### PR TITLE
refactor: make it clear that regular_op_cost uses the multiplier

### DIFF
--- a/core/primitives-core/src/config.rs
+++ b/core/primitives-core/src/config.rs
@@ -87,7 +87,7 @@ impl Default for VMConfig {
         VMConfig {
             ext_costs: ExtCostsConfig::default(),
             grow_mem_cost: 1,
-            regular_op_cost: 3856371,
+            regular_op_cost: (SAFETY_MULTIPLIER as u32) * 1285457,
             limit_config: VMLimitConfig::default(),
         }
     }


### PR DESCRIPTION
The numeric value of the cost stays exactly the same (3856371 is evenly
divisible by 3).

Looking at the recent measurements in

https://github.com/near/nearcore/pull/4455#issuecomment-874790365

it's clear that the measured cost is 3x lower.

Test Plan:
--------

Just visual inspection that the constant stays the same. 