### PR TITLE
Profile by default

### DIFF
--- a/core/primitives-core/Cargo.toml
+++ b/core/primitives-core/Cargo.toml
@@ -24,7 +24,6 @@ lazy_static = "1.4"
 
 [features]
 default = []
-costs_counting = []
 protocol_feature_add_account_versions = []
 protocol_feature_evm = []
 protocol_feature_alt_bn128 = []

--- a/core/primitives-core/src/profile.rs
+++ b/core/primitives-core/src/profile.rs
@@ -71,7 +71,7 @@ impl ProfileData {
     fn add_val(&self, index: usize, value: u64) {
         self.with_slot(index, |slot| {
             let old = slot.get();
-            slot.set(old + value);
+            slot.set(old.saturating_add(value));
         })
     }
 
@@ -220,5 +220,15 @@ mod test {
     fn test_profile_data_debug_no_data() {
         let profile_data = ProfileData::new_enabled();
         println!("{:#?}", &profile_data);
+    }
+
+    #[test]
+    fn test_no_panic_on_overflow() {
+        let profile_data = ProfileData::new_enabled();
+        profile_data.add_action_cost(ActionCosts::function_call, u64::MAX);
+        profile_data.add_action_cost(ActionCosts::function_call, u64::MAX);
+
+        let res = profile_data.get_action_cost(ActionCosts::function_call as usize);
+        assert_eq!(res, u64::MAX);
     }
 }

--- a/core/primitives-core/src/profile.rs
+++ b/core/primitives-core/src/profile.rs
@@ -1,33 +1,21 @@
+use std::rc::Rc;
 use std::{cell::Cell, fmt};
 
 use crate::config::{ActionCosts, ExtCosts};
 use crate::types::Gas;
 
 /// Data for total gas burnt (index 0), and then each external cost and action
-#[allow(dead_code)]
 type DataArray = [Cell<u64>; ProfileData::LEN];
 
 /// Profile of gas consumption.
 #[derive(Clone)]
 pub struct ProfileData {
-    repr: Repr,
+    data: Rc<DataArray>,
 }
-
-#[derive(Clone)]
-enum Repr {
-    #[cfg(feature = "costs_counting")]
-    Enabled {
-        data: std::rc::Rc<DataArray>,
-    },
-    Disabled,
-}
-
-#[cfg(not(feature = "costs_counting"))]
-const _ASSERT_NO_OP_IF_COUNTING_DISABLED: [(); 0] = [(); std::mem::size_of::<ProfileData>()];
 
 impl Default for ProfileData {
     fn default() -> ProfileData {
-        ProfileData::new_disabled()
+        ProfileData::new()
     }
 }
 
@@ -37,26 +25,12 @@ impl ProfileData {
     const LEN: usize = 1 + ActionCosts::count() + ExtCosts::count();
 
     #[inline]
-    #[cfg(feature = "costs_counting")]
-    pub fn new_enabled() -> Self {
+    pub fn new() -> Self {
         // We must manually promote to a constant for array literal to work.
         const ZERO: Cell<u64> = Cell::new(0);
 
-        let data = std::rc::Rc::new([ZERO; ProfileData::LEN]);
-        let repr = Repr::Enabled { data };
-        ProfileData { repr }
-    }
-
-    #[inline]
-    #[cfg(not(feature = "costs_counting"))]
-    pub fn new_enabled() -> Self {
-        Self::new_disabled()
-    }
-
-    #[inline]
-    pub fn new_disabled() -> Self {
-        let repr = Repr::Disabled;
-        ProfileData { repr }
+        let data = Rc::new([ZERO; ProfileData::LEN]);
+        ProfileData { data }
     }
 
     #[inline]
@@ -69,24 +43,14 @@ impl ProfileData {
     }
     #[inline]
     fn add_val(&self, index: usize, value: u64) {
-        self.with_slot(index, |slot| {
-            let old = slot.get();
-            slot.set(old.saturating_add(value));
-        })
+        let slot = &self.data[index];
+        let old = slot.get();
+        slot.set(old.saturating_add(value));
     }
 
-    #[inline]
-    fn with_slot(&self, index: usize, f: impl FnOnce(&Cell<u64>)) {
-        match &self.repr {
-            #[cfg(feature = "costs_counting")]
-            Repr::Enabled { data } => f(&data[index]),
-            Repr::Disabled => drop((index, f)),
-        }
-    }
     fn read(&self, index: usize) -> u64 {
-        let mut res = 0;
-        self.with_slot(index, |slot| res = slot.get());
-        res
+        let slot = &self.data[index];
+        slot.get()
     }
 
     pub fn all_gas(&self) -> Gas {
@@ -121,18 +85,12 @@ impl ProfileData {
     }
 
     pub fn set_burnt_gas(&self, burnt_gas: u64) {
-        self.with_slot(0, |slot| slot.set(burnt_gas));
+        let slot = &self.data[0];
+        slot.set(burnt_gas)
     }
 }
 
 impl fmt::Debug for ProfileData {
-    #[cfg(not(feature = "costs_counting"))]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "ERROR: cost_counting feature is not enabled in near-primitives-core, cannot print profile data")?;
-        Ok(())
-    }
-
-    #[cfg(feature = "costs_counting")]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use num_rational::Ratio;
         let all_gas = self.all_gas();
@@ -201,30 +159,27 @@ mod test {
     use super::*;
     #[test]
     fn test_profile_all_gas() {
-        let profile_data = ProfileData::new_enabled();
+        let profile_data = ProfileData::new();
         profile_data.set_burnt_gas(42);
-        #[cfg(not(feature = "costs_counting"))]
-        assert_eq!(profile_data.all_gas(), 0);
-        #[cfg(feature = "costs_counting")]
         assert_eq!(profile_data.all_gas(), 42);
     }
 
     #[test]
     fn test_profile_data_debug() {
-        let profile_data = ProfileData::new_enabled();
+        let profile_data = ProfileData::new();
         profile_data.set_burnt_gas(42);
         println!("{:#?}", &profile_data);
     }
 
     #[test]
     fn test_profile_data_debug_no_data() {
-        let profile_data = ProfileData::new_enabled();
+        let profile_data = ProfileData::new();
         println!("{:#?}", &profile_data);
     }
 
     #[test]
     fn test_no_panic_on_overflow() {
-        let profile_data = ProfileData::new_enabled();
+        let profile_data = ProfileData::new();
         profile_data.add_action_cost(ActionCosts::function_call, u64::MAX);
         profile_data.add_action_cost(ActionCosts::function_call, u64::MAX);
 

--- a/core/primitives-core/src/profile.rs
+++ b/core/primitives-core/src/profile.rs
@@ -120,10 +120,6 @@ impl ProfileData {
         self.all_gas() - self.host_gas() - self.action_gas()
     }
 
-    pub fn unaccounted_gas(&self) -> u64 {
-        self.all_gas() - self.wasm_gas() - self.action_gas() - self.host_gas()
-    }
-
     pub fn set_burnt_gas(&self, burnt_gas: u64) {
         self.with_slot(0, |slot| slot.set(burnt_gas));
     }
@@ -168,15 +164,6 @@ impl fmt::Debug for ProfileData {
             wasm_gas,
             Ratio::new(wasm_gas * 100, all_gas).to_integer()
         )?;
-        let unaccounted_gas = self.unaccounted_gas();
-        if unaccounted_gas > 0 {
-            writeln!(
-                f,
-                "Unaccounted: {} [{}% total]",
-                unaccounted_gas,
-                Ratio::new(unaccounted_gas * 100, all_gas).to_integer()
-            )?;
-        }
         writeln!(f, "------ Host functions --------")?;
         for e in 0..ExtCosts::count() {
             let d = self.get_ext_cost(e);

--- a/runtime/near-vm-logic/Cargo.toml
+++ b/runtime/near-vm-logic/Cargo.toml
@@ -42,7 +42,7 @@ wasmtime_default = []
 wasmer1_default = []
 
 # Use this feature to enable counting of fees and costs applied.
-costs_counting = ["near-primitives-core/costs_counting"]
+costs_counting = []
 
 [[test]]
 name = "test_storage_read_write"

--- a/runtime/near-vm-logic/src/gas_counter.rs
+++ b/runtime/near-vm-logic/src/gas_counter.rs
@@ -240,7 +240,7 @@ mod tests {
     #[test]
     fn test_deduct_gas() {
         let mut counter =
-            GasCounter::new(ExtCostsConfig::default(), 10, 10, false, ProfileData::new_disabled());
+            GasCounter::new(ExtCostsConfig::default(), 10, 10, false, ProfileData::new());
         counter.deduct_gas(5, 10).expect("deduct_gas should work");
         assert_eq!(counter.burnt_gas(), 5);
         assert_eq!(counter.used_gas(), 10);
@@ -250,7 +250,7 @@ mod tests {
     #[should_panic]
     fn test_prepaid_gas_min() {
         let mut counter =
-            GasCounter::new(ExtCostsConfig::default(), 100, 10, false, ProfileData::new_disabled());
+            GasCounter::new(ExtCostsConfig::default(), 100, 10, false, ProfileData::new());
         counter.deduct_gas(10, 5).unwrap();
     }
 }

--- a/runtime/near-vm-runner-standalone/src/main.rs
+++ b/runtime/near-vm-runner-standalone/src/main.rs
@@ -161,11 +161,6 @@ fn main() {
                 .possible_values(&["wasmer", "wasmer1", "wasmtime"]),
         )
         .arg(
-            Arg::with_name("profile-gas")
-                .long("profile-gas")
-                .help("Profiles gas consumption.")
-        )
-        .arg(
             Arg::with_name("timings")
                 .long("timings")
                 .help("Prints execution times of various components.")
@@ -199,8 +194,6 @@ fn main() {
     if let Some(version) = matches.value_of("protocol-version") {
         script.protocol_version(version.parse().unwrap())
     }
-    let profile_gas = matches.is_present("profile-gas");
-    script.profile(profile_gas);
 
     if let Some(state_str) = matches.value_of("state") {
         script.initial_state(serde_json::from_str(state_str).unwrap());
@@ -251,8 +244,6 @@ fn main() {
         .unwrap()
     );
 
-    if profile_gas {
-        assert_eq!(all_gas, results.profile.all_gas());
-        println!("{:#?}", results.profile);
-    }
+    assert_eq!(all_gas, results.profile.all_gas());
+    println!("{:#?}", results.profile);
 }

--- a/runtime/near-vm-runner-standalone/src/script.rs
+++ b/runtime/near-vm-runner-standalone/src/script.rs
@@ -49,7 +49,7 @@ impl Default for Script {
             vm_kind: VMKind::default(),
             vm_config: VMConfig::default(),
             protocol_version: ProtocolVersion::MAX,
-            profile: ProfileData::new_disabled(),
+            profile: ProfileData::new(),
             contract_cache: None,
             initial_state: None,
             steps: Vec::new(),
@@ -86,10 +86,6 @@ impl Script {
 
     pub(crate) fn protocol_version(&mut self, protocol_version: ProtocolVersion) {
         self.protocol_version = protocol_version;
-    }
-
-    pub(crate) fn profile(&mut self, yes: bool) {
-        self.profile = if yes { ProfileData::new_enabled() } else { ProfileData::new_disabled() }
     }
 
     #[allow(unused)]

--- a/runtime/near-vm-runner/src/tests.rs
+++ b/runtime/near-vm-runner/src/tests.rs
@@ -81,7 +81,7 @@ fn make_simple_contract_call_with_gas_vm(
         vm_kind,
         LATEST_PROTOCOL_VERSION,
         None,
-        ProfileData::new_disabled(),
+        ProfileData::new(),
     )
 }
 
@@ -123,6 +123,6 @@ fn make_cached_contract_call_vm(
         vm_kind,
         LATEST_PROTOCOL_VERSION,
         Some(cache),
-        ProfileData::new_disabled(),
+        ProfileData::new(),
     )
 }

--- a/runtime/near-vm-runner/src/tests/contract_preload.rs
+++ b/runtime/near-vm-runner/src/tests/contract_preload.rs
@@ -105,7 +105,7 @@ fn test_vm_runner(preloaded: bool, vm_kind: VMKind, repeat: i32) {
         Some(Arc::new(MockCompiledContractCache::new(0)));
     let fees = RuntimeFeesConfig::default();
     let promise_results = vec![];
-    let profile_data = ProfileData::new_disabled();
+    let profile_data = ProfileData::new();
     let mut oks = 0;
     let mut errs = 0;
 

--- a/runtime/near-vm-runner/src/tests/rs_contract.rs
+++ b/runtime/near-vm-runner/src/tests/rs_contract.rs
@@ -71,7 +71,7 @@ pub fn test_read_write() {
             vm_kind.clone(),
             LATEST_PROTOCOL_VERSION,
             None,
-            ProfileData::new_disabled(),
+            ProfileData::new(),
         );
         assert_run_result(result, 0);
 
@@ -87,7 +87,7 @@ pub fn test_read_write() {
             vm_kind,
             LATEST_PROTOCOL_VERSION,
             None,
-            ProfileData::new_disabled(),
+            ProfileData::new(),
         );
         assert_run_result(result, 20);
     });
@@ -134,7 +134,7 @@ fn run_test_ext(
     let fees = RuntimeFeesConfig::default();
     let context = create_context(input.to_vec());
 
-    let profile = ProfileData::new_enabled();
+    let profile = ProfileData::new();
     let (outcome, err) = run_vm(
         &code,
         &method,
@@ -280,7 +280,7 @@ pub fn test_out_of_memory() {
             vm_kind,
             LATEST_PROTOCOL_VERSION,
             None,
-            ProfileData::new_disabled(),
+            ProfileData::new(),
         );
         assert_eq!(
             result.1,

--- a/runtime/near-vm-runner/src/tests/ts_contract.rs
+++ b/runtime/near-vm-runner/src/tests/ts_contract.rs
@@ -32,7 +32,7 @@ pub fn test_ts_contract() {
             vm_kind.clone(),
             LATEST_PROTOCOL_VERSION,
             None,
-            ProfileData::new_disabled(),
+            ProfileData::new(),
         );
         assert_eq!(
             result.1,
@@ -54,7 +54,7 @@ pub fn test_ts_contract() {
             vm_kind.clone(),
             LATEST_PROTOCOL_VERSION,
             None,
-            ProfileData::new_disabled(),
+            ProfileData::new(),
         )
         .0
         .unwrap();
@@ -80,7 +80,7 @@ pub fn test_ts_contract() {
             vm_kind,
             LATEST_PROTOCOL_VERSION,
             None,
-            ProfileData::new_disabled(),
+            ProfileData::new(),
         );
 
         if let ReturnData::Value(value) = result.0.unwrap().return_data {

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1556,7 +1556,7 @@ mod tests {
             is_new_chunk: true,
             #[cfg(feature = "protocol_feature_evm")]
             evm_chain_id: near_chain_configs::TESTNET_EVM_CHAIN_ID,
-            profile: ProfileData::new_enabled(),
+            profile: ProfileData::new(),
         };
 
         (runtime, tries, root, apply_state, signer, MockEpochInfoProvider::default())


### PR DESCRIPTION
Having costs breakdown (how much gas was spend for each operation type)
is helpful for both increasing reliability (as we can eyeball if the
costs "make sense") and developer friendliness (as devs can understand
where all the gas is going).

Currently this is hidden behind a feature flag, but I would love to
argue that we should just always enable it.

Performance cost seems to be negligible: we heap-allocate an array once
per apply state, and actual cost increasse are just counter increments,
they should be dwarfed by the host functions themselves.

Correctness-wise, the code is semi-sensitive. It is executed by runtime,
but doesn't affect the results. So it's enough if it doesn't panic.

# Test Plan

All of existing tests now exercise costs councting code. An additional unit-test is added to smoke-test that costs profiling can't panic due to overflow. 