### PR TITLE
add test to cover stress.py fails

### DIFF
--- a/nightly/pytest-sanity.txt
+++ b/nightly/pytest-sanity.txt
@@ -1,4 +1,6 @@
 # python sanity tests
+pytest sanity/proxy_loose_block_messages.py
+pytest sanity/proxy_loose_block_messages.py --features nightly_protocol,nightly_protocol_features
 pytest sanity/block_production.py
 pytest sanity/block_production.py --features nightly_protocol,nightly_protocol_features
 pytest sanity/transactions.py

--- a/pytest/tests/sanity/proxy_loose_block_messages.py
+++ b/pytest/tests/sanity/proxy_loose_block_messages.py
@@ -16,6 +16,7 @@ max_height = Value('i', 0)
 
 
 class Handler(ProxyHandler):
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -27,7 +28,8 @@ class Handler(ProxyHandler):
             print(h, fr, to, msg, msg.Block.enum)
             tpl = (h, fr, to)
 
-            if h == NODES - 1 and to < (NODES - 1) / 2 and tpl not in ignored_messages:
+            if h == NODES - 1 and to < (NODES -
+                                        1) / 2 and tpl not in ignored_messages:
                 ignored_messages.add(tpl)
                 print("skipping msg from %d to %d" % (fr, to))
                 return False

--- a/pytest/tests/sanity/proxy_loose_block_messages.py
+++ b/pytest/tests/sanity/proxy_loose_block_messages.py
@@ -1,0 +1,49 @@
+import sys
+import time
+
+sys.path.append('lib')
+
+from cluster import start_cluster
+from peer import *
+from proxy import ProxyHandler
+
+from multiprocessing import Value
+
+TIMEOUT = 120
+NODES = 9
+ignored_messages = set()
+max_height = Value('i', 0)
+
+
+class Handler(ProxyHandler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    async def handle(self, msg, fr, to):
+        if msg.enum == 'Block':
+            h = msg.Block.BlockV1.header.BlockHeaderV2.inner_lite.height
+            if h > max_height.value:
+                max_height.value = h
+            print(h, fr, to, msg, msg.Block.enum)
+            tpl = (h, fr, to)
+
+            if h == NODES - 1 and to < (NODES - 1) / 2 and tpl not in ignored_messages:
+                ignored_messages.add(tpl)
+                print("skipping msg from %d to %d" % (fr, to))
+                return False
+
+        return True
+
+
+if __name__ == '__main__':
+    start_cluster(NODES, 0, 1, None, [], {}, message_handler=Handler)
+
+    start = time.time()
+    while True:
+        print("max_height", max_height.value)
+        if time.time() - start >= TIMEOUT or max_height.value > 3 * NODES:
+            print("DONE")
+            break
+        time.sleep(1)
+
+    assert max_height.value > 3 * NODES

--- a/pytest/tests/sanity/proxy_loose_block_messages.py
+++ b/pytest/tests/sanity/proxy_loose_block_messages.py
@@ -21,7 +21,7 @@ class Handler(ProxyHandler):
 
     async def handle(self, msg, fr, to):
         if msg.enum == 'Block':
-            h = msg.Block.BlockV1.header.BlockHeaderV2.inner_lite.height
+            h = msg.Block.BlockV2.header.inner_lite().height
             if h > max_height.value:
                 max_height.value = h
             print(h, fr, to, msg, msg.Block.enum)


### PR DESCRIPTION
Add a new test, which should. detect failures fixed in https://github.com/nearprotocol/nearcore/pull/3036

Adds test for https://github.com/nearprotocol/nearcore/pull/3036