### PR TITLE
pytest: verify that `genesis-populate` run succeeded

### DIFF
--- a/pytest/lib/populate.py
+++ b/pytest/lib/populate.py
@@ -1,17 +1,16 @@
-from subprocess import Popen
+import subprocess
 from os.path import join
 from shutil import copy2, rmtree
 
 
 def genesis_populate(near_root, additional_accounts, node_dir):
-    proc = Popen([
+    subprocess.check_call((
         join(near_root, 'genesis-populate'),
         '--additional-accounts-num',
         str(additional_accounts),
         '--home',
         node_dir
-    ])
-    proc.wait()
+    ))
     rmtree(join(node_dir, 'data'), ignore_errors=True)
 
 


### PR DESCRIPTION
Popen.wait does not check whether the executed command failed or not and
there was nothing in genesis_populate that would test that.  As a result,
the test would ignore any failures in the genesis-populate tool.  Change
the code to use subprocess.check_call instead which raises on failure.

Issue: https://github.com/near/nearcore/issues/4574