### PR TITLE
Separate test methods from production code in PeerManager.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2918,6 +2918,7 @@ dependencies = [
  "near-client-primitives",
  "near-crypto",
  "near-metrics",
+ "near-network",
  "near-primitives",
  "near-primitives-core",
  "near-rpc-error-macro",

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -965,7 +965,7 @@ pub fn setup_mock_all_validators(
                         | NetworkRequests::RequestUpdateNonce(_, _)
                         | NetworkRequests::ResponseUpdateNonce(_)
                         | NetworkRequests::ReceiptOutComeRequest(_, _)=> {}
-                        #[cfg(feature = "adversarial")]
+                        #[cfg(feature = "test_features")]
                         | NetworkRequests::PingTo(_, _)
                         | NetworkRequests::FetchPingPongInfo
                         | NetworkRequests::FetchRoutingTable  => {}

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -958,9 +958,6 @@ pub fn setup_mock_all_validators(
                         }
                         NetworkRequests::ForwardTx(_, _)
                         | NetworkRequests::Sync { .. }
-                        | NetworkRequests::FetchRoutingTable
-                        | NetworkRequests::PingTo(_, _)
-                        | NetworkRequests::FetchPingPongInfo
                         | NetworkRequests::BanPeer { .. }
                         | NetworkRequests::TxStatus(_, _, _)
                         | NetworkRequests::Query { .. }
@@ -968,6 +965,10 @@ pub fn setup_mock_all_validators(
                         | NetworkRequests::RequestUpdateNonce(_, _)
                         | NetworkRequests::ResponseUpdateNonce(_)
                         | NetworkRequests::ReceiptOutComeRequest(_, _) => {}
+                        #[cfg(feature = "adversarial")]
+                        | NetworkRequests::PingTo(_, _)
+                        | NetworkRequests::FetchPingPongInfo
+                        | NetworkRequests::FetchRoutingTable  => {}
                         #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
                         | NetworkRequests::IbfMessage { .. } => {}
                     };

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -964,7 +964,8 @@ pub fn setup_mock_all_validators(
                         | NetworkRequests::Challenge(_)
                         | NetworkRequests::RequestUpdateNonce(_, _)
                         | NetworkRequests::ResponseUpdateNonce(_)
-                        | NetworkRequests::ReceiptOutComeRequest(_, _)
+                        | NetworkRequests::ReceiptOutComeRequest(_, _)=> {}
+                        #[cfg(feature = "adversarial")]
                         | NetworkRequests::PingTo(_, _)
                         | NetworkRequests::FetchPingPongInfo
                         | NetworkRequests::FetchRoutingTable  => {}

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -964,8 +964,7 @@ pub fn setup_mock_all_validators(
                         | NetworkRequests::Challenge(_)
                         | NetworkRequests::RequestUpdateNonce(_, _)
                         | NetworkRequests::ResponseUpdateNonce(_)
-                        | NetworkRequests::ReceiptOutComeRequest(_, _) => {}
-                        #[cfg(feature = "adversarial")]
+                        | NetworkRequests::ReceiptOutComeRequest(_, _)
                         | NetworkRequests::PingTo(_, _)
                         | NetworkRequests::FetchPingPongInfo
                         | NetworkRequests::FetchRoutingTable  => {}

--- a/chain/jsonrpc-primitives/Cargo.toml
+++ b/chain/jsonrpc-primitives/Cargo.toml
@@ -22,6 +22,7 @@ near-metrics = { path = "../../core/metrics" }
 near-primitives = { path = "../../core/primitives" }
 near-primitives-core = { path = "../../core/primitives-core" }
 near-rpc-error-macro = { path = "../../tools/rpctypegen/macro" }
+near-network = { path = "../network", optional = true }
 
 [features]
 test_features = []

--- a/chain/jsonrpc/test-utils/Cargo.toml
+++ b/chain/jsonrpc/test-utils/Cargo.toml
@@ -15,4 +15,4 @@ near-network = { path = "../../network" }
 near-jsonrpc = { path = "../" }
 
 [features]
-test_features = []
+test_features = ["near-client/test_features"]

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -1845,10 +1845,7 @@ impl Handler<NetworkRequests> for PeerManagerActor {
             }
             NetworkRequests::PingTo(_nonce, _target) => {
                 #[cfg(feature = "adversarial")]
-                {
-                    self.send_ping(ctx, _nonce, _target)
-                }
-                #[cfg(not(feature = "adversarial"))]
+                self.send_ping(ctx, _nonce, _target);
                 NetworkResponses::NoResponse
             }
             NetworkRequests::FetchPingPongInfo => {

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -26,7 +26,7 @@ use metrics::NetworkMetrics;
 use near_performance_metrics::framed_write::FramedWrite;
 use near_performance_metrics_macros::perf;
 use near_primitives::checked_feature;
-#[cfg(feature = "adversarial")]
+#[cfg(feature = "test_features")]
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::{AnnounceAccount, PeerId};
 use near_primitives::types::{AccountId, ProtocolVersion};
@@ -1338,7 +1338,7 @@ impl PeerManagerActor {
 
     // Ping pong useful functions.
 
-    #[cfg(feature = "adversarial")]
+    #[cfg(feature = "test_features")]
     fn send_ping(&mut self, ctx: &mut Context<Self>, nonce: usize, target: PeerId) {
         let body =
             RoutedMessageBody::Ping(Ping { nonce: nonce as u64, source: self.peer_id.clone() });
@@ -1347,7 +1347,7 @@ impl PeerManagerActor {
         self.send_message_to_peer(ctx, msg);
     }
 
-    #[cfg(feature = "adversarial")]
+    #[cfg(feature = "test_features")]
     fn send_pong(&mut self, ctx: &mut Context<Self>, nonce: usize, target: CryptoHash) {
         let body =
             RoutedMessageBody::Pong(Pong { nonce: nonce as u64, source: self.peer_id.clone() });
@@ -1355,14 +1355,14 @@ impl PeerManagerActor {
         self.send_message_to_peer(ctx, msg);
     }
 
-    #[cfg(feature = "adversarial")]
+    #[cfg(feature = "test_features")]
     fn handle_ping(&mut self, ctx: &mut Context<Self>, ping: Ping, hash: CryptoHash) {
         self.send_pong(ctx, ping.nonce as usize, hash);
         self.routing_table.add_ping(ping);
     }
 
     /// Handle pong messages. Add pong temporary to the routing table, mostly used for testing.
-    #[cfg(feature = "adversarial")]
+    #[cfg(feature = "test_features")]
     fn handle_pong(&mut self, _ctx: &mut Context<Self>, pong: Pong) {
         #[allow(unused_variables)]
         let latency = self.routing_table.add_pong(pong);
@@ -1729,7 +1729,7 @@ impl Handler<NetworkRequests> for PeerManagerActor {
                     NetworkResponses::RouteNotFound
                 }
             }
-            #[cfg(feature = "adversarial")]
+            #[cfg(feature = "test_features")]
             NetworkRequests::FetchRoutingTable => {
                 NetworkResponses::RoutingTableInfo(self.routing_table.info())
             }
@@ -1837,12 +1837,12 @@ impl Handler<NetworkRequests> for PeerManagerActor {
                     NetworkResponses::BanPeer(ReasonForBan::InvalidEdge)
                 }
             }
-            #[cfg(feature = "adversarial")]
+            #[cfg(feature = "test_features")]
             NetworkRequests::PingTo(_nonce, _target) => {
                 self.send_ping(ctx, _nonce, _target);
                 NetworkResponses::NoResponse
             }
-            #[cfg(feature = "adversarial")]
+            #[cfg(feature = "test_features")]
             NetworkRequests::FetchPingPongInfo => {
                 let (pings, pongs) = self.routing_table.fetch_ping_pong();
                 NetworkResponses::PingPongInfo { pings, pongs }
@@ -2164,12 +2164,12 @@ impl Handler<RoutedMessageFrom> for PeerManagerActor {
             // Handle Ping and Pong message if they are for us without sending to client.
             // i.e. Return false in case of Ping and Pong
             match &msg.body {
-                #[cfg(feature = "adversarial")]
+                #[cfg(feature = "test_features")]
                 RoutedMessageBody::Ping(ping) => {
                     self.handle_ping(ctx, ping.clone(), msg.hash());
                     false
                 }
-                #[cfg(feature = "adversarial")]
+                #[cfg(feature = "test_features")]
                 RoutedMessageBody::Pong(pong) => {
                     self.handle_pong(ctx, pong.clone());
                     false

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -1729,15 +1729,9 @@ impl Handler<NetworkRequests> for PeerManagerActor {
                     NetworkResponses::RouteNotFound
                 }
             }
+            #[cfg(feature = "adversarial")]
             NetworkRequests::FetchRoutingTable => {
-                #[cfg(feature = "adversarial")]
-                {
-                    NetworkResponses::RoutingTableInfo(self.routing_table.info())
-                }
-                #[cfg(not(feature = "adversarial"))]
-                {
-                    NetworkResponses::NoResponse
-                }
+                NetworkResponses::RoutingTableInfo(self.routing_table.info())
             }
             NetworkRequests::Sync { peer_id, sync_data } => {
                 // Process edges and add new edges to the routing table. Also broadcast new edges.
@@ -1843,19 +1837,15 @@ impl Handler<NetworkRequests> for PeerManagerActor {
                     NetworkResponses::BanPeer(ReasonForBan::InvalidEdge)
                 }
             }
+            #[cfg(feature = "adversarial")]
             NetworkRequests::PingTo(_nonce, _target) => {
-                #[cfg(feature = "adversarial")]
                 self.send_ping(ctx, _nonce, _target);
                 NetworkResponses::NoResponse
             }
+            #[cfg(feature = "adversarial")]
             NetworkRequests::FetchPingPongInfo => {
-                #[cfg(feature = "adversarial")]
-                {
-                    let (pings, pongs) = self.routing_table.fetch_ping_pong();
-                    NetworkResponses::PingPongInfo { pings, pongs }
-                }
-                #[cfg(not(feature = "adversarial"))]
-                NetworkResponses::NoResponse
+                let (pings, pongs) = self.routing_table.fetch_ping_pong();
+                NetworkResponses::PingPongInfo { pings, pongs }
             }
         }
     }

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -1845,7 +1845,9 @@ impl Handler<NetworkRequests> for PeerManagerActor {
             }
             NetworkRequests::PingTo(_nonce, _target) => {
                 #[cfg(feature = "adversarial")]
-                self.send_ping(ctx, _nonce, _target);
+                {
+                    self.send_ping(ctx, _nonce, _target)
+                }
                 #[cfg(not(feature = "adversarial"))]
                 NetworkResponses::NoResponse
             }

--- a/chain/network/src/routing.rs
+++ b/chain/network/src/routing.rs
@@ -385,7 +385,7 @@ impl Default for EdgeVerifierHelper {
 }
 
 #[cfg(feature = "adversarial")]
-pub struct TestHelper {
+pub struct NetworkTestHelper {
     ping_info: SizedCache<usize, Ping>,
     /// Ping received by nonce.
     pong_info: SizedCache<usize, Pong>,
@@ -396,8 +396,8 @@ pub struct TestHelper {
 }
 
 #[cfg(feature = "adversarial")]
-impl TestHelper {
-    fn default() -> TestHelper {
+impl NetworkTestHelper {
+    fn default() -> NetworkTestHelper {
         Self {
             ping_info: SizedCache::with_size(PING_PONG_CACHE_SIZE),
             pong_info: SizedCache::with_size(PING_PONG_CACHE_SIZE),
@@ -428,7 +428,7 @@ pub struct RoutingTable {
     route_nonce: SizedCache<PeerId, usize>,
     /// Contains data structures used for tests
     #[cfg(feature = "adversarial")]
-    test_helper: TestHelper,
+    test_helper: NetworkTestHelper,
     /// Last nonce used to store edges on disk.
     pub component_nonce: u64,
 }
@@ -463,7 +463,7 @@ impl RoutingTable {
             raw_graph: Graph::new(peer_id),
             route_nonce: SizedCache::with_size(ROUND_ROBIN_NONCE_CACHE_SIZE),
             #[cfg(feature = "adversarial")]
-            test_helper: TestHelper::default(),
+            test_helper: NetworkTestHelper::default(),
             component_nonce,
         }
     }

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -639,6 +639,7 @@ pub enum NetworkRequests {
 
     /// The following types of requests are used to trigger actions in the Peer Manager for testing.
     /// Fetch current routing table.
+    #[cfg(feature = "adversarial")]
     FetchRoutingTable,
     /// Data to sync routing table from active peer.
     Sync {
@@ -650,8 +651,10 @@ pub enum NetworkRequests {
     ResponseUpdateNonce(Edge),
 
     /// Start ping to `PeerId` with `nonce`.
+    #[cfg(feature = "adversarial")]
     PingTo(usize, PeerId),
     /// Fetch all received ping and pong so far.
+    #[cfg(feature = "adversarial")]
     FetchPingPongInfo,
 
     /// A challenge to invalidate a block.

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -640,7 +640,7 @@ pub enum NetworkRequests {
     /// The following types of requests are used to trigger actions in the Peer Manager for testing.
     /// Fetch current routing table.
     /// Used for testing purposes, unfortunately, this is now part of protocol.
-    #[cfg(feature = "adversarial")]
+    #[cfg(feature = "test_features")]
     FetchRoutingTable,
     /// Data to sync routing table from active peer.
     Sync {
@@ -653,11 +653,11 @@ pub enum NetworkRequests {
 
     /// Start ping to `PeerId` with `nonce`.
     /// Used for testing purposes, unfortunately, this is now part of protocol.
-    #[cfg(feature = "adversarial")]
+    #[cfg(feature = "test_features")]
     PingTo(usize, PeerId),
     /// Fetch all received ping and pong so far.
     /// Used for testing purposes, unfortunately, this is now part of protocol.
-    #[cfg(feature = "adversarial")]
+    #[cfg(feature = "test_features")]
     FetchPingPongInfo,
 
     /// A challenge to invalidate a block.

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -640,6 +640,7 @@ pub enum NetworkRequests {
     /// The following types of requests are used to trigger actions in the Peer Manager for testing.
     /// Fetch current routing table.
     /// Used for testing purposes, unfortunately, this is now part of protocol.
+    #[cfg(feature = "adversarial")]
     FetchRoutingTable,
     /// Data to sync routing table from active peer.
     Sync {
@@ -652,9 +653,11 @@ pub enum NetworkRequests {
 
     /// Start ping to `PeerId` with `nonce`.
     /// Used for testing purposes, unfortunately, this is now part of protocol.
+    #[cfg(feature = "adversarial")]
     PingTo(usize, PeerId),
     /// Fetch all received ping and pong so far.
     /// Used for testing purposes, unfortunately, this is now part of protocol.
+    #[cfg(feature = "adversarial")]
     FetchPingPongInfo,
 
     /// A challenge to invalidate a block.

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -639,7 +639,7 @@ pub enum NetworkRequests {
 
     /// The following types of requests are used to trigger actions in the Peer Manager for testing.
     /// Fetch current routing table.
-    #[cfg(feature = "adversarial")]
+    /// Used for testing purposes, unfortunately, this is now part of protocol.
     FetchRoutingTable,
     /// Data to sync routing table from active peer.
     Sync {
@@ -651,10 +651,10 @@ pub enum NetworkRequests {
     ResponseUpdateNonce(Edge),
 
     /// Start ping to `PeerId` with `nonce`.
-    #[cfg(feature = "adversarial")]
+    /// Used for testing purposes, unfortunately, this is now part of protocol.
     PingTo(usize, PeerId),
     /// Fetch all received ping and pong so far.
-    #[cfg(feature = "adversarial")]
+    /// Used for testing purposes, unfortunately, this is now part of protocol.
     FetchPingPongInfo,
 
     /// A challenge to invalidate a block.

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -50,7 +50,7 @@ testlib = { path = "../test-utils/testlib" }
 performance_stats = ["nearcore/performance_stats", "near-network/performance_stats"]
 regression_tests = []
 expensive_tests = []
-test_features = ["nearcore/test_features"]
+test_features = ["nearcore/test_features", "near-client/test_features"]
 protocol_feature_alt_bn128 = [
     "near-primitives/protocol_feature_alt_bn128",
     "node-runtime/protocol_feature_alt_bn128",

--- a/integration-tests/tests/network/main.rs
+++ b/integration-tests/tests/network/main.rs
@@ -1,14 +1,14 @@
-#[cfg(feature = "adversarial")]
+#[cfg(feature = "test_features")]
 mod ban_peers;
-#[cfg(feature = "adversarial")]
+#[cfg(feature = "test_features")]
 mod churn_attack;
-#[cfg(feature = "adversarial")]
+#[cfg(feature = "test_features")]
 mod full_network;
 mod infinite_loop;
-#[cfg(feature = "adversarial")]
+#[cfg(feature = "test_features")]
 mod peer_handshake;
-#[cfg(feature = "adversarial")]
+#[cfg(feature = "test_features")]
 mod routing;
-#[cfg(feature = "adversarial")]
+#[cfg(feature = "test_features")]
 mod runner;
 mod stress_network;

--- a/integration-tests/tests/network/main.rs
+++ b/integration-tests/tests/network/main.rs
@@ -1,8 +1,14 @@
+#[cfg(feature = "adversarial")]
 mod ban_peers;
+#[cfg(feature = "adversarial")]
 mod churn_attack;
+#[cfg(feature = "adversarial")]
 mod full_network;
 mod infinite_loop;
+#[cfg(feature = "adversarial")]
 mod peer_handshake;
+#[cfg(feature = "adversarial")]
 mod routing;
+#[cfg(feature = "adversarial")]
 mod runner;
 mod stress_network;


### PR DESCRIPTION
Puts test methods under `adversarial` flag.