### PR TITLE
nayduck: support reading commented ./<path> include directives

### DIFF
--- a/nightly/TODO-disabled-4552.txt
+++ b/nightly/TODO-disabled-4552.txt
@@ -1,14 +1,8 @@
-# TODO(#4552): Those tests were identified as missing from any of the test list
-# files.  It’s not entirely clear why so some investigation is necessary to
-# figure that out.  The tests need to either be enabled or removed completely if
-# they are no longer needed/valid.
-# pytest adversarial/gc_rollback.py
-# pytest adversarial/gc_rollback.py --features nightly_protocol,nightly_protocol_features
-# pytest sanity/restart.py
-# pytest sanity/restart.py --features nightly_protocol,nightly_protocol_features
-# pytest sanity/rpc_finality.py
-# pytest sanity/rpc_finality.py --features nightly_protocol,nightly_protocol_features
-# pytest sanity/state_migration.py
-# pytest sanity/state_migration.py --features nightly_protocol,nightly_protocol_features
-# pytest stress/network_stress.py
-# pytest stress/network_stress.py --features nightly_protocol,nightly_protocol_features
+pytest adversarial/gc_rollback.py
+pytest adversarial/gc_rollback.py --features nightly_protocol,nightly_protocol_features
+pytest sanity/restart.py
+pytest sanity/restart.py --features nightly_protocol,nightly_protocol_features
+pytest sanity/rpc_finality.py
+pytest sanity/rpc_finality.py --features nightly_protocol,nightly_protocol_features
+pytest sanity/state_migration.py
+pytest sanity/state_migration.py --features nightly_protocol,nightly_protocol_features

--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -1,4 +1,8 @@
-./TODO-disabled-4552.txt
+# TODO(#4552): Those tests were identified as missing from any of the test list
+# files.  It’s not clear why so some investigation is necessary.  The tests need
+# to either be enabled or removed completely if they are no longer needed/valid.
+#./TODO-disabled-4552.txt
+
 ./sandbox.txt
 ./pytest.txt
 ./expensive.txt

--- a/nightly/pytest-stress.txt
+++ b/nightly/pytest-stress.txt
@@ -19,5 +19,6 @@ pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions node_restart
 pytest --timeout=300 stress/saturate_routing_table.py
 pytest --timeout=300 stress/saturate_routing_table.py --features nightly_protocol,nightly_protocol_features
 
+# TODO(#4552): Enable this at some point.
 # pytest stress/network_stress.py
 # pytest stress/network_stress.py --features nightly_protocol,nightly_protocol_features


### PR DESCRIPTION
When check_pytest.py and check_nightly.py read the test list files
handle commented out include directives (i.e. `#./<path>` lines) so
that the include can be commented out with a TODO and the check
scripts will treat files listed in those files as being mentioned.

Issue: https://github.com/near/nearcore/issues/4362
Issue: https://github.com/near/nearcore/issues/4552