### PR TITLE
Remove `protocol_feature_evm` mention from emu-cost/README.md

### DIFF
--- a/runtime/runtime-params-estimator/emu-cost/README.md
+++ b/runtime/runtime-params-estimator/emu-cost/README.md
@@ -29,8 +29,8 @@ Start container and build estimator with:
 
     host> ./run.sh
     docker> cd /host/nearcore
-    docker> cargo run -j2 --release --package neard --features protocol_feature_evm --bin neard -- --home /tmp/data init --test-seed=alice.near --account-id=test.near --fast
-    docker> cargo run -j2 --release --package genesis-populate --features protocol_feature_evm --bin genesis-populate -- --additional-accounts-num=200000 --home /tmp/data
+    docker> cargo run -j2 --release --package neard --bin neard -- --home /tmp/data init --test-seed=alice.near --account-id=test.near --fast
+    docker> cargo run -j2 --release --package genesis-populate --bin genesis-populate -- --additional-accounts-num=200000 --home /tmp/data
     docker> cd /host/nearcore/runtime/runtime-params-estimator
     docker> pushd ./test-contract && ./build.sh && popd
     docker> cargo build --release --package runtime-params-estimator --features required


### PR DESCRIPTION
Small fix to remove the unused `protocol_feature_evm` from the README.md or `emu-cost`. In genesis populate, it doesn't even exist.