### PR TITLE
test: add more cases for gas overflow behavior

### DIFF
--- a/runtime/near-vm-logic/tests/test_gas_counter.rs
+++ b/runtime/near-vm-logic/tests/test_gas_counter.rs
@@ -20,7 +20,7 @@ fn test_dont_burn_gas_when_exceeding_attached_gas_limit() {
 
     // Just avoid hard-coding super-precise amount of gas burnt.
     assert!(outcome.burnt_gas < limit / 2);
-    assert!(outcome.used_gas == limit);
+    assert_eq!(outcome.used_gas, limit);
 }
 
 #[test]
@@ -29,7 +29,7 @@ fn test_limit_wasm_gas_after_attaching_gas() {
     let context = get_context(vec![], false);
     let regular_op_cost = logic_builder.config.regular_op_cost;
     let limit = context.prepaid_gas;
-    let op_limit = limit / (regular_op_cost as u64);
+    let op_limit = (limit / (regular_op_cost as u64)) as u32;
     let mut logic = logic_builder.build(context);
 
     let index = promise_create(&mut logic, b"rick.test", 0, 0).expect("should create a promise");
@@ -38,6 +38,39 @@ fn test_limit_wasm_gas_after_attaching_gas() {
     logic.gas((op_limit / 2) as u32).expect_err("should fail with gas limit");
     let outcome = logic.outcome();
 
-    assert!(outcome.used_gas == limit);
-    assert!(limit / 2 < outcome.burnt_gas && outcome.burnt_gas < limit);
+    assert_eq!(outcome.used_gas, limit);
+    assert!(limit / 2 < outcome.burnt_gas);
+    assert!(outcome.burnt_gas < limit);
+}
+
+#[test]
+fn test_cant_burn_more_than_max_gas_burnt_gas() {
+    let mut logic_builder = VMLogicBuilder::default();
+    let regular_op_cost = logic_builder.config.regular_op_cost;
+    let limit = logic_builder.config.limit_config.max_gas_burnt;
+    let op_limit = (limit / (regular_op_cost as u64)) as u32;
+    let mut context = get_context(vec![], false);
+    context.prepaid_gas = limit * 2;
+    let mut logic = logic_builder.build(context);
+
+    logic.gas(op_limit * 3).expect_err("should fail with gas limit");
+    let outcome = logic.outcome();
+
+    assert_eq!(outcome.burnt_gas, limit);
+}
+
+#[test]
+fn test_cant_burn_more_than_prepaid_gas() {
+    let mut logic_builder = VMLogicBuilder::default();
+    let regular_op_cost = logic_builder.config.regular_op_cost;
+    let limit = logic_builder.config.limit_config.max_gas_burnt;
+    let op_limit = (limit / (regular_op_cost as u64)) as u32;
+    let mut context = get_context(vec![], false);
+    context.prepaid_gas = limit / 2;
+    let mut logic = logic_builder.build(context);
+
+    logic.gas(op_limit).expect_err("should fail with gas limit");
+    let outcome = logic.outcome();
+
+    assert_eq!(outcome.burnt_gas, limit / 2);
 }

--- a/runtime/near-vm-logic/tests/test_gas_counter.rs
+++ b/runtime/near-vm-logic/tests/test_gas_counter.rs
@@ -4,73 +4,89 @@ mod vm_logic_builder;
 
 use fixtures::get_context;
 use helpers::*;
+use near_vm_logic::types::Gas;
+use near_vm_logic::{VMConfig, VMLogic};
 use vm_logic_builder::VMLogicBuilder;
 
 #[test]
 fn test_dont_burn_gas_when_exceeding_attached_gas_limit() {
-    let mut logic_builder = VMLogicBuilder::default();
-    let context = get_context(vec![], false);
-    let limit = context.prepaid_gas;
-    let mut logic = logic_builder.build(context);
+    let gas_limit = 10u64.pow(14);
+
+    let mut logic_builder = VMLogicBuilder::default().max_gas_burnt(gas_limit * 2);
+    let mut logic = logic_builder.build_with_prepaid_gas(gas_limit);
 
     let index = promise_create(&mut logic, b"rick.test", 0, 0).expect("should create a promise");
-    promise_batch_action_function_call(&mut logic, index, 0, limit * 2)
+    promise_batch_action_function_call(&mut logic, index, 0, gas_limit * 2)
         .expect_err("should fail with gas limit");
     let outcome = logic.outcome();
 
     // Just avoid hard-coding super-precise amount of gas burnt.
-    assert!(outcome.burnt_gas < limit / 2);
-    assert_eq!(outcome.used_gas, limit);
+    assert!(outcome.burnt_gas < gas_limit / 2);
+    assert_eq!(outcome.used_gas, gas_limit);
 }
 
 #[test]
 fn test_limit_wasm_gas_after_attaching_gas() {
-    let mut logic_builder = VMLogicBuilder::default();
-    let context = get_context(vec![], false);
-    let regular_op_cost = logic_builder.config.regular_op_cost;
-    let limit = context.prepaid_gas;
-    let op_limit = (limit / (regular_op_cost as u64)) as u32;
-    let mut logic = logic_builder.build(context);
+    let gas_limit = 10u64.pow(14);
+    let op_limit = op_limit(gas_limit);
+
+    let mut logic_builder = VMLogicBuilder::default().max_gas_burnt(gas_limit * 2);
+    let mut logic = logic_builder.build_with_prepaid_gas(gas_limit);
 
     let index = promise_create(&mut logic, b"rick.test", 0, 0).expect("should create a promise");
-    promise_batch_action_function_call(&mut logic, index, 0, limit / 2)
+    promise_batch_action_function_call(&mut logic, index, 0, gas_limit / 2)
         .expect("should add action to receipt");
     logic.gas((op_limit / 2) as u32).expect_err("should fail with gas limit");
     let outcome = logic.outcome();
 
-    assert_eq!(outcome.used_gas, limit);
-    assert!(limit / 2 < outcome.burnt_gas);
-    assert!(outcome.burnt_gas < limit);
+    assert_eq!(outcome.used_gas, gas_limit);
+    assert!(gas_limit / 2 < outcome.burnt_gas);
+    assert!(outcome.burnt_gas < gas_limit);
 }
 
 #[test]
 fn test_cant_burn_more_than_max_gas_burnt_gas() {
-    let mut logic_builder = VMLogicBuilder::default();
-    let regular_op_cost = logic_builder.config.regular_op_cost;
-    let limit = logic_builder.config.limit_config.max_gas_burnt;
-    let op_limit = (limit / (regular_op_cost as u64)) as u32;
-    let mut context = get_context(vec![], false);
-    context.prepaid_gas = limit * 2;
-    let mut logic = logic_builder.build(context);
+    let gas_limit = 10u64.pow(14);
+    let op_limit = op_limit(gas_limit);
 
-    logic.gas(op_limit * 3).expect_err("should fail with gas limit");
+    let mut logic_builder = VMLogicBuilder::default().max_gas_burnt(gas_limit);
+    let mut logic = logic_builder.build_with_prepaid_gas(gas_limit * 2);
+
+    logic.gas(op_limit * 2).expect_err("should fail with gas limit");
     let outcome = logic.outcome();
 
-    assert_eq!(outcome.burnt_gas, limit);
+    assert_eq!(outcome.burnt_gas, gas_limit);
 }
 
 #[test]
 fn test_cant_burn_more_than_prepaid_gas() {
-    let mut logic_builder = VMLogicBuilder::default();
-    let regular_op_cost = logic_builder.config.regular_op_cost;
-    let limit = logic_builder.config.limit_config.max_gas_burnt;
-    let op_limit = (limit / (regular_op_cost as u64)) as u32;
-    let mut context = get_context(vec![], false);
-    context.prepaid_gas = limit / 2;
-    let mut logic = logic_builder.build(context);
+    let gas_limit = 10u64.pow(14);
+    let op_limit = op_limit(gas_limit);
 
-    logic.gas(op_limit).expect_err("should fail with gas limit");
+    let mut logic_builder = VMLogicBuilder::default().max_gas_burnt(gas_limit * 2);
+    let mut logic = logic_builder.build_with_prepaid_gas(gas_limit);
+
+    logic.gas(op_limit * 2).expect_err("should fail with gas limit");
     let outcome = logic.outcome();
 
-    assert_eq!(outcome.burnt_gas, limit / 2);
+    assert_eq!(outcome.burnt_gas, gas_limit);
+}
+
+impl VMLogicBuilder {
+    fn max_gas_burnt(mut self, max_gas_burnt: Gas) -> Self {
+        self.config.limit_config.max_gas_burnt = max_gas_burnt;
+        self
+    }
+
+    fn build_with_prepaid_gas(&mut self, prepaid_gas: Gas) -> VMLogic<'_> {
+        let mut context = get_context(vec![], false);
+        context.prepaid_gas = prepaid_gas;
+        self.build(context)
+    }
+}
+
+/// Given the limit in gas, compute the corresponding limit in wasm ops for use
+/// with [`VMLogic::gas`] function.
+fn op_limit(gas_limit: Gas) -> u32 {
+    (gas_limit / (VMConfig::default().regular_op_cost as u64)) as u32
 }

