### PR TITLE
chore: modify stale bot configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,6 +1,6 @@
 issues:
   # Number of days of inactivity before an issue or PR becomes stale
-  daysUntilStale: 60
+  daysUntilStale: 90
 
   # Number of days of inactivity before a stale issue or PR is closed
   daysUntilClose: 7
@@ -8,6 +8,7 @@ issues:
   # Issues or PRs with these labels will never be considered stale
   exemptLabels:
     - S-pinned
+    - S-blocked
     - A-security
 
   # Label to use when marking an issue as stale
@@ -38,6 +39,7 @@ pulls:
   # Issues or PRs with these labels will never be considered stale
   exemptLabels:
     - S-pinned
+    - S-blocked
     - A-security
 
   # Label to use when marking an issue as stale
@@ -46,7 +48,7 @@ pulls:
   # Comment to post when marking an issue as stale. Set to `false` to disable
   markComment: >
     This PR has been automatically marked as stale because it has not had
-    recent activity in the 2 weeks. 
+    recent activity in the 2 weeks.
 
     It will be closed in 3 days if no further activity occurs.
 

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -3,7 +3,7 @@ issues:
   daysUntilStale: 90
 
   # Number of days of inactivity before a stale issue or PR is closed
-  daysUntilClose: 7
+  daysUntilClose: false
 
   # Issues or PRs with these labels will never be considered stale
   exemptLabels:
@@ -23,18 +23,12 @@ issues:
 
     Thank you for your contributions.
 
-  closeComment: >
-    This issue has been automatically closed as there was no updates
-    after being inactive for 2 months and stale for additional week.
-
-    Thank you for your contributions.
-
 pulls:
   # Number of days of inactivity before an issue or PR becomes stale
   daysUntilStale: 14
 
-  # Number of days of inactivity before a stale issue or PR is closed
-  daysUntilClose: 3
+  # Number of days of inactivity before a stale issue or PR is closed.
+  daysUntilClose: false
 
   # Issues or PRs with these labels will never be considered stale
   exemptLabels:
@@ -51,12 +45,5 @@ pulls:
     recent activity in the 2 weeks.
 
     It will be closed in 3 days if no further activity occurs.
-
-    Thank you for your contributions.
-
-  # Comment to post when closing a stale issue. Set to `false` to disable
-  closeComment: >
-    This PR has been automatically closed as there was no updates
-    after being inactive for 2 weeks and stale for additional 3 days.
 
     Thank you for your contributions.


### PR DESCRIPTION
Change days until stale to be longer (sorry for the opposite suggestion earlier). Also @chefsale my experience so far is that it seems that we don't actually need the bot to automatically close the issue. What we want is for the bot to ping when an issue becomes stale so that we can do some manual triage. Is it possible to configure the bot that way?