### PR TITLE
fix(runtime): Bump runtime and VM version to `2.3.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "near-evm-runner"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bn",
  "borsh",
@@ -2959,7 +2959,7 @@ dependencies = [
  "rlp",
  "serde",
  "serde_json",
- "sha2 0.9.1",
+ "sha2 0.8.1",
  "sha3",
  "vm",
 ]
@@ -3193,7 +3193,7 @@ dependencies = [
 
 [[package]]
 name = "near-runtime-standalone"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "near-crypto",
  "near-pool",
@@ -3205,7 +3205,7 @@ dependencies = [
 
 [[package]]
 name = "near-runtime-utils"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "lazy_static",
  "regex",
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-errors"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "borsh",
  "ethereum-types",
@@ -3277,7 +3277,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3299,7 +3299,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner-standalone"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "base64 0.11.0",
  "clap 2.33.0",
@@ -3412,7 +3412,7 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "base64 0.11.0",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-params-estimator"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "borsh",
  "clap 2.33.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3185,7 +3185,7 @@ dependencies = [
 
 [[package]]
 name = "near-runtime-fees"
-version = "3.0.0"
+version = "2.3.0"
 dependencies = [
  "num-rational 0.2.4",
  "serde",
@@ -3260,7 +3260,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-logic"
-version = "3.0.0"
+version = "2.3.0"
 dependencies = [
  "base64 0.11.0",
  "borsh",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3185,7 +3185,7 @@ dependencies = [
 
 [[package]]
 name = "near-runtime-fees"
-version = "2.2.0"
+version = "3.0.0"
 dependencies = [
  "num-rational 0.2.4",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3260,7 +3260,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-logic"
-version = "2.2.0"
+version = "3.0.0"
 dependencies = [
  "base64 0.11.0",
  "borsh",
@@ -3271,7 +3271,7 @@ dependencies = [
  "near-vm-errors",
  "serde",
  "serde_json",
- "sha2 0.9.1",
+ "sha2 0.8.1",
  "sha3",
 ]
 

--- a/runtime/CHANGELOG.md
+++ b/runtime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.3.0
+
+- Added disk cache to `near-vm-runner`
+- Contains a dependency on `near-primitives`, so it's impossible to publish to crates.io
+- Needed to differentiate from `2.2.0` to avoid patch conflicts.
+
 ## 2.2.0
 
 - Add ability to specify protocol version when initializing VMLogic.

--- a/runtime/near-evm-runner/Cargo.toml
+++ b/runtime/near-evm-runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-evm-runner"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/runtime/near-runtime-fees/Cargo.toml
+++ b/runtime/near-runtime-fees/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-runtime-fees"
-version = "3.0.0"
+version = "2.3.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/runtime/near-runtime-fees/Cargo.toml
+++ b/runtime/near-runtime-fees/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-runtime-fees"
-version = "2.2.0"
+version = "3.0.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/runtime/near-runtime-utils/Cargo.toml
+++ b/runtime/near-runtime-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-runtime-utils"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/runtime/near-vm-errors/Cargo.toml
+++ b/runtime/near-vm-errors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-vm-errors"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/runtime/near-vm-logic/Cargo.toml
+++ b/runtime/near-vm-logic/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1", features = ["derive"] }
 sha2 = ">=0.8,<0.10"
 sha3 = ">=0.8,<0.10"
 
-near-runtime-fees = { path = "../near-runtime-fees", version = "2.2.0" }
+near-runtime-fees = { path = "../near-runtime-fees", version = "3.0.0" }
 near-vm-errors = { path = "../near-vm-errors", version = "2.2.0" }
 near-runtime-utils = { path = "../near-runtime-utils", version = "2.2.0" }
 

--- a/runtime/near-vm-logic/Cargo.toml
+++ b/runtime/near-vm-logic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-vm-logic"
-version = "3.0.0"
+version = "2.3.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -21,7 +21,7 @@ serde = { version = "1", features = ["derive"] }
 sha2 = ">=0.8,<0.10"
 sha3 = ">=0.8,<0.10"
 
-near-runtime-fees = { path = "../near-runtime-fees", version = "3.0.0" }
+near-runtime-fees = { path = "../near-runtime-fees", version = "2.3.0" }
 near-vm-errors = { path = "../near-vm-errors", version = "2.2.0" }
 near-runtime-utils = { path = "../near-runtime-utils", version = "2.2.0" }
 

--- a/runtime/near-vm-logic/Cargo.toml
+++ b/runtime/near-vm-logic/Cargo.toml
@@ -22,8 +22,8 @@ sha2 = ">=0.8,<0.10"
 sha3 = ">=0.8,<0.10"
 
 near-runtime-fees = { path = "../near-runtime-fees", version = "2.3.0" }
-near-vm-errors = { path = "../near-vm-errors", version = "2.2.0" }
-near-runtime-utils = { path = "../near-runtime-utils", version = "2.2.0" }
+near-vm-errors = { path = "../near-vm-errors", version = "2.3.0" }
+near-runtime-utils = { path = "../near-runtime-utils", version = "2.3.0" }
 
 [dev-dependencies]
 serde_json = {version= "1", features= ["preserve_order"]}

--- a/runtime/near-vm-logic/Cargo.toml
+++ b/runtime/near-vm-logic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-vm-logic"
-version = "2.2.0"
+version = "3.0.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/runtime/near-vm-runner-standalone/Cargo.toml
+++ b/runtime/near-vm-runner-standalone/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-vm-runner-standalone"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -26,7 +26,7 @@ strum = "0.18"
 num-rational = { version = "0.2.4" }
 
 near-vm-logic = { path = "../near-vm-logic", version = "2.3.0", features = ["costs_counting"]}
-near-vm-runner = { path = "../near-vm-runner", version = "2.2.0", features = ["wasmtime_vm"] }
+near-vm-runner = { path = "../near-vm-runner", version = "2.3.0", features = ["wasmtime_vm"] }
 near-runtime-fees = { path = "../near-runtime-fees", version = "2.3.0" }
 
 [features]

--- a/runtime/near-vm-runner-standalone/Cargo.toml
+++ b/runtime/near-vm-runner-standalone/Cargo.toml
@@ -25,9 +25,9 @@ base64 = "0.11"
 strum = "0.18"
 num-rational = { version = "0.2.4" }
 
-near-vm-logic = { path = "../near-vm-logic", version = "3.0.0", features = ["costs_counting"]}
+near-vm-logic = { path = "../near-vm-logic", version = "2.3.0", features = ["costs_counting"]}
 near-vm-runner = { path = "../near-vm-runner", version = "2.2.0", features = ["wasmtime_vm"] }
-near-runtime-fees = { path = "../near-runtime-fees", version = "3.0.0" }
+near-runtime-fees = { path = "../near-runtime-fees", version = "2.3.0" }
 
 [features]
 default = []

--- a/runtime/near-vm-runner-standalone/Cargo.toml
+++ b/runtime/near-vm-runner-standalone/Cargo.toml
@@ -27,7 +27,7 @@ num-rational = { version = "0.2.4" }
 
 near-vm-logic = { path = "../near-vm-logic", version = "2.2.0", features = ["costs_counting"]}
 near-vm-runner = { path = "../near-vm-runner", version = "2.2.0", features = ["wasmtime_vm"] }
-near-runtime-fees = { path = "../near-runtime-fees", version = "2.2.0" }
+near-runtime-fees = { path = "../near-runtime-fees", version = "3.0.0" }
 
 [features]
 default = []

--- a/runtime/near-vm-runner-standalone/Cargo.toml
+++ b/runtime/near-vm-runner-standalone/Cargo.toml
@@ -25,7 +25,7 @@ base64 = "0.11"
 strum = "0.18"
 num-rational = { version = "0.2.4" }
 
-near-vm-logic = { path = "../near-vm-logic", version = "2.2.0", features = ["costs_counting"]}
+near-vm-logic = { path = "../near-vm-logic", version = "3.0.0", features = ["costs_counting"]}
 near-vm-runner = { path = "../near-vm-runner", version = "2.2.0", features = ["wasmtime_vm"] }
 near-runtime-fees = { path = "../near-runtime-fees", version = "3.0.0" }
 

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -20,7 +20,7 @@ pwasm-utils = "0.12"
 parity-wasm = "0.41"
 wasmtime = { version = "0.17.0", features = ["lightbeam"], default-features = false, optional = true }
 anyhow = { version = "1.0.19", optional = true }
-near-runtime-fees = { path="../near-runtime-fees", version = "2.2.0" }
+near-runtime-fees = { path="../near-runtime-fees", version = "3.0.0" }
 near-vm-logic = { path="../near-vm-logic", version = "2.2.0", default-features = false, features = []}
 near-vm-errors = { path = "../near-vm-errors", version = "2.2.0" }
 near-primitives = { path = "../../core/primitives" }

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-vm-runner"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -22,10 +22,10 @@ wasmtime = { version = "0.17.0", features = ["lightbeam"], default-features = fa
 anyhow = { version = "1.0.19", optional = true }
 near-runtime-fees = { path="../near-runtime-fees", version = "2.3.0" }
 near-vm-logic = { path="../near-vm-logic", version = "2.3.0", default-features = false, features = []}
-near-vm-errors = { path = "../near-vm-errors", version = "2.2.0" }
+near-vm-errors = { path = "../near-vm-errors", version = "2.3.0" }
 near-primitives = { path = "../../core/primitives" }
 log = "0.4"
-near-evm-runner = { path = "../near-evm-runner", version = "2.2.0", optional = true}
+near-evm-runner = { path = "../near-evm-runner", version = "2.3.0", optional = true}
 
 [dev-dependencies]
 assert_matches = "1.3"

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -21,7 +21,7 @@ parity-wasm = "0.41"
 wasmtime = { version = "0.17.0", features = ["lightbeam"], default-features = false, optional = true }
 anyhow = { version = "1.0.19", optional = true }
 near-runtime-fees = { path="../near-runtime-fees", version = "3.0.0" }
-near-vm-logic = { path="../near-vm-logic", version = "2.2.0", default-features = false, features = []}
+near-vm-logic = { path="../near-vm-logic", version = "3.0.0", default-features = false, features = []}
 near-vm-errors = { path = "../near-vm-errors", version = "2.2.0" }
 near-primitives = { path = "../../core/primitives" }
 log = "0.4"

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -20,8 +20,8 @@ pwasm-utils = "0.12"
 parity-wasm = "0.41"
 wasmtime = { version = "0.17.0", features = ["lightbeam"], default-features = false, optional = true }
 anyhow = { version = "1.0.19", optional = true }
-near-runtime-fees = { path="../near-runtime-fees", version = "3.0.0" }
-near-vm-logic = { path="../near-vm-logic", version = "3.0.0", default-features = false, features = []}
+near-runtime-fees = { path="../near-runtime-fees", version = "2.3.0" }
+near-vm-logic = { path="../near-vm-logic", version = "2.3.0", default-features = false, features = []}
 near-vm-errors = { path = "../near-vm-errors", version = "2.2.0" }
 near-primitives = { path = "../../core/primitives" }
 log = "0.4"

--- a/runtime/runtime-params-estimator/Cargo.toml
+++ b/runtime/runtime-params-estimator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-params-estimator"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 

--- a/runtime/runtime-standalone/Cargo.toml
+++ b/runtime/runtime-standalone/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-runtime-standalone"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 

--- a/runtime/runtime/Cargo.toml
+++ b/runtime/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node-runtime"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Bumping version of near runtime crates to `2.3.0`, so direct dependency on master can be used as a crates.io patch from `near-sdk-rs` for CI against `nearcore:master`

## Test plan
- Tested `near-sdk-rs` `v2.0.0` still compatible.
    - Patched `near-sdk-rs` branch for tag `v2.0.0` with this branch.
    - Executed `cargo update` to upgrade local versions in `Cargo.lock`
    - Verified it compiles and tests pass
