### PR TITLE
feature: Add logging in indexer to stdout

### DIFF
--- a/tools/indexer/example/src/configs.rs
+++ b/tools/indexer/example/src/configs.rs
@@ -65,7 +65,7 @@ pub(crate) struct InitConfigArgs {
 
 pub(crate) fn init_logging() {
     let env_filter = EnvFilter::new(
-        "tokio_reactor=info,near=info,near=error,stats=info,telemetry=info,indexer_example=info,indexer=info,near-performance-metrics=info",
+        "indexer-example=info,tokio_reactor=info,near=info,near=error,stats=info,telemetry=info,indexer_example=info,indexer=info,near-performance-metrics=info",
     );
     tracing_subscriber::fmt::Subscriber::builder()
         .with_env_filter(env_filter)


### PR DESCRIPTION
Logging to stdout for `info!` doesn't work for indexer.
`indexer-example=info,` is missing from `pub(crate) fn init_logging() {`