### PR TITLE
Fix build with NayDuck

### DIFF
--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -45,7 +45,7 @@ tempfile = "3"
 bencher = "0.1.5"
 
 [features]
-adversarial = ["near-network-primitives/adversarial", "serde", "protocol_feature_routing_exchange_algorithm"]
+adversarial = ["near-network-primitives/adversarial", "serde"]
 delay_detector = ["delay-detector"]
 performance_stats = ["near-performance-metrics/performance_stats"]
 sandbox = ["near-network-primitives/sandbox"]


### PR DESCRIPTION
Building with `cargo build --all-targets --features adversarial` is failing.

See http://nayduck.near.org/#/build/2184

Reported by @mina86 