### PR TITLE
nightly: move disabled tests to their corresponding files

### DIFF
--- a/nightly/TODO-disabled-4552.txt
+++ b/nightly/TODO-disabled-4552.txt
@@ -1,8 +1,0 @@
-pytest adversarial/gc_rollback.py
-pytest adversarial/gc_rollback.py --features nightly_protocol,nightly_protocol_features
-pytest sanity/restart.py
-pytest sanity/restart.py --features nightly_protocol,nightly_protocol_features
-pytest sanity/rpc_finality.py
-pytest sanity/rpc_finality.py --features nightly_protocol,nightly_protocol_features
-pytest sanity/state_migration.py
-pytest sanity/state_migration.py --features nightly_protocol,nightly_protocol_features

--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -1,8 +1,3 @@
-# TODO(#4552): Those tests were identified as missing from any of the test list
-# files.  It’s not clear why so some investigation is necessary.  The tests need
-# to either be enabled or removed completely if they are no longer needed/valid.
-#./TODO-disabled-4552.txt
-
 ./sandbox.txt
 ./pytest.txt
 ./expensive.txt

--- a/nightly/pytest-adversarial.txt
+++ b/nightly/pytest-adversarial.txt
@@ -1,4 +1,3 @@
-# python adversarial tests
 pytest --timeout=600 adversarial/fork_sync.py
 pytest --timeout=600 adversarial/fork_sync.py --features nightly_protocol,nightly_protocol_features
 pytest adversarial/wrong_sync_info.py
@@ -15,3 +14,8 @@ pytest adversarial/start_from_genesis.py doomslug_off
 pytest adversarial/start_from_genesis.py doomslug_off --features nightly_protocol,nightly_protocol_features
 pytest adversarial/start_from_genesis.py overtake doomslug_off
 pytest adversarial/start_from_genesis.py overtake doomslug_off --features nightly_protocol,nightly_protocol_features
+
+# TODO(#4618): Those tests are currently broken.  Comment out while we’re
+# working on a fix.
+#pytest adversarial/gc_rollback.py
+#pytest adversarial/gc_rollback.py --features nightly_protocol,nightly_protocol_features

--- a/nightly/pytest-sanity.txt
+++ b/nightly/pytest-sanity.txt
@@ -109,3 +109,12 @@ pytest sanity/proxy_example.py
 pytest sanity/proxy_example.py --features nightly_protocol,nightly_protocol_features
 pytest sanity/rpc_tx_submission.py
 pytest sanity/rpc_tx_submission.py --features nightly_protocol,nightly_protocol_features
+
+# TODO(#4618): Those tests are currently broken.  Comment out while we’re
+# working on a fix / deciding whether to remove them.
+#pytest sanity/restart.py
+#pytest sanity/restart.py --features nightly_protocol,nightly_protocol_features
+#pytest sanity/rpc_finality.py
+#pytest sanity/rpc_finality.py --features nightly_protocol,nightly_protocol_features
+#pytest sanity/state_migration.py
+#pytest sanity/state_migration.py --features nightly_protocol,nightly_protocol_features

--- a/nightly/pytest-stress.txt
+++ b/nightly/pytest-stress.txt
@@ -19,6 +19,7 @@ pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions node_restart
 pytest --timeout=300 stress/saturate_routing_table.py
 pytest --timeout=300 stress/saturate_routing_table.py --features nightly_protocol,nightly_protocol_features
 
-# TODO(#4552): Enable this at some point.
+# TODO(#4618): Those tests are currently broken.  Comment out while we’re
+# working on a fix / deciding whether to remove them.
 # pytest stress/network_stress.py
 # pytest stress/network_stress.py --features nightly_protocol,nightly_protocol_features


### PR DESCRIPTION
Delete `TODO-disabled-4552.txt` file and move the four tests listed there
to files they belong to.  With that also retire issue #4552 since now all
the tests are tracked in #4618.

Fixes: https://github.com/near/nearcore/issues/4552
Issue: https://github.com/near/nearcore/issues/4618