### PR TITLE
Add cython to pytest requirements

### DIFF
--- a/pytest/requirements.txt
+++ b/pytest/requirements.txt
@@ -11,6 +11,7 @@ python-rc==0.3.9
 tqdm
 deepdiff
 pynacl
+cython
 numpy
 scikit-learn==0.21.3
 PyGithub


### PR DESCRIPTION
I suggest to add `cython` because building venv for pytest from scratch always ends up with

```
    Running setup.py install for scikit-learn ... error
    ERROR: Command errored out with exit status 1:
     command: /home/Aleksandr1/nearcore/venv/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-cak7r1gr/scikit-learn/setup.py'"'"'; __file__='"'"'/tmp/pip-install-cak7r1gr/scikit-learn/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-z15d8knj/install-record.txt --single-version-externally-managed --compile --install-headers /home/Aleksandr1/nearcore/venv/include/site/python3.8/scikit-learn
         cwd: /tmp/pip-install-cak7r1gr/scikit-learn/
...
      File "sklearn/utils/setup.py", line 8, in configuration
        from Cython import Tempita
    ModuleNotFoundError: No module named 'Cython'
    ----------------------------------------
```