### PR TITLE
Replace PeerId with Arc<PeerId>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2769,6 +2769,7 @@ dependencies = [
  "near-rust-allocator-proxy",
  "near-stable-hasher",
  "near-store",
+ "once_cell",
  "rand 0.7.3",
  "serde",
  "strum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2769,7 +2769,6 @@ dependencies = [
  "near-rust-allocator-proxy",
  "near-stable-hasher",
  "near-store",
- "once_cell",
  "rand 0.7.3",
  "serde",
  "strum",

--- a/chain/network-primitives/Cargo.toml
+++ b/chain/network-primitives/Cargo.toml
@@ -9,7 +9,7 @@ actix = "=0.11.0-beta.2"
 tokio = { version = "1.1", features = ["full"] }
 chrono = { version = "0.4.4", features = ["serde"] }
 borsh = "0.9"
-serde = { version = "1", features = [ "derive" ] }
+serde = { version = "1", features = ["derive", "rc", "alloc"] }
 strum = { version = "0.20", features = ["derive"] }
 tracing = "0.1.13"
 

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -21,6 +21,7 @@ near-rust-allocator-proxy = "0.3.0"
 bytesize = "1.0.1"
 conqueue = "0.4.0"
 serde = { version = "1", features = ["derive", "rc", "alloc"], optional=true }
+once_cell = "1.5.2"
 
 borsh = { version = "0.9", features = ["rc"]}
 cached = "0.23"

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -20,8 +20,7 @@ strum = { version = "0.20", features = ["derive"] }
 near-rust-allocator-proxy = "0.3.0"
 bytesize = "1.0.1"
 conqueue = "0.4.0"
-serde = { version = "1", features = ["derive"], optional=true }
-once_cell = "1.5.2"
+serde = { version = "1", features = ["derive", "rc", "alloc"], optional=true }
 
 borsh = { version = "0.9", features = ["rc"]}
 cached = "0.23"

--- a/core/primitives/src/network.rs
+++ b/core/primitives/src/network.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use std::hash::Hash;
+use std::sync::Arc;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
@@ -11,11 +12,27 @@ use crate::types::{AccountId, EpochId};
 
 /// Peer id is the public key.
 #[derive(
+    BorshSerialize, BorshDeserialize, Clone, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
+pub struct PeerId(Arc<PeerIdInner>);
+
+/// Peer id is the public key.
+#[derive(
     BorshSerialize, BorshDeserialize, Clone, Eq, PartialOrd, Ord, Serialize, Deserialize, Hash,
 )]
-pub struct PeerId(PublicKey);
+pub struct PeerIdInner(PublicKey);
 
 impl PeerId {
+    pub fn new(key: PublicKey) -> Self {
+        Self(Arc::new(PeerIdInner(key)))
+    }
+
+    pub fn public_key(&self) -> &PublicKey {
+        &self.0 .0
+    }
+}
+
+impl PeerIdInner {
     pub fn new(key: PublicKey) -> Self {
         Self(key)
     }
@@ -39,7 +56,7 @@ impl From<&PeerId> for Vec<u8> {
 
 impl From<PublicKey> for PeerId {
     fn from(public_key: PublicKey) -> PeerId {
-        PeerId(public_key)
+        PeerId::new(public_key)
     }
 }
 
@@ -47,11 +64,17 @@ impl TryFrom<Vec<u8>> for PeerId {
     type Error = Box<dyn std::error::Error>;
 
     fn try_from(bytes: Vec<u8>) -> Result<PeerId, Self::Error> {
-        Ok(PeerId(PublicKey::try_from_slice(&bytes)?))
+        Ok(PeerId::new(PublicKey::try_from_slice(&bytes)?))
     }
 }
 
 impl PartialEq for PeerId {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 .0 == other.0 .0
+    }
+}
+
+impl PartialEq for PeerIdInner {
     fn eq(&self, other: &Self) -> bool {
         self.0 == other.0
     }
@@ -59,18 +82,18 @@ impl PartialEq for PeerId {
 
 impl fmt::Display for PeerId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+        write!(f, "{}", self.0 .0)
     }
 }
 
 impl fmt::Debug for PeerId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+        write!(f, "{}", self.0 .0)
     }
 }
 
 /// Account announcement information
-#[derive(BorshSerialize, BorshDeserialize, Serialize, PartialEq, Eq, Clone, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Clone, Debug)]
 pub struct AnnounceAccount {
     /// AccountId to be announced.
     pub account_id: AccountId,


### PR DESCRIPTION
We ran a test, and we found that that we can replace old routing table exchange by 30% if we replace `PeerId` with `Arc<PeerId>`.

Mentioned in https://github.com/near/nearcore/issues/5221

Before
```
running 3 tests
test calculate_distance_10_10  ... bench:      12,261 ns/iter (+/- 329)
test calculate_distance_10_100 ... bench:   1,333,230 ns/iter (+/- 20,893)
test calculate_distance_3_3    ... bench:         732 ns/iter (+/- 16)
```

After
```
test calculate_distance_10_10  ... bench:      11,488 ns/iter (+/- 220)
test calculate_distance_10_100 ... bench:     672,570 ns/iter (+/- 58,342)
test calculate_distance_3_3    ... bench:         616 ns/iter (+/- 5)
```


Before
```
test get_all_edges_bench_old  ... bench:   1,001,797 ns/iter (+/- 383,813)
```
After:
```                                                                                                                                                                                               
test get_all_edges_bench_old  ... bench:     761,119 ns/iter (+/- 463,381)            
```