### PR TITLE
Break the circular dependency of runtime/runtime on testlib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5040,7 +5040,6 @@ dependencies = [
  "near-store",
  "near-test-contracts",
  "near-vm-errors",
- "node-runtime",
  "num-rational",
  "rand 0.7.3",
  "serde_json",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -41,7 +41,7 @@ near-test-contracts = { path = "../runtime/near-test-contracts" }
 near-vm-errors = { path = "../runtime/near-vm-errors" }
 near-vm-runner = { path = "../runtime/near-vm-runner" }
 nearcore = { path = "../nearcore" }
-node-runtime = { path = "../runtime/runtime"}
+node-runtime = { path = "../runtime/runtime" }
 testlib = { path = "../test-utils/testlib" }
 
 [features]
@@ -50,7 +50,11 @@ regression_tests = []
 expensive_tests = []
 adversarial = ["nearcore/adversarial"]
 metric_recorder = ["near-client-primitives/metric_recorder"]
-protocol_feature_alt_bn128 = ["nearcore/protocol_feature_alt_bn128"]
+protocol_feature_alt_bn128 = [
+    "near-primitives/protocol_feature_alt_bn128",
+    "node-runtime/protocol_feature_alt_bn128",
+    "near-vm-errors/protocol_feature_alt_bn128",
+]
 protocol_feature_block_header_v3 = ["near-primitives/protocol_feature_block_header_v3", "near-chain/protocol_feature_block_header_v3", "near-store/protocol_feature_block_header_v3"]
 nightly_protocol_features = ["nearcore/nightly_protocol_features", "protocol_feature_alt_bn128", "protocol_feature_block_header_v3"]
 nightly_protocol = ["nearcore/nightly_protocol"]

--- a/integration-tests/src/node/runtime_node.rs
+++ b/integration-tests/src/node/runtime_node.rs
@@ -4,13 +4,12 @@ use near_chain_configs::Genesis;
 use near_crypto::{InMemorySigner, KeyType, Signer};
 use near_primitives::types::AccountId;
 use nearcore::config::GenesisExt;
+use testlib::runtime_utils::{add_test_contract, alice_account, bob_account};
 
 use crate::node::Node;
+use crate::runtime_utils::get_runtime_and_trie_from_genesis;
 use crate::user::runtime_user::MockClient;
 use crate::user::{RuntimeUser, User};
-use testlib::runtime_utils::{
-    add_test_contract, alice_account, bob_account, get_runtime_and_trie_from_genesis,
-};
 
 pub struct RuntimeNode {
     pub client: Arc<RwLock<MockClient>>,

--- a/integration-tests/src/runtime_utils.rs
+++ b/integration-tests/src/runtime_utils.rs
@@ -1,11 +1,14 @@
+use std::collections::HashSet;
+
 use near_chain_configs::Genesis;
+use near_primitives::state_record::{state_record_to_account_id, StateRecord};
+use near_primitives::types::AccountId;
 use near_primitives::types::StateRoot;
+use near_store::test_utils::create_tries;
 use near_store::{ShardTries, TrieUpdate};
 use nearcore::config::GenesisExt;
 use node_runtime::{state_viewer::TrieViewer, Runtime};
-use testlib::runtime_utils::{
-    add_test_contract, alice_account, bob_account, get_runtime_and_trie_from_genesis,
-};
+use testlib::runtime_utils::{add_test_contract, alice_account, bob_account};
 
 pub fn get_runtime_and_trie() -> (Runtime, ShardTries, StateRoot) {
     let mut genesis =
@@ -19,4 +22,33 @@ pub fn get_test_trie_viewer() -> (TrieViewer, TrieUpdate) {
     let trie_viewer = TrieViewer::default();
     let state_update = tries.new_trie_update(0, root);
     (trie_viewer, state_update)
+}
+
+pub fn get_runtime_and_trie_from_genesis(genesis: &Genesis) -> (Runtime, ShardTries, StateRoot) {
+    let tries = create_tries();
+    let runtime = Runtime::new();
+    let mut account_ids: HashSet<AccountId> = HashSet::new();
+    genesis.for_each_record(|record: &StateRecord| {
+        account_ids.insert(state_record_to_account_id(record).clone());
+    });
+    let genesis_root = runtime.apply_genesis_state(
+        tries.clone(),
+        0,
+        &genesis
+            .config
+            .validators
+            .iter()
+            .map(|account_info| {
+                (
+                    account_info.account_id.clone(),
+                    account_info.public_key.clone(),
+                    account_info.amount,
+                )
+            })
+            .collect::<Vec<_>>(),
+        &genesis,
+        &genesis.config.runtime_config,
+        account_ids,
+    );
+    (runtime, tries, genesis_root)
 }

--- a/test-utils/testlib/Cargo.toml
+++ b/test-utils/testlib/Cargo.toml
@@ -27,7 +27,6 @@ near-chain-configs = { path = "../../core/chain-configs" }
 near-crypto = { path = "../../core/crypto" }
 near-primitives = { path = "../../core/primitives" }
 near-store = { path = "../../core/store" }
-node-runtime = { path = "../../runtime/runtime" }
 near-vm-errors = { path = "../../runtime/near-vm-errors" }
 near-chain = { path = "../../chain/chain" }
 near-client = { path = "../../chain/client" }
@@ -41,6 +40,5 @@ near-test-contracts = { path = "../../runtime/near-test-contracts" }
 default = []
 protocol_feature_alt_bn128 = [
     "near-primitives/protocol_feature_alt_bn128",
-    "node-runtime/protocol_feature_alt_bn128",
     "near-vm-errors/protocol_feature_alt_bn128",
 ]

--- a/test-utils/testlib/src/runtime_utils.rs
+++ b/test-utils/testlib/src/runtime_utils.rs
@@ -3,13 +3,8 @@ use byteorder::{ByteOrder, LittleEndian};
 use near_chain_configs::Genesis;
 use near_primitives::account::Account;
 use near_primitives::hash::{hash, CryptoHash};
-use near_primitives::state_record::{state_record_to_account_id, StateRecord};
-use near_primitives::types::{AccountId, StateRoot};
-use near_store::test_utils::create_tries;
-use near_store::ShardTries;
-use node_runtime::Runtime;
-
-use std::collections::HashSet;
+use near_primitives::state_record::StateRecord;
+use near_primitives::types::AccountId;
 
 pub fn alice_account() -> AccountId {
     "alice.near".parse().unwrap()
@@ -45,35 +40,6 @@ pub fn add_test_contract(genesis: &mut Genesis, account_id: &AccountId) {
         account_id: account_id.clone(),
         code: near_test_contracts::rs_contract().to_vec(),
     });
-}
-
-pub fn get_runtime_and_trie_from_genesis(genesis: &Genesis) -> (Runtime, ShardTries, StateRoot) {
-    let tries = create_tries();
-    let runtime = Runtime::new();
-    let mut account_ids: HashSet<AccountId> = HashSet::new();
-    genesis.for_each_record(|record: &StateRecord| {
-        account_ids.insert(state_record_to_account_id(record).clone());
-    });
-    let genesis_root = runtime.apply_genesis_state(
-        tries.clone(),
-        0,
-        &genesis
-            .config
-            .validators
-            .iter()
-            .map(|account_info| {
-                (
-                    account_info.account_id.clone(),
-                    account_info.public_key.clone(),
-                    account_info.amount,
-                )
-            })
-            .collect::<Vec<_>>(),
-        &genesis,
-        &genesis.config.runtime_config,
-        account_ids,
-    );
-    (runtime, tries, genesis_root)
 }
 
 pub fn encode_int(val: i32) -> [u8; 4] {


### PR DESCRIPTION
 by moving the 'get_runtime_and_trie_from_genesis' function into the 'integration-tests' crate, which is the only place using this function.

Fixes #4357

`cargo test --package node-runtime`
After: `Finished test [unoptimized] target(s) in 2m 55s`, 587 targets
Before: `Finished test [unoptimized] target(s) in 3m 01s`, 612 targets