### PR TITLE
fix(build): fix failing action for mac osx build

### DIFF
--- a/.github/workflows/mac_binary.yml
+++ b/.github/workflows/mac_binary.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         rust-version: nightly-2020-03-19
     - uses: actions/checkout@master
-    - uses: chrislennon/action-aws-cli@v1.1
+    - uses: isbang/setup-awscli@v0.1.0
     - run: scripts/binary-release.sh
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
The old actoin we used for pulling aws-cli tool isn't maintained anymore and the API which it was using got broken.