### PR TITLE
feat: one button "run estimator in docker \w qemu" 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4383,18 +4383,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "run-nodes"
-version = "0.1.0"
-dependencies = [
- "clap 2.33.3",
- "integration-tests",
- "near-logger-utils",
-]
-
-[[package]]
 name = "runtime-params-estimator"
 version = "3.0.0"
 dependencies = [
+ "anyhow",
  "borsh 0.8.1",
  "cfg-if 1.0.0",
  "clap 3.0.0-beta.2",

--- a/runtime/runtime-params-estimator/Cargo.toml
+++ b/runtime/runtime-params-estimator/Cargo.toml
@@ -19,6 +19,7 @@ csv = "1.1.3"
 clap = "=3.0.0-beta.2"
 borsh = "0.8.1"
 num-rational = "0.3"
+anyhow = "1"
 
 near-chain-configs = { path = "../../core/chain-configs" }
 near-crypto = { path = "../../core/crypto" }

--- a/runtime/runtime-params-estimator/README.md
+++ b/runtime/runtime-params-estimator/README.md
@@ -14,7 +14,7 @@ Use this tool to measure the running time of elementary runtime operations that 
     ```
 
     With the given parameters above estimator will run relatively fast.
-    Note the `--metric time` flag: it instructs the estimator to use wal-clock time for estimation, which is quick, but highly variable between runs and physical machines.
+    Note the `--metric time` flag: it instructs the estimator to use wall-clock time for estimation, which is quick, but highly variable between runs and physical machines.
     To get more robust estimates, use these arguments:
 
     ```bash

--- a/runtime/runtime-params-estimator/README.md
+++ b/runtime/runtime-params-estimator/README.md
@@ -13,6 +13,17 @@ Use this tool to measure the running time of elementary runtime operations that 
     cargo run --release --package runtime-params-estimator --features required --bin runtime-params-estimator -- --home /tmp/data --accounts-num 20000 --iters 1 --warmup-iters 1 --metric time
     ```
 
-    With the given parameters above estimator will run relatively fast. We will be using different parameters to do the actual parameter estimation. Also note that the default metric is `icount`, instruction count, but requires using QEMU to emulate the processor. So this example provides a way to get a quick way to test out the estimator based on time, but the instructions in [`emu-cost/README.md`](./emu-cost/README.md) should be followed to get the real data.
+    With the given parameters above estimator will run relatively fast.
+    Note the `--metric time` flag: it instructs the estimator to use wal-clock time for estimation, which is quick, but highly variable between runs and physical machines.
+    To get more robust estimates, use these arguments:
+
+    ```bash
+    --docker --home /tmp/data --accounts-num 20000 --iters 1 --warmup-iters 1 --metric icount
+    ```
+
+    This will run and build the estimator inside a docker container, using QEMU to precisely count the number of executed instructions.
+
+    We will be using different parameters to do the actual parameter estimation.
+    The instructions in [`emu-cost/README.md`](./emu-cost/README.md) should be followed to get the real data.
 
 Note, if you use the plotting functionality you would need to install [gnuplot](http://gnuplot.info/) to see the graphs.

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -91,7 +91,7 @@ fn main_docker(state_dump_path: &Path) -> anyhow::Result<()> {
 
     let project_root = project_root();
     if exec("docker images -q rust-emu")?.is_empty() {
-        // Build docked image if there isn't one already.
+        // Build a docker image if there isn't one already.
         let status = Command::new("docker")
             .args(&["build", "--tag", "rust-emu"])
             .arg(project_root.join("runtime/runtime-params-estimator/emu-cost"))

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -1,11 +1,16 @@
+use anyhow::Context;
 use clap::Clap;
 use near_vm_runner::VMKind;
 use nearcore::get_default_home;
 use runtime_params_estimator::cases::run;
 use runtime_params_estimator::testbed_runners::Config;
 use runtime_params_estimator::testbed_runners::GasMetric;
+use std::env;
+use std::fmt::Write;
 use std::fs;
+use std::path::Path;
 use std::path::PathBuf;
+use std::process::Command;
 
 #[derive(Clap)]
 struct CliArgs {
@@ -30,12 +35,20 @@ struct CliArgs {
     /// Only test contract compilation costs.
     #[clap(long)]
     compile_only: bool,
+    /// Build and run the estimator inside a docker container via QEMU.
+    #[clap(long)]
+    docker: bool,
 }
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     let cli_args = CliArgs::parse();
 
     let state_dump_path = cli_args.home.unwrap_or_else(|| get_default_home().into());
+
+    if cli_args.docker {
+        return main_docker(&state_dump_path);
+    }
+
     let warmup_iters_per_block = cli_args.warmup_iters;
     let iter_per_block = cli_args.iters;
     let active_accounts = cli_args.accounts_num;
@@ -69,5 +82,100 @@ fn main() {
     let str = serde_json::to_string_pretty(&runtime_config)
         .expect("Failed serializing the runtime config");
     fs::write(state_dump_path.join("runtime_config.json"), &str)
-        .unwrap_or_else(|err| panic!("Failed to write runtime config to file {}", err))
+        .context("Failed to write runtime config to file")?;
+    Ok(())
+}
+
+fn main_docker(state_dump_path: &Path) -> anyhow::Result<()> {
+    exec("docker --version").context("please install `docker`")?;
+
+    let project_root = project_root();
+    if exec("docker images -q rust-emu")?.is_empty() {
+        // Build docked image if there isn't one already.
+        let status = Command::new("docker")
+            .args(&["build", "--tag", "rust-emu"])
+            .arg(project_root.join("runtime/runtime-params-estimator/emu-cost"))
+            .status()?;
+        if !status.success() {
+            anyhow::bail!("failed to build a docker image")
+        }
+    }
+
+    let init = {
+        // Build a bash script to run inside the container. Concatenating a bash
+        // script from strings is fragile, but I don't know a better way.
+
+        let mut buf = String::new();
+        buf.push_str("set -ex;\n");
+        buf.push_str(
+            "\
+cargo build --manifest-path /nearcore/Cargo.toml \
+  --package runtime-params-estimator --bin runtime-params-estimator \
+  --features required --release;
+",
+        );
+        buf.push_str(
+            "\
+/nearcore/runtime/runtime-params-estimator/emu-cost/counter_plugin/qemu-x86_64 \
+  -plugin file=/nearcore/runtime/runtime-params-estimator/emu-cost/counter_plugin/libcounter.so \
+  -cpu Westmere-v1 /nearcore/target/release/runtime-params-estimator --home /.near",
+        );
+
+        // Sanitize & forward our arguments to the estimator to be run inside
+        // docker.
+        let mut args = env::args();
+        let _binary_name = args.next();
+        while let Some(arg) = args.next() {
+            match arg.as_str() {
+                "--docker" => continue,
+                "--home" => {
+                    args.next();
+                    continue;
+                }
+                _ => {
+                    write!(buf, " {:?}", arg).unwrap();
+                }
+            }
+        }
+
+        buf
+    };
+
+    let nearcore = format!("type=bind,source={},target=/nearcore", project_root.to_str().unwrap());
+    let nearhome = format!("type=bind,source={},target=/.near", state_dump_path.to_str().unwrap());
+
+    let mut cmd = Command::new("docker");
+    cmd.args(&["run", "--rm", "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"])
+        .args(&["--mount", &nearcore])
+        .args(&["--mount", &nearhome])
+        .args(&["--mount", "source=rust-emu-target-dir,target=/nearcore/target"])
+        .args(&["--mount", "source=rust-emu-cargo-dir,target=/usr/local/cargo"])
+        .args(&["--interactive", "--tty"])
+        .arg("rust-emu")
+        .args(&["/usr/bin/env", "bash", "-c", &init]);
+
+    cmd.status()?;
+    Ok(())
+}
+
+fn exec(command: &str) -> anyhow::Result<String> {
+    let args = command.split_ascii_whitespace().collect::<Vec<_>>();
+    let (cmd, args) = args.split_first().unwrap();
+    let output = std::process::Command::new(cmd)
+        .args(args)
+        .output()
+        .with_context(|| format!("failed to run `{}`", command))?;
+    if !output.status.success() {
+        anyhow::bail!("failed to run `{}`", command);
+    }
+    let stdout =
+        String::from_utf8(output.stdout).with_context(|| format!("failed to run `{}`", command))?;
+    Ok(stdout.trim().to_string())
+}
+
+fn project_root() -> PathBuf {
+    let dir = env!("CARGO_MANIFEST_DIR");
+    let res = PathBuf::from(dir).ancestors().nth(2).unwrap().to_owned();
+    assert!(res.join(".github").exists());
+    res
 }

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -109,16 +109,16 @@ fn main_docker(state_dump_path: &Path) -> anyhow::Result<()> {
         buf.push_str("set -ex;\n");
         buf.push_str(
             "\
-cargo build --manifest-path /nearcore/Cargo.toml \
+cargo build --manifest-path /host/nearcore/Cargo.toml \
   --package runtime-params-estimator --bin runtime-params-estimator \
   --features required --release;
 ",
         );
         buf.push_str(
             "\
-/nearcore/runtime/runtime-params-estimator/emu-cost/counter_plugin/qemu-x86_64 \
-  -plugin file=/nearcore/runtime/runtime-params-estimator/emu-cost/counter_plugin/libcounter.so \
-  -cpu Westmere-v1 /nearcore/target/release/runtime-params-estimator --home /.near",
+/host/nearcore/runtime/runtime-params-estimator/emu-cost/counter_plugin/qemu-x86_64 \
+  -plugin file=/host/nearcore/runtime/runtime-params-estimator/emu-cost/counter_plugin/libcounter.so \
+  -cpu Westmere-v1 /host/nearcore/target/release/runtime-params-estimator --home /.near",
         );
 
         // Sanitize & forward our arguments to the estimator to be run inside
@@ -148,7 +148,7 @@ cargo build --manifest-path /nearcore/Cargo.toml \
     cmd.args(&["run", "--rm", "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"])
         .args(&["--mount", &nearcore])
         .args(&["--mount", &nearhome])
-        .args(&["--mount", "source=rust-emu-target-dir,target=/nearcore/target"])
+        .args(&["--mount", "source=rust-emu-target-dir,target=/host/nearcore/target"])
         .args(&["--mount", "source=rust-emu-cargo-dir,target=/usr/local/cargo"])
         .args(&["--interactive", "--tty"])
         .arg("rust-emu")


### PR DESCRIPTION
Today, to get precise gas estimations via instruction counts, one needs
to follow a series of manual steps from emu-cost/README.md.

This PR optimizes part of that. It adds `--docker` argument to the
parameter estimator, which takes care of docker and qemu.

With this argument, the estimator on the host machine launches a docker
container, compiles a copy of itself in docker, and runs that copy via
qemu.

There are a couple of manual steps left:

* running neard init
* running genesis-populate
* picking the specific parameter values we use for estimation

Those will be automated in subsequent PR. The desired end goal is that

```console
$ cargo run -- --docker
```

is the *single* command you need to run the whole estimation process.
At that point, all various bash and python scripts will be removed.