### PR TITLE
pytest: respect $TEMP variable when creating /tmp/near directory

### DIFF
--- a/pytest/lib/utils.py
+++ b/pytest/lib/utils.py
@@ -181,6 +181,16 @@ def chain_query(node, block_handler, *, block_hash=None, max_blocks=-1):
                 break
 
 
+def get_near_tempdir(subdir=None, *, clean=False):
+    tempdir = pathlib.Path(tempfile.gettempdir()) / 'near'
+    if subdir:
+        tempdir = tempdir / subdir
+    if clean and tempdir.exists():
+        shutil.rmtree(node_root)
+    tempdir.mkdir(parents=True, exist_ok=True)
+    return tempdir
+
+
 def load_binary_file(filepath):
     with open(filepath, "rb") as binaryfile:
         return bytearray(binaryfile.read())
@@ -197,8 +207,7 @@ def load_test_contract(filename='test_contract_rs.wasm'):
 
 
 def compile_rust_contract(content):
-    tempdir = pathlib.Path(tempfile.gettempdir()) / 'near'
-    tempdir.mkdir(parents=True, exist_ok=True)
+    tempdir = get_near_tempdir()
     with tempfile.TemporaryDirectory(dir=tempdir) as build_dir:
         build_dir = pathlib.Path(build_dir) / 'empty-contract-rs'
         shutil.copytree(
@@ -248,29 +257,23 @@ class Unbuffered(object):
 
 
 def collect_gcloud_config(num_nodes):
+    tempdir = get_near_tempdir()
     keys = []
     for i in range(num_nodes):
-        if not os.path.exists(f'/tmp/near/node{i}'):
+        node_dir = tempdir / f'node{i}'
+        if not node_dir.exists():
             # TODO: avoid hardcoding the username
             logger.info(f'downloading node{i} config from gcloud')
-            pathlib.Path(f'/tmp/near/node{i}').mkdir(parents=True,
-                                                     exist_ok=True)
-            gcloud.get(f'pytest-node-{user_name()}-{i}').download(
-                '/home/bowen_nearprotocol_com/.near/config.json',
-                f'/tmp/near/node{i}/')
-            gcloud.get(f'pytest-node-{user_name()}-{i}').download(
-                '/home/bowen_nearprotocol_com/.near/signer0_key.json',
-                f'/tmp/near/node{i}/')
-            gcloud.get(f'pytest-node-{user_name()}-{i}').download(
-                '/home/bowen_nearprotocol_com/.near/validator_key.json',
-                f'/tmp/near/node{i}/')
-            gcloud.get(f'pytest-node-{user_name()}-{i}').download(
-                '/home/bowen_nearprotocol_com/.near/node_key.json',
-                f'/tmp/near/node{i}/')
-        with open(f'/tmp/near/node{i}/signer0_key.json') as f:
+            node_dir.mkdir(parents=True, exist_ok=True)
+            host = gcloud.get(f'pytest-node-{user_name()}-{i}')
+            for filename in ('config.json', 'signer0_key.json',
+                             'validator_key.json', 'node_key.json'):
+                host.download(f'/home/bowen_nearprotocol_com/.near/{filename}',
+                              str(node_dir))
+        with open(node_dir / 'signer0_key.json') as f:
             key = json.load(f)
         keys.append(key)
-    with open('/tmp/near/node0/config.json') as f:
+    with open(tempdir / 'node0' / 'config.json') as f:
         config = json.load(f)
     ip_addresses = map(lambda x: x.split('@')[-1],
                        config['network']['boot_nodes'].split(','))
@@ -284,10 +287,10 @@ def collect_gcloud_config(num_nodes):
         'accounts':
             keys
     }
-    outfile = '/tmp/near/gcloud_config.json'
-    with open(outfile, 'w+') as f:
+    outfile = tempdir / 'gcloud_config.json'
+    with open(outfile, 'w') as f:
         json.dump(res, f)
-    os.environ[CONFIG_ENV_VAR] = outfile
+    os.environ[CONFIG_ENV_VAR] = str(outfile)
 
 
 def obj_to_string(obj, extra='    ', full=False):

--- a/pytest/tests/sanity/backward_compatible.py
+++ b/pytest/tests/sanity/backward_compatible.py
@@ -8,7 +8,6 @@ import sys
 import os
 import subprocess
 import time
-import shutil
 import base58
 import json
 
@@ -16,15 +15,11 @@ sys.path.append('lib')
 
 import branches
 import cluster
-from utils import load_test_contract
+from utils import load_test_contract, get_near_tempdir
 from transaction import sign_deploy_contract_tx, sign_function_call_tx, sign_payment_tx, sign_create_account_with_full_access_key_and_balance_tx
 
 def main():
-    node_root = "/tmp/near/backward"
-    if os.path.exists(node_root):
-        shutil.rmtree(node_root)
-    subprocess.check_output('mkdir -p /tmp/near', shell=True)
-
+    node_root = get_near_tempdir('backward', clean=True)
     branch = branches.latest_rc_branch()
     near_root, (stable_branch,
                 current_branch) = branches.prepare_ab_test(branch)
@@ -42,11 +37,11 @@ def main():
         'binary_name': "near-%s" % stable_branch
     }
     stable_node = cluster.spin_up_node(config, near_root,
-                                       os.path.join(node_root, "test0"), 0,
+                                       str(node_root / 'test0'), 0,
                                        None, None)
     config["binary_name"] = "near-%s" % current_branch
     current_node = cluster.spin_up_node(config, near_root,
-                                        os.path.join(node_root, "test1"), 1,
+                                        str(node_root / 'test1'), 1,
                                         stable_node.node_key.pk,
                                         stable_node.addr())
 

