### PR TITLE
feat(mac): add osx nightly builds to the github action

### DIFF
--- a/.github/workflows/mac_binary.yml
+++ b/.github/workflows/mac_binary.yml
@@ -20,3 +20,7 @@ jobs:
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    - run: scripts/binary-release.sh nightly-release
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
we are currently building only the normal release, this is needed for nearup to operate on osx for betanet.