### PR TITLE
feat(runtime): profile per receipt.

### DIFF
--- a/core/primitives-core/src/profile.rs
+++ b/core/primitives-core/src/profile.rs
@@ -8,7 +8,7 @@ use crate::types::Gas;
 type DataArray = [Cell<u64>; ProfileData::LEN];
 
 /// Profile of gas consumption.
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct ProfileData {
     data: Rc<DataArray>,
 }
@@ -31,6 +31,17 @@ impl ProfileData {
 
         let data = Rc::new([ZERO; ProfileData::LEN]);
         ProfileData { data }
+    }
+
+    #[inline]
+    pub fn merge(&self, other: &ProfileData) {
+        for i in 0..ProfileData::LEN {
+            let slot = &self.data[i];
+            let slot_other = &other.data[i];
+            let value = slot.get();
+            let value_other = slot_other.get();
+            slot.set(value.saturating_add(value_other));
+        }
     }
 
     #[inline]

--- a/core/primitives/src/runtime/apply_state.rs
+++ b/core/primitives/src/runtime/apply_state.rs
@@ -40,8 +40,6 @@ pub struct ApplyState {
     /// Ethereum chain id.
     #[cfg(feature = "protocol_feature_evm")]
     pub evm_chain_id: u64,
-    /// Data collected from making a contract call
-    pub profile: crate::profile::ProfileData,
     /// Data for migrations that may need to be applied at the start of an epoch when protocol
     /// version changes
     pub migration_data: Arc<MigrationData>,

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -434,7 +434,6 @@ impl NightshadeRuntime {
             is_new_chunk,
             #[cfg(feature = "protocol_feature_evm")]
             evm_chain_id: self.evm_chain_id(),
-            profile: Default::default(),
             migration_data: Arc::clone(&self.migration_data),
             migration_flags: MigrationFlags {
                 is_first_block_of_version,

--- a/runtime/near-evm-runner/src/runner.rs
+++ b/runtime/near-evm-runner/src/runner.rs
@@ -698,6 +698,7 @@ pub fn run_evm(
                 burnt_gas: context.gas_counter.burnt_gas(),
                 used_gas: context.gas_counter.used_gas(),
                 logs: context.logs,
+                profile: Default::default(),
             };
             (Some(outcome), None)
         }

--- a/runtime/near-vm-logic/src/gas_counter.rs
+++ b/runtime/near-vm-logic/src/gas_counter.rs
@@ -74,7 +74,6 @@ impl GasCounter {
         max_gas_burnt: Gas,
         prepaid_gas: Gas,
         is_view: bool,
-        profile: ProfileData,
     ) -> Self {
         Self {
             ext_costs_config,
@@ -83,7 +82,7 @@ impl GasCounter {
             max_gas_burnt,
             prepaid_gas,
             is_view,
-            profile,
+            profile: Default::default(),
         }
     }
 

--- a/runtime/near-vm-logic/src/logic.rs
+++ b/runtime/near-vm-logic/src/logic.rs
@@ -110,7 +110,6 @@ impl<'a> VMLogic<'a> {
         fees_config: &'a RuntimeFeesConfig,
         promise_results: &'a [PromiseResult],
         memory: &'a mut dyn MemoryLike,
-        profile: ProfileData,
         current_protocol_version: ProtocolVersion,
     ) -> Self {
         ext.reset_touched_nodes_counter();
@@ -128,7 +127,6 @@ impl<'a> VMLogic<'a> {
             max_gas_burnt,
             context.prepaid_gas,
             context.is_view,
-            profile,
         );
         Self {
             ext,
@@ -160,7 +158,6 @@ impl<'a> VMLogic<'a> {
         fees_config: &'a RuntimeFeesConfig,
         promise_results: &'a [PromiseResult],
         memory: &'a mut dyn MemoryLike,
-        profile: ProfileData,
     ) -> Self {
         Self::new_with_protocol_version(
             ext,
@@ -169,7 +166,6 @@ impl<'a> VMLogic<'a> {
             fees_config,
             promise_results,
             memory,
-            profile,
             LEGACY_DEFAULT_PROTOCOL_VERSION,
         )
     }
@@ -2509,6 +2505,7 @@ impl<'a> VMLogic<'a> {
             burnt_gas: self.gas_counter.burnt_gas(),
             used_gas: self.gas_counter.used_gas(),
             logs: self.logs,
+            profile: Default::default(),
         }
     }
 
@@ -2523,6 +2520,7 @@ impl<'a> VMLogic<'a> {
             burnt_gas: self.gas_counter.burnt_gas(),
             used_gas: self.gas_counter.used_gas(),
             logs,
+            profile: Default::default(),
         }
     }
 
@@ -2542,6 +2540,9 @@ pub struct VMOutcome {
     pub burnt_gas: Gas,
     pub used_gas: Gas,
     pub logs: Vec<String>,
+    #[serde(skip)]
+    /// Data collected from making a contract call
+    pub profile: ProfileData,
 }
 
 impl std::fmt::Debug for VMOutcome {

--- a/runtime/near-vm-logic/tests/vm_logic_builder.rs
+++ b/runtime/near-vm-logic/tests/vm_logic_builder.rs
@@ -40,7 +40,6 @@ impl VMLogicBuilder {
             &self.fees_config,
             &self.promise_results,
             &mut self.memory,
-            Default::default(),
             self.current_protocol_version,
         )
     }

--- a/runtime/near-vm-runner-standalone/src/main.rs
+++ b/runtime/near-vm-runner-standalone/src/main.rs
@@ -188,6 +188,7 @@ fn main() {
         .unwrap()
     );
 
-    assert_eq!(all_gas, results.profile.all_gas());
-    println!("{:#?}", results.profile);
+    // TODO: replace with results' outcomes' profile
+    // assert_eq!(all_gas, results.profile.all_gas());
+    // println!("{:#?}", results.profile);
 }

--- a/runtime/near-vm-runner-standalone/src/script.rs
+++ b/runtime/near-vm-runner-standalone/src/script.rs
@@ -3,7 +3,6 @@ use std::path::Path;
 
 use near_primitives::contract::ContractCode;
 use near_primitives::types::CompiledContractCache;
-use near_primitives_core::profile::ProfileData;
 use near_primitives_core::runtime::fees::RuntimeFeesConfig;
 use near_vm_logic::mocks::mock_external::MockedExternal;
 use near_vm_logic::types::PromiseResult;
@@ -22,7 +21,6 @@ pub struct Script {
     vm_kind: VMKind,
     vm_config: VMConfig,
     protocol_version: ProtocolVersion,
-    profile: ProfileData,
     contract_cache: Option<Box<dyn CompiledContractCache>>,
     initial_state: Option<State>,
     steps: Vec<Step>,
@@ -39,7 +37,6 @@ pub struct Step {
 pub struct ScriptResults {
     pub outcomes: Vec<(Option<VMOutcome>, Option<VMError>)>,
     pub state: MockedExternal,
-    pub profile: ProfileData,
 }
 
 impl Default for Script {
@@ -49,7 +46,6 @@ impl Default for Script {
             vm_kind: VMKind::default(),
             vm_config: VMConfig::default(),
             protocol_version: ProtocolVersion::MAX,
-            profile: ProfileData::new(),
             contract_cache: None,
             initial_state: None,
             steps: Vec::new(),
@@ -129,12 +125,11 @@ impl Script {
                     self.vm_kind,
                     self.protocol_version,
                     self.contract_cache.as_deref(),
-                    self.profile.clone(),
                 );
                 outcomes.push(res);
             }
         }
-        ScriptResults { outcomes, state: external, profile: self.profile }
+        ScriptResults { outcomes, state: external }
     }
 }
 

--- a/runtime/near-vm-runner/src/preload.rs
+++ b/runtime/near-vm-runner/src/preload.rs
@@ -173,7 +173,6 @@ impl ContractCaller {
                                     &self.vm_config,
                                     fees_config,
                                     promise_results,
-                                    profile,
                                     current_protocol_version,
                                 )
                             }
@@ -203,7 +202,6 @@ impl ContractCaller {
                                     &self.vm_config,
                                     fees_config,
                                     promise_results,
-                                    profile,
                                     current_protocol_version,
                                 )
                             }

--- a/runtime/near-vm-runner/src/runner.rs
+++ b/runtime/near-vm-runner/src/runner.rs
@@ -1,9 +1,7 @@
 use near_primitives::contract::ContractCode;
 use near_primitives::hash::CryptoHash;
 use near_primitives::runtime::fees::RuntimeFeesConfig;
-use near_primitives::{
-    config::VMConfig, profile::ProfileData, types::CompiledContractCache, version::ProtocolVersion,
-};
+use near_primitives::{config::VMConfig, types::CompiledContractCache, version::ProtocolVersion};
 use near_vm_errors::{CompilationError, FunctionCallError, VMError};
 use near_vm_logic::types::PromiseResult;
 use near_vm_logic::{External, VMContext, VMOutcome};
@@ -32,7 +30,6 @@ pub fn run<'a>(
     promise_results: &'a [PromiseResult],
     current_protocol_version: ProtocolVersion,
     cache: Option<&'a dyn CompiledContractCache>,
-    profile: &ProfileData,
 ) -> (Option<VMOutcome>, Option<VMError>) {
     run_vm(
         code,
@@ -45,7 +42,6 @@ pub fn run<'a>(
         VMKind::default(),
         current_protocol_version,
         cache,
-        profile.clone(),
     )
 }
 
