### PR TITLE
feat: Add `num_epoch_to_store` to `config.json`

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -97,7 +97,8 @@ pub const TX_ROUTING_HEIGHT_HORIZON: BlockHeightDelta = 4;
 /// Private constant for 1 NEAR (copy from near/config.rs) used for reporting.
 const NEAR_BASE: Balance = 1_000_000_000_000_000_000_000_000;
 
-/// Number of epochs for which we keep store data
+/// Default number of epochs for which we keep store data.
+/// This value may be overridden by `Config.additional_epochs_to_keep`.
 pub const NUM_EPOCHS_TO_KEEP_STORE_DATA: u64 = 5;
 
 /// Maximum number of height to go through at each step when cleaning forks during garbage collection.

--- a/chain/epoch_manager/src/lib.rs
+++ b/chain/epoch_manager/src/lib.rs
@@ -70,12 +70,15 @@ pub struct EpochManager {
     epoch_info_aggregator: Option<EpochInfoAggregator>,
     /// Largest final height. Monotonically increasing.
     largest_final_height: BlockHeight,
+    /// Number of additional epochs to keep in memory.
+    pub additional_epochs_to_keep: u64,
 }
 
 impl EpochManager {
     pub fn new_from_genesis_config(
         store: Store,
         genesis_config: &GenesisConfig,
+        additional_epochs_to_keep: u64,
     ) -> Result<Self, EpochError> {
         let reward_calculator = RewardCalculator::new(genesis_config);
         let all_epoch_config = AllEpochConfig::from(genesis_config);
@@ -85,6 +88,7 @@ impl EpochManager {
             genesis_config.protocol_version,
             reward_calculator,
             genesis_config.validators(),
+            additional_epochs_to_keep,
         )
     }
 
@@ -94,6 +98,7 @@ impl EpochManager {
         genesis_protocol_version: ProtocolVersion,
         reward_calculator: RewardCalculator,
         validators: Vec<ValidatorStake>,
+        additional_epochs_to_keep: u64,
     ) -> Result<Self, EpochError> {
         let validator_reward = vec![(reward_calculator.protocol_treasury_account.clone(), 0u128)]
             .into_iter()
@@ -110,6 +115,7 @@ impl EpochManager {
             epoch_validators_ordered_unique: lru::LruCache::new(EPOCH_CACHE_SIZE),
             epoch_info_aggregator: None,
             largest_final_height: 0,
+            additional_epochs_to_keep,
         };
         let genesis_epoch_id = EpochId::default();
         if !epoch_manager.has_epoch_info(&genesis_epoch_id)? {
@@ -1626,6 +1632,7 @@ mod tests2 {
                 .iter()
                 .map(|(account_id, balance)| stake(account_id.clone(), *balance))
                 .collect(),
+            0,
         )
         .unwrap();
         assert!(compare_epoch_infos(epoch_manager2.get_epoch_info(&epoch3).unwrap(), &expected3));
@@ -1894,6 +1901,7 @@ mod tests2 {
             PROTOCOL_VERSION,
             default_reward_calculator(),
             validators,
+            0,
         )
         .unwrap();
         let h = hash_range(8);
@@ -1964,6 +1972,7 @@ mod tests2 {
             PROTOCOL_VERSION,
             default_reward_calculator(),
             validators,
+            0,
         )
         .unwrap();
 
@@ -2036,6 +2045,7 @@ mod tests2 {
             PROTOCOL_VERSION,
             default_reward_calculator(),
             validators,
+            0,
         )
         .unwrap();
 
@@ -3706,7 +3716,8 @@ mod tests2 {
             stake("test2".parse().unwrap(), amount_staked),
         ];
         let mut epoch_manager =
-            EpochManager::new(store, config, 0, default_reward_calculator(), validators).unwrap();
+            EpochManager::new(store, config, 0, default_reward_calculator(), validators, 0)
+                .unwrap();
         let h = hash_range(8);
         record_block(&mut epoch_manager, CryptoHash::default(), h[0], 0, vec![]);
         let mut block_info1 =
@@ -3750,6 +3761,7 @@ mod tests2 {
             new_protocol_version - 1,
             default_reward_calculator(),
             validators,
+            0,
         )
         .unwrap();
         let h = hash_range(8);
@@ -3837,7 +3849,8 @@ mod tests2 {
             stake("test2".parse().unwrap(), amount_staked / 5),
         ];
         let mut epoch_manager =
-            EpochManager::new(store, config, 0, default_reward_calculator(), validators).unwrap();
+            EpochManager::new(store, config, 0, default_reward_calculator(), validators, 0)
+                .unwrap();
         let h = hash_range(50);
         record_block(&mut epoch_manager, CryptoHash::default(), h[0], 0, vec![]);
         let mut block_info1 =
@@ -3873,6 +3886,7 @@ mod tests2 {
             UPGRADABILITY_FIX_PROTOCOL_VERSION,
             default_reward_calculator(),
             validators,
+            0,
         )
         .unwrap();
         let h = hash_range(5 * epoch_length);

--- a/chain/epoch_manager/src/test_utils.rs
+++ b/chain/epoch_manager/src/test_utils.rs
@@ -218,6 +218,7 @@ pub fn setup_epoch_manager_with_simple_nightshade_config(
             .iter()
             .map(|(account_id, balance)| stake(account_id.clone(), *balance))
             .collect(),
+        0,
     )
     .unwrap()
 }

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -65,6 +65,7 @@ impl GenesisBuilder {
             None,
             None,
             None,
+            0,
         );
         Self {
             home_dir: home_dir.to_path_buf(),

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -311,6 +311,10 @@ fn default_gc_blocks_limit() -> NumBlocks {
     2
 }
 
+fn default_additional_epochs_to_keep() -> u64 {
+    0
+}
+
 fn default_view_client_threads() -> usize {
     4
 }
@@ -453,6 +457,8 @@ pub struct Config {
     /// For example, setting "use_db_migration_snapshot" to "/tmp/" will create a directory "/tmp/db_migration_snapshot" and populate it with the database files.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub db_migration_snapshot_path: Option<PathBuf>,
+    #[serde(default = "default_additional_epochs_to_keep")]
+    pub additional_epochs_to_keep: u64,
 }
 
 impl Default for Config {
@@ -481,6 +487,7 @@ impl Default for Config {
             max_gas_burnt_view: None,
             db_migration_snapshot_path: None,
             use_db_migration_snapshot: true,
+            additional_epochs_to_keep: default_additional_epochs_to_keep(),
         }
     }
 }

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -149,6 +149,7 @@ pub fn migrate_18_to_19(path: &Path, near_config: &NearConfig) {
             near_config.genesis.config.protocol_version,
             RewardCalculator::new(&near_config.genesis.config),
             near_config.genesis.config.validators(),
+            0,
         )
         .unwrap();
         for (key, value) in store.iter(DBCol::ColEpochStart) {

--- a/nearcore/src/shard_tracker.rs
+++ b/nearcore/src/shard_tracker.rs
@@ -204,6 +204,7 @@ mod tests {
                 #[cfg(feature = "protocol_feature_chunk_only_producers")]
                 false,
             )],
+            0,
         )
         .unwrap()
     }

