### PR TITLE
feat: Make `deepsize` import and `DeepSizeOf` derive optional 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1216,6 +1216,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "deepsize"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cdb987ec36f6bf7bfbea3f928b75590b736fc42af8e54d97592481351b2b96c"
+dependencies = [
+ "chrono",
+ "deepsize_derive",
+]
+
+[[package]]
+name = "deepsize_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990101d41f3bc8c1a45641024377ee284ecc338e5ecf3ea0f0e236d897c72796"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "delay-detector"
 version = "0.0.0"
 dependencies = [
@@ -2387,6 +2408,7 @@ name = "near-account-id"
 version = "0.0.0"
 dependencies = [
  "borsh 0.9.1",
+ "deepsize",
  "serde",
  "serde_json",
 ]
@@ -2559,6 +2581,7 @@ dependencies = [
  "bs58",
  "c2-chacha",
  "curve25519-dalek",
+ "deepsize",
  "derive_more",
  "ed25519-dalek",
  "hex-literal",
@@ -2834,6 +2857,7 @@ dependencies = [
  "byteorder",
  "bytesize",
  "chrono",
+ "deepsize",
  "derive_more",
  "easy-ext",
  "hex",
@@ -2858,6 +2882,7 @@ dependencies = [
  "base64 0.11.0",
  "borsh 0.9.1",
  "bs58",
+ "deepsize",
  "derive_more",
  "near-account-id",
  "num-rational",
@@ -3003,6 +3028,7 @@ name = "near-vm-errors"
 version = "0.0.0"
 dependencies = [
  "borsh 0.9.1",
+ "deepsize",
  "hex",
  "near-account-id",
  "near-rpc-error-macro",

--- a/core/account-id/Cargo.toml
+++ b/core/account-id/Cargo.toml
@@ -15,6 +15,7 @@ internal_unstable = []
 [dependencies]
 borsh = { version = "0.9", optional = true }
 serde = { version = "1", optional = true }
+deepsize = {version = "0.2.0", optional=true }
 
 [dev-dependencies]
 serde_json = "1"

--- a/core/account-id/src/lib.rs
+++ b/core/account-id/src/lib.rs
@@ -7,6 +7,8 @@ mod borsh;
 #[cfg(feature = "serde")]
 mod serde;
 
+#[cfg(feature = "deepsize")]
+use deepsize::DeepSizeOf;
 pub use error::{ParseAccountError, ParseErrorKind};
 
 pub const MIN_ACCOUNT_ID_LEN: usize = 2;
@@ -15,6 +17,7 @@ pub const MAX_ACCOUNT_ID_LEN: usize = 64;
 /// Account identifier. Provides access to user's state.
 ///
 /// This guarantees all properly constructed AccountId's are valid for the NEAR network.
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(Eq, Ord, Hash, Clone, Debug, PartialEq, PartialOrd)]
 pub struct AccountId(Box<str>);
 

--- a/core/crypto/Cargo.toml
+++ b/core/crypto/Cargo.toml
@@ -28,7 +28,9 @@ serde_json = "1"
 subtle = "2.2"
 thiserror = "1"
 near-account-id = { path = "../account-id" }
+deepsize = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
 hex-literal = "0.2"
 sha2 = ">=0.8,<0.10"
+

--- a/core/crypto/src/signature.rs
+++ b/core/crypto/src/signature.rs
@@ -8,7 +8,11 @@ use std::str::FromStr;
 use borsh::{BorshDeserialize, BorshSerialize};
 // We need to import ed25519::signature::Signature, because we use traits from those structs.
 // However, `Signature` symbol is already used to define a different data structure.
+#[cfg(feature = "deepsize")]
+use deepsize::{Context, DeepSizeOf};
 use ed25519_dalek::ed25519::signature::{Signature as _Signature, Signer, Verifier};
+#[cfg(feature = "deepsize")]
+use ed25519_dalek::SIGNATURE_LENGTH;
 use lazy_static::lazy_static;
 use primitive_types::U256;
 use rand_core::OsRng;
@@ -78,6 +82,13 @@ fn split_key_type_data(value: &str) -> Result<(KeyType, &str), crate::errors::Pa
 #[derive(Copy, Clone)]
 pub struct Secp256K1PublicKey([u8; 64]);
 
+#[cfg(feature = "deepsize")]
+impl DeepSizeOf for Secp256K1PublicKey {
+    fn deep_size_of_children(&self, _context: &mut Context) -> usize {
+        0
+    }
+}
+
 impl From<[u8; 64]> for Secp256K1PublicKey {
     fn from(data: [u8; 64]) -> Self {
         Self(data)
@@ -144,6 +155,7 @@ impl Ord for Secp256K1PublicKey {
     }
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(Copy, Clone, derive_more::AsRef)]
 #[as_ref(forward)]
 pub struct ED25519PublicKey(pub [u8; ed25519_dalek::PUBLIC_KEY_LENGTH]);
@@ -192,6 +204,7 @@ impl Ord for ED25519PublicKey {
 }
 
 /// Public key container supporting different curves.
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(Clone, PartialEq, PartialOrd, Ord, Eq)]
 pub enum PublicKey {
     ED25519(ED25519PublicKey),
@@ -564,8 +577,10 @@ const SECP256K1_N: U256 =
 const SECP256K1_N_HALF_ONE: U256 =
     U256([0xdfe92f46681b20a1, 0x5d576e7357a4501d, 0xffffffffffffffff, 0x7fffffffffffffff]);
 
+const SECP256K1_SIGNATURE_LENGTH: usize = 65;
+
 #[derive(Clone, Hash)]
-pub struct Secp256K1Signature([u8; 65]);
+pub struct Secp256K1Signature([u8; SECP256K1_SIGNATURE_LENGTH]);
 
 impl Secp256K1Signature {
     pub fn check_signature_values(&self, reject_upper: bool) -> bool {
@@ -668,6 +683,16 @@ impl From<Secp256K1Signature> for [u8; 65] {
 pub enum Signature {
     ED25519(ed25519_dalek::Signature),
     SECP256K1(Secp256K1Signature),
+}
+
+#[cfg(feature = "deepsize")]
+impl DeepSizeOf for Signature {
+    fn deep_size_of_children(&self, _context: &mut Context) -> usize {
+        match self {
+            Signature::ED25519(_) => SIGNATURE_LENGTH,
+            Signature::SECP256K1(_) => SECP256K1_SIGNATURE_LENGTH,
+        }
+    }
 }
 
 impl Hash for Signature {

--- a/core/crypto/src/vrf.rs
+++ b/core/crypto/src/vrf.rs
@@ -3,6 +3,8 @@ use bs58;
 use curve25519_dalek::constants::{
     RISTRETTO_BASEPOINT_POINT as G, RISTRETTO_BASEPOINT_TABLE as GT,
 };
+#[cfg(feature = "deepsize")]
+use deepsize::{Context, DeepSizeOf};
 use rand_core::OsRng;
 use std::borrow::Borrow;
 use subtle::{ConditionallySelectable, ConstantTimeEq};
@@ -13,6 +15,20 @@ pub struct PublicKey(pub(crate) [u8; 32], pub(crate) Point);
 pub struct SecretKey(pub(crate) Scalar, pub(crate) PublicKey);
 value_type!(pub, Value, 32, "value");
 value_type!(pub, Proof, 64, "proof");
+
+#[cfg(feature = "deepsize")]
+impl DeepSizeOf for Value {
+    fn deep_size_of_children(&self, _context: &mut Context) -> usize {
+        0
+    }
+}
+
+#[cfg(feature = "deepsize")]
+impl DeepSizeOf for Proof {
+    fn deep_size_of_children(&self, _context: &mut Context) -> usize {
+        0
+    }
+}
 
 impl PublicKey {
     fn from_bytes(bytes: &[u8; 32]) -> Option<Self> {

--- a/core/primitives-core/Cargo.toml
+++ b/core/primitives-core/Cargo.toml
@@ -19,6 +19,7 @@ num-rational = { version = "0.3.1", features = ["serde"]}
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.9"
+deepsize = { version = "0.2.0", optional = true }
 
 near-account-id = { path = "../account-id" }
 

--- a/core/primitives-core/src/account.rs
+++ b/core/primitives-core/src/account.rs
@@ -1,4 +1,6 @@
 use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "deepsize")]
+use deepsize::DeepSizeOf;
 use serde::{Deserialize, Serialize};
 use std::io;
 
@@ -148,6 +150,7 @@ impl BorshSerialize for Account {
 /// access keys. Access keys allow to act on behalf of the account by restricting transactions
 /// that can be issued.
 /// `account_id,public_key` is a key in the state
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(
     BorshSerialize, BorshDeserialize, Serialize, Deserialize, PartialEq, Eq, Hash, Clone, Debug,
 )]
@@ -171,6 +174,7 @@ impl AccessKey {
 }
 
 /// Defines permissions for AccessKey
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(
     BorshSerialize, BorshDeserialize, Serialize, Deserialize, PartialEq, Eq, Hash, Clone, Debug,
 )]
@@ -186,6 +190,7 @@ pub enum AccessKeyPermission {
 /// The permission can limit the allowed balance to be spent on the prepaid gas.
 /// It also restrict the account ID of the receiver for this function call.
 /// It also can restrict the method name for the allowed function calls.
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(
     BorshSerialize, BorshDeserialize, Serialize, Deserialize, PartialEq, Eq, Hash, Clone, Debug,
 )]

--- a/core/primitives-core/src/hash.rs
+++ b/core/primitives-core/src/hash.rs
@@ -1,6 +1,8 @@
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
+#[cfg(feature = "deepsize")]
+use deepsize::DeepSizeOf;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sha2::Digest;
 
@@ -8,6 +10,7 @@ use crate::borsh::BorshSerialize;
 use crate::logging::pretty_hash;
 use crate::serialize::{from_base, to_base, BaseDecode};
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, derive_more::AsRef, derive_more::AsMut)]
 #[as_ref(forward)]
 #[as_mut(forward)]

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -27,6 +27,7 @@ reed-solomon-erasure = "4"
 hex = "0.4"
 num-rational = { version = "0.3", features = ["serde"] }
 primitive-types = "0.10"
+deepsize = { version = "0.2.0", features = ["chrono"], optional=true }
 
 borsh = { version = "0.9", features = ["rc"] }
 

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -2,7 +2,10 @@ use std::cmp::max;
 
 use crate::time::{Clock, Utc};
 use borsh::{BorshDeserialize, BorshSerialize};
+
 use chrono::DateTime;
+#[cfg(feature = "deepsize")]
+use deepsize::DeepSizeOf;
 use near_crypto::Signature;
 use num_rational::Rational;
 use primitive_types::U256;
@@ -27,6 +30,7 @@ use crate::validator_signer::{EmptyValidatorSigner, ValidatorSigner};
 use crate::version::{ProtocolVersion, SHARD_CHUNK_HEADER_UPGRADE_VERSION};
 use std::ops::Index;
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, Default)]
 pub struct GenesisId {
     /// Chain Id
@@ -35,6 +39,7 @@ pub struct GenesisId {
     pub hash: CryptoHash,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 pub enum BlockValidityError {
     InvalidStateRoot,
@@ -45,6 +50,7 @@ pub enum BlockValidityError {
     InvalidChallengeRoot,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone, Eq, PartialEq)]
 pub struct BlockV1 {
     pub header: BlockHeader,
@@ -56,6 +62,7 @@ pub struct BlockV1 {
     pub vrf_proof: near_crypto::vrf::Proof,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone, Eq, PartialEq)]
 pub struct BlockV2 {
     pub header: BlockHeader,
@@ -69,6 +76,7 @@ pub struct BlockV2 {
 
 /// Versioned Block data structure.
 /// For each next version, document what are the changes between versions.
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone, Eq, PartialEq)]
 pub enum Block {
     BlockV1(Box<BlockV1>),

--- a/core/primitives/src/block_header.rs
+++ b/core/primitives/src/block_header.rs
@@ -1,6 +1,8 @@
 use crate::time::Utc;
 use borsh::{BorshDeserialize, BorshSerialize};
 use chrono::DateTime;
+#[cfg(feature = "deepsize")]
+use deepsize::DeepSizeOf;
 use serde::Serialize;
 
 use near_crypto::{KeyType, PublicKey, Signature};
@@ -15,6 +17,7 @@ use crate::utils::{from_timestamp, to_timestamp};
 use crate::validator_signer::ValidatorSigner;
 use crate::version::{ProtocolVersion, PROTOCOL_VERSION};
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Debug, Clone, Eq, PartialEq)]
 pub struct BlockHeaderInnerLite {
     /// Height of this block.
@@ -35,6 +38,7 @@ pub struct BlockHeaderInnerLite {
     pub block_merkle_root: CryptoHash,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Debug, Clone, Eq, PartialEq)]
 pub struct BlockHeaderInnerRest {
     /// Root hash of the chunk receipts in the given block.
@@ -73,6 +77,7 @@ pub struct BlockHeaderInnerRest {
 }
 
 /// Remove `chunks_included` from V1
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Debug, Clone, Eq, PartialEq)]
 pub struct BlockHeaderInnerRestV2 {
     /// Root hash of the chunk receipts in the given block.
@@ -113,6 +118,7 @@ pub struct BlockHeaderInnerRestV2 {
 /// Add `epoch_sync_data_hash`
 /// Use new `ValidatorStake` struct
 #[cfg(feature = "protocol_feature_block_header_v3")]
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Debug, Clone, Eq, PartialEq)]
 pub struct BlockHeaderInnerRestV3 {
     /// Root hash of the chunk receipts in the given block.
@@ -156,6 +162,7 @@ pub struct BlockHeaderInnerRestV3 {
 }
 
 /// The part of the block approval that is different for endorsements and skips
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ApprovalInner {
     Endorsement(CryptoHash),
@@ -163,6 +170,7 @@ pub enum ApprovalInner {
 }
 
 /// Block approval by other block producers with a signature
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct Approval {
     pub inner: ApprovalInner,
@@ -179,6 +187,7 @@ pub enum ApprovalType {
 }
 
 /// Block approval by other block producers.
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct ApprovalMessage {
     pub approval: Approval,
@@ -222,6 +231,7 @@ impl ApprovalMessage {
     }
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Debug, Clone, Eq, PartialEq)]
 #[borsh_init(init)]
 pub struct BlockHeaderV1 {
@@ -251,6 +261,7 @@ impl BlockHeaderV1 {
 }
 
 /// V1 -> V2: Remove `chunks_included` from `inner_reset`
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Debug, Clone, Eq, PartialEq)]
 #[borsh_init(init)]
 pub struct BlockHeaderV2 {
@@ -272,6 +283,7 @@ pub struct BlockHeaderV2 {
 /// V2 -> V3: Add `prev_height` to `inner_rest` and use new `ValidatorStake`
 // Add `block_ordinal` to `inner_rest`
 #[cfg(feature = "protocol_feature_block_header_v3")]
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Debug, Clone, Eq, PartialEq)]
 #[borsh_init(init)]
 pub struct BlockHeaderV3 {
@@ -312,6 +324,7 @@ impl BlockHeaderV3 {
 
 /// Versioned BlockHeader data structure.
 /// For each next version, document what are the changes between versions.
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Debug, Clone, Eq, PartialEq)]
 pub enum BlockHeader {
     BlockHeaderV1(Box<BlockHeaderV1>),

--- a/core/primitives/src/challenge.rs
+++ b/core/primitives/src/challenge.rs
@@ -1,4 +1,6 @@
 use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "deepsize")]
+use deepsize::DeepSizeOf;
 use serde::{Deserialize, Serialize};
 
 use near_crypto::Signature;
@@ -12,10 +14,12 @@ use crate::validator_signer::ValidatorSigner;
 /// Serialized TrieNodeWithSize
 pub type StateItem = Vec<u8>;
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Debug, Clone, Eq, PartialEq)]
 pub struct PartialState(pub Vec<StateItem>);
 
 /// Double signed block.
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Clone, Debug)]
 pub struct BlockDoubleSign {
     pub left_block_header: Vec<u8>,
@@ -29,6 +33,7 @@ impl std::fmt::Display for BlockDoubleSign {
 }
 
 /// Invalid chunk (body of the chunk doesn't match proofs or invalid encoding).
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Clone, Debug)]
 pub struct ChunkProofs {
     /// Encoded block header that contains invalid chunk.
@@ -43,6 +48,7 @@ pub struct ChunkProofs {
 /// `Decoded` is used to avoid re-encoding an already decoded chunk to construct a challenge.
 /// `Encoded` is still needed in case a challenge challenges an invalid encoded chunk that can't be
 /// decoded.
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Clone, Debug)]
 pub enum MaybeEncodedShardChunk {
     Encoded(EncodedShardChunk),
@@ -50,6 +56,7 @@ pub enum MaybeEncodedShardChunk {
 }
 
 /// Doesn't match post-{state root, outgoing receipts, gas used, etc} results after applying previous chunk.
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Clone, Debug)]
 pub struct ChunkState {
     /// Encoded prev block header.
@@ -68,6 +75,7 @@ pub struct ChunkState {
     pub partial_state: PartialState,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Clone, Debug)]
 // TODO(#1313): Use Box
 #[allow(clippy::large_enum_variant)]
