### PR TITLE
Cover cargo build failures in buildkite/nearcore

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -29,7 +29,7 @@ steps:
       fi
       RUSTFLAGS='-D warnings' cargo check --workspace --all-targets --all-features
       RUSTFLAGS='-D warnings' cargo check -p neard
-      RUSTFLAGS='-D warnings' cargo check -p neard --features
+      RUSTFLAGS='-D warnings' cargo check -p neard --features nightly_protocol,nightly_protocol_features
       # build a sandbox node should succeed
       RUSTFLAGS='-D warnings' cargo check -p neard --features sandbox
       python3 scripts/state/update_res.py check

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -28,6 +28,8 @@ steps:
         cargo-deny --all-features check bans
       fi
       RUSTFLAGS='-D warnings' cargo check --workspace --all-targets --all-features
+      RUSTFLAGS='-D warnings' cargo check -p neard
+      RUSTFLAGS='-D warnings' cargo check -p neard --features
       # build a sandbox node should succeed
       RUSTFLAGS='-D warnings' cargo check -p neard --features sandbox
       python3 scripts/state/update_res.py check


### PR DESCRIPTION
Attempt to solve https://github.com/near/nearcore/issues/4367

Check both stable and nightly `cargo build -p neard`

Checked that it covers previous commit:
```
$ git checkout 377908d18e0d4ed46eab2f0cdabf3f9a648179e3
$ cargo check -p neard --features nightly_protocol,nightly_protocol_features
error: failed to select a version for `near-client`.
    ... required by package `nearcore v1.2.0 (/home/Aleksandr1/nearcore/nearcore)`
    ... which is depended on by `neard v1.2.0 (/home/Aleksandr1/nearcore/neard)`
versions that meet the requirements `=0.1.0` are: 0.1.0

the package `nearcore` depends on `near-client`, with features: `nearcore` but `near-client` does not have these features.
```