### PR TITLE
refactor: improve test compilation speed and organization

### DIFF
--- a/runtime/near-vm-runner/src/lib.rs
+++ b/runtime/near-vm-runner/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+mod tests;
+
 mod cache;
 mod errors;
 mod imports;
@@ -21,6 +24,5 @@ pub use runner::compile_module;
 pub use runner::run;
 pub use runner::run_vm;
 pub use runner::run_vm_profiled;
-pub use runner::with_vm_variants;
 
 pub use near_vm_logic::with_ext_cost_counter;

--- a/runtime/near-vm-runner/src/runner.rs
+++ b/runtime/near-vm-runner/src/runner.rs
@@ -207,17 +207,6 @@ pub fn precompile<'a>(
     }
 }
 
-pub fn with_vm_variants(runner: fn(VMKind) -> ()) {
-    #[cfg(feature = "wasmer0_vm")]
-    runner(VMKind::Wasmer0);
-
-    #[cfg(feature = "wasmtime_vm")]
-    runner(VMKind::Wasmtime);
-
-    #[cfg(feature = "wasmer1_vm")]
-    runner(VMKind::Wasmer1);
-}
-
 /// Used for testing cost of compiling a module
 pub fn compile_module(vm_kind: VMKind, code: &Vec<u8>) -> bool {
     match vm_kind {

--- a/runtime/near-vm-runner/src/tests.rs
+++ b/runtime/near-vm-runner/src/tests.rs
@@ -1,26 +1,41 @@
-use std::collections::hash_map::DefaultHasher;
+mod error_cases;
+mod invalid_contracts;
+mod rs_contract;
+mod ts_contract;
+
+use std::collections::hash_map::{DefaultHasher, HashMap};
 use std::hash::{Hash, Hasher};
+use std::sync::{Arc, Mutex};
 
 use wabt::Wat2Wasm;
 
+use crate::run_vm;
 use near_primitives::runtime::fees::RuntimeFeesConfig;
 use near_primitives::types::CompiledContractCache;
 use near_primitives::version::ProtocolVersion;
 use near_vm_errors::VMError;
 use near_vm_logic::mocks::mock_external::MockedExternal;
 use near_vm_logic::{VMConfig, VMContext, VMKind, VMOutcome};
-use near_vm_runner::run_vm;
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
 
-pub const CURRENT_ACCOUNT_ID: &str = "alice";
-pub const SIGNER_ACCOUNT_ID: &str = "bob";
-pub const SIGNER_ACCOUNT_PK: [u8; 3] = [0, 1, 2];
-pub const PREDECESSOR_ACCOUNT_ID: &str = "carol";
+const CURRENT_ACCOUNT_ID: &str = "alice";
+const SIGNER_ACCOUNT_ID: &str = "bob";
+const SIGNER_ACCOUNT_PK: [u8; 3] = [0, 1, 2];
+const PREDECESSOR_ACCOUNT_ID: &str = "carol";
 
-pub const LATEST_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::MAX;
+const LATEST_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::MAX;
 
-pub fn create_context(input: Vec<u8>) -> VMContext {
+fn with_vm_variants(runner: fn(VMKind) -> ()) {
+    #[cfg(feature = "wasmer0_vm")]
+    runner(VMKind::Wasmer0);
+
+    #[cfg(feature = "wasmtime_vm")]
+    runner(VMKind::Wasmtime);
+
+    #[cfg(feature = "wasmer1_vm")]
+    runner(VMKind::Wasmer1);
+}
+
+fn create_context(input: Vec<u8>) -> VMContext {
     VMContext {
         current_account_id: CURRENT_ACCOUNT_ID.to_owned(),
         signer_account_id: SIGNER_ACCOUNT_ID.to_owned(),
@@ -41,7 +56,7 @@ pub fn create_context(input: Vec<u8>) -> VMContext {
     }
 }
 
-pub fn make_simple_contract_call_with_gas_vm(
+fn make_simple_contract_call_with_gas_vm(
     code: &[u8],
     method_name: &str,
     prepaid_gas: u64,
@@ -73,22 +88,7 @@ pub fn make_simple_contract_call_with_gas_vm(
     )
 }
 
-pub fn make_simple_contract_call_with_gas(
-    code: &[u8],
-    method_name: &str,
-    prepaid_gas: u64,
-) -> (Option<VMOutcome>, Option<VMError>) {
-    make_simple_contract_call_with_gas_vm(code, method_name, prepaid_gas, VMKind::default())
-}
-
-pub fn make_simple_contract_call(
-    code: &[u8],
-    method_name: &str,
-) -> (Option<VMOutcome>, Option<VMError>) {
-    make_simple_contract_call_with_gas(code, method_name, 10u64.pow(14))
-}
-
-pub fn make_simple_contract_call_vm(
+fn make_simple_contract_call_vm(
     code: &[u8],
     method_name: &str,
     vm_kind: VMKind,
@@ -96,12 +96,12 @@ pub fn make_simple_contract_call_vm(
     make_simple_contract_call_with_gas_vm(code, method_name, 10u64.pow(14), vm_kind)
 }
 
-pub fn wat2wasm_no_validate(wat: &str) -> Vec<u8> {
+fn wat2wasm_no_validate(wat: &str) -> Vec<u8> {
     Wat2Wasm::new().validate(false).convert(wat).unwrap().as_ref().to_vec()
 }
 
-pub struct MockCompiledContractCache {
-    pub store: Arc<Mutex<HashMap<Vec<u8>, Vec<u8>>>>,
+struct MockCompiledContractCache {
+    store: Arc<Mutex<HashMap<Vec<u8>, Vec<u8>>>>,
 }
 
 impl CompiledContractCache for MockCompiledContractCache {
@@ -118,7 +118,7 @@ impl CompiledContractCache for MockCompiledContractCache {
     }
 }
 
-pub fn make_cached_contract_call_vm(
+fn make_cached_contract_call_vm(
     cache: &mut dyn CompiledContractCache,
     code: &[u8],
     method_name: &str,

--- a/runtime/near-vm-runner/src/tests/error_cases.rs
+++ b/runtime/near-vm-runner/src/tests/error_cases.rs
@@ -2,16 +2,13 @@ use near_vm_errors::{
     CompilationError, FunctionCallError, HostError, MethodResolveError, PrepareError, VMError,
 };
 use near_vm_logic::{ReturnData, VMKind, VMOutcome};
-use near_vm_runner::with_vm_variants;
-
-pub mod test_utils;
-
-use self::test_utils::{
-    make_cached_contract_call_vm, make_simple_contract_call_vm,
-    make_simple_contract_call_with_gas_vm, MockCompiledContractCache,
-};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+
+use crate::tests::{
+    make_cached_contract_call_vm, make_simple_contract_call_vm,
+    make_simple_contract_call_with_gas_vm, with_vm_variants, MockCompiledContractCache,
+};
 
 fn vm_outcome_with_gas(gas: u64) -> VMOutcome {
     VMOutcome {

--- a/runtime/near-vm-runner/src/tests/invalid_contracts.rs
+++ b/runtime/near-vm-runner/src/tests/invalid_contracts.rs
@@ -1,10 +1,7 @@
 use near_vm_errors::{CompilationError, FunctionCallError, PrepareError, VMError};
-use near_vm_runner::with_vm_variants;
-
-pub mod test_utils;
-
-use self::test_utils::{make_simple_contract_call_vm, wat2wasm_no_validate};
 use near_vm_logic::VMKind;
+
+use crate::tests::{make_simple_contract_call_vm, wat2wasm_no_validate, with_vm_variants};
 
 fn initializer_wrong_signature_contract() -> Vec<u8> {
     wat2wasm_no_validate(

--- a/runtime/near-vm-runner/src/tests/rs_contract.rs
+++ b/runtime/near-vm-runner/src/tests/rs_contract.rs
@@ -2,15 +2,13 @@ use near_primitives::runtime::fees::RuntimeFeesConfig;
 use near_primitives::types::Balance;
 use near_vm_errors::{FunctionCallError, VMError};
 use near_vm_logic::mocks::mock_external::MockedExternal;
-use near_vm_logic::{types::ReturnData, VMConfig, VMContext, VMKind, VMOutcome};
-use near_vm_runner::{run_vm, with_vm_variants};
+use near_vm_logic::{types::ReturnData, VMConfig, VMKind, VMOutcome};
 use std::mem::size_of;
 
-pub mod test_utils;
-
-use self::test_utils::{
-    CURRENT_ACCOUNT_ID, LATEST_PROTOCOL_VERSION, PREDECESSOR_ACCOUNT_ID, SIGNER_ACCOUNT_ID,
-    SIGNER_ACCOUNT_PK,
+use crate::run_vm;
+use crate::tests::{
+    create_context, with_vm_variants, CURRENT_ACCOUNT_ID, LATEST_PROTOCOL_VERSION,
+    PREDECESSOR_ACCOUNT_ID, SIGNER_ACCOUNT_ID, SIGNER_ACCOUNT_PK,
 };
 
 #[cfg(feature = "protocol_feature_alt_bn128")]
@@ -50,17 +48,13 @@ fn arr_u64_to_u8(value: &[u64]) -> Vec<u8> {
     res
 }
 
-fn create_context(input: &[u8]) -> VMContext {
-    test_utils::create_context(input.to_owned())
-}
-
 #[test]
 pub fn test_read_write() {
     with_vm_variants(|vm_kind: VMKind| {
         let code = &TEST_CONTRACT;
         let mut fake_external = MockedExternal::new();
 
-        let context = create_context(&arr_u64_to_u8(&[10u64, 20u64]));
+        let context = create_context(arr_u64_to_u8(&[10u64, 20u64]));
         let config = VMConfig::default();
         let fees = RuntimeFeesConfig::default();
 
@@ -80,7 +74,7 @@ pub fn test_read_write() {
         );
         assert_run_result(result, 0);
 
-        let context = create_context(&arr_u64_to_u8(&[10u64]));
+        let context = create_context(arr_u64_to_u8(&[10u64]));
         let result = run_vm(
             vec![],
             &code,
@@ -137,10 +131,10 @@ fn run_test_ext(
     fake_external.validators = validators.into_iter().map(|(s, b)| (s.to_string(), b)).collect();
     let config = VMConfig::default();
     let fees = RuntimeFeesConfig::default();
-    let context = create_context(&input);
+    let context = create_context(input.to_vec());
 
     let (outcome, err) = run_vm(
-        input.to_owned(),
+        Vec::new(),
         &code,
         &method,
         &mut fake_external,
@@ -266,7 +260,7 @@ pub fn test_out_of_memory() {
         let code = &TEST_CONTRACT;
         let mut fake_external = MockedExternal::new();
 
-        let context = create_context(&[]);
+        let context = create_context(Vec::new());
         let config = VMConfig::free();
         let fees = RuntimeFeesConfig::free();
 

--- a/runtime/near-vm-runner/src/tests/ts_contract.rs
+++ b/runtime/near-vm-runner/src/tests/ts_contract.rs
@@ -1,19 +1,13 @@
-use crate::test_utils::LATEST_PROTOCOL_VERSION;
 use near_primitives::runtime::fees::RuntimeFeesConfig;
 use near_vm_errors::{FunctionCallError, HostError, VMError};
 use near_vm_logic::mocks::mock_external::MockedExternal;
 use near_vm_logic::types::ReturnData;
-use near_vm_logic::{External, VMConfig, VMContext, VMKind};
-use near_vm_runner::{run_vm, with_vm_variants};
+use near_vm_logic::{External, VMConfig, VMKind};
 
-pub mod test_utils;
+use crate::run_vm;
+use crate::tests::{create_context, with_vm_variants, LATEST_PROTOCOL_VERSION};
 
-fn create_context(input: &[u8]) -> VMContext {
-    let input = input.to_vec();
-    test_utils::create_context(input)
-}
-
-const TEST_CONTRACT: &'static [u8] = include_bytes!("../tests/res/test_contract_ts.wasm");
+const TEST_CONTRACT: &'static [u8] = include_bytes!("../../tests/res/test_contract_ts.wasm");
 
 #[test]
 pub fn test_ts_contract() {
@@ -21,7 +15,7 @@ pub fn test_ts_contract() {
         let code = &TEST_CONTRACT;
         let mut fake_external = MockedExternal::new();
 
-        let context = create_context(&[]);
+        let context = create_context(Vec::new());
         let config = VMConfig::default();
         let fees = RuntimeFeesConfig::default();
 
@@ -48,7 +42,7 @@ pub fn test_ts_contract() {
         );
 
         // Call method that writes something into storage.
-        let context = create_context(b"foo bar");
+        let context = create_context(b"foo bar".to_vec());
         run_vm(
             vec![],
             &code,
@@ -74,7 +68,7 @@ pub fn test_ts_contract() {
         }
 
         // Call method that reads the value from storage using registers.
-        let context = create_context(b"foo");
+        let context = create_context(b"foo".to_vec());
         let result = run_vm(
             vec![],
             &code,


### PR DESCRIPTION
By moving from many integration integration test crates to a single (nested) unit-tests module, we:

* improve test compilation performance by cutting down on linking time
  significantly
* improve test run-time by increasing parallelism (20s -> 12s, when
  `test_out_of_memory` outlier is removed)
* improve organization by making more things private and making it
  easier to share code between various tests.

See this post for an in-depth explanation:

  https://matklad.github.io/2021/02/27/delete-cargo-integration-tests.html

When adding a new integration test file, consider an option of putting
it into `src` dir instead.