### PR TITLE
Chunk delays monitoring for `1.22`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3357,7 +3357,7 @@ dependencies = [
 
 [[package]]
 name = "neard"
-version = "1.22.0-rc.4"
+version = "1.22.0-rc.5"
 dependencies = [
  "actix",
  "clap 3.0.0-beta.2",

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1088,6 +1088,7 @@ impl Chain {
         F3: FnMut(ChallengeBody) -> (),
     {
         near_metrics::inc_counter(&metrics::BLOCK_PROCESSED_TOTAL);
+        near_metrics::set_gauge(&metrics::NUM_ORPHANS, self.orphans.len() as i64);
 
         let prev_head = self.store.head()?;
         let mut chain_update = self.chain_update();

--- a/chain/chain/src/metrics.rs
+++ b/chain/chain/src/metrics.rs
@@ -25,4 +25,6 @@ lazy_static! {
         "near_validator_active_total",
         "The total number of validators active after last block"
     );
+    pub static ref NUM_ORPHANS: near_metrics::Result<IntGauge> =
+        try_create_int_gauge("near_num_orphans", "Number of orphan blocks.");
 }

--- a/chain/client/src/chunks_delay_tracker.rs
+++ b/chain/client/src/chunks_delay_tracker.rs
@@ -1,0 +1,185 @@
+use std::collections::{BTreeMap, HashMap};
+use std::time::Instant;
+
+use near_primitives::types::{BlockHeight, ShardId};
+
+use crate::metrics;
+use std::cmp::max;
+
+/// Provides monitoring information about the delays of receiving blocks and their corresponding chunks.
+/// Keeps timestamps of a limited number of blocks before the current head.
+/// Keeps timestamps of all blocks and chunks from the future.
+/// Doesn't make any assumptions about shard layout or the number of shards. If the head was moved forward, we assume that all requirements were satisfied.
+/// This object provides two metrics:
+/// 1) max delay between discovering a block and receiving the last chunk from that block.
+/// 2) the difference between the latest known block and the current head.
+/// If a chunk or a block is received multiple times, only the first time is recorded.
+#[derive(Debug, Default)]
+pub(crate) struct ChunksDelayTracker {
+    heights: BTreeMap<BlockHeight, HeightInfo>,
+}
+
+const CHUNKS_DELAY_TRACKER_HORIZON: u64 = 10;
+
+#[derive(Debug, Default)]
+struct HeightInfo {
+    block_received: Option<Instant>,
+    chunks_received: HashMap<ShardId, Instant>,
+}
+
+impl ChunksDelayTracker {
+    // Blocks below this heights are not tracked.
+    fn lowest_height(head_height: BlockHeight) -> BlockHeight {
+        head_height.saturating_sub(CHUNKS_DELAY_TRACKER_HORIZON)
+    }
+
+    fn remove_old_entries(&mut self, head_height: BlockHeight) {
+        let heights_to_drop: Vec<BlockHeight> = self
+            .heights
+            .range(..ChunksDelayTracker::lowest_height(head_height))
+            .map(|(&k, _v)| k)
+            .collect();
+        for h in heights_to_drop {
+            self.heights.remove(&h);
+        }
+    }
+
+    // Computes the delay between receiving a block and receiving the latest of its chunks.
+    // Updates the metric to the max delay across the most recently processed blocks.
+    fn update_chunks_metric(&mut self, head_height: BlockHeight) {
+        let mut max_delay = 0;
+        for (_, v) in self.heights.range(..=head_height) {
+            if let Some(block_received) = v.block_received {
+                if let Some(latest_chunk) = v.chunks_received.values().max() {
+                    if latest_chunk > &block_received {
+                        let delay = latest_chunk.duration_since(block_received).as_micros();
+                        max_delay = max(max_delay, delay);
+                    }
+                }
+            }
+        }
+        near_metrics::set_gauge(&metrics::CHUNKS_RECEIVING_DELAY_US, max_delay as i64);
+    }
+
+    // Computes the difference between the latest block we are aware of and the current head.
+    fn update_blocks_ahead_metric(&mut self, head_height: BlockHeight) {
+        let value = if let Some((&latest, _)) = self.heights.iter().next_back() {
+            latest.saturating_sub(head_height)
+        } else {
+            0
+        };
+        near_metrics::set_gauge(&metrics::BLOCKS_AHEAD_OF_HEAD, value as i64);
+    }
+
+    fn update_metrics(&mut self, head_height: BlockHeight) {
+        self.update_chunks_metric(head_height);
+        self.update_blocks_ahead_metric(head_height);
+    }
+
+    pub fn add_block_timestamp(
+        &mut self,
+        height: BlockHeight,
+        head_height: BlockHeight,
+        timestamp: Instant,
+    ) {
+        self.remove_old_entries(head_height);
+        if height >= head_height {
+            self.heights.entry(height).or_default().block_received.get_or_insert(timestamp);
+        }
+        self.update_metrics(head_height);
+    }
+
+    pub fn add_chunk_timestamp(
+        &mut self,
+        height: BlockHeight,
+        shard_id: ShardId,
+        head_height: BlockHeight,
+        timestamp: Instant,
+    ) {
+        self.remove_old_entries(head_height);
+        if height >= head_height {
+            self.heights
+                .entry(height)
+                .or_default()
+                .chunks_received
+                .entry(shard_id)
+                .or_insert(timestamp);
+        }
+        self.update_metrics(head_height);
+    }
+}
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn test_blocks_ahead_of_head() {
+        let mut tracker = ChunksDelayTracker::default();
+        tracker.add_block_timestamp(3, 1, Instant::now());
+        assert_eq!(near_metrics::get_gauge(&metrics::BLOCKS_AHEAD_OF_HEAD), Ok(2));
+        tracker.add_block_timestamp(4, 1, Instant::now());
+        assert_eq!(near_metrics::get_gauge(&metrics::BLOCKS_AHEAD_OF_HEAD), Ok(3));
+        tracker.add_block_timestamp(4, 3, Instant::now());
+        assert_eq!(near_metrics::get_gauge(&metrics::BLOCKS_AHEAD_OF_HEAD), Ok(1));
+        tracker.add_block_timestamp(4, 5, Instant::now());
+        assert_eq!(near_metrics::get_gauge(&metrics::BLOCKS_AHEAD_OF_HEAD), Ok(0));
+        tracker.add_block_timestamp(4, 999, Instant::now());
+        assert_eq!(near_metrics::get_gauge(&metrics::BLOCKS_AHEAD_OF_HEAD), Ok(0));
+    }
+
+    #[test]
+    fn test_timestamps() {
+        let start = Instant::now();
+        let mut tracker = ChunksDelayTracker::default();
+
+        // Multiple chunks.
+        tracker.add_block_timestamp(3, 1, start);
+        tracker.add_chunk_timestamp(3, 0, 1, start + Duration::from_secs(1));
+        tracker.add_chunk_timestamp(3, 1, 1, start + Duration::from_secs(2));
+
+        // No chunks.
+        tracker.add_block_timestamp(4, 3, start + Duration::from_secs(5));
+
+        // Block and chunk from the past.
+        tracker.add_block_timestamp(1, 4, start + Duration::from_secs(7));
+        tracker.add_chunk_timestamp(1, 0, 4, start + Duration::from_secs(7));
+
+        assert_eq!(
+            near_metrics::get_gauge(&metrics::CHUNKS_RECEIVING_DELAY_US),
+            Ok(Duration::from_secs(2).as_micros() as i64)
+        );
+
+        // New block with a smaller delay between receiving chunks.
+        tracker.add_block_timestamp(5, 4, start + Duration::from_secs(10));
+        tracker.add_chunk_timestamp(5, 0, 5, start + Duration::from_secs(11));
+        assert_eq!(
+            near_metrics::get_gauge(&metrics::CHUNKS_RECEIVING_DELAY_US),
+            Ok(Duration::from_secs(2).as_micros() as i64)
+        );
+
+        // New block with a smaller delay between receiving chunks but far in the future, the old block should be forgotten.
+        tracker.add_block_timestamp(105, 5, start + Duration::from_secs(20));
+        tracker.add_chunk_timestamp(105, 0, 105, start + Duration::from_secs(21));
+        assert_eq!(
+            near_metrics::get_gauge(&metrics::CHUNKS_RECEIVING_DELAY_US),
+            Ok(Duration::from_secs(1).as_micros() as i64)
+        );
+
+        // New block with a larger delay between receiving chunks.
+        tracker.add_block_timestamp(106, 105, start + Duration::from_secs(23));
+        tracker.add_chunk_timestamp(106, 0, 106, start + Duration::from_secs(28));
+        assert_eq!(
+            near_metrics::get_gauge(&metrics::CHUNKS_RECEIVING_DELAY_US),
+            Ok(Duration::from_secs(5).as_micros() as i64)
+        );
+
+        // A block in the future doesn't matter for the metric.
+        tracker.add_block_timestamp(206, 106, start + Duration::from_secs(100));
+        tracker.add_chunk_timestamp(206, 0, 106, start + Duration::from_secs(999));
+        assert_eq!(
+            near_metrics::get_gauge(&metrics::CHUNKS_RECEIVING_DELAY_US),
+            Ok(Duration::from_secs(5).as_micros() as i64)
+        );
+    }
+}

--- a/chain/client/src/lib.rs
+++ b/chain/client/src/lib.rs
@@ -15,6 +15,7 @@ pub use crate::client_actor::{start_client, ClientActor};
 pub use crate::view_client::AdversarialControls;
 pub use crate::view_client::{start_view_client, ViewClientActor};
 
+mod chunks_delay_tracker;
 mod client;
 mod client_actor;
 mod info;

--- a/chain/client/src/metrics.rs
+++ b/chain/client/src/metrics.rs
@@ -34,4 +34,12 @@ lazy_static! {
         "near_chunk_tgas_used",
         "Number of Tgas (10^12 of gas) used by the last processed chunk"
     );
+    pub static ref CHUNKS_RECEIVING_DELAY_US: near_metrics::Result<IntGauge> = try_create_int_gauge(
+        "near_chunks_receiving_delay_us",
+        "Max delay between receiving a block and its chunks for several most recent blocks"
+    );
+    pub static ref BLOCKS_AHEAD_OF_HEAD: near_metrics::Result<IntGauge> = try_create_int_gauge(
+        "near_blocks_ahead_of_head",
+        "Height difference between the current head and the newest block or chunk received"
+    );
 }

--- a/core/metrics/src/lib.rs
+++ b/core/metrics/src/lib.rs
@@ -230,3 +230,10 @@ pub fn dec_gauge(gauge: &Result<IntGauge>) {
         error!(target: "metrics", "Failed to fetch gauge");
     }
 }
+pub fn get_gauge(gauge: &Result<IntGauge>) -> std::result::Result<i64, String> {
+    if let Ok(gauge) = gauge {
+        Ok(gauge.get())
+    } else {
+        Err("Failed to fetch gauge".to_string())
+    }
+}

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -683,6 +683,19 @@ impl PartialEncodedChunk {
             }
         }
     }
+
+    pub fn height_created(&self) -> BlockHeight {
+        match self {
+            Self::V1(chunk) => chunk.header.inner.height_created,
+            Self::V2(chunk) => chunk.header.height_created(),
+        }
+    }
+    pub fn shard_id(&self) -> ShardId {
+        match self {
+            Self::V1(chunk) => chunk.header.inner.shard_id,
+            Self::V2(chunk) => chunk.header.shard_id(),
+        }
+    }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone, Eq, PartialEq)]

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neard"
-version = "1.22.0-rc.4"
+version = "1.22.0-rc.5"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 publish = false
 edition = "2018"


### PR DESCRIPTION
Include https://github.com/near/nearcore/pull/5185 in the `1.22` release.