### PR TITLE
refactor: significantly reduce costs_conting blast radius

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,12 +113,7 @@ protocol_feature_forward_chunk_parts = ["neard/protocol_feature_forward_chunk_pa
 protocol_feature_evm = ["neard/protocol_feature_evm", "testlib/protocol_feature_evm", "runtime-params-estimator/protocol_feature_evm"]
 protocol_feature_alt_bn128 = ["neard/protocol_feature_alt_bn128", "testlib/protocol_feature_alt_bn128", "runtime-params-estimator/protocol_feature_alt_bn128"]
 protocol_feature_block_header_v3 = ["near-primitives/protocol_feature_block_header_v3", "near-chain/protocol_feature_block_header_v3", "neard/protocol_feature_block_header_v3"]
-costs_counting = [
-    "near-primitives/costs_counting",
-    "neard/costs_counting",
-    "node-runtime/costs_counting",
-    "testlib/costs_counting"
-]
+
 # enable this to build neard with wasmer 1.0 runner
 # now if none of wasmer0_default, wasmer1_default or wasmtime_default is enabled, wasmer0 would be default
 wasmer1_default = ["node-runtime/wasmer1_default"]

--- a/core/primitives-core/src/profile.rs
+++ b/core/primitives-core/src/profile.rs
@@ -19,46 +19,92 @@ impl<T> Clone for FixedArray<T> {
 }
 
 /// Profile of gas consumption.
-pub type ProfileData = FixedArray<u64>;
+#[derive(Clone)]
+pub struct ProfileData {
+    repr: Repr,
+}
 
-pub fn clone_profile(profile: &ProfileData) -> ProfileData {
-    profile.clone()
+#[derive(Clone)]
+enum Repr {
+    #[cfg(feature = "costs_counting")]
+    Enabled {
+        data: FixedArray<u64>,
+    },
+    Disabled,
+}
+
+#[cfg(not(feature = "costs_counting"))]
+const _ASSERT_NO_OP_IF_COUNTING_DISABLED: [(); 0] = [(); std::mem::size_of::<ProfileData>()];
+
+impl Default for ProfileData {
+    fn default() -> ProfileData {
+        ProfileData::new_disabled()
+    }
 }
 
 impl ProfileData {
-    pub fn new() -> Self {
-        Self { data: Rc::new(RefCell::new([0u64; 1 + ExtCosts::count() + ActionCosts::count()])) }
-    }
-
     const EXT_START: usize = 1;
     const ACTION_START: usize = ProfileData::EXT_START + ExtCosts::count();
     // const LENGTH: usize = PROFILE_DATA_LEN;
-    pub fn all_gas(&self) -> Gas {
-        (*self.data.borrow())[0]
+
+    #[inline]
+    #[cfg(feature = "costs_counting")]
+    pub fn new_enabled() -> Self {
+        let data = Rc::new(RefCell::new([0u64; 1 + ExtCosts::count() + ActionCosts::count()]));
+        let data = FixedArray { data };
+        let repr = Repr::Enabled { data };
+        ProfileData { repr }
     }
 
-    fn borrow(&self) -> InternalProfileData<u64> {
-        *self.data.borrow()
+    #[inline]
+    #[cfg(not(feature = "costs_counting"))]
+    pub fn new_enabled() -> Self {
+        Self::new_disabled()
     }
 
-    fn add_val(&self, index: usize, value: u64) {
-        *self.data.borrow_mut().get_mut(index).unwrap() += value;
+    #[inline]
+    pub fn new_disabled() -> Self {
+        let repr = Repr::Disabled;
+        ProfileData { repr }
     }
 
+    #[inline]
     pub fn add_action_cost(&self, action: ActionCosts, value: u64) {
         self.add_val(ProfileData::ACTION_START + action as usize, value);
     }
+    #[inline]
+    pub fn add_ext_cost(&self, ext: ExtCosts, value: u64) {
+        self.add_val(ProfileData::EXT_START + ext as usize, value);
+    }
+    #[inline]
+    fn add_val(&self, index: usize, value: u64) {
+        self.with_data(|data| data[index] += value)
+    }
+
+    #[inline]
+    fn with_data(&self, f: impl FnOnce(&mut InternalProfileData<u64>)) {
+        match &self.repr {
+            #[cfg(feature = "costs_counting")]
+            Repr::Enabled { data } => f(&mut data.data.borrow_mut()),
+            Repr::Disabled => drop(f),
+        }
+    }
+    fn read(&self, index: usize) -> u64 {
+        let mut res = 0;
+        self.with_data(|data| res = data[index]);
+        res
+    }
+
+    pub fn all_gas(&self) -> Gas {
+        self.read(0)
+    }
 
     pub fn get_action_cost(&self, action: usize) -> u64 {
-        self.borrow()[ProfileData::ACTION_START + action]
+        self.read(ProfileData::ACTION_START + action)
     }
 
     pub fn get_ext_cost(&self, ext: usize) -> u64 {
-        self.borrow()[ProfileData::EXT_START + ext]
-    }
-
-    pub fn add_ext_cost(&self, ext: ExtCosts, value: u64) {
-        self.add_val(ProfileData::EXT_START + ext as usize, value);
+        self.read(ProfileData::EXT_START + ext)
     }
 
     pub fn host_gas(&self) -> u64 {
@@ -85,7 +131,7 @@ impl ProfileData {
     }
 
     pub fn set_burnt_gas(&self, burnt_gas: u64) {
-        *self.data.borrow_mut().get_mut(0 as usize).unwrap() = burnt_gas;
+        self.with_data(|data| data[0] = burnt_gas);
     }
 }
 

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -50,7 +50,6 @@ protocol_feature_block_header_v3 = []
 protocol_feature_alt_bn128 = ["near-primitives-core/protocol_feature_alt_bn128", "near-vm-errors/protocol_feature_alt_bn128"]
 nightly_protocol_features = ["nightly_protocol", "protocol_feature_forward_chunk_parts", "protocol_feature_rectify_inflation", "protocol_feature_evm", "protocol_feature_block_header_v3", "protocol_feature_alt_bn128"]
 nightly_protocol = []
-costs_counting = ["near-primitives-core/costs_counting"]
 
 
 [dev-dependencies]

--- a/core/primitives/src/runtime/apply_state.rs
+++ b/core/primitives/src/runtime/apply_state.rs
@@ -38,6 +38,5 @@ pub struct ApplyState {
     #[cfg(feature = "protocol_feature_evm")]
     pub evm_chain_id: u64,
     /// Data collected from making a contract call
-    #[cfg(feature = "costs_counting")]
-    pub profile: Option<crate::profile::ProfileData>,
+    pub profile: crate::profile::ProfileData,
 }

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -72,7 +72,6 @@ protocol_feature_alt_bn128 = ["near-primitives/protocol_feature_alt_bn128", "nod
 protocol_feature_block_header_v3 = ["near-primitives/protocol_feature_block_header_v3", "near-chain/protocol_feature_block_header_v3", "near-client/protocol_feature_block_header_v3"]
 nightly_protocol_features = ["nightly_protocol", "near-primitives/nightly_protocol_features", "near-client/nightly_protocol_features", "near-epoch-manager/nightly_protocol_features", "near-store/nightly_protocol_features", "protocol_feature_forward_chunk_parts", "protocol_feature_rectify_inflation", "protocol_feature_evm", "protocol_feature_block_header_v3", "protocol_feature_alt_bn128"]
 nightly_protocol = ["near-primitives/nightly_protocol", "near-jsonrpc/nightly_protocol"]
-costs_counting = ["near-primitives/costs_counting", "node-runtime/costs_counting"]
 
 [[bin]]
 path = "src/main.rs"

--- a/neard/src/runtime.rs
+++ b/neard/src/runtime.rs
@@ -461,8 +461,7 @@ impl NightshadeRuntime {
             cache: Some(Arc::new(StoreCompiledContractCache { store: self.store.clone() })),
             #[cfg(feature = "protocol_feature_evm")]
             evm_chain_id: self.evm_chain_id(),
-            #[cfg(feature = "costs_counting")]
-            profile: None,
+            profile: Default::default(),
         };
 
         let apply_result = self

--- a/runtime/near-evm-runner/Cargo.toml
+++ b/runtime/near-evm-runner/Cargo.toml
@@ -50,7 +50,6 @@ criterion = "0.3.0"
 near-crypto = { path = "../../core/crypto" }
 
 [features]
-costs_counting = ["near-vm-logic/costs_counting"]
 protocol_feature_evm = ["near-vm-logic/protocol_feature_evm", "near-primitives/protocol_feature_evm", "near-vm-errors/protocol_feature_alt_bn128"]
 
 [[test]]

--- a/runtime/near-evm-runner/src/runner.rs
+++ b/runtime/near-evm-runner/src/runner.rs
@@ -175,7 +175,7 @@ impl<'a> EvmContext<'a> {
                 max_gas_burnt,
                 prepaid_gas,
                 is_view,
-                None,
+                Default::default(),
             ),
             evm_gas_counter: EvmGasCounter::new(0.into(), evm_gas),
             fees_config,

--- a/runtime/near-vm-logic/src/logic.rs
+++ b/runtime/near-vm-logic/src/logic.rs
@@ -107,7 +107,7 @@ impl<'a> VMLogic<'a> {
         fees_config: &'a RuntimeFeesConfig,
         promise_results: &'a [PromiseResult],
         memory: &'a mut dyn MemoryLike,
-        profile: Option<ProfileData>,
+        profile: ProfileData,
         current_protocol_version: ProtocolVersion,
     ) -> Self {
         ext.reset_touched_nodes_counter();
@@ -157,7 +157,7 @@ impl<'a> VMLogic<'a> {
         fees_config: &'a RuntimeFeesConfig,
         promise_results: &'a [PromiseResult],
         memory: &'a mut dyn MemoryLike,
-        profile: Option<ProfileData>,
+        profile: ProfileData,
     ) -> Self {
         Self::new_with_protocol_version(
             ext,

--- a/runtime/near-vm-logic/tests/vm_logic_builder.rs
+++ b/runtime/near-vm-logic/tests/vm_logic_builder.rs
@@ -40,7 +40,7 @@ impl VMLogicBuilder {
             &self.fees_config,
             &self.promise_results,
             &mut self.memory,
-            None,
+            Default::default(),
             self.current_protocol_version,
         )
     }

--- a/runtime/near-vm-runner-standalone/src/main.rs
+++ b/runtime/near-vm-runner-standalone/src/main.rs
@@ -257,7 +257,7 @@ fn main() {
         fs::read(matches.value_of("wasm-file").expect("Wasm file needs to be specified")).unwrap();
 
     let fees = RuntimeFeesConfig::default();
-    let profile_data = ProfileData::new();
+    let profile_data = ProfileData::new_enabled();
     let do_profile = matches.is_present("profile-gas");
     let (outcome, err) = if do_profile {
         run_vm_profiled(

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -49,9 +49,6 @@ lightbeam = ["wasmtime/lightbeam"]
 no_cpu_compatibility_checks = []
 protocol_feature_evm = ["near-primitives/protocol_feature_evm", "near-evm-runner/protocol_feature_evm"]
 
-# Use this feature to enable counting of fees and costs applied.
-costs_counting = ["near-vm-logic/costs_counting", "near-primitives/costs_counting"]
-
 no_cache = []
 
 protocol_feature_alt_bn128 = [

--- a/runtime/near-vm-runner/benches/bench.rs
+++ b/runtime/near-vm-runner/benches/bench.rs
@@ -79,7 +79,7 @@ fn pass_through(bench: &mut Bencher) {
             &promise_results,
             LATEST_PROTOCOL_VERSION,
             None,
-            None,
+            &Default::default(),
         );
         assert_run_result(result, 42);
     });
@@ -99,7 +99,7 @@ fn benchmark_fake_storage_8b_1000(bench: &mut Bencher) {
             &promise_results,
             LATEST_PROTOCOL_VERSION,
             None,
-            None,
+            &Default::default(),
         );
         assert_run_result(result, 999 * 1000 / 2);
     });
@@ -119,7 +119,7 @@ fn benchmark_fake_storage_10kib_1000(bench: &mut Bencher) {
             &promise_results,
             LATEST_PROTOCOL_VERSION,
             None,
-            None,
+            &Default::default(),
         );
         assert_run_result(result, 999 * 1000 / 2);
     });
@@ -139,7 +139,7 @@ fn sum_n_1000000(bench: &mut Bencher) {
             &promise_results,
             LATEST_PROTOCOL_VERSION,
             None,
-            None,
+            &Default::default(),
         );
         assert_run_result(result, (1000000 - 1) * 1000000 / 2);
     });

--- a/runtime/near-vm-runner/src/runner.rs
+++ b/runtime/near-vm-runner/src/runner.rs
@@ -30,11 +30,9 @@ pub fn run<'a>(
     promise_results: &'a [PromiseResult],
     current_protocol_version: ProtocolVersion,
     cache: Option<&'a dyn CompiledContractCache>,
-    #[cfg(feature = "costs_counting")] profile: Option<&ProfileData>,
+    profile: &ProfileData,
 ) -> (Option<VMOutcome>, Option<VMError>) {
-    #[cfg(not(feature = "costs_counting"))]
-    let profile = None;
-    run_vm_impl(
+    run_vm_profiled(
         code_hash,
         code,
         method_name,
@@ -44,7 +42,7 @@ pub fn run<'a>(
         fees_config,
         promise_results,
         VMKind::default(),
-        profile,
+        profile.clone(),
         current_protocol_version,
         cache,
     )
@@ -62,7 +60,8 @@ pub fn run_vm<'a>(
     current_protocol_version: ProtocolVersion,
     cache: Option<&'a dyn CompiledContractCache>,
 ) -> (Option<VMOutcome>, Option<VMError>) {
-    run_vm_impl(
+    let profile = ProfileData::new_disabled();
+    run_vm_profiled(
         code_hash,
         code,
         method_name,
@@ -72,7 +71,7 @@ pub fn run_vm<'a>(
         fees_config,
         promise_results,
         vm_kind,
-        None,
+        profile,
         current_protocol_version,
         cache,
     )
@@ -91,36 +90,6 @@ pub fn run_vm_profiled<'a>(
     profile: ProfileData,
     current_protocol_version: ProtocolVersion,
     cache: Option<&'a dyn CompiledContractCache>,
-) -> (Option<VMOutcome>, Option<VMError>) {
-    run_vm_impl(
-        code_hash,
-        code,
-        method_name,
-        ext,
-        context,
-        wasm_config,
-        fees_config,
-        promise_results,
-        vm_kind,
-        Some(&profile),
-        current_protocol_version,
-        cache,
-    )
-}
-
-fn run_vm_impl(
-    code_hash: Vec<u8>,
-    code: &[u8],
-    method_name: &[u8],
-    ext: &mut dyn External,
-    context: VMContext,
-    wasm_config: &VMConfig,
-    fees_config: &RuntimeFeesConfig,
-    promise_results: &[PromiseResult],
-    vm_kind: VMKind,
-    profile: Option<&ProfileData>,
-    current_protocol_version: ProtocolVersion,
-    cache: Option<&dyn CompiledContractCache>,
 ) -> (Option<VMOutcome>, Option<VMError>) {
     #[cfg(feature = "wasmer0_vm")]
     use crate::wasmer_runner::run_wasmer;
@@ -142,7 +111,7 @@ fn run_vm_impl(
             wasm_config,
             fees_config,
             promise_results,
-            profile.cloned(),
+            profile.clone(),
             current_protocol_version,
             cache,
         ),
@@ -158,7 +127,7 @@ fn run_vm_impl(
             wasm_config,
             fees_config,
             promise_results,
-            profile.cloned(),
+            profile.clone(),
             current_protocol_version,
             cache,
         ),
@@ -176,20 +145,19 @@ fn run_vm_impl(
             wasm_config,
             fees_config,
             promise_results,
-            profile.cloned(),
+            profile.clone(),
             current_protocol_version,
             cache,
         ),
         #[cfg(not(feature = "wasmer1_vm"))]
         VMKind::Wasmer1 => panic!("Wasmer1 is not supported, compile with '--features wasmer1_vm'"),
     };
-    if let Some(profile) = profile {
-        if let Some(VMOutcome { burnt_gas, .. }) = &outcome {
-            profile.set_burnt_gas(*burnt_gas)
-        }
+    if let Some(VMOutcome { burnt_gas, .. }) = &outcome {
+        profile.set_burnt_gas(*burnt_gas)
     }
     (outcome, error)
 }
+
 /// `precompile` compiles WASM contract to a VM specific format and stores result into the `cache`.
 /// Further execution with the same cache will result in compilation avoidance and reusing cached
 /// result. `wasm_config` is required as during compilation we decide if gas metering shall be

--- a/runtime/near-vm-runner/src/wasmer1_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer1_runner.rs
@@ -149,7 +149,7 @@ pub fn run_wasmer1<'a>(
     wasm_config: &'a VMConfig,
     fees_config: &'a RuntimeFeesConfig,
     promise_results: &'a [PromiseResult],
-    profile: Option<ProfileData>,
+    profile: ProfileData,
     current_protocol_version: ProtocolVersion,
     cache: Option<&'a dyn CompiledContractCache>,
 ) -> (Option<VMOutcome>, Option<VMError>) {

--- a/runtime/near-vm-runner/src/wasmer_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer_runner.rs
@@ -177,7 +177,7 @@ pub fn run_wasmer<'a>(
     wasm_config: &'a VMConfig,
     fees_config: &'a RuntimeFeesConfig,
     promise_results: &'a [PromiseResult],
-    profile: Option<ProfileData>,
+    profile: ProfileData,
     current_protocol_version: ProtocolVersion,
     cache: Option<&'a dyn CompiledContractCache>,
 ) -> (Option<VMOutcome>, Option<VMError>) {

--- a/runtime/near-vm-runner/src/wasmtime_runner.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner.rs
@@ -120,7 +120,7 @@ pub mod wasmtime_runner {
         wasm_config: &'a VMConfig,
         fees_config: &'a RuntimeFeesConfig,
         promise_results: &'a [PromiseResult],
-        profile: Option<ProfileData>,
+        profile: ProfileData,
         current_protocol_version: ProtocolVersion,
         _cache: Option<&'a dyn CompiledContractCache>,
     ) -> (Option<VMOutcome>, Option<VMError>) {

--- a/runtime/runtime-params-estimator/Cargo.toml
+++ b/runtime/runtime-params-estimator/Cargo.toml
@@ -46,12 +46,7 @@ libc = "0.2.81"
 
 [features]
 default = ["costs_counting"]
-costs_counting = ["near-vm-logic/costs_counting",
-                  "near-vm-runner/costs_counting",
-                  "neard/costs_counting",
-                  "node-runtime/costs_counting",
-                  "testlib/costs_counting",
-                  "near-evm-runner/costs_counting"]
+costs_counting = ["near-vm-logic/costs_counting"]
 # Required feature for proper config, but can't be enabled by default because it is leaked to other release crates.
 required = ["costs_counting", "near-vm-runner/no_cpu_compatibility_checks", "no_cache"]
 no_cache = ["node-runtime/no_cache", "near-store/no_cache"]
@@ -67,7 +62,6 @@ protocol_feature_alt_bn128 = [
     "neard/protocol_feature_alt_bn128",
 ]
 protocol_feature_evm = ["near-evm-runner/protocol_feature_evm",
-                        "near-evm-runner/costs_counting",
                         "near-vm-runner/protocol_feature_evm",
                         "near-chain-configs/protocol_feature_evm",
                         "node-runtime/protocol_feature_evm",

--- a/runtime/runtime-params-estimator/src/testbed.rs
+++ b/runtime/runtime-params-estimator/src/testbed.rs
@@ -93,8 +93,7 @@ impl RuntimeTestbed {
             cache: Some(Arc::new(StoreCompiledContractCache { store: tries.get_store() })),
             #[cfg(feature = "protocol_feature_evm")]
             evm_chain_id: near_chain_configs::TESTNET_EVM_CHAIN_ID,
-            #[cfg(feature = "costs_counting")]
-            profile: None,
+            profile: Default::default(),
         };
         Self {
             workdir,

--- a/runtime/runtime-params-estimator/src/vm_estimator.rs
+++ b/runtime/runtime-params-estimator/src/vm_estimator.rs
@@ -62,8 +62,7 @@ fn call(code: &[u8]) -> (Option<VMOutcome>, Option<VMError>) {
         &promise_results,
         PROTOCOL_VERSION,
         None,
-        #[cfg(feature = "costs_counting")]
-        None,
+        &Default::default(),
     )
 }
 

--- a/runtime/runtime/Cargo.toml
+++ b/runtime/runtime/Cargo.toml
@@ -40,8 +40,6 @@ wasmer1_default = ["wasmer1_vm", "near-vm-logic/wasmer1_default"]
 wasmer0_default = ["wasmer0_vm", "near-vm-logic/wasmer0_default"]
 wasmtime_default = ["wasmtime_vm", "near-vm-logic/wasmtime_default"]
 
-# Use this feature to enable counting of fees and costs applied.
-costs_counting = ["near-vm-logic/costs_counting", "near-vm-runner/costs_counting"]
 no_cpu_compatibility_checks = [ "near-vm-runner/no_cpu_compatibility_checks"]
 
 no_cache = ["near-vm-runner/no_cache", "near-store/no_cache"]

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -143,8 +143,7 @@ pub(crate) fn execute_function_call(
             promise_results,
             apply_state.current_protocol_version,
             cache,
-            #[cfg(feature = "costs_counting")]
-            apply_state.profile.as_ref(),
+            &apply_state.profile,
         )
     }
 }

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1521,8 +1521,7 @@ mod tests {
             cache: Some(Arc::new(StoreCompiledContractCache { store: tries.get_store() })),
             #[cfg(feature = "protocol_feature_evm")]
             evm_chain_id: near_chain_configs::TESTNET_EVM_CHAIN_ID,
-            #[cfg(feature = "costs_counting")]
-            profile: Some(ProfileData::new()),
+            profile: ProfileData::new_enabled(),
         };
 
         (runtime, tries, root, apply_state, signer, MockEpochInfoProvider::default())

--- a/runtime/runtime/src/state_viewer.rs
+++ b/runtime/runtime/src/state_viewer.rs
@@ -144,8 +144,7 @@ impl TrieViewer {
             cache: view_state.cache,
             #[cfg(feature = "protocol_feature_evm")]
             evm_chain_id: view_state.evm_chain_id,
-            #[cfg(feature = "costs_counting")]
-            profile: None,
+            profile: Default::default(),
         };
         let action_receipt = ActionReceipt {
             signer_id: originator_id.clone(),

--- a/runtime/runtime/tests/runtime_group_tools/mod.rs
+++ b/runtime/runtime/tests/runtime_group_tools/mod.rs
@@ -71,8 +71,7 @@ impl StandaloneRuntime {
             cache: None,
             #[cfg(feature = "protocol_feature_evm")]
             evm_chain_id: near_chain_configs::TESTNET_EVM_CHAIN_ID,
-            #[cfg(feature = "costs_counting")]
-            profile: None,
+            profile: Default::default(),
         };
 
         Self {

--- a/test-utils/testlib/Cargo.toml
+++ b/test-utils/testlib/Cargo.toml
@@ -52,4 +52,3 @@ protocol_feature_alt_bn128 = [
     "near-vm-errors/protocol_feature_alt_bn128",
 ]
 protocol_feature_evm = ["near-evm-runner/protocol_feature_evm", "near-primitives/protocol_feature_evm", "neard/protocol_feature_evm", "node-runtime/protocol_feature_evm", "near-chain-configs/protocol_feature_evm", "near-chain/protocol_feature_evm"]
-costs_counting = ["node-runtime/costs_counting", "neard/costs_counting"]

--- a/test-utils/testlib/src/user/runtime_user.rs
+++ b/test-utils/testlib/src/user/runtime_user.rs
@@ -141,8 +141,7 @@ impl RuntimeUser {
             cache: None,
             #[cfg(feature = "protocol_feature_evm")]
             evm_chain_id: TESTNET_EVM_CHAIN_ID,
-            #[cfg(feature = "costs_counting")]
-            profile: None,
+            profile: Default::default(),
         }
     }
 


### PR DESCRIPTION
The goal here is to make sure that only the leaf crates (primitives-core
and vm-logic) and the topmost crate (params-estimator) know about this
feature.

Before this PR, every intermediary crate would have to know about this
feature as well.

To fix this, we encapsulate all conditional compilation logic inside
ProfileData type, while making sure it compiles to no-op unless the
feature is enabled.