### PR TITLE
CI: make sure neard builds with adversarial feature

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -29,7 +29,7 @@ steps:
       RUSTFLAGS='-D warnings' cargo check --workspace --all-targets --all-features
       RUSTFLAGS='-D warnings' cargo check -p neard
       RUSTFLAGS='-D warnings' cargo check -p neard --features nightly_protocol,nightly_protocol_features
-      # build a sandbox node should succeed
+      RUSTFLAGS='-D warnings' cargo check -p neard --features adversarial
       RUSTFLAGS='-D warnings' cargo check -p neard --features sandbox
       python3 scripts/state/update_res.py check
       python3 scripts/check_nightly.py

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -27,10 +27,10 @@ steps:
         cargo-deny --all-features check bans
       fi
       RUSTFLAGS='-D warnings' cargo check --workspace --all-targets --all-features
-      RUSTFLAGS='-D warnings' cargo check -p neard
       RUSTFLAGS='-D warnings' cargo check -p neard --features nightly_protocol,nightly_protocol_features
       RUSTFLAGS='-D warnings' cargo check -p neard --features adversarial
       RUSTFLAGS='-D warnings' cargo check -p neard --features sandbox
+      RUSTFLAGS='-D warnings' cargo check -p neard
       python3 scripts/state/update_res.py check
       python3 scripts/check_nightly.py
       python3 scripts/check_pytests.py


### PR DESCRIPTION
This shouldn’t add more than around 30s to the ‘sanity checks’ CI step
(so a bit less than 10% of current run time) which is hardly the
critical step (‘sanity checks’ take less than six minutes while
running tests takes over twenty).

Issue: https://github.com/near/nearcore/issues/4893