### PR TITLE
fix broken release due to wrong rust version and resolver conflit, remove the dockerfile caching as it is not used anyway.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,16 +29,12 @@ COPY . .
 ENV CARGO_TARGET_DIR=/tmp/target
 ENV RUSTC_FLAGS='-C target-cpu=x86-64'
 ENV PORTABLE=ON
-RUN --mount=type=cache,target=/tmp/target \
-    --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/usr/local/cargo/registry \
-    cargo +"$(cat /tmp/rust-toolchain)" build -p neard --release && \
+RUN cargo +"$(cat /tmp/rust-toolchain)" build -p neard --release && \
     mkdir /tmp/build && \
     cd /tmp/target/release && \
     mv ./neard /tmp/build
 
 COPY scripts/run_docker.sh /tmp/build/run.sh
-
 
 # Actual image
 FROM ubuntu:18.04

--- a/Dockerfile.nightly
+++ b/Dockerfile.nightly
@@ -29,10 +29,7 @@ COPY . .
 ENV CARGO_TARGET_DIR=/tmp/target
 ENV RUSTC_FLAGS='-C target-cpu=x86-64'
 ENV PORTABLE=ON
-RUN --mount=type=cache,target=/tmp/target \
-    --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=cache,target=/usr/local/cargo/registry \
-    cargo +"$(cat /tmp/rust-toolchain)" build -p neard --release --features nightly_protocol --features nightly_protocol_features && \
+RUN cargo +"$(cat /tmp/rust-toolchain)" build -p neard --release --features nightly_protocol --features nightly_protocol_features && \
     mkdir /tmp/build && \
     cd /tmp/target/release && \
     mv ./neard /tmp/build

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 docker-nearcore:
-	DOCKER_BUILDKIT=1 docker build -t nearcore -f Dockerfile .
+	DOCKER_BUILDKIT=1 docker build -t nearcore -f Dockerfile --progress=plain . 
 
 docker-nearcore-nightly:
-	DOCKER_BUILDKIT=1 docker build -t nearcore-nightly -f Dockerfile.nightly .
+	DOCKER_BUILDKIT=1 docker build -t nearcore-nightly -f Dockerfile.nightly --progress=plain . 
 
-RUST_OPTIONS:=+stable
+RUST_OPTIONS:=$(cat rust-toolchain)
 
 export RUSTFLAGS = -D warnings
 


### PR DESCRIPTION
builds to fail:
https://buildkite.com/nearprotocol/nearcore-release/builds/601

Created a build to verify if it works as a quick fix to unblock master failing: https://buildkite.com/nearprotocol/nearcore-release/builds/607

As well remove the mount=type=cache as they get removed eitherways every time once we destroy the container, so there aren't useful at all here.