### PR TITLE
fix(primitives): backwards compatible ExecutionOutcomeView

### DIFF
--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -1031,6 +1031,12 @@ pub struct ExecutionMetadataView {
     gas_profile: Option<Vec<CostGasUsed>>,
 }
 
+impl Default for ExecutionMetadataView {
+    fn default() -> Self {
+        ExecutionMetadata::V1.into()
+    }
+}
+
 impl From<ExecutionMetadata> for ExecutionMetadataView {
     fn from(metadata: ExecutionMetadata) -> Self {
         let gas_profile = match metadata {
@@ -1080,12 +1086,8 @@ pub struct ExecutionOutcomeView {
     /// Execution status. Contains the result in case of successful execution.
     pub status: ExecutionStatusView,
     /// Execution metadata, versioned
-    #[serde(default = "default_execution_metadata_view")]
+    #[serde(default)]
     pub metadata: ExecutionMetadataView,
-}
-
-fn default_execution_metadata_view() -> ExecutionMetadataView {
-    ExecutionMetadata::V1.into()
 }
 
 impl From<ExecutionOutcome> for ExecutionOutcomeView {

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -1080,7 +1080,12 @@ pub struct ExecutionOutcomeView {
     /// Execution status. Contains the result in case of successful execution.
     pub status: ExecutionStatusView,
     /// Execution metadata, versioned
+    #[serde(default = "default_execution_metadata_view")]
     pub metadata: ExecutionMetadataView,
+}
+
+fn default_execution_metadata_view() -> ExecutionMetadataView {
+    ExecutionMetadata::V1.into()
 }
 
 impl From<ExecutionOutcome> for ExecutionOutcomeView {


### PR DESCRIPTION
Since #4438, the `metadata` field was introduced on `ExecutionOutcomeView`.
Older nodes _(e.g the ones deployed on `[archival-]rpc.<network>.near.org` as of today)_ do not include that field. This means deserializing that data into the new `ExecutionOutcomeView` fails.

This PR introduces a default value for that field. Specifically, from `ExecutionMetadata::V1`.