### PR TITLE
Pin the syn dependency to avoid breaking change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ca8ce00b267af8ccebbd647de0d61e0674b6e61185cc7a592ff88772bed655"
 dependencies = [
  "quote 1.0.7",
- "syn 1.0.54",
+ "syn 1.0.57",
 ]
 
 [[package]]
@@ -335,7 +335,7 @@ checksum = "a71bf475cbe07281d0b3696abb48212db118e7e23219f13596ce865235ff5766"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.54",
+ "syn 1.0.57",
 ]
 
 [[package]]
@@ -346,7 +346,7 @@ checksum = "b95aceadaf327f18f0df5962fedc1bde2f870566a0b9f65c89508a3b1f79334c"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.54",
+ "syn 1.0.57",
 ]
 
 [[package]]
@@ -423,7 +423,7 @@ checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.54",
+ "syn 1.0.57",
 ]
 
 [[package]]
@@ -680,7 +680,7 @@ checksum = "b2d74755d937d261d5e9bdef87e0addfbc1ace0214f7776f21532d6e97325356"
 dependencies = [
  "borsh-derive-internal",
  "borsh-schema-derive-internal",
- "syn 1.0.54",
+ "syn 1.0.57",
 ]
 
 [[package]]
@@ -691,7 +691,7 @@ checksum = "4c9f966cb7a42c8ed83546ef481bc1d1dec888fe5f84a4737d5c2094a483e41e"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.54",
+ "syn 1.0.57",
 ]
 
 [[package]]
@@ -702,7 +702,7 @@ checksum = "5df2543b56ebc2b4493e70d024ebde2cbb48d97bf7b1a16318eff30bd02669b8"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.54",
+ "syn 1.0.57",
 ]
 
 [[package]]
@@ -928,7 +928,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.54",
+ "syn 1.0.57",
 ]
 
 [[package]]
@@ -1309,7 +1309,7 @@ checksum = "cb582b60359da160a9477ee80f15c8d784c477e69c217ef2cdd4169c24ea380f"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.54",
+ "syn 1.0.57",
 ]
 
 [[package]]
@@ -1320,7 +1320,7 @@ checksum = "41cb0e6161ad61ed084a36ba71fbba9e3ac5aee3606fb607fe08da6acbcf3d8c"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.54",
+ "syn 1.0.57",
 ]
 
 [[package]]
@@ -1331,7 +1331,7 @@ checksum = "64196eb9f551916167225134f1e8a90f0b5774331d3c900d6328fd94bafe3544"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.54",
+ "syn 1.0.57",
 ]
 
 [[package]]
@@ -1403,7 +1403,7 @@ dependencies = [
  "owning_ref",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.54",
+ "syn 1.0.57",
 ]
 
 [[package]]
@@ -1418,7 +1418,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.54",
+ "syn 1.0.57",
 ]
 
 [[package]]
@@ -1449,7 +1449,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73bb6373ab18cda357d060e1cc36ca2f3fc2783a81b033087a55ac2829cfa737"
 dependencies = [
  "quote 1.0.7",
- "syn 1.0.54",
+ "syn 1.0.57",
 ]
 
 [[package]]
@@ -1523,7 +1523,7 @@ dependencies = [
  "heck",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.54",
+ "syn 1.0.57",
 ]
 
 [[package]]
@@ -1534,7 +1534,7 @@ checksum = "5f52288f9a7ebb08959188872b58e7eaa12af9cb47da8e94158e16da7e143340"
 dependencies = [
  "num-traits",
  "quote 1.0.7",
- "syn 1.0.54",
+ "syn 1.0.57",
 ]
 
 [[package]]
@@ -1644,7 +1644,7 @@ dependencies = [
  "heck",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.54",
+ "syn 1.0.57",
 ]
 
 [[package]]
@@ -1720,7 +1720,7 @@ checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.54",
+ "syn 1.0.57",
  "synstructure",
 ]
 
@@ -1888,7 +1888,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.54",
+ "syn 1.0.57",
 ]
 
 [[package]]
@@ -2062,7 +2062,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.54",
+ "syn 1.0.57",
 ]
 
 [[package]]
@@ -2490,7 +2490,7 @@ checksum = "86a94bc12a53bf84b705acee29eb8697a5ea7b4587d836152499e5db0a6d52b9"
 dependencies = [
  "derive_utils",
  "quote 1.0.7",
- "syn 1.0.54",
+ "syn 1.0.57",
 ]
 
 [[package]]
@@ -2616,7 +2616,7 @@ checksum = "e10200e516c7a80a6dcfb1cdc23cd01ca0d8e97df71e9c5aa6d116302b89a928"
 dependencies = [
  "lazy_static",
  "starts-ends-with-caseless",
- "syn 1.0.54",
+ "syn 1.0.57",
 ]
 
 [[package]]
@@ -2833,7 +2833,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "632647502a8bfa82458c07134791fffa7a719f00427d1afd79c3cb6d4960a982"
 dependencies = [
  "proc-macro2 1.0.24",
- "syn 1.0.54",
+ "syn 1.0.57",
  "synstructure",
 ]
 
