### PR TITLE
fix: Fixing an error in cross_shard_tx

### DIFF
--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -68,6 +68,7 @@ pub struct KeyValueRuntime {
     validator_groups: u64,
     num_shards: NumShards,
     epoch_length: u64,
+    no_gc: bool,
 
     // A mapping state_root => {account id => amounts}, for transactions and receipts
     state: RwLock<HashMap<StateRoot, KVState>>,
@@ -108,6 +109,24 @@ impl KeyValueRuntime {
         validator_groups: u64,
         num_shards: NumShards,
         epoch_length: u64,
+    ) -> Self {
+        Self::new_with_validators_and_no_gc(
+            store,
+            validators,
+            validator_groups,
+            num_shards,
+            epoch_length,
+            false,
+        )
+    }
+
+    pub fn new_with_validators_and_no_gc(
+        store: Arc<Store>,
+        validators: Vec<Vec<AccountId>>,
+        validator_groups: u64,
+        num_shards: NumShards,
+        epoch_length: u64,
+        no_gc: bool,
     ) -> Self {
         let tries = ShardTries::new(store.clone(), num_shards);
         let mut initial_amounts = HashMap::new();
@@ -163,6 +182,7 @@ impl KeyValueRuntime {
             hash_to_next_epoch: RwLock::new(map_with_default_hash1),
             hash_to_valset: RwLock::new(map_with_default_hash3),
             epoch_start: RwLock::new(map_with_default_hash2),
+            no_gc,
         }
     }
 
@@ -918,12 +938,16 @@ impl RuntimeAdapter for KeyValueRuntime {
     }
 
     fn get_gc_stop_height(&self, block_hash: &CryptoHash) -> BlockHeight {
-        let block_height = self
-            .get_block_header(block_hash)
-            .unwrap_or_default()
-            .map(|h| h.height())
-            .unwrap_or_default();
-        block_height.saturating_sub(NUM_EPOCHS_TO_KEEP_STORE_DATA * self.epoch_length)
+        if !self.no_gc {
+            let block_height = self
+                .get_block_header(block_hash)
+                .unwrap_or_default()
+                .map(|h| h.height())
+                .unwrap_or_default();
+            block_height.saturating_sub(NUM_EPOCHS_TO_KEEP_STORE_DATA * self.epoch_length)
+        } else {
+            0
+        }
     }
 
     fn epoch_exists(&self, epoch_id: &EpochId) -> bool {

--- a/chain/client/src/sync.rs
+++ b/chain/client/src/sync.rs
@@ -431,9 +431,7 @@ impl BlockSync {
                         }
                     }
                     Err(e) => match e.kind() {
-                        near_chain::ErrorKind::DBNotFoundErr(_) => {
-                            break;
-                        }
+                        near_chain::ErrorKind::DBNotFoundErr(_) => break,
                         _ => return Err(e),
                     },
                 }

--- a/chain/client/src/sync.rs
+++ b/chain/client/src/sync.rs
@@ -400,6 +400,49 @@ impl BlockSync {
             _ => chain.head()?.last_block_hash,
         };
 
