### PR TITLE
fix(better_route_back): Use target peer if exists

### DIFF
--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -14,7 +14,7 @@ use near_chain::{
     RuntimeAdapter,
 };
 use near_network::types::{
-    NetworkAdapter, PartialEncodedChunkRequestMsg, PartialEncodedChunkResponseMsg,
+    NetworkAdapter, PartialEncodedChunkRequestMsg, PartialEncodedChunkResponseMsg, RoutedTarget,
 };
 use near_network::NetworkRequests;
 use near_pool::{PoolIteratorWrapper, TransactionPool};
@@ -759,7 +759,7 @@ impl ShardsManager {
     pub fn process_partial_encoded_chunk_request(
         &mut self,
         request: PartialEncodedChunkRequestMsg,
-        route_back: CryptoHash,
+        route_back: RoutedTarget,
         chain_store: &mut ChainStore,
     ) {
         debug!(target: "chunks", "Received partial encoded chunk request for {:?}, part_ordinals: {:?}, receipts: {:?}, I'm {:?}", request.chunk_hash.0, request.part_ords, request.tracking_shards, self.me);
@@ -824,7 +824,7 @@ impl ShardsManager {
     fn maybe_send_partial_encoded_chunk_response<A, B>(
         &self,
         chunk_hash: ChunkHash,
-        route_back: CryptoHash,
+        route_back: RoutedTarget,
         parts_iter: A,
         receipts_iter: B,
     ) where

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -21,15 +21,15 @@ use near_crypto::{InMemorySigner, KeyType, PublicKey};
 use near_network::recorder::MetricRecorder;
 use near_network::routing::EdgeInfo;
 use near_network::types::{
-    AccountOrPeerIdOrHash, NetworkInfo, NetworkViewClientMessages, NetworkViewClientResponses,
-    PeerChainInfo,
+    AccountOrPeerId, NetworkInfo, NetworkViewClientMessages, NetworkViewClientResponses,
+    PeerChainInfo, RoutedTarget,
 };
 use near_network::{
     FullPeerInfo, NetworkAdapter, NetworkClientMessages, NetworkClientResponses, NetworkRecipient,
     NetworkRequests, NetworkResponses, PeerInfo, PeerManagerActor,
 };
 use near_primitives::block::{ApprovalInner, Block, GenesisId};
-use near_primitives::hash::{hash, CryptoHash};
+use near_primitives::hash::CryptoHash;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{
     AccountId, Balance, BlockHeight, BlockHeightDelta, NumBlocks, NumSeats, NumShards,
@@ -351,7 +351,8 @@ pub fn setup_mock_all_validators(
     let validators_clone = validators.clone();
     let key_pairs = key_pairs;
 
-    let addresses: Vec<_> = (0..key_pairs.len()).map(|i| hash(vec![i as u8].as_ref())).collect();
+    let addresses: Vec<_> =
+        (0..key_pairs.len()).map(|i| RoutedTarget::from_peer_id(key_pairs[i].id.clone())).collect();
     let genesis_time = Utc::now();
     let mut ret = vec![];
 
@@ -487,7 +488,7 @@ pub fn setup_mock_all_validators(
                                         connectors1.read().unwrap()[i].0.do_send(
                                             NetworkClientMessages::PartialEncodedChunkRequest(
                                                 request.clone(),
-                                                my_address,
+                                                my_address.clone(),
                                             ),
                                         );
                                     }
@@ -591,7 +592,7 @@ pub fn setup_mock_all_validators(
                             target: target_account_id,
                         } => {
                             let target_account_id = match target_account_id {
-                                AccountOrPeerIdOrHash::AccountId(x) => x,
+                                AccountOrPeerId::AccountId(x) => x,
                                 _ => panic!(),
                             };
                             for (i, name) in validators_clone2.iter().flatten().enumerate() {
@@ -634,7 +635,7 @@ pub fn setup_mock_all_validators(
                             target: target_account_id,
                         } => {
                             let target_account_id = match target_account_id {
-                                AccountOrPeerIdOrHash::AccountId(x) => x,
+                                AccountOrPeerId::AccountId(x) => x,
                                 _ => panic!(),
                             };
                             for (i, name) in validators_clone2.iter().flatten().enumerate() {

--- a/chain/client/src/types.rs
+++ b/chain/client/src/types.rs
@@ -8,7 +8,7 @@ use actix::Message;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use near_network::types::{AccountOrPeerIdOrHash, KnownProducer};
+use near_network::types::{AccountOrPeerId, KnownProducer};
 use near_network::PeerInfo;
 use near_primitives::errors::InvalidTxError;
 use near_primitives::hash::CryptoHash;
@@ -82,7 +82,7 @@ pub struct DownloadStatus {
     pub error: bool,
     pub done: bool,
     pub state_requests_count: u64,
-    pub last_target: Option<AccountOrPeerIdOrHash>,
+    pub last_target: Option<AccountOrPeerId>,
 }
 
 impl Clone for DownloadStatus {

--- a/chain/client/tests/catching_up.rs
+++ b/chain/client/tests/catching_up.rs
@@ -15,10 +15,11 @@ mod tests {
     use near_client::{ClientActor, Query, ViewClientActor};
     use near_crypto::{InMemorySigner, KeyType};
     use near_logger_utils::init_integration_logger;
-    use near_network::types::AccountOrPeerIdOrHash;
+    use near_network::types::AccountOrPeerId;
     use near_network::{NetworkClientMessages, NetworkRequests, NetworkResponses, PeerInfo};
     use near_primitives::hash::hash as hash_func;
     use near_primitives::hash::CryptoHash;
+    use near_primitives::network::PeerId;
     use near_primitives::receipt::Receipt;
     use near_primitives::sharding::ChunkHash;
     use near_primitives::transaction::SignedTransaction;
@@ -86,7 +87,7 @@ mod tests {
         pub shard_id: u64,
         pub sync_hash: CryptoHash,
         pub part_id: Option<u64>,
-        pub target: AccountOrPeerIdOrHash,
+        pub target: AccountOrPeerId,
     }
 
     /// Sanity checks that the incoming and outgoing receipts are properly sent and received
@@ -919,8 +920,7 @@ mod tests {
             let seen_chunk_same_sender =
                 Arc::new(RwLock::new(HashSet::<(String, u64, u64)>::new()));
             let requested = Arc::new(RwLock::new(HashSet::<(String, Vec<u64>, ChunkHash)>::new()));
-            let responded =
-                Arc::new(RwLock::new(HashSet::<(CryptoHash, Vec<u64>, ChunkHash)>::new()));
+            let responded = Arc::new(RwLock::new(HashSet::<(PeerId, Vec<u64>, ChunkHash)>::new()));
 
             let (_, conn, _) = setup_mock_all_validators(
                 validators.clone(),
@@ -986,14 +986,14 @@ mod tests {
                         {
                             if verbose {
                                 if responded.contains(&(
-                                    route_back.clone(),
+                                    route_back.peer_id.clone(),
                                     response.parts.iter().map(|x| x.part_ord).collect(),
                                     response.chunk_hash.clone(),
                                 )) {
                                     println!("=== SAME RESPONSE AGAIN!");
                                 }
                                 responded.insert((
-                                    route_back.clone(),
+                                    route_back.peer_id.clone(),
                                     response.parts.iter().map(|x| x.part_ord).collect(),
                                     response.chunk_hash.clone(),
                                 ));

--- a/chain/client/tests/chunks_management.rs
+++ b/chain/client/tests/chunks_management.rs
@@ -260,7 +260,7 @@ fn test_request_chunk_restart() {
     let client = &mut env.clients[0];
     client.shards_mgr.process_partial_encoded_chunk_request(
         request.clone(),
-        CryptoHash::default(),
+        Default::default(),
         client.chain.mut_store(),
     );
     assert!(env.network_adapters[0].pop().is_some());
@@ -269,7 +269,7 @@ fn test_request_chunk_restart() {
     let client = &mut env.clients[0];
     client.shards_mgr.process_partial_encoded_chunk_request(
         request,
-        CryptoHash::default(),
+        Default::default(),
         client.chain.mut_store(),
     );
     let response = env.network_adapters[0].pop().unwrap();

--- a/chain/network/src/codec.rs
+++ b/chain/network/src/codec.rs
@@ -84,7 +84,7 @@ mod test {
 
     use crate::routing::EdgeInfo;
     use crate::types::{
-        Handshake, PeerChainInfo, PeerIdOrHash, PeerInfo, RoutedMessage, RoutedMessageBody,
+        Handshake, PeerChainInfo, PeerInfo, RoutedMessage, RoutedMessageBody, RoutedTarget,
         SyncData,
     };
 
@@ -149,7 +149,7 @@ mod test {
         let signature = sk.sign(hash.as_ref());
 
         let msg = PeerMessage::Routed(RoutedMessage {
-            target: PeerIdOrHash::PeerId(sk.public_key().into()),
+            target: RoutedTarget::from_peer_id(sk.public_key().into()),
             author: sk.public_key().into(),
             signature: signature.clone(),
             ttl: 100,

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -18,9 +18,9 @@ pub const DB_VERSION: DbVersion = 6;
 pub type ProtocolVersion = u32;
 
 /// Current latest version of the protocol.
-pub const PROTOCOL_VERSION: ProtocolVersion = 33;
+pub const PROTOCOL_VERSION: ProtocolVersion = 34;
 
-pub const FIRST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION: ProtocolVersion = 29;
+pub const FIRST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION: ProtocolVersion = 34;
 
 /// Minimum gas price proposed in NEP 92 and the associated protocol version
 pub const MIN_GAS_PRICE_NEP_92: Balance = 1_000_000_000;

--- a/neard/res/genesis_config.json
+++ b/neard/res/genesis_config.json
@@ -1,5 +1,5 @@
 {
-  "protocol_version": 33,
+  "protocol_version": 34,
   "genesis_time": "1970-01-01T00:00:00.000000000Z",
   "chain_id": "sample",
   "genesis_height": 0,


### PR DESCRIPTION
In routed message that uses hash to route message back, add also target peer to it, so message are routed optimally when the path to such peer is known.

~~This upgrade change layout of the message, so extra work is required to make it backward compatible.~~

Fixes #2989 

Most of dropped messages happens because the combination of routed back heuristic and rebalancing strategy. This issue is solved in this PR.

Test plan
=========
1. Existing tests (rust+nightly) extensively cover routing mechanism.
2. Is backward compatible