### PR TITLE
fix: count vm_runner cache operation as busy, not as idle

### DIFF
--- a/runtime/near-vm-runner/src/cache.rs
+++ b/runtime/near-vm-runner/src/cache.rs
@@ -117,7 +117,7 @@ pub mod wasmer0_cache {
         key: &CryptoHash,
         cache: &dyn CompiledContractCache,
     ) -> Result<wasmer_runtime::Module, VMError> {
-        let _span = tracing::debug_span!("compile_and_serialize_wasmer");
+        let _span = tracing::debug_span!("compile_and_serialize_wasmer").entered();
 
         let module = compile_module(wasm_code, config).map_err(|e| cache_error(e, &key, cache))?;
         let artifact = module
@@ -137,7 +137,7 @@ pub mod wasmer0_cache {
     fn deserialize_wasmer(
         serialized: &[u8],
     ) -> Result<Result<wasmer_runtime::Module, VMError>, CacheError> {
-        let _span = tracing::debug_span!("deserialize_wasmer");
+        let _span = tracing::debug_span!("deserialize_wasmer").entered();
 
         let record = CacheRecord::try_from_slice(serialized).map_err(|_e| DeserializationError)?;
         let serialized_artifact = match record {
@@ -241,7 +241,7 @@ pub mod wasmer1_cache {
         cache: &dyn CompiledContractCache,
         store: &wasmer::Store,
     ) -> Result<wasmer::Module, VMError> {
-        let _span = tracing::debug_span!("compile_and_serialize_wasmer1");
+        let _span = tracing::debug_span!("compile_and_serialize_wasmer1").entered();
 
         let module = compile_module_wasmer1(wasm_code, config, store)
             .map_err(|e| cache_error(e, &key, cache))?;
@@ -257,7 +257,7 @@ pub mod wasmer1_cache {
         serialized: &[u8],
         store: &wasmer::Store,
     ) -> Result<Result<wasmer::Module, VMError>, CacheError> {
-        let _span = tracing::debug_span!("deserialize_wasmer1");
+        let _span = tracing::debug_span!("deserialize_wasmer1").entered();
 
         let record = CacheRecord::try_from_slice(serialized).map_err(|_e| DeserializationError)?;
         let serialized_module = match record {


### PR DESCRIPTION
Unentered spans count towrads "idle" measure, which is not what we want. We want "busy", and for that the span must be entered. 