### PR TITLE
nightly: fix `test_gc_after_state_sync` test

### DIFF
--- a/nightly/expensive.txt
+++ b/nightly/expensive.txt
@@ -125,8 +125,8 @@ expensive --timeout=600 near-chain gc tests::test_gc_pine
 expensive --timeout=600 near-chain gc tests::test_gc_pine --features nightly_protocol,nightly_protocol_features
 expensive --timeout=700 near-chain gc tests::test_gc_star_large
 expensive --timeout=700 near-chain gc tests::test_gc_star_large --features nightly_protocol,nightly_protocol_features
-expensive integration-tests client test_gc_after_state_sync
-expensive integration-tests client test_gc_after_state_sync --features nightly_protocol,nightly_protocol_features
+expensive integration-tests client process_blocks::test_gc_after_state_sync
+expensive integration-tests client process_blocks::test_gc_after_state_sync --features nightly_protocol,nightly_protocol_features
 
 # lib tests
 lib near-chunks test::test_seal_removal


### PR DESCRIPTION
The test name in the `expensive` nightly tests must match exactly
the path of the path otherwise it won’t match any known tests.
The `test_gc_after_state_sync` is in `process_blocks` module thus
it requires `process_blocks::test_gc_after_state_sync` to be used.

Issues: https://github.com/near/nearcore/issues/4618