### PR TITLE
draft: swap stack limiter and gas counter

### DIFF
--- a/runtime/near-vm-runner/src/prepare.rs
+++ b/runtime/near-vm-runner/src/prepare.rs
@@ -156,8 +156,8 @@ pub fn prepare_contract(original_code: &[u8], config: &VMConfig) -> Result<Vec<u
     ContractModule::init(original_code, config)?
         .standardize_mem()
         .ensure_no_internal_memory()?
-        .inject_gas_metering()?
         .inject_stack_height_metering()?
+        .inject_gas_metering()?
         .scan_imports()?
         .into_wasm_code()
 }


### PR DESCRIPTION
Context:
We aim to make old and new gas counter behaves exactly same. However, in the case of stack overflow test they diverge because we first inject gas counter, then inject stack limiter. When inject new gas counter, it makes function body more fat for trivial functions, and that result in spent less gas when stack overflow happens compare to old gas counter (because pwasm-utils stack limiter count function body size and fit less recursive calls for larger body).

One way to fix this problem is to inject stack limiter first, then inject gas_counter. This alone becomes a protocol change and I think if we do this, we should do before #4688 and bump it as a new protocol version

This makes almost any function call more expensive because the added stack limiter code is now also considered as spent gas. (See some example difference below) So whether is this a good idea?

```

failures:

---- tests::error_cases::test_div_by_zero_contract stdout ----
thread 'tests::error_cases::test_div_by_zero_contract' panicked at 'assertion failed: `(left == right)`
  left: `(Some(VMOutcome: balance 4 storage_usage 12 return data None burnt gas 109891020 used gas 109891020), Some(FunctionCallError(WasmTrap(IllegalArithmetic))))`,
 right: `(Some(VMOutcome: balance 4 storage_usage 12 return data None burnt gas 59758197 used gas 59758197), Some(FunctionCallError(WasmTrap(IllegalArithmetic))))`', runtime/near-vm-runner/src/tests/error_cases.rs:254:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- tests::error_cases::test_external_call_ok stdout ----
thread 'tests::error_cases::test_external_call_ok' panicked at 'assertion failed: `(left == right)`
  left: `(Some(VMOutcome: balance 4 storage_usage 12 return data None burnt gas 371714889 used gas 371714889), None)`,
 right: `(Some(VMOutcome: balance 4 storage_usage 12 return data None burnt gas 321582066 used gas 321582066), None)`', runtime/near-vm-runner/src/tests/error_cases.rs:726:9

---- tests::error_cases::test_external_call_indirect stdout ----
thread 'tests::error_cases::test_external_call_indirect' panicked at 'assertion failed: `(left == right)`
  left: `Some(VMOutcome: balance 4 storage_usage 12 return data None burnt gas 384674760 used gas 384674760)`,
 right: `Some(VMOutcome: balance 4 storage_usage 12 return data None burnt gas 334541937 used gas 334541937)`', runtime/near-vm-runner/src/tests/error_cases.rs:779:9

---- tests::error_cases::test_float_to_int_contract stdout ----
thread 'tests::error_cases::test_float_to_int_contract' panicked at 'assertion failed: `(left == right)`
  left: `(Some(VMOutcome: balance 4 storage_usage 12 return data None burnt gas 107118399 used gas 107118399), Some(FunctionCallError(WasmTrap(IllegalArithmetic))))`,
 right: `(Some(VMOutcome: balance 4 storage_usage 12 return data None burnt gas 56985576 used gas 56985576), Some(FunctionCallError(WasmTrap(IllegalArithmetic))))`', runtime/near-vm-runner/src/tests/error_cases.rs:294:13

---- tests::error_cases::test_indirect_call_to_null_contract stdout ----
thread 'tests::error_cases::test_indirect_call_to_null_contract' panicked at 'assertion failed: `(left == right)`
  left: `(Some(VMOutcome: balance 4 storage_usage 12 return data None burnt gas 107335149 used gas 107335149), Some(FunctionCallError(WasmTrap(IndirectCallToNull))))`,
 right: `(Some(VMOutcome: balance 4 storage_usage 12 return data None burnt gas 57202326 used gas 57202326), Some(FunctionCallError(WasmTrap(IndirectCallToNull))))`', runtime/near-vm-runner/src/tests/error_cases.rs:335:9

---- tests::error_cases::test_indirect_call_to_wrong_signature_contract stdout ----
thread 'tests::error_cases::test_indirect_call_to_wrong_signature_contract' panicked at 'assertion failed: `(left == right)`
  left: `(Some(VMOutcome: balance 4 storage_usage 12 return data None burnt gas 112103649 used gas 112103649), Some(FunctionCallError(WasmTrap(IncorrectCallIndirectSignature))))`,
 right: `(Some(VMOutcome: balance 4 storage_usage 12 return data None burnt gas 61970826 used gas 61970826), Some(FunctionCallError(WasmTrap(IncorrectCallIndirectSignature))))`', runtime/near-vm-runner/src/tests/error_cases.rs:379:9

---- tests::error_cases::test_stack_overflow stdout ----
thread 'tests::error_cases::test_stack_overflow' panicked at 'assertion failed: `(left == right)`
  left: `(Some(VMOutcome: balance 4 storage_usage 12 return data None burnt gas 124696801917 used gas 124696801917), Some(FunctionCallError(WasmTrap(Unreachable))))`,
 right: `(Some(VMOutcome: balance 4 storage_usage 12 return data None burnt gas 63226248177 used gas 63226248177), Some(FunctionCallError(WasmTrap(Unreachable))))`', runtime/near-vm-runner/src/tests/error_cases.rs:494:50

---- tests::contract_preload::test_run_preloaded stdout ----
thread 'tests::contract_preload::test_run_preloaded' panicked at 'assertion failed: `(left == right)`
  left: `11138184744`,
 right: `11088051921`', runtime/near-vm-runner/src/tests/contract_preload.rs:76:17


failures:
    tests::contract_preload::test_run_preloaded
    tests::error_cases::test_div_by_zero_contract
    tests::error_cases::test_external_call_indirect
    tests::error_cases::test_external_call_ok
    tests::error_cases::test_float_to_int_contract
    tests::error_cases::test_indirect_call_to_null_contract
    tests::error_cases::test_indirect_call_to_wrong_signature_contract
    tests::error_cases::test_stack_overflow

test result: FAILED. 51 passed; 8 failed; 0 ignored; 0 measured; 0 filtered out; finished in 27.12s

```