### PR TITLE
feat: Refactor Config out of Runtime

### DIFF
--- a/core/runtime-configs/src/lib.rs
+++ b/core/runtime-configs/src/lib.rs
@@ -4,8 +4,10 @@ use serde::{Deserialize, Serialize};
 use near_primitives::account::Account;
 use near_primitives::serialize::u128_dec_format;
 use near_primitives::types::{AccountId, Balance};
+use near_primitives::version::ProtocolVersion;
 use near_runtime_fees::RuntimeFeesConfig;
 use near_vm_logic::VMConfig;
+use std::sync::Arc;
 
 /// The structure that holds the parameters of the runtime, mostly economics.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -44,6 +46,13 @@ impl RuntimeConfig {
             wasm_config: VMConfig::free(),
             account_creation_config: AccountCreationConfig::default(),
         }
+    }
+
+    pub fn from_protocol_version(
+        genesis_runtime_config: &Arc<RuntimeConfig>,
+        _protocol_version: ProtocolVersion,
+    ) -> Arc<Self> {
+        genesis_runtime_config.clone()
     }
 }
 

--- a/core/runtime-configs/src/lib.rs
+++ b/core/runtime-configs/src/lib.rs
@@ -48,6 +48,9 @@ impl RuntimeConfig {
         }
     }
 
