### PR TITLE
fix(doc): clarify wasmer 0.x is default when build with no feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ rosetta_rpc = ["neard/rosetta_rpc"]
 protocol_feature_forward_chunk_parts = ["neard/protocol_feature_forward_chunk_parts"]
 nightly_protocol = ["near-primitives/nightly_protocol", "near-jsonrpc/nightly_protocol"]
 # enable this to build neard with wasmer 1.0 runner
-# now if none of wasmer0_default, wasmer1_default or wasmtime_default is enabled, wasmer1 would be default
+# now if none of wasmer0_default, wasmer1_default or wasmtime_default is enabled, wasmer0 would be default
 wasmer1_default = ["node-runtime/wasmer1_default"]
 wasmer0_default = ["node-runtime/wasmer0_default"]
 wasmtime_default = ["node-runtime/wasmtime_default"]


### PR DESCRIPTION
I made wasmer1 as default and this doc, but revert to wasmer0 default when applied code reviews, however forget to update this comment.

Test Plan
---------
Tested locally with debug prints to see build neard with wasmer_default, wasmer1_default and none of them when build trigger correct vm. 