### PR TITLE
Validate each edge only once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,6 +953,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ae45936bbf9bddd6a0268c0ea5d3814a72403f4b69a1c318aae2ce90444ad55"
 
 [[package]]
+name = "conqueue"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac4306c796b95d3964b94fa65018a57daee08b45a54b86a4f64910426427b66"
+
+[[package]]
 name = "console"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3354,6 +3360,7 @@ dependencies = [
  "bytesize",
  "cached",
  "chrono",
+ "conqueue",
  "delay-detector",
  "futures",
  "lazy_static",

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -21,6 +21,7 @@ tracing = "0.1.13"
 strum = { version = "0.20", features = ["derive"] }
 near-rust-allocator-proxy = "0.2.9"
 bytesize = "1.0.1"
+conqueue = "0.4.0"
 
 borsh = "0.8.1"
 cached = "0.23"

--- a/chain/network/src/peer.rs
+++ b/chain/network/src/peer.rs
@@ -3,7 +3,7 @@ use std::io;
 use std::net::SocketAddr;
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
-    Arc, RwLock,
+    Arc,
 };
 use std::time::{Duration, Instant};
 

--- a/chain/network/src/peer.rs
+++ b/chain/network/src/peer.rs
@@ -3,7 +3,7 @@ use std::io;
 use std::net::SocketAddr;
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
-    Arc,
+    Arc, RwLock,
 };
 use std::time::{Duration, Instant};
 

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -1485,14 +1485,7 @@ impl Handler<NetworkRequests> for PeerManagerActor {
             }
             NetworkRequests::Sync { peer_id, sync_data } => {
                 // Process edges and add new edges to the routing table. Also broadcast new edges.
-                let SyncData { mut edges, accounts } = sync_data;
-                edges.retain(|edge| {
-                    match self.routing_table.get_edge(edge.peer0.clone(), edge.peer1.clone()) {
-                        // only consider edges with bigger nonce
-                        Some(cur_edge) => cur_edge.nonce < edge.nonce,
-                        None => true,
-                    }
-                });
+                let SyncData { edges, accounts } = sync_data;
 
                 self.edge_verifier_pool.send(EdgeList(edges, self.routing_table.get_edges_info_shared(), self.routing_table.edges_to_add_sender.clone()))
                     .into_actor(self)

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -49,6 +49,7 @@ use metrics::NetworkMetrics;
 use near_performance_metrics::framed_write::FramedWrite;
 use near_performance_metrics_macros::perf;
 use rand::thread_rng;
+use std::cmp::max;
 
 /// How often to request peers from active peers.
 const REQUEST_PEERS_SECS: u64 = 60;
@@ -1489,18 +1490,8 @@ impl Handler<NetworkRequests> for PeerManagerActor {
                         None => true,
                     }
                 });
-                info!(
-                    "PIOTR SYNC edges.len: {} announce_len: {} active_edges: {} nodes.used: {} nodes.unused: {} new_edges: {}/{}",
-                    self.routing_table.edges_info.len(),
-                    self.routing_table.get_announce_accounts_size(),
-                    self.routing_table.raw_graph.total_active_edges,
-                    self.routing_table.raw_graph.used.len(),
-                    self.routing_table.raw_graph.unused.len(),
-                    edges.len(),
-                    edges_len,
-                );
 
