### PR TITLE
Makefile: add a default ‘all’ target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,11 @@ export CARGO_PROFILE_RELEASE_LTO = fat
 export DOCKER_BUILDKIT = 1
 export RUSTFLAGS = -D warnings
 
+
+# By default, build a regular release
+all: release
+
+
 docker-nearcore:
 	docker build -t nearcore -f Dockerfile --progress=plain .
 


### PR DESCRIPTION
Introduce a default ‘all’ target to the Makefile so that running
‘make’ on its own produces a relaese build which is likely what
user meant.

Issue: https://github.com/near/nearcore/issues/4403