### PR TITLE
TxFlow testgen to handle epoch blocks + internal stress test

### DIFF
--- a/core/txflow/src/dag/message/generated_tests.rs
+++ b/core/txflow/src/dag/message/generated_tests.rs
@@ -1,9 +1,10 @@
 #[cfg(test)]
 mod tests {
-    use primitives::traits::WitnessSelector;
+    use primitives::traits::{Payload, WitnessSelector};
     use primitives::types::UID;
     use std::collections::HashSet;
     use typed_arena::Arena;
+    use dag::message::Message;
 
     struct FakeNonContinuousWitnessSelector {
         num_users: u64,
@@ -32,6 +33,16 @@ mod tests {
         }
     }
 
+    fn make_assertions<P: Payload>(messages: &[Option<&Message<P>>], assertions: &[(u64, Option<u64>, bool, u64)]) {
+        for it in messages.iter().zip(assertions.iter()) {
+            let (msg, a) = it;
+            if let Some(msg) = msg.as_ref() {
+                // If this assert triggers, the last element of tuples indicates the node uid
+                assert_eq!((a.0, a.1, a.2, a.3), (msg.computed_epoch, msg.computed_is_representative, msg.computed_is_kickout, a.3));
+            }
+        }
+    }
+
     #[test]
     fn generated_simple_test() {
         /* Simple test with two representative messages and no kickouts */
@@ -39,24 +50,17 @@ mod tests {
         /* {"s":[{"owner":0,"parents":[]},{"owner":1,"parents":[]},{"owner":2,"parents":[0,1]},{"owner":1,"parents":[2]}],"n":4,"c":"Simple test with two representative messages and no kickouts","f":"simple_test"} */
         let arena = Arena::new();
         let selector = FakeNonContinuousWitnessSelector::new(4);
-        let (v0, v1, v2, v3);
-        simple_messages!(0, &selector, arena [0, 0, true => v0;]);
-        simple_messages!(0, &selector, arena [1, 0, true => v1;]);
-        simple_messages!(0, &selector, arena [[=> v0; => v1; ] => 2, 0, true => v2;]);
-        simple_messages!(0, &selector, arena [[=> v2; ] => 1, 0, true => v3;]);
-
-        assert_eq!(v0.computed_epoch, 0);
-        assert_eq!(v0.computed_is_representative, Some(0));
-        assert_eq!(v0.computed_is_kickout, false);
-        assert_eq!(v1.computed_epoch, 0);
-        assert_eq!(v1.computed_is_representative, None);
-        assert_eq!(v1.computed_is_kickout, false);
-        assert_eq!(v2.computed_epoch, 0);
-        assert_eq!(v2.computed_is_representative, None);
-        assert_eq!(v2.computed_is_kickout, false);
-        assert_eq!(v3.computed_epoch, 1);
-        assert_eq!(v3.computed_is_representative, Some(1));
-        assert_eq!(v3.computed_is_kickout, false);
+        let (v0,v1,v2,v3);
+        let mut v = [None; 4];
+        let test = |v:&[_]| make_assertions(&v, &[(0, Some(0), false, 0), (0, None, false, 1), (0, None, false, 2), (1, Some(1), false, 3)]);
+        simple_messages!(0, &selector, arena [0, 0, true => v0;]); v[0] = Some(v0);
+        test(&v);
+        simple_messages!(0, &selector, arena [1, 0, true => v1;]); v[1] = Some(v1);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v0; => v1; ] => 2, 0, true => v2;]); v[2] = Some(v2);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v2; ] => 1, 0, true => v3;]); v[3] = Some(v3);
+        test(&v);
     }
 
     #[test]
