### PR TITLE
replace size package with bytesize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3330,6 +3330,7 @@ dependencies = [
  "borsh",
  "byteorder",
  "bytes",
+ "bytesize",
  "cached",
  "chrono",
  "delay-detector",
@@ -3352,7 +3353,6 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "serde_json",
- "size",
  "strum",
  "tempfile",
  "tokio",
@@ -5177,15 +5177,6 @@ name = "similar"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad1d488a557b235fc46dae55512ffbfc429d2482b08b4d9435ab07384ca8aec"
-
-[[package]]
-name = "size"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5021178e8e70579d009fb545932e274ec2dde4c917791c6063d1002bee2a56"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "slab"

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -21,7 +21,7 @@ lazy_static = "1.4"
 tracing = "0.1.13"
 strum = { version = "0.20", features = ["derive"] }
 near-rust-allocator-proxy = "0.2.9"
-size = "0.1.2"
+bytesize = "1.0.1"
 
 borsh = "0.8.1"
 cached = "0.23"

--- a/chain/network/src/codec.rs
+++ b/chain/network/src/codec.rs
@@ -13,7 +13,7 @@ use near_performance_metrics::framed_write::EncoderCallBack;
 use near_performance_metrics::stats_enabled::get_thread_stats_logger;
 use near_rust_allocator_proxy::allocator::get_tid;
 
-const NETWORK_MESSAGE_MAX_SIZE: u32 = 512 * MIB as u32; // 512MB
+const NETWORK_MESSAGE_MAX_SIZE: u32 = 512 * MIB as u32;
 const MAX_CAPACITY: u64 = GIB;
 
 pub struct Codec {

--- a/chain/network/src/codec.rs
+++ b/chain/network/src/codec.rs
@@ -2,6 +2,7 @@ use std::io::{Error, ErrorKind};
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use bytes::{Buf, BufMut, BytesMut};
+use bytesize::{GIB, MIB};
 use log::error;
 use tokio_util::codec::{Decoder, Encoder};
 
@@ -11,10 +12,9 @@ use near_performance_metrics::framed_write::EncoderCallBack;
 #[cfg(feature = "performance_stats")]
 use near_performance_metrics::stats_enabled::get_thread_stats_logger;
 use near_rust_allocator_proxy::allocator::get_tid;
-use size::{GIBIBYTE, MEBIBYTE};
 
-const NETWORK_MESSAGE_MAX_SIZE: u32 = 512 * MEBIBYTE as u32; // 512MB
-const MAX_CAPACITY: u64 = GIBIBYTE;
+const NETWORK_MESSAGE_MAX_SIZE: u32 = 512 * MIB as u32; // 512MB
+const MAX_CAPACITY: u64 = GIB;
 
 pub struct Codec {
     max_length: u32,


### PR DESCRIPTION
As @matklad pointed, there is no point in importing both `size` and `bytesize` packages.