### PR TITLE
make account_id_to_shard_id() and num_shards() dependent on epoch_id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2418,6 +2418,7 @@ name = "near-epoch-manager"
 version = "0.0.1"
 dependencies = [
  "borsh",
+ "byteorder",
  "cached",
  "log",
  "near-chain",

--- a/chain/chain/src/validate.rs
+++ b/chain/chain/src/validate.rs
@@ -47,7 +47,8 @@ pub fn validate_chunk_proofs(chunk: &ShardChunk, runtime_adapter: &dyn RuntimeAd
         return chunk.receipts.len() == 0
             && chunk.header.inner.outgoing_receipts_root == CryptoHash::default();
     } else {
-        let outgoing_receipts_hashes = runtime_adapter.build_receipts_hashes(&chunk.receipts);
+        let outgoing_receipts_hashes = runtime_adapter
+            .build_receipts_hashes(&chunk.receipts, &chunk.header.inner.prev_block_hash);
         let (receipts_root, _) = merklize(&outgoing_receipts_hashes);
         if receipts_root != chunk.header.inner.outgoing_receipts_root {
             byzantine_assert!(false);
@@ -128,7 +129,8 @@ pub fn validate_chunk_with_chunk_extra(
         chunk_header.inner.shard_id,
         prev_chunk_header.height_included,
     )?;
-    let outgoing_receipts_hashes = runtime_adapter.build_receipts_hashes(&receipt_response.1);
+    let outgoing_receipts_hashes =
+        runtime_adapter.build_receipts_hashes(&receipt_response.1, &receipt_response.0);
     let (outgoing_receipts_root, _) = merklize(&outgoing_receipts_hashes);
 
     if outgoing_receipts_root != chunk_header.inner.outgoing_receipts_root {

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -554,7 +554,7 @@ impl ShardsManager {
     }
 
     fn get_tracking_shards(&self, parent_hash: &CryptoHash) -> HashSet<ShardId> {
-        (0..self.runtime_adapter.num_shards())
+        (0..self.runtime_adapter.num_shards(parent_hash).unwrap())
             .filter(|chunk_shard_id| {
                 self.cares_about_shard_this_or_next_epoch(
                     self.me.as_ref(),
@@ -732,15 +732,18 @@ impl ShardsManager {
         tracking_shards: &HashSet<ShardId>,
         receipts: &Vec<Receipt>,
         proofs: &Vec<MerklePath>,
+        prev_block_hash: &CryptoHash,
     ) -> Vec<ReceiptProof> {
         let mut part_receipt_proofs = vec![];
-        for to_shard_id in 0..self.runtime_adapter.num_shards() {
+        for to_shard_id in 0..self.runtime_adapter.num_shards(prev_block_hash).unwrap() {
             if tracking_shards.contains(&to_shard_id) {
                 part_receipt_proofs.push(ReceiptProof(
                     receipts
                         .iter()
                         .filter(|&receipt| {
-                            self.runtime_adapter.account_id_to_shard_id(&receipt.receiver_id)
+                            self.runtime_adapter
+                                .account_id_to_shard_id(&receipt.receiver_id, prev_block_hash)
+                                .unwrap()
                                 == to_shard_id
                         })
                         .cloned()
@@ -1027,7 +1030,8 @@ impl ShardsManager {
 
         // 6. Checking receipts validity
         let receipts = collect_receipts(&partial_encoded_chunk.receipts);
-        let receipts_hashes = self.runtime_adapter.build_receipts_hashes(&receipts);
+        let receipts_hashes =
+            self.runtime_adapter.build_receipts_hashes(&receipts, &prev_block_hash);
 
         for proof in partial_encoded_chunk.receipts.iter() {
             let shard_id = proof.1.to_shard_id;
@@ -1156,7 +1160,7 @@ impl ShardsManager {
         prev_block_hash: &CryptoHash,
         chunk_entry: &EncodedChunksCacheEntry,
     ) -> Result<bool, Error> {
-        for shard_id in 0..self.runtime_adapter.num_shards() {
+        for shard_id in 0..self.runtime_adapter.num_shards(prev_block_hash).unwrap() {
             let shard_id = shard_id as ShardId;
             if !chunk_entry.receipts.contains_key(&shard_id) {
                 if self.need_receipt(&prev_block_hash, shard_id) {
@@ -1314,8 +1318,9 @@ impl ShardsManager {
         store_update: &mut ChainStoreUpdate<'_>,
     ) {
         let shard_id = encoded_chunk.header.inner.shard_id;
+        let prev_block_hash = encoded_chunk.header.inner.prev_block_hash;
         let outgoing_receipts_hashes =
-            self.runtime_adapter.build_receipts_hashes(outgoing_receipts);
+            self.runtime_adapter.build_receipts_hashes(outgoing_receipts, &prev_block_hash);
         let (outgoing_receipts_root, outgoing_receipts_proofs) =
             merklize(&outgoing_receipts_hashes);
         assert_eq!(encoded_chunk.header.inner.outgoing_receipts_root, outgoing_receipts_root);
@@ -1339,9 +1344,10 @@ impl ShardsManager {
             receipts: self
                 .receipts_recipient_filter(
                     shard_id,
-                    &(0..self.runtime_adapter.num_shards()).collect(),
+                    &(0..self.runtime_adapter.num_shards(&prev_block_hash).unwrap()).collect(),
                     outgoing_receipts,
                     &outgoing_receipts_proofs,
+                    &prev_block_hash,
                 )
                 .into_iter()
                 .map(|receipt_proof| (receipt_proof.1.to_shard_id, receipt_proof))
@@ -1366,7 +1372,7 @@ impl ShardsManager {
         let prev_block_hash = encoded_chunk.header.inner.prev_block_hash;
         let shard_id = encoded_chunk.header.inner.shard_id;
         let outgoing_receipts_hashes =
-            self.runtime_adapter.build_receipts_hashes(&outgoing_receipts);
+            self.runtime_adapter.build_receipts_hashes(&outgoing_receipts, &prev_block_hash);
         let (outgoing_receipts_root, outgoing_receipts_proofs) =
             merklize(&outgoing_receipts_hashes);
         assert_eq!(encoded_chunk.header.inner.outgoing_receipts_root, outgoing_receipts_root);
@@ -1382,7 +1388,7 @@ impl ShardsManager {
         }
 
         for (to_whom, part_ords) in block_producer_mapping {
-            let tracking_shards = (0..self.runtime_adapter.num_shards())
+            let tracking_shards = (0..self.runtime_adapter.num_shards(&prev_block_hash).unwrap())
                 .filter(|chunk_shard_id| {
                     self.cares_about_shard_this_or_next_epoch(
                         Some(&to_whom),
@@ -1398,6 +1404,7 @@ impl ShardsManager {
                 &tracking_shards,
                 &outgoing_receipts,
                 &outgoing_receipts_proofs,
+                &prev_block_hash,
             );
             let partial_encoded_chunk = encoded_chunk.create_partial_encoded_chunk(
                 part_ords,
@@ -1507,7 +1514,7 @@ mod test {
                 vec![],
                 vec![],
                 &vec![],
-                merklize(&runtime_adapter.build_receipts_hashes(&[])).0,
+                merklize(&runtime_adapter.build_receipts_hashes(&[], &CryptoHash::default())).0,
                 CryptoHash::default(),
                 &signer,
                 &mut rs,

--- a/chain/chunks/src/test_utils.rs
+++ b/chain/chunks/src/test_utils.rs
@@ -206,7 +206,7 @@ impl Default for ChunkForwardingTestFixture {
             mock_network.clone(),
         );
         let receipts = Vec::new();
-        let receipts_hashes = mock_runtime.build_receipts_hashes(&receipts);
+        let receipts_hashes = mock_runtime.build_receipts_hashes(&receipts, &mock_parent_hash);
         let (receipts_root, _) = merkle::merklize(&receipts_hashes);
         let (mock_chunk, mock_merkles) = producer_shard_manager
             .create_encoded_shard_chunk(

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -496,7 +496,7 @@ impl Client {
         // will receive a piece of incoming receipts only
         // with merkle receipts proofs which can be checked locally
         let outgoing_receipts_hashes =
-            self.runtime_adapter.build_receipts_hashes(&outgoing_receipts);
+            self.runtime_adapter.build_receipts_hashes(&outgoing_receipts, &prev_block_hash);
         let (outgoing_receipts_root, _) = merklize(&outgoing_receipts_hashes);
 
         let (encoded_chunk, merkle_paths) = self.shards_mgr.create_encoded_shard_chunk(
@@ -872,7 +872,7 @@ impl Client {
 
             if provenance != Provenance::SYNC && !self.sync_status.is_syncing() {
                 // Produce new chunks
-                for shard_id in 0..self.runtime_adapter.num_shards() {
+                for shard_id in 0..self.runtime_adapter.num_shards(block.hash()).unwrap() {
                     let epoch_id = self
                         .runtime_adapter
                         .get_epoch_id_from_prev_block(&block.header().hash())
@@ -1081,8 +1081,10 @@ impl Client {
 
     /// Forwards given transaction to upcoming validators.
     fn forward_tx(&self, epoch_id: &EpochId, tx: &SignedTransaction) -> Result<(), Error> {
-        let shard_id = self.runtime_adapter.account_id_to_shard_id(&tx.transaction.signer_id);
         let head = self.chain.head()?;
+        let shard_id = self
+            .runtime_adapter
+            .account_id_to_shard_id(&tx.transaction.signer_id, &head.last_block_hash)?;
         let maybe_next_epoch_id = self.get_next_epoch_id_if_at_boundary(&head)?;
 
         let mut validators = HashSet::new();
@@ -1173,7 +1175,9 @@ impl Client {
     ) -> Result<NetworkClientResponses, Error> {
         let head = self.chain.head()?;
         let me = self.validator_signer.as_ref().map(|vs| vs.validator_id());
-        let shard_id = self.runtime_adapter.account_id_to_shard_id(&tx.transaction.signer_id);
+        let shard_id = self
+            .runtime_adapter
+            .account_id_to_shard_id(&tx.transaction.signer_id, &head.last_block_hash)?;
         let cur_block_header = self.chain.head_header()?.clone();
         let transaction_validity_period = self.chain.transaction_validity_period;
         // here it is fine to use `cur_block_header` as it is a best effort estimate. If the transaction

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -28,7 +28,7 @@ use near_primitives::block::{ApprovalInner, Block, GenesisId};
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{
-    AccountId, Balance, BlockHeight, BlockHeightDelta, NumBlocks, NumSeats, NumShards,
+    AccountId, Balance, BlockHeight, BlockHeightDelta, NumBlocks, NumSeats, NumShards, ShardId,
 };
 use near_primitives::validator_signer::{InMemoryValidatorSigner, ValidatorSigner};
 use near_primitives::version::PROTOCOL_VERSION;
@@ -925,4 +925,8 @@ impl TestEnv {
             self.chain_genesis.clone(),
         )
     }
+}
+
+pub fn account_id_to_shard_id_by_hash(account_id: &AccountId, num_shards: NumShards) -> ShardId {
+    u64::from((hash(&account_id.clone().into_bytes()).0).0[0]) % num_shards
 }

--- a/chain/client/tests/bug_repros.rs
+++ b/chain/client/tests/bug_repros.rs
@@ -8,8 +8,7 @@ use std::sync::{Arc, RwLock};
 use actix::{Addr, System};
 use rand::{thread_rng, Rng};
 
-use near_chain::test_utils::account_id_to_shard_id;
-use near_client::test_utils::setup_mock_all_validators;
+use near_client::test_utils::{account_id_to_shard_id_by_hash, setup_mock_all_validators};
 use near_client::{ClientActor, ViewClientActor};
 use near_crypto::{InMemorySigner, KeyType};
 use near_logger_utils::init_test_logger;
@@ -88,7 +87,7 @@ fn repro_1183() {
                     for from in vec!["test1", "test2", "test3", "test4"] {
                         for to in vec!["test1", "test2", "test3", "test4"] {
                             connectors1.write().unwrap()
-                                [account_id_to_shard_id(&from.to_string(), 4) as usize]
+                                [account_id_to_shard_id_by_hash(&from.to_string(), 4) as usize]
                                 .0
                                 .do_send(NetworkClientMessages::Transaction {
                                     transaction: SignedTransaction::send_money(

--- a/chain/client/tests/catching_up.rs
+++ b/chain/client/tests/catching_up.rs
@@ -9,9 +9,8 @@ mod tests {
     use borsh::{BorshDeserialize, BorshSerialize};
     use futures::{future, FutureExt};
 
-    use near_chain::test_utils::account_id_to_shard_id;
     use near_client::sync::STATE_SYNC_TIMEOUT;
-    use near_client::test_utils::setup_mock_all_validators;
+    use near_client::test_utils::{account_id_to_shard_id_by_hash, setup_mock_all_validators};
     use near_client::{ClientActor, Query, ViewClientActor};
     use near_crypto::{InMemorySigner, KeyType};
     use near_logger_utils::init_integration_logger;
@@ -150,8 +149,8 @@ mod tests {
                     move |_account_id: String, msg: &NetworkRequests| {
                         let account_from = "test3.3".to_string();
                         let account_to = "test1.1".to_string();
-                        let source_shard_id = account_id_to_shard_id(&account_from, 4);
-                        let destination_shard_id = account_id_to_shard_id(&account_to, 4);
+                        let source_shard_id = account_id_to_shard_id_by_hash(&account_from, 4);
+                        let destination_shard_id = account_id_to_shard_id_by_hash(&account_to, 4);
 
                         let mut phase = phase.write().unwrap();
                         let mut seen_heights_with_receipts =

--- a/chain/client/tests/challenges.rs
+++ b/chain/client/tests/challenges.rs
@@ -555,13 +555,16 @@ fn test_receive_invalid_chunk_as_chunk_producer() {
     assert!(result.is_err());
     assert_eq!(client.chain.head().unwrap().height, 1);
     // But everyone who doesn't track this shard have accepted.
-    let receipts_hashes = env.clients[0].runtime_adapter.build_receipts_hashes(&receipts);
+    let prev_block_hash = &client.chain.head().unwrap().prev_block_hash;
+    let receipts_hashes =
+        env.clients[0].runtime_adapter.build_receipts_hashes(&receipts, prev_block_hash);
     let (_receipts_root, receipts_proofs) = merklize(&receipts_hashes);
     let one_part_receipt_proofs = env.clients[0].shards_mgr.receipts_recipient_filter(
         0,
         &HashSet::default(),
         &receipts,
         &receipts_proofs,
+        prev_block_hash,
     );
 
     assert!(env.clients[1]

--- a/chain/client/tests/cross_shard_tx.rs
+++ b/chain/client/tests/cross_shard_tx.rs
@@ -84,8 +84,7 @@ mod tests {
     use actix::{Addr, MailboxError, System};
     use futures::{future, FutureExt};
 
-    use near_chain::test_utils::account_id_to_shard_id;
-    use near_client::test_utils::setup_mock_all_validators;
+    use near_client::test_utils::{account_id_to_shard_id_by_hash, setup_mock_all_validators};
     use near_client::{ClientActor, Query, ViewClientActor};
     use near_crypto::{InMemorySigner, KeyType};
     use near_logger_utils::init_test_logger;
@@ -192,7 +191,7 @@ mod tests {
                 let observed_balances1 = observed_balances.clone();
                 let presumable_epoch1 = presumable_epoch.clone();
                 actix::spawn(
-                    connectors_[account_id_to_shard_id(&account_id, 8) as usize
+                    connectors_[account_id_to_shard_id_by_hash(&account_id, 8) as usize
                         + (*presumable_epoch.read().unwrap() * 8) % 24]
                         .1
                         .send(Query::new(
@@ -252,7 +251,7 @@ mod tests {
                     send_tx(
                         validators.len(),
                         connectors.clone(),
-                        account_id_to_shard_id(&validators[from].to_string(), 8) as usize,
+                        account_id_to_shard_id_by_hash(&validators[from].to_string(), 8) as usize,
                         validators[from].to_string(),
                         validators[to].to_string(),
                         amount,
@@ -282,8 +281,10 @@ mod tests {
                         let presumable_epoch1 = presumable_epoch.clone();
                         let account_id1 = validators[i].to_string();
                         actix::spawn(
-                            connectors_[account_id_to_shard_id(&validators[i].to_string(), 8)
-                                as usize
+                            connectors_[account_id_to_shard_id_by_hash(
+                                &validators[i].to_string(),
+                                8,
+                            ) as usize
                                 + (*presumable_epoch.read().unwrap() * 8) % 24]
                                 .1
                                 .send(Query::new(
@@ -334,7 +335,7 @@ mod tests {
                 let connectors1 = connectors.clone();
                 let presumable_epoch1 = presumable_epoch.clone();
                 actix::spawn(
-                    connectors_[account_id_to_shard_id(&account_id, 8) as usize
+                    connectors_[account_id_to_shard_id_by_hash(&account_id, 8) as usize
                         + (*presumable_epoch.read().unwrap() * 8) % 24]
                         .1
                         .send(Query::new(

--- a/chain/epoch_manager/Cargo.toml
+++ b/chain/epoch_manager/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 
 [dependencies]
 # Changing this version will lead to change to the protocol, as will change how validators get shuffled.
+byteorder = "1.2"
 protocol_defining_rand = { package = "rand", version = "0.6.5", default-features = false }
 log = "0.4"
 cached = "0.12"

--- a/chain/epoch_manager/src/types.rs
+++ b/chain/epoch_manager/src/types.rs
@@ -51,8 +51,8 @@ impl EpochInfoAggregator {
     ) {
         // Step 1: update block tracer
         for height in prev_block_height + 1..=block_info.height {
-            let block_producer_id = epoch_info.block_producers_settlement
-                [(height as u64 % (epoch_info.block_producers_settlement.len() as u64)) as usize];
+            let block_producer_id = epoch_info.block_producers_settlement()
+                [(height as u64 % (epoch_info.block_producers_settlement().len() as u64)) as usize];
             let entry = self.block_tracker.entry(block_producer_id);
             if height == block_info.height {
                 entry

--- a/chain/epoch_manager/tests/random_epochs.rs
+++ b/chain/epoch_manager/tests/random_epochs.rs
@@ -190,8 +190,8 @@ fn verify_epochs(epoch_infos: &Vec<EpochInfo>) {
         let epoch_info = &epoch_infos[i];
         let prev_epoch_info = &epoch_infos[i - 1];
         assert_eq!(
-            epoch_info.epoch_height,
-            prev_epoch_info.epoch_height + 1,
+            *epoch_info.epoch_height(),
+            prev_epoch_info.epoch_height() + 1,
             "epoch height increases by 1"
         );
         let stakes_before_change = get_stakes_map(prev_epoch_info);
@@ -201,12 +201,12 @@ fn verify_epochs(epoch_infos: &Vec<EpochInfo>) {
         }
         let stakes_after_change = get_stakes_map(epoch_info);
         let mut stakes_with_change = stakes_before_change.clone();
-        for (account_id, new_stake) in &epoch_info.stake_change {
+        for (account_id, new_stake) in epoch_info.stake_change() {
             if *new_stake == 0 {
                 if stakes_before_change.get(account_id).is_none() {
                     // Stake change from 0 to 0
-                    assert!(prev_epoch_info.validator_kickout.contains_key(account_id));
-                    assert!(epoch_info.validator_kickout.contains_key(account_id));
+                    assert!(prev_epoch_info.validator_kickout().contains_key(account_id));
+                    assert!(epoch_info.validator_kickout().contains_key(account_id));
                 }
                 stakes_with_change.remove(account_id);
             } else {
@@ -214,14 +214,15 @@ fn verify_epochs(epoch_infos: &Vec<EpochInfo>) {
             }
         }
         assert_eq!(
-            stakes_with_change, stakes_after_change,
+            stakes_with_change,
+            stakes_after_change,
             "stake change: {:?}",
-            epoch_info.stake_change
+            epoch_info.stake_change()
         );
 
         for account_id in stakes_after_change.keys() {
             assert!(
-                epoch_info.validator_kickout.get(account_id).is_none(),
+                epoch_info.validator_kickout().get(account_id).is_none(),
                 "cannot be in both validator and kickout set"
             );
         }
@@ -229,10 +230,10 @@ fn verify_epochs(epoch_infos: &Vec<EpochInfo>) {
         if is_possible_bad_epochs_case(&epoch_infos[i - 1], &epoch_infos[i]) {
             continue;
         }
-        for (account_id, reason) in &epoch_info.validator_kickout {
+        for (account_id, reason) in epoch_info.validator_kickout() {
             let was_validaror_2_ago = (i >= 2
-                && epoch_infos[i - 2].validator_to_index.contains_key(account_id))
-                || (i == 1 && epoch_infos[0].validator_to_index.contains_key(account_id));
+                && epoch_infos[i - 2].validator_to_index().contains_key(account_id))
+                || (i == 1 && epoch_infos[0].validator_to_index().contains_key(account_id));
             let in_slashes_set = reason == &ValidatorKickoutReason::Slashed;
             assert!(
                 was_validaror_2_ago || in_slashes_set,
@@ -308,7 +309,7 @@ fn verify_slashes(
                     continue;
                 }
                 if slash_state == &SlashState::AlreadySlashed {
-                    if epoch_info.stake_change.contains_key(account) {
+                    if epoch_info.stake_change().contains_key(account) {
                         assert_eq!(slashes_set.get(account), Some(&SlashState::AlreadySlashed));
                     } else {
                         assert_eq!(slashes_set.get(account), None);
@@ -356,11 +357,11 @@ fn verify_block_stats(
                 .unwrap();
             let epoch_info = epoch_manager.get_epoch_info(&block_infos[i].epoch_id).unwrap();
             for key in aggregator.block_tracker.keys().copied() {
-                assert!(key < epoch_info.validators.len() as u64);
+                assert!(key < epoch_info.validators().len() as u64);
             }
             for shard_stats in aggregator.shard_tracker.values() {
                 for key in shard_stats.keys().copied() {
-                    assert!(key < epoch_info.validators.len() as u64);
+                    assert!(key < epoch_info.validators().len() as u64);
                 }
             }
             let sum_produced =
@@ -394,15 +395,15 @@ fn verify_block_stats(
 // Bad epoch case: All validators are kicked out.
 fn is_possible_bad_epochs_case(prev: &EpochInfo, curr: &EpochInfo) -> bool {
     let mut copy = prev.clone();
-    copy.epoch_height += 1;
+    copy.get_mut().epoch_height += 1;
     &copy == curr
 }
 
 fn get_stakes_map(epoch_info: &EpochInfo) -> HashMap<AccountId, Balance> {
     epoch_info
-        .validators
+        .validators()
         .iter()
-        .chain(epoch_info.fishermen.iter())
+        .chain(epoch_info.fishermen().iter())
         .map(|stake| (stake.account_id.clone(), stake.stake))
         .collect::<HashMap<_, _>>()
 }

--- a/core/primitives/src/block_header.rs
+++ b/core/primitives/src/block_header.rs
@@ -193,7 +193,7 @@ impl BlockHeaderV1 {
     }
 }
 
-/// V1 -> V2: Remove `chunks_included` from `inner_reset`
+/// V1 -> V2: Remove `chunks_included` from `inner_rest`
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Debug, Clone, Eq, PartialEq)]
 #[borsh_init(init)]
 pub struct BlockHeaderV2 {
@@ -239,8 +239,7 @@ impl BlockHeader {
 
     pub fn compute_hash(prev_hash: CryptoHash, inner_lite: &[u8], inner_rest: &[u8]) -> CryptoHash {
         let hash_inner = BlockHeader::compute_inner_hash(inner_lite, inner_rest);
-
-        return combine_hash(hash_inner, prev_hash);
+        combine_hash(hash_inner, prev_hash)
     }
 
     pub fn new(

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -12,7 +12,7 @@ pub struct Version {
 pub type DbVersion = u32;
 
 /// Current version of the database.
-pub const DB_VERSION: DbVersion = 4;
+pub const DB_VERSION: DbVersion = 5;
 
 /// Protocol version type.
 pub type ProtocolVersion = u32;

--- a/core/store/src/migrations.rs
+++ b/core/store/src/migrations.rs
@@ -3,13 +3,15 @@ use std::collections::{HashMap, HashSet};
 
 use borsh::BorshDeserialize;
 
+use near_primitives::epoch_manager::{EpochInfo, EpochInfoV1, EpochInfoV2, AGGREGATOR_KEY};
 use near_primitives::hash::CryptoHash;
+use near_primitives::sharding::ShardChunk;
 use near_primitives::transaction::ExecutionOutcomeWithIdAndProof;
+use near_primitives::types::AccountId;
 use near_primitives::version::DbVersion;
 
 use crate::db::{DBCol, RocksDB, VERSION_KEY};
 use crate::Store;
-use near_primitives::sharding::ShardChunk;
 
 pub fn get_store_version(path: &str) -> DbVersion {
     RocksDB::get_version(path).expect("Failed to open the database")
@@ -60,6 +62,7 @@ pub fn fill_col_outcomes_by_hash(store: &Store) {
             .set_ser(DBCol::ColOutcomesByBlockHash, block_hash.as_ref(), &hash_set)
             .expect("BorshSerialize should not fail");
     }
+    store_update.commit().expect("Failed to migrate");
 }
 
 pub fn fill_col_transaction_refcount(store: &Store) {
@@ -80,4 +83,60 @@ pub fn fill_col_transaction_refcount(store: &Store) {
             .set_ser(DBCol::ColTransactionRefCount, tx_hash.as_ref(), &refcount)
             .expect("BorshSerialize should not fail");
     }
+    store_update.commit().expect("Failed to migrate");
+}
+
+pub fn fill_accounts_to_shard(store: &Store) {
+    let mut store_update = store.store_update();
+    for record in store.iter(DBCol::ColEpochInfo).map(|(key, value)| {
+        if key.as_ref() == AGGREGATOR_KEY {
+            None
+        } else {
+            Some((
+                key,
+                EpochInfoV1::try_from_slice(&value).expect("BorshDeserialize should not fail"),
+            ))
+        }
+    }) {
+        if let Some((key, old_epoch_info)) = record {
+            let EpochInfoV1 {
+                epoch_height,
+                validators,
+                validator_to_index,
+                block_producers_settlement,
+                chunk_producers_settlement,
+                hidden_validators_settlement,
+                fishermen,
+                fishermen_to_index,
+                stake_change,
+                validator_reward,
+                validator_kickout,
+                minted_amount,
+                seat_price,
+                protocol_version,
+            } = old_epoch_info;
+            let num_shards = chunk_producers_settlement.len();
+            let epoch_info = EpochInfo::EpochInfoV2(Box::new(EpochInfoV2 {
+                epoch_height,
+                validators,
+                validator_to_index,
+                block_producers_settlement,
+                chunk_producers_settlement,
+                hidden_validators_settlement,
+                fishermen,
+                fishermen_to_index,
+                stake_change,
+                validator_reward,
+                validator_kickout,
+                minted_amount,
+                seat_price,
+                accounts_to_shard: vec![AccountId::default(); num_shards],
+                protocol_version,
+            }));
+            store_update
+                .set_ser(DBCol::ColEpochInfo, &key, &epoch_info)
+                .expect("BorshSerialize should not fail");
+        }
+    }
+    store_update.commit().expect("Failed to migrate");
 }

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -120,7 +120,8 @@ impl GenesisBuilder {
         self.unflushed_records =
             self.roots.keys().cloned().map(|shard_idx| (shard_idx, vec![])).collect();
 
-        let total_accounts_num = self.additional_accounts_num * self.runtime.num_shards();
+        let total_accounts_num =
+            self.additional_accounts_num * self.runtime.num_shards(&CryptoHash::default()).unwrap();
         let bar = ProgressBar::new(total_accounts_num as _);
         bar.set_style(ProgressStyle::default_bar().template(
             "[elapsed {elapsed_precise} remaining {eta_precise}] Writing into storage {bar} {pos:>7}/{len:7}",
@@ -132,7 +133,7 @@ impl GenesisBuilder {
             bar.inc(1);
         }
 
-        for shard_id in 0..self.runtime.num_shards() {
+        for shard_id in 0..self.runtime.num_shards(&CryptoHash::default()).unwrap() {
             self.flush_shard_records(shard_id)?;
         }
         bar.finish();
@@ -184,7 +185,7 @@ impl GenesisBuilder {
     fn write_genesis_block(&mut self) -> Result<()> {
         let genesis_chunks = genesis_chunks(
             self.roots.values().cloned().collect(),
-            self.runtime.num_shards(),
+            self.runtime.num_shards(&CryptoHash::default()).unwrap(),
             self.genesis.config.gas_limit,
             self.genesis.config.genesis_height,
         );
@@ -233,7 +234,7 @@ impl GenesisBuilder {
     fn add_additional_account(&mut self, account_id: AccountId) -> Result<()> {
         let testing_init_balance: Balance = 10u128.pow(30);
         let testing_init_stake: Balance = 0;
-        let shard_id = self.runtime.account_id_to_shard_id(&account_id);
+        let shard_id = self.runtime.account_id_to_shard_id(&account_id, &CryptoHash::default())?;
         let mut records = self.unflushed_records.remove(&shard_id).unwrap_or_default();
         let mut state_update =
             self.state_updates.remove(&shard_id).expect("State update should have been added");

--- a/neard/tests/sync_nodes.rs
+++ b/neard/tests/sync_nodes.rs
@@ -10,7 +10,7 @@ use near_chain::{Block, Chain};
 use near_chain_configs::Genesis;
 use near_client::{ClientActor, GetBlock};
 use near_crypto::{InMemorySigner, KeyType};
-use near_logger_utils::init_integration_logger;
+use near_logger_utils::init_test_logger;
 use near_network::test_utils::{convert_boot_nodes, open_port, WaitOrTimeout};
 use near_network::{NetworkClientMessages, PeerInfo};
 use near_primitives::block::Approval;
@@ -93,7 +93,7 @@ fn add_blocks(
 #[test]
 fn sync_nodes() {
     heavy_test(|| {
-        init_integration_logger();
+        init_test_logger();
 
         let mut genesis = Genesis::test(vec!["other"], 1);
         genesis.config.epoch_length = 5;
@@ -145,7 +145,7 @@ fn sync_nodes() {
 #[test]
 fn sync_after_sync_nodes() {
     heavy_test(|| {
-        init_integration_logger();
+        init_test_logger();
 
         let mut genesis = Genesis::test(vec!["other"], 1);
         genesis.config.epoch_length = 5;
@@ -216,7 +216,7 @@ fn sync_after_sync_nodes() {
 #[test]
 fn sync_state_stake_change() {
     heavy_test(|| {
-        init_integration_logger();
+        init_test_logger();
 
         let mut genesis = Genesis::test(vec!["test1"], 1);
         genesis.config.epoch_length = 5;


### PR DESCRIPTION
This is the important step for the Dynamic Resharding.

We expect that number of Shards may be different between Epochs. There is the same number of Shards within Epoch. Number of Shards (num_shards) and account boundaries are stored in EpochInfo.

`account_id_to_shard_id` and `state_record_to_shard_id ` are incapsulated into EpochManager and requires epoch_id (prev_block_hash). `num_shards` requires epoch_id as well (prev_block_hash to obtain epoch_id). There is a `account_id_to_shard_id_by_hash` function for testing purposes.

Versioning for EpochInfo is added. There is `fill_accounts_to_shard` function to migrate to the next db version. Other db migrations are fixed by commiting at the end.

Unresolved questions:
1. Can't get the number of shards in `process_block` on the epoch boundary (sync_nodes test).
2. Too many unwraps because `num_shards` returns Result now instead of u64.

TEST PLAN
---------
CI + custom Nightly