@@ -60,7 +56,6 @@ pub fn run_vm(
     vm_kind: VMKind,
     current_protocol_version: ProtocolVersion,
     cache: Option<&dyn CompiledContractCache>,
-    profile: ProfileData,
 ) -> (Option<VMOutcome>, Option<VMError>) {
     let _span = tracing::debug_span!(target: "vm", "run_vm").entered();
 
@@ -83,7 +78,6 @@ pub fn run_vm(
             wasm_config,
             fees_config,
             promise_results,
-            profile.clone(),
             current_protocol_version,
             cache,
         ),
@@ -98,7 +92,6 @@ pub fn run_vm(
             wasm_config,
             fees_config,
             promise_results,
-            profile.clone(),
             current_protocol_version,
             cache,
         ),
@@ -115,16 +108,15 @@ pub fn run_vm(
             wasm_config,
             fees_config,
             promise_results,
-            profile.clone(),
             current_protocol_version,
             cache,
         ),
         #[cfg(not(feature = "wasmer1_vm"))]
         VMKind::Wasmer1 => panic!("Wasmer1 is not supported, compile with '--features wasmer1_vm'"),
     };
-    if let Some(VMOutcome { burnt_gas, .. }) = &outcome {
-        profile.set_burnt_gas(*burnt_gas)
-    }
+    // if let Some(VMOutcome { burnt_gas, .. }) = &outcome {
+    //     profile.set_burnt_gas(*burnt_gas)
+    // }
     (outcome, error)
 }
 

