### PR TITLE
pytest: format Python source files

### DIFF
--- a/pytest/.style.yapf
+++ b/pytest/.style.yapf
@@ -1,0 +1,4 @@
+[style]
+based_on_style = google
+indent_width = 4
+column_limit = 80

--- a/pytest/lib/bridge.py
+++ b/pytest/lib/bridge.py
@@ -24,7 +24,10 @@ from transaction import sign_function_call_tx, sign_create_account_with_full_acc
 
 logger = logging.getLogger('bridge')
 log_handler = logging.StreamHandler()
-log_handler.setFormatter(logging.Formatter('[%(asctime)s] %(levelname)-8s %(process)-6d %(funcName)-18s %(message)s', '%Y-%m-%d %H:%M:%S'))
+log_handler.setFormatter(
+    logging.Formatter(
+        '[%(asctime)s] %(levelname)-8s %(process)-6d %(funcName)-18s %(message)s',
+        '%Y-%m-%d %H:%M:%S'))
 # do not propagate bridge messages to the root logger
 logger.propagate = False
 logger.addHandler(log_handler)
@@ -49,6 +52,7 @@ bridge_cluster_config_changes = {
     }
 }
 
+
 class JSAdapter:
 
     def __init__(self, config):
@@ -59,10 +63,15 @@ class JSAdapter:
     def js_call(self, args, timeout):
         logger.info(' '.join(args))
         try:
-            res = subprocess.check_output(args, timeout=timeout, stderr=subprocess.STDOUT, cwd=self.cli_dir).decode('ascii').strip()
+            res = subprocess.check_output(
+                args,
+                timeout=timeout,
+                stderr=subprocess.STDOUT,
+                cwd=self.cli_dir).decode('ascii').strip()
             return res
         except subprocess.CalledProcessError as e:
-            logger.error('js call failed, exit code %d, msg: %s' % (e.returncode, e.output))
+            logger.error('js call failed, exit code %d, msg: %s' %
+                         (e.returncode, e.output))
             assert False
 
     def js_call_cli(self, args, timeout=3):
@@ -82,7 +91,10 @@ class JSAdapter:
             args = [args]
         args = ['node', 'index.js', 'start'] + args + ['--daemon', 'false']
         logger.info(' '.join(args))
-        service = subprocess.Popen(args, stdout=stdout, stderr=stderr, cwd=self.cli_dir)
+        service = subprocess.Popen(args,
+                                   stdout=stdout,
+                                   stderr=stderr,
+                                   cwd=self.cli_dir)
         # TODO ping and wait until service really starts
         time.sleep(5)
         return service
@@ -104,27 +116,47 @@ class BridgeUser(object):
 #
 # 10000000000000000000000000000 = 1000000000 tokens
 billion_tokens = 10000000000000000000000000000
-bridge_master_account = BridgeUser('bridge_master_account', '0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501200', "ed25519:LXTdSRpvkKzz44bxuW7H6sZJbKTCD42rABwAPhXGStJmNDZU22VmDp6QwqBvkb2MBq5sqZzUjD1CmWWJsagUib2", "ed25519:nANzoQA6Ms8KLr2Tz6e67SWQBr9zhF1wH6GuZrncfxC")
-alice = BridgeUser('alice', '0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501201', "ed25519:44zgjKVsfQUdKZPx8QqBoiMWLXDUsnpKwW1j6DBtSQDfYBuZxgGZMWZbj7WfkA1sgncZahqx95GdvTJYg9EurkiK", "ed25519:GNs8KmGWwq1BUfXF8QMCGzBrxESkN7qCNd1Pw1Gdp2po")
-bob = BridgeUser('bob', '0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501202', "ed25519:2Hgngtr9BRTKuV7qwCpzBoHB5y9KCQZ6VLtLtM92rmDLUFZEPrPnU6BA4tGTt7Aog4ggF6diRU6rWWk7DM8S4V2g", "ed25519:BgxhfV9Ur7sacijNtcECXDFqDMvVfzGz8Psn7zATVQCY")
-carol = BridgeUser('carol', '0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501203', "ed25519:4N89ZhJFLMoijh4ShPoiHGndv61J1k5P75giW9gsDDsXKCcNEnwbNGmjZHWrrV1rb44Km7AUdowhhrSPt4fujXih", "ed25519:CDo1oshUCvobiaUFmHJYD4yBYDutwdQYxHAXLGRG5LXs")
+bridge_master_account = BridgeUser(
+    'bridge_master_account',
+    '0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501200',
+    "ed25519:LXTdSRpvkKzz44bxuW7H6sZJbKTCD42rABwAPhXGStJmNDZU22VmDp6QwqBvkb2MBq5sqZzUjD1CmWWJsagUib2",
+    "ed25519:nANzoQA6Ms8KLr2Tz6e67SWQBr9zhF1wH6GuZrncfxC")
+alice = BridgeUser(
+    'alice',
+    '0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501201',
+    "ed25519:44zgjKVsfQUdKZPx8QqBoiMWLXDUsnpKwW1j6DBtSQDfYBuZxgGZMWZbj7WfkA1sgncZahqx95GdvTJYg9EurkiK",
+    "ed25519:GNs8KmGWwq1BUfXF8QMCGzBrxESkN7qCNd1Pw1Gdp2po")
+bob = BridgeUser(
+    'bob', '0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501202',
+    "ed25519:2Hgngtr9BRTKuV7qwCpzBoHB5y9KCQZ6VLtLtM92rmDLUFZEPrPnU6BA4tGTt7Aog4ggF6diRU6rWWk7DM8S4V2g",
+    "ed25519:BgxhfV9Ur7sacijNtcECXDFqDMvVfzGz8Psn7zATVQCY")
+carol = BridgeUser(
+    'carol',
+    '0x2bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501203',
+    "ed25519:4N89ZhJFLMoijh4ShPoiHGndv61J1k5P75giW9gsDDsXKCcNEnwbNGmjZHWrrV1rb44Km7AUdowhhrSPt4fujXih",
+    "ed25519:CDo1oshUCvobiaUFmHJYD4yBYDutwdQYxHAXLGRG5LXs")
+
 
 class BridgeTxDirection(Enum):
     ETH2NEAR = 0,
     NEAR2ETH = 1
 
+
 class BridgeTx(object):
 
-    def __init__(self,
-                 direction,
-                 sender,
-                 receiver,
-                 amount,
-                 token_name='erc20',
-                 near_token_factory_id='neartokenfactory',
-                 near_client_account_id='rainbow_bridge_eth_on_near_client',
-                 near_token_account_id='7cc4b1851c35959d34e635a470f6b5c43ba3c9c9.neartokenfactory'):
-        self.id = ''.join(random.choices(string.ascii_uppercase + string.digits, k=8))
+    def __init__(
+        self,
+        direction,
+        sender,
+        receiver,
+        amount,
+        token_name='erc20',
+        near_token_factory_id='neartokenfactory',
+        near_client_account_id='rainbow_bridge_eth_on_near_client',
+        near_token_account_id='7cc4b1851c35959d34e635a470f6b5c43ba3c9c9.neartokenfactory'
+    ):
+        self.id = ''.join(
+            random.choices(string.ascii_uppercase + string.digits, k=8))
         self.direction = direction
         self.sender = sender
         self.receiver = receiver
@@ -135,6 +167,7 @@ class BridgeTx(object):
         self.near_token_account_id = near_token_account_id
         # for custom fields
         self.custom = dict()
+
 
 def atexit_cleanup(obj):
     logger.info("Cleaning %s on script exit" % (obj.__class__.__name__))
@@ -175,7 +208,9 @@ class Cleanable(object):
                 self.stderr.close()
             self.kill()
         except BaseException:
-            logger.error('Kill %s failed on cleanup', type(self).__name__, exc_info=sys.exc_info())
+            logger.error('Kill %s failed on cleanup',
+                         type(self).__name__,
+                         exc_info=sys.exc_info())
 
     def restart(self):
         assert not self.cleaned
@@ -201,32 +236,22 @@ class GanacheNode(Cleanable):
     def start(self):
         ganache_bin = os.path.join(self.bridge_dir, self.config['ganache_bin'])
         self.stdout = open(
-            os.path.join(
-                self.config_dir,
-                'logs/ganache/out.log'),
-            'w')
+            os.path.join(self.config_dir, 'logs/ganache/out.log'), 'w')
         self.stderr = open(
-            os.path.join(
-                self.config_dir,
-                'logs/ganache/err.log'),
-            'w')
+            os.path.join(self.config_dir, 'logs/ganache/err.log'), 'w')
         # TODO set params
-        self.pid.value = subprocess.Popen(
-            [
-                ganache_bin,
-                '--port',
-                '9545',
-                '--blockTime',
-                str(self.config['ganache_block_prod_time']),
-                '--gasLimit',
-                '10000000',
-                '--account="%s,%d"' % (bridge_master_account.eth_secret_key, billion_tokens),
-                '--account="%s,%d"' % (alice.eth_secret_key, billion_tokens),
-                '--account="%s,%d"' % (bob.eth_secret_key, billion_tokens),
-                '--account="%s,%d"' % (carol.eth_secret_key, billion_tokens)
-            ],
-            stdout=self.stdout,
-            stderr=self.stderr).pid
+        self.pid.value = subprocess.Popen([
+            ganache_bin, '--port', '9545', '--blockTime',
+            str(self.config['ganache_block_prod_time']), '--gasLimit',
+            '10000000',
+            '--account="%s,%d"' %
+            (bridge_master_account.eth_secret_key, billion_tokens),
+            '--account="%s,%d"' % (alice.eth_secret_key, billion_tokens),
+            '--account="%s,%d"' % (bob.eth_secret_key, billion_tokens),
+            '--account="%s,%d"' % (carol.eth_secret_key, billion_tokens)
+        ],
+                                          stdout=self.stdout,
+                                          stderr=self.stderr).pid
         if self.pid.value == 0:
             logger.error('Cannot start ganache')
             assert False
@@ -237,20 +262,14 @@ class Near2EthBlockRelay(Cleanable):
     def __init__(self, config):
         super(Near2EthBlockRelay, self).__init__(config)
 
-    def start(
-            self,
-            eth_master_secret_key=bridge_master_account.eth_secret_key):
+    def start(self, eth_master_secret_key=bridge_master_account.eth_secret_key):
         self.stdout = open(
-            os.path.join(
-                self.config_dir,
-                'logs/near2eth-relay/out.log'),
-            'a')
+            os.path.join(self.config_dir, 'logs/near2eth-relay/out.log'), 'a')
         self.stderr = open(
-            os.path.join(
-                self.config_dir,
-                'logs/near2eth-relay/err.log'),
-            'a')
-        self.pid.value = self.adapter.js_start_service(['near2eth-relay', '--eth-master-sk', eth_master_secret_key], self.stdout, self.stderr).pid
+            os.path.join(self.config_dir, 'logs/near2eth-relay/err.log'), 'a')
+        self.pid.value = self.adapter.js_start_service(
+            ['near2eth-relay', '--eth-master-sk', eth_master_secret_key],
+            self.stdout, self.stderr).pid
         if self.pid.value == 0:
             logger.error('Cannot start Near2EthBlockRelay')
             assert False
@@ -263,16 +282,12 @@ class Eth2NearBlockRelay(Cleanable):
 
     def start(self):
         self.stdout = open(
-            os.path.join(
-                self.config_dir,
-                'logs/eth2near-relay/out.log'),
-            'a')
+            os.path.join(self.config_dir, 'logs/eth2near-relay/out.log'), 'a')
         self.stderr = open(
-            os.path.join(
-                self.config_dir,
-                'logs/eth2near-relay/err.log'),
-            'a')
-        self.pid.value = self.adapter.js_start_service('eth2near-relay', self.stdout, self.stderr).pid
+            os.path.join(self.config_dir, 'logs/eth2near-relay/err.log'), 'a')
+        self.pid.value = self.adapter.js_start_service('eth2near-relay',
+                                                       self.stdout,
+                                                       self.stderr).pid
         if self.pid.value == 0:
             logger.error('Cannot start Eth2NearBlockRelay')
             assert False
@@ -289,7 +304,8 @@ def assert_success(message):
         # empty message is considered valid
         return
     message = message.strip().split('\n')[-1].strip().split(' ')
-    if not (message[0] in ('Deployed', 'Done') or message[-1] in ('deployed', 'initialized')):
+    if not (message[0] in ('Deployed', 'Done') or
+            message[-1] in ('deployed', 'initialized')):
         logger.error(message)
         assert False
 
@@ -318,8 +334,8 @@ class RainbowBridge:
         # TODO resolve
         # This hack is for NayDuck
         os.system(
-            'wget -q https://raw.githubusercontent.com/near/nearcore/6cb489aee566b85091339d90c40b7517bdfbd2f2/pytest/lib/bridge_helpers/write_config.js -P %s' %
-            self.bridge_dir)
+            'wget -q https://raw.githubusercontent.com/near/nearcore/6cb489aee566b85091339d90c40b7517bdfbd2f2/pytest/lib/bridge_helpers/write_config.js -P %s'
+            % self.bridge_dir)
 
         if os.path.exists(self.config_dir):
             assert os.path.isdir(self.config_dir)
@@ -327,16 +343,16 @@ class RainbowBridge:
         logs_dir = os.path.join(self.config_dir, 'logs')
         os.makedirs(logs_dir)
         for service in [
-            'ganache',
-            'near2eth-relay',
-            'eth2near-relay',
-                'watchdog']:
+                'ganache', 'near2eth-relay', 'eth2near-relay', 'watchdog'
+        ]:
             os.mkdir(os.path.join(logs_dir, service))
             (Path(logs_dir) / service / 'err.log').touch()
             (Path(logs_dir) / service / 'out.log').touch()
 
         logger.info('Running write_config.js...')
-        assert_success(subprocess.check_output(['node', 'write_config.js'], cwd=self.bridge_dir))
+        assert_success(
+            subprocess.check_output(['node', 'write_config.js'],
+                                    cwd=self.bridge_dir))
         logger.info('Setting up users\' addresses...')
         for user in [bridge_master_account, alice, bob, carol]:
             user.eth_address = self.get_eth_address(user)
@@ -346,15 +362,13 @@ class RainbowBridge:
     @retry(wait_exponential_multiplier=1.2, wait_exponential_max=10000)
     def create_account(self, user, node):
         status = node.get_status(check_storage=False)
-        h = base58.b58decode(status['sync_info']['latest_block_hash'].encode('utf8'))
-        nonce = node.get_nonce_for_pk(node.signer_key.account_id, node.signer_key.pk)
+        h = base58.b58decode(
+            status['sync_info']['latest_block_hash'].encode('utf8'))
+        nonce = node.get_nonce_for_pk(node.signer_key.account_id,
+                                      node.signer_key.pk)
         create_account_tx = sign_create_account_with_full_access_key_and_balance_tx(
-                node.signer_key,
-                user.near_account_name,
-                user.near_signer_key,
-                billion_tokens // 10,
-                nonce + 1,
-                h)
+            node.signer_key, user.near_account_name, user.near_signer_key,
+            billion_tokens // 10, nonce + 1, h)
         res = node.send_tx(create_account_tx)['result']
         while True:
             try:
@@ -381,28 +395,31 @@ class RainbowBridge:
                  str(self.config['bridge_repo']), str(self.bridge_dir)))
         assert_success(subprocess.check_output(['yarn'], cwd=self.bridge_dir))
         ethash_dir = os.path.join(self.bridge_dir, 'eth2near/ethashproof')
-        assert_success(subprocess.check_output(['/bin/sh', 'build.sh'], cwd=ethash_dir))
+        assert_success(
+            subprocess.check_output(['/bin/sh', 'build.sh'], cwd=ethash_dir))
         # Make sure that ethash is assembled
         assert os.path.exists(os.path.join(ethash_dir, 'cmd/relayer/relayer'))
 
     def init_near_contracts(self):
-        assert_success(self.adapter.js_call_cli('init-near-contracts', timeout=60))
+        assert_success(
+            self.adapter.js_call_cli('init-near-contracts', timeout=60))
 
     def init_eth_contracts(self):
         assert_success(self.adapter.js_call_cli('init-eth-ed25519', timeout=60))
-        assert_success(self.adapter.js_call_cli([
-            'init-eth-client',
-            '--eth-client-lock-eth-amount',
-            '1000000000000000000',
-            '--eth-client-lock-duration',
-            '30'], timeout=60))
+        assert_success(
+            self.adapter.js_call_cli([
+                'init-eth-client', '--eth-client-lock-eth-amount',
+                '1000000000000000000', '--eth-client-lock-duration', '30'
+            ],
+                                     timeout=60))
         assert_success(self.adapter.js_call_cli('init-eth-prover', timeout=60))
         assert_success(self.adapter.js_call_cli('init-eth-erc20', timeout=60))
         assert_success(self.adapter.js_call_cli('init-eth-locker', timeout=60))
 
     @retry(stop_max_attempt_number=10, wait_fixed=1000)
     def init_near_token_factory(self):
-        assert_success(self.adapter.js_call_cli('init-near-token-factory', timeout=60))
+        assert_success(
+            self.adapter.js_call_cli('init-near-token-factory', timeout=60))
 
     def start_eth2near_block_relay(self):
         self.eth2near_block_relay = Eth2NearBlockRelay(self.config)
@@ -412,7 +429,8 @@ class RainbowBridge:
         self.near2eth_block_relay = Near2EthBlockRelay(self.config)
         self.near2eth_block_relay.start()
 
-    def update_expected_balances(self, sender, receiver, send_token_name, receive_token_name, amount):
+    def update_expected_balances(self, sender, receiver, send_token_name,
+                                 receive_token_name, amount):
         # The only known reason of not updating is insufficient balance of sender
         if sender.tokens_expected[send_token_name] >= amount:
             sender.tokens_expected[send_token_name] -= amount
@@ -420,7 +438,13 @@ class RainbowBridge:
                 receiver.tokens_expected[receive_token_name] = 0
             receiver.tokens_expected[receive_token_name] += amount
 
-    def transfer_tx(self, tx, withdraw_func=None, get_proof_func=None, wait_func=None, deposit_func=None, node=None):
+    def transfer_tx(self,
+                    tx,
+                    withdraw_func=None,
+                    get_proof_func=None,
+                    wait_func=None,
+                    deposit_func=None,
+                    node=None):
         if not node:
             node = self.node
 
@@ -433,7 +457,8 @@ class RainbowBridge:
                 wait_func = eth2near_wait
             if not deposit_func:
                 deposit_func = eth2near_deposit
-            self.update_expected_balances(tx.sender, tx.receiver, tx.token_name, 'near-' + tx.token_name, tx.amount)
+            self.update_expected_balances(tx.sender, tx.receiver, tx.token_name,
+                                          'near-' + tx.token_name, tx.amount)
         else:
             assert tx.direction == BridgeTxDirection.NEAR2ETH
             if not withdraw_func:
@@ -444,45 +469,71 @@ class RainbowBridge:
                 wait_func = near2eth_wait
             if not deposit_func:
                 deposit_func = near2eth_deposit
-            self.update_expected_balances(tx.sender, tx.receiver, 'near-' + tx.token_name, tx.token_name, tx.amount)
+            self.update_expected_balances(tx.sender, tx.receiver,
+                                          'near-' + tx.token_name,
+                                          tx.token_name, tx.amount)
 
-        p = Process(target=transfer_routine, args=(tx, deposit_func, get_proof_func, wait_func, withdraw_func, node, self.adapter))
+        p = Process(target=transfer_routine,
+                    args=(tx, deposit_func, get_proof_func, wait_func,
+                          withdraw_func, node, self.adapter))
         p.start()
 
         return p
 
-    def transfer_eth2near(self, sender, amount, receiver=None, token_name='erc20', near_token_factory_id='neartokenfactory', near_client_account_id='rainbow_bridge_eth_on_near_client', near_token_account_id='7cc4b1851c35959d34e635a470f6b5c43ba3c9c9.neartokenfactory', withdraw_func=None, get_proof_func=None, wait_func=None, deposit_func=None, node=None):
+    def transfer_eth2near(
+            self,
+            sender,
+            amount,
+            receiver=None,
+            token_name='erc20',
+            near_token_factory_id='neartokenfactory',
+            near_client_account_id='rainbow_bridge_eth_on_near_client',
+            near_token_account_id='7cc4b1851c35959d34e635a470f6b5c43ba3c9c9.neartokenfactory',
+            withdraw_func=None,
+            get_proof_func=None,
+            wait_func=None,
+            deposit_func=None,
+            node=None):
         if not receiver:
             receiver = sender
         assert sender.eth_address
