### PR TITLE
fix(test): staking2.py false failures

### DIFF
--- a/pytest/tests/sanity/staking2.py
+++ b/pytest/tests/sanity/staking2.py
@@ -14,9 +14,9 @@ from transaction import sign_staking_tx
 TIMEOUT = 360
 TIMEOUT_PER_ITER = 30
 
-FAKE_OFFSET = 4
-REAL_OFFSET = 8
-EPOCH_LENGTH = 12
+FAKE_OFFSET = 6
+REAL_OFFSET = 12
+EPOCH_LENGTH = 18
 
 all_stakes = []
 fake_stakes = [0, 0, 0]
@@ -88,11 +88,12 @@ def doit(seq=[]):
                           [["epoch_length", EPOCH_LENGTH],
                            ["block_producer_kickout_threshold", 40],
                            ["chunk_producer_kickout_threshold", 40]],
-                          {0: {"view_client_throttle_period": {"secs": 0, "nanos": 0}},
-                           1: {"view_client_throttle_period": {"secs": 0, "nanos": 0}},
+                          {0: {"view_client_throttle_period": {"secs": 0, "nanos": 0}, "consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}}},
+                           1: {"view_client_throttle_period": {"secs": 0, "nanos": 0}, "consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}}},
                            2: {
                               "tracked_shards": [0],
-                              "view_client_throttle_period": {"secs": 0, "nanos": 0}
+                              "view_client_throttle_period": {"secs": 0, "nanos": 0},
+                              "consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}}
                           }})
 
     started = time.time()


### PR DESCRIPTION
60 second state sync timeout is too high for tests with short epochs.
Set it to two seconds, and increase epoch length from 12 to 18.
Fixes #4037

Test plan
---------
staking2.py
before: 19/30 failures in last 30 nightly
state_sync_timeout: 2/60 fail
state_sync_timeout + increase epoch length: 60/60 pass