--- a/runtime/near-vm-runner/src/tests/error_cases.rs
+++ b/runtime/near-vm-runner/src/tests/error_cases.rs
@@ -19,6 +19,7 @@ fn vm_outcome_with_gas(gas: u64) -> VMOutcome {
         burnt_gas: gas,
         used_gas: gas,
         logs: vec![],
+        profile: Default::default(),
     }
 }
 

--- a/runtime/near-vm-runner/src/wasmer1_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer1_runner.rs
@@ -2,7 +2,7 @@ use crate::errors::IntoVMError;
 use crate::{cache, imports};
 use near_primitives::contract::ContractCode;
 use near_primitives::runtime::fees::RuntimeFeesConfig;
-use near_primitives::{profile::ProfileData, types::CompiledContractCache};
+use near_primitives::types::CompiledContractCache;
 use near_vm_errors::{
     CompilationError, FunctionCallError, MethodResolveError, PrepareError, VMError, WasmTrap,
 };
@@ -187,7 +187,6 @@ pub fn run_wasmer1(
     wasm_config: &VMConfig,
     fees_config: &RuntimeFeesConfig,
     promise_results: &[PromiseResult],
-    profile: ProfileData,
     current_protocol_version: ProtocolVersion,
     cache: Option<&dyn CompiledContractCache>,
 ) -> (Option<VMOutcome>, Option<VMError>) {
@@ -238,7 +237,6 @@ pub fn run_wasmer1(
         fees_config,
         promise_results,
         &mut memory,
-        profile,
         current_protocol_version,
     );
 
@@ -339,7 +337,6 @@ pub(crate) fn run_wasmer1_module<'a>(
     wasm_config: &'a VMConfig,
     fees_config: &'a RuntimeFeesConfig,
     promise_results: &'a [PromiseResult],
-    profile: ProfileData,
     current_protocol_version: ProtocolVersion,
 ) -> (Option<VMOutcome>, Option<VMError>) {
     // Do we really need that code?
@@ -362,7 +359,6 @@ pub(crate) fn run_wasmer1_module<'a>(
         fees_config,
         promise_results,
         memory,
-        profile,
         current_protocol_version,
     );
 