--- a/runtime/near-vm-logic/tests/test_gas_counter.rs
+++ b/runtime/near-vm-logic/tests/test_gas_counter.rs
@@ -1,0 +1,43 @@
+mod fixtures;
+mod helpers;
+mod vm_logic_builder;
+
+use fixtures::get_context;
+use helpers::*;
+use vm_logic_builder::VMLogicBuilder;
+
+#[test]
+fn test_dont_burn_gas_when_exceeding_attached_gas_limit() {
+    let mut logic_builder = VMLogicBuilder::default();
+    let context = get_context(vec![], false);
+    let limit = context.prepaid_gas;
+    let mut logic = logic_builder.build(context);
+
+    let index = promise_create(&mut logic, b"rick.test", 0, 0).expect("should create a promise");
+    promise_batch_action_function_call(&mut logic, index, 0, limit * 2)
+        .expect_err("should fail with gas limit");
+    let outcome = logic.outcome();
+
+    // Just avoid hard-coding super-precise amount of gas burnt.
+    assert!(outcome.burnt_gas < limit / 2);
+    assert!(outcome.used_gas == limit);
+}
+
+#[test]
+fn test_limit_wasm_gas_after_attaching_gas() {
+    let mut logic_builder = VMLogicBuilder::default();
+    let context = get_context(vec![], false);
+    let regular_op_cost = logic_builder.config.regular_op_cost;
+    let limit = context.prepaid_gas;
+    let op_limit = limit / (regular_op_cost as u64);
+    let mut logic = logic_builder.build(context);
+
+    let index = promise_create(&mut logic, b"rick.test", 0, 0).expect("should create a promise");
+    promise_batch_action_function_call(&mut logic, index, 0, limit / 2)
+        .expect("should add action to receipt");
+    logic.gas((op_limit / 2) as u32).expect_err("should fail with gas limit");
+    let outcome = logic.outcome();
+
+    assert!(outcome.used_gas == limit);
+    assert!(limit / 2 < outcome.burnt_gas && outcome.burnt_gas < limit);
+}

