### PR TITLE
Reorganize dependencies in Cargo.toml for near-network

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2755,6 +2755,7 @@ dependencies = [
  "conqueue",
  "delay-detector",
  "futures",
+ "lazy_static",
  "near-actix-test-utils",
  "near-chain",
  "near-chain-configs",

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -6,52 +6,51 @@ publish = false
 edition = "2021"
 
 [dependencies]
-bytes = "1"
 actix = "=0.11.0-beta.2"
-tokio = { version = "1.1", features = ["full"] }
-tokio-util = { version = "0.6", features = ["codec"] }
-tokio-stream = { version = "0.1.2", features = ["net"] }
-futures = "0.3"
-chrono = { version = "0.4.4", features = ["serde"] }
-rand = "0.7"
-byteorder = "1.2"
-tracing = "0.1.13"
-strum = { version = "0.20", features = ["derive"] }
-near-rust-allocator-proxy = "0.3.0"
-bytesize = "1.0.1"
-conqueue = "0.4.0"
-serde = { version = "1", features = ["derive", "rc", "alloc"], optional=true }
-once_cell = "1.5.2"
-
 borsh = { version = "0.9", features = ["rc"]}
+byteorder = "1.2"
+bytes = "1"
+bytesize = "1.0.1"
 cached = "0.23"
-
-near-network-primitives = { path = "../network-primitives" }
-near-chain-configs = { path = "../../core/chain-configs" }
-near-crypto = { path = "../../core/crypto" }
-near-primitives = { path = "../../core/primitives" }
-near-store = { path = "../../core/store" }
-near-metrics = { path = "../../core/metrics" }
-near-performance-metrics = { path = "../../utils/near-performance-metrics" }
-near-performance-metrics-macros = { path = "../../utils/near-performance-metrics-macros" }
-near-stable-hasher = { path = "../../utils/near-stable-hasher" }
-near-rate-limiter = {path = "../../utils/near-rate-limiter" }
+chrono = { version = "0.4.4", features = ["serde"] }
+conqueue = "0.4.0"
+futures = "0.3"
+lazy_static = "1.4"
+near-rust-allocator-proxy = "0.3.0"
+once_cell = "1.5.2"
+rand = "0.7"
+serde = { version = "1", features = ["derive", "rc", "alloc"], optional=true }
+strum = { version = "0.20", features = ["derive"] }
+tokio = { version = "1.1", features = ["full"] }
+tokio-stream = { version = "0.1.2", features = ["net"] }
+tokio-util = { version = "0.6", features = ["codec"] }
+tracing = "0.1.13"
 
 delay-detector = { path = "../../tools/delay_detector", optional = true}
+near-chain-configs = { path = "../../core/chain-configs" }
+near-crypto = { path = "../../core/crypto" }
+near-metrics = { path = "../../core/metrics" }
+near-network-primitives = { path = "../network-primitives" }
+near-performance-metrics = { path = "../../utils/near-performance-metrics" }
+near-performance-metrics-macros = { path = "../../utils/near-performance-metrics-macros" }
+near-primitives = { path = "../../core/primitives" }
+near-rate-limiter = {path = "../../utils/near-rate-limiter" }
+near-stable-hasher = { path = "../../utils/near-stable-hasher" }
+near-store = { path = "../../core/store" }
 
 [dev-dependencies]
+bencher = "0.1.5"
+near-actix-test-utils = { path = "../../test-utils/actix-test-utils" }
 near-chain = { path = "../chain" }
 near-logger-utils = {path = "../../test-utils/logger"}
-near-actix-test-utils = { path = "../../test-utils/actix-test-utils" }
 tempfile = "3"
-bencher = "0.1.5"
 
 [features]
-test_features = ["near-network-primitives/test_features", "serde"]
 delay_detector = ["delay-detector"]
 performance_stats = ["near-performance-metrics/performance_stats"]
-sandbox = ["near-network-primitives/sandbox"]
 protocol_feature_routing_exchange_algorithm = ["near-primitives/protocol_feature_routing_exchange_algorithm"]
+sandbox = ["near-network-primitives/sandbox"]
+test_features = ["near-network-primitives/test_features", "serde"]
 
 [[bench]]
 name = "graph"


### PR DESCRIPTION
Dependencies in `near-network` / `Cargo.toml` are not sorted correctly. Let's fix that.