### PR TITLE
FEATURE: Add extra checks to ping_jump test

### DIFF
--- a/integration-tests/tests/network/routing.rs
+++ b/integration-tests/tests/network/routing.rs
@@ -97,18 +97,23 @@ fn ping_simple() {
 }
 
 #[test]
+/// Crate 3 nodes connected in a line and try to use Ping.
 fn ping_jump() {
     let mut runner = Runner::new(3, 2);
 
+    // Add edges
     runner.push(Action::AddEdge(0, 1));
     runner.push(Action::AddEdge(1, 2));
+    // Check routing tables and wait for `PeerManager` to update it's routing table
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![1])]));
     runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0]), (2, vec![2])]));
     runner.push(Action::CheckRoutingTable(2, vec![(0, vec![1]), (1, vec![1])]));
-    // We update routing table with 1s delay in PeerManager
-    runner.push(Action::Wait(1500));
+
+    // Try Pinging from node 0 to 2
     runner.push(Action::PingTo(0, 0, 2));
+    // Check whenever Node 2 got message from 0
     runner.push(Action::CheckPingPong(2, vec![(0, 0, None)], vec![]));
+    // Check whenever Node 0 got reply from 2.
     runner.push(Action::CheckPingPong(0, vec![], vec![(0, 2, None)]));
 
     start_test(runner);

--- a/integration-tests/tests/network/routing.rs
+++ b/integration-tests/tests/network/routing.rs
@@ -103,6 +103,8 @@ fn ping_jump() {
     runner.push(Action::AddEdge(0, 1));
     runner.push(Action::AddEdge(1, 2));
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![1])]));
+    runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0]), (2, vec![2])]));
+    runner.push(Action::CheckRoutingTable(2, vec![(0, vec![1]), (1, vec![1])]));
     // We update routing table with 1s delay in PeerManager
     runner.push(Action::Wait(1500));
     runner.push(Action::PingTo(0, 0, 2));


### PR DESCRIPTION
Due to recent changes bin `near-networking`, where we moves Routing Table calculation to another thread. This action is no longer synchronous.

I added extra checks to make sure that the routing table is correct.

I saw in the output logs that the routing failed. I want to figure out whenever that was due to routing table not being updated properly on all nodes, or for some other reason.

I caused failing CI, and therefore we were unable to do a merge.
For example: https://buildkite.com/nearprotocol/nearcore/builds/6774#c2582722-b8ab-49e0-8ee1-0c98fdca9b85