### PR TITLE
fix(trie): fix iterator seek

### DIFF
--- a/core/store/src/trie/iterator.rs
+++ b/core/store/src/trie/iterator.rs
@@ -116,7 +116,15 @@ impl<'a> TrieIterator<'a> {
                         hash = child;
                         key = key.mid(existing_key.len());
                     } else {
-                        self.descend_into_node(&copy_node);
+                        self.trail.push(Crumb {
+                            status: if existing_key >= key {
+                                CrumbStatus::Entering
+                            } else {
+                                CrumbStatus::Exiting
+                            },
+                            node: copy_node,
+                        });
+                        self.key_nibbles.extend(existing_key.iter());
                         return Ok(());
                     }
                 }

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -954,6 +954,27 @@ mod tests {
     }
 
     #[test]
+    fn test_iterator_seek() {
+        let mut rng = rand::thread_rng();
+        for _test_run in 0..10 {
+            let tries = create_tries();
+            let trie = tries.get_trie_for_shard(0);
+            let trie_changes = gen_changes(&mut rng, 500);
+
+            let state_root =
+                test_populate_trie(&tries, &Trie::empty_root(), 0, trie_changes.clone());
+            let queries = gen_changes(&mut rng, 500).into_iter().map(|(key, _)| key);
+            for query in queries {
+                let mut iterator = trie.iter(&state_root).unwrap();
+                iterator.seek(&query).unwrap();
+                if let Some(Ok((key, _))) = iterator.next() {
+                    assert!(key >= query);
+                }
+            }
+        }
+    }
+
+    #[test]
     fn test_refcounts() {
         let mut rng = rand::thread_rng();
         for _test_run in 0..10 {


### PR DESCRIPTION
TrieIterator::seek comment:
/// Position the iterator on the first element with key => `key`.

Fix a bug where it could incorrectly position the iterator at a
a subtree of keys with a prefix < `key`.

The bug never triggers: `seek` is currently used in the following places
1. TrieUpdateIterator with key prefix. It works correctly, because if
   the trie has keys with the prefix, the bug does not trigger, and if
   it doesn't, TrieUpdateIterator's internal logic will stop it.
2. TrieUpdateIterator with prefix and range. Used only in tests.
3. TrieViewer view_state. Works correctly because of similar logic to
   TrieUpdateIterator.
4. get_trie_nodes_for_part. Works because key for `seek` always ends in
   a trie node.

Test plan
---------
new test
manually check all calls to `seek` to make sure this doesn't actually
change the protocol.