### PR TITLE
feat(indexer): Simplify usage of init_configs from indexer perspective

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3154,7 +3154,7 @@ dependencies = [
 
 [[package]]
 name = "near-indexer"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "actix",
  "futures",

--- a/chain/indexer/CHANGELOG.md
+++ b/chain/indexer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.8.1
+
+* Add `InitConfigArgs` and `indexer_init_configs`
+
+As current `neard::init_configs()` signature is a bit hard to read and use we introduce `InitConfigArgs` struct to make a process of passing arguments more explicit. That's why we introduce `indexer_init_configs` which is just a wrapper on `neard::init_configs()` but takes `dir` and `InitConfigArgs` as an input.
+
 ## 0.8.0
 
 * Upgrade dependencies
@@ -14,7 +20,7 @@ created and started on the Indexer implementation, not on the Indexer Framework 
 
 * State changes return changes with cause instead of kinds
 
-## Breaking changes 
+## Breaking changes
 
 * `StreamerMessage` now contains `StateChangesView` which is an alias for  `Vec<StateChangesWithCauseView>`, previously it contained `StateChangesKindsView`
 
@@ -24,7 +30,7 @@ created and started on the Indexer implementation, not on the Indexer Framework 
 
 ## Breaking changes
 
-* `IndexerConfig` was extended with another field `await_for_node_synced`. Corresponding enum is `AwaitForNodeSyncedEnum` with variants: 
+* `IndexerConfig` was extended with another field `await_for_node_synced`. Corresponding enum is `AwaitForNodeSyncedEnum` with variants:
   * `WaitForFullSync` - await for node to be fully synced (previous default behaviour)
   * `StreamWhileSyncing`- start streaming right away while node is syncing (it's useful in case of Indexing from genesis)
 
@@ -36,7 +42,7 @@ created and started on the Indexer implementation, not on the Indexer Framework 
 
 Since #3529 nearcore stores `ExecutionOutcome`s in their execution order, and we can also attribute outcomes to specific chunk. That's why:
 * `receipt_execution_outcomes` was moved from `StreamerMessage` to a relevant `IndexerChunkView`
-* `ExecutionOutcomesWithReceipts` type alias was removed (just use `Vec<IndexerExecutionOutcomeWithReceipt>` instead) 
+* `ExecutionOutcomesWithReceipts` type alias was removed (just use `Vec<IndexerExecutionOutcomeWithReceipt>` instead)
 
 ## 0.4.0
 
@@ -45,7 +51,7 @@ Since #3529 nearcore stores `ExecutionOutcome`s in their execution order, and we
 ## Breaking changes
 
 * For local receipt to have a relation to specific chunk we have prepended them to original receipts in particular chunk
-as in the most cases local receipts are executed before normal receipts. That's why there is no reason to have `local_receipts` 
+as in the most cases local receipts are executed before normal receipts. That's why there is no reason to have `local_receipts`
 field in `StreamerMessage` struct anymore. `local_receipts` field was removed.
 
 ## 0.3.1
@@ -57,7 +63,7 @@ field in `StreamerMessage` struct anymore. `local_receipts` field was removed.
 
 ### Breaking changes
 
-* To extended the `receipt_execution_outcomes` with information about the corresponding receipt we had to break the API 
+* To extended the `receipt_execution_outcomes` with information about the corresponding receipt we had to break the API
 (the old outcome structure is just one layer deeper now [under `execution_outcome` field])
 
 ## 0.2.0
@@ -65,4 +71,4 @@ field in `StreamerMessage` struct anymore. `local_receipts` field was removed.
 * Refactor the way of fetching `ExecutionOutcome`s (use the new way to get all of them for specific block)
 * Rename `StreamerMessage.outcomes` field to `receipt_execution_outcomes` and change type to `HashMap<CryptoHash, ExecutionOutcomeWithId>` and now it includes only `ExecutionOutcome`s for receipts (no transactions)
 * Introduce `IndexerTransactionWithOutcome` struct to contain `SignedTransactionView` and `ExecutionOutcomeWithId` for the transaction
-* Introduce `IndexerChunkView` to replace `StreamerMessage.chunks` to include `IndexerTransactionWithOutcome` vec in `transactions` 
+* Introduce `IndexerChunkView` to replace `StreamerMessage.chunks` to include `IndexerTransactionWithOutcome` vec in `transactions`

--- a/chain/indexer/Cargo.toml
+++ b/chain/indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-indexer"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 

--- a/chain/indexer/src/lib.rs
+++ b/chain/indexer/src/lib.rs
@@ -18,12 +18,34 @@ pub use self::streamer::{
 };
 pub use near_primitives;
 
+/// Config wrapper to simplify signature and usage of `neard::init_configs`
+/// function by making args more explicit via struct
+#[derive(Debug, Clone)]
+pub struct InitConfigArgs {
+    /// chain/network id (localnet, testnet, devnet, betanet)
+    pub chain_id: Option<String>,
+    /// Account ID for the validator key
+    pub account_id: Option<String>,
+    /// Specify private key generated from seed (TESTING ONLY)
+    pub test_seed: Option<String>,
+    /// Number of shards to initialize the chain with
+    pub num_shards: u64,
+    /// Makes block production fast (TESTING ONLY)
+    pub fast: bool,
+    /// Genesis file to use when initialize testnet (including downloading)
+    pub genesis: Option<String>,
+    /// Download the verified NEAR genesis file automatically.
+    pub download: bool,
+    /// Specify a custom download URL for the genesis-file.
+    pub download_genesis_url: Option<String>,
+}
+
 /// Enum to define a mode of syncing for NEAR Indexer
 #[derive(Debug, Clone)]
 pub enum SyncModeEnum {
     /// Real-time syncing, always taking the latest finalized block to stream
     LatestSynced,
-    /// Starts syncing from the block NEAR Indexer was interrupted last time  
+    /// Starts syncing from the block NEAR Indexer was interrupted last time
     FromInterruption,
     /// Specific block height to start syncing from
     BlockHeight(u64),
@@ -98,4 +120,20 @@ impl Indexer {
     ) -> (actix::Addr<near_client::ViewClientActor>, actix::Addr<near_client::ClientActor>) {
         (self.view_client.clone(), self.client.clone())
     }
+}
+
+/// Function that initializes configs for the node which
+/// accepts `InitConfigWrapper` and calls original `init_configs` from `neard`
+pub fn indexer_init_configs(dir: &std::path::PathBuf, params: InitConfigArgs) {
+    init_configs(
+        dir,
+        params.chain_id.as_ref().map(AsRef::as_ref),
+        params.account_id.as_ref().map(AsRef::as_ref),
+        params.test_seed.as_ref().map(AsRef::as_ref),
+        params.num_shards,
+        params.fast,
+        params.genesis.as_ref().map(AsRef::as_ref),
+        params.download,
+        params.download_genesis_url.as_ref().map(AsRef::as_ref),
+    )
 }

--- a/tools/indexer/example/src/configs.rs
+++ b/tools/indexer/example/src/configs.rs
@@ -59,3 +59,18 @@ pub(crate) fn init_logging() {
         .with_writer(std::io::stderr)
         .init();
 }
+
+impl From<InitConfigArgs> for near_indexer::InitConfigArgs {
+    fn from(config_args: InitConfigArgs) -> Self {
+        Self {
+            chain_id: config_args.chain_id,
+            account_id: config_args.account_id,
+            test_seed: config_args.test_seed,
+            num_shards: config_args.num_shards,
+            fast: config_args.fast,
+            genesis: config_args.genesis,
+            download: config_args.download,
+            download_genesis_url: config_args.download_genesis_url,
+        }
+    }
+}

--- a/tools/indexer/example/src/main.rs
+++ b/tools/indexer/example/src/main.rs
@@ -278,16 +278,8 @@ fn main() {
                 })
                 .unwrap();
         }
