### PR TITLE
Optimize build_hash function by 50%

### DIFF
--- a/chain/network-primitives/src/types.rs
+++ b/chain/network-primitives/src/types.rs
@@ -18,7 +18,7 @@ use tracing::{error, warn};
 
 use near_crypto::{KeyType, PublicKey, SecretKey, Signature};
 use near_primitives::block::{Approval, Block, BlockHeader, GenesisId};
-use near_primitives::hash::{hash, CryptoHash};
+use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::combine_hash;
 use near_primitives::network::{AnnounceAccount, PeerId};
 use near_primitives::sharding::{
@@ -418,11 +418,7 @@ impl RoutedMessage {
         source: &PeerId,
         body: &RoutedMessageBody,
     ) -> CryptoHash {
-        hash(
-            &RoutedMessageNoSignature { target, author: source, body }
-                .try_to_vec()
-                .expect("Failed to serialize"),
-        )
+        CryptoHash::hash_borsh(&RoutedMessageNoSignature { target, author: source, body })
     }
 
     pub fn hash(&self) -> CryptoHash {

--- a/chain/network/benches/routing_table_actor.rs
+++ b/chain/network/benches/routing_table_actor.rs
@@ -3,7 +3,7 @@ extern crate bencher;
 
 use bencher::black_box;
 use bencher::Bencher;
-use near_crypto::Signature;
+use near_crypto::{KeyType, SecretKey, Signature};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -101,11 +101,25 @@ fn get_all_edges_bench_new3(bench: &mut Bencher) {
     });
 }
 
+#[allow(dead_code)]
+fn benchmark_sign_edge(bench: &mut Bencher) {
+    let sk = SecretKey::from_seed(KeyType::ED25519, "1234");
+
+    let p0 = PeerId::from(sk.public_key());
+    let p1 = PeerId::random();
+
+    bench.iter(|| {
+        let ei = EdgeInner::build_hash(&p0, &p1, 123);
+        black_box(ei);
+    });
+}
+
 benchmark_group!(
     benches,
     get_all_edges_bench_old,
     get_all_edges_bench_new2,
-    get_all_edges_bench_new3
+    get_all_edges_bench_new3,
+    benchmark_sign_edge
 );
 
 benchmark_main!(benches);

--- a/chain/network/benches/routing_table_actor.rs
+++ b/chain/network/benches/routing_table_actor.rs
@@ -109,7 +109,7 @@ fn benchmark_sign_edge(bench: &mut Bencher) {
     let p1 = PeerId::random();
 
     bench.iter(|| {
-        let ei = EdgeInner::build_hash(&p0, &p1, 123);
+        let ei = Edge::build_hash(&p0, &p1, 123);
         black_box(ei);
     });
 }

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -986,8 +986,8 @@ impl PeerManagerActor {
             ctx,
             other.clone(),
             PeerMessage::RequestUpdateNonce(EdgeInfo::new(
-                self.my_peer_id.clone(),
-                other.clone(),
+                &self.my_peer_id,
+                other,
                 nonce,
                 &self.config.secret_key,
             )),
@@ -1432,7 +1432,7 @@ impl PeerManagerActor {
                 .map_or(1, |edge| edge.next())
         });
 
-        EdgeInfo::new(key.0, key.1, nonce, &self.config.secret_key)
+        EdgeInfo::new(&key.0, &key.1, nonce, &self.config.secret_key)
     }
 
     // Ping pong useful functions.

--- a/chain/network/src/routing/routing.rs
+++ b/chain/network/src/routing/routing.rs
@@ -114,7 +114,7 @@ impl Edge {
 
     /// Build the hash of the edge given its content.
     /// It is important that peer0 < peer1 at this point.
-    fn build_hash(peer0: &PeerId, peer1: &PeerId, nonce: u64) -> CryptoHash {
+    pub fn build_hash(peer0: &PeerId, peer1: &PeerId, nonce: u64) -> CryptoHash {
         CryptoHash::hash_borsh(&(peer0, peer1, nonce))
     }
 

--- a/chain/network/src/routing/routing.rs
+++ b/chain/network/src/routing/routing.rs
@@ -115,13 +115,7 @@ impl Edge {
     /// Build the hash of the edge given its content.
     /// It is important that peer0 < peer1 at this point.
     fn build_hash(peer0: &PeerId, peer1: &PeerId, nonce: u64) -> CryptoHash {
-        let mut buffer = Vec::<u8>::new();
-        let peer0: Vec<u8> = peer0.into();
-        buffer.extend_from_slice(peer0.as_slice());
-        let peer1: Vec<u8> = peer1.into();
-        buffer.extend_from_slice(peer1.as_slice());
-        buffer.write_u64::<LittleEndian>(nonce).unwrap();
-        hash(buffer.as_slice())
+        CryptoHash::hash_borsh(&(peer0, peer1, nonce))
     }
 
     pub fn make_key(peer0: PeerId, peer1: PeerId) -> (PeerId, PeerId) {

--- a/core/primitives/src/network.rs
+++ b/core/primitives/src/network.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use near_crypto::{KeyType, PublicKey, SecretKey, Signature};
 
-use crate::hash::{hash, CryptoHash};
+use crate::hash::CryptoHash;
 use crate::types::{AccountId, EpochId};
 
 /// Peer id is the public key.
@@ -88,12 +88,9 @@ impl AnnounceAccount {
         peer_id: &PeerId,
         epoch_id: &EpochId,
     ) -> CryptoHash {
-        let header = AnnounceAccountRouteHeader {
-            account_id: account_id.clone(),
-            peer_id: peer_id.clone(),
-            epoch_id: epoch_id.clone(),
-        };
-        hash(&header.try_to_vec().unwrap())
+        let header = AnnounceAccountRouteHeader { account_id, peer_id, epoch_id };
+
+        CryptoHash::hash_borsh(&header)
     }
 
     pub fn hash(&self) -> CryptoHash {
@@ -102,8 +99,8 @@ impl AnnounceAccount {
 }
 
 #[derive(BorshSerialize, BorshDeserialize)]
-struct AnnounceAccountRouteHeader {
-    pub account_id: AccountId,
-    pub peer_id: PeerId,
-    pub epoch_id: EpochId,
+struct AnnounceAccountRouteHeader<'a> {
+    pub account_id: &'a AccountId,
+    pub peer_id: &'a PeerId,
+    pub epoch_id: &'a EpochId,
 }


### PR DESCRIPTION
`build_hash` can be optimized by 50% from 450ns per loop to around 300 ns per loop