### PR TITLE
feat(jsonrpc): Add warn log to jsronrpc methods where time out can happen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3188,6 +3188,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
  "validator",
 ]
 

--- a/chain/jsonrpc/Cargo.toml
+++ b/chain/jsonrpc/Cargo.toml
@@ -15,6 +15,7 @@ prometheus = "0.11"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 validator = "0.12"
+tracing = "0.1.13"
 borsh = "0.8.1"
 
 near-chain-configs = { path = "../../core/chain-configs" }

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -337,6 +337,7 @@ impl JsonRpcHandler {
         .await
         .map_err(|_| {
             near_metrics::inc_counter(&metrics::RPC_TIMEOUT_TOTAL);
+            tracing::warn!(target: "jsonrpc", "Timeout: tx_exists method");
             ServerError::Timeout
         })?
     }
@@ -382,6 +383,7 @@ impl JsonRpcHandler {
         .await
         .map_err(|_| {
             near_metrics::inc_counter(&metrics::RPC_TIMEOUT_TOTAL);
+            tracing::warn!(target: "jsonrpc", "Timeout: tx_status_fetch method");
             TxStatusError::TimeoutError
         })?
     }
@@ -404,6 +406,7 @@ impl JsonRpcHandler {
         .await
         .map_err(|_| {
             near_metrics::inc_counter(&metrics::RPC_TIMEOUT_TOTAL);
+            tracing::warn!(target: "jsonrpc", "Timeout: tx_polling method");
             timeout_err()
         })?
     }

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -337,7 +337,11 @@ impl JsonRpcHandler {
         .await
         .map_err(|_| {
             near_metrics::inc_counter(&metrics::RPC_TIMEOUT_TOTAL);
-            tracing::warn!(target: "jsonrpc", "Timeout: tx_exists method");
+            tracing::warn!(
+                target: "jsonrpc", "Timeout: tx_exists method. tx_hash {:?} signer_account_id {:?}",
+                tx_hash,
+                signer_account_id
+            );
             ServerError::Timeout
         })?
     }
@@ -383,7 +387,11 @@ impl JsonRpcHandler {
         .await
         .map_err(|_| {
             near_metrics::inc_counter(&metrics::RPC_TIMEOUT_TOTAL);
-            tracing::warn!(target: "jsonrpc", "Timeout: tx_status_fetch method");
+            tracing::warn!(
+                target: "jsonrpc", "Timeout: tx_status_fetch method. tx_info {:?} fetch_receipt {:?}",
+                tx_info,
+                fetch_receipt,
+            );
             TxStatusError::TimeoutError
         })?
     }
@@ -406,7 +414,10 @@ impl JsonRpcHandler {
         .await
         .map_err(|_| {
             near_metrics::inc_counter(&metrics::RPC_TIMEOUT_TOTAL);
-            tracing::warn!(target: "jsonrpc", "Timeout: tx_polling method");
+            tracing::warn!(
+                target: "jsonrpc", "Timeout: tx_polling method. tx_info {:?}",
+                tx_info,
+            );
             timeout_err()
         })?
     }


### PR DESCRIPTION
Closes #3951 

Doesn't affect #3938 because that particular method (`query`) is being refactored right now in #3944 

As for the `query` timeout can appear there because of network routing but in my PR which refactors `query` method we totally removed routing (decision made by @bowenwang1996 and @frol) so it seems like timeout from jsonrpc side wouldn't be possible.