+        let reference_hash = {
+            // Find the most recent block we known on the canonical chain.
+            // In practice the forks from the last final block are very short, so it is
+            // acceptable to perform this on each request
+            let header = chain.get_block_header(&reference_hash)?;
+            let mut candidate = (header.height(), *header.hash(), *header.prev_hash());
+
+            // First go back until we find the common block
+            while match chain.get_header_by_height(candidate.0) {
+                Ok(header) => header.hash() != &candidate.1,
+                Err(e) => match e.kind() {
+                    near_chain::ErrorKind::DBNotFoundErr(_) => true,
+                    _ => return Err(e),
+                },
+            } {
+                let prev_header = chain.get_block_header(&candidate.2)?;
+                candidate = (prev_header.height(), *prev_header.hash(), *prev_header.prev_hash());
+            }
+
+            // Then go forward for as long as we known the next block
+            let mut ret_hash = candidate.1;
+            loop {
+                match chain.mut_store().get_next_block_hash(&ret_hash) {
+                    Ok(hash) => {
+                        let hash = hash.clone();
+                        if chain.block_exists(&hash)? {
+                            ret_hash = hash;
+                        } else {
+                            break;
+                        }
+                    }
+                    Err(e) => match e.kind() {
+                        near_chain::ErrorKind::DBNotFoundErr(_) => {
+                            break;
+                        }
+                        _ => return Err(e),
+                    },
+                }
+            }
+
+            ret_hash
+        };
+
         let next_hash = match chain.mut_store().get_next_block_hash(&reference_hash) {
             Ok(hash) => *hash,
             Err(e) => match e.kind() {

--- a/chain/client/src/sync.rs
+++ b/chain/client/src/sync.rs
@@ -424,9 +424,8 @@ impl BlockSync {
             loop {
                 match chain.mut_store().get_next_block_hash(&ret_hash) {
                     Ok(hash) => {
-                        let hash = hash.clone();
-                        if chain.block_exists(&hash)? {
-                            ret_hash = hash;
+                        if chain.block_exists(hash)? {
+                            ret_hash = hash.clone();
                         } else {
                             break;
                         }

--- a/chain/client/src/sync.rs
+++ b/chain/client/src/sync.rs
@@ -424,8 +424,9 @@ impl BlockSync {
             loop {
                 match chain.mut_store().get_next_block_hash(&ret_hash) {
                     Ok(hash) => {
-                        if chain.block_exists(hash)? {
-                            ret_hash = hash.clone();
+                        let hash = hash.clone();
+                        if chain.block_exists(&hash)? {
+                            ret_hash = hash;
                         } else {
                             break;
                         }

--- a/chain/client/src/sync.rs
+++ b/chain/client/src/sync.rs
@@ -401,7 +401,7 @@ impl BlockSync {
         };
 
         let reference_hash = {
-            // Find the most recent block we known on the canonical chain.
+            // Find the most recent block we know on the canonical chain.
             // In practice the forks from the last final block are very short, so it is
             // acceptable to perform this on each request
             let header = chain.get_block_header(&reference_hash)?;

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -72,12 +72,13 @@ pub fn setup(
 ) -> (Block, ClientActor, Addr<ViewClientActor>) {
     let store = create_test_store();
     let num_validator_seats = validators.iter().map(|x| x.len()).sum::<usize>() as NumSeats;
-    let runtime = Arc::new(KeyValueRuntime::new_with_validators(
+    let runtime = Arc::new(KeyValueRuntime::new_with_validators_and_no_gc(
         store,
         validators.into_iter().map(|inner| inner.into_iter().map(Into::into).collect()).collect(),
         validator_groups,
         num_shards,
         epoch_length,
+        archive,
     ));
     let chain_genesis = ChainGenesis {
         time: genesis_time,
@@ -460,7 +461,7 @@ pub fn setup_mock_all_validators(
                                     },
                                     height: last_height2[i],
                                     tracked_shards: vec![],
-                                    archival: false,
+                                    archival: true,
                                 },
                                 edge_info: EdgeInfo::default(),
                             })

--- a/chain/client/tests/cross_shard_tx.rs
+++ b/chain/client/tests/cross_shard_tx.rs
@@ -471,7 +471,9 @@ mod tests {
                 let account_id1 = flat_validators[i].clone();
                 let block_stats1 = block_stats.clone();
                 actix::spawn(
-                    connectors_[i + *presumable_epoch.read().unwrap() * 8]
+                    connectors_[account_id_to_shard_id(&flat_validators[i].to_string(), 8)
+                        as usize
+                        + *presumable_epoch.read().unwrap() * 8]
                         .1
                         .send(Query::new(
                             BlockReference::latest(),
@@ -513,7 +515,7 @@ mod tests {
 
     #[test]
     fn test_cross_shard_tx() {
-        test_cross_shard_tx_common(64, false, false, false, 80, Some(2.4), None);
+        test_cross_shard_tx_common(64, false, false, false, 70, Some(2.3), None);
     }
 
     #[test]


### PR DESCRIPTION
There were several issues, of which one is an actual bug.

The bug was my regression in the latest rewrite of the block sync: if
the current head is not on the canonical header chain, the block sync
would continuously try to fetch a block that build on top of the current
head, which is not what needs to be fetched. This is the main fix in
this change (changes in sync.rs)

The smaller issues fixed:
a) With the recent changes the node became faster, and 80ms was no longer
adequate for the acceptable forkfulness. Changed to 70ms. With 70 the
forkfulness sometimes was below 2.4, but reducing the timeout below 70
was sometimes resulting in nodes not being able to keep up, so I had to
decrease the min forkfulness to 2.3.
b) There was a bug that was querying the balance at the very start of
the test from a wrong node. In the past it was working because the query
was processed before the first block was produced, and all nodes can
respond to any queries on the genesis state. But with the changes making
the node faster the first block now was produced before some queries
were processed, and the query could not be properly processed.
c) The nodes were configured to report each other as non-archival,
resulting in them not having any viable peers to request older blocks.
d) `gc_stop_height` was five epochs behind, while the test sometimes
generates forks longer than that, making it impossible to apply blocks.
Changing it to return 0 in `KeyValueRuntime`.

Test plan
---------
http://nayduck.eastus.cloudapp.azure.com:3000/#/run/1202