### PR TITLE
pytest: fix sandbox test

### DIFF
--- a/nightly/complete_nayduck_set.txt
+++ b/nightly/complete_nayduck_set.txt
@@ -150,7 +150,7 @@ pytest adversarial/start_from_genesis.py overtake doomslug_off
 pytest adversarial/start_from_genesis.py overtake doomslug_off --features nightly_protocol --features nightly_protocol_features
 
 # python sandbox node tests
-pytest sandbox/patch_state.py
+pytest sandbox/patch_state.py --features sandbox
 
 # python upgradable test
 # upgradable.py moves `near` binary, and must be the last python test in the set

--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -77,7 +77,7 @@ pytest adversarial/start_from_genesis.py doomslug_off
 pytest adversarial/start_from_genesis.py overtake doomslug_off
 
 # python sandbox node tests
-pytest sandbox/patch_state.py
+pytest sandbox/patch_state.py --features sandbox
 
 # python upgradable test
 # upgradable.py moves `near` binary, and must be the last python test in the set

--- a/nightly/tests_for_nayduck.txt
+++ b/nightly/tests_for_nayduck.txt
@@ -81,7 +81,7 @@ pytest adversarial/start_from_genesis.py doomslug_off
 pytest adversarial/start_from_genesis.py overtake doomslug_off
 
 # python sandbox node tests
-pytest sandbox/patch_state.py
+pytest sandbox/patch_state.py --features sandbox
 
 # python upgradable test
 # upgradable.py moves `near` binary, and must be the last python test in the set

--- a/pytest/tests/sandbox/patch_state.py
+++ b/pytest/tests/sandbox/patch_state.py
@@ -3,6 +3,7 @@
 import sys, time
 import base58
 import base64
+import pathlib
 
 sys.path.append('lib')
 
@@ -13,10 +14,24 @@ from utils import load_test_contract
 CONFIG = {
     'local': True,
     'preexist': False,
-    'near_root': '../target/debug/',
-    'binary_name': 'near-sandbox',
     'release': False,
 }
+
+def figure_out_binary():
+    # When run on NayDuck we end up with a binary called neard in target/debug
+    # but when run locally the binary might be near-sandbox instead.  Try to
+    # figure out whichever binary is available and use that.
+    for release in ('release', 'debug'):
+        root = pathlib.Path('../target') / release
+        for exe in ('near-sandbox', 'neard'):
+            if (root / exe).exists():
+                CONFIG['near_root'] = str(root)
+                CONFIG['binary_name'] = exe
+                return
+    assert False, ('Unable to figure out location of near-sandbox binary; '
+                   'Did you forget to run `make sandbax`?')
+
+figure_out_binary()
 
 # start node
 nodes = start_cluster(


### PR DESCRIPTION
Make sure that NayDuck builds neard binary with --features sandbox when
running sandbox tests and also make the sandbox test a bit smarter about
locating the executable.
