### PR TITLE
Change per column rocksdb block cache size from 180mb to 32mb

### DIFF
--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -485,8 +485,8 @@ fn rocksdb_options() -> Options {
 fn rocksdb_block_based_options() -> BlockBasedOptions {
     let mut block_opts = BlockBasedOptions::default();
     block_opts.set_block_size(1024 * 16);
-    // We create block_cache for each of 47 columns, so the total cache size is 1 * 47 = 47mb
-    let cache_size = 1024 * 1024 * 1;
+    // We create block_cache for each of 47 columns, so the total cache size is 32 * 47 = 1504mb
+    let cache_size = 1024 * 1024 * 32;
     block_opts.set_block_cache(&Cache::new_lru_cache(cache_size).unwrap());
     block_opts.set_pin_l0_filter_and_index_blocks_in_cache(true);
     block_opts.set_cache_index_and_filter_blocks(true);


### PR DESCRIPTION
Rocksdb block size cache gets allocated per column. Currently it's 47*180 mb = 8.5gb.
By decreasing rocksdb block cache size to 32mb, we will decrease total cache size to 1.5gb.

In the future total cache size can be decreased by fine tuning cache sizes per column.