### PR TITLE
nayduck: add support for suffix in ./<path> include directive

### DIFF
--- a/nightly/TODO-disabled-4552.txt
+++ b/nightly/TODO-disabled-4552.txt
@@ -1,14 +1,4 @@
-# TODO(#4552): Those tests were identified as missing from any of the test list
-# files.  It’s not entirely clear why so some investigation is necessary to
-# figure that out.  The tests need to either be enabled or removed completely if
-# they are no longer needed/valid.
-# pytest adversarial/gc_rollback.py
-# pytest adversarial/gc_rollback.py --features nightly_protocol,nightly_protocol_features
-# pytest sanity/restart.py
-# pytest sanity/restart.py --features nightly_protocol,nightly_protocol_features
-# pytest sanity/rpc_finality.py
-# pytest sanity/rpc_finality.py --features nightly_protocol,nightly_protocol_features
-# pytest sanity/state_migration.py
-# pytest sanity/state_migration.py --features nightly_protocol,nightly_protocol_features
-# pytest stress/network_stress.py
-# pytest stress/network_stress.py --features nightly_protocol,nightly_protocol_features
+pytest adversarial/gc_rollback.py
+pytest sanity/restart.py
+pytest sanity/rpc_finality.py
+pytest sanity/state_migration.py

--- a/nightly/expensive.txt
+++ b/nightly/expensive.txt
@@ -1,132 +1,74 @@
 # catchup tests
 expensive --timeout=1800 near-client catching_up tests::test_catchup_receipts_sync_third_epoch
-expensive --timeout=1800 near-client catching_up tests::test_catchup_receipts_sync_third_epoch --features nightly_protocol,nightly_protocol_features
 expensive --timeout=1800 near-client catching_up tests::test_catchup_receipts_sync_last_block
-expensive --timeout=1800 near-client catching_up tests::test_catchup_receipts_sync_last_block --features nightly_protocol,nightly_protocol_features
 expensive --timeout=1800 near-client catching_up tests::test_catchup_receipts_sync_distant_epoch
-expensive --timeout=1800 near-client catching_up tests::test_catchup_receipts_sync_distant_epoch --features nightly_protocol,nightly_protocol_features
 expensive --timeout=1800 near-client catching_up tests::test_catchup_random_single_part_sync
-expensive --timeout=1800 near-client catching_up tests::test_catchup_random_single_part_sync --features nightly_protocol,nightly_protocol_features
 expensive --timeout=1800 near-client catching_up tests::test_catchup_random_single_part_sync_skip_15
-expensive --timeout=1800 near-client catching_up tests::test_catchup_random_single_part_sync_skip_15 --features nightly_protocol,nightly_protocol_features
 expensive --timeout=1800 near-client catching_up tests::test_catchup_random_single_part_sync_send_15
-expensive --timeout=1800 near-client catching_up tests::test_catchup_random_single_part_sync_send_15 --features nightly_protocol,nightly_protocol_features
 expensive --timeout=1800 near-client catching_up tests::test_catchup_random_single_part_sync_non_zero_amounts
-expensive --timeout=1800 near-client catching_up tests::test_catchup_random_single_part_sync_non_zero_amounts --features nightly_protocol,nightly_protocol_features
 expensive --timeout=1800 near-client catching_up tests::test_catchup_random_single_part_sync_height_6
-expensive --timeout=1800 near-client catching_up tests::test_catchup_random_single_part_sync_height_6 --features nightly_protocol,nightly_protocol_features
 expensive --timeout=1800 near-client catching_up tests::test_catchup_sanity_blocks_produced
-expensive --timeout=1800 near-client catching_up tests::test_catchup_sanity_blocks_produced --features nightly_protocol,nightly_protocol_features
 expensive --timeout=3600 near-client catching_up tests::test_all_chunks_accepted_1000
