### PR TITLE
runtime: simplify prepaid gas accounting in view calls

### DIFF
--- a/runtime/near-vm-logic/src/gas_counter.rs
+++ b/runtime/near-vm-logic/src/gas_counter.rs
@@ -91,6 +91,9 @@ impl GasCounter {
         }
     }
 
+    /// Accounts for burnt and used gas; reports an error if max gas burnt or
+    /// prepaid gas limit is crossed.  Panics when trying to burn more gas than
+    /// being used, i.e. if `burn_gas > use_gas`.
     fn deduct_gas(&mut self, burn_gas: Gas, use_gas: Gas) -> Result<()> {
         assert!(burn_gas <= use_gas);
         let promise_gas = use_gas - burn_gas;

--- a/runtime/near-vm-logic/src/gas_counter.rs
+++ b/runtime/near-vm-logic/src/gas_counter.rs
@@ -262,8 +262,8 @@ impl GasCounter {
 
 #[cfg(test)]
 mod tests {
-    use near_primitives_core::types::Gas;
     use crate::HostError;
+    use near_primitives_core::types::Gas;
 
     fn test_counter(max_burnt: Gas, prepaid: Gas, is_view: bool) -> super::GasCounter {
         super::GasCounter::new(Default::default(), max_burnt, 1, prepaid, is_view)

--- a/runtime/near-vm-logic/src/gas_counter.rs
+++ b/runtime/near-vm-logic/src/gas_counter.rs
@@ -268,13 +268,13 @@ mod tests {
     use crate::HostError;
     use near_primitives_core::types::Gas;
 
-    fn test_counter(max_burnt: Gas, prepaid: Gas, is_view: bool) -> super::GasCounter {
+    fn make_test_counter(max_burnt: Gas, prepaid: Gas, is_view: bool) -> super::GasCounter {
         super::GasCounter::new(Default::default(), max_burnt, 1, prepaid, is_view)
     }
 
     #[test]
     fn test_deduct_gas() {
-        let mut counter = test_counter(10, 10, false);
+        let mut counter = make_test_counter(10, 10, false);
         counter.deduct_gas(5, 10).expect("deduct_gas should work");
         assert_eq!(counter.burnt_gas(), 5);
         assert_eq!(counter.used_gas(), 10);
@@ -283,14 +283,19 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_burn_gas_must_be_lt_use_gas() {
-        let _ = test_counter(10, 10, false).deduct_gas(5, 2);
-        let _ = test_counter(10, 10, true).deduct_gas(5, 2);
+        let _ = make_test_counter(10, 10, false).deduct_gas(5, 2);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_burn_gas_must_be_lt_use_gas_view() {
+        let _ = make_test_counter(10, 10, true).deduct_gas(5, 2);
     }
 
     #[test]
     fn test_burn_too_much() {
         fn test(burn: Gas, prepaid: Gas, view: bool, want: Result<(), HostError>) {
-            let mut counter = test_counter(burn, prepaid, view);
+            let mut counter = make_test_counter(burn, prepaid, view);
             assert_eq!(counter.burn_gas(5), Ok(()));
             assert_eq!(counter.burn_gas(3), want.map_err(Into::into));
         }
@@ -306,7 +311,7 @@ mod tests {
     #[test]
     fn test_deduct_too_much() {
         fn test(burn: Gas, prepaid: Gas, view: bool, want: Result<(), HostError>) {
-            let mut counter = test_counter(burn, prepaid, view);
+            let mut counter = make_test_counter(burn, prepaid, view);
             assert_eq!(counter.deduct_gas(5, 5), Ok(()));
             assert_eq!(counter.deduct_gas(3, 3), want.map_err(Into::into));
         }


### PR DESCRIPTION
Rather than special casing view calls each time prepaid gas is
checked, simply assume that prepaid gas is effectively infinite.  The
max gas burnt limit will still have an effect.

This fixes `sanity/rpc_max_gas_burnt.py` pytest which has been broken
by the recent ‘Simplify gas metering’ commit.  The commit changed
GasLimitExceeded failure into GasExceeded (by changing order in which
error conditions were checked).  This commit changes this back by
effectively disabling the first if branch in `process_gas_limit`
function when performing a view call.