### PR TITLE
producing/processing last block before shard layout changes

### DIFF
--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -9,6 +9,7 @@ use near_primitives::block::BlockValidityError;
 use near_primitives::challenge::{ChunkProofs, ChunkState};
 use near_primitives::errors::{EpochError, StorageError};
 use near_primitives::serialize::to_base;
+use near_primitives::shard_layout::ShardLayoutError;
 use near_primitives::sharding::{ChunkHash, ShardChunkHeader};
 use near_primitives::types::{BlockHeight, EpochId, ShardId};
 
@@ -350,6 +351,17 @@ impl From<EpochError> for Error {
             EpochError::EpochOutOfBounds(epoch_id) => ErrorKind::EpochOutOfBounds(epoch_id),
             EpochError::MissingBlock(h) => ErrorKind::DBNotFoundErr(to_base(&h)),
             err => ErrorKind::ValidatorError(err.to_string()),
+        }
+        .into()
+    }
+}
+
+impl From<ShardLayoutError> for Error {
+    fn from(error: ShardLayoutError) -> Self {
+        match error {
+            ShardLayoutError::InvalidShardIdError { shard_id } => {
+                ErrorKind::InvalidShardId(shard_id)
+            }
         }
         .into()
     }

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2571,6 +2571,17 @@ impl Chain {
             .ok_or_else(|| ErrorKind::DBNotFoundErr(format!("EXECUTION OUTCOME: {}", id)).into())
     }
 
+    /// Returns a vector of chunk headers, each of which corresponds to the previous chunk of
+    /// a chunk in the block after `prev_block`
+    /// This function is important when the block after `prev_block` has different number of chunks
+    /// from `prev_block`.
+    /// In block production and processing, often we need to get the previous chunks of chunks
+    /// in the current block, this function provides a way to do so while handling sharding changes
+    /// correctly.
+    /// For example, if `prev_block` has two shards 0, 1 and the block after `prev_block` will have
+    /// 4 shards 0, 1, 2, 3, 0 and 1 split from shard 0 and 2 and 3 split from shard 1.
+    /// `get_prev_chunks(runtime_adapter, prev_block)` will return
+    /// [prev_block.chunks()[0], prev_block.chunks()[0], prev_block.chunks()[1], prev_block.chunks()[1]]
     pub fn get_prev_chunks(
         runtime_adapter: &dyn RuntimeAdapter,
         prev_block: &Block,

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -704,6 +704,7 @@ impl Chain {
                 // Special case: genesis chunks can be in non-genesis blocks and don't have a signature
                 // We must verify that content matches and signature is empty.
                 // TODO: this code will not work when genesis block has different number of chunks as the current block
+                // https://github.com/near/nearcore/issues/4908
                 let genesis_chunk = &genesis_block.chunks()[shard_id];
                 if genesis_chunk.chunk_hash() != chunk_header.chunk_hash()
                     || genesis_chunk.signature() != chunk_header.signature()
@@ -3351,7 +3352,7 @@ impl<'a> ChainUpdate<'a> {
                     // Note that here we do not split outcomes by the new shard layout, we simply store
                     // the outcome_root from the parent shard. This is because outcome proofs are
                     // generated per shard using the old shard layout and stored in the database.
-                    // For these proofs to work, we must store the outcome root using per shard
+                    // For these proofs to work, we must store the outcome root per shard
                     // using the old shard layout instead of the new shard layout
                     let chunk_extra =
                         self.chain_store_update.get_chunk_extra(block_hash, shard_uid)?;

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3295,7 +3295,7 @@ impl<'a> ChainUpdate<'a> {
         Ok(result)
     }
 
-    /// Postprocess ApplyTransactionResult to apply changes to split states
+    /// Process ApplyTransactionResult to apply changes to split states
     /// When shards will change next epoch,
     ///    if `split_state_roots` is not None, that means states for the split shards are ready
     ///    this function updates these states and return apply results for these states
@@ -3332,7 +3332,7 @@ impl<'a> ChainUpdate<'a> {
         }
     }
 
-    /// process split state results or state changes, do the necessary update on chain
+    /// Postprocess split state results or state changes, do the necessary update on chain
     /// for split state results: store the chunk extras and trie changes for the split states
     /// for state changes, store the state changes for splitting states
     fn process_split_state(

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -476,9 +476,7 @@ impl ChainStore {
 
                 // get the shard from which the outgoing receipt were generated
                 let receipts_shard_id = if shard_layout != receipts_shard_layout {
-                    shard_layout
-                        .get_parent_shard_id(shard_id)
-                        .ok_or(ErrorKind::InvalidShardId(shard_id))?
+                    shard_layout.get_parent_shard_id(shard_id)?
                 } else {
                     shard_id
                 };

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -481,6 +481,14 @@ impl RuntimeAdapter for KeyValueRuntime {
         Ok(ShardLayout::v0(self.num_shards, 0))
     }
 
+    fn get_prev_shard_ids(
+        &self,
+        _prev_hash: &CryptoHash,
+        shard_ids: Vec<ShardId>,
+    ) -> Result<Vec<ShardId>, Error> {
+        Ok(shard_ids)
+    }
+
     fn get_shard_layout_from_prev_block(
         &self,
         _parent_hash: &CryptoHash,

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -1182,10 +1182,6 @@ impl RuntimeAdapter for KeyValueRuntime {
         _state_roots: HashMap<ShardUId, StateRoot>,
         _next_shard_layout: &ShardLayout,
         _state_changes: StateChangesForSplitStates,
-        _outgoing_receipts: Vec<Receipt>,
-        _validator_proposals: Vec<ValidatorStake>,
-        _total_gas_burnt: Gas,
-        _total_balance_burnt: Balance,
     ) -> Result<Vec<ApplySplitStateResult>, Error> {
         Ok(vec![])
     }

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -634,7 +634,6 @@ impl RuntimeAdapter for KeyValueRuntime {
         &self,
         shard_id: ShardId,
         state_root: &StateRoot,
-        _state_roots: Option<HashMap<ShardUId, StateRoot>>,
         _height: BlockHeight,
         _block_timestamp: u64,
         _prev_block_hash: &CryptoHash,
@@ -819,7 +818,7 @@ impl RuntimeAdapter for KeyValueRuntime {
             total_gas_burnt: 0,
             total_balance_burnt: 0,
             proof: None,
-            apply_split_state_result_or_state_changes: None,
+            processed_delayed_receipts: vec![],
         })
     }
 
@@ -1170,7 +1169,10 @@ impl RuntimeAdapter for KeyValueRuntime {
         }
     }
 
-    fn will_shard_layout_change(&self, _parent_hash: &CryptoHash) -> Result<bool, Error> {
+    fn will_shard_layout_change_next_epoch(
+        &self,
+        _parent_hash: &CryptoHash,
+    ) -> Result<bool, Error> {
         Ok(false)
     }
 
@@ -1180,6 +1182,10 @@ impl RuntimeAdapter for KeyValueRuntime {
         _state_roots: HashMap<ShardUId, StateRoot>,
         _next_shard_layout: &ShardLayout,
         _state_changes: StateChangesForSplitStates,
+        _outgoing_receipts: Vec<Receipt>,
+        _validator_proposals: Vec<ValidatorStake>,
+        _total_gas_burnt: Gas,
+        _total_balance_burnt: Balance,
     ) -> Result<Vec<ApplySplitStateResult>, Error> {
         Ok(vec![])
     }

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -565,17 +565,6 @@ pub trait RuntimeAdapter: Send + Sync {
     ) -> Result<StoreUpdate, Error>;
 
     /// Apply transactions to given state root and return store update and new state root.
-    /// `split_state_roots` is only used when shards will change next epoch and we are building
-    /// states for the next epoch.
-    /// When shards will change next epoch,
-    ///    if `split_state_roots` is not None, that means states for the split shards are ready
-    ///    `apply_transations` will update these states and return apply results for these states
-    ///     through `ApplyTransactionResult.apply_split_state_result_or_state_changes`
-    ///    otherwise, `apply_transactions` will generate state changes needed to be applied to split
-    ///    states and return them through
-    ///    `ApplyTransactionResult.apply_split_state_result_or_state_changes`.
-    ///     The caller(chain) can store it in the database, waiting to be processed after state
-    ///     catchup is finished
     /// Also returns transaction result for each transaction and new receipts.
     fn apply_transactions(
         &self,

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -95,17 +95,6 @@ pub enum ApplySplitStateResultOrStateChanges {
     StateChangesForSplitStates(StateChangesForSplitStates),
 }
 
-impl ApplySplitStateResultOrStateChanges {
-    pub fn get_state_changes(&self) -> Option<&StateChangesForSplitStates> {
-        match self {
-            ApplySplitStateResultOrStateChanges::ApplySplitStateResults(_) => None,
-            ApplySplitStateResultOrStateChanges::StateChangesForSplitStates(state_changes) => {
-                Some(state_changes)
-            }
-        }
-    }
-}
-
 pub struct ApplyTransactionResult {
     pub trie_changes: WrappedTrieChanges,
     pub new_root: StateRoot,

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -447,6 +447,12 @@ pub trait RuntimeAdapter: Send + Sync {
 
     fn get_shard_layout(&self, epoch_id: &EpochId) -> Result<ShardLayout, Error>;
 
+    fn get_prev_shard_ids(
+        &self,
+        prev_hash: &CryptoHash,
+        shard_ids: Vec<ShardId>,
+    ) -> Result<Vec<ShardId>, Error>;
+
     /// Get shard layout given hash of previous block.
     fn get_shard_layout_from_prev_block(
         &self,

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -83,10 +83,6 @@ pub struct ApplySplitStateResult {
     pub shard_uid: ShardUId,
     pub trie_changes: WrappedTrieChanges,
     pub new_root: StateRoot,
-    pub outgoing_receipts: Vec<Receipt>,
-    pub validator_proposals: Vec<ValidatorStake>,
-    pub total_gas_burnt: Gas,
-    pub total_balance_burnt: Balance,
 }
 
 // This struct captures two cases
@@ -707,10 +703,6 @@ pub trait RuntimeAdapter: Send + Sync {
         state_roots: HashMap<ShardUId, StateRoot>,
         next_shard_layout: &ShardLayout,
         state_changes: StateChangesForSplitStates,
-        outgoing_receipts: Vec<Receipt>,
-        validator_proposals: Vec<ValidatorStake>,
-        total_gas_burnt: Gas,
-        total_balance_burnt: Balance,
     ) -> Result<Vec<ApplySplitStateResult>, Error>;
 
     fn build_state_for_split_shards(

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -438,7 +438,7 @@ impl Client {
         let block_ordinal: NumBlocks = block_merkle_tree.size() + 1;
         let prev_block_extra = self.chain.get_block_extra(&prev_hash)?.clone();
         let prev_block = self.chain.get_block(&prev_hash)?;
-        let mut chunks = Chain::get_prev_chunks(&*self.runtime_adapter, prev_block)?;
+        let mut chunks = Chain::get_prev_chunk_headers(&*self.runtime_adapter, prev_block)?;
 
         // Collect new chunks.
         for (shard_id, mut chunk_header) in new_chunks {
@@ -1105,7 +1105,8 @@ impl Client {
                         match self.produce_chunk(
                             *block.hash(),
                             &epoch_id,
-                            block.chunks()[shard_id as usize].clone(),
+                            Chain::get_prev_chunk_header(&*self.runtime_adapter, &block, shard_id)
+                                .unwrap(),
                             block.header().height() + 1,
                             shard_id,
                         ) {

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -435,7 +435,7 @@ impl Client {
         let block_ordinal: NumBlocks = block_merkle_tree.size() + 1;
         let prev_block_extra = self.chain.get_block_extra(&prev_hash)?.clone();
         let prev_block = self.chain.get_block(&prev_hash)?;
-        let mut chunks: Vec<_> = prev_block.chunks().iter().cloned().collect();
+        let mut chunks = Chain::get_prev_chunks(&*self.runtime_adapter, prev_block)?;
 
         // Collect new chunks.
         for (shard_id, mut chunk_header) in new_chunks {
@@ -1583,7 +1583,7 @@ impl Client {
             let new_shard_sync = {
                 let prev_hash = self.chain.get_block(&sync_hash)?.header().prev_hash().clone();
                 let need_to_split_states =
-                    self.runtime_adapter.will_shard_layout_change(&prev_hash)?;
+                    self.runtime_adapter.will_shard_layout_change_next_epoch(&prev_hash)?;
                 if need_to_split_states {
                     // If the client already has the state for this epoch, skip the downloading phase
                     let new_shard_sync = state_sync_info

--- a/chain/client/src/sync.rs
+++ b/chain/client/src/sync.rs
@@ -681,7 +681,7 @@ impl StateSync {
         };
 
         let prev_hash = chain.get_block_header(&sync_hash)?.prev_hash().clone();
-        let split_states = runtime_adapter.will_shard_layout_change(&prev_hash)?;
+        let split_states = runtime_adapter.will_shard_layout_change_next_epoch(&prev_hash)?;
 
         for shard_id in tracking_shards {
             let mut download_timeout = false;

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -39,7 +39,7 @@ use near_primitives::shard_layout::ShardUId;
 use near_primitives::sharding::{EncodedShardChunk, ReedSolomonWrapper};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{
-    AccountId, Balance, BlockHeight, BlockHeightDelta, NumBlocks, NumSeats, NumShards,
+    AccountId, Balance, BlockHeight, BlockHeightDelta, NumBlocks, NumSeats, NumShards, ShardId,
 };
 use near_primitives::validator_signer::{InMemoryValidatorSigner, ValidatorSigner};
 use near_primitives::version::PROTOCOL_VERSION;
@@ -1358,9 +1358,10 @@ impl TestEnv {
     }
 }
 
-pub fn create_chunk_on_height(
+pub fn create_chunk_on_height_for_shard(
     client: &mut Client,
     next_height: BlockHeight,
+    shard_id: ShardId,
 ) -> (EncodedShardChunk, Vec<MerklePath>, Vec<Receipt>) {
     let last_block_hash = client.chain.head().unwrap().last_block_hash;
     let last_block = client.chain.get_block(&last_block_hash).unwrap().clone();
@@ -1368,12 +1369,19 @@ pub fn create_chunk_on_height(
         .produce_chunk(
             last_block_hash,
             &client.runtime_adapter.get_epoch_id_from_prev_block(&last_block_hash).unwrap(),
-            last_block.chunks()[0].clone(),
+            Chain::get_prev_chunk_header(&*client.runtime_adapter, &last_block, shard_id).unwrap(),
             next_height,
-            0,
+            shard_id,
         )
         .unwrap()
         .unwrap()
+}
+
+pub fn create_chunk_on_height(
+    client: &mut Client,
+    next_height: BlockHeight,
+) -> (EncodedShardChunk, Vec<MerklePath>, Vec<Receipt>) {
+    create_chunk_on_height_for_shard(client, next_height, 0)
 }
 
 pub fn create_chunk_with_transactions(

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -1364,7 +1364,7 @@ pub fn create_chunk_on_height(
     client
         .produce_chunk(
             last_block_hash,
-            last_block.header().epoch_id(),
+            &client.runtime_adapter.get_epoch_id_from_prev_block(&last_block_hash).unwrap(),
             last_block.chunks()[0].clone(),
             next_height,
             0,

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -52,6 +52,10 @@ pub struct ShardLayoutV1 {
     version: ShardVersion,
 }
 
+pub enum ShardLayoutError {
+    InvalidShardIdError { shard_id: ShardId },
+}
+
 impl ShardLayout {
     pub fn default() -> Self {
         Self::v0(1, 0)
@@ -110,14 +114,23 @@ impl ShardLayout {
     }
 
     #[inline]
-    pub fn get_parent_shard_id(&self, shard_id: ShardId) -> Option<ShardId> {
-        match self {
-            Self::V0(_) => None,
-            Self::V1(v1) => match &v1.to_parent_shard_map {
-                Some(to_parent_shard_map) => to_parent_shard_map.get(shard_id as usize).cloned(),
-                None => None,
-            },
+    /// Only calls this function for shard layout that has parent shard layouts
+    /// Returns error if `shard_id` is an invalid shard id in the current layout
+    /// Panics if `self` has no parent shard layout
+    pub fn get_parent_shard_id(&self, shard_id: ShardId) -> Result<ShardId, ShardLayoutError> {
+        if shard_id > self.num_shards() {
+            return Err(ShardLayoutError::InvalidShardIdError { shard_id });
         }
+        let parent_shard_id = match self {
+            Self::V0(_) => panic!("shard layout has no parent shard"),
+            Self::V1(v1) => match &v1.to_parent_shard_map {
+                // we can safely unwrap here because the construction of to_parent_shard_map guarantees
+                // that every shard has a parent shard
+                Some(to_parent_shard_map) => *to_parent_shard_map.get(shard_id as usize).unwrap(),
+                None => panic!("shard_layout has no parent shard"),
+            },
+        };
+        Ok(parent_shard_id)
     }
 
     #[inline]

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -52,6 +52,7 @@ pub struct ShardLayoutV1 {
     version: ShardVersion,
 }
 
+#[derive(Debug)]
 pub enum ShardLayoutError {
     InvalidShardIdError { shard_id: ShardId },
 }

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -290,6 +290,10 @@ impl WrappedTrieChanges {
         WrappedTrieChanges { tries, shard_uid, trie_changes, state_changes, block_hash }
     }
 
+    pub fn state_changes(&self) -> &[RawStateChangesWithTrieKey] {
+        &self.state_changes
+    }
+
     pub fn insertions_into(&self, store_update: &mut StoreUpdate) -> Result<(), StorageError> {
         self.tries.apply_insertions(&self.trie_changes, self.shard_uid, store_update)
     }

--- a/integration-tests/tests/client/process_blocks.rs
+++ b/integration-tests/tests/client/process_blocks.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::convert::TryFrom;
 use std::iter::FromIterator;
 use std::path::Path;
@@ -19,7 +19,10 @@ use near_chain::{
 };
 use near_chain_configs::{ClientConfig, Genesis};
 use near_chunks::{ChunkStatus, ShardsManager};
-use near_client::test_utils::{create_chunk_on_height, run_catchup, setup_mock_all_validators};
+use near_client::test_utils::{
+    create_chunk_on_height, create_chunk_on_height_for_shard, run_catchup,
+    setup_mock_all_validators,
+};
 use near_client::test_utils::{setup_client, setup_mock, TestEnv};
 use near_client::{Client, GetBlock, GetBlockWithMerkleTree};
 use near_crypto::{InMemorySigner, KeyType, PublicKey, Signature, Signer};
@@ -44,7 +47,7 @@ use near_primitives::receipt::DelayedReceiptIndices;
 use near_primitives::runtime::config_store::RuntimeConfigStore;
 #[cfg(feature = "protocol_feature_simple_nightshade")]
 use near_primitives::shard_layout::ShardLayout;
-use near_primitives::shard_layout::ShardUId;
+use near_primitives::shard_layout::{account_id_to_shard_uid, ShardUId};
 #[cfg(not(feature = "protocol_feature_block_header_v3"))]
 use near_primitives::sharding::ShardChunkHeaderV2;
 use near_primitives::sharding::{EncodedShardChunk, ReedSolomonWrapper, ShardChunkHeader};
@@ -68,7 +71,7 @@ use near_primitives::views::{
 };
 use near_store::db::DBCol::ColStateParts;
 use near_store::get;
-use near_store::test_utils::create_test_store;
+use near_store::test_utils::{create_test_store, gen_accounts};
 use nearcore::config::{GenesisExt, TESTING_INIT_BALANCE, TESTING_INIT_STAKE};
 use nearcore::NEAR_BASE;
 use rand::Rng;
@@ -2592,20 +2595,24 @@ fn test_refund_receipts_processing() {
 fn test_shard_layout_upgrade() {
     init_test_logger();
     let epoch_length = 5;
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 2);
+    let mut rng = rand::thread_rng();
+    let mut account_ids = vec!["test0".parse().unwrap(), "test1".parse().unwrap()];
+    account_ids.extend(gen_accounts(&mut rng, 100));
+    let mut genesis = Genesis::test(account_ids.clone(), 2);
     let simple_nightshade_protocol_version = ProtocolFeature::SimpleNightshade.protocol_version();
     genesis.config.epoch_length = epoch_length;
     genesis.config.protocol_version = simple_nightshade_protocol_version - 1;
     let new_num_shards = 4;
+    let simple_nightshade_shard_layout = ShardLayout::v1(
+        vec!["test0"].into_iter().map(|s| s.parse().unwrap()).collect(),
+        vec!["abc", "foo"].into_iter().map(|s| s.parse().unwrap()).collect(),
+        Some(vec![vec![0, 1, 2, 3]]),
+        1,
+    );
     genesis.config.simple_nightshade_shard_config = Some(ShardConfig {
         num_block_producer_seats_per_shard: vec![2; new_num_shards],
         avg_hidden_validator_seats_per_shard: vec![0; new_num_shards],
-        shard_layout: ShardLayout::v1(
-            vec!["test0"].into_iter().map(|s| s.parse().unwrap()).collect(),
-            vec!["abc", "foo"].into_iter().map(|s| s.parse().unwrap()).collect(),
-            Some(vec![vec![0, 1, 2, 3]]),
-            1,
-        ),
+        shard_layout: simple_nightshade_shard_layout.clone(),
     });
     let genesis_height = genesis.config.genesis_height;
     let chain_genesis = ChainGenesis::from(&genesis);
@@ -2614,36 +2621,55 @@ fn test_shard_layout_upgrade() {
         .validator_seats(2)
         .runtime_adapters(create_nightshade_runtimes(&genesis, 2))
         .build();
+    let account_to_client_index = |account_id: &AccountId| {
+        let index = if account_id.as_ref() == "test0" { 0 } else { 1 };
+        index
+    };
     // ShardLayout changes at epoch 2
     // Test that state is caught up correctly at epoch 1 (block height 6-10)
-    // TODO: change this number to 16 once splitting states is fully implemented
     for i in 1..=16 {
         let head = env.clients[0].chain.head().unwrap();
         let epoch_id = env.clients[0]
             .runtime_adapter
             .get_epoch_id_from_prev_block(&head.last_block_hash)
             .unwrap();
-        let block_producer =
-            env.clients[0].runtime_adapter.get_block_producer(&epoch_id, i).unwrap();
-        let index = if block_producer.as_ref() == "test0" { 0 } else { 1 };
-        let (encoded_chunk, merkle_paths, receipts) =
-            create_chunk_on_height(&mut env.clients[index], i);
+        let shard_layout = env.clients[0].runtime_adapter.get_shard_layout(&epoch_id).unwrap();
+        println!(
+            "producing block {} {} last block {:?} for epoch id {:?} shards {}",
+            i,
+            head.height + 1,
+            head.last_block_hash,
+            epoch_id,
+            shard_layout.num_shards()
+        );
 
-        for j in 0..2 {
-            let mut chain_store =
-                ChainStore::new(env.clients[j].chain.store().owned_store(), genesis_height);
-            env.clients[j]
-                .shards_mgr
-                .distribute_encoded_chunk(
-                    encoded_chunk.clone(),
-                    merkle_paths.clone(),
-                    receipts.clone(),
-                    &mut chain_store,
-                )
-                .unwrap();
+        // produce chunks
+        for shard_id in 0..shard_layout.num_shards() {
+            let chunk_producer =
+                env.clients[0].runtime_adapter.get_chunk_producer(&epoch_id, i, shard_id).unwrap();
+            let chunk_producer_client = &mut env.clients[account_to_client_index(&chunk_producer)];
+            let (encoded_chunk, merkle_paths, receipts) =
+                create_chunk_on_height_for_shard(chunk_producer_client, i, shard_id);
+            for client in env.clients.iter_mut() {
+                let mut chain_store =
+                    ChainStore::new(client.chain.store().owned_store(), genesis_height);
+                client
+                    .shards_mgr
+                    .distribute_encoded_chunk(
+                        encoded_chunk.clone(),
+                        merkle_paths.clone(),
+                        receipts.clone(),
+                        &mut chain_store,
+                    )
+                    .unwrap();
+            }
         }
 
-        let mut block = env.clients[index].produce_block(i).unwrap().unwrap();
+        // produce block
+        let block_producer =
+            env.clients[0].runtime_adapter.get_block_producer(&epoch_id, i).unwrap();
+        let block_producer_client = &mut env.clients[account_to_client_index(&block_producer)];
+        let mut block = block_producer_client.produce_block(i).unwrap().unwrap();
         // upgrade to new protocol version but in the second epoch one node vote for the old version.
         if i != 10 {
             set_block_protocol_version(
@@ -2652,10 +2678,51 @@ fn test_shard_layout_upgrade() {
                 simple_nightshade_protocol_version,
             );
         }
+
+        // process block
         for j in 0..2 {
             let (_, res) = env.clients[j].process_block(block.clone(), Provenance::NONE);
             assert!(res.is_ok(), "{:?}", res);
             run_catchup(&mut env.clients[j], &vec![]).unwrap();
+        }
+
+        // after state split, check chunk extra exists and the states are correct
+        if i >= 6 {
+            let mut state_roots = HashMap::new();
+
+            for account_id in &account_ids {
+                let shard_uid =
+                    account_id_to_shard_uid(account_id, &simple_nightshade_shard_layout);
+                for j in 0..2 {
+                    if env.clients[j].runtime_adapter.cares_about_shard(
+                        None,
+                        block.header().prev_hash(),
+                        shard_uid.shard_id(),
+                        true,
+                    ) {
+                        if !state_roots.contains_key(&shard_uid) {
+                            let chunk_extra = env.clients[j]
+                                .chain
+                                .get_chunk_extra(block.hash(), &shard_uid)
+                                .unwrap();
+                            state_roots.insert(shard_uid.clone(), chunk_extra.state_root().clone());
+                        }
+                        env.clients[j]
+                            .runtime_adapter
+                            .query(
+                                shard_uid,
+                                &state_roots[&shard_uid],
+                                block.header().height(),
+                                0,
+                                block.header().prev_hash(),
+                                block.hash(),
+                                block.header().epoch_id(),
+                                &QueryRequest::ViewAccount { account_id: account_id.clone() },
+                            )
+                            .unwrap();
+                    }
+                }
+            }
         }
     }
 }

--- a/integration-tests/tests/client/process_blocks.rs
+++ b/integration-tests/tests/client/process_blocks.rs
@@ -2775,12 +2775,9 @@ fn test_epoch_protocol_version_change() {
     for i in 1..=16 {
         let head = env.clients[0].chain.head().unwrap();
         let epoch_id = env.clients[0]
-            .chain
-            .get_block(&head.last_block_hash)
-            .unwrap()
-            .header()
-            .epoch_id()
-            .clone();
+            .runtime_adapter
+            .get_epoch_id_from_prev_block(&head.last_block_hash)
+            .unwrap();
         let chunk_producer =
             env.clients[0].runtime_adapter.get_chunk_producer(&epoch_id, i, 0).unwrap();
         let index = if chunk_producer.as_ref() == "test0" { 0 } else { 1 };

--- a/integration-tests/tests/client/process_blocks.rs
+++ b/integration-tests/tests/client/process_blocks.rs
@@ -1,4 +1,6 @@
-use std::collections::{HashMap, HashSet, VecDeque};
+#[cfg(feature = "protocol_feature_simple_nightshade")]
+use std::collections::HashMap;
+use std::collections::{HashSet, VecDeque};
 use std::convert::TryFrom;
 use std::iter::FromIterator;
 use std::path::Path;
@@ -19,11 +21,12 @@ use near_chain::{
 };
 use near_chain_configs::{ClientConfig, Genesis};
 use near_chunks::{ChunkStatus, ShardsManager};
+#[cfg(feature = "protocol_feature_simple_nightshade")]
+use near_client::test_utils::create_chunk_on_height_for_shard;
 use near_client::test_utils::{
-    create_chunk_on_height, create_chunk_on_height_for_shard, run_catchup,
-    setup_mock_all_validators,
+    create_chunk_on_height, run_catchup, setup_client, setup_mock, setup_mock_all_validators,
+    TestEnv,
 };
-use near_client::test_utils::{setup_client, setup_mock, TestEnv};
 use near_client::{Client, GetBlock, GetBlockWithMerkleTree};
 use near_crypto::{InMemorySigner, KeyType, PublicKey, Signature, Signer};
 use near_logger_utils::init_test_logger;
@@ -45,9 +48,9 @@ use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::merkle::verify_hash;
 use near_primitives::receipt::DelayedReceiptIndices;
 use near_primitives::runtime::config_store::RuntimeConfigStore;
+use near_primitives::shard_layout::ShardUId;
 #[cfg(feature = "protocol_feature_simple_nightshade")]
-use near_primitives::shard_layout::ShardLayout;
-use near_primitives::shard_layout::{account_id_to_shard_uid, ShardUId};
+use near_primitives::shard_layout::{account_id_to_shard_uid, ShardLayout};
 #[cfg(not(feature = "protocol_feature_block_header_v3"))]
 use near_primitives::sharding::ShardChunkHeaderV2;
 use near_primitives::sharding::{EncodedShardChunk, ReedSolomonWrapper, ShardChunkHeader};
@@ -71,7 +74,9 @@ use near_primitives::views::{
 };
 use near_store::db::DBCol::ColStateParts;
 use near_store::get;
-use near_store::test_utils::{create_test_store, gen_accounts};
+use near_store::test_utils::create_test_store;
+#[cfg(feature = "protocol_feature_simple_nightshade")]
+use near_store::test_utils::gen_accounts;
 use nearcore::config::{GenesisExt, TESTING_INIT_BALANCE, TESTING_INIT_STAKE};
 use nearcore::NEAR_BASE;
 use rand::Rng;

--- a/integration-tests/tests/client/process_blocks.rs
+++ b/integration-tests/tests/client/process_blocks.rs
@@ -2618,7 +2618,7 @@ fn test_shard_layout_upgrade() {
     // ShardLayout changes at epoch 2
     // Test that state is caught up correctly at epoch 1 (block height 6-10)
     // TODO: change this number to 16 once splitting states is fully implemented
-    for i in 1..=10 {
+    for i in 1..=16 {
         let head = env.clients[0].chain.head().unwrap();
         let epoch_id = env.clients[0]
             .runtime_adapter

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -68,7 +68,6 @@ fn apply_block_at_height(
         .apply_transactions(
             shard_id,
             &chunk_header.prev_state_root(),
-            None,
             block_height,
             block.header().raw_timestamp(),
             block.header().prev_hash(),
@@ -252,7 +251,6 @@ pub fn migrate_19_to_20(path: &Path, near_config: &NearConfig) {
                         .apply_transactions(
                             shard_id,
                             new_extra.state_root(),
-                            None,
                             block.header().height(),
                             block.header().raw_timestamp(),
                             block.header().prev_hash(),
@@ -330,7 +328,6 @@ pub fn migrate_22_to_23(path: &Path, near_config: &NearConfig) {
                     .apply_transactions(
                         shard_id,
                         &chunk_header.prev_state_root(),
-                        None,
                         block.header().height(),
                         block.header().raw_timestamp(),
                         block.header().prev_hash(),

--- a/test-utils/state-viewer/src/main.rs
+++ b/test-utils/state-viewer/src/main.rs
@@ -361,7 +361,6 @@ fn apply_chain_range(
                 .apply_transactions(
                     shard_id,
                     chunk_inner.prev_state_root(),
-                    None,
                     height,
                     block.header().raw_timestamp(),
                     block.header().prev_hash(),

--- a/test-utils/state-viewer/src/main.rs
+++ b/test-utils/state-viewer/src/main.rs
@@ -388,7 +388,6 @@ fn apply_chain_range(
                 .apply_transactions(
                     shard_id,
                     chunk_extra.state_root(),
-                    None,
                     block.header().height(),
                     block.header().raw_timestamp(),
                     block.header().prev_hash(),
@@ -504,7 +503,6 @@ fn apply_block_at_height(
             .apply_transactions(
                 shard_id,
                 chunk_inner.prev_state_root(),
-                None,
                 height,
                 block.header().raw_timestamp(),
                 block.header().prev_hash(),
@@ -529,7 +527,6 @@ fn apply_block_at_height(
             .apply_transactions(
                 shard_id,
                 chunk_extra.state_root(),
-                None,
                 block.header().height(),
                 block.header().raw_timestamp(),
                 block.header().prev_hash(),

--- a/tools/restored-receipts-verifier/src/main.rs
+++ b/tools/restored-receipts-verifier/src/main.rs
@@ -93,7 +93,6 @@ fn main() -> Result<()> {
             .apply_transactions(
                 shard_id,
                 chunk_extra.state_root(),
-                None,
                 block.header().height(),
                 block.header().raw_timestamp(),
                 block.header().prev_hash(),


### PR DESCRIPTION
This PR makes the transition at the last block before sharding changes correct.
1. chunk_extra for splitting states are stored correctly. These chunk_extra will have all information that is needed for chunk header validation when the new epoch with the new shard layout begins. Note that technically, only the last block of the epoch before sharding changes need to store the full extra information, but here we implement storing that for all blocks in the transitioning epoch.
2. `produce_blocks`, `process_blocks` now can handle the case where number of chunks in the last block is different from number of chunks in this block

Test Plan:
1. `test_shard_layout_upgrade` tests that blocks can still get produced after shard layout changes. However, currently it only tests for a simple state. It doesn't test the chunk producing/receipts handling logic because the produced chunks are not distributed. I will modify that in a later PR. 
2. I will add more integration tests