### PR TITLE
fix a bug in produce_block regarding shard_id

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -441,6 +441,9 @@ impl Client {
         let prev_block_extra = self.chain.get_block_extra(&prev_hash)?.clone();
         let prev_block = self.chain.get_block(&prev_hash)?;
         let mut chunks = Chain::get_prev_chunk_headers(&*self.runtime_adapter, prev_block)?;
+        for (shard_id, chunk) in chunks.iter_mut().enumerate() {
+            *chunk.shard_id_mut() = shard_id as ShardId;
+        }
 
         // Collect new chunks.
         for (shard_id, mut chunk_header) in new_chunks {

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -438,6 +438,16 @@ impl ShardChunkHeader {
     }
 
     #[inline]
+    pub fn shard_id_mut(&mut self) -> &mut ShardId {
+        match self {
+            Self::V1(header) => &mut header.inner.shard_id,
+            Self::V2(header) => &mut header.inner.shard_id,
+            #[cfg(feature = "protocol_feature_block_header_v3")]
+            Self::V3(header) => header.inner.shard_id_mut(),
+        }
+    }
+
+    #[inline]
     pub fn encoded_length(&self) -> u64 {
         match self {
             Self::V1(header) => header.inner.encoded_length,

--- a/core/primitives/src/sharding/shard_chunk_header_inner.rs
+++ b/core/primitives/src/sharding/shard_chunk_header_inner.rs
@@ -68,6 +68,14 @@ impl ShardChunkHeaderInner {
     }
 
     #[inline]
+    pub fn shard_id_mut(&mut self) -> &mut ShardId {
+        match self {
+            Self::V1(inner) => &mut inner.shard_id,
+            Self::V2(inner) => &mut inner.shard_id,
+        }
+    }
+
+    #[inline]
     pub fn outcome_root(&self) -> &CryptoHash {
         match self {
             Self::V1(inner) => &inner.outcome_root,


### PR DESCRIPTION
This PR fixes bug in `produce_block`. This bug will only be triggered during sharding upgrade at the first block of the new epoch that uses the new shard layout, if the new block has empty chunks.

I checked that this bug was not triggered in the testnet launch because that block does not have empty chunks (#68081211)