### PR TITLE
fix(test): test_ban_peer_for_invalid_block_header

### DIFF
--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -627,11 +627,13 @@ fn ban_peer_for_invalid_block_common(mode: InvalidBlockMode) {
             false,
             network_mock.clone(),
         );
+        let mut sent_bad_blocks = false;
         *network_mock.write().unwrap() =
             Box::new(move |_: String, msg: &NetworkRequests| -> (NetworkResponses, bool) {
                 match msg {
                     NetworkRequests::Block { block } => {
-                        if block.header().height() == 4 {
+                        if block.header().height() >= 4 && !sent_bad_blocks {
+                            sent_bad_blocks = true;
                             let mut block_mut = block.clone();
                             match mode {
                                 InvalidBlockMode::InvalidHeader => {


### PR DESCRIPTION
The test messes with the block at height 4, and fails if that height
gets skipped. Change it to the first block at height >=4.
Fixes #3634

Test plan
---------
run locally