--- a/runtime/near-vm-runner/src/wasmer_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer_runner.rs
@@ -3,9 +3,7 @@ use crate::memory::WasmerMemory;
 use crate::{cache, imports};
 use near_primitives::contract::ContractCode;
 use near_primitives::runtime::fees::RuntimeFeesConfig;
-use near_primitives::{
-    config::VMConfig, profile::ProfileData, types::CompiledContractCache, version::ProtocolVersion,
-};
+use near_primitives::{config::VMConfig, types::CompiledContractCache, version::ProtocolVersion};
 use near_vm_errors::{CompilationError, FunctionCallError, MethodResolveError, VMError, WasmTrap};
 use near_vm_logic::types::PromiseResult;
 use near_vm_logic::{External, VMContext, VMLogic, VMLogicError, VMOutcome};
@@ -218,7 +216,6 @@ pub fn run_wasmer<'a>(
     wasm_config: &'a VMConfig,
     fees_config: &'a RuntimeFeesConfig,
     promise_results: &'a [PromiseResult],
-    profile: ProfileData,
     current_protocol_version: ProtocolVersion,
     cache: Option<&'a dyn CompiledContractCache>,
 ) -> (Option<VMOutcome>, Option<VMError>) {
@@ -264,7 +261,6 @@ pub fn run_wasmer<'a>(
         fees_config,
         promise_results,
         &mut memory,
-        profile,
         current_protocol_version,
     );
 
@@ -318,7 +314,6 @@ pub(crate) fn run_wasmer0_module<'a>(
     wasm_config: &'a VMConfig,
     fees_config: &'a RuntimeFeesConfig,
     promise_results: &'a [PromiseResult],
