### PR TITLE
ibf: fix [usize; 3] not being an iterator compilation error

### DIFF
--- a/chain/network/src/ibf.rs
+++ b/chain/network/src/ibf.rs
@@ -212,9 +212,9 @@ impl Ibf {
     ) {
         let pos_list = self.generate_idx(elem_hash);
 
-        for pos in pos_list {
-            self.data[pos].merge(&IbfBox::new(elem, elem_hash));
-            queue.push(pos);
+        for pos in pos_list.iter() {
+            self.data[*pos].merge(&IbfBox::new(elem, elem_hash));
+            queue.push(*pos);
         }
     }
 
@@ -223,8 +223,8 @@ impl Ibf {
         let elem_hash = self.compute_hash(elem);
         let pos_list = self.generate_idx(elem_hash);
 
-        for pos in pos_list {
-            self.data[pos].merge(&IbfBox::new(elem, elem_hash));
+        for pos in pos_list.iter() {
+            self.data[*pos].merge(&IbfBox::new(elem, elem_hash));
         }
     }
 }


### PR DESCRIPTION
Fixes the following compiler error:

    $ cargo build --release
    error[E0277]: `[usize; 3]` is not an iterator
       --> chain/network/src/ibf.rs:215:20
    215 |         for pos in pos_list {
        |                    ^^^^^^^^ borrow the array with `&` or call `.iter()` on it to iterate over it

Issue: https://github.com/near/nearcore/issues/3838