### PR TITLE
Refactor code for handling time in near-performance-metrics

### DIFF
--- a/utils/near-performance-metrics/src/actix_enabled.rs
+++ b/utils/near-performance-metrics/src/actix_enabled.rs
@@ -34,8 +34,8 @@ where
 
         f(a, b);
 
-        let ended = Instant::now();
-        let took = ended - now;
+        let now = Instant::now();
+        let ended = now.saturating_duration_since(ended);
         stat.lock().unwrap().log("run_later", loc.file(), loc.line(), took, ended, "");
         if took > SLOW_CALL_THRESHOLD {
             warn!(

--- a/utils/near-performance-metrics/src/actix_enabled.rs
+++ b/utils/near-performance-metrics/src/actix_enabled.rs
@@ -29,13 +29,13 @@ where
 
     let f2 = move |a: &mut A, b: &mut A::Context| {
         let stat = get_thread_stats_logger();
-        let now = Instant::now();
-        stat.lock().unwrap().pre_log(now);
+        let started = Instant::now();
+        stat.lock().unwrap().pre_log(started);
 
         f(a, b);
 
-        let now = Instant::now();
-        let ended = now.saturating_duration_since(ended);
+        let ended = Instant::now();
+        let took = ended.saturating_duration_since(started);
         stat.lock().unwrap().log("run_later", loc.file(), loc.line(), took, ended, "");
         if took > SLOW_CALL_THRESHOLD {
             warn!(

--- a/utils/near-performance-metrics/src/framed_write.rs
+++ b/utils/near-performance-metrics/src/framed_write.rs
@@ -336,7 +336,7 @@ impl<I, T: AsyncWrite + Unpin, U: Encoder<I>, K: 'static + EncoderCallBack>
                 high: HIGH_WATERMARK,
                 handle: SpawnHandle::default(),
                 task: None,
-                callback: callback,
+                callback,
             })),
             Rc::new(RefCell::new(io)),
         );

--- a/utils/near-performance-metrics/src/stats_enabled.rs
+++ b/utils/near-performance-metrics/src/stats_enabled.rs
@@ -110,7 +110,7 @@ impl ThreadStats {
         self.in_progress_since = None;
         self.c_mem = get_c_memory_usage_cur_thread();
 
-        let took_since_last_check = min(took, max(self.last_check, now) - self.last_check);
+        let took_since_last_check = min(took, now.saturating_duration_since(self.last_check));
 
         let entry = self.stat.entry((msg, line, msg_text)).or_insert_with(|| Entry {
             cnt: 0,
@@ -135,7 +135,7 @@ impl ThreadStats {
         let mut ratio = self.time.as_nanos() as f64;
         if let Some(in_progress_since) = self.in_progress_since {
             let from = max(in_progress_since, self.last_check);
-            ratio += (max(now, from) - from).as_nanos() as f64;
+            ratio += (now.saturating_duration_since(from)).as_nanos() as f64;
         }
         ratio /= sleep_time.as_nanos() as f64;
 
@@ -318,11 +318,11 @@ where
 
     reset_memory_usage_max();
     let initial_memory_usage = current_thread_memory_usage();
-    let now = Instant::now();
-    stat.lock().unwrap().pre_log(now);
+    let start = Instant::now();
+    stat.lock().unwrap().pre_log(start);
     let result = f(msg);
 
-    let took = now.elapsed();
+    let took = start.elapsed();
 
     let peak_memory =
         ByteSize::b(current_thread_peak_memory_usage().saturating_sub(initial_memory_usage) as u64);
@@ -362,7 +362,7 @@ where
         }
     }
     let ended = Instant::now();
-    let took = ended - now;
+    let took = ended.saturating_duration_since(start);
     stat.lock().unwrap().log(
         class_name,
         std::any::type_name::<Message>(),
@@ -394,12 +394,12 @@ where
         let this = unsafe { self.get_unchecked_mut() };
 
         let stat = get_thread_stats_logger();
-        let now = Instant::now();
-        stat.lock().unwrap().pre_log(now);
+        let start = Instant::now();
+        stat.lock().unwrap().pre_log(start);
 
         let res = unsafe { Pin::new_unchecked(&mut this.f) }.poll(cx);
         let ended = Instant::now();
-        let took = ended - now;
+        let took = ended.saturating_duration_since(start);
         stat.lock().unwrap().log(this.class_name, this.file, this.line, took, ended, "");
 
         if took > SLOW_CALL_THRESHOLD {


### PR DESCRIPTION
We should refactor the code to handle time in a safe way.

It's not safe to compute duration using `end - start`. Due to various bugs, this can cause panic as seen in #5172

We have seen a crash related to not handling time correctly https://github.com/near/nearcore/pull/5172