### PR TITLE
fix: test_consensus_with_epoch_switches

### DIFF
--- a/chain/client/tests/consensus.rs
+++ b/chain/client/tests/consensus.rs
@@ -276,9 +276,9 @@ mod tests {
             );
             *connectors.write().unwrap() = conn;
 
-            // We only check the terminating condition once every 20 heights, thus extra 20 to
+            // We only check the terminating condition once every 20 heights, thus extra 80 to
             // account for possibly going beyond the HEIGHT_GOAL.
-            near_network::test_utils::wait_or_panic(3000 * (20 + HEIGHT_GOAL));
+            near_network::test_utils::wait_or_panic(3000 * (80 + HEIGHT_GOAL));
         });
     }
 }


### PR DESCRIPTION
Fix `test_consensus_with_epoch_switches by increasing timeout.

Test plan
---------
http://nayduck.eastus.cloudapp.azure.com:3000/#/run/1622