### PR TITLE
fix(primitives-core): make default profile disabled

### DIFF
--- a/core/primitives-core/src/profile.rs
+++ b/core/primitives-core/src/profile.rs
@@ -225,7 +225,6 @@ mod test {
 
     #[test]
     fn test_profile_data_debug() {
-        #[cfg(not(feature = "costs_counting"))]
         println!("{:#?}", ProfileData::new_enabled());
     }
 }

--- a/core/primitives-core/src/profile.rs
+++ b/core/primitives-core/src/profile.rs
@@ -215,7 +215,7 @@ mod test {
     use super::*;
     #[test]
     fn test_profile_all_gas() {
-        let profile_data = ProfileData::default();
+        let profile_data = ProfileData::new_enabled();
         profile_data.set_burnt_gas(42);
         #[cfg(not(feature = "costs_counting"))]
         assert_eq!(profile_data.all_gas(), 0);

--- a/core/primitives-core/src/profile.rs
+++ b/core/primitives-core/src/profile.rs
@@ -36,14 +36,8 @@ enum Repr {
 const _ASSERT_NO_OP_IF_COUNTING_DISABLED: [(); 0] = [(); std::mem::size_of::<ProfileData>()];
 
 impl Default for ProfileData {
-    #[cfg(not(feature = "costs_counting"))]
     fn default() -> ProfileData {
         ProfileData::new_disabled()
-    }
-
-    #[cfg(feature = "costs_counting")]
-    fn default() -> ProfileData {
-        ProfileData::new_enabled()
     }
 }
 
@@ -232,6 +226,6 @@ mod test {
     #[test]
     fn test_profile_data_debug() {
         #[cfg(not(feature = "costs_counting"))]
-        println!("{:#?}", ProfileData::default());
+        println!("{:#?}", ProfileData::new_enabled());
     }
 }

--- a/core/primitives-core/src/profile.rs
+++ b/core/primitives-core/src/profile.rs
@@ -137,7 +137,7 @@ impl ProfileData {
 impl fmt::Debug for ProfileData {
     #[cfg(not(feature = "costs_counting"))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "cost_counting feature is not enabled in near-primitives-core, cannot print profile data")?;
+        writeln!(f, "ERROR: cost_counting feature is not enabled in near-primitives-core, cannot print profile data")?;
         Ok(())
     }
 
@@ -145,6 +145,10 @@ impl fmt::Debug for ProfileData {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use num_rational::Ratio;
         let all_gas = self.all_gas();
+        if all_gas == 0 {
+            writeln!(f, "ERROR: No gas profiled")?;
+            return Ok(());
+        }
         let host_gas = self.host_gas();
         let action_gas = self.action_gas();
         let wasm_gas = self.wasm_gas();
@@ -225,6 +229,14 @@ mod test {
 
     #[test]
     fn test_profile_data_debug() {
-        println!("{:#?}", ProfileData::new_enabled());
+        let profile_data = ProfileData::new_enabled();
+        profile_data.set_burnt_gas(42);
+        println!("{:#?}", &profile_data);
+    }
+
+    #[test]
+    fn test_profile_data_debug_no_data() {
+        let profile_data = ProfileData::new_enabled();
+        println!("{:#?}", &profile_data);
     }
 }


### PR DESCRIPTION
As per @matklad suggested that default shouldn't be dependent on feature flag.