@@ -66,48 +70,29 @@ mod tests {
         /* {"s":[{"owner":1,"parents":[]},{"owner":2,"parents":[0]},{"owner":3,"parents":[1]},{"owner":0,"parents":[2]},{"owner":1,"parents":[3]},{"owner":1,"parents":[3]},{"owner":2,"parents":[4]},{"owner":0,"parents":[4,5]},{"owner":3,"parents":[5]},{"owner":2,"parents":[5,6]}],"n":4,"c":"Representative message fork from Bob, testing endorsements","f":"bob_fork"} */
         let arena = Arena::new();
         let selector = FakeNonContinuousWitnessSelector::new(4);
-        let (v4, v5, v6, v7, v8, v9, v10, v11, v12, v13);
-        simple_messages!(0, &selector, arena [1, 0, true => v4;]);
-        simple_messages!(0, &selector, arena [[=> v4; ] => 2, 0, true => v5;]);
-        simple_messages!(0, &selector, arena [[=> v5; ] => 3, 0, true => v6;]);
-        simple_messages!(0, &selector, arena [[=> v6; ] => 0, 0, true => v7;]);
-        simple_messages!(0, &selector, arena [[=> v7; ] => 1, 0, true => v8;]);
-        simple_messages!(0, &selector, arena [[=> v7; ] => 1, 0, true => v9;]);
-        simple_messages!(0, &selector, arena [[=> v8; ] => 2, 0, true => v10;]);
-        simple_messages!(0, &selector, arena [[=> v8; => v9; ] => 0, 0, true => v11;]);
-        simple_messages!(0, &selector, arena [[=> v9; ] => 3, 0, true => v12;]);
-        simple_messages!(0, &selector, arena [[=> v9; => v10; ] => 2, 0, true => v13;]);
-
-        assert_eq!(v4.computed_epoch, 0);
-        assert_eq!(v4.computed_is_representative, None);
-        assert_eq!(v4.computed_is_kickout, false);
-        assert_eq!(v5.computed_epoch, 0);
-        assert_eq!(v5.computed_is_representative, None);
-        assert_eq!(v5.computed_is_kickout, false);
-        assert_eq!(v6.computed_epoch, 0);
-        assert_eq!(v6.computed_is_representative, None);
-        assert_eq!(v6.computed_is_kickout, false);
-        assert_eq!(v7.computed_epoch, 0);
-        assert_eq!(v7.computed_is_representative, Some(0));
-        assert_eq!(v7.computed_is_kickout, false);
-        assert_eq!(v8.computed_epoch, 1);
-        assert_eq!(v8.computed_is_representative, Some(1));
-        assert_eq!(v8.computed_is_kickout, false);
-        assert_eq!(v9.computed_epoch, 1);
-        assert_eq!(v9.computed_is_representative, Some(1));
-        assert_eq!(v9.computed_is_kickout, false);
-        assert_eq!(v10.computed_epoch, 1);
-        assert_eq!(v10.computed_is_representative, None);
-        assert_eq!(v10.computed_is_kickout, false);
-        assert_eq!(v11.computed_epoch, 1);
-        assert_eq!(v11.computed_is_representative, None);
-        assert_eq!(v11.computed_is_kickout, false);
-        assert_eq!(v12.computed_epoch, 1);
-        assert_eq!(v12.computed_is_representative, None);
-        assert_eq!(v12.computed_is_kickout, false);
-        assert_eq!(v13.computed_epoch, 1);
-        assert_eq!(v13.computed_is_representative, None);
-        assert_eq!(v13.computed_is_kickout, false);
+        let (v0,v1,v2,v3,v4,v5,v6,v7,v8,v9);
+        let mut v = [None; 10];
+        let test = |v:&[_]| make_assertions(&v, &[(0, None, false, 0), (0, None, false, 1), (0, None, false, 2), (0, Some(0), false, 3), (1, Some(1), false, 4), (1, Some(1), false, 5), (1, None, false, 6), (1, None, false, 7), (1, None, false, 8), (1, None, false, 9)]);
+        simple_messages!(0, &selector, arena [1, 0, true => v0;]); v[0] = Some(v0);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v0; ] => 2, 0, true => v1;]); v[1] = Some(v1);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v1; ] => 3, 0, true => v2;]); v[2] = Some(v2);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v2; ] => 0, 0, true => v3;]); v[3] = Some(v3);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v3; ] => 1, 0, true => v4;]); v[4] = Some(v4);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v3; ] => 1, 0, true => v5;]); v[5] = Some(v5);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v4; ] => 2, 0, true => v6;]); v[6] = Some(v6);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v4; => v5; ] => 0, 0, true => v7;]); v[7] = Some(v7);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v5; ] => 3, 0, true => v8;]); v[8] = Some(v8);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v5; => v6; ] => 2, 0, true => v9;]); v[9] = Some(v9);
+        test(&v);
     }
 
     #[test]
