### PR TITLE
refactor: Remove slab from near-rate-limiter dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2892,7 +2892,6 @@ dependencies = [
  "futures-core",
  "log",
  "pin-project-lite",
- "slab",
  "tokio",
  "tokio-util",
 ]

--- a/utils/near-rate-limiter/Cargo.toml
+++ b/utils/near-rate-limiter/Cargo.toml
@@ -8,6 +8,5 @@ bytes = "1.0.0"
 futures-core = "0.3.0"
 log = "0.4"
 pin-project-lite = "0.2.0"
-slab = "0.4.1"
 tokio = { version = "1.0.0", features = ["sync"]}
 tokio-util = { version = "0.6.9", features = ["io"]}


### PR DESCRIPTION
Let's remove unused  `slab`  dependency for `near-rate-limiter`