### PR TITLE
Mocking the system clock

### DIFF
--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -1,7 +1,9 @@
 use std::fmt::{self, Display};
 use std::io;
 
-use chrono::{DateTime, Utc};
+use chrono::DateTime;
+use near_primitives::time::Utc;
+
 use failure::{Backtrace, Context, Fail};
 use log::error;
 

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -4,8 +4,8 @@ use std::time::{Duration as TimeDuration, Instant};
 
 use borsh::BorshSerialize;
 use chrono::Duration;
-use chrono::Utc;
 use itertools::Itertools;
+use near_primitives::time::{Clock, Utc};
 use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
 use rand::SeedableRng;
@@ -476,7 +476,7 @@ impl Chain {
         self.orphans.add(Orphan {
             block: block.clone(),
             provenance: Provenance::NONE,
-            added: Instant::now(),
+            added: Clock::instant(),
         });
         Ok(())
     }
@@ -1145,7 +1145,7 @@ impl Chain {
                         // we only add blocks that couldn't have been gc'ed to the orphan pool.
                         if block_height >= tail_height {
                             let block_hash = *block.hash();
-                            let orphan = Orphan { block, provenance, added: Instant::now() };
+                            let orphan = Orphan { block, provenance, added: Clock::instant() };
 
                             self.orphans.add(orphan);
 
@@ -1165,7 +1165,7 @@ impl Chain {
                     ErrorKind::ChunksMissing(missing_chunks) => {
                         let block_hash = *block.hash();
                         block_misses_chunks(missing_chunks.clone());
-                        let orphan = Orphan { block, provenance, added: Instant::now() };
+                        let orphan = Orphan { block, provenance, added: Clock::instant() };
 
                         self.blocks_with_missing_chunks.add_block_with_missing_chunks(
                             orphan,

--- a/chain/chain/src/doomslug.rs
+++ b/chain/chain/src/doomslug.rs
@@ -5,6 +5,7 @@ use std::time::{Duration, Instant};
 use near_crypto::Signature;
 use near_primitives::block::{Approval, ApprovalInner};
 use near_primitives::hash::CryptoHash;
+use near_primitives::time::Clock;
 use near_primitives::types::{AccountId, ApprovalStake, Balance, BlockHeight, BlockHeightDelta};
 use near_primitives::validator_signer::ValidatorSigner;
 
@@ -296,8 +297,8 @@ impl Doomslug {
             tip: DoomslugTip { block_hash: CryptoHash::default(), height: 0 },
             endorsement_pending: false,
             timer: DoomslugTimer {
-                started: Instant::now(),
-                last_endorsement_sent: Instant::now(),
+                started: Clock::instant(),
+                last_endorsement_sent: Clock::instant(),
                 height: 0,
                 endorsement_delay,
                 min_delay,
@@ -596,11 +597,12 @@ impl Doomslug {
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
-    use std::time::{Duration, Instant};
+    use std::time::Duration;
 
     use near_crypto::{KeyType, SecretKey};
     use near_primitives::block::{Approval, ApprovalInner};
     use near_primitives::hash::hash;
+    use near_primitives::time::Clock;
     use near_primitives::types::{AccountId, ApprovalStake};
     use near_primitives::validator_signer::InMemoryValidatorSigner;
 
@@ -625,7 +627,7 @@ mod tests {
             DoomslugThresholdMode::TwoThirds,
         );
 
-        let mut now = Instant::now(); // For the test purposes the absolute value of the initial instant doesn't matter
+        let mut now = Clock::instant(); // For the test purposes the absolute value of the initial instant doesn't matter
 
         // Set a new tip, must produce an endorsement
         ds.set_tip(now, hash(&[1]), 1, 1);
@@ -781,7 +783,7 @@ mod tests {
             DoomslugThresholdMode::TwoThirds,
         );
 
-        let mut now = Instant::now();
+        let mut now = Clock::instant();
 
         // In the comments below the format is
         // account, height -> approved stake
@@ -914,7 +916,12 @@ mod tests {
         let a2_3 = Approval::new(hash(&[3]), 3, 4, &signers[2]);
 
         // Process first approval, and then process it again and make sure it works
-        tracker.process_approval(Instant::now(), &a1_1, &stakes, DoomslugThresholdMode::TwoThirds);
+        tracker.process_approval(
+            Clock::instant(),
+            &a1_1,
+            &stakes,
+            DoomslugThresholdMode::TwoThirds,
+        );
 
         assert_eq!(
             tracker
@@ -934,7 +941,12 @@ mod tests {
             0
         );
 
-        tracker.process_approval(Instant::now(), &a1_1, &stakes, DoomslugThresholdMode::TwoThirds);
+        tracker.process_approval(
+            Clock::instant(),
+            &a1_1,
+            &stakes,
+            DoomslugThresholdMode::TwoThirds,
+        );
 
         assert_eq!(
             tracker
@@ -955,8 +967,18 @@ mod tests {
         );
 
         // Process the remaining two approvals on the first block
-        tracker.process_approval(Instant::now(), &a1_2, &stakes, DoomslugThresholdMode::TwoThirds);
-        tracker.process_approval(Instant::now(), &a1_3, &stakes, DoomslugThresholdMode::TwoThirds);
+        tracker.process_approval(
+            Clock::instant(),
+            &a1_2,
+            &stakes,
+            DoomslugThresholdMode::TwoThirds,
+        );
+        tracker.process_approval(
+            Clock::instant(),
+            &a1_3,
+            &stakes,
+            DoomslugThresholdMode::TwoThirds,
+        );
 
         assert_eq!(
             tracker
@@ -977,7 +999,12 @@ mod tests {
         );
 
         // Process new approvals one by one, expect the approved and endorsed stake to slowly decrease
-        tracker.process_approval(Instant::now(), &a2_1, &stakes, DoomslugThresholdMode::TwoThirds);
+        tracker.process_approval(
+            Clock::instant(),
+            &a2_1,
+            &stakes,
+            DoomslugThresholdMode::TwoThirds,
+        );
 
         assert_eq!(
             tracker
@@ -997,7 +1024,12 @@ mod tests {
             5
         );
 
-        tracker.process_approval(Instant::now(), &a2_2, &stakes, DoomslugThresholdMode::TwoThirds);
+        tracker.process_approval(
+            Clock::instant(),
+            &a2_2,
+            &stakes,
+            DoomslugThresholdMode::TwoThirds,
+        );
 
         assert_eq!(
             tracker
@@ -1018,7 +1050,12 @@ mod tests {
         );
 
         // As we update the last of the three approvals, the tracker for the first block should be completely removed
-        tracker.process_approval(Instant::now(), &a2_3, &stakes, DoomslugThresholdMode::TwoThirds);
+        tracker.process_approval(
+            Clock::instant(),
+            &a2_3,
+            &stakes,
+            DoomslugThresholdMode::TwoThirds,
+        );
 
         assert!(tracker.approval_trackers.get(&ApprovalInner::Skip(1)).is_none());
 
@@ -1043,7 +1080,12 @@ mod tests {
             5
         );
 
-        tracker.process_approval(Instant::now(), &a2_3, &stakes, DoomslugThresholdMode::TwoThirds);
+        tracker.process_approval(
+            Clock::instant(),
+            &a2_3,
+            &stakes,
+            DoomslugThresholdMode::TwoThirds,
+        );
 
         assert_eq!(
             tracker

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use cached::{Cached, SizedCache};
-use chrono::Utc;
+use near_primitives::time::Utc;
 
 use near_chain_primitives::error::{Error, ErrorKind};
 use near_primitives::block::{Approval, Tip};

--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -26,6 +26,7 @@ use validate::StoreValidatorError;
 
 use crate::RuntimeAdapter;
 use near_primitives::shard_layout::get_block_shard_uid_rev;
+use near_primitives::time::Clock;
 
 mod validate;
 
@@ -98,7 +99,7 @@ impl StoreValidator {
             store: store.clone(),
             inner: StoreValidatorCache::new(),
             timeout: None,
-            start_time: Instant::now(),
+            start_time: Clock::instant(),
             errors: vec![],
             tests: 0,
         }
@@ -345,7 +346,7 @@ impl StoreValidator {
         Ok(())
     }
     pub fn validate(&mut self) {
-        self.start_time = Instant::now();
+        self.start_time = Clock::instant();
 
         // Init checks
         // Check Head-Tail validity and fill cache with their values

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
 
 use borsh::{BorshDeserialize, BorshSerialize};
-use chrono::Utc;
+
 use num_rational::Rational;
 use tracing::debug;
 
@@ -56,6 +56,7 @@ use crate::types::{
 use crate::Doomslug;
 use crate::{BlockHeader, DoomslugThresholdMode, RuntimeAdapter};
 use near_primitives::epoch_manager::ShardConfig;
+use near_primitives::time::Clock;
 
 #[derive(BorshSerialize, BorshDeserialize, Hash, PartialEq, Eq, Ord, PartialOrd, Clone, Debug)]
 struct AccountNonce(AccountId, Nonce);
@@ -1220,7 +1221,7 @@ pub fn setup_with_tx_validity_period(
     let chain = Chain::new(
         runtime.clone(),
         &ChainGenesis {
-            time: Utc::now(),
+            time: Clock::utc(),
             height: 0,
             gas_limit: 1_000_000,
             min_gas_price: 100,
@@ -1267,7 +1268,7 @@ pub fn setup_with_validators(
     let chain = Chain::new(
         runtime.clone(),
         &ChainGenesis {
-            time: Utc::now(),
+            time: Clock::utc(),
             height: 0,
             gas_limit: 1_000_000,
             min_gas_price: 100,
@@ -1386,7 +1387,7 @@ pub fn display_chain(me: &Option<AccountId>, chain: &mut Chain, tail: bool) {
 impl ChainGenesis {
     pub fn test() -> Self {
         ChainGenesis {
-            time: Utc::now(),
+            time: Clock::utc(),
             height: 0,
             gas_limit: 1_000_000,
             min_gas_price: 0,
@@ -1402,7 +1403,7 @@ impl ChainGenesis {
 
 #[cfg(test)]
 mod test {
-    use std::time::Instant;
+    use std::convert::TryFrom;
 
     use borsh::BorshSerialize;
     use rand::Rng;
@@ -1410,6 +1411,7 @@ mod test {
     use near_primitives::hash::{hash, CryptoHash};
     use near_primitives::receipt::Receipt;
     use near_primitives::sharding::ReceiptList;
+    use near_primitives::time::Clock;
     use near_primitives::types::{AccountId, EpochId, NumShards};
     use near_store::test_utils::create_test_store;
 
@@ -1459,10 +1461,10 @@ mod test {
                 )
             })
             .collect::<Vec<_>>();
-        let start = Instant::now();
+        let start = Clock::instant();
         let naive_result = runtime_adapter.naive_build_receipt_hashes(&receipts);
         let naive_duration = start.elapsed();
-        let start = Instant::now();
+        let start = Clock::instant();
         let shard_layout = runtime_adapter.get_shard_layout(&EpochId::default()).unwrap();
         let prod_result = runtime_adapter.build_receipts_hashes(&receipts, &shard_layout);
         let prod_duration = start.elapsed();

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -3,7 +3,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use borsh::{BorshDeserialize, BorshSerialize};
-use chrono::{DateTime, Utc};
+use chrono::DateTime;
+use near_primitives::time::Utc;
 use num_rational::Rational;
 use serde::Serialize;
 
@@ -800,7 +801,7 @@ pub enum ValidatorInfoIdentifier {
 
 #[cfg(test)]
 mod tests {
-    use chrono::Utc;
+    use near_primitives::time::Utc;
 
     use near_crypto::KeyType;
     use near_primitives::block::{genesis_chunks, Approval};

--- a/chain/chain/tests/doomslug.rs
+++ b/chain/chain/tests/doomslug.rs
@@ -1,11 +1,11 @@
 #[cfg(test)]
 #[cfg(feature = "expensive_tests")]
 mod tests {
+    use near_primitives::time::Clock;
+    use rand::{thread_rng, Rng};
     use std::collections::{HashMap, HashSet};
     use std::sync::Arc;
     use std::time::{Duration, Instant};
-
-    use rand::{thread_rng, Rng};
 
     use near_chain::{Doomslug, DoomslugThresholdMode};
     use near_crypto::{KeyType, SecretKey};
@@ -75,7 +75,7 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
-        let mut now = Instant::now();
+        let mut now = Clock::instant();
         let started = now;
 
         let gst = now + time_to_gst;

--- a/chain/chunks/src/test_utils.rs
+++ b/chain/chunks/src/test_utils.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use chrono::Utc;
+use near_primitives::time::Clock;
 
 use near_chain::test_utils::KeyValueRuntime;
 use near_chain::types::RuntimeAdapter;
@@ -67,7 +67,7 @@ impl Default for SealsManagerTestFixture {
             Default::default(),
             Default::default(),
             Default::default(),
-            Utc::now(),
+            Clock::utc(),
             Default::default(),
             Default::default(),
             Default::default(),

--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -3,7 +3,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use actix::Message;
-use chrono::{DateTime, Utc};
+use chrono::DateTime;
+use near_primitives::time::Utc;
 use serde::{Deserialize, Serialize};
 
 use near_chain_configs::ProtocolConfigView;

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -7,8 +7,8 @@ use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
 use cached::{Cached, SizedCache};
-use chrono::Utc;
 use log::{debug, error, info, warn};
+use near_primitives::time::Clock;
 
 use near_chain::chain::{
     ApplyStatePartsRequest, BlockCatchUpRequest, BlocksCatchUpState, StateSplitRequest,
@@ -158,7 +158,6 @@ impl Client {
             validator_signer.clone(),
             doomslug_threshold_mode,
         );
-
         Ok(Self {
             #[cfg(feature = "test_features")]
             adv_produce_blocks: false,
@@ -181,21 +180,21 @@ impl Client {
             challenges: Default::default(),
             rs: ReedSolomonWrapper::new(data_parts, parity_parts),
             rebroadcasted_blocks: SizedCache::with_size(NUM_REBROADCAST_BLOCKS),
-            last_time_head_progress_made: Instant::now(),
+            last_time_head_progress_made: Clock::instant(),
         })
     }
 
     // Checks if it's been at least `stall_timeout` since the last time the head was updated, or
     // this method was called. If yes, rebroadcasts the current head.
     pub fn check_head_progress_stalled(&mut self, stall_timeout: Duration) -> Result<(), Error> {
-        if Instant::now() > self.last_time_head_progress_made + stall_timeout
+        if Clock::instant() > self.last_time_head_progress_made + stall_timeout
             && !self.sync_status.is_syncing()
         {
             let block = self.chain.get_block(&self.chain.head()?.last_block_hash)?;
             self.network_adapter.do_send(PeerManagerMessageRequest::NetworkRequests(
                 NetworkRequests::Block { block: block.clone() },
             ));
-            self.last_time_head_progress_made = Instant::now();
+            self.last_time_head_progress_made = Clock::instant();
         }
         Ok(())
     }
@@ -505,7 +504,7 @@ impl Client {
         // Update latest known even before returning block out, to prevent race conditions.
         self.chain.mut_store().save_latest_known(LatestKnown {
             height: next_height,
-            seen: to_timestamp(Utc::now()),
+            seen: to_timestamp(Clock::utc()),
         })?;
 
         near_metrics::inc_counter(&metrics::BLOCK_PRODUCED_TOTAL);
@@ -759,7 +758,7 @@ impl Client {
         }
 
         if let Ok(Some(_)) = result {
-            self.last_time_head_progress_made = Instant::now();
+            self.last_time_head_progress_made = Clock::instant();
         }
 
         let protocol_version = self
@@ -926,9 +925,8 @@ impl Client {
             } else {
                 self.chain.get_block_header(&last_final_hash)?.height()
             };
-
             self.doomslug.set_tip(
-                Instant::now(),
+                Clock::instant(),
                 tip.last_block_hash,
                 tip.height,
                 last_final_height,
@@ -1374,8 +1372,7 @@ impl Client {
                     return;
                 }
             };
-
-        self.doomslug.on_approval_message(Instant::now(), &approval, &block_producer_stakes);
+        self.doomslug.on_approval_message(Clock::instant(), &approval, &block_producer_stakes);
     }
 
     /// Forwards given transaction to upcoming validators.

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -1,6 +1,6 @@
+use near_primitives::time::Instant;
 use std::cmp::min;
 use std::sync::Arc;
-use std::time::Instant;
 
 use actix::Addr;
 use ansi_term::Color::{Blue, Cyan, Green, White, Yellow};
@@ -24,6 +24,7 @@ use near_telemetry::{telemetry, TelemetryActor};
 use crate::metrics;
 use crate::SyncStatus;
 use near_client_primitives::types::ShardSyncStatus;
+use near_primitives::time::Clock;
 
 pub struct ValidatorInfoHelper {
     pub is_validator: bool,
@@ -63,7 +64,7 @@ impl InfoHelper {
             nearcore_version: client_config.version.clone(),
             sys: System::new(),
             pid: get_current_pid().ok(),
-            started: Instant::now(),
+            started: Clock::instant(),
             num_blocks_processed: 0,
             gas_used: 0,
             telemetry_actor,
@@ -160,7 +161,7 @@ impl InfoHelper {
         let teragas = 1_000_000_000_000u64;
         set_gauge(&metrics::AVG_TGAS_USAGE, (avg_gas_used as f64 / teragas as f64).round() as i64);
 
-        self.started = Instant::now();
+        self.started = Clock::instant();
         self.num_blocks_processed = 0;
         self.gas_used = 0;
 

--- a/chain/client/src/sync.rs
+++ b/chain/client/src/sync.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::{ops::Add, time::Duration as TimeDuration};
 
 use ansi_term::Color::{Purple, Yellow};
-use chrono::{DateTime, Duration, Utc};
+use chrono::{DateTime, Duration};
 use futures::{future, FutureExt};
 use log::{debug, error, info, warn};
 use rand::seq::{IteratorRandom, SliceRandom};
@@ -21,6 +21,7 @@ use near_primitives::block::Tip;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
 use near_primitives::syncing::get_num_state_parts;
+use near_primitives::time::{Clock, Utc};
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{
     AccountId, BlockHeight, BlockHeightDelta, EpochId, ShardId, StateRoot,
@@ -121,7 +122,7 @@ impl EpochSync {
             next_epoch_id: genesis_next_epoch_id.clone(),
             next_block_producers: first_epoch_block_producers,
             requested_epoch_id: genesis_epoch_id,
-            last_request_time: Utc::now(),
+            last_request_time: Clock::utc(),
             last_request_peer_id: None,
             request_timeout: Duration::from_std(request_timeout).unwrap(),
             peer_timeout: Duration::from_std(peer_timeout).unwrap(),
@@ -160,7 +161,7 @@ impl HeaderSync {
         HeaderSync {
             network_adapter,
             history_locator: vec![],
-            prev_header_sync: (Utc::now(), 0, 0, 0),
+            prev_header_sync: (Clock::utc(), 0, 0, 0),
             syncing_peer: None,
             stalling_ts: None,
             initial_timeout: Duration::from_std(initial_timeout).unwrap(),
@@ -227,7 +228,7 @@ impl HeaderSync {
         header_head: &Tip,
         highest_height: BlockHeight,
     ) -> bool {
-        let now = Utc::now();
+        let now = Clock::utc();
         let (timeout, old_expected_height, prev_height, prev_highest_height) =
             self.prev_header_sync;
 
@@ -537,8 +538,7 @@ impl BlockSync {
             },
         };
         let next_height = chain.get_block_header(&next_hash)?.height();
-
-        let request = BlockSyncRequest { height: next_height, hash: next_hash, when: Utc::now() };
+        let request = BlockSyncRequest { height: next_height, hash: next_hash, when: Clock::utc() };
 
         let head = chain.head()?;
         let header_head = chain.header_head()?;
@@ -576,7 +576,7 @@ impl BlockSync {
             None => Ok(true),
             Some(request) => Ok(chain.head()?.height >= request.height
                 || chain.is_chunk_orphan(&request.hash)
-                || Utc::now() - request.when > Duration::seconds(BLOCK_REQUEST_TIMEOUT)),
+                || Clock::utc() - request.when > Duration::seconds(BLOCK_REQUEST_TIMEOUT)),
         }
     }
 }
@@ -598,10 +598,10 @@ struct PendingRequestStatus {
 
 impl PendingRequestStatus {
     fn new(timeout: Duration) -> Self {
-        Self { missing_parts: 1, wait_until: Utc::now().add(timeout) }
+        Self { missing_parts: 1, wait_until: Clock::utc().add(timeout) }
     }
     fn expired(&self) -> bool {
-        Utc::now() > self.wait_until
+        Clock::utc() > self.wait_until
     }
 }
 
@@ -1173,7 +1173,7 @@ impl StateSync {
         state_split_scheduler: &dyn Fn(StateSplitRequest),
     ) -> Result<StateSyncResult, near_chain::Error> {
         let prev_hash = chain.get_block_header(&sync_hash)?.prev_hash().clone();
-        let now = Utc::now();
+        let now = Clock::utc();
 
         let (request_block, have_block) = self.sync_block_status(&prev_hash, chain, now)?;
 

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -5,12 +5,12 @@ use std::mem::swap;
 use std::ops::DerefMut;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
-use std::time::Instant;
 
 use actix::actors::mocker::Mocker;
 use actix::{Actor, Addr, AsyncContext, Context};
-use chrono::{DateTime, Utc};
+use chrono::DateTime;
 use futures::{future, FutureExt};
+use near_primitives::time::Utc;
 use num_rational::Rational;
 use rand::{thread_rng, Rng};
 
@@ -55,6 +55,7 @@ use near_chain::chain::{do_apply_chunks, BlockCatchUpRequest, StateSplitRequest}
 use near_chain::types::AcceptedBlock;
 use near_client_primitives::types::Error;
 use near_primitives::runtime::config::RuntimeConfig;
+use near_primitives::time::{Clock, Instant};
 use near_primitives::utils::MaybeValidated;
 
 pub type PeerManagerMock = Mocker<PeerManagerActor>;
@@ -282,7 +283,7 @@ pub fn setup_mock_with_validity_period_and_no_epoch_sync(
             false,
             network_adapter.clone(),
             transaction_validity_period,
-            Utc::now(),
+            Clock::utc(),
             ctx,
         );
         vca = Some(view_client_addr);
@@ -322,7 +323,7 @@ impl BlockStats {
             hash2depth: HashMap::new(),
             num_blocks: 0,
             max_chain_length: 0,
-            last_check: Instant::now(),
+            last_check: Clock::instant(),
             max_divergence: 0,
             last_hash: None,
             parent: HashMap::new(),
@@ -371,7 +372,7 @@ impl BlockStats {
     }
 
     pub fn check_stats(&mut self, force: bool) {
-        let now = Instant::now();
+        let now = Clock::instant();
         let diff = now.duration_since(self.last_check);
         if !force && diff.lt(&Duration::from_secs(60)) {
             return;
@@ -485,7 +486,7 @@ pub fn setup_mock_all_validators(
     let key_pairs = key_pairs;
 
     let addresses: Vec<_> = (0..key_pairs.len()).map(|i| hash(vec![i as u8].as_ref())).collect();
-    let genesis_time = Utc::now();
+    let genesis_time = Clock::utc();
     let mut ret = vec![];
 
     let connectors: Arc<RwLock<Vec<(Addr<ClientActor>, Addr<ViewClientActor>)>>> =

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -1,6 +1,7 @@
 //! Readonly view of the chain and state of the database.
 //! Useful for querying from RPC.
 
+use near_primitives::time::Clock;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::collections::VecDeque;
@@ -161,7 +162,7 @@ impl ViewClientActor {
     }
 
     fn need_request<K: Hash + Eq + Clone>(key: K, cache: &mut SizedCache<K, Instant>) -> bool {
-        let now = Instant::now();
+        let now = Clock::instant();
         let need_request = match cache.cache_get(&key) {
             Some(time) => now - *time > Duration::from_millis(REQUEST_WAIT_TIME),
             None => true,
@@ -510,7 +511,7 @@ impl ViewClientActor {
 
     fn check_state_sync_request(&self) -> bool {
         let mut cache = self.state_request_cache.lock().expect(POISONED_LOCK_ERR);
-        let now = Instant::now();
+        let now = Clock::instant();
         let cutoff = now - self.config.view_client_throttle_period;
         // Assume that time is linear. While in different threads there might be some small differences,
         // it should not matter in practice.

--- a/chain/client/tests/query_client.rs
+++ b/chain/client/tests/query_client.rs
@@ -1,7 +1,6 @@
 use actix::System;
 use futures::{future, FutureExt};
 
-use chrono::Utc;
 use near_actix_test_utils::run_actix;
 use near_client::test_utils::{setup_no_network, setup_only_view};
 use near_client::{
@@ -13,6 +12,7 @@ use near_network::test_utils::MockPeerManagerAdapter;
 use near_network::types::{NetworkViewClientMessages, NetworkViewClientResponses};
 use near_network::{NetworkClientMessages, NetworkClientResponses, PeerInfo};
 use near_primitives::block::{Block, BlockHeader};
+use near_primitives::time::Utc;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{BlockId, BlockReference, EpochId};
 use near_primitives::utils::to_timestamp;

--- a/chain/network-primitives/src/types.rs
+++ b/chain/network-primitives/src/types.rs
@@ -9,7 +9,8 @@ use std::time::Duration;
 use actix::dev::{MessageResponse, ResponseChannel};
 use actix::{Actor, Message};
 use borsh::{BorshDeserialize, BorshSerialize};
-use chrono::{DateTime, Utc};
+use chrono::DateTime;
+use near_primitives::time::{Clock, Utc};
 use serde::{Deserialize, Serialize};
 use strum::AsStaticStr;
 use tokio::net::TcpStream;
@@ -664,8 +665,8 @@ impl KnownPeerState {
         KnownPeerState {
             peer_info,
             status: KnownPeerStatus::Unknown,
-            first_seen: to_timestamp(Utc::now()),
-            last_seen: to_timestamp(Utc::now()),
+            first_seen: to_timestamp(Clock::utc()),
+            last_seen: to_timestamp(Clock::utc()),
         }
     }
 

--- a/chain/network/src/peer_manager/peer_store.rs
+++ b/chain/network/src/peer_manager/peer_store.rs
@@ -6,7 +6,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use borsh::BorshSerialize;
-use chrono::Utc;
+use near_primitives::time::Utc;
 use rand::seq::SliceRandom;
 use rand::thread_rng;
 use tracing::{debug, error};

--- a/chain/network/src/routing/route_back_cache.rs
+++ b/chain/network/src/routing/route_back_cache.rs
@@ -1,9 +1,9 @@
+use near_primitives::hash::CryptoHash;
+use near_primitives::network::PeerId;
+use near_primitives::time::Clock;
 use std::collections::btree_map;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::time::{Duration, Instant};
-
-use near_primitives::hash::CryptoHash;
-use near_primitives::network::PeerId;
 
 type Size = u64;
 
@@ -115,9 +115,8 @@ impl RouteBackCache {
         if self.is_full() {
             self.remove_frequent();
 
-            let now = Instant::now();
+            let now = Clock::instant();
             let remove_until = now - self.evict_timeout;
-
             let mut remove_empty = vec![];
 
             for (key, value) in self.record_per_target.iter_mut() {
@@ -207,7 +206,7 @@ impl RouteBackCache {
 
         self.remove_evicted();
 
-        let now = Instant::now();
+        let now = Clock::instant();
 
         self.main.insert(hash, (now, target.clone()));
 

--- a/chain/network/src/routing/routing.rs
+++ b/chain/network/src/routing/routing.rs
@@ -1,3 +1,4 @@
+use near_primitives::time::Clock;
 use std::collections::{hash_map::Entry, HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -538,9 +539,9 @@ impl RoutingTableView {
         let mut res = None;
 
         if let Some(nonces) = self.waiting_pong.cache_get_mut(&pong.source) {
-            res = nonces
-                .cache_remove(&(pong.nonce as usize))
-                .and_then(|sent| Some(Instant::now().duration_since(sent).as_secs_f64() * 1000f64));
+            res = nonces.cache_remove(&(pong.nonce as usize)).and_then(|sent| {
+                Some(Clock::instant().duration_since(sent).as_secs_f64() * 1000f64)
+            });
         }
 
         let cnt = self.pong_info.cache_get(&(pong.nonce as usize)).map(|v| v.1).unwrap_or(0);
@@ -559,7 +560,7 @@ impl RoutingTableView {
             self.waiting_pong.cache_get_mut(&target).unwrap()
         };
 
-        entry.cache_set(nonce, Instant::now());
+        entry.cache_set(nonce, Clock::instant());
     }
 
     pub fn get_ping(&mut self, peer_id: PeerId) -> usize {

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -1,9 +1,9 @@
+use near_primitives::time::Instant;
 use std::collections::HashMap;
 use std::fmt;
 use std::fmt::{Debug, Formatter};
 use std::io;
 use std::sync::{Arc, Mutex, RwLock};
-use std::time::Instant;
 
 use actix::dev::{MessageResponse, ResponseChannel};
 use actix::{Actor, Addr, MailboxError, Message, Recipient};

--- a/chain/network/tests/cache_edges.rs
+++ b/chain/network/tests/cache_edges.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use borsh::de::BorshDeserialize;
+use near_primitives::time::Clock;
 
 use near_crypto::Signature;
 use near_network::routing::routing::{
@@ -37,7 +38,7 @@ impl RoutingTableTest {
     fn new() -> Self {
         let me = random_peer_id();
         let store = create_test_store();
-        let now = Instant::now();
+        let now = Clock::instant();
 
         Self {
             routing_table: RoutingTableActor::new(me.clone(), store.clone()),

--- a/core/primitives/benches/serialization.rs
+++ b/core/primitives/benches/serialization.rs
@@ -3,7 +3,7 @@ extern crate bencher;
 
 use bencher::Bencher;
 use borsh::{BorshDeserialize, BorshSerialize};
-use chrono::Utc;
+use near_primitives::time::Clock;
 
 use near_crypto::{KeyType, PublicKey, Signature};
 use near_primitives::account::Account;
@@ -39,7 +39,7 @@ fn create_block() -> Block {
     let genesis = Block::genesis(
         PROTOCOL_VERSION,
         genesis_chunks.into_iter().map(|chunk| chunk.take_header()).collect(),
-        Utc::now(),
+        Clock::utc(),
         0,
         1_000,
         1_000,

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -1,7 +1,8 @@
 use std::cmp::max;
 
+use crate::time::{Clock, Utc};
 use borsh::{BorshDeserialize, BorshSerialize};
-use chrono::{DateTime, Utc};
+use chrono::DateTime;
 use near_crypto::Signature;
 use num_rational::Rational;
 use primitive_types::U256;
@@ -240,8 +241,7 @@ impl Block {
         );
 
         let new_total_supply = prev.total_supply() + minted_amount.unwrap_or(0) - balance_burnt;
-
-        let now = to_timestamp(Utc::now());
+        let now = to_timestamp(Clock::utc());
         let time = if now <= prev.raw_timestamp() { prev.raw_timestamp() + 1 } else { now };
 
         let (vrf_value, vrf_proof) = signer.compute_vrf_with_proof(prev.random_value().as_ref());

--- a/core/primitives/src/block_header.rs
+++ b/core/primitives/src/block_header.rs
@@ -1,5 +1,6 @@
+use crate::time::Utc;
 use borsh::{BorshDeserialize, BorshSerialize};
-use chrono::{DateTime, Utc};
+use chrono::DateTime;
 use serde::Serialize;
 
 use near_crypto::{KeyType, PublicKey, Signature};

--- a/core/primitives/src/lib.rs
+++ b/core/primitives/src/lib.rs
@@ -25,6 +25,7 @@ pub mod state_record;
 pub mod syncing;
 pub mod telemetry;
 pub mod test_utils;
+pub mod time;
 pub mod transaction;
 pub mod trie_key;
 pub mod types;

--- a/core/primitives/src/time.rs
+++ b/core/primitives/src/time.rs
@@ -1,0 +1,155 @@
+use std::default::Default;
+
+use chrono;
+
+pub use chrono::Utc;
+pub use std::time::{Duration, Instant};
+
+use chrono::DateTime;
+use std::cell::RefCell;
+use std::collections::VecDeque;
+
+struct MockClockPerThread {
+    utc: VecDeque<DateTime<Utc>>,
+    durations: VecDeque<Duration>,
+    utc_call_count: u64,
+    instant_call_count: u64,
+    instant: Instant,
+    is_mock: bool,
+}
+
+pub struct Clock {}
+
+impl MockClockPerThread {
+    pub fn reset(&mut self) {
+        self.utc.clear();
+        self.durations.clear();
+        self.utc_call_count = 0;
+        self.instant_call_count = 0;
+        self.instant = Instant::now();
+        self.is_mock = false;
+    }
+
+    fn with<F, T>(f: F) -> T
+    where
+        F: FnOnce(&mut MockClockPerThread) -> T,
+    {
+        thread_local! {
+            static INSTANCE: RefCell<MockClockPerThread> = RefCell::default()
+        }
+        INSTANCE.with(|it| f(&mut *it.borrow_mut()))
+    }
+
+    fn pop_utc(&mut self) -> Option<DateTime<chrono::Utc>> {
+        self.utc_call_count += 1;
+        self.utc.pop_front()
+    }
+    fn pop_instant(&mut self) -> Option<Instant> {
+        self.instant_call_count += 1;
+        let x = self.durations.pop_front();
+        match x {
+            Some(t) => self.instant.checked_add(t),
+            None => None,
+        }
+    }
+}
+
+impl Default for MockClockPerThread {
+    fn default() -> Self {
+        Self {
+            utc: VecDeque::with_capacity(16),
+            durations: VecDeque::with_capacity(16),
+            utc_call_count: 0,
+            instant_call_count: 0,
+            instant: Instant::now(),
+            is_mock: false,
+        }
+    }
+}
+
+pub struct MockClockGuard {}
+
+impl Default for MockClockGuard {
+    fn default() -> Self {
+        Clock::set_mock();
+        Self {}
+    }
+}
+
+impl Drop for MockClockGuard {
+    fn drop(&mut self) {
+        Clock::reset();
+    }
+}
+
+impl Clock {
+    pub fn set_mock() {
+        MockClockPerThread::with(|clock| {
+            clock.is_mock = true;
+        });
+    }
+    pub fn reset() {
+        MockClockPerThread::with(|clock| {
+            clock.reset();
+        });
+    }
+    pub fn add_utc(mock_date: DateTime<chrono::Utc>) {
+        MockClockPerThread::with(|clock| {
+            if clock.is_mock {
+                clock.utc.push_back(mock_date);
+            } else {
+                panic!("Use MockClockGuard in your test");
+            }
+        });
+    }
+
+    pub fn add_instant(mock_instant: Duration) {
+        MockClockPerThread::with(|clock| {
+            if clock.is_mock {
+                clock.durations.push_back(mock_instant);
+            } else {
+                panic!("Use MockClockGuard in your test");
+            }
+        });
+    }
+
+    pub fn utc() -> DateTime<chrono::Utc> {
+        MockClockPerThread::with(|clock| {
+            if clock.is_mock {
+                let x = clock.pop_utc();
+                match x {
+                    Some(t) => t,
+                    None => {
+                        panic!("Mock clock run out of samples");
+                    }
+                }
+            } else {
+                chrono::Utc::now()
+            }
+        })
+    }
+
+    pub fn instant() -> Instant {
+        MockClockPerThread::with(|clock| {
+            if clock.is_mock {
+                let x = clock.pop_instant();
+                match x {
+                    Some(t) => t,
+                    None => {
+                        panic!("Mock clock run out of samples");
+                    }
+                }
+            } else {
+                Instant::now()
+            }
+        })
+    }
+
+    pub fn instant_call_count() -> u64 {
+        MockClockPerThread::with(|clock| clock.instant_call_count)
+    }
+
+    pub fn utc_call_count() -> u64 {
+        MockClockPerThread::with(|clock| clock.utc_call_count)
+    }
+}

--- a/core/primitives/src/utils.rs
+++ b/core/primitives/src/utils.rs
@@ -3,7 +3,8 @@ use std::convert::AsRef;
 use std::fmt;
 
 use byteorder::{LittleEndian, WriteBytesExt};
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono;
+use chrono::{DateTime, NaiveDateTime};
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 use serde;
@@ -313,18 +314,18 @@ macro_rules! unwrap_option_or_return {
 }
 
 /// Converts timestamp in ns into DateTime UTC time.
-pub fn from_timestamp(timestamp: u64) -> DateTime<Utc> {
+pub fn from_timestamp(timestamp: u64) -> DateTime<chrono::Utc> {
     DateTime::from_utc(
         NaiveDateTime::from_timestamp(
             (timestamp / NS_IN_SECOND) as i64,
             (timestamp % NS_IN_SECOND) as u32,
         ),
-        Utc,
+        chrono::Utc,
     )
 }
 
 /// Converts DateTime UTC time into timestamp in ns.
-pub fn to_timestamp(time: DateTime<Utc>) -> u64 {
+pub fn to_timestamp(time: DateTime<chrono::Utc>) -> u64 {
     time.timestamp_nanos() as u64
 }
 

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -7,7 +7,7 @@ use std::fmt;
 use std::sync::Arc;
 
 use borsh::{BorshDeserialize, BorshSerialize};
-use chrono::{DateTime, Utc};
+use chrono::DateTime;
 use serde::{Deserialize, Serialize};
 
 use near_crypto::{PublicKey, Signature};
@@ -294,11 +294,11 @@ pub struct StatusSyncInfo {
     pub latest_block_hash: CryptoHash,
     pub latest_block_height: BlockHeight,
     pub latest_state_root: CryptoHash,
-    pub latest_block_time: DateTime<Utc>,
+    pub latest_block_time: DateTime<chrono::Utc>,
     pub syncing: bool,
     pub earliest_block_hash: Option<CryptoHash>,
     pub earliest_block_height: Option<BlockHeight>,
-    pub earliest_block_time: Option<DateTime<Utc>>,
+    pub earliest_block_time: Option<DateTime<chrono::Utc>>,
 }
 
 // TODO: add more information to ValidatorInfo

--- a/genesis-tools/genesis-csv-to-json/src/csv_parser.rs
+++ b/genesis-tools/genesis-csv-to-json/src/csv_parser.rs
@@ -3,8 +3,9 @@ use std::fs::File;
 use std::io::Read;
 use std::path::PathBuf;
 
-use chrono::{DateTime, Utc};
+use chrono::DateTime;
 use csv::ReaderBuilder;
+use near_primitives::time::Utc;
 use serde::{Deserialize, Serialize};
 
 use near_crypto::{KeyType, PublicKey};

--- a/integration-tests/tests/client/chunks_management.rs
+++ b/integration-tests/tests/client/chunks_management.rs
@@ -1,7 +1,7 @@
+use near_primitives::time::Instant;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
-use std::time::Instant;
 
 use actix::{Addr, System};
 use futures::{future, FutureExt};

--- a/integration-tests/tests/network/infinite_loop.rs
+++ b/integration-tests/tests/network/infinite_loop.rs
@@ -1,6 +1,6 @@
+use near_primitives::time::Instant;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
-use std::time::Instant;
 
 use actix::actors::mocker::Mocker;
 use actix::{Actor, System};

--- a/integration-tests/tests/network/runner.rs
+++ b/integration-tests/tests/network/runner.rs
@@ -5,8 +5,9 @@ use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use actix::{Actor, Addr, AsyncContext, Context, Handler, Message, System};
-use chrono::{DateTime, Utc};
+use chrono::DateTime;
 use futures::{future, FutureExt, TryFutureExt};
+use near_primitives::time::Utc;
 use tracing::debug;
 
 use near_actix_test_utils::run_actix;

--- a/integration-tests/tests/test_simple.rs
+++ b/integration-tests/tests/test_simple.rs
@@ -5,8 +5,9 @@ mod test {
     use integration_tests::node::{create_nodes, sample_two_nodes, Node};
     use integration_tests::test_helpers::{heavy_test, wait};
     use near_logger_utils::init_integration_logger;
+    use near_primitives::time::Clock;
     use near_primitives::transaction::SignedTransaction;
-    use std::time::{Duration, Instant};
+    use std::time::Duration;
 
     fn run_multiple_nodes(num_nodes: usize, num_trials: usize, test_prefix: &str) {
         init_integration_logger();
@@ -21,7 +22,7 @@ mod test {
         }
 
         // waiting for nodes to be synced
-        let started = Instant::now();
+        let started = Clock::instant();
         loop {
             if started.elapsed() > Duration::from_secs(10) {
                 panic!("nodes are not synced in 10s");

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use actix;
-use chrono::Utc;
+use near_primitives::time::Clock;
 use num_rational::Rational;
 use serde::{Deserialize, Serialize};
 use tracing::info;
@@ -535,7 +535,7 @@ impl Genesis {
         add_protocol_account(&mut records);
         let config = GenesisConfig {
             protocol_version: PROTOCOL_VERSION,
-            genesis_time: Utc::now(),
+            genesis_time: Clock::utc(),
             chain_id: random_chain_id(),
             num_block_producer_seats: num_validator_seats,
             num_block_producer_seats_per_shard: num_validator_seats_per_shard.clone(),
@@ -945,7 +945,7 @@ pub fn init_configs(
 
             let genesis_config = GenesisConfig {
                 protocol_version: PROTOCOL_VERSION,
-                genesis_time: Utc::now(),
+                genesis_time: Clock::utc(),
                 chain_id,
                 genesis_height: 0,
                 num_block_producer_seats: NUM_BLOCK_PRODUCER_SEATS,


### PR DESCRIPTION
I accidentally invoke everybody on the review. Feel free to leave, if you feel there are enough colleagues already invoked. For those who want to participate, I will explain the motivation:

We want to test our code using fuzz tests, because it provides benefits, using like random input 
 * to maximize code coverage
 * identify bugs in the code and recording the randomized input, so later a developer can replay/inspect that specific test
 
 In order to get those benefits, we need repeatable tests with require high level of determinism. Putting the `Utc::now` in blockchain header and computing hash is not deterministic. There are other source of not-deterministic behaviour like threads, random seed which will not be addressed in this review.
 
The goal of this PR is to make it possible to inject values into system clock before invoking the production code. The actual code in production should have no idea that we are mocking the system clock. 

Mocking the system clock. 
