### PR TITLE
start using near-rust-alloctor-proxy 0.2.7 from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3430,8 +3430,9 @@ dependencies = [
 
 [[package]]
 name = "near-rust-allocator-proxy"
-version = "0.2.6"
-source = "git+https://github.com/near/near-memory-tracker.git?tag=v0.2.6#567647c4987d4f04910ab47e00f427c0c1bf3bf6"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74a52d373eeb19962f3a5e05b716957196a124de1484153f6cb081c36f54cb79"
 dependencies = [
  "arr_macro",
  "backtrace",

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -26,6 +26,7 @@ tracing = "0.1.13"
 tracing-subscriber = "0.2.4"
 num-rational = { version = "0.3", features = ["serde"] }
 openssl-probe = { version = "0.1.2" }
+near-rust-allocator-proxy = "0.2.7"
 
 near-crypto = { path = "../core/crypto" }
 near-primitives = { path = "../core/primitives" }
@@ -42,7 +43,6 @@ near-rosetta-rpc = { path = "../chain/rosetta-rpc", optional = true }
 near-telemetry = { path = "../chain/telemetry" }
 near-epoch-manager = { path = "../chain/epoch_manager" }
 near-performance-metrics = { path = "../utils/near-performance-metrics" }
-near-rust-allocator-proxy = { git = "https://github.com/near/near-memory-tracker.git", tag="v0.2.6" }
 
 delay-detector = { path = "../tools/delay_detector", optional = true }
 

--- a/utils/near-performance-metrics/Cargo.toml
+++ b/utils/near-performance-metrics/Cargo.toml
@@ -13,7 +13,7 @@ futures = "0.3.5"
 log = "0.4"
 once_cell = "1.5.2"
 strum = "0.20"
-near-rust-allocator-proxy = { git = "https://github.com/near/near-memory-tracker.git", tag="v0.2.6" }
+near-rust-allocator-proxy = "0.2.7"
 nix = "0.15.0"
 
 [features]


### PR DESCRIPTION
We will use near-rust-allocator-proxy from crates.io instead of from url.


Closes #3889 