@@ -117,32 +102,21 @@ mod tests {
         /* {"s":[{"owner":1,"parents":[]},{"owner":0,"parents":[0]},{"owner":2,"parents":[1]},{"owner":3,"parents":[2]},{"owner":1,"parents":[2]},{"owner":2,"parents":[3,4]}],"n":4,"c":"This used to panic","f":"used_to_panic"} */
         let arena = Arena::new();
         let selector = FakeNonContinuousWitnessSelector::new(4);
-        let (v0, v1, v2, v3, v4, v5);
-        simple_messages!(0, &selector, arena [1, 0, true => v0;]);
-        simple_messages!(0, &selector, arena [[=> v0; ] => 0, 0, true => v1;]);
-        simple_messages!(0, &selector, arena [[=> v1; ] => 2, 0, true => v2;]);
-        simple_messages!(0, &selector, arena [[=> v2; ] => 3, 0, true => v3;]);
-        simple_messages!(0, &selector, arena [[=> v2; ] => 1, 0, true => v4;]);
-        simple_messages!(0, &selector, arena [[=> v3; => v4; ] => 2, 0, true => v5;]);
-
-        assert_eq!(v0.computed_epoch, 0);
-        assert_eq!(v0.computed_is_representative, None);
-        assert_eq!(v0.computed_is_kickout, false);
-        assert_eq!(v1.computed_epoch, 0);
-        assert_eq!(v1.computed_is_representative, Some(0));
-        assert_eq!(v1.computed_is_kickout, false);
-        assert_eq!(v2.computed_epoch, 0);
-        assert_eq!(v2.computed_is_representative, None);
-        assert_eq!(v2.computed_is_kickout, false);
-        assert_eq!(v3.computed_epoch, 0);
-        assert_eq!(v3.computed_is_representative, None);
-        assert_eq!(v3.computed_is_kickout, false);
-        assert_eq!(v4.computed_epoch, 1);
-        assert_eq!(v4.computed_is_representative, Some(1));
-        assert_eq!(v4.computed_is_kickout, false);
-        assert_eq!(v5.computed_epoch, 1);
-        assert_eq!(v5.computed_is_representative, None);
-        assert_eq!(v5.computed_is_kickout, false);
+        let (v0,v1,v2,v3,v4,v5);
+        let mut v = [None; 6];
+        let test = |v:&[_]| make_assertions(&v, &[(0, None, false, 0), (0, Some(0), false, 1), (0, None, false, 2), (0, None, false, 3), (1, Some(1), false, 4), (1, None, false, 5)]);
+        simple_messages!(0, &selector, arena [1, 0, true => v0;]); v[0] = Some(v0);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v0; ] => 0, 0, true => v1;]); v[1] = Some(v1);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v1; ] => 2, 0, true => v2;]); v[2] = Some(v2);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v2; ] => 3, 0, true => v3;]); v[3] = Some(v3);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v2; ] => 1, 0, true => v4;]); v[4] = Some(v4);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v3; => v4; ] => 2, 0, true => v5;]); v[5] = Some(v5);
+        test(&v);
     }
 
     #[test]
