### PR TITLE
neard: handle SIGINT by stopping the node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3762,6 +3762,7 @@ dependencies = [
  "near-rust-allocator-proxy",
  "nearcore",
  "openssl-probe",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -22,6 +22,7 @@ tracing-subscriber = "0.2.4"
 openssl-probe = "0.1.2"
 near-rust-allocator-proxy = { version = "0.2.8", optional = true }
 lazy_static = "1.4"
+tokio = "1.1"
 
 nearcore = { path = "../nearcore" }
 near-primitives = { path = "../core/primitives" }

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -250,6 +250,8 @@ impl RunCmd {
         let sys = actix::System::new();
         sys.block_on(async move {
             nearcore::start_with_config(home_dir, near_config);
+            tokio::signal::ctrl_c().await.unwrap();
+            actix::System::current().stop();
         });
         sys.run().unwrap();
     }


### PR DESCRIPTION
Stop the system once a SIGINT is received.  This should allow for graceful
termination since System::stop will stop all the arbiters and that in turn
will stop all the actors (leading them through stopping and stopped states
thus allowing all the necessary cleanups).

Fixes: https://github.com/near/nearcore/issues/3266