### PR TITLE
fix: near-rate-limter build

### DIFF
--- a/utils/near-rate-limiter/Cargo.toml
+++ b/utils/near-rate-limiter/Cargo.toml
@@ -8,5 +8,5 @@ bytes = "1.0.0"
 futures-core = "0.3.0"
 log = "0.4"
 pin-project-lite = "0.2.0"
-tokio = { version = "1.0.0", features = ["sync"]}
-tokio-util = { version = "0.6.9", features = ["io"]}
+tokio = { version = "1.0.0", features = ["sync"] }
+tokio-util = { version = "0.6.9", features = ["io", "codec"] }


### PR DESCRIPTION
`near-rate-limiter`, while compilable as a dependency of `near-network`, is not compilable in isolation due to missing features.

```console
$ cargo check -p near-rate-limiter
   Compiling near-rate-limiter v0.0.0 (/git/near/nearcore/utils/near-rate-limiter)
error[E0432]: unresolved import `tokio_util::codec`
  --> utils/near-rate-limiter/src/framed_read.rs:13:17
   |
13 | use tokio_util::codec::Decoder;
   |                 ^^^^^ could not find `codec` in `tokio_util`
```