### PR TITLE
refactor: separate default and test runtime configs

### DIFF
--- a/chain/rosetta-rpc/src/adapters/mod.rs
+++ b/chain/rosetta-rpc/src/adapters/mod.rs
@@ -907,7 +907,7 @@ mod tests {
 
     #[test]
     fn test_convert_block_changes_to_transactions() {
-        let runtime_config = near_primitives::runtime::config::RuntimeConfig::default();
+        let runtime_config = near_primitives::runtime::config::RuntimeConfig::test();
         let block_hash = near_primitives::hash::CryptoHash::default();
         let nfvalidator1_receipt_processing_hash =
             near_primitives::hash::CryptoHash::try_from(vec![1u8; 32]).unwrap();

--- a/core/chain-configs/src/genesis_config.rs
+++ b/core/chain-configs/src/genesis_config.rs
@@ -123,6 +123,8 @@ pub struct GenesisConfig {
     #[default(Rational::from_integer(0))]
     pub gas_price_adjustment_rate: Rational,
     /// Runtime configuration (mostly economics constants).
+    /// TODO #4649: remove this field together with hacky default value setting
+    #[default(RuntimeConfig::test())]
     pub runtime_config: RuntimeConfig,
     /// List of initial validators.
     pub validators: Vec<AccountInfo>,

--- a/core/primitives-core/src/config.rs
+++ b/core/primitives-core/src/config.rs
@@ -110,8 +110,8 @@ impl VMConfig {
             regular_op_cost: 0,
             // We shouldn't have any costs in the limit config.
             limit_config: VMLimitConfig {
-                max_gas_burnt: std::u64::MAX,
-                max_gas_burnt_view: std::u64::MAX,
+                max_gas_burnt: u64::MAX,
+                max_gas_burnt_view: u64::MAX,
                 ..Default::default()
             },
         }

--- a/core/primitives-core/src/config.rs
+++ b/core/primitives-core/src/config.rs
@@ -343,6 +343,7 @@ pub struct ExtCostsConfig {
 // have certain reserve for further gas price variation.
 const SAFETY_MULTIPLIER: u64 = 3;
 
+/// TODO #4649: remove default implementation when LowerEcrecoverBaseCost will be released
 impl Default for ExtCostsConfig {
     fn default() -> ExtCostsConfig {
         ExtCostsConfig {

--- a/core/primitives-core/src/runtime/fees.rs
+++ b/core/primitives-core/src/runtime/fees.rs
@@ -38,7 +38,7 @@ impl Fee {
     }
 
     /// The minimum fee to send and execute.
-    fn min_send_and_exec_fee(&self) -> Gas {
+    pub fn min_send_and_exec_fee(&self) -> Gas {
         std::cmp::min(self.send_sir, self.send_not_sir) + self.execution
     }
 }
@@ -136,8 +136,8 @@ pub struct StorageUsageConfig {
     pub num_extra_bytes_record: u64,
 }
 
-impl Default for RuntimeFeesConfig {
-    fn default() -> Self {
+impl RuntimeFeesConfig {
+    pub fn test() -> Self {
         #[allow(clippy::unreadable_literal)]
         Self {
             action_receipt_creation_config: Fee {
@@ -231,9 +231,7 @@ impl Default for RuntimeFeesConfig {
             pessimistic_gas_price_inflation_ratio: Rational::new(103, 100),
         }
     }
-}
 
-impl RuntimeFeesConfig {
     pub fn free() -> Self {
         let free = Fee { send_sir: 0, send_not_sir: 0, execution: 0 };
         RuntimeFeesConfig {
@@ -326,27 +324,5 @@ pub mod u128_dec_format {
     {
         let s = String::deserialize(deserializer)?;
         u128::from_str_radix(&s, 10).map_err(de::Error::custom)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_data_roundtrip_is_more_expensive() {
-        // We have an assumption that the deepest receipts we can create is by creating recursive
-        // function call promises (calling function call from a function call).
-        // If the cost of a data receipt is cheaper than the cost of a function call, then it's
-        // possible to create a promise with a dependency which will be executed in two blocks that
-        // is cheaper than just two recursive function calls.
-        // That's why we need to enforce that the cost of the data receipt is not less than a
-        // function call. Otherwise we'd have to modify the way we compute the maximum depth.
-        let transaction_costs = RuntimeFeesConfig::default();
-        assert!(
-            transaction_costs.data_receipt_creation_config.base_cost.min_send_and_exec_fee()
-                >= transaction_costs.min_receipt_with_function_call_gas(),
-            "The data receipt cost can't be larger than the cost of a receipt with a function call"
-        );
     }
 }

--- a/core/primitives-core/src/runtime/fees.rs
+++ b/core/primitives-core/src/runtime/fees.rs
@@ -44,7 +44,6 @@ impl Fee {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Hash, PartialEq, Eq)]
-#[serde(default)]
 pub struct RuntimeFeesConfig {
     /// Describes the cost of creating an action receipt, `ActionReceipt`, excluding the actual cost
     /// of actions.

--- a/core/primitives-core/src/runtime/fees.rs
+++ b/core/primitives-core/src/runtime/fees.rs
@@ -38,7 +38,7 @@ impl Fee {
     }
 
     /// The minimum fee to send and execute.
-    pub fn min_send_and_exec_fee(&self) -> Gas {
+    fn min_send_and_exec_fee(&self) -> Gas {
         std::cmp::min(self.send_sir, self.send_not_sir) + self.execution
     }
 }

--- a/core/primitives/src/runtime/config.rs
+++ b/core/primitives/src/runtime/config.rs
@@ -26,8 +26,8 @@ pub struct RuntimeConfig {
     pub account_creation_config: AccountCreationConfig,
 }
 
-impl Default for RuntimeConfig {
-    fn default() -> Self {
+impl RuntimeConfig {
+    pub fn test() -> Self {
         RuntimeConfig {
             // See https://nomicon.io/Economics/README.html#general-variables for how it was calculated.
             storage_amount_per_byte: 909 * 100_000_000_000_000_000,
@@ -36,9 +36,7 @@ impl Default for RuntimeConfig {
             account_creation_config: AccountCreationConfig::default(),
         }
     }
-}
 
-impl RuntimeConfig {
     pub fn free() -> Self {
         Self {
             storage_amount_per_byte: 0,
@@ -122,7 +120,7 @@ mod tests {
 
     #[test]
     fn test_max_prepaid_gas() {
-        let config = RuntimeConfig::default();
+        let config = RuntimeConfig::test();
         assert!(
             config.wasm_config.limit_config.max_total_prepaid_gas
                 / config.transaction_costs.min_receipt_with_function_call_gas()
@@ -133,7 +131,7 @@ mod tests {
 
     #[test]
     fn test_lower_cost() {
-        let config = RuntimeConfig::default();
+        let config = RuntimeConfig::test();
         let default_amount = config.storage_amount_per_byte;
         #[allow(deprecated)]
         let config = ActualRuntimeConfig::new(config);

--- a/core/primitives/src/runtime/config.rs
+++ b/core/primitives/src/runtime/config.rs
@@ -31,7 +31,7 @@ impl RuntimeConfig {
         RuntimeConfig {
             // See https://nomicon.io/Economics/README.html#general-variables for how it was calculated.
             storage_amount_per_byte: 909 * 100_000_000_000_000_000,
-            transaction_costs: RuntimeFeesConfig::default(),
+            transaction_costs: RuntimeFeesConfig::test(),
             wasm_config: VMConfig::default(),
             account_creation_config: AccountCreationConfig::default(),
         }

--- a/core/primitives/src/runtime/config.rs
+++ b/core/primitives/src/runtime/config.rs
@@ -8,7 +8,6 @@ use crate::types::{AccountId, Balance};
 
 /// The structure that holds the parameters of the runtime, mostly economics.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
-#[serde(default)]
 pub struct RuntimeConfig {
     /// Amount of yN per byte required to have on the account.
     /// See https://nomicon.io/Economics/README.html#state-stake for details.

--- a/core/primitives/src/runtime/config_store.rs
+++ b/core/primitives/src/runtime/config_store.rs
@@ -133,26 +133,6 @@ mod tests {
     }
 
     #[test]
-    fn test_data_roundtrip_is_more_expensive() {
-        // We have an assumption that the deepest receipts we can create is by creating recursive
-        // function call promises (calling function call from a function call).
-        // If the cost of a data receipt is cheaper than the cost of a function call, then it's
-        // possible to create a promise with a dependency which will be executed in two blocks that
-        // is cheaper than just two recursive function calls.
-        // That's why we need to enforce that the cost of the data receipt is not less than a
-        // function call. Otherwise we'd have to modify the way we compute the maximum depth.
-        let store = RuntimeConfigStore::new(None);
-        for config in store.store.values() {
-            let transaction_costs = &config.transaction_costs;
-            assert!(
-                transaction_costs.data_receipt_creation_config.base_cost.min_send_and_exec_fee()
-                    >= transaction_costs.min_receipt_with_function_call_gas(),
-                "The data receipt cost can't be larger than the cost of a receipt with a function call"
-            );
-        }
-    }
-
-    #[test]
     fn test_lower_storage_cost() {
         let store = RuntimeConfigStore::new(None);
         let base_cfg = store.get_config(GENESIS_PROTOCOL_VERSION);

--- a/core/primitives/src/runtime/config_store.rs
+++ b/core/primitives/src/runtime/config_store.rs
@@ -142,7 +142,7 @@ mod tests {
         // That's why we need to enforce that the cost of the data receipt is not less than a
         // function call. Otherwise we'd have to modify the way we compute the maximum depth.
         let store = RuntimeConfigStore::new(None);
-        for (protocol_version, config) in store.store.iter() {
+        for config in store.store.values() {
             let transaction_costs = &config.transaction_costs;
             assert!(
                 transaction_costs.data_receipt_creation_config.base_cost.min_send_and_exec_fee()

--- a/core/primitives/src/runtime/config_store.rs
+++ b/core/primitives/src/runtime/config_store.rs
@@ -133,6 +133,26 @@ mod tests {
     }
 
     #[test]
+    fn test_data_roundtrip_is_more_expensive() {
+        // We have an assumption that the deepest receipts we can create is by creating recursive
+        // function call promises (calling function call from a function call).
+        // If the cost of a data receipt is cheaper than the cost of a function call, then it's
+        // possible to create a promise with a dependency which will be executed in two blocks that
+        // is cheaper than just two recursive function calls.
+        // That's why we need to enforce that the cost of the data receipt is not less than a
+        // function call. Otherwise we'd have to modify the way we compute the maximum depth.
+        let store = RuntimeConfigStore::new(None);
+        for (protocol_version, config) in store.store.iter() {
+            let transaction_costs = &config.transaction_costs;
+            assert!(
+                transaction_costs.data_receipt_creation_config.base_cost.min_send_and_exec_fee()
+                    >= transaction_costs.min_receipt_with_function_call_gas(),
+                "The data receipt cost can't be larger than the cost of a receipt with a function call"
+            );
+        }
+    }
+
+    #[test]
     fn test_lower_storage_cost() {
         let store = RuntimeConfigStore::new(None);
         let base_cfg = store.get_config(GENESIS_PROTOCOL_VERSION);

--- a/core/primitives/src/runtime/config_store.rs
+++ b/core/primitives/src/runtime/config_store.rs
@@ -56,9 +56,7 @@ impl RuntimeConfigStore {
 
     /// Constructs test store.
     pub fn test() -> Self {
-        Self {
-            store: BTreeMap::from_iter([(0, Arc::new(RuntimeConfig::default()))].iter().cloned()),
-        }
+        Self { store: BTreeMap::from_iter([(0, Arc::new(RuntimeConfig::test()))].iter().cloned()) }
     }
 
     /// Constructs store with a single config with zero costs.

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -977,7 +977,6 @@ pub fn init_configs(
                 chunk_producer_kickout_threshold: CHUNK_PRODUCER_KICKOUT_THRESHOLD,
                 online_max_threshold: Rational::new(99, 100),
                 online_min_threshold: Rational::new(BLOCK_PRODUCER_KICKOUT_THRESHOLD as isize, 100),
-                runtime_config: Default::default(),
                 validators: vec![AccountInfo {
                     account_id: account_id.clone(),
                     public_key: signer.public_key(),

--- a/runtime/near-vm-logic/tests/vm_logic_builder.rs
+++ b/runtime/near-vm-logic/tests/vm_logic_builder.rs
@@ -22,7 +22,7 @@ impl Default for VMLogicBuilder {
     fn default() -> Self {
         VMLogicBuilder {
             config: VMConfig::default(),
-            fees_config: RuntimeFeesConfig::default(),
+            fees_config: RuntimeFeesConfig::test(),
             ext: MockedExternal::default(),
             memory: MockedMemory::default(),
             promise_results: vec![],

--- a/runtime/near-vm-runner-standalone/src/script.rs
+++ b/runtime/near-vm-runner-standalone/src/script.rs
@@ -5,7 +5,6 @@ use near_primitives::contract::ContractCode;
 use near_primitives::runtime::config_store::RuntimeConfigStore;
 use near_primitives::types::CompiledContractCache;
 use near_primitives::version::PROTOCOL_VERSION;
-use near_primitives_core::runtime::fees::RuntimeFeesConfig;
 use near_vm_logic::mocks::mock_external::MockedExternal;
 use near_vm_logic::types::PromiseResult;
 use near_vm_logic::{ProtocolVersion, VMConfig, VMContext, VMOutcome};

--- a/runtime/near-vm-runner-standalone/src/script.rs
+++ b/runtime/near-vm-runner-standalone/src/script.rs
@@ -113,8 +113,8 @@ impl Script {
             external.fake_trie = trie;
         }
 
-        let runtime_fees_config =
-            &RuntimeConfigStore::new(None).get_config(self.protocol_version).transaction_costs;
+        let config_store = RuntimeConfigStore::new(None);
+        let runtime_fees_config = &config_store.get_config(self.protocol_version).transaction_costs;
         let mut outcomes = Vec::new();
         for step in &self.steps {
             for _ in 0..step.repeat {

--- a/runtime/near-vm-runner-standalone/src/script.rs
+++ b/runtime/near-vm-runner-standalone/src/script.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::path::Path;
 
 use near_primitives::contract::ContractCode;
+use near_primitives::runtime::config_store::RuntimeConfigStore;
 use near_primitives::types::CompiledContractCache;
 use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives_core::runtime::fees::RuntimeFeesConfig;
@@ -113,6 +114,8 @@ impl Script {
             external.fake_trie = trie;
         }
 
+        let runtime_fees_config =
+            &RuntimeConfigStore::new(None).get_config(self.protocol_version).transaction_costs;
         let mut outcomes = Vec::new();
         for step in &self.steps {
             for _ in 0..step.repeat {
@@ -122,7 +125,7 @@ impl Script {
                     &mut external,
                     step.vm_context.clone(),
                     &self.vm_config,
-                    &RuntimeFeesConfig::default(),
+                    runtime_fees_config,
                     &step.promise_results,
                     self.vm_kind,
                     self.protocol_version,

--- a/runtime/near-vm-runner/src/tests.rs
+++ b/runtime/near-vm-runner/src/tests.rs
@@ -63,7 +63,7 @@ fn make_simple_contract_call_with_gas_vm(
     let mut context = create_context(vec![]);
     context.prepaid_gas = prepaid_gas;
     let config = VMConfig::default();
-    let fees = RuntimeFeesConfig::default();
+    let fees = RuntimeFeesConfig::test();
 
     let promise_results = vec![];
 
@@ -100,7 +100,7 @@ fn make_cached_contract_call_vm(
     let mut fake_external = MockedExternal::new();
     let mut context = create_context(vec![]);
     let config = VMConfig::default();
-    let fees = RuntimeFeesConfig::default();
+    let fees = RuntimeFeesConfig::test();
     let promise_results = vec![];
     context.prepaid_gas = prepaid_gas;
     let code = ContractCode::new(code.to_vec(), None);

--- a/runtime/near-vm-runner/src/tests/contract_preload.rs
+++ b/runtime/near-vm-runner/src/tests/contract_preload.rs
@@ -102,7 +102,7 @@ fn test_vm_runner(preloaded: bool, vm_kind: VMKind, repeat: i32) {
     let vm_config = VMConfig::default();
     let cache: Option<Arc<dyn CompiledContractCache>> =
         Some(Arc::new(MockCompiledContractCache::new(0)));
-    let fees = RuntimeFeesConfig::default();
+    let fees = RuntimeFeesConfig::test();
     let promise_results = vec![];
     let mut oks = 0;
     let mut errs = 0;

--- a/runtime/near-vm-runner/src/tests/rs_contract.rs
+++ b/runtime/near-vm-runner/src/tests/rs_contract.rs
@@ -56,7 +56,7 @@ pub fn test_read_write() {
 
         let context = create_context(arr_u64_to_u8(&[10u64, 20u64]));
         let config = VMConfig::default();
-        let fees = RuntimeFeesConfig::default();
+        let fees = RuntimeFeesConfig::test();
 
         let promise_results = vec![];
         let result = run_vm(
@@ -129,7 +129,7 @@ fn run_test_ext(
     fake_external.validators =
         validators.into_iter().map(|(s, b)| (s.parse().unwrap(), b)).collect();
     let config = VMConfig::default();
-    let fees = RuntimeFeesConfig::default();
+    let fees = RuntimeFeesConfig::test();
     let context = create_context(input.to_vec());
 
     let (outcome, err) = run_vm(

--- a/runtime/near-vm-runner/src/tests/ts_contract.rs
+++ b/runtime/near-vm-runner/src/tests/ts_contract.rs
@@ -16,7 +16,7 @@ pub fn test_ts_contract() {
 
         let context = create_context(Vec::new());
         let config = VMConfig::default();
-        let fees = RuntimeFeesConfig::default();
+        let fees = RuntimeFeesConfig::test();
 
         // Call method that panics.
         let promise_results = vec![];

--- a/runtime/runtime-params-estimator/src/costs_to_runtime_config.rs
+++ b/runtime/runtime-params-estimator/src/costs_to_runtime_config.rs
@@ -49,8 +49,8 @@ fn runtime_fees_config(cost_table: &CostTable) -> anyhow::Result<RuntimeFeesConf
         Ok(Fee { send_sir: total_gas / 2, send_not_sir: total_gas / 2, execution: total_gas / 2 })
     };
 
-    let actual_fees_config =
-        &RuntimeConfigStore::new(None).get_config(PROTOCOL_VERSION).transaction_costs;
+    let config_store = RuntimeConfigStore::new(None);
+    let actual_fees_config = &config_store.get_config(PROTOCOL_VERSION).transaction_costs;
     let res = RuntimeFeesConfig {
         action_receipt_creation_config: fee(Cost::ActionReceiptCreation)?,
         data_receipt_creation_config: DataReceiptCreationConfig {

--- a/runtime/runtime-params-estimator/src/costs_to_runtime_config.rs
+++ b/runtime/runtime-params-estimator/src/costs_to_runtime_config.rs
@@ -1,11 +1,14 @@
 use std::convert::TryFrom;
 
 use anyhow::Context;
+use near_primitives::runtime::config::AccountCreationConfig;
+use near_primitives::runtime::config_store::RuntimeConfigStore;
 use near_primitives::runtime::fees::{
     AccessKeyCreationConfig, ActionCreationConfig, DataReceiptCreationConfig, Fee,
     RuntimeFeesConfig,
 };
 use near_primitives::types::Gas;
+use near_primitives::version::PROTOCOL_VERSION;
 use near_vm_logic::{ExtCostsConfig, VMConfig, VMLimitConfig};
 use node_runtime::config::RuntimeConfig;
 
@@ -24,14 +27,16 @@ pub fn costs_to_runtime_config(cost_table: &CostTable) -> anyhow::Result<Runtime
         .with_context(|| format!("undefined cost: {}", Cost::WasmInstruction))?;
 
     let res = RuntimeConfig {
+        // See https://nomicon.io/Economics/README.html#general-variables for how it was calculated.
+        storage_amount_per_byte: 909 * 100_000_000_000_000_000,
+        transaction_costs: runtime_fees_config(cost_table)?,
         wasm_config: VMConfig {
             ext_costs: ext_costs_config(cost_table)?,
             grow_mem_cost: 1,
             regular_op_cost: u32::try_from(regular_op_cost).unwrap(),
             limit_config: VMLimitConfig::default(),
         },
-        transaction_costs: runtime_fees_config(cost_table)?,
-        ..RuntimeConfig::test()
+        account_creation_config: AccountCreationConfig::default(),
     };
     Ok(res)
 }
@@ -44,6 +49,8 @@ fn runtime_fees_config(cost_table: &CostTable) -> anyhow::Result<RuntimeFeesConf
         Ok(Fee { send_sir: total_gas / 2, send_not_sir: total_gas / 2, execution: total_gas / 2 })
     };
 
+    let actual_fees_config =
+        &RuntimeConfigStore::new(None).get_config(PROTOCOL_VERSION).transaction_costs;
     let res = RuntimeFeesConfig {
         action_receipt_creation_config: fee(Cost::ActionReceiptCreation)?,
         data_receipt_creation_config: DataReceiptCreationConfig {
@@ -66,7 +73,7 @@ fn runtime_fees_config(cost_table: &CostTable) -> anyhow::Result<RuntimeFeesConf
             delete_key_cost: fee(Cost::ActionDeleteKey)?,
             delete_account_cost: fee(Cost::ActionDeleteAccount)?,
         },
-        ..RuntimeFeesConfig::default()
+        ..actual_fees_config.clone()
     };
     Ok(res)
 }

--- a/runtime/runtime-params-estimator/src/costs_to_runtime_config.rs
+++ b/runtime/runtime-params-estimator/src/costs_to_runtime_config.rs
@@ -31,7 +31,7 @@ pub fn costs_to_runtime_config(cost_table: &CostTable) -> anyhow::Result<Runtime
             limit_config: VMLimitConfig::default(),
         },
         transaction_costs: runtime_fees_config(cost_table)?,
-        ..RuntimeConfig::default()
+        ..RuntimeConfig::test()
     };
     Ok(res)
 }

--- a/runtime/runtime-params-estimator/src/function_call.rs
+++ b/runtime/runtime-params-estimator/src/function_call.rs
@@ -106,7 +106,7 @@ pub fn compute_function_call_cost(
     let vm_config = VMConfig::default();
     let mut fake_external = MockedExternal::new();
     let fake_context = create_context(vec![]);
-    let fees = RuntimeFeesConfig::default();
+    let fees = RuntimeFeesConfig::test();
     let promise_results = vec![];
 
     // Warmup.

--- a/runtime/runtime-params-estimator/src/gas_metering.rs
+++ b/runtime/runtime-params-estimator/src/gas_metering.rs
@@ -178,7 +178,7 @@ pub fn compute_gas_metering_cost(
     let vm_config_gas = VMConfig::default();
     let mut fake_external = MockedExternal::new();
     let fake_context = create_context(vec![]);
-    let fees = RuntimeFeesConfig::default();
+    let fees = RuntimeFeesConfig::test();
     let promise_results = vec![];
 
     // Warmup.

--- a/runtime/runtime-params-estimator/src/testbed.rs
+++ b/runtime/runtime-params-estimator/src/testbed.rs
@@ -38,7 +38,7 @@ impl RuntimeTestbed {
         assert!(!roots.is_empty(), "No state roots found.");
         let root = roots[0];
 
-        let mut runtime_config = RuntimeConfig::default();
+        let mut runtime_config = RuntimeConfig::test();
 
         runtime_config.wasm_config.limit_config = VMLimitConfig {
             max_total_log_length: u64::max_value(),

--- a/runtime/runtime-params-estimator/src/testbed.rs
+++ b/runtime/runtime-params-estimator/src/testbed.rs
@@ -57,6 +57,7 @@ impl RuntimeTestbed {
 
             ..Default::default()
         };
+        runtime_config.account_creation_config.min_allowed_top_level_account_length = 0;
 
         let runtime = Runtime::new();
         let prev_receipts = vec![];

--- a/runtime/runtime-params-estimator/src/testbed.rs
+++ b/runtime/runtime-params-estimator/src/testbed.rs
@@ -1,6 +1,7 @@
 use genesis_populate::state_dump::StateDump;
 use near_primitives::receipt::Receipt;
 use near_primitives::runtime::config::RuntimeConfig;
+use near_primitives::runtime::config_store::RuntimeConfigStore;
 use near_primitives::runtime::migration_data::{MigrationData, MigrationFlags};
 use near_primitives::test_utils::MockEpochInfoProvider;
 use near_primitives::transaction::{ExecutionStatus, SignedTransaction};
@@ -38,21 +39,22 @@ impl RuntimeTestbed {
         assert!(!roots.is_empty(), "No state roots found.");
         let root = roots[0];
 
-        let mut runtime_config = RuntimeConfig::test();
+        let mut runtime_config =
+            RuntimeConfigStore::new(None).get_config(PROTOCOL_VERSION).as_ref().clone();
 
         runtime_config.wasm_config.limit_config = VMLimitConfig {
-            max_total_log_length: u64::max_value(),
-            max_number_registers: u64::max_value(),
-            max_gas_burnt: u64::max_value(),
-            max_register_size: u64::max_value(),
-            max_number_logs: u64::max_value(),
+            max_total_log_length: u64::MAX,
+            max_number_registers: u64::MAX,
+            max_gas_burnt: u64::MAX,
+            max_register_size: u64::MAX,
+            max_number_logs: u64::MAX,
 
-            max_actions_per_receipt: u64::max_value(),
-            max_promises_per_function_call_action: u64::max_value(),
-            max_number_input_data_dependencies: u64::max_value(),
+            max_actions_per_receipt: u64::MAX,
+            max_promises_per_function_call_action: u64::MAX,
+            max_number_input_data_dependencies: u64::MAX,
 
-            max_total_prepaid_gas: u64::max_value(),
-            max_number_bytes_method_names: u64::max_value(),
+            max_total_prepaid_gas: u64::MAX,
+            max_number_bytes_method_names: u64::MAX,
 
             ..Default::default()
         };

--- a/runtime/runtime-params-estimator/src/testbed.rs
+++ b/runtime/runtime-params-estimator/src/testbed.rs
@@ -1,6 +1,5 @@
 use genesis_populate::state_dump::StateDump;
 use near_primitives::receipt::Receipt;
-use near_primitives::runtime::config::RuntimeConfig;
 use near_primitives::runtime::config_store::RuntimeConfigStore;
 use near_primitives::runtime::migration_data::{MigrationData, MigrationFlags};
 use near_primitives::test_utils::MockEpochInfoProvider;

--- a/runtime/runtime-params-estimator/src/vm_estimator.rs
+++ b/runtime/runtime-params-estimator/src/vm_estimator.rs
@@ -47,7 +47,7 @@ fn call(code: &[u8]) -> (Option<VMOutcome>, Option<VMError>) {
     let mut fake_external = MockedExternal::new();
     let context = create_context(vec![]);
     let config = VMConfig::default();
-    let fees = RuntimeFeesConfig::default();
+    let fees = RuntimeFeesConfig::test();
 
     let promise_results = vec![];
 
@@ -357,7 +357,7 @@ fn test_many_contracts_call(gas_metric: GasMetric, vm_kind: VMKind) {
     }
     let mut fake_external = MockedExternal::new();
     let fake_context = create_context(vec![]);
-    let fees = RuntimeFeesConfig::default();
+    let fees = RuntimeFeesConfig::test();
 
     let start = start_count(gas_metric);
     for contract in &contracts {

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -730,7 +730,7 @@ mod tests {
         let mut actor_id = predecessor_id.clone();
         let mut action_result = ActionResult::default();
         action_create_account(
-            &RuntimeFeesConfig::default(),
+            &RuntimeFeesConfig::test(),
             &AccountCreationConfig {
                 min_allowed_top_level_account_length: length,
                 registrar_account_id: "registrar".parse().unwrap(),

--- a/runtime/runtime/src/balance_checker.rs
+++ b/runtime/runtime/src/balance_checker.rs
@@ -249,7 +249,7 @@ mod tests {
         let root = MerkleHash::default();
         let initial_state = tries.new_trie_update(ShardUId::default(), root);
         let final_state = tries.new_trie_update(ShardUId::default(), root);
-        let transaction_costs = RuntimeFeesConfig::default();
+        let transaction_costs = RuntimeFeesConfig::test();
         check_balance(
             &transaction_costs,
             &initial_state,
@@ -270,7 +270,7 @@ mod tests {
         let root = MerkleHash::default();
         let initial_state = tries.new_trie_update(ShardUId::default(), root);
         let final_state = tries.new_trie_update(ShardUId::default(), root);
-        let transaction_costs = RuntimeFeesConfig::default();
+        let transaction_costs = RuntimeFeesConfig::test();
         let err = check_balance(
             &transaction_costs,
             &initial_state,
@@ -305,7 +305,7 @@ mod tests {
         set_account(&mut final_state, account_id.clone(), &final_account);
         final_state.commit(StateChangeCause::NotWritableToDisk);
 
-        let transaction_costs = RuntimeFeesConfig::default();
+        let transaction_costs = RuntimeFeesConfig::test();
         check_balance(
             &transaction_costs,
             &initial_state,
@@ -329,7 +329,7 @@ mod tests {
         let initial_balance = TESTING_INIT_BALANCE / 2;
         let deposit = 500_000_000;
         let gas_price = 100;
-        let cfg = RuntimeFeesConfig::default();
+        let cfg = RuntimeFeesConfig::test();
         let exec_gas = cfg.action_receipt_creation_config.exec_fee()
             + cfg.action_creation_config.transfer_cost.exec_fee();
         let send_gas = cfg.action_receipt_creation_config.send_fee(false)
@@ -431,7 +431,7 @@ mod tests {
             }),
         };
 
-        let transaction_costs = RuntimeFeesConfig::default();
+        let transaction_costs = RuntimeFeesConfig::test();
         assert_eq!(
             check_balance(
                 &transaction_costs,

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1604,7 +1604,7 @@ mod tests {
             gas_limit: Some(gas_limit),
             random_seed: Default::default(),
             current_protocol_version: PROTOCOL_VERSION,
-            config: Arc::new(RuntimeConfig::default()),
+            config: Arc::new(RuntimeConfig::test()),
             cache: Some(Arc::new(StoreCompiledContractCache { store: tries.get_store() })),
             is_new_chunk: true,
             migration_data: Arc::new(MigrationData::default()),

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -12,7 +12,6 @@ use near_primitives::{
     receipt::ActionReceipt,
     runtime::{
         apply_state::ApplyState,
-        config::RuntimeConfig,
         migration_data::{MigrationData, MigrationFlags},
     },
     serialize::to_base64,
@@ -193,7 +192,8 @@ impl TrieViewer {
             epoch_info_provider,
             view_state.current_protocol_version,
         );
-        let config = RuntimeConfigStore::new(None).get_config(PROTOCOL_VERSION);
+        let config_store = RuntimeConfigStore::new(None);
+        let config = config_store.get_config(PROTOCOL_VERSION);
         let apply_state = ApplyState {
             block_index: view_state.block_height,
             // Used for legacy reasons

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -191,7 +191,7 @@ impl TrieViewer {
             epoch_info_provider,
             view_state.current_protocol_version,
         );
-        let config = Arc::new(RuntimeConfig::default());
+        let config = Arc::new(RuntimeConfig::test());
         let apply_state = ApplyState {
             block_index: view_state.block_height,
             // Used for legacy reasons

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -1,6 +1,8 @@
+use crate::near_primitives::version::PROTOCOL_VERSION;
 use crate::{actions::execute_function_call, ext::RuntimeExt};
 use log::debug;
 use near_crypto::{KeyType, PublicKey};
+use near_primitives::runtime::config_store::RuntimeConfigStore;
 use near_primitives::{
     account::{AccessKey, Account},
     borsh::BorshDeserialize,
@@ -191,7 +193,7 @@ impl TrieViewer {
             epoch_info_provider,
             view_state.current_protocol_version,
         );
-        let config = Arc::new(RuntimeConfig::test());
+        let config = RuntimeConfigStore::new(None).get_config(PROTOCOL_VERSION);
         let apply_state = ApplyState {
             block_index: view_state.block_height,
             // Used for legacy reasons

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -518,7 +518,7 @@ mod tests {
 
     #[test]
     fn test_validate_transaction_valid() {
-        let config = RuntimeConfig::default();
+        let config = RuntimeConfig::test();
         let (signer, mut state_update, gas_price) =
             setup_common(TESTING_INIT_BALANCE, 0, Some(AccessKey::full_access()));
 
@@ -569,7 +569,7 @@ mod tests {
 
     #[test]
     fn test_validate_transaction_invalid_signature() {
-        let config = RuntimeConfig::default();
+        let config = RuntimeConfig::test();
         let (signer, mut state_update, gas_price) =
             setup_common(TESTING_INIT_BALANCE, 0, Some(AccessKey::full_access()));
 
@@ -594,7 +594,7 @@ mod tests {
 
     #[test]
     fn test_validate_transaction_invalid_access_key_not_found() {
-        let config = RuntimeConfig::default();
+        let config = RuntimeConfig::test();
         let (bad_signer, mut state_update, gas_price) = setup_common(TESTING_INIT_BALANCE, 0, None);
 
         assert_eq!(
@@ -626,7 +626,7 @@ mod tests {
 
     #[test]
     fn test_validate_transaction_invalid_bad_action() {
-        let mut config = RuntimeConfig::default();
+        let mut config = RuntimeConfig::test();
         let (signer, mut state_update, gas_price) =
             setup_common(TESTING_INIT_BALANCE, 0, Some(AccessKey::full_access()));
 
@@ -660,7 +660,7 @@ mod tests {
 
     #[test]
     fn test_validate_transaction_invalid_bad_signer() {
-        let config = RuntimeConfig::default();
+        let config = RuntimeConfig::test();
         let (signer, mut state_update, gas_price) =
             setup_common(TESTING_INIT_BALANCE, 0, Some(AccessKey::full_access()));
 
@@ -690,7 +690,7 @@ mod tests {
 
     #[test]
     fn test_validate_transaction_invalid_bad_nonce() {
-        let config = RuntimeConfig::default();
+        let config = RuntimeConfig::test();
         let (signer, mut state_update, gas_price) = setup_common(
             TESTING_INIT_BALANCE,
             0,
@@ -721,7 +721,7 @@ mod tests {
 
     #[test]
     fn test_validate_transaction_invalid_balance_overflow() {
-        let config = RuntimeConfig::default();
+        let config = RuntimeConfig::test();
         let (signer, mut state_update, gas_price) =
             setup_common(TESTING_INIT_BALANCE, 0, Some(AccessKey::full_access()));
 
@@ -743,7 +743,7 @@ mod tests {
 
     #[test]
     fn test_validate_transaction_invalid_not_enough_balance() {
-        let config = RuntimeConfig::default();
+        let config = RuntimeConfig::test();
         let (signer, mut state_update, gas_price) =
             setup_common(TESTING_INIT_BALANCE, 0, Some(AccessKey::full_access()));
 
@@ -780,7 +780,7 @@ mod tests {
 
     #[test]
     fn test_validate_transaction_invalid_not_enough_allowance() {
-        let config = RuntimeConfig::default();
+        let config = RuntimeConfig::test();
         let (signer, mut state_update, gas_price) = setup_common(
             TESTING_INIT_BALANCE,
             0,
@@ -869,7 +869,7 @@ mod tests {
 
     #[test]
     fn test_validate_transaction_invalid_actions_for_function_call() {
-        let config = RuntimeConfig::default();
+        let config = RuntimeConfig::test();
         let (signer, mut state_update, gas_price) = setup_common(
             TESTING_INIT_BALANCE,
             0,
@@ -963,7 +963,7 @@ mod tests {
 
     #[test]
     fn test_validate_transaction_invalid_receiver_for_function_call() {
-        let config = RuntimeConfig::default();
+        let config = RuntimeConfig::test();
         let (signer, mut state_update, gas_price) = setup_common(
             TESTING_INIT_BALANCE,
             0,
@@ -1011,7 +1011,7 @@ mod tests {
 
     #[test]
     fn test_validate_transaction_invalid_method_name_for_function_call() {
-        let config = RuntimeConfig::default();
+        let config = RuntimeConfig::test();
         let (signer, mut state_update, gas_price) = setup_common(
             TESTING_INIT_BALANCE,
             0,
@@ -1056,7 +1056,7 @@ mod tests {
 
     #[test]
     fn test_validate_transaction_deposit_with_function_call() {
-        let config = RuntimeConfig::default();
+        let config = RuntimeConfig::test();
         let (signer, mut state_update, gas_price) = setup_common(
             TESTING_INIT_BALANCE,
             0,
@@ -1114,7 +1114,7 @@ mod tests {
         );
         let transaction_size = transaction.get_size();
 
-        let mut config = RuntimeConfig::default();
+        let mut config = RuntimeConfig::test();
         let max_transaction_size = transaction_size - 1;
         config.wasm_config.limit_config.max_transaction_size = transaction_size - 1;
 

--- a/runtime/runtime/tests/runtime_group_tools/random_config.rs
+++ b/runtime/runtime/tests/runtime_group_tools/random_config.rs
@@ -47,7 +47,7 @@ pub fn random_config() -> RuntimeConfig {
                 100,
             ),
         },
-        ..Default::default()
+        ..RuntimeConfig::test()
     }
 }
 

--- a/tools/storage-usage-delta-calculator/src/main.rs
+++ b/tools/storage-usage-delta-calculator/src/main.rs
@@ -19,7 +19,7 @@ fn main() -> Result<(), Error> {
     debug!("Genesis read");
 
     let storage_usage =
-        Runtime::new().compute_storage_usage(&genesis.records.0[..], &RuntimeConfig::default());
+        Runtime::new().compute_storage_usage(&genesis.records.0[..], &RuntimeConfig::test());
     debug!("Storage usage calculated");
 
     let mut result = Vec::new();

--- a/tools/storage-usage-delta-calculator/src/main.rs
+++ b/tools/storage-usage-delta-calculator/src/main.rs
@@ -1,7 +1,8 @@
 use log::{debug, LevelFilter};
 use near_chain_configs::Genesis;
-use near_primitives::runtime::config::RuntimeConfig;
+use near_primitives::runtime::config_store::RuntimeConfigStore;
 use near_primitives::state_record::StateRecord;
+use near_primitives::version::PROTOCOL_VERSION;
 use node_runtime::Runtime;
 use std::fs::File;
 use std::io::Error;
@@ -18,8 +19,8 @@ fn main() -> Result<(), Error> {
     let genesis = Genesis::from_file("output.json");
     debug!("Genesis read");
 
-    let storage_usage =
-        Runtime::new().compute_storage_usage(&genesis.records.0[..], &RuntimeConfig::test());
+    let config = RuntimeConfigStore::new(None).get_config(PROTOCOL_VERSION);
+    let storage_usage = Runtime::new().compute_storage_usage(&genesis.records.0[..], config);
     debug!("Storage usage calculated");
 
     let mut result = Vec::new();

--- a/tools/storage-usage-delta-calculator/src/main.rs
+++ b/tools/storage-usage-delta-calculator/src/main.rs
@@ -19,7 +19,8 @@ fn main() -> Result<(), Error> {
     let genesis = Genesis::from_file("output.json");
     debug!("Genesis read");
 
-    let config = RuntimeConfigStore::new(None).get_config(PROTOCOL_VERSION);
+    let config_store = RuntimeConfigStore::new(None);
+    let config = config_store.get_config(PROTOCOL_VERSION);
     let storage_usage = Runtime::new().compute_storage_usage(&genesis.records.0[..], config);
     debug!("Storage usage calculated");
 


### PR DESCRIPTION
Having default impls for `RuntimeConfig` and `RuntimeFeesConfig` is confusing, because one may think that it is the actual protocol sub-configs, whereas they are used mostly for testing.
Here I separate cases where we want to take:
- actual protocol config
- some test config

Helps to solve https://github.com/near/nearcore/issues/4649.

Test plan
---------
Existing tests. 

~~Note that `test_data_roundtrip_is_more_expensive` was moved to `config_store` because I don't see a reason for testing test config.~~
Note that `test_data_roundtrip_is_more_expensive` is removed because its logic seems to be incorrect (see comments).