### PR TITLE
feat(chain): Epoch Sync / GC Headers skeleton

### DIFF
--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 use borsh::{BorshDeserialize, BorshSerialize};
 use cached::{Cached, SizedCache};
 use chrono::Utc;
-use tracing::debug;
 
 use near_chain_primitives::error::{Error, ErrorKind};
 use near_primitives::block::{Approval, Tip};
@@ -37,14 +36,15 @@ use near_store::{
     read_with_cache, ColBlock, ColBlockExtra, ColBlockHeader, ColBlockHeight, ColBlockInfo,
     ColBlockMerkleTree, ColBlockMisc, ColBlockOrdinal, ColBlockPerHeight, ColBlockRefCount,
     ColBlocksToCatchup, ColChallengedBlocks, ColChunkExtra, ColChunkHashesByHeight,
-    ColChunkPerHeightShard, ColChunks, ColEpochLightClientBlocks, ColGCCount, ColIncomingReceipts,
-    ColInvalidChunks, ColLastBlockWithNewChunk, ColNextBlockHashes, ColNextBlockWithNewChunk,
-    ColOutcomeIds, ColOutgoingReceipts, ColPartialChunks, ColProcessedBlockHeights,
-    ColReceiptIdToShardId, ColReceipts, ColState, ColStateChanges, ColStateDlInfos,
-    ColStateHeaders, ColStateParts, ColTransactionResult, ColTransactions, ColTrieChanges, DBCol,
-    KeyForStateChanges, ShardTries, Store, StoreUpdate, TrieChanges, WrappedTrieChanges,
-    CHUNK_TAIL_KEY, FINAL_HEAD_KEY, FORK_TAIL_KEY, HEADER_HEAD_KEY, HEAD_KEY,
-    LARGEST_TARGET_HEIGHT_KEY, LATEST_KNOWN_KEY, SHOULD_COL_GC, TAIL_KEY,
+    ColChunkPerHeightShard, ColChunks, ColEpochLightClientBlocks, ColGCCount,
+    ColHeaderHashesByHeight, ColIncomingReceipts, ColInvalidChunks, ColLastBlockWithNewChunk,
+    ColNextBlockHashes, ColNextBlockWithNewChunk, ColOutcomeIds, ColOutgoingReceipts,
+    ColPartialChunks, ColProcessedBlockHeights, ColReceiptIdToShardId, ColReceipts, ColState,
+    ColStateChanges, ColStateDlInfos, ColStateHeaders, ColStateParts, ColTransactionResult,
+    ColTransactions, ColTrieChanges, DBCol, KeyForStateChanges, ShardTries, Store, StoreUpdate,
+    TrieChanges, WrappedTrieChanges, CHUNK_TAIL_KEY, FINAL_HEAD_KEY, FORK_TAIL_KEY,
+    HEADER_HEAD_KEY, HEAD_KEY, LARGEST_TARGET_HEIGHT_KEY, LATEST_KNOWN_KEY, SHOULD_COL_GC,
+    TAIL_KEY,
 };
 
 use crate::types::{Block, BlockHeader, LatestKnown};
@@ -188,6 +188,11 @@ pub trait ChainStoreAccess {
         &mut self,
         height: BlockHeight,
     ) -> Result<HashSet<ChunkHash>, Error>;
+    /// Returns a HashSet of Header Hashes for current Height
+    fn get_all_header_hashes_by_height(
+        &mut self,
+        height: BlockHeight,
+    ) -> Result<HashSet<CryptoHash>, Error>;
     /// Returns a number of references for Block with `block_hash`
     fn get_block_refcount(&mut self, block_hash: &CryptoHash) -> Result<&u64, Error>;
     /// Check if we saw chunk hash at given height and shard id.
