### PR TITLE
fix(build): macos not building due {:?} warning

### DIFF
--- a/utils/near-performance-metrics-macros/src/lib.rs
+++ b/utils/near-performance-metrics-macros/src/lib.rs
@@ -115,6 +115,6 @@ fn perf_internal(_attr: TokenStream, item: TokenStream, debug: bool) -> TokenStr
         let output = quote! { #result_item };
         output.into()
     } else {
-        panic!("not a function {:?}");
+        panic!("not a function");
     }
 }


### PR DESCRIPTION
Once we enabled rust flags for denying warnings, macosx build broke due to this panic.