### PR TITLE
Revert "Validate each edge only once"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,12 +953,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ae45936bbf9bddd6a0268c0ea5d3814a72403f4b69a1c318aae2ce90444ad55"
 
 [[package]]
-name = "conqueue"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac4306c796b95d3964b94fa65018a57daee08b45a54b86a4f64910426427b66"
-
-[[package]]
 name = "console"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3360,7 +3354,6 @@ dependencies = [
  "bytesize",
  "cached",
  "chrono",
- "conqueue",
  "delay-detector",
  "futures",
  "lazy_static",

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -21,7 +21,6 @@ tracing = "0.1.13"
 strum = { version = "0.20", features = ["derive"] }
 near-rust-allocator-proxy = "0.2.9"
 bytesize = "1.0.1"
-conqueue = "0.4.0"
 
 borsh = "0.8.1"
 cached = "0.23"

--- a/chain/network/src/routing.rs
+++ b/chain/network/src/routing.rs
@@ -1,6 +1,6 @@
 use std::collections::{hash_map::Entry, HashMap, HashSet, VecDeque};
 use std::ops::Sub;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Instant;
 
 use serde::Serialize;
@@ -28,7 +28,6 @@ use crate::{
     types::{PeerIdOrHash, Ping, Pong},
     utils::cache_to_hashmap,
 };
-use conqueue::{QueueReceiver, QueueSender};
 #[cfg(feature = "delay_detector")]
 use delay_detector::DelayDetector;
 
@@ -72,7 +71,7 @@ pub enum EdgeType {
 }
 
 /// Edge object. Contains information relative to a new edge that is being added or removed
-/// from the network. This is the information that is required.
+/// from the network. This is the information that is required
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct Edge {
     /// Since edges are not directed `peer0 < peer1` should hold.
@@ -252,25 +251,6 @@ impl Edge {
             Some(self.peer0.clone())
         } else {
             None
-        }
-    }
-}
-
-pub struct EdgeVerifierHelper {
-    /// Shared version of edges_info used by multiple threads
-    pub edges_info_shared: Arc<Mutex<HashMap<(PeerId, PeerId), u64>>>,
-    /// Queue of edges verified, but not added yes
-    pub edges_to_add_receiver: QueueReceiver<Edge>,
-    pub edges_to_add_sender: QueueSender<Edge>,
-}
-
-impl Default for EdgeVerifierHelper {
-    fn default() -> Self {
-        let (tx, rx) = conqueue::Queue::unbounded::<Edge>();
-        Self {
-            edges_info_shared: Default::default(),
-            edges_to_add_sender: tx,
-            edges_to_add_receiver: rx,
         }
     }
 }

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -3,7 +3,7 @@ use std::convert::{Into, TryFrom, TryInto};
 use std::fmt;
 use std::net::{AddrParseError, IpAddr, SocketAddr};
 use std::str::FromStr;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::RwLock;
 use std::time::{Duration, Instant};
 
 use actix::dev::{MessageResponse, ResponseChannel};
@@ -46,7 +46,6 @@ use crate::routing::{Edge, EdgeInfo, RoutingTableInfo};
 use std::fmt::{Debug, Error, Formatter};
 use std::io;
 
-use conqueue::QueueSender;
 #[cfg(feature = "protocol_feature_forward_chunk_parts")]
 use near_primitives::merkle::combine_hash;
 
@@ -1283,11 +1282,7 @@ pub enum PeerManagerRequest {
     UnregisterPeer,
 }
 
-pub struct EdgeList {
-    pub edges: Vec<Edge>,
-    pub edges_info_shared: Arc<Mutex<HashMap<(PeerId, PeerId), u64>>>,
-    pub sender: QueueSender<Edge>,
-}
+pub struct EdgeList(pub Vec<Edge>);
 
 impl Message for EdgeList {
     type Result = bool;


### PR DESCRIPTION
Reverts near/nearcore#4111

Reverting change, that could break exchange of routing tables.

In 4111, we switches, how we add edges to PeerManager. We will now send only some edges to PeerManager in one request, not the whole graph. 

Inside `try_save_edges`, we run code, which tries to prune edges that are unreachable. We may remove some valid edges, because we didn't get full graph yet.

@bowenwang1996 