### PR TITLE
pytest: don’t complain if trying to kill already dead process

### DIFF
--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -337,7 +337,10 @@ class LocalNode(BaseNode):
 
     def kill(self):
         if self.pid.value != 0:
-            os.kill(self.pid.value, signal.SIGKILL)
+            try:
+                os.kill(self.pid.value, signal.SIGKILL)
+            except ProcessLookupError:
+                pass  # the process has already terminated
             self.pid.value = 0
 
             if self._proxy_local_stopped is not None:


### PR DESCRIPTION
If a process has already terminated, there’s no point complaining
that we’ve failed to deliver SIGKILL signal to it.  Just treat it
as successful termination.

This eliminate noisy logs such as:

    [2021-08-05 23:31:07] CRITICAL: Kill failed on cleanup!
    Traceback (most recent call last):
      File "lib/cluster.py", line 365, in cleanup
        self.kill()
      File "lib/cluster.py", line 341, in kill
        os.kill(self.pid.value, signal.SIGKILL)
    ProcessLookupError: [Errno 3] No such process

Issue: https://github.com/near/nearcore/issues/4574
