### PR TITLE
set db_write_buffer_size for RocksDB to 64mb

### DIFF
--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -462,6 +462,7 @@ fn rocksdb_options() -> Options {
     opts.set_keep_log_file_num(1);
     opts.set_bytes_per_sync(1048576);
     opts.set_write_buffer_size(1024 * 1024 * 512 / 2);
+    opts.set_db_write_buffer_size(1024 * 1024 * 64);
     opts.set_max_bytes_for_level_base(1024 * 1024 * 512 / 2);
     #[cfg(not(feature = "single_thread_rocksdb"))]
     {


### PR DESCRIPTION
Currently we have a limit of single write buffer size to 256mb. However, it's column has it's own write buffer, so the total size of all write buffers can be up to 12gb.
We should set db_write_buffer_size to 512mb, which limit total size of all write buffers to be 512mb. RocksDB recommends setting it no lower than 2mb for spinning disks.