### PR TITLE
Revert "fix: clear trie view caches before state sync (#3593)"

### DIFF
--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -1737,7 +1737,8 @@ fn test_data_reset_before_state_sync() {
         head_block.header().epoch_id(),
         &QueryRequest::ViewAccount { account_id: "test_account".to_string() },
     );
-    assert!(response.is_err());
+    // TODO(#3742): ViewClient still has data in cache by current design.
+    assert!(response.is_ok());
 }
 
 #[test]

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -82,8 +82,7 @@ impl ShardTries {
             }
         }
         for (shard_id, ops) in shards.into_iter().enumerate() {
-            self.caches[shard_id].update_cache(&ops);
-            self.view_caches[shard_id].update_cache(&ops);
+            self.caches[shard_id].update_cache(ops);
         }
         Ok(())
     }

--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -21,13 +21,13 @@ impl TrieCache {
         Self(Arc::new(Mutex::new(SizedCache::with_size(TRIE_MAX_CACHE_SIZE))))
     }
 
-    pub fn update_cache(&self, ops: &[(CryptoHash, Option<Vec<u8>>)]) {
+    pub fn update_cache(&self, ops: Vec<(CryptoHash, Option<Vec<u8>>)>) {
         let mut guard = self.0.lock().expect(POISONED_LOCK_ERR);
         for (hash, opt_value_rc) in ops {
             if let Some(value_rc) = opt_value_rc {
-                if let (Some(value), _rc) = decode_value_with_rc(value_rc) {
+                if let (Some(value), _rc) = decode_value_with_rc(&value_rc) {
                     if value.len() < TRIE_LIMIT_CACHED_VALUE_SIZE {
-                        guard.cache_set(*hash, value.to_vec());
+                        guard.cache_set(hash, value.to_vec());
                     }
                 } else {
                     guard.cache_remove(&hash);


### PR DESCRIPTION
Revert invalidating view client cache on gc/data reset to avoid
lock contention.
Fixes #3712.
This reverts commit 9428c7dd149e0998e5e693c8c253e490919f293c.