### PR TITLE
fix(Increase historgram levels up to 30)

### DIFF
--- a/chain/jsonrpc/src/metrics.rs
+++ b/chain/jsonrpc/src/metrics.rs
@@ -6,7 +6,8 @@ lazy_static! {
         near_metrics::try_create_histogram_vec(
             "near_rpc_processing_time",
             "Time taken to process rpc queries",
-            &["method"]
+            &["method"],
+            Some(prometheus::exponential_buckets(0.001, 2.0, 16).unwrap())
         );
     pub static ref RPC_TIMEOUT_TOTAL: near_metrics::Result<IntCounter> =
         near_metrics::try_create_int_counter(
@@ -15,23 +16,23 @@ lazy_static! {
         );
     pub static ref PROMETHEUS_REQUEST_COUNT: near_metrics::Result<IntCounter> =
         near_metrics::try_create_int_counter(
-            "http_prometheus_requests_total",
+            "near_http_prometheus_requests_total",
             "Total count of Prometheus requests received"
         );
     pub static ref HTTP_RPC_REQUEST_COUNT: near_metrics::Result<IntCounterVec> =
         near_metrics::try_create_int_counter_vec(
-            "http_rpc_requests_total",
+            "near_rpc_total_count",
             "Total count of HTTP RPC requests received, by method",
             &["method"]
         );
     pub static ref HTTP_STATUS_REQUEST_COUNT: near_metrics::Result<IntCounter> =
         near_metrics::try_create_int_counter(
-            "http_status_requests_total",
+            "near_http_status_requests_total",
             "Total count of HTTP Status requests received"
         );
     pub static ref RPC_ERROR_COUNT: near_metrics::Result<IntCounterVec> =
         near_metrics::try_create_int_counter_vec(
-            "rpc_error_count",
+            "near_rpc_error_count",
             "Total count of errors by method and message",
             &["method", "err_code"]
         );

--- a/core/metrics/src/lib.rs
+++ b/core/metrics/src/lib.rs
@@ -109,8 +109,16 @@ pub fn try_create_histogram(name: &str, help: &str) -> Result<Histogram> {
 
 /// Attempts to create a `HistogramVector`, returning `Err` if the registry does not accept the counter
 /// (potentially due to naming conflict).
-pub fn try_create_histogram_vec(name: &str, help: &str, labels: &[&str]) -> Result<HistogramVec> {
-    let opts = HistogramOpts::new(name, help);
+pub fn try_create_histogram_vec(
+    name: &str,
+    help: &str,
+    labels: &[&str],
+    buckets: Option<Vec<f64>>,
+) -> Result<HistogramVec> {
+    let mut opts = HistogramOpts::new(name, help);
+    if let Some(buckets) = buckets {
+        opts = opts.buckets(buckets);
+    }
     let histogram = HistogramVec::new(opts, labels)?;
     prometheus::register(Box::new(histogram.clone()))?;
     Ok(histogram)


### PR DESCRIPTION
Instaead of default use exponential histogram buckets.
Renaming of existing rpc metrics to all start with near_rpc.