### PR TITLE
refactor ShardTries

### DIFF
--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -207,7 +207,7 @@ impl StoreUpdate {
             if self.tries.is_none() {
                 self.tries = Some(tries);
             } else {
-                debug_assert!(self.tries.as_ref().unwrap() == &tries);
+                debug_assert!(self.tries.as_ref().unwrap().is_same(&tries));
             }
         }
 

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -168,7 +168,7 @@ impl StoreUpdate {
     pub fn new_with_tries(tries: ShardTries) -> Self {
         let storage = tries.get_store().storage.clone();
         let transaction = storage.transaction();
-        StoreUpdate { storage, transaction, tries: Some(tries) }
+        StoreUpdate { storage, transaction, tries: Some(tries.clone()) }
     }
 
     pub fn update_refcount(&mut self, column: DBCol, key: &[u8], value: &[u8], rc_delta: i64) {
@@ -207,10 +207,7 @@ impl StoreUpdate {
             if self.tries.is_none() {
                 self.tries = Some(tries);
             } else {
-                debug_assert_eq!(
-                    self.tries.as_ref().unwrap().caches.as_ref() as *const _,
-                    tries.caches.as_ref() as *const _
-                );
+                debug_assert!(self.tries.as_ref().unwrap() == &tries);
             }
         }
 

--- a/core/store/src/trie/split_state.rs
+++ b/core/store/src/trie/split_state.rs
@@ -201,7 +201,7 @@ mod tests {
         let mut rng = rand::thread_rng();
 
         for _ in 0..20 {
-            let mut tries = create_tries();
+            let tries = create_tries();
             // add 4 new shards for version 1
             let num_shards = 4;
             let shards: Vec<_> = (0..num_shards)
@@ -335,7 +335,7 @@ mod tests {
     fn test_apply_delayed_receipts_to_new_states() {
         let mut rng = rand::thread_rng();
 
-        let mut tries = create_tries();
+        let tries = create_tries();
         let num_shards = 4;
         let shards: Vec<_> = (0..num_shards)
             .map(|shard_id| ShardUId { shard_id: shard_id as u32, version: 1 })

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -131,7 +131,7 @@ pub struct NightshadeRuntime {
     runtime_config_store: RuntimeConfigStore,
 
     store: Arc<Store>,
-    tries: RwLock<ShardTries>,
+    tries: ShardTries,
     trie_viewer: TrieViewer,
     pub runtime: Runtime,
     epoch_manager: SafeEpochManager,
@@ -181,7 +181,7 @@ impl NightshadeRuntime {
             genesis_config,
             runtime_config_store,
             store,
-            tries: RwLock::new(tries),
+            tries,
             runtime,
             trie_viewer,
             epoch_manager: SafeEpochManager(epoch_manager),
@@ -630,14 +630,12 @@ impl RuntimeAdapter for NightshadeRuntime {
     }
 
     fn get_tries(&self) -> ShardTries {
-        let tries = self.tries.read().expect(POISONED_LOCK_ERR);
-        tries.clone()
+        self.tries.clone()
     }
 
     fn get_trie_for_shard(&self, shard_id: ShardId, prev_hash: &CryptoHash) -> Result<Trie, Error> {
         let shard_uid = self.get_shard_uid_from_prev_hash(shard_id, prev_hash)?;
-        let tries = self.tries.read().expect(POISONED_LOCK_ERR);
-        Ok(tries.get_trie_for_shard(shard_uid))
+        Ok(self.tries.get_trie_for_shard(shard_uid))
     }
 
     fn get_view_trie_for_shard(
@@ -646,8 +644,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         prev_hash: &CryptoHash,
     ) -> Result<Trie, Error> {
         let shard_uid = self.get_shard_uid_from_prev_hash(shard_id, prev_hash)?;
-        let tries = self.tries.read().expect(POISONED_LOCK_ERR);
-        Ok(tries.get_view_trie_for_shard(shard_uid))
+        Ok(self.tries.get_view_trie_for_shard(shard_uid))
     }
 
     fn verify_block_vrf(
@@ -685,8 +682,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         if let Some(state_root) = state_root {
             let shard_uid =
                 self.account_id_to_shard_uid(&transaction.transaction.signer_id, epoch_id)?;
-            let tries = self.tries.read().expect(POISONED_LOCK_ERR);
-            let mut state_update = tries.new_trie_update(shard_uid, state_root);
+            let mut state_update = self.tries.new_trie_update(shard_uid, state_root);
 
             match verify_and_charge_transaction(
                 runtime_config,
@@ -744,8 +740,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         current_protocol_version: ProtocolVersion,
     ) -> Result<Vec<SignedTransaction>, Error> {
         let shard_uid = self.get_shard_uid_from_epoch_id(shard_id, epoch_id)?;
-        let tries = self.tries.read().expect(POISONED_LOCK_ERR);
-        let mut state_update = tries.new_trie_update(shard_uid, state_root);
+        let mut state_update = self.tries.new_trie_update(shard_uid, state_root);
 
         // Total amount of gas burnt for converting transactions towards receipts.
         let mut total_gas_burnt = 0;
@@ -1520,8 +1515,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         assert!(part_id < num_parts);
         let epoch_id = self.get_epoch_id(block_hash)?;
         let shard_uid = self.get_shard_uid_from_epoch_id(shard_id, &epoch_id)?;
-        let tries = self.tries.read().expect(POISONED_LOCK_ERR);
-        let trie = tries.get_view_trie_for_shard(shard_uid);
+        let trie = self.tries.get_view_trie_for_shard(shard_uid);
         let result = match trie.get_trie_nodes_for_part(part_id, num_parts, state_root) {
             Ok(partial_state) => partial_state,
             Err(e) => {
@@ -1565,8 +1559,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         state_root: &StateRoot,
         next_epoch_shard_layout: &ShardLayout,
     ) -> Result<HashMap<ShardUId, StateRoot>, Error> {
-        let mut tries = self.tries.write().expect(POISONED_LOCK_ERR);
-        let trie = tries.get_view_trie_for_shard(shard_uid);
+        let trie = self.tries.get_view_trie_for_shard(shard_uid);
         let shard_id = shard_uid.shard_id();
         let new_shards: Vec<_> = {
             let split_shards = next_epoch_shard_layout
@@ -1577,7 +1570,7 @@ impl RuntimeAdapter for NightshadeRuntime {
                 .map(|id| ShardUId::from_shard_id_and_layout(*id, &next_epoch_shard_layout))
                 .collect()
         };
-        tries.add_new_shards(&new_shards);
+        self.tries.add_new_shards(&new_shards);
         let mut state_roots: HashMap<_, _> =
             new_shards.into_iter().map(|shard_uid| (shard_uid, StateRoot::default())).collect();
 
@@ -1586,7 +1579,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         debug!(target: "runtime", "splitting state for shard {} to {} parts to build new states", shard_id, num_parts);
         for part_id in 0..num_parts {
             let trie_items = trie.get_trie_items_for_part(part_id, num_parts, state_root)?;
-            let (store_update, new_state_roots) = tries.apply_changes_to_new_states(
+            let (store_update, new_state_roots) = self.tries.apply_changes_to_new_states(
                 &state_roots,
                 trie_items.into_iter().map(|(key, value)| (key, Some(value.clone()))).collect(),
                 &|raw_key| {
@@ -1624,7 +1617,7 @@ impl RuntimeAdapter for NightshadeRuntime {
             store_update.commit()?;
         }
         state_roots = apply_delayed_receipts(
-            &tries,
+            &self.tries,
             shard_uid,
             state_root.clone(),
             state_roots,
@@ -1663,8 +1656,7 @@ impl RuntimeAdapter for NightshadeRuntime {
     ) -> Result<StateRootNode, Error> {
         let epoch_id = self.get_epoch_id(block_hash)?;
         let shard_uid = self.get_shard_uid_from_epoch_id(shard_id, &epoch_id)?;
-        let tries = self.tries.read().expect(POISONED_LOCK_ERR);
-        tries
+        self.tries
             .get_view_trie_for_shard(shard_uid)
             .retrieve_root_node(state_root)
             .map_err(|e| e.to_string().into())
@@ -1760,8 +1752,7 @@ impl node_runtime::adapter::ViewRuntimeAdapter for NightshadeRuntime {
         state_root: MerkleHash,
         account_id: &AccountId,
     ) -> Result<Account, node_runtime::state_viewer::errors::ViewAccountError> {
-        let tries = self.tries.read().expect(POISONED_LOCK_ERR);
-        let state_update = tries.new_trie_update_view(*shard_uid, state_root);
+        let state_update = self.tries.new_trie_update_view(*shard_uid, state_root);
         self.trie_viewer.view_account(&state_update, account_id)
     }
 
@@ -1771,8 +1762,7 @@ impl node_runtime::adapter::ViewRuntimeAdapter for NightshadeRuntime {
         state_root: MerkleHash,
         account_id: &AccountId,
     ) -> Result<ContractCode, node_runtime::state_viewer::errors::ViewContractCodeError> {
-        let tries = self.tries.read().expect(POISONED_LOCK_ERR);
-        let state_update = tries.new_trie_update_view(*shard_uid, state_root);
+        let state_update = self.tries.new_trie_update_view(*shard_uid, state_root);
         self.trie_viewer.view_contract_code(&state_update, account_id)
     }
 
@@ -1793,8 +1783,7 @@ impl node_runtime::adapter::ViewRuntimeAdapter for NightshadeRuntime {
         epoch_info_provider: &dyn EpochInfoProvider,
         current_protocol_version: ProtocolVersion,
     ) -> Result<Vec<u8>, node_runtime::state_viewer::errors::CallFunctionError> {
-        let tries = self.tries.read().expect(POISONED_LOCK_ERR);
-        let state_update = tries.new_trie_update_view(*shard_uid, state_root);
+        let state_update = self.tries.new_trie_update_view(*shard_uid, state_root);
         let view_state = ViewApplyState {
             block_height: height,
             prev_block_hash: *prev_block_hash,
@@ -1803,7 +1792,7 @@ impl node_runtime::adapter::ViewRuntimeAdapter for NightshadeRuntime {
             epoch_height,
             block_timestamp,
             current_protocol_version,
-            cache: Some(Arc::new(StoreCompiledContractCache { store: tries.get_store() })),
+            cache: Some(Arc::new(StoreCompiledContractCache { store: self.tries.get_store() })),
         };
         self.trie_viewer.call_function(
             state_update,
@@ -1823,8 +1812,7 @@ impl node_runtime::adapter::ViewRuntimeAdapter for NightshadeRuntime {
         account_id: &AccountId,
         public_key: &PublicKey,
     ) -> Result<AccessKey, node_runtime::state_viewer::errors::ViewAccessKeyError> {
-        let tries = self.tries.read().expect(POISONED_LOCK_ERR);
-        let state_update = tries.new_trie_update_view(*shard_uid, state_root);
+        let state_update = self.tries.new_trie_update_view(*shard_uid, state_root);
         self.trie_viewer.view_access_key(&state_update, account_id, public_key)
     }
 
@@ -1835,8 +1823,7 @@ impl node_runtime::adapter::ViewRuntimeAdapter for NightshadeRuntime {
         account_id: &AccountId,
     ) -> Result<Vec<(PublicKey, AccessKey)>, node_runtime::state_viewer::errors::ViewAccessKeyError>
     {
-        let tries = self.tries.read().expect(POISONED_LOCK_ERR);
-        let state_update = tries.new_trie_update_view(*shard_uid, state_root);
+        let state_update = self.tries.new_trie_update_view(*shard_uid, state_root);
         self.trie_viewer.view_access_keys(&state_update, account_id)
     }
 
@@ -1847,8 +1834,7 @@ impl node_runtime::adapter::ViewRuntimeAdapter for NightshadeRuntime {
         account_id: &AccountId,
         prefix: &[u8],
     ) -> Result<ViewStateResult, node_runtime::state_viewer::errors::ViewStateError> {
-        let tries = self.tries.read().expect(POISONED_LOCK_ERR);
-        let state_update = tries.new_trie_update_view(*shard_uid, state_root);
+        let state_update = self.tries.new_trie_update_view(*shard_uid, state_root);
         self.trie_viewer.view_state(&state_update, account_id, prefix)
     }
 }


### PR DESCRIPTION
This PR refactors the implementation of ShardTries to make it more comply with the general rust design guideline such as interior mutability. It makes two changes
- remove the Arc of individual fields in ShardTries and Arc the whole ShardTries struct instead
- hide the RwLock inside ShardTries so the callers of ShardTries do not need to worry about locking (interior mutability)