### PR TITLE
pytest: fix import of `configured_logger` in bridge tests

### DIFF
--- a/pytest/tests/bridge/multiple_relays.py
+++ b/pytest/tests/bridge/multiple_relays.py
@@ -5,6 +5,7 @@
 # Wait at the end for 60 seconds more to make sure balances are not chaning.
 
 import sys, time
+sys.path.append('lib')
 from configured_logger import logger
 
 add_relay_while_tx = False

--- a/pytest/tests/bridge/same_block.py
+++ b/pytest/tests/bridge/same_block.py
@@ -3,9 +3,10 @@
 # Guarantee that all txs will be in same block.
 
 import base58
-from configured_logger import logger
 from retrying import retry
 import sys, time
+sys.path.append('lib')
+from configured_logger import logger
 
 if len(sys.argv) < 3:
     logger.info("python same_block.py <eth2near_tx_number> <near2eth_tx_number> [...]")


### PR DESCRIPTION
This fixes failures such as:

    Traceback (most recent call last):
      File "tests/bridge/multiple_relays.py", line 8, in <module>
        from configured_logger import logger
    ModuleNotFoundError: No module named 'configured_logger'

Issue: https://github.com/near/nearcore/issues/4618
