### PR TITLE
fix: change default behavior of neard testnet 

### DIFF
--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -311,7 +311,7 @@ pub(super) struct TestnetCmd {
     #[clap(long, default_value = "node")]
     prefix: String,
     /// Number of shards to initialize the testnet with.
-    #[clap(long, default_value = "4")]
+    #[clap(long, default_value = "1")]
     shards: NumShards,
     /// Number of validators to initialize the testnet with.
     #[clap(long = "v", default_value = "4")]


### PR DESCRIPTION
fixes #4464 
fixes #4569

Test plan: verify the genesis config generated is the same as 1.19.2

``` 
$ nearcore-1 git:(ebc1e0a26) diff /Users/minzhang/.near-1.19.2/test0/genesis.json /Users/minzhang/.near-now/test0/genesis.json
2,4c2,4
<   "protocol_version": 45,
<   "genesis_time": "2021-08-18T15:45:26.235826Z",
<   "chain_id": "test-chain-WLJhS",
---
>   "protocol_version": 47,
>   "genesis_time": "2021-08-18T15:40:31.252129Z",
>   "chain_id": "test-chain-b25OT",
156a157,159
>         "ripemd160_base": 853675086,
>         "ripemd160_block": 680107584,
>         "ecrecover_base": 3365369625000,
205a209
>         "max_transaction_size": 4194304,
242a247
>   "simple_nightshade_shard_config": null,
251c256,257
<           "storage_usage": 0
---
>           "storage_usage": 0,
>           "version": "V1"
272c278,279
<           "storage_usage": 0
---
>           "storage_usage": 0,
>           "version": "V1"
293c300,301
<           "storage_usage": 0
---
>           "storage_usage": 0,
>           "version": "V1"```