### PR TITLE
fix(chunks): Do not apply a block until we have all its missing chunks

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -12,6 +12,7 @@ use rand::SeedableRng;
 
 use crate::error::{Error, ErrorKind, LogTransientStorageError};
 use crate::lightclient::get_epoch_block_producers_view;
+use crate::missing_chunks::{BlockLike, MissingChunksPool};
 use crate::store::{ChainStore, ChainStoreAccess, ChainStoreUpdate, GCMode};
 use crate::types::{
     AcceptedBlock, ApplyTransactionResult, Block, BlockEconomicsConfig, BlockHeader,
@@ -88,6 +89,16 @@ pub struct Orphan {
     block: Block,
     provenance: Provenance,
     added: Instant,
+}
+
+impl BlockLike for Orphan {
+    fn hash(&self) -> CryptoHash {
+        *self.block.hash()
+    }
+
+    fn height(&self) -> u64 {
+        self.block.header().height()
+    }
 }
 
 pub struct OrphanBlockPool {
@@ -179,7 +190,7 @@ pub struct Chain {
     store: ChainStore,
     pub runtime_adapter: Arc<dyn RuntimeAdapter>,
     orphans: OrphanBlockPool,
-    blocks_with_missing_chunks: OrphanBlockPool,
+    pub blocks_with_missing_chunks: MissingChunksPool<Orphan>,
     genesis: Block,
     pub transaction_validity_period: NumBlocks,
     pub epoch_length: BlockHeightDelta,
@@ -216,7 +227,7 @@ impl Chain {
             store,
             runtime_adapter,
             orphans: OrphanBlockPool::new(),
-            blocks_with_missing_chunks: OrphanBlockPool::new(),
+            blocks_with_missing_chunks: MissingChunksPool::new(),
             genesis: genesis.clone(),
             transaction_validity_period: chain_genesis.transaction_validity_period,
             epoch_length: chain_genesis.epoch_length,
@@ -328,7 +339,7 @@ impl Chain {
             store,
             runtime_adapter,
             orphans: OrphanBlockPool::new(),
-            blocks_with_missing_chunks: OrphanBlockPool::new(),
+            blocks_with_missing_chunks: MissingChunksPool::new(),
             genesis: genesis.clone(),
             transaction_validity_period: chain_genesis.transaction_validity_period,
             epoch_length: chain_genesis.epoch_length,
@@ -1077,7 +1088,10 @@ impl Chain {
                         block_misses_chunks(missing_chunks.clone());
                         let orphan = Orphan { block, provenance, added: Instant::now() };
 
-                        self.blocks_with_missing_chunks.add(orphan);
+                        self.blocks_with_missing_chunks.add_block_with_missing_chunks(
+                            orphan,
+                            missing_chunks.iter().map(|header| header.chunk_hash()).collect(),
+                        );
 
                         debug!(
                             target: "chain",
@@ -1145,7 +1159,6 @@ impl Chain {
     pub fn check_blocks_with_missing_chunks<F, F2, F3>(
         &mut self,
         me: &Option<AccountId>,
-        prev_hash: CryptoHash,
         block_accepted: F,
         block_misses_chunks: F2,
         on_challenge: F3,
@@ -1155,28 +1168,27 @@ impl Chain {
         F3: Copy + FnMut(ChallengeBody) -> (),
     {
         let mut new_blocks_accepted = vec![];
-        if let Some(orphans) = self.blocks_with_missing_chunks.remove_by_prev_hash(prev_hash) {
-            for orphan in orphans.into_iter() {
-                let block_hash = *orphan.block.header().hash();
-                let res = self.process_block_single(
-                    me,
-                    orphan.block,
-                    orphan.provenance,
-                    block_accepted,
-                    block_misses_chunks,
-                    on_challenge,
-                );
-                match res {
-                    Ok(_) => {
-                        debug!(target: "chain", "Block with missing chunks is accepted; me: {:?}", me);
-                        new_blocks_accepted.push(block_hash);
-                    }
-                    Err(_) => {
-                        debug!(target: "chain", "Block with missing chunks is declined; me: {:?}", me);
-                    }
+        let orphans = self.blocks_with_missing_chunks.ready_blocks();
+        for orphan in orphans {
+            let block_hash = *orphan.block.header().hash();
+            let res = self.process_block_single(
+                me,
+                orphan.block,
+                orphan.provenance,
+                block_accepted,
+                block_misses_chunks,
+                on_challenge,
+            );
+            match res {
+                Ok(_) => {
+                    debug!(target: "chain", "Block with missing chunks is accepted; me: {:?}", me);
+                    new_blocks_accepted.push(block_hash);
+                }
+                Err(_) => {
+                    debug!(target: "chain", "Block with missing chunks is declined; me: {:?}", me);
                 }
             }
-        };
+        }
 
         for accepted_block in new_blocks_accepted {
             self.check_orphans(
@@ -2429,7 +2441,7 @@ pub struct ChainUpdate<'a> {
     runtime_adapter: Arc<dyn RuntimeAdapter>,
     chain_store_update: ChainStoreUpdate<'a>,
     orphans: &'a OrphanBlockPool,
-    blocks_with_missing_chunks: &'a OrphanBlockPool,
+    blocks_with_missing_chunks: &'a MissingChunksPool<Orphan>,
     epoch_length: BlockHeightDelta,
     block_economics_config: &'a BlockEconomicsConfig,
     doomslug_threshold_mode: DoomslugThresholdMode,
@@ -2441,7 +2453,7 @@ impl<'a> ChainUpdate<'a> {
         store: &'a mut ChainStore,
         runtime_adapter: Arc<dyn RuntimeAdapter>,
         orphans: &'a OrphanBlockPool,
-        blocks_with_missing_chunks: &'a OrphanBlockPool,
+        blocks_with_missing_chunks: &'a MissingChunksPool<Orphan>,
         epoch_length: BlockHeightDelta,
         block_economics_config: &'a BlockEconomicsConfig,
         doomslug_threshold_mode: DoomslugThresholdMode,

--- a/chain/chain/src/lib.rs
+++ b/chain/chain/src/lib.rs
@@ -16,6 +16,7 @@ mod doomslug;
 mod error;
 mod lightclient;
 mod metrics;
+pub mod missing_chunks;
 mod store;
 pub mod store_validator;
 pub mod test_utils;

--- a/chain/chain/src/missing_chunks.rs
+++ b/chain/chain/src/missing_chunks.rs
@@ -1,0 +1,292 @@
+use log::warn;
+use near_primitives::hash::CryptoHash;
+use near_primitives::sharding::ChunkHash;
+use near_primitives::types::BlockHeight;
+use std::cmp::Ordering;
+use std::collections::{
+    btree_map::{self, BTreeMap},
+    hash_map::{self, HashMap},
+    BinaryHeap, HashSet,
+};
+
+type BlockHash = CryptoHash;
+
+const MAX_BLOCKS_MISSING_CHUNKS: usize = 1024;
+
+pub trait BlockLike {
+    fn hash(&self) -> BlockHash;
+    fn height(&self) -> BlockHeight;
+}
+
+#[derive(Debug)]
+struct HeightOrdered<T>(T);
+
+impl<T: BlockLike> PartialEq for HeightOrdered<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.height() == other.0.height()
+    }
+}
+impl<T: BlockLike> Eq for HeightOrdered<T> {}
+impl<T: BlockLike> PartialOrd for HeightOrdered<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.0.height().cmp(&other.0.height()))
+    }
+}
+impl<T: BlockLike> Ord for HeightOrdered<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.height().cmp(&other.0.height())
+    }
+}
+
+/// Structure for keeping track of missing chunks.
+/// The reason to have a Block type parameter instead of using the
+/// `block::Block` type is to make testing easier (`block::Block` is a complex structure and I
+/// don't care about most of it).
+#[derive(Debug, Default)]
+pub struct MissingChunksPool<Block: BlockLike> {
+    missing_chunks: HashMap<ChunkHash, HashSet<BlockHash>>,
+    blocks_missing_chunks: HashMap<BlockHash, HashSet<ChunkHash>>,
+    blocks_waiting_for_chunks: HashMap<BlockHash, Block>,
+    blocks_ready_to_process: BinaryHeap<HeightOrdered<Block>>,
+    height_idx: BTreeMap<BlockHeight, HashSet<BlockHash>>,
+}
+
+impl<Block: BlockLike> MissingChunksPool<Block> {
+    pub fn new() -> Self {
+        Self {
+            missing_chunks: Default::default(),
+            blocks_missing_chunks: Default::default(),
+            blocks_waiting_for_chunks: Default::default(),
+            blocks_ready_to_process: BinaryHeap::new(),
+            height_idx: Default::default(),
+        }
+    }
+
+    pub fn contains(&self, block_hash: &BlockHash) -> bool {
+        self.blocks_waiting_for_chunks.contains_key(block_hash)
+    }
+
+    pub fn len(&self) -> usize {
+        self.blocks_waiting_for_chunks.len()
+    }
+
+    pub fn ready_blocks(&mut self) -> Vec<Block> {
+        if self.blocks_ready_to_process.is_empty() {
+            return Vec::new();
+        }
+        let heap = std::mem::replace(&mut self.blocks_ready_to_process, BinaryHeap::new());
+        heap.into_sorted_vec().into_iter().map(|x| x.0).collect()
+    }
+
+    pub fn add_block_with_missing_chunks(&mut self, block: Block, missing_chunks: Vec<ChunkHash>) {
+        let block_hash = block.hash();
+        // This case can only happen when missing chunks are not being eventually received and
+        // thus removing blocks from the HashMap. It means the this node has severely stalled out.
+        // It is ok to ignore further blocks because either (a) we will start receiving chunks
+        // again, work through the backlog of the pool, then naturally sync the later blocks
+        // which were not added initially, or (b) someone will restart the node because something
+        // has gone horribly wrong, in which case these HashMaps will be lost anyways.
+        if self.blocks_missing_chunks.len() >= MAX_BLOCKS_MISSING_CHUNKS {
+            warn!(target: "chunks", "Not recording block with hash {} even though it is missing chunks. The missing chunks pool is full.", block_hash);
+            return;
+        }
+
+        for chunk_hash in missing_chunks.iter().cloned() {
+            let blocks_for_chunk =
+                self.missing_chunks.entry(chunk_hash).or_insert_with(HashSet::new);
+            blocks_for_chunk.insert(block_hash);
+        }
+
+        // Convert to HashSet
+        let missing_chunks = missing_chunks.into_iter().collect();
+        match self.blocks_missing_chunks.entry(block_hash) {
+            hash_map::Entry::Vacant(entry) => {
+                entry.insert(missing_chunks);
+            }
+            // The Occupied case should never happen since we know
+            // all the missing chunks for a block the first time we receive it,
+            // and we should not call `add_block_with_missing_chunks` again after
+            // we know a block is missing chunks.
+            hash_map::Entry::Occupied(mut entry) => {
+                let previous_chunks = entry.insert(missing_chunks);
+                warn!(target: "chunks", "Block with hash {} was already missing chunks {:?}.", block_hash, previous_chunks);
+            }
+        }
+
+        let height = block.height();
+        let blocks_at_height = self.height_idx.entry(height).or_insert_with(HashSet::new);
+        blocks_at_height.insert(block_hash);
+        self.blocks_waiting_for_chunks.insert(block_hash, block);
+    }
+
+    pub fn accept_chunk(&mut self, chunk_hash: &ChunkHash, height_included: BlockHeight) {
+        let block_hashes = self.missing_chunks.remove(chunk_hash).unwrap_or_else(HashSet::new);
+        for block_hash in block_hashes {
+            match self.blocks_missing_chunks.entry(block_hash) {
+                hash_map::Entry::Occupied(mut missing_chunks_entry) => {
+                    let missing_chunks = missing_chunks_entry.get_mut();
+                    missing_chunks.remove(chunk_hash);
+                    if missing_chunks.is_empty() {
+                        // No more missing chunks!
+                        missing_chunks_entry.remove_entry();
+                        self.mark_block_as_ready(&block_hash);
+                    }
+                }
+                hash_map::Entry::Vacant(_) => {
+                    warn!(target: "chunks", "Invalid MissingChunksPool state. Block with hash {} was still a value of the missing_chunks map, but not present in the blocks_missing_chunks map", block_hash);
+                    self.mark_block_as_ready(&block_hash);
+                }
+            }
+        }
+        // Chunks are accepted in order of height (because they rely on knowing the prev_block),
+        // so if we accept a chunk at `height_included` then we know we are not waiting for anything
+        // below that height. This is another way we can keep the size of this data structure
+        // under its limit.
+        self.prune_blocks_below_height(height_included);
+    }
+
+    fn mark_block_as_ready(&mut self, block_hash: &BlockHash) {
+        for block in self.blocks_waiting_for_chunks.remove(block_hash) {
+            let height = block.height();
+            if let btree_map::Entry::Occupied(mut entry) = self.height_idx.entry(height) {
+                let blocks_at_height = entry.get_mut();
+                blocks_at_height.remove(block_hash);
+                if blocks_at_height.is_empty() {
+                    entry.remove_entry();
+                }
+            }
+            self.blocks_ready_to_process.push(HeightOrdered(block));
+        }
+    }
+
+    fn prune_blocks_below_height(&mut self, height: BlockHeight) {
+        let heights_to_remove: Vec<BlockHeight> =
+            self.height_idx.keys().copied().take_while(|h| *h < height).collect();
+        for h in heights_to_remove {
+            if let Some(block_hashes) = self.height_idx.remove(&h) {
+                for block_hash in block_hashes {
+                    self.blocks_waiting_for_chunks.remove(&block_hash);
+                    if let Some(chunk_hashes) = self.blocks_missing_chunks.remove(&block_hash) {
+                        for chunk_hash in chunk_hashes {
+                            if let hash_map::Entry::Occupied(mut entry) =
+                                self.missing_chunks.entry(chunk_hash)
+                            {
+                                let blocks_for_chunk = entry.get_mut();
+                                blocks_for_chunk.remove(&block_hash);
+                                if blocks_for_chunk.is_empty() {
+                                    entry.remove_entry();
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{BlockHash, BlockLike, MissingChunksPool, MAX_BLOCKS_MISSING_CHUNKS};
+    use near_primitives::hash::{hash, CryptoHash};
+    use near_primitives::sharding::ChunkHash;
+    use near_primitives::types::BlockHeight;
+
+    fn get_hash(idx: u64) -> CryptoHash {
+        hash(&idx.to_le_bytes())
+    }
+
+    fn get_chunk_hash(idx: u64) -> ChunkHash {
+        ChunkHash(get_hash(idx))
+    }
+
+    #[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
+    struct MockBlock {
+        hash: BlockHash,
+        height: BlockHeight,
+    }
+    impl MockBlock {
+        fn new(height: BlockHeight) -> Self {
+            Self { hash: get_hash(height), height }
+        }
+    }
+    impl BlockLike for MockBlock {
+        fn hash(&self) -> BlockHash {
+            self.hash
+        }
+
+        fn height(&self) -> u64 {
+            self.height
+        }
+    }
+
+    #[test]
+    fn should_mark_blocks_as_ready_after_all_chunks_accepted() {
+        let mut pool: MissingChunksPool<MockBlock> = MissingChunksPool::default();
+
+        let block_height = 0;
+        let block = MockBlock::new(block_height);
+        let chunk_hashes: Vec<ChunkHash> = (101..105).map(get_chunk_hash).collect();
+
+        pool.add_block_with_missing_chunks(block.clone(), chunk_hashes.clone());
+        assert!(pool.contains(&block.hash));
+
+        for chunk_hash in chunk_hashes.iter().skip(1) {
+            pool.accept_chunk(chunk_hash, block_height);
+            assert!(pool.contains(&block.hash));
+        }
+
+        // after the last chunk is accepted the block is ready to process
+        pool.accept_chunk(&chunk_hashes[0], block_height);
+        assert!(!pool.contains(&block.hash));
+        assert_eq!(pool.ready_blocks(), vec![block]);
+    }
+
+    #[test]
+    fn should_not_add_new_blocks_after_size_limit() {
+        let mut pool: MissingChunksPool<MockBlock> = MissingChunksPool::default();
+        let mut chunk_hash_idx = MAX_BLOCKS_MISSING_CHUNKS as BlockHeight;
+
+        for block_height in 0..MAX_BLOCKS_MISSING_CHUNKS {
+            let block_height = block_height as BlockHeight;
+            let block = MockBlock::new(block_height);
+            chunk_hash_idx += 1;
+            let missing_chunk_hash = get_chunk_hash(chunk_hash_idx);
+            let block_hash = block.hash;
+            pool.add_block_with_missing_chunks(block, vec![missing_chunk_hash]);
+            assert!(pool.contains(&block_hash));
+        }
+
+        let block_height = MAX_BLOCKS_MISSING_CHUNKS as BlockHeight;
+        let block = MockBlock::new(block_height);
+        chunk_hash_idx += 1;
+        let missing_chunk_hash = get_chunk_hash(chunk_hash_idx);
+        let block_hash = block.hash;
+        pool.add_block_with_missing_chunks(block, vec![missing_chunk_hash]);
+        assert!(!pool.contains(&block_hash));
+    }
+
+    #[test]
+    fn should_remove_old_blocks_if_later_chunk_added() {
+        let mut pool: MissingChunksPool<MockBlock> = MissingChunksPool::default();
+
+        let block = MockBlock::new(0);
+        let early_block_hash = block.hash;
+        let missing_chunk_hash = get_chunk_hash(100);
+        pool.add_block_with_missing_chunks(block, vec![missing_chunk_hash]);
+
+        let block_height = 1;
+        let block = MockBlock::new(block_height);
+        let missing_chunk_hash = get_chunk_hash(200);
+        pool.add_block_with_missing_chunks(block.clone(), vec![missing_chunk_hash.clone()]);
+
+        let later_block = MockBlock::new(block_height + 1);
+        let later_block_hash = later_block.hash;
+        pool.add_block_with_missing_chunks(later_block, vec![get_chunk_hash(300)]);
+
+        pool.accept_chunk(&missing_chunk_hash, block_height);
+        assert_eq!(pool.ready_blocks(), vec![block]);
+        assert!(!pool.contains(&early_block_hash));
+        assert!(pool.contains(&later_block_hash));
+    }
+}

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -926,7 +926,10 @@ impl Client {
         }
 
         if status.is_new_head() {
-            self.shards_mgr.update_largest_seen_height(block.header().height());
+            let height = block.header().height();
+            self.shards_mgr.update_largest_seen_height(height);
+            let prune_height = height - 2 * self.config.epoch_length;
+            self.chain.blocks_with_missing_chunks.prune_blocks_below_height(prune_height);
             if !self.config.archive {
                 let timer = near_metrics::start_timer(&metrics::GC_TIME);
                 if let Err(err) = self

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -796,7 +796,6 @@ impl Client {
                 };
 
                 let chunk_hash = partial_encoded_chunk.chunk_hash();
-                let height_included = partial_encoded_chunk.height_included();
                 let process_result = self.shards_mgr.process_partial_encoded_chunk(
                     partial_encoded_chunk.clone().into(),
                     self.chain.mut_store(),
@@ -807,9 +806,7 @@ impl Client {
                 match process_result {
                     ProcessPartialEncodedChunkResult::Known => Ok(vec![]),
                     ProcessPartialEncodedChunkResult::HaveAllPartsAndReceipts(_) => {
-                        self.chain
-                            .blocks_with_missing_chunks
-                            .accept_chunk(&chunk_hash, height_included);
+                        self.chain.blocks_with_missing_chunks.accept_chunk(&chunk_hash);
                         Ok(self.process_blocks_with_missing_chunks(protocol_version))
                     }
                     ProcessPartialEncodedChunkResult::NeedMorePartsOrReceipts(chunk_header) => {

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -961,7 +961,6 @@ impl ClientActor {
             debug!(target: "client", "dropping block {} that is too far behind. Block height {} current tail height {}", block.hash(), block.header().height(), tail);
             return;
         }
-        self.client.chain.blocks_with_missing_chunks.prune_blocks_below_height(tail);
         let prev_hash = *block.header().prev_hash();
         let block_protocol_version = block.header().latest_protocol_version();
         let provenance =

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -961,6 +961,7 @@ impl ClientActor {
             debug!(target: "client", "dropping block {} that is too far behind. Block height {} current tail height {}", block.hash(), block.header().height(), tail);
             return;
         }
+        self.client.chain.blocks_with_missing_chunks.prune_blocks_below_height(tail);
         let prev_hash = *block.header().prev_hash();
         let block_protocol_version = block.header().latest_protocol_version();
         let provenance =

--- a/chain/client/tests/challenges.rs
+++ b/chain/client/tests/challenges.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use borsh::BorshSerialize;
 
+use near_chain::missing_chunks::MissingChunksPool;
 use near_chain::types::BlockEconomicsConfig;
 use near_chain::validate::validate_challenge;
 use near_chain::{
@@ -368,6 +369,7 @@ fn test_verify_chunk_invalid_state_challenge() {
         let adapter = chain.runtime_adapter.clone();
         let epoch_length = chain.epoch_length;
         let empty_block_pool = OrphanBlockPool::new();
+        let empty_chunks_pool = MissingChunksPool::new();
         let chain_genesis = ChainGenesis::from(&genesis);
         let economics_config = BlockEconomicsConfig::from(&chain_genesis);
 
@@ -375,7 +377,7 @@ fn test_verify_chunk_invalid_state_challenge() {
             chain.mut_store(),
             adapter,
             &empty_block_pool,
-            &empty_block_pool,
+            &empty_chunks_pool,
             epoch_length,
             &economics_config,
             DoomslugThresholdMode::NoApprovals,

--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -1897,12 +1897,16 @@ fn test_validate_chunk_extra() {
     // Process the previously unavailable chunk. This causes two blocks to be accepted.
     let mut chain_store =
         ChainStore::new(env.clients[0].chain.store().owned_store(), genesis_height);
+    let chunk_header = encoded_chunk.cloned_header();
     env.clients[0]
         .shards_mgr
         .distribute_encoded_chunk(encoded_chunk, merkle_paths, receipts, &mut chain_store)
         .unwrap();
-    let accepted_blocks =
-        env.clients[0].process_blocks_with_missing_chunks(*last_block.hash(), PROTOCOL_VERSION);
+    env.clients[0]
+        .chain
+        .blocks_with_missing_chunks
+        .accept_chunk(&chunk_header.chunk_hash(), chunk_header.height_included());
+    let accepted_blocks = env.clients[0].process_blocks_with_missing_chunks(PROTOCOL_VERSION);
     assert_eq!(accepted_blocks.len(), 2);
     for (i, accepted_block) in accepted_blocks.into_iter().enumerate() {
         if i == 0 {

--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -1902,10 +1902,7 @@ fn test_validate_chunk_extra() {
         .shards_mgr
         .distribute_encoded_chunk(encoded_chunk, merkle_paths, receipts, &mut chain_store)
         .unwrap();
-    env.clients[0]
-        .chain
-        .blocks_with_missing_chunks
-        .accept_chunk(&chunk_header.chunk_hash(), chunk_header.height_included());
+    env.clients[0].chain.blocks_with_missing_chunks.accept_chunk(&chunk_header.chunk_hash());
     let accepted_blocks = env.clients[0].process_blocks_with_missing_chunks(PROTOCOL_VERSION);
     assert_eq!(accepted_blocks.len(), 2);
     for (i, accepted_block) in accepted_blocks.into_iter().enumerate() {

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -428,6 +428,13 @@ impl PartialEncodedChunk {
         }
     }
 
+    pub fn height_included(&self) -> BlockHeight {
+        match self {
+            Self::V1(chunk) => chunk.header.height_included,
+            Self::V2(chunk) => chunk.header.height_included(),
+        }
+    }
+
     #[inline]
     pub fn parts(&self) -> &Vec<PartialEncodedChunkPart> {
         match self {


### PR DESCRIPTION
Previously the logic was to try applying all blocks which were missing chunks each time we added a new chunk, even if there were still more chunks missing. With this change we now keep track of what chunks each block is missing and only apply the block again after we have all the missing chunks.

Fixes #3684 

Testing plan:

* new tests for the new data structure
* existing unit tests