### PR TITLE
Support disabling RPC endpoint at runtime as well as compile time

### DIFF
--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -600,7 +600,12 @@ impl Handler<Status> for ClientActor {
             protocol_version,
             latest_protocol_version: PROTOCOL_VERSION,
             chain_id: self.client.config.chain_id.clone(),
-            rpc_addr: self.client.config.rpc_addr.clone(),
+            rpc_addr: self
+                .client
+                .config
+                .rpc_addr
+                .as_ref()
+                .map(|addr| addr.clone()),
             validators,
             sync_info: StatusSyncInfo {
                 latest_block_hash: head.last_block_hash.into(),

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -24,7 +24,7 @@ pub struct ClientConfig {
     /// Chain id for status.
     pub chain_id: String,
     /// Listening rpc port for status.
-    pub rpc_addr: String,
+    pub rpc_addr: Option<String>,
     /// Duration to check for producing / skipping block.
     pub block_production_tracking_delay: Duration,
     /// Minimum duration before producing block.
@@ -111,7 +111,7 @@ impl ClientConfig {
         ClientConfig {
             version: Default::default(),
             chain_id: "unittest".to_string(),
-            rpc_addr: "0.0.0.0:3030".to_string(),
+            rpc_addr: Some("0.0.0.0:3030".to_string()),
             block_production_tracking_delay: Duration::from_millis(std::cmp::max(
                 10,
                 min_block_prod_time / 5,

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -317,8 +317,9 @@ pub struct StatusResponse {
     pub protocol_version: u32,
     /// Latest protocol version that this client supports.
     pub latest_protocol_version: u32,
-    /// Address for RPC server.
-    pub rpc_addr: String,
+    /// Address for RPC server.  None if node doesn’t have RPC endpoint enabled.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rpc_addr: Option<String>,
     /// Current epoch validators.
     pub validators: Vec<ValidatorInfo>,
     /// Sync status of the node.

--- a/nearcore/Cargo.toml
+++ b/nearcore/Cargo.toml
@@ -35,7 +35,7 @@ near-chunks = { path = "../chain/chunks" }
 near-client = { path = "../chain/client" }
 near-pool = { path = "../chain/pool" }
 near-network = { path = "../chain/network" }
-near-jsonrpc = { path = "../chain/jsonrpc" }
+near-jsonrpc = { path = "../chain/jsonrpc", optional = true }
 near-rosetta-rpc = { path = "../chain/rosetta-rpc", optional = true }
 near-telemetry = { path = "../chain/telemetry" }
 near-epoch-manager = { path = "../chain/epoch_manager" }
@@ -61,6 +61,7 @@ metric_recorder = ["near-network/metric_recorder", "near-client/metric_recorder"
 no_cache = ["node-runtime/no_cache", "near-store/no_cache", "near-chain/no_cache"]
 delay_detector = ["near-client/delay_detector"]
 rosetta_rpc = ["near-rosetta-rpc"]
+json_rpc = ["near-jsonrpc"]
 protocol_feature_evm = ["near-primitives/protocol_feature_evm", "node-runtime/protocol_feature_evm", "near-chain-configs/protocol_feature_evm", "near-chain/protocol_feature_evm"]
 protocol_feature_alt_bn128 = ["near-primitives/protocol_feature_alt_bn128", "node-runtime/protocol_feature_alt_bn128"]
 protocol_feature_block_header_v3 = ["near-epoch-manager/protocol_feature_block_header_v3", "near-store/protocol_feature_block_header_v3", "near-primitives/protocol_feature_block_header_v3", "near-chain/protocol_feature_block_header_v3", "near-client/protocol_feature_block_header_v3"]

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -408,7 +408,8 @@ pub struct Config {
     pub genesis_records_file: Option<String>,
     pub validator_key_file: String,
     pub node_key_file: String,
-    pub rpc: RpcConfig,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rpc: Option<RpcConfig>,
     #[cfg(feature = "rosetta_rpc")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rosetta_rpc: Option<RosettaRpcConfig>,
@@ -437,7 +438,7 @@ impl Default for Config {
             genesis_records_file: None,
             validator_key_file: VALIDATOR_KEY_FILE.to_string(),
             node_key_file: NODE_KEY_FILE.to_string(),
-            rpc: RpcConfig::default(),
+            rpc: Some(RpcConfig::default()),
             #[cfg(feature = "rosetta_rpc")]
             rosetta_rpc: None,
             telemetry: TelemetryConfig::default(),
@@ -561,7 +562,7 @@ pub struct NearConfig {
     config: Config,
     pub client_config: ClientConfig,
     pub network_config: NetworkConfig,
-    pub rpc_config: RpcConfig,
+    pub rpc_config: Option<RpcConfig>,
     #[cfg(feature = "rosetta_rpc")]
     pub rosetta_rpc_config: Option<RosettaRpcConfig>,
     pub telemetry_config: TelemetryConfig,
@@ -581,7 +582,7 @@ impl NearConfig {
             client_config: ClientConfig {
                 version: Default::default(),
                 chain_id: genesis.config.chain_id.clone(),
-                rpc_addr: config.rpc.addr.clone(),
+                rpc_addr: config.rpc.as_ref().map(|rpc| rpc.addr.clone()),
                 block_production_tracking_delay: config.consensus.block_production_tracking_delay,
                 min_block_production_delay: config.consensus.min_block_production_delay,
                 max_block_production_delay: config.consensus.max_block_production_delay,
@@ -948,7 +949,7 @@ pub fn create_testnet_configs_from_seeds(
         if local_ports {
             config.network.addr =
                 format!("127.0.0.1:{}", if i == 0 { first_node_port } else { open_port() });
-            config.rpc.addr = format!("127.0.0.1:{}", open_port());
+            config.rpc.get_or_insert(Default::default()).addr = format!("127.0.0.1:{}", open_port());
             config.network.boot_nodes = if i == 0 {
                 "".to_string()
             } else {
@@ -1088,7 +1089,7 @@ pub fn load_config(dir: &Path) -> NearConfig {
 pub fn load_test_config(seed: &str, port: u16, genesis: Genesis) -> NearConfig {
     let mut config = Config::default();
     config.network.addr = format!("0.0.0.0:{}", port);
-    config.rpc.addr = format!("0.0.0.0:{}", open_port());
+    config.rpc.get_or_insert(Default::default()).addr = format!("0.0.0.0:{}", open_port());
     config.consensus.min_block_production_delay =
         Duration::from_millis(FAST_MIN_BLOCK_PRODUCTION_DELAY);
     config.consensus.max_block_production_delay =

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -10,7 +10,6 @@ use near_chain::ChainGenesis;
 #[cfg(feature = "adversarial")]
 use near_client::AdversarialControls;
 use near_client::{start_client, start_view_client, ClientActor, ViewClientActor};
-use near_jsonrpc::start_http;
 use near_network::{NetworkRecipient, PeerManagerActor};
 #[cfg(feature = "rosetta_rpc")]
 use near_rosetta_rpc::start_rosetta_rpc;
@@ -292,8 +291,9 @@ pub fn start_with_config(
         #[cfg(feature = "adversarial")]
         adv.clone(),
     );
+    #[cfg(feature = "json_rpc")]
     if let Some(rpc_config) = config.rpc_config {
-        start_http(
+        near_jsonrpc::start_http(
             rpc_config,
             config.genesis.config.clone(),
             client_actor.clone(),

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -292,12 +292,14 @@ pub fn start_with_config(
         #[cfg(feature = "adversarial")]
         adv.clone(),
     );
-    start_http(
-        config.rpc_config,
-        config.genesis.config.clone(),
-        client_actor.clone(),
-        view_client.clone(),
-    );
+    if let Some(rpc_config) = config.rpc_config {
+        start_http(
+            rpc_config,
+            config.genesis.config.clone(),
+            client_actor.clone(),
+            view_client.clone(),
+        );
+    }
     #[cfg(feature = "rosetta_rpc")]
     if let Some(rosetta_rpc_config) = config.rosetta_rpc_config {
         start_rosetta_rpc(

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -28,6 +28,8 @@ near-primitives = { path = "../core/primitives" }
 near-performance-metrics = { path = "../utils/near-performance-metrics" }
 
 [features]
+default = ["json_rpc"]
+
 performance_stats = ["nearcore/performance_stats"]
 memory_stats = ["nearcore/memory_stats", "near-rust-allocator-proxy"]
 c_memory_stats = ["nearcore/c_memory_stats"]
@@ -37,6 +39,7 @@ metric_recorder = ["nearcore/metric_recorder"]
 no_cache = ["nearcore/no_cache"]
 delay_detector = ["nearcore/delay_detector"]
 rosetta_rpc = ["nearcore/rosetta_rpc"]
+json_rpc = ["nearcore/json_rpc"]
 protocol_feature_evm = ["nearcore/protocol_feature_evm"]
 protocol_feature_alt_bn128 = ["nearcore/protocol_feature_alt_bn128"]
 protocol_feature_block_header_v3 = ["nearcore/protocol_feature_block_header_v3"]

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -168,10 +168,13 @@ pub(super) struct RunCmd {
     produce_empty_blocks: Option<bool>,
     /// Customize RPC listening address (useful for running multiple nodes on
     /// the same machine).  Ignored if ‘--disable-rpc’ is given.
+    #[cfg(feature = "json_rpc")]
     #[clap(long)]
     rpc_addr: Option<String>,
-    /// Disable the RPC endpoint.  If given, `--rpc-addr` option is ignored.
+    /// Disable the RPC endpoint.  This is a no-op on builds which don’t support
+    /// RPC endpoint.
     #[clap(long)]
+    #[allow(dead_code)]
     disable_rpc: bool,
     /// Customize telemetry url.
     #[clap(long)]
@@ -203,6 +206,7 @@ impl RunCmd {
         if let Some(network_addr) = self.network_addr {
             near_config.network_config.addr = Some(network_addr);
         }
+        #[cfg(feature = "json_rpc")]
         if self.disable_rpc {
             near_config.rpc_config = None;
         } else if let Some(rpc_addr) = self.rpc_addr {

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -166,9 +166,13 @@ pub(super) struct RunCmd {
     /// Set this to false to only produce blocks when there are txs or receipts (default true).
     #[clap(long)]
     produce_empty_blocks: Option<bool>,
-    /// Customize RPC listening address (useful for running multiple nodes on the same machine).
+    /// Customize RPC listening address (useful for running multiple nodes on
+    /// the same machine).  Ignored if ‘--disable-rpc’ is given.
     #[clap(long)]
     rpc_addr: Option<String>,
+    /// Disable the RPC endpoint.  If given, `--rpc-addr` option is ignored.
+    #[clap(long)]
+    disable_rpc: bool,
     /// Customize telemetry url.
     #[clap(long)]
     telemetry_url: Option<String>,
@@ -199,8 +203,10 @@ impl RunCmd {
         if let Some(network_addr) = self.network_addr {
             near_config.network_config.addr = Some(network_addr);
         }
-        if let Some(rpc_addr) = self.rpc_addr {
-            near_config.rpc_config.addr = rpc_addr;
+        if self.disable_rpc {
+            near_config.rpc_config = None;
+        } else if let Some(rpc_addr) = self.rpc_addr {
+            near_config.rpc_config.get_or_insert(Default::default()).addr = rpc_addr;
         }
         if let Some(telemetry_url) = self.telemetry_url {
             if !telemetry_url.is_empty() {

--- a/test-utils/testlib/src/lib.rs
+++ b/test-utils/testlib/src/lib.rs
@@ -82,7 +82,7 @@ pub fn start_nodes(
             if i == 0 { first_node } else { open_port() },
             genesis.clone(),
         );
-        rpc_addrs.push(near_config.rpc_config.as_ref().unwrap().addr.clone());
+        rpc_addrs.push(near_config.rpc_addr().unwrap().clone());
         near_config.client_config.min_num_peers = num_nodes - 1;
         if i > 0 {
             near_config.network_config.boot_nodes =

--- a/test-utils/testlib/src/lib.rs
+++ b/test-utils/testlib/src/lib.rs
@@ -82,7 +82,7 @@ pub fn start_nodes(
             if i == 0 { first_node } else { open_port() },
             genesis.clone(),
         );
-        rpc_addrs.push(near_config.rpc_config.addr.clone());
+        rpc_addrs.push(near_config.rpc_config.as_ref().unwrap().addr.clone());
         near_config.client_config.min_num_peers = num_nodes - 1;
         if i > 0 {
             near_config.network_config.boot_nodes =

--- a/test-utils/testlib/src/node/process_node.rs
+++ b/test-utils/testlib/src/node/process_node.rs
@@ -51,7 +51,7 @@ impl Node for ProcessNode {
                 let child =
                     self.get_start_node_command().spawn().expect("start node command failed");
                 self.state = ProcessNodeState::Running(child);
-                let addr = self.config.rpc_config.addr.clone();
+                let addr = self.config.rpc_config.as_ref().unwrap().addr.clone();
                 thread::sleep(Duration::from_secs(3));
                 near_actix_test_utils::run_actix_until_stop(async move {
                     WaitOrTimeout::new(
@@ -97,7 +97,11 @@ impl Node for ProcessNode {
 
     fn user(&self) -> Box<dyn User> {
         let account_id = self.signer.account_id.clone();
-        Box::new(RpcUser::new(&self.config.rpc_config.addr, account_id, self.signer.clone()))
+        Box::new(RpcUser::new(
+            &self.config.rpc_config.as_ref().unwrap().addr,
+            account_id,
+            self.signer.clone(),
+        ))
     }
 
     fn as_process_ref(&self) -> &ProcessNode {

--- a/test-utils/testlib/src/node/process_node.rs
+++ b/test-utils/testlib/src/node/process_node.rs
@@ -51,13 +51,13 @@ impl Node for ProcessNode {
                 let child =
                     self.get_start_node_command().spawn().expect("start node command failed");
                 self.state = ProcessNodeState::Running(child);
-                let addr = self.config.rpc_config.as_ref().unwrap().addr.clone();
+                let client_addr = format!("http://{}", self.config.rpc_addr().unwrap());
                 thread::sleep(Duration::from_secs(3));
                 near_actix_test_utils::run_actix_until_stop(async move {
                     WaitOrTimeout::new(
                         Box::new(move |_| {
                             actix::spawn(
-                                new_client(&format!("http://{}", addr))
+                                new_client(&client_addr)
                                     .status()
                                     .map_ok(|_| System::current().stop())
                                     .then(|_| futures::future::ready(())),
@@ -98,7 +98,7 @@ impl Node for ProcessNode {
     fn user(&self) -> Box<dyn User> {
         let account_id = self.signer.account_id.clone();
         Box::new(RpcUser::new(
-            &self.config.rpc_config.as_ref().unwrap().addr,
+            self.config.rpc_addr().unwrap(),
             account_id,
             self.signer.clone(),
         ))

--- a/test-utils/testlib/src/node/thread_node.rs
+++ b/test-utils/testlib/src/node/thread_node.rs
@@ -70,7 +70,11 @@ impl Node for ThreadNode {
 
     fn user(&self) -> Box<dyn User> {
         let account_id = self.signer.account_id.clone();
-        Box::new(RpcUser::new(&self.config.rpc_config.addr, account_id, self.signer.clone()))
+        Box::new(RpcUser::new(
+            &self.config.rpc_config.as_ref().unwrap().addr,
+            account_id,
+            self.signer.clone(),
+        ))
     }
 
     fn as_thread_ref(&self) -> &ThreadNode {

--- a/test-utils/testlib/src/node/thread_node.rs
+++ b/test-utils/testlib/src/node/thread_node.rs
@@ -71,7 +71,7 @@ impl Node for ThreadNode {
     fn user(&self) -> Box<dyn User> {
         let account_id = self.signer.account_id.clone();
         Box::new(RpcUser::new(
-            &self.config.rpc_config.as_ref().unwrap().addr,
+            self.config.rpc_addr().unwrap(),
             account_id,
             self.signer.clone(),
         ))

--- a/test-utils/testlib/src/run_nodes.rs
+++ b/test-utils/testlib/src/run_nodes.rs
@@ -29,7 +29,7 @@ fn main() {
     print!("Connect via RPC to: ");
     for i in 0..num_nodes {
         match &nodes[i] {
-            NodeConfig::Thread(cfg) => print!("{}, ", cfg.rpc_config.addr),
+            NodeConfig::Thread(cfg) => print!("{}, ", cfg.rpc_config.as_ref().unwrap().addr),
             _ => (),
         }
     }

--- a/test-utils/testlib/src/run_nodes.rs
+++ b/test-utils/testlib/src/run_nodes.rs
@@ -29,7 +29,7 @@ fn main() {
     print!("Connect via RPC to: ");
     for i in 0..num_nodes {
         match &nodes[i] {
-            NodeConfig::Thread(cfg) => print!("{}, ", cfg.rpc_config.as_ref().unwrap().addr),
+            NodeConfig::Thread(cfg) => print!("{}, ", cfg.rpc_addr().unwrap()),
             _ => (),
         }
     }


### PR DESCRIPTION
1. Add `--disable-rpc` command line switch to `neard run` subcommand.
2. Add `json_rpc` build feature which can be disabled to completely remove RPC endpoint support from the binary.
