### PR TITLE
refactor: remove needless rayon pool setup in the estimator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4892,7 +4892,6 @@ dependencies = [
  "once_cell",
  "rand 0.7.3",
  "rand_xorshift 0.2.0",
- "rayon",
  "rocksdb",
  "serde_json",
  "state-viewer",

--- a/runtime/runtime-params-estimator/Cargo.toml
+++ b/runtime/runtime-params-estimator/Cargo.toml
@@ -17,8 +17,6 @@ gnuplot = "0.0.37"
 serde_json = "1"
 csv = "1.1.3"
 clap = "2.33"
-rayon = "1.5"
-
 borsh = "0.8.1"
 num-rational = "0.3"
 

--- a/runtime/runtime-params-estimator/src/vm_estimator.rs
+++ b/runtime/runtime-params-estimator/src/vm_estimator.rs
@@ -276,26 +276,22 @@ pub(crate) fn compute_compile_cost_vm(
     vm_kind: VMKind,
     verbose: bool,
 ) -> (u64, u64) {
-    let mut base = 0i64;
-    let mut per_byte = 0i64;
-    rayon::ThreadPoolBuilder::new().num_threads(1).build().unwrap().install(|| {
-        let (a, b) = precompilation_cost(metric, vm_kind);
-        base = ratio_to_gas_signed(metric, a);
-        per_byte = ratio_to_gas_signed(metric, b);
-        if verbose {
-            println!(
-                "{:?} using {:?}: in a + b * x: a = {} ({}) b = {}({}) base = {} per_byte = {}",
-                vm_kind,
-                metric,
-                a,
-                a.to_f64().unwrap(),
-                b,
-                b.to_f64().unwrap(),
-                base,
-                per_byte
-            );
-        }
-    });
+    let (a, b) = precompilation_cost(metric, vm_kind);
+    let base = ratio_to_gas_signed(metric, a);
+    let per_byte = ratio_to_gas_signed(metric, b);
+    if verbose {
+        println!(
+            "{:?} using {:?}: in a + b * x: a = {} ({}) b = {}({}) base = {} per_byte = {}",
+            vm_kind,
+            metric,
+            a,
+            a.to_f64().unwrap(),
+            b,
+            b.to_f64().unwrap(),
+            base,
+            per_byte
+        );
+    }
     match metric {
         GasMetric::ICount => (u64::try_from(base).unwrap(), u64::try_from(per_byte).unwrap()),
         // Time metric can lead to negative coefficients.


### PR DESCRIPTION
Forgot to do this in #4293: the original motivation here was to force
wasmer1 to compile code in a single thread,  but we've since contributed
a "no rayon" mode upstream and upgraded to that.

In other words, wasmer1 no longer uses threads, so we don't need this.