### PR TITLE
refactor: prepare to share resources between contract executions

### DIFF
--- a/runtime/near-vm-runner/src/lib.rs
+++ b/runtime/near-vm-runner/src/lib.rs
@@ -23,8 +23,9 @@ mod wasmer1_runner;
 pub use near_vm_errors::VMError;
 pub use preload::{ContractCallPrepareRequest, ContractCallPrepareResult, ContractCaller};
 pub use runner::compile_module;
-pub use runner::run;
 pub use runner::run_vm;
+pub use runner::run;
+pub use runner::WasmMachine;
 
 pub use near_vm_logic::with_ext_cost_counter;
 

--- a/runtime/near-vm-runner/src/runner.rs
+++ b/runtime/near-vm-runner/src/runner.rs
@@ -8,6 +8,8 @@ use near_vm_errors::{CompilationError, FunctionCallError, VMError};
 use near_vm_logic::types::PromiseResult;
 use near_vm_logic::{External, VMContext, VMKind, VMOutcome};
 
+/// Runs a single contract
+///
 /// `run` does the following:
 /// - deserializes and validate the `code` binary (see `prepare::prepare_contract`)
 /// - injects gas counting into
@@ -45,6 +47,48 @@ pub fn run<'a>(
         cache,
         profile.clone(),
     )
+}
+
+/// Runs a batch of contracts.
+///
+/// Re-using the same `WasmMachine` is potentially more efficient than calling
+/// `run` repeatedly.
+pub struct WasmMachine {
+    _private: (),
+}
+
+impl WasmMachine {
+    pub fn new() -> WasmMachine {
+        WasmMachine { _private: () }
+    }
+
+    pub fn run(
+        &mut self,
+        code: &ContractCode,
+        method_name: &str,
+        ext: &mut dyn External,
+        context: VMContext,
+        vm_config: &VMConfig,
+        fees_config: &RuntimeFeesConfig,
+        promise_results: &[PromiseResult],
+        current_protocol_version: ProtocolVersion,
+        cache: Option<&dyn CompiledContractCache>,
+        profile: &ProfileData,
+    ) -> (Option<VMOutcome>, Option<VMError>) {
+        run_vm(
+            code,
+            method_name,
+            ext,
+            context,
+            vm_config,
+            fees_config,
+            promise_results,
+            VMKind::default(),
+            current_protocol_version,
+            cache,
+            profile.clone(),
+        )
+    }
 }
 
 pub fn run_vm(

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -32,6 +32,7 @@ use near_vm_errors::{
 };
 use near_vm_logic::types::PromiseResult;
 use near_vm_logic::{VMContext, VMOutcome};
+use near_vm_runner::WasmMachine;
 
 use crate::config::{safe_add_gas, RuntimeConfig};
 use crate::ext::RuntimeExt;
@@ -42,6 +43,7 @@ use crate::{ActionResult, ApplyState};
 ///  - 0x1: EVM interpreter;
 pub(crate) fn execute_function_call(
     apply_state: &ApplyState,
+    machine: &mut WasmMachine,
     runtime_ext: &mut RuntimeExt,
     account: &mut Account,
     predecessor_id: &AccountId,
@@ -128,7 +130,7 @@ pub(crate) fn execute_function_call(
             output_data_receivers,
         };
 
-        near_vm_runner::run(
+        machine.run(
             &code,
             &function_call.method_name,
             runtime_ext,
@@ -146,6 +148,7 @@ pub(crate) fn execute_function_call(
 pub(crate) fn action_function_call(
     state_update: &mut TrieUpdate,
     apply_state: &ApplyState,
+    machine: &mut WasmMachine,
     account: &mut Account,
     receipt: &Receipt,
     action_receipt: &ActionReceipt,
@@ -179,6 +182,7 @@ pub(crate) fn action_function_call(
     );
     let (outcome, err) = execute_function_call(
         apply_state,
+        machine,
         &mut runtime_ext,
         account,
         &receipt.predecessor_id,

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -16,6 +16,7 @@ use near_primitives::{
 use near_runtime_utils::is_valid_account_id;
 use near_store::{get_access_key, get_account, get_code, TrieUpdate};
 use near_vm_logic::ReturnData;
+use near_vm_runner::WasmMachine;
 use std::{str, sync::Arc, time::Instant};
 
 use crate::{actions::execute_function_call, ext::RuntimeExt};
@@ -216,8 +217,10 @@ impl TrieViewer {
             gas: config.wasm_config.limit_config.max_gas_burnt_view,
             deposit: 0,
         };
+        let mut machine = WasmMachine::new();
         let (outcome, err) = execute_function_call(
             &apply_state,
+            &mut machine,
             &mut runtime_ext,
             &mut account,
             &originator_id,


### PR DESCRIPTION
This commit introduces a `WasmerMachine` -- an entity which is created
once at the start of the block through which the contracts are executed.

The goal here is to re-use VM resources between contract executions. At
minimum, we would want to re-use virtual memory mapping crated by wasm
runtimes. But we might want to introduce bigger bits of state as well,
for, for example, contract prefetching.

Another way to look at it is that contract execution requires to pay certain fixed-costs.
By sharing the WasmerMachine, we pay these costs once per apply, and not
once per contract call. 