-        tx = BridgeTx(BridgeTxDirection.ETH2NEAR,
-                      sender,
-                      receiver,
-                      amount,
-                      token_name,
-                      near_token_factory_id,
-                      near_client_account_id,
+        tx = BridgeTx(BridgeTxDirection.ETH2NEAR, sender, receiver, amount,
+                      token_name, near_token_factory_id, near_client_account_id,
                       near_token_account_id)
-        return self.transfer_tx(tx, deposit_func, get_proof_func, wait_func, withdraw_func, node)
+        return self.transfer_tx(tx, deposit_func, get_proof_func, wait_func,
+                                withdraw_func, node)
 
-    def transfer_near2eth(self, sender, amount, receiver=None, token_name='erc20', near_token_factory_id='neartokenfactory', near_client_account_id='rainbow_bridge_eth_on_near_client', near_token_account_id='7cc4b1851c35959d34e635a470f6b5c43ba3c9c9.neartokenfactory', withdraw_func=None, get_proof_func=None, wait_func=None, deposit_func=None, node=None):
+    def transfer_near2eth(
+            self,
+            sender,
+            amount,
+            receiver=None,
+            token_name='erc20',
+            near_token_factory_id='neartokenfactory',
+            near_client_account_id='rainbow_bridge_eth_on_near_client',
+            near_token_account_id='7cc4b1851c35959d34e635a470f6b5c43ba3c9c9.neartokenfactory',
+            withdraw_func=None,
+            get_proof_func=None,
+            wait_func=None,
+            deposit_func=None,
+            node=None):
         if not receiver:
             receiver = sender
         assert receiver.eth_address
-        tx = BridgeTx(BridgeTxDirection.NEAR2ETH,
-                      sender,
-                      receiver,
-                      amount,
-                      token_name,
-                      near_token_factory_id,
-                      near_client_account_id,
+        tx = BridgeTx(BridgeTxDirection.NEAR2ETH, sender, receiver, amount,
+                      token_name, near_token_factory_id, near_client_account_id,
                       near_token_account_id)
-        return self.transfer_tx(tx, deposit_func, get_proof_func, wait_func, withdraw_func, node)
+        return self.transfer_tx(tx, deposit_func, get_proof_func, wait_func,
+                                withdraw_func, node)
 
     def mint_erc20_tokens(self, user, amount, token_name='erc20'):
         assert user.eth_address
         # js parses 0x as number, not as string
-        res = self.adapter.js_call_testing(['mint-erc20-tokens', user.eth_address[2:], str(amount), token_name], timeout=15)
+        res = self.adapter.js_call_testing([
+            'mint-erc20-tokens', user.eth_address[2:],
+            str(amount), token_name
+        ],
+                                           timeout=15)
         res = res.strip().split('\n')
         if res[-1] != 'OK':
             logger.error('Mint failed, %s' % (res))
@@ -493,14 +544,17 @@ class RainbowBridge:
     def get_eth_address(self, user):
         if not user.eth_address:
             # js parses 0x as number, not as string
-            user.eth_address = self.adapter.js_call_testing(['get-account-address', user.eth_secret_key[2:]])
+            user.eth_address = self.adapter.js_call_testing(
+                ['get-account-address', user.eth_secret_key[2:]])
         return user.eth_address
 
     @retry(wait_exponential_multiplier=1.2, wait_exponential_max=10000)
     def get_eth_balance(self, user, token_name='erc20'):
         assert user.eth_address
         # js parses 0x as number, not as string
-        return int(self.adapter.js_call_testing(['get-erc20-balance', user.eth_address[2:], token_name]))
+        return int(
+            self.adapter.js_call_testing(
+                ['get-erc20-balance', user.eth_address[2:], token_name]))
 
     @retry(wait_exponential_multiplier=1.2, wait_exponential_max=10000)
     def get_near_balance(self, user, token_account_id=None, node=None):
@@ -509,14 +563,13 @@ class RainbowBridge:
         if not token_account_id:
             # use default token_account
             token_account_id = '7cc4b1851c35959d34e635a470f6b5c43ba3c9c9.neartokenfactory'
-        res = node.call_function(
-            token_account_id,
-            'get_balance',
-            base64.b64encode(
-                bytes(
-                    '{"owner_id": "' + user.near_account_name + '"}',
-                    encoding='utf8')).decode("ascii"),
-            timeout=10)
+        res = node.call_function(token_account_id,
+                                 'get_balance',
+                                 base64.b64encode(
+                                     bytes('{"owner_id": "' +
+                                           user.near_account_name + '"}',
+                                           encoding='utf8')).decode("ascii"),
+                                 timeout=10)
         res = int("".join(map(chr, res['result']['result']))[1:-1])
         return res
 
@@ -530,7 +583,9 @@ class RainbowBridge:
             else:
                 # This is ETH side token
                 actual_amount = self.get_eth_balance(user, token_name)
-            logger.info('%s\'s expected amount of %s token is %d, actual amount is %d' % (user.name, token_name, amount, actual_amount))
+            logger.info(
+                '%s\'s expected amount of %s token is %d, actual amount is %d' %
+                (user.name, token_name, amount, actual_amount))
             assert actual_amount == amount
 
 
@@ -543,34 +598,56 @@ def retry_func(attempt, delay):
         logging.getLogger('bridge').setLevel(logging.DEBUG)
     return delay
 
-@retry(stop_max_attempt_number=MAX_ATTEMPTS, wait_random_min=1000, wait_random_max=2500, wait_func=retry_func)
+
+@retry(stop_max_attempt_number=MAX_ATTEMPTS,
+       wait_random_min=1000,
+       wait_random_max=2500,
+       wait_func=retry_func)
 def eth2near_withdraw(tx, node, adapter):
     logger.info('TX %s, WITHDRAW PHASE' % (tx.id))
 
-    approve = adapter.js_call_testing(['eth-to-near-approve', tx.sender.eth_address[2:], str(tx.amount), tx.token_name], timeout=15)
+    approve = adapter.js_call_testing([
+        'eth-to-near-approve', tx.sender.eth_address[2:],
+        str(tx.amount), tx.token_name
+    ],
+                                      timeout=15)
     logger.debug('APPROVE: %s' % (approve))
     approve = approve.strip().split('\n')
     assert approve[-1] == 'OK'
     # This tx is critical.
     # Executing it successfully without getting proper answer will lead any test to failing.
-    locker = adapter.js_call_testing(['eth-to-near-lock', tx.sender.eth_address[2:], tx.receiver.near_account_name, str(tx.amount), tx.token_name], timeout=45)
+    locker = adapter.js_call_testing([
+        'eth-to-near-lock', tx.sender.eth_address[2:],
+        tx.receiver.near_account_name,
+        str(tx.amount), tx.token_name
+    ],
+                                     timeout=45)
     logger.debug('LOCKER: %s' % (locker))
     locker = locker.strip().split('\n')
     assert locker[-2] == 'OK'
     return locker[-1]
 
-@retry(stop_max_attempt_number=MAX_ATTEMPTS, wait_random_min=1000, wait_random_max=2500, wait_func=retry_func)
+
+@retry(stop_max_attempt_number=MAX_ATTEMPTS,
+       wait_random_min=1000,
+       wait_random_max=2500,
+       wait_func=retry_func)
 def eth2near_get_proof(tx, withdraw_ticket, node, adapter):
     logger.info('TX %s, GETTING PROOF PHASE' % (tx.id))
 
-    event = adapter.js_call_cli(['eth-to-near-find-proof', withdraw_ticket], timeout=15)
+    event = adapter.js_call_cli(['eth-to-near-find-proof', withdraw_ticket],
+                                timeout=15)
     logger.debug('EVENT: %s' % (event))
     event = event.strip().split('\n')
     event_parsed = json.loads(event[-1])
     logger.debug('EVENT PARSED: %s' % (event_parsed))
     return event_parsed
 
-@retry(stop_max_attempt_number=MAX_ATTEMPTS, wait_random_min=1000, wait_random_max=2500, wait_func=retry_func)
+
+@retry(stop_max_attempt_number=MAX_ATTEMPTS,
+       wait_random_min=1000,
+       wait_random_max=2500,
+       wait_func=retry_func)
 def eth2near_wait(tx, proof_ticket, node, adapter):
     logger.info('TX %s, WAITING PHASE' % (tx.id))
 
@@ -578,13 +655,14 @@ def eth2near_wait(tx, proof_ticket, node, adapter):
     logger.debug('BLOCK NUMBER: %s' % (str(block_number)))
     serializer = BinarySerializer(None)
     serializer.serialize_field(block_number, 'u64')
-    logger.debug('BLOCK NUMBER SERIALIZED: %s' % (base64.b64encode(bytes(serializer.array)).decode("ascii")))
+    logger.debug('BLOCK NUMBER SERIALIZED: %s' %
+                 (base64.b64encode(bytes(serializer.array)).decode("ascii")))
     while True:
-        res = node.call_function(
-            tx.near_client_account_id,
-            'block_hash_safe',
-            base64.b64encode(bytes(serializer.array)).decode("ascii"),
-            timeout=15)
+        res = node.call_function(tx.near_client_account_id,
+                                 'block_hash_safe',
+                                 base64.b64encode(bytes(
+                                     serializer.array)).decode("ascii"),
+                                 timeout=15)
         logger.info('BLOCK HASH SAFE CALL: %s' % (res))
         if 'result' in res:
             if res['result']['result'] == [0]:
@@ -592,7 +670,11 @@ def eth2near_wait(tx, proof_ticket, node, adapter):
             else:
                 return proof_ticket
 
-@retry(stop_max_attempt_number=MAX_ATTEMPTS, wait_random_min=1000, wait_random_max=2500, wait_func=retry_func)
+
+@retry(stop_max_attempt_number=MAX_ATTEMPTS,
+       wait_random_min=1000,
+       wait_random_max=2500,
+       wait_func=retry_func)
 def eth2near_deposit(tx, wait_ticket, node, adapter):
     logger.info('TX %s, DEPOSIT PHASE' % (tx.id))
 
@@ -607,22 +689,22 @@ def eth2near_deposit(tx, wait_ticket, node, adapter):
     proof.header_data = proof_parsed['header_data']
     proof.proof = proof_parsed['proof']
     proof_ser = serializer.serialize(proof)
-    logger.debug('PROOF SERIALIZED: %s' % (base64.b64encode(bytes(proof_ser)).decode("ascii")))
+    logger.debug('PROOF SERIALIZED: %s' %
+                 (base64.b64encode(bytes(proof_ser)).decode("ascii")))
     status = node.get_status(check_storage=False)
     logger.debug('STATUS: %s' % (status))
-    h = base58.b58decode(status['sync_info']['latest_block_hash'].encode('utf8'))
-    logger.debug('HASH: %s %s' % (str(status['sync_info']['latest_block_hash']), str(h)))
-    nonce = node.get_nonce_for_pk(tx.sender.near_account_name, tx.sender.near_signer_key.pk)
+    h = base58.b58decode(
+        status['sync_info']['latest_block_hash'].encode('utf8'))
+    logger.debug('HASH: %s %s' %
+                 (str(status['sync_info']['latest_block_hash']), str(h)))
+    nonce = node.get_nonce_for_pk(tx.sender.near_account_name,
+                                  tx.sender.near_signer_key.pk)
     logger.debug('NONCE: %s' % (nonce))
-    deposit_tx = sign_function_call_tx(
-        tx.sender.near_signer_key,
-        tx.near_token_factory_id,
-        'deposit',
-        bytes(proof_ser),
-        300000000000000,
-        100000000000000000000*600,
-        nonce + 1,
-        h)
+    deposit_tx = sign_function_call_tx(tx.sender.near_signer_key,
+                                       tx.near_token_factory_id, 'deposit',
+                                       bytes(proof_ser), 300000000000000,
+                                       100000000000000000000 * 600, nonce + 1,
+                                       h)
     logger.debug('DEPOSIT_TX: %s' % (deposit_tx))
     res = node.send_tx(deposit_tx)
     logger.debug('DEPOSIT_TX RES: %s' % (res))
@@ -640,15 +722,22 @@ def eth2near_deposit(tx, wait_ticket, node, adapter):
     logger.info('CANNOT GET DEPOSIT TX %s' % (deposited))
     assert False
 
-@retry(stop_max_attempt_number=MAX_ATTEMPTS, wait_random_min=1000, wait_random_max=2500, wait_func=retry_func)
+
+@retry(stop_max_attempt_number=MAX_ATTEMPTS,
+       wait_random_min=1000,
+       wait_random_max=2500,
+       wait_func=retry_func)
 def near2eth_withdraw(tx, node, adapter):
     logger.info('TX %s, WITHDRAW PHASE' % (tx.id))
 
     status = node.get_status(check_storage=False)
     logger.debug('STATUS: %s' % (status))
-    h = base58.b58decode(status['sync_info']['latest_block_hash'].encode('utf8'))
-    logger.debug('HASH: %s %s' % (str(status['sync_info']['latest_block_hash']), str(h)))
-    nonce = node.get_nonce_for_pk(tx.sender.near_account_name, tx.sender.near_signer_key.pk)
+    h = base58.b58decode(
+        status['sync_info']['latest_block_hash'].encode('utf8'))
+    logger.debug('HASH: %s %s' %
+                 (str(status['sync_info']['latest_block_hash']), str(h)))
+    nonce = node.get_nonce_for_pk(tx.sender.near_account_name,
+                                  tx.sender.near_signer_key.pk)
     logger.debug('NONCE: %d' % (nonce))
     receiver_address = tx.receiver.eth_address
     if receiver_address.startswith('0x'):
@@ -660,26 +749,27 @@ def near2eth_withdraw(tx, node, adapter):
     nonce_increment = os.getpid() % 1000 + 1
 
     withdraw_tx = sign_function_call_tx(
-        tx.sender.near_signer_key,
-        tx.near_token_account_id,
-        'withdraw',
-        bytes('{"amount": "' + str(tx.amount) + '", "recipient": "' + receiver_address + '"}', encoding='utf8'),
-        300000000000000,
-        0,
-        nonce + nonce_increment,
-        h)
+        tx.sender.near_signer_key, tx.near_token_account_id, 'withdraw',
+        bytes('{"amount": "' + str(tx.amount) + '", "recipient": "' +
+              receiver_address + '"}',
+              encoding='utf8'), 300000000000000, 0, nonce + nonce_increment, h)
     logger.debug('WITHDRAW_TX: %s' % (withdraw_tx))
     withdraw = node.send_tx(withdraw_tx)
     logger.debug('WITHDRAW_TX SEND: %s' % (withdraw))
     return withdraw['result']
 
-@retry(stop_max_attempt_number=MAX_ATTEMPTS, wait_random_min=1000, wait_random_max=2500, wait_func=retry_func)
+
+@retry(stop_max_attempt_number=MAX_ATTEMPTS,
+       wait_random_min=1000,
+       wait_random_max=2500,
+       wait_func=retry_func)
 def near2eth_get_proof(tx, withdraw_ticket, node, adapter):
     logger.info('TX %s, GETTING PROOF PHASE' % (tx.id))
 
     while True:
         try:
-            withdraw_res = node.get_tx(withdraw_ticket, tx.near_token_account_id)['result']
+            withdraw_res = node.get_tx(withdraw_ticket,
+                                       tx.near_token_account_id)['result']
             logger.debug('WITHDRAW_TX RES: %s' % (str(withdraw_res)))
             break
         except:
@@ -698,7 +788,11 @@ def near2eth_get_proof(tx, withdraw_ticket, node, adapter):
             return (receipt_id, block_hash)
     logger.debug('NO PROOF FOUND')
 
-@retry(stop_max_attempt_number=MAX_ATTEMPTS, wait_random_min=1000, wait_random_max=2500, wait_func=retry_func)
+
+@retry(stop_max_attempt_number=MAX_ATTEMPTS,
+       wait_random_min=1000,
+       wait_random_max=2500,
+       wait_func=retry_func)
 def near2eth_wait(tx, proof_ticket, node, adapter):
     logger.info('TX %s, WAITING PHASE' % (tx.id))
 
@@ -717,32 +811,56 @@ def near2eth_wait(tx, proof_ticket, node, adapter):
             break
         time.sleep(3)
     while True:
-        [eth_client_block_height, eth_client_block_hash] = adapter.js_call_testing(['get-client-block-height-hash']).strip().split()
+        [eth_client_block_height, eth_client_block_hash
+        ] = adapter.js_call_testing(['get-client-block-height-hash'
+                                    ]).strip().split()
         eth_client_block_height = int(eth_client_block_height)
-        logger.info('ETH BLOCK HEIGHT: %d, HASH: %s' % (eth_client_block_height, str(eth_client_block_hash)))
+        logger.info('ETH BLOCK HEIGHT: %d, HASH: %s' %
+                    (eth_client_block_height, str(eth_client_block_hash)))
         if eth_client_block_height > height:
             return (receipt_id, eth_client_block_hash, eth_client_block_height)
         time.sleep(15 + random.randrange(10))
 
-@retry(stop_max_attempt_number=MAX_ATTEMPTS, wait_random_min=1000, wait_random_max=2500, wait_func=retry_func)
+
+@retry(stop_max_attempt_number=MAX_ATTEMPTS,
+       wait_random_min=1000,
+       wait_random_max=2500,
+       wait_func=retry_func)
 def near2eth_deposit(tx, wait_ticket, node, adapter):
     logger.info('TX %s, DEPOSIT PHASE' % (tx.id))
 
     (receipt_id, eth_client_block_hash, eth_client_block_height) = wait_ticket
-    logger.debug('receipt_id: %s, eth_client_block_hash: %s, eth_client_block_height: %d' % (receipt_id, eth_client_block_hash, eth_client_block_height))
-    proof = node.json_rpc('light_client_proof', {"type": "receipt", "receipt_id": receipt_id, "receiver_id": tx.sender.near_account_name, "light_client_head": eth_client_block_hash}, timeout=15)
+    logger.debug(
+        'receipt_id: %s, eth_client_block_hash: %s, eth_client_block_height: %d'
+        % (receipt_id, eth_client_block_hash, eth_client_block_height))
+    proof = node.json_rpc('light_client_proof', {
+        "type": "receipt",
+        "receipt_id": receipt_id,
+        "receiver_id": tx.sender.near_account_name,
+        "light_client_head": eth_client_block_hash
+    },
+                          timeout=15)
     logger.debug('PROOF: %s' % (proof))
     light_client_proof = json.dumps(proof['result'], separators=(',', ':'))
     logger.debug('PROOF TO SEND: %s' % (proof))
-    unlock = adapter.js_call_testing(['near-to-eth-unlock', str(eth_client_block_height), light_client_proof], timeout=45)
+    unlock = adapter.js_call_testing([
+        'near-to-eth-unlock',
+        str(eth_client_block_height), light_client_proof
+    ],
+                                     timeout=45)
     logger.debug('UNLOCK: %s' % (unlock))
     unlock = unlock.strip().split('\n')
     assert unlock[-1] == 'OK'
     logger.info('TX %s, TRANSFER SUCCESSFUL' % (tx.id))
 
-def transfer_routine(tx, deposit_func, get_proof_func, wait_func, withdraw_func, node, adapter):
+
+def transfer_routine(tx, deposit_func, get_proof_func, wait_func, withdraw_func,
+                     node, adapter):
     assert tx.sender.eth_address
-    logger.info('Tranferring tokens from %s to %s, amount %d, token name %s, direction %s' % (tx.sender.name, tx. receiver.name, tx.amount, tx.token_name, tx.direction))
+    logger.info(
+        'Tranferring tokens from %s to %s, amount %d, token name %s, direction %s'
+        % (tx.sender.name, tx.receiver.name, tx.amount, tx.token_name,
+           tx.direction))
 
     withdraw_ticket = withdraw_func(tx, node, adapter)
     proof_ticket = get_proof_func(tx, withdraw_ticket, node, adapter)

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -68,13 +68,13 @@ def nretry(fn, timeout):
 
 
 class BaseNode(object):
+
     def __init__(self):
         self._start_proxy = None
         self._proxy_local_stopped = None
         self.proxy = None
         self.store_tests = 0
         self.is_check_store = True
-
 
     def _get_command_line(self,
                           near_root,
@@ -85,15 +85,14 @@ class BaseNode(object):
         if boot_key is None:
             assert boot_node_addr is None
             return [
-                os.path.join(near_root, binary_name), "--home",
-                node_dir, "run"
+                os.path.join(near_root, binary_name), "--home", node_dir, "run"
             ]
         else:
             assert boot_node_addr is not None
             boot_key = boot_key.split(':')[1]
             return [
-                os.path.join(near_root, binary_name), "--home",
-                node_dir, "run", '--boot-nodes',
+                os.path.join(near_root, binary_name), "--home", node_dir, "run",
+                '--boot-nodes',
                 "%s@%s:%s" % (boot_key, boot_node_addr[0], boot_node_addr[1])
             ]
 
@@ -123,7 +122,8 @@ class BaseNode(object):
                              timeout=timeout)
 
     def get_status(self, check_storage=True, timeout=2):
-        r = requests.get("http://%s:%s/status" % self.rpc_addr(), timeout=timeout)
+        r = requests.get("http://%s:%s/status" % self.rpc_addr(),
+                         timeout=timeout)
         r.raise_for_status()
         status = json.loads(r.content)
         if check_storage and status['sync_info']['syncing'] == False:
@@ -139,7 +139,8 @@ class BaseNode(object):
         while True:
             block = self.get_block(hash_)
             if 'error' in block and 'data' in block[
-                    'error'] and 'DB Not Found Error: BLOCK:' in block['error']['data']:
+                    'error'] and 'DB Not Found Error: BLOCK:' in block['error'][
+                        'data']:
                 break
             elif 'result' not in block:
                 logger.info(block)
@@ -162,14 +163,20 @@ class BaseNode(object):
             "finality": finality
         })
 
-    def call_function(self, acc, method, args, finality='optimistic', timeout=2):
+    def call_function(self,
+                      acc,
+                      method,
+                      args,
+                      finality='optimistic',
+                      timeout=2):
         return self.json_rpc('query', {
             "request_type": "call_function",
             "account_id": acc,
             "method_name": method,
             "args_base64": args,
             "finality": finality
-        }, timeout=timeout)
+        },
+                             timeout=timeout)
 
     def get_access_key_list(self, acc, finality='optimistic'):
         return self.json_rpc(
@@ -209,7 +216,7 @@ class BaseNode(object):
 
     def stop_checking_store(self):
         logger.warning("Stopping checking Storage for inconsistency for %s:%s" %
-              self.addr())
+                       self.addr())
         self.is_check_store = False
 
     def check_store(self):
@@ -221,8 +228,8 @@ class BaseNode(object):
             else:
                 if res['result'] == 0:
                     logger.error(
-                        "Storage for %s:%s in inconsistent state, stopping"
-                        % self.addr())
+                        "Storage for %s:%s in inconsistent state, stopping" %
+                        self.addr())
                     self.kill()
                 self.store_tests += res['result']
 
@@ -295,17 +302,16 @@ class LocalNode(BaseNode):
         if self._start_proxy is not None:
             self._proxy_local_stopped = self._start_proxy()
 
-
     def start(self, boot_key, boot_node_addr, skip_starting_proxy=False):
         if self._proxy_local_stopped is not None:
             while self._proxy_local_stopped.value != 2:
                 logger.info(f'Waiting for previous proxy instance to close')
                 time.sleep(1)
 
-
         env = os.environ.copy()
         env["RUST_BACKTRACE"] = "1"
-        env["RUST_LOG"] = "actix_web=warn,mio=warn,tokio_util=warn,actix_server=warn,actix_http=warn," + env.get("RUST_LOG", "debug")
+        env["RUST_LOG"] = "actix_web=warn,mio=warn,tokio_util=warn,actix_server=warn,actix_http=warn," + env.get(
+            "RUST_LOG", "debug")
 
         self.stdout_name = os.path.join(self.node_dir, 'stdout')
         self.stderr_name = os.path.join(self.node_dir, 'stderr')
@@ -325,8 +331,7 @@ class LocalNode(BaseNode):
             self.wait_for_rpc(10)
         except:
             logger.error(
-                '=== failed to start node, rpc does not ready in 10 seconds'
-            )
+                '=== failed to start node, rpc does not ready in 10 seconds')
             self.stdout.close()
             self.stderr.close()
             if os.environ.get('BUILDKITE'):
@@ -483,9 +488,9 @@ chmod +x near
         return super().json_rpc(method, params, timeout=timeout)
 
     def get_status(self):
-        r = nretry(lambda: requests.get(
-            "http://%s:%s/status" % self.rpc_addr(), timeout=15),
-                           timeout=45)
+        r = nretry(lambda: requests.get("http://%s:%s/status" % self.rpc_addr(),
+                                        timeout=15),
+                   timeout=45)
         r.raise_for_status()
         return json.loads(r.content)
 
@@ -507,65 +512,72 @@ chmod +x near
 
 
 class AzureNode(BaseNode):
-        def __init__(self, ip, token, node_dir, release):
-            super(AzureNode, self).__init__()
-            self.ip = ip
-            self.token = token
-            if release:
-                self.near_root = '/datadrive/testnodes/worker/nearcore/target/release'
-            else:
-                self.near_root = '/datadrive/testnodes/worker/nearcore/target/debug'
-            self.port = 24567
-            self.rpc_port = 3030
-            self.node_dir = node_dir
-            self._upload_config_files(node_dir)
 
-        def _upload_config_files(self, node_dir):
-            post = {'ip': self.ip, 'token': self.token}
-            res = requests.post('http://40.112.59.229:5000/cleanup', json=post)
-            for f in os.listdir(node_dir):
-                if f.endswith(".json"):
-                    with open(os.path.join(node_dir, f), "r") as fl:
-                        cnt = fl.read()
-                    post = {'ip': self.ip, 'cnt': cnt, 'fl_name': f, 'token': self.token}
-                    res = requests.post('http://40.112.59.229:5000/upload', json=post)
-                    json_res = json.loads(res.text)
-                    if json_res['stderr'] != '':
-                        logger.info(json_res['stderr'])
-                        sys.exit()
-            self.validator_key = Key.from_json_file(
-                os.path.join(node_dir, "validator_key.json"))
-            self.node_key = Key.from_json_file(
-                os.path.join(node_dir, "node_key.json"))
-            self.signer_key = Key.from_json_file(
-                os.path.join(node_dir, "validator_key.json"))
+    def __init__(self, ip, token, node_dir, release):
+        super(AzureNode, self).__init__()
+        self.ip = ip
+        self.token = token
+        if release:
+            self.near_root = '/datadrive/testnodes/worker/nearcore/target/release'
+        else:
+            self.near_root = '/datadrive/testnodes/worker/nearcore/target/debug'
+        self.port = 24567
+        self.rpc_port = 3030
+        self.node_dir = node_dir
+        self._upload_config_files(node_dir)
 
-        def start(self, boot_key, boot_node_addr, skip_starting_proxy):
-            cmd = ('RUST_BACKTRACE=1 ADVERSARY_CONSENT=1 ' + ' '.join(
-                self._get_command_line(self.near_root,
-                                       '.near', boot_key, boot_node_addr)))
-            post = {'ip': self.ip, 'cmd': cmd, 'token': self.token}
-            res = requests.post('http://40.112.59.229:5000/run_cmd', json=post)
-            json_res = json.loads(res.text)
-            if json_res['stderr'] != '':
-                logger.info(json_res['stderr'])
-                sys.exit()
-            self.wait_for_rpc(timeout=30)
+    def _upload_config_files(self, node_dir):
+        post = {'ip': self.ip, 'token': self.token}
+        res = requests.post('http://40.112.59.229:5000/cleanup', json=post)
+        for f in os.listdir(node_dir):
+            if f.endswith(".json"):
+                with open(os.path.join(node_dir, f), "r") as fl:
+                    cnt = fl.read()
+                post = {
+                    'ip': self.ip,
+                    'cnt': cnt,
+                    'fl_name': f,
+                    'token': self.token
+                }
+                res = requests.post('http://40.112.59.229:5000/upload',
+                                    json=post)
+                json_res = json.loads(res.text)
+                if json_res['stderr'] != '':
+                    logger.info(json_res['stderr'])
+                    sys.exit()
+        self.validator_key = Key.from_json_file(
+            os.path.join(node_dir, "validator_key.json"))
+        self.node_key = Key.from_json_file(
+            os.path.join(node_dir, "node_key.json"))
+        self.signer_key = Key.from_json_file(
+            os.path.join(node_dir, "validator_key.json"))
 
-        def kill(self):
-            cmd = 'killall -9 neard'
-            post = {'ip': self.ip, 'cmd': cmd, 'token': self.token}
-            res = requests.post('http://40.112.59.229:5000/run_cmd', json=post)
-            json_res = json.loads(res.text)
-            if json_res['stderr'] != '':
-                logger.info(json_res['stderr'])
+    def start(self, boot_key, boot_node_addr, skip_starting_proxy):
+        cmd = ('RUST_BACKTRACE=1 ADVERSARY_CONSENT=1 ' + ' '.join(
+            self._get_command_line(self.near_root, '.near', boot_key,
+                                   boot_node_addr)))
+        post = {'ip': self.ip, 'cmd': cmd, 'token': self.token}
+        res = requests.post('http://40.112.59.229:5000/run_cmd', json=post)
+        json_res = json.loads(res.text)
+        if json_res['stderr'] != '':
+            logger.info(json_res['stderr'])
             sys.exit()
+        self.wait_for_rpc(timeout=30)
 
-        def addr(self):
-            return (self.ip, self.port)
+    def kill(self):
+        cmd = 'killall -9 neard'
+        post = {'ip': self.ip, 'cmd': cmd, 'token': self.token}
+        res = requests.post('http://40.112.59.229:5000/run_cmd', json=post)
+        json_res = json.loads(res.text)
+        if json_res['stderr'] != '':
+            logger.info(json_res['stderr'])
+        sys.exit()
 
