### PR TITLE
Move routing table exchange to another thread

### DIFF
--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -41,8 +41,8 @@ use near_metrics::{Encoder, TextEncoder};
 use near_network::routing::routing::GetRoutingTableResult;
 #[cfg(feature = "test_features")]
 use near_network::types::{
-    GetPeerId, GetRoutingTable, NetworkAdversarialMessage, NetworkViewClientMessages,
-    PeerManagerMessageRequest, SetAdvOptions,
+    GetPeerId, NetworkAdversarialMessage, NetworkViewClientMessages, PeerManagerMessageRequest,
+    SetAdvOptions,
 };
 #[cfg(feature = "sandbox")]
 use near_network::types::{NetworkSandboxMessage, SandboxResponse};
@@ -324,16 +324,6 @@ impl JsonRpcHandler {
                     )
                 }
                 "adv_get_routing_table" => {
-                    let result = self
-                        .peer_manager_addr
-                        .send(PeerManagerMessageRequest::GetRoutingTable(GetRoutingTable {}))
-                        .await?;
-                    Some(
-                        serde_json::to_value(result.as_get_routing_table_result())
-                            .map_err(|err| RpcError::serialization_error(err.to_string())),
-                    )
-                }
-                "adv_get_routing_table_new" => {
                     let result = self
                         .routing_table_addr
                         .send(RoutingTableMessages::RequestRoutingTable)

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -38,25 +38,31 @@ use crate::peer_manager::peer_store::{PeerStore, TrustLevel};
 use crate::routing::codec::Codec;
 use crate::{RoutingTableActor, RoutingTableMessages, RoutingTableMessagesResponse};
 
+#[cfg(all(
+    feature = "test_features",
+    feature = "protocol_feature_routing_exchange_algorithm"
+))]
+use crate::routing::routing::SimpleEdge;
+
 use crate::routing::routing::{
-    Edge, EdgeInfo, EdgeType, EdgeVerifierHelper, GetRoutingTableResult, PeerRequestResult,
-    ProcessEdgeResult, RoutingTable, SimpleEdge, MAX_NUM_PEERS, SAVE_PEERS_AFTER_TIME,
+    Edge, EdgeInfo, EdgeType, EdgeVerifierHelper, PeerRequestResult, RoutingTableView,
+    DELETE_PEERS_AFTER_TIME, MAX_NUM_PEERS,
 };
 
-use crate::routing::edge_verifier_actor::EdgeVerifierActor;
-use crate::stats::metrics;
+use crate::edge_verifier::EdgeVerifierActor;
+use crate::routing_table_actor::Prune;
+
 #[cfg(feature = "test_features")]
 use crate::types::SetAdvOptions;
 use crate::types::{
     AccountOrPeerIdOrHash, Ban, BlockedPorts, Consolidate, ConsolidateResponse, EdgeList,
-    FullPeerInfo, GetRoutingTable, InboundTcpConnect, KnownPeerState, KnownPeerStatus,
-    KnownProducer, NetworkClientMessages, NetworkConfig, NetworkInfo, NetworkRequests,
-    NetworkResponses, NetworkViewClientMessages, NetworkViewClientResponses, OutboundTcpConnect,
-    PeerIdOrHash, PeerInfo, PeerManagerMessageRequest, PeerManagerMessageResponse,
-    PeerManagerRequest, PeerMessage, PeerRequest, PeerResponse, PeerType, PeersRequest,
-    PeersResponse, Ping, Pong, QueryPeerStats, RawRoutedMessage, ReasonForBan, RoutedMessage,
-    RoutedMessageBody, RoutedMessageFrom, SendMessage, StateResponseInfo, StopMsg, SyncData,
-    Unregister,
+    FullPeerInfo, InboundTcpConnect, KnownPeerState, KnownPeerStatus, KnownProducer,
+    NetworkClientMessages, NetworkConfig, NetworkInfo, NetworkRequests, NetworkResponses,
+    NetworkViewClientMessages, NetworkViewClientResponses, OutboundTcpConnect, PeerIdOrHash,
+    PeerInfo, PeerManagerMessageRequest, PeerManagerMessageResponse, PeerManagerRequest,
+    PeerMessage, PeerRequest, PeerResponse, PeerType, PeersRequest, PeersResponse, Ping, Pong,
+    QueryPeerStats, RawRoutedMessage, ReasonForBan, RoutedMessage, RoutedMessageBody,
+    RoutedMessageFrom, SendMessage, StateResponseInfo, StopMsg, SyncData, Unregister,
 };
 use crate::types::{GetPeerId, GetPeerIdResult};
 #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
