### PR TITLE
Introduce ‘max_gas_burnt_view’ client config and command line flag

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1707,6 +1707,7 @@ mod test {
                     vec![],
                     vec![],
                     None,
+                    None,
                 )) as Arc<dyn RuntimeAdapter>
             })
             .collect()

--- a/chain/client/tests/challenges.rs
+++ b/chain/client/tests/challenges.rs
@@ -277,6 +277,7 @@ fn test_verify_chunk_invalid_state_challenge() {
         vec![],
         vec![],
         None,
+        None,
     ))];
     let mut env = TestEnv::new_with_runtime(ChainGenesis::test(), 1, 1, runtimes);
     let signer = InMemorySigner::from_seed("test0", KeyType::ED25519, "test0");
@@ -570,6 +571,7 @@ fn test_fishermen_challenge() {
             vec![],
             vec![],
             None,
+            None,
         ))
     };
     let runtime1 = create_runtime();
@@ -632,6 +634,7 @@ fn test_challenge_in_different_epoch() {
         vec![],
         vec![],
         None,
+        None,
     ));
     let runtime2 = Arc::new(nearcore::NightshadeRuntime::new(
         Path::new("."),
@@ -639,6 +642,7 @@ fn test_challenge_in_different_epoch() {
         &genesis.clone(),
         vec![],
         vec![],
+        None,
         None,
     ));
     let runtimes: Vec<Arc<dyn RuntimeAdapter>> = vec![runtime1, runtime2];

--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -85,6 +85,7 @@ pub fn create_nightshade_runtimes(genesis: &Genesis, n: usize) -> Vec<Arc<dyn Ru
                 vec![],
                 vec![],
                 None,
+                None,
             )) as Arc<dyn RuntimeAdapter>
         })
         .collect()
@@ -1804,6 +1805,7 @@ fn test_incorrect_validator_key_produce_block() {
         vec![],
         vec![],
         None,
+        None,
     ));
     let signer = Arc::new(InMemoryValidatorSigner::from_seed("test0", KeyType::ED25519, "seed"));
     let mut config = ClientConfig::test(true, 10, 20, 2, false, true);
@@ -2938,6 +2940,7 @@ mod protocol_feature_restore_receipts_after_fix_tests {
             &genesis,
             vec![],
             vec![],
+            None,
             None,
         );
         // TODO #4305: get directly from NightshadeRuntime

--- a/chain/client/tests/sandbox.rs
+++ b/chain/client/tests/sandbox.rs
@@ -37,6 +37,7 @@ fn test_setup() -> (TestEnv, InMemorySigner) {
             vec![],
             vec![],
             None,
+            None,
         )) as Arc<dyn RuntimeAdapter>],
     );
     let signer = InMemorySigner::from_seed("test0", KeyType::ED25519, "test0");

--- a/chain/indexer/src/lib.rs
+++ b/chain/indexer/src/lib.rs
@@ -18,6 +18,7 @@ pub use self::streamer::{
     StreamerMessage,
 };
 pub use near_primitives;
+use near_primitives::types::Gas;
 
 /// Config wrapper to simplify signature and usage of `nearcore::init_configs`
 /// function by making args more explicit via struct
@@ -39,6 +40,8 @@ pub struct InitConfigArgs {
     pub download: bool,
     /// Specify a custom download URL for the genesis-file.
     pub download_genesis_url: Option<String>,
+    /// Specify a custom max_gas_burnt_view limit.
+    pub max_gas_burnt_view: Option<Gas>,
 }
 
 /// Enum to define a mode of syncing for NEAR Indexer
@@ -135,5 +138,6 @@ pub fn indexer_init_configs(dir: &std::path::PathBuf, params: InitConfigArgs) {
         params.genesis.as_deref(),
         params.download,
         params.download_genesis_url.as_deref(),
+        params.max_gas_burnt_view,
     )
 }

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
-use near_primitives::types::{AccountId, BlockHeightDelta, NumBlocks, NumSeats, ShardId};
+use near_primitives::types::{AccountId, BlockHeightDelta, Gas, NumBlocks, NumSeats, ShardId};
 use near_primitives::version::Version;
 
 pub const TEST_STATE_SYNC_TIMEOUT: u64 = 5;
