### PR TITLE
fix: make `param-estimator --docker` work with default additional-acc…

### DIFF
--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -217,14 +217,8 @@ cargo build --manifest-path /host/nearcore/Cargo.toml \
         let _binary_name = args.next();
         while let Some(arg) = args.next() {
             match arg.as_str() {
-                "--docker" => continue,
-                "--full" => continue,
-                "--additional-accounts-num" => {
-                    args.next();
-                    write!(buf, " {:?} 0", arg).unwrap();
-                    continue;
-                }
-                "--home" => {
+                "--docker" | "--full" => continue,
+                "--additional-accounts-num" | "--home" => {
                     args.next();
                     continue;
                 }
@@ -233,7 +227,9 @@ cargo build --manifest-path /host/nearcore/Cargo.toml \
                 }
             }
         }
+
         write!(buf, " --skip-build-test-contract").unwrap();
+        write!(buf, " --additional-accounts-num 0").unwrap();
 
         buf
     };


### PR DESCRIPTION
…ounts-num

We always want to populate genesis on the host, and never populate it in
docker. The previous logic didn't work when no
`--additional-accounts-num` was passed.

Test Plan
---------

Manual verification of param estimator CLI