### PR TITLE
re: First part of splitting 500 lines long method in `near-network::PeerActor`

### DIFF
--- a/chain/network/src/peer/codec.rs
+++ b/chain/network/src/peer/codec.rs
@@ -115,7 +115,7 @@ fn peer_id_type_field_len(enum_var: u8) -> Option<usize> {
 /// and `RoutedMessage.body` has type of `RoutedMessageBody::ForwardTx`.
 ///
 /// This is done to avoid expensive borsch-deserializing.
-pub(crate) fn is_forward_tx(bytes: &[u8]) -> Option<bool> {
+pub(crate) fn is_forward_transaction(bytes: &[u8]) -> Option<bool> {
     // PeerMessage::Routed variant == 13
     let peer_message_variant = *bytes.get(0)?;
     if peer_message_variant != 13 {
@@ -174,7 +174,7 @@ pub(crate) fn is_forward_tx(bytes: &[u8]) -> Option<bool> {
 
 #[cfg(test)]
 mod test {
-    use crate::peer::codec::{is_forward_tx, Codec, NETWORK_MESSAGE_MAX_SIZE_BYTES};
+    use crate::peer::codec::{is_forward_transaction, Codec, NETWORK_MESSAGE_MAX_SIZE_BYTES};
     use crate::routing::edge::EdgeInfo;
     use crate::types::{Handshake, HandshakeFailureReason, HandshakeV2, PeerMessage, SyncData};
     use crate::PeerInfo;
@@ -281,7 +281,7 @@ mod test {
         schemas.for_each(|s| {
             let msg = create_tx_forward(s);
             let bytes = msg.try_to_vec().unwrap();
-            assert!(is_forward_tx(&bytes).unwrap());
+            assert!(is_forward_transaction(&bytes).unwrap());
         })
     }
 

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -28,6 +28,7 @@ use near_performance_metrics;
 use near_performance_metrics::framed_write::{FramedWrite, WriteHandler};
 use near_performance_metrics_macros::perf;
 use near_primitives::block::GenesisId;
+use near_primitives::borsh::maybestd::io::Error;
 use near_primitives::network::PeerId;
 use near_primitives::sharding::PartialEncodedChunk;
 use near_primitives::time::Clock;
@@ -56,7 +57,7 @@ const MAX_PEER_MSG_PER_MIN: u64 = u64::MAX;
 /// Maximum number of transaction messages we will accept between block messages.
 /// The purpose of this constant is to ensure we do not spend too much time deserializing and
 /// dispatching transactions when we should be focusing on consensus-related messages.
-const MAX_TXNS_PER_BLOCK_MESSAGE: usize = 1000;
+const MAX_TRANSACTIONS_PER_BLOCK_MESSAGE: usize = 1000;
 /// Limit cache size of 1000 messages
 pub const ROUTED_MESSAGE_CACHE_SIZE: usize = 1000;
 /// Duplicated messages will be dropped if routed through the same peer multiple times.
@@ -98,6 +99,7 @@ pub struct PeerActor {
     /// Dynamic Prometheus metrics
     network_metrics: NetworkMetrics,
     /// How many transactions we have received since the last block message
+    /// Note: Shared between multiple Peers.
     txns_since_last_block: Arc<AtomicUsize>,
     /// How many peer actors are created
     peer_counter: Arc<AtomicUsize>,
@@ -543,6 +545,52 @@ impl PeerActor {
             }
         }
     }
+
+    /// Update stats when receiving msg
+    fn update_stats_on_receiving_message(&mut self, msg_len: usize) {
+        metrics::PEER_DATA_RECEIVED_BYTES.inc_by(msg_len as u64);
+        metrics::PEER_MESSAGE_RECEIVED_TOTAL.inc();
+        self.tracker.increment_received(msg_len as u64);
+    }
+
+    /// Check whenever we exceeded number of transactions we got since last block.
+    /// If so, drop the transaction.
+    fn should_we_drop_msg_without_decoding(&self, msg: &Vec<u8>) -> bool {
+        if codec::is_forward_transaction(&msg).unwrap_or(false) {
+            let r = self.txns_since_last_block.load(Ordering::Acquire);
+            if r > MAX_TRANSACTIONS_PER_BLOCK_MESSAGE {
+                return true;
+            }
+        }
+        false
+    }
+
+    // Checks errors from decoding a message.
+    // We may send `HandshakeFailure` to the other peer.
+    fn handle_peer_message_decode_error(&mut self, msg: &Vec<u8>, err: Error) {
+        if let Some(version) = err
+            .get_ref()
+            .and_then(|err| err.downcast_ref::<HandshakeFailureReason>())
+            .and_then(|inner| {
+                if let HandshakeFailureReason::ProtocolVersionMismatch { version, .. } = *inner {
+                    Some(version)
+                } else {
+                    None
+                }
+            })
+        {
+            debug!(target: "network", "Received connection from node with unsupported version: {}", version);
+            self.send_message(&PeerMessage::HandshakeFailure(
+                self.node_info.clone(),
+                HandshakeFailureReason::ProtocolVersionMismatch {
+                    version: PROTOCOL_VERSION,
+                    oldest_supported_version: OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION,
+                },
+            ));
+        } else {
+            info!(target: "network", "Received invalid data {:?} from {}: {}", logging::pretty_vec(&msg), self.peer_info, err);
+        }
+    }
 }
 
 impl Actor for PeerActor {
@@ -616,43 +664,16 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for PeerActor {
         // TODO(#5155) We should change our code to track size of messages received from Peer
         // as long as it travels to PeerManager, etc.
 
-        metrics::PEER_DATA_RECEIVED_BYTES.inc_by(msg.len() as u64);
-        metrics::PEER_MESSAGE_RECEIVED_TOTAL.inc();
+        self.update_stats_on_receiving_message(msg.len());
 
-        self.tracker.increment_received(msg.len() as u64);
-        if codec::is_forward_tx(&msg).unwrap_or(false) {
-            let r = self.txns_since_last_block.load(Ordering::Acquire);
-            if r > MAX_TXNS_PER_BLOCK_MESSAGE {
-                return;
-            }
+        if self.should_we_drop_msg_without_decoding(&msg) {
+            return;
         }
         let mut peer_msg = match PeerMessage::try_from_slice(&msg) {
             Ok(peer_msg) => peer_msg,
             Err(err) => {
-                if let Some(version) = err
-                    .get_ref()
-                    .and_then(|err| err.downcast_ref::<HandshakeFailureReason>())
-                    .and_then(|inner| {
-                        if let HandshakeFailureReason::ProtocolVersionMismatch { version, .. } =
-                            *inner
-                        {
-                            Some(version)
-                        } else {
-                            None
-                        }
-                    })
-                {
-                    debug!(target: "network", "Received connection from node with unsupported version: {}", version);
-                    self.send_message(&PeerMessage::HandshakeFailure(
-                        self.node_info.clone(),
-                        HandshakeFailureReason::ProtocolVersionMismatch {
-                            version: PROTOCOL_VERSION,
-                            oldest_supported_version: OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION,
-                        },
-                    ));
-                } else {
-                    info!(target: "network", "Received invalid data {:?} from {}: {}", logging::pretty_vec(&msg), self.peer_info, err);
-                }
+                // This may send `HandshakeFailure` to the other peer.
+                self.handle_peer_message_decode_error(&msg, err);
                 return;
             }
         };

--- a/docs/style.md
+++ b/docs/style.md
@@ -81,13 +81,8 @@ imports and rely on `rustfmt` to sort them.
 
 ```rust
 // GOOD
-<<<<<<< HEAD
 use crate::types::KnownPeerState;
 use borsh::BorshSerialize;
-=======
-use borsh::BorshSerialize;
-use crate::types::KnownPeerState;
->>>>>>> 28291a693... docs: document consistent import style (#5290)
 use near_primitives::utils::to_timestamp;
 use near_store::{ColPeers, Store};
 use rand::seq::SliceRandom;


### PR DESCRIPTION
There is a 500 lines `handle` method in `PeerActor`. We should add comments to it and try to split it.

Reasons:
- Currently too much is going on in this method. It will be much easier to read the code, by splitting parts of it into independent functions. This has to be done in parts. Analyzing what each part does it time consuming.
- As a good rule of thumb: method names alone should be descriptive of what the method does.
`handle` is too generic.
- We have a lot of weird logic here. It needs to be double checked at documented.