### PR TITLE
Cache contract on deployment.

### DIFF
--- a/core/primitives/src/errors.rs
+++ b/core/primitives/src/errors.rs
@@ -90,6 +90,10 @@ pub enum StorageError {
     /// panic in every place that produces this error.
     /// We can check if db is corrupted by verifying everything in the state trie.
     StorageInconsistentState(String),
+    /// Data processing error.
+    /// When storing value we perform an additional operation, and this operation failed
+    /// for some reason. Reason is recorded as string.
+    DataProcessingError(String),
 }
 
 impl std::fmt::Display for StorageError {

--- a/runtime/near-vm-runner/src/lib.rs
+++ b/runtime/near-vm-runner/src/lib.rs
@@ -9,6 +9,7 @@ mod wasmer_runner;
 mod wasmtime_runner;
 pub use near_vm_errors::VMError;
 pub use runner::compile_module;
+pub use runner::precompile;
 pub use runner::run;
 pub use runner::run_vm;
 pub use runner::run_vm_profiled;

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -361,6 +361,8 @@ impl Runtime {
                     account.as_mut().expect(EXPECT_ACCOUNT_EXISTS),
                     &account_id,
                     deploy_contract,
+                    apply_state.cache.clone(),
+                    &apply_state.config.wasm_config,
                 )?;
             }
             Action::FunctionCall(function_call) => {


### PR DESCRIPTION
### Problem
 Currently we blindly deploy the contract, and do not check if it is fully correct Wasm
binary that could be linked with NEAR host functions. As result, our compilation caches could
be attacked by incorrect contracts execution attempts both intentionally and non-intentionally.
Also node on which deployment happened will get precompiled contract immediately.

### Solution

Precompile contracts on deployment and return deployment error immediately.

### Test plan

cargo test --all --workspace

### Considerations

As we store precompiled contracts in regular store, not in trie, propagation of compiled contracts across nodes happens gradually. We could come up with a mechanism to actually distribute precompiled contracts, but this looks like a next step.