-expensive --timeout=3600 near-client catching_up tests::test_all_chunks_accepted_1000 --features nightly_protocol,nightly_protocol_features
 # expensive --timeout=7200 near-client catching_up tests::test_all_chunks_accepted_1000_slow
-# expensive --timeout=7200 near-client catching_up tests::test_all_chunks_accepted_1000_slow --features nightly_protocol,nightly_protocol_features
 expensive --timeout=1800 near-client catching_up tests::test_all_chunks_accepted_1000_rare_epoch_changing
-expensive --timeout=1800 near-client catching_up tests::test_all_chunks_accepted_1000_rare_epoch_changing --features nightly_protocol,nightly_protocol_features
 expensive --timeout=1800 near-client catching_up tests::test_catchup_receipts_sync_hold
-expensive --timeout=1800 near-client catching_up tests::test_catchup_receipts_sync_hold --features nightly_protocol,nightly_protocol_features
 expensive --timeout=1800 near-client catching_up tests::test_chunk_grieving
-expensive --timeout=1800 near-client catching_up tests::test_chunk_grieving --features nightly_protocol,nightly_protocol_features
 
 expensive integration-tests test_catchup test_catchup
-expensive integration-tests test_catchup test_catchup --features nightly_protocol,nightly_protocol_features
 
 # cross-shard transactions tests
 expensive --timeout=3000 near-client cross_shard_tx tests::test_cross_shard_tx
-expensive --timeout=3000 near-client cross_shard_tx tests::test_cross_shard_tx --features nightly_protocol,nightly_protocol_features
 expensive --timeout=3000 near-client cross_shard_tx tests::test_cross_shard_tx_doomslug
-expensive --timeout=3000 near-client cross_shard_tx tests::test_cross_shard_tx_doomslug --features nightly_protocol,nightly_protocol_features
 expensive --timeout=3000 near-client cross_shard_tx tests::test_cross_shard_tx_drop_chunks
-expensive --timeout=3000 near-client cross_shard_tx tests::test_cross_shard_tx_drop_chunks --features nightly_protocol,nightly_protocol_features
 expensive --timeout=5400 near-client cross_shard_tx tests::test_cross_shard_tx_with_validator_rotation_1
-expensive --timeout=5400 near-client cross_shard_tx tests::test_cross_shard_tx_with_validator_rotation_1 --features nightly_protocol,nightly_protocol_features
 expensive --timeout=5400 near-client cross_shard_tx tests::test_cross_shard_tx_with_validator_rotation_2
-expensive --timeout=5400 near-client cross_shard_tx tests::test_cross_shard_tx_with_validator_rotation_2 --features nightly_protocol,nightly_protocol_features
 expensive --timeout=4800 near-client cross_shard_tx tests::test_cross_shard_tx_8_iterations
 expensive --timeout=4800 near-client cross_shard_tx tests::test_cross_shard_tx_8_iterations_drop_chunks
 
 # consensus tests
 expensive --timeout=3000 near-chain doomslug tests::test_fuzzy_doomslug_liveness_and_safety
-expensive --timeout=3000 near-chain doomslug tests::test_fuzzy_doomslug_liveness_and_safety --features nightly_protocol,nightly_protocol_features
 expensive --timeout=500 near-client consensus tests::test_consensus_with_epoch_switches
-expensive --timeout=500 near-client consensus tests::test_consensus_with_epoch_switches --features nightly_protocol,nightly_protocol_features
 
 # testnet rpc
 expensive nearcore test_tps_regression test::test_highload
-expensive nearcore test_tps_regression test::test_highload --features nightly_protocol,nightly_protocol_features
 
 expensive integration-tests standard_cases rpc::test::test_access_key_smart_contract_testnet
-expensive integration-tests standard_cases rpc::test::test_access_key_smart_contract_testnet --features nightly_protocol,nightly_protocol_features
 expensive integration-tests standard_cases rpc::test::test_access_key_smart_contract_testnet
