### PR TITLE
pytest: remove contract building from deploy_call_smart_contract test

### DIFF
--- a/pytest/tests/contracts/deploy_call_smart_contract.py
+++ b/pytest/tests/contracts/deploy_call_smart_contract.py
@@ -1,63 +1,37 @@
-# Spins up four nodes, deploy an smart contract to one node,
-# Call a smart contract method in another node
+"""Deploy a smart contract on one node and call it on another."""
 
-import sys, time
 import base58
+import sys
+import time
 
 sys.path.append('lib')
 from cluster import start_cluster
 from transaction import sign_deploy_contract_tx, sign_function_call_tx
-from utils import load_binary_file, load_test_contract, compile_rust_contract
+from utils import load_test_contract
 
-nodes = start_cluster(
-    4, 0, 4, None,
-    [["epoch_length", 10], ["block_producer_kickout_threshold", 80]], {})
+def test_deploy_contract():
+    nodes = start_cluster(
+        2, 0, 1, None,
+        [["epoch_length", 10], ["block_producer_kickout_threshold", 80]], {})
 
-status = nodes[0].get_status()
-hash_ = status['sync_info']['latest_block_hash']
-hash_ = base58.b58decode(hash_.encode('utf8'))
-tx = sign_deploy_contract_tx(nodes[0].signer_key, load_test_contract(),
-                             10, hash_)
-nodes[0].send_tx(tx)
+    status = nodes[0].get_status()
+    last_block_hash = status['sync_info']['latest_block_hash']
+    last_block_hash = base58.b58decode(last_block_hash.encode('utf8'))
+    tx = sign_deploy_contract_tx(
+            nodes[0].signer_key, load_test_contract(), 10, last_block_hash)
+    nodes[0].send_tx(tx)
+    time.sleep(3)
 
-time.sleep(3)
+    status = nodes[1].get_status()
+    last_block_hash = status['sync_info']['latest_block_hash']
+    last_block_hash = base58.b58decode(last_block_hash.encode('utf8'))
+    tx = sign_function_call_tx(
+            nodes[0].signer_key, nodes[0].signer_key.account_id,
+            'log_something', [], 100000000000, 100000000000, 20,
+            last_block_hash)
+    res = nodes[1].send_tx_and_wait(tx, 20)
+    assert res['result']['receipts_outcome'][0]['outcome']['logs'][0] == 'hello'
 
-status2 = nodes[1].get_status()
-hash_2 = status2['sync_info']['latest_block_hash']
-hash_2 = base58.b58decode(hash_2.encode('utf8'))
-tx2 = sign_function_call_tx(nodes[0].signer_key, nodes[0].signer_key.account_id,
-                            'log_something', [], 100000000000, 100000000000, 20,
-                            hash_2)
-res = nodes[1].send_tx_and_wait(tx2, 20)
-assert res['result']['receipts_outcome'][0]['outcome']['logs'][0] == 'hello'
 
-wasm_file = compile_rust_contract('''
-metadata! {
-  #[near_bindgen]
-  #[derive(Default, BorshDeserialize, BorshSerialize)]
-  pub struct StatusMessage {}
-}
-
-#[near_bindgen]
-impl StatusMessage {
-  pub fn log_world(&self) {
-    env::log(b"world");
-  }
-}
-''')
-
-status3 = nodes[2].get_status()
-hash_3 = status3['sync_info']['latest_block_hash']
-hash_3 = base58.b58decode(hash_3.encode('utf8'))
-tx3 = sign_deploy_contract_tx(nodes[2].signer_key, load_binary_file(wasm_file),
-                              10, hash_3)
-res = nodes[3].send_tx(tx3)
-time.sleep(3)
-
-status4 = nodes[3].get_status()
-hash_4 = status4['sync_info']['latest_block_hash']
-hash_4 = base58.b58decode(hash_4.encode('utf8'))
-tx4 = sign_function_call_tx(nodes[2].signer_key, nodes[2].signer_key.account_id,
-                            'log_world', [], 3000000000000, 0, 20, hash_4)
-res = nodes[3].send_tx_and_wait(tx4, 20)
-assert res['result']['receipts_outcome'][0]['outcome']['logs'][0] == 'world', res
+if __name__ == '__main__':
+    test_deploy_contract()


### PR DESCRIPTION
The deploy_call_smart_contract test has two parts.  First, it deployes
the test contract from near-test-contracts and calls its function.
Second, it builds a new contract, deployes that and calls its function.

The second part however doesn’t really test anything additional compared
to the first.  The only difference is building of the contract but
that’s really beyond scope of nearcore tests.  Furthermore, because the
compiled contract depends on near-sdk repository the test is
non-reproducible.

Remove the second part and only test deploying and calling a single
smart contraact.

Issue: https://github.com/near/nearcore/issues/4480