### PR TITLE
Split state in SyncJobsActor

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -67,7 +67,7 @@ use crate::{metrics, DoomslugThresholdMode};
 use actix::Message;
 #[cfg(feature = "delay_detector")]
 use delay_detector::DelayDetector;
-use near_primitives::shard_layout::ShardUId;
+use near_primitives::shard_layout::{ShardLayout, ShardUId};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 /// Maximum number of orphans chain can store.
@@ -1865,30 +1865,42 @@ impl Chain {
         Ok(())
     }
 
-    pub fn build_state_for_split_shards(
+    pub fn build_state_for_split_shards_preprocessing(
         &mut self,
         sync_hash: &CryptoHash,
         shard_id: ShardId,
+        state_split_scheduler: &dyn Fn(StateSplitRequest),
     ) -> Result<(), Error> {
         let (epoch_id, next_epoch_id) = {
             let block_header = self.get_block_header(sync_hash)?;
             (block_header.epoch_id().clone(), block_header.next_epoch_id().clone())
         };
         let shard_layout = self.runtime_adapter.get_shard_layout(&epoch_id)?;
-        let next_shard_layout = self.runtime_adapter.get_shard_layout(&next_epoch_id)?;
+        let next_epoch_shard_layout = self.runtime_adapter.get_shard_layout(&next_epoch_id)?;
         let shard_uid = ShardUId::from_shard_id_and_layout(shard_id, &shard_layout);
         let prev_hash = *self.get_block_header(sync_hash)?.prev_hash();
         let state_root = *self.get_chunk_extra(&prev_hash, &shard_uid)?.state_root();
+        assert_ne!(shard_layout, next_epoch_shard_layout);
 
-        assert_ne!(shard_layout, next_shard_layout);
-        let state_roots = self.runtime_adapter.build_state_for_split_shards(
+        state_split_scheduler(StateSplitRequest {
+            sync_hash: sync_hash.clone(),
+            shard_id,
             shard_uid,
-            &state_root,
-            &next_shard_layout,
-        )?;
+            state_root: state_root.clone(),
+            next_epoch_shard_layout,
+        });
 
+        Ok(())
+    }
+
+    pub fn build_state_for_split_shards_postprocessing(
+        &mut self,
+        sync_hash: &CryptoHash,
+        state_roots: Result<HashMap<ShardUId, StateRoot>, Error>,
+    ) -> Result<(), Error> {
+        let prev_hash = *self.get_block_header(sync_hash)?.prev_hash();
         let mut chain_update = self.chain_update();
-        for (shard_uid, state_root) in state_roots {
+        for (shard_uid, state_root) in state_roots? {
             // here we store the state roots in chunk_extra in the database for later use
             let chunk_extra = ChunkExtra::new_with_only_state_root(&state_root);
             chain_update.chain_store_update.save_chunk_extra(&prev_hash, &shard_uid, chunk_extra);
@@ -4334,6 +4346,24 @@ pub struct BlockCatchUpResponse {
     pub sync_hash: CryptoHash,
     pub block_hash: CryptoHash,
     pub results: Vec<Result<ApplyChunkResult, Error>>,
+}
+
+#[derive(Message)]
+#[rtype(result = "()")]
+pub struct StateSplitRequest {
+    pub sync_hash: CryptoHash,
+    pub shard_id: ShardId,
+    pub shard_uid: ShardUId,
+    pub state_root: StateRoot,
+    pub next_epoch_shard_layout: ShardLayout,
+}
+
+#[derive(Message)]
+#[rtype(result = "()")]
+pub struct StateSplitResponse {
+    pub sync_hash: CryptoHash,
+    pub shard_id: ShardId,
+    pub new_state_roots: Result<HashMap<ShardUId, StateRoot>, Error>,
 }
 
 /// Helper to track blocks catch up

--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -108,7 +108,8 @@ pub enum ShardSyncStatus {
     StateDownloadScheduling,
     StateDownloadApplying,
     StateDownloadComplete,
-    StateSplit,
+    StateSplitScheduling,
+    StateSplitApplying,
     StateSyncDone,
 }
 

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -11,7 +11,8 @@ use chrono::Utc;
 use log::{debug, error, info, warn};
 
 use near_chain::chain::{
-    ApplyStatePartsRequest, BlockCatchUpRequest, BlocksCatchUpState, TX_ROUTING_HEIGHT_HORIZON,
+    ApplyStatePartsRequest, BlockCatchUpRequest, BlocksCatchUpState, StateSplitRequest,
+    TX_ROUTING_HEIGHT_HORIZON,
 };
 use near_chain::test_utils::format_hash;
 use near_chain::types::{AcceptedBlock, LatestKnown};
@@ -1578,6 +1579,7 @@ impl Client {
         highest_height_peers: &Vec<FullPeerInfo>,
         state_parts_task_scheduler: &dyn Fn(ApplyStatePartsRequest),
         block_catch_up_task_scheduler: &dyn Fn(BlockCatchUpRequest),
+        state_split_scheduler: &dyn Fn(StateSplitRequest),
     ) -> Result<Vec<AcceptedBlock>, Error> {
         let me = &self.validator_signer.as_ref().map(|x| x.validator_id().clone());
         for (sync_hash, state_sync_info) in self.chain.store().iterate_state_sync_infos() {
@@ -1605,7 +1607,7 @@ impl Client {
                                     shard_id,
                                     ShardSyncDownload {
                                         downloads: vec![],
-                                        status: ShardSyncStatus::StateSplit,
+                                        status: ShardSyncStatus::StateSplitScheduling,
                                     },
                                 ))
                             } else {
@@ -1645,6 +1647,7 @@ impl Client {
                 highest_height_peers,
                 state_sync_info.shards.iter().map(|tuple| tuple.0).collect(),
                 state_parts_task_scheduler,
+                state_split_scheduler,
             )? {
                 StateSyncResult::Unchanged => {}
                 StateSyncResult::Changed(fetch_block) => {

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -250,7 +250,8 @@ fn display_sync_status(
                             ShardSyncStatus::StateDownloadScheduling => format!("scheduling"),
                             ShardSyncStatus::StateDownloadApplying => format!("applying"),
                             ShardSyncStatus::StateDownloadComplete => format!("download complete"),
-                            ShardSyncStatus::StateSplit => format!("split"),
+                            ShardSyncStatus::StateSplitScheduling => format!("split scheduling"),
+                            ShardSyncStatus::StateSplitApplying => format!("split applying"),
                             ShardSyncStatus::StateSyncDone => format!("done"),
                         }
                     )

--- a/chain/client/src/sync.rs
+++ b/chain/client/src/sync.rs
@@ -20,14 +20,17 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
 use near_primitives::syncing::get_num_state_parts;
 use near_primitives::types::validator_stake::ValidatorStake;
-use near_primitives::types::{AccountId, BlockHeight, BlockHeightDelta, EpochId, ShardId};
+use near_primitives::types::{
+    AccountId, BlockHeight, BlockHeightDelta, EpochId, ShardId, StateRoot,
+};
 use near_primitives::utils::to_timestamp;
 
 use cached::{Cached, SizedCache};
-use near_chain::chain::ApplyStatePartsRequest;
+use near_chain::chain::{ApplyStatePartsRequest, StateSplitRequest};
 use near_client_primitives::types::{
     DownloadStatus, ShardSyncDownload, ShardSyncStatus, SyncStatus,
 };
+use near_primitives::shard_layout::ShardUId;
 
 /// Maximum number of block headers send over the network.
 pub const MAX_BLOCK_HEADERS: u64 = 512;
@@ -607,6 +610,9 @@ pub struct StateSync {
 
     /// Maps shard_id to result of applying downloaded state
     state_parts_apply_results: HashMap<ShardId, Result<(), near_chain_primitives::error::Error>>,
+
+    /// Maps shard_id to result of splitting state for resharding
+    split_state_roots: HashMap<ShardId, Result<HashMap<ShardUId, StateRoot>, Error>>,
 }
 
 impl StateSync {
@@ -619,6 +625,7 @@ impl StateSync {
             requested_target: SizedCache::with_size(MAX_PENDING_PART as usize),
             timeout: Duration::from_std(timeout).unwrap(),
             state_parts_apply_results: HashMap::new(),
+            split_state_roots: HashMap::new(),
         }
     }
 
@@ -661,6 +668,7 @@ impl StateSync {
         tracking_shards: Vec<ShardId>,
         now: DateTime<Utc>,
         state_parts_task_scheduler: &dyn Fn(ApplyStatePartsRequest),
+        state_split_scheduler: &dyn Fn(StateSplitRequest),
     ) -> Result<(bool, bool), near_chain::Error> {
         let mut all_done = true;
         let mut update_sync_status = false;
@@ -820,7 +828,7 @@ impl StateSync {
                     if split_states {
                         *shard_sync_download = ShardSyncDownload {
                             downloads: vec![],
-                            status: ShardSyncStatus::StateSplit,
+                            status: ShardSyncStatus::StateSplitScheduling,
                         }
                     } else {
                         *shard_sync_download = ShardSyncDownload {
@@ -830,15 +838,31 @@ impl StateSync {
                         this_done = true;
                     }
                 }
-                ShardSyncStatus::StateSplit => {
+                ShardSyncStatus::StateSplitScheduling => {
                     debug_assert!(split_states);
-                    chain.build_state_for_split_shards(&sync_hash, shard_id)?;
-                    debug!(target: "sync", "State sync split: me {:?}, shard = {}, hash = {}", me, shard_id, sync_hash);
+                    chain.build_state_for_split_shards_preprocessing(
+                        &sync_hash,
+                        shard_id,
+                        state_split_scheduler,
+                    )?;
+                    debug!(target: "sync", "State sync split scheduled: me {:?}, shard = {}, hash = {}", me, shard_id, sync_hash);
                     *shard_sync_download = ShardSyncDownload {
                         downloads: vec![],
-                        status: ShardSyncStatus::StateSyncDone,
+                        status: ShardSyncStatus::StateSplitApplying,
                     };
-                    this_done = true;
+                }
+                ShardSyncStatus::StateSplitApplying => {
+                    debug_assert!(split_states);
+                    let result = self.split_state_roots.remove(&shard_id);
+                    if let Some(state_roots) = result {
+                        chain
+                            .build_state_for_split_shards_postprocessing(&sync_hash, state_roots)?;
+                        *shard_sync_download = ShardSyncDownload {
+                            downloads: vec![],
+                            status: ShardSyncStatus::StateSyncDone,
+                        };
+                        this_done = true;
+                    }
                 }
                 ShardSyncStatus::StateSyncDone => {
                     this_done = true;
@@ -894,6 +918,14 @@ impl StateSync {
 
     pub fn set_apply_result(&mut self, shard_id: ShardId, apply_result: Result<(), Error>) {
         self.state_parts_apply_results.insert(shard_id, apply_result);
+    }
+
+    pub fn set_split_result(
+        &mut self,
+        shard_id: ShardId,
+        result: Result<HashMap<ShardUId, StateRoot>, Error>,
+    ) {
+        self.split_state_roots.insert(shard_id, result);
     }
 
     /// Find the hash of the first block on the same epoch (and chain) of block with hash `sync_hash`.
@@ -1116,6 +1148,7 @@ impl StateSync {
         highest_height_peers: &Vec<FullPeerInfo>,
         tracking_shards: Vec<ShardId>,
         state_parts_task_scheduler: &dyn Fn(ApplyStatePartsRequest),
+        state_split_scheduler: &dyn Fn(StateSplitRequest),
     ) -> Result<StateSyncResult, near_chain::Error> {
         let prev_hash = chain.get_block_header(&sync_hash)?.prev_hash().clone();
         let now = Utc::now();
@@ -1143,6 +1176,7 @@ impl StateSync {
             tracking_shards,
             now,
             state_parts_task_scheduler,
+            state_split_scheduler,
         )?;
 
         if have_block && all_done {


### PR DESCRIPTION
We need to split state in SyncJobActor to free up ClientActor to do other things in the meantime (very important for validators)

### Test plan

This still requires full integration test