### PR TITLE
tests: remove write_random_value smart contract function

### DIFF
--- a/integration-tests/tests/client/sandbox.rs
+++ b/integration-tests/tests/client/sandbox.rs
@@ -53,8 +53,8 @@ fn test_setup() -> (TestEnv, InMemorySigner) {
         "test0".to_string(),
         &signer,
         vec![Action::FunctionCall(FunctionCallAction {
-            method_name: "write_random_value".to_string(),
-            args: vec![],
+            method_name: "write_key_value".to_string(),
+            args: vec![42, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0],
             gas: 100000000000000,
             deposit: 0,
         })],

--- a/pytest/tests/sanity/backward_compatible.py
+++ b/pytest/tests/sanity/backward_compatible.py
@@ -6,6 +6,7 @@ sure they are backward compatible.
 
 import sys
 import os
+import struct
 import subprocess
 import time
 import base58
@@ -83,8 +84,8 @@ def main():
 
     tx = sign_function_call_tx(new_signer_key,
                                new_account_id,
-                               'write_random_value', [], 10**13, 0, nonce + 1,
-                               block_hash)
+                               'write_key_value', struct.pack('<QQ', 42, 24),
+                               10**13, 0, nonce + 1, block_hash)
     res = stable_node.send_tx_and_wait(tx, timeout=20)
     assert 'error' not in res, res
     assert 'Failure' not in res['result']['status'], res

--- a/pytest/tests/sanity/upgradable.py
+++ b/pytest/tests/sanity/upgradable.py
@@ -6,6 +6,7 @@ At the end run for 3 epochs and observe that current protocol version of the net
 """
 
 import os
+import struct
 import subprocess
 import sys
 import time
@@ -79,7 +80,8 @@ def main():
     # write some random value
     tx = sign_function_call_tx(nodes[0].signer_key,
                                nodes[0].signer_key.account_id,
-                               'write_random_value', [], 10 ** 13, 0, 2,
+                               'write_key_value', struct.pack('<QQ', 42, 24),
+                               10 ** 13, 0, 2,
                                base58.b58decode(hash.encode('utf8')))
     res = nodes[0].send_tx_and_wait(tx, timeout=20)
     assert 'error' not in res, res
@@ -107,7 +109,8 @@ def main():
     # write some random value again
     tx = sign_function_call_tx(nodes[0].signer_key,
                                nodes[0].signer_key.account_id,
-                               'write_random_value', [], 10 ** 13, 0, 4,
+                               'write_key_value', struct.pack('<QQ', 42, 24),
+                               10 ** 13, 0, 4,
                                base58.b58decode(hash.encode('utf8')))
     res = nodes[0].send_tx_and_wait(tx, timeout=20)
     assert 'error' not in res, res

--- a/runtime/near-test-contracts/test-contract-rs/src/lib.rs
+++ b/runtime/near-test-contracts/test-contract-rs/src/lib.rs
@@ -304,15 +304,6 @@ pub unsafe fn write_block_height() {
 }
 
 #[no_mangle]
-pub unsafe fn write_random_value() {
-    random_seed(0);
-    let data = [0u8; 32];
-    read_register(0, data.as_ptr() as u64);
-    let value = b"hello";
-    storage_write(data.len() as _, data.as_ptr() as _, value.len() as _, value.as_ptr() as _, 1);
-}
-
-#[no_mangle]
 pub unsafe fn read_value() {
     input(0);
     if register_len(0) != size_of::<u64>() as u64 {


### PR DESCRIPTION
There’s really no point to it other than reducing amount of code in
the test contract and we know that less code is always better.