### PR TITLE
fix(chunks): Validate partial encoded chunk header signatures exactly once

### DIFF
--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -1117,7 +1117,7 @@ impl ShardsManager {
         // We must check the protocol version every time, since a new value
         // could be passed to the function, whereas the signature check is intrinsic
         // to the header, thus only needs to happen exactly once.
-        let partial_encoded_chunk = partial_encoded_chunk.unwrap();
+        let partial_encoded_chunk = partial_encoded_chunk.extract();
         if !partial_encoded_chunk.header.version_range().contains(protocol_version) {
             return Err(Error::InvalidChunkHeader);
         }

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -35,6 +35,7 @@ use near_primitives::types::{
     AccountId, Balance, BlockHeight, BlockHeightDelta, Gas, MerkleHash, ShardId, StateRoot,
     ValidatorStake,
 };
+use near_primitives::utils::MaybeValidated;
 use near_primitives::validator_signer::ValidatorSigner;
 use near_primitives::version::ProtocolVersion;
 use near_primitives::{checked_feature, unwrap_or_return};
@@ -1082,21 +1083,17 @@ impl ShardsManager {
 
     pub fn process_partial_encoded_chunk(
         &mut self,
-        partial_encoded_chunk: PartialEncodedChunkV2,
+        partial_encoded_chunk: MaybeValidated<PartialEncodedChunkV2>,
         chain_store: &mut ChainStore,
         rs: &mut ReedSolomonWrapper,
         protocol_version: ProtocolVersion,
     ) -> Result<ProcessPartialEncodedChunkResult, Error> {
         // Check validity first
 
-        if !partial_encoded_chunk.header.version_range().contains(protocol_version) {
-            return Err(Error::InvalidChunkHeader);
-        }
-        let header = partial_encoded_chunk.header.clone();
-        let chunk_hash = header.chunk_hash();
-
-        // 1. Checking signature validity
-        match self.runtime_adapter.verify_chunk_header_signature(&header) {
+        // 1. Checking signature validity (if needed)
+        let signature_check = partial_encoded_chunk
+            .validate_with(|pec| self.runtime_adapter.verify_chunk_header_signature(&pec.header));
+        match signature_check {
             Ok(false) => {
                 byzantine_assert!(false);
                 return Err(Error::InvalidChunkSignature);
@@ -1116,6 +1113,16 @@ impl ShardsManager {
                 };
             }
         };
+
+        // We must check the protocol version every time, since a new value
+        // could be passed to the function, whereas the signature check is intrinsic
+        // to the header, thus only needs to happen exactly once.
+        let partial_encoded_chunk = partial_encoded_chunk.unwrap();
+        if !partial_encoded_chunk.header.version_range().contains(protocol_version) {
+            return Err(Error::InvalidChunkHeader);
+        }
+        let header = partial_encoded_chunk.header.clone();
+        let chunk_hash = header.chunk_hash();
 
         // 2. Leave if we received known chunk
         if let Some(entry) = self.encoded_chunks.get(&chunk_hash) {
@@ -1314,7 +1321,9 @@ impl ShardsManager {
                 // properly in the next call. Note no requests are actually sent at this point.
                 self.request_chunk_single(header, None, protocol_version);
                 self.process_partial_encoded_chunk(
-                    forwarded_chunk,
+                    // We can assert the signature on the header is valid because
+                    // it would have been checked in an earlier call to this function.
+                    MaybeValidated::Validated(forwarded_chunk),
                     chain_store,
                     rs,
                     protocol_version,
@@ -1838,7 +1847,7 @@ mod test {
         for partial_encoded_chunk in vec![partial_encoded_chunk1, partial_encoded_chunk2] {
             shards_manager
                 .process_partial_encoded_chunk(
-                    partial_encoded_chunk.into(),
+                    MaybeValidated::NotValidated(partial_encoded_chunk.into()),
                     &mut chain_store,
                     &mut rs,
                     PROTOCOL_VERSION,
@@ -1953,7 +1962,7 @@ mod test {
         let partial_encoded_chunk = fixture.make_partial_encoded_chunk(&fixture.mock_part_ords);
         let result = shards_manager
             .process_partial_encoded_chunk(
-                partial_encoded_chunk,
+                MaybeValidated::NotValidated(partial_encoded_chunk),
                 &mut fixture.chain_store,
                 &mut fixture.rs,
                 PROTOCOL_VERSION,
@@ -2024,7 +2033,7 @@ mod test {
         };
         let result = shards_manager
             .process_partial_encoded_chunk(
-                partial_encoded_chunk,
+                MaybeValidated::NotValidated(partial_encoded_chunk),
                 &mut fixture.chain_store,
                 &mut fixture.rs,
                 PROTOCOL_VERSION,

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -33,7 +33,7 @@ use near_primitives::syncing::ReceiptResponse;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{AccountId, ApprovalStake, BlockHeight, ChunkExtra, EpochId, ShardId};
 use near_primitives::unwrap_or_return;
-use near_primitives::utils::to_timestamp;
+use near_primitives::utils::{to_timestamp, MaybeValidated};
 use near_primitives::validator_signer::ValidatorSigner;
 
 use crate::metrics;
@@ -728,7 +728,9 @@ impl Client {
     ) -> Result<Vec<AcceptedBlock>, Error> {
         let header = self.shards_mgr.get_partial_encoded_chunk_header(&response.chunk_hash)?;
         let partial_chunk = PartialEncodedChunk::new(header, response.parts, response.receipts);
-        self.process_partial_encoded_chunk(partial_chunk)
+        // We already know the header signature is valid because we read it from the
+        // shard manager.
+        self.process_partial_encoded_chunk(MaybeValidated::Validated(partial_chunk))
     }
 
     #[cfg(feature = "protocol_feature_forward_chunk_parts")]
@@ -771,12 +773,14 @@ impl Client {
             parts: forward.parts,
             receipts: Vec::new(),
         });
-        self.process_partial_encoded_chunk(partial_chunk)
+        // We already know the header signature is valid because we read it from the
+        // shard manager.
+        self.process_partial_encoded_chunk(MaybeValidated::Validated(partial_chunk))
     }
 
     pub fn process_partial_encoded_chunk(
         &mut self,
-        partial_encoded_chunk: PartialEncodedChunk,
+        partial_encoded_chunk: MaybeValidated<PartialEncodedChunk>,
     ) -> Result<Vec<AcceptedBlock>, Error> {
         fn missing_block_handler(
             client: &mut Client,
@@ -795,8 +799,9 @@ impl Client {
                     return Err(Error::Other("Invalid chunk version".to_string()));
                 };
 
+                let pec = PartialEncodedChunk::clone(&partial_encoded_chunk);
                 let process_result = self.shards_mgr.process_partial_encoded_chunk(
-                    partial_encoded_chunk.clone().into(),
+                    partial_encoded_chunk.map(Into::into),
                     self.chain.mut_store(),
                     &mut self.rs,
                     protocol_version,
@@ -816,15 +821,13 @@ impl Client {
                         );
                         Ok(vec![])
                     }
-                    ProcessPartialEncodedChunkResult::NeedBlock => {
-                        missing_block_handler(self, partial_encoded_chunk)
-                    }
+                    ProcessPartialEncodedChunkResult::NeedBlock => missing_block_handler(self, pec),
                 }
             }
 
             // If the epoch_id cannot be looked up then we have not processed
             // `partial_encoded_chunk.prev_block()` yet.
-            Err(_) => missing_block_handler(self, partial_encoded_chunk),
+            Err(_) => missing_block_handler(self, partial_encoded_chunk.unwrap()),
         }
     }
 
@@ -1053,9 +1056,9 @@ impl Client {
         let mut partial_encoded_chunks =
             self.shards_mgr.get_stored_partial_encoded_chunks(next_height);
         for (_shard_id, partial_encoded_chunk) in partial_encoded_chunks.drain() {
-            if let Ok(accepted_blocks) =
-                self.process_partial_encoded_chunk(PartialEncodedChunk::V2(partial_encoded_chunk))
-            {
+            let chunk =
+                MaybeValidated::NotValidated(PartialEncodedChunk::V2(partial_encoded_chunk));
+            if let Ok(accepted_blocks) = self.process_partial_encoded_chunk(chunk) {
                 // Executing process_partial_encoded_chunk can unlock some blocks.
                 // Any block that is in the blocks_with_missing_chunks which doesn't have any chunks
                 // for which we track shards will be unblocked here.
@@ -1615,6 +1618,7 @@ mod test {
     use near_primitives::block_header::ApprovalType;
     use near_primitives::network::PeerId;
     use near_primitives::sharding::{PartialEncodedChunk, ShardChunkHeader};
+    use near_primitives::utils::MaybeValidated;
 
     fn create_runtimes(n: usize) -> Vec<Arc<dyn RuntimeAdapter>> {
         let genesis = Genesis::test(vec!["test0", "test1"], 1);
@@ -1704,7 +1708,7 @@ mod test {
         // process_partial_encoded_chunk should return Ok(NeedBlock) if the chunk is
         // based on a missing block.
         let result = client.shards_mgr.process_partial_encoded_chunk(
-            mock_chunk.clone(),
+            MaybeValidated::NotValidated(mock_chunk.clone()),
             client.chain.mut_store(),
             &mut client.rs,
             PROTOCOL_VERSION,
@@ -1713,7 +1717,9 @@ mod test {
 
         // Client::process_partial_encoded_chunk should not return an error
         // if the chunk is based on a missing block.
-        let result = client.process_partial_encoded_chunk(PartialEncodedChunk::V2(mock_chunk));
+        let result = client.process_partial_encoded_chunk(MaybeValidated::NotValidated(
+            PartialEncodedChunk::V2(mock_chunk),
+        ));
         match result {
             Ok(accepted_blocks) => assert!(accepted_blocks.is_empty()),
             Err(e) => panic!("Client::process_partial_encoded_chunk failed with {:?}", e),

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -827,7 +827,7 @@ impl Client {
 
             // If the epoch_id cannot be looked up then we have not processed
             // `partial_encoded_chunk.prev_block()` yet.
-            Err(_) => missing_block_handler(self, partial_encoded_chunk.unwrap()),
+            Err(_) => missing_block_handler(self, partial_encoded_chunk.extract()),
         }
     }
 

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -36,7 +36,7 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::network::{AnnounceAccount, PeerId};
 use near_primitives::types::{BlockHeight, EpochId};
 use near_primitives::unwrap_or_return;
-use near_primitives::utils::from_timestamp;
+use near_primitives::utils::{from_timestamp, MaybeValidated};
 use near_primitives::validator_signer::ValidatorSigner;
 use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives::views::ValidatorInfo;
@@ -479,9 +479,9 @@ impl Handler<NetworkClientMessages> for ClientActor {
                 NetworkClientResponses::NoResponse
             }
             NetworkClientMessages::PartialEncodedChunk(partial_encoded_chunk) => {
-                if let Ok(accepted_blocks) =
-                    self.client.process_partial_encoded_chunk(partial_encoded_chunk)
-                {
+                if let Ok(accepted_blocks) = self.client.process_partial_encoded_chunk(
+                    MaybeValidated::NotValidated(partial_encoded_chunk),
+                ) {
                     self.process_accepted_blocks(accepted_blocks);
                 }
                 NetworkClientResponses::NoResponse

--- a/chain/client/tests/challenges.rs
+++ b/chain/client/tests/challenges.rs
@@ -26,6 +26,7 @@ use near_primitives::serialize::BaseDecode;
 use near_primitives::sharding::{EncodedShardChunk, ReedSolomonWrapper};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::StateRoot;
+use near_primitives::utils::MaybeValidated;
 use near_primitives::validator_signer::InMemoryValidatorSigner;
 use near_primitives::version::PROTOCOL_VERSION;
 use near_store::test_utils::create_test_store;
@@ -475,7 +476,9 @@ fn test_receive_invalid_chunk_as_chunk_producer() {
         one_part_receipt_proofs,
         &vec![merkle_paths[0].clone()],
     );
-    assert!(env.clients[1].process_partial_encoded_chunk(partial_encoded_chunk).is_ok());
+    assert!(env.clients[1]
+        .process_partial_encoded_chunk(MaybeValidated::NotValidated(partial_encoded_chunk))
+        .is_ok());
     env.process_block(1, block.clone(), Provenance::NONE);
 
     // At this point we should create a challenge and send it out.

--- a/core/primitives/src/utils.rs
+++ b/core/primitives/src/utils.rs
@@ -42,7 +42,7 @@ impl<T> MaybeValidated<T> {
         }
     }
 
-    pub fn unwrap(self) -> T {
+    pub fn extract(self) -> T {
         match self {
             Self::Validated(t) => t,
             Self::NotValidated(t) => t,

--- a/core/primitives/src/utils.rs
+++ b/core/primitives/src/utils.rs
@@ -16,9 +16,50 @@ use crate::version::{
     ProtocolVersion, CORRECT_RANDOM_VALUE_PROTOCOL_VERSION, CREATE_HASH_PROTOCOL_VERSION,
 };
 use std::mem::size_of;
+use std::ops::Deref;
 
 /// Number of nano seconds in a second.
 const NS_IN_SECOND: u64 = 1_000_000_000;
+
+/// A data structure for tagging data as already being validated to prevent redundant work.
+pub enum MaybeValidated<T> {
+    Validated(T),
+    NotValidated(T),
+}
+
+impl<T> MaybeValidated<T> {
+    pub fn validate_with<E, F: FnOnce(&T) -> Result<bool, E>>(&self, f: F) -> Result<bool, E> {
+        match &self {
+            Self::Validated(_) => Ok(true),
+            Self::NotValidated(t) => f(t),
+        }
+    }
+
+    pub fn map<U, F: FnOnce(T) -> U>(self, f: F) -> MaybeValidated<U> {
+        match self {
+            Self::Validated(t) => MaybeValidated::Validated(f(t)),
+            Self::NotValidated(t) => MaybeValidated::NotValidated(f(t)),
+        }
+    }
+
+    pub fn unwrap(self) -> T {
+        match self {
+            Self::Validated(t) => t,
+            Self::NotValidated(t) => t,
+        }
+    }
+}
+
+impl<T: Sized> Deref for MaybeValidated<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        match &self {
+            Self::Validated(t) => t,
+            Self::NotValidated(t) => t,
+        }
+    }
+}
 
 pub fn get_block_shard_id(block_hash: &CryptoHash, shard_id: ShardId) -> Vec<u8> {
     let mut res = Vec::with_capacity(40);


### PR DESCRIPTION
This PR fixes an issue where the node is doing redundant (and expensive) validation work. This overhead is especially an issue when chunk forwarding is enabled.

Fixes #3683

Testing plan:

* Existing tests