### PR TITLE
Add a metric for the average amount of Tgas burned in chunks

### DIFF
--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -157,6 +157,8 @@ impl InfoHelper {
         set_gauge(&metrics::BLOCKS_PER_MINUTE, (avg_bls * (60 as f64)) as i64);
         set_gauge(&metrics::CPU_USAGE, cpu_usage as i64);
         set_gauge(&metrics::MEMORY_USAGE, (memory_usage * 1024) as i64);
+        let teragas = 1_000_000_000_000u64;
+        set_gauge(&metrics::AVG_TGAS_USAGE, (avg_gas_used / teragas) as i64);
 
         self.started = Instant::now();
         self.num_blocks_processed = 0;

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -158,7 +158,7 @@ impl InfoHelper {
         set_gauge(&metrics::CPU_USAGE, cpu_usage as i64);
         set_gauge(&metrics::MEMORY_USAGE, (memory_usage * 1024) as i64);
         let teragas = 1_000_000_000_000u64;
-        set_gauge(&metrics::AVG_TGAS_USAGE, (avg_gas_used / teragas) as i64);
+        set_gauge(&metrics::AVG_TGAS_USAGE, (avg_gas_used as f64 / teragas as f64).round() as i64);
 
         self.started = Instant::now();
         self.num_blocks_processed = 0;

--- a/chain/client/src/metrics.rs
+++ b/chain/client/src/metrics.rs
@@ -30,4 +30,8 @@ lazy_static! {
         try_create_int_gauge("near_memory_usage_bytes", "Amount of RAM memory usage");
     pub static ref GC_TIME: near_metrics::Result<Histogram> =
         try_create_histogram("near_gc_time", "Time taken to do garbage collection");
+    pub static ref AVG_TGAS_USAGE: near_metrics::Result<IntGauge> = try_create_int_gauge(
+        "near_chunk_tgas_used",
+        "Number of Tgas (10^12 of gas) used by the last processed chunk"
+    );
 }


### PR DESCRIPTION
…t run mainnet validators, this metric can still be exported by the RPC nodes and can be used in our dashboard. This is a useful indicator of block fullness for loadtests.