-expensive integration-tests standard_cases rpc::test::test_access_key_smart_contract_testnet --features nightly_protocol,nightly_protocol_features
 expensive integration-tests standard_cases rpc::test::test_add_access_key_function_call_testnet
-expensive integration-tests standard_cases rpc::test::test_add_access_key_function_call_testnet --features nightly_protocol,nightly_protocol_features
 expensive integration-tests standard_cases rpc::test::test_add_access_key_with_allowance_testnet
-expensive integration-tests standard_cases rpc::test::test_add_access_key_with_allowance_testnet --features nightly_protocol,nightly_protocol_features
 expensive integration-tests standard_cases rpc::test::test_add_existing_key_testnet
-expensive integration-tests standard_cases rpc::test::test_add_existing_key_testnet --features nightly_protocol,nightly_protocol_features
 expensive integration-tests standard_cases rpc::test::test_add_key_testnet
-expensive integration-tests standard_cases rpc::test::test_add_key_testnet --features nightly_protocol,nightly_protocol_features
 expensive integration-tests standard_cases rpc::test::test_create_account_again_testnet
-expensive integration-tests standard_cases rpc::test::test_create_account_again_testnet --features nightly_protocol,nightly_protocol_features
 expensive integration-tests standard_cases rpc::test::test_create_account_failure_already_exists_testnet
-expensive integration-tests standard_cases rpc::test::test_create_account_failure_already_exists_testnet --features nightly_protocol,nightly_protocol_features
 expensive integration-tests standard_cases rpc::test::test_create_account_testnet
-expensive integration-tests standard_cases rpc::test::test_create_account_testnet --features nightly_protocol,nightly_protocol_features
 expensive integration-tests standard_cases rpc::test::test_delete_access_key_testnet
-expensive integration-tests standard_cases rpc::test::test_delete_access_key_testnet --features nightly_protocol,nightly_protocol_features
 expensive integration-tests standard_cases rpc::test::test_delete_access_key_with_allowance_testnet
-expensive integration-tests standard_cases rpc::test::test_delete_access_key_with_allowance_testnet --features nightly_protocol,nightly_protocol_features
 expensive integration-tests standard_cases rpc::test::test_delete_key_last_testnet
-expensive integration-tests standard_cases rpc::test::test_delete_key_last_testnet --features nightly_protocol,nightly_protocol_features
 expensive integration-tests standard_cases rpc::test::test_delete_key_not_owned_testnet
-expensive integration-tests standard_cases rpc::test::test_delete_key_not_owned_testnet --features nightly_protocol,nightly_protocol_features
 expensive integration-tests standard_cases rpc::test::test_delete_key_testnet
-expensive integration-tests standard_cases rpc::test::test_delete_key_testnet --features nightly_protocol,nightly_protocol_features
 expensive integration-tests standard_cases rpc::test::test_nonce_update_when_deploying_contract_testnet
-expensive integration-tests standard_cases rpc::test::test_nonce_update_when_deploying_contract_testnet --features nightly_protocol,nightly_protocol_features
 expensive integration-tests standard_cases rpc::test::test_nonce_updated_when_tx_failed_testnet
-expensive integration-tests standard_cases rpc::test::test_nonce_updated_when_tx_failed_testnet --features nightly_protocol,nightly_protocol_features
 expensive integration-tests standard_cases rpc::test::test_redeploy_contract_testnet
-expensive integration-tests standard_cases rpc::test::test_redeploy_contract_testnet --features nightly_protocol,nightly_protocol_features
 expensive integration-tests standard_cases rpc::test::test_refund_on_send_money_to_non_existent_account_testnet
-expensive integration-tests standard_cases rpc::test::test_refund_on_send_money_to_non_existent_account_testnet --features nightly_protocol,nightly_protocol_features
 expensive integration-tests standard_cases rpc::test::test_send_money_over_balance_testnet