@@ -3359,7 +3359,7 @@ name = "near-performance-metrics-macros"
 version = "0.1.0"
 dependencies = [
  "quote 1.0.7",
- "syn 1.0.54",
+ "syn 1.0.57",
 ]
 
 [[package]]
@@ -3437,7 +3437,7 @@ dependencies = [
  "quote 1.0.7",
  "serde",
  "serde_json",
- "syn 1.0.54",
+ "syn 1.0.57",
 ]
 
 [[package]]
@@ -3449,7 +3449,7 @@ dependencies = [
  "quote 1.0.7",
  "serde",
  "serde_json",
- "syn 1.0.54",
+ "syn 1.0.57",
 ]
 
 [[package]]
@@ -3617,6 +3617,7 @@ dependencies = [
  "rand 0.7.3",
  "runtime-params-estimator",
  "serde_json",
+ "syn 1.0.57",
  "testlib",
 ]
 
@@ -4009,7 +4010,7 @@ dependencies = [
  "quote 1.0.7",
  "strum",
  "strum_macros",
- "syn 1.0.54",
+ "syn 1.0.57",
 ]
 
 [[package]]
@@ -4195,7 +4196,7 @@ checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.54",
+ "syn 1.0.57",
 ]
 
 [[package]]
@@ -4206,7 +4207,7 @@ checksum = "f8e8d2bf0b23038a4424865103a4df472855692821aab4e4f5c3312d461d9e5f"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.54",
+ "syn 1.0.57",
 ]
 
 [[package]]
@@ -4293,7 +4294,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.54",
+ "syn 1.0.57",
  "version_check",
 ]
 
@@ -5038,7 +5039,7 @@ checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.54",
+ "syn 1.0.57",
 ]
 
 [[package]]
@@ -5192,7 +5193,7 @@ checksum = "133659a15339456eeeb07572eb02a91c91e9815e9cbc89566944d2c8d3efdbf6"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.54",
+ "syn 1.0.57",
 ]
 
 [[package]]
@@ -5313,7 +5314,7 @@ dependencies = [
  "heck",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.54",
+ "syn 1.0.57",
 ]
 
 [[package]]
@@ -5341,9 +5342,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.54"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2af957a63d6bd42255c359c93d9bfdb97076bd3b820897ce55ffbfbf107f44"
+checksum = "4211ce9909eb971f111059df92c45640aad50a619cf55cd76476be803c4c68e6"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -5358,7 +5359,7 @@ checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.54",
+ "syn 1.0.57",
  "unicode-xid 0.2.1",
 ]
 
@@ -5503,7 +5504,7 @@ checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.54",
+ "syn 1.0.57",
 ]
 
 [[package]]
@@ -5601,7 +5602,7 @@ checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.54",
+ "syn 1.0.57",
 ]
 
 [[package]]
@@ -5700,7 +5701,7 @@ checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.54",
+ "syn 1.0.57",
 ]
 
 [[package]]
@@ -5986,7 +5987,7 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
  "regex",
- "syn 1.0.54",
+ "syn 1.0.57",
  "validator",
 ]
 
@@ -6084,7 +6085,7 @@ dependencies = [
  "heck",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.54",
+ "syn 1.0.57",
 ]
 
 [[package]]
@@ -6132,7 +6133,7 @@ dependencies = [
  "log",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.54",
+ "syn 1.0.57",
  "wasm-bindgen-shared",
 ]
 
@@ -6166,7 +6167,7 @@ checksum = "b5a48c72f299d80557c7c62e37e7225369ecc0c963964059509fbafe917c7549"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.54",
+ "syn 1.0.57",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6592,6 +6593,6 @@ checksum = "c3f369ddb18862aba61aa49bf31e74d29f0f162dec753063200e1dc084345d16"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.54",
+ "syn 1.0.57",
  "synstructure",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,8 @@ members = [
 # pins this version to fix https://github.com/actix/actix-net/issues/129
 actix-rt = "=1.1.1"
 openssl-probe = { version = "0.1.2" }
+# pin syn to fix https://github.com/nushell/nushell/pull/2868
+syn = "=1.0.57"
 
 [dev-dependencies]
 actix = "0.9"


### PR DESCRIPTION
[syn](https://crates.io/crates/syn) [1.0.58](https://crates.io/crates/syn/1.0.58), released yesterday (January 5), breaks our build despite it ostensibly being a semver-compatible update:

<img width="885" alt="Screen Shot 2021-01-06 at 19 25 47" src="https://user-images.githubusercontent.com/4963/103800857-99572700-5055-11eb-9435-e75db91c6da1.png">

To reproduce the problem, remove your top-level `Cargo.lock` and attempt to rebuild nearcore from scratch.

See https://github.com/nushell/nushell/issues/2867 and https://github.com/nushell/nushell/pull/2868 for another project who already ran into this same trouble.

This pull request pins syn to 1.0.57 for now. The pin can be removed once upstream fixes their broken release management process.
