### PR TITLE
feat: ability to run next protocol version directly

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1461,6 +1461,7 @@ mod test {
             Arc::new(genesis),
             vec![],
             vec![],
+            false,
         ))]
     }
 

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -555,7 +555,11 @@ impl Handler<Status> for ClientActor {
         Ok(StatusResponse {
             version: self.client.config.version.clone(),
             protocol_version,
-            latest_protocol_version: PROTOCOL_VERSION,
+            latest_protocol_version: if self.client.config.use_next_protocol_version {
+                PROTOCOL_VERSION + 1
+            } else {
+                PROTOCOL_VERSION
+            },
             chain_id: self.client.config.chain_id.clone(),
             rpc_addr: self.client.config.rpc_addr.clone(),
             validators,

--- a/chain/client/tests/challenges.rs
+++ b/chain/client/tests/challenges.rs
@@ -283,6 +283,7 @@ fn test_verify_chunk_invalid_state_challenge() {
         Arc::clone(&genesis),
         vec![],
         vec![],
+        false,
     ))];
     let mut env = TestEnv::new_with_runtime(ChainGenesis::test(), 1, 1, runtimes);
     let signer = InMemorySigner::from_seed("test0", KeyType::ED25519, "test0");
@@ -559,6 +560,7 @@ fn test_fishermen_challenge() {
             Arc::clone(&genesis),
             vec![],
             vec![],
+            false,
         ))
     };
     let runtime1 = create_runtime();
@@ -620,6 +622,7 @@ fn test_challenge_in_different_epoch() {
         Arc::clone(&genesis),
         vec![],
         vec![],
+        false,
     ));
     let runtime2 = Arc::new(neard::NightshadeRuntime::new(
         Path::new("."),
@@ -627,6 +630,7 @@ fn test_challenge_in_different_epoch() {
         genesis,
         vec![],
         vec![],
+        false,
     ));
     let runtimes: Vec<Arc<dyn RuntimeAdapter>> = vec![runtime1, runtime2];
     let networks = vec![network_adapter.clone(), network_adapter.clone()];

--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -1022,6 +1022,7 @@ fn test_gc_with_epoch_length_common(epoch_length: NumBlocks) {
         Arc::new(genesis),
         vec![],
         vec![],
+        false,
     ))];
     let mut chain_genesis = ChainGenesis::test();
     chain_genesis.epoch_length = epoch_length;
@@ -1089,6 +1090,7 @@ fn test_gc_long_epoch() {
             Arc::new(genesis.clone()),
             vec![],
             vec![],
+            false,
         )),
         Arc::new(neard::NightshadeRuntime::new(
             Path::new("."),
@@ -1096,6 +1098,7 @@ fn test_gc_long_epoch() {
             Arc::new(genesis),
             vec![],
             vec![],
+            false,
         )),
     ];
     let mut chain_genesis = ChainGenesis::test();
@@ -1178,6 +1181,7 @@ fn test_gc_execution_outcome() {
         Arc::new(genesis.clone()),
         vec![],
         vec![],
+        false,
     ))];
     let mut chain_genesis = ChainGenesis::test();
     chain_genesis.epoch_length = epoch_length;
@@ -1219,6 +1223,7 @@ fn test_gc_after_state_sync() {
             Arc::new(genesis.clone()),
             vec![],
             vec![],
+            false,
         )),
         Arc::new(neard::NightshadeRuntime::new(
             Path::new("."),
@@ -1226,6 +1231,7 @@ fn test_gc_after_state_sync() {
             Arc::new(genesis.clone()),
             vec![],
             vec![],
+            false,
         )),
     ];
     let mut chain_genesis = ChainGenesis::test();
@@ -1264,6 +1270,7 @@ fn test_process_block_after_state_sync() {
         Arc::new(genesis.clone()),
         vec![],
         vec![],
+        false,
     ))];
     let mut chain_genesis = ChainGenesis::test();
     chain_genesis.epoch_length = epoch_length;
@@ -1304,6 +1311,7 @@ fn test_gc_fork_tail() {
             Arc::new(genesis.clone()),
             vec![],
             vec![],
+            false,
         )),
         Arc::new(neard::NightshadeRuntime::new(
             Path::new("."),
@@ -1311,6 +1319,7 @@ fn test_gc_fork_tail() {
             Arc::new(genesis.clone()),
             vec![],
             vec![],
+            false,
         )),
     ];
     let mut chain_genesis = ChainGenesis::test();
