### PR TITLE
We shouldn't be cloning PeerId so often

### DIFF
--- a/chain/network/benches/graph.rs
+++ b/chain/network/benches/graph.rs
@@ -13,16 +13,13 @@ fn build_graph(depth: usize, size: usize) -> Graph {
     let mut graph = Graph::new(source.clone());
 
     for i in 0..size {
-        graph.add_edge(source.clone(), nodes[i].clone());
+        graph.add_edge(&source, &nodes[i]);
     }
 
     for layer in 0..depth - 1 {
         for u in 0..size {
             for v in 0..size {
-                graph.add_edge(
-                    nodes[layer * size + u].clone(),
-                    nodes[(layer + 1) * size + v].clone(),
-                );
+                graph.add_edge(&nodes[layer * size + u], &nodes[(layer + 1) * size + v]);
             }
         }
     }
@@ -70,6 +67,6 @@ benchmark_group!(
 benchmark_main!(benches);
 
 // running 3 tests
-// test calculate_distance_10_10  ... bench:   1,503,222 ns/iter (+/- 126,811)
-// test calculate_distance_10_100 ... bench: 988,705,595 ns/iter (+/- 118,318,208)
-// test calculate_distance_3_3    ... bench:      18,928 ns/iter (+/- 3,174)
+// test calculate_distance_10_10  ... bench:      12,442 ns/iter (+/- 307)
+// test calculate_distance_10_100 ... bench:   1,337,039 ns/iter (+/- 74,565)
+// test calculate_distance_3_3    ... bench:         636 ns/iter (+/- 12)

--- a/chain/network/src/routing/routing.rs
+++ b/chain/network/src/routing/routing.rs
@@ -151,9 +151,9 @@ impl Edge {
     /// It is important that peer0 < peer1 at this point.
     fn build_hash(peer0: &PeerId, peer1: &PeerId, nonce: u64) -> CryptoHash {
         let mut buffer = Vec::<u8>::new();
-        let peer0: Vec<u8> = peer0.clone().into();
+        let peer0: Vec<u8> = peer0.into();
         buffer.extend_from_slice(peer0.as_slice());
-        let peer1: Vec<u8> = peer1.clone().into();
+        let peer1: Vec<u8> = peer1.into();
         buffer.extend_from_slice(peer1.as_slice());
         buffer.write_u64::<LittleEndian>(nonce).unwrap();
         hash(buffer.as_slice())

--- a/chain/network/src/routing/routing.rs
+++ b/chain/network/src/routing/routing.rs
@@ -745,11 +745,11 @@ impl Graph {
         }
     }
 
-    pub fn add_edge(&mut self, peer0: PeerId, peer1: PeerId) {
+    pub fn add_edge(&mut self, peer0: &PeerId, peer1: &PeerId) {
         assert_ne!(peer0, peer1);
-        if !self.contains_edge(&peer0, &peer1) {
-            let id0 = self.get_id(&peer0);
-            let id1 = self.get_id(&peer1);
+        if !self.contains_edge(peer0, peer1) {
+            let id0 = self.get_id(peer0);
+            let id1 = self.get_id(peer1);
 
             self.adjacency[id0 as usize].push(id1);
             self.adjacency[id1 as usize].push(id0);
@@ -868,7 +868,7 @@ mod test {
         assert_eq!(graph.contains_edge(&node0, &node1), false);
         assert_eq!(graph.contains_edge(&node1, &node0), false);
 
-        graph.add_edge(node0.clone(), node1.clone());
+        graph.add_edge(&node0, &node1);
 
         assert_eq!(graph.contains_edge(&source, &node0), false);
         assert_eq!(graph.contains_edge(&source, &node1), false);
@@ -890,9 +890,9 @@ mod test {
         let node0 = random_peer_id();
 
         let mut graph = Graph::new(source.clone());
-        graph.add_edge(source.clone(), node0.clone());
+        graph.add_edge(&source, &node0);
         graph.remove_edge(&source, &node0);
-        graph.add_edge(source.clone(), node0.clone());
+        graph.add_edge(&source, &node0);
 
         assert!(expected_routing_tables(
             graph.calculate_distance(),
@@ -910,9 +910,9 @@ mod test {
 
         let mut graph = Graph::new(source.clone());
 
-        graph.add_edge(nodes[0].clone(), nodes[1].clone());
-        graph.add_edge(nodes[2].clone(), nodes[1].clone());
-        graph.add_edge(nodes[1].clone(), nodes[2].clone());
+        graph.add_edge(&nodes[0], &nodes[1]);
+        graph.add_edge(&nodes[2], &nodes[1]);
+        graph.add_edge(&nodes[1], &nodes[2]);
 
         assert!(expected_routing_tables(graph.calculate_distance(), vec![]));
 
@@ -927,10 +927,10 @@ mod test {
 
         let mut graph = Graph::new(source.clone());
 
-        graph.add_edge(nodes[0].clone(), nodes[1].clone());
-        graph.add_edge(nodes[2].clone(), nodes[1].clone());
-        graph.add_edge(nodes[1].clone(), nodes[2].clone());
-        graph.add_edge(source.clone(), nodes[0].clone());
+        graph.add_edge(&nodes[0], &nodes[1]);
+        graph.add_edge(&nodes[2], &nodes[1]);
+        graph.add_edge(&nodes[1], &nodes[2]);
+        graph.add_edge(&source, &nodes[0]);
 
         assert!(expected_routing_tables(
             graph.calculate_distance(),
@@ -952,11 +952,11 @@ mod test {
 
         let mut graph = Graph::new(source.clone());
 
-        graph.add_edge(nodes[0].clone(), nodes[1].clone());
-        graph.add_edge(nodes[2].clone(), nodes[1].clone());
-        graph.add_edge(nodes[0].clone(), nodes[2].clone());
-        graph.add_edge(source.clone(), nodes[0].clone());
-        graph.add_edge(source.clone(), nodes[1].clone());
+        graph.add_edge(&nodes[0], &nodes[1]);
+        graph.add_edge(&nodes[2], &nodes[1]);
+        graph.add_edge(&nodes[0], &nodes[2]);
+        graph.add_edge(&source, &nodes[0]);
+        graph.add_edge(&source, &nodes[1]);
 
         assert!(expected_routing_tables(
             graph.calculate_distance(),
@@ -989,19 +989,19 @@ mod test {
         let mut graph = Graph::new(source.clone());
 
         for i in 0..3 {
-            graph.add_edge(source.clone(), nodes[i].clone());
+            graph.add_edge(&source, &nodes[i]);
         }
 
         for level in 0..2 {
             for i in 0..3 {
                 for j in 0..3 {
-                    graph.add_edge(nodes[level * 3 + i].clone(), nodes[level * 3 + 3 + j].clone());
+                    graph.add_edge(&nodes[level * 3 + i], &nodes[level * 3 + 3 + j]);
                 }
             }
         }
 
         // Dummy edge.
-        graph.add_edge(nodes[9].clone(), nodes[10].clone());
+        graph.add_edge(&nodes[9], &nodes[10]);
 
         let mut next_hops: Vec<_> =
             (0..3).map(|i| (nodes[i].clone(), vec![nodes[i].clone()])).collect();

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -130,7 +130,7 @@ impl RoutingTableActor {
             self.needs_routing_table_recalculation = true;
             match edge.edge_type() {
                 EdgeType::Added => {
-                    self.raw_graph.add_edge(key.0.clone(), key.1.clone());
+                    self.raw_graph.add_edge(&key.0, &key.1);
                 }
                 EdgeType::Removed => {
                     self.raw_graph.remove_edge(&key.0, &key.1);

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -184,7 +184,7 @@ impl RoutingTableActor {
         let my_peer_id = self.my_peer_id().clone();
 
         // Get the "row" (a.k.a nonce) at which we've stored a given peer in the past (when we pruned it).
-        if let Ok(component_nonce) = self.component_nonce_from_peer(other_peer_id.clone()) {
+        if let Ok(component_nonce) = self.component_nonce_from_peer(other_peer_id) {
             let mut update = self.store.store_update();
 
             // Load all edges that were persisted in database in the cell - and add them to the current graph.
@@ -198,14 +198,13 @@ impl RoutingTableActor {
                         }
 
                         // `edge = (peer_id, other_peer_id)` belongs to component that we loaded from database.
-                        if let Ok(cur_nonce) = self.component_nonce_from_peer(peer_id.clone()) {
+                        if let Ok(cur_nonce) = self.component_nonce_from_peer(peer_id) {
                             // If `peer_id` belongs to current component
                             if cur_nonce == component_nonce {
                                 // Mark it as reachable and delete from database.
                                 self.peer_last_time_reachable
                                     .insert(peer_id.clone(), Instant::now() - SAVE_PEERS_MAX_TIME);
-                                update
-                                    .delete(ColPeerComponent, Vec::from(peer_id.clone()).as_ref());
+                                update.delete(ColPeerComponent, Vec::from(peer_id).as_ref());
                             } else {
                                 warn!("We expected `peer_id` to belong to component {}, but it belongs to {}",
                                        component_nonce, cur_nonce);
@@ -317,7 +316,7 @@ impl RoutingTableActor {
         for peer_id in peers_to_remove.iter() {
             let _ = update.set_ser(
                 ColPeerComponent,
-                Vec::from(peer_id.clone()).as_ref(),
+                Vec::from(peer_id).as_ref(),
                 &current_component_nonce,
             );
 
@@ -361,7 +360,7 @@ impl RoutingTableActor {
     }
 
     /// Get edges stored in DB under `ColPeerComponent` column at `peer_id` key.
-    fn component_nonce_from_peer(&mut self, peer_id: PeerId) -> Result<u64, ()> {
+    fn component_nonce_from_peer(&mut self, peer_id: &PeerId) -> Result<u64, ()> {
         match self.store.get_ser::<u64>(ColPeerComponent, Vec::from(peer_id).as_ref()) {
             Ok(Some(nonce)) => Ok(nonce),
             _ => Err(()),

--- a/core/primitives/src/network.rs
+++ b/core/primitives/src/network.rs
@@ -31,8 +31,8 @@ impl PeerId {
     }
 }
 
-impl From<PeerId> for Vec<u8> {
-    fn from(peer_id: PeerId) -> Vec<u8> {
+impl From<&PeerId> for Vec<u8> {
+    fn from(peer_id: &PeerId) -> Vec<u8> {
         peer_id.0.try_to_vec().unwrap()
     }
 }


### PR DESCRIPTION
We've been cloning `Edge` in order to convert it to `Vec<u8>`. That seems wasteful.

- change `impl From<PeerId> for Vec<u8> {` to `impl From<&PeerId> for Vec<u8> {`