### PR TITLE
fix: remove test code from neard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3751,7 +3751,6 @@ dependencies = [
  "nearcore",
  "node-runtime",
  "openssl-probe",
- "testlib",
  "tracing",
  "tracing-subscriber",
 ]

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -34,7 +34,6 @@ near-jsonrpc = { path = "../chain/jsonrpc" }
 near-rosetta-rpc = { path = "../chain/rosetta-rpc", optional = true }
 near-epoch-manager = { path = "../chain/epoch_manager" }
 near-performance-metrics = { path = "../utils/near-performance-metrics" }
-testlib = { path = "../test-utils/testlib" }
 
 [features]
 performance_stats = ["near-performance-metrics/performance_stats"]
@@ -51,7 +50,7 @@ protocol_feature_alt_bn128 = ["near-primitives/protocol_feature_alt_bn128", "nod
 protocol_feature_block_header_v3 = ["near-epoch-manager/protocol_feature_block_header_v3", "near-store/protocol_feature_block_header_v3", "near-primitives/protocol_feature_block_header_v3", "near-chain/protocol_feature_block_header_v3", "near-client/protocol_feature_block_header_v3"]
 protocol_feature_add_account_versions = ["near-primitives/protocol_feature_add_account_versions"]
 protocol_feature_tx_size_limit = ["near-primitives/protocol_feature_tx_size_limit", "node-runtime/protocol_feature_tx_size_limit"]
-protocol_feature_allow_create_account_on_delete = ["node-runtime/protocol_feature_allow_create_account_on_delete", "testlib/protocol_feature_allow_create_account_on_delete"]
+protocol_feature_allow_create_account_on_delete = ["node-runtime/protocol_feature_allow_create_account_on_delete"]
 protocol_feature_fix_storage_usage = ["near-primitives/protocol_feature_fix_storage_usage", "node-runtime/protocol_feature_fix_storage_usage"]
 protocol_feature_restore_receipts_after_fix = ["near-primitives/protocol_feature_restore_receipts_after_fix"]
 protocol_feature_cap_max_gas_price = ["near-primitives/protocol_feature_cap_max_gas_price", "near-chain/protocol_feature_cap_max_gas_price"]


### PR DESCRIPTION
testlib is the library we use for testing, it makes no sense that we
compile it into our production code. Admittedly, I lack the context as
to *why* it was added as a non-dev dep in the first place. I have a
suspicion that it was a workaround some feature bugs.

Now that we use resolever=2, it makes sense to try to fix this in a more
principled way, so let's see if some tests start failing due to this
change.