@@ -97,6 +97,10 @@ pub struct ClientConfig {
     pub view_client_throttle_period: Duration,
     /// Upper bound of the byte size of contract state that is still viewable. None is no limit
     pub trie_viewer_state_size_limit: Option<u64>,
+    /// Max burnt gas per view method.  If present, overrides value stored in
+    /// genesis file.  The value only affects the RPCs without influencing the
+    /// protocol thus changing it per-node doesn’t affect the blockchain.
+    pub max_gas_burnt_view: Option<Gas>,
 }
 
 impl ClientConfig {
@@ -154,6 +158,7 @@ impl ClientConfig {
             epoch_sync_enabled,
             view_client_throttle_period: Duration::from_secs(1),
             trie_viewer_state_size_limit: None,
+            max_gas_burnt_view: None,
         }
     }
 }

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -67,6 +67,7 @@ impl GenesisBuilder {
             vec![],
             vec![],
             None,
+            None,
         );
         Self {
             home_dir: home_dir.to_path_buf(),

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -268,6 +268,7 @@ pub fn start_with_config(
         config.client_config.tracked_accounts.clone(),
         config.client_config.tracked_shards.clone(),
         config.client_config.trie_viewer_state_size_limit,
+        config.client_config.max_gas_burnt_view,
     ));
 
     let telemetry = TelemetryActor::new(config.telemetry_config.clone()).start();

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -112,6 +112,7 @@ pub fn migrate_12_to_13(path: &String, near_config: &NearConfig) {
             near_config.client_config.tracked_accounts.clone(),
             near_config.client_config.tracked_shards.clone(),
             None,
+            None,
         );
         let mut store_update = store.store_update();
         store_update.delete_all(DBCol::ColTransactionResult);
@@ -221,6 +222,7 @@ pub fn migrate_19_to_20(path: &String, near_config: &NearConfig) {
             near_config.client_config.tracked_accounts.clone(),
             near_config.client_config.tracked_shards.clone(),
             None,
+            None,
         );
         let shard_id = 0;
         // This is hardcoded for mainnet specifically. Blocks with lower heights have been checked.
