### PR TITLE
refactor(jsonrpc): Add structured errors to query method in ViewClient and RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5534,6 +5534,7 @@ dependencies = [
  "near-evm-runner",
  "near-jsonrpc",
  "near-jsonrpc-client",
+ "near-jsonrpc-primitives",
  "near-logger-utils",
  "near-network",
  "near-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3050,6 +3050,7 @@ dependencies = [
  "failure",
  "failure_derive",
  "log",
+ "near-crypto",
  "near-primitives",
  "thiserror",
 ]
@@ -3128,6 +3129,7 @@ dependencies = [
  "near-chain-configs",
  "near-chain-primitives",
  "near-chunks",
+ "near-crypto",
  "near-network",
  "near-primitives",
  "serde",
@@ -3290,12 +3292,14 @@ dependencies = [
  "lazy_static",
  "near-chain-configs",
  "near-client-primitives",
+ "near-crypto",
  "near-metrics",
  "near-primitives",
  "near-primitives-core",
  "serde",
  "serde_json",
  "thiserror",
+ "tracing",
  "uuid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3292,6 +3292,7 @@ dependencies = [
  "near-client-primitives",
  "near-metrics",
  "near-primitives",
+ "near-primitives-core",
  "serde",
  "serde_json",
  "thiserror",
@@ -3465,6 +3466,7 @@ dependencies = [
  "lazy_static",
  "near-chain-configs",
  "near-client",
+ "near-client-primitives",
  "near-crypto",
  "near-network",
  "near-primitives",
@@ -3752,6 +3754,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "testlib",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3051,6 +3051,7 @@ dependencies = [
  "failure_derive",
  "log",
  "near-primitives",
+ "thiserror",
 ]
 
 [[package]]
@@ -3115,6 +3116,7 @@ dependencies = [
  "strum",
  "sysinfo",
  "testlib",
+ "thiserror",
 ]
 
 [[package]]
@@ -3699,6 +3701,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "testlib",
+ "thiserror",
  "tracing",
  "tracing-subscriber",
 ]

--- a/chain/chain-primitives/Cargo.toml
+++ b/chain/chain-primitives/Cargo.toml
@@ -14,3 +14,4 @@ log = "0.4"
 thiserror = "1.0"
 
 near-primitives = { path = "../../core/primitives" }
+near-crypto = { path = "../../core/crypto" }

--- a/chain/chain-primitives/Cargo.toml
+++ b/chain/chain-primitives/Cargo.toml
@@ -11,5 +11,6 @@ chrono = { version = "0.4.4", features = ["serde"] }
 failure = "0.1"
 failure_derive = "0.1"
 log = "0.4"
+thiserror = "1.0"
 
 near-primitives = { path = "../../core/primitives" }

--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -22,12 +22,15 @@ pub enum QueryError {
     ContractCodeDoesNotExist { contract_account_id: near_primitives::types::AccountId },
     #[error("Access key for public key #{public_key} does not exist while viewing")]
     AccessKeyDoesNotExist { public_key: String },
-    #[error("Storage error occurred: {0:?}")]
-    StorageError(#[from] near_primitives::errors::StorageError),
+    #[error("Storage error occurred: #{storage_error:?}")]
+    StorageError {
+        #[from]
+        storage_error: near_primitives::errors::StorageError,
+    },
     #[error("Internal error occurred: #{error_message}")]
     InternalError { error_message: String },
-    #[error("VM error occurred: {0}")]
-    VMError(String),
+    #[error("VM error occurred: #{error_message}")]
+    VMError { error_message: String },
 }
 
 #[derive(Debug)]

--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -14,18 +14,18 @@ use near_primitives::types::{BlockHeight, EpochId, ShardId};
 
 #[derive(thiserror::Error, Debug)]
 pub enum QueryError {
-    #[error("Invalid account ID {0}")]
-    InvalidAccount(near_primitives::types::AccountId),
-    #[error("Account ID {0} does not exist while viewing")]
-    AccountDoesNotExist(near_primitives::types::AccountId),
-    #[error("Contract ID {0} code does not exist while viewing")]
-    ContractCodeDoesNotExist(near_primitives::types::AccountId),
-    #[error("Access key for public key {0} does not exist while viewing")]
-    AccessKeyDoesNotExist(String),
+    #[error("Invalid account ID #{requested_account_id}")]
+    InvalidAccount { requested_account_id: near_primitives::types::AccountId },
+    #[error("Account ID #{requested_account_id} does not exist while viewing")]
+    AccountDoesNotExist { requested_account_id: near_primitives::types::AccountId },
+    #[error("Contract ID #{contract_account_id} code does not exist while viewing")]
+    ContractCodeDoesNotExist { contract_account_id: near_primitives::types::AccountId },
+    #[error("Access key for public key #{public_key} does not exist while viewing")]
+    AccessKeyDoesNotExist { public_key: String },
     #[error("Storage error occurred: {0:?}")]
     StorageError(#[from] near_primitives::errors::StorageError),
-    #[error("Internal error occurred: {0}")]
-    InternalError(String),
+    #[error("Internal error occurred: #{error_message}")]
+    InternalError { error_message: String },
     #[error("VM error occurred: {0}")]
     VMError(String),
 }

--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -12,6 +12,24 @@ use near_primitives::serialize::to_base;
 use near_primitives::sharding::{ChunkHash, ShardChunkHeader};
 use near_primitives::types::{BlockHeight, EpochId, ShardId};
 
+#[derive(thiserror::Error, Debug)]
+pub enum QueryError {
+    #[error("Invalid account ID {0}")]
+    InvalidAccount(near_primitives::types::AccountId),
+    #[error("Account ID {0} does not exist while viewing")]
+    AccountDoesNotExist(near_primitives::types::AccountId),
+    #[error("Contract ID {0} code does not exist while viewing")]
+    ContractCodeDoesNotExist(near_primitives::types::AccountId),
+    #[error("Access key for public key {0} does not exist while viewing")]
+    AccessKeyDoesNotExist(String),
+    #[error("Storage error occurred: {0:?}")]
+    StorageError(#[from] near_primitives::errors::StorageError),
+    #[error("Internal error occurred: {0}")]
+    InternalError(String),
+    #[error("VM error occurred: {0}")]
+    VMError(String),
+}
+
 #[derive(Debug)]
 pub struct Error {
     inner: Context<ErrorKind>,

--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -14,14 +14,14 @@ use near_primitives::types::{BlockHeight, EpochId, ShardId};
 
 #[derive(thiserror::Error, Debug)]
 pub enum QueryError {
-    #[error("Invalid account ID #{requested_account_id}")]
+    #[error("Account ID #{requested_account_id} is invalid")]
     InvalidAccount { requested_account_id: near_primitives::types::AccountId },
     #[error("Account ID #{requested_account_id} does not exist while viewing")]
     AccountDoesNotExist { requested_account_id: near_primitives::types::AccountId },
     #[error("Contract ID #{contract_account_id} code does not exist while viewing")]
     ContractCodeDoesNotExist { contract_account_id: near_primitives::types::AccountId },
     #[error("Access key for public key #{public_key} does not exist while viewing")]
-    AccessKeyDoesNotExist { public_key: String },
+    AccessKeyDoesNotExist { public_key: near_crypto::PublicKey },
     #[error("Storage error occurred: #{storage_error:?}")]
     StorageError {
         #[from]

--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -16,21 +16,18 @@ use near_primitives::types::{BlockHeight, EpochId, ShardId};
 pub enum QueryError {
     #[error("Account ID #{requested_account_id} is invalid")]
     InvalidAccount { requested_account_id: near_primitives::types::AccountId },
-    #[error("Account ID #{requested_account_id} does not exist while viewing")]
-    AccountDoesNotExist { requested_account_id: near_primitives::types::AccountId },
-    #[error("Contract ID #{contract_account_id} code does not exist while viewing")]
-    ContractCodeDoesNotExist { contract_account_id: near_primitives::types::AccountId },
+    #[error("Account #{requested_account_id} does not exist while viewing")]
+    UnknownAccount { requested_account_id: near_primitives::types::AccountId },
+    #[error(
+        "Contract code for contract ID #{contract_account_id} has never been observed on the node"
+    )]
+    NoContractCode { contract_account_id: near_primitives::types::AccountId },
     #[error("Access key for public key #{public_key} does not exist while viewing")]
-    AccessKeyDoesNotExist { public_key: near_crypto::PublicKey },
-    #[error("Storage error occurred: #{storage_error:?}")]
-    StorageError {
-        #[from]
-        storage_error: near_primitives::errors::StorageError,
-    },
+    UnknownAccessKey { public_key: near_crypto::PublicKey },
     #[error("Internal error occurred: #{error_message}")]
     InternalError { error_message: String },
-    #[error("VM error occurred: #{error_message}")]
-    VMError { error_message: String },
+    #[error("Function call returned an error: #{error_message}")]
+    ContractExecutionError { error_message: String },
 }
 
 #[derive(Debug)]

--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -15,19 +15,43 @@ use near_primitives::types::{BlockHeight, EpochId, ShardId};
 #[derive(thiserror::Error, Debug)]
 pub enum QueryError {
     #[error("Account ID #{requested_account_id} is invalid")]
-    InvalidAccount { requested_account_id: near_primitives::types::AccountId },
+    InvalidAccount {
+        requested_account_id: near_primitives::types::AccountId,
+        block_height: near_primitives::types::BlockHeight,
+        block_hash: near_primitives::hash::CryptoHash,
+    },
     #[error("Account #{requested_account_id} does not exist while viewing")]
-    UnknownAccount { requested_account_id: near_primitives::types::AccountId },
+    UnknownAccount {
+        requested_account_id: near_primitives::types::AccountId,
+        block_height: near_primitives::types::BlockHeight,
+        block_hash: near_primitives::hash::CryptoHash,
+    },
     #[error(
         "Contract code for contract ID #{contract_account_id} has never been observed on the node"
     )]
-    NoContractCode { contract_account_id: near_primitives::types::AccountId },
+    NoContractCode {
+        contract_account_id: near_primitives::types::AccountId,
+        block_height: near_primitives::types::BlockHeight,
+        block_hash: near_primitives::hash::CryptoHash,
+    },
     #[error("Access key for public key #{public_key} does not exist while viewing")]
-    UnknownAccessKey { public_key: near_crypto::PublicKey },
+    UnknownAccessKey {
+        public_key: near_crypto::PublicKey,
+        block_height: near_primitives::types::BlockHeight,
+        block_hash: near_primitives::hash::CryptoHash,
+    },
     #[error("Internal error occurred: #{error_message}")]
-    InternalError { error_message: String },
+    InternalError {
+        error_message: String,
+        block_height: near_primitives::types::BlockHeight,
+        block_hash: near_primitives::hash::CryptoHash,
+    },
     #[error("Function call returned an error: #{error_message}")]
-    ContractExecutionError { error_message: String },
+    ContractExecutionError {
+        error_message: String,
+        block_height: near_primitives::types::BlockHeight,
+        block_hash: near_primitives::hash::CryptoHash,
+    },
 }
 
 #[derive(Debug)]

--- a/chain/chain/src/lib.rs
+++ b/chain/chain/src/lib.rs
@@ -4,6 +4,7 @@ extern crate lazy_static;
 pub use chain::{collect_receipts, Chain, MAX_ORPHAN_SIZE};
 pub use doomslug::{Doomslug, DoomslugBlockProductionReadiness, DoomslugThresholdMode};
 pub use lightclient::{create_light_client_block_view, get_epoch_block_producers_view};
+pub use near_chain_primitives;
 pub use near_chain_primitives::{Error, ErrorKind};
 pub use store::{ChainStore, ChainStoreAccess, ChainStoreUpdate};
 pub use store_validator::{ErrorMessage, StoreValidator};

--- a/chain/chain/src/lib.rs
+++ b/chain/chain/src/lib.rs
@@ -4,8 +4,7 @@ extern crate lazy_static;
 pub use chain::{collect_receipts, Chain, MAX_ORPHAN_SIZE};
 pub use doomslug::{Doomslug, DoomslugBlockProductionReadiness, DoomslugThresholdMode};
 pub use lightclient::{create_light_client_block_view, get_epoch_block_producers_view};
-pub use near_chain_primitives;
-pub use near_chain_primitives::{Error, ErrorKind};
+pub use near_chain_primitives::{self, Error, ErrorKind};
 pub use store::{ChainStore, ChainStoreAccess, ChainStoreUpdate};
 pub use store_validator::{ErrorMessage, StoreValidator};
 pub use types::{

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -787,7 +787,7 @@ impl RuntimeAdapter for KeyValueRuntime {
         block_hash: &CryptoHash,
         _epoch_id: &EpochId,
         request: &QueryRequest,
-    ) -> Result<QueryResponse, Box<dyn std::error::Error>> {
+    ) -> Result<QueryResponse, near_chain_primitives::error::QueryError> {
         match request {
             QueryRequest::ViewAccount { account_id, .. } => Ok(QueryResponse {
                 kind: QueryResponseKind::ViewAccount(

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -575,7 +575,7 @@ pub trait RuntimeAdapter: Send + Sync {
         block_hash: &CryptoHash,
         epoch_id: &EpochId,
         request: &QueryRequest,
-    ) -> Result<QueryResponse, Box<dyn std::error::Error>>;
+    ) -> Result<QueryResponse, near_chain_primitives::error::QueryError>;
 
     fn get_validator_info(
         &self,

--- a/chain/client-primitives/Cargo.toml
+++ b/chain/client-primitives/Cargo.toml
@@ -17,6 +17,7 @@ near-chain-primitives = { path = "../chain-primitives" }
 near-chain-configs = { path = "../../core/chain-configs" }
 
 near-chunks = { path = "../chunks" }
+near-crypto = { path = "../../core/crypto" }
 near-network = { path = "../network" }
 near-primitives = { path = "../../core/primitives" }
 

--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -279,17 +279,37 @@ pub enum QueryError {
     #[error("The node does not track the shard")]
     UnavailableShard { requested_shard_id: near_primitives::types::ShardId },
     #[error("Account ID #{requested_account_id} is invalid")]
-    InvalidAccount { requested_account_id: near_primitives::types::AccountId },
+    InvalidAccount {
+        requested_account_id: near_primitives::types::AccountId,
+        block_height: near_primitives::types::BlockHeight,
+        block_hash: near_primitives::hash::CryptoHash,
+    },
     #[error("Account #{requested_account_id} does not exist while viewing")]
-    UnknownAccount { requested_account_id: near_primitives::types::AccountId },
+    UnknownAccount {
+        requested_account_id: near_primitives::types::AccountId,
+        block_height: near_primitives::types::BlockHeight,
+        block_hash: near_primitives::hash::CryptoHash,
+    },
     #[error(
         "Contract code for contract ID #{contract_account_id} has never been observed on the node"
     )]
-    NoContractCode { contract_account_id: near_primitives::types::AccountId },
+    NoContractCode {
+        contract_account_id: near_primitives::types::AccountId,
+        block_height: near_primitives::types::BlockHeight,
+        block_hash: near_primitives::hash::CryptoHash,
+    },
     #[error("Access key for public key #{public_key} has never been observed on the node")]
-    UnknownAccessKey { public_key: near_crypto::PublicKey },
+    UnknownAccessKey {
+        public_key: near_crypto::PublicKey,
+        block_height: near_primitives::types::BlockHeight,
+        block_hash: near_primitives::hash::CryptoHash,
+    },
     #[error("Function call returned an error: #{vm_error}")]
-    ContractExecutionError { vm_error: String },
+    ContractExecutionError {
+        vm_error: String,
+        block_height: near_primitives::types::BlockHeight,
+        block_hash: near_primitives::hash::CryptoHash,
+    },
     // NOTE: Currently, the underlying errors are too broad, and while we tried to handle
     // expected cases, we cannot statically guarantee that no other errors will be returned
     // in the future.

--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -274,22 +274,22 @@ impl Message for Query {
 pub enum QueryError {
     #[error("IO Error: #{error_message}")]
     IOError { error_message: String },
-    #[error("There are no fully synchronized blocks yet")]
-    NotSyncedYet,
-    #[error("The node does not track the shard #{requested_shard_id} where the requested account resides")]
+    #[error("There are no fully synchronized blocks on the node yet")]
+    NoSyncedBlocks,
+    #[error("The node does not track the shard")]
     UnavailableShard { requested_shard_id: near_primitives::types::ShardId },
-    #[error("Invalid account ID #{requested_account_id}")]
+    #[error("Account ID #{requested_account_id} is invalid")]
     InvalidAccount { requested_account_id: near_primitives::types::AccountId },
-    #[error("Account ID #{requested_account_id} has never been observed on the node")]
-    AccountDoesNotExist { requested_account_id: near_primitives::types::AccountId },
+    #[error("account #{requested_account_id} does not exist while viewing")]
+    UnknownAccount { requested_account_id: near_primitives::types::AccountId },
     #[error(
         "Contract code for contract ID #{contract_account_id} has never been observed on the node"
     )]
-    ContractCodeDoesNotExist { contract_account_id: near_primitives::types::AccountId },
+    NoContractCode { contract_account_id: near_primitives::types::AccountId },
     #[error("Access key for public key #{public_key} has never been observed on the node")]
-    AccessKeyDoesNotExist { public_key: near_crypto::PublicKey },
-    #[error("VM error occurred: #{error_message}")]
-    VMError { error_message: String },
+    UnknownAccessKey { public_key: near_crypto::PublicKey },
+    #[error("Function call returned an error: #{vm_error}")]
+    ContractExecutionError { vm_error: String },
     // NOTE: Currently, the underlying errors are too broad, and while we tried to handle
     // expected cases, we cannot statically guarantee that no other errors will be returned
     // in the future.

--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -287,7 +287,7 @@ pub enum QueryError {
     )]
     ContractCodeDoesNotExist { contract_account_id: near_primitives::types::AccountId },
     #[error("Access key for public key #{public_key} has never been observed on the node")]
-    AccessKeyDoesNotExist { public_key: String },
+    AccessKeyDoesNotExist { public_key: near_crypto::PublicKey },
     #[error("VM error occurred: #{error_message}")]
     VMError { error_message: String },
     // NOTE: Currently, the underlying errors are too broad, and while we tried to handle

--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -272,39 +272,41 @@ impl Message for Query {
 
 #[derive(thiserror::Error, Debug)]
 pub enum QueryError {
-    #[error("IO Error: #{error_message}")]
-    IOError { error_message: String },
+    #[error("Internal error: {error_message}")]
+    InternalError { error_message: String },
     #[error("There are no fully synchronized blocks on the node yet")]
     NoSyncedBlocks,
-    #[error("The node does not track the shard")]
+    #[error("The node does not track the shard ID {requested_shard_id}")]
     UnavailableShard { requested_shard_id: near_primitives::types::ShardId },
-    #[error("Account ID #{requested_account_id} is invalid")]
+    #[error("Account ID {requested_account_id} is invalid")]
     InvalidAccount {
         requested_account_id: near_primitives::types::AccountId,
         block_height: near_primitives::types::BlockHeight,
         block_hash: near_primitives::hash::CryptoHash,
     },
-    #[error("Account #{requested_account_id} does not exist while viewing")]
+    #[error(
+        "Account {requested_account_id} does not exist while viewing at block #{block_height}"
+    )]
     UnknownAccount {
         requested_account_id: near_primitives::types::AccountId,
         block_height: near_primitives::types::BlockHeight,
         block_hash: near_primitives::hash::CryptoHash,
     },
     #[error(
-        "Contract code for contract ID #{contract_account_id} has never been observed on the node"
+        "Contract code for contract ID {contract_account_id} has never been observed on the node at block #{block_height}"
     )]
     NoContractCode {
         contract_account_id: near_primitives::types::AccountId,
         block_height: near_primitives::types::BlockHeight,
         block_hash: near_primitives::hash::CryptoHash,
     },
-    #[error("Access key for public key #{public_key} has never been observed on the node")]
+    #[error("Access key for public key {public_key} has never been observed on the node at block #{block_height}")]
     UnknownAccessKey {
         public_key: near_crypto::PublicKey,
         block_height: near_primitives::types::BlockHeight,
         block_hash: near_primitives::hash::CryptoHash,
     },
-    #[error("Function call returned an error: #{vm_error}")]
+    #[error("Function call returned an error: {vm_error}")]
     ContractExecutionError {
         vm_error: String,
         block_height: near_primitives::types::BlockHeight,
@@ -314,7 +316,7 @@ pub enum QueryError {
     // expected cases, we cannot statically guarantee that no other errors will be returned
     // in the future.
     // TODO #3851: Remove this variant once we can exhaustively match all the underlying errors
-    #[error("It is a bug if you receive this error type, please, report this incident: https://github.com/near/nearcore/issues/new/choose. Details: #{error_message}")]
+    #[error("It is a bug if you receive this error type, please, report this incident: https://github.com/near/nearcore/issues/new/choose. Details: {error_message}")]
     Unreachable { error_message: String },
 }
 
@@ -322,7 +324,7 @@ impl From<near_chain_primitives::Error> for QueryError {
     fn from(error: near_chain_primitives::Error) -> Self {
         match error.kind() {
             near_chain_primitives::ErrorKind::IOErr(error_message) => {
-                Self::IOError { error_message }
+                Self::InternalError { error_message }
             }
             _ => Self::Unreachable { error_message: error.to_string() },
         }

--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -280,7 +280,7 @@ pub enum QueryError {
     UnavailableShard { requested_shard_id: near_primitives::types::ShardId },
     #[error("Account ID #{requested_account_id} is invalid")]
     InvalidAccount { requested_account_id: near_primitives::types::AccountId },
-    #[error("account #{requested_account_id} does not exist while viewing")]
+    #[error("Account #{requested_account_id} does not exist while viewing")]
     UnknownAccount { requested_account_id: near_primitives::types::AccountId },
     #[error(
         "Contract code for contract ID #{contract_account_id} has never been observed on the node"

--- a/chain/client/Cargo.toml
+++ b/chain/client/Cargo.toml
@@ -23,6 +23,7 @@ borsh = "0.8.1"
 reed-solomon-erasure = "4"
 num-rational = "0.3"
 linked-hash-map = "0.5.3"
+thiserror = "1.0"
 
 near-crypto = { path = "../../core/crypto" }
 near-primitives = { path = "../../core/primitives" }

--- a/chain/client/src/lib.rs
+++ b/chain/client/src/lib.rs
@@ -6,7 +6,7 @@ pub use near_client_primitives::types::{
     GetExecutionOutcome, GetExecutionOutcomeResponse, GetExecutionOutcomesForBlock, GetGasPrice,
     GetNetworkInfo, GetNextLightClientBlock, GetProtocolConfig, GetReceipt, GetStateChanges,
     GetStateChangesInBlock, GetStateChangesWithCauseInBlock, GetValidatorInfo, GetValidatorOrdered,
-    Query, Status, StatusResponse, SyncStatus, TxStatus, TxStatusError,
+    Query, QueryError, Status, StatusResponse, SyncStatus, TxStatus, TxStatusError,
 };
 
 pub use crate::client::Client;

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -252,7 +252,7 @@ impl ViewClientActor {
                 Err(query_error) => Err(match query_error {
                     near_chain::near_chain_primitives::error::QueryError::InternalError {
                         error_message, ..
-                    } => QueryError::Unreachable { error_message },
+                    } => QueryError::InternalError { error_message },
                     near_chain::near_chain_primitives::error::QueryError::InvalidAccount {
                         requested_account_id, block_height, block_hash
                     } => QueryError::InvalidAccount { requested_account_id, block_height, block_hash },

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -211,7 +211,7 @@ impl ViewClientActor {
                 {
                     self.chain.get_block_header(&block_hash)
                 } else {
-                    return Err(QueryError::NotSyncedYet);
+                    return Err(QueryError::NoSyncedBlocks);
                 }
             }
         };
@@ -463,18 +463,18 @@ impl From<RuntimeQueryError> for near_client_primitives::types::QueryError {
             } => Self::InvalidAccount { requested_account_id },
             near_chain::near_chain_primitives::error::QueryError::AccountDoesNotExist {
                 requested_account_id,
-            } => Self::AccountDoesNotExist { requested_account_id },
+            } => Self::UnknownAccount { requested_account_id },
             near_chain::near_chain_primitives::error::QueryError::ContractCodeDoesNotExist {
                 contract_account_id,
-            } => Self::ContractCodeDoesNotExist { contract_account_id },
+            } => Self::NoContractCode { contract_account_id },
             near_chain::near_chain_primitives::error::QueryError::AccessKeyDoesNotExist {
                 public_key,
-            } => Self::AccessKeyDoesNotExist { public_key },
+            } => Self::UnknownAccessKey { public_key },
             near_chain::near_chain_primitives::error::QueryError::StorageError {
                 storage_error,
             } => Self::IOError { error_message: storage_error.to_string() },
             near_chain::near_chain_primitives::error::QueryError::VMError { error_message } => {
-                Self::VMError { error_message }
+                Self::ContractExecutionError { vm_error: error_message }
             }
         }
     }

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -251,23 +251,23 @@ impl ViewClientActor {
                 Ok(query_response) => Ok(query_response),
                 Err(query_error) => Err(match query_error {
                     near_chain::near_chain_primitives::error::QueryError::InternalError {
-                        error_message,
+                        error_message, ..
                     } => QueryError::Unreachable { error_message },
                     near_chain::near_chain_primitives::error::QueryError::InvalidAccount {
-                        requested_account_id,
-                    } => QueryError::InvalidAccount { requested_account_id },
+                        requested_account_id, block_height, block_hash
+                    } => QueryError::InvalidAccount { requested_account_id, block_height, block_hash },
                     near_chain::near_chain_primitives::error::QueryError::UnknownAccount {
-                        requested_account_id,
-                    } => QueryError::UnknownAccount { requested_account_id },
+                        requested_account_id, block_height, block_hash
+                    } => QueryError::UnknownAccount { requested_account_id, block_height, block_hash },
                     near_chain::near_chain_primitives::error::QueryError::NoContractCode {
-                        contract_account_id,
-                    } => QueryError::NoContractCode { contract_account_id },
+                        contract_account_id, block_height, block_hash
+                    } => QueryError::NoContractCode { contract_account_id, block_height, block_hash },
                     near_chain::near_chain_primitives::error::QueryError::UnknownAccessKey {
-                        public_key,
-                    } => QueryError::UnknownAccessKey { public_key },
+                        public_key, block_height, block_hash
+                    } => QueryError::UnknownAccessKey { public_key, block_height, block_hash },
                     near_chain::near_chain_primitives::error::QueryError::ContractExecutionError {
-                        error_message,
-                    } => QueryError::ContractExecutionError { vm_error: error_message },
+                        error_message, block_hash, block_height
+                    } => QueryError::ContractExecutionError { vm_error: error_message, block_height, block_hash },
                 })
             }
         } else {

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -22,7 +22,8 @@ use near_client_primitives::types::{
     Error, GetBlock, GetBlockError, GetBlockProof, GetBlockProofResponse, GetBlockWithMerkleTree,
     GetChunkError, GetExecutionOutcome, GetExecutionOutcomesForBlock, GetGasPrice,
     GetProtocolConfig, GetProtocolConfigError, GetReceipt, GetReceiptError,
-    GetStateChangesWithCauseInBlock, GetValidatorInfoError, Query, TxStatus, TxStatusError,
+    GetStateChangesWithCauseInBlock, GetValidatorInfoError, Query, QueryError, TxStatus,
+    TxStatusError,
 };
 #[cfg(feature = "adversarial")]
 use near_network::types::NetworkAdversarialMessage;

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -470,10 +470,10 @@ impl From<RuntimeQueryError> for near_client_primitives::types::QueryError {
             near_chain::near_chain_primitives::error::QueryError::AccessKeyDoesNotExist {
                 public_key,
             } => Self::AccessKeyDoesNotExist { public_key },
-            near_chain::near_chain_primitives::error::QueryError::StorageError(storage_error) => {
-                Self::IOError { error_message: storage_error.to_string() }
-            }
-            near_chain::near_chain_primitives::error::QueryError::VMError(error_message) => {
+            near_chain::near_chain_primitives::error::QueryError::StorageError {
+                storage_error,
+            } => Self::IOError { error_message: storage_error.to_string() },
+            near_chain::near_chain_primitives::error::QueryError::VMError { error_message } => {
                 Self::VMError { error_message }
             }
         }

--- a/chain/client/tests/catching_up.rs
+++ b/chain/client/tests/catching_up.rs
@@ -323,7 +323,7 @@ mod tests {
                                                     ))
                                                     .then(move |res| {
                                                         let res_inner = res.unwrap();
-                                                        if let Ok(Some(query_response)) = res_inner
+                                                        if let Ok(query_response) = res_inner
                                                         {
                                                             if let ViewAccount(
                                                                 view_account_result,
@@ -528,7 +528,7 @@ mod tests {
                                                         ))
                                                         .then(move |res| {
                                                             let res_inner = res.unwrap();
-                                                            if let Ok(Some(query_response)) =
+                                                            if let Ok(query_response) =
                                                                 res_inner
                                                             {
                                                                 if let ViewAccount(

--- a/chain/client/tests/catching_up.rs
+++ b/chain/client/tests/catching_up.rs
@@ -323,8 +323,7 @@ mod tests {
                                                     ))
                                                     .then(move |res| {
                                                         let res_inner = res.unwrap();
-                                                        if let Ok(query_response) = res_inner
-                                                        {
+                                                        if let Ok(query_response) = res_inner {
                                                             if let ViewAccount(
                                                                 view_account_result,
                                                             ) = query_response.kind
@@ -528,9 +527,7 @@ mod tests {
                                                         ))
                                                         .then(move |res| {
                                                             let res_inner = res.unwrap();
-                                                            if let Ok(query_response) =
-                                                                res_inner
-                                                            {
+                                                            if let Ok(query_response) = res_inner {
                                                                 if let ViewAccount(
                                                                     view_account_result,
                                                                 ) = query_response.kind

--- a/chain/client/tests/cross_shard_tx.rs
+++ b/chain/client/tests/cross_shard_tx.rs
@@ -163,7 +163,7 @@ mod tests {
     }
 
     fn test_cross_shard_tx_callback(
-        res: Result<Result<Option<QueryResponse>, String>, MailboxError>,
+        res: Result<Result<QueryResponse, near_client::QueryError>, MailboxError>,
         account_id: AccountId,
         connectors: Arc<RwLock<Vec<(Addr<ClientActor>, Addr<ViewClientActor>)>>>,
         iteration: Arc<AtomicUsize>,
@@ -180,7 +180,7 @@ mod tests {
         min_ratio: Option<f64>,
         max_ratio: Option<f64>,
     ) {
-        let res = res.unwrap().and_then(|r| r.ok_or_else(|| "Request routed".to_string()));
+        let res = res.unwrap();
 
         let query_response = match res {
             Ok(query_response) => query_response,

--- a/chain/client/tests/cross_shard_tx.rs
+++ b/chain/client/tests/cross_shard_tx.rs
@@ -59,7 +59,7 @@ fn test_keyvalue_runtime_balances() {
                         QueryRequest::ViewAccount { account_id: flat_validators[i].to_string() },
                     ))
                     .then(move |res| {
-                        let query_response = res.unwrap().unwrap().unwrap();
+                        let query_response = res.unwrap().unwrap();
                         if let ViewAccount(view_account_result) = query_response.kind {
                             assert_eq!(view_account_result.amount, expected);
                             successful_queries2.fetch_add(1, Ordering::Relaxed);

--- a/chain/client/tests/query_client.rs
+++ b/chain/client/tests/query_client.rs
@@ -36,7 +36,7 @@ fn query_client() {
                     QueryRequest::ViewAccount { account_id: "test".to_owned() },
                 ))
                 .then(|res| {
-                    match res.unwrap().unwrap().unwrap().kind {
+                    match res.unwrap().unwrap().kind {
                         QueryResponseKind::ViewAccount(_) => (),
                         _ => panic!("Invalid response"),
                     }

--- a/chain/jsonrpc-primitives/Cargo.toml
+++ b/chain/jsonrpc-primitives/Cargo.toml
@@ -16,5 +16,6 @@ uuid = { version = "~0.8", features = ["v4"] }
 
 near-client-primitives = { path = "../client-primitives" }
 near-primitives = { path = "../../core/primitives" }
+near-primitives-core = { path = "../../core/primitives-core" }
 near-metrics = { path = "../../core/metrics" }
 near-chain-configs = { path = "../../core/chain-configs" }

--- a/chain/jsonrpc-primitives/Cargo.toml
+++ b/chain/jsonrpc-primitives/Cargo.toml
@@ -12,10 +12,12 @@ lazy_static = "1.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1.0"
+tracing = "0.1.13"
 uuid = { version = "~0.8", features = ["v4"] }
 
+near-chain-configs = { path = "../../core/chain-configs" }
 near-client-primitives = { path = "../client-primitives" }
+near-crypto = { path = "../../core/crypto" }
+near-metrics = { path = "../../core/metrics" }
 near-primitives = { path = "../../core/primitives" }
 near-primitives-core = { path = "../../core/primitives-core" }
-near-metrics = { path = "../../core/metrics" }
-near-chain-configs = { path = "../../core/chain-configs" }

--- a/chain/jsonrpc-primitives/src/types/blocks.rs
+++ b/chain/jsonrpc-primitives/src/types/blocks.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tracing::error;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -66,7 +65,7 @@ impl From<near_client_primitives::types::GetBlockError> for RpcBlockError {
             near_client_primitives::types::GetBlockError::NotSyncedYet => Self::NotSyncedYet,
             near_client_primitives::types::GetBlockError::IOError(s) => Self::InternalError(s),
             near_client_primitives::types::GetBlockError::Unreachable(error_message) => {
-                error!(target: "jsonrpc", "Unreachable error occurred: {}", &error_message);
+                tracing::warn!(target: "jsonrpc", "Unreachable error occurred: {}", &error_message);
                 near_metrics::inc_counter_vec(
                     &crate::metrics::RPC_UNREACHABLE_ERROR_COUNT,
                     &["RpcBlockError", &error_message],

--- a/chain/jsonrpc-primitives/src/types/blocks.rs
+++ b/chain/jsonrpc-primitives/src/types/blocks.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use tracing::error;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -64,12 +65,13 @@ impl From<near_client_primitives::types::GetBlockError> for RpcBlockError {
             }
             near_client_primitives::types::GetBlockError::NotSyncedYet => Self::NotSyncedYet,
             near_client_primitives::types::GetBlockError::IOError(s) => Self::InternalError(s),
-            near_client_primitives::types::GetBlockError::Unreachable(s) => {
+            near_client_primitives::types::GetBlockError::Unreachable(error_message) => {
+                error!(target: "jsonrpc", "Unreachable error occurred: {}", &error_message);
                 near_metrics::inc_counter_vec(
                     &crate::metrics::RPC_UNREACHABLE_ERROR_COUNT,
-                    &["RpcBlockError", &s],
+                    &["RpcBlockError", &error_message],
                 );
-                Self::Unreachable(s)
+                Self::Unreachable(error_message)
             }
         }
     }

--- a/chain/jsonrpc-primitives/src/types/chunks.rs
+++ b/chain/jsonrpc-primitives/src/types/chunks.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tracing::error;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -95,7 +94,7 @@ impl From<near_client_primitives::types::GetChunkError> for RpcChunkError {
                 Self::UnknownChunk(hash)
             }
             near_client_primitives::types::GetChunkError::Unreachable(error_message) => {
-                error!(target: "jsonrpc", "Unreachable error occurred: {}", &error_message);
+                tracing::warn!(target: "jsonrpc", "Unreachable error occurred: {}", &error_message);
                 near_metrics::inc_counter_vec(
                     &crate::metrics::RPC_UNREACHABLE_ERROR_COUNT,
                     &["RpcChunkError", &error_message],

--- a/chain/jsonrpc-primitives/src/types/chunks.rs
+++ b/chain/jsonrpc-primitives/src/types/chunks.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use tracing::error;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -93,12 +94,13 @@ impl From<near_client_primitives::types::GetChunkError> for RpcChunkError {
             near_client_primitives::types::GetChunkError::UnknownChunk(hash) => {
                 Self::UnknownChunk(hash)
             }
-            near_client_primitives::types::GetChunkError::Unreachable(s) => {
+            near_client_primitives::types::GetChunkError::Unreachable(error_message) => {
+                error!(target: "jsonrpc", "Unreachable error occurred: {}", &error_message);
                 near_metrics::inc_counter_vec(
                     &crate::metrics::RPC_UNREACHABLE_ERROR_COUNT,
-                    &["RpcChunkError", &s],
+                    &["RpcChunkError", &error_message],
                 );
-                Self::Unreachable(s)
+                Self::Unreachable(error_message)
             }
         }
     }

--- a/chain/jsonrpc-primitives/src/types/config.rs
+++ b/chain/jsonrpc-primitives/src/types/config.rs
@@ -1,6 +1,7 @@
 use crate::types::blocks::BlockReference;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use tracing::error;
 
 #[derive(Serialize, Deserialize)]
 pub struct RpcProtocolConfigRequest {
@@ -46,12 +47,13 @@ impl From<near_client_primitives::types::GetProtocolConfigError> for RpcProtocol
             near_client_primitives::types::GetProtocolConfigError::IOError(s) => {
                 Self::InternalError(s)
             }
-            near_client_primitives::types::GetProtocolConfigError::Unreachable(s) => {
+            near_client_primitives::types::GetProtocolConfigError::Unreachable(error_message) => {
+                error!(target: "jsonrpc", "Unreachable error occurred: {}", &error_message);
                 near_metrics::inc_counter_vec(
                     &crate::metrics::RPC_UNREACHABLE_ERROR_COUNT,
-                    &["RpcProtocolConfigError", &s],
+                    &["RpcProtocolConfigError", &error_message],
                 );
-                Self::Unreachable(s)
+                Self::Unreachable(error_message)
             }
         }
     }

--- a/chain/jsonrpc-primitives/src/types/config.rs
+++ b/chain/jsonrpc-primitives/src/types/config.rs
@@ -1,7 +1,6 @@
 use crate::types::blocks::BlockReference;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tracing::error;
 
 #[derive(Serialize, Deserialize)]
 pub struct RpcProtocolConfigRequest {
@@ -48,7 +47,7 @@ impl From<near_client_primitives::types::GetProtocolConfigError> for RpcProtocol
                 Self::InternalError(s)
             }
             near_client_primitives::types::GetProtocolConfigError::Unreachable(error_message) => {
-                error!(target: "jsonrpc", "Unreachable error occurred: {}", &error_message);
+                tracing::warn!(target: "jsonrpc", "Unreachable error occurred: {}", &error_message);
                 near_metrics::inc_counter_vec(
                     &crate::metrics::RPC_UNREACHABLE_ERROR_COUNT,
                     &["RpcProtocolConfigError", &error_message],

--- a/chain/jsonrpc-primitives/src/types/mod.rs
+++ b/chain/jsonrpc-primitives/src/types/mod.rs
@@ -1,5 +1,6 @@
 pub mod blocks;
 pub mod chunks;
 pub mod config;
+pub mod query;
 pub mod receipts;
 pub mod validator;

--- a/chain/jsonrpc-primitives/src/types/query.rs
+++ b/chain/jsonrpc-primitives/src/types/query.rs
@@ -65,7 +65,21 @@ pub enum RpcQueryError {
 #[derive(Serialize, Deserialize)]
 pub struct RpcQueryResponse {
     #[serde(flatten)]
-    pub query_response: near_primitives::views::QueryResponse,
+    pub kind: QueryResponseKind,
+    pub block_height: near_primitives::types::BlockHeight,
+    pub block_hash: near_primitives::hash::CryptoHash,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum QueryResponseKind {
+    ViewAccount(near_primitives::views::AccountView),
+    ViewCode(near_primitives::views::ContractCodeView),
+    ViewState(near_primitives::views::ViewStateResult),
+    CallResult(near_primitives::views::CallResult),
+    Error(near_primitives::views::QueryError),
+    AccessKey(near_primitives::views::AccessKeyView),
+    AccessKeyList(near_primitives::views::AccessKeyList),
 }
 
 impl RpcQueryRequest {
@@ -184,6 +198,44 @@ impl From<near_client_primitives::types::QueryError> for RpcQueryError {
                     &["RpcQueryError", &error_message],
                 );
                 Self::Unreachable { error_message }
+            }
+        }
+    }
+}
+
+impl From<near_primitives::views::QueryResponse> for RpcQueryResponse {
+    fn from(query_response: near_primitives::views::QueryResponse) -> Self {
+        Self {
+            kind: query_response.kind.into(),
+            block_hash: query_response.block_hash,
+            block_height: query_response.block_height,
+        }
+    }
+}
+
+impl From<near_primitives::views::QueryResponseKind> for QueryResponseKind {
+    fn from(query_response_kind: near_primitives::views::QueryResponseKind) -> Self {
+        match query_response_kind {
+            near_primitives::views::QueryResponseKind::ViewAccount(account_view) => {
+                Self::ViewAccount(account_view)
+            }
+            near_primitives::views::QueryResponseKind::ViewCode(contract_code_view) => {
+                Self::ViewCode(contract_code_view)
+            }
+            near_primitives::views::QueryResponseKind::ViewState(view_state_result) => {
+                Self::ViewState(view_state_result)
+            }
+            near_primitives::views::QueryResponseKind::CallResult(call_result) => {
+                Self::CallResult(call_result)
+            }
+            near_primitives::views::QueryResponseKind::Error(query_error) => {
+                Self::Error(query_error)
+            }
+            near_primitives::views::QueryResponseKind::AccessKey(access_key_view) => {
+                Self::AccessKey(access_key_view)
+            }
+            near_primitives::views::QueryResponseKind::AccessKeyList(access_key_list) => {
+                Self::AccessKeyList(access_key_list)
             }
         }
     }

--- a/chain/jsonrpc-primitives/src/types/query.rs
+++ b/chain/jsonrpc-primitives/src/types/query.rs
@@ -77,7 +77,6 @@ pub enum QueryResponseKind {
     ViewCode(near_primitives::views::ContractCodeView),
     ViewState(near_primitives::views::ViewStateResult),
     CallResult(near_primitives::views::CallResult),
-    Error(near_primitives::views::QueryError),
     AccessKey(near_primitives::views::AccessKeyView),
     AccessKeyList(near_primitives::views::AccessKeyList),
 }
@@ -227,9 +226,6 @@ impl From<near_primitives::views::QueryResponseKind> for QueryResponseKind {
             }
             near_primitives::views::QueryResponseKind::CallResult(call_result) => {
                 Self::CallResult(call_result)
-            }
-            near_primitives::views::QueryResponseKind::Error(query_error) => {
-                Self::Error(query_error)
             }
             near_primitives::views::QueryResponseKind::AccessKey(access_key_view) => {
                 Self::AccessKey(access_key_view)

--- a/chain/jsonrpc-primitives/src/types/query.rs
+++ b/chain/jsonrpc-primitives/src/types/query.rs
@@ -70,7 +70,7 @@ pub struct RpcQueryResponse {
     pub block_hash: near_primitives::hash::CryptoHash,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 #[serde(untagged)]
 pub enum QueryResponseKind {
     ViewAccount(near_primitives::views::AccountView),

--- a/chain/jsonrpc-primitives/src/types/query.rs
+++ b/chain/jsonrpc-primitives/src/types/query.rs
@@ -1,0 +1,11 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueryReference {}
+
+#[derive(Serialize, Deserialize)]
+pub struct RpcQueryRequest {
+    #[serde(flatten)]
+    pub query_reference: QueryReference,
+}

--- a/chain/jsonrpc-primitives/src/types/query.rs
+++ b/chain/jsonrpc-primitives/src/types/query.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tracing::error;
 
 /// Max size of the query path (soft-deprecated)
 const QUERY_DATA_MAX_SIZE: usize = 10 * 1024;
@@ -149,7 +148,7 @@ impl From<near_client_primitives::types::QueryError> for RpcQueryError {
                 Self::ContractExecutionError { vm_error }
             }
             near_client_primitives::types::QueryError::Unreachable { error_message } => {
-                error!(target: "jsonrpc", "Unreachable error occurred: {}", &error_message);
+                tracing::warn!(target: "jsonrpc", "Unreachable error occurred: {}", &error_message);
                 near_metrics::inc_counter_vec(
                     &crate::metrics::RPC_UNREACHABLE_ERROR_COUNT,
                     &["RpcQueryError", &error_message],

--- a/chain/jsonrpc-primitives/src/types/query.rs
+++ b/chain/jsonrpc-primitives/src/types/query.rs
@@ -1,6 +1,9 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+/// Max size of the query path (soft-deprecated)
+const QUERY_DATA_MAX_SIZE: usize = 10 * 1024;
+
 #[derive(Serialize, Deserialize)]
 pub struct RpcQueryRequest {
     #[serde(flatten)]
@@ -11,30 +14,32 @@ pub struct RpcQueryRequest {
 
 #[derive(thiserror::Error, Debug)]
 pub enum RpcQueryError {
-    #[error("IO Error: {0}")]
-    IOError(String),
-    #[error("There are no fully synchronized blocks yet")]
-    NotSyncedYet,
+    #[error("IO Error: #{error_message}")]
+    IOError { error_message: String },
+    #[error("There are no fully synchronized blocks on the node yet")]
+    NoSyncedBlocks,
     #[error("The node does not track the shard")]
-    DoesNotTrackShard,
-    #[error("Invalid account ID {0}")]
-    InvalidAccount(near_primitives::types::AccountId),
-    #[error("Account ID {0} has never been observed on the node")]
-    AccountDoesNotExist(near_primitives::types::AccountId),
-    #[error("Contract code for contract ID {0} has never been observed on the node")]
-    ContractCodeDoesNotExist(near_primitives::types::AccountId),
-    #[error("Access key for public key {0} has never been observed on the node")]
-    AccessKeyDoesNotExist(String),
-    #[error("VM error occurred: {0}")]
-    VMError(String),
-    #[error("The node reached its limits. Try again later. More details: {0}")]
-    InternalError(String),
+    DoesNotTrackShard { requested_shard_id: near_primitives::types::ShardId },
+    #[error("Account ID #{requested_account_id} is invalid")]
+    InvalidAccount { requested_account_id: near_primitives::types::AccountId },
+    #[error("account #{requested_account_id} does not exist while viewing")]
+    UnknownAccount { requested_account_id: near_primitives::types::AccountId },
+    #[error(
+        "Contract code for contract ID #{contract_account_id} has never been observed on the node"
+    )]
+    NoContractCode { contract_account_id: near_primitives::types::AccountId },
+    #[error("Access key for public key #{public_key} has never been observed on the node")]
+    UnknownAccessKey { public_key: String },
+    #[error("Function call returned an error: #{vm_error}")]
+    FunctionCall { vm_error: String },
+    #[error("The node reached its limits. Try again later. More details: #{error_message}")]
+    InternalError { error_message: String },
     // NOTE: Currently, the underlying errors are too broad, and while we tried to handle
     // expected cases, we cannot statically guarantee that no other errors will be returned
     // in the future.
     // TODO #3851: Remove this variant once we can exhaustively match all the underlying errors
-    #[error("It is a bug if you receive this error type, please, report this incident: https://github.com/near/nearcore/issues/new/choose. Details: {0}")]
-    Unreachable(String),
+    #[error("It is a bug if you receive this error type, please, report this incident: https://github.com/near/nearcore/issues/new/choose. Details: #{error_message}")]
+    Unreachable { error_message: String },
 }
 
 #[derive(Serialize, Deserialize)]
@@ -48,9 +53,19 @@ impl RpcQueryRequest {
         let query_request = if let Ok((path, data)) =
             crate::utils::parse_params::<(String, String)>(value.clone())
         {
+            // Handle a soft-deprecated version of the query API, which is based on
+            // positional arguments with a "path"-style first argument.
+            //
+            // This whole block can be removed one day, when the new API is 100% adopted.
             let data = near_primitives_core::serialize::from_base(&data)
                 .map_err(|err| crate::errors::RpcParseError(err.to_string()))?;
             let query_data_size = path.len() + data.len();
+            if query_data_size > QUERY_DATA_MAX_SIZE {
+                return Err(crate::errors::RpcParseError(format!(
+                    "Query data size {} is too large",
+                    query_data_size
+                )));
+            }
 
             let mut path_parts = path.splitn(3, '/');
             let make_err =
@@ -95,6 +110,7 @@ impl RpcQueryRequest {
                     )))
                 }
             };
+            // Use Finality::None here to make backward compatibility tests work
             RpcQueryRequest {
                 request,
                 block_reference: near_primitives::types::BlockReference::latest(),
@@ -109,28 +125,34 @@ impl RpcQueryRequest {
 impl From<near_client_primitives::types::QueryError> for RpcQueryError {
     fn from(error: near_client_primitives::types::QueryError) -> Self {
         match error {
-            near_client_primitives::types::QueryError::IOError(s) => Self::InternalError(s),
-            near_client_primitives::types::QueryError::NotSyncedYet => Self::NotSyncedYet,
-            near_client_primitives::types::QueryError::DoesNotTrackShard => Self::DoesNotTrackShard,
-            near_client_primitives::types::QueryError::InvalidAccount(account_id) => {
-                Self::InvalidAccount(account_id)
+            near_client_primitives::types::QueryError::IOError { error_message } => {
+                Self::InternalError { error_message }
             }
-            near_client_primitives::types::QueryError::AccountDoesNotExist(account_id) => {
-                Self::AccountDoesNotExist(account_id)
+            near_client_primitives::types::QueryError::NotSyncedYet => Self::NoSyncedBlocks,
+            near_client_primitives::types::QueryError::UnavailableShard { requested_shard_id } => {
+                Self::DoesNotTrackShard { requested_shard_id }
             }
-            near_client_primitives::types::QueryError::ContractCodeDoesNotExist(account_id) => {
-                Self::ContractCodeDoesNotExist(account_id)
+            near_client_primitives::types::QueryError::InvalidAccount { requested_account_id } => {
+                Self::InvalidAccount { requested_account_id }
             }
-            near_client_primitives::types::QueryError::AccessKeyDoesNotExist(public_key) => {
-                Self::AccessKeyDoesNotExist(public_key)
+            near_client_primitives::types::QueryError::AccountDoesNotExist {
+                requested_account_id,
+            } => Self::UnknownAccount { requested_account_id },
+            near_client_primitives::types::QueryError::ContractCodeDoesNotExist {
+                contract_account_id,
+            } => Self::NoContractCode { contract_account_id },
+            near_client_primitives::types::QueryError::AccessKeyDoesNotExist { public_key } => {
+                Self::UnknownAccessKey { public_key }
             }
-            near_client_primitives::types::QueryError::VMError(s) => Self::VMError(s),
-            near_client_primitives::types::QueryError::Unreachable(s) => {
+            near_client_primitives::types::QueryError::VMError { error_message } => {
+                Self::FunctionCall { vm_error: error_message }
+            }
+            near_client_primitives::types::QueryError::Unreachable { error_message } => {
                 near_metrics::inc_counter_vec(
                     &crate::metrics::RPC_UNREACHABLE_ERROR_COUNT,
-                    &["RpcQueryError", &s],
+                    &["RpcQueryError", &error_message],
                 );
-                Self::Unreachable(s)
+                Self::Unreachable { error_message }
             }
         }
     }
@@ -146,6 +168,6 @@ impl From<RpcQueryError> for crate::errors::RpcError {
 
 impl From<actix::MailboxError> for RpcQueryError {
     fn from(error: actix::MailboxError) -> Self {
-        Self::InternalError(error.to_string())
+        Self::InternalError { error_message: error.to_string() }
     }
 }

--- a/chain/jsonrpc-primitives/src/types/query.rs
+++ b/chain/jsonrpc-primitives/src/types/query.rs
@@ -20,7 +20,7 @@ pub enum RpcQueryError {
     #[error("There are no fully synchronized blocks on the node yet")]
     NoSyncedBlocks,
     #[error("The node does not track the shard")]
-    DoesNotTrackShard { requested_shard_id: near_primitives::types::ShardId },
+    UnavailableShard { requested_shard_id: near_primitives::types::ShardId },
     #[error("Account ID #{requested_account_id} is invalid")]
     InvalidAccount { requested_account_id: near_primitives::types::AccountId },
     #[error("account #{requested_account_id} does not exist while viewing")]
@@ -32,7 +32,7 @@ pub enum RpcQueryError {
     #[error("Access key for public key #{public_key} has never been observed on the node")]
     UnknownAccessKey { public_key: near_crypto::PublicKey },
     #[error("Function call returned an error: #{vm_error}")]
-    FunctionCall { vm_error: String },
+    ContractExecutionError { vm_error: String },
     #[error("The node reached its limits. Try again later. More details: #{error_message}")]
     InternalError { error_message: String },
     // NOTE: Currently, the underlying errors are too broad, and while we tried to handle
@@ -129,24 +129,24 @@ impl From<near_client_primitives::types::QueryError> for RpcQueryError {
             near_client_primitives::types::QueryError::IOError { error_message } => {
                 Self::InternalError { error_message }
             }
-            near_client_primitives::types::QueryError::NotSyncedYet => Self::NoSyncedBlocks,
+            near_client_primitives::types::QueryError::NoSyncedBlocks => Self::NoSyncedBlocks,
             near_client_primitives::types::QueryError::UnavailableShard { requested_shard_id } => {
-                Self::DoesNotTrackShard { requested_shard_id }
+                Self::UnavailableShard { requested_shard_id }
             }
             near_client_primitives::types::QueryError::InvalidAccount { requested_account_id } => {
                 Self::InvalidAccount { requested_account_id }
             }
-            near_client_primitives::types::QueryError::AccountDoesNotExist {
-                requested_account_id,
-            } => Self::UnknownAccount { requested_account_id },
-            near_client_primitives::types::QueryError::ContractCodeDoesNotExist {
-                contract_account_id,
-            } => Self::NoContractCode { contract_account_id },
-            near_client_primitives::types::QueryError::AccessKeyDoesNotExist { public_key } => {
+            near_client_primitives::types::QueryError::UnknownAccount { requested_account_id } => {
+                Self::UnknownAccount { requested_account_id }
+            }
+            near_client_primitives::types::QueryError::NoContractCode { contract_account_id } => {
+                Self::NoContractCode { contract_account_id }
+            }
+            near_client_primitives::types::QueryError::UnknownAccessKey { public_key } => {
                 Self::UnknownAccessKey { public_key }
             }
-            near_client_primitives::types::QueryError::VMError { error_message } => {
-                Self::FunctionCall { vm_error: error_message }
+            near_client_primitives::types::QueryError::ContractExecutionError { vm_error } => {
+                Self::ContractExecutionError { vm_error }
             }
             near_client_primitives::types::QueryError::Unreachable { error_message } => {
                 error!(target: "jsonrpc", "Unreachable error occurred: {}", &error_message);

--- a/chain/jsonrpc-primitives/src/types/query.rs
+++ b/chain/jsonrpc-primitives/src/types/query.rs
@@ -1,11 +1,151 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct QueryReference {}
-
 #[derive(Serialize, Deserialize)]
 pub struct RpcQueryRequest {
     #[serde(flatten)]
-    pub query_reference: QueryReference,
+    pub block_reference: near_primitives::types::BlockReference,
+    #[serde(flatten)]
+    pub request: near_primitives::views::QueryRequest,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum RpcQueryError {
+    #[error("IO Error: {0}")]
+    IOError(String),
+    #[error("There are no fully synchronized blocks yet")]
+    NotSyncedYet,
+    #[error("The node does not track the shard")]
+    DoesNotTrackShard,
+    #[error("Invalid account ID {0}")]
+    InvalidAccount(near_primitives::types::AccountId),
+    #[error("Account ID {0} has never been observed on the node")]
+    AccountDoesNotExist(near_primitives::types::AccountId),
+    #[error("Contract code for contract ID {0} has never been observed on the node")]
+    ContractCodeDoesNotExist(near_primitives::types::AccountId),
+    #[error("Access key for public key {0} has never been observed on the node")]
+    AccessKeyDoesNotExist(String),
+    #[error("VM error occurred: {0}")]
+    VMError(String),
+    #[error("The node reached its limits. Try again later. More details: {0}")]
+    InternalError(String),
+    // NOTE: Currently, the underlying errors are too broad, and while we tried to handle
+    // expected cases, we cannot statically guarantee that no other errors will be returned
+    // in the future.
+    // TODO #3851: Remove this variant once we can exhaustively match all the underlying errors
+    #[error("It is a bug if you receive this error type, please, report this incident: https://github.com/near/nearcore/issues/new/choose. Details: {0}")]
+    Unreachable(String),
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct RpcQueryResponse {
+    #[serde(flatten)]
+    pub query_response: near_primitives::views::QueryResponse,
+}
+
+impl RpcQueryRequest {
+    pub fn parse(value: Option<Value>) -> Result<RpcQueryRequest, crate::errors::RpcParseError> {
+        let query_request = if let Ok((path, data)) =
+            crate::utils::parse_params::<(String, String)>(value.clone())
+        {
+            let data = near_primitives_core::serialize::from_base(&data)
+                .map_err(|err| crate::errors::RpcParseError(err.to_string()))?;
+            let query_data_size = path.len() + data.len();
+
+            let mut path_parts = path.splitn(3, '/');
+            let make_err =
+                || crate::errors::RpcParseError("Not enough query parameters provided".to_string());
+            let query_command = path_parts.next().ok_or_else(make_err)?;
+            let account_id =
+                near_primitives::types::AccountId::from(path_parts.next().ok_or_else(make_err)?);
+            let maybe_extra_arg = path_parts.next();
+
+            let request = match query_command {
+                "account" => near_primitives::views::QueryRequest::ViewAccount { account_id },
+                "access_key" => match maybe_extra_arg {
+                    None => near_primitives::views::QueryRequest::ViewAccessKeyList { account_id },
+                    Some(pk) => near_primitives::views::QueryRequest::ViewAccessKey {
+                        account_id,
+                        public_key: pk.parse().map_err(|_| {
+                            crate::errors::RpcParseError("Invalid public key".to_string())
+                        })?,
+                    },
+                },
+                "code" => near_primitives::views::QueryRequest::ViewCode { account_id },
+                "contract" => near_primitives::views::QueryRequest::ViewState {
+                    account_id,
+                    prefix: data.into(),
+                },
+                "call" => match maybe_extra_arg {
+                    Some(method_name) => near_primitives::views::QueryRequest::CallFunction {
+                        account_id,
+                        method_name: method_name.to_string(),
+                        args: data.into(),
+                    },
+                    None => {
+                        return Err(crate::errors::RpcParseError(
+                            "Method name is missing".to_string(),
+                        ))
+                    }
+                },
+                _ => {
+                    return Err(crate::errors::RpcParseError(format!(
+                        "Unknown path {}",
+                        query_command
+                    )))
+                }
+            };
+            RpcQueryRequest {
+                request,
+                block_reference: near_primitives::types::BlockReference::latest(),
+            }
+        } else {
+            crate::utils::parse_params::<RpcQueryRequest>(value)?
+        };
+        Ok(query_request)
+    }
+}
+
+impl From<near_client_primitives::types::QueryError> for RpcQueryError {
+    fn from(error: near_client_primitives::types::QueryError) -> Self {
+        match error {
+            near_client_primitives::types::QueryError::IOError(s) => Self::InternalError(s),
+            near_client_primitives::types::QueryError::NotSyncedYet => Self::NotSyncedYet,
+            near_client_primitives::types::QueryError::DoesNotTrackShard => Self::DoesNotTrackShard,
+            near_client_primitives::types::QueryError::InvalidAccount(account_id) => {
+                Self::InvalidAccount(account_id)
+            }
+            near_client_primitives::types::QueryError::AccountDoesNotExist(account_id) => {
+                Self::AccountDoesNotExist(account_id)
+            }
+            near_client_primitives::types::QueryError::ContractCodeDoesNotExist(account_id) => {
+                Self::ContractCodeDoesNotExist(account_id)
+            }
+            near_client_primitives::types::QueryError::AccessKeyDoesNotExist(public_key) => {
+                Self::AccessKeyDoesNotExist(public_key)
+            }
+            near_client_primitives::types::QueryError::VMError(s) => Self::VMError(s),
+            near_client_primitives::types::QueryError::Unreachable(s) => {
+                near_metrics::inc_counter_vec(
+                    &crate::metrics::RPC_UNREACHABLE_ERROR_COUNT,
+                    &["RpcQueryError", &s],
+                );
+                Self::Unreachable(s)
+            }
+        }
+    }
+}
+
+impl From<RpcQueryError> for crate::errors::RpcError {
+    fn from(error: RpcQueryError) -> Self {
+        let error_data = Some(Value::String(error.to_string()));
+
+        Self::new(-32_000, "Server error".to_string(), error_data)
+    }
+}
+
+impl From<actix::MailboxError> for RpcQueryError {
+    fn from(error: actix::MailboxError) -> Self {
+        Self::InternalError(error.to_string())
+    }
 }

--- a/chain/jsonrpc-primitives/src/types/query.rs
+++ b/chain/jsonrpc-primitives/src/types/query.rs
@@ -145,7 +145,7 @@ impl RpcQueryRequest {
 impl From<near_client_primitives::types::QueryError> for RpcQueryError {
     fn from(error: near_client_primitives::types::QueryError) -> Self {
         match error {
-            near_client_primitives::types::QueryError::IOError { error_message } => {
+            near_client_primitives::types::QueryError::InternalError { error_message } => {
                 Self::InternalError { error_message }
             }
             near_client_primitives::types::QueryError::NoSyncedBlocks => Self::NoSyncedBlocks,

--- a/chain/jsonrpc-primitives/src/types/receipts.rs
+++ b/chain/jsonrpc-primitives/src/types/receipts.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use tracing::error;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReceiptReference {
@@ -52,12 +53,13 @@ impl From<near_client_primitives::types::GetReceiptError> for RpcReceiptError {
             near_client_primitives::types::GetReceiptError::UnknownReceipt(hash) => {
                 Self::UnknownReceipt(hash)
             }
-            near_client_primitives::types::GetReceiptError::Unreachable(s) => {
+            near_client_primitives::types::GetReceiptError::Unreachable(error_message) => {
+                error!(target: "jsonrpc", "Unreachable error occurred: {}", &error_message);
                 near_metrics::inc_counter_vec(
                     &crate::metrics::RPC_UNREACHABLE_ERROR_COUNT,
-                    &["RpcReceiptError", &s],
+                    &["RpcReceiptError", &error_message],
                 );
-                Self::Unreachable(s)
+                Self::Unreachable(error_message)
             }
         }
     }

--- a/chain/jsonrpc-primitives/src/types/receipts.rs
+++ b/chain/jsonrpc-primitives/src/types/receipts.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tracing::error;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReceiptReference {
@@ -54,7 +53,7 @@ impl From<near_client_primitives::types::GetReceiptError> for RpcReceiptError {
                 Self::UnknownReceipt(hash)
             }
             near_client_primitives::types::GetReceiptError::Unreachable(error_message) => {
-                error!(target: "jsonrpc", "Unreachable error occurred: {}", &error_message);
+                tracing::warn!(target: "jsonrpc", "Unreachable error occurred: {}", &error_message);
                 near_metrics::inc_counter_vec(
                     &crate::metrics::RPC_UNREACHABLE_ERROR_COUNT,
                     &["RpcReceiptError", &error_message],

--- a/chain/jsonrpc/client/src/lib.rs
+++ b/chain/jsonrpc/client/src/lib.rs
@@ -14,7 +14,7 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::types::{BlockId, BlockReference, MaybeBlockId, ShardId};
 use near_primitives::views::{
     BlockView, ChunkView, EpochValidatorInfo, FinalExecutionOutcomeView, GasPriceView,
-    QueryResponse, StatusResponse, ValidatorStakeView,
+    StatusResponse, ValidatorStakeView,
 };
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -194,7 +194,11 @@ jsonrpc_client!(pub struct JsonRpcClient {
 impl JsonRpcClient {
     /// This is a soft-deprecated method to do query RPC request with a path and data positional
     /// parameters.
-    pub fn query_by_path(&self, path: String, data: String) -> RpcRequest<QueryResponse> {
+    pub fn query_by_path(
+        &self,
+        path: String,
+        data: String,
+    ) -> RpcRequest<near_jsonrpc_primitives::types::query::RpcQueryResponse> {
         call_method(&self.client, &self.server_addr, "query", [path, data])
     }
 

--- a/chain/jsonrpc/client/src/lib.rs
+++ b/chain/jsonrpc/client/src/lib.rs
@@ -8,8 +8,9 @@ use serde::Serialize;
 use near_jsonrpc_primitives::errors::RpcError;
 use near_jsonrpc_primitives::message::{from_slice, Message};
 use near_jsonrpc_primitives::rpc::{
-    RpcQueryRequest, RpcStateChangesRequest, RpcStateChangesResponse, RpcValidatorsOrderedRequest,
+    RpcStateChangesRequest, RpcStateChangesResponse, RpcValidatorsOrderedRequest,
 };
+use near_jsonrpc_primitives::types::query::RpcQueryRequest;
 use near_primitives::hash::CryptoHash;
 use near_primitives::types::{BlockId, BlockReference, MaybeBlockId, ShardId};
 use near_primitives::views::{
@@ -198,7 +199,10 @@ impl JsonRpcClient {
         call_method(&self.client, &self.server_addr, "query", [path, data])
     }
 
-    pub fn query(&self, request: RpcQueryRequest) -> RpcRequest<QueryResponse> {
+    pub fn query(
+        &self,
+        request: near_jsonrpc_primitives::types::query::RpcQueryRequest,
+    ) -> RpcRequest<near_jsonrpc_primitives::types::query::RpcQueryResponse> {
         call_method(&self.client, &self.server_addr, "query", request)
     }
 

--- a/chain/jsonrpc/client/src/lib.rs
+++ b/chain/jsonrpc/client/src/lib.rs
@@ -10,7 +10,6 @@ use near_jsonrpc_primitives::message::{from_slice, Message};
 use near_jsonrpc_primitives::rpc::{
     RpcStateChangesRequest, RpcStateChangesResponse, RpcValidatorsOrderedRequest,
 };
-use near_jsonrpc_primitives::types::query::RpcQueryRequest;
 use near_primitives::hash::CryptoHash;
 use near_primitives::types::{BlockId, BlockReference, MaybeBlockId, ShardId};
 use near_primitives::views::{

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -11,7 +11,7 @@ use futures::{FutureExt, TryFutureExt};
 use prometheus;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 use tokio::time::{sleep, timeout};
 use tracing::info;
 
@@ -177,7 +177,12 @@ fn timeout_err() -> RpcError {
 
 /// This function processes response from query method to introduce
 /// backward compatible response in case of specific errors
-fn process_query_response(query_response: Result<near_jsonrpc_primitives::types::query::RpcQueryResponse, near_jsonrpc_primitives::types::query::RpcQueryError>) -> Result<Value, RpcError> {
+fn process_query_response(
+    query_response: Result<
+        near_jsonrpc_primitives::types::query::RpcQueryResponse,
+        near_jsonrpc_primitives::types::query::RpcQueryError,
+    >,
+) -> Result<Value, RpcError> {
     // This match is used here to give backward compatible error message for specific
     // error variants. Should be refactored once structured errors fully shipped
     match query_response {
@@ -208,7 +213,7 @@ fn process_query_response(query_response: Result<near_jsonrpc_primitives::types:
                 "block_hash": block_hash,
             })),
             _ => Err(err.into()),
-        }
+        },
     }
 }
 

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -587,17 +587,12 @@ impl JsonRpcHandler {
         let query = Query::new(request_data.block_reference, request_data.request);
         // This match is used here to give backward compatible error message for specific
         // error variants. Should be refactored once structured errors fully shipped
-        match self
-            .view_client_addr
-            .send(query)
-            .await?
-            .map_err(near_jsonrpc_primitives::types::query::RpcQueryError::from)
-        {
+        match self.view_client_addr.send(query).await? {
             Ok(query_response) => {
                 Ok(near_jsonrpc_primitives::types::query::RpcQueryResponse { query_response })
             }
             Err(err) => match err {
-                near_jsonrpc_primitives::types::query::RpcQueryError::ContractExecutionError {
+                near_client::QueryError::ContractExecutionError {
                     vm_error,
                     block_height,
                     block_hash,
@@ -610,7 +605,7 @@ impl JsonRpcHandler {
                         block_hash,
                     },
                 }),
-                near_jsonrpc_primitives::types::query::RpcQueryError::UnknownAccessKey {
+                near_client::QueryError::UnknownAccessKey {
                     public_key,
                     block_height,
                     block_hash,
@@ -629,7 +624,7 @@ impl JsonRpcHandler {
                         block_hash,
                     },
                 }),
-                _ => Err(err),
+                _ => Err(err.into()),
             },
         }
     }

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -46,9 +46,6 @@ use near_runtime_utils::is_valid_account_id;
 
 mod metrics;
 
-/// Max size of the query path (soft-deprecated)
-const QUERY_DATA_MAX_SIZE: usize = 10 * 1024;
-
 #[derive(Serialize, Deserialize, Clone, Copy, Debug)]
 pub struct RpcPollingConfig {
     pub polling_interval: Duration,
@@ -588,7 +585,7 @@ impl JsonRpcHandler {
         near_jsonrpc_primitives::types::query::RpcQueryError,
     > {
         let query = Query::new(request_data.block_reference, request_data.request);
-        let query_response = self.view_client_addr.send(query.clone()).await??;
+        let query_response = self.view_client_addr.send(query).await??;
         Ok(near_jsonrpc_primitives::types::query::RpcQueryResponse { query_response })
     }
 

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -585,10 +585,53 @@ impl JsonRpcHandler {
         near_jsonrpc_primitives::types::query::RpcQueryError,
     > {
         let query = Query::new(request_data.block_reference, request_data.request);
-        let query_response = self.view_client_addr.send(query).await??;
-        // view_access_key
-        // call_function
-        Ok(near_jsonrpc_primitives::types::query::RpcQueryResponse { query_response })
+        // This match is used here to give backward compatible error message for specific
+        // error variants. Should be refactored once structured errors fully shipped
+        match self
+            .view_client_addr
+            .send(query)
+            .await?
+            .map_err(near_jsonrpc_primitives::types::query::RpcQueryError::from)
+        {
+            Ok(query_response) => {
+                Ok(near_jsonrpc_primitives::types::query::RpcQueryResponse { query_response })
+            }
+            Err(err) => match err {
+                near_jsonrpc_primitives::types::query::RpcQueryError::ContractExecutionError {
+                    vm_error,
+                    block_height,
+                    block_hash,
+                } => Ok(near_jsonrpc_primitives::types::query::RpcQueryResponse {
+                    query_response: near_primitives::views::QueryResponse {
+                        kind: near_primitives::views::QueryResponseKind::Error(
+                            near_primitives::views::QueryError { error: vm_error, logs: vec![] },
+                        ),
+                        block_height,
+                        block_hash,
+                    },
+                }),
+                near_jsonrpc_primitives::types::query::RpcQueryError::UnknownAccessKey {
+                    public_key,
+                    block_height,
+                    block_hash,
+                } => Ok(near_jsonrpc_primitives::types::query::RpcQueryResponse {
+                    query_response: near_primitives::views::QueryResponse {
+                        kind: near_primitives::views::QueryResponseKind::Error(
+                            near_primitives::views::QueryError {
+                                error: format!(
+                                    "access key {} does not exist while viewing",
+                                    public_key.to_string()
+                                ),
+                                logs: vec![],
+                            },
+                        ),
+                        block_height,
+                        block_hash,
+                    },
+                }),
+                _ => Err(err),
+            },
+        }
     }
 
     async fn tx_status_common(

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -586,6 +586,8 @@ impl JsonRpcHandler {
     > {
         let query = Query::new(request_data.block_reference, request_data.request);
         let query_response = self.view_client_addr.send(query).await??;
+        // view_access_key
+        // call_function
         Ok(near_jsonrpc_primitives::types::query::RpcQueryResponse { query_response })
     }
 

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -588,41 +588,35 @@ impl JsonRpcHandler {
         // This match is used here to give backward compatible error message for specific
         // error variants. Should be refactored once structured errors fully shipped
         match self.view_client_addr.send(query).await? {
-            Ok(query_response) => {
-                Ok(near_jsonrpc_primitives::types::query::RpcQueryResponse { query_response })
-            }
+            Ok(query_response) => Ok(query_response.into()),
             Err(err) => match err {
                 near_client::QueryError::ContractExecutionError {
                     vm_error,
                     block_height,
                     block_hash,
                 } => Ok(near_jsonrpc_primitives::types::query::RpcQueryResponse {
-                    query_response: near_primitives::views::QueryResponse {
-                        kind: near_primitives::views::QueryResponseKind::Error(
-                            near_primitives::views::QueryError { error: vm_error, logs: vec![] },
-                        ),
-                        block_height,
-                        block_hash,
-                    },
+                    kind: near_jsonrpc_primitives::types::query::QueryResponseKind::Error(
+                        near_primitives::views::QueryError { error: vm_error, logs: vec![] },
+                    ),
+                    block_height,
+                    block_hash,
                 }),
                 near_client::QueryError::UnknownAccessKey {
                     public_key,
                     block_height,
                     block_hash,
                 } => Ok(near_jsonrpc_primitives::types::query::RpcQueryResponse {
-                    query_response: near_primitives::views::QueryResponse {
-                        kind: near_primitives::views::QueryResponseKind::Error(
-                            near_primitives::views::QueryError {
-                                error: format!(
-                                    "access key {} does not exist while viewing",
-                                    public_key.to_string()
-                                ),
-                                logs: vec![],
-                            },
-                        ),
-                        block_height,
-                        block_hash,
-                    },
+                    kind: near_jsonrpc_primitives::types::query::QueryResponseKind::Error(
+                        near_primitives::views::QueryError {
+                            error: format!(
+                                "access key {} does not exist while viewing",
+                                public_key.to_string()
+                            ),
+                            logs: vec![],
+                        },
+                    ),
+                    block_height,
+                    block_hash,
                 }),
                 _ => Err(err.into()),
             },

--- a/chain/jsonrpc/tests/rpc_query.rs
+++ b/chain/jsonrpc/tests/rpc_query.rs
@@ -188,7 +188,10 @@ fn test_query_account() {
             {
                 account
             } else {
-                panic!("queried account, but received something else: {:?}", query_response.query_response.kind);
+                panic!(
+                    "queried account, but received something else: {:?}",
+                    query_response.query_response.kind
+                );
             };
             assert_eq!(account_info.amount, 0);
             assert_eq!(account_info.code_hash.as_ref(), &[0; 32]);
@@ -230,11 +233,15 @@ fn test_query_access_keys() {
             .await
             .unwrap();
         assert_eq!(query_response.query_response.block_height, 0);
-        let access_keys = if let QueryResponseKind::AccessKeyList(access_keys) = query_response.query_response.kind
+        let access_keys = if let QueryResponseKind::AccessKeyList(access_keys) =
+            query_response.query_response.kind
         {
             access_keys
         } else {
-            panic!("queried access keys, but received something else: {:?}", query_response.query_response.kind);
+            panic!(
+                "queried access keys, but received something else: {:?}",
+                query_response.query_response.kind
+            );
         };
         assert_eq!(access_keys.keys.len(), 1);
         assert_eq!(access_keys.keys[0].access_key, AccessKey::full_access().into());
@@ -281,11 +288,15 @@ fn test_query_access_key() {
             .await
             .unwrap();
         assert_eq!(query_response.query_response.block_height, 0);
-        let access_key = if let QueryResponseKind::AccessKey(access_keys) = query_response.query_response.kind {
-            access_keys
-        } else {
-            panic!("queried access keys, but received something else: {:?}", query_response.query_response.kind);
-        };
+        let access_key =
+            if let QueryResponseKind::AccessKey(access_keys) = query_response.query_response.kind {
+                access_keys
+            } else {
+                panic!(
+                    "queried access keys, but received something else: {:?}",
+                    query_response.query_response.kind
+                );
+            };
         assert_eq!(access_key.nonce, 0);
         assert_eq!(access_key.permission, AccessKeyPermission::FullAccess.into());
     });
@@ -306,10 +317,14 @@ fn test_query_state() {
             .await
             .unwrap();
         assert_eq!(query_response.query_response.block_height, 0);
-        let state = if let QueryResponseKind::ViewState(state) = query_response.query_response.kind {
+        let state = if let QueryResponseKind::ViewState(state) = query_response.query_response.kind
+        {
             state
         } else {
-            panic!("queried state, but received something else: {:?}", query_response.query_response.kind);
+            panic!(
+                "queried state, but received something else: {:?}",
+                query_response.query_response.kind
+            );
         };
         assert_eq!(state.values.len(), 0);
     });
@@ -331,7 +346,9 @@ fn test_query_call_function() {
             .await
             .unwrap();
         assert_eq!(query_response.query_response.block_height, 0);
-        let call_result = if let QueryResponseKind::CallResult(call_result) = query_response.query_response.kind {
+        let call_result = if let QueryResponseKind::CallResult(call_result) =
+            query_response.query_response.kind
+        {
             call_result
         } else {
             panic!(
@@ -359,7 +376,10 @@ fn test_query_contract_code() {
         let code = if let QueryResponseKind::ViewCode(code) = query_response.query_response.kind {
             code
         } else {
-            panic!("queried code, but received something else: {:?}", query_response.query_response.kind);
+            panic!(
+                "queried code, but received something else: {:?}",
+                query_response.query_response.kind
+            );
         };
         assert_eq!(code.code, Vec::<u8>::new());
         assert_eq!(code.hash.to_string(), "11111111111111111111111111111111");

--- a/chain/network/src/peer.rs
+++ b/chain/network/src/peer.rs
@@ -382,12 +382,6 @@ impl Peer {
             PeerMessage::Routed(message) => {
                 msg_hash = Some(message.hash());
                 match message.body {
-                    RoutedMessageBody::QueryRequest { query_id, block_reference, request } => {
-                        NetworkViewClientMessages::Query { query_id, block_reference, request }
-                    }
-                    RoutedMessageBody::QueryResponse { query_id, response } => {
-                        NetworkViewClientMessages::QueryResponse { query_id, response }
-                    }
                     RoutedMessageBody::TxStatusRequest(account_id, tx_hash) => {
                         NetworkViewClientMessages::TxStatus {
                             tx_hash,

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -1503,10 +1503,6 @@ pub enum NetworkViewClientMessages {
     TxStatus { tx_hash: CryptoHash, signer_account_id: AccountId },
     /// Transaction status response
     TxStatusResponse(Box<FinalExecutionOutcomeView>),
-    /// General query
-    Query { query_id: String, block_reference: BlockReference, request: QueryRequest },
-    /// Query response
-    QueryResponse { query_id: String, response: Result<QueryResponse, String> },
     /// Request for receipt outcome
     ReceiptOutcomeRequest(CryptoHash),
     /// Receipt outcome response

--- a/chain/rosetta-rpc/Cargo.toml
+++ b/chain/rosetta-rpc/Cargo.toml
@@ -28,6 +28,7 @@ near-primitives = { path = "../../core/primitives" }
 near-crypto = { path = "../../core/crypto" }
 near-chain-configs = { path = "../../core/chain-configs" }
 near-client = { path = "../client" }
+near-client-primitives = { path = "../client-primitives" }
 near-network = { path = "../network" }
 
 [dev-dependencies]

--- a/chain/rosetta-rpc/src/utils.rs
+++ b/chain/rosetta-rpc/src/utils.rs
@@ -327,16 +327,16 @@ pub(crate) async fn query_account(
         near_primitives::views::QueryResponseKind::ViewAccount(account_info) => {
             Ok((account_info_response.block_hash, account_info_response.block_height, account_info))
         }
-        near_primitives::views::QueryResponseKind::Error(near_primitives::views::QueryError {
-            error,
-            ..
-        }) => {
-            if error.contains("does not exist") {
-                Err(crate::errors::ErrorKind::NotFound(error))
-            } else {
-                Err(crate::errors::ErrorKind::InternalError(error))
-            }
-        }
+        // near_primitives::views::QueryResponseKind::Error(near_primitives::views::QueryError {
+        //     error,
+        //     ..
+        // }) => {
+        //     if error.contains("does not exist") {
+        //         Err(crate::errors::ErrorKind::NotFound(error))
+        //     } else {
+        //         Err(crate::errors::ErrorKind::InternalError(error))
+        //     }
+        // }
         _ => Err(crate::errors::ErrorKind::InternalInvariantError(format!(
             "queried ViewAccount, but received {:?}.",
             account_info_response.kind
@@ -410,16 +410,16 @@ pub(crate) async fn query_access_key(
             access_key_query_response.block_height,
             access_key,
         )),
-        near_primitives::views::QueryResponseKind::Error(near_primitives::views::QueryError {
-            error,
-            ..
-        }) => {
-            if error.contains("does not exist") {
-                Err(crate::errors::ErrorKind::NotFound(error))
-            } else {
-                Err(crate::errors::ErrorKind::InternalError(error))
-            }
-        }
+        // near_primitives::views::QueryResponseKind::Error(near_primitives::views::QueryError {
+        //     error,
+        //     ..
+        // }) => {
+        //     if error.contains("does not exist") {
+        //         Err(crate::errors::ErrorKind::NotFound(error))
+        //     } else {
+        //         Err(crate::errors::ErrorKind::InternalError(error))
+        //     }
+        // }
         _ => Err(crate::errors::ErrorKind::InternalInvariantError(
             "queried ViewAccessKey, but received something else.".to_string(),
         )),

--- a/chain/rosetta-rpc/src/utils.rs
+++ b/chain/rosetta-rpc/src/utils.rs
@@ -327,16 +327,6 @@ pub(crate) async fn query_account(
         near_primitives::views::QueryResponseKind::ViewAccount(account_info) => {
             Ok((account_info_response.block_hash, account_info_response.block_height, account_info))
         }
-        // near_primitives::views::QueryResponseKind::Error(near_primitives::views::QueryError {
-        //     error,
-        //     ..
-        // }) => {
-        //     if error.contains("does not exist") {
-        //         Err(crate::errors::ErrorKind::NotFound(error))
-        //     } else {
-        //         Err(crate::errors::ErrorKind::InternalError(error))
-        //     }
-        // }
         _ => Err(crate::errors::ErrorKind::InternalInvariantError(format!(
             "queried ViewAccount, but received {:?}.",
             account_info_response.kind
@@ -410,16 +400,6 @@ pub(crate) async fn query_access_key(
             access_key_query_response.block_height,
             access_key,
         )),
-        // near_primitives::views::QueryResponseKind::Error(near_primitives::views::QueryError {
-        //     error,
-        //     ..
-        // }) => {
-        //     if error.contains("does not exist") {
-        //         Err(crate::errors::ErrorKind::NotFound(error))
-        //     } else {
-        //         Err(crate::errors::ErrorKind::InternalError(error))
-        //     }
-        // }
         _ => Err(crate::errors::ErrorKind::InternalInvariantError(
             "queried ViewAccessKey, but received something else.".to_string(),
         )),

--- a/chain/rosetta-rpc/src/utils.rs
+++ b/chain/rosetta-rpc/src/utils.rs
@@ -313,7 +313,7 @@ pub(crate) async fn query_account(
         block_id,
         near_primitives::views::QueryRequest::ViewAccount { account_id },
     );
-    let account_info_response = match view_client_addr.send(query.clone()).await? {
+    let account_info_response = match view_client_addr.send(query).await? {
         Ok(query_response) => query_response,
         Err(err) => match err {
             near_client_primitives::types::QueryError::AccountDoesNotExist { .. } => {
@@ -391,7 +391,7 @@ pub(crate) async fn query_access_key(
         block_id,
         near_primitives::views::QueryRequest::ViewAccessKey { account_id, public_key },
     );
-    let access_key_query_response = match view_client_addr.send(access_key_query.clone()).await? {
+    let access_key_query_response = match view_client_addr.send(access_key_query).await? {
         Ok(query_response) => query_response,
         Err(err) => {
             return match err {

--- a/chain/rosetta-rpc/src/utils.rs
+++ b/chain/rosetta-rpc/src/utils.rs
@@ -316,7 +316,7 @@ pub(crate) async fn query_account(
     let account_info_response = match view_client_addr.send(query).await? {
         Ok(query_response) => query_response,
         Err(err) => match err {
-            near_client_primitives::types::QueryError::AccountDoesNotExist { .. } => {
+            near_client_primitives::types::QueryError::UnknownAccount { .. } => {
                 return Err(crate::errors::ErrorKind::NotFound(err.to_string()))
             }
             _ => return Err(crate::errors::ErrorKind::InternalError(err.to_string())),
@@ -395,8 +395,8 @@ pub(crate) async fn query_access_key(
         Ok(query_response) => query_response,
         Err(err) => {
             return match err {
-                near_client_primitives::types::QueryError::AccountDoesNotExist { .. }
-                | near_client_primitives::types::QueryError::AccessKeyDoesNotExist { .. } => {
+                near_client_primitives::types::QueryError::UnknownAccount { .. }
+                | near_client_primitives::types::QueryError::UnknownAccessKey { .. } => {
                     Err(crate::errors::ErrorKind::NotFound(err.to_string()))
                 }
                 _ => Err(crate::errors::ErrorKind::InternalError(err.to_string())),

--- a/chain/rosetta-rpc/src/utils.rs
+++ b/chain/rosetta-rpc/src/utils.rs
@@ -316,7 +316,7 @@ pub(crate) async fn query_account(
     let account_info_response = match view_client_addr.send(query.clone()).await? {
         Ok(query_response) => query_response,
         Err(err) => match err {
-            near_client_primitives::types::QueryError::AccountDoesNotExist(_) => {
+            near_client_primitives::types::QueryError::AccountDoesNotExist { .. } => {
                 return Err(crate::errors::ErrorKind::NotFound(err.to_string()))
             }
             _ => return Err(crate::errors::ErrorKind::InternalError(err.to_string())),
@@ -395,8 +395,8 @@ pub(crate) async fn query_access_key(
         Ok(query_response) => query_response,
         Err(err) => {
             return match err {
-                near_client_primitives::types::QueryError::AccountDoesNotExist(_)
-                | near_client_primitives::types::QueryError::AccessKeyDoesNotExist(_) => {
+                near_client_primitives::types::QueryError::AccountDoesNotExist { .. }
+                | near_client_primitives::types::QueryError::AccessKeyDoesNotExist { .. } => {
                     Err(crate::errors::ErrorKind::NotFound(err.to_string()))
                 }
                 _ => Err(crate::errors::ErrorKind::InternalError(err.to_string())),

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -252,7 +252,6 @@ pub enum QueryResponseKind {
     ViewCode(ContractCodeView),
     ViewState(ViewStateResult),
     CallResult(CallResult),
-    // Error(QueryError),
     AccessKey(AccessKeyView),
     AccessKeyList(AccessKeyList),
 }

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -252,7 +252,7 @@ pub enum QueryResponseKind {
     ViewCode(ContractCodeView),
     ViewState(ViewStateResult),
     CallResult(CallResult),
-    Error(QueryError),
+    // Error(QueryError),
     AccessKey(AccessKeyView),
     AccessKeyList(AccessKeyList),
 }

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -246,8 +246,7 @@ impl std::iter::FromIterator<AccessKeyInfoView> for AccessKeyList {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
-#[serde(untagged)]
+#[derive(BorshSerialize, BorshDeserialize, Debug, PartialEq, Eq, Clone)]
 pub enum QueryResponseKind {
     ViewAccount(AccountView),
     ViewCode(ContractCodeView),
@@ -287,9 +286,8 @@ pub enum QueryRequest {
     },
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[derive(BorshSerialize, BorshDeserialize, Debug, PartialEq, Eq, Clone)]
 pub struct QueryResponse {
-    #[serde(flatten)]
     pub kind: QueryResponseKind,
     pub block_height: BlockHeight,
     pub block_hash: CryptoHash,
@@ -330,61 +328,6 @@ pub struct StatusResponse {
     pub sync_info: StatusSyncInfo,
     /// Validator id of the node
     pub validator_account_id: Option<AccountId>,
-}
-
-impl TryFrom<QueryResponse> for AccountView {
-    type Error = String;
-
-    fn try_from(query_response: QueryResponse) -> Result<Self, Self::Error> {
-        match query_response.kind {
-            QueryResponseKind::ViewAccount(acc) => Ok(acc),
-            _ => Err("Invalid type of response".into()),
-        }
-    }
-}
-
-impl TryFrom<QueryResponse> for CallResult {
-    type Error = String;
-
-    fn try_from(query_response: QueryResponse) -> Result<Self, Self::Error> {
-        match query_response.kind {
-            QueryResponseKind::CallResult(res) => Ok(res),
-            _ => Err("Invalid type of response".into()),
-        }
-    }
-}
-
-impl TryFrom<QueryResponse> for ViewStateResult {
-    type Error = String;
-
-    fn try_from(query_response: QueryResponse) -> Result<Self, Self::Error> {
-        match query_response.kind {
-            QueryResponseKind::ViewState(vs) => Ok(vs),
-            _ => Err("Invalid type of response".into()),
-        }
-    }
-}
-
-impl TryFrom<QueryResponse> for AccessKeyView {
-    type Error = String;
-
-    fn try_from(query_response: QueryResponse) -> Result<Self, Self::Error> {
-        match query_response.kind {
-            QueryResponseKind::AccessKey(access_key) => Ok(access_key),
-            _ => Err("Invalid type of response".into()),
-        }
-    }
-}
-
-impl TryFrom<QueryResponse> for ContractCodeView {
-    type Error = String;
-
-    fn try_from(query_response: QueryResponse) -> Result<Self, Self::Error> {
-        match query_response.kind {
-            QueryResponseKind::ViewCode(contract_code) => Ok(contract_code),
-            _ => Err("Invalid type of response".into()),
-        }
-    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1"
 lazy_static = "1.4"
 dirs = "3"
 borsh = "0.8.1"
+thiserror = "1.0"
 tracing = "0.1.13"
 tracing-subscriber = "0.2.4"
 num-rational = { version = "0.3", features = ["serde"] }

--- a/neard/src/lib.rs
+++ b/neard/src/lib.rs
@@ -29,6 +29,7 @@ use near_store::migrations::{
 
 #[cfg(feature = "protocol_feature_rectify_inflation")]
 use near_store::migrations::migrate_18_to_rectify_inflation;
+pub use runtime::errors as runtime_errors;
 
 pub mod config;
 pub mod genesis_validate;

--- a/neard/src/lib.rs
+++ b/neard/src/lib.rs
@@ -29,7 +29,6 @@ use near_store::migrations::{
 
 #[cfg(feature = "protocol_feature_rectify_inflation")]
 use near_store::migrations::migrate_18_to_rectify_inflation;
-pub use runtime::errors as runtime_errors;
 
 pub mod config;
 pub mod genesis_validate;

--- a/neard/src/runtime/errors.rs
+++ b/neard/src/runtime/errors.rs
@@ -4,6 +4,12 @@ use near_chain::near_chain_primitives::error::QueryError;
 #[error(transparent)]
 pub struct RuntimeQueryError(#[from] pub QueryError);
 
+impl From<RuntimeQueryError> for QueryError {
+    fn from(error: RuntimeQueryError) -> Self {
+        error.0
+    }
+}
+
 impl From<node_runtime::state_viewer::errors::ViewAccountError> for RuntimeQueryError {
     fn from(error: node_runtime::state_viewer::errors::ViewAccountError) -> Self {
         match error {
@@ -20,7 +26,7 @@ impl From<node_runtime::state_viewer::errors::ViewAccountError> for RuntimeQuery
     }
 }
 
-impl From<node_runtime::state_viewer::errors::ViewContractCodeError> for QueryError {
+impl From<node_runtime::state_viewer::errors::ViewContractCodeError> for RuntimeQueryError {
     fn from(error: node_runtime::state_viewer::errors::ViewContractCodeError) -> Self {
         match error {
             node_runtime::state_viewer::errors::ViewContractCodeError::InvalidAccountId(
@@ -39,7 +45,7 @@ impl From<node_runtime::state_viewer::errors::ViewContractCodeError> for QueryEr
     }
 }
 
-impl From<node_runtime::state_viewer::errors::CallFunctionError> for QueryError {
+impl From<node_runtime::state_viewer::errors::CallFunctionError> for RuntimeQueryError {
     fn from(error: node_runtime::state_viewer::errors::CallFunctionError) -> Self {
         match error {
             node_runtime::state_viewer::errors::CallFunctionError::InvalidAccountId(account_id) => {
@@ -58,7 +64,7 @@ impl From<node_runtime::state_viewer::errors::CallFunctionError> for QueryError 
     }
 }
 
-impl From<node_runtime::state_viewer::errors::ViewStateError> for QueryError {
+impl From<node_runtime::state_viewer::errors::ViewStateError> for RuntimeQueryError {
     fn from(error: node_runtime::state_viewer::errors::ViewStateError) -> Self {
         match error {
             node_runtime::state_viewer::errors::ViewStateError::InvalidAccountId(account_id) => {
@@ -68,5 +74,11 @@ impl From<node_runtime::state_viewer::errors::ViewStateError> for QueryError {
                 Self(QueryError::StorageError(storage_error))
             }
         }
+    }
+}
+
+impl From<near_primitives::errors::EpochError> for RuntimeQueryError {
+    fn from(error: near_primitives::errors::EpochError) -> Self {
+        Self(QueryError::InternalError(error.to_string()))
     }
 }

--- a/neard/src/runtime/errors.rs
+++ b/neard/src/runtime/errors.rs
@@ -90,7 +90,7 @@ impl From<node_runtime::state_viewer::errors::ViewAccessKeyError> for WrappedQue
             } => Self(QueryError::StorageError { storage_error }),
             node_runtime::state_viewer::errors::ViewAccessKeyError::AccessKeyDoesNotExist {
                 public_key,
-            } => Self(QueryError::AccessKeyDoesNotExist { public_key: public_key.to_string() }),
+            } => Self(QueryError::AccessKeyDoesNotExist { public_key }),
             node_runtime::state_viewer::errors::ViewAccessKeyError::InternalError {
                 error_message,
             } => Self(QueryError::InternalError { error_message }),

--- a/neard/src/runtime/errors.rs
+++ b/neard/src/runtime/errors.rs
@@ -1,0 +1,72 @@
+use near_chain::near_chain_primitives::error::QueryError;
+
+#[derive(thiserror::Error, Debug)]
+#[error(transparent)]
+pub struct RuntimeQueryError(#[from] pub QueryError);
+
+impl From<node_runtime::state_viewer::errors::ViewAccountError> for RuntimeQueryError {
+    fn from(error: node_runtime::state_viewer::errors::ViewAccountError) -> Self {
+        match error {
+            node_runtime::state_viewer::errors::ViewAccountError::InvalidAccountId(account_id) => {
+                Self(QueryError::InvalidAccount(account_id))
+            }
+            node_runtime::state_viewer::errors::ViewAccountError::AccountDoesNotExist(
+                account_id,
+            ) => Self(QueryError::AccountDoesNotExist(account_id)),
+            node_runtime::state_viewer::errors::ViewAccountError::StorageError(storage_error) => {
+                Self(QueryError::StorageError(storage_error))
+            }
+        }
+    }
+}
+
+impl From<node_runtime::state_viewer::errors::ViewContractCodeError> for QueryError {
+    fn from(error: node_runtime::state_viewer::errors::ViewContractCodeError) -> Self {
+        match error {
+            node_runtime::state_viewer::errors::ViewContractCodeError::InvalidAccountId(
+                account_id,
+            ) => Self(QueryError::InvalidAccount(account_id)),
+            node_runtime::state_viewer::errors::ViewContractCodeError::AccountDoesNotExist(
+                account_id,
+            ) => Self(QueryError::AccountDoesNotExist(account_id)),
+            node_runtime::state_viewer::errors::ViewContractCodeError::StorageError(
+                storage_error,
+            ) => Self(QueryError::StorageError(storage_error)),
+            node_runtime::state_viewer::errors::ViewContractCodeError::ContractCodeDoesNotExist(
+                contract_id,
+            ) => Self(QueryError::ContractCodeDoesNotExist(contract_id)),
+        }
+    }
+}
+
+impl From<node_runtime::state_viewer::errors::CallFunctionError> for QueryError {
+    fn from(error: node_runtime::state_viewer::errors::CallFunctionError) -> Self {
+        match error {
+            node_runtime::state_viewer::errors::CallFunctionError::InvalidAccountId(account_id) => {
+                Self(QueryError::InvalidAccount(account_id))
+            }
+            node_runtime::state_viewer::errors::CallFunctionError::AccountDoesNotExist(
+                account_id,
+            ) => Self(QueryError::AccountDoesNotExist(account_id)),
+            node_runtime::state_viewer::errors::CallFunctionError::StorageError(storage_error) => {
+                Self(QueryError::StorageError(storage_error))
+            }
+            node_runtime::state_viewer::errors::CallFunctionError::VMError(s) => {
+                Self(QueryError::VMError(s))
+            }
+        }
+    }
+}
+
+impl From<node_runtime::state_viewer::errors::ViewStateError> for QueryError {
+    fn from(error: node_runtime::state_viewer::errors::ViewStateError) -> Self {
+        match error {
+            node_runtime::state_viewer::errors::ViewStateError::InvalidAccountId(account_id) => {
+                Self(QueryError::InvalidAccount(account_id))
+            }
+            node_runtime::state_viewer::errors::ViewStateError::StorageError(storage_error) => {
+                Self(QueryError::StorageError(storage_error))
+            }
+        }
+    }
+}

--- a/neard/src/runtime/errors.rs
+++ b/neard/src/runtime/errors.rs
@@ -21,9 +21,9 @@ impl From<node_runtime::state_viewer::errors::ViewAccountError> for WrappedQuery
             node_runtime::state_viewer::errors::ViewAccountError::AccountDoesNotExist {
                 requested_account_id,
             } => Self(QueryError::AccountDoesNotExist { requested_account_id }),
-            node_runtime::state_viewer::errors::ViewAccountError::StorageError(storage_error) => {
-                Self(QueryError::StorageError(storage_error))
-            }
+            node_runtime::state_viewer::errors::ViewAccountError::StorageError {
+                storage_error,
+            } => Self(QueryError::StorageError { storage_error }),
         }
     }
 }
@@ -37,9 +37,9 @@ impl From<node_runtime::state_viewer::errors::ViewContractCodeError> for Wrapped
             node_runtime::state_viewer::errors::ViewContractCodeError::AccountDoesNotExist {
                 requested_account_id,
             } => Self(QueryError::AccountDoesNotExist { requested_account_id }),
-            node_runtime::state_viewer::errors::ViewContractCodeError::StorageError(
+            node_runtime::state_viewer::errors::ViewContractCodeError::StorageError {
                 storage_error,
-            ) => Self(QueryError::StorageError(storage_error)),
+            } => Self(QueryError::StorageError { storage_error }),
             node_runtime::state_viewer::errors::ViewContractCodeError::NoContractCode {
                 contract_account_id,
             } => Self(QueryError::ContractCodeDoesNotExist { contract_account_id }),
@@ -57,10 +57,10 @@ impl From<node_runtime::state_viewer::errors::CallFunctionError> for WrappedQuer
                 requested_account_id,
             } => Self(QueryError::AccountDoesNotExist { requested_account_id }),
             node_runtime::state_viewer::errors::CallFunctionError::StorageError(storage_error) => {
-                Self(QueryError::StorageError(storage_error))
+                Self(QueryError::StorageError { storage_error })
             }
-            node_runtime::state_viewer::errors::CallFunctionError::VMError(s) => {
-                Self(QueryError::VMError(s))
+            node_runtime::state_viewer::errors::CallFunctionError::VMError { error_message } => {
+                Self(QueryError::VMError { error_message })
             }
         }
     }
@@ -72,8 +72,8 @@ impl From<node_runtime::state_viewer::errors::ViewStateError> for WrappedQueryEr
             node_runtime::state_viewer::errors::ViewStateError::InvalidAccountId {
                 requested_account_id,
             } => Self(QueryError::InvalidAccount { requested_account_id }),
-            node_runtime::state_viewer::errors::ViewStateError::StorageError(storage_error) => {
-                Self(QueryError::StorageError(storage_error))
+            node_runtime::state_viewer::errors::ViewStateError::StorageError { storage_error } => {
+                Self(QueryError::StorageError { storage_error })
             }
         }
     }
@@ -85,9 +85,9 @@ impl From<node_runtime::state_viewer::errors::ViewAccessKeyError> for WrappedQue
             node_runtime::state_viewer::errors::ViewAccessKeyError::InvalidAccountId {
                 requested_account_id,
             } => Self(QueryError::InvalidAccount { requested_account_id }),
-            node_runtime::state_viewer::errors::ViewAccessKeyError::StorageError(storage_error) => {
-                Self(QueryError::StorageError(storage_error))
-            }
+            node_runtime::state_viewer::errors::ViewAccessKeyError::StorageError {
+                storage_error,
+            } => Self(QueryError::StorageError { storage_error }),
             node_runtime::state_viewer::errors::ViewAccessKeyError::AccessKeyDoesNotExist {
                 public_key,
             } => Self(QueryError::AccessKeyDoesNotExist { public_key: public_key.to_string() }),

--- a/neard/src/runtime/errors.rs
+++ b/neard/src/runtime/errors.rs
@@ -1,24 +1,26 @@
 use near_chain::near_chain_primitives::error::QueryError;
 
+// This wrapper struct is necessary because we cannot implement
+// From<> trait for the original QueryError struct since it is a foreign type
 #[derive(thiserror::Error, Debug)]
 #[error(transparent)]
-pub struct RuntimeQueryError(#[from] pub QueryError);
+pub struct WrappedQueryError(pub QueryError);
 
-impl From<RuntimeQueryError> for QueryError {
-    fn from(error: RuntimeQueryError) -> Self {
+impl From<WrappedQueryError> for QueryError {
+    fn from(error: WrappedQueryError) -> Self {
         error.0
     }
 }
 
-impl From<node_runtime::state_viewer::errors::ViewAccountError> for RuntimeQueryError {
+impl From<node_runtime::state_viewer::errors::ViewAccountError> for WrappedQueryError {
     fn from(error: node_runtime::state_viewer::errors::ViewAccountError) -> Self {
         match error {
-            node_runtime::state_viewer::errors::ViewAccountError::InvalidAccountId(account_id) => {
-                Self(QueryError::InvalidAccount(account_id))
-            }
-            node_runtime::state_viewer::errors::ViewAccountError::AccountDoesNotExist(
-                account_id,
-            ) => Self(QueryError::AccountDoesNotExist(account_id)),
+            node_runtime::state_viewer::errors::ViewAccountError::InvalidAccountId {
+                requested_account_id,
+            } => Self(QueryError::InvalidAccount { requested_account_id }),
+            node_runtime::state_viewer::errors::ViewAccountError::AccountDoesNotExist {
+                requested_account_id,
+            } => Self(QueryError::AccountDoesNotExist { requested_account_id }),
             node_runtime::state_viewer::errors::ViewAccountError::StorageError(storage_error) => {
                 Self(QueryError::StorageError(storage_error))
             }
@@ -26,34 +28,34 @@ impl From<node_runtime::state_viewer::errors::ViewAccountError> for RuntimeQuery
     }
 }
 
-impl From<node_runtime::state_viewer::errors::ViewContractCodeError> for RuntimeQueryError {
+impl From<node_runtime::state_viewer::errors::ViewContractCodeError> for WrappedQueryError {
     fn from(error: node_runtime::state_viewer::errors::ViewContractCodeError) -> Self {
         match error {
-            node_runtime::state_viewer::errors::ViewContractCodeError::InvalidAccountId(
-                account_id,
-            ) => Self(QueryError::InvalidAccount(account_id)),
-            node_runtime::state_viewer::errors::ViewContractCodeError::AccountDoesNotExist(
-                account_id,
-            ) => Self(QueryError::AccountDoesNotExist(account_id)),
+            node_runtime::state_viewer::errors::ViewContractCodeError::InvalidAccountId {
+                requested_account_id,
+            } => Self(QueryError::InvalidAccount { requested_account_id }),
+            node_runtime::state_viewer::errors::ViewContractCodeError::AccountDoesNotExist {
+                requested_account_id,
+            } => Self(QueryError::AccountDoesNotExist { requested_account_id }),
             node_runtime::state_viewer::errors::ViewContractCodeError::StorageError(
                 storage_error,
             ) => Self(QueryError::StorageError(storage_error)),
-            node_runtime::state_viewer::errors::ViewContractCodeError::ContractCodeDoesNotExist(
-                contract_id,
-            ) => Self(QueryError::ContractCodeDoesNotExist(contract_id)),
+            node_runtime::state_viewer::errors::ViewContractCodeError::NoContractCode {
+                contract_account_id,
+            } => Self(QueryError::ContractCodeDoesNotExist { contract_account_id }),
         }
     }
 }
 
-impl From<node_runtime::state_viewer::errors::CallFunctionError> for RuntimeQueryError {
+impl From<node_runtime::state_viewer::errors::CallFunctionError> for WrappedQueryError {
     fn from(error: node_runtime::state_viewer::errors::CallFunctionError) -> Self {
         match error {
-            node_runtime::state_viewer::errors::CallFunctionError::InvalidAccountId(account_id) => {
-                Self(QueryError::InvalidAccount(account_id))
-            }
-            node_runtime::state_viewer::errors::CallFunctionError::AccountDoesNotExist(
-                account_id,
-            ) => Self(QueryError::AccountDoesNotExist(account_id)),
+            node_runtime::state_viewer::errors::CallFunctionError::InvalidAccountId {
+                requested_account_id,
+            } => Self(QueryError::InvalidAccount { requested_account_id }),
+            node_runtime::state_viewer::errors::CallFunctionError::AccountDoesNotExist {
+                requested_account_id,
+            } => Self(QueryError::AccountDoesNotExist { requested_account_id }),
             node_runtime::state_viewer::errors::CallFunctionError::StorageError(storage_error) => {
                 Self(QueryError::StorageError(storage_error))
             }
@@ -64,12 +66,12 @@ impl From<node_runtime::state_viewer::errors::CallFunctionError> for RuntimeQuer
     }
 }
 
-impl From<node_runtime::state_viewer::errors::ViewStateError> for RuntimeQueryError {
+impl From<node_runtime::state_viewer::errors::ViewStateError> for WrappedQueryError {
     fn from(error: node_runtime::state_viewer::errors::ViewStateError) -> Self {
         match error {
-            node_runtime::state_viewer::errors::ViewStateError::InvalidAccountId(account_id) => {
-                Self(QueryError::InvalidAccount(account_id))
-            }
+            node_runtime::state_viewer::errors::ViewStateError::InvalidAccountId {
+                requested_account_id,
+            } => Self(QueryError::InvalidAccount { requested_account_id }),
             node_runtime::state_viewer::errors::ViewStateError::StorageError(storage_error) => {
                 Self(QueryError::StorageError(storage_error))
             }
@@ -77,8 +79,27 @@ impl From<node_runtime::state_viewer::errors::ViewStateError> for RuntimeQueryEr
     }
 }
 
-impl From<near_primitives::errors::EpochError> for RuntimeQueryError {
+impl From<node_runtime::state_viewer::errors::ViewAccessKeyError> for WrappedQueryError {
+    fn from(error: node_runtime::state_viewer::errors::ViewAccessKeyError) -> Self {
+        match error {
+            node_runtime::state_viewer::errors::ViewAccessKeyError::InvalidAccountId {
+                requested_account_id,
+            } => Self(QueryError::InvalidAccount { requested_account_id }),
+            node_runtime::state_viewer::errors::ViewAccessKeyError::StorageError(storage_error) => {
+                Self(QueryError::StorageError(storage_error))
+            }
+            node_runtime::state_viewer::errors::ViewAccessKeyError::AccessKeyDoesNotExist {
+                public_key,
+            } => Self(QueryError::AccessKeyDoesNotExist { public_key: public_key.to_string() }),
+            node_runtime::state_viewer::errors::ViewAccessKeyError::InternalError {
+                error_message,
+            } => Self(QueryError::InternalError { error_message }),
+        }
+    }
+}
+
+impl From<near_primitives::errors::EpochError> for WrappedQueryError {
     fn from(error: near_primitives::errors::EpochError) -> Self {
-        Self(QueryError::InternalError(error.to_string()))
+        Self(QueryError::InternalError { error_message: error.to_string() })
     }
 }

--- a/neard/src/runtime/errors.rs
+++ b/neard/src/runtime/errors.rs
@@ -20,10 +20,10 @@ impl From<node_runtime::state_viewer::errors::ViewAccountError> for WrappedQuery
             } => Self(QueryError::InvalidAccount { requested_account_id }),
             node_runtime::state_viewer::errors::ViewAccountError::AccountDoesNotExist {
                 requested_account_id,
-            } => Self(QueryError::AccountDoesNotExist { requested_account_id }),
-            node_runtime::state_viewer::errors::ViewAccountError::StorageError {
-                storage_error,
-            } => Self(QueryError::StorageError { storage_error }),
+            } => Self(QueryError::UnknownAccount { requested_account_id }),
+            node_runtime::state_viewer::errors::ViewAccountError::InternalError {
+                error_message,
+            } => Self(QueryError::InternalError { error_message }),
         }
     }
 }
@@ -36,13 +36,13 @@ impl From<node_runtime::state_viewer::errors::ViewContractCodeError> for Wrapped
             } => Self(QueryError::InvalidAccount { requested_account_id }),
             node_runtime::state_viewer::errors::ViewContractCodeError::AccountDoesNotExist {
                 requested_account_id,
-            } => Self(QueryError::AccountDoesNotExist { requested_account_id }),
-            node_runtime::state_viewer::errors::ViewContractCodeError::StorageError {
-                storage_error,
-            } => Self(QueryError::StorageError { storage_error }),
+            } => Self(QueryError::UnknownAccount { requested_account_id }),
+            node_runtime::state_viewer::errors::ViewContractCodeError::InternalError {
+                error_message,
+            } => Self(QueryError::InternalError { error_message }),
             node_runtime::state_viewer::errors::ViewContractCodeError::NoContractCode {
                 contract_account_id,
-            } => Self(QueryError::ContractCodeDoesNotExist { contract_account_id }),
+            } => Self(QueryError::NoContractCode { contract_account_id }),
         }
     }
 }
@@ -55,12 +55,12 @@ impl From<node_runtime::state_viewer::errors::CallFunctionError> for WrappedQuer
             } => Self(QueryError::InvalidAccount { requested_account_id }),
             node_runtime::state_viewer::errors::CallFunctionError::AccountDoesNotExist {
                 requested_account_id,
-            } => Self(QueryError::AccountDoesNotExist { requested_account_id }),
-            node_runtime::state_viewer::errors::CallFunctionError::StorageError(storage_error) => {
-                Self(QueryError::StorageError { storage_error })
-            }
+            } => Self(QueryError::UnknownAccount { requested_account_id }),
+            node_runtime::state_viewer::errors::CallFunctionError::InternalError {
+                error_message,
+            } => Self(QueryError::InternalError { error_message }),
             node_runtime::state_viewer::errors::CallFunctionError::VMError { error_message } => {
-                Self(QueryError::VMError { error_message })
+                Self(QueryError::ContractExecutionError { error_message })
             }
         }
     }
@@ -72,8 +72,8 @@ impl From<node_runtime::state_viewer::errors::ViewStateError> for WrappedQueryEr
             node_runtime::state_viewer::errors::ViewStateError::InvalidAccountId {
                 requested_account_id,
             } => Self(QueryError::InvalidAccount { requested_account_id }),
-            node_runtime::state_viewer::errors::ViewStateError::StorageError { storage_error } => {
-                Self(QueryError::StorageError { storage_error })
+            node_runtime::state_viewer::errors::ViewStateError::InternalError { error_message } => {
+                Self(QueryError::InternalError { error_message })
             }
         }
     }
@@ -85,12 +85,9 @@ impl From<node_runtime::state_viewer::errors::ViewAccessKeyError> for WrappedQue
             node_runtime::state_viewer::errors::ViewAccessKeyError::InvalidAccountId {
                 requested_account_id,
             } => Self(QueryError::InvalidAccount { requested_account_id }),
-            node_runtime::state_viewer::errors::ViewAccessKeyError::StorageError {
-                storage_error,
-            } => Self(QueryError::StorageError { storage_error }),
             node_runtime::state_viewer::errors::ViewAccessKeyError::AccessKeyDoesNotExist {
                 public_key,
-            } => Self(QueryError::AccessKeyDoesNotExist { public_key }),
+            } => Self(QueryError::UnknownAccessKey { public_key }),
             node_runtime::state_viewer::errors::ViewAccessKeyError::InternalError {
                 error_message,
             } => Self(QueryError::InternalError { error_message }),

--- a/neard/src/runtime/errors.rs
+++ b/neard/src/runtime/errors.rs
@@ -1,8 +1,6 @@
-use easy_ext::ext;
-
 use near_chain::near_chain_primitives::error::QueryError;
 
-#[ext(FromStateViewerErrors)]
+#[easy_ext::ext(FromStateViewerErrors)]
 impl QueryError {
     pub fn from_call_function_error(
         error: node_runtime::state_viewer::errors::CallFunctionError,

--- a/neard/src/runtime/mod.rs
+++ b/neard/src/runtime/mod.rs
@@ -59,6 +59,8 @@ use near_primitives::runtime::config::RuntimeConfig;
 #[cfg(feature = "protocol_feature_rectify_inflation")]
 use near_epoch_manager::NUM_SECONDS_IN_A_YEAR;
 
+use errors::FromStateViewerErrors;
+
 pub mod errors;
 
 const POISONED_LOCK_ERR: &str = "The lock was poisoned.";
@@ -1251,7 +1253,7 @@ impl RuntimeAdapter for NightshadeRuntime {
             QueryRequest::ViewAccount { account_id } => {
                 let account = self
                     .view_account(shard_id, *state_root, account_id)
-                    .map_err(errors::WrappedQueryError::from)?;
+                    .map_err(|err| near_chain::near_chain_primitives::error::QueryError::from_view_account_error(err, block_height, *block_hash))?;
                 Ok(QueryResponse {
                     kind: QueryResponseKind::ViewAccount(account.into()),
                     block_height,
@@ -1261,7 +1263,7 @@ impl RuntimeAdapter for NightshadeRuntime {
             QueryRequest::ViewCode { account_id } => {
                 let contract_code = self
                     .view_contract_code(shard_id, *state_root, account_id)
-                    .map_err(errors::WrappedQueryError::from)?;
+                    .map_err(|err| near_chain::near_chain_primitives::error::QueryError::from_view_contract_code_error(err, block_height, *block_hash))?;
                 Ok(QueryResponse {
                     kind: QueryResponseKind::ViewCode(contract_code.into()),
                     block_height,
@@ -1273,9 +1275,13 @@ impl RuntimeAdapter for NightshadeRuntime {
                 let (epoch_height, current_protocol_version) = {
                     let mut epoch_manager =
                         self.epoch_manager.as_ref().write().expect(POISONED_LOCK_ERR);
-                    let epoch_info = epoch_manager
-                        .get_epoch_info(&epoch_id)
-                        .map_err(errors::WrappedQueryError::from)?;
+                    let epoch_info = epoch_manager.get_epoch_info(&epoch_id).map_err(|err| {
+                        near_chain::near_chain_primitives::error::QueryError::from_epoch_error(
+                            err,
+                            block_height,
+                            *block_hash,
+                        )
+                    })?;
                     (epoch_info.epoch_height, epoch_info.protocol_version)
                 };
 
@@ -1298,7 +1304,7 @@ impl RuntimeAdapter for NightshadeRuntime {
                         #[cfg(feature = "protocol_feature_evm")]
                         self.evm_chain_id(),
                     )
-                    .map_err(errors::WrappedQueryError::from)?;
+                    .map_err(|err| near_chain::near_chain_primitives::error::QueryError::from_call_function_error(err, block_height, *block_hash))?;
                 Ok(QueryResponse {
                     kind: QueryResponseKind::CallResult(CallResult {
                         result: call_function_result,
@@ -1311,7 +1317,13 @@ impl RuntimeAdapter for NightshadeRuntime {
             QueryRequest::ViewState { account_id, prefix } => {
                 let view_state_result = self
                     .view_state(shard_id, *state_root, account_id, prefix.as_ref())
-                    .map_err(errors::WrappedQueryError::from)?;
+                    .map_err(|err| {
+                        near_chain::near_chain_primitives::error::QueryError::from_view_state_error(
+                            err,
+                            block_height,
+                            *block_hash,
+                        )
+                    })?;
                 Ok(QueryResponse {
                     kind: QueryResponseKind::ViewState(view_state_result),
                     block_height,
@@ -1319,9 +1331,14 @@ impl RuntimeAdapter for NightshadeRuntime {
                 })
             }
             QueryRequest::ViewAccessKeyList { account_id } => {
-                let access_key_list = self
-                    .view_access_keys(shard_id, *state_root, account_id)
-                    .map_err(errors::WrappedQueryError::from)?;
+                let access_key_list =
+                    self.view_access_keys(shard_id, *state_root, account_id).map_err(|err| {
+                        near_chain::near_chain_primitives::error::QueryError::from_view_access_key_error(
+                            err,
+                            block_height,
+                            *block_hash,
+                        )
+                    })?;
                 Ok(QueryResponse {
                     kind: QueryResponseKind::AccessKeyList(
                         access_key_list
@@ -1339,7 +1356,13 @@ impl RuntimeAdapter for NightshadeRuntime {
             QueryRequest::ViewAccessKey { account_id, public_key } => {
                 let access_key = self
                     .view_access_key(shard_id, *state_root, account_id, public_key)
-                    .map_err(errors::WrappedQueryError::from)?;
+                    .map_err(|err| {
+                        near_chain::near_chain_primitives::error::QueryError::from_view_access_key_error(
+                            err,
+                            block_height,
+                            *block_hash,
+                        )
+                    })?;
                 Ok(QueryResponse {
                     kind: QueryResponseKind::AccessKey(access_key.into()),
                     block_height,

--- a/neard/src/runtime/mod.rs
+++ b/neard/src/runtime/mod.rs
@@ -1275,7 +1275,9 @@ impl RuntimeAdapter for NightshadeRuntime {
                 let (epoch_height, current_protocol_version) = {
                     let mut epoch_manager =
                         self.epoch_manager.as_ref().write().expect(POISONED_LOCK_ERR);
-                    let epoch_info = epoch_manager.get_epoch_info(&epoch_id)?;
+                    let epoch_info = epoch_manager
+                        .get_epoch_info(&epoch_id)
+                        .map_err(errors::RuntimeQueryError::from)?;
                     (epoch_info.epoch_height, epoch_info.protocol_version)
                 };
 

--- a/neard/tests/rpc_nodes.rs
+++ b/neard/tests/rpc_nodes.rs
@@ -357,6 +357,7 @@ fn test_tx_status_with_light_client1() {
     });
 }
 
+#[ignore] // TODO: change this test https://github.com/near/nearcore/issues/4062
 #[test]
 fn test_rpc_routing() {
     init_integration_logger();
@@ -410,6 +411,7 @@ fn test_rpc_routing() {
     });
 }
 
+#[ignore] // TODO: change this test https://github.com/near/nearcore/issues/4062
 /// When we call rpc to view an account that does not exist, an error should be routed back.
 #[test]
 fn test_rpc_routing_error() {

--- a/neard/tests/rpc_nodes.rs
+++ b/neard/tests/rpc_nodes.rs
@@ -708,3 +708,42 @@ fn test_protocol_config_rpc() {
         });
     });
 }
+
+#[test]
+fn test_query_rpc() {
+    init_integration_logger();
+    heavy_test(|| {
+        System::builder()
+            .stop_on_panic(true)
+            .run(move || {
+                let num_nodes = 1;
+                let dirs = (0..num_nodes)
+                    .map(|i| {
+                        tempfile::Builder::new()
+                            .prefix(&format!("protocol_config{}", i))
+                            .tempdir()
+                            .unwrap()
+                    })
+                    .collect::<Vec<_>>();
+                let (_genesis, rpc_addrs, _) = start_nodes(1, &dirs, 1, 0, 10, 0);
+
+                actix::spawn(async move {
+                    let client = new_client(&format!("http://{}", rpc_addrs[0]));
+                    let query_response = client
+                        .query(near_jsonrpc_primitives::types::query::RpcQueryRequest {
+                            block_reference: near_primitives::types::BlockReference::Finality(
+                                Finality::Final,
+                            ),
+                            request: near_primitives::views::QueryRequest::ViewAccount {
+                                account_id: "test.near".to_string(),
+                            },
+                        })
+                        .await
+                        .unwrap();
+                    assert_eq!(false, true);
+                    System::current().stop();
+                });
+            })
+            .unwrap();
+    });
+}

--- a/neard/tests/rpc_nodes.rs
+++ b/neard/tests/rpc_nodes.rs
@@ -789,7 +789,11 @@ fn test_query_rpc_account_view_invalid_account_must_return_error() {
                     Ok(result) => panic!("expected error but received Ok: {:?}", result.kind),
                     Err(err) => err.data.unwrap(),
                 };
-                assert!(error_message.to_string().contains("Account ID 1nval$d*@cc0ount is invalid"), "{}", error_message);
+                assert!(
+                    error_message.to_string().contains("Account ID 1nval$d*@cc0ount is invalid"),
+                    "{}",
+                    error_message
+                );
                 System::current().stop();
             });
         });
@@ -830,7 +834,9 @@ fn test_query_rpc_account_view_account_doesnt_exist_must_return_error() {
                     Err(err) => err.data.unwrap(),
                 };
                 assert!(
-                    error_message.to_string().contains("account accountdoesntexist.0 does not exist while viewing"),
+                    error_message
+                        .to_string()
+                        .contains("account accountdoesntexist.0 does not exist while viewing"),
                     "{}",
                     error_message
                 );

--- a/neard/tests/rpc_nodes.rs
+++ b/neard/tests/rpc_nodes.rs
@@ -789,7 +789,7 @@ fn test_query_rpc_account_view_invalid_account_must_return_error() {
                     Ok(result) => panic!("expected error but received Ok: {:?}", result.kind),
                     Err(err) => err.data.unwrap(),
                 };
-                assert!(error_message.to_string().contains("is invalid"), "{}", error_message);
+                assert!(error_message.to_string().contains("Account ID 1nval$d*@cc0ount is invalid"), "{}", error_message);
                 System::current().stop();
             });
         });
@@ -830,7 +830,7 @@ fn test_query_rpc_account_view_account_doesnt_exist_must_return_error() {
                     Err(err) => err.data.unwrap(),
                 };
                 assert!(
-                    error_message.to_string().contains("does not exist while viewing"),
+                    error_message.to_string().contains("account accountdoesntexist.0 does not exist while viewing"),
                     "{}",
                     error_message
                 );

--- a/neard/tests/rpc_nodes.rs
+++ b/neard/tests/rpc_nodes.rs
@@ -19,7 +19,6 @@ use near_primitives::transaction::{PartialExecutionStatus, SignedTransaction};
 use near_primitives::types::{BlockId, BlockReference, Finality, TransactionOrReceiptId};
 use near_primitives::views::{
     ExecutionOutcomeView, ExecutionStatusView, FinalExecutionOutcomeViewEnum, FinalExecutionStatus,
-    QueryResponseKind,
 };
 use neard::config::TESTING_INIT_BALANCE;
 use std::sync::atomic::AtomicBool;
@@ -387,7 +386,7 @@ fn test_rpc_routing() {
                                         .query_by_path("account/near.2".to_string(), "".to_string())
                                         .map_err(|err| panic_on_rpc_error!(err))
                                         .map_ok(move |result| match result.kind {
-                                            QueryResponseKind::ViewAccount(account_view) => {
+                                            near_jsonrpc_primitives::types::query::QueryResponseKind::ViewAccount(account_view) => {
                                                 assert_eq!(
                                                     account_view.amount,
                                                     TESTING_INIT_BALANCE

--- a/neard/tests/stake_nodes.rs
+++ b/neard/tests/stake_nodes.rs
@@ -251,18 +251,16 @@ fn test_validator_kickout() {
                                                         .clone(),
                                                 },
                                             ))
-                                            .then(move |res| {
-                                                match res.unwrap().unwrap().unwrap().kind {
-                                                    QueryResponseKind::ViewAccount(result) => {
-                                                        if result.locked == 0
-                                                            || result.amount == TESTING_INIT_BALANCE
-                                                        {
-                                                            mark.store(true, Ordering::SeqCst);
-                                                        }
-                                                        future::ready(())
+                                            .then(move |res| match res.unwrap().unwrap().kind {
+                                                QueryResponseKind::ViewAccount(result) => {
+                                                    if result.locked == 0
+                                                        || result.amount == TESTING_INIT_BALANCE
+                                                    {
+                                                        mark.store(true, Ordering::SeqCst);
                                                     }
-                                                    _ => panic!("wrong return result"),
+                                                    future::ready(())
                                                 }
+                                                _ => panic!("wrong return result"),
                                             }),
                                     );
                                 }
@@ -280,23 +278,17 @@ fn test_validator_kickout() {
                                                         .clone(),
                                                 },
                                             ))
-                                            .then(move |res| {
-                                                match res.unwrap().unwrap().unwrap().kind {
-                                                    QueryResponseKind::ViewAccount(result) => {
-                                                        assert_eq!(
-                                                            result.locked,
-                                                            TESTING_INIT_STAKE
-                                                        );
-                                                        assert_eq!(
-                                                            result.amount,
-                                                            TESTING_INIT_BALANCE
-                                                                - TESTING_INIT_STAKE
-                                                        );
-                                                        mark.store(true, Ordering::SeqCst);
-                                                        future::ready(())
-                                                    }
-                                                    _ => panic!("wrong return result"),
+                                            .then(move |res| match res.unwrap().unwrap().kind {
+                                                QueryResponseKind::ViewAccount(result) => {
+                                                    assert_eq!(result.locked, TESTING_INIT_STAKE);
+                                                    assert_eq!(
+                                                        result.amount,
+                                                        TESTING_INIT_BALANCE - TESTING_INIT_STAKE
+                                                    );
+                                                    mark.store(true, Ordering::SeqCst);
+                                                    future::ready(())
                                                 }
+                                                _ => panic!("wrong return result"),
                                             }),
                                     );
                                 }
@@ -421,16 +413,14 @@ fn test_validator_join() {
                                                 account_id: test_nodes[1].account_id.clone(),
                                             },
                                         ))
-                                        .then(move |res| {
-                                            match res.unwrap().unwrap().unwrap().kind {
-                                                QueryResponseKind::ViewAccount(result) => {
-                                                    if result.locked == 0 {
-                                                        done1_copy2.store(true, Ordering::SeqCst);
-                                                    }
-                                                    future::ready(())
+                                        .then(move |res| match res.unwrap().unwrap().kind {
+                                            QueryResponseKind::ViewAccount(result) => {
+                                                if result.locked == 0 {
+                                                    done1_copy2.store(true, Ordering::SeqCst);
                                                 }
-                                                _ => panic!("wrong return result"),
+                                                future::ready(())
                                             }
+                                            _ => panic!("wrong return result"),
                                         }),
                                 );
                                 actix::spawn(
@@ -442,17 +432,15 @@ fn test_validator_join() {
                                                 account_id: test_nodes[2].account_id.clone(),
                                             },
                                         ))
-                                        .then(move |res| {
-                                            match res.unwrap().unwrap().unwrap().kind {
-                                                QueryResponseKind::ViewAccount(result) => {
-                                                    if result.locked == TESTING_INIT_STAKE {
-                                                        done2_copy2.store(true, Ordering::SeqCst);
-                                                    }
-
-                                                    future::ready(())
+                                        .then(move |res| match res.unwrap().unwrap().kind {
+                                            QueryResponseKind::ViewAccount(result) => {
+                                                if result.locked == TESTING_INIT_STAKE {
+                                                    done2_copy2.store(true, Ordering::SeqCst);
                                                 }
-                                                _ => panic!("wrong return result"),
+
+                                                future::ready(())
                                             }
+                                            _ => panic!("wrong return result"),
                                         }),
                                 );
                             }

--- a/runtime/runtime/Cargo.toml
+++ b/runtime/runtime/Cargo.toml
@@ -16,6 +16,7 @@ num-bigint = "0.3"
 num-traits = "0.2.11"
 hex = "0.4.2"
 ethereum-types = "0.11.0"
+thiserror = "1.0"
 
 borsh = "0.8.1"
 

--- a/runtime/runtime/src/adapter.rs
+++ b/runtime/runtime/src/adapter.rs
@@ -15,14 +15,14 @@ pub trait ViewRuntimeAdapter {
         shard_id: ShardId,
         state_root: MerkleHash,
         account_id: &AccountId,
-    ) -> Result<Account, Box<dyn std::error::Error>>;
+    ) -> Result<Account, crate::state_viewer::errors::ViewAccountError>;
 
     fn view_contract_code(
         &self,
         shard_id: ShardId,
         state_root: MerkleHash,
         account_id: &AccountId,
-    ) -> Result<ContractCode, Box<dyn std::error::Error>>;
+    ) -> Result<ContractCode, crate::state_viewer::errors::ViewContractCodeError>;
 
     fn call_function(
         &self,
@@ -41,7 +41,7 @@ pub trait ViewRuntimeAdapter {
         epoch_info_provider: &dyn EpochInfoProvider,
         current_protocol_version: ProtocolVersion,
         #[cfg(feature = "protocol_feature_evm")] evm_chain_id: u64,
-    ) -> Result<Vec<u8>, Box<dyn std::error::Error>>;
+    ) -> Result<Vec<u8>, crate::state_viewer::errors::CallFunctionError>;
 
     fn view_access_key(
         &self,
@@ -49,14 +49,14 @@ pub trait ViewRuntimeAdapter {
         state_root: MerkleHash,
         account_id: &AccountId,
         public_key: &PublicKey,
-    ) -> Result<AccessKey, Box<dyn std::error::Error>>;
+    ) -> Result<AccessKey, crate::state_viewer::errors::ViewAccessKeyError>;
 
     fn view_access_keys(
         &self,
         shard_id: ShardId,
         state_root: MerkleHash,
         account_id: &AccountId,
-    ) -> Result<Vec<(PublicKey, AccessKey)>, Box<dyn std::error::Error>>;
+    ) -> Result<Vec<(PublicKey, AccessKey)>, crate::state_viewer::errors::ViewAccessKeyError>;
 
     fn view_state(
         &self,
@@ -64,5 +64,5 @@ pub trait ViewRuntimeAdapter {
         state_root: MerkleHash,
         account_id: &AccountId,
         prefix: &[u8],
-    ) -> Result<ViewStateResult, Box<dyn std::error::Error>>;
+    ) -> Result<ViewStateResult, crate::state_viewer::errors::ViewStateError>;
 }

--- a/runtime/runtime/src/state_viewer/errors.rs
+++ b/runtime/runtime/src/state_viewer/errors.rs
@@ -1,95 +1,67 @@
 #[derive(thiserror::Error, Debug)]
 pub enum ViewAccountError {
-    #[error("Account ID {0} is invalid")]
-    InvalidAccountId(near_primitives::types::AccountId),
-    #[error("Account ID {0} does not exist")]
-    AccountDoesNotExist(near_primitives::types::AccountId),
+    #[error("Account ID #{requested_account_id} is invalid")]
+    InvalidAccountId { requested_account_id: near_primitives::types::AccountId },
+    #[error("Account ID #{requested_account_id} does not exist")]
+    AccountDoesNotExist { requested_account_id: near_primitives::types::AccountId },
     #[error("Storage error: {0}")]
-    StorageError(near_primitives::errors::StorageError),
+    StorageError(#[from] near_primitives::errors::StorageError),
 }
 
 #[derive(thiserror::Error, Debug)]
 pub enum ViewContractCodeError {
-    #[error("Account ID {0} is invalid")]
-    InvalidAccountId(near_primitives::types::AccountId),
-    #[error("Account ID {0} does not exist")]
-    AccountDoesNotExist(near_primitives::types::AccountId),
+    #[error("Account ID #{requested_account_id} is invalid")]
+    InvalidAccountId { requested_account_id: near_primitives::types::AccountId },
+    #[error("Account ID #{requested_account_id} does not exist")]
+    AccountDoesNotExist { requested_account_id: near_primitives::types::AccountId },
     #[error("Storage error: {0}")]
-    StorageError(near_primitives::errors::StorageError),
-    #[error("Contract code for contract ID {0} does not exist")]
-    ContractCodeDoesNotExist(near_primitives::types::AccountId),
+    StorageError(#[from] near_primitives::errors::StorageError),
+    #[error("Contract code for contract ID #{contract_account_id} does not exist")]
+    NoContractCode { contract_account_id: near_primitives::types::AccountId },
 }
 
 #[derive(thiserror::Error, Debug)]
 pub enum ViewAccessKeyError {
-    #[error("Account ID {0} is invalid")]
-    InvalidAccountId(near_primitives::types::AccountId),
+    #[error("Account ID #{requested_account_id} is invalid")]
+    InvalidAccountId { requested_account_id: near_primitives::types::AccountId },
     #[error("Storage error: {0}")]
-    StorageError(near_primitives::errors::StorageError),
-    #[error("Access key for public key {0} does not exist")]
-    AccessKeyDoesNotExist(near_crypto::PublicKey),
-    #[error("Internal error occurred: {0}")]
-    InternalError(String),
+    StorageError(#[from] near_primitives::errors::StorageError),
+    #[error("Access key for public key #{public_key} does not exist")]
+    AccessKeyDoesNotExist { public_key: near_crypto::PublicKey },
+    #[error("Internal error occurred: #{error_message}")]
+    InternalError { error_message: String },
 }
 
 #[derive(thiserror::Error, Debug)]
 pub enum ViewStateError {
-    #[error("Account ID {0} is invalid")]
-    InvalidAccountId(near_primitives::types::AccountId),
+    #[error("Account ID #{requested_account_id} is invalid")]
+    InvalidAccountId { requested_account_id: near_primitives::types::AccountId },
     #[error("Storage error: {0}")]
-    StorageError(near_primitives::errors::StorageError),
+    StorageError(#[from] near_primitives::errors::StorageError),
 }
 
 #[derive(thiserror::Error, Debug)]
 pub enum CallFunctionError {
-    #[error("Account ID {0} is invalid")]
-    InvalidAccountId(near_primitives::types::AccountId),
-    #[error("Account ID {0} does not exist")]
-    AccountDoesNotExist(near_primitives::types::AccountId),
+    #[error("Account ID #{requested_account_id} is invalid")]
+    InvalidAccountId { requested_account_id: near_primitives::types::AccountId },
+    #[error("Account ID #{requested_account_id} does not exist")]
+    AccountDoesNotExist { requested_account_id: near_primitives::types::AccountId },
     #[error("Storage error: {0}")]
-    StorageError(near_primitives::errors::StorageError),
+    StorageError(#[from] near_primitives::errors::StorageError),
     #[error("VM error occurred: {0}")]
     VMError(String),
-}
-
-impl From<near_primitives::errors::StorageError> for ViewAccountError {
-    fn from(storage_error: near_primitives::errors::StorageError) -> Self {
-        Self::StorageError(storage_error)
-    }
 }
 
 impl From<ViewAccountError> for ViewContractCodeError {
     fn from(view_account_error: ViewAccountError) -> Self {
         match view_account_error {
-            ViewAccountError::InvalidAccountId(account_id) => Self::AccountDoesNotExist(account_id),
-            ViewAccountError::AccountDoesNotExist(account_id) => {
-                Self::AccountDoesNotExist(account_id)
+            ViewAccountError::InvalidAccountId { requested_account_id } => {
+                Self::AccountDoesNotExist { requested_account_id }
+            }
+            ViewAccountError::AccountDoesNotExist { requested_account_id } => {
+                Self::AccountDoesNotExist { requested_account_id }
             }
             ViewAccountError::StorageError(storage_error) => Self::StorageError(storage_error),
         }
-    }
-}
-
-impl From<near_primitives::errors::StorageError> for ViewContractCodeError {
-    fn from(storage_error: near_primitives::errors::StorageError) -> Self {
-        Self::StorageError(storage_error)
-    }
-}
-
-impl From<near_primitives::errors::StorageError> for ViewAccessKeyError {
-    fn from(storage_error: near_primitives::errors::StorageError) -> Self {
-        Self::StorageError(storage_error)
-    }
-}
-
-impl From<near_primitives::errors::StorageError> for ViewStateError {
-    fn from(storage_error: near_primitives::errors::StorageError) -> Self {
-        Self::StorageError(storage_error)
-    }
-}
-
-impl From<near_primitives::errors::StorageError> for CallFunctionError {
-    fn from(storage_error: near_primitives::errors::StorageError) -> Self {
-        Self::StorageError(storage_error)
     }
 }

--- a/runtime/runtime/src/state_viewer/errors.rs
+++ b/runtime/runtime/src/state_viewer/errors.rs
@@ -1,32 +1,54 @@
+#[derive(thiserror::Error, Debug)]
 pub enum ViewAccountError {
+    #[error("Account ID {0} is invalid")]
     InvalidAccountId(near_primitives::types::AccountId),
+    #[error("Account ID {0} does not exist")]
     AccountDoesNotExist(near_primitives::types::AccountId),
+    #[error("Storage error: {0}")]
     StorageError(near_primitives::errors::StorageError),
 }
 
+#[derive(thiserror::Error, Debug)]
 pub enum ViewContractCodeError {
+    #[error("Account ID {0} is invalid")]
     InvalidAccountId(near_primitives::types::AccountId),
+    #[error("Account ID {0} does not exist")]
     AccountDoesNotExist(near_primitives::types::AccountId),
+    #[error("Storage error: {0}")]
     StorageError(near_primitives::errors::StorageError),
+    #[error("Contract code for contract ID {0} does not exist")]
     ContractCodeDoesNotExist(near_primitives::types::AccountId),
 }
 
+#[derive(thiserror::Error, Debug)]
 pub enum ViewAccessKeyError {
+    #[error("Account ID {0} is invalid")]
     InvalidAccountId(near_primitives::types::AccountId),
+    #[error("Storage error: {0}")]
     StorageError(near_primitives::errors::StorageError),
+    #[error("Access key for public key {0} does not exist")]
     AccessKeyDoesNotExist(near_crypto::PublicKey),
+    #[error("Internal error occurred: {0}")]
     InternalError(String),
 }
 
+#[derive(thiserror::Error, Debug)]
 pub enum ViewStateError {
+    #[error("Account ID {0} is invalid")]
     InvalidAccountId(near_primitives::types::AccountId),
+    #[error("Storage error: {0}")]
     StorageError(near_primitives::errors::StorageError),
 }
 
+#[derive(thiserror::Error, Debug)]
 pub enum CallFunctionError {
+    #[error("Account ID {0} is invalid")]
     InvalidAccountId(near_primitives::types::AccountId),
+    #[error("Account ID {0} does not exist")]
     AccountDoesNotExist(near_primitives::types::AccountId),
+    #[error("Storage error: {0}")]
     StorageError(near_primitives::errors::StorageError),
+    #[error("VM error occurred: {0}")]
     VMError(String),
 }
 

--- a/runtime/runtime/src/state_viewer/errors.rs
+++ b/runtime/runtime/src/state_viewer/errors.rs
@@ -1,6 +1,6 @@
 #[derive(thiserror::Error, Debug)]
 pub enum ViewAccountError {
-    #[error("Account ID #{requested_account_id} is invalid")]
+    #[error("Account ID \"{requested_account_id}\" is invalid")]
     InvalidAccountId { requested_account_id: near_primitives::types::AccountId },
     #[error("Account ID #{requested_account_id} does not exist")]
     AccountDoesNotExist { requested_account_id: near_primitives::types::AccountId },
@@ -10,7 +10,7 @@ pub enum ViewAccountError {
 
 #[derive(thiserror::Error, Debug)]
 pub enum ViewContractCodeError {
-    #[error("Account ID #{requested_account_id} is invalid")]
+    #[error("Account ID \"{requested_account_id}\" is invalid")]
     InvalidAccountId { requested_account_id: near_primitives::types::AccountId },
     #[error("Account ID #{requested_account_id} does not exist")]
     AccountDoesNotExist { requested_account_id: near_primitives::types::AccountId },
@@ -22,7 +22,7 @@ pub enum ViewContractCodeError {
 
 #[derive(thiserror::Error, Debug)]
 pub enum ViewAccessKeyError {
-    #[error("Account ID #{requested_account_id} is invalid")]
+    #[error("Account ID \"{requested_account_id}\" is invalid")]
     InvalidAccountId { requested_account_id: near_primitives::types::AccountId },
     #[error("Access key for public key #{public_key} does not exist")]
     AccessKeyDoesNotExist { public_key: near_crypto::PublicKey },
@@ -32,7 +32,7 @@ pub enum ViewAccessKeyError {
 
 #[derive(thiserror::Error, Debug)]
 pub enum ViewStateError {
-    #[error("Account ID #{requested_account_id} is invalid")]
+    #[error("Account ID \"{requested_account_id}\" is invalid")]
     InvalidAccountId { requested_account_id: near_primitives::types::AccountId },
     #[error("Internal error: #{error_message}")]
     InternalError { error_message: String },
@@ -40,7 +40,7 @@ pub enum ViewStateError {
 
 #[derive(thiserror::Error, Debug)]
 pub enum CallFunctionError {
-    #[error("Account ID #{requested_account_id} is invalid")]
+    #[error("Account ID \"{requested_account_id}\" is invalid")]
     InvalidAccountId { requested_account_id: near_primitives::types::AccountId },
     #[error("Account ID #{requested_account_id} does not exist")]
     AccountDoesNotExist { requested_account_id: near_primitives::types::AccountId },

--- a/runtime/runtime/src/state_viewer/errors.rs
+++ b/runtime/runtime/src/state_viewer/errors.rs
@@ -4,11 +4,8 @@ pub enum ViewAccountError {
     InvalidAccountId { requested_account_id: near_primitives::types::AccountId },
     #[error("Account ID #{requested_account_id} does not exist")]
     AccountDoesNotExist { requested_account_id: near_primitives::types::AccountId },
-    #[error("Storage error: #{storage_error}")]
-    StorageError {
-        #[from]
-        storage_error: near_primitives::errors::StorageError,
-    },
+    #[error("Internal error: #{error_message}")]
+    InternalError { error_message: String },
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -17,27 +14,19 @@ pub enum ViewContractCodeError {
     InvalidAccountId { requested_account_id: near_primitives::types::AccountId },
     #[error("Account ID #{requested_account_id} does not exist")]
     AccountDoesNotExist { requested_account_id: near_primitives::types::AccountId },
-    #[error("Storage error: #{storage_error}")]
-    StorageError {
-        #[from]
-        storage_error: near_primitives::errors::StorageError,
-    },
     #[error("Contract code for contract ID #{contract_account_id} does not exist")]
     NoContractCode { contract_account_id: near_primitives::types::AccountId },
+    #[error("Internal error: #{error_message}")]
+    InternalError { error_message: String },
 }
 
 #[derive(thiserror::Error, Debug)]
 pub enum ViewAccessKeyError {
     #[error("Account ID #{requested_account_id} is invalid")]
     InvalidAccountId { requested_account_id: near_primitives::types::AccountId },
-    #[error("Storage error: #{storage_error:?}")]
-    StorageError {
-        #[from]
-        storage_error: near_primitives::errors::StorageError,
-    },
     #[error("Access key for public key #{public_key} does not exist")]
     AccessKeyDoesNotExist { public_key: near_crypto::PublicKey },
-    #[error("Internal error occurred: #{error_message}")]
+    #[error("Internal error: #{error_message}")]
     InternalError { error_message: String },
 }
 
@@ -45,11 +34,8 @@ pub enum ViewAccessKeyError {
 pub enum ViewStateError {
     #[error("Account ID #{requested_account_id} is invalid")]
     InvalidAccountId { requested_account_id: near_primitives::types::AccountId },
-    #[error("Storage error: #{storage_error}")]
-    StorageError {
-        #[from]
-        storage_error: near_primitives::errors::StorageError,
-    },
+    #[error("Internal error: #{error_message}")]
+    InternalError { error_message: String },
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -58,8 +44,8 @@ pub enum CallFunctionError {
     InvalidAccountId { requested_account_id: near_primitives::types::AccountId },
     #[error("Account ID #{requested_account_id} does not exist")]
     AccountDoesNotExist { requested_account_id: near_primitives::types::AccountId },
-    #[error("Storage error: {0}")]
-    StorageError(#[from] near_primitives::errors::StorageError),
+    #[error("Internal error: #{error_message}")]
+    InternalError { error_message: String },
     #[error("VM error occurred: #{error_message}")]
     VMError { error_message: String },
 }
@@ -73,9 +59,39 @@ impl From<ViewAccountError> for ViewContractCodeError {
             ViewAccountError::AccountDoesNotExist { requested_account_id } => {
                 Self::AccountDoesNotExist { requested_account_id }
             }
-            ViewAccountError::StorageError { storage_error } => {
-                Self::StorageError { storage_error }
+            ViewAccountError::InternalError { error_message } => {
+                Self::InternalError { error_message }
             }
         }
+    }
+}
+
+impl From<near_primitives::errors::StorageError> for ViewAccountError {
+    fn from(storage_error: near_primitives::errors::StorageError) -> Self {
+        Self::InternalError { error_message: storage_error.to_string() }
+    }
+}
+
+impl From<near_primitives::errors::StorageError> for ViewContractCodeError {
+    fn from(storage_error: near_primitives::errors::StorageError) -> Self {
+        Self::InternalError { error_message: storage_error.to_string() }
+    }
+}
+
+impl From<near_primitives::errors::StorageError> for ViewAccessKeyError {
+    fn from(storage_error: near_primitives::errors::StorageError) -> Self {
+        Self::InternalError { error_message: storage_error.to_string() }
+    }
+}
+
+impl From<near_primitives::errors::StorageError> for ViewStateError {
+    fn from(storage_error: near_primitives::errors::StorageError) -> Self {
+        Self::InternalError { error_message: storage_error.to_string() }
+    }
+}
+
+impl From<near_primitives::errors::StorageError> for CallFunctionError {
+    fn from(storage_error: near_primitives::errors::StorageError) -> Self {
+        Self::InternalError { error_message: storage_error.to_string() }
     }
 }

--- a/runtime/runtime/src/state_viewer/errors.rs
+++ b/runtime/runtime/src/state_viewer/errors.rs
@@ -4,8 +4,11 @@ pub enum ViewAccountError {
     InvalidAccountId { requested_account_id: near_primitives::types::AccountId },
     #[error("Account ID #{requested_account_id} does not exist")]
     AccountDoesNotExist { requested_account_id: near_primitives::types::AccountId },
-    #[error("Storage error: {0}")]
-    StorageError(#[from] near_primitives::errors::StorageError),
+    #[error("Storage error: #{storage_error}")]
+    StorageError {
+        #[from]
+        storage_error: near_primitives::errors::StorageError,
+    },
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -14,8 +17,11 @@ pub enum ViewContractCodeError {
     InvalidAccountId { requested_account_id: near_primitives::types::AccountId },
     #[error("Account ID #{requested_account_id} does not exist")]
     AccountDoesNotExist { requested_account_id: near_primitives::types::AccountId },
-    #[error("Storage error: {0}")]
-    StorageError(#[from] near_primitives::errors::StorageError),
+    #[error("Storage error: #{storage_error}")]
+    StorageError {
+        #[from]
+        storage_error: near_primitives::errors::StorageError,
+    },
     #[error("Contract code for contract ID #{contract_account_id} does not exist")]
     NoContractCode { contract_account_id: near_primitives::types::AccountId },
 }
@@ -24,8 +30,11 @@ pub enum ViewContractCodeError {
 pub enum ViewAccessKeyError {
     #[error("Account ID #{requested_account_id} is invalid")]
     InvalidAccountId { requested_account_id: near_primitives::types::AccountId },
-    #[error("Storage error: {0}")]
-    StorageError(#[from] near_primitives::errors::StorageError),
+    #[error("Storage error: #{storage_error:?}")]
+    StorageError {
+        #[from]
+        storage_error: near_primitives::errors::StorageError,
+    },
     #[error("Access key for public key #{public_key} does not exist")]
     AccessKeyDoesNotExist { public_key: near_crypto::PublicKey },
     #[error("Internal error occurred: #{error_message}")]
@@ -36,8 +45,11 @@ pub enum ViewAccessKeyError {
 pub enum ViewStateError {
     #[error("Account ID #{requested_account_id} is invalid")]
     InvalidAccountId { requested_account_id: near_primitives::types::AccountId },
-    #[error("Storage error: {0}")]
-    StorageError(#[from] near_primitives::errors::StorageError),
+    #[error("Storage error: #{storage_error}")]
+    StorageError {
+        #[from]
+        storage_error: near_primitives::errors::StorageError,
+    },
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -48,8 +60,8 @@ pub enum CallFunctionError {
     AccountDoesNotExist { requested_account_id: near_primitives::types::AccountId },
     #[error("Storage error: {0}")]
     StorageError(#[from] near_primitives::errors::StorageError),
-    #[error("VM error occurred: {0}")]
-    VMError(String),
+    #[error("VM error occurred: #{error_message}")]
+    VMError { error_message: String },
 }
 
 impl From<ViewAccountError> for ViewContractCodeError {
@@ -61,7 +73,9 @@ impl From<ViewAccountError> for ViewContractCodeError {
             ViewAccountError::AccountDoesNotExist { requested_account_id } => {
                 Self::AccountDoesNotExist { requested_account_id }
             }
-            ViewAccountError::StorageError(storage_error) => Self::StorageError(storage_error),
+            ViewAccountError::StorageError { storage_error } => {
+                Self::StorageError { storage_error }
+            }
         }
     }
 }

--- a/runtime/runtime/src/state_viewer/errors.rs
+++ b/runtime/runtime/src/state_viewer/errors.rs
@@ -1,0 +1,73 @@
+pub enum ViewAccountError {
+    InvalidAccountId(near_primitives::types::AccountId),
+    AccountDoesNotExist(near_primitives::types::AccountId),
+    StorageError(near_primitives::errors::StorageError),
+}
+
+pub enum ViewContractCodeError {
+    InvalidAccountId(near_primitives::types::AccountId),
+    AccountDoesNotExist(near_primitives::types::AccountId),
+    StorageError(near_primitives::errors::StorageError),
+    ContractCodeDoesNotExist(near_primitives::types::AccountId),
+}
+
+pub enum ViewAccessKeyError {
+    InvalidAccountId(near_primitives::types::AccountId),
+    StorageError(near_primitives::errors::StorageError),
+    AccessKeyDoesNotExist(near_crypto::PublicKey),
+    InternalError(String),
+}
+
+pub enum ViewStateError {
+    InvalidAccountId(near_primitives::types::AccountId),
+    StorageError(near_primitives::errors::StorageError),
+}
+
+pub enum CallFunctionError {
+    InvalidAccountId(near_primitives::types::AccountId),
+    AccountDoesNotExist(near_primitives::types::AccountId),
+    StorageError(near_primitives::errors::StorageError),
+    VMError(String),
+}
+
+impl From<near_primitives::errors::StorageError> for ViewAccountError {
+    fn from(storage_error: near_primitives::errors::StorageError) -> Self {
+        Self::StorageError(storage_error)
+    }
+}
+
+impl From<ViewAccountError> for ViewContractCodeError {
+    fn from(view_account_error: ViewAccountError) -> Self {
+        match view_account_error {
+            ViewAccountError::InvalidAccountId(account_id) => Self::AccountDoesNotExist(account_id),
+            ViewAccountError::AccountDoesNotExist(account_id) => {
+                Self::AccountDoesNotExist(account_id)
+            }
+            ViewAccountError::StorageError(storage_error) => Self::StorageError(storage_error),
+        }
+    }
+}
+
+impl From<near_primitives::errors::StorageError> for ViewContractCodeError {
+    fn from(storage_error: near_primitives::errors::StorageError) -> Self {
+        Self::StorageError(storage_error)
+    }
+}
+
+impl From<near_primitives::errors::StorageError> for ViewAccessKeyError {
+    fn from(storage_error: near_primitives::errors::StorageError) -> Self {
+        Self::StorageError(storage_error)
+    }
+}
+
+impl From<near_primitives::errors::StorageError> for ViewStateError {
+    fn from(storage_error: near_primitives::errors::StorageError) -> Self {
+        Self::StorageError(storage_error)
+    }
+}
+
+impl From<near_primitives::errors::StorageError> for CallFunctionError {
+    fn from(storage_error: near_primitives::errors::StorageError) -> Self {
+        Self::StorageError(storage_error)
+    }
+}

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -329,7 +329,7 @@ mod tests {
 
         let err = result.unwrap_err();
         assert!(
-            err.to_string().contains(r#"Contract ID "bad!contract" is not valid"#),
+            err.to_string().contains(r#"Account ID "bad!contract" is invalid"#),
             format!("Got different error that doesn't match: {}", err)
         );
     }

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -240,7 +240,7 @@ impl TrieViewer {
             }
             let message = format!("wasm execution failed with error: {:?}", err);
             debug!(target: "runtime", "(exec time {}) {}", time_str, message);
-            Err(errors::CallFunctionError::VMError(message))
+            Err(errors::CallFunctionError::VMError { error_message: message })
         } else {
             let outcome = outcome.unwrap();
             debug!(target: "runtime", "(exec time {}) result of execution: {:#?}", time_str, outcome);

--- a/test-utils/testlib/Cargo.toml
+++ b/test-utils/testlib/Cargo.toml
@@ -40,6 +40,7 @@ near-vm-errors = { path = "../../runtime/near-vm-errors" }
 near-chain = { path = "../../chain/chain" }
 near-client = { path = "../../chain/client" }
 near-jsonrpc = { path = "../../chain/jsonrpc" }
+near-jsonrpc-primitives = { path = "../../chain/jsonrpc-primitives" }
 near-network = { path = "../../chain/network" }
 near-jsonrpc-client = { path = "../../chain/jsonrpc/client" }
 neard = { path = "../../neard" }


### PR DESCRIPTION
* add some errors to `runtime/runtime/state_viewer`
* introduce `QueryError` into chain primitives
* refactor runtime `query` method implementation in `neard`
* refactor `view_client` `handle_query` method
* remove routing for `query` method (resolves #3848)

Still need to implement errors on the RPC and Rosetta side. Work in progress. 

I'm creating this draft PR to ask for a review of error structs and error messages.