### PR TITLE
re: Rename active peer to connected peer terminology in `near-network`

### DIFF
--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -463,8 +463,8 @@ impl From<near_chain_primitives::Error> for GetGasPriceError {
 
 #[derive(Debug)]
 pub struct NetworkInfoResponse {
-    pub active_peers: Vec<PeerInfo>,
-    pub num_active_peers: usize,
+    pub connected_peers: Vec<PeerInfo>,
+    pub num_connected_peers: usize,
     pub peer_max_count: u32,
     pub sent_bytes_per_sec: u64,
     pub received_bytes_per_sec: u64,

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -176,8 +176,8 @@ impl ClientActor {
             network_adapter,
             node_id,
             network_info: NetworkInfo {
-                active_peers: vec![],
-                num_active_peers: 0,
+                connected_peers: vec![],
+                num_connected_peers: 0,
                 peer_max_count: 0,
                 highest_height_peers: vec![],
                 received_bytes_per_sec: 0,
@@ -703,14 +703,14 @@ impl Handler<GetNetworkInfo> for ClientActor {
         self.check_triggers(ctx);
 
         Ok(NetworkInfoResponse {
-            active_peers: self
+            connected_peers: self
                 .network_info
-                .active_peers
+                .connected_peers
                 .clone()
                 .into_iter()
                 .map(|a| a.peer_info)
                 .collect::<Vec<_>>(),
-            num_active_peers: self.network_info.num_active_peers,
+            num_connected_peers: self.network_info.num_connected_peers,
             peer_max_count: self.network_info.peer_max_count,
             sent_bytes_per_sec: self.network_info.sent_bytes_per_sec,
             received_bytes_per_sec: self.network_info.received_bytes_per_sec,
@@ -736,7 +736,7 @@ impl ClientActor {
     /// Account Id is sent when is not current a validator but are becoming a validator soon.
     fn check_send_announce_account(&mut self, prev_block_hash: CryptoHash) {
         // If no peers, there is no one to announce to.
-        if self.network_info.num_active_peers == 0 {
+        if self.network_info.num_connected_peers == 0 {
             debug!(target: "client", "No peers: skip account announce");
             return;
         }
@@ -1185,7 +1185,7 @@ impl ClientActor {
     /// Starts syncing and then switches to either syncing or regular mode.
     fn start_sync(&mut self, ctx: &mut Context<ClientActor>) {
         // Wait for connections reach at least minimum peers unless skipping sync.
-        if self.network_info.num_active_peers < self.client.config.min_num_peers
+        if self.network_info.num_connected_peers < self.client.config.min_num_peers
             && !self.client.config.skip_sync_wait
         {
             near_performance_metrics::actix::run_later(

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -119,7 +119,7 @@ impl InfoHelper {
         let sync_status_log = display_sync_status(&sync_status, &head, genesis_height);
         let network_info_log = format!(
             "{:2}/{:?}/{:2} peers ⬇ {} ⬆ {}",
-            network_info.num_active_peers,
+            network_info.num_connected_peers,
             network_info.highest_height_peers.len(),
             network_info.peer_max_count,
             pretty_bytes_per_sec(network_info.received_bytes_per_sec),
@@ -182,7 +182,7 @@ impl InfoHelper {
                 status: sync_status.as_variant_name().to_string(),
                 latest_block_hash: to_base(&head.last_block_hash),
                 latest_block_height: head.height,
-                num_peers: network_info.num_active_peers,
+                num_peers: network_info.num_connected_peers,
             },
         };
         // Sign telemetry if there is a signer present.

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -582,8 +582,8 @@ pub fn setup_mock_all_validators(
                             .collect();
                         let peers2 = peers.clone();
                         let info = NetworkInfo {
-                            active_peers: peers,
-                            num_active_peers: key_pairs1.len(),
+                            connected_peers: peers,
+                            num_connected_peers: key_pairs1.len(),
                             peer_max_count: key_pairs1.len() as u32,
                             highest_height_peers: peers2,
                             sent_bytes_per_sec: 0,

--- a/chain/jsonrpc-primitives/src/types/network_info.rs
+++ b/chain/jsonrpc-primitives/src/types/network_info.rs
@@ -22,8 +22,8 @@ pub enum RpcNetworkInfoError {
 impl From<near_client_primitives::types::NetworkInfoResponse> for RpcNetworkInfoResponse {
     fn from(network_info_response: near_client_primitives::types::NetworkInfoResponse) -> Self {
         Self {
-            active_peers: network_info_response.active_peers,
-            num_active_peers: network_info_response.num_active_peers,
+            active_peers: network_info_response.connected_peers,
+            num_active_peers: network_info_response.num_connected_peers,
             peer_max_count: network_info_response.peer_max_count,
             sent_bytes_per_sec: network_info_response.sent_bytes_per_sec,
             received_bytes_per_sec: network_info_response.received_bytes_per_sec,

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -69,7 +69,7 @@ const REQUEST_PEERS_INTERVAL: Duration = Duration::from_millis(60_000);
 /// This number should be large to handle pair of nodes with high latency.
 const WAIT_ON_TRY_UPDATE_NONCE: Duration = Duration::from_millis(6_000);
 /// If we see an edge between us and other peer, but this peer is not a current connection, wait this
-/// timeout and in case it didn't become an active peer, broadcast edge removal update.
+/// timeout and in case it didn't become a connected peer, broadcast edge removal update.
 const WAIT_PEER_BEFORE_REMOVE: Duration = Duration::from_millis(6_000);
 /// Maximum number an edge can increase between oldest known edge and new proposed edge.
 const EDGE_NONCE_BUMP_ALLOWED: u64 = 1_000;
@@ -116,8 +116,8 @@ macro_rules! unwrap_or_error(($obj: expr, $error: expr) => (match $obj {
     }
 }));
 
-/// Contains information relevant to an active peer.
-struct ActivePeer {
+/// Contains information relevant to a connected peer.
+struct ConnectedPeer {
     addr: Addr<PeerActor>,
     full_peer_info: FullPeerInfo,
     /// Number of bytes we've received from the peer.
@@ -150,8 +150,8 @@ pub struct PeerManagerActor {
     peer_store: PeerStore,
     /// Set of outbound connections that were not consolidated yet.
     outgoing_peers: HashSet<PeerId>,
-    /// Active peers (inbound and outbound) with their full peer information.
-    active_peers: HashMap<PeerId, ActivePeer>,
+    /// Connected peers (inbound and outbound) with their full peer information.
+    connected_peers: HashMap<PeerId, ConnectedPeer>,
     /// View of the Routing table. It keeps:
     /// - routing information - how to route messages
     /// - edges adjacent to my_peer_id
@@ -164,7 +164,7 @@ pub struct PeerManagerActor {
     started_connect_attempts: bool,
     /// Monitor peers attempts, used for fast checking in the beginning with exponential backoff.
     monitor_peers_attempts: u64,
-    /// Active peers we have sent new edge update, but we haven't received response so far.
+    /// Connected peers we have sent new edge update, but we haven't received response so far.
     local_peer_pending_update_nonce_request: HashMap<PeerId, u64>,
     /// Dynamic Prometheus metrics
     network_metrics: NetworkMetrics,
@@ -175,7 +175,7 @@ pub struct PeerManagerActor {
     txns_since_last_block: Arc<AtomicUsize>,
     /// Number of incoming connections, that were not established yet; used for rate limiting.
     pending_incoming_connections_counter: Arc<AtomicUsize>,
-    /// Number of active peers, used for rate limiting.
+    /// Number of connected peers, used for rate limiting.
     peer_counter: Arc<AtomicUsize>,
     /// Used for testing, for disabling features.
     adv_helper: AdvHelper,
@@ -240,7 +240,7 @@ impl PeerManagerActor {
             client_addr,
             view_client_addr,
             peer_store,
-            active_peers: HashMap::default(),
+            connected_peers: HashMap::default(),
             outgoing_peers: HashSet::default(),
             routing_table_view: routing_table,
             routing_table_exchange_helper: Default::default(),
@@ -366,7 +366,7 @@ impl PeerManagerActor {
     fn report_bandwidth_stats_trigger(&mut self, ctx: &mut Context<Self>, every: Duration) {
         let mut total_bandwidth_used_by_all_peers: usize = 0;
         let mut total_msg_received_count: usize = 0;
-        for (peer_id, active_peer) in self.active_peers.iter_mut() {
+        for (peer_id, active_peer) in self.connected_peers.iter_mut() {
             let bandwidth_used = active_peer.throttle_controller.consume_bandwidth_used();
             let msg_received_count = active_peer.throttle_controller.consume_msg_seen();
 
@@ -422,7 +422,7 @@ impl PeerManagerActor {
                         continue;
                     }
                     // We belong to this edge.
-                    if self.active_peers.contains_key(other_peer) {
+                    if self.connected_peers.contains_key(other_peer) {
                         // This is an active connection.
                         match edge.edge_type() {
                             EdgeState::Removed => {
@@ -452,8 +452,8 @@ impl PeerManagerActor {
         });
     }
 
-    fn num_active_peers(&self) -> usize {
-        self.active_peers.len()
+    fn num_connected_peers(&self) -> usize {
+        self.connected_peers.len()
     }
 
     fn is_blacklisted(&self, addr: &SocketAddr) -> bool {
@@ -524,7 +524,7 @@ impl PeerManagerActor {
     }
 
     /// Register a direct connection to a new peer. This will be called after successfully
-    /// establishing a connection with another peer. It become part of the active peers.
+    /// establishing a connection with another peer. It become part of the connected peers.
     ///
     /// To build new edge between this pair of nodes both signatures are required.
     /// Signature from this node is passed in `edge_info`
@@ -561,9 +561,9 @@ impl PeerManagerActor {
             full_peer_info.partial_edge_info.signature.clone(),
         );
 
-        self.active_peers.insert(
+        self.connected_peers.insert(
             target_peer_id.clone(),
-            ActivePeer {
+            ConnectedPeer {
                 addr: addr.clone(),
                 full_peer_info,
                 sent_bytes_per_sec: 0,
@@ -642,7 +642,7 @@ impl PeerManagerActor {
 
             // Ask for peers list on connection.
             let _ = addr.do_send(SendMessage { message: PeerMessage::PeersRequest });
-            if let Some(active_peer) = act.active_peers.get_mut(&target_peer_id) {
+            if let Some(active_peer) = act.connected_peers.get_mut(&target_peer_id) {
                 active_peer.last_time_peer_requested = Clock::instant();
             }
 
@@ -671,7 +671,7 @@ impl PeerManagerActor {
         peer_type: Option<PeerType>,
     ) {
         if let Some(peer_type) = peer_type {
-            if let Some(peer) = self.active_peers.get(peer_id) {
+            if let Some(peer) = self.connected_peers.get(peer_id) {
                 if peer.peer_type != peer_type {
                     // Don't remove the peer
                     return;
@@ -681,7 +681,7 @@ impl PeerManagerActor {
 
         // If the last edge we have with this peer represent a connection addition, create the edge
         // update that represents the connection removal.
-        self.active_peers.remove(peer_id);
+        self.connected_peers.remove(peer_id);
 
         #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
         self.routing_table_addr
@@ -707,7 +707,7 @@ impl PeerManagerActor {
         }
     }
 
-    /// Remove a peer from the active peer set. If the peer doesn't belong to the active peer set
+    /// Remove a peer from the connected peer set. If the peer doesn't belong to the connected peer set
     /// data from ongoing connection established is removed.
     fn unregister_peer(
         &mut self,
@@ -749,7 +749,7 @@ impl PeerManagerActor {
         peer_id: &PeerId,
         ban_reason: ReasonForBan,
     ) {
-        if let Some(peer) = self.active_peers.get(peer_id) {
+        if let Some(peer) = self.connected_peers.get(peer_id) {
             let _ = peer.addr.do_send(PeerManagerRequest::BanPeer(ban_reason));
         } else {
             warn!(target: "network", "Try to ban a disconnected peer for {:?}: {:?}", ban_reason, peer_id);
@@ -845,15 +845,15 @@ impl PeerManagerActor {
         });
     }
 
-    fn num_active_outgoing_peers(&self) -> usize {
-        self.active_peers
+    fn num_connected_outgoing_peers(&self) -> usize {
+        self.connected_peers
             .values()
             .filter(|active_peer| active_peer.peer_type == PeerType::Outbound)
             .count()
     }
 
     fn num_archival_peers(&self) -> usize {
-        self.active_peers
+        self.connected_peers
             .values()
             .filter(|active_peer| active_peer.full_peer_info.chain_info.archival)
             .count()
@@ -864,9 +864,9 @@ impl PeerManagerActor {
     /// (the number of outgoing connections is less than `minimum_outbound_peers`
     ///     and the total connections is less than `max_num_peers`)
     fn is_outbound_bootstrap_needed(&self) -> bool {
-        let total_connections = self.active_peers.len() + self.outgoing_peers.len();
+        let total_connections = self.connected_peers.len() + self.outgoing_peers.len();
         let potential_outgoing_connections =
-            self.num_active_outgoing_peers() + self.outgoing_peers.len();
+            self.num_connected_outgoing_peers() + self.outgoing_peers.len();
 
         (total_connections < self.config.ideal_connections_lo as usize
             || (total_connections < self.config.max_num_peers as usize
@@ -875,14 +875,14 @@ impl PeerManagerActor {
     }
 
     fn is_inbound_allowed(&self) -> bool {
-        self.active_peers.len() + self.outgoing_peers.len() < self.config.max_num_peers as usize
+        self.connected_peers.len() + self.outgoing_peers.len() < self.config.max_num_peers as usize
     }
 
     /// Returns single random peer with close to the highest height
     fn highest_height_peers(&self) -> Vec<FullPeerInfo> {
         // This finds max height among peers, and returns one peer close to such height.
         let max_height = match self
-            .active_peers
+            .connected_peers
             .values()
             .map(|active_peers| active_peers.full_peer_info.chain_info.height)
             .max()
@@ -891,7 +891,7 @@ impl PeerManagerActor {
             None => return vec![],
         };
         // Find all peers whose height is within `highest_peer_horizon` from max height peer(s).
-        self.active_peers
+        self.connected_peers
             .values()
             .filter(|active_peer| {
                 active_peer
@@ -907,8 +907,8 @@ impl PeerManagerActor {
 
     /// Returns bytes sent/received across all peers.
     fn get_total_bytes_per_sec(&self) -> (u64, u64) {
-        let sent_bps = self.active_peers.values().map(|x| x.sent_bytes_per_sec).sum();
-        let received_bps = self.active_peers.values().map(|x| x.received_bytes_per_sec).sum();
+        let sent_bps = self.connected_peers.values().map(|x| x.sent_bytes_per_sec).sum();
+        let received_bps = self.connected_peers.values().map(|x| x.received_bytes_per_sec).sum();
         (sent_bps, received_bps)
     }
 
@@ -922,7 +922,7 @@ impl PeerManagerActor {
     fn query_active_peers_for_more_peers(&mut self, ctx: &mut Context<Self>) {
         let mut requests = futures::stream::FuturesUnordered::new();
         let msg = SendMessage { message: PeerMessage::PeersRequest };
-        for (_, active_peer) in self.active_peers.iter_mut() {
+        for (_, active_peer) in self.connected_peers.iter_mut() {
             if active_peer.last_time_peer_requested.elapsed() > REQUEST_PEERS_INTERVAL {
                 active_peer.last_time_peer_requested = Clock::instant();
                 requests.push(active_peer.addr.send(msg.clone()));
@@ -965,7 +965,7 @@ impl PeerManagerActor {
     }
 
     fn wait_peer_or_remove(&mut self, ctx: &mut Context<Self>, edge: Edge) {
-        // This edge says this is an active peer, which is currently not in the set of active peers.
+        // This edge says this is an connected peer, which is currently not in the set of connected peers.
         // Wait for some time to let the connection begin or broadcast edge removal instead.
 
         near_performance_metrics::actix::run_later(
@@ -973,7 +973,7 @@ impl PeerManagerActor {
             WAIT_PEER_BEFORE_REMOVE,
             move |act, ctx| {
                 let other = edge.other(&act.my_peer_id).unwrap();
-                if !act.active_peers.contains_key(other) {
+                if !act.connected_peers.contains_key(other) {
                     // Peer is still not active after waiting a timeout.
                     let new_edge = edge.remove_edge(act.my_peer_id.clone(), &act.config.secret_key);
                     act.broadcast_message(
@@ -1023,7 +1023,7 @@ impl PeerManagerActor {
             move |act, _ctx| {
                 if let Some(cur_nonce) = act.local_peer_pending_update_nonce_request.get(&other) {
                     if *cur_nonce == nonce {
-                        if let Some(peer) = act.active_peers.get(&other) {
+                        if let Some(peer) = act.connected_peers.get(&other) {
                             // Send disconnect signal to this peer if we haven't edge update.
                             peer.addr.do_send(PeerManagerRequest::UnregisterPeer);
                         }
@@ -1036,7 +1036,7 @@ impl PeerManagerActor {
 
     /// Periodically query peer actors for latest weight and traffic info.
     fn monitor_peer_stats_trigger(&mut self, ctx: &mut Context<Self>, interval: Duration) {
-        for (peer_id, active_peer) in self.active_peers.iter() {
+        for (peer_id, active_peer) in self.connected_peers.iter() {
             let peer_id1 = peer_id.clone();
             active_peer
                 .addr
@@ -1050,10 +1050,10 @@ impl PeerManagerActor {
                             // TODO(MarX, #1586): Ban peer if we found them abusive. Fix issue with heavy
                             //  network traffic that flags honest peers.
                             // Send ban signal to peer instance. It should send ban signal back and stop the instance.
-                            // if let Some(active_peer) = act.active_peers.get(&peer_id1) {
+                            // if let Some(active_peer) = act.connected_peers.get(&peer_id1) {
                             //     active_peer.addr.do_send(PeerManagerRequest::BanPeer(ReasonForBan::Abusive));
                             // }
-                        } else if let Some(active_peer) = act.active_peers.get_mut(&peer_id1) {
+                        } else if let Some(active_peer) = act.connected_peers.get_mut(&peer_id1) {
                             active_peer.full_peer_info.chain_info = res.chain_info;
                             active_peer.sent_bytes_per_sec = res.sent_bytes_per_sec;
                             active_peer.received_bytes_per_sec = res.received_bytes_per_sec;
@@ -1079,17 +1079,17 @@ impl PeerManagerActor {
     ///         else break
     fn try_stop_active_connection(&self) {
         debug!(target: "network", message = "Trying to stop an active connection.",
-            active_peers_len = self.active_peers.len(),
+            connected_peers_len = self.connected_peers.len(),
             ideal_connections_hi = self.config.ideal_connections_hi,
         );
 
         // Build safe set
         let mut safe_set = HashSet::new();
 
-        if self.num_active_outgoing_peers() + self.outgoing_peers.len()
+        if self.num_connected_outgoing_peers() + self.outgoing_peers.len()
             <= self.config.minimum_outbound_peers as usize
         {
-            for (peer, active) in self.active_peers.iter() {
+            for (peer, active) in self.connected_peers.iter() {
                 if active.peer_type == PeerType::Outbound {
                     safe_set.insert(peer.clone());
                 }
@@ -1100,7 +1100,7 @@ impl PeerManagerActor {
             && self.num_archival_peers()
                 <= self.config.archival_peer_connections_lower_bound as usize
         {
-            for (peer, active) in self.active_peers.iter() {
+            for (peer, active) in self.connected_peers.iter() {
                 if active.full_peer_info.chain_info.archival {
                     safe_set.insert(peer.clone());
                 }
@@ -1109,7 +1109,7 @@ impl PeerManagerActor {
 
         // Find all recent connections
         let mut recent_connections = self
-            .active_peers
+            .connected_peers
             .iter()
             .filter_map(|(peer_id, active)| {
                 if active.last_time_received_message.elapsed() < self.config.peer_recent_time_window
@@ -1136,7 +1136,7 @@ impl PeerManagerActor {
 
         // Build valid candidate list to choose the peer to be removed. All peers outside the safe set.
         let candidates = self
-            .active_peers
+            .connected_peers
             .keys()
             .filter_map(
                 |peer_id| {
@@ -1150,7 +1150,7 @@ impl PeerManagerActor {
             .collect::<Vec<_>>();
 
         if let Some(peer_id) = candidates.choose(&mut rand::thread_rng()) {
-            if let Some(active_peer) = self.active_peers.get(peer_id) {
+            if let Some(active_peer) = self.connected_peers.get(peer_id) {
                 debug!(target: "network", "Stop active connection: {:?}", peer_id);
                 active_peer.addr.do_send(PeerManagerRequest::UnregisterPeer);
             }
@@ -1205,7 +1205,7 @@ impl PeerManagerActor {
         }
 
         // If there are too many active connections try to remove some connections
-        if self.active_peers.len() > self.config.ideal_connections_hi as usize {
+        if self.connected_peers.len() > self.config.ideal_connections_hi as usize {
             self.try_stop_active_connection();
         }
 
@@ -1271,7 +1271,7 @@ impl PeerManagerActor {
         // without cloning.
         let msg = Arc::new(msg);
         let mut requests: futures::stream::FuturesUnordered<_> =
-            self.active_peers.values().map(|peer| peer.addr.send(Arc::clone(&msg))).collect();
+            self.connected_peers.values().map(|peer| peer.addr.send(Arc::clone(&msg))).collect();
 
         ctx.spawn(async move {
             while let Some(response) = requests.next().await {
@@ -1305,7 +1305,7 @@ impl PeerManagerActor {
         peer_id: PeerId,
         message: PeerMessage,
     ) -> bool {
-        if let Some(active_peer) = self.active_peers.get(&peer_id) {
+        if let Some(active_peer) = self.connected_peers.get(&peer_id) {
             let msg_kind = message.msg_variant().to_string();
             trace!(target: "network", "Send message: {}", msg_kind);
             active_peer
@@ -1315,7 +1315,7 @@ impl PeerManagerActor {
                 .map(move |res, act, _|
                     res.map_err(|e| {
                         // Peer could have disconnect between check and sending the message.
-                        if act.active_peers.contains_key(&peer_id) {
+                        if act.connected_peers.contains_key(&peer_id) {
                             error!(target: "network", "Failed sending message(send_message, {}): {}", msg_kind, e)
                         }
                     })
@@ -1325,9 +1325,9 @@ impl PeerManagerActor {
             true
         } else {
             debug!(target: "network",
-                   "Sending message to: {} (which is not an active peer) Num active Peers: {}\n{}",
+                   "Sending message to: {} (which is not an connected peer) Num connected Peers: {}\n{}",
                    peer_id,
-                   self.active_peers.len(),
+                   self.connected_peers.len(),
                    message
             );
             false
@@ -1485,12 +1485,12 @@ impl PeerManagerActor {
     pub(crate) fn get_network_info(&mut self) -> NetworkInfo {
         let (sent_bytes_per_sec, received_bytes_per_sec) = self.get_total_bytes_per_sec();
         NetworkInfo {
-            active_peers: self
-                .active_peers
+            connected_peers: self
+                .connected_peers
                 .values()
                 .map(|a| a.full_peer_info.clone())
                 .collect::<Vec<_>>(),
-            num_active_peers: self.num_active_peers(),
+            num_connected_peers: self.num_connected_peers(),
             peer_max_count: self.config.max_num_peers,
             highest_height_peers: self.highest_height_peers(),
             sent_bytes_per_sec,
@@ -1599,11 +1599,11 @@ impl Actor for PeerManagerActor {
         self.report_bandwidth_stats_trigger(ctx, REPORT_BANDWIDTH_STATS_TRIGGER_INTERVAL);
     }
 
-    /// Try to gracefully disconnect from active peers.
+    /// Try to gracefully disconnect from connected peers.
     fn stopping(&mut self, ctx: &mut Self::Context) -> Running {
         let msg = SendMessage { message: PeerMessage::Disconnect };
 
-        for (_, active_peer) in self.active_peers.iter() {
+        for (_, active_peer) in self.connected_peers.iter() {
             active_peer.addr.do_send(msg.clone());
         }
 
@@ -1738,7 +1738,7 @@ impl PeerManagerActor {
                         }
                     } else {
                         let mut matching_peers = vec![];
-                        for (peer_id, active_peer) in self.active_peers.iter() {
+                        for (peer_id, active_peer) in self.connected_peers.iter() {
                             if (active_peer.full_peer_info.chain_info.archival
                                 || !target.only_archival)
                                 && active_peer.full_peer_info.chain_info.height >= target.min_height
@@ -1907,7 +1907,7 @@ impl PeerManagerActor {
             #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
             NetworkRequests::IbfMessage { peer_id, ibf_msg } => match ibf_msg {
                 RoutingSyncV2::Version2(ibf_msg) => {
-                    if let Some(addr) = self.active_peers.get(&peer_id).map(|p| p.addr.clone()) {
+                    if let Some(addr) = self.connected_peers.get(&peer_id).map(|p| p.addr.clone()) {
                         self.process_ibf_msg(ctx, &peer_id, ibf_msg, addr, throttle_controller)
                     }
                     NetworkResponses::NoResponse
@@ -1993,7 +1993,7 @@ impl PeerManagerActor {
         ctx: &mut Context<Self>,
         throttle_controller: Option<ThrottleController>,
     ) {
-        if let Some(active_peer) = self.active_peers.get(&msg.peer_id) {
+        if let Some(active_peer) = self.connected_peers.get(&msg.peer_id) {
             let addr = active_peer.addr.clone();
             self.initialize_routing_table_exchange(
                 msg.peer_id,
@@ -2148,7 +2148,7 @@ impl PeerManagerActor {
         }
 
         // We already connected to this peer.
-        if self.active_peers.contains_key(&msg.peer_info.id) {
+        if self.connected_peers.contains_key(&msg.peer_info.id) {
             debug!(target: "network", "Dropping handshake (Active Peer). {:?} {:?}", self.my_peer_id, msg.peer_info.id);
             return RegisterPeerResponse::Reject;
         }
@@ -2166,7 +2166,7 @@ impl PeerManagerActor {
         if msg.peer_type == PeerType::Inbound && !self.is_inbound_allowed() {
             // TODO(1896): Gracefully drop inbound connection for other peer.
             debug!(target: "network", message = "Inbound connection dropped (network at max capacity).",
-                active_peers = self.active_peers.len(), outgoing_peers = self.outgoing_peers.len(),
+                active_peers = self.connected_peers.len(), outgoing_peers = self.outgoing_peers.len(),
                 max_num_peers = self.config.max_num_peers
             );
             return RegisterPeerResponse::Reject;
@@ -2424,7 +2424,7 @@ impl PeerManagerActor {
                 PeerResponse::NoResponse
             }
             PeerRequest::ReceivedMessage(peer_id, last_time_received_message) => {
-                if let Some(active_peer) = self.active_peers.get_mut(&peer_id) {
+                if let Some(active_peer) = self.connected_peers.get_mut(&peer_id) {
                     active_peer.last_time_received_message = last_time_received_message;
                 }
                 PeerResponse::NoResponse

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -495,8 +495,8 @@ pub struct FullPeerInfo {
 
 #[derive(Debug)]
 pub struct NetworkInfo {
-    pub active_peers: Vec<FullPeerInfo>,
-    pub num_active_peers: usize,
+    pub connected_peers: Vec<FullPeerInfo>,
+    pub num_connected_peers: usize,
     pub peer_max_count: u32,
     pub highest_height_peers: Vec<FullPeerInfo>,
     pub sent_bytes_per_sec: u64,

--- a/chain/rosetta-rpc/src/lib.rs
+++ b/chain/rosetta-rpc/src/lib.rs
@@ -141,7 +141,7 @@ async fn network_status(
             None
         },
         peers: network_info
-            .active_peers
+            .connected_peers
             .into_iter()
             .map(|peer| models::Peer { peer_id: peer.id.to_string() })
             .collect(),

--- a/integration-tests/tests/client/process_blocks.rs
+++ b/integration-tests/tests/client/process_blocks.rs
@@ -950,7 +950,7 @@ fn client_sync_headers() {
             }),
         );
         client.do_send(NetworkClientMessages::NetworkInfo(NetworkInfo {
-            active_peers: vec![FullPeerInfo {
+            connected_peers: vec![FullPeerInfo {
                 peer_info: peer_info2.clone(),
                 chain_info: PeerChainInfoV2 {
                     genesis_id: Default::default(),
@@ -960,7 +960,7 @@ fn client_sync_headers() {
                 },
                 partial_edge_info: PartialEdgeInfo::default(),
             }],
-            num_active_peers: 1,
+            num_connected_peers: 1,
             peer_max_count: 1,
             highest_height_peers: vec![FullPeerInfo {
                 peer_info: peer_info2.clone(),

--- a/integration-tests/tests/network/infinite_loop.rs
+++ b/integration-tests/tests/network/infinite_loop.rs
@@ -127,7 +127,7 @@ fn test_infinite_loop() {
                 if state_value == 0 {
                     actix::spawn(pm2.clone().send(GetInfo {}).then(move |res| {
                         if let Ok(info) = res {
-                            if !info.active_peers.is_empty() {
+                            if !info.connected_peers.is_empty() {
                                 state1.store(1, Ordering::SeqCst);
                             }
                         }

--- a/integration-tests/tests/network/peer_handshake.rs
+++ b/integration-tests/tests/network/peer_handshake.rs
@@ -86,7 +86,7 @@ fn peer_handshake() {
             Box::new(move |_| {
                 actix::spawn(pm1.send(GetInfo {}).then(move |res| {
                     let info = res.unwrap();
-                    if info.num_active_peers == 1 {
+                    if info.num_connected_peers == 1 {
                         System::current().stop();
                     }
                     future::ready(())
@@ -121,7 +121,7 @@ fn peers_connect_all() {
                     let flags1 = flags.clone();
                     actix::spawn(peers[i].send(GetInfo {}).then(move |res| {
                         let info = res.unwrap();
-                        if info.num_active_peers > num_peers - 1
+                        if info.num_connected_peers > num_peers - 1
                             && (flags1.load(Ordering::Relaxed) >> i) % 2 == 0
                         {
                             flags1.fetch_add(1 << i, Ordering::Relaxed);
@@ -172,7 +172,7 @@ fn peer_recover() {
                         let flag1 = flag.clone();
                         actix::spawn(pm0.send(GetInfo {}).then(move |res| {
                             if let Ok(info) = res {
-                                if info.active_peers.len() == 1 {
+                                if info.connected_peers.len() == 1 {
                                     flag1.clone().store(true, Ordering::Relaxed);
                                 }
                             }
@@ -192,7 +192,7 @@ fn peer_recover() {
                     // Wait until node2 is connected with node0
                     actix::spawn(pm2.send(GetInfo {}).then(|res| {
                         if let Ok(info) = res {
-                            if info.active_peers.len() == 1 {
+                            if info.connected_peers.len() == 1 {
                                 System::current().stop();
                             }
                         }

--- a/integration-tests/tests/network/runner.rs
+++ b/integration-tests/tests/network/runner.rs
@@ -810,13 +810,13 @@ pub fn check_expected_connections(
                     .map_err(|_| ())
                     .and_then(move |res| {
                         let left = if let Some(expected_connections_lo) = expected_connections_lo {
-                            expected_connections_lo <= res.num_active_peers
+                            expected_connections_lo <= res.num_connected_peers
                         } else {
                             true
                         };
 
                         let right = if let Some(expected_connections_hi) = expected_connections_hi {
-                            res.num_active_peers <= expected_connections_hi
+                            res.num_connected_peers <= expected_connections_hi
                         } else {
                             true
                         };

--- a/integration-tests/tests/network/stress_network.rs
+++ b/integration-tests/tests/network/stress_network.rs
@@ -128,7 +128,7 @@ fn stress_test() {
 
                             actix::spawn(pms[ix].send(GetInfo {}).then(move |info| {
                                 if let Ok(info) = info {
-                                    if info.num_active_peers == num_nodes - 2 {
+                                    if info.num_connected_peers == num_nodes - 2 {
                                         flag1.store(true, Ordering::Relaxed);
                                     }
                                 } else {


### PR DESCRIPTION
Change terminology used in `near-network` to be more accurate.

Currently we use `active peer` terminology to mean `connected peer`.
Unfortunately, that term is not self explanatory and leads to some confussion.

See #5424

Blocked by #5515