### PR TITLE
fix(release): fix the failing builds on an error due to non-existing …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,24 +22,24 @@ debug:
 
 perf-release:
 	CARGO_PROFILE_RELEASE_DEBUG=true cargo $(RUST_OPTIONS) build -p neard --release --features performance_stats,memory_stats
-	cargo $(RUST_OPTIONS) build -p near-vm-runner-standalone --release --features performance_stats,memory_stats
-	cargo $(RUST_OPTIONS) build -p state-viewer --release --features performance_stats,memory_stats
-	cargo $(RUST_OPTIONS) build -p store-validator --release --features performance_stats,memory_stats
+	cargo $(RUST_OPTIONS) build -p near-vm-runner-standalone --release 
+	cargo $(RUST_OPTIONS) build -p state-viewer --release
+	cargo $(RUST_OPTIONS) build -p store-validator --release
 
 perf-debug:
 	CARGO_PROFILE_RELEASE_DEBUG=true cargo $(RUST_OPTIONS) build -p neard --features performance_stats,memory_stats
-	cargo $(RUST_OPTIONS) build -p near-vm-runner-standalone --features performance_stats,memory_stats
-	cargo $(RUST_OPTIONS) build -p state-viewer --features performance_stats,memory_stats
-	cargo $(RUST_OPTIONS) build -p store-validator --features performance_stats,memory_stats
+	cargo $(RUST_OPTIONS) build -p near-vm-runner-standalone
+	cargo $(RUST_OPTIONS) build -p state-viewer
+	cargo $(RUST_OPTIONS) build -p store-validator
 
 nightly-release:
 	CARGO_PROFILE_RELEASE_DEBUG=true cargo $(RUST_OPTIONS) build -p neard --release --features nightly_protocol,nightly_protocol_features,performance_stats,memory_stats
-	cargo $(RUST_OPTIONS) build -p near-vm-runner-standalone --release --features nightly_protocol,nightly_protocol_features,performance_stats,memory_stats
-	cargo $(RUST_OPTIONS) build -p state-viewer --release --features nightly_protocol,nightly_protocol_features,performance_stats,memory_stats
-	cargo $(RUST_OPTIONS) build -p store-validator --release --features nightly_protocol,nightly_protocol_features,performance_stats,memory_stats
+	cargo $(RUST_OPTIONS) build -p near-vm-runner-standalone --release --features nightly_protocol,nightly_protocol_features
+	cargo $(RUST_OPTIONS) build -p state-viewer --release --features nightly_protocol,nightly_protocol_features
+	cargo $(RUST_OPTIONS) build -p store-validator --release --features nightly_protocol,nightly_protocol_features
 
 nightly-debug:
 	CARGO_PROFILE_RELEASE_DEBUG=true cargo $(RUST_OPTIONS) build -p neard --features nightly_protocol,nightly_protocol_features,performance_stats,memory_stats
-	cargo $(RUST_OPTIONS) build -p near-vm-runner-standalone --features nightly_protocol,nightly_protocol_features,performance_stats,memory_stats
-	cargo $(RUST_OPTIONS) build -p state-viewer --features nightly_protocol,nightly_protocol_features,performance_stats,memory_stats
-	cargo $(RUST_OPTIONS) build -p store-validator --features nightly_protocol,nightly_protocol_features,performance_stats,memory_stats
+	cargo $(RUST_OPTIONS) build -p near-vm-runner-standalone --features nightly_protocol,nightly_protocol_features
+	cargo $(RUST_OPTIONS) build -p state-viewer --features nightly_protocol,nightly_protocol_features
+	cargo $(RUST_OPTIONS) build -p store-validator --features nightly_protocol,nightly_protocol_features


### PR DESCRIPTION
…features. Created a build to verify the fix works: https://buildkite.com/nearprotocol/nearcore-perf-release/builds/235. It seems before the features which don't exist would get ignored, but now it fails due to changes in tooling.