### PR TITLE
Remove unneccesarry ‘INFO’ prefix from log messages

### DIFF
--- a/pytest/lib/mocknet.py
+++ b/pytest/lib/mocknet.py
@@ -85,7 +85,7 @@ def list_validators(node):
 
 def setup_python_environment(node, wasm_contract):
     m = node.machine
-    logger.info(f'INFO: Setting up python environment on {m.name}')
+    logger.info(f'Setting up python environment on {m.name}')
     m.run('bash', input=PYTHON_SETUP_SCRIPT)
     m.upload('lib', PYTHON_DIR, switch_user='ubuntu')
     m.upload('requirements.txt', PYTHON_DIR, switch_user='ubuntu')
@@ -94,7 +94,7 @@ def setup_python_environment(node, wasm_contract):
              PYTHON_DIR,
              switch_user='ubuntu')
     m.run('bash', input=INSTALL_PYTHON_REQUIREMENTS)
-    logger.info(f'INFO: {m.name} python setup complete')
+    logger.info(f'{m.name} python setup complete')
 
 
 def setup_python_environments(nodes, wasm_contract):
@@ -110,7 +110,7 @@ def start_load_test_helper_script(script, index, pk, sk):
 
 def start_load_test_helper(node, script, pk, sk):
     m = node.machine
-    logger.info(f'INFO: Starting load_test_helper on {m.name}')
+    logger.info(f'Starting load_test_helper on {m.name}')
     index = int(m.name.split('node')[-1])
     m.run('bash', input=start_load_test_helper_script(script, index, pk, sk))
 
@@ -247,7 +247,7 @@ def send_transaction(node, tx, tx_hash, account_id, timeout=120):
 
 
 def transfer_between_nodes(nodes):
-    logger.info('INFO: Testing transfer between mocknet validators')
+    logger.info('Testing transfer between mocknet validators')
     node = nodes[0]
     alice = get_validator_account(nodes[1])
     bob = get_validator_account(nodes[0])
@@ -258,8 +258,8 @@ def transfer_between_nodes(nodes):
     alice_initial_balance = get_balance(alice)
     alice_nonce = node.get_nonce_for_pk(alice.account_id, alice.pk)
     bob_initial_balance = get_balance(bob)
-    logger.info(f'INFO: Alice initial balance: {alice_initial_balance}')
-    logger.info(f'INFO: Bob initial balance: {bob_initial_balance}')
+    logger.info(f'Alice initial balance: {alice_initial_balance}')
+    logger.info(f'Bob initial balance: {bob_initial_balance}')
 
     last_block_hash = node.get_status()['sync_info']['latest_block_hash']
     last_block_hash_decoded = base58.b58decode(last_block_hash.encode('utf8'))
@@ -271,8 +271,8 @@ def transfer_between_nodes(nodes):
 
     alice_final_balance = get_balance(alice)
     bob_final_balance = get_balance(bob)
-    logger.info(f'INFO: Alice final balance: {alice_final_balance}')
-    logger.info(f'INFO: Bob final balance: {bob_final_balance}')
+    logger.info(f'Alice final balance: {alice_final_balance}')
+    logger.info(f'Bob final balance: {bob_final_balance}')
 
     # Check mod 1000 to ignore the cost of the transaction itself
     assert (alice_initial_balance -
@@ -282,7 +282,7 @@ def transfer_between_nodes(nodes):
 
 def stake_node(node):
     account = get_validator_account(node)
-    logger.info(f'INFO: Staking {account.account_id}.')
+    logger.info(f'Staking {account.account_id}.')
     nonce = node.get_nonce_for_pk(account.account_id, account.pk)
 
     validators = node.get_validators()['result']
@@ -320,7 +320,7 @@ def get_near_pid(machine):
 
 def stop_node(node):
     m = node.machine
-    logger.info(f'INFO: Stopping node {m.name}')
+    logger.info(f'Stopping node {m.name}')
     pid = get_near_pid(m)
     if pid != '':
         m.run('bash', input=kill_proccess_script(pid))
@@ -329,7 +329,7 @@ def stop_node(node):
 
 def start_node(node):
     m = node.machine
-    logger.info(f'INFO: Starting node {m.name}')
+    logger.info(f'Starting node {m.name}')
     pid = get_near_pid(m)
     if pid == '':
         start_process = m.run('sudo -u ubuntu -i', input=TMUX_START_SCRIPT)
@@ -340,7 +340,7 @@ def reset_data(node, retries=0):
     try:
         m = node.machine
         stop_node(node)
-        logger.info(f'INFO: Clearing data directory of node {m.name}')
+        logger.info(f'Clearing data directory of node {m.name}')
         start_process = m.run('bash',
                               input='/home/ubuntu/near unsafe_reset_data')
         assert start_process.returncode == 0, m.name + '\n' + start_process.stderr

--- a/pytest/tests/mocknet/load_testing.py
+++ b/pytest/tests/mocknet/load_testing.py
@@ -67,7 +67,7 @@ def measure_tps_bps(nodes):
         'in_tps': input_tps,
         'out_tps': measurement['tps']
     }
