### PR TITLE
chore: don't include near-vm-runner-standalone in release artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ docker-nearcore-nightly:
 
 release:
 	cargo build -p neard --release
-	cargo build -p near-vm-runner-standalone --release
 	cargo build -p state-viewer --release
 	cargo build -p store-validator --release
 	cargo build -p runtime-params-estimator --release
@@ -38,7 +37,6 @@ debug:
 
 perf-release:
 	CARGO_PROFILE_RELEASE_DEBUG=true cargo build -p neard --release --features performance_stats,memory_stats
-	cargo build -p near-vm-runner-standalone --release
 	cargo build -p state-viewer --release --features nearcore/performance_stats,nearcore/memory_stats
 	cargo build -p store-validator --release --features nearcore/performance_stats,nearcore/memory_stats
 
@@ -50,7 +48,6 @@ perf-debug:
 
 nightly-release:
 	cargo build -p neard --release --features nightly_protocol,nightly_protocol_features,performance_stats,memory_stats
-	cargo build -p near-vm-runner-standalone --release --features nightly_protocol,nightly_protocol_features
 	cargo build -p state-viewer --release --features nearcore/nightly_protocol,nearcore/nightly_protocol_features,nearcore/performance_stats,nearcore/memory_stats
 	cargo build -p store-validator --release --features nearcore/nightly_protocol,nearcore/nightly_protocol_features,nearcore/performance_stats,nearcore/memory_stats
 	cargo build -p runtime-params-estimator --release --features nightly_protocol,nightly_protocol_features,nearcore/nightly_protocol,nearcore/nightly_protocol_features,nearcore/performance_stats,nearcore/memory_stats


### PR DESCRIPTION
We used to use near-vm-runner-standalone as a way to run contracts
locally, but that never worked properly, as the standalone runner can't
perfectly recreate proper blockchain environment. Today, the task of
running a contract "locally" is solved by a sandbox node

https://github.com/near/sandbox

We still keep the code in the repo, as it is sometimes useful for ad-hoc
investigations by contract runtime team. We just forgot to remove it
from releases, which we should have done ages ago.