### PR TITLE
feat(jsonrpc): stabilize `EXPERIMENTAL_tx_status` endpoint into previously existed `tx` (no breaking changes)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3274,7 +3274,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "actix",
  "actix-cors",
@@ -3306,7 +3306,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client"
-version = "0.1.0"
+version = "0.2.2"
 dependencies = [
  "actix-web",
  "awc",

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1059,9 +1059,9 @@ impl Chain {
             Ok((head, needs_to_start_fetching_state)) => {
                 chain_update.chain_store_update.save_block_height_processed(block_height);
                 chain_update.commit()?;
-            
+
                 self.pending_states_to_patch = None;
-                
+
                 if needs_to_start_fetching_state {
                     debug!(target: "chain", "Downloading state for block {}", block.hash());
                     self.start_downloading_state(me, &block)?;

--- a/chain/jsonrpc/CHANGELOG.md
+++ b/chain/jsonrpc/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.2.2
+
+* Stabilized `EXPERIMENTAL_tx_status` into the existing `tx` endpoint where all the previous fields
+  are left as is, and the response was extended with an extra `receipts` field exposing all the
+  non-local receipts where we previously only exposed `receipts_outcome` (results without the
+  inputs).
+
 ## 0.2.1
 
 * Refactored methods:

--- a/chain/jsonrpc/Cargo.toml
+++ b/chain/jsonrpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-jsonrpc"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 

--- a/chain/jsonrpc/client/Cargo.toml
+++ b/chain/jsonrpc/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-jsonrpc-client"
-version = "0.1.0"
+version = "0.2.2"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 

--- a/chain/jsonrpc/client/src/lib.rs
+++ b/chain/jsonrpc/client/src/lib.rs
@@ -13,8 +13,8 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::types::{BlockId, BlockReference, MaybeBlockId, ShardId};
 use near_primitives::views::validator_stake_view::ValidatorStakeView;
 use near_primitives::views::{
-    BlockView, ChunkView, EpochValidatorInfo, FinalExecutionOutcomeView, GasPriceView,
-    StatusResponse,
+    BlockView, ChunkView, EpochValidatorInfo, FinalExecutionOutcomeView,
+    FinalExecutionOutcomeWithReceiptView, GasPriceView, StatusResponse,
 };
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -186,10 +186,8 @@ jsonrpc_client!(pub struct JsonRpcClient {
     pub fn EXPERIMENTAL_genesis_config(&self) -> RpcRequest<serde_json::Value>;
     #[allow(non_snake_case)]
     pub fn EXPERIMENTAL_broadcast_tx_sync(&self, tx: String) -> RpcRequest<serde_json::Value>;
-    #[allow(non_snake_case)]
-    pub fn EXPERIMENTAL_tx_status(&self, tx: String) -> RpcRequest<serde_json::Value>;
     pub fn health(&self) -> RpcRequest<()>;
-    pub fn tx(&self, hash: String, account_id: String) -> RpcRequest<FinalExecutionOutcomeView>;
+    pub fn tx(&self, tx_hash: String, account_id: String) -> RpcRequest<FinalExecutionOutcomeWithReceiptView>;
     pub fn chunk(&self, id: ChunkId) -> RpcRequest<ChunkView>;
     pub fn validators(&self, block_id: MaybeBlockId) -> RpcRequest<EpochValidatorInfo>;
     pub fn gas_price(&self, block_id: MaybeBlockId) -> RpcRequest<GasPriceView>;
@@ -219,6 +217,13 @@ impl JsonRpcClient {
 
     pub fn block(&self, request: BlockReference) -> RpcRequest<BlockView> {
         call_method(&self.client, &self.server_addr, "block", request)
+    }
+
+    pub fn tx_status_by_signed_transaction(
+        &self,
+        tx: String,
+    ) -> RpcRequest<FinalExecutionOutcomeWithReceiptView> {
+        call_method(&self.client, &self.server_addr, "tx", [tx])
     }
 
     #[allow(non_snake_case)]

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -311,11 +311,10 @@ impl JsonRpcHandler {
                 serde_json::to_value(status_response)
                     .map_err(|err| RpcError::serialization_error(err.to_string()))
             }
-            "tx" => {
-                let rpc_transaction_status_common_request =
-                    near_jsonrpc_primitives::types::transactions::RpcTransactionStatusCommonRequest::parse(request.params)?;
+            "tx" | "EXPERIMENTAL_tx_status" => {
+                let rpc_transaction_status_common_request = near_jsonrpc_primitives::types::transactions::RpcTransactionStatusCommonRequest::parse(request.params)?;
                 let rpc_transaction_response =
-                    self.tx_status_common(rpc_transaction_status_common_request, false).await?;
+                    self.tx_status(rpc_transaction_status_common_request).await?;
                 serde_json::to_value(rpc_transaction_response)
                     .map_err(|err| RpcError::serialization_error(err.to_string()))
             }
@@ -394,13 +393,6 @@ impl JsonRpcHandler {
                     )?;
                 let receipt = self.receipt(rpc_receipt_request).await?;
                 serde_json::to_value(receipt)
-                    .map_err(|err| RpcError::serialization_error(err.to_string()))
-            }
-            "EXPERIMENTAL_tx_status" => {
-                let rpc_transaction_status_common_request = near_jsonrpc_primitives::types::transactions::RpcTransactionStatusCommonRequest::parse(request.params)?;
-                let rpc_transaction_response =
-                    self.tx_status_common(rpc_transaction_status_common_request, true).await?;
-                serde_json::to_value(rpc_transaction_response)
                     .map_err(|err| RpcError::serialization_error(err.to_string()))
             }
             "EXPERIMENTAL_validators_ordered" => {
@@ -768,15 +760,14 @@ impl JsonRpcHandler {
         Ok(self.view_client_addr.send(query).await??.into())
     }
 
-    async fn tx_status_common(
+    async fn tx_status(
         &self,
         request_data: near_jsonrpc_primitives::types::transactions::RpcTransactionStatusCommonRequest,
-        fetch_receipt: bool,
     ) -> Result<
         near_jsonrpc_primitives::types::transactions::RpcTransactionResponse,
         near_jsonrpc_primitives::types::transactions::RpcTransactionError,
     > {
-        Ok(self.tx_status_fetch(request_data.transaction_info, fetch_receipt).await?.into())
+        Ok(self.tx_status_fetch(request_data.transaction_info, true).await?.into())
     }
 
     async fn block(

--- a/chain/jsonrpc/tests/rpc_transactions.rs
+++ b/chain/jsonrpc/tests/rpc_transactions.rs
@@ -62,7 +62,9 @@ fn test_send_tx_async() {
                             .tx(tx_hash.to_string(), signer_account_id)
                             .map_err(|err| println!("Error: {:?}", err))
                             .map_ok(|result| {
-                                if let FinalExecutionStatus::SuccessValue(_) = result.status {
+                                if let FinalExecutionStatus::SuccessValue(_) =
+                                    result.final_outcome.status
+                                {
                                     System::current().stop();
                                 }
                             })

--- a/nearcore/tests/rpc_nodes.rs
+++ b/nearcore/tests/rpc_nodes.rs
@@ -247,7 +247,9 @@ fn test_tx_status_with_light_client() {
                         .tx(tx_hash.to_string(), signer_account_id)
                         .map_err(|_| ())
                         .map_ok(move |result| {
-                            if result.status == FinalExecutionStatus::SuccessValue("".to_string()) {
+                            if result.final_outcome.status
+                                == FinalExecutionStatus::SuccessValue("".to_string())
+                            {
                                 System::current().stop();
                             }
                         })
@@ -317,7 +319,9 @@ fn test_tx_status_with_light_client1() {
                         .tx(tx_hash.to_string(), signer_account_id)
                         .map_err(|_| ())
                         .map_ok(move |result| {
-                            if result.status == FinalExecutionStatus::SuccessValue("".to_string()) {
+                            if result.final_outcome.status
+                                == FinalExecutionStatus::SuccessValue("".to_string())
+                            {
                                 System::current().stop();
                             }
                         })
@@ -974,7 +978,7 @@ fn test_check_unknown_tx_must_return_error() {
                 if let Ok(Ok(block)) = res {
                     if block.header.height > 10 {
                         let _ = client
-                            .EXPERIMENTAL_tx_status(to_base64(&bytes))
+                            .tx_status_by_signed_transaction(to_base64(&bytes))
                             .map_err(|err| {
                                 assert_eq!(
                                     err.data.unwrap(),

--- a/test-utils/testlib/src/user/rpc_user.rs
+++ b/test-utils/testlib/src/user/rpc_user.rs
@@ -173,7 +173,7 @@ impl User for RpcUser {
     fn get_transaction_final_result(&self, hash: &CryptoHash) -> FinalExecutionOutcomeView {
         let account_id = self.account_id.clone();
         let hash = hash.to_string();
-        self.actix(move |client| client.tx(hash, account_id)).unwrap()
+        self.actix(move |client| client.tx(hash, account_id)).unwrap().final_outcome
     }
 
     fn get_state_root(&self) -> CryptoHash {


### PR DESCRIPTION
I reviewed the `EXPERIMENTAL_tx_status` changes: `receipts` field was added which only exposes non-local receipts and its structure is similar to the `transaction` structure. It is yet to be desired to use tagged enum representations, but given that `transaction` structure is already there using non-tagged representation, it is better to keep them aligned.

Checkpoints:

* [x] The `EXPERIMENTAL_` endpoint is left in the code-base for compatibility reasons (we don't need to remove it and existing clients may keep using it just fine)
* [x] CHANGELOG is updated
* [x] jsonrpc-client is updated (it has a minor breaking change, but it is an internal crate used for testing purposes)

# Test Plan

* [ ] All existing tests pass
* [x] Updated near-api-js to be compatible with the change: https://github.com/near/near-api-js/pull/623 (it expected that `broadcast_tx_commit` output will exactly match `tx` status endpoint output)