### PR TITLE
refactor: remove roundabout way to connect to socket

### DIFF
--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 use actix::io::FramedWrite;
 use actix::{
     Actor, ActorFuture, Addr, Arbiter, AsyncContext, Context, ContextFutureSpawner, Handler,
-    Recipient, Running, StreamHandler, SyncArbiter, SyncContext, SystemService, WrapFuture,
+    Recipient, Running, StreamHandler, SyncArbiter, SyncContext, WrapFuture,
 };
 use chrono::Utc;
 use futures::task::Poll;
@@ -1647,10 +1647,15 @@ impl Handler<OutboundTcpConnect> for PeerManagerActor {
         let _d = DelayDetector::new("outbound tcp connect".into());
         debug!(target: "network", "Trying to connect to {}", msg.peer_info);
         if let Some(addr) = msg.peer_info.addr {
-            #[allow(deprecated)]
-            // There is not clear migration path at the moment: https://github.com/actix/actix/issues/451
-            actix::actors::resolver::Resolver::from_registry()
-                .send(actix::actors::resolver::ConnectAddr(addr))
+            // The `connect` may take several minutes. This happens when the
+            // `SYN` packet for establishing a TCP connection gets silently
+            // dropped, in which case the default TCP timeout is applied. That's
+            // too long for us, so we shorten it to one second.
+            //
+            // Why exactly a second? It was hard-coded in a library we used
+            // before, so we keep it to preserve behavior. Removing the timeout
+            // completely was observed to break stuff for real on the testnet.
+            tokio::time::timeout(Duration::from_secs(1), TcpStream::connect(addr))
                 .into_actor(self)
                 .then(move |res, act, ctx| match res {
                     Ok(res) => match res {


### PR DESCRIPTION
Seems like this Resolver stuff is just ... unnecessary? It sounds like
it does DNS resolution (with its notoriously sync-only APO), but this
isn't needed in this case. addr is a `SocketAddr`, ie, a resolved IP.

Note the 1 second timeout: it's the same value that was used by actix:
https://github.com/actix/actix/blob/v0.11.0-beta.1/src/actors/resolver.rs#L382

This is a second attempt at https://github.com/near/nearcore/pull/3961, which was reverted in https://github.com/near/nearcore/pull/3964. I've looked at the code more closely, and noticed that atix hard-codded a one-second timeout here.

This is def a problem in theory -- if the peer just drops packets (instead of actively refusing the connection), the whole peer manager get's stuck in the `.wait(ctx);` call for several minutes. Not sure if this is exactly a problem we've observed thoug!

Note that, even with a timeout, it feels like this code is vulnerable to DOS, as it's pretty easy to freeze the peer manager for one second this way. 

