### PR TITLE
refactor: remove heavy dependency from vm-logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3633,7 +3633,6 @@ dependencies = [
  "borsh",
  "bs58",
  "byteorder",
- "near-primitives",
  "near-primitives-core",
  "near-runtime-utils",
  "near-vm-errors",

--- a/runtime/near-vm-logic/Cargo.toml
+++ b/runtime/near-vm-logic/Cargo.toml
@@ -21,7 +21,9 @@ serde = { version = "1", features = ["derive"] }
 sha2 = ">=0.8,<0.10"
 sha3 = ">=0.8,<0.10"
 
-near-primitives = { path = "../../core/primitives" }
+# If you want to uncomment this, think twice: `near-primitives` are a heavy dependency,
+# we are intentionally avoiding it here.
+# near-primitives = { path = "../../core/primitives" }
 near-primitives-core = { path = "../../core/primitives-core", version = "0.1.0" }
 near-vm-errors = { path = "../near-vm-errors", version = "3.0.0" }
 near-runtime-utils = { path = "../near-runtime-utils", version = "3.0.0" }

--- a/runtime/near-vm-logic/src/lib.rs
+++ b/runtime/near-vm-logic/src/lib.rs
@@ -11,7 +11,7 @@ mod utils;
 
 pub use context::VMContext;
 pub use dependencies::{External, MemoryLike, ValuePtr};
-pub use logic::{VMLogic, VMOutcome};
+pub use logic::{VMLogic, VMLogicProtocolFeatures, VMOutcome};
 pub use near_primitives_core::config::*;
 pub use near_primitives_core::profile;
 pub use near_primitives_core::types::ProtocolVersion;

--- a/runtime/near-vm-logic/tests/vm_logic_builder.rs
+++ b/runtime/near-vm-logic/tests/vm_logic_builder.rs
@@ -1,13 +1,10 @@
 use near_primitives_core::runtime::fees::RuntimeFeesConfig;
 use near_vm_logic::mocks::mock_external::MockedExternal;
 use near_vm_logic::mocks::mock_memory::MockedMemory;
-use near_vm_logic::VMContext;
 use near_vm_logic::{VMConfig, VMLogic};
+use near_vm_logic::{VMContext, VMLogicProtocolFeatures};
 
 use near_vm_logic::types::PromiseResult;
-use near_vm_logic::ProtocolVersion;
-
-pub(crate) const LATEST_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::MAX;
 
 pub struct VMLogicBuilder {
     pub ext: MockedExternal,
@@ -15,7 +12,7 @@ pub struct VMLogicBuilder {
     pub fees_config: RuntimeFeesConfig,
     pub promise_results: Vec<PromiseResult>,
     pub memory: MockedMemory,
-    pub current_protocol_version: ProtocolVersion,
+    pub protocol_features: VMLogicProtocolFeatures,
 }
 
 impl Default for VMLogicBuilder {
@@ -26,14 +23,17 @@ impl Default for VMLogicBuilder {
             ext: MockedExternal::default(),
             memory: MockedMemory::default(),
             promise_results: vec![],
-            current_protocol_version: LATEST_PROTOCOL_VERSION,
+            protocol_features: VMLogicProtocolFeatures {
+                implicit_account_creation: true,
+                allow_create_account_on_delete: true,
+            },
         }
     }
 }
 
 impl VMLogicBuilder {
     pub fn build(&mut self, context: VMContext) -> VMLogic<'_> {
-        VMLogic::new_with_protocol_version(
+        VMLogic::new_with_protocol_features(
             &mut self.ext,
             context,
             &self.config,
@@ -41,7 +41,7 @@ impl VMLogicBuilder {
             &self.promise_results,
             &mut self.memory,
             Default::default(),
-            self.current_protocol_version,
+            self.protocol_features,
         )
     }
     #[allow(dead_code)]
@@ -52,7 +52,10 @@ impl VMLogicBuilder {
             ext: MockedExternal::default(),
             memory: MockedMemory::default(),
             promise_results: vec![],
-            current_protocol_version: LATEST_PROTOCOL_VERSION,
+            protocol_features: VMLogicProtocolFeatures {
+                implicit_account_creation: true,
+                allow_create_account_on_delete: true,
+            },
         }
     }
 }

--- a/runtime/near-vm-runner/src/lib.rs
+++ b/runtime/near-vm-runner/src/lib.rs
@@ -21,6 +21,10 @@ mod wasmtime_runner;
 #[cfg(feature = "wasmer1_vm")]
 mod wasmer1_runner;
 
+use near_primitives::checked_feature;
+use near_primitives::version::is_implicit_account_creation_enabled;
+use near_vm_logic::{ProtocolVersion, VMLogicProtocolFeatures};
+
 pub use near_vm_errors::VMError;
 pub use preload::{ContractCallPrepareRequest, ContractCallPrepareResult, ContractCaller};
 pub use runner::compile_module;
@@ -36,3 +40,18 @@ pub use cache::MockCompiledContractCache;
 // detail of `near-vm-runner`. Public API like `run` should not expose VMKind.
 pub use runner::run_vm;
 pub use vm_kind::VMKind;
+
+/// This is a bit of an odd place to convert from [`ProtocolVersion`] to [`VMLogicProtocolFeatures`].
+/// Ideally, we'd let the caller to pass [`VMLogicProtocolFeatures`] in. We, however, do need
+/// to know about [`ProtocolVersion`] anyway to create the appropriate subset of host function
+/// imports, so we might as well decide about [`VMLogicProtocolFeatures`].
+fn vm_logic_protocol_features(protocol_version: ProtocolVersion) -> VMLogicProtocolFeatures {
+    VMLogicProtocolFeatures {
+        implicit_account_creation: is_implicit_account_creation_enabled(protocol_version),
+        allow_create_account_on_delete: checked_feature!(
+            "protocol_feature_allow_create_account_on_delete",
+            AllowCreateAccountOnDelete,
+            protocol_version
+        ),
+    }
+}

--- a/runtime/near-vm-runner/src/wasmer1_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer1_runner.rs
@@ -1,5 +1,5 @@
 use crate::errors::IntoVMError;
-use crate::{cache, imports};
+use crate::{cache, imports, vm_logic_protocol_features};
 use near_primitives::contract::ContractCode;
 use near_primitives::runtime::fees::RuntimeFeesConfig;
 use near_primitives::{profile::ProfileData, types::CompiledContractCache};
@@ -231,7 +231,7 @@ pub fn run_wasmer1(
     // Note that we don't clone the actual backing memory, just increase the RC.
     let memory_copy = memory.clone();
 
-    let mut logic = VMLogic::new_with_protocol_version(
+    let mut logic = VMLogic::new_with_protocol_features(
         ext,
         context,
         wasm_config,
@@ -239,7 +239,7 @@ pub fn run_wasmer1(
         promise_results,
         &mut memory,
         profile,
-        current_protocol_version,
+        vm_logic_protocol_features(current_protocol_version),
     );
 
     // TODO: remove, as those costs are incorrectly computed, and we shall account it on deployment.
@@ -355,7 +355,7 @@ pub(crate) fn run_wasmer1_module<'a>(
     // Note that we don't clone the actual backing memory, just increase the RC.
     let memory_copy = memory.clone();
 
-    let mut logic = VMLogic::new_with_protocol_version(
+    let mut logic = VMLogic::new_with_protocol_features(
         ext,
         context,
         wasm_config,
@@ -363,7 +363,7 @@ pub(crate) fn run_wasmer1_module<'a>(
         promise_results,
         memory,
         profile,
-        current_protocol_version,
+        vm_logic_protocol_features(current_protocol_version),
     );
 
     let import = imports::build_wasmer1(store, memory_copy, &mut logic, current_protocol_version);

--- a/runtime/near-vm-runner/src/wasmer_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer_runner.rs
@@ -1,6 +1,6 @@
 use crate::errors::IntoVMError;
 use crate::memory::WasmerMemory;
-use crate::{cache, imports};
+use crate::{cache, imports, vm_logic_protocol_features};
 use near_primitives::contract::ContractCode;
 use near_primitives::runtime::fees::RuntimeFeesConfig;
 use near_primitives::{
@@ -257,7 +257,7 @@ pub fn run_wasmer<'a>(
     // Note that we don't clone the actual backing memory, just increase the RC.
     let memory_copy = memory.clone();
 
-    let mut logic = VMLogic::new_with_protocol_version(
+    let mut logic = VMLogic::new_with_protocol_features(
         ext,
         context,
         wasm_config,
@@ -265,7 +265,7 @@ pub fn run_wasmer<'a>(
         promise_results,
         &mut memory,
         profile,
-        current_protocol_version,
+        vm_logic_protocol_features(current_protocol_version),
     );
 
     // TODO: remove, as those costs are incorrectly computed, and we shall account it on deployment.
@@ -332,7 +332,7 @@ pub(crate) fn run_wasmer0_module<'a>(
     // Note that we don't clone the actual backing memory, just increase the RC.
     let memory_copy = memory.clone();
 
-    let mut logic = VMLogic::new_with_protocol_version(
+    let mut logic = VMLogic::new_with_protocol_features(
         ext,
         context,
         wasm_config,
@@ -340,7 +340,7 @@ pub(crate) fn run_wasmer0_module<'a>(
         promise_results,
         memory,
         profile,
-        current_protocol_version,
+        vm_logic_protocol_features(current_protocol_version),
     );
 
     let import_object = imports::build_wasmer(memory_copy, &mut logic, current_protocol_version);

--- a/runtime/near-vm-runner/src/wasmtime_runner.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner.rs
@@ -4,7 +4,7 @@ use wasmtime::Module;
 #[cfg(feature = "wasmtime_vm")]
 pub mod wasmtime_runner {
     use crate::errors::IntoVMError;
-    use crate::{imports, prepare};
+    use crate::{imports, prepare, vm_logic_protocol_features};
     use near_primitives::contract::ContractCode;
     use near_primitives::runtime::fees::RuntimeFeesConfig;
     use near_primitives::{
@@ -175,7 +175,7 @@ pub mod wasmtime_runner {
         // Note that we don't clone the actual backing memory, just increase the RC.
         let memory_copy = memory.clone();
         let mut linker = Linker::new(&store);
-        let mut logic = VMLogic::new_with_protocol_version(
+        let mut logic = VMLogic::new_with_protocol_features(
             ext,
             context,
             wasm_config,
@@ -183,7 +183,7 @@ pub mod wasmtime_runner {
             promise_results,
             &mut memory,
             profile,
-            current_protocol_version,
+            vm_logic_protocol_features(current_protocol_version),
         );
         // TODO: remove, as those costs are incorrectly computed, and we shall account it on deployment.
         if logic.add_contract_compile_fee(code.code.len() as u64).is_err() {


### PR DESCRIPTION
primitives are much heavier that primitives-core, so it's best to avoid
depending on them. In this case, the dependency was mostly accidental,
as we only used primitives for ProtocolVersion decisions.

The idea here is exposte the set of knobs to let the caller make
decisions about how protocol version affects VMLogic behavior. As a side
benefit, VMLogic is now oblivious of the protocol version concept at
all.