### PR TITLE
chore(ci): add sanity checks to ensure errors schema is always up-to-date

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -52,10 +52,11 @@ steps:
           echo '    python3 -m yapf -pir pytest scripts'
           exit 1
       fi >&2
+      rm target/rpc_errors_schema.json
       RUSTFLAGS='-D warnings' cargo check -p near-jsonrpc --features dump_errors_schema
       if ! git --no-pager diff --no-index chain/jsonrpc/res/rpc_errors_schema.json target/rpc_errors_schema.json; then
           echo 'The RPC errors schema reflects outdated typing structure; please run'
-          echo '    cargo build -p near-jsonrpc --features dump_errors_schema'
+          echo '    ./chain/jsonrpc/build_errors_schema.sh'
           exit 1
       fi >&2
     timeout: 30


### PR DESCRIPTION
Add CI sanity check to ensure RPC errors schema is always up-to-date

Do not merge until https://github.com/near/nearcore/pull/5042 has either been merged or resolved, otherwise all new CI checks would fail on the unresolved conflict.