### PR TITLE
Use protocol version of the latest block instead of protocol version of the genesis block when dumping state

### DIFF
--- a/test-utils/state-viewer/Cargo.toml
+++ b/test-utils/state-viewer/Cargo.toml
@@ -26,3 +26,5 @@ near-client = { path = "../../chain/client" }
 
 [features]
 sandbox = ["node-runtime/sandbox", "near-chain/sandbox", "near-network/sandbox", "near-client/sandbox"]
+nightly_protocol_features = ["nearcore/nightly_protocol_features"]
+nightly_protocol = ["nearcore/nightly_protocol"]

--- a/test-utils/state-viewer/src/state_dump.rs
+++ b/test-utils/state-viewer/src/state_dump.rs
@@ -60,6 +60,10 @@ pub fn state_dump(
         .into_iter()
         .map(|(account_id, (public_key, amount))| AccountInfo { account_id, public_key, amount })
         .collect();
+    // Record the protocol version of the latest block. Otherwise, the state
+    // dump ignores the fact that the nodes can be running a newer protocol
+    // version than the protocol version of the genesis.
+    genesis_config.protocol_version = last_block_header.latest_protocol_version();
     Genesis::new(genesis_config, records.into())
 }
 


### PR DESCRIPTION
Tested by running a `betanet` node with `nightly_protocol` and `nightly_protocol_features`.
Fixes #4207