### PR TITLE
Upgrade to OpenEthereum 2.6.8 (Istanbul support)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1500,7 +1500,7 @@ dependencies = [
 [[package]]
 name = "ethjson"
 version = "0.1.0"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.4#badb04502f425008d04b27802c5f30c681609a29"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.5#753b923ee9fe8c59e3a8464a5754456e80dffe1e"
 dependencies = [
  "ethereum-types",
  "rustc-hex 1.0.0",
@@ -1511,7 +1511,7 @@ dependencies = [
 [[package]]
 name = "evm"
 version = "0.1.0"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.4#badb04502f425008d04b27802c5f30c681609a29"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.5#753b923ee9fe8c59e3a8464a5754456e80dffe1e"
 dependencies = [
  "bit-set",
  "ethereum-types",
@@ -1521,7 +1521,7 @@ dependencies = [
  "memory-cache",
  "parity-bytes",
  "parity-util-mem",
- "parking_lot 0.7.1",
+ "parking_lot 0.9.0",
  "vm",
 ]
 
@@ -2365,7 +2365,7 @@ dependencies = [
 [[package]]
 name = "keccak-hasher"
 version = "0.1.1"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.4#badb04502f425008d04b27802c5f30c681609a29"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.5#753b923ee9fe8c59e3a8464a5754456e80dffe1e"
 dependencies = [
  "ethereum-types",
  "hash-db",
@@ -2647,7 +2647,7 @@ dependencies = [
 [[package]]
 name = "memory-cache"
 version = "0.1.0"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.4#badb04502f425008d04b27802c5f30c681609a29"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.5#753b923ee9fe8c59e3a8464a5754456e80dffe1e"
 dependencies = [
  "lru-cache",
  "parity-util-mem",
@@ -3765,6 +3765,17 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
+dependencies = [
+ "lock_api 0.3.4",
+ "parking_lot_core 0.6.2",
+ "rustc_version",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
@@ -3792,6 +3803,21 @@ checksum = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
 dependencies = [
  "libc",
  "rand 0.6.5",
+ "rustc_version",
+ "smallvec 0.6.13",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
+dependencies = [
+ "cfg-if",
+ "cloudabi 0.0.3",
+ "libc",
+ "redox_syscall",
  "rustc_version",
  "smallvec 0.6.13",
  "winapi 0.3.8",
@@ -3829,7 +3855,7 @@ dependencies = [
 [[package]]
 name = "patricia-trie-ethereum"
 version = "0.1.0"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.4#badb04502f425008d04b27802c5f30c681609a29"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.5#753b923ee9fe8c59e3a8464a5754456e80dffe1e"
 dependencies = [
  "elastic-array 0.10.3",
  "ethereum-types",
@@ -5655,7 +5681,7 @@ checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 [[package]]
 name = "vm"
 version = "0.1.0"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.4#badb04502f425008d04b27802c5f30c681609a29"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.5#753b923ee9fe8c59e3a8464a5754456e80dffe1e"
 dependencies = [
  "ethereum-types",
  "ethjson",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1500,19 +1500,18 @@ dependencies = [
 [[package]]
 name = "ethjson"
 version = "0.1.0"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.3#b7b1484f2e4b81641b0c1375ce9c88e4843796f1"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.4#badb04502f425008d04b27802c5f30c681609a29"
 dependencies = [
  "ethereum-types",
  "rustc-hex 1.0.0",
  "serde",
- "serde_derive",
  "serde_json",
 ]
 
 [[package]]
 name = "evm"
 version = "0.1.0"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.3#b7b1484f2e4b81641b0c1375ce9c88e4843796f1"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.4#badb04502f425008d04b27802c5f30c681609a29"
 dependencies = [
  "bit-set",
  "ethereum-types",
@@ -2366,7 +2365,7 @@ dependencies = [
 [[package]]
 name = "keccak-hasher"
 version = "0.1.1"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.3#b7b1484f2e4b81641b0c1375ce9c88e4843796f1"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.4#badb04502f425008d04b27802c5f30c681609a29"
 dependencies = [
  "ethereum-types",
  "hash-db",
@@ -2648,7 +2647,7 @@ dependencies = [
 [[package]]
 name = "memory-cache"
 version = "0.1.0"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.3#b7b1484f2e4b81641b0c1375ce9c88e4843796f1"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.4#badb04502f425008d04b27802c5f30c681609a29"
 dependencies = [
  "lru-cache",
  "parity-util-mem",
@@ -3830,7 +3829,7 @@ dependencies = [
 [[package]]
 name = "patricia-trie-ethereum"
 version = "0.1.0"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.3#b7b1484f2e4b81641b0c1375ce9c88e4843796f1"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.4#badb04502f425008d04b27802c5f30c681609a29"
 dependencies = [
  "elastic-array 0.10.3",
  "ethereum-types",
@@ -5656,7 +5655,7 @@ checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 [[package]]
 name = "vm"
 version = "0.1.0"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.3#b7b1484f2e4b81641b0c1375ce9c88e4843796f1"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.4#badb04502f425008d04b27802c5f30c681609a29"
 dependencies = [
  "ethereum-types",
  "ethjson",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1500,7 +1500,7 @@ dependencies = [
 [[package]]
 name = "ethjson"
 version = "0.1.0"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.7#ba1b879e9f9aae0e949c1530268d0ff7c0347cca"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.8#9bf6ed8450ec2eb61f14b362574c453ed68bd761"
 dependencies = [
  "ethereum-types",
  "rustc-hex 1.0.0",
@@ -1511,7 +1511,7 @@ dependencies = [
 [[package]]
 name = "evm"
 version = "0.1.0"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.7#ba1b879e9f9aae0e949c1530268d0ff7c0347cca"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.8#9bf6ed8450ec2eb61f14b362574c453ed68bd761"
 dependencies = [
  "bit-set",
  "ethereum-types",
@@ -2365,7 +2365,7 @@ dependencies = [
 [[package]]
 name = "keccak-hasher"
 version = "0.1.1"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.7#ba1b879e9f9aae0e949c1530268d0ff7c0347cca"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.8#9bf6ed8450ec2eb61f14b362574c453ed68bd761"
 dependencies = [
  "ethereum-types",
  "hash-db",
@@ -2647,7 +2647,7 @@ dependencies = [
 [[package]]
 name = "memory-cache"
 version = "0.1.0"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.7#ba1b879e9f9aae0e949c1530268d0ff7c0347cca"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.8#9bf6ed8450ec2eb61f14b362574c453ed68bd761"
 dependencies = [
  "lru-cache",
  "parity-util-mem",
@@ -3855,7 +3855,7 @@ dependencies = [
 [[package]]
 name = "patricia-trie-ethereum"
 version = "0.1.0"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.7#ba1b879e9f9aae0e949c1530268d0ff7c0347cca"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.8#9bf6ed8450ec2eb61f14b362574c453ed68bd761"
 dependencies = [
  "elastic-array 0.10.3",
  "ethereum-types",
@@ -5681,7 +5681,7 @@ checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 [[package]]
 name = "vm"
 version = "0.1.0"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.7#ba1b879e9f9aae0e949c1530268d0ff7c0347cca"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.8#9bf6ed8450ec2eb61f14b362574c453ed68bd761"
 dependencies = [
  "ethereum-types",
  "ethjson",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1500,7 +1500,7 @@ dependencies = [
 [[package]]
 name = "ethjson"
 version = "0.1.0"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.2#25936ae0f6d48f5ac6fb93cd467c15f4f8a631c2"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.3#b7b1484f2e4b81641b0c1375ce9c88e4843796f1"
 dependencies = [
  "ethereum-types",
  "rustc-hex 1.0.0",
@@ -1512,7 +1512,7 @@ dependencies = [
 [[package]]
 name = "evm"
 version = "0.1.0"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.2#25936ae0f6d48f5ac6fb93cd467c15f4f8a631c2"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.3#b7b1484f2e4b81641b0c1375ce9c88e4843796f1"
 dependencies = [
  "bit-set",
  "ethereum-types",
@@ -2366,7 +2366,7 @@ dependencies = [
 [[package]]
 name = "keccak-hasher"
 version = "0.1.1"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.2#25936ae0f6d48f5ac6fb93cd467c15f4f8a631c2"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.3#b7b1484f2e4b81641b0c1375ce9c88e4843796f1"
 dependencies = [
  "ethereum-types",
  "hash-db",
@@ -2648,7 +2648,7 @@ dependencies = [
 [[package]]
 name = "memory-cache"
 version = "0.1.0"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.2#25936ae0f6d48f5ac6fb93cd467c15f4f8a631c2"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.3#b7b1484f2e4b81641b0c1375ce9c88e4843796f1"
 dependencies = [
  "lru-cache",
  "parity-util-mem",
@@ -3830,7 +3830,7 @@ dependencies = [
 [[package]]
 name = "patricia-trie-ethereum"
 version = "0.1.0"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.2#25936ae0f6d48f5ac6fb93cd467c15f4f8a631c2"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.3#b7b1484f2e4b81641b0c1375ce9c88e4843796f1"
 dependencies = [
  "elastic-array 0.10.3",
  "ethereum-types",
@@ -5656,7 +5656,7 @@ checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 [[package]]
 name = "vm"
 version = "0.1.0"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.2#25936ae0f6d48f5ac6fb93cd467c15f4f8a631c2"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.3#b7b1484f2e4b81641b0c1375ce9c88e4843796f1"
 dependencies = [
  "ethereum-types",
  "ethjson",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1500,7 +1500,7 @@ dependencies = [
 [[package]]
 name = "ethjson"
 version = "0.1.0"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.6#5162bc2c882e9210b74131e65145cc725a8b6a35"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.7#ba1b879e9f9aae0e949c1530268d0ff7c0347cca"
 dependencies = [
  "ethereum-types",
  "rustc-hex 1.0.0",
@@ -1511,7 +1511,7 @@ dependencies = [
 [[package]]
 name = "evm"
 version = "0.1.0"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.6#5162bc2c882e9210b74131e65145cc725a8b6a35"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.7#ba1b879e9f9aae0e949c1530268d0ff7c0347cca"
 dependencies = [
  "bit-set",
  "ethereum-types",
@@ -2365,7 +2365,7 @@ dependencies = [
 [[package]]
 name = "keccak-hasher"
 version = "0.1.1"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.6#5162bc2c882e9210b74131e65145cc725a8b6a35"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.7#ba1b879e9f9aae0e949c1530268d0ff7c0347cca"
 dependencies = [
  "ethereum-types",
  "hash-db",
@@ -2647,7 +2647,7 @@ dependencies = [
 [[package]]
 name = "memory-cache"
 version = "0.1.0"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.6#5162bc2c882e9210b74131e65145cc725a8b6a35"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.7#ba1b879e9f9aae0e949c1530268d0ff7c0347cca"
 dependencies = [
  "lru-cache",
  "parity-util-mem",
@@ -3855,7 +3855,7 @@ dependencies = [
 [[package]]
 name = "patricia-trie-ethereum"
 version = "0.1.0"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.6#5162bc2c882e9210b74131e65145cc725a8b6a35"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.7#ba1b879e9f9aae0e949c1530268d0ff7c0347cca"
 dependencies = [
  "elastic-array 0.10.3",
  "ethereum-types",
@@ -5681,7 +5681,7 @@ checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 [[package]]
 name = "vm"
 version = "0.1.0"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.6#5162bc2c882e9210b74131e65145cc725a8b6a35"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.7#ba1b879e9f9aae0e949c1530268d0ff7c0347cca"
 dependencies = [
  "ethereum-types",
  "ethjson",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1500,7 +1500,7 @@ dependencies = [
 [[package]]
 name = "ethjson"
 version = "0.1.0"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.5#753b923ee9fe8c59e3a8464a5754456e80dffe1e"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.6#5162bc2c882e9210b74131e65145cc725a8b6a35"
 dependencies = [
  "ethereum-types",
  "rustc-hex 1.0.0",
@@ -1511,7 +1511,7 @@ dependencies = [
 [[package]]
 name = "evm"
 version = "0.1.0"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.5#753b923ee9fe8c59e3a8464a5754456e80dffe1e"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.6#5162bc2c882e9210b74131e65145cc725a8b6a35"
 dependencies = [
  "bit-set",
  "ethereum-types",
@@ -2365,7 +2365,7 @@ dependencies = [
 [[package]]
 name = "keccak-hasher"
 version = "0.1.1"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.5#753b923ee9fe8c59e3a8464a5754456e80dffe1e"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.6#5162bc2c882e9210b74131e65145cc725a8b6a35"
 dependencies = [
  "ethereum-types",
  "hash-db",
@@ -2647,7 +2647,7 @@ dependencies = [
 [[package]]
 name = "memory-cache"
 version = "0.1.0"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.5#753b923ee9fe8c59e3a8464a5754456e80dffe1e"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.6#5162bc2c882e9210b74131e65145cc725a8b6a35"
 dependencies = [
  "lru-cache",
  "parity-util-mem",
@@ -3855,7 +3855,7 @@ dependencies = [
 [[package]]
 name = "patricia-trie-ethereum"
 version = "0.1.0"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.5#753b923ee9fe8c59e3a8464a5754456e80dffe1e"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.6#5162bc2c882e9210b74131e65145cc725a8b6a35"
 dependencies = [
  "elastic-array 0.10.3",
  "ethereum-types",
@@ -5681,7 +5681,7 @@ checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 [[package]]
 name = "vm"
 version = "0.1.0"
-source = "git+https://github.com/openethereum/openethereum?rev=v2.6.5#753b923ee9fe8c59e3a8464a5754456e80dffe1e"
+source = "git+https://github.com/openethereum/openethereum?rev=v2.6.6#5162bc2c882e9210b74131e65145cc725a8b6a35"
 dependencies = [
  "ethereum-types",
  "ethjson",

--- a/runtime/near-evm-runner/Cargo.toml
+++ b/runtime/near-evm-runner/Cargo.toml
@@ -24,8 +24,8 @@ keccak-hash = "0.2.0"
 ripemd160 = "0.9.0"
 libsecp256k1 = "0.3.5"
 
-evm = { git = "https://github.com/openethereum/openethereum", rev = "v2.6.4" }
-vm = { git = "https://github.com/openethereum/openethereum", rev = "v2.6.4" }
+evm = { git = "https://github.com/openethereum/openethereum", rev = "v2.6.5" }
+vm = { git = "https://github.com/openethereum/openethereum", rev = "v2.6.5" }
 bn = { git = "https://github.com/paritytech/bn", default-features = false }
 parity-bytes = "0.1.0"
 ethereum-types = "0.6.0"

--- a/runtime/near-evm-runner/Cargo.toml
+++ b/runtime/near-evm-runner/Cargo.toml
@@ -24,8 +24,8 @@ keccak-hash = "0.2.0"
 ripemd160 = "0.9.0"
 libsecp256k1 = "0.3.5"
 
-evm = { git = "https://github.com/openethereum/openethereum", rev = "v2.6.5" }
-vm = { git = "https://github.com/openethereum/openethereum", rev = "v2.6.5" }
+evm = { git = "https://github.com/openethereum/openethereum", rev = "v2.6.6" }
+vm = { git = "https://github.com/openethereum/openethereum", rev = "v2.6.6" }
 bn = { git = "https://github.com/paritytech/bn", default-features = false }
 parity-bytes = "0.1.0"
 ethereum-types = "0.6.0"

--- a/runtime/near-evm-runner/Cargo.toml
+++ b/runtime/near-evm-runner/Cargo.toml
@@ -24,8 +24,8 @@ keccak-hash = "0.2.0"
 ripemd160 = "0.9.0"
 libsecp256k1 = "0.3.5"
 
-evm = { git = "https://github.com/openethereum/openethereum", rev = "v2.6.7" }
-vm = { git = "https://github.com/openethereum/openethereum", rev = "v2.6.7" }
+evm = { git = "https://github.com/openethereum/openethereum", rev = "v2.6.8" }
+vm = { git = "https://github.com/openethereum/openethereum", rev = "v2.6.8" }
 bn = { git = "https://github.com/paritytech/bn", default-features = false }
 parity-bytes = "0.1.0"
 ethereum-types = "0.6.0"

--- a/runtime/near-evm-runner/Cargo.toml
+++ b/runtime/near-evm-runner/Cargo.toml
@@ -24,8 +24,8 @@ keccak-hash = "0.2.0"
 ripemd160 = "0.9.0"
 libsecp256k1 = "0.3.5"
 
-evm = { git = "https://github.com/openethereum/openethereum", rev = "v2.6.2" }
-vm = { git = "https://github.com/openethereum/openethereum", rev = "v2.6.2" }
+evm = { git = "https://github.com/openethereum/openethereum", rev = "v2.6.3" }
+vm = { git = "https://github.com/openethereum/openethereum", rev = "v2.6.3" }
 bn = { git = "https://github.com/paritytech/bn", default-features = false }
 parity-bytes = "0.1.0"
 ethereum-types = "0.6.0"

--- a/runtime/near-evm-runner/Cargo.toml
+++ b/runtime/near-evm-runner/Cargo.toml
@@ -24,8 +24,8 @@ keccak-hash = "0.2.0"
 ripemd160 = "0.9.0"
 libsecp256k1 = "0.3.5"
 
-evm = { git = "https://github.com/openethereum/openethereum", rev = "v2.6.3" }
-vm = { git = "https://github.com/openethereum/openethereum", rev = "v2.6.3" }
+evm = { git = "https://github.com/openethereum/openethereum", rev = "v2.6.4" }
+vm = { git = "https://github.com/openethereum/openethereum", rev = "v2.6.4" }
 bn = { git = "https://github.com/paritytech/bn", default-features = false }
 parity-bytes = "0.1.0"
 ethereum-types = "0.6.0"

--- a/runtime/near-evm-runner/Cargo.toml
+++ b/runtime/near-evm-runner/Cargo.toml
@@ -24,8 +24,8 @@ keccak-hash = "0.2.0"
 ripemd160 = "0.9.0"
 libsecp256k1 = "0.3.5"
 
-evm = { git = "https://github.com/openethereum/openethereum", rev = "v2.6.6" }
-vm = { git = "https://github.com/openethereum/openethereum", rev = "v2.6.6" }
+evm = { git = "https://github.com/openethereum/openethereum", rev = "v2.6.7" }
+vm = { git = "https://github.com/openethereum/openethereum", rev = "v2.6.7" }
 bn = { git = "https://github.com/paritytech/bn", default-features = false }
 parity-bytes = "0.1.0"
 ethereum-types = "0.6.0"

--- a/runtime/near-evm-runner/src/interpreter.rs
+++ b/runtime/near-evm-runner/src/interpreter.rs
@@ -26,6 +26,7 @@ pub fn deploy_code<T: EvmState>(
     code: &[u8],
     gas: &U256,
     evm_gas_config: &EvmCostConfig,
+    chain_id: u128,
 ) -> Result<ContractCreateResult> {
     let mut nonce = U256::zero();
     if address_type == CreateContractAddress::FromSenderAndNonce {
@@ -49,6 +50,7 @@ pub fn deploy_code<T: EvmState>(
         code,
         gas,
         evm_gas_config,
+        chain_id,
     )?;
 
     // Apply known gas amount changes (all reverts are NeedsReturn)
@@ -82,6 +84,7 @@ pub fn _create<T: EvmState>(
     code: &[u8],
     gas: &U256,
     evm_gas_config: &EvmCostConfig,
+    chain_id: u128,
 ) -> Result<(ExecTrapResult<GasLeft>, Option<StateStore>)> {
     let mut store = StateStore::default();
     let mut sub_state = SubState::new(sender, &mut store, state);
@@ -110,6 +113,7 @@ pub fn _create<T: EvmState>(
         call_stack_depth + 1,
         false,
         evm_gas_config,
+        chain_id,
     );
     ext.info.gas_limit = U256::from(gas);
     ext.schedule = Schedule::new_constantinople();
@@ -133,6 +137,7 @@ pub fn call<T: EvmState>(
     should_commit: bool,
     gas: &U256,
     evm_gas_config: &EvmCostConfig,
+    chain_id: u128,
 ) -> Result<MessageCallResult> {
     run_and_commit_if_success(
         state,
@@ -148,6 +153,7 @@ pub fn call<T: EvmState>(
         should_commit,
         gas,
         evm_gas_config,
+        chain_id,
     )
 }
 
@@ -161,6 +167,7 @@ pub fn delegate_call<T: EvmState>(
     input: &[u8],
     gas: &U256,
     evm_gas_config: &EvmCostConfig,
+    chain_id: u128,
 ) -> Result<MessageCallResult> {
     run_and_commit_if_success(
         state,
@@ -176,6 +183,7 @@ pub fn delegate_call<T: EvmState>(
         true,
         gas,
         evm_gas_config,
+        chain_id,
     )
 }
 
@@ -188,6 +196,7 @@ pub fn static_call<T: EvmState>(
     input: &[u8],
     gas: &U256,
     evm_gas_config: &EvmCostConfig,
+    chain_id: u128,
 ) -> Result<MessageCallResult> {
     run_and_commit_if_success(
         state,
@@ -203,6 +212,7 @@ pub fn static_call<T: EvmState>(
         false,
         gas,
         evm_gas_config,
+        chain_id,
     )
 }
 
@@ -221,6 +231,7 @@ fn run_and_commit_if_success<T: EvmState>(
     should_commit: bool,
     gas: &U256,
     evm_gas_config: &EvmCostConfig,
+    chain_id: u128,
 ) -> Result<MessageCallResult> {
     // run the interpreter and
     let (result, state_updates) = run_against_state(
@@ -236,6 +247,7 @@ fn run_and_commit_if_success<T: EvmState>(
         is_static,
         gas,
         evm_gas_config,
+        chain_id,
     )?;
 
     // Apply known gas amount changes (all reverts are NeedsReturn)
@@ -279,6 +291,7 @@ fn run_against_state<T: EvmState>(
     is_static: bool,
     gas: &U256,
     evm_gas_config: &EvmCostConfig,
+    chain_id: u128,
 ) -> Result<(ExecTrapResult<GasLeft>, Option<StateStore>)> {
     let code = state.code_at(code_address)?.unwrap_or_else(Vec::new);
 
@@ -319,6 +332,7 @@ fn run_against_state<T: EvmState>(
         call_stack_depth + 1,
         is_static,
         evm_gas_config,
+        chain_id,
     );
     // Gas limit is evm block gas limit, should at least prepaid gas.
     ext.info.gas_limit = *gas;

--- a/runtime/near-evm-runner/src/lib.rs
+++ b/runtime/near-evm-runner/src/lib.rs
@@ -39,6 +39,7 @@ pub struct EvmContext<'a> {
     gas_counter: GasCounter,
     pub evm_gas_counter: EvmGasCounter,
     fees_config: &'a RuntimeFeesConfig,
+    chain_id: u128,
     domain_separator: RawU256,
 }
 
@@ -181,6 +182,7 @@ impl<'a> EvmContext<'a> {
             ),
             evm_gas_counter: EvmGasCounter::new(0.into(), evm_gas),
             fees_config,
+            chain_id,
             domain_separator,
         }
     }
@@ -203,6 +205,7 @@ impl<'a> EvmContext<'a> {
             &bytecode,
             &self.evm_gas_counter.gas_left(),
             &self.fees_config.evm_config,
+            self.chain_id,
         )? {
             ContractCreateResult::Created(address, gas_left) => {
                 self.evm_gas_counter.set_gas_left(gas_left);
@@ -241,6 +244,7 @@ impl<'a> EvmContext<'a> {
             true,
             &self.evm_gas_counter.gas_left(),
             &self.fees_config.evm_config,
+            self.chain_id,
         )?;
         match result {
             MessageCallResult::Success(gas_left, data) => {
@@ -277,6 +281,7 @@ impl<'a> EvmContext<'a> {
             true,
             &self.evm_gas_counter.gas_left(),
             &self.fees_config.evm_config,
+            self.chain_id,
         )?;
         match result {
             MessageCallResult::Success(gas_left, data) => {
@@ -313,6 +318,7 @@ impl<'a> EvmContext<'a> {
             false,
             &self.evm_gas_counter.gas_left(),
             &self.fees_config.evm_config,
+            self.chain_id,
         )?;
         let result = match result {
             MessageCallResult::Success(gas_left, data) => {

--- a/runtime/near-evm-runner/src/near_ext.rs
+++ b/runtime/near-evm-runner/src/near_ext.rs
@@ -64,6 +64,10 @@ impl<'a> NearExt<'a> {
 }
 
 impl<'a> vm::Ext for NearExt<'a> {
+    /// EIP-1344: Returns the current chain's EIP-155 unique identifier.
+    /// See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1344.md
+    fn chain_id(&self) -> u64 { todo!() }
+
     /// Returns the storage value for a given key if reversion happens on the current transaction.
     fn initial_storage_at(&self, key: &H256) -> EvmResult<H256> {
         let raw_val = self

--- a/runtime/near-evm-runner/src/near_ext.rs
+++ b/runtime/near-evm-runner/src/near_ext.rs
@@ -1,3 +1,4 @@
+use std::convert::TryInto;
 use std::sync::Arc;
 
 use ethereum_types::{Address, H256, U256};
@@ -26,6 +27,7 @@ pub struct NearExt<'a> {
     pub static_flag: bool,
     pub depth: usize,
     pub evm_gas_config: &'a EvmCostConfig,
+    pub chain_id: u128,
 }
 
 impl std::fmt::Debug for NearExt<'_> {
@@ -36,6 +38,7 @@ impl std::fmt::Debug for NearExt<'_> {
         write!(f, "\n\tcontext_addr: {:?}", self.context_addr)?;
         write!(f, "\n\tstatic_flag: {:?}", self.static_flag)?;
         write!(f, "\n\tdepth: {:?}", self.depth)?;
+        write!(f, "\n\tchain_id: {:?}", self.chain_id)?;
         write!(f, "\n}}")
     }
 }
@@ -48,6 +51,7 @@ impl<'a> NearExt<'a> {
         depth: usize,
         static_flag: bool,
         evm_gas_config: &'a EvmCostConfig,
+        chain_id: u128,
     ) -> Self {
         Self {
             info: Default::default(),
@@ -59,6 +63,7 @@ impl<'a> NearExt<'a> {
             static_flag,
             depth,
             evm_gas_config,
+            chain_id,
         }
     }
 }
@@ -66,7 +71,9 @@ impl<'a> NearExt<'a> {
 impl<'a> vm::Ext for NearExt<'a> {
     /// EIP-1344: Returns the current chain's EIP-155 unique identifier.
     /// See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1344.md
-    fn chain_id(&self) -> u64 { todo!() }
+    fn chain_id(&self) -> u64 {
+      self.chain_id.try_into().unwrap()
+    }
 
     /// Returns the storage value for a given key if reversion happens on the current transaction.
     fn initial_storage_at(&self, key: &H256) -> EvmResult<H256> {
@@ -154,6 +161,7 @@ impl<'a> vm::Ext for NearExt<'a> {
             &code.to_vec(),
             gas,
             &self.evm_gas_config,
+            self.chain_id,
         )
         .map_err(|_| TrapKind::Call(ActionParams::default()))
     }
@@ -204,6 +212,7 @@ impl<'a> vm::Ext for NearExt<'a> {
                 true, // should_commit
                 gas,
                 &self.evm_gas_config,
+                self.chain_id,
             ),
             CallType::StaticCall => interpreter::static_call(
                 self.sub_state,
@@ -214,6 +223,7 @@ impl<'a> vm::Ext for NearExt<'a> {
                 &data.to_vec(),
                 gas,
                 &self.evm_gas_config,
+                self.chain_id,
             ),
             CallType::CallCode => {
                 // Call another contract using storage of the current contract. No longer used.
@@ -229,6 +239,7 @@ impl<'a> vm::Ext for NearExt<'a> {
                 &data.to_vec(),
                 gas,
                 &self.evm_gas_config,
+                self.chain_id,
             ),
         };
         result.map_err(|_| TrapKind::Call(ActionParams::default()))


### PR DESCRIPTION
As the next step in #3506, and following up from #3542, upgrade OpenEthereum from [2.6.2](https://github.com/openethereum/openethereum/releases/tag/v2.6.2) (Aug 2019) to [2.6.8](https://github.com/openethereum/openethereum/releases/tag/v2.6.8) (Dec 2019), the last release in the 2.6.x series.

This brings us up to par on the [Istanbul](https://eth.wiki/en/roadmap/istanbul) hard fork, which incorporated many EIPs, changing gas metering and adding a new precompile as well as two new opcodes:

- [EIP-152: Add BLAKE2 compression function `F` precompile](https://eips.ethereum.org/EIPS/eip-152)
- [EIP-1108: Reduce alt_bn128 precompile gas costs](https://eips.ethereum.org/EIPS/eip-1108)
- [EIP-1344: ChainID opcode](https://eips.ethereum.org/EIPS/eip-1344) (includes a new opcode: `CHAINID`)
- [EIP-1884: Repricing for trie-size-dependent opcodes](https://eips.ethereum.org/EIPS/eip-1884) (includes a new opcode: `SELFBALANCE`)
- [EIP-2028: Transaction data gas cost reduction](https://eips.ethereum.org/EIPS/eip-2028)
- [EIP-2200: Structured Definitions for Net Gas Metering](https://eips.ethereum.org/EIPS/eip-2200)

This PR includes an implementation of the `CHAINID` opcode. (The `SELFBALANCE` opcode doesn't need anything from our runtime.)

The upstream changelog for 2.6.8 is at: https://github.com/openethereum/openethereum/blob/v2.6.8/CHANGELOG.md

The upstream diff from 2.6.2 to 2.6.8 is at: https://github.com/openethereum/openethereum/compare/v2.6.2...v2.6.8