### PR TITLE
Add `--dry-run` option to `runtime/publish.sh` script

### DIFF
--- a/runtime/publish.sh
+++ b/runtime/publish.sh
@@ -1,10 +1,31 @@
 #!/usr/bin/env bash
-set -ex
-for p in near-runtime-utils near-vm-errors near-vm-logic near-vm-runner near-vm-runner-standalone
-do
-pushd ./${p}
-cargo publish
-popd
-# Sleep a bit to let the previous package upload to crates.io. Otherwise we fail publishing checks.
-sleep 30
+
+set -eu
+
+dry_run_arg=
+if [ "$#" -ge 1 ]; then
+	case "${1-}" in
+	--dry-run)
+		dry_run_arg=--dry-run
+		;;
+	*)
+		echo "${0##*/}: $1: unknown argument" >&2
+		exit 1
+		;;
+	esac
+fi
+
+pwd=$(pwd)
+
+set -x
+
+for pkg in near-runtime-utils near-vm-errors near-vm-logic near-vm-runner \
+           near-vm-runner-standalone; do
+	cd "$pwd/$pkg"
+	cargo publish $dry_run_arg
+	if [ -z "$dry_run_arg" ]; then
+		# Sleep a bit to let the previous package upload to
+		# crates.io.  Otherwise we fail publishing checks.
+		sleep 30
+	fi
 done


### PR DESCRIPTION
The `--dry-run` flag will allow to run `runtime/publish.sh` script to
test whether all the crates are in a state where they can be published.
Note that at the moment, this check fails due to problems described in
the GitHub Issue.

Issue: https://github.com/near/nearcore/issues/4379