### PR TITLE
chore: remove deprecated IsSyncing variant check

### DIFF
--- a/integration-tests/tests/nearcore/rpc_nodes.rs
+++ b/integration-tests/tests/nearcore/rpc_nodes.rs
@@ -24,17 +24,6 @@ use near_primitives::views::{ExecutionOutcomeView, ExecutionStatusView};
 
 use crate::node_cluster::NodeCluster;
 
-macro_rules! panic_on_rpc_error {
-    ($e:expr) => {
-        if !serde_json::to_string(&$e.data.clone().unwrap_or_default())
-            .unwrap()
-            .contains("IsSyncing")
-        {
-            panic!("{:?}", $e)
-        }
-    };
-}
-
 #[test]
 fn test_get_validator_info_rpc() {
     init_integration_logger();
@@ -440,11 +429,8 @@ fn test_send_tx_sync_returns_transaction_hash() {
                 let res = view_client.send(GetBlock::latest()).await;
                 if let Ok(Ok(block)) = res {
                     if block.header.height > 10 {
-                        let response = client
-                            .EXPERIMENTAL_broadcast_tx_sync(to_base64(&bytes))
-                            .map_err(|err| panic_on_rpc_error!(err))
-                            .await
-                            .unwrap();
+                        let response =
+                            client.EXPERIMENTAL_broadcast_tx_sync(to_base64(&bytes)).await.unwrap();
                         assert_eq!(response["transaction_hash"], tx_hash.to_string());
                         System::current().stop();
                         break;

--- a/pytest/tests/stress/stress.py
+++ b/pytest/tests/stress/stress.py
@@ -354,8 +354,7 @@ def monkey_transactions(stopped, error, nodes, nonces):
                     for validator_id in shuffled_validator_ids:
                         try:
                             info = nodes[validator_id].send_tx(tx)
-                            if 'error' in info and info['error'][
-                                    'data'] == 'IsSyncing':
+                            if 'error' in info:
                                 pass
 
                             elif 'result' in info:


### PR DESCRIPTION
Since https://github.com/near/nearcore/pull/3059 there no longer is any `IsSyncing` server error respnse.