### PR TITLE
fix: prevent LLVM from optimizing the benchmark to O(1) computation

### DIFF
--- a/runtime/near-test-contracts/test-contract-rs/src/lib.rs
+++ b/runtime/near-test-contracts/test-contract-rs/src/lib.rs
@@ -477,7 +477,12 @@ pub unsafe fn sum_n() {
 
     let mut sum = 0u64;
     for i in 0..n {
-        sum += i;
+        // LLVM optimizes sum += i into O(1) computation, use volatile to thwart
+        // that.
+        unsafe {
+            let new_sum = std::ptr::read_volatile(&sum).wrapping_add(i);
+            std::ptr::write_volatile(&mut sum, new_sum);
+        }
     }
 
     let data = sum.to_le_bytes();


### PR DESCRIPTION
LLVM is able to compute closed form for polynomial sums like

    let mut sum = 0i
    for i in 0..n {
        sum += a_0 + a_1*i + a_2*i*i ... + a_k*i^k;
    }

https://godbolt.org/z/4Wx7G8vEx