### PR TITLE
Refactor network code

### DIFF
--- a/chain/jsonrpc/jsonrpc-tests/src/lib.rs
+++ b/chain/jsonrpc/jsonrpc-tests/src/lib.rs
@@ -11,7 +11,7 @@ use near_jsonrpc::{start_http, RpcConfig};
 use near_jsonrpc_primitives::message::{from_slice, Message};
 use near_network::test_utils::open_port;
 #[cfg(feature = "test_features")]
-use near_network::test_utils::{make_ibf_routing_pool, make_peer_manager};
+use near_network::test_utils::{make_peer_manager, make_routing_table_actor};
 use near_primitives::types::NumBlocks;
 
 lazy_static::lazy_static! {
@@ -48,14 +48,14 @@ pub fn start_all_with_validity_period_and_no_epoch_sync(
     let addr = format!("127.0.0.1:{}", open_port());
 
     #[cfg(feature = "test_features")]
-    let ibf_routing_pool = make_ibf_routing_pool();
+    let routing_table_addr = make_routing_table_actor();
     #[cfg(feature = "test_features")]
     let peer_manager_addr = make_peer_manager(
         "test2",
         open_port(),
         vec![("test1", open_port())],
         10,
-        ibf_routing_pool.clone(),
+        routing_table_addr.clone(),
     )
     .0
     .start();
@@ -68,7 +68,7 @@ pub fn start_all_with_validity_period_and_no_epoch_sync(
         #[cfg(feature = "test_features")]
         peer_manager_addr,
         #[cfg(feature = "test_features")]
-        ibf_routing_pool,
+        routing_table_addr,
     );
     (view_client_addr, addr)
 }

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -232,7 +232,7 @@ struct JsonRpcHandler {
     #[cfg(feature = "test_features")]
     peer_manager_addr: Addr<PeerManagerActor>,
     #[cfg(feature = "test_features")]
-    ibf_routing_pool: Addr<RoutingTableActor>,
+    routing_table_addr: Addr<RoutingTableActor>,
 }
 
 impl JsonRpcHandler {
@@ -335,7 +335,7 @@ impl JsonRpcHandler {
                 }
                 "adv_get_routing_table_new" => {
                     let result = self
-                        .ibf_routing_pool
+                        .routing_table_addr
                         .send(RoutingTableMessages::RequestRoutingTable)
                         .await?;
 
@@ -1342,7 +1342,7 @@ pub fn start_http(
     client_addr: Addr<ClientActor>,
     view_client_addr: Addr<ViewClientActor>,
     #[cfg(feature = "test_features")] peer_manager_addr: Addr<PeerManagerActor>,
-    #[cfg(feature = "test_features")] ibf_routing_pool: Addr<RoutingTableActor>,
+    #[cfg(feature = "test_features")] routing_table_addr: Addr<RoutingTableActor>,
 ) -> Vec<(&'static str, actix_web::dev::Server)> {
     let RpcConfig { addr, prometheus_addr, cors_allowed_origins, polling_config, limits_config } =
         config;
@@ -1361,7 +1361,7 @@ pub fn start_http(
                 #[cfg(feature = "test_features")]
                 peer_manager_addr: peer_manager_addr.clone(),
                 #[cfg(feature = "test_features")]
-                ibf_routing_pool: ibf_routing_pool.clone(),
+                routing_table_addr: routing_table_addr.clone(),
             })
             .app_data(web::JsonConfig::default().limit(limits_config.json_payload_max_size))
             .wrap(middleware::Logger::default())

--- a/chain/network/src/edge_verifier.rs
+++ b/chain/network/src/edge_verifier.rs
@@ -6,20 +6,20 @@ use near_performance_metrics_macros::perf;
 
 use crate::types::{EdgeList, StopMsg};
 
-pub(crate) struct EdgeVerifier {}
+pub(crate) struct EdgeVerifierActor {}
 
-impl Actor for EdgeVerifier {
+impl Actor for EdgeVerifierActor {
     type Context = SyncContext<Self>;
 }
 
-impl Handler<StopMsg> for EdgeVerifier {
+impl Handler<StopMsg> for EdgeVerifierActor {
     type Result = ();
     fn handle(&mut self, _: StopMsg, _ctx: &mut Self::Context) -> Self::Result {
         System::current().stop();
     }
 }
 
-impl Handler<EdgeList> for EdgeVerifier {
+impl Handler<EdgeList> for EdgeVerifierActor {
     type Result = bool;
 
     #[perf]

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -405,8 +405,8 @@ impl PeerManagerActor {
         let target_peer_id = full_peer_info.peer_info.id.clone();
 
         let new_edge = Edge::new(
-            self.my_peer_id.clone(), // source
-            target_peer_id.clone(),  // target
+            self.my_peer_id.clone(),
+            target_peer_id.clone(),
             edge_info.nonce,
             edge_info.signature,
             full_peer_info.edge_info.signature.clone(),

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -43,7 +43,7 @@ use crate::routing::{
     ProcessEdgeResult, RoutingTable, SimpleEdge, MAX_NUM_PEERS, SAVE_PEERS_AFTER_TIME,
 };
 
-use crate::edge_verifier::EdgeVerifier;
+use crate::edge_verifier::EdgeVerifierActor;
 #[cfg(feature = "test_features")]
 use crate::types::SetAdvOptions;
 use crate::types::{
@@ -62,7 +62,7 @@ use crate::types::{GetPeerId, GetPeerIdResult};
 use crate::types::{RoutingState, RoutingSyncV2, RoutingVersion2};
 
 /// How often to request peers from active peers.
-const REQUEST_PEERS_SECS: Duration = Duration::from_millis(60_000);
+const REQUEST_PEERS_INTERVAL: Duration = Duration::from_millis(60_000);
 /// How much time to wait (in milliseconds) after we send update nonce request before disconnecting.
 /// This number should be large to handle pair of nodes with high latency.
 const WAIT_ON_TRY_UPDATE_NONCE: Duration = Duration::from_millis(6_000);
@@ -124,7 +124,7 @@ pub struct PeerManagerActor {
     /// Networking configuration.
     config: NetworkConfig,
     /// Peer information for this node.
-    peer_id: PeerId,
+    my_peer_id: PeerId,
     /// Address of the client actor.
     client_addr: Recipient<NetworkClientMessages>,
     /// Address of the view client actor.
@@ -147,7 +147,7 @@ pub struct PeerManagerActor {
     pending_update_nonce_request: HashMap<PeerId, u64>,
     /// Dynamic Prometheus metrics
     network_metrics: NetworkMetrics,
-    edge_verifier_pool: Addr<EdgeVerifier>,
+    edge_verifier_pool: Addr<EdgeVerifierActor>,
     routing_table_pool: Addr<RoutingTableActor>,
     txns_since_last_block: Arc<AtomicUsize>,
     pending_incoming_connections_counter: Arc<AtomicUsize>,
@@ -169,7 +169,7 @@ impl PeerManagerActor {
         config: NetworkConfig,
         client_addr: Recipient<NetworkClientMessages>,
         view_client_addr: Recipient<NetworkViewClientMessages>,
-        ibf_routing_pool: Addr<RoutingTableActor>,
+        routing_table_addr: Addr<RoutingTableActor>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         if config.max_num_peers as usize > MAX_NUM_PEERS {
             panic!("Exceeded max peer limit: {}", MAX_NUM_PEERS);
@@ -179,15 +179,15 @@ impl PeerManagerActor {
         debug!(target: "network", "Found known peers: {} (boot nodes={})", peer_store.len(), config.boot_nodes.len());
         debug!(target: "network", "Blacklist: {:?}", config.blacklist);
 
-        let edge_verifier_pool = SyncArbiter::start(4, || EdgeVerifier {});
+        let edge_verifier_pool = SyncArbiter::start(4, || EdgeVerifierActor {});
 
-        let me: PeerId = config.public_key.clone().into();
-        let routing_table = RoutingTable::new(me.clone(), store);
+        let my_peer_id: PeerId = config.public_key.clone().into();
+        let routing_table = RoutingTable::new(my_peer_id.clone(), store);
 
         let txns_since_last_block = Arc::new(AtomicUsize::new(0));
 
         Ok(PeerManagerActor {
-            peer_id: me,
+            my_peer_id,
             config,
             client_addr,
             view_client_addr,
@@ -201,7 +201,7 @@ impl PeerManagerActor {
             pending_update_nonce_request: HashMap::new(),
             network_metrics: NetworkMetrics::new(),
             edge_verifier_pool,
-            routing_table_pool: ibf_routing_pool,
+            routing_table_pool: routing_table_addr,
             txns_since_last_block,
             pending_incoming_connections_counter: Arc::new(AtomicUsize::new(0)),
             peer_counter: Arc::new(AtomicUsize::new(0)),
@@ -216,7 +216,7 @@ impl PeerManagerActor {
         })
     }
 
-    fn update_and_remove_edges(
+    fn update_routing_table_and_prune_edges(
         &mut self,
         ctx: &mut Context<PeerManagerActor>,
         can_save_edges: bool,
@@ -255,8 +255,8 @@ impl PeerManagerActor {
 
     /// Receives list of edges that were verified, in a trigger every 20ms, and adds them to
     /// the routing table.
-    fn broadcast_edges(&mut self, ctx: &mut Context<PeerManagerActor>) {
-        let me = self.peer_id.clone();
+    fn broadcast_edges_trigger(&mut self, ctx: &mut Context<PeerManagerActor>) {
+        let me = self.my_peer_id.clone();
 
         let start = Instant::now();
         let mut new_edges = Vec::new();
@@ -319,7 +319,7 @@ impl PeerManagerActor {
             ctx,
             BROADCAST_EDGES_INTERVAL,
             move |act, ctx| {
-                act.broadcast_edges(ctx);
+                act.broadcast_edges_trigger(ctx);
             },
         );
     }
@@ -347,14 +347,14 @@ impl PeerManagerActor {
         addr: Addr<Peer>,
         ctx: &mut Context<Self>,
     ) {
-        near_performance_metrics::actix::run_later(ctx, WAIT_FOR_SYNC_DELAY, move |act, ctx2| {
+        near_performance_metrics::actix::run_later(ctx, WAIT_FOR_SYNC_DELAY, move |act2, ctx2| {
             if peer_type == PeerType::Inbound {
-                act.routing_table_pool
+                act2.routing_table_pool
                     .send(RoutingTableMessages::AddPeerIfMissing(peer_id, None))
-                    .into_actor(act)
-                    .map(move |response, act2, _ctx| match response {
+                    .into_actor(act2)
+                    .map(move |response, act3, _ctx3| match response {
                         Ok(RoutingTableMessagesResponse::AddPeerResponse { seed }) => {
-                            act2.start_routing_table_syncv2(addr, seed)
+                            act3.start_routing_table_syncv2(addr, seed)
                         }
                         _ => error!(target: "network", "expected AddIbfSetResponse"),
                     })
@@ -404,8 +404,8 @@ impl PeerManagerActor {
         let target_peer_id = full_peer_info.peer_info.id.clone();
 
         let new_edge = Edge::new(
-            self.peer_id.clone(),   // source
-            target_peer_id.clone(), // target
+            self.my_peer_id.clone(), // source
+            target_peer_id.clone(),  // target
             edge_info.nonce,
             edge_info.signature,
             full_peer_info.edge_info.signature.clone(),
@@ -437,15 +437,15 @@ impl PeerManagerActor {
                 return;
             }
         );
-        near_performance_metrics::actix::run_later(ctx, WAIT_FOR_SYNC_DELAY, move |act, ctx2| {
-            act.routing_table_pool
+        near_performance_metrics::actix::run_later(ctx, WAIT_FOR_SYNC_DELAY, move |act2, ctx2| {
+            act2.routing_table_pool
                 .send(RoutingTableMessages::RequestRoutingTable)
-                .into_actor(act)
-                .map(move |response, act2, ctx3| match response {
+                .into_actor(act2)
+                .map(move |response, act3, ctx3| match response {
                     Ok(RoutingTableMessagesResponse::RequestRoutingTableResponse {
                         edges_info: routing_table,
                     }) => {
-                        act2.send_sync(
+                        act3.send_sync(
                             peer_type,
                             addr,
                             ctx3,
@@ -530,9 +530,10 @@ impl PeerManagerActor {
             .map(|_, _, _| ())
             .spawn(ctx);
 
-        if let Some(edge) = self.routing_table.get_edge(self.peer_id.clone(), peer_id.clone()) {
+        if let Some(edge) = self.routing_table.get_edge(self.my_peer_id.clone(), peer_id.clone()) {
             if edge.edge_type() == EdgeType::Added {
-                let edge_update = edge.remove_edge(self.peer_id.clone(), &self.config.secret_key);
+                let edge_update =
+                    edge.remove_edge(self.my_peer_id.clone(), &self.config.secret_key);
                 self.add_verified_edges_to_routing_table(ctx, vec![edge_update.clone()]);
                 self.broadcast_message(
                     ctx,
@@ -606,7 +607,7 @@ impl PeerManagerActor {
         peer_info: Option<PeerInfo>,
         edge_info: Option<EdgeInfo>,
     ) {
-        let peer_id = self.peer_id.clone();
+        let peer_id = self.my_peer_id.clone();
         let account_id = self.config.account_id.clone();
         let server_addr = self.config.addr;
         let handshake_timeout = self.config.handshake_timeout;
@@ -753,7 +754,7 @@ impl PeerManagerActor {
         let mut requests = futures::stream::FuturesUnordered::new();
         let msg = SendMessage { message: PeerMessage::PeersRequest };
         for (_, active_peer) in self.active_peers.iter_mut() {
-            if active_peer.last_time_peer_requested.elapsed() > REQUEST_PEERS_SECS {
+            if active_peer.last_time_peer_requested.elapsed() > REQUEST_PEERS_INTERVAL {
                 active_peer.last_time_peer_requested = Instant::now();
                 requests.push(active_peer.addr.send(msg.clone()));
             }
@@ -785,17 +786,22 @@ impl PeerManagerActor {
             near_performance_metrics::actix::run_later(
                 ctx,
                 UPDATE_ROUTING_TABLE_INTERVAL,
-                |act, ctx2| {
-                    act.scheduled_routing_table_update = false;
+                |act2, ctx2| {
+                    act2.scheduled_routing_table_update = false;
                     // We only want to save prune edges if there are no pending requests to EdgeVerifier
 
                     #[cfg(feature = "test_features")]
-                    let cond = act.edge_verifier_requests_in_progress == 0
-                        && !act.adv_disable_edge_pruning;
+                    let cond = act2.edge_verifier_requests_in_progress == 0
+                        && !act2.adv_disable_edge_pruning;
                     #[cfg(not(feature = "test_features"))]
-                    let cond = act.edge_verifier_requests_in_progress == 0;
+                    let cond = act2.edge_verifier_requests_in_progress == 0;
 
-                    act.update_and_remove_edges(ctx2, cond, false, SAVE_PEERS_AFTER_TIME);
+                    act2.update_routing_table_and_prune_edges(
+                        ctx2,
+                        cond,
+                        false,
+                        SAVE_PEERS_AFTER_TIME,
+                    );
                 },
             );
         }
@@ -838,10 +844,10 @@ impl PeerManagerActor {
             ctx,
             WAIT_PEER_BEFORE_REMOVE,
             move |act, ctx| {
-                let other = edge.other(&act.peer_id).unwrap();
+                let other = edge.other(&act.my_peer_id).unwrap();
                 if !act.active_peers.contains_key(&other) {
                     // Peer is still not active after waiting a timeout.
-                    let new_edge = edge.remove_edge(act.peer_id.clone(), &act.config.secret_key);
+                    let new_edge = edge.remove_edge(act.my_peer_id.clone(), &act.config.secret_key);
                     act.broadcast_message(
                         ctx,
                         SendMessage {
@@ -867,7 +873,7 @@ impl PeerManagerActor {
             ctx,
             other.clone(),
             PeerMessage::RequestUpdateNonce(EdgeInfo::new(
-                self.peer_id.clone(),
+                self.my_peer_id.clone(),
                 other.clone(),
                 nonce,
                 &self.config.secret_key,
@@ -894,7 +900,7 @@ impl PeerManagerActor {
     }
 
     /// Periodically query peer actors for latest weight and traffic info.
-    fn monitor_peer_stats(&mut self, ctx: &mut Context<Self>) {
+    fn monitor_peer_stats_trigger(&mut self, ctx: &mut Context<Self>) {
         for (peer_id, active_peer) in self.active_peers.iter() {
             let peer_id1 = peer_id.clone();
             active_peer
@@ -926,7 +932,7 @@ impl PeerManagerActor {
             ctx,
             self.config.peer_stats_period,
             move |act, ctx| {
-                act.monitor_peer_stats(ctx);
+                act.monitor_peer_stats_trigger(ctx);
             },
         );
     }
@@ -1022,7 +1028,7 @@ impl PeerManagerActor {
     ///  - bootstrap outbound connections from known peers,
     ///  - unban peers that have been banned for awhile,
     ///  - remove expired peers,
-    fn monitor_peers(&mut self, ctx: &mut Context<Self>) {
+    fn monitor_peers_trigger(&mut self, ctx: &mut Context<Self>) {
         let mut to_unban = vec![];
         for (peer_id, peer_state) in self.peer_store.iter() {
             if let KnownPeerStatus::Banned(_, last_banned) = peer_state.status {
@@ -1044,7 +1050,7 @@ impl PeerManagerActor {
         if self.is_outbound_bootstrap_needed() {
             if let Some(peer_info) = self.sample_random_peer(|peer_state| {
                 // Ignore connecting to ourself
-                self.peer_id == peer_state.peer_info.id
+                self.my_peer_id == peer_state.peer_info.id
                     || self.config.addr == peer_state.peer_info.addr
                     // Or to peers we are currently trying to connect to
                     || self.outgoing_peers.contains(&peer_state.peer_info.id)
@@ -1089,7 +1095,7 @@ impl PeerManagerActor {
             ctx,
             Duration::from_millis(wait),
             move |act, ctx| {
-                act.monitor_peers(ctx);
+                act.monitor_peers_trigger(ctx);
             },
         );
     }
@@ -1213,8 +1219,8 @@ impl PeerManagerActor {
     fn send_signed_message_to_peer(&mut self, ctx: &mut Context<Self>, msg: RoutedMessage) -> bool {
         // Check if the message is for myself and don't try to send it in that case.
         if let PeerIdOrHash::PeerId(target) = &msg.target {
-            if target == &self.peer_id {
-                debug!(target: "network", "{:?} Drop signed message to myself ({:?}). Message: {:?}.", self.config.account_id, self.peer_id, msg);
+            if target == &self.my_peer_id {
+                debug!(target: "network", "{:?} Drop signed message to myself ({:?}). Message: {:?}.", self.config.account_id, self.my_peer_id, msg);
                 return false;
             }
         }
@@ -1222,9 +1228,9 @@ impl PeerManagerActor {
         match self.routing_table.find_route(&msg.target) {
             Ok(peer_id) => {
                 // Remember if we expect a response for this message.
-                if msg.author == self.peer_id && msg.expect_response() {
+                if msg.author == self.my_peer_id && msg.expect_response() {
                     trace!(target: "network", "initiate route back {:?}", msg);
-                    self.routing_table.add_route_back(msg.hash(), self.peer_id.clone());
+                    self.routing_table.add_route_back(msg.hash(), self.my_peer_id.clone());
                 }
 
                 self.send_message(ctx, peer_id, PeerMessage::Routed(msg))
@@ -1284,26 +1290,28 @@ impl PeerManagerActor {
     }
 
     fn sign_routed_message(&self, msg: RawRoutedMessage) -> RoutedMessage {
-        msg.sign(self.peer_id.clone(), &self.config.secret_key, self.config.routed_message_ttl)
+        msg.sign(self.my_peer_id.clone(), &self.config.secret_key, self.config.routed_message_ttl)
     }
 
     // Determine if the given target is referring to us.
     fn message_for_me(&mut self, target: &PeerIdOrHash) -> bool {
         match target {
-            PeerIdOrHash::PeerId(peer_id) => peer_id == &self.peer_id,
+            PeerIdOrHash::PeerId(peer_id) => peer_id == &self.my_peer_id,
             PeerIdOrHash::Hash(hash) => {
-                self.routing_table.compare_route_back(hash.clone(), &self.peer_id)
+                self.routing_table.compare_route_back(hash.clone(), &self.my_peer_id)
             }
         }
     }
 
     fn propose_edge(&self, peer1: PeerId, with_nonce: Option<u64>) -> EdgeInfo {
-        let key = Edge::key(self.peer_id.clone(), peer1.clone());
+        let key = Edge::key(self.my_peer_id.clone(), peer1.clone());
 
         // When we create a new edge we increase the latest nonce by 2 in case we miss a removal
         // proposal from our partner.
         let nonce = with_nonce.unwrap_or_else(|| {
-            self.routing_table.get_edge(self.peer_id.clone(), peer1).map_or(1, |edge| edge.next())
+            self.routing_table
+                .get_edge(self.my_peer_id.clone(), peer1)
+                .map_or(1, |edge| edge.next())
         });
 
         EdgeInfo::new(key.0, key.1, nonce, &self.config.secret_key)
@@ -1314,7 +1322,7 @@ impl PeerManagerActor {
     // for unit tests
     fn send_ping(&mut self, ctx: &mut Context<Self>, nonce: usize, target: PeerId) {
         let body =
-            RoutedMessageBody::Ping(Ping { nonce: nonce as u64, source: self.peer_id.clone() });
+            RoutedMessageBody::Ping(Ping { nonce: nonce as u64, source: self.my_peer_id.clone() });
         self.routing_table.sending_ping(nonce, target.clone());
         let msg = RawRoutedMessage { target: AccountOrPeerIdOrHash::PeerId(target), body };
         self.send_message_to_peer(ctx, msg);
@@ -1322,7 +1330,7 @@ impl PeerManagerActor {
 
     fn send_pong(&mut self, ctx: &mut Context<Self>, nonce: usize, target: CryptoHash) {
         let body =
-            RoutedMessageBody::Pong(Pong { nonce: nonce as u64, source: self.peer_id.clone() });
+            RoutedMessageBody::Pong(Pong { nonce: nonce as u64, source: self.my_peer_id.clone() });
         let msg = RawRoutedMessage { target: AccountOrPeerIdOrHash::Hash(target), body };
         self.send_message_to_peer(ctx, msg);
     }
@@ -1366,7 +1374,7 @@ impl PeerManagerActor {
         }
     }
 
-    fn push_network_info(&mut self, ctx: &mut Context<Self>) {
+    fn push_network_info_trigger(&mut self, ctx: &mut Context<Self>) {
         let network_info = self.get_network_info();
 
         let _ = self.client_addr.do_send(NetworkClientMessages::NetworkInfo(network_info));
@@ -1375,7 +1383,7 @@ impl PeerManagerActor {
             ctx,
             self.config.push_info_period,
             move |act, ctx| {
-                act.push_network_info(ctx);
+                act.push_network_info_trigger(ctx);
             },
         );
     }
@@ -1411,7 +1419,7 @@ impl Actor for PeerManagerActor {
                     let incoming = IncomingCrutch {
                         listener: tokio_stream::wrappers::TcpListenerStream::new(listener),
                     };
-                    info!(target: "stats", "Server listening at {}@{}", act.peer_id, server_addr);
+                    info!(target: "stats", "Server listening at {}@{}", act.my_peer_id, server_addr);
                     let pending_incoming_connections_counter =
                         act.pending_incoming_connections_counter.clone();
                     let peer_counter = act.peer_counter.clone();
@@ -1440,15 +1448,15 @@ impl Actor for PeerManagerActor {
         }
 
         // Periodically push network information to client
-        self.push_network_info(ctx);
+        self.push_network_info_trigger(ctx);
 
         // Start peer monitoring.
-        self.monitor_peers(ctx);
+        self.monitor_peers_trigger(ctx);
 
         // Start active peer stats querying.
-        self.monitor_peer_stats(ctx);
+        self.monitor_peer_stats_trigger(ctx);
 
-        self.broadcast_edges(ctx);
+        self.broadcast_edges_trigger(ctx);
     }
 
     /// Try to gracefully disconnect from active peers.
@@ -1771,9 +1779,9 @@ impl PeerManagerActor {
                 NetworkResponses::NoResponse
             }
             NetworkRequests::RequestUpdateNonce(peer_id, edge_info) => {
-                if Edge::partial_verify(self.peer_id.clone(), peer_id.clone(), &edge_info) {
+                if Edge::partial_verify(self.my_peer_id.clone(), peer_id.clone(), &edge_info) {
                     if let Some(cur_edge) =
-                        self.routing_table.get_edge(self.peer_id.clone(), peer_id.clone())
+                        self.routing_table.get_edge(self.my_peer_id.clone(), peer_id.clone())
                     {
                         if cur_edge.edge_type() == EdgeType::Added
                             && cur_edge.nonce >= edge_info.nonce
@@ -1783,7 +1791,7 @@ impl PeerManagerActor {
                     }
 
                     let new_edge = Edge::build_with_secret_key(
-                        self.peer_id.clone(),
+                        self.my_peer_id.clone(),
                         peer_id,
                         edge_info.nonce,
                         &self.config.secret_key,
@@ -1797,9 +1805,9 @@ impl PeerManagerActor {
                 }
             }
             NetworkRequests::ResponseUpdateNonce(edge) => {
-                if edge.contains_peer(&self.peer_id) && edge.verify() {
+                if edge.contains_peer(&self.my_peer_id) && edge.verify() {
                     if self.add_verified_edges_to_routing_table(ctx, vec![edge.clone()]) {
-                        let other = edge.other(&self.peer_id).unwrap();
+                        let other = edge.other(&self.my_peer_id).unwrap();
                         if let Some(nonce) = self.pending_update_nonce_request.get(&other) {
                             if edge.nonce >= *nonce {
                                 self.pending_update_nonce_request.remove(&other);
@@ -1915,7 +1923,7 @@ impl PeerManagerActor {
         }
         if let Some(true) = msg.prune_edges {
             debug!(target: "network", "test_features prune_edges");
-            self.update_and_remove_edges(ctx, true, true, Duration::from_secs(2));
+            self.update_routing_table_and_prune_edges(ctx, true, true, Duration::from_secs(2));
         }
     }
 }
@@ -1927,7 +1935,7 @@ impl PeerManagerActor {
         msg: GetPeerId,
         _ctx: &mut Context<Self>,
     ) -> GetPeerIdResult {
-        GetPeerIdResult { peer_id: self.peer_id.clone() }
+        GetPeerIdResult { peer_id: self.my_peer_id.clone() }
     }
 }
 
@@ -2009,7 +2017,7 @@ impl PeerManagerActor {
 
         // We already connected to this peer.
         if self.active_peers.contains_key(&msg.peer_info.id) {
-            debug!(target: "network", "Dropping handshake (Active Peer). {:?} {:?}", self.peer_id, msg.peer_info.id);
+            debug!(target: "network", "Dropping handshake (Active Peer). {:?} {:?}", self.my_peer_id, msg.peer_info.id);
             return ConsolidateResponse::Reject;
         }
 
@@ -2017,8 +2025,8 @@ impl PeerManagerActor {
         // This only happens when both of us connect at the same time, break tie using higher peer id.
         if msg.peer_type == PeerType::Inbound && self.outgoing_peers.contains(&msg.peer_info.id) {
             // We pick connection that has lower id.
-            if msg.peer_info.id > self.peer_id {
-                debug!(target: "network", "Dropping handshake (Tied). {:?} {:?}", self.peer_id, msg.peer_info.id);
+            if msg.peer_info.id > self.my_peer_id {
+                debug!(target: "network", "Dropping handshake (Tied). {:?} {:?}", self.my_peer_id, msg.peer_info.id);
                 return ConsolidateResponse::Reject;
             }
         }
@@ -2034,18 +2042,19 @@ impl PeerManagerActor {
             return ConsolidateResponse::Reject;
         }
 
-        let last_edge = self.routing_table.get_edge(self.peer_id.clone(), msg.peer_info.id.clone());
+        let last_edge =
+            self.routing_table.get_edge(self.my_peer_id.clone(), msg.peer_info.id.clone());
         let last_nonce = last_edge.as_ref().map_or(0, |edge| edge.nonce);
 
         // Check that the received nonce is greater than the current nonce of this connection.
         if last_nonce >= msg.other_edge_info.nonce {
-            debug!(target: "network", "Too low nonce. ({} <= {}) {:?} {:?}", msg.other_edge_info.nonce, last_nonce, self.peer_id, msg.peer_info.id);
+            debug!(target: "network", "Too low nonce. ({} <= {}) {:?} {:?}", msg.other_edge_info.nonce, last_nonce, self.my_peer_id, msg.peer_info.id);
             // If the check fails don't allow this connection.
             return ConsolidateResponse::InvalidNonce(last_edge.map(Box::new).unwrap());
         }
 
         if msg.other_edge_info.nonce >= Edge::next_nonce(last_nonce) + EDGE_NONCE_BUMP_ALLOWED {
-            debug!(target: "network", "Too large nonce. ({} >= {} + {}) {:?} {:?}", msg.other_edge_info.nonce, last_nonce, EDGE_NONCE_BUMP_ALLOWED, self.peer_id, msg.peer_info.id);
+            debug!(target: "network", "Too large nonce. ({} >= {} + {}) {:?} {:?}", msg.other_edge_info.nonce, last_nonce, EDGE_NONCE_BUMP_ALLOWED, self.my_peer_id, msg.peer_info.id);
             return ConsolidateResponse::Reject;
         }
 
@@ -2112,7 +2121,7 @@ impl PeerManagerActor {
         let _d = DelayDetector::new("peers response".into());
         unwrap_or_error!(
             self.peer_store.add_indirect_peers(
-                msg.peers.into_iter().filter(|peer_info| peer_info.id != self.peer_id).collect()
+                msg.peers.into_iter().filter(|peer_info| peer_info.id != self.my_peer_id).collect()
             ),
             "Fail to update peer store"
         );

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -223,7 +223,8 @@ impl PeerManagerActor {
         force_pruning: bool,
         timeout: Duration,
     ) {
-        let edges_to_remove = self.routing_table.update(can_save_edges, force_pruning, timeout);
+        let edges_to_remove =
+            self.routing_table.recalculate_routing_table(can_save_edges, force_pruning, timeout);
         self.routing_table_pool
             .send(RoutingTableMessages::RemoveEdges(edges_to_remove))
             .into_actor(self)
@@ -774,7 +775,8 @@ impl PeerManagerActor {
         ctx: &mut Context<Self>,
         edges: Vec<Edge>,
     ) -> bool {
-        let ProcessEdgeResult { new_edge, edges } = self.routing_table.process_edges(edges);
+        let ProcessEdgeResult { new_edge, edges } =
+            self.routing_table.add_verified_edges_to_routing_table(edges);
         self.routing_table_pool
             .send(RoutingTableMessages::AddEdges(edges))
             .into_actor(self)

--- a/chain/network/src/routing.rs
+++ b/chain/network/src/routing.rs
@@ -409,8 +409,8 @@ pub enum FindRouteError {
 
 impl RoutingTable {
     pub fn new(peer_id: PeerId, store: Arc<Store>) -> Self {
-        // Find greater nonce on disk and set `component_nonce` to this value.
-        let component_nonce = store
+        // Find greater nonce on disk and set `next_available_component_nonce` to this value.
+        let next_available_component_nonce = store
             .get_ser::<u64>(ColLastComponentNonce, &[])
             .unwrap_or(None)
             .map_or(0, |nonce| nonce + 1);
@@ -432,7 +432,7 @@ impl RoutingTable {
             pong_info: SizedCache::with_size(PING_PONG_CACHE_SIZE),
             waiting_pong: SizedCache::with_size(PING_PONG_CACHE_SIZE),
             last_ping_nonce: SizedCache::with_size(PING_PONG_CACHE_SIZE),
-            next_available_component_nonce: component_nonce,
+            next_available_component_nonce,
         }
     }
 

--- a/chain/network/src/routing.rs
+++ b/chain/network/src/routing.rs
@@ -436,7 +436,7 @@ impl RoutingTable {
         }
     }
 
-    fn peer_id(&self) -> &PeerId {
+    fn my_peer_id(&self) -> &PeerId {
         &self.raw_graph.source
     }
 
@@ -549,11 +549,11 @@ impl RoutingTable {
 
     /// If peer_id is not on memory check if it is on disk in bring it back on memory.
     fn touch(&mut self, peer_id: &PeerId) {
-        if peer_id == self.peer_id() || self.peer_last_time_reachable.contains_key(peer_id) {
+        if peer_id == self.my_peer_id() || self.peer_last_time_reachable.contains_key(peer_id) {
             return;
         }
 
-        let me = self.peer_id().clone();
+        let me = self.my_peer_id().clone();
 
         if let Ok(nonce) = self.component_nonce_from_peer(peer_id.clone()) {
             let mut update = self.store.store_update();

--- a/chain/network/src/routing.rs
+++ b/chain/network/src/routing.rs
@@ -618,7 +618,7 @@ impl RoutingTable {
     /// Add several edges to the current view of the network.
     /// These edges are assumed to be valid at this point.
     /// Return true if some of the edges contains new information to the network.
-    pub fn process_edges(&mut self, edges: Vec<Edge>) -> ProcessEdgeResult {
+    pub fn add_verified_edges_to_routing_table(&mut self, edges: Vec<Edge>) -> ProcessEdgeResult {
         let mut new_edge = false;
         let total = edges.len();
         let mut result = Vec::with_capacity(edges.len() as usize);
@@ -795,7 +795,7 @@ impl RoutingTable {
     }
 
     /// Recalculate routing table.
-    pub fn update(
+    pub fn recalculate_routing_table(
         &mut self,
         can_save_edges: bool,
         force_pruning: bool,

--- a/chain/network/src/routing.rs
+++ b/chain/network/src/routing.rs
@@ -395,7 +395,7 @@ pub struct RoutingTable {
     waiting_pong: SizedCache<PeerId, SizedCache<usize, Instant>>,
     /// Last nonce sent to each peer through pings.
     last_ping_nonce: SizedCache<PeerId, usize>,
-    /// Last nonce used to store edges on disk.
+    /// First component nonce id that doesn't been used to. Used for creating new components.
     pub next_available_component_nonce: u64,
 }
 

--- a/chain/network/src/routing.rs
+++ b/chain/network/src/routing.rs
@@ -395,7 +395,7 @@ pub struct RoutingTable {
     waiting_pong: SizedCache<PeerId, SizedCache<usize, Instant>>,
     /// Last nonce sent to each peer through pings.
     last_ping_nonce: SizedCache<PeerId, usize>,
-    /// First component nonce id that doesn't been used to. Used for creating new components.
+    /// First component nonce id that hasn't been used. Used for creating new components.
     pub next_available_component_nonce: u64,
 }
 
@@ -616,7 +616,7 @@ impl RoutingTable {
     }
 
     /// Add several edges to the current view of the network.
-    /// These edges are assumed to be valid at this point.
+    /// These edges are assumed to have their signature verified at this point.
     /// Return true if some of the edges contains new information to the network.
     pub fn add_verified_edges_to_routing_table(&mut self, edges: Vec<Edge>) -> ProcessEdgeResult {
         let mut new_edge = false;

--- a/chain/network/src/routing.rs
+++ b/chain/network/src/routing.rs
@@ -396,7 +396,7 @@ pub struct RoutingTable {
     /// Last nonce sent to each peer through pings.
     last_ping_nonce: SizedCache<PeerId, usize>,
     /// Last nonce used to store edges on disk.
-    pub component_nonce: u64,
+    pub next_available_component_nonce: u64,
 }
 
 #[derive(Debug)]
@@ -432,7 +432,7 @@ impl RoutingTable {
             pong_info: SizedCache::with_size(PING_PONG_CACHE_SIZE),
             waiting_pong: SizedCache::with_size(PING_PONG_CACHE_SIZE),
             last_ping_nonce: SizedCache::with_size(PING_PONG_CACHE_SIZE),
-            component_nonce,
+            next_available_component_nonce: component_nonce,
         }
     }
 
@@ -756,8 +756,8 @@ impl RoutingTable {
         }
         debug!(target: "network", "try_save_edges: We are going to remove {} peers", to_save.len());
 
-        let component_nonce = self.component_nonce;
-        self.component_nonce += 1;
+        let component_nonce = self.next_available_component_nonce;
+        self.next_available_component_nonce += 1;
 
         let mut update = self.store.store_update();
         let _ = update.set_ser(ColLastComponentNonce, &[], &component_nonce);

--- a/chain/network/src/routing_table_actor.rs
+++ b/chain/network/src/routing_table_actor.rs
@@ -26,7 +26,7 @@ use crate::types::{PartialSync, RoutingState, RoutingVersion2};
 #[derive(Default)]
 pub struct RoutingTableActor {
     /// Data structures with all edges.
-    edges: HashMap<(PeerId, PeerId), Edge>,
+    edges_info: HashMap<(PeerId, PeerId), Edge>,
     /// Data structure used for exchanging routing tables.
     #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
     pub peer_ibf_set: IbfPeerSet,
@@ -129,7 +129,7 @@ impl Handler<RoutingTableMessages> for RoutingTableActor {
                         let se = edge.to_simple_edge();
                         self.peer_ibf_set.add_edge(&se);
                     }
-                    self.edges.insert((edge.peer0.clone(), edge.peer1.clone()), edge.clone());
+                    self.edges_info.insert((edge.peer0.clone(), edge.peer1.clone()), edge.clone());
                 }
                 RoutingTableMessagesResponse::Empty
             }
@@ -138,18 +138,19 @@ impl Handler<RoutingTableMessages> for RoutingTableActor {
                     #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
                     self.peer_ibf_set.remove_edge(&edge.to_simple_edge());
 
-                    self.edges.remove(&(edge.peer0.clone(), edge.peer1.clone()));
+                    self.edges_info.remove(&(edge.peer0.clone(), edge.peer1.clone()));
                 }
                 RoutingTableMessagesResponse::Empty
             }
             RoutingTableMessages::RequestRoutingTable => {
                 RoutingTableMessagesResponse::RequestRoutingTableResponse {
-                    edges_info: self.edges.iter().map(|(_k, v)| v.clone()).collect(),
+                    edges_info: self.edges_info.iter().map(|(_k, v)| v.clone()).collect(),
                 }
             }
             #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
             RoutingTableMessages::AddPeerIfMissing(peer_id, ibf_set) => {
-                let seed = self.peer_ibf_set.add_peer(peer_id.clone(), ibf_set, &mut self.edges);
+                let seed =
+                    self.peer_ibf_set.add_peer(peer_id.clone(), ibf_set, &mut self.edges_info);
                 RoutingTableMessagesResponse::AddPeerResponse { seed }
             }
             #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
@@ -174,14 +175,14 @@ impl Handler<RoutingTableMessages> for RoutingTableActor {
 
                             let edges_for_peer = edges_for_peer
                                 .iter()
-                                .filter_map(|x| self.edges.get(&x.key()).cloned())
+                                .filter_map(|x| self.edges_info.get(&x.key()).cloned())
                                 .collect();
                             // Prepare message
                             let ibf_msg = if unknown_edges_count == 0
                                 && unknown_edge_hashes.len() > 0
                             {
                                 RoutingVersion2 {
-                                    known_edges: self.edges.len() as u64,
+                                    known_edges: self.edges_info.len() as u64,
                                     seed,
                                     edges: edges_for_peer,
                                     routing_state: RoutingState::RequestMissingEdges(
@@ -190,7 +191,7 @@ impl Handler<RoutingTableMessages> for RoutingTableActor {
                                 }
                             } else if unknown_edges_count == 0 && unknown_edge_hashes.len() == 0 {
                                 RoutingVersion2 {
-                                    known_edges: self.edges.len() as u64,
+                                    known_edges: self.edges_info.len() as u64,
                                     seed,
                                     edges: edges_for_peer,
                                     routing_state: RoutingState::Done,
@@ -199,7 +200,7 @@ impl Handler<RoutingTableMessages> for RoutingTableActor {
                                 if let Some(new_ibf_level) = partial_sync.ibf_level.inc() {
                                     let ibf_vec = ibf_set.get_ibf_vec(new_ibf_level);
                                     RoutingVersion2 {
-                                        known_edges: self.edges.len() as u64,
+                                        known_edges: self.edges_info.len() as u64,
                                         seed,
                                         edges: edges_for_peer,
                                         routing_state: RoutingState::PartialSync(PartialSync {
@@ -209,9 +210,13 @@ impl Handler<RoutingTableMessages> for RoutingTableActor {
                                     }
                                 } else {
                                     RoutingVersion2 {
-                                        known_edges: self.edges.len() as u64,
+                                        known_edges: self.edges_info.len() as u64,
                                         seed,
-                                        edges: self.edges.iter().map(|x| x.1.clone()).collect(),
+                                        edges: self
+                                            .edges_info
+                                            .iter()
+                                            .map(|x| x.1.clone())
+                                            .collect(),
                                         routing_state: RoutingState::RequestAllEdges,
                                     }
                                 }
@@ -228,14 +233,14 @@ impl Handler<RoutingTableMessages> for RoutingTableActor {
                         self.peer_ibf_set.add_peer(
                             peer_id.clone(),
                             Some(ibf_msg.seed),
-                            &mut self.edges,
+                            &mut self.edges_info,
                         );
                         if let Some(ibf_set) = self.peer_ibf_set.get(&peer_id) {
                             let seed = ibf_set.get_seed();
                             let ibf_vec = ibf_set.get_ibf_vec(MIN_IBF_LEVEL);
                             RoutingTableMessagesResponse::ProcessIbfMessageResponse {
                                 ibf_msg: Some(RoutingVersion2 {
-                                    known_edges: self.edges.len() as u64,
+                                    known_edges: self.edges_info.len() as u64,
                                     seed,
                                     edges: Default::default(),
                                     routing_state: RoutingState::PartialSync(PartialSync {
@@ -256,11 +261,11 @@ impl Handler<RoutingTableMessages> for RoutingTableActor {
 
                         let edges_for_peer = edges_for_peer
                             .iter()
-                            .filter_map(|x| self.edges.get(&x.key()).cloned())
+                            .filter_map(|x| self.edges_info.get(&x.key()).cloned())
                             .collect();
 
                         let ibf_msg = RoutingVersion2 {
-                            known_edges: self.edges.len() as u64,
+                            known_edges: self.edges_info.len() as u64,
                             seed,
                             edges: edges_for_peer,
                             routing_state: RoutingState::Done,
@@ -272,9 +277,9 @@ impl Handler<RoutingTableMessages> for RoutingTableActor {
                     RoutingState::RequestAllEdges => {
                         RoutingTableMessagesResponse::ProcessIbfMessageResponse {
                             ibf_msg: Some(RoutingVersion2 {
-                                known_edges: self.edges.len() as u64,
+                                known_edges: self.edges_info.len() as u64,
                                 seed: ibf_msg.seed,
-                                edges: self.edges.iter().map(|x| x.1.clone()).collect(),
+                                edges: self.edges_info.iter().map(|x| x.1.clone()).collect(),
                                 routing_state: RoutingState::Done,
                             }),
                         }

--- a/chain/network/src/test_utils.rs
+++ b/chain/network/src/test_utils.rs
@@ -281,7 +281,7 @@ impl MockPeerManagerAdapter {
     }
 }
 
-pub fn make_ibf_routing_pool() -> Addr<RoutingTableActor> {
+pub fn make_routing_table_actor() -> Addr<RoutingTableActor> {
     SyncArbiter::start(1, move || RoutingTableActor::default())
 }
 
@@ -291,7 +291,7 @@ pub fn make_peer_manager(
     port: u16,
     boot_nodes: Vec<(&str, u16)>,
     peer_max_count: u32,
-    ibf_routing_pool: Addr<RoutingTableActor>,
+    routing_table_addr: Addr<RoutingTableActor>,
 ) -> (PeerManagerActor, PeerId, Arc<AtomicUsize>) {
     let store = create_test_store();
     let mut config = NetworkConfig::from_seed(seed, port);
@@ -334,7 +334,7 @@ pub fn make_peer_manager(
             config,
             client_addr.recipient(),
             view_client_addr.recipient(),
-            ibf_routing_pool,
+            routing_table_addr,
         )
         .unwrap(),
         peer_id,

--- a/chain/network/tests/cache_edges.rs
+++ b/chain/network/tests/cache_edges.rs
@@ -159,7 +159,7 @@ impl RoutingTableTest {
         self.routing_table.process_edges(vec![edge]);
     }
 
-    fn update(&mut self) {
+    fn update_routing_table(&mut self) {
         self.routing_table.update(true, false, SAVE_PEERS_AFTER_TIME);
     }
 }
@@ -183,7 +183,7 @@ fn active_old_edge() {
     let mut test = RoutingTableTest::new();
     test.add_edge(0, 1, 1);
     test.set_times(vec![(1, 2)]);
-    test.update();
+    test.update_routing_table();
     test.check(vec![(0, 1, true)], vec![], vec![]);
 }
 
@@ -192,7 +192,7 @@ fn inactive_old_edge() {
     let mut test = RoutingTableTest::new();
     test.add_edge(0, 1, 2);
     test.set_times(vec![(1, 2)]);
-    test.update();
+    test.update_routing_table();
     test.check(vec![], vec![(0, vec![(0, 1, false)])], vec![(1, 0)]);
 }
 
@@ -201,7 +201,7 @@ fn inactive_recent_edge() {
     let mut test = RoutingTableTest::new();
     test.add_edge(0, 1, 2);
     test.set_times(vec![(1, 1)]);
-    test.update();
+    test.update_routing_table();
     test.check(vec![(0, 1, false)], vec![], vec![]);
 }
 
@@ -210,7 +210,7 @@ fn load_component_nonce_on_start() {
     let mut test = RoutingTableTest::new();
     test.add_edge(0, 1, 2);
     test.set_times(vec![(1, 2)]);
-    test.update();
+    test.update_routing_table();
     let routing_table = RoutingTable::new(random_peer_id(), test.store.clone());
     assert_eq!(routing_table.component_nonce, 1);
 }
@@ -220,10 +220,10 @@ fn load_component_nonce_2_on_start() {
     let mut test = RoutingTableTest::new();
     test.add_edge(0, 1, 2);
     test.set_times(vec![(1, 2)]);
-    test.update();
+    test.update_routing_table();
     test.add_edge(0, 2, 2);
     test.set_times(vec![(2, 2)]);
-    test.update();
+    test.update_routing_table();
     test.check(
         vec![],
         vec![(0, vec![(0, 1, false)]), (1, vec![(0, 2, false)])],
@@ -238,12 +238,12 @@ fn two_components() {
     let mut test = RoutingTableTest::new();
     test.add_edge(0, 1, 2);
     test.set_times(vec![(1, 2)]);
-    test.update();
+    test.update_routing_table();
     test.add_edge(0, 2, 2);
     test.set_times(vec![(2, 2)]);
-    test.update();
+    test.update_routing_table();
     test.add_edge(1, 2, 1);
-    test.update();
+    test.update_routing_table();
     test.check(
         vec![],
         vec![(2, vec![(0, 1, false), (0, 2, false), (1, 2, true)])],
@@ -256,13 +256,13 @@ fn overwrite_edge() {
     let mut test = RoutingTableTest::new();
     test.add_edge(0, 1, 2);
     test.set_times(vec![(1, 2)]);
-    test.update();
+    test.update_routing_table();
     test.add_edge(0, 2, 2);
     test.set_times(vec![(2, 2)]);
-    test.update();
+    test.update_routing_table();
     test.add_edge(1, 2, 1);
-    test.update();
+    test.update_routing_table();
     test.add_edge(0, 1, 3);
-    test.update();
+    test.update_routing_table();
     test.check(vec![(0, 1, true), (1, 2, true), (0, 2, false)], vec![], vec![]);
 }

--- a/chain/network/tests/cache_edges.rs
+++ b/chain/network/tests/cache_edges.rs
@@ -168,7 +168,7 @@ impl RoutingTableTest {
 fn empty() {
     let mut test = RoutingTableTest::new();
     test.check(vec![], vec![], vec![]);
-    assert_eq!(test.routing_table.component_nonce, 0);
+    assert_eq!(test.routing_table.next_available_component_nonce, 0);
 }
 
 #[test]
@@ -212,7 +212,7 @@ fn load_component_nonce_on_start() {
     test.set_times(vec![(1, 2)]);
     test.update_routing_table();
     let routing_table = RoutingTable::new(random_peer_id(), test.store.clone());
-    assert_eq!(routing_table.component_nonce, 1);
+    assert_eq!(routing_table.next_available_component_nonce, 1);
 }
 
 #[test]
@@ -230,7 +230,7 @@ fn load_component_nonce_2_on_start() {
         vec![(1, 0), (2, 1)],
     );
     let routing_table = RoutingTable::new(random_peer_id(), test.store.clone());
-    assert_eq!(routing_table.component_nonce, 2);
+    assert_eq!(routing_table.next_available_component_nonce, 2);
 }
 
 #[test]

--- a/chain/network/tests/cache_edges.rs
+++ b/chain/network/tests/cache_edges.rs
@@ -156,11 +156,11 @@ impl RoutingTableTest {
         let peer0 = self.get_peer(peer0).clone();
         let peer1 = self.get_peer(peer1).clone();
         let edge = Edge::new(peer0, peer1, nonce, Signature::default(), Signature::default());
-        self.routing_table.process_edges(vec![edge]);
+        self.routing_table.add_verified_edges_to_routing_table(vec![edge]);
     }
 
     fn update_routing_table(&mut self) {
-        self.routing_table.update(true, false, SAVE_PEERS_AFTER_TIME);
+        self.routing_table.recalculate_routing_table(true, false, SAVE_PEERS_AFTER_TIME);
     }
 }
 

--- a/integration-tests/tests/network/infinite_loop.rs
+++ b/integration-tests/tests/network/infinite_loop.rs
@@ -10,7 +10,7 @@ use near_actix_test_utils::run_actix;
 use near_client::ClientActor;
 use near_logger_utils::init_integration_logger;
 use near_network::test_utils::{
-    convert_boot_nodes, make_ibf_routing_pool, open_port, GetInfo, WaitOrTimeout,
+    convert_boot_nodes, make_routing_table_actor, open_port, GetInfo, WaitOrTimeout,
 };
 use near_network::types::{
     NetworkViewClientMessages, NetworkViewClientResponses, PeerManagerMessageRequest, SyncData,
@@ -61,7 +61,7 @@ pub fn make_peer_manager(
         }
     }))
     .start();
-    let ibf_routing_pool = make_ibf_routing_pool();
+    let routing_table_addr = make_routing_table_actor();
     let peer_id = config.public_key.clone().into();
     (
         PeerManagerActor::new(
@@ -69,7 +69,7 @@ pub fn make_peer_manager(
             config,
             client_addr.recipient(),
             view_client_addr.recipient(),
-            ibf_routing_pool,
+            routing_table_addr,
         )
         .unwrap(),
         peer_id,

--- a/integration-tests/tests/network/peer_handshake.rs
+++ b/integration-tests/tests/network/peer_handshake.rs
@@ -13,7 +13,7 @@ use near_actix_test_utils::run_actix;
 use near_client::{ClientActor, ViewClientActor};
 use near_logger_utils::init_test_logger;
 use near_network::test_utils::{
-    convert_boot_nodes, make_ibf_routing_pool, open_port, GetInfo, StopSignal, WaitOrTimeout,
+    convert_boot_nodes, make_routing_table_actor, open_port, GetInfo, StopSignal, WaitOrTimeout,
 };
 use near_network::types::{NetworkViewClientMessages, NetworkViewClientResponses};
 use near_network::{NetworkClientResponses, NetworkConfig, PeerManagerActor};
@@ -52,13 +52,13 @@ fn make_peer_manager(
         }
     }))
     .start();
-    let ibf_routing_pool = make_ibf_routing_pool();
+    let routing_table_addr = make_routing_table_actor();
     PeerManagerActor::new(
         store,
         config,
         client_addr.recipient(),
         view_client_addr.recipient(),
-        ibf_routing_pool,
+        routing_table_addr,
     )
     .unwrap()
 }

--- a/integration-tests/tests/network/runner.rs
+++ b/integration-tests/tests/network/runner.rs
@@ -16,7 +16,7 @@ use near_client::{start_client, start_view_client};
 use near_crypto::KeyType;
 use near_logger_utils::init_test_logger;
 use near_network::test_utils::{
-    convert_boot_nodes, expected_routing_tables, make_ibf_routing_pool, open_port,
+    convert_boot_nodes, expected_routing_tables, make_routing_table_actor, open_port,
     peer_id_from_seed, BanPeerSignal, GetInfo, StopSignal, WaitOrTimeout,
 };
 
@@ -96,13 +96,13 @@ pub fn setup_network_node(
             adv.clone(),
         );
 
-        let ibf_routing_pool = make_ibf_routing_pool();
+        let routing_table_addr = make_routing_table_actor();
         PeerManagerActor::new(
             store.clone(),
             config,
             client_actor.recipient(),
             view_client_actor.recipient(),
-            ibf_routing_pool,
+            routing_table_addr,
         )
         .unwrap()
     });

--- a/integration-tests/tests/network/stress_network.rs
+++ b/integration-tests/tests/network/stress_network.rs
@@ -11,7 +11,7 @@ use near_actix_test_utils::run_actix;
 use near_client::{ClientActor, ViewClientActor};
 use near_logger_utils::init_test_logger_allow_panic;
 use near_network::test_utils::{
-    convert_boot_nodes, make_ibf_routing_pool, open_port, GetInfo, StopSignal, WaitOrTimeout,
+    convert_boot_nodes, make_routing_table_actor, open_port, GetInfo, StopSignal, WaitOrTimeout,
 };
 use near_network::types::{NetworkViewClientMessages, NetworkViewClientResponses};
 use near_network::{NetworkClientResponses, NetworkConfig, PeerManagerActor};
@@ -43,13 +43,13 @@ fn make_peer_manager(seed: &str, port: u16, boot_nodes: Vec<(&str, u16)>) -> Pee
         }
     }))
     .start();
-    let ibf_routing_pool = make_ibf_routing_pool();
+    let routing_table_addr = make_routing_table_actor();
     PeerManagerActor::new(
         store,
         config,
         client_addr.recipient(),
         view_client_addr.recipient(),
-        ibf_routing_pool,
+        routing_table_addr,
     )
     .unwrap()
 }


### PR DESCRIPTION
We should refactor network code, before https://github.com/near/nearcore/pull/5089

- This refactoring doesn't contain any code changes, only methods/attributes are renamed to better names
- All changes are extracted from #5089, this was done to keep that PR smaller. This will cause merge conflicts, but it's better to extract syntax only changes to make #5089 easier to review.

Here is design doc for changes planned (https://docs.google.com/document/d/1FV3oyMRo52EQAgYroVd6Ws-5-ylkLSTdMOstY-IdL-M/edit?usp=sharing)