@@ -286,6 +288,7 @@ pub fn migrate_22_to_23(path: &String, near_config: &NearConfig) {
             &near_config.genesis,
             near_config.client_config.tracked_accounts.clone(),
             near_config.client_config.tracked_shards.clone(),
+            None,
             None,
         );
         let shard_id = 0;

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -122,7 +122,10 @@ impl EpochInfoProvider for SafeEpochManager {
 /// TODO: this possibly should be merged with the runtime cargo or at least reconciled on the interfaces.
 pub struct NightshadeRuntime {
     genesis_config: GenesisConfig,
-    genesis_runtime_config: Arc<RuntimeConfig>,
+    /// Runtime configuration.  Note that it may be slightly different than
+    /// `genesis_config.runtime_config`.  Consider `max_gas_burnt_view` value
+    /// which may be configured per node.
+    runtime_config: Arc<RuntimeConfig>,
 
     store: Arc<Store>,
     tries: ShardTries,
@@ -142,11 +145,18 @@ impl NightshadeRuntime {
         initial_tracking_accounts: Vec<AccountId>,
         initial_tracking_shards: Vec<ShardId>,
         trie_viewer_state_size_limit: Option<u64>,
+        max_gas_burnt_view: Option<Gas>,
     ) -> Self {
         let runtime = Runtime::new();
-        let trie_viewer = TrieViewer::new_with_state_size_limit(trie_viewer_state_size_limit);
+        let trie_viewer = TrieViewer::new(trie_viewer_state_size_limit, max_gas_burnt_view);
         let genesis_config = genesis.config.clone();
-        let genesis_runtime_config = Arc::new(genesis_config.runtime_config.clone());
+        let runtime_config = Arc::new({
+            let mut cfg = genesis_config.runtime_config.clone();
+            if let Some(gas) = max_gas_burnt_view {
+                cfg.wasm_config.limit_config.max_gas_burnt_view = gas;
+            }
+            cfg
+        });
         let num_shards = genesis.config.num_block_producer_seats_per_shard.len() as NumShards;
         let initial_epoch_config = EpochConfig::from(&genesis_config);
         let reward_calculator = RewardCalculator::new(&genesis_config);
@@ -175,7 +185,7 @@ impl NightshadeRuntime {
         );
         NightshadeRuntime {
             genesis_config,
-            genesis_runtime_config,
+            runtime_config,
             store,
             tries,
             runtime,
@@ -420,7 +430,7 @@ impl NightshadeRuntime {
             random_seed,
             current_protocol_version,
             config: RuntimeConfig::from_protocol_version(
-                &self.genesis_runtime_config,
+                &self.runtime_config,
                 current_protocol_version,
             ),
             cache: Some(Arc::new(StoreCompiledContractCache { store: self.store.clone() })),
@@ -552,10 +562,8 @@ impl RuntimeAdapter for NightshadeRuntime {
         verify_signature: bool,
         current_protocol_version: ProtocolVersion,
     ) -> Result<Option<InvalidTxError>, Error> {
-        let runtime_config = RuntimeConfig::from_protocol_version(
-            &self.genesis_runtime_config,
-            current_protocol_version,
-        );
+        let runtime_config =
+            RuntimeConfig::from_protocol_version(&self.runtime_config, current_protocol_version);
 
         if let Some(state_root) = state_root {
             let shard_id = self.account_id_to_shard_id(&transaction.transaction.signer_id);
@@ -624,10 +632,8 @@ impl RuntimeAdapter for NightshadeRuntime {
         let mut transactions = vec![];
         let mut num_checked_transactions = 0;
 
-        let runtime_config = RuntimeConfig::from_protocol_version(
-            &self.genesis_runtime_config,
-            current_protocol_version,
-        );
+        let runtime_config =
+            RuntimeConfig::from_protocol_version(&self.runtime_config, current_protocol_version);
 
         while total_gas_burnt < transactions_gas_limit {
             if let Some(iter) = pool_iterator.next() {
@@ -1507,8 +1513,17 @@ impl RuntimeAdapter for NightshadeRuntime {
         config.protocol_version = protocol_version;
         // Currently only runtime config is changed through protocol upgrades.
         let runtime_config =
-            RuntimeConfig::from_protocol_version(&self.genesis_runtime_config, protocol_version);
-        config.runtime_config = (*runtime_config).clone();
+            RuntimeConfig::from_protocol_version(&self.runtime_config, protocol_version);
+        // If we were initialised with a custom max_gas_burnt_view (see new
+        // function), bring back the value from genesis configuration.  Since
+        // max_gas_burnt_view never changes as a result of protocol upgrade, we
+        // can be sure that this value will be correct.
+        config.runtime_config = {
+            let mut cfg = (*runtime_config).clone();
+            cfg.wasm_config.limit_config.max_gas_burnt_view =
+                config.runtime_config.wasm_config.limit_config.max_gas_burnt_view;
+            cfg
+        };
         Ok(config)
     }
 
@@ -1757,6 +1772,7 @@ mod test {
                 &genesis,
                 initial_tracked_accounts,
                 initial_tracked_shards,
+                None,
                 None,
             );
             let (_store, state_roots) = runtime.genesis_state();

--- a/nearcore/tests/economics.rs
+++ b/nearcore/tests/economics.rs
@@ -32,6 +32,7 @@ fn setup_env(f: &mut dyn FnMut(&mut Genesis) -> ()) -> (TestEnv, FeeHelper) {
         vec![],
         vec![],
         None,
+        None,
     ))];
     let env = TestEnv::new_with_runtime(ChainGenesis::from(&genesis), 1, 1, runtimes);
     (env, fee_helper)

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -1,6 +1,6 @@
 use super::{DEFAULT_HOME, NEARD_VERSION, NEARD_VERSION_STRING, PROTOCOL_VERSION};
 use clap::{AppSettings, Clap};
-use near_primitives::types::{NumSeats, NumShards};
+use near_primitives::types::{Gas, NumSeats, NumShards};
 use nearcore::get_store_path;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
@@ -123,6 +123,10 @@ pub(super) struct InitCmd {
     /// Specify private key generated from seed (TESTING ONLY).
     #[clap(long)]
     test_seed: Option<String>,
+    /// Customize max_gas_burnt_view runtime limit.  If not specified, value
+    /// from genesis configuration will be taken.
+    #[clap(long)]
+    max_gas_burnt_view: Option<Gas>,
 }
 
 impl InitCmd {
@@ -145,6 +149,7 @@ impl InitCmd {
             self.genesis.as_deref(),
             self.download_genesis,
             self.download_genesis_url.as_deref(),
+            self.max_gas_burnt_view,
         );
     }
 }
@@ -179,6 +184,11 @@ pub(super) struct RunCmd {
     /// Customize telemetry url.
     #[clap(long)]
     telemetry_url: Option<String>,
+    /// Customize max_gas_burnt_view runtime limit.  If not specified, either
+    /// value given at ‘init’ (i.e. present in config.json) or one from genesis
+    /// configuration will be taken.
+    #[clap(long)]
+    max_gas_burnt_view: Option<Gas>,
 }
 
 impl RunCmd {
@@ -219,6 +229,9 @@ impl RunCmd {
         }
         if self.archive {
             near_config.client_config.archive = true;
+        }
+        if self.max_gas_burnt_view.is_some() {
+            near_config.client_config.max_gas_burnt_view = self.max_gas_burnt_view;
         }
 
         #[cfg(feature = "sandbox")]

--- a/nightly/tests_for_nayduck.txt
+++ b/nightly/tests_for_nayduck.txt
@@ -29,6 +29,7 @@ pytest --timeout=360 sanity/block_sync_archival.py
 pytest --timeout=240 sanity/validator_switch.py
 pytest --timeout=240 sanity/restaked.py
 pytest --timeout=240 sanity/rpc_state_changes.py
+pytest sanity/rpc_max_gas_burnt.py
 pytest sanity/rpc_tx_status.py
 pytest --timeout=120 sanity/garbage_collection.py
 pytest --timeout=120 sanity/garbage_collection1.py

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -810,8 +810,13 @@ def apply_config_changes(node_dir, client_config_change):
     with open(fname) as f:
         config_json = json.loads(f.read())
 
+    # ClientConfig keys which are valid but may be missing from the config.json
+    # file.  At the moment it’s only max_gas_burnt_view which is an Option and
+    # None by default.  If None, the key is not present in the file.
+    allowed_missing_configs = ('max_gas_burnt_view',)
+
     for k, v in client_config_change.items():
-        assert k in config_json
+        assert k in allowed_missing_configs or k in config_json
         if isinstance(v, dict):
             for key, value in v.items():
                 assert key in config_json[k], key

--- a/pytest/tests/sanity/rpc_max_gas_burnt.py
+++ b/pytest/tests/sanity/rpc_max_gas_burnt.py
@@ -1,0 +1,68 @@
+"""Test max_gas_burnt_view client configuration.
+
+Spins up two nodes with different max_gas_burnt_view client configuration,
+deploys a smart contract and finally calls a view function against both nodes
+expecting the one with low max_gas_burnt_view limit to fail.
+"""
+
+import sys
+import base58
+import base64
+import json
+
+sys.path.append('lib')
+from cluster import start_cluster
+from utils import load_binary_file
+import transaction
+
+def test_max_gas_burnt_view():
+    nodes = start_cluster(2, 0, 1,
+                          config=None,
+                          genesis_config_changes=[],
+                          client_config_changes={
+                              1: {'max_gas_burnt_view': int(5e10)}
+                          })
+
+    contract_key = nodes[0].signer_key
+    contract = load_binary_file(
+        '../runtime/near-test-contracts/res/test_contract_rs.wasm')
+
+    # Deploy the fib smart contract
+    status = nodes[0].get_status()
+    latest_block_hash = status['sync_info']['latest_block_hash']
+    deploy_contract_tx = transaction.sign_deploy_contract_tx(
+        contract_key, contract, 10,
+        base58.b58decode(latest_block_hash.encode('utf8')))
+    deploy_contract_response = nodes[0].send_tx_and_wait(deploy_contract_tx, 10)
+
+    def call_fib(node, n):
+        args = base64.b64encode(bytes([n])).decode('ascii')
+        return node.call_function(contract_key.account_id, 'fibonacci', args,
+                                  timeout=10).get('result')
+
+    # Call view function of the smart contract via the first node.  This should
+    # succeed.
+    result = call_fib(nodes[0], 25)
+    assert 'result' in result and 'error' not in result, (
+        'Expected "result" and no "error" in response, got: {}'.format(result))
+    n = int.from_bytes(bytes(result['result']), 'little')
+    assert n == 75025, 'Expected result to be 75025 but got: {}'.format(n)
+
+    # Same but against the second node.  This should fail because of gas limit.
+    result = call_fib(nodes[1], 25)
+    assert 'result' not in result and 'error' in result, (
+        'Expected "error" and no "result" in response, got: {}'.format(result))
+    error = result['error']
+    assert 'HostError(GasLimitExceeded)' in error, (
+        'Expected error due to GasLimitExceeded but got: {}'.format(error))
+
+    # It should still succeed for small arguments.
+    result = call_fib(nodes[1], 5)
+    assert 'result' in result and 'error' not in result, (
+        'Expected "result" and no "error" in response, got: {}'.format(result))
+    n = int.from_bytes(bytes(result['result']), 'little')
+    assert n == 5, 'Expected result to be 5 but got: {}'.format(n)
+
+
+if __name__ == '__main__':
+    test_max_gas_burnt_view()

--- a/runtime/near-test-contracts/test-contract-rs/src/lib.rs
+++ b/runtime/near-test-contracts/test-contract-rs/src/lib.rs
@@ -494,6 +494,30 @@ pub unsafe fn sum_n() {
     value_return(data.len() as u64, data.as_ptr() as u64);
 }
 
+/// Calculates Fibonacci numbers in inefficient way.  Used to burn gas for the
+/// sanity/max_gas_burnt_view.py test.  The implementation has exponential
+/// complexity (1.62^n to be exact) so even small increase in argument result in
+/// large increase in gas use.
+#[no_mangle]
+pub unsafe fn fibonacci() {
+    input(0);
+    if register_len(0) != 1 {
+        panic()
+    }
+    let mut n: u8 = 0;
+    read_register(0, &mut n as *mut u8 as u64);
+    let data = fib(n).to_le_bytes();
+    value_return(data.len() as u64, data.as_ptr() as u64);
+}
+
+fn fib(n: u8) -> u64 {
+    if n < 2 {
+        n as u64
+    } else {
+        fib(n - 2) + fib(n - 1)
+    }
+}
+
 #[no_mangle]
 pub unsafe fn insert_strings() {
     input(0);

--- a/test-utils/state-viewer/src/main.rs
+++ b/test-utils/state-viewer/src/main.rs
@@ -64,6 +64,7 @@ fn load_trie_stop_at_height(
         near_config.client_config.tracked_accounts.clone(),
         near_config.client_config.tracked_shards.clone(),
         None,
+        near_config.client_config.max_gas_burnt_view,
     );
     let head = chain_store.head().unwrap();
     let last_block = match mode {
@@ -121,6 +122,7 @@ fn print_chain(
         near_config.client_config.tracked_accounts.clone(),
         near_config.client_config.tracked_shards.clone(),
         None,
+        near_config.client_config.max_gas_burnt_view,
     );
     let mut account_id_to_blocks = HashMap::new();
     let mut cur_epoch_id = None;
@@ -191,6 +193,7 @@ fn replay_chain(
         near_config.client_config.tracked_accounts.clone(),
         near_config.client_config.tracked_shards.clone(),
         None,
+        near_config.client_config.max_gas_burnt_view,
     );
     for height in start_height..=end_height {
         if let Ok(block_hash) = chain_store.get_block_hash_by_height(height) {
@@ -222,6 +225,7 @@ fn apply_block_at_height(
         near_config.client_config.tracked_accounts.clone(),
         near_config.client_config.tracked_shards.clone(),
         None,
+        near_config.client_config.max_gas_burnt_view,
     ));
     let block_hash = chain_store.get_block_hash_by_height(height).unwrap();
     let block = chain_store.get_block(&block_hash).unwrap().clone();

--- a/test-utils/state-viewer/src/state_dump.rs
+++ b/test-utils/state-viewer/src/state_dump.rs
@@ -91,8 +91,15 @@ mod test {
         genesis.config.num_block_producer_seats_per_shard = vec![2];
         genesis.config.epoch_length = epoch_length;
         let store = create_test_store();
-        let nightshade_runtime =
-            NightshadeRuntime::new(Path::new("."), store.clone(), &genesis, vec![], vec![], None);
+        let nightshade_runtime = NightshadeRuntime::new(
+            Path::new("."),
+            store.clone(),
+            &genesis,
+            vec![],
+            vec![],
+            None,
+            None,
+        );
         let runtimes: Vec<Arc<dyn RuntimeAdapter>> = vec![Arc::new(nightshade_runtime)];
         let mut chain_genesis = ChainGenesis::test();
         chain_genesis.epoch_length = epoch_length;
@@ -133,8 +140,15 @@ mod test {
         );
         let last_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap().clone();
         let state_roots = last_block.chunks().iter().map(|chunk| chunk.prev_state_root()).collect();
-        let runtime =
-            NightshadeRuntime::new(Path::new("."), store.clone(), &genesis, vec![], vec![], None);
+        let runtime = NightshadeRuntime::new(
+            Path::new("."),
+            store.clone(),
+            &genesis,
+            vec![],
+            vec![],
+            None,
+            None,
+        );
         let new_genesis =
             state_dump(runtime, state_roots, last_block.header().clone(), &genesis.config);
         assert_eq!(new_genesis.config.validators.len(), 2);
@@ -163,8 +177,15 @@ mod test {
         let head = env.clients[0].chain.head().unwrap();
         let last_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap().clone();
         let state_roots = last_block.chunks().iter().map(|chunk| chunk.prev_state_root()).collect();
-        let runtime =
-            NightshadeRuntime::new(Path::new("."), store.clone(), &genesis, vec![], vec![], None);
+        let runtime = NightshadeRuntime::new(
+            Path::new("."),
+            store.clone(),
+            &genesis,
+            vec![],
+            vec![],
+            None,
+            None,
+        );
         let new_genesis =
             state_dump(runtime, state_roots, last_block.header().clone(), &genesis.config);
         assert_eq!(
@@ -192,7 +213,7 @@ mod test {
         let store1 = create_test_store();
         let store2 = create_test_store();
         let create_runtime = |store| -> NightshadeRuntime {
-            NightshadeRuntime::new(Path::new("."), store, &genesis, vec![], vec![], None)
+            NightshadeRuntime::new(Path::new("."), store, &genesis, vec![], vec![], None, None)
         };
         let runtimes: Vec<Arc<dyn RuntimeAdapter>> = vec![
             Arc::new(create_runtime(store1.clone())),
@@ -240,8 +261,15 @@ mod test {
         genesis.config.num_block_producer_seats_per_shard = vec![2];
         genesis.config.epoch_length = epoch_length;
         let store = create_test_store();
-        let nightshade_runtime =
-            NightshadeRuntime::new(Path::new("."), store.clone(), &genesis, vec![], vec![], None);
+        let nightshade_runtime = NightshadeRuntime::new(
+            Path::new("."),
+            store.clone(),
+            &genesis,
+            vec![],
+            vec![],
+            None,
+            None,
+        );
         let runtimes: Vec<Arc<dyn RuntimeAdapter>> = vec![Arc::new(nightshade_runtime)];
         let mut chain_genesis = ChainGenesis::test();
         chain_genesis.epoch_length = epoch_length;
@@ -273,8 +301,15 @@ mod test {
         );
         let last_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap().clone();
         let state_roots = last_block.chunks().iter().map(|chunk| chunk.prev_state_root()).collect();
-        let runtime =
-            NightshadeRuntime::new(Path::new("."), store.clone(), &genesis, vec![], vec![], None);
+        let runtime = NightshadeRuntime::new(
+            Path::new("."),
+            store.clone(),
+            &genesis,
+            vec![],
+            vec![],
+            None,
+            None,
+        );
         let new_genesis =
             state_dump(runtime, state_roots, last_block.header().clone(), &genesis.config);
         assert_eq!(new_genesis.config.validators.len(), 2);

--- a/test-utils/store-validator/src/main.rs
+++ b/test-utils/store-validator/src/main.rs
@@ -38,6 +38,7 @@ fn main() {
         near_config.client_config.tracked_accounts.clone(),
         near_config.client_config.tracked_shards.clone(),
         None,
+        None,
     ));
 
     let mut store_validator = StoreValidator::new(

--- a/test-utils/testlib/src/lib.rs
+++ b/test-utils/testlib/src/lib.rs
@@ -35,7 +35,7 @@ pub fn genesis_header(genesis: &Genesis) -> BlockHeader {
     let store = create_test_store();
     let chain_genesis = ChainGenesis::from(genesis);
     let runtime =
-        Arc::new(NightshadeRuntime::new(dir.path(), store, genesis, vec![], vec![], None));
+        Arc::new(NightshadeRuntime::new(dir.path(), store, genesis, vec![], vec![], None, None));
     let chain = Chain::new(runtime, &chain_genesis, DoomslugThresholdMode::TwoThirds).unwrap();
     chain.genesis().clone()
 }
@@ -46,7 +46,7 @@ pub fn genesis_block(genesis: &Genesis) -> Block {
     let store = create_test_store();
     let chain_genesis = ChainGenesis::from(genesis);
     let runtime =
-        Arc::new(NightshadeRuntime::new(dir.path(), store, genesis, vec![], vec![], None));
+        Arc::new(NightshadeRuntime::new(dir.path(), store, genesis, vec![], vec![], None, None));
     let mut chain = Chain::new(runtime, &chain_genesis, DoomslugThresholdMode::TwoThirds).unwrap();
     chain.get_block(&chain.genesis().hash().clone()).unwrap().clone()
 }

--- a/test-utils/testlib/src/runtime_utils.rs
+++ b/test-utils/testlib/src/runtime_utils.rs
@@ -92,7 +92,7 @@ pub fn get_runtime_and_trie() -> (Runtime, ShardTries, StateRoot) {
 
 pub fn get_test_trie_viewer() -> (TrieViewer, TrieUpdate) {
     let (_, tries, root) = get_runtime_and_trie();
-    let trie_viewer = TrieViewer::new_with_state_size_limit(None);
+    let trie_viewer = TrieViewer::default();
     let state_update = tries.new_trie_update(0, root);
     (trie_viewer, state_update)
 }

--- a/test-utils/testlib/src/user/runtime_user.rs
+++ b/test-utils/testlib/src/user/runtime_user.rs
@@ -61,7 +61,7 @@ impl RuntimeUser {
         let runtime_config = Arc::new(client.read().unwrap().runtime_config.clone());
         RuntimeUser {
             signer,
-            trie_viewer: TrieViewer::new_with_state_size_limit(None),
+            trie_viewer: TrieViewer::default(),
             account_id: account_id.to_string(),
             client,
             transaction_results: Default::default(),

--- a/tools/indexer/example/src/configs.rs
+++ b/tools/indexer/example/src/configs.rs
@@ -1,5 +1,7 @@
 use clap::Clap;
 
+use near_indexer::near_primitives::types::Gas;
+
 use tracing_subscriber::EnvFilter;
 
 /// NEAR Indexer Example
@@ -48,6 +50,9 @@ pub(crate) struct InitConfigArgs {
     /// Specify a custom download URL for the genesis-file.
     #[clap(long)]
     pub download_genesis_url: Option<String>,
+    /// Specify a custom max_gas_burnt_view limit.
+    #[clap(long)]
+    pub max_gas_burnt_view: Option<Gas>,
 }
 
 pub(crate) fn init_logging() {
@@ -71,6 +76,7 @@ impl From<InitConfigArgs> for near_indexer::InitConfigArgs {
             genesis: config_args.genesis,
             download: config_args.download,
             download_genesis_url: config_args.download_genesis_url,
+            max_gas_burnt_view: config_args.max_gas_burnt_view,
         }
     }
 }

--- a/tools/restored-receipts-verifier/src/main.rs
+++ b/tools/restored-receipts-verifier/src/main.rs
@@ -66,6 +66,7 @@ fn main() -> Result<()> {
         near_config.client_config.tracked_accounts.clone(),
         near_config.client_config.tracked_shards.clone(),
         None,
+        near_config.client_config.max_gas_burnt_view,
     );
 
     let mut receipts_missing = Vec::<Receipt>::new();


### PR DESCRIPTION
The ‘max_gas_burnt_view’ affects the RPCs only and therefore doesn’t
need to be part of the consensus.  In other words, all nodes could
have this value customised rather than using an agreed upon value
from genesis configuration.

Introduce a ‘max_gas_burnt_view’ field to ClientConfig and
a corresponding flag to ‘init’ and ‘run’ subcommands.  When present,
it will override the limit used by the node ignoring whatever is
stored in genesis configuration.

Fixes: https://github.com/near/nearcore/issues/3080