### PR TITLE
chore: don't check latest crates.io releases on CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -150,14 +150,3 @@ steps:
   #  branches: "!master"
   #  artifact_paths:
   #  - "rainbow-bridge/logs/**/*.log"
-
-  - label: "cargo check nearcore library (without Cargo.lock)"
-    command: |
-      source ~/.cargo/env && set -eux
-      rm Cargo.lock
-      cd nearcore
-      RUSTFLAGS='-D warnings' cargo check
-
-    timeout: 30
-    agents:
-    - "distro=amazonlinux"


### PR DESCRIPTION
This CI job tries to build nearcore without Cargo.lock. That means it
uses the latest crates.io dependencies at the time the build is run.

This isn't a useful property to check for us -- we build a binary, and
we ship Cargo.lock. We only care about specific version set pinned
there. We are not a library, we are an end-application.

Additionally, this check creates more busy work for us. Given the amount
of dependencies we have, it's highly probable that someone would
sometimes publish a broken revision (which would be subsequently yank).
With the current setup, this'll break any PR to nearcore, even those
that don't touch dependencies.