### PR TITLE
feat: allow more sophisticated vm benchmarks 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3616,6 +3616,7 @@ version = "3.0.0"
 dependencies = [
  "base64 0.13.0",
  "clap 2.33.3",
+ "near-primitives",
  "near-primitives-core",
  "near-vm-logic",
  "near-vm-runner",

--- a/runtime/near-vm-runner-standalone/Cargo.toml
+++ b/runtime/near-vm-runner-standalone/Cargo.toml
@@ -30,6 +30,7 @@ tracing-subscriber = "0.2"
 near-vm-logic = { path = "../near-vm-logic", version = "3.0.0", features = ["costs_counting"]}
 near-vm-runner = { path = "../near-vm-runner", version = "3.0.0", features = ["wasmtime_vm", "wasmer1_vm"] }
 near-primitives-core = { path = "../../core/primitives-core", version = "0.1.0" }
+near-primitives = { path = "../../core/primitives", version = "0.1.0" }
 
 [features]
 default = []

--- a/runtime/near-vm-runner-standalone/src/main.rs
+++ b/runtime/near-vm-runner-standalone/src/main.rs
@@ -6,20 +6,20 @@
 //! ```
 //! Optional `--context-file=/tmp/context.json --config-file=/tmp/config.json` could be added
 //! to provide custom context and VM config.
+mod script;
 mod tracing_timings;
 
+use crate::script::Script;
 use clap::{App, Arg};
-use near_primitives_core::runtime::fees::RuntimeFeesConfig;
-use near_vm_logic::mocks::mock_external::{MockedExternal, Receipt};
-use near_vm_logic::profile::ProfileData;
-use near_vm_logic::types::PromiseResult;
-use near_vm_logic::{ProtocolVersion, VMConfig, VMContext, VMKind, VMOutcome};
-use near_vm_runner::{run_vm, run_vm_profiled, VMError};
+use near_vm_logic::mocks::mock_external::Receipt;
+use near_vm_logic::{VMKind, VMOutcome};
+use near_vm_runner::VMError;
 use serde::{
     de::{MapAccess, Visitor},
     ser::SerializeMap,
     {Deserialize, Deserializer, Serialize, Serializer},
 };
+use std::path::Path;
 use std::{collections::HashMap, fmt, fs};
 
 #[derive(Debug, Clone)]
@@ -72,27 +72,6 @@ struct StandaloneOutput {
     pub state: State,
 }
 
-fn default_vm_context() -> VMContext {
-    return VMContext {
-        current_account_id: "alice".to_string(),
-        signer_account_id: "bob".to_string(),
-        signer_account_pk: vec![0, 1, 2],
-        predecessor_account_id: "carol".to_string(),
-        input: vec![],
-        block_index: 1,
-        block_timestamp: 1586796191203000000,
-        account_balance: 10u128.pow(25),
-        account_locked_balance: 0,
-        storage_usage: 100,
-        attached_deposit: 0,
-        prepaid_gas: 10u64.pow(18),
-        random_seed: vec![0, 1, 2],
-        is_view: false,
-        output_data_receivers: vec![],
-        epoch_height: 1,
-    };
-}
-
 fn main() {
     let matches = App::new(env!("CARGO_PKG_NAME"))
         .version(env!("CARGO_PKG_VERSION"))
@@ -124,7 +103,8 @@ fn main() {
                 .long("method-name")
                 .value_name("METHOD_NAME")
                 .help("The name of the method to call on the smart contract.")
-                .takes_value(true),
+                .takes_value(true)
+                .required(true),
         )
         .arg(
             Arg::with_name("state")
@@ -162,14 +142,16 @@ fn main() {
                 .long("wasm-file")
                 .value_name("WASM_FILE")
                 .help("File path that contains the Wasm code to run.")
-                .takes_value(true),
+                .takes_value(true)
+                .required(true),
         )
         .arg(
             Arg::with_name("vm-kind")
                 .long("vm-kind")
                 .value_name("VM_KIND")
                 .help("Select VM kind to run.")
-                .takes_value(true),
+                .takes_value(true)
+                .possible_values(&["wasmer", "wasmer1", "wasmtime"]),
         )
         .arg(
             Arg::with_name("profile-gas")
@@ -193,116 +175,74 @@ fn main() {
         tracing_timings::enable();
     }
 
-    let vm_kind: VMKind = match matches.value_of("vm-kind") {
-        Some(value) => match value {
-            "wasmtime" => VMKind::Wasmtime,
-            "wasmer" => VMKind::Wasmer0,
-            "wasmer1" => VMKind::Wasmer1,
-            _ => VMKind::default(),
-        },
-        None => VMKind::default(),
-    };
+    let mut script = Script::default();
 
-    let mut context: VMContext = match matches.value_of("context") {
-        Some(value) => serde_json::from_str(value).unwrap(),
-        None => match matches.value_of("context-file") {
-            Some(filepath) => {
-                let data = fs::read(&filepath).unwrap();
-                serde_json::from_slice(&data).unwrap()
-            }
-            None => default_vm_context(),
-        },
+    match matches.value_of("vm-kind") {
+        Some("wasmtime") => script.vm_kind(VMKind::Wasmtime),
+        Some("wasmer") => script.vm_kind(VMKind::Wasmer0),
+        Some("wasmer1") => script.vm_kind(VMKind::Wasmer1),
+        _ => (),
     };
-
-    if let Some(value_str) = matches.value_of("input") {
-        context.input = value_str.as_bytes().to_vec();
+    if let Some(config) = matches.value_of("config") {
+        script.vm_config(serde_json::from_str(config).unwrap());
     }
-
-    let mut fake_external = MockedExternal::new();
+    if let Some(path) = matches.value_of("config-file") {
+        script.vm_config_from_file(Path::new(path));
+    }
+    if let Some(version) = matches.value_of("protocol-version") {
+        script.protocol_version(version.parse().unwrap())
+    }
+    let profile_gas = matches.is_present("profile-gas");
+    script.profile(profile_gas);
 
     if let Some(state_str) = matches.value_of("state") {
-        let state: State = serde_json::from_str(state_str).unwrap();
-        fake_external.fake_trie = state.0;
+        script.initial_state(serde_json::from_str(state_str).unwrap());
     }
 
-    let method_name =
-        matches.value_of("method-name").expect("Name of the method must be specified");
+    let code = fs::read(matches.value_of("wasm-file").unwrap()).unwrap();
+    let contract = script.contract(code);
 
-    let promise_results: Vec<PromiseResult> = matches
-        .values_of("promise-results")
-        .unwrap_or_default()
-        .map(|res_str| serde_json::from_str(res_str).unwrap())
-        .collect();
+    let method = matches.value_of("method-name").unwrap();
+    let step = script.step(contract, method);
 
-    let config: VMConfig = match matches.value_of("config") {
-        Some(value) => serde_json::from_str(value).unwrap(),
-        None => match matches.value_of("config-file") {
-            Some(filepath) => {
-                let data = fs::read(&filepath).unwrap();
-                serde_json::from_slice(&data).unwrap()
-            }
-            None => VMConfig::default(),
-        },
-    };
+    if let Some(value) = matches.value_of("context") {
+        step.context(serde_json::from_str(value).unwrap());
+    }
+    if let Some(path) = matches.value_of("context-file") {
+        step.context_from_file(Path::new(path));
+    }
 
-    let protocol_version = matches
-        .value_of("protocol-version")
-        .map(|s| s.parse().unwrap())
-        .unwrap_or(ProtocolVersion::MAX);
+    if let Some(value) = matches.value_of("input") {
+        step.input(value.as_bytes().to_vec());
+    }
 
-    let code =
-        fs::read(matches.value_of("wasm-file").expect("Wasm file needs to be specified")).unwrap();
+    if let Some(values) = matches.values_of("promise-results") {
+        let promise_results =
+            values.map(serde_json::from_str).collect::<Result<Vec<_>, _>>().unwrap();
+        step.promise_results(promise_results);
+    }
 
-    let fees = RuntimeFeesConfig::default();
-    let profile_data = ProfileData::new_enabled();
-    let do_profile = matches.is_present("profile-gas");
-    let (outcome, err) = if do_profile {
-        run_vm_profiled(
-            vec![],
-            &code,
-            &method_name,
-            &mut fake_external,
-            context,
-            &config,
-            &fees,
-            &promise_results,
-            vm_kind,
-            profile_data.clone(),
-            protocol_version,
-            None,
-        )
-    } else {
-        run_vm(
-            vec![],
-            &code,
-            &method_name,
-            &mut fake_external,
-            context,
-            &config,
-            &fees,
-            &promise_results,
-            vm_kind,
-            protocol_version,
-            None,
-        )
-    };
-    let all_gas = match outcome.clone() {
+    let mut results = script.run();
+    let (outcome, err) = results.outcomes.pop().unwrap();
+
+    let all_gas = match &outcome {
         Some(outcome) => outcome.burnt_gas,
         _ => 1,
     };
+
     println!(
         "{}",
         serde_json::to_string(&StandaloneOutput {
             outcome,
             err,
-            receipts: fake_external.get_receipt_create_calls().clone(),
-            state: State(fake_external.fake_trie),
+            receipts: results.state.get_receipt_create_calls().clone(),
+            state: State(results.state.fake_trie),
         })
         .unwrap()
     );
 
-    if do_profile {
-        assert_eq!(all_gas, profile_data.all_gas());
-        println!("{:#?}", profile_data);
+    if profile_gas {
+        assert_eq!(all_gas, results.profile.all_gas());
+        println!("{:#?}", results.profile);
     }
 }

--- a/runtime/near-vm-runner-standalone/src/script.rs
+++ b/runtime/near-vm-runner-standalone/src/script.rs
@@ -1,0 +1,220 @@
+use std::fs;
+use std::path::Path;
+
+use near_primitives::types::CompiledContractCache;
+use near_primitives_core::profile::ProfileData;
+use near_primitives_core::runtime::fees::RuntimeFeesConfig;
+use near_vm_logic::mocks::mock_external::MockedExternal;
+use near_vm_logic::types::PromiseResult;
+use near_vm_logic::{ProtocolVersion, VMConfig, VMContext, VMKind, VMOutcome};
+use near_vm_runner::{run_vm_profiled, MockCompiledContractCache, VMError};
+
+use crate::State;
+
+#[derive(Clone, Copy)]
+pub struct Contract(usize);
+
+/// Constructs a "script" to execute several contracts in a row. This is mainly
+/// intended for VM benchmarking.
+pub struct Script {
+    contracts: Vec<Vec<u8>>,
+    vm_kind: VMKind,
+    vm_config: VMConfig,
+    protocol_version: ProtocolVersion,
+    profile: ProfileData,
+    contract_cache: Option<Box<dyn CompiledContractCache>>,
+    initial_state: Option<State>,
+    steps: Vec<Step>,
+}
+
+pub struct Step {
+    contract: Contract,
+    method: String,
+    vm_context: VMContext,
+    promise_results: Vec<PromiseResult>,
+    repeat: u32,
+}
+
+pub struct ScriptResults {
+    pub outcomes: Vec<(Option<VMOutcome>, Option<VMError>)>,
+    pub state: MockedExternal,
+    pub profile: ProfileData,
+}
+
+impl Default for Script {
+    fn default() -> Self {
+        Script {
+            contracts: Vec::new(),
+            vm_kind: VMKind::default(),
+            vm_config: VMConfig::default(),
+            protocol_version: ProtocolVersion::MAX,
+            profile: ProfileData::new_disabled(),
+            contract_cache: None,
+            initial_state: None,
+            steps: Vec::new(),
+        }
+    }
+}
+
+impl Script {
+    pub(crate) fn contract(&mut self, contract: Vec<u8>) -> Contract {
+        let res = Contract(self.contracts.len());
+        self.contracts.push(contract);
+        res
+    }
+
+    #[allow(unused)]
+    pub(crate) fn contract_from_file(&mut self, path: &Path) -> Contract {
+        let data = fs::read(path).unwrap();
+        self.contract(data)
+    }
+
+    pub(crate) fn vm_kind(&mut self, vm_kind: VMKind) {
+        self.vm_kind = vm_kind;
+    }
+
+    pub(crate) fn vm_config(&mut self, vm_config: VMConfig) {
+        self.vm_config = vm_config;
+    }
+
+    pub(crate) fn vm_config_from_file(&mut self, path: &Path) {
+        let data = fs::read(path).unwrap();
+        let vm_config = serde_json::from_slice(&data).unwrap();
+        self.vm_config(vm_config)
+    }
+
+    pub(crate) fn protocol_version(&mut self, protocol_version: ProtocolVersion) {
+        self.protocol_version = protocol_version;
+    }
+
+    pub(crate) fn profile(&mut self, yes: bool) {
+        self.profile = if yes { ProfileData::new_enabled() } else { ProfileData::new_disabled() }
+    }
+
+    #[allow(unused)]
+    pub(crate) fn contract_cache(&mut self, yes: bool) {
+        self.contract_cache =
+            if yes { Some(Box::new(MockCompiledContractCache::default())) } else { None };
+    }
+
+    pub(crate) fn initial_state(&mut self, state: State) {
+        self.initial_state = Some(state);
+    }
+
+    pub(crate) fn step(&mut self, contract: Contract, method: &str) -> &mut Step {
+        self.steps.push(Step::new(contract, method.to_string()));
+        self.steps.last_mut().unwrap()
+    }
+
+    pub(crate) fn run(mut self) -> ScriptResults {
+        let mut external = MockedExternal::new();
+        if let Some(State(trie)) = self.initial_state.take() {
+            external.fake_trie = trie;
+        }
+
+        let mut outcomes = Vec::new();
+        for step in &self.steps {
+            for _ in 0..step.repeat {
+                let res = run_vm_profiled(
+                    vec![],
+                    &self.contracts[step.contract.0],
+                    &step.method,
+                    &mut external,
+                    step.vm_context.clone(),
+                    &self.vm_config,
+                    &RuntimeFeesConfig::default(),
+                    &step.promise_results,
+                    self.vm_kind,
+                    self.profile.clone(),
+                    self.protocol_version,
+                    self.contract_cache.as_deref(),
+                );
+                outcomes.push(res);
+            }
+        }
+        ScriptResults { outcomes, state: external, profile: self.profile }
+    }
+}
+
+impl Step {
+    fn new(contract: Contract, method: String) -> Step {
+        Step {
+            contract,
+            method,
+            vm_context: default_vm_context(),
+            promise_results: Vec::new(),
+            repeat: 1,
+        }
+    }
+    pub(crate) fn context(&mut self, context: VMContext) -> &mut Step {
+        self.vm_context = context;
+        self
+    }
+    pub(crate) fn context_from_file(&mut self, path: &Path) -> &mut Step {
+        let data = fs::read(path).unwrap();
+        let context = serde_json::from_slice(&data).unwrap();
+        self.context(context)
+    }
+    pub(crate) fn input(&mut self, input: Vec<u8>) -> &mut Step {
+        self.vm_context.input = input;
+        self
+    }
+    pub(crate) fn promise_results(&mut self, promise_results: Vec<PromiseResult>) -> &mut Step {
+        self.promise_results = promise_results;
+        self
+    }
+    #[allow(unused)]
+    pub(crate) fn repeat(&mut self, n: u32) -> &mut Step {
+        self.repeat = n;
+        self
+    }
+}
+
+fn default_vm_context() -> VMContext {
+    VMContext {
+        current_account_id: "alice".to_string(),
+        signer_account_id: "bob".to_string(),
+        signer_account_pk: vec![0, 1, 2],
+        predecessor_account_id: "carol".to_string(),
+        input: vec![],
+        block_index: 1,
+        block_timestamp: 1586796191203000000,
+        account_balance: 10u128.pow(25),
+        account_locked_balance: 0,
+        storage_usage: 100,
+        attached_deposit: 0,
+        prepaid_gas: 10u64.pow(18),
+        random_seed: vec![0, 1, 2],
+        is_view: false,
+        output_data_receivers: vec![],
+        epoch_height: 1,
+    }
+}
+
+#[test]
+fn vm_script_smoke_test() {
+    use near_vm_logic::ReturnData;
+
+    crate::tracing_timings::enable();
+
+    let mut script = Script::default();
+    script.contract_cache(true);
+
+    let contract =
+        script.contract_from_file(Path::new("../near-vm-runner/tests/res/test_contract_rs.wasm"));
+
+    script.step(contract, "log_something").repeat(3);
+    script.step(contract, "sum_n").input(100u64.to_le_bytes().to_vec());
+
+    let res = script.run();
+
+    assert_eq!(res.outcomes.len(), 4);
+
+    let logs = &res.outcomes[0].0.as_ref().unwrap().logs;
+    assert_eq!(logs, &vec!["hello".to_string()]);
+
+    let ret = res.outcomes.last().unwrap().0.as_ref().unwrap().return_data.clone();
+
+    let expected = ReturnData::Value(4950u64.to_le_bytes().to_vec());
+    assert_eq!(ret, expected);
+}

--- a/runtime/near-vm-runner/src/lib.rs
+++ b/runtime/near-vm-runner/src/lib.rs
@@ -26,3 +26,5 @@ pub use runner::run_vm;
 pub use runner::run_vm_profiled;
 
 pub use near_vm_logic::with_ext_cost_counter;
+
+pub use cache::MockCompiledContractCache;

--- a/runtime/near-vm-runner/src/tests.rs
+++ b/runtime/near-vm-runner/src/tests.rs
@@ -3,9 +3,8 @@ mod invalid_contracts;
 mod rs_contract;
 mod ts_contract;
 
-use std::collections::hash_map::{DefaultHasher, HashMap};
+use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
-use std::sync::{Arc, Mutex};
 
 use wabt::Wat2Wasm;
 
@@ -98,24 +97,6 @@ fn make_simple_contract_call_vm(
 
 fn wat2wasm_no_validate(wat: &str) -> Vec<u8> {
     Wat2Wasm::new().validate(false).convert(wat).unwrap().as_ref().to_vec()
-}
-
-struct MockCompiledContractCache {
-    store: Arc<Mutex<HashMap<Vec<u8>, Vec<u8>>>>,
-}
-
-impl CompiledContractCache for MockCompiledContractCache {
-    fn put(&self, key: &[u8], value: &[u8]) -> Result<(), std::io::Error> {
-        self.store.lock().unwrap().insert(key.to_vec(), value.to_vec());
-        Ok(())
-    }
-
-    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, std::io::Error> {
-        match self.store.lock().unwrap().get(key) {
-            Some(value) => Ok(Some(value.clone())),
-            None => Ok(None),
-        }
-    }
 }
 
 fn make_cached_contract_call_vm(

--- a/runtime/near-vm-runner/src/tests/error_cases.rs
+++ b/runtime/near-vm-runner/src/tests/error_cases.rs
@@ -2,12 +2,11 @@ use near_vm_errors::{
     CompilationError, FunctionCallError, HostError, MethodResolveError, PrepareError, VMError,
 };
 use near_vm_logic::{ReturnData, VMKind, VMOutcome};
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
 
+use crate::cache::MockCompiledContractCache;
 use crate::tests::{
     make_cached_contract_call_vm, make_simple_contract_call_vm,
-    make_simple_contract_call_with_gas_vm, with_vm_variants, MockCompiledContractCache,
+    make_simple_contract_call_with_gas_vm, with_vm_variants,
 };
 
 fn vm_outcome_with_gas(gas: u64) -> VMOutcome {
@@ -557,14 +556,14 @@ fn test_contract_error_caching() {
             VMKind::Wasmtime => return,
             _ => {}
         }
-        let mut cache = MockCompiledContractCache { store: Arc::new(Mutex::new(HashMap::new())) };
+        let mut cache = MockCompiledContractCache::default();
         let code = [42; 1000];
         let terragas = 1000000000000u64;
-        assert_eq!(cache.store.lock().unwrap().len(), 0);
+        assert_eq!(cache.len(), 0);
         let err1 =
             make_cached_contract_call_vm(&mut cache, &code, "method_name1", terragas, vm_kind);
-        println!("{:?}", cache.store.lock().unwrap());
-        assert_eq!(cache.store.lock().unwrap().len(), 1);
+        println!("{:?}", cache);
+        assert_eq!(cache.len(), 1);
         let err2 =
             make_cached_contract_call_vm(&mut cache, &code, "method_name2", terragas, vm_kind);
         assert_eq!(err1, err2);


### PR DESCRIPTION
We now can run several contracts in a row which allows us to, eg,
observe caching effects:

        374.26ms compile_module
      374.29ms compile_module_cached_wasmer_impl
      123.06µs run_wasmer/call
    383.05ms run_wasmer

      52.46µs run_wasmer/call
    8.45ms run_wasmer

      57.97µs run_wasmer/call
    8.47ms run_wasmer

      128.15µs run_wasmer/call
    8.59ms run_wasmer

This includes #3974 just to get nice numbers, but can be landed separately. 

At the moment, the `Script` has only programmatic interface -- the best way to create your custom test scenario is to write a `#[test]`. We *can* add some kind of interpreter here, so that the script can be read as text, but I feel that just using Rust would be more productive. 