+    /// Returns a `RuntimeConfig` for the corresponding protocol version.
+    /// It uses `genesis_runtime_config` to keep the unchanged fees.
+    /// TODO: https://github.com/nearprotocol/NEPs/issues/120
     pub fn from_protocol_version(
         genesis_runtime_config: &Arc<RuntimeConfig>,
         _protocol_version: ProtocolVersion,

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -163,7 +163,11 @@ impl GenesisBuilder {
             self.state_updates.remove(&shard_idx).expect("State updates are always available");
 
         // Compute storage usage and update accounts.
-        for (account_id, storage_usage) in self.runtime.runtime.compute_storage_usage(&records) {
+        for (account_id, storage_usage) in self
+            .runtime
+            .runtime
+            .compute_storage_usage(&records, &self.genesis.config.runtime_config)
+        {
             let mut account =
                 get_account(&state_update, &account_id)?.expect("We should've created account");
             account.storage_usage = storage_usage;

--- a/runtime/runtime-params-estimator/src/testbed.rs
+++ b/runtime/runtime-params-estimator/src/testbed.rs
@@ -14,6 +14,7 @@ use near_vm_logic::VMLimitConfig;
 use neard::get_store_path;
 use node_runtime::config::RuntimeConfig;
 use node_runtime::{ApplyState, Runtime};
+use std::sync::Arc;
 
 const STATE_DUMP_FILE: &str = "state_dump";
 const GENESIS_ROOTS_FILE: &str = "genesis_roots";
@@ -71,7 +72,7 @@ impl RuntimeTestbed {
             ..Default::default()
         };
 
-        let runtime = Runtime::new(runtime_config);
+        let runtime = Runtime::new();
         let prev_receipts = vec![];
 
         let apply_state = ApplyState {
@@ -86,6 +87,7 @@ impl RuntimeTestbed {
             gas_limit: None,
             random_seed: Default::default(),
             current_protocol_version: PROTOCOL_VERSION,
+            config: Arc::new(runtime_config),
         };
         Self {
             workdir,

--- a/runtime/runtime-standalone/src/lib.rs
+++ b/runtime/runtime-standalone/src/lib.rs
@@ -115,6 +115,7 @@ impl Block {
 
 pub struct RuntimeStandalone {
     genesis: GenesisConfig,
+    runtime_config: Arc<RuntimeConfig>,
     tx_pool: TransactionPool,
     transactions: HashMap<CryptoHash, SignedTransaction>,
     outcomes: HashMap<CryptoHash, ExecutionOutcome>,
@@ -129,16 +130,23 @@ impl RuntimeStandalone {
     pub fn new(genesis: GenesisConfig, store: Arc<Store>) -> Self {
         let mut genesis_block = Block::genesis(&genesis);
         let mut store_update = store.store_update();
-        let runtime = Runtime::new(genesis.runtime_config.clone());
+        let runtime = Runtime::new();
         let tries = ShardTries::new(store, 1);
-        let (s_update, state_root) =
-            runtime.apply_genesis_state(tries.clone(), 0, &[], &genesis.state_records);
+        let runtime_config = Arc::new(genesis.runtime_config.clone());
+        let (s_update, state_root) = runtime.apply_genesis_state(
+            tries.clone(),
+            0,
+            &[],
+            &genesis.state_records,
+            &runtime_config,
+        );
         store_update.merge(s_update);
         store_update.commit().unwrap();
         genesis_block.state_root = state_root;
         let validators = genesis.validators.clone();
         Self {
             genesis,
+            runtime_config,
             tries,
             runtime,
             transactions: HashMap::new(),
@@ -216,6 +224,7 @@ impl RuntimeStandalone {
             last_block_hash: CryptoHash::default(),
             epoch_id: EpochId::default(),
             current_protocol_version: PROTOCOL_VERSION,
+            config: self.runtime_config.clone(),
         };
 
         let apply_result = self.runtime.apply(

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -43,7 +43,9 @@ use crate::config::{
 use crate::verifier::validate_receipt;
 pub use crate::verifier::{validate_transaction, verify_and_charge_transaction};
 use near_primitives::version::{ProtocolVersion, IMPLICIT_ACCOUNT_CREATION_PROTOCOL_VERSION};
+use near_runtime_fees::RuntimeFeesConfig;
 use std::rc::Rc;
+use std::sync::Arc;
 
 mod actions;
 pub mod adapter;
@@ -79,6 +81,8 @@ pub struct ApplyState {
     pub random_seed: CryptoHash,
     /// Current Protocol version when we apply the state transition
     pub current_protocol_version: ProtocolVersion,
+    /// The Runtime config to use for the current transition.
+    pub config: Arc<RuntimeConfig>,
 }
 
 /// Contains information to update validators accounts at the first block of a new epoch.
@@ -195,13 +199,11 @@ impl Default for ActionResult {
     }
 }
 
-pub struct Runtime {
-    pub config: RuntimeConfig,
-}
+pub struct Runtime {}
 
 impl Runtime {
-    pub fn new(config: RuntimeConfig) -> Self {
-        Runtime { config }
+    pub fn new() -> Self {
+        Self {}
     }
 
     fn print_log(log: &[LogEntry]) {
@@ -236,7 +238,7 @@ impl Runtime {
     ) -> Result<(Receipt, ExecutionOutcomeWithId), RuntimeError> {
         near_metrics::inc_counter(&metrics::TRANSACTION_PROCESSED_TOTAL);
         match verify_and_charge_transaction(
-            &self.config,
+            &apply_state.config,
             state_update,
             apply_state.gas_price,
             signed_transaction,
@@ -307,7 +309,7 @@ impl Runtime {
     ) -> Result<ActionResult, RuntimeError> {
         let mut result = ActionResult::default();
         let exec_fees = exec_fee(
-            &self.config.transaction_costs,
+            &apply_state.config.transaction_costs,
             action,
             &receipt.receiver_id,
             apply_state.current_protocol_version,
@@ -338,8 +340,8 @@ impl Runtime {
             Action::CreateAccount(_) => {
                 near_metrics::inc_counter(&metrics::ACTION_CREATE_ACCOUNT_TOTAL);
                 action_create_account(
-                    &self.config.transaction_costs,
-                    &self.config.account_creation_config,
+                    &apply_state.config.transaction_costs,
+                    &apply_state.config.account_creation_config,
                     account,
                     actor_id,
                     &receipt.receiver_id,
@@ -369,7 +371,7 @@ impl Runtime {
                     account_id,
                     function_call,
                     action_hash,
-                    &self.config,
+                    &apply_state.config,
                     action_index + 1 == actions.len(),
                     epoch_info_provider,
                 )?;
@@ -396,7 +398,7 @@ impl Runtime {
                     debug_assert!(!is_refund);
                     action_implicit_account_creation_transfer(
                         state_update,
-                        &self.config.transaction_costs,
+                        &apply_state.config.transaction_costs,
                         account,
                         actor_id,
                         &receipt.receiver_id,
@@ -418,7 +420,7 @@ impl Runtime {
             Action::AddKey(add_key) => {
                 near_metrics::inc_counter(&metrics::ACTION_ADD_KEY_TOTAL);
                 action_add_key(
-                    &self.config.transaction_costs,
+                    &apply_state.config.transaction_costs,
                     state_update,
                     account.as_mut().expect(EXPECT_ACCOUNT_EXISTS),
                     &mut result,
@@ -429,7 +431,7 @@ impl Runtime {
             Action::DeleteKey(delete_key) => {
                 near_metrics::inc_counter(&metrics::ACTION_DELETE_KEY_TOTAL);
                 action_delete_key(
-                    &self.config.transaction_costs,
+                    &apply_state.config.transaction_costs,
                     state_update,
                     account.as_mut().expect(EXPECT_ACCOUNT_EXISTS),
                     &mut result,
@@ -500,7 +502,8 @@ impl Runtime {
         let mut account = get_account(state_update, account_id)?;
         let mut actor_id = receipt.predecessor_id.clone();
         let mut result = ActionResult::default();
-        let exec_fee = self.config.transaction_costs.action_receipt_creation_config.exec_fee();
+        let exec_fee =
+            apply_state.config.transaction_costs.action_receipt_creation_config.exec_fee();
         result.gas_used = exec_fee;
         result.gas_burnt = exec_fee;
         // Executing actions one by one
@@ -527,7 +530,7 @@ impl Runtime {
             )?;
             if new_result.result.is_ok() {
                 if let Err(e) = new_result.new_receipts.iter().try_for_each(|receipt| {
-                    validate_receipt(&self.config.wasm_config.limit_config, receipt)
+                    validate_receipt(&apply_state.config.wasm_config.limit_config, receipt)
                 }) {
                     new_result.result = Err(ActionErrorKind::NewReceiptValidationError(e).into());
                 }
@@ -543,7 +546,7 @@ impl Runtime {
         // Going to check balance covers account's storage.
         if result.result.is_ok() {
             if let Some(ref mut account) = account {
-                if let Some(amount) = get_insufficient_storage_stake(account, &self.config)
+                if let Some(amount) = get_insufficient_storage_stake(account, &apply_state.config)
                     .map_err(|err| StorageError::StorageInconsistentState(err))?
                 {
                     result.merge(ActionResult {
@@ -582,6 +585,7 @@ impl Runtime {
                 action_receipt,
                 &mut result,
                 apply_state.current_protocol_version,
+                &apply_state.config.transaction_costs,
             )?
         };
         stats.gas_deficit_amount = safe_add_balance(stats.gas_deficit_amount, gas_deficit_amount)?;
@@ -610,8 +614,8 @@ impl Runtime {
 
         // Adding burnt gas reward for function calls if the account exists.
         let receiver_gas_reward = result.gas_burnt_for_function_call
-            * *self.config.transaction_costs.burnt_gas_reward.numer() as u64
-            / *self.config.transaction_costs.burnt_gas_reward.denom() as u64;
+            * *apply_state.config.transaction_costs.burnt_gas_reward.numer() as u64
+            / *apply_state.config.transaction_costs.burnt_gas_reward.denom() as u64;
         // The balance that the current account should receive as a reward for function call
         // execution.
         let receiver_reward = safe_gas_to_balance(apply_state.gas_price, receiver_gas_reward)?
@@ -736,17 +740,18 @@ impl Runtime {
         action_receipt: &ActionReceipt,
         result: &mut ActionResult,
         current_protocol_version: ProtocolVersion,
+        transaction_costs: &RuntimeFeesConfig,
     ) -> Result<Balance, RuntimeError> {
         let total_deposit = total_deposit(&action_receipt.actions)?;
         let prepaid_gas = total_prepaid_gas(&action_receipt.actions)?;
         let exec_gas = safe_add_gas(
             total_exec_fees(
-                &self.config.transaction_costs,
+                &transaction_costs,
                 &action_receipt.actions,
                 &receipt.receiver_id,
                 current_protocol_version,
             )?,
-            self.config.transaction_costs.action_receipt_creation_config.exec_fee(),
+            transaction_costs.action_receipt_creation_config.exec_fee(),
         )?;
         let deposit_refund = if result.result.is_err() { total_deposit } else { 0 };
         let gas_refund = if result.result.is_err() {
@@ -1183,12 +1188,14 @@ impl Runtime {
             })?;
 
             // Validating the delayed receipt. If it fails, it's likely the state is inconsistent.
-            validate_receipt(&self.config.wasm_config.limit_config, &receipt).map_err(|e| {
-                StorageError::StorageInconsistentState(format!(
-                    "Delayed receipt #{} in the state is invalid: {}",
-                    delayed_receipts_indices.first_index, e
-                ))
-            })?;
+            validate_receipt(&apply_state.config.wasm_config.limit_config, &receipt).map_err(
+                |e| {
+                    StorageError::StorageInconsistentState(format!(
+                        "Delayed receipt #{} in the state is invalid: {}",
+                        delayed_receipts_indices.first_index, e
+                    ))
+                },
+            )?;
 
             state_update.remove(key);
             // Math checked above: first_index is less than next_available_index
@@ -1200,7 +1207,7 @@ impl Runtime {
         for receipt in incoming_receipts.iter() {
             // Validating new incoming no matter whether we have available gas or not. We don't
             // want to store invalid receipts in state as delayed.
-            validate_receipt(&self.config.wasm_config.limit_config, &receipt)
+            validate_receipt(&apply_state.config.wasm_config.limit_config, &receipt)
                 .map_err(RuntimeError::ReceiptValidationError)?;
             if total_gas_burnt < gas_limit {
                 process_receipt(&receipt, &mut state_update, &mut total_gas_burnt)?;
@@ -1214,7 +1221,7 @@ impl Runtime {
         }
 
         check_balance(
-            &self.config.transaction_costs,
+            &apply_state.config.transaction_costs,
             &initial_state,
             &state_update,
             validator_accounts_update,
@@ -1277,9 +1284,13 @@ impl Runtime {
 
     /// It's okay to use unsafe math here, because this method should only be called on the trusted
     /// state records (e.g. at launch from genesis)
-    pub fn compute_storage_usage(&self, records: &[StateRecord]) -> HashMap<AccountId, u64> {
+    pub fn compute_storage_usage(
+        &self,
+        records: &[StateRecord],
+        config: &RuntimeConfig,
+    ) -> HashMap<AccountId, u64> {
         let mut result = HashMap::new();
-        let config = &self.config.transaction_costs.storage_usage_config;
+        let config = &config.transaction_costs.storage_usage_config;
         for record in records {
             let account_and_storage = match record {
                 StateRecord::Account { account_id, .. } => {
@@ -1319,6 +1330,7 @@ impl Runtime {
         shard_id: ShardId,
         validators: &[(AccountId, PublicKey, Balance)],
         records: &[StateRecord],
+        config: &RuntimeConfig,
     ) -> (StoreUpdate, StateRoot) {
         let mut state_update = tries.new_trie_update(shard_id, MerkleHash::default());
         let mut postponed_receipts: Vec<Receipt> = vec![];
@@ -1363,7 +1375,7 @@ impl Runtime {
                 }
             }
         }
-        for (account_id, storage_usage) in self.compute_storage_usage(records) {
+        for (account_id, storage_usage) in self.compute_storage_usage(records, &config) {
             let mut account = get_account(&state_update, &account_id)
                 .expect("Genesis storage error")
                 .expect("Account must exist");
@@ -1490,7 +1502,7 @@ mod tests {
     {
         let tries = create_tries();
         let root = MerkleHash::default();
-        let runtime = Runtime::new(RuntimeConfig::default());
+        let runtime = Runtime::new();
 
         let account_id = alice_account();
         let signer =
@@ -1521,6 +1533,7 @@ mod tests {
             gas_limit: Some(gas_limit),
             random_seed: Default::default(),
             current_protocol_version: PROTOCOL_VERSION,
+            config: Arc::new(RuntimeConfig::default()),
         };
 
         (runtime, tries, root, apply_state, signer, MockEpochInfoProvider::default())
@@ -1621,9 +1634,12 @@ mod tests {
         let (runtime, tries, mut root, mut apply_state, _, epoch_info_provider) =
             setup_runtime(initial_balance, initial_locked, 1);
 
-        let receipt_gas_cost =
-            runtime.config.transaction_costs.action_receipt_creation_config.exec_fee()
-                + runtime.config.transaction_costs.action_creation_config.transfer_cost.exec_fee();
+        let receipt_gas_cost = apply_state
+            .config
+            .transaction_costs
+            .action_receipt_creation_config
+            .exec_fee()
+            + apply_state.config.transaction_costs.action_creation_config.transfer_cost.exec_fee();
         apply_state.gas_limit = Some(receipt_gas_cost * 3);
 
         let n = 40;
@@ -1667,9 +1683,12 @@ mod tests {
         let (runtime, tries, mut root, mut apply_state, _, epoch_info_provider) =
             setup_runtime(initial_balance, initial_locked, 1);
 
-        let receipt_gas_cost =
-            runtime.config.transaction_costs.action_receipt_creation_config.exec_fee()
-                + runtime.config.transaction_costs.action_creation_config.transfer_cost.exec_fee();
+        let receipt_gas_cost = apply_state
+            .config
+            .transaction_costs
+            .action_receipt_creation_config
+            .exec_fee()
+            + apply_state.config.transaction_costs.action_creation_config.transfer_cost.exec_fee();
 
         let n = 120;
         let receipts = generate_receipts(small_transfer, n);
@@ -1747,13 +1766,14 @@ mod tests {
         let initial_balance = to_yocto(1_000_000);
         let initial_locked = to_yocto(500_000);
         let small_transfer = to_yocto(10_000);
-        let (mut runtime, tries, root, mut apply_state, signer, epoch_info_provider) =
+        let (runtime, tries, root, mut apply_state, signer, epoch_info_provider) =
             setup_runtime(initial_balance, initial_locked, 1);
 
         let receipt_exec_gas_fee = 1000;
-        runtime.config = RuntimeConfig::free();
-        runtime.config.transaction_costs.action_receipt_creation_config.execution =
+        let mut free_config = RuntimeConfig::free();
+        free_config.transaction_costs.action_receipt_creation_config.execution =
             receipt_exec_gas_fee;
+        apply_state.config = Arc::new(free_config);
         // This allows us to execute 3 receipts per apply.
         apply_state.gas_limit = Some(receipt_exec_gas_fee * 3);
 
@@ -2084,9 +2104,9 @@ mod tests {
         })];
 
         let expected_gas_burnt = safe_add_gas(
-            runtime.config.transaction_costs.action_receipt_creation_config.exec_fee(),
+            apply_state.config.transaction_costs.action_receipt_creation_config.exec_fee(),
             total_exec_fees(
-                &runtime.config.transaction_costs,
+                &apply_state.config.transaction_costs,
                 &actions,
                 &alice_account(),
                 PROTOCOL_VERSION,
@@ -2153,9 +2173,9 @@ mod tests {
         })];
 
         let expected_gas_burnt = safe_add_gas(
-            runtime.config.transaction_costs.action_receipt_creation_config.exec_fee(),
+            apply_state.config.transaction_costs.action_receipt_creation_config.exec_fee(),
             total_exec_fees(
-                &runtime.config.transaction_costs,
+                &apply_state.config.transaction_costs,
                 &actions,
                 &alice_account(),
                 PROTOCOL_VERSION,

--- a/runtime/runtime/tests/runtime_group_tools/mod.rs
+++ b/runtime/runtime/tests/runtime_group_tools/mod.rs
@@ -50,10 +50,10 @@ impl StandaloneRuntime {
         runtime_config.transaction_costs.data_receipt_creation_config.base_cost.execution =
             runtime_config.wasm_config.limit_config.max_total_prepaid_gas / 64;
 
-        let runtime = Runtime::new(runtime_config);
+        let runtime = Runtime::new();
 
         let (store_update, root) =
-            runtime.apply_genesis_state(tries.clone(), 0, &[], state_records);
+            runtime.apply_genesis_state(tries.clone(), 0, &[], state_records, &runtime_config);
         store_update.commit().unwrap();
 
         let apply_state = ApplyState {
@@ -66,6 +66,7 @@ impl StandaloneRuntime {
             gas_limit: None,
             random_seed: Default::default(),
             current_protocol_version: PROTOCOL_VERSION,
+            config: Arc::new(runtime_config),
         };
 
         Self {

--- a/runtime/runtime/tests/test_regression.rs
+++ b/runtime/runtime/tests/test_regression.rs
@@ -162,7 +162,9 @@ fn template_test(transaction_type: TransactionType, db_type: DataBaseType, expec
             }
         }
         // Compute storage usage and update accounts.
-        for (account_id, storage_usage) in runtime.runtime.compute_storage_usage(&records) {
+        for (account_id, storage_usage) in
+            runtime.runtime.compute_storage_usage(&records, &runtime.apply_state.config)
+        {
             let mut account = get_account(&state_update, &account_id)
                 .expect("Genesis storage error")
                 .expect("Account must exist");

--- a/test-utils/testlib/src/node/runtime_node.rs
+++ b/test-utils/testlib/src/node/runtime_node.rs
@@ -34,6 +34,7 @@ impl RuntimeNode {
             tries,
             state_root: root,
             epoch_length: genesis.config.epoch_length,
+            runtime_config: genesis.config.runtime_config.clone(),
         }));
         RuntimeNode { signer, client, genesis }
     }

--- a/test-utils/testlib/src/runtime_utils.rs
+++ b/test-utils/testlib/src/runtime_utils.rs
@@ -66,7 +66,7 @@ pub fn add_test_contract(genesis: &mut Genesis, account_id: &AccountId) {
 
 pub fn get_runtime_and_trie_from_genesis(genesis: &Genesis) -> (Runtime, ShardTries, StateRoot) {
     let tries = create_tries();
-    let runtime = Runtime::new(genesis.config.runtime_config.clone());
+    let runtime = Runtime::new();
     let (store_update, genesis_root) = runtime.apply_genesis_state(
         tries.clone(),
         0,
@@ -83,6 +83,7 @@ pub fn get_runtime_and_trie_from_genesis(genesis: &Genesis) -> (Runtime, ShardTr
             })
             .collect::<Vec<_>>(),
         &genesis.records.as_ref(),
+        &genesis.config.runtime_config,
     );
     store_update.commit().unwrap();
     (runtime, tries, genesis_root)

--- a/test-utils/testlib/src/user/runtime_user.rs
+++ b/test-utils/testlib/src/user/runtime_user.rs
@@ -22,6 +22,7 @@ use node_runtime::{ApplyState, Runtime};
 use crate::user::{User, POISONED_LOCK_ERR};
 use near_primitives::test_utils::MockEpochInfoProvider;
 use neard::config::MIN_GAS_PRICE;
+use node_runtime::config::RuntimeConfig;
 
 /// Mock client without chain, used in RuntimeUser and RuntimeNode
 pub struct MockClient {
@@ -29,6 +30,7 @@ pub struct MockClient {
     pub tries: ShardTries,
     pub state_root: MerkleHash,
     pub epoch_length: BlockHeightDelta,
+    pub runtime_config: RuntimeConfig,
 }
 
 impl MockClient {
@@ -48,10 +50,12 @@ pub struct RuntimeUser {
     pub receipts: RefCell<HashMap<CryptoHash, Receipt>>,
     pub transactions: RefCell<HashSet<SignedTransaction>>,
     pub epoch_info_provider: MockEpochInfoProvider,
+    pub runtime_config: Arc<RuntimeConfig>,
 }
 
 impl RuntimeUser {
     pub fn new(account_id: &str, signer: Arc<dyn Signer>, client: Arc<RwLock<MockClient>>) -> Self {
+        let runtime_config = Arc::new(client.read().unwrap().runtime_config.clone());
         RuntimeUser {
             signer,
             trie_viewer: TrieViewer::new(),
@@ -61,6 +65,7 @@ impl RuntimeUser {
             receipts: Default::default(),
             transactions: RefCell::new(Default::default()),
             epoch_info_provider: MockEpochInfoProvider::default(),
+            runtime_config,
         }
     }
 
@@ -129,6 +134,7 @@ impl RuntimeUser {
             random_seed: Default::default(),
             epoch_id: Default::default(),
             current_protocol_version: PROTOCOL_VERSION,
+            config: self.runtime_config.clone(),
         }
     }
 


### PR DESCRIPTION
Move `RuntimeConfig` from `Runtime` initialization to `ApplyState` object.
This makes `Runtime` completely stateless and allows to execute transitions based on different configs.
It allows to upgrade `RuntimeConfig` with the new fees based on the protocol version for the current block.

This change should be NOOP and doesn't change the protocol. 

NEP: https://github.com/nearprotocol/NEPs/issues/120
Issue: #3158

# Test plan:

- [X] CI
- [x] http://nayduck.eastus.cloudapp.azure.com:3000/#/run/553