### PR TITLE
refactor: remove work-around for cargo features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2801,7 +2801,6 @@ dependencies = [
  "near-telemetry",
  "near-test-contracts",
  "near-vm-runner",
- "node-runtime",
  "num-rational",
  "rand 0.7.3",
  "reed-solomon-erasure",

--- a/chain/client/Cargo.toml
+++ b/chain/client/Cargo.toml
@@ -40,10 +40,6 @@ near-performance-metrics = { path = "../../utils/near-performance-metrics" }
 near-performance-metrics-macros = { path = "../../utils/near-performance-metrics-macros" }
 near-vm-runner = { path = "../../runtime/near-vm-runner" }
 
-# Required to pass sandbox feature to node-runtime. Used in tests but cannot in dev-dependencies because
-# of passing features
-node-runtime = { path = "../../runtime/runtime"}
-
 delay-detector = { path = "../../tools/delay_detector", optional = true }
 
 [dev-dependencies]
@@ -61,4 +57,4 @@ delay_detector = ["near-chain/delay_detector", "near-network/delay_detector", "d
 protocol_feature_block_header_v3 = ["near-primitives/protocol_feature_block_header_v3", "near-chain/protocol_feature_block_header_v3", "near-store/protocol_feature_block_header_v3"]
 nightly_protocol = []
 nightly_protocol_features = ["nightly_protocol", "near-chain/nightly_protocol_features", "protocol_feature_block_header_v3"]
-sandbox = ["near-network/sandbox", "near-chain/sandbox", "node-runtime/sandbox"]
+sandbox = ["near-network/sandbox", "near-chain/sandbox"]


### PR DESCRIPTION
refactor: remove work-around for cargo features

The `node-runtime` dependency in `client` creates a cyclic dependency:

near_client -> node_runtime -> testlib -> near_client

Looks like we can remove it just now, because the dep is used to
work-around cargo features, and is not otherwise used.

I think this was enabled by the recent work on

https://github.com/near/nearcore/issues/4357

Test Plan
--------

```
cargo check --all-targets && \
cargo check --all-targets --features sandbox && \
cargo check --all-targets -p near-client && \
cargo check --all-targets -p near-client --features sandbox
```
