### PR TITLE
fix: use correct (not safely-multiplied) cost in the canonical costs file

### DIFF
--- a/runtime/runtime-params-estimator/costs.txt
+++ b/runtime/runtime-params-estimator/costs.txt
@@ -14,7 +14,7 @@ ActionAddFunctionAccessKeyPerByte                   3_850_662
 ActionDeleteKey                               189_893_250_000
 ActionDeleteAccount                           294_978_000_000
 HostFunctionCall                                   88_256_037
-WasmInstruction                                     3_856_371
+WasmInstruction                                     1_285_457
 ReadMemoryBase                                    869_954_400
 ReadMemoryByte                                      1_267_111
 WriteMemoryBase                                   934_598_287


### PR DESCRIPTION

cc #4639

Test Plan
--------

This file is not a source of truth currently, so the change doesn't
affect anything.