### PR TITLE
refactor: Stop using near_metrics::Result<IntCounter>

### DIFF
--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -18,7 +18,6 @@ use tracing::{debug, error, info, trace, warn};
 #[cfg(feature = "delay_detector")]
 use delay_detector::DelayDetector;
 use near_crypto::Signature;
-use near_metrics;
 use near_network_primitives::types::{
     Ban, NetworkViewClientMessages, NetworkViewClientResponses, PeerChainInfo, PeerChainInfoV2,
     PeerIdOrHash, PeerManagerRequest, PeerStatsResult, PeerStatus, PeerType, QueryPeerStats,
@@ -402,20 +401,20 @@ impl PeerActor {
 
     /// Process non handshake/peer related messages.
     fn receive_client_message(&mut self, ctx: &mut Context<PeerActor>, msg: PeerMessage) {
-        near_metrics::inc_counter(&metrics::PEER_CLIENT_MESSAGE_RECEIVED_TOTAL);
+        metrics::PEER_CLIENT_MESSAGE_RECEIVED_TOTAL.inc();
         let peer_id = unwrap_option_or_return!(self.peer_id());
 
         // Wrap peer message into what client expects.
         let network_client_msg = match msg {
             PeerMessage::Block(block) => {
-                near_metrics::inc_counter(&metrics::PEER_BLOCK_RECEIVED_TOTAL);
+                metrics::PEER_BLOCK_RECEIVED_TOTAL.inc();
                 let block_hash = *block.hash();
                 self.tracker.push_received(block_hash);
                 self.chain_info.height = max(self.chain_info.height, block.header().height());
                 NetworkClientMessages::Block(block, peer_id, self.tracker.has_request(&block_hash))
             }
             PeerMessage::Transaction(transaction) => {
-                near_metrics::inc_counter(&metrics::PEER_TRANSACTION_RECEIVED_TOTAL);
+                metrics::PEER_TRANSACTION_RECEIVED_TOTAL.inc();
                 NetworkClientMessages::Transaction {
                     transaction,
                     is_forwarded: false,
@@ -553,7 +552,7 @@ impl Actor for PeerActor {
     type Context = Context<PeerActor>;
 
     fn started(&mut self, ctx: &mut Self::Context) {
-        near_metrics::inc_gauge(&metrics::PEER_CONNECTIONS_TOTAL);
+        metrics::PEER_CONNECTIONS_TOTAL.inc();
         // Fetch genesis hash from the client.
         self.fetch_client_chain_info(ctx);
 
@@ -575,7 +574,7 @@ impl Actor for PeerActor {
 
     fn stopping(&mut self, _: &mut Self::Context) -> Running {
         self.peer_counter.fetch_sub(1, Ordering::SeqCst);
-        near_metrics::dec_gauge(&metrics::PEER_CONNECTIONS_TOTAL);
+        metrics::PEER_CONNECTIONS_TOTAL.dec();
         debug!(target: "network", "{:?}: Peer {} disconnected. {:?}", self.node_info.id, self.peer_info, self.peer_status);
         if let Some(peer_info) = self.peer_info.as_ref() {
             if let PeerStatus::Banned(ban_reason) = self.peer_status {
@@ -620,8 +619,8 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for PeerActor {
         // TODO(#5155) We should change our code to track size of messages received from Peer
         // as long as it travels to PeerManager, etc.
 
-        near_metrics::inc_counter_by(&metrics::PEER_DATA_RECEIVED_BYTES, msg.len() as u64);
-        near_metrics::inc_counter(&metrics::PEER_MESSAGE_RECEIVED_TOTAL);
+        metrics::PEER_DATA_RECEIVED_BYTES.inc_by(msg.len() as u64);
+        metrics::PEER_MESSAGE_RECEIVED_TOTAL.inc();
 
         self.tracker.increment_received(msg.len() as u64);
         if codec::is_forward_tx(&msg).unwrap_or(false) {
@@ -757,7 +756,7 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for PeerActor {
                 }
 
                 if handshake.peer_id == self.node_info.id {
-                    near_metrics::inc_counter(&metrics::RECEIVED_INFO_ABOUT_ITSELF);
+                    metrics::RECEIVED_INFO_ABOUT_ITSELF.inc();
                     debug!(target: "network", "Received info about itself. Disconnecting this peer.");
                     ctx.stop();
                     return;

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -1394,7 +1394,7 @@ impl PeerManagerActor {
             Ok(peer_id) => peer_id,
             Err(find_route_error) => {
                 // TODO(MarX, #1369): Message is dropped here. Define policy for this case.
-                near_metrics::inc_counter(&metrics::DROP_MESSAGE_UNKNOWN_ACCOUNT);
+                metrics::DROP_MESSAGE_UNKNOWN_ACCOUNT.inc();
                 debug!(target: "network", "{:?} Drop message to {} Reason {:?}. Message {:?}",
                        self.config.account_id,
                        account_id,

--- a/chain/network/src/routing/codec.rs
+++ b/chain/network/src/routing/codec.rs
@@ -61,7 +61,7 @@ impl Encoder<Vec<u8>> for Codec {
             {
                 error!(target: "network", "{} throwing away message, because buffer is full item.len(): {} buf.capacity: {}", get_tid(), item.len(), buf.capacity());
 
-                near_metrics::inc_counter_by(&metrics::DROPPED_MESSAGES_COUNT, 1);
+                metrics::DROPPED_MESSAGES_COUNT.inc_by(1);
                 return Err(Error::new(ErrorKind::Other, "Buf max capacity exceeded"));
             }
             // First four bytes is the length of the buffer.

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -171,8 +171,8 @@ impl RoutingTableActor {
         self.needs_routing_table_recalculation = true;
 
         // Update metrics after edge update
-        near_metrics::inc_counter_by(&metrics::EDGE_UPDATES, total as u64);
-        near_metrics::set_gauge(&metrics::EDGE_ACTIVE, self.raw_graph.total_active_edges() as i64);
+        metrics::EDGE_UPDATES.inc_by(total as u64);
+        metrics::EDGE_ACTIVE.set(self.raw_graph.total_active_edges() as i64);
 
         edges
     }
@@ -242,7 +242,7 @@ impl RoutingTableActor {
         #[cfg(feature = "delay_detector")]
         let _d = DelayDetector::new("routing table update".into());
         let _routing_table_recalculation =
-            near_metrics::start_timer(&metrics::ROUTING_TABLE_RECALCULATION_HISTOGRAM);
+            metrics::ROUTING_TABLE_RECALCULATION_HISTOGRAM.start_timer();
 
         trace!(target: "network", "Update routing table.");
 
@@ -253,8 +253,8 @@ impl RoutingTableActor {
             self.peer_last_time_reachable.insert(peer.clone(), now);
         }
 
-        near_metrics::inc_counter_by(&metrics::ROUTING_TABLE_RECALCULATIONS, 1);
-        near_metrics::set_gauge(&metrics::PEER_REACHABLE, self.peer_forwarding.len() as i64);
+        metrics::ROUTING_TABLE_RECALCULATIONS.inc();
+        metrics::PEER_REACHABLE.set(self.peer_forwarding.len() as i64);
     }
 
     /// If pruning is enabled we will remove unused edges and store them to disk.

--- a/chain/network/src/stats/metrics.rs
+++ b/chain/network/src/stats/metrics.rs
@@ -11,76 +11,86 @@ use near_metrics::{
 use crate::types::PeerMessage;
 use near_network_primitives::types::RoutedMessageBody;
 
-pub static PEER_CONNECTIONS_TOTAL: Lazy<near_metrics::Result<IntGauge>> =
-    Lazy::new(|| try_create_int_gauge("near_peer_connections_total", "Number of connected peers"));
-pub static PEER_DATA_RECEIVED_BYTES: Lazy<near_metrics::Result<IntCounter>> = Lazy::new(|| {
-    try_create_int_counter("near_peer_data_received_bytes", "Total data received from peers")
+pub static PEER_CONNECTIONS_TOTAL: Lazy<IntGauge> = Lazy::new(|| {
+    try_create_int_gauge("near_peer_connections_total", "Number of connected peers").unwrap()
 });
-pub static PEER_MESSAGE_RECEIVED_TOTAL: Lazy<near_metrics::Result<IntCounter>> = Lazy::new(|| {
+pub static PEER_DATA_RECEIVED_BYTES: Lazy<IntCounter> = Lazy::new(|| {
+    try_create_int_counter("near_peer_data_received_bytes", "Total data received from peers")
+        .unwrap()
+});
+pub static PEER_MESSAGE_RECEIVED_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
     try_create_int_counter(
         "near_peer_message_received_total",
         "Number of messages received from peers",
     )
+    .unwrap()
 });
-pub static PEER_CLIENT_MESSAGE_RECEIVED_TOTAL: Lazy<near_metrics::Result<IntCounter>> =
-    Lazy::new(|| {
-        try_create_int_counter(
-            "near_peer_client_message_received_total",
-            "Number of messages for client received from peers",
-        )
-    });
-pub static PEER_BLOCK_RECEIVED_TOTAL: Lazy<near_metrics::Result<IntCounter>> = Lazy::new(|| {
+pub static PEER_CLIENT_MESSAGE_RECEIVED_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
+    try_create_int_counter(
+        "near_peer_client_message_received_total",
+        "Number of messages for client received from peers",
+    )
+    .unwrap()
+});
+pub static PEER_BLOCK_RECEIVED_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
     try_create_int_counter("near_peer_block_received_total", "Number of blocks received by peers")
+        .unwrap()
 });
-pub static PEER_TRANSACTION_RECEIVED_TOTAL: Lazy<near_metrics::Result<IntCounter>> =
-    Lazy::new(|| {
-        try_create_int_counter(
-            "near_peer_transaction_received_total",
-            "Number of transactions received by peers",
-        )
-    });
+pub static PEER_TRANSACTION_RECEIVED_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
+    try_create_int_counter(
+        "near_peer_transaction_received_total",
+        "Number of transactions received by peers",
+    )
+    .unwrap()
+});
 
 // Routing table metrics
-pub static ROUTING_TABLE_RECALCULATIONS: Lazy<near_metrics::Result<IntCounter>> = Lazy::new(|| {
+pub static ROUTING_TABLE_RECALCULATIONS: Lazy<IntCounter> = Lazy::new(|| {
     try_create_int_counter(
         "near_routing_table_recalculations_total",
         "Number of times routing table have been recalculated from scratch",
     )
+    .unwrap()
 });
-pub static ROUTING_TABLE_RECALCULATION_HISTOGRAM: Lazy<near_metrics::Result<Histogram>> =
-    Lazy::new(|| {
-        try_create_histogram(
-            "near_routing_table_recalculation_seconds",
-            "Time spent recalculating routing table",
-        )
-    });
-pub static EDGE_UPDATES: Lazy<near_metrics::Result<IntCounter>> =
-    Lazy::new(|| try_create_int_counter("near_edge_updates", "Unique edge updates"));
-pub static EDGE_ACTIVE: Lazy<near_metrics::Result<IntGauge>> =
-    Lazy::new(|| try_create_int_gauge("near_edge_active", "Total edges active between peers"));
-pub static PEER_REACHABLE: Lazy<near_metrics::Result<IntGauge>> = Lazy::new(|| {
+pub static ROUTING_TABLE_RECALCULATION_HISTOGRAM: Lazy<Histogram> = Lazy::new(|| {
+    try_create_histogram(
+        "near_routing_table_recalculation_seconds",
+        "Time spent recalculating routing table",
+    )
+    .unwrap()
+});
+pub static EDGE_UPDATES: Lazy<IntCounter> =
+    Lazy::new(|| try_create_int_counter("near_edge_updates", "Unique edge updates").unwrap());
+pub static EDGE_ACTIVE: Lazy<IntGauge> = Lazy::new(|| {
+    try_create_int_gauge("near_edge_active", "Total edges active between peers").unwrap()
+});
+pub static PEER_REACHABLE: Lazy<IntGauge> = Lazy::new(|| {
     try_create_int_gauge(
         "near_peer_reachable",
         "Total peers such that there is a path potentially through other peers",
     )
+    .unwrap()
 });
-pub static DROP_MESSAGE_UNKNOWN_ACCOUNT: Lazy<near_metrics::Result<IntCounter>> = Lazy::new(|| {
+pub static DROP_MESSAGE_UNKNOWN_ACCOUNT: Lazy<IntCounter> = Lazy::new(|| {
     try_create_int_counter(
         "near_drop_message_unknown_account",
         "Total messages dropped because target account is not known",
     )
+    .unwrap()
 });
-pub static RECEIVED_INFO_ABOUT_ITSELF: Lazy<near_metrics::Result<IntCounter>> = Lazy::new(|| {
+pub static RECEIVED_INFO_ABOUT_ITSELF: Lazy<IntCounter> = Lazy::new(|| {
     try_create_int_counter(
         "received_info_about_itself",
         "Number of times a peer tried to connect to itself",
     )
+    .unwrap()
 });
-pub static DROPPED_MESSAGES_COUNT: Lazy<near_metrics::Result<IntCounter>> = Lazy::new(|| {
+pub static DROPPED_MESSAGES_COUNT: Lazy<IntCounter> = Lazy::new(|| {
     near_metrics::try_create_int_counter(
         "near_dropped_messages_count",
         "Total count of messages which were dropped, because write buffer was full",
     )
+    .unwrap()
 });
 
 #[derive(Clone)]

--- a/integration-tests/tests/network/peer_handshake.rs
+++ b/integration-tests/tests/network/peer_handshake.rs
@@ -232,9 +232,7 @@ fn check_connection_with_new_identity() {
     runner.push(Action::Wait(2000));
 
     // Check the no node tried to connect to itself in this process.
-    runner.push_action(wait_for(|| {
-        near_metrics::get_counter(&near_network::metrics::RECEIVED_INFO_ABOUT_ITSELF) == Ok(0)
-    }));
+    runner.push_action(wait_for(|| near_network::metrics::RECEIVED_INFO_ABOUT_ITSELF.get() == 0));
 
     start_test(runner);
 }


### PR DESCRIPTION
Current implementation of metrics in `chain/network/src/stats/metrics.rs` can be done better.

As discussed in https://github.com/near/nearcore/pull/5240
I replaced usage of `Lazy<near_metrics::Result<IntCounter>> ` with simply `Lazy<IntCounter>`.

This will make code much cleaner, and we will notice whenever there is an issue with name conflict between two different metrics in Prometheus while running CI, rather than finding out later that something doesn't work as it should.