-expensive integration-tests standard_cases rpc::test::test_send_money_over_balance_testnet --features nightly_protocol,nightly_protocol_features
 expensive integration-tests standard_cases rpc::test::test_send_money_testnet
-expensive integration-tests standard_cases rpc::test::test_send_money_testnet --features nightly_protocol,nightly_protocol_features
 expensive integration-tests standard_cases rpc::test::test_smart_contract_bad_method_name_testnet
-expensive integration-tests standard_cases rpc::test::test_smart_contract_bad_method_name_testnet --features nightly_protocol,nightly_protocol_features
 expensive integration-tests standard_cases rpc::test::test_smart_contract_empty_method_name_with_no_tokens_testnet
-expensive integration-tests standard_cases rpc::test::test_smart_contract_empty_method_name_with_no_tokens_testnet --features nightly_protocol,nightly_protocol_features
 expensive integration-tests standard_cases rpc::test::test_smart_contract_empty_method_name_with_tokens_testnet
-expensive integration-tests standard_cases rpc::test::test_smart_contract_empty_method_name_with_tokens_testnet --features nightly_protocol,nightly_protocol_features
 expensive integration-tests standard_cases rpc::test::test_smart_contract_self_call_testnet
-expensive integration-tests standard_cases rpc::test::test_smart_contract_self_call_testnet --features nightly_protocol,nightly_protocol_features
 expensive integration-tests standard_cases rpc::test::test_smart_contract_simple_testnet
-expensive integration-tests standard_cases rpc::test::test_smart_contract_simple_testnet --features nightly_protocol,nightly_protocol_features
 expensive integration-tests standard_cases rpc::test::test_smart_contract_with_args_testnet
-expensive integration-tests standard_cases rpc::test::test_smart_contract_with_args_testnet --features nightly_protocol,nightly_protocol_features
 expensive integration-tests standard_cases rpc::test::test_swap_key_testnet
-expensive integration-tests standard_cases rpc::test::test_swap_key_testnet --features nightly_protocol,nightly_protocol_features
 expensive integration-tests standard_cases rpc::test::test_upload_contract_testnet
-expensive integration-tests standard_cases rpc::test::test_upload_contract_testnet --features nightly_protocol,nightly_protocol_features
 
 # GC tests
 expensive --timeout=900 near-chain gc tests::test_gc_remove_fork_large
-expensive --timeout=900 near-chain gc tests::test_gc_remove_fork_large --features nightly_protocol,nightly_protocol_features
 expensive --timeout=1200 near-chain gc tests::test_gc_not_remove_fork_large
-expensive --timeout=1200 near-chain gc tests::test_gc_not_remove_fork_large --features nightly_protocol,nightly_protocol_features
 expensive --timeout=1200 near-chain gc tests::test_gc_boundaries_large
-expensive --timeout=1200 near-chain gc tests::test_gc_boundaries_large --features nightly_protocol,nightly_protocol_features
 expensive --timeout=900 near-chain gc tests::test_gc_random_large
-expensive --timeout=900 near-chain gc tests::test_gc_random_large --features nightly_protocol,nightly_protocol_features
 expensive --timeout=600 near-chain gc tests::test_gc_pine
-expensive --timeout=600 near-chain gc tests::test_gc_pine --features nightly_protocol,nightly_protocol_features
 expensive --timeout=700 near-chain gc tests::test_gc_star_large
-expensive --timeout=700 near-chain gc tests::test_gc_star_large --features nightly_protocol,nightly_protocol_features
 expensive integration-tests client process_blocks::test_gc_after_state_sync
-expensive integration-tests client process_blocks::test_gc_after_state_sync --features nightly_protocol,nightly_protocol_features
 
 # lib tests
 lib near-chunks test::test_seal_removal
@@ -134,15 +76,9 @@ lib --timeout=300 near-chain store::tests::test_clear_old_data_too_many_heights
 
 # other tests
 expensive integration-tests test_simple test::test_2_10_multiple_nodes
