### PR TITLE
Integration test for sharding upgrade

### DIFF
--- a/chain/chain/src/migrations.rs
+++ b/chain/chain/src/migrations.rs
@@ -28,8 +28,13 @@ pub fn check_if_block_is_first_with_chunk_of_version(
     // to avoid get_epoch_id_of_last_block_with_chunk call in the opposite case
     if is_first_epoch_with_protocol_version(runtime_adapter, prev_block_hash)? {
         // Compare only epochs because we already know that current epoch is the first one with current protocol version
-        let prev_epoch_id =
-            chain_store.get_epoch_id_of_last_block_with_chunk(prev_block_hash, shard_id)?;
+        // convert shard id to shard id of previous epoch because number of shards may change
+        let shard_id = runtime_adapter.get_prev_shard_ids(&prev_block_hash, vec![shard_id])?[0];
+        let prev_epoch_id = chain_store.get_epoch_id_of_last_block_with_chunk(
+            runtime_adapter,
+            prev_block_hash,
+            shard_id,
+        )?;
         let epoch_id = runtime_adapter.get_epoch_id_from_prev_block(prev_block_hash)?;
         Ok(prev_epoch_id != epoch_id)
     } else {

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -286,16 +286,19 @@ pub trait ChainStoreAccess {
     /// Get epoch id of the last block with existing chunk for the given shard id.
     fn get_epoch_id_of_last_block_with_chunk(
         &mut self,
+        runtime_adapter: &dyn RuntimeAdapter,
         hash: &CryptoHash,
         shard_id: ShardId,
     ) -> Result<EpochId, Error> {
         let mut candidate_hash = *hash;
+        let mut shard_id = shard_id;
         loop {
             let block_header = self.get_block_header(&candidate_hash)?;
             if block_header.chunk_mask()[shard_id as usize] {
                 break Ok(block_header.epoch_id().clone());
             }
             candidate_hash = *block_header.prev_hash();
+            shard_id = runtime_adapter.get_prev_shard_ids(&candidate_hash, vec![shard_id])?[0];
         }
     }
 }

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1013,7 +1013,7 @@ impl Client {
                     .runtime_adapter
                     .get_epoch_protocol_version(block.header().next_epoch_id()));
                 if next_epoch_protocol_version > PROTOCOL_VERSION {
-                    panic!("The client protocol version is older than the protocol version of the network. Please update nearcore");
+                    panic!("The client protocol version {} is older than the protocol version of the network {}. Please update nearcore", PROTOCOL_VERSION, next_epoch_protocol_version);
                 }
             }
         }

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1013,7 +1013,7 @@ impl Client {
                     .runtime_adapter
                     .get_epoch_protocol_version(block.header().next_epoch_id()));
                 if next_epoch_protocol_version > PROTOCOL_VERSION {
-                    panic!("The client protocol version {} is older than the protocol version of the network {}. Please update nearcore", PROTOCOL_VERSION, next_epoch_protocol_version);
+                    panic!("The client protocol version is older than the protocol version of the network. Please update nearcore");
                 }
             }
         }

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -54,6 +54,7 @@ use crate::{start_view_client, Client, ClientActor, SyncStatus, ViewClientActor}
 use near_chain::chain::{do_apply_chunks, BlockCatchUpRequest};
 use near_chain::types::AcceptedBlock;
 use near_client_primitives::types::Error;
+use near_primitives::utils::MaybeValidated;
 
 pub type NetworkMock = Mocker<PeerManagerActor>;
 
@@ -1105,6 +1106,7 @@ pub struct TestEnv {
     pub validators: Vec<AccountId>,
     pub network_adapters: Vec<Arc<MockNetworkAdapter>>,
     pub clients: Vec<Client>,
+    account_to_client_index: HashMap<AccountId, usize>,
 }
 
 /// A builder for the TestEnv structure.
