### PR TITLE
pytest: fix compilation of test contracts after SDK update

### DIFF
--- a/pytest/empty-contract-rs/src/lib.rs
+++ b/pytest/empty-contract-rs/src/lib.rs
@@ -1,5 +1,2 @@
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::{env, metadata, near_bindgen};
-
-#[global_allocator]
-static ALLOC: near_sdk::wee_alloc::WeeAlloc = near_sdk::wee_alloc::WeeAlloc::INIT;


### PR DESCRIPTION
The near-sdk crate has been updated¹ to define global allocator by
default.  It no longer re-exports `wee_alloc` and there is no longer
a need for contracts to set is as the allocator manually.

This fixes the following tests/contracts/deploy_call_smart_contract.py
failure:

    error[E0433]: failed to resolve: could not find `wee_alloc` in `near_sdk`
     --> src/lib.rs:5:25
      |
    5 | static ALLOC: near_sdk::wee_alloc::WeeAlloc = near_sdk::wee_alloc::WeeAlloc::INIT;
      |                         ^^^^^^^^^ could not find `wee_alloc` in `near_sdk`

¹ https://github.com/near/near-sdk-rs/commit/f69d375fff99f355c4c9b94fb5bd659750b3e31a

Issue: https://github.com/near/nearcore/issues/4432