### PR TITLE
chore: mark near-rate-limiter unpublishable

### DIFF
--- a/utils/near-rate-limiter/Cargo.toml
+++ b/utils/near-rate-limiter/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2018"
 name = "near-rate-limiter"
 version = "0.0.0"
+publish = false
 
 [dependencies]
 bytes = "1.0.0"


### PR DESCRIPTION
`near-rate-limiter`, introduced in https://github.com/near/nearcore/pull/4927, should be a private crate.