### PR TITLE
Added --no-ansi flag to disable coloring and ansi chars in logging

### DIFF
--- a/neard/src/main.rs
+++ b/neard/src/main.rs
@@ -18,7 +18,7 @@ use neard::config::init_testnet_configs;
 use neard::genesis_validate::validate_genesis;
 use neard::{get_default_home, get_store_path, init_configs, load_config, start_with_config};
 
-fn init_logging(verbose: Option<&str>) {
+fn init_logging(verbose: Option<&str>, ansi: bool) {
     let mut env_filter = EnvFilter::new(
         "tokio_reactor=info,near=info,stats=info,telemetry=info,delay_detector=info",
     );
@@ -56,6 +56,7 @@ fn init_logging(verbose: Option<&str>) {
     tracing_subscriber::fmt::Subscriber::builder()
         .with_env_filter(env_filter)
         .with_writer(io::stderr)
+        .with_ansi(ansi)
         .init();
 }
 
@@ -78,6 +79,7 @@ fn main() {
                 .help("Directory for config and data (default \"~/.near\")")
                 .takes_value(true),
         )
+        .arg(Arg::with_name("no-color").long("no-color").takes_value(false).help("Disable ansi charset and colored logging."))
         .subcommand(SubCommand::with_name("init").about("Initializes NEAR configuration")
             .arg(Arg::with_name("chain-id").long("chain-id").takes_value(true).help("Chain ID, by default creates new random"))
             .arg(Arg::with_name("account-id").long("account-id").takes_value(true).help("Account ID for the validator key"))
@@ -107,7 +109,7 @@ fn main() {
         .subcommand(SubCommand::with_name("unsafe_reset_all").about("(unsafe) Remove all the config, keys, data and effectively removing all information about the network"))
         .get_matches();
 
-    init_logging(matches.value_of("verbose"));
+    init_logging(matches.value_of("verbose"), !matches.is_present("no-color"));
     info!(target: "near", "Version: {}, Build: {}, Latest Protocol: {}", version.version, version.build, PROTOCOL_VERSION);
 
     #[cfg(feature = "adversarial")]


### PR DESCRIPTION
Added no-ansi flag to disable coloring in neard and special chars:

`
sandi@sandi-ThinkPad-X1-Carbon-7th ~/w/n/nearcore (master)> ./target/debug/near --no-ansi run
`


`                                                                                                                                                                                                                                                                   sandi@sandi-ThinkPad-X1-Carbon-7th ~/w/n/nearcore (master)> ./target/debug/near run
`  