### PR TITLE
Fix build.sh failing

### DIFF
--- a/runtime/runtime-params-estimator/test-contract/build.sh
+++ b/runtime/runtime-params-estimator/test-contract/build.sh
@@ -30,6 +30,7 @@ echo ${bare_wasm}
 
 # 10KiB
 
+# hotfix for people building cargo with debug flags, causing binary to be 35kb
 if [ "${bare_wasm}" -ge 10239 ]; then
     bare_wasm=10239
 fi

--- a/runtime/runtime-params-estimator/test-contract/build.sh
+++ b/runtime/runtime-params-estimator/test-contract/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ex
 
 function filesize
@@ -29,6 +29,11 @@ echo ${bare_wasm}
 # bloat its size to the given values.
 
 # 10KiB
+
+if [ "${bare_wasm}" -ge 10239 ]; then
+    bare_wasm=10239
+fi
+
 dd if=/dev/urandom of=./res/payload bs=$(expr 10240 - ${bare_wasm}) count=1
 RUSTFLAGS='-C link-arg=-s' cargo build --target wasm32-unknown-unknown --release  --features payload
 cp target/wasm32-unknown-unknown/release/test_contract.wasm ./res/stable_small_contract.wasm
@@ -57,6 +62,9 @@ echo ${bare_wasm}
 
 # Note the base is 16057 due to alt_bn128 hardcoded input.
 # 20KiB
+if [ "${bare_wasm}" -ge 20479 ]; then
+    bare_wasm=20479
+fi
 dd if=/dev/urandom of=./res/payload bs=$(expr 20480 - ${bare_wasm}) count=1
 RUSTFLAGS='-C link-arg=-s' cargo build --target wasm32-unknown-unknown --release  --features payload,nightly_protocol_features
 cp target/wasm32-unknown-unknown/release/test_contract.wasm ./res/nightly_small_contract.wasm


### PR DESCRIPTION
Bare wasm contract is 35k on my system, which causes script to fail, due to `dd` value being negative.


```

++ filesize target/wasm32-unknown-unknown/release/test_contract.wasm
++ local file=target/wasm32-unknown-unknown/release/test_contract.wasm
+++ stat -c%s target/wasm32-unknown-unknown/release/test_contract.wasm
++ size=39792
++ '[' 0 -eq 0 ']'
++ echo 39792
++ return 0
+ bare_wasm=39792
+ echo 39792
39792
++ expr 10240 - 39792
+ dd if=/dev/urandom of=./res/payload bs=-29552 count=1
dd: invalid number: ‘-29552’
```

I also switched `#!/bin/bash` to `#!/usr/bin/env bash`, which should be portable and work for both linux and macOS.
