### PR TITLE
pytest: remove unnecessary companion.py script

### DIFF
--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -557,7 +557,7 @@ class AzureNode(BaseNode):
             self.wait_for_rpc(timeout=30)
 
         def kill(self):
-            cmd = ('killall -9 neard; pkill -9 -e -f companion.py')
+            cmd = 'killall -9 neard'
             post = {'ip': self.ip, 'cmd': cmd, 'token': self.token}
             res = requests.post('http://40.112.59.229:5000/run_cmd', json=post)
             json_res = json.loads(res.text)
@@ -570,14 +570,6 @@ class AzureNode(BaseNode):
 
         def rpc_addr(self):
             return (self.ip, self.rpc_port)
-
-        def companion(self, *args):
-            post = {'ip': self.ip, 'args': ' '.join(map(str, args)), 'token': self.token}
-            res = requests.post('http://40.112.59.229:5000/companion', json=post)
-            json_res = json.loads(res.text)
-            if json_res['stderr'] != '':
-                logger.info(json_res['stderr'])
-                sys.exit()
 
 
 def spin_up_node(config,

--- a/pytest/tests/companion.py
+++ b/pytest/tests/companion.py
@@ -1,8 +1,0 @@
-import sys
-sys.path.append('lib')
-from configured_logger import logger
-
-
-logger.info("I am running!")
-
-print ('Argument List:', str(sys.argv))

--- a/scripts/check_pytests.py
+++ b/scripts/check_pytests.py
@@ -21,11 +21,9 @@ import nayduck
 # List of globs of Python scripts in the pytest/tests directory which are not
 # test but rather helper scripts and libraries.
 HELPER_SCRIPTS = [
-    'companion.py',
     'delete_remote_nodes.py',
     'mocknet/load_testing_helper.py',
     'stress/hundred_nodes/*',
-    'tests/delete_remote_nodes.py',
 ]
 
 


### PR DESCRIPTION
The tests/companion.py script is not used for anything (and as far as
I can tell it was never really used).  Delete it.