### PR TITLE
up time limit for block production Closes #4982

### DIFF
--- a/test-utils/runtime-tester/fuzz/fuzz_targets/runtime_fuzzer.rs
+++ b/test-utils/runtime-tester/fuzz/fuzz_targets/runtime_fuzzer.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 fn do_fuzz(scenario: &Scenario) -> Result<(), String> {
     let stats = scenario.run().result.map_err(|e| format!("{}", e))?;
     for block_stats in stats.blocks_stats {
-        if block_stats.block_production_time > Duration::from_secs(1) {
+        if block_stats.block_production_time > Duration::from_secs(3) {
             return Err(format!("block at height {} was produced in {:?}",
                                block_stats.height, block_stats.block_production_time));
         }


### PR DESCRIPTION
Time limit nayduck fuzzing failures are not reproducible, it takes third of the time to run these scenarios on gcp. Thus I would like to up time limit for block production from 1s to 3s.