### PR TITLE
fix: disable threading on wasmer 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6264,15 +6264,13 @@ dependencies = [
 [[package]]
 name = "wasmer-compiler-singlepass"
 version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "426ae6ef0f606ca815510f3e2ef6f520e217514bfb7a664defe180b9a9e75d07"
+source = "git+https://github.com/near/wasmer?branch=1.0.2-single-threaded#a98937b4e9e149e4a7773689313b7e43800f6eb9"
 dependencies = [
  "byteorder",
  "dynasm",
  "dynasmrt",
  "lazy_static",
  "more-asserts",
- "rayon",
  "serde",
  "smallvec",
  "wasmer-compiler",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,10 @@ testlib = { path = "./test-utils/testlib" }
 
 [patch.crates-io]
 ethereum-types = { path = "./patches/ethereum-types-0.10.0-to-0.11.0" }
+# Temporary wasmer fork which disables rayon (parallel compilation)
+# https://github.com/wasmerio/wasmer/pull/2262
+# Revome this when the new version of wasmer is published.
+wasmer-compiler-singlepass = { git = "https://github.com/near/wasmer", branch = "1.0.2-single-threaded"}
 
 [profile.release]
 lto = true        # Enable full link-time optimization.

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -20,7 +20,7 @@ wasmer-runtime = { version="0.17.1", features = ["default-backend-singlepass"], 
 wasmer-runtime-core = {version = "0.17.1", package = "wasmer-runtime-core-near" }
 wasmer = { version = "1.0.2", optional = true }
 wasmer-types = { version = "1.0.2", optional = true }
-wasmer-compiler-singlepass = { version = "1.0.2", optional = true }
+wasmer-compiler-singlepass = { version = "1.0.2", optional = true, default-features = false, features = ["std", "enable-serde"] } # disable `rayon` feature.
 wasmer-compiler-cranelift = { version = "1.0.2", optional = true }
 wasmer-engine-native = { version = "1.0.2", optional = true }
 wasmer-vm = { version = "1.0.2" }


### PR DESCRIPTION
Wasmer 1 uses rayon for parallel execution, which we don't want to use.
We've upstreammed the patch making rayon support optional, but it is not
yet released. So let's use our fork at the moment, which patches the
existing 1.0.2 release we use.