### PR TITLE
Add new features to RoutingTableActor

### DIFF
--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -363,6 +363,7 @@ impl PeerManagerActor {
             }
         });
     }
+
     #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
     fn start_routing_table_syncv2(&self, ctx: &mut Context<Self>, addr: Addr<Peer>, seed: u64) {
         self.routing_table_addr

--- a/chain/network/src/routing.rs
+++ b/chain/network/src/routing.rs
@@ -922,6 +922,10 @@ impl Graph {
         res
     }
 
+    pub fn my_peer_id(&self) -> &PeerId {
+        &self.my_peer_id
+    }
+
     pub fn total_active_edges(&self) -> u64 {
         self.total_active_edges
     }

--- a/chain/network/src/routing_table_actor.rs
+++ b/chain/network/src/routing_table_actor.rs
@@ -159,7 +159,7 @@ impl RoutingTableActor {
 
         // Update metrics after edge update
         near_metrics::inc_counter_by(&metrics::EDGE_UPDATES, total as u64);
-        near_metrics::set_gauge(&metrics::EDGE_ACTIVE, self.raw_graph.total_active_edges as i64);
+        near_metrics::set_gauge(&metrics::EDGE_ACTIVE, self.raw_graph.total_active_edges() as i64);
 
         edges
     }
@@ -219,7 +219,7 @@ impl RoutingTableActor {
     }
 
     fn my_peer_id(&self) -> &PeerId {
-        &self.raw_graph.source
+        &self.raw_graph.my_peer_id()
     }
 
     /// Recalculate routing table and update list of reachable peers.

--- a/chain/network/src/routing_table_actor.rs
+++ b/chain/network/src/routing_table_actor.rs
@@ -54,7 +54,8 @@ pub struct RoutingTableActor {
     /// Data structure used for exchanging routing tables.
     #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
     pub peer_ibf_set: IbfPeerSet,
-    /// Current view of the network. Nodes are Peers and edges are active connections.
+    /// Current view of the network represented by undirected graph.
+    /// Nodes are Peers and edges are active connections.
     pub raw_graph: Graph,
     /// Active PeerId that are part of the shortest path to each PeerId.
     pub peer_forwarding: Arc<HashMap<PeerId, Vec<PeerId>>>,

--- a/chain/network/src/routing_table_actor.rs
+++ b/chain/network/src/routing_table_actor.rs
@@ -115,7 +115,8 @@ impl RoutingTableActor {
         }
     }
 
-    /// `add_verified_edge` add edges that have already been verified.
+    /// `add_verified_edge` adds edges, for which we already that theirs signatures
+    /// are valid (`signature0`, `signature`).
     fn add_verified_edge(&mut self, edge: Edge) -> bool {
         let key = edge.get_pair();
         if !self.is_edge_newer(&key, edge.nonce) {

--- a/chain/network/src/routing_table_actor.rs
+++ b/chain/network/src/routing_table_actor.rs
@@ -279,7 +279,7 @@ impl RoutingTableActor {
         }
         debug!(target: "network", "try_save_edges: We are going to remove {} peers", peers_to_remove.len());
 
-        let old_component_nonce = self.next_available_component_nonce;
+        let current_component_nonce = self.next_available_component_nonce;
         self.next_available_component_nonce += 1;
 
         let mut update = self.store.store_update();
@@ -292,13 +292,13 @@ impl RoutingTableActor {
             let _ = update.set_ser(
                 ColPeerComponent,
                 Vec::from(peer_id.clone()).as_ref(),
-                &old_component_nonce,
+                &current_component_nonce,
             );
 
             self.peer_last_time_reachable.remove(peer_id);
         }
 
-        let component_nonce = index_to_bytes(old_component_nonce);
+        let component_nonce = index_to_bytes(current_component_nonce);
         let edges_to_remove = self
             .edges_info
             .iter()

--- a/chain/network/src/routing_table_actor.rs
+++ b/chain/network/src/routing_table_actor.rs
@@ -62,7 +62,7 @@ pub struct RoutingTableActor {
     pub peer_last_time_reachable: HashMap<PeerId, Instant>,
     /// Everytime a group of peers becomes unreachable at the same time; We store edges belonging to
     /// them in components. We remove all of those edges from memory, and save them to database,
-    /// If any of them were to be reachable again, we would re-add them.
+    /// If any of them become reachable again, we re-add whole component.
     ///
     /// To store components, we have following column in the DB.
     /// ColLastComponentNonce -> stores component_nonce: u64, which is the lowest nonce that

--- a/chain/network/src/routing_table_actor.rs
+++ b/chain/network/src/routing_table_actor.rs
@@ -393,6 +393,9 @@ pub enum RoutingTableMessages {
     // Remove edges. (Will be removed soon).
     RemoveEdges(Vec<Edge>),
     // Add verified edges to routing table actor and update stats.
+    // Each edge contains signature of both peers.
+    // We say that the edge is "verified" if and only if we checked that the `signature0` and
+    // `signature1` is valid.
     AddVerifiedEdges {
         edges: Vec<Edge>,
     },

--- a/chain/network/src/routing_table_actor.rs
+++ b/chain/network/src/routing_table_actor.rs
@@ -58,7 +58,7 @@ pub struct RoutingTableActor {
     pub raw_graph: Graph,
     /// Active PeerId that are part of the shortest path to each PeerId.
     pub peer_forwarding: Arc<HashMap<PeerId, Vec<PeerId>>>,
-    /// Last time a peer was reachable through with active edges.
+    /// Last time a peer was reachable through active edges.
     pub peer_last_time_reachable: HashMap<PeerId, Instant>,
     /// Everytime a group of peers becomes unreachable at the same time; We store edges belonging to
     /// them in components. We remove all of those edges from memory, and save them do database,

--- a/chain/network/src/routing_table_actor.rs
+++ b/chain/network/src/routing_table_actor.rs
@@ -32,8 +32,8 @@ use std::time::{Duration, Instant};
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum Prune {
-    Allow,
-    Force,
+    PruneOncePerHour,
+    PruneNow,
     Disable,
 }
 
@@ -49,7 +49,7 @@ pub enum Prune {
 ///   - store removed edges to disk
 ///   - we currently don't store active edges to disk
 pub struct RoutingTableActor {
-    /// Data structure with all edges.
+    /// Data structure with all edges. It's guaranteed that `peer.0` < `peer.1`.
     pub edges_info: HashMap<(PeerId, PeerId), Edge>,
     /// Data structure used for exchanging routing tables.
     #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
@@ -240,7 +240,7 @@ impl RoutingTableActor {
 
         let edges_to_remove = if prune != Prune::Disable {
             self.prune_unreachable_edges_and_save_to_db(
-                prune == Prune::Force,
+                prune == Prune::PruneNow,
                 prune_edges_not_reachable_for,
             )
         } else {

--- a/chain/network/src/routing_table_actor.rs
+++ b/chain/network/src/routing_table_actor.rs
@@ -61,7 +61,7 @@ pub struct RoutingTableActor {
     /// Last time a peer was reachable through active edges.
     pub peer_last_time_reachable: HashMap<PeerId, Instant>,
     /// Everytime a group of peers becomes unreachable at the same time; We store edges belonging to
-    /// them in components. We remove all of those edges from memory, and save them do database,
+    /// them in components. We remove all of those edges from memory, and save them to database,
     /// If any of them were to be reachable again, we would re-add them.
     ///
     /// To store components, we have following column in the DB.

--- a/chain/network/src/routing_table_actor.rs
+++ b/chain/network/src/routing_table_actor.rs
@@ -511,6 +511,8 @@ impl Handler<RoutingTableMessages> for RoutingTableActor {
                 };
                 self.needs_routing_table_recalculation = false;
                 RoutingTableMessagesResponse::RoutingTableUpdateResponse {
+                    // PeerManager maintains list of local edges. We will notify `PeerManager`
+                    // to remove those edges.
                     edges_to_remove: edges_removed
                         .iter()
                         .filter(|p| p.contains_peer(&self.my_peer_id()))

--- a/chain/network/src/routing_table_actor.rs
+++ b/chain/network/src/routing_table_actor.rs
@@ -30,17 +30,21 @@ use near_store::{Store, StoreUpdate};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+/// `Prune` enum is to specify how often should we prune edges.
 #[derive(Debug, Eq, PartialEq)]
 pub enum Prune {
+    /// Prune once per hour - default.
     PruneOncePerHour,
+    /// Prune right now - for testing purposes.
     PruneNow,
+    /// Don't prune at all.
     Disable,
 }
 
 /// RoutingTableActor that maintains routing table information. We currently have only one
 /// instance of this actor.
 ///
-/// We store following information
+/// We store the following information
 ///   - list of all known edges
 ///   - helper data structure for exchanging routing table
 ///   - routing information (where a message should be send to reach given peer)


### PR DESCRIPTION
Add new features to routing table actor.

- do edge pruning (not used yet)
- store all edges in `edges_info`
-  `StartRoutingTableSync` (handling first message of protocol_feature_routing_exchange_algorithm)  (not yet used)
-  `RoutingTableUpdate` (updating routing table and maybe pruning edges) (not yet used)
-  `AddVerifiedEdges` - adds verified edges and updates stats (Similar to `AddEdges`, but does more) (not yet used)

This is done to split https://github.com/near/nearcore/pull/5089 into smaller pieces.
This should be reviewed after https://github.com/near/nearcore/pull/5159, as this PR also includes changes in that request.