### PR TITLE
chore: drop explicit opt-level spec for dropped package ring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,9 +57,6 @@ overflow-checks = true
 [profile.dev.package.hex]
 opt-level = 3 # BLS library is too slow to use in debug
 
-[profile.dev.package.ring]
-opt-level = 3 # BLS library is too slow to use in debug
-
 [profile.dev.package.rand]
 opt-level = 3 # BLS library is too slow to use in debug
 


### PR DESCRIPTION
https://github.com/near/nearcore/pull/5069 removed the rust loadtester, removing `reqwest > rustls > ring` from the dep graph

This PR removes the explicit `opt-level` package spec, clearing up this warning message.

```console
warning: profile package spec `ring` in profile `dev` did not match any packages

        Did you mean `rand`?
```