### PR TITLE
Revert "pytest: fuzz: enable parallelism (#4755)"

### DIFF
--- a/pytest/tests/runtime/fuzz.py
+++ b/pytest/tests/runtime/fuzz.py
@@ -1,11 +1,8 @@
 import os
-import shutil
-import sys
 
 
 def main():
-    cpus = len(os.sched_getaffinity(0))
-    args = ('cargo', 'fuzz', 'run', '--jobs', str(cpus), 'runtime-fuzzer', '--',
+    args = ('cargo', 'fuzz', 'run', 'runtime-fuzzer', '--',
            '-len_control=0' '-prefer_small=0', '-max_len=4000000')
     os.chdir('../test-utils/runtime-tester/fuzz')
     os.environ['RUSTC_BOOTSTRAP'] = '1'


### PR DESCRIPTION
Enabling parallelism in the fuzz slows down the execution and thus leads
to spurious crashes because of asserts on block production time.  Remove
the --jobs switch.

This reverts commit a0b76201c394cb3f609b5efea374c5ba1bdb0693.

Issue: https://github.com/near/nearcore/issues/4550