### PR TITLE
We should remove cloning from Edge

### DIFF
--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -298,7 +298,7 @@ impl PeerManagerActor {
             }
             self.routing_table_view
                 .local_edges_info
-                .insert((edge.peer0.clone(), edge.peer1.clone()), edge.clone());
+                .insert((edge.key.0.clone(), edge.key.1.clone()), edge.clone());
         }
 
         self.routing_table_addr
@@ -941,10 +941,10 @@ impl PeerManagerActor {
     // We will broadcast that edge to that peer, and if that peer doesn't reply within specific time,
     // that peer will be removed. However, the connected peer may gives us a new edge indicating
     // that we should in fact be connected to it.
-    fn maybe_remove_connected_peer(&mut self, ctx: &mut Context<Self>, edge: Edge, other: PeerId) {
+    fn maybe_remove_connected_peer(&mut self, ctx: &mut Context<Self>, edge: Edge, other: &PeerId) {
         let nonce = edge.next();
 
-        if let Some(last_nonce) = self.local_peer_pending_update_nonce_request.get(&other) {
+        if let Some(last_nonce) = self.local_peer_pending_update_nonce_request.get(other) {
             if *last_nonce >= nonce {
                 // We already tried to update an edge with equal or higher nonce.
                 return;
@@ -964,6 +964,7 @@ impl PeerManagerActor {
 
         self.local_peer_pending_update_nonce_request.insert(other.clone(), nonce);
 
+        let other = other.clone();
         near_performance_metrics::actix::run_later(
             ctx,
             WAIT_ON_TRY_UPDATE_NONCE,

--- a/chain/network/src/routing/edge_verifier_actor.rs
+++ b/chain/network/src/routing/edge_verifier_actor.rs
@@ -25,9 +25,8 @@ impl Handler<EdgeList> for EdgeVerifierActor {
     #[perf]
     fn handle(&mut self, msg: EdgeList, _ctx: &mut Self::Context) -> Self::Result {
         for edge in msg.edges {
-            let key = (edge.peer0.clone(), edge.peer1.clone());
-            if msg.edges_info_shared.lock().unwrap().get(&key).cloned().unwrap_or(0u64)
-                >= edge.nonce
+            let key = &edge.key;
+            if msg.edges_info_shared.lock().unwrap().get(key).cloned().unwrap_or(0u64) >= edge.nonce
             {
                 continue;
             }
@@ -43,7 +42,7 @@ impl Handler<EdgeList> for EdgeVerifierActor {
             }
             {
                 let mut guard = msg.edges_info_shared.lock().unwrap();
-                let entry = guard.entry(key);
+                let entry = guard.entry(key.clone());
 
                 let cur_nonce = entry.or_insert(edge.nonce);
                 *cur_nonce = max(*cur_nonce, edge.nonce);

--- a/chain/network/src/routing/routing.rs
+++ b/chain/network/src/routing/routing.rs
@@ -70,7 +70,7 @@ pub enum EdgeType {
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "test_features", derive(Serialize, Deserialize))]
 pub struct Edge {
-    /// Since edges are not directed `peer0 < peer1` should hold.
+    /// Since edges are not directed `key.0 < peer1` should hold.
     pub key: (PeerId, PeerId),
     /// Nonce to keep tracking of the last update on this edge.
     /// It must be even

--- a/chain/network/src/routing/routing.rs
+++ b/chain/network/src/routing/routing.rs
@@ -71,8 +71,7 @@ pub enum EdgeType {
 #[cfg_attr(feature = "test_features", derive(Serialize, Deserialize))]
 pub struct Edge {
     /// Since edges are not directed `peer0 < peer1` should hold.
-    pub peer0: PeerId,
-    pub peer1: PeerId,
+    pub key: (PeerId, PeerId),
     /// Nonce to keep tracking of the last update on this edge.
     /// It must be even
     pub nonce: u64,
@@ -100,17 +99,16 @@ impl Edge {
             (peer1, signature1, peer0, signature0)
         };
 
-        Self { peer0, peer1, nonce, signature0, signature1, removal_info: None }
+        Self { key: (peer0, peer1), nonce, signature0, signature1, removal_info: None }
     }
 
     pub fn to_simple_edge(&self) -> SimpleEdge {
-        SimpleEdge::new(self.peer0.clone(), self.peer1.clone(), self.nonce)
+        SimpleEdge::new(self.key.0.clone(), self.key.1.clone(), self.nonce)
     }
 
     pub fn make_fake_edge(peer0: PeerId, peer1: PeerId, nonce: u64) -> Self {
         Self {
-            peer0,
-            peer1,
+            key: (peer0, peer1),
             nonce,
             signature0: Signature::empty(KeyType::ED25519),
             signature1: Signature::empty(KeyType::ED25519),
@@ -140,7 +138,7 @@ impl Edge {
         assert_eq!(self.edge_type(), EdgeType::Added);
         let mut edge = self.clone();
         edge.nonce += 1;
-        let me = edge.peer0 == my_peer_id;
+        let me = edge.key.0 == my_peer_id;
         let hash = edge.hash();
         let signature = sk.sign(hash.as_ref());
         edge.removal_info = Some((me, signature));
@@ -160,15 +158,15 @@ impl Edge {
     }
 
     fn hash(&self) -> CryptoHash {
-        Edge::build_hash(&self.peer0, &self.peer1, self.nonce)
+        Edge::build_hash(&self.key.0, &self.key.1, self.nonce)
     }
 
     fn prev_hash(&self) -> CryptoHash {
-        Edge::build_hash(&self.peer0, &self.peer1, self.nonce - 1)
+        Edge::build_hash(&self.key.0, &self.key.1, self.nonce - 1)
     }
 
     pub fn verify(&self) -> bool {
-        if self.peer0 > self.peer1 {
+        if self.key.0 > self.key.1 {
             return false;
         }
 
@@ -177,8 +175,8 @@ impl Edge {
                 let data = self.hash();
 
                 self.removal_info.is_none()
-                    && self.signature0.verify(data.as_ref(), &self.peer0.public_key())
-                    && self.signature1.verify(data.as_ref(), &self.peer1.public_key())
+                    && self.signature0.verify(data.as_ref(), &self.key.0.public_key())
+                    && self.signature1.verify(data.as_ref(), &self.key.1.public_key())
             }
             EdgeType::Removed => {
                 // nonce should be an even positive number
@@ -188,14 +186,14 @@ impl Edge {
 
                 // Check referring added edge is valid.
                 let add_hash = self.prev_hash();
-                if !self.signature0.verify(add_hash.as_ref(), &self.peer0.public_key())
-                    || !self.signature1.verify(add_hash.as_ref(), &self.peer1.public_key())
+                if !self.signature0.verify(add_hash.as_ref(), &self.key.0.public_key())
+                    || !self.signature1.verify(add_hash.as_ref(), &self.key.1.public_key())
                 {
                     return false;
                 }
 
                 if let Some((party, signature)) = &self.removal_info {
-                    let peer = if *party { &self.peer0 } else { &self.peer1 };
+                    let peer = if *party { &self.key.0 } else { &self.key.1 };
                     let del_hash = self.hash();
                     signature.verify(del_hash.as_ref(), &peer.public_key())
                 } else {
@@ -222,8 +220,8 @@ impl Edge {
         edge_info.signature.verify(data.as_ref(), &pk)
     }
 
-    pub fn get_pair(&self) -> (PeerId, PeerId) {
-        (self.peer0.clone(), self.peer1.clone())
+    pub fn get_pair(&self) -> &(PeerId, PeerId) {
+        &self.key
     }
 
     /// It will be considered as a new edge if the nonce is odd, otherwise it is canceling the
@@ -251,15 +249,15 @@ impl Edge {
     }
 
     pub fn contains_peer(&self, peer_id: &PeerId) -> bool {
-        self.peer0 == *peer_id || self.peer1 == *peer_id
+        self.key.0 == *peer_id || self.key.1 == *peer_id
     }
 
     /// Find a peer id in this edge different from `me`.
-    pub fn other(&self, me: &PeerId) -> Option<PeerId> {
-        if self.peer0 == *me {
-            Some(self.peer1.clone())
-        } else if self.peer1 == *me {
-            Some(self.peer0.clone())
+    pub fn other(&self, me: &PeerId) -> Option<&PeerId> {
+        if self.key.0 == *me {
+            Some(&self.key.1)
+        } else if self.key.1 == *me {
+            Some(&self.key.0)
         } else {
             None
         }
@@ -509,8 +507,8 @@ impl RoutingTableView {
 
     pub fn remove_edges(&mut self, edges: &Vec<Edge>) {
         for edge in edges.iter() {
-            assert!(edge.peer0 == self.my_peer_id || edge.peer1 == self.my_peer_id);
-            let key = (edge.peer0.clone(), edge.peer1.clone());
+            assert!(edge.key.0 == self.my_peer_id || edge.key.1 == self.my_peer_id);
+            let key = (edge.key.0.clone(), edge.key.1.clone());
             self.local_edges_info.remove(&key);
         }
     }

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -112,9 +112,9 @@ impl RoutingTableActor {
         #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
         self.peer_ibf_set.remove_edge(&edge.to_simple_edge());
 
-        let key = (edge.peer0.clone(), edge.peer1.clone());
+        let key = &edge.key;
         if self.edges_info.remove(&key).is_some() {
-            self.raw_graph.remove_edge(&edge.peer0, &edge.peer1);
+            self.raw_graph.remove_edge(&edge.key.0, &edge.key.1);
             self.needs_routing_table_recalculation = true;
         }
     }
@@ -138,7 +138,7 @@ impl RoutingTableActor {
             }
             #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
             self.peer_ibf_set.add_edge(&edge.to_simple_edge());
-            self.edges_info.insert(key, edge);
+            self.edges_info.insert(key.clone(), edge);
             true
         }
     }
@@ -190,7 +190,7 @@ impl RoutingTableActor {
             // Load all edges that were persisted in database in the cell - and add them to the current graph.
             if let Ok(edges) = self.get_and_remove_component_edges(component_nonce, &mut update) {
                 for edge in edges {
-                    for &peer_id in vec![&edge.peer0, &edge.peer1].iter() {
+                    for &peer_id in vec![&edge.key.0, &edge.key.1].iter() {
                         if peer_id == &my_peer_id
                             || self.peer_last_time_reachable.contains_key(peer_id)
                         {

--- a/chain/network/tests/cache_edges.rs
+++ b/chain/network/tests/cache_edges.rs
@@ -71,8 +71,8 @@ impl RoutingTableTest {
     }
 
     fn get_edge_description(&self, edge: &Edge) -> EdgeDescription {
-        let peer0 = self.rev_peers.get(&edge.peer0).unwrap();
-        let peer1 = self.rev_peers.get(&edge.peer1).unwrap();
+        let peer0 = self.rev_peers.get(&edge.key.0).unwrap();
+        let peer1 = self.rev_peers.get(&edge.key.1).unwrap();
         let edge_type = edge.edge_type();
         EdgeDescription(*peer0, *peer1, edge_type)
     }


### PR DESCRIPTION
We are using `clone()` a lot in `Edge`.

I propose we change structure of `Edge` to use
```rust
   key: (PeerId, PeerId)
```
instead of
```rust
   peer0: PeerId,
   peer1: PeerId
```

Resolves #5221 