--- a/test-utils/runtime-tester/src/run_test.rs
+++ b/test-utils/runtime-tester/src/run_test.rs
@@ -63,6 +63,7 @@ impl Scenario {
                 &genesis,
                 TrackedConfig::new_empty(),
                 runtime_config_store,
+                0,
             ))])
             .build();
 

--- a/test-utils/store-validator/src/main.rs
+++ b/test-utils/store-validator/src/main.rs
@@ -40,6 +40,7 @@ fn main() {
         None,
         None,
         None,
+        near_config.config.additional_epochs_to_keep,
     ));
 
     let mut store_validator = StoreValidator::new(

--- a/tools/restored-receipts-verifier/src/main.rs
+++ b/tools/restored-receipts-verifier/src/main.rs
@@ -54,6 +54,7 @@ fn main() -> Result<()> {
         None,
         near_config.client_config.max_gas_burnt_view,
         None,
+        near_config.config.additional_epochs_to_keep,
     );
 
     let mut receipts_missing = Vec::<Receipt>::new();

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -446,7 +446,7 @@ pub(crate) fn view_chain(
         }
     };
     let mut epoch_manager =
-        EpochManager::new_from_genesis_config(store.clone(), &near_config.genesis.config)
+        EpochManager::new_from_genesis_config(store.clone(), &near_config.genesis.config, 0)
             .expect("Failed to start Epoch Manager");
     let shard_layout = epoch_manager.get_shard_layout(block.header().epoch_id()).unwrap();
 
@@ -530,7 +530,7 @@ pub(crate) fn print_epoch_info(
     let genesis_height = near_config.genesis.config.genesis_height;
     let mut chain_store = ChainStore::new(store.clone(), genesis_height);
     let mut epoch_manager =
-        EpochManager::new_from_genesis_config(store.clone(), &near_config.genesis.config)
+        EpochManager::new_from_genesis_config(store.clone(), &near_config.genesis.config, 0)
             .expect("Failed to start Epoch Manager");
     let runtime_adapter: Arc<dyn RuntimeAdapter> = Arc::new(NightshadeRuntime::with_config(
         &home_dir,


### PR DESCRIPTION
Currently for a regular node the number of epochs for which we retain data is fixed (5 epochs) and we have received requests to make that flexible, since some partners have requirements on data retention.

We are going to add `num_epoch_to_store` to `Config` with default value of `DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA  = 5`.

Resolves https://github.com/near/nearcore/issues/5347