### PR TITLE
refactor: reduce code duplication

### DIFF
--- a/runtime/near-vm-runner-standalone/src/script.rs
+++ b/runtime/near-vm-runner-standalone/src/script.rs
@@ -7,7 +7,7 @@ use near_primitives_core::runtime::fees::RuntimeFeesConfig;
 use near_vm_logic::mocks::mock_external::MockedExternal;
 use near_vm_logic::types::PromiseResult;
 use near_vm_logic::{ProtocolVersion, VMConfig, VMContext, VMKind, VMOutcome};
-use near_vm_runner::{run_vm_profiled, MockCompiledContractCache, VMError};
+use near_vm_runner::{run_vm, MockCompiledContractCache, VMError};
 
 use crate::State;
 
@@ -115,7 +115,7 @@ impl Script {
         let mut outcomes = Vec::new();
         for step in &self.steps {
             for _ in 0..step.repeat {
-                let res = run_vm_profiled(
+                let res = run_vm(
                     vec![],
                     &self.contracts[step.contract.0],
                     &step.method,
@@ -125,9 +125,9 @@ impl Script {
                     &RuntimeFeesConfig::default(),
                     &step.promise_results,
                     self.vm_kind,
-                    self.profile.clone(),
                     self.protocol_version,
                     self.contract_cache.as_deref(),
+                    self.profile.clone(),
                 );
                 outcomes.push(res);
             }

--- a/runtime/near-vm-runner/src/lib.rs
+++ b/runtime/near-vm-runner/src/lib.rs
@@ -23,7 +23,6 @@ pub use near_vm_errors::VMError;
 pub use runner::compile_module;
 pub use runner::run;
 pub use runner::run_vm;
-pub use runner::run_vm_profiled;
 
 pub use near_vm_logic::with_ext_cost_counter;
 

--- a/runtime/near-vm-runner/src/runner.rs
+++ b/runtime/near-vm-runner/src/runner.rs
@@ -32,7 +32,7 @@ pub fn run<'a>(
     cache: Option<&'a dyn CompiledContractCache>,
     profile: &ProfileData,
 ) -> (Option<VMOutcome>, Option<VMError>) {
-    run_vm_profiled(
+    run_vm(
         code_hash,
         code,
         method_name,
@@ -42,56 +42,27 @@ pub fn run<'a>(
         fees_config,
         promise_results,
         VMKind::default(),
+        current_protocol_version,
+        cache,
         profile.clone(),
-        current_protocol_version,
-        cache,
-    )
-}
-pub fn run_vm<'a>(
-    code_hash: Vec<u8>,
-    code: &[u8],
-    method_name: &str,
-    ext: &mut dyn External,
-    context: VMContext,
-    wasm_config: &'a VMConfig,
-    fees_config: &'a RuntimeFeesConfig,
-    promise_results: &'a [PromiseResult],
-    vm_kind: VMKind,
-    current_protocol_version: ProtocolVersion,
-    cache: Option<&'a dyn CompiledContractCache>,
-) -> (Option<VMOutcome>, Option<VMError>) {
-    let profile = ProfileData::new_disabled();
-    run_vm_profiled(
-        code_hash,
-        code,
-        method_name,
-        ext,
-        context,
-        wasm_config,
-        fees_config,
-        promise_results,
-        vm_kind,
-        profile,
-        current_protocol_version,
-        cache,
     )
 }
 
-pub fn run_vm_profiled<'a>(
+pub fn run_vm(
     code_hash: Vec<u8>,
     code: &[u8],
     method_name: &str,
     ext: &mut dyn External,
     context: VMContext,
-    wasm_config: &'a VMConfig,
-    fees_config: &'a RuntimeFeesConfig,
-    promise_results: &'a [PromiseResult],
+    wasm_config: &VMConfig,
+    fees_config: &RuntimeFeesConfig,
+    promise_results: &[PromiseResult],
     vm_kind: VMKind,
-    profile: ProfileData,
     current_protocol_version: ProtocolVersion,
-    cache: Option<&'a dyn CompiledContractCache>,
+    cache: Option<&dyn CompiledContractCache>,
+    profile: ProfileData,
 ) -> (Option<VMOutcome>, Option<VMError>) {
-    let _span = tracing::info_span!("run_vm_profiled").entered();
+    let _span = tracing::info_span!("run_vm").entered();
 
     #[cfg(feature = "wasmer0_vm")]
     use crate::wasmer_runner::run_wasmer;

--- a/runtime/near-vm-runner/src/tests.rs
+++ b/runtime/near-vm-runner/src/tests.rs
@@ -6,6 +6,7 @@ mod ts_contract;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
+use near_primitives::profile::ProfileData;
 use wabt::Wat2Wasm;
 
 use crate::run_vm;
@@ -84,6 +85,7 @@ fn make_simple_contract_call_with_gas_vm(
         vm_kind,
         LATEST_PROTOCOL_VERSION,
         None,
+        ProfileData::new_disabled(),
     )
 }
 
@@ -128,5 +130,6 @@ fn make_cached_contract_call_vm(
         vm_kind,
         LATEST_PROTOCOL_VERSION,
         Some(cache),
+        ProfileData::new_disabled(),
     )
 }

--- a/runtime/near-vm-runner/src/tests/rs_contract.rs
+++ b/runtime/near-vm-runner/src/tests/rs_contract.rs
@@ -1,3 +1,4 @@
+use near_primitives::profile::ProfileData;
 use near_primitives::runtime::fees::RuntimeFeesConfig;
 use near_primitives::types::Balance;
 use near_vm_errors::{FunctionCallError, VMError};
@@ -71,6 +72,7 @@ pub fn test_read_write() {
             vm_kind.clone(),
             LATEST_PROTOCOL_VERSION,
             None,
+            ProfileData::new_disabled(),
         );
         assert_run_result(result, 0);
 
@@ -87,6 +89,7 @@ pub fn test_read_write() {
             vm_kind,
             LATEST_PROTOCOL_VERSION,
             None,
+            ProfileData::new_disabled(),
         );
         assert_run_result(result, 20);
     });
