### PR TITLE
fix(test): Use all the cpus on the machine for running parallel tests…

### DIFF
--- a/scripts/flaky_test_check.py
+++ b/scripts/flaky_test_check.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import os
-from testlib import clean_binary_tests, build_tests, test_binaries, workers, run_test
+from testlib import clean_binary_tests, build_tests, test_binaries, run_test
 from concurrent.futures import as_completed, ThreadPoolExecutor
 
 TIMES = 10

--- a/scripts/parallel_coverage.py
+++ b/scripts/parallel_coverage.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 import os
-from testlib import clean_binary_tests, build_tests, test_binaries, workers, current_path
+from testlib import clean_binary_tests, build_tests, test_binaries, current_path
 from concurrent.futures import ThreadPoolExecutor, as_completed, wait
 import subprocess
 import sys
 import glob
 from itertools import zip_longest
+from multiprocessing import cpu_count
 
 
 def grouper(iterable, n, fillvalue=None):
@@ -78,7 +79,7 @@ if __name__ == "__main__":
     errors = False
 
     # Run coverage
-    with ThreadPoolExecutor(max_workers=workers()) as executor:
+    with ThreadPoolExecutor(max_workers=cpu_count()) as executor:
         future_to_binary = {
             executor.submit(coverage, binary): binary for binary in binaries
         }
@@ -97,7 +98,7 @@ if __name__ == "__main__":
     # Merge coverage
     i = 0
     j = 0
-    with ThreadPoolExecutor(max_workers=workers()) as executor:
+    with ThreadPoolExecutor(max_workers=cpu_count()) as executor:
         while True:
             covs = glob.glob(f'{coverage_dir(i)}/*')
             if len(covs) == 1:

--- a/scripts/parallel_run_tests.py
+++ b/scripts/parallel_run_tests.py
@@ -2,8 +2,10 @@
 import argparse
 import os
 
-from testlib import clean_binary_tests, build_tests, test_binaries, workers, run_test, run_doc_tests
 from concurrent.futures import as_completed, ThreadPoolExecutor
+from multiprocessing import cpu_count
+
+from testlib import clean_binary_tests, build_tests, test_binaries, run_test, run_doc_tests
 
 RERUN_THRESHOLD = 5
 
@@ -34,7 +36,7 @@ if __name__ == "__main__":
 
     completed = 0
     fails = []
-    with ThreadPoolExecutor(max_workers=workers()) as executor:
+    with ThreadPoolExecutor(max_workers=cpu_count()) as executor:
         future_to_binary = {
             executor.submit(run_test, binary): binary for binary in binaries
         }

--- a/scripts/testlib.py
+++ b/scripts/testlib.py
@@ -4,7 +4,6 @@ import glob
 import os
 import subprocess
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from multiprocessing import cpu_count
 import fcntl
 import re
 import filecmp
@@ -47,12 +46,6 @@ def run_doc_tests(nightly=False):
     p = subprocess.run(command)
     if p.returncode != 0:
         os._exit(p.returncode)
-
-
-def workers():
-    workers = cpu_count() // 2
-    print(f'========= run in {workers} workers')
-    return workers
 
 
 def test_binaries(exclude=None):


### PR DESCRIPTION
… and coverage instead half of them

We currently use just 2 cpus for running the tests and coverage, but I don't see any reason why this should be the case. Changed it to use all cpus instead.