### PR TITLE
feat(build): Added param-estimator and genesis-populate to the Makefile for nightly and stable releases to store artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,16 @@ release:
 	cargo build -p near-vm-runner-standalone --release
 	cargo build -p state-viewer --release
 	cargo build -p store-validator --release
+	cargo build -p runtime-param-estimator --release
+	cargo build -p genesis-populate --release
 
 debug:
-	CARGO_PROFILE_RELEASE_DEBUG=true cargo build -p neard
+	cargo build -p neard
 	cargo build -p near-vm-runner-standalone
 	cargo build -p state-viewer
 	cargo build -p store-validator
+	cargo build -p runtime-param-estimator
+	cargo build -p genesis-populate
 
 perf-release:
 	CARGO_PROFILE_RELEASE_DEBUG=true cargo build -p neard --release --features performance_stats,memory_stats
@@ -25,22 +29,26 @@ perf-release:
 	cargo build -p store-validator --release --features nearcore/performance_stats,nearcore/memory_stats
 
 perf-debug:
-	CARGO_PROFILE_RELEASE_DEBUG=true cargo build -p neard --features performance_stats,memory_stats
+	cargo build -p neard --features performance_stats,memory_stats
 	cargo build -p near-vm-runner-standalone
 	cargo build -p state-viewer --features nearcore/performance_stats,nearcore/memory_stats
 	cargo build -p store-validator --features nearcore/performance_stats,nearcore/memory_stats
 
 nightly-release:
-	CARGO_PROFILE_RELEASE_DEBUG=true cargo build -p neard --release --features nightly_protocol,nightly_protocol_features,performance_stats,memory_stats
+	cargo build -p neard --release --features nightly_protocol,nightly_protocol_features,performance_stats,memory_stats
 	cargo build -p near-vm-runner-standalone --release --features nightly_protocol,nightly_protocol_features
 	cargo build -p state-viewer --release --features nearcore/nightly_protocol,nearcore/nightly_protocol_features,nearcore/performance_stats,nearcore/memory_stats
 	cargo build -p store-validator --release --features nearcore/nightly_protocol,nearcore/nightly_protocol_features,nearcore/performance_stats,nearcore/memory_stats
+	cargo build -p runtime-param-estimator --release --features nearcore/nightly_protocol,nearcore/nightly_protocol_features,nearcore/performance_stats,nearcore/memory_stats
+	cargo build -p genesis-populate --release --features nearcore/nightly_protocol,nearcore/nightly_protocol_features,nearcore/performance_stats,nearcore/memory_stats
 
 nightly-debug:
-	CARGO_PROFILE_RELEASE_DEBUG=true cargo build -p neard --features nightly_protocol,nightly_protocol_features,performance_stats,memory_stats
+	cargo build -p neard --features nightly_protocol,nightly_protocol_features,performance_stats,memory_stats
 	cargo build -p near-vm-runner-standalone --features nightly_protocol,nightly_protocol_features
 	cargo build -p state-viewer --features nearcore/nightly_protocol,nearcore/nightly_protocol_features,nearcore/performance_stats,nearcore/memory_stats
 	cargo build -p store-validator --features nearcore/nightly_protocol,nearcore/nightly_protocol_features,nearcore/performance_stats,nearcore/memory_stats
+	cargo build -p runtime-param-estimator --features nearcore/nightly_protocol,nearcore/nightly_protocol_features,nearcore/performance_stats,nearcore/memory_stats
+	cargo build -p genesis-populate --features nearcore/nightly_protocol,nearcore/nightly_protocol_features,nearcore/performance_stats,nearcore/memory_stats
 
 sandbox:
 	CARGO_PROFILE_RELEASE_DEBUG=true cargo build -p neard --features sandbox

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ release:
 	cargo build -p store-validator --release
 
 debug:
-	cargo build -p neard
+	CARGO_PROFILE_RELEASE_DEBUG=true cargo build -p neard
 	cargo build -p near-vm-runner-standalone
 	cargo build -p state-viewer
 	cargo build -p store-validator
@@ -25,7 +25,7 @@ perf-release:
 	cargo build -p store-validator --release --features nearcore/performance_stats,nearcore/memory_stats
 
 perf-debug:
-	cargo build -p neard --features performance_stats,memory_stats
+	CARGO_PROFILE_RELEASE_DEBUG=true cargo build -p neard --features performance_stats,memory_stats
 	cargo build -p near-vm-runner-standalone
 	cargo build -p state-viewer --features nearcore/performance_stats,nearcore/memory_stats
 	cargo build -p store-validator --features nearcore/performance_stats,nearcore/memory_stats
@@ -37,7 +37,7 @@ nightly-release:
 	cargo build -p store-validator --release --features nearcore/nightly_protocol,nearcore/nightly_protocol_features,nearcore/performance_stats,nearcore/memory_stats
 
 nightly-debug:
-	cargo build -p neard --features nightly_protocol,nightly_protocol_features,performance_stats,memory_stats
+	CARGO_PROFILE_RELEASE_DEBUG=true cargo build -p neard --features nightly_protocol,nightly_protocol_features,performance_stats,memory_stats
 	cargo build -p near-vm-runner-standalone --features nightly_protocol,nightly_protocol_features
 	cargo build -p state-viewer --features nearcore/nightly_protocol,nearcore/nightly_protocol_features,nearcore/performance_stats,nearcore/memory_stats
 	cargo build -p store-validator --features nearcore/nightly_protocol,nearcore/nightly_protocol_features,nearcore/performance_stats,nearcore/memory_stats

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,0 @@
-coverage:
-  status:
-    project: off
-    patch: off

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+coverage:
+  status:
+    project: off
+    patch: off


### PR DESCRIPTION
@Longarithm has asked me if we can build the binaries for `param-estimator` and `genesis-populate` in the current pipeline as currently he is using a Docker image which recompiles them every time and this would save him time.