### PR TITLE
Increase cache for RockDB by column

### DIFF
--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -672,7 +672,7 @@ fn rocksdb_block_based_options(cache_size: usize) -> BlockBasedOptions {
 
 fn choose_cache_size_mb(col: DBCol) -> usize {
     match col {
-        DBCol::ColState => 256 * 1024 * 1024,
+        DBCol::ColState => 128 * 1024 * 1024,
         _ => 32 * 1024 * 1024,
     }
 }

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -672,7 +672,7 @@ fn rocksdb_block_based_options(cache_size: usize) -> BlockBasedOptions {
 // TODO(#5213) Use ByteSize package to represent sizes.
 fn choose_cache_size(col: DBCol) -> usize {
     match col {
-        DBCol::ColState => 128 * 1024 * 1024,
+        DBCol::ColState => 512 * 1024 * 1024,
         _ => 32 * 1024 * 1024,
     }
 }

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -670,6 +670,7 @@ fn rocksdb_block_based_options(cache_size: usize) -> BlockBasedOptions {
     block_opts
 }
 
+// TODO(#5213) Use ByteSize package to represent sizes.
 fn choose_cache_size_mb(col: DBCol) -> usize {
     match col {
         DBCol::ColState => 128 * 1024 * 1024,

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -658,11 +658,11 @@ fn rocksdb_read_options() -> ReadOptions {
     read_options
 }
 
-fn rocksdb_block_based_options() -> BlockBasedOptions {
+fn rocksdb_block_based_options(cache_size: usize) -> BlockBasedOptions {
     let mut block_opts = BlockBasedOptions::default();
     block_opts.set_block_size(1024 * 16);
     // We create block_cache for each of 47 columns, so the total cache size is 32 * 47 = 1504mb
-    let cache_size = 1024 * 1024 * 32;
+    let cache_size = cache_size;
     block_opts.set_block_cache(&Cache::new_lru_cache(cache_size).unwrap());
     block_opts.set_pin_l0_filter_and_index_blocks_in_cache(true);
     block_opts.set_cache_index_and_filter_blocks(true);
@@ -670,10 +670,18 @@ fn rocksdb_block_based_options() -> BlockBasedOptions {
     block_opts
 }
 
+fn choose_cache_size_mb(col: DBCol) -> usize {
+    match col {
+        DBCol::ColState => 256 * 1024 * 1024,
+        _ => 32 * 1024 * 1024,
+    }
+}
+
 fn rocksdb_column_options(col: DBCol) -> Options {
     let mut opts = Options::default();
     opts.set_level_compaction_dynamic_level_bytes(true);
-    opts.set_block_based_table_factory(&rocksdb_block_based_options());
+    let cache_size = choose_cache_size_mb(col);
+    opts.set_block_based_table_factory(&rocksdb_block_based_options(cache_size));
     opts.optimize_level_style_compaction(1024 * 1024 * 128);
     opts.set_target_file_size_base(1024 * 1024 * 64);
     opts.set_compression_per_level(&[]);

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -662,7 +662,6 @@ fn rocksdb_block_based_options(cache_size: usize) -> BlockBasedOptions {
     let mut block_opts = BlockBasedOptions::default();
     block_opts.set_block_size(1024 * 16);
     // We create block_cache for each of 47 columns, so the total cache size is 32 * 47 = 1504mb
-    let cache_size = cache_size;
     block_opts.set_block_cache(&Cache::new_lru_cache(cache_size).unwrap());
     block_opts.set_pin_l0_filter_and_index_blocks_in_cache(true);
     block_opts.set_cache_index_and_filter_blocks(true);

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -670,7 +670,7 @@ fn rocksdb_block_based_options(cache_size: usize) -> BlockBasedOptions {
 }
 
 // TODO(#5213) Use ByteSize package to represent sizes.
-fn choose_cache_size_mb(col: DBCol) -> usize {
+fn choose_cache_size(col: DBCol) -> usize {
     match col {
         DBCol::ColState => 128 * 1024 * 1024,
         _ => 32 * 1024 * 1024,
@@ -680,7 +680,7 @@ fn choose_cache_size_mb(col: DBCol) -> usize {
 fn rocksdb_column_options(col: DBCol) -> Options {
     let mut opts = Options::default();
     opts.set_level_compaction_dynamic_level_bytes(true);
-    let cache_size = choose_cache_size_mb(col);
+    let cache_size = choose_cache_size(col);
     opts.set_block_based_table_factory(&rocksdb_block_based_options(cache_size));
     opts.optimize_level_style_compaction(1024 * 1024 * 128);
     opts.set_target_file_size_base(1024 * 1024 * 64);


### PR DESCRIPTION
We recently found out that our rockdb is not efficient enough.
Therefore we would like to increase cache size of specific columns.
In this PR we will increase cache size for `DBCol::ColState` to 128mb.

We can adjust that cache size later, but we try to be conservative in memory usage. 
Some testing should be done to determine optimize cache sizes. 


Closes https://github.com/near/nearcore/issues/5203