### PR TITLE
feat(primitive): prepare for adding profile data to execution outcome

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3278,6 +3278,7 @@ version = "0.2.1"
 dependencies = [
  "actix",
  "actix-cors",
+ "actix-http",
  "actix-web",
  "awc",
  "borsh",
@@ -3308,6 +3309,7 @@ dependencies = [
 name = "near-jsonrpc-client"
 version = "0.1.0"
 dependencies = [
+ "actix-http",
  "actix-web",
  "awc",
  "futures",
@@ -3498,6 +3500,7 @@ version = "0.1.1"
 dependencies = [
  "actix",
  "actix-cors",
+ "actix-http",
  "actix-web",
  "awc",
  "derive_more",

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -22,8 +22,8 @@ use near_primitives::receipt::{ActionReceipt, Receipt, ReceiptEnum};
 use near_primitives::serialize::to_base;
 use near_primitives::sharding::ChunkHash;
 use near_primitives::transaction::{
-    Action, ExecutionOutcome, ExecutionOutcomeWithId, ExecutionStatus, SignedTransaction,
-    TransferAction,
+    Action, ExecutionMetadata, ExecutionOutcome, ExecutionOutcomeWithId, ExecutionStatus,
+    SignedTransaction, TransferAction,
 };
 use near_primitives::types::validator_stake::{ValidatorStake, ValidatorStakeIter};
 use near_primitives::types::{
@@ -726,6 +726,7 @@ impl RuntimeAdapter for KeyValueRuntime {
                         gas_burnt: 0,
                         tokens_burnt: 0,
                         executor_id: to.clone(),
+                        metadata: ExecutionMetadata::ExecutionMetadataV1,
                     },
                 });
             }

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -721,7 +721,7 @@ mod tests {
     use near_crypto::KeyType;
     use near_primitives::block::{genesis_chunks, Approval};
     use near_primitives::merkle::verify_path;
-    use near_primitives::transaction::{ExecutionOutcome, ExecutionStatus};
+    use near_primitives::transaction::{ExecutionMetadata, ExecutionOutcome, ExecutionStatus};
     use near_primitives::validator_signer::InMemoryValidatorSigner;
     use near_primitives::version::PROTOCOL_VERSION;
 
@@ -773,6 +773,7 @@ mod tests {
                 gas_burnt: 100,
                 tokens_burnt: 10000,
                 executor_id: "alice".to_string(),
+                metadata: ExecutionMetadata::ExecutionMetadataV1,
             },
         };
         let outcome2 = ExecutionOutcomeWithId {
@@ -784,6 +785,7 @@ mod tests {
                 gas_burnt: 0,
                 tokens_burnt: 0,
                 executor_id: "bob".to_string(),
+                metadata: ExecutionMetadata::ExecutionMetadataV1,
             },
         };
         let outcomes = vec![outcome1, outcome2];

--- a/chain/jsonrpc/Cargo.toml
+++ b/chain/jsonrpc/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2018"
 [dependencies]
 actix = "=0.11.0-beta.2"
 awc = "3.0.0-beta.5"
-actix-web = "4.0.0-beta.6"
+actix-web = "=4.0.0-beta.6"
+actix-http = "=3.0.0-beta.6"
 actix-cors = { git = "https://github.com/near/actix-extras.git", branch="actix-web-4-beta.6" }
 easy-ext = "0.2"
 tokio = { version = "1.1", features = ["full"] }

--- a/chain/jsonrpc/client/Cargo.toml
+++ b/chain/jsonrpc/client/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2018"
 
 [dependencies]
 awc = "3.0.0-beta.5"
-actix-web = "4.0.0-beta.6"
+actix-web = "=4.0.0-beta.6"
+actix-http = "=3.0.0-beta.6"
 futures = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/chain/rosetta-rpc/Cargo.toml
+++ b/chain/rosetta-rpc/Cargo.toml
@@ -14,7 +14,8 @@ strum = { version = "0.20", features = ["derive"] }
 
 awc = "3.0.0-beta.5"
 actix = "=0.11.0-beta.2"
-actix-web = "4.0.0-beta.6"
+actix-web = "=4.0.0-beta.6"
+actix-http = "=3.0.0-beta.6"
 actix-cors = { git = "https://github.com/near/actix-extras.git", branch="actix-web-4-beta.6" }
 futures = "0.3.5"
 tokio = { version = "1.1", features = ["full"] }

--- a/chain/telemetry/Cargo.toml
+++ b/chain/telemetry/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 openssl = { version = "0.10", features = ["vendored"] }
 awc = "3.0.0-beta.5"
-actix-web = { version = "4.0.0-beta.6", features = [ "openssl" ] }
+actix-web = { version = "=4.0.0-beta.6", features = [ "openssl" ] }
 futures = "0.3"
 actix = "=0.11.0-beta.2"
 serde = { version = "1", features = [ "derive" ] }

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -285,7 +285,7 @@ impl Default for ExecutionStatus {
     }
 }
 
-/// ExecutionOutcome for proof. Excludes logs.
+/// ExecutionOutcome for proof. Excludes logs and metadata
 #[derive(BorshSerialize, BorshDeserialize, Serialize, PartialEq, Clone)]
 struct PartialExecutionOutcome {
     pub receipt_ids: Vec<CryptoHash>,
@@ -348,6 +348,20 @@ pub struct ExecutionOutcome {
     /// NOTE: Should be the latest field since it contains unparsable by light client
     /// ExecutionStatus::Failure
     pub status: ExecutionStatus,
+    /// Execution metadata, versioned
+    pub metadata: ExecutionMetadata,
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, PartialEq, Clone, Eq, Debug)]
+pub enum ExecutionMetadata {
+    // V1: Empty Metadata
+    ExecutionMetadataV1,
+}
+
+impl Default for ExecutionMetadata {
+    fn default() -> Self {
+        ExecutionMetadata::ExecutionMetadataV1
+    }
 }
 
 impl ExecutionOutcome {
@@ -370,6 +384,7 @@ impl fmt::Debug for ExecutionOutcome {
             .field("burnt_gas", &self.gas_burnt)
             .field("tokens_burnt", &self.tokens_burnt)
             .field("status", &self.status)
+            .field("meatdata", &self.metadata)
             .finish()
     }
 }
@@ -508,6 +523,7 @@ mod tests {
             gas_burnt: 123,
             tokens_burnt: 1234000,
             executor_id: "alice".to_string(),
+            metadata: ExecutionMetadata::ExecutionMetadataV1,
         };
         let hashes = outcome.to_hashes();
         assert_eq!(hashes.len(), 3);

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -13,7 +13,7 @@ pub struct Version {
 pub type DbVersion = u32;
 
 /// Current version of the database.
-pub const DB_VERSION: DbVersion = 23;
+pub const DB_VERSION: DbVersion = 24;
 
 /// Protocol version type.
 pub use near_primitives_core::types::ProtocolVersion;

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -39,8 +39,8 @@ use crate::sharding::{ChunkHash, ShardChunk, ShardChunkHeader, ShardChunkHeaderI
 use crate::sharding::{ShardChunkHeaderInnerV2, ShardChunkHeaderV3};
 use crate::transaction::{
     Action, AddKeyAction, CreateAccountAction, DeleteAccountAction, DeleteKeyAction,
-    DeployContractAction, ExecutionOutcome, ExecutionOutcomeWithIdAndProof, ExecutionStatus,
-    FunctionCallAction, SignedTransaction, StakeAction, TransferAction,
+    DeployContractAction, ExecutionMetadata, ExecutionOutcome, ExecutionOutcomeWithIdAndProof,
+    ExecutionStatus, FunctionCallAction, SignedTransaction, StakeAction, TransferAction,
 };
 use crate::types::{
     AccountId, AccountWithPublicKey, Balance, BlockHeight, CompiledContractCache, EpochHeight,
@@ -1017,6 +1017,8 @@ pub struct ExecutionOutcomeView {
     pub executor_id: AccountId,
     /// Execution status. Contains the result in case of successful execution.
     pub status: ExecutionStatusView,
+    /// Execution metadata, versioned
+    pub metadata: ExecutionMetadata,
 }
 
 impl From<ExecutionOutcome> for ExecutionOutcomeView {
@@ -1028,6 +1030,7 @@ impl From<ExecutionOutcome> for ExecutionOutcomeView {
             tokens_burnt: outcome.tokens_burnt,
             executor_id: outcome.executor_id,
             status: outcome.status.into(),
+            metadata: outcome.metadata,
         }
     }
 }

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -1018,6 +1018,7 @@ pub struct ExecutionOutcomeView {
     /// Execution status. Contains the result in case of successful execution.
     pub status: ExecutionStatusView,
     /// Execution metadata, versioned
+    #[serde(skip)]
     pub metadata: ExecutionMetadata,
 }
 

--- a/core/store/src/migrations.rs
+++ b/core/store/src/migrations.rs
@@ -718,7 +718,7 @@ pub fn migrate_18_to_new_validator_stake(store: &Store) {
     use near_primitives::types::chunk_extra::{ChunkExtra, ChunkExtraV1};
     use near_primitives::types::validator_stake::ValidatorStakeV1;
     use near_primitives::types::{
-        AccountId, BlockChunkValidatorStats, EpochId, ProtocolVersion, ShardId, ValidatorId,
+        BlockChunkValidatorStats, EpochId, ProtocolVersion, ShardId, ValidatorId,
         ValidatorKickoutReason, ValidatorStats,
     };
     use std::collections::BTreeMap;

--- a/core/store/src/migrations.rs
+++ b/core/store/src/migrations.rs
@@ -856,7 +856,7 @@ pub fn fill_col_outcomes_with_metadata(store: &Store) {
         let outcomes: Vec<ExecutionOutcomeWithIdAndProof> =
             outcomes.into_iter().map(|outcome| outcome.into()).collect();
         store_update
-            .set_ser(DBCol::ColOutcomeIds, key.as_ref(), &outcomes)
+            .set_ser(DBCol::ColTransactionResult, key.as_ref(), &outcomes)
             .expect("BorshSerialize should not fail");
     }
     store_update.commit().expect("Failed to migrate");

--- a/core/store/src/migrations.rs
+++ b/core/store/src/migrations.rs
@@ -840,15 +840,15 @@ pub fn fill_col_outcomes_with_metadata(store: &Store) {
         }
     }
 
+    let mut store_update = BatchedStoreUpdate::new(&store, 10_000_000);
     for (key, value) in store.iter(DBCol::ColTransactionResult) {
         let old_outcomes = Vec::<OldExecutionOutcomeWithIdAndProof>::try_from_slice(&value)
             .expect("BorshDeserialize should not fail");
         let outcomes: Vec<ExecutionOutcomeWithIdAndProof> =
             old_outcomes.into_iter().map(|outcome| outcome.into()).collect();
-        let mut store_update = store.store_update();
         store_update
             .set_ser(DBCol::ColTransactionResult, key.as_ref(), &outcomes)
             .expect("BorshSerialize should not fail");
-        store_update.commit().expect("Failed to migrate");
     }
+    store_update.finish().expect("Failed to migrate");
 }

--- a/core/store/src/migrations.rs
+++ b/core/store/src/migrations.rs
@@ -9,7 +9,10 @@ use near_primitives::sharding::{
     EncodedShardChunk, EncodedShardChunkV1, PartialEncodedChunk, PartialEncodedChunkV1,
     ReceiptList, ReceiptProof, ReedSolomonWrapper, ShardChunk, ShardChunkV1, ShardProof,
 };
-use near_primitives::transaction::ExecutionOutcomeWithIdAndProof;
+use near_primitives::transaction::{
+    ExecutionMetadata, ExecutionOutcome, ExecutionOutcomeWithId, ExecutionOutcomeWithIdAndProof,
+    ExecutionStatus, LogEntry,
+};
 use near_primitives::version::DbVersion;
 
 use crate::db::DBCol::{ColBlockHeader, ColBlockMisc, ColChunks, ColPartialChunks, ColStateParts};
@@ -29,12 +32,13 @@ use near_primitives::block_header::BlockHeader;
 #[cfg(feature = "protocol_feature_block_header_v3")]
 use near_primitives::epoch_manager::epoch_info::EpochInfo;
 use near_primitives::epoch_manager::epoch_info::EpochInfoV1;
-use near_primitives::merkle::merklize;
+use near_primitives::merkle::{merklize, MerklePath};
 use near_primitives::receipt::{DelayedReceiptIndices, Receipt, ReceiptEnum};
 use near_primitives::syncing::{ShardStateSyncResponseHeader, ShardStateSyncResponseHeaderV1};
 use near_primitives::trie_key::TrieKey;
 #[cfg(feature = "protocol_feature_block_header_v3")]
 use near_primitives::types::validator_stake::ValidatorStake;
+use near_primitives::types::{AccountId, Balance, Gas};
 use near_primitives::utils::{create_receipt_id_from_transaction, get_block_shard_id};
 use near_primitives::validator_signer::InMemoryValidatorSigner;
 use std::rc::Rc;
@@ -565,7 +569,7 @@ pub fn migrate_17_to_18(path: &String) {
 
     use near_primitives::challenge::SlashedValidator;
     use near_primitives::types::validator_stake::ValidatorStakeV1;
-    use near_primitives::types::{Balance, BlockHeight, EpochId};
+    use near_primitives::types::{BlockHeight, EpochId};
     use near_primitives::version::ProtocolVersion;
 
     // Migrate from OldBlockInfo to NewBlockInfo - add hash
@@ -645,7 +649,7 @@ pub fn migrate_21_to_22(path: &String) {
     use near_primitives::epoch_manager::BlockInfoV1;
     use near_primitives::epoch_manager::SlashState;
     use near_primitives::types::validator_stake::ValidatorStakeV1;
-    use near_primitives::types::{AccountId, Balance, BlockHeight, EpochId};
+    use near_primitives::types::{BlockHeight, EpochId};
     use near_primitives::version::ProtocolVersion;
     #[derive(BorshDeserialize)]
     struct OldBlockInfo {
@@ -789,4 +793,70 @@ pub fn migrate_18_to_new_validator_stake(store: &Store) {
         }
     }
     store_update.finish().unwrap();
+}
+
+pub fn fill_col_outcomes_with_metadata(store: &Store) {
+    #[derive(BorshSerialize, BorshDeserialize, PartialEq, Clone, Default, Eq, Debug)]
+    pub struct OldExecutionOutcome {
+        pub logs: Vec<LogEntry>,
+        pub receipt_ids: Vec<CryptoHash>,
+        pub gas_burnt: Gas,
+        pub tokens_burnt: Balance,
+        pub executor_id: AccountId,
+        pub status: ExecutionStatus,
+    }
+
+    #[derive(PartialEq, Clone, Default, Debug, BorshSerialize, BorshDeserialize, Eq)]
+    pub struct OldExecutionOutcomeWithId {
+        pub id: CryptoHash,
+        pub outcome: OldExecutionOutcome,
+    }
+
+    #[derive(PartialEq, Clone, Default, Debug, BorshSerialize, BorshDeserialize, Eq)]
+    pub struct OldExecutionOutcomeWithIdAndProof {
+        pub proof: MerklePath,
+        pub block_hash: CryptoHash,
+        pub outcome_with_id: OldExecutionOutcomeWithId,
+    }
+
+    impl Into<ExecutionOutcomeWithIdAndProof> for OldExecutionOutcomeWithIdAndProof {
+        fn into(self) -> ExecutionOutcomeWithIdAndProof {
+            ExecutionOutcomeWithIdAndProof {
+                proof: self.proof,
+                block_hash: self.block_hash,
+                outcome_with_id: ExecutionOutcomeWithId {
+                    id: self.outcome_with_id.id,
+                    outcome: ExecutionOutcome {
+                        logs: self.outcome_with_id.outcome.logs,
+                        receipt_ids: self.outcome_with_id.outcome.receipt_ids,
+                        gas_burnt: self.outcome_with_id.outcome.gas_burnt,
+                        tokens_burnt: self.outcome_with_id.outcome.tokens_burnt,
+                        executor_id: self.outcome_with_id.outcome.executor_id,
+                        status: self.outcome_with_id.outcome.status,
+                        metadata: ExecutionMetadata::ExecutionMetadataV1,
+                    },
+                },
+            }
+        }
+    }
+
+    let mut store_update = store.store_update();
+    let outcomes: Vec<(_, OldExecutionOutcomeWithIdAndProof)> = store
+        .iter(DBCol::ColTransactionResult)
+        .map(|(key, value)| {
+            (
+                key,
+                OldExecutionOutcomeWithIdAndProof::try_from_slice(&value)
+                    .expect("BorshDeserialize should not fail"),
+            )
+        })
+        .collect();
+
+    for (key, outcome) in outcomes {
+        let outcome: ExecutionOutcomeWithIdAndProof = outcome.into();
+        store_update
+            .set_ser(DBCol::ColOutcomeIds, key.as_ref(), &outcome)
+            .expect("BorshSerialize should not fail");
+    }
+    store_update.commit().expect("Failed to migrate");
 }

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -23,9 +23,10 @@ pub use crate::config::{init_configs, load_config, load_test_config, NearConfig,
 use crate::migrations::{migrate_12_to_13, migrate_18_to_19, migrate_19_to_20, migrate_22_to_23};
 pub use crate::runtime::NightshadeRuntime;
 use near_store::migrations::{
-    fill_col_outcomes_by_hash, fill_col_transaction_refcount, get_store_version, migrate_10_to_11,
-    migrate_11_to_12, migrate_13_to_14, migrate_14_to_15, migrate_17_to_18, migrate_21_to_22,
-    migrate_6_to_7, migrate_7_to_8, migrate_8_to_9, migrate_9_to_10, set_store_version,
+    fill_col_outcomes_by_hash, fill_col_outcomes_with_metadata, fill_col_transaction_refcount,
+    get_store_version, migrate_10_to_11, migrate_11_to_12, migrate_13_to_14, migrate_14_to_15,
+    migrate_17_to_18, migrate_21_to_22, migrate_6_to_7, migrate_7_to_8, migrate_8_to_9,
+    migrate_9_to_10, set_store_version,
 };
 
 #[cfg(feature = "protocol_feature_block_header_v3")]
@@ -215,6 +216,12 @@ pub fn apply_store_migrations(path: &String, near_config: &NearConfig) {
     if db_version <= 22 {
         info!(target: "near", "Migrate DB from version 22 to 23");
         migrate_22_to_23(&path, &near_config);
+    }
+    if db_version <= 23 {
+        info!(target: "near", "Migrate DB from version 23 to 24");
+        let store = create_store(&path);
+        fill_col_outcomes_with_metadata(&store);
+        set_store_version(&store, 24);
     }
     #[cfg(feature = "nightly_protocol")]
     {

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -55,6 +55,7 @@ use near_primitives::contract::ContractCode;
 pub use near_primitives::runtime::apply_state::ApplyState;
 use near_primitives::runtime::fees::RuntimeFeesConfig;
 use near_primitives::runtime::migration_data::{MigrationData, MigrationFlags};
+use near_primitives::transaction::ExecutionMetadata;
 use near_primitives::version::{
     is_implicit_account_creation_enabled, ProtocolFeature, ProtocolVersion,
 };
@@ -262,6 +263,7 @@ impl Runtime {
                         gas_burnt: verification_result.gas_burnt,
                         tokens_burnt: verification_result.burnt_amount,
                         executor_id: transaction.signer_id.clone(),
+                        metadata: ExecutionMetadata::ExecutionMetadataV1,
                     },
                 };
                 Ok((receipt, outcome))
@@ -719,6 +721,7 @@ impl Runtime {
                 gas_burnt: result.gas_burnt,
                 tokens_burnt,
                 executor_id: account_id.clone(),
+                metadata: ExecutionMetadata::ExecutionMetadataV1,
             },
         })
     }


### PR DESCRIPTION
This PR does not introduce any functional change. It adds a metadata field to ExecutionOutcome which is versioned. Add a V1 ExecutionMetadata with is empty. Next PR will add a V2 ExecutionMetadata which add ProfileData into ExecutionOutcome. Add migrations to change exisiting outcome in storage to new format

Test Plan
------------
CI