-    logger.info(f'INFO: {result}')
+    logger.info(f'{result}')
     return result
 
 
@@ -83,7 +83,7 @@ def check_tps(measurement, expected_in, expected_out=None, tolarance=0.05):
 def check_memory_usage(node):
     metrics = mocknet.get_metrics(node)
     mem_usage = metrics.memory_usage / 1e6
-    logger.info(f'INFO: Memory usage (MB) = {mem_usage}')
+    logger.info(f'Memory usage (MB) = {mem_usage}')
     return mem_usage < 4500
 
 
@@ -92,18 +92,18 @@ def check_slow_blocks(initial_metrics, final_metrics):
     slow_process_blocks = delta.block_processing_time[
         'le +Inf'] - delta.block_processing_time['le 1']
     logger.info(
-        f'INFO: Number of blocks processing for more than 1s: {slow_process_blocks}'
+        f'Number of blocks processing for more than 1s: {slow_process_blocks}'
     )
     return slow_process_blocks == 0
 
 
 if __name__ == '__main__':
-    logger.info('INFO: Starting Load test.')
+    logger.info('Starting Load test.')
     nodes = mocknet.get_nodes()
     initial_validator_accounts = mocknet.list_validators(nodes[0])
     test_passed = True
 
-    logger.info('INFO: Performing baseline block time measurement')
+    logger.info('Performing baseline block time measurement')
     # We do not include tps here because there are no transactions on mocknet normally.
     time.sleep(120)
     baseline_measurement = mocknet.chain_measure_bps_and_tps(
@@ -111,22 +111,22 @@ if __name__ == '__main__':
     baseline_measurement['in_tps'] = 0.0
     # quit test early if the baseline is poor.
     assert baseline_measurement['bps'] > 1.0
-    logger.info(f'INFO: {baseline_measurement}')
-    logger.info('INFO: Baseline block time measurement complete')
+    logger.info(f'{baseline_measurement}')
+    logger.info('Baseline block time measurement complete')
 
-    logger.info('INFO: Setting remote python environments.')
+    logger.info('Setting remote python environments.')
     mocknet.setup_python_environments(nodes, wasm_contract())
-    logger.info('INFO: Starting transaction spamming scripts.')
+    logger.info('Starting transaction spamming scripts.')
     mocknet.start_load_test_helpers(nodes, 'load_testing_helper.py')
 
     initial_metrics = mocknet.get_metrics(nodes[-1])
-    logger.info('INFO: Waiting for transfer only period to complete.')
+    logger.info('Waiting for transfer only period to complete.')
     time.sleep(TRANSFER_ONLY_TIMEOUT)
     transfer_final_metrics = mocknet.get_metrics(nodes[-1])
 
     # wait before doing measurement to ensure tx_events written by helpers
     time.sleep(5)
-    logger.info('INFO: Transfer-only results:')
+    logger.info('Transfer-only results:')
     transfer_only_measurement = measure_tps_bps(nodes)
     test_passed = (transfer_only_measurement['bps'] > 0.5) and test_passed
     test_passed = check_tps(transfer_only_measurement, MAX_TPS) and test_passed
@@ -134,17 +134,17 @@ if __name__ == '__main__':
     test_passed = check_slow_blocks(initial_metrics,
                                     transfer_final_metrics) and test_passed
 
-    logger.info('INFO: Waiting for contracts to be deployed.')
+    logger.info('Waiting for contracts to be deployed.')
     measurement_duration = transfer_final_metrics.timestamp - time.time()
     time.sleep(CONTRACT_DEPLOY_TIME - measurement_duration)
 
-    logger.info('INFO: Waiting for random transactions period to complete.')
+    logger.info('Waiting for random transactions period to complete.')
     all_tx_initial_metrics = mocknet.get_metrics(nodes[-1])
     time.sleep(ALL_TX_TIMEOUT)
     final_metrics = mocknet.get_metrics(nodes[-1])
 
     time.sleep(5)
-    logger.info('INFO: All transaction types results:')
+    logger.info('All transaction types results:')
     all_tx_measurement = measure_tps_bps(nodes)
     test_passed = (all_tx_measurement['bps'] > 0.5) and test_passed
     test_passed = check_memory_usage(nodes[0]) and test_passed
@@ -156,4 +156,4 @@ if __name__ == '__main__':
 
     assert test_passed
 
-    logger.info('INFO: Load test complete.')
+    logger.info('Load test complete.')

--- a/pytest/tests/mocknet/outage.py
+++ b/pytest/tests/mocknet/outage.py
@@ -45,14 +45,14 @@ def wait_until_next_epoch(current_start_height, query_node):
         time.sleep(5)
 
 
-logger.info('INFO: Starting Outage test.')
+logger.info('Starting Outage test.')
 
 # Ensure we start the test closer to the beginning of an epoch than the end.
 epoch_start_height = nodes[0].get_validators()['result']['epoch_start_height']
 current_height = nodes[0].get_status()['sync_info']['latest_block_height']
 if current_height > epoch_start_height + (epoch_length / 2):
     logger.info(
-        'INFO: Presently over half way through epoch, waiting for the next epoch to start'
+        'Presently over half way through epoch, waiting for the next epoch to start'
     )
     wait_until_next_epoch(epoch_start_height, nodes[0])
 
@@ -67,7 +67,7 @@ time.sleep(10)
 check_transfer()
 
 # Wait an epoch
-logger.info('INFO: Waiting until next epoch.')
+logger.info('Waiting until next epoch.')
 validators = query_node.get_validators()['result']
 wait_until_next_epoch(validators['epoch_start_height'], query_node)
 
@@ -83,7 +83,7 @@ for k in kick_out:
     assert 'NotEnoughBlocks' in k['reason']
 
 # Wait another epoch
-logger.info('INFO: Waiting until next epoch.')
+logger.info('Waiting until next epoch.')
 wait_until_next_epoch(validators['epoch_start_height'], query_node)
 
 # Check the network still functions
@@ -98,7 +98,7 @@ time.sleep(60)
 # Let the node catch up
 sync_start = time.time()
 sync_timeout = 300  # allow up to 5 minutes for syncing
-logger.info('INFO: Waiting for node0 to sync.')
+logger.info('Waiting for node0 to sync.')
 while nodes[0].get_status()['sync_info']['syncing']:
     if time.time() - sync_start >= sync_timeout:
         raise TimeoutError('nodes[0] seems to be stalled while syncing')
@@ -111,7 +111,7 @@ mocknet.transfer_between_nodes(nodes)
 for i in range(len(offline_validators)):
     mocknet.stake_node(nodes[i])
 validators = nodes[0].get_validators()['result']
-logger.info('INFO: Waiting until next epoch.')
+logger.info('Waiting until next epoch.')
 wait_until_next_epoch(validators['epoch_start_height'], nodes[0])
 
 # Confirm previously offline nodes will be validators in the next epoch
@@ -120,8 +120,8 @@ next_validators = set(
     map(lambda v: v['account_id'], validators['next_validators']))
 for v in offline_validators:
     assert v in next_validators
-logger.info('INFO: previously offline nodes in next epoch validator set.')
-logger.info('INFO: Waiting until next epoch.')
+logger.info('previously offline nodes in next epoch validator set.')
+logger.info('Waiting until next epoch.')
 wait_until_next_epoch(validators['epoch_start_height'], nodes[0])
 
 # Confirm nodes are a validators again
@@ -130,5 +130,5 @@ current_validators = set(
     map(lambda v: v['account_id'], validators['current_validators']))
 for v in offline_validators:
     assert v in current_validators
-logger.info('INFO: previously offline nodes now in current epoch validator set.')
-logger.info('INFO: Outage test complete.')
+logger.info('previously offline nodes now in current epoch validator set.')
+logger.info('Outage test complete.')


### PR DESCRIPTION
The logger is cofigured to include message level so there’s no need to
include INFO in the actual message.  AS it stands, this results in log
lines such as:

    [2021-07-09 05:37:33] INFO: INFO: Starting Load test.

Remove the unnecessary ‘INFO’ prefix.  This has been done with a simple:

    sed -i 's/INFO: //' pytest/**/*.py