### PR TITLE
fix(jsonrpc-primitives): fix adversarial-related compilation errors

### DIFF
--- a/chain/jsonrpc-primitives/Cargo.toml
+++ b/chain/jsonrpc-primitives/Cargo.toml
@@ -22,7 +22,7 @@ near-metrics = { path = "../../core/metrics" }
 near-primitives = { path = "../../core/primitives" }
 near-primitives-core = { path = "../../core/primitives-core" }
 near-rpc-error-macro = { path = "../../tools/rpctypegen/macro" }
-near-network = { path = "../network", optional=true }
+near-network = { path = "../network", optional = true, features = ["adversarial"] }
 
 [features]
 adversarial = ["near-network"]

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -45,11 +45,11 @@ tempfile = "3"
 bencher = "0.1.5"
 
 [features]
-adversarial = ["near-network-primitives/adversarial", "serde"]
+adversarial = ["near-network-primitives/adversarial", "serde", "protocol_feature_routing_exchange_algorithm"]
 delay_detector = ["delay-detector"]
 performance_stats = ["near-performance-metrics/performance_stats"]
 sandbox = ["near-network-primitives/sandbox"]
-protocol_feature_routing_exchange_algorithm = []
+protocol_feature_routing_exchange_algorithm = ["near-primitives/protocol_feature_routing_exchange_algorithm"]
 
 [[bench]]
 name = "graph"


### PR DESCRIPTION
Fix compilation error in `near-jsonrpc-primitives` when building with the `adversarial` feature enabled after https://github.com/near/nearcore/pull/4112

### Test Plan

- [X] Ensure `near-jsonrpc-primitives` compiles with `adversarial` features turned on