### PR TITLE
integration-tests: fix compiler warnings

### DIFF
--- a/integration-tests/tests/test_catchup.rs
+++ b/integration-tests/tests/test_catchup.rs
@@ -21,7 +21,7 @@ fn test_catchup() {
         let nodes = create_nodes(num_nodes, test_prefix);
 
         let mut nodes: Vec<Arc<RwLock<dyn Node>>> =
-            nodes.into_iter().map(|cfg| Node::new_sharable(cfg)).collect();
+            nodes.into_iter().map(|cfg| <dyn Node>::new_sharable(cfg)).collect();
 
         let late_node = nodes.pop().unwrap();
         // Start all but one.

--- a/integration-tests/tests/test_rejoin.rs
+++ b/integration-tests/tests/test_rejoin.rs
@@ -16,6 +16,7 @@ mod test {
 
     fn warmup() {
         if let Err(_) = std::env::var("NIGHTLY_RUNNER") {
+            #[allow(unused_mut)]
             let mut args = vec!["build", "-p", "neard"];
             #[cfg(feature = "nightly_protocol")]
             {
@@ -90,7 +91,7 @@ mod test {
             })
             .collect();
 
-        let nodes: Vec<_> = nodes.into_iter().map(|cfg| Node::new_sharable(cfg)).collect();
+        let nodes: Vec<_> = nodes.into_iter().map(|cfg| <dyn Node>::new_sharable(cfg)).collect();
         let account_names: Vec<_> =
             nodes.iter().map(|node| node.read().unwrap().account_id().unwrap()).collect();
 
@@ -174,7 +175,7 @@ mod test {
             })
             .collect();
         let nodes: Vec<Arc<RwLock<dyn Node>>> =
-            nodes.into_iter().map(|cfg| Node::new_sharable(cfg)).collect();
+            nodes.into_iter().map(|cfg| <dyn Node>::new_sharable(cfg)).collect();
         let account_names: Vec<_> =
             nodes.iter().map(|node| node.read().unwrap().account_id().unwrap()).collect();
 

--- a/integration-tests/tests/test_simple.rs
+++ b/integration-tests/tests/test_simple.rs
@@ -12,7 +12,7 @@ mod test {
         init_integration_logger();
 
         let nodes = create_nodes(num_nodes, test_prefix);
-        let nodes: Vec<_> = nodes.into_iter().map(|cfg| Node::new_sharable(cfg)).collect();
+        let nodes: Vec<_> = nodes.into_iter().map(|cfg| <dyn Node>::new_sharable(cfg)).collect();
         let account_names: Vec<_> =
             nodes.iter().map(|node| node.read().unwrap().account_id().unwrap()).collect();
 

--- a/integration-tests/tests/test_tps_regression.rs
+++ b/integration-tests/tests/test_tps_regression.rs
@@ -64,7 +64,7 @@ mod test {
         let nodes = create_nodes(num_nodes, test_prefix);
 
         let nodes: Vec<Arc<RwLock<dyn Node>>> =
-            nodes.into_iter().map(|cfg| Node::new_sharable(cfg)).collect();
+            nodes.into_iter().map(|cfg| <dyn Node>::new_sharable(cfg)).collect();
         for i in 0..num_nodes {
             nodes[i].write().unwrap().start();
         }


### PR DESCRIPTION
Fix three instances of ‘trait objects without an explicit `dyn` are
deprecated’ warning and one instance of unused mut warning.