### PR TITLE
Refactor PeerManager to group messages under one enum

### DIFF
--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -1767,12 +1767,7 @@ mod test {
         // For the chunks that would otherwise be requested from self we expect a request to be
         // sent to any peer tracking shard
 
-        let msg = network_adapter.requests.read().unwrap()[0].clone();
-        let msg = match msg {
-            PeerMessageRequest::NetworkRequests(msg) => msg,
-            _ => panic!("expected PeerMessageRequest"),
-        };
-
+        let msg = network_adapter.requests.read().unwrap()[0].clone().as_network_requests();
         if let NetworkRequests::PartialEncodedChunkRequest { target, .. } = msg {
             assert!(target.account_id == None);
         } else {

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -1984,7 +1984,7 @@ mod test {
             let mut forwards_count = 0;
             let mut requests_count = 0;
             fixture.mock_network.requests.read().unwrap().iter().for_each(|r| {
-                match r.as_network_requests() {
+                match r.as_network_requests_ref() {
                     NetworkRequests::PartialEncodedChunkForward { .. } => forwards_count += 1,
                     NetworkRequests::PartialEncodedChunkRequest { .. } => requests_count += 1,
                     _ => (),
@@ -2060,7 +2060,7 @@ mod test {
             .unwrap()
             .iter()
             .find(|r| {
-                match r.as_network_requests() {
+                match r.as_network_requests_ref() {
                     NetworkRequests::PartialEncodedChunkRequest { .. } => true,
                     _ => false,
                 }

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -1989,12 +1989,7 @@ mod test {
             let mut forwards_count = 0;
             let mut requests_count = 0;
             fixture.mock_network.requests.read().unwrap().iter().for_each(|r| {
-                let r = match r {
-                    PeerMessageRequest::NetworkRequests(msg) => msg,
-                    _ => panic!("expected PeerMessageRequest::NetworkRequests"),
-                };
-
-                match r {
+                match r.as_network_requests() {
                     NetworkRequests::PartialEncodedChunkForward { .. } => forwards_count += 1,
                     NetworkRequests::PartialEncodedChunkRequest { .. } => requests_count += 1,
                     _ => (),
@@ -2070,12 +2065,7 @@ mod test {
             .unwrap()
             .iter()
             .find(|r| {
-                let r = match r {
-                    PeerMessageRequest::NetworkRequests(msg) => msg,
-                    _ => panic!("expected PeerMessageRequest::NetworkRequests"),
-                };
-
-                match r {
+                match r.as_network_requests() {
                     NetworkRequests::PartialEncodedChunkRequest { .. } => true,
                     _ => false,
                 }

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -17,7 +17,7 @@ use near_network::types::{
     AccountIdOrPeerTrackingShard, PartialEncodedChunkRequestMsg, PartialEncodedChunkResponseMsg,
     PeerManagerAdapter,
 };
-use near_network::types::{PartialEncodedChunkForwardMsg, PeerMessageRequest};
+use near_network::types::{PartialEncodedChunkForwardMsg, PeerManagerMessageRequest};
 use near_network::NetworkRequests;
 use near_pool::{PoolIteratorWrapper, TransactionPool};
 use near_primitives::block::{BlockHeader, Tip};
@@ -535,7 +535,7 @@ impl ShardsManager {
                     },
                 };
 
-                self.peer_manager_adapter.do_send(PeerMessageRequest::NetworkRequests(
+                self.peer_manager_adapter.do_send(PeerManagerMessageRequest::NetworkRequests(
                     NetworkRequests::PartialEncodedChunkRequest { target, request },
                 ));
             } else {
@@ -929,7 +929,7 @@ impl ShardsManager {
 
         let response = PartialEncodedChunkResponseMsg { chunk_hash, parts, receipts };
 
-        self.peer_manager_adapter.do_send(PeerMessageRequest::NetworkRequests(
+        self.peer_manager_adapter.do_send(PeerManagerMessageRequest::NetworkRequests(
             NetworkRequests::PartialEncodedChunkResponse { route_back, response },
         ));
     }
@@ -1374,7 +1374,7 @@ impl ShardsManager {
                 false,
             );
             if cares_about_shard {
-                self.peer_manager_adapter.do_send(PeerMessageRequest::NetworkRequests(
+                self.peer_manager_adapter.do_send(PeerManagerMessageRequest::NetworkRequests(
                     NetworkRequests::PartialEncodedChunkForward {
                         account_id: bp_account_id,
                         forward: forward.clone(),
@@ -1692,7 +1692,7 @@ impl ShardsManager {
                 );
 
             if Some(&to_whom) != self.me.as_ref() {
-                self.peer_manager_adapter.do_send(PeerMessageRequest::NetworkRequests(
+                self.peer_manager_adapter.do_send(PeerManagerMessageRequest::NetworkRequests(
                     NetworkRequests::PartialEncodedChunkMessage {
                         account_id: to_whom.clone(),
                         partial_encoded_chunk,

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -1767,7 +1767,7 @@ mod test {
         // For the chunks that would otherwise be requested from self we expect a request to be
         // sent to any peer tracking shard
 
-        let msg = network_adapter.requests.read().unwrap()[0].clone().as_network_requests();
+        let msg = network_adapter.requests.read().unwrap()[0].as_network_requests_ref().clone();
         if let NetworkRequests::PartialEncodedChunkRequest { target, .. } = msg {
             assert!(target.account_id == None);
         } else {

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -13,11 +13,11 @@ use near_chain::validate::validate_chunk_proofs;
 use near_chain::{
     byzantine_assert, ChainStore, ChainStoreAccess, ChainStoreUpdate, ErrorKind, RuntimeAdapter,
 };
-use near_network::types::PartialEncodedChunkForwardMsg;
 use near_network::types::{
-    AccountIdOrPeerTrackingShard, NetworkAdapter, PartialEncodedChunkRequestMsg,
-    PartialEncodedChunkResponseMsg,
+    AccountIdOrPeerTrackingShard, PartialEncodedChunkRequestMsg, PartialEncodedChunkResponseMsg,
+    PeerManagerAdapter,
 };
+use near_network::types::{PartialEncodedChunkForwardMsg, PeerMessageRequest};
 use near_network::NetworkRequests;
 use near_pool::{PoolIteratorWrapper, TransactionPool};
 use near_primitives::block::{BlockHeader, Tip};
@@ -379,7 +379,7 @@ pub struct ShardsManager {
     tx_pools: HashMap<ShardId, TransactionPool>,
 
     runtime_adapter: Arc<dyn RuntimeAdapter>,
-    network_adapter: Arc<dyn NetworkAdapter>,
+    peer_manager_adapter: Arc<dyn PeerManagerAdapter>,
 
     encoded_chunks: EncodedChunksCache,
     requested_partial_encoded_chunks: RequestPool,
@@ -393,13 +393,13 @@ impl ShardsManager {
     pub fn new(
         me: Option<AccountId>,
         runtime_adapter: Arc<dyn RuntimeAdapter>,
-        network_adapter: Arc<dyn NetworkAdapter>,
+        network_adapter: Arc<dyn PeerManagerAdapter>,
     ) -> Self {
         Self {
             me: me.clone(),
             tx_pools: HashMap::new(),
             runtime_adapter: runtime_adapter.clone(),
-            network_adapter,
+            peer_manager_adapter: network_adapter,
             encoded_chunks: EncodedChunksCache::new(),
             requested_partial_encoded_chunks: RequestPool::new(
                 Duration::from_millis(CHUNK_REQUEST_RETRY_MS),
@@ -535,8 +535,9 @@ impl ShardsManager {
                     },
                 };
 
-                self.network_adapter
-                    .do_send(NetworkRequests::PartialEncodedChunkRequest { target, request });
+                self.peer_manager_adapter.do_send(PeerMessageRequest::NetworkRequests(
+                    NetworkRequests::PartialEncodedChunkRequest { target, request },
+                ));
             } else {
                 warn!(target: "client", "{:?} requests parts {:?} for chunk {:?} from self",
                     me, part_ords, chunk_hash
@@ -928,8 +929,9 @@ impl ShardsManager {
 
         let response = PartialEncodedChunkResponseMsg { chunk_hash, parts, receipts };
 
-        self.network_adapter
-            .do_send(NetworkRequests::PartialEncodedChunkResponse { route_back, response });
+        self.peer_manager_adapter.do_send(PeerMessageRequest::NetworkRequests(
+            NetworkRequests::PartialEncodedChunkResponse { route_back, response },
+        ));
     }
 
     pub fn check_chunk_complete(
@@ -1372,10 +1374,12 @@ impl ShardsManager {
                 false,
             );
             if cares_about_shard {
-                self.network_adapter.do_send(NetworkRequests::PartialEncodedChunkForward {
-                    account_id: bp_account_id,
-                    forward: forward.clone(),
-                });
+                self.peer_manager_adapter.do_send(PeerMessageRequest::NetworkRequests(
+                    NetworkRequests::PartialEncodedChunkForward {
+                        account_id: bp_account_id,
+                        forward: forward.clone(),
+                    },
+                ));
             }
         }
 
@@ -1688,10 +1692,12 @@ impl ShardsManager {
                 );
 
             if Some(&to_whom) != self.me.as_ref() {
-                self.network_adapter.do_send(NetworkRequests::PartialEncodedChunkMessage {
-                    account_id: to_whom.clone(),
-                    partial_encoded_chunk,
-                });
+                self.peer_manager_adapter.do_send(PeerMessageRequest::NetworkRequests(
+                    NetworkRequests::PartialEncodedChunkMessage {
+                        account_id: to_whom.clone(),
+                        partial_encoded_chunk,
+                    },
+                ));
             }
         }
 
@@ -1710,7 +1716,7 @@ mod test {
     use super::*;
     use crate::test_utils::*;
     use near_chain::test_utils::KeyValueRuntime;
-    use near_network::test_utils::MockNetworkAdapter;
+    use near_network::test_utils::MockPeerManagerAdapter;
     use near_network::types::PartialEncodedChunkForwardMsg;
     use near_primitives::hash::{hash, CryptoHash};
     use near_primitives::version::PROTOCOL_VERSION;
@@ -1733,7 +1739,7 @@ mod test {
     #[test]
     fn test_request_partial_encoded_chunk_from_self() {
         let runtime_adapter = Arc::new(KeyValueRuntime::new(create_test_store()));
-        let network_adapter = Arc::new(MockNetworkAdapter::default());
+        let network_adapter = Arc::new(MockPeerManagerAdapter::default());
         let mut shards_manager = ShardsManager::new(
             Some("test".parse().unwrap()),
             runtime_adapter,
@@ -1760,9 +1766,14 @@ mod test {
 
         // For the chunks that would otherwise be requested from self we expect a request to be
         // sent to any peer tracking shard
-        if let NetworkRequests::PartialEncodedChunkRequest { target, .. } =
-            network_adapter.requests.read().unwrap()[0].clone()
-        {
+
+        let msg = network_adapter.requests.read().unwrap()[0].clone();
+        let msg = match msg {
+            PeerMessageRequest::NetworkRequests(msg) => msg,
+            _ => panic!("expected PeerMessageRequest"),
+        };
+
+        if let NetworkRequests::PartialEncodedChunkRequest { target, .. } = msg {
             assert!(target.account_id == None);
         } else {
             println!("{:?}", network_adapter.requests.read().unwrap());
@@ -1786,7 +1797,7 @@ mod test {
             1,
             5,
         ));
-        let network_adapter = Arc::new(MockNetworkAdapter::default());
+        let network_adapter = Arc::new(MockPeerManagerAdapter::default());
         let mut chain_store = ChainStore::new(create_test_store(), 0);
         let mut shards_manager = ShardsManager::new(
             Some("test".parse().unwrap()),
@@ -1977,10 +1988,17 @@ mod test {
         let count_forwards_and_requests = |fixture: &ChunkForwardingTestFixture| -> (usize, usize) {
             let mut forwards_count = 0;
             let mut requests_count = 0;
-            fixture.mock_network.requests.read().unwrap().iter().for_each(|r| match r {
-                NetworkRequests::PartialEncodedChunkForward { .. } => forwards_count += 1,
-                NetworkRequests::PartialEncodedChunkRequest { .. } => requests_count += 1,
-                _ => (),
+            fixture.mock_network.requests.read().unwrap().iter().for_each(|r| {
+                let r = match r {
+                    PeerMessageRequest::NetworkRequests(msg) => msg,
+                    _ => panic!("expected PeerMessageRequest::NetworkRequests"),
+                };
+
+                match r {
+                    NetworkRequests::PartialEncodedChunkForward { .. } => forwards_count += 1,
+                    NetworkRequests::PartialEncodedChunkRequest { .. } => requests_count += 1,
+                    _ => (),
+                }
             });
             (forwards_count, requests_count)
         };
@@ -2051,9 +2069,16 @@ mod test {
             .read()
             .unwrap()
             .iter()
-            .find(|r| match r {
-                NetworkRequests::PartialEncodedChunkRequest { .. } => true,
-                _ => false,
+            .find(|r| {
+                let r = match r {
+                    PeerMessageRequest::NetworkRequests(msg) => msg,
+                    _ => panic!("expected PeerMessageRequest::NetworkRequests"),
+                };
+
+                match r {
+                    NetworkRequests::PartialEncodedChunkRequest { .. } => true,
+                    _ => false,
+                }
             })
             .is_none());
     }

--- a/chain/chunks/src/test_utils.rs
+++ b/chain/chunks/src/test_utils.rs
@@ -6,7 +6,7 @@ use near_chain::test_utils::KeyValueRuntime;
 use near_chain::types::RuntimeAdapter;
 use near_chain::ChainStore;
 use near_crypto::KeyType;
-use near_network::test_utils::MockNetworkAdapter;
+use near_network::test_utils::MockPeerManagerAdapter;
 use near_primitives::block::BlockHeader;
 use near_primitives::hash::{self, CryptoHash};
 use near_primitives::merkle;
@@ -133,7 +133,7 @@ impl SealsManagerTestFixture {
 
 pub struct ChunkForwardingTestFixture {
     pub mock_runtime: Arc<KeyValueRuntime>,
-    pub mock_network: Arc<MockNetworkAdapter>,
+    pub mock_network: Arc<MockPeerManagerAdapter>,
     pub chain_store: ChainStore,
     pub mock_part_ords: Vec<u64>,
     pub mock_chunk_part_owner: AccountId,
@@ -155,7 +155,7 @@ impl Default for ChunkForwardingTestFixture {
             3,
             5,
         ));
-        let mock_network = Arc::new(MockNetworkAdapter::default());
+        let mock_network = Arc::new(MockPeerManagerAdapter::default());
 
         let data_parts = mock_runtime.num_data_parts();
         let parity_parts = mock_runtime.num_total_parts() - data_parts;

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -22,7 +22,7 @@ use near_chain::{
 };
 use near_chain_configs::ClientConfig;
 use near_chunks::{ProcessPartialEncodedChunkResult, ShardsManager};
-use near_network::types::{PartialEncodedChunkResponseMsg, PeerMessageRequest};
+use near_network::types::{PartialEncodedChunkResponseMsg, PeerManagerMessageRequest};
 use near_network::{
     FullPeerInfo, NetworkClientResponses, NetworkRequests, PeerManagerAdapter,
     EPOCH_SYNC_PEER_TIMEOUT_MS, EPOCH_SYNC_REQUEST_TIMEOUT_MS,
@@ -192,7 +192,7 @@ impl Client {
             && !self.sync_status.is_syncing()
         {
             let block = self.chain.get_block(&self.chain.head()?.last_block_hash)?;
-            self.network_adapter.do_send(PeerMessageRequest::NetworkRequests(
+            self.network_adapter.do_send(PeerManagerMessageRequest::NetworkRequests(
                 NetworkRequests::Block { block: block.clone() },
             ));
             self.last_time_head_progress_made = Instant::now();
@@ -675,7 +675,7 @@ impl Client {
             for body in challenges.write().unwrap().drain(..) {
                 let challenge = Challenge::produce(body, &**validator_signer);
                 self.challenges.insert(challenge.hash, challenge.clone());
-                self.network_adapter.do_send(PeerMessageRequest::NetworkRequests(
+                self.network_adapter.do_send(PeerManagerMessageRequest::NetworkRequests(
                     NetworkRequests::Challenge(challenge),
                 ));
             }
@@ -737,7 +737,7 @@ impl Client {
             match &result {
                 Err(e) => match e.kind() {
                     near_chain::ErrorKind::InvalidChunkProofs(chunk_proofs) => {
-                        self.network_adapter.do_send(PeerMessageRequest::NetworkRequests(
+                        self.network_adapter.do_send(PeerManagerMessageRequest::NetworkRequests(
                             NetworkRequests::Challenge(Challenge::produce(
                                 ChallengeBody::ChunkProofs(*chunk_proofs),
                                 &**validator_signer,
@@ -745,7 +745,7 @@ impl Client {
                         ));
                     }
                     near_chain::ErrorKind::InvalidChunkState(chunk_state) => {
-                        self.network_adapter.do_send(PeerMessageRequest::NetworkRequests(
+                        self.network_adapter.do_send(PeerManagerMessageRequest::NetworkRequests(
                             NetworkRequests::Challenge(Challenge::produce(
                                 ChallengeBody::ChunkState(*chunk_state),
                                 &**validator_signer,
@@ -783,7 +783,7 @@ impl Client {
 
     pub fn rebroadcast_block(&mut self, block: Block) {
         if self.rebroadcasted_blocks.cache_get(&block.hash()).is_none() {
-            self.network_adapter.do_send(PeerMessageRequest::NetworkRequests(
+            self.network_adapter.do_send(PeerManagerMessageRequest::NetworkRequests(
                 NetworkRequests::Block { block: block.clone() },
             ));
             self.rebroadcasted_blocks.cache_set(*block.hash(), ());
@@ -951,7 +951,7 @@ impl Client {
         } else {
             debug!(target: "client", "Sending an approval {:?} from {} to {} for {}", approval.inner, approval.account_id, next_block_producer.clone(), approval.target_height);
             let approval_message = ApprovalMessage::new(approval, next_block_producer);
-            self.network_adapter.do_send(PeerMessageRequest::NetworkRequests(
+            self.network_adapter.do_send(PeerManagerMessageRequest::NetworkRequests(
                 NetworkRequests::Approval { approval_message },
             ));
         }
@@ -1418,7 +1418,7 @@ impl Client {
             );
 
             // Send message to network to actually forward transaction.
-            self.network_adapter.do_send(PeerMessageRequest::NetworkRequests(
+            self.network_adapter.do_send(PeerManagerMessageRequest::NetworkRequests(
                 NetworkRequests::ForwardTx(validator, tx.clone()),
             ));
         }

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -22,9 +22,9 @@ use near_chain::{
 };
 use near_chain_configs::ClientConfig;
 use near_chunks::{ProcessPartialEncodedChunkResult, ShardsManager};
-use near_network::types::PartialEncodedChunkResponseMsg;
+use near_network::types::{PartialEncodedChunkResponseMsg, PeerMessageRequest};
 use near_network::{
-    FullPeerInfo, NetworkAdapter, NetworkClientResponses, NetworkRequests,
+    FullPeerInfo, NetworkClientResponses, NetworkRequests, PeerManagerAdapter,
     EPOCH_SYNC_PEER_TIMEOUT_MS, EPOCH_SYNC_REQUEST_TIMEOUT_MS,
 };
 use near_primitives::block::{Approval, ApprovalInner, ApprovalMessage, Block, BlockHeader, Tip};
@@ -70,7 +70,7 @@ pub struct Client {
     pub runtime_adapter: Arc<dyn RuntimeAdapter>,
     pub shards_mgr: ShardsManager,
     /// Network adapter.
-    network_adapter: Arc<dyn NetworkAdapter>,
+    network_adapter: Arc<dyn PeerManagerAdapter>,
     /// Signer for block producer (if present).
     pub validator_signer: Option<Arc<dyn ValidatorSigner>>,
     /// Approvals for which we do not have the block yet
@@ -103,7 +103,7 @@ impl Client {
         config: ClientConfig,
         chain_genesis: ChainGenesis,
         runtime_adapter: Arc<dyn RuntimeAdapter>,
-        network_adapter: Arc<dyn NetworkAdapter>,
+        network_adapter: Arc<dyn PeerManagerAdapter>,
         validator_signer: Option<Arc<dyn ValidatorSigner>>,
         enable_doomslug: bool,
     ) -> Result<Self, Error> {
@@ -192,7 +192,9 @@ impl Client {
             && !self.sync_status.is_syncing()
         {
             let block = self.chain.get_block(&self.chain.head()?.last_block_hash)?;
-            self.network_adapter.do_send(NetworkRequests::Block { block: block.clone() });
+            self.network_adapter.do_send(PeerMessageRequest::NetworkRequests(
+                NetworkRequests::Block { block: block.clone() },
+            ));
             self.last_time_head_progress_made = Instant::now();
         }
         Ok(())
@@ -673,7 +675,9 @@ impl Client {
             for body in challenges.write().unwrap().drain(..) {
                 let challenge = Challenge::produce(body, &**validator_signer);
                 self.challenges.insert(challenge.hash, challenge.clone());
-                self.network_adapter.do_send(NetworkRequests::Challenge(challenge));
+                self.network_adapter.do_send(PeerMessageRequest::NetworkRequests(
+                    NetworkRequests::Challenge(challenge),
+                ));
             }
         }
     }
@@ -733,19 +737,19 @@ impl Client {
             match &result {
                 Err(e) => match e.kind() {
                     near_chain::ErrorKind::InvalidChunkProofs(chunk_proofs) => {
-                        self.network_adapter.do_send(NetworkRequests::Challenge(
-                            Challenge::produce(
+                        self.network_adapter.do_send(PeerMessageRequest::NetworkRequests(
+                            NetworkRequests::Challenge(Challenge::produce(
                                 ChallengeBody::ChunkProofs(*chunk_proofs),
                                 &**validator_signer,
-                            ),
+                            )),
                         ));
                     }
                     near_chain::ErrorKind::InvalidChunkState(chunk_state) => {
-                        self.network_adapter.do_send(NetworkRequests::Challenge(
-                            Challenge::produce(
+                        self.network_adapter.do_send(PeerMessageRequest::NetworkRequests(
+                            NetworkRequests::Challenge(Challenge::produce(
                                 ChallengeBody::ChunkState(*chunk_state),
                                 &**validator_signer,
-                            ),
+                            )),
                         ));
                     }
                     _ => {}
@@ -779,7 +783,9 @@ impl Client {
 
     pub fn rebroadcast_block(&mut self, block: Block) {
         if self.rebroadcasted_blocks.cache_get(&block.hash()).is_none() {
-            self.network_adapter.do_send(NetworkRequests::Block { block: block.clone() });
+            self.network_adapter.do_send(PeerMessageRequest::NetworkRequests(
+                NetworkRequests::Block { block: block.clone() },
+            ));
             self.rebroadcasted_blocks.cache_set(*block.hash(), ());
         }
     }
@@ -945,7 +951,9 @@ impl Client {
         } else {
             debug!(target: "client", "Sending an approval {:?} from {} to {} for {}", approval.inner, approval.account_id, next_block_producer.clone(), approval.target_height);
             let approval_message = ApprovalMessage::new(approval, next_block_producer);
-            self.network_adapter.do_send(NetworkRequests::Approval { approval_message });
+            self.network_adapter.do_send(PeerMessageRequest::NetworkRequests(
+                NetworkRequests::Approval { approval_message },
+            ));
         }
 
         Ok(())
@@ -1410,7 +1418,9 @@ impl Client {
             );
 
             // Send message to network to actually forward transaction.
-            self.network_adapter.do_send(NetworkRequests::ForwardTx(validator, tx.clone()));
+            self.network_adapter.do_send(PeerMessageRequest::NetworkRequests(
+                NetworkRequests::ForwardTx(validator, tx.clone()),
+            ));
         }
 
         Ok(())

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -29,11 +29,11 @@ use near_chain_configs::GenesisConfig;
 use near_crypto::Signature;
 #[cfg(feature = "test_features")]
 use near_network::types::NetworkAdversarialMessage;
-use near_network::types::{NetworkInfo, ReasonForBan};
+use near_network::types::{NetworkInfo, PeerMessageRequest, ReasonForBan};
 #[cfg(feature = "sandbox")]
 use near_network::types::{NetworkSandboxMessage, SandboxResponse};
 use near_network::{
-    NetworkAdapter, NetworkClientMessages, NetworkClientResponses, NetworkRequests,
+    NetworkClientMessages, NetworkClientResponses, NetworkRequests, PeerManagerAdapter,
 };
 use near_performance_metrics;
 use near_performance_metrics_macros::{perf, perf_with_debug};
@@ -82,7 +82,7 @@ pub struct ClientActor {
     pub adv: Arc<RwLock<AdversarialControls>>,
 
     client: Client,
-    network_adapter: Arc<dyn NetworkAdapter>,
+    network_adapter: Arc<dyn PeerManagerAdapter>,
     network_info: NetworkInfo,
     /// Identity that represents this Client at the network level.
     /// It is used as part of the messages that identify this client.
@@ -130,7 +130,7 @@ impl ClientActor {
         chain_genesis: ChainGenesis,
         runtime_adapter: Arc<dyn RuntimeAdapter>,
         node_id: PeerId,
-        network_adapter: Arc<dyn NetworkAdapter>,
+        network_adapter: Arc<dyn PeerManagerAdapter>,
         validator_signer: Option<Arc<dyn ValidatorSigner>>,
         telemetry_actor: Addr<TelemetryActor>,
         enable_doomslug: bool,
@@ -285,8 +285,9 @@ impl Handler<NetworkClientMessages> for ClientActor {
                             }
                             let block = block.expect("block should exist after produced");
                             info!(target: "adversary", "Producing {} block out of {}, height = {}", blocks_produced, num_blocks, height);
-                            self.network_adapter
-                                .do_send(NetworkRequests::Block { block: block.clone() });
+                            self.network_adapter.do_send(PeerMessageRequest::NetworkRequests(
+                                NetworkRequests::Block { block: block.clone() },
+                            ));
                             let (accepted_blocks, _) =
                                 self.client.process_block(block, Provenance::PRODUCED);
                             for accepted_block in accepted_blocks {
@@ -759,12 +760,14 @@ impl ClientActor {
             self.last_validator_announce_time = Some(now);
             let signature = self.sign_announce_account(&next_epoch_id).unwrap();
 
-            self.network_adapter.do_send(NetworkRequests::AnnounceAccount(AnnounceAccount {
-                account_id: validator_signer.validator_id().clone(),
-                peer_id: self.node_id.clone(),
-                epoch_id: next_epoch_id,
-                signature,
-            }));
+            self.network_adapter.do_send(PeerMessageRequest::NetworkRequests(
+                NetworkRequests::AnnounceAccount(AnnounceAccount {
+                    account_id: validator_signer.validator_id().clone(),
+                    peer_id: self.node_id.clone(),
+                    epoch_id: next_epoch_id,
+                    signature,
+                }),
+            ));
         }
     }
 
@@ -1009,7 +1012,9 @@ impl ClientActor {
         // If we didn't produce the block and didn't request it, do basic validation
         // before sending it out.
         if provenance == Provenance::PRODUCED {
-            self.network_adapter.do_send(NetworkRequests::Block { block: block.clone() });
+            self.network_adapter.do_send(PeerMessageRequest::NetworkRequests(
+                NetworkRequests::Block { block: block.clone() },
+            ));
         } else {
             match self.client.chain.validate_block(&block) {
                 Ok(_) => {
@@ -1025,10 +1030,12 @@ impl ClientActor {
                 }
                 Err(e) => {
                     if e.is_bad_data() {
-                        self.network_adapter.do_send(NetworkRequests::BanPeer {
-                            peer_id: peer_id.clone(),
-                            ban_reason: ReasonForBan::BadBlockHeader,
-                        });
+                        self.network_adapter.do_send(PeerMessageRequest::NetworkRequests(
+                            NetworkRequests::BanPeer {
+                                peer_id: peer_id.clone(),
+                                ban_reason: ReasonForBan::BadBlockHeader,
+                            },
+                        ));
                         return Err(e);
                     }
                 }
@@ -1135,7 +1142,9 @@ impl ClientActor {
     fn request_block_by_hash(&mut self, hash: CryptoHash, peer_id: PeerId) {
         match self.client.chain.block_exists(&hash) {
             Ok(false) => {
-                self.network_adapter.do_send(NetworkRequests::BlockRequest { hash, peer_id });
+                self.network_adapter.do_send(PeerMessageRequest::NetworkRequests(
+                    NetworkRequests::BlockRequest { hash, peer_id },
+                ));
             }
             Ok(true) => {
                 debug!(target: "client", "send_block_request_to_peer: block {} already known", hash)
@@ -1675,7 +1684,7 @@ pub fn start_client(
     chain_genesis: ChainGenesis,
     runtime_adapter: Arc<dyn RuntimeAdapter>,
     node_id: PeerId,
-    network_adapter: Arc<dyn NetworkAdapter>,
+    network_adapter: Arc<dyn PeerManagerAdapter>,
     validator_signer: Option<Arc<dyn ValidatorSigner>>,
     telemetry_actor: Addr<TelemetryActor>,
     #[cfg(feature = "test_features")] adv: Arc<RwLock<AdversarialControls>>,

--- a/chain/client/src/sync.rs
+++ b/chain/client/src/sync.rs
@@ -1367,12 +1367,7 @@ mod test {
         assert!(sync_status.is_syncing());
         // Check that it queried last block, and then stepped down to genesis block to find common block with the peer.
 
-        let item = mock_adapter.pop().unwrap();
-        let item = match item {
-            PeerMessageRequest::NetworkRequests(item) => item,
-            _ => panic!("expected NetworkRequests"),
-        };
-
+        let item = mock_adapter.pop().unwrap().as_network_requests();
         assert_eq!(
             item,
             NetworkRequests::BlockHeadersRequest {
@@ -1531,13 +1526,8 @@ mod test {
         }
         // This time the peer should be banned, because 4 blocks/s is not fast enough
         let ban_peer = network_adapter.requests.write().unwrap().pop_back().unwrap();
-        let ban_peer = if let PeerMessageRequest::NetworkRequests(ban_peer) = ban_peer {
-            ban_peer
-        } else {
-            panic!("expected  PeerMessageRequest::NetworkRequests");
-        };
 
-        if let NetworkRequests::BanPeer { .. } = ban_peer {
+        if let NetworkRequests::BanPeer { .. } = ban_peer.as_network_requests() {
             /* expected */
         } else {
             assert!(false);

--- a/chain/client/src/sync.rs
+++ b/chain/client/src/sync.rs
@@ -13,8 +13,10 @@ use rand::seq::{IteratorRandom, SliceRandom};
 use rand::{thread_rng, Rng};
 
 use near_chain::{Chain, RuntimeAdapter};
-use near_network::types::{AccountOrPeerIdOrHash, NetworkResponses, ReasonForBan};
-use near_network::{FullPeerInfo, NetworkAdapter, NetworkRequests};
+use near_network::types::{
+    AccountOrPeerIdOrHash, NetworkResponses, PeerMessageRequest, PeerMessageResponse, ReasonForBan,
+};
+use near_network::{FullPeerInfo, NetworkRequests, PeerManagerAdapter};
 use near_primitives::block::Tip;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
@@ -64,7 +66,7 @@ pub fn highest_height_peer(highest_height_peers: &Vec<FullPeerInfo>) -> Option<F
 // TODO #3488
 #[allow(dead_code)]
 pub struct EpochSync {
-    network_adapter: Arc<dyn NetworkAdapter>,
+    network_adapter: Arc<dyn PeerManagerAdapter>,
     /// Datastructure to keep track of when the last request to each peer was made.
     /// Peers do not respond to Epoch Sync requests more frequently than once per a certain time
     /// interval, thus there's no point in requesting more frequently.
@@ -104,7 +106,7 @@ pub struct EpochSync {
 
 impl EpochSync {
     pub fn new(
-        network_adapter: Arc<dyn NetworkAdapter>,
+        network_adapter: Arc<dyn PeerManagerAdapter>,
         genesis_epoch_id: EpochId,
         genesis_next_epoch_id: EpochId,
         first_epoch_block_producers: Vec<ValidatorStake>,
@@ -135,7 +137,7 @@ impl EpochSync {
 /// Helper to keep track of sync headers.
 /// Handles major re-orgs by finding closest header that matches and re-downloading headers from that point.
 pub struct HeaderSync {
-    network_adapter: Arc<dyn NetworkAdapter>,
+    network_adapter: Arc<dyn PeerManagerAdapter>,
     history_locator: Vec<(BlockHeight, CryptoHash)>,
     prev_header_sync: (DateTime<Utc>, BlockHeight, BlockHeight, BlockHeight),
     syncing_peer: Option<FullPeerInfo>,
@@ -149,7 +151,7 @@ pub struct HeaderSync {
 
 impl HeaderSync {
     pub fn new(
-        network_adapter: Arc<dyn NetworkAdapter>,
+        network_adapter: Arc<dyn PeerManagerAdapter>,
         initial_timeout: TimeDuration,
         progress_timeout: TimeDuration,
         stall_ban_timeout: TimeDuration,
@@ -270,10 +272,14 @@ impl HeaderSync {
                                 {
                                     warn!(target: "sync", "Sync: ban a fraudulent peer: {}, claimed height: {}",
                                         peer.peer_info, peer.chain_info.height);
-                                    self.network_adapter.do_send(NetworkRequests::BanPeer {
-                                        peer_id: peer.peer_info.id.clone(),
-                                        ban_reason: ReasonForBan::HeightFraud,
-                                    });
+                                    self.network_adapter.do_send(
+                                        PeerMessageRequest::NetworkRequests(
+                                            NetworkRequests::BanPeer {
+                                                peer_id: peer.peer_info.id.clone(),
+                                                ban_reason: ReasonForBan::HeightFraud,
+                                            },
+                                        ),
+                                    );
                                     // This peer is fraudulent, let's skip this beat and wait for
                                     // the next one when this peer is not in the list anymore.
                                     self.syncing_peer = None;
@@ -312,10 +318,12 @@ impl HeaderSync {
     fn request_headers(&mut self, chain: &mut Chain, peer: FullPeerInfo) -> Option<FullPeerInfo> {
         if let Ok(locator) = self.get_locator(chain) {
             debug!(target: "sync", "Sync: request headers: asking {} for headers, {:?}", peer.peer_info.id, locator);
-            self.network_adapter.do_send(NetworkRequests::BlockHeadersRequest {
-                hashes: locator,
-                peer_id: peer.peer_info.id.clone(),
-            });
+            self.network_adapter.do_send(PeerMessageRequest::NetworkRequests(
+                NetworkRequests::BlockHeadersRequest {
+                    hashes: locator,
+                    peer_id: peer.peer_info.id.clone(),
+                },
+            ));
             return Some(peer);
         }
         None
@@ -400,7 +408,7 @@ pub struct BlockSyncRequest {
 
 /// Helper to track block syncing.
 pub struct BlockSync {
-    network_adapter: Arc<dyn NetworkAdapter>,
+    network_adapter: Arc<dyn PeerManagerAdapter>,
     last_request: Option<BlockSyncRequest>,
     /// How far to fetch blocks vs fetch state.
     block_fetch_horizon: BlockHeightDelta,
@@ -410,7 +418,7 @@ pub struct BlockSync {
 
 impl BlockSync {
     pub fn new(
-        network_adapter: Arc<dyn NetworkAdapter>,
+        network_adapter: Arc<dyn PeerManagerAdapter>,
         block_fetch_horizon: BlockHeightDelta,
         archive: bool,
     ) -> Self {
@@ -549,10 +557,12 @@ impl BlockSync {
         };
 
         if let Some(peer) = peer {
-            self.network_adapter.do_send(NetworkRequests::BlockRequest {
-                hash: request.hash,
-                peer_id: peer.peer_info.id.clone(),
-            });
+            self.network_adapter.do_send(PeerMessageRequest::NetworkRequests(
+                NetworkRequests::BlockRequest {
+                    hash: request.hash,
+                    peer_id: peer.peer_info.id.clone(),
+                },
+            ));
         }
 
         self.last_request = Some(request);
@@ -597,7 +607,7 @@ impl PendingRequestStatus {
 
 /// Helper to track state sync.
 pub struct StateSync {
-    network_adapter: Arc<dyn NetworkAdapter>,
+    network_adapter: Arc<dyn PeerManagerAdapter>,
 
     state_sync_time: HashMap<ShardId, DateTime<Utc>>,
     last_time_block_requested: Option<DateTime<Utc>>,
@@ -616,7 +626,7 @@ pub struct StateSync {
 }
 
 impl StateSync {
-    pub fn new(network_adapter: Arc<dyn NetworkAdapter>, timeout: TimeDuration) -> Self {
+    pub fn new(network_adapter: Arc<dyn PeerManagerAdapter>, timeout: TimeDuration) -> Self {
         StateSync {
             network_adapter,
             state_sync_time: Default::default(),
@@ -1086,8 +1096,16 @@ impl StateSync {
                 near_performance_metrics::actix::spawn(
                     std::any::type_name::<Self>(),
                     self.network_adapter
-                        .send(NetworkRequests::StateRequestHeader { shard_id, sync_hash, target })
+                        .send(PeerMessageRequest::NetworkRequests(
+                            NetworkRequests::StateRequestHeader { shard_id, sync_hash, target },
+                        ))
                         .then(move |result| {
+                            let result = match result {
+                                Ok(PeerMessageResponse::NetworkResponses(val)) => Ok(val),
+                                Err(val) => Err(val),
+                                _ => panic!("expected RoutedMessageFrom"),
+                            };
+
                             if let Ok(NetworkResponses::RouteNotFound) = result {
                                 // Send a StateRequestHeader on the next iteration
                                 run_me.store(true, Ordering::SeqCst);
@@ -1120,13 +1138,21 @@ impl StateSync {
                     near_performance_metrics::actix::spawn(
                         std::any::type_name::<Self>(),
                         self.network_adapter
-                            .send(NetworkRequests::StateRequestPart {
-                                shard_id,
-                                sync_hash,
-                                part_id: part_id as u64,
-                                target: target.clone(),
-                            })
+                            .send(PeerMessageRequest::NetworkRequests(
+                                NetworkRequests::StateRequestPart {
+                                    shard_id,
+                                    sync_hash,
+                                    part_id: part_id as u64,
+                                    target: target.clone(),
+                                },
+                            ))
                             .then(move |result| {
+                                let result = match result {
+                                    Ok(PeerMessageResponse::NetworkResponses(val)) => Ok(val),
+                                    Err(val) => Err(val),
+                                    _ => panic!("expected RoutedMessageFrom"),
+                                };
+
                                 if let Ok(NetworkResponses::RouteNotFound) = result {
                                     // Send a StateRequestPart on the next iteration
                                     run_me.store(true, Ordering::SeqCst);
@@ -1266,7 +1292,7 @@ mod test {
     use near_chain::test_utils::{setup, setup_with_validators};
     use near_chain::{ChainGenesis, Provenance};
     use near_crypto::{KeyType, PublicKey};
-    use near_network::test_utils::MockNetworkAdapter;
+    use near_network::test_utils::MockPeerManagerAdapter;
     use near_network::types::PeerChainInfoV2;
     use near_network::PeerInfo;
     use near_primitives::block::{Approval, Block, GenesisId};
@@ -1304,7 +1330,7 @@ mod test {
     /// Starts two chains that fork of genesis and checks that they can sync heaaders to the longest.
     #[test]
     fn test_sync_headers_fork() {
-        let mock_adapter = Arc::new(MockNetworkAdapter::default());
+        let mock_adapter = Arc::new(MockPeerManagerAdapter::default());
         let mut header_sync = HeaderSync::new(
             mock_adapter.clone(),
             TimeDuration::from_secs(10),
@@ -1348,8 +1374,15 @@ mod test {
             .is_ok());
         assert!(sync_status.is_syncing());
         // Check that it queried last block, and then stepped down to genesis block to find common block with the peer.
+
+        let item = mock_adapter.pop().unwrap();
+        let item = match item {
+            PeerMessageRequest::NetworkRequests(item) => item,
+            _ => panic!("expected NetworkRequests"),
+        };
+
         assert_eq!(
-            mock_adapter.pop().unwrap(),
+            item,
             NetworkRequests::BlockHeadersRequest {
                 hashes: [3, 1, 0]
                     .iter()
@@ -1368,7 +1401,7 @@ mod test {
     /// adjusted for time passed)
     #[test]
     fn test_slow_header_sync() {
-        let network_adapter = Arc::new(MockNetworkAdapter::default());
+        let network_adapter = Arc::new(MockPeerManagerAdapter::default());
         let highest_height = 1000;
 
         // Setup header_sync with expectation of 25 headers/second
@@ -1506,6 +1539,12 @@ mod test {
         }
         // This time the peer should be banned, because 4 blocks/s is not fast enough
         let ban_peer = network_adapter.requests.write().unwrap().pop_back().unwrap();
+        let ban_peer = if let PeerMessageRequest::NetworkRequests(ban_peer) = ban_peer {
+            ban_peer
+        } else {
+            panic!("expected  PeerMessageRequest::NetworkRequests");
+        };
+
         if let NetworkRequests::BanPeer { .. } = ban_peer {
             /* expected */
         } else {
@@ -1515,11 +1554,16 @@ mod test {
 
     /// Helper function for block sync tests
     fn collect_hashes_from_network_adapter(
-        network_adapter: Arc<MockNetworkAdapter>,
+        network_adapter: Arc<MockPeerManagerAdapter>,
     ) -> HashSet<CryptoHash> {
         let mut requested_block_hashes = HashSet::new();
         let mut network_request = network_adapter.requests.write().unwrap();
         while let Some(request) = network_request.pop_back() {
+            let request = match request {
+                PeerMessageRequest::NetworkRequests(result) => result,
+                _ => panic!("expected PeerMessageRequest::NetworkRequests"),
+            };
+
             match request {
                 NetworkRequests::BlockRequest { hash, .. } => {
                     requested_block_hashes.insert(hash);
@@ -1546,7 +1590,7 @@ mod test {
 
     #[test]
     fn test_block_sync() {
-        let network_adapter = Arc::new(MockNetworkAdapter::default());
+        let network_adapter = Arc::new(MockPeerManagerAdapter::default());
         let block_fetch_horizon = 10;
         let mut block_sync = BlockSync::new(network_adapter.clone(), block_fetch_horizon, false);
         let mut chain_genesis = ChainGenesis::test();
@@ -1588,7 +1632,7 @@ mod test {
 
     #[test]
     fn test_block_sync_archival() {
-        let network_adapter = Arc::new(MockNetworkAdapter::default());
+        let network_adapter = Arc::new(MockPeerManagerAdapter::default());
         let block_fetch_horizon = 10;
         let mut block_sync = BlockSync::new(network_adapter.clone(), block_fetch_horizon, true);
         let mut chain_genesis = ChainGenesis::test();

--- a/chain/client/src/sync.rs
+++ b/chain/client/src/sync.rs
@@ -14,7 +14,7 @@ use rand::{thread_rng, Rng};
 
 use near_chain::{Chain, RuntimeAdapter};
 use near_network::types::{
-    AccountOrPeerIdOrHash, NetworkResponses, PeerMessageRequest, PeerMessageResponse, ReasonForBan,
+    AccountOrPeerIdOrHash, NetworkResponses, PeerMessageRequest, ReasonForBan,
 };
 use near_network::{FullPeerInfo, NetworkRequests, PeerManagerAdapter};
 use near_primitives::block::Tip;
@@ -1541,8 +1541,10 @@ mod test {
         let mut requested_block_hashes = HashSet::new();
         let mut network_request = network_adapter.requests.write().unwrap();
         while let Some(request) = network_request.pop_back() {
-            match request.as_network_requests() {
-                NetworkRequests::BlockRequest { hash, .. } => {
+            match request {
+                PeerMessageRequest::NetworkRequests(NetworkRequests::BlockRequest {
+                    hash, ..
+                }) => {
                     requested_block_hashes.insert(hash);
                 }
                 _ => panic!("unexpected network request {:?}", request),

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -29,10 +29,10 @@ use near_client_primitives::types::{
 #[cfg(feature = "test_features")]
 use near_network::types::NetworkAdversarialMessage;
 use near_network::types::{
-    NetworkViewClientMessages, NetworkViewClientResponses, ReasonForBan, StateResponseInfo,
-    StateResponseInfoV1, StateResponseInfoV2,
+    NetworkViewClientMessages, NetworkViewClientResponses, PeerMessageRequest, ReasonForBan,
+    StateResponseInfo, StateResponseInfoV1, StateResponseInfoV2,
 };
-use near_network::{NetworkAdapter, NetworkRequests};
+use near_network::{NetworkRequests, PeerManagerAdapter};
 use near_performance_metrics_macros::perf;
 use near_performance_metrics_macros::perf_with_debug;
 use near_primitives::block::{Block, BlockHeader, GenesisId, Tip};
@@ -99,7 +99,7 @@ pub struct ViewClientActor {
     validator_account_id: Option<AccountId>,
     chain: Chain,
     runtime_adapter: Arc<dyn RuntimeAdapter>,
-    network_adapter: Arc<dyn NetworkAdapter>,
+    network_adapter: Arc<dyn PeerManagerAdapter>,
     pub config: ClientConfig,
     request_manager: Arc<RwLock<ViewClientRequestManager>>,
     state_request_cache: Arc<Mutex<VecDeque<Instant>>>,
@@ -125,7 +125,7 @@ impl ViewClientActor {
         validator_account_id: Option<AccountId>,
         chain_genesis: &ChainGenesis,
         runtime_adapter: Arc<dyn RuntimeAdapter>,
-        network_adapter: Arc<dyn NetworkAdapter>,
+        network_adapter: Arc<dyn PeerManagerAdapter>,
         config: ClientConfig,
         request_manager: Arc<RwLock<ViewClientRequestManager>>,
         #[cfg(feature = "test_features")] adv: Arc<RwLock<AdversarialControls>>,
@@ -346,8 +346,9 @@ impl ViewClientActor {
                         .chain
                         .find_validator_for_forwarding(dst_shard_id)
                         .map_err(|e| TxStatusError::ChainError(e))?;
-                    self.network_adapter
-                        .do_send(NetworkRequests::ReceiptOutComeRequest(validator, receipt_id));
+                    self.network_adapter.do_send(PeerMessageRequest::NetworkRequests(
+                        NetworkRequests::ReceiptOutComeRequest(validator, receipt_id),
+                    ));
                 }
             }
         }
@@ -447,10 +448,8 @@ impl ViewClientActor {
                     .find_validator_for_forwarding(target_shard_id)
                     .map_err(|e| TxStatusError::ChainError(e))?;
 
-                self.network_adapter.do_send(NetworkRequests::TxStatus(
-                    validator,
-                    signer_account_id,
-                    tx_hash,
+                self.network_adapter.do_send(PeerMessageRequest::NetworkRequests(
+                    NetworkRequests::TxStatus(validator, signer_account_id, tx_hash),
                 ));
             }
         }
@@ -1326,7 +1325,7 @@ pub fn start_view_client(
     validator_account_id: Option<AccountId>,
     chain_genesis: ChainGenesis,
     runtime_adapter: Arc<dyn RuntimeAdapter>,
-    network_adapter: Arc<dyn NetworkAdapter>,
+    network_adapter: Arc<dyn PeerManagerAdapter>,
     config: ClientConfig,
     #[cfg(feature = "test_features")] adv: Arc<RwLock<AdversarialControls>>,
 ) -> Addr<ViewClientActor> {

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -29,7 +29,7 @@ use near_client_primitives::types::{
 #[cfg(feature = "test_features")]
 use near_network::types::NetworkAdversarialMessage;
 use near_network::types::{
-    NetworkViewClientMessages, NetworkViewClientResponses, PeerMessageRequest, ReasonForBan,
+    NetworkViewClientMessages, NetworkViewClientResponses, PeerManagerMessageRequest, ReasonForBan,
     StateResponseInfo, StateResponseInfoV1, StateResponseInfoV2,
 };
 use near_network::{NetworkRequests, PeerManagerAdapter};
@@ -346,7 +346,7 @@ impl ViewClientActor {
                         .chain
                         .find_validator_for_forwarding(dst_shard_id)
                         .map_err(|e| TxStatusError::ChainError(e))?;
-                    self.network_adapter.do_send(PeerMessageRequest::NetworkRequests(
+                    self.network_adapter.do_send(PeerManagerMessageRequest::NetworkRequests(
                         NetworkRequests::ReceiptOutComeRequest(validator, receipt_id),
                     ));
                 }
@@ -448,7 +448,7 @@ impl ViewClientActor {
                     .find_validator_for_forwarding(target_shard_id)
                     .map_err(|e| TxStatusError::ChainError(e))?;
 
-                self.network_adapter.do_send(PeerMessageRequest::NetworkRequests(
+                self.network_adapter.do_send(PeerManagerMessageRequest::NetworkRequests(
                     NetworkRequests::TxStatus(validator, signer_account_id, tx_hash),
                 ));
             }

--- a/chain/client/tests/catching_up.rs
+++ b/chain/client/tests/catching_up.rs
@@ -17,7 +17,7 @@ mod tests {
     use near_crypto::{InMemorySigner, KeyType};
     use near_logger_utils::init_integration_logger;
     use near_network::types::{
-        AccountIdOrPeerTrackingShard, AccountOrPeerIdOrHash, PeerMessageRequest,
+        AccountIdOrPeerTrackingShard, AccountOrPeerIdOrHash, PeerManagerMessageRequest,
     };
     use near_network::{NetworkClientMessages, NetworkRequests, NetworkResponses, PeerInfo};
     use near_primitives::hash::hash as hash_func;
@@ -160,200 +160,203 @@ mod tests {
                 vec![true; validators.iter().map(|x| x.len()).sum()],
                 vec![false; validators.iter().map(|x| x.len()).sum()],
                 false,
-                Arc::new(RwLock::new(Box::new(move |_account_id: _, msg: &PeerMessageRequest| {
-                    let msg = msg.as_network_requests_ref();
-                    let account_from = "test3.3".parse().unwrap();
-                    let account_to = "test1.1".parse().unwrap();
-                    let source_shard_id = account_id_to_shard_id(&account_from, 4);
-                    let destination_shard_id = account_id_to_shard_id(&account_to, 4);
+                Arc::new(RwLock::new(Box::new(
+                    move |_account_id: _, msg: &PeerManagerMessageRequest| {
+                        let msg = msg.as_network_requests_ref();
+                        let account_from = "test3.3".parse().unwrap();
+                        let account_to = "test1.1".parse().unwrap();
+                        let source_shard_id = account_id_to_shard_id(&account_from, 4);
+                        let destination_shard_id = account_id_to_shard_id(&account_to, 4);
 
-                    let mut phase = phase.write().unwrap();
-                    let mut seen_heights_with_receipts =
-                        seen_heights_with_receipts.write().unwrap();
-                    let mut seen_hashes_with_state = seen_hashes_with_state.write().unwrap();
-                    match *phase {
-                        ReceiptsSyncPhases::WaitingForFirstBlock => {
-                            if let NetworkRequests::Block { block } = msg {
-                                assert!(block.header().height() <= send);
-                                // This tx is rather fragile, specifically it's important that
-                                //   1. the `from` and `to` account are not in the same shard;
-                                //   2. ideally the producer of the chunk at height 3 for the shard
-                                //      in which `from` resides should not also be a block producer
-                                //      at height 3
-                                //   3. The `from` shard should also not match the block producer
-                                //      for height 1, because such block producer will produce
-                                //      the chunk for height 2 right away, before we manage to send
-                                //      the transaction.
-                                if block.header().height() == send {
+                        let mut phase = phase.write().unwrap();
+                        let mut seen_heights_with_receipts =
+                            seen_heights_with_receipts.write().unwrap();
+                        let mut seen_hashes_with_state = seen_hashes_with_state.write().unwrap();
+                        match *phase {
+                            ReceiptsSyncPhases::WaitingForFirstBlock => {
+                                if let NetworkRequests::Block { block } = msg {
+                                    assert!(block.header().height() <= send);
+                                    // This tx is rather fragile, specifically it's important that
+                                    //   1. the `from` and `to` account are not in the same shard;
+                                    //   2. ideally the producer of the chunk at height 3 for the shard
+                                    //      in which `from` resides should not also be a block producer
+                                    //      at height 3
+                                    //   3. The `from` shard should also not match the block producer
+                                    //      for height 1, because such block producer will produce
+                                    //      the chunk for height 2 right away, before we manage to send
+                                    //      the transaction.
+                                    if block.header().height() == send {
+                                        println!(
+                                            "From shard: {}, to shard: {}",
+                                            source_shard_id, destination_shard_id,
+                                        );
+                                        for i in 0..16 {
+                                            send_tx(
+                                                &connectors1.write().unwrap()[i].0,
+                                                account_from.clone(),
+                                                account_to.clone(),
+                                                111,
+                                                1,
+                                                *block.header().prev_hash(),
+                                            );
+                                        }
+                                        *phase = ReceiptsSyncPhases::WaitingForSecondBlock;
+                                    }
+                                }
+                            }
+                            ReceiptsSyncPhases::WaitingForSecondBlock => {
+                                // This block now contains a chunk with the transaction sent above.
+                                if let NetworkRequests::Block { block } = msg {
+                                    assert!(block.header().height() <= send + 1);
+                                    if block.header().height() == send + 1 {
+                                        *phase = ReceiptsSyncPhases::WaitingForDistantEpoch;
+                                    }
+                                }
+                            }
+                            ReceiptsSyncPhases::WaitingForDistantEpoch => {
+                                // This block now contains a chunk with the transaction sent above.
+                                if let NetworkRequests::Block { block } = msg {
+                                    assert!(block.header().height() >= send + 1);
+                                    assert!(block.header().height() <= wait_till);
+                                    if block.header().height() == wait_till {
+                                        *phase = ReceiptsSyncPhases::VerifyingOutgoingReceipts;
+                                    }
+                                }
+                                if let NetworkRequests::PartialEncodedChunkMessage {
+                                    partial_encoded_chunk,
+                                    ..
+                                } = msg
+                                {
+                                    // The chunk producers in all epochs before `distant` need to be trying to
+                                    //     include the receipt. The `distant` epoch is the first one that
+                                    //     will get the receipt through the state sync.
+                                    let receipts: Vec<Receipt> = partial_encoded_chunk
+                                        .receipts
+                                        .iter()
+                                        .map(|x| x.0.clone())
+                                        .flatten()
+                                        .collect();
+                                    if receipts.len() > 0 {
+                                        assert_eq!(
+                                            partial_encoded_chunk.header.shard_id(),
+                                            source_shard_id
+                                        );
+                                        seen_heights_with_receipts
+                                            .insert(partial_encoded_chunk.header.height_created());
+                                    } else {
+                                        assert_ne!(
+                                            partial_encoded_chunk.header.shard_id(),
+                                            source_shard_id
+                                        );
+                                    }
+                                    // Do not propagate any one parts, this will prevent any chunk from
+                                    //    being included in the block
+                                    return (NetworkResponses::NoResponse.into(), false);
+                                }
+                                if let NetworkRequests::StateRequestHeader {
+                                    shard_id,
+                                    sync_hash,
+                                    target,
+                                } = msg
+                                {
+                                    if sync_hold {
+                                        let srs = StateRequestStruct {
+                                            shard_id: *shard_id,
+                                            sync_hash: *sync_hash,
+                                            part_id: None,
+                                            target: target.clone(),
+                                        };
+                                        if !seen_hashes_with_state
+                                            .contains(&hash_func(&srs.try_to_vec().unwrap()))
+                                        {
+                                            seen_hashes_with_state
+                                                .insert(hash_func(&srs.try_to_vec().unwrap()));
+                                            return (NetworkResponses::NoResponse.into(), false);
+                                        }
+                                    }
+                                }
+                                if let NetworkRequests::StateRequestPart {
+                                    shard_id,
+                                    sync_hash,
+                                    part_id,
+                                    target,
+                                } = msg
+                                {
+                                    if sync_hold {
+                                        let srs = StateRequestStruct {
+                                            shard_id: *shard_id,
+                                            sync_hash: *sync_hash,
+                                            part_id: Some(*part_id),
+                                            target: target.clone(),
+                                        };
+                                        if !seen_hashes_with_state
+                                            .contains(&hash_func(&srs.try_to_vec().unwrap()))
+                                        {
+                                            seen_hashes_with_state
+                                                .insert(hash_func(&srs.try_to_vec().unwrap()));
+                                            return (NetworkResponses::NoResponse.into(), false);
+                                        }
+                                    }
+                                }
+                            }
+                            ReceiptsSyncPhases::VerifyingOutgoingReceipts => {
+                                for height in send + 2..=wait_till {
                                     println!(
-                                        "From shard: {}, to shard: {}",
-                                        source_shard_id, destination_shard_id,
+                                        "checking height {:?} out of {:?}, result = {:?}",
+                                        height,
+                                        wait_till,
+                                        seen_heights_with_receipts.contains(&height)
                                     );
-                                    for i in 0..16 {
-                                        send_tx(
-                                            &connectors1.write().unwrap()[i].0,
-                                            account_from.clone(),
-                                            account_to.clone(),
-                                            111,
-                                            1,
-                                            *block.header().prev_hash(),
-                                        );
-                                    }
-                                    *phase = ReceiptsSyncPhases::WaitingForSecondBlock;
-                                }
-                            }
-                        }
-                        ReceiptsSyncPhases::WaitingForSecondBlock => {
-                            // This block now contains a chunk with the transaction sent above.
-                            if let NetworkRequests::Block { block } = msg {
-                                assert!(block.header().height() <= send + 1);
-                                if block.header().height() == send + 1 {
-                                    *phase = ReceiptsSyncPhases::WaitingForDistantEpoch;
-                                }
-                            }
-                        }
-                        ReceiptsSyncPhases::WaitingForDistantEpoch => {
-                            // This block now contains a chunk with the transaction sent above.
-                            if let NetworkRequests::Block { block } = msg {
-                                assert!(block.header().height() >= send + 1);
-                                assert!(block.header().height() <= wait_till);
-                                if block.header().height() == wait_till {
-                                    *phase = ReceiptsSyncPhases::VerifyingOutgoingReceipts;
-                                }
-                            }
-                            if let NetworkRequests::PartialEncodedChunkMessage {
-                                partial_encoded_chunk,
-                                ..
-                            } = msg
-                            {
-                                // The chunk producers in all epochs before `distant` need to be trying to
-                                //     include the receipt. The `distant` epoch is the first one that
-                                //     will get the receipt through the state sync.
-                                let receipts: Vec<Receipt> = partial_encoded_chunk
-                                    .receipts
-                                    .iter()
-                                    .map(|x| x.0.clone())
-                                    .flatten()
-                                    .collect();
-                                if receipts.len() > 0 {
-                                    assert_eq!(
-                                        partial_encoded_chunk.header.shard_id(),
-                                        source_shard_id
-                                    );
-                                    seen_heights_with_receipts
-                                        .insert(partial_encoded_chunk.header.height_created());
-                                } else {
-                                    assert_ne!(
-                                        partial_encoded_chunk.header.shard_id(),
-                                        source_shard_id
-                                    );
-                                }
-                                // Do not propagate any one parts, this will prevent any chunk from
-                                //    being included in the block
-                                return (NetworkResponses::NoResponse.into(), false);
-                            }
-                            if let NetworkRequests::StateRequestHeader {
-                                shard_id,
-                                sync_hash,
-                                target,
-                            } = msg
-                            {
-                                if sync_hold {
-                                    let srs = StateRequestStruct {
-                                        shard_id: *shard_id,
-                                        sync_hash: *sync_hash,
-                                        part_id: None,
-                                        target: target.clone(),
-                                    };
-                                    if !seen_hashes_with_state
-                                        .contains(&hash_func(&srs.try_to_vec().unwrap()))
-                                    {
-                                        seen_hashes_with_state
-                                            .insert(hash_func(&srs.try_to_vec().unwrap()));
-                                        return (NetworkResponses::NoResponse.into(), false);
+                                    if !sync_hold {
+                                        // If we don't delay the state, all heights should contain the same receipts
+                                        assert!(seen_heights_with_receipts.contains(&height));
                                     }
                                 }
+                                *phase = ReceiptsSyncPhases::WaitingForValidate;
                             }
-                            if let NetworkRequests::StateRequestPart {
-                                shard_id,
-                                sync_hash,
-                                part_id,
-                                target,
-                            } = msg
-                            {
-                                if sync_hold {
-                                    let srs = StateRequestStruct {
-                                        shard_id: *shard_id,
-                                        sync_hash: *sync_hash,
-                                        part_id: Some(*part_id),
-                                        target: target.clone(),
-                                    };
-                                    if !seen_hashes_with_state
-                                        .contains(&hash_func(&srs.try_to_vec().unwrap()))
-                                    {
-                                        seen_hashes_with_state
-                                            .insert(hash_func(&srs.try_to_vec().unwrap()));
-                                        return (NetworkResponses::NoResponse.into(), false);
+                            ReceiptsSyncPhases::WaitingForValidate => {
+                                // This block now contains a chunk with the transaction sent above.
+                                if let NetworkRequests::Block { block } = msg {
+                                    assert!(block.header().height() >= wait_till);
+                                    assert!(block.header().height() <= wait_till + 20);
+                                    if block.header().height() == wait_till + 20 {
+                                        System::current().stop();
                                     }
-                                }
-                            }
-                        }
-                        ReceiptsSyncPhases::VerifyingOutgoingReceipts => {
-                            for height in send + 2..=wait_till {
-                                println!(
-                                    "checking height {:?} out of {:?}, result = {:?}",
-                                    height,
-                                    wait_till,
-                                    seen_heights_with_receipts.contains(&height)
-                                );
-                                if !sync_hold {
-                                    // If we don't delay the state, all heights should contain the same receipts
-                                    assert!(seen_heights_with_receipts.contains(&height));
-                                }
-                            }
-                            *phase = ReceiptsSyncPhases::WaitingForValidate;
-                        }
-                        ReceiptsSyncPhases::WaitingForValidate => {
-                            // This block now contains a chunk with the transaction sent above.
-                            if let NetworkRequests::Block { block } = msg {
-                                assert!(block.header().height() >= wait_till);
-                                assert!(block.header().height() <= wait_till + 20);
-                                if block.header().height() == wait_till + 20 {
-                                    System::current().stop();
-                                }
-                                if block.header().height() == wait_till + 10 {
-                                    for i in 0..16 {
-                                        actix::spawn(
-                                            connectors1.write().unwrap()[i]
-                                                .1
-                                                .send(Query::new(
-                                                    BlockReference::latest(),
-                                                    QueryRequest::ViewAccount {
-                                                        account_id: account_to.clone(),
-                                                    },
-                                                ))
-                                                .then(move |res| {
-                                                    let res_inner = res.unwrap();
-                                                    if let Ok(query_response) = res_inner {
-                                                        if let ViewAccount(view_account_result) =
-                                                            query_response.kind
-                                                        {
-                                                            assert_eq!(
-                                                                view_account_result.amount,
-                                                                1111
-                                                            );
+                                    if block.header().height() == wait_till + 10 {
+                                        for i in 0..16 {
+                                            actix::spawn(
+                                                connectors1.write().unwrap()[i]
+                                                    .1
+                                                    .send(Query::new(
+                                                        BlockReference::latest(),
+                                                        QueryRequest::ViewAccount {
+                                                            account_id: account_to.clone(),
+                                                        },
+                                                    ))
+                                                    .then(move |res| {
+                                                        let res_inner = res.unwrap();
+                                                        if let Ok(query_response) = res_inner {
+                                                            if let ViewAccount(
+                                                                view_account_result,
+                                                            ) = query_response.kind
+                                                            {
+                                                                assert_eq!(
+                                                                    view_account_result.amount,
+                                                                    1111
+                                                                );
+                                                            }
                                                         }
-                                                    }
-                                                    future::ready(())
-                                                }),
-                                        );
+                                                        future::ready(())
+                                                    }),
+                                            );
+                                        }
                                     }
                                 }
                             }
-                        }
-                    };
-                    (NetworkResponses::NoResponse.into(), true)
-                }))),
+                        };
+                        (NetworkResponses::NoResponse.into(), true)
+                    },
+                ))),
             );
             *connectors.write().unwrap() = conn;
             let mut max_wait_ms = 240000;
@@ -455,151 +458,157 @@ mod tests {
                 vec![false; validators.iter().map(|x| x.len()).sum()],
                 vec![true; validators.iter().map(|x| x.len()).sum()],
                 false,
-                Arc::new(RwLock::new(Box::new(move |_account_id: _, msg: &PeerMessageRequest| {
-                    let msg = msg.as_network_requests_ref();
-                    let mut seen_heights_same_block = seen_heights_same_block.write().unwrap();
-                    let mut phase = phase.write().unwrap();
-                    match *phase {
-                        RandomSinglePartPhases::WaitingForFirstBlock => {
-                            if let NetworkRequests::Block { block } = msg {
-                                assert_eq!(block.header().height(), 1);
-                                *phase = RandomSinglePartPhases::WaitingForThirdEpoch;
-                            }
-                        }
-                        RandomSinglePartPhases::WaitingForThirdEpoch => {
-                            if let NetworkRequests::Block { block } = msg {
-                                if block.header().height() == 1 {
-                                    return (NetworkResponses::NoResponse.into(), false);
-                                }
-                                assert!(block.header().height() >= 2);
-                                assert!(block.header().height() <= height);
-                                let mut tx_count = 0;
-                                if block.header().height() == height && block.header().height() >= 2
-                                {
-                                    for (i, validator1) in flat_validators.iter().enumerate() {
-                                        for (j, validator2) in flat_validators.iter().enumerate() {
-                                            let mut amount =
-                                                (((i + j + 17) * 701) % 42 + 1) as u128;
-                                            if non_zero {
-                                                if i > j {
-                                                    amount = 2;
-                                                } else {
-                                                    amount = 1;
-                                                }
-                                            }
-                                            println!(
-                                                "VALUES {:?} {:?} {:?}",
-                                                validator1.to_string(),
-                                                validator2.to_string(),
-                                                amount
-                                            );
-                                            for conn in 0..flat_validators.len() {
-                                                send_tx(
-                                                    &connectors1.write().unwrap()[conn].0,
-                                                    validator1.clone(),
-                                                    validator2.clone(),
-                                                    amount,
-                                                    (12345 + tx_count) as u64,
-                                                    *block.header().prev_hash(),
-                                                );
-                                            }
-                                            tx_count += 1;
-                                        }
-                                    }
-                                    *phase = RandomSinglePartPhases::WaitingForSixEpoch;
-                                    assert_eq!(tx_count, 16 * 16);
+                Arc::new(RwLock::new(Box::new(
+                    move |_account_id: _, msg: &PeerManagerMessageRequest| {
+                        let msg = msg.as_network_requests_ref();
+                        let mut seen_heights_same_block = seen_heights_same_block.write().unwrap();
+                        let mut phase = phase.write().unwrap();
+                        match *phase {
+                            RandomSinglePartPhases::WaitingForFirstBlock => {
+                                if let NetworkRequests::Block { block } = msg {
+                                    assert_eq!(block.header().height(), 1);
+                                    *phase = RandomSinglePartPhases::WaitingForThirdEpoch;
                                 }
                             }
-                        }
-                        RandomSinglePartPhases::WaitingForSixEpoch => {
-                            if let NetworkRequests::Block { block } = msg {
-                                assert!(block.header().height() >= height);
-                                assert!(block.header().height() <= 32);
-                                let check_height = if skip_15 { 28 } else { 26 };
-                                if block.header().height() >= check_height {
-                                    println!("BLOCK HEIGHT {:?}", block.header().height());
-                                    for i in 0..16 {
-                                        for j in 0..16 {
-                                            let amounts1 = amounts.clone();
-                                            let validator = flat_validators[j].clone();
-                                            actix::spawn(
-                                                connectors1.write().unwrap()[i]
-                                                    .1
-                                                    .send(Query::new(
-                                                        BlockReference::latest(),
-                                                        QueryRequest::ViewAccount {
-                                                            account_id: flat_validators[j].clone(),
-                                                        },
-                                                    ))
-                                                    .then(move |res| {
-                                                        let res_inner = res.unwrap();
-                                                        if let Ok(query_response) = res_inner {
-                                                            if let ViewAccount(
-                                                                view_account_result,
-                                                            ) = query_response.kind
-                                                            {
-                                                                check_amount(
-                                                                    amounts1,
-                                                                    validator,
-                                                                    view_account_result.amount,
-                                                                );
-                                                            }
-                                                        }
-                                                        future::ready(())
-                                                    }),
-                                            );
-                                        }
-                                    }
-                                }
-                                if block.header().height() == 32 {
-                                    println!(
-                                        "SEEN HEIGHTS SAME BLOCK {:?}",
-                                        seen_heights_same_block.len()
-                                    );
-                                    assert_eq!(seen_heights_same_block.len(), 1);
-                                    let amounts1 = amounts.clone();
-                                    for flat_validator in &flat_validators {
-                                        match amounts1
-                                            .write()
-                                            .unwrap()
-                                            .entry(flat_validator.clone())
-                                        {
-                                            Entry::Occupied(_) => {
-                                                continue;
-                                            }
-                                            Entry::Vacant(entry) => {
-                                                println!(
-                                                    "VALIDATOR = {:?}, ENTRY = {:?}",
-                                                    flat_validator, entry
-                                                );
-                                                assert!(false);
-                                            }
-                                        };
-                                    }
-                                    System::current().stop();
-                                }
-                            }
-                            if let NetworkRequests::PartialEncodedChunkMessage {
-                                partial_encoded_chunk,
-                                ..
-                            } = msg
-                            {
-                                if partial_encoded_chunk.header.height_created() == 22 {
-                                    seen_heights_same_block
-                                        .insert(partial_encoded_chunk.header.prev_block_hash());
-                                }
-                                if skip_15 {
-                                    if partial_encoded_chunk.header.height_created() == 14
-                                        || partial_encoded_chunk.header.height_created() == 15
-                                    {
+                            RandomSinglePartPhases::WaitingForThirdEpoch => {
+                                if let NetworkRequests::Block { block } = msg {
+                                    if block.header().height() == 1 {
                                         return (NetworkResponses::NoResponse.into(), false);
                                     }
+                                    assert!(block.header().height() >= 2);
+                                    assert!(block.header().height() <= height);
+                                    let mut tx_count = 0;
+                                    if block.header().height() == height
+                                        && block.header().height() >= 2
+                                    {
+                                        for (i, validator1) in flat_validators.iter().enumerate() {
+                                            for (j, validator2) in
+                                                flat_validators.iter().enumerate()
+                                            {
+                                                let mut amount =
+                                                    (((i + j + 17) * 701) % 42 + 1) as u128;
+                                                if non_zero {
+                                                    if i > j {
+                                                        amount = 2;
+                                                    } else {
+                                                        amount = 1;
+                                                    }
+                                                }
+                                                println!(
+                                                    "VALUES {:?} {:?} {:?}",
+                                                    validator1.to_string(),
+                                                    validator2.to_string(),
+                                                    amount
+                                                );
+                                                for conn in 0..flat_validators.len() {
+                                                    send_tx(
+                                                        &connectors1.write().unwrap()[conn].0,
+                                                        validator1.clone(),
+                                                        validator2.clone(),
+                                                        amount,
+                                                        (12345 + tx_count) as u64,
+                                                        *block.header().prev_hash(),
+                                                    );
+                                                }
+                                                tx_count += 1;
+                                            }
+                                        }
+                                        *phase = RandomSinglePartPhases::WaitingForSixEpoch;
+                                        assert_eq!(tx_count, 16 * 16);
+                                    }
                                 }
                             }
-                        }
-                    };
-                    (NetworkResponses::NoResponse.into(), true)
-                }))),
+                            RandomSinglePartPhases::WaitingForSixEpoch => {
+                                if let NetworkRequests::Block { block } = msg {
+                                    assert!(block.header().height() >= height);
+                                    assert!(block.header().height() <= 32);
+                                    let check_height = if skip_15 { 28 } else { 26 };
+                                    if block.header().height() >= check_height {
+                                        println!("BLOCK HEIGHT {:?}", block.header().height());
+                                        for i in 0..16 {
+                                            for j in 0..16 {
+                                                let amounts1 = amounts.clone();
+                                                let validator = flat_validators[j].clone();
+                                                actix::spawn(
+                                                    connectors1.write().unwrap()[i]
+                                                        .1
+                                                        .send(Query::new(
+                                                            BlockReference::latest(),
+                                                            QueryRequest::ViewAccount {
+                                                                account_id: flat_validators[j]
+                                                                    .clone(),
+                                                            },
+                                                        ))
+                                                        .then(move |res| {
+                                                            let res_inner = res.unwrap();
+                                                            if let Ok(query_response) = res_inner {
+                                                                if let ViewAccount(
+                                                                    view_account_result,
+                                                                ) = query_response.kind
+                                                                {
+                                                                    check_amount(
+                                                                        amounts1,
+                                                                        validator,
+                                                                        view_account_result.amount,
+                                                                    );
+                                                                }
+                                                            }
+                                                            future::ready(())
+                                                        }),
+                                                );
+                                            }
+                                        }
+                                    }
+                                    if block.header().height() == 32 {
+                                        println!(
+                                            "SEEN HEIGHTS SAME BLOCK {:?}",
+                                            seen_heights_same_block.len()
+                                        );
+                                        assert_eq!(seen_heights_same_block.len(), 1);
+                                        let amounts1 = amounts.clone();
+                                        for flat_validator in &flat_validators {
+                                            match amounts1
+                                                .write()
+                                                .unwrap()
+                                                .entry(flat_validator.clone())
+                                            {
+                                                Entry::Occupied(_) => {
+                                                    continue;
+                                                }
+                                                Entry::Vacant(entry) => {
+                                                    println!(
+                                                        "VALIDATOR = {:?}, ENTRY = {:?}",
+                                                        flat_validator, entry
+                                                    );
+                                                    assert!(false);
+                                                }
+                                            };
+                                        }
+                                        System::current().stop();
+                                    }
+                                }
+                                if let NetworkRequests::PartialEncodedChunkMessage {
+                                    partial_encoded_chunk,
+                                    ..
+                                } = msg
+                                {
+                                    if partial_encoded_chunk.header.height_created() == 22 {
+                                        seen_heights_same_block
+                                            .insert(partial_encoded_chunk.header.prev_block_hash());
+                                    }
+                                    if skip_15 {
+                                        if partial_encoded_chunk.header.height_created() == 14
+                                            || partial_encoded_chunk.header.height_created() == 15
+                                        {
+                                            return (NetworkResponses::NoResponse.into(), false);
+                                        }
+                                    }
+                                }
+                            }
+                        };
+                        (NetworkResponses::NoResponse.into(), true)
+                    },
+                ))),
             );
             *connectors.write().unwrap() = conn;
 
@@ -649,29 +658,37 @@ mod tests {
                 vec![false; validators.iter().map(|x| x.len()).sum()],
                 vec![true; validators.iter().map(|x| x.len()).sum()],
                 false,
-                Arc::new(RwLock::new(Box::new(move |_account_id: _, msg: &PeerMessageRequest| {
-                    let msg = msg.as_network_requests_ref();
-                    let propagate = if let NetworkRequests::Block { block } = msg {
-                        check_height(*block.hash(), block.header().height());
+                Arc::new(RwLock::new(Box::new(
+                    move |_account_id: _, msg: &PeerManagerMessageRequest| {
+                        let msg = msg.as_network_requests_ref();
+                        let propagate = if let NetworkRequests::Block { block } = msg {
+                            check_height(*block.hash(), block.header().height());
 
-                        if block.header().height() % 10 == 5 {
-                            check_height(*block.header().prev_hash(), block.header().height() - 2);
+                            if block.header().height() % 10 == 5 {
+                                check_height(
+                                    *block.header().prev_hash(),
+                                    block.header().height() - 2,
+                                );
+                            } else {
+                                check_height(
+                                    *block.header().prev_hash(),
+                                    block.header().height() - 1,
+                                );
+                            }
+
+                            if block.header().height() >= 25 {
+                                System::current().stop();
+                            }
+
+                            // Do not propagate blocks at heights %10=4
+                            block.header().height() % 10 != 4
                         } else {
-                            check_height(*block.header().prev_hash(), block.header().height() - 1);
-                        }
+                            true
+                        };
 
-                        if block.header().height() >= 25 {
-                            System::current().stop();
-                        }
-
-                        // Do not propagate blocks at heights %10=4
-                        block.header().height() % 10 != 4
-                    } else {
-                        true
-                    };
-
-                    (NetworkResponses::NoResponse.into(), propagate)
-                }))),
+                        (NetworkResponses::NoResponse.into(), propagate)
+                    },
+                ))),
             );
             *connectors.write().unwrap() = conn;
 
@@ -719,7 +736,7 @@ mod tests {
                 vec![true; validators.iter().map(|x| x.len()).sum()],
                 false,
                 Arc::new(RwLock::new(Box::new(
-                    move |sender_account_id: AccountId, msg: &PeerMessageRequest| {
+                    move |sender_account_id: AccountId, msg: &PeerManagerMessageRequest| {
                         let msg = msg.as_network_requests_ref();
                         let mut grieving_chunk_hash = grieving_chunk_hash.write().unwrap();
                         let mut unaccepted_block_hash = unaccepted_block_hash.write().unwrap();
@@ -890,7 +907,7 @@ mod tests {
                 vec![true; validators.iter().map(|x| x.len()).sum()],
                 false,
                 Arc::new(RwLock::new(Box::new(
-                    move |sender_account_id: AccountId, msg: &PeerMessageRequest| {
+                    move |sender_account_id: AccountId, msg: &PeerManagerMessageRequest| {
                         let msg = msg.as_network_requests_ref();
                         let mut seen_chunk_same_sender = seen_chunk_same_sender.write().unwrap();
                         let mut requested = requested.write().unwrap();

--- a/chain/client/tests/chunks_management.rs
+++ b/chain/client/tests/chunks_management.rs
@@ -4,7 +4,7 @@ use near_chain::ChainGenesis;
 use near_client::test_utils::TestEnv;
 use near_crypto::KeyType;
 use near_logger_utils::{init_integration_logger, init_test_logger};
-use near_network::types::PartialEncodedChunkRequestMsg;
+use near_network::types::{PartialEncodedChunkRequestMsg, PeerMessageRequest};
 use near_network::NetworkRequests;
 use near_primitives::hash::{hash, CryptoHash};
 #[cfg(feature = "protocol_feature_block_header_v3")]
@@ -45,6 +45,12 @@ fn test_request_chunk_restart() {
         client.chain.mut_store(),
     );
     let response = env.network_adapters[0].pop().unwrap();
+
+    let response = match response {
+        PeerMessageRequest::NetworkRequests(result) => result,
+        _ => panic!("expected PeerMessageRequest::NetworkRequests"),
+    };
+
     if let NetworkRequests::PartialEncodedChunkResponse { response: response_body, .. } = response {
         assert_eq!(response_body.chunk_hash, block1.chunks()[0].chunk_hash());
     } else {

--- a/chain/client/tests/chunks_management.rs
+++ b/chain/client/tests/chunks_management.rs
@@ -44,12 +44,7 @@ fn test_request_chunk_restart() {
         CryptoHash::default(),
         client.chain.mut_store(),
     );
-    let response = env.network_adapters[0].pop().unwrap();
-
-    let response = match response {
-        PeerMessageRequest::NetworkRequests(result) => result,
-        _ => panic!("expected PeerMessageRequest::NetworkRequests"),
-    };
+    let response = env.network_adapters[0].pop().unwrap().as_network_requests();
 
     if let NetworkRequests::PartialEncodedChunkResponse { response: response_body, .. } = response {
         assert_eq!(response_body.chunk_hash, block1.chunks()[0].chunk_hash());

--- a/chain/client/tests/chunks_management.rs
+++ b/chain/client/tests/chunks_management.rs
@@ -4,7 +4,7 @@ use near_chain::ChainGenesis;
 use near_client::test_utils::TestEnv;
 use near_crypto::KeyType;
 use near_logger_utils::{init_integration_logger, init_test_logger};
-use near_network::types::{PartialEncodedChunkRequestMsg, PeerMessageRequest};
+use near_network::types::PartialEncodedChunkRequestMsg;
 use near_network::NetworkRequests;
 use near_primitives::hash::{hash, CryptoHash};
 #[cfg(feature = "protocol_feature_block_header_v3")]

--- a/chain/client/tests/consensus.rs
+++ b/chain/client/tests/consensus.rs
@@ -12,6 +12,7 @@ mod tests {
     use near_client::test_utils::setup_mock_all_validators;
     use near_client::{ClientActor, ViewClientActor};
     use near_logger_utils::init_integration_logger;
+    use near_network::types::PeerMessageRequest;
     use near_network::{NetworkClientMessages, NetworkRequests, NetworkResponses, PeerInfo};
     use near_primitives::block::{Approval, ApprovalInner};
     use near_primitives::types::{AccountId, BlockHeight};
@@ -77,7 +78,7 @@ mod tests {
                 vec![false; validators.iter().map(|x| x.len()).sum()],
                 false,
                 Arc::new(RwLock::new(Box::new(
-                    move |from_whom: AccountId, msg: &NetworkRequests| {
+                    move |from_whom: AccountId, msg: &PeerMessageRequest| {
                         let mut all_blocks: RwLockWriteGuard<BTreeMap<BlockHeight, Block>> =
                             all_blocks.write().unwrap();
                         let mut final_block_heights = final_block_heights.write().unwrap();
@@ -89,7 +90,7 @@ mod tests {
 
                         let mut delayed_blocks = delayed_blocks.write().unwrap();
 
-                        match msg {
+                        match msg.as_network_requests_ref() {
                             NetworkRequests::Block { block } => {
                                 if !all_blocks.contains_key(&block.header().height()) {
                                     println!(
@@ -142,7 +143,7 @@ mod tests {
                                     *largest_block_height = block.header().height();
                                     if delayed_blocks.len() < 2 {
                                         delayed_blocks.push(block.clone());
-                                        return (NetworkResponses::NoResponse, false);
+                                        return (NetworkResponses::NoResponse.into(), false);
                                     }
                                 }
                                 *largest_block_height =
@@ -151,7 +152,7 @@ mod tests {
                                 let mut new_delayed_blocks = vec![];
                                 for delayed_block in delayed_blocks.iter() {
                                     if delayed_block.hash() == block.hash() {
-                                        return (NetworkResponses::NoResponse, false);
+                                        return (NetworkResponses::NoResponse.into(), false);
                                     }
                                     if delayed_block.header().height()
                                         <= block.header().height() + 2
@@ -229,7 +230,7 @@ mod tests {
                                             // We already manually sent a skip conflicting with this endorsement
                                             // my_ord % 8 < 2 are two malicious actors in every epoch and they
                                             // continue sending endorsements
-                                            return (NetworkResponses::NoResponse, false);
+                                            return (NetworkResponses::NoResponse.into(), false);
                                         }
 
                                         approval_message.approval.target_height - 1
@@ -275,13 +276,13 @@ mod tests {
                                     // the paritcipants who haven't sent their endorsements to be converted
                                     // to skips change their head.
                                     if my_ord % 8 < 2 {
-                                        return (NetworkResponses::NoResponse, false);
+                                        return (NetworkResponses::NoResponse.into(), false);
                                     }
                                 }
                             }
                             _ => {}
                         };
-                        (NetworkResponses::NoResponse, true)
+                        (NetworkResponses::NoResponse.into(), true)
                     },
                 ))),
             );

--- a/chain/client/tests/consensus.rs
+++ b/chain/client/tests/consensus.rs
@@ -12,7 +12,7 @@ mod tests {
     use near_client::test_utils::setup_mock_all_validators;
     use near_client::{ClientActor, ViewClientActor};
     use near_logger_utils::init_integration_logger;
-    use near_network::types::PeerMessageRequest;
+    use near_network::types::PeerManagerMessageRequest;
     use near_network::{NetworkClientMessages, NetworkRequests, NetworkResponses, PeerInfo};
     use near_primitives::block::{Approval, ApprovalInner};
     use near_primitives::types::{AccountId, BlockHeight};
@@ -78,7 +78,7 @@ mod tests {
                 vec![false; validators.iter().map(|x| x.len()).sum()],
                 false,
                 Arc::new(RwLock::new(Box::new(
-                    move |from_whom: AccountId, msg: &PeerMessageRequest| {
+                    move |from_whom: AccountId, msg: &PeerManagerMessageRequest| {
                         let mut all_blocks: RwLockWriteGuard<BTreeMap<BlockHeight, Block>> =
                             all_blocks.write().unwrap();
                         let mut final_block_heights = final_block_heights.write().unwrap();

--- a/chain/client/tests/cross_shard_tx.rs
+++ b/chain/client/tests/cross_shard_tx.rs
@@ -8,7 +8,8 @@ use near_actix_test_utils::run_actix;
 use near_client::test_utils::setup_mock_all_validators;
 use near_client::{ClientActor, Query, ViewClientActor};
 use near_logger_utils::init_integration_logger;
-use near_network::{NetworkRequests, NetworkResponses, PeerInfo};
+use near_network::types::PeerMessageRequest;
+use near_network::{NetworkResponses, PeerInfo};
 use near_primitives::types::BlockReference;
 use near_primitives::views::{QueryRequest, QueryResponseKind::ViewAccount};
 
@@ -44,8 +45,8 @@ fn test_keyvalue_runtime_balances() {
             vec![false; validators.iter().map(|x| x.len()).sum()],
             vec![true; validators.iter().map(|x| x.len()).sum()],
             false,
-            Arc::new(RwLock::new(Box::new(move |_account_id: _, _msg: &NetworkRequests| {
-                (NetworkResponses::NoResponse, true)
+            Arc::new(RwLock::new(Box::new(move |_account_id: _, _msg: &PeerMessageRequest| {
+                (NetworkResponses::NoResponse.into(), true)
             }))),
         );
         *connectors.write().unwrap() = conn;
@@ -97,9 +98,8 @@ mod tests {
     use near_client::{ClientActor, Query, ViewClientActor};
     use near_crypto::{InMemorySigner, KeyType};
     use near_logger_utils::init_integration_logger;
-    use near_network::{
-        NetworkClientMessages, NetworkClientResponses, NetworkRequests, NetworkResponses, PeerInfo,
-    };
+    use near_network::types::{PeerMessageRequest, PeerMessageResponse};
+    use near_network::{NetworkClientMessages, NetworkClientResponses, NetworkResponses, PeerInfo};
     use near_primitives::hash::CryptoHash;
     use near_primitives::transaction::SignedTransaction;
     use near_primitives::types::{AccountId, BlockReference};
@@ -450,9 +450,11 @@ mod tests {
                 vec![true; validators.iter().map(|x| x.len()).sum()],
                 vec![false; validators.iter().map(|x| x.len()).sum()],
                 true,
-                Arc::new(RwLock::new(Box::new(move |_account_id: _, _msg: &NetworkRequests| {
-                    (NetworkResponses::NoResponse, true)
-                }))),
+                Arc::new(RwLock::new(Box::new(
+                    move |_account_id: _, _msg: &PeerMessageRequest| {
+                        (PeerMessageResponse::NetworkResponses(NetworkResponses::NoResponse), true)
+                    },
+                ))),
             );
             *connectors.write().unwrap() = conn;
             let block_hash = *genesis_block.hash();

--- a/chain/client/tests/cross_shard_tx.rs
+++ b/chain/client/tests/cross_shard_tx.rs
@@ -8,7 +8,7 @@ use near_actix_test_utils::run_actix;
 use near_client::test_utils::setup_mock_all_validators;
 use near_client::{ClientActor, Query, ViewClientActor};
 use near_logger_utils::init_integration_logger;
-use near_network::types::PeerMessageRequest;
+use near_network::types::PeerManagerMessageRequest;
 use near_network::{NetworkResponses, PeerInfo};
 use near_primitives::types::BlockReference;
 use near_primitives::views::{QueryRequest, QueryResponseKind::ViewAccount};
@@ -45,9 +45,11 @@ fn test_keyvalue_runtime_balances() {
             vec![false; validators.iter().map(|x| x.len()).sum()],
             vec![true; validators.iter().map(|x| x.len()).sum()],
             false,
-            Arc::new(RwLock::new(Box::new(move |_account_id: _, _msg: &PeerMessageRequest| {
-                (NetworkResponses::NoResponse.into(), true)
-            }))),
+            Arc::new(RwLock::new(Box::new(
+                move |_account_id: _, _msg: &PeerManagerMessageRequest| {
+                    (NetworkResponses::NoResponse.into(), true)
+                },
+            ))),
         );
         *connectors.write().unwrap() = conn;
 
@@ -98,7 +100,7 @@ mod tests {
     use near_client::{ClientActor, Query, ViewClientActor};
     use near_crypto::{InMemorySigner, KeyType};
     use near_logger_utils::init_integration_logger;
-    use near_network::types::{PeerMessageRequest, PeerMessageResponse};
+    use near_network::types::{PeerManagerMessageRequest, PeerManagerMessageResponse};
     use near_network::{NetworkClientMessages, NetworkClientResponses, NetworkResponses, PeerInfo};
     use near_primitives::hash::CryptoHash;
     use near_primitives::transaction::SignedTransaction;
@@ -451,8 +453,13 @@ mod tests {
                 vec![false; validators.iter().map(|x| x.len()).sum()],
                 true,
                 Arc::new(RwLock::new(Box::new(
-                    move |_account_id: _, _msg: &PeerMessageRequest| {
-                        (PeerMessageResponse::NetworkResponses(NetworkResponses::NoResponse), true)
+                    move |_account_id: _, _msg: &PeerManagerMessageRequest| {
+                        (
+                            PeerManagerMessageResponse::NetworkResponses(
+                                NetworkResponses::NoResponse,
+                            ),
+                            true,
+                        )
                     },
                 ))),
             );

--- a/chain/client/tests/query_client.rs
+++ b/chain/client/tests/query_client.rs
@@ -9,7 +9,7 @@ use near_client::{
 };
 use near_crypto::{InMemorySigner, KeyType};
 use near_logger_utils::init_test_logger;
-use near_network::test_utils::MockNetworkAdapter;
+use near_network::test_utils::MockPeerManagerAdapter;
 use near_network::types::{NetworkViewClientMessages, NetworkViewClientResponses};
 use near_network::{NetworkClientMessages, NetworkClientResponses, PeerInfo};
 use near_primitives::block::{Block, BlockHeader};
@@ -188,7 +188,7 @@ fn test_state_request() {
             false,
             true,
             false,
-            Arc::new(MockNetworkAdapter::default()),
+            Arc::new(MockPeerManagerAdapter::default()),
             100,
             Utc::now(),
         );

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -39,6 +39,7 @@ use near_jsonrpc_primitives::types::config::RpcProtocolConfigResponse;
 use near_metrics::{Encoder, TextEncoder};
 #[cfg(feature = "test_features")]
 use near_network::routing::GetRoutingTableResult;
+use near_network::types::PeerMessageRequest;
 #[cfg(feature = "test_features")]
 use near_network::types::{
     GetPeerId, GetRoutingTable, NetworkAdversarialMessage, NetworkViewClientMessages, SetAdvOptions,
@@ -314,9 +315,12 @@ impl JsonRpcHandler {
                     )
                 }
                 "adv_get_peer_id" => {
-                    let response = self.peer_manager_addr.send(GetPeerId {}).await?;
+                    let response = self
+                        .peer_manager_addr
+                        .send(PeerMessageRequest::GetPeerId(GetPeerId {}))
+                        .await?;
                     Some(
-                        serde_json::to_value(response)
+                        serde_json::to_value(response.as_peer_id_result())
                             .map_err(|err| RpcError::serialization_error(err.to_string())),
                     )
                 }

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -39,10 +39,10 @@ use near_jsonrpc_primitives::types::config::RpcProtocolConfigResponse;
 use near_metrics::{Encoder, TextEncoder};
 #[cfg(feature = "test_features")]
 use near_network::routing::GetRoutingTableResult;
-use near_network::types::PeerMessageRequest;
 #[cfg(feature = "test_features")]
 use near_network::types::{
-    GetPeerId, GetRoutingTable, NetworkAdversarialMessage, NetworkViewClientMessages, SetAdvOptions,
+    GetPeerId, GetRoutingTable, NetworkAdversarialMessage, NetworkViewClientMessages,
+    PeerMessageRequest, SetAdvOptions,
 };
 #[cfg(feature = "sandbox")]
 use near_network::types::{NetworkSandboxMessage, SandboxResponse};

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -42,7 +42,7 @@ use near_network::routing::GetRoutingTableResult;
 #[cfg(feature = "test_features")]
 use near_network::types::{
     GetPeerId, GetRoutingTable, NetworkAdversarialMessage, NetworkViewClientMessages,
-    PeerMessageRequest, SetAdvOptions,
+    PeerManagerMessageRequest, SetAdvOptions,
 };
 #[cfg(feature = "sandbox")]
 use near_network::types::{NetworkSandboxMessage, SandboxResponse};
@@ -271,7 +271,7 @@ impl JsonRpcHandler {
                 "adv_set_options" => {
                     let params = parse_params::<SetAdvOptionsRequest>(params)?;
                     self.peer_manager_addr
-                        .send(PeerMessageRequest::SetAdvOptions(SetAdvOptions {
+                        .send(PeerManagerMessageRequest::SetAdvOptions(SetAdvOptions {
                             disable_edge_signature_verification: params
                                 .disable_edge_signature_verification,
                             disable_edge_propagation: params.disable_edge_propagation,
@@ -288,7 +288,7 @@ impl JsonRpcHandler {
                 "adv_set_routing_table" => {
                     let request = SetRoutingTableRequest::parse(params)?;
                     self.peer_manager_addr
-                        .send(PeerMessageRequest::SetRoutingTable(SetRoutingTable {
+                        .send(PeerManagerMessageRequest::SetRoutingTable(SetRoutingTable {
                             add_edges: request.add_edges,
                             remove_edges: request.remove_edges,
                             prune_edges: request.prune_edges,
@@ -304,9 +304,9 @@ impl JsonRpcHandler {
                     let params = parse_params::<StartRoutingTableSyncRequest>(params)?;
 
                     self.peer_manager_addr
-                        .send(PeerMessageRequest::StartRoutingTableSync(StartRoutingTableSync {
-                            peer_id: params.peer_id,
-                        }))
+                        .send(PeerManagerMessageRequest::StartRoutingTableSync(
+                            StartRoutingTableSync { peer_id: params.peer_id },
+                        ))
                         .await?;
                     Some(
                         serde_json::to_value(())
@@ -316,7 +316,7 @@ impl JsonRpcHandler {
                 "adv_get_peer_id" => {
                     let response = self
                         .peer_manager_addr
-                        .send(PeerMessageRequest::GetPeerId(GetPeerId {}))
+                        .send(PeerManagerMessageRequest::GetPeerId(GetPeerId {}))
                         .await?;
                     Some(
                         serde_json::to_value(response.as_peer_id_result())
@@ -326,7 +326,7 @@ impl JsonRpcHandler {
                 "adv_get_routing_table" => {
                     let result = self
                         .peer_manager_addr
-                        .send(PeerMessageRequest::GetRoutingTable(GetRoutingTable {}))
+                        .send(PeerManagerMessageRequest::GetRoutingTable(GetRoutingTable {}))
                         .await?;
                     Some(
                         serde_json::to_value(result.as_get_routing_table_result())

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -270,34 +270,32 @@ impl JsonRpcHandler {
                 "adv_check_store" => Some(self.adv_check_store(params).await),
                 "adv_set_options" => {
                     let params = parse_params::<SetAdvOptionsRequest>(params)?;
-                    let result = self
-                        .peer_manager_addr
-                        .send(SetAdvOptions {
+                    self.peer_manager_addr
+                        .send(PeerMessageRequest::SetAdvOptions(SetAdvOptions {
                             disable_edge_signature_verification: params
                                 .disable_edge_signature_verification,
                             disable_edge_propagation: params.disable_edge_propagation,
                             disable_edge_pruning: params.disable_edge_pruning,
                             set_max_peers: None,
-                        })
+                        }))
                         .await?;
                     Some(
-                        serde_json::to_value(result)
+                        serde_json::to_value(())
                             .map_err(|err| RpcError::serialization_error(err.to_string())),
                     )
                 }
                 #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
                 "adv_set_routing_table" => {
                     let request = SetRoutingTableRequest::parse(params)?;
-                    let result = self
-                        .peer_manager_addr
-                        .send(SetRoutingTable {
+                    self.peer_manager_addr
+                        .send(PeerMessageRequest::SetRoutingTable(SetRoutingTable {
                             add_edges: request.add_edges,
                             remove_edges: request.remove_edges,
                             prune_edges: request.prune_edges,
-                        })
+                        }))
                         .await?;
                     Some(
-                        serde_json::to_value(result)
+                        serde_json::to_value(())
                             .map_err(|err| RpcError::serialization_error(err.to_string())),
                     )
                 }
@@ -305,12 +303,13 @@ impl JsonRpcHandler {
                 "adv_start_routing_table_syncv2" => {
                     let params = parse_params::<StartRoutingTableSyncRequest>(params)?;
 
-                    let result = self
-                        .peer_manager_addr
-                        .send(StartRoutingTableSync { peer_id: params.peer_id })
+                    self.peer_manager_addr
+                        .send(PeerMessageRequest::StartRoutingTableSync(StartRoutingTableSync {
+                            peer_id: params.peer_id,
+                        }))
                         .await?;
                     Some(
-                        serde_json::to_value(result)
+                        serde_json::to_value(())
                             .map_err(|err| RpcError::serialization_error(err.to_string())),
                     )
                 }
@@ -325,9 +324,12 @@ impl JsonRpcHandler {
                     )
                 }
                 "adv_get_routing_table" => {
-                    let result = self.peer_manager_addr.send(GetRoutingTable {}).await?;
+                    let result = self
+                        .peer_manager_addr
+                        .send(PeerMessageRequest::GetRoutingTable(GetRoutingTable {}))
+                        .await?;
                     Some(
-                        serde_json::to_value(result)
+                        serde_json::to_value(result.as_get_routing_table_result())
                             .map_err(|err| RpcError::serialization_error(err.to_string())),
                     )
                 }

--- a/chain/network-primitives/src/types.rs
+++ b/chain/network-primitives/src/types.rs
@@ -769,7 +769,7 @@ pub enum ReasonForBan {
 
 /// Banning signal sent from Peer instance to PeerManager
 /// just before Peer instance is stopped.
-#[derive(Message)]
+#[derive(Message, Debug)]
 #[rtype(result = "()")]
 pub struct Ban {
     pub peer_id: PeerId,

--- a/chain/network-primitives/src/types.rs
+++ b/chain/network-primitives/src/types.rs
@@ -453,6 +453,7 @@ impl RoutedMessage {
 }
 
 /// Routed Message wrapped with previous sender of the message.
+#[derive(Clone, Debug)]
 pub struct RoutedMessageFrom {
     /// Routed messages.
     pub msg: RoutedMessage,
@@ -782,6 +783,11 @@ pub enum PeerManagerRequest {
     BanPeer(ReasonForBan),
     UnregisterPeer,
 }
+
+/// Messages from Peer to PeerManager
+#[derive(Message, Debug)]
+#[rtype(result = "()")]
+pub enum PeerRequest {}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct KnownProducer {

--- a/chain/network-primitives/src/types.rs
+++ b/chain/network-primitives/src/types.rs
@@ -687,7 +687,7 @@ impl TryFrom<Vec<u8>> for KnownPeerState {
 }
 
 /// Actor message that holds the TCP stream from an inbound TCP connection
-#[derive(Message)]
+#[derive(Message, Debug)]
 #[rtype(result = "()")]
 pub struct InboundTcpConnect {
     /// Tcp stream of the inbound connections
@@ -702,7 +702,7 @@ impl InboundTcpConnect {
 }
 
 /// Actor message to request the creation of an outbound TCP connection to a peer.
-#[derive(Message)]
+#[derive(Message, Clone, Debug)]
 #[rtype(result = "()")]
 pub struct OutboundTcpConnect {
     /// Peer information of the outbound connection

--- a/chain/network-primitives/src/types.rs
+++ b/chain/network-primitives/src/types.rs
@@ -357,7 +357,7 @@ impl AccountOrPeerIdOrHash {
     }
 }
 
-#[derive(Message)]
+#[derive(Message, Clone, Debug)]
 #[rtype(result = "()")]
 pub struct RawRoutedMessage {
     pub target: AccountOrPeerIdOrHash,

--- a/chain/network/src/lib.rs
+++ b/chain/network/src/lib.rs
@@ -4,8 +4,8 @@ pub use routing_table_actor::{
     RoutingTableActor, RoutingTableMessages, RoutingTableMessagesResponse,
 };
 pub use types::{
-    FullPeerInfo, NetworkAdapter, NetworkClientMessages, NetworkClientResponses, NetworkConfig,
-    NetworkRecipient, NetworkRequests, NetworkResponses, PeerInfo,
+    FullPeerInfo, NetworkClientMessages, NetworkClientResponses, NetworkConfig, NetworkRecipient,
+    NetworkRequests, NetworkResponses, PeerInfo, PeerManagerAdapter,
 };
 
 mod cache;

--- a/chain/network/src/peer.rs
+++ b/chain/network/src/peer.rs
@@ -971,7 +971,8 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for Peer {
             }
             (_, PeerStatus::Ready, PeerMessage::PeersResponse(peers)) => {
                 debug!(target: "network", "Received peers from {}: {} peers.", self.peer_info, peers.len());
-                self.peer_manager_addr.do_send(PeersResponse { peers });
+                self.peer_manager_addr
+                    .do_send(PeerMessageRequest::PeersResponse(PeersResponse { peers }));
             }
             (_, PeerStatus::Ready, PeerMessage::RequestUpdateNonce(edge_info)) => self
                 .peer_manager_addr

--- a/chain/network/src/peer.rs
+++ b/chain/network/src/peer.rs
@@ -668,9 +668,12 @@ impl Actor for Peer {
         debug!(target: "network", "{:?}: Peer {} disconnected. {:?}", self.node_info.id, self.peer_info, self.peer_status);
         if let Some(peer_info) = self.peer_info.as_ref() {
             if let PeerStatus::Banned(ban_reason) = self.peer_status {
-                self.peer_manager_addr.do_send(Ban { peer_id: peer_info.id.clone(), ban_reason });
+                self.peer_manager_addr.do_send(PeerMessageRequest::Ban(Ban {
+                    peer_id: peer_info.id.clone(),
+                    ban_reason,
+                }));
             } else {
-                self.peer_manager_addr.do_send(Unregister {
+                self.peer_manager_addr.do_send(PeerMessageRequest::Unregister(Unregister {
                     peer_id: peer_info.id.clone(),
                     peer_type: self.peer_type,
                     // If the PeerActor is no longer in the Connecting state this means
@@ -680,7 +683,7 @@ impl Actor for Peer {
                     // each other, and after resolving the tie, a peer tries to remove the other
                     // peer from the active connection if it was added in the parallel connection.
                     remove_from_peer_store: self.peer_status != PeerStatus::Connecting,
-                })
+                }))
             }
         }
         Running::Stop

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -1919,7 +1919,7 @@ impl PeerManagerActor {
     #[perf]
     fn handle_msg_get_peer_id(
         &mut self,
-        _msg: GetPeerId,
+        msg: GetPeerId,
         _ctx: &mut Context<Self>,
     ) -> GetPeerIdResult {
         GetPeerIdResult { peer_id: self.peer_id.clone() }

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -54,7 +54,8 @@ use crate::types::{
     PeerIdOrHash, PeerInfo, PeerManagerRequest, PeerMessage, PeerMessageRequest,
     PeerMessageResponse, PeerRequest, PeerResponse, PeerType, PeersRequest, PeersResponse, Ping,
     Pong, QueryPeerStats, RawRoutedMessage, ReasonForBan, RoutedMessage, RoutedMessageBody,
-    RoutedMessageFrom, SendMessage, StateResponseInfo, StopMsg, SyncData, Unregister,
+    RoutedMessageFrom, SendMessage, SetRoutingTable, StateResponseInfo, StopMsg, SyncData,
+    Unregister,
 };
 #[cfg(feature = "test_features")]
 use crate::types::{GetPeerId, GetPeerIdResult, SetAdvOptions};
@@ -1894,7 +1895,7 @@ impl Handler<GetRoutingTable> for PeerManagerActor {
 
 #[cfg(feature = "test_features")]
 #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
-impl Handler<crate::types::SetRoutingTable> for PeerManagerActor {
+impl Handler<SetRoutingTable> for PeerManagerActor {
     type Result = ();
 
     #[perf]

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -1916,7 +1916,6 @@ impl PeerManagerActor {
     }
 }
 
-#[cfg(feature = "test_features")]
 impl PeerManagerActor {
     #[perf]
     fn handle_msg_get_peer_id(

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -44,6 +44,8 @@ use crate::routing::{
 };
 
 use crate::edge_verifier::EdgeVerifier;
+#[cfg(feature = "test_features")]
+use crate::types::SetAdvOptions;
 use crate::types::{
     AccountOrPeerIdOrHash, Ban, BlockedPorts, Consolidate, ConsolidateResponse, EdgeList,
     FullPeerInfo, GetRoutingTable, InboundTcpConnect, KnownPeerState, KnownPeerStatus,
@@ -54,8 +56,7 @@ use crate::types::{
     Pong, QueryPeerStats, RawRoutedMessage, ReasonForBan, RoutedMessage, RoutedMessageBody,
     RoutedMessageFrom, SendMessage, StateResponseInfo, StopMsg, SyncData, Unregister,
 };
-#[cfg(feature = "test_features")]
-use crate::types::{GetPeerId, GetPeerIdResult, SetAdvOptions};
+use crate::types::{GetPeerId, GetPeerIdResult};
 #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
 use crate::types::{RoutingState, RoutingSyncV2, RoutingVersion2};
 

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -2133,6 +2133,9 @@ impl Handler<PeerMessageRequest> for PeerManagerActor {
             PeerMessageRequest::PeersResponse(msg) => {
                 PeerMessageResponse::PeersResponseResult(self.handle_msg_peers_response(msg, ctx))
             }
+            PeerMessageRequest::PeerRequest(msg) => {
+                PeerMessageResponse::PeerResponse(self.handle_msg_peer_request(msg, ctx))
+            }
         }
     }
 }
@@ -2173,11 +2176,12 @@ impl PeerManagerActor {
     }
 }
 
-impl Handler<PeerRequest> for PeerManagerActor {
-    type Result = PeerResponse;
-
-    #[perf]
-    fn handle(&mut self, msg: PeerRequest, ctx: &mut Self::Context) -> Self::Result {
+impl PeerManagerActor {
+    fn handle_msg_peer_request(
+        &mut self,
+        msg: PeerRequest,
+        ctx: &mut Context<Self>,
+    ) -> PeerResponse {
         #[cfg(feature = "delay_detector")]
         let _d = DelayDetector::new(format!("peer request {}", msg.as_ref()).into());
         match msg {

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -2173,23 +2173,6 @@ impl PeerManagerActor {
     }
 }
 
-impl Handler<RawRoutedMessage> for PeerManagerActor {
-    type Result = ();
-
-    #[perf]
-    fn handle(&mut self, msg: RawRoutedMessage, ctx: &mut Self::Context) {
-        #[cfg(feature = "delay_detector")]
-        let _d = DelayDetector::new(
-            format!("raw routed message {}", strum::AsStaticRef::as_static(&msg.body)).into(),
-        );
-        if let AccountOrPeerIdOrHash::AccountId(target) = msg.target {
-            self.send_message_to_account(ctx, &target, msg.body);
-        } else {
-            self.send_message_to_peer(ctx, msg);
-        }
-    }
-}
-
 impl Handler<PeerRequest> for PeerManagerActor {
     type Result = PeerResponse;
 

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -1470,6 +1470,7 @@ impl Actor for PeerManagerActor {
 }
 
 impl PeerManagerActor {
+    #[perf]
     fn handle_msg_network_requests(
         &mut self,
         msg: NetworkRequests,
@@ -1914,11 +1915,13 @@ impl Handler<crate::types::SetRoutingTable> for PeerManagerActor {
 }
 
 #[cfg(feature = "test_features")]
-impl Handler<GetPeerId> for PeerManagerActor {
-    type Result = GetPeerIdResult;
-
+impl PeerManagerActor {
     #[perf]
-    fn handle(&mut self, msg: GetPeerId, _ctx: &mut Self::Context) -> GetPeerIdResult {
+    fn handle_msg_get_peer_id(
+        &mut self,
+        _msg: GetPeerId,
+        _ctx: &mut Context<Self>,
+    ) -> GetPeerIdResult {
         GetPeerIdResult { peer_id: self.peer_id.clone() }
     }
 }
@@ -1977,6 +1980,7 @@ impl Handler<OutboundTcpConnect> for PeerManagerActor {
 }
 
 impl PeerManagerActor {
+    #[perf]
     fn handle_msg_consolidate(
         &mut self,
         msg: Consolidate,
@@ -2135,6 +2139,9 @@ impl Handler<PeerMessageRequest> for PeerManagerActor {
             }
             PeerMessageRequest::PeerRequest(msg) => {
                 PeerMessageResponse::PeerResponse(self.handle_msg_peer_request(msg, ctx))
+            }
+            PeerMessageRequest::GetPeerId(msg) => {
+                PeerMessageResponse::GetPeerIdResult(self.handle_msg_get_peer_id(msg, ctx))
             }
         }
     }

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -1475,6 +1475,7 @@ impl PeerManagerActor {
         msg: NetworkRequests,
         ctx: &mut Context<Self>,
     ) -> NetworkResponses {
+        #[cfg(feature = "delay_detector")]
         let _d = DelayDetector::new(format!("network request {}", msg.as_ref()).into());
         match msg {
             NetworkRequests::Block { block } => {
@@ -2098,11 +2099,8 @@ impl PeerManagerActor {
     }
 }
 
-impl Handler<PeersResponse> for PeerManagerActor {
-    type Result = ();
-
-    #[perf]
-    fn handle(&mut self, msg: PeersResponse, _ctx: &mut Self::Context) {
+impl PeerManagerActor {
+    fn handle_msg_peers_response(&mut self, msg: PeersResponse, _ctx: &mut Context<Self>) {
         #[cfg(feature = "delay_detector")]
         let _d = DelayDetector::new("peers response".into());
         unwrap_or_error!(
@@ -2131,6 +2129,9 @@ impl Handler<PeerMessageRequest> for PeerManagerActor {
             }
             PeerMessageRequest::PeersRequest(msg) => {
                 PeerMessageResponse::PeerRequestResult(self.handle_msg_peers_request(msg, ctx))
+            }
+            PeerMessageRequest::PeersResponse(msg) => {
+                PeerMessageResponse::PeersResponseResult(self.handle_msg_peers_response(msg, ctx))
             }
         }
     }

--- a/chain/network/src/routing.rs
+++ b/chain/network/src/routing.rs
@@ -325,6 +325,7 @@ impl ValidIBFLevel {
     }
 }
 
+#[derive(Debug)]
 #[cfg_attr(feature = "test_features", derive(Serialize))]
 pub struct PeerRequestResult {
     pub peers: Vec<PeerInfo>,

--- a/chain/network/src/routing.rs
+++ b/chain/network/src/routing.rs
@@ -345,10 +345,6 @@ where
 
 #[derive(MessageResponse, Debug)]
 #[cfg_attr(feature = "test_features", derive(Serialize))]
-pub struct SetAdvOptionsResult {}
-
-#[derive(MessageResponse, Debug)]
-#[cfg_attr(feature = "test_features", derive(Serialize))]
 pub struct GetRoutingTableResult {
     pub edges_info: Vec<SimpleEdge>,
 }

--- a/chain/network/src/test_utils.rs
+++ b/chain/network/src/test_utils.rs
@@ -23,7 +23,7 @@ use near_store::test_utils::create_test_store;
 
 use crate::types::{
     NetworkInfo, NetworkViewClientMessages, NetworkViewClientResponses, PeerInfo,
-    PeerMessageRequest, PeerMessageResponse, ReasonForBan,
+    PeerManagerMessageRequest, PeerManagerMessageResponse, ReasonForBan,
 };
 use crate::{
     NetworkClientMessages, NetworkClientResponses, NetworkConfig, NetworkResponses,
@@ -257,25 +257,26 @@ impl Handler<BanPeerSignal> for PeerManagerActor {
 
 #[derive(Default)]
 pub struct MockPeerManagerAdapter {
-    pub requests: Arc<RwLock<VecDeque<PeerMessageRequest>>>,
+    pub requests: Arc<RwLock<VecDeque<PeerManagerMessageRequest>>>,
 }
 
 impl PeerManagerAdapter for MockPeerManagerAdapter {
     fn send(
         &self,
-        msg: PeerMessageRequest,
-    ) -> BoxFuture<'static, Result<PeerMessageResponse, MailboxError>> {
+        msg: PeerManagerMessageRequest,
+    ) -> BoxFuture<'static, Result<PeerManagerMessageResponse, MailboxError>> {
         self.do_send(msg);
-        future::ok(PeerMessageResponse::NetworkResponses(NetworkResponses::NoResponse)).boxed()
+        future::ok(PeerManagerMessageResponse::NetworkResponses(NetworkResponses::NoResponse))
+            .boxed()
     }
 
-    fn do_send(&self, msg: PeerMessageRequest) {
+    fn do_send(&self, msg: PeerManagerMessageRequest) {
         self.requests.write().unwrap().push_back(msg);
     }
 }
 
 impl MockPeerManagerAdapter {
-    pub fn pop(&self) -> Option<PeerMessageRequest> {
+    pub fn pop(&self) -> Option<PeerManagerMessageRequest> {
         self.requests.write().unwrap().pop_front()
     }
 }

--- a/chain/network/src/test_utils.rs
+++ b/chain/network/src/test_utils.rs
@@ -22,11 +22,12 @@ use near_primitives::utils::index_to_bytes;
 use near_store::test_utils::create_test_store;
 
 use crate::types::{
-    NetworkInfo, NetworkViewClientMessages, NetworkViewClientResponses, PeerInfo, ReasonForBan,
+    NetworkInfo, NetworkViewClientMessages, NetworkViewClientResponses, PeerInfo,
+    PeerMessageRequest, PeerMessageResponse, ReasonForBan,
 };
 use crate::{
-    NetworkAdapter, NetworkClientMessages, NetworkClientResponses, NetworkConfig, NetworkRequests,
-    NetworkResponses, PeerManagerActor, RoutingTableActor,
+    NetworkClientMessages, NetworkClientResponses, NetworkConfig, NetworkResponses,
+    PeerManagerActor, PeerManagerAdapter, RoutingTableActor,
 };
 
 type ClientMock = Mocker<NetworkClientMessages>;
@@ -255,26 +256,26 @@ impl Handler<BanPeerSignal> for PeerManagerActor {
 }
 
 #[derive(Default)]
-pub struct MockNetworkAdapter {
-    pub requests: Arc<RwLock<VecDeque<NetworkRequests>>>,
+pub struct MockPeerManagerAdapter {
+    pub requests: Arc<RwLock<VecDeque<PeerMessageRequest>>>,
 }
 
-impl NetworkAdapter for MockNetworkAdapter {
+impl PeerManagerAdapter for MockPeerManagerAdapter {
     fn send(
         &self,
-        msg: NetworkRequests,
-    ) -> BoxFuture<'static, Result<NetworkResponses, MailboxError>> {
+        msg: PeerMessageRequest,
+    ) -> BoxFuture<'static, Result<PeerMessageResponse, MailboxError>> {
         self.do_send(msg);
-        future::ok(NetworkResponses::NoResponse).boxed()
+        future::ok(PeerMessageResponse::NetworkResponses(NetworkResponses::NoResponse)).boxed()
     }
 
-    fn do_send(&self, msg: NetworkRequests) {
+    fn do_send(&self, msg: PeerMessageRequest) {
         self.requests.write().unwrap().push_back(msg);
     }
 }
 
-impl MockNetworkAdapter {
-    pub fn pop(&self) -> Option<NetworkRequests> {
+impl MockPeerManagerAdapter {
+    pub fn pop(&self) -> Option<PeerMessageRequest> {
         self.requests.write().unwrap().pop_front()
     }
 }

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -851,6 +851,12 @@ pub enum NetworkResponses {
     RouteNotFound,
 }
 
+impl From<NetworkResponses> for PeerMessageResponse {
+    fn from(msg: NetworkResponses) -> Self {
+        PeerMessageResponse::NetworkResponses(msg)
+    }
+}
+
 impl<A, M> MessageResponse<A, M> for NetworkResponses
 where
     A: Actor,

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -548,7 +548,7 @@ pub struct PeersResponse {
     pub peers: Vec<PeerInfo>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub enum PeerMessageRequest {
     RoutedMessageFrom(RoutedMessageFrom),
     NetworkRequests(NetworkRequests),
@@ -557,6 +557,8 @@ pub enum PeerMessageRequest {
     PeersResponse(PeersResponse),
     PeerRequest(PeerRequest),
     GetPeerId(GetPeerId),
+    OutboundTcpConnect(OutboundTcpConnect),
+    InboundTcpConnect(InboundTcpConnect),
 }
 
 impl PeerMessageRequest {
@@ -590,6 +592,8 @@ pub enum PeerMessageResponse {
     PeersResponseResult(()),
     PeerResponse(PeerResponse),
     GetPeerIdResult(GetPeerIdResult),
+    OutboundTcpConnect(()),
+    InboundTcpConnect(()),
 }
 
 impl PeerMessageResponse {

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -541,7 +541,7 @@ impl Message for PeersRequest {
 }
 
 /// Received new peers from another peer.
-#[derive(Message, Debug)]
+#[derive(Message, Debug, Clone)]
 #[rtype(result = "()")]
 pub struct PeersResponse {
     pub peers: Vec<PeerInfo>,
@@ -553,6 +553,7 @@ pub enum PeerMessageRequest {
     NetworkRequests(NetworkRequests),
     Consolidate(Consolidate),
     PeersRequest(PeersRequest),
+    PeersResponse(PeersResponse),
 }
 
 impl PeerMessageRequest {
@@ -575,6 +576,7 @@ pub enum PeerMessageResponse {
     NetworkResponses(NetworkResponses),
     ConsolidateResponse(ConsolidateResponse),
     PeerRequestResult(PeerRequestResult),
+    PeersResponseResult(()),
 }
 
 impl PeerMessageResponse {

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -632,7 +632,7 @@ impl PeerMessageResponse {
         if let PeerMessageResponse::NetworkResponses(item) = self {
             item
         } else {
-            panic!("expected PeerMessageRequest::NetworkRequests(");
+            panic!("expected PeerMessageRequest::NetworkResponses(");
         }
     }
 
@@ -640,7 +640,7 @@ impl PeerMessageResponse {
         if let PeerMessageResponse::ConsolidateResponse(item) = self {
             item
         } else {
-            panic!("expected PeerMessageRequest::NetworkRequests(");
+            panic!("expected PeerMessageRequest::ConsolidateResponse(");
         }
     }
 
@@ -648,7 +648,7 @@ impl PeerMessageResponse {
         if let PeerMessageResponse::PeerRequestResult(item) = self {
             item
         } else {
-            panic!("expected PeerMessageRequest::NetworkRequests(");
+            panic!("expected PeerMessageRequest::PeerRequestResult(");
         }
     }
 
@@ -656,7 +656,7 @@ impl PeerMessageResponse {
         if let PeerMessageResponse::PeerResponse(item) = self {
             item
         } else {
-            panic!("expected PeerMessageRequest::NetworkRequests(");
+            panic!("expected PeerMessageRequest::PeerResponse(");
         }
     }
 
@@ -664,7 +664,7 @@ impl PeerMessageResponse {
         if let PeerMessageResponse::GetPeerIdResult(item) = self {
             item
         } else {
-            panic!("expected PeerMessageRequest::NetworkRequests(");
+            panic!("expected PeerMessageRequest::GetPeerIdResult(");
         }
     }
 
@@ -672,7 +672,7 @@ impl PeerMessageResponse {
         if let PeerMessageResponse::GetRoutingTableResult(item) = self {
             item
         } else {
-            panic!("expected PeerMessageRequest::NetworkRequests(");
+            panic!("expected PeerMessageRequest::GetRoutingTableResult(");
         }
     }
 }

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -580,6 +580,14 @@ pub enum PeerMessageResponse {
 }
 
 impl PeerMessageResponse {
+    pub fn as_routed_message_from(self) -> bool {
+        if let PeerMessageResponse::RoutedMessageFrom(item) = self {
+            item
+        } else {
+            panic!("expected PeerMessageRequest::RoutedMessageFrom(");
+        }
+    }
+
     pub fn as_network_response(self) -> NetworkResponses {
         if let PeerMessageResponse::NetworkResponses(item) = self {
             item

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -452,6 +452,7 @@ impl Message for Consolidate {
     type Result = ConsolidateResponse;
 }
 
+#[derive(Clone, Debug)]
 pub struct GetPeerId {}
 
 impl Message for GetPeerId {
@@ -555,6 +556,7 @@ pub enum PeerMessageRequest {
     PeersRequest(PeersRequest),
     PeersResponse(PeersResponse),
     PeerRequest(PeerRequest),
+    GetPeerId(GetPeerId),
 }
 
 impl PeerMessageRequest {
@@ -587,6 +589,7 @@ pub enum PeerMessageResponse {
     PeerRequestResult(PeerRequestResult),
     PeersResponseResult(()),
     PeerResponse(PeerResponse),
+    GetPeerIdResult(GetPeerIdResult),
 }
 
 impl PeerMessageResponse {
@@ -624,6 +627,14 @@ impl PeerMessageResponse {
 
     pub fn as_peer_response(self) -> PeerResponse {
         if let PeerMessageResponse::PeerResponse(item) = self {
+            item
+        } else {
+            panic!("expected PeerMessageRequest::NetworkRequests(");
+        }
+    }
+
+    pub fn as_peer_id_result(self) -> GetPeerIdResult {
+        if let PeerMessageResponse::GetPeerIdResult(item) = self {
             item
         } else {
             panic!("expected PeerMessageRequest::NetworkRequests(");

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -514,7 +514,7 @@ pub struct Unregister {
 pub struct StopMsg {}
 
 /// Message from peer to peer manager
-#[derive(strum::AsRefStr)]
+#[derive(strum::AsRefStr, Clone, Debug)]
 pub enum PeerRequest {
     UpdateEdge((PeerId, u64)),
     RouteBack(Box<RoutedMessageBody>, CryptoHash),
@@ -526,7 +526,7 @@ impl Message for PeerRequest {
     type Result = PeerResponse;
 }
 
-#[derive(MessageResponse)]
+#[derive(MessageResponse, Debug)]
 pub enum PeerResponse {
     NoResponse,
     UpdatedEdge(EdgeInfo),
@@ -554,6 +554,7 @@ pub enum PeerMessageRequest {
     Consolidate(Consolidate),
     PeersRequest(PeersRequest),
     PeersResponse(PeersResponse),
+    PeerRequest(PeerRequest),
 }
 
 impl PeerMessageRequest {
@@ -585,6 +586,7 @@ pub enum PeerMessageResponse {
     ConsolidateResponse(ConsolidateResponse),
     PeerRequestResult(PeerRequestResult),
     PeersResponseResult(()),
+    PeerResponse(PeerResponse),
 }
 
 impl PeerMessageResponse {
@@ -614,6 +616,14 @@ impl PeerMessageResponse {
 
     pub fn as_peers_request_result(self) -> PeerRequestResult {
         if let PeerMessageResponse::PeerRequestResult(item) = self {
+            item
+        } else {
+            panic!("expected PeerMessageRequest::NetworkRequests(");
+        }
+    }
+
+    pub fn as_peer_response(self) -> PeerResponse {
+        if let PeerMessageResponse::PeerResponse(item) = self {
             item
         } else {
             panic!("expected PeerMessageRequest::NetworkRequests(");

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -562,8 +562,13 @@ pub enum PeerMessageRequest {
     InboundTcpConnect(InboundTcpConnect),
     Unregister(Unregister),
     Ban(Ban),
+    #[cfg(feature = "test_features")]
+    #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
     StartRoutingTableSync(StartRoutingTableSync),
+    #[cfg(feature = "test_features")]
     SetAdvOptions(SetAdvOptions),
+    #[cfg(feature = "test_features")]
+    #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
     SetRoutingTable(SetRoutingTable),
     GetRoutingTable(GetRoutingTable),
 }
@@ -603,8 +608,13 @@ pub enum PeerMessageResponse {
     InboundTcpConnect(()),
     Unregister(()),
     Ban(()),
+    #[cfg(feature = "test_features")]
+    #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
     StartRoutingTableSync(()),
+    #[cfg(feature = "test_features")]
     SetAdvOptions(()),
+    #[cfg(feature = "test_features")]
+    #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
     SetRoutingTable(()),
     GetRoutingTableResult(GetRoutingTableResult),
 }

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -564,6 +564,14 @@ impl PeerMessageRequest {
             panic!("expected PeerMessageRequest::NetworkRequests(");
         }
     }
+
+    pub fn as_network_requests_ref(&self) -> &NetworkRequests {
+        if let PeerMessageRequest::NetworkRequests(item) = self {
+            item
+        } else {
+            panic!("expected PeerMessageRequest::NetworkRequests(");
+        }
+    }
 }
 
 impl Message for PeerMessageRequest {

--- a/integration-tests/tests/client/challenges.rs
+++ b/integration-tests/tests/client/challenges.rs
@@ -15,7 +15,6 @@ use near_client::Client;
 use near_crypto::{InMemorySigner, KeyType, Signer};
 use near_logger_utils::init_test_logger;
 use near_network::test_utils::MockPeerManagerAdapter;
-use near_network::types::PeerMessageRequest;
 use near_network::NetworkRequests;
 use near_primitives::challenge::{
     BlockDoubleSign, Challenge, ChallengeBody, ChunkProofs, MaybeEncodedShardChunk,

--- a/integration-tests/tests/client/challenges.rs
+++ b/integration-tests/tests/client/challenges.rs
@@ -441,12 +441,7 @@ fn test_verify_chunk_invalid_state_challenge() {
     let (_, tip) = client.process_block(block, Provenance::NONE);
     assert!(tip.is_err());
 
-    let last_message = env.network_adapters[0].pop().unwrap();
-    let last_message = if let PeerMessageRequest::NetworkRequests(item) = last_message {
-        item
-    } else {
-        panic!("expected PeerMessageRequest::NetworkRequests(");
-    };
+    let last_message = env.network_adapters[0].pop().unwrap().as_network_requests();
 
     if let NetworkRequests::Challenge(network_challenge) = last_message {
         assert_eq!(challenge, network_challenge);

--- a/integration-tests/tests/client/challenges.rs
+++ b/integration-tests/tests/client/challenges.rs
@@ -14,7 +14,8 @@ use near_client::test_utils::{create_chunk, create_chunk_with_transactions, run_
 use near_client::Client;
 use near_crypto::{InMemorySigner, KeyType, Signer};
 use near_logger_utils::init_test_logger;
-use near_network::test_utils::MockNetworkAdapter;
+use near_network::test_utils::MockPeerManagerAdapter;
+use near_network::types::PeerMessageRequest;
 use near_network::NetworkRequests;
 use near_primitives::challenge::{
     BlockDoubleSign, Challenge, ChallengeBody, ChunkProofs, MaybeEncodedShardChunk,
@@ -108,9 +109,9 @@ fn test_verify_block_double_sign_challenge() {
 
     let (_, result) = env.clients[0].process_block(b2, Provenance::SYNC);
     assert!(result.is_ok());
-    let mut last_message = env.network_adapters[0].pop().unwrap();
+    let mut last_message = env.network_adapters[0].pop().unwrap().as_network_requests();
     if let NetworkRequests::Block { .. } = last_message {
-        last_message = env.network_adapters[0].pop().unwrap();
+        last_message = env.network_adapters[0].pop().unwrap().as_network_requests();
     }
     if let NetworkRequests::Challenge(network_challenge) = last_message {
         assert_eq!(network_challenge, valid_challenge);
@@ -441,6 +442,12 @@ fn test_verify_chunk_invalid_state_challenge() {
     assert!(tip.is_err());
 
     let last_message = env.network_adapters[0].pop().unwrap();
+    let last_message = if let PeerMessageRequest::NetworkRequests(item) = last_message {
+        item
+    } else {
+        panic!("expected PeerMessageRequest::NetworkRequests(");
+    };
+
     if let NetworkRequests::Challenge(network_challenge) = last_message {
         assert_eq!(challenge, network_challenge);
     } else {
@@ -499,17 +506,7 @@ fn test_receive_invalid_chunk_as_chunk_producer() {
     env.process_block(1, block.clone(), Provenance::NONE);
 
     // At this point we should create a challenge and send it out.
-    let last_message = env.network_adapters[0].pop().unwrap();
-    if let NetworkRequests::Challenge(Challenge {
-        body: ChallengeBody::ChunkProofs(chunk_proofs),
-        ..
-    }) = last_message.clone()
-    {
-        assert_eq!(chunk_proofs.chunk, MaybeEncodedShardChunk::Encoded(chunk));
-    } else {
-        assert!(false);
-    }
-
+    let last_message = env.network_adapters[0].pop().unwrap().as_network_requests();
     // The other client processes challenge and invalidates the chain.
     if let NetworkRequests::Challenge(challenge) = last_message {
         assert_eq!(env.clients[1].chain.head().unwrap().height, 2);
@@ -629,7 +626,7 @@ fn test_challenge_in_different_epoch() {
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 2);
     genesis.config.epoch_length = 3;
     //    genesis.config.validator_kickout_threshold = 10;
-    let network_adapter = Arc::new(MockNetworkAdapter::default());
+    let network_adapter = Arc::new(MockPeerManagerAdapter::default());
     let runtime1 = Arc::new(nearcore::NightshadeRuntime::test(
         Path::new("."),
         create_test_store(),
@@ -682,7 +679,13 @@ fn test_challenge_in_different_epoch() {
         }
         let len = network_adapter.requests.write().unwrap().len();
         for _ in 0..len {
-            match network_adapter.requests.write().unwrap().pop_front() {
+            match network_adapter
+                .requests
+                .write()
+                .unwrap()
+                .pop_front()
+                .map(|f| f.as_network_requests())
+            {
                 Some(NetworkRequests::Challenge(_)) => {
                     panic!("Unexpected challenge");
                 }

--- a/integration-tests/tests/client/chunks_management.rs
+++ b/integration-tests/tests/client/chunks_management.rs
@@ -16,7 +16,7 @@ use near_chunks::{
 use near_client::test_utils::setup_mock_all_validators;
 use near_client::{ClientActor, GetBlock, ViewClientActor};
 use near_logger_utils::init_test_logger;
-use near_network::types::{AccountIdOrPeerTrackingShard, PeerMessageRequest};
+use near_network::types::{AccountIdOrPeerTrackingShard, PeerManagerMessageRequest};
 use near_network::{NetworkClientMessages, NetworkRequests, NetworkResponses, PeerInfo};
 use near_primitives::hash::CryptoHash;
 use near_primitives::transaction::SignedTransaction;
@@ -82,22 +82,23 @@ fn chunks_produced_and_distributed_common(
         vec![false; validators.iter().map(|x| x.len()).sum()],
         vec![true; validators.iter().map(|x| x.len()).sum()],
         false,
-        Arc::new(RwLock::new(Box::new(move |from_whom: AccountId, msg: &PeerMessageRequest| {
-            let msg = msg.as_network_requests_ref();
-            match msg {
-                NetworkRequests::Block { block } => {
-                    check_height(*block.hash(), block.header().height());
-                    check_height(*block.header().prev_hash(), block.header().height() - 1);
+        Arc::new(RwLock::new(Box::new(
+            move |from_whom: AccountId, msg: &PeerManagerMessageRequest| {
+                let msg = msg.as_network_requests_ref();
+                match msg {
+                    NetworkRequests::Block { block } => {
+                        check_height(*block.hash(), block.header().height());
+                        check_height(*block.header().prev_hash(), block.header().height() - 1);
 
-                    let h = block.header().height();
+                        let h = block.header().height();
 
-                    let mut height_to_hash = height_to_hash.write().unwrap();
-                    height_to_hash.insert(h, *block.hash());
+                        let mut height_to_hash = height_to_hash.write().unwrap();
+                        height_to_hash.insert(h, *block.hash());
 
-                    let mut height_to_epoch = height_to_epoch.write().unwrap();
-                    height_to_epoch.insert(h, block.header().epoch_id().clone());
+                        let mut height_to_epoch = height_to_epoch.write().unwrap();
+                        height_to_epoch.insert(h, block.header().epoch_id().clone());
 
-                    println!(
+                        println!(
                             "[{:?}]: BLOCK {} HEIGHT {}; HEADER HEIGHTS: {} / {} / {} / {};\nAPPROVALS: {:?}",
                             Instant::now(),
                             block.hash(),
@@ -109,104 +110,108 @@ fn chunks_produced_and_distributed_common(
                             block.header().approvals(),
                         );
 
-                    if h > 1 {
-                        // Make sure doomslug finality is computed correctly.
-                        assert_eq!(
-                            block.header().last_ds_final_block(),
-                            height_to_hash.get(&(h - 1)).unwrap()
-                        );
+                        if h > 1 {
+                            // Make sure doomslug finality is computed correctly.
+                            assert_eq!(
+                                block.header().last_ds_final_block(),
+                                height_to_hash.get(&(h - 1)).unwrap()
+                            );
 
-                        // Make sure epoch length actually corresponds to the desired epoch length
-                        // The switches are expected at 0->1, 5->6 and 10->11
-                        let prev_epoch_id = height_to_epoch.get(&(h - 1)).unwrap().clone();
-                        assert_eq!(block.header().epoch_id() == &prev_epoch_id, h % 5 != 1);
+                            // Make sure epoch length actually corresponds to the desired epoch length
+                            // The switches are expected at 0->1, 5->6 and 10->11
+                            let prev_epoch_id = height_to_epoch.get(&(h - 1)).unwrap().clone();
+                            assert_eq!(block.header().epoch_id() == &prev_epoch_id, h % 5 != 1);
 
-                        // Make sure that the blocks leading to the epoch switch have twice as
-                        // many approval slots
-                        assert_eq!(block.header().approvals().len() == 8, h % 5 == 0 || h % 5 == 4);
-                    }
-                    if h > 2 {
-                        // Make sure BFT finality is computed correctly
-                        assert_eq!(
-                            block.header().last_final_block(),
-                            height_to_hash.get(&(h - 2)).unwrap()
-                        );
-                    }
+                            // Make sure that the blocks leading to the epoch switch have twice as
+                            // many approval slots
+                            assert_eq!(
+                                block.header().approvals().len() == 8,
+                                h % 5 == 0 || h % 5 == 4
+                            );
+                        }
+                        if h > 2 {
+                            // Make sure BFT finality is computed correctly
+                            assert_eq!(
+                                block.header().last_final_block(),
+                                height_to_hash.get(&(h - 2)).unwrap()
+                            );
+                        }
 
-                    if block.header().height() > 1 {
-                        for shard_id in 0..4 {
-                            // If messages from 1 to 4 are dropped, 4 at their heights will
-                            //    receive the block significantly later than the chunks, and
-                            //    thus would discard the chunks
-                            if !drop_from_1_to_4 || block.header().height() % 4 != 3 {
-                                assert_eq!(
-                                    block.header().height(),
-                                    block.chunks()[shard_id].height_created()
-                                );
+                        if block.header().height() > 1 {
+                            for shard_id in 0..4 {
+                                // If messages from 1 to 4 are dropped, 4 at their heights will
+                                //    receive the block significantly later than the chunks, and
+                                //    thus would discard the chunks
+                                if !drop_from_1_to_4 || block.header().height() % 4 != 3 {
+                                    assert_eq!(
+                                        block.header().height(),
+                                        block.chunks()[shard_id].height_created()
+                                    );
+                                }
                             }
                         }
-                    }
 
-                    if block.header().height() >= 12 {
-                        println!("PREV BLOCK HASH: {}", block.header().prev_hash());
-                        println!(
-                            "STATS: responses: {} requests: {}",
-                            partial_chunk_msgs, partial_chunk_request_msgs
-                        );
+                        if block.header().height() >= 12 {
+                            println!("PREV BLOCK HASH: {}", block.header().prev_hash());
+                            println!(
+                                "STATS: responses: {} requests: {}",
+                                partial_chunk_msgs, partial_chunk_request_msgs
+                            );
 
-                        System::current().stop();
+                            System::current().stop();
+                        }
                     }
-                }
-                NetworkRequests::PartialEncodedChunkMessage {
-                    account_id: to_whom,
-                    partial_encoded_chunk: _,
-                } => {
-                    partial_chunk_msgs += 1;
-                    if drop_from_1_to_4
-                        && from_whom.as_ref() == "test1"
-                        && to_whom.as_ref() == "test4"
-                    {
-                        println!("Dropping Partial Encoded Chunk Message from test1 to test4");
-                        return (NetworkResponses::NoResponse.into(), false);
+                    NetworkRequests::PartialEncodedChunkMessage {
+                        account_id: to_whom,
+                        partial_encoded_chunk: _,
+                    } => {
+                        partial_chunk_msgs += 1;
+                        if drop_from_1_to_4
+                            && from_whom.as_ref() == "test1"
+                            && to_whom.as_ref() == "test4"
+                        {
+                            println!("Dropping Partial Encoded Chunk Message from test1 to test4");
+                            return (NetworkResponses::NoResponse.into(), false);
+                        }
                     }
-                }
-                NetworkRequests::PartialEncodedChunkForward { account_id: to_whom, .. } => {
-                    if drop_from_1_to_4
-                        && from_whom.as_ref() == "test1"
-                        && to_whom.as_ref() == "test4"
-                    {
-                        println!(
+                    NetworkRequests::PartialEncodedChunkForward { account_id: to_whom, .. } => {
+                        if drop_from_1_to_4
+                            && from_whom.as_ref() == "test1"
+                            && to_whom.as_ref() == "test4"
+                        {
+                            println!(
                             "Dropping Partial Encoded Chunk Forward Message from test1 to test4"
                         );
-                        return (NetworkResponses::NoResponse.into(), false);
+                            return (NetworkResponses::NoResponse.into(), false);
+                        }
                     }
-                }
-                NetworkRequests::PartialEncodedChunkResponse { route_back: _, response: _ } => {
-                    partial_chunk_msgs += 1;
-                }
-                NetworkRequests::PartialEncodedChunkRequest {
-                    target: AccountIdOrPeerTrackingShard { account_id: Some(to_whom), .. },
-                    request: _,
-                } => {
-                    if drop_from_1_to_4
-                        && from_whom.as_ref() == "test4"
-                        && to_whom.as_ref() == "test1"
-                    {
-                        info!("Dropping Partial Encoded Chunk Request from test4 to test1");
-                        return (NetworkResponses::NoResponse.into(), false);
+                    NetworkRequests::PartialEncodedChunkResponse { route_back: _, response: _ } => {
+                        partial_chunk_msgs += 1;
                     }
-                    if drop_from_1_to_4
-                        && from_whom.as_ref() == "test4"
-                        && to_whom.as_ref() == "test2"
-                    {
-                        info!("Observed Partial Encoded Chunk Request from test4 to test2");
+                    NetworkRequests::PartialEncodedChunkRequest {
+                        target: AccountIdOrPeerTrackingShard { account_id: Some(to_whom), .. },
+                        request: _,
+                    } => {
+                        if drop_from_1_to_4
+                            && from_whom.as_ref() == "test4"
+                            && to_whom.as_ref() == "test1"
+                        {
+                            info!("Dropping Partial Encoded Chunk Request from test4 to test1");
+                            return (NetworkResponses::NoResponse.into(), false);
+                        }
+                        if drop_from_1_to_4
+                            && from_whom.as_ref() == "test4"
+                            && to_whom.as_ref() == "test2"
+                        {
+                            info!("Observed Partial Encoded Chunk Request from test4 to test2");
+                        }
+                        partial_chunk_request_msgs += 1;
                     }
-                    partial_chunk_request_msgs += 1;
-                }
-                _ => {}
-            };
-            (NetworkResponses::NoResponse.into(), true)
-        }))),
+                    _ => {}
+                };
+                (NetworkResponses::NoResponse.into(), true)
+            },
+        ))),
     );
     *connectors.write().unwrap() = conn;
 

--- a/integration-tests/tests/client/runtimes.rs
+++ b/integration-tests/tests/client/runtimes.rs
@@ -13,7 +13,7 @@ use near_chunks::test_utils::ChunkForwardingTestFixture;
 use near_chunks::ProcessPartialEncodedChunkResult;
 use near_client::test_utils::TestEnv;
 use near_crypto::KeyType;
-use near_network::test_utils::MockNetworkAdapter;
+use near_network::test_utils::MockPeerManagerAdapter;
 use near_network::types::PartialEncodedChunkForwardMsg;
 use near_primitives::block::{Approval, ApprovalInner};
 use near_primitives::block_header::ApprovalType;
@@ -66,7 +66,7 @@ fn test_pending_approvals() {
 
 #[test]
 fn test_invalid_approvals() {
-    let network_adapter = Arc::new(MockNetworkAdapter::default());
+    let network_adapter = Arc::new(MockPeerManagerAdapter::default());
     let mut env = TestEnv::builder(ChainGenesis::test())
         .runtime_adapters(create_runtimes(1))
         .network_adapters(vec![network_adapter.clone()])

--- a/integration-tests/tests/network/infinite_loop.rs
+++ b/integration-tests/tests/network/infinite_loop.rs
@@ -12,7 +12,9 @@ use near_logger_utils::init_integration_logger;
 use near_network::test_utils::{
     convert_boot_nodes, make_ibf_routing_pool, open_port, GetInfo, WaitOrTimeout,
 };
-use near_network::types::{NetworkViewClientMessages, NetworkViewClientResponses, SyncData};
+use near_network::types::{
+    NetworkViewClientMessages, NetworkViewClientResponses, PeerMessageRequest, SyncData,
+};
 use near_network::{NetworkClientResponses, NetworkConfig, NetworkRequests, PeerManagerActor};
 use near_primitives::block::GenesisId;
 use near_primitives::network::{AnnounceAccount, PeerId};
@@ -125,25 +127,37 @@ fn test_infinite_loop() {
                         future::ready(())
                     }));
                 } else if state_value == 1 {
-                    actix::spawn(pm1.clone().send(request1.clone()).then(move |res| {
-                        assert!(res.is_ok());
-                        state1.store(2, Ordering::SeqCst);
-                        future::ready(())
-                    }));
+                    actix::spawn(
+                        pm1.clone()
+                            .send(PeerMessageRequest::NetworkRequests(request1.clone()))
+                            .then(move |res| {
+                                assert!(res.is_ok());
+                                state1.store(2, Ordering::SeqCst);
+                                future::ready(())
+                            }),
+                    );
                 } else if state_value == 2 {
                     if counter1.load(Ordering::SeqCst) == 1 && counter2.load(Ordering::SeqCst) == 1
                     {
                         state.store(3, Ordering::SeqCst);
                     }
                 } else if state_value == 3 {
-                    actix::spawn(pm1.clone().send(request1.clone()).then(move |res| {
-                        assert!(res.is_ok());
-                        future::ready(())
-                    }));
-                    actix::spawn(pm2.clone().send(request2.clone()).then(move |res| {
-                        assert!(res.is_ok());
-                        future::ready(())
-                    }));
+                    actix::spawn(
+                        pm1.clone()
+                            .send(PeerMessageRequest::NetworkRequests(request1.clone()))
+                            .then(move |res| {
+                                assert!(res.is_ok());
+                                future::ready(())
+                            }),
+                    );
+                    actix::spawn(
+                        pm2.clone()
+                            .send(PeerMessageRequest::NetworkRequests(request2.clone()))
+                            .then(move |res| {
+                                assert!(res.is_ok());
+                                future::ready(())
+                            }),
+                    );
                     state.store(4, Ordering::SeqCst);
                 } else if state_value == 4 {
                     assert_eq!(counter1.load(Ordering::SeqCst), 1);

--- a/integration-tests/tests/network/infinite_loop.rs
+++ b/integration-tests/tests/network/infinite_loop.rs
@@ -13,7 +13,7 @@ use near_network::test_utils::{
     convert_boot_nodes, make_ibf_routing_pool, open_port, GetInfo, WaitOrTimeout,
 };
 use near_network::types::{
-    NetworkViewClientMessages, NetworkViewClientResponses, PeerMessageRequest, SyncData,
+    NetworkViewClientMessages, NetworkViewClientResponses, PeerManagerMessageRequest, SyncData,
 };
 use near_network::{NetworkClientResponses, NetworkConfig, NetworkRequests, PeerManagerActor};
 use near_primitives::block::GenesisId;
@@ -129,7 +129,7 @@ fn test_infinite_loop() {
                 } else if state_value == 1 {
                     actix::spawn(
                         pm1.clone()
-                            .send(PeerMessageRequest::NetworkRequests(request1.clone()))
+                            .send(PeerManagerMessageRequest::NetworkRequests(request1.clone()))
                             .then(move |res| {
                                 assert!(res.is_ok());
                                 state1.store(2, Ordering::SeqCst);
@@ -144,7 +144,7 @@ fn test_infinite_loop() {
                 } else if state_value == 3 {
                     actix::spawn(
                         pm1.clone()
-                            .send(PeerMessageRequest::NetworkRequests(request1.clone()))
+                            .send(PeerManagerMessageRequest::NetworkRequests(request1.clone()))
                             .then(move |res| {
                                 assert!(res.is_ok());
                                 future::ready(())
@@ -152,7 +152,7 @@ fn test_infinite_loop() {
                     );
                     actix::spawn(
                         pm2.clone()
-                            .send(PeerMessageRequest::NetworkRequests(request2.clone()))
+                            .send(PeerManagerMessageRequest::NetworkRequests(request2.clone()))
                             .then(move |res| {
                                 assert!(res.is_ok());
                                 future::ready(())

--- a/integration-tests/tests/network/runner.rs
+++ b/integration-tests/tests/network/runner.rs
@@ -160,12 +160,12 @@ impl StateMachine {
                           _runner| {
                         let addr = info.read().unwrap().pm_addr[target].clone();
                         actix::spawn(
-                            addr.send(SetAdvOptions {
+                            addr.send(PeerMessageRequest::SetAdvOptions(SetAdvOptions {
                                 disable_edge_signature_verification: None,
                                 disable_edge_propagation: None,
                                 disable_edge_pruning: None,
                                 set_max_peers: max_num_peers,
-                            })
+                            }))
                             .then(move |res| match res {
                                 Ok(_) => {
                                     flag.store(true, Ordering::Relaxed);

--- a/integration-tests/tests/network/runner.rs
+++ b/integration-tests/tests/network/runner.rs
@@ -187,8 +187,11 @@ impl StateMachine {
                           _runner| {
                         let addr = info.read().unwrap().pm_addr[u].clone();
                         let peer_info = info.read().unwrap().peers_info[v].clone();
-                        actix::spawn(addr.send(OutboundTcpConnect { peer_info }).then(
-                            move |res| match res {
+                        actix::spawn(
+                            addr.send(PeerMessageRequest::OutboundTcpConnect(OutboundTcpConnect {
+                                peer_info,
+                            }))
+                            .then(move |res| match res {
                                 Ok(_) => {
                                     flag.store(true, Ordering::Relaxed);
                                     future::ready(())
@@ -196,8 +199,8 @@ impl StateMachine {
                                 Err(e) => {
                                     panic!("Error adding edge. {:?}", e);
                                 }
-                            },
-                        ));
+                            }),
+                        );
                     },
                 ));
             }


### PR DESCRIPTION
Closes #5142

We are going to group all messages in `PeerManager` under one enum called `PeerManagerMessageRequest`. `PeerManager` will have one single `Handler<...>` for messages. We will be able to extend this enum with extra paypoad that track sizes of all messages not processed yet, but coming from w given peer, which is needed for (https://github.com/near/nearcore/pull/4927), and make mocking PeerManager easier for test in the future.
