### PR TITLE
Remove unused dependencies from core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,12 +2845,10 @@ dependencies = [
  "primitive-types",
  "rand 0.7.3",
  "reed-solomon-erasure",
- "regex",
  "serde",
  "serde_json",
  "sha2",
  "smart-default",
- "validator",
 ]
 
 [[package]]
@@ -2861,8 +2859,6 @@ dependencies = [
  "borsh 0.9.1",
  "bs58",
  "derive_more",
- "hex",
- "lazy_static",
  "near-account-id",
  "num-rational",
  "serde",

--- a/core/primitives-core/Cargo.toml
+++ b/core/primitives-core/Cargo.toml
@@ -14,13 +14,11 @@ This crate provides the core set of primitives used by other nearcore crates inc
 base64 = "0.11"
 borsh = "0.9"
 bs58 = "0.4"
-hex = "0.4"
 derive_more = "0.99.3"
 num-rational = { version = "0.3.1", features = ["serde"]}
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.9"
-lazy_static = "1.4"
 
 near-account-id = { path = "../account-id" }
 

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -11,7 +11,6 @@ This crate provides the base set of primitives used by other nearcore crates
 """
 
 [dependencies]
-regex = "1"
 bs58 = "0.4"
 base64 = "0.13"
 byteorder = "1.3"
@@ -23,7 +22,6 @@ sha2 = "0.9"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 smart-default = "0.6"
-validator = "0.12"
 rand = "0.7"
 reed-solomon-erasure = "4"
 hex = "0.4"


### PR DESCRIPTION
Remove unused dependencies

`primitives-core`:
- `hex = "0.4"`
- `lazy_static = "1.4"`

`primitives-core`:
- `regex = "1"`
- `validator = "0.12"`