-expensive integration-tests test_simple test::test_2_10_multiple_nodes --features nightly_protocol,nightly_protocol_features
 expensive integration-tests test_simple test::test_4_10_multiple_nodes
-expensive integration-tests test_simple test::test_4_10_multiple_nodes --features nightly_protocol,nightly_protocol_features
 expensive integration-tests test_simple test::test_7_10_multiple_nodes
-expensive integration-tests test_simple test::test_7_10_multiple_nodes --features nightly_protocol,nightly_protocol_features
 
 expensive integration-tests test_rejoin test::test_4_20_kill1
-expensive integration-tests test_rejoin test::test_4_20_kill1 --features nightly_protocol,nightly_protocol_features
 expensive integration-tests test_rejoin test::test_4_20_kill1_two_shards
-expensive integration-tests test_rejoin test::test_4_20_kill1_two_shards --features nightly_protocol,nightly_protocol_features
 expensive integration-tests test_rejoin test::test_4_20_kill2
-expensive integration-tests test_rejoin test::test_4_20_kill2 --features nightly_protocol,nightly_protocol_features

--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -1,6 +1,12 @@
-./TODO-disabled-4552.txt
+# TODO(#4552): Those tests were identified as missing from any of the test list
+# files.  It’s not clear why so some investigation is necessary.  The tests need
+# to either be enabled or removed completely if they are no longer needed/valid.
+#./TODO-disabled-4552.txt
+
 ./sandbox.txt
 ./pytest.txt
+./pytest.txt --features nightly_protocol,nightly_protocol_features
 ./expensive.txt
+./expensive.txt --features nightly_protocol,nightly_protocol_features
 ./mocknet.txt
 ./bridge.txt

--- a/nightly/pytest-adversarial.txt
+++ b/nightly/pytest-adversarial.txt
@@ -1,17 +1,9 @@
 # python adversarial tests
 pytest --timeout=600 adversarial/fork_sync.py
-pytest --timeout=600 adversarial/fork_sync.py --features nightly_protocol,nightly_protocol_features
 pytest adversarial/wrong_sync_info.py
-pytest adversarial/wrong_sync_info.py --features nightly_protocol,nightly_protocol_features
 pytest adversarial/malicious_chain.py
-pytest adversarial/malicious_chain.py --features nightly_protocol,nightly_protocol_features
 pytest adversarial/malicious_chain.py valid_blocks_only
-pytest adversarial/malicious_chain.py valid_blocks_only --features nightly_protocol,nightly_protocol_features
 pytest adversarial/start_from_genesis.py
-pytest adversarial/start_from_genesis.py --features nightly_protocol,nightly_protocol_features
 pytest adversarial/start_from_genesis.py overtake
-pytest adversarial/start_from_genesis.py overtake --features nightly_protocol,nightly_protocol_features
 pytest adversarial/start_from_genesis.py doomslug_off
-pytest adversarial/start_from_genesis.py doomslug_off --features nightly_protocol,nightly_protocol_features
 pytest adversarial/start_from_genesis.py overtake doomslug_off
-pytest adversarial/start_from_genesis.py overtake doomslug_off --features nightly_protocol,nightly_protocol_features

--- a/nightly/pytest-contracts.txt
+++ b/nightly/pytest-contracts.txt
@@ -1,7 +1,4 @@
 # python tests for smart contract deployment and invocation
 pytest contracts/deploy_call_smart_contract.py
-pytest contracts/deploy_call_smart_contract.py --features nightly_protocol,nightly_protocol_features
 pytest --timeout=240 contracts/gibberish.py
-pytest --timeout=240 contracts/gibberish.py --features nightly_protocol,nightly_protocol_features
 pytest --timeout=400 contracts/infinite_loops.py
-pytest --timeout=400 contracts/infinite_loops.py --features nightly_protocol,nightly_protocol_features