-    profile: ProfileData,
     current_protocol_version: ProtocolVersion,
 ) -> (Option<VMOutcome>, Option<VMError>) {
     if method_name.is_empty() {
@@ -339,7 +334,6 @@ pub(crate) fn run_wasmer0_module<'a>(
         fees_config,
         promise_results,
         memory,
-        profile,
         current_protocol_version,
     );
 

--- a/runtime/near-vm-runner/src/wasmtime_runner.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner.rs
@@ -8,8 +8,7 @@ pub mod wasmtime_runner {
     use near_primitives::contract::ContractCode;
     use near_primitives::runtime::fees::RuntimeFeesConfig;
     use near_primitives::{
-        config::VMConfig, profile::ProfileData, types::CompiledContractCache,
-        version::ProtocolVersion,
+        config::VMConfig, types::CompiledContractCache, version::ProtocolVersion,
     };
     use near_vm_errors::{FunctionCallError, MethodResolveError, VMError, VMLogicError, WasmTrap};
     use near_vm_logic::{
@@ -151,7 +150,6 @@ pub mod wasmtime_runner {
         wasm_config: &VMConfig,
         fees_config: &RuntimeFeesConfig,
         promise_results: &[PromiseResult],
-        profile: ProfileData,
         current_protocol_version: ProtocolVersion,
         _cache: Option<&dyn CompiledContractCache>,
     ) -> (Option<VMOutcome>, Option<VMError>) {
@@ -182,7 +180,6 @@ pub mod wasmtime_runner {
             fees_config,
             promise_results,
             &mut memory,
-            profile,
             current_protocol_version,
         );
         // TODO: remove, as those costs are incorrectly computed, and we shall account it on deployment.

--- a/runtime/runtime-params-estimator/src/function_call.rs
+++ b/runtime/runtime-params-estimator/src/function_call.rs
@@ -3,7 +3,6 @@ use crate::testbed_runners::{end_count, start_count, GasMetric};
 use crate::vm_estimator::{create_context, least_squares_method};
 use near_primitives::config::VMConfig;
 use near_primitives::contract::ContractCode;
-use near_primitives::profile::ProfileData;
 use near_primitives::runtime::fees::RuntimeFeesConfig;
 use near_primitives::types::{CompiledContractCache, ProtocolVersion};
 use near_store::{create_store, StoreCompiledContractCache};
@@ -123,7 +122,6 @@ pub fn compute_function_call_cost(
             vm_kind,
             ProtocolVersion::MAX,
             cache,
-            ProfileData::new(),
         );
         assert!(result.1.is_none());
     }
@@ -141,7 +139,6 @@ pub fn compute_function_call_cost(
             vm_kind,
             ProtocolVersion::MAX,
             cache,
-            ProfileData::new(),
         );
         assert!(result.1.is_none());
     }

--- a/runtime/runtime-params-estimator/src/gas_metering.rs
+++ b/runtime/runtime-params-estimator/src/gas_metering.rs
@@ -3,7 +3,6 @@ use crate::testbed_runners::{end_count, start_count, GasMetric};
 use crate::vm_estimator::{create_context, least_squares_method};
 use near_primitives::config::VMConfig;
 use near_primitives::contract::ContractCode;
-use near_primitives::profile::ProfileData;
 use near_primitives::runtime::fees::RuntimeFeesConfig;
 use near_primitives::types::{CompiledContractCache, ProtocolVersion};
 use near_store::{create_store, StoreCompiledContractCache};
@@ -194,7 +193,6 @@ pub fn compute_gas_metering_cost(
         vm_kind,
         ProtocolVersion::MAX,
         cache,
-        ProfileData::new(),
     );
     assert!(result.1.is_none());
 
@@ -212,7 +210,6 @@ pub fn compute_gas_metering_cost(
             vm_kind,
             ProtocolVersion::MAX,
             cache,
-            ProfileData::new(),
         );
         assert!(result.1.is_none());
     }
@@ -230,7 +227,6 @@ pub fn compute_gas_metering_cost(
         vm_kind,
         ProtocolVersion::MAX,
         cache,
-        ProfileData::new(),
     );
     assert!(result.1.is_none());
     let start = start_count(gas_metric);
@@ -246,7 +242,6 @@ pub fn compute_gas_metering_cost(
             vm_kind,
             ProtocolVersion::MAX,
             cache,
-            ProfileData::new(),
         );
         assert!(result.1.is_none());
     }

--- a/runtime/runtime-params-estimator/src/testbed.rs
+++ b/runtime/runtime-params-estimator/src/testbed.rs
@@ -95,7 +95,6 @@ impl RuntimeTestbed {
             is_new_chunk: true,
             #[cfg(feature = "protocol_feature_evm")]
             evm_chain_id: near_chain_configs::TESTNET_EVM_CHAIN_ID,
-            profile: Default::default(),
             migration_data: Arc::new(MigrationData::default()),
             migration_flags: MigrationFlags::default(),
         };

