### PR TITLE
nit: improve neard --help text

### DIFF
--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -66,7 +66,7 @@ struct NeardOpts {
     /// Verbose logging.
     #[clap(long)]
     verbose: Option<String>,
-    /// Directory for config and data (default "~/.near").
+    /// Directory for config and data.
     #[clap(long, parse(from_os_str), default_value_os = DEFAULT_HOME.as_os_str())]
     home: PathBuf,
 }

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -63,8 +63,9 @@ impl NeardCmd {
 
 #[derive(Clap, Debug)]
 struct NeardOpts {
-    /// Verbose logging.
-    #[clap(long)]
+    /// Sets verbose logging for the given target, or for all targets
+    /// if "debug" is given.
+    #[clap(long, name = "target")]
     verbose: Option<String>,
     /// Directory for config and data.
     #[clap(long, parse(from_os_str), default_value_os = DEFAULT_HOME.as_os_str())]


### PR DESCRIPTION
Currently, the --verbose flag help text doesn't really explain what its argument should be, and the --home-dir flag's help text prints the default twice.