### PR TITLE
Disable clippy::map_entry

### DIFF
--- a/scripts/run_clippy.sh
+++ b/scripts/run_clippy.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-cargo clippy --all  -- -A clippy::unit_arg -A clippy::if_same_then_else -A clippy::collapsible_if -D warnings
+cargo clippy --all  -- -A clippy::unit_arg -A clippy::if_same_then_else -A clippy::collapsible_if -A clippy::map-entry -D warnings


### PR DESCRIPTION
It does not seem to take into account the lifetimes. So what it suggests is either impossible or very hard to pull off without mangling the code.