### PR TITLE
make `account_id_to_shard_id` and `num_shards` to take shard layout from the current epoch

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -219,7 +219,7 @@ impl Chain {
         let store = ChainStore::new(store, chain_genesis.height);
         let genesis_chunks = genesis_chunks(
             state_roots.clone(),
-            runtime_adapter.num_shards(),
+            runtime_adapter.num_shards(&EpochId::default()),
             chain_genesis.gas_limit,
             chain_genesis.height,
             chain_genesis.protocol_version,
@@ -257,7 +257,7 @@ impl Chain {
         let mut store = ChainStore::new(store, chain_genesis.height);
         let genesis_chunks = genesis_chunks(
             state_roots.clone(),
-            runtime_adapter.num_shards(),
+            runtime_adapter.num_shards(&EpochId::default()),
             chain_genesis.gas_limit,
             chain_genesis.height,
             chain_genesis.protocol_version,
@@ -1180,7 +1180,8 @@ impl Chain {
         me: &Option<AccountId>,
         parent_hash: &CryptoHash,
     ) -> Vec<ShardId> {
-        (0..self.runtime_adapter.num_shards())
+        let epoch_id = self.runtime_adapter().get_epoch_id_from_prev_block(parent_hash).unwrap();
+        (0..self.runtime_adapter.num_shards(&epoch_id))
             .filter(|shard_id| {
                 self.runtime_adapter.will_care_about_shard(
                     me.as_ref(),
@@ -2605,7 +2606,8 @@ impl<'a> ChainUpdate<'a> {
         me: &Option<AccountId>,
         parent_hash: CryptoHash,
     ) -> Result<bool, Error> {
-        for shard_id in 0..self.runtime_adapter.num_shards() {
+        let epoch_id = self.runtime_adapter.get_epoch_id_from_prev_block(&parent_hash)?;
+        for shard_id in 0..self.runtime_adapter.num_shards(&epoch_id) {
             if self.runtime_adapter.cares_about_shard(me.as_ref(), &parent_hash, shard_id, true)
                 || self.runtime_adapter.will_care_about_shard(
                     me.as_ref(),
@@ -3118,7 +3120,15 @@ impl<'a> ChainUpdate<'a> {
     {
         debug!(target: "chain", "Process block {} at {}, approvals: {}, me: {:?}", block.hash(), block.header().height(), block.header().num_approvals(), me);
 
-        if block.chunks().len() != self.runtime_adapter.num_shards() as usize {
+        // Check that we know the epoch of the block before we try to get the header
+        // (so that a block from unknown epoch doesn't get marked as an orphan)
+        if !self.runtime_adapter.epoch_exists(&block.header().epoch_id()) {
+            return Err(ErrorKind::EpochOutOfBounds(block.header().epoch_id().clone()).into());
+        }
+
+        if block.chunks().len()
+            != self.runtime_adapter.num_shards(&block.header().epoch_id()) as usize
+        {
             return Err(ErrorKind::IncorrectNumberOfChunkHeaders.into());
         }
 
@@ -3128,12 +3138,6 @@ impl<'a> ChainUpdate<'a> {
         // Delay hitting the db for current chain head until we know this block is not already known.
         let head = self.chain_store_update.head()?;
         let is_next = block.header().prev_hash() == &head.last_block_hash;
-
-        // Check that we know the epoch of the block before we try to get the header
-        // (so that a block from unknown epoch doesn't get marked as an orphan)
-        if !self.runtime_adapter.epoch_exists(&block.header().epoch_id()) {
-            return Err(ErrorKind::EpochOutOfBounds(block.header().epoch_id().clone()).into());
-        }
 
         // A heuristic to prevent block height to jump too fast towards BlockHeight::max and cause
         // overflow-related problems
@@ -3465,7 +3469,7 @@ impl<'a> ChainUpdate<'a> {
             }
         }
 
-        if header.chunk_mask().len() as u64 != self.runtime_adapter.num_shards() {
+        if header.chunk_mask().len() as u64 != self.runtime_adapter.num_shards(&header.epoch_id()) {
             return Err(ErrorKind::InvalidChunkMask.into());
         }
 

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -219,7 +219,7 @@ impl Chain {
         let store = ChainStore::new(store, chain_genesis.height);
         let genesis_chunks = genesis_chunks(
             state_roots.clone(),
-            runtime_adapter.num_shards(&EpochId::default()),
+            runtime_adapter.num_shards(&EpochId::default())?,
             chain_genesis.gas_limit,
             chain_genesis.height,
             chain_genesis.protocol_version,
@@ -257,7 +257,7 @@ impl Chain {
         let mut store = ChainStore::new(store, chain_genesis.height);
         let genesis_chunks = genesis_chunks(
             state_roots.clone(),
-            runtime_adapter.num_shards(&EpochId::default()),
+            runtime_adapter.num_shards(&EpochId::default())?,
             chain_genesis.gas_limit,
             chain_genesis.height,
             chain_genesis.protocol_version,
@@ -1181,7 +1181,7 @@ impl Chain {
         parent_hash: &CryptoHash,
     ) -> Vec<ShardId> {
         let epoch_id = self.runtime_adapter().get_epoch_id_from_prev_block(parent_hash).unwrap();
-        (0..self.runtime_adapter.num_shards(&epoch_id))
+        (0..self.runtime_adapter.num_shards(&epoch_id).unwrap())
             .filter(|shard_id| {
                 self.runtime_adapter.will_care_about_shard(
                     me.as_ref(),
@@ -2607,7 +2607,7 @@ impl<'a> ChainUpdate<'a> {
         parent_hash: CryptoHash,
     ) -> Result<bool, Error> {
         let epoch_id = self.runtime_adapter.get_epoch_id_from_prev_block(&parent_hash)?;
-        for shard_id in 0..self.runtime_adapter.num_shards(&epoch_id) {
+        for shard_id in 0..self.runtime_adapter.num_shards(&epoch_id)? {
             if self.runtime_adapter.cares_about_shard(me.as_ref(), &parent_hash, shard_id, true)
                 || self.runtime_adapter.will_care_about_shard(
                     me.as_ref(),
@@ -3127,7 +3127,7 @@ impl<'a> ChainUpdate<'a> {
         }
 
         if block.chunks().len()
-            != self.runtime_adapter.num_shards(&block.header().epoch_id()) as usize
+            != self.runtime_adapter.num_shards(&block.header().epoch_id())? as usize
         {
             return Err(ErrorKind::IncorrectNumberOfChunkHeaders.into());
         }
@@ -3469,7 +3469,9 @@ impl<'a> ChainUpdate<'a> {
             }
         }
 
-        if header.chunk_mask().len() as u64 != self.runtime_adapter.num_shards(&header.epoch_id()) {
+        if header.chunk_mask().len() as u64
+            != self.runtime_adapter.num_shards(&header.epoch_id())?
+        {
             return Err(ErrorKind::InvalidChunkMask.into());
         }
 

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -488,7 +488,11 @@ impl RuntimeAdapter for KeyValueRuntime {
         }
     }
 
-    fn account_id_to_shard_id(&self, account_id: &AccountId, _epoch_id: &EpochId) -> Result<ShardId, Error> {
+    fn account_id_to_shard_id(
+        &self,
+        account_id: &AccountId,
+        _epoch_id: &EpochId,
+    ) -> Result<ShardId, Error> {
         Ok(account_id_to_shard_id(account_id, self.num_shards))
     }
 
@@ -1369,7 +1373,8 @@ mod test {
                 let shard_receipts: Vec<Receipt> = receipts
                     .iter()
                     .filter(|&receipt| {
-                        self.account_id_to_shard_id(&receipt.receiver_id, &EpochId::default()).unwrap()
+                        self.account_id_to_shard_id(&receipt.receiver_id, &EpochId::default())
+                            .unwrap()
                             == shard_id
                     })
                     .cloned()

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -466,8 +466,8 @@ impl RuntimeAdapter for KeyValueRuntime {
         Ok(validators[offset + delta].account_id().clone())
     }
 
-    fn num_shards(&self, _epoch_id: &EpochId) -> ShardId {
-        self.num_shards
+    fn num_shards(&self, _epoch_id: &EpochId) -> Result<ShardId, Error> {
+        Ok(self.num_shards)
     }
 
     fn get_shard_layout(&self, _epoch_id: &EpochId) -> Result<ShardLayout, Error> {

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -36,6 +36,7 @@ use near_store::{PartialStorage, ShardTries, Store, StoreUpdate, Trie, WrappedTr
 
 #[cfg(feature = "protocol_feature_block_header_v3")]
 use crate::DoomslugThresholdMode;
+use near_primitives::shard_layout::{account_id_to_shard_id, ShardLayout};
 use near_primitives::state_record::StateRecord;
 
 #[derive(Eq, PartialEq, Debug, Clone)]
@@ -277,6 +278,7 @@ pub trait RuntimeAdapter: Send + Sync {
         state_root: Option<StateRoot>,
         transaction: &SignedTransaction,
         verify_signature: bool,
+        epoch_id: &EpochId,
         current_protocol_version: ProtocolVersion,
     ) -> Result<Option<InvalidTxError>, Error>;
 
@@ -415,10 +417,12 @@ pub trait RuntimeAdapter: Send + Sync {
     fn num_data_parts(&self) -> usize;
 
     /// Account Id to Shard Id mapping, given current number of shards.
-    fn account_id_to_shard_id(&self, account_id: &AccountId) -> ShardId;
+    fn account_id_to_shard_id(&self, account_id: &AccountId, epoch_id: &EpochId) -> ShardId;
 
     /// Returns `account_id` that suppose to have the `part_id` of all chunks given previous block hash.
     fn get_part_owner(&self, parent_hash: &CryptoHash, part_id: u64) -> Result<AccountId, Error>;
+
+    fn get_shard_layout(&self, epoch_id: &EpochId) -> Result<ShardLayout, Error>;
 
     /// Whether the client cares about some shard right now.
     /// * If `account_id` is None, `is_me` is not checked and the
@@ -685,18 +689,22 @@ pub trait RuntimeAdapter: Send + Sync {
     /// Build receipts hashes.
     // Due to borsh serialization constraints, we have to use `&Vec<Receipt>` instead of `&[Receipt]`
     // here.
-    fn build_receipts_hashes(&self, receipts: &Vec<Receipt>) -> Vec<CryptoHash> {
+    fn build_receipts_hashes(
+        &self,
+        receipts: &Vec<Receipt>,
+        shard_layout: &ShardLayout,
+    ) -> Vec<CryptoHash> {
         if self.num_shards() == 1 {
             return vec![hash(&ReceiptList(0, receipts).try_to_vec().unwrap())];
         }
-        let mut account_id_to_shard_id = HashMap::new();
+        let mut account_id_to_shard_id_map = HashMap::new();
         let mut shard_receipts: Vec<_> = (0..self.num_shards()).map(|i| (i, Vec::new())).collect();
         for receipt in receipts.iter() {
-            let shard_id = match account_id_to_shard_id.get(&receipt.receiver_id) {
+            let shard_id = match account_id_to_shard_id_map.get(&receipt.receiver_id) {
                 Some(id) => *id,
                 None => {
-                    let id = self.account_id_to_shard_id(&receipt.receiver_id);
-                    account_id_to_shard_id.insert(receipt.receiver_id.clone(), id);
+                    let id = account_id_to_shard_id(&receipt.receiver_id, shard_layout);
+                    account_id_to_shard_id_map.insert(receipt.receiver_id.clone(), id);
                     id
                 }
             };

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -417,7 +417,11 @@ pub trait RuntimeAdapter: Send + Sync {
     fn num_data_parts(&self) -> usize;
 
     /// Account Id to Shard Id mapping, given current number of shards.
-    fn account_id_to_shard_id(&self, account_id: &AccountId, epoch_id: &EpochId) -> Result<ShardId, Error>;
+    fn account_id_to_shard_id(
+        &self,
+        account_id: &AccountId,
+        epoch_id: &EpochId,
+    ) -> Result<ShardId, Error>;
 
     /// Returns `account_id` that suppose to have the `part_id` of all chunks given previous block hash.
     fn get_part_owner(&self, parent_hash: &CryptoHash, part_id: u64) -> Result<AccountId, Error>;

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -410,7 +410,7 @@ pub trait RuntimeAdapter: Send + Sync {
     ) -> Result<(ValidatorStake, bool), Error>;
 
     /// Get current number of shards.
-    fn num_shards(&self) -> ShardId;
+    fn num_shards(&self, epoch_id: &EpochId) -> ShardId;
 
     fn num_total_parts(&self) -> usize;
 
@@ -694,11 +694,12 @@ pub trait RuntimeAdapter: Send + Sync {
         receipts: &Vec<Receipt>,
         shard_layout: &ShardLayout,
     ) -> Vec<CryptoHash> {
-        if self.num_shards() == 1 {
+        if shard_layout.num_shards() == 1 {
             return vec![hash(&ReceiptList(0, receipts).try_to_vec().unwrap())];
         }
         let mut account_id_to_shard_id_map = HashMap::new();
-        let mut shard_receipts: Vec<_> = (0..self.num_shards()).map(|i| (i, Vec::new())).collect();
+        let mut shard_receipts: Vec<_> =
+            (0..shard_layout.num_shards()).map(|i| (i, Vec::new())).collect();
         for receipt in receipts.iter() {
             let shard_id = match account_id_to_shard_id_map.get(&receipt.receiver_id) {
                 Some(id) => *id,

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -417,7 +417,7 @@ pub trait RuntimeAdapter: Send + Sync {
     fn num_data_parts(&self) -> usize;
 
     /// Account Id to Shard Id mapping, given current number of shards.
-    fn account_id_to_shard_id(&self, account_id: &AccountId, epoch_id: &EpochId) -> ShardId;
+    fn account_id_to_shard_id(&self, account_id: &AccountId, epoch_id: &EpochId) -> Result<ShardId, Error>;
 
     /// Returns `account_id` that suppose to have the `part_id` of all chunks given previous block hash.
     fn get_part_owner(&self, parent_hash: &CryptoHash, part_id: u64) -> Result<AccountId, Error>;

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -410,7 +410,7 @@ pub trait RuntimeAdapter: Send + Sync {
     ) -> Result<(ValidatorStake, bool), Error>;
 
     /// Get current number of shards.
-    fn num_shards(&self, epoch_id: &EpochId) -> ShardId;
+    fn num_shards(&self, epoch_id: &EpochId) -> Result<ShardId, Error>;
 
     fn num_total_parts(&self) -> usize;
 

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -585,7 +585,7 @@ impl ShardsManager {
 
     fn get_tracking_shards(&self, parent_hash: &CryptoHash) -> HashSet<ShardId> {
         let epoch_id = self.runtime_adapter.get_epoch_id_from_prev_block(parent_hash).unwrap();
-        (0..self.runtime_adapter.num_shards(&epoch_id))
+        (0..self.runtime_adapter.num_shards(&epoch_id).unwrap())
             .filter(|chunk_shard_id| {
                 self.cares_about_shard_this_or_next_epoch(
                     self.me.as_ref(),
@@ -1401,7 +1401,7 @@ impl ShardsManager {
         chunk_entry: &EncodedChunksCacheEntry,
     ) -> Result<bool, Error> {
         let epoch_id = self.runtime_adapter.get_epoch_id_from_prev_block(prev_block_hash)?;
-        for shard_id in 0..self.runtime_adapter.num_shards(&epoch_id) {
+        for shard_id in 0..self.runtime_adapter.num_shards(&epoch_id)? {
             let shard_id = shard_id as ShardId;
             if !chunk_entry.receipts.contains_key(&shard_id) {
                 if self.need_receipt(&prev_block_hash, shard_id) {

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -41,6 +41,7 @@ use near_primitives::{checked_feature, unwrap_or_return};
 
 use crate::chunk_cache::{EncodedChunksCache, EncodedChunksCacheEntry};
 pub use near_chunks_primitives::Error;
+use near_primitives::shard_layout::{account_id_to_shard_id, ShardLayout};
 use rand::Rng;
 
 mod chunk_cache;
@@ -795,10 +796,11 @@ impl ShardsManager {
     pub fn group_receipts_by_shard(
         &self,
         receipts: Vec<Receipt>,
+        shard_layout: &ShardLayout,
     ) -> HashMap<ShardId, Vec<Receipt>> {
         let mut result = HashMap::with_capacity(self.runtime_adapter.num_shards() as usize);
         for receipt in receipts {
-            let shard_id = self.runtime_adapter.account_id_to_shard_id(&receipt.receiver_id);
+            let shard_id = account_id_to_shard_id(&receipt.receiver_id, &shard_layout);
             let entry = result.entry(shard_id).or_insert_with(Vec::new);
             entry.push(receipt)
         }
@@ -1543,7 +1545,7 @@ impl ShardsManager {
                 merkle_paths,
                 shard_chunk.receipts().clone(),
                 &mut store_update,
-            );
+            )?;
 
             // Decoded a valid chunk, store it in the permanent store
             store_update.save_chunk(shard_chunk);
@@ -1569,17 +1571,24 @@ impl ShardsManager {
         merkle_paths: Vec<MerklePath>,
         outgoing_receipts: Vec<Receipt>,
         store_update: &mut ChainStoreUpdate<'_>,
-    ) {
+    ) -> Result<(), Error> {
         let header = encoded_chunk.cloned_header();
         let shard_id = header.shard_id();
+        let shard_layout = {
+            let epoch_id = self
+                .runtime_adapter
+                .get_epoch_id_from_prev_block(&header.prev_block_hash())
+                .unwrap();
+            self.runtime_adapter.get_shard_layout(&epoch_id)?
+        };
         let outgoing_receipts_hashes =
-            self.runtime_adapter.build_receipts_hashes(&outgoing_receipts);
+            self.runtime_adapter.build_receipts_hashes(&outgoing_receipts, &shard_layout);
         let (outgoing_receipts_root, outgoing_receipts_proofs) =
             merklize(&outgoing_receipts_hashes);
         assert_eq!(header.outgoing_receipts_root(), outgoing_receipts_root);
 
         // Save this chunk into encoded_chunks & process encoded chunk to add to the store.
-        let mut receipts_by_shard = self.group_receipts_by_shard(outgoing_receipts);
+        let mut receipts_by_shard = self.group_receipts_by_shard(outgoing_receipts, &shard_layout);
         let receipts = outgoing_receipts_proofs
             .into_iter()
             .enumerate()
@@ -1613,6 +1622,8 @@ impl ShardsManager {
 
         // Save this chunk into encoded_chunks.
         self.encoded_chunks.insert(cache_entry.header.chunk_hash(), cache_entry);
+
+        Ok(())
     }
 
     pub fn distribute_encoded_chunk(
@@ -1626,8 +1637,12 @@ impl ShardsManager {
         let chunk_header = encoded_chunk.cloned_header();
         let prev_block_hash = chunk_header.prev_block_hash();
         let shard_id = chunk_header.shard_id();
+        let shard_layout = {
+            let epoch_id = self.runtime_adapter.get_epoch_id_from_prev_block(&prev_block_hash)?;
+            self.runtime_adapter.get_shard_layout(&epoch_id)?
+        };
         let outgoing_receipts_hashes =
-            self.runtime_adapter.build_receipts_hashes(&outgoing_receipts);
+            self.runtime_adapter.build_receipts_hashes(&outgoing_receipts, &shard_layout);
         let (outgoing_receipts_root, outgoing_receipts_proofs) =
             merklize(&outgoing_receipts_hashes);
         assert_eq!(chunk_header.outgoing_receipts_root(), outgoing_receipts_root);
@@ -1642,7 +1657,7 @@ impl ShardsManager {
             entry.push(part_ord);
         }
 
-        let mut receipts_by_shard = self.group_receipts_by_shard(outgoing_receipts);
+        let mut receipts_by_shard = self.group_receipts_by_shard(outgoing_receipts, &shard_layout);
         let receipt_proofs: Vec<_> = outgoing_receipts_proofs
             .into_iter()
             .enumerate()
@@ -1786,6 +1801,7 @@ mod test {
         let signer =
             InMemoryValidatorSigner::from_seed("test".parse().unwrap(), KeyType::ED25519, "test");
         let mut rs = ReedSolomonWrapper::new(4, 10);
+        let shard_layout = runtime_adapter.get_shard_layout(&EpochId::default()).unwrap();
         let (encoded_chunk, proof) = shards_manager
             .create_encoded_shard_chunk(
                 CryptoHash::default(),
@@ -1799,7 +1815,7 @@ mod test {
                 vec![],
                 vec![],
                 &vec![],
-                merklize(&runtime_adapter.build_receipts_hashes(&vec![])).0,
+                merklize(&runtime_adapter.build_receipts_hashes(&vec![], &shard_layout)).0,
                 CryptoHash::default(),
                 &signer,
                 &mut rs,

--- a/chain/chunks/src/test_utils.rs
+++ b/chain/chunks/src/test_utils.rs
@@ -14,7 +14,7 @@ use near_primitives::merkle;
 use near_primitives::sharding::{
     ChunkHash, PartialEncodedChunkPart, PartialEncodedChunkV2, ReedSolomonWrapper, ShardChunkHeader,
 };
-use near_primitives::types::{AccountId, ShardId};
+use near_primitives::types::{AccountId, EpochId, ShardId};
 use near_primitives::types::{BlockHeight, MerkleHash};
 use near_primitives::validator_signer::InMemoryValidatorSigner;
 use near_primitives::version::PROTOCOL_VERSION;
@@ -207,7 +207,8 @@ impl Default for ChunkForwardingTestFixture {
             mock_network.clone(),
         );
         let receipts = Vec::new();
-        let receipts_hashes = mock_runtime.build_receipts_hashes(&receipts);
+        let shard_layout = mock_runtime.get_shard_layout(&EpochId::default()).unwrap();
+        let receipts_hashes = mock_runtime.build_receipts_hashes(&receipts, &shard_layout);
         let (receipts_root, _) = merkle::merklize(&receipts_hashes);
         let (mock_chunk, mock_merkles) = producer_shard_manager
             .create_encoded_shard_chunk(

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1360,7 +1360,9 @@ impl Client {
                 self.chain.find_chunk_producer_for_forwarding(epoch_id, shard_id, horizon)?;
             validators.insert(validator);
             if let Some(next_epoch_id) = &maybe_next_epoch_id {
-                let next_shard_id = self.runtime_adapter.account_id_to_shard_id(&tx.transaction.signer_id, next_epoch_id)?;
+                let next_shard_id = self
+                    .runtime_adapter
+                    .account_id_to_shard_id(&tx.transaction.signer_id, next_epoch_id)?;
                 let validator = self.chain.find_chunk_producer_for_forwarding(
                     next_epoch_id,
                     next_shard_id,

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1348,7 +1348,7 @@ impl Client {
     /// Forwards given transaction to upcoming validators.
     fn forward_tx(&self, epoch_id: &EpochId, tx: &SignedTransaction) -> Result<(), Error> {
         let shard_id =
-            self.runtime_adapter.account_id_to_shard_id(&tx.transaction.signer_id, epoch_id);
+            self.runtime_adapter.account_id_to_shard_id(&tx.transaction.signer_id, epoch_id)?;
         let head = self.chain.head()?;
         let maybe_next_epoch_id = self.get_next_epoch_id_if_at_boundary(&head)?;
 
@@ -1441,7 +1441,7 @@ impl Client {
         let head = self.chain.head()?;
         let me = self.validator_signer.as_ref().map(|vs| vs.validator_id());
         let shard_id =
-            self.runtime_adapter.account_id_to_shard_id(&tx.transaction.signer_id, &head.epoch_id);
+            self.runtime_adapter.account_id_to_shard_id(&tx.transaction.signer_id, &head.epoch_id)?;
         let cur_block_header = self.chain.head_header()?.clone();
         let transaction_validity_period = self.chain.transaction_validity_period;
         // here it is fine to use `cur_block_header` as it is a best effort estimate. If the transaction

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1360,9 +1360,10 @@ impl Client {
                 self.chain.find_chunk_producer_for_forwarding(epoch_id, shard_id, horizon)?;
             validators.insert(validator);
             if let Some(next_epoch_id) = &maybe_next_epoch_id {
+                let next_shard_id = self.runtime_adapter.account_id_to_shard_id(&tx.transaction.signer_id, next_epoch_id)?;
                 let validator = self.chain.find_chunk_producer_for_forwarding(
                     next_epoch_id,
-                    shard_id,
+                    next_shard_id,
                     horizon,
                 )?;
                 validators.insert(validator);

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1088,11 +1088,11 @@ impl Client {
 
             if provenance != Provenance::SYNC && !self.sync_status.is_syncing() {
                 // Produce new chunks
-                for shard_id in 0..self.runtime_adapter.num_shards() {
-                    let epoch_id = self
-                        .runtime_adapter
-                        .get_epoch_id_from_prev_block(&block.header().hash())
-                        .unwrap();
+                let epoch_id = self
+                    .runtime_adapter
+                    .get_epoch_id_from_prev_block(&block.header().hash())
+                    .unwrap();
+                for shard_id in 0..self.runtime_adapter.num_shards(&epoch_id) {
                     let chunk_proposer = self
                         .runtime_adapter
                         .get_chunk_producer(&epoch_id, block.header().height() + 1, shard_id)

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -576,8 +576,9 @@ impl Client {
         // 2. anyone who just asks for one's incoming receipts
         // will receive a piece of incoming receipts only
         // with merkle receipts proofs which can be checked locally
+        let shard_layout = self.runtime_adapter.get_shard_layout(epoch_id)?;
         let outgoing_receipts_hashes =
-            self.runtime_adapter.build_receipts_hashes(&outgoing_receipts);
+            self.runtime_adapter.build_receipts_hashes(&outgoing_receipts, &shard_layout);
         let (outgoing_receipts_root, _) = merklize(&outgoing_receipts_hashes);
 
         let protocol_version = self.runtime_adapter.get_epoch_protocol_version(epoch_id)?;
@@ -1346,7 +1347,8 @@ impl Client {
 
     /// Forwards given transaction to upcoming validators.
     fn forward_tx(&self, epoch_id: &EpochId, tx: &SignedTransaction) -> Result<(), Error> {
-        let shard_id = self.runtime_adapter.account_id_to_shard_id(&tx.transaction.signer_id);
+        let shard_id =
+            self.runtime_adapter.account_id_to_shard_id(&tx.transaction.signer_id, epoch_id);
         let head = self.chain.head()?;
         let maybe_next_epoch_id = self.get_next_epoch_id_if_at_boundary(&head)?;
 
@@ -1438,7 +1440,8 @@ impl Client {
     ) -> Result<NetworkClientResponses, Error> {
         let head = self.chain.head()?;
         let me = self.validator_signer.as_ref().map(|vs| vs.validator_id());
-        let shard_id = self.runtime_adapter.account_id_to_shard_id(&tx.transaction.signer_id);
+        let shard_id =
+            self.runtime_adapter.account_id_to_shard_id(&tx.transaction.signer_id, &head.epoch_id);
         let cur_block_header = self.chain.head_header()?.clone();
         let transaction_validity_period = self.chain.transaction_validity_period;
         // here it is fine to use `cur_block_header` as it is a best effort estimate. If the transaction
@@ -1459,7 +1462,7 @@ impl Client {
 
         if let Some(err) = self
             .runtime_adapter
-            .validate_tx(gas_price, None, &tx, true, protocol_version)
+            .validate_tx(gas_price, None, &tx, true, &epoch_id, protocol_version)
             .expect("no storage errors")
         {
             debug!(target: "client", "Invalid tx during basic validation: {:?}", err);
@@ -1486,7 +1489,7 @@ impl Client {
             };
             if let Some(err) = self
                 .runtime_adapter
-                .validate_tx(gas_price, Some(state_root), &tx, false, protocol_version)
+                .validate_tx(gas_price, Some(state_root), &tx, false, &epoch_id, protocol_version)
                 .expect("no storage errors")
             {
                 debug!(target: "client", "Invalid tx: {:?}", err);

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1092,7 +1092,7 @@ impl Client {
                     .runtime_adapter
                     .get_epoch_id_from_prev_block(&block.header().hash())
                     .unwrap();
-                for shard_id in 0..self.runtime_adapter.num_shards(&epoch_id) {
+                for shard_id in 0..self.runtime_adapter.num_shards(&epoch_id).unwrap() {
                     let chunk_proposer = self
                         .runtime_adapter
                         .get_chunk_producer(&epoch_id, block.header().height() + 1, shard_id)

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1440,8 +1440,9 @@ impl Client {
     ) -> Result<NetworkClientResponses, Error> {
         let head = self.chain.head()?;
         let me = self.validator_signer.as_ref().map(|vs| vs.validator_id());
-        let shard_id =
-            self.runtime_adapter.account_id_to_shard_id(&tx.transaction.signer_id, &head.epoch_id)?;
+        let shard_id = self
+            .runtime_adapter
+            .account_id_to_shard_id(&tx.transaction.signer_id, &head.epoch_id)?;
         let cur_block_header = self.chain.head_header()?.clone();
         let transaction_validity_period = self.chain.transaction_validity_period;
         // here it is fine to use `cur_block_header` as it is a best effort estimate. If the transaction

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -745,8 +745,8 @@ impl ClientActor {
                 == Some(&next_block_producer_account)
             {
                 let num_chunks = self.client.shards_mgr.num_chunks_for_block(&head.last_block_hash);
-                let have_all_chunks =
-                    head.height == 0 || num_chunks == self.client.runtime_adapter.num_shards();
+                let have_all_chunks = head.height == 0
+                    || num_chunks == self.client.runtime_adapter.num_shards(&epoch_id);
 
                 if self.client.doomslug.ready_to_produce_block(
                     Instant::now(),
@@ -1328,7 +1328,8 @@ impl ClientActor {
                 let block_header =
                     unwrap_or_run_later!(self.client.chain.get_block_header(&sync_hash));
                 let prev_hash = block_header.prev_hash().clone();
-                let shards_to_sync = (0..self.client.runtime_adapter.num_shards())
+                let epoch_id = self.client.chain.get_block_header(&sync_hash).unwrap().epoch_id();
+                let shards_to_sync = (0..self.client.runtime_adapter.num_shards(&epoch_id))
                     .filter(|x| {
                         self.client.shards_mgr.cares_about_shard_this_or_next_epoch(
                             me.as_ref(),

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -746,7 +746,7 @@ impl ClientActor {
             {
                 let num_chunks = self.client.shards_mgr.num_chunks_for_block(&head.last_block_hash);
                 let have_all_chunks = head.height == 0
-                    || num_chunks == self.client.runtime_adapter.num_shards(&epoch_id);
+                    || num_chunks == self.client.runtime_adapter.num_shards(&epoch_id).unwrap();
 
                 if self.client.doomslug.ready_to_produce_block(
                     Instant::now(),
@@ -1329,16 +1329,17 @@ impl ClientActor {
                     unwrap_or_run_later!(self.client.chain.get_block_header(&sync_hash));
                 let prev_hash = block_header.prev_hash().clone();
                 let epoch_id = self.client.chain.get_block_header(&sync_hash).unwrap().epoch_id();
-                let shards_to_sync = (0..self.client.runtime_adapter.num_shards(&epoch_id))
-                    .filter(|x| {
-                        self.client.shards_mgr.cares_about_shard_this_or_next_epoch(
-                            me.as_ref(),
-                            &prev_hash,
-                            *x,
-                            true,
-                        )
-                    })
-                    .collect();
+                let shards_to_sync =
+                    (0..self.client.runtime_adapter.num_shards(&epoch_id).unwrap())
+                        .filter(|x| {
+                            self.client.shards_mgr.cares_about_shard_this_or_next_epoch(
+                                me.as_ref(),
+                                &prev_hash,
+                                *x,
+                                true,
+                            )
+                        })
+                        .collect();
 
                 if !self.client.config.archive && just_enter_state_sync {
                     unwrap_or_run_later!(self.client.chain.reset_data_pre_state_sync(sync_hash));

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -248,7 +248,7 @@ impl ViewClientActor {
             QueryRequest::CallFunction { account_id, .. } => account_id,
             QueryRequest::ViewCode { account_id, .. } => account_id,
         };
-        let shard_id = self.runtime_adapter.account_id_to_shard_id(account_id);
+        let shard_id = self.runtime_adapter.account_id_to_shard_id(account_id, &header.epoch_id());
 
         let chunk_extra = self.chain.get_chunk_extra(header.hash(), shard_id).map_err(|err| {
             match err.kind() {
@@ -358,7 +358,10 @@ impl ViewClientActor {
         }
 
         let head = self.chain.head().map_err(|e| TxStatusError::ChainError(e))?;
-        let target_shard_id = self.runtime_adapter.account_id_to_shard_id(&signer_account_id);
+        // TODO: get_tx may not work properly after re-sharding for transactions processed
+        //       by previous shards, fix this
+        let target_shard_id =
+            self.runtime_adapter.account_id_to_shard_id(&signer_account_id, &head.epoch_id);
         // Check if we are tracking this shard.
         if self.runtime_adapter.cares_about_shard(
             self.validator_account_id.as_ref(),
@@ -416,8 +419,10 @@ impl ViewClientActor {
         } else {
             let mut request_manager = self.request_manager.write().expect(POISONED_LOCK_ERR);
             if Self::need_request(tx_hash, &mut request_manager.tx_status_requests) {
+                let epoch_id =
+                    self.chain.head().map_err(|e| TxStatusError::ChainError(e))?.epoch_id;
                 let target_shard_id =
-                    self.runtime_adapter.account_id_to_shard_id(&signer_account_id);
+                    self.runtime_adapter.account_id_to_shard_id(&signer_account_id, &epoch_id);
                 let validator = self
                     .chain
                     .find_validator_for_forwarding(target_shard_id)
@@ -789,17 +794,20 @@ impl Handler<GetExecutionOutcome> for ViewClientActor {
 
     #[perf]
     fn handle(&mut self, msg: GetExecutionOutcome, _: &mut Self::Context) -> Self::Result {
-        let (id, target_shard_id) = match msg.id {
+        let (id, account_id) = match msg.id {
             TransactionOrReceiptId::Transaction { transaction_hash, sender_id } => {
-                (transaction_hash, self.runtime_adapter.account_id_to_shard_id(&sender_id))
+                (transaction_hash, sender_id)
             }
             TransactionOrReceiptId::Receipt { receipt_id, receiver_id } => {
-                (receipt_id, self.runtime_adapter.account_id_to_shard_id(&receiver_id))
+                (receipt_id, receiver_id)
             }
         };
         match self.chain.get_execution_outcome(&id) {
             Ok(outcome) => {
                 let mut outcome_proof = outcome.clone();
+                let epoch_id = self.chain.get_block(&outcome_proof.block_hash)?.header().epoch_id();
+                let target_shard_id =
+                    self.runtime_adapter.account_id_to_shard_id(&account_id, epoch_id);
                 let next_block_hash = self
                     .chain
                     .get_next_block_hash_with_new_chunk(&outcome_proof.block_hash, target_shard_id)?
@@ -837,6 +845,8 @@ impl Handler<GetExecutionOutcome> for ViewClientActor {
             Err(e) => match e.kind() {
                 ErrorKind::DBNotFoundErr(_) => {
                     let head = self.chain.head().map_err(|e| TxStatusError::ChainError(e))?;
+                    let target_shard_id =
+                        self.runtime_adapter.account_id_to_shard_id(&account_id, &head.epoch_id);
                     if self.runtime_adapter.cares_about_shard(
                         self.validator_account_id.as_ref(),
                         &head.last_block_hash,

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -248,9 +248,10 @@ impl ViewClientActor {
             QueryRequest::CallFunction { account_id, .. } => account_id,
             QueryRequest::ViewCode { account_id, .. } => account_id,
         };
-        let shard_id = self.runtime_adapter.account_id_to_shard_id(account_id, &header.epoch_id()).map_err(|err|{
-            QueryError::InternalError{error_message: err.to_string()}
-        })?;
+        let shard_id = self
+            .runtime_adapter
+            .account_id_to_shard_id(account_id, &header.epoch_id())
+            .map_err(|err| QueryError::InternalError { error_message: err.to_string() })?;
 
         let chunk_extra = self.chain.get_chunk_extra(header.hash(), shard_id).map_err(|err| {
             match err.kind() {
@@ -362,10 +363,10 @@ impl ViewClientActor {
         let head = self.chain.head().map_err(|e| TxStatusError::ChainError(e))?;
         // TODO: get_tx may not work properly after re-sharding for transactions processed
         //       by previous shards, fix this
-        let target_shard_id =
-            self.runtime_adapter.account_id_to_shard_id(&signer_account_id, &head.epoch_id).map_err(|err|{
-                TxStatusError::InternalError(err.to_string())
-            })?;
+        let target_shard_id = self
+            .runtime_adapter
+            .account_id_to_shard_id(&signer_account_id, &head.epoch_id)
+            .map_err(|err| TxStatusError::InternalError(err.to_string()))?;
         // Check if we are tracking this shard.
         if self.runtime_adapter.cares_about_shard(
             self.validator_account_id.as_ref(),
@@ -425,10 +426,10 @@ impl ViewClientActor {
             if Self::need_request(tx_hash, &mut request_manager.tx_status_requests) {
                 let epoch_id =
                     self.chain.head().map_err(|e| TxStatusError::ChainError(e))?.epoch_id;
-                let target_shard_id =
-                    self.runtime_adapter.account_id_to_shard_id(&signer_account_id, &epoch_id).map_err(|err|{
-                        TxStatusError::InternalError(err.to_string())
-                    })?;
+                let target_shard_id = self
+                    .runtime_adapter
+                    .account_id_to_shard_id(&signer_account_id, &epoch_id)
+                    .map_err(|err| TxStatusError::InternalError(err.to_string()))?;
                 let validator = self
                     .chain
                     .find_validator_for_forwarding(target_shard_id)

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -361,8 +361,6 @@ impl ViewClientActor {
         }
 
         let head = self.chain.head().map_err(|e| TxStatusError::ChainError(e))?;
-        // TODO: get_tx may not work properly after re-sharding for transactions processed
-        //       by previous shards, fix this
         let target_shard_id = self
             .runtime_adapter
             .account_id_to_shard_id(&signer_account_id, &head.epoch_id)

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -18,7 +18,7 @@ use near_primitives::account::{AccessKey, Account};
 use near_primitives::block::{genesis_chunks, Tip};
 use near_primitives::contract::ContractCode;
 use near_primitives::hash::{hash, CryptoHash};
-use near_primitives::shard_layout::ShardUId;
+use near_primitives::shard_layout::{account_id_to_shard_id, ShardUId};
 use near_primitives::state_record::StateRecord;
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{AccountId, Balance, EpochId, ShardId, StateChangeCause, StateRoot};
@@ -245,7 +245,7 @@ impl GenesisBuilder {
     fn add_additional_account(&mut self, account_id: AccountId) -> Result<()> {
         let testing_init_balance: Balance = 10u128.pow(30);
         let testing_init_stake: Balance = 0;
-        let shard_id = self.runtime.account_id_to_shard_id(&account_id);
+        let shard_id = account_id_to_shard_id(&account_id, &self.genesis.config.shard_layout);
         let mut records = self.unflushed_records.remove(&shard_id).unwrap_or_default();
         let mut state_update =
             self.state_updates.remove(&shard_id).expect("State update should have been added");

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -129,7 +129,8 @@ impl GenesisBuilder {
         self.unflushed_records =
             self.roots.keys().cloned().map(|shard_idx| (shard_idx, vec![])).collect();
 
-        let total_accounts_num = self.additional_accounts_num * self.runtime.num_shards();
+        let num_shards = self.genesis.config.shard_layout.num_shards();
+        let total_accounts_num = self.additional_accounts_num * num_shards;
         let bar = ProgressBar::new(total_accounts_num as _);
         bar.set_style(ProgressStyle::default_bar().template(
             "[elapsed {elapsed_precise} remaining {eta_precise}] Writing into storage {bar} {pos:>7}/{len:7}",
@@ -141,7 +142,7 @@ impl GenesisBuilder {
             bar.inc(1);
         }
 
-        for shard_id in 0..self.runtime.num_shards() {
+        for shard_id in 0..num_shards {
             self.flush_shard_records(shard_id)?;
         }
         bar.finish();
@@ -191,7 +192,7 @@ impl GenesisBuilder {
     fn write_genesis_block(&mut self) -> Result<()> {
         let genesis_chunks = genesis_chunks(
             self.roots.values().cloned().collect(),
-            self.runtime.num_shards(),
+            self.genesis.config.shard_layout.num_shards(),
             self.genesis.config.gas_limit,
             self.genesis.config.genesis_height,
             self.genesis.config.protocol_version,

--- a/integration-tests/tests/client/challenges.rs
+++ b/integration-tests/tests/client/challenges.rs
@@ -27,7 +27,7 @@ use near_primitives::receipt::Receipt;
 use near_primitives::serialize::BaseDecode;
 use near_primitives::sharding::{EncodedShardChunk, ReedSolomonWrapper};
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::{AccountId, StateRoot};
+use near_primitives::types::{AccountId, EpochId, StateRoot};
 use near_primitives::utils::MaybeValidated;
 use near_primitives::validator_signer::InMemoryValidatorSigner;
 use near_primitives::version::PROTOCOL_VERSION;
@@ -478,9 +478,13 @@ fn test_receive_invalid_chunk_as_chunk_producer() {
     assert!(result.is_err());
     assert_eq!(client.chain.head().unwrap().height, 1);
     // But everyone who doesn't track this shard have accepted.
-    let receipts_hashes = env.clients[0].runtime_adapter.build_receipts_hashes(&receipts);
+    let shard_layout =
+        env.clients[0].runtime_adapter.get_shard_layout(&EpochId::default()).unwrap();
+    let receipts_hashes =
+        env.clients[0].runtime_adapter.build_receipts_hashes(&receipts, &shard_layout);
     let (_receipts_root, receipts_proofs) = merklize(&receipts_hashes);
-    let receipts_by_shard = env.clients[0].shards_mgr.group_receipts_by_shard(receipts.clone());
+    let receipts_by_shard =
+        env.clients[0].shards_mgr.group_receipts_by_shard(receipts.clone(), &shard_layout);
     let one_part_receipt_proofs = env.clients[0].shards_mgr.receipts_recipient_filter(
         0,
         Vec::default(),

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -357,7 +357,11 @@ impl NightshadeRuntime {
         Ok(ShardUId { version: shard_version, shard_id: shard_id as u32 })
     }
 
-    fn account_id_to_shard_uid(&self, account_id: &AccountId, epoch_id: &EpochId) -> Result<ShardUId, Error> {
+    fn account_id_to_shard_uid(
+        &self,
+        account_id: &AccountId,
+        epoch_id: &EpochId,
+    ) -> Result<ShardUId, Error> {
         let mut epoch_manager = self.epoch_manager.as_ref().write().expect(POISONED_LOCK_ERR);
         let shard_layout = epoch_manager.get_shard_layout(epoch_id).map_err(Error::from)?;
         let shard_id = account_id_to_shard_id(account_id, shard_layout);
@@ -1018,7 +1022,11 @@ impl RuntimeAdapter for NightshadeRuntime {
         }
     }
 
-    fn account_id_to_shard_id(&self, account_id: &AccountId, epoch_id: &EpochId) -> Result<ShardId, Error> {
+    fn account_id_to_shard_id(
+        &self,
+        account_id: &AccountId,
+        epoch_id: &EpochId,
+    ) -> Result<ShardId, Error> {
         let mut epoch_manager = self.epoch_manager.as_ref().write().expect(POISONED_LOCK_ERR);
         let shard_layout = epoch_manager.get_shard_layout(epoch_id).map_err(Error::from)?;
         Ok(account_id_to_shard_id(account_id, shard_layout))
@@ -2005,7 +2013,8 @@ mod test {
         }
 
         pub fn view_account(&self, account_id: &AccountId) -> AccountView {
-            let shard_id = self.runtime.account_id_to_shard_id(account_id, &self.head.epoch_id).unwrap();
+            let shard_id =
+                self.runtime.account_id_to_shard_id(account_id, &self.head.epoch_id).unwrap();
             let shard_layout = self.runtime.get_shard_layout(&self.head.epoch_id).unwrap();
             self.runtime
                 .view_account(
@@ -2506,8 +2515,10 @@ mod test {
             validators[0].as_ref(),
         );
         let staking_transaction = stake(1, &signer, &block_producers[0], TESTING_INIT_STAKE - 1);
-        let first_account_shard_id =
-            env.runtime.account_id_to_shard_id(&"test1".parse().unwrap(), &EpochId::default()).unwrap();
+        let first_account_shard_id = env
+            .runtime
+            .account_id_to_shard_id(&"test1".parse().unwrap(), &EpochId::default())
+            .unwrap();
         let transactions = if first_account_shard_id == 0 {
             vec![vec![staking_transaction], vec![]]
         } else {

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -994,9 +994,9 @@ impl RuntimeAdapter for NightshadeRuntime {
         }
     }
 
-    fn num_shards(&self, epoch_id: &EpochId) -> NumShards {
+    fn num_shards(&self, epoch_id: &EpochId) -> Result<NumShards, Error> {
         let mut epoch_manager = self.epoch_manager.as_ref().write().expect(POISONED_LOCK_ERR);
-        epoch_manager.get_shard_layout(epoch_id).unwrap().num_shards()
+        Ok(epoch_manager.get_shard_layout(epoch_id).map_err(Error::From)?.num_shards())
     }
 
     fn get_shard_layout(&self, epoch_id: &EpochId) -> Result<ShardLayout, Error> {
@@ -1940,7 +1940,7 @@ mod test {
             challenges_result: ChallengesResult,
         ) {
             let new_hash = hash(&vec![(self.head.height + 1) as u8]);
-            let num_shards = self.runtime.num_shards(&self.head.epoch_id);
+            let num_shards = self.runtime.num_shards(&self.head.epoch_id).unwrap();
             assert_eq!(transactions.len() as NumShards, num_shards);
             assert_eq!(chunk_mask.len() as NumShards, num_shards);
             let mut all_proposals = vec![];

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -996,7 +996,7 @@ impl RuntimeAdapter for NightshadeRuntime {
 
     fn num_shards(&self, epoch_id: &EpochId) -> Result<NumShards, Error> {
         let mut epoch_manager = self.epoch_manager.as_ref().write().expect(POISONED_LOCK_ERR);
-        Ok(epoch_manager.get_shard_layout(epoch_id).map_err(Error::From)?.num_shards())
+        Ok(epoch_manager.get_shard_layout(epoch_id).map_err(Error::from)?.num_shards())
     }
 
     fn get_shard_layout(&self, epoch_id: &EpochId) -> Result<ShardLayout, Error> {


### PR DESCRIPTION
Now the signature becomes `account_id_to_shard_id(account_id: &AccountId, epoch_id: &EpochId)` and `num_shards(epoch_id: &EpochId)`

Test Plan: passes all existing tests. 

It is hard to fully test this change before we implement state transitioning for resharding. Before that, all epochs still use the same shard layout, so we can't actually test that `account_id_to_shard_id` and `num_shards` are using the correct shard layout from the current epoch. I will add tests later once we implement state transition. 