### PR TITLE
Fix ‘bare_trait_objects’ warning

### DIFF
--- a/test-utils/testlib/src/run_nodes.rs
+++ b/test-utils/testlib/src/run_nodes.rs
@@ -35,7 +35,7 @@ fn main() {
     }
     println!();
 
-    let nodes: Vec<_> = nodes.into_iter().map(|cfg| Node::new_sharable(cfg)).collect();
+    let nodes: Vec<_> = nodes.into_iter().map(|cfg| <dyn Node>::new_sharable(cfg)).collect();
 
     // Start nodes.
     for i in 0..num_nodes {


### PR DESCRIPTION
The change fixes the following compiler warning:

    warning: trait objects without an explicit `dyn` are deprecated
      --> test-utils/testlib/src/run_nodes.rs:38:53
       |
    38 |     let nodes: Vec<_> = nodes.into_iter().map(|cfg| Node::new_sharable(cfg)).collect();
       |                                                     ^^^^ help: use `dyn`: `<dyn Node>`
       |
       = note: `#[warn(bare_trait_objects)]` on by default