@@ -136,8 +142,12 @@ pub struct PeerManagerActor {
     outgoing_peers: HashSet<PeerId>,
     /// Active peers (inbound and outbound) with their full peer information.
     active_peers: HashMap<PeerId, ActivePeer>,
-    /// Routing table to keep track of account id
-    routing_table: RoutingTable,
+    /// View of the Routing table. It keeps:
+    /// - routing information - how to route messages
+    /// - edges adjacent to my_peer_id
+    /// - account id
+    /// Full routing table (that currently includes information about all edges in the graph) is now inside Routing Table.
+    routing_table_view: RoutingTableView,
     /// Fields used for communicating with EdgeVerifier
     routing_table_exchange_helper: EdgeVerifierHelper,
     /// Flag that track whether we started attempts to establish outbound connections.
@@ -148,20 +158,54 @@ pub struct PeerManagerActor {
     pending_update_nonce_request: HashMap<PeerId, u64>,
     /// Dynamic Prometheus metrics
     network_metrics: NetworkMetrics,
+    /// EdgeVerifierActor, which is responsible for veryfing edges.
     edge_verifier_pool: Addr<EdgeVerifierActor>,
+    /// RoutingTableActor, responsible for computing routing table, routing table exchange, etc.
     routing_table_addr: Addr<RoutingTableActor>,
+    /// Shared counter across all PeerActors, which counts number of `RoutedMessageBody::ForwardTx`
+    /// messages sincce last block.
     txns_since_last_block: Arc<AtomicUsize>,
+    /// Number of incoming connections, that were not established yet; used for rate limiting.
     pending_incoming_connections_counter: Arc<AtomicUsize>,
+    /// Number of active peers, used for rate limiting.
     peer_counter: Arc<AtomicUsize>,
-    scheduled_routing_table_update: bool,
+    /// Number of edge verifications in progress; We will not update routing table as long as
+    /// this number is non zero.
     edge_verifier_requests_in_progress: u64,
+    /// Used for testing, for disabling features.
+    adv_helper: AdvHelper,
+}
 
+#[derive(Default)]
+struct AdvHelper {
     #[cfg(feature = "test_features")]
     adv_disable_edge_propagation: bool,
     #[cfg(feature = "test_features")]
     adv_disable_edge_signature_verification: bool,
     #[cfg(feature = "test_features")]
     adv_disable_edge_pruning: bool,
+}
+
+impl AdvHelper {
+    #[cfg(not(feature = "test_features"))]
+    fn can_broadcast_edges(&self) -> bool {
+        true
+    }
+
+    #[cfg(feature = "test_features")]
+    fn can_broadcast_edges(&self) -> bool {
+        !self.adv_disable_edge_propagation
+    }
+
+    #[cfg(not(feature = "test_features"))]
+    fn adv_disable_edge_pruning(&self) -> bool {
+        false
+    }
+
+    #[cfg(feature = "test_features")]
+    fn adv_disable_edge_pruning(&self) -> bool {
+        self.adv_disable_edge_pruning
+    }
 }
 
 impl PeerManagerActor {
@@ -183,7 +227,7 @@ impl PeerManagerActor {
         let edge_verifier_pool = SyncArbiter::start(4, || EdgeVerifierActor {});
 
         let my_peer_id: PeerId = config.public_key.clone().into();
-        let routing_table = RoutingTable::new(my_peer_id.clone(), store);
+        let routing_table = RoutingTableView::new(my_peer_id.clone(), store);
 
         let txns_since_last_block = Arc::new(AtomicUsize::new(0));
 
@@ -195,41 +239,86 @@ impl PeerManagerActor {
             peer_store,
             active_peers: HashMap::default(),
             outgoing_peers: HashSet::default(),
-            routing_table,
+            routing_table_view: routing_table,
             routing_table_exchange_helper: Default::default(),
             monitor_peers_attempts: 0,
             started_connect_attempts: false,
             pending_update_nonce_request: HashMap::new(),
             network_metrics: NetworkMetrics::new(),
             edge_verifier_pool,
-            routing_table_addr: routing_table_addr,
+            routing_table_addr,
             txns_since_last_block,
             pending_incoming_connections_counter: Arc::new(AtomicUsize::new(0)),
             peer_counter: Arc::new(AtomicUsize::new(0)),
-            scheduled_routing_table_update: false,
             edge_verifier_requests_in_progress: 0,
-            #[cfg(feature = "test_features")]
-            adv_disable_edge_propagation: false,
-            #[cfg(feature = "test_features")]
-            adv_disable_edge_signature_verification: false,
-            #[cfg(feature = "test_features")]
-            adv_disable_edge_pruning: false,
+            adv_helper: AdvHelper::default(),
         })
     }
 
     fn update_routing_table_and_prune_edges(
         &mut self,
-        ctx: &mut Context<PeerManagerActor>,
-        can_save_edges: bool,
-        force_pruning: bool,
-        timeout: Duration,
+        ctx: &mut Context<Self>,
+        prune: Prune,
+        prune_edges_not_reachable_for: Duration,
     ) {
-        let edges_to_remove =
-            self.routing_table.recalculate_routing_table(can_save_edges, force_pruning, timeout);
         self.routing_table_addr
-            .send(RoutingTableMessages::RemoveEdges(edges_to_remove))
+            .send(RoutingTableMessages::RoutingTableUpdate { prune, prune_edges_not_reachable_for })
             .into_actor(self)
-            .map(|_, _, _| ())
+            .map(|response, act, _| match response {
+                Ok(RoutingTableMessagesResponse::RoutingTableUpdateResponse {
+                    edges_to_remove,
+                    peer_forwarding,
+                }) => {
+                    act.routing_table_view.remove_edges(&edges_to_remove);
+                    act.routing_table_view.peer_forwarding = peer_forwarding;
+                }
+                _ => error!(target: "network", "expected RoutingTableUpdateResponse"),
+            })
+            .spawn(ctx);
+    }
+
+    fn add_verified_edges_to_routing_table(
+        &mut self,
+        ctx: &mut Context<Self>,
+        edges: Vec<Edge>,
+        broadcast_edges: bool,
+    ) {
+        if edges.len() == 0 {
+            return;
+        }
+        // RoutingTable keeps list of local edges; let's apply changes immediately.
+        for edge in edges.iter() {
+            if !edge.contains_peer(&self.my_peer_id) {
+                continue;
+            }
+            let key = edge.get_pair();
+            if !self.routing_table_view.is_local_edge_newer(&key, edge.nonce) {
+                continue;
+            }
+            self.routing_table_view
+                .local_edges_info
+                .insert((edge.peer0.clone(), edge.peer1.clone()), edge.clone());
+        }
+
+        self.routing_table_addr
+            .send(RoutingTableMessages::AddVerifiedEdges { edges })
+            .into_actor(self)
+            .map(move |response, act, ctx| match response {
+                Ok(RoutingTableMessagesResponse::AddVerifiedEdgesResponse(filtered_edges)) => {
+                    // Broadcast new edges to all other peers.
+                    if broadcast_edges {
+                        if act.adv_helper.can_broadcast_edges() {
+                            let new_data =
+                                SyncData { edges: filtered_edges, accounts: Default::default() };
+                            act.broadcast_message(
+                                ctx,
+                                SendMessage { message: PeerMessage::RoutingTableSync(new_data) },
+                            )
+                        }
+                    }
+                }
+                _ => error!(target: "network", "expected AddIbfSetResponse"),
+            })
             .spawn(ctx);
     }
 
@@ -242,7 +331,7 @@ impl PeerManagerActor {
             debug!(target: "network", "{:?} Received new accounts: {:?}", self.config.account_id, accounts);
         }
         for account in accounts.iter() {
-            self.routing_table.add_account(account.clone());
+            self.routing_table_view.add_account(account.clone());
         }
 
         let new_data = SyncData { edges: Default::default(), accounts };
@@ -255,66 +344,73 @@ impl PeerManagerActor {
         };
     }
 
