### PR TITLE
add service and rpc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,6 @@ members = [
     "core/txflow",
     "node/cli",
     "node/runtime",
+    "node/service",
     "test-utils/node"
 ]

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -1,3 +1,6 @@
 [package]
 name = "node-cli"
 version = "0.1.0"
+
+[dependencies]
+service = { path = "../service" }

--- a/node/cli/src/lib.rs
+++ b/node/cli/src/lib.rs
@@ -1,1 +1,8 @@
-pub fn run() {}
+extern crate service;
+
+use service::Service;
+
+pub fn run() {
+    let service = Service::default();
+    service.run()
+}

--- a/node/client/Cargo.toml
+++ b/node/client/Cargo.toml
@@ -4,6 +4,4 @@ version = "0.0.1"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 
 [dependencies]
-primitives = { path = "../../primitives" }
-storage = { path = "../../storage" }
-runtime = { path = "../runtime" }
+primitives = { path = "../../core/primitives" }

--- a/node/client/src/lib.rs
+++ b/node/client/src/lib.rs
@@ -1,32 +1,12 @@
-extern crate runtime;
 extern crate primitives;
-extern crate storage;
 
-use runtime::Runtime;
-use primitives::{types::EpochBlockHeader, hash::HashValue};
-use storage::Storage;
+use primitives::types::TransactionBody;
 
-pub struct Client {
-    runtime: Runtime,
-    storage: Storage,
-    last_header: HashValue,
-}
+#[derive(Default, Clone, Copy)]
+pub struct Client;
 
 impl Client {
-    pub fn new(genesis: EpochBlockHeader,
-               runtime: Runtime,
-               storage: Storage) -> Self {
-        let last_header = storage.put(genesis);
-        Client {
-            runtime,
-            storage,
-            last_header,
-        }
-    }
-
-    pub fn add_header(&self, header: EpochBlockHeader) {
-        if self.runtime.verify_epoch_header(&header) {
-            self.storage.put(&header);
-        }
+    pub fn receive_transaction(self, t: &TransactionBody) {
+        println!("{:?}", t);
     }
 }

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "service"
+version = "0.1.0"
+
+[dependencies]
+jsonrpc-core = { git = "https://github.com/paritytech/jsonrpc" }
+jsonrpc-macros = { git = "https://github.com/paritytech/jsonrpc" }
+jsonrpc-minihttp-server = { git = "https://github.com/paritytech/jsonrpc" }
+
+client = { path = "../client" }
+primitives = { path = "../../core/primitives" }
+
+[dev-dependencies]
+jsonrpc-test = { git = "https://github.com/paritytech/jsonrpc" }

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -1,0 +1,53 @@
+extern crate client;
+extern crate jsonrpc_core;
+#[macro_use]
+extern crate jsonrpc_macros;
+extern crate jsonrpc_minihttp_server;
+extern crate primitives;
+
+mod rpc;
+
+use rpc::api::{RpcImpl, TransactionApi};
+
+#[derive(Default)]
+pub struct Service {
+    rpc_impl: RpcImpl,
+}
+
+impl Service {
+    pub fn run(&self) {
+        let io = self.get_io();
+        rpc::server::run_server(io);
+    }
+
+    fn get_io(&self) -> jsonrpc_core::IoHandler {
+        let mut io = jsonrpc_core::IoHandler::new();
+        io.extend_with(self.rpc_impl.to_delegate());
+        io
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    extern crate jsonrpc_test;
+    extern crate primitives;
+
+    use self::jsonrpc_test::Rpc;
+    use primitives::types::TransactionBody;
+
+    #[test]
+    fn test_call() {
+        let service = Service::default();
+        let io = service.get_io();
+        let rpc = Rpc::from(io);
+        let t = TransactionBody {
+            nonce: 0,
+            sender: 1,
+            receiver: 0,
+            amount: 0,
+        };
+        assert_eq!(rpc.request("receive_transaction", &[t]), "null");
+    }
+}

--- a/node/service/src/rpc/api.rs
+++ b/node/service/src/rpc/api.rs
@@ -1,0 +1,23 @@
+use jsonrpc_core::Result as JsonRpcResult;
+
+use client::Client;
+use primitives::types::TransactionBody;
+
+build_rpc_trait! {
+    pub trait TransactionApi {
+        /// Receive new transaction
+        #[rpc(name = "receive_transaction")]
+        fn rpc_receive_transaction(&self, TransactionBody) -> JsonRpcResult<()>;
+    }
+}
+
+#[derive(Default, Copy, Clone)]
+pub struct RpcImpl {
+    client: Client,
+}
+
+impl TransactionApi for RpcImpl {
+    fn rpc_receive_transaction(&self, t: TransactionBody) -> JsonRpcResult<()> {
+        Ok(self.client.receive_transaction(&t))
+    }
+}

--- a/node/service/src/rpc/mod.rs
+++ b/node/service/src/rpc/mod.rs
@@ -1,0 +1,2 @@
+pub mod api;
+pub mod server;

--- a/node/service/src/rpc/server.rs
+++ b/node/service/src/rpc/server.rs
@@ -1,0 +1,13 @@
+use jsonrpc_core::IoHandler;
+use jsonrpc_minihttp_server::cors::AccessControlAllowOrigin;
+use jsonrpc_minihttp_server::{DomainsValidation, ServerBuilder};
+
+pub fn run_server(io: IoHandler) {
+    let server = ServerBuilder::new(io)
+        .cors(DomainsValidation::AllowOnly(vec![
+            AccessControlAllowOrigin::Null,
+        ])).start_http(&"127.0.0.1:3030".parse().unwrap())
+        .expect("Unable to start RPC server");
+
+    server.wait().unwrap();
+}


### PR DESCRIPTION
@ilblackdragon here's a working implementation of an RPC server.

you should be able to plug into https://github.com/nearprotocol/nearcore/compare/node-service-rpc?expand=1#diff-33c6a6085e8d34650cbb10a57bf89e7bR9 in order to receive a transaction. 

[here's](https://github.com/nearprotocol/nearcore/compare/node-service-rpc?expand=1#diff-8dcf55bb02e5a4cae989141cba16b32cR41) an example of making a request in a test.

the server will run with `cargo run`, and you can make requests with the following command:
```
curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1,"method":"receive_transaction","params":[{"nonce":0,"sender":1,"receiver":0,"amount":0}]}' 127.0.0.1:3030
```