### PR TITLE
Introduce `TrieRefcountChange` for better readability

### DIFF
--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -409,14 +409,15 @@ pub struct Trie {
     pub counter: TouchedNodesCounter,
 }
 
-/// Stores reference count increase for the given key and value.
+/// Stores reference count change for some Trie key and value.
 #[derive(BorshSerialize, BorshDeserialize, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct TrieRefcountChange {
     /// Hash of TrieKey.
     key_hash: CryptoHash,
     /// Value corresponding to the TrieKey stored in Trie.
     value: Vec<u8>,
-    /// Reference count increase.
+    /// Reference count difference which will be added to the total refcount if it corresponds to
+    /// insertion and subtracted from it in the case of deletion.
     rc: u32,
 }
 

--- a/core/store/src/trie/state_parts.rs
+++ b/core/store/src/trie/state_parts.rs
@@ -227,7 +227,7 @@ mod tests {
 
     use crate::test_utils::{create_tries, gen_changes, test_populate_trie};
     use crate::trie::iterator::CrumbStatus;
-    use crate::trie::ValueHandle;
+    use crate::trie::{TrieRefcountChange, ValueHandle};
 
     use super::*;
 
@@ -260,8 +260,10 @@ mod tests {
                 }
                 Ok(())
             })?;
-            let mut insertions =
-                insertions.into_iter().map(|(k, (v, rc))| (k, v, rc)).collect::<Vec<_>>();
+            let mut insertions = insertions
+                .into_iter()
+                .map(|(k, (v, rc))| TrieRefcountChange { key_hash: k, value: v, rc })
+                .collect::<Vec<_>>();
             insertions.sort();
             Ok(TrieChanges {
                 old_root: Default::default(),
@@ -542,11 +544,11 @@ mod tests {
         let mut map = HashMap::new();
         for changes_set in changes {
             assert!(changes_set.deletions.is_empty(), "state parts only have insertions");
-            for (key, value, rc) in changes_set.insertions {
-                map.entry(key).or_insert_with(|| (value, 0)).1 += rc as i32;
+            for TrieRefcountChange { key_hash, value, rc } in changes_set.insertions {
+                map.entry(key_hash).or_insert_with(|| (value, 0)).1 += rc as i32;
             }
-            for (key, value, rc) in changes_set.deletions {
-                map.entry(key).or_insert_with(|| (value, 0)).1 -= rc as i32;
+            for TrieRefcountChange { key_hash, value, rc } in changes_set.deletions {
+                map.entry(key_hash).or_insert_with(|| (value, 0)).1 -= rc as i32;
             }
         }
         let (insertions, deletions) = Trie::convert_to_insertions_and_deletions(map);


### PR DESCRIPTION
One step to solve https://github.com/near/NEPs/issues/217

It took a while to understand what exactly `(CryptoHash, Vec<u8>, u32)` stores, so I make a struct which self-describes it.