### PR TITLE
fix crash in performance stats while logging

### DIFF
--- a/utils/near-performance-metrics/src/stats_enabled.rs
+++ b/utils/near-performance-metrics/src/stats_enabled.rs
@@ -76,7 +76,7 @@ impl ThreadStats {
     ) {
         self.in_progress_since = None;
 
-        let took_since_last_check = min(took, now - self.last_check);
+        let took_since_last_check = min(took, max(self.last_check, now) - self.last_check);
 
         let entry = self.stat.entry((msg, line)).or_insert_with(|| Entry {
             cnt: 0,


### PR DESCRIPTION
There was a crash in log function it would happen rarely because of a race condition when 'performance-stats' feature was enabled.