### PR TITLE
Replace Arc<Edge> with a structure

### DIFF
--- a/chain/network/benches/routing_table_actor.rs
+++ b/chain/network/benches/routing_table_actor.rs
@@ -7,7 +7,7 @@ use near_crypto::Signature;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use near_network::routing::routing::{Edge, EdgeInner};
+use near_network::routing::routing::Edge;
 use near_network::test_utils::random_peer_id;
 use near_network::RoutingTableActor;
 use near_primitives::network::PeerId;
@@ -22,7 +22,7 @@ fn build_graph(depth: usize, size: usize) -> RoutingTableActor {
 
     let mut edges: Vec<Edge> = Vec::new();
     for i in 0..size {
-        edges.push(EdgeInner::make_fake_edge(source.clone(), nodes[i].clone(), 1));
+        edges.push(Edge::make_fake_edge(source.clone(), nodes[i].clone(), 1));
     }
 
     for layer in 0..depth - 1 {
@@ -30,7 +30,7 @@ fn build_graph(depth: usize, size: usize) -> RoutingTableActor {
             for v in 0..size {
                 let peer0 = nodes[layer * size + u].clone();
                 let peer1 = nodes[(layer + 1) * size + v].clone();
-                edges.push(EdgeInner::make_fake_edge(peer0, peer1, (layer + u + v) as u64));
+                edges.push(Edge::make_fake_edge(peer0, peer1, (layer + u + v) as u64));
             }
         }
     }

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -38,7 +38,7 @@ use near_rate_limiter::ThrottleController;
 use near_rust_allocator_proxy::allocator::get_tid;
 
 use crate::routing::codec::{self, bytes_to_peer_message, peer_message_to_bytes, Codec};
-use crate::routing::routing::{EdgeInfo, EdgeInner};
+use crate::routing::routing::{Edge, EdgeInfo};
 use crate::stats::metrics::{self, NetworkMetrics};
 use crate::stats::rate_counter::RateCounter;
 use crate::types::{
@@ -869,7 +869,7 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for PeerActor {
                 }
 
                 // Verify signature of the new edge in handshake.
-                if !EdgeInner::partial_verify(
+                if !Edge::partial_verify(
                     self.node_id(),
                     handshake.peer_id.clone(),
                     &handshake.edge_info,

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -47,7 +47,7 @@ use crate::{RoutingTableActor, RoutingTableMessages, RoutingTableMessagesRespons
 use crate::routing::routing::SimpleEdge;
 
 use crate::routing::routing::{
-    Edge, EdgeInfo, EdgeInner, EdgeType, EdgeVerifierHelper, PeerRequestResult, RoutingTableView,
+    Edge, EdgeInfo, EdgeType, EdgeVerifierHelper, PeerRequestResult, RoutingTableView,
     DELETE_PEERS_AFTER_TIME, MAX_NUM_PEERS,
 };
 
@@ -527,13 +527,13 @@ impl PeerManagerActor {
 
         let target_peer_id = full_peer_info.peer_info.id.clone();
 
-        let new_edge = Arc::new(EdgeInner::new(
+        let new_edge = Edge::new(
             self.my_peer_id.clone(),
             target_peer_id.clone(),
             edge_info.nonce,
             edge_info.signature,
             full_peer_info.edge_info.signature.clone(),
-        ));
+        );
 
         self.active_peers.insert(
             target_peer_id.clone(),
@@ -928,13 +928,13 @@ impl PeerManagerActor {
         let edges: Vec<Edge> = edges
             .iter()
             .map(|se| {
-                Arc::new(EdgeInner::new(
+                Edge::new(
                     se.key().0.clone(),
                     se.key().1.clone(),
                     se.nonce(),
                     near_crypto::Signature::default(),
                     near_crypto::Signature::default(),
-                ))
+                )
             })
             .collect();
         self.routing_table_view.remove_edges(&edges);
@@ -1422,7 +1422,7 @@ impl PeerManagerActor {
     }
 
     fn propose_edge(&self, peer1: PeerId, with_nonce: Option<u64>) -> EdgeInfo {
-        let key = EdgeInner::make_key(self.my_peer_id.clone(), peer1.clone());
+        let key = Edge::make_key(self.my_peer_id.clone(), peer1.clone());
 
         // When we create a new edge we increase the latest nonce by 2 in case we miss a removal
         // proposal from our partner.
@@ -1901,7 +1901,7 @@ impl PeerManagerActor {
                 NetworkResponses::NoResponse
             }
             NetworkRequests::RequestUpdateNonce(peer_id, edge_info) => {
-                if EdgeInner::partial_verify(self.my_peer_id.clone(), peer_id.clone(), &edge_info) {
+                if Edge::partial_verify(self.my_peer_id.clone(), peer_id.clone(), &edge_info) {
                     if let Some(cur_edge) =
                         self.routing_table_view.get_edge(self.my_peer_id.clone(), peer_id.clone())
                     {
@@ -1912,13 +1912,13 @@ impl PeerManagerActor {
                         }
                     }
 
-                    let new_edge = Arc::new(EdgeInner::build_with_secret_key(
+                    let new_edge = Edge::build_with_secret_key(
                         self.my_peer_id.clone(),
                         peer_id,
                         edge_info.nonce,
                         &self.config.secret_key,
                         edge_info.signature,
-                    ));
+                    );
 
                     self.add_verified_edges_to_routing_table(ctx, vec![new_edge.clone()], false);
                     NetworkResponses::EdgeUpdate(Box::new(new_edge))
@@ -2162,8 +2162,7 @@ impl PeerManagerActor {
             return ConsolidateResponse::InvalidNonce(last_edge.cloned().map(Box::new).unwrap());
         }
 
-        if msg.other_edge_info.nonce >= EdgeInner::next_nonce(last_nonce) + EDGE_NONCE_BUMP_ALLOWED
-        {
+        if msg.other_edge_info.nonce >= Edge::next_nonce(last_nonce) + EDGE_NONCE_BUMP_ALLOWED {
             debug!(target: "network", "Too large nonce. ({} >= {} + {}) {:?} {:?}", msg.other_edge_info.nonce, last_nonce, EDGE_NONCE_BUMP_ALLOWED, self.my_peer_id, msg.peer_info.id);
             return ConsolidateResponse::Reject;
         }

--- a/chain/network/src/routing/ibf_peer_set.rs
+++ b/chain/network/src/routing/ibf_peer_set.rs
@@ -147,7 +147,7 @@ impl IbfPeerSet {
 mod test {
     use crate::routing::ibf_peer_set::{IbfPeerSet, SimpleEdge, SlotMap, SlotMapId};
     use crate::routing::ibf_set::IbfSet;
-    use crate::routing::routing::{Edge, EdgeInner, ValidIBFLevel};
+    use crate::routing::routing::{Edge, ValidIBFLevel};
     use crate::test_utils::random_peer_id;
     use near_primitives::network::PeerId;
     use std::collections::HashMap;
@@ -199,7 +199,7 @@ mod test {
 
         let mut ibf_set = IbfSet::<SimpleEdge>::new(1111);
 
-        let edge = EdgeInner::make_fake_edge(peer_id.clone(), peer_id2.clone(), 111);
+        let edge = Edge::make_fake_edge(peer_id.clone(), peer_id2.clone(), 111);
         let mut edges_info: HashMap<(PeerId, PeerId), Edge> = Default::default();
         edges_info.insert((peer_id.clone(), peer_id2.clone()), edge.clone());
 

--- a/chain/network/src/routing/routing.rs
+++ b/chain/network/src/routing/routing.rs
@@ -132,8 +132,11 @@ impl Edge {
     /// to verify the signature.
     pub fn partial_verify(peer0: PeerId, peer1: PeerId, edge_info: &EdgeInfo) -> bool {
         let pk = peer1.public_key();
-        let (peer0, peer1) = Edge::make_key(peer0, peer1);
-        let data = Edge::build_hash(&peer0, &peer1, edge_info.nonce);
+        let data = if peer0 < peer1 {
+            Edge::build_hash(&peer0, &peer1, edge_info.nonce)
+        } else {
+            Edge::build_hash(&peer1, &peer0, edge_info.nonce)
+        };
         edge_info.signature.verify(data.as_ref(), &pk)
     }
 

--- a/chain/network/src/routing/routing.rs
+++ b/chain/network/src/routing/routing.rs
@@ -51,8 +51,8 @@ pub struct EdgeInfo {
 
 impl EdgeInfo {
     pub fn new(peer0: PeerId, peer1: PeerId, nonce: u64, secret_key: &SecretKey) -> Self {
-        let (peer0, peer1) = EdgeInner::make_key(peer0, peer1);
-        let data = EdgeInner::build_hash(&peer0, &peer1, nonce);
+        let (peer0, peer1) = Edge::make_key(peer0, peer1);
+        let data = Edge::build_hash(&peer0, &peer1, nonce);
         let signature = secret_key.sign(data.as_ref());
         Self { nonce, signature }
     }
@@ -65,7 +65,95 @@ pub enum EdgeType {
     Removed,
 }
 
-pub type Edge = Arc<EdgeInner>;
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "test_features", derive(Serialize, Deserialize))]
+pub struct Edge(pub Arc<EdgeInner>);
+
+impl Edge {
+    /// Create an addition edge.
+    pub fn new(
+        peer0: PeerId,
+        peer1: PeerId,
+        nonce: u64,
+        signature0: Signature,
+        signature1: Signature,
+    ) -> Self {
+        Edge(Arc::new(EdgeInner::new(peer0, peer1, nonce, signature0, signature1)))
+    }
+
+    pub fn make_fake_edge(peer0: PeerId, peer1: PeerId, nonce: u64) -> Self {
+        Self(Arc::new(EdgeInner {
+            key: (peer0, peer1),
+            nonce,
+            signature0: Signature::empty(KeyType::ED25519),
+            signature1: Signature::empty(KeyType::ED25519),
+            removal_info: None,
+        }))
+    }
+
+    /// Build a new edge with given information from the other party.
+    pub fn build_with_secret_key(
+        peer0: PeerId,
+        peer1: PeerId,
+        nonce: u64,
+        secret_key: &SecretKey,
+        signature1: Signature,
+    ) -> Self {
+        let hash = if peer0 < peer1 {
+            Self::build_hash(&peer0, &peer1, nonce)
+        } else {
+            Self::build_hash(&peer1, &peer0, nonce)
+        };
+        let signature0 = secret_key.sign(hash.as_ref());
+        Self::new(peer0, peer1, nonce, signature0, signature1)
+    }
+
+    /// Build the hash of the edge given its content.
+    /// It is important that peer0 < peer1 at this point.
+    fn build_hash(peer0: &PeerId, peer1: &PeerId, nonce: u64) -> CryptoHash {
+        let mut buffer = Vec::<u8>::new();
+        let peer0: Vec<u8> = peer0.into();
+        buffer.extend_from_slice(peer0.as_slice());
+        let peer1: Vec<u8> = peer1.into();
+        buffer.extend_from_slice(peer1.as_slice());
+        buffer.write_u64::<LittleEndian>(nonce).unwrap();
+        hash(buffer.as_slice())
+    }
+
+    pub fn make_key(peer0: PeerId, peer1: PeerId) -> (PeerId, PeerId) {
+        if peer0 < peer1 {
+            (peer0, peer1)
+        } else {
+            (peer1, peer0)
+        }
+    }
+
+    /// Helper function when adding a new edge and we receive information from new potential peer
+    /// to verify the signature.
+    pub fn partial_verify(peer0: PeerId, peer1: PeerId, edge_info: &EdgeInfo) -> bool {
+        let pk = peer1.public_key();
+        let (peer0, peer1) = Edge::make_key(peer0, peer1);
+        let data = Edge::build_hash(&peer0, &peer1, edge_info.nonce);
+        edge_info.signature.verify(data.as_ref(), &pk)
+    }
+
+    /// Next nonce of valid addition edge.
+    pub fn next_nonce(nonce: u64) -> u64 {
+        if nonce % 2 == 1 {
+            nonce + 2
+        } else {
+            nonce + 1
+        }
+    }
+}
+
+impl std::ops::Deref for Edge {
+    type Target = EdgeInner;
+
+    fn deref(&self) -> &EdgeInner {
+        &self.0
+    }
+}
 
 /// Edge object. Contains information relative to a new edge that is being added or removed
 /// from the network. This is the information that is required.
@@ -112,35 +200,8 @@ impl EdgeInner {
         SimpleEdge::new(self.key.0.clone(), self.key.1.clone(), self.nonce)
     }
 
-    pub fn make_fake_edge(peer0: PeerId, peer1: PeerId, nonce: u64) -> Arc<Self> {
-        Arc::new(Self {
-            key: (peer0, peer1),
-            nonce,
-            signature0: Signature::empty(KeyType::ED25519),
-            signature1: Signature::empty(KeyType::ED25519),
-            removal_info: None,
-        })
-    }
-
-    /// Build a new edge with given information from the other party.
-    pub fn build_with_secret_key(
-        peer0: PeerId,
-        peer1: PeerId,
-        nonce: u64,
-        secret_key: &SecretKey,
-        signature1: Signature,
-    ) -> Self {
-        let hash = if peer0 < peer1 {
-            Self::build_hash(&peer0, &peer1, nonce)
-        } else {
-            Self::build_hash(&peer1, &peer0, nonce)
-        };
-        let signature0 = secret_key.sign(hash.as_ref());
-        Self::new(peer0, peer1, nonce, signature0, signature1)
-    }
-
     /// Create the remove edge change from an added edge change.
-    pub fn remove_edge(&self, my_peer_id: PeerId, sk: &SecretKey) -> Arc<Self> {
+    pub fn remove_edge(&self, my_peer_id: PeerId, sk: &SecretKey) -> Edge {
         assert_eq!(self.edge_type(), EdgeType::Added);
         let mut edge = self.clone();
         edge.nonce += 1;
@@ -148,27 +209,15 @@ impl EdgeInner {
         let hash = edge.hash();
         let signature = sk.sign(hash.as_ref());
         edge.removal_info = Some((me, signature));
-        Arc::new(edge)
-    }
-
-    /// Build the hash of the edge given its content.
-    /// It is important that peer0 < peer1 at this point.
-    fn build_hash(peer0: &PeerId, peer1: &PeerId, nonce: u64) -> CryptoHash {
-        let mut buffer = Vec::<u8>::new();
-        let peer0: Vec<u8> = peer0.into();
-        buffer.extend_from_slice(peer0.as_slice());
-        let peer1: Vec<u8> = peer1.into();
-        buffer.extend_from_slice(peer1.as_slice());
-        buffer.write_u64::<LittleEndian>(nonce).unwrap();
-        hash(buffer.as_slice())
+        Edge(Arc::new(edge))
     }
 
     fn hash(&self) -> CryptoHash {
-        Self::build_hash(&self.key.0, &self.key.1, self.nonce)
+        Edge::build_hash(&self.key.0, &self.key.1, self.nonce)
     }
 
     fn prev_hash(&self) -> CryptoHash {
-        Self::build_hash(&self.key.0, &self.key.1, self.nonce - 1)
+        Edge::build_hash(&self.key.0, &self.key.1, self.nonce - 1)
     }
 
     pub fn verify(&self) -> bool {
@@ -209,23 +258,6 @@ impl EdgeInner {
         }
     }
 
-    pub fn make_key(peer0: PeerId, peer1: PeerId) -> (PeerId, PeerId) {
-        if peer0 < peer1 {
-            (peer0, peer1)
-        } else {
-            (peer1, peer0)
-        }
-    }
-
-    /// Helper function when adding a new edge and we receive information from new potential peer
-    /// to verify the signature.
-    pub fn partial_verify(peer0: PeerId, peer1: PeerId, edge_info: &EdgeInfo) -> bool {
-        let pk = peer1.public_key().clone();
-        let (peer0, peer1) = EdgeInner::make_key(peer0, peer1);
-        let data = EdgeInner::build_hash(&peer0, &peer1, edge_info.nonce);
-        edge_info.signature.verify(data.as_ref(), &pk)
-    }
-
     pub fn get_pair(&self) -> &(PeerId, PeerId) {
         &self.key
     }
@@ -239,19 +271,9 @@ impl EdgeInner {
             EdgeType::Removed
         }
     }
-
-    /// Next nonce of valid addition edge.
-    pub fn next_nonce(nonce: u64) -> u64 {
-        if nonce % 2 == 1 {
-            nonce + 2
-        } else {
-            nonce + 1
-        }
-    }
-
     /// Next nonce of valid addition edge.
     pub fn next(&self) -> u64 {
-        EdgeInner::next_nonce(self.nonce)
+        Edge::next_nonce(self.nonce)
     }
 
     pub fn contains_peer(&self, peer_id: &PeerId) -> bool {
@@ -280,7 +302,7 @@ pub struct SimpleEdge {
 
 impl SimpleEdge {
     pub fn new(peer0: PeerId, peer1: PeerId, nonce: u64) -> SimpleEdge {
-        let (peer0, peer1) = EdgeInner::make_key(peer0, peer1);
+        let (peer0, peer1) = Edge::make_key(peer0, peer1);
         SimpleEdge { key: (peer0, peer1), nonce }
     }
 
@@ -635,7 +657,7 @@ impl RoutingTableView {
     pub fn get_edge(&self, peer0: PeerId, peer1: PeerId) -> Option<&Edge> {
         assert!(peer0 == self.my_peer_id || peer1 == self.my_peer_id);
 
-        let key = EdgeInner::make_key(peer0, peer1);
+        let key = Edge::make_key(peer0, peer1);
         self.local_edges_info.get(&key)
     }
 }

--- a/chain/network/tests/cache_edges.rs
+++ b/chain/network/tests/cache_edges.rs
@@ -7,7 +7,7 @@ use near_primitives::time::Clock;
 
 use near_crypto::Signature;
 use near_network::routing::routing::{
-    Edge, EdgeInner, EdgeType, DELETE_PEERS_AFTER_TIME, SAVE_PEERS_MAX_TIME,
+    Edge, EdgeType, DELETE_PEERS_AFTER_TIME, SAVE_PEERS_MAX_TIME,
 };
 use near_network::routing::routing_table_actor::Prune;
 use near_network::test_utils::random_peer_id;
@@ -107,7 +107,7 @@ impl RoutingTableTest {
         for EdgeDescription(peer0, peer1, edge_type) in on_memory.iter() {
             let peer0 = self.get_peer(*peer0).clone();
             let peer1 = self.get_peer(*peer1).clone();
-            let (peer0, peer1) = EdgeInner::make_key(peer0, peer1);
+            let (peer0, peer1) = Edge::make_key(peer0, peer1);
 
             let res = self.routing_table.edges_info.get(&(peer0, peer1));
             assert!(res.is_some());
@@ -162,13 +162,7 @@ impl RoutingTableTest {
     fn add_edge(&mut self, peer0: usize, peer1: usize, nonce: u64) {
         let peer0 = self.get_peer(peer0).clone();
         let peer1 = self.get_peer(peer1).clone();
-        let edge = Arc::new(EdgeInner::new(
-            peer0,
-            peer1,
-            nonce,
-            Signature::default(),
-            Signature::default(),
-        ));
+        let edge = Edge::new(peer0, peer1, nonce, Signature::default(), Signature::default());
         self.routing_table.add_verified_edges_to_routing_table(vec![edge]);
     }
 


### PR DESCRIPTION
As @matklad suggested, it's a good idea to replace `Arc<Edge>` with a structure, to make code more readable.