### PR TITLE
chore: don't hide Cargo.lock from diff

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
-Cargo.lock linguist-generated=true -diff
 **/package-lock.json linguist-generated=true -diff


### PR DESCRIPTION
Cargo.lock is one of the more important files in the project, especially
in security-sensitive projects. We need to know which dependencies
change and when, we need to keep an eye on accidental additions of new
dependencies.

It's very easy to accidentally upgrade everything when adding just a
single new dependency, and that's what almost happened in #4395.

I haven't seen other big rust-projects adding Cargo.lock to
.gitattributes.