### PR TITLE
tests: make panicks in near-test-contracts more verbose

### DIFF
--- a/runtime/near-test-contracts/src/lib.rs
+++ b/runtime/near-test-contracts/src/lib.rs
@@ -1,32 +1,35 @@
-use std::io;
 use std::path::Path;
 
 use once_cell::sync::OnceCell;
 
 pub fn rs_contract() -> &'static [u8] {
     static CONTRACT: OnceCell<Vec<u8>> = OnceCell::new();
-    CONTRACT.get_or_init(|| read_contract("test_contract_rs.wasm").unwrap()).as_slice()
+    CONTRACT.get_or_init(|| read_contract("test_contract_rs.wasm")).as_slice()
 }
 
 pub fn nightly_rs_contract() -> &'static [u8] {
     static CONTRACT: OnceCell<Vec<u8>> = OnceCell::new();
-    CONTRACT.get_or_init(|| read_contract("nightly_test_contract_rs.wasm").unwrap()).as_slice()
+    CONTRACT.get_or_init(|| read_contract("nightly_test_contract_rs.wasm")).as_slice()
 }
 
 pub fn ts_contract() -> &'static [u8] {
     static CONTRACT: OnceCell<Vec<u8>> = OnceCell::new();
-    CONTRACT.get_or_init(|| read_contract("test_contract_ts.wasm").unwrap()).as_slice()
+    CONTRACT.get_or_init(|| read_contract("test_contract_ts.wasm")).as_slice()
 }
 
 pub fn tiny_contract() -> &'static [u8] {
     static CONTRACT: OnceCell<Vec<u8>> = OnceCell::new();
-    CONTRACT.get_or_init(|| read_contract("tiny_contract_rs.wasm").unwrap()).as_slice()
+    CONTRACT.get_or_init(|| read_contract("tiny_contract_rs.wasm")).as_slice()
 }
 
-fn read_contract(file_name: &str) -> io::Result<Vec<u8>> {
+/// Read given wasm file or panic if unable to.
+fn read_contract(file_name: &str) -> Vec<u8> {
     let base = Path::new(env!("CARGO_MANIFEST_DIR"));
     let path = base.join("res").join(file_name);
-    std::fs::read(path)
+    match std::fs::read(&path) {
+        Ok(data) => data,
+        Err(err) => panic!("{}: {}", path.display(), err),
+    }
 }
 
 #[test]


### PR DESCRIPTION
Include the full path of the file that the test tried to read in
panic message.

Issue: https://github.com/near/nearcore/issues/4574