### PR TITLE
Revert "Compress compiled contracts."

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,12 +365,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
-name = "adler32"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2610,18 +2604,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
 
 [[package]]
-name = "libflate"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9135df43b1f5d0e333385cb6e7897ecd1a43d7d11b91ac003f4d2c2d2401fdd"
-dependencies = [
- "adler32",
- "crc32fast",
- "rle-decode-fast",
- "take_mut",
-]
-
-[[package]]
 name = "libloading"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3574,7 +3556,6 @@ dependencies = [
  "assert_matches",
  "bencher",
  "borsh",
- "libflate",
  "log",
  "near-evm-runner",
  "near-primitives",
@@ -4789,12 +4770,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rle-decode-fast"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
-
-[[package]]
 name = "rlp"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5392,12 +5367,6 @@ dependencies = [
  "rayon",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "take_mut"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
 name = "target-lexicon"

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -26,7 +26,6 @@ near-vm-errors = { path = "../near-vm-errors", version = "2.3.0" }
 near-primitives = { path = "../../core/primitives" }
 log = "0.4"
 near-evm-runner = { path = "../near-evm-runner", version = "2.3.0", optional = true}
-libflate = "0.1"
 
 [dev-dependencies]
 assert_matches = "1.3"

--- a/runtime/near-vm-runner/src/cache.rs
+++ b/runtime/near-vm-runner/src/cache.rs
@@ -7,7 +7,6 @@ use near_vm_errors::CacheError::{DeserializationError, ReadError, SerializationE
 use near_vm_errors::{CacheError, VMError};
 use near_vm_logic::{VMConfig, VMKind};
 use std::convert::TryFrom;
-use std::io::{Read, Write};
 use wasmer_runtime::{compiler_for_backend, Backend};
 use wasmer_runtime_core::cache::Artifact;
 use wasmer_runtime_core::load_cache_with;
@@ -22,17 +21,7 @@ pub(crate) fn compile_module(
 
 #[derive(Debug, Clone, BorshDeserialize, BorshSerialize)]
 enum ContractCacheKey {
-    Version1 {
-        code_hash: CryptoHash,
-        vm_config_non_crypto_hash: u64,
-        vm_kind: VMKind,
-    },
-    Version2 {
-        code_hash: CryptoHash,
-        vm_config_non_crypto_hash: u64,
-        vm_kind: VMKind,
-        compressed: bool,
-    },
+    Version1 { code_hash: CryptoHash, vm_config_non_crypto_hash: u64, vm_kind: VMKind },
 }
 
 #[derive(Debug, Clone, BorshDeserialize, BorshSerialize)]
@@ -47,11 +36,10 @@ fn get_key(code_hash: &[u8], code: &[u8], vm_kind: VMKind, config: &VMConfig) ->
         // Sometimes caller doesn't compute code_hash, so hash the code ourselves.
         Err(_e) => near_primitives::hash::hash(code),
     };
-    let key = ContractCacheKey::Version2 {
+    let key = ContractCacheKey::Version1 {
         code_hash: hash,
         vm_config_non_crypto_hash: config.non_crypto_hash(),
         vm_kind: vm_kind,
-        compressed: true,
     };
     near_primitives::hash::hash(&key.try_to_vec().unwrap())
 }
@@ -77,12 +65,7 @@ pub(crate) fn compile_and_serialize_wasmer(
     let code = artifact
         .serialize()
         .map_err(|_e| VMError::CacheError(SerializationError { hash: (key.0).0 }))?;
-    let mut encoder =
-        libflate::gzip::Encoder::new(Vec::new()).map_err(|_e| VMError::CacheError(WriteError))?;
-    encoder.write(&code).map_err(|_e| VMError::CacheError(WriteError))?;
-    let compressed_code =
-        encoder.finish().into_result().map_err(|_e| VMError::CacheError(WriteError))?;
-    let serialized = CacheRecord::Code(compressed_code).try_to_vec().unwrap();
+    let serialized = CacheRecord::Code(code).try_to_vec().unwrap();
     cache.put(key.as_ref(), &serialized).map_err(|_e| VMError::CacheError(WriteError))?;
     Ok(module)
 }
@@ -94,14 +77,10 @@ fn deserialize_wasmer(
     serialized: &[u8],
 ) -> Result<Result<wasmer_runtime::Module, VMError>, CacheError> {
     let record = CacheRecord::try_from_slice(serialized).map_err(|_e| DeserializationError)?;
-    let compressed_serialized_artifact = match record {
+    let serialized_artifact = match record {
         CacheRecord::Error(err) => return Ok(Err(err)),
         CacheRecord::Code(code) => code,
     };
-    let mut decoder = libflate::gzip::Decoder::new(&*compressed_serialized_artifact)
-        .map_err(|_e| CacheError::DeserializationError)?;
-    let mut serialized_artifact = Vec::new();
-    decoder.read_to_end(&mut serialized_artifact).map_err(|_e| CacheError::DeserializationError)?;
     let artifact = Artifact::deserialize(serialized_artifact.as_slice())
         .map_err(|_e| CacheError::DeserializationError)?;
     unsafe {


### PR DESCRIPTION
Reverts near/nearcore#3855

What do we gain by compressing contracts in cache? It definitely slows down the runtime which decreases the function call TPS. What the cost effects of doing it?

There was no migration done from cache Key1 to Key2, so if a node runs a current protocol, then all contracts becomes uncompiled at once.

