### PR TITLE
fix: make sure to join all arbiters

### DIFF
--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -154,6 +154,12 @@ pub struct PeerManagerActor {
     scheduled_routing_table_update: bool,
 }
 
+impl Drop for PeerManagerActor {
+    fn drop(&mut self) {
+        while self.edge_verifier_pool.connected() {}
+    }
+}
+
 impl PeerManagerActor {
     pub fn new(
         store: Arc<Store>,


### PR DESCRIPTION
fixes #3925

It is a combination of two effects.

_First_, we are using rocks db. It is implemented in C++ and makes use of global
data with desctuctors. Those dtors are run "after main". In practice, "after
main" means "after the main thread is exited". It is thus an error to use
rocksdb instance after main, even if just to destroy it.

_Second_, we use actix, and it doesn't obey the structured concurrency
discipline ouf of the box. Specifically, if you have a test like this:

```rust
#[test]
fn some_test() {
    // do some actix shenanigans
}
```

it very well might be the case that, after the `some_text` function exits, there
are some leftover actix therads running!

In combination, this means that the main testing thread might exit first, while
some actix thread is also exiting and droping rocksdb, which will then observe
destroyed global state.

This PR tries to manually wait for actix threads. There's an API to join
`Arbiter`, which we use. For `SyncArbiter`, the equivalent API seems to be
missing, so we just busy wait.


TODO:

* figure out, why did this surface only actix upgrade? The problem seems
  pre-existing.

* figure out a proper way to join the `SyncActor`.

* figure out patterns that make sure that no therads are leaked by construction
  (aka structured concurrency).