@@ -152,105 +126,56 @@ mod tests {
         /* {"s":[{"owner":1,"parents":[]},{"owner":0,"parents":[0]},{"owner":2,"parents":[1]},{"owner":3,"parents":[2]},{"owner":1,"parents":[2]},{"owner":2,"parents":[3,4]},{"owner":0,"parents":[4]},{"owner":1,"parents":[5]},{"owner":0,"parents":[6,7]},{"owner":3,"parents":[8]},{"owner":3,"parents":[9]},{"owner":1,"parents":[10]},{"owner":3,"parents":[11]},{"owner":2,"parents":[11]},{"owner":3,"parents":[12,13]},{"owner":1,"parents":[12,13]},{"owner":2,"parents":[15]},{"owner":1,"parents":[14,16]},{"owner":2,"parents":[14,16]},{"owner":3,"parents":[14,16]},{"owner":1,"parents":[17,18,19]},{"owner":2,"parents":[20]},{"owner":3,"parents":[20]},{"owner":1,"parents":[21,22]}],"n":4,"c":"Some kickout messages","f":"kickouts"} */
         let arena = Arena::new();
         let selector = FakeNonContinuousWitnessSelector::new(4);
-        let (v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18,
-            v19, v20, v21, v22, v23,);
-        simple_messages!(0, &selector, arena [1, 0, true => v0;]);
-        simple_messages!(0, &selector, arena [[=> v0; ] => 0, 0, true => v1;]);
-        simple_messages!(0, &selector, arena [[=> v1; ] => 2, 0, true => v2;]);
-        simple_messages!(0, &selector, arena [[=> v2; ] => 3, 0, true => v3;]);
-        simple_messages!(0, &selector, arena [[=> v2; ] => 1, 0, true => v4;]);
-        simple_messages!(0, &selector, arena [[=> v3; => v4; ] => 2, 0, true => v5;]);
-        simple_messages!(0, &selector, arena [[=> v4; ] => 0, 0, true => v6;]);
-        simple_messages!(0, &selector, arena [[=> v5; ] => 1, 0, true => v7;]);
-        simple_messages!(0, &selector, arena [[=> v6; => v7; ] => 0, 0, true => v8;]);
-        simple_messages!(0, &selector, arena [[=> v8; ] => 3, 0, true => v9;]);
-        simple_messages!(0, &selector, arena [[=> v9; ] => 3, 0, true => v10;]);
-        simple_messages!(0, &selector, arena [[=> v10; ] => 1, 0, true => v11;]);
-        simple_messages!(0, &selector, arena [[=> v11; ] => 3, 0, true => v12;]);
-        simple_messages!(0, &selector, arena [[=> v11; ] => 2, 0, true => v13;]);
-        simple_messages!(0, &selector, arena [[=> v12; => v13; ] => 3, 0, true => v14;]);
-        simple_messages!(0, &selector, arena [[=> v12; => v13; ] => 1, 0, true => v15;]);
-        simple_messages!(0, &selector, arena [[=> v15; ] => 2, 0, true => v16;]);
-        simple_messages!(0, &selector, arena [[=> v14; => v16; ] => 1, 0, true => v17;]);
-        simple_messages!(0, &selector, arena [[=> v14; => v16; ] => 2, 0, true => v18;]);
-        simple_messages!(0, &selector, arena [[=> v14; => v16; ] => 3, 0, true => v19;]);
-        simple_messages!(0, &selector, arena [[=> v17; => v18; => v19; ] => 1, 0, true => v20;]);
-        simple_messages!(0, &selector, arena [[=> v20; ] => 2, 0, true => v21;]);
-        simple_messages!(0, &selector, arena [[=> v20; ] => 3, 0, true => v22;]);
-        simple_messages!(0, &selector, arena [[=> v21; => v22; ] => 1, 0, true => v23;]);
-
-        assert_eq!(v0.computed_epoch, 0);
-        assert_eq!(v0.computed_is_representative, None);
-        assert_eq!(v0.computed_is_kickout, false);
-        assert_eq!(v1.computed_epoch, 0);
-        assert_eq!(v1.computed_is_representative, Some(0));
-        assert_eq!(v1.computed_is_kickout, false);
-        assert_eq!(v2.computed_epoch, 0);
-        assert_eq!(v2.computed_is_representative, None);
-        assert_eq!(v2.computed_is_kickout, false);
-        assert_eq!(v3.computed_epoch, 0);
-        assert_eq!(v3.computed_is_representative, None);
-        assert_eq!(v3.computed_is_kickout, false);
-        assert_eq!(v4.computed_epoch, 1);
-        assert_eq!(v4.computed_is_representative, Some(1));
-        assert_eq!(v4.computed_is_kickout, false);
-        assert_eq!(v5.computed_epoch, 1);
-        assert_eq!(v5.computed_is_representative, None);
-        assert_eq!(v5.computed_is_kickout, false);
-        assert_eq!(v6.computed_epoch, 1);
-        assert_eq!(v6.computed_is_representative, None);
-        assert_eq!(v6.computed_is_kickout, false);
-        assert_eq!(v7.computed_epoch, 1);
-        assert_eq!(v7.computed_is_representative, None);
-        assert_eq!(v7.computed_is_kickout, false);
-        assert_eq!(v8.computed_epoch, 2);
-        assert_eq!(v8.computed_is_representative, None);
-        assert_eq!(v8.computed_is_kickout, false);
-        assert_eq!(v9.computed_epoch, 1);
-        assert_eq!(v9.computed_is_representative, None);
-        assert_eq!(v9.computed_is_kickout, false);
-        assert_eq!(v10.computed_epoch, 2);
-        assert_eq!(v10.computed_is_representative, None);
-        assert_eq!(v10.computed_is_kickout, false);
-        assert_eq!(v11.computed_epoch, 2);
-        assert_eq!(v11.computed_is_representative, None);
-        assert_eq!(v11.computed_is_kickout, false);
-        assert_eq!(v12.computed_epoch, 3);
-        assert_eq!(v12.computed_is_representative, None);
-        assert_eq!(v12.computed_is_kickout, true);
-        assert_eq!(v13.computed_epoch, 2);
-        assert_eq!(v13.computed_is_representative, Some(2));
-        assert_eq!(v13.computed_is_kickout, false);
-        assert_eq!(v14.computed_epoch, 3);
-        assert_eq!(v14.computed_is_representative, Some(3));
-        assert_eq!(v14.computed_is_kickout, false);
-        assert_eq!(v15.computed_epoch, 3);
-        assert_eq!(v15.computed_is_representative, None);
-        assert_eq!(v15.computed_is_kickout, false);
-        assert_eq!(v16.computed_epoch, 3);
-        assert_eq!(v16.computed_is_representative, None);
-        assert_eq!(v16.computed_is_kickout, false);
-        assert_eq!(v17.computed_epoch, 4);
-        assert_eq!(v17.computed_is_representative, None);
-        assert_eq!(v17.computed_is_kickout, false);
-        assert_eq!(v18.computed_epoch, 4);
-        assert_eq!(v18.computed_is_representative, None);
-        assert_eq!(v18.computed_is_kickout, false);
-        assert_eq!(v19.computed_epoch, 4);
-        assert_eq!(v19.computed_is_representative, None);
-        assert_eq!(v19.computed_is_kickout, false);
-        assert_eq!(v20.computed_epoch, 5);
-        assert_eq!(v20.computed_is_representative, None);
-        assert_eq!(v20.computed_is_kickout, true);
-        assert_eq!(v21.computed_epoch, 5);
-        assert_eq!(v21.computed_is_representative, None);
-        assert_eq!(v21.computed_is_kickout, false);
-        assert_eq!(v22.computed_epoch, 5);
-        assert_eq!(v22.computed_is_representative, None);
-        assert_eq!(v22.computed_is_kickout, false);
-        assert_eq!(v23.computed_epoch, 6);
-        assert_eq!(v23.computed_is_representative, Some(5));
-        assert_eq!(v23.computed_is_kickout, false);
+        let (v0,v1,v2,v3,v4,v5,v6,v7,v8,v9,v10,v11,v12,v13,v14,v15,v16,v17,v18,v19,v20,v21,v22,v23);
+        let mut v = [None; 24];
+        let test = |v:&[_]| make_assertions(&v, &[(0, None, false, 0), (0, Some(0), false, 1), (0, None, false, 2), (0, None, false, 3), (1, Some(1), false, 4), (1, None, false, 5), (1, None, false, 6), (1, None, false, 7), (2, None, false, 8), (1, None, false, 9), (2, None, false, 10), (2, None, false, 11), (3, None, true, 12), (2, Some(2), false, 13), (3, Some(3), false, 14), (3, None, false, 15), (3, None, false, 16), (4, None, false, 17), (4, None, false, 18), (4, None, false, 19), (5, None, true, 20), (5, None, false, 21), (5, None, false, 22), (6, Some(5), false, 23)]);
+        simple_messages!(0, &selector, arena [1, 0, true => v0;]); v[0] = Some(v0);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v0; ] => 0, 0, true => v1;]); v[1] = Some(v1);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v1; ] => 2, 0, true => v2;]); v[2] = Some(v2);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v2; ] => 3, 0, true => v3;]); v[3] = Some(v3);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v2; ] => 1, 0, true => v4;]); v[4] = Some(v4);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v3; => v4; ] => 2, 0, true => v5;]); v[5] = Some(v5);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v4; ] => 0, 0, true => v6;]); v[6] = Some(v6);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v5; ] => 1, 0, true => v7;]); v[7] = Some(v7);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v6; => v7; ] => 0, 0, true => v8;]); v[8] = Some(v8);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v8; ] => 3, 0, true => v9;]); v[9] = Some(v9);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v9; ] => 3, 0, true => v10;]); v[10] = Some(v10);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v10; ] => 1, 0, true => v11;]); v[11] = Some(v11);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v11; ] => 3, 0, true => v12;]); v[12] = Some(v12);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v11; ] => 2, 0, true => v13;]); v[13] = Some(v13);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v12; => v13; ] => 3, 0, true => v14;]); v[14] = Some(v14);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v12; => v13; ] => 1, 0, true => v15;]); v[15] = Some(v15);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v15; ] => 2, 0, true => v16;]); v[16] = Some(v16);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v14; => v16; ] => 1, 0, true => v17;]); v[17] = Some(v17);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v14; => v16; ] => 2, 0, true => v18;]); v[18] = Some(v18);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v14; => v16; ] => 3, 0, true => v19;]); v[19] = Some(v19);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v17; => v18; => v19; ] => 1, 0, true => v20;]); v[20] = Some(v20);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v20; ] => 2, 0, true => v21;]); v[21] = Some(v21);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v20; ] => 3, 0, true => v22;]); v[22] = Some(v22);
+        test(&v);
+        simple_messages!(0, &selector, arena [[=> v21; => v22; ] => 1, 0, true => v23;]); v[23] = Some(v23);
+        test(&v);
     }
