### PR TITLE
refactor: remove some spurious Serializes

### DIFF
--- a/runtime/near-vm-errors/src/lib.rs
+++ b/runtime/near-vm-errors/src/lib.rs
@@ -5,8 +5,7 @@ use near_account_id::AccountId;
 use near_rpc_error_macro::RpcError;
 use serde::{Deserialize, Serialize};
 
-// TODO: remove serialization derives, once fix compilation caching.
-#[derive(Debug, Clone, PartialEq, Eq, BorshDeserialize, BorshSerialize, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshDeserialize, BorshSerialize)]
 pub enum VMError {
     FunctionCallError(FunctionCallError),
     /// Serialized external error from External trait implementation.
@@ -18,8 +17,8 @@ pub enum VMError {
     CacheError(CacheError),
 }
 
-// TODO(4217): remove serialization derives, once fix compilation caching.
-#[derive(Debug, Clone, PartialEq, Eq, BorshDeserialize, BorshSerialize, Serialize, Deserialize)]
+// TODO(4217): remove borsh serialization derives, once fix compilation caching.
+#[derive(Debug, Clone, PartialEq, Eq, BorshDeserialize, BorshSerialize)]
 pub enum FunctionCallError {
     /// Wasm compilation error
     CompilationError(CompilationError),

--- a/runtime/near-vm-runner-standalone/src/main.rs
+++ b/runtime/near-vm-runner-standalone/src/main.rs
@@ -12,7 +12,7 @@ use crate::script::Script;
 use clap::Clap;
 use near_vm_logic::VMOutcome;
 use near_vm_logic::{mocks::mock_external::Receipt, ProtocolVersion};
-use near_vm_runner::{VMError, VMKind};
+use near_vm_runner::VMKind;
 use serde::{
     de::{MapAccess, Visitor},
     ser::SerializeMap,
@@ -111,7 +111,7 @@ struct CliArgs {
 #[derive(Debug, Clone, Serialize)]
 struct StandaloneOutput {
     pub outcome: Option<VMOutcome>,
-    pub err: Option<VMError>,
+    pub err: Option<String>,
     pub receipts: Vec<Receipt>,
     pub state: State,
 }
@@ -175,7 +175,7 @@ fn main() {
         "{}",
         serde_json::to_string(&StandaloneOutput {
             outcome: outcome.clone(),
-            err,
+            err: err.map(|it| it.to_string()),
             receipts: results.state.get_receipt_create_calls().clone(),
             state: State(results.state.fake_trie),
         })

--- a/runtime/near-vm-runner/src/vm_kind.rs
+++ b/runtime/near-vm-runner/src/vm_kind.rs
@@ -1,11 +1,9 @@
 use borsh::BorshSerialize;
 use near_primitives::checked_feature;
 use near_vm_logic::ProtocolVersion;
-use serde::Serialize;
 use std::hash::Hash;
 
-#[derive(Clone, Copy, Debug, Hash, Serialize, BorshSerialize)]
-#[allow(dead_code)]
+#[derive(Clone, Copy, Debug, Hash, BorshSerialize)]
 // Note, that VMKind is part of serialization protocol, so we cannor remove entries
 // from this list if particular VM reached publically visible networks.
 pub enum VMKind {


### PR DESCRIPTION
We generally want to move away from marking various internal structures
as Serialize -- it's very easy to introduce breakages that way.

In this case, the only reason why we need serialize is to print outcome
in the standalone runner, but we can just to-string it.

Test Plan
-------------

Pure refactoring, existing tests should suffice. 