### PR TITLE
fix(runtime): fix receipt id change

### DIFF
--- a/core/primitives/src/utils.rs
+++ b/core/primitives/src/utils.rs
@@ -153,13 +153,14 @@ pub fn create_action_hash(
 pub fn create_data_id(
     protocol_version: ProtocolVersion,
     action_hash: &CryptoHash,
+    prev_block_hash: &CryptoHash,
     block_hash: &CryptoHash,
     data_index: usize,
 ) -> CryptoHash {
     create_hash_upgradable(
         protocol_version,
         &action_hash,
-        &block_hash,
+        &prev_block_hash,
         &block_hash,
         data_index as u64,
     )

--- a/pytest/tests/sanity/backward_compatible.py
+++ b/pytest/tests/sanity/backward_compatible.py
@@ -87,6 +87,28 @@ def main():
     assert 'error' not in res, res
     assert 'Failure' not in res['result']['status'], res
 
+    data = json.dumps([{"create": {
+        "account_id": "near_2",
+        "method_name": "call_promise",
+        "arguments": [],
+        "amount": "0",
+        "gas": 30000000000000,
+    }, "id": 0 },
+        {"then": {
+            "promise_index": 0,
+            "account_id": "near_3",
+            "method_name": "call_promise",
+            "arguments": [],
+            "amount": "0",
+            "gas": 30000000000000,
+        }, "id": 1}])
+
+    tx = sign_function_call_tx(new_signer_key, new_account_id, 'call_promise', bytes(data, 'utf-8'), 90000000000000, 0, 3, block_hash)
+    res = stable_node.send_tx_and_wait(tx, timeout=20)
+
+    assert 'error' not in res, res
+    assert 'Failure' not in res['result']['status'], res
+
     while max_height < BLOCKS:
         assert time.time() - started < TIMEOUT
         status = current_node.get_status()

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -177,6 +177,7 @@ pub(crate) fn action_function_call(
         action_receipt.gas_price,
         action_hash,
         &apply_state.epoch_id,
+        &apply_state.prev_block_hash,
         &apply_state.block_hash,
         epoch_info_provider,
         apply_state.current_protocol_version,

--- a/runtime/runtime/src/ext.rs
+++ b/runtime/runtime/src/ext.rs
@@ -31,6 +31,7 @@ pub struct RuntimeExt<'a> {
     action_hash: &'a CryptoHash,
     data_count: u64,
     epoch_id: &'a EpochId,
+    prev_block_hash: &'a CryptoHash,
     last_block_hash: &'a CryptoHash,
     epoch_info_provider: &'a dyn EpochInfoProvider,
     current_protocol_version: ProtocolVersion,
@@ -57,6 +58,7 @@ impl<'a> RuntimeExt<'a> {
         gas_price: Balance,
         action_hash: &'a CryptoHash,
         epoch_id: &'a EpochId,
+        prev_block_hash: &'a CryptoHash,
         last_block_hash: &'a CryptoHash,
         epoch_info_provider: &'a dyn EpochInfoProvider,
         current_protocol_version: ProtocolVersion,
@@ -71,6 +73,7 @@ impl<'a> RuntimeExt<'a> {
             action_hash,
             data_count: 0,
             epoch_id,
+            prev_block_hash,
             last_block_hash,
             epoch_info_provider,
             current_protocol_version,
@@ -99,6 +102,7 @@ impl<'a> RuntimeExt<'a> {
         let data_id = create_data_id(
             self.current_protocol_version,
             &self.action_hash,
+            &self.prev_block_hash,
             &self.last_block_hash,
             self.data_count as usize,
         );

--- a/runtime/runtime/src/state_viewer.rs
+++ b/runtime/runtime/src/state_viewer.rs
@@ -126,6 +126,7 @@ impl TrieViewer {
             0,
             &empty_hash,
             &view_state.epoch_id,
+            &view_state.prev_block_hash,
             &view_state.block_hash,
             epoch_info_provider,
             view_state.current_protocol_version,


### PR DESCRIPTION
#3821 introduces a bug in data id calculation as it directly passes in the current block hash instead of passing the prev block hash first and then upgrade to current block hash. This causes nodes with that commit to produce different receipts and therefore different state after they apply a block. The reason why we didn't catch it in CI is that backward_compatible.py does not have a function call that uses promise.

Test plan
----------
`backward_compatible.py` fails after the fix to the test on master but passes after the change in this PR.