--- a/pytest/tests/sanity/db_migration.py
+++ b/pytest/tests/sanity/db_migration.py
@@ -9,7 +9,6 @@ import logging
 import os
 import sys
 import time
-import shutil
 import subprocess
 import base58
 
@@ -17,7 +16,7 @@ sys.path.append('lib')
 
 import branches
 import cluster
-from utils import wait_for_blocks_or_timeout, load_test_contract
+from utils import wait_for_blocks_or_timeout, load_test_contract, get_near_tempdir
 from transaction import sign_deploy_contract_tx, sign_function_call_tx
 
 logging.basicConfig(level=logging.INFO)
@@ -56,10 +55,7 @@ def send_some_tx(node):
 def main():
     near_root, (stable_branch,
                 current_branch) = branches.prepare_ab_test("master")
-    node_root = "/tmp/near/db_migration"
-    if os.path.exists(node_root):
-        shutil.rmtree(node_root)
-    subprocess.check_output('mkdir -p /tmp/near', shell=True)
+    node_root = get_near_tempdir('db_migration', clean=True)
 
     logging.info(f"The near root is {near_root}...")
     logging.info(f"The node root is {node_root}...")
@@ -83,8 +79,8 @@ def main():
 
     logging.info("Starting the stable node...")
 
-    node = cluster.spin_up_node(config, near_root, node_root , 0, None,
-                                       None)
+    node = cluster.spin_up_node(config, near_root, str(node_root) , 0, None,
+                                None)
 
     logging.info("Running the stable node...")
     wait_for_blocks_or_timeout(node, 20, 100)

--- a/pytest/tests/sanity/state_migration.py
+++ b/pytest/tests/sanity/state_migration.py
@@ -19,13 +19,10 @@ sys.path.append('lib')
 
 import branches
 import cluster
-from utils import wait_for_blocks_or_timeout
+from utils import wait_for_blocks_or_timeout, get_near_tempdir
 
 def main():
-    node_root = '/tmp/near/state_migration'
-    if os.path.exists(node_root):
-        shutil.rmtree(node_root)
-    subprocess.check_output('mkdir -p /tmp/near', shell=True)
+    node_root = get_near_tempdir('state_migration', clean=True)
 
     near_root, (stable_branch,
                 current_branch) = branches.prepare_ab_test("beta")

--- a/pytest/tests/sanity/upgradable.py
+++ b/pytest/tests/sanity/upgradable.py
@@ -7,7 +7,6 @@ At the end run for 3 epochs and observe that current protocol version of the net
 
 import os
 import subprocess
-import shutil
 import sys
 import time
 import base58
@@ -17,17 +16,13 @@ sys.path.append('lib')
 import branches
 import cluster
 from configured_logger import logger
-from utils import wait_for_blocks_or_timeout, load_test_contract
+from utils import wait_for_blocks_or_timeout, load_test_contract, get_near_tempdir
 from transaction import sign_deploy_contract_tx, sign_function_call_tx, sign_payment_tx, \
     sign_create_account_tx, sign_delete_account_tx, sign_create_account_with_full_access_key_and_balance_tx
 
 
 def main():
-    node_root = "/tmp/near/upgradable"
-    if os.path.exists(node_root):
-        shutil.rmtree(node_root)
-    subprocess.check_output('mkdir -p /tmp/near', shell=True)
-
+    node_root = get_near_tempdir('upgradable', clean=True)
     branch = branches.latest_rc_branch()
     logger.info(f"Latest rc release branch is {branch}")
     near_root, (stable_branch,

--- a/pytest/tests/stress/hundred_nodes/node_rotation.py
+++ b/pytest/tests/stress/hundred_nodes/node_rotation.py
@@ -1,9 +1,11 @@
-import sys
-from enum import Enum
-import random
 import base58
-import time
+from enum import Enum
 import os
+import pathlib
+import random
+import sys
+import tempfile
+import time
 
 sys.path.append('lib')
 from cluster import GCloudNode, Key
@@ -41,9 +43,9 @@ class NodeState(Enum):
 class RemoteNode(GCloudNode):
     def __init__(self, instance_name, node_dir):
         super().__init__(instance_name)
-        self.validator_key = Key.from_json_file(os.path.join(node_dir, "validator_key.json"))
-        self.node_key = Key.from_json_file(os.path.join(node_dir, "node_key.json"))
-        self.signer_key = Key.from_json_file(os.path.join(node_dir, "signer0_key.json"))
+        self.validator_key = Key.from_json_file(node_dir / 'validator_key.json')
+        self.node_key = Key.from_json_file(node_dir / 'node_key.json')
+        self.signer_key = Key.from_json_file(node_dir / 'signer0_key.json')
         self.last_synced_height = 0
 
         try:
@@ -115,7 +117,9 @@ class RemoteNode(GCloudNode):
 
 num_nodes = 100
 collect_gcloud_config(num_nodes)
-nodes = [RemoteNode(f'pytest-node-{user_name()}-{i}', f'/tmp/near/node{i}') for i in range(num_nodes)]
+nodes = [RemoteNode(f'pytest-node-{user_name()}-{i}',
+                    pathlib.Path(tempfile.gettempdir()) / 'near' / f'node{i}')
+         for i in range(num_nodes)]
 
 while True:
     # find a node that is not syncing and get validator information


### PR DESCRIPTION
Respect TMPDIR, TEMP and TMP environment variables when creating
a temporary /tmp/near directory.  This helps clean up any artefacts
remaining after a test.

There are other places where the scripts hardcode /tmp as the temporary
directory but for now those are left alone just to keep this change
smaller.

Issue: https://github.com/near/nayduck/issues/9