### PR TITLE
refactor: reduce the number of deps for public libraries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3440,7 +3440,6 @@ dependencies = [
  "base64 0.11.0",
  "borsh",
  "bs58",
- "derive_more",
  "hex",
  "lazy_static",
  "num-rational",

--- a/core/primitives-core/Cargo.toml
+++ b/core/primitives-core/Cargo.toml
@@ -15,7 +15,6 @@ base64 = "0.11"
 borsh = "0.8.1"
 bs58 = "0.4"
 hex = "0.4"
-derive_more = "0.99.3"
 num-rational = { version = "0.3.1", features = ["serde"]}
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/core/primitives-core/src/hash.rs
+++ b/core/primitives-core/src/hash.rs
@@ -7,12 +7,16 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use crate::logging::pretty_hash;
 use crate::serialize::{from_base, to_base, BaseDecode};
 
-#[derive(Copy, Clone, PartialOrd, PartialEq, Eq, Ord, derive_more::AsRef)]
-#[as_ref(forward)]
+#[derive(Copy, Clone, PartialOrd, PartialEq, Eq, Ord)]
 pub struct Digest(pub [u8; 32]);
 
-#[derive(Copy, Clone, PartialOrd, Ord, derive_more::AsRef)]
-#[as_ref(forward)]
+impl AsRef<[u8]> for Digest {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+#[derive(Copy, Clone, PartialOrd, Ord)]
 pub struct CryptoHash(pub Digest);
 
 impl<'a> From<&'a CryptoHash> for String {
@@ -24,6 +28,12 @@ impl<'a> From<&'a CryptoHash> for String {
 impl Default for CryptoHash {
     fn default() -> Self {
         CryptoHash(Digest(Default::default()))
+    }
+}
+
+impl AsRef<[u8]> for CryptoHash {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
     }
 }
 


### PR DESCRIPTION
primitives-core is an API crate, so all of its deps become deps of
consumers of the library. This makes deps significantly more costly.

For derive-more in particular, it seems like it is not used that
heavily.