### PR TITLE
feat: pass environment variables to docker

### DIFF
--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -196,7 +196,6 @@ fn main_docker(state_dump_path: &Path, full: bool) -> anyhow::Result<()> {
 
         let mut buf = String::new();
         buf.push_str("set -ex;\n");
-        buf.push_str("export CARGO_PROFILE_RELEASE_LTO CARGO_PROFILE_RELEASE_CODEGEN_UNITS;\n");
         buf.push_str("cd /host/nearcore;\n");
         buf.push_str(
             "\

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -242,8 +242,8 @@ cargo build --manifest-path /host/nearcore/Cargo.toml \
         .args(&["--mount", "source=rust-emu-target-dir,target=/host/nearcore/target"])
         .args(&["--mount", "source=rust-emu-cargo-dir,target=/usr/local/cargo"])
         .args(&["--interactive", "--tty"])
-        .arg(&["--env", "CARGO_PROFILE_RELEASE_LTO"])
-        .arg(&["--env", "CARGO_PROFILE_RELEASE_CODEGEN_UNITS"])
+        .args(&["--env", "CARGO_PROFILE_RELEASE_LTO"])
+        .args(&["--env", "CARGO_PROFILE_RELEASE_CODEGEN_UNITS"])
         .arg("rust-emu")
         .args(&["/usr/bin/env", "bash", "-c", &init]);
 

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -58,7 +58,7 @@ struct CliArgs {
     docker: bool,
     /// If docker is also set, run estimator in the fully production setting to get usable cost
     /// table. See runtime-params-estimator/emu-cost/README.md for more details.
-    /// Works only with enabled docker, because precise computations outside it doesn't make sense.
+    /// Works only with enabled docker, because precise computations without it doesn't make sense.
     #[clap(long)]
     full: bool,
 }

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -87,7 +87,7 @@ fn main() -> anyhow::Result<()> {
         let project_root = project_root();
         buf.push_str(&format!(
             "cd {};\n",
-            project_root.join("runtime/runtime-params-estimator").as_str().unwrap()
+            project_root.join("runtime/runtime-params-estimator").to_str().unwrap()
         ));
         buf.push_str("pushd ./test-contract && ./build.sh && popd;");
 

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -83,6 +83,7 @@ fn main() -> anyhow::Result<()> {
         .unwrap();
     }
 
+    // TODO: consider implementing the same in Rust to reduce complexity
     if !cli_args.skip_build_test_contract {
         let build_test_contract = "./build.sh";
         let project_root = project_root();
@@ -190,8 +191,6 @@ fn main_docker(state_dump_path: &Path) -> anyhow::Result<()> {
         let mut buf = String::new();
         buf.push_str("set -ex;\n");
         buf.push_str("export CARGO_PROFILE_RELEASE_LTO CARGO_PROFILE_RELEASE_CODEGEN_UNITS;\n");
-        buf.push_str("echo $CARGO_PROFILE_RELEASE_LTO;\n");
-        buf.push_str("echo $CARGO_PROFILE_RELEASE_CODEGEN_UNITS;\n");
         buf.push_str("cd /host/nearcore;\n");
         buf.push_str(
             "\

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -84,10 +84,12 @@ fn main() -> anyhow::Result<()> {
         // Build test contract for later usage in metrics computation.
 
         let mut buf = String::new();
-        let estimator_root =
-            project_root().join("runtime/runtime-params-estimator").to_str().unwrap();
-        buf.push_str(format!("cd {};\n", estimator_root).as_str());
-        buf.push_str("pushd ./test-contract && ./build.sh && popd");
+        let project_root = project_root();
+        buf.push_str(&format!(
+            "cd {};\n",
+            project_root.join("runtime/runtime-params-estimator").as_str().unwrap()
+        ));
+        buf.push_str("pushd ./test-contract && ./build.sh && popd;");
 
         buf
     };

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -35,9 +35,9 @@ struct CliArgs {
     /// Number of additional accounts to add to the state, among which active accounts are selected.
     #[clap(long, default_value = "200000")]
     additional_accounts_num: usize,
-    /// Build test contract for later usage in metrics computation.
-    #[clap(long, default_value = true)]
-    build_test_contract: bool,
+    /// Skip building test contract which is used in metrics computation.
+    #[clap(long)]
+    skip_build_test_contract: bool,
     /// What metric to use.
     #[clap(long, default_value = "icount", possible_values = &["icount", "time"])]
     metric: String,
@@ -83,7 +83,7 @@ fn main() -> anyhow::Result<()> {
         .unwrap();
     }
 
-    if cli_args.build_test_contract {
+    if !cli_args.skip_build_test_contract {
         let build_test_contract = "./build.sh";
         let project_root = project_root();
         let estimator_dir = project_root.join("runtime/runtime-params-estimator/test-contract");
@@ -212,7 +212,6 @@ cargo build --manifest-path /host/nearcore/Cargo.toml \
         while let Some(arg) = args.next() {
             match arg.as_str() {
                 "--docker" => continue,
-                "--build-test-contract" => continue,
                 "--additional-accounts-num" => {
                     args.next();
                     write!(buf, " {:?} 0", arg).unwrap();
@@ -227,6 +226,7 @@ cargo build --manifest-path /host/nearcore/Cargo.toml \
                 }
             }
         }
+        write!(buf, " --skip-build-test-contract").unwrap();
 
         buf
     };

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -189,6 +189,7 @@ fn main_docker(state_dump_path: &Path) -> anyhow::Result<()> {
 
         let mut buf = String::new();
         buf.push_str("set -ex;\n");
+        buf.push_str("export CARGO_PROFILE_RELEASE_LTO CARGO_PROFILE_RELEASE_CODEGEN_UNITS");
         buf.push_str("cd /host/nearcore;\n");
         buf.push_str(
             "\
@@ -240,6 +241,8 @@ cargo build --manifest-path /host/nearcore/Cargo.toml \
         .args(&["--mount", "source=rust-emu-target-dir,target=/host/nearcore/target"])
         .args(&["--mount", "source=rust-emu-cargo-dir,target=/usr/local/cargo"])
         .args(&["--interactive", "--tty"])
+        .arg(&["--env", "CARGO_PROFILE_RELEASE_LTO"])
+        .arg(&["--env", "CARGO_PROFILE_RELEASE_CODEGEN_UNITS"])
         .arg("rust-emu")
         .args(&["/usr/bin/env", "bash", "-c", &init]);
 

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -189,7 +189,9 @@ fn main_docker(state_dump_path: &Path) -> anyhow::Result<()> {
 
         let mut buf = String::new();
         buf.push_str("set -ex;\n");
-        buf.push_str("export CARGO_PROFILE_RELEASE_LTO CARGO_PROFILE_RELEASE_CODEGEN_UNITS");
+        buf.push_str("export CARGO_PROFILE_RELEASE_LTO CARGO_PROFILE_RELEASE_CODEGEN_UNITS;\n");
+        buf.push_str("echo $CARGO_PROFILE_RELEASE_LTO;\n");
+        buf.push_str("echo $CARGO_PROFILE_RELEASE_CODEGEN_UNITS;\n");
         buf.push_str("cd /host/nearcore;\n");
         buf.push_str(
             "\

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -80,6 +80,19 @@ fn main() -> anyhow::Result<()> {
         .unwrap();
     }
 
+    let build_test_contract = {
+        // Build test contract for later usage in metrics computation.
+
+        let mut buf = String::new();
+        let estimator_root =
+            project_root().join("runtime/runtime-params-estimator").to_str().unwrap();
+        buf.push_str(format!("cd {};\n", estimator_root).as_str());
+        buf.push_str("pushd ./test-contract && ./build.sh && popd");
+
+        buf
+    };
+    exec(&build_test_contract).context("could not build test contract")?;
+
     if cli_args.docker {
         return main_docker(&state_dump_path);
     }


### PR DESCRIPTION
And also build test contract, which is used in some metrics computation. Corresponding command was included into README.

We could also consider adding this to each metric separately.

Test plan
---------
- cargo check
- make two separate runs and check difference: https://hackmd.io/glLIGVM7RjKSKSe8p9h6rw