### PR TITLE
refactor: Reorganize imports in near-network

### DIFF
--- a/chain/network/benches/routing_table_actor.rs
+++ b/chain/network/benches/routing_table_actor.rs
@@ -1,8 +1,7 @@
 #[macro_use]
 extern crate bencher;
 
-use bencher::black_box;
-use bencher::Bencher;
+use bencher::{black_box, Bencher};
 use near_crypto::{KeyType, SecretKey, Signature};
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -22,6 +22,7 @@ use near_network_primitives::types::{
     ReasonForBan, RoutedMessage, RoutedMessageBody, RoutedMessageFrom, StateResponseInfo,
     UPDATE_INTERVAL_LAST_TIME_RECEIVED_MESSAGE,
 };
+use near_performance_metrics;
 use near_performance_metrics::framed_write::{FramedWrite, WriteHandler};
 use near_performance_metrics_macros::perf;
 use near_primitives::block::GenesisId;
@@ -35,7 +36,6 @@ use near_primitives::version::{
 use near_primitives::{logging, unwrap_option_or_return};
 use near_rate_limiter::ThrottleController;
 use near_rust_allocator_proxy::allocator::get_tid;
-use {near_metrics, near_performance_metrics};
 
 use crate::peer::tracker::Tracker;
 use crate::routing::codec::{self, bytes_to_peer_message, peer_message_to_bytes, Codec};

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -2,10 +2,8 @@ use std::cmp::max;
 use std::fmt::Debug;
 use std::io;
 use std::net::SocketAddr;
-use std::sync::{
-    atomic::{AtomicUsize, Ordering},
-    Arc,
-};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use actix::{
@@ -24,21 +22,20 @@ use near_network_primitives::types::{
     ReasonForBan, RoutedMessage, RoutedMessageBody, RoutedMessageFrom, StateResponseInfo,
     UPDATE_INTERVAL_LAST_TIME_RECEIVED_MESSAGE,
 };
-use near_performance_metrics;
 use near_performance_metrics::framed_write::{FramedWrite, WriteHandler};
 use near_performance_metrics_macros::perf;
 use near_primitives::block::GenesisId;
-use near_primitives::logging;
 use near_primitives::network::PeerId;
 use near_primitives::sharding::PartialEncodedChunk;
 use near_primitives::time::Clock;
-use near_primitives::unwrap_option_or_return;
 use near_primitives::utils::DisplayOption;
 use near_primitives::version::{
     ProtocolVersion, OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION, PROTOCOL_VERSION,
 };
+use near_primitives::{logging, unwrap_option_or_return};
 use near_rate_limiter::ThrottleController;
 use near_rust_allocator_proxy::allocator::get_tid;
+use {near_metrics, near_performance_metrics};
 
 use crate::peer::tracker::Tracker;
 use crate::routing::codec::{self, bytes_to_peer_message, peer_message_to_bytes, Codec};

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -5,8 +5,8 @@ use std::collections::{HashMap, HashSet};
 use std::mem::swap;
 use std::net::SocketAddr;
 use std::pin::Pin;
-use std::sync::atomic::Ordering;
-use std::sync::{atomic::AtomicUsize, Arc};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use actix::{

--- a/chain/network/src/peer_manager/peer_store.rs
+++ b/chain/network/src/peer_manager/peer_store.rs
@@ -1,7 +1,5 @@
-use std::collections::{
-    hash_map::{Entry, Iter},
-    HashMap,
-};
+use std::collections::hash_map::{Entry, Iter};
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 

--- a/chain/network/src/routing/codec.rs
+++ b/chain/network/src/routing/codec.rs
@@ -173,10 +173,8 @@ mod test {
     use near_primitives::hash::{self, CryptoHash};
     use near_primitives::network::{AnnounceAccount, PeerId};
     use near_primitives::transaction::{SignedTransaction, Transaction};
-    use near_primitives::{
-        types::EpochId,
-        version::{OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION, PROTOCOL_VERSION},
-    };
+    use near_primitives::types::EpochId;
+    use near_primitives::version::{OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION, PROTOCOL_VERSION};
 
     use super::*;
     use crate::routing::edge::EdgeInfo;

--- a/chain/network/src/routing/route_back_cache.rs
+++ b/chain/network/src/routing/route_back_cache.rs
@@ -1,5 +1,4 @@
-use std::collections::btree_map;
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{btree_map, BTreeMap, BTreeSet, HashMap};
 use std::time::{Duration, Instant};
 
 use near_primitives::hash::CryptoHash;
@@ -229,7 +228,8 @@ impl RouteBackCache {
 mod test {
     use super::*;
     use near_primitives::hash::hash;
-    use std::{thread, time::Duration};
+    use std::thread;
+    use std::time::Duration;
 
     /// Check internal state of the cache is ok
     fn check_consistency(cache: &RouteBackCache) {

--- a/chain/network/src/routing/routing.rs
+++ b/chain/network/src/routing/routing.rs
@@ -1,5 +1,6 @@
 use near_primitives::time::Clock;
-use std::collections::{hash_map::Entry, HashMap, VecDeque};
+use std::collections::hash_map::Entry;
+use std::collections::{HashMap, VecDeque};
 use std::hash::Hash;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -1,14 +1,14 @@
 use near_primitives::time::Instant;
 use std::collections::HashMap;
-use std::fmt;
 use std::fmt::{Debug, Formatter};
-use std::io;
 use std::sync::{Arc, Mutex, RwLock};
+use std::{fmt, io};
 
 use actix::dev::{MessageResponse, ResponseChannel};
 use actix::{Actor, Addr, MailboxError, Message, Recipient};
 use borsh::{BorshDeserialize, BorshSerialize};
-use futures::{future::BoxFuture, FutureExt};
+use futures::future::BoxFuture;
+use futures::FutureExt;
 #[cfg(feature = "test_features")]
 use serde::Serialize;
 use strum::AsStaticStr;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,6 @@
 use_small_heuristics = "Max"
 reorder_imports = true
 edition = "2021"
+# imports_granularity = "Module"
 # fn_args_density = "Compressed"
 # overflow_delimited_expr = "true"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,7 @@
 use_small_heuristics = "Max"
 reorder_imports = true
 edition = "2021"
+# This option will merge imports, however it's only available in +nightly.
 # imports_granularity = "Module"
 # fn_args_density = "Compressed"
 # overflow_delimited_expr = "true"

--- a/utils/near-performance-metrics/src/actix_enabled.rs
+++ b/utils/near-performance-metrics/src/actix_enabled.rs
@@ -1,7 +1,6 @@
 use log::warn;
 use std::panic::Location;
-use std::time::Duration;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crate::stats_enabled::{get_thread_stats_logger, MyFuture, REF_COUNTER, SLOW_CALL_THRESHOLD};
 

--- a/utils/near-performance-metrics/src/stats_enabled.rs
+++ b/utils/near-performance-metrics/src/stats_enabled.rs
@@ -12,8 +12,7 @@ use std::pin::Pin;
 use std::sync::atomic::AtomicUsize;
 use std::sync::{Arc, Mutex};
 use std::task::Poll;
-use std::time::Duration;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use bytesize::ByteSize;
 use strum::AsStaticRef;

--- a/utils/near-rate-limiter/src/lib.rs
+++ b/utils/near-rate-limiter/src/lib.rs
@@ -1,4 +1,3 @@
 pub(crate) mod framed_read;
 
-pub use framed_read::ThrottleController;
-pub use framed_read::ThrottledFrameRead;
+pub use framed_read::{ThrottleController, ThrottledFrameRead};


### PR DESCRIPTION
Let's group imports together in `near-network`. This was done with running rustfmt with 'imports_granuality = "Module"' in `rustfmt.toml`.

Command used:
`rustfmt +nightly *.rs`