### PR TITLE
pytest: pin scipy to 1.7.1

### DIFF
--- a/pytest/requirements.txt
+++ b/pytest/requirements.txt
@@ -10,5 +10,8 @@ python-rc==0.3.9
 requests
 retrying
 scikit-learn
+# TODO(mina86): scipy 1.7.2 breaks buildkite so for the time being pin
+# to an older version.  Remove the pin once issue is fixed properly.
+scipy==1.7.1
 semver
 tqdm


### PR DESCRIPTION
scipy 1.7.2 causes buildkite to fail, see:
- https://buildkite.com/nearprotocol/nearcore/builds/6093#4a0ce8d7-f8c5-43ff-b0d6-db7343a84076 and
- https://buildkite.com/nearprotocol/nearcore/builds/6094#8a07e3cf-b646-447d-92e3-378846cab4b9

Pin to the last working version.
