### PR TITLE
fix(chain): reject old blocks right away

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2198,6 +2198,12 @@ impl Chain {
         self.store.head()
     }
 
+    /// Gets chain tail height
+    #[inline]
+    pub fn tail(&self) -> Result<BlockHeight, Error> {
+        self.store.tail()
+    }
+
     /// Gets chain header head.
     #[inline]
     pub fn header_head(&self) -> Result<Tip, Error> {

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -324,6 +324,8 @@ pub struct ChainStore {
     latest_known: Option<LatestKnown>,
     /// Current head of the chain
     head: Option<Tip>,
+    /// Tail height of the chain,
+    tail: Option<BlockHeight>,
     /// Cache with headers.
     headers: SizedCache<Vec<u8>, BlockHeader>,
     /// Cache with blocks.
@@ -392,6 +394,7 @@ impl ChainStore {
             genesis_height,
             latest_known: None,
             head: None,
+            tail: None,
             blocks: SizedCache::with_size(CACHE_SIZE),
             headers: SizedCache::with_size(CACHE_SIZE),
             chunks: SizedCache::with_size(CHUNK_CACHE_SIZE),
@@ -550,10 +553,14 @@ impl ChainStoreAccess for ChainStore {
 
     /// The chain Blocks Tail height, used by GC.
     fn tail(&self) -> Result<BlockHeight, Error> {
-        self.store
-            .get_ser(ColBlockMisc, TAIL_KEY)
-            .map(|option| option.unwrap_or_else(|| self.genesis_height))
-            .map_err(|e| e.into())
+        if let Some(tail) = self.tail.as_ref() {
+            Ok(*tail)
+        } else {
+            self.store
+                .get_ser(ColBlockMisc, TAIL_KEY)
+                .map(|option| option.unwrap_or_else(|| self.genesis_height))
+                .map_err(|e| e.into())
+        }
     }
 
     /// The chain Chunks Tail height, used by GC.
@@ -2856,6 +2863,7 @@ impl<'a> ChainStoreUpdate<'a> {
             self.chain_store.processed_block_heights.cache_set(index_to_bytes(block_height), ());
         }
         self.chain_store.head = self.head;
+        self.chain_store.tail = self.tail;
 
         Ok(())
     }

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -919,8 +919,6 @@ impl Client {
             {
                 self.collect_block_approval(&approval, approval_type);
             }
-
-            self.rebroadcast_block(block.clone());
         }
 
         if status.is_new_head() {

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -956,6 +956,11 @@ impl ClientActor {
             debug!(target: "client", "dropping block {} that is too far ahead. Block height {} current head height {}", block.hash(), block.header().height(), head.height);
             return;
         }
+        let tail = unwrap_or_return!(self.client.chain.tail());
+        if block.header().height() < tail {
+            debug!(target: "client", "dropping block {} that is too far behind. Block height {} current tail height {}", block.hash(), block.header().height(), tail);
+            return;
+        }
         let prev_hash = *block.header().prev_hash();
         let block_protocol_version = block.header().latest_protocol_version();
         let provenance =


### PR DESCRIPTION
Fix the following issues:
* Reject blocks older than tail right away. Resolves #3691.
* Avoid broadcasting blocks when they are accepted. Resolves #3690.

Test plan
---------
* `test_not_broadcast_block_on_accept`
* Nayduck