### PR TITLE
pytest: add testing protocol version to `upgradable.py` test

### DIFF
--- a/pytest/tests/sanity/upgradable.py
+++ b/pytest/tests/sanity/upgradable.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python3
-"""
-First run network with 3 `stable` nodes and 1 `new` node.
-Then start switching `stable` nodes one by one with new nodes.
-At the end run for 3 epochs and observe that current protocol version of the network matches `new` nodes.
-"""
+"""Test if the node is backwards compatible with the latest release."""
 
+import base58
 import os
+import pathlib
+import re
 import subprocess
 import sys
 import time
-import base58
+import typing
 
 sys.path.append('lib')
 
@@ -20,12 +19,56 @@ from utils import wait_for_blocks_or_timeout, load_test_contract, get_near_tempd
 from transaction import sign_deploy_contract_tx, sign_function_call_tx, sign_payment_tx, \
     sign_create_account_tx, sign_delete_account_tx, sign_create_account_with_full_access_key_and_balance_tx
 
+_EXECUTABLES = None
 
-def main():
+
+def get_executables() -> branches.ABExecutables:
+    global _EXECUTABLES
+    if _EXECUTABLES is None:
+        branch = branches.latest_rc_branch()
+        logger.info(f"Latest rc release branch is {branch}")
+        _EXECUTABLES = branches.prepare_ab_test(branch)
+    return _EXECUTABLES
+
+
+def test_protocol_versions() -> None:
+    """Verify that ‘stable’ and ‘current’ protocol versions differ by at most 1.
+
+    Checks whether the protocol number’s used by the latest release and current
+    binary do not differed by more than one.  This is because some protocol
+    features implementations rely on the fact that no protocol version is
+    skipped.  See <https://github.com/near/nearcore/issues/4956>.
+    """
+    executables = get_executables()
+
+    def get_proto_version(exe: pathlib.Path) -> int:
+        line = subprocess.check_output((exe, '--version'), text=True)
+        m = re.search(r'\(release (.*?)\) .* \(protocol ([0-9]+)\)', line)
+        assert m, (f'Unable to extract protocol version number from {exe};\n'
+                   f'Got {line.rstrip()} on standard output')
+        return m.group(1), int(m.group(2))
+
+    stable_release, stable_proto = get_proto_version(executables.stable.neard)
+    curr_release, curr_proto = get_proto_version(executables.current.neard)
+    assert stable_proto == curr_proto or stable_proto + 1 == curr_proto, (
+        f'If changed, protocol version of a new release can increase by at '
+        'most one.\n'
+        f'Got protocol {stable_proto} version in release {stable_release}\n'
+        f'but protocol {curr_proto} version in {curr_release}')
+    logger.info(f'Got proto {stable_proto} in release {stable_release} and '
+                f'and proto {curr_proto} in {curr_release}')
+
+
+def test_upgrade() -> None:
+    """Test that upgrade from ‘stable’ to ‘current’ binary is possible.
+
+    1. Start a network with 3 `stable` nodes and 1 `new` node.
+    2. Start switching `stable` nodes one by one with `new` nodes.
+    3. Run for three epochs and observe that current protocol version of the
+       network matches `new` nodes.
+    """
+    executables = get_executables()
     node_root = get_near_tempdir('upgradable', clean=True)
-    branch = branches.latest_rc_branch()
-    logger.info(f"Latest rc release branch is {branch}")
-    executables = branches.prepare_ab_test(branch)
 
     # Setup local network.
     cmd = (executables.stable.neard, "--home=%s" % node_root, "testnet", "--v",
@@ -119,6 +162,11 @@ def main():
     hex_account_balance = int(
         nodes[0].get_account(hex_account_id)['result']['amount'])
     assert hex_account_balance == 10**25
+
+
+def main():
+    test_protocol_versions()
+    test_upgrade()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Extend the `upgradable.py` test (which is run from CI) to compare
protocol version in the stable and current releases.  The protocol
version is read from the `--version` screen of a `neard` binary.  This
way, the tests verifies the actual versions without having to manually
maintain a ‘current mainnet version’ constant somewhere.

Fixes: https://github.com/near/nearcore/issues/4956