### PR TITLE
refactor: Move codes.rs in the same module as peer_actor.rs

### DIFF
--- a/chain/network/src/peer/codec.rs
+++ b/chain/network/src/peer/codec.rs
@@ -86,7 +86,6 @@ impl Decoder for Codec {
         let mut len_bytes: [u8; 4] = [0; 4];
         len_bytes.copy_from_slice(&buf[0..4]);
         let len = u32::from_le_bytes(len_bytes);
-
         if len > self.max_length {
             // If this point is reached, abusive peer is banned.
             return Ok(Some(Err(ReasonForBan::Abusive)));

--- a/chain/network/src/peer/codec.rs
+++ b/chain/network/src/peer/codec.rs
@@ -103,11 +103,11 @@ impl Decoder for Codec {
     }
 }
 
-pub fn peer_message_to_bytes(peer_message: &PeerMessage) -> Result<Vec<u8>, std::io::Error> {
+pub(crate) fn peer_message_to_bytes(peer_message: &PeerMessage) -> Result<Vec<u8>, std::io::Error> {
     peer_message.try_to_vec()
 }
 
-pub fn bytes_to_peer_message(bytes: &[u8]) -> Result<PeerMessage, std::io::Error> {
+pub(crate) fn bytes_to_peer_message(bytes: &[u8]) -> Result<PeerMessage, std::io::Error> {
     PeerMessage::try_from_slice(bytes)
 }
 
@@ -121,7 +121,7 @@ fn peer_id_type_field_len(enum_var: u8) -> Option<usize> {
     }
 }
 
-pub fn is_forward_tx(bytes: &[u8]) -> Option<bool> {
+pub(crate) fn is_forward_tx(bytes: &[u8]) -> Option<bool> {
     let peer_message_variant = *bytes.get(0)?;
 
     // PeerMessage::Routed variant == 13

--- a/chain/network/src/peer/mod.rs
+++ b/chain/network/src/peer/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod codec;
 pub(crate) mod peer_actor;
 mod rate_counter;
 mod tracker;

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -37,8 +37,8 @@ use near_primitives::{logging, unwrap_option_or_return};
 use near_rate_limiter::ThrottleController;
 use near_rust_allocator_proxy::allocator::get_tid;
 
+use crate::peer::codec::{self, bytes_to_peer_message, peer_message_to_bytes, Codec};
 use crate::peer::tracker::Tracker;
-use crate::routing::codec::{self, bytes_to_peer_message, peer_message_to_bytes, Codec};
 use crate::routing::edge::{Edge, EdgeInfo};
 use crate::stats::metrics::{self, NetworkMetrics};
 use crate::types::{

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -40,9 +40,9 @@ use near_store::Store;
 use rand::thread_rng;
 use tokio_util::sync::PollSemaphore;
 
+use crate::peer::codec::Codec;
 use crate::peer::peer_actor::PeerActor;
 use crate::peer_manager::peer_store::{PeerStore, TrustLevel};
-use crate::routing::codec::Codec;
 use crate::stats::metrics;
 use crate::stats::metrics::NetworkMetrics;
 use crate::types::{FullPeerInfo, NetworkClientMessages, NetworkRequests, NetworkResponses};

--- a/chain/network/src/routing/mod.rs
+++ b/chain/network/src/routing/mod.rs
@@ -1,4 +1,3 @@
-pub(crate) mod codec;
 pub(crate) mod edge;
 pub(crate) mod edge_verifier_actor;
 #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]


### PR DESCRIPTION
`codes.rs` doesn't make much sense to be in `near-network/src/routing`. `Codec` is used to create `PeerActor` by `PeerActorManager`. Therefore it's only used by those two places.
