### PR TITLE
Make fields of `GenesisConfig` private, replacing them with acces…

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1765,10 +1765,10 @@ mod test {
     fn test_cap_max_gas_price() {
         let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
         let epoch_length = 5;
-        genesis.config.min_gas_price = 1_000;
-        genesis.config.max_gas_price = 1_000_000;
-        genesis.config.protocol_version = ProtocolFeature::CapMaxGasPrice.protocol_version();
-        genesis.config.epoch_length = epoch_length;
+        genesis.get_mut_ref_config().min_gas_price = 1_000;
+        genesis.get_mut_ref_config().max_gas_price = 1_000_000;
+        genesis.get_mut_ref_config().protocol_version = ProtocolFeature::CapMaxGasPrice.protocol_version();
+        genesis.get_mut_ref_config().epoch_length = epoch_length;
         let chain_genesis = ChainGenesis::from(&genesis);
         let runtimes = create_nightshade_runtimes(&genesis, 1);
         let mut env = TestEnv::new_with_runtime(chain_genesis, 1, 1, runtimes);

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1767,7 +1767,8 @@ mod test {
         let epoch_length = 5;
         genesis.get_mut_ref_config().min_gas_price = 1_000;
         genesis.get_mut_ref_config().max_gas_price = 1_000_000;
-        genesis.get_mut_ref_config().protocol_version = ProtocolFeature::CapMaxGasPrice.protocol_version();
+        genesis.get_mut_ref_config().protocol_version =
+            ProtocolFeature::CapMaxGasPrice.protocol_version();
         genesis.get_mut_ref_config().epoch_length = epoch_length;
         let chain_genesis = ChainGenesis::from(&genesis);
         let runtimes = create_nightshade_runtimes(&genesis, 1);

--- a/chain/client/tests/challenges.rs
+++ b/chain/client/tests/challenges.rs
@@ -269,7 +269,7 @@ fn challenge(
 fn test_verify_chunk_invalid_state_challenge() {
     let store1 = create_test_store();
     let genesis = Genesis::test(vec!["test0", "test1"], 1);
-    let transaction_validity_period = genesis.config.transaction_validity_period;
+    let transaction_validity_period = genesis.get_ref_config().transaction_validity_period;
     let runtimes: Vec<Arc<dyn RuntimeAdapter>> = vec![Arc::new(nearcore::NightshadeRuntime::new(
         Path::new("."),
         store1,
@@ -562,7 +562,7 @@ fn test_block_challenge() {
 fn test_fishermen_challenge() {
     init_test_logger();
     let mut genesis = Genesis::test(vec!["test0", "test1", "test2"], 1);
-    genesis.config.epoch_length = 5;
+    genesis.get_mut_ref_config().epoch_length = 5;
     let create_runtime = || -> Arc<NightshadeRuntime> {
         Arc::new(nearcore::NightshadeRuntime::new(
             Path::new("."),
@@ -624,7 +624,7 @@ fn test_fishermen_challenge() {
 fn test_challenge_in_different_epoch() {
     init_test_logger();
     let mut genesis = Genesis::test(vec!["test0", "test1"], 2);
-    genesis.config.epoch_length = 2;
+    genesis.get_mut_ref_config().epoch_length = 2;
     //    genesis.config.validator_kickout_threshold = 10;
     let network_adapter = Arc::new(MockNetworkAdapter::default());
     let runtime1 = Arc::new(nearcore::NightshadeRuntime::new(

--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -102,11 +102,11 @@ fn prepare_env_with_congestion(
     init_test_logger();
     let epoch_length = 100;
     let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
-    genesis.config.protocol_version = protocol_version;
-    genesis.config.epoch_length = epoch_length;
-    genesis.config.gas_limit = 10_000_000_000_000;
+    genesis.get_mut_ref_config().protocol_version = protocol_version;
+    genesis.get_mut_ref_config().epoch_length = epoch_length;
+    genesis.get_mut_ref_config().gas_limit = 10_000_000_000_000;
     if let Some(gas_price_adjustment_rate) = gas_price_adjustment_rate {
-        genesis.config.gas_price_adjustment_rate = gas_price_adjustment_rate;
+        genesis.get_mut_ref_config().gas_price_adjustment_rate = gas_price_adjustment_rate;
     }
     let chain_genesis = ChainGenesis::from(&genesis);
     let mut env =
@@ -1274,7 +1274,7 @@ fn test_minimum_gas_price() {
 
 fn test_gc_with_epoch_length_common(epoch_length: NumBlocks) {
     let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
-    genesis.config.epoch_length = epoch_length;
+    genesis.get_mut_ref_config().epoch_length = epoch_length;
     let mut chain_genesis = ChainGenesis::test();
     chain_genesis.epoch_length = epoch_length;
     let mut env =
@@ -1334,7 +1334,7 @@ fn test_gc_with_epoch_length() {
 fn test_gc_long_epoch() {
     let epoch_length = 5;
     let mut genesis = Genesis::test(vec!["test0", "test1"], 5);
-    genesis.config.epoch_length = epoch_length;
+    genesis.get_mut_ref_config().epoch_length = epoch_length;
     let mut chain_genesis = ChainGenesis::test();
     chain_genesis.epoch_length = epoch_length;
     let mut env =
@@ -1409,7 +1409,7 @@ fn test_gc_chunk_tail() {
 fn test_gc_execution_outcome() {
     let epoch_length = 5;
     let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
-    genesis.config.epoch_length = epoch_length;
+    genesis.get_mut_ref_config().epoch_length = epoch_length;
     let mut chain_genesis = ChainGenesis::test();
     chain_genesis.epoch_length = epoch_length;
     let mut env =
@@ -1443,7 +1443,7 @@ fn test_gc_execution_outcome() {
 fn test_gc_after_state_sync() {
     let epoch_length = 1024;
     let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
-    genesis.config.epoch_length = epoch_length;
+    genesis.get_mut_ref_config().epoch_length = epoch_length;
     let mut chain_genesis = ChainGenesis::test();
     chain_genesis.epoch_length = epoch_length;
     let mut env =
@@ -1474,7 +1474,7 @@ fn test_gc_after_state_sync() {
 fn test_process_block_after_state_sync() {
     let epoch_length = 1024;
     let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
-    genesis.config.epoch_length = epoch_length;
+    genesis.get_mut_ref_config().epoch_length = epoch_length;
     let mut chain_genesis = ChainGenesis::test();
     chain_genesis.epoch_length = epoch_length;
     let mut env =
@@ -1510,7 +1510,7 @@ fn test_process_block_after_state_sync() {
 fn test_gc_fork_tail() {
     let epoch_length = 101;
     let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
-    genesis.config.epoch_length = epoch_length;
+    genesis.get_mut_ref_config().epoch_length = epoch_length;
     let mut chain_genesis = ChainGenesis::test();
     chain_genesis.epoch_length = epoch_length;
     let mut env = TestEnv::new_with_runtime(
@@ -1568,12 +1568,12 @@ fn test_tx_forwarding_no_double_forwarding() {
 fn test_tx_forward_around_epoch_boundary() {
     let epoch_length = 4;
     let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
-    genesis.config.num_block_producer_seats = 2;
-    genesis.config.num_block_producer_seats_per_shard = vec![2];
-    genesis.config.epoch_length = epoch_length;
+    genesis.get_mut_ref_config().num_block_producer_seats = 2;
+    genesis.get_mut_ref_config().num_block_producer_seats_per_shard = vec![2];
+    genesis.get_mut_ref_config().epoch_length = epoch_length;
     let mut chain_genesis = ChainGenesis::test();
     chain_genesis.epoch_length = epoch_length;
-    chain_genesis.gas_limit = genesis.config.gas_limit;
+    chain_genesis.gas_limit = genesis.get_ref_config().gas_limit;
     let mut env =
         TestEnv::new_with_runtime(chain_genesis, 3, 2, create_nightshade_runtimes(&genesis, 3));
     let genesis_hash = *env.clients[0].chain.genesis().hash();
@@ -1623,7 +1623,7 @@ fn test_tx_forward_around_epoch_boundary() {
 fn test_not_resync_old_blocks() {
     let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
     let epoch_length = 5;
-    genesis.config.epoch_length = epoch_length;
+    genesis.get_mut_ref_config().epoch_length = epoch_length;
     let mut chain_genesis = ChainGenesis::test();
     chain_genesis.epoch_length = epoch_length;
     let mut env =
@@ -1647,7 +1647,7 @@ fn test_not_resync_old_blocks() {
 fn test_gc_tail_update() {
     let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
     let epoch_length = 2;
-    genesis.config.epoch_length = epoch_length;
+    genesis.get_mut_ref_config().epoch_length = epoch_length;
     let mut chain_genesis = ChainGenesis::test();
     chain_genesis.epoch_length = epoch_length;
     let mut env =
@@ -1684,34 +1684,34 @@ fn test_gas_price_change() {
     let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
     let target_num_tokens_left = NEAR_BASE / 10 + 1;
     let send_money_total_gas = genesis
-        .config
+        .get_ref_config()
         .runtime_config
         .transaction_costs
         .action_creation_config
         .transfer_cost
         .send_fee(false)
         + genesis
-            .config
+            .get_ref_config()
             .runtime_config
             .transaction_costs
             .action_receipt_creation_config
             .send_fee(false)
         + genesis
-            .config
+            .get_ref_config()
             .runtime_config
             .transaction_costs
             .action_creation_config
             .transfer_cost
             .exec_fee()
-        + genesis.config.runtime_config.transaction_costs.action_receipt_creation_config.exec_fee();
+        + genesis.get_ref_config().runtime_config.transaction_costs.action_receipt_creation_config.exec_fee();
     let min_gas_price = target_num_tokens_left / send_money_total_gas as u128;
     let gas_limit = 1000000000000;
     let gas_price_adjustment_rate = Rational::new(1, 10);
 
-    genesis.config.min_gas_price = min_gas_price;
-    genesis.config.gas_limit = gas_limit;
-    genesis.config.gas_price_adjustment_rate = gas_price_adjustment_rate;
-    genesis.config.runtime_config.storage_amount_per_byte = 0;
+    genesis.get_mut_ref_config().min_gas_price = min_gas_price;
+    genesis.get_mut_ref_config().gas_limit = gas_limit;
+    genesis.get_mut_ref_config().gas_price_adjustment_rate = gas_price_adjustment_rate;
+    genesis.get_mut_ref_config().runtime_config.storage_amount_per_byte = 0;
     let chain_genesis = ChainGenesis::from(&genesis);
     let mut env =
         TestEnv::new_with_runtime(chain_genesis, 1, 1, create_nightshade_runtimes(&genesis, 1));
@@ -1751,12 +1751,12 @@ fn test_gas_price_overflow() {
     let max_gas_price = 10_u128.pow(20);
     let gas_limit = 450000000000;
     let gas_price_adjustment_rate = Rational::from_integer(1);
-    genesis.config.min_gas_price = min_gas_price;
-    genesis.config.gas_limit = gas_limit;
-    genesis.config.gas_price_adjustment_rate = gas_price_adjustment_rate;
-    genesis.config.transaction_validity_period = 100000;
-    genesis.config.epoch_length = 43200;
-    genesis.config.max_gas_price = max_gas_price;
+    genesis.get_mut_ref_config().min_gas_price = min_gas_price;
+    genesis.get_mut_ref_config().gas_limit = gas_limit;
+    genesis.get_mut_ref_config().gas_price_adjustment_rate = gas_price_adjustment_rate;
+    genesis.get_mut_ref_config().transaction_validity_period = 100000;
+    genesis.get_mut_ref_config().epoch_length = 43200;
+    genesis.get_mut_ref_config().max_gas_price = max_gas_price;
 
     let chain_genesis = ChainGenesis::from(&genesis);
     let mut env =
@@ -1863,7 +1863,7 @@ fn test_block_merkle_proof_same_hash() {
 fn test_data_reset_before_state_sync() {
     let mut genesis = Genesis::test(vec!["test0"], 1);
     let epoch_length = 5;
-    genesis.config.epoch_length = epoch_length;
+    genesis.get_mut_ref_config().epoch_length = epoch_length;
     let mut env = TestEnv::new_with_runtime(
         ChainGenesis::test(),
         1,
@@ -1923,7 +1923,7 @@ fn test_data_reset_before_state_sync() {
 fn test_sync_hash_validity() {
     let epoch_length = 5;
     let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
-    genesis.config.epoch_length = epoch_length;
+    genesis.get_mut_ref_config().epoch_length = epoch_length;
     let mut chain_genesis = ChainGenesis::test();
     chain_genesis.epoch_length = epoch_length;
     let mut env =
@@ -1988,7 +1988,7 @@ fn test_block_height_processed_orphan() {
 fn test_validate_chunk_extra() {
     let epoch_length = 5;
     let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
-    genesis.config.epoch_length = epoch_length;
+    genesis.get_mut_ref_config().epoch_length = epoch_length;
     let mut env = TestEnv::new_with_runtime(
         ChainGenesis::test(),
         1,
@@ -2115,9 +2115,9 @@ fn test_gas_price_change_no_chunk() {
     let min_gas_price = 5000;
     let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
     let genesis_protocol_version = PROTOCOL_VERSION - 1;
-    genesis.config.epoch_length = epoch_length;
-    genesis.config.protocol_version = genesis_protocol_version;
-    genesis.config.min_gas_price = min_gas_price;
+    genesis.get_mut_ref_config().epoch_length = epoch_length;
+    genesis.get_mut_ref_config().protocol_version = genesis_protocol_version;
+    genesis.get_mut_ref_config().min_gas_price = min_gas_price;
     let chain_genesis = ChainGenesis::from(&genesis);
     let mut env =
         TestEnv::new_with_runtime(chain_genesis, 1, 1, create_nightshade_runtimes(&genesis, 1));
@@ -2143,9 +2143,9 @@ fn test_catchup_gas_price_change() {
     let epoch_length = 5;
     let min_gas_price = 10000;
     let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
-    genesis.config.epoch_length = epoch_length;
-    genesis.config.min_gas_price = min_gas_price;
-    genesis.config.gas_limit = 1000000000000;
+    genesis.get_mut_ref_config().epoch_length = epoch_length;
+    genesis.get_mut_ref_config().min_gas_price = min_gas_price;
+    genesis.get_mut_ref_config().gas_limit = 1000000000000;
     let chain_genesis = ChainGenesis::from(&genesis);
     let mut env =
         TestEnv::new_with_runtime(chain_genesis, 2, 1, create_nightshade_runtimes(&genesis, 2));
@@ -2218,9 +2218,9 @@ fn test_block_execution_outcomes() {
     let epoch_length = 5;
     let min_gas_price = 10000;
     let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
-    genesis.config.epoch_length = epoch_length;
-    genesis.config.min_gas_price = min_gas_price;
-    genesis.config.gas_limit = 1000000000000;
+    genesis.get_mut_ref_config().epoch_length = epoch_length;
+    genesis.get_mut_ref_config().min_gas_price = min_gas_price;
+    genesis.get_mut_ref_config().gas_limit = 1000000000000;
     let chain_genesis = ChainGenesis::from(&genesis);
     let mut env =
         TestEnv::new_with_runtime(chain_genesis, 1, 1, create_nightshade_runtimes(&genesis, 1));
@@ -2301,10 +2301,10 @@ fn test_refund_receipts_processing() {
     let epoch_length = 5;
     let min_gas_price = 10000;
     let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
-    genesis.config.epoch_length = epoch_length;
-    genesis.config.min_gas_price = min_gas_price;
+    genesis.get_mut_ref_config().epoch_length = epoch_length;
+    genesis.get_mut_ref_config().min_gas_price = min_gas_price;
     // set gas limit to be small
-    genesis.config.gas_limit = 1_000_000;
+    genesis.get_mut_ref_config().gas_limit = 1_000_000;
     let chain_genesis = ChainGenesis::from(&genesis);
     let mut env =
         TestEnv::new_with_runtime(chain_genesis, 1, 1, create_nightshade_runtimes(&genesis, 1));
@@ -2405,9 +2405,9 @@ fn test_epoch_protocol_version_change() {
     init_test_logger();
     let epoch_length = 5;
     let mut genesis = Genesis::test(vec!["test0", "test1"], 2);
-    genesis.config.epoch_length = epoch_length;
-    genesis.config.protocol_version = PROTOCOL_VERSION;
-    let genesis_height = genesis.config.genesis_height;
+    genesis.get_mut_ref_config().epoch_length = epoch_length;
+    genesis.get_mut_ref_config().protocol_version = PROTOCOL_VERSION;
+    let genesis_height = genesis.get_ref_config().genesis_height;
     let chain_genesis = ChainGenesis::from(&genesis);
     let mut env =
         TestEnv::new_with_runtime(chain_genesis, 2, 2, create_nightshade_runtimes(&genesis, 2));
@@ -2469,7 +2469,7 @@ fn test_epoch_protocol_version_change() {
 fn test_query_final_state() {
     let epoch_length = 10;
     let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
-    genesis.config.epoch_length = epoch_length;
+    genesis.get_mut_ref_config().epoch_length = epoch_length;
 
     let chain_genesis = ChainGenesis::from(&genesis);
     let mut env =
@@ -2652,7 +2652,7 @@ fn test_fork_execution_outcome() {
 fn prepare_env_with_transaction() -> (TestEnv, CryptoHash) {
     let epoch_length = 5;
     let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
-    genesis.config.epoch_length = epoch_length;
+    genesis.get_mut_ref_config().epoch_length = epoch_length;
     let mut env = TestEnv::new_with_runtime(
         ChainGenesis::test(),
         1,
@@ -2679,7 +2679,7 @@ fn prepare_env_with_transaction() -> (TestEnv, CryptoHash) {
 fn test_not_broadcast_block_on_accept() {
     let epoch_length = 5;
     let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
-    genesis.config.epoch_length = epoch_length;
+    genesis.get_mut_ref_config().epoch_length = epoch_length;
     let network_adapter = Arc::new(MockNetworkAdapter::default());
     let mut env = TestEnv::new_with_runtime_and_network_adapter(
         ChainGenesis::test(),
@@ -2701,7 +2701,7 @@ fn test_not_broadcast_block_on_accept() {
 fn test_header_version_downgrade() {
     use borsh::ser::BorshSerialize;
     let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
-    genesis.config.epoch_length = 5;
+    genesis.get_mut_ref_config().epoch_length = 5;
     let chain_genesis = ChainGenesis::from(&genesis);
     let mut env =
         TestEnv::new_with_runtime(chain_genesis, 1, 1, create_nightshade_runtimes(&genesis, 1));
@@ -2747,7 +2747,7 @@ fn test_header_version_downgrade() {
 fn test_node_shutdown_with_old_protocol_version() {
     let epoch_length = 5;
     let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
-    genesis.config.epoch_length = epoch_length;
+    genesis.get_mut_ref_config().epoch_length = epoch_length;
     let mut env = TestEnv::new_with_runtime(
         ChainGenesis::test(),
         1,
@@ -2896,7 +2896,7 @@ mod access_key_nonce_range_tests {
     fn test_transaction_hash_collision() {
         let epoch_length = 5;
         let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
-        genesis.config.epoch_length = epoch_length;
+        genesis.get_mut_ref_config().epoch_length = epoch_length;
         let mut env = TestEnv::new_with_runtime(
             ChainGenesis::test(),
             1,
@@ -2955,7 +2955,7 @@ mod access_key_nonce_range_tests {
     fn test_chunk_transaction_validity() {
         let epoch_length = 5;
         let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
-        genesis.config.epoch_length = epoch_length;
+        genesis.get_mut_ref_config().epoch_length = epoch_length;
         let mut env = TestEnv::new_with_runtime(
             ChainGenesis::test(),
             1,
@@ -2993,7 +2993,7 @@ mod access_key_nonce_range_tests {
     fn test_transaction_nonce_too_large() {
         let epoch_length = 5;
         let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
-        genesis.config.epoch_length = epoch_length;
+        genesis.get_mut_ref_config().epoch_length = epoch_length;
         let mut env = TestEnv::new_with_runtime(
             ChainGenesis::test(),
             1,
@@ -3039,9 +3039,9 @@ mod protocol_feature_restore_receipts_after_fix_tests {
 
         let protocol_version = ProtocolFeature::RestoreReceiptsAfterFix.protocol_version() - 1;
         let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
-        genesis.config.chain_id = String::from(chain_id);
-        genesis.config.epoch_length = EPOCH_LENGTH;
-        genesis.config.protocol_version = protocol_version;
+        genesis.get_mut_ref_config().chain_id = String::from(chain_id);
+        genesis.get_mut_ref_config().epoch_length = EPOCH_LENGTH;
+        genesis.get_mut_ref_config().protocol_version = protocol_version;
         let chain_genesis = ChainGenesis::from(&genesis);
         let runtime = nearcore::NightshadeRuntime::new(
             Path::new("."),
@@ -3053,7 +3053,7 @@ mod protocol_feature_restore_receipts_after_fix_tests {
             None,
         );
         // TODO #4305: get directly from NightshadeRuntime
-        let migration_data = load_migration_data(&genesis.config.chain_id);
+        let migration_data = load_migration_data(&genesis.get_ref_config().chain_id);
 
         let mut env = TestEnv::new_with_runtime(
             chain_genesis.clone(),
@@ -3186,9 +3186,9 @@ mod storage_usage_fix_tests {
     ) {
         let epoch_length = 5;
         let mut genesis = Genesis::test(vec!["test0", "near"], 1);
-        genesis.config.chain_id = chain_id;
-        genesis.config.epoch_length = epoch_length;
-        genesis.config.protocol_version = ProtocolFeature::FixStorageUsage.protocol_version() - 1;
+        genesis.get_mut_ref_config().chain_id = chain_id;
+        genesis.get_mut_ref_config().epoch_length = epoch_length;
+        genesis.get_mut_ref_config().protocol_version = ProtocolFeature::FixStorageUsage.protocol_version() - 1;
         let chain_genesis = ChainGenesis::from(&genesis);
         let mut env =
             TestEnv::new_with_runtime(chain_genesis, 1, 1, create_nightshade_runtimes(&genesis, 1));
@@ -3364,8 +3364,8 @@ mod contract_precompilation_tests {
         let num_clients = 2;
         let stores: Vec<Arc<Store>> = (0..num_clients).map(|_| create_test_store()).collect();
         let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
-        genesis.config.epoch_length = EPOCH_LENGTH;
-        let genesis_config = genesis.config.clone();
+        genesis.get_mut_ref_config().epoch_length = EPOCH_LENGTH;
+        let genesis_config = genesis.get_ref_config().clone();
         let runtimes: Vec<Arc<nearcore::NightshadeRuntime>> = stores
             .iter()
             .map(|store| {
@@ -3456,8 +3456,8 @@ mod contract_precompilation_tests {
         let num_clients = 2;
         let stores: Vec<Arc<Store>> = (0..num_clients).map(|_| create_test_store()).collect();
         let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
-        genesis.config.epoch_length = EPOCH_LENGTH;
-        let genesis_config = genesis.config.clone();
+        genesis.get_mut_ref_config().epoch_length = EPOCH_LENGTH;
+        let genesis_config = genesis.get_ref_config().clone();
         let runtimes: Vec<Arc<nearcore::NightshadeRuntime>> = stores
             .iter()
             .map(|store| {
@@ -3522,8 +3522,8 @@ mod contract_precompilation_tests {
         let num_clients = 3;
         let stores: Vec<Arc<Store>> = (0..num_clients).map(|_| create_test_store()).collect();
         let mut genesis = Genesis::test(vec!["test0", "test1", "test2"], 1);
-        genesis.config.epoch_length = EPOCH_LENGTH;
-        let genesis_config = genesis.config.clone();
+        genesis.get_mut_ref_config().epoch_length = EPOCH_LENGTH;
+        let genesis_config = genesis.get_ref_config().clone();
         let runtimes: Vec<Arc<nearcore::NightshadeRuntime>> = stores
             .iter()
             .map(|store| {

--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -1703,7 +1703,12 @@ fn test_gas_price_change() {
             .action_creation_config
             .transfer_cost
             .exec_fee()
-        + genesis.get_ref_config().runtime_config.transaction_costs.action_receipt_creation_config.exec_fee();
+        + genesis
+            .get_ref_config()
+            .runtime_config
+            .transaction_costs
+            .action_receipt_creation_config
+            .exec_fee();
     let min_gas_price = target_num_tokens_left / send_money_total_gas as u128;
     let gas_limit = 1000000000000;
     let gas_price_adjustment_rate = Rational::new(1, 10);
@@ -3188,7 +3193,8 @@ mod storage_usage_fix_tests {
         let mut genesis = Genesis::test(vec!["test0", "near"], 1);
         genesis.get_mut_ref_config().chain_id = chain_id;
         genesis.get_mut_ref_config().epoch_length = epoch_length;
-        genesis.get_mut_ref_config().protocol_version = ProtocolFeature::FixStorageUsage.protocol_version() - 1;
+        genesis.get_mut_ref_config().protocol_version =
+            ProtocolFeature::FixStorageUsage.protocol_version() - 1;
         let chain_genesis = ChainGenesis::from(&genesis);
         let mut env =
             TestEnv::new_with_runtime(chain_genesis, 1, 1, create_nightshade_runtimes(&genesis, 1));

--- a/chain/rosetta-rpc/src/adapters/mod.rs
+++ b/chain/rosetta-rpc/src/adapters/mod.rs
@@ -23,7 +23,7 @@ async fn convert_genesis_records_to_transaction(
     view_client_addr: Addr<ViewClientActor>,
     block: &near_primitives::views::BlockView,
 ) -> Result<crate::models::Transaction, crate::errors::ErrorKind> {
-    let genesis_account_ids = genesis.records.as_ref().iter().filter_map(|record| {
+    let genesis_account_ids = genesis.get_ref_records().0.iter().filter_map(|record| {
         if let near_primitives::state_record::StateRecord::Account { account_id, .. } = record {
             Some(account_id)
         } else {
@@ -41,7 +41,7 @@ async fn convert_genesis_records_to_transaction(
     for (account_id, account) in genesis_accounts {
         let account_balances = crate::utils::RosettaAccountBalances::from_account(
             &account,
-            &genesis.config.runtime_config,
+            &genesis.get_ref_config().runtime_config,
         );
 
         if account_balances.liquid != 0 {
@@ -142,7 +142,7 @@ pub(crate) async fn convert_block_to_transactions(
         .await??;
 
     let transactions = convert_block_changes_to_transactions(
-        &genesis.config.runtime_config,
+        &genesis.get_ref_config().runtime_config,
         &block.header.hash,
         accounts_changes,
         accounts_previous_state,

--- a/chain/rosetta-rpc/src/lib.rs
+++ b/chain/rosetta-rpc/src/lib.rs
@@ -73,7 +73,7 @@ async fn network_status(
         });
     }
 
-    let genesis_height = genesis.config.genesis_height;
+    let genesis_height = genesis.get_ref_config().genesis_height;
     let (network_info, genesis_block, earliest_block) = tokio::try_join!(
         client_addr.send(near_client::GetNetworkInfo {}),
         view_client_addr.send(near_client::GetBlock(
@@ -383,7 +383,7 @@ async fn account_balance(
 
     let account_balances = crate::utils::RosettaAccountBalances::from_account(
         account_info,
-        &genesis.config.runtime_config,
+        &genesis.get_ref_config().runtime_config,
     );
 
     let balance = if let Some(sub_account) = account_identifier.sub_account {

--- a/core/chain-configs/src/genesis_config.rs
+++ b/core/chain-configs/src/genesis_config.rs
@@ -190,9 +190,15 @@ pub struct Genesis {
 }
 
 impl Genesis {
-    pub fn get_config(self) -> GenesisConfig { self.config }
-    pub fn get_ref_config(&self) -> &GenesisConfig { &self.config }
-    pub fn get_mut_ref_config(&mut self) -> &mut GenesisConfig { &mut self.config }
+    pub fn get_config(self) -> GenesisConfig {
+        self.config
+    }
+    pub fn get_ref_config(&self) -> &GenesisConfig {
+        &self.config
+    }
+    pub fn get_mut_ref_config(&mut self) -> &mut GenesisConfig {
+        &mut self.config
+    }
     pub fn get_records(self) -> GenesisRecords {
         self.records
     }
@@ -202,7 +208,9 @@ impl Genesis {
     pub fn get_mut_ref_records(&mut self) -> &mut GenesisRecords {
         &mut self.records
     }
-    pub fn get_records_file_path(&self) -> &Path { self.records_file.as_path() }
+    pub fn get_records_file_path(&self) -> &Path {
+        self.records_file.as_path()
+    }
 }
 
 impl AsRef<GenesisConfig> for &Genesis {

--- a/genesis-tools/genesis-csv-to-json/src/csv_to_json_configs.rs
+++ b/genesis-tools/genesis-csv-to-json/src/csv_to_json_configs.rs
@@ -83,7 +83,7 @@ pub fn csv_to_json_configs(home: &Path, chain_id: String, tracked_shards: Vec<Sh
         ..Default::default()
     };
     let genesis = Genesis::new(genesis_config, records.into());
-    verify_total_supply(genesis.config.total_supply, &chain_id);
+    verify_total_supply(genesis.get_ref_config().total_supply, &chain_id);
 
     // Write all configs to files.
     config.write_to_file(&home.join(CONFIG_FILENAME));

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -167,7 +167,7 @@ impl GenesisBuilder {
         for (account_id, storage_usage) in self
             .runtime
             .runtime
-            .compute_storage_usage(&records, &self.genesis.config.runtime_config)
+            .compute_storage_usage(&records, &self.genesis.get_ref_config().runtime_config)
         {
             let mut account =
                 get_account(&state_update, &account_id)?.expect("We should've created account");
@@ -189,21 +189,22 @@ impl GenesisBuilder {
         let genesis_chunks = genesis_chunks(
             self.roots.values().cloned().collect(),
             self.runtime.num_shards(),
-            self.genesis.config.gas_limit,
-            self.genesis.config.genesis_height,
-            self.genesis.config.protocol_version,
+            self.genesis.get_ref_config().gas_limit,
+            self.genesis.get_ref_config().genesis_height,
+            self.genesis.get_ref_config().protocol_version,
         );
         let genesis = Block::genesis(
-            self.genesis.config.protocol_version,
+            self.genesis.get_ref_config().protocol_version,
             genesis_chunks.into_iter().map(|chunk| chunk.take_header()).collect(),
-            self.genesis.config.genesis_time,
-            self.genesis.config.genesis_height,
-            self.genesis.config.min_gas_price,
-            self.genesis.config.total_supply,
+            self.genesis.get_ref_config().genesis_time,
+            self.genesis.get_ref_config().genesis_height,
+            self.genesis.get_ref_config().min_gas_price,
+            self.genesis.get_ref_config().total_supply,
             Chain::compute_bp_hash(&self.runtime, EpochId::default(), &CryptoHash::default())?,
         );
 
-        let mut store = ChainStore::new(self.store.clone(), self.genesis.config.genesis_height);
+        let mut store =
+            ChainStore::new(self.store.clone(), self.genesis.get_ref_config().genesis_height);
         let mut store_update = store.store_update();
 
         store_update.merge(
@@ -225,7 +226,7 @@ impl GenesisBuilder {
                     CryptoHash::default(),
                     vec![],
                     0,
-                    self.genesis.config.gas_limit.clone(),
+                    self.genesis.get_ref_config().gas_limit.clone(),
                     0,
                 ),
             );

--- a/integration-tests/tests/test_cases_runtime.rs
+++ b/integration-tests/tests/test_cases_runtime.rs
@@ -21,8 +21,8 @@ mod test {
         let mut genesis = Genesis::test(vec![&alice_account(), &bob_account(), "carol.near"], 1);
         add_test_contract(&mut genesis, &bob_account());
         // Set expensive state requirements and add alice more money.
-        genesis.config.runtime_config.storage_amount_per_byte = TESTING_INIT_BALANCE / 1000;
-        match &mut genesis.records.as_mut()[0] {
+        genesis.get_mut_ref_config().runtime_config.storage_amount_per_byte = TESTING_INIT_BALANCE / 1000;
+        match &mut genesis.get_mut_ref_records().0[0] {
             StateRecord::Account { account, .. } => {
                 account.set_amount(TESTING_INIT_BALANCE * 10000)
             }
@@ -30,7 +30,7 @@ mod test {
                 panic!("the first record is expected to be alice account creation!");
             }
         }
-        genesis.records.as_mut().push(StateRecord::Data {
+        genesis.get_mut_ref_records().0.push(StateRecord::Data {
             account_id: bob_account(),
             data_key: b"test".to_vec(),
             value: b"123".to_vec(),

--- a/integration-tests/tests/test_cases_runtime.rs
+++ b/integration-tests/tests/test_cases_runtime.rs
@@ -21,7 +21,8 @@ mod test {
         let mut genesis = Genesis::test(vec![&alice_account(), &bob_account(), "carol.near"], 1);
         add_test_contract(&mut genesis, &bob_account());
         // Set expensive state requirements and add alice more money.
-        genesis.get_mut_ref_config().runtime_config.storage_amount_per_byte = TESTING_INIT_BALANCE / 1000;
+        genesis.get_mut_ref_config().runtime_config.storage_amount_per_byte =
+            TESTING_INIT_BALANCE / 1000;
         match &mut genesis.get_mut_ref_records().0[0] {
             StateRecord::Account { account, .. } => {
                 account.set_amount(TESTING_INIT_BALANCE * 10000)

--- a/integration-tests/tests/test_errors.rs
+++ b/integration-tests/tests/test_errors.rs
@@ -60,8 +60,8 @@ fn test_check_tx_error_log() {
 fn test_deliver_tx_error_log() {
     let node = start_node();
     let fee_helper = testlib::fees_utils::FeeHelper::new(
-        node.genesis().config.runtime_config.transaction_costs.clone(),
-        node.genesis().config.min_gas_price,
+        node.genesis().get_ref_config().runtime_config.transaction_costs.clone(),
+        node.genesis().get_ref_config().min_gas_price,
     );
     let signer = Arc::new(InMemorySigner::from_seed("alice.near", KeyType::ED25519, "alice.near"));
     let block_hash = node.user().get_best_block_hash().unwrap();

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -567,7 +567,7 @@ impl Genesis {
     pub fn test_free(seeds: Vec<&str>, num_validator_seats: NumSeats) -> Self {
         let mut genesis =
             Self::test_with_seeds(seeds, num_validator_seats, vec![num_validator_seats]);
-        genesis.config.runtime_config = RuntimeConfig::free();
+        genesis.get_mut_ref_config().runtime_config = RuntimeConfig::free();
         genesis
     }
 
@@ -605,7 +605,7 @@ impl NearConfig {
             config: config.clone(),
             client_config: ClientConfig {
                 version: Default::default(),
-                chain_id: genesis.config.chain_id.clone(),
+                chain_id: genesis.get_ref_config().chain_id.clone(),
                 rpc_addr: config.rpc_addr().map(|addr| addr.clone()),
                 block_production_tracking_delay: config.consensus.block_production_tracking_delay,
                 min_block_production_delay: config.consensus.min_block_production_delay,
@@ -626,9 +626,9 @@ impl NearConfig {
                 min_num_peers: config.consensus.min_num_peers,
                 log_summary_period: Duration::from_secs(10),
                 produce_empty_blocks: config.consensus.produce_empty_blocks,
-                epoch_length: genesis.config.epoch_length,
-                num_block_producer_seats: genesis.config.num_block_producer_seats,
-                announce_account_horizon: genesis.config.epoch_length / 2,
+                epoch_length: genesis.get_ref_config().epoch_length,
+                num_block_producer_seats: genesis.get_ref_config().num_block_producer_seats,
+                announce_account_horizon: genesis.get_ref_config().epoch_length / 2,
                 ttl_account_id_router: config.network.ttl_account_id_router,
                 // TODO(1047): this should be adjusted depending on the speed of sync of state.
                 block_fetch_horizon: config.consensus.block_fetch_horizon,
@@ -877,7 +877,7 @@ pub fn init_configs(
             }
 
             let mut genesis = Genesis::from_file(&genesis_path_str);
-            genesis.config.chain_id = chain_id.clone();
+            genesis.get_mut_ref_config().chain_id = chain_id.clone();
 
             genesis.to_file(&dir.join(config.genesis_file));
             info!(target: "near", "Generated for {} network node key and genesis file in {}", chain_id, dir.to_str().unwrap());

--- a/nearcore/src/genesis_validate.rs
+++ b/nearcore/src/genesis_validate.rs
@@ -6,7 +6,7 @@ use std::collections::{HashMap, HashSet};
 
 /// Validate genesis config and records. Panics if genesis is ill-formed.
 pub fn validate_genesis(genesis: &Genesis) {
-    let mut genesis_validator = GenesisValidator::new(&genesis.config);
+    let mut genesis_validator = GenesisValidator::new(&genesis.get_ref_config());
     genesis.for_each_record(|record: &StateRecord| {
         genesis_validator.process_record(record);
     });
@@ -149,12 +149,12 @@ mod test {
     #[should_panic(expected = "wrong total supply")]
     fn test_total_supply_not_match() {
         let mut genesis = Genesis::default();
-        genesis.config.validators = vec![AccountInfo {
+        genesis.get_mut_ref_config().validators = vec![AccountInfo {
             account_id: "test".to_string(),
             public_key: VALID_ED25519_RISTRETTO_KEY.parse().unwrap(),
             amount: 10,
         }];
-        genesis.records = GenesisRecords(vec![StateRecord::Account {
+        *genesis.get_mut_ref_records() = GenesisRecords(vec![StateRecord::Account {
             account_id: "test".to_string(),
             account: create_account(),
         }]);
@@ -165,12 +165,12 @@ mod test {
     #[should_panic(expected = "validator staking key is not valid")]
     fn test_invalid_staking_key() {
         let mut genesis = Genesis::default();
-        genesis.config.validators = vec![AccountInfo {
+        genesis.get_mut_ref_config().validators = vec![AccountInfo {
             account_id: "test".to_string(),
             public_key: PublicKey::empty(KeyType::ED25519),
             amount: 10,
         }];
-        genesis.records = GenesisRecords(vec![StateRecord::Account {
+        *genesis.get_mut_ref_records() = GenesisRecords(vec![StateRecord::Account {
             account_id: "test".to_string(),
             account: create_account(),
         }]);
@@ -181,13 +181,13 @@ mod test {
     #[should_panic(expected = "validator accounts do not match staked accounts")]
     fn test_validator_not_match() {
         let mut genesis = Genesis::default();
-        genesis.config.validators = vec![AccountInfo {
+        genesis.get_mut_ref_config().validators = vec![AccountInfo {
             account_id: "test".to_string(),
             public_key: VALID_ED25519_RISTRETTO_KEY.parse().unwrap(),
             amount: 100,
         }];
-        genesis.config.total_supply = 110;
-        genesis.records = GenesisRecords(vec![StateRecord::Account {
+        genesis.get_mut_ref_config().total_supply = 110;
+        *genesis.get_mut_ref_records() = GenesisRecords(vec![StateRecord::Account {
             account_id: "test".to_string(),
             account: create_account(),
         }]);
@@ -198,7 +198,7 @@ mod test {
     #[should_panic(expected = "no validators in genesis")]
     fn test_empty_validator() {
         let mut genesis = Genesis::default();
-        genesis.records = GenesisRecords(vec![StateRecord::Account {
+        *genesis.get_mut_ref_records() = GenesisRecords(vec![StateRecord::Account {
             account_id: "test".to_string(),
             account: create_account(),
         }]);
@@ -209,13 +209,13 @@ mod test {
     #[should_panic(expected = "access key account test1 does not exist")]
     fn test_access_key_with_nonexistent_account() {
         let mut genesis = Genesis::default();
-        genesis.config.validators = vec![AccountInfo {
+        genesis.get_mut_ref_config().validators = vec![AccountInfo {
             account_id: "test".to_string(),
             public_key: VALID_ED25519_RISTRETTO_KEY.parse().unwrap(),
             amount: 10,
         }];
-        genesis.config.total_supply = 110;
-        genesis.records = GenesisRecords(vec![
+        genesis.get_mut_ref_config().total_supply = 110;
+        *genesis.get_mut_ref_records() = GenesisRecords(vec![
             StateRecord::Account { account_id: "test".to_string(), account: create_account() },
             StateRecord::AccessKey {
                 account_id: "test1".to_string(),
@@ -230,13 +230,13 @@ mod test {
     #[should_panic(expected = "account test has more than one contract deployed")]
     fn test_more_than_one_contract() {
         let mut genesis = Genesis::default();
-        genesis.config.validators = vec![AccountInfo {
+        genesis.get_mut_ref_config().validators = vec![AccountInfo {
             account_id: "test".to_string(),
             public_key: VALID_ED25519_RISTRETTO_KEY.parse().unwrap(),
             amount: 10,
         }];
-        genesis.config.total_supply = 110;
-        genesis.records = GenesisRecords(vec![
+        genesis.get_mut_ref_config().total_supply = 110;
+        *genesis.get_mut_ref_records() = GenesisRecords(vec![
             StateRecord::Account { account_id: "test".to_string(), account: create_account() },
             StateRecord::Contract { account_id: "test".to_string(), code: [1, 2, 3].to_vec() },
             StateRecord::Contract { account_id: "test".to_string(), code: [1, 2, 3, 4].to_vec() },

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -307,7 +307,7 @@ pub fn start_with_config(
     if let Some(rpc_config) = config.rpc_config {
         near_jsonrpc::start_http(
             rpc_config,
-            config.genesis.config.clone(),
+            config.genesis.get_ref_config().clone(),
             client_actor.clone(),
             view_client.clone(),
         );

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -106,7 +106,7 @@ pub fn migrate_12_to_13(path: &String, near_config: &NearConfig) {
         store_update.commit().unwrap();
     } else {
         // archival node. Fix the inconsistencies by re-applying the entire history.
-        let genesis_height = near_config.genesis.config.genesis_height;
+        let genesis_height = near_config.genesis.get_ref_config().genesis_height;
         let mut chain_store = ChainStore::new(store.clone(), genesis_height);
         let head = chain_store.head().expect("head must exist");
         let runtime = NightshadeRuntime::new(
@@ -146,14 +146,14 @@ pub fn migrate_18_to_19(path: &String, near_config: &NearConfig) {
     use near_primitives::types::EpochId;
     let store = create_store(path);
     if near_config.client_config.archive {
-        let genesis_height = near_config.genesis.config.genesis_height;
+        let genesis_height = near_config.genesis.get_ref_config().genesis_height;
         let mut chain_store = ChainStore::new(store.clone(), genesis_height);
         let mut epoch_manager = EpochManager::new(
             store.clone(),
-            EpochConfig::from(&near_config.genesis.config),
-            near_config.genesis.config.protocol_version,
-            RewardCalculator::new(&near_config.genesis.config),
-            near_config.genesis.config.validators(),
+            EpochConfig::from(near_config.genesis.get_ref_config()),
+            near_config.genesis.get_ref_config().protocol_version,
+            RewardCalculator::new(&near_config.genesis.get_ref_config()),
+            near_config.genesis.get_ref_config().validators(),
         )
         .unwrap();
         for (key, value) in store.iter(DBCol::ColEpochStart) {
@@ -215,8 +215,8 @@ pub fn migrate_18_to_19(path: &String, near_config: &NearConfig) {
 
 pub fn migrate_19_to_20(path: &String, near_config: &NearConfig) {
     let store = create_store(path);
-    if near_config.client_config.archive && &near_config.genesis.config.chain_id == "mainnet" {
-        let genesis_height = near_config.genesis.config.genesis_height;
+    if near_config.client_config.archive && &near_config.genesis.get_ref_config().chain_id == "mainnet" {
+        let genesis_height = near_config.genesis.get_ref_config().genesis_height;
         let mut chain_store = ChainStore::new(store.clone(), genesis_height);
         let head = chain_store.head().unwrap();
         let runtime = NightshadeRuntime::new(
@@ -283,8 +283,8 @@ pub fn migrate_19_to_20(path: &String, near_config: &NearConfig) {
 /// This is a one time patch to fix an existing issue in mainnet database (https://github.com/near/near-indexer-for-explorer/issues/110)
 pub fn migrate_22_to_23(path: &String, near_config: &NearConfig) {
     let store = create_store(path);
-    if near_config.client_config.archive && &near_config.genesis.config.chain_id == "mainnet" {
-        let genesis_height = near_config.genesis.config.genesis_height;
+    if near_config.client_config.archive && &near_config.genesis.get_ref_config().chain_id == "mainnet" {
+        let genesis_height = near_config.genesis.get_ref_config().genesis_height;
         let mut chain_store = ChainStore::new(store.clone(), genesis_height);
         let runtime = NightshadeRuntime::new(
             &Path::new(path),
@@ -364,7 +364,7 @@ lazy_static_include::lazy_static_include_bytes! {
 /// Put receipts restored in scope of issue https://github.com/near/nearcore/pull/4248 to storage.
 pub fn migrate_23_to_24(path: &String, near_config: &NearConfig) {
     let store = create_store(path);
-    if &near_config.genesis.config.chain_id == "mainnet" {
+    if &near_config.genesis.get_ref_config().chain_id == "mainnet" {
         let mut store_update = store.store_update();
         let restored_receipts: ReceiptResult = serde_json::from_slice(&MAINNET_RESTORED_RECEIPTS)
             .expect("File with receipts restored after apply_chunks fix have to be correct");

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -215,7 +215,9 @@ pub fn migrate_18_to_19(path: &String, near_config: &NearConfig) {
 
 pub fn migrate_19_to_20(path: &String, near_config: &NearConfig) {
     let store = create_store(path);
-    if near_config.client_config.archive && &near_config.genesis.get_ref_config().chain_id == "mainnet" {
+    if near_config.client_config.archive
+        && &near_config.genesis.get_ref_config().chain_id == "mainnet"
+    {
         let genesis_height = near_config.genesis.get_ref_config().genesis_height;
         let mut chain_store = ChainStore::new(store.clone(), genesis_height);
         let head = chain_store.head().unwrap();
@@ -283,7 +285,9 @@ pub fn migrate_19_to_20(path: &String, near_config: &NearConfig) {
 /// This is a one time patch to fix an existing issue in mainnet database (https://github.com/near/near-indexer-for-explorer/issues/110)
 pub fn migrate_22_to_23(path: &String, near_config: &NearConfig) {
     let store = create_store(path);
-    if near_config.client_config.archive && &near_config.genesis.get_ref_config().chain_id == "mainnet" {
+    if near_config.client_config.archive
+        && &near_config.genesis.get_ref_config().chain_id == "mainnet"
+    {
         let genesis_height = near_config.genesis.get_ref_config().genesis_height;
         let mut chain_store = ChainStore::new(store.clone(), genesis_height);
         let runtime = NightshadeRuntime::new(

--- a/nearcore/tests/economics.rs
+++ b/nearcore/tests/economics.rs
@@ -22,8 +22,8 @@ fn setup_env(f: &mut dyn FnMut(&mut Genesis) -> ()) -> (TestEnv, FeeHelper) {
     let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
     f(&mut genesis);
     let fee_helper = FeeHelper::new(
-        genesis.config.runtime_config.transaction_costs.clone(),
-        genesis.config.min_gas_price,
+        genesis.get_ref_config().runtime_config.transaction_costs.clone(),
+        genesis.get_ref_config().min_gas_price,
     );
     let runtimes: Vec<Arc<dyn RuntimeAdapter>> = vec![Arc::new(nearcore::NightshadeRuntime::new(
         Path::new("."),
@@ -67,14 +67,14 @@ fn calc_total_supply(env: &mut TestEnv) -> u128 {
 /// This combines Client & NightshadeRuntime to also test EpochManager.
 #[test]
 fn test_burn_mint() {
-    let (mut env, fee_helper) = setup_env(&mut |mut genesis| {
-        genesis.config.epoch_length = 2;
-        genesis.config.num_blocks_per_year = 2;
-        genesis.config.protocol_reward_rate = Rational::new_raw(1, 10);
-        genesis.config.max_inflation_rate = Rational::new_raw(1, 10);
-        genesis.config.chunk_producer_kickout_threshold = 30;
-        genesis.config.online_min_threshold = Rational::new_raw(0, 1);
-        genesis.config.online_max_threshold = Rational::new_raw(1, 1);
+    let (mut env, fee_helper) = setup_env(&mut |genesis| {
+        genesis.get_mut_ref_config().epoch_length = 2;
+        genesis.get_mut_ref_config().num_blocks_per_year = 2;
+        genesis.get_mut_ref_config().protocol_reward_rate = Rational::new_raw(1, 10);
+        genesis.get_mut_ref_config().max_inflation_rate = Rational::new_raw(1, 10);
+        genesis.get_mut_ref_config().chunk_producer_kickout_threshold = 30;
+        genesis.get_mut_ref_config().online_min_threshold = Rational::new_raw(0, 1);
+        genesis.get_mut_ref_config().online_max_threshold = Rational::new_raw(1, 1);
     });
     let signer = InMemorySigner::from_seed("test0", KeyType::ED25519, "test0");
     let initial_total_supply = env.chain_genesis.total_supply;

--- a/nearcore/tests/rpc_nodes.rs
+++ b/nearcore/tests/rpc_nodes.rs
@@ -257,7 +257,7 @@ fn test_protocol_config_rpc() {
             .unwrap();
         assert_ne!(
             config_response.config_view.runtime_config.storage_amount_per_byte,
-            genesis.config.runtime_config.storage_amount_per_byte
+            genesis.get_ref_config().runtime_config.storage_amount_per_byte
         );
         assert_eq!(
             config_response.config_view.runtime_config.storage_amount_per_byte,

--- a/nearcore/tests/stake_nodes.rs
+++ b/nearcore/tests/stake_nodes.rs
@@ -49,14 +49,14 @@ fn init_test_staking(
     let seeds = (0..num_node_seats).map(|i| format!("near.{}", i)).collect::<Vec<_>>();
     let mut genesis =
         Genesis::test(seeds.iter().map(|s| s.as_str()).collect(), num_validator_seats);
-    genesis.config.epoch_length = epoch_length;
-    genesis.config.num_block_producer_seats = num_node_seats;
-    genesis.config.block_producer_kickout_threshold = 20;
-    genesis.config.chunk_producer_kickout_threshold = 20;
-    genesis.config.minimum_stake_divisor = minimum_stake_divisor;
+    genesis.get_mut_ref_config().epoch_length = epoch_length;
+    genesis.get_mut_ref_config().num_block_producer_seats = num_node_seats;
+    genesis.get_mut_ref_config().block_producer_kickout_threshold = 20;
+    genesis.get_mut_ref_config().chunk_producer_kickout_threshold = 20;
+    genesis.get_mut_ref_config().minimum_stake_divisor = minimum_stake_divisor;
     if !enable_rewards {
-        genesis.config.max_inflation_rate = Rational::from_integer(0);
-        genesis.config.min_gas_price = 0;
+        genesis.get_mut_ref_config().max_inflation_rate = Rational::from_integer(0);
+        genesis.get_mut_ref_config().min_gas_price = 0;
     }
     let first_node = open_port();
 
@@ -478,8 +478,9 @@ fn test_inflation() {
                 true,
                 10,
             );
-            let initial_total_supply = test_nodes[0].config.genesis.config.total_supply;
-            let max_inflation_rate = test_nodes[0].config.genesis.config.max_inflation_rate;
+            let initial_total_supply = test_nodes[0].config.genesis.get_ref_config().total_supply;
+            let max_inflation_rate =
+                test_nodes[0].config.genesis.get_ref_config().max_inflation_rate;
 
             let (done1, done2) =
                 (Arc::new(AtomicBool::new(false)), Arc::new(AtomicBool::new(false)));

--- a/nearcore/tests/sync_nodes.rs
+++ b/nearcore/tests/sync_nodes.rs
@@ -97,7 +97,7 @@ fn add_blocks(
 
 fn setup_configs() -> (Genesis, Block, NearConfig, NearConfig) {
     let mut genesis = Genesis::test(vec!["other"], 1);
-    genesis.config.epoch_length = 5;
+    genesis.get_mut_ref_config().epoch_length = 5;
     let genesis_block = genesis_block(&genesis);
 
     let (port1, port2) = (open_port(), open_port());
@@ -126,7 +126,7 @@ fn sync_nodes() {
 
             let signer = InMemoryValidatorSigner::from_seed("other", KeyType::ED25519, "other");
             let _ =
-                add_blocks(vec![genesis_block], client1, 13, genesis.config.epoch_length, &signer);
+                add_blocks(vec![genesis_block], client1, 13, genesis.get_ref_config().epoch_length, &signer);
 
             let dir2 = tempfile::Builder::new().prefix("sync_nodes_2").tempdir().unwrap();
             let (_, view_client2, _) = start_with_config(dir2.path(), near2);
@@ -170,12 +170,12 @@ fn sync_after_sync_nodes() {
                 vec![genesis_block],
                 client1.clone(),
                 13,
-                genesis.config.epoch_length,
+                genesis.get_ref_config().epoch_length,
                 &signer,
             );
 
             let next_step = Arc::new(AtomicBool::new(false));
-            let epoch_length = genesis.config.epoch_length;
+            let epoch_length = genesis.get_ref_config().epoch_length;
             WaitOrTimeout::new(
                 Box::new(move |_ctx| {
                     let blocks1 = blocks.clone();
@@ -214,8 +214,8 @@ fn sync_state_stake_change() {
         init_integration_logger();
 
         let mut genesis = Genesis::test(vec!["test1"], 1);
-        genesis.config.epoch_length = 5;
-        genesis.config.block_producer_kickout_threshold = 80;
+        genesis.get_mut_ref_config().epoch_length = 5;
+        genesis.get_mut_ref_config().block_producer_kickout_threshold = 80;
 
         let (port1, port2) = (open_port(), open_port());
         let mut near1 = load_test_config("test1", port1, genesis.clone());

--- a/nearcore/tests/sync_nodes.rs
+++ b/nearcore/tests/sync_nodes.rs
@@ -125,8 +125,13 @@ fn sync_nodes() {
             let (client1, _, _) = start_with_config(dir1.path(), near1);
 
             let signer = InMemoryValidatorSigner::from_seed("other", KeyType::ED25519, "other");
-            let _ =
-                add_blocks(vec![genesis_block], client1, 13, genesis.get_ref_config().epoch_length, &signer);
+            let _ = add_blocks(
+                vec![genesis_block],
+                client1,
+                13,
+                genesis.get_ref_config().epoch_length,
+                &signer,
+            );
 
             let dir2 = tempfile::Builder::new().prefix("sync_nodes_2").tempdir().unwrap();
             let (_, view_client2, _) = start_with_config(dir2.path(), near2);

--- a/nearcore/tests/sync_state_nodes.rs
+++ b/nearcore/tests/sync_state_nodes.rs
@@ -110,7 +110,7 @@ fn sync_state_nodes_multishard() {
 
         let mut genesis =
             Genesis::test_sharded(vec!["test1", "test2", "test3", "test4"], 4, vec![2, 2]);
-        genesis.config.epoch_length = 150; // so that by the time test2 joins it is not kicked out yet
+        genesis.get_mut_ref_config().epoch_length = 150; // so that by the time test2 joins it is not kicked out yet
 
         run_actix(async move {
             let (port1, port2, port3, port4) = (open_port(), open_port(), open_port(), open_port());
@@ -244,7 +244,7 @@ fn sync_empty_state() {
         init_integration_logger();
 
         let mut genesis = Genesis::test_sharded(vec!["test1", "test2"], 1, vec![1, 1, 1, 1]);
-        genesis.config.epoch_length = 20;
+        genesis.get_mut_ref_config().epoch_length = 20;
 
         run_actix(async move {
             let (port1, port2) = (open_port(), open_port());

--- a/test-utils/state-viewer/src/main.rs
+++ b/test-utils/state-viewer/src/main.rs
@@ -55,7 +55,8 @@ fn load_trie_stop_at_height(
     near_config: &NearConfig,
     mode: LoadTrieMode,
 ) -> (NightshadeRuntime, Vec<StateRoot>, BlockHeader) {
-    let mut chain_store = ChainStore::new(store.clone(), near_config.genesis.config.genesis_height);
+    let mut chain_store =
+        ChainStore::new(store.clone(), near_config.genesis.get_ref_config().genesis_height);
 
     let runtime = NightshadeRuntime::new(
         &home_dir,
@@ -114,7 +115,8 @@ fn print_chain(
     start_height: BlockHeight,
     end_height: BlockHeight,
 ) {
-    let mut chain_store = ChainStore::new(store.clone(), near_config.genesis.config.genesis_height);
+    let mut chain_store =
+        ChainStore::new(store.clone(), near_config.genesis.get_ref_config().genesis_height);
     let runtime = NightshadeRuntime::new(
         &home_dir,
         store,
@@ -184,7 +186,8 @@ fn replay_chain(
     start_height: BlockHeight,
     end_height: BlockHeight,
 ) {
-    let mut chain_store = ChainStore::new(store, near_config.genesis.config.genesis_height);
+    let mut chain_store =
+        ChainStore::new(store, near_config.genesis.get_ref_config().genesis_height);
     let new_store = create_test_store();
     let runtime = NightshadeRuntime::new(
         &home_dir,
@@ -217,7 +220,8 @@ fn apply_block_at_height(
     height: BlockHeight,
     shard_id: ShardId,
 ) {
-    let mut chain_store = ChainStore::new(store.clone(), near_config.genesis.config.genesis_height);
+    let mut chain_store =
+        ChainStore::new(store.clone(), near_config.genesis.get_ref_config().genesis_height);
     let runtime_adapter: Arc<dyn RuntimeAdapter> = Arc::new(NightshadeRuntime::new(
         &home_dir,
         store,
@@ -302,7 +306,7 @@ fn apply_block_at_height(
         outcome_root,
         apply_result.validator_proposals,
         apply_result.total_gas_burnt,
-        near_config.genesis.config.gas_limit,
+        near_config.genesis.get_ref_config().gas_limit,
         apply_result.total_balance_burnt,
     );
 
@@ -324,7 +328,8 @@ fn view_chain(
     view_block: bool,
     view_chunks: bool,
 ) {
-    let mut chain_store = ChainStore::new(store.clone(), near_config.genesis.config.genesis_height);
+    let mut chain_store =
+        ChainStore::new(store.clone(), near_config.genesis.get_ref_config().genesis_height);
     let block = {
         match height {
             Some(h) => {
@@ -384,7 +389,7 @@ fn view_chain(
 }
 
 fn check_block_chunk_existence(store: Arc<Store>, near_config: &NearConfig) {
-    let genesis_height = near_config.genesis.config.genesis_height;
+    let genesis_height = near_config.genesis.get_ref_config().genesis_height;
     let mut chain_store = ChainStore::new(store.clone(), genesis_height);
     let head = chain_store.head().unwrap();
     let mut cur_block = chain_store.get_block(&head.last_block_hash).unwrap().clone();
@@ -605,8 +610,12 @@ fn main() {
             let height = header.height();
             let home_dir = PathBuf::from(&home_dir);
 
-            let new_genesis =
-                state_dump(runtime, state_roots.clone(), header, &near_config.genesis.config);
+            let new_genesis = state_dump(
+                runtime,
+                state_roots.clone(),
+                header,
+                near_config.genesis.get_ref_config(),
+            );
 
             let output_path = home_dir.join(Path::new("output.json"));
             println!(

--- a/test-utils/state-viewer/src/state_dump.rs
+++ b/test-utils/state-viewer/src/state_dump.rs
@@ -91,9 +91,9 @@ mod test {
 
     fn setup(epoch_length: NumBlocks) -> (Arc<Store>, Genesis, TestEnv) {
         let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
-        genesis.config.num_block_producer_seats = 2;
-        genesis.config.num_block_producer_seats_per_shard = vec![2];
-        genesis.config.epoch_length = epoch_length;
+        genesis.get_mut_ref_config().num_block_producer_seats = 2;
+        genesis.get_mut_ref_config().num_block_producer_seats_per_shard = vec![2];
+        genesis.get_mut_ref_config().epoch_length = epoch_length;
         let store = create_test_store();
         let nightshade_runtime = NightshadeRuntime::new(
             Path::new("."),
@@ -107,7 +107,7 @@ mod test {
         let runtimes: Vec<Arc<dyn RuntimeAdapter>> = vec![Arc::new(nightshade_runtime)];
         let mut chain_genesis = ChainGenesis::test();
         chain_genesis.epoch_length = epoch_length;
-        chain_genesis.gas_limit = genesis.config.gas_limit;
+        chain_genesis.gas_limit = genesis.get_ref_config().gas_limit;
         let env = TestEnv::new_with_runtime(chain_genesis, 1, 2, runtimes);
         (store, genesis, env)
     }
@@ -153,9 +153,13 @@ mod test {
             None,
             None,
         );
-        let new_genesis =
-            state_dump(runtime, state_roots, last_block.header().clone(), &genesis.config);
-        assert_eq!(new_genesis.config.validators.len(), 2);
+        let new_genesis = state_dump(
+            runtime,
+            state_roots,
+            last_block.header().clone(),
+            &genesis.get_ref_config(),
+        );
+        assert_eq!(new_genesis.get_ref_config().validators.len(), 2);
         validate_genesis(&new_genesis);
     }
 
@@ -190,11 +194,15 @@ mod test {
             None,
             None,
         );
-        let new_genesis =
-            state_dump(runtime, state_roots, last_block.header().clone(), &genesis.config);
+        let new_genesis = state_dump(
+            runtime,
+            state_roots,
+            last_block.header().clone(),
+            &genesis.get_ref_config(),
+        );
         assert_eq!(
             new_genesis
-                .config
+                .get_ref_config()
                 .validators
                 .clone()
                 .into_iter()
@@ -211,9 +219,9 @@ mod test {
     fn test_dump_state_not_track_shard() {
         let epoch_length = 4;
         let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
-        genesis.config.num_block_producer_seats = 2;
-        genesis.config.num_block_producer_seats_per_shard = vec![2];
-        genesis.config.epoch_length = epoch_length;
+        genesis.get_mut_ref_config().num_block_producer_seats = 2;
+        genesis.get_mut_ref_config().num_block_producer_seats_per_shard = vec![2];
+        genesis.get_mut_ref_config().epoch_length = epoch_length;
         let store1 = create_test_store();
         let store2 = create_test_store();
         let create_runtime = |store| -> NightshadeRuntime {
@@ -225,7 +233,7 @@ mod test {
         ];
         let mut chain_genesis = ChainGenesis::test();
         chain_genesis.epoch_length = epoch_length;
-        chain_genesis.gas_limit = genesis.config.gas_limit;
+        chain_genesis.gas_limit = genesis.get_ref_config().gas_limit;
         let mut env = TestEnv::new_with_runtime(chain_genesis, 2, 1, runtimes);
         let genesis_hash = *env.clients[0].chain.genesis().hash();
         let signer = InMemorySigner::from_seed("test1", KeyType::ED25519, "test1");
@@ -253,17 +261,21 @@ mod test {
             last_block.chunks().iter().map(|chunk| chunk.prev_state_root()).collect::<Vec<_>>();
         let runtime2 = create_runtime(store2);
 
-        let _ =
-            state_dump(runtime2, state_roots.clone(), last_block.header().clone(), &genesis.config);
+        let _ = state_dump(
+            runtime2,
+            state_roots.clone(),
+            last_block.header().clone(),
+            &genesis.get_ref_config(),
+        );
     }
 
     #[test]
     fn test_dump_state_with_delayed_receipt() {
         let epoch_length = 4;
         let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
-        genesis.config.num_block_producer_seats = 2;
-        genesis.config.num_block_producer_seats_per_shard = vec![2];
-        genesis.config.epoch_length = epoch_length;
+        genesis.get_mut_ref_config().num_block_producer_seats = 2;
+        genesis.get_mut_ref_config().num_block_producer_seats_per_shard = vec![2];
+        genesis.get_mut_ref_config().epoch_length = epoch_length;
         let store = create_test_store();
         let nightshade_runtime = NightshadeRuntime::new(
             Path::new("."),
@@ -314,9 +326,13 @@ mod test {
             None,
             None,
         );
-        let new_genesis =
-            state_dump(runtime, state_roots, last_block.header().clone(), &genesis.config);
-        assert_eq!(new_genesis.config.validators.len(), 2);
+        let new_genesis = state_dump(
+            runtime,
+            state_roots,
+            last_block.header().clone(),
+            &genesis.get_ref_config(),
+        );
+        assert_eq!(new_genesis.get_ref_config().validators.len(), 2);
         validate_genesis(&new_genesis);
     }
 }

--- a/test-utils/store-validator/src/main.rs
+++ b/test-utils/store-validator/src/main.rs
@@ -43,7 +43,7 @@ fn main() {
 
     let mut store_validator = StoreValidator::new(
         near_config.validator_signer.as_ref().map(|x| x.validator_id().clone()),
-        near_config.genesis.config.clone(),
+        near_config.genesis.get_ref_config().clone(),
         runtime_adapter.clone(),
         store.clone(),
     );

--- a/test-utils/testlib/src/lib.rs
+++ b/test-utils/testlib/src/lib.rs
@@ -69,8 +69,8 @@ pub fn start_nodes(
         num_validator_seats,
         (0..num_shards).map(|_| num_validator_seats).collect(),
     );
-    genesis.config.epoch_length = epoch_length;
-    genesis.config.genesis_height = genesis_height;
+    genesis.get_mut_ref_config().epoch_length = epoch_length;
+    genesis.get_mut_ref_config().genesis_height = genesis_height;
 
     let validators = (0..num_validator_seats).map(|i| format!("near.{}", i)).collect::<Vec<_>>();
     let mut near_configs = vec![];

--- a/test-utils/testlib/src/node/mod.rs
+++ b/test-utils/testlib/src/node/mod.rs
@@ -150,10 +150,10 @@ pub fn create_nodes_from_seeds(seeds: Vec<String>) -> Vec<NodeConfig> {
     let code = near_test_contracts::rs_contract();
     let (configs, validator_signers, network_signers, mut genesis) =
         create_testnet_configs_from_seeds(seeds.clone(), 1, 0, true, false);
-    genesis.config.gas_price_adjustment_rate = Rational::from_integer(0);
+    genesis.get_mut_ref_config().gas_price_adjustment_rate = Rational::from_integer(0);
     for seed in seeds {
         let mut is_account_record_found = false;
-        for record in genesis.records.as_mut() {
+        for record in &mut genesis.get_mut_ref_records().0 {
             if let StateRecord::Account { account_id: record_account_id, ref mut account } = record
             {
                 if *record_account_id == seed {
@@ -164,8 +164,8 @@ pub fn create_nodes_from_seeds(seeds: Vec<String>) -> Vec<NodeConfig> {
         }
         assert!(is_account_record_found);
         genesis
-            .records
-            .as_mut()
+            .get_mut_ref_records()
+            .0
             .push(StateRecord::Contract { account_id: seed, code: code.to_vec() });
     }
     near_configs_to_node_configs(configs, validator_signers, network_signers, genesis)

--- a/test-utils/testlib/src/node/runtime_node.rs
+++ b/test-utils/testlib/src/node/runtime_node.rs
@@ -26,7 +26,7 @@ impl RuntimeNode {
         let mut genesis = Genesis::test(vec![&alice_account(), &bob_account(), "carol.near"], 3);
         add_test_contract(&mut genesis, &alice_account());
         add_test_contract(&mut genesis, &bob_account());
-        genesis.records.as_mut().push(StateRecord::Account {
+        genesis.get_mut_ref_records().0.push(StateRecord::Account {
             account_id: evm_account(),
             account: Account::new(TESTING_INIT_BALANCE, 0, CryptoHash::default(), 0),
         });
@@ -40,8 +40,8 @@ impl RuntimeNode {
             runtime,
             tries,
             state_root: root,
-            epoch_length: genesis.config.epoch_length,
-            runtime_config: genesis.config.runtime_config.clone(),
+            epoch_length: genesis.get_ref_config().epoch_length,
+            runtime_config: genesis.get_ref_config().runtime_config.clone(),
         }));
         RuntimeNode { signer, client, genesis }
     }
@@ -105,8 +105,8 @@ mod tests {
         );
         node_user.send_money(alice_account(), bob_account(), 1).unwrap();
         let fee_helper = FeeHelper::new(
-            node.genesis().config.runtime_config.transaction_costs.clone(),
-            node.genesis().config.min_gas_price,
+            node.genesis().get_ref_config().runtime_config.transaction_costs.clone(),
+            node.genesis().get_ref_config().min_gas_price,
         );
         let transfer_cost = fee_helper.transfer_cost();
         let (alice2, bob2) = (

--- a/test-utils/testlib/src/runtime_utils.rs
+++ b/test-utils/testlib/src/runtime_utils.rs
@@ -31,7 +31,7 @@ lazy_static::lazy_static! {
 
 pub fn add_test_contract(genesis: &mut Genesis, account_id: &AccountId) {
     let mut is_account_record_found = false;
-    for record in genesis.records.as_mut() {
+    for record in &mut genesis.get_mut_ref_records().0 {
         if let StateRecord::Account { account_id: record_account_id, ref mut account } = record {
             if record_account_id == account_id {
                 is_account_record_found = true;
@@ -40,12 +40,12 @@ pub fn add_test_contract(genesis: &mut Genesis, account_id: &AccountId) {
         }
     }
     if !is_account_record_found {
-        genesis.records.as_mut().push(StateRecord::Account {
+        genesis.get_mut_ref_records().0.push(StateRecord::Account {
             account_id: account_id.clone(),
             account: Account::new(0, 0, *DEFAULT_TEST_CONTRACT_HASH, 0),
         });
     }
-    genesis.records.as_mut().push(StateRecord::Contract {
+    genesis.get_mut_ref_records().0.push(StateRecord::Contract {
         account_id: account_id.clone(),
         code: near_test_contracts::rs_contract().to_vec(),
     });
@@ -62,7 +62,7 @@ pub fn get_runtime_and_trie_from_genesis(genesis: &Genesis) -> (Runtime, ShardTr
         tries.clone(),
         0,
         &genesis
-            .config
+            .get_ref_config()
             .validators
             .iter()
             .map(|account_info| {
@@ -74,7 +74,7 @@ pub fn get_runtime_and_trie_from_genesis(genesis: &Genesis) -> (Runtime, ShardTr
             })
             .collect::<Vec<_>>(),
         &genesis,
-        &genesis.config.runtime_config,
+        &genesis.get_ref_config().runtime_config,
         account_ids,
     );
     (runtime, tries, genesis_root)

--- a/test-utils/testlib/src/standard_test_cases.rs
+++ b/test-utils/testlib/src/standard_test_cases.rs
@@ -27,8 +27,8 @@ const FUNCTION_CALL_AMOUNT: Balance = TESTING_INIT_BALANCE / 10;
 
 fn fee_helper(node: &impl Node) -> FeeHelper {
     FeeHelper::new(
-        node.genesis().config.runtime_config.transaction_costs.clone(),
-        node.genesis().config.min_gas_price,
+        node.genesis().get_ref_config().runtime_config.transaction_costs.clone(),
+        node.genesis().get_ref_config().min_gas_price,
     )
 }
 

--- a/tools/restored-receipts-verifier/src/main.rs
+++ b/tools/restored-receipts-verifier/src/main.rs
@@ -58,7 +58,8 @@ fn main() -> Result<()> {
     let home_dir = matches.value_of("home").map(Path::new).unwrap();
     let near_config = load_config(&home_dir);
     let store = create_store(&get_store_path(&home_dir));
-    let mut chain_store = ChainStore::new(store.clone(), near_config.genesis.get_ref_config().genesis_height);
+    let mut chain_store =
+        ChainStore::new(store.clone(), near_config.genesis.get_ref_config().genesis_height);
     let runtime = NightshadeRuntime::new(
         &home_dir,
         store,

--- a/tools/restored-receipts-verifier/src/main.rs
+++ b/tools/restored-receipts-verifier/src/main.rs
@@ -58,7 +58,7 @@ fn main() -> Result<()> {
     let home_dir = matches.value_of("home").map(Path::new).unwrap();
     let near_config = load_config(&home_dir);
     let store = create_store(&get_store_path(&home_dir));
-    let mut chain_store = ChainStore::new(store.clone(), near_config.genesis.config.genesis_height);
+    let mut chain_store = ChainStore::new(store.clone(), near_config.genesis.get_ref_config().genesis_height);
     let runtime = NightshadeRuntime::new(
         &home_dir,
         store,

--- a/tools/storage-usage-delta-calculator/src/main.rs
+++ b/tools/storage-usage-delta-calculator/src/main.rs
@@ -18,8 +18,8 @@ fn main() -> Result<(), Error> {
     let genesis = Genesis::from_file("output.json");
     debug!("Genesis read");
 
-    let storage_usage =
-        Runtime::new().compute_storage_usage(&genesis.get_ref_records().0[..], &RuntimeConfig::default());
+    let storage_usage = Runtime::new()
+        .compute_storage_usage(&genesis.get_ref_records().0[..], &RuntimeConfig::default());
     debug!("Storage usage calculated");
 
     let mut result = Vec::new();

--- a/tools/storage-usage-delta-calculator/src/main.rs
+++ b/tools/storage-usage-delta-calculator/src/main.rs
@@ -19,11 +19,11 @@ fn main() -> Result<(), Error> {
     debug!("Genesis read");
 
     let storage_usage =
-        Runtime::new().compute_storage_usage(&genesis.records.0[..], &RuntimeConfig::default());
+        Runtime::new().compute_storage_usage(&genesis.get_ref_records().0[..], &RuntimeConfig::default());
     debug!("Storage usage calculated");
 
     let mut result = Vec::new();
-    for record in genesis.records.0 {
+    for record in genesis.get_records().0 {
         if let StateRecord::Account { account_id, account } = record {
             let actual_storage_usage = storage_usage.get(account_id.as_str()).unwrap();
             let saved_storage_usage = account.storage_usage();


### PR DESCRIPTION
…sors.

Remove `PhantonData` from `GenesisConfig`, because its only function was preventing `GenesisConfig `construction as `{}`.

Fixes #2459 