### PR TITLE
REFACTOR Remove unused method from Edge struct

### DIFF
--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -300,7 +300,7 @@ impl PeerManagerActor {
             if !edge.contains_peer(&self.my_peer_id) {
                 continue;
             }
-            let key = edge.get_pair();
+            let key = edge.key();
             if !self.routing_table_view.is_local_edge_newer(&key, edge.nonce()) {
                 continue;
             }
@@ -398,7 +398,7 @@ impl PeerManagerActor {
                 if !edge.contains_peer(&self.my_peer_id) {
                     continue;
                 }
-                let key = edge.get_pair();
+                let key = edge.key();
                 if !self.routing_table_view.is_local_edge_newer(&key, edge.nonce()) {
                     continue;
                 }
@@ -1927,7 +1927,7 @@ impl PeerManagerActor {
             }
             NetworkRequests::ResponseUpdateNonce(edge) => {
                 if edge.contains_peer(&self.my_peer_id) && edge.verify() {
-                    let key = edge.get_pair();
+                    let key = edge.key();
                     if self.routing_table_view.is_local_edge_newer(&key, edge.nonce()) {
                         let other = edge.other(&self.my_peer_id).unwrap();
                         if let Some(nonce) =

--- a/chain/network/src/routing/edge.rs
+++ b/chain/network/src/routing/edge.rs
@@ -241,10 +241,6 @@ impl EdgeInner {
         }
     }
 
-    pub fn get_pair(&self) -> &(PeerId, PeerId) {
-        &self.key
-    }
-
     /// It will be considered as a new edge if the nonce is odd, otherwise it is canceling the
     /// previous edge.
     pub fn edge_type(&self) -> EdgeType {

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -116,7 +116,7 @@ impl RoutingTableActor {
         #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
         self.peer_ibf_set.remove_edge(&edge.to_simple_edge());
 
-        let key = &edge.key();
+        let key = edge.key();
         if self.edges_info.remove(&key).is_some() {
             self.raw_graph.remove_edge(&edge.key().0, &edge.key().1);
             self.needs_routing_table_recalculation = true;
@@ -126,7 +126,7 @@ impl RoutingTableActor {
     /// `add_verified_edge` adds edges, for which we already that theirs signatures
     /// are valid (`signature0`, `signature`).
     fn add_verified_edge(&mut self, edge: Edge) -> bool {
-        let key = edge.get_pair();
+        let key = edge.key();
         if !self.is_edge_newer(&key, edge.nonce()) {
             // We already have a newer information about this edge. Discard this information.
             false
@@ -161,7 +161,7 @@ impl RoutingTableActor {
 
         let total = edges.len();
         edges.retain(|edge| {
-            let key = edge.get_pair();
+            let key = edge.key();
 
             self.fetch_edges_for_peer_from_disk(&key.0);
             self.fetch_edges_for_peer_from_disk(&key.1);


### PR DESCRIPTION
`key` and `nonce` attributes of `Edge` have `pub` modifier. We are going to remove `pub` modifier to make internal structure of `Edge` private. This will be used in the future, to change `Edge` internal representation to make `PeerManager`, `RoutingTableActor` more efficient.

For example, we could make Edge use `Arc<PeerId>` to remove duplicates of signatures, thus reducing size of `Edge` and improving efficiency.
Or change key to use `Arc<PeerId, PeerId>`, etc. This would remove having to store duplicates of key, in a few hashmaps like `edges_info`, and ones used for `IBF` algorithm.