### PR TITLE
Take CapMaxGasPrice feature on nightly

### DIFF
--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -117,7 +117,7 @@ pub const PROTOCOL_VERSION: ProtocolVersion = 45;
 
 /// Current latest nightly version of the protocol.
 #[cfg(feature = "nightly_protocol")]
-pub const PROTOCOL_VERSION: ProtocolVersion = 112;
+pub const PROTOCOL_VERSION: ProtocolVersion = 113;
 
 impl ProtocolFeature {
     pub const fn protocol_version(self) -> ProtocolVersion {


### PR DESCRIPTION
Actually update nightly protocol version to catch CapMaxGasPrice feature which I forgot to do here: https://github.com/near/nearcore/pull/4308