### PR TITLE
fix(account-id): subaccounts are valid one level deep only

### DIFF
--- a/core/account-id/src/lib.rs
+++ b/core/account-id/src/lib.rs
@@ -94,7 +94,8 @@ impl AccountId {
         // e.g. when `near` creates `aa.near`, it splits into `aa.` and `near`
         let (prefix, suffix) = self.0.split_at(self.len() - parent_account_id.len());
 
-        prefix.ends_with('.') && &suffix[..suffix.len()] == parent_account_id.as_ref()
+        prefix.find('.') == Some(prefix.len() - 1)
+            && &suffix[..suffix.len()] == parent_account_id.as_ref()
     }
 
     /// Returns true if the account ID length is 64 characters and it's a hex representation.
@@ -357,6 +358,7 @@ mod tests {
         let bad_pairs = &[
             ("test", ".test"),
             ("test", "test"),
+            ("test", "a1.a.test"),
             ("test", "est"),
             ("test", ""),
             ("test", "st"),


### PR DESCRIPTION
Fixes `AccountId::is_sub_account_of()`, subaccount checks are valid one level deep only.

The previous behaviour accepts `a.b.c.test` as a valid subaccount of `c.test`. This fix marks that as invalid and exclusively matches `a.b.c.test` only as a valid subaccount of `b.c.test`.