### PR TITLE
fix: off by one in db refcounting

### DIFF
--- a/core/store/src/db/refcount.rs
+++ b/core/store/src/db/refcount.rs
@@ -50,8 +50,8 @@ pub(crate) fn merge_refcounted_records(result: &mut Vec<u8>, val: &[u8]) {
 }
 
 /// Returns
-/// (Some(value), rc) if rc > 0
-/// (None, rc) if rc <= 0
+/// (Some(value), rc) if rc >= 0
+/// (None, rc) if rc < 0
 pub fn decode_value_with_rc(bytes: &[u8]) -> (Option<&[u8]>, i64) {
     if bytes.len() < 8 {
         debug_assert!(bytes.is_empty());


### PR DESCRIPTION
This feels like a typo to me, but I have next to zero understanding of this code, so I would prefer that someone else takes over this, if this is a bug at all. 