### PR TITLE
nightly: fix saturate_routing_table test description

### DIFF
--- a/nightly/TODO-disabled-4552.txt
+++ b/nightly/TODO-disabled-4552.txt
@@ -18,5 +18,3 @@
 # pytest sanity/state_migration.py --features nightly_protocol,nightly_protocol_features
 # pytest stress/network_stress.py
 # pytest stress/network_stress.py --features nightly_protocol,nightly_protocol_features
-# pytest stress/saturate_routing_table.py
-# pytest stress/saturate_routing_table.py --features nightly_protocol,nightly_protocol_features

--- a/nightly/pytest-sanity.txt
+++ b/nightly/pytest-sanity.txt
@@ -85,8 +85,6 @@ pytest sanity/repro_2916.py
 pytest sanity/repro_2916.py --features nightly_protocol,nightly_protocol_features
 pytest --timeout=240 sanity/switch_node_key.py
 pytest --timeout=240 sanity/switch_node_key.py --features nightly_protocol,nightly_protocol_features
-pytest --timeout=300 sanity/saturate_routing_table.py
-pytest --timeout=300 sanity/saturate_routing_table.py --features nightly_protocol,nightly_protocol_features
 # TODO: re-enable after #2949 is fixed
 # pytest --timeout=240 sanity/validator_switch_key.py
 # pytest --timeout=240 sanity/validator_switch_key.py --features nightly_protocol,nightly_protocol_features

--- a/nightly/pytest-stress.txt
+++ b/nightly/pytest-stress.txt
@@ -16,5 +16,8 @@ pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions node_restart
 # pytest --timeout=2000 stress/stress.py 3 2 4 0 staking transactions node_set
 # pytest --timeout=2000 stress/stress.py 3 2 4 0 staking transactions node_set --features nightly_protocol,nightly_protocol_features
 
+pytest --timeout=300 stress/saturate_routing_table.py
+pytest --timeout=300 stress/saturate_routing_table.py --features nightly_protocol,nightly_protocol_features
+
 # pytest stress/network_stress.py
 # pytest stress/network_stress.py --features nightly_protocol,nightly_protocol_features


### PR DESCRIPTION
saturate_routing_table test lives in stress directory not sanity directory.

Issue: https://github.com/near/nearcore/issues/4552