### PR TITLE
refactor: simplify access to COSTS_CONTER thread local

### DIFF
--- a/runtime/near-vm-logic/src/lib.rs
+++ b/runtime/near-vm-logic/src/lib.rs
@@ -18,5 +18,4 @@ pub use near_primitives_core::types::ProtocolVersion;
 pub use near_vm_errors::{HostError, VMLogicError};
 pub use types::ReturnData;
 
-#[cfg(feature = "costs_counting")]
-pub use gas_counter::EXT_COSTS_COUNTER;
+pub use gas_counter::with_ext_cost_counter;

--- a/runtime/near-vm-logic/tests/helpers.rs
+++ b/runtime/near-vm-logic/tests/helpers.rs
@@ -1,6 +1,6 @@
 use near_primitives_core::{config::ExtCosts, types::Gas};
 use near_vm_errors::VMLogicError;
-use near_vm_logic::{VMLogic, EXT_COSTS_COUNTER};
+use near_vm_logic::{gas_counter::with_ext_cost_counter, VMLogic};
 use std::collections::HashMap;
 
 #[allow(dead_code)]
@@ -86,20 +86,18 @@ macro_rules! map(
 
 #[allow(dead_code)]
 pub fn print_costs() {
-    EXT_COSTS_COUNTER.with(|f| {
-        println!("{:#?}", f.borrow().iter().collect::<std::collections::BTreeMap<_, _>>())
+    with_ext_cost_counter(|cc| {
+        println!("{:#?}", cc.iter().collect::<std::collections::BTreeMap<_, _>>())
     });
     reset_costs_counter();
 }
 
 pub fn reset_costs_counter() {
-    EXT_COSTS_COUNTER.with(|f| f.borrow_mut().clear());
+    with_ext_cost_counter(|cc| cc.clear())
 }
 
 #[allow(dead_code)]
 pub fn assert_costs(expected: HashMap<ExtCosts, u64>) {
-    EXT_COSTS_COUNTER.with(|f| {
-        assert_eq!(f.borrow().clone(), expected);
-    });
+    with_ext_cost_counter(|cc| assert_eq!(*cc, expected));
     reset_costs_counter();
 }

--- a/runtime/near-vm-runner/src/lib.rs
+++ b/runtime/near-vm-runner/src/lib.rs
@@ -14,5 +14,4 @@ pub use runner::run_vm;
 pub use runner::run_vm_profiled;
 pub use runner::with_vm_variants;
 
-#[cfg(feature = "costs_counting")]
-pub use near_vm_logic::EXT_COSTS_COUNTER;
+pub use near_vm_logic::with_ext_cost_counter;

--- a/runtime/runtime-params-estimator/src/stats.rs
+++ b/runtime/runtime-params-estimator/src/stats.rs
@@ -26,11 +26,8 @@ impl Measurements {
         block_size: usize,
         block_cost: ExecutionCost,
     ) {
-        #[cfg(feature = "costs_counting")]
-        let ext_costs = node_runtime::EXT_COSTS_COUNTER
-            .with(|f| f.borrow_mut().drain().collect::<HashMap<_, _>>());
-        #[cfg(not(feature = "costs_counting"))]
-        let ext_costs = HashMap::new();
+        let mut ext_costs = HashMap::new();
+        node_runtime::with_ext_cost_counter(|cc| ext_costs.extend(cc.drain()));
         self.data.entry(metric).or_insert_with(Vec::new).push((block_size, block_cost, ext_costs));
     }
 

--- a/runtime/runtime-params-estimator/src/testbed_runners.rs
+++ b/runtime/runtime-params-estimator/src/testbed_runners.rs
@@ -226,10 +226,7 @@ where
     bar.set_style(ProgressStyle::default_bar().template(
         "[elapsed {elapsed_precise} remaining {eta_precise}] Measuring {bar} {pos:>7}/{len:7} {msg}",
     ));
-    #[cfg(feature = "costs_counting")]
-    node_runtime::EXT_COSTS_COUNTER.with(|f| {
-        f.borrow_mut().clear();
-    });
+    node_runtime::with_ext_cost_counter(|cc| cc.clear());
     for _ in 0..config.iter_per_block {
         for block_size in config.block_sizes.clone() {
             let block: Vec<_> = (0..block_size).map(|_| (*f)()).collect();

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -39,8 +39,7 @@ use near_store::{
 };
 use near_vm_logic::types::PromiseResult;
 use near_vm_logic::ReturnData;
-#[cfg(feature = "costs_counting")]
-pub use near_vm_runner::EXT_COSTS_COUNTER;
+pub use near_vm_runner::with_ext_cost_counter;
 
 use crate::actions::*;
 use crate::balance_checker::check_balance;


### PR DESCRIPTION
Practically, this gets rid of `#[cfg]` here and there.

In general, it's a good rule of thumb to protect access to global and
thread local data with accessor functions. That way, the clients don't
need to deal with RefCells and Mutexes themselves.