### PR TITLE
Fix the broken docker release due to stable toolchain change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update -qq && apt-get install -y \
     clang \
     && rm -rf /var/lib/apt/lists/*
 
-COPY ./stable.rust-toolchain /tmp/rust-toolchain
+COPY ./rust-toolchain /tmp/rust-toolchain
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \

--- a/Dockerfile.nightly
+++ b/Dockerfile.nightly
@@ -13,7 +13,7 @@ RUN apt-get update -qq && apt-get install -y \
     clang \
     && rm -rf /var/lib/apt/lists/*
 
-COPY ./stable.rust-toolchain /tmp/rust-toolchain
+COPY ./rust-toolchain /tmp/rust-toolchain
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \


### PR DESCRIPTION
Docker release was broken due to deletion of the stable.rust-toolchain file in: https://github.com/near/nearcore/commit/08653bad65f4a137190514249e8f4ef6d132556c