### PR TITLE
nayduck: remove ‘basic’ test since it’s not a thing

### DIFF
--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -1,6 +1,3 @@
-# basic tests (the ones we run in CI)
-basic --timeout=1800
-
 # python sanity tests
 pytest sanity/block_production.py
 pytest sanity/transactions.py
@@ -174,4 +171,3 @@ expensive --timeout=600 nearcore test_simple test::test_7_10_multiple_nodes
 expensive --timeout=1200 nearcore test_rejoin test::test_4_20_kill1
 expensive --timeout=1200 nearcore test_rejoin test::test_4_20_kill1_two_shards
 expensive --timeout=1200 nearcore test_rejoin test::test_4_20_kill2
-


### PR DESCRIPTION
NayDuck is unaware of a ‘basic’ test category and each time it has
been executed it has failed†.  Remove it from the list of NayDuck
nightly tests

† http://nayduck.eastus.cloudapp.azure.com:3000/#/test_history/67137