### PR TITLE
runtime-tester: fix runtime_fuzzer test

### DIFF
--- a/test-utils/runtime-tester/fuzz/fuzz_targets/runtime_fuzzer.rs
+++ b/test-utils/runtime-tester/fuzz/fuzz_targets/runtime_fuzzer.rs
@@ -4,22 +4,23 @@ use runtime_tester::Scenario;
 use std::fs::File;
 use std::time::Duration;
 
-fuzz_target!(|scenario: Scenario| {
-    let filename = "failed_scenario.json";
-    let stats = match scenario.run().result {
-        Err(e) => {
-            serde_json::to_writer(&File::create(filename).unwrap(), &scenario).unwrap();
-            panic!("Bad scenario: {}, Error: {}", filename, e);
-        },
-        Ok(stats) => stats
-    };
+fn do_fuzz(scenario: &Scenario) -> Result<(), String> {
+    let stats = scenario.run().result.map_err(|e| format!("{}", e))?;
     for block_stats in stats.blocks_stats {
         if block_stats.block_production_time > Duration::from_secs(1) {
-            serde_json::to_writer(&File::create(filename).unwrap(), &scenario).unwrap();
-            panic!(
-                "Bad scenario: {}, block at height {} was produced in {:?}",
-                filename, block_stats.height, block_stats.block_production_time
-            );
+            return Err(format!("block at height {} was produced in {:?}",
+                               block_stats.height, block_stats.block_production_time));
         }
     }
-});
+    Ok(())
+}
+
+fn fuzz(scenario: Scenario) {
+    if let Err(err) = do_fuzz(&scenario) {
+        let file = "failed_scenario.json";
+        serde_json::to_writer(&File::create(file).unwrap(), &scenario).unwrap();
+        panic!("Bad scenario: {}, {}", file, err);
+    }
+}
+
+fuzz_target!(|scenario: Scenario| { fuzz(scenario) });

--- a/test-utils/runtime-tester/fuzz/fuzz_targets/runtime_fuzzer.rs
+++ b/test-utils/runtime-tester/fuzz/fuzz_targets/runtime_fuzzer.rs
@@ -6,20 +6,20 @@ use std::time::Duration;
 
 fuzz_target!(|scenario: Scenario| {
     let filename = "failed_scenario.json";
-    let runtime_stats = scenario.run();
-    if let Err(e) = runtime_stats {
-        serde_json::to_writer(&File::create(filename).unwrap(), &scenario).unwrap();
-        panic!("Bad scenario: {}, Error: {}", filename, e);
-    } else {
-        let stats = runtime_stats.unwrap();
-        for block_stats in stats.blocks_stats {
-            if block_stats.block_production_time > Duration::from_secs(1) {
-                serde_json::to_writer(&File::create(filename).unwrap(), &scenario).unwrap();
-                panic!(
-                    "Bad scenario: {}, block at height {} was produced in {:?}",
-                    filename, block_stats.height, block_stats.block_production_time
-                );
-            }
+    let stats = match scenario.run().result {
+        Err(e) => {
+            serde_json::to_writer(&File::create(filename).unwrap(), &scenario).unwrap();
+            panic!("Bad scenario: {}, Error: {}", filename, e);
+        },
+        Ok(stats) => stats
+    };
+    for block_stats in stats.blocks_stats {
+        if block_stats.block_production_time > Duration::from_secs(1) {
+            serde_json::to_writer(&File::create(filename).unwrap(), &scenario).unwrap();
+            panic!(
+                "Bad scenario: {}, block at height {} was produced in {:?}",
+                filename, block_stats.height, block_stats.block_production_time
+            );
         }
     }
 });


### PR DESCRIPTION
This fixes the following error:

    error[E0308]: mismatched types
      --> fuzz_targets/runtime_fuzzer.rs:10:12
    10 |     if let Err(e) = runtime_stats {
       |            ^^^^^^   ------------- this expression has type `ScenarioResult<RuntimeStats, near_client_primitives::types::Error>`
       |            |
       |            expected struct `ScenarioResult`, found enum `Result`
    error[E0599]: no method named `unwrap` found for struct `ScenarioResult` in the current scope
      --> fuzz_targets/runtime_fuzzer.rs:14:35
    14 |         let stats = runtime_stats.unwrap();
       |                                   ^^^^^^ method not found in `ScenarioResult<RuntimeStats, near_client_primitives::types::Error>`

It can be reproduced by running runtime/fuzz.py pytest.

Issue: https://github.com/near/nearcore/issues/4835
