### PR TITLE
refactor: Split `test_utils.rs` to avoid having code with `test_features` and without in one file.

### DIFF
--- a/chain/jsonrpc/jsonrpc-tests/src/lib.rs
+++ b/chain/jsonrpc/jsonrpc-tests/src/lib.rs
@@ -8,9 +8,9 @@ use near_client::test_utils::setup_no_network_with_validity_period_and_no_epoch_
 use near_client::ViewClientActor;
 use near_jsonrpc::{start_http, RpcConfig};
 use near_jsonrpc_primitives::message::{from_slice, Message};
-#[cfg(feature = "test_features")]
-use near_network::test_utils::make_peer_manager_routing_table_addr_pair;
 use near_network::test_utils::open_port;
+#[cfg(feature = "test_features")]
+use near_network::test_utils::test_features::make_peer_manager_routing_table_addr_pair;
 use near_primitives::types::NumBlocks;
 
 pub static TEST_GENESIS_CONFIG: Lazy<GenesisConfig> = Lazy::new(|| {

--- a/chain/network/src/test_utils.rs
+++ b/chain/network/src/test_utils.rs
@@ -1,14 +1,8 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::net::TcpListener;
-#[cfg(feature = "test_features")]
-use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
 
-#[cfg(feature = "test_features")]
-use actix::actors::mocker::Mocker;
-#[cfg(feature = "test_features")]
-use actix::Addr;
 use actix::{Actor, ActorContext, Context, Handler, MailboxError, Message};
 use futures::future::BoxFuture;
 use futures::{future, FutureExt};
@@ -17,45 +11,18 @@ use rand::{thread_rng, RngCore};
 use tracing::debug;
 
 use near_crypto::{KeyType, SecretKey};
-#[cfg(feature = "test_features")]
-use near_network_primitives::types::NetworkConfig;
 use near_network_primitives::types::ReasonForBan;
-#[cfg(feature = "test_features")]
-use near_network_primitives::types::{NetworkViewClientMessages, NetworkViewClientResponses};
-#[cfg(feature = "test_features")]
-use near_primitives::block::GenesisId;
-#[cfg(feature = "test_features")]
-use near_primitives::borsh::maybestd::sync::atomic::AtomicUsize;
 use near_primitives::hash::hash;
 use near_primitives::network::PeerId;
 use near_primitives::types::EpochId;
 use near_primitives::utils::index_to_bytes;
-#[cfg(feature = "test_features")]
-use near_store::test_utils::create_test_store;
-#[cfg(feature = "test_features")]
-use near_store::Store;
 
-#[cfg(feature = "test_features")]
-use crate::routing::routing_table_actor::start_routing_table_actor;
-#[cfg(feature = "test_features")]
-use crate::types::NetworkClientMessages;
-#[cfg(feature = "test_features")]
-use crate::types::NetworkClientResponses;
 use crate::types::{
     NetworkInfo, NetworkResponses, PeerManagerAdapter, PeerManagerMessageRequest,
     PeerManagerMessageResponse,
 };
 use crate::PeerInfo;
 use crate::PeerManagerActor;
-#[cfg(feature = "test_features")]
-use crate::RoutingTableActor;
-
-/// Mock for `ClientActor`
-#[cfg(feature = "test_features")]
-type ClientMock = Mocker<NetworkClientMessages>;
-/// Mock for `ViewClientActor`
-#[cfg(feature = "test_features")]
-type ViewClientMock = Mocker<NetworkViewClientMessages>;
 
 static OPENED_PORTS: Lazy<Mutex<HashSet<u16>>> = Lazy::new(|| Mutex::new(HashSet::new()));
 
@@ -313,88 +280,110 @@ impl MockPeerManagerAdapter {
     }
 }
 
-// Start PeerManagerActor, and RoutingTableActor together and returns pairs of addresses
-// for each of them.
 #[cfg(feature = "test_features")]
-pub fn make_peer_manager_routing_table_addr_pair(
-) -> (Addr<PeerManagerActor>, Addr<RoutingTableActor>) {
-    let seed = "test2";
-    let port = open_port();
+pub mod test_features {
+    use crate::routing::routing_table_actor::start_routing_table_actor;
+    use crate::test_utils::{convert_boot_nodes, open_port};
+    use crate::types::{NetworkClientMessages, NetworkClientResponses};
+    use crate::{PeerManagerActor, RoutingTableActor};
+    use actix::actors::mocker::Mocker;
+    use actix::{Actor, Addr};
+    use near_network_primitives::types::{
+        NetworkConfig, NetworkViewClientMessages, NetworkViewClientResponses,
+    };
+    use near_primitives::block::GenesisId;
+    use near_primitives::network::PeerId;
+    use near_store::test_utils::create_test_store;
+    use near_store::Store;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
 
-    let net_config = NetworkConfig::from_seed(seed, port);
-    let store = create_test_store();
-    let routing_table_addr =
-        start_routing_table_actor(PeerId::new(net_config.public_key.clone()), store.clone());
-    let peer_manager_addr = make_peer_manager(
-        store,
-        net_config,
-        vec![("test1", open_port())],
-        10,
-        routing_table_addr.clone(),
-    )
-    .0
-    .start();
-    (peer_manager_addr, routing_table_addr)
-}
+    /// Mock for `ClientActor`
+    type ClientMock = Mocker<NetworkClientMessages>;
+    /// Mock for `ViewClientActor`
+    type ViewClientMock = Mocker<NetworkViewClientMessages>;
 
-// Make peer manager for unit tests
-//
-// Returns:
-//    PeerManagerActor
-//    PeerId - PeerId associated with given actor
-//    Arc<AtomicUsize> - shared pointer for counting the number of received
-//                       `NetworkViewClientMessages::AnnounceAccount` messages
-#[cfg(feature = "test_features")]
-pub fn make_peer_manager(
-    store: Arc<Store>,
-    mut config: NetworkConfig,
-    boot_nodes: Vec<(&str, u16)>,
-    peer_max_count: u32,
-    routing_table_addr: Addr<RoutingTableActor>,
-) -> (PeerManagerActor, PeerId, Arc<AtomicUsize>) {
-    config.boot_nodes = convert_boot_nodes(boot_nodes);
-    config.max_num_peers = peer_max_count;
-    let counter = Arc::new(AtomicUsize::new(0));
-    let counter1 = counter.clone();
-    let client_addr = ClientMock::mock(Box::new(move |_msg, _ctx| {
-        Box::new(Some(NetworkClientResponses::NoResponse))
-    }))
-    .start();
+    // Start PeerManagerActor, and RoutingTableActor together and returns pairs of addresses
+    // for each of them.
+    pub fn make_peer_manager_routing_table_addr_pair(
+    ) -> (Addr<PeerManagerActor>, Addr<RoutingTableActor>) {
+        let seed = "test2";
+        let port = open_port();
 
-    let view_client_addr = ViewClientMock::mock(Box::new(move |msg, _ctx| {
-        let msg = msg.downcast_ref::<NetworkViewClientMessages>().unwrap();
-        match msg {
-            NetworkViewClientMessages::AnnounceAccount(accounts) => {
-                if !accounts.is_empty() {
-                    counter1.fetch_add(1, Ordering::SeqCst);
-                }
-                Box::new(Some(NetworkViewClientResponses::AnnounceAccount(
-                    accounts.clone().into_iter().map(|obj| obj.0).collect(),
-                )))
-            }
-            NetworkViewClientMessages::GetChainInfo => {
-                Box::new(Some(NetworkViewClientResponses::ChainInfo {
-                    genesis_id: GenesisId::default(),
-                    height: 1,
-                    tracked_shards: vec![],
-                    archival: false,
-                }))
-            }
-            _ => Box::new(Some(NetworkViewClientResponses::NoResponse)),
-        }
-    }))
-    .start();
-    let peer_id = PeerId::new(config.public_key.clone());
-    (
-        PeerManagerActor::new(
+        let net_config = NetworkConfig::from_seed(seed, port);
+        let store = create_test_store();
+        let routing_table_addr =
+            start_routing_table_actor(PeerId::new(net_config.public_key.clone()), store.clone());
+        let peer_manager_addr = make_peer_manager(
             store,
-            config,
-            client_addr.recipient(),
-            view_client_addr.recipient(),
-            routing_table_addr,
+            net_config,
+            vec![("test1", open_port())],
+            10,
+            routing_table_addr.clone(),
         )
-        .unwrap(),
-        peer_id,
-        counter,
-    )
+        .0
+        .start();
+        (peer_manager_addr, routing_table_addr)
+    }
+
+    // Make peer manager for unit tests
+    //
+    // Returns:
+    //    PeerManagerActor
+    //    PeerId - PeerId associated with given actor
+    //    Arc<AtomicUsize> - shared pointer for counting the number of received
+    //                       `NetworkViewClientMessages::AnnounceAccount` messages
+    pub fn make_peer_manager(
+        store: Arc<Store>,
+        mut config: NetworkConfig,
+        boot_nodes: Vec<(&str, u16)>,
+        peer_max_count: u32,
+        routing_table_addr: Addr<RoutingTableActor>,
+    ) -> (PeerManagerActor, PeerId, Arc<AtomicUsize>) {
+        config.boot_nodes = convert_boot_nodes(boot_nodes);
+        config.max_num_peers = peer_max_count;
+        let counter = Arc::new(AtomicUsize::new(0));
+        let counter1 = counter.clone();
+        let client_addr = ClientMock::mock(Box::new(move |_msg, _ctx| {
+            Box::new(Some(NetworkClientResponses::NoResponse))
+        }))
+        .start();
+
+        let view_client_addr = ViewClientMock::mock(Box::new(move |msg, _ctx| {
+            let msg = msg.downcast_ref::<NetworkViewClientMessages>().unwrap();
+            match msg {
+                NetworkViewClientMessages::AnnounceAccount(accounts) => {
+                    if !accounts.is_empty() {
+                        counter1.fetch_add(1, Ordering::SeqCst);
+                    }
+                    Box::new(Some(NetworkViewClientResponses::AnnounceAccount(
+                        accounts.clone().into_iter().map(|obj| obj.0).collect(),
+                    )))
+                }
+                NetworkViewClientMessages::GetChainInfo => {
+                    Box::new(Some(NetworkViewClientResponses::ChainInfo {
+                        genesis_id: GenesisId::default(),
+                        height: 1,
+                        tracked_shards: vec![],
+                        archival: false,
+                    }))
+                }
+                _ => Box::new(Some(NetworkViewClientResponses::NoResponse)),
+            }
+        }))
+        .start();
+        let peer_id = PeerId::new(config.public_key.clone());
+        (
+            PeerManagerActor::new(
+                store,
+                config,
+                client_addr.recipient(),
+                view_client_addr.recipient(),
+                routing_table_addr,
+            )
+            .unwrap(),
+            peer_id,
+            counter,
+        )
+    }
 }


### PR DESCRIPTION
`test_utils.rs` currently has code code that's under `test_features` feature. It's better to split the code into two parts.