### PR TITLE
REFACTOR Make peer_manager.rs pub(crate) instead of pub

### DIFF
--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -49,8 +49,7 @@ use crate::types::{
     ReasonForBan, RoutedMessage, RoutedMessageBody, RoutedMessageFrom, SendMessage,
     StateResponseInfo, Unregister, UPDATE_INTERVAL_LAST_TIME_RECEIVED_MESSAGE,
 };
-use crate::NetworkResponses;
-use crate::PeerManagerActor;
+use crate::{NetworkResponses, PeerManagerActor};
 
 type WriteHalf = tokio::io::WriteHalf<tokio::net::TcpStream>;
 

--- a/chain/network/src/peer_manager/mod.rs
+++ b/chain/network/src/peer_manager/mod.rs
@@ -1,2 +1,2 @@
-pub mod peer_manager_actor;
-pub mod peer_store;
+pub(crate) mod peer_manager_actor;
+pub(crate) mod peer_store;

--- a/chain/network/src/peer_manager/mod.rs
+++ b/chain/network/src/peer_manager/mod.rs
@@ -1,2 +1,2 @@
 pub mod peer_manager_actor;
-pub(crate) mod peer_store;
+pub mod peer_store;


### PR DESCRIPTION
peer_manager.rs is not used from outside. It should be marked with `pub(crate)` instead of `pub`.