### PR TITLE
feature: more runtime performance visibility into runtime

### DIFF
--- a/runtime/near-vm-runner/src/cache.rs
+++ b/runtime/near-vm-runner/src/cache.rs
@@ -46,6 +46,7 @@ fn vm_hash(vm_kind: VMKind) -> u64 {
 }
 
 fn get_key(code: &ContractCode, vm_kind: VMKind, config: &VMConfig) -> CryptoHash {
+    let _span = tracing::debug_span!("get_key").entered();
     let key = ContractCacheKey::Version2 {
         code_hash: code.hash,
         vm_config_non_crypto_hash: config.non_crypto_hash(),

--- a/runtime/near-vm-runner/src/wasmer_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer_runner.rs
@@ -10,7 +10,7 @@ use near_vm_errors::FunctionCallError::{WasmTrap, WasmUnknownError};
 use near_vm_errors::{CompilationError, FunctionCallError, MethodResolveError, VMError};
 use near_vm_logic::types::PromiseResult;
 use near_vm_logic::{External, VMContext, VMLogic, VMLogicError, VMOutcome};
-use wasmer_runtime::Module;
+use wasmer_runtime::{ImportObject, Module};
 
 fn check_method(module: &Module, method_name: &str) -> Result<(), VMError> {
     let info = module.info();
@@ -242,21 +242,29 @@ pub fn run_wasmer<'a>(
         return (None, Some(e));
     }
 
-    let instantiate = {
-        let _span = tracing::debug_span!("run_wasmer/instantiate").entered();
-        module.instantiate(&import_object)
-    };
-    match instantiate {
-        Ok(instance) => {
-            let _span = tracing::debug_span!("run_wasmer/call").entered();
+    let err = run_method(&module, &import_object, method_name).err();
+    (Some(logic.outcome()), err)
+}
 
-            match instance.call(&method_name, &[]) {
-                Ok(_) => (Some(logic.outcome()), None),
-                Err(err) => (Some(logic.outcome()), Some(err.into_vm_error())),
-            }
-        }
-        Err(err) => (Some(logic.outcome()), Some(err.into_vm_error())),
+fn run_method(module: &Module, import: &ImportObject, method_name: &str) -> Result<(), VMError> {
+    let _span = tracing::debug_span!("run_method").entered();
+
+    let instance = {
+        let _span = tracing::debug_span!("run_method/instantiate").entered();
+        module.instantiate(import).map_err(|err| err.into_vm_error())?
+    };
+
+    {
+        let _span = tracing::debug_span!("run_method/call").entered();
+        instance.call(&method_name, &[]).map_err(|err| err.into_vm_error())?;
     }
+
+    {
+        let _span = tracing::debug_span!("run_method/drop_instance").entered();
+        drop(instance)
+    }
+
+    Ok(())
 }
 
 pub(crate) fn run_wasmer0_module<'a>(
@@ -303,13 +311,8 @@ pub(crate) fn run_wasmer0_module<'a>(
         return (None, Some(e));
     }
 
-    match module.instantiate(&import_object) {
-        Ok(instance) => match instance.call(&method_name, &[]) {
-            Ok(_) => (Some(logic.outcome()), None),
-            Err(err) => (Some(logic.outcome()), Some(err.into_vm_error())),
-        },
-        Err(err) => (Some(logic.outcome()), Some(err.into_vm_error())),
-    }
+    let err = run_method(&module, &import_object, method_name).err();
+    (Some(logic.outcome()), err)
 }
 
 pub fn compile_wasmer0_module(code: &[u8]) -> bool {


### PR DESCRIPTION
- add a couple of spans that turned out to be potentially significant
  during #4030 investigation, notably dropping of the instance

- refactor code to make sure that preloading code path also has the same
  spans.

See [1] for how to read the timing info from spans

[1]: https://github.com/near/nearcore/tree/ad3de8f3a597b6cc5c01871a4709973828de3b9f/runtime/near-vm-runner#profiling