### PR TITLE
fix(runtime): clean up runtime traps, remove unused ones, map wasmer 0.x trap to near error

### DIFF
--- a/runtime/near-vm-errors/src/lib.rs
+++ b/runtime/near-vm-errors/src/lib.rs
@@ -65,10 +65,6 @@ pub enum WasmTrap {
     MisalignedAtomicAccess,
     /// Breakpoint trap.
     BreakpointTrap,
-    /// Stack overflow.
-    StackOverflow,
-    /// Generic trap.
-    GenericTrap,
 }
 
 #[derive(
@@ -359,9 +355,7 @@ impl fmt::Display for WasmTrap {
                 write!(f, "An arithmetic exception, e.g. divided by zero.")
             }
             WasmTrap::MisalignedAtomicAccess => write!(f, "Misaligned atomic access trap."),
-            WasmTrap::GenericTrap => write!(f, "Generic trap."),
             WasmTrap::BreakpointTrap => write!(f, "Breakpoint trap."),
-            WasmTrap::StackOverflow => write!(f, "Stack overflow."),
         }
     }
 }

--- a/runtime/near-vm-runner/tests/test_rs_contract.rs
+++ b/runtime/near-vm-runner/tests/test_rs_contract.rs
@@ -1,5 +1,5 @@
 use near_runtime_fees::RuntimeFeesConfig;
-use near_vm_errors::FunctionCallError;
+use near_vm_errors::{FunctionCallError, WasmTrap};
 use near_vm_logic::mocks::mock_external::MockedExternal;
 use near_vm_logic::types::{Balance, ReturnData};
 use near_vm_logic::{VMConfig, VMContext, VMKind, VMOutcome};
@@ -245,5 +245,5 @@ pub fn test_out_of_memory() {
         LATEST_PROTOCOL_VERSION,
         None,
     );
-    assert_eq!(result.1, Some(VMError::FunctionCallError(FunctionCallError::WasmUnknownError)));
+    assert_eq!(result.1, Some(VMError::FunctionCallError(FunctionCallError::WasmTrap(WasmTrap::Unreachable))));
 }


### PR DESCRIPTION
Some near vm errors were never constructed. Drop some of them, and construct remaining of them when wasmer 0.x trap corresponding traps

Test Plan
---------
near vm tests in CI