### PR TITLE
chore(jsonrpc): updated rpc_errors_schema

### DIFF
--- a/chain/jsonrpc/res/rpc_errors_schema.json
+++ b/chain/jsonrpc/res/rpc_errors_schema.json
@@ -316,7 +316,8 @@
         "GasInstrumentation",
         "StackHeightInstrumentation",
         "Instantiate",
-        "Memory"
+        "Memory",
+        "TooManyFunctions"
       ],
       "props": {}
     },
@@ -347,6 +348,11 @@
     },
     "StackOverflow": {
       "name": "StackOverflow",
+      "subtypes": [],
+      "props": {}
+    },
+    "TooManyFunctions": {
+      "name": "TooManyFunctions",
       "subtypes": [],
       "props": {}
     },


### PR DESCRIPTION
Update `rpc_errors_schema.json` after the introduction of `TooManyFunctions` in https://github.com/near/nearcore/pull/4954