--- a/nightly/pytest-sanity.txt
+++ b/nightly/pytest-sanity.txt
@@ -1,107 +1,55 @@
 # python sanity tests
 pytest sanity/block_production.py
-pytest sanity/block_production.py --features nightly_protocol,nightly_protocol_features
 pytest sanity/transactions.py
-pytest sanity/transactions.py --features nightly_protocol,nightly_protocol_features
 pytest sanity/staking1.py
-pytest sanity/staking1.py --features nightly_protocol,nightly_protocol_features
 pytest --timeout=800 sanity/staking2.py
-pytest --timeout=800 sanity/staking2.py --features nightly_protocol,nightly_protocol_features
 pytest --timeout=800 sanity/staking_repro1.py
-pytest --timeout=800 sanity/staking_repro1.py --features nightly_protocol,nightly_protocol_features
 pytest --timeout=800 sanity/staking_repro2.py
-pytest --timeout=800 sanity/staking_repro2.py --features nightly_protocol,nightly_protocol_features
 pytest sanity/epoch_switches.py
-pytest sanity/epoch_switches.py --features nightly_protocol,nightly_protocol_features
 pytest sanity/state_sync.py manytx 30
-pytest sanity/state_sync.py manytx 30 --features nightly_protocol,nightly_protocol_features
 pytest --timeout=600 sanity/state_sync.py manytx 265
-pytest --timeout=600 sanity/state_sync.py manytx 265 --features nightly_protocol,nightly_protocol_features
 pytest sanity/state_sync.py onetx 30
-pytest sanity/state_sync.py onetx 30 --features nightly_protocol,nightly_protocol_features
 pytest --timeout=600 sanity/state_sync.py onetx 265
-pytest --timeout=600 sanity/state_sync.py onetx 265 --features nightly_protocol,nightly_protocol_features
 pytest --timeout=240 sanity/state_sync1.py
-pytest --timeout=240 sanity/state_sync1.py --features nightly_protocol,nightly_protocol_features
 pytest --timeout=900 sanity/state_sync2.py
-pytest --timeout=900 sanity/state_sync2.py --features nightly_protocol,nightly_protocol_features
 pytest --timeout=1200 sanity/state_sync3.py
-pytest --timeout=1200 sanity/state_sync3.py --features nightly_protocol,nightly_protocol_features
 pytest --timeout=240 sanity/state_sync4.py
-pytest --timeout=240 sanity/state_sync4.py --features nightly_protocol,nightly_protocol_features
 pytest --timeout=240 sanity/state_sync5.py
-pytest --timeout=240 sanity/state_sync5.py --features nightly_protocol,nightly_protocol_features
 pytest --timeout=600 sanity/state_sync_routed.py manytx 115
-pytest --timeout=600 sanity/state_sync_routed.py manytx 115 --features nightly_protocol,nightly_protocol_features
 pytest --timeout=300 sanity/state_sync_late.py notx
-pytest --timeout=300 sanity/state_sync_late.py notx --features nightly_protocol,nightly_protocol_features
 pytest --timeout=900 sanity/state_sync_massive.py
-pytest --timeout=900 sanity/state_sync_massive.py --features nightly_protocol,nightly_protocol_features
 pytest sanity/sync_chunks_from_archival.py
-pytest sanity/sync_chunks_from_archival.py --features nightly_protocol,nightly_protocol_features
 pytest sanity/rpc_tx_forwarding.py
-pytest sanity/rpc_tx_forwarding.py --features nightly_protocol,nightly_protocol_features
 pytest --timeout=240 sanity/skip_epoch.py
-pytest --timeout=240 sanity/skip_epoch.py --features nightly_protocol,nightly_protocol_features
 pytest --timeout=240 sanity/one_val.py
-pytest --timeout=240 sanity/one_val.py --features nightly_protocol,nightly_protocol_features
 pytest --timeout=240 sanity/lightclnt.py
