### PR TITLE
cli: unix: catch SIGTERM in addition to SIGINT and terminate gracefully

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3758,6 +3758,7 @@ version = "1.2.0"
 dependencies = [
  "actix",
  "clap 3.0.0-beta.2",
+ "futures",
  "git-version",
  "lazy_static",
  "near-performance-metrics",

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -23,6 +23,7 @@ openssl-probe = "0.1.2"
 near-rust-allocator-proxy = { version = "0.2.8", optional = true }
 lazy_static = "1.4"
 tokio = "1.1"
+futures = "0.3"
 
 nearcore = { path = "../nearcore" }
 near-primitives = { path = "../core/primitives" }

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -277,7 +277,7 @@ impl RunCmd {
                 tokio::signal::ctrl_c().await.unwrap();
                 "Ctrl+C"
             };
-            info!("Got {}, stopping", sig);
+            info!(target: "neard", "Got {}, stopping", sig);
             actix::System::current().stop();
         });
         sys.run().unwrap();

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -1,5 +1,6 @@
 use super::{DEFAULT_HOME, NEARD_VERSION, NEARD_VERSION_STRING, PROTOCOL_VERSION};
 use clap::{AppSettings, Clap};
+use futures::future::FutureExt;
 use near_primitives::types::{Gas, NumSeats, NumShards};
 use nearcore::get_store_path;
 use std::net::SocketAddr;
@@ -263,8 +264,20 @@ impl RunCmd {
         let sys = actix::System::new();
         sys.block_on(async move {
             nearcore::start_with_config(home_dir, near_config);
-            tokio::signal::ctrl_c().await.unwrap();
-            info!("Got Ctrl+C, stopping");
+
+            let sig = if cfg!(unix) {
+                use tokio::signal::unix::{signal, SignalKind};
+                let mut sigint = signal(SignalKind::interrupt()).unwrap();
+                let mut sigterm = signal(SignalKind::terminate()).unwrap();
+                futures::select! {
+                    _ = sigint .recv().fuse() => "SIGINT",
+                    _ = sigterm.recv().fuse() => "SIGTERM"
+                }
+            } else {
+                tokio::signal::ctrl_c().await.unwrap();
+                "Ctrl+C"
+            };
+            info!("Got {}, stopping", sig);
             actix::System::current().stop();
         });
         sys.run().unwrap();


### PR DESCRIPTION
The ‘kill’ command sends SIGTERM signal by default.  Catch it in
addition ta SIGINT when running under Unix-like system.

Issue: https://github.com/near/nearcore/issues/3266