### PR TITLE
Mark some of near-network crates as private

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -23,10 +23,7 @@ use near_chain::{
 use near_chain_configs::ClientConfig;
 use near_chunks::{ProcessPartialEncodedChunkResult, ShardsManager};
 use near_network::types::{PartialEncodedChunkResponseMsg, PeerManagerMessageRequest};
-use near_network::{
-    FullPeerInfo, NetworkClientResponses, NetworkRequests, PeerManagerAdapter,
-    EPOCH_SYNC_PEER_TIMEOUT_MS, EPOCH_SYNC_REQUEST_TIMEOUT_MS,
-};
+use near_network::{FullPeerInfo, NetworkClientResponses, NetworkRequests, PeerManagerAdapter};
 use near_primitives::block::{Approval, ApprovalInner, ApprovalMessage, Block, BlockHeader, Tip};
 use near_primitives::challenge::{Challenge, ChallengeBody};
 use near_primitives::hash::CryptoHash;
@@ -56,6 +53,13 @@ use near_primitives::version::{ProtocolVersion, PROTOCOL_VERSION};
 use near_network::types::PartialEncodedChunkForwardMsg;
 
 const NUM_REBROADCAST_BLOCKS: usize = 30;
+
+/// The time we wait for the response to a Epoch Sync request before retrying
+// TODO #3488 set 30_000
+pub const EPOCH_SYNC_REQUEST_TIMEOUT_MS: u64 = 1_000;
+/// How frequently a Epoch Sync response can be sent to a particular peer
+// TODO #3488 set 60_000
+pub const EPOCH_SYNC_PEER_TIMEOUT_MS: u64 = 10;
 
 pub struct Client {
     /// Adversarial controls

--- a/chain/network/src/lib.rs
+++ b/chain/network/src/lib.rs
@@ -1,4 +1,3 @@
-pub use peer::peer_actor::{EPOCH_SYNC_PEER_TIMEOUT_MS, EPOCH_SYNC_REQUEST_TIMEOUT_MS};
 pub use peer_manager::peer_manager_actor::PeerManagerActor;
 pub use routing::routing_table_actor::{
     RoutingTableActor, RoutingTableMessages, RoutingTableMessagesResponse,

--- a/chain/network/src/peer/mod.rs
+++ b/chain/network/src/peer/mod.rs
@@ -1,2 +1,2 @@
-pub mod peer_actor;
+pub(crate) mod peer_actor;
 mod rate_counter;

--- a/chain/network/src/routing/mod.rs
+++ b/chain/network/src/routing/mod.rs
@@ -1,6 +1,6 @@
-pub mod codec;
-pub mod edge_verifier_actor;
-pub mod ibf;
+pub(crate) mod codec;
+pub(crate) mod edge_verifier_actor;
+pub(crate) mod ibf;
 pub mod ibf_peer_set;
 pub mod ibf_set;
 mod route_back_cache;


### PR DESCRIPTION
Mark some of near-network crates as private.


Also move 
```

/// The time we wait for the response to a Epoch Sync request before retrying
// TODO #3488 set 30_000
pub const EPOCH_SYNC_REQUEST_TIMEOUT_MS: u64 = 1_000;
/// How frequently a Epoch Sync response can be sent to a particular peer
// TODO #3488 set 60_000
pub const EPOCH_SYNC_PEER_TIMEOUT_MS: u64 = 10;

```

to `ClientActor`.