### PR TITLE
feat: add `tracing` infrastructure to contract runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3633,6 +3633,7 @@ dependencies = [
  "near-vm-logic",
  "parity-wasm",
  "pwasm-utils",
+ "tracing",
  "wabt",
  "wasmer",
  "wasmer-compiler-singlepass",
@@ -3655,6 +3656,8 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -5840,9 +5843,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.22"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
+checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite",
@@ -5852,9 +5855,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.11"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
+checksum = "a8a9bd1db7706f2373a190b0d067146caa39350c486f3d455b0e33b431f94c07"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.8",

--- a/runtime/near-vm-runner-standalone/Cargo.toml
+++ b/runtime/near-vm-runner-standalone/Cargo.toml
@@ -24,6 +24,8 @@ clap = "2.33.0"
 base64 = "0.13"
 strum = "0.20"
 num-rational = { version = "0.3" }
+tracing = { version = "0.1"}
+tracing-subscriber = "0.2"
 
 near-vm-logic = { path = "../near-vm-logic", version = "3.0.0", features = ["costs_counting"]}
 near-vm-runner = { path = "../near-vm-runner", version = "3.0.0", features = ["wasmtime_vm", "wasmer1_vm"] }

--- a/runtime/near-vm-runner-standalone/src/main.rs
+++ b/runtime/near-vm-runner-standalone/src/main.rs
@@ -6,6 +6,8 @@
 //! ```
 //! Optional `--context-file=/tmp/context.json --config-file=/tmp/config.json` could be added
 //! to provide custom context and VM config.
+mod tracing_timings;
+
 use clap::{App, Arg};
 use near_primitives_core::runtime::fees::RuntimeFeesConfig;
 use near_vm_logic::mocks::mock_external::{MockedExternal, Receipt};
@@ -175,12 +177,21 @@ fn main() {
                 .help("Profiles gas consumption.")
         )
         .arg(
+            Arg::with_name("timings")
+                .long("timings")
+                .help("Prints execution times of various components.")
+        )
+        .arg(
             Arg::with_name("protocol-version")
                 .long("protocol-version")
                 .help("Protocol version")
                 .takes_value(true),
         )
         .get_matches();
+
+    if matches.is_present("timings") {
+        tracing_timings::enable();
+    }
 
     let vm_kind: VMKind = match matches.value_of("vm-kind") {
         Some(value) => match value {

--- a/runtime/near-vm-runner-standalone/src/tracing_timings.rs
+++ b/runtime/near-vm-runner-standalone/src/tracing_timings.rs
@@ -1,0 +1,75 @@
+//! Consumer of `tracing` data, which prints a hierarchical profile.
+//!
+//! Based on https://github.com/davidbarsky/tracing-tree, but does less, while
+//! actually printing timings for spans.
+
+use std::fmt;
+use std::time::Instant;
+
+use tracing::field::{Field, Visit};
+use tracing::span::Attributes;
+use tracing::{Event, Id, Subscriber};
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::Layer;
+
+pub fn enable() {
+    let subscriber = tracing_subscriber::Registry::default().with(Timings);
+    tracing::subscriber::set_global_default(subscriber).unwrap();
+}
+
+struct Timings;
+
+struct Data {
+    start: Instant,
+}
+
+impl Data {
+    fn new(attrs: &Attributes<'_>) -> Self {
+        let mut span = Self { start: Instant::now() };
+        attrs.record(&mut span);
+        span
+    }
+}
+
+impl Visit for Data {
+    fn record_debug(&mut self, _field: &Field, _value: &dyn fmt::Debug) {}
+}
+
+impl<S> Layer<S> for Timings
+where
+    S: Subscriber + for<'span> LookupSpan<'span> + fmt::Debug,
+{
+    fn new_span(&self, attrs: &Attributes, id: &Id, ctx: Context<S>) {
+        let span = ctx.span(id).unwrap();
+
+        let data = Data::new(attrs);
+        span.extensions_mut().insert(data);
+    }
+
+    fn on_event(&self, _event: &Event<'_>, _ctx: Context<S>) {}
+
+    fn on_close(&self, id: Id, ctx: Context<S>) {
+        let span = ctx.span(&id).unwrap();
+        let level = ctx.scope().count();
+
+        let ext = span.extensions();
+        let data = ext.get::<Data>().unwrap();
+
+        let bold = "\u{001b}[1m";
+        let reset = "\u{001b}[0m";
+        eprintln!(
+            "{:width$}  {:3.2?} {bold}{}{reset}",
+            "",
+            data.start.elapsed(),
+            span.name(),
+            bold = bold,
+            reset = reset,
+            width = level * 2
+        );
+        if level == 0 {
+            eprintln!()
+        }
+    }
+}

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -30,6 +30,7 @@ near-primitives = { path = "../../core/primitives" }
 log = "0.4"
 near-evm-runner = { path = "../near-evm-runner", optional = true }
 cached = "0.23.0"
+tracing = { version = "0.1", default-features = false }
 
 [dev-dependencies]
 assert_matches = "1.3"

--- a/runtime/near-vm-runner/src/wasmer_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer_runner.rs
@@ -181,6 +181,8 @@ pub fn run_wasmer<'a>(
     current_protocol_version: ProtocolVersion,
     cache: Option<&'a dyn CompiledContractCache>,
 ) -> (Option<VMOutcome>, Option<VMError>) {
+    let _span = tracing::info_span!("run_wasmer").entered();
+
     if !cfg!(target_arch = "x86") && !cfg!(target_arch = "x86_64") {
         // TODO(#1940): Remove once NaN is standardized by the VM.
         panic!(
@@ -256,10 +258,14 @@ pub fn run_wasmer<'a>(
     }
 
     match module.instantiate(&import_object) {
-        Ok(instance) => match instance.call(&method_name, &[]) {
-            Ok(_) => (Some(logic.outcome()), None),
-            Err(err) => (Some(logic.outcome()), Some(err.into_vm_error())),
-        },
+        Ok(instance) => {
+            let _span = tracing::info_span!("run_wasmer/call").entered();
+
+            match instance.call(&method_name, &[]) {
+                Ok(_) => (Some(logic.outcome()), None),
+                Err(err) => (Some(logic.outcome()), Some(err.into_vm_error())),
+            }
+        }
         Err(err) => (Some(logic.outcome()), Some(err.into_vm_error())),
     }
 }


### PR DESCRIPTION
(builds on top of #3973)

`tracing` is a generic instrumentation framework. It allows manually
instrumented code to signal point-in-time events and nested spans.
Separately, a consumer for those spans and events can be defined.

In this particular case, we use `tracing` to measure time of various
phases of contract execution, with the output ending up like this (read
it bottom up):

        398.15ms compile_module
      398.19ms compile_module_cached_wasmer_impl
      140.19µs run_wasmer/call
    407.21ms run_wasmer

The output's format can certainly be improved, but the beauty of
`tracing` is that it can be done separately from instrumentation.

`tracing` is a bit over-engineered to my personal taste, but other than
that it is a well-maintained crate with a large ecosystem buy-in, and is
a solid bet.

The following pattern is suggested for using tracing:

```rust
  fn some_function(arg: Arg) {
    let span = tracing::info_span!("some_function");
    let _span = span.enter();

    let foo = {
        let span = tracing::info_span!("some_function/foo");
        let _span = span.enter();

        complex_computation_a() + long_computation_b()
    }
  }
```

That is:

* use `info` level (no strong motivation here, maybe we should switch to
  debug?)
* use function name as the message (helps finding it using "goto
  symbol" in an IDE)
* use `func_name/section` format to instrument sections of code, but
  prefer to extract them into a separate function.
* do not use `#[instrument]` attribute (it requires all args to be
  `Debug`, and works nicely only for common case).