### PR TITLE
Add a RwLock to tries in NightshadeRuntime

### DIFF
--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -47,6 +47,17 @@ impl ShardTries {
         }
     }
 
+    // add new shards to ShardTries, only used when shard layout changes and we are building
+    // states for new shards
+    pub fn add_new_shards(&mut self, shards: Vec<ShardUId>) {
+        Arc::get_mut(&mut self.caches)
+            .unwrap()
+            .extend(Self::get_new_cache(&shards).as_ref().clone());
+        Arc::get_mut(&mut self.view_caches)
+            .unwrap()
+            .extend(Self::get_new_cache(&shards).as_ref().clone());
+    }
+
     pub fn new_trie_update(&self, shard_uid: ShardUId, state_root: CryptoHash) -> TrieUpdate {
         TrieUpdate::new(Rc::new(self.get_trie_for_shard(shard_uid)), state_root)
     }


### PR DESCRIPTION
This PR makes two changes
- Add a new function `add_new_shards` in ShardTries that adds new shards to it. This function will need to be called for building states for new shards in re-sharding
- Locks `tries` in NightshadeRuntime since now it can be modified through `add_new_shards`

Test Plan:
Existing CI tests