### PR TITLE
refactor: get rid of a single duplicate of `VMContext`

### DIFF
--- a/runtime/near-vm-logic/src/context.rs
+++ b/runtime/near-vm-logic/src/context.rs
@@ -68,3 +68,26 @@ impl VMContext {
         self.view_config.is_some()
     }
 }
+
+impl Default for VMContext {
+    fn default() -> Self {
+        VMContext {
+            current_account_id: "alice".parse().unwrap(),
+            signer_account_id: "bob".parse().unwrap(),
+            signer_account_pk: vec![0, 1, 2],
+            predecessor_account_id: "carol".parse().unwrap(),
+            input: vec![],
+            block_index: 1,
+            block_timestamp: 1586796191203000000,
+            account_balance: 10u128.pow(25),
+            account_locked_balance: 0,
+            storage_usage: 100,
+            attached_deposit: 0,
+            prepaid_gas: 10u64.pow(18),
+            random_seed: vec![0, 1, 2],
+            view_config: None,
+            output_data_receivers: vec![],
+            epoch_height: 1,
+        }
+    }
+}

--- a/runtime/near-vm-runner-standalone/src/script.rs
+++ b/runtime/near-vm-runner-standalone/src/script.rs
@@ -138,7 +138,7 @@ impl Step {
         Step {
             contract,
             method,
-            vm_context: default_vm_context(),
+            vm_context: VMContext::default(),
             promise_results: Vec::new(),
             repeat: 1,
         }
@@ -164,27 +164,6 @@ impl Step {
     pub(crate) fn repeat(&mut self, n: u32) -> &mut Step {
         self.repeat = n;
         self
-    }
-}
-
-fn default_vm_context() -> VMContext {
-    VMContext {
-        current_account_id: "alice".parse().unwrap(),
-        signer_account_id: "bob".parse().unwrap(),
-        signer_account_pk: vec![0, 1, 2],
-        predecessor_account_id: "carol".parse().unwrap(),
-        input: vec![],
-        block_index: 1,
-        block_timestamp: 1586796191203000000,
-        account_balance: 10u128.pow(25),
-        account_locked_balance: 0,
-        storage_usage: 100,
-        attached_deposit: 0,
-        prepaid_gas: 10u64.pow(18),
-        random_seed: vec![0, 1, 2],
-        view_config: None,
-        output_data_receivers: vec![],
-        epoch_height: 1,
     }
 }
 

--- a/runtime/near-vm-runner/src/tests/contract_preload.rs
+++ b/runtime/near-vm-runner/src/tests/contract_preload.rs
@@ -13,27 +13,6 @@ use std::sync::{Arc, Mutex};
 use std::thread::sleep;
 use std::time::Duration;
 
-fn default_vm_context() -> VMContext {
-    return VMContext {
-        current_account_id: "alice".parse().unwrap(),
-        signer_account_id: "bob".parse().unwrap(),
-        signer_account_pk: vec![0, 1, 2],
-        predecessor_account_id: "carol".parse().unwrap(),
-        input: vec![],
-        block_index: 1,
-        block_timestamp: 1586796191203000000,
-        account_balance: 10u128.pow(25),
-        account_locked_balance: 0,
-        storage_usage: 100,
-        attached_deposit: 0,
-        prepaid_gas: 10u64.pow(18),
-        random_seed: vec![0, 1, 2],
-        view_config: None,
-        output_data_receivers: vec![],
-        epoch_height: 1,
-    };
-}
-
 #[derive(Default, Clone)]
 pub struct MockCompiledContractCache {
     store: Arc<Mutex<HashMap<Vec<u8>, Vec<u8>>>>,
@@ -98,7 +77,7 @@ fn test_vm_runner(preloaded: bool, vm_kind: VMKind, repeat: i32) {
 
     let mut fake_external = MockedExternal::new();
 
-    let context = VMContext::;
+    let context = VMContext::default();
     let vm_config = VMConfig::default();
     let cache: Option<Arc<dyn CompiledContractCache>> =
         Some(Arc::new(MockCompiledContractCache::new(0)));

--- a/runtime/near-vm-runner/src/tests/contract_preload.rs
+++ b/runtime/near-vm-runner/src/tests/contract_preload.rs
@@ -98,7 +98,7 @@ fn test_vm_runner(preloaded: bool, vm_kind: VMKind, repeat: i32) {
 
     let mut fake_external = MockedExternal::new();
 
-    let context = default_vm_context();
+    let context = VMContext::;
     let vm_config = VMConfig::default();
     let cache: Option<Arc<dyn CompiledContractCache>> =
         Some(Arc::new(MockCompiledContractCache::new(0)));


### PR DESCRIPTION
Get rid of a single duplicate for `VMContext`.
Advance a little to solution of https://github.com/near/nearcore/issues/4724.
For other usages, it's still unclear how to get rid of duplicates properly.

Test plan
---------
`cargo check`