### PR TITLE
feat(version): include the protocol version in the version command

### DIFF
--- a/neard/src/main.rs
+++ b/neard/src/main.rs
@@ -71,7 +71,7 @@ fn main() {
     };
     let matches = App::new("NEAR Protocol Node")
         .setting(AppSettings::SubcommandRequiredElseHelp)
-        .version(format!("{} (build {})", version.version, version.build).as_str())
+        .version(format!("{} (build {}) (protocol {})", version.version, version.build, PROTOCOL_VERSION).as_str())
         .arg(Arg::with_name("verbose").long("verbose").help("Verbose logging").takes_value(true))
         .arg(
             Arg::with_name("home")


### PR DESCRIPTION
Added the protocol version to to  version command for detecting protocol version changes in betanet based on two binaries for triggering a hard-fork on betanet.
```
sandi@sandi-ThinkPad-X1-Carbon-7th ~/w/n/nearcore (protocol-flag)> ./target/debug/neard --version
NEAR Protocol Node 1.2.0 (build 522ccf21) (protocol 41)
```