### PR TITLE
Change migration step size to address oom issue in db migration

### DIFF
--- a/neard/src/migrations.rs
+++ b/neard/src/migrations.rs
@@ -98,7 +98,7 @@ pub fn migrate_12_to_13(path: &String, near_config: &NearConfig) {
         let mut cur_height = genesis_height;
         while cur_height <= head.height {
             let mut store_update = store.store_update();
-            for height in cur_height..std::cmp::min(cur_height + 10000, head.height + 1) {
+            for height in cur_height..std::cmp::min(cur_height + 100, head.height + 1) {
                 if let Err(e) =
                     apply_block_at_height(&mut store_update, &mut chain_store, &runtime, height, 0)
                 {
@@ -108,7 +108,7 @@ pub fn migrate_12_to_13(path: &String, near_config: &NearConfig) {
                     }
                 }
             }
-            cur_height += 10000;
+            cur_height += 100;
             store_update.commit().unwrap();
         }
     }


### PR DESCRIPTION
Testing on betanet-nearup4:
```
ubuntu@betanet-nearup4:~$ ./near --home=/home/ubuntu/.near/betanet/ run
Oct 21 18:40:12.275  INFO near: Version: 1.2.0, Build: 9b367a8b, Latest Protocol: 40    
Oct 21 18:40:14.542  INFO near: Opening store database at "/home/ubuntu/.near/betanet/data"    
Oct 21 18:40:14.557  INFO near: Migrate DB from version 12 to 13    
```
Migration is still running, if it passes will remove donotmerge label.