### PR TITLE
Replace Edge with Arc<Edge> to improve performance

### DIFF
--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -23,7 +23,7 @@ bytesize = "1.0.1"
 conqueue = "0.4.0"
 serde = { version = "1", features = ["derive"], optional=true }
 
-borsh = "0.9"
+borsh = { version = "0.9", features = ["rc"]}
 cached = "0.23"
 
 near-network-primitives = { path = "../network-primitives" }

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -60,3 +60,7 @@ harness = false
 [[bench]]
 name = "ibf"
 harness = false
+
+[[bench]]
+name = "routing_table_actor"
+harness = false

--- a/chain/network/benches/routing_table_actor.rs
+++ b/chain/network/benches/routing_table_actor.rs
@@ -58,11 +58,11 @@ fn get_all_edges_bench_new(bench: &mut Bencher) {
     let all_edges = routing_table_actor.get_all_edges();
     let mut new_edges_info = HashMap::new();
     for edge in all_edges {
-        new_edges_info.insert((edge.key().0.clone(), edge.key().1.clone()), Arc::new(edge.clone()));
+        new_edges_info.insert((edge.key().0.clone(), edge.key().1.clone()), edge.clone());
     }
 
     bench.iter(|| {
-        let result: Vec<Arc<Edge>> = new_edges_info.iter().map(|x| x.1.clone()).collect();
+        let result: Vec<Edge> = new_edges_info.iter().map(|x| x.1.clone()).collect();
         black_box(result);
     });
 }

--- a/chain/network/benches/routing_table_actor.rs
+++ b/chain/network/benches/routing_table_actor.rs
@@ -50,24 +50,6 @@ fn get_all_edges_bench_old(bench: &mut Bencher) {
 }
 
 #[allow(dead_code)]
-fn get_all_edges_bench_new(bench: &mut Bencher) {
-    // this is how we efficient we could make get_all_edges by using Arc
-
-    // 1000 nodes, 10m edges
-    let routing_table_actor = build_graph(10, 100);
-    let all_edges = routing_table_actor.get_all_edges();
-    let mut new_edges_info = HashMap::new();
-    for edge in all_edges {
-        new_edges_info.insert((edge.key().0.clone(), edge.key().1.clone()), edge.clone());
-    }
-
-    bench.iter(|| {
-        let result: Vec<Edge> = new_edges_info.iter().map(|x| x.1.clone()).collect();
-        black_box(result);
-    });
-}
-
-#[allow(dead_code)]
 fn get_all_edges_bench_new2(bench: &mut Bencher) {
     // this is how we efficient we could make get_all_edges by using Arc
 
@@ -93,12 +75,7 @@ fn get_all_edges_bench_new2(bench: &mut Bencher) {
     });
 }
 
-benchmark_group!(
-    benches,
-    get_all_edges_bench_old,
-    get_all_edges_bench_new,
-    get_all_edges_bench_new2
-);
+benchmark_group!(benches, get_all_edges_bench_old, get_all_edges_bench_new2);
 
 benchmark_main!(benches);
 

--- a/chain/network/benches/routing_table_actor.rs
+++ b/chain/network/benches/routing_table_actor.rs
@@ -47,9 +47,6 @@ fn get_all_edges_bench_old(bench: &mut Bencher) {
         let result = routing_table_actor.get_all_edges();
         black_box(result);
     });
-    // println!("took {}ns", bench.ns_per_iter());
-    // This code gets executed multiple tests, so assert will not work.
-    // assert!(((bench.ns_per_iter() as f64) < (5_045_404.0 * TEST_COEF)));
 }
 
 #[allow(dead_code)]
@@ -68,9 +65,6 @@ fn get_all_edges_bench_new(bench: &mut Bencher) {
         let result: Vec<Arc<Edge>> = new_edges_info.iter().map(|x| x.1.clone()).collect();
         black_box(result);
     });
-    // println!("took {}ns", bench.ns_per_iter());
-    // This code gets executed multiple tests, so assert will not work.
-    // assert!(((bench.ns_per_iter() as f64) < (1_231_155.0 * TEST_COEF)));
 }
 
 benchmark_group!(benches, get_all_edges_bench_old, get_all_edges_bench_new);

--- a/chain/network/benches/routing_table_actor.rs
+++ b/chain/network/benches/routing_table_actor.rs
@@ -38,8 +38,8 @@ fn build_graph(depth: usize, size: usize) -> RoutingTableActor {
 }
 
 #[allow(dead_code)]
