### PR TITLE
Prevent crash in stats_enabled.rs

### DIFF
--- a/utils/near-performance-metrics/src/stats_enabled.rs
+++ b/utils/near-performance-metrics/src/stats_enabled.rs
@@ -324,8 +324,10 @@ where
 
     let took = now.elapsed();
 
-    let peak_memory =
-        ByteSize::b((current_thread_peak_memory_usage() - initial_memory_usage) as u64);
+    let peak_memory = ByteSize::b(
+        (max(initial_memory_usage, current_thread_peak_memory_usage()) - initial_memory_usage)
+            as u64,
+    );
 
     if peak_memory >= ByteSize::b(MEMORY_LIMIT) {
         warn!(

--- a/utils/near-performance-metrics/src/stats_enabled.rs
+++ b/utils/near-performance-metrics/src/stats_enabled.rs
@@ -324,10 +324,8 @@ where
 
     let took = now.elapsed();
 
-    let peak_memory = ByteSize::b(
-        (max(initial_memory_usage, current_thread_peak_memory_usage()) - initial_memory_usage)
-            as u64,
-    );
+    let peak_memory =
+        ByteSize::b(current_thread_peak_memory_usage().saturating_sub(initial_memory_usage) as u64);
 
     if peak_memory >= ByteSize::b(MEMORY_LIMIT) {
         warn!(


### PR DESCRIPTION
We saw a node crash in `stats_enabled.rs`. This PR will prevent those crashes from happening.


```
    let peak_memory =
        ByteSize::b((max(initial_memory_usage, current_thread_peak_memory_usage() - initial_memory_usage) as u64);
```

```
thread 'actix-rt|system:0|arbiter:0' panicked at 'attempt to subtract with overflow', /var/lib/buildkite-agent/builds/buildkite-i-05f8afe8aa72d3ae8-1/nearprotocol/nearcore-nightly-release/utils/near-performance-metrics/src/stats_enabled.rs:328:21
stack backtrace:
   0: rust_begin_unwind
             at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/std/src/panicking.rs:517:5
   1: core::panicking::panic_fmt
             at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/core/src/panicking.rs:101:14
   2: core::panicking::panic
             at /rustc/09c42c45858d5f3aedfa670698275303a3d19afa/library/core/src/panicking.rs:50:5
   3: <near_network::peer_manager::PeerManagerActor as actix::handler::Handler<near_network::types::PeerManagerMessageRequest>>::handle
   4: <actix::contextitems::ActorMessageItem<A,M> as actix::fut::ActorFuture>::poll
   5: <actix::contextimpl::ContextFut<A,C> as core::future::future::Future>::poll
   6: tokio::runtime::task::raw::poll
   7: tokio::task::local::LocalSet::tick
   8: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```