### PR TITLE
feat(runtime): use native engine in wasmer 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3627,6 +3627,7 @@ dependencies = [
  "wabt",
  "wasmer",
  "wasmer-compiler-singlepass",
+ "wasmer-engine-native",
  "wasmer-runtime-core-near",
  "wasmer-runtime-near",
  "wasmer-types",

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -20,6 +20,7 @@ wasmer-runtime-core = {version = "0.17.1", package = "wasmer-runtime-core-near" 
 wasmer = { version = "1.0.2", optional = true }
 wasmer-types = { version = "1.0.2", optional = true }
 wasmer-compiler-singlepass = { version = "1.0.2", optional = true }
+wasmer-engine-native = { version = "1.0.2", optional = true }
 pwasm-utils = "0.12"
 parity-wasm = "0.41"
 wasmtime = { version = "0.20.0", default-features = false, optional = true }
@@ -44,7 +45,7 @@ base64 = "0.13"
 default = ["wasmer0_vm", "wasmtime_vm", "wasmer1_vm"]
 wasmer0_vm = [ "wasmer-runtime" ]
 wasmtime_vm = [ "wasmtime", "anyhow"]
-wasmer1_vm = [ "wasmer", "wasmer-types", "wasmer-compiler-singlepass" ]
+wasmer1_vm = [ "wasmer", "wasmer-types", "wasmer-compiler-singlepass", "wasmer-engine-native" ]
 lightbeam = ["wasmtime/lightbeam"]
 no_cpu_compatibility_checks = []
 protocol_feature_evm = ["near-primitives/protocol_feature_evm", "near-evm-runner/protocol_feature_evm"]

--- a/runtime/near-vm-runner/src/runner.rs
+++ b/runtime/near-vm-runner/src/runner.rs
@@ -158,8 +158,10 @@ pub fn precompile<'a>(
         }
         #[cfg(feature = "wasmer1_vm")]
         VMKind::Wasmer1 => {
-            let engine =
-                wasmer::JIT::new(wasmer_compiler_singlepass::Singlepass::default()).engine();
+            let engine = wasmer_engine_native::Native::new(
+                wasmer_compiler_singlepass::Singlepass::default(),
+            )
+            .engine();
             let store = wasmer::Store::new(&engine);
             let result = crate::cache::wasmer1_cache::compile_and_serialize_wasmer1(
                 code,

--- a/runtime/near-vm-runner/src/wasmer1_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer1_runner.rs
@@ -7,8 +7,9 @@ use near_vm_errors::{
 };
 use near_vm_logic::types::{PromiseResult, ProtocolVersion};
 use near_vm_logic::{External, MemoryLike, VMConfig, VMContext, VMLogic, VMLogicError, VMOutcome};
-use wasmer::{Bytes, ImportObject, Instance, Memory, MemoryType, Module, Pages, Store, JIT};
+use wasmer::{Bytes, ImportObject, Instance, Memory, MemoryType, Module, Pages, Store};
 use wasmer_compiler_singlepass::Singlepass;
+use wasmer_engine_native::Native;
 
 pub struct Wasmer1Memory(Memory);
 
@@ -173,7 +174,7 @@ pub fn run_wasmer1<'a>(
         );
     }
 
-    let engine = JIT::new(Singlepass::default()).engine();
+    let engine = Native::new(Singlepass::default()).engine();
     let store = Store::new(&engine);
     let module = match cache::wasmer1_cache::compile_module_cached_wasmer1(
         code_hash,
@@ -240,7 +241,7 @@ fn run_method(module: &Module, import: &ImportObject, method_name: &str) -> Resu
 }
 
 pub fn compile_module(code: &[u8]) -> bool {
-    let engine = JIT::new(Singlepass::default()).engine();
+    let engine = Native::new(Singlepass::default()).engine();
     let store = Store::new(&engine);
     Module::new(&store, code).is_ok()
 }


### PR DESCRIPTION
This changes compilation artifact format and would have a better execution performance. Deserialization performance is going to be measured separately, but even if it's slower, it'll replaced by flatdata based artifact (in near/wasmer), which has a constant ~0.2ms "deserialization"

Test Plan
---------
CI near-vm-runner tests should still work