+    fn update_routing_table_trigger(&mut self, ctx: &mut Context<Self>) {
+        let can_prune_edges = self.edge_verifier_requests_in_progress == 0
+            && !self.adv_helper.adv_disable_edge_pruning();
+
+        self.update_routing_table_and_prune_edges(
+            ctx,
+            if can_prune_edges { Prune::PruneOncePerHour } else { Prune::Disable },
+            DELETE_PEERS_AFTER_TIME,
+        );
+
+        near_performance_metrics::actix::run_later(
+            ctx,
+            UPDATE_ROUTING_TABLE_INTERVAL,
+            move |act, ctx| {
+                act.update_routing_table_trigger(ctx);
+            },
+        );
+    }
+
     /// Receives list of edges that were verified, in a trigger every 20ms, and adds them to
     /// the routing table.
     fn broadcast_edges_trigger(&mut self, ctx: &mut Context<PeerManagerActor>) {
-        let me = self.my_peer_id.clone();
-
         let start = Instant::now();
         let mut new_edges = Vec::new();
         while let Some(edge) = self.routing_table_exchange_helper.edges_to_add_receiver.pop() {
-            if let Some(cur_edge) =
-                self.routing_table.get_edge(edge.peer0.clone(), edge.peer1.clone())
-            {
-                if cur_edge.nonce >= edge.nonce {
-                    // We have newer update. Drop this.
-                    continue;
-                }
-            }
-            // Add new edge update to the routing table.
-            self.add_verified_edges_to_routing_table(ctx, vec![edge.clone()]);
-            if let Some(other) = edge.other(&me) {
-                // We belong to this edge.
-                if self.active_peers.contains_key(&other) {
-                    // This is an active connection.
-                    match edge.edge_type() {
-                        EdgeType::Added => {}
-                        EdgeType::Removed => {
-                            // Try to update the nonce, and in case it fails removes the peer.
-                            self.try_update_nonce(ctx, edge.clone(), other);
-                            continue;
-                        }
-                    }
-                } else {
-                    match edge.edge_type() {
-                        EdgeType::Added => {
-                            self.wait_peer_or_remove(ctx, edge.clone());
-                            continue;
-                        }
-                        EdgeType::Removed => {}
-                    }
-                }
-            }
             new_edges.push(edge);
             if start.elapsed() >= BROAD_CAST_EDGES_MAX_WORK_ALLOWED {
                 break;
             }
         }
 
-        let new_data = SyncData { edges: new_edges, accounts: Default::default() };
-
-        if !new_data.is_empty() {
-            #[cfg(not(feature = "test_features"))]
-            let condition = true;
-            #[cfg(feature = "test_features")]
-            let condition = !self.adv_disable_edge_propagation;
-
-            if condition {
-                self.broadcast_message(
-                    ctx,
-                    SendMessage { message: PeerMessage::RoutingTableSync(new_data) },
-                )
+        if !new_edges.is_empty() {
+            for edge in new_edges.iter() {
+                if !edge.contains_peer(&self.my_peer_id) {
+                    continue;
+                }
+                let key = edge.get_pair();
+                if !self.routing_table_view.is_local_edge_newer(&key, edge.nonce) {
+                    continue;
+                }
+                // Check whenever peer needs to be removed when edge is removed.
+                if let Some(other) = edge.other(&self.my_peer_id) {
+                    // We belong to this edge.
+                    if self.active_peers.contains_key(&other) {
+                        // This is an active connection.
+                        match edge.edge_type() {
+                            EdgeType::Removed => {
+                                // Try to update the nonce, and in case it fails removes the peer.
+                                self.try_update_nonce(ctx, edge.clone(), other);
+                            }
+                            _ => {}
+                        }
+                    } else {
+                        match edge.edge_type() {
+                            EdgeType::Added => {
+                                // We are not connected to this peer, but routing table contains
+                                // information that we do. We should wait and remove that peer
+                                // from routing table
+                                self.wait_peer_or_remove(ctx, edge.clone());
+                            }
+                            _ => {}
+                        }
+                    }
+                }
             }
+            // Add new edge update to the routing table.
+            self.add_verified_edges_to_routing_table(ctx, new_edges, true);
         };
 
         near_performance_metrics::actix::run_later(
@@ -435,7 +531,7 @@ impl PeerManagerActor {
             },
         );
 
-        self.add_verified_edges_to_routing_table(ctx, vec![new_edge.clone()]);
+        self.add_verified_edges_to_routing_table(ctx, vec![new_edge.clone()], false);
 
         checked_feature!(
             "protocol_feature_routing_exchange_algorithm",
@@ -479,7 +575,7 @@ impl PeerManagerActor {
         new_edge: Edge,
         known_edges: Vec<Edge>,
     ) {
-        let known_accounts = self.routing_table.get_announce_accounts();
+        let known_accounts = self.routing_table_view.get_announce_accounts();
 
         // Start syncing network point of view. Wait until both parties are connected before start
         // sending messages.
@@ -540,11 +636,13 @@ impl PeerManagerActor {
             .map(|_, _, _| ())
             .spawn(ctx);
 
-        if let Some(edge) = self.routing_table.get_edge(self.my_peer_id.clone(), peer_id.clone()) {
+        if let Some(edge) =
+            self.routing_table_view.get_edge(self.my_peer_id.clone(), peer_id.clone())
+        {
             if edge.edge_type() == EdgeType::Added {
                 let edge_update =
                     edge.remove_edge(self.my_peer_id.clone(), &self.config.secret_key);
-                self.add_verified_edges_to_routing_table(ctx, vec![edge_update.clone()]);
+                self.add_verified_edges_to_routing_table(ctx, vec![edge_update.clone()], false);
                 self.broadcast_message(
                     ctx,
                     SendMessage {
@@ -778,48 +876,6 @@ impl PeerManagerActor {
         }.into_actor(self));
     }
 
-    /// Add an edge update to the routing table and return if it is a new edge update.
-    fn add_verified_edges_to_routing_table(
-        &mut self,
-        ctx: &mut Context<Self>,
-        edges: Vec<Edge>,
-    ) -> bool {
-        let ProcessEdgeResult { new_edge, edges } =
-            self.routing_table.add_verified_edges_to_routing_table(edges);
-        self.routing_table_addr
-            .send(RoutingTableMessages::AddEdges(edges))
-            .into_actor(self)
-            .map(|_, _, _| ())
-            .spawn(ctx);
-
-        if !self.scheduled_routing_table_update {
-            self.scheduled_routing_table_update = true;
-            near_performance_metrics::actix::run_later(
-                ctx,
-                UPDATE_ROUTING_TABLE_INTERVAL,
-                |act, ctx| {
-                    act.scheduled_routing_table_update = false;
-                    // We only want to save prune edges if there are no pending requests to EdgeVerifier
-
-                    #[cfg(feature = "test_features")]
-                    let cond = act.edge_verifier_requests_in_progress == 0
-                        && !act.adv_disable_edge_pruning;
-                    #[cfg(not(feature = "test_features"))]
-                    let cond = act.edge_verifier_requests_in_progress == 0;
-
-                    act.update_routing_table_and_prune_edges(
-                        ctx,
-                        cond,
-                        false,
-                        SAVE_PEERS_AFTER_TIME,
-                    );
-                },
-            );
-        }
-
-        new_edge
-    }
-
     #[cfg(all(feature = "test_features", feature = "protocol_feature_routing_exchange_algorithm"))]
     fn adv_remove_edges_from_routing_table(
         &mut self,
@@ -839,9 +895,9 @@ impl PeerManagerActor {
                 )
             })
             .collect();
-        self.routing_table.remove_edges(&edges);
+        self.routing_table_view.remove_edges(&edges);
         self.routing_table_addr
-            .send(RoutingTableMessages::RemoveEdges(edges))
+            .send(RoutingTableMessages::AdvRemoveEdges(edges))
             .into_actor(self)
             .map(|_, _, _| ())
             .spawn(ctx);
@@ -1123,6 +1179,7 @@ impl PeerManagerActor {
                 sender: self.routing_table_exchange_helper.edges_to_add_sender.clone(),
                 #[cfg(feature = "test_features")]
                 adv_disable_edge_signature_verification: self
+                    .adv_helper
                     .adv_disable_edge_signature_verification,
             })
             .into_actor(self)
@@ -1158,8 +1215,8 @@ impl PeerManagerActor {
 
     fn announce_account(&mut self, ctx: &mut Context<Self>, announce_account: AnnounceAccount) {
         debug!(target: "network", "{:?} Account announce: {:?}", self.config.account_id, announce_account);
-        if !self.routing_table.contains_account(&announce_account) {
-            self.routing_table.add_account(announce_account.clone());
+        if !self.routing_table_view.contains_account(&announce_account) {
+            self.routing_table_view.add_account(announce_account.clone());
             self.broadcast_message(
                 ctx,
                 SendMessage {
@@ -1236,12 +1293,12 @@ impl PeerManagerActor {
             }
         }
 
-        match self.routing_table.find_route(&msg.target) {
+        match self.routing_table_view.find_route(&msg.target) {
             Ok(peer_id) => {
                 // Remember if we expect a response for this message.
                 if msg.author == self.my_peer_id && msg.expect_response() {
                     trace!(target: "network", "initiate route back {:?}", msg);
-                    self.routing_table.add_route_back(msg.hash(), self.my_peer_id.clone());
+                    self.routing_table_view.add_route_back(msg.hash(), self.my_peer_id.clone());
                 }
 
                 self.send_message(ctx, peer_id, PeerMessage::Routed(msg))
@@ -1257,7 +1314,7 @@ impl PeerManagerActor {
                       self.config.account_id,
                       msg.target,
                       find_route_error,
-                      self.routing_table.peer_forwarding.len(),
+                      self.routing_table_view.peer_forwarding.len(),
                       msg.body,
                 );
                 false
@@ -1280,7 +1337,7 @@ impl PeerManagerActor {
         account_id: &AccountId,
         msg: RoutedMessageBody,
     ) -> bool {
-        let target = match self.routing_table.account_owner(&account_id) {
+        let target = match self.routing_table_view.account_owner(&account_id) {
             Ok(peer_id) => peer_id,
             Err(find_route_error) => {
                 // TODO(MarX, #1369): Message is dropped here. Define policy for this case.
@@ -1291,7 +1348,7 @@ impl PeerManagerActor {
                        find_route_error,
                        msg,
                 );
-                trace!(target: "network", "Known peers: {:?}", self.routing_table.get_accounts_keys());
+                trace!(target: "network", "Known peers: {:?}", self.routing_table_view.get_accounts_keys());
                 return false;
             }
         };
@@ -1309,7 +1366,7 @@ impl PeerManagerActor {
         match target {
             PeerIdOrHash::PeerId(peer_id) => peer_id == &self.my_peer_id,
             PeerIdOrHash::Hash(hash) => {
-                self.routing_table.compare_route_back(hash.clone(), &self.my_peer_id)
+                self.routing_table_view.compare_route_back(hash.clone(), &self.my_peer_id)
             }
         }
     }
@@ -1320,7 +1377,7 @@ impl PeerManagerActor {
         // When we create a new edge we increase the latest nonce by 2 in case we miss a removal
         // proposal from our partner.
         let nonce = with_nonce.unwrap_or_else(|| {
-            self.routing_table
+            self.routing_table_view
                 .get_edge(self.my_peer_id.clone(), peer1)
                 .map_or(1, |edge| edge.next())
         });
@@ -1334,7 +1391,7 @@ impl PeerManagerActor {
     fn send_ping(&mut self, ctx: &mut Context<Self>, nonce: usize, target: PeerId) {
         let body =
             RoutedMessageBody::Ping(Ping { nonce: nonce as u64, source: self.my_peer_id.clone() });
-        self.routing_table.sending_ping(nonce, target.clone());
+        self.routing_table_view.sending_ping(nonce, target.clone());
         let msg = RawRoutedMessage { target: AccountOrPeerIdOrHash::PeerId(target), body };
         self.send_message_to_peer(ctx, msg);
     }
@@ -1348,13 +1405,13 @@ impl PeerManagerActor {
 
     fn handle_ping(&mut self, ctx: &mut Context<Self>, ping: Ping, hash: CryptoHash) {
         self.send_pong(ctx, ping.nonce as usize, hash);
-        self.routing_table.add_ping(ping);
+        self.routing_table_view.add_ping(ping);
     }
 
     /// Handle pong messages. Add pong temporary to the routing table, mostly used for testing.
     fn handle_pong(&mut self, _ctx: &mut Context<Self>, pong: Pong) {
         #[allow(unused_variables)]
-        let latency = self.routing_table.add_pong(pong);
+        let latency = self.routing_table_view.add_pong(pong);
     }
 
     pub(crate) fn get_network_info(&mut self) -> NetworkInfo {
@@ -1371,7 +1428,7 @@ impl PeerManagerActor {
             sent_bytes_per_sec,
             received_bytes_per_sec,
             known_producers: self
-                .routing_table
+                .routing_table_view
                 .get_announce_accounts()
                 .iter()
                 .map(|announce_account| KnownProducer {
@@ -1467,7 +1524,10 @@ impl Actor for PeerManagerActor {
         // Start active peer stats querying.
         self.monitor_peer_stats_trigger(ctx);
 
+        // Read verified edges and broadcast them.
         self.broadcast_edges_trigger(ctx);
+
+        self.update_routing_table_trigger(ctx);
     }
 
     /// Try to gracefully disconnect from active peers.
@@ -1724,7 +1784,7 @@ impl PeerManagerActor {
             }
             // For unit tests
             NetworkRequests::FetchRoutingTable => {
-                NetworkResponses::RoutingTableInfo(self.routing_table.info())
+                NetworkResponses::RoutingTableInfo(self.routing_table_view.info())
             }
             NetworkRequests::Sync { peer_id, sync_data } => {
                 // Process edges and add new edges to the routing table. Also broadcast new edges.
@@ -1735,7 +1795,7 @@ impl PeerManagerActor {
                     .into_iter()
                     .filter_map(|announce_account| {
                         if let Some(current_announce_account) =
-                            self.routing_table.get_announce(&announce_account.account_id)
+                            self.routing_table_view.get_announce(&announce_account.account_id)
                         {
                             if announce_account.epoch_id == current_announce_account.epoch_id {
                                 None
@@ -1792,12 +1852,12 @@ impl PeerManagerActor {
             NetworkRequests::RequestUpdateNonce(peer_id, edge_info) => {
                 if Edge::partial_verify(self.my_peer_id.clone(), peer_id.clone(), &edge_info) {
                     if let Some(cur_edge) =
-                        self.routing_table.get_edge(self.my_peer_id.clone(), peer_id.clone())
+                        self.routing_table_view.get_edge(self.my_peer_id.clone(), peer_id.clone())
                     {
                         if cur_edge.edge_type() == EdgeType::Added
                             && cur_edge.nonce >= edge_info.nonce
                         {
-                            return NetworkResponses::EdgeUpdate(Box::new(cur_edge));
+                            return NetworkResponses::EdgeUpdate(Box::new(cur_edge.clone()));
                         }
                     }
 
@@ -1809,7 +1869,7 @@ impl PeerManagerActor {
                         edge_info.signature,
                     );
 
-                    self.add_verified_edges_to_routing_table(ctx, vec![new_edge.clone()]);
+                    self.add_verified_edges_to_routing_table(ctx, vec![new_edge.clone()], false);
                     NetworkResponses::EdgeUpdate(Box::new(new_edge))
                 } else {
                     NetworkResponses::BanPeer(ReasonForBan::InvalidEdge)
@@ -1817,7 +1877,8 @@ impl PeerManagerActor {
             }
             NetworkRequests::ResponseUpdateNonce(edge) => {
                 if edge.contains_peer(&self.my_peer_id) && edge.verify() {
-                    if self.add_verified_edges_to_routing_table(ctx, vec![edge.clone()]) {
+                    let key = edge.get_pair();
+                    if self.routing_table_view.is_local_edge_newer(&key, edge.nonce) {
                         let other = edge.other(&self.my_peer_id).unwrap();
                         if let Some(nonce) = self.pending_update_nonce_request.get(&other) {
                             if edge.nonce >= *nonce {
@@ -1825,6 +1886,7 @@ impl PeerManagerActor {
                             }
                         }
                     }
+                    self.add_verified_edges_to_routing_table(ctx, vec![edge.clone()], false);
                     NetworkResponses::NoResponse
                 } else {
                     NetworkResponses::BanPeer(ReasonForBan::InvalidEdge)
@@ -1837,7 +1899,7 @@ impl PeerManagerActor {
             }
             // For unit tests
             NetworkRequests::FetchPingPongInfo => {
-                let (pings, pongs) = self.routing_table.fetch_ping_pong();
+                let (pings, pongs) = self.routing_table_view.fetch_ping_pong();
                 NetworkResponses::PingPongInfo { pings, pongs }
             }
         }
@@ -1883,34 +1945,17 @@ impl PeerManagerActor {
     #[perf]
     fn handle_msg_set_adv_options(&mut self, msg: SetAdvOptions, _ctx: &mut Context<Self>) {
         if let Some(disable_edge_propagation) = msg.disable_edge_propagation {
-            self.adv_disable_edge_propagation = disable_edge_propagation;
+            self.adv_helper.adv_disable_edge_propagation = disable_edge_propagation;
         }
         if let Some(disable_edge_signature_verification) = msg.disable_edge_signature_verification {
-            self.adv_disable_edge_signature_verification = disable_edge_signature_verification;
+            self.adv_helper.adv_disable_edge_signature_verification =
+                disable_edge_signature_verification;
         }
         if let Some(disable_edge_pruning) = msg.disable_edge_pruning {
-            self.adv_disable_edge_pruning = disable_edge_pruning;
+            self.adv_helper.adv_disable_edge_pruning = disable_edge_pruning;
         }
         if let Some(set_max_peers) = msg.set_max_peers {
             self.config.max_num_peers = set_max_peers as u32;
-        }
-    }
-}
-
-impl PeerManagerActor {
-    #[perf]
-    fn handle_msg_get_routing_table(
-        &mut self,
-        msg: GetRoutingTable,
-        _ctx: &mut Context<Self>,
-    ) -> GetRoutingTableResult {
-        GetRoutingTableResult {
-            edges_info: self
-                .routing_table
-                .edges_info
-                .iter()
-                .map(|(_, e)| (SimpleEdge::new(e.peer0.clone(), e.peer1.clone(), e.nonce)))
-                .collect(),
         }
     }
 }
@@ -1926,7 +1971,7 @@ impl PeerManagerActor {
     ) {
         if let Some(add_edges) = msg.add_edges {
             debug!(target: "network", "test_features add_edges {}", add_edges.len());
-            self.add_verified_edges_to_routing_table(ctx, add_edges);
+            self.add_verified_edges_to_routing_table(ctx, add_edges, false);
         }
         if let Some(remove_edges) = msg.remove_edges {
             debug!(target: "network", "test_features remove_edges {}", remove_edges.len());
@@ -1934,7 +1979,7 @@ impl PeerManagerActor {
         }
         if let Some(true) = msg.prune_edges {
             debug!(target: "network", "test_features prune_edges");
-            self.update_routing_table_and_prune_edges(ctx, true, true, Duration::from_secs(2));
+            self.update_routing_table_and_prune_edges(ctx, Prune::PruneNow, Duration::from_secs(2));
         }
     }
 }
@@ -2054,14 +2099,14 @@ impl PeerManagerActor {
         }
 
         let last_edge =
-            self.routing_table.get_edge(self.my_peer_id.clone(), msg.peer_info.id.clone());
+            self.routing_table_view.get_edge(self.my_peer_id.clone(), msg.peer_info.id.clone());
         let last_nonce = last_edge.as_ref().map_or(0, |edge| edge.nonce);
 
         // Check that the received nonce is greater than the current nonce of this connection.
         if last_nonce >= msg.other_edge_info.nonce {
             debug!(target: "network", "Too low nonce. ({} <= {}) {:?} {:?}", msg.other_edge_info.nonce, last_nonce, self.my_peer_id, msg.peer_info.id);
             // If the check fails don't allow this connection.
-            return ConsolidateResponse::InvalidNonce(last_edge.map(Box::new).unwrap());
+            return ConsolidateResponse::InvalidNonce(last_edge.cloned().map(Box::new).unwrap());
         }
 
         if msg.other_edge_info.nonce >= Edge::next_nonce(last_nonce) + EDGE_NONCE_BUMP_ALLOWED {
@@ -2207,11 +2252,6 @@ impl Handler<PeerManagerMessageRequest> for PeerManagerActor {
                     self.handle_msg_set_routing_table(msg, ctx),
                 )
             }
-            PeerManagerMessageRequest::GetRoutingTable(msg) => {
-                PeerManagerMessageResponse::GetRoutingTableResult(
-                    self.handle_msg_get_routing_table(msg, ctx),
-                )
-            }
         }
     }
 }
@@ -2228,7 +2268,7 @@ impl PeerManagerActor {
 
         if msg.expect_response() {
             trace!(target: "network", "Received peer message that requires route back: {}", PeerMessage::Routed(msg.clone()));
-            self.routing_table.add_route_back(msg.hash(), from.clone());
+            self.routing_table_view.add_route_back(msg.hash(), from.clone());
         }
 
         if self.message_for_me(&msg.target) {

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -345,6 +345,11 @@ impl PeerManagerActor {
         };
     }
 
+    /// `update_routing_table_trigger` schedule updating routing table to `RoutingTableActor`
+    /// Usually we do edge pruning one an hour. However it may be disabled in following cases:
+    /// - there are edges, that were supposed to be added, but are still in `EdgeVerifierActor,
+    ///   waiting to have their signatures checked.
+    /// - edge pruning may be disabled for unit testing.
     fn update_routing_table_trigger(&mut self, ctx: &mut Context<Self>) {
         let can_prune_edges = self.edge_verifier_requests_in_progress == 0
             && !self.adv_helper.adv_disable_edge_pruning();
@@ -410,7 +415,7 @@ impl PeerManagerActor {
                     }
                 }
             }
-            // Add new edge update to the routing table.
+            // Add new edge update to the routing table and broadcast it to peers.
             self.add_verified_edges_to_routing_table(ctx, new_edges, true);
         };
 

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -20,6 +20,7 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio_util::codec::FramedRead;
 use tracing::{debug, error, info, trace, warn};
 
+use crate::stats::metrics;
 use crate::stats::metrics::NetworkMetrics;
 #[cfg(feature = "delay_detector")]
 use delay_detector::DelayDetector;
@@ -49,8 +50,8 @@ use crate::routing::routing::{
     DELETE_PEERS_AFTER_TIME, MAX_NUM_PEERS,
 };
 
-use crate::edge_verifier::EdgeVerifierActor;
-use crate::routing_table_actor::Prune;
+use crate::routing::edge_verifier_actor::EdgeVerifierActor;
+use crate::routing::routing_table_actor::Prune;
 
 #[cfg(feature = "test_features")]
 use crate::types::SetAdvOptions;

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -1542,6 +1542,7 @@ impl Actor for PeerManagerActor {
         // Read verified edges and broadcast them.
         self.broadcast_edges_trigger(ctx);
 
+        // Update routing table and prune edges that are no longer reachable.
         self.update_routing_table_trigger(ctx);
     }
 

--- a/chain/network/src/routing/routing.rs
+++ b/chain/network/src/routing/routing.rs
@@ -13,6 +13,7 @@ use near_primitives::network::{AnnounceAccount, PeerId};
 use near_primitives::types::AccountId;
 use near_store::{ColAccountAnnouncements, Store};
 
+use crate::routing::route_back_cache::RouteBackCache;
 use crate::PeerInfo;
 use crate::{
     types::{PeerIdOrHash, Ping, Pong},

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -404,10 +404,6 @@ impl Handler<StopMsg> for RoutingTableActor {
 // Messages for RoutingTableActor
 #[derive(Debug)]
 pub enum RoutingTableMessages {
-    // Add verified edges to routing table actor (Will be removed soon).
-    AddEdges(Vec<Edge>),
-    // Remove edges. (Will be removed soon).
-    RemoveEdges(Vec<Edge>),
     // Add verified edges to routing table actor and update stats.
     // Each edge contains signature of both peers.
     // We say that the edge is "verified" if and only if we checked that the `signature0` and
@@ -504,16 +500,6 @@ impl Handler<RoutingTableMessages> for RoutingTableActor {
     #[perf]
     fn handle(&mut self, msg: RoutingTableMessages, _ctx: &mut Self::Context) -> Self::Result {
         match msg {
-            RoutingTableMessages::AddEdges(edges) => {
-                for edge in edges {
-                    self.add_verified_edge(edge);
-                }
-                RoutingTableMessagesResponse::Empty
-            }
-            RoutingTableMessages::RemoveEdges(edges) => {
-                self.remove_edges(&edges);
-                RoutingTableMessagesResponse::Empty
-            }
             RoutingTableMessages::AddVerifiedEdges { edges } => {
                 RoutingTableMessagesResponse::AddVerifiedEdgesResponse(
                     self.add_verified_edges_to_routing_table(edges),

--- a/chain/network/src/test_utils.rs
+++ b/chain/network/src/test_utils.rs
@@ -288,6 +288,7 @@ impl MockPeerManagerAdapter {
 // Start PeerManagerActor, and RoutingTableActor together and returns pairs of addresses
 // for each of them.
 #[cfg(feature = "test_features")]
+#[allow(dead_code)]
 pub fn make_peer_manager_routing_table_addr_pair(
 ) -> (Addr<PeerManagerActor>, Addr<RoutingTableActor>) {
     let seed = "test2";

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -573,7 +573,6 @@ pub enum PeerManagerMessageRequest {
     #[cfg(feature = "test_features")]
     #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
     SetRoutingTable(SetRoutingTable),
-    GetRoutingTable(GetRoutingTable),
 }
 
 impl PeerManagerMessageRequest {
@@ -620,7 +619,6 @@ pub enum PeerManagerMessageResponse {
     #[cfg(feature = "test_features")]
     #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
     SetRoutingTable(()),
-    GetRoutingTableResult(GetRoutingTableResult),
 }
 
 impl PeerManagerMessageResponse {
@@ -669,14 +667,6 @@ impl PeerManagerMessageResponse {
             item
         } else {
             panic!("expected PeerMessageRequest::GetPeerIdResult(");
-        }
-    }
-
-    pub fn as_get_routing_table_result(self) -> GetRoutingTableResult {
-        if let PeerManagerMessageResponse::GetRoutingTableResult(item) = self {
-            item
-        } else {
-            panic!("expected PeerMessageRequest::GetRoutingTableResult(");
         }
     }
 }

--- a/chain/network/tests/cache.rs
+++ b/chain/network/tests/cache.rs
@@ -1,5 +1,5 @@
 use near_crypto::Signature;
-use near_network::routing::routing::RoutingTable;
+use near_network::routing::routing::RoutingTableView;
 use near_network::test_utils::{random_epoch_id, random_peer_id};
 use near_primitives::network::AnnounceAccount;
 use near_store::test_utils::create_test_store;
@@ -12,7 +12,7 @@ fn announcement_same_epoch() {
     let peer_id1 = random_peer_id();
     let epoch_id0 = random_epoch_id();
 
-    let mut routing_table = RoutingTable::new(peer_id0.clone(), store);
+    let mut routing_table = RoutingTableView::new(peer_id0.clone(), store);
 
     let announce0 = AnnounceAccount {
         account_id: "near0".parse().unwrap(),
@@ -48,7 +48,7 @@ fn dont_load_on_build() {
     let epoch_id0 = random_epoch_id();
     let epoch_id1 = random_epoch_id();
 
-    let mut routing_table = RoutingTable::new(peer_id0.clone(), store.clone());
+    let mut routing_table = RoutingTableView::new(peer_id0.clone(), store.clone());
 
     let announce0 = AnnounceAccount {
         account_id: "near0".parse().unwrap(),
@@ -73,7 +73,7 @@ fn dont_load_on_build() {
         .all(|announce| { accounts.contains(announce) }));
     assert_eq!(routing_table.get_announce_accounts().len(), 2);
 
-    let mut routing_table1 = RoutingTable::new(peer_id0, store);
+    let mut routing_table1 = RoutingTableView::new(peer_id0, store);
     assert!(routing_table1.get_announce_accounts().is_empty());
 }
 
@@ -84,8 +84,8 @@ fn load_from_disk() {
     let peer_id0 = random_peer_id();
     let epoch_id0 = random_epoch_id();
 
-    let mut routing_table = RoutingTable::new(peer_id0.clone(), store.clone());
-    let mut routing_table1 = RoutingTable::new(peer_id0.clone(), store.clone());
+    let mut routing_table = RoutingTableView::new(peer_id0.clone(), store.clone());
+    let mut routing_table1 = RoutingTableView::new(peer_id0.clone(), store.clone());
 
     let announce0 = AnnounceAccount {
         account_id: "near0".parse().unwrap(),

--- a/chain/network/tests/cache_edges.rs
+++ b/chain/network/tests/cache_edges.rs
@@ -8,7 +8,7 @@ use near_crypto::Signature;
 use near_network::routing::routing::{
     Edge, EdgeType, DELETE_PEERS_AFTER_TIME, SAVE_PEERS_MAX_TIME,
 };
-use near_network::routing_table_actor::Prune;
+use near_network::routing::routing_table_actor::Prune;
 use near_network::test_utils::random_peer_id;
 use near_network::RoutingTableActor;
 use near_primitives::network::PeerId;

--- a/integration-tests/tests/network/runner.rs
+++ b/integration-tests/tests/network/runner.rs
@@ -246,7 +246,7 @@ impl StateMachine {
                                         res.as_network_response()
                                     {
                                         if expected_routing_tables(
-                                            (routing_table.peer_forwarding).clone(),
+                                            (*routing_table.peer_forwarding.as_ref()).clone(),
                                             expected,
                                         ) {
                                             flag.store(true, Ordering::Relaxed);

--- a/pytest/tests/sanity/routing_table_sync.py
+++ b/pytest/tests/sanity/routing_table_sync.py
@@ -170,16 +170,6 @@ for (left, right, common, TIMEOUT) in tests:
         var_b = {(x['key'][0], x['key'][1], x['nonce']) for x in var_b}
         return var_a, var_b
 
-    def adv_get_routing_table_new(n):
-        logger.info("getting routing tables")
-        var_a = n[0].json_rpc("adv_get_routing_table_new", {},
-                              timeout=60)["result"]["edges_info"]
-        var_b = n[1].json_rpc("adv_get_routing_table_new", {},
-                              timeout=60)["result"]["edges_info"]
-        var_a = {(x['key'][0], x['key'][1], x['nonce']) for x in var_a}
-        var_b = {(x['key'][0], x['key'][1], x['nonce']) for x in var_b}
-        return var_a, var_b
-
     # compute set difference of routing tables
     a, b = adv_get_routing_table(nodes)
     logger.info("case 1 nodes %s vs %s diff %s " %
@@ -187,12 +177,6 @@ for (left, right, common, TIMEOUT) in tests:
     assert (len(a) == 1 + left + common)
     assert (len(b) == 1 + right + common)
     assert (len(a.symmetric_difference(b)) == left + right)
-    a2, b2 = adv_get_routing_table_new(nodes)
-    logger.info("case 1 nodes %s vs %s diff %s " %
-                (len(a2), len(b2), len(a2.symmetric_difference(b2))))
-    assert (len(a2) == 1 + left + common)
-    assert (len(b2) == 1 + right + common)
-    assert (len(a2.symmetric_difference(b2)) == left + right)
 
     time.sleep(1)
 
@@ -219,10 +203,6 @@ for (left, right, common, TIMEOUT) in tests:
     logger.info("case 2 nodes %s vs %s diff %s " %
                 (len(a), len(b), len(a.symmetric_difference(b))))
     assert (len(a.symmetric_difference(b)) == 0)
-    a2, b2 = adv_get_routing_table_new(nodes)
-    logger.info("case 2 nodes %s vs %s diff %s " %
-                (len(a2), len(b2), len(a2.symmetric_difference(b2))))
-    assert (len(a2.symmetric_difference(b2)) == 0)
 
     # remove edges
     logger.info("removing edges")
@@ -238,9 +218,6 @@ for (left, right, common, TIMEOUT) in tests:
                       timeout=30)
 
     a, b = adv_get_routing_table(nodes)
-    a2, b2 = adv_get_routing_table_new(nodes)
     logger.info("case 3: %s %s" % (len(a), len(b)))
     assert (len(a) == 1 and len(b) == 1)
-    logger.info("case 3: %s %s" % (len(a2), len(b2)))
-    assert (len(a2) == 1 and len(b2) == 1)
     logger.info("test took %s" % round(time.time() - start))


### PR DESCRIPTION
In this PR we will creating copy of routing table to another thread.

This is related to https://github.com/near/nearcore/issues/4859

Summary:
- `PeerManager` no longer has copy of `edges_info`, instead it only stores list of edges to peers that it is/was connected to `local_edges_info`
- Removed usage of edges in `PeerManager` that were stored in ` edges_info`
- Computation of `peer_forwarding` is done in `RoutingTableActor`, `PeerManager` gets it from another thread every second / tests now use `RoutingTableActor` instead of `RoutingTable` struct
- moved `pub raw_graph: Graph,`  and a few other data structures  to `RoutingTableActor`
- Removed `adv_get_routing_table_new` from jsonrpc server. Now, routing table is only stored in one place, so this method is no longer needed
- Added code/struct comments

Closes #4859