### PR TITLE
fix: fix 12 -> 13 migration

### DIFF
--- a/neard/src/migrations.rs
+++ b/neard/src/migrations.rs
@@ -67,13 +67,8 @@ fn apply_block_at_height(
     for (outcome_with_id, proof) in apply_result.outcomes.into_iter().zip(outcome_paths.into_iter())
     {
         let id = outcome_with_id.id;
-        let mut existing_outcomes = chain_store.get_outcomes_by_id(&id)?;
-        existing_outcomes.push(ExecutionOutcomeWithIdAndProof {
-            proof,
-            block_hash,
-            outcome_with_id,
-        });
-        store_update.set_ser(DBCol::ColTransactionResult, id.as_ref(), &existing_outcomes)?;
+        let outcome = vec![ExecutionOutcomeWithIdAndProof { proof, block_hash, outcome_with_id }];
+        store_update.set_ser(DBCol::ColTransactionResult, id.as_ref(), &outcome)?;
     }
     Ok(())
 }


### PR DESCRIPTION
This was a one-off fix done a while ago but somehow wasn't merged into master. Some partners ran into the same issue so it makes sense to merge this to master. The issue is that the migration can fail due to
```
thread 'main' panicked at 'unexpected error during migration, IO Error: Not all bytes read
 Cause: Unknown', neard/src/migrations.rs:102:30
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
and I realized that the logic there is not actually needed since we only care about the canonical chain when migrating past data.