### PR TITLE
enable simple nightshade upgrade on betanet

### DIFF
--- a/core/chain-configs/src/genesis_config.rs
+++ b/core/chain-configs/src/genesis_config.rs
@@ -71,9 +71,6 @@ fn default_num_chunk_only_producer_seats() -> u64 {
 }
 
 fn default_simple_nightshade_shard_layout() -> Option<ShardLayout> {
-    // TODO: uncomment this when we are ready to enable simple nightshade on betanet
-    //       also remember to bump SimpleNightshade protocol version to a higher number
-    /*
     #[cfg(feature = "protocol_feature_simple_nightshade")]
     return Some(ShardLayout::v1(
         vec![],
@@ -85,7 +82,6 @@ fn default_simple_nightshade_shard_layout() -> Option<ShardLayout> {
         1,
     ));
     #[cfg(not(feature = "protocol_feature_simple_nightshade"))]
-     */
     None
 }
 

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -117,12 +117,12 @@ pub enum ProtocolFeature {
     BlockHeaderV3,
     #[cfg(feature = "protocol_feature_alt_bn128")]
     AltBn128,
-    #[cfg(feature = "protocol_feature_simple_nightshade")]
-    SimpleNightshade,
     #[cfg(feature = "protocol_feature_chunk_only_producers")]
     ChunkOnlyProducers,
     #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
     RoutingExchangeAlgorithm,
+    #[cfg(feature = "protocol_feature_simple_nightshade")]
+    SimpleNightshade,
 }
 
 /// Current latest stable version of the protocol.
@@ -133,7 +133,7 @@ pub const PROTOCOL_VERSION: ProtocolVersion = 48;
 
 /// Current latest nightly version of the protocol.
 #[cfg(feature = "nightly_protocol")]
-pub const PROTOCOL_VERSION: ProtocolVersion = 119;
+pub const PROTOCOL_VERSION: ProtocolVersion = 120;
 
 impl ProtocolFeature {
     pub const fn protocol_version(self) -> ProtocolVersion {
@@ -159,12 +159,12 @@ impl ProtocolFeature {
             ProtocolFeature::AltBn128 => 105,
             #[cfg(feature = "protocol_feature_block_header_v3")]
             ProtocolFeature::BlockHeaderV3 => 109,
-            #[cfg(feature = "protocol_feature_simple_nightshade")]
-            ProtocolFeature::SimpleNightshade => 114,
             #[cfg(feature = "protocol_feature_chunk_only_producers")]
             ProtocolFeature::ChunkOnlyProducers => 115,
             #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
             ProtocolFeature::RoutingExchangeAlgorithm => 117,
+            #[cfg(feature = "protocol_feature_simple_nightshade")]
+            ProtocolFeature::SimpleNightshade => 120,
         }
     }
 }


### PR DESCRIPTION
This PR enabled simple nightshade upgrade on betanet

When this change gets picked up by most betanet validators, the simple nightshade upgrade on betanet will be triggered and betanet will transition from one shard to four shards