### PR TITLE
Add help to `tools/indexer/example`

### DIFF
--- a/tools/indexer/example/src/configs.rs
+++ b/tools/indexer/example/src/configs.rs
@@ -1,4 +1,4 @@
-use clap::Clap;
+use clap::{AppSettings, Clap};
 
 use near_indexer::near_primitives::types::Gas;
 
@@ -8,6 +8,7 @@ use tracing_subscriber::EnvFilter;
 /// Watches for stream of blocks from the chain
 #[derive(Clap, Debug)]
 #[clap(version = "0.1", author = "Near Inc. <hello@nearprotocol.com>")]
+#[clap(setting = AppSettings::SubcommandRequiredElseHelp)]
 pub(crate) struct Opts {
     /// Sets a custom config dir. Defaults to ~/.near/
     #[clap(short, long)]


### PR DESCRIPTION
Current `neard` binary implement `--help` option, while `tools/inder/example` doesn't.
Let's add `--help` to `tools/indexer/example`.