### PR TITLE
chore(ci): Deny duplicate dependencies for all the features on CI sanity check

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,7 +25,7 @@ steps:
       rustc --version && cargo --version
       cargo fmt --all -- --check
       if [ -e deny.toml ]; then
-        cargo-deny check bans
+        cargo-deny --all-features check bans
       fi
       RUSTFLAGS='-D warnings' cargo check --all --tests --benches --all-features
       python3 scripts/state/update_res.py check


### PR DESCRIPTION
After a recent #3869, we can further improve the sanity of all the dependencies to avoid multiple versions (not only it can increase the binary size and compilation time, but it might also bring some security issues).