### PR TITLE
fix: correct #4938

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -391,11 +391,11 @@ impl Chain {
             BlockHeaderV3,
             protocol_version,
             {
-                let validator_stakes = bps.into_iter().map(|(bp, _)| bp).collect();
+                let validator_stakes = bps.into_iter().map(|(bp, _)| bp.into_v1()).collect();
                 Chain::compute_collection_hash(validator_stakes)
             },
             {
-                let validator_stakes = bps.into_iter().map(|(bp, _)| bp.into_v1()).collect();
+                let validator_stakes = bps.into_iter().map(|(bp, _)| bp).collect();
                 Chain::compute_collection_hash(validator_stakes)
             }
         )


### PR DESCRIPTION
#4938 we noticed the buggy behavior *if* the feature is enabled at compile time and changed that to be *always* buggy. Let's fix it to be always correct instead :)  

Side note: I am a bit unnerved that this isn't covered by tests. 