### PR TITLE
feat: enable "how long did this thing run?" logging

### DIFF
--- a/neard/src/main.rs
+++ b/neard/src/main.rs
@@ -64,6 +64,7 @@ fn init_logging(verbose: Option<&str>) {
         }
     }
     tracing_subscriber::fmt::Subscriber::builder()
+        .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
         .with_env_filter(env_filter)
         .with_writer(io::stderr)
         .init();

--- a/runtime/near-vm-runner/src/runner.rs
+++ b/runtime/near-vm-runner/src/runner.rs
@@ -91,6 +91,8 @@ pub fn run_vm_profiled<'a>(
     current_protocol_version: ProtocolVersion,
     cache: Option<&'a dyn CompiledContractCache>,
 ) -> (Option<VMOutcome>, Option<VMError>) {
+    let _span = tracing::info_span!("run_vm_profiled").entered();
+
     #[cfg(feature = "wasmer0_vm")]
     use crate::wasmer_runner::run_wasmer;
 

--- a/test-utils/logger/src/lib.rs
+++ b/test-utils/logger/src/lib.rs
@@ -14,6 +14,7 @@ fn setup_subscriber_from_filter(mut env_filter: EnvFilter) {
     }
 
     let _ = tracing_subscriber::fmt::Subscriber::builder()
+        .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
         .with_env_filter(env_filter)
         .with_writer(std::io::stderr)
         .try_init();


### PR DESCRIPTION
Tracing spans are a pairs of start/stop events, and can be used to
monitor how well the code is performing in production and, if it is
slow, which specific part is slow. To get this magic power, we need two
things:

* actually use `span!` macros from tracing (we already do in contract
  runtime, this PR adds one more span right at the entry point, now that
  we have a single entry point)

* ask tracing to please print this valuable info, as it is disabled by
  default.