-fn get_all_edges_bench(bench: &mut Bencher) {
-    let routing_table_actor = build_graph(100, 100);
+fn get_all_edges_bench_old(bench: &mut Bencher) {
+    let routing_table_actor = build_graph(10, 100);
     bench.iter(|| {
         let result = routing_table_actor.get_all_edges();
         black_box(result);
@@ -47,7 +47,7 @@ fn get_all_edges_bench(bench: &mut Bencher) {
 }
 
 #[allow(dead_code)]
-fn get_all_edges_bench2(bench: &mut Bencher) {
+fn get_all_edges_bench_new(bench: &mut Bencher) {
     // this is how we efficient we could make get_all_edges by using Arc
 
     let routing_table_actor = build_graph(10, 100);
@@ -63,9 +63,10 @@ fn get_all_edges_bench2(bench: &mut Bencher) {
     });
 }
 
-benchmark_group!(benches, get_all_edges_bench,);
+benchmark_group!(benches, get_all_edges_bench_old, get_all_edges_bench_new);
 
 benchmark_main!(benches);
 
-// running 3 tests
-// test get_all_edges_bench  ... bench:   1,503,222 ns/iter (+/- 126,811)
+// running 2 tests
+// test get_all_edges_bench_new ...bench:   1,231,155 ns/iter (+/- 95,776)
+// test get_all_edges_bench_old ... bench:   5,045,404 ns/iter (+/- 168,446)

--- a/chain/network/benches/routing_table_actor.rs
+++ b/chain/network/benches/routing_table_actor.rs
@@ -3,12 +3,14 @@ extern crate bencher;
 
 use bencher::black_box;
 use bencher::Bencher;
+use near_crypto::Signature;
 use std::collections::HashMap;
 use std::sync::Arc;
 
 use near_network::routing::routing::Edge;
 use near_network::test_utils::random_peer_id;
 use near_network::RoutingTableActor;
+use near_primitives::network::PeerId;
 use near_store::test_utils::create_test_store;
 
 fn build_graph(depth: usize, size: usize) -> RoutingTableActor {
@@ -65,10 +67,58 @@ fn get_all_edges_bench_new(bench: &mut Bencher) {
     });
 }
 
-benchmark_group!(benches, get_all_edges_bench_old, get_all_edges_bench_new);
+#[allow(dead_code)]
+fn get_all_edges_bench_new2(bench: &mut Bencher) {
+    // this is how we efficient we could make get_all_edges by using Arc
+
+    // 1000 nodes, 10m edges
+    let routing_table_actor = build_graph(10, 100);
+    let all_edges = routing_table_actor.get_all_edges();
+    let mut new_edges_info = HashMap::new();
+    for edge in all_edges {
+        let edge = EdgeNew {
+            key: Arc::new((edge.peer0, edge.peer1)),
+            nonce: edge.nonce,
+            signature0: edge.signature0,
+            signature1: edge.signature1,
+            removal_info: edge.removal_info,
+        };
+
+        new_edges_info.insert(edge.key.clone(), Arc::new(edge));
+    }
+
+    bench.iter(|| {
+        let result: Vec<Arc<EdgeNew>> = new_edges_info.iter().map(|x| x.1.clone()).collect();
+        black_box(result);
+    });
+}
+
+benchmark_group!(
+    benches,
+    get_all_edges_bench_old,
+    get_all_edges_bench_new,
+    get_all_edges_bench_new2
+);
 
 benchmark_main!(benches);
 
 // running 2 tests
-// test get_all_edges_bench_new ...bench:   1,231,155 ns/iter (+/- 95,776)
 // test get_all_edges_bench_old ... bench:   5,045,404 ns/iter (+/- 168,446)
+// test get_all_edges_bench_new ...bench:   1,231,155 ns/iter (+/- 95,776)
+// using new Edge Representation - EdgeNew
+// test get_all_edges_bench_new2 ... bench:     943,015 ns/iter (+/- 15,679)
+
+pub struct EdgeNew {
+    /// Since edges are not directed `peer0 < peer1` should hold.
+    pub key: Arc<(PeerId, PeerId)>,
+    /// Nonce to keep tracking of the last update on this edge.
+    /// It must be even
+    pub nonce: u64,
+    /// Signature from parties validating the edge. These are signature of the added edge.
+    signature0: Signature,
+    signature1: Signature,
+    /// Info necessary to declare an edge as removed.
+    /// The bool says which party is removing the edge: false for Peer0, true for Peer1
+    /// The signature from the party removing the edge.
+    removal_info: Option<(bool, Signature)>,
+}

--- a/chain/network/benches/routing_table_actor.rs
+++ b/chain/network/benches/routing_table_actor.rs
@@ -1,8 +1,6 @@
 #[macro_use]
 extern crate bencher;
 
-const TEST_COEF: f64 = 2.5;
-
 use bencher::black_box;
 use bencher::Bencher;
 use std::collections::HashMap;

--- a/chain/network/benches/routing_table_actor.rs
+++ b/chain/network/benches/routing_table_actor.rs
@@ -58,7 +58,7 @@ fn get_all_edges_bench_new(bench: &mut Bencher) {
     let all_edges = routing_table_actor.get_all_edges();
     let mut new_edges_info = HashMap::new();
     for edge in all_edges {
-        new_edges_info.insert((edge.peer0.clone(), edge.peer1.clone()), Arc::new(edge.clone()));
+        new_edges_info.insert((edge.key().0.clone(), edge.key().1.clone()), Arc::new(edge.clone()));
     }
 
     bench.iter(|| {
@@ -77,7 +77,7 @@ fn get_all_edges_bench_new2(bench: &mut Bencher) {
     let mut new_edges_info = HashMap::new();
     for edge in all_edges {
         let edge = EdgeNew {
-            key: Arc::new((edge.peer0.clone(), edge.peer1.clone())),
+            key: Arc::new((edge.key.0.clone(), edge.key.1.clone())),
             nonce: edge.nonce,
             signature0: edge.signature0.clone(),
             signature1: edge.signature1.clone(),

--- a/chain/network/benches/routing_table_actor.rs
+++ b/chain/network/benches/routing_table_actor.rs
@@ -111,9 +111,11 @@ benchmark_group!(
 benchmark_main!(benches);
 
 // running 3 tests
-// test get_all_edges_bench_new2 ... bench:   1,001,090 ns/iter (+/- 25,434)
-// test get_all_edges_bench_new3 ... bench:   1,017,563 ns/iter (+/- 37,675)
 // test get_all_edges_bench_old  ... bench:   1,296,045 ns/iter (+/- 601,626)
+// replace key with Arc
+// test get_all_edges_bench_new2 ... bench:   1,001,090 ns/iter (+/- 25,434)
+// replace PeerId with Arc (Preferred)
+// test get_all_edges_bench_new3 ... bench:   1,017,563 ns/iter (+/- 37,675)
 
 pub struct EdgeNew {
     /// Since edges are not directed `peer0 < peer1` should hold.

--- a/chain/network/benches/routing_table_actor.rs
+++ b/chain/network/benches/routing_table_actor.rs
@@ -50,7 +50,7 @@ fn get_all_edges_bench(bench: &mut Bencher) {
 fn get_all_edges_bench2(bench: &mut Bencher) {
     // this is how we efficient we could make get_all_edges by using Arc
 
-    let routing_table_actor = build_graph(100, 100);
+    let routing_table_actor = build_graph(10, 100);
     let all_edges = routing_table_actor.get_all_edges();
     let mut new_edges_info = HashMap::new();
     for edge in all_edges {

--- a/chain/network/benches/routing_table_actor.rs
+++ b/chain/network/benches/routing_table_actor.rs
@@ -7,7 +7,7 @@ use near_crypto::Signature;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use near_network::routing::routing::Edge;
+use near_network::routing::routing::{Edge, EdgeInner};
 use near_network::test_utils::random_peer_id;
 use near_network::RoutingTableActor;
 use near_primitives::network::PeerId;
@@ -22,7 +22,7 @@ fn build_graph(depth: usize, size: usize) -> RoutingTableActor {
 
     let mut edges: Vec<Edge> = Vec::new();
     for i in 0..size {
-        edges.push(Edge::make_fake_edge(source.clone(), nodes[i].clone(), 1));
+        edges.push(EdgeInner::make_fake_edge(source.clone(), nodes[i].clone(), 1));
     }
 
     for layer in 0..depth - 1 {
@@ -30,7 +30,7 @@ fn build_graph(depth: usize, size: usize) -> RoutingTableActor {
             for v in 0..size {
                 let peer0 = nodes[layer * size + u].clone();
                 let peer1 = nodes[(layer + 1) * size + v].clone();
-                edges.push(Edge::make_fake_edge(peer0, peer1, (layer + u + v) as u64));
+                edges.push(EdgeInner::make_fake_edge(peer0, peer1, (layer + u + v) as u64));
             }
         }
     }
@@ -77,11 +77,11 @@ fn get_all_edges_bench_new2(bench: &mut Bencher) {
     let mut new_edges_info = HashMap::new();
     for edge in all_edges {
         let edge = EdgeNew {
-            key: Arc::new((edge.peer0, edge.peer1)),
+            key: Arc::new((edge.peer0.clone(), edge.peer1.clone())),
             nonce: edge.nonce,
-            signature0: edge.signature0,
-            signature1: edge.signature1,
-            removal_info: edge.removal_info,
+            signature0: edge.signature0.clone(),
+            signature1: edge.signature1.clone(),
+            removal_info: edge.removal_info.clone(),
         };
 
         new_edges_info.insert(edge.key.clone(), Arc::new(edge));

--- a/chain/network/benches/routing_table_actor.rs
+++ b/chain/network/benches/routing_table_actor.rs
@@ -115,10 +115,13 @@ pub struct EdgeNew {
     /// It must be even
     pub nonce: u64,
     /// Signature from parties validating the edge. These are signature of the added edge.
+    #[allow(unused)]
     signature0: Signature,
+    #[allow(unused)]
     signature1: Signature,
     /// Info necessary to declare an edge as removed.
     /// The bool says which party is removing the edge: false for Peer0, true for Peer1
     /// The signature from the party removing the edge.
+    #[allow(unused)]
     removal_info: Option<(bool, Signature)>,
 }

--- a/chain/network/benches/routing_table_actor.rs
+++ b/chain/network/benches/routing_table_actor.rs
@@ -110,11 +110,10 @@ benchmark_group!(
 
 benchmark_main!(benches);
 
-// running 2 tests
-// test get_all_edges_bench_old ... bench:   5,045,404 ns/iter (+/- 168,446)
-// test get_all_edges_bench_new ...bench:   1,231,155 ns/iter (+/- 95,776)
-// using new Edge Representation - EdgeNew
-// test get_all_edges_bench_new2 ... bench:     943,015 ns/iter (+/- 15,679)
+// running 3 tests
+// test get_all_edges_bench_new2 ... bench:   1,001,090 ns/iter (+/- 25,434)
+// test get_all_edges_bench_new3 ... bench:   1,017,563 ns/iter (+/- 37,675)
+// test get_all_edges_bench_old  ... bench:   1,296,045 ns/iter (+/- 601,626)
 
 pub struct EdgeNew {
     /// Since edges are not directed `peer0 < peer1` should hold.

--- a/chain/network/benches/routing_table_actor.rs
+++ b/chain/network/benches/routing_table_actor.rs
@@ -1,6 +1,8 @@
 #[macro_use]
 extern crate bencher;
 
+const TEST_COEF: f64 = 2.5;
+
 use bencher::black_box;
 use bencher::Bencher;
 use std::collections::HashMap;
@@ -45,6 +47,9 @@ fn get_all_edges_bench_old(bench: &mut Bencher) {
         let result = routing_table_actor.get_all_edges();
         black_box(result);
     });
+    // println!("took {}ns", bench.ns_per_iter());
+    // This code gets executed multiple tests, so assert will not work.
+    // assert!(((bench.ns_per_iter() as f64) < (5_045_404.0 * TEST_COEF)));
 }
 
 #[allow(dead_code)]
@@ -63,6 +68,9 @@ fn get_all_edges_bench_new(bench: &mut Bencher) {
         let result: Vec<Arc<Edge>> = new_edges_info.iter().map(|x| x.1.clone()).collect();
         black_box(result);
     });
+    // println!("took {}ns", bench.ns_per_iter());
+    // This code gets executed multiple tests, so assert will not work.
+    // assert!(((bench.ns_per_iter() as f64) < (1_231_155.0 * TEST_COEF)));
 }
 
 benchmark_group!(benches, get_all_edges_bench_old, get_all_edges_bench_new);

--- a/chain/network/benches/routing_table_actor.rs
+++ b/chain/network/benches/routing_table_actor.rs
@@ -1,0 +1,52 @@
+#[macro_use]
+extern crate bencher;
+
+use bencher::black_box;
+use bencher::Bencher;
+
+use near_network::routing::routing::{Edge, Graph};
+use near_network::test_utils::random_peer_id;
+use near_network::RoutingTableActor;
+
+fn build_graph(depth: usize, size: usize) -> RoutingTableActor {
+    let source = random_peer_id();
+    let nodes: Vec<_> = (0..depth * size).map(|_| random_peer_id()).collect();
+
+    let mut routing_table_actor = RoutingTableActor::new(source.clone());
+
+    for i in 0..size {
+        graph.add_edge(source.clone(), nodes[i].clone());
+    }
+
+    let mut edges: Vec<Edges> = Vec::new();
+    for layer in 0..depth - 1 {
+        for u in 0..size {
+            for v in 0..size {
+                let peer0 = nodes[layer * size + u].clone();
+                let peer1 = nodes[(layer + 1) * size + v].clone();
+                edges.push(Edge::make_fake_edge(peer0, peer1, lay + u + v));
+            }
+        }
+    }
+    routing_table_actor.add_verified_edges_to_routing_table(edges);
+
+    routing_table_actor
+}
+
+#[allow(dead_code)]
+fn get_all_edges_bench(bench: &mut Bencher) {
+    let routing_table_actor = build_graph(100, 100);
+    bench.iter(|| {
+        let result = routing_table_actor.get_all_edges();
+        black_box(result);
+    });
+}
+
+benchmark_group!(benches, get_all_edges_bench,);
+
+benchmark_main!(benches);
+
+// running 3 tests
+// test calculate_distance_10_10  ... bench:   1,503,222 ns/iter (+/- 126,811)
+// test calculate_distance_10_100 ... bench: 988,705,595 ns/iter (+/- 118,318,208)
+// test calculate_distance_3_3    ... bench:      18,928 ns/iter (+/- 3,174)

--- a/chain/network/benches/routing_table_actor.rs
+++ b/chain/network/benches/routing_table_actor.rs
@@ -3,28 +3,32 @@ extern crate bencher;
 
 use bencher::black_box;
 use bencher::Bencher;
+use std::collections::HashMap;
+use std::sync::Arc;
 
-use near_network::routing::routing::{Edge, Graph};
+use near_network::routing::routing::Edge;
 use near_network::test_utils::random_peer_id;
 use near_network::RoutingTableActor;
+use near_store::test_utils::create_test_store;
 
 fn build_graph(depth: usize, size: usize) -> RoutingTableActor {
     let source = random_peer_id();
     let nodes: Vec<_> = (0..depth * size).map(|_| random_peer_id()).collect();
 
-    let mut routing_table_actor = RoutingTableActor::new(source.clone());
+    let store = create_test_store();
+    let mut routing_table_actor = RoutingTableActor::new(source.clone(), store);
 
+    let mut edges: Vec<Edge> = Vec::new();
     for i in 0..size {
-        graph.add_edge(source.clone(), nodes[i].clone());
+        edges.push(Edge::make_fake_edge(source.clone(), nodes[i].clone(), 1));
     }
 
-    let mut edges: Vec<Edges> = Vec::new();
     for layer in 0..depth - 1 {
         for u in 0..size {
             for v in 0..size {
                 let peer0 = nodes[layer * size + u].clone();
                 let peer1 = nodes[(layer + 1) * size + v].clone();
-                edges.push(Edge::make_fake_edge(peer0, peer1, lay + u + v));
+                edges.push(Edge::make_fake_edge(peer0, peer1, (layer + u + v) as u64));
             }
         }
     }
@@ -42,11 +46,26 @@ fn get_all_edges_bench(bench: &mut Bencher) {
     });
 }
 
+#[allow(dead_code)]
+fn get_all_edges_bench2(bench: &mut Bencher) {
+    // this is how we efficient we could make get_all_edges by using Arc
+
+    let routing_table_actor = build_graph(100, 100);
+    let all_edges = routing_table_actor.get_all_edges();
+    let mut new_edges_info = HashMap::new();
+    for edge in all_edges {
+        new_edges_info.insert((edge.peer0.clone(), edge.peer1.clone()), Arc::new(edge.clone()));
+    }
+
+    bench.iter(|| {
+        let result: Vec<Arc<Edge>> = new_edges_info.iter().map(|x| x.1.clone()).collect();
+        black_box(result);
+    });
+}
+
 benchmark_group!(benches, get_all_edges_bench,);
 
 benchmark_main!(benches);
 
 // running 3 tests
-// test calculate_distance_10_10  ... bench:   1,503,222 ns/iter (+/- 126,811)
-// test calculate_distance_10_100 ... bench: 988,705,595 ns/iter (+/- 118,318,208)
-// test calculate_distance_3_3    ... bench:      18,928 ns/iter (+/- 3,174)
+// test get_all_edges_bench  ... bench:   1,503,222 ns/iter (+/- 126,811)

--- a/chain/network/benches/routing_table_actor.rs
+++ b/chain/network/benches/routing_table_actor.rs
@@ -75,7 +75,38 @@ fn get_all_edges_bench_new2(bench: &mut Bencher) {
     });
 }
 
-benchmark_group!(benches, get_all_edges_bench_old, get_all_edges_bench_new2);
+#[allow(dead_code)]
+fn get_all_edges_bench_new3(bench: &mut Bencher) {
+    // this is how we efficient we could make get_all_edges by using Arc
+
+    // 1000 nodes, 10m edges
+    let routing_table_actor = build_graph(10, 100);
+    let all_edges = routing_table_actor.get_all_edges();
+    let mut new_edges_info = HashMap::new();
+    for edge in all_edges {
+        let edge = EdgeNew2 {
+            key: (Arc::new(edge.key.0.clone()), Arc::new(edge.key.1.clone())),
+            nonce: edge.nonce,
+            signature0: edge.signature0.clone(),
+            signature1: edge.signature1.clone(),
+            removal_info: edge.removal_info.clone(),
+        };
+
+        new_edges_info.insert(edge.key.clone(), Arc::new(edge));
+    }
+
+    bench.iter(|| {
+        let result: Vec<Arc<EdgeNew2>> = new_edges_info.iter().map(|x| x.1.clone()).collect();
+        black_box(result);
+    });
+}
+
+benchmark_group!(
+    benches,
+    get_all_edges_bench_old,
+    get_all_edges_bench_new2,
+    get_all_edges_bench_new3
+);
 
 benchmark_main!(benches);
 
@@ -88,6 +119,24 @@ benchmark_main!(benches);
 pub struct EdgeNew {
     /// Since edges are not directed `peer0 < peer1` should hold.
     pub key: Arc<(PeerId, PeerId)>,
+    /// Nonce to keep tracking of the last update on this edge.
+    /// It must be even
+    pub nonce: u64,
+    /// Signature from parties validating the edge. These are signature of the added edge.
+    #[allow(unused)]
+    signature0: Signature,
+    #[allow(unused)]
+    signature1: Signature,
+    /// Info necessary to declare an edge as removed.
+    /// The bool says which party is removing the edge: false for Peer0, true for Peer1
+    /// The signature from the party removing the edge.
+    #[allow(unused)]
+    removal_info: Option<(bool, Signature)>,
+}
+
+pub struct EdgeNew2 {
+    /// Since edges are not directed `peer0 < peer1` should hold.
+    pub key: (Arc<PeerId>, Arc<PeerId>),
     /// Nonce to keep tracking of the last update on this edge.
     /// It must be even
     pub nonce: u64,

--- a/chain/network/benches/routing_table_actor.rs
+++ b/chain/network/benches/routing_table_actor.rs
@@ -39,6 +39,7 @@ fn build_graph(depth: usize, size: usize) -> RoutingTableActor {
 
 #[allow(dead_code)]
 fn get_all_edges_bench_old(bench: &mut Bencher) {
+    // 1000 nodes, 10m edges
     let routing_table_actor = build_graph(10, 100);
     bench.iter(|| {
         let result = routing_table_actor.get_all_edges();
@@ -50,6 +51,7 @@ fn get_all_edges_bench_old(bench: &mut Bencher) {
 fn get_all_edges_bench_new(bench: &mut Bencher) {
     // this is how we efficient we could make get_all_edges by using Arc
 
+    // 1000 nodes, 10m edges
     let routing_table_actor = build_graph(10, 100);
     let all_edges = routing_table_actor.get_all_edges();
     let mut new_edges_info = HashMap::new();

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -38,7 +38,7 @@ use near_rate_limiter::ThrottleController;
 use near_rust_allocator_proxy::allocator::get_tid;
 
 use crate::routing::codec::{self, bytes_to_peer_message, peer_message_to_bytes, Codec};
-use crate::routing::routing::{Edge, EdgeInfo};
+use crate::routing::routing::{EdgeInfo, EdgeInner};
 use crate::stats::metrics::{self, NetworkMetrics};
 use crate::stats::rate_counter::RateCounter;
 use crate::types::{
@@ -869,7 +869,7 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for PeerActor {
                 }
 
                 // Verify signature of the new edge in handshake.
-                if !Edge::partial_verify(
+                if !EdgeInner::partial_verify(
                     self.node_id(),
                     handshake.peer_id.clone(),
                     &handshake.edge_info,

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -47,7 +47,7 @@ use crate::{RoutingTableActor, RoutingTableMessages, RoutingTableMessagesRespons
 use crate::routing::routing::SimpleEdge;
 
 use crate::routing::routing::{
-    Edge, EdgeInfo, EdgeType, EdgeVerifierHelper, PeerRequestResult, RoutingTableView,
+    Edge, EdgeInfo, EdgeInner, EdgeType, EdgeVerifierHelper, PeerRequestResult, RoutingTableView,
     DELETE_PEERS_AFTER_TIME, MAX_NUM_PEERS,
 };
 
@@ -527,13 +527,13 @@ impl PeerManagerActor {
 
         let target_peer_id = full_peer_info.peer_info.id.clone();
 
-        let new_edge = Edge::new(
+        let new_edge = Arc::new(EdgeInner::new(
             self.my_peer_id.clone(),
             target_peer_id.clone(),
             edge_info.nonce,
             edge_info.signature,
             full_peer_info.edge_info.signature.clone(),
-        );
+        ));
 
         self.active_peers.insert(
             target_peer_id.clone(),
@@ -1402,7 +1402,7 @@ impl PeerManagerActor {
     }
 
     fn propose_edge(&self, peer1: PeerId, with_nonce: Option<u64>) -> EdgeInfo {
-        let key = Edge::key(self.my_peer_id.clone(), peer1.clone());
+        let key = EdgeInner::make_key(self.my_peer_id.clone(), peer1.clone());
 
         // When we create a new edge we increase the latest nonce by 2 in case we miss a removal
         // proposal from our partner.
@@ -1881,7 +1881,7 @@ impl PeerManagerActor {
                 NetworkResponses::NoResponse
             }
             NetworkRequests::RequestUpdateNonce(peer_id, edge_info) => {
-                if Edge::partial_verify(self.my_peer_id.clone(), peer_id.clone(), &edge_info) {
+                if EdgeInner::partial_verify(self.my_peer_id.clone(), peer_id.clone(), &edge_info) {
                     if let Some(cur_edge) =
                         self.routing_table_view.get_edge(self.my_peer_id.clone(), peer_id.clone())
                     {
@@ -1892,13 +1892,13 @@ impl PeerManagerActor {
                         }
                     }
 
-                    let new_edge = Edge::build_with_secret_key(
+                    let new_edge = Arc::new(EdgeInner::build_with_secret_key(
                         self.my_peer_id.clone(),
                         peer_id,
                         edge_info.nonce,
                         &self.config.secret_key,
                         edge_info.signature,
-                    );
+                    ));
 
                     self.add_verified_edges_to_routing_table(ctx, vec![new_edge.clone()], false);
                     NetworkResponses::EdgeUpdate(Box::new(new_edge))
@@ -2142,7 +2142,8 @@ impl PeerManagerActor {
             return ConsolidateResponse::InvalidNonce(last_edge.cloned().map(Box::new).unwrap());
         }
 
-        if msg.other_edge_info.nonce >= Edge::next_nonce(last_nonce) + EDGE_NONCE_BUMP_ALLOWED {
+        if msg.other_edge_info.nonce >= EdgeInner::next_nonce(last_nonce) + EDGE_NONCE_BUMP_ALLOWED
+        {
             debug!(target: "network", "Too large nonce. ({} >= {} + {}) {:?} {:?}", msg.other_edge_info.nonce, last_nonce, EDGE_NONCE_BUMP_ALLOWED, self.my_peer_id, msg.peer_info.id);
             return ConsolidateResponse::Reject;
         }

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -911,13 +911,13 @@ impl PeerManagerActor {
         let edges: Vec<Edge> = edges
             .iter()
             .map(|se| {
-                Edge::new(
+                Arc::new(EdgeInner::new(
                     se.key().0.clone(),
                     se.key().1.clone(),
                     se.nonce(),
                     near_crypto::Signature::default(),
                     near_crypto::Signature::default(),
-                )
+                ))
             })
             .collect();
         self.routing_table_view.remove_edges(&edges);

--- a/chain/network/src/routing/ibf_peer_set.rs
+++ b/chain/network/src/routing/ibf_peer_set.rs
@@ -147,7 +147,7 @@ impl IbfPeerSet {
 mod test {
     use crate::routing::ibf_peer_set::{IbfPeerSet, SimpleEdge, SlotMap, SlotMapId};
     use crate::routing::ibf_set::IbfSet;
-    use crate::routing::routing::{Edge, ValidIBFLevel};
+    use crate::routing::routing::{Edge, EdgeInner, ValidIBFLevel};
     use crate::test_utils::random_peer_id;
     use near_primitives::network::PeerId;
     use std::collections::HashMap;
@@ -199,7 +199,7 @@ mod test {
 
         let mut ibf_set = IbfSet::<SimpleEdge>::new(1111);
 
-        let edge = Edge::make_fake_edge(peer_id.clone(), peer_id2.clone(), 111);
+        let edge = EdgeInner::make_fake_edge(peer_id.clone(), peer_id2.clone(), 111);
         let mut edges_info: HashMap<(PeerId, PeerId), Edge> = Default::default();
         edges_info.insert((peer_id.clone(), peer_id2.clone()), edge.clone());
 

--- a/chain/network/src/routing/routing.rs
+++ b/chain/network/src/routing/routing.rs
@@ -76,12 +76,12 @@ pub struct Edge {
     /// It must be even
     pub nonce: u64,
     /// Signature from parties validating the edge. These are signature of the added edge.
-    signature0: Signature,
-    signature1: Signature,
+    pub signature0: Signature,
+    pub signature1: Signature,
     /// Info necessary to declare an edge as removed.
     /// The bool says which party is removing the edge: false for Peer0, true for Peer1
     /// The signature from the party removing the edge.
-    removal_info: Option<(bool, Signature)>,
+    pub removal_info: Option<(bool, Signature)>,
 }
 
 impl Edge {

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -492,6 +492,10 @@ impl RoutingTableActor {
 
         (known, unknown_edges, unknown_edges_count)
     }
+
+    pub fn get_all_edges(&self) -> Vec<Edge> {
+        self.edges_info.iter().map(|x| x.1.clone()).collect()
+    }
 }
 
 impl Handler<RoutingTableMessages> for RoutingTableActor {
@@ -679,7 +683,7 @@ impl Handler<RoutingTableMessages> for RoutingTableActor {
                             ibf_msg: Some(RoutingVersion2 {
                                 known_edges: self.edges_info.len() as u64,
                                 seed: ibf_msg.seed,
-                                edges: self.edges_info.iter().map(|x| x.1.clone()).collect(),
+                                edges: self.get_all_edges(),
                                 routing_state: RoutingState::Done,
                             }),
                         }

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -375,6 +375,10 @@ impl RoutingTableActor {
 
         res
     }
+
+    pub fn get_all_edges(&self) -> Vec<Edge> {
+        self.edges_info.iter().map(|x| x.1.clone()).collect()
+    }
 }
 
 impl Actor for RoutingTableActor {
@@ -491,10 +495,6 @@ impl RoutingTableActor {
         let (known, unknown_edges) = self.split_edges_for_peer(&peer_id, &edge_hashes);
 
         (known, unknown_edges, unknown_edges_count)
-    }
-
-    pub fn get_all_edges(&self) -> Vec<Edge> {
-        self.edges_info.iter().map(|x| x.1.clone()).collect()
     }
 }
 

--- a/chain/network/tests/cache_edges.rs
+++ b/chain/network/tests/cache_edges.rs
@@ -7,7 +7,7 @@ use near_primitives::time::Clock;
 
 use near_crypto::Signature;
 use near_network::routing::routing::{
-    Edge, EdgeType, DELETE_PEERS_AFTER_TIME, SAVE_PEERS_MAX_TIME,
+    Edge, EdgeInner, EdgeType, DELETE_PEERS_AFTER_TIME, SAVE_PEERS_MAX_TIME,
 };
 use near_network::routing::routing_table_actor::Prune;
 use near_network::test_utils::random_peer_id;
@@ -107,7 +107,7 @@ impl RoutingTableTest {
         for EdgeDescription(peer0, peer1, edge_type) in on_memory.iter() {
             let peer0 = self.get_peer(*peer0).clone();
             let peer1 = self.get_peer(*peer1).clone();
-            let (peer0, peer1) = Edge::key(peer0, peer1);
+            let (peer0, peer1) = EdgeInner::make_key(peer0, peer1);
 
             let res = self.routing_table.edges_info.get(&(peer0, peer1));
             assert!(res.is_some());
@@ -162,7 +162,13 @@ impl RoutingTableTest {
     fn add_edge(&mut self, peer0: usize, peer1: usize, nonce: u64) {
         let peer0 = self.get_peer(peer0).clone();
         let peer1 = self.get_peer(peer1).clone();
-        let edge = Edge::new(peer0, peer1, nonce, Signature::default(), Signature::default());
+        let edge = Arc::new(EdgeInner::new(
+            peer0,
+            peer1,
+            nonce,
+            Signature::default(),
+            Signature::default(),
+        ));
         self.routing_table.add_verified_edges_to_routing_table(vec![edge]);
     }
 


### PR DESCRIPTION
Add bench to measure time it takes to copy routing table.

- We should compare what the performance would be if we were using
` HashSet<(PeerId, PeerId), Edge>` vs ` HashSet<(PeerId, PeerId), Arc<Edge>>`

 