### PR TITLE
fix some python tests

### DIFF
--- a/pytest/tests/sanity/skip_epoch.py
+++ b/pytest/tests/sanity/skip_epoch.py
@@ -22,10 +22,10 @@ near_root, node_dirs = init_cluster(
     4, 1, 4, config,
     [["min_gas_price", 0], ["max_inflation_rate", [0, 1]], ["epoch_length", 12],
      ["block_producer_kickout_threshold", 20], ["chunk_producer_kickout_threshold", 20]],
-    {0: {"view_client_throttle_period": {"secs": 0, "nanos": 0}},
-     1: {"view_client_throttle_period": {"secs": 0, "nanos": 0}},
-     2: {"view_client_throttle_period": {"secs": 0, "nanos": 0}},
-     3: {"view_client_throttle_period": {"secs": 0, "nanos": 0}}, 4: {
+    {0: {"view_client_throttle_period": {"secs": 0, "nanos": 0}, "consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}}},
+     1: {"view_client_throttle_period": {"secs": 0, "nanos": 0}, "consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}}},
+     2: {"view_client_throttle_period": {"secs": 0, "nanos": 0}, "consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}}},
+     3: {"view_client_throttle_period": {"secs": 0, "nanos": 0}, "consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}}}, 4: {
         "tracked_shards": [0, 1, 2, 3],
         "view_client_throttle_period": {"secs": 0, "nanos": 0}
     }})
@@ -40,7 +40,7 @@ node4 = spin_up_node(config, near_root, node_dirs[3], 3, boot_node.node_key.pk,
 observer = spin_up_node(config, near_root, node_dirs[4], 4,
                         boot_node.node_key.pk, boot_node.addr())
 
-ctx = TxContext([0, 0, 0, 0, 0], [boot_node, None, node3, node4, observer])
+ctx = TxContext([4, 4, 4, 4, 4], [boot_node, None, node3, node4, observer])
 initial_balances = ctx.get_balances()
 total_supply = sum(initial_balances)
 
@@ -73,6 +73,8 @@ while True:
 
     time.sleep(0.1)
 
+print("stage 1 done")
+
 # 2. Spin up the second node and make sure it gets to 35 as well, and doesn't diverge
 node2 = spin_up_node(config, near_root, node_dirs[1], 1, boot_node.node_key.pk,
                      boot_node.addr())
@@ -103,6 +105,8 @@ while True:
 
     time.sleep(0.1)
 
+print("stage 2 done")
+
 # 3. During (1) we sent some txs. Make sure the state changed. We can't compare to the
 #    expected balances directly, since the tx sent to the shard that node1 is responsible
 #    for was never applied, but we can make sure that some change to the state was done,
@@ -117,6 +121,8 @@ assert (balances != initial_balances)
 assert (sum(balances) == total_supply)
 
 initial_balances = balances
+
+print("stage 3 done")
 
 # 4. Stake for the second node to bring it back up as a validator and wait until it actually
 #    becomes one
@@ -147,13 +153,15 @@ while True:
 
     time.sleep(1)
 
+print("stage 4 done")
+
 ctx.next_nonce = 100
 # 5. Record the latest height and bring down the first node, wait for couple epochs to pass
 status = node2.get_status()
 last_height = status['sync_info']['latest_block_height']
 
 ctx.nodes = [boot_node, node2, node3, node4, observer]
-ctx.act_to_val = [1, 1, 1, 1, 1]
+ctx.act_to_val = [4, 4, 4, 4, 4]
 
 boot_node.kill()
 seen_boot_heights = set()
@@ -182,6 +190,7 @@ balances = ctx.get_balances()
 print("New balances: %s\nNew total supply: %s" % (balances, sum(balances)))
 
 ctx.nodes = [observer, node2]
+ctx.act_to_val = [0, 0, 0, 0, 0]
 print("Observer sees: %s" % ctx.get_balances())
 
 assert (balances != initial_balances)

--- a/pytest/tests/sanity/state_sync.py
+++ b/pytest/tests/sanity/state_sync.py
@@ -30,9 +30,11 @@ config = load_config()
 near_root, node_dirs = init_cluster(
     2, 1, 1, config,
     [["min_gas_price", 0], ["max_inflation_rate", [0, 1]], ["epoch_length", 10],
-     ["block_producer_kickout_threshold", 80]], {2: {
-         "tracked_shards": [0]
-     }})
+     ["block_producer_kickout_threshold", 80]], {
+        0: {"tracked_shards": [0]},
+        1: {"tracked_shards": [0]},
+        2: {"tracked_shards": [0]}
+    })
 
 started = time.time()
 


### PR DESCRIPTION
Fix python tests failure caused by rpc routing removal and wrong state sync timeout configuration.

Test plan
---------
http://nayduck.eastus.cloudapp.azure.com:3000/#/run/1464