### PR TITLE
pytest: fuzz: don’t capture output

### DIFF
--- a/pytest/tests/runtime/fuzz.py
+++ b/pytest/tests/runtime/fuzz.py
@@ -1,33 +1,16 @@
-import subprocess
 import os
-import re
+import shutil
 import sys
-
-def run_fuzz():
-    env = os.environ.copy()
-    env["RUSTC_BOOTSTRAP"] = "1"
-    cpus = len(os.sched_getaffinity(0))
-    fuzzing = subprocess.Popen(('cargo', 'fuzz', 'run', '--jobs', str(cpus),
-                                'runtime-fuzzer', '--', '-len_control=0'
-                                '-prefer_small=0', '-max_len=4000000'),
-                               env=env, cwd='../test-utils/runtime-tester/fuzz',
-                               stderr=subprocess.PIPE)
-    _, err = fuzzing.communicate()
-
-    sys.stderr.buffer.write(err)
-
-    re_expr = re.compile(rb'Output of `std::fmt::Debug`:(.*)Reproduce', re.DOTALL)
-    res = re_expr.search(err)
-
-    if res:
-        sys.stdout.buffer.write(res.group(1))
-
-    if fuzzing.returncode != 0:
-        sys.exit(f'Invalid result: { fuzzing.returncode }')
 
 
 def main():
-    run_fuzz()
+    cpus = len(os.sched_getaffinity(0))
+    args = ('cargo', 'fuzz', 'run', '--jobs', str(cpus), 'runtime-fuzzer', '--',
+           '-len_control=0' '-prefer_small=0', '-max_len=4000000')
+    os.chdir('../test-utils/runtime-tester/fuzz')
+    os.environ['RUSTC_BOOTSTRAP'] = '1'
+    os.execvp('cargo', args)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Standard error output of the fuzzing is passed through directly
and standard output generated by the `fuzz.py` test only duplicates
information already present in standard error.  And the data can get
quite big† so it’s a waste to include it in both streams.

Stop capturing output of the `cargo fuzz` command and instead
convert the `fuzz.py` test to simply exec the command setting up
the environment beforehand.

† For example http://nayduck.eastus.cloudapp.azure.com:3000/#/run/2047

Issue: https://github.com/near/nearcore/issues/4550