### PR TITLE
fix(rosetta-rpc): fixed CORS to be permissive by default

### DIFF
--- a/chain/rosetta-rpc/src/lib.rs
+++ b/chain/rosetta-rpc/src/lib.rs
@@ -869,7 +869,7 @@ async fn construction_submit(
 }
 
 fn get_cors(cors_allowed_origins: &[String]) -> Cors {
-    let mut cors = Cors::default();
+    let mut cors = Cors::permissive();
     if cors_allowed_origins != ["*".to_string()] {
         for origin in cors_allowed_origins {
             cors = cors.allowed_origin(&origin);


### PR DESCRIPTION
It is similar to #3911 (fix for JSON RPC), but now it is for Rosetta RPC