@@ -609,44 +614,10 @@ impl ChainStoreAccess for ChainStore {
 
     /// Get full block.
     fn get_block(&mut self, h: &CryptoHash) -> Result<&Block, Error> {
-        let block_result = option_to_not_found(
+        option_to_not_found(
             read_with_cache(&*self.store, ColBlock, &mut self.blocks, h.as_ref()),
             &format!("BLOCK: {}", h),
-        );
-        match block_result {
-            Ok(block) => Ok(block),
-            Err(e) => match e.kind() {
-                ErrorKind::DBNotFoundErr(_) => {
-                    let block_header_result = read_with_cache(
-                        &*self.store,
-                        ColBlockHeader,
-                        &mut self.headers,
-                        h.as_ref(),
-                    );
-                    match block_header_result {
-                        Ok(Some(_)) => Err(ErrorKind::BlockMissing(h.clone()).into()),
-                        Ok(None) => Err(e),
-                        Err(header_error) => {
-                            debug_assert!(
-                                false,
-                                "If the block was not found, the block header may either \
-                                 exist or not found as well, instead the error was returned {:?}",
-                                header_error
-                            );
-                            debug!(
-                                target: "store",
-                                "If the block was not found, the block header may either \
-                                exist or not found as well, instead the error was returned {:?}. \
-                                This is not expected to happen, but it is not a fatal error.",
-                                header_error
-                            );
-                            Err(e)
-                        }
-                    }
-                }
-                _ => Err(e),
-            },
-        }
+        )
     }
 
     /// Get full chunk.
@@ -782,11 +753,17 @@ impl ChainStoreAccess for ChainStore {
         &mut self,
         height: BlockHeight,
     ) -> Result<HashSet<ChunkHash>, Error> {
-        match self.store.get_ser(ColChunkHashesByHeight, &index_to_bytes(height)) {
-            Ok(Some(hash_set)) => Ok(hash_set),
-            Ok(None) => Ok(HashSet::new()),
-            Err(e) => Err(e.into()),
-        }
+        Ok(self.store.get_ser(ColChunkHashesByHeight, &index_to_bytes(height))?.unwrap_or_default())
+    }
+
+    fn get_all_header_hashes_by_height(
+        &mut self,
+        height: BlockHeight,
+    ) -> Result<HashSet<CryptoHash>, Error> {
+        Ok(self
+            .store
+            .get_ser(ColHeaderHashesByHeight, &index_to_bytes(height))?
+            .unwrap_or_default())
     }
 
     fn get_block_refcount(&mut self, block_hash: &CryptoHash) -> Result<&u64, Error> {
@@ -1417,6 +1394,13 @@ impl<'a> ChainStoreAccess for ChainStoreUpdate<'a> {
         self.chain_store.get_all_chunk_hashes_by_height(height)
     }
 
+    fn get_all_header_hashes_by_height(
+        &mut self,
+        height: BlockHeight,
+    ) -> Result<HashSet<CryptoHash>, Error> {
+        self.chain_store.get_all_header_hashes_by_height(height)
+    }
+
     fn get_block_refcount(&mut self, block_hash: &CryptoHash) -> Result<&u64, Error> {
         if let Some(refcount) = self.chain_store_cache_update.block_refcounts.get(block_hash) {
             Ok(refcount)
@@ -1750,6 +1734,22 @@ impl<'a> ChainStoreUpdate<'a> {
         }
     }
 
+    /// Save header head in Epoch Sync
+    /// Checking validity of header head is delegated to Epoch Sync methods
+    pub fn force_save_header_head(&mut self, t: &Tip) -> Result<(), Error> {
+        self.try_save_latest_known(t.height)?;
+
+        // TODO #3488
+        // Bowen: It seems that height_to_hashes is used to update ColBlockHeight, which stores blocks,
+        // not block headers, by height. Therefore I wonder whether this line here breaks some invariant
+        // since now we potentially don't have the corresponding block in storage.
+
+        //self.chain_tore_cache_update.height_to_hashes.insert(t.height, Some(t.last_block_hash));
+        //self.chain_store_cache_update.next_block_hashes.insert(t.prev_block_hash, t.last_block_hash);
+        self.header_head = Some(t.clone());
+        Ok(())
+    }
+
     /// Update header head and height to hash index for this branch.
     pub fn save_header_head_if_not_challenged(&mut self, t: &Tip) -> Result<(), Error> {
         if t.height > self.chain_store.genesis_height {
@@ -1857,6 +1857,13 @@ impl<'a> ChainStoreUpdate<'a> {
             block_merkle_tree.insert(prev_hash);
             self.save_block_merkle_tree(*header.hash(), block_merkle_tree);
         }
+        Ok(())
+    }
+
+    /// Used only in Epoch Sync finalization
+    /// Validity of Header is checked by Epoch Sync methods
+    pub fn save_block_header_no_update_tree(&mut self, header: BlockHeader) -> Result<(), Error> {
+        self.chain_store_cache_update.headers.insert(*header.hash(), header);
         Ok(())
     }
 
@@ -2040,7 +2047,10 @@ impl<'a> ChainStoreUpdate<'a> {
         self.chunk_tail = Some(height);
     }
 
-    pub fn clear_chunk_data(&mut self, min_chunk_height: BlockHeight) -> Result<(), Error> {
+    pub fn clear_chunk_data_and_headers(
+        &mut self,
+        min_chunk_height: BlockHeight,
+    ) -> Result<(), Error> {
         let chunk_tail = self.chunk_tail()?;
         for height in chunk_tail..min_chunk_height {
             let chunk_hashes = self.get_all_chunk_hashes_by_height(height)?;
@@ -2061,8 +2071,17 @@ impl<'a> ChainStoreUpdate<'a> {
                 self.gc_col(ColPartialChunks, &chunk_header_hash);
                 self.gc_col(ColInvalidChunks, &chunk_header_hash);
             }
-            // 3. Delete chunks_tail-related data
+
+            let header_hashes = self.get_all_header_hashes_by_height(height)?;
+            for _header_hash in header_hashes {
+                // 3. Delete header_hash-indexed data
+                // TODO #3488: enable
+                //self.gc_col(ColBlockHeader, &header_hash.into());
+            }
+
+            // 4. Delete chunks_tail-related data
             self.gc_col(ColChunkHashesByHeight, &index_to_bytes(height));
+            self.gc_col(ColHeaderHashesByHeight, &index_to_bytes(height));
         }
         self.update_chunk_tail(min_chunk_height);
         Ok(())
@@ -2198,14 +2217,14 @@ impl<'a> ChainStoreUpdate<'a> {
             }
             GCMode::Canonical(_) => {
                 // 6. Canonical Chain only clearing
-                // Delete chunks and chunk-indexed data
+                // Delete chunks, chunk-indexed data and block headers
                 let mut min_chunk_height = self.tail()?;
                 for chunk_header in block.chunks().iter() {
                     if min_chunk_height > chunk_header.height_created() {
                         min_chunk_height = chunk_header.height_created();
                     }
                 }
-                self.clear_chunk_data(min_chunk_height)?;
+                self.clear_chunk_data_and_headers(min_chunk_height)?;
             }
             GCMode::StateSync { .. } => {
                 // 7. State Sync clearing
@@ -2352,6 +2371,12 @@ impl<'a> ChainStoreUpdate<'a> {
             DBCol::ColStateHeaders => {
                 store_update.delete(col, key);
             }
+            DBCol::ColBlockHeader => {
+                // TODO #3488
+                store_update.delete(col, key);
+                self.chain_store.headers.cache_remove(key);
+                unreachable!();
+            }
             DBCol::ColBlock => {
                 store_update.delete(col, key);
                 self.chain_store.blocks.cache_remove(key);
@@ -2406,7 +2431,6 @@ impl<'a> ChainStoreUpdate<'a> {
             }
             DBCol::ColChunkHashesByHeight => {
                 store_update.delete(col, key);
-                self.chain_store.chunk_hash_per_height_shard.cache_remove(key);
             }
             DBCol::ColStateParts => {
                 store_update.delete(col, key);
@@ -2440,9 +2464,11 @@ impl<'a> ChainStoreUpdate<'a> {
                 store_update.delete(col, key);
                 self.chain_store.processed_block_heights.cache_remove(key);
             }
+            DBCol::ColHeaderHashesByHeight => {
+                store_update.delete(col, key);
+            }
             DBCol::ColDbVersion
             | DBCol::ColBlockMisc
-            | DBCol::ColBlockHeader
             | DBCol::ColGCCount
             | DBCol::ColBlockHeight
             | DBCol::ColPeers
@@ -2513,8 +2539,31 @@ impl<'a> ChainStoreUpdate<'a> {
                 .insert(block.header().height(), map);
             store_update.set_ser(ColBlock, hash.as_ref(), block)?;
         }
+        let mut header_hashes_by_height: HashMap<BlockHeight, HashSet<CryptoHash>> = HashMap::new();
         for (hash, header) in self.chain_store_cache_update.headers.iter() {
+            if self.chain_store.get_block_header(hash).is_ok() {
+                // No need to add same Header once again
+                continue;
+            }
+
+            match header_hashes_by_height.entry(header.height()) {
+                Entry::Occupied(mut entry) => {
+                    entry.get_mut().insert(hash.clone());
+                }
+                Entry::Vacant(entry) => {
+                    let mut hash_set =
+                        match self.chain_store.get_all_header_hashes_by_height(header.height()) {
+                            Ok(hash_set) => hash_set.clone(),
+                            Err(_) => HashSet::new(),
+                        };
+                    hash_set.insert(hash.clone());
+                    entry.insert(hash_set);
+                }
+            };
             store_update.set_ser(ColBlockHeader, hash.as_ref(), header)?;
+        }
+        for (height, hash_set) in header_hashes_by_height {
+            store_update.set_ser(ColHeaderHashesByHeight, &index_to_bytes(height), &hash_set)?;
         }
         for ((block_hash, shard_id), chunk_extra) in
             self.chain_store_cache_update.chunk_extras.iter()

--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -144,6 +144,8 @@ impl StoreValidator {
                     self.check(&validate::block_header_hash_validity, &block_hash, &header, col);
                     // Block Header Height is valid
                     self.check(&validate::block_header_height_validity, &block_hash, &header, col);
+                    // Block Header can be indexed by Height
+                    self.check(&validate::header_hash_indexed_by_height, &block_hash, &header, col);
                 }
                 DBCol::ColBlock => {
                     let block_hash = CryptoHash::try_from(key_ref)?;
@@ -214,6 +216,17 @@ impl StoreValidator {
                     let chunk_hashes = HashSet::<ChunkHash>::try_from_slice(value_ref)?;
                     // ShardChunk which can be indexed by Height exists
                     self.check(&validate::chunk_of_height_exists, &height, &chunk_hashes, col);
+                }
+                DBCol::ColHeaderHashesByHeight => {
+                    let height = BlockHeight::try_from_slice(key_ref)?;
+                    let header_hashes = HashSet::<CryptoHash>::try_from_slice(value_ref)?;
+                    // Headers which can be indexed by Height exists
+                    self.check(
+                        &validate::header_hash_of_height_exists,
+                        &height,
+                        &header_hashes,
+                        col,
+                    );
                 }
                 DBCol::ColOutcomeIds => {
                     let (block_hash, _) = get_block_shard_id_rev(key_ref)?;

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -13,6 +13,7 @@ use near_crypto::Signature;
 use near_pool::types::PoolIterator;
 pub use near_primitives::block::{Block, BlockHeader, Tip};
 use near_primitives::challenge::{ChallengesResult, SlashedValidator};
+use near_primitives::epoch_manager::{BlockInfo, EpochInfo};
 use near_primitives::errors::InvalidTxError;
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::merkle::{merklize, MerklePath};
@@ -453,8 +454,40 @@ pub trait RuntimeAdapter: Send + Sync {
     /// Amount of tokens minted in given epoch.
     fn get_epoch_minted_amount(&self, epoch_id: &EpochId) -> Result<Balance, Error>;
 
+    // TODO #3488 this likely to be updated
+    /// Data that is necessary for prove Epochs in Epoch Sync.
+    fn get_epoch_sync_data(
+        &self,
+        prev_epoch_last_block_hash: &CryptoHash,
+        epoch_id: &EpochId,
+        next_epoch_id: &EpochId,
+    ) -> Result<(BlockInfo, BlockInfo, BlockInfo, EpochInfo, EpochInfo, EpochInfo), Error>;
+
+    // TODO #3488 this likely to be updated
+    /// Hash that is necessary for prove Epochs in Epoch Sync.
+    fn get_epoch_sync_data_hash(
+        &self,
+        prev_epoch_last_block_hash: &CryptoHash,
+        epoch_id: &EpochId,
+        next_epoch_id: &EpochId,
+    ) -> Result<CryptoHash, Error>;
+
     /// Epoch active protocol version.
     fn get_epoch_protocol_version(&self, epoch_id: &EpochId) -> Result<ProtocolVersion, Error>;
+
+    /// Epoch Manager init procedure that is necessary after Epoch Sync.
+    fn epoch_sync_init_epoch_manager(
+        &self,
+        prev_epoch_first_block_info: BlockInfo,
+        prev_epoch_prev_last_block_info: BlockInfo,
+        prev_epoch_last_block_info: BlockInfo,
+        prev_epoch_id: &EpochId,
+        prev_epoch_info: EpochInfo,
+        epoch_id: &EpochId,
+        epoch_info: EpochInfo,
+        next_epoch_id: &EpochId,
+        next_epoch_info: EpochInfo,
+    ) -> Result<(), Error>;
 
     /// Add proposals for validators.
     fn add_validator_proposals(&self, block_header_info: BlockHeaderInfo) -> Result<(), Error>;

--- a/chain/chain/tests/simple_chain.rs
+++ b/chain/chain/tests/simple_chain.rs
@@ -42,10 +42,13 @@ fn build_chain_with_orhpans() {
         PROTOCOL_VERSION,
         &last_block.header(),
         10,
-        last_block.header().block_ordinal() + 1,
+        #[cfg(feature = "protocol_feature_block_header_v3")]
+        (last_block.header().block_ordinal() + 1),
         last_block.chunks().iter().cloned().collect(),
         last_block.header().epoch_id().clone(),
         last_block.header().next_epoch_id().clone(),
+        #[cfg(feature = "protocol_feature_block_header_v3")]
+        None,
         vec![],
         Rational::from_integer(0),
         0,

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -1101,8 +1101,7 @@ impl ShardsManager {
             Ok(true) => (),
             Err(chain_error) => {
                 return match chain_error.kind() {
-                    near_chain::ErrorKind::BlockMissing(_)
-                    | near_chain::ErrorKind::DBNotFoundErr(_) => {
+                    near_chain::ErrorKind::DBNotFoundErr(_) => {
                         // We can't check if this chunk came from a valid chunk producer because
                         // we don't know `prev_block`, so return that we need a block.
                         Ok(ProcessPartialEncodedChunkResult::NeedBlock)

--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -124,6 +124,10 @@ pub enum SyncStatus {
     AwaitingPeers,
     /// Not syncing / Done syncing.
     NoSync,
+    /// Syncing using light-client headers to a recent epoch
+    // TODO #3488
+    // Bowen: why do we use epoch ordinal instead of epoch id?
+    EpochSync { epoch_ord: u64 },
     /// Downloading block headers for fast sync.
     HeaderSync { current_height: BlockHeight, highest_height: BlockHeight },
     /// State sync, with different states of state sync for different shards.
@@ -175,7 +179,6 @@ impl From<near_chain_primitives::Error> for GetBlockError {
         match error.kind() {
             near_chain_primitives::ErrorKind::IOErr(s) => Self::IOError(s),
             near_chain_primitives::ErrorKind::DBNotFoundErr(s) => Self::BlockNotFound(s),
-            near_chain_primitives::ErrorKind::BlockMissing(hash) => Self::BlockMissing(hash),
             _ => Self::Unreachable(error.to_string()),
         }
     }
@@ -240,7 +243,6 @@ impl From<near_chain_primitives::Error> for GetChunkError {
         match error.kind() {
             near_chain_primitives::ErrorKind::IOErr(s) => Self::IOError(s),
             near_chain_primitives::ErrorKind::DBNotFoundErr(s) => Self::UnknownBlock(s),
-            near_chain_primitives::ErrorKind::BlockMissing(hash) => Self::UnavailableBlock(hash),
             near_chain_primitives::ErrorKind::InvalidShardId(shard_id) => {
                 Self::InvalidShardId(shard_id)
             }
@@ -373,7 +375,7 @@ impl From<near_chain_primitives::Error> for GetValidatorInfoError {
     fn from(error: near_chain_primitives::Error) -> Self {
         match error.kind() {
             near_chain_primitives::ErrorKind::DBNotFoundErr(_)
-            | near_chain_primitives::ErrorKind::EpochOutOfBounds => Self::UnknownEpoch,
+            | near_chain_primitives::ErrorKind::EpochOutOfBounds(_) => Self::UnknownEpoch,
             near_chain_primitives::ErrorKind::IOErr(s) => Self::IOError(s),
             _ => Self::Unreachable(error.to_string()),
         }

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -20,7 +20,10 @@ use near_chain::{
 use near_chain_configs::ClientConfig;
 use near_chunks::{ProcessPartialEncodedChunkResult, ShardsManager};
 use near_network::types::PartialEncodedChunkResponseMsg;
-use near_network::{FullPeerInfo, NetworkAdapter, NetworkClientResponses, NetworkRequests};
+use near_network::{
+    FullPeerInfo, NetworkAdapter, NetworkClientResponses, NetworkRequests,
+    EPOCH_SYNC_PEER_TIMEOUT_MS, EPOCH_SYNC_REQUEST_TIMEOUT_MS,
+};
 use near_primitives::block::{Approval, ApprovalInner, ApprovalMessage, Block, BlockHeader, Tip};
 use near_primitives::challenge::{Challenge, ChallengeBody};
 use near_primitives::hash::CryptoHash;
@@ -32,15 +35,15 @@ use near_primitives::sharding::{
 };
 use near_primitives::syncing::ReceiptResponse;
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::{
-    AccountId, ApprovalStake, BlockHeight, ChunkExtra, EpochId, NumBlocks, ShardId,
-};
+#[cfg(feature = "protocol_feature_block_header_v3")]
+use near_primitives::types::NumBlocks;
+use near_primitives::types::{AccountId, ApprovalStake, BlockHeight, ChunkExtra, EpochId, ShardId};
 use near_primitives::unwrap_or_return;
 use near_primitives::utils::{to_timestamp, MaybeValidated};
 use near_primitives::validator_signer::ValidatorSigner;
 
 use crate::metrics;
-use crate::sync::{BlockSync, HeaderSync, StateSync, StateSyncResult};
+use crate::sync::{BlockSync, EpochSync, HeaderSync, StateSync, StateSyncResult};
 use crate::SyncStatus;
 use near_client_primitives::types::{Error, ShardSyncDownload};
 use near_primitives::block_header::ApprovalType;
@@ -73,6 +76,8 @@ pub struct Client {
     /// A mapping from a block for which a state sync is underway for the next epoch, and the object
     /// storing the current status of the state sync
     pub catchup_state_syncs: HashMap<CryptoHash, (StateSync, HashMap<u64, ShardSyncDownload>)>,
+    /// Keeps track of information needed to perform the initial Epoch Sync
+    pub epoch_sync: EpochSync,
     /// Keeps track of syncing headers.
     pub header_sync: HeaderSync,
     /// Keeps track of syncing block.
@@ -111,6 +116,22 @@ impl Client {
             network_adapter.clone(),
         );
         let sync_status = SyncStatus::AwaitingPeers;
+        let genesis_block = chain.genesis_block();
+        let epoch_sync = EpochSync::new(
+            network_adapter.clone(),
+            genesis_block.header().epoch_id().clone(),
+            genesis_block.header().next_epoch_id().clone(),
+            runtime_adapter
+                .get_epoch_block_producers_ordered(
+                    &genesis_block.header().epoch_id(),
+                    &genesis_block.hash(),
+                )?
+                .iter()
+                .map(|x| x.0.clone().into())
+                .collect(),
+            Duration::from_millis(EPOCH_SYNC_REQUEST_TIMEOUT_MS),
+            Duration::from_millis(EPOCH_SYNC_PEER_TIMEOUT_MS),
+        );
         let header_sync = HeaderSync::new(
             network_adapter.clone(),
             config.header_sync_initial_timeout,
@@ -150,6 +171,7 @@ impl Client {
             validator_signer,
             pending_approvals: SizedCache::with_size(num_block_producer_seats),
             catchup_state_syncs: HashMap::new(),
+            epoch_sync,
             header_sync,
             block_sync,
             state_sync,
@@ -408,6 +430,7 @@ impl Client {
         let block_merkle_root = block_merkle_tree.root();
         // The number of leaves in Block Merkle Tree is the amount of Blocks on the Canonical Chain by construction.
         // The ordinal of the next Block will be equal to this amount plus one.
+        #[cfg(feature = "protocol_feature_block_header_v3")]
         let block_ordinal: NumBlocks = block_merkle_tree.size() + 1;
         let prev_block_extra = self.chain.get_block_extra(&prev_hash)?.clone();
         let prev_block = self.chain.get_block(&prev_hash)?;
@@ -431,6 +454,18 @@ impl Client {
                 None
             };
 
+        #[cfg(feature = "protocol_feature_block_header_v3")]
+        let epoch_sync_data_hash =
+            if self.runtime_adapter.is_next_block_epoch_start(&head.last_block_hash)? {
+                Some(self.runtime_adapter.get_epoch_sync_data_hash(
+                    prev_block.hash(),
+                    &epoch_id,
+                    &next_epoch_id,
+                )?)
+            } else {
+                None
+            };
+
         // Get all the current challenges.
         // TODO(2445): Enable challenges when they are working correctly.
         // let challenges = self.challenges.drain().map(|(_, challenge)| challenge).collect();
@@ -440,10 +475,13 @@ impl Client {
             protocol_version,
             &prev_header,
             next_height,
+            #[cfg(feature = "protocol_feature_block_header_v3")]
             block_ordinal,
             chunks,
             epoch_id,
             next_epoch_id,
+            #[cfg(feature = "protocol_feature_block_header_v3")]
+            epoch_sync_data_hash,
             approvals,
             gas_price_adjustment_rate,
             min_gas_price,
@@ -764,8 +802,7 @@ impl Client {
             }
             Err(near_chunks::Error::ChainError(chain_error)) => {
                 match chain_error.kind() {
-                    near_chain::ErrorKind::BlockMissing(_)
-                    | near_chain::ErrorKind::DBNotFoundErr(_) => {
+                    near_chain::ErrorKind::DBNotFoundErr(_) => {
                         // We can't check if this chunk came from a valid chunk producer because
                         // we don't know `prev_block`, however the signature is checked when
                         // forwarded parts are later processed as partial encoded chunks, so we

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -306,13 +306,13 @@ impl Handler<NetworkClientMessages> for ClientActor {
                     if let SyncStatus::StateSync(sync_hash, _) = &mut self.client.sync_status {
                         if let Ok(header) = self.client.chain.get_block_header(sync_hash) {
                             if block.hash() == header.prev_hash() {
-                                if let Err(_) = self.client.chain.save_block(&block) {
-                                    error!(target: "client", "Failed to save a block during state sync");
+                                if let Err(e) = self.client.chain.save_block(&block) {
+                                    error!(target: "client", "Failed to save a block during state sync: {}", e);
                                 }
                                 return NetworkClientResponses::NoResponse;
                             } else if block.hash() == sync_hash {
-                                if let Err(_) = self.client.chain.save_orphan(&block) {
-                                    error!(target: "client", "Received an invalid block during state sync");
+                                if let Err(e) = self.client.chain.save_orphan(&block) {
+                                    error!(target: "client", "Received an invalid block during state sync: {}", e);
                                 }
                                 return NetworkClientResponses::NoResponse;
                             }
@@ -466,6 +466,14 @@ impl Handler<NetworkClientMessages> for ClientActor {
                     error!(target: "sync", "State sync received hash {} that we're not expecting, potential malicious peer", hash);
                 }
 
+                NetworkClientResponses::NoResponse
+            }
+            NetworkClientMessages::EpochSyncResponse(_peer_id, _response) => {
+                // TODO #3488
+                NetworkClientResponses::NoResponse
+            }
+            NetworkClientMessages::EpochSyncFinalizationResponse(_peer_id, _response) => {
+                // TODO #3488
                 NetworkClientResponses::NoResponse
             }
             NetworkClientMessages::PartialEncodedChunkRequest(part_request_msg, route_back) => {

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -206,6 +206,9 @@ fn display_sync_status(
     match sync_status {
         SyncStatus::AwaitingPeers => format!("#{:>8} Waiting for peers", head.height),
         SyncStatus::NoSync => format!("#{:>8} {:>44}", head.height, head.last_block_hash),
+        SyncStatus::EpochSync { epoch_ord } => {
+            format!("[EPOCH: {:>5}] Getting to a recent epoch", epoch_ord)
+        }
         SyncStatus::HeaderSync { current_height, highest_height } => {
             let percent = if *highest_height <= genesis_height {
                 0.0

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -66,6 +66,7 @@ pub fn setup(
     max_block_prod_time: u64,
     enable_doomslug: bool,
     archive: bool,
+    epoch_sync_enabled: bool,
     network_adapter: Arc<dyn NetworkAdapter>,
     transaction_validity_period: NumBlocks,
     genesis_time: DateTime<Utc>,
@@ -109,6 +110,7 @@ pub fn setup(
         max_block_prod_time,
         num_validator_seats,
         archive,
+        epoch_sync_enabled,
     );
 
     #[cfg(feature = "adversarial")]
@@ -154,7 +156,7 @@ pub fn setup_mock(
         ) -> NetworkResponses,
     >,
 ) -> (Addr<ClientActor>, Addr<ViewClientActor>) {
-    setup_mock_with_validity_period(
+    setup_mock_with_validity_period_and_no_epoch_sync(
         validators,
         account_id,
         skip_sync_wait,
@@ -164,7 +166,7 @@ pub fn setup_mock(
     )
 }
 
-pub fn setup_mock_with_validity_period(
+pub fn setup_mock_with_validity_period_and_no_epoch_sync(
     validators: Vec<&'static str>,
     account_id: &'static str,
     skip_sync_wait: bool,
@@ -189,6 +191,7 @@ pub fn setup_mock_with_validity_period(
         100,
         200,
         enable_doomslug,
+        false,
         false,
         network_adapter.clone(),
         transaction_validity_period,
@@ -375,6 +378,7 @@ pub fn setup_mock_all_validators(
     epoch_length: BlockHeightDelta,
     enable_doomslug: bool,
     archive: Vec<bool>,
+    epoch_sync_enabled: Vec<bool>,
     check_block_stats: bool,
     network_mock: Arc<RwLock<Box<dyn FnMut(String, &NetworkRequests) -> (NetworkResponses, bool)>>>,
 ) -> (Block, Vec<(Addr<ClientActor>, Addr<ViewClientActor>)>, Arc<RwLock<BlockStats>>) {
@@ -422,6 +426,7 @@ pub fn setup_mock_all_validators(
         let largest_skipped_height1 = largest_skipped_height.clone();
         let hash_to_height1 = hash_to_height.clone();
         let archive1 = archive.clone();
+        let epoch_sync_enabled1 = epoch_sync_enabled.clone();
         let client_addr = ClientActor::create(move |ctx| {
             let client_addr = ctx.address();
             let pm = NetworkMock::mock(Box::new(move |msg, _ctx| {
@@ -583,6 +588,66 @@ pub fn setup_mock_all_validators(
                                                             .0
                                                             .do_send(NetworkClientMessages::Block(
                                                                 *block, peer_id, true,
+                                                            ));
+                                                    }
+                                                    NetworkViewClientResponses::NoResponse => {}
+                                                    _ => assert!(false),
+                                                }
+                                                future::ready(())
+                                            }),
+                                    );
+                                }
+                            }
+                        }
+                        NetworkRequests::EpochSyncRequest { epoch_id, peer_id } => {
+                            for (i, peer_info) in key_pairs.iter().enumerate() {
+                                let peer_id = peer_id.clone();
+                                if peer_info.id == peer_id {
+                                    let connectors2 = connectors1.clone();
+                                    actix::spawn(
+                                        connectors1.read().unwrap()[i]
+                                            .1
+                                            .send(NetworkViewClientMessages::EpochSyncRequest{
+                                                epoch_id: epoch_id.clone(),
+                                            })
+                                            .then(move |response| {
+                                                let response = response.unwrap();
+                                                match response {
+                                                    NetworkViewClientResponses::EpochSyncResponse(response) => {
+                                                        connectors2.read().unwrap()[my_ord]
+                                                            .0
+                                                            .do_send(NetworkClientMessages::EpochSyncResponse(
+                                                                peer_id, response
+                                                            ));
+                                                    }
+                                                    NetworkViewClientResponses::NoResponse => {}
+                                                    _ => assert!(false),
+                                                }
+                                                future::ready(())
+                                            }),
+                                    );
+                                }
+                            }
+                        }
+                        NetworkRequests::EpochSyncFinalizationRequest { epoch_id, peer_id } => {
+                            for (i, peer_info) in key_pairs.iter().enumerate() {
+                                let peer_id = peer_id.clone();
+                                if peer_info.id == peer_id {
+                                    let connectors2 = connectors1.clone();
+                                    actix::spawn(
+                                        connectors1.read().unwrap()[i]
+                                            .1
+                                            .send(NetworkViewClientMessages::EpochSyncFinalizationRequest{
+                                                epoch_id: epoch_id.clone(),
+                                            })
+                                            .then(move |response| {
+                                                let response = response.unwrap();
+                                                match response {
+                                                    NetworkViewClientResponses::EpochSyncFinalizationResponse(response) => {
+                                                        connectors2.read().unwrap()[my_ord]
+                                                            .0
+                                                            .do_send(NetworkClientMessages::EpochSyncFinalizationResponse(
+                                                                peer_id, response
                                                             ));
                                                     }
                                                     NetworkViewClientResponses::NoResponse => {}
@@ -832,6 +897,7 @@ pub fn setup_mock_all_validators(
                 block_prod_time * 3,
                 enable_doomslug,
                 archive1[index],
+                epoch_sync_enabled1[index],
                 Arc::new(network_adapter),
                 10000,
                 genesis_time,
@@ -860,7 +926,7 @@ pub fn setup_no_network(
     skip_sync_wait: bool,
     enable_doomslug: bool,
 ) -> (Addr<ClientActor>, Addr<ViewClientActor>) {
-    setup_no_network_with_validity_period(
+    setup_no_network_with_validity_period_and_no_epoch_sync(
         validators,
         account_id,
         skip_sync_wait,
@@ -869,14 +935,14 @@ pub fn setup_no_network(
     )
 }
 
-pub fn setup_no_network_with_validity_period(
+pub fn setup_no_network_with_validity_period_and_no_epoch_sync(
     validators: Vec<&'static str>,
     account_id: &'static str,
     skip_sync_wait: bool,
     transaction_validity_period: NumBlocks,
     enable_doomslug: bool,
 ) -> (Addr<ClientActor>, Addr<ViewClientActor>) {
-    setup_mock_with_validity_period(
+    setup_mock_with_validity_period_and_no_epoch_sync(
         validators,
         account_id,
         skip_sync_wait,
@@ -898,7 +964,7 @@ pub fn setup_client_with_runtime(
         Arc::new(InMemoryValidatorSigner::from_seed(x, KeyType::ED25519, x))
             as Arc<dyn ValidatorSigner>
     });
-    let mut config = ClientConfig::test(true, 10, 20, num_validator_seats, false);
+    let mut config = ClientConfig::test(true, 10, 20, num_validator_seats, false, true);
     config.epoch_length = chain_genesis.epoch_length;
     let mut client = Client::new(
         config,
@@ -1188,10 +1254,13 @@ pub fn create_chunk(
         PROTOCOL_VERSION,
         &last_block.header(),
         2,
-        last_block.header().block_ordinal() + 1,
+        #[cfg(feature = "protocol_feature_block_header_v3")]
+        (last_block.header().block_ordinal() + 1),
         vec![chunk.cloned_header()],
         last_block.header().epoch_id().clone(),
         last_block.header().next_epoch_id().clone(),
+        #[cfg(feature = "protocol_feature_block_header_v3")]
+        None,
         vec![],
         Rational::from_integer(0),
         0,

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -1177,6 +1177,14 @@ impl Handler<NetworkViewClientMessages> for ViewClientActor {
 
                 NetworkViewClientResponses::AnnounceAccount(filtered_announce_accounts)
             }
+            NetworkViewClientMessages::EpochSyncRequest { epoch_id: _epoch_id } => {
+                // TODO #3488
+                NetworkViewClientResponses::NoResponse
+            }
+            NetworkViewClientMessages::EpochSyncFinalizationRequest { epoch_id: _epoch_id } => {
+                // TODO #3488
+                NetworkViewClientResponses::NoResponse
+            }
         }
     }
 }

--- a/chain/client/tests/bug_repros.rs
+++ b/chain/client/tests/bug_repros.rs
@@ -51,6 +51,7 @@ fn repro_1183() {
             5,
             false,
             vec![false; validators.iter().map(|x| x.len()).sum()],
+            vec![true; validators.iter().map(|x| x.len()).sum()],
             false,
             Arc::new(RwLock::new(Box::new(move |_account_id: String, msg: &NetworkRequests| {
                 if let NetworkRequests::Block { block } = msg {
@@ -162,6 +163,7 @@ fn test_sync_from_achival_node() {
             epoch_length,
             false,
             vec![true, false, false, false],
+            vec![false, true, true, true],
             false,
             network_mock.clone(),
         );
@@ -257,6 +259,7 @@ fn test_long_gap_between_blocks() {
             epoch_length,
             true,
             vec![false, false],
+            vec![true, true],
             false,
             network_mock.clone(),
         );

--- a/chain/client/tests/catching_up.rs
+++ b/chain/client/tests/catching_up.rs
@@ -147,6 +147,7 @@ mod tests {
                 5,
                 false,
                 vec![true; validators.iter().map(|x| x.len()).sum()],
+                vec![false; validators.iter().map(|x| x.len()).sum()],
                 false,
                 Arc::new(RwLock::new(Box::new(
                     move |_account_id: String, msg: &NetworkRequests| {
@@ -443,6 +444,7 @@ mod tests {
                 5,
                 true,
                 vec![false; validators.iter().map(|x| x.len()).sum()],
+                vec![true; validators.iter().map(|x| x.len()).sum()],
                 false,
                 Arc::new(RwLock::new(Box::new(
                     move |_account_id: String, msg: &NetworkRequests| {
@@ -643,6 +645,7 @@ mod tests {
                 5,
                 true,
                 vec![false; validators.iter().map(|x| x.len()).sum()],
+                vec![true; validators.iter().map(|x| x.len()).sum()],
                 false,
                 Arc::new(RwLock::new(Box::new(
                     move |_account_id: String, msg: &NetworkRequests| {
@@ -718,6 +721,7 @@ mod tests {
                 5,
                 true,
                 vec![false; validators.iter().map(|x| x.len()).sum()],
+                vec![true; validators.iter().map(|x| x.len()).sum()],
                 false,
                 Arc::new(RwLock::new(Box::new(
                     move |sender_account_id: String, msg: &NetworkRequests| {
@@ -886,6 +890,7 @@ mod tests {
                 epoch_length,
                 true,
                 vec![false; validators.iter().map(|x| x.len()).sum()],
+                vec![true; validators.iter().map(|x| x.len()).sum()],
                 false,
                 Arc::new(RwLock::new(Box::new(
                     move |sender_account_id: String, msg: &NetworkRequests| {

--- a/chain/client/tests/challenges.rs
+++ b/chain/client/tests/challenges.rs
@@ -51,10 +51,13 @@ fn test_verify_block_double_sign_challenge() {
         PROTOCOL_VERSION,
         genesis.header(),
         2,
-        genesis.header().block_ordinal() + 1,
+        #[cfg(feature = "protocol_feature_block_header_v3")]
+        (genesis.header().block_ordinal() + 1),
         genesis.chunks().iter().cloned().collect(),
         b1.header().epoch_id().clone(),
         b1.header().next_epoch_id().clone(),
+        #[cfg(feature = "protocol_feature_block_header_v3")]
+        None,
         vec![],
         Rational::from_integer(0),
         0,
@@ -350,10 +353,13 @@ fn test_verify_chunk_invalid_state_challenge() {
         PROTOCOL_VERSION,
         &last_block.header(),
         last_block.header().height() + 1,
-        last_block.header().block_ordinal() + 1,
+        #[cfg(feature = "protocol_feature_block_header_v3")]
+        (last_block.header().block_ordinal() + 1),
         vec![invalid_chunk.cloned_header()],
         last_block.header().epoch_id().clone(),
         last_block.header().next_epoch_id().clone(),
+        #[cfg(feature = "protocol_feature_block_header_v3")]
+        None,
         vec![],
         Rational::from_integer(0),
         0,

--- a/chain/client/tests/chunks_management.rs
+++ b/chain/client/tests/chunks_management.rs
@@ -144,6 +144,7 @@ fn chunks_produced_and_distributed_common(
         5,
         true,
         vec![false; validators.iter().map(|x| x.len()).sum()],
+        vec![true; validators.iter().map(|x| x.len()).sum()],
         false,
         Arc::new(RwLock::new(Box::new(move |from_whom: String, msg: &NetworkRequests| {
             match msg {

--- a/chain/client/tests/consensus.rs
+++ b/chain/client/tests/consensus.rs
@@ -71,6 +71,7 @@ mod tests {
                 4,
                 true,
                 vec![true; validators.iter().map(|x| x.len()).sum()],
+                vec![false; validators.iter().map(|x| x.len()).sum()],
                 false,
                 Arc::new(RwLock::new(Box::new(move |from_whom: String, msg: &NetworkRequests| {
                     let mut all_blocks: RwLockWriteGuard<BTreeMap<BlockHeight, Block>> =

--- a/chain/client/tests/cross_shard_tx.rs
+++ b/chain/client/tests/cross_shard_tx.rs
@@ -37,6 +37,7 @@ fn test_keyvalue_runtime_balances() {
             5,
             false,
             vec![false; validators.iter().map(|x| x.len()).sum()],
+            vec![true; validators.iter().map(|x| x.len()).sum()],
             false,
             Arc::new(RwLock::new(Box::new(move |_account_id: String, _msg: &NetworkRequests| {
                 (NetworkResponses::NoResponse, true)
@@ -441,6 +442,7 @@ mod tests {
                 20,
                 test_doomslug,
                 vec![true; validators.iter().map(|x| x.len()).sum()],
+                vec![false; validators.iter().map(|x| x.len()).sum()],
                 true,
                 Arc::new(RwLock::new(Box::new(
                     move |_account_id: String, _msg: &NetworkRequests| {

--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -189,18 +189,13 @@ fn receive_network_block() {
             let (last_block, mut block_merkle_tree) = res.unwrap().unwrap();
             let signer = InMemoryValidatorSigner::from_seed("test1", KeyType::ED25519, "test1");
             block_merkle_tree.insert(last_block.header.hash);
-            let next_block_ordinal = {
-                #[cfg(feature = "protocol_feature_block_header_v3")]
-                {
-                    last_block.header.block_ordinal.unwrap() + 1
-                }
-                #[cfg(not(feature = "protocol_feature_block_header_v3"))]
-                0
-            };
+            #[cfg(feature = "protocol_feature_block_header_v3")]
+            let next_block_ordinal = last_block.header.block_ordinal.unwrap() + 1;
             let block = Block::produce(
                 PROTOCOL_VERSION,
                 &last_block.header.clone().into(),
                 last_block.header.height + 1,
+                #[cfg(feature = "protocol_feature_block_header_v3")]
                 next_block_ordinal,
                 last_block.chunks.into_iter().map(Into::into).collect(),
                 EpochId::default(),
@@ -209,6 +204,8 @@ fn receive_network_block() {
                 } else {
                     EpochId(last_block.header.next_epoch_id.clone())
                 },
+                #[cfg(feature = "protocol_feature_block_header_v3")]
+                None,
                 vec![],
                 Rational::from_integer(0),
                 0,
@@ -267,18 +264,13 @@ fn produce_block_with_approvals() {
             let (last_block, mut block_merkle_tree) = res.unwrap().unwrap();
             let signer1 = InMemoryValidatorSigner::from_seed("test2", KeyType::ED25519, "test2");
             block_merkle_tree.insert(last_block.header.hash);
-            let next_block_ordinal = {
-                #[cfg(feature = "protocol_feature_block_header_v3")]
-                {
-                    last_block.header.block_ordinal.unwrap() + 1
-                }
-                #[cfg(not(feature = "protocol_feature_block_header_v3"))]
-                0
-            };
+            #[cfg(feature = "protocol_feature_block_header_v3")]
+            let next_block_ordinal = last_block.header.block_ordinal.unwrap() + 1;
             let block = Block::produce(
                 PROTOCOL_VERSION,
                 &last_block.header.clone().into(),
                 last_block.header.height + 1,
+                #[cfg(feature = "protocol_feature_block_header_v3")]
                 next_block_ordinal,
                 last_block.chunks.into_iter().map(Into::into).collect(),
                 EpochId::default(),
@@ -287,6 +279,8 @@ fn produce_block_with_approvals() {
                 } else {
                     EpochId(last_block.header.next_epoch_id.clone())
                 },
+                #[cfg(feature = "protocol_feature_block_header_v3")]
+                None,
                 vec![],
                 Rational::from_integer(0),
                 0,
@@ -349,6 +343,7 @@ fn produce_block_with_approvals_arrived_early() {
             100,
             true,
             vec![false; validators.iter().map(|x| x.len()).sum()],
+            vec![true; validators.iter().map(|x| x.len()).sum()],
             false,
             network_mock.clone(),
         );
@@ -436,18 +431,13 @@ fn invalid_blocks_common(is_requested: bool) {
             let (last_block, mut block_merkle_tree) = res.unwrap().unwrap();
             let signer = InMemoryValidatorSigner::from_seed("test", KeyType::ED25519, "test");
             block_merkle_tree.insert(last_block.header.hash);
-            let next_block_ordinal = {
-                #[cfg(feature = "protocol_feature_block_header_v3")]
-                {
-                    last_block.header.block_ordinal.unwrap() + 1
-                }
-                #[cfg(not(feature = "protocol_feature_block_header_v3"))]
-                0
-            };
+            #[cfg(feature = "protocol_feature_block_header_v3")]
+            let next_block_ordinal = last_block.header.block_ordinal.unwrap() + 1;
             let valid_block = Block::produce(
                 PROTOCOL_VERSION,
                 &last_block.header.clone().into(),
                 last_block.header.height + 1,
+                #[cfg(feature = "protocol_feature_block_header_v3")]
                 next_block_ordinal,
                 last_block.chunks.iter().cloned().map(Into::into).collect(),
                 EpochId::default(),
@@ -456,6 +446,8 @@ fn invalid_blocks_common(is_requested: bool) {
                 } else {
                     EpochId(last_block.header.next_epoch_id.clone())
                 },
+                #[cfg(feature = "protocol_feature_block_header_v3")]
+                None,
                 vec![],
                 Rational::from_integer(0),
                 0,
@@ -561,6 +553,7 @@ fn ban_peer_for_invalid_block_common(mode: InvalidBlockMode) {
             100,
             true,
             vec![false; validators.iter().map(|x| x.len()).sum()],
+            vec![true; validators.iter().map(|x| x.len()).sum()],
             false,
             network_mock.clone(),
         );
@@ -980,8 +973,11 @@ fn test_bad_orphan() {
         block.mut_header().get_mut().inner_lite.epoch_id = EpochId(CryptoHash(Digest([1; 32])));
         block.mut_header().get_mut().prev_hash = CryptoHash(Digest([1; 32]));
         block.mut_header().resign(&*signer);
-        let (_, res) = env.clients[0].process_block(block, Provenance::NONE);
-        assert_eq!(res.as_ref().unwrap_err().kind(), ErrorKind::EpochOutOfBounds);
+        let (_, res) = env.clients[0].process_block(block.clone(), Provenance::NONE);
+        assert_eq!(
+            res.as_ref().unwrap_err().kind(),
+            ErrorKind::EpochOutOfBounds(block.header().epoch_id().clone())
+        );
     }
     {
         // Orphan block with invalid signature
@@ -1168,11 +1164,11 @@ fn test_gc_with_epoch_length_common(epoch_length: NumBlocks) {
             let block_hash = *blocks[i as usize].hash();
             assert!(matches!(
                 env.clients[0].chain.get_block(&block_hash).unwrap_err().kind(),
-                ErrorKind::BlockMissing(missing_block_hash) if missing_block_hash == block_hash
+                ErrorKind::DBNotFoundErr(missing_block_hash) if missing_block_hash == "BLOCK: ".to_owned() + &block_hash.to_string()
             ));
             assert!(matches!(
                 env.clients[0].chain.get_block_by_height(i).unwrap_err().kind(),
-                ErrorKind::BlockMissing(missing_block_hash) if missing_block_hash == block_hash
+                ErrorKind::DBNotFoundErr(missing_block_hash) if missing_block_hash == "BLOCK: ".to_owned() + &block_hash.to_string()
             ));
             assert!(env.clients[0]
                 .chain
@@ -1676,7 +1672,7 @@ fn test_incorrect_validator_key_produce_block() {
         vec![],
     ));
     let signer = Arc::new(InMemoryValidatorSigner::from_seed("test0", KeyType::ED25519, "seed"));
-    let mut config = ClientConfig::test(true, 10, 20, 2, false);
+    let mut config = ClientConfig::test(true, 10, 20, 2, false, true);
     config.epoch_length = chain_genesis.epoch_length;
     let mut client = Client::new(
         config,

--- a/chain/client/tests/query_client.rs
+++ b/chain/client/tests/query_client.rs
@@ -59,10 +59,13 @@ fn query_status_not_crash() {
                 PROTOCOL_VERSION,
                 &header,
                 block.header.height + 1,
-                header.block_ordinal() + 1,
+                #[cfg(feature = "protocol_feature_block_header_v3")]
+                (header.block_ordinal() + 1),
                 block.chunks.into_iter().map(|c| c.into()).collect(),
                 EpochId(block.header.next_epoch_id),
                 EpochId(block.header.hash),
+                #[cfg(feature = "protocol_feature_block_header_v3")]
+                None,
                 vec![],
                 Rational::from_integer(0),
                 0,

--- a/chain/epoch_manager/Cargo.toml
+++ b/chain/epoch_manager/Cargo.toml
@@ -27,5 +27,6 @@ near-store = { path = "../../core/store" }
 [features]
 expensive_tests = []
 protocol_feature_rectify_inflation = ["near-primitives/protocol_feature_rectify_inflation", "chrono"]
-nightly_protocol_features = ["nightly_protocol", "near-primitives/nightly_protocol_features", "protocol_feature_rectify_inflation"]
+protocol_feature_block_header_v3 = ["near-primitives/protocol_feature_block_header_v3"]
+nightly_protocol_features = ["nightly_protocol", "near-primitives/nightly_protocol_features", "protocol_feature_rectify_inflation", "protocol_feature_block_header_v3"]
 nightly_protocol = ["near-primitives/nightly_protocol"]

--- a/chain/epoch_manager/src/test_utils.rs
+++ b/chain/epoch_manager/src/test_utils.rs
@@ -237,8 +237,8 @@ pub fn record_block_with_final_block_hash(
 ) {
     epoch_manager
         .record_block_info(
-            &cur_h,
             BlockInfo::new(
+                cur_h,
                 height,
                 height.saturating_sub(2),
                 last_final_block_hash,
@@ -270,8 +270,8 @@ pub fn record_block_with_slashes(
 ) {
     epoch_manager
         .record_block_info(
-            &cur_h,
             BlockInfo::new(
+                cur_h,
                 height,
                 height.saturating_sub(2),
                 prev_h,
@@ -304,6 +304,7 @@ pub fn record_block(
 }
 
 pub fn block_info(
+    hash: CryptoHash,
     height: BlockHeight,
     last_finalized_height: BlockHeight,
     last_final_block_hash: CryptoHash,
@@ -313,6 +314,7 @@ pub fn block_info(
     total_supply: Balance,
 ) -> BlockInfo {
     BlockInfo {
+        hash,
         height,
         last_finalized_height,
         last_final_block_hash,
@@ -329,10 +331,6 @@ pub fn block_info(
     }
 }
 
-pub fn record_with_block_info(
-    epoch_manager: &mut EpochManager,
-    cur_hash: CryptoHash,
-    block_info: BlockInfo,
-) {
-    epoch_manager.record_block_info(&cur_hash, block_info, [0; 32]).unwrap().commit().unwrap();
+pub fn record_with_block_info(epoch_manager: &mut EpochManager, block_info: BlockInfo) {
+    epoch_manager.record_block_info(block_info, [0; 32]).unwrap().commit().unwrap();
 }

--- a/chain/jsonrpc/test-utils/src/lib.rs
+++ b/chain/jsonrpc/test-utils/src/lib.rs
@@ -1,7 +1,7 @@
 use actix::Addr;
 
 use near_chain_configs::GenesisConfig;
-use near_client::test_utils::setup_no_network_with_validity_period;
+use near_client::test_utils::setup_no_network_with_validity_period_and_no_epoch_sync;
 use near_client::ViewClientActor;
 use near_jsonrpc::{start_http, RpcConfig};
 use near_network::test_utils::open_port;
@@ -18,15 +18,15 @@ pub enum NodeType {
 }
 
 pub fn start_all(node_type: NodeType) -> (Addr<ViewClientActor>, String) {
-    start_all_with_validity_period(node_type, 100, false)
+    start_all_with_validity_period_and_no_epoch_sync(node_type, 100, false)
 }
 
-pub fn start_all_with_validity_period(
+pub fn start_all_with_validity_period_and_no_epoch_sync(
     node_type: NodeType,
     transaction_validity_period: NumBlocks,
     enable_doomslug: bool,
 ) -> (Addr<ViewClientActor>, String) {
-    let (client_addr, view_client_addr) = setup_no_network_with_validity_period(
+    let (client_addr, view_client_addr) = setup_no_network_with_validity_period_and_no_epoch_sync(
         vec!["test1", "test2"],
         if let NodeType::Validator = node_type { "test1" } else { "other" },
         true,

--- a/chain/jsonrpc/tests/rpc_transactions.rs
+++ b/chain/jsonrpc/tests/rpc_transactions.rs
@@ -102,8 +102,11 @@ fn test_send_tx_commit() {
 fn test_expired_tx() {
     init_integration_logger();
     run_actix_until_stop(async {
-        let (_, addr) =
-            test_utils::start_all_with_validity_period(test_utils::NodeType::Validator, 1, false);
+        let (_, addr) = test_utils::start_all_with_validity_period_and_no_epoch_sync(
+            test_utils::NodeType::Validator,
+            1,
+            false,
+        );
 
         let block_hash = Arc::new(Mutex::new(None));
         let block_height = Arc::new(Mutex::new(None));

--- a/chain/jsonrpc/tests/test_utils/mod.rs
+++ b/chain/jsonrpc/tests/test_utils/mod.rs
@@ -3,7 +3,7 @@ use futures::{future, future::LocalBoxFuture, FutureExt, TryFutureExt};
 use serde_json::json;
 
 use near_chain_configs::GenesisConfig;
-use near_client::test_utils::setup_no_network_with_validity_period;
+use near_client::test_utils::setup_no_network_with_validity_period_and_no_epoch_sync;
 use near_client::ViewClientActor;
 use near_jsonrpc::{start_http, RpcConfig};
 use near_network::test_utils::open_port;
@@ -22,15 +22,15 @@ pub enum NodeType {
 }
 
 pub fn start_all(node_type: NodeType) -> (Addr<ViewClientActor>, String) {
-    start_all_with_validity_period(node_type, 100, false)
+    start_all_with_validity_period_and_no_epoch_sync(node_type, 100, false)
 }
 
-pub fn start_all_with_validity_period(
+pub fn start_all_with_validity_period_and_no_epoch_sync(
     node_type: NodeType,
     transaction_validity_period: NumBlocks,
     enable_doomslug: bool,
 ) -> (Addr<ViewClientActor>, String) {
-    let (client_addr, view_client_addr) = setup_no_network_with_validity_period(
+    let (client_addr, view_client_addr) = setup_no_network_with_validity_period_and_no_epoch_sync(
         vec!["test1", "test2"],
         if let NodeType::Validator = node_type { "test1" } else { "other" },
         true,

--- a/chain/network/src/lib.rs
+++ b/chain/network/src/lib.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 extern crate lazy_static;
 
+pub use peer::{EPOCH_SYNC_PEER_TIMEOUT_MS, EPOCH_SYNC_REQUEST_TIMEOUT_MS};
 pub use peer_manager::PeerManagerActor;
 pub use types::{
     FullPeerInfo, NetworkAdapter, NetworkClientMessages, NetworkClientResponses, NetworkConfig,

--- a/chain/network/src/peer.rs
+++ b/chain/network/src/peer.rs
@@ -61,6 +61,13 @@ const MAX_PEER_MSG_PER_MIN: u64 = std::u64::MAX;
 /// dispatching transactions when we should be focusing on consensus-related messages.
 const MAX_TXNS_PER_BLOCK_MESSAGE: usize = 1000;
 
+/// The time we wait for the response to a Epoch Sync request before retrying
+// TODO #3488 set 30_000
+pub const EPOCH_SYNC_REQUEST_TIMEOUT_MS: u64 = 1_000;
+/// How frequently a Epoch Sync response can be sent to a particular peer
+// TODO #3488 set 60_000
+pub const EPOCH_SYNC_PEER_TIMEOUT_MS: u64 = 10;
+
 /// Internal structure to keep a circular queue within a tracker with unique hashes.
 struct CircularUniqueQueue {
     v: Vec<CryptoHash>,
@@ -183,6 +190,8 @@ pub struct Peer {
     txns_since_last_block: Arc<AtomicUsize>,
     /// How many peer actors are created
     peer_counter: Arc<AtomicUsize>,
+    /// The last time a Epoch Sync request was received from this peer
+    last_time_received_epoch_sync_request: Instant,
 }
 
 impl Peer {
@@ -221,6 +230,8 @@ impl Peer {
             network_metrics,
             txns_since_last_block,
             peer_counter,
+            last_time_received_epoch_sync_request: Instant::now()
+                - Duration::from_millis(EPOCH_SYNC_PEER_TIMEOUT_MS),
         }
     }
 
@@ -408,6 +419,13 @@ impl Peer {
             PeerMessage::BlockHeadersRequest(hashes) => {
                 NetworkViewClientMessages::BlockHeadersRequest(hashes)
             }
+            PeerMessage::EpochSyncRequest(epoch_id) => {
+                self.last_time_received_epoch_sync_request = Instant::now();
+                NetworkViewClientMessages::EpochSyncRequest { epoch_id }
+            }
+            PeerMessage::EpochSyncFinalizationRequest(epoch_id) => {
+                NetworkViewClientMessages::EpochSyncFinalizationRequest { epoch_id }
+            }
             peer_message => {
                 error!(target: "network", "Peer receive_view_client_message received unexpected type: {:?}", peer_message);
                 return;
@@ -454,6 +472,12 @@ impl Peer {
                     }
                     Ok(NetworkViewClientResponses::BlockHeaders(headers)) => {
                         act.send_message(&PeerMessage::BlockHeaders(headers))
+                    }
+                    Ok(NetworkViewClientResponses::EpochSyncResponse(response)) => {
+                        act.send_message(&PeerMessage::EpochSyncResponse(response))
+                    }
+                    Ok(NetworkViewClientResponses::EpochSyncFinalizationResponse(response)) => {
+                        act.send_message(&PeerMessage::EpochSyncFinalizationResponse(response))
                     }
                     Err(err) => {
                         error!(
@@ -551,6 +575,12 @@ impl Peer {
                 }
             }
             PeerMessage::Challenge(challenge) => NetworkClientMessages::Challenge(challenge),
+            PeerMessage::EpochSyncResponse(response) => {
+                NetworkClientMessages::EpochSyncResponse(peer_id, response)
+            }
+            PeerMessage::EpochSyncFinalizationResponse(response) => {
+                NetworkClientMessages::EpochSyncFinalizationResponse(peer_id, response)
+            }
             PeerMessage::Handshake(_)
             | PeerMessage::HandshakeV2(_)
             | PeerMessage::HandshakeFailure(_, _)
@@ -562,7 +592,9 @@ impl Peer {
             | PeerMessage::RequestUpdateNonce(_)
             | PeerMessage::ResponseUpdateNonce(_)
             | PeerMessage::BlockRequest(_)
-            | PeerMessage::BlockHeadersRequest(_) => {
+            | PeerMessage::BlockHeadersRequest(_)
+            | PeerMessage::EpochSyncRequest(_)
+            | PeerMessage::EpochSyncFinalizationRequest(_) => {
                 error!(target: "network", "Peer receive_client_message received unexpected type: {:?}", msg);
                 return;
             }

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -1307,6 +1307,24 @@ impl Handler<NetworkRequests> for PeerManagerActor {
                     NetworkResponses::RouteNotFound
                 }
             }
+            NetworkRequests::EpochSyncRequest { peer_id, epoch_id } => {
+                if self.send_message(ctx, peer_id, PeerMessage::EpochSyncRequest(epoch_id)) {
+                    NetworkResponses::NoResponse
+                } else {
+                    NetworkResponses::RouteNotFound
+                }
+            }
+            NetworkRequests::EpochSyncFinalizationRequest { peer_id, epoch_id } => {
+                if self.send_message(
+                    ctx,
+                    peer_id,
+                    PeerMessage::EpochSyncFinalizationRequest(epoch_id),
+                ) {
+                    NetworkResponses::NoResponse
+                } else {
+                    NetworkResponses::RouteNotFound
+                }
+            }
             NetworkRequests::BanPeer { peer_id, ban_reason } => {
                 self.try_ban_peer(ctx, &peer_id, ban_reason);
                 NetworkResponses::NoResponse

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -27,7 +27,10 @@ use near_primitives::sharding::{
     ChunkHash, PartialEncodedChunk, PartialEncodedChunkPart, PartialEncodedChunkV1,
     PartialEncodedChunkWithArcReceipts, ReceiptProof, ShardChunkHeader,
 };
-use near_primitives::syncing::{ShardStateSyncResponse, ShardStateSyncResponseV1};
+use near_primitives::syncing::{
+    EpochSyncFinalizationResponse, EpochSyncResponse, ShardStateSyncResponse,
+    ShardStateSyncResponseV1,
+};
 use near_primitives::transaction::{ExecutionOutcomeWithIdAndProof, SignedTransaction};
 use near_primitives::types::{AccountId, BlockHeight, BlockReference, EpochId, ShardId};
 use near_primitives::utils::{from_timestamp, to_timestamp};
@@ -761,6 +764,11 @@ pub enum PeerMessage {
     Disconnect,
     Challenge(Challenge),
     HandshakeV2(HandshakeV2),
+
+    EpochSyncRequest(EpochId),
+    EpochSyncResponse(EpochSyncResponse),
+    EpochSyncFinalizationRequest(EpochId),
+    EpochSyncFinalizationResponse(EpochSyncFinalizationResponse),
 }
 
 impl fmt::Display for PeerMessage {
@@ -784,7 +792,9 @@ impl PeerMessage {
             PeerMessage::Block(_)
             | PeerMessage::BlockHeaders(_)
             | PeerMessage::Transaction(_)
-            | PeerMessage::Challenge(_) => true,
+            | PeerMessage::Challenge(_)
+            | PeerMessage::EpochSyncResponse(_)
+            | PeerMessage::EpochSyncFinalizationResponse(_) => true,
             PeerMessage::Routed(r) => match r.body {
                 RoutedMessageBody::BlockApproval(_)
                 | RoutedMessageBody::ForwardTx(_)
@@ -817,6 +827,8 @@ impl PeerMessage {
             },
             PeerMessage::BlockHeadersRequest(_) => true,
             PeerMessage::BlockRequest(_) => true,
+            PeerMessage::EpochSyncRequest(_) => true,
+            PeerMessage::EpochSyncFinalizationRequest(_) => true,
             _ => false,
         }
     }
@@ -1135,6 +1147,9 @@ pub enum ReasonForBan {
     InvalidPeerId = 8,
     InvalidHash = 9,
     InvalidEdge = 10,
+    EpochSyncNoResponse = 11,
+    EpochSyncInvalidResponse = 12,
+    EpochSyncInvalidFinalizationResponse = 13,
 }
 
 /// Banning signal sent from Peer instance to PeerManager
@@ -1185,6 +1200,14 @@ pub enum NetworkRequests {
     StateResponse {
         route_back: CryptoHash,
         response: StateResponseInfo,
+    },
+    EpochSyncRequest {
+        peer_id: PeerId,
+        epoch_id: EpochId,
+    },
+    EpochSyncFinalizationRequest {
+        peer_id: PeerId,
+        epoch_id: EpochId,
     },
     /// Ban given peer.
     BanPeer {
@@ -1411,6 +1434,10 @@ pub enum NetworkClientMessages {
     BlockApproval(Approval, PeerId),
     /// State response.
     StateResponse(StateResponseInfo),
+    /// Epoch Sync response for light client block request
+    EpochSyncResponse(PeerId, EpochSyncResponse),
+    /// Epoch Sync response for finalization request
+    EpochSyncFinalizationResponse(PeerId, EpochSyncFinalizationResponse),
 
     /// Request chunk parts and/or receipts.
     PartialEncodedChunkRequest(PartialEncodedChunkRequestMsg, CryptoHash),
@@ -1492,6 +1519,10 @@ pub enum NetworkViewClientMessages {
     StateRequestHeader { shard_id: ShardId, sync_hash: CryptoHash },
     /// State request part.
     StateRequestPart { shard_id: ShardId, sync_hash: CryptoHash, part_id: u64 },
+    /// A request for a light client info during Epoch Sync
+    EpochSyncRequest { epoch_id: EpochId },
+    /// A request for headers and proofs during Epoch Sync
+    EpochSyncFinalizationRequest { epoch_id: EpochId },
     /// Get Chain information from Client.
     GetChainInfo,
     /// Account announcements that needs to be validated before being processed.
@@ -1522,6 +1553,10 @@ pub enum NetworkViewClientResponses {
     StateResponse(Box<StateResponseInfo>),
     /// Valid announce accounts.
     AnnounceAccount(Vec<AnnounceAccount>),
+    /// A response to a request for a light client block during Epoch Sync
+    EpochSyncResponse(EpochSyncResponse),
+    /// A response to a request for headers and proofs during Epoch Sync
+    EpochSyncFinalizationResponse(EpochSyncFinalizationResponse),
     /// Ban peer for malicious behavior.
     Ban { ban_reason: ReasonForBan },
     /// Response not needed

--- a/chain/network/tests/runner/mod.rs
+++ b/chain/network/tests/runner/mod.rs
@@ -62,7 +62,7 @@ pub fn setup_network_node(
     chain_genesis.time = genesis_time;
 
     let peer_manager = PeerManagerActor::create(move |ctx| {
-        let mut client_config = ClientConfig::test(false, 100, 200, num_validators, false);
+        let mut client_config = ClientConfig::test(false, 100, 200, num_validators, false, true);
         client_config.archive = config.archive;
         client_config.ttl_account_id_router = config.ttl_account_id_router;
         let network_adapter = NetworkRecipient::new();

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -91,6 +91,8 @@ pub struct ClientConfig {
     pub archive: bool,
     /// Number of threads for ViewClientActor pool.
     pub view_client_threads: usize,
+    /// Run Epoch Sync on the start.
+    pub epoch_sync_enabled: bool,
 }
 
 impl ClientConfig {
@@ -100,6 +102,7 @@ impl ClientConfig {
         max_block_prod_time: u64,
         num_block_producer_seats: NumSeats,
         archive: bool,
+        epoch_sync_enabled: bool,
     ) -> Self {
         ClientConfig {
             version: Default::default(),
@@ -144,6 +147,7 @@ impl ClientConfig {
             archive,
             log_summary_style: LogSummaryStyle::Colored,
             view_client_threads: 1,
+            epoch_sync_enabled,
         }
     }
 }

--- a/core/primitives/benches/serialization.rs
+++ b/core/primitives/benches/serialization.rs
@@ -50,10 +50,13 @@ fn create_block() -> Block {
         PROTOCOL_VERSION,
         genesis.header(),
         10,
-        genesis.header().block_ordinal() + 1,
+        #[cfg(feature = "protocol_feature_block_header_v3")]
+        (genesis.header().block_ordinal() + 1),
         vec![genesis.chunks()[0].clone()],
         EpochId::default(),
         EpochId::default(),
+        #[cfg(feature = "protocol_feature_block_header_v3")]
+        None,
         vec![],
         Rational::from_integer(0),
         0,

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -19,7 +19,9 @@ use crate::sharding::{
     ChunkHashHeight, EncodedShardChunk, ReedSolomonWrapper, ShardChunk, ShardChunkHeader,
     ShardChunkHeaderV1,
 };
-use crate::types::{Balance, BlockHeight, EpochId, Gas, NumBlocks, NumShards, StateRoot};
+#[cfg(feature = "protocol_feature_block_header_v3")]
+use crate::types::NumBlocks;
+use crate::types::{Balance, BlockHeight, EpochId, Gas, NumShards, StateRoot};
 use crate::utils::to_timestamp;
 use crate::validator_signer::{EmptyValidatorSigner, ValidatorSigner};
 use crate::version::{ProtocolVersion, SHARD_CHUNK_HEADER_UPGRADE_VERSION};
@@ -189,10 +191,13 @@ impl Block {
         protocol_version: ProtocolVersion,
         prev: &BlockHeader,
         height: BlockHeight,
-        block_ordinal: NumBlocks,
+        #[cfg(feature = "protocol_feature_block_header_v3")] block_ordinal: NumBlocks,
         chunks: Vec<ShardChunkHeader>,
         epoch_id: EpochId,
         next_epoch_id: EpochId,
+        #[cfg(feature = "protocol_feature_block_header_v3")] epoch_sync_data_hash: Option<
+            CryptoHash,
+        >,
         approvals: Vec<Option<Signature>>,
         gas_price_adjustment_rate: Rational,
         min_gas_price: Balance,
@@ -272,6 +277,7 @@ impl Block {
             random_value,
             validator_proposals,
             chunk_mask,
+            #[cfg(feature = "protocol_feature_block_header_v3")]
             block_ordinal,
             epoch_id,
             next_epoch_id,
@@ -281,6 +287,8 @@ impl Block {
             signer,
             last_final_block.clone(),
             last_ds_final_block.clone(),
+            #[cfg(feature = "protocol_feature_block_header_v3")]
+            epoch_sync_data_hash,
             approvals,
             next_bp_hash,
             block_merkle_root,

--- a/core/primitives/src/block_header.rs
+++ b/core/primitives/src/block_header.rs
@@ -110,6 +110,7 @@ pub struct BlockHeaderInnerRestV2 {
 
 /// Add `prev_height`
 /// Add `block_ordinal`
+/// Add `epoch_sync_data_hash`
 #[cfg(feature = "protocol_feature_block_header_v3")]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Debug, Clone, Eq, PartialEq)]
 pub struct BlockHeaderInnerRestV3 {
@@ -142,6 +143,8 @@ pub struct BlockHeaderInnerRestV3 {
     pub last_ds_final_block: CryptoHash,
 
     pub prev_height: BlockHeight,
+
+    pub epoch_sync_data_hash: Option<CryptoHash>,
 
     /// All the approvals included in this block
     pub approvals: Vec<Option<Signature>>,
@@ -343,7 +346,7 @@ impl BlockHeader {
         random_value: CryptoHash,
         validator_proposals: Vec<ValidatorStake>,
         chunk_mask: Vec<bool>,
-        #[allow(unused)] block_ordinal: NumBlocks,
+        #[cfg(feature = "protocol_feature_block_header_v3")] block_ordinal: NumBlocks,
         epoch_id: EpochId,
         next_epoch_id: EpochId,
         gas_price: Balance,
@@ -352,6 +355,9 @@ impl BlockHeader {
         signer: &dyn ValidatorSigner,
         last_final_block: CryptoHash,
         last_ds_final_block: CryptoHash,
+        #[cfg(feature = "protocol_feature_block_header_v3")] epoch_sync_data_hash: Option<
+            CryptoHash,
+        >,
         approvals: Vec<Option<Signature>>,
         next_bp_hash: CryptoHash,
         block_merkle_root: CryptoHash,
@@ -459,6 +465,7 @@ impl BlockHeader {
                     last_final_block,
                     last_ds_final_block,
                     prev_height,
+                    epoch_sync_data_hash,
                     approvals,
                     latest_protocol_version: PROTOCOL_VERSION,
                 };
@@ -594,6 +601,7 @@ impl BlockHeader {
                     last_final_block: CryptoHash::default(),
                     last_ds_final_block: CryptoHash::default(),
                     prev_height: 0,
+                    epoch_sync_data_hash: None, // Epoch Sync cannot be executed up to Genesis
                     approvals: vec![],
                     latest_protocol_version: genesis_protocol_version,
                 };
@@ -873,6 +881,16 @@ impl BlockHeader {
             BlockHeader::BlockHeaderV2(header) => &header.inner_lite.block_merkle_root,
             #[cfg(feature = "protocol_feature_block_header_v3")]
             BlockHeader::BlockHeaderV3(header) => &header.inner_lite.block_merkle_root,
+        }
+    }
+
+    #[inline]
+    pub fn epoch_sync_data_hash(&self) -> Option<CryptoHash> {
+        match self {
+            BlockHeader::BlockHeaderV1(_) => None,
+            BlockHeader::BlockHeaderV2(_) => None,
+            #[cfg(feature = "protocol_feature_block_header_v3")]
+            BlockHeader::BlockHeaderV3(header) => header.inner_rest.epoch_sync_data_hash,
         }
     }
 

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -50,8 +50,9 @@ pub struct EpochConfig {
 }
 
 /// Information per each block.
-#[derive(Default, BorshSerialize, BorshDeserialize, Serialize, Clone, Debug)]
+#[derive(Default, BorshSerialize, BorshDeserialize, Serialize, Eq, PartialEq, Clone, Debug)]
 pub struct BlockInfo {
+    pub hash: CryptoHash,
     pub height: BlockHeight,
     pub last_finalized_height: BlockHeight,
     pub last_final_block_hash: CryptoHash,
@@ -72,6 +73,7 @@ pub struct BlockInfo {
 
 impl BlockInfo {
     pub fn new(
+        hash: CryptoHash,
         height: BlockHeight,
         last_finalized_height: BlockHeight,
         last_final_block_hash: CryptoHash,
@@ -84,6 +86,7 @@ impl BlockInfo {
         #[cfg(feature = "protocol_feature_rectify_inflation")] timestamp_nanosec: u64,
     ) -> Self {
         Self {
+            hash,
             height,
             last_finalized_height,
             last_final_block_hash,

--- a/core/primitives/src/errors.rs
+++ b/core/primitives/src/errors.rs
@@ -685,7 +685,7 @@ pub enum EpochError {
     /// Only should happened if calling code doesn't check for integer value of stake > number of seats.
     ThresholdError { stake_sum: Balance, num_seats: u64 },
     /// Requesting validators for an epoch that wasn't computed yet.
-    EpochOutOfBounds,
+    EpochOutOfBounds(EpochId),
     /// Missing block hash in the storage (means there is some structural issue).
     MissingBlock(CryptoHash),
     /// Error due to IO (DB read/write, serialization, etc.).
@@ -704,7 +704,9 @@ impl Display for EpochError {
                 "Total stake {} must be higher than the number of seats {}",
                 stake_sum, num_seats
             ),
-            EpochError::EpochOutOfBounds => write!(f, "Epoch out of bounds"),
+            EpochError::EpochOutOfBounds(epoch_id) => {
+                write!(f, "Epoch {:?} is out of bounds", epoch_id)
+            }
             EpochError::MissingBlock(hash) => write!(f, "Missing block {}", hash),
             EpochError::IOErr(err) => write!(f, "IO: {}", err),
             EpochError::NotAValidator(account_id, epoch_id) => {
@@ -720,7 +722,7 @@ impl Debug for EpochError {
             EpochError::ThresholdError { stake_sum, num_seats } => {
                 write!(f, "ThresholdError({}, {})", stake_sum, num_seats)
             }
-            EpochError::EpochOutOfBounds => write!(f, "EpochOutOfBounds"),
+            EpochError::EpochOutOfBounds(epoch_id) => write!(f, "EpochOutOfBounds({:?})", epoch_id),
             EpochError::MissingBlock(hash) => write!(f, "MissingBlock({})", hash),
             EpochError::IOErr(err) => write!(f, "IOErr({})", err),
             EpochError::NotAValidator(account_id, epoch_id) => {

--- a/core/primitives/src/merkle.rs
+++ b/core/primitives/src/merkle.rs
@@ -131,7 +131,7 @@ pub fn compute_root_from_path_and_item<T: BorshSerialize>(
 /// The root can be computed by folding `path` from right but is not explicitly
 /// maintained to save space.
 /// The size of the object is O(log(n)) where n is the number of leaves in the tree, i.e, `size`.
-#[derive(Default, Clone, BorshSerialize, BorshDeserialize)]
+#[derive(Default, Clone, BorshSerialize, BorshDeserialize, Eq, PartialEq, Debug)]
 pub struct PartialMerkleTree {
     /// Path for the next leaf.
     path: Vec<MerkleHash>,

--- a/core/primitives/src/syncing.rs
+++ b/core/primitives/src/syncing.rs
@@ -1,13 +1,16 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::Serialize;
 
+use crate::block_header::BlockHeader;
+use crate::epoch_manager::{BlockInfo, EpochInfo};
 use crate::hash::CryptoHash;
-use crate::merkle::MerklePath;
+use crate::merkle::{MerklePath, PartialMerkleTree};
 use crate::receipt::Receipt;
 use crate::sharding::{
     ReceiptProof, ShardChunk, ShardChunkHeader, ShardChunkHeaderV1, ShardChunkV1,
 };
 use crate::types::{BlockHeight, ShardId, StateRoot, StateRootNode};
+use crate::views::LightClientBlockView;
 
 #[derive(PartialEq, Eq, Clone, Debug, BorshSerialize, BorshDeserialize, Serialize)]
 pub struct ReceiptResponse(pub CryptoHash, pub Vec<Receipt>);
@@ -186,6 +189,34 @@ impl ShardStateSyncResponseV1 {
     pub fn part_id(&self) -> Option<u64> {
         self.part.as_ref().map(|(part_id, _)| *part_id)
     }
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Eq, PartialEq, Debug, Clone)]
+pub struct EpochSyncFinalizationResponse {
+    pub cur_epoch_header: BlockHeader,
+    pub prev_epoch_headers: Vec<BlockHeader>,
+    pub header_sync_init_header: BlockHeader,
+    pub header_sync_init_header_tree: PartialMerkleTree,
+    // This Block Info is required by Epoch Manager when it checks if it's a good time to start a new Epoch.
+    // Epoch Manager asks for height difference by obtaining first Block Info of the Epoch.
+    pub prev_epoch_first_block_info: BlockInfo,
+    // This Block Info is required in State Sync that is started right after Epoch Sync is finished.
+    // It is used by `verify_chunk_signature_with_header_parts` in `save_block` as it calls `get_epoch_id_from_prev_block`.
+    pub prev_epoch_prev_last_block_info: BlockInfo,
+    // This Block Info is connected with the first actual Block received in State Sync.
+    // It is also used in Epoch Manager.
+    pub prev_epoch_last_block_info: BlockInfo,
+    pub prev_epoch_info: EpochInfo,
+    pub cur_epoch_info: EpochInfo,
+    // Next Epoch Info is required by Block Sync when Blocks of current Epoch will come.
+    // It asks in `process_block_single`, returns `Epoch Out Of Bounds` error otherwise.
+    pub next_epoch_info: EpochInfo,
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Eq, PartialEq, Debug, Clone)]
+pub enum EpochSyncResponse {
+    UpToDate,
+    Advance { light_client_block_view: LightClientBlockView },
 }
 
 pub fn get_num_state_parts(memory_usage: u64) -> u64 {

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -399,10 +399,13 @@ impl Block {
             PROTOCOL_VERSION,
             prev.header(),
             height,
-            prev.header().block_ordinal() + 1,
+            #[cfg(feature = "protocol_feature_block_header_v3")]
+            (prev.header().block_ordinal() + 1),
             prev.chunks().iter().cloned().collect(),
             epoch_id,
             next_epoch_id,
+            #[cfg(feature = "protocol_feature_block_header_v3")]
+            None,
             approvals,
             Rational::from_integer(0),
             0,

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -16,7 +16,7 @@ pub struct Version {
 pub type DbVersion = u32;
 
 /// Current version of the database.
-pub const DB_VERSION: DbVersion = 17;
+pub const DB_VERSION: DbVersion = 18;
 
 /// Protocol version type.
 pub use near_primitives_core::types::ProtocolVersion;

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -438,6 +438,8 @@ pub struct BlockHeaderView {
     pub last_ds_final_block: CryptoHash,
     pub next_bp_hash: CryptoHash,
     pub block_merkle_root: CryptoHash,
+    #[cfg(feature = "protocol_feature_block_header_v3")]
+    pub epoch_sync_data_hash: Option<CryptoHash>,
     pub approvals: Vec<Option<Signature>>,
     pub signature: Signature,
     pub latest_protocol_version: ProtocolVersion,
@@ -484,6 +486,8 @@ impl From<BlockHeader> for BlockHeaderView {
             last_ds_final_block: header.last_ds_final_block().clone(),
             next_bp_hash: header.next_bp_hash().clone(),
             block_merkle_root: header.block_merkle_root().clone(),
+            #[cfg(feature = "protocol_feature_block_header_v3")]
+            epoch_sync_data_hash: header.epoch_sync_data_hash(),
             approvals: header.approvals().to_vec(),
             signature: header.signature().clone(),
             latest_protocol_version: header.latest_protocol_version(),
@@ -604,6 +608,7 @@ impl From<BlockHeaderView> for BlockHeader {
                         last_final_block: view.last_final_block,
                         last_ds_final_block: view.last_ds_final_block,
                         prev_height: view.prev_height.unwrap_or_default(),
+                        epoch_sync_data_hash: view.epoch_sync_data_hash,
                         approvals: view.approvals.clone(),
                         latest_protocol_version: view.latest_protocol_version,
                     },
@@ -617,7 +622,7 @@ impl From<BlockHeaderView> for BlockHeader {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, BorshDeserialize, BorshSerialize)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, BorshDeserialize, BorshSerialize)]
 pub struct BlockHeaderInnerLiteView {
     pub height: BlockHeight,
     pub epoch_id: CryptoHash,
@@ -669,6 +674,21 @@ impl From<BlockHeader> for BlockHeaderInnerLiteView {
                 next_bp_hash: header.inner_lite.next_bp_hash,
                 block_merkle_root: header.inner_lite.block_merkle_root,
             },
+        }
+    }
+}
+
+impl From<BlockHeaderInnerLiteView> for BlockHeaderInnerLite {
+    fn from(view: BlockHeaderInnerLiteView) -> Self {
+        BlockHeaderInnerLite {
+            height: view.height,
+            epoch_id: EpochId(view.epoch_id),
+            next_epoch_id: EpochId(view.next_epoch_id),
+            prev_state_root: view.prev_state_root,
+            outcome_root: view.outcome_root,
+            timestamp: view.timestamp_nanosec,
+            next_bp_hash: view.next_bp_hash,
+            block_merkle_root: view.block_merkle_root,
         }
     }
 }
@@ -1286,7 +1306,7 @@ pub struct NextEpochValidatorInfo {
     pub shards: Vec<ShardId>,
 }
 
-#[derive(Serialize, Debug, Clone, BorshDeserialize, BorshSerialize)]
+#[derive(Serialize, PartialEq, Eq, Debug, Clone, BorshDeserialize, BorshSerialize)]
 pub struct LightClientBlockView {
     pub prev_block_hash: CryptoHash,
     pub next_block_inner_hash: CryptoHash,

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -36,8 +36,9 @@ default = []
 no_cache = []
 adversarial = []
 protocol_feature_rectify_inflation = []
+protocol_feature_block_header_v3 = []
 nightly_protocol = []
-nightly_protocol_features = ["nightly_protocol", "protocol_feature_rectify_inflation"]
+nightly_protocol_features = ["nightly_protocol", "protocol_feature_rectify_inflation", "protocol_feature_block_header_v3"]
 
 [package.metadata.workspaces]
 independent = true

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -115,10 +115,12 @@ pub enum DBCol {
     ColCachedContractCode = 46,
     /// Epoch validator information used for rpc purposes
     ColEpochValidatorInfo = 47,
+    /// Header Hashes indexed by Height
+    ColHeaderHashesByHeight = 48,
 }
 
 // Do not move this line from enum DBCol
-pub const NUM_COLS: usize = 48;
+pub const NUM_COLS: usize = 49;
 
 impl std::fmt::Display for DBCol {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
@@ -171,6 +173,7 @@ impl std::fmt::Display for DBCol {
             Self::ColReceipts => "receipts",
             Self::ColCachedContractCode => "cached code",
             Self::ColEpochValidatorInfo => "epoch validator info",
+            Self::ColHeaderHashesByHeight => "header hashes indexed by their height",
         };
         write!(formatter, "{}", desc)
     }
@@ -188,6 +191,7 @@ lazy_static! {
         let mut col_gc = vec![true; NUM_COLS];
         col_gc[DBCol::ColDbVersion as usize] = false; // DB version is unrelated to GC
         col_gc[DBCol::ColBlockMisc as usize] = false;
+        // TODO #3488 remove
         col_gc[DBCol::ColBlockHeader as usize] = false; // header sync needs headers
         col_gc[DBCol::ColGCCount as usize] = false; // GC count it self isn't GCed
         col_gc[DBCol::ColBlockHeight as usize] = false; // block sync needs it + genesis should be accessible

--- a/core/store/src/migrations.rs
+++ b/core/store/src/migrations.rs
@@ -20,7 +20,9 @@ use crate::migrations::v6_to_v7::{
 use crate::migrations::v8_to_v9::{
     recompute_col_rc, repair_col_receipt_id_to_shard_id, repair_col_transactions,
 };
-use crate::{create_store, Store, StoreUpdate, Trie, TrieUpdate, FINAL_HEAD_KEY, HEAD_KEY};
+use crate::{
+    create_store, Store, StoreUpdate, Trie, TrieUpdate, CHUNK_TAIL_KEY, FINAL_HEAD_KEY, HEAD_KEY,
+};
 
 use crate::trie::{TrieCache, TrieCachingStorage};
 use near_crypto::KeyType;
@@ -276,11 +278,11 @@ pub fn migrate_11_to_12(path: &String) {
     set_store_version(&store, 12);
 }
 
-fn map_col<T, U, F>(store: &Store, col: DBCol, f: F) -> Result<(), std::io::Error>
+fn map_col<T, U, F>(store: &Store, col: DBCol, mut f: F) -> Result<(), std::io::Error>
 where
     T: BorshDeserialize,
     U: BorshSerialize,
-    F: Fn(T) -> U,
+    F: FnMut(T) -> U,
 {
     let mut store_update = store.store_update();
     let batch_size_limit = 10_000_000;
@@ -512,14 +514,102 @@ pub fn migrate_14_to_15(path: &String) {
     set_store_version(&store, 15);
 }
 
+pub fn migrate_17_to_18(path: &String) {
+    use std::convert::TryFrom;
+
+    use near_primitives::challenge::SlashedValidator;
+    use near_primitives::types::{Balance, BlockHeight, EpochId, ValidatorStake};
+    use near_primitives::utils::index_to_bytes;
+    use near_primitives::version::ProtocolVersion;
+
+    // Migrate from OldBlockInfo to NewBlockInfo - add hash
+    #[derive(BorshDeserialize)]
+    struct OldBlockInfo {
+        pub height: BlockHeight,
+        pub last_finalized_height: BlockHeight,
+        pub last_final_block_hash: CryptoHash,
+        pub prev_hash: CryptoHash,
+        pub epoch_first_block: CryptoHash,
+        pub epoch_id: EpochId,
+        pub proposals: Vec<ValidatorStake>,
+        pub validator_mask: Vec<bool>,
+        pub latest_protocol_version: ProtocolVersion,
+        pub slashed: Vec<SlashedValidator>,
+        pub total_supply: Balance,
+    }
+    #[derive(BorshSerialize)]
+    struct NewBlockInfo {
+        pub hash: CryptoHash,
+        pub height: BlockHeight,
+        pub last_finalized_height: BlockHeight,
+        pub last_final_block_hash: CryptoHash,
+        pub prev_hash: CryptoHash,
+        pub epoch_first_block: CryptoHash,
+        pub epoch_id: EpochId,
+        pub proposals: Vec<ValidatorStake>,
+        pub validator_mask: Vec<bool>,
+        pub latest_protocol_version: ProtocolVersion,
+        pub slashed: Vec<SlashedValidator>,
+        pub total_supply: Balance,
+    }
+    let store = create_store(path);
+    map_col_from_key(&store, DBCol::ColBlockInfo, |key| {
+        let hash = CryptoHash::try_from(key).unwrap();
+        let old_block_info =
+            store.get_ser::<OldBlockInfo>(DBCol::ColBlockInfo, key).unwrap().unwrap();
+        NewBlockInfo {
+            hash,
+            height: old_block_info.height,
+            last_finalized_height: old_block_info.last_finalized_height,
+            last_final_block_hash: old_block_info.last_final_block_hash,
+            prev_hash: old_block_info.prev_hash,
+            epoch_first_block: old_block_info.epoch_first_block,
+            epoch_id: old_block_info.epoch_id,
+            proposals: old_block_info.proposals,
+            validator_mask: old_block_info.validator_mask,
+            latest_protocol_version: old_block_info.latest_protocol_version,
+            slashed: old_block_info.slashed,
+            total_supply: old_block_info.total_supply,
+        }
+    })
+    .unwrap();
+
+    // Add ColHeaderHashesByHeight
+    let chunk_tail =
+        store.get_ser::<BlockHeight>(ColBlockMisc, CHUNK_TAIL_KEY).unwrap().unwrap_or(0);
+    let mut heights_to_hashes = HashMap::new();
+
+    map_col(&store, DBCol::ColBlockHeader, |header: BlockHeader| {
+        let height = header.height();
+        if height >= chunk_tail {
+            heights_to_hashes.entry(height).or_insert_with(Vec::new).push(header.hash().clone());
+        } else {
+            // ColHeaderHashesByHeight will be GCed for current height, do nothing
+        };
+        header
+    })
+    .unwrap();
+
+    let mut store_update = store.store_update();
+    for (height, hashes) in heights_to_hashes {
+        store_update
+            .set_ser(DBCol::ColHeaderHashesByHeight, &index_to_bytes(height), &hashes)
+            .expect("storage update should not fail");
+    }
+    store_update.commit().expect("storage update should not fail");
+
+    set_store_version(&store, 18);
+}
+
 #[cfg(feature = "protocol_feature_rectify_inflation")]
-pub fn migrate_16_to_rectify_inflation(path: &String) {
+pub fn migrate_18_to_rectify_inflation(path: &String) {
     use near_primitives::epoch_manager::BlockInfo;
     use near_primitives::epoch_manager::SlashState;
     use near_primitives::types::{AccountId, Balance, BlockHeight, EpochId, ValidatorStake};
     use near_primitives::version::ProtocolVersion;
     #[derive(BorshDeserialize)]
     struct OldBlockInfo {
+        pub hash: CryptoHash,
         pub height: BlockHeight,
         pub last_finalized_height: BlockHeight,
         pub last_final_block_hash: CryptoHash,
@@ -539,6 +629,7 @@ pub fn migrate_16_to_rectify_inflation(path: &String) {
         let old_block_info =
             store.get_ser::<OldBlockInfo>(DBCol::ColBlockInfo, key).unwrap().unwrap();
         BlockInfo::new(
+            *block_header.hash(),
             block_header.height(),
             old_block_info.last_finalized_height,
             *block_header.last_final_block(),

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -69,7 +69,7 @@ protocol_feature_forward_chunk_parts = ["near-client/protocol_feature_forward_ch
 protocol_feature_rectify_inflation = ["near-epoch-manager/protocol_feature_rectify_inflation"]
 protocol_feature_evm = ["near-primitives/protocol_feature_evm", "node-runtime/protocol_feature_evm", "near-chain-configs/protocol_feature_evm", "near-chain/protocol_feature_evm"]
 protocol_feature_alt_bn128 = ["near-primitives/protocol_feature_alt_bn128", "node-runtime/protocol_feature_alt_bn128"]
-protocol_feature_block_header_v3 = ["near-primitives/protocol_feature_block_header_v3", "near-chain/protocol_feature_block_header_v3", "near-client/protocol_feature_block_header_v3"]
+protocol_feature_block_header_v3 = ["near-epoch-manager/protocol_feature_block_header_v3", "near-primitives/protocol_feature_block_header_v3", "near-chain/protocol_feature_block_header_v3", "near-client/protocol_feature_block_header_v3"]
 nightly_protocol_features = ["nightly_protocol", "near-primitives/nightly_protocol_features", "near-client/nightly_protocol_features", "near-epoch-manager/nightly_protocol_features", "near-store/nightly_protocol_features", "protocol_feature_forward_chunk_parts", "protocol_feature_rectify_inflation", "protocol_feature_evm", "protocol_feature_block_header_v3", "protocol_feature_alt_bn128"]
 nightly_protocol = ["near-primitives/nightly_protocol", "near-jsonrpc/nightly_protocol"]
 

--- a/neard/src/config.rs
+++ b/neard/src/config.rs
@@ -419,6 +419,7 @@ pub struct Config {
     pub gc_blocks_limit: NumBlocks,
     #[serde(default = "default_view_client_threads")]
     pub view_client_threads: usize,
+    pub epoch_sync_enabled: bool,
 }
 
 impl Default for Config {
@@ -440,6 +441,7 @@ impl Default for Config {
             log_summary_style: LogSummaryStyle::Colored,
             gc_blocks_limit: default_gc_blocks_limit(),
             view_client_threads: 4,
+            epoch_sync_enabled: true,
         }
     }
 }
@@ -606,6 +608,7 @@ impl NearConfig {
                 log_summary_style: config.log_summary_style,
                 gc_blocks_limit: config.gc_blocks_limit,
                 view_client_threads: config.view_client_threads,
+                epoch_sync_enabled: config.epoch_sync_enabled,
             },
             network_config: NetworkConfig {
                 public_key: network_key_pair.public_key,

--- a/neard/src/lib.rs
+++ b/neard/src/lib.rs
@@ -23,12 +23,12 @@ use crate::migrations::migrate_12_to_13;
 pub use crate::runtime::NightshadeRuntime;
 use near_store::migrations::{
     fill_col_outcomes_by_hash, fill_col_transaction_refcount, get_store_version, migrate_10_to_11,
-    migrate_11_to_12, migrate_13_to_14, migrate_14_to_15, migrate_6_to_7, migrate_7_to_8,
-    migrate_8_to_9, migrate_9_to_10, set_store_version,
+    migrate_11_to_12, migrate_13_to_14, migrate_14_to_15, migrate_17_to_18, migrate_6_to_7,
+    migrate_7_to_8, migrate_8_to_9, migrate_9_to_10, set_store_version,
 };
 
 #[cfg(feature = "protocol_feature_rectify_inflation")]
-use near_store::migrations::migrate_16_to_rectify_inflation;
+use near_store::migrations::migrate_18_to_rectify_inflation;
 
 pub mod config;
 pub mod genesis_validate;
@@ -184,10 +184,15 @@ pub fn apply_store_migrations(path: &String, near_config: &NearConfig) {
         let store = create_store(&path);
         set_store_version(&store, 17);
     }
+    if db_version <= 17 {
+        info!(target: "near", "Migrate DB from version 17 to 18");
+        // version 17 => 18: add `hash` to `BlockInfo` and ColHeaderHashesByHeight
+        migrate_17_to_18(&path);
+    }
     #[cfg(feature = "protocol_feature_rectify_inflation")]
-    if db_version <= 16 {
-        // version 16 => rectify inflation: add `timestamp` to `BlockInfo`
-        migrate_16_to_rectify_inflation(&path);
+    if db_version <= 18 {
+        // version 18 => rectify inflation: add `timestamp` to `BlockInfo`
+        migrate_18_to_rectify_inflation(&path);
     }
     #[cfg(feature = "nightly_protocol")]
     {

--- a/neard/src/runtime.rs
+++ b/neard/src/runtime.rs
@@ -26,7 +26,7 @@ use near_primitives::account::{AccessKey, Account};
 use near_primitives::block::{Approval, ApprovalInner};
 use near_primitives::challenge::ChallengesResult;
 use near_primitives::contract::ContractCode;
-use near_primitives::epoch_manager::{BlockInfo, EpochConfig};
+use near_primitives::epoch_manager::{BlockInfo, EpochConfig, EpochInfo};
 use near_primitives::errors::{EpochError, InvalidTxError, RuntimeError};
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::receipt::Receipt;
@@ -1048,9 +1048,82 @@ impl RuntimeAdapter for NightshadeRuntime {
         Ok(epoch_manager.get_epoch_info(epoch_id)?.minted_amount)
     }
 
+    // TODO #3488 this likely to be updated
+    fn get_epoch_sync_data_hash(
+        &self,
+        prev_epoch_last_block_hash: &CryptoHash,
+        epoch_id: &EpochId,
+        next_epoch_id: &EpochId,
+    ) -> Result<CryptoHash, Error> {
+        let (
+            prev_epoch_first_block_info,
+            prev_epoch_prev_last_block_info,
+            prev_epoch_last_block_info,
+            prev_epoch_info,
+            cur_epoch_info,
+            next_epoch_info,
+        ) = self.get_epoch_sync_data(prev_epoch_last_block_hash, epoch_id, next_epoch_id)?;
+        let mut data = prev_epoch_first_block_info.try_to_vec().unwrap();
+        data.extend(prev_epoch_prev_last_block_info.try_to_vec().unwrap());
+        data.extend(prev_epoch_last_block_info.try_to_vec().unwrap());
+        data.extend(prev_epoch_info.try_to_vec().unwrap());
+        data.extend(cur_epoch_info.try_to_vec().unwrap());
+        data.extend(next_epoch_info.try_to_vec().unwrap());
+        Ok(hash(data.as_slice()))
+    }
+
+    // TODO #3488 this likely to be updated
+    fn get_epoch_sync_data(
+        &self,
+        prev_epoch_last_block_hash: &CryptoHash,
+        epoch_id: &EpochId,
+        next_epoch_id: &EpochId,
+    ) -> Result<(BlockInfo, BlockInfo, BlockInfo, EpochInfo, EpochInfo, EpochInfo), Error> {
+        let mut epoch_manager = self.epoch_manager.as_ref().write().expect(POISONED_LOCK_ERR);
+        let last_block_info = epoch_manager.get_block_info(prev_epoch_last_block_hash)?.clone();
+        let prev_epoch_id = last_block_info.epoch_id.clone();
+        Ok((
+            epoch_manager.get_block_info(&last_block_info.epoch_first_block)?.clone(),
+            epoch_manager.get_block_info(&last_block_info.prev_hash)?.clone(),
+            last_block_info,
+            epoch_manager.get_epoch_info(&prev_epoch_id)?.clone(),
+            epoch_manager.get_epoch_info(epoch_id)?.clone(),
+            epoch_manager.get_epoch_info(next_epoch_id)?.clone(),
+        ))
+    }
+
     fn get_epoch_protocol_version(&self, epoch_id: &EpochId) -> Result<ProtocolVersion, Error> {
         let mut epoch_manager = self.epoch_manager.as_ref().write().expect(POISONED_LOCK_ERR);
         Ok(epoch_manager.get_epoch_info(epoch_id)?.protocol_version)
+    }
+
+    fn epoch_sync_init_epoch_manager(
+        &self,
+        prev_epoch_first_block_info: BlockInfo,
+        prev_epoch_prev_last_block_info: BlockInfo,
+        prev_epoch_last_block_info: BlockInfo,
+        prev_epoch_id: &EpochId,
+        prev_epoch_info: EpochInfo,
+        epoch_id: &EpochId,
+        epoch_info: EpochInfo,
+        next_epoch_id: &EpochId,
+        next_epoch_info: EpochInfo,
+    ) -> Result<(), Error> {
+        let mut epoch_manager = self.epoch_manager.as_ref().write().expect(POISONED_LOCK_ERR);
+        epoch_manager
+            .init_after_epoch_sync(
+                prev_epoch_first_block_info,
+                prev_epoch_prev_last_block_info,
+                prev_epoch_last_block_info,
+                prev_epoch_id,
+                prev_epoch_info,
+                epoch_id,
+                epoch_info,
+                next_epoch_id,
+                next_epoch_info,
+            )?
+            .commit()
+            .map_err(|err| err.into())
     }
 
     fn add_validator_proposals(&self, block_header_info: BlockHeaderInfo) -> Result<(), Error> {
@@ -1064,6 +1137,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         // Deal with validator proposals and epoch finishing.
         let mut epoch_manager = self.epoch_manager.as_ref().write().expect(POISONED_LOCK_ERR);
         let block_info = BlockInfo::new(
+            block_header_info.hash,
             block_header_info.height,
             block_header_info.last_finalized_height,
             block_header_info.last_finalized_block_hash,
@@ -1078,10 +1152,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         );
         let rng_seed = (block_header_info.random_value.0).0;
         // TODO: don't commit here, instead contribute to upstream store update.
-        epoch_manager
-            .record_block_info(&block_header_info.hash, block_info, rng_seed)?
-            .commit()
-            .map_err(|err| err.into())
+        epoch_manager.record_block_info(block_info, rng_seed)?.commit().map_err(|err| err.into())
     }
 
     fn apply_transactions_with_optional_storage_proof(

--- a/neard/src/shard_tracker.rs
+++ b/neard/src/shard_tracker.rs
@@ -296,8 +296,8 @@ mod tests {
     ) {
         epoch_manager
             .record_block_info(
-                &cur_h,
                 BlockInfo::new(
+                    cur_h,
                     height,
                     0,
                     prev_h,

--- a/neard/tests/stake_nodes.rs
+++ b/neard/tests/stake_nodes.rs
@@ -71,6 +71,7 @@ fn init_test_staking(
             config.network_config.boot_nodes = convert_boot_nodes(vec![("near.0", first_node)]);
         }
         config.client_config.min_num_peers = num_node_seats as usize - 1;
+        config.client_config.epoch_sync_enabled = false;
         config
     });
     configs

--- a/neard/tests/sync_state_nodes.rs
+++ b/neard/tests/sync_state_nodes.rs
@@ -24,6 +24,7 @@ fn sync_state_nodes() {
         let mut near1 = load_test_config("test1", port1, genesis.clone());
         near1.network_config.boot_nodes = convert_boot_nodes(vec![]);
         near1.client_config.min_num_peers = 0;
+        near1.client_config.epoch_sync_enabled = false;
         run_actix_until_stop(async move {
             let dir1 = tempfile::Builder::new().prefix("sync_nodes_1").tempdir().unwrap();
             let (_, view_client1, _) = start_with_config(dir1.path(), near1);
@@ -53,6 +54,7 @@ fn sync_state_nodes() {
                                         near2.client_config.min_num_peers = 1;
                                         near2.network_config.boot_nodes =
                                             convert_boot_nodes(vec![("test1", port1)]);
+                                        near2.client_config.epoch_sync_enabled = false;
 
                                         let dir2 = tempfile::Builder::new()
                                             .prefix("sync_nodes_2")
@@ -119,6 +121,7 @@ fn sync_state_nodes_multishard() {
             near1.client_config.min_num_peers = 2;
             near1.client_config.min_block_production_delay = Duration::from_millis(200);
             near1.client_config.max_block_production_delay = Duration::from_millis(400);
+            near1.client_config.epoch_sync_enabled = false;
 
             let mut near3 = load_test_config("test3", port3, genesis.clone());
             near3.network_config.boot_nodes =
@@ -128,6 +131,7 @@ fn sync_state_nodes_multishard() {
                 near1.client_config.min_block_production_delay;
             near3.client_config.max_block_production_delay =
                 near1.client_config.max_block_production_delay;
+            near3.client_config.epoch_sync_enabled = false;
 
             let mut near4 = load_test_config("test4", port4, genesis.clone());
             near4.network_config.boot_nodes =
@@ -137,6 +141,7 @@ fn sync_state_nodes_multishard() {
                 near1.client_config.min_block_production_delay;
             near4.client_config.max_block_production_delay =
                 near1.client_config.max_block_production_delay;
+            near4.client_config.epoch_sync_enabled = false;
 
             let dir1 = tempfile::Builder::new().prefix("sync_nodes_1").tempdir().unwrap();
             let (_, view_client1, _) = start_with_config(dir1.path(), near1);
@@ -178,6 +183,7 @@ fn sync_state_nodes_multishard() {
                                             ("test3", port3),
                                             ("test4", port4),
                                         ]);
+                                        near2.client_config.epoch_sync_enabled = false;
 
                                         let dir2 = tempfile::Builder::new()
                                             .prefix("sync_nodes_2")
@@ -250,6 +256,7 @@ fn sync_empty_state() {
             near1.client_config.min_num_peers = 0;
             near1.client_config.min_block_production_delay = Duration::from_millis(200);
             near1.client_config.max_block_production_delay = Duration::from_millis(400);
+            near1.client_config.epoch_sync_enabled = false;
 
             let dir1 = tempfile::Builder::new().prefix("sync_nodes_1").tempdir().unwrap();
             let (_, view_client1, _) = start_with_config(dir1.path(), near1);
@@ -290,6 +297,7 @@ fn sync_empty_state() {
                                         near2.client_config.block_fetch_horizon =
                                             block_fetch_horizon;
                                         near2.client_config.tracked_shards = vec![0, 1, 2, 3];
+                                        near2.client_config.epoch_sync_enabled = false;
 
                                         let (_, view_client2, arbiters) =
                                             start_with_config(dir2.path(), near2);

--- a/test-utils/testlib/src/lib.rs
+++ b/test-utils/testlib/src/lib.rs
@@ -96,6 +96,7 @@ pub fn start_nodes(
             );
             near_config.client_config.tracked_shards.extend(&(from..to).collect::<Vec<_>>());
         }
+        near_config.client_config.epoch_sync_enabled = false;
         near_configs.push(near_config);
     }
 


### PR DESCRIPTION
This change is related to #3488 and contains the following features:

- `ColHeaderHashesByHeight` DB column is added that stores map from Block Header Height to the list of available Headers (GC at chunk_tail is enabled)
- BlockHeaderV3 is updated with Epoch Manager data needed by Epoch Sync
- Network Epoch Sync requests and responses skeleton
- EpochSync class and its initialization
- `save_header_head_forcibly`, `save_block_header_no_update_tree`, `epoch_sync_init_epoch_manager` and other methods needed by Epoch Sync
- BlockInfo is updated to store its hash
- `migrate_16_to_17` migration
- Store Validator update
- `BlockMissing` error is removed
- `update_*head*` methods need Header instead of Block
- `EpochOutOfBounds` error is extended with EpochId
- tests fixes and other minor updates/fixes

This change is important for two reasons:
1. The nodes will apply migrations early and will be prepared to the following protocol upgrade.
2. Due to many files affected (58), this commit solidifies the scope of Epoch Sync / GC Headers work, helps to manage following tasks and decreases the number of merge conflicts in future.

Also tested locally on `gc_sync_after_sync.py` and `gc_after_sync.py` as those tests are most sensitive to the changes.