### PR TITLE
Fix routing::ping_jump test

### DIFF
--- a/integration-tests/tests/network/routing.rs
+++ b/integration-tests/tests/network/routing.rs
@@ -102,6 +102,7 @@ fn ping_jump() {
 
     runner.push(Action::AddEdge(0, 1));
     runner.push(Action::AddEdge(1, 2));
+    runner.push(Action::Wait(1000));
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![1])]));
     runner.push(Action::PingTo(0, 0, 2));
     runner.push(Action::CheckPingPong(2, vec![(0, 0, None)], vec![]));

--- a/integration-tests/tests/network/routing.rs
+++ b/integration-tests/tests/network/routing.rs
@@ -102,8 +102,9 @@ fn ping_jump() {
 
     runner.push(Action::AddEdge(0, 1));
     runner.push(Action::AddEdge(1, 2));
-    runner.push(Action::Wait(1000));
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![1])]));
+    // We update routing table with 1s delay in PeerManager
+    runner.push(Action::Wait(1500));
     runner.push(Action::PingTo(0, 0, 2));
     runner.push(Action::CheckPingPong(2, vec![(0, 0, None)], vec![]));
     runner.push(Action::CheckPingPong(0, vec![], vec![(0, 2, None)]));


### PR DESCRIPTION
Add fix to `routing::ping_jump` test
As seen in `https://buildkite.com/nearprotocol/nearcore/builds/6677#5ccd6608-35c5-474b-9cb9-819a4033eccb`

This happened, because updating routing table is not done in `PeerManager` anymore.