### PR TITLE
Document `near-network::peer::code::Codec`  and make it's constr default

### DIFF
--- a/chain/network/src/peer/codec.rs
+++ b/chain/network/src/peer/codec.rs
@@ -1,3 +1,10 @@
+/// The purpose of this crate is to encode/decode messages on the network layer.
+/// Each message contains:
+///     - 4 bytes - length of the message as u32
+///     - the message itself, which is encoded with `borsh`
+///
+/// NOTES:
+///     - Code has an extra logic to ban peers if they sent messages that are too large.
 use crate::stats::metrics;
 use bytes::{Buf, BufMut, BytesMut};
 use bytesize::{GIB, MIB};
@@ -145,7 +152,7 @@ pub(crate) fn is_forward_tx(bytes: &[u8]) -> Option<bool> {
 
 #[cfg(test)]
 mod test {
-    use crate::peer::codec::{is_forward_tx, Codec, NETWORK_MESSAGE_MAX_SIZE};
+    use crate::peer::codec::{is_forward_tx, Codec, NETWORK_MESSAGE_MAX_SIZE_BYTES};
     use crate::routing::edge::EdgeInfo;
     use crate::types::{Handshake, HandshakeFailureReason, HandshakeV2, PeerMessage, SyncData};
     use crate::PeerInfo;

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -773,7 +773,7 @@ impl PeerManagerActor {
                 MAX_MESSAGES_TOTAL_SIZE,
             );
             PeerActor::add_stream(
-                ThrottledFrameRead::new(read, Codec::new(), rate_limiter.clone(), semaphore)
+                ThrottledFrameRead::new(read, Codec::default(), rate_limiter.clone(), semaphore)
                     .take_while(|x| match x {
                         Ok(_) => future::ready(true),
                         Err(e) => {
@@ -790,7 +790,7 @@ impl PeerManagerActor {
                 remote_addr,
                 peer_info,
                 peer_type,
-                FramedWrite::new(write, Codec::new(), Codec::new(), ctx),
+                FramedWrite::new(write, Codec::default(), Codec::default(), ctx),
                 handshake_timeout,
                 recipient,
                 client_addr,


### PR DESCRIPTION
In an ongoing effort to improve code readability, I propose we
- Use `default` rather than `new` for `Coded`
- remove `max_length` from attribute list of `Codec`.  We don't use/plan to modify it through constructor. If we ever do, well, we will refactor the code, but that's unlikely.
- switch constant `MAX_CAPACITY` to proper type. It defines used to define capacity of a buffer, which is returned as `usize` - we avoid extra casting from u64 to usize.
- Add comments to constants.