### PR TITLE
fix(chain): validate chunk mask

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3181,10 +3181,7 @@ impl<'a> ChainUpdate<'a> {
             return Err(ErrorKind::InvalidChunkMask.into());
         }
 
-        // Actually only needed for BlockHeaderV1
-        if header.chunk_mask().iter().map(|&x| u64::from(x)).sum::<u64>()
-            != header.chunks_included()
-        {
+        if !header.verify_chunks_included() {
             return Err(ErrorKind::InvalidChunkMask.into());
         }
 

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3181,6 +3181,13 @@ impl<'a> ChainUpdate<'a> {
             return Err(ErrorKind::InvalidChunkMask.into());
         }
 
+        // Actually only needed for BlockHeaderV1
+        if header.chunk_mask().iter().map(|&x| u64::from(x)).sum::<u64>()
+            != header.chunks_included()
+        {
+            return Err(ErrorKind::InvalidChunkMask.into());
+        }
+
         // Prevent time warp attacks and some timestamp manipulations by forcing strict
         // time progression.
         if header.raw_timestamp() <= prev_header.raw_timestamp() {

--- a/chain/chain/src/error.rs
+++ b/chain/chain/src/error.rs
@@ -320,7 +320,7 @@ impl From<BlockValidityError> for Error {
             BlockValidityError::InvalidReceiptRoot => ErrorKind::InvalidChunkReceiptsRoot,
             BlockValidityError::InvalidTransactionRoot => ErrorKind::InvalidTxRoot,
             BlockValidityError::InvalidChunkHeaderRoot => ErrorKind::InvalidChunkHeadersRoot,
-            BlockValidityError::InvalidNumChunksIncluded => ErrorKind::InvalidChunkMask,
+            BlockValidityError::InvalidChunkMask => ErrorKind::InvalidChunkMask,
             BlockValidityError::InvalidChallengeRoot => ErrorKind::InvalidChallengeRoot,
         }
         .into()

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -8,7 +8,7 @@ use primitive_types::U256;
 use serde::Serialize;
 
 use crate::block::BlockValidityError::{
-    InvalidChallengeRoot, InvalidChunkHeaderRoot, InvalidNumChunksIncluded, InvalidReceiptRoot,
+    InvalidChallengeRoot, InvalidChunkHeaderRoot, InvalidChunkMask, InvalidReceiptRoot,
     InvalidStateRoot, InvalidTransactionRoot,
 };
 pub use crate::block_header::*;
@@ -39,7 +39,7 @@ pub enum BlockValidityError {
     InvalidReceiptRoot,
     InvalidChunkHeaderRoot,
     InvalidTransactionRoot,
-    InvalidNumChunksIncluded,
+    InvalidChunkMask,
     InvalidChallengeRoot,
 }
 
@@ -154,6 +154,9 @@ impl Block {
         next_bp_hash: CryptoHash,
     ) -> Self {
         let challenges = vec![];
+        for chunk in &chunks {
+            assert_eq!(chunk.height_included(), 0);
+        }
         let header = BlockHeader::genesis(
             genesis_protocol_version,
             height,
@@ -161,7 +164,7 @@ impl Block {
             Block::compute_chunk_receipts_root(&chunks),
             Block::compute_chunk_headers_root(&chunks).0,
             Block::compute_chunk_tx_root(&chunks),
-            Block::compute_chunks_included(&chunks, 0),
+            chunks.len() as u64,
             Block::compute_challenges_root(&challenges),
             timestamp,
             initial_gas_price,
@@ -255,7 +258,6 @@ impl Block {
             Block::compute_chunk_tx_root(&chunks),
             Block::compute_outcome_root(&chunks),
             time,
-            Block::compute_chunks_included(&chunks, height),
             Block::compute_challenges_root(&challenges),
             random_value,
             validator_proposals,
@@ -365,13 +367,6 @@ impl Block {
         chunks: T,
     ) -> CryptoHash {
         merklize(&chunks.into_iter().map(|chunk| chunk.tx_root()).collect::<Vec<CryptoHash>>()).0
-    }
-
-    pub fn compute_chunks_included<'a, T: IntoIterator<Item = &'a ShardChunkHeader>>(
-        chunks: T,
-        height: BlockHeight,
-    ) -> u64 {
-        chunks.into_iter().filter(|chunk| chunk.height_included() == height).count() as u64
     }
 
     pub fn compute_outcome_root<'a, T: IntoIterator<Item = &'a ShardChunkHeader>>(
@@ -495,10 +490,13 @@ impl Block {
         }
 
         // Check that chunk included root stored in the header matches the chunk included root of the chunks
-        let num_chunks_included =
-            Block::compute_chunks_included(self.chunks().iter(), self.header().height());
-        if self.header().chunks_included() != num_chunks_included {
-            return Err(InvalidNumChunksIncluded);
+        let chunk_mask: Vec<bool> = self
+            .chunks()
+            .iter()
+            .map(|chunk| chunk.height_included() == self.header().height())
+            .collect();
+        if self.header().chunk_mask() != &chunk_mask[..] {
+            return Err(InvalidChunkMask);
         }
 
         // Check that challenges root stored in the header matches the challenges root of the challenges

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -155,7 +155,7 @@ impl Block {
     ) -> Self {
         let challenges = vec![];
         for chunk in &chunks {
-            assert_eq!(chunk.height_included(), 0);
+            assert_eq!(chunk.height_included(), height);
         }
         let header = BlockHeader::genesis(
             genesis_protocol_version,

--- a/core/primitives/src/block_header.rs
+++ b/core/primitives/src/block_header.rs
@@ -261,7 +261,6 @@ impl BlockHeader {
         chunk_tx_root: MerkleHash,
         outcome_root: MerkleHash,
         timestamp: u64,
-        chunks_included: u64,
         challenges_root: MerkleHash,
         random_value: CryptoHash,
         validator_proposals: Vec<ValidatorStake>,
@@ -289,6 +288,7 @@ impl BlockHeader {
             block_merkle_root,
         };
         if protocol_version <= 29 {
+            let chunks_included = chunk_mask.iter().map(|val| *val as u64).sum::<u64>();
             let inner_rest = BlockHeaderInnerRest {
                 chunk_receipts_root,
                 chunk_headers_root,
@@ -357,7 +357,7 @@ impl BlockHeader {
         chunk_receipts_root: MerkleHash,
         chunk_headers_root: MerkleHash,
         chunk_tx_root: MerkleHash,
-        chunks_included: u64,
+        num_shards: u64,
         challenges_root: MerkleHash,
         timestamp: DateTime<Utc>,
         initial_gas_price: Balance,
@@ -379,7 +379,7 @@ impl BlockHeader {
                 chunk_receipts_root,
                 chunk_headers_root,
                 chunk_tx_root,
-                chunks_included,
+                chunks_included: num_shards,
                 challenges_root,
                 random_value: CryptoHash::default(),
                 validator_proposals: vec![],
@@ -412,7 +412,7 @@ impl BlockHeader {
                 challenges_root,
                 random_value: CryptoHash::default(),
                 validator_proposals: vec![],
-                chunk_mask: vec![true; chunks_included as usize],
+                chunk_mask: vec![true; num_shards as usize],
                 gas_price: initial_gas_price,
                 total_supply: initial_total_supply,
                 challenges_result: vec![],


### PR DESCRIPTION
Make header validation match chunk mask against chunks_included for V1
headers.
Make block validation match chunk mask in header against computed mask
from block body. Don't check chunks_included anymore, as it's checked
in header validation.
Also refactor chunks_included logic in Block::genesis as it was
unnecessarily complex and did not match the logic for non-genesis
blocks anyway.

Fixes #3586

Test plan
---------
Unit test