### PR TITLE
fix: add a warning for disk type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2419,7 +2419,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "sysinfo",
+ "sysinfo 0.14.3",
  "testlib",
 ]
 
@@ -2831,6 +2831,7 @@ dependencies = [
  "rocksdb",
  "serde",
  "serde_json",
+ "sysinfo 0.15.0",
  "tempfile",
  "testlib",
  "tracing",
@@ -4091,6 +4092,21 @@ dependencies = [
 name = "sysinfo"
 version = "0.14.3"
 source = "git+https://github.com/near/sysinfo?rev=3cb97ee79a02754407d2f0f63628f247d7c65e7b#3cb97ee79a02754407d2f0f63628f247d7c65e7b"
+dependencies = [
+ "cfg-if",
+ "doc-comment",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f597c00e6548b9ddd54c11b8e8534fc11223f28509d57e021f01797b50ca5ca1"
 dependencies = [
  "cfg-if",
  "doc-comment",

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -26,6 +26,7 @@ tracing = "0.1.13"
 tracing-subscriber = "0.2.4"
 num-rational = { version = "0.2.4", features = ["serde"] }
 openssl-probe = { version = "0.1.2" }
+sysinfo = "0.15.0"
 
 near-actix-utils = { path = "../utils/actix" }
 near-crypto = { path = "../core/crypto" }

--- a/neard/src/main.rs
+++ b/neard/src/main.rs
@@ -8,7 +8,8 @@ use actix::System;
 use clap::{crate_version, App, AppSettings, Arg, SubCommand};
 #[cfg(feature = "adversarial")]
 use log::error;
-use log::info;
+use log::{info, warn};
+use sysinfo::{DiskExt, SystemExt};
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::EnvFilter;
 
@@ -180,6 +181,13 @@ fn main() {
             );
         }
         ("run", Some(args)) => {
+            // check disk
+            let system = sysinfo::System::new_all();
+            for disk in system.get_disks() {
+                if !matches!(disk.get_type(), sysinfo::DiskType::SSD) {
+                    warn!("!!! DETECTED NON-SSD DISK. PLEASE MAKE SURE THAT YOU USE SSD FOR NEAR NODE !!!");
+                }
+            }
             // Load configs from home.
             let mut near_config = load_config(home_dir);
             validate_genesis(&near_config.genesis);


### PR DESCRIPTION
We realized that storage read and write could be too slow if we use hdd. This PR adds a warning at the node start if the machine has some non-ssd disk.

Test plan
---------
* Manually test it on a machine with hdd and make sure that the warning is displayed.