### PR TITLE
Change ShardTracker interface

### DIFF
--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -1074,7 +1074,11 @@ impl Handler<NetworkViewClientMessages> for ViewClientActor {
                             hash: *self.chain.genesis().hash(),
                         },
                         height,
-                        tracked_shards: self.config.tracked_shards.clone(),
+                        tracked_shards: if self.config.track_all_shards {
+                            (0..self.runtime_adapter.num_shards() - 1).collect()
+                        } else {
+                            vec![]
+                        },
                         archival: self.config.archive,
                     }
                 }

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
-use near_primitives::types::{AccountId, BlockHeightDelta, Gas, NumBlocks, NumSeats, ShardId};
+use near_primitives::types::{AccountId, BlockHeightDelta, Gas, NumBlocks, NumSeats};
 use near_primitives::version::Version;
 
 pub const TEST_STATE_SYNC_TIMEOUT: u64 = 5;
@@ -85,8 +85,8 @@ pub struct ClientConfig {
     pub gc_blocks_limit: NumBlocks,
     /// Accounts that this client tracks
     pub tracked_accounts: Vec<AccountId>,
-    /// Shards that this client tracks
-    pub tracked_shards: Vec<ShardId>,
+    /// Whether to track all shards
+    pub track_all_shards: bool,
     /// Not clear old data, set `true` for archive nodes.
     pub archive: bool,
     /// Number of threads for ViewClientActor pool.
@@ -151,7 +151,7 @@ impl ClientConfig {
             block_header_fetch_horizon: 50,
             gc_blocks_limit: 100,
             tracked_accounts: vec![],
-            tracked_shards: vec![],
+            track_all_shards: false,
             archive,
             log_summary_style: LogSummaryStyle::Colored,
             view_client_threads: 1,

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -59,17 +59,7 @@ impl GenesisBuilder {
         store: Arc<Store>,
     ) -> Self {
         let tmpdir = tempfile::Builder::new().prefix("storage").tempdir().unwrap();
-        let runtime = NightshadeRuntime::new(
-            tmpdir.path(),
-            store.clone(),
-            &genesis,
-            // Since we are not using runtime as an actor
-            // there is no reason to track accounts or shards.
-            vec![],
-            vec![],
-            None,
-            None,
-        );
+        let runtime = NightshadeRuntime::default(tmpdir.path(), store.clone(), &genesis);
         Self {
             home_dir: home_dir.to_path_buf(),
             tmpdir,

--- a/integration-tests/tests/client/challenges.rs
+++ b/integration-tests/tests/client/challenges.rs
@@ -271,15 +271,8 @@ fn test_verify_chunk_invalid_state_challenge() {
     let store1 = create_test_store();
     let genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     let transaction_validity_period = genesis.config.transaction_validity_period;
-    let runtimes: Vec<Arc<dyn RuntimeAdapter>> = vec![Arc::new(nearcore::NightshadeRuntime::new(
-        Path::new("."),
-        store1,
-        &genesis,
-        vec![],
-        vec![],
-        None,
-        None,
-    ))];
+    let runtimes: Vec<Arc<dyn RuntimeAdapter>> =
+        vec![Arc::new(nearcore::NightshadeRuntime::default(Path::new("."), store1, &genesis))];
     let mut env = TestEnv::new_with_runtime(ChainGenesis::test(), 1, 1, runtimes);
     let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
     let validator_signer =
@@ -569,14 +562,10 @@ fn test_fishermen_challenge() {
     );
     genesis.config.epoch_length = 5;
     let create_runtime = || -> Arc<NightshadeRuntime> {
-        Arc::new(nearcore::NightshadeRuntime::new(
+        Arc::new(nearcore::NightshadeRuntime::default(
             Path::new("."),
             create_test_store(),
             &genesis.clone(),
-            vec![],
-            vec![],
-            None,
-            None,
         ))
     };
     let runtime1 = create_runtime();
@@ -632,23 +621,15 @@ fn test_challenge_in_different_epoch() {
     genesis.config.epoch_length = 2;
     //    genesis.config.validator_kickout_threshold = 10;
     let network_adapter = Arc::new(MockNetworkAdapter::default());
-    let runtime1 = Arc::new(nearcore::NightshadeRuntime::new(
+    let runtime1 = Arc::new(nearcore::NightshadeRuntime::default(
         Path::new("."),
         create_test_store(),
         &genesis.clone(),
-        vec![],
-        vec![],
-        None,
-        None,
     ));
-    let runtime2 = Arc::new(nearcore::NightshadeRuntime::new(
+    let runtime2 = Arc::new(nearcore::NightshadeRuntime::default(
         Path::new("."),
         create_test_store(),
         &genesis.clone(),
-        vec![],
-        vec![],
-        None,
-        None,
     ));
     let runtimes: Vec<Arc<dyn RuntimeAdapter>> = vec![runtime1, runtime2];
     let networks = vec![network_adapter.clone(), network_adapter.clone()];

--- a/integration-tests/tests/client/process_blocks.rs
+++ b/integration-tests/tests/client/process_blocks.rs
@@ -84,14 +84,10 @@ fn set_block_protocol_version(
 pub fn create_nightshade_runtimes(genesis: &Genesis, n: usize) -> Vec<Arc<dyn RuntimeAdapter>> {
     (0..n)
         .map(|_| {
-            Arc::new(nearcore::NightshadeRuntime::new(
+            Arc::new(nearcore::NightshadeRuntime::default(
                 Path::new("."),
                 create_test_store(),
                 genesis,
-                vec![],
-                vec![],
-                None,
-                None,
             )) as Arc<dyn RuntimeAdapter>
         })
         .collect()
@@ -1878,14 +1874,10 @@ fn test_invalid_block_root() {
 fn test_incorrect_validator_key_produce_block() {
     let genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 2);
     let chain_genesis = ChainGenesis::from(&genesis);
-    let runtime_adapter: Arc<dyn RuntimeAdapter> = Arc::new(nearcore::NightshadeRuntime::new(
+    let runtime_adapter: Arc<dyn RuntimeAdapter> = Arc::new(nearcore::NightshadeRuntime::default(
         Path::new("."),
         create_test_store(),
         &genesis,
-        vec![],
-        vec![],
-        None,
-        None,
     ));
     let signer = Arc::new(InMemoryValidatorSigner::from_seed(
         "test0".parse().unwrap(),
@@ -3179,15 +3171,8 @@ mod protocol_feature_restore_receipts_after_fix_tests {
         genesis.config.epoch_length = EPOCH_LENGTH;
         genesis.config.protocol_version = protocol_version;
         let chain_genesis = ChainGenesis::from(&genesis);
-        let runtime = nearcore::NightshadeRuntime::new(
-            Path::new("."),
-            create_test_store(),
-            &genesis,
-            vec![],
-            vec![],
-            None,
-            None,
-        );
+        let runtime =
+            nearcore::NightshadeRuntime::default(Path::new("."), create_test_store(), &genesis);
         // TODO #4305: get directly from NightshadeRuntime
         let migration_data = load_migration_data(&genesis.config.chain_id);
 
@@ -3471,14 +3456,10 @@ mod contract_precompilation_tests {
         let runtimes: Vec<Arc<nearcore::NightshadeRuntime>> = stores
             .iter()
             .map(|store| {
-                Arc::new(nearcore::NightshadeRuntime::new(
+                Arc::new(nearcore::NightshadeRuntime::default(
                     Path::new("."),
                     store.clone(),
                     &genesis,
-                    vec![],
-                    vec![],
-                    None,
-                    None,
                 ))
             })
             .collect();
@@ -3568,14 +3549,10 @@ mod contract_precompilation_tests {
         let runtimes: Vec<Arc<nearcore::NightshadeRuntime>> = stores
             .iter()
             .map(|store| {
-                Arc::new(nearcore::NightshadeRuntime::new(
+                Arc::new(nearcore::NightshadeRuntime::default(
                     Path::new("."),
                     store.clone(),
                     &genesis,
-                    vec![],
-                    vec![],
-                    None,
-                    None,
                 ))
             })
             .collect();
@@ -3649,14 +3626,10 @@ mod contract_precompilation_tests {
         let runtimes: Vec<Arc<nearcore::NightshadeRuntime>> = stores
             .iter()
             .map(|store| {
-                Arc::new(nearcore::NightshadeRuntime::new(
+                Arc::new(nearcore::NightshadeRuntime::default(
                     Path::new("."),
                     store.clone(),
                     &genesis,
-                    vec![],
-                    vec![],
-                    None,
-                    None,
                 ))
             })
             .collect();

--- a/integration-tests/tests/client/runtimes.rs
+++ b/integration-tests/tests/client/runtimes.rs
@@ -32,14 +32,10 @@ use nearcore::config::GenesisExt;
 pub fn create_nightshade_runtimes(genesis: &Genesis, n: usize) -> Vec<Arc<dyn RuntimeAdapter>> {
     (0..n)
         .map(|_| {
-            Arc::new(nearcore::NightshadeRuntime::new(
+            Arc::new(nearcore::NightshadeRuntime::default(
                 Path::new("."),
                 create_test_store(),
                 &genesis,
-                vec![],
-                vec![],
-                None,
-                None,
             )) as Arc<dyn RuntimeAdapter>
         })
         .collect()

--- a/integration-tests/tests/client/sandbox.rs
+++ b/integration-tests/tests/client/sandbox.rs
@@ -23,14 +23,10 @@ fn test_setup() -> (TestEnv, InMemorySigner) {
         ChainGenesis::test(),
         1,
         1,
-        vec![Arc::new(nearcore::NightshadeRuntime::new(
+        vec![Arc::new(nearcore::NightshadeRuntime::default(
             Path::new("."),
             create_test_store(),
             &genesis,
-            vec![],
-            vec![],
-            None,
-            None,
         )) as Arc<dyn RuntimeAdapter>],
     );
     let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -28,7 +28,7 @@ use near_primitives::runtime::config::RuntimeConfig;
 use near_primitives::state_record::StateRecord;
 use near_primitives::types::{
     AccountId, AccountInfo, Balance, BlockHeightDelta, EpochHeight, Gas, NumBlocks, NumSeats,
-    NumShards, ShardId,
+    NumShards,
 };
 use near_primitives::utils::{generate_random_string, get_num_seats_per_shard};
 use near_primitives::validator_signer::{InMemoryValidatorSigner, ValidatorSigner};
@@ -418,7 +418,7 @@ pub struct Config {
     pub network: Network,
     pub consensus: Consensus,
     pub tracked_accounts: Vec<AccountId>,
-    pub tracked_shards: Vec<ShardId>,
+    pub track_all_shards: bool,
     pub archive: bool,
     pub log_summary_style: LogSummaryStyle,
     #[serde(default = "default_gc_blocks_limit")]
@@ -450,7 +450,7 @@ impl Default for Config {
             network: Network::default(),
             consensus: Consensus::default(),
             tracked_accounts: vec![],
-            tracked_shards: vec![],
+            track_all_shards: false,
             archive: false,
             log_summary_style: LogSummaryStyle::Colored,
             gc_blocks_limit: default_gc_blocks_limit(),
@@ -639,7 +639,7 @@ impl NearConfig {
                 chunk_request_retry_period: config.consensus.chunk_request_retry_period,
                 doosmslug_step_period: config.consensus.doomslug_step_period,
                 tracked_accounts: config.tracked_accounts,
-                tracked_shards: config.tracked_shards,
+                track_all_shards: config.track_all_shards,
                 archive: config.archive,
                 log_summary_style: config.log_summary_style,
                 gc_blocks_limit: config.gc_blocks_limit,

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -272,7 +272,7 @@ pub fn start_with_config(
         Arc::clone(&store),
         &config.genesis,
         config.client_config.tracked_accounts.clone(),
-        config.client_config.tracked_shards.clone(),
+        config.client_config.track_all_shards,
         config.client_config.trie_viewer_state_size_limit,
         config.client_config.max_gas_burnt_view,
     ));

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -114,7 +114,7 @@ pub fn migrate_12_to_13(path: &String, near_config: &NearConfig) {
             store.clone(),
             &near_config.genesis,
             near_config.client_config.tracked_accounts.clone(),
-            near_config.client_config.tracked_shards.clone(),
+            near_config.client_config.track_all_shards,
             None,
             None,
         );
@@ -224,7 +224,7 @@ pub fn migrate_19_to_20(path: &String, near_config: &NearConfig) {
             store.clone(),
             &near_config.genesis,
             near_config.client_config.tracked_accounts.clone(),
-            near_config.client_config.tracked_shards.clone(),
+            near_config.client_config.track_all_shards,
             None,
             None,
         );
@@ -291,7 +291,7 @@ pub fn migrate_22_to_23(path: &String, near_config: &NearConfig) {
             store.clone(),
             &near_config.genesis,
             near_config.client_config.tracked_accounts.clone(),
-            near_config.client_config.tracked_shards.clone(),
+            near_config.client_config.track_all_shards,
             None,
             None,
         );

--- a/nearcore/tests/economics.rs
+++ b/nearcore/tests/economics.rs
@@ -25,15 +25,8 @@ fn setup_env(f: &mut dyn FnMut(&mut Genesis) -> ()) -> (TestEnv, FeeHelper) {
         genesis.config.runtime_config.transaction_costs.clone(),
         genesis.config.min_gas_price,
     );
-    let runtimes: Vec<Arc<dyn RuntimeAdapter>> = vec![Arc::new(nearcore::NightshadeRuntime::new(
-        Path::new("."),
-        store1,
-        &genesis,
-        vec![],
-        vec![],
-        None,
-        None,
-    ))];
+    let runtimes: Vec<Arc<dyn RuntimeAdapter>> =
+        vec![Arc::new(nearcore::NightshadeRuntime::default(Path::new("."), store1, &genesis))];
     let env = TestEnv::new_with_runtime(ChainGenesis::from(&genesis), 1, 1, runtimes);
     (env, fee_helper)
 }

--- a/test-utils/runtime-tester/src/run_test.rs
+++ b/test-utils/runtime-tester/src/run_test.rs
@@ -30,15 +30,10 @@ impl Scenario {
             ChainGenesis::from(&genesis),
             1,
             1,
-            vec![Arc::new(NightshadeRuntime::new(
-                Path::new("."),
-                create_test_store(),
-                &genesis,
-                vec![],
-                vec![],
-                None,
-                None,
-            )) as Arc<dyn RuntimeAdapter>],
+            vec![
+                Arc::new(NightshadeRuntime::default(Path::new("."), create_test_store(), &genesis))
+                    as Arc<dyn RuntimeAdapter>,
+            ],
         );
 
         let mut last_block = env.clients[0].chain.get_block_by_height(0).unwrap().clone();

--- a/test-utils/state-viewer/src/main.rs
+++ b/test-utils/state-viewer/src/main.rs
@@ -62,7 +62,7 @@ fn load_trie_stop_at_height(
         store,
         &near_config.genesis,
         near_config.client_config.tracked_accounts.clone(),
-        near_config.client_config.tracked_shards.clone(),
+        near_config.client_config.track_all_shards,
         None,
         near_config.client_config.max_gas_burnt_view,
     );
@@ -120,7 +120,7 @@ fn print_chain(
         store,
         &near_config.genesis,
         near_config.client_config.tracked_accounts.clone(),
-        near_config.client_config.tracked_shards.clone(),
+        near_config.client_config.track_all_shards,
         None,
         near_config.client_config.max_gas_burnt_view,
     );
@@ -191,7 +191,7 @@ fn replay_chain(
         new_store,
         &near_config.genesis,
         near_config.client_config.tracked_accounts.clone(),
-        near_config.client_config.tracked_shards.clone(),
+        near_config.client_config.track_all_shards,
         None,
         near_config.client_config.max_gas_burnt_view,
     );
@@ -223,7 +223,7 @@ fn apply_block_at_height(
         store,
         &near_config.genesis,
         near_config.client_config.tracked_accounts.clone(),
-        near_config.client_config.tracked_shards.clone(),
+        near_config.client_config.track_all_shards,
         None,
         near_config.client_config.max_gas_burnt_view,
     ));

--- a/test-utils/state-viewer/src/state_dump.rs
+++ b/test-utils/state-viewer/src/state_dump.rs
@@ -96,15 +96,8 @@ mod test {
         genesis.config.num_block_producer_seats_per_shard = vec![2];
         genesis.config.epoch_length = epoch_length;
         let store = create_test_store();
-        let nightshade_runtime = NightshadeRuntime::new(
-            Path::new("."),
-            store.clone(),
-            &genesis,
-            vec![],
-            vec![],
-            None,
-            None,
-        );
+        let nightshade_runtime =
+            NightshadeRuntime::default(Path::new("."), store.clone(), &genesis);
         let runtimes: Vec<Arc<dyn RuntimeAdapter>> = vec![Arc::new(nightshade_runtime)];
         let mut chain_genesis = ChainGenesis::test();
         chain_genesis.epoch_length = epoch_length;
@@ -145,15 +138,7 @@ mod test {
         );
         let last_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap().clone();
         let state_roots = last_block.chunks().iter().map(|chunk| chunk.prev_state_root()).collect();
-        let runtime = NightshadeRuntime::new(
-            Path::new("."),
-            store.clone(),
-            &genesis,
-            vec![],
-            vec![],
-            None,
-            None,
-        );
+        let runtime = NightshadeRuntime::default(Path::new("."), store.clone(), &genesis);
         let new_genesis =
             state_dump(runtime, state_roots, last_block.header().clone(), &genesis.config);
         assert_eq!(new_genesis.config.validators.len(), 2);
@@ -182,15 +167,7 @@ mod test {
         let head = env.clients[0].chain.head().unwrap();
         let last_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap().clone();
         let state_roots = last_block.chunks().iter().map(|chunk| chunk.prev_state_root()).collect();
-        let runtime = NightshadeRuntime::new(
-            Path::new("."),
-            store.clone(),
-            &genesis,
-            vec![],
-            vec![],
-            None,
-            None,
-        );
+        let runtime = NightshadeRuntime::default(Path::new("."), store.clone(), &genesis);
         let new_genesis =
             state_dump(runtime, state_roots, last_block.header().clone(), &genesis.config);
         assert_eq!(
@@ -219,7 +196,7 @@ mod test {
         let store1 = create_test_store();
         let store2 = create_test_store();
         let create_runtime = |store| -> NightshadeRuntime {
-            NightshadeRuntime::new(Path::new("."), store, &genesis, vec![], vec![], None, None)
+            NightshadeRuntime::default(Path::new("."), store, &genesis)
         };
         let runtimes: Vec<Arc<dyn RuntimeAdapter>> = vec![
             Arc::new(create_runtime(store1.clone())),
@@ -268,15 +245,8 @@ mod test {
         genesis.config.num_block_producer_seats_per_shard = vec![2];
         genesis.config.epoch_length = epoch_length;
         let store = create_test_store();
-        let nightshade_runtime = NightshadeRuntime::new(
-            Path::new("."),
-            store.clone(),
-            &genesis,
-            vec![],
-            vec![],
-            None,
-            None,
-        );
+        let nightshade_runtime =
+            NightshadeRuntime::default(Path::new("."), store.clone(), &genesis);
         let runtimes: Vec<Arc<dyn RuntimeAdapter>> = vec![Arc::new(nightshade_runtime)];
         let mut chain_genesis = ChainGenesis::test();
         chain_genesis.epoch_length = epoch_length;
@@ -308,15 +278,7 @@ mod test {
         );
         let last_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap().clone();
         let state_roots = last_block.chunks().iter().map(|chunk| chunk.prev_state_root()).collect();
-        let runtime = NightshadeRuntime::new(
-            Path::new("."),
-            store.clone(),
-            &genesis,
-            vec![],
-            vec![],
-            None,
-            None,
-        );
+        let runtime = NightshadeRuntime::default(Path::new("."), store.clone(), &genesis);
         let new_genesis =
             state_dump(runtime, state_roots, last_block.header().clone(), &genesis.config);
         assert_eq!(new_genesis.config.validators.len(), 2);

--- a/test-utils/store-validator/src/main.rs
+++ b/test-utils/store-validator/src/main.rs
@@ -36,7 +36,7 @@ fn main() {
         store.clone(),
         &near_config.genesis,
         near_config.client_config.tracked_accounts.clone(),
-        near_config.client_config.tracked_shards.clone(),
+        near_config.client_config.track_all_shards,
         None,
         None,
     ));

--- a/test-utils/testlib/src/lib.rs
+++ b/test-utils/testlib/src/lib.rs
@@ -11,7 +11,7 @@ use near_logger_utils::init_integration_logger;
 use near_network::test_utils::{convert_boot_nodes, open_port};
 use near_primitives::block::{Block, BlockHeader};
 use near_primitives::hash::CryptoHash;
-use near_primitives::types::{BlockHeight, BlockHeightDelta, NumSeats, NumShards, ShardId};
+use near_primitives::types::{BlockHeight, BlockHeightDelta, NumSeats, NumShards};
 use near_store::test_utils::create_test_store;
 use nearcore::{config::GenesisExt, load_test_config, start_with_config, NightshadeRuntime};
 
@@ -31,8 +31,7 @@ pub fn genesis_header(genesis: &Genesis) -> BlockHeader {
     let dir = tempdir().unwrap();
     let store = create_test_store();
     let chain_genesis = ChainGenesis::from(genesis);
-    let runtime =
-        Arc::new(NightshadeRuntime::new(dir.path(), store, genesis, vec![], vec![], None, None));
+    let runtime = Arc::new(NightshadeRuntime::default(dir.path(), store, genesis));
     let chain = Chain::new(runtime, &chain_genesis, DoomslugThresholdMode::TwoThirds).unwrap();
     chain.genesis().clone()
 }
@@ -42,8 +41,7 @@ pub fn genesis_block(genesis: &Genesis) -> Block {
     let dir = tempdir().unwrap();
     let store = create_test_store();
     let chain_genesis = ChainGenesis::from(genesis);
-    let runtime =
-        Arc::new(NightshadeRuntime::new(dir.path(), store, genesis, vec![], vec![], None, None));
+    let runtime = Arc::new(NightshadeRuntime::default(dir.path(), store, genesis));
     let mut chain = Chain::new(runtime, &chain_genesis, DoomslugThresholdMode::TwoThirds).unwrap();
     chain.get_block(&chain.genesis().hash().clone()).unwrap().clone()
 }
@@ -85,15 +83,9 @@ pub fn start_nodes(
             near_config.network_config.boot_nodes =
                 convert_boot_nodes(vec![("near.0", first_node)]);
         }
-        // if non validator, add some shards to track.
+        // if non validator, track all shards to track.
         if i >= (num_validator_seats as usize) && i < num_tracking_nodes {
-            let shards_per_node =
-                num_shards as usize / (num_tracking_nodes - num_validator_seats as usize);
-            let (from, to) = (
-                ((i - num_validator_seats as usize) * shards_per_node) as ShardId,
-                ((i - (num_validator_seats as usize) + 1) * shards_per_node) as ShardId,
-            );
-            near_config.client_config.tracked_shards.extend(&(from..to).collect::<Vec<_>>());
+            near_config.client_config.track_all_shards = true;
         }
         near_config.client_config.epoch_sync_enabled = false;
         near_configs.push(near_config);

--- a/tools/restored-receipts-verifier/src/main.rs
+++ b/tools/restored-receipts-verifier/src/main.rs
@@ -64,7 +64,7 @@ fn main() -> Result<()> {
         store,
         &near_config.genesis,
         near_config.client_config.tracked_accounts.clone(),
-        near_config.client_config.tracked_shards.clone(),
+        near_config.client_config.track_all_shards,
         None,
         near_config.client_config.max_gas_burnt_view,
     );


### PR DESCRIPTION
Now a client can either track a set of accounts or track all shards. They no longer has the option of tracking an individual shard. The reason is that an outside client should not care about a particular shard at all. This also makes the interface more robust to sharding changes. 