### PR TITLE
refactor: typify MethodUTF8Error out of existence

### DIFF
--- a/runtime/near-vm-errors/src/lib.rs
+++ b/runtime/near-vm-errors/src/lib.rs
@@ -80,7 +80,6 @@ pub enum WasmTrap {
 )]
 pub enum MethodResolveError {
     MethodEmptyName,
-    MethodUTF8Error,
     MethodNotFound,
     MethodInvalidSignature,
 }

--- a/runtime/near-vm-runner-standalone/src/main.rs
+++ b/runtime/near-vm-runner-standalone/src/main.rs
@@ -225,11 +225,8 @@ fn main() {
         fake_external.fake_trie = state.0;
     }
 
-    let method_name = matches
-        .value_of("method-name")
-        .expect("Name of the method must be specified")
-        .as_bytes()
-        .to_vec();
+    let method_name =
+        matches.value_of("method-name").expect("Name of the method must be specified");
 
     let promise_results: Vec<PromiseResult> = matches
         .values_of("promise-results")

--- a/runtime/near-vm-runner/benches/bench.rs
+++ b/runtime/near-vm-runner/benches/bench.rs
@@ -71,7 +71,7 @@ fn pass_through(bench: &mut Bencher) {
         let result = run(
             vec![],
             &code,
-            b"pass_through",
+            "pass_through",
             &mut external,
             context.clone(),
             &config,
@@ -91,7 +91,7 @@ fn benchmark_fake_storage_8b_1000(bench: &mut Bencher) {
         let result = run(
             vec![],
             &code,
-            b"benchmark_storage_8b",
+            "benchmark_storage_8b",
             &mut external,
             context.clone(),
             &config,
@@ -111,7 +111,7 @@ fn benchmark_fake_storage_10kib_1000(bench: &mut Bencher) {
         let result = run(
             vec![],
             &code,
-            b"benchmark_storage_10kib",
+            "benchmark_storage_10kib",
             &mut external,
             context.clone(),
             &config,
@@ -131,7 +131,7 @@ fn sum_n_1000000(bench: &mut Bencher) {
         let result = run(
             vec![],
             &code,
-            b"sum_n",
+            "sum_n",
             &mut external,
             context.clone(),
             &config,

--- a/runtime/near-vm-runner/src/runner.rs
+++ b/runtime/near-vm-runner/src/runner.rs
@@ -22,7 +22,7 @@ use near_vm_logic::{External, VMContext, VMKind, VMOutcome};
 pub fn run<'a>(
     code_hash: Vec<u8>,
     code: &[u8],
-    method_name: &[u8],
+    method_name: &str,
     ext: &mut dyn External,
     context: VMContext,
     wasm_config: &'a VMConfig,
@@ -50,7 +50,7 @@ pub fn run<'a>(
 pub fn run_vm<'a>(
     code_hash: Vec<u8>,
     code: &[u8],
-    method_name: &[u8],
+    method_name: &str,
     ext: &mut dyn External,
     context: VMContext,
     wasm_config: &'a VMConfig,
@@ -80,7 +80,7 @@ pub fn run_vm<'a>(
 pub fn run_vm_profiled<'a>(
     code_hash: Vec<u8>,
     code: &[u8],
-    method_name: &[u8],
+    method_name: &str,
     ext: &mut dyn External,
     context: VMContext,
     wasm_config: &'a VMConfig,

--- a/runtime/near-vm-runner/src/wasmer1_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer1_runner.rs
@@ -143,7 +143,7 @@ fn check_method(module: &Module, method_name: &str) -> Result<(), VMError> {
 pub fn run_wasmer1<'a>(
     code_hash: &[u8],
     code: &[u8],
-    method_name: &[u8],
+    method_name: &str,
     ext: &mut dyn External,
     context: VMContext,
     wasm_config: &'a VMConfig,
@@ -215,18 +215,6 @@ pub fn run_wasmer1<'a>(
     }
     let import_object =
         imports::build_wasmer1(&store, memory_copy, &mut logic, current_protocol_version);
-
-    let method_name = match std::str::from_utf8(method_name) {
-        Ok(x) => x,
-        Err(_) => {
-            return (
-                None,
-                Some(VMError::FunctionCallError(FunctionCallError::MethodResolveError(
-                    MethodResolveError::MethodUTF8Error,
-                ))),
-            )
-        }
-    };
 
     if let Err(e) = check_method(&module, method_name) {
         return (None, Some(e));

--- a/runtime/near-vm-runner/src/wasmer_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer_runner.rs
@@ -171,7 +171,7 @@ impl IntoVMError for wasmer_runtime::error::RuntimeError {
 pub fn run_wasmer<'a>(
     code_hash: &[u8],
     code: &[u8],
-    method_name: &[u8],
+    method_name: &str,
     ext: &mut dyn External,
     context: VMContext,
     wasm_config: &'a VMConfig,
@@ -242,17 +242,6 @@ pub fn run_wasmer<'a>(
 
     let import_object = imports::build_wasmer(memory_copy, &mut logic, current_protocol_version);
 
-    let method_name = match std::str::from_utf8(method_name) {
-        Ok(x) => x,
-        Err(_) => {
-            return (
-                None,
-                Some(VMError::FunctionCallError(FunctionCallError::MethodResolveError(
-                    MethodResolveError::MethodUTF8Error,
-                ))),
-            )
-        }
-    };
     if let Err(e) = check_method(&module, method_name) {
         return (None, Some(e));
     }

--- a/runtime/near-vm-runner/src/wasmtime_runner.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner.rs
@@ -114,7 +114,7 @@ pub mod wasmtime_runner {
     pub fn run_wasmtime<'a>(
         _code_hash: &[u8],
         code: &[u8],
-        method_name: &[u8],
+        method_name: &str,
         ext: &mut dyn External,
         context: VMContext,
         wasm_config: &'a VMConfig,
@@ -163,17 +163,6 @@ pub mod wasmtime_runner {
         // lifetimes of the logic instance and pass raw pointers here.
         let raw_logic = &mut logic as *mut _ as *mut c_void;
         imports::link_wasmtime(&mut linker, memory_copy, raw_logic, current_protocol_version);
-        let func_name = match str::from_utf8(method_name) {
-            Ok(name) => name,
-            Err(_) => {
-                return (
-                    None,
-                    Some(VMError::FunctionCallError(FunctionCallError::MethodResolveError(
-                        MethodResolveError::MethodUTF8Error,
-                    ))),
-                )
-            }
-        };
         if method_name.is_empty() {
             return (
                 None,
@@ -182,7 +171,7 @@ pub mod wasmtime_runner {
                 ))),
             );
         }
-        match module.get_export(func_name) {
+        match module.get_export(method_name) {
             Some(export) => match export {
                 Func(func_type) => {
                     if !func_type.params().is_empty() || !func_type.results().is_empty() {
@@ -215,7 +204,7 @@ pub mod wasmtime_runner {
             }
         }
         match linker.instantiate(&module) {
-            Ok(instance) => match instance.get_func(func_name) {
+            Ok(instance) => match instance.get_func(method_name) {
                 Some(func) => match func.get0::<()>() {
                     Ok(run) => match run() {
                         Ok(_) => (Some(logic.outcome()), None),
@@ -226,7 +215,7 @@ pub mod wasmtime_runner {
                 None => (
                     None,
                     Some(VMError::FunctionCallError(FunctionCallError::MethodResolveError(
-                        MethodResolveError::MethodUTF8Error,
+                        MethodResolveError::MethodNotFound,
                     ))),
                 ),
             },

--- a/runtime/near-vm-runner/tests/test_error_cases.rs
+++ b/runtime/near-vm-runner/tests/test_error_cases.rs
@@ -42,7 +42,7 @@ fn infinite_initializer_contract() -> Vec<u8> {
 fn test_infinite_initializer() {
     with_vm_variants(|vm_kind: VMKind| {
         assert_eq!(
-            make_simple_contract_call_vm(&infinite_initializer_contract(), b"hello", vm_kind),
+            make_simple_contract_call_vm(&infinite_initializer_contract(), "hello", vm_kind),
             (
                 Some(vm_outcome_with_gas(100000000000000)),
                 Some(VMError::FunctionCallError(FunctionCallError::HostError(
@@ -57,7 +57,7 @@ fn test_infinite_initializer() {
 fn test_infinite_initializer_export_not_found() {
     with_vm_variants(|vm_kind: VMKind| {
         assert_eq!(
-            make_simple_contract_call_vm(&infinite_initializer_contract(), b"hello2", vm_kind),
+            make_simple_contract_call_vm(&infinite_initializer_contract(), "hello2", vm_kind),
             (
                 None,
                 Some(VMError::FunctionCallError(FunctionCallError::MethodResolveError(
@@ -84,7 +84,7 @@ fn simple_contract() -> Vec<u8> {
 fn test_simple_contract() {
     with_vm_variants(|vm_kind: VMKind| {
         assert_eq!(
-            make_simple_contract_call_vm(&simple_contract(), b"hello", vm_kind),
+            make_simple_contract_call_vm(&simple_contract(), "hello", vm_kind),
             (Some(vm_outcome_with_gas(43032213)), None),
         );
     });
@@ -94,7 +94,7 @@ fn test_simple_contract() {
 fn test_export_not_found() {
     with_vm_variants(|vm_kind: VMKind| {
         assert_eq!(
-            make_simple_contract_call_vm(&simple_contract(), b"hello2", vm_kind),
+            make_simple_contract_call_vm(&simple_contract(), "hello2", vm_kind),
             (
                 None,
                 Some(VMError::FunctionCallError(FunctionCallError::MethodResolveError(
@@ -109,26 +109,11 @@ fn test_export_not_found() {
 fn test_empty_method() {
     with_vm_variants(|vm_kind: VMKind| {
         assert_eq!(
-            make_simple_contract_call_vm(&simple_contract(), b"", vm_kind),
+            make_simple_contract_call_vm(&simple_contract(), "", vm_kind),
             (
                 None,
                 Some(VMError::FunctionCallError(FunctionCallError::MethodResolveError(
                     MethodResolveError::MethodEmptyName
-                )))
-            )
-        );
-    });
-}
-
-#[test]
-fn test_invalid_utf8() {
-    with_vm_variants(|vm_kind: VMKind| {
-        assert_eq!(
-            make_simple_contract_call_vm(&simple_contract(), &[255u8], vm_kind),
-            (
-                None,
-                Some(VMError::FunctionCallError(FunctionCallError::MethodResolveError(
-                    MethodResolveError::MethodUTF8Error
                 )))
             )
         );
@@ -153,14 +138,14 @@ fn test_trap_contract() {
     with_vm_variants(|vm_kind: VMKind| match vm_kind {
         VMKind::Wasmtime => return,
         VMKind::Wasmer0 => assert_eq!(
-            make_simple_contract_call_vm(&trap_contract(), b"hello", vm_kind),
+            make_simple_contract_call_vm(&trap_contract(), "hello", vm_kind),
             (
                 Some(vm_outcome_with_gas(47105334)),
                 Some(VMError::FunctionCallError(FunctionCallError::WasmUnknownError))
             )
         ),
         VMKind::Wasmer1 => assert_eq!(
-            make_simple_contract_call_vm(&trap_contract(), b"hello", vm_kind),
+            make_simple_contract_call_vm(&trap_contract(), "hello", vm_kind),
             (
                 Some(vm_outcome_with_gas(47105334)),
                 Some(VMError::FunctionCallError(FunctionCallError::Wasmer1Trap(
@@ -190,14 +175,14 @@ fn test_trap_initializer() {
     with_vm_variants(|vm_kind: VMKind| match vm_kind {
         VMKind::Wasmtime => return,
         VMKind::Wasmer0 => assert_eq!(
-            make_simple_contract_call_vm(&trap_initializer(), b"hello", vm_kind),
+            make_simple_contract_call_vm(&trap_initializer(), "hello", vm_kind),
             (
                 Some(vm_outcome_with_gas(47755584)),
                 Some(VMError::FunctionCallError(FunctionCallError::WasmUnknownError))
             )
         ),
         VMKind::Wasmer1 => assert_eq!(
-            make_simple_contract_call_vm(&trap_initializer(), b"hello", vm_kind),
+            make_simple_contract_call_vm(&trap_initializer(), "hello", vm_kind),
             (
                 Some(vm_outcome_with_gas(47755584)),
                 Some(VMError::FunctionCallError(FunctionCallError::Wasmer1Trap(
@@ -224,7 +209,7 @@ fn wrong_signature_contract() -> Vec<u8> {
 fn test_wrong_signature_contract() {
     with_vm_variants(|vm_kind: VMKind| {
         assert_eq!(
-            make_simple_contract_call_vm(&wrong_signature_contract(), b"hello", vm_kind),
+            make_simple_contract_call_vm(&wrong_signature_contract(), "hello", vm_kind),
             (
                 None,
                 Some(VMError::FunctionCallError(FunctionCallError::MethodResolveError(
@@ -250,7 +235,7 @@ fn export_wrong_type() -> Vec<u8> {
 fn test_export_wrong_type() {
     with_vm_variants(|vm_kind: VMKind| {
         assert_eq!(
-            make_simple_contract_call_vm(&export_wrong_type(), b"hello", vm_kind),
+            make_simple_contract_call_vm(&export_wrong_type(), "hello", vm_kind),
             (
                 None,
                 Some(VMError::FunctionCallError(FunctionCallError::MethodResolveError(
@@ -278,7 +263,7 @@ fn guest_panic() -> Vec<u8> {
 fn test_guest_panic() {
     with_vm_variants(|vm_kind: VMKind| {
         assert_eq!(
-            make_simple_contract_call_vm(&guest_panic(), b"hello", vm_kind),
+            make_simple_contract_call_vm(&guest_panic(), "hello", vm_kind),
             (
                 Some(vm_outcome_with_gas(315341445)),
                 Some(VMError::FunctionCallError(FunctionCallError::HostError(
@@ -308,14 +293,14 @@ fn test_stack_overflow() {
         // Wasmer signal handlers may catch signals thrown from the Wasmtime, and produce fake failing tests.
         match vm_kind {
             VMKind::Wasmer0 => assert_eq!(
-                make_simple_contract_call_vm(&stack_overflow(), b"hello", vm_kind),
+                make_simple_contract_call_vm(&stack_overflow(), "hello", vm_kind),
                 (
                     Some(vm_outcome_with_gas(63226248177)),
                     Some(VMError::FunctionCallError(FunctionCallError::WasmUnknownError))
                 )
             ),
             VMKind::Wasmer1 => assert_eq!(
-                make_simple_contract_call_vm(&stack_overflow(), b"hello", vm_kind),
+                make_simple_contract_call_vm(&stack_overflow(), "hello", vm_kind),
                 (
                     Some(vm_outcome_with_gas(63226248177)),
                     Some(VMError::FunctionCallError(FunctionCallError::Wasmer1Trap(
@@ -351,7 +336,7 @@ fn memory_grow() -> Vec<u8> {
 fn test_memory_grow() {
     with_vm_variants(|vm_kind: VMKind| {
         assert_eq!(
-            make_simple_contract_call_vm(&memory_grow(), b"hello", vm_kind),
+            make_simple_contract_call_vm(&memory_grow(), "hello", vm_kind),
             (
                 Some(vm_outcome_with_gas(100000000000000)),
                 Some(VMError::FunctionCallError(FunctionCallError::HostError(
@@ -397,7 +382,7 @@ fn bad_import_func(env: &str) -> Vec<u8> {
 fn test_bad_import_1() {
     with_vm_variants(|vm_kind: VMKind| {
         assert_eq!(
-            make_simple_contract_call_vm(&bad_import_global("wtf"), b"hello", vm_kind),
+            make_simple_contract_call_vm(&bad_import_global("wtf"), "hello", vm_kind),
             (
                 None,
                 Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
@@ -412,7 +397,7 @@ fn test_bad_import_1() {
 fn test_bad_import_2() {
     with_vm_variants(|vm_kind: VMKind| {
         assert_eq!(
-            make_simple_contract_call_vm(&bad_import_func("wtf"), b"hello", vm_kind),
+            make_simple_contract_call_vm(&bad_import_func("wtf"), "hello", vm_kind),
             (
                 None,
                 Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
@@ -432,7 +417,7 @@ fn test_bad_import_3() {
             VMKind::Wasmer1 => "Error while importing \"env\".\"input\": incompatible import type. Expected Global(GlobalType { ty: I32, mutability: Const }) but received Function(FunctionType { params: [I64], results: [] })"
         }.to_string();
         assert_eq!(
-            make_simple_contract_call_vm(&bad_import_global("env"), b"hello", vm_kind),
+            make_simple_contract_call_vm(&bad_import_global("env"), "hello", vm_kind),
             (
                 Some(vm_outcome_with_gas(46500213)),
                 Some(VMError::FunctionCallError(FunctionCallError::LinkError { msg: msg }))
@@ -451,7 +436,7 @@ fn test_bad_import_4() {
         }
         .to_string();
         assert_eq!(
-            make_simple_contract_call_vm(&bad_import_func("env"), b"hello", vm_kind),
+            make_simple_contract_call_vm(&bad_import_func("env"), "hello", vm_kind),
             (
                 Some(vm_outcome_with_gas(45849963)),
                 Some(VMError::FunctionCallError(FunctionCallError::LinkError { msg: msg }))
@@ -479,7 +464,7 @@ fn test_initializer_no_gas() {
         assert_eq!(
             make_simple_contract_call_with_gas_vm(
                 &some_initializer_contract(),
-                b"hello",
+                "hello",
                 0,
                 vm_kind
             ),
@@ -518,7 +503,7 @@ fn bad_many_imports() -> Vec<u8> {
 #[test]
 fn test_bad_many_imports() {
     with_vm_variants(|vm_kind: VMKind| {
-        let result = make_simple_contract_call_vm(&bad_many_imports(), b"hello", vm_kind);
+        let result = make_simple_contract_call_vm(&bad_many_imports(), "hello", vm_kind);
         assert_eq!(result.0, Some(vm_outcome_with_gas(299664213)));
         if let Some(VMError::FunctionCallError(FunctionCallError::LinkError { msg })) = result.1 {
             eprintln!("{}", msg);
@@ -547,7 +532,7 @@ fn external_call_contract() -> Vec<u8> {
 fn test_external_call_ok() {
     with_vm_variants(|vm_kind: VMKind| {
         assert_eq!(
-            make_simple_contract_call_vm(&external_call_contract(), b"hello", vm_kind),
+            make_simple_contract_call_vm(&external_call_contract(), "hello", vm_kind),
             (Some(vm_outcome_with_gas(321582066)), None)
         );
     });
@@ -557,12 +542,7 @@ fn test_external_call_ok() {
 fn test_external_call_error() {
     with_vm_variants(|vm_kind: VMKind| {
         assert_eq!(
-            make_simple_contract_call_with_gas_vm(
-                &external_call_contract(),
-                b"hello",
-                100,
-                vm_kind
-            ),
+            make_simple_contract_call_with_gas_vm(&external_call_contract(), "hello", 100, vm_kind),
             (
                 Some(vm_outcome_with_gas(100)),
                 Some(VMError::FunctionCallError(FunctionCallError::HostError(
@@ -585,11 +565,11 @@ fn test_contract_error_caching() {
         let terragas = 1000000000000u64;
         assert_eq!(cache.store.lock().unwrap().len(), 0);
         let err1 =
-            make_cached_contract_call_vm(&mut cache, &code, b"method_name1", terragas, vm_kind);
+            make_cached_contract_call_vm(&mut cache, &code, "method_name1", terragas, vm_kind);
         println!("{:?}", cache.store.lock().unwrap());
         assert_eq!(cache.store.lock().unwrap().len(), 1);
         let err2 =
-            make_cached_contract_call_vm(&mut cache, &code, b"method_name2", terragas, vm_kind);
+            make_cached_contract_call_vm(&mut cache, &code, "method_name2", terragas, vm_kind);
         assert_eq!(err1, err2);
     })
 }

--- a/runtime/near-vm-runner/tests/test_invalid_contracts.rs
+++ b/runtime/near-vm-runner/tests/test_invalid_contracts.rs
@@ -22,11 +22,7 @@ fn initializer_wrong_signature_contract() -> Vec<u8> {
 fn test_initializer_wrong_signature_contract() {
     with_vm_variants(|vm_kind: VMKind| {
         assert_eq!(
-            make_simple_contract_call_vm(
-                &initializer_wrong_signature_contract(),
-                b"hello",
-                vm_kind
-            ),
+            make_simple_contract_call_vm(&initializer_wrong_signature_contract(), "hello", vm_kind),
             (
                 None,
                 Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
@@ -51,7 +47,7 @@ fn function_not_defined_contract() -> Vec<u8> {
 fn test_function_not_defined_contract() {
     with_vm_variants(|vm_kind: VMKind| {
         assert_eq!(
-            make_simple_contract_call_vm(&function_not_defined_contract(), b"hello", vm_kind),
+            make_simple_contract_call_vm(&function_not_defined_contract(), "hello", vm_kind),
             (
                 None,
                 Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
@@ -77,7 +73,7 @@ fn function_type_not_defined_contract(bad_type: u64) -> Vec<u8> {
 fn test_function_type_not_defined_contract_1() {
     with_vm_variants(|vm_kind: VMKind| {
         assert_eq!(
-            make_simple_contract_call_vm(&function_type_not_defined_contract(1), b"hello", vm_kind),
+            make_simple_contract_call_vm(&function_type_not_defined_contract(1), "hello", vm_kind),
             (
                 None,
                 Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
@@ -93,7 +89,7 @@ fn test_function_type_not_defined_contract_1() {
 fn test_function_type_not_defined_contract_2() {
     with_vm_variants(|vm_kind: VMKind| {
         assert_eq!(
-            make_simple_contract_call_vm(&function_type_not_defined_contract(0), b"hello", vm_kind),
+            make_simple_contract_call_vm(&function_type_not_defined_contract(0), "hello", vm_kind),
             (
                 None,
                 Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
@@ -108,7 +104,7 @@ fn test_function_type_not_defined_contract_2() {
 fn test_garbage_contract() {
     with_vm_variants(|vm_kind: VMKind| {
         assert_eq!(
-            make_simple_contract_call_vm(&[], b"hello", vm_kind),
+            make_simple_contract_call_vm(&[], "hello", vm_kind),
             (
                 None,
                 Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
@@ -135,7 +131,7 @@ fn evil_function_index() -> Vec<u8> {
 fn test_evil_function_index() {
     with_vm_variants(|vm_kind: VMKind| {
         assert_eq!(
-            make_simple_contract_call_vm(&evil_function_index(), b"abort_with_zero", vm_kind),
+            make_simple_contract_call_vm(&evil_function_index(), "abort_with_zero", vm_kind),
             (
                 None,
                 Some(VMError::FunctionCallError(FunctionCallError::CompilationError(

--- a/runtime/near-vm-runner/tests/test_rs_contract.rs
+++ b/runtime/near-vm-runner/tests/test_rs_contract.rs
@@ -68,7 +68,7 @@ pub fn test_read_write() {
         let result = run_vm(
             vec![],
             &code,
-            b"write_key_value",
+            "write_key_value",
             &mut fake_external,
             context,
             &config,
@@ -84,7 +84,7 @@ pub fn test_read_write() {
         let result = run_vm(
             vec![],
             &code,
-            b"read_value",
+            "read_value",
             &mut fake_external,
             context,
             &config,
@@ -126,7 +126,7 @@ macro_rules! def_test_ext {
 }
 
 fn run_test_ext(
-    method: &[u8],
+    method: &str,
     expected: &[u8],
     input: &[u8],
     validators: Vec<(&str, Balance)>,
@@ -168,28 +168,28 @@ fn run_test_ext(
     }
 }
 
-def_test_ext!(ext_account_id, b"ext_account_id", CURRENT_ACCOUNT_ID.as_bytes());
+def_test_ext!(ext_account_id, "ext_account_id", CURRENT_ACCOUNT_ID.as_bytes());
 
-def_test_ext!(ext_signer_id, b"ext_signer_id", SIGNER_ACCOUNT_ID.as_bytes());
+def_test_ext!(ext_signer_id, "ext_signer_id", SIGNER_ACCOUNT_ID.as_bytes());
 def_test_ext!(
     ext_predecessor_account_id,
-    b"ext_predecessor_account_id",
+    "ext_predecessor_account_id",
     PREDECESSOR_ACCOUNT_ID.as_bytes(),
     &[]
 );
-def_test_ext!(ext_signer_pk, b"ext_signer_pk", &SIGNER_ACCOUNT_PK);
-def_test_ext!(ext_random_seed, b"ext_random_seed", &[0, 1, 2]);
+def_test_ext!(ext_signer_pk, "ext_signer_pk", &SIGNER_ACCOUNT_PK);
+def_test_ext!(ext_random_seed, "ext_random_seed", &[0, 1, 2]);
 
-def_test_ext!(ext_prepaid_gas, b"ext_prepaid_gas", &(10_u64.pow(14)).to_le_bytes());
-def_test_ext!(ext_block_index, b"ext_block_index", &10u64.to_le_bytes());
-def_test_ext!(ext_block_timestamp, b"ext_block_timestamp", &42u64.to_le_bytes());
-def_test_ext!(ext_storage_usage, b"ext_storage_usage", &12u64.to_le_bytes());
+def_test_ext!(ext_prepaid_gas, "ext_prepaid_gas", &(10_u64.pow(14)).to_le_bytes());
+def_test_ext!(ext_block_index, "ext_block_index", &10u64.to_le_bytes());
+def_test_ext!(ext_block_timestamp, "ext_block_timestamp", &42u64.to_le_bytes());
+def_test_ext!(ext_storage_usage, "ext_storage_usage", &12u64.to_le_bytes());
 // Note, the used_gas is not a global used_gas at the beginning of method, but instead a diff
 // in used_gas for computing fib(30) in a loop
-def_test_ext!(ext_used_gas, b"ext_used_gas", &[111, 10, 200, 15, 0, 0, 0, 0]);
+def_test_ext!(ext_used_gas, "ext_used_gas", &[111, 10, 200, 15, 0, 0, 0, 0]);
 def_test_ext!(
     ext_sha256,
-    b"ext_sha256",
+    "ext_sha256",
     &[
         18, 176, 115, 156, 45, 100, 241, 132, 180, 134, 77, 42, 105, 111, 199, 127, 118, 112, 92,
         255, 88, 43, 83, 147, 122, 55, 26, 36, 42, 156, 160, 158,
@@ -197,26 +197,26 @@ def_test_ext!(
     b"tesdsst"
 );
 // current_account_balance = context.account_balance + context.attached_deposit;
-def_test_ext!(ext_account_balance, b"ext_account_balance", &(2u128 + 2).to_le_bytes());
-def_test_ext!(ext_attached_deposit, b"ext_attached_deposit", &2u128.to_le_bytes());
+def_test_ext!(ext_account_balance, "ext_account_balance", &(2u128 + 2).to_le_bytes());
+def_test_ext!(ext_attached_deposit, "ext_attached_deposit", &2u128.to_le_bytes());
 
 def_test_ext!(
     ext_validator_stake_alice,
-    b"ext_validator_stake",
+    "ext_validator_stake",
     &(100u128).to_le_bytes(),
     b"alice",
     vec![("alice", 100), ("bob", 1)]
 );
 def_test_ext!(
     ext_validator_stake_bob,
-    b"ext_validator_stake",
+    "ext_validator_stake",
     &(1u128).to_le_bytes(),
     b"bob",
     vec![("alice", 100), ("bob", 1)]
 );
 def_test_ext!(
     ext_validator_stake_carol,
-    b"ext_validator_stake",
+    "ext_validator_stake",
     &(0u128).to_le_bytes(),
     b"carol",
     vec![("alice", 100), ("bob", 1)]
@@ -224,7 +224,7 @@ def_test_ext!(
 
 def_test_ext!(
     ext_validator_total_stake,
-    b"ext_validator_total_stake",
+    "ext_validator_total_stake",
     &(100u128 + 1).to_le_bytes(),
     &[],
     vec![("alice", 100), ("bob", 1)]
@@ -233,7 +233,7 @@ def_test_ext!(
 #[cfg(feature = "protocol_feature_alt_bn128")]
 def_test_ext!(
     ext_alt_bn128_pairing_check,
-    b"ext_alt_bn128_pairing_check",
+    "ext_alt_bn128_pairing_check",
     &[1],
     &base64::decode("AgAAAHUK2WNxTupDt1oaOshWw3squNVY4PgSyGwGtQYcEWMHJIY1c8C0A3FM466TMq5PSpfDrArT0hpcdfZB7ahoEAQBGgPbBg3Bc03mGw3y1sMJ1WOHDKDKcoevKnSsT+oaKdRvwIF8cDlrJvTm3vAkQe6FvBMrlDvNKKGzreRYqecdEUOjM6W7ZSz6GERlXIDLvjNVCSs6iES0XG65qGuBLR67FmQRS13YfRfUC7rHzAGMhQtSLEHeFBowGoTcGdVdGU+wBJWX8wuD/el5Jt4PdnXI1q/pgrXBp/+ZqfDP6xwfU0pFswaWSENKpoJTUnN7b9DdQCvt1brrBzj7s1/pnxdtrVVnCKXr4tpPSHis+xRTecmMYqr2edoTcyqHPO8eIDGqq8zExaCeqC8Xbot73t71Yn3QRiduupL+Qrl2A04gL7PFXU/wzE7shdWtdV4/mkRZ7IoA9/LU9SH5ACP26QB8VsaiyTYTGsRL/kdG7jMCF7mYi4ZBa4Fy9C/78FDBFw==").unwrap()
 );
@@ -241,7 +241,7 @@ def_test_ext!(
 #[cfg(feature = "protocol_feature_alt_bn128")]
 def_test_ext!(
     ext_alt_bn128_g1_sum,
-    b"ext_alt_bn128_g1_sum",
+    "ext_alt_bn128_g1_sum",
     &base64::decode("6I9NGC6Ikzk7Xw/CIippAtOEsTx4TodcXRjzzu5TLh4EIPsrWPsfnQMtqKfMMF+SHgSphZseRKyej9jTVCT8Aw==").unwrap(),
     &base64::decode("AgAAAADs00QWBTHQDDU1J1FtsDVGC5rDTICkFAtdvqNcFVO0EsRf4pf1kU9yNWyaj2ligWxqnoZGLtEEu3Ldp8+dgkQpAT+SS7pJZ4ql4b8tnwGv8W020cyHrmLCU15/Hp+LLCsDb34dEXKnY0BG4EoWCfaLdEAFcmAKKBbqXEqkAlbaTDA=").unwrap()
 );
@@ -249,7 +249,7 @@ def_test_ext!(
 #[cfg(feature = "protocol_feature_alt_bn128")]
 def_test_ext!(
     ext_alt_bn128_g1_multiexp,
-    b"ext_alt_bn128_g1_multiexp",
+    "ext_alt_bn128_g1_multiexp",
     &base64::decode("qoK67D1yppH5iP0qhCrD8Ms+idcZtEry4EegUtSpIylhCyZNbRQ0xVdRe9hQBxZIovzCMwFRMAdcZ5FB+QA6Lg==").unwrap(),
     &base64::decode("AgAAAOzTRBYFMdAMNTUnUW2wNUYLmsNMgKQUC12+o1wVU7QSxF/il/WRT3I1bJqPaWKBbGqehkYu0QS7ct2nz52CRCn3EXSIf0p4ORYJ7mRmZLWtUyGrqlKl/4DNx2kHDEUrET+SS7pJZ4ql4b8tnwGv8W020cyHrmLCU15/Hp+LLCsD2H5fx6TkvPtG6iZSiHT1Ih1TDyGsHTrOzFWN3hx0FwAaB2tgYeH+WuEKReDHNFmxyi8v597Ji5NP4PU8bZXkGQ==").unwrap()
 );
@@ -274,7 +274,7 @@ pub fn test_out_of_memory() {
         let result = run_vm(
             vec![],
             &code,
-            b"out_of_memory",
+            "out_of_memory",
             &mut fake_external,
             context,
             &config,

--- a/runtime/near-vm-runner/tests/test_ts_contract.rs
+++ b/runtime/near-vm-runner/tests/test_ts_contract.rs
@@ -30,7 +30,7 @@ pub fn test_ts_contract() {
         let result = run_vm(
             vec![],
             &code,
-            b"try_panic",
+            "try_panic",
             &mut fake_external,
             context,
             &config,
@@ -52,7 +52,7 @@ pub fn test_ts_contract() {
         run_vm(
             vec![],
             &code,
-            b"try_storage_write",
+            "try_storage_write",
             &mut fake_external,
             context,
             &config,
@@ -78,7 +78,7 @@ pub fn test_ts_contract() {
         let result = run_vm(
             vec![],
             &code,
-            b"try_storage_read",
+            "try_storage_read",
             &mut fake_external,
             context,
             &config,

--- a/runtime/near-vm-runner/tests/test_utils/mod.rs
+++ b/runtime/near-vm-runner/tests/test_utils/mod.rs
@@ -43,7 +43,7 @@ pub fn create_context(input: Vec<u8>) -> VMContext {
 
 pub fn make_simple_contract_call_with_gas_vm(
     code: &[u8],
-    method_name: &[u8],
+    method_name: &str,
     prepaid_gas: u64,
     vm_kind: VMKind,
 ) -> (Option<VMOutcome>, Option<VMError>) {
@@ -75,7 +75,7 @@ pub fn make_simple_contract_call_with_gas_vm(
 
 pub fn make_simple_contract_call_with_gas(
     code: &[u8],
-    method_name: &[u8],
+    method_name: &str,
     prepaid_gas: u64,
 ) -> (Option<VMOutcome>, Option<VMError>) {
     make_simple_contract_call_with_gas_vm(code, method_name, prepaid_gas, VMKind::default())
@@ -83,14 +83,14 @@ pub fn make_simple_contract_call_with_gas(
 
 pub fn make_simple_contract_call(
     code: &[u8],
-    method_name: &[u8],
+    method_name: &str,
 ) -> (Option<VMOutcome>, Option<VMError>) {
     make_simple_contract_call_with_gas(code, method_name, 10u64.pow(14))
 }
 
 pub fn make_simple_contract_call_vm(
     code: &[u8],
-    method_name: &[u8],
+    method_name: &str,
     vm_kind: VMKind,
 ) -> (Option<VMOutcome>, Option<VMError>) {
     make_simple_contract_call_with_gas_vm(code, method_name, 10u64.pow(14), vm_kind)
@@ -121,7 +121,7 @@ impl CompiledContractCache for MockCompiledContractCache {
 pub fn make_cached_contract_call_vm(
     cache: &mut dyn CompiledContractCache,
     code: &[u8],
-    method_name: &[u8],
+    method_name: &str,
     prepaid_gas: u64,
     vm_kind: VMKind,
 ) -> (Option<VMOutcome>, Option<VMError>) {

--- a/runtime/runtime-params-estimator/src/vm_estimator.rs
+++ b/runtime/runtime-params-estimator/src/vm_estimator.rs
@@ -54,7 +54,7 @@ fn call(code: &[u8]) -> (Option<VMOutcome>, Option<VMError>) {
     near_vm_runner::run(
         code_hash,
         code,
-        b"cpu_ram_soak_test",
+        "cpu_ram_soak_test",
         &mut fake_external,
         context,
         &config,

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -135,7 +135,7 @@ pub(crate) fn execute_function_call(
         near_vm_runner::run(
             code.hash.as_ref().to_vec(),
             &code.code,
-            function_call.method_name.as_bytes(),
+            &function_call.method_name,
             runtime_ext,
             context,
             &config.wasm_config,


### PR DESCRIPTION
runtime actually stores method name as `String`, so we have a static
proof that utf8 validation already happened.

Wasm import/export tables are specked to use utf8, so we don't need to
worry about supporting non-utf8 even in theory.