### PR TITLE
Make @mm-near code owners of  /core /neard /nearcore

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -20,10 +20,10 @@
 /tools/rpctypegen/ @frol
 /tools/indexer/ @khorolets @frol
 
-/core/  @bowenwang1996 @frol @matklad
+/core/  @bowenwang1996 @frol @matklad @mm-near
 /core/store/src/trie @mzhangmzz @longarithm
-/neard/ @bowenwang1996 @frol
-/nearcore/ @bowenwang1996 @frol
+/neard/ @bowenwang1996 @frol @mm-near
+/nearcore/ @bowenwang1996 @frol @mm-near
 /test-utils/state-viewer @nikurt
 /test-utils/runtime-tester @posvyatokum @matklad
 


### PR DESCRIPTION
Make @mm-near code owners of 
```
/core
/neard
/nearcore
```

I noticed that Marcin is not a code owner in a few places. Changes like https://github.com/near/nearcore/pull/5237 require approval from  @bowenwang1996 and @mm-near 