### PR TITLE
Verify edges only once in a correct way

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,6 +953,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ae45936bbf9bddd6a0268c0ea5d3814a72403f4b69a1c318aae2ce90444ad55"
 
 [[package]]
+name = "conqueue"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac4306c796b95d3964b94fa65018a57daee08b45a54b86a4f64910426427b66"
+
+[[package]]
 name = "console"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3364,6 +3370,7 @@ dependencies = [
  "bytesize",
  "cached",
  "chrono",
+ "conqueue",
  "delay-detector",
  "futures",
  "lazy_static",

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -21,6 +21,7 @@ tracing = "0.1.13"
 strum = { version = "0.20", features = ["derive"] }
 near-rust-allocator-proxy = "0.2.9"
 bytesize = "1.0.1"
+conqueue = "0.4.0"
 
 borsh = "0.8.1"
 cached = "0.23"

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -30,7 +30,9 @@ use crate::peer::Peer;
 use crate::peer_store::{PeerStore, TrustLevel};
 #[cfg(feature = "metric_recorder")]
 use crate::recorder::{MetricRecorder, PeerMessageMetadata};
-use crate::routing::{Edge, EdgeInfo, EdgeType, ProcessEdgeResult, RoutingTable, MAX_NUM_PEERS};
+use crate::routing::{
+    Edge, EdgeInfo, EdgeType, EdgeVerifierHelper, ProcessEdgeResult, RoutingTable, MAX_NUM_PEERS,
+};
 use crate::types::{
     AccountOrPeerIdOrHash, Ban, BlockedPorts, Consolidate, ConsolidateResponse, FullPeerInfo,
     InboundTcpConnect, KnownPeerStatus, KnownProducer, NetworkInfo, NetworkViewClientMessages,
@@ -49,6 +51,7 @@ use metrics::NetworkMetrics;
 use near_performance_metrics::framed_write::FramedWrite;
 use near_performance_metrics_macros::perf;
 use rand::thread_rng;
+use std::cmp::max;
 
 /// How often to request peers from active peers.
 const REQUEST_PEERS_SECS: u64 = 60;
@@ -114,7 +117,26 @@ impl Handler<EdgeList> for EdgeVerifier {
 
     #[perf]
     fn handle(&mut self, msg: EdgeList, _ctx: &mut Self::Context) -> Self::Result {
-        msg.0.iter().all(|edge| edge.verify())
+        for edge in msg.edges {
+            let key = (edge.peer0.clone(), edge.peer1.clone());
+            if msg.edges_info_shared.lock().unwrap().get(&key).cloned().unwrap_or(0u64)
+                >= edge.nonce
+            {
+                continue;
+            }
+            if !edge.verify() {
+                return false;
+            }
+            {
+                let mut guard = msg.edges_info_shared.lock().unwrap();
+                let entry = guard.entry(key);
+
+                let cur_nonce = entry.or_insert(edge.nonce);
+                *cur_nonce = max(*cur_nonce, edge.nonce);
+            }
+            msg.sender.push(edge);
+        }
+        true
     }
 }
 
@@ -136,6 +158,8 @@ pub struct PeerManagerActor {
     active_peers: HashMap<PeerId, ActivePeer>,
     /// Routing table to keep track of account id
     routing_table: RoutingTable,
+    /// Fields used for communicating with EdgeVerifier
+    routing_table_exchange_helper: EdgeVerifierHelper,
     /// Flag that track whether we started attempts to establish outbound connections.
     started_connect_attempts: bool,
     /// Monitor peers attempts, used for fast checking in the beginning with exponential backoff.
@@ -152,6 +176,7 @@ pub struct PeerManagerActor {
     pending_incoming_connections_counter: Arc<AtomicUsize>,
     peer_counter: Arc<AtomicUsize>,
     scheduled_routing_table_update: bool,
+    edge_verifier_requests_in_progress: u64,
 }
 
 impl PeerManagerActor {
@@ -188,6 +213,7 @@ impl PeerManagerActor {
             active_peers: HashMap::default(),
             outgoing_peers: HashSet::default(),
             routing_table,
+            routing_table_exchange_helper: Default::default(),
             monitor_peers_attempts: 0,
             started_connect_attempts: false,
             pending_update_nonce_request: HashMap::new(),
@@ -199,7 +225,94 @@ impl PeerManagerActor {
             pending_incoming_connections_counter: Arc::new(AtomicUsize::new(0)),
             peer_counter: Arc::new(AtomicUsize::new(0)),
             scheduled_routing_table_update: false,
+            edge_verifier_requests_in_progress: 0,
         })
+    }
+
+    fn broadcast_accounts(
+        &mut self,
+        ctx: &mut Context<PeerManagerActor>,
+        accounts: Vec<AnnounceAccount>,
+    ) {
+        if !accounts.is_empty() {
+            debug!(target: "network", "{:?} Received new accounts: {:?}", self.config.account_id, accounts);
+        }
+        for account in accounts.iter() {
+            self.routing_table.add_account(account.clone());
+        }
+
+        let new_data = SyncData { edges: Default::default(), accounts };
+
+        if !new_data.is_empty() {
+            self.broadcast_message(
+                ctx,
+                SendMessage { message: PeerMessage::RoutingTableSync(new_data) },
+            )
+        };
+    }
+
+    fn broadcast_edges(&mut self, ctx: &mut Context<PeerManagerActor>) {
+        let me = self.peer_id.clone();
+
+        let start = Instant::now();
+        let mut new_edges = Vec::new();
+        while let Some(edge) = self.routing_table_exchange_helper.edges_to_add_receiver.pop() {
+            if let Some(cur_edge) =
+                self.routing_table.get_edge(edge.peer0.clone(), edge.peer1.clone())
+            {
+                if cur_edge.nonce >= edge.nonce {
+                    // We have newer update. Drop this.
+                    continue;
+                }
+            }
+            // Add new edge update to the routing table.
+            self.process_edges(ctx, vec![edge.clone()]);
+            if let Some(other) = edge.other(&me) {
+                // We belong to this edge.
+                if self.active_peers.contains_key(&other) {
+                    // This is an active connection.
+                    match edge.edge_type() {
+                        EdgeType::Added => {}
+                        EdgeType::Removed => {
+                            // Try to update the nonce, and in case it fails removes the peer.
+                            self.try_update_nonce(ctx, edge.clone(), other);
+                            continue;
+                        }
+                    }
+                } else {
+                    match edge.edge_type() {
+                        EdgeType::Added => {
+                            self.wait_peer_or_remove(ctx, edge.clone());
+                            continue;
+                        }
+                        EdgeType::Removed => {}
+                    }
+                }
+            }
+            new_edges.push(edge);
+            if start.elapsed() >= Duration::from_millis(50) {
+                break;
+            }
+        }
+
+        let new_data = SyncData { edges: new_edges, accounts: Default::default() };
+
+        if !new_data.is_empty() {
+            self.broadcast_message(
+                ctx,
+                SendMessage { message: PeerMessage::RoutingTableSync(new_data) },
+            )
+        };
+
+        near_performance_metrics::actix::run_later(
+            ctx,
+            file!(),
+            line!(),
+            Duration::from_millis(50),
+            move |act, ctx| {
+                act.broadcast_edges(ctx);
+            },
+        );
     }
 
     fn num_active_peers(&self) -> usize {
@@ -581,7 +694,8 @@ impl PeerManagerActor {
                 Duration::from_millis(1000),
                 |act, _ctx| {
                     act.scheduled_routing_table_update = false;
-                    act.routing_table.update();
+                    // We only want to save prune edges if there are no pending requests to EdgeVerifier
+                    act.routing_table.update(act.edge_verifier_requests_in_progress == 0);
                     #[cfg(feature = "metric_recorder")]
                     act.metric_recorder.set_graph(act.routing_table.get_raw_graph())
                 },
@@ -1218,6 +1332,8 @@ impl Actor for PeerManagerActor {
         // Periodically ping all peers to determine latencies between pair of peers.
         #[cfg(feature = "metric_recorder")]
         self.ping_all_peers(ctx);
+
+        self.broadcast_edges(ctx);
     }
 
     /// Try to gracefully disconnect from active peers.
@@ -1464,116 +1580,63 @@ impl Handler<NetworkRequests> for PeerManagerActor {
             }
             NetworkRequests::Sync { peer_id, sync_data } => {
                 // Process edges and add new edges to the routing table. Also broadcast new edges.
-                let SyncData { mut edges, accounts } = sync_data;
-                edges.retain(|edge| {
-                    match self.routing_table.get_edge(edge.peer0.clone(), edge.peer1.clone()) {
-                        // only consider edges with bigger nonce
-                        Some(cur_edge) => cur_edge.nonce < edge.nonce,
-                        None => true,
-                    }
-                });
+                let SyncData { edges, accounts } = sync_data;
 
-                self.edge_verifier_pool.send(EdgeList(edges.clone()))
+                // Filter known accounts before validating them.
+                let accounts = accounts
+                    .into_iter()
+                    .filter_map(|announce_account| {
+                        if let Some(current_announce_account) =
+                            self.routing_table.get_announce(&announce_account.account_id)
+                        {
+                            if announce_account.epoch_id == current_announce_account.epoch_id {
+                                None
+                            } else {
+                                Some((announce_account, Some(current_announce_account.epoch_id)))
+                            }
+                        } else {
+                            Some((announce_account, None))
+                        }
+                    })
+                    .collect();
+
+                // Ask client to validate accounts before accepting them.
+                let peer_id_clone = peer_id.clone();
+                self.view_client_addr
+                    .send(NetworkViewClientMessages::AnnounceAccount(accounts))
                     .into_actor(self)
                     .then(move |response, act, ctx| {
                         match response {
-                            Ok(false) => act.try_ban_peer(ctx, &peer_id, ReasonForBan::InvalidEdge),
-                            Ok(true) => {
-                            // Filter known accounts before validating them.
-                            let new_accounts = accounts
-                                .into_iter()
-                                .filter_map(|announce_account| {
-                                    if let Some(current_announce_account) =
-                                        act.routing_table.get_announce(&announce_account.account_id)
-                                    {
-                                        if announce_account.epoch_id == current_announce_account.epoch_id {
-                                            None
-                                        } else {
-                                            Some((announce_account, Some(current_announce_account.epoch_id)))
-                                        }
-                                    } else {
-                                        Some((announce_account, None))
-                                    }
-                                })
-                                .collect();
-
-                            // Ask client to validate accounts before accepting them.
-                            act.view_client_addr
-                                .send(NetworkViewClientMessages::AnnounceAccount(new_accounts))
-                                .into_actor(act)
-                                .then(move |response, act, ctx| {
-                                    match response {
-                                    Ok(NetworkViewClientResponses::Ban { ban_reason }) => {
-                                        act.try_ban_peer(ctx, &peer_id, ban_reason);
-                                    }
-                                    Ok(NetworkViewClientResponses::AnnounceAccount(accounts)) => {
-                                        // Filter known edges.
-                                        let me = act.peer_id.clone();
-
-                                        let new_edges: Vec<_> = edges
-                                            .into_iter()
-                                            .filter( |edge| {
-                                                if let Some(cur_edge) = act.routing_table.get_edge(edge.peer0.clone(), edge.peer1.clone()){
-                                                    if cur_edge.nonce >= edge.nonce {
-                                                        // We have newer update. Drop this.
-                                                        return false;
-                                                    }
-                                                }
-                                                // Add new edge update to the routing table.
-                                                act.process_edges(ctx, vec![edge.clone()]);
-                                                if let Some(other) = edge.other(&me) {
-                                                    // We belong to this edge.
-                                                    if act.active_peers.contains_key(&other) {
-                                                        // This is an active connection.
-                                                        match edge.edge_type() {
-                                                            EdgeType::Added => true,
-                                                            EdgeType::Removed => {
-                                                                // Try to update the nonce, and in case it fails removes the peer.
-                                                                act.try_update_nonce(ctx, edge.clone(), other);
-                                                                false
-                                                            }
-                                                        }
-                                                    } else {
-                                                        match edge.edge_type() {
-                                                            EdgeType::Added => {
-                                                                act.wait_peer_or_remove(ctx, edge.clone());
-                                                                false
-                                                            }
-                                                            EdgeType::Removed => true
-                                                        }
-                                                    }
-                                                } else {
-                                                    true
-                                                }
-
-                                            })
-                                            .collect();
-
-                                        // Add accounts to the routing table.
-                                        if !accounts.is_empty() {
-                                            debug!(target: "network", "{:?} Received new accounts: {:?}", act.config.account_id, accounts);
-                                        }
-                                        for account in accounts.iter() {
-                                            act.routing_table.add_account(account.clone());
-                                        }
-
-                                        let new_data = SyncData { edges: new_edges, accounts };
-
-                                        if !new_data.is_empty() {
-                                            act.broadcast_message(
-                                                ctx,
-                                                SendMessage { message: PeerMessage::RoutingTableSync(new_data) },
-                                            )
-                                        };
-                                    }
-                                    _ => {
-                                        debug!(target: "network", "Received invalid account confirmation from client.");
-                                    }
-                                }
-                                    actix::fut::ready(())
-                                })
-                                .spawn(ctx);
+                            Ok(NetworkViewClientResponses::Ban { ban_reason }) => {
+                                act.try_ban_peer(ctx, &peer_id_clone, ban_reason);
                             }
+                            Ok(NetworkViewClientResponses::AnnounceAccount(accounts)) => {
+                                act.broadcast_accounts(ctx, accounts);
+                            }
+                            _ => {
+                                debug!(target: "network", "Received invalid account confirmation from client.");
+                            }
+                        }
+                        actix::fut::ready(())
+                    }).spawn(ctx);
+
+                // Broadcast edges once EdgeVerifier finishes
+                self.edge_verifier_requests_in_progress += 1;
+                self.edge_verifier_pool
+                    .send(EdgeList {
+                        edges,
+                        edges_info_shared: self
+                            .routing_table_exchange_helper
+                            .edges_info_shared
+                            .clone(),
+                        sender: self.routing_table_exchange_helper.edges_to_add_sender.clone(),
+                    })
+                    .into_actor(self)
+                    .then(move |response, act, ctx| {
+                        act.edge_verifier_requests_in_progress -= 1;
+                        match response {
+                            Ok(false) => act.try_ban_peer(ctx, &peer_id, ReasonForBan::InvalidEdge),
+                            Ok(true) => {}
                             Err(err) => warn!(target: "network", "error validating edges: {}", err),
                         }
                         actix::fut::ready(())

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -79,6 +79,10 @@ const EXPONENTIAL_BACKOFF_LIMIT: u64 = 91;
 const WAIT_BEFORE_PING: u64 = 20_000;
 /// Limit number of pending Peer actors to avoid OOM.
 const LIMIT_PENDING_PEERS: usize = 60;
+/// How ofter should we broadcast edges.
+const BROADCAST_EDGES_INTERVAL: Duration = Duration::from_millis(50);
+/// Maximum amount of time spend processing edges.
+const BROAD_CAST_EDGES_MAX_WORK_ALLOVED: Duration = Duration::from_millis(50);
 
 macro_rules! unwrap_or_error(($obj: expr, $error: expr) => (match $obj {
     Ok(result) => result,
@@ -290,7 +294,7 @@ impl PeerManagerActor {
                 }
             }
             new_edges.push(edge);
-            if start.elapsed() >= Duration::from_millis(50) {
+            if start.elapsed() >= BROAD_CAST_EDGES_MAX_WORK_ALLOVED {
                 break;
             }
         }
@@ -308,7 +312,7 @@ impl PeerManagerActor {
             ctx,
             file!(),
             line!(),
-            Duration::from_millis(50),
+            BROADCAST_EDGES_INTERVAL,
             move |act, ctx| {
                 act.broadcast_edges(ctx);
             },

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -3,7 +3,7 @@ use std::convert::{Into, TryFrom, TryInto};
 use std::fmt;
 use std::net::{AddrParseError, IpAddr, SocketAddr};
 use std::str::FromStr;
-use std::sync::RwLock;
+use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
 use actix::dev::{MessageResponse, ResponseChannel};
@@ -46,6 +46,7 @@ use crate::routing::{Edge, EdgeInfo, RoutingTableInfo};
 use std::fmt::{Debug, Error, Formatter};
 use std::io;
 
+use conqueue::QueueSender;
 #[cfg(feature = "protocol_feature_forward_chunk_parts")]
 use near_primitives::merkle::combine_hash;
 
@@ -1282,7 +1283,11 @@ pub enum PeerManagerRequest {
     UnregisterPeer,
 }
 
-pub struct EdgeList(pub Vec<Edge>);
+pub struct EdgeList {
+    pub edges: Vec<Edge>,
+    pub edges_info_shared: Arc<Mutex<HashMap<(PeerId, PeerId), u64>>>,
+    pub sender: QueueSender<Edge>,
+}
 
 impl Message for EdgeList {
     type Result = bool;

--- a/chain/network/tests/cache_edges.rs
+++ b/chain/network/tests/cache_edges.rs
@@ -161,7 +161,7 @@ impl RoutingTableTest {
     }
 
     fn update(&mut self) {
-        self.routing_table.update();
+        self.routing_table.update(true);
     }
 }
 


### PR DESCRIPTION
This is a corrected version of #4145 which I reverted.
I added a check, to make sure we don't prune edges while they are requests to edge versifier in progress.