### PR TITLE
ci: add `performance_stats` to nightly CI tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,7 +12,7 @@ steps:
   - label: "cargo test nightly"
     command: |
       source ~/.cargo/env && set -eux
-      RUSTFLAGS='-D warnings' cargo test --workspace --features nightly_protocol,nightly_protocol_features
+      RUSTFLAGS='-D warnings' cargo test --workspace --features nightly_protocol,nightly_protocol_features,performance_stats
 
     timeout: 60
     agents:


### PR DESCRIPTION
With cargo features comes the gubernatorial explosion of possible
versions of the code that need to be tested.  In current CI
configuration we are testing (i) code with no features and (ii) code
with nightly_protocol and nightly_protocol_features features enabled.

As it turns out, we run betanet nodes which enables performance_stats
feature which is variant of the code we are currently not testing.
Unfortunately, a bug in code enabled by that feature caused a betanet
failure.  To avoid further such issues, add performance_stats feature
to the nightly tests run.

The disadvantage of this change is of course that now variant of the
code with nightly features enabled but performance stats disabled is
not tested.  Hopefully though, since we are also testing code with no
features, overall this change increases coverage of code paths.