### PR TITLE
pytest: don’t depend on near-sdk in empty-contract-rs

### DIFF
--- a/pytest/empty-contract-rs/Cargo.toml
+++ b/pytest/empty-contract-rs/Cargo.toml
@@ -7,9 +7,6 @@ edition = "2018"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[dependencies]
-near-sdk = { git = "https://github.com/near/near-sdk-rs", branch = "master"}
-
 [profile.release]
 codegen-units = 1
 # Tell `rustc` to optimize for small code size.
@@ -17,6 +14,3 @@ opt-level = "z"
 lto = true
 debug = false
 panic = "abort"
-
-[workspace]
-members = []

--- a/pytest/empty-contract-rs/build.sh
+++ b/pytest/empty-contract-rs/build.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-cargo build --target wasm32-unknown-unknown --release
-cp target/wasm32-unknown-unknown/release/empty_contract_rs.wasm target/release/

--- a/pytest/empty-contract-rs/src/lib.rs
+++ b/pytest/empty-contract-rs/src/lib.rs
@@ -1,2 +1,0 @@
-use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
-use near_sdk::{env, metadata, near_bindgen};


### PR DESCRIPTION
There’s very little reason to make the empty-contract-rs depend on
near-sdk.  The code is trivial and only uses the log method which
can be easily called directly without the near-sdk wrapper.

This also fixes the issue where the test was not reproducible as the
empty-contract-rs would depend on the near-sdk from the git
repository rather than a released crate.

An obvious question which arises is why not use near-test-contracts
like the rest of pytests.  That would be an ideal endgoal but it
doesn’t interact well with how NayDuck runs mocknet tests.
Specifically, near-test-contracts needs to be built and NayDuck
currently skips build stage when running mocknet tests.  Long term
this could be addressed but for now this change improves the
situation so it’s what we’ve got.

Issue: https://github.com/near/nearcore/issues/4480