### PR TITLE
nightly: disable currently broken tests

### DIFF
--- a/nightly/pytest-sanity.txt
+++ b/nightly/pytest-sanity.txt
@@ -63,7 +63,10 @@ pytest --timeout=360 sanity/block_sync_archival.py --features nightly_protocol,n
 pytest --timeout=240 sanity/validator_switch.py
 pytest --timeout=240 sanity/validator_switch.py --features nightly_protocol,nightly_protocol_features
 pytest --timeout=240 sanity/restaked.py
-pytest --timeout=240 sanity/restaked.py --features nightly_protocol,nightly_protocol_features
+# TODO(#4618): This is currently broken (even though non-nightly
+# works).  Comment out while we’re working on a fix / deciding whether
+# to remove them.
+#pytest --timeout=240 sanity/restaked.py --features nightly_protocol,nightly_protocol_features
 pytest --timeout=240 sanity/rpc_state_changes.py
 pytest --timeout=240 sanity/rpc_state_changes.py --features nightly_protocol,nightly_protocol_features
 pytest sanity/rpc_max_gas_burnt.py
@@ -86,8 +89,10 @@ pytest --timeout=300 sanity/large_messages.py
 pytest --timeout=300 sanity/large_messages.py --features nightly_protocol,nightly_protocol_features
 pytest --timeout=120 sanity/handshake_tie_resolution.py
 pytest --timeout=120 sanity/handshake_tie_resolution.py --features nightly_protocol,nightly_protocol_features
-pytest sanity/repro_2916.py
-pytest sanity/repro_2916.py --features nightly_protocol,nightly_protocol_features
+# TODO(#4618): Those tests are currently broken.  Comment out while we’re
+# working on a fix / deciding whether to remove them.
+#pytest sanity/repro_2916.py
+#pytest sanity/repro_2916.py --features nightly_protocol,nightly_protocol_features
 pytest --timeout=240 sanity/switch_node_key.py
 pytest --timeout=240 sanity/switch_node_key.py --features nightly_protocol,nightly_protocol_features
 # TODO: re-enable after #2949 is fixed
@@ -112,8 +117,10 @@ pytest sanity/proxy_example.py
 pytest sanity/proxy_example.py --features nightly_protocol,nightly_protocol_features
 pytest sanity/rpc_tx_submission.py
 pytest sanity/rpc_tx_submission.py --features nightly_protocol,nightly_protocol_features
-pytest sanity/state_sync_fail.py
-pytest sanity/state_sync_fail.py --features nightly_protocol,nightly_protocol_features
+# TODO(#4618): Those tests are currently broken.  Comment out while we’re
+# working on a fix / deciding whether to remove them.
+#pytest sanity/state_sync_fail.py
+#pytest sanity/state_sync_fail.py --features nightly_protocol,nightly_protocol_features
 pytest sanity/garbage_collection_sharding_upgrade.py
 pytest sanity/garbage_collection_sharding_upgrade.py --features nightly_protocol,nightly_protocol_features
 

--- a/nightly/pytest-sanity.txt
+++ b/nightly/pytest-sanity.txt
@@ -117,12 +117,13 @@ pytest sanity/proxy_example.py
 pytest sanity/proxy_example.py --features nightly_protocol,nightly_protocol_features
 pytest sanity/rpc_tx_submission.py
 pytest sanity/rpc_tx_submission.py --features nightly_protocol,nightly_protocol_features
+pytest sanity/state_sync_fail.py
 # TODO(#4618): Those tests are currently broken.  Comment out while we’re
 # working on a fix / deciding whether to remove them.
-#pytest sanity/state_sync_fail.py
 #pytest sanity/state_sync_fail.py --features nightly_protocol,nightly_protocol_features
-pytest sanity/garbage_collection_sharding_upgrade.py
-pytest sanity/garbage_collection_sharding_upgrade.py --features nightly_protocol,nightly_protocol_features
+# TODO(#5095): Currently broken.
+#pytest sanity/garbage_collection_sharding_upgrade.py
+#pytest sanity/garbage_collection_sharding_upgrade.py --features nightly_protocol,nightly_protocol_features
 
 
 # TODO(#4618): Those tests are currently broken.  Comment out while we’re


### PR DESCRIPTION
Those tests are consistently failing. Disable them and add to
the tracking Issue.

Issues: https://github.com/near/nearcore/issues/4618
Issue: https://github.com/near/nearcore/issues/5095