### PR TITLE
refactor(jsonrpc-primitives): impl Display instead of ToString for RpcError

### DIFF
--- a/chain/jsonrpc-primitives/src/errors.rs
+++ b/chain/jsonrpc-primitives/src/errors.rs
@@ -146,9 +146,9 @@ impl RpcError {
     }
 }
 
-impl std::string::ToString for RpcError {
-    fn to_string(&self) -> String {
-        format!("{:?}", self)
+impl fmt::Display for RpcError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
     }
 }
 


### PR DESCRIPTION
`format!("error: {}", err.to_string())` -> `format!("error: {}", err)`