### PR TITLE
Add config option for gas profiling

### DIFF
--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -847,10 +847,7 @@ impl RuntimeAdapter for KeyValueRuntime {
                 block_hash: *block_hash,
             }),
             QueryRequest::CallFunction { .. } => Ok(QueryResponse {
-                kind: QueryResponseKind::CallResult(CallResult {
-                    result: Default::default(),
-                    logs: Default::default(),
-                }),
+                kind: QueryResponseKind::CallResult(CallResult::default()),
                 block_height,
                 block_hash: *block_hash,
             }),

--- a/core/primitives-core/Cargo.toml
+++ b/core/primitives-core/Cargo.toml
@@ -24,7 +24,6 @@ lazy_static = "1.4"
 
 [features]
 default = []
-costs_counting = []
 protocol_feature_add_account_versions = []
 protocol_feature_evm = []
 protocol_feature_alt_bn128 = []

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -3,6 +3,7 @@
 //! These types should only change when we cannot avoid this. Thus, when the counterpart internal
 //! type gets changed, the view should preserve the old shape and only re-map the necessary bits
 //! from the source structure in the relevant `From<SourceStruct>` impl.
+use std::collections::BTreeMap;
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
 use std::sync::Arc;
@@ -219,6 +220,16 @@ pub struct ViewStateResult {
 pub struct CallResult {
     pub result: Vec<u8>,
     pub logs: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile: Option<CallProfile>,
+}
+
+#[derive(
+    BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default,
+)]
+#[serde(transparent)]
+pub struct CallProfile {
+    pub map: BTreeMap<String, u64>,
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -23,7 +23,7 @@ use near_primitives::types::{AccountId, Balance, EpochId, ShardId, StateChangeCa
 use near_store::{
     create_store, get_account, set_access_key, set_account, set_code, ColState, Store, TrieUpdate,
 };
-use neard::{get_store_path, NightshadeRuntime};
+use neard::{get_store_path, NightshadeRuntime, TrieViewer};
 
 fn get_account_id(account_index: u64) -> String {
     format!("near_{}_{}", account_index, account_index)
@@ -59,6 +59,7 @@ impl GenesisBuilder {
     ) -> Self {
         let tmpdir = tempfile::Builder::new().prefix("storage").tempdir().unwrap();
         let runtime = NightshadeRuntime::new(
+            TrieViewer::new_with_state_size_limit(None),
             tmpdir.path(),
             store.clone(),
             &genesis,
@@ -66,7 +67,6 @@ impl GenesisBuilder {
             // there is no reason to track accounts or shards.
             vec![],
             vec![],
-            None,
         );
         Self {
             home_dir: home_dir.to_path_buf(),

--- a/neard/src/config.rs
+++ b/neard/src/config.rs
@@ -568,6 +568,7 @@ pub struct NearConfig {
     pub telemetry_config: TelemetryConfig,
     pub genesis: Genesis,
     pub validator_signer: Option<Arc<dyn ValidatorSigner>>,
+    pub enable_gas_profiling: bool,
 }
 
 impl NearConfig {
@@ -673,6 +674,7 @@ impl NearConfig {
             rosetta_rpc_config: config.rosetta_rpc,
             genesis,
             validator_signer,
+            enable_gas_profiling: true,
         }
     }
 }

--- a/neard/src/lib.rs
+++ b/neard/src/lib.rs
@@ -40,6 +40,8 @@ mod migrations;
 mod runtime;
 mod shard_tracker;
 
+pub use node_runtime::state_viewer::TrieViewer;
+
 const STORE_PATH: &str = "data";
 
 pub fn store_path_exists<P: AsRef<Path>>(path: P) -> bool {
@@ -253,12 +255,12 @@ pub fn start_with_config(
     let store = init_and_migrate_store(home_dir, &config);
 
     let runtime = Arc::new(NightshadeRuntime::new(
+        TrieViewer::new_with_state_size_limit(config.client_config.trie_viewer_state_size_limit),
         home_dir,
         Arc::clone(&store),
         &config.genesis,
         config.client_config.tracked_accounts.clone(),
         config.client_config.tracked_shards.clone(),
-        config.client_config.trie_viewer_state_size_limit,
     ));
 
     let telemetry = TelemetryActor::new(config.telemetry_config.clone()).start();

--- a/neard/src/lib.rs
+++ b/neard/src/lib.rs
@@ -254,8 +254,11 @@ pub fn start_with_config(
 ) -> (Addr<ClientActor>, Addr<ViewClientActor>, Vec<ArbiterHandle>) {
     let store = init_and_migrate_store(home_dir, &config);
 
+    let mut trie_viewer =
+        TrieViewer::new_with_state_size_limit(config.client_config.trie_viewer_state_size_limit);
+    trie_viewer.enable_gas_profiling = config.enable_gas_profiling;
     let runtime = Arc::new(NightshadeRuntime::new(
-        TrieViewer::new_with_state_size_limit(config.client_config.trie_viewer_state_size_limit),
+        trie_viewer,
         home_dir,
         Arc::clone(&store),
         &config.genesis,

--- a/neard/src/migrations.rs
+++ b/neard/src/migrations.rs
@@ -10,6 +10,7 @@ use near_primitives::transaction::ExecutionOutcomeWithIdAndProof;
 use near_primitives::types::{BlockHeight, ShardId};
 use near_store::migrations::set_store_version;
 use near_store::{create_store, db::GENESIS_JSON_HASH_KEY, DBCol, StoreUpdate};
+use node_runtime::state_viewer::TrieViewer;
 use std::path::Path;
 
 fn get_chunk(chain_store: &ChainStore, chunk_hash: ChunkHash) -> ShardChunkV1 {
@@ -93,12 +94,12 @@ pub fn migrate_12_to_13(path: &String, near_config: &NearConfig) {
         let mut chain_store = ChainStore::new(store.clone(), genesis_height);
         let head = chain_store.head().expect("head must exist");
         let runtime = NightshadeRuntime::new(
+            TrieViewer::new_with_state_size_limit(None),
             &Path::new(path),
             store.clone(),
             &near_config.genesis,
             near_config.client_config.tracked_accounts.clone(),
             near_config.client_config.tracked_shards.clone(),
-            None,
         );
         let mut store_update = store.store_update();
         store_update.delete_all(DBCol::ColTransactionResult);
@@ -202,12 +203,12 @@ pub fn migrate_19_to_20(path: &String, near_config: &NearConfig) {
         let mut chain_store = ChainStore::new(store.clone(), genesis_height);
         let head = chain_store.head().unwrap();
         let runtime = NightshadeRuntime::new(
+            TrieViewer::new_with_state_size_limit(None),
             &Path::new(path),
             store.clone(),
             &near_config.genesis,
             near_config.client_config.tracked_accounts.clone(),
             near_config.client_config.tracked_shards.clone(),
-            None,
         );
         let shard_id = 0;
         // This is hardcoded for mainnet specifically. Blocks with lower heights have been checked.

--- a/neard/src/runtime/mod.rs
+++ b/neard/src/runtime/mod.rs
@@ -134,15 +134,14 @@ pub struct NightshadeRuntime {
 
 impl NightshadeRuntime {
     pub fn new(
+        trie_viewer: TrieViewer,
         home_dir: &Path,
         store: Arc<Store>,
         genesis: &Genesis,
         initial_tracking_accounts: Vec<AccountId>,
         initial_tracking_shards: Vec<ShardId>,
-        trie_viewer_state_size_limit: Option<u64>,
     ) -> Self {
         let runtime = Runtime::new();
-        let trie_viewer = TrieViewer::new_with_state_size_limit(trie_viewer_state_size_limit);
         let genesis_config = genesis.config.clone();
         let genesis_runtime_config = Arc::new(genesis_config.runtime_config.clone());
         let num_shards = genesis.config.num_block_producer_seats_per_shard.len() as NumShards;
@@ -1726,12 +1725,12 @@ mod test {
             let genesis_total_supply = genesis.config.total_supply;
             let genesis_protocol_version = genesis.config.protocol_version;
             let runtime = NightshadeRuntime::new(
+                TrieViewer::new_with_state_size_limit(None),
                 dir.path(),
                 store,
                 &genesis,
                 initial_tracked_accounts,
                 initial_tracked_shards,
-                None,
             );
             let (_store, state_roots) = runtime.genesis_state();
             let genesis_hash = hash(&vec![0]);

--- a/neard/tests/economics.rs
+++ b/neard/tests/economics.rs
@@ -11,7 +11,7 @@ use near_crypto::{InMemorySigner, KeyType};
 use near_logger_utils::init_integration_logger;
 use near_primitives::transaction::SignedTransaction;
 use near_store::test_utils::create_test_store;
-use neard::config::GenesisExt;
+use neard::{config::GenesisExt,};
 use testlib::fees_utils::FeeHelper;
 
 #[cfg(feature = "protocol_feature_rectify_inflation")]
@@ -27,12 +27,12 @@ fn setup_env(f: &mut dyn FnMut(&mut Genesis) -> ()) -> (TestEnv, FeeHelper) {
         genesis.config.min_gas_price,
     );
     let runtimes: Vec<Arc<dyn RuntimeAdapter>> = vec![Arc::new(neard::NightshadeRuntime::new(
+        neard::TrieViewer::new_with_state_size_limit(None),
         Path::new("."),
         store1,
         &genesis,
         vec![],
         vec![],
-        None,
     ))];
     let env = TestEnv::new_with_runtime(ChainGenesis::from(&genesis), 1, 1, runtimes);
     (env, fee_helper)

--- a/runtime/near-vm-logic/Cargo.toml
+++ b/runtime/near-vm-logic/Cargo.toml
@@ -42,7 +42,7 @@ wasmtime_default = []
 wasmer1_default = []
 
 # Use this feature to enable counting of fees and costs applied.
-costs_counting = ["near-primitives-core/costs_counting"]
+costs_counting = []
 
 [[test]]
 name = "test_storage_read_write"

--- a/runtime/runtime/src/adapter.rs
+++ b/runtime/runtime/src/adapter.rs
@@ -2,6 +2,7 @@ use near_crypto::PublicKey;
 use near_primitives::account::{AccessKey, Account};
 use near_primitives::contract::ContractCode;
 use near_primitives::hash::CryptoHash;
+use near_primitives::profile::ProfileData;
 use near_primitives::types::{
     AccountId, BlockHeight, EpochHeight, EpochId, EpochInfoProvider, MerkleHash, ShardId,
 };
@@ -41,6 +42,7 @@ pub trait ViewRuntimeAdapter {
         epoch_info_provider: &dyn EpochInfoProvider,
         current_protocol_version: ProtocolVersion,
         #[cfg(feature = "protocol_feature_evm")] evm_chain_id: u64,
+        profile_data: ProfileData,
     ) -> Result<Vec<u8>, crate::state_viewer::errors::CallFunctionError>;
 
     fn view_access_key(

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -25,11 +25,12 @@ pub mod errors;
 pub struct TrieViewer {
     /// Upper bound of the byte size of contract state that is still viewable. None is no limit
     state_size_limit: Option<u64>,
+    enable_gas_profiling: bool,
 }
 
 impl TrieViewer {
     pub fn new_with_state_size_limit(state_size_limit: Option<u64>) -> Self {
-        Self { state_size_limit }
+        Self { state_size_limit, enable_gas_profiling: false }
     }
 
     pub fn view_account(

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -5,6 +5,7 @@ use near_primitives::{
     borsh::BorshDeserialize,
     contract::ContractCode,
     hash::CryptoHash,
+    profile::ProfileData,
     receipt::ActionReceipt,
     runtime::{apply_state::ApplyState, config::RuntimeConfig},
     serialize::to_base64,
@@ -25,14 +26,13 @@ pub mod errors;
 pub struct TrieViewer {
     /// Upper bound of the byte size of contract state that is still viewable. None is no limit
     state_size_limit: Option<u64>,
-    enable_gas_profiling: bool,
+    pub enable_gas_profiling: bool,
 }
 
 impl TrieViewer {
     pub fn new_with_state_size_limit(state_size_limit: Option<u64>) -> Self {
         Self { state_size_limit, enable_gas_profiling: false }
     }
-
     pub fn view_account(
         &self,
         state_update: &TrieUpdate,
@@ -177,6 +177,7 @@ impl TrieViewer {
         args: &[u8],
         logs: &mut Vec<String>,
         epoch_info_provider: &dyn EpochInfoProvider,
+        profile_data: ProfileData,
     ) -> Result<Vec<u8>, errors::CallFunctionError> {
         let now = Instant::now();
         if !is_valid_account_id(contract_id) {
@@ -225,7 +226,7 @@ impl TrieViewer {
             is_new_chunk: false,
             #[cfg(feature = "protocol_feature_evm")]
             evm_chain_id: view_state.evm_chain_id,
-            profile: Default::default(),
+            profile: profile_data,
         };
         let action_receipt = ActionReceipt {
             signer_id: originator_id.clone(),

--- a/test-utils/state-viewer/src/main.rs
+++ b/test-utils/state-viewer/src/main.rs
@@ -24,7 +24,9 @@ use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{BlockHeight, ShardId, StateRoot};
 use near_store::test_utils::create_test_store;
 use near_store::{create_store, Store, TrieIterator};
-use neard::{get_default_home, get_store_path, load_config, NearConfig, NightshadeRuntime};
+use neard::{
+    get_default_home, get_store_path, load_config, NearConfig, NightshadeRuntime, TrieViewer,
+};
 use node_runtime::adapter::ViewRuntimeAdapter;
 use state_dump::state_dump;
 
@@ -57,12 +59,12 @@ fn load_trie_stop_at_height(
     let mut chain_store = ChainStore::new(store.clone(), near_config.genesis.config.genesis_height);
 
     let runtime = NightshadeRuntime::new(
+        TrieViewer::new_with_state_size_limit(None),
         &home_dir,
         store,
         &near_config.genesis,
         near_config.client_config.tracked_accounts.clone(),
         near_config.client_config.tracked_shards.clone(),
-        None,
     );
     let head = chain_store.head().unwrap();
     let last_block = match mode {
@@ -114,12 +116,12 @@ fn print_chain(
 ) {
     let mut chain_store = ChainStore::new(store.clone(), near_config.genesis.config.genesis_height);
     let runtime = NightshadeRuntime::new(
+        TrieViewer::new_with_state_size_limit(None),
         &home_dir,
         store,
         &near_config.genesis,
         near_config.client_config.tracked_accounts.clone(),
         near_config.client_config.tracked_shards.clone(),
-        None,
     );
     let mut account_id_to_blocks = HashMap::new();
     let mut cur_epoch_id = None;
@@ -184,12 +186,12 @@ fn replay_chain(
     let mut chain_store = ChainStore::new(store, near_config.genesis.config.genesis_height);
     let new_store = create_test_store();
     let runtime = NightshadeRuntime::new(
+        TrieViewer::new_with_state_size_limit(None),
         &home_dir,
         new_store,
         &near_config.genesis,
         near_config.client_config.tracked_accounts.clone(),
         near_config.client_config.tracked_shards.clone(),
-        None,
     );
     for height in start_height..=end_height {
         if let Ok(block_hash) = chain_store.get_block_hash_by_height(height) {
@@ -215,12 +217,12 @@ fn apply_block_at_height(
 ) {
     let mut chain_store = ChainStore::new(store.clone(), near_config.genesis.config.genesis_height);
     let runtime = NightshadeRuntime::new(
+        TrieViewer::new_with_state_size_limit(None),
         &home_dir,
         store,
         &near_config.genesis,
         near_config.client_config.tracked_accounts.clone(),
         near_config.client_config.tracked_shards.clone(),
-        None,
     );
     let block_hash = chain_store.get_block_hash_by_height(height).unwrap();
     let block = chain_store.get_block(&block_hash).unwrap().clone();

--- a/test-utils/state-viewer/src/state_dump.rs
+++ b/test-utils/state-viewer/src/state_dump.rs
@@ -77,6 +77,7 @@ mod test {
     use near_primitives::transaction::SignedTransaction;
     use near_primitives::types::NumBlocks;
     use near_store::test_utils::create_test_store;
+    use node_runtime::state_viewer::TrieViewer;
     use near_store::Store;
     use neard::config::GenesisExt;
     use neard::config::TESTING_INIT_STAKE;
@@ -92,7 +93,7 @@ mod test {
         genesis.config.epoch_length = epoch_length;
         let store = create_test_store();
         let nightshade_runtime =
-            NightshadeRuntime::new(Path::new("."), store.clone(), &genesis, vec![], vec![], None);
+            NightshadeRuntime::new(TrieViewer::new_with_state_size_limit(None), Path::new("."), store.clone(), &genesis, vec![], vec![]);
         let runtimes: Vec<Arc<dyn RuntimeAdapter>> = vec![Arc::new(nightshade_runtime)];
         let mut chain_genesis = ChainGenesis::test();
         chain_genesis.epoch_length = epoch_length;
@@ -134,7 +135,7 @@ mod test {
         let last_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap().clone();
         let state_roots = last_block.chunks().iter().map(|chunk| chunk.prev_state_root()).collect();
         let runtime =
-            NightshadeRuntime::new(Path::new("."), store.clone(), &genesis, vec![], vec![], None);
+            NightshadeRuntime::new(TrieViewer::new_with_state_size_limit(None), Path::new("."), store.clone(), &genesis, vec![], vec![]);
         let new_genesis =
             state_dump(runtime, state_roots, last_block.header().clone(), &genesis.config);
         assert_eq!(new_genesis.config.validators.len(), 2);
@@ -164,7 +165,7 @@ mod test {
         let last_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap().clone();
         let state_roots = last_block.chunks().iter().map(|chunk| chunk.prev_state_root()).collect();
         let runtime =
-            NightshadeRuntime::new(Path::new("."), store.clone(), &genesis, vec![], vec![], None);
+            NightshadeRuntime::new(TrieViewer::new_with_state_size_limit(None), Path::new("."), store.clone(), &genesis, vec![], vec![]);
         let new_genesis =
             state_dump(runtime, state_roots, last_block.header().clone(), &genesis.config);
         assert_eq!(
@@ -192,7 +193,7 @@ mod test {
         let store1 = create_test_store();
         let store2 = create_test_store();
         let create_runtime = |store| -> NightshadeRuntime {
-            NightshadeRuntime::new(Path::new("."), store, &genesis, vec![], vec![], None)
+            NightshadeRuntime::new(TrieViewer::new_with_state_size_limit(None), Path::new("."), store, &genesis, vec![], vec![])
         };
         let runtimes: Vec<Arc<dyn RuntimeAdapter>> = vec![
             Arc::new(create_runtime(store1.clone())),
@@ -241,7 +242,7 @@ mod test {
         genesis.config.epoch_length = epoch_length;
         let store = create_test_store();
         let nightshade_runtime =
-            NightshadeRuntime::new(Path::new("."), store.clone(), &genesis, vec![], vec![], None);
+            NightshadeRuntime::new(TrieViewer::new_with_state_size_limit(None), Path::new("."), store.clone(), &genesis, vec![], vec![]);
         let runtimes: Vec<Arc<dyn RuntimeAdapter>> = vec![Arc::new(nightshade_runtime)];
         let mut chain_genesis = ChainGenesis::test();
         chain_genesis.epoch_length = epoch_length;
@@ -274,7 +275,7 @@ mod test {
         let last_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap().clone();
         let state_roots = last_block.chunks().iter().map(|chunk| chunk.prev_state_root()).collect();
         let runtime =
-            NightshadeRuntime::new(Path::new("."), store.clone(), &genesis, vec![], vec![], None);
+            NightshadeRuntime::new(TrieViewer::new_with_state_size_limit(None), Path::new("."), store.clone(), &genesis, vec![], vec![]);
         let new_genesis =
             state_dump(runtime, state_roots, last_block.header().clone(), &genesis.config);
         assert_eq!(new_genesis.config.validators.len(), 2);

--- a/test-utils/store-validator/src/main.rs
+++ b/test-utils/store-validator/src/main.rs
@@ -32,12 +32,12 @@ fn main() {
     let store = create_store(&get_store_path(&home_dir));
 
     let runtime_adapter: Arc<dyn RuntimeAdapter> = Arc::new(neard::NightshadeRuntime::new(
+        neard::TrieViewer::new_with_state_size_limit(None),
         &home_dir,
         store.clone(),
         &near_config.genesis,
         near_config.client_config.tracked_accounts.clone(),
         near_config.client_config.tracked_shards.clone(),
-        None,
     ));
 
     let mut store_validator = StoreValidator::new(

--- a/test-utils/testlib/src/lib.rs
+++ b/test-utils/testlib/src/lib.rs
@@ -13,7 +13,9 @@ use near_primitives::block::{Block, BlockHeader};
 use near_primitives::hash::CryptoHash;
 use near_primitives::types::{BlockHeight, BlockHeightDelta, NumSeats, NumShards, ShardId};
 use near_store::test_utils::create_test_store;
-use neard::{config::GenesisExt, load_test_config, start_with_config, NightshadeRuntime};
+use neard::{
+    config::GenesisExt, load_test_config, start_with_config, NightshadeRuntime, TrieViewer,
+};
 
 pub mod fees_utils;
 pub mod node;
@@ -34,8 +36,14 @@ pub fn genesis_header(genesis: &Genesis) -> BlockHeader {
     let dir = tempdir().unwrap();
     let store = create_test_store();
     let chain_genesis = ChainGenesis::from(genesis);
-    let runtime =
-        Arc::new(NightshadeRuntime::new(dir.path(), store, genesis, vec![], vec![], None));
+    let runtime = Arc::new(NightshadeRuntime::new(
+        TrieViewer::new_with_state_size_limit(None),
+        dir.path(),
+        store,
+        genesis,
+        vec![],
+        vec![],
+    ));
     let chain = Chain::new(runtime, &chain_genesis, DoomslugThresholdMode::TwoThirds).unwrap();
     chain.genesis().clone()
 }
@@ -45,8 +53,14 @@ pub fn genesis_block(genesis: &Genesis) -> Block {
     let dir = tempdir().unwrap();
     let store = create_test_store();
     let chain_genesis = ChainGenesis::from(genesis);
-    let runtime =
-        Arc::new(NightshadeRuntime::new(dir.path(), store, genesis, vec![], vec![], None));
+    let runtime = Arc::new(NightshadeRuntime::new(
+        TrieViewer::new_with_state_size_limit(None),
+        dir.path(),
+        store,
+        genesis,
+        vec![],
+        vec![],
+    ));
     let mut chain = Chain::new(runtime, &chain_genesis, DoomslugThresholdMode::TwoThirds).unwrap();
     chain.get_block(&chain.genesis().hash().clone()).unwrap().clone()
 }

--- a/test-utils/testlib/src/user/runtime_user.rs
+++ b/test-utils/testlib/src/user/runtime_user.rs
@@ -6,6 +6,7 @@ use near_crypto::{PublicKey, Signer};
 use near_jsonrpc_primitives::errors::ServerError;
 use near_primitives::errors::{RuntimeError, TxExecutionError};
 use near_primitives::hash::CryptoHash;
+use near_primitives::profile::ProfileData;
 use near_primitives::receipt::Receipt;
 use near_primitives::runtime::config::RuntimeConfig;
 use near_primitives::test_utils::MockEpochInfoProvider;
@@ -261,6 +262,7 @@ impl User for RuntimeUser {
                 args,
                 &mut result.logs,
                 &self.epoch_info_provider,
+                ProfileData::default(),
             )
             .map_err(|err| err.to_string())?;
         Ok(result)


### PR DESCRIPTION
This is an alternative version to #4185, which enables profiling via config flag.

This is not finished, but I am feeling like I am hopelessly bogged down in the weeds, so I am opening this PR to ask question mostly. 

What happens here is:

* remove compile-time flag for ProfileData
* cleanup it's interface somewhat (in particular, `ProfileData::non_zero_costs` is what we want to ship to users)
* add `gas_profiling` config and thread it to TrieViewer
* expose profile data for the **view** RPC calls

Questions I need help with, in order of priority:

* how do I expose this for non-view calls? Should I store profile data in the database (together with other outcome records)? Should we add a dedicated `replay` call, which works like view, but can reply things (without modifying the state)?
* what's our final strategy for enabling this functionalitty? Do we enable it by default, or do we have a runtime flag? 
* If we add a runtime flag, where it should be stored? at the moment it's a field of TrieViewer, but I don't feel like that's neccessary the right thing to do
* what's the best way to check that this works? The PR description doesn't mention TestPlan because I don't know what's the best place to test this functionality. 