### PR TITLE
bug: Fix for `fuzz` not compiling `core/primitives/src/network.rs`

### DIFF
--- a/core/primitives/src/network.rs
+++ b/core/primitives/src/network.rs
@@ -94,24 +94,17 @@ pub struct AnnounceAccount {
 }
 
 impl AnnounceAccount {
+    /// We hash only (account_id, peer_id, epoch_id). There is no need hash the signature
+    /// as it's uniquely determined the the triple.
     pub fn build_header_hash(
         account_id: &AccountId,
         peer_id: &PeerId,
         epoch_id: &EpochId,
     ) -> CryptoHash {
-        let header = AnnounceAccountRouteHeader { account_id, peer_id, epoch_id };
-
-        CryptoHash::hash_borsh(&header)
+        CryptoHash::hash_borsh(&(account_id, peer_id, epoch_id))
     }
 
     pub fn hash(&self) -> CryptoHash {
         AnnounceAccount::build_header_hash(&self.account_id, &self.peer_id, &self.epoch_id)
     }
-}
-
-#[derive(BorshSerialize)]
-struct AnnounceAccountRouteHeader<'a> {
-    pub account_id: &'a AccountId,
-    pub peer_id: &'a PeerId,
-    pub epoch_id: &'a EpochId,
 }


### PR DESCRIPTION
There is a compile error when trying to compile our code using Fuzz.
Anyway, we can remove `AnnounceAccountRouteHeader` and make our code cleaner. That structure was only created, so that we can use `BorshSerializer` on it to get hash, it's not longer anyder. 

Closes #5386

Tested fix locally with 
```
cd test-utils/runtime-tester/fuzz/
env RUSTC_BOOTSTRAP=1 'cargo' 'fuzz' 'run' 'runtime-fuzzer' '--' '-len_control=0' '-prefer_small=0' '-max_len=4000000' '-rss_limit_mb=10240'
```

TODO:
- [x] Remove `AnnounceAccountRouteHeader` and replace it with a tuple
- [x] Run with the command above locally