### PR TITLE
remove num_shards from EpochConfig since it is not used

### DIFF
--- a/chain/epoch_manager/src/proposals.rs
+++ b/chain/epoch_manager/src/proposals.rs
@@ -271,7 +271,6 @@ mod tests {
             proposals_to_epoch_info(
                 &EpochConfig {
                     epoch_length: 2,
-                    num_shards: 5,
                     num_block_producer_seats: 6,
                     num_block_producer_seats_per_shard: vec![6, 2, 2, 2, 2],
                     avg_hidden_validator_seats_per_shard: vec![6, 2, 2, 2, 2],

--- a/chain/epoch_manager/src/test_utils.rs
+++ b/chain/epoch_manager/src/test_utils.rs
@@ -135,7 +135,6 @@ pub fn epoch_config(
 ) -> EpochConfig {
     EpochConfig {
         epoch_length,
-        num_shards,
         num_block_producer_seats,
         num_block_producer_seats_per_shard: get_num_seats_per_shard(
             num_shards,

--- a/core/chain-configs/src/genesis_config.rs
+++ b/core/chain-configs/src/genesis_config.rs
@@ -18,7 +18,6 @@ use smart_default::SmartDefault;
 
 use near_primitives::epoch_manager::EpochConfig;
 use near_primitives::types::validator_stake::ValidatorStake;
-use near_primitives::types::NumShards;
 use near_primitives::{
     hash::CryptoHash,
     runtime::config::RuntimeConfig,
@@ -146,7 +145,6 @@ impl From<&GenesisConfig> for EpochConfig {
     fn from(config: &GenesisConfig) -> Self {
         EpochConfig {
             epoch_length: config.epoch_length,
-            num_shards: config.num_block_producer_seats_per_shard.len() as NumShards,
             num_block_producer_seats: config.num_block_producer_seats,
             num_block_producer_seats_per_shard: config.num_block_producer_seats_per_shard.clone(),
             avg_hidden_validator_seats_per_shard: config

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -5,8 +5,8 @@ use serde::Serialize;
 use crate::challenge::SlashedValidator;
 use crate::types::validator_stake::ValidatorStakeV1;
 use crate::types::{
-    AccountId, Balance, BlockHeightDelta, EpochHeight, EpochId, NumSeats, NumShards,
-    ProtocolVersion, ValidatorId, ValidatorKickoutReason,
+    AccountId, Balance, BlockHeightDelta, EpochHeight, EpochId, NumSeats, ProtocolVersion,
+    ValidatorId, ValidatorKickoutReason,
 };
 use crate::version::PROTOCOL_VERSION;
 use near_primitives_core::hash::CryptoHash;
@@ -24,8 +24,6 @@ pub const AGGREGATOR_KEY: &[u8] = b"AGGREGATOR";
 pub struct EpochConfig {
     /// Epoch length in block heights.
     pub epoch_length: BlockHeightDelta,
-    /// Number of shards currently.
-    pub num_shards: NumShards,
     /// Number of seats for block producers.
     pub num_block_producer_seats: NumSeats,
     /// Number of seats of block producers per each shard.

--- a/nearcore/src/shard_tracker.rs
+++ b/nearcore/src/shard_tracker.rs
@@ -245,11 +245,10 @@ mod tests {
 
     const DEFAULT_TOTAL_SUPPLY: u128 = 1_000_000_000_000;
 
-    fn get_epoch_manager(num_shards: NumShards) -> Arc<RwLock<EpochManager>> {
+    fn get_epoch_manager() -> Arc<RwLock<EpochManager>> {
         let store = create_test_store();
         let initial_epoch_config = EpochConfig {
             epoch_length: 1,
-            num_shards,
             num_block_producer_seats: 1,
             num_block_producer_seats_per_shard: vec![1],
             avg_hidden_validator_seats_per_shard: vec![],
@@ -320,7 +319,7 @@ mod tests {
     #[test]
     fn test_track_new_accounts_and_shards() {
         let num_shards = 4;
-        let epoch_manager = get_epoch_manager(num_shards);
+        let epoch_manager = get_epoch_manager();
         let mut tracker =
             ShardTracker::new(vec![], vec![], EpochId::default(), epoch_manager, num_shards);
         tracker.track_accounts(&["test1".to_string(), "test2".to_string()]);
@@ -336,7 +335,7 @@ mod tests {
     #[test]
     fn test_untrack_accounts() {
         let num_shards = 4;
-        let epoch_manager = get_epoch_manager(num_shards);
+        let epoch_manager = get_epoch_manager();
         let mut tracker = ShardTracker::new(
             vec![],
             vec![],
@@ -368,7 +367,7 @@ mod tests {
     #[test]
     fn test_untrack_shards() {
         let num_shards = 4;
-        let epoch_manager = get_epoch_manager(num_shards);
+        let epoch_manager = get_epoch_manager();
         let mut tracker = ShardTracker::new(
             vec![],
             vec![],

--- a/nearcore/src/shard_tracker.rs
+++ b/nearcore/src/shard_tracker.rs
@@ -236,7 +236,7 @@ mod tests {
     use near_primitives::epoch_manager::EpochConfig;
     use near_primitives::hash::{hash, CryptoHash};
     use near_primitives::types::validator_stake::ValidatorStake;
-    use near_primitives::types::{BlockHeight, EpochId, NumShards};
+    use near_primitives::types::{BlockHeight, EpochId};
     use near_store::test_utils::create_test_store;
 
     use super::{account_id_to_shard_id, ShardTracker, POISONED_LOCK_ERR};


### PR DESCRIPTION
num_shards is managed in multiple places in the codebase, I'm trying to consolidate it a bit before I change num shards to be dynamic. num_shards in EpochConfig does not seem to be used at all, so I'm removing it.