### PR TITLE
fix: add fallback for git version

### DIFF
--- a/neard/src/main.rs
+++ b/neard/src/main.rs
@@ -66,8 +66,10 @@ fn main() {
     openssl_probe::init_ssl_cert_env_vars();
 
     let default_home = get_default_home();
-    let version =
-        Version { version: crate_version!().to_string(), build: git_version!().to_string() };
+    let version = Version {
+        version: crate_version!().to_string(),
+        build: git_version!(fallback = "unknown").to_string(),
+    };
     let matches = App::new("NEAR Protocol Node")
         .setting(AppSettings::SubcommandRequiredElseHelp)
         .version(format!("{} (build {})", version.version, version.build).as_str())


### PR DESCRIPTION
Currently if the directory doesn't contain git version information (for example downloaded as a zip), then neard will fail to compile. This PR fixes the issue by adding a fallback.

Test plan
---------
Download code as zip and verify that it can now compile