-pytest --timeout=240 sanity/lightclnt.py --features nightly_protocol,nightly_protocol_features
 pytest sanity/rpc_light_client_execution_outcome_proof.py
-pytest sanity/rpc_light_client_execution_outcome_proof.py --features nightly_protocol,nightly_protocol_features
 pytest --timeout=240 sanity/block_sync.py
-pytest --timeout=240 sanity/block_sync.py --features nightly_protocol,nightly_protocol_features
 pytest --timeout=360 sanity/block_sync_archival.py
-pytest --timeout=360 sanity/block_sync_archival.py --features nightly_protocol,nightly_protocol_features
 pytest --timeout=240 sanity/validator_switch.py
-pytest --timeout=240 sanity/validator_switch.py --features nightly_protocol,nightly_protocol_features
 pytest --timeout=240 sanity/restaked.py
-pytest --timeout=240 sanity/restaked.py --features nightly_protocol,nightly_protocol_features
 pytest --timeout=240 sanity/rpc_state_changes.py
-pytest --timeout=240 sanity/rpc_state_changes.py --features nightly_protocol,nightly_protocol_features
 pytest sanity/rpc_max_gas_burnt.py
-pytest sanity/rpc_max_gas_burnt.py --features nightly_protocol,nightly_protocol_features
 pytest sanity/rpc_tx_status.py
-pytest sanity/rpc_tx_status.py --features nightly_protocol,nightly_protocol_features
 pytest --timeout=120 sanity/garbage_collection.py
-pytest --timeout=120 sanity/garbage_collection.py --features nightly_protocol,nightly_protocol_features
 pytest --timeout=120 sanity/garbage_collection1.py
-pytest --timeout=120 sanity/garbage_collection1.py --features nightly_protocol,nightly_protocol_features
 pytest --timeout=300 sanity/gc_after_sync.py
-pytest --timeout=300 sanity/gc_after_sync.py --features nightly_protocol,nightly_protocol_features
 pytest --timeout=300 sanity/gc_after_sync1.py
-pytest --timeout=300 sanity/gc_after_sync1.py --features nightly_protocol,nightly_protocol_features
 pytest --timeout=300 sanity/gc_sync_after_sync.py
-pytest --timeout=300 sanity/gc_sync_after_sync.py --features nightly_protocol,nightly_protocol_features
 pytest --timeout=300 sanity/gc_sync_after_sync.py swap_nodes
-pytest --timeout=300 sanity/gc_sync_after_sync.py swap_nodes --features nightly_protocol,nightly_protocol_features
 pytest --timeout=300 sanity/large_messages.py
-pytest --timeout=300 sanity/large_messages.py --features nightly_protocol,nightly_protocol_features
 pytest --timeout=120 sanity/handshake_tie_resolution.py
-pytest --timeout=120 sanity/handshake_tie_resolution.py --features nightly_protocol,nightly_protocol_features
 pytest sanity/repro_2916.py
-pytest sanity/repro_2916.py --features nightly_protocol,nightly_protocol_features
 pytest --timeout=240 sanity/switch_node_key.py
-pytest --timeout=240 sanity/switch_node_key.py --features nightly_protocol,nightly_protocol_features
 # TODO: re-enable after #2949 is fixed
 # pytest --timeout=240 sanity/validator_switch_key.py
-# pytest --timeout=240 sanity/validator_switch_key.py --features nightly_protocol,nightly_protocol_features
 pytest sanity/proxy_simple.py
-pytest sanity/proxy_simple.py --features nightly_protocol,nightly_protocol_features
 pytest sanity/proxy_restart.py
-pytest sanity/proxy_restart.py --features nightly_protocol,nightly_protocol_features
 pytest sanity/network_drop_package.py
-pytest sanity/network_drop_package.py --features nightly_protocol,nightly_protocol_features
 # TODO: enable them when we fix the issue with proxy shutdown (#2942)
 # pytest --timeout=900 sanity/sync_ban.py true
