### PR TITLE
 feat(runtime): expose profile data in execution outcome 

### DIFF
--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -14,6 +14,7 @@ use crate::logging;
 use crate::merkle::MerklePath;
 use crate::serialize::{base64_format, u128_dec_format, u128_dec_format_compatible};
 use crate::types::{AccountId, Balance, Gas, Nonce};
+use near_primitives_core::profile::ProfileData;
 
 pub type LogEntry = String;
 
@@ -356,7 +357,14 @@ pub struct ExecutionOutcome {
 pub enum ExecutionMetadata {
     // V1: Empty Metadata
     ExecutionMetadataV1,
+
+    // V2: With ProfileData
+    ExecutionMetadataV2(ProfileData),
 }
+
+// Metadata SHOULD NOT be mutated after creation
+unsafe impl std::marker::Send for ExecutionMetadata {}
+unsafe impl std::marker::Sync for ExecutionMetadata {}
 
 impl Default for ExecutionMetadata {
     fn default() -> Self {

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -14,7 +14,7 @@ use crate::logging;
 use crate::merkle::MerklePath;
 use crate::serialize::{base64_format, u128_dec_format, u128_dec_format_compatible};
 use crate::types::{AccountId, Balance, Gas, Nonce};
-use near_primitives_core::profile::ProfileData;
+use near_primitives_core::profile::ProfileDataResult;
 
 pub type LogEntry = String;
 
@@ -359,12 +359,8 @@ pub enum ExecutionMetadata {
     ExecutionMetadataV1,
 
     // V2: With ProfileData
-    ExecutionMetadataV2(ProfileData),
+    ExecutionMetadataV2(ProfileDataResult),
 }
-
-// Metadata SHOULD NOT be mutated after creation
-unsafe impl std::marker::Send for ExecutionMetadata {}
-unsafe impl std::marker::Sync for ExecutionMetadata {}
 
 impl Default for ExecutionMetadata {
     fn default() -> Self {

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -1019,7 +1019,6 @@ pub struct ExecutionOutcomeView {
     /// Execution status. Contains the result in case of successful execution.
     pub status: ExecutionStatusView,
     /// Execution metadata, versioned
-    #[serde(skip)]
     pub metadata: ExecutionMetadata,
 }
 

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -264,7 +264,7 @@ impl Runtime {
                         gas_burnt: verification_result.gas_burnt,
                         tokens_burnt: verification_result.burnt_amount,
                         executor_id: transaction.signer_id.clone(),
-                        metadata: ExecutionMetadata::ExecutionMetadataV1,
+                        metadata: ExecutionMetadata::ExecutionMetadataV2(apply_state.profile.cut()),
                     },
                 };
                 Ok((receipt, outcome))


### PR DESCRIPTION
Expose profile data in execution outcome. So it's stored in database and available in RPC response where there's ExecutionOutcome and FinalExecutionOutcome. Exposed format is detailed and the most compact form, indexer/explorer will need to format it as their need, for example one possible formatting: https://github.com/near/nearcore/blob/b0945d609aced3d0b32ba204f55c306f36bd199b/core/primitives-core/src/profile.rs#L94

Test Plan
---------
CI