### PR TITLE
refactor: reduce duplication in the vm running code

### DIFF
--- a/runtime/near-vm-runner/src/runner.rs
+++ b/runtime/near-vm-runner/src/runner.rs
@@ -134,7 +134,7 @@ fn run_vm_impl(
     let (outcome, error) = match vm_kind {
         #[cfg(feature = "wasmer0_vm")]
         VMKind::Wasmer0 => run_wasmer(
-            code_hash,
+            &code_hash,
             code,
             method_name,
             ext,
@@ -150,7 +150,7 @@ fn run_vm_impl(
         VMKind::Wasmer0 => panic!("Wasmer0 is not supported, compile with '--features wasmer0_vm'"),
         #[cfg(feature = "wasmtime_vm")]
         VMKind::Wasmtime => run_wasmtime(
-            code_hash,
+            &code_hash,
             code,
             method_name,
             ext,
@@ -168,7 +168,7 @@ fn run_vm_impl(
         }
         #[cfg(feature = "wasmer1_vm")]
         VMKind::Wasmer1 => run_wasmer1(
-            code_hash,
+            &code_hash,
             code,
             method_name,
             ext,

--- a/runtime/near-vm-runner/src/runner.rs
+++ b/runtime/near-vm-runner/src/runner.rs
@@ -32,24 +32,9 @@ pub fn run<'a>(
     cache: Option<&'a dyn CompiledContractCache>,
     #[cfg(feature = "costs_counting")] profile: Option<&ProfileData>,
 ) -> (Option<VMOutcome>, Option<VMError>) {
-    #[cfg(feature = "costs_counting")]
-    if let Some(profile) = profile {
-        return run_vm_profiled(
-            code_hash,
-            code,
-            method_name,
-            ext,
-            context,
-            wasm_config,
-            fees_config,
-            promise_results,
-            VMKind::default(),
-            profile.clone(),
-            current_protocol_version,
-            cache,
-        );
-    }
-    run_vm(
+    #[cfg(not(feature = "costs_counting"))]
+    let profile = None;
+    run_vm_impl(
         code_hash,
         code,
         method_name,
@@ -59,6 +44,7 @@ pub fn run<'a>(
         fees_config,
         promise_results,
         VMKind::default(),
+        profile,
         current_protocol_version,
         cache,
     )
@@ -76,67 +62,20 @@ pub fn run_vm<'a>(
     current_protocol_version: ProtocolVersion,
     cache: Option<&'a dyn CompiledContractCache>,
 ) -> (Option<VMOutcome>, Option<VMError>) {
-    #[cfg(feature = "wasmer0_vm")]
-    use crate::wasmer_runner::run_wasmer;
-
-    #[cfg(feature = "wasmtime_vm")]
-    use crate::wasmtime_runner::wasmtime_runner::run_wasmtime;
-
-    #[cfg(feature = "wasmer1_vm")]
-    use crate::wasmer1_runner::run_wasmer1;
-
-    match vm_kind {
-        #[cfg(feature = "wasmer0_vm")]
-        VMKind::Wasmer0 => run_wasmer(
-            code_hash,
-            code,
-            method_name,
-            ext,
-            context,
-            wasm_config,
-            fees_config,
-            promise_results,
-            None,
-            current_protocol_version,
-            cache,
-        ),
-        #[cfg(not(feature = "wasmer0_vm"))]
-        VMKind::Wasmer0 => panic!("Wasmer0 is not supported, compile with '--features wasmer0_vm'"),
-        #[cfg(feature = "wasmtime_vm")]
-        VMKind::Wasmtime => run_wasmtime(
-            code_hash,
-            code,
-            method_name,
-            ext,
-            context,
-            wasm_config,
-            fees_config,
-            promise_results,
-            None,
-            current_protocol_version,
-            cache,
-        ),
-        #[cfg(not(feature = "wasmtime_vm"))]
-        VMKind::Wasmtime => {
-            panic!("Wasmtime is not supported, compile with '--features wasmtime_vm'")
-        }
-        #[cfg(feature = "wasmer1_vm")]
-        VMKind::Wasmer1 => run_wasmer1(
-            code_hash,
-            code,
-            method_name,
-            ext,
-            context,
-            wasm_config,
-            fees_config,
-            promise_results,
-            None,
-            current_protocol_version,
-            cache,
-        ),
-        #[cfg(not(feature = "wasmer1_vm"))]
-        VMKind::Wasmer1 => panic!("Wasmer1 is not supported, compile with '--features wasmer1_vm'"),
-    }
+    run_vm_impl(
+        code_hash,
+        code,
+        method_name,
+        ext,
+        context,
+        wasm_config,
+        fees_config,
+        promise_results,
+        vm_kind,
+        None,
+        current_protocol_version,
+        cache,
+    )
 }
 
 pub fn run_vm_profiled<'a>(
@@ -153,6 +92,36 @@ pub fn run_vm_profiled<'a>(
     current_protocol_version: ProtocolVersion,
     cache: Option<&'a dyn CompiledContractCache>,
 ) -> (Option<VMOutcome>, Option<VMError>) {
+    run_vm_impl(
+        code_hash,
+        code,
+        method_name,
+        ext,
+        context,
+        wasm_config,
+        fees_config,
+        promise_results,
+        vm_kind,
+        Some(&profile),
+        current_protocol_version,
+        cache,
+    )
+}
+
+fn run_vm_impl(
+    code_hash: Vec<u8>,
+    code: &[u8],
+    method_name: &[u8],
+    ext: &mut dyn External,
+    context: VMContext,
+    wasm_config: &VMConfig,
+    fees_config: &RuntimeFeesConfig,
+    promise_results: &[PromiseResult],
+    vm_kind: VMKind,
+    profile: Option<&ProfileData>,
+    current_protocol_version: ProtocolVersion,
+    cache: Option<&dyn CompiledContractCache>,
+) -> (Option<VMOutcome>, Option<VMError>) {
     #[cfg(feature = "wasmer0_vm")]
     use crate::wasmer_runner::run_wasmer;
 
@@ -161,6 +130,7 @@ pub fn run_vm_profiled<'a>(
 
     #[cfg(feature = "wasmer1_vm")]
     use crate::wasmer1_runner::run_wasmer1;
+
     let (outcome, error) = match vm_kind {
         #[cfg(feature = "wasmer0_vm")]
         VMKind::Wasmer0 => run_wasmer(
@@ -172,7 +142,7 @@ pub fn run_vm_profiled<'a>(
             wasm_config,
             fees_config,
             promise_results,
-            Some(profile.clone()),
+            profile.cloned(),
             current_protocol_version,
             cache,
         ),
@@ -188,7 +158,7 @@ pub fn run_vm_profiled<'a>(
             wasm_config,
             fees_config,
             promise_results,
-            Some(profile.clone()),
+            profile.cloned(),
             current_protocol_version,
             cache,
         ),
@@ -206,17 +176,18 @@ pub fn run_vm_profiled<'a>(
             wasm_config,
             fees_config,
             promise_results,
-            Some(profile.clone()),
+            profile.cloned(),
             current_protocol_version,
             cache,
         ),
         #[cfg(not(feature = "wasmer1_vm"))]
         VMKind::Wasmer1 => panic!("Wasmer1 is not supported, compile with '--features wasmer1_vm'"),
     };
-    match &outcome {
-        Some(VMOutcome { burnt_gas, .. }) => profile.set_burnt_gas(*burnt_gas),
-        _ => (),
-    };
+    if let Some(profile) = profile {
+        if let Some(VMOutcome { burnt_gas, .. }) = &outcome {
+            profile.set_burnt_gas(*burnt_gas)
+        }
+    }
     (outcome, error)
 }
 /// `precompile` compiles WASM contract to a VM specific format and stores result into the `cache`.

--- a/runtime/near-vm-runner/src/wasmer1_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer1_runner.rs
@@ -141,7 +141,7 @@ fn check_method(module: &Module, method_name: &str) -> Result<(), VMError> {
 }
 
 pub fn run_wasmer1<'a>(
-    code_hash: Vec<u8>,
+    code_hash: &[u8],
     code: &[u8],
     method_name: &[u8],
     ext: &mut dyn External,
@@ -175,7 +175,7 @@ pub fn run_wasmer1<'a>(
     let engine = JIT::new(Singlepass::default()).engine();
     let store = Store::new(&engine);
     let module = match cache::wasmer1_cache::compile_module_cached_wasmer1(
-        &code_hash,
+        code_hash,
         &code,
         wasm_config,
         cache,

--- a/runtime/near-vm-runner/src/wasmer_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer_runner.rs
@@ -169,7 +169,7 @@ impl IntoVMError for wasmer_runtime::error::RuntimeError {
 }
 
 pub fn run_wasmer<'a>(
-    code_hash: Vec<u8>,
+    code_hash: &[u8],
     code: &[u8],
     method_name: &[u8],
     ext: &mut dyn External,

--- a/runtime/near-vm-runner/src/wasmtime_runner.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner.rs
@@ -112,7 +112,7 @@ pub mod wasmtime_runner {
     }
 
     pub fn run_wasmtime<'a>(
-        _code_hash: Vec<u8>,
+        _code_hash: &[u8],
         code: &[u8],
         method_name: &[u8],
         ext: &mut dyn External,


### PR DESCRIPTION
I've brietly tried to add a command object here, so that the API looks like this:

```rust
VmRunConfig::new(code, hash, context, ...)
  .vm(VmKind::Wasmtime)
  .profile(profile_data)
  .run()
```

but it wasn't a clear cut improvement. 