@@ -77,6 +85,7 @@ pub enum ChallengeBody {
     ChunkState(ChunkState),
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Clone, Debug)]
 #[borsh_init(init)]
 pub struct Challenge {
@@ -101,6 +110,7 @@ impl Challenge {
 
 pub type Challenges = Vec<Challenge>;
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
 pub struct SlashedValidator {
     pub account_id: AccountId,

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -1,4 +1,6 @@
 use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "deepsize")]
+use deepsize::DeepSizeOf;
 use num_rational::Rational;
 use serde::{Deserialize, Serialize};
 
@@ -11,6 +13,8 @@ use crate::types::{
     ValidatorId, ValidatorKickoutReason,
 };
 use crate::version::PROTOCOL_VERSION;
+#[cfg(feature = "deepsize")]
+use deepsize::Context;
 use near_primitives_core::hash::CryptoHash;
 use near_primitives_core::types::BlockHeight;
 use smart_default::SmartDefault;
@@ -122,6 +126,13 @@ pub struct ValidatorSelectionConfig {
     pub minimum_stake_ratio: Rational,
 }
 
+#[cfg(feature = "deepsize")]
+impl DeepSizeOf for ValidatorSelectionConfig {
+    fn deep_size_of_children(&self, _context: &mut Context) -> usize {
+        0
+    }
+}
+
 #[cfg(feature = "protocol_feature_block_header_v3")]
 pub mod block_info {
     use super::SlashState;
@@ -129,6 +140,8 @@ pub mod block_info {
     use crate::types::validator_stake::{ValidatorStake, ValidatorStakeIter};
     use crate::types::EpochId;
     use borsh::{BorshDeserialize, BorshSerialize};
+    #[cfg(feature = "deepsize")]
+    use deepsize::DeepSizeOf;
     use near_primitives_core::hash::CryptoHash;
     use near_primitives_core::types::{AccountId, Balance, BlockHeight, ProtocolVersion};
     use std::collections::HashMap;
@@ -136,6 +149,7 @@ pub mod block_info {
     pub use super::BlockInfoV1;
 
     /// Information per each block.
+    #[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
     #[derive(BorshSerialize, BorshDeserialize, Eq, PartialEq, Clone, Debug)]
     pub enum BlockInfo {
         V1(BlockInfoV1),
@@ -319,6 +333,7 @@ pub mod block_info {
     }
 
     // V1 -> V2: Use versioned ValidatorStake structure in proposals
+    #[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
     #[derive(Default, BorshSerialize, BorshDeserialize, Eq, PartialEq, Clone, Debug)]
     pub struct BlockInfoV2 {
         pub hash: CryptoHash,
@@ -435,6 +450,7 @@ pub mod block_info {
 }
 
 /// Information per each block.
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(Default, BorshSerialize, BorshDeserialize, Eq, PartialEq, Clone, Debug)]
 pub struct BlockInfoV1 {
     pub hash: CryptoHash,
@@ -494,6 +510,7 @@ impl BlockInfoV1 {
     }
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(Default, BorshSerialize, BorshDeserialize, Clone, Debug, PartialEq, Eq)]
 pub struct ValidatorWeight(ValidatorId, u64);
 
@@ -504,6 +521,8 @@ pub mod epoch_info {
     use crate::types::{BlockChunkValidatorStats, ValidatorKickoutReason};
     use crate::version::PROTOCOL_VERSION;
     use borsh::{BorshDeserialize, BorshSerialize};
+    #[cfg(feature = "deepsize")]
+    use deepsize::DeepSizeOf;
     use near_primitives_core::hash::CryptoHash;
     use near_primitives_core::types::{
         AccountId, Balance, EpochHeight, ProtocolVersion, ValidatorId,
@@ -522,6 +541,7 @@ pub mod epoch_info {
     pub use super::EpochInfoV1;
 
     /// Information per epoch.
+    #[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
     #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, PartialEq, Eq)]
     pub enum EpochInfo {
         V1(EpochInfoV1),
@@ -537,6 +557,7 @@ pub mod epoch_info {
     }
 
     // V1 -> V2: Use versioned ValidatorStake structure in validators and fishermen
+    #[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
     #[derive(SmartDefault, BorshSerialize, BorshDeserialize, Clone, Debug, PartialEq, Eq)]
     pub struct EpochInfoV2 {
         /// Ordinal of given epoch from genesis.
@@ -574,6 +595,7 @@ pub mod epoch_info {
     // V2 -> V3: Structures for randomly selecting validators at each height based on new
     // block producer and chunk producer selection algorithm.
     #[cfg(feature = "protocol_feature_new_validator_selection_algorithm")]
+    #[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
     #[derive(SmartDefault, BorshSerialize, BorshDeserialize, Clone, Debug, PartialEq, Eq)]
     pub struct EpochInfoV3 {
         pub epoch_height: EpochHeight,
@@ -1186,6 +1208,7 @@ pub mod epoch_info {
 }
 
 /// Information per epoch.
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(SmartDefault, BorshSerialize, BorshDeserialize, Clone, Debug, PartialEq, Eq)]
 pub struct EpochInfoV1 {
     /// Ordinal of given epoch from genesis.
@@ -1221,6 +1244,7 @@ pub struct EpochInfoV1 {
 }
 
 /// State that a slashed validator can be in.
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub enum SlashState {
     /// Double Sign, will be partially slashed.

--- a/core/primitives/src/errors.rs
+++ b/core/primitives/src/errors.rs
@@ -1,6 +1,8 @@
 use crate::serialize::u128_dec_format;
 use crate::types::{AccountId, Balance, EpochId, Gas, Nonce};
 use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "deepsize")]
+use deepsize::DeepSizeOf;
 use near_crypto::PublicKey;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display};
@@ -10,6 +12,7 @@ use near_rpc_error_macro::RpcError;
 use near_vm_errors::{CompilationError, FunctionCallErrorSer, MethodResolveError, VMLogicError};
 
 /// Error returned in the ExecutionOutcome in case of failure
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(
     BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq, Deserialize, Serialize, RpcError,
 )]
@@ -101,6 +104,7 @@ impl std::fmt::Display for StorageError {
 impl std::error::Error for StorageError {}
 
 /// An error happened during TX execution
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(
     BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq, Deserialize, Serialize, RpcError,
 )]
@@ -147,6 +151,7 @@ pub enum InvalidTxError {
     TransactionSizeExceeded { size: u64, limit: u64 },
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(
     BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq, Deserialize, Serialize, RpcError,
 )]
@@ -173,6 +178,7 @@ pub enum InvalidAccessKeyError {
 }
 
 /// Describes the error for validating a list of actions.
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(
     BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, Clone, PartialEq, Eq, RpcError,
 )]
@@ -204,6 +210,7 @@ pub enum ActionsValidationError {
 }
 
 /// Describes the error for validating a receipt.
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(
     BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, Clone, PartialEq, Eq, RpcError,
 )]
@@ -320,6 +327,7 @@ impl Display for ActionsValidationError {
 }
 
 /// An error happened during Acton execution
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(
     BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq, Deserialize, Serialize, RpcError,
 )]
@@ -331,6 +339,7 @@ pub struct ActionError {
     pub kind: ActionErrorKind,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(Debug, Clone, PartialEq, Eq, RpcError)]
 pub enum ContractCallError {
     MethodResolveError(MethodResolveError),
@@ -369,6 +378,7 @@ impl From<FunctionCallErrorSer> for ContractCallError {
     }
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(
     BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq, Deserialize, Serialize, RpcError,
 )]

--- a/core/primitives/src/merkle.rs
+++ b/core/primitives/src/merkle.rs
@@ -1,9 +1,12 @@
 use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "deepsize")]
+use deepsize::DeepSizeOf;
 use serde::{Deserialize, Serialize};
 
 use crate::hash::{hash, CryptoHash};
 use crate::types::MerkleHash;
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
 pub struct MerklePathItem {
     pub hash: MerkleHash,
@@ -12,6 +15,7 @@ pub struct MerklePathItem {
 
 pub type MerklePath = Vec<MerklePathItem>;
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
 pub enum Direction {
     Left,
@@ -131,6 +135,7 @@ pub fn compute_root_from_path_and_item<T: BorshSerialize>(
 /// The root can be computed by folding `path` from right but is not explicitly
 /// maintained to save space.
 /// The size of the object is O(log(n)) where n is the number of leaves in the tree, i.e, `size`.
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(Default, Clone, BorshSerialize, BorshDeserialize, Eq, PartialEq, Debug)]
 pub struct PartialMerkleTree {
     /// Path for the next leaf.

--- a/core/primitives/src/network.rs
+++ b/core/primitives/src/network.rs
@@ -3,6 +3,8 @@ use std::hash::Hash;
 use std::sync::Arc;
 
 use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "deepsize")]
+use deepsize::DeepSizeOf;
 use serde::{Deserialize, Serialize};
 
 use near_crypto::{KeyType, PublicKey, SecretKey, Signature};
@@ -11,12 +13,14 @@ use crate::hash::CryptoHash;
 use crate::types::{AccountId, EpochId};
 
 /// Peer id is the public key.
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(
     BorshSerialize, BorshDeserialize, Clone, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
 )]
 pub struct PeerId(Arc<PeerIdInner>);
 
 /// Peer id is the public key.
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(
     BorshSerialize, BorshDeserialize, Clone, Eq, PartialOrd, Ord, Serialize, Deserialize, Hash,
 )]
@@ -81,6 +85,7 @@ impl fmt::Debug for PeerId {
 }
 
 /// Account announcement information
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Clone, Debug)]
 pub struct AnnounceAccount {
     /// AccountId to be announced.

--- a/core/primitives/src/rand.rs
+++ b/core/primitives/src/rand.rs
@@ -1,8 +1,11 @@
 use crate::types::Balance;
 use aliases::Aliases;
 use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "deepsize")]
+use deepsize::DeepSizeOf;
 use serde::Serialize;
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(Default, BorshSerialize, BorshDeserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct WeightedIndex {
     weight_sum: Balance,

--- a/core/primitives/src/receipt.rs
+++ b/core/primitives/src/receipt.rs
@@ -2,6 +2,8 @@ use std::borrow::Borrow;
 use std::fmt;
 
 use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "deepsize")]
+use deepsize::DeepSizeOf;
 use serde::{Deserialize, Serialize};
 
 use near_crypto::{KeyType, PublicKey};
@@ -15,6 +17,7 @@ use crate::types::{AccountId, Balance, ShardId};
 
 /// Receipts are used for a cross-shard communication.
 /// Receipts could be 2 types (determined by a `ReceiptEnum`): `ReceiptEnum::Action` of `ReceiptEnum::Data`.
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct Receipt {
     /// An issuer account_id of a particular receipt.
@@ -89,6 +92,7 @@ impl Receipt {
 }
 
 /// Receipt could be either ActionReceipt or DataReceipt
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub enum ReceiptEnum {
     Action(ActionReceipt),
@@ -96,6 +100,7 @@ pub enum ReceiptEnum {
 }
 
 /// ActionReceipt is derived from an Action from `Transaction or from Receipt`
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct ActionReceipt {
     /// A signer of the original transaction
@@ -119,6 +124,7 @@ pub struct ActionReceipt {
 
 /// An incoming (ingress) `DataReceipt` which is going to a Receipt's `receiver` input_data_ids
 /// Which will be converted to `PromiseResult::Successful(value)` or `PromiseResult::Failed`
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Hash, PartialEq, Eq, Clone)]
 pub struct DataReceipt {
     pub data_id: CryptoHash,
@@ -128,6 +134,7 @@ pub struct DataReceipt {
 
 /// The outgoing (egress) data which will be transformed
 /// to a `DataReceipt` to be sent to a `receipt.receiver`
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(
     BorshSerialize, BorshDeserialize, Serialize, Deserialize, Hash, Clone, Debug, PartialEq, Eq,
 )]

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -1,4 +1,6 @@
 use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "deepsize")]
+use deepsize::DeepSizeOf;
 use reed_solomon_erasure::galois_8::{Field, ReedSolomon};
 use serde::{Deserialize, Serialize};
 
@@ -17,6 +19,7 @@ use crate::version::{ProtocolVersion, ProtocolVersionRange, SHARD_CHUNK_HEADER_U
 use reed_solomon_erasure::ReconstructShard;
 use std::sync::Arc;
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(
     BorshSerialize,
     BorshDeserialize,
@@ -71,6 +74,7 @@ pub use shard_chunk_header_inner::{
 };
 
 #[cfg(not(feature = "protocol_feature_block_header_v3"))]
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Clone, PartialEq, Eq, Debug)]
 pub struct ShardChunkHeaderInner {
     /// Previous block hash.
@@ -166,6 +170,7 @@ impl ShardChunkHeaderInner {
     }
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Clone, PartialEq, Eq, Debug)]
 #[borsh_init(init)]
 pub struct ShardChunkHeaderV1 {
@@ -180,6 +185,7 @@ pub struct ShardChunkHeaderV1 {
     pub hash: ChunkHash,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Clone, PartialEq, Eq, Debug)]
 #[borsh_init(init)]
 pub struct ShardChunkHeaderV2 {
@@ -245,6 +251,7 @@ impl ShardChunkHeaderV2 {
 
 // V2 -> V3: Use versioned ShardChunkHeaderInner structure
 #[cfg(feature = "protocol_feature_block_header_v3")]
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Clone, PartialEq, Eq, Debug)]
 #[borsh_init(init)]
 pub struct ShardChunkHeaderV3 {
@@ -309,6 +316,7 @@ impl ShardChunkHeaderV3 {
     }
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Clone, PartialEq, Eq, Debug)]
 pub enum ShardChunkHeader {
     V1(ShardChunkHeaderV1),
@@ -545,6 +553,7 @@ impl ShardChunkHeader {
     }
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Hash, Eq, PartialEq, Clone, Debug, Default)]
 pub struct ChunkHashHeight(pub ChunkHash, pub BlockHeight);
 