-        def rpc_addr(self):
-            return (self.ip, self.rpc_port)
+    def addr(self):
+        return (self.ip, self.port)
+
+    def rpc_addr(self):
+        return (self.ip, self.rpc_port)
 
 
 def spin_up_node(config,
@@ -580,18 +592,18 @@ def spin_up_node(config,
                  single_node=False):
     is_local = config['local']
 
-    logger.info("Starting node %s %s" % (ordinal,
-                                   ("as BOOT NODE" if boot_addr is None else
-                                    ("with boot=%s@%s:%s" %
-                                     (boot_key, boot_addr[0], boot_addr[1])))))
+    logger.info("Starting node %s %s" %
+                (ordinal, ("as BOOT NODE" if boot_addr is None else
+                           ("with boot=%s@%s:%s" %
+                            (boot_key, boot_addr[0], boot_addr[1])))))
     if is_local:
         blacklist = [
             "127.0.0.1:%s" % (24567 + 10 + bl_ordinal)
             for bl_ordinal in blacklist
         ]
-        node = LocalNode(24567 + 10 + ordinal, 3030 + 10 + ordinal, near_root,
-                         node_dir, blacklist, config.get('binary_name'),
-                         single_node)
+        node = LocalNode(24567 + 10 + ordinal, 3030 + 10 + ordinal,
+                         near_root, node_dir, blacklist,
+                         config.get('binary_name'), single_node)
     else:
         # TODO: Figure out how to know IP address beforehand for remote deployment.
         assert len(
@@ -623,7 +635,8 @@ def init_cluster(num_nodes, num_observers, num_shards, config,
     Create cluster configuration
     """
     if 'local' not in config and 'nodes' in config:
-        logger.critical("Attempt to launch a regular test with a mocknet config")
+        logger.critical(
+            "Attempt to launch a regular test with a mocknet config")
         sys.exit(1)
 
     is_local = config['local']
@@ -631,7 +644,7 @@ def init_cluster(num_nodes, num_observers, num_shards, config,
     binary_name = config.get('binary_name', 'neard')
 
     logger.info("Creating %s cluster configuration with %s nodes" %
-          ("LOCAL" if is_local else "REMOTE", num_nodes + num_observers))
+                ("LOCAL" if is_local else "REMOTE", num_nodes + num_observers))
 
     process = subprocess.Popen([
         os.path.join(near_root, binary_name), "testnet", "--v",
@@ -733,8 +746,14 @@ def start_cluster(num_nodes,
 
     def spin_up_node_and_push(i, boot_key, boot_addr):
         single_node = (num_nodes == 1) and (num_observers == 0)
-        node = spin_up_node(config, near_root, node_dirs[i], i, boot_key,
-                            boot_addr, [], proxy, skip_starting_proxy=True,
+        node = spin_up_node(config,
+                            near_root,
+                            node_dirs[i],
+                            i,
+                            boot_key,
+                            boot_addr, [],
+                            proxy,
+                            skip_starting_proxy=True,
                             single_node=single_node)
         ret.append((i, node))
         return node
@@ -758,12 +777,19 @@ def start_cluster(num_nodes,
 
     return nodes
 
-def start_bridge(nodes, start_local_ethereum=True, handle_contracts=True, handle_relays=True, config=None):
+
+def start_bridge(nodes,
+                 start_local_ethereum=True,
+                 handle_contracts=True,
+                 handle_relays=True,
+                 config=None):
     if not config:
         config = load_config()
 
-    config['bridge']['bridge_dir'] = os.path.abspath(os.path.expanduser(os.path.expandvars(config['bridge']['bridge_dir'])))
-    config['bridge']['config_dir'] = os.path.abspath(os.path.expanduser(os.path.expandvars(config['bridge']['config_dir'])))
+    config['bridge']['bridge_dir'] = os.path.abspath(
+        os.path.expanduser(os.path.expandvars(config['bridge']['bridge_dir'])))
+    config['bridge']['config_dir'] = os.path.abspath(
+        os.path.expanduser(os.path.expandvars(config['bridge']['config_dir'])))
 
     # Run bridge.__init__() here.
     # It will create necessary folders, download repos and install services automatically.
@@ -800,6 +826,7 @@ def start_bridge(nodes, start_local_ethereum=True, handle_contracts=True, handle
 
     return (bridge, ganache_node)
 
+
 DEFAULT_CONFIG = {
     'local': True,
     'near_root': '../target/debug/',
@@ -829,7 +856,8 @@ def load_config():
                 config.update(new_config)
                 logger.info(f"Load config from {config_file}, config {config}")
         except FileNotFoundError:
-            logger.info(f"Failed to load config file, use default config {config}")
+            logger.info(
+                f"Failed to load config file, use default config {config}")
     else:
         logger.info(f"Use default config {config}")
     return config

--- a/pytest/lib/configured_logger.py
+++ b/pytest/lib/configured_logger.py
@@ -27,7 +27,8 @@ def new_logger(
 
     log = logging.getLogger(name)
     log.setLevel(level)
-    fmt = logging.Formatter('[%(asctime)s] %(levelname)s: %(message)s', '%Y-%m-%d %H:%M:%S')
+    fmt = logging.Formatter('[%(asctime)s] %(levelname)s: %(message)s',
+                            '%Y-%m-%d %H:%M:%S')
 
     if outfile is not None:
         handler = logging.FileHandler(outfile)

--- a/pytest/lib/messages/__init__.py
+++ b/pytest/lib/messages/__init__.py
@@ -5,4 +5,5 @@ from .network import network_schema
 from .shard import shard_schema
 from .tx import tx_schema
 
-schema = dict(block_schema + bridge_schema + crypto_schema + network_schema + shard_schema + tx_schema)
+schema = dict(block_schema + bridge_schema + crypto_schema + network_schema +
+              shard_schema + tx_schema)

--- a/pytest/lib/messages/block.py
+++ b/pytest/lib/messages/block.py
@@ -15,6 +15,7 @@ class BlockV2:
 
 
 class BlockHeader:
+
     def inner_lite(self):
         if self.enum == 'BlockHeaderV3':
             return self.BlockHeaderV3.inner_lite
@@ -36,6 +37,7 @@ class BlockHeaderV2:
 class BlockHeaderV3:
     pass
 
+
 class BlockHeaderInnerLite:
     pass
 
@@ -50,6 +52,7 @@ class BlockHeaderInnerRestV2:
 
 class BlockHeaderInnerRestV3:
     pass
+
 
 class ShardChunk:
     pass
@@ -68,44 +71,56 @@ class ShardChunkHeader:
 
 
 class ShardChunkHeaderV1:
+
     @staticmethod
     def chunk_hash(inner):
         import hashlib
         from messages.crypto import crypto_schema
         from serializer import BinarySerializer
-        inner_serialized = BinarySerializer(dict(block_schema + crypto_schema)).serialize(inner)
+        inner_serialized = BinarySerializer(
+            dict(block_schema + crypto_schema)).serialize(inner)
         return hashlib.sha256(inner_serialized).digest()
 
+
 class ShardChunkHeaderV2:
+
     @staticmethod
     def chunk_hash(inner):
         import hashlib
         from messages.crypto import crypto_schema
         from serializer import BinarySerializer
-        inner_serialized = BinarySerializer(dict(block_schema + crypto_schema)).serialize(inner)
+        inner_serialized = BinarySerializer(
+            dict(block_schema + crypto_schema)).serialize(inner)
         inner_hash = hashlib.sha256(inner_serialized).digest()
 
         return hashlib.sha256(inner_hash + inner.encoded_merkle_root).digest()
+
 
 class ShardChunkHeaderV3:
+
     @staticmethod
     def chunk_hash(inner):
         import hashlib
         from messages.crypto import crypto_schema
         from serializer import BinarySerializer
-        inner_serialized = BinarySerializer(dict(block_schema + crypto_schema)).serialize(inner)
+        inner_serialized = BinarySerializer(
+            dict(block_schema + crypto_schema)).serialize(inner)
         inner_hash = hashlib.sha256(inner_serialized).digest()
 
         return hashlib.sha256(inner_hash + inner.encoded_merkle_root).digest()
+
 
 class ShardChunkHeaderInner:
     pass
 
+
 class ShardChunkHeaderInnerV1:
     pass
 
+
 class ShardChunkHeaderInnerV2:
     pass
+
 
 class PartialEncodedChunkPart:
     pass
@@ -116,6 +131,7 @@ class ReceiptProof:
 
 
 class PartialEncodedChunk:
+
     def inner_header(self):
         version = self.enum
         if version == 'V1':
@@ -127,7 +143,7 @@ class PartialEncodedChunk:
                 return header.V1.inner
             elif header_version == 'V2':
                 return header.V2.inner
-    
+
     def header_version(self):
         version = self.enum
         if version == 'V1':
@@ -155,11 +171,14 @@ class PartialEncodedChunkResponseMsg:
 class PartialEncodedChunkForwardMsg:
     pass
 
+
 class ValidatorStake:
     pass
 
+
 class ValidatorStakeV1:
     pass
+
 
 class Approval:
     pass
@@ -181,26 +200,28 @@ block_schema = [
         }
     ],
     [
-        BlockV1, {
-            'kind': 'struct',
+        BlockV1,
+        {
+            'kind':
+                'struct',
             'fields': [
                 ['header', BlockHeader],
                 ['chunks', [ShardChunkHeaderV1]],
-                ['challenges', [()]], # TODO
-
+                ['challenges', [()]],  # TODO
                 ['vrf_value', [32]],
                 ['vrf_proof', [64]],
             ]
         }
     ],
     [
-        BlockV2, {
-            'kind': 'struct',
+        BlockV2,
+        {
+            'kind':
+                'struct',
             'fields': [
                 ['header', BlockHeader],
                 ['chunks', [ShardChunkHeader]],
-                ['challenges', [()]], # TODO
-
+                ['challenges', [()]],  # TODO
                 ['vrf_value', [32]],
                 ['vrf_proof', [64]],
             ]
@@ -208,18 +229,19 @@ block_schema = [
     ],
     [
         BlockHeader, {
-            'kind': 'enum',
-            'field': 'enum',
-            'values': [
-                ['BlockHeaderV1', BlockHeaderV1],
-                ['BlockHeaderV2', BlockHeaderV2],
-                ['BlockHeaderV3', BlockHeaderV3]
-            ]
+            'kind':
+                'enum',
+            'field':
+                'enum',
+            'values': [['BlockHeaderV1', BlockHeaderV1],
+                       ['BlockHeaderV2', BlockHeaderV2],
+                       ['BlockHeaderV3', BlockHeaderV3]]
         }
     ],
     [
         BlockHeaderV1, {
-            'kind': 'struct',
+            'kind':
+                'struct',
             'fields': [
                 ['prev_hash', [32]],
                 ['inner_lite', BlockHeaderInnerLite],
@@ -230,7 +252,8 @@ block_schema = [
     ],
     [
         BlockHeaderV2, {
-            'kind' : 'struct',
+            'kind':
+                'struct',
             'fields': [
                 ['prev_hash', [32]],
                 ['inner_lite', BlockHeaderInnerLite],
@@ -241,7 +264,8 @@ block_schema = [
     ],
     [
         BlockHeaderV3, {
-            'kind' : 'struct',
+            'kind':
+                'struct',
             'fields': [
                 ['prev_hash', [32]],
                 ['inner_lite', BlockHeaderInnerLite],
@@ -252,7 +276,8 @@ block_schema = [
     ],
     [
         BlockHeaderInnerLite, {
-            'kind': 'struct',
+            'kind':
+                'struct',
             'fields': [
                 ['height', 'u64'],
                 ['epoch_id', [32]],
@@ -266,8 +291,10 @@ block_schema = [
         }
     ],
     [
-        BlockHeaderInnerRest, {
-            'kind': 'struct',
+        BlockHeaderInnerRest,
+        {
+            'kind':
+                'struct',
             'fields': [
                 ['chunk_receipts_root', [32]],
                 ['chunk_headers_root', [32]],
@@ -279,17 +306,22 @@ block_schema = [
                 ['chunk_mask', ['u8']],
                 ['gas_price', 'u128'],
                 ['total_supply', 'u128'],
-                ['challenges_result', [()]], # TODO
+                ['challenges_result', [()]],  # TODO
                 ['last_final_block', [32]],
                 ['last_ds_final_block', [32]],
-                ['approvals', [{'kind': 'option', 'type': Signature}]],
+                ['approvals', [{
+                    'kind': 'option',
+                    'type': Signature
+                }]],
                 ['latest_protocol_verstion', 'u32'],
             ]
         }
     ],
     [
-        BlockHeaderInnerRestV2, {
-            'kind': 'struct',
+        BlockHeaderInnerRestV2,
+        {
+            'kind':
+                'struct',
             'fields': [
                 ['chunk_receipts_root', [32]],
                 ['chunk_headers_root', [32]],
@@ -300,17 +332,22 @@ block_schema = [
                 ['chunk_mask', ['u8']],
                 ['gas_price', 'u128'],
                 ['total_supply', 'u128'],
-                ['challenges_result', [()]], # TODO
+                ['challenges_result', [()]],  # TODO
                 ['last_final_block', [32]],
                 ['last_ds_final_block', [32]],
-                ['approvals', [{'kind': 'option', 'type': Signature}]],
+                ['approvals', [{
+                    'kind': 'option',
+                    'type': Signature
+                }]],
                 ['latest_protocol_verstion', 'u32'],
             ]
         }
     ],
     [
-        BlockHeaderInnerRestV3, {
-            'kind': 'struct',
+        BlockHeaderInnerRestV3,
+        {
+            'kind':
+                'struct',
             'fields': [
                 ['chunk_receipts_root', [32]],
                 ['chunk_headers_root', [32]],
@@ -321,31 +358,37 @@ block_schema = [
                 ['chunk_mask', ['u8']],
                 ['gas_price', 'u128'],
                 ['total_supply', 'u128'],
-                ['challenges_result', [()]], # TODO
+                ['challenges_result', [()]],  # TODO
                 ['last_final_block', [32]],
                 ['last_ds_final_block', [32]],
                 ['block_ordinal', 'u64'],
                 ['prev_height', 'u64'],
-                ['epoch_sync_data_hash', {'kind': 'option', 'type': [32]}],
-                ['approvals', [{'kind': 'option', 'type': Signature}]],
+                ['epoch_sync_data_hash', {
+                    'kind': 'option',
+                    'type': [32]
+                }],
+                ['approvals', [{
+                    'kind': 'option',
+                    'type': Signature
+                }]],
                 ['latest_protocol_verstion', 'u32'],
             ]
         }
     ],
     [
         ShardChunkHeader, {
-            'kind': 'enum',
-            'field': 'enum',
-            'values': [
-                ['V1', ShardChunkHeaderV1],
-                ['V2', ShardChunkHeaderV2],
-                ['V3', ShardChunkHeaderV3]
-            ]
+            'kind':
+                'enum',
+            'field':
+                'enum',
+            'values': [['V1', ShardChunkHeaderV1], ['V2', ShardChunkHeaderV2],
+                       ['V3', ShardChunkHeaderV3]]
         }
     ],
     [
         ShardChunkHeaderV1, {
-            'kind': 'struct',
+            'kind':
+                'struct',
             'fields': [
                 ['inner', ShardChunkHeaderInnerV1],
                 ['height_included', 'u64'],
@@ -355,7 +398,8 @@ block_schema = [
     ],
     [
         ShardChunkHeaderV2, {
-            'kind': 'struct',
+            'kind':
+                'struct',
             'fields': [
                 ['inner', ShardChunkHeaderInnerV1],
                 ['height_included', 'u64'],
@@ -365,7 +409,8 @@ block_schema = [
     ],
     [
         ShardChunkHeaderV3, {
-            'kind': 'struct',
+            'kind':
+                'struct',
             'fields': [
                 ['inner', ShardChunkHeaderInner],
                 ['height_included', 'u64'],
@@ -375,17 +420,18 @@ block_schema = [
     ],
     [
         ShardChunkHeaderInner, {
-            'kind': 'enum',
-            'field': 'enum',
-            'values': [
-                ['V1', ShardChunkHeaderInnerV1],
-                ['V2', ShardChunkHeaderInnerV2]
-            ]
+            'kind':
+                'enum',
+            'field':
+                'enum',
+            'values': [['V1', ShardChunkHeaderInnerV1],
+                       ['V2', ShardChunkHeaderInnerV2]]
         }
     ],
     [
         ShardChunkHeaderInnerV1, {
-            'kind': 'struct',
+            'kind':
+                'struct',
             'fields': [
                 ['prev_block_hash', [32]],
                 ['prev_state_root', [32]],
@@ -405,7 +451,8 @@ block_schema = [
     ],
     [
         ShardChunkHeaderInnerV2, {
-            'kind': 'struct',
+            'kind':
+                'struct',
             'fields': [
                 ['prev_block_hash', [32]],
                 ['prev_state_root', [32]],
@@ -427,15 +474,13 @@ block_schema = [
         ShardChunk, {
             'kind': 'enum',
             'field': 'enum',
-            'values': [
-                ['V1', ShardChunkV1],
-                ['V2', ShardChunkV2]
-            ]
+            'values': [['V1', ShardChunkV1], ['V2', ShardChunkV2]]
         }
     ],
     [
         ShardChunkV1, {
-            'kind': 'struct',
+            'kind':
+                'struct',
             'fields': [
                 ['chunk_hash', [32]],
                 ['header', ShardChunkHeaderV1],
@@ -446,7 +491,8 @@ block_schema = [
     ],
     [
         ShardChunkV2, {
-            'kind': 'struct',
+            'kind':
+                'struct',
             'fields': [
                 ['chunk_hash', [32]],
                 ['header', ShardChunkHeader],
@@ -457,7 +503,8 @@ block_schema = [
     ],
     [
         PartialEncodedChunkPart, {
-            'kind': 'struct',
+            'kind':
+                'struct',
             'fields': [
                 ['part_ord', 'u64'],
                 ['part', ['u8']],
@@ -476,81 +523,71 @@ block_schema = [
     ],
     [
         PartialEncodedChunk, {
-            'kind': 'enum',
-            'field': 'enum',
-            'values': [
-                ['V1', PartialEncodedChunkV1],
-                ['V2', PartialEncodedChunkV2]
-            ]
+            'kind':
+                'enum',
+            'field':
+                'enum',
+            'values': [['V1', PartialEncodedChunkV1],
+                       ['V2', PartialEncodedChunkV2]]
         }
     ],
     [
         PartialEncodedChunkV1, {
-            'kind': 'struct',
-            'fields': [
-                ['header', ShardChunkHeaderV1],
-                ['parts', [PartialEncodedChunkPart]],
-                ['receipts', [ReceiptProof]]
-            ]
+            'kind':
+                'struct',
+            'fields': [['header', ShardChunkHeaderV1],
+                       ['parts', [PartialEncodedChunkPart]],
+                       ['receipts', [ReceiptProof]]]
         }
     ],
     [
         PartialEncodedChunkV2, {
-            'kind': 'struct',
-            'fields': [
-                ['header', ShardChunkHeader],
-                ['parts', [PartialEncodedChunkPart]],
-                ['receipts', [ReceiptProof]]
-            ]
+            'kind':
+                'struct',
+            'fields': [['header', ShardChunkHeader],
+                       ['parts', [PartialEncodedChunkPart]],
+                       ['receipts', [ReceiptProof]]]
         }
     ],
     [
         PartialEncodedChunkRequestMsg, {
-            'kind': 'struct',
-            'fields': [
-                ['chunk_hash', [32]],
-                ['part_ords', ['u64']],
-                ['tracking_shards', ['u64']]
-            ]
+            'kind':
+                'struct',
+            'fields': [['chunk_hash', [32]], ['part_ords', ['u64']],
+                       ['tracking_shards', ['u64']]]
         }
     ],
     [
         PartialEncodedChunkResponseMsg, {
-            'kind': 'struct',
-            'fields': [
-                ['chunk_hash', [32]],
-                ['parts', [PartialEncodedChunkPart]],
-                ['receipts', [ReceiptProof]]
-            ]
+            'kind':
+                'struct',
+            'fields': [['chunk_hash', [32]],
+                       ['parts', [PartialEncodedChunkPart]],
+                       ['receipts', [ReceiptProof]]]
         }
     ],
     [
         PartialEncodedChunkForwardMsg, {
-            'kind': 'struct',
-            'fields': [
-                ['chunk_hash', [32]],
-                ['inner_header_hash', [32]],
-                ['merkle_root', [32]],
-                ['signature', Signature],
-                ['prev_block_hash', [32]],
-                ['height_created', 'u64'],
-                ['shard_id', 'u64'],
-                ['parts', [PartialEncodedChunkPart]]
-            ]
+            'kind':
+                'struct',
+            'fields': [['chunk_hash', [32]], ['inner_header_hash', [32]],
+                       ['merkle_root', [32]], ['signature', Signature],
+                       ['prev_block_hash', [32]], ['height_created', 'u64'],
+                       ['shard_id', 'u64'],
+                       ['parts', [PartialEncodedChunkPart]]]
         }
     ],
     [
         ValidatorStake, {
             'kind': 'enum',
             'field': 'enum',
-            'values': [
-                ['V1', ValidatorStakeV1]
-            ]
+            'values': [['V1', ValidatorStakeV1]]
         }
     ],
     [
         ValidatorStakeV1, {
-            'kind': 'struct',
+            'kind':
+                'struct',
             'fields': [
                 ['account_id', 'string'],
                 ['public_key', PublicKey],
@@ -560,7 +597,8 @@ block_schema = [
     ],
     [
         Approval, {
-            'kind': 'struct',
+            'kind':
+                'struct',
             'fields': [
                 ['inner', ApprovalInner],
                 ['target_height', 'u64'],
@@ -580,4 +618,3 @@ block_schema = [
         }
     ],
 ]
-

--- a/pytest/lib/messages/bridge.py
+++ b/pytest/lib/messages/bridge.py
@@ -1,18 +1,18 @@
 class Proof:
     pass
 
-bridge_schema = [
-    [
-        Proof, {
-            'kind': 'struct',
-            'fields': [
-                ['log_index', 'u64'],
-                ['log_entry_data', ['u8']],
-                ['receipt_index', 'u64'],
-                ['receipt_data', ['u8']],
-                ['header_data', ['u8']],
-                ['proof', [['u8']]],
-            ]
-        }
-    ]
-]
+
+bridge_schema = [[
+    Proof, {
+        'kind':
+            'struct',
+        'fields': [
+            ['log_index', 'u64'],
+            ['log_entry_data', ['u8']],
+            ['receipt_index', 'u64'],
+            ['receipt_data', ['u8']],
+            ['header_data', ['u8']],
+            ['proof', [['u8']]],
+        ]
+    }
+]]

--- a/pytest/lib/messages/crypto.py
+++ b/pytest/lib/messages/crypto.py
@@ -86,17 +86,23 @@ crypto_schema = [
         'kind': 'struct',
         'fields': []
     }],
-    [Direction, {
-        'kind': 'enum',
-        'field': 'enum',
-        'values': [['Left', ()], ['Right', ()]],
-    }],
+    [
+        Direction, {
+            'kind': 'enum',
+            'field': 'enum',
+            'values': [['Left', ()], ['Right', ()]],
+        }
+    ],
     [MerklePath, {
         'kind': 'struct',
         'fields': [['f1', [([32], Direction)]]],
     }],
-    [ShardProof, {
-        'kind': 'struct',
-        'fields': [['from_shard_id', 'u64'], ['to_shard_id', 'u64'], ['proof', MerklePath]],
-    }],
+    [
+        ShardProof, {
+            'kind':
+                'struct',
+            'fields': [['from_shard_id', 'u64'], ['to_shard_id', 'u64'],
+                       ['proof', MerklePath]],
+        }
+    ],
 ]

--- a/pytest/lib/messages/network.py
+++ b/pytest/lib/messages/network.py
@@ -3,6 +3,7 @@ from messages.tx import SignedTransaction, Receipt
 from messages.block import Block, Approval, PartialEncodedChunk, PartialEncodedChunkV1, PartialEncodedChunkRequestMsg, PartialEncodedChunkResponseMsg, PartialEncodedChunkForwardMsg, BlockHeader, ShardChunk, ShardChunkHeader, ShardChunkHeaderV1
 from messages.shard import StateRootNode
 
+
 class SocketAddr:
     pass
 
@@ -120,29 +121,31 @@ network_schema = [
         }
     ],
     [
-        PeerMessage, {
+        PeerMessage,
+        {
             'kind':
                 'enum',
             'field':
                 'enum',
-            'values': [['Handshake', Handshake],
-                       ['HandshakeFailure', (PeerInfo, HandshakeFailureReason)],
-                       ['LastEdge', Edge],
-                       ['Sync', SyncData],
-                       ['RequestUpdateNonce', EdgeInfo],
-                       ['ResponseUpdateNonce', Edge],
-                       ['PeersRequest', ()],
-                       ['PeersResponse', [PeerInfo]],
-                       ['BlockHeadersRequest', [[32]]],
-                       ['BlockHeaders', [BlockHeader]],
-                       ['BlockRequest', [32]],
-                       ['Block', Block],
-                       ['Transaction', SignedTransaction],
-                       ['Routed', RoutedMessage],
-                       ['Disconnect', ()],
-                       ['Challenge', None], # TODO
-                       ['HandshakeV2', HandshakeV2],
-                       ]
+            'values': [
+                ['Handshake', Handshake],
+                ['HandshakeFailure', (PeerInfo, HandshakeFailureReason)],
+                ['LastEdge', Edge],
+                ['Sync', SyncData],
+                ['RequestUpdateNonce', EdgeInfo],
+                ['ResponseUpdateNonce', Edge],
+                ['PeersRequest', ()],
+                ['PeersResponse', [PeerInfo]],
+                ['BlockHeadersRequest', [[32]]],
+                ['BlockHeaders', [BlockHeader]],
+                ['BlockRequest', [32]],
+                ['Block', Block],
+                ['Transaction', SignedTransaction],
+                ['Routed', RoutedMessage],
+                ['Disconnect', ()],
+                ['Challenge', None],  # TODO
+                ['HandshakeV2', HandshakeV2],
+            ]
         }
     ],
     [
@@ -196,8 +199,7 @@ network_schema = [
     ],
     [
         ProtocolVersionMismatch, {
-            'kind':
-                'struct',
+            'kind': 'struct',
             'fields': [
                 ['version', 'u32'],
                 ['oldest_supported_version', 'u32'],
@@ -230,24 +232,24 @@ network_schema = [
         PeerChainInfoV2, {
             'kind':
                 'struct',
-            'fields': [
-                ['genesis_id', GenesisId],
-                ['height', 'u64'],
-                ['tracked_shards', ['u64']],
-                ['archival', 'bool']
-            ]
+            'fields': [['genesis_id', GenesisId], ['height', 'u64'],
+                       ['tracked_shards', ['u64']], ['archival', 'bool']]
         }
     ],
     [
         Edge, {
-            'kind': 'struct',
+            'kind':
+                'struct',
             'fields': [
                 ['peer0', PublicKey],
                 ['peer1', PublicKey],
                 ['nonce', 'u64'],
                 ['signature0', Signature],
                 ['signature1', Signature],
-                ['removal_info', {'kind': 'option', 'type': ('u8', Signature)}],
+                ['removal_info', {
+                    'kind': 'option',
+                    'type': ('u8', Signature)
+                }],
             ]
         }
     ],
@@ -280,7 +282,8 @@ network_schema = [
     ],
     [
         AnnounceAccount, {
-            'kind': 'struct',
+            'kind':
+                'struct',
             'fields': [
                 ['account_id', 'string'],
                 ['peer_id', PublicKey],
@@ -291,7 +294,8 @@ network_schema = [
     ],
     [
         RoutedMessage, {
-            'kind': 'struct',
+            'kind':
+                'struct',
             'fields': [
                 ['target', PeerIdOrHash],
                 ['author', PublicKey],
@@ -312,18 +316,21 @@ network_schema = [
         }
     ],
     [
-        RoutedMessageBody, {
-            'kind': 'enum',
-            'field': 'enum',
+        RoutedMessageBody,
+        {
+            'kind':
+                'enum',
+            'field':
+                'enum',
             'values': [
                 ['BlockApproval', Approval],
                 ['ForwardTx', SignedTransaction],
                 ['TxStatusRequest', ('string', [32])],
-                ['TxStatusResponse', None], # TODO
-                ['QueryRequest', None], # TODO
-                ['QueryResponse', None], # TODO
+                ['TxStatusResponse', None],  # TODO
+                ['QueryRequest', None],  # TODO
+                ['QueryResponse', None],  # TODO
                 ['ReceiptOutcomeRequest', [32]],
-                ['ReceiptOutcomeResponse', None], # TODO
+                ['ReceiptOutcomeResponse', None],  # TODO
                 ['StateRequestHeader', ('u64', [32])],
                 ['StateRequestPart', ('u64', [32], 'u64')],
                 ['StateResponseInfo', StateResponseInfoV1],
@@ -348,82 +355,121 @@ network_schema = [
         StateResponseInfo, {
             'kind': 'enum',
             'field': 'enum',
-            'values': [
-                ['V1', StateResponseInfoV1],
-                ['V2', StateResponseInfoV2]
-            ]
+            'values': [['V1', StateResponseInfoV1], ['V2', StateResponseInfoV2]]
         }
     ],
     [
         StateResponseInfoV1, {
-            'kind': 'struct',
-            'fields': [['shard_id', 'u64'], ['sync_hash', [32]], ['state_response', ShardStateSyncResponseV1]]
+            'kind':
+                'struct',
+            'fields': [['shard_id', 'u64'], ['sync_hash', [32]],
+                       ['state_response', ShardStateSyncResponseV1]]
         }
     ],
     [
         StateResponseInfoV2, {
-            'kind': 'struct',
-            'fields': [['shard_id', 'u64'], ['sync_hash', [32]], ['state_response', ShardStateSyncResponse]]
+            'kind':
+                'struct',
+            'fields': [['shard_id', 'u64'], ['sync_hash', [32]],
+                       ['state_response', ShardStateSyncResponse]]
         }
     ],
     [
         ShardStateSyncResponse, {
-            'kind': 'enum',
-            'field': 'enum',
-            'values': [
-                ['V1', ShardStateSyncResponseV1],
-                ['V2', ShardStateSyncResponseV2]
-            ]
+            'kind':
+                'enum',
+            'field':
+                'enum',
+            'values': [['V1', ShardStateSyncResponseV1],
+                       ['V2', ShardStateSyncResponseV2]]
         }
     ],
     [
         ShardStateSyncResponseV1, {
-            'kind': 'struct',
-            'fields': [['header', {'kind': 'option', 'type': ShardStateSyncResponseHeaderV1}], ['part', {'kind': 'option', 'type': ('u64', ['u8'])}]]
+            'kind':
+                'struct',
+            'fields': [[
+                'header', {
+                    'kind': 'option',
+                    'type': ShardStateSyncResponseHeaderV1
+                }
+            ], ['part', {
+                'kind': 'option',
+                'type': ('u64', ['u8'])
+            }]]
         }
     ],
     [
         ShardStateSyncResponseV2, {
-            'kind': 'struct',
-            'fields': [['header', {'kind': 'option', 'type': ShardStateSyncResponseHeaderV2}], ['part', {'kind': 'option', 'type': ('u64', ['u8'])}]]
+            'kind':
+                'struct',
+            'fields': [[
+                'header', {
+                    'kind': 'option',
+                    'type': ShardStateSyncResponseHeaderV2
+                }
+            ], ['part', {
+                'kind': 'option',
+                'type': ('u64', ['u8'])
+            }]]
         }
     ],
     [
         ShardStateSyncResponseHeader, {
-            'kind': 'enum',
-            'field': 'enum',
-            'values': [
-                ['V1', ShardStateSyncResponseHeaderV1],
-                ['V2', ShardStateSyncResponseHeaderV2]
-            ]
+            'kind':
+                'enum',
+            'field':
+                'enum',
+            'values': [['V1', ShardStateSyncResponseHeaderV1],
+                       ['V2', ShardStateSyncResponseHeaderV2]]
         }
     ],
     [
         ShardStateSyncResponseHeaderV1, {
-            'kind': 'struct',
-            'fields': [
-                ['chunk', ShardChunk],
-                ['chunk_proof', MerklePath],
-                ['prev_chunk_header', {'kind': 'option', 'type': ShardChunkHeaderV1}],
-                ['prev_chunk_proof', {'kind': 'option', 'type': MerklePath}],
-                ['incoming_receipts_proofs', [([32], [([Receipt], ShardProof)])]],
-                ['root_proofs', [[([32], MerklePath)]]],
-                ['state_root_node', StateRootNode]
-            ]
+            'kind':
+                'struct',
+            'fields': [['chunk', ShardChunk], ['chunk_proof', MerklePath],
+                       [
+                           'prev_chunk_header', {
+                               'kind': 'option',
+                               'type': ShardChunkHeaderV1
+                           }
+                       ],
+                       [
+                           'prev_chunk_proof', {
+                               'kind': 'option',
+                               'type': MerklePath
+                           }
+                       ],
+                       [
+                           'incoming_receipts_proofs',
+                           [([32], [([Receipt], ShardProof)])]
+                       ], ['root_proofs', [[([32], MerklePath)]]],
+                       ['state_root_node', StateRootNode]]
         }
     ],
     [
         ShardStateSyncResponseHeaderV2, {
-            'kind': 'struct',
-            'fields': [
-                ['chunk', ShardChunk],
-                ['chunk_proof', MerklePath],
-                ['prev_chunk_header', {'kind': 'option', 'type': ShardChunkHeader}],
-                ['prev_chunk_proof', {'kind': 'option', 'type': MerklePath}],
-                ['incoming_receipts_proofs', [([32], [([Receipt], ShardProof)])]],
-                ['root_proofs', [[([32], MerklePath)]]],
-                ['state_root_node', StateRootNode]
-            ]
+            'kind':
+                'struct',
+            'fields': [['chunk', ShardChunk], ['chunk_proof', MerklePath],
+                       [
+                           'prev_chunk_header', {
+                               'kind': 'option',
+                               'type': ShardChunkHeader
+                           }
+                       ],
+                       [
+                           'prev_chunk_proof', {
+                               'kind': 'option',
+                               'type': MerklePath
+                           }
+                       ],
+                       [
+                           'incoming_receipts_proofs',
+                           [([32], [([Receipt], ShardProof)])]
+                       ], ['root_proofs', [[([32], MerklePath)]]],
+                       ['state_root_node', StateRootNode]]
         }
     ],
 ]

--- a/pytest/lib/messages/shard.py
+++ b/pytest/lib/messages/shard.py
@@ -1,11 +1,10 @@
 class StateRootNode:
     pass
 
-shard_schema = [
-    [
-        StateRootNode, {
-            'kind': 'struct',
-            'fields': [['data', ['u8']], ['memory_usage', 'u64']]
-        }
-    ]
-]
+
+shard_schema = [[
+    StateRootNode, {
+        'kind': 'struct',
+        'fields': [['data', ['u8']], ['memory_usage', 'u64']]
+    }
+]]

--- a/pytest/lib/messages/tx.py
+++ b/pytest/lib/messages/tx.py
@@ -143,7 +143,8 @@ tx_schema = [
     ],
     [
         Receipt, {
-            'kind': 'struct',
+            'kind':
+                'struct',
             'fields': [
                 ['predecessor_id', 'string'],
                 ['receiver_id', 'string'],
@@ -164,7 +165,8 @@ tx_schema = [
     ],
     [
         ActionReceipt, {
-            'kind': 'struct',
+            'kind':
+                'struct',
             'fields': [
                 ['signer_id', 'string'],
                 ['signer_public_key', PublicKey],
@@ -177,10 +179,14 @@ tx_schema = [
     ],
     [
         DataReceipt, {
-            'kind': 'struct',
+            'kind':
+                'struct',
             'fields': [
                 ['data_id', [32]],
-                ['data', {'kind': 'option', 'type': ['u8']}],
+                ['data', {
+                    'kind': 'option',
+                    'type': ['u8']
+                }],
             ]
         }
     ],

--- a/pytest/lib/metrics.py
+++ b/pytest/lib/metrics.py
@@ -67,7 +67,8 @@ class Metrics:
         memory_usage = final_metrics.memory_usage - initial_metrics.memory_usage
         total_transactions = final_metrics.total_transactions - initial_metrics.total_transactions
         timestamp = final_metrics.timestamp - initial_metrics.timestamp
-        blocks_per_second = (final_metrics.blocks_per_second + initial_metrics.blocks_per_second) / 2.0
+        blocks_per_second = (final_metrics.blocks_per_second +
+                             initial_metrics.blocks_per_second) / 2.0
         block_processing_time = {}
         for sample in final_metrics.block_processing_time.keys():
             block_processing_time[sample] = final_metrics.block_processing_time[

--- a/pytest/lib/mocknet.py
+++ b/pytest/lib/mocknet.py
@@ -347,8 +347,7 @@ def reset_data(node, retries=0):
     except:
         if retries < 3:
             logger.warning(
-                f'And error occured while clearing data directory, retrying'
-            )
+                f'And error occured while clearing data directory, retrying')
             reset_data(node, retries=retries + 1)
         else:
             raise Exception(

--- a/pytest/lib/peer.py
+++ b/pytest/lib/peer.py
@@ -68,7 +68,6 @@ class Connection:
 
             return response
 
-
     async def close(self):
         self.writer.close()
         await self.writer.wait_closed()
@@ -174,18 +173,21 @@ async def run_handshake(conn: Connection,
 
     response = await send_handshake()
 
-    if response.enum == 'HandshakeFailure' and response.HandshakeFailure[1].enum == 'ProtocolVersionMismatch':
+    if response.enum == 'HandshakeFailure' and response.HandshakeFailure[
+            1].enum == 'ProtocolVersionMismatch':
         pvm = response.HandshakeFailure[1].ProtocolVersionMismatch.version
         handshake.Handshake.version = pvm
         response = await send_handshake()
 
-    if response.enum == 'HandshakeFailure' and response.HandshakeFailure[1].enum == 'GenesisMismatch':
+    if response.enum == 'HandshakeFailure' and response.HandshakeFailure[
+            1].enum == 'GenesisMismatch':
         gm = response.HandshakeFailure[1].GenesisMismatch
         handshake.Handshake.chain_info.genesis_id.chain_id = gm.chain_id
         handshake.Handshake.chain_info.genesis_id.hash = gm.hash
         response = await send_handshake()
 
-    assert response.enum == 'Handshake', response.enum if response.enum != 'HandshakeFailure' else response.HandshakeFailure[1].enum
+    assert response.enum == 'Handshake', response.enum if response.enum != 'HandshakeFailure' else response.HandshakeFailure[
+        1].enum
 
 
 def create_and_sign_routed_peer_message(routed_msg_body, target_node,

--- a/pytest/lib/populate.py
+++ b/pytest/lib/populate.py
@@ -4,13 +4,9 @@ from shutil import copy2, rmtree
 
 
 def genesis_populate(near_root, additional_accounts, node_dir):
-    subprocess.check_call((
-        join(near_root, 'genesis-populate'),
-        '--additional-accounts-num',
-        str(additional_accounts),
-        '--home',
-        node_dir
-    ))
+    subprocess.check_call(
+        (join(near_root, 'genesis-populate'), '--additional-accounts-num',
+         str(additional_accounts), '--home', node_dir))
     rmtree(join(node_dir, 'data'), ignore_errors=True)
 
 

--- a/pytest/lib/proxy_instances.py
+++ b/pytest/lib/proxy_instances.py
@@ -12,14 +12,17 @@ class RejectListHandler(ProxyHandler):
     async def handle(self, msg, fr, to):
         msg_type = msg.enum if msg.enum != 'Routed' else msg.Routed.body.enum
 
-        if self.drop_probability > 0 and 'Handshake' not in msg_type and random.uniform(0, 1) < self.drop_probability:
+        if (self.drop_probability > 0 and 'Handshake' not in msg_type and
+                random.uniform(0, 1) < self.drop_probability):
             logging.info(
-                f'NODE {self.ordinal} dropping message {msg_type} from {fr} to {to}')
+                f'NODE {self.ordinal} dropping message {msg_type} from {fr} to {to}'
+            )
             return False
 
         if fr in self.reject_list or to in self.reject_list:
             logging.info(
-                f'NODE {self.ordinal} blocking message {msg_type} from {fr} to {to}')
+                f'NODE {self.ordinal} blocking message {msg_type} from {fr} to {to}'
+            )
             return False
         else:
             return True
@@ -30,7 +33,8 @@ class RejectListProxy(NodesProxy):
     def __init__(self, reject_list, drop_probability):
         self.reject_list = reject_list
         self.drop_probability = drop_probability
-        handler = lambda ordinal: RejectListHandler(reject_list, drop_probability, ordinal)
+        handler = lambda ordinal: RejectListHandler(reject_list,
+                                                    drop_probability, ordinal)
         super().__init__(handler)
 
     @staticmethod

--- a/pytest/lib/serializer.py
+++ b/pytest/lib/serializer.py
@@ -5,7 +5,9 @@ class BinarySerializer:
         self.schema = schema
 
     def read_bytes(self, n):
-        assert n + self.offset <= len(self.array), f'n: {n} offset: {self.offset}, length: {len(self.array)}'
+        assert n + self.offset <= len(
+            self.array
+        ), f'n: {n} offset: {self.offset}, length: {len(self.array)}'
         ret = self.array[self.offset:self.offset + n]
         self.offset += n
         return ret
@@ -94,7 +96,9 @@ class BinarySerializer:
                 return bytes(self.read_bytes(fieldType[0]))
             else:
                 len_ = self.deserialize_num(4)
-                return [self.deserialize_field(fieldType[0]) for _ in range(len_)]
+                return [
+                    self.deserialize_field(fieldType[0]) for _ in range(len_)
+                ]
         elif type(fieldType) == dict:
             assert fieldType['kind'] == 'option'
             is_none = self.deserialize_num(1) == 0
@@ -137,7 +141,8 @@ class BinarySerializer:
             value_ord = self.deserialize_num(1)
             value_schema = structSchema['values'][value_ord]
             setattr(ret, structSchema['field'], value_schema[0])
-            setattr(ret, value_schema[0], self.deserialize_field(value_schema[1]))
+            setattr(ret, value_schema[0],
+                    self.deserialize_field(value_schema[1]))
 
             return ret
         else:
@@ -151,6 +156,6 @@ class BinarySerializer:
         self.array = bytearray(bytes_)
         self.offset = 0
         ret = self.deserialize_field(type_)
-        assert self.offset == len(bytes_), "%s != %s" % (self.offset, len(bytes_))
+        assert self.offset == len(bytes_), "%s != %s" % (self.offset,
+                                                         len(bytes_))
         return ret
-

--- a/pytest/lib/utils.py
+++ b/pytest/lib/utils.py
@@ -51,7 +51,8 @@ class TxContext:
                 to += 1
             amt = random.randint(0, 500)
             if self.expected_balances[from_] >= amt:
-                logger.info("Sending a tx from %s to %s for %s" % (from_, to, amt))
+                logger.info("Sending a tx from %s to %s for %s" %
+                            (from_, to, amt))
                 tx = sign_payment_tx(
                     self.nodes[from_].signer_key, 'test%s' % to, amt,
                     self.next_nonce,
@@ -210,18 +211,21 @@ def compile_rust_contract(content):
     tempdir = get_near_tempdir()
     with tempfile.TemporaryDirectory(dir=tempdir) as build_dir:
         build_dir = pathlib.Path(build_dir) / 'empty-contract-rs'
-        shutil.copytree(
-            pathlib.Path(__file__).parent.parent / 'empty-contract-rs',
-            build_dir, symlinks=True)
+        shutil.copytree(pathlib.Path(__file__).parent.parent /
+                        'empty-contract-rs',
+                        build_dir,
+                        symlinks=True)
         (build_dir / 'src').mkdir(parents=True, exist_ok=True)
         with open(build_dir / 'src' / 'lib.rs', 'w') as wr:
             wr.write(content)
         subprocess.check_call(('cargo', 'build', '--release', '--target',
-                               'wasm32-unknown-unknown'), cwd=build_dir)
+                               'wasm32-unknown-unknown'),
+                              cwd=build_dir)
         wasm_src = (build_dir / 'target' / 'wasm32-unknown-unknown' /
                     'release' / 'empty_contract_rs.wasm')
         wasm_fno, wasm_path = tempfile.mkstemp(suffix='.wasm')
-        atexit.register(pathlib.Path.unlink, pathlib.Path(wasm_path),
+        atexit.register(pathlib.Path.unlink,
+                        pathlib.Path(wasm_path),
                         missing_ok=True)
         with open(wasm_src, mode='rb') as rd, open(wasm_fno, mode='wb') as wr:
             shutil.copyfileobj(rd, wr)
@@ -296,14 +300,12 @@ def collect_gcloud_config(num_nodes):
 def obj_to_string(obj, extra='    ', full=False):
     if type(obj) in [tuple, list]:
         return "tuple" + '\n' + '\n'.join(
-            (extra + obj_to_string(x, extra + '    '))
-            for x in obj
-        )
+            (extra + obj_to_string(x, extra + '    ')) for x in obj)
     elif hasattr(obj, "__dict__"):
         return str(obj.__class__) + '\n' + '\n'.join(
             extra + (str(item) + ' = ' +
                      obj_to_string(obj.__dict__[item], extra + '    '))
-        for item in sorted(obj.__dict__))
+            for item in sorted(obj.__dict__))
     elif isinstance(obj, bytes):
         if not full:
             if len(obj) > 10:
@@ -327,7 +329,11 @@ def compute_merkle_root_from_path(path, leaf_hash):
     return res
 
 
-def wait_for_blocks_or_timeout(node, num_blocks, timeout, callback=None, check_sec=1):
+def wait_for_blocks_or_timeout(node,
+                               num_blocks,
+                               timeout,
+                               callback=None,
+                               check_sec=1):
     status = node.get_status()
     start_height = status['sync_info']['latest_block_height']
     max_height = 0

--- a/pytest/tests/adversarial/start_from_genesis.py
+++ b/pytest/tests/adversarial/start_from_genesis.py
@@ -16,13 +16,20 @@ if "doomslug_off" in sys.argv:
 TIMEOUT = 300
 BLOCKS = 30
 
-
 # Low sync_check_period to sync from a new peer with greater height
-client_config_change = {"consensus":{"sync_check_period": {"secs": 0, "nanos": 100000000}}}
+client_config_change = {
+    "consensus": {
+        "sync_check_period": {
+            "secs": 0,
+            "nanos": 100000000
+        }
+    }
+}
 
 nodes = start_cluster(
     2, 0, 2, None,
-    [["epoch_length", 100], ["block_producer_kickout_threshold", 80]], {0: client_config_change})
+    [["epoch_length", 100], ["block_producer_kickout_threshold", 80]],
+    {0: client_config_change})
 if not doomslug:
     # we expect inconsistency in store in node 0
     # because we're going to turn off doomslug

--- a/pytest/tests/bridge/end2end.py
+++ b/pytest/tests/bridge/end2end.py
@@ -17,7 +17,7 @@ no_txs_in_parallel = False
 if 'no_txs_in_parallel' in sys.argv:
     no_txs_in_parallel = True
 
-assert not (no_txs_in_same_block and no_txs_in_parallel) # to avoid errors
+assert not (no_txs_in_same_block and no_txs_in_parallel)  # to avoid errors
 
 eth2near_tx_number = int(sys.argv[1])
 near2eth_tx_number = int(sys.argv[2])
@@ -50,7 +50,8 @@ txs = []
 for _ in range(near2eth_tx_number):
     txs.append(bridge.transfer_near2eth(alice, 1))
     if no_txs_in_same_block:
-        time.sleep(bridge_cluster_config_changes['consensus']['min_block_production_delay']['secs'] + 2)
+        time.sleep(bridge_cluster_config_changes['consensus']
+                   ['min_block_production_delay']['secs'] + 2)
     if no_txs_in_parallel:
         [p.join() for p in txs]
 [p.join() for p in txs]
@@ -58,6 +59,5 @@ exit_codes = [p.exitcode for p in txs]
 
 assert exit_codes == [0 for _ in txs]
 bridge.check_balances(alice)
-
 
 logger.info('EPIC')

--- a/pytest/tests/bridge/multiple_relays.py
+++ b/pytest/tests/bridge/multiple_relays.py
@@ -67,5 +67,4 @@ time.sleep(60)
 bridge.check_balances(alice)
 logger.info('=== BALANCES ARE OK AFTER SLEEPING')
 
-
 logger.info('EPIC')

--- a/pytest/tests/bridge/same_block.py
+++ b/pytest/tests/bridge/same_block.py
@@ -9,7 +9,8 @@ sys.path.append('lib')
 from configured_logger import logger
 
 if len(sys.argv) < 3:
-    logger.info("python same_block.py <eth2near_tx_number> <near2eth_tx_number> [...]")
+    logger.info(
+        "python same_block.py <eth2near_tx_number> <near2eth_tx_number> [...]")
     exit(1)
 
 eth2near_tx_number = int(sys.argv[1])
@@ -23,14 +24,17 @@ from cluster import start_cluster, start_bridge
 from bridge import alice, bridge_cluster_config_changes, BridgeTx, BridgeTxDirection
 from transaction import sign_function_call_tx
 
+
 @retry(wait_exponential_multiplier=1.2, wait_exponential_max=100)
 def send_tx(node, tx):
     res = node.send_tx(tx)
     logger.info(res)
     return res['result']
 
+
 def near2eth_custom_withdraw(tx, node, adapter):
     return tx.custom['withdraw_ticket']
+
 
 nodes = start_cluster(2, 0, 1, None, [], bridge_cluster_config_changes)
 (bridge, ganache) = start_bridge(nodes)
@@ -52,7 +56,8 @@ while True:
     time.sleep(0.1)
     try:
         status = nodes[0].get_status(check_storage=False)
-        hh = base58.b58decode(status['sync_info']['latest_block_hash'].encode('utf8'))
+        hh = base58.b58decode(
+            status['sync_info']['latest_block_hash'].encode('utf8'))
         if h != hh:
             logger.info(h, status, "new block just appeared!")
             h = hh
@@ -61,21 +66,19 @@ while True:
         pass
 
 withdraws = []
-base_nonce = nodes[0].get_nonce_for_pk(alice.near_account_name, alice.near_signer_key.pk)
+base_nonce = nodes[0].get_nonce_for_pk(alice.near_account_name,
+                                       alice.near_signer_key.pk)
 for nonce_increment in range(near2eth_tx_number):
     tx = BridgeTx(BridgeTxDirection.NEAR2ETH, alice, alice, 1)
     receiver_address = tx.receiver.eth_address
     if receiver_address.startswith('0x'):
         receiver_address = receiver_address[2:]
     withdraw_tx = sign_function_call_tx(
-        tx.sender.near_signer_key,
-        tx.near_token_account_id,
-        'withdraw',
-        bytes('{"amount": "' + str(tx.amount) + '", "recipient": "' + receiver_address + '"}', encoding='utf8'),
-        300000000000000,
-        0,
-        base_nonce + nonce_increment + 1,
-        h)
+        tx.sender.near_signer_key, tx.near_token_account_id, 'withdraw',
+        bytes('{"amount": "' + str(tx.amount) + '", "recipient": "' +
+              receiver_address + '"}',
+              encoding='utf8'), 300000000000000, 0,
+        base_nonce + nonce_increment + 1, h)
     withdraws.append((send_tx(nodes[0], withdraw_tx), tx))
 
 status = nodes[0].get_status(check_storage=False)
@@ -95,6 +98,5 @@ exit_codes = [p.exitcode for p in txs]
 
 assert exit_codes == [0 for _ in txs]
 bridge.check_balances(alice)
-
 
 logger.info('EPIC')

--- a/pytest/tests/bridge/turn_off_relays.py
+++ b/pytest/tests/bridge/turn_off_relays.py
@@ -48,5 +48,4 @@ tx.join()
 assert tx.exitcode == 0
 bridge.check_balances(alice)
 
-
 logger.info('EPIC')

--- a/pytest/tests/bridge/two_users.py
+++ b/pytest/tests/bridge/two_users.py
@@ -8,7 +8,6 @@ import sys, time
 sys.path.append('lib')
 from configured_logger import logger
 
-
 same_amount = False
 if 'same_amount' in sys.argv:
     same_amount = True
@@ -21,7 +20,7 @@ no_txs_in_parallel = False
 if 'no_txs_in_parallel' in sys.argv:
     no_txs_in_parallel = True
 
-assert not (no_txs_in_same_block and no_txs_in_parallel) # to avoid errors
+assert not (no_txs_in_same_block and no_txs_in_parallel)  # to avoid errors
 
 alice_amount = 123
 bob_amount = 15
@@ -56,7 +55,8 @@ bob_amount = bob_amount // 2
 txs = []
 txs.append(bridge.transfer_near2eth(alice, alice_amount))
 if no_txs_in_same_block:
-    time.sleep(bridge_cluster_config_changes['consensus']['min_block_production_delay']['secs'] + 2)
+    time.sleep(bridge_cluster_config_changes['consensus']
+               ['min_block_production_delay']['secs'] + 2)
 if no_txs_in_parallel:
     [p.join() for p in txs]
 txs.append(bridge.transfer_near2eth(bob, bob_amount))
@@ -65,6 +65,5 @@ txs.append(bridge.transfer_near2eth(bob, bob_amount))
 assert exit_codes == [0 for _ in txs]
 bridge.check_balances(alice)
 bridge.check_balances(bob)
-
 
 logger.info('EPIC')

--- a/pytest/tests/contracts/deploy_call_smart_contract.py
+++ b/pytest/tests/contracts/deploy_call_smart_contract.py
@@ -9,6 +9,7 @@ from cluster import start_cluster
 from transaction import sign_deploy_contract_tx, sign_function_call_tx
 from utils import load_test_contract
 
+
 def test_deploy_contract():
     nodes = start_cluster(
         2, 0, 1, None,
@@ -17,18 +18,18 @@ def test_deploy_contract():
     status = nodes[0].get_status()
     last_block_hash = status['sync_info']['latest_block_hash']
     last_block_hash = base58.b58decode(last_block_hash.encode('utf8'))
-    tx = sign_deploy_contract_tx(
-            nodes[0].signer_key, load_test_contract(), 10, last_block_hash)
+    tx = sign_deploy_contract_tx(nodes[0].signer_key, load_test_contract(), 10,
+                                 last_block_hash)
     nodes[0].send_tx(tx)
     time.sleep(3)
 
     status = nodes[1].get_status()
     last_block_hash = status['sync_info']['latest_block_hash']
     last_block_hash = base58.b58decode(last_block_hash.encode('utf8'))
-    tx = sign_function_call_tx(
-            nodes[0].signer_key, nodes[0].signer_key.account_id,
-            'log_something', [], 100000000000, 100000000000, 20,
-            last_block_hash)
+    tx = sign_function_call_tx(nodes[0].signer_key,
+                               nodes[0].signer_key.account_id, 'log_something',
+                               [], 100000000000, 100000000000, 20,
+                               last_block_hash)
     res = nodes[1].send_tx_and_wait(tx, 20)
     import json
     print(json.dumps(res, indent=2))

--- a/pytest/tests/contracts/gibberish.py
+++ b/pytest/tests/contracts/gibberish.py
@@ -72,8 +72,8 @@ status2 = nodes[1].get_status()
 hash_2 = status2['sync_info']['latest_block_hash']
 hash_2 = base58.b58decode(hash_2.encode('utf8'))
 tx2 = sign_function_call_tx(nodes[0].signer_key, nodes[0].signer_key.account_id,
-                            'log_something', [], 3000000000000, 100000000000, 62,
-                            hash_2)
+                            'log_something', [], 3000000000000, 100000000000,
+                            62, hash_2)
 res = nodes[1].send_tx_and_wait(tx2, 20)
 logger.info(res)
 assert res['result']['receipts_outcome'][0]['outcome']['logs'][0] == 'hello'

--- a/pytest/tests/contracts/infinite_loops.py
+++ b/pytest/tests/contracts/infinite_loops.py
@@ -12,15 +12,18 @@ from utils import load_test_contract
 
 nodes = start_cluster(
     4, 0, 1, None,
-    [["epoch_length", 10], ["block_producer_kickout_threshold", 80], ["transaction_validity_period", 10000]], {})
+    [["epoch_length", 10], ["block_producer_kickout_threshold", 80],
+     ["transaction_validity_period", 10000]], {})
 
 status = nodes[0].get_status()
 hash_ = status['sync_info']['latest_block_hash']
 hash_ = base58.b58decode(hash_.encode('utf8'))
-tx = sign_deploy_contract_tx(nodes[0].signer_key, load_test_contract(), 10, hash_)
+tx = sign_deploy_contract_tx(nodes[0].signer_key, load_test_contract(), 10,
+                             hash_)
 nodes[0].send_tx(tx)
 
 time.sleep(3)
+
 
 # send num_tx function calls from node[i]'s account
 def send_transactions(i, num_tx):
@@ -30,13 +33,18 @@ def send_transactions(i, num_tx):
     hash_2 = base58.b58decode(hash_2.encode('utf8'))
     nonce = 20
     for _ in range(num_tx):
-        tx = sign_function_call_tx(nodes[i].signer_key, nodes[0].signer_key.account_id,
-                                    'loop_forever', [], 300000000000, 0, nonce,
-                                    hash_2)
+        tx = sign_function_call_tx(nodes[i].signer_key,
+                                   nodes[0].signer_key.account_id,
+                                   'loop_forever', [], 300000000000, 0, nonce,
+                                   hash_2)
         nonce += 1
         res = nodes[i].send_tx_and_wait(tx, 20)
         assert 'result' in res, res
-        assert res['result']['status']['Failure']['ActionError']['kind']['FunctionCallError']['ExecutionError'] == 'Exceeded the prepaid gas.', "result: {}".format(res)
+        assert res['result']['status']['Failure']['ActionError']['kind'][
+            'FunctionCallError'][
+                'ExecutionError'] == 'Exceeded the prepaid gas.', "result: {}".format(
+                    res)
+
 
 with concurrent.futures.ThreadPoolExecutor() as executor:
     futures = []

--- a/pytest/tests/delete_remote_nodes.py
+++ b/pytest/tests/delete_remote_nodes.py
@@ -12,12 +12,16 @@ sys.path.append('lib')
 from utils import user_name
 
 machines = gcloud.list()
-to_delete_prefix = sys.argv[1] if len(sys.argv) >= 2 else f"pytest-node-{user_name()}-"
-to_delete = list(filter(lambda m: m.name.startswith(to_delete_prefix), machines))
+to_delete_prefix = sys.argv[1] if len(
+    sys.argv) >= 2 else f"pytest-node-{user_name()}-"
+to_delete = list(filter(lambda m: m.name.startswith(to_delete_prefix),
+                        machines))
 
 if to_delete:
-    a = input(f"going to delete {list(map(lambda m: m.name, to_delete))}\ny/n: ")
+    a = input(
+        f"going to delete {list(map(lambda m: m.name, to_delete))}\ny/n: ")
     if strtobool(a):
+
         def delete_machine(m):
             logger.info(f'deleting {m.name}')
             m.delete()

--- a/pytest/tests/mocknet/load_testing.py
+++ b/pytest/tests/mocknet/load_testing.py
@@ -92,8 +92,7 @@ def check_slow_blocks(initial_metrics, final_metrics):
     slow_process_blocks = delta.block_processing_time[
         'le +Inf'] - delta.block_processing_time['le 1']
     logger.info(
-        f'Number of blocks processing for more than 1s: {slow_process_blocks}'
-    )
+        f'Number of blocks processing for more than 1s: {slow_process_blocks}')
     return slow_process_blocks == 0
 
 

--- a/pytest/tests/mocknet/sanity.py
+++ b/pytest/tests/mocknet/sanity.py
@@ -46,8 +46,8 @@ assert (initial_balances[1] + 100) % 1000 == new_balances[1] % 1000
 
 # Test contract deployment
 
-tx = sign_deploy_contract_tx(
-    accounts[2], load_test_contract(), nonces[2] + 1, last_block_hash_decoded)
+tx = sign_deploy_contract_tx(accounts[2], load_test_contract(), nonces[2] + 1,
+                             last_block_hash_decoded)
 nodes[0].send_tx_and_wait(tx, timeout=20)
 
 tx2 = sign_function_call_tx(accounts[2], accounts[2].account_id,

--- a/pytest/tests/runtime/fuzz.py
+++ b/pytest/tests/runtime/fuzz.py
@@ -2,8 +2,8 @@ import os
 
 
 def main():
-    args = ('cargo', 'fuzz', 'run', 'runtime-fuzzer', '--',
-           '-len_control=0' '-prefer_small=0', '-max_len=4000000')
+    args = ('cargo', 'fuzz', 'run', 'runtime-fuzzer', '--', '-len_control=0'
+            '-prefer_small=0', '-max_len=4000000')
     os.chdir('../test-utils/runtime-tester/fuzz')
     os.environ['RUSTC_BOOTSTRAP'] = '1'
     os.execvp('cargo', args)

--- a/pytest/tests/sandbox/patch_state.py
+++ b/pytest/tests/sandbox/patch_state.py
@@ -16,6 +16,7 @@ CONFIG = {
     'release': False,
 }
 
+
 def figure_out_binary():
     # When run on NayDuck we end up with a binary called neard in target/debug
     # but when run locally the binary might be near-sandbox instead.  Try to
@@ -30,12 +31,11 @@ def figure_out_binary():
     assert False, ('Unable to figure out location of near-sandbox binary; '
                    'Did you forget to run `make sandbax`?')
 
+
 figure_out_binary()
 
 # start node
-nodes = start_cluster(
-    1, 0, 1, CONFIG,
-    [["epoch_length", 10]], {})
+nodes = start_cluster(1, 0, 1, CONFIG, [["epoch_length", 10]], {})
 
 # deploy contract
 status = nodes[0].get_status()
@@ -53,23 +53,28 @@ hash_2 = base58.b58decode(hash_2.encode('utf8'))
 k = (10).to_bytes(8, byteorder="little")
 v = (20).to_bytes(8, byteorder="little")
 tx2 = sign_function_call_tx(nodes[0].signer_key, nodes[0].signer_key.account_id,
-                            'write_key_value', k + v,
-                            1000000000000, 0, 20, hash_2)
+                            'write_key_value', k + v, 1000000000000, 0, 20,
+                            hash_2)
 res = nodes[0].send_tx_and_wait(tx2, 20)
-assert('SuccessValue' in res['result']['status'])
-res = nodes[0].call_function("test0", "read_value", base64.b64encode(k).decode('ascii'))
-assert(res['result']['result'] == list(v))
+assert ('SuccessValue' in res['result']['status'])
+res = nodes[0].call_function("test0", "read_value",
+                             base64.b64encode(k).decode('ascii'))
+assert (res['result']['result'] == list(v))
 
 # patch it
 new_v = (30).to_bytes(8, byteorder="little")
-res = nodes[0].json_rpc('sandbox_patch_state', {
-    "records": [{'Data': {
-        'account_id': "test0",
-        'data_key': base64.b64encode(k).decode('ascii'),
-        'value': base64.b64encode(new_v).decode('ascii'),
-    }}]
-})
+res = nodes[0].json_rpc(
+    'sandbox_patch_state', {
+        "records": [{
+            'Data': {
+                'account_id': "test0",
+                'data_key': base64.b64encode(k).decode('ascii'),
+                'value': base64.b64encode(new_v).decode('ascii'),
+            }
+        }]
+    })
 
 # patch should succeed
-res = nodes[0].call_function("test0", "read_value", base64.b64encode(k).decode('ascii'))
-assert(res['result']['result'] == list(new_v))
+res = nodes[0].call_function("test0", "read_value",
+                             base64.b64encode(k).decode('ascii'))
+assert (res['result']['result'] == list(new_v))

--- a/pytest/tests/sanity/block_chunk_signature.py
+++ b/pytest/tests/sanity/block_chunk_signature.py
@@ -10,7 +10,9 @@ from configured_logger import logger
 from peer import *
 from proxy import ProxyHandler
 
+
 class Handler(ProxyHandler):
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.blocks = 0

--- a/pytest/tests/sanity/block_production.py
+++ b/pytest/tests/sanity/block_production.py
@@ -21,7 +21,8 @@ BLOCKS = 50
 
 nodes = start_cluster(
     4, 0, 4, None,
-    [["epoch_length", 10], ["block_producer_kickout_threshold", 60], ["chunk_producer_kickout_threshold", 60]], {})
+    [["epoch_length", 10], ["block_producer_kickout_threshold", 60],
+     ["chunk_producer_kickout_threshold", 60]], {})
 
 started = time.time()
 
@@ -61,7 +62,7 @@ while max_height < BLOCKS:
             max_height = height
             if height % 10 == 0:
                 logger.info("Reached height %s, min common: %s" %
-                      (height, min_common()))
+                            (height, min_common()))
 
         if height not in height_to_hash:
             height_to_hash[height] = hash_

--- a/pytest/tests/sanity/block_sync_archival.py
+++ b/pytest/tests/sanity/block_sync_archival.py
@@ -10,7 +10,7 @@ from cluster import start_cluster
 TARGET_HEIGHT = 100
 TIMEOUT = 120
 
-client_config0 = { "archive": True }
+client_config0 = {"archive": True}
 client_config1 = {
     "archive": True,
     "tracked_shards": [0],
@@ -18,7 +18,10 @@ client_config1 = {
 
 nodes = start_cluster(
     1, 1, 1, None,
-    [["epoch_length", 10], ["block_producer_kickout_threshold", 80]], {0: client_config0, 1: client_config1})
+    [["epoch_length", 10], ["block_producer_kickout_threshold", 80]], {
+        0: client_config0,
+        1: client_config1
+    })
 
 nodes[1].kill()
 

--- a/pytest/tests/sanity/concurrent_function_calls.py
+++ b/pytest/tests/sanity/concurrent_function_calls.py
@@ -34,26 +34,32 @@ for i in range(10):
     keyvalue = bytearray(16)
     keyvalue[0] = i
     keyvalue[8] = i
-    tx2 = sign_function_call_tx(nodes[0].signer_key, nodes[0].signer_key.account_id,
-                                'write_key_value', bytes(keyvalue), 10000000000000, 100000000000, 20 + i * 10,
+    tx2 = sign_function_call_tx(nodes[0].signer_key,
+                                nodes[0].signer_key.account_id,
+                                'write_key_value', bytes(keyvalue),
+                                10000000000000, 100000000000, 20 + i * 10,
                                 hash_2)
     res = nodes[1].send_tx(tx2)
 
 time.sleep(3)
 acc_id = nodes[0].signer_key.account_id
 
+
 def process():
     for i in range(100):
         key = bytearray(8)
         key[0] = i % 10
-        res = nodes[1].call_function(acc_id, 'read_value', base64.b64encode(bytes(key)).decode("ascii"))
+        res = nodes[1].call_function(
+            acc_id, 'read_value',
+            base64.b64encode(bytes(key)).decode("ascii"))
         res = int.from_bytes(res["result"]["result"], byteorder='little')
         assert res == (i % 10)
     logger.info("all done")
 
-ps = [ multiprocessing.Process(target=process, args=()) for i in range(6) ]
+
+ps = [multiprocessing.Process(target=process, args=()) for i in range(6)]
 for p in ps:
- p.start()
+    p.start()
 
 for p in ps:
- p.join()
+    p.join()

--- a/pytest/tests/sanity/epoch_switches.py
+++ b/pytest/tests/sanity/epoch_switches.py
@@ -17,12 +17,56 @@ config = None
 nodes = start_cluster(
     2, 2, 1, config,
     [["epoch_length", EPOCH_LENGTH], ["block_producer_kickout_threshold", 40]],
-    {0: {"view_client_throttle_period": {"secs": 0, "nanos": 0}, "consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}}},
-     1: {"view_client_throttle_period": {"secs": 0, "nanos": 0}, "consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}}},
-     2: {
-        "tracked_shards": [0], "view_client_throttle_period": {"secs": 0, "nanos": 0}, "consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}}
-    },
-    3: {"view_client_throttle_period": {"secs": 0, "nanos": 0}, "consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}}}
+    {
+        0: {
+            "view_client_throttle_period": {
+                "secs": 0,
+                "nanos": 0
+            },
+            "consensus": {
+                "state_sync_timeout": {
+                    "secs": 2,
+                    "nanos": 0
+                }
+            }
+        },
+        1: {
+            "view_client_throttle_period": {
+                "secs": 0,
+                "nanos": 0
+            },
+            "consensus": {
+                "state_sync_timeout": {
+                    "secs": 2,
+                    "nanos": 0
+                }
+            }
+        },
+        2: {
+            "tracked_shards": [0],
+            "view_client_throttle_period": {
+                "secs": 0,
+                "nanos": 0
+            },
+            "consensus": {
+                "state_sync_timeout": {
+                    "secs": 2,
+                    "nanos": 0
+                }
+            }
+        },
+        3: {
+            "view_client_throttle_period": {
+                "secs": 0,
+                "nanos": 0
+            },
+            "consensus": {
+                "state_sync_timeout": {
+                    "secs": 2,
+                    "nanos": 0
+                }
+            }
+        }
     })
 
 started = time.time()
@@ -97,9 +141,11 @@ while True:
         seen_epochs.add(epoch_id)
 
         while len(seen_epochs) > 1:
-            prev_block = nodes[0].get_block(block['result']['header']['prev_hash'])
+            prev_block = nodes[0].get_block(
+                block['result']['header']['prev_hash'])
             logger.info(prev_block)
-            if prev_block['result']['header']['epoch_id'] != block['result']['header']['epoch_id']:
+            if prev_block['result']['header']['epoch_id'] != block['result'][
+                    'header']['epoch_id']:
                 height = block['result']['header']['height']
                 break
             block = prev_block

--- a/pytest/tests/sanity/gc_after_sync1.py
+++ b/pytest/tests/sanity/gc_after_sync1.py
@@ -16,9 +16,7 @@ TARGET_HEIGHT2 = 35
 TARGET_HEIGHT3 = 105
 TIME_OUT = 80
 
-node0_config = {
-    "gc_blocks_limit": 10
-}
+node0_config = {"gc_blocks_limit": 10}
 
 node1_config = {
     "consensus": {
@@ -33,8 +31,10 @@ node1_config = {
 nodes = start_cluster(
     1, 1, 1, None,
     [["epoch_length", 10], ["block_producer_kickout_threshold", 80],
-     ["chunk_producer_kickout_threshold", 80]
-     ], {0: node0_config, 1: node1_config})
+     ["chunk_producer_kickout_threshold", 80]], {
+         0: node0_config,
+         1: node1_config
+     })
 
 status1 = nodes[1].get_status()
 height = status1['sync_info']['latest_block_height']

--- a/pytest/tests/sanity/handshake_tie_resolution.py
+++ b/pytest/tests/sanity/handshake_tie_resolution.py
@@ -10,14 +10,12 @@ sys.path.append('lib')
 from cluster import start_cluster
 from utils import LogTracker
 
-
 TIMEOUT = 150
 BLOCKS = 20
 
 nodes = start_cluster(4, 0, 4, None, [], {})
 
 started = time.time()
-
 
 trackers = [LogTracker(node) for node in nodes]
 
@@ -29,4 +27,5 @@ while True:
     if height >= BLOCKS:
         break
 
-assert all(not tracker.check('Dropping handshake (Active Peer).') for tracker in trackers)
+assert all(not tracker.check('Dropping handshake (Active Peer).')
+           for tracker in trackers)

--- a/pytest/tests/sanity/lightclnt.py
+++ b/pytest/tests/sanity/lightclnt.py
@@ -97,7 +97,8 @@ def get_up_to(from_, to):
 
     for i in range(from_, to + 1):
         hash_ = height_to_hash[i]
-        logger.info(f"{i} {hash_} {hash_to_epoch[hash_]} {hash_to_next_epoch[hash_]}")
+        logger.info(
+            f"{i} {hash_} {hash_to_epoch[hash_]} {hash_to_next_epoch[hash_]}")
 
         if len(epochs) == 0 or epochs[-1] != hash_to_epoch[hash_]:
             epochs.append(hash_to_epoch[hash_])

--- a/pytest/tests/sanity/network_drop_package.py
+++ b/pytest/tests/sanity/network_drop_package.py
@@ -17,12 +17,13 @@ height = Value('i', 0)
 # Ratio of message that are dropped to simulate bad network performance
 DROP_RATIO = 0.05
 
+
 class Handler(ProxyHandler):
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.dropped = 0
         self.total = 0
-
 
     async def handle(self, msg, fr, to):
         if msg.enum == 'Block':
@@ -35,7 +36,8 @@ class Handler(ProxyHandler):
 
             with success.get_lock():
                 if h >= 10 and success.value == 0:
-                    logging.info(f'SUCCESS DROP={self.dropped} TOTAL={self.total}')
+                    logging.info(
+                        f'SUCCESS DROP={self.dropped} TOTAL={self.total}')
                     success.value = 1
 
         drop = random.random() < DROP_RATIO and 'Handshake' not in msg.enum

--- a/pytest/tests/sanity/one_val.py
+++ b/pytest/tests/sanity/one_val.py
@@ -54,7 +54,7 @@ while True:
 
     if ctx.get_balances() == ctx.expected_balances:
         logger.info("Balances caught up, took %s blocks, moving on" %
-              (height - sent_height))
+                    (height - sent_height))
         ctx.send_moar_txs(hash_, 10, use_routing=True)
         sent_height = height
         caught_up_times += 1

--- a/pytest/tests/sanity/proxy_example.py
+++ b/pytest/tests/sanity/proxy_example.py
@@ -20,7 +20,9 @@ from multiprocessing import Value
 TIMEOUT = 30
 success = Value('i', 0)
 
+
 class Handler(ProxyHandler):
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.peers_response = 0

--- a/pytest/tests/sanity/proxy_restart.py
+++ b/pytest/tests/sanity/proxy_restart.py
@@ -19,7 +19,6 @@ nodes[1].kill()
 nodes[1].start(nodes[0].node_key.pk, nodes[0].addr())
 started = time.time()
 
-
 while True:
     assert time.time() - started < TIMEOUT
     time.sleep(2)

--- a/pytest/tests/sanity/proxy_simple.py
+++ b/pytest/tests/sanity/proxy_simple.py
@@ -16,7 +16,9 @@ from utils import obj_to_string
 TIMEOUT = 30
 success = Value('i', 0)
 
+
 class Handler(ProxyHandler):
+
     async def handle(self, msg, fr, to):
         if msg.enum == 'Block':
             h = msg.Block.BlockV2.header.inner_lite().height

--- a/pytest/tests/sanity/repro_2916.py
+++ b/pytest/tests/sanity/repro_2916.py
@@ -26,6 +26,7 @@ from messages.block import *
 from messages.crypto import *
 from messages.network import *
 
+
 async def main():
     # start a cluster with two shards
     nodes = start_cluster(2, 0, 2, None, [], {})
@@ -42,7 +43,10 @@ async def main():
 
         if height > 2:
             block = nodes[0].get_block(hash_)
-            chunk_hashes = [base58.b58decode(x['chunk_hash']) for x in block['result']['chunks']]
+            chunk_hashes = [
+                base58.b58decode(x['chunk_hash'])
+                for x in block['result']['chunks']
+            ]
 
             assert len(chunk_hashes) == 2
             assert all([len(x) == 32 for x in chunk_hashes])
@@ -52,8 +56,8 @@ async def main():
     my_key_pair_nacl = nacl.signing.SigningKey.generate()
     received_responses = [None, None]
 
-# step = 0: before the node is killed
-# step = 1: after the node is killed
+    # step = 0: before the node is killed
+    # step = 1: after the node is killed
     for step in range(2):
 
         conn0 = await connect(nodes[0].addr())
@@ -69,7 +73,8 @@ async def main():
             routed_msg_body.enum = 'PartialEncodedChunkRequest'
             routed_msg_body.PartialEncodedChunkRequest = request
 
-            peer_message = create_and_sign_routed_peer_message(routed_msg_body, nodes[0], my_key_pair_nacl)
+            peer_message = create_and_sign_routed_peer_message(
+                routed_msg_body, nodes[0], my_key_pair_nacl)
 
             await conn0.send(peer_message)
 
@@ -92,7 +97,10 @@ async def main():
             if step == 0:
                 received_responses[shard_ord] = received_response
             else:
-                assert received_responses[shard_ord] == received_response, "The response doesn't match for the chunk in shard %s. Received response before node killed: %s, after: %s" % (shard_ord, received_responses[shard_ord], received_response)
+                assert received_responses[
+                    shard_ord] == received_response, "The response doesn't match for the chunk in shard %s. Received response before node killed: %s, after: %s" % (
+                        shard_ord, received_responses[shard_ord],
+                        received_response)
 
         # we expect first node to only respond to one of the chunk requests, for the shard assigned to it
         assert received_responses[0] != received_responses[1], received_responses

--- a/pytest/tests/sanity/restaked.py
+++ b/pytest/tests/sanity/restaked.py
@@ -35,7 +35,8 @@ def start_restaked(node_dir, rpc_port, config):
     if node_dir:
         command.extend(['--home', node_dir])
     pid = subprocess.Popen(command).pid
-    logger.info("Starting restaked for %s, rpc = 0.0.0.0:%d" % (node_dir, rpc_port))
+    logger.info("Starting restaked for %s, rpc = 0.0.0.0:%d" %
+                (node_dir, rpc_port))
     atexit.register(atexit_stop_restaked, pid)
 
 

--- a/pytest/tests/sanity/restart.py
+++ b/pytest/tests/sanity/restart.py
@@ -47,7 +47,7 @@ while max_height < BLOCKS1:
             max_height = height
             if height % 10 == 0:
                 logger.info("Reached height %s, min common: %s" %
-                      (height, min_common()))
+                            (height, min_common()))
 
         if height not in height_to_hash:
             height_to_hash[height] = hash_
@@ -84,7 +84,7 @@ while max_height < BLOCKS2:
             max_height = height
             if height % 10 == 0:
                 logger.info("Reached height %s, min common: %s" %
-                      (height, min_common()))
+                            (height, min_common()))
 
         if height not in height_to_hash:
             height_to_hash[height] = hash_

--- a/pytest/tests/sanity/rpc_light_client_execution_outcome_proof.py
+++ b/pytest/tests/sanity/rpc_light_client_execution_outcome_proof.py
@@ -36,58 +36,61 @@ class Failure:
 
 partial_execution_outcome_schema = dict([
     [
-        PartialExecutionOutcome, {
-        'kind':
-            'struct',
-        'fields': [
-            ['receipt_ids', [[32]]],
-            ['gas_burnt', 'u64'],
-            ['tokens_burnt', 'u128'],
-            ['executor_id', 'string'],
-            ['status', PartialExecutionStatus],
-        ]
-    },
+        PartialExecutionOutcome,
+        {
+            'kind':
+                'struct',
+            'fields': [
+                ['receipt_ids', [[32]]],
+                ['gas_burnt', 'u64'],
+                ['tokens_burnt', 'u128'],
+                ['executor_id', 'string'],
+                ['status', PartialExecutionStatus],
+            ]
+        },
     ],
     [
         PartialExecutionStatus, {
-        'kind': 'enum',
-        'field': 'enum',
-        'values': [
-            ['unknown', Unknown],
-            ['failure', Failure],
-            ['successValue', ['u8']],
-            ['successReceiptId', [32]],
-        ]
-    }
+            'kind':
+                'enum',
+            'field':
+                'enum',
+            'values': [
+                ['unknown', Unknown],
+                ['failure', Failure],
+                ['successValue', ['u8']],
+                ['successReceiptId', [32]],
+            ]
+        }
     ],
-    [
-        Unknown, {
+    [Unknown, {
         'kind': 'struct',
         'fields': []
-    }
-    ],
-    [
-        Failure, {
+    }],
+    [Failure, {
         'kind': 'struct',
         'fields': []
-    }
-    ],
+    }],
 ])
 
 
 def serialize_execution_outcome_with_id(outcome, id):
     partial_outcome = PartialExecutionOutcome()
-    partial_outcome.receipt_ids = [base58.b58decode(x) for x in outcome['receipt_ids']]
+    partial_outcome.receipt_ids = [
+        base58.b58decode(x) for x in outcome['receipt_ids']
+    ]
     partial_outcome.gas_burnt = outcome['gas_burnt']
     partial_outcome.tokens_burnt = int(outcome['tokens_burnt'])
     partial_outcome.executor_id = outcome['executor_id']
     execution_status = PartialExecutionStatus()
     if 'SuccessValue' in outcome['status']:
         execution_status.enum = 'successValue'
-        execution_status.successValue = base64.b64decode(outcome['status']['SuccessValue'])
+        execution_status.successValue = base64.b64decode(
+            outcome['status']['SuccessValue'])
     elif 'SuccessReceiptId' in outcome['status']:
         execution_status.enum = 'successReceiptId'
-        execution_status.successReceiptId = base58.b58decode(outcome['status']['SuccessReceiptId'])
+        execution_status.successReceiptId = base58.b58decode(
+            outcome['status']['SuccessReceiptId'])
     elif 'Failure' in outcome['status']:
         execution_status.enum = 'failure'
         execution_status.failure = Failure()
@@ -97,11 +100,13 @@ def serialize_execution_outcome_with_id(outcome, id):
     else:
         assert False, f'status not supported: {outcome["status"]}'
     partial_outcome.status = execution_status
-    msg = BinarySerializer(partial_execution_outcome_schema).serialize(partial_outcome)
+    msg = BinarySerializer(partial_execution_outcome_schema).serialize(
+        partial_outcome)
     partial_outcome_hash = hashlib.sha256(msg).digest()
     outcome_hashes = [partial_outcome_hash]
     for log_entry in outcome['logs']:
-        outcome_hashes.append(hashlib.sha256(bytes(log_entry, 'utf-8')).digest())
+        outcome_hashes.append(
+            hashlib.sha256(bytes(log_entry, 'utf-8')).digest())
     res = [base58.b58decode(id)]
     res.extend(outcome_hashes)
     borsh_res = bytearray()
@@ -136,59 +141,84 @@ def check_transaction_outcome_proof(nodes, should_succeed, nonce):
         status = nodes[0].get_status()
         cur_height = status['sync_info']['latest_block_height']
         if cur_height > latest_block_height + 2 and light_client_request_block_hash is None:
-            light_client_request_block_hash = status['sync_info']['latest_block_hash']
+            light_client_request_block_hash = status['sync_info'][
+                'latest_block_hash']
         if cur_height > latest_block_height + 7:
             break
         time.sleep(1)
 
-    light_client_block = nodes[0].json_rpc('next_light_client_block', [light_client_request_block_hash])['result']
-    light_client_block_hash = compute_block_hash(light_client_block['inner_lite'],
-                                                 light_client_block['inner_rest_hash'],
-                                                 light_client_block['prev_block_hash']).decode('utf-8')
+    light_client_block = nodes[0].json_rpc(
+        'next_light_client_block', [light_client_request_block_hash])['result']
+    light_client_block_hash = compute_block_hash(
+        light_client_block['inner_lite'], light_client_block['inner_rest_hash'],
+        light_client_block['prev_block_hash']).decode('utf-8')
 
-    queries = [
-        {"type": "transaction", "transaction_hash": function_call_result['result']['transaction_outcome']['id'], "sender_id": "test0",
-         "light_client_head": light_client_block_hash}
+    queries = [{
+        "type":
+            "transaction",
+        "transaction_hash":
+            function_call_result['result']['transaction_outcome']['id'],
+        "sender_id":
+            "test0",
+        "light_client_head":
+            light_client_block_hash
+    }]
+    outcomes = [
+        (function_call_result['result']['transaction_outcome']['outcome'],
+         function_call_result['result']['transaction_outcome']['id'])
     ]
-    outcomes = [(function_call_result['result']['transaction_outcome']['outcome'],
-                 function_call_result['result']['transaction_outcome']['id'])]
     for receipt_outcome in function_call_result['result']['receipts_outcome']:
         outcomes.append((receipt_outcome['outcome'], receipt_outcome['id']))
-        queries.append({"type": "receipt", "receipt_id": receipt_outcome['id'], "receiver_id": "test0",
-                        "light_client_head": light_client_block_hash})
+        queries.append({
+            "type": "receipt",
+            "receipt_id": receipt_outcome['id'],
+            "receiver_id": "test0",
+            "light_client_head": light_client_block_hash
+        })
 
     for query, (outcome, id) in zip(queries, outcomes):
         res = nodes[0].json_rpc('light_client_proof', query, timeout=10)
         assert 'error' not in res, res
         light_client_proof = res['result']
         # check that execution outcome root proof is valid
-        execution_outcome_hash = hashlib.sha256(serialize_execution_outcome_with_id(outcome, id)).digest()
-        outcome_root = compute_merkle_root_from_path(light_client_proof['outcome_proof']['proof'],
-                                                     execution_outcome_hash)
-        block_outcome_root = compute_merkle_root_from_path(light_client_proof['outcome_root_proof'],
-                                                           hashlib.sha256(outcome_root).digest())
-        block = nodes[0].json_rpc('block', {"block_id": light_client_proof['outcome_proof']['block_hash']})
+        execution_outcome_hash = hashlib.sha256(
+            serialize_execution_outcome_with_id(outcome, id)).digest()
+        outcome_root = compute_merkle_root_from_path(
+            light_client_proof['outcome_proof']['proof'],
+            execution_outcome_hash)
+        block_outcome_root = compute_merkle_root_from_path(
+            light_client_proof['outcome_root_proof'],
+            hashlib.sha256(outcome_root).digest())
+        block = nodes[0].json_rpc(
+            'block',
+            {"block_id": light_client_proof['outcome_proof']['block_hash']})
         expected_root = block['result']['header']['outcome_root']
         assert base58.b58decode(
-            expected_root) == block_outcome_root, f'expected outcome root {expected_root} actual {base58.b58encode(block_outcome_root)}'
+            expected_root
+        ) == block_outcome_root, f'expected outcome root {expected_root} actual {base58.b58encode(block_outcome_root)}'
         # check that the light block header is valid
         block_header_lite = light_client_proof['block_header_lite']
-        computed_block_hash = compute_block_hash(block_header_lite['inner_lite'], block_header_lite['inner_rest_hash'],
-                                                 block_header_lite['prev_block_hash'])
-        assert light_client_proof['outcome_proof']['block_hash'] == computed_block_hash.decode(
-            'utf-8'), f'expected block hash {light_client_proof["outcome_proof"]["block_hash"]} actual {computed_block_hash}'
+        computed_block_hash = compute_block_hash(
+            block_header_lite['inner_lite'],
+            block_header_lite['inner_rest_hash'],
+            block_header_lite['prev_block_hash'])
+        assert light_client_proof['outcome_proof'][
+            'block_hash'] == computed_block_hash.decode(
+                'utf-8'
+            ), f'expected block hash {light_client_proof["outcome_proof"]["block_hash"]} actual {computed_block_hash}'
         # check that block proof is valid
-        block_merkle_root = compute_merkle_root_from_path(light_client_proof['block_proof'],
-                                                          light_client_proof['outcome_proof']['block_hash'])
-        assert base58.b58decode(light_client_block['inner_lite'][
-                                    'block_merkle_root']) == block_merkle_root, f'expected block merkle root {light_client_block["inner_lite"]["block_merkle_root"]} actual {base58.b58encode(block_merkle_root)}'
+        block_merkle_root = compute_merkle_root_from_path(
+            light_client_proof['block_proof'],
+            light_client_proof['outcome_proof']['block_hash'])
+        assert base58.b58decode(
+            light_client_block['inner_lite']['block_merkle_root']
+        ) == block_merkle_root, f'expected block merkle root {light_client_block["inner_lite"]["block_merkle_root"]} actual {base58.b58encode(block_merkle_root)}'
 
 
 def test_outcome_proof():
     nodes = start_cluster(
         2, 0, 1, None,
-        [["epoch_length", 1000], ["block_producer_kickout_threshold", 80]], {}
-    )
+        [["epoch_length", 1000], ["block_producer_kickout_threshold", 80]], {})
 
     status = nodes[0].get_status()
     latest_block_hash = status['sync_info']['latest_block_hash']

--- a/pytest/tests/sanity/rpc_max_gas_burnt.py
+++ b/pytest/tests/sanity/rpc_max_gas_burnt.py
@@ -15,13 +15,17 @@ from cluster import start_cluster
 from utils import load_binary_file
 import transaction
 
+
 def test_max_gas_burnt_view():
-    nodes = start_cluster(2, 0, 1,
-                          config=None,
-                          genesis_config_changes=[],
-                          client_config_changes={
-                              1: {'max_gas_burnt_view': int(5e10)}
-                          })
+    nodes = start_cluster(
+        2,
+        0,
+        1,
+        config=None,
+        genesis_config_changes=[],
+        client_config_changes={1: {
+            'max_gas_burnt_view': int(5e10)
+        }})
 
     contract_key = nodes[0].signer_key
     contract = load_binary_file(
@@ -37,7 +41,9 @@ def test_max_gas_burnt_view():
 
     def call_fib(node, n):
         args = base64.b64encode(bytes([n])).decode('ascii')
-        return node.call_function(contract_key.account_id, 'fibonacci', args,
+        return node.call_function(contract_key.account_id,
+                                  'fibonacci',
+                                  args,
                                   timeout=10).get('result')
 
     # Call view function of the smart contract via the first node.  This should

--- a/pytest/tests/sanity/rpc_state_changes.py
+++ b/pytest/tests/sanity/rpc_state_changes.py
@@ -113,7 +113,8 @@ def test_changes_with_new_account_with_access_key():
 
     # Test happy-path
     block_header = nodes[0].get_block(block_hash)['result']['header']
-    prev_block_header = nodes[0].get_block(block_header['prev_hash'])['result']['header']
+    prev_block_header = nodes[0].get_block(
+        block_header['prev_hash'])['result']['header']
     nonce = prev_block_header['height'] * 1000000
     expected_response = {
         "block_hash":
@@ -399,10 +400,8 @@ def test_key_value_changes():
             },
             "type": "contract_code_update",
             "change": {
-                "account_id":
-                    contract_key.account_id,
-                "code_base64":
-                    base64.b64encode(contract_blob).decode('utf-8'),
+                "account_id": contract_key.account_id,
+                "code_base64": base64.b64encode(contract_blob).decode('utf-8'),
             }
         },]
     }
@@ -436,8 +435,8 @@ def test_key_value_changes():
     def set_value(value, *, nounce):
         args = key + struct.pack('<Q', value)
         tx = transaction.sign_function_call_tx(
-            function_caller_key, contract_key.account_id,
-            'write_key_value', args, 300000000000000, 100000000000, nounce,
+            function_caller_key, contract_key.account_id, 'write_key_value',
+            args, 300000000000000, 100000000000, nounce,
             base58.b58decode(latest_block_hash.encode('utf8')))
         response = nodes[1].send_tx_and_wait(tx, 10)
         try:
@@ -460,7 +459,8 @@ def test_key_value_changes():
     assert_changes_in_block_response(
         request={"block_id": tx_block_hash},
         expected_response={
-            "block_hash": tx_block_hash,
+            "block_hash":
+                tx_block_hash,
             "changes": [
                 {
                     "type": "account_touched",
@@ -511,31 +511,34 @@ def test_key_value_changes():
 
     # Test happy-path
     expected_response = {
-        "block_hash": tx_block_hash,
+        "block_hash":
+            tx_block_hash,
         "changes": [{
             "cause": {
                 "type": "receipt_processing",
             },
             "type": "data_update",
             "change": {
-                "account_id": contract_key.account_id,
-                "key_base64": key_base64,
-                "value_base64": base64.b64encode(
-                    struct.pack('<Q', 10)).decode('ascii'),
+                "account_id":
+                    contract_key.account_id,
+                "key_base64":
+                    key_base64,
+                "value_base64":
+                    base64.b64encode(struct.pack('<Q', 10)).decode('ascii'),
             }
         }, {
             "cause": {
-                "type":
-                    "receipt_processing",
-                "receipt_hash":
-                    response["result"]["receipts_outcome"][0]["id"],
+                "type": "receipt_processing",
+                "receipt_hash": response["result"]["receipts_outcome"][0]["id"],
             },
             "type": "data_update",
             "change": {
-                "account_id": contract_key.account_id,
-                "key_base64": key_base64,
-                "value_base64": base64.b64encode(
-                    struct.pack('<Q', 20)).decode('ascii'),
+                "account_id":
+                    contract_key.account_id,
+                "key_base64":
+                    key_base64,
+                "value_base64":
+                    base64.b64encode(struct.pack('<Q', 20)).decode('ascii'),
             }
         }]
     }

--- a/pytest/tests/sanity/rpc_tx_forwarding.py
+++ b/pytest/tests/sanity/rpc_tx_forwarding.py
@@ -12,17 +12,43 @@ from configured_logger import logger
 from utils import TxContext
 from transaction import sign_payment_tx
 
-nodes = start_cluster(2, 2, 4, None,
-                      [["min_gas_price", 0], ["epoch_length", 10],
-                       ["block_producer_kickout_threshold", 70]],
-                      {
-                          0: {"consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}}},
-                          1: {"consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}}},
-                          2: {"consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}}},
-                          3: {
-                              "tracked_shards": [0, 1, 2, 3],
-                              "consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}}
-                      }})
+nodes = start_cluster(
+    2, 2, 4, None, [["min_gas_price", 0], ["epoch_length", 10],
+                    ["block_producer_kickout_threshold", 70]], {
+                        0: {
+                            "consensus": {
+                                "state_sync_timeout": {
+                                    "secs": 2,
+                                    "nanos": 0
+                                }
+                            }
+                        },
+                        1: {
+                            "consensus": {
+                                "state_sync_timeout": {
+                                    "secs": 2,
+                                    "nanos": 0
+                                }
+                            }
+                        },
+                        2: {
+                            "consensus": {
+                                "state_sync_timeout": {
+                                    "secs": 2,
+                                    "nanos": 0
+                                }
+                            }
+                        },
+                        3: {
+                            "tracked_shards": [0, 1, 2, 3],
+                            "consensus": {
+                                "state_sync_timeout": {
+                                    "secs": 2,
+                                    "nanos": 0
+                                }
+                            }
+                        }
+                    })
 
 time.sleep(3)
 started = time.time()

--- a/pytest/tests/sanity/rpc_tx_status.py
+++ b/pytest/tests/sanity/rpc_tx_status.py
@@ -35,19 +35,18 @@ def submit_tx_and_check(nodes, node_index, tx):
 
 
 def test_tx_status():
-    nodes = start_cluster(4, 0, 1, None,
-                          [["epoch_length", 1000],
-                           ["block_producer_kickout_threshold", 80],
-                           ["transaction_validity_period", 10000]],
-                          {})
+    nodes = start_cluster(
+        4, 0, 1, None,
+        [["epoch_length", 1000], ["block_producer_kickout_threshold", 80],
+         ["transaction_validity_period", 10000]], {})
 
     signer_key = nodes[0].signer_key
     status = nodes[0].get_status()
     block_hash = status['sync_info']['latest_block_hash']
     encoded_block_hash = base58.b58decode(block_hash.encode('ascii'))
 
-    payment_tx = transaction.sign_payment_tx(
-        signer_key, 'test1', 100, 1, encoded_block_hash)
+    payment_tx = transaction.sign_payment_tx(signer_key, 'test1', 100, 1,
+                                             encoded_block_hash)
     submit_tx_and_check(nodes, 0, payment_tx)
 
     deploy_contract_tx = transaction.sign_deploy_contract_tx(
@@ -55,9 +54,8 @@ def test_tx_status():
     submit_tx_and_check(nodes, 0, deploy_contract_tx)
 
     function_call_tx = transaction.sign_function_call_tx(
-        signer_key, signer_key.account_id,
-        'write_key_value', struct.pack('<QQ', 42, 24),
-        300000000000000, 0, 3, encoded_block_hash)
+        signer_key, signer_key.account_id, 'write_key_value',
+        struct.pack('<QQ', 42, 24), 300000000000000, 0, 3, encoded_block_hash)
     submit_tx_and_check(nodes, 0, deploy_contract_tx)
 
 

--- a/pytest/tests/sanity/rpc_tx_submission.py
+++ b/pytest/tests/sanity/rpc_tx_submission.py
@@ -10,10 +10,9 @@ from utils import TxContext
 from transaction import sign_payment_tx
 
 nodes = start_cluster(
-    2, 1, 1, None,
-    [["min_gas_price", 0], ['max_inflation_rate', [0, 1]], ["epoch_length", 100],
-     ['transaction_validity_period', 200],
-     ["block_producer_kickout_threshold", 70]], {})
+    2, 1, 1, None, [["min_gas_price", 0], ['max_inflation_rate', [0, 1]],
+                    ["epoch_length", 100], ['transaction_validity_period', 200],
+                    ["block_producer_kickout_threshold", 70]], {})
 
 time.sleep(3)
 started = time.time()
@@ -57,18 +56,15 @@ tx = sign_payment_tx(nodes[0].signer_key, 'test1', 100, 1,
                      base58.b58decode(hash1.encode('utf8')))
 
 # tx status check should be idempotent
-res = nodes[0].json_rpc('tx',
-                        [base64.b64encode(tx).decode('utf8')], timeout=10)
+res = nodes[0].json_rpc('tx', [base64.b64encode(tx).decode('utf8')], timeout=10)
 assert 'error' not in res, res
 
 # broadcast_tx_commit should be idempotent
 res = nodes[0].send_tx_and_wait(tx, timeout=15)
 assert 'error' not in res, res
 
-
 tx = sign_payment_tx(nodes[0].signer_key, 'test1', 100, 10,
                      base58.b58decode(hash_.encode('utf8')))
 # check a transaction that doesn't exist yet
-res = nodes[0].json_rpc('tx',
-                        [base64.b64encode(tx).decode('utf8')], timeout=10)
+res = nodes[0].json_rpc('tx', [base64.b64encode(tx).decode('utf8')], timeout=10)
 assert "doesn't exist" in res['error']['data'], res

--- a/pytest/tests/sanity/skip_epoch.py
+++ b/pytest/tests/sanity/skip_epoch.py
@@ -22,14 +22,64 @@ config = load_config()
 near_root, node_dirs = init_cluster(
     4, 1, 4, config,
     [["min_gas_price", 0], ["max_inflation_rate", [0, 1]], ["epoch_length", 12],
-     ["block_producer_kickout_threshold", 20], ["chunk_producer_kickout_threshold", 20]],
-    {0: {"view_client_throttle_period": {"secs": 0, "nanos": 0}, "consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}}},
-     1: {"view_client_throttle_period": {"secs": 0, "nanos": 0}, "consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}}},
-     2: {"view_client_throttle_period": {"secs": 0, "nanos": 0}, "consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}}},
-     3: {"view_client_throttle_period": {"secs": 0, "nanos": 0}, "consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}}}, 4: {
-        "tracked_shards": [0, 1, 2, 3],
-        "view_client_throttle_period": {"secs": 0, "nanos": 0}
-    }})
+     ["block_producer_kickout_threshold", 20],
+     ["chunk_producer_kickout_threshold", 20]], {
+         0: {
+             "view_client_throttle_period": {
+                 "secs": 0,
+                 "nanos": 0
+             },
+             "consensus": {
+                 "state_sync_timeout": {
+                     "secs": 2,
+                     "nanos": 0
+                 }
+             }
+         },
+         1: {
+             "view_client_throttle_period": {
+                 "secs": 0,
+                 "nanos": 0
+             },
+             "consensus": {
+                 "state_sync_timeout": {
+                     "secs": 2,
+                     "nanos": 0
+                 }
+             }
+         },
+         2: {
+             "view_client_throttle_period": {
+                 "secs": 0,
+                 "nanos": 0
+             },
+             "consensus": {
+                 "state_sync_timeout": {
+                     "secs": 2,
+                     "nanos": 0
+                 }
+             }
+         },
+         3: {
+             "view_client_throttle_period": {
+                 "secs": 0,
+                 "nanos": 0
+             },
+             "consensus": {
+                 "state_sync_timeout": {
+                     "secs": 2,
+                     "nanos": 0
+                 }
+             }
+         },
+         4: {
+             "tracked_shards": [0, 1, 2, 3],
+             "view_client_throttle_period": {
+                 "secs": 0,
+                 "nanos": 0
+             }
+         }
+     })
 
 started = time.time()
 
@@ -48,7 +98,7 @@ initial_balances = ctx.get_balances()
 total_supply = sum(initial_balances)
 
 logger.info("Initial balances: %s\nTotal supply: %s" %
-      (initial_balances, total_supply))
+            (initial_balances, total_supply))
 
 seen_boot_heights = set()
 sent_txs = False
@@ -119,7 +169,8 @@ logger.info("stage 2 done")
 #    receipts during the state sync from the observer.
 #    `max_inflation_rate` is set to zero, so the rewards do not mess up with the balances
 balances = ctx.get_balances()
-logger.info("New balances: %s\nNew total supply: %s" % (balances, sum(balances)))
+logger.info("New balances: %s\nNew total supply: %s" %
+            (balances, sum(balances)))
 
 assert (balances != initial_balances)
 assert (sum(balances) == total_supply)
@@ -191,11 +242,13 @@ while True:
     time.sleep(0.1)
 
 balances = ctx.get_balances()
-logger.info("New balances: %s\nNew total supply: %s" % (balances, sum(balances)))
+logger.info("New balances: %s\nNew total supply: %s" %
+            (balances, sum(balances)))
 
 ctx.nodes = [observer, node2]
 ctx.act_to_val = [0, 0, 0, 0, 0]
 logger.info("Observer sees: %s" % ctx.get_balances())
 
-assert balances != initial_balances, "current balance %s, initial balance %s" % (balances, initial_balances)
+assert balances != initial_balances, "current balance %s, initial balance %s" % (
+    balances, initial_balances)
 assert sum(balances) == total_supply

--- a/pytest/tests/sanity/staking2.py
+++ b/pytest/tests/sanity/staking2.py
@@ -42,7 +42,11 @@ def get_stakes():
 
 def get_expected_stakes():
     global all_stakes
-    return [max(fake_stakes[i], max([x[i] for x in all_stakes[-3:]])) for i in range(3)]
+    return [
+        max(fake_stakes[i], max([x[i]
+                                 for x in all_stakes[-3:]]))
+        for i in range(3)
+    ]
 
 
 def do_moar_stakes(last_block_hash, update_expected):
@@ -76,7 +80,7 @@ def do_moar_stakes(last_block_hash, update_expected):
         fake_stakes = stakes
 
     logger.info("Sent %s staking txs: %s" %
-          ("REAL" if update_expected else "fake", stakes))
+                ("REAL" if update_expected else "fake", stakes))
 
 
 def doit(seq=[]):
@@ -84,17 +88,48 @@ def doit(seq=[]):
     sequence = seq
 
     config = None
-    nodes = start_cluster(2, 1, 1, config,
-                          [["epoch_length", EPOCH_LENGTH],
-                           ["block_producer_kickout_threshold", 40],
-                           ["chunk_producer_kickout_threshold", 40]],
-                          {0: {"view_client_throttle_period": {"secs": 0, "nanos": 0}, "consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}}},
-                           1: {"view_client_throttle_period": {"secs": 0, "nanos": 0}, "consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}}},
-                           2: {
-                              "tracked_shards": [0],
-                              "view_client_throttle_period": {"secs": 0, "nanos": 0},
-                              "consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}}
-                          }})
+    nodes = start_cluster(
+        2, 1, 1, config, [["epoch_length", EPOCH_LENGTH],
+                          ["block_producer_kickout_threshold", 40],
+                          ["chunk_producer_kickout_threshold", 40]], {
+                              0: {
+                                  "view_client_throttle_period": {
+                                      "secs": 0,
+                                      "nanos": 0
+                                  },
+                                  "consensus": {
+                                      "state_sync_timeout": {
+                                          "secs": 2,
+                                          "nanos": 0
+                                      }
+                                  }
+                              },
+                              1: {
+                                  "view_client_throttle_period": {
+                                      "secs": 0,
+                                      "nanos": 0
+                                  },
+                                  "consensus": {
+                                      "state_sync_timeout": {
+                                          "secs": 2,
+                                          "nanos": 0
+                                      }
+                                  }
+                              },
+                              2: {
+                                  "tracked_shards": [0],
+                                  "view_client_throttle_period": {
+                                      "secs": 0,
+                                      "nanos": 0
+                                  },
+                                  "consensus": {
+                                      "state_sync_timeout": {
+                                          "secs": 2,
+                                          "nanos": 0
+                                      }
+                                  }
+                              }
+                          })
 
     started = time.time()
     last_iter = started
@@ -138,7 +173,6 @@ def doit(seq=[]):
 
             send_reals = True
 
-
         if send_fakes or send_reals:
             cur_stakes = get_stakes()
             logger.info("Current stakes: %s" % cur_stakes)
@@ -151,7 +185,7 @@ def doit(seq=[]):
                     else:
                         assert expected <= cur <= expected * 1.1
 
-            do_moar_stakes(hash_, update_expected = send_reals)
+            do_moar_stakes(hash_, update_expected=send_reals)
 
         if send_fakes:
             last_fake_stakes_height += EPOCH_LENGTH

--- a/pytest/tests/sanity/state_migration.py
+++ b/pytest/tests/sanity/state_migration.py
@@ -21,6 +21,7 @@ import branches
 import cluster
 from utils import wait_for_blocks_or_timeout, get_near_tempdir
 
+
 def main():
     node_root = get_near_tempdir('state_migration', clean=True)
 
@@ -89,8 +90,7 @@ def main():
 
     # New genesis can be deserialized by new near is verified above (new near can produce blocks)
     # Also test new genesis protocol_version matches nearcore/res/genesis_config's
-    new_genesis = json.load(
-        open(os.path.join(node_root, 'test0/genesis.json')))
+    new_genesis = json.load(open(os.path.join(node_root, 'test0/genesis.json')))
     res_genesis = json.load(open('../nearcore/res/genesis_config.json'))
     assert new_genesis['protocol_version'] == res_genesis['protocol_version']
 

--- a/pytest/tests/sanity/state_sync.py
+++ b/pytest/tests/sanity/state_sync.py
@@ -32,10 +32,16 @@ near_root, node_dirs = init_cluster(
     2, 1, 1, config,
     [["min_gas_price", 0], ["max_inflation_rate", [0, 1]], ["epoch_length", 10],
      ["block_producer_kickout_threshold", 80]], {
-        0: {"tracked_shards": [0]},
-        1: {"tracked_shards": [0]},
-        2: {"tracked_shards": [0]}
-    })
+         0: {
+             "tracked_shards": [0]
+         },
+         1: {
+             "tracked_shards": [0]
+         },
+         2: {
+             "tracked_shards": [0]
+         }
+     })
 
 started = time.time()
 

--- a/pytest/tests/sanity/state_sync2.py
+++ b/pytest/tests/sanity/state_sync2.py
@@ -21,7 +21,8 @@ nodes = start_cluster(
     2, 0, 2, None,
     [["num_block_producer_seats", 199],
      ["num_block_producer_seats_per_shard", [99, 100]], ["epoch_length", 10],
-     ["block_producer_kickout_threshold", 10], ["chunk_producer_kickout_threshold", 10]], {})
+     ["block_producer_kickout_threshold", 10],
+     ["chunk_producer_kickout_threshold", 10]], {})
 logger.info('cluster started')
 
 started = time.time()

--- a/pytest/tests/sanity/state_sync4.py
+++ b/pytest/tests/sanity/state_sync4.py
@@ -41,10 +41,12 @@ balance = 50000000000000000000000000000000
 account_keys = []
 for i in range(num_new_accounts):
     account_name = f'test_account{i}.test0'
-    signer_key = Key(account_name, nodes[0].signer_key.pk, nodes[0].signer_key.sk)
+    signer_key = Key(account_name, nodes[0].signer_key.pk,
+                     nodes[0].signer_key.sk)
     create_account_tx = sign_create_account_with_full_access_key_and_balance_tx(
-        nodes[0].signer_key, account_name, signer_key, balance // num_new_accounts, i + 1, base58.b58decode(block_hash.encode('utf8'))
-    )
+        nodes[0].signer_key, account_name, signer_key,
+        balance // num_new_accounts, i + 1,
+        base58.b58decode(block_hash.encode('utf8')))
     account_keys.append(signer_key)
     res = nodes[0].send_tx_and_wait(create_account_tx, timeout=15)
     assert 'error' not in res, res
@@ -59,7 +61,10 @@ status = nodes[0].get_status()
 block_hash = status['sync_info']['latest_block_hash']
 
 for signer_key in account_keys:
-    staking_tx = sign_staking_tx(signer_key, nodes[0].validator_key, balance // (num_new_accounts * 2), cur_height * 1_000_000 - 1, base58.b58decode(block_hash.encode('utf8')))
+    staking_tx = sign_staking_tx(signer_key, nodes[0].validator_key,
+                                 balance // (num_new_accounts * 2),
+                                 cur_height * 1_000_000 - 1,
+                                 base58.b58decode(block_hash.encode('utf8')))
     res = nodes[0].send_tx_and_wait(staking_tx, timeout=15)
     assert 'error' not in res
 

--- a/pytest/tests/sanity/state_sync5.py
+++ b/pytest/tests/sanity/state_sync5.py
@@ -58,7 +58,8 @@ while node1_height <= cur_height:
         status1 = nodes[1].get_status()
         logger.info(status1)
         node1_height = status1['sync_info']['latest_block_height']
-    tx = sign_payment_tx(nodes[0].signer_key, 'test1', 1, nonce, base58.b58decode(genesis_hash.encode('utf8')))
+    tx = sign_payment_tx(nodes[0].signer_key, 'test1', 1, nonce,
+                         base58.b58decode(genesis_hash.encode('utf8')))
     nodes[1].send_tx(tx)
     nonce += 1
     time.sleep(0.05)

--- a/pytest/tests/sanity/state_sync_massive.py
+++ b/pytest/tests/sanity/state_sync_massive.py
@@ -59,13 +59,16 @@ else:
 
 config = load_config()
 near_root, node_dirs = init_cluster(
-    1, 2, 1, config,
-    [["min_gas_price", 0], ["max_inflation_rate", [0, 1]], ["epoch_length", 300],
-     ["block_producer_kickout_threshold", 80]], {1: {
-         "tracked_shards": [0]
-     }, 2: {
-         "tracked_shards": [0]
-     }})
+    1, 2, 1,
+    config, [["min_gas_price", 0], ["max_inflation_rate", [0, 1]],
+             ["epoch_length", 300], ["block_producer_kickout_threshold", 80]], {
+                 1: {
+                     "tracked_shards": [0]
+                 },
+                 2: {
+                     "tracked_shards": [0]
+                 }
+             })
 
 logging.info("Populating genesis")
 
@@ -89,7 +92,9 @@ TIMEOUT = 1450
 start = time.time()
 
 boot_node = spin_up_node(config, near_root, node_dirs[0], 0, None, None)
-observer = spin_up_node(config, near_root, node_dirs[1], 1, boot_node.node_key.pk, boot_node.addr())
+observer = spin_up_node(config, near_root, node_dirs[1], 1,
+                        boot_node.node_key.pk, boot_node.addr())
+
 
 def wait_for_height(target_height, rpc_node, sleep_time=2, bps_threshold=-1):
     queue = []
@@ -121,7 +126,6 @@ def wait_for_height(target_height, rpc_node, sleep_time=2, bps_threshold=-1):
             tail = queue[0]
             bps = (head[1] - tail[1]) / (head[0] - tail[0])
 
-
         logging.info(f"bps: {bps} queue length: {len(queue)}")
         time.sleep(sleep_time)
         assert bps is None or bps >= bps_threshold
@@ -129,7 +133,8 @@ def wait_for_height(target_height, rpc_node, sleep_time=2, bps_threshold=-1):
 
 wait_for_height(SMALL_HEIGHT, boot_node)
 
-observer = spin_up_node(config, near_root, node_dirs[2], 2, boot_node.node_key.pk, boot_node.addr())
+observer = spin_up_node(config, near_root, node_dirs[2], 2,
+                        boot_node.node_key.pk, boot_node.addr())
 tracker = LogTracker(observer)
 
 # Check that bps is not degraded

--- a/pytest/tests/sanity/switch_node_key.py
+++ b/pytest/tests/sanity/switch_node_key.py
@@ -12,29 +12,17 @@ EPOCH_LENGTH = 40
 STOP_HEIGHT1 = 35
 TIMEOUT = 50
 
-config1 = {
-    "network": {
-        "ttl_account_id_router": {
-            "secs": 1,
-            "nanos": 0
-        },
-    }
-}
+config1 = {"network": {"ttl_account_id_router": {"secs": 1, "nanos": 0},}}
 nodes = start_cluster(
     2, 0, 1, None,
-    [
-        ["epoch_length", EPOCH_LENGTH],
-        ["block_producer_kickout_threshold", 30],
-        ["chunk_producer_kickout_threshold", 30],
-        ["num_block_producer_seats", 4],
-        ["num_block_producer_seats_per_shard", [4]],
-        ["validators", 0, "amount", "150000000000000000000000000000000"],
-        [
-            "records", 0, "Account", "account", "locked",
-            "150000000000000000000000000000000"
-        ],
-        ["total_supply", "3100000000000000000000000000000000"]
-    ], {1: config1})
+    [["epoch_length", EPOCH_LENGTH], ["block_producer_kickout_threshold", 30],
+     ["chunk_producer_kickout_threshold", 30], ["num_block_producer_seats", 4],
+     ["num_block_producer_seats_per_shard", [4]],
+     ["validators", 0, "amount", "150000000000000000000000000000000"],
+     [
+         "records", 0, "Account", "account", "locked",
+         "150000000000000000000000000000000"
+     ], ["total_supply", "3100000000000000000000000000000000"]], {1: config1})
 time.sleep(2)
 
 status1 = nodes[1].get_status()
@@ -62,7 +50,9 @@ while True:
 
 seed = bytes([1] * 32)
 public_key, secret_key = nacl.bindings.crypto_sign_seed_keypair(seed)
-node_key = Key("", base58.b58encode(public_key).decode('utf-8'), base58.b58encode(secret_key).decode('utf-8'))
+node_key = Key("",
+               base58.b58encode(public_key).decode('utf-8'),
+               base58.b58encode(secret_key).decode('utf-8'))
 nodes[1].reset_node_key(node_key)
 nodes[1].start(nodes[0].node_key.pk, nodes[0].addr())
 time.sleep(2)
@@ -75,4 +65,6 @@ while height1 < EPOCH_LENGTH * 2 + 5:
     height1 = status1['sync_info']['latest_block_height']
 
 validators = nodes[1].get_validators()
-assert len(validators['result']['next_validators']) == 2, f'unexpected number of validators, current validators: {status1["validators"]}'
+assert len(
+    validators['result']['next_validators']
+) == 2, f'unexpected number of validators, current validators: {status1["validators"]}'

--- a/pytest/tests/sanity/sync_ban.py
+++ b/pytest/tests/sanity/sync_ban.py
@@ -27,7 +27,9 @@ BAN_STRING = 'ban a fraudulent peer'
 
 should_sync = Value('i', False)
 
+
 class Handler(ProxyHandler):
+
     async def handle(self, msg, fr, to):
         if msg is not None:
             if msg.enum == 'Block':
@@ -52,6 +54,7 @@ class Handler(ProxyHandler):
                 return False
         return True
 
+
 node0_config = {
     "consensus": {
         "min_block_production_delay": {
@@ -73,7 +76,10 @@ node1_config = {
     },
     "tracked_shards": [0]
 }
-nodes = start_cluster(1, 1, 1, None, [["epoch_length", EPOCH_LENGTH]], {0: node0_config, 1: node1_config}, Handler)
+nodes = start_cluster(1, 1, 1, None, [["epoch_length", EPOCH_LENGTH]], {
+    0: node0_config,
+    1: node1_config
+}, Handler)
 
 status = nodes[0].get_status()
 cur_height = status['sync_info']['latest_block_height']
@@ -104,11 +110,13 @@ while True:
 
         status1 = nodes[1].get_status()
         node1_height = status1['sync_info']['latest_block_height']
-        if abs(node1_height - cur_height) < 5 and status1['sync_info']['syncing'] is False:
+        if abs(node1_height -
+               cur_height) < 5 and status1['sync_info']['syncing'] is False:
             break
     time.sleep(2)
 
-if not should_ban and (tracker0.check(BAN_STRING) or tracker1.check(BAN_STRING)):
+if not should_ban and (tracker0.check(BAN_STRING) or
+                       tracker1.check(BAN_STRING)):
     assert False, "unexpected ban of peers"
 
 logger.info('shutting down')

--- a/pytest/tests/sanity/transactions.py
+++ b/pytest/tests/sanity/transactions.py
@@ -20,21 +20,53 @@ nodes = start_cluster(
     num_observers=1,
     num_shards=4,
     config=None,
-    genesis_config_changes=[
-        ["min_gas_price", 0],
-        ["max_inflation_rate", [0, 1]],
-        ["epoch_length", 10],
-        ["block_producer_kickout_threshold", 70]
-    ],
+    genesis_config_changes=[["min_gas_price",
+                             0], ["max_inflation_rate", [0, 1]],
+                            ["epoch_length", 10],
+                            ["block_producer_kickout_threshold", 70]],
     client_config_changes={
-                                  0: {"consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}}},
-                                  1: {"consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}}},
-                                  2: {"consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}}},
-                                  3: {"consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}}},
-                                  4: {"consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}},
-                                      "tracked_shards": [0, 1, 2, 3]}
-    }
-)
+        0: {
+            "consensus": {
+                "state_sync_timeout": {
+                    "secs": 2,
+                    "nanos": 0
+                }
+            }
+        },
+        1: {
+            "consensus": {
+                "state_sync_timeout": {
+                    "secs": 2,
+                    "nanos": 0
+                }
+            }
+        },
+        2: {
+            "consensus": {
+                "state_sync_timeout": {
+                    "secs": 2,
+                    "nanos": 0
+                }
+            }
+        },
+        3: {
+            "consensus": {
+                "state_sync_timeout": {
+                    "secs": 2,
+                    "nanos": 0
+                }
+            }
+        },
+        4: {
+            "consensus": {
+                "state_sync_timeout": {
+                    "secs": 2,
+                    "nanos": 0
+                }
+            },
+            "tracked_shards": [0, 1, 2, 3]
+        }
+    })
 
 started = time.time()
 
@@ -78,7 +110,7 @@ while True:
         # we are done with the sanity test, now let's stress it
         if ctx.get_balances() == ctx.expected_balances:
             logger.info("Balances caught up, took %s blocks, moving on" %
-                  (height - sent_height))
+                        (height - sent_height))
             last_balances = [x for x in ctx.expected_balances]
             ctx.send_moar_txs(hash_, 10, use_routing=True)
             sent_height = height

--- a/pytest/tests/sanity/validator_switch.py
+++ b/pytest/tests/sanity/validator_switch.py
@@ -14,11 +14,13 @@ from transaction import sign_staking_tx
 EPOCH_LENGTH = 20
 tracked_shards = {"tracked_shards": [0, 1, 2, 3]}
 
-nodes = start_cluster(3, 1, 4, None, [["epoch_length", EPOCH_LENGTH], ["block_producer_kickout_threshold", 10],
-    ["chunk_producer_kickout_threshold", 10]], {
-        0: tracked_shards,
-        1: tracked_shards
-    })
+nodes = start_cluster(
+    3, 1, 4, None,
+    [["epoch_length", EPOCH_LENGTH], ["block_producer_kickout_threshold", 10],
+     ["chunk_producer_kickout_threshold", 10]], {
+         0: tracked_shards,
+         1: tracked_shards
+     })
 
 time.sleep(3)
 

--- a/pytest/tests/sanity/validator_switch_key.py
+++ b/pytest/tests/sanity/validator_switch_key.py
@@ -15,14 +15,27 @@ from transaction import sign_staking_tx
 EPOCH_LENGTH = 30
 TIMEOUT = 200
 
-client_config = {"network": {"ttl_account_id_router": {"secs": 0, "nanos": 100000000}}}
-nodes = start_cluster(2, 1, 1, None, [["epoch_length", EPOCH_LENGTH], ["block_producer_kickout_threshold", 10],
-                                      ["chunk_producer_kickout_threshold", 10]], {1: client_config, 2: client_config})
+client_config = {
+    "network": {
+        "ttl_account_id_router": {
+            "secs": 0,
+            "nanos": 100000000
+        }
+    }
+}
+nodes = start_cluster(
+    2, 1, 1, None,
+    [["epoch_length", EPOCH_LENGTH], ["block_producer_kickout_threshold", 10],
+     ["chunk_producer_kickout_threshold", 10]], {
+         1: client_config,
+         2: client_config
+     })
 time.sleep(2)
 
 nodes[2].kill()
 
-validator_key = Key(nodes[1].validator_key.account_id, nodes[2].signer_key.pk, nodes[2].signer_key.sk)
+validator_key = Key(nodes[1].validator_key.account_id, nodes[2].signer_key.pk,
+                    nodes[2].signer_key.sk)
 nodes[2].reset_validator_key(validator_key)
 nodes[2].reset_data()
 nodes[2].start(nodes[0].node_key.pk, nodes[0].addr())
@@ -32,7 +45,8 @@ status = nodes[0].get_status()
 block_hash = status['sync_info']['latest_block_hash']
 block_height = status['sync_info']['latest_block_height']
 
-tx = sign_staking_tx(nodes[1].signer_key, validator_key, 50000000000000000000000000000000, 1,
+tx = sign_staking_tx(nodes[1].signer_key, validator_key,
+                     50000000000000000000000000000000, 1,
                      base58.b58decode(block_hash.encode('utf8')))
 res = nodes[0].send_tx_and_wait(tx, timeout=15)
 assert 'error' not in res

--- a/pytest/tests/spec/network/future_handshake.py
+++ b/pytest/tests/spec/network/future_handshake.py
@@ -17,7 +17,6 @@ import nacl.signing
 from cluster import start_cluster
 from peer import ED_PREFIX, connect, create_handshake, sign_handshake, BinarySerializer, schema
 
-
 nodes = start_cluster(1, 0, 4, None, [], {})
 
 
@@ -37,14 +36,16 @@ async def main():
     # - 1 byte  PeerMessage::Handshake enum id
     # - 4 bytes version
     # - 4 bytes oldest_supported_version
-    raw_message = raw_message[:9] + bytes([random.randint(0, 255) for _ in range(random.randint(1, 32))])
+    raw_message = raw_message[:9] + bytes(
+        [random.randint(0, 255) for _ in range(random.randint(1, 32))])
 
     # First handshake attempt. Should fail with Protocol Version Mismatch
     await conn.send_raw(raw_message)
     response = await conn.recv()
 
     assert response.enum == 'HandshakeFailure', response.enum
-    assert response.HandshakeFailure[1].enum == 'ProtocolVersionMismatch', response.HandshakeFailure[1].enum
+    assert response.HandshakeFailure[
+        1].enum == 'ProtocolVersionMismatch', response.HandshakeFailure[1].enum
     pvm = response.HandshakeFailure[1].ProtocolVersionMismatch.version
     handshake.Handshake.version = pvm
 

--- a/pytest/tests/spec/network/handshake.py
+++ b/pytest/tests/spec/network/handshake.py
@@ -17,7 +17,6 @@ import nacl.signing
 from cluster import start_cluster
 from peer import ED_PREFIX, connect, create_handshake, sign_handshake
 
-
 nodes = start_cluster(1, 0, 4, None, [], {})
 
 
@@ -34,7 +33,8 @@ async def main():
     response = await conn.recv()
 
     assert response.enum == 'HandshakeFailure', response.enum
-    assert response.HandshakeFailure[1].enum == 'ProtocolVersionMismatch', response.HandshakeFailure[1].enum
+    assert response.HandshakeFailure[
+        1].enum == 'ProtocolVersionMismatch', response.HandshakeFailure[1].enum
     pvm = response.HandshakeFailure[1].ProtocolVersionMismatch.version
     handshake.Handshake.version = pvm
 
@@ -44,7 +44,8 @@ async def main():
     response = await conn.recv()
 
     assert response.enum == 'HandshakeFailure', response.enum
-    assert response.HandshakeFailure[1].enum == 'GenesisMismatch', response.HandshakeFailure[1].enum
+    assert response.HandshakeFailure[
+        1].enum == 'GenesisMismatch', response.HandshakeFailure[1].enum
     gm = response.HandshakeFailure[1].GenesisMismatch
     handshake.Handshake.chain_info.genesis_id.chain_id = gm.chain_id
     handshake.Handshake.chain_info.genesis_id.hash = gm.hash

--- a/pytest/tests/spec/network/peers_request.py
+++ b/pytest/tests/spec/network/peers_request.py
@@ -18,13 +18,16 @@ from peer import ED_PREFIX, connect, run_handshake, create_peer_request
 from utils import obj_to_string
 from messages import schema
 
-
 nodes = start_cluster(1, 0, 4, None, [], {})
+
 
 async def main():
     key_pair_0 = nacl.signing.SigningKey.generate()
     conn0 = await connect(nodes[0].addr())
-    await run_handshake(conn0, nodes[0].node_key.pk, key_pair_0, listen_port=12345)
+    await run_handshake(conn0,
+                        nodes[0].node_key.pk,
+                        key_pair_0,
+                        listen_port=12345)
     peer_request = create_peer_request()
     await conn0.send(peer_request)
     response = await conn0.recv('PeersResponse')
@@ -32,13 +35,16 @@ async def main():
 
     key_pair_1 = nacl.signing.SigningKey.generate()
     conn1 = await connect(nodes[0].addr())
-    await run_handshake(conn1, nodes[0].node_key.pk, key_pair_1, listen_port=12346)
+    await run_handshake(conn1,
+                        nodes[0].node_key.pk,
+                        key_pair_1,
+                        listen_port=12346)
     peer_request = create_peer_request()
     await conn1.send(peer_request)
     response = await conn1.recv('PeersResponse')
     assert response.enum == 'PeersResponse', obj_to_string(response)
-    assert any(peer_info.addr.V4[1] == 12345 for peer_info in response.PeersResponse), obj_to_string(response)
-
+    assert any(peer_info.addr.V4[1] == 12345
+               for peer_info in response.PeersResponse), obj_to_string(response)
 
 
 asyncio.run(main())

--- a/pytest/tests/stress/hundred_nodes/100_node_block_production.py
+++ b/pytest/tests/stress/hundred_nodes/100_node_block_production.py
@@ -4,7 +4,6 @@ from rc import pmap
 
 sys.path.append('lib')
 
-
 from cluster import GCloudNode, RpcNode
 from configured_logger import new_logger
 from utils import chain_query
@@ -15,7 +14,9 @@ def print_chain_data(block, logger):
     all_catch_up = False
     if all(map(lambda h: h == block['header']['height'], all_height)):
         all_catch_up = True
-    logger.info(f"{block['header']['hash']} {block['header']['height']} {block['header']['approvals']} {all_catch_up} {all_height}")
+    logger.info(
+        f"{block['header']['hash']} {block['header']['height']} {block['header']['approvals']} {all_catch_up} {all_height}"
+    )
 
 
 subprocess.run('mkdir -p /tmp/100_node/', shell=True)
@@ -24,9 +25,11 @@ f = []
 for node in range(100):
     f.append(new_logger(outfile=f'/tmp/100_node/pytest-node-{node}.txt'))
 
+
 def query_node(i):
     node = GCloudNode(f'pytest-node-{i}')
     chain_query(node, lambda b: print_chain_data(b, f[i]), max_blocks=20)
+
 
 pmap(query_node, range(100))
 

--- a/pytest/tests/stress/hundred_nodes/block_chunks.py
+++ b/pytest/tests/stress/hundred_nodes/block_chunks.py
@@ -4,16 +4,21 @@ from rc import pmap
 
 sys.path.append('lib')
 
-
 from cluster import GCloudNode, RpcNode
 from configured_logger import new_logger
 from utils import chain_query
 
+
 def print_chain_data(block, logger):
     chunks = []
     for c in block['chunks']:
-        chunks.append(f'{c["chunk_hash"]} {c["shard_id"]} {c["height_created"]} {c["height_included"]}')
-    logger.info(f"{block['header']['height']} {block['header']['hash']} {','.join(chunks)}")
+        chunks.append(
+            f'{c["chunk_hash"]} {c["shard_id"]} {c["height_created"]} {c["height_included"]}'
+        )
+    logger.info(
+        f"{block['header']['height']} {block['header']['hash']} {','.join(chunks)}"
+    )
+
 
 subprocess.run('mkdir -p /tmp/100_node/', shell=True)
 
@@ -21,11 +26,15 @@ f = []
 for node in range(100):
     f.append(new_logger(outfile=f'/tmp/100_node/pytest-node-{node}.txt'))
 
+
 def query_node(i):
     node = GCloudNode(f'pytest-node-{i}')
     chain_query(node, lambda b: print_chain_data(b, f[i]), max_blocks=20)
 
+
 # pmap(query_node, range(100))
 
 node = GCloudNode('pytest-node-0')
-chain_query(node, print_chain_data, block_hash='9rnC5G6qDpXgT4gTG4znowmdSUavC1etuV99F18ByxxK')
+chain_query(node,
+            print_chain_data,
+            block_hash='9rnC5G6qDpXgT4gTG4znowmdSUavC1etuV99F18ByxxK')

--- a/pytest/tests/stress/hundred_nodes/collect_logs.py
+++ b/pytest/tests/stress/hundred_nodes/collect_logs.py
@@ -13,23 +13,27 @@ if len(sys.argv) >= 2:
     node_prefix = sys.argv[1]
 else:
     node_prefix = f'pytest-node-{user_name()}'
-nodes = [machine
-         for machine in gcloud.list()
-         if machine.name.startswith(node_prefix)]
+nodes = [
+    machine for machine in gcloud.list() if machine.name.startswith(node_prefix)
+]
 
 if len(sys.argv) >= 3:
     log_file = sys.argv[2]
 else:
     log_file = pathlib.Path(tempfile.gettempdir()) / 'python-rc.log'
 
-collected_place = (pathlib.Path(tempfile.gettempdir()) / 'near' /
-                   f'collected_logs_{datetime.datetime.strftime(datetime.datetime.now(),"%Y%m%d")}')
+collected_place = (
+    pathlib.Path(tempfile.gettempdir()) / 'near' /
+    f'collected_logs_{datetime.datetime.strftime(datetime.datetime.now(),"%Y%m%d")}'
+)
 collected_place.mkdir(parents=True, exist_ok=True)
+
 
 def collect_file(node):
     logger.info(f'Download file from {node.name}')
     node.download(str(log_file), str(collected_place / f'{node.name}.txt'))
     logger.info(f'Download file from {node.name} finished')
+
 
 pmap(collect_file, nodes)
 logger.info(f'All download finish, log collected at {collected_place}')

--- a/pytest/tests/stress/hundred_nodes/create_gcloud_image.py
+++ b/pytest/tests/stress/hundred_nodes/create_gcloud_image.py
@@ -7,11 +7,11 @@ from rc import gcloud, run
 sys.path.append('lib')
 from configured_logger import logger
 
-
 additional_flags = ''
 
-toolchain = open(os.path.join(os.path.dirname(__file__),
-                              '../../../../rust-toolchain')).read().strip()
+toolchain = open(
+    os.path.join(os.path.dirname(__file__),
+                 '../../../../rust-toolchain')).read().strip()
 
 try:
     image_name = sys.argv[1]
@@ -26,20 +26,19 @@ machine_name = f'{image_name}-image-builder'
 
 logger.info(f"Creating machine: {machine_name}")
 
-m = gcloud.create(
-    name=machine_name,
-    machine_type='n1-standard-64',
-    disk_size='50G',
-    image_project='ubuntu-os-cloud',
-    image_family='ubuntu-1804-lts',
-    zone='us-west2-c',
-    firewall_allows=['tcp:3030', 'tcp:24567'],
-    min_cpu_platform='Intel Skylake'
-)
+m = gcloud.create(name=machine_name,
+                  machine_type='n1-standard-64',
+                  disk_size='50G',
+                  image_project='ubuntu-os-cloud',
+                  image_family='ubuntu-1804-lts',
+                  zone='us-west2-c',
+                  firewall_allows=['tcp:3030', 'tcp:24567'],
+                  min_cpu_platform='Intel Skylake')
 
 logger.info(f'machine created: {image_name}')
 
-p = m.run('bash', input=f'''
+p = m.run('bash',
+          input=f'''
 for i in `seq 1 3`; do
     sudo apt update
 done

--- a/pytest/tests/stress/hundred_nodes/start_100_nodes.py
+++ b/pytest/tests/stress/hundred_nodes/start_100_nodes.py
@@ -55,17 +55,8 @@ client_config_changes = {
 
 # default is 50; 7,7,6,6,6,6,6,6
 genesis_config_changes = [
-  ["num_block_producer_seats", 100],
-  ["num_block_producer_seats_per_shard", [
-    13,
-    13,
-    13,
-    13,
-    12,
-    12,
-    12,
-    12
-  ]],
+    ["num_block_producer_seats", 100],
+    ["num_block_producer_seats_per_shard", [13, 13, 13, 13, 12, 12, 12, 12]],
 ]
 
 num_machines = 100
@@ -141,11 +132,13 @@ zones = [
     'us-west2-c',
 ]
 # Unless you want to shutdown gcloud instance and restart, keep this `False'
-reserve_ip=False
+reserve_ip = False
 
 pbar = tqdm(total=num_machines, desc=' create machines')
+
+
 def create_machine(i):
-    m = gcloud.create(name=machine_name_prefix+str(i),
+    m = gcloud.create(name=machine_name_prefix + str(i),
                       machine_type='n1-standard-2',
                       disk_size='200G',
                       image_project='near-core',
@@ -156,6 +149,7 @@ def create_machine(i):
     pbar.update(1)
     return m
 
+
 machines = pmap(create_machine, range(num_machines))
 pbar.close()
 # machines = pmap(lambda name: gcloud.get(name), [
@@ -163,14 +157,17 @@ pbar.close()
 
 tempdir = pathlib.Path(tempfile.gettempdir()) / 'near'
 
+
 def get_node_dir(i):
     node_dir = tempdir / f'node{i}'
     node_dir.mkdir(parents=True, exist_ok=True)
     return node_dir
 
+
 for i in range(num_machines):
     node_dir = get_node_dir(i)
-    p = run('bash', input=f'''
+    p = run('bash',
+            input=f'''
 # deactivate virtualenv doesn't work in non interactive shell, explicitly run with python2
 cd ..
 python2 scripts/start_stakewars.py --local --home {node_dir} --init --signer-keys --account-id=node{i}
@@ -205,8 +202,8 @@ with open(tempdir / 'accounts.csv', 'w', newline='') as f:
 
     writer = csv.DictWriter(f, fieldnames=fieldnames)
     writer.writeheader()
-    amount = 1000 * 10 ** 24
-    staked_amount = 10 * 10 ** 24
+    amount = 1000 * 10**24
+    staked_amount = 10 * 10**24
 
     for i in range(num_machines):
         writer.writerow({
@@ -224,7 +221,8 @@ with open(tempdir / 'accounts.csv', 'w', newline='') as f:
 for i in range(num_machines):
     node_dir = get_node_dir(i)
     shutil.copy(tempdir / 'accounts.csv', node_dir / 'accounts.csv')
-    p=run('bash', input=f'''
+    p = run('bash',
+            input=f'''
 cd ..
 target/release/genesis-csv-to-json --home {node_dir} --chain-id pytest
 ''')
@@ -232,6 +230,8 @@ target/release/genesis-csv-to-json --home {node_dir} --chain-id pytest
     apply_genesis_changes(node_dir, genesis_config_changes)
 
 pbar = tqdm(total=num_machines, desc=' upload nodedir')
+
+
 # Upload json and accounts.csv
 def upload_genesis_files(i):
     # stop if already start
@@ -240,24 +240,31 @@ def upload_genesis_files(i):
     machines[i].kill_detach_tmux()
     machines[i].run('rm -rf ~/.near')
     # upload keys, config, genesis
-    machines[i].upload(str(get_node_dir(i)), f'/home/{machines[i].username}/.near')
+    machines[i].upload(str(get_node_dir(i)),
+                       f'/home/{machines[i].username}/.near')
     pbar.update(1)
+
 
 pmap(upload_genesis_files, range(num_machines))
 pbar.close()
 
 pbar = tqdm(total=num_machines, desc=' start near')
+
+
 def start_nearcore(i):
     m = machines[i]
     if i < num_docker_machines:
-        m.run('bash', input=f'''
+        m.run('bash',
+              input=f'''
 docker run -d -u $UID:$UID -v /home/{m.username}/.near:/srv/near \
     -p 3030:3030 -p 24567:24567 --name nearcore {docker_image} near --home=/srv/near run
 ''')
     else:
         m.run_detach_tmux(
-            'cd nearcore && export RUST_LOG=diagnostic=trace && target/release/near run --archive')
+            'cd nearcore && export RUST_LOG=diagnostic=trace && target/release/near run --archive'
+        )
     pbar.update(1)
+
 
 pmap(start_nearcore, range(len(machines)))
 pbar.close()

--- a/pytest/tests/stress/hundred_nodes/watch_fork.py
+++ b/pytest/tests/stress/hundred_nodes/watch_fork.py
@@ -9,7 +9,7 @@ from utils import user_name
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import datetime
 
-validators = [None]*100
+validators = [None] * 100
 
 while True:
     futures = {}
@@ -26,4 +26,6 @@ while True:
         assert v == validators[0], f'{v} not equal to {validators[0]}'
 
     v0 = sorted(list(validators[0]))
-    logger.info(f'{datetime.datetime.now(datetime.timezone.utc).isoformat()}, {len(v0)}, {v0}')
+    logger.info(
+        f'{datetime.datetime.now(datetime.timezone.utc).isoformat()}, {len(v0)}, {v0}'
+    )

--- a/pytest/tests/stress/saturate_routing_table.py
+++ b/pytest/tests/stress/saturate_routing_table.py
@@ -26,6 +26,7 @@ import base58
 
 seed(0)
 
+
 def key_seed():
     return bytes([randint(0, 255) for _ in range(32)])
 
@@ -61,7 +62,8 @@ def create_edge(key0, key1, nonce):
 
     edge.nonce = nonce
 
-    val = bytes([0]) + bytes(edge.peer0.data) + bytes([0]) + bytes(edge.peer1.data) + struct.pack('Q', nonce)
+    val = bytes([0]) + bytes(edge.peer0.data) + bytes([0]) + bytes(
+        edge.peer1.data) + struct.pack('Q', nonce)
     hsh = hashlib.sha256(val).digest()
     enc58 = base58.b58encode(hsh)
 
@@ -82,12 +84,17 @@ async def main():
     key_pair_0 = nacl.signing.SigningKey(key_seed())
     tracker = LogTracker(nodes[0])
     conn = await connect(nodes[0].addr())
-    await run_handshake(conn, nodes[0].node_key.pk, key_pair_0, listen_port=12345)
+    await run_handshake(conn,
+                        nodes[0].node_key.pk,
+                        key_pair_0,
+                        listen_port=12345)
 
     num_nodes = 300
 
     def create_update():
-        key_pairs = [key_pair_0] +  [nacl.signing.SigningKey(key_seed()) for _ in range(num_nodes - 1)]
+        key_pairs = [key_pair_0] + [
+            nacl.signing.SigningKey(key_seed()) for _ in range(num_nodes - 1)
+        ]
         nonces = [[1] * num_nodes for _ in range(num_nodes)]
 
         edges = []

--- a/pytest/tests/stress/stress.py
+++ b/pytest/tests/stress/stress.py
@@ -58,7 +58,7 @@ block_timeout = 20  # if two blocks are not produced within that many seconds, t
 balances_timeout = 15  # how long to tolerate for balances to update after txs are sent
 restart_sync_timeout = 30  # for how long to wait for nodes to sync in `node_restart`
 tx_tolerance = 0.1
-wait_if_restart = False # whether to wait between `kill` and `start`, is needed when nodes are proxied
+wait_if_restart = False  # whether to wait between `kill` and `start`, is needed when nodes are proxied
 wipe_data = False
 
 assert balances_timeout * 2 <= TIMEOUT_SHUTDOWN
@@ -98,7 +98,8 @@ def get_recent_hash(node, sync_timeout):
         info = node.json_rpc('block', [hash_], timeout=10)
 
         is_syncing = status['sync_info']['syncing']
-        sync_error = 'error' in info and 'unavailable on the node' in info['error']['data']
+        sync_error = 'error' in info and 'unavailable on the node' in info[
+            'error']['data']
         if is_syncing or sync_error:
             time.sleep(1)
         else:
@@ -149,7 +150,7 @@ def monkey_node_set(stopped, error, nodes, nonces):
                     wipe = True
                     node.reset_data()
                 logging.info("Node set: stopping%s node %s" %
-                      (" and wiping" if wipe else "", i))
+                             (" and wiping" if wipe else "", i))
             nodes_stopped[i] = not nodes_stopped[i]
             change_status_at[i] = get_future_time()
 
@@ -170,12 +171,15 @@ def monkey_node_restart(stopped, error, nodes, nonces):
             _, h = get_recent_hash(node, restart_sync_timeout)
             assert h >= heights_after_restart[node_idx], "%s > %s" % (
                 h, heights_after_restart[node_idx])
-            if h > heights_after_restart[node_idx] + (5 if not wipe_data else 10):
+            if h > heights_after_restart[node_idx] + (5
+                                                      if not wipe_data else 10):
                 break
             time.sleep(1)
 
         reset_data = wipe_data and random.choice([True, False, False])
-        logging.info("NUKING NODE %s%s" % (node_idx, " AND WIPING ITS STORAGE" if reset_data else ""))
+        logging.info(
+            "NUKING NODE %s%s" %
+            (node_idx, " AND WIPING ITS STORAGE" if reset_data else ""))
 
         node.kill()
         if reset_data:
@@ -206,7 +210,8 @@ def monkey_local_network(stopped, error, nodes, nonces):
 
     while stopped.value == 0:
         _, cur_height = get_recent_hash(nodes[-1], 15)
-        if cur_height == last_height and time.time() - last_time_height_updated > 10:
+        if cur_height == last_height and time.time(
+        ) - last_time_height_updated > 10:
             time.sleep(25)
         else:
             last_height = cur_height
@@ -259,7 +264,8 @@ def monkey_transactions(stopped, error, nodes, nonces):
         validator_ids = get_validator_ids(nodes)
         if time.time() - last_iter_switch > balances_timeout:
             if mode == 0:
-                logging.info("%s TRANSACTIONS SENT. WAITING FOR BALANCES" % tx_count)
+                logging.info("%s TRANSACTIONS SENT. WAITING FOR BALANCES" %
+                             tx_count)
                 mode = 1
             else:
                 logging.info(
@@ -277,8 +283,8 @@ def monkey_transactions(stopped, error, nodes, nonces):
                             'tx', [tx[3], "test%s" % tx[1]], timeout=5)
 
                         if 'error' in response and 'data' in response[
-                                'error'] and "doesn't exist" in response['error'][
-                                    'data']:
+                                'error'] and "doesn't exist" in response[
+                                    'error']['data']:
                             tx_happened = False
                         elif 'result' in response and 'receipts_outcome' in response[
                                 'result']:
@@ -298,8 +304,9 @@ def monkey_transactions(stopped, error, nodes, nonces):
                 good, bad = revert_txs()
                 if expected_balances == get_balances():
                     # reverting helped
-                    logging.info("REVERTING HELPED, TX EXECUTED: %s, TX LOST: %s" %
-                          (good, bad))
+                    logging.info(
+                        "REVERTING HELPED, TX EXECUTED: %s, TX LOST: %s" %
+                        (good, bad))
                     bad_ratio = bad / (good + bad)
                     if bad_ratio > rolling_tolerance:
                         rolling_tolerance -= bad_ratio - rolling_tolerance
@@ -347,7 +354,8 @@ def monkey_transactions(stopped, error, nodes, nonces):
                     for validator_id in shuffled_validator_ids:
                         try:
                             info = nodes[validator_id].send_tx(tx)
-                            if 'error' in info and info['error']['data'] == 'IsSyncing':
+                            if 'error' in info and info['error'][
+                                    'data'] == 'IsSyncing':
                                 pass
 
                             elif 'result' in info:
@@ -467,7 +475,8 @@ def blocks_tracker(stopped, error, nodes, nonces):
                     if stopped.value != 0:
                         done = True
                     if not every_ten or largest_height % 10 == 0:
-                        logging.info("BLOCK TRACKER: new height %s" % largest_height)
+                        logging.info("BLOCK TRACKER: new height %s" %
+                                     largest_height)
                     if largest_height >= 20:
                         if not every_ten:
                             every_ten = True
@@ -549,8 +558,17 @@ def doit(s, n, N, k, monkeys, timeout):
 
     for i in range(N + k + 1):
         local_config_changes[i] = {
-            "consensus": {"block_header_fetch_horizon": BLOCK_HEADER_FETCH_HORIZON, "state_sync_timeout": {"secs": 5, "nanos": 0}},
-            "view_client_throttle_period": {"secs": 0, "nanos": 0}
+            "consensus": {
+                "block_header_fetch_horizon": BLOCK_HEADER_FETCH_HORIZON,
+                "state_sync_timeout": {
+                    "secs": 5,
+                    "nanos": 0
+                }
+            },
+            "view_client_throttle_period": {
+                "secs": 0,
+                "nanos": 0
+            }
         }
     for i in range(N, N + k + 1):
         # make all the observers track all the shards
@@ -567,7 +585,8 @@ def doit(s, n, N, k, monkeys, timeout):
         block_timeout += 40
 
     if 'monkey_local_network' in monkey_names or 'monkey_packets_drop' in monkey_names:
-        assert config['local'], 'Network stress operations only work on local nodes'
+        assert config[
+            'local'], 'Network stress operations only work on local nodes'
         drop_probability = 0.05 if 'monkey_packets_drop' in monkey_names else 0
 
         reject_list = RejectListProxy.create_reject_list(1)
@@ -598,7 +617,8 @@ def doit(s, n, N, k, monkeys, timeout):
         # if packets can also be dropped, each state-sync-related request or response lost adds 10 seconds
         # to the sync process.
         restart_sync_timeout = 45 if 'monkey_packets_drop' not in monkey_names else 90
-        block_timeout += (10 if 'monkey_packets_drop' not in monkey_names else 40)
+        block_timeout += (10
+                          if 'monkey_packets_drop' not in monkey_names else 40)
 
     # We need to make sure that the blocks that include txs are not garbage collected. From the first tx sent until
     # we check balances time equal to `balances_timeout * 2` passes, and the block production is capped at 1.7/s.
@@ -606,24 +626,34 @@ def doit(s, n, N, k, monkeys, timeout):
     min_epoch_length = (int((balances_timeout * 2) * 1.7) + 4) // 5
     epoch_length = max(epoch_length, min_epoch_length)
 
-
     near_root, node_dirs = init_cluster(
         N, k + 1, s, config,
         [["min_gas_price", 0], ["max_inflation_rate", [0, 1]],
-         ["epoch_length", epoch_length],
-         ["block_producer_kickout_threshold", 10],
-         ["chunk_producer_kickout_threshold", 10]], local_config_changes)
+         ["epoch_length", epoch_length], [
+             "block_producer_kickout_threshold", 10
+         ], ["chunk_producer_kickout_threshold", 10]], local_config_changes)
 
     started = time.time()
 
-    boot_node = spin_up_node(config, near_root, node_dirs[0], 0, None, None, proxy=proxy)
+    boot_node = spin_up_node(config,
+                             near_root,
+                             node_dirs[0],
+                             0,
+                             None,
+                             None,
+                             proxy=proxy)
     boot_node.stop_checking_store()
     boot_node.mess_with = False
     nodes = [boot_node]
 
     for i in range(1, N + k + 1):
-        node = spin_up_node(config, near_root, node_dirs[i], i,
-                            boot_node.node_key.pk, boot_node.addr(), proxy=proxy)
+        node = spin_up_node(config,
+                            near_root,
+                            node_dirs[i],
+                            i,
+                            boot_node.node_key.pk,
+                            boot_node.addr(),
+                            proxy=proxy)
         node.stop_checking_store()
         nodes.append(node)
         if i >= n and i < N:
@@ -681,14 +711,16 @@ def doit(s, n, N, k, monkeys, timeout):
         # proxies rigth away, because that would interfere with block production, and
         # might prevent other workers (e.g. block_tracker) from completing in a timely
         # manner. Thus, kill the proxies some time into the shut down process.
-        if time.time() - started_shutdown > TIMEOUT_SHUTDOWN / 2 and not proxies_stopped:
-            logging.info("Shutdown is %s seconds in, shutting down proxies if any" % (TIMEOUT_SHUTDOWN / 2))
+        if time.time(
+        ) - started_shutdown > TIMEOUT_SHUTDOWN / 2 and not proxies_stopped:
+            logging.info(
+                "Shutdown is %s seconds in, shutting down proxies if any" %
+                (TIMEOUT_SHUTDOWN / 2))
             if boot_node.proxy is not None:
                 boot_node.proxy.global_stopped.value = 1
                 for p in boot_node.proxy.ps:
                     p.terminate()
             proxies_stopped = True
-
 
         if time.time() - started_shutdown > TIMEOUT_SHUTDOWN:
             for (p, _) in ps:


### PR DESCRIPTION
Add YAPF style configuration file and format all files using it.  I’ve
skimmed over the changes and there were no outrageous formatting changes
that I’ve noticed.

Formatting can be done with `python3 -m yapf -pir .`.

The YAPF configuration is the one used by NayDuck.  At this point I don’t
recall where I got it from or whether I wrote it myself.