@@ -145,6 +148,7 @@ fn run_test_ext(
         vm_kind,
         LATEST_PROTOCOL_VERSION,
         None,
+        ProfileData::new_disabled(),
     );
 
     if let Some(_) = err {
@@ -277,6 +281,7 @@ pub fn test_out_of_memory() {
             vm_kind,
             LATEST_PROTOCOL_VERSION,
             None,
+            ProfileData::new_disabled(),
         );
         assert_eq!(
             result.1,

--- a/runtime/near-vm-runner/src/tests/ts_contract.rs
+++ b/runtime/near-vm-runner/src/tests/ts_contract.rs
@@ -1,3 +1,4 @@
+use near_primitives::profile::ProfileData;
 use near_primitives::runtime::fees::RuntimeFeesConfig;
 use near_vm_errors::{FunctionCallError, HostError, VMError};
 use near_vm_logic::mocks::mock_external::MockedExternal;
@@ -33,6 +34,7 @@ pub fn test_ts_contract() {
             vm_kind.clone(),
             LATEST_PROTOCOL_VERSION,
             None,
+            ProfileData::new_disabled(),
         );
         assert_eq!(
             result.1,
@@ -55,6 +57,7 @@ pub fn test_ts_contract() {
             vm_kind.clone(),
             LATEST_PROTOCOL_VERSION,
             None,
+            ProfileData::new_disabled(),
         )
         .0
         .unwrap();
@@ -81,6 +84,7 @@ pub fn test_ts_contract() {
             vm_kind,
             LATEST_PROTOCOL_VERSION,
             None,
+            ProfileData::new_disabled(),
         );
 
         if let ReturnData::Value(value) = result.0.unwrap().return_data {


### PR DESCRIPTION
After a series of previous refactors, we can finally consolidate all
entry points. We still need two functions: `run` is a public API, and it
picks the appropriate VM automatically. `run_vm` is an internal API
which allows us to check that all supported VMs work.