@@ -601,6 +610,7 @@ impl ShardChunkHeaderV1 {
     }
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone, Eq, PartialEq)]
 pub enum PartialEncodedChunk {
     V1(PartialEncodedChunkV1),
@@ -698,6 +708,7 @@ impl PartialEncodedChunk {
     }
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone, Eq, PartialEq)]
 pub struct PartialEncodedChunkV2 {
     pub header: ShardChunkHeader,
@@ -718,6 +729,7 @@ impl From<PartialEncodedChunk> for PartialEncodedChunkV2 {
     }
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone, Eq, PartialEq)]
 pub struct PartialEncodedChunkV1 {
     pub header: ShardChunkHeaderV1,
@@ -725,6 +737,7 @@ pub struct PartialEncodedChunkV1 {
     pub receipts: Vec<ReceiptProof>,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct PartialEncodedChunkWithArcReceipts {
     pub header: ShardChunkHeader,
@@ -742,17 +755,20 @@ impl From<PartialEncodedChunkWithArcReceipts> for PartialEncodedChunk {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
+#[derive(BorshSerialize, BorshDeserialize, Debug, Clone, Eq, PartialEq, Deserialize)]
 pub struct ShardProof {
     pub from_shard_id: ShardId,
     pub to_shard_id: ShardId,
     pub proof: MerklePath,
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
+#[derive(BorshSerialize, BorshDeserialize, Debug, Clone, Eq, PartialEq, Deserialize)]
 /// For each Merkle proof there is a subset of receipts which may be proven.
 pub struct ReceiptProof(pub Vec<Receipt>, pub ShardProof);
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone, Eq, PartialEq)]
 pub struct PartialEncodedChunkPart {
     pub part_ord: u64,
@@ -760,6 +776,7 @@ pub struct PartialEncodedChunkPart {
     pub merkle_proof: MerklePath,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone, Eq, PartialEq)]
 pub struct ShardChunkV1 {
     pub chunk_hash: ChunkHash,
@@ -768,6 +785,7 @@ pub struct ShardChunkV1 {
     pub receipts: Vec<Receipt>,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone, Eq, PartialEq)]
 pub struct ShardChunkV2 {
     pub chunk_hash: ChunkHash,
@@ -776,6 +794,7 @@ pub struct ShardChunkV2 {
     pub receipts: Vec<Receipt>,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone, Eq, PartialEq)]
 pub enum ShardChunk {
     V1(ShardChunkV1),
@@ -900,6 +919,7 @@ impl ShardChunk {
     }
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(Default, BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
 pub struct EncodedShardChunkBody {
     pub parts: Vec<Option<Box<[u8]>>>,
@@ -937,6 +957,7 @@ pub struct ReceiptList<'a>(pub ShardId, pub &'a [Receipt]);
 #[derive(BorshSerialize, BorshDeserialize)]
 struct TransactionReceipt(Vec<SignedTransaction>, Vec<Receipt>);
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
 pub struct EncodedShardChunkV1 {
     pub header: ShardChunkHeaderV1,
@@ -963,12 +984,14 @@ impl EncodedShardChunkV1 {
     }
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
 pub struct EncodedShardChunkV2 {
     pub header: ShardChunkHeader,
     pub content: EncodedShardChunkBody,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
 pub enum EncodedShardChunk {
     V1(EncodedShardChunkV1),

--- a/core/primitives/src/sharding/shard_chunk_header_inner.rs
+++ b/core/primitives/src/sharding/shard_chunk_header_inner.rs
@@ -1,9 +1,12 @@
 use crate::types::validator_stake::{ValidatorStake, ValidatorStakeIter, ValidatorStakeV1};
 use crate::types::StateRoot;
 use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "deepsize")]
+use deepsize::DeepSizeOf;
 use near_primitives_core::hash::CryptoHash;
 use near_primitives_core::types::{Balance, BlockHeight, Gas, ShardId};
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Clone, PartialEq, Eq, Debug)]
 pub enum ShardChunkHeaderInner {
     V1(ShardChunkHeaderInnerV1),
@@ -116,6 +119,7 @@ impl ShardChunkHeaderInner {
     }
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Clone, PartialEq, Eq, Debug)]
 pub struct ShardChunkHeaderInnerV1 {
     /// Previous block hash.
@@ -143,6 +147,7 @@ pub struct ShardChunkHeaderInnerV1 {
 }
 
 // V1 -> V2: Use versioned ValidatorStake structure in proposals
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Clone, PartialEq, Eq, Debug)]
 pub struct ShardChunkHeaderInnerV2 {
     /// Previous block hash.

--- a/core/primitives/src/syncing.rs
+++ b/core/primitives/src/syncing.rs
@@ -1,4 +1,6 @@
 use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "deepsize")]
+use deepsize::DeepSizeOf;
 
 use crate::block_header::BlockHeader;
 use crate::epoch_manager::block_info::BlockInfo;
@@ -11,18 +13,23 @@ use crate::sharding::{
 use crate::types::{BlockHeight, ShardId, StateRoot, StateRootNode};
 use crate::views::LightClientBlockView;
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(PartialEq, Eq, Clone, Debug, BorshSerialize, BorshDeserialize)]
 pub struct ReceiptProofResponse(pub CryptoHash, pub Vec<ReceiptProof>);
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(PartialEq, Eq, Clone, Debug, BorshSerialize, BorshDeserialize)]
 pub struct RootProof(pub CryptoHash, pub MerklePath);
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(PartialEq, Eq, Clone, Debug, BorshSerialize, BorshDeserialize)]
 pub struct StateHeaderKey(pub ShardId, pub CryptoHash);
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(PartialEq, Eq, Clone, Debug, BorshSerialize, BorshDeserialize)]
 pub struct StatePartKey(pub CryptoHash, pub ShardId, pub u64 /* PartId */);
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ShardStateSyncResponseHeaderV1 {
     pub chunk: ShardChunkV1,
@@ -34,6 +41,7 @@ pub struct ShardStateSyncResponseHeaderV1 {
     pub state_root_node: StateRootNode,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ShardStateSyncResponseHeaderV2 {
     pub chunk: ShardChunk,
@@ -45,6 +53,7 @@ pub struct ShardStateSyncResponseHeaderV2 {
     pub state_root_node: StateRootNode,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum ShardStateSyncResponseHeader {
     V1(ShardStateSyncResponseHeaderV1),
@@ -133,18 +142,21 @@ impl ShardStateSyncResponseHeader {
     }
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ShardStateSyncResponseV1 {
     pub header: Option<ShardStateSyncResponseHeaderV1>,
     pub part: Option<(u64, Vec<u8>)>,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ShardStateSyncResponseV2 {
     pub header: Option<ShardStateSyncResponseHeaderV2>,
     pub part: Option<(u64, Vec<u8>)>,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum ShardStateSyncResponse {
     V1(ShardStateSyncResponseV1),
@@ -187,6 +199,7 @@ impl ShardStateSyncResponseV1 {
     }
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Eq, PartialEq, Debug, Clone)]
 pub struct EpochSyncFinalizationResponse {
     pub cur_epoch_header: BlockHeader,
@@ -209,6 +222,7 @@ pub struct EpochSyncFinalizationResponse {
     pub next_epoch_info: EpochInfo,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Eq, PartialEq, Debug, Clone)]
 pub enum EpochSyncResponse {
     UpToDate,

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -3,6 +3,8 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 
 use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "deepsize")]
+use deepsize::DeepSizeOf;
 use serde::{Deserialize, Serialize};
 
 use near_crypto::{PublicKey, Signature};
@@ -18,6 +20,7 @@ use near_primitives_core::profile::ProfileData;
 
 pub type LogEntry = String;
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone)]
 pub struct Transaction {
     /// An account on which behalf transaction is signed
@@ -44,6 +47,7 @@ impl Transaction {
     }
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 pub enum Action {
     /// Create an (sub)account using a transaction `receiver_id` as an ID for
@@ -79,6 +83,7 @@ impl Action {
 }
 
 /// Create account action
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
 pub struct CreateAccountAction {}
 
@@ -89,6 +94,7 @@ impl From<CreateAccountAction> for Action {
 }
 
 /// Deploy contract action
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct DeployContractAction {
     /// WebAssembly binary
@@ -110,6 +116,7 @@ impl fmt::Debug for DeployContractAction {
     }
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct FunctionCallAction {
     pub method_name: String,
@@ -137,6 +144,7 @@ impl fmt::Debug for FunctionCallAction {
     }
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
 pub struct TransferAction {
     #[serde(with = "u128_dec_format_compatible")]
@@ -150,6 +158,7 @@ impl From<TransferAction> for Action {
 }
 
 /// An action which stakes singer_id tokens and setup's validator public key
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
 pub struct StakeAction {
     /// Amount of tokens to stake.
@@ -165,6 +174,7 @@ impl From<StakeAction> for Action {
     }
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
 pub struct AddKeyAction {
     /// A public key which will be associated with an access_key
@@ -179,6 +189,7 @@ impl From<AddKeyAction> for Action {
     }
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
 pub struct DeleteKeyAction {
     /// A public key associated with the access_key to be deleted.
@@ -191,6 +202,7 @@ impl From<DeleteKeyAction> for Action {
     }
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
 pub struct DeleteAccountAction {
     pub beneficiary_id: AccountId,
@@ -202,6 +214,7 @@ impl From<DeleteAccountAction> for Action {
     }
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Eq, Debug, Clone)]
 #[borsh_init(init)]
 pub struct SignedTransaction {

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -1,4 +1,6 @@
 use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "deepsize")]
+use deepsize::DeepSizeOf;
 use derive_more::{AsRef as DeriveAsRef, From as DeriveFrom};
 use serde::{Deserialize, Serialize};
 
@@ -19,6 +21,7 @@ pub use near_primitives_core::types::*;
 pub type StateRoot = CryptoHash;
 
 /// Different types of finality.
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(Serialize, Deserialize, BorshSerialize, BorshDeserialize, Clone, Debug, PartialEq, Eq)]
 pub enum Finality {
     #[serde(rename = "optimistic")]
@@ -54,6 +57,7 @@ pub struct AccountInfo {
 ///
 /// NOTE: Currently, this type is only used in the view_client and RPC to be able to transparently
 /// pretty-serialize the bytes arrays as base64-encoded strings (see `serialize.rs`).
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(
     Debug, Clone, PartialEq, Eq, DeriveAsRef, DeriveFrom, BorshSerialize, BorshDeserialize,
 )]
@@ -75,6 +79,7 @@ pub struct StoreValue(Vec<u8>);
 /// NOTE: The main reason for this to exist (except the type-safety) is that the value is
 /// transparently serialized and deserialized as a base64-encoded string when serde is used
 /// (serde_json).
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(
     Debug, Clone, PartialEq, Eq, DeriveAsRef, DeriveFrom, BorshSerialize, BorshDeserialize,
 )]
@@ -400,6 +405,7 @@ impl StateChanges {
     }
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(PartialEq, Eq, Clone, Debug, BorshSerialize, BorshDeserialize, Serialize)]
 pub struct StateRootNode {
     /// in Nightshade, data is the serialized TrieNodeWithSize
@@ -417,6 +423,7 @@ impl StateRootNode {
 /// Epoch identifier -- wrapped hash, to make it easier to distinguish.
 /// EpochId of epoch T is the hash of last block in T-2
 /// EpochId of first two epochs is 0
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(
     Debug,
     Clone,
@@ -437,6 +444,7 @@ pub struct EpochId(pub CryptoHash);
 /// Stores validator and its stake for two consecutive epochs.
 /// It is necessary because the blocks on the epoch boundary need to contain approvals from both
 /// epochs.
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct ApprovalStake {
     /// Account that stakes money.
@@ -452,6 +460,8 @@ pub struct ApprovalStake {
 pub mod validator_stake {
     use crate::types::ApprovalStake;
     use borsh::{BorshDeserialize, BorshSerialize};
+    #[cfg(feature = "deepsize")]
+    use deepsize::DeepSizeOf;
     use near_crypto::PublicKey;
     use near_primitives_core::types::{AccountId, Balance};
     use serde::Serialize;
@@ -459,6 +469,7 @@ pub mod validator_stake {
     pub use super::ValidatorStakeV1;
 
     /// Stores validator and its stake.
+    #[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
     #[derive(BorshSerialize, BorshDeserialize, Serialize, Debug, Clone, PartialEq, Eq)]
     #[serde(tag = "validator_stake_struct_version")]
     pub enum ValidatorStake {
@@ -467,6 +478,7 @@ pub mod validator_stake {
         V2(ValidatorStakeV2),
     }
 
+    #[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
     #[cfg(feature = "protocol_feature_chunk_only_producers")]
     #[derive(BorshSerialize, BorshDeserialize, Serialize, Debug, Clone, PartialEq, Eq)]
     pub struct ValidatorStakeV2 {
@@ -769,6 +781,7 @@ pub mod validator_stake {
 }
 
 /// Stores validator and its stake.
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct ValidatorStakeV1 {
     /// Account that stakes money.
@@ -780,6 +793,7 @@ pub struct ValidatorStakeV1 {
 }
 
 /// Information after block was processed.
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(Debug, PartialEq, BorshSerialize, BorshDeserialize, Clone, Eq)]
 pub struct BlockExtra {
     pub challenges_result: ChallengesResult,
@@ -986,6 +1000,7 @@ pub struct ChunkExtraV1 {
     pub balance_burnt: Balance,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum BlockId {
@@ -995,6 +1010,7 @@ pub enum BlockId {
 
 pub type MaybeBlockId = Option<BlockId>;
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SyncCheckpoint {
@@ -1002,6 +1018,7 @@ pub enum SyncCheckpoint {
     EarliestAvailable,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum BlockReference {
@@ -1068,6 +1085,7 @@ impl Serialize for EpochReference {
 }
 
 /// Reasons for removing a validator from the validator set.
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub enum ValidatorKickoutReason {
     /// Slashed validators are kicked out.

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -1,8 +1,11 @@
+#[cfg(feature = "deepsize")]
+use deepsize::DeepSizeOf;
 use serde::{Deserialize, Serialize};
 
 use crate::types::Balance;
 
 /// Data structure for semver version and github tag or commit.
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]
 pub struct Version {
     pub version: String,

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -8,6 +8,8 @@ use std::sync::Arc;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use chrono::DateTime;
+#[cfg(feature = "deepsize")]
+use deepsize::DeepSizeOf;
 use serde::{Deserialize, Serialize};
 
 use near_crypto::{PublicKey, Signature};
@@ -52,6 +54,7 @@ use crate::version::{ProtocolVersion, Version};
 use validator_stake_view::ValidatorStakeView;
 
 /// A view of the account
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub struct AccountView {
     #[serde(with = "u128_dec_format")]
@@ -66,6 +69,7 @@ pub struct AccountView {
 }
 
 /// A view of the contract code.
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 pub struct ContractCodeView {
     #[serde(rename = "code_base64", with = "base64_format")]
@@ -138,6 +142,7 @@ impl From<ContractCodeView> for ContractCode {
     }
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub enum AccessKeyPermissionView {
     FunctionCall {
@@ -177,6 +182,7 @@ impl From<AccessKeyPermissionView> for AccessKeyPermission {
     }
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub struct AccessKeyView {
     pub nonce: Nonce,
@@ -199,6 +205,7 @@ impl From<AccessKeyView> for AccessKey {
 pub type TrieProofPath = Vec<String>;
 
 /// Item of the state, key and value are serialized in base64 and proof for inclusion of given state item.
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct StateItem {
     pub key: String,
@@ -206,12 +213,14 @@ pub struct StateItem {
     pub proof: TrieProofPath,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct ViewStateResult {
     pub values: Vec<StateItem>,
     pub proof: TrieProofPath,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(
     BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default,
 )]
@@ -220,18 +229,21 @@ pub struct CallResult {
     pub logs: Vec<String>,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct QueryError {
     pub error: String,
     pub logs: Vec<String>,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct AccessKeyInfoView {
     pub public_key: PublicKey,
     pub access_key: AccessKeyView,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct AccessKeyList {
     pub keys: Vec<AccessKeyInfoView>,
@@ -243,6 +255,7 @@ impl FromIterator<AccessKeyInfoView> for AccessKeyList {
     }
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Debug, PartialEq, Eq, Clone)]
 pub enum QueryResponseKind {
     ViewAccount(AccountView),
@@ -253,6 +266,7 @@ pub enum QueryResponseKind {
     AccessKeyList(AccessKeyList),
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(tag = "request_type", rename_all = "snake_case")]
 pub enum QueryRequest {
@@ -282,6 +296,7 @@ pub enum QueryRequest {
     },
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Debug, PartialEq, Eq, Clone)]
 pub struct QueryResponse {
     pub kind: QueryResponseKind,
@@ -289,6 +304,7 @@ pub struct QueryResponse {
     pub block_hash: CryptoHash,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct StatusSyncInfo {
     pub latest_block_hash: CryptoHash,
@@ -302,6 +318,7 @@ pub struct StatusSyncInfo {
 }
 
 // TODO: add more information to ValidatorInfo
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct ValidatorInfo {
     pub account_id: AccountId,
@@ -309,6 +326,7 @@ pub struct ValidatorInfo {
 }
 
 // TODO: add more information to status.
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct StatusResponse {
     /// Binary version.
@@ -566,6 +584,7 @@ impl From<BlockHeaderView> for BlockHeader {
     }
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, BorshDeserialize, BorshSerialize)]
 pub struct BlockHeaderInnerLiteView {
     pub height: BlockHeight,
@@ -793,6 +812,7 @@ impl ChunkView {
     }
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(Serialize, Deserialize, Clone, Debug, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
 pub enum ActionView {
     CreateAccount,
@@ -904,6 +924,7 @@ impl TryFrom<ActionView> for Action {
     }
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(Serialize, Deserialize, Debug, BorshSerialize, BorshDeserialize, PartialEq, Eq, Clone)]
 pub struct SignedTransactionView {
     pub signer_id: AccountId,
@@ -935,6 +956,7 @@ impl From<SignedTransaction> for SignedTransactionView {
     }
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub enum FinalExecutionStatus {
     /// The execution has not yet started.
@@ -967,6 +989,7 @@ impl Default for FinalExecutionStatus {
     }
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub enum ServerError {
     TxExecutionError(TxExecutionError),
@@ -974,6 +997,7 @@ pub enum ServerError {
     Closed,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub enum ExecutionStatusView {
     /// The execution is pending or unknown.
@@ -1016,6 +1040,7 @@ impl From<ExecutionStatus> for ExecutionStatusView {
     }
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, PartialEq, Clone, Eq, Debug)]
 pub struct CostGasUsed {
     pub cost_category: String,
@@ -1024,6 +1049,7 @@ pub struct CostGasUsed {
     pub gas_used: Gas,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, PartialEq, Clone, Eq, Debug)]
 pub struct ExecutionMetadataView {
     version: u32,
@@ -1066,6 +1092,7 @@ impl From<ExecutionMetadata> for ExecutionMetadataView {
     }
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct ExecutionOutcomeView {
     /// Logs from this transaction or receipt.
@@ -1103,6 +1130,7 @@ impl From<ExecutionOutcome> for ExecutionOutcomeView {
     }
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct ExecutionOutcomeWithIdView {
     pub proof: MerklePath,
@@ -1130,6 +1158,7 @@ pub enum FinalExecutionOutcomeViewEnum {
 }
 
 /// Final execution outcome of the transaction and all of subsequent the receipts.
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct FinalExecutionOutcomeView {
     /// Execution status. Contains the result in case of successful execution.
@@ -1158,6 +1187,7 @@ impl fmt::Debug for FinalExecutionOutcomeView {
 
 /// Final execution outcome of the transaction and all of subsequent the receipts. Also includes
 /// the generated receipt.
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
 pub struct FinalExecutionOutcomeWithReceiptView {
     /// Final outcome view without receipts
@@ -1177,6 +1207,8 @@ impl From<FinalExecutionOutcomeWithReceiptView> for FinalExecutionOutcomeView {
 pub mod validator_stake_view {
     use crate::types::validator_stake::ValidatorStake;
     use borsh::{BorshDeserialize, BorshSerialize};
+    #[cfg(feature = "deepsize")]
+    use deepsize::DeepSizeOf;
     use near_primitives_core::types::AccountId;
     use serde::{Deserialize, Serialize};
 
@@ -1189,6 +1221,7 @@ pub mod validator_stake_view {
 
     pub use super::ValidatorStakeViewV1;
 
+    #[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
     #[derive(
         BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, Clone, Eq, PartialEq,
     )]
@@ -1224,6 +1257,7 @@ pub mod validator_stake_view {
     }
 
     #[cfg(feature = "protocol_feature_chunk_only_producers")]
+    #[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
     #[derive(
         BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, Clone, Eq, PartialEq,
     )]
@@ -1300,6 +1334,7 @@ pub mod validator_stake_view {
     }
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 pub struct ValidatorStakeViewV1 {
     pub account_id: AccountId,
@@ -1308,6 +1343,7 @@ pub struct ValidatorStakeViewV1 {
     pub stake: Balance,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct ReceiptView {
     pub predecessor_id: AccountId,
@@ -1317,12 +1353,14 @@ pub struct ReceiptView {
     pub receipt: ReceiptEnumView,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct DataReceiverView {
     pub data_id: CryptoHash,
     pub receiver_id: AccountId,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub enum ReceiptEnumView {
     Action {
@@ -1417,6 +1455,7 @@ impl TryFrom<ReceiptView> for Receipt {
 }
 
 /// Information about this epoch validators and next epoch validators
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct EpochValidatorInfo {
     /// Validators for the current epoch
@@ -1437,12 +1476,14 @@ pub struct EpochValidatorInfo {
     pub epoch_height: EpochHeight,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct ValidatorKickoutView {
     pub account_id: AccountId,
     pub reason: ValidatorKickoutReason,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct CurrentEpochValidatorInfo {
     pub account_id: AccountId,
@@ -1455,6 +1496,7 @@ pub struct CurrentEpochValidatorInfo {
     pub num_expected_blocks: NumBlocks,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct NextEpochValidatorInfo {
     pub account_id: AccountId,
@@ -1464,6 +1506,7 @@ pub struct NextEpochValidatorInfo {
     pub shards: Vec<ShardId>,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, BorshDeserialize, BorshSerialize)]
 pub struct LightClientBlockView {
     pub prev_block_hash: CryptoHash,

--- a/runtime/near-vm-errors/Cargo.toml
+++ b/runtime/near-vm-errors/Cargo.toml
@@ -17,10 +17,11 @@ hex = "0.4"
 serde = { version = "1", features = ["derive"] }
 
 borsh = "0.9"
-
+deepsize = { version = "0.2.0", optional = true }
 near-account-id = { path = "../../core/account-id" }
 near-rpc-error-macro = { path = "../../tools/rpctypegen/macro" }
 
 [features]
 dump_errors_schema = ["near-rpc-error-macro/dump_errors_schema"]
 protocol_feature_alt_bn128 = []
+deepsize_featre = ["deepsize"]

--- a/runtime/near-vm-errors/src/lib.rs
+++ b/runtime/near-vm-errors/src/lib.rs
@@ -3,6 +3,8 @@
 use std::fmt::{self, Error, Formatter};
 
 use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "deepsize")]
+use deepsize::DeepSizeOf;
 use near_account_id::AccountId;
 use near_rpc_error_macro::RpcError;
 use serde::{Deserialize, Serialize};
@@ -46,6 +48,7 @@ pub enum FunctionCallError {
 /// add new variants at the end (but do that very carefully). This type must be never used
 /// directly, and must be converted to `ContractCallError` instead using `into()` converter.
 /// It describes stable serialization format, and only used by serialization logic.
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(Debug, Clone, PartialEq, Eq, BorshDeserialize, BorshSerialize, Serialize, Deserialize)]
 pub enum FunctionCallErrorSer {
     /// Wasm compilation error
@@ -74,6 +77,7 @@ pub enum CacheError {
     SerializationError { hash: [u8; 32] },
 }
 /// A kind of a trap happened during execution of a binary
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(
     Debug, Clone, PartialEq, Eq, BorshDeserialize, BorshSerialize, Deserialize, Serialize, RpcError,
 )]
@@ -98,6 +102,7 @@ pub enum WasmTrap {
     GenericTrap,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(
     Debug, Clone, PartialEq, Eq, BorshDeserialize, BorshSerialize, Deserialize, Serialize, RpcError,
 )]
@@ -107,6 +112,7 @@ pub enum MethodResolveError {
     MethodInvalidSignature,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(
     Debug, Clone, PartialEq, Eq, BorshDeserialize, BorshSerialize, Deserialize, Serialize, RpcError,
 )]
@@ -117,6 +123,7 @@ pub enum CompilationError {
     UnsupportedCompiler { msg: String },
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(
     Debug, Clone, PartialEq, Eq, BorshDeserialize, BorshSerialize, Deserialize, Serialize, RpcError,
 )]
@@ -147,6 +154,7 @@ pub enum PrepareError {
     TooManyFunctions,
 }
 
+#[cfg_attr(feature = "deepsize", derive(DeepSizeOf))]
 #[derive(
     Debug, Clone, PartialEq, Eq, BorshDeserialize, BorshSerialize, Deserialize, Serialize, RpcError,
 )]


### PR DESCRIPTION
We would like to use `deepsize` crate and `DeepSizeof` derive in our code. In discussed that it's better not to add extra dependencies to our code base if possible. That's useful for external projects using `core/primitives`.

Here is a proposal on how to include `deepsize`/`DeepSizeOf` inside our repo as optional dependency.

We could do it this the same way for other dependencies like, for example:
```
use serde::{Deserialize, Serialize};
use borsh::{BorshDeserialize, BorshSerialize};
```



@frol I hope this solves your concerns. @matklad Can you take a look?