### PR TITLE
Fix timeout in routing_table_sync.py

### DIFF
--- a/pytest/tests/sanity/routing_table_sync.py
+++ b/pytest/tests/sanity/routing_table_sync.py
@@ -188,7 +188,7 @@ for (left, right, common, TIMEOUT) in tests:
     started = time.time()
     while True:
         assert time.time() - started < TIMEOUT
-        status = nodes[0].get_status()
+        status = nodes[0].get_status(timeout=30)
         height = status['sync_info']['latest_block_height']
         if success.value == 1:
             break

--- a/pytest/tests/sanity/routing_table_sync.py
+++ b/pytest/tests/sanity/routing_table_sync.py
@@ -85,11 +85,11 @@ tests = [
     # Only second node has new edges
     [0, 3, 0, 5],
     # check edge case, where full sync is required
-    [50000, 50000, 0, 15],
+    [25000, 25000, 0, 15],
     # Both nodes have new edges
     [1, 11, 0, 5],
     # Both nodes have 1 each other doesn't know about, and there are bunch of common edges
-    [1, 1, 100000, 5],
+    [1, 1, 50000, 5],
     # medium test, both nodes have some edges
     [10000, 10000, 0, 15],
 ]

--- a/pytest/tests/sanity/routing_table_sync.py
+++ b/pytest/tests/sanity/routing_table_sync.py
@@ -85,7 +85,7 @@ tests = [
     # Only second node has new edges
     [0, 3, 0, 5],
     # check edge case, where full sync is required
-    [50000, 50000, 0, 15],
+    [25000, 25000, 0, 15],
     # Both nodes have new edges
     [1, 11, 0, 5],
     # Both nodes have 1 each other doesn't know about, and there are bunch of common edges

--- a/pytest/tests/sanity/routing_table_sync.py
+++ b/pytest/tests/sanity/routing_table_sync.py
@@ -85,11 +85,11 @@ tests = [
     # Only second node has new edges
     [0, 3, 0, 5],
     # check edge case, where full sync is required
-    [25000, 25000, 0, 15],
+    [50000, 50000, 0, 15],
     # Both nodes have new edges
     [1, 11, 0, 5],
     # Both nodes have 1 each other doesn't know about, and there are bunch of common edges
-    [1, 1, 200000, 5],
+    [1, 1, 100000, 5],
     # medium test, both nodes have some edges
     [10000, 10000, 0, 15],
 ]


### PR DESCRIPTION
We saw that nayduck test failed, due to having 2s timeout in `nodes[0].get_status(timeout=30)`


Closes https://github.com/near/nearcore/issues/5188#event-5600015413