### PR TITLE
feat: Move `EdgeVerifierActor` inside `RoutingTableActor`

### DIFF
--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -8,7 +8,7 @@ use crate::peer_manager::peer_store::{PeerStore, TrustLevel};
 ))]
 use crate::routing::edge::SimpleEdge;
 use crate::routing::edge::{Edge, EdgeInfo, EdgeType};
-use crate::routing::edge_verifier_actor::{EdgeVerifierActor, EdgeVerifierHelper};
+use crate::routing::edge_verifier_actor::EdgeVerifierHelper;
 use crate::routing::routing::{
     PeerRequestResult, RoutingTableView, DELETE_PEERS_AFTER_TIME, MAX_NUM_PEERS,
 };
@@ -28,7 +28,7 @@ use crate::types::{RoutingSyncV2, RoutingVersion2};
 use crate::{PeerInfo, RoutingTableActor, RoutingTableMessages, RoutingTableMessagesResponse};
 use actix::{
     Actor, ActorFuture, Addr, Arbiter, AsyncContext, Context, ContextFutureSpawner, Handler,
-    Recipient, Running, StreamHandler, SyncArbiter, WrapFuture,
+    Recipient, Running, StreamHandler, WrapFuture,
 };
 #[cfg(feature = "delay_detector")]
 use delay_detector::DelayDetector;
@@ -164,8 +164,6 @@ pub struct PeerManagerActor {
     local_peer_pending_update_nonce_request: HashMap<PeerId, u64>,
     /// Dynamic Prometheus metrics
     network_metrics: NetworkMetrics,
-    /// EdgeVerifierActor, which is responsible for veryfing edges.
-    edge_verifier_pool: Addr<EdgeVerifierActor>,
     /// RoutingTableActor, responsible for computing routing table, routing table exchange, etc.
     routing_table_addr: Addr<RoutingTableActor>,
     /// Shared counter across all PeerActors, which counts number of `RoutedMessageBody::ForwardTx`
@@ -175,9 +173,6 @@ pub struct PeerManagerActor {
     pending_incoming_connections_counter: Arc<AtomicUsize>,
     /// Number of active peers, used for rate limiting.
     peer_counter: Arc<AtomicUsize>,
-    /// Number of edge verifications in progress; We will not update routing table as long as
-    /// this number is non zero.
-    edge_verifier_requests_in_progress: u64,
     /// Used for testing, for disabling features.
     adv_helper: AdvHelper,
 }
@@ -230,8 +225,6 @@ impl PeerManagerActor {
         debug!(target: "network", "Found known peers: {} (boot nodes={})", peer_store.len(), config.boot_nodes.len());
         debug!(target: "network", "Blacklist: {:?}", config.blacklist);
 
-        let edge_verifier_pool = SyncArbiter::start(4, || EdgeVerifierActor {});
-
         let my_peer_id: PeerId = PeerId::new(config.public_key.clone());
         let routing_table = RoutingTableView::new(my_peer_id.clone(), store);
 
@@ -251,12 +244,10 @@ impl PeerManagerActor {
             started_connect_attempts: false,
             local_peer_pending_update_nonce_request: HashMap::new(),
             network_metrics: NetworkMetrics::new(),
-            edge_verifier_pool,
             routing_table_addr,
             txns_since_last_block,
             pending_incoming_connections_counter: Arc::new(AtomicUsize::new(0)),
             peer_counter: Arc::new(AtomicUsize::new(0)),
-            edge_verifier_requests_in_progress: 0,
             adv_helper: AdvHelper::default(),
         })
     }
