### PR TITLE
refactor: Add Default and move constants to route_back_cache.rs

### DIFF
--- a/chain/network/src/routing/route_back_cache.rs
+++ b/chain/network/src/routing/route_back_cache.rs
@@ -5,6 +5,13 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
 use near_primitives::time::Clock;
 
+/// default value for `capacity`
+const DEFAULT_CAPACITY: usize = 100_000;
+/// default value for `evict_timeout`
+const DEFAULT_CACHE_EVICT_TIMEOUT: Duration = Duration::from_millis(120_000);
+/// default value for `remove_frequent_min_size`
+const DEFAULT_REMOVE_BATCH_SIZE: usize = 100;
+
 /// Cache to store route back messages.
 ///
 /// The interface of the cache is similar to a regular HashMap:
@@ -59,6 +66,12 @@ pub struct RouteBackCache {
     /// are sorted by the time they arrived from older to newer.
     /// Size: O(capacity)
     record_per_target: BTreeMap<PeerId, BTreeSet<(Instant, CryptoHash)>>,
+}
+
+impl Default for RouteBackCache {
+    fn default() -> Self {
+        Self::new(DEFAULT_CAPACITY, DEFAULT_CACHE_EVICT_TIMEOUT, DEFAULT_REMOVE_BATCH_SIZE)
+    }
 }
 
 impl RouteBackCache {

--- a/chain/network/src/routing/routing.rs
+++ b/chain/network/src/routing/routing.rs
@@ -26,9 +26,6 @@ use crate::routing::utils::cache_to_hashmap;
 use crate::PeerInfo;
 
 const ANNOUNCE_ACCOUNT_CACHE_SIZE: usize = 10_000;
-const ROUTE_BACK_CACHE_SIZE: usize = 100_000;
-const ROUTE_BACK_CACHE_EVICT_TIMEOUT: Duration = Duration::from_millis(120_000);
-const ROUTE_BACK_CACHE_REMOVE_BATCH: usize = 100;
 const PING_PONG_CACHE_SIZE: usize = 1_000;
 const ROUND_ROBIN_MAX_NONCE_DIFFERENCE_ALLOWED: usize = 10;
 const ROUND_ROBIN_NONCE_CACHE_SIZE: usize = 10_000;
@@ -156,11 +153,7 @@ impl RoutingTableView {
             account_peers: SizedCache::with_size(ANNOUNCE_ACCOUNT_CACHE_SIZE),
             peer_forwarding: Default::default(),
             local_edges_info: Default::default(),
-            route_back: RouteBackCache::new(
-                ROUTE_BACK_CACHE_SIZE,
-                ROUTE_BACK_CACHE_EVICT_TIMEOUT,
-                ROUTE_BACK_CACHE_REMOVE_BATCH,
-            ),
+            route_back: RouteBackCache::default(),
             store,
             route_nonce: SizedCache::with_size(ROUND_ROBIN_NONCE_CACHE_SIZE),
             ping_info: SizedCache::with_size(PING_PONG_CACHE_SIZE),

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -627,7 +627,7 @@ fn rocksdb_options() -> Options {
     opts.create_missing_column_families(true);
     opts.create_if_missing(true);
     opts.set_use_fsync(false);
-    opts.set_max_open_files(512);
+    opts.PeerInfo(512);
     opts.set_keep_log_file_num(1);
     opts.set_bytes_per_sync(bytesize::MIB);
     opts.set_write_buffer_size(256 * bytesize::MIB as usize);

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -627,7 +627,7 @@ fn rocksdb_options() -> Options {
     opts.create_missing_column_families(true);
     opts.create_if_missing(true);
     opts.set_use_fsync(false);
-    opts.PeerInfo(512);
+    opts.set_max_open_files(512);
     opts.set_keep_log_file_num(1);
     opts.set_bytes_per_sync(bytesize::MIB);
     opts.set_write_buffer_size(256 * bytesize::MIB as usize);


### PR DESCRIPTION
We should make core more readable by moving `RouteBackCache` related constants inside `route_back_cache.rs`.