### PR TITLE
Make RoutingTableActor use Contex instead of SyncContext.

### DIFF
--- a/chain/jsonrpc/jsonrpc-tests/src/lib.rs
+++ b/chain/jsonrpc/jsonrpc-tests/src/lib.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "test_features")]
-use actix::Actor;
 use actix::Addr;
 use futures::{future, future::LocalBoxFuture, FutureExt, TryFutureExt};
 use serde_json::json;
@@ -9,9 +7,9 @@ use near_client::test_utils::setup_no_network_with_validity_period_and_no_epoch_
 use near_client::ViewClientActor;
 use near_jsonrpc::{start_http, RpcConfig};
 use near_jsonrpc_primitives::message::{from_slice, Message};
-use near_network::test_utils::open_port;
 #[cfg(feature = "test_features")]
-use near_network::test_utils::{make_peer_manager, make_routing_table_actor};
+use near_network::test_utils::make_peer_manager_routing_table_addr_pair;
+use near_network::test_utils::open_port;
 use near_primitives::types::NumBlocks;
 
 lazy_static::lazy_static! {
@@ -48,17 +46,7 @@ pub fn start_all_with_validity_period_and_no_epoch_sync(
     let addr = format!("127.0.0.1:{}", open_port());
 
     #[cfg(feature = "test_features")]
-    let routing_table_addr = make_routing_table_actor();
-    #[cfg(feature = "test_features")]
-    let peer_manager_addr = make_peer_manager(
-        "test2",
-        open_port(),
-        vec![("test1", open_port())],
-        10,
-        routing_table_addr.clone(),
-    )
-    .0
-    .start();
+    let (peer_manager_addr, routing_table_addr) = make_peer_manager_routing_table_addr_pair();
 
     start_http(
         RpcConfig::new(&addr),

--- a/chain/network/src/lib.rs
+++ b/chain/network/src/lib.rs
@@ -20,7 +20,7 @@ mod peer_manager;
 pub mod peer_store;
 mod rate_counter;
 pub mod routing;
-mod routing_table_actor;
+pub mod routing_table_actor;
 pub mod test_utils;
 pub mod types;
 pub mod utils;

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -148,7 +148,7 @@ pub struct PeerManagerActor {
     /// Dynamic Prometheus metrics
     network_metrics: NetworkMetrics,
     edge_verifier_pool: Addr<EdgeVerifierActor>,
-    routing_table_pool: Addr<RoutingTableActor>,
+    routing_table_addr: Addr<RoutingTableActor>,
     txns_since_last_block: Arc<AtomicUsize>,
     pending_incoming_connections_counter: Arc<AtomicUsize>,
     peer_counter: Arc<AtomicUsize>,
@@ -201,7 +201,7 @@ impl PeerManagerActor {
             pending_update_nonce_request: HashMap::new(),
             network_metrics: NetworkMetrics::new(),
             edge_verifier_pool,
-            routing_table_pool: routing_table_addr,
+            routing_table_addr: routing_table_addr,
             txns_since_last_block,
             pending_incoming_connections_counter: Arc::new(AtomicUsize::new(0)),
             peer_counter: Arc::new(AtomicUsize::new(0)),
@@ -225,7 +225,7 @@ impl PeerManagerActor {
     ) {
         let edges_to_remove =
             self.routing_table.recalculate_routing_table(can_save_edges, force_pruning, timeout);
-        self.routing_table_pool
+        self.routing_table_addr
             .send(RoutingTableMessages::RemoveEdges(edges_to_remove))
             .into_actor(self)
             .map(|_, _, _| ())
@@ -350,7 +350,7 @@ impl PeerManagerActor {
     ) {
         near_performance_metrics::actix::run_later(ctx, WAIT_FOR_SYNC_DELAY, move |act, ctx| {
             if peer_type == PeerType::Inbound {
-                act.routing_table_pool
+                act.routing_table_addr
                     .send(RoutingTableMessages::AddPeerIfMissing(peer_id, None))
                     .into_actor(act)
                     .map(move |response, act, ctx| match response {
@@ -441,7 +441,7 @@ impl PeerManagerActor {
             }
         );
         near_performance_metrics::actix::run_later(ctx, WAIT_FOR_SYNC_DELAY, move |act, ctx| {
-            act.routing_table_pool
+            act.routing_table_addr
                 .send(RoutingTableMessages::RequestRoutingTable)
                 .into_actor(act)
                 .map(move |response, act, ctx| match response {
@@ -527,7 +527,7 @@ impl PeerManagerActor {
         self.active_peers.remove(&peer_id);
 
         #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
-        self.routing_table_pool
+        self.routing_table_addr
             .send(RoutingTableMessages::RemovePeer(peer_id.clone()))
             .into_actor(self)
             .map(|_, _, _| ())
@@ -779,7 +779,7 @@ impl PeerManagerActor {
     ) -> bool {
         let ProcessEdgeResult { new_edge, edges } =
             self.routing_table.add_verified_edges_to_routing_table(edges);
-        self.routing_table_pool
+        self.routing_table_addr
             .send(RoutingTableMessages::AddEdges(edges))
             .into_actor(self)
             .map(|_, _, _| ())
@@ -833,7 +833,7 @@ impl PeerManagerActor {
             })
             .collect();
         self.routing_table.remove_edges(&edges);
-        self.routing_table_pool
+        self.routing_table_addr
             .send(RoutingTableMessages::RemoveEdges(edges))
             .into_actor(self)
             .map(|_, _, _| ())
@@ -1477,7 +1477,7 @@ impl Actor for PeerManagerActor {
             .then(move |_, _, _| actix::fut::ready(()))
             .spawn(ctx);
 
-        self.routing_table_pool
+        self.routing_table_addr
             .send(StopMsg {})
             .into_actor(self)
             .then(move |_, _, _| actix::fut::ready(()))
@@ -2294,7 +2294,7 @@ impl PeerManagerActor {
         let mut edges: Vec<Edge> = Vec::new();
         swap(&mut edges, &mut ibf_msg.edges);
         self.verify_edges(ctx, peer_id.clone(), edges);
-        self.routing_table_pool
+        self.routing_table_addr
             .send(RoutingTableMessages::ProcessIbfMessage { peer_id: peer_id.clone(), ibf_msg })
             .into_actor(self)
             .map(move |response, _act: &mut PeerManagerActor, _ctx| match response {

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -365,7 +365,7 @@ impl PeerManagerActor {
     }
     #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
     fn start_routing_table_syncv2(&self, ctx: &mut Context<Self>, addr: Addr<Peer>, seed: u64) {
-        self.routing_table_pool
+        self.routing_table_addr
             .send(RoutingTableMessages::StartRoutingTableSync { seed })
             .into_actor(self)
             .map(move |response, _act, _ctx| match response {

--- a/chain/network/src/routing_table_actor.rs
+++ b/chain/network/src/routing_table_actor.rs
@@ -126,6 +126,7 @@ impl RoutingTableActor {
 
 impl RoutingTableActor {
     pub fn new(_my_peer_id: PeerId, _store: Arc<Store>) -> Self {
+        // Those areguments are for future use, will be used when we merge #5089
         Self {
             edges_info: Default::default(),
             #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]

--- a/chain/network/src/test_utils.rs
+++ b/chain/network/src/test_utils.rs
@@ -19,9 +19,11 @@ use near_primitives::hash::hash;
 use near_primitives::network::PeerId;
 use near_primitives::types::EpochId;
 use near_primitives::utils::index_to_bytes;
+#[cfg(feature = "test_features")]
 use near_store::test_utils::create_test_store;
 use near_store::Store;
 
+#[cfg(feature = "test_features")]
 use crate::routing_table_actor::start_routing_table_actor;
 use crate::types::{
     NetworkInfo, NetworkViewClientMessages, NetworkViewClientResponses, PeerInfo,
@@ -283,7 +285,9 @@ impl MockPeerManagerAdapter {
     }
 }
 
-#[allow(dead_code)]
+// Start PeerManagerActor, and RoutingTableActor together and returns pairs of addresses
+// for each of them.
+#[cfg(feature = "test_features")]
 pub fn make_peer_manager_routing_table_addr_pair(
 ) -> (Addr<PeerManagerActor>, Addr<RoutingTableActor>) {
     let seed = "test2";

--- a/integration-tests/tests/network/infinite_loop.rs
+++ b/integration-tests/tests/network/infinite_loop.rs
@@ -9,9 +9,9 @@ use futures::{future, FutureExt};
 use near_actix_test_utils::run_actix;
 use near_client::ClientActor;
 use near_logger_utils::init_integration_logger;
-use near_network::test_utils::{
-    convert_boot_nodes, make_routing_table_actor, open_port, GetInfo, WaitOrTimeout,
-};
+
+use near_network::routing_table_actor::start_routing_table_actor;
+use near_network::test_utils::{convert_boot_nodes, open_port, GetInfo, WaitOrTimeout};
 use near_network::types::{
     NetworkViewClientMessages, NetworkViewClientResponses, PeerManagerMessageRequest, SyncData,
 };
@@ -61,7 +61,11 @@ pub fn make_peer_manager(
         }
     }))
     .start();
-    let routing_table_addr = make_routing_table_actor();
+
+    let net_config = NetworkConfig::from_seed(seed, port);
+    let routing_table_addr =
+        start_routing_table_actor(net_config.public_key.clone().into(), store.clone());
+
     let peer_id = config.public_key.clone().into();
     (
         PeerManagerActor::new(

--- a/integration-tests/tests/network/peer_handshake.rs
+++ b/integration-tests/tests/network/peer_handshake.rs
@@ -12,9 +12,9 @@ use futures::{future, FutureExt};
 use near_actix_test_utils::run_actix;
 use near_client::{ClientActor, ViewClientActor};
 use near_logger_utils::init_test_logger;
-use near_network::test_utils::{
-    convert_boot_nodes, make_routing_table_actor, open_port, GetInfo, StopSignal, WaitOrTimeout,
-};
+
+use near_network::routing_table_actor::start_routing_table_actor;
+use near_network::test_utils::{convert_boot_nodes, open_port, GetInfo, StopSignal, WaitOrTimeout};
 use near_network::types::{NetworkViewClientMessages, NetworkViewClientResponses};
 use near_network::{NetworkClientResponses, NetworkConfig, PeerManagerActor};
 use near_store::test_utils::create_test_store;
@@ -52,7 +52,9 @@ fn make_peer_manager(
         }
     }))
     .start();
-    let routing_table_addr = make_routing_table_actor();
+    let routing_table_addr =
+        start_routing_table_actor(config.public_key.clone().into(), store.clone());
+
     PeerManagerActor::new(
         store,
         config,

--- a/integration-tests/tests/network/stress_network.rs
+++ b/integration-tests/tests/network/stress_network.rs
@@ -10,9 +10,9 @@ use tracing::info;
 use near_actix_test_utils::run_actix;
 use near_client::{ClientActor, ViewClientActor};
 use near_logger_utils::init_test_logger_allow_panic;
-use near_network::test_utils::{
-    convert_boot_nodes, make_routing_table_actor, open_port, GetInfo, StopSignal, WaitOrTimeout,
-};
+
+use near_network::routing_table_actor::start_routing_table_actor;
+use near_network::test_utils::{convert_boot_nodes, open_port, GetInfo, StopSignal, WaitOrTimeout};
 use near_network::types::{NetworkViewClientMessages, NetworkViewClientResponses};
 use near_network::{NetworkClientResponses, NetworkConfig, PeerManagerActor};
 use near_store::test_utils::create_test_store;
@@ -43,7 +43,10 @@ fn make_peer_manager(seed: &str, port: u16, boot_nodes: Vec<(&str, u16)>) -> Pee
         }
     }))
     .start();
-    let routing_table_addr = make_routing_table_actor();
+    let net_config = NetworkConfig::from_seed(seed, port);
+    let routing_table_addr =
+        start_routing_table_actor(net_config.public_key.clone().into(), store.clone());
+
     PeerManagerActor::new(
         store,
         config,

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -13,6 +13,7 @@ use near_chain::ChainGenesis;
 #[cfg(feature = "test_features")]
 use near_client::AdversarialControls;
 use near_client::{start_client, start_view_client, ClientActor, ViewClientActor};
+use near_network::routing_table_actor::start_routing_table_actor;
 use near_network::{NetworkRecipient, PeerManagerActor};
 #[cfg(feature = "rosetta_rpc")]
 use near_rosetta_rpc::start_rosetta_rpc;
@@ -35,7 +36,6 @@ use crate::migrations::{
 };
 pub use crate::runtime::NightshadeRuntime;
 pub use crate::shard_tracker::TrackedConfig;
-use near_network::test_utils::make_routing_table_actor;
 
 pub mod append_only_map;
 pub mod config;
@@ -344,7 +344,8 @@ pub fn start_with_config(home_dir: &Path, config: NearConfig) -> NearNode {
     let view_client1 = view_client.clone().recipient();
     config.network_config.verify();
     let network_config = config.network_config;
-    let routing_table_addr = make_routing_table_actor();
+    let routing_table_addr =
+        start_routing_table_actor(network_config.public_key.clone().into(), store.clone());
     #[cfg(all(feature = "json_rpc", feature = "test_features"))]
     let routing_table_addr2 = routing_table_addr.clone();
     let network_actor = PeerManagerActor::start_in_arbiter(&arbiter.handle(), move |_ctx| {


### PR DESCRIPTION
Make `RoutingTableActor` use Context instead of `SyncContext`.
`SyncContext` is meant to be used in situations, where someone wants to start multiple instances of actors, each one separate thread. We only have one instance, and the code wouldn't work with multiple instances, so we are changing `SyncContext` to `Context`, to make reading code less confusion.


Additional changes:
- Add `edge_verifier_pool` to `RoutingTableActor` (for https://github.com/near/nearcore/pull/5089)
- Rename `routing_table_pool` to `routing_table_addr`

Changes are extracted from https://github.com/near/nearcore/pull/5089 to make it easier to review.
