### PR TITLE
docs: document consistent import style

### DIFF
--- a/docs/style.md
+++ b/docs/style.md
@@ -74,6 +74,81 @@ in rust-analyzer
 
 **Rationale:** Consistency, matches existing practice.
 
+### Import Blocks
+
+**Proposal A**
+
+Separate the group of `use` items with blank lines:
+
+1. Imports from the standard library.
+2. Imports from crates.io crates.
+3. Imports from other crates in nearcore repository.
+4. Imports from the current crate
+
+Within each group, imports are sorted automatically by `rustfmt`
+
+```rust
+// GOOD
+use std::collections::HashMap;
+use std::net::SocketAddr;
+
+use borsh::BorshSerialize;
+use rand::seq::SliceRandom;
+
+use near_primitives::utils::to_timestamp;
+use near_store::{ColPeers, Store};
+
+use crate::types::KnownPeerState;
+
+// BAD -- no blank lines between the groups, groups are in a wrong order
+use borsh::BorshSerialize;
+use crate::types::KnownPeerState;
+use near_primitives::utils::to_timestamp;
+use near_store::{ColPeers, Store};
+use rand::seq::SliceRandom;
+use std::collections::HashMap;
+use std::net::SocketAddr;
+```
+
+**Rationale:** Consistency, improved readability. Specifically, correct
+dependencies and non-dependencies between modules and crates is what makes the
+overall architecture easy or hard to work with. More readable imports allow to
+spot problems like layering violations more easily.
+
+<hr/>
+
+**Proposal B**
+
+Do not separate imports into groups with blank lines. Write a single block of
+imports and rely on `rustfmt` to sort them.
+
+```rust
+// GOOD
+use borsh::BorshSerialize;
+use crate::types::KnownPeerState;
+use near_primitives::utils::to_timestamp;
+use near_store::{ColPeers, Store};
+use rand::seq::SliceRandom;
+use std::collections::HashMap;
+use std::net::SocketAddr;
+
+// BAD -- several groups of imports
+use std::collections::HashMap;
+use std::net::SocketAddr;
+
+use borsh::BorshSerialize;
+use rand::seq::SliceRandom;
+
+use near_primitives::utils::to_timestamp;
+use near_store::{ColPeers, Store};
+
+use crate::types::KnownPeerState;
+```
+
+**Rationale:** Consistency, ease of automatic enforcement. Today stable rustfmt
+can't split imports into groups automatically, and doing that manually
+consistently is a chore.
+
 ## Documentation
 
 When writing documentation in `.md` files, wrap lines at approximately 80

--- a/docs/style.md
+++ b/docs/style.md
@@ -76,49 +76,6 @@ in rust-analyzer
 
 ### Import Blocks
 
-**Proposal A**
-
-Separate the group of `use` items with blank lines:
-
-1. Imports from the standard library.
-2. Imports from crates.io crates.
-3. Imports from other crates in nearcore repository.
-4. Imports from the current crate
-
-Within each group, imports are sorted automatically by `rustfmt`
-
-```rust
-// GOOD
-use std::collections::HashMap;
-use std::net::SocketAddr;
-
-use borsh::BorshSerialize;
-use rand::seq::SliceRandom;
-
-use near_primitives::utils::to_timestamp;
-use near_store::{ColPeers, Store};
-
-use crate::types::KnownPeerState;
-
-// BAD -- no blank lines between the groups, groups are in a wrong order
-use borsh::BorshSerialize;
-use crate::types::KnownPeerState;
-use near_primitives::utils::to_timestamp;
-use near_store::{ColPeers, Store};
-use rand::seq::SliceRandom;
-use std::collections::HashMap;
-use std::net::SocketAddr;
-```
-
-**Rationale:** Consistency, improved readability. Specifically, correct
-dependencies and non-dependencies between modules and crates is what makes the
-overall architecture easy or hard to work with. More readable imports allow to
-spot problems like layering violations more easily.
-
-<hr/>
-
-**Proposal B**
-
 Do not separate imports into groups with blank lines. Write a single block of
 imports and rely on `rustfmt` to sort them.
 


### PR DESCRIPTION
Document whether we should do

```rust
use near_store::{ColPeers, Store};
use std::collections::HashMap;
use std::net::SocketAddr;
```

or 

```rust
use std::collections::HashMap;
use std::net::SocketAddr;

use near_store::{ColPeers, Store};
```

This PR currently documents both suggested guidelines, and we'll use this PR to decide which one we pick. 

Decision procedure: if you don't care about the style, ignore this PR, and just note the final decision :) Otherwise, react with :+1: for proposal A or proposal B (do read the actual proposals in the changset). Feel free to leave a comment explaining your choice.

If there's a clear consensus around one option, we'll just pick it. Otherwise, @bowenwang1996 makes the final call or delegates the decision to make the final call. 