### PR TITLE
refactor (indexer) Update Indexer Framework and Indexer example according to changes on actix side

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "near-indexer"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "actix",
  "futures",

--- a/chain/indexer/CHANGELOG.md
+++ b/chain/indexer/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.8.0
+
+* Upgrade dependencies
+
+## Breaking change
+
+actix update changed the way we used to deal with starting the node and getting necessary data from neard.
+The `start()` method was deleted, `Indexer` struct doesn't have `actix_runtime` anymore and runtime should be
+created and started on the Indexer implementation, not on the Indexer Framework one.
+
 ## 0.7.0
 
 * State changes return changes with cause instead of kinds

--- a/chain/indexer/Cargo.toml
+++ b/chain/indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-indexer"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 

--- a/tools/indexer/example/src/main.rs
+++ b/tools/indexer/example/src/main.rs
@@ -269,10 +269,14 @@ fn main() {
                 sync_mode: near_indexer::SyncModeEnum::FromInterruption,
                 await_for_node_synced: near_indexer::AwaitForNodeSyncedEnum::WaitForFullSync,
             };
-            let indexer = near_indexer::Indexer::new(indexer_config);
-            let stream = indexer.streamer();
-            actix::spawn(listen_blocks(stream));
-            indexer.start();
+            actix::System::builder()
+                .stop_on_panic(true)
+                .run(move || {
+                    let indexer = near_indexer::Indexer::new(indexer_config);
+                    let stream = indexer.streamer();
+                    actix::spawn(listen_blocks(stream));
+                })
+                .unwrap();
         }
         SubCommand::Init(config) => near_indexer::init_configs(
             &home_dir,


### PR DESCRIPTION
* Update Indexer Framework to version 0.8.0
* Corresponding changes to Indexer Example to be up to date

All the changes made because of breaking change in actix runtime, we cannot attach processes to runtime while runtime isn't started. That's why runtime needs to be created on the Indexer side like shown in Indexer Example.