-                self.edge_verifier_pool.send(EdgeList(edges.clone(), self.routing_table.edges_info_shared.clone()))
+                self.edge_verifier_pool.send(EdgeList(edges.clone(), self.routing_table.get_edges_info_shared()))
                     .into_actor(self)
                     .then(move |response, act, ctx| {
                         match response {

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -274,7 +274,6 @@ impl PeerManagerActor {
             self.routing_table.add_account(account.clone());
         }
 
-        info!("PIOTR {} {}", new_edges.len(), accounts.len());
         let new_data = SyncData { edges: new_edges, accounts };
 
         if !new_data.is_empty() {
@@ -293,7 +292,6 @@ impl PeerManagerActor {
                 Duration::from_secs(1),
                 move |act, ctx| {
                     act.scheduled_broadcast_edges = false;
-                    info!("PIOTR1");
                     act.broadcast_accounts_and_edges(ctx, Default::default());
                 },
             );
@@ -1584,7 +1582,6 @@ impl Handler<NetworkRequests> for PeerManagerActor {
                         }
                     })
                     .collect();
-                info!("SYNC {}", edges.len());
 
                 // Ask client to validate accounts before accepting them.
                 let peer_id_clone = peer_id.clone();
@@ -1597,7 +1594,6 @@ impl Handler<NetworkRequests> for PeerManagerActor {
                                 act.try_ban_peer(ctx, &peer_id_clone, ban_reason);
                             }
                             Ok(NetworkViewClientResponses::AnnounceAccount(accounts)) => {
-                                info!("PIOTR2");
                                 act.broadcast_accounts_and_edges(ctx, accounts);
                             }
                             _ => {
@@ -1621,7 +1617,6 @@ impl Handler<NetworkRequests> for PeerManagerActor {
                             Ok(true) => {}
                             Err(err) => warn!(target: "network", "error validating edges: {}", err),
                         }
-                        info!("PIOTR3");
                         act.broadcast_accounts_and_edges(ctx, Default::default());
 
                         actix::fut::ready(())

--- a/chain/network/src/routing.rs
+++ b/chain/network/src/routing.rs
@@ -1,6 +1,6 @@
 use std::collections::{hash_map::Entry, HashMap, HashSet, VecDeque};
 use std::ops::Sub;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
 use serde::Serialize;
@@ -308,6 +308,7 @@ impl RoutingTable {
             account_peers: SizedCache::with_size(ANNOUNCE_ACCOUNT_CACHE_SIZE),
             peer_forwarding: HashMap::new(),
             edges_info: HashMap::new(),
+            edges_info_shared: Default::default(),
             route_back: RouteBackCache::new(
                 ROUTE_BACK_CACHE_SIZE,
                 ROUTE_BACK_CACHE_EVICT_TIMEOUT,

--- a/chain/network/src/routing.rs
+++ b/chain/network/src/routing.rs
@@ -1,6 +1,6 @@
 use std::collections::{hash_map::Entry, HashMap, HashSet, VecDeque};
 use std::ops::Sub;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use serde::Serialize;
@@ -263,9 +263,9 @@ pub struct RoutingTable {
     /// Store last update for known edges.
     pub edges_info: HashMap<(PeerId, PeerId), Edge>,
     /// Shared version of edges_info used by multiple threads
-    edges_info_shared: Arc<RwLock<HashMap<(PeerId, PeerId), u64>>>,
+    edges_info_shared: Arc<Mutex<HashMap<(PeerId, PeerId), u64>>>,
     /// List of edges that should be added
-    edges_to_add_shared: Arc<RwLock<Vec<Edge>>>,
+    edges_to_add_shared: Arc<Mutex<Vec<Edge>>>,
     /// Hash of messages that requires routing back to respective previous hop.
     pub route_back: RouteBackCache,
     /// Last time a peer with reachable through active edges.
@@ -565,11 +565,11 @@ impl RoutingTable {
         self.edges_info.iter().map(|(_, edge)| edge.clone()).collect()
     }
 
-    pub fn get_edges_info_shared(&self) -> Arc<RwLock<HashMap<(PeerId, PeerId), u64>>> {
+    pub fn get_edges_info_shared(&self) -> Arc<Mutex<HashMap<(PeerId, PeerId), u64>>> {
         self.edges_info_shared.clone()
     }
 
-    pub fn get_edges_to_add_shared(&self) -> Arc<RwLock<Vec<Edge>>> {
+    pub fn get_edges_to_add_shared(&self) -> Arc<Mutex<Vec<Edge>>> {
         self.edges_to_add_shared.clone()
     }
 

--- a/chain/network/src/routing.rs
+++ b/chain/network/src/routing.rs
@@ -71,7 +71,7 @@ pub enum EdgeType {
 }
 
 /// Edge object. Contains information relative to a new edge that is being added or removed
-/// from the network. This is the information that is required
+/// from the network. This is the information that is required.
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct Edge {
     /// Since edges are not directed `peer0 < peer1` should hold.

--- a/chain/network/src/routing.rs
+++ b/chain/network/src/routing.rs
@@ -262,6 +262,8 @@ pub struct RoutingTable {
     pub peer_forwarding: HashMap<PeerId, Vec<PeerId>>,
     /// Store last update for known edges.
     pub edges_info: HashMap<(PeerId, PeerId), Edge>,
+    /// Shared version of edges_info used by multiple threads
+    edges_info_shared: Arc<RwLock<HashMap<(PeerId, PeerId), u64>>>,
     /// Hash of messages that requires routing back to respective previous hop.
     pub route_back: RouteBackCache,
     /// Last time a peer with reachable through active edges.
@@ -558,6 +560,10 @@ impl RoutingTable {
 
     pub fn get_edges(&self) -> Vec<Edge> {
         self.edges_info.iter().map(|(_, edge)| edge.clone()).collect()
+    }
+
+    pub fn get_edges_info_shared(&self) -> Arc<RwLock<HashMap<(PeerId, PeerId), u64>>> {
+        self.edges_info_shared.clone()
     }
 
     pub fn add_route_back(&mut self, hash: CryptoHash, peer_id: PeerId) {

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -1283,11 +1283,11 @@ pub enum PeerManagerRequest {
     UnregisterPeer,
 }
 
-pub struct EdgeList(
-    pub Vec<Edge>,
-    pub Arc<Mutex<HashMap<(PeerId, PeerId), u64>>>,
-    pub QueueSender<Edge>,
-);
+pub struct EdgeList {
+    pub edges: Vec<Edge>,
+    pub edges_info_shared: Arc<Mutex<HashMap<(PeerId, PeerId), u64>>>,
+    pub sender: QueueSender<Edge>,
+}
 
 impl Message for EdgeList {
     type Result = bool;

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -46,6 +46,7 @@ use crate::routing::{Edge, EdgeInfo, RoutingTableInfo};
 use std::fmt::{Debug, Error, Formatter};
 use std::io;
 
+use conqueue::QueueSender;
 #[cfg(feature = "protocol_feature_forward_chunk_parts")]
 use near_primitives::merkle::combine_hash;
 
@@ -1285,7 +1286,7 @@ pub enum PeerManagerRequest {
 pub struct EdgeList(
     pub Vec<Edge>,
     pub Arc<Mutex<HashMap<(PeerId, PeerId), u64>>>,
-    pub Arc<Mutex<Vec<Edge>>>,
+    pub QueueSender<Edge>,
 );
 
 impl Message for EdgeList {

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -3,7 +3,7 @@ use std::convert::{Into, TryFrom, TryInto};
 use std::fmt;
 use std::net::{AddrParseError, IpAddr, SocketAddr};
 use std::str::FromStr;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
 use actix::dev::{MessageResponse, ResponseChannel};
@@ -1284,8 +1284,8 @@ pub enum PeerManagerRequest {
 
 pub struct EdgeList(
     pub Vec<Edge>,
-    pub Arc<RwLock<HashMap<(PeerId, PeerId), u64>>>,
-    pub Arc<RwLock<Vec<Edge>>>,
+    pub Arc<Mutex<HashMap<(PeerId, PeerId), u64>>>,
+    pub Arc<Mutex<Vec<Edge>>>,
 );
 
 impl Message for EdgeList {

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -1282,7 +1282,11 @@ pub enum PeerManagerRequest {
     UnregisterPeer,
 }
 
-pub struct EdgeList(pub Vec<Edge>, pub Arc<RwLock<HashMap<(PeerId, PeerId), u64>>>);
+pub struct EdgeList(
+    pub Vec<Edge>,
+    pub Arc<RwLock<HashMap<(PeerId, PeerId), u64>>>,
+    pub Arc<RwLock<Vec<Edge>>>,
+);
 
 impl Message for EdgeList {
     type Result = bool;

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -1282,7 +1282,7 @@ pub enum PeerManagerRequest {
     UnregisterPeer,
 }
 
-pub struct EdgeList(pub Vec<Edge>);
+pub struct EdgeList(pub Vec<Edge>, pub Arc<RwLock<HashMap<(PeerId, PeerId), u64>>>);
 
 impl Message for EdgeList {
     type Result = bool;

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -3,7 +3,7 @@ use std::convert::{Into, TryFrom, TryInto};
 use std::fmt;
 use std::net::{AddrParseError, IpAddr, SocketAddr};
 use std::str::FromStr;
-use std::sync::RwLock;
+use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
 use actix::dev::{MessageResponse, ResponseChannel};


### PR DESCRIPTION
Currently we may validate each edge a few times after a node connects to a network. This PR will guarantee that each node edge will be only verified once on node joining the network.