### PR TITLE
Reset max memory usage after loading config

### DIFF
--- a/neard/src/lib.rs
+++ b/neard/src/lib.rs
@@ -26,6 +26,7 @@ use near_store::migrations::{
     migrate_7_to_8, migrate_8_to_9, migrate_9_to_10, set_store_version,
 };
 
+use near_rust_allocator_proxy::allocator::reset_memory_usage_max;
 #[cfg(feature = "protocol_feature_rectify_inflation")]
 use near_store::migrations::migrate_18_to_rectify_inflation;
 
@@ -293,6 +294,9 @@ pub fn start_with_config(
     network_adapter.set_recipient(network_actor.recipient());
 
     trace!(target: "diagnostic", key="log", "Starting NEAR node with diagnostic activated");
+
+    // We probably reached peak memory once on this thread, we want to see when it happens again.
+    reset_memory_usage_max();
 
     (client_actor, view_client, vec![client_arbiter_handle, arbiter.handle()])
 }

--- a/neard/src/lib.rs
+++ b/neard/src/lib.rs
@@ -14,6 +14,7 @@ use near_jsonrpc::start_http;
 use near_network::{NetworkRecipient, PeerManagerActor};
 #[cfg(feature = "rosetta_rpc")]
 use near_rosetta_rpc::start_rosetta_rpc;
+#[cfg(feature = "performance_stats")]
 use near_rust_allocator_proxy::allocator::reset_memory_usage_max;
 use near_store::{create_store, Store};
 use near_telemetry::TelemetryActor;
@@ -296,6 +297,7 @@ pub fn start_with_config(
     trace!(target: "diagnostic", key="log", "Starting NEAR node with diagnostic activated");
 
     // We probably reached peak memory once on this thread, we want to see when it happens again.
+    #[cfg(feature = "performance_stats")]
     reset_memory_usage_max();
 
     (client_actor, view_client, vec![client_arbiter_handle, arbiter.handle()])

--- a/neard/src/lib.rs
+++ b/neard/src/lib.rs
@@ -14,6 +14,7 @@ use near_jsonrpc::start_http;
 use near_network::{NetworkRecipient, PeerManagerActor};
 #[cfg(feature = "rosetta_rpc")]
 use near_rosetta_rpc::start_rosetta_rpc;
+use near_rust_allocator_proxy::allocator::reset_memory_usage_max;
 use near_store::{create_store, Store};
 use near_telemetry::TelemetryActor;
 
@@ -26,7 +27,6 @@ use near_store::migrations::{
     migrate_7_to_8, migrate_8_to_9, migrate_9_to_10, set_store_version,
 };
 
-use near_rust_allocator_proxy::allocator::reset_memory_usage_max;
 #[cfg(feature = "protocol_feature_rectify_inflation")]
 use near_store::migrations::migrate_18_to_rectify_inflation;
 


### PR DESCRIPTION
We want to know when given thread reaches peak memory usage. However, the main thread reaches peak memory usage while loading config, then it frees memory. We will reset peak memory usage after `start_with_config`, so we can see report when the main thread reaches peak memory usage.