### PR TITLE
fix: upgrade wasmer 0.17 to fix memory leak

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6416,9 +6416,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-runtime-core-near"
-version = "0.17.1"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2390b0b8cf58615c2f8b454d9535e1aed1d14c510cc1ce1af806a1992ad53300"
+checksum = "c65db7e27877fb7499a5af9d7ab763bb0ddc78c3d1a6310a8ca6e86e71e532f9"
 dependencies = [
  "bincode",
  "blake3",

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -17,7 +17,7 @@ borsh = "0.8.1"
 serde = { version = "1", features = ["derive"] }
 wasmer-runtime = { version="0.17.1", features = ["default-backend-singlepass"], default-features = false, package = "wasmer-runtime-near", optional = true }
 # Always used even for wasmer 1.0 for validating wasm, will be replaced when refactor prepare.rs
-wasmer-runtime-core = {version = "0.17.1", package = "wasmer-runtime-core-near" }
+wasmer-runtime-core = {version = "0.17.3", package = "wasmer-runtime-core-near" }
 wasmer = { version = "1.0.2", optional = true }
 wasmer-types = { version = "1.0.2", optional = true }
 wasmer-compiler-singlepass = { version = "1.0.2", optional = true, default-features = false, features = ["std", "enable-serde"] } # disable `rayon` feature.


### PR DESCRIPTION
See https://github.com/near/wasmer/commit/aa573888b8ca6832498b4ed16de1486d8037f5ab for the actual fix in wasmer. It is published as https://crates.io/crates/wasmer-runtime-core-near/0.17.3. 

## Test Plan

Testing for memory leaks is a bit hard, as we don't already use asan. So I just verified manually that the node leaks without this patch and dosen't leak with this patch. Old test help to make sure that, functionally, the node behaves the same. 