-# pytest --timeout=900 sanity/sync_ban.py true --features nightly_protocol,nightly_protocol_features
 # pytest --timeout=900 sanity/sync_ban.py false
-# pytest --timeout=900 sanity/sync_ban.py false --features nightly_protocol,nightly_protocol_features
 pytest sanity/block_chunk_signature.py
-pytest sanity/block_chunk_signature.py --features nightly_protocol,nightly_protocol_features
 pytest sanity/concurrent_function_calls.py
-pytest sanity/concurrent_function_calls.py --features nightly_protocol,nightly_protocol_features
 pytest sanity/proxy_example.py
-pytest sanity/proxy_example.py --features nightly_protocol,nightly_protocol_features
 pytest sanity/rpc_tx_submission.py
-pytest sanity/rpc_tx_submission.py --features nightly_protocol,nightly_protocol_features

--- a/nightly/pytest-spec.txt
+++ b/nightly/pytest-spec.txt
@@ -1,7 +1,4 @@
 # python spec tests
 pytest spec/network/handshake.py
-pytest spec/network/handshake.py --features nightly_protocol,nightly_protocol_features
 pytest spec/network/future_handshake.py
-pytest spec/network/future_handshake.py --features nightly_protocol,nightly_protocol_features
 pytest spec/network/peers_request.py
-pytest spec/network/peers_request.py --features nightly_protocol,nightly_protocol_features

--- a/nightly/pytest-stress.txt
+++ b/nightly/pytest-stress.txt
@@ -1,23 +1,14 @@
 # python stress tests
 pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions
-pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions --features nightly_protocol,nightly_protocol_features
 pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions local_network
-pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions local_network --features nightly_protocol,nightly_protocol_features
 pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions local_network packets_drop
-pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions local_network packets_drop --features nightly_protocol,nightly_protocol_features
 pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions node_restart
-pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions node_restart --features nightly_protocol,nightly_protocol_features
 pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions node_restart packets_drop
-pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions node_restart packets_drop --features nightly_protocol,nightly_protocol_features
 pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions node_restart wipe_data
-pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions node_restart wipe_data --features nightly_protocol,nightly_protocol_features
 pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions node_restart packets_drop wipe_data
-pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions node_restart packets_drop wipe_data --features nightly_protocol,nightly_protocol_features
 # pytest --timeout=2000 stress/stress.py 3 2 4 0 staking transactions node_set
-# pytest --timeout=2000 stress/stress.py 3 2 4 0 staking transactions node_set --features nightly_protocol,nightly_protocol_features
 
 pytest --timeout=300 stress/saturate_routing_table.py
-pytest --timeout=300 stress/saturate_routing_table.py --features nightly_protocol,nightly_protocol_features
 
+# TODO(#4552): Enable this at some point.
 # pytest stress/network_stress.py
-# pytest stress/network_stress.py --features nightly_protocol,nightly_protocol_features

--- a/nightly/pytest.txt
+++ b/nightly/pytest.txt
@@ -7,4 +7,3 @@
 # python upgradable test
 # upgradable.py moves `near` binary, and must be the last python test in the set
 pytest --timeout=600 sanity/upgradable.py
-pytest --timeout=600 sanity/upgradable.py --features nightly_protocol,nightly_protocol_features


### PR DESCRIPTION
Extend the `./<path>` directive so that it accepts arbitrary suffix
after the path.  If that suffix is present, all lines read from the
file are augmented by adding the prefix.  This makes it possible to do
things like:

    ./pytest.txt
    ./pytest.txt --features nightly_protocol,nightly_protocol_features

and avoid having to list every test twice in `pytest.txt` file.

Furthermore, when check_pytest.py and check_nightly.py read the files
also handle `#./<path>` so that a whole include can be commented out
with a TODO and the check scripts will treat files listed in those
files as being mentioned.

Issue: https://github.com/near/nearcore/issues/4552