### PR TITLE
fix: don't misinterprent alt_bn128_g1 costs as action costs

### DIFF
--- a/core/primitives-core/src/config.rs
+++ b/core/primitives-core/src/config.rs
@@ -537,7 +537,7 @@ pub enum ExtCosts {
     #[cfg(feature = "protocol_feature_alt_bn128")]
     alt_bn128_g1_sum_byte,
 
-    // NB: this should be the last element of the enum.
+    // NOTE: this should be the last element of the enum.
     __count,
 }
 
@@ -556,7 +556,7 @@ pub enum ActionCosts {
     value_return,
     new_receipt,
 
-    // NB: this should be the last element of the enum.
+    // NOTE: this should be the last element of the enum.
     __count,
 }
 

--- a/core/primitives-core/src/config.rs
+++ b/core/primitives-core/src/config.rs
@@ -536,6 +536,9 @@ pub enum ExtCosts {
     alt_bn128_g1_sum_base,
     #[cfg(feature = "protocol_feature_alt_bn128")]
     alt_bn128_g1_sum_byte,
+
+    // NB: this should be the last element of the enum.
+    __count,
 }
 
 // Type of an action, used in fees logic.
@@ -552,6 +555,9 @@ pub enum ActionCosts {
     delete_key,
     value_return,
     new_receipt,
+
+    // NB: this should be the last element of the enum.
+    __count,
 }
 
 impl fmt::Display for ActionCosts {
@@ -562,7 +568,7 @@ impl fmt::Display for ActionCosts {
 
 impl ActionCosts {
     pub const fn count() -> usize {
-        ActionCosts::new_receipt as usize + 1
+        ActionCosts::__count as usize
     }
 
     pub fn name_of(index: usize) -> &'static str {
@@ -654,11 +660,13 @@ impl ExtCosts {
             alt_bn128_g1_sum_base => config.alt_bn128_g1_sum_base,
             #[cfg(feature = "protocol_feature_alt_bn128")]
             alt_bn128_g1_sum_byte => config.alt_bn128_g1_sum_byte,
+
+            __count => unreachable!(),
         }
     }
 
     pub const fn count() -> usize {
-        ExtCosts::validator_total_stake_base as usize + 1
+        ExtCosts::__count as usize
     }
 
     pub fn name_of(index: usize) -> &'static str {

--- a/runtime/near-vm-runner/src/tests/rs_contract.rs
+++ b/runtime/near-vm-runner/src/tests/rs_contract.rs
@@ -134,6 +134,7 @@ fn run_test_ext(
     let fees = RuntimeFeesConfig::default();
     let context = create_context(input.to_vec());
 
+    let profile = ProfileData::new_enabled();
     let (outcome, err) = run_vm(
         &code,
         &method,
@@ -145,8 +146,10 @@ fn run_test_ext(
         vm_kind,
         LATEST_PROTOCOL_VERSION,
         None,
-        ProfileData::new_disabled(),
+        profile.clone(),
     );
+
+    assert_eq!(profile.action_gas(), 0);
 
     if let Some(_) = err {
         panic!("Failed execution: {:?}", err);


### PR DESCRIPTION
Before this PR, we store costs for `alt_bn128_g1` and costs of certain actions in the same array index, becaues, when adding alt_bn128_g1, we forgot to update the number of costs. The fix is to make this mistake impossible, by including an explicit sentinel node at the end.


Test plan
---------

Add sanity check to existing ext tests that they don't increase action costs. 