### PR TITLE
Fix protocol upgrade for non-mainnet chains

### DIFF
--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -2904,7 +2904,6 @@ mod access_key_nonce_range_tests {
 #[cfg(test)]
 mod protocol_feature_restore_receipts_after_fix_tests {
     use super::*;
-    use near_primitives::receipt::Receipt;
     use near_primitives::runtime::migration_data::MigrationData;
     use near_primitives::version::ProtocolFeature;
 

--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -2906,20 +2906,22 @@ mod protocol_feature_restore_receipts_after_fix_tests {
     use super::*;
     use near_primitives::runtime::migration_data::MigrationData;
     use near_primitives::version::ProtocolFeature;
+    use near_primitives::receipt::Receipt;
 
     const EPOCH_LENGTH: u64 = 5;
     const HEIGHT_TIMEOUT: u64 = 10;
 
     fn run_test(
+        chain_id: &str,
         low_height_with_no_chunk: BlockHeight,
         high_height_with_no_chunk: BlockHeight,
-        should_pass: bool,
+        should_be_restored: bool,
     ) {
         init_test_logger();
 
         let protocol_version = ProtocolFeature::RestoreReceiptsAfterFix.protocol_version() - 1;
         let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
-        genesis.config.chain_id = String::from("mainnet");
+        genesis.config.chain_id = String::from(chain_id);
         genesis.config.epoch_length = EPOCH_LENGTH;
         genesis.config.protocol_version = protocol_version;
         let chain_genesis = ChainGenesis::from(&genesis);
@@ -2946,8 +2948,8 @@ mod protocol_feature_restore_receipts_after_fix_tests {
                 migration_data
                     .restored_receipts
                     .get(&0u64)
-                    .expect("Receipts to restore must contain an entry for shard 0")
-                    .clone()
+                    .cloned()
+                    .unwrap_or_default()
                     .iter()
                     .map(|receipt| receipt.receipt_id),
             )
@@ -2957,9 +2959,11 @@ mod protocol_feature_restore_receipts_after_fix_tests {
         let mut height: BlockHeight = 1;
         let mut last_update_height: BlockHeight = 0;
 
-        // If some receipts are still not applied, upgrade already happened, and no new receipt was
-        // applied in some last blocks, consider the process stuck to avoid any possibility of infinite loop.
-        while !receipt_hashes_to_restore.is_empty() && height - last_update_height < HEIGHT_TIMEOUT
+        // Simulate several blocks to guarantee that they are produced successfully.
+        // Stop block production if all receipts were restored. Or, if some receipts are still not
+        // applied, upgrade already happened, and no new receipt was applied in some last blocks,
+        // consider the process stuck to avoid any possibility of infinite loop.
+        while height < 15 || (!receipt_hashes_to_restore.is_empty() && height - last_update_height < HEIGHT_TIMEOUT)
         {
             let mut block = env.clients[0].produce_block(height).unwrap().unwrap();
             if low_height_with_no_chunk <= height && height < high_height_with_no_chunk {
@@ -2995,7 +2999,7 @@ mod protocol_feature_restore_receipts_after_fix_tests {
             height += 1;
         }
 
-        if should_pass {
+        if should_be_restored {
             assert!(
                 receipt_hashes_to_restore.is_empty(),
                 "Some of receipts were not executed, hashes: {:?}",
@@ -3013,20 +3017,27 @@ mod protocol_feature_restore_receipts_after_fix_tests {
     #[test]
     fn test_no_chunks_missing() {
         // If there are no chunks missing, all receipts should be applied
-        run_test(1, 0, true);
+        run_test("mainnet",1, 0, true);
     }
 
     #[test]
     fn test_first_chunk_in_epoch_missing() {
         // If the first chunk in the first epoch with needed protocol version is missing,
         // all receipts should still be applied
-        run_test(8, 12, true);
+        run_test("mainnet",8, 12, true);
     }
 
     #[test]
     fn test_all_chunks_in_epoch_missing() {
         // If all chunks are missing in the first epoch, no receipts should be applied
-        run_test(11, 11 + EPOCH_LENGTH, false);
+        run_test("mainnet", 11, 11 + EPOCH_LENGTH, false);
+    }
+
+    #[test]
+    fn test_run_for_testnet() {
+        // Run the same process for chain other than mainnet to ensure that blocks are produced
+        // successfully during the protocol upgrade.
+        run_test("testnet",1, 0, true);
     }
 }
 

--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -2904,9 +2904,9 @@ mod access_key_nonce_range_tests {
 #[cfg(test)]
 mod protocol_feature_restore_receipts_after_fix_tests {
     use super::*;
+    use near_primitives::receipt::Receipt;
     use near_primitives::runtime::migration_data::MigrationData;
     use near_primitives::version::ProtocolFeature;
-    use near_primitives::receipt::Receipt;
 
     const EPOCH_LENGTH: u64 = 5;
     const HEIGHT_TIMEOUT: u64 = 10;
@@ -2963,7 +2963,9 @@ mod protocol_feature_restore_receipts_after_fix_tests {
         // Stop block production if all receipts were restored. Or, if some receipts are still not
         // applied, upgrade already happened, and no new receipt was applied in some last blocks,
         // consider the process stuck to avoid any possibility of infinite loop.
-        while height < 15 || (!receipt_hashes_to_restore.is_empty() && height - last_update_height < HEIGHT_TIMEOUT)
+        while height < 15
+            || (!receipt_hashes_to_restore.is_empty()
+                && height - last_update_height < HEIGHT_TIMEOUT)
         {
             let mut block = env.clients[0].produce_block(height).unwrap().unwrap();
             if low_height_with_no_chunk <= height && height < high_height_with_no_chunk {
@@ -3017,14 +3019,14 @@ mod protocol_feature_restore_receipts_after_fix_tests {
     #[test]
     fn test_no_chunks_missing() {
         // If there are no chunks missing, all receipts should be applied
-        run_test("mainnet",1, 0, true);
+        run_test("mainnet", 1, 0, true);
     }
 
     #[test]
     fn test_first_chunk_in_epoch_missing() {
         // If the first chunk in the first epoch with needed protocol version is missing,
         // all receipts should still be applied
-        run_test("mainnet",8, 12, true);
+        run_test("mainnet", 8, 12, true);
     }
 
     #[test]
@@ -3037,7 +3039,7 @@ mod protocol_feature_restore_receipts_after_fix_tests {
     fn test_run_for_testnet() {
         // Run the same process for chain other than mainnet to ensure that blocks are produced
         // successfully during the protocol upgrade.
-        run_test("testnet",1, 0, true);
+        run_test("testnet", 1, 0, true);
     }
 }
 

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1116,11 +1116,7 @@ impl Runtime {
             == protocol_version
             && migration_flags.is_first_block_with_chunk_of_version
         {
-            migration_data
-                .restored_receipts
-                .get(&0u64)
-                .cloned()
-                .unwrap_or_default()
+            migration_data.restored_receipts.get(&0u64).cloned().unwrap_or_default()
         } else {
             vec![]
         };

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1119,8 +1119,8 @@ impl Runtime {
             migration_data
                 .restored_receipts
                 .get(&0u64)
-                .expect("Receipts to restore must contain an entry for shard 0")
-                .clone()
+                .cloned()
+                .unwrap_or_default()
         } else {
             vec![]
         };

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1116,6 +1116,7 @@ impl Runtime {
             == protocol_version
             && migration_flags.is_first_block_with_chunk_of_version
         {
+            // We restore receipts only on mainnet so result will be None on other chains.
             migration_data.restored_receipts.get(&0u64).cloned().unwrap_or_default()
         } else {
             vec![]

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1116,7 +1116,8 @@ impl Runtime {
             == protocol_version
             && migration_flags.is_first_block_with_chunk_of_version
         {
-            // We restore receipts only on mainnet so result will be None on other chains.
+            // Note that receipts are restored only on mainnet so restored_receipts will be empty on
+            // other chains.
             migration_data.restored_receipts.get(&0u64).cloned().unwrap_or_default()
         } else {
             vec![]


### PR DESCRIPTION
Prevent non-mainnet chains from crashing during protocol upgrade to `RestoreReceiptsAfterFix`: https://github.com/near/nearcore/issues/4321

- Remove unnecessary assertion because it's already checked in `test_restored_receipts_data`
- Test protocol upgrade on testnet in `protocol_feature_restore_receipts_after_fix_tests::test_run_for_testnet`  