@@ -1187,14 +1189,14 @@ impl TestEnvBuilder {
     /// configured clients.
     pub fn build(self) -> TestEnv {
         let chain_genesis = self.chain_genesis;
-        let clients = self.clients;
+        let clients = self.clients.clone();
         let num_clients = clients.len();
         let validators = self.validators;
         let num_validators = validators.len();
         let network_adapters = self
             .network_adapters
             .unwrap_or_else(|| (0..num_clients).map(|_| Arc::new(Default::default())).collect());
-        assert!(clients.len() == network_adapters.len());
+        assert_eq!(clients.len(), network_adapters.len());
         let clients = match self.runtime_adapters {
             None => clients
                 .into_iter()
@@ -1232,7 +1234,18 @@ impl TestEnvBuilder {
             }
         };
 
-        TestEnv { chain_genesis, validators, network_adapters, clients }
+        TestEnv {
+            chain_genesis,
+            validators,
+            network_adapters,
+            clients,
+            account_to_client_index: self
+                .clients
+                .into_iter()
+                .enumerate()
+                .map(|(index, client)| (client, index))
+                .collect(),
+        }
     }
 
     fn make_accounts(count: usize) -> Vec<AccountId> {
@@ -1266,6 +1279,36 @@ impl TestEnv {
     pub fn produce_block(&mut self, id: usize, height: BlockHeight) {
         let block = self.clients[id].produce_block(height).unwrap();
         self.process_block(id, block.unwrap(), Provenance::PRODUCED);
+    }
+
+    pub fn client(&mut self, account_id: &AccountId) -> &mut Client {
+        &mut self.clients[self.account_to_client_index[account_id]]
+    }
+
+    pub fn process_partial_encoded_chunks(&mut self) {
+        let network_adapters = self.network_adapters.clone();
+        for network_adapter in network_adapters {
+            // process partial encoded chunks
+            loop {
+                if let Some(request) = network_adapter.pop() {
+                    match request {
+                        NetworkRequests::PartialEncodedChunkMessage {
+                            account_id,
+                            partial_encoded_chunk,
+                        } => {
+                            self.client(&account_id)
+                                .process_partial_encoded_chunk(MaybeValidated::NotValidated(
+                                    partial_encoded_chunk.into(),
+                                ))
+                                .unwrap();
+                        }
+                        _ => {}
+                    }
+                } else {
+                    break;
+                }
+            }
+        }
     }
 
     pub fn send_money(&mut self, id: usize) -> NetworkClientResponses {

--- a/core/store/src/test_utils.rs
+++ b/core/store/src/test_utils.rs
@@ -49,7 +49,7 @@ pub fn test_populate_trie(
 }
 
 pub fn gen_accounts(rng: &mut impl Rng, max_size: usize) -> Vec<AccountId> {
-    let alphabet = &b"abcdefgh"[0..rng.gen_range(4, 8)];
+    let alphabet = b"abcdefghijklmn";
     let size = rng.gen_range(0, max_size) + 1;
 
     let mut accounts = vec![];

--- a/integration-tests/tests/client/main.rs
+++ b/integration-tests/tests/client/main.rs
@@ -5,3 +5,5 @@ mod process_blocks;
 mod runtimes;
 #[cfg(feature = "sandbox")]
 mod sandbox;
+#[cfg(feature = "protocol_feature_simple_nightshade")]
+mod sharding_upgrade;

--- a/integration-tests/tests/client/process_blocks.rs
+++ b/integration-tests/tests/client/process_blocks.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "protocol_feature_simple_nightshade")]
-use std::collections::HashMap;
 use std::collections::{HashSet, VecDeque};
 use std::convert::TryFrom;
 use std::iter::FromIterator;
@@ -21,8 +19,6 @@ use near_chain::{
 };
 use near_chain_configs::{ClientConfig, Genesis};
 use near_chunks::{ChunkStatus, ShardsManager};
-#[cfg(feature = "protocol_feature_simple_nightshade")]
-use near_client::test_utils::create_chunk_on_height_for_shard;
 use near_client::test_utils::{
     create_chunk_on_height, run_catchup, setup_client, setup_mock, setup_mock_all_validators,
     TestEnv,
@@ -40,8 +36,6 @@ use near_primitives::block::{Approval, ApprovalInner};
 use near_primitives::block_header::BlockHeader;
 
 use near_network::routing::EdgeInfo;
-#[cfg(feature = "protocol_feature_simple_nightshade")]
-use near_primitives::epoch_manager::ShardConfig;
 use near_primitives::errors::InvalidTxError;
 use near_primitives::errors::TxExecutionError;
 use near_primitives::hash::{hash, CryptoHash};
@@ -49,8 +43,6 @@ use near_primitives::merkle::verify_hash;
 use near_primitives::receipt::DelayedReceiptIndices;
 use near_primitives::runtime::config_store::RuntimeConfigStore;
 use near_primitives::shard_layout::ShardUId;
-#[cfg(feature = "protocol_feature_simple_nightshade")]
-use near_primitives::shard_layout::{account_id_to_shard_uid, ShardLayout};
 #[cfg(not(feature = "protocol_feature_block_header_v3"))]
 use near_primitives::sharding::ShardChunkHeaderV2;
 use near_primitives::sharding::{EncodedShardChunk, ReedSolomonWrapper, ShardChunkHeader};
@@ -64,10 +56,8 @@ use near_primitives::transaction::{
 use near_primitives::trie_key::TrieKey;
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{AccountId, BlockHeight, EpochId, NumBlocks, ProtocolVersion};
-use near_primitives::utils::{to_timestamp, MaybeValidated};
+use near_primitives::utils::to_timestamp;
 use near_primitives::validator_signer::{InMemoryValidatorSigner, ValidatorSigner};
-#[cfg(feature = "protocol_feature_simple_nightshade")]
-use near_primitives::version::ProtocolFeature;
 use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives::views::{
     BlockHeaderView, FinalExecutionStatus, QueryRequest, QueryResponseKind,
@@ -75,13 +65,11 @@ use near_primitives::views::{
 use near_store::db::DBCol::ColStateParts;
 use near_store::get;
 use near_store::test_utils::create_test_store;
-#[cfg(feature = "protocol_feature_simple_nightshade")]
-use near_store::test_utils::gen_accounts;
 use nearcore::config::{GenesisExt, TESTING_INIT_BALANCE, TESTING_INIT_STAKE};
 use nearcore::NEAR_BASE;
 use rand::Rng;
 
-fn set_block_protocol_version(
+pub fn set_block_protocol_version(
     block: &mut Block,
     block_producer: AccountId,
     protocol_version: ProtocolVersion,
@@ -2593,208 +2581,6 @@ fn test_refund_receipts_processing() {
         assert!(chunk_extra.gas_used() >= chunk_extra.gas_limit());
     }
     assert_eq!(processed_refund_receipt_ids, refund_receipt_ids);
-}
-
-#[test]
-#[cfg(feature = "protocol_feature_simple_nightshade")]
-fn test_shard_layout_upgrade() {
-    init_test_logger();
-    let epoch_length = 5;
-    let mut rng = rand::thread_rng();
-    let mut account_ids = vec!["test0".parse().unwrap(), "test1".parse().unwrap()];
-    account_ids.extend(gen_accounts(&mut rng, 100).into_iter().collect::<HashSet<_>>());
-    let mut genesis = Genesis::test(account_ids.clone(), 2);
-    let simple_nightshade_protocol_version = ProtocolFeature::SimpleNightshade.protocol_version();
-    genesis.config.epoch_length = epoch_length;
-    genesis.config.protocol_version = simple_nightshade_protocol_version - 1;
-    let new_num_shards = 4;
-    let simple_nightshade_shard_layout = ShardLayout::v1(
-        vec!["test0"].into_iter().map(|s| s.parse().unwrap()).collect(),
-        vec!["abc", "foo"].into_iter().map(|s| s.parse().unwrap()).collect(),
-        Some(vec![vec![0, 1, 2, 3]]),
-        1,
-    );
-    genesis.config.simple_nightshade_shard_config = Some(ShardConfig {
-        num_block_producer_seats_per_shard: vec![2; new_num_shards],
-        avg_hidden_validator_seats_per_shard: vec![0; new_num_shards],
-        shard_layout: simple_nightshade_shard_layout.clone(),
-    });
-    let genesis_height = genesis.config.genesis_height;
-    let chain_genesis = ChainGenesis::from(&genesis);
-    let network_adapter = Arc::new(MockNetworkAdapter::default());
-    let mut env = TestEnv::builder(chain_genesis)
-        .clients_count(2)
-        .validator_seats(2)
-        .runtime_adapters(create_nightshade_runtimes(&genesis, 2))
-        .network_adapters(vec![network_adapter.clone(), network_adapter.clone()])
-        .build();
-    let account_to_client_index = |account_id: &AccountId| {
-        let index = if account_id.as_ref() == "test0" { 0 } else { 1 };
-        index
-    };
-    // ShardLayout changes at epoch 2
-    // Test that state is caught up correctly at epoch 1 (block height 6-10)
-    for i in 1..=16 {
-        let head = env.clients[0].chain.head().unwrap();
-        let epoch_id = env.clients[0]
-            .runtime_adapter
-            .get_epoch_id_from_prev_block(&head.last_block_hash)
-            .unwrap();
-        let shard_layout = env.clients[0].runtime_adapter.get_shard_layout(&epoch_id).unwrap();
-        println!(
-            "producing block {} {} last block {:?} for epoch id {:?} shards {}",
-            i,
-            head.height + 1,
-            head.last_block_hash,
-            epoch_id,
-            shard_layout.num_shards()
-        );
-
-        // produce chunks
-        for shard_id in 0..shard_layout.num_shards() {
-            let chunk_producer =
-                env.clients[0].runtime_adapter.get_chunk_producer(&epoch_id, i, shard_id).unwrap();
-            let chunk_producer_client = &mut env.clients[account_to_client_index(&chunk_producer)];
-            let (encoded_chunk, merkle_paths, receipts) =
-                create_chunk_on_height_for_shard(chunk_producer_client, i, shard_id);
-            let mut chain_store =
-                ChainStore::new(chunk_producer_client.chain.store().owned_store(), genesis_height);
-            chunk_producer_client
-                .shards_mgr
-                .distribute_encoded_chunk(
-                    encoded_chunk.clone(),
-                    merkle_paths.clone(),
-                    receipts.clone(),
-                    &mut chain_store,
-                )
-                .unwrap();
-        }
-
-        // process partial encoded chunks
-        loop {
-            if let Some(request) = network_adapter.pop() {
-                match request {
-                    NetworkRequests::PartialEncodedChunkMessage {
-                        account_id,
-                        partial_encoded_chunk,
-                    } => {
-                        let client = &mut env.clients[account_to_client_index(&account_id)];
-                        client
-                            .process_partial_encoded_chunk(MaybeValidated::NotValidated(
-                                partial_encoded_chunk.into(),
-                            ))
-                            .unwrap();
-                    }
-                    _ => {}
-                }
-            } else {
-                break;
-            }
-        }
-
-        // produce block
-        let block_producer =
-            env.clients[0].runtime_adapter.get_block_producer(&epoch_id, i).unwrap();
-        let block_producer_client = &mut env.clients[account_to_client_index(&block_producer)];
-        let mut block = block_producer_client.produce_block(i).unwrap().unwrap();
-        // upgrade to new protocol version but in the second epoch one node vote for the old version.
-        if i != 10 {
-            set_block_protocol_version(
-                &mut block,
-                block_producer.clone(),
-                simple_nightshade_protocol_version,
-            );
-        }
-
-        // process block
-        for j in 0..2 {
-            let (accepted_blocks, res) =
-                env.clients[j].process_block(block.clone(), Provenance::NONE);
-            for accepted_block in accepted_blocks {
-                let new_height =
-                    env.clients[j].chain.get_block(&accepted_block.hash).unwrap().header().height();
-                if accepted_block.status.is_new_head() {
-                    env.clients[j].shards_mgr.update_largest_seen_height(new_height);
-                }
-            }
-            assert!(res.is_ok(), "{:?}", res);
-            run_catchup(&mut env.clients[j], &vec![]).unwrap();
-        }
-
-        // after state split, check chunk extra exists and the states are correct
-        if i >= 6 {
-            let mut state_roots = HashMap::new();
-
-            for account_id in &account_ids {
-                let shard_uid =
-                    account_id_to_shard_uid(account_id, &simple_nightshade_shard_layout);
-                for j in 0..2 {
-                    if env.clients[j].runtime_adapter.cares_about_shard(
-                        None,
-                        block.header().prev_hash(),
-                        shard_uid.shard_id(),
-                        true,
-                    ) {
-                        if !state_roots.contains_key(&shard_uid) {
-                            let chunk_extra = env.clients[j]
-                                .chain
-                                .get_chunk_extra(block.hash(), &shard_uid)
-                                .unwrap();
-                            state_roots.insert(shard_uid.clone(), chunk_extra.state_root().clone());
-                        }
-                        env.clients[j]
-                            .runtime_adapter
-                            .query(
-                                shard_uid,
-                                &state_roots[&shard_uid],
-                                block.header().height(),
-                                0,
-                                block.header().prev_hash(),
-                                block.hash(),
-                                block.header().epoch_id(),
-                                &QueryRequest::ViewAccount { account_id: account_id.clone() },
-                            )
-                            .unwrap();
-                    }
-                }
-            }
-        }
-    }
-
-    let head = env.clients[0].chain.head().unwrap();
-    let block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap().clone();
-    for chunk in block.chunks().iter() {
-        assert_eq!(block.header().height(), chunk.height_included());
-    }
-    for account_id in &account_ids {
-        let shard_uid = account_id_to_shard_uid(account_id, &simple_nightshade_shard_layout);
-        for j in 0..2 {
-            if env.clients[j].runtime_adapter.cares_about_shard(
-                None,
-                block.header().prev_hash(),
-                shard_uid.shard_id(),
-                true,
-            ) {
-                env.clients[j]
-                    .runtime_adapter
-                    .query(
-                        shard_uid,
-                        &block
-                            .chunks()
-                            .get(shard_uid.shard_id() as usize)
-                            .unwrap()
-                            .prev_state_root(),
-                        block.header().height(),
-                        0,
-                        block.header().prev_hash(),
-                        block.hash(),
-                        block.header().epoch_id(),
-                        &QueryRequest::ViewAccount { account_id: account_id.clone() },
-                    )
-                    .unwrap();
-            }
-        }
-    }
 }
 
 #[test]

--- a/integration-tests/tests/client/sharding_upgrade.rs
+++ b/integration-tests/tests/client/sharding_upgrade.rs
@@ -24,6 +24,7 @@ fn test_shard_layout_upgrade() {
     account_ids.extend(gen_accounts(&mut rng, 100).into_iter().collect::<HashSet<_>>());
     let mut genesis = Genesis::test(account_ids.clone(), 2);
     let simple_nightshade_protocol_version = ProtocolFeature::SimpleNightshade.protocol_version();
+    genesis.config.chunk_producer_kickout_threshold = 50;
     genesis.config.epoch_length = epoch_length;
     genesis.config.protocol_version = simple_nightshade_protocol_version - 1;
     let new_num_shards = 4;

--- a/integration-tests/tests/client/sharding_upgrade.rs
+++ b/integration-tests/tests/client/sharding_upgrade.rs
@@ -1,0 +1,219 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use crate::process_blocks::{create_nightshade_runtimes, set_block_protocol_version};
+use near_chain::{ChainGenesis, ChainStore, Provenance};
+use near_chain_configs::Genesis;
+use near_client::test_utils::{create_chunk_on_height_for_shard, run_catchup, TestEnv};
+use near_logger_utils::init_test_logger;
+use near_network::test_utils::MockNetworkAdapter;
+use near_network::NetworkRequests;
+use near_primitives::account::id::AccountId;
+use near_primitives::epoch_manager::ShardConfig;
+use near_primitives::shard_layout::{account_id_to_shard_uid, ShardLayout};
+use near_primitives::utils::MaybeValidated;
+use near_primitives::version::ProtocolFeature;
+use near_primitives::views::QueryRequest;
+use near_store::test_utils::gen_accounts;
+use nearcore::config::GenesisExt;
+
+#[test]
+fn test_shard_layout_upgrade() {
+    init_test_logger();
+    let epoch_length = 5;
+    let mut rng = rand::thread_rng();
+    let mut account_ids = vec!["test0".parse().unwrap(), "test1".parse().unwrap()];
+    account_ids.extend(gen_accounts(&mut rng, 100).into_iter().collect::<HashSet<_>>());
+    let mut genesis = Genesis::test(account_ids.clone(), 2);
+    let simple_nightshade_protocol_version = ProtocolFeature::SimpleNightshade.protocol_version();
+    genesis.config.epoch_length = epoch_length;
+    genesis.config.protocol_version = simple_nightshade_protocol_version - 1;
+    let new_num_shards = 4;
+    let simple_nightshade_shard_layout = ShardLayout::v1(
+        vec!["test0"].into_iter().map(|s| s.parse().unwrap()).collect(),
+        vec!["abc", "foo"].into_iter().map(|s| s.parse().unwrap()).collect(),
+        Some(vec![vec![0, 1, 2, 3]]),
+        1,
+    );
+    genesis.config.simple_nightshade_shard_config = Some(ShardConfig {
+        num_block_producer_seats_per_shard: vec![2; new_num_shards],
+        avg_hidden_validator_seats_per_shard: vec![0; new_num_shards],
+        shard_layout: simple_nightshade_shard_layout.clone(),
+    });
+    let genesis_height = genesis.config.genesis_height;
+    let chain_genesis = ChainGenesis::from(&genesis);
+    let network_adapter = Arc::new(MockNetworkAdapter::default());
+    let mut env = TestEnv::builder(chain_genesis)
+        .clients_count(2)
+        .validator_seats(2)
+        .runtime_adapters(create_nightshade_runtimes(&genesis, 2))
+        .network_adapters(vec![network_adapter.clone(), network_adapter.clone()])
+        .build();
+    let account_to_client_index = |account_id: &AccountId| {
+        let index = if account_id.as_ref() == "test0" { 0 } else { 1 };
+        index
+    };
+    // ShardLayout changes at epoch 2
+    // Test that state is caught up correctly at epoch 1 (block height 6-10)
+    for i in 1..=16 {
+        let head = env.clients[0].chain.head().unwrap();
+        let epoch_id = env.clients[0]
+            .runtime_adapter
+            .get_epoch_id_from_prev_block(&head.last_block_hash)
+            .unwrap();
+        let shard_layout = env.clients[0].runtime_adapter.get_shard_layout(&epoch_id).unwrap();
+        println!(
+            "producing block {} {} last block {:?} for epoch id {:?} shards {}",
+            i,
+            head.height + 1,
+            head.last_block_hash,
+            epoch_id,
+            shard_layout.num_shards()
+        );
+
+        // produce chunks
+        for shard_id in 0..shard_layout.num_shards() {
+            let chunk_producer =
+                env.clients[0].runtime_adapter.get_chunk_producer(&epoch_id, i, shard_id).unwrap();
+            let chunk_producer_client = &mut env.clients[account_to_client_index(&chunk_producer)];
+            let (encoded_chunk, merkle_paths, receipts) =
+                create_chunk_on_height_for_shard(chunk_producer_client, i, shard_id);
+            let mut chain_store =
+                ChainStore::new(chunk_producer_client.chain.store().owned_store(), genesis_height);
+            chunk_producer_client
+                .shards_mgr
+                .distribute_encoded_chunk(
+                    encoded_chunk.clone(),
+                    merkle_paths.clone(),
+                    receipts.clone(),
+                    &mut chain_store,
+                )
+                .unwrap();
+        }
+
+        // process partial encoded chunks
+        loop {
+            if let Some(request) = network_adapter.pop() {
+                match request {
+                    NetworkRequests::PartialEncodedChunkMessage {
+                        account_id,
+                        partial_encoded_chunk,
+                    } => {
+                        let client = &mut env.clients[account_to_client_index(&account_id)];
+                        client
+                            .process_partial_encoded_chunk(MaybeValidated::NotValidated(
+                                partial_encoded_chunk.into(),
+                            ))
+                            .unwrap();
+                    }
+                    _ => {}
+                }
+            } else {
+                break;
+            }
+        }
+
+        // produce block
+        let block_producer =
+            env.clients[0].runtime_adapter.get_block_producer(&epoch_id, i).unwrap();
+        let block_producer_client = &mut env.clients[account_to_client_index(&block_producer)];
+        let mut block = block_producer_client.produce_block(i).unwrap().unwrap();
+        // upgrade to new protocol version but in the second epoch one node vote for the old version.
+        if i != 10 {
+            set_block_protocol_version(
+                &mut block,
+                block_producer.clone(),
+                simple_nightshade_protocol_version,
+            );
+        }
+
+        // process block
+        for j in 0..2 {
+            let (accepted_blocks, res) =
+                env.clients[j].process_block(block.clone(), Provenance::NONE);
+            for accepted_block in accepted_blocks {
+                let new_height =
+                    env.clients[j].chain.get_block(&accepted_block.hash).unwrap().header().height();
+                if accepted_block.status.is_new_head() {
+                    env.clients[j].shards_mgr.update_largest_seen_height(new_height);
+                }
+            }
+            assert!(res.is_ok(), "{:?}", res);
+            run_catchup(&mut env.clients[j], &vec![]).unwrap();
+        }
+
+        // after state split, check chunk extra exists and the states are correct
+        if i >= 6 {
+            let mut state_roots = HashMap::new();
+
+            for account_id in &account_ids {
+                let shard_uid =
+                    account_id_to_shard_uid(account_id, &simple_nightshade_shard_layout);
+                for j in 0..2 {
+                    if env.clients[j].runtime_adapter.cares_about_shard(
+                        None,
+                        block.header().prev_hash(),
+                        shard_uid.shard_id(),
+                        true,
+                    ) {
+                        if !state_roots.contains_key(&shard_uid) {
+                            let chunk_extra = env.clients[j]
+                                .chain
+                                .get_chunk_extra(block.hash(), &shard_uid)
+                                .unwrap();
+                            state_roots.insert(shard_uid.clone(), chunk_extra.state_root().clone());
+                        }
+                        env.clients[j]
+                            .runtime_adapter
+                            .query(
+                                shard_uid,
+                                &state_roots[&shard_uid],
+                                block.header().height(),
+                                0,
+                                block.header().prev_hash(),
+                                block.hash(),
+                                block.header().epoch_id(),
+                                &QueryRequest::ViewAccount { account_id: account_id.clone() },
+                            )
+                            .unwrap();
+                    }
+                }
+            }
+        }
+    }
+
+    let head = env.clients[0].chain.head().unwrap();
+    let block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap().clone();
+    for chunk in block.chunks().iter() {
+        assert_eq!(block.header().height(), chunk.height_included());
+    }
+    for account_id in &account_ids {
+        let shard_uid = account_id_to_shard_uid(account_id, &simple_nightshade_shard_layout);
+        for j in 0..2 {
+            if env.clients[j].runtime_adapter.cares_about_shard(
+                None,
+                block.header().prev_hash(),
+                shard_uid.shard_id(),
+                true,
+            ) {
+                env.clients[j]
+                    .runtime_adapter
+                    .query(
+                        shard_uid,
+                        &block
+                            .chunks()
+                            .get(shard_uid.shard_id() as usize)
+                            .unwrap()
+                            .prev_state_root(),
+                        block.header().height(),
+                        0,
+                        block.header().prev_hash(),
+                        block.hash(),
+                        block.header().epoch_id(),
+                        &QueryRequest::ViewAccount { account_id: account_id.clone() },
+                    )
+                    .unwrap();
+            }
+        }
+    }
+}

--- a/integration-tests/tests/client/sharding_upgrade.rs
+++ b/integration-tests/tests/client/sharding_upgrade.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 use crate::process_blocks::{create_nightshade_runtimes, set_block_protocol_version};
 use near_chain::{ChainGenesis, Provenance};
@@ -6,27 +6,85 @@ use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
 use near_crypto::{InMemorySigner, KeyType, Signer};
 use near_logger_utils::init_test_logger;
+use near_primitives::account::id::AccountId;
+use near_primitives::block::Block;
 use near_primitives::epoch_manager::ShardConfig;
 use near_primitives::shard_layout::{account_id_to_shard_uid, ShardLayout};
 use near_primitives::transaction::SignedTransaction;
+use near_primitives::types::ProtocolVersion;
 use near_primitives::version::ProtocolFeature;
 use near_primitives::views::QueryRequest;
 use near_store::test_utils::gen_accounts;
 use nearcore::config::GenesisExt;
 use nearcore::NEAR_BASE;
 
-#[test]
-fn test_shard_layout_upgrade() {
+const SIMPLE_NIGHTSHADE_PROTOCOL_VERSION: ProtocolVersion =
+    ProtocolFeature::SimpleNightshade.protocol_version();
+
+// Checks that account exists in the state after `block` is processed
+// This function checks both state_root from chunk extra and state root from chunk header, if
+// the corresponding chunk is included in the block
+fn check_account(env: &mut TestEnv, account_id: &AccountId, block: &Block) {
+    let prev_hash = block.header().prev_hash();
+    let shard_layout =
+        env.clients[0].runtime_adapter.get_shard_layout_from_prev_block(prev_hash).unwrap();
+    let shard_uid = account_id_to_shard_uid(account_id, &shard_layout);
+    let shard_id = shard_uid.shard_id();
+    for (i, me) in env.validators.iter().enumerate() {
+        if env.clients[i].runtime_adapter.cares_about_shard(Some(me), prev_hash, shard_id, true) {
+            let state_root = env.clients[i]
+                .chain
+                .get_chunk_extra(block.hash(), &shard_uid)
+                .unwrap()
+                .state_root()
+                .clone();
+            env.clients[i]
+                .runtime_adapter
+                .query(
+                    shard_uid,
+                    &state_root,
+                    block.header().height(),
+                    0,
+                    prev_hash,
+                    block.hash(),
+                    block.header().epoch_id(),
+                    &QueryRequest::ViewAccount { account_id: account_id.clone() },
+                )
+                .unwrap();
+
+            let chunk = &block.chunks()[shard_id as usize];
+            if chunk.height_included() == block.header().height() {
+                env.clients[i]
+                    .runtime_adapter
+                    .query(
+                        shard_uid,
+                        &chunk.prev_state_root(),
+                        block.header().height(),
+                        0,
+                        block.header().prev_hash(),
+                        block.hash(),
+                        block.header().epoch_id(),
+                        &QueryRequest::ViewAccount { account_id: account_id.clone() },
+                    )
+                    .unwrap();
+            }
+        }
+    }
+}
+
+fn setup_test_env(
+    epoch_length: u64,
+    num_clients: usize,
+    num_validators: usize,
+    initial_accounts: Vec<AccountId>,
+) -> TestEnv {
     init_test_logger();
-    let epoch_length = 5;
-    let mut rng = rand::thread_rng();
-    let mut account_ids = vec!["test0".parse().unwrap(), "test1".parse().unwrap()];
-    account_ids.extend(gen_accounts(&mut rng, 100).into_iter().collect::<HashSet<_>>());
-    let mut genesis = Genesis::test(account_ids.clone(), 2);
-    let simple_nightshade_protocol_version = ProtocolFeature::SimpleNightshade.protocol_version();
+    let mut genesis = Genesis::test(initial_accounts, 2);
+    // Set kickout threshold to 50 because chunks in the first block won't be produced (a known issue)
+    // We don't want the validators get kicked out because of that
     genesis.config.chunk_producer_kickout_threshold = 50;
     genesis.config.epoch_length = epoch_length;
-    genesis.config.protocol_version = simple_nightshade_protocol_version - 1;
+    genesis.config.protocol_version = SIMPLE_NIGHTSHADE_PROTOCOL_VERSION - 1;
     let new_num_shards = 4;
     let simple_nightshade_shard_layout = ShardLayout::v1(
         vec!["test0"].into_iter().map(|s| s.parse().unwrap()).collect(),
@@ -34,29 +92,156 @@ fn test_shard_layout_upgrade() {
         Some(vec![vec![0, 1, 2, 3]]),
         1,
     );
+
     genesis.config.simple_nightshade_shard_config = Some(ShardConfig {
         num_block_producer_seats_per_shard: vec![2; new_num_shards],
         avg_hidden_validator_seats_per_shard: vec![0; new_num_shards],
         shard_layout: simple_nightshade_shard_layout.clone(),
     });
     let chain_genesis = ChainGenesis::from(&genesis);
-    let mut env = TestEnv::builder(chain_genesis)
-        .clients_count(2)
-        .validator_seats(2)
+
+    TestEnv::builder(chain_genesis)
+        .clients_count(num_clients)
+        .validator_seats(num_validators)
         .runtime_adapters(create_nightshade_runtimes(&genesis, 2))
-        .build();
+        .build()
+}
+
+/// Test shard layout upgrade. This function runs `env` to produce and process blocks
+/// from 1 to 3 * epoch_length + 1, ie, to the beginning of epoch 3.
+/// Epoch 0: 1 shard
+/// Epoch 1: 1 shard, state split happens
+/// Epoch 2: shard layout upgrades to simple_night_shade_shard,
+/// `init_txs` are added before any block is produced
+/// `txs_before_shard_split` are added before the last block of epoch 0, so they might be included
+/// in the last block of epoch 0, before state split happens
+/// `txs_before_shard_change` are added before the last block of epoch 1, so they might be included
+/// in the last block of epoch 1, before sharding change happens
+/// This functions checks
+/// 1) all transactions are processed successfully
+/// 2) all accounts in `initial_accounts_to_check` always exists in state at every step
+/// 2) all accounts in `final_accounts_to_check` exist in the final state
+fn test_shard_layout_upgrade_helper(
+    env: &mut TestEnv,
+    init_txs: Vec<SignedTransaction>,
+    txs_before_shard_split: Vec<SignedTransaction>,
+    txs_before_shard_change: Vec<SignedTransaction>,
+    initial_accounts_to_check: &[AccountId],
+    final_accounts_to_check: &[AccountId],
+) {
+    let num_validators = env.validators.len();
+    let epoch_length = env.clients[0].config.epoch_length;
+    for tx in init_txs.iter() {
+        for j in 0..num_validators {
+            env.clients[j].process_tx(tx.clone(), false, false);
+        }
+    }
 
     // ShardLayout changes at epoch 2
-    // Test that state is caught up correctly at epoch 1 (block height 6-10)
-    let mut txs = vec![];
-    let mut added_accounts = vec![];
+    // Test that state is caught up correctly at epoch 1 (block height epoch_length+1..=2*epoch_length)
+    for i in 1..=3 * epoch_length + 1 {
+        if i == epoch_length - 1 {
+            for tx in txs_before_shard_split.iter() {
+                for j in 0..num_validators {
+                    env.clients[j].process_tx(tx.clone(), false, false);
+                }
+            }
+        }
+
+        if i == 2 * epoch_length - 1 {
+            for tx in txs_before_shard_change.iter() {
+                for j in 0..num_validators {
+                    env.clients[j].process_tx(tx.clone(), false, false);
+                }
+            }
+        }
+        let head = env.clients[0].chain.head().unwrap();
+        let epoch_id = env.clients[0]
+            .runtime_adapter
+            .get_epoch_id_from_prev_block(&head.last_block_hash)
+            .unwrap();
+
+        // produce block
+        let block_producer =
+            env.clients[0].runtime_adapter.get_block_producer(&epoch_id, i).unwrap();
+        let block_producer_client = env.client(&block_producer);
+        let mut block = block_producer_client.produce_block(i).unwrap().unwrap();
+        set_block_protocol_version(
+            &mut block,
+            block_producer.clone(),
+            SIMPLE_NIGHTSHADE_PROTOCOL_VERSION,
+        );
+        // process block, this also triggers chunk producers for the next block to produce chunks
+        for j in 0..num_validators {
+            env.process_block(j, block.clone(), Provenance::NONE);
+        }
+
+        env.process_partial_encoded_chunks();
+
+        // after state split, check chunk extra exists and the states are correct
+        if i >= epoch_length + 1 {
+            for account_id in initial_accounts_to_check {
+                check_account(env, account_id, &block);
+            }
+        }
+    }
+
+    // check final state has all accounts
+    let head = env.clients[0].chain.head().unwrap();
+    let block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap().clone();
+    for chunk in block.chunks().iter() {
+        assert_eq!(block.header().height(), chunk.height_included());
+    }
+    for account_id in final_accounts_to_check {
+        check_account(env, account_id, &block)
+    }
+
+    // check execution outcomes
+    let mut txs = init_txs;
+    txs.extend(txs_before_shard_split);
+    txs.extend(txs_before_shard_change);
+    let shard_layout = env.clients[0]
+        .runtime_adapter
+        .get_shard_layout_from_prev_block(&head.last_block_hash)
+        .unwrap();
+    for tx in txs.iter() {
+        let id = &tx.get_hash();
+        let account_id = &tx.transaction.signer_id;
+        let shard_uid = account_id_to_shard_uid(account_id, &shard_layout);
+        for (i, account_id) in env.validators.iter().enumerate() {
+            if env.clients[i].runtime_adapter.cares_about_shard(
+                Some(account_id),
+                block.header().prev_hash(),
+                shard_uid.shard_id(),
+                true,
+            ) {
+                let execution_outcome =
+                    env.clients[i].chain.get_final_transaction_result(id).unwrap();
+                assert!(execution_outcome.status.as_success().is_some());
+            }
+        }
+    }
+}
+
+// test some shard layout upgrade with some simple transactions to create accounts
+#[test]
+fn test_shard_layout_upgrade_simple() {
+    let mut rng = rand::thread_rng();
+    let mut initial_accounts = vec!["test0".parse().unwrap(), "test1".parse().unwrap()];
+    initial_accounts.extend(gen_accounts(&mut rng, 100).into_iter().collect::<HashSet<_>>());
+
+    let mut env = setup_test_env(5, 2, 2, initial_accounts.clone());
+
     let mut nonce = 100;
-    for i in 1..=16 {
-        // add some transactions right before state split
-        if i == 4 || i == 10 {
-            let new_accounts = gen_accounts(&mut rng, 100);
+
+    let genesis_hash = env.clients[0].chain.genesis_block().hash().clone();
+    let mut all_accounts = initial_accounts.clone();
+    let generate_create_accounts_txs: &mut dyn FnMut(usize) -> Vec<SignedTransaction> =
+        &mut |max_size: usize| -> Vec<SignedTransaction> {
+            let new_accounts = gen_accounts(&mut rng, max_size);
             let signer0 =
                 InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+            let mut txs = vec![];
             for account_id in new_accounts.iter() {
                 let signer = InMemorySigner::from_seed(
                     account_id.clone(),
@@ -70,141 +255,20 @@ fn test_shard_layout_upgrade() {
                     NEAR_BASE,
                     signer.public_key(),
                     &signer0,
-                    env.clients[0].chain.genesis_block().hash().clone(),
+                    genesis_hash.clone(),
                 );
                 nonce += 1;
-                txs.push(tx.get_hash());
-                added_accounts.push(account_id.clone());
-
-                for j in 0..2 {
-                    env.clients[j].process_tx(tx.clone(), false, false);
-                }
+                txs.push(tx);
+                all_accounts.push(account_id.clone());
             }
-        }
-
-        let head = env.clients[0].chain.head().unwrap();
-        let epoch_id = env.clients[0]
-            .runtime_adapter
-            .get_epoch_id_from_prev_block(&head.last_block_hash)
-            .unwrap();
-        let shard_layout = env.clients[0].runtime_adapter.get_shard_layout(&epoch_id).unwrap();
-        println!(
-            "producing block {} {} last block {:?} for epoch id {:?} shards {}",
-            i,
-            head.height + 1,
-            head.last_block_hash,
-            epoch_id,
-            shard_layout.num_shards()
-        );
-
-        // produce block
-        let block_producer =
-            env.clients[0].runtime_adapter.get_block_producer(&epoch_id, i).unwrap();
-        let block_producer_client = env.client(&block_producer);
-        let mut block = block_producer_client.produce_block(i).unwrap().unwrap();
-        // upgrade to new protocol version but in the second epoch one node vote for the old version.
-        if i != 10 {
-            set_block_protocol_version(
-                &mut block,
-                block_producer.clone(),
-                simple_nightshade_protocol_version,
-            );
-        }
-        for j in 0..2 {
-            env.process_block(j, block.clone(), Provenance::NONE);
-        }
-
-        env.process_partial_encoded_chunks();
-
-        // after state split, check chunk extra exists and the states are correct
-        if i >= 6 {
-            let mut state_roots = HashMap::new();
-
-            for account_id in &account_ids {
-                let shard_uid =
-                    account_id_to_shard_uid(account_id, &simple_nightshade_shard_layout);
-                for j in 0..2 {
-                    if env.clients[j].runtime_adapter.cares_about_shard(
-                        None,
-                        block.header().prev_hash(),
-                        shard_uid.shard_id(),
-                        true,
-                    ) {
-                        if !state_roots.contains_key(&shard_uid) {
-                            let chunk_extra = env.clients[j]
-                                .chain
-                                .get_chunk_extra(block.hash(), &shard_uid)
-                                .unwrap();
-                            state_roots.insert(shard_uid.clone(), chunk_extra.state_root().clone());
-                        }
-                        env.clients[j]
-                            .runtime_adapter
-                            .query(
-                                shard_uid,
-                                &state_roots[&shard_uid],
-                                block.header().height(),
-                                0,
-                                block.header().prev_hash(),
-                                block.hash(),
-                                block.header().epoch_id(),
-                                &QueryRequest::ViewAccount { account_id: account_id.clone() },
-                            )
-                            .unwrap();
-                    }
-                }
-            }
-        }
-    }
-
-    let head = env.clients[0].chain.head().unwrap();
-    let block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap().clone();
-    for chunk in block.chunks().iter() {
-        assert_eq!(block.header().height(), chunk.height_included());
-    }
-    for account_id in &account_ids {
-        let shard_uid = account_id_to_shard_uid(account_id, &simple_nightshade_shard_layout);
-        for j in 0..2 {
-            if env.clients[j].runtime_adapter.cares_about_shard(
-                None,
-                block.header().prev_hash(),
-                shard_uid.shard_id(),
-                true,
-            ) {
-                env.clients[j]
-                    .runtime_adapter
-                    .query(
-                        shard_uid,
-                        &block
-                            .chunks()
-                            .get(shard_uid.shard_id() as usize)
-                            .unwrap()
-                            .prev_state_root(),
-                        block.header().height(),
-                        0,
-                        block.header().prev_hash(),
-                        block.hash(),
-                        block.header().epoch_id(),
-                        &QueryRequest::ViewAccount { account_id: account_id.clone() },
-                    )
-                    .unwrap();
-            }
-        }
-    }
-
-    // check execution outcomes
-    for (i, id) in txs.iter().enumerate() {
-        let account_id = &added_accounts[i];
-        let shard_uid = account_id_to_shard_uid(account_id, &simple_nightshade_shard_layout);
-        for j in 0..2 {
-            if env.clients[j].runtime_adapter.cares_about_shard(
-                None,
-                block.header().prev_hash(),
-                shard_uid.shard_id(),
-                true,
-            ) {
-                let execution_outcome = env.clients[0].chain.get_execution_outcome(id).unwrap();
-                assert_eq!(execution_outcome.outcome_with_id.outcome.receipt_ids.len(), 1);
-            }
-        }
-    }
+            txs
+        };
+    test_shard_layout_upgrade_helper(
+        &mut env,
+        vec![],
+        generate_create_accounts_txs(100),
+        generate_create_accounts_txs(100),
+        &initial_accounts,
+        &all_accounts,
+    );
 }


### PR DESCRIPTION
This PR adds an integration test for sharding upgrade. It also fixes function `check_if_block_is_first_with_chunk_of_version` to make it work when number of shards changes.

The integration test tests logic on the client level (no logic in ClientActor is included) and checks that transactions/receipts are processed correctly during sharding upgrade. It also checks that the final after sharding upgrade is correct. 

This PR is a beginning. I will add more tests in the same file using the framework. 