### PR TITLE
Fix various minor documentation warnings

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2632,7 +2632,7 @@ impl Chain {
     /// For example, if `prev_block` has two shards 0, 1 and the block after `prev_block` will have
     /// 4 shards 0, 1, 2, 3, 0 and 1 split from shard 0 and 2 and 3 split from shard 1.
     /// `get_prev_chunks(runtime_adapter, prev_block)` will return
-    /// [prev_block.chunks()[0], prev_block.chunks()[0], prev_block.chunks()[1], prev_block.chunks()[1]]
+    /// `[prev_block.chunks()[0], prev_block.chunks()[0], prev_block.chunks()[1], prev_block.chunks()[1]]`
     pub fn get_prev_chunk_headers(
         runtime_adapter: &dyn RuntimeAdapter,
         prev_block: &Block,

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -457,7 +457,7 @@ impl ChainStore {
     /// changes very rarely.
     /// But we need to implement a more theoretically correct algorithm if shard layouts will change
     /// more often in the future
-    /// https://github.com/near/nearcore/issues/4877
+    /// <https://github.com/near/nearcore/issues/4877>
     pub fn get_outgoing_receipts_for_shard(
         &mut self,
         runtime_adapter: &dyn RuntimeAdapter,

--- a/chain/chain/src/validate.rs
+++ b/chain/chain/src/validate.rs
@@ -93,7 +93,7 @@ pub fn validate_chunk_proofs(
 }
 
 /// Validates that the given transactions are in proper valid order.
-/// See https://nomicon.io/ChainSpec/Transactions.html#transaction-ordering
+/// See <https://nomicon.io/ChainSpec/Transactions.html#transaction-ordering>
 pub fn validate_transactions_order(transactions: &[SignedTransaction]) -> bool {
     let mut nonces: HashMap<(&AccountId, &PublicKey), Nonce> = HashMap::new();
     let mut batches: HashMap<(&AccountId, &PublicKey), usize> = HashMap::new();
@@ -380,7 +380,8 @@ fn validate_chunk_state_challenge(
     }
 }
 
-/// Returns Some(block hash, vec![account_id]) of invalid block and who to slash if challenge is correct and None if incorrect.
+/// Returns `Some(block_hash, vec![account_id])` of invalid block and who to
+/// slash if challenge is correct and None if incorrect.
 pub fn validate_challenge(
     runtime_adapter: &dyn RuntimeAdapter,
     epoch_id: &EpochId,

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -1158,10 +1158,11 @@ impl TestEnvBuilder {
     }
 
     /// Specifies custom runtime adaptors for each client.  This allows us to
-    /// construct [`TestEnv`] with [`NightshadeRuntime`].
+    /// construct [`TestEnv`] with `NightshadeRuntime`.
     ///
     /// The vector must have the same number of elements as they are clients
-    /// (one by default).  If that does not hold, [`build`] method will panic.
+    /// (one by default).  If that does not hold, [`Self::build`] method will
+    /// panic.
     pub fn runtime_adapters(mut self, adapters: Vec<Arc<dyn RuntimeAdapter>>) -> Self {
         self.runtime_adapters = Some(adapters);
         self
@@ -1170,7 +1171,8 @@ impl TestEnvBuilder {
     /// Specifies custom network adaptors for each client.
     ///
     /// The vector must have the same number of elements as they are clients
-    /// (one by default).  If that does not hold, [`build`] method will panic.
+    /// (one by default).  If that does not hold, [`Self::build`] method will
+    /// panic.
     pub fn network_adapters(mut self, adapters: Vec<Arc<MockNetworkAdapter>>) -> Self {
         self.network_adapters = Some(adapters);
         self

--- a/chain/epoch_manager/src/reward_calculator.rs
+++ b/chain/epoch_manager/src/reward_calculator.rs
@@ -38,7 +38,7 @@ impl RewardCalculator {
     }
     /// Calculate validator reward for an epoch based on their block and chunk production stats.
     /// Returns map of validators with their rewards and amount of newly minted tokens including to protocol's treasury.
-    /// See spec https://nomicon.io/Economics/README.html#rewards-calculation
+    /// See spec <https://nomicon.io/Economics/README.html#rewards-calculation>.
     pub fn calculate_reward(
         &self,
         validator_block_chunk_stats: HashMap<AccountId, BlockChunkValidatorStats>,

--- a/core/primitives-core/src/config.rs
+++ b/core/primitives-core/src/config.rs
@@ -32,7 +32,7 @@ pub struct VMLimitConfig {
 
     /// How tall the stack is allowed to grow?
     ///
-    /// See https://wiki.parity.io/WebAssembly-StackHeight to find out
+    /// See <https://wiki.parity.io/WebAssembly-StackHeight> to find out
     /// how the stack frame cost is calculated.
     pub max_stack_height: u32,
 

--- a/core/primitives-core/src/serialize.rs
+++ b/core/primitives-core/src/serialize.rs
@@ -163,8 +163,8 @@ pub mod u128_dec_format_compatible {
     //! This in an extension to `u128_dec_format` that serves a compatibility layer role to
     //! deserialize u128 from a "small" JSON number (u64).
     //!
-    //! It is unfortunate that we cannot enable "arbitrary_precision" feature in serde_json due to
-    //! a bug: https://github.com/serde-rs/json/issues/505
+    //! It is unfortunate that we cannot enable "arbitrary_precision" feature in
+    //! serde_json due to a bug: <https://github.com/serde-rs/json/issues/505>.
     use serde::{de, Deserialize, Deserializer};
 
     pub use super::u128_dec_format::serialize;

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -102,8 +102,8 @@ impl AllEpochConfig {
     }
 }
 
-/// Additional configuration parameters for the new validator selection algorithm.
-/// See https://github.com/near/NEPs/pull/167 for details
+/// Additional configuration parameters for the new validator selection
+/// algorithm.  See <https://github.com/near/NEPs/pull/167> for details.
 #[derive(Debug, Clone, SmartDefault, PartialEq, Eq)]
 pub struct ValidatorSelectionConfig {
     #[default(300)]

--- a/core/primitives/src/errors.rs
+++ b/core/primitives/src/errors.rs
@@ -107,11 +107,11 @@ impl std::error::Error for StorageError {}
 pub enum InvalidTxError {
     /// Happens if a wrong AccessKey used or AccessKey has not enough permissions
     InvalidAccessKeyError(InvalidAccessKeyError),
-    /// TX signer_id is not a valid AccountId
+    /// TX signer_id is not a valid [`AccountId`]
     InvalidSignerId { signer_id: String },
     /// TX signer_id is not found in a storage
     SignerDoesNotExist { signer_id: AccountId },
-    /// Transaction nonce must be account[access_key].nonce + 1
+    /// Transaction nonce must be `account[access_key].nonce + 1`.
     InvalidNonce { tx_nonce: Nonce, ak_nonce: Nonce },
     /// Transaction nonce is larger than the upper bound given by the block height
     NonceTooLarge { tx_nonce: Nonce, upper_bound: Nonce },
@@ -426,8 +426,9 @@ pub enum ActionErrorKind {
     /// Error occurs when a new `ActionReceipt` created by the `FunctionCall` action fails
     /// receipt validation.
     NewReceiptValidationError(ReceiptValidationError),
-    /// Error occurs when a `CreateAccount` action is called on hex-characters account of length 64.
-    /// See implicit account creation NEP: https://github.com/nearprotocol/NEPs/pull/71
+    /// Error occurs when a `CreateAccount` action is called on hex-characters
+    /// account of length 64.  See implicit account creation NEP:
+    /// <https://github.com/nearprotocol/NEPs/pull/71>.
     OnlyImplicitAccountCreationAllowed { account_id: AccountId },
     /// Delete account whose state is large is temporarily banned.
     DeleteAccountWithLargeState { account_id: AccountId },

--- a/core/primitives/src/runtime/config.rs
+++ b/core/primitives/src/runtime/config.rs
@@ -10,8 +10,8 @@ use crate::types::{AccountId, Balance};
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(default)]
 pub struct RuntimeConfig {
-    /// Amount of yN per byte required to have on the account.
-    /// See https://nomicon.io/Economics/README.html#state-stake for details.
+    /// Amount of yN per byte required to have on the account.  See
+    /// <https://nomicon.io/Economics/README.html#state-stake> for details.
     #[serde(with = "u128_dec_format")]
     pub storage_amount_per_byte: Balance,
     /// Costs of different actions that need to be performed when sending and processing transaction

--- a/core/primitives/src/runtime/mod.rs
+++ b/core/primitives/src/runtime/mod.rs
@@ -15,7 +15,8 @@ pub mod migration_data;
 ///  - Some(insufficient_balance) if account doesn't have enough and how much need to be added,
 ///  - Err(message) if account has invalid storage usage or amount/locked.
 ///
-/// Read details of state staking https://nomicon.io/Economics/README.html#state-stake
+/// Read details of state staking
+/// <https://nomicon.io/Economics/README.html#state-stake>.
 pub fn get_insufficient_storage_stake(
     account: &Account,
     runtime_config: &RuntimeConfig,

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -1276,7 +1276,7 @@ const RS_TTL: u64 = 2 * 1024;
 
 /// Wrapper around reed solomon which occasionally resets the underlying
 /// reed solomon instead to work around the memory leak in reed solomon
-/// implementation https://github.com/darrenldl/reed-solomon-erasure/issues/74.
+/// implementation <https://github.com/darrenldl/reed-solomon-erasure/issues/74>
 pub struct ReedSolomonWrapper {
     rs: ReedSolomon,
     ttl: u64,

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -46,8 +46,9 @@ impl Transaction {
 
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 pub enum Action {
-    /// Create an (sub)account using a transaction `receiver_id` as an ID for a new account
-    /// ID must pass validation rules described here http://nomicon.io/Primitives/Account.html
+    /// Create an (sub)account using a transaction `receiver_id` as an ID for
+    /// a new account ID must pass validation rules described here
+    /// <http://nomicon.io/Primitives/Account.html>.
     CreateAccount(CreateAccountAction),
     /// Sets a Wasm code to a receiver_id
     DeployContract(DeployContractAction),

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -97,7 +97,8 @@ pub enum ProtocolFeature {
     CountRefundReceiptsInGasLimit,
     /// Add `ripemd60` and `ecrecover` host function
     MathExtension,
-    /// Restore receipts that were previously stuck because of https://github.com/near/nearcore/pull/4228
+    /// Restore receipts that were previously stuck because of
+    /// <https://github.com/near/nearcore/pull/4228>.
     RestoreReceiptsAfterFix,
 
     // nightly features

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -333,9 +333,9 @@ pub struct RocksDBOptions {
     warn_treshold: bytesize::ByteSize,
 }
 
-/// Sets [`check_free_space_interval`](RocksDBOptions::check_free_space_interval) to 256,
-/// [`free_space_threshold`](RocksDBOptions::free_space_threshold) to 16 Mb and
-/// [`free_disk_space_warn_threshold`](RocksDBOptions::free_disk_space_warn_threshold) to 256 Mb
+/// Sets [`RocksDBOptions::check_free_space_interval`] to 256,
+/// [`RocksDBOptions::free_disk_space_threshold`] to 16 MB and
+/// [`RocksDBOptions::free_disk_space_warn_threshold`] to 256 MB.
 impl Default for RocksDBOptions {
     fn default() -> Self {
         RocksDBOptions {

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -286,7 +286,8 @@ pub fn migrate_19_to_20(path: &Path, near_config: &NearConfig) {
     set_store_version(&store, 20);
 }
 
-/// This is a one time patch to fix an existing issue in mainnet database (https://github.com/near/near-indexer-for-explorer/issues/110)
+/// This is a one time patch to fix an existing issue in mainnet database
+/// (<https://github.com/near/near-indexer-for-explorer/issues/110>)
 pub fn migrate_22_to_23(path: &Path, near_config: &NearConfig) {
     let store = create_store(path);
     if near_config.client_config.archive && &near_config.genesis.config.chain_id == "mainnet" {
@@ -368,7 +369,8 @@ lazy_static_include::lazy_static_include_bytes! {
     MAINNET_RESTORED_RECEIPTS => "res/mainnet_restored_receipts.json",
 }
 
-/// Put receipts restored in scope of issue https://github.com/near/nearcore/pull/4248 to storage.
+/// Put receipts restored in scope of issue
+/// <https://github.com/near/nearcore/pull/4248> to storage.
 pub fn migrate_23_to_24(path: &Path, near_config: &NearConfig) {
     let store = create_store(path);
     if &near_config.genesis.config.chain_id == "mainnet" {

--- a/runtime/near-vm-logic/src/context.rs
+++ b/runtime/near-vm-logic/src/context.rs
@@ -56,7 +56,7 @@ pub struct VMContext {
     pub random_seed: Vec<u8>,
     /// If Some, it means that execution is made in a view mode and defines its configuration.
     /// View mode means that only read-only operations are allowed.
-    /// See https://nomicon.io/Proposals/0018-view-change-method.html for more details.
+    /// See <https://nomicon.io/Proposals/0018-view-change-method.html> for more details.
     pub view_config: Option<ViewConfig>,
     /// How many `DataReceipt`'s should receive this execution result. This should be empty if
     /// this function call is a part of a batch and it is not the last action.

--- a/runtime/near-vm-logic/src/serde_with.rs
+++ b/runtime/near-vm-logic/src/serde_with.rs
@@ -133,8 +133,8 @@ pub mod u128_dec_format_compatible {
     //! This in an extension to `u128_dec_format` that serves a compatibility layer role to
     //! deserialize u128 from a "small" JSON number (u64).
     //!
-    //! It is unfortunate that we cannot enable "arbitrary_precision" feature in serde_json due to
-    //! a bug: https://github.com/serde-rs/json/issues/505
+    //! It is unfortunate that we cannot enable "arbitrary_precision" feature in
+    //! serde_json due to a bug: <https://github.com/serde-rs/json/issues/505>.
     use serde::{de, Deserialize, Deserializer};
 
     pub use super::u128_dec_format::serialize;

--- a/runtime/near-vm-runner-standalone/src/main.rs
+++ b/runtime/near-vm-runner-standalone/src/main.rs
@@ -1,6 +1,6 @@
 //! See package description.
 //! Usage example:
-//! ```
+//! ```bash
 //! cargo run --package near-vm-runner-standalone --bin near-vm-runner-standalone \
 //! -- --method-name=hello --wasm-file=/tmp/main.wasm
 //! ```


### PR DESCRIPTION
Mostly wrapping URLs in angle brackets and code fragments in backticks
to make `cargo doc` happy.