### PR TITLE
modify shard_upgrade test

### DIFF
--- a/integration-tests/tests/client/sharding_upgrade.rs
+++ b/integration-tests/tests/client/sharding_upgrade.rs
@@ -227,14 +227,10 @@ impl TestShardUpgradeEnv {
                             env.clients[i].chain.get_final_transaction_result(id).unwrap();
 
                         let outcome_status = final_outcome.status.clone();
-                        assert_matches!(
-                            outcome_status,
-                            FinalExecutionStatus::SuccessValue(_),
-                            "{:?}",
-                            final_outcome
-                        );
                         if matches!(outcome_status, FinalExecutionStatus::SuccessValue(_)) {
                             successful_txs.push(tx.get_hash());
+                        } else {
+                            panic!("tx failed {:?}", final_outcome);
                         }
                         for outcome in final_outcome.receipts_outcome {
                             assert_matches!(


### PR DESCRIPTION
Make these tests cover more cases

Previously, all transactions in these tests are sent from one account, this PR makes the transactions sample from different account
Also test processing transactions after the sharding upgrade finishes too, since we hit this bug in loadtest