### PR TITLE
fix: update wasmer 0 to prevent miscompilation on a specific nightly rust version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5796,9 +5796,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-runtime-core-near"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f280f695867a25b7181516167aa660452ffc26772fd5e15c07f6fbbf989d7ba1"
+checksum = "2cf26de331c8ef4257bef33649b4665535b105c927ab2e00715f17891362efe8"
 dependencies = [
  "bincode",
  "blake3",

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -16,7 +16,7 @@ This crate implements the specification of the interface that Near blockchain ex
 borsh = "0.8.1"
 serde = { version = "1", features = ["derive"] }
 wasmer-runtime = { version = "0.18.0", features = ["default-backend-singlepass"], default-features = false, package = "wasmer-runtime-near", optional = true }
-wasmer-runtime-core = { version = "0.18.1", package = "wasmer-runtime-core-near", optional = true}
+wasmer-runtime-core = { version = "0.18.2", package = "wasmer-runtime-core-near", optional = true}
 wasmparser = "0.51"
 wasmer = { version = "1.0.2", optional = true }
 wasmer-types = { version = "1.0.2", optional = true }


### PR DESCRIPTION
Before this fix, the following fails:

```
$ git diff Cargo.toml
diff --git a/Cargo.toml b/Cargo.toml
index 9b5e2c16..ab7f34f1 100644
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,10 +54,11 @@ members = [
 wasmer-compiler-singlepass = { git = "https://github.com/near/wasmer", branch = "1.0.2-single-threaded" }

 [profile.release]
+codegen-units = 1
 overflow-checks = true

 [profile.bench]
-lto = true
+# lto = true
 codegen-units = 1 # Use only 1 codegen-unit to enable full optimizations.
 overflow-checks = true

$ cargo +nightly-2021-03-25 test --release --package near-vm-runner --lib \
    -- tests::error_cases::test_guest_panic --exact
```

The is fix on wasmer side:

  https://github.com/near/wasmer/commit/1ad551ac734d9f9e3823136b79291a6832aa4324