### PR TITLE
Fix `tests/sanity/routing_table_sync.py`test

### DIFF
--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -516,10 +516,13 @@ impl Handler<RoutingTableMessages> for RoutingTableActor {
                 )
             }
             RoutingTableMessages::RoutingTableUpdate { prune, prune_edges_not_reachable_for } => {
-                if self.needs_routing_table_recalculation {
-                    self.recalculate_routing_table();
-                }
-                let edges_removed = self.prune_edges(prune, prune_edges_not_reachable_for);
+                let edges_removed =
+                    if self.needs_routing_table_recalculation || prune == Prune::PruneNow {
+                        self.recalculate_routing_table();
+                        self.prune_edges(prune, prune_edges_not_reachable_for)
+                    } else {
+                        Vec::new()
+                    };
                 self.needs_routing_table_recalculation = false;
                 RoutingTableMessagesResponse::RoutingTableUpdateResponse {
                     // PeerManager maintains list of local edges. We will notify `PeerManager`

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -518,12 +518,12 @@ impl Handler<RoutingTableMessages> for RoutingTableActor {
             RoutingTableMessages::RoutingTableUpdate { prune, prune_edges_not_reachable_for } => {
                 let edges_removed =
                     if self.needs_routing_table_recalculation || prune == Prune::PruneNow {
+                        self.needs_routing_table_recalculation = false;
                         self.recalculate_routing_table();
                         self.prune_edges(prune, prune_edges_not_reachable_for)
                     } else {
                         Vec::new()
                     };
-                self.needs_routing_table_recalculation = false;
                 RoutingTableMessagesResponse::RoutingTableUpdateResponse {
                     // PeerManager maintains list of local edges. We will notify `PeerManager`
                     // to remove those edges.

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -511,14 +511,15 @@ impl Handler<RoutingTableMessages> for RoutingTableActor {
                 )
             }
             RoutingTableMessages::RoutingTableUpdate { prune, prune_edges_not_reachable_for } => {
-                let edges_removed = if self.needs_routing_table_recalculation {
-                    self.recalculate_routing_table_and_maybe_prune_edges(
-                        prune,
-                        prune_edges_not_reachable_for,
-                    )
-                } else {
-                    Vec::new()
-                };
+                let edges_removed =
+                    if self.needs_routing_table_recalculation || prune == Prune::PruneNow {
+                        self.recalculate_routing_table_and_maybe_prune_edges(
+                            prune,
+                            prune_edges_not_reachable_for,
+                        )
+                    } else {
+                        Vec::new()
+                    };
                 self.needs_routing_table_recalculation = false;
                 RoutingTableMessagesResponse::RoutingTableUpdateResponse {
                     // PeerManager maintains list of local edges. We will notify `PeerManager`

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -242,11 +242,6 @@ impl RoutingTableActor {
 
         self.peer_forwarding = Arc::new(self.raw_graph.calculate_distance());
 
-        let now = Instant::now();
-        for peer in self.peer_forwarding.keys() {
-            self.peer_last_time_reachable.insert(peer.clone(), now);
-        }
-
         near_metrics::inc_counter_by(&metrics::ROUTING_TABLE_RECALCULATIONS, 1);
         near_metrics::set_gauge(&metrics::PEER_REACHABLE, self.peer_forwarding.len() as i64);
     }
@@ -263,6 +258,11 @@ impl RoutingTableActor {
         if prune == Prune::Disable {
             return Vec::new();
         }
+        let now = Instant::now();
+        for peer in self.peer_forwarding.keys() {
+            self.peer_last_time_reachable.insert(peer.clone(), now);
+        }
+
         #[cfg(feature = "delay_detector")]
         let _d = DelayDetector::new("pruning edges".into());
 

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -271,6 +271,7 @@ impl RoutingTableActor {
             prune_edges_not_reachable_for,
         );
         self.remove_edges(&edges_to_remove);
+        near_metrics::set_gauge(&metrics::PEER_REACHABLE, self.peer_forwarding.len() as i64);
         edges_to_remove
     }
 

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -271,7 +271,6 @@ impl RoutingTableActor {
             prune_edges_not_reachable_for,
         );
         self.remove_edges(&edges_to_remove);
-        near_metrics::set_gauge(&metrics::PEER_REACHABLE, self.peer_forwarding.len() as i64);
         edges_to_remove
     }
 

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -242,12 +242,13 @@ impl RoutingTableActor {
 
         self.peer_forwarding = Arc::new(self.raw_graph.calculate_distance());
 
-        near_metrics::inc_counter_by(&metrics::ROUTING_TABLE_RECALCULATIONS, 1);
-        near_metrics::set_gauge(&metrics::PEER_REACHABLE, self.peer_forwarding.len() as i64);
         let now = Instant::now();
         for peer in self.peer_forwarding.keys() {
             self.peer_last_time_reachable.insert(peer.clone(), now);
         }
+
+        near_metrics::inc_counter_by(&metrics::ROUTING_TABLE_RECALCULATIONS, 1);
+        near_metrics::set_gauge(&metrics::PEER_REACHABLE, self.peer_forwarding.len() as i64);
     }
 
     /// If pruning is enabled we will remove unused edges and store them to disk.

--- a/chain/network/tests/cache_edges.rs
+++ b/chain/network/tests/cache_edges.rs
@@ -166,10 +166,8 @@ impl RoutingTableTest {
     }
 
     fn update_routing_table(&mut self) {
-        self.routing_table.recalculate_routing_table_and_maybe_prune_edges(
-            Prune::PruneOncePerHour,
-            DELETE_PEERS_AFTER_TIME,
-        );
+        self.routing_table.recalculate_routing_table();
+        self.routing_table.prune_edges(Prune::PruneOncePerHour, DELETE_PEERS_AFTER_TIME);
     }
 }
 


### PR DESCRIPTION
`tests/sanity/routing_table_sync.py` test wasn't fully fixed.

We were not pruning while `prune == Prune::PruneNow`, because no routing table calculation was done.

This PR fixed the test properly.

The bug was in not having ```prune == Prune::PruneNow ``` check. In this PR we will improve code quality as well, and split `recalculate_routing_table_and_maybe_prune_edges` into to separate methods.