### PR TITLE
Change code owners for network primitives

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,6 +4,7 @@
 /chain/client/src/view_client.rs @frol @khorolets @chefsale
 /chain/client-primitives/ @frol @khorolets @chefsale
 /chain/network/ @mm-near @bowenwang1996 @pmnoxx
+/chain/network-primitives/ @mm-near @bowenwang1996 @pmnoxx
 /chain/jsonrpc/ @frol @khorolets @chefsale
 /chain/jsonrpc-primitives/ @frol @khorolets @chefsale
 /chain/indexer/ @khorolets @frol

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,7 +4,7 @@
 /chain/client/src/view_client.rs @frol @khorolets @chefsale
 /chain/client-primitives/ @frol @khorolets @chefsale
 /chain/network/ @mm-near @bowenwang1996 @pmnoxx
-/chain/network-primitives/ @mm-near @bowenwang1996 @pmnoxx
+/chain/network-primitives/ @mm-near @pmnoxx
 /chain/jsonrpc/ @frol @khorolets @chefsale
 /chain/jsonrpc-primitives/ @frol @khorolets @chefsale
 /chain/indexer/ @khorolets @frol


### PR DESCRIPTION
`/chain/jsonrpc` has same owners as `/chain/jsonrpc-primitives`.
same for /chain/client/src/view_client.rs` and `/chain/client-primitives`.

Should we do the same thing for `/chain/network` and `/chain/network-primitives` ?