### PR TITLE
refactor: keep bench and release profile in sync to avoid surprises

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,8 +57,6 @@ wasmer-compiler-singlepass = { git = "https://github.com/near/wasmer", branch = 
 overflow-checks = true
 
 [profile.bench]
-lto = true
-codegen-units = 1 # Use only 1 codegen-unit to enable full optimizations.
 overflow-checks = true
 
 [profile.dev.package.hex]


### PR DESCRIPTION
Cargo's smaller profiles, like `test` and `bench`, work in a rather
curious fashion. When you run `cargo test`, `cargo test --release` or
`cargo bench`, the tset/bench profiles apply only to a subset of code
being compiled. Most things are compiled with dev/release profile
instead.

To avoid surprises where things compile differently, it's advisable to
keep bench in sync with release.

cc https://github.com/near/nearcore/pull/4507