### PR TITLE
feat(client): Read snapshots for state

### DIFF
--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -67,7 +67,7 @@ pub struct StoreValidator {
     me: Option<AccountId>,
     config: GenesisConfig,
     runtime_adapter: Arc<dyn RuntimeAdapter>,
-    store: Arc<Store>,
+    store: Store,
     inner: StoreValidatorCache,
     timeout: Option<u64>,
     start_time: Instant,
@@ -81,7 +81,7 @@ impl StoreValidator {
         me: Option<AccountId>,
         config: GenesisConfig,
         runtime_adapter: Arc<dyn RuntimeAdapter>,
-        store: Arc<Store>,
+        store: Store,
     ) -> Self {
         StoreValidator {
             me,
@@ -128,7 +128,7 @@ impl StoreValidator {
         self.errors.push(ErrorMessage { key: to_string(&key), col: to_string(&col), err })
     }
     fn validate_col(&mut self, col: DBCol) -> Result<(), StoreValidatorError> {
-        for (key, value) in self.store.clone().iter(col) {
+        for (key, value) in self.store.clone().iter_unsafe(col) {
             let key_ref = key.as_ref();
             let value_ref = value.as_ref();
             match col {

--- a/chain/chain/src/store_validator/validate.rs
+++ b/chain/chain/src/store_validator/validate.rs
@@ -492,7 +492,7 @@ pub(crate) fn trie_changes_chunk_extra_exists(
                 block_hash,
                 shard_id
             );
-            let trie = sv.runtime_adapter.get_trie_for_shard(*shard_id);
+            let trie = sv.runtime_adapter.get_state_adapter().get_trie_for_shard(*shard_id);
             let trie_iterator = unwrap_or_err!(
                 TrieIterator::new(&trie, &new_root),
                 "Trie Node Missing for ShardChunk {:?}",

--- a/chain/chain/src/store_validator/validate.rs
+++ b/chain/chain/src/store_validator/validate.rs
@@ -492,9 +492,10 @@ pub(crate) fn trie_changes_chunk_extra_exists(
                 block_hash,
                 shard_id
             );
-            let trie = sv.runtime_adapter.get_state_adapter().get_trie_for_shard(*shard_id);
+            let trie =
+                sv.runtime_adapter.get_state_adapter().get_trie_for_shard(*shard_id, new_root);
             let trie_iterator = unwrap_or_err!(
-                TrieIterator::new(&trie, &new_root),
+                TrieIterator::new(&trie),
                 "Trie Node Missing for ShardChunk {:?}",
                 chunk_header
             );

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -263,8 +263,8 @@ impl RuntimeStateAdapter for &KeyValueRuntime {
         ShardTriesSnapshot::new(self.store.clone(), self.trie_caches.clone())
     }
 
-    fn get_trie_for_shard(&self, shard_id: ShardId) -> Trie {
-        self.get_tries().get_trie_for_shard(shard_id)
+    fn get_trie_for_shard(&self, shard_id: ShardId, state_root: StateRoot) -> Trie {
+        self.get_tries().get_trie_for_shard(shard_id, state_root)
     }
 
     fn validate_tx(

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -225,7 +225,7 @@ pub trait RuntimeStateAdapter: Send + Sync {
     fn get_tries(&self) -> ShardTriesSnapshot;
 
     /// Returns trie.
-    fn get_trie_for_shard(&self, shard_id: ShardId) -> Trie;
+    fn get_trie_for_shard(&self, shard_id: ShardId, state_root: StateRoot) -> Trie;
 
     /// Validates a given signed transaction.
     /// If the state root is given, then the verification will use the account. Otherwise it will

--- a/chain/chain/tests/gc.rs
+++ b/chain/chain/tests/gc.rs
@@ -11,7 +11,7 @@ mod tests {
     use near_primitives::merkle::PartialMerkleTree;
     use near_primitives::types::{NumBlocks, NumShards, StateRoot};
     use near_primitives::validator_signer::InMemoryValidatorSigner;
-    use near_store::test_utils::{create_test_store, gen_changes};
+    use near_store::test_utils::{create_test_store, gen_changes, ShardTriesTestUtils};
     use near_store::{ShardTries, StoreUpdate, Trie, WrappedTrieChanges};
     use rand::Rng;
 
@@ -75,7 +75,7 @@ mod tests {
             for shard_id in 0..num_shards {
                 let trie_changes_data = gen_changes(&mut rng, max_changes);
                 let state_root = prev_state_roots[shard_id as usize];
-                let trie = tries.get_trie_for_shard(shard_id);
+                let trie = tries.snapshot().get_trie_for_shard(shard_id);
                 let trie_changes =
                     trie.update(&state_root, trie_changes_data.iter().cloned()).unwrap();
                 if verbose {
@@ -119,10 +119,9 @@ mod tests {
 
         // Init Chain 1
         let mut chain1 = get_chain(num_shards);
-        let tries1 = chain1.runtime_adapter.get_tries();
+        let tries1 = chain1.runtime_adapter.get_tries_writer();
         let mut rng = rand::thread_rng();
         let shard_to_check_trie = rng.gen_range(0, num_shards);
-        let trie1 = tries1.get_trie_for_shard(shard_to_check_trie);
         let genesis1 = chain1.get_block_by_height(0).unwrap().clone();
         let mut states1 = vec![];
         states1.push((
@@ -153,8 +152,7 @@ mod tests {
         }
 
         let mut chain2 = get_chain(num_shards);
-        let tries2 = chain2.runtime_adapter.get_tries();
-        let trie2 = tries2.get_trie_for_shard(shard_to_check_trie);
+        let tries2 = chain2.runtime_adapter.get_tries_writer();
 
         // Find gc_height
         let mut gc_height = simple_chains[0].length - 51;
@@ -183,6 +181,7 @@ mod tests {
 
             let mut state_root2 = state_roots2[simple_chain.from as usize];
             let state_root1 = states1[simple_chain.from as usize].1[shard_to_check_trie as usize];
+            let trie1 = tries1.snapshot().get_trie_for_shard(shard_to_check_trie);
             assert!(trie1.iter(&state_root1).is_ok());
             assert_eq!(state_root1, state_root2);
 
@@ -190,12 +189,13 @@ mod tests {
                 let mut store_update2 = chain2.mut_store().store_update();
                 let (block1, state_root1, changes1) = states1[i as usize].clone();
                 // Apply to Trie 2 the same changes (changes1) as applied to Trie 1
+                let trie2 = tries2.snapshot().get_trie_for_shard(shard_to_check_trie);
                 let trie_changes2 = trie2
                     .update(&state_root2, changes1[shard_to_check_trie as usize].iter().cloned())
                     .unwrap();
                 // i == gc_height is the only height should be processed here
                 if block1.header().height() > gc_height || i == gc_height {
-                    let mut trie_store_update2 = StoreUpdate::new_with_tries(tries2.clone());
+                    let mut trie_store_update2 = StoreUpdate::new_with_tries(&tries2);
                     tries2
                         .apply_insertions(
                             &trie_changes2,
@@ -219,6 +219,8 @@ mod tests {
         }
 
         let mut start_index = 1; // zero is for genesis
+        let trie1 = tries1.snapshot().get_trie_for_shard(shard_to_check_trie);
+        let trie2 = tries2.snapshot().get_trie_for_shard(shard_to_check_trie);
         for simple_chain in simple_chains.iter() {
             if simple_chain.is_removed {
                 start_index += simple_chain.length;

--- a/chain/chunks/src/test_utils.rs
+++ b/chain/chunks/src/test_utils.rs
@@ -40,8 +40,7 @@ impl Default for SealsManagerTestFixture {
         let store = near_store::test_utils::create_test_store();
         // 12 validators, 3 shards => 4 validators per shard
         let validators = make_validators(12);
-        let mock_runtime =
-            KeyValueRuntime::new_with_validators(Arc::clone(&store), validators, 1, 3, 5);
+        let mock_runtime = KeyValueRuntime::new_with_validators(store.clone(), validators, 1, 3, 5);
 
         let mock_parent_hash = CryptoHash::default();
         let mock_height: BlockHeight = 1;
@@ -90,7 +89,7 @@ impl Default for SealsManagerTestFixture {
 }
 
 impl SealsManagerTestFixture {
-    fn store_block_header(store: Arc<Store>, header: BlockHeader) {
+    fn store_block_header(store: Store, header: BlockHeader) {
         let mut chain_store = ChainStore::new(store, header.height());
         let mut update = chain_store.store_update();
         update.save_block_header(header).unwrap();
@@ -149,7 +148,7 @@ impl Default for ChunkForwardingTestFixture {
         // 12 validators, 3 shards => 4 validators per shard
         let validators = make_validators(12);
         let mock_runtime = Arc::new(KeyValueRuntime::new_with_validators(
-            Arc::clone(&store),
+            store.clone(),
             validators.clone(),
             1,
             3,

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -259,7 +259,7 @@ impl Handler<NetworkClientMessages> for ClientActor {
                         info!(target: "adversary", "Requested number of saved blocks");
                         let store = self.client.chain.store().store();
                         let mut num_blocks = 0;
-                        for _ in store.iter(ColBlock) {
+                        for _ in store.iter_unsafe(ColBlock) {
                             num_blocks += 1;
                         }
                         NetworkClientResponses::AdvResult(num_blocks)

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -760,7 +760,7 @@ pub fn setup_client_with_runtime(
 }
 
 pub fn setup_client(
-    store: Arc<Store>,
+    store: Store,
     validators: Vec<Vec<&str>>,
     validator_groups: u64,
     num_shards: NumShards,
@@ -898,6 +898,7 @@ impl TestEnv {
         let last_block = self.clients[0].chain.get_block(&head.last_block_hash).unwrap().clone();
         let response = self.clients[0]
             .runtime_adapter
+            .get_state_adapter()
             .query(
                 0,
                 &last_block.chunks()[0].inner.prev_state_root,

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -197,6 +197,7 @@ impl ViewClientActor {
             Ok(chunk_extra) => {
                 let state_root = chunk_extra.state_root;
                 self.runtime_adapter
+                    .get_state_adapter()
                     .query(
                         shard_id,
                         &state_root,

--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -1234,7 +1234,7 @@ fn test_gc_after_state_sync() {
     ));
     // mimic what we do in possible_targets
     assert!(env.clients[1].runtime_adapter.get_epoch_id_from_prev_block(&prev_block_hash).is_ok());
-    let tries = env.clients[1].runtime_adapter.get_tries();
+    let tries = env.clients[1].runtime_adapter.get_tries_writer();
     assert!(env.clients[1].chain.clear_data(tries, 2).is_ok());
 }
 
@@ -1637,6 +1637,7 @@ fn test_data_reset_before_state_sync() {
     let head_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap().clone();
     let response = env.clients[0]
         .runtime_adapter
+        .get_state_adapter()
         .query(
             0,
             &head_block.chunks()[0].inner.prev_state_root,
@@ -1650,7 +1651,7 @@ fn test_data_reset_before_state_sync() {
     assert!(matches!(response.kind, QueryResponseKind::ViewAccount(_)));
     env.clients[0].chain.reset_data_pre_state_sync(*head_block.hash()).unwrap();
     // account should not exist after clearing state
-    let response = env.clients[0].runtime_adapter.query(
+    let response = env.clients[0].runtime_adapter.get_state_adapter().query(
         0,
         &head_block.chunks()[0].inner.prev_state_root,
         head.height,

--- a/chain/epoch_manager/src/lib.rs
+++ b/chain/epoch_manager/src/lib.rs
@@ -1,6 +1,5 @@
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::sync::Arc;
 
 use cached::{Cached, SizedCache};
 use log::{debug, warn};
@@ -38,7 +37,11 @@ const AGGREGATOR_SAVE_PERIOD: u64 = 1000;
 /// Tracks epoch information across different forks, such as validators.
 /// Note: that even after garbage collection, the data about genesis epoch should be in the store.
 pub struct EpochManager {
-    store: Arc<Store>,
+    /// Notes:
+    /// 1. Store records are immutable with the exception of EpochInfoAggregator
+    /// 2. Cache can have entries that were GC-ed from store.
+    /// 3. Store does not use snapshots, so data can disappear between reads.
+    store: Store,
     /// Current epoch config.
     /// TODO: must be dynamically changing over time, so there should be a way to change it.
     config: EpochConfig,
@@ -56,7 +59,7 @@ pub struct EpochManager {
 
 impl EpochManager {
     pub fn new(
-        store: Arc<Store>,
+        store: Store,
         config: EpochConfig,
         genesis_protocol_version: ProtocolVersion,
         reward_calculator: RewardCalculator,

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -3,7 +3,6 @@ use std::cmp;
 use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
 use std::pin::Pin;
-use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use actix::actors::resolver::{ConnectAddr, Resolver};
@@ -117,7 +116,7 @@ pub struct PeerManagerActor {
 
 impl PeerManagerActor {
     pub fn new(
-        store: Arc<Store>,
+        store: Store,
         config: NetworkConfig,
         client_addr: Recipient<NetworkClientMessages>,
         view_client_addr: Recipient<NetworkViewClientMessages>,

--- a/chain/network/src/peer_store.rs
+++ b/chain/network/src/peer_store.rs
@@ -4,7 +4,6 @@ use std::collections::{
 };
 use std::convert::TryInto;
 use std::net::SocketAddr;
-use std::sync::Arc;
 
 use borsh::BorshSerialize;
 use chrono::Utc;
@@ -46,7 +45,7 @@ impl VerifiedPeer {
 
 /// Known peers store, maintaining cache of known peers and connection to storage to save/load them.
 pub struct PeerStore {
-    store: Arc<Store>,
+    store: Store,
     peer_states: HashMap<PeerId, KnownPeerState>,
     // This is a reverse index, from physical address to peer_id
     // It can happens that some peers don't have known address, so
@@ -55,10 +54,7 @@ pub struct PeerStore {
 }
 
 impl PeerStore {
-    pub fn new(
-        store: Arc<Store>,
-        boot_nodes: &[PeerInfo],
-    ) -> Result<Self, Box<dyn std::error::Error>> {
+    pub fn new(store: Store, boot_nodes: &[PeerInfo]) -> Result<Self, Box<dyn std::error::Error>> {
         let mut peer_states = HashMap::default();
         let mut addr_peers = HashMap::default();
 
@@ -82,7 +78,7 @@ impl PeerStore {
             }
         }
 
-        for (key, value) in store.iter(ColPeers) {
+        for (key, value) in store.iter_unsafe(ColPeers) {
             let key: Vec<u8> = key.into();
             let value: Vec<u8> = value.into();
             let peer_id: PeerId = key.try_into()?;

--- a/chain/network/src/routing.rs
+++ b/chain/network/src/routing.rs
@@ -1,6 +1,5 @@
 use std::collections::{hash_map::Entry, HashMap, HashSet};
 use std::ops::Sub;
-use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use serde::Serialize;
@@ -263,7 +262,7 @@ pub struct RoutingTable {
     /// Last time a peer with reachable through active edges.
     pub peer_last_time_reachable: HashMap<PeerId, chrono::DateTime<chrono::Utc>>,
     /// Access to store on disk
-    store: Arc<Store>,
+    store: Store,
     /// Current view of the network. Nodes are Peers and edges are active connections.
     raw_graph: Graph,
     /// Number of times each active connection was used to route a message.
@@ -293,7 +292,7 @@ pub enum FindRouteError {
 }
 
 impl RoutingTable {
-    pub fn new(peer_id: PeerId, store: Arc<Store>) -> Self {
+    pub fn new(peer_id: PeerId, store: Store) -> Self {
         // Find greater nonce on disk and set `component_nonce` to this value.
         let component_nonce = store
             .get_ser::<u64>(ColLastComponentNonce, &[])

--- a/chain/network/tests/cache_edges.rs
+++ b/chain/network/tests/cache_edges.rs
@@ -1,6 +1,5 @@
 use chrono::{DateTime, Duration, Utc};
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
 
 use borsh::de::BorshDeserialize;
 
@@ -25,7 +24,7 @@ impl EdgeDescription {
 
 struct RoutingTableTest {
     routing_table: RoutingTable,
-    store: Arc<Store>,
+    store: Store,
     peers: Vec<PeerId>,
     rev_peers: HashMap<PeerId, usize>,
     times: Vec<DateTime<Utc>>,
@@ -122,7 +121,7 @@ impl RoutingTableTest {
 
         // Check for peers on disk
         let mut total_peers = 0;
-        for (peer, nonce) in self.store.iter(ColPeerComponent) {
+        for (peer, nonce) in self.store.iter_unsafe(ColPeerComponent) {
             total_peers += 1;
 
             let peer = PeerId::try_from_slice(peer.as_ref()).unwrap();
@@ -135,7 +134,7 @@ impl RoutingTableTest {
 
         // Check for edges on disk
         let mut total_nonces = 0;
-        for (nonce, edges) in self.store.iter(ColComponentEdges) {
+        for (nonce, edges) in self.store.iter_unsafe(ColComponentEdges) {
             total_nonces += 1;
 
             let nonce = u64::try_from_slice(nonce.as_ref()).unwrap();

--- a/core/store/benches/trie_bench.rs
+++ b/core/store/benches/trie_bench.rs
@@ -19,16 +19,16 @@ fn trie_lookup(bench: &mut Bencher) {
         changes.push((rand_bytes(), Some(rand_bytes())));
     }
     let other_changes = changes.clone();
-    let trie = tries.snapshot().get_trie_for_shard(0);
-    let trie_changes = trie.update(&root, changes.drain(..)).unwrap();
+    let trie = tries.snapshot().get_trie_for_shard(0, root);
+    let trie_changes = trie.update(changes.drain(..)).unwrap();
     let (state_update, root) = tries.apply_all(&trie_changes, 0).unwrap();
     state_update.commit().expect("Failed to commit");
 
-    let trie = tries.snapshot().get_trie_for_shard(0);
+    let trie = tries.snapshot().get_trie_for_shard(0, root);
     bench.iter(|| {
         for _ in 0..1 {
             for (key, _) in other_changes.iter() {
-                trie.get(&root, &key).unwrap();
+                trie.get(&key).unwrap();
             }
         }
     });
@@ -36,8 +36,7 @@ fn trie_lookup(bench: &mut Bencher) {
 
 fn trie_update(bench: &mut Bencher) {
     let tries = create_tries();
-    let trie = tries.snapshot().get_trie_for_shard(0);
-    let root = Trie::empty_root();
+    let trie = tries.snapshot().get_trie_for_shard(0, Trie::empty_root());
     let mut changes = vec![];
     for _ in 0..100 {
         changes.push((rand_bytes(), Some(rand_bytes())));
@@ -45,7 +44,7 @@ fn trie_update(bench: &mut Bencher) {
 
     bench.iter(|| {
         let mut this_changes = changes.clone();
-        let _ = trie.update(&root, this_changes.drain(..));
+        let _ = trie.update(this_changes.drain(..));
     });
 }
 

--- a/core/store/src/migrations.rs
+++ b/core/store/src/migrations.rs
@@ -36,7 +36,7 @@ fn get_outcomes_by_block_hash(store: &Store, block_hash: &CryptoHash) -> HashSet
 pub fn fill_col_outcomes_by_hash(store: &Store) {
     let mut store_update = store.store_update();
     let outcomes: Vec<ExecutionOutcomeWithIdAndProof> = store
-        .iter(DBCol::ColTransactionResult)
+        .iter_unsafe(DBCol::ColTransactionResult)
         .map(|key| {
             ExecutionOutcomeWithIdAndProof::try_from_slice(&key.1)
                 .expect("BorshDeserialize should not fail")
@@ -65,7 +65,7 @@ pub fn fill_col_outcomes_by_hash(store: &Store) {
 pub fn fill_col_transaction_refcount(store: &Store) {
     let mut store_update = store.store_update();
     let chunks: Vec<ShardChunk> = store
-        .iter(DBCol::ColChunks)
+        .iter_unsafe(DBCol::ColChunks)
         .map(|key| ShardChunk::try_from_slice(&key.1).expect("BorshDeserialize should not fail"))
         .collect();
 

--- a/core/store/src/test_utils.rs
+++ b/core/store/src/test_utils.rs
@@ -38,14 +38,15 @@ pub fn test_populate_trie(
     shard_id: ShardId,
     changes: Vec<(Vec<u8>, Option<Vec<u8>>)>,
 ) -> CryptoHash {
-    let trie = tries.snapshot().get_trie_for_shard(shard_id);
+    let trie = tries.snapshot().get_trie_for_shard(shard_id, *root);
     assert_eq!(trie.storage.as_caching_storage().unwrap().shard_id, 0);
-    let trie_changes = trie.update(root, changes.iter().cloned()).unwrap();
+    let trie_changes = trie.update(changes.iter().cloned()).unwrap();
     let (store_update, root) = tries.apply_all(&trie_changes, 0).unwrap();
     store_update.commit().unwrap();
     let deduped = simplify_changes(&changes);
+    let trie = tries.snapshot().get_trie_for_shard(shard_id, root);
     for (key, value) in deduped {
-        assert_eq!(trie.get(&root, &key), Ok(value));
+        assert_eq!(trie.get(&key), Ok(value));
     }
     root
 }

--- a/core/store/src/trie/iterator.rs
+++ b/core/store/src/trie/iterator.rs
@@ -1,5 +1,3 @@
-use near_primitives::hash::CryptoHash;
-
 use crate::trie::nibble_slice::NibbleSlice;
 use crate::trie::{NodeHandle, TrieNode, TrieNodeWithSize, ValueHandle};
 use crate::{StorageError, Trie};
@@ -36,7 +34,6 @@ pub struct TrieIterator<'a> {
     trie: &'a Trie,
     trail: Vec<Crumb>,
     pub(crate) key_nibbles: Vec<u8>,
-    root: CryptoHash,
 }
 
 pub type TrieItem<'a> = Result<(Vec<u8>, Vec<u8>), StorageError>;
@@ -44,14 +41,13 @@ pub type TrieItem<'a> = Result<(Vec<u8>, Vec<u8>), StorageError>;
 impl<'a> TrieIterator<'a> {
     #![allow(clippy::new_ret_no_self)]
     /// Create a new iterator.
-    pub fn new(trie: &'a Trie, root: &CryptoHash) -> Result<Self, StorageError> {
+    pub fn new(trie: &'a Trie) -> Result<Self, StorageError> {
         let mut r = TrieIterator {
             trie,
             trail: Vec::with_capacity(8),
             key_nibbles: Vec::with_capacity(64),
-            root: *root,
         };
-        let node = trie.retrieve_node(root)?;
+        let node = trie.retrieve_node(&trie.root)?;
         r.descend_into_node(&node);
         Ok(r)
     }
@@ -67,7 +63,7 @@ impl<'a> TrieIterator<'a> {
     ) -> Result<(), StorageError> {
         self.trail.clear();
         self.key_nibbles.clear();
-        let mut hash = NodeHandle::Hash(self.root);
+        let mut hash = NodeHandle::Hash(self.trie.root);
         loop {
             let node = match hash {
                 NodeHandle::Hash(hash) => self.trie.retrieve_node(&hash)?,

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -172,16 +172,16 @@ impl ShardTriesSnapshot {
     }
 
     pub fn new_trie_update(&self, shard_id: ShardId, state_root: CryptoHash) -> TrieUpdate {
-        TrieUpdate::new(Rc::new(self.get_trie_for_shard(shard_id)), state_root)
+        TrieUpdate::new(Rc::new(self.get_trie_for_shard(shard_id, state_root)))
     }
 
-    pub fn get_trie_for_shard(&self, shard_id: ShardId) -> Trie {
+    pub fn get_trie_for_shard(&self, shard_id: ShardId, root: CryptoHash) -> Trie {
         let store = Box::new(TrieCachingStorage::new(
             self.store.clone(),
             self.caches.0[shard_id as usize].clone(),
             shard_id,
         ));
-        Trie::new(store, shard_id)
+        Trie::new(store, root)
     }
 }
 

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -175,10 +175,6 @@ impl ShardTriesSnapshot {
         TrieUpdate::new(Rc::new(self.get_trie_for_shard(shard_id)), state_root)
     }
 
-    pub fn get_caches(&self) -> TrieCaches {
-        self.caches.clone()
-    }
-
     pub fn get_trie_for_shard(&self, shard_id: ShardId) -> Trie {
         let store = Box::new(TrieCachingStorage::new(
             self.store.clone(),
@@ -186,14 +182,6 @@ impl ShardTriesSnapshot {
             shard_id,
         ));
         Trie::new(store, shard_id)
-    }
-
-    pub fn writer(self) -> ShardTries {
-        ShardTries::new(self.get_store(), self.caches)
-    }
-
-    pub(crate) fn get_store(&self) -> Store {
-        Store::new(self.store.get_store().clone())
     }
 }
 

--- a/core/store/src/trie/state_parts.rs
+++ b/core/store/src/trie/state_parts.rs
@@ -317,7 +317,7 @@ mod tests {
 
     use near_primitives::hash::{hash, CryptoHash};
 
-    use crate::test_utils::{create_tries, gen_changes, test_populate_trie};
+    use crate::test_utils::{create_tries, gen_changes, test_populate_trie, ShardTriesTestUtils};
 
     use super::*;
     use rand::prelude::ThreadRng;
@@ -404,7 +404,7 @@ mod tests {
         let trie_changes = gen_trie_changes(&mut rng, max_key_length, big_value_length);
         println!("Number of nodes: {}", trie_changes.len());
         let tries = create_tries();
-        let trie = tries.get_trie_for_shard(0);
+        let trie = tries.snapshot().get_trie_for_shard(0);
         let state_root = test_populate_trie(&tries, &Trie::empty_root(), 0, trie_changes);
         let memory_size = trie.retrieve_root_node(&state_root).unwrap().memory_usage;
         println!("Total memory size: {}", memory_size);
@@ -445,11 +445,11 @@ mod tests {
         let mut rng = rand::thread_rng();
         for _ in 0..20 {
             let tries = create_tries();
-            let trie = tries.get_trie_for_shard(0);
             let trie_changes = gen_changes(&mut rng, 500);
 
             let state_root =
                 test_populate_trie(&tries, &Trie::empty_root(), 0, trie_changes.clone());
+            let trie = tries.snapshot().get_trie_for_shard(0);
             let root_memory_usage = trie.retrieve_root_node(&state_root).unwrap().memory_usage;
             for _ in 0..100 {
                 // Test that creating and validating are consistent

--- a/core/store/src/trie/trie_tests.rs
+++ b/core/store/src/trie/trie_tests.rs
@@ -1,4 +1,6 @@
-use crate::test_utils::{create_tries, gen_changes, simplify_changes, test_populate_trie};
+use crate::test_utils::{
+    create_tries, gen_changes, simplify_changes, test_populate_trie, ShardTriesTestUtils,
+};
 use crate::trie::trie_storage::{TrieMemoryPartialStorage, TrieStorage};
 use crate::trie::POISONED_LOCK_ERR;
 use crate::{PartialStorage, Trie, TrieUpdate};
@@ -88,7 +90,7 @@ fn test_reads_with_incomplete_storage() {
     let mut rng = rand::thread_rng();
     for _ in 0..50 {
         let tries = create_tries();
-        let trie = tries.get_trie_for_shard(0);
+        let trie = tries.snapshot().get_trie_for_shard(0);
         let trie = Rc::new(trie);
         let mut state_root = Trie::empty_root();
         let trie_changes = gen_changes(&mut rng, 20);

--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -325,7 +325,7 @@ impl<'a> Iterator for TrieUpdateIterator<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::test_utils::create_tries;
+    use crate::test_utils::{create_tries, ShardTriesTestUtils};
 
     use super::*;
 
@@ -337,7 +337,7 @@ mod tests {
     fn trie() {
         let tries = create_tries();
         let root = CryptoHash::default();
-        let mut trie_update = tries.new_trie_update(0, root);
+        let mut trie_update = tries.snapshot().new_trie_update(0, root);
         trie_update.set(test_key(b"dog".to_vec()), b"puppy".to_vec());
         trie_update.set(test_key(b"dog2".to_vec()), b"puppy".to_vec());
         trie_update.set(test_key(b"xxx".to_vec()), b"puppy".to_vec());
@@ -346,7 +346,7 @@ mod tests {
         let trie_changes = trie_update.finalize().unwrap().0;
         let (store_update, new_root) = tries.apply_all(&trie_changes, 0).unwrap();
         store_update.commit().unwrap();
-        let trie_update2 = tries.new_trie_update(0, new_root);
+        let trie_update2 = tries.snapshot().new_trie_update(0, new_root);
         assert_eq!(trie_update2.get(&test_key(b"dog".to_vec())), Ok(Some(b"puppy".to_vec())));
         let values = trie_update2
             .iter(&test_key(b"dog".to_vec()).to_vec())
@@ -364,7 +364,7 @@ mod tests {
         let tries = create_tries();
 
         // Delete non-existing element.
-        let mut trie_update = tries.new_trie_update(0, CryptoHash::default());
+        let mut trie_update = tries.snapshot().new_trie_update(0, CryptoHash::default());
         trie_update.remove(test_key(b"dog".to_vec()));
         trie_update
             .commit(StateChangeCause::TransactionProcessing { tx_hash: CryptoHash::default() });
@@ -374,7 +374,7 @@ mod tests {
         assert_eq!(new_root, CryptoHash::default());
 
         // Add and right away delete element.
-        let mut trie_update = tries.new_trie_update(0, CryptoHash::default());
+        let mut trie_update = tries.snapshot().new_trie_update(0, CryptoHash::default());
         trie_update.set(test_key(b"dog".to_vec()), b"puppy".to_vec());
         trie_update.remove(test_key(b"dog".to_vec()));
         trie_update
@@ -385,7 +385,7 @@ mod tests {
         assert_eq!(new_root, CryptoHash::default());
 
         // Add, apply changes and then delete element.
-        let mut trie_update = tries.new_trie_update(0, CryptoHash::default());
+        let mut trie_update = tries.snapshot().new_trie_update(0, CryptoHash::default());
         trie_update.set(test_key(b"dog".to_vec()), b"puppy".to_vec());
         trie_update
             .commit(StateChangeCause::TransactionProcessing { tx_hash: CryptoHash::default() });
@@ -393,7 +393,7 @@ mod tests {
         let (store_update, new_root) = tries.apply_all(&trie_changes, 0).unwrap();
         store_update.commit().unwrap();
         assert_ne!(new_root, CryptoHash::default());
-        let mut trie_update = tries.new_trie_update(0, new_root);
+        let mut trie_update = tries.snapshot().new_trie_update(0, new_root);
         trie_update.remove(test_key(b"dog".to_vec()));
         trie_update
             .commit(StateChangeCause::TransactionProcessing { tx_hash: CryptoHash::default() });
@@ -406,7 +406,7 @@ mod tests {
     #[test]
     fn trie_iter() {
         let tries = create_tries();
-        let mut trie_update = tries.new_trie_update(0, CryptoHash::default());
+        let mut trie_update = tries.snapshot().new_trie_update(0, CryptoHash::default());
         trie_update.set(test_key(b"dog".to_vec()), b"puppy".to_vec());
         trie_update.set(test_key(b"aaa".to_vec()), b"puppy".to_vec());
         trie_update
@@ -415,7 +415,7 @@ mod tests {
         let (store_update, new_root) = tries.apply_all(&trie_changes, 0).unwrap();
         store_update.commit().unwrap();
 
-        let mut trie_update = tries.new_trie_update(0, new_root);
+        let mut trie_update = tries.snapshot().new_trie_update(0, new_root);
         trie_update.set(test_key(b"dog2".to_vec()), b"puppy".to_vec());
         trie_update.set(test_key(b"xxx".to_vec()), b"puppy".to_vec());
 
@@ -432,14 +432,14 @@ mod tests {
             trie_update.iter(&test_key(b"dog".to_vec()).to_vec()).unwrap().collect();
         assert_eq!(values.unwrap(), vec![test_key(b"dog".to_vec()).to_vec()]);
 
-        let mut trie_update = tries.new_trie_update(0, new_root);
+        let mut trie_update = tries.snapshot().new_trie_update(0, new_root);
         trie_update.remove(test_key(b"dog".to_vec()));
 
         let values: Result<Vec<Vec<u8>>, _> =
             trie_update.iter(&test_key(b"dog".to_vec()).to_vec()).unwrap().collect();
         assert_eq!(values.unwrap().len(), 0);
 
-        let mut trie_update = tries.new_trie_update(0, new_root);
+        let mut trie_update = tries.snapshot().new_trie_update(0, new_root);
         trie_update.set(test_key(b"dog2".to_vec()), b"puppy".to_vec());
         trie_update
             .commit(StateChangeCause::TransactionProcessing { tx_hash: CryptoHash::default() });
@@ -449,7 +449,7 @@ mod tests {
             trie_update.iter(&test_key(b"dog".to_vec()).to_vec()).unwrap().collect();
         assert_eq!(values.unwrap(), vec![test_key(b"dog".to_vec()).to_vec()]);
 
-        let mut trie_update = tries.new_trie_update(0, new_root);
+        let mut trie_update = tries.snapshot().new_trie_update(0, new_root);
         trie_update.set(test_key(b"dog2".to_vec()), b"puppy".to_vec());
         trie_update
             .commit(StateChangeCause::TransactionProcessing { tx_hash: CryptoHash::default() });

--- a/neard/src/lib.rs
+++ b/neard/src/lib.rs
@@ -101,7 +101,7 @@ pub fn apply_store_migrations(path: &String) {
     debug_assert_eq!(db_version, near_primitives::version::DB_VERSION);
 }
 
-pub fn init_and_migrate_store(home_dir: &Path) -> Arc<Store> {
+pub fn init_and_migrate_store(home_dir: &Path) -> Store {
     let path = get_store_path(home_dir);
     let store_exists = store_path_exists(&path);
     if store_exists {
@@ -123,7 +123,7 @@ pub fn start_with_config(
 
     let runtime = Arc::new(NightshadeRuntime::new(
         home_dir,
-        Arc::clone(&store),
+        store.clone(),
         Arc::clone(&config.genesis),
         config.client_config.tracked_accounts.clone(),
         config.client_config.tracked_shards.clone(),

--- a/runtime/runtime-params-estimator/src/testbed.rs
+++ b/runtime/runtime-params-estimator/src/testbed.rs
@@ -8,7 +8,8 @@ use near_primitives::receipt::Receipt;
 use near_primitives::test_utils::MockEpochInfoProvider;
 use near_primitives::transaction::{ExecutionStatus, SignedTransaction};
 use near_primitives::types::{Gas, MerkleHash, StateRoot};
-use near_store::{create_store, ColState, ShardTries};
+use near_store::test_utils::ShardTriesTestUtils;
+use near_store::{create_store, ColState, ShardTries, TrieCaches};
 use near_vm_logic::VMLimitConfig;
 use neard::get_store_path;
 use node_runtime::config::RuntimeConfig;
@@ -35,7 +36,7 @@ impl RuntimeTestbed {
         let workdir = tempfile::Builder::new().prefix("runtime_testbed").tempdir().unwrap();
         println!("workdir {}", workdir.path().to_str().unwrap());
         let store = create_store(&get_store_path(workdir.path()));
-        let tries = ShardTries::new(store.clone(), 1);
+        let tries = ShardTries::new(store.clone(), TrieCaches::new(1));
 
         let mut state_file = dump_dir.to_path_buf();
         state_file.push(STATE_DUMP_FILE);
@@ -103,7 +104,7 @@ impl RuntimeTestbed {
         let apply_result = self
             .runtime
             .apply(
-                self.tries.get_trie_for_shard(0),
+                self.tries.snapshot().get_trie_for_shard(0),
                 self.root,
                 &None,
                 &self.apply_state,

--- a/runtime/runtime-params-estimator/src/testbed.rs
+++ b/runtime/runtime-params-estimator/src/testbed.rs
@@ -104,8 +104,7 @@ impl RuntimeTestbed {
         let apply_result = self
             .runtime
             .apply(
-                self.tries.snapshot().get_trie_for_shard(0),
-                self.root,
+                self.tries.snapshot().get_trie_for_shard(0, self.root),
                 &None,
                 &self.apply_state,
                 &self.prev_receipts,

--- a/runtime/runtime-standalone/src/lib.rs
+++ b/runtime/runtime-standalone/src/lib.rs
@@ -217,8 +217,7 @@ impl RuntimeStandalone {
         };
 
         let apply_result = self.runtime.apply(
-            self.tries.snapshot().get_trie_for_shard(0),
-            self.cur_block.state_root,
+            self.tries.snapshot().get_trie_for_shard(0, self.cur_block.state_root),
             &None,
             &apply_state,
             &self.pending_receipts,

--- a/runtime/runtime/src/balance_checker.rs
+++ b/runtime/runtime/src/balance_checker.rs
@@ -226,7 +226,7 @@ mod tests {
     use near_primitives::types::{MerkleHash, StateChangeCause};
     use near_runtime_fees::RuntimeFeesConfig;
     use near_store::set_account;
-    use near_store::test_utils::create_tries;
+    use near_store::test_utils::{create_tries, ShardTriesTestUtils};
     use testlib::runtime_utils::{alice_account, bob_account};
 
     use assert_matches::assert_matches;
@@ -241,8 +241,9 @@ mod tests {
     fn test_check_balance_no_op() {
         let tries = create_tries();
         let root = MerkleHash::default();
-        let initial_state = tries.new_trie_update(0, root);
-        let final_state = tries.new_trie_update(0, root);
+        let snapshot = tries.snapshot();
+        let initial_state = snapshot.new_trie_update(0, root);
+        let final_state = snapshot.new_trie_update(0, root);
         let transaction_costs = RuntimeFeesConfig::default();
         check_balance(
             &transaction_costs,
@@ -261,8 +262,9 @@ mod tests {
     fn test_check_balance_unaccounted_refund() {
         let tries = create_tries();
         let root = MerkleHash::default();
-        let initial_state = tries.new_trie_update(0, root);
-        let final_state = tries.new_trie_update(0, root);
+        let snapshot = tries.snapshot();
+        let initial_state = snapshot.new_trie_update(0, root);
+        let final_state = snapshot.new_trie_update(0, root);
         let transaction_costs = RuntimeFeesConfig::default();
         let err = check_balance(
             &transaction_costs,
@@ -287,12 +289,12 @@ mod tests {
         let initial_balance = TESTING_INIT_BALANCE;
         let refund_balance = 1000;
 
-        let mut initial_state = tries.new_trie_update(0, root);
+        let mut initial_state = tries.snapshot().new_trie_update(0, root);
         let initial_account = account_new(initial_balance, hash(&[]));
         set_account(&mut initial_state, account_id.clone(), &initial_account);
         initial_state.commit(StateChangeCause::NotWritableToDisk);
 
-        let mut final_state = tries.new_trie_update(0, root);
+        let mut final_state = tries.snapshot().new_trie_update(0, root);
         let final_account = account_new(initial_balance + refund_balance, hash(&[]));
         set_account(&mut final_state, account_id.clone(), &final_account);
         final_state.commit(StateChangeCause::NotWritableToDisk);
@@ -328,12 +330,12 @@ mod tests {
         let contract_reward = send_gas as u128 * *cfg.burnt_gas_reward.numer() as u128 * gas_price
             / (*cfg.burnt_gas_reward.denom() as u128);
         let total_validator_reward = send_gas as Balance * gas_price - contract_reward;
-        let mut initial_state = tries.new_trie_update(0, root);
+        let mut initial_state = tries.snapshot().new_trie_update(0, root);
         let initial_account = account_new(initial_balance, hash(&[]));
         set_account(&mut initial_state, account_id.clone(), &initial_account);
         initial_state.commit(StateChangeCause::NotWritableToDisk);
 
-        let mut final_state = tries.new_trie_update(0, root);
+        let mut final_state = tries.snapshot().new_trie_update(0, root);
         let final_account = account_new(
             initial_balance - (exec_gas + send_gas) as Balance * gas_price - deposit
                 + contract_reward,
@@ -392,7 +394,7 @@ mod tests {
         let gas_price = 100;
         let deposit = 1000;
 
-        let mut initial_state = tries.new_trie_update(0, root);
+        let mut initial_state = tries.snapshot().new_trie_update(0, root);
         let alice = account_new(std::u128::MAX, hash(&[]));
         let bob = account_new(1u128, hash(&[]));
 

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1015,7 +1015,6 @@ impl Runtime {
     pub fn apply(
         &self,
         trie: Trie,
-        root: CryptoHash,
         validator_accounts_update: &Option<ValidatorAccountsUpdate>,
         apply_state: &ApplyState,
         incoming_receipts: &[Receipt],
@@ -1023,8 +1022,8 @@ impl Runtime {
         epoch_info_provider: &dyn EpochInfoProvider,
     ) -> Result<ApplyResult, RuntimeError> {
         let trie = Rc::new(trie);
-        let initial_state = TrieUpdate::new(trie.clone(), root);
-        let mut state_update = TrieUpdate::new(trie.clone(), root);
+        let initial_state = TrieUpdate::new(trie.clone());
+        let mut state_update = TrieUpdate::new(trie.clone());
 
         let mut stats = ApplyStats::default();
 
@@ -1460,8 +1459,7 @@ mod tests {
             setup_runtime(to_yocto(1_000_000), 0, 10u64.pow(15));
         runtime
             .apply(
-                tries.snapshot().get_trie_for_shard(0),
-                root,
+                tries.snapshot().get_trie_for_shard(0, root),
                 &None,
                 &apply_state,
                 &[],
@@ -1489,8 +1487,7 @@ mod tests {
 
         runtime
             .apply(
-                tries.snapshot().get_trie_for_shard(0),
-                root,
+                tries.snapshot().get_trie_for_shard(0, root),
                 &Some(validator_accounts_update),
                 &apply_state,
                 &[Receipt::new_balance_refund(&alice_account(), small_refund)],
@@ -1517,8 +1514,7 @@ mod tests {
             let prev_receipts: &[Receipt] = if i == 1 { &receipts } else { &[] };
             let apply_result = runtime
                 .apply(
-                    tries.snapshot().get_trie_for_shard(0),
-                    root,
+                    tries.snapshot().get_trie_for_shard(0, root),
                     &None,
                     &apply_state,
                     prev_receipts,
@@ -1563,8 +1559,7 @@ mod tests {
             let prev_receipts: &[Receipt] = receipt_chunks.next().unwrap_or_default();
             let apply_result = runtime
                 .apply(
-                    tries.snapshot().get_trie_for_shard(0),
-                    root,
+                    tries.snapshot().get_trie_for_shard(0, root),
                     &None,
                     &apply_state,
                     prev_receipts,
@@ -1618,8 +1613,7 @@ mod tests {
             num_receipts_given += prev_receipts.len() as u64;
             let apply_result = runtime
                 .apply(
-                    tries.snapshot().get_trie_for_shard(0),
-                    root,
+                    tries.snapshot().get_trie_for_shard(0, root),
                     &None,
                     &apply_state,
                     prev_receipts,
@@ -1704,8 +1698,7 @@ mod tests {
         // The new delayed queue is TX#3, R#0, R#1.
         let apply_result = runtime
             .apply(
-                tries.snapshot().get_trie_for_shard(0),
-                root,
+                tries.snapshot().get_trie_for_shard(0, root),
                 &None,
                 &apply_state,
                 &receipts[0..2],
@@ -1736,8 +1729,7 @@ mod tests {
         // The new delayed queue is R#1, R#2
         let apply_result = runtime
             .apply(
-                tries.snapshot().get_trie_for_shard(0),
-                root,
+                tries.snapshot().get_trie_for_shard(0, root),
                 &None,
                 &apply_state,
                 &receipts[2..3],
@@ -1765,8 +1757,7 @@ mod tests {
         // The new delayed queue is R#1, R#2, TX#8, R#3
         let apply_result = runtime
             .apply(
-                tries.snapshot().get_trie_for_shard(0),
-                root,
+                tries.snapshot().get_trie_for_shard(0, root),
                 &None,
                 &apply_state,
                 &receipts[3..4],
@@ -1797,8 +1788,7 @@ mod tests {
         // The new delayed queue is R#3, R#4
         let apply_result = runtime
             .apply(
-                tries.snapshot().get_trie_for_shard(0),
-                root,
+                tries.snapshot().get_trie_for_shard(0, root),
                 &None,
                 &apply_state,
                 &receipts[4..5],
@@ -1824,8 +1814,7 @@ mod tests {
         // The new delayed queue is empty.
         let apply_result = runtime
             .apply(
-                tries.snapshot().get_trie_for_shard(0),
-                root,
+                tries.snapshot().get_trie_for_shard(0, root),
                 &None,
                 &apply_state,
                 &receipts[5..6],
@@ -1861,8 +1850,7 @@ mod tests {
 
         let err = runtime
             .apply(
-                tries.snapshot().get_trie_for_shard(0),
-                root,
+                tries.snapshot().get_trie_for_shard(0, root),
                 &None,
                 &apply_state,
                 &receipts,
@@ -1906,8 +1894,7 @@ mod tests {
 
         let err = runtime
             .apply(
-                tries.snapshot().get_trie_for_shard(0),
-                root,
+                tries.snapshot().get_trie_for_shard(0, root),
                 &None,
                 &apply_state,
                 &[],
@@ -1942,8 +1929,7 @@ mod tests {
 
         let result = runtime
             .apply(
-                tries.snapshot().get_trie_for_shard(0),
-                root,
+                tries.snapshot().get_trie_for_shard(0, root),
                 &None,
                 &apply_state,
                 &receipts,
@@ -1995,8 +1981,7 @@ mod tests {
 
         let result = runtime
             .apply(
-                tries.snapshot().get_trie_for_shard(0),
-                root,
+                tries.snapshot().get_trie_for_shard(0, root),
                 &None,
                 &apply_state,
                 &receipts,
@@ -2058,8 +2043,7 @@ mod tests {
 
         let result = runtime
             .apply(
-                tries.snapshot().get_trie_for_shard(0),
-                root,
+                tries.snapshot().get_trie_for_shard(0, root),
                 &None,
                 &apply_state,
                 &receipts,

--- a/runtime/runtime/src/state_viewer.rs
+++ b/runtime/runtime/src/state_viewer.rs
@@ -190,6 +190,7 @@ mod tests {
 
     use super::*;
     use near_primitives::test_utils::MockEpochInfoProvider;
+    use near_store::test_utils::ShardTriesTestUtils;
 
     #[test]
     fn test_view_call() {
@@ -288,7 +289,7 @@ mod tests {
     #[test]
     fn test_view_state() {
         let (_, tries, root) = get_runtime_and_trie();
-        let mut state_update = tries.new_trie_update(0, root);
+        let mut state_update = tries.snapshot().new_trie_update(0, root);
         state_update.set(
             TrieKey::ContractData { account_id: alice_account(), key: b"test123".to_vec() },
             b"123".to_vec(),
@@ -310,7 +311,7 @@ mod tests {
         let (db_changes, new_root) = tries.apply_all(&trie_changes, 0).unwrap();
         db_changes.commit().unwrap();
 
-        let state_update = tries.new_trie_update(0, new_root);
+        let state_update = tries.snapshot().new_trie_update(0, new_root);
         let trie_viewer = TrieViewer::new();
         let result = trie_viewer.view_state(&state_update, &alice_account(), b"").unwrap();
         assert_eq!(result.proof, Vec::<String>::new());

--- a/runtime/runtime/src/state_viewer.rs
+++ b/runtime/runtime/src/state_viewer.rs
@@ -66,7 +66,7 @@ impl TrieViewer {
         let mut values = vec![];
         let query = trie_key_parsers::get_raw_prefix_for_contract_data(account_id, prefix);
         let acc_sep_len = query.len() - prefix.len();
-        let mut iter = state_update.trie.iter(&state_update.get_root())?;
+        let mut iter = state_update.trie.iter()?;
         iter.seek(&query)?;
         for item in iter {
             let (key, value) = item?;

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -414,7 +414,7 @@ mod tests {
         CreateAccountAction, DeleteKeyAction, StakeAction, TransferAction,
     };
     use near_primitives::types::{AccountId, Balance, MerkleHash, StateChangeCause};
-    use near_store::test_utils::create_tries;
+    use near_store::test_utils::{create_tries, ShardTriesTestUtils};
     use std::convert::TryInto;
     use std::sync::Arc;
     use testlib::runtime_utils::{alice_account, bob_account, eve_dot_alice_account};
@@ -443,7 +443,7 @@ mod tests {
         let signer =
             Arc::new(InMemorySigner::from_seed(&account_id, KeyType::ED25519, &account_id));
 
-        let mut initial_state = tries.new_trie_update(0, root);
+        let mut initial_state = tries.snapshot().new_trie_update(0, root);
         for (account_id, initial_balance, initial_locked, access_key) in accounts {
             let mut initial_account = account_new(initial_balance, hash(&[]));
             initial_account.locked = initial_locked;
@@ -462,7 +462,7 @@ mod tests {
         let (store_update, root) = tries.apply_all(&trie_changes, 0).unwrap();
         store_update.commit().unwrap();
 
-        (signer, tries.new_trie_update(0, root), 100)
+        (signer, tries.snapshot().new_trie_update(0, root), 100)
     }
 
     fn assert_err_both_validations(

--- a/runtime/runtime/tests/runtime_group_tools/mod.rs
+++ b/runtime/runtime/tests/runtime_group_tools/mod.rs
@@ -6,7 +6,7 @@ use near_primitives::state_record::StateRecord;
 use near_primitives::test_utils::MockEpochInfoProvider;
 use near_primitives::transaction::{ExecutionOutcomeWithId, SignedTransaction};
 use near_primitives::types::Balance;
-use near_store::test_utils::create_tries;
+use near_store::test_utils::{create_tries, ShardTriesTestUtils};
 use near_store::ShardTries;
 use node_runtime::{ApplyState, Runtime};
 use random_config::random_config;
@@ -51,8 +51,7 @@ impl StandaloneRuntime {
 
         let runtime = Runtime::new(runtime_config);
 
-        let (store_update, root) =
-            runtime.apply_genesis_state(tries.clone(), 0, &[], state_records);
+        let (store_update, root) = runtime.apply_genesis_state(&tries, 0, &[], state_records);
         store_update.commit().unwrap();
 
         let apply_state = ApplyState {
@@ -83,7 +82,7 @@ impl StandaloneRuntime {
         let apply_result = self
             .runtime
             .apply(
-                self.tries.get_trie_for_shard(0),
+                self.tries.snapshot().get_trie_for_shard(0),
                 self.root,
                 &None,
                 &self.apply_state,

--- a/runtime/runtime/tests/runtime_group_tools/mod.rs
+++ b/runtime/runtime/tests/runtime_group_tools/mod.rs
@@ -82,8 +82,7 @@ impl StandaloneRuntime {
         let apply_result = self
             .runtime
             .apply(
-                self.tries.snapshot().get_trie_for_shard(0),
-                self.root,
+                self.tries.snapshot().get_trie_for_shard(0, self.root),
                 &None,
                 &self.apply_state,
                 receipts,

--- a/test-utils/state-viewer/src/main.rs
+++ b/test-utils/state-viewer/src/main.rs
@@ -443,8 +443,9 @@ fn main() {
             let (runtime, state_roots, header) = load_trie(store, &home_dir, &near_config);
             println!("Storage roots are {:?}, block height is {}", state_roots, header.height());
             for (shard_id, state_root) in state_roots.iter().enumerate() {
-                let trie = runtime.get_state_adapter().get_trie_for_shard(shard_id as u64);
-                let trie = TrieIterator::new(&trie, &state_root).unwrap();
+                let trie =
+                    runtime.get_state_adapter().get_trie_for_shard(shard_id as u64, *state_root);
+                let trie = TrieIterator::new(&trie).unwrap();
                 for item in trie {
                     let (key, value) = item.unwrap();
                     if let Some(state_record) = StateRecord::from_raw_key_value(key, value) {

--- a/test-utils/state-viewer/src/main.rs
+++ b/test-utils/state-viewer/src/main.rs
@@ -33,7 +33,7 @@ enum LoadTrieMode {
 }
 
 fn load_trie(
-    store: Arc<Store>,
+    store: Store,
     home_dir: &Path,
     near_config: &NearConfig,
 ) -> (NightshadeRuntime, Vec<StateRoot>, BlockHeader) {
@@ -41,7 +41,7 @@ fn load_trie(
 }
 
 fn load_trie_stop_at_height(
-    store: Arc<Store>,
+    store: Store,
     home_dir: &Path,
     near_config: &NearConfig,
     mode: LoadTrieMode,
@@ -97,7 +97,7 @@ pub fn format_hash(h: CryptoHash) -> String {
 }
 
 fn print_chain(
-    store: Arc<Store>,
+    store: Store,
     home_dir: &Path,
     near_config: &NearConfig,
     start_height: BlockHeight,
@@ -165,7 +165,7 @@ fn print_chain(
 }
 
 fn replay_chain(
-    store: Arc<Store>,
+    store: Store,
     home_dir: &Path,
     near_config: &NearConfig,
     start_height: BlockHeight,
@@ -194,7 +194,7 @@ fn replay_chain(
 }
 
 fn apply_block_at_height(
-    store: Arc<Store>,
+    store: Store,
     home_dir: &Path,
     near_config: &NearConfig,
     height: BlockHeight,
@@ -225,6 +225,7 @@ fn apply_block_at_height(
     let receipts = collect_receipts_from_response(&receipt_proof_response);
 
     let apply_result = runtime
+        .get_state_adapter()
         .apply_transactions(
             shard_id,
             &chunk.header.inner.prev_state_root,
@@ -262,7 +263,7 @@ fn apply_block_at_height(
 }
 
 fn view_chain(
-    store: Arc<Store>,
+    store: Store,
     near_config: &NearConfig,
     height: Option<BlockHeight>,
     view_block: bool,
@@ -442,7 +443,7 @@ fn main() {
             let (runtime, state_roots, header) = load_trie(store, &home_dir, &near_config);
             println!("Storage roots are {:?}, block height is {}", state_roots, header.height());
             for (shard_id, state_root) in state_roots.iter().enumerate() {
-                let trie = runtime.get_trie_for_shard(shard_id as u64);
+                let trie = runtime.get_state_adapter().get_trie_for_shard(shard_id as u64);
                 let trie = TrieIterator::new(&trie, &state_root).unwrap();
                 for item in trie {
                     let (key, value) = item.unwrap();

--- a/test-utils/state-viewer/src/state_dump.rs
+++ b/test-utils/state-viewer/src/state_dump.rs
@@ -36,8 +36,8 @@ pub fn state_dump(
 
     let mut records = vec![];
     for (shard_id, state_root) in state_roots.iter().enumerate() {
-        let trie = runtime.get_state_adapter().get_trie_for_shard(shard_id as u64);
-        let trie = TrieIterator::new(&trie, &state_root).unwrap();
+        let trie = runtime.get_state_adapter().get_trie_for_shard(shard_id as u64, *state_root);
+        let trie = TrieIterator::new(&trie).unwrap();
         for item in trie {
             let (key, value) = item.unwrap();
             if let Some(mut sr) = StateRecord::from_raw_key_value(key, value) {

--- a/test-utils/state-viewer/src/state_dump.rs
+++ b/test-utils/state-viewer/src/state_dump.rs
@@ -36,7 +36,7 @@ pub fn state_dump(
 
     let mut records = vec![];
     for (shard_id, state_root) in state_roots.iter().enumerate() {
-        let trie = runtime.get_trie_for_shard(shard_id as u64);
+        let trie = runtime.get_state_adapter().get_trie_for_shard(shard_id as u64);
         let trie = TrieIterator::new(&trie, &state_root).unwrap();
         for item in trie {
             let (key, value) = item.unwrap();
@@ -84,7 +84,7 @@ mod test {
 
     use crate::state_dump::state_dump;
 
-    fn setup(epoch_length: NumBlocks) -> (Arc<Store>, Genesis, TestEnv) {
+    fn setup(epoch_length: NumBlocks) -> (Store, Genesis, TestEnv) {
         let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
         genesis.config.num_block_producer_seats = 2;
         genesis.config.num_block_producer_seats_per_shard = vec![2];

--- a/test-utils/testlib/src/runtime_utils.rs
+++ b/test-utils/testlib/src/runtime_utils.rs
@@ -8,7 +8,7 @@ use near_primitives::account::Account;
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::state_record::StateRecord;
 use near_primitives::types::{AccountId, StateRoot};
-use near_store::test_utils::create_tries;
+use near_store::test_utils::{create_tries, ShardTriesTestUtils};
 use near_store::{ShardTries, TrieUpdate};
 use neard::config::GenesisExt;
 use node_runtime::{state_viewer::TrieViewer, Runtime};
@@ -68,7 +68,7 @@ pub fn get_runtime_and_trie_from_genesis(genesis: &Genesis) -> (Runtime, ShardTr
     let tries = create_tries();
     let runtime = Runtime::new(genesis.config.runtime_config.clone());
     let (store_update, genesis_root) = runtime.apply_genesis_state(
-        tries.clone(),
+        &tries,
         0,
         &genesis
             .config
@@ -97,7 +97,7 @@ pub fn get_runtime_and_trie() -> (Runtime, ShardTries, StateRoot) {
 pub fn get_test_trie_viewer() -> (TrieViewer, TrieUpdate) {
     let (_, tries, root) = get_runtime_and_trie();
     let trie_viewer = TrieViewer::new();
-    let state_update = tries.new_trie_update(0, root);
+    let state_update = tries.snapshot().new_trie_update(0, root);
     (trie_viewer, state_update)
 }
 

--- a/test-utils/testlib/src/user/runtime_user.rs
+++ b/test-utils/testlib/src/user/runtime_user.rs
@@ -80,8 +80,7 @@ impl RuntimeUser {
             let apply_result = client
                 .runtime
                 .apply(
-                    client.tries.snapshot().get_trie_for_shard(0),
-                    client.state_root,
+                    client.tries.snapshot().get_trie_for_shard(0, client.state_root),
                     &None,
                     &apply_state,
                     &receipts,

--- a/test-utils/testlib/src/user/runtime_user.rs
+++ b/test-utils/testlib/src/user/runtime_user.rs
@@ -20,6 +20,7 @@ use node_runtime::{ApplyState, Runtime};
 
 use crate::user::{User, POISONED_LOCK_ERR};
 use near_primitives::test_utils::MockEpochInfoProvider;
+use near_store::test_utils::ShardTriesTestUtils;
 use neard::config::MIN_GAS_PRICE;
 
 /// Mock client without chain, used in RuntimeUser and RuntimeNode
@@ -32,7 +33,7 @@ pub struct MockClient {
 
 impl MockClient {
     pub fn get_state_update(&self) -> TrieUpdate {
-        self.tries.new_trie_update(0, self.state_root)
+        self.tries.snapshot().new_trie_update(0, self.state_root)
     }
 }
 
@@ -79,7 +80,7 @@ impl RuntimeUser {
             let apply_result = client
                 .runtime
                 .apply(
-                    client.tries.get_trie_for_shard(0),
+                    client.tries.snapshot().get_trie_for_shard(0),
                     client.state_root,
                     &None,
                     &apply_state,


### PR DESCRIPTION
Make all reads from state use a read snapshot.

Refactor RuntimeAdapter: methods that touch state now require creating a
RuntimeStateAdapter.

For now client and gc run in the same thread, so nothing should change
for client. For view client it will be impossible to get storage errors
if reading storage root succeeds.

Test plan
---------
Existing tests.
Small sanity test.