@@ -1375,6 +1384,7 @@ fn test_tx_forward_around_epoch_boundary() {
             Arc::new(genesis.clone()),
             vec![],
             vec![],
+            false,
         )
     };
     let runtimes: Vec<Arc<dyn RuntimeAdapter>> = vec![
@@ -1441,6 +1451,7 @@ fn test_not_resync_old_blocks() {
         Arc::new(genesis),
         vec![],
         vec![],
+        false,
     ))];
     let mut chain_genesis = ChainGenesis::test();
     chain_genesis.epoch_length = epoch_length;
@@ -1472,6 +1483,7 @@ fn test_gc_tail_update() {
             Arc::new(genesis.clone()),
             vec![],
             vec![],
+            false,
         )),
         Arc::new(neard::NightshadeRuntime::new(
             Path::new("."),
@@ -1479,6 +1491,7 @@ fn test_gc_tail_update() {
             Arc::new(genesis),
             vec![],
             vec![],
+            false,
         )),
     ];
     let mut chain_genesis = ChainGenesis::test();
@@ -1552,6 +1565,7 @@ fn test_gas_price_change() {
         genesis,
         vec![],
         vec![],
+        false,
     ))];
     let mut env = TestEnv::new_with_runtime(chain_genesis, 1, 1, runtimes);
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
@@ -1604,6 +1618,7 @@ fn test_gas_price_overflow() {
         genesis,
         vec![],
         vec![],
+        false,
     ))];
     let mut env = TestEnv::new_with_runtime(chain_genesis, 1, 1, runtimes);
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
@@ -1653,6 +1668,7 @@ fn test_incorrect_validator_key_produce_block() {
         genesis,
         vec![],
         vec![],
+        false,
     ));
     let signer = Arc::new(InMemoryValidatorSigner::from_seed("test0", KeyType::ED25519, "seed"));
     let mut config = ClientConfig::test(true, 10, 20, 2, false);
@@ -1714,6 +1730,7 @@ fn test_data_reset_before_state_sync() {
         Arc::new(genesis.clone()),
         vec![],
         vec![],
+        false,
     ))];
     let mut env = TestEnv::new_with_runtime(ChainGenesis::test(), 1, 1, runtimes);
     let signer = InMemorySigner::from_seed("test0", KeyType::ED25519, "test0");
@@ -1773,6 +1790,7 @@ fn test_sync_hash_validity() {
         Arc::new(genesis.clone()),
         vec![],
         vec![],
+        false,
     ))];
     let mut chain_genesis = ChainGenesis::test();
     chain_genesis.epoch_length = epoch_length;
@@ -1832,6 +1850,7 @@ fn test_validate_chunk_extra() {
         Arc::new(genesis.clone()),
         vec![],
         vec![],
+        false,
     ))];
     let mut env = TestEnv::new_with_runtime(ChainGenesis::test(), 1, 1, runtimes);
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap().clone();
@@ -1959,6 +1978,7 @@ fn test_gas_price_change_no_chunk() {
         Arc::new(genesis.clone()),
         vec![],
         vec![],
+        false,
     ))];
     let chain_genesis = ChainGenesis::from(Arc::new(genesis));
     let mut env = TestEnv::new_with_runtime(chain_genesis, 1, 1, runtimes);
