### PR TITLE
Stream dumping of state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4849,7 +4849,9 @@ dependencies = [
  "near-store",
  "nearcore",
  "node-runtime",
+ "serde",
  "serde_json",
+ "tempfile",
  "tracing",
 ]
 

--- a/test-utils/state-viewer/Cargo.toml
+++ b/test-utils/state-viewer/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2018"
 ansi_term = "0.12"
 borsh = "0.9"
 clap = "2.33"
+serde = "1"
+serde_json = "1"
+tempfile = "3"
 tracing = "0.1"
 
 near-chain-configs = { path = "../../core/chain-configs" }
@@ -23,7 +26,6 @@ nearcore = { path = "../../nearcore" }
 near-epoch-manager = { path = "../../chain/epoch_manager" }
 
 [dev-dependencies]
-serde_json = "1"
 near-client = { path = "../../chain/client" }
 
 [features]

--- a/test-utils/state-viewer/src/main.rs
+++ b/test-utils/state-viewer/src/main.rs
@@ -879,10 +879,11 @@ fn main() {
             let height = header.height();
             let home_dir = PathBuf::from(&home_dir);
 
+            let records_path = home_dir.join("records.json");
             let new_genesis =
-                state_dump(runtime, state_roots.clone(), header, &near_config.genesis.config);
+                state_dump(runtime, state_roots.clone(), header, &near_config.genesis.config, records_path);
 
-            let output_path = home_dir.join(Path::new("output.json"));
+            let output_path = home_dir.join("output.json");
             println!(
                 "Saving state at {:?} @ {} into {}",
                 state_roots,


### PR DESCRIPTION
Streaming genesis records to a separate file makes the dumping process work in O(1) memory, regardless of the size of the state.