### PR TITLE
REFACTOR Make all attributes in `EdgeInfo` private

### DIFF
--- a/chain/network/benches/routing_table_actor.rs
+++ b/chain/network/benches/routing_table_actor.rs
@@ -59,11 +59,11 @@ fn get_all_edges_bench_new2(bench: &mut Bencher) {
     let mut new_edges_info = HashMap::new();
     for edge in all_edges {
         let edge = EdgeNew {
-            key: Arc::new((edge.key.0.clone(), edge.key.1.clone())),
-            nonce: edge.nonce,
-            signature0: edge.signature0.clone(),
-            signature1: edge.signature1.clone(),
-            removal_info: edge.removal_info.clone(),
+            key: Arc::new((edge.key().0.clone(), edge.key().1.clone())),
+            nonce: edge.nonce(),
+            signature0: edge.signature0().clone(),
+            signature1: edge.signature1().clone(),
+            removal_info: edge.removal_info().clone(),
         };
 
         new_edges_info.insert(edge.key.clone(), Arc::new(edge));
@@ -85,11 +85,11 @@ fn get_all_edges_bench_new3(bench: &mut Bencher) {
     let mut new_edges_info = HashMap::new();
     for edge in all_edges {
         let edge = EdgeNew2 {
-            key: (Arc::new(edge.key.0.clone()), Arc::new(edge.key.1.clone())),
-            nonce: edge.nonce,
-            signature0: edge.signature0.clone(),
-            signature1: edge.signature1.clone(),
-            removal_info: edge.removal_info.clone(),
+            key: (Arc::new(edge.key().0.clone()), Arc::new(edge.key().1.clone())),
+            nonce: edge.nonce(),
+            signature0: edge.signature0().clone(),
+            signature1: edge.signature1().clone(),
+            removal_info: edge.removal_info().clone(),
         };
 
         new_edges_info.insert(edge.key.clone(), Arc::new(edge));

--- a/chain/network/benches/routing_table_actor.rs
+++ b/chain/network/benches/routing_table_actor.rs
@@ -59,7 +59,7 @@ fn get_all_edges_bench_new2(bench: &mut Bencher) {
     let mut new_edges_info = HashMap::new();
     for edge in all_edges {
         let edge = EdgeNew {
-            key: Arc::new((edge.key().0.clone(), edge.key().1.clone())),
+            key: Arc::new(edge.key().clone()),
             nonce: edge.nonce(),
             signature0: edge.signature0().clone(),
             signature1: edge.signature1().clone(),

--- a/chain/network/benches/routing_table_actor.rs
+++ b/chain/network/benches/routing_table_actor.rs
@@ -63,7 +63,7 @@ fn get_all_edges_bench_new2(bench: &mut Bencher) {
             nonce: edge.nonce(),
             signature0: edge.signature0().clone(),
             signature1: edge.signature1().clone(),
-            removal_info: edge.removal_info().clone(),
+            removal_info: edge.removal_info().cloned(),
         };
 
         new_edges_info.insert(edge.key.clone(), Arc::new(edge));
@@ -89,7 +89,7 @@ fn get_all_edges_bench_new3(bench: &mut Bencher) {
             nonce: edge.nonce(),
             signature0: edge.signature0().clone(),
             signature1: edge.signature1().clone(),
-            removal_info: edge.removal_info().clone(),
+            removal_info: edge.removal_info().cloned(),
         };
 
         new_edges_info.insert(edge.key.clone(), Arc::new(edge));

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -301,12 +301,12 @@ impl PeerManagerActor {
                 continue;
             }
             let key = edge.get_pair();
-            if !self.routing_table_view.is_local_edge_newer(&key, edge.nonce) {
+            if !self.routing_table_view.is_local_edge_newer(&key, edge.nonce()) {
                 continue;
             }
             self.routing_table_view
                 .local_edges_info
-                .insert((edge.key.0.clone(), edge.key.1.clone()), edge.clone());
+                .insert((edge.key().0.clone(), edge.key().1.clone()), edge.clone());
         }
 
         self.routing_table_addr
@@ -401,7 +401,7 @@ impl PeerManagerActor {
                     continue;
                 }
                 let key = edge.get_pair();
-                if !self.routing_table_view.is_local_edge_newer(&key, edge.nonce) {
+                if !self.routing_table_view.is_local_edge_newer(&key, edge.nonce()) {
                     continue;
                 }
                 // Check whenever peer needs to be removed when edge is removed.
@@ -1907,7 +1907,7 @@ impl PeerManagerActor {
                         self.routing_table_view.get_edge(self.my_peer_id.clone(), peer_id.clone())
                     {
                         if cur_edge.edge_type() == EdgeType::Added
-                            && cur_edge.nonce >= edge_info.nonce
+                            && cur_edge.nonce() >= edge_info.nonce
                         {
                             return NetworkResponses::EdgeUpdate(Box::new(cur_edge.clone()));
                         }
@@ -1930,12 +1930,12 @@ impl PeerManagerActor {
             NetworkRequests::ResponseUpdateNonce(edge) => {
                 if edge.contains_peer(&self.my_peer_id) && edge.verify() {
                     let key = edge.get_pair();
-                    if self.routing_table_view.is_local_edge_newer(&key, edge.nonce) {
+                    if self.routing_table_view.is_local_edge_newer(&key, edge.nonce()) {
                         let other = edge.other(&self.my_peer_id).unwrap();
                         if let Some(nonce) =
                             self.local_peer_pending_update_nonce_request.get(&other)
                         {
-                            if edge.nonce >= *nonce {
+                            if edge.nonce() >= *nonce {
                                 self.local_peer_pending_update_nonce_request.remove(&other);
                             }
                         }
@@ -2138,7 +2138,7 @@ impl PeerManagerActor {
 
         let last_edge =
             self.routing_table_view.get_edge(self.my_peer_id.clone(), msg.peer_info.id.clone());
-        let last_nonce = last_edge.as_ref().map_or(0, |edge| edge.nonce);
+        let last_nonce = last_edge.as_ref().map_or(0, |edge| edge.nonce());
 
         // Check that the received nonce is greater than the current nonce of this connection.
         if last_nonce >= msg.other_edge_info.nonce {

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -304,9 +304,7 @@ impl PeerManagerActor {
             if !self.routing_table_view.is_local_edge_newer(&key, edge.nonce()) {
                 continue;
             }
-            self.routing_table_view
-                .local_edges_info
-                .insert((edge.key().0.clone(), edge.key().1.clone()), edge.clone());
+            self.routing_table_view.local_edges_info.insert(edge.key().clone(), edge.clone());
         }
 
         self.routing_table_addr

--- a/chain/network/src/routing/edge.rs
+++ b/chain/network/src/routing/edge.rs
@@ -44,6 +44,22 @@ impl Edge {
         Edge(Arc::new(EdgeInner::new(peer0, peer1, nonce, signature0, signature1)))
     }
 
+    pub fn nonce(&self) -> u64 {
+        self.0.nonce
+    }
+
+    pub fn signature0(&self) -> &Signature {
+        &self.0.signature0
+    }
+
+    pub fn signature1(&self) -> &Signature {
+        &self.0.signature1
+    }
+
+    pub fn removal_info(&self) -> &Option<(bool, Signature)> {
+        &self.0.removal_info
+    }
+
     pub fn make_fake_edge(peer0: PeerId, peer1: PeerId, nonce: u64) -> Self {
         Self(Arc::new(EdgeInner {
             key: (peer0, peer1),
@@ -121,17 +137,17 @@ impl std::ops::Deref for Edge {
 #[cfg_attr(feature = "test_features", derive(Serialize, Deserialize))]
 pub struct EdgeInner {
     /// Since edges are not directed `key.0 < peer1` should hold.
-    pub key: (PeerId, PeerId),
+    key: (PeerId, PeerId),
     /// Nonce to keep tracking of the last update on this edge.
     /// It must be even
-    pub nonce: u64,
+    nonce: u64,
     /// Signature from parties validating the edge. These are signature of the added edge.
-    pub signature0: Signature,
-    pub signature1: Signature,
+    signature0: Signature,
+    signature1: Signature,
     /// Info necessary to declare an edge as removed.
     /// The bool says which party is removing the edge: false for Peer0, true for Peer1
     /// The signature from the party removing the edge.
-    pub removal_info: Option<(bool, Signature)>,
+    removal_info: Option<(bool, Signature)>,
 }
 
 impl EdgeInner {

--- a/chain/network/src/routing/edge.rs
+++ b/chain/network/src/routing/edge.rs
@@ -56,8 +56,8 @@ impl Edge {
         &self.0.signature1
     }
 
-    pub fn removal_info(&self) -> &Option<(bool, Signature)> {
-        &self.0.removal_info
+    pub fn removal_info(&self) -> Option<&(bool, Signature)> {
+        self.0.removal_info.as_ref()
     }
 
     pub fn make_fake_edge(peer0: PeerId, peer1: PeerId, nonce: u64) -> Self {

--- a/chain/network/src/routing/edge_verifier_actor.rs
+++ b/chain/network/src/routing/edge_verifier_actor.rs
@@ -25,8 +25,9 @@ impl Handler<EdgeList> for EdgeVerifierActor {
     #[perf]
     fn handle(&mut self, msg: EdgeList, _ctx: &mut Self::Context) -> Self::Result {
         for edge in msg.edges {
-            let key = &edge.key;
-            if msg.edges_info_shared.lock().unwrap().get(key).cloned().unwrap_or(0u64) >= edge.nonce
+            let key = edge.key();
+            if msg.edges_info_shared.lock().unwrap().get(key).cloned().unwrap_or(0u64)
+                >= edge.nonce()
             {
                 continue;
             }
@@ -44,8 +45,8 @@ impl Handler<EdgeList> for EdgeVerifierActor {
                 let mut guard = msg.edges_info_shared.lock().unwrap();
                 let entry = guard.entry(key.clone());
 
-                let cur_nonce = entry.or_insert(edge.nonce);
-                *cur_nonce = max(*cur_nonce, edge.nonce);
+                let cur_nonce = entry.or_insert(edge.nonce());
+                *cur_nonce = max(*cur_nonce, edge.nonce());
             }
             msg.sender.push(edge);
         }

--- a/chain/network/src/routing/ibf_peer_set.rs
+++ b/chain/network/src/routing/ibf_peer_set.rs
@@ -85,7 +85,7 @@ impl IbfPeerSet {
         let mut ibf_set = IbfSet::new(seed);
         // Initialize IbfSet with edges
         for (key, e) in edges_info.iter() {
-            let se = SimpleEdge::new(key.0.clone(), key.1.clone(), e.nonce);
+            let se = SimpleEdge::new(key.0.clone(), key.1.clone(), e.nonce());
             if let Some(id) = self.slot_map.get(&se) {
                 ibf_set.add_edge(&se, id);
             }

--- a/chain/network/src/routing/routing.rs
+++ b/chain/network/src/routing/routing.rs
@@ -175,7 +175,7 @@ impl RoutingTableView {
     /// Works only for local edges.
     pub fn is_local_edge_newer(&self, key: &(PeerId, PeerId), nonce: u64) -> bool {
         assert!(key.0 == self.my_peer_id || key.1 == self.my_peer_id);
-        self.local_edges_info.get(&key).map_or(0, |x| x.nonce) < nonce
+        self.local_edges_info.get(&key).map_or(0, |x| x.nonce()) < nonce
     }
 
     pub fn reachable_peers(&self) -> impl Iterator<Item = &PeerId> {
@@ -260,8 +260,8 @@ impl RoutingTableView {
 
     pub fn remove_edges(&mut self, edges: &Vec<Edge>) {
         for edge in edges.iter() {
-            assert!(edge.key.0 == self.my_peer_id || edge.key.1 == self.my_peer_id);
-            let key = (edge.key.0.clone(), edge.key.1.clone());
+            assert!(edge.key().0 == self.my_peer_id || edge.key().1 == self.my_peer_id);
+            let key = (edge.key().0.clone(), edge.key().1.clone());
             self.local_edges_info.remove(&key);
         }
     }

--- a/chain/network/src/routing/routing.rs
+++ b/chain/network/src/routing/routing.rs
@@ -261,8 +261,7 @@ impl RoutingTableView {
     pub fn remove_edges(&mut self, edges: &Vec<Edge>) {
         for edge in edges.iter() {
             assert!(edge.key().0 == self.my_peer_id || edge.key().1 == self.my_peer_id);
-            let key = (edge.key().0.clone(), edge.key().1.clone());
-            self.local_edges_info.remove(&key);
+            self.local_edges_info.remove(&edge.key());
         }
     }
 

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -116,9 +116,9 @@ impl RoutingTableActor {
         #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
         self.peer_ibf_set.remove_edge(&edge.to_simple_edge());
 
-        let key = &edge.key;
+        let key = &edge.key();
         if self.edges_info.remove(&key).is_some() {
-            self.raw_graph.remove_edge(&edge.key.0, &edge.key.1);
+            self.raw_graph.remove_edge(&edge.key().0, &edge.key().1);
             self.needs_routing_table_recalculation = true;
         }
     }
@@ -127,7 +127,7 @@ impl RoutingTableActor {
     /// are valid (`signature0`, `signature`).
     fn add_verified_edge(&mut self, edge: Edge) -> bool {
         let key = edge.get_pair();
-        if !self.is_edge_newer(&key, edge.nonce) {
+        if !self.is_edge_newer(&key, edge.nonce()) {
             // We already have a newer information about this edge. Discard this information.
             false
         } else {
@@ -194,7 +194,7 @@ impl RoutingTableActor {
             // Load all edges that were persisted in database in the cell - and add them to the current graph.
             if let Ok(edges) = self.get_and_remove_component_edges(component_nonce, &mut update) {
                 for edge in edges {
-                    for &peer_id in vec![&edge.key.0, &edge.key.1].iter() {
+                    for &peer_id in vec![&edge.key().0, &edge.key().1].iter() {
                         if peer_id == &my_peer_id
                             || self.peer_last_time_reachable.contains_key(peer_id)
                         {
@@ -353,7 +353,7 @@ impl RoutingTableActor {
 
     /// Checks whenever given edge is newer than the one we already have.
     pub fn is_edge_newer(&self, key: &(PeerId, PeerId), nonce: u64) -> bool {
-        self.edges_info.get(&key).map_or(0, |x| x.nonce) < nonce
+        self.edges_info.get(&key).map_or(0, |x| x.nonce()) < nonce
     }
 
     /// Get edges stored in DB under `ColPeerComponent` column at `peer_id` key.

--- a/chain/network/tests/cache_edges.rs
+++ b/chain/network/tests/cache_edges.rs
@@ -70,8 +70,8 @@ impl RoutingTableTest {
     }
 
     fn get_edge_description(&self, edge: &Edge) -> EdgeDescription {
-        let peer0 = self.rev_peers.get(&edge.key.0).unwrap();
-        let peer1 = self.rev_peers.get(&edge.key.1).unwrap();
+        let peer0 = self.rev_peers.get(&edge.key().0).unwrap();
+        let peer1 = self.rev_peers.get(&edge.key().1).unwrap();
         let edge_type = edge.edge_type();
         EdgeDescription(*peer0, *peer1, edge_type)
     }


### PR DESCRIPTION
`EdgeInfo` is used in a lot of places in our code. We should remove `pub` modifier from all it's attributes.

Splitting https://github.com/near/nearcore/pull/5267 due to some unknown bug.