### PR TITLE
Upgrade to OpenEthereum 2.6.2

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -1,14 +1,14 @@
 # NEAR Client Attributions
 
 We have taken inspiration and few pieces of code from:
- * [Parity Ethereum](https://github.com/paritytech/parity-ethereum)
+ * [OpenEthereum](https://github.com/openethereum/openethereum)
  * [Parity Substrate](https://github.com/paritytech/substrate)
  * [Parity Trie](https://github.com/paritytech/trie)
  * [Grin](https://github.com/mimblewimble/grin/)
 
 ## Licenses
 
-### Parity {Ethereum, Substrate}
+### OpenEthereum, Parity Substrate
 
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1462,7 +1462,7 @@ dependencies = [
 [[package]]
 name = "ethjson"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/parity-ethereum?rev=eed630a002bbebed3a3097127f2483213ff52079#eed630a002bbebed3a3097127f2483213ff52079"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.2#25936ae0f6d48f5ac6fb93cd467c15f4f8a631c2"
 dependencies = [
  "ethereum-types",
  "rustc-hex 1.0.0",
@@ -1474,16 +1474,16 @@ dependencies = [
 [[package]]
 name = "evm"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/parity-ethereum?rev=eed630a002bbebed3a3097127f2483213ff52079#eed630a002bbebed3a3097127f2483213ff52079"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.2#25936ae0f6d48f5ac6fb93cd467c15f4f8a631c2"
 dependencies = [
  "bit-set",
  "ethereum-types",
- "heapsize",
  "keccak-hash",
  "lazy_static",
  "log",
  "memory-cache",
  "parity-bytes",
+ "parity-util-mem",
  "parking_lot 0.7.1",
  "vm",
 ]
@@ -1901,9 +1901,15 @@ dependencies = [
 
 [[package]]
 name = "hash-db"
-version = "0.11.0"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03501f6e1a2a97f1618879aba3156f14ca2847faa530c4e28859638bd11483"
+checksum = "0b3c95a428c86ed4633d83e07ef9e0a147a906da01e931f07e74a85bedce5a43"
+
+[[package]]
+name = "hashmap_core"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6852e5a86250521973b0c1d39677166d8a9c0047c908d7e04f1aa04177973c"
 
 [[package]]
 name = "heapsize"
@@ -2308,7 +2314,7 @@ dependencies = [
 [[package]]
 name = "keccak-hasher"
 version = "0.1.1"
-source = "git+https://github.com/paritytech/parity-ethereum?rev=eed630a002bbebed3a3097127f2483213ff52079#eed630a002bbebed3a3097127f2483213ff52079"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.2#25936ae0f6d48f5ac6fb93cd467c15f4f8a631c2"
 dependencies = [
  "ethereum-types",
  "hash-db",
@@ -2525,6 +2531,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "malloc_size_of_derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e37c5d4cd9473c5f4c9c111f033f15d4df9bd378fdf615944e360a4f55a05f0b"
+dependencies = [
+ "proc-macro2 1.0.20",
+ "syn 1.0.38",
+ "synstructure",
+]
+
+[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2579,10 +2596,10 @@ dependencies = [
 [[package]]
 name = "memory-cache"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/parity-ethereum?rev=eed630a002bbebed3a3097127f2483213ff52079#eed630a002bbebed3a3097127f2483213ff52079"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.2#25936ae0f6d48f5ac6fb93cd467c15f4f8a631c2"
 dependencies = [
- "heapsize",
  "lru-cache",
+ "parity-util-mem",
 ]
 
 [[package]]
@@ -3657,6 +3674,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "parity-util-mem"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89e80f22052161e0cb55cb5a8a75890420c525031f95c9d262dbb0434aa85dc1"
+dependencies = [
+ "cfg-if",
+ "clear_on_drop",
+ "elastic-array 0.10.3",
+ "ethereum-types",
+ "malloc_size_of_derive",
+ "parking_lot 0.7.1",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "parity-wasm"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3738,7 +3770,7 @@ dependencies = [
 [[package]]
 name = "patricia-trie-ethereum"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/parity-ethereum?rev=eed630a002bbebed3a3097127f2483213ff52079#eed630a002bbebed3a3097127f2483213ff52079"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.2#25936ae0f6d48f5ac6fb93cd467c15f4f8a631c2"
 dependencies = [
  "elastic-array 0.10.3",
  "ethereum-types",
@@ -5281,12 +5313,13 @@ checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 
 [[package]]
 name = "trie-db"
-version = "0.11.0"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c7319e28ca295f27359d944a682f7f65b419158bf1590c92cadc0000258d788"
+checksum = "ae063390324bfcf36c7e8e4fb1f85f6f0fb5dd04e1cd282581eb7b8b34b32de7"
 dependencies = [
  "elastic-array 0.10.3",
  "hash-db",
+ "hashmap_core",
  "log",
  "rand 0.6.5",
 ]
@@ -5523,17 +5556,14 @@ checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 [[package]]
 name = "vm"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/parity-ethereum?rev=eed630a002bbebed3a3097127f2483213ff52079#eed630a002bbebed3a3097127f2483213ff52079"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.2#25936ae0f6d48f5ac6fb93cd467c15f4f8a631c2"
 dependencies = [
- "byteorder",
  "ethereum-types",
  "ethjson",
  "keccak-hash",
- "log",
  "parity-bytes",
  "patricia-trie-ethereum",
  "rlp",
- "trie-db",
 ]
 
 [[package]]

--- a/core/crypto/src/signature.rs
+++ b/core/crypto/src/signature.rs
@@ -625,7 +625,7 @@ impl Signature {
                 .unwrap();
                 let sig = rsig.to_standard(&SECP256K1);
                 let pdata: [u8; 65] = {
-                    // code borrowed from https://github.com/paritytech/parity-ethereum/blob/98b7c07171cd320f32877dfa5aa528f585dc9a72/ethkey/src/signature.rs#L210
+                    // code borrowed from https://github.com/openethereum/openethereum/blob/98b7c07171cd320f32877dfa5aa528f585dc9a72/ethkey/src/signature.rs#L210
                     let mut temp = [4u8; 65];
                     temp[1..65].copy_from_slice(&public_key.0);
                     temp

--- a/runtime/near-evm-runner/Cargo.toml
+++ b/runtime/near-evm-runner/Cargo.toml
@@ -24,8 +24,8 @@ keccak-hash = "0.2.0"
 ripemd160 = "0.9.0"
 libsecp256k1 = "0.3.5"
 
-evm = { git = "https://github.com/paritytech/parity-ethereum", rev = "eed630a002bbebed3a3097127f2483213ff52079" }
-vm = { git = "https://github.com/paritytech/parity-ethereum", rev = "eed630a002bbebed3a3097127f2483213ff52079" }
+evm = { git = "https://github.com/openethereum/openethereum", rev = "v2.6.2" }
+vm = { git = "https://github.com/openethereum/openethereum", rev = "v2.6.2" }
 bn = { git = "https://github.com/paritytech/bn", default-features = false }
 parity-bytes = "0.1.0"
 ethereum-types = "0.6.0"

--- a/runtime/near-evm-runner/src/near_ext.rs
+++ b/runtime/near-evm-runner/src/near_ext.rs
@@ -15,7 +15,7 @@ use crate::evm_state::{EvmState, SubState};
 use crate::interpreter;
 use crate::utils::format_log;
 
-// https://github.com/paritytech/parity-ethereum/blob/77643c13e80ca09d9a6b10631034f5a1568ba6d3/ethcore/machine/src/externalities.rs
+// https://github.com/openethereum/openethereum/blob/77643c13e80ca09d9a6b10631034f5a1568ba6d3/ethcore/machine/src/externalities.rs
 pub struct NearExt<'a> {
     pub info: EnvInfo,
     pub origin: Address,


### PR DESCRIPTION
As a first step in #3506, upgrade OpenEthereum from [pre-2.6.0](https://github.com/openethereum/openethereum/commit/eed630a002bbebed3a3097127f2483213ff52079) (Jun 2019) to [2.6.2](https://github.com/openethereum/openethereum/releases/tag/v2.6.2) (Aug 2019).

OpenEthereum 2.6.2 is the last release that nearcore can currently pull in without build errors. Further upgrades will require code changes in near-evm-runner. (I'm working on those.)

The upstream diff from what we currently pull in compared to 2.6.2: https://github.com/openethereum/openethereum/compare/eed630a...v2.6.2