### PR TITLE
feat: infrastructure for reusing memory and store between contracts

### DIFF
--- a/runtime/near-vm-runner/src/preload.rs
+++ b/runtime/near-vm-runner/src/preload.rs
@@ -96,7 +96,7 @@ impl ContractCaller {
                         None
                     }),
                 )
-            },
+            }
             VMKind::Wasmtime => panic!("Not currently supported"),
         };
         ContractCaller {

--- a/runtime/near-vm-runner/src/preload.rs
+++ b/runtime/near-vm-runner/src/preload.rs
@@ -96,8 +96,8 @@ impl ContractCaller {
                         None
                     }),
                 )
-            }
-            _ => panic!("Not currently supported"),
+            },
+            VMKind::Wasmtime => panic!("Not currently supported"),
         };
         ContractCaller {
             pool: ThreadPool::new(num_threads),
@@ -156,7 +156,7 @@ impl ContractCaller {
                                 let mut new_memory;
                                 run_wasmer0_module(
                                     module.clone(),
-                                    if SHARE_MEMORY_INSTANCE {
+                                    if memory.is_some() {
                                         memory.as_mut().unwrap()
                                     } else {
                                         new_memory = WasmerMemory::new(
@@ -185,7 +185,7 @@ impl ContractCaller {
                                 run_wasmer1_module(
                                     &module,
                                     store,
-                                    if SHARE_MEMORY_INSTANCE {
+                                    if memory.is_some() {
                                         memory.as_mut().unwrap()
                                     } else {
                                         new_memory = Wasmer1Memory::new(

--- a/runtime/near-vm-runner/src/preload.rs
+++ b/runtime/near-vm-runner/src/preload.rs
@@ -153,20 +153,17 @@ impl ContractCaller {
                                 VMDataPrivate::Wasmer0(memory),
                                 VMDataShared::Wasmer0,
                             ) => {
-                                assert!(
-                                    !SHARE_MEMORY_INSTANCE,
-                                    "Remove new_memory once get will start to reuse memory"
-                                );
-                                let mut new_memory = WasmerMemory::new(
-                                    self.vm_config.limit_config.initial_memory_pages,
-                                    self.vm_config.limit_config.max_memory_pages,
-                                )
-                                .unwrap();
+                                let mut new_memory;
                                 run_wasmer0_module(
                                     module.clone(),
                                     if SHARE_MEMORY_INSTANCE {
                                         memory.as_mut().unwrap()
                                     } else {
+                                        new_memory = WasmerMemory::new(
+                                            self.vm_config.limit_config.initial_memory_pages,
+                                            self.vm_config.limit_config.max_memory_pages,
+                                        )
+                                        .unwrap();
                                         &mut new_memory
                                     },
                                     method_name,
@@ -184,22 +181,19 @@ impl ContractCaller {
                                 VMDataPrivate::Wasmer1(memory),
                                 VMDataShared::Wasmer1(store),
                             ) => {
-                                assert!(
-                                    !SHARE_MEMORY_INSTANCE,
-                                    "Remove new_memory once get will start to reuse memory"
-                                );
-                                let mut new_memory = Wasmer1Memory::new(
-                                    store,
-                                    self.vm_config.limit_config.initial_memory_pages,
-                                    self.vm_config.limit_config.max_memory_pages,
-                                )
-                                .unwrap();
+                                let mut new_memory;
                                 run_wasmer1_module(
                                     &module,
                                     store,
                                     if SHARE_MEMORY_INSTANCE {
                                         memory.as_mut().unwrap()
                                     } else {
+                                        new_memory = Wasmer1Memory::new(
+                                            store,
+                                            self.vm_config.limit_config.initial_memory_pages,
+                                            self.vm_config.limit_config.max_memory_pages,
+                                        )
+                                        .unwrap();
                                         &mut new_memory
                                     },
                                     method_name,

--- a/runtime/near-vm-runner/src/tests/contract_preload.rs
+++ b/runtime/near-vm-runner/src/tests/contract_preload.rs
@@ -114,23 +114,21 @@ fn test_vm_runner(preloaded: bool, vm_kind: VMKind, repeat: i32) {
         for _ in 0..repeat {
             requests.push(ContractCallPrepareRequest {
                 code: Arc::clone(&code1),
-                vm_config: vm_config.clone(),
                 cache: cache.clone(),
             });
             requests.push(ContractCallPrepareRequest {
                 code: Arc::clone(&code2),
-                vm_config: vm_config.clone(),
                 cache: cache.clone(),
             });
         }
-        let calls = caller.preload(requests, vm_kind);
+        let calls = caller.preload(requests, vm_kind, vm_config.clone());
         for prepared in &calls {
             let result = caller.run_preloaded(
                 prepared,
                 method_name1,
                 &mut fake_external,
                 context.clone(),
-                &vm_config,
+                &vm_config.clone(),
                 &fees,
                 &promise_results,
                 ProtocolVersion::MAX,

--- a/runtime/near-vm-runner/src/tests/contract_preload.rs
+++ b/runtime/near-vm-runner/src/tests/contract_preload.rs
@@ -110,7 +110,7 @@ fn test_vm_runner(preloaded: bool, vm_kind: VMKind, repeat: i32) {
 
     if preloaded {
         let mut requests = Vec::new();
-        let mut caller = ContractCaller::new(4);
+        let mut caller = ContractCaller::new(4, vm_kind, vm_config);
         for _ in 0..repeat {
             requests.push(ContractCallPrepareRequest {
                 code: Arc::clone(&code1),
@@ -121,14 +121,13 @@ fn test_vm_runner(preloaded: bool, vm_kind: VMKind, repeat: i32) {
                 cache: cache.clone(),
             });
         }
-        let calls = caller.preload(requests, vm_kind, vm_config.clone());
+        let calls = caller.preload(requests);
         for prepared in &calls {
             let result = caller.run_preloaded(
                 prepared,
                 method_name1,
                 &mut fake_external,
                 context.clone(),
-                &vm_config.clone(),
                 &fees,
                 &promise_results,
                 ProtocolVersion::MAX,

--- a/runtime/near-vm-runner/src/wasmer1_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer1_runner.rs
@@ -294,6 +294,7 @@ pub(crate) fn default_wasmer1_store() -> Store {
 pub(crate) fn run_wasmer1_module<'a>(
     module: &Module,
     store: &Store,
+    memory: &mut Wasmer1Memory,
     method_name: &str,
     ext: &mut dyn External,
     context: VMContext,
@@ -312,12 +313,6 @@ pub(crate) fn run_wasmer1_module<'a>(
             ))),
         );
     }
-    let mut memory = Wasmer1Memory::new(
-        store,
-        wasm_config.limit_config.initial_memory_pages,
-        wasm_config.limit_config.max_memory_pages,
-    )
-    .unwrap();
 
     // Note that we don't clone the actual backing memory, just increase the RC.
     let memory_copy = memory.clone();
@@ -328,7 +323,7 @@ pub(crate) fn run_wasmer1_module<'a>(
         wasm_config,
         fees_config,
         promise_results,
-        &mut memory,
+        memory,
         profile,
         current_protocol_version,
     );

--- a/runtime/near-vm-runner/src/wasmer_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer_runner.rs
@@ -269,6 +269,7 @@ fn run_method(module: &Module, import: &ImportObject, method_name: &str) -> Resu
 
 pub(crate) fn run_wasmer0_module<'a>(
     module: Module,
+    memory: &mut WasmerMemory,
     method_name: &str,
     ext: &mut dyn External,
     context: VMContext,
@@ -286,11 +287,6 @@ pub(crate) fn run_wasmer0_module<'a>(
             ))),
         );
     }
-    let mut memory = WasmerMemory::new(
-        wasm_config.limit_config.initial_memory_pages,
-        wasm_config.limit_config.max_memory_pages,
-    )
-    .expect("Cannot create memory for a contract call");
     // Note that we don't clone the actual backing memory, just increase the RC.
     let memory_copy = memory.clone();
 
@@ -300,7 +296,7 @@ pub(crate) fn run_wasmer0_module<'a>(
         wasm_config,
         fees_config,
         promise_results,
-        &mut memory,
+        memory,
         profile,
         current_protocol_version,
     );


### PR DESCRIPTION
feat: infrastructure for reusing memory and store between contracts

To prepare for optimized pipelined execution of contracts we need to be able to share reusable parts of state.
This is a preparation PR allowing to share certain parts of the VM state between runs. By default, memory state is turned 
off, as we need to ensure that no memory data of one contract execution can be seen in another execution.
Once https://github.com/near/nearcore/pull/4128 will be merged, we could test performance impact of different
sharing practises.

Test plan
---------

cargo test
more specifically tests::contract_preload::test_run_preloaded which tests the behavior of the preloader.

