### PR TITLE
pytest: bridge: fix `git_clone_install` method

### DIFF
--- a/pytest/lib/bridge.py
+++ b/pytest/lib/bridge.py
@@ -369,16 +369,16 @@ class RainbowBridge:
 
     def git_clone_install(self):
         if os.path.exists(self.bridge_dir):
-            logger.info('No rainbow-bridge repo found, cloning...')
-            subprocess.check_call(
-                ('git', 'clone', '--recurse-submodules',
-                 str(self.config['bridge_repo']), str(self.bridge_dir)))
-        else:
             logger.info('rainbow-bridge repo found, updating...')
             subprocess.check_call(('git', 'remote', 'update', '-p', 'origin'),
                                   cwd=self.bridge_dir)
             subprocess.check_call(('git', 'reset', '--hard', 'origin/master'),
                                   cwd=self.bridge_dir)
+        else:
+            logger.info('No rainbow-bridge repo found, cloning...')
+            subprocess.check_call(
+                ('git', 'clone', '--recurse-submodules',
+                 str(self.config['bridge_repo']), str(self.bridge_dir)))
         assert_success(subprocess.check_output(['yarn'], cwd=self.bridge_dir))
         ethash_dir = os.path.join(self.bridge_dir, 'eth2near/ethashproof')
         assert_success(subprocess.check_output(['/bin/sh', 'build.sh'], cwd=ethash_dir))


### PR DESCRIPTION
Swap if bodies in the `git_clone_install` they way thay should be.

Fixes: b24e7a44323bf36e01bb6ba6deba33bc624cae9f
Issue: https://github.com/near/nearcore/issues/4618