### PR TITLE
Add extra logs to investigate issues

### DIFF
--- a/chain/network/src/routing/route_back_cache.rs
+++ b/chain/network/src/routing/route_back_cache.rs
@@ -199,9 +199,9 @@ impl RouteBackCache {
         }
     }
 
-    pub fn insert(&mut self, hash: CryptoHash, target: PeerId) {
+    pub fn insert(&mut self, hash: CryptoHash, target: PeerId) -> bool {
         if self.main.contains_key(&hash) {
-            return;
+            return false;
         }
 
         self.remove_evicted();
@@ -220,6 +220,7 @@ impl RouteBackCache {
 
         size += 1;
         self.size_per_target.insert((self.capacity - size, target));
+        true
     }
 }
 

--- a/chain/network/src/routing/routing.rs
+++ b/chain/network/src/routing/routing.rs
@@ -513,8 +513,8 @@ impl RoutingTableView {
         }
     }
 
-    pub fn add_route_back(&mut self, hash: CryptoHash, peer_id: PeerId) {
-        self.route_back.insert(hash, peer_id);
+    pub fn add_route_back(&mut self, hash: CryptoHash, peer_id: PeerId) -> bool {
+        self.route_back.insert(hash, peer_id)
     }
 
     // Find route back with given hash and removes it from cache.


### PR DESCRIPTION
We have seen cases where nodes would get stack syncing. (https://github.com/near/nearcore/issues/5112)

It looks like we are trying to request headers from a route to which we don't have a route:
```
Nov 08 08:05:14 public-v1-archive-mainnet-rpc-node-p3x5 sh[1942]: Nov 08 08:05:14.108 DEBUG network: None Drop signed message to Hash(`GC72RjNQpJuKMierihJ4bYaF7WMFQCYfPgadbRyGE3fA`) Reason RouteBackNotFound. Num known peers: 411 Message PartialChunkResponse(ChunkHash(`6Y2YYNUpp62uNQxAvo3a7LxfC4eLMDeXeoZisKHcPANx`), [84])
Nov 08 08:05:14 public-v1-archive-mainnet-rpc-node-p3x5 sh[1942]: Nov 08 08:05:14.131 DEBUG network: None Drop signed message to Hash(`C6Q52jRSJxnfuSn7TuoSbVXcEVM8DtpB2xikFDamzLVT`) Reason RouteBackNotFound. Num known peers: 411 Message PartialChunkResponse(ChunkHash(`DNEWNwDysCsAHg14vy6UdVQHvdSQHU1i6yxiDcanhieA`), [84])
```

I noticed a code path, where it's possible we will return to `PeerActor` list of peers to which we have no route to `highest_height_peers`.
I added printing an error when that happens.
