### PR TITLE
Wrong feature in cargo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ opt-level = 3 # BLS library is too slow to use in debug
 opt-level = 3 # bs58 library is too slow to use in debug
 
 [features]
+default = []
 expensive_tests = ["neard/expensive_tests"]
 regression_tests = []
 old_tests = []

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -591,6 +591,8 @@ mod tests {
 
     #[test]
     fn rocksdb_merge_sanity() {
+        #[cfg(feature = "no_cache")]
+        panic!("wrong feature2");
         let tmp_dir = tempfile::Builder::new().prefix("_test_snapshot_sanity").tempdir().unwrap();
         let store = create_store(tmp_dir.path().to_str().unwrap());
         assert_eq!(store.get(ColState, &[1]).unwrap(), None);

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -593,6 +593,8 @@ mod tests {
     fn rocksdb_merge_sanity() {
         #[cfg(feature = "no_cache")]
         panic!("wrong feature2");
+        // #[cfg(feature = "single_thread_rocksdb")]
+        // panic!("wrong feature");
         let tmp_dir = tempfile::Builder::new().prefix("_test_snapshot_sanity").tempdir().unwrap();
         let store = create_store(tmp_dir.path().to_str().unwrap());
         assert_eq!(store.get(ColState, &[1]).unwrap(), None);

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -591,10 +591,6 @@ mod tests {
 
     #[test]
     fn rocksdb_merge_sanity() {
-        #[cfg(feature = "no_cache")]
-        panic!("wrong feature2");
-        // #[cfg(feature = "single_thread_rocksdb")]
-        // panic!("wrong feature");
         let tmp_dir = tempfile::Builder::new().prefix("_test_snapshot_sanity").tempdir().unwrap();
         let store = create_store(tmp_dir.path().to_str().unwrap());
         assert_eq!(store.get(ColState, &[1]).unwrap(), None);

--- a/runtime/runtime-params-estimator/Cargo.toml
+++ b/runtime/runtime-params-estimator/Cargo.toml
@@ -1,4 +1,4 @@
-package]
+[package]
 name = "runtime-params-estimator"
 version = "1.1.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]

--- a/runtime/runtime-params-estimator/Cargo.toml
+++ b/runtime/runtime-params-estimator/Cargo.toml
@@ -1,4 +1,4 @@
-[package]
+package]
 name = "runtime-params-estimator"
 version = "1.1.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
@@ -19,13 +19,10 @@ num-rational = "0.2.4"
 
 near-runtime-fees = { path = "../../runtime/near-runtime-fees" }
 near-crypto = { path = "../../core/crypto" }
-near-vm-logic = {path = "../../runtime/near-vm-logic"}
-near-vm-runner = {path = "../../runtime/near-vm-runner"}
-node-runtime = { path = "../../runtime/runtime"}
-near-store = { path = "../../core/store"}
+near-vm-logic = {path = "../../runtime/near-vm-logic" , features = ["costs_counting"]}
+near-vm-runner = {path = "../../runtime/near-vm-runner" , features = ["costs_counting", "no_cache"]}
+node-runtime = { path = "../../runtime/runtime" , features = ["costs_counting", "no_cache"]}
+near-store = { path = "../../core/store", features = ["no_cache", "single_thread_rocksdb"]}
 near-primitives = { path = "../../core/primitives" }
 neard = { path = "../../neard" }
 rocksdb = { git = "https://github.com/nearprotocol/rust-rocksdb", branch="disable-thread" }
-
-[features]
-default = ["near-vm-logic/costs_counting", "near-store/single_thread_rocksdb", "near-store/no_cache", "near-vm-runner/costs_counting", "near-vm-runner/no_cache", "node-runtime/costs_counting", "node-runtime/no_cache"]

--- a/runtime/runtime-params-estimator/Cargo.toml
+++ b/runtime/runtime-params-estimator/Cargo.toml
@@ -19,10 +19,13 @@ num-rational = "0.2.4"
 
 near-runtime-fees = { path = "../../runtime/near-runtime-fees" }
 near-crypto = { path = "../../core/crypto" }
-near-vm-logic = {path = "../../runtime/near-vm-logic" , features = ["costs_counting"]}
-near-vm-runner = {path = "../../runtime/near-vm-runner" , features = ["costs_counting", "no_cache"]}
-node-runtime = { path = "../../runtime/runtime" , features = ["costs_counting", "no_cache"]}
-near-store = { path = "../../core/store", features = ["no_cache", "single_thread_rocksdb"]}
+near-vm-logic = {path = "../../runtime/near-vm-logic"}
+near-vm-runner = {path = "../../runtime/near-vm-runner"}
+node-runtime = { path = "../../runtime/runtime"}
+near-store = { path = "../../core/store"}
 near-primitives = { path = "../../core/primitives" }
 neard = { path = "../../neard" }
 rocksdb = { git = "https://github.com/nearprotocol/rust-rocksdb", branch="disable-thread" }
+
+[features]
+default = ["near-vm-logic/costs_counting", "near-store/single_thread_rocksdb", "near-store/no_cache", "near-vm-runner/costs_counting", "near-vm-runner/no_cache", "node-runtime/costs_counting", "node-runtime/no_cache"]


### PR DESCRIPTION
runtime-param-estimator features (no-cache, single-thread-rocksdb) was incorrectly included in other crate test. To reproduce, checkout to 8b46df6f9e3d71c4fb5bdbbd84a318cb7c715400
```
cargo clean
cargo test --workspace --no-run
target/debug/near_store_<Tab to auto complete>
```
Will get a panic indicates no_cache and single_thread_rocksdb feature is incorrectly included. 

Test Plan
---------
- Run 3de84c6f26689add649ad42d67b075beedf1398f locally, will see above test pass with no panic. Not able to observe this on CI because compile warning treats as error
- Also whenever single thread rocksdb is enabled it's print that, there was two of that print in ci tests, and expect to see none in this PR's CI