@@ -270,13 +261,17 @@ impl PeerManagerActor {
         self.routing_table_addr
             .send(RoutingTableMessages::RoutingTableUpdate { prune, prune_edges_not_reachable_for })
             .into_actor(self)
-            .map(|response, act, _| match response {
+            .map(|response, act, ctx| match response {
                 Ok(RoutingTableMessagesResponse::RoutingTableUpdateResponse {
                     edges_to_remove,
                     peer_forwarding,
+                    peers_to_ban,
                 }) => {
                     act.routing_table_view.remove_edges(&edges_to_remove);
                     act.routing_table_view.peer_forwarding = peer_forwarding;
+                    for peer in peers_to_ban {
+                        act.ban_peer(ctx, &peer, ReasonForBan::InvalidEdge);
+                    }
                 }
                 _ => error!(target: "network", "expected RoutingTableUpdateResponse"),
             })
@@ -354,8 +349,7 @@ impl PeerManagerActor {
     ///   waiting to have their signatures checked.
     /// - edge pruning may be disabled for unit testing.
     fn update_routing_table_trigger(&mut self, ctx: &mut Context<Self>) {
-        let can_prune_edges = self.edge_verifier_requests_in_progress == 0
-            && !self.adv_helper.adv_disable_edge_pruning();
+        let can_prune_edges = !self.adv_helper.adv_disable_edge_pruning();
 
         self.update_routing_table_and_prune_edges(
             ctx,
@@ -1210,33 +1204,22 @@ impl PeerManagerActor {
         );
     }
 
-    fn verify_edges(&mut self, ctx: &mut Context<Self>, peer_id: PeerId, edges: Vec<Edge>) {
+    fn verify_edges(&mut self, _ctx: &mut Context<Self>, peer_id: PeerId, edges: Vec<Edge>) {
         if edges.is_empty() {
             return;
         }
-        self.edge_verifier_requests_in_progress += 1;
-        self.edge_verifier_pool
-            .send(EdgeList {
-                edges,
-                edges_info_shared: self.routing_table_exchange_helper.edges_info_shared.clone(),
-                sender: self.routing_table_exchange_helper.edges_to_add_sender.clone(),
-                #[cfg(feature = "test_features")]
-                adv_disable_edge_signature_verification: self
-                    .adv_helper
-                    .adv_disable_edge_signature_verification,
-            })
-            .into_actor(self)
-            .then(move |response, act, ctx| {
-                act.edge_verifier_requests_in_progress -= 1;
-                match response {
-                    Ok(false) => act.try_ban_peer(ctx, &peer_id, ReasonForBan::InvalidEdge),
-                    Ok(true) => {}
-                    Err(err) => warn!(target: "network", "error validating edges: {}", err),
-                }
-                actix::fut::ready(())
-            })
-            .spawn(ctx);
+        self.routing_table_addr.do_send(EdgeList {
+            edges,
+            edges_info_shared: self.routing_table_exchange_helper.edges_info_shared.clone(),
+            sender: self.routing_table_exchange_helper.edges_to_add_sender.clone(),
+            #[cfg(feature = "test_features")]
+            adv_disable_edge_signature_verification: self
+                .adv_helper
+                .adv_disable_edge_signature_verification,
+            peer_id,
+        });
     }
+
     /// Broadcast message to all active peers.
     fn broadcast_message(&self, ctx: &mut Context<Self>, msg: SendMessage) {
         // TODO(MarX, #1363): Implement smart broadcasting. (MST)
@@ -1584,12 +1567,6 @@ impl Actor for PeerManagerActor {
         for (_, active_peer) in self.active_peers.iter() {
             active_peer.addr.do_send(msg.clone());
         }
-
-        self.edge_verifier_pool
-            .send(StopMsg {})
-            .into_actor(self)
-            .then(move |_, _, _| actix::fut::ready(()))
-            .spawn(ctx);
 
         self.routing_table_addr
             .send(StopMsg {})

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -855,6 +855,7 @@ pub struct EdgeList {
     pub(crate) sender: QueueSender<Edge>,
     #[cfg(feature = "test_features")]
     pub(crate) adv_disable_edge_signature_verification: bool,
+    pub(crate) peer_id: PeerId,
 }
 
 impl Message for EdgeList {

--- a/chain/network/tests/cache_edges.rs
+++ b/chain/network/tests/cache_edges.rs
@@ -1,3 +1,4 @@
+use actix::System;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Instant;
@@ -171,57 +172,83 @@ impl RoutingTableTest {
 
 #[test]
 fn empty() {
+    let _system = System::new();
+
     let mut test = RoutingTableTest::new();
     test.check(vec![], vec![], vec![]);
     assert_eq!(test.routing_table.next_available_component_nonce, 0);
+
+    System::current().stop();
 }
 
 #[test]
 fn one_edge() {
+    let _system = System::new();
+
     let mut test = RoutingTableTest::new();
     test.add_edge(0, 1, 1);
     test.check(vec![(0, 1, true)], vec![], vec![]);
+
+    System::current().stop();
 }
 
 #[test]
 fn active_old_edge() {
+    let _system = System::new();
+
     let mut test = RoutingTableTest::new();
     test.add_edge(0, 1, 1);
     test.set_times(vec![(1, 2)]);
     test.update_routing_table();
     test.check(vec![(0, 1, true)], vec![], vec![]);
+
+    System::current().stop();
 }
 
 #[test]
 fn inactive_old_edge() {
+    let _system = System::new();
+
     let mut test = RoutingTableTest::new();
     test.add_edge(0, 1, 2);
     test.set_times(vec![(1, 2)]);
     test.update_routing_table();
     test.check(vec![], vec![(0, vec![(0, 1, false)])], vec![(1, 0)]);
+
+    System::current().stop();
 }
 
 #[test]
 fn inactive_recent_edge() {
+    let _system = System::new();
+
     let mut test = RoutingTableTest::new();
     test.add_edge(0, 1, 2);
     test.set_times(vec![(1, 1)]);
     test.update_routing_table();
     test.check(vec![(0, 1, false)], vec![], vec![]);
+
+    System::current().stop();
 }
 
 #[test]
 fn load_component_nonce_on_start() {
+    let _system = System::new();
+
     let mut test = RoutingTableTest::new();
     test.add_edge(0, 1, 2);
     test.set_times(vec![(1, 2)]);
     test.update_routing_table();
     let routing_table = RoutingTableActor::new(random_peer_id(), test.store.clone());
     assert_eq!(routing_table.next_available_component_nonce, 2);
+
+    System::current().stop();
 }
 
 #[test]
 fn load_component_nonce_2_on_start() {
+    let _system = System::new();
+
     let mut test = RoutingTableTest::new();
     test.add_edge(0, 1, 2);
     test.set_times(vec![(1, 2)]);
@@ -236,10 +263,14 @@ fn load_component_nonce_2_on_start() {
     );
     let routing_table = RoutingTableActor::new(random_peer_id(), test.store.clone());
     assert_eq!(routing_table.next_available_component_nonce, 3);
+
+    System::current().stop();
 }
 
 #[test]
 fn two_components() {
+    let _system = System::new();
+
     let mut test = RoutingTableTest::new();
     test.add_edge(0, 1, 2);
     test.set_times(vec![(1, 2)]);
@@ -254,10 +285,14 @@ fn two_components() {
         vec![(2, vec![(0, 1, false), (0, 2, false), (1, 2, true)])],
         vec![(1, 2), (2, 2)],
     );
+
+    System::current().stop();
 }
 
 #[test]
 fn overwrite_edge() {
+    let _system = System::new();
+
     let mut test = RoutingTableTest::new();
     test.add_edge(0, 1, 2);
     test.set_times(vec![(1, 2)]);
@@ -270,4 +305,6 @@ fn overwrite_edge() {
     test.add_edge(0, 1, 3);
     test.update_routing_table();
     test.check(vec![(0, 1, true), (1, 2, true), (0, 2, false)], vec![], vec![]);
+
+    System::current().stop();
 }


### PR DESCRIPTION
Currently, `PeerManager` is responsible to sending edges to check their signatures `EdgeVerifierActor`.
Then `PeerManager` runs `broadcast_edges_trigger` trigger, which is time consuming.
And then `PeerManager` sends edges to `RoutingTableActor`.

This has a few issues:
- `PeerManager` is spends a bit of time running  `broadcast_edges_trigger`.
- There is an extra structure in `EdgeVerifierActor` which leaks memory and can be removed
- `PeerManager` doesn't care about the edges by itself. This adds extra complexity in the logic.

In the current design:
We create `RoutingTableActor` first then `PeerManagerActor` We pass `Addr<RoutingTableActor>` to `PeerManagerActor`, and we keep references to for both.
- `RoutingTableActor` create `EdgeVerifierActor` and also talks to ` RoutingTableActor`. 
- When new edges are received from network. `PeerManagerActor` sends edges to `EdgeVerifierActors`, reads reply from a `ConcurrentQueue`, and sends them to `RoutingTableActor` for `RoutingTableActor` to update it's storage of `Edges` and updating `RoutingTable`.

That design is a bit compileted:
The final design in 3-4 PRs.
- We create `PeerManagerActor`, `PeerManagerActor` creates `RoutingTableActor`. Then then `RoutingTableActor` created `EdgeVerifierActor`.
- When edges are received from Network. `PeerManagerActor` will send a message with edges to `RoutingTableActor`.
`RoutingTableActor` actor will send edges to `EdgeVerifierActor`, read the response, and update the routing table.

In conclusion:
- `PeerManager` will be less loaded
- We will fix memory leak
- `Code` structure will be easier to understand.

Part 1: `RoutingTableActor` goes inside `RouringTableActor`
- [x] implement ban peer logic
- [x] filter out edges before sending them to `EdgeVerifier`
- [x] Fix tests

Part 2: Offload work from `PeerManagerActor`
- [ ] Move `trigger` from `PeerManager` to `RoutingTableActor`. 

Part 3: Fix memory leak
- [ ] Rewrite how we use `EdgeVerifierActor`

Part 4: Move `RoutingTableActor` fully back to `PeerManagerActor
- [ ] Rewrite how `JsonRpcServer` communicates with `PeerManagerActor`
- [ ] Initially this was done to add support for `JsonRpcServer`, that can be done in a better way.
