### PR TITLE
cleanup(version): move master version to 0.0.0 instead of 1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3728,7 +3728,7 @@ dependencies = [
 
 [[package]]
 name = "nearcore"
-version = "1.2.0"
+version = "0.0.0"
 dependencies = [
  "actix",
  "actix-rt",
@@ -3777,7 +3777,7 @@ dependencies = [
 
 [[package]]
 name = "neard"
-version = "1.2.0"
+version = "0.0.0"
 dependencies = [
  "actix",
  "clap 3.0.0-beta.2",

--- a/nearcore/Cargo.toml
+++ b/nearcore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nearcore"
-version = "1.2.0"
+version = "0.0.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neard"
-version = "1.2.0"
+version = "0.0.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 default-run = "neard"

--- a/neard/src/main.rs
+++ b/neard/src/main.rs
@@ -12,14 +12,19 @@ use near_primitives::version::{Version, DB_VERSION, PROTOCOL_VERSION};
 use near_rust_allocator_proxy::allocator::MyAllocator;
 use nearcore::get_default_home;
 
+pub fn get_version() -> String {
+    match crate_version!() {
+        "0.0.0" => "trunk".to_string(),
+        _ => crate_version!().to_string(),
+    }
+}
+
 lazy_static! {
-    static ref NEARD_VERSION: Version = Version {
-        version: crate_version!().to_string(),
-        build: git_version!(fallback = "unknown").to_string(),
-    };
+    static ref NEARD_VERSION: Version =
+        Version { version: get_version(), build: git_version!(fallback = "unknown").to_string() };
     static ref NEARD_VERSION_STRING: String = {
         format!(
-            "{} (build {}) (protocol {}) (db {})",
+            "(release {}) (build {}) (protocol {}) (db {})",
             NEARD_VERSION.version, NEARD_VERSION.build, PROTOCOL_VERSION, DB_VERSION
         )
     };


### PR DESCRIPTION
Currently our master version is 1.2.0 and we do not update it due to using a trunk based release process.

I have looked into some options and the most sensible is this (https://softwareengineering.stackexchange.com/questions/333680/how-to-version-when-using-trunk-based-development).

Use 0.0.0 for master so it doesn't create confusion as we already include the build commit in the versioning.

Before:
```
sandi@sandi-ThinkPad-X1-Carbon-7th ~/w/n/nearcore (use-trunk) [2]> ./target/release/neard --version
neard 1.2.0 (build 12fd620c) (protocol 46) (db 26)
```

Now:
```
sandi@sandi-ThinkPad-X1-Carbon-7th ~/w/n/nearcore (use-trunk)> ./target/release/neard --version
neard (version trunk) (build 5ba32a5f-modified) (protocol 46) (db 26)
```