### PR TITLE
refactor(pytest): Update sanity/transactions.py test to pass according to dropped routing in handle_query ViewClient method

### DIFF
--- a/pytest/tests/sanity/transactions.py
+++ b/pytest/tests/sanity/transactions.py
@@ -16,8 +16,8 @@ TIMEOUT = 240
 
 nodes = start_cluster(
     num_nodes=4,
-    num_observers=0,
-    num_shards=1,
+    num_observers=1,
+    num_shards=4,
     config=None,
     genesis_config_changes=[
         ["min_gas_price", 0],
@@ -25,12 +25,12 @@ nodes = start_cluster(
         ["epoch_length", 10],
         ["block_producer_kickout_threshold", 70]
     ],
-    client_config_changes={}
+    client_config_changes={ 4: {"tracked_shards": [0, 1, 2, 3]}}
 )
 
 started = time.time()
 
-act_to_val = [0, 0, 0, 0]
+act_to_val = [4, 4, 4, 4, 4]
 
 ctx = TxContext(act_to_val, nodes)
 
@@ -50,7 +50,7 @@ while True:
         if height >= 1:
             tx = sign_payment_tx(nodes[0].signer_key, 'test1', 100, 1,
                                  base58.b58decode(hash_.encode('utf8')))
-            nodes[3].send_tx(tx)
+            nodes[4].send_tx(tx)
             ctx.expected_balances[0] -= 100
             ctx.expected_balances[1] += 100
             print('Sent tx at height %s' % height)

--- a/pytest/tests/sanity/transactions.py
+++ b/pytest/tests/sanity/transactions.py
@@ -15,13 +15,22 @@ from transaction import sign_payment_tx
 TIMEOUT = 240
 
 nodes = start_cluster(
-    4, 0, 4, None,
-    [["min_gas_price", 0], ["max_inflation_rate", [0, 1]], ["epoch_length", 10],
-     ["block_producer_kickout_threshold", 70]], {})
+    num_nodes=4,
+    num_observers=0,
+    num_shards=1,
+    config=None,
+    genesis_config_changes=[
+        ["min_gas_price", 0],
+        ["max_inflation_rate", [0, 1]],
+        ["epoch_length", 10],
+        ["block_producer_kickout_threshold", 70]
+    ],
+    client_config_changes={}
+)
 
 started = time.time()
 
-act_to_val = [3, 2, 0, 3]
+act_to_val = [0, 0, 0, 0]
 
 ctx = TxContext(act_to_val, nodes)
 


### PR DESCRIPTION
In merged PR #3944 I've dropped routing for the `Query` handler in ViewClient (@frol and @bowenwang1996 discussed it and approved this change).

After that test `pytest/tests/sanity/transactions.py` started failing. @frol and I investigated it and found out that the fails related to the attempts to test transactions between shards, all the test relies on the querying jsonrpc `query` method to get accounts from different shards and check their balances, but since routing is not present there anymore it's impossible to do it.

In this PR I've made the smallest change introducing only one shard and all the accounts on that shard so the test is not failing anymore, but I'm not sure if it not brakes the main idea of the test.

@bowenwang1996 @SkidanovAlex could you assist in refactoring this test so it could still be useful by checking what it supposed to be checking, please?