### PR TITLE
fix(storage): fix 14->15 migration

### DIFF
--- a/core/store/src/migrations.rs
+++ b/core/store/src/migrations.rs
@@ -28,7 +28,7 @@ use near_primitives::block::{Block, Tip};
 use near_primitives::block_header::BlockHeader;
 use near_primitives::epoch_manager::EpochInfo;
 use near_primitives::merkle::merklize;
-use near_primitives::receipt::{DelayedReceiptIndices, Receipt};
+use near_primitives::receipt::{DelayedReceiptIndices, Receipt, ReceiptEnum};
 use near_primitives::syncing::{ShardStateSyncResponseHeader, ShardStateSyncResponseHeaderV1};
 use near_primitives::trie_key::TrieKey;
 use near_primitives::utils::{create_receipt_id_from_transaction, get_block_shard_id};
@@ -392,8 +392,8 @@ pub fn migrate_14_to_15(path: &String) {
             new_execution_outcome_ids.extend(local_receipt_ids);
 
             // Step 2: delayed receipts
+            let state_root = chunk.prev_state_root();
             if !local_receipt_congestion {
-                let state_root = chunk.prev_state_root();
                 let mut delayed_receipt_indices: DelayedReceiptIndices = trie
                     .get(&state_root, &TrieKey::DelayedReceiptIndices.to_vec())
                     .unwrap()
@@ -422,8 +422,46 @@ pub fn migrate_14_to_15(path: &String) {
 
             // Step 3: receipts
             for receipt in chunk.receipts() {
-                if execution_outcome_ids.contains(&receipt.receipt_id) {
-                    new_execution_outcome_ids.push(receipt.receipt_id);
+                match &receipt.receipt {
+                    ReceiptEnum::Action(_) => {
+                        if execution_outcome_ids.contains(&receipt.receipt_id) {
+                            new_execution_outcome_ids.push(receipt.receipt_id);
+                        }
+                    }
+                    ReceiptEnum::Data(data_receipt) => {
+                        if let Some(bytes) = trie
+                            .get(
+                                &state_root,
+                                &TrieKey::PostponedReceiptId {
+                                    receiver_id: receipt.receiver_id.clone(),
+                                    data_id: data_receipt.data_id,
+                                }
+                                .to_vec(),
+                            )
+                            .unwrap()
+                        {
+                            let receipt_id = CryptoHash::try_from_slice(&bytes).unwrap();
+                            let pending_receipt_count = u32::try_from_slice(
+                                &trie
+                                    .get(
+                                        &state_root,
+                                        &TrieKey::PendingDataCount {
+                                            receiver_id: receipt.receiver_id.clone(),
+                                            receipt_id,
+                                        }
+                                        .to_vec(),
+                                    )
+                                    .unwrap()
+                                    .unwrap(),
+                            )
+                            .unwrap();
+                            if pending_receipt_count == 1
+                                && execution_outcome_ids.contains(&receipt_id)
+                            {
+                                new_execution_outcome_ids.push(receipt_id);
+                            }
+                        }
+                    }
                 }
             }
             assert_eq!(

--- a/core/store/src/migrations.rs
+++ b/core/store/src/migrations.rs
@@ -31,6 +31,7 @@ use near_primitives::merkle::merklize;
 use near_primitives::receipt::{DelayedReceiptIndices, Receipt, ReceiptEnum};
 use near_primitives::syncing::{ShardStateSyncResponseHeader, ShardStateSyncResponseHeaderV1};
 use near_primitives::trie_key::TrieKey;
+use near_primitives::types::StateRoot;
 use near_primitives::utils::{create_receipt_id_from_transaction, get_block_shard_id};
 use near_primitives::validator_signer::InMemoryValidatorSigner;
 
@@ -391,6 +392,49 @@ pub fn migrate_14_to_15(path: &String) {
             // Step 1: local receipts
             new_execution_outcome_ids.extend(local_receipt_ids);
 
+            let mut process_receipt =
+                |receipt: &Receipt, trie: &Trie, state_root: &StateRoot| match &receipt.receipt {
+                    ReceiptEnum::Action(_) => {
+                        if execution_outcome_ids.contains(&receipt.receipt_id) {
+                            new_execution_outcome_ids.push(receipt.receipt_id);
+                        }
+                    }
+                    ReceiptEnum::Data(data_receipt) => {
+                        if let Some(bytes) = trie
+                            .get(
+                                state_root,
+                                &TrieKey::PostponedReceiptId {
+                                    receiver_id: receipt.receiver_id.clone(),
+                                    data_id: data_receipt.data_id,
+                                }
+                                .to_vec(),
+                            )
+                            .unwrap()
+                        {
+                            let receipt_id = CryptoHash::try_from_slice(&bytes).unwrap();
+                            let pending_receipt_count = u32::try_from_slice(
+                                &trie
+                                    .get(
+                                        state_root,
+                                        &TrieKey::PendingDataCount {
+                                            receiver_id: receipt.receiver_id.clone(),
+                                            receipt_id,
+                                        }
+                                        .to_vec(),
+                                    )
+                                    .unwrap()
+                                    .unwrap(),
+                            )
+                            .unwrap();
+                            if pending_receipt_count == 1
+                                && execution_outcome_ids.contains(&receipt_id)
+                            {
+                                new_execution_outcome_ids.push(receipt_id);
+                            }
+                        }
+                    }
+                };
+
             // Step 2: delayed receipts
             let state_root = chunk.prev_state_root();
             if !local_receipt_congestion {
@@ -412,57 +456,14 @@ pub fn migrate_14_to_15(path: &String) {
                         .unwrap()
                         .map(|bytes| Receipt::try_from_slice(&bytes).unwrap())
                         .unwrap();
-                    if !execution_outcome_ids.contains(&receipt.receipt_id) {
-                        break;
-                    }
-                    new_execution_outcome_ids.push(receipt.receipt_id);
+                    process_receipt(&receipt, &trie, &state_root);
                     delayed_receipt_indices.first_index += 1;
                 }
             }
 
             // Step 3: receipts
             for receipt in chunk.receipts() {
-                match &receipt.receipt {
-                    ReceiptEnum::Action(_) => {
-                        if execution_outcome_ids.contains(&receipt.receipt_id) {
-                            new_execution_outcome_ids.push(receipt.receipt_id);
-                        }
-                    }
-                    ReceiptEnum::Data(data_receipt) => {
-                        if let Some(bytes) = trie
-                            .get(
-                                &state_root,
-                                &TrieKey::PostponedReceiptId {
-                                    receiver_id: receipt.receiver_id.clone(),
-                                    data_id: data_receipt.data_id,
-                                }
-                                .to_vec(),
-                            )
-                            .unwrap()
-                        {
-                            let receipt_id = CryptoHash::try_from_slice(&bytes).unwrap();
-                            let pending_receipt_count = u32::try_from_slice(
-                                &trie
-                                    .get(
-                                        &state_root,
-                                        &TrieKey::PendingDataCount {
-                                            receiver_id: receipt.receiver_id.clone(),
-                                            receipt_id,
-                                        }
-                                        .to_vec(),
-                                    )
-                                    .unwrap()
-                                    .unwrap(),
-                            )
-                            .unwrap();
-                            if pending_receipt_count == 1
-                                && execution_outcome_ids.contains(&receipt_id)
-                            {
-                                new_execution_outcome_ids.push(receipt_id);
-                            }
-                        }
-                    }
-                }
+                process_receipt(receipt, &trie, &state_root);
             }
             assert_eq!(
                 new_execution_outcome_ids.len(),


### PR DESCRIPTION
Currently in 14 -> 15 database migration we didn't take into account postponed receipts and therefore the migration can fail.

Test plan
---------
Test on testnet data that previously failed the migration.