@@ -1993,6 +2013,7 @@ fn test_catchup_gas_price_change() {
             Arc::new(genesis.clone()),
             vec![],
             vec![],
+            false,
         )),
         Arc::new(neard::NightshadeRuntime::new(
             Path::new("."),
@@ -2000,6 +2021,7 @@ fn test_catchup_gas_price_change() {
             Arc::new(genesis.clone()),
             vec![],
             vec![],
+            false,
         )),
     ];
     let chain_genesis = ChainGenesis::from(Arc::new(genesis));

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -77,6 +77,9 @@ pub struct ClientConfig {
     pub archive: bool,
     /// Number of threads for ViewClientActor pool.
     pub view_client_threads: usize,
+    /// Whether we should use next protocol version without going through upgrade process.
+    /// Useful for testing latest protocol change.
+    pub use_next_protocol_version: bool,
 }
 
 impl ClientConfig {
@@ -128,6 +131,7 @@ impl ClientConfig {
             tracked_shards: vec![],
             archive,
             view_client_threads: 1,
+            use_next_protocol_version: false,
         }
     }
 }

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -67,6 +67,7 @@ impl GenesisBuilder {
             // there is no reason to track accounts or shards.
             vec![],
             vec![],
+            false,
         );
         Self {
             home_dir: home_dir.to_path_buf(),

--- a/neard/src/config.rs
+++ b/neard/src/config.rs
@@ -299,6 +299,10 @@ fn default_doomslug_step_period() -> Duration {
     Duration::from_millis(100)
 }
 
+fn default_use_next_protocol_version() -> bool {
+    false
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Consensus {
     /// Minimum number of peers to start syncing.
@@ -347,6 +351,9 @@ pub struct Consensus {
     /// Time between running doomslug timer.
     #[serde(default = "default_doomslug_step_period")]
     pub doomslug_step_period: Duration,
+    /// Whether to use next protocol version without going through upgrade process.
+    #[serde(default = "default_use_next_protocol_version")]
+    pub use_next_protocol_version: bool,
 }
 
 impl Default for Consensus {
@@ -372,6 +379,7 @@ impl Default for Consensus {
             sync_check_period: default_sync_check_period(),
             sync_step_period: default_sync_step_period(),
             doomslug_step_period: default_doomslug_step_period(),
+            use_next_protocol_version: default_use_next_protocol_version(),
         }
     }
 }
@@ -584,6 +592,7 @@ impl NearConfig {
                 archive: config.archive,
                 gc_blocks_limit: config.gc_blocks_limit,
                 view_client_threads: config.view_client_threads,
+                use_next_protocol_version: config.consensus.use_next_protocol_version,
             },
             network_config: NetworkConfig {
                 public_key: network_key_pair.public_key,

--- a/neard/src/lib.rs
+++ b/neard/src/lib.rs
@@ -154,6 +154,7 @@ pub fn start_with_config(
         Arc::clone(&config.genesis),
         config.client_config.tracked_accounts.clone(),
         config.client_config.tracked_shards.clone(),
+        config.client_config.use_next_protocol_version,
     ));
 
     let telemetry = TelemetryActor::new(config.telemetry_config.clone()).start();

--- a/neard/tests/economics.rs
+++ b/neard/tests/economics.rs
@@ -30,6 +30,7 @@ fn setup_env(f: &mut dyn FnMut(&mut Genesis) -> ()) -> (TestEnv, FeeHelper) {
         arc_genesis.clone(),
         vec![],
         vec![],
+        false,
     ))];
     let env = TestEnv::new_with_runtime(ChainGenesis::from(&arc_genesis), 1, 1, runtimes);
     (env, fee_helper)

--- a/nightly/tests_for_nayduck.txt
+++ b/nightly/tests_for_nayduck.txt
@@ -1,5 +1,6 @@
 # python sanity tests
 pytest sanity/block_production.py
+pytest sanity/block_production.py use_next_protocol_version
 pytest sanity/transactions.py
 pytest sanity/staking1.py
 pytest --timeout=800 sanity/staking2.py

