### PR TITLE
pytest: remove breaking assert in bridge pytests

### DIFF
--- a/pytest/lib/bridge.py
+++ b/pytest/lib/bridge.py
@@ -370,10 +370,9 @@ class RainbowBridge:
 
     def git_clone_install(self):
         logger.info('No rainbow-bridge repo found, cloning...')
-        args = ('git clone --recurse-submodules %s %s' %
-                (self.config['bridge_repo'], self.bridge_dir)).split()
-        assert subprocess.check_output(args).decode('ascii').strip(
-        ) == "Submodule path 'eth2near/ethashproof': checked out 'b7e7e22979a9b25043b649c22e41cb149267fbeb'"
+        args = ('git', 'clone', '--recurse-submodules',
+                str(self.config['bridge_repo']), str(self.bridge_dir))
+        subprocess.check_call(args)
         assert_success(subprocess.check_output(['yarn'], cwd=self.bridge_dir))
         ethash_dir = os.path.join(self.bridge_dir, 'eth2near/ethashproof')
         assert_success(subprocess.check_output(['/bin/sh', 'build.sh'], cwd=ethash_dir))


### PR DESCRIPTION
I’ve got seriously no idea what the assertion in git_clone_install was
supposed to check.  Tying the test to particular commit isn’t a good
idea in the first place.  Plus at the moment `eth2near/ethashproof`
isn’t even a submodule in rainbow bridge repository anyway.

Whatever the reason for the assert, it causes the tests to fail.
Removing it improves the situation (but letting the tests progress)
though it doesn’t fix it completely.

Issue: https://github.com/near/nearcore/issues/4618
