### PR TITLE
feat: when logging tracing spans, display both start and end events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5348,9 +5348,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.17"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
+checksum = "46125608c26121c81b0c6d693eab5a420e416da7e43c426d2e8f7df8da8a3acf"
 dependencies = [
  "lazy_static",
 ]
@@ -5388,9 +5388,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.16"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ab8966ac3ca27126141f7999361cc97dd6fb4b71da04c02044fa9045d98bb96"
+checksum = "fdd0568dbfe3baf7048b7908d2b32bca0d81cd56bec6d2a8f894b01d74f86be3"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -368,7 +368,10 @@ fn init_logging(verbose: Option<&str>) {
         }
     }
     tracing_subscriber::fmt::Subscriber::builder()
-        .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
+        .with_span_events(
+            tracing_subscriber::fmt::format::FmtSpan::ENTER
+                | tracing_subscriber::fmt::format::FmtSpan::CLOSE,
+        )
         .with_env_filter(env_filter)
         .with_writer(io::stderr)
         .init();


### PR DESCRIPTION
We are trying to embrace tracing spans for logging:


    let _span = tracing::debug_span(target: "vm", "frobnicate");
    // code for frobnicate

Logically, a span produces two events -- start and stop. At the time of
`stop`, we also know how long the span took to complete, which is
invaluable for accessing systems performance.

Before, we were only logging span closing events, as they contain this
timing data. The two problems there are:

* ordering is a bit counter-intuitive -- you get log output *after* the fact
* if the process aborts without dropping the spans, the events don't get
  printed

So here we change the logic to produce two log-lines per span:

* once we enter the span (which contains just the name)
* once we exit the span (which contains the timing information)

Exmample output before:

```
  Oct 01 14:59:04.205 DEBUG run_vm{vm_kind=Wasmer0}:run_wasmer:get_key: vm: close time.busy=32.1µs time.idle=5.95µs
  Oct 01 14:59:04.485 DEBUG run_vm{vm_kind=Wasmer0}:run_wasmer:compile_and_serialize_wasmer: vm: close time.busy=280ms time.idle=13.5µs
  Oct 01 14:59:04.488 DEBUG run_vm{vm_kind=Wasmer0}:run_wasmer:run_method:run_method/instantiate: vm: close time.busy=2.35ms time.idle=6.26µs
  Oct 01 14:59:04.488 DEBUG run_vm{vm_kind=Wasmer0}:run_wasmer:run_method:run_method/call: vm: close time.busy=125µs time.idle=7.84µs
  Oct 01 14:59:04.489 DEBUG run_vm{vm_kind=Wasmer0}:run_wasmer:run_method:run_method/drop_instance: vm: close time.busy=1.10ms time.idle=6.88µs
  Oct 01 14:59:04.489 DEBUG run_vm{vm_kind=Wasmer0}:run_wasmer:run_method: vm: close time.busy=3.77ms time.idle=9.01µs
  Oct 01 14:59:04.489 DEBUG run_vm{vm_kind=Wasmer0}:run_wasmer: vm: close time.busy=284ms time.idle=7.02µs
  Oct 01 14:59:04.489 DEBUG run_vm{vm_kind=Wasmer0}: vm: close time.busy=284ms time.idle=21.6µs
```

Example output after:

```
  Oct 01 14:59:36.863 DEBUG run_vm{vm_kind=Wasmer0}: vm: enter
  Oct 01 14:59:36.863 DEBUG run_vm{vm_kind=Wasmer0}:run_wasmer: vm: enter
  Oct 01 14:59:36.863 DEBUG run_vm{vm_kind=Wasmer0}:run_wasmer:get_key: vm: enter
  Oct 01 14:59:36.864 DEBUG run_vm{vm_kind=Wasmer0}:run_wasmer:get_key: vm: close time.busy=66.7µs time.idle=7.00µs
  Oct 01 14:59:36.864 DEBUG run_vm{vm_kind=Wasmer0}:run_wasmer:compile_and_serialize_wasmer: vm: enter
  Oct 01 14:59:37.146 DEBUG run_vm{vm_kind=Wasmer0}:run_wasmer:compile_and_serialize_wasmer: vm: close time.busy=282ms time.idle=12.4µs
  Oct 01 14:59:37.146 DEBUG run_vm{vm_kind=Wasmer0}:run_wasmer:run_method: vm: enter
  Oct 01 14:59:37.146 DEBUG run_vm{vm_kind=Wasmer0}:run_wasmer:run_method:run_method/instantiate: vm: enter
  Oct 01 14:59:37.149 DEBUG run_vm{vm_kind=Wasmer0}:run_wasmer:run_method:run_method/instantiate: vm: close time.busy=2.41ms time.idle=7.53µs
  Oct 01 14:59:37.149 DEBUG run_vm{vm_kind=Wasmer0}:run_wasmer:run_method:run_method/call: vm: enter
  Oct 01 14:59:37.149 DEBUG run_vm{vm_kind=Wasmer0}:run_wasmer:run_method:run_method/call: vm: close time.busy=150µs time.idle=7.97µs
  Oct 01 14:59:37.149 DEBUG run_vm{vm_kind=Wasmer0}:run_wasmer:run_method:run_method/drop_instance: vm: enter
  Oct 01 14:59:37.150 DEBUG run_vm{vm_kind=Wasmer0}:run_wasmer:run_method:run_method/drop_instance: vm: close time.busy=1.16ms time.idle=7.50µs
  Oct 01 14:59:37.150 DEBUG run_vm{vm_kind=Wasmer0}:run_wasmer:run_method: vm: close time.busy=3.97ms time.idle=8.39µs
  Oct 01 14:59:37.150 DEBUG run_vm{vm_kind=Wasmer0}:run_wasmer: vm: close time.busy=287ms time.idle=6.66µs
  Oct 01 14:59:37.150 DEBUG run_vm{vm_kind=Wasmer0}: vm: close time.busy=287ms time.idle=22.7µs
```

This is 2x more verbose, which is not super great, but seems like a fine
tradeoff to me. We'll probably want to reduce the overall verbosity in
the future by configuring logs emitter to not print all the nested spans
each time.

Note that we need to upgrade `tracing` to get the opening span events

Test Plan
---------

Manually verify that new logging works. 