### PR TITLE
Hotfix removing edges from `Graph` inside `RoutingTable`

### DIFF
--- a/chain/network/src/routing.rs
+++ b/chain/network/src/routing.rs
@@ -785,7 +785,7 @@ impl RoutingTable {
         }
 
         let component_nonce = index_to_bytes(component_nonce);
-        let mut edges_to_remove = self
+        let edges_to_remove = self
             .edges_info
             .iter()
             .filter_map(|((peer0, peer1), edge)| {

--- a/chain/network/src/routing.rs
+++ b/chain/network/src/routing.rs
@@ -598,7 +598,6 @@ impl RoutingTable {
         }
     }
 
-    #[cfg(feature = "test_features")]
     pub fn remove_edges(&mut self, edges: &Vec<Edge>) {
         for edge in edges.iter() {
             let key = (edge.peer0.clone(), edge.peer1.clone());

--- a/chain/network/src/routing.rs
+++ b/chain/network/src/routing.rs
@@ -786,16 +786,18 @@ impl RoutingTable {
         }
 
         let component_nonce = index_to_bytes(component_nonce);
-        let mut edges_to_remove = vec![];
-
-        self.edges_info.retain(|(peer0, peer1), edge| {
-            if to_save.contains(peer0) || to_save.contains(peer1) {
-                edges_to_remove.push(edge.clone());
-                false
-            } else {
-                true
-            }
-        });
+        let mut edges_to_remove = self
+            .edges_info
+            .iter()
+            .filter_map(|((peer0, peer1), edge)| {
+                if to_save.contains(peer0) || to_save.contains(peer1) {
+                    Some(edge.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        self.remove_edges(&edges_to_remove);
 
         let _ = update.set_ser(ColComponentEdges, component_nonce.as_ref(), &edges_to_remove);
 

--- a/chain/network/tests/cache_edges.rs
+++ b/chain/network/tests/cache_edges.rs
@@ -111,6 +111,12 @@ impl RoutingTableTest {
             let edge = res.unwrap();
             assert_eq!(edge.edge_type(), *edge_type);
         }
+        let active_edges = on_memory
+            .iter()
+            .filter_map(|x| if x.2 == EdgeType::Added { Some(1) } else { None })
+            .count();
+
+        assert_eq!(active_edges, self.routing_table.raw_graph.total_active_edges as usize);
         assert_eq!(on_memory.len(), self.routing_table.edges_info.len());
 
         // Check for peers on disk


### PR DESCRIPTION
Closes #5135

`RoutingTable::update` method is not removing edges from `Graph` while graph pruning.
We will use `remove_edges` method, which has proper implementation of removing edges.