### PR TITLE
nayduck: fix `lib` tests

### DIFF
--- a/nightly/expensive.txt
+++ b/nightly/expensive.txt
@@ -128,11 +128,10 @@ expensive --timeout=700 near-chain gc tests::test_gc_star_large --features night
 expensive integration-tests client process_blocks::test_gc_after_state_sync
 expensive integration-tests client process_blocks::test_gc_after_state_sync --features nightly_protocol,nightly_protocol_features
 
-# lib tests
-lib near-chunks test::test_seal_removal
-lib --timeout=300 near-chain store::tests::test_clear_old_data_too_many_heights
-
 # other tests
+expensive near-chunks near-chunks test::test_seal_removal
+expensive --timeout=300 near-chain near-chain store::tests::test_clear_old_data_too_many_heights
+
 expensive integration-tests test_simple test::test_2_10_multiple_nodes
 expensive integration-tests test_simple test::test_2_10_multiple_nodes --features nightly_protocol,nightly_protocol_features
 expensive integration-tests test_simple test::test_4_10_multiple_nodes


### PR DESCRIPTION
The `lib` tests are a bit of a lie.  They are really `expensive` tests
where package and binary name is the same.  `expensive` tests are
specified using

    expensive <package> <binary> <test>

syntax while `lib` test use:

    lib <package> <test>

syntax with the additional assumption that `<binary>` is the same as
`<package>`.  This means that in both cases expensive tests need to be
built and there’s no real difference between the two test categories.

At the moment NayDuck has a bug where it doesn’t treat the two test
categories the same way.  In particular, expensive tests are not built
when handling `lib` tests.  This results in failures†.

Because there’s no fundamental difference between `expensive` and
`lib` tests, rather than fixing handling of `lib` tests, convert them
to `expensive` instead. Later, support for `lib` tests will be removed
from NayDuck altogether.  This will make things cleaner as there will
be fewer cases to handle.

† Though usually things conspire such that the tests pass.  This
  happens if there are some expensive builds in the same run and the
  worker happened to grab the binary needed to execute the lib tests.
  This of course is not robust.

Issue: https://github.com/near/nayduck/issues/19