-        SubCommand::Init(config) => near_indexer::init_configs(
-            &home_dir,
-            config.chain_id.as_ref().map(AsRef::as_ref),
-            config.account_id.as_ref().map(AsRef::as_ref),
-            config.test_seed.as_ref().map(AsRef::as_ref),
-            config.num_shards,
-            config.fast,
-            config.genesis.as_ref().map(AsRef::as_ref),
-            config.download,
-            config.download_genesis_url.as_ref().map(AsRef::as_ref),
-        ),
+        SubCommand::Init(config) => {
+            near_indexer::indexer_init_configs(&home_dir, config.into())
+        }
     }
 }

--- a/tools/indexer/example/src/main.rs
+++ b/tools/indexer/example/src/main.rs
@@ -278,8 +278,6 @@ fn main() {
                 })
                 .unwrap();
         }
-        SubCommand::Init(config) => {
-            near_indexer::indexer_init_configs(&home_dir, config.into())
-        }
+        SubCommand::Init(config) => near_indexer::indexer_init_configs(&home_dir, config.into()),
     }
 }


### PR DESCRIPTION
During the creation of a tutorial about an indexer we've noticed that the signature of `neard::init_configs` is quite big and hard to use, especially from indexer perspective, so we want to introduce a way of simplifying things.

`InitConfigArgs` from indexer example was taken as a base, so now we have the same struct exposed from NEAR Indexer Framework along with wrapper-function `indexer_init_configs`. It takes `dir` arg and new structure with the same arguments as `neard::init_configs` function. Calls the original one to initialize configs, but now is a bit easier to use from user's point of view.

I am open for suggestions to make it even better, this is a blocker for publishing of the first indexer tutorial to the docs.