### PR TITLE
nightly: disable mocknet tests since Mocknet isn’t currently running

### DIFF
--- a/nightly/mocknet.txt
+++ b/nightly/mocknet.txt
@@ -1,7 +1,5 @@
-mocknet --timeout=300 mocknet/sanity.py
-mocknet --timeout=300 mocknet/bounce.py
-
-# TODO(#4618): Those tests are currently broken.  Comment out while we’re
-# working on a fix / deciding whether to remove them.
+# TODO(#4726): Mocknet is not operational at the moment.
+#mocknet --timeout=300 mocknet/sanity.py
+#mocknet --timeout=300 mocknet/bounce.py
 #mocknet --timeout=2700 mocknet/outage.py
 #mocknet --timeout=3600 mocknet/load_testing.py


### PR DESCRIPTION
Issue: https://github.com/near/nearcore/issues/4726