### PR TITLE
Remove unused dependencies for near-network

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2762,7 +2762,6 @@ dependencies = [
  "lazy_static",
  "near-actix-test-utils",
  "near-chain",
- "near-chain-configs",
  "near-crypto",
  "near-logger-utils",
  "near-metrics",

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -27,7 +27,6 @@ tokio-util = { version = "0.6", features = ["codec"] }
 tracing = "0.1.13"
 
 delay-detector = { path = "../../tools/delay_detector", optional = true}
-near-chain-configs = { path = "../../core/chain-configs" }
 near-crypto = { path = "../../core/crypto" }
 near-metrics = { path = "../../core/metrics" }
 near-network-primitives = { path = "../network-primitives" }


### PR DESCRIPTION
Remove unused dependency:
- `near-chain-configs = { path = "../../core/chain-configs" }`