### PR TITLE
fix(chunks & network): Remove some unnecessary cloning

### DIFF
--- a/chain/chunks/src/chunk_cache.rs
+++ b/chain/chunks/src/chunk_cache.rs
@@ -75,17 +75,14 @@ impl EncodedChunksCache {
     }
 
     // `chunk_header` must be `Some` if the entry is absent, caller must ensure that
-    pub fn get_or_insert_from_header<F>(
+    pub fn get_or_insert_from_header(
         &mut self,
         chunk_hash: ChunkHash,
-        lazy_chunk_header: F,
-    ) -> &mut EncodedChunksCacheEntry
-    where
-        F: FnOnce() -> ShardChunkHeader,
-    {
+        chunk_header: &ShardChunkHeader,
+    ) -> &mut EncodedChunksCacheEntry {
         self.encoded_chunks
             .entry(chunk_hash)
-            .or_insert_with(|| EncodedChunksCacheEntry::from_chunk_header(lazy_chunk_header()))
+            .or_insert_with(|| EncodedChunksCacheEntry::from_chunk_header(chunk_header.clone()))
     }
 
     pub fn height_within_front_horizon(&self, height: BlockHeight) -> bool {
@@ -105,8 +102,8 @@ impl EncodedChunksCache {
         partial_encoded_chunk: &PartialEncodedChunkV2,
     ) {
         let chunk_hash = partial_encoded_chunk.header.chunk_hash();
-        let entry = self
-            .get_or_insert_from_header(chunk_hash.clone(), || partial_encoded_chunk.header.clone());
+        let entry =
+            self.get_or_insert_from_header(chunk_hash.clone(), &partial_encoded_chunk.header);
         let height = entry.header.height_created();
         entry.merge_in_partial_encoded_chunk(&partial_encoded_chunk);
         self.height_map.entry(height).or_insert_with(|| HashSet::default()).insert(chunk_hash);

--- a/chain/chunks/src/chunk_cache.rs
+++ b/chain/chunks/src/chunk_cache.rs
@@ -75,14 +75,17 @@ impl EncodedChunksCache {
     }
 
     // `chunk_header` must be `Some` if the entry is absent, caller must ensure that
-    pub fn get_or_insert_from_header(
+    pub fn get_or_insert_from_header<F>(
         &mut self,
         chunk_hash: ChunkHash,
-        chunk_header: ShardChunkHeader,
-    ) -> &mut EncodedChunksCacheEntry {
+        lazy_chunk_header: F,
+    ) -> &mut EncodedChunksCacheEntry
+    where
+        F: FnOnce() -> ShardChunkHeader,
+    {
         self.encoded_chunks
             .entry(chunk_hash)
-            .or_insert_with(|| EncodedChunksCacheEntry::from_chunk_header(chunk_header))
+            .or_insert_with(|| EncodedChunksCacheEntry::from_chunk_header(lazy_chunk_header()))
     }
 
     pub fn height_within_front_horizon(&self, height: BlockHeight) -> bool {
@@ -103,7 +106,7 @@ impl EncodedChunksCache {
     ) {
         let chunk_hash = partial_encoded_chunk.header.chunk_hash();
         let entry = self
-            .get_or_insert_from_header(chunk_hash.clone(), partial_encoded_chunk.header.clone());
+            .get_or_insert_from_header(chunk_hash.clone(), || partial_encoded_chunk.header.clone());
         let height = entry.header.height_created();
         entry.merge_in_partial_encoded_chunk(&partial_encoded_chunk);
         self.height_map.entry(height).or_insert_with(|| HashSet::default()).insert(chunk_hash);

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -75,7 +75,7 @@ pub enum ProcessPartialEncodedChunkResult {
     HaveAllPartsAndReceipts(CryptoHash),
     /// The Header is the header of the current chunk, which is unknown to the caller, to request
     ///     parts / receipts for
-    NeedMorePartsOrReceipts(Box<ShardChunkHeader>),
+    NeedMorePartsOrReceipts,
     /// PartialEncodedChunkMessage is received earlier than Block for the same height.
     /// Without the block we cannot restore the epoch and save encoded chunk data.
     NeedBlock,
@@ -598,7 +598,7 @@ impl ShardsManager {
 
     fn request_chunk_single(
         &mut self,
-        chunk_header: ShardChunkHeader,
+        chunk_header: &ShardChunkHeader,
         header_head: Option<&Tip>,
         protocol_version: ProtocolVersion,
     ) {
@@ -611,7 +611,7 @@ impl ShardsManager {
             return;
         }
 
-        self.encoded_chunks.get_or_insert_from_header(chunk_hash.clone(), chunk_header);
+        self.encoded_chunks.get_or_insert_from_header(chunk_hash.clone(), || chunk_header.clone());
 
         self.requested_partial_encoded_chunks.insert(
             chunk_hash.clone(),
@@ -669,7 +669,7 @@ impl ShardsManager {
         T: IntoIterator<Item = ShardChunkHeader>,
     {
         for chunk_header in chunks_to_request {
-            self.request_chunk_single(chunk_header, Some(header_head), protocol_version)
+            self.request_chunk_single(&chunk_header, Some(header_head), protocol_version)
         }
     }
 
@@ -1083,7 +1083,7 @@ impl ShardsManager {
 
     pub fn process_partial_encoded_chunk(
         &mut self,
-        partial_encoded_chunk: MaybeValidated<PartialEncodedChunkV2>,
+        partial_encoded_chunk: MaybeValidated<&PartialEncodedChunkV2>,
         chain_store: &mut ChainStore,
         rs: &mut ReedSolomonWrapper,
         protocol_version: ProtocolVersion,
@@ -1121,7 +1121,7 @@ impl ShardsManager {
         if !partial_encoded_chunk.header.version_range().contains(protocol_version) {
             return Err(Error::InvalidChunkHeader);
         }
-        let header = partial_encoded_chunk.header.clone();
+        let header = &partial_encoded_chunk.header;
         let chunk_hash = header.chunk_hash();
 
         // 2. Leave if we received known chunk
@@ -1212,7 +1212,7 @@ impl ShardsManager {
         );
         store_update.commit()?;
 
-        self.encoded_chunks.merge_in_partial_encoded_chunk(&partial_encoded_chunk);
+        self.encoded_chunks.merge_in_partial_encoded_chunk(partial_encoded_chunk);
 
         // Forward my parts to others tracking this chunk's shard
         checked_feature!(
@@ -1284,7 +1284,7 @@ impl ShardsManager {
         if can_reconstruct {
             let height = header.height_created();
             let mut encoded_chunk = EncodedShardChunk::from_header(
-                header,
+                header.clone(),
                 self.runtime_adapter.num_total_parts(),
                 protocol_version,
             );
@@ -1307,7 +1307,7 @@ impl ShardsManager {
         }
 
         match self.chunk_forwards_cache.cache_remove(&chunk_hash) {
-            None => Ok(ProcessPartialEncodedChunkResult::NeedMorePartsOrReceipts(Box::new(header))),
+            None => Ok(ProcessPartialEncodedChunkResult::NeedMorePartsOrReceipts),
 
             Some(forwarded_parts) => {
                 // We have the header now, and there were some parts we were forwarded earlier.
@@ -1323,7 +1323,7 @@ impl ShardsManager {
                 self.process_partial_encoded_chunk(
                     // We can assert the signature on the header is valid because
                     // it would have been checked in an earlier call to this function.
-                    MaybeValidated::Validated(forwarded_chunk),
+                    MaybeValidated::Validated(&forwarded_chunk),
                     chain_store,
                     rs,
                     protocol_version,
@@ -1337,7 +1337,7 @@ impl ShardsManager {
     #[cfg(feature = "protocol_feature_forward_chunk_parts")]
     pub fn send_partial_encoded_chunk_to_chunk_trackers(
         &mut self,
-        partial_encoded_chunk: PartialEncodedChunkV2,
+        partial_encoded_chunk: &PartialEncodedChunkV2,
     ) -> Result<(), Error> {
         let me = match &self.me {
             Some(me) => me,
@@ -1348,12 +1348,13 @@ impl ShardsManager {
         let shard_id = partial_encoded_chunk.header.shard_id();
         let owned_parts: Vec<_> = partial_encoded_chunk
             .parts
-            .into_iter()
+            .iter()
             .filter(|part| {
                 self.runtime_adapter
                     .get_part_owner(&parent_hash, part.part_ord)
                     .map_or(false, |owner| &owner == me)
             })
+            .cloned()
             .collect();
 
         if owned_parts.is_empty() {
@@ -1845,9 +1846,10 @@ mod test {
             encoded_chunk.create_partial_encoded_chunk(vec![2, 3, 4], vec![], &proof);
         std::thread::sleep(Duration::from_millis(ACCEPTING_SEAL_PERIOD_MS as u64 + 100));
         for partial_encoded_chunk in vec![partial_encoded_chunk1, partial_encoded_chunk2] {
+            let pec_v2 = partial_encoded_chunk.into();
             shards_manager
                 .process_partial_encoded_chunk(
-                    MaybeValidated::NotValidated(partial_encoded_chunk.into()),
+                    MaybeValidated::NotValidated(&pec_v2),
                     &mut chain_store,
                     &mut rs,
                     PROTOCOL_VERSION,
@@ -1962,15 +1964,15 @@ mod test {
         let partial_encoded_chunk = fixture.make_partial_encoded_chunk(&fixture.mock_part_ords);
         let result = shards_manager
             .process_partial_encoded_chunk(
-                MaybeValidated::NotValidated(partial_encoded_chunk),
+                MaybeValidated::NotValidated(&partial_encoded_chunk),
                 &mut fixture.chain_store,
                 &mut fixture.rs,
                 PROTOCOL_VERSION,
             )
             .unwrap();
         match result {
-            ProcessPartialEncodedChunkResult::NeedMorePartsOrReceipts(_) => shards_manager
-                .request_chunk_single(fixture.mock_chunk_header.clone(), None, PROTOCOL_VERSION),
+            ProcessPartialEncodedChunkResult::NeedMorePartsOrReceipts => shards_manager
+                .request_chunk_single(&fixture.mock_chunk_header, None, PROTOCOL_VERSION),
 
             _ => panic!("Expected to need more parts!"),
         }
@@ -2033,7 +2035,7 @@ mod test {
         };
         let result = shards_manager
             .process_partial_encoded_chunk(
-                MaybeValidated::NotValidated(partial_encoded_chunk),
+                MaybeValidated::NotValidated(&partial_encoded_chunk),
                 &mut fixture.chain_store,
                 &mut fixture.rs,
                 PROTOCOL_VERSION,

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -611,7 +611,7 @@ impl ShardsManager {
             return;
         }
 
-        self.encoded_chunks.get_or_insert_from_header(chunk_hash.clone(), || chunk_header.clone());
+        self.encoded_chunks.get_or_insert_from_header(chunk_hash.clone(), chunk_header);
 
         self.requested_partial_encoded_chunks.insert(
             chunk_hash.clone(),

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -27,7 +27,8 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{merklize, MerklePath};
 use near_primitives::receipt::Receipt;
 use near_primitives::sharding::{
-    EncodedShardChunk, PartialEncodedChunk, ReedSolomonWrapper, ShardChunkHeader,
+    EncodedShardChunk, PartialEncodedChunk, PartialEncodedChunkV2, ReedSolomonWrapper,
+    ShardChunkHeader,
 };
 use near_primitives::syncing::ReceiptResponse;
 use near_primitives::transaction::SignedTransaction;
@@ -45,8 +46,6 @@ use near_primitives::version::{ProtocolVersion, PROTOCOL_VERSION};
 
 #[cfg(feature = "protocol_feature_forward_chunk_parts")]
 use near_network::types::PartialEncodedChunkForwardMsg;
-#[cfg(feature = "protocol_feature_forward_chunk_parts")]
-use near_primitives::sharding::PartialEncodedChunkV2;
 
 const NUM_REBROADCAST_BLOCKS: usize = 30;
 

--- a/chain/network/src/codec.rs
+++ b/chain/network/src/codec.rs
@@ -66,7 +66,7 @@ impl Decoder for Codec {
     }
 }
 
-pub fn peer_message_to_bytes(peer_message: PeerMessage) -> Result<Vec<u8>, std::io::Error> {
+pub fn peer_message_to_bytes(peer_message: &PeerMessage) -> Result<Vec<u8>, std::io::Error> {
     peer_message.try_to_vec()
 }
 
@@ -148,7 +148,7 @@ mod test {
     fn test_codec(msg: PeerMessage) {
         let mut codec = Codec::new();
         let mut buffer = BytesMut::new();
-        codec.encode(peer_message_to_bytes(msg.clone()).unwrap(), &mut buffer).unwrap();
+        codec.encode(peer_message_to_bytes(&msg).unwrap(), &mut buffer).unwrap();
         let decoded = codec.decode(&mut buffer).unwrap().unwrap().unwrap();
         assert_eq!(bytes_to_peer_message(&decoded).unwrap(), msg);
     }
@@ -290,7 +290,7 @@ mod test {
 
         let mut codec = Codec::new();
         let mut buffer = BytesMut::new();
-        codec.encode(peer_message_to_bytes(msg.clone()).unwrap(), &mut buffer).unwrap();
+        codec.encode(peer_message_to_bytes(&msg).unwrap(), &mut buffer).unwrap();
         let decoded = codec.decode(&mut buffer).unwrap().unwrap().unwrap();
 
         let err = bytes_to_peer_message(&decoded).unwrap_err();

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -836,8 +836,11 @@ impl PeerManagerActor {
     fn broadcast_message(&self, ctx: &mut Context<Self>, msg: SendMessage) {
         // TODO(MarX, #1363): Implement smart broadcasting. (MST)
 
+        // Change message to reference counted to allow sharing with all actors
+        // without cloning.
+        let msg = Arc::new(msg);
         let mut requests: futures::stream::FuturesUnordered<_> =
-            self.active_peers.values().map(|peer| peer.addr.send(msg.clone())).collect();
+            self.active_peers.values().map(|peer| peer.addr.send(Arc::clone(&msg))).collect();
 
         ctx.spawn(async move {
             while let Some(response) = requests.next().await {

--- a/core/primitives/src/utils.rs
+++ b/core/primitives/src/utils.rs
@@ -42,6 +42,13 @@ impl<T> MaybeValidated<T> {
         }
     }
 
+    pub fn as_ref(&self) -> MaybeValidated<&T> {
+        match &self {
+            Self::Validated(ref t) => MaybeValidated::Validated(t),
+            Self::NotValidated(ref t) => MaybeValidated::NotValidated(t),
+        }
+    }
+
     pub fn extract(self) -> T {
         match self {
             Self::Validated(t) => t,


### PR DESCRIPTION
This PR attempts to improve performance by limiting the amount of cloning done in the logic for processing partial encoded chunks. In the process I found there were a couple places in the networking layer where there was excess cloning as well, and fixed there too.

Fixes #3700 

Testing plan:
  * No logic is changed, so we rely on existing testing infrastructure