### PR TITLE
refactor: cleanup sanity checks CI step

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -28,7 +28,7 @@ steps:
       if [ -e deny.toml ]; then
         cargo-deny --all-features check bans
       fi
-      RUSTFLAGS='-D warnings' cargo check --all --tests --benches --all-features
+      RUSTFLAGS='-D warnings' cargo check --workspace --all-targets --all-features
       python3 scripts/state/update_res.py check
       python3 scripts/check_nightly.py
     timeout: 30


### PR DESCRIPTION
* `--all` is deprecated in favor of `--workspace`
* `--all-targets` is even better than `--tests` and `--benches`