### PR TITLE
pytest: add a pre-commit check testing if all pytests are enabled

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -34,7 +34,7 @@ steps:
       RUSTFLAGS='-D warnings' cargo check -p neard --features sandbox
       python3 scripts/state/update_res.py check
       python3 scripts/check_nightly.py
-      python3 scripts/check_pytest.py
+      python3 scripts/check_pytests.py
     timeout: 30
     agents:
     - "distro=amazonlinux"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -34,6 +34,7 @@ steps:
       RUSTFLAGS='-D warnings' cargo check -p neard --features sandbox
       python3 scripts/state/update_res.py check
       python3 scripts/check_nightly.py
+      python3 scripts/check_pytest.py
     timeout: 30
     agents:
     - "distro=amazonlinux"

--- a/nightly/complete_nayduck_set.txt
+++ b/nightly/complete_nayduck_set.txt
@@ -1,3 +1,17 @@
+# TODO(#4552): Those tests were identified as missing from any of the test list
+# files.  It’s not entirely clear why so some investigation is necessary to
+# figure that out.  The tests need to either be enabled or removed completely if
+# they are no longer needed/valid.
+# pytest adversarial/gc_rollback.py
+# pytest sanity/concurrent_function_calls.py
+# pytest sanity/proxy_example.py
+# pytest sanity/restart.py
+# pytest sanity/rpc_finality.py
+# pytest sanity/rpc_tx_submission.py
+# pytest sanity/state_migration.py
+# pytest stress/network_stress.py
+# pytest stress/saturate_routing_table.py
+
 # python sanity tests
 pytest sanity/block_production.py
 pytest sanity/block_production.py --features nightly_protocol --features nightly_protocol_features


### PR DESCRIPTION
Add the scripts/check_pytest.py to the ‘sanity checks’ pre-commit
tests to make sure that all pytest tests are enabled in one of the
nightly/*.txt files.

Because at the moment there are nine files which do not meet that
criteria, add them to nightly/complete_nayduck_set.txt with a comment
documenting the state.

Issue: https://github.com/near/nearcore/issues/4552
Fixes: https://github.com/near/nearcore/issues/2736