### PR TITLE
Fix improper prooning of edges

### DIFF
--- a/chain/network/src/routing.rs
+++ b/chain/network/src/routing.rs
@@ -666,9 +666,9 @@ impl RoutingTable {
         self.edges_info.retain(|(peer0, peer1), edge| {
             if to_save.contains(peer0) || to_save.contains(peer1) {
                 edges_in_component.push(edge.clone());
-                false
-            } else {
                 true
+            } else {
+                false
             }
         });
 


### PR DESCRIPTION
I noticed we are removing all reachable edges from PeerManager::edge_info.
That doesn't make any sense whatsoever?

@bowenwang1996 