### PR TITLE
refactor(jsonrpc-primitives): deduplicate BlockReference

### DIFF
--- a/chain/jsonrpc-primitives/src/types/blocks.rs
+++ b/chain/jsonrpc-primitives/src/types/blocks.rs
@@ -1,14 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum BlockReference {
-    BlockId(near_primitives::types::BlockId),
-    Finality(near_primitives::types::Finality),
-    SyncCheckpoint(near_primitives::types::SyncCheckpoint),
-}
-
 #[derive(thiserror::Error, Debug, Serialize)]
 #[serde(tag = "name", content = "info", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum RpcBlockError {
@@ -29,27 +21,13 @@ pub enum RpcBlockError {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RpcBlockRequest {
     #[serde(flatten)]
-    pub block_reference: BlockReference,
+    pub block_reference: near_primitives::types::BlockReference,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RpcBlockResponse {
     #[serde(flatten)]
     pub block_view: near_primitives::views::BlockView,
-}
-
-// near_client_primitives::types::GetBlock wants BlockReference from near_primitives
-// that's why this impl exists
-impl From<BlockReference> for near_primitives::types::BlockReference {
-    fn from(block_reference: BlockReference) -> Self {
-        match block_reference {
-            BlockReference::BlockId(block_id) => Self::BlockId(block_id),
-            BlockReference::Finality(finality) => Self::Finality(finality),
-            BlockReference::SyncCheckpoint(sync_checkpoint) => {
-                Self::SyncCheckpoint(sync_checkpoint)
-            }
-        }
-    }
 }
 
 impl From<near_client_primitives::types::GetBlockError> for RpcBlockError {
@@ -111,9 +89,9 @@ impl RpcBlockRequest {
         let block_reference = if let Ok((block_id,)) =
             crate::utils::parse_params::<(near_primitives::types::BlockId,)>(value.clone())
         {
-            BlockReference::BlockId(block_id)
+            near_primitives::types::BlockReference::BlockId(block_id)
         } else {
-            crate::utils::parse_params::<BlockReference>(value)?
+            crate::utils::parse_params::<near_primitives::types::BlockReference>(value)?
         };
         Ok(RpcBlockRequest { block_reference })
     }

--- a/chain/jsonrpc-primitives/src/types/changes.rs
+++ b/chain/jsonrpc-primitives/src/types/changes.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RpcStateChangesRequest {
     #[serde(flatten)]
-    pub block_reference: crate::types::blocks::BlockReference,
+    pub block_reference: near_primitives::types::BlockReference,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -16,7 +16,7 @@ pub struct RpcStateChangesResponse {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RpcStateChangesInBlockRequest {
     #[serde(flatten)]
-    pub block_reference: crate::types::blocks::BlockReference,
+    pub block_reference: near_primitives::types::BlockReference,
     #[serde(flatten)]
     pub state_changes_request: near_primitives::views::StateChangesRequestView,
 }

--- a/chain/jsonrpc-primitives/src/types/config.rs
+++ b/chain/jsonrpc-primitives/src/types/config.rs
@@ -1,18 +1,17 @@
-use crate::types::blocks::BlockReference;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 #[derive(Serialize, Deserialize)]
 pub struct RpcProtocolConfigRequest {
     #[serde(flatten)]
-    pub block_reference: BlockReference,
+    pub block_reference: near_primitives::types::BlockReference,
 }
 
 impl RpcProtocolConfigRequest {
     pub fn parse(
         value: Option<Value>,
     ) -> Result<RpcProtocolConfigRequest, crate::errors::RpcParseError> {
-        crate::utils::parse_params::<BlockReference>(value)
+        crate::utils::parse_params::<near_primitives::types::BlockReference>(value)
             .map(|block_reference| RpcProtocolConfigRequest { block_reference })
     }
 }

--- a/integration-tests/tests/nearcore/rpc_error_structs.rs
+++ b/integration-tests/tests/nearcore/rpc_error_structs.rs
@@ -171,7 +171,7 @@ fn test_protocol_config_unknown_block_error() {
                                 client
                                     .EXPERIMENTAL_protocol_config(
                                         near_jsonrpc_primitives::types::config::RpcProtocolConfigRequest {
-                                            block_reference: near_jsonrpc_primitives::types::blocks::BlockReference::BlockId(BlockId::Height(block.header.height + 100))
+                                            block_reference: near_primitives::types::BlockReference::BlockId(BlockId::Height(block.header.height + 100))
                                         }
                                     )
                                     .map_err(|err| {

--- a/integration-tests/tests/nearcore/rpc_nodes.rs
+++ b/integration-tests/tests/nearcore/rpc_nodes.rs
@@ -247,10 +247,9 @@ fn test_protocol_config_rpc() {
         let config_response = client
             .EXPERIMENTAL_protocol_config(
                 near_jsonrpc_primitives::types::config::RpcProtocolConfigRequest {
-                    block_reference:
-                        near_jsonrpc_primitives::types::blocks::BlockReference::Finality(
-                            Finality::None,
-                        ),
+                    block_reference: near_primitives::types::BlockReference::Finality(
+                        Finality::None,
+                    ),
                 },
             )
             .await


### PR DESCRIPTION
The `BlockReference` enum is duplicated in `near-primitives` and `near-jsonrpc-primitives`. The likely reason for this, was to allow for jsonrpc-specific features [Context: <https://github.com/near/nearcore/pull/3861#discussion_r566134004>], but at this moment, they are, for the purposes that matter, identical. With the one in `near_jsonrpc_primitives` plainly convertible `Into` the one in `near_primitives`.