-
 }

--- a/test-utils/txflow-test-gen/index.html
+++ b/test-utils/txflow-test-gen/index.html
@@ -1,6 +1,8 @@
+<meta charset="UTF-8">
 <html>
 <head>
 <script src=txflow.js></script>
+<script src=utils.js></script>
 <style>
 body {
     font-family: Helvetica;
@@ -14,7 +16,14 @@ body {
 <div id='buttons' style='z-index: 5; position: absolute; left: 0px; top: 0px'></div>
 <canvas id='here' style='position: absolute; top: 60px;'></canvas>
 <div id='serializer_holder' style='position: fixed; top: 60px;'>
-<button onclick='delete_node()'>Delete Node</button> <button onclick='if (num_users < 26) num_users ++; refresh(); serialize();'>Add User</button> <button onclick='if (num_users > 1) num_users --; refresh(); serialize();'>Remove User</button><br><br>
+<button onclick='delete_node()'>Delete Node</button> <a href='#' onclick='z = document.getElementById("more_actions").style; z.display = (z.display == "") ? "none" : "";'>More actions</a>
+<div id='more_actions' style='display: none; text-align: center'>
+    <br>
+    <button style="width: 200px" onclick='if (num_users < 26) num_users ++; refresh(); serialize();'>Add User</button><br>
+    <button style="width: 200px" onclick='if (num_users > 1) num_users --; refresh(); serialize();'>Remove User</button><br>
+    <button style="width: 200px" onclick='stress_epoch_blocks(nodes, num_users)'>Stress Epoch Blocks</button><br>
+    <input id='random_graph_num_malicious' style='width:75px' placeholder='Malicious'><input id='random_graph_num_nodes' style='width: 75px' placeholder='Nodes'><button style="width: 50px" onclick='generate_random_graph(num_users, parseInt(document.getElementById("random_graph_num_malicious").value), parseInt(document.getElementById("random_graph_num_nodes").value))'>rnd</button><br>
+</div><br><br>
 <b>Comment:</b><br>
 <textarea id='comment' rows=8 cols=40 onkeyup='serialize()'></textarea><br>
 <b>Serialized:</b><br>
@@ -106,10 +115,10 @@ var refresh = function() {
         var node = annotation.node;
         var a = document.createElement('div');
         a.style.position = 'absolute';
-        a.style.left = node.coords.l + 'px';
-        a.style.top = node.coords.t + 'px';
-        a.style.width = node.coords.w + 'px';
-        a.style.height = node.coords.h + 'px';
+        a.style.left = node.coords.l + 1 + 'px';
+        a.style.top = node.coords.t + 1 + 'px';
+        a.style.width = node.coords.w - 1 + 'px';
+        a.style.height = node.coords.h - 1 + 'px';
 
         var flags = "";
         if (annotation.representative >= 0) {
@@ -122,8 +131,9 @@ var refresh = function() {
             }
             flags += ")</small> ";
         }
+        if (annotation.epoch_block) a.style.backgroundColor = '#D0FFD0';
         if (annotation.kickout) flags += "<b>K</b>";
-        a.innerHTML = '<small>(v' + node.uid + ')</small> <u>' + names[node.owner] + '</u><br>Epoch: ' + annotation.epoch + "<br>" + flags;
+        a.innerHTML = '<small>(v' + node.uid + ')</small> <u>' + names[node.owner] + '</u><br>E: ' + annotation.epoch + " / K: " + annotation.largest_kickout_promise + "<br>" + flags;
 
         annot.appendChild(a);
     }
@@ -201,6 +211,13 @@ var gen_rust = function() {
     else {
         s += indent + "let " + var_names[0] + ";\n";
     }
+    s += indent + "let mut v = [None; " + var_names.length + "];\n";
+    var nf = function(node) {
+        var a = a_mapping[node.uid];
+        var repr = a.representative < 0 ? 'None' : `Some(${a.representative})`;
+        return `(${a.epoch}, ${repr}, ${a.kickout}, ${node.uid})`;
+    };
+    s += indent + 'let test = |v:&[_]| make_assertions(&v, &[' + nodes.map(nf).join(', ') + ']);\n';
     for (var i = 0; i < nodes.length; ++ i) {
         var node = nodes[i];
         s += indent + 'simple_messages!(0, &selector, arena [';
@@ -212,17 +229,8 @@ var gen_rust = function() {
             s += '[' + parent_names.join('') + '] => ';
         }
         // use 0 for epoch, and `true` to recompute the epochs
-        s += node.owner + ', 0, true => ' + var_names[i] + ';]);\n'
-    }
-
-    s += '\n';
-
-    for (var i = 0; i < nodes.length; ++ i) {
-        var node = nodes[i];
-        var a = a_mapping[node.uid];
-        s += indent + 'assert_eq!(' + var_names[i] + '.computed_epoch, ' + a.epoch + ');\n';
-        s += indent + 'assert_eq!(' + var_names[i] + '.computed_is_representative, ' + (a.representative >= 0 ? 'true' : 'false') + ');\n';
-        s += indent + 'assert_eq!(' + var_names[i] + '.computed_is_kickout, ' + (a.kickout ? 'true' : 'false') + ');\n';
+        s += node.owner + ', 0, true => ' + var_names[i] + ';]); v[' + i + '] = Some(' + var_names[i] + ');\n'
+        s += indent + 'test(&v);\n';
     }
 
     s += "    }\n"

--- a/test-utils/txflow-test-gen/utils.js
+++ b/test-utils/txflow-test-gen/utils.js
@@ -1,0 +1,156 @@
+var _rand_int = function(n) {
+    return parseInt(Math.random() * n);
+}
+
+var _select_random_nodes = function(nodes) {
+    if (nodes.length == 0) return [];
+
+    if (_rand_int(2) == 0) {
+        var ret = [];
+        var prob = _rand_int(10);
+        for (var i = 0; i < nodes.length; ++ i) {
+            if (_rand_int(prob) == 0) {
+                ret.push(nodes[i]);
+            }
+        }
+
+        if (ret.length) return ret;
+        return _select_random_nodes(nodes);
+    }
+    else {
+        return [nodes[_rand_int(nodes.length)]];
+    }
+}
+
+var stress_epoch_blocks = function(nodes, num_users, seconds) {
+    if (nodes.length == 0) return;
+    seconds = seconds || 2;
+
+    var started = new Date().getTime();
+    var iter = 0;
+    var longest_epoch_blocks = [];
+    var longest_selected_node_ids = [];
+    while (new Date().getTime() - started < seconds * 1000) {
+        var selected_nodes = _select_random_nodes(nodes);
+        var annotations = compute_annotations(selected_nodes, num_users);
+        var epoch_blocks = [];
+        var selected_node_ids = selected_nodes.map(x => x.uid);
+
+        for (var a_idx = 0; a_idx < annotations.length; ++ a_idx) {
+            var a = annotations[a_idx];
+            if (a.epoch_block) {
+                epoch_blocks.push([a.representative, 'v' + a.node.uid]);
+            }
+        }
+
+        epoch_blocks.sort((x, y) => x[0] < y[0] ? -1 : x[0] > y[0] ? 1 : 0);
+
+        var smaller = Math.min(longest_epoch_blocks.length, epoch_blocks.length);
+
+        for (var i = 0; i < smaller; ++ i) {
+            var left = longest_epoch_blocks[i];
+            var right = epoch_blocks[i];
+
+            if (left[0] != right[0] || left[1] != right[1]) {
+                alert(`FAILED!\nLeft: nodes: ${longest_selected_node_ids}, epoch blocks: ${longest_epoch_blocks}\nRight: nodes: ${selected_node_ids}, epoch blocks: ${epoch_blocks}`);
+                return;
+            }
+        }
+
+        if (epoch_blocks.length > longest_epoch_blocks.length) {
+            longest_epoch_blocks = epoch_blocks;
+            longest_selected_node_ids = selected_node_ids;
+        }
+
+        ++ iter;
+    }
+
+    alert(`PASSED!\nRan stress for ${seconds} seconds. Completed ${iter} iterations.\nLongest epoch blocks: ${longest_epoch_blocks}`);
+}
+
+var generate_random_graph = function(num_users, num_malicious, num_nodes) {
+    last_node_uid = 0;
+
+    var mode_users_hanging = _rand_int(2);
+    var mode_prefer_non_repr = _rand_int(2);
+
+    var all_nodes = [];
+    var nodes_as_seen = [];
+    var users_hanging = [];
+    var _random_user = function() {
+        if (mode_users_hanging) {
+            for (var i = 0; i < num_users; ++ i) {
+                if (!users_hanging[i] && _rand_int(latencies[i] * 2) == 0) users_hanging[i] = true;
+                if (users_hanging[i] && _rand_int(latencies[i] * 3) == 0) users_hanging[i] = false;
+            }
+        }
+        var ret = _rand_int(num_users);
+        if (users_hanging[ret]) return _random_user();
+        return ret;
+    }
+
+    var _get_roots = function(nodes_with_ts, ts) {
+        var mark = {};
+        for (var pair of nodes_with_ts) {
+            if (pair[1] <= ts) {
+                for (var parent_ of pair[0].parents) mark[parent_.uid] = 1;
+            }
+        }
+        var ret = [];
+        for (var pair of nodes_with_ts) {
+            if (pair[1] <= ts) {
+                if (mark[pair[0].uid] === undefined) ret.push(pair[0]);
+            }
+        }
+        return ret;
+    }
+    var _get_parents = function(user_id, ts) {
+        if (user_id < num_malicious && _rand_int(3) == 0) {
+            return _select_random_nodes(nodes_as_seen[user_id].map(x => x[0]));
+        }
+        else {
+            return _get_roots(nodes_as_seen[user_id], ts);
+        }
+    }
+
+    var latencies = [];
+    var max_latency = Math.max(_rand_int(num_users * 5), _rand_int(num_users * 3));
+
+    for (var i = 0; i < num_users; ++ i) {
+        latencies.push(Math.max(_rand_int(max_latency + 1), _rand_int(max_latency + 1)));
+        nodes_as_seen.push([]);
+        users_hanging.push(false);
+    }
+
+    for (var i = 0; i < num_nodes; ++ i) {
+        var user_id = _random_user();
+        var parents = _get_parents(user_id, i);
+
+        var node = create_node(user_id, parents);
+        if (mode_prefer_non_repr && _rand_int(3) != 0) {
+            var annotations = compute_annotations([node], num_users)
+            var skip = false;
+            for (var a of annotations) {
+                if (a.node.uid == node.uid && a.representative != -1) {
+                    skip = true;
+                }
+            }
+            if (skip) { --i; continue; }
+        }
+        all_nodes.push([node, 0]);
+        for (var j = 0; j < num_users; ++ j) {
+            var latency = Math.max(_rand_int(latencies[j] + 1), _rand_int(latencies[j] + 1));
+            if (j == user_id) latency = 0;
+            nodes_as_seen[j].push([node, i + latency]);
+        }
+    }
+
+    graph = _get_roots(all_nodes, 0);
+    for (var node of graph) node.selected = true;
+
+    refresh();
+    serialize();
+
+    stress_epoch_blocks(all_nodes.map(x => x[0]), num_users, 0.5);
+}
+


### PR DESCRIPTION
The visual testgen for TxFlow now has a full implementation of annotating epoch blocks.
The generated tests now test after adding each message (not much sense yet since mesasges are immutable, will be more interesting once epoch blocks are also tested)
Added a function to generate a random TxFlow DAG.
Added a function to stress test that the epoch blocks are consistent when seen from different points of view.