### PR TITLE
(indexer) Add `json_rpc` feature to enable JSON RPC on demand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3255,7 +3255,7 @@ dependencies = [
 
 [[package]]
 name = "near-indexer"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "actix",
  "async-recursion",

--- a/chain/indexer/CHANGELOG.md
+++ b/chain/indexer/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.10.0
+
+* Add `json_rpc` feature which allows to choose whether to include and run JSON RPC or not. **The `json_rpc` feature is disabled by default**
+
+## Breaking changes
+
+JSON RPC is not a default feature in nearcore by default since nearcore 1.20.0 version. You can enable JSON RPC by using a feature in your dependencies:
+
+Example:
+
+```toml
+[dependencies]
+near-indexer = { git = "https://github.com/near/nearcore", features = ["json_rpc"] }
+```
+
 ## 0.9.2
 
 * Optimize the delayed receipts tracking process introduced in previous version to avoid indexer stuck.

--- a/chain/indexer/Cargo.toml
+++ b/chain/indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-indexer"
-version = "0.9.2"
+version = "0.10.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 
@@ -20,3 +20,6 @@ near-chain-configs = { path = "../../core/chain-configs" }
 near-crypto = { path = "../../core/crypto" }
 near-primitives = { path = "../../core/primitives" }
 node-runtime = { path = "../../runtime/runtime" }
+
+[features]
+json_rpc = ["nearcore/json_rpc"]


### PR DESCRIPTION
Adds a possibility to include JSON RPC in indexer nodes using `near-indexer` as a dependency

```toml
[dependencies]
near-indexer = { git = "https://github.com/near/nearcore", features = ["json_rpc"] }
```

Bump NEAR Indexer Framework version to 0.10.0