### PR TITLE
tool(delay_detector): add configurable min delay

### DIFF
--- a/tools/delay_detector/src/lib.rs
+++ b/tools/delay_detector/src/lib.rs
@@ -12,7 +12,13 @@ pub struct DelayDetector<'a> {
 
 impl<'a> DelayDetector<'a> {
     pub fn new(msg: Cow<'a, str>) -> Self {
-        Self { msg, started: Instant::now(), snapshots: vec![], last_snapshot: None, min_delay: Duration::from_millis(50) }
+        Self {
+            msg,
+            started: Instant::now(),
+            snapshots: vec![],
+            last_snapshot: None,
+            min_delay: Duration::from_millis(50),
+        }
     }
 
     pub fn min_delay(mut self, min_delay: Duration) -> Self {

--- a/tools/delay_detector/src/lib.rs
+++ b/tools/delay_detector/src/lib.rs
@@ -3,6 +3,7 @@ use std::borrow::Cow;
 use std::time::{Duration, Instant};
 
 pub struct DelayDetector<'a> {
+    min_delay: Duration,
     msg: Cow<'a, str>,
     started: Instant,
     snapshots: Vec<((String, String), Duration)>,
@@ -10,8 +11,12 @@ pub struct DelayDetector<'a> {
 }
 
 impl<'a> DelayDetector<'a> {
+    pub fn new_with_min_delay(msg: Cow<'a, str>, min_delay: Duration) -> Self {
+        Self { msg, started: Instant::now(), snapshots: vec![], last_snapshot: None, min_delay }
+    }
+
     pub fn new(msg: Cow<'a, str>) -> Self {
-        Self { msg, started: Instant::now(), snapshots: vec![], last_snapshot: None }
+        Self::new_with_min_delay(msg, Duration::from_millis(50))
     }
 
     pub fn snapshot(&mut self, msg: &str) {
@@ -26,10 +31,11 @@ impl<'a> DelayDetector<'a> {
 impl<'a> Drop for DelayDetector<'a> {
     fn drop(&mut self) {
         let elapsed = Instant::now() - self.started;
-        if elapsed > Duration::from_millis(50) && elapsed <= Duration::from_millis(500) {
+        let long_delay = self.min_delay * 10;
+        if elapsed > self.min_delay && elapsed <= long_delay {
             info!(target: "delay_detector", "Took {:?} processing {}", elapsed, self.msg);
         }
-        if elapsed > Duration::from_millis(500) {
+        if elapsed > long_delay {
             warn!(target: "delay_detector", "LONG DELAY! Took {:?} processing {}", elapsed, self.msg);
             if self.last_snapshot.is_some() {
                 self.snapshot("end");

--- a/tools/delay_detector/src/lib.rs
+++ b/tools/delay_detector/src/lib.rs
@@ -11,12 +11,13 @@ pub struct DelayDetector<'a> {
 }
 
 impl<'a> DelayDetector<'a> {
-    pub fn new_with_min_delay(msg: Cow<'a, str>, min_delay: Duration) -> Self {
-        Self { msg, started: Instant::now(), snapshots: vec![], last_snapshot: None, min_delay }
+    pub fn new(msg: Cow<'a, str>) -> Self {
+        Self { msg, started: Instant::now(), snapshots: vec![], last_snapshot: None, min_delay: Duration::from_millis(50) }
     }
 
-    pub fn new(msg: Cow<'a, str>) -> Self {
-        Self::new_with_min_delay(msg, Duration::from_millis(50))
+    pub fn min_delay(mut self, min_delay: Duration) -> Self {
+        self.min_delay = min_delay;
+        self
     }
 
     pub fn snapshot(&mut self, msg: &str) {


### PR DESCRIPTION
In runtime we often want to cache delay < 50ms, make it configurable so delays from other module still filtered at 50ms.

Test Plan
---------
Build with delay_detector it still works. use delay detector with shorter delay works