### PR TITLE
FEATURE Simplify usage of metrics - panic if we fail to create prometheus metric

### DIFF
--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -1390,7 +1390,7 @@ impl PeerManagerActor {
             Ok(peer_id) => peer_id,
             Err(find_route_error) => {
                 // TODO(MarX, #1369): Message is dropped here. Define policy for this case.
-                near_metrics::inc_counter(&metrics::DROP_MESSAGE_UNKNOWN_ACCOUNT);
+                metrics::DROP_MESSAGE_UNKNOWN_ACCOUNT.inc();
                 debug!(target: "network", "{:?} Drop message to {} Reason {:?}. Message {:?}",
                        self.config.account_id,
                        account_id,

--- a/chain/network/src/routing/codec.rs
+++ b/chain/network/src/routing/codec.rs
@@ -60,7 +60,7 @@ impl Encoder<Vec<u8>> for Codec {
             {
                 error!(target: "network", "{} throwing away message, because buffer is full item.len(): {} buf.capacity: {}", get_tid(), item.len(), buf.capacity());
 
-                near_metrics::inc_counter_by(&metrics::DROPPED_MESSAGES_COUNT, 1);
+                metrics::DROPPED_MESSAGES_COUNT.inc_by(1);
                 return Err(Error::new(ErrorKind::Other, "Buf max capacity exceeded"));
             }
             // First four bytes is the length of the buffer.

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -171,8 +171,8 @@ impl RoutingTableActor {
         self.needs_routing_table_recalculation = true;
 
         // Update metrics after edge update
-        near_metrics::inc_counter_by(&metrics::EDGE_UPDATES, total as u64);
-        near_metrics::set_gauge(&metrics::EDGE_ACTIVE, self.raw_graph.total_active_edges() as i64);
+        metrics::EDGE_UPDATES.inc_by(total as u64);
+        metrics::EDGE_ACTIVE.set(self.raw_graph.total_active_edges() as i64);
 
         edges
     }
@@ -242,7 +242,7 @@ impl RoutingTableActor {
         #[cfg(feature = "delay_detector")]
         let _d = DelayDetector::new("routing table update".into());
         let _routing_table_recalculation =
-            near_metrics::start_timer(&metrics::ROUTING_TABLE_RECALCULATION_HISTOGRAM);
+            metrics::ROUTING_TABLE_RECALCULATION_HISTOGRAM.start_timer();
 
         trace!(target: "network", "Update routing table.");
 
@@ -253,8 +253,8 @@ impl RoutingTableActor {
             self.peer_last_time_reachable.insert(peer.clone(), now);
         }
 
-        near_metrics::inc_counter_by(&metrics::ROUTING_TABLE_RECALCULATIONS, 1);
-        near_metrics::set_gauge(&metrics::PEER_REACHABLE, self.peer_forwarding.len() as i64);
+        metrics::ROUTING_TABLE_RECALCULATIONS.inc();
+        metrics::PEER_REACHABLE.set(self.peer_forwarding.len() as i64);
     }
 
     /// If pruning is enabled we will remove unused edges and store them to disk.

--- a/chain/network/src/stats/metrics.rs
+++ b/chain/network/src/stats/metrics.rs
@@ -10,76 +10,86 @@ use near_metrics::{
 
 use crate::types::{PeerMessage, RoutedMessageBody};
 
-pub static PEER_CONNECTIONS_TOTAL: Lazy<near_metrics::Result<IntGauge>> =
-    Lazy::new(|| try_create_int_gauge("near_peer_connections_total", "Number of connected peers"));
-pub static PEER_DATA_RECEIVED_BYTES: Lazy<near_metrics::Result<IntCounter>> = Lazy::new(|| {
-    try_create_int_counter("near_peer_data_received_bytes", "Total data received from peers")
+pub static PEER_CONNECTIONS_TOTAL: Lazy<IntGauge> = Lazy::new(|| {
+    try_create_int_gauge("near_peer_connections_total", "Number of connected peers").unwrap()
 });
-pub static PEER_MESSAGE_RECEIVED_TOTAL: Lazy<near_metrics::Result<IntCounter>> = Lazy::new(|| {
+pub static PEER_DATA_RECEIVED_BYTES: Lazy<IntCounter> = Lazy::new(|| {
+    try_create_int_counter("near_peer_data_received_bytes", "Total data received from peers")
+        .unwrap()
+});
+pub static PEER_MESSAGE_RECEIVED_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
     try_create_int_counter(
         "near_peer_message_received_total",
         "Number of messages received from peers",
     )
+    .unwrap()
 });
-pub static PEER_CLIENT_MESSAGE_RECEIVED_TOTAL: Lazy<near_metrics::Result<IntCounter>> =
-    Lazy::new(|| {
-        try_create_int_counter(
-            "near_peer_client_message_received_total",
-            "Number of messages for client received from peers",
-        )
-    });
-pub static PEER_BLOCK_RECEIVED_TOTAL: Lazy<near_metrics::Result<IntCounter>> = Lazy::new(|| {
+pub static PEER_CLIENT_MESSAGE_RECEIVED_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
+    try_create_int_counter(
+        "near_peer_client_message_received_total",
+        "Number of messages for client received from peers",
+    )
+    .unwrap()
+});
+pub static PEER_BLOCK_RECEIVED_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
     try_create_int_counter("near_peer_block_received_total", "Number of blocks received by peers")
+        .unwrap()
 });
-pub static PEER_TRANSACTION_RECEIVED_TOTAL: Lazy<near_metrics::Result<IntCounter>> =
-    Lazy::new(|| {
-        try_create_int_counter(
-            "near_peer_transaction_received_total",
-            "Number of transactions received by peers",
-        )
-    });
+pub static PEER_TRANSACTION_RECEIVED_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
+    try_create_int_counter(
+        "near_peer_transaction_received_total",
+        "Number of transactions received by peers",
+    )
+    .unwrap()
+});
 
 // Routing table metrics
-pub static ROUTING_TABLE_RECALCULATIONS: Lazy<near_metrics::Result<IntCounter>> = Lazy::new(|| {
+pub static ROUTING_TABLE_RECALCULATIONS: Lazy<IntCounter> = Lazy::new(|| {
     try_create_int_counter(
         "near_routing_table_recalculations_total",
         "Number of times routing table have been recalculated from scratch",
     )
+    .unwrap()
 });
-pub static ROUTING_TABLE_RECALCULATION_HISTOGRAM: Lazy<near_metrics::Result<Histogram>> =
-    Lazy::new(|| {
-        try_create_histogram(
-            "near_routing_table_recalculation_seconds",
-            "Time spent recalculating routing table",
-        )
-    });
-pub static EDGE_UPDATES: Lazy<near_metrics::Result<IntCounter>> =
-    Lazy::new(|| try_create_int_counter("near_edge_updates", "Unique edge updates"));
-pub static EDGE_ACTIVE: Lazy<near_metrics::Result<IntGauge>> =
-    Lazy::new(|| try_create_int_gauge("near_edge_active", "Total edges active between peers"));
-pub static PEER_REACHABLE: Lazy<near_metrics::Result<IntGauge>> = Lazy::new(|| {
+pub static ROUTING_TABLE_RECALCULATION_HISTOGRAM: Lazy<Histogram> = Lazy::new(|| {
+    try_create_histogram(
+        "near_routing_table_recalculation_seconds",
+        "Time spent recalculating routing table",
+    )
+    .unwrap()
+});
+pub static EDGE_UPDATES: Lazy<IntCounter> =
+    Lazy::new(|| try_create_int_counter("near_edge_updates", "Unique edge updates").unwrap());
+pub static EDGE_ACTIVE: Lazy<IntGauge> = Lazy::new(|| {
+    try_create_int_gauge("near_edge_active", "Total edges active between peers").unwrap()
+});
+pub static PEER_REACHABLE: Lazy<IntGauge> = Lazy::new(|| {
     try_create_int_gauge(
         "near_peer_reachable",
         "Total peers such that there is a path potentially through other peers",
     )
+    .unwrap()
 });
-pub static DROP_MESSAGE_UNKNOWN_ACCOUNT: Lazy<near_metrics::Result<IntCounter>> = Lazy::new(|| {
+pub static DROP_MESSAGE_UNKNOWN_ACCOUNT: Lazy<IntCounter> = Lazy::new(|| {
     try_create_int_counter(
         "near_drop_message_unknown_account",
         "Total messages dropped because target account is not known",
     )
+    .unwrap()
 });
-pub static RECEIVED_INFO_ABOUT_ITSELF: Lazy<near_metrics::Result<IntCounter>> = Lazy::new(|| {
+pub static RECEIVED_INFO_ABOUT_ITSELF: Lazy<IntCounter> = Lazy::new(|| {
     try_create_int_counter(
         "received_info_about_itself",
         "Number of times a peer tried to connect to itself",
     )
+    .unwrap()
 });
-pub static DROPPED_MESSAGES_COUNT: Lazy<near_metrics::Result<IntCounter>> = Lazy::new(|| {
+pub static DROPPED_MESSAGES_COUNT: Lazy<IntCounter> = Lazy::new(|| {
     near_metrics::try_create_int_counter(
         "near_dropped_messages_count",
         "Total count of messages which were dropped, because write buffer was full",
     )
+    .unwrap()
 });
 
 #[derive(Clone)]

--- a/integration-tests/tests/network/peer_handshake.rs
+++ b/integration-tests/tests/network/peer_handshake.rs
@@ -226,9 +226,7 @@ fn check_connection_with_new_identity() {
     runner.push(Action::Wait(2000));
 
     // Check the no node tried to connect to itself in this process.
-    runner.push_action(wait_for(|| {
-        near_metrics::get_counter(&near_network::metrics::RECEIVED_INFO_ABOUT_ITSELF) == Ok(0)
-    }));
+    runner.push_action(wait_for(|| near_network::metrics::RECEIVED_INFO_ABOUT_ITSELF.get() == 0));
 
     start_test(runner);
 }


### PR DESCRIPTION
As discussed with @matklad I think we should refactor code for using Prometheus metrics. 

Creating a propethius metric can fail if there is a naming error. We should panic when application starts, and find out that there is an issue, rather than trying to silently hide errors.

If we think this change is good, we should consider doing that in other places as well.