### PR TITLE
Introduce TestEnvBuilder structure

### DIFF
--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -1102,7 +1102,137 @@ pub struct TestEnv {
     pub clients: Vec<Client>,
 }
 
+/// A builder for the TestEnv structure.
+pub struct TestEnvBuilder {
+    chain_genesis: ChainGenesis,
+    clients: Vec<AccountId>,
+    validators: Vec<AccountId>,
+    runtime_adapters: Option<Vec<Arc<dyn RuntimeAdapter>>>,
+    network_adapters: Option<Vec<Arc<MockNetworkAdapter>>>,
+}
+
+impl TestEnvBuilder {
+    pub fn new(chain_genesis: ChainGenesis) -> Self {
+        Self {
+            chain_genesis,
+            clients: Self::make_accounts(1, Self::default_formatter),
+            validators: Self::make_accounts(1, Self::default_formatter),
+            runtime_adapters: None,
+            network_adapters: None,
+        }
+    }
+
+    pub fn clients(mut self, clients: Vec<AccountId>) -> Self {
+        assert!(!clients.is_empty());
+        self.clients = clients;
+        self
+    }
+
+    pub fn clients_count(mut self, num_clients: usize) -> Self {
+        self.clients_with_formatter(num_clients, Self::default_formatter)
+    }
+
+    pub fn clients_with_formatter<F>(mut self, num_clients: usize, formatter: F) -> Self
+    where
+        F: Fn(usize) -> std::string::String,
+    {
+        self.clients(Self::make_accounts(num_clients, formatter))
+    }
+
+    pub fn validators(mut self, validators: Vec<AccountId>) -> Self {
+        assert!(!validators.is_empty());
+        self.validators = validators;
+        self
+    }
+
+    pub fn validators_count(mut self, num_validators: usize) -> Self {
+        self.validators_with_formatter(num_validators, Self::default_formatter)
+    }
+
+    pub fn validators_with_formatter<F>(mut self, num_validators: usize, formatter: F) -> Self
+    where
+        F: Fn(usize) -> std::string::String,
+    {
+        self.validators(Self::make_accounts(num_validators, formatter))
+    }
+
+    pub fn runtime_adapters(mut self, adapters: Vec<Arc<dyn RuntimeAdapter>>) -> Self {
+        self.runtime_adapters = Some(adapters);
+        self
+    }
+
+    pub fn network_adapters(mut self, adapters: Vec<Arc<MockNetworkAdapter>>) -> Self {
+        self.network_adapters = Some(adapters);
+        self
+    }
+
+    pub fn build(self) -> TestEnv {
+        let chain_genesis = self.chain_genesis;
+        let clients = self.clients;
+        let num_clients = clients.len();
+        let validators = self.validators;
+        let num_validators = validators.len();
+        let network_adapters = self
+            .network_adapters
+            .unwrap_or_else(|| (0..num_clients).map(|_| Arc::new(Default::default())).collect());
+        assert!(clients.len() == network_adapters.len());
+        let clients = match self.runtime_adapters {
+            None => clients
+                .into_iter()
+                .zip(network_adapters.iter())
+                .map(|(account_id, network_adapter)| {
+                    setup_client(
+                        create_test_store(),
+                        vec![validators.clone()],
+                        1,
+                        1,
+                        Some(account_id),
+                        false,
+                        network_adapter.clone(),
+                        chain_genesis.clone(),
+                    )
+                })
+                .collect(),
+            Some(runtime_adapters) => {
+                assert!(clients.len() == runtime_adapters.len());
+                clients
+                    .into_iter()
+                    .zip((&network_adapters).iter())
+                    .zip(runtime_adapters.into_iter())
+                    .map(|((account_id, network_adapter), runtime_adapter)| {
+                        setup_client_with_runtime(
+                            u64::try_from(num_validators).unwrap(),
+                            Some(account_id),
+                            false,
+                            network_adapter.clone(),
+                            chain_genesis.clone(),
+                            runtime_adapter,
+                        )
+                    })
+                    .collect()
+            }
+        };
+
+        TestEnv { chain_genesis, validators, network_adapters, clients }
+    }
+
+    fn default_formatter(id: usize) -> std::string::String {
+        format!("test{}", id)
+    }
+
+    fn make_accounts<F>(count: usize, formatter: F) -> Vec<AccountId>
+    where
+        F: Fn(usize) -> std::string::String,
+    {
+        (0..count).map(|i| AccountId::try_from(formatter(i)).unwrap()).collect()
+    }
+}
+
 impl TestEnv {
+    pub fn builder(chain_genesis: ChainGenesis) -> TestEnvBuilder {
+        TestEnvBuilder::new(chain_genesis)
+    }
+
     /// Create a `TestEnv` with `KeyValueRuntime`.
     pub fn new(chain_genesis: ChainGenesis, num_clients: usize, num_validators: usize) -> Self {
         let validators: Vec<AccountId> = (0..num_validators)
@@ -1135,41 +1265,14 @@ impl TestEnv {
         num_validator_seats: NumSeats,
         runtime_adapters: Vec<Arc<dyn RuntimeAdapter>>,
     ) -> Self {
-        let network_adapters: Vec<Arc<MockNetworkAdapter>> =
+        let network_adapters =
             (0..num_clients).map(|_| Arc::new(MockNetworkAdapter::default())).collect();
-        Self::new_with_runtime_and_network_adapter(
-            chain_genesis,
-            num_clients,
-            num_validator_seats,
-            runtime_adapters,
-            network_adapters,
-        )
-    }
-
-    /// Create a `TestEnv` with custom runtime adapters and `MockNetworkAdapter`s.
-    pub fn new_with_runtime_and_network_adapter(
-        chain_genesis: ChainGenesis,
-        num_clients: usize,
-        num_validator_seats: NumSeats,
-        runtime_adapters: Vec<Arc<dyn RuntimeAdapter>>,
-        network_adapters: Vec<Arc<MockNetworkAdapter>>,
-    ) -> Self {
-        let validators: Vec<AccountId> = (0..num_validator_seats)
-            .map(|i| AccountId::try_from(format!("test{}", i)).unwrap())
-            .collect();
-        let clients = (0..num_clients)
-            .map(|i| {
-                setup_client_with_runtime(
-                    num_validator_seats,
-                    Some(AccountId::try_from(format!("test{}", i)).unwrap()),
-                    false,
-                    network_adapters[i].clone(),
-                    chain_genesis.clone(),
-                    runtime_adapters[i].clone(),
-                )
-            })
-            .collect();
-        TestEnv { chain_genesis, validators, network_adapters, clients }
+        Self::builder(chain_genesis)
+            .clients_count(num_clients)
+            .validators_count(usize::try_from(num_validator_seats).unwrap())
+            .network_adapters(network_adapters)
+            .runtime_adapters(runtime_adapters)
+            .build()
     }
 
     /// Process a given block in the client with index `id`.

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -1111,8 +1111,10 @@ pub struct TestEnvBuilder {
     network_adapters: Option<Vec<Arc<MockNetworkAdapter>>>,
 }
 
+/// Builder for the `TestEnv` structure.
 impl TestEnvBuilder {
-    pub fn new(chain_genesis: ChainGenesis) -> Self {
+    /// Constructs a new builder.
+    fn new(chain_genesis: ChainGenesis) -> Self {
         Self {
             chain_genesis,
             clients: Self::make_accounts(1, Self::default_formatter),
@@ -1122,50 +1124,62 @@ impl TestEnvBuilder {
         }
     }
 
+    /// Sets list of client `AccountId`s to the one provided.  Panics if the
+    /// vector is empty.
     pub fn clients(mut self, clients: Vec<AccountId>) -> Self {
         assert!(!clients.is_empty());
         self.clients = clients;
         self
     }
 
-    pub fn clients_count(self, num_clients: usize) -> Self {
-        self.clients_with_formatter(num_clients, Self::default_formatter)
+    /// Sets number of clients to given one.  Each client will use `AccountId`
+    /// in the form `test{}` where `{}` will count from zero.
+    pub fn clients_count(self, num: usize) -> Self {
+        self.clients(Self::make_accounts(num, Self::default_formatter))
     }
 
-    pub fn clients_with_formatter<F>(self, num_clients: usize, formatter: F) -> Self
-    where
-        F: Fn(usize) -> std::string::String,
-    {
-        self.clients(Self::make_accounts(num_clients, formatter))
-    }
-
+    /// Sets list of validator `AccountId`s to the one provided.  Panics if the
+    /// vector is empty.
     pub fn validators(mut self, validators: Vec<AccountId>) -> Self {
         assert!(!validators.is_empty());
         self.validators = validators;
         self
     }
 
-    pub fn validators_seats(self, num_validators: usize) -> Self {
-        self.validators_with_formatter(num_validators, Self::default_formatter)
+    /// Sets number of validator seats to given one.  Each validator will use
+    /// `AccountId` in the form `test{}` where `{}` will count from zero.
+    pub fn validator_seats(self, num: usize) -> Self {
+        self.validators(Self::make_accounts(num, Self::default_formatter))
     }
 
-    pub fn validators_with_formatter<F>(self, num_validators: usize, formatter: F) -> Self
-    where
-        F: Fn(usize) -> std::string::String,
-    {
-        self.validators(Self::make_accounts(num_validators, formatter))
-    }
-
+    /// Specifies custom runtime adaptors for each client.  This allows us to
+    /// construct `TestEnv` with `NightshadeRuntime`.
+    ///
+    /// The vector must have the same number of elements as they are clients.
+    /// If that does not hold, `build` method will panic.
     pub fn runtime_adapters(mut self, adapters: Vec<Arc<dyn RuntimeAdapter>>) -> Self {
         self.runtime_adapters = Some(adapters);
         self
     }
 
+    /// Specifies custom network adaptors for each client.
+    ///
+    /// The vector must have the same number of elements as they are clients.
+    /// If that does not hold, `build` method will panic.
     pub fn network_adapters(mut self, adapters: Vec<Arc<MockNetworkAdapter>>) -> Self {
         self.network_adapters = Some(adapters);
         self
     }
 
+    /// Constructs new `TestEnv` structure.
+    ///
+    /// If no clients were configured (either through count or vector) one
+    /// client is created.  Similarly, if no validator seats were configured,
+    /// one seat is configured.
+    ///
+    /// Panics if `runtime_adapters` or `network_adapters` methods were used and
+    /// the length of the vectors passed to them did not equal number of
+    /// configured clients.
     pub fn build(self) -> TestEnv {
         let chain_genesis = self.chain_genesis;
         let clients = self.clients;
@@ -1269,7 +1283,7 @@ impl TestEnv {
             (0..num_clients).map(|_| Arc::new(MockNetworkAdapter::default())).collect();
         Self::builder(chain_genesis)
             .clients_count(num_clients)
-            .validators_seats(usize::try_from(num_validator_seats).unwrap())
+            .validator_seats(usize::try_from(num_validator_seats).unwrap())
             .network_adapters(network_adapters)
             .runtime_adapters(runtime_adapters)
             .build()

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -1145,7 +1145,7 @@ impl TestEnvBuilder {
         self
     }
 
-    pub fn validators_count(mut self, num_validators: usize) -> Self {
+    pub fn validators_seats(mut self, num_validators: usize) -> Self {
         self.validators_with_formatter(num_validators, Self::default_formatter)
     }
 
@@ -1269,7 +1269,7 @@ impl TestEnv {
             (0..num_clients).map(|_| Arc::new(MockNetworkAdapter::default())).collect();
         Self::builder(chain_genesis)
             .clients_count(num_clients)
-            .validators_count(usize::try_from(num_validator_seats).unwrap())
+            .validators_seats(usize::try_from(num_validator_seats).unwrap())
             .network_adapters(network_adapters)
             .runtime_adapters(runtime_adapters)
             .build()

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -1128,11 +1128,11 @@ impl TestEnvBuilder {
         self
     }
 
-    pub fn clients_count(mut self, num_clients: usize) -> Self {
+    pub fn clients_count(self, num_clients: usize) -> Self {
         self.clients_with_formatter(num_clients, Self::default_formatter)
     }
 
-    pub fn clients_with_formatter<F>(mut self, num_clients: usize, formatter: F) -> Self
+    pub fn clients_with_formatter<F>(self, num_clients: usize, formatter: F) -> Self
     where
         F: Fn(usize) -> std::string::String,
     {
@@ -1145,11 +1145,11 @@ impl TestEnvBuilder {
         self
     }
 
-    pub fn validators_seats(mut self, num_validators: usize) -> Self {
+    pub fn validators_seats(self, num_validators: usize) -> Self {
         self.validators_with_formatter(num_validators, Self::default_formatter)
     }
 
-    pub fn validators_with_formatter<F>(mut self, num_validators: usize, formatter: F) -> Self
+    pub fn validators_with_formatter<F>(self, num_validators: usize, formatter: F) -> Self
     where
         F: Fn(usize) -> std::string::String,
     {

--- a/integration-tests/tests/client/challenges.rs
+++ b/integration-tests/tests/client/challenges.rs
@@ -659,12 +659,16 @@ fn test_challenge_in_different_epoch() {
         None,
         RuntimeConfigStore::test(),
     ));
-    let runtimes: Vec<Arc<dyn RuntimeAdapter>> = vec![runtime1, runtime2];
-    let networks = vec![network_adapter.clone(), network_adapter.clone()];
     let mut chain_genesis = ChainGenesis::test();
     chain_genesis.epoch_length = 3;
-    let mut env =
-        TestEnv::new_with_runtime_and_network_adapter(chain_genesis, 2, 2, runtimes, networks);
+
+    let mut env = TestEnv::builder(chain_genesis)
+        .clients_count(2)
+        .validators_count(2)
+        .runtime_adapters(vec![runtime1, runtime2])
+        .network_adapters(vec![network_adapter.clone(), network_adapter.clone()])
+        .build();
+
     let mut fork_blocks = vec![];
     for h in 1..13 {
         if let Some(block) = env.clients[0].produce_block(h).unwrap() {

--- a/integration-tests/tests/client/challenges.rs
+++ b/integration-tests/tests/client/challenges.rs
@@ -664,7 +664,7 @@ fn test_challenge_in_different_epoch() {
 
     let mut env = TestEnv::builder(chain_genesis)
         .clients_count(2)
-        .validators_count(2)
+        .validators_seats(2)
         .runtime_adapters(vec![runtime1, runtime2])
         .network_adapters(vec![network_adapter.clone(), network_adapter.clone()])
         .build();

--- a/integration-tests/tests/client/challenges.rs
+++ b/integration-tests/tests/client/challenges.rs
@@ -664,7 +664,7 @@ fn test_challenge_in_different_epoch() {
 
     let mut env = TestEnv::builder(chain_genesis)
         .clients_count(2)
-        .validators_seats(2)
+        .validator_seats(2)
         .runtime_adapters(vec![runtime1, runtime2])
         .network_adapters(vec![network_adapter.clone(), network_adapter.clone()])
         .build();

--- a/integration-tests/tests/client/process_blocks.rs
+++ b/integration-tests/tests/client/process_blocks.rs
@@ -2938,13 +2938,12 @@ fn test_not_broadcast_block_on_accept() {
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
     let network_adapter = Arc::new(MockNetworkAdapter::default());
-    let mut env = TestEnv::new_with_runtime_and_network_adapter(
-        ChainGenesis::test(),
-        2,
-        1,
-        create_nightshade_runtimes(&genesis, 2),
-        vec![Arc::new(MockNetworkAdapter::default()), network_adapter.clone()],
-    );
+    let mut env = TestEnv::builder(ChainGenesis::test())
+        .clients_count(2)
+        .validators_count(1)
+        .runtime_adapters(create_nightshade_runtimes(&genesis, 2))
+        .network_adapters(vec![Arc::new(MockNetworkAdapter::default()), network_adapter.clone()])
+        .build();
     let b1 = env.clients[0].produce_block(1).unwrap().unwrap();
     for i in 0..2 {
         env.process_block(i, b1.clone(), Provenance::NONE);

--- a/integration-tests/tests/client/process_blocks.rs
+++ b/integration-tests/tests/client/process_blocks.rs
@@ -2940,7 +2940,6 @@ fn test_not_broadcast_block_on_accept() {
     let network_adapter = Arc::new(MockNetworkAdapter::default());
     let mut env = TestEnv::builder(ChainGenesis::test())
         .clients_count(2)
-        .validators_seats(1)
         .runtime_adapters(create_nightshade_runtimes(&genesis, 2))
         .network_adapters(vec![Arc::new(MockNetworkAdapter::default()), network_adapter.clone()])
         .build();

--- a/integration-tests/tests/client/process_blocks.rs
+++ b/integration-tests/tests/client/process_blocks.rs
@@ -2940,7 +2940,7 @@ fn test_not_broadcast_block_on_accept() {
     let network_adapter = Arc::new(MockNetworkAdapter::default());
     let mut env = TestEnv::builder(ChainGenesis::test())
         .clients_count(2)
-        .validators_count(1)
+        .validators_seats(1)
         .runtime_adapters(create_nightshade_runtimes(&genesis, 2))
         .network_adapters(vec![Arc::new(MockNetworkAdapter::default()), network_adapter.clone()])
         .build();

--- a/integration-tests/tests/client/runtimes.rs
+++ b/integration-tests/tests/client/runtimes.rs
@@ -74,8 +74,6 @@ fn test_pending_approvals() {
 fn test_invalid_approvals() {
     let network_adapter = Arc::new(MockNetworkAdapter::default());
     let mut env = TestEnv::builder(ChainGenesis::test())
-        .clients_count(1)
-        .validators_seats(1)
         .runtime_adapters(create_runtimes(1))
         .network_adapters(vec![network_adapter.clone()])
         .build();

--- a/integration-tests/tests/client/runtimes.rs
+++ b/integration-tests/tests/client/runtimes.rs
@@ -72,15 +72,13 @@ fn test_pending_approvals() {
 
 #[test]
 fn test_invalid_approvals() {
-    let runtimes = create_runtimes(1);
     let network_adapter = Arc::new(MockNetworkAdapter::default());
-    let mut env = TestEnv::new_with_runtime_and_network_adapter(
-        ChainGenesis::test(),
-        1,
-        1,
-        runtimes,
-        vec![network_adapter.clone()],
-    );
+    let mut env = TestEnv::builder(ChainGenesis::test())
+        .clients_count(1)
+        .validators_count(1)
+        .runtime_adapters(create_runtimes(1))
+        .network_adapters(vec![network_adapter.clone()])
+        .build();
     let signer =
         InMemoryValidatorSigner::from_seed("random".parse().unwrap(), KeyType::ED25519, "random");
     let parent_hash = hash(&[1]);

--- a/integration-tests/tests/client/runtimes.rs
+++ b/integration-tests/tests/client/runtimes.rs
@@ -75,7 +75,7 @@ fn test_invalid_approvals() {
     let network_adapter = Arc::new(MockNetworkAdapter::default());
     let mut env = TestEnv::builder(ChainGenesis::test())
         .clients_count(1)
-        .validators_count(1)
+        .validators_seats(1)
         .runtime_adapters(create_runtimes(1))
         .network_adapters(vec![network_adapter.clone()])
         .build();


### PR DESCRIPTION
Replace TestEnv constructors with a TestEnvBuilder structure instead.
Motivation for this change are twofold.  First of all, with Rust’s
lack of default or keyword arguments constructors of TestEnv would
just continue to multiply with more and more arguments.  Second of
all, with the current design whoever uses TestEnv structure must
adhere to `test{}` AccountId format which may not always be desired.

With this commit also change three instances where
TestEnv::new_with_runtime_and_network_adapter was used by the use of
the builder.  Other places where TestEnv constructors are used are
left for now and will be dealt in another commit.

Issue: https://github.com/near/nearcore/issues/4835