--- a/runtime/runtime-params-estimator/src/vm_estimator.rs
+++ b/runtime/runtime-params-estimator/src/vm_estimator.rs
@@ -1,7 +1,6 @@
 use crate::cases::ratio_to_gas_signed;
 use crate::testbed_runners::{end_count, start_count, GasMetric};
 use near_primitives::contract::ContractCode;
-use near_primitives::profile::ProfileData;
 use near_primitives::runtime::fees::RuntimeFeesConfig;
 use near_primitives::types::{CompiledContractCache, ProtocolVersion};
 use near_primitives::version::PROTOCOL_VERSION;
@@ -63,7 +62,6 @@ fn call(code: &[u8]) -> (Option<VMOutcome>, Option<VMError>) {
         &promise_results,
         PROTOCOL_VERSION,
         None,
-        &Default::default(),
     )
 }
 
@@ -375,7 +373,6 @@ fn test_many_contracts_call(gas_metric: GasMetric, vm_kind: VMKind) {
             vm_kind,
             ProtocolVersion::MAX,
             cache,
-            ProfileData::new(),
         );
         assert!(result.1.is_none());
     }

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -39,6 +39,7 @@ use near_vm_logic::{VMContext, VMOutcome};
 use crate::config::{safe_add_gas, RuntimeConfig};
 use crate::ext::RuntimeExt;
 use crate::{ActionResult, ApplyState};
+use near_vm_logic::profile::ProfileData;
 use near_vm_runner::precompile_contract;
 
 /// Runs given function call with given context / apply state.
@@ -142,7 +143,6 @@ pub(crate) fn execute_function_call(
             promise_results,
             apply_state.current_protocol_version,
             apply_state.cache.as_deref(),
-            &apply_state.profile,
         )
     }
 }
@@ -266,6 +266,7 @@ pub(crate) fn action_function_call(
         // `FunctionCall`s error.
         result.gas_used = safe_add_gas(result.gas_used, outcome.used_gas)?;
         result.logs.extend(outcome.logs.into_iter());
+        result.profile.merge(outcome.profile);
         if execution_succeeded {
             account.set_amount(outcome.balance);
             account.set_storage_usage(outcome.storage_usage);

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -245,7 +245,6 @@ impl TrieViewer {
             is_new_chunk: false,
             #[cfg(feature = "protocol_feature_evm")]
             evm_chain_id: view_state.evm_chain_id,
-            profile: Default::default(),
             migration_data: Arc::new(MigrationData::default()),
             migration_flags: MigrationFlags::default(),
         };

--- a/runtime/runtime/tests/runtime_group_tools/mod.rs
+++ b/runtime/runtime/tests/runtime_group_tools/mod.rs
@@ -85,7 +85,6 @@ impl StandaloneRuntime {
             is_new_chunk: true,
             #[cfg(feature = "protocol_feature_evm")]
             evm_chain_id: near_chain_configs::TESTNET_EVM_CHAIN_ID,
-            profile: Default::default(),
             migration_data: Arc::new(MigrationData::default()),
             migration_flags: MigrationFlags::default(),
         };

--- a/test-utils/testlib/src/user/runtime_user.rs
+++ b/test-utils/testlib/src/user/runtime_user.rs
@@ -144,7 +144,6 @@ impl RuntimeUser {
             is_new_chunk: true,
             #[cfg(feature = "protocol_feature_evm")]
             evm_chain_id: TESTNET_EVM_CHAIN_ID,
-            profile: Default::default(),
             migration_data: Arc::new(MigrationData::default()),
             migration_flags: MigrationFlags::default(),
         }


### PR DESCRIPTION
Very draft. Basically it does:
> 
-  rather than passing ProfileData everywhere via ApplyAction, create a fresh GasProfile in GasCounter::new -- this is the only place that uses it.
-   add gas_profile field to VMOutcome
-   Add gas_profile field to ActionResult here and in merge.

As mentioned in https://github.com/near/nearcore/issues/4560. Need more examination, consider about compatibility, fix and add tests etc.