### PR TITLE
fix: tidy test checks everything, and not only one dir

### DIFF
--- a/integration-tests/tests/tidy.rs
+++ b/integration-tests/tests/tidy.rs
@@ -1,12 +1,24 @@
+use std::path::PathBuf;
 use std::process::Command;
 
 #[test]
 fn code_is_formatted() {
-    let mut child = Command::new("cargo").args(&["fmt", "--", "--check"]).spawn().unwrap();
+    let mut child = Command::new("cargo")
+        .current_dir(project_root())
+        .args(&["fmt", "--", "--check"])
+        .spawn()
+        .unwrap();
 
     let status = child.wait().unwrap();
 
     if !status.success() {
         panic!("Please format the code by running `cargo fmt`");
     }
+}
+
+fn project_root() -> PathBuf {
+    let dir = env!("CARGO_MANIFEST_DIR");
+    let res = PathBuf::from(dir).parent().unwrap().to_owned();
+    assert!(res.join(".github").exists());
+    res
 }


### PR DESCRIPTION
This test used to be run from the root of the repo, but got moved to a
subdir. After that, it stopped checking everything, so let's restore the
old, correct behavior.

closes #4505

Test Plan
--------

Manually check that invalid formatting is detected. 