### PR TITLE
fix: wasmer1_default feature actually selects wasmer1

### DIFF
--- a/runtime/near-vm-logic/Cargo.toml
+++ b/runtime/near-vm-logic/Cargo.toml
@@ -37,10 +37,6 @@ protocol_feature_evm = ["near-primitives-core/protocol_feature_evm"]
 protocol_feature_alt_bn128 = ["bn", "near-primitives-core/protocol_feature_alt_bn128", "near-vm-errors/protocol_feature_alt_bn128"]
 protocol_feature_allow_create_account_on_delete = []
 
-wasmer0_default = []
-wasmtime_default = []
-wasmer1_default = []
-
 # Use this feature to enable counting of fees and costs applied.
 costs_counting = ["near-primitives-core/costs_counting"]
 

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -49,6 +49,11 @@ default = ["wasmer0_vm", "wasmtime_vm", "wasmer1_vm"]
 wasmer0_vm = [ "wasmer-runtime" ]
 wasmtime_vm = [ "wasmtime", "anyhow"]
 wasmer1_vm = [ "wasmer", "wasmer-types", "wasmer-compiler-singlepass",  "wasmer-compiler-cranelift", "wasmer-engine-native", ]
+
+wasmer0_default = []
+wasmtime_default = []
+wasmer1_default = []
+
 lightbeam = ["wasmtime/lightbeam"]
 no_cpu_compatibility_checks = []
 protocol_feature_evm = ["near-primitives/protocol_feature_evm", "near-evm-runner/protocol_feature_evm"]

--- a/runtime/runtime-params-estimator/Cargo.toml
+++ b/runtime/runtime-params-estimator/Cargo.toml
@@ -51,7 +51,7 @@ costs_counting = ["near-vm-logic/costs_counting"]
 # Required feature for proper config, but can't be enabled by default because it is leaked to other release crates.
 required = ["costs_counting", "near-vm-runner/no_cpu_compatibility_checks", "no_cache"]
 no_cache = ["node-runtime/no_cache", "near-store/no_cache"]
-wasmtime = ["near-vm-logic/wasmtime_default"]
+wasmtime = ["near-vm-runner/wasmtime_default"]
 lightbeam = ["wasmtime", "near-vm-runner/lightbeam"]
 nightly_protocol = ["near-primitives/nightly_protocol"]
 nightly_protocol_features = ["protocol_feature_alt_bn128", "protocol_feature_evm"]

--- a/runtime/runtime/Cargo.toml
+++ b/runtime/runtime/Cargo.toml
@@ -37,9 +37,9 @@ protocol_feature_evm = ["near-evm-runner/protocol_feature_evm", "near-primitives
 wasmer1_vm = ["near-vm-runner/wasmer1_vm"]
 wasmer0_vm = ["near-vm-runner/wasmer0_vm"]
 wasmtime_vm = ["near-vm-runner/wasmtime_vm"]
-wasmer1_default = ["wasmer1_vm", "near-vm-logic/wasmer1_default"]
-wasmer0_default = ["wasmer0_vm", "near-vm-logic/wasmer0_default"]
-wasmtime_default = ["wasmtime_vm", "near-vm-logic/wasmtime_default"]
+wasmer1_default = ["wasmer1_vm", "near-vm-runner/wasmer1_default"]
+wasmer0_default = ["wasmer0_vm", "near-vm-runner/wasmer0_default"]
+wasmtime_default = ["wasmtime_vm", "near-vm-runner/wasmtime_default"]
 
 no_cpu_compatibility_checks = [ "near-vm-runner/no_cpu_compatibility_checks"]
 


### PR DESCRIPTION
We use this feature in ./runtime/near-vm-runner/src/vm_kind.rs.

So, it should be declared in `vm_runner` Cargo.toml rather than in
`vm_logic`.