### PR TITLE
refactor: minimize work-around

### DIFF
--- a/core/crypto/src/signature.rs
+++ b/core/crypto/src/signature.rs
@@ -6,11 +6,9 @@ use std::io::{Error, ErrorKind, Write};
 use std::str::FromStr;
 
 use borsh::{BorshDeserialize, BorshSerialize};
-// We need to import ed25519::signature::Signature, because we use traits from those structs.
-// However, `Signature` symbol is already used to define a different data structure.
 #[cfg(feature = "deepsize_feature")]
 use deepsize::DeepSizeOf;
-use ed25519_dalek::ed25519::signature::{Signature as _Signature, Signer, Verifier};
+use ed25519_dalek::ed25519::signature::{Signature as _, Signer, Verifier};
 #[cfg(feature = "deepsize_feature")]
 use ed25519_dalek::SIGNATURE_LENGTH;
 use once_cell::sync::Lazy;


### PR DESCRIPTION
`use Trait as _` is a standard Rust idiom -- it allows calling trait's
methods without bringing the trait itself in scope. This is useful to
avoid naming conflicts, which is exactly what happens in this case
(there's a `Signature` struct defined in this file).

We *could* `as _` the other two crates as well, but we don't as:

a) we don't have an active name conflict for them
b) more than one `_` confuses CLion: https://github.com/intellij-rust/intellij-rust/issues/8143

Notes:

Rust naming convention suggests using verbs as trait names, which helps
with dodging similar conflicts.