### PR TITLE
Optimize pruning edges

### DIFF
--- a/chain/network/src/routing/routing.rs
+++ b/chain/network/src/routing/routing.rs
@@ -1,5 +1,6 @@
 use near_primitives::time::Clock;
-use std::collections::{hash_map::Entry, HashMap, VecDeque};
+use std::cmp::{max, min};
+use std::collections::{hash_map::Entry, HashMap, HashSet, VecDeque};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -814,6 +815,21 @@ impl Graph {
         }
 
         self.compute_result(&mut routes, &distance)
+    }
+
+    pub fn get_edges_to_prune(&self, peers: &HashSet<PeerId>) -> HashSet<(PeerId, PeerId)> {
+        let mut result = HashSet::new();
+        for peer in peers.iter() {
+            if let Some(id) = self.p2id.get(peer) {
+                for id2 in self.adjacency[*id as usize].iter() {
+                    if let Some(peer2) = self.id2p.get(*id2 as usize) {
+                        let key = (min(peer, peer2).clone(), max(peer, peer2).clone());
+                        result.insert(key);
+                    }
+                }
+            }
+        }
+        result
     }
 
     fn compute_result(&self, routes: &[u128], distance: &[i32]) -> HashMap<PeerId, Vec<PeerId>> {

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -275,15 +275,14 @@ impl RoutingTableActor {
         #[cfg(feature = "delay_detector")]
         let _d = DelayDetector::new("pruning edges".into());
 
-        let edges_to_remove = self.prune_unreachable_edges_and_save_to_db_edges(
+        let edges_to_remove = self.prune_unreachable_edges_and_save_to_db(
             prune == Prune::PruneNow,
             prune_edges_not_reachable_for,
         );
-        self.remove_edges(&edges_to_remove);
         edges_to_remove
     }
 
-    fn prune_unreachable_edges_and_save_to_db_edges(
+    fn prune_unreachable_edges_and_save_to_db(
         &mut self,
         force_pruning: bool,
         prune_edges_not_reachable_for: Duration,
@@ -319,8 +318,10 @@ impl RoutingTableActor {
 
         let edges_to_remove = self.raw_graph.get_edges_to_prune(&peers_to_remove);
 
-        let edges_to_remove =
+        let edges_to_remove: Vec<Edge> =
             edges_to_remove.iter().filter_map(|key| self.edges_info.remove(key)).collect();
+
+        self.remove_active_edges(&edges_to_remove);
 
         let _ = update.set_ser(ColComponentEdges, component_nonce.as_ref(), &edges_to_remove);
 

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -287,8 +287,11 @@ impl RoutingTableActor {
         force_pruning: bool,
         prune_edges_not_reachable_for: Duration,
     ) -> Vec<Edge> {
-        let peers_to_remove =
-            self.peers_to_prune(force_pruning, prune_edges_not_reachable_for, SAVE_PEERS_MAX_TIME);
+        let peers_to_remove = self.find_peers_to_prune(
+            force_pruning,
+            prune_edges_not_reachable_for,
+            SAVE_PEERS_MAX_TIME,
+        );
 
         if peers_to_remove.is_empty() {
             return Vec::new();
@@ -335,7 +338,7 @@ impl RoutingTableActor {
     // `peers_to_prune` chooses list of peers for which we should prune all their edges.
     // In order not to do pruning to often. We will prune, nodes not reachable for at least,
     // `min_prune_time, if and only if there was at least one node not reachable for `max_prune_time`.
-    fn peers_to_prune(
+    fn find_peers_to_prune(
         &mut self,
         force_pruning: bool,
         min_prune_time: Duration,


### PR DESCRIPTION
Currently we are going through all edges whenever we want to remove unused edges. We can optimize that process by only going through edges, which we are going to remove.

- We will remove extra allocations of `Edge`
- We will remove `edges_info.iter()`
- Extract `peer_to_prune` method
- Code refactor
- Rewrite comments to make the code easier to understand.