--- a/test-utils/state-viewer/src/main.rs
+++ b/test-utils/state-viewer/src/main.rs
@@ -54,6 +54,7 @@ fn load_trie_stop_at_height(
         Arc::clone(&near_config.genesis),
         near_config.client_config.tracked_accounts.clone(),
         near_config.client_config.tracked_shards.clone(),
+        false,
     );
     let head = chain_store.head().unwrap();
     let last_block = match mode {
@@ -110,6 +111,7 @@ fn print_chain(
         Arc::clone(&near_config.genesis),
         near_config.client_config.tracked_accounts.clone(),
         near_config.client_config.tracked_shards.clone(),
+        false,
     );
     let mut account_id_to_blocks = HashMap::new();
     let mut cur_epoch_id = None;
@@ -179,6 +181,7 @@ fn replay_chain(
         Arc::clone(&near_config.genesis),
         near_config.client_config.tracked_accounts.clone(),
         near_config.client_config.tracked_shards.clone(),
+        false,
     );
     for height in start_height..=end_height {
         if let Ok(block_hash) = chain_store.get_block_hash_by_height(height) {
@@ -207,6 +210,7 @@ fn apply_block_at_height(
         Arc::clone(&near_config.genesis),
         near_config.client_config.tracked_accounts.clone(),
         near_config.client_config.tracked_shards.clone(),
+        false,
     );
     let block_hash = chain_store.get_block_hash_by_height(height).unwrap();
     let block = chain_store.get_block(&block_hash).unwrap().clone();

--- a/test-utils/state-viewer/src/state_dump.rs
+++ b/test-utils/state-viewer/src/state_dump.rs
@@ -96,6 +96,7 @@ mod test {
             Arc::new(genesis.clone()),
             vec![],
             vec![],
+            false,
         );
         let runtimes: Vec<Arc<dyn RuntimeAdapter>> = vec![Arc::new(nightshade_runtime)];
         let mut chain_genesis = ChainGenesis::test();
@@ -144,6 +145,7 @@ mod test {
             Arc::new(genesis.clone()),
             vec![],
             vec![],
+            false,
         );
         let new_genesis =
             state_dump(runtime, state_roots, last_block.header().clone(), &genesis.config);
@@ -180,6 +182,7 @@ mod test {
             Arc::new(genesis.clone()),
             vec![],
             vec![],
+            false,
         );
         let new_genesis =
             state_dump(runtime, state_roots, last_block.header().clone(), &genesis.config);
@@ -208,7 +211,14 @@ mod test {
         let store1 = create_test_store();
         let store2 = create_test_store();
         let create_runtime = |store| -> NightshadeRuntime {
-            NightshadeRuntime::new(Path::new("."), store, Arc::new(genesis.clone()), vec![], vec![])
+            NightshadeRuntime::new(
+                Path::new("."),
+                store,
+                Arc::new(genesis.clone()),
+                vec![],
+                vec![],
+                false,
+            )
         };
         let runtimes: Vec<Arc<dyn RuntimeAdapter>> = vec![
             Arc::new(create_runtime(store1.clone())),
@@ -262,6 +272,7 @@ mod test {
             Arc::new(genesis.clone()),
             vec![],
             vec![],
+            false,
         );
         let runtimes: Vec<Arc<dyn RuntimeAdapter>> = vec![Arc::new(nightshade_runtime)];
         let mut chain_genesis = ChainGenesis::test();
@@ -301,6 +312,7 @@ mod test {
             Arc::new(genesis.clone()),
             vec![],
             vec![],
+            false,
         );
         let new_genesis =
             state_dump(runtime, state_roots, last_block.header().clone(), &genesis.config);

--- a/test-utils/store-validator/src/main.rs
+++ b/test-utils/store-validator/src/main.rs
@@ -37,6 +37,7 @@ fn main() {
         Arc::clone(&near_config.genesis),
         near_config.client_config.tracked_accounts.clone(),
         near_config.client_config.tracked_shards.clone(),
+        false,
     ));
 
     let mut store_validator = StoreValidator::new(

--- a/test-utils/testlib/src/lib.rs
+++ b/test-utils/testlib/src/lib.rs
@@ -32,7 +32,8 @@ pub fn genesis_header(genesis: Arc<Genesis>) -> BlockHeader {
     let dir = tempdir().unwrap();
     let store = create_test_store();
     let chain_genesis = ChainGenesis::from(&genesis);
-    let runtime = Arc::new(NightshadeRuntime::new(dir.path(), store, genesis, vec![], vec![]));
+    let runtime =
+        Arc::new(NightshadeRuntime::new(dir.path(), store, genesis, vec![], vec![], false));
     let chain = Chain::new(runtime, &chain_genesis, DoomslugThresholdMode::TwoThirds).unwrap();
     chain.genesis().clone()
 }
@@ -42,7 +43,8 @@ pub fn genesis_block(genesis: Arc<Genesis>) -> Block {
     let dir = tempdir().unwrap();
     let store = create_test_store();
     let chain_genesis = ChainGenesis::from(&genesis);
-    let runtime = Arc::new(NightshadeRuntime::new(dir.path(), store, genesis, vec![], vec![]));
+    let runtime =
+        Arc::new(NightshadeRuntime::new(dir.path(), store, genesis, vec![], vec![], false));
     let mut chain = Chain::new(runtime, &chain_genesis, DoomslugThresholdMode::TwoThirds).unwrap();
     chain.get_block(&chain.genesis().hash().clone()).unwrap().clone()
 }


### PR DESCRIPTION
Introduce the ability for a node to run next protocol version directly without going through the upgrade process. Fixes #3268. More specifically, this PR allows us to:
* Batch protocol version changes together and do not update protocol version immediately when there is a protocol version change.
* Instead we can use the new change by setting `use_next_protocol_version` in `config.json` to be `true` and this will make the node run with the new version (`PROTOCOL_VERSION + 1`).

Test plan
---------
Add `use_next_protocol_version` option to `block_production.py`.