### PR TITLE
Add labels to rpc processing time historgram.

### DIFF
--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -200,7 +200,10 @@ impl JsonRpcHandler {
 
     async fn process_request(&self, request: Request) -> Result<Value, RpcError> {
         near_metrics::inc_counter_vec(&metrics::HTTP_RPC_REQUEST_COUNT, &[request.method.as_ref()]);
-        let _rpc_processing_time = near_metrics::start_timer(&metrics::RPC_PROCESSING_TIME);
+        let _rpc_processing_time = near_metrics::start_timer_vec(
+            &metrics::RPC_PROCESSING_TIME,
+            &[request.method.as_ref()],
+        );
 
         #[cfg(feature = "adversarial")]
         {

--- a/chain/jsonrpc/src/metrics.rs
+++ b/chain/jsonrpc/src/metrics.rs
@@ -1,11 +1,12 @@
 use lazy_static::lazy_static;
-use near_metrics::{Histogram, IntCounter, IntCounterVec};
+use near_metrics::{HistogramVec, IntCounter, IntCounterVec};
 
 lazy_static! {
-    pub static ref RPC_PROCESSING_TIME: near_metrics::Result<Histogram> =
-        near_metrics::try_create_histogram(
+    pub static ref RPC_PROCESSING_TIME: near_metrics::Result<HistogramVec> =
+        near_metrics::try_create_histogram_vec(
             "near_rpc_processing_time",
-            "Time taken to process rpc queries"
+            "Time taken to process rpc queries",
+            &["method"]
         );
     pub static ref RPC_TIMEOUT_TOTAL: near_metrics::Result<IntCounter> =
         near_metrics::try_create_int_counter(


### PR DESCRIPTION
This adds per method processing time tracking
so which should make monitoring easier.