### PR TITLE
fix(near-primitives): `EpochReference` enum can be flattened into a struct

### DIFF
--- a/chain/jsonrpc-primitives/src/types/status.rs
+++ b/chain/jsonrpc-primitives/src/types/status.rs
@@ -6,7 +6,7 @@ pub struct RpcStatusResponse {
     pub status_response: near_primitives::views::StatusResponse,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct RpcHealthResponse;
 
 #[derive(thiserror::Error, Debug, Serialize, Deserialize)]

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -998,12 +998,31 @@ pub struct BlockChunkValidatorStats {
     pub chunk_stats: ValidatorStats,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Deserialize, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum EpochReference {
     EpochId(EpochId),
     BlockId(BlockId),
     Latest,
+}
+
+impl Serialize for EpochReference {
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            EpochReference::EpochId(epoch_id) => {
+                s.serialize_newtype_variant("EpochReference", 0, "epoch_id", epoch_id)
+            }
+            EpochReference::BlockId(block_id) => {
+                s.serialize_newtype_variant("EpochReference", 1, "block_id", block_id)
+            }
+            EpochReference::Latest => {
+                s.serialize_newtype_variant("EpochReference", 2, "latest", &())
+            }
+        }
+    }
 }
 
 /// Reasons for removing a validator from the validator set.


### PR DESCRIPTION
`EpochReference` is defined as such:

https://github.com/near/nearcore/blob/06d05bce3fab578a91b210d7354fb17427fcc9d6/core/primitives/src/types.rs#L1001-L1007

And it's serialization, as such:

| % | `EpochReference::BlockId(...)` | `EpochReference::Latest` |
| - | ------------------------------ | ------------------------ |
| expectation | `{"block_id": ...}` | `{"latest": null}`
| reality | `{"block_id": ...}` | `"latest"` |

As you can already see, `serde`'s default method for serializing unit variants is to use a string 
unlike how it uses an object for the rest of the variants.

This PR implements custom serialization for `EpochReference`, specifically for the `Latest` variant. So it serializes to `{"latest": null}`.

> Note: this retains the default deserialization so we have no breaking changes on the deserialization side.
>
> So, the following values properly deserialize into that variant:
> - `"latest"`
> - `{"latest": null}`
> - `{"latest": []}`

_props to @volovyk-s 🎉  for discovering this while using the new [`near-jsonrpc-client`](https://github.com/near/near-jsonrpc-client-rs)_