### PR TITLE
component_nonce variable not updated properly on node restart.

### DIFF
--- a/chain/network/src/routing.rs
+++ b/chain/network/src/routing.rs
@@ -769,23 +769,23 @@ impl RoutingTable {
         }
         debug!(target: "network", "try_save_edges: We are going to remove {} peers", to_save.len());
 
-        let component_nonce = self.component_nonce;
+        let old_component_nonce = self.component_nonce;
         self.component_nonce += 1;
 
         let mut update = self.store.store_update();
-        let _ = update.set_ser(ColLastComponentNonce, &[], &component_nonce);
+        let _ = update.set_ser(ColLastComponentNonce, &[], &self.component_nonce);
 
         for peer_id in to_save.iter() {
             let _ = update.set_ser(
                 ColPeerComponent,
                 Vec::from(peer_id.clone()).as_ref(),
-                &component_nonce,
+                &old_component_nonce,
             );
 
             self.peer_last_time_reachable.remove(peer_id);
         }
 
-        let component_nonce = index_to_bytes(component_nonce);
+        let component_nonce = index_to_bytes(old_component_nonce);
         let mut edges_to_remove = vec![];
 
         self.edges_info.retain(|(peer0, peer1), edge| {

--- a/chain/network/tests/cache_edges.rs
+++ b/chain/network/tests/cache_edges.rs
@@ -206,7 +206,7 @@ fn load_component_nonce_on_start() {
     test.set_times(vec![(1, 2)]);
     test.update();
     let routing_table = RoutingTable::new(random_peer_id(), test.store.clone());
-    assert_eq!(routing_table.component_nonce, 1);
+    assert_eq!(routing_table.component_nonce, 2);
 }
 
 #[test]
@@ -224,7 +224,7 @@ fn load_component_nonce_2_on_start() {
         vec![(1, 0), (2, 1)],
     );
     let routing_table = RoutingTable::new(random_peer_id(), test.store.clone());
-    assert_eq!(routing_table.component_nonce, 2);
+    assert_eq!(routing_table.component_nonce, 3);
 }
 
 #[test]


### PR DESCRIPTION
Closes #5133 

After we remove edges we store them inside components, each with unique `component_nonce`. 
When that happens, we store that `component_nonce` on disk, increase it by 1 in memory, and then create new component with `component_nonce`.
However, if the node restarts we will load `component_nonce` value from disk, and when we remove edges, we will create another component with `component_nonce`.

That's a problem, because ids of components are no longer unique, and we will override previously stored component on disk. 

To solve this problem, we will change the logic to;
- use `component_nonce` for current component
- store `component_nonce+1` on disk
- increase `component_nonce` for future
 