--- a/runtime/near-vm-logic/tests/test_gas_counter.rs
+++ b/runtime/near-vm-logic/tests/test_gas_counter.rs
@@ -52,7 +52,7 @@ fn test_cant_burn_more_than_max_gas_burnt_gas() {
     let mut logic_builder = VMLogicBuilder::default().max_gas_burnt(gas_limit);
     let mut logic = logic_builder.build_with_prepaid_gas(gas_limit * 2);
 
-    logic.gas(op_limit * 2).expect_err("should fail with gas limit");
+    logic.gas(op_limit * 3).expect_err("should fail with gas limit");
     let outcome = logic.outcome();
 
     assert_eq!(outcome.burnt_gas, gas_limit);
@@ -66,7 +66,7 @@ fn test_cant_burn_more_than_prepaid_gas() {
     let mut logic_builder = VMLogicBuilder::default().max_gas_burnt(gas_limit * 2);
     let mut logic = logic_builder.build_with_prepaid_gas(gas_limit);
 
-    logic.gas(op_limit * 2).expect_err("should fail with gas limit");
+    logic.gas(op_limit * 3).expect_err("should fail with gas limit");
     let outcome = logic.outcome();
 
     assert_eq!(outcome.burnt_gas, gas_limit);

--- a/runtime/near-vm-logic/tests/test_promises.rs
+++ b/runtime/near-vm-logic/tests/test_promises.rs
@@ -66,42 +66,6 @@ fn test_promise_batch_action_function_call() {
 }
 
 #[test]
-fn test_dont_burn_gas_when_exceeding_attached_gas_limit() {
-    let mut logic_builder = VMLogicBuilder::default();
-    let context = get_context(vec![], false);
-    let limit = context.prepaid_gas;
-    let mut logic = logic_builder.build(context);
-
-    let index = promise_create(&mut logic, b"rick.test", 0, 0).expect("should create a promise");
-    promise_batch_action_function_call(&mut logic, index, 0, limit * 2)
-        .expect_err("should fail with gas limit");
-    let outcome = logic.outcome();
-
-    // Just avoid hard-coding super-precise amount of gas burnt.
-    assert!(outcome.burnt_gas < limit / 2);
-    assert!(outcome.used_gas == limit);
-}
-
-#[test]
-fn test_limit_wasm_gas_after_attaching_gas() {
-    let mut logic_builder = VMLogicBuilder::default();
-    let context = get_context(vec![], false);
-    let regular_op_cost = logic_builder.config.regular_op_cost;
-    let limit = context.prepaid_gas;
-    let op_limit = limit / (regular_op_cost as u64);
-    let mut logic = logic_builder.build(context);
-
-    let index = promise_create(&mut logic, b"rick.test", 0, 0).expect("should create a promise");
-    promise_batch_action_function_call(&mut logic, index, 0, limit / 2)
-        .expect("should add action to receipt");
-    logic.gas((op_limit / 2) as u32).expect_err("should fail with gas limit");
-    let outcome = logic.outcome();
-
-    assert!(outcome.used_gas == limit);
-    assert!(limit / 2 < outcome.burnt_gas && outcome.burnt_gas < limit);
-}
-
-#[test]
 fn test_promise_batch_action_create_account() {
     let mut logic_builder = VMLogicBuilder::default();
     let mut logic = logic_builder.build(get_context(vec![], false));


### PR DESCRIPTION
Add vm logic tests targeting gas counting logic specifically. In particular, `test_cant_burn_more_than_max_gas_burnt_gas` I believe passes the current master, but fails with #5121 (which passes all other tests). 