### PR TITLE
fix(download-genesis): increase the maximum size of the genesis size

### DIFF
--- a/neard/src/config.rs
+++ b/neard/src/config.rs
@@ -1011,9 +1011,9 @@ pub fn download_genesis(url: &String, path: &PathBuf) {
         // In case where the genesis is bigger than the specified limit Overflow Error is thrown
         let body = response
             .body()
-            .limit(2_500_000_000)
+            .limit(10_000_000_000)
             .await
-            .expect("Genesis file is bigger than 2.5GB. Please make the limit higher.");
+            .expect("Genesis file is bigger than 10GB. Please make the limit higher.");
 
         std::fs::write(&path, &body).expect("Failed to create / write a config file.");
 


### PR DESCRIPTION
We started hitting the limit of the genesis size on testnet. Increasing it.