### PR TITLE
Remove unused code

### DIFF
--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -350,11 +350,6 @@ impl RoutingTableActor {
         self.edges_info.get(&key).map_or(0, |x| x.nonce) < nonce
     }
 
-    pub fn get_edge(&self, peer0: PeerId, peer1: PeerId) -> Option<Edge> {
-        let key = Edge::key(peer0, peer1);
-        self.edges_info.get(&key).cloned()
-    }
-
     #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
     pub fn convert_simple_edges_to_edges(&self, edges: Vec<SimpleEdge>) -> Vec<Edge> {
         edges.iter().filter_map(|k| self.edges_info.get(&k.key()).cloned()).collect()

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -350,11 +350,6 @@ impl RoutingTableActor {
         self.edges_info.get(&key).map_or(0, |x| x.nonce) < nonce
     }
 
-    #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
-    pub fn convert_simple_edges_to_edges(&self, edges: Vec<SimpleEdge>) -> Vec<Edge> {
-        edges.iter().filter_map(|k| self.edges_info.get(&k.key()).cloned()).collect()
-    }
-
     /// Get edges stored in DB under `ColPeerComponent` column at `peer_id` key.
     fn component_nonce_from_peer(&mut self, peer_id: PeerId) -> Result<u64, ()> {
         match self.store.get_ser::<u64>(ColPeerComponent, Vec::from(peer_id).as_ref()) {


### PR DESCRIPTION
We found some unused code

- `pub fn get_edge(&self, peer0: PeerId, peer1: PeerId) -> Option<Edge> {`
- `pub fn convert_simple_edges_to_edges(&self, edges: Vec<SimpleEdge>) -> Vec<Edge> {`