### PR TITLE
fix: fix nightly version check

### DIFF
--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -125,7 +125,7 @@ macro_rules! checked_feature {
         #[cfg(feature = $feature_name)]
         let is_feature_enabled = near_primitives::version::PROTOCOL_FEATURES_TO_VERSION_MAPPING
             [&near_primitives::version::ProtocolFeature::$feature]
-            >= $current_protocol_version;
+            <= $current_protocol_version;
         #[cfg(not(feature = $feature_name))]
         let is_feature_enabled = {
             // Workaround unused variable warning


### PR DESCRIPTION
The macro was broken and checked if the feature protocol version was not less than the current protocol version.
Fixing the macro.

Discovered by @ailisp 

Test plan:
- CI