### PR TITLE
re: Stop using conditional imports in `near-network`

### DIFF
--- a/chain/network-primitives/src/types.rs
+++ b/chain/network-primitives/src/types.rs
@@ -13,8 +13,6 @@ use near_primitives::sharding::{
     ChunkHash, PartialEncodedChunk, PartialEncodedChunkPart, PartialEncodedChunkV1,
     PartialEncodedChunkWithArcReceipts, ReceiptProof, ShardChunkHeader,
 };
-#[cfg(feature = "sandbox")]
-use near_primitives::state_record::StateRecord;
 use near_primitives::syncing::{
     EpochSyncFinalizationResponse, EpochSyncResponse, ShardStateSyncResponse,
     ShardStateSyncResponseV1,
@@ -892,7 +890,7 @@ pub enum NetworkAdversarialMessage {
 #[cfg(feature = "sandbox")]
 #[derive(Debug)]
 pub enum NetworkSandboxMessage {
-    SandboxPatchState(Vec<StateRecord>),
+    SandboxPatchState(Vec<near_primitives::state_record::StateRecord>),
     SandboxPatchStateStatus,
 }
 

--- a/chain/network/src/peer/codec.rs
+++ b/chain/network/src/peer/codec.rs
@@ -10,8 +10,6 @@ use bytes::{Buf, BufMut, BytesMut};
 use bytesize::{GIB, MIB};
 use near_network_primitives::types::ReasonForBan;
 use near_performance_metrics::framed_write::EncoderCallBack;
-#[cfg(feature = "performance_stats")]
-use near_performance_metrics::stats_enabled::get_thread_stats_logger;
 use near_rust_allocator_proxy::allocator::get_tid;
 use std::io::{Error, ErrorKind};
 use tokio_util::codec::{Decoder, Encoder};
@@ -31,7 +29,7 @@ impl EncoderCallBack for Codec {
     fn drained(&mut self, bytes: usize, buf_len: usize, buf_capacity: usize) {
         #[cfg(feature = "performance_stats")]
         {
-            let stat = get_thread_stats_logger();
+            let stat = near_performance_metrics::stats_enabled::get_thread_stats_logger();
             stat.lock().unwrap().log_drain_write_buffer(bytes, buf_len, buf_capacity);
         }
     }
@@ -46,7 +44,7 @@ impl Encoder<Vec<u8>> for Codec {
         } else {
             #[cfg(feature = "performance_stats")]
             {
-                let stat = get_thread_stats_logger();
+                let stat = near_performance_metrics::stats_enabled::get_thread_stats_logger();
                 stat.lock().unwrap().log_add_write_buffer(
                     item.len() + 4,
                     buf.len(),

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -17,8 +17,6 @@ use actix::{
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 use cached::{Cached, SizedCache};
-#[cfg(feature = "delay_detector")]
-use delay_detector::DelayDetector;
 use near_crypto::Signature;
 use near_network_primitives::types::{
     Ban, NetworkViewClientMessages, NetworkViewClientResponses, PeerChainInfo, PeerChainInfoV2,
@@ -1007,7 +1005,7 @@ impl Handler<SendMessage> for PeerActor {
     #[perf]
     fn handle(&mut self, msg: SendMessage, _: &mut Self::Context) {
         #[cfg(feature = "delay_detector")]
-        let _d = DelayDetector::new("send message".into());
+        let _d = delay_detector::DelayDetector::new("send message".into());
         self.send_message(&msg.message);
     }
 }
@@ -1018,7 +1016,7 @@ impl Handler<Arc<SendMessage>> for PeerActor {
     #[perf]
     fn handle(&mut self, msg: Arc<SendMessage>, _: &mut Self::Context) {
         #[cfg(feature = "delay_detector")]
-        let _d = DelayDetector::new("send message".into());
+        let _d = delay_detector::DelayDetector::new("send message".into());
         self.send_message(&msg.as_ref().message);
     }
 }
@@ -1029,7 +1027,7 @@ impl Handler<QueryPeerStats> for PeerActor {
     #[perf]
     fn handle(&mut self, msg: QueryPeerStats, _: &mut Self::Context) -> Self::Result {
         #[cfg(feature = "delay_detector")]
-        let _d = DelayDetector::new("query peer stats".into());
+        let _d = delay_detector::DelayDetector::new("query peer stats".into());
         PeerStatsResult {
             chain_info: self.chain_info.clone(),
             received_bytes_per_sec: self.tracker.received_bytes.bytes_per_min() / 60,
@@ -1049,7 +1047,8 @@ impl Handler<PeerManagerRequest> for PeerActor {
     #[perf]
     fn handle(&mut self, msg: PeerManagerRequest, ctx: &mut Self::Context) -> Self::Result {
         #[cfg(feature = "delay_detector")]
-        let _d = DelayDetector::new(format!("peer manager request {:?}", msg).into());
+        let _d =
+            delay_detector::DelayDetector::new(format!("peer manager request {:?}", msg).into());
         match msg {
             PeerManagerRequest::BanPeer(ban_reason) => {
                 self.ban_peer(ctx, ban_reason);

--- a/chain/network/src/routing/edge.rs
+++ b/chain/network/src/routing/edge.rs
@@ -5,8 +5,6 @@ use near_crypto::{KeyType, SecretKey, Signature};
 use near_primitives::borsh::maybestd::sync::Arc;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
-#[cfg(feature = "test_features")]
-use serde::{Deserialize, Serialize};
 
 /// Information that will be ultimately used to create a new edge.
 /// It contains nonce proposed for the edge with signature from peer.
@@ -31,7 +29,7 @@ impl EdgeInfo {
 
 #[cfg_attr(feature = "deepsize_feature", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "test_features", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "test_features", derive(serde::Serialize, serde::Deserialize))]
 pub struct Edge(pub Arc<EdgeInner>);
 
 impl Edge {
@@ -223,7 +221,7 @@ impl Edge {
 /// from the network. This is the information that is required.
 #[cfg_attr(feature = "deepsize_feature", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "test_features", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "test_features", derive(serde::Serialize, serde::Deserialize))]
 pub struct EdgeInner {
     /// Since edges are not directed `key.0 < peer1` should hold.
     key: (PeerId, PeerId),
@@ -265,7 +263,7 @@ impl EdgeInner {
 /// Represents edge between two nodes. Unlike `Edge` it doesn't contain signatures.
 #[cfg_attr(feature = "deepsize_feature", derive(DeepSizeOf))]
 #[derive(Hash, Clone, Eq, PartialEq, Debug)]
-#[cfg_attr(feature = "test_features", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "test_features", derive(serde::Serialize, serde::Deserialize))]
 pub struct SimpleEdge {
     key: (PeerId, PeerId),
     nonce: u64,

--- a/chain/network/src/routing/routing.rs
+++ b/chain/network/src/routing/routing.rs
@@ -11,8 +11,6 @@ use near_primitives::network::{AnnounceAccount, PeerId};
 use near_primitives::time::Clock;
 use near_primitives::types::AccountId;
 use near_store::{ColAccountAnnouncements, Store};
-#[cfg(feature = "test_features")]
-use serde::Serialize;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
@@ -32,7 +30,7 @@ pub const DELETE_PEERS_AFTER_TIME: Duration = Duration::from_secs(3_600);
 pub const MAX_NUM_PEERS: usize = 128;
 
 #[derive(Debug)]
-#[cfg_attr(feature = "test_features", derive(Serialize))]
+#[cfg_attr(feature = "test_features", derive(serde::Serialize))]
 pub struct PeerRequestResult {
     pub peers: Vec<PeerInfo>,
 }
@@ -50,7 +48,7 @@ where
 }
 
 #[derive(MessageResponse, Debug)]
-#[cfg_attr(feature = "test_features", derive(Serialize))]
+#[cfg_attr(feature = "test_features", derive(serde::Serialize))]
 pub struct GetRoutingTableResult {
     pub edges_info: Vec<SimpleEdge>,
 }

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -1,23 +1,13 @@
 use crate::metrics;
-#[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
-use crate::routing::edge::SimpleEdge;
 use crate::routing::edge::{Edge, EdgeType};
 use crate::routing::edge_verifier_actor::EdgeVerifierActor;
-#[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
-use crate::routing::ibf::{Ibf, IbfBox};
-#[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
-use crate::routing::ibf_peer_set::IbfPeerSet;
-#[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
-use crate::routing::ibf_peer_set::{ValidIBFLevel, MIN_IBF_LEVEL};
-#[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
-use crate::routing::ibf_set::IbfSet;
+use crate::routing::routing::{Graph, SAVE_PEERS_MAX_TIME};
+use crate::types::{EdgeList, StopMsg};
 use actix::dev::MessageResponse;
 use actix::{
     Actor, ActorFuture, Addr, Context, ContextFutureSpawner, Handler, Message, Running,
     SyncArbiter, System, WrapFuture,
 };
-#[cfg(feature = "delay_detector")]
-use delay_detector::DelayDetector;
 use near_performance_metrics_macros::perf;
 use near_primitives::borsh::BorshSerialize;
 use near_primitives::network::PeerId;
@@ -28,14 +18,7 @@ use std::collections::{HashMap, HashSet};
 use std::mem::swap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-#[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
-use tracing::error;
 use tracing::{debug, trace, warn};
-
-use crate::routing::routing::{Graph, SAVE_PEERS_MAX_TIME};
-use crate::types::{EdgeList, StopMsg};
-#[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
-use crate::types::{PartialSync, PeerMessage, RoutingState, RoutingSyncV2, RoutingVersion2};
 
 /// `Prune` enum is to specify how often should we prune edges.
 #[derive(Debug, Eq, PartialEq)]
@@ -64,7 +47,7 @@ pub struct RoutingTableActor {
     pub edges_info: HashMap<(PeerId, PeerId), Edge>,
     /// Data structure used for exchanging routing tables.
     #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
-    pub peer_ibf_set: IbfPeerSet,
+    pub peer_ibf_set: crate::routing::ibf_peer_set::IbfPeerSet,
     /// Current view of the network represented by undirected graph.
     /// Nodes are Peers and edges are active connections.
     pub raw_graph: Graph,
@@ -254,7 +237,7 @@ impl RoutingTableActor {
     /// Recalculate routing table and update list of reachable peers.
     pub fn recalculate_routing_table(&mut self) {
         #[cfg(feature = "delay_detector")]
-        let _d = DelayDetector::new("routing table update".into());
+        let _d = delay_detector::DelayDetector::new("routing table update".into());
         let _routing_table_recalculation =
             metrics::ROUTING_TABLE_RECALCULATION_HISTOGRAM.start_timer();
 
@@ -285,7 +268,7 @@ impl RoutingTableActor {
         }
 
         #[cfg(feature = "delay_detector")]
-        let _d = DelayDetector::new("pruning edges".into());
+        let _d = delay_detector::DelayDetector::new("pruning edges".into());
 
         let edges_to_remove = self.prune_unreachable_edges_and_save_to_db(
             prune == Prune::PruneNow,
@@ -418,7 +401,7 @@ impl RoutingTableActor {
         &self,
         peer_id: &PeerId,
         unknown_edges: &[u64],
-    ) -> (Vec<SimpleEdge>, Vec<u64>) {
+    ) -> (Vec<crate::routing::SimpleEdge>, Vec<u64>) {
         self.peer_ibf_set.split_edges_for_peer(peer_id, unknown_edges)
     }
 }
@@ -482,7 +465,7 @@ pub enum RoutingTableMessages {
     #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
     ProcessIbfMessage {
         peer_id: PeerId,
-        ibf_msg: RoutingVersion2,
+        ibf_msg: crate::types::RoutingVersion2,
     },
     // Start new routing table sync.
     #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
@@ -509,14 +492,14 @@ pub enum RoutingTableMessagesResponse {
     Empty,
     #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
     ProcessIbfMessageResponse {
-        ibf_msg: Option<RoutingVersion2>,
+        ibf_msg: Option<crate::types::RoutingVersion2>,
     },
     RequestRoutingTableResponse {
         edges_info: Vec<Edge>,
     },
     AddVerifiedEdgesResponse(Vec<Edge>),
     #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
-    StartRoutingTableSyncResponse(PeerMessage),
+    StartRoutingTableSyncResponse(crate::types::PeerMessage),
     RoutingTableUpdateResponse {
         edges_to_remove: Vec<Edge>,
         /// Active PeerId that are part of the shortest path to each PeerId.
@@ -531,17 +514,18 @@ impl RoutingTableActor {
     pub fn exchange_routing_tables_using_ibf(
         &self,
         peer_id: &PeerId,
-        ibf_set: &IbfSet<SimpleEdge>,
-        ibf_level: ValidIBFLevel,
-        ibf_vec: &[IbfBox],
+        ibf_set: &crate::routing::IbfSet<crate::routing::SimpleEdge>,
+        ibf_level: crate::routing::ibf_peer_set::ValidIBFLevel,
+        ibf_vec: &[crate::routing::ibf::IbfBox],
         seed: u64,
-    ) -> (Vec<SimpleEdge>, Vec<u64>, u64) {
+    ) -> (Vec<crate::routing::SimpleEdge>, Vec<u64>, u64) {
         let ibf = ibf_set.get_ibf(ibf_level);
 
-        let mut new_ibf = Ibf::from_vec(ibf_vec.clone(), seed ^ (ibf_level.0 as u64));
+        let mut new_ibf =
+            crate::routing::ibf::Ibf::from_vec(ibf_vec.clone(), seed ^ (ibf_level.0 as u64));
 
         if !new_ibf.merge(&ibf.data, seed ^ (ibf_level.0 as u64)) {
-            error!(target: "network", "exchange routing tables failed with peer {}", peer_id);
+            tracing::error!(target: "network", "exchange routing tables failed with peer {}", peer_id);
             return (Default::default(), Default::default(), 0);
         }
 
@@ -597,12 +581,14 @@ impl Handler<RoutingTableMessages> for RoutingTableActor {
             #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
             RoutingTableMessages::StartRoutingTableSync { seed } => {
                 RoutingTableMessagesResponse::StartRoutingTableSyncResponse(
-                    PeerMessage::RoutingTableSyncV2(RoutingSyncV2::Version2(RoutingVersion2 {
-                        known_edges: self.edges_info.len() as u64,
-                        seed,
-                        edges: Default::default(),
-                        routing_state: RoutingState::InitializeIbf,
-                    })),
+                    crate::types::PeerMessage::RoutingTableSyncV2(
+                        crate::types::RoutingSyncV2::Version2(crate::types::RoutingVersion2 {
+                            known_edges: self.edges_info.len() as u64,
+                            seed,
+                            edges: Default::default(),
+                            routing_state: crate::types::RoutingState::InitializeIbf,
+                        }),
+                    ),
                 )
             }
             #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
@@ -631,7 +617,7 @@ impl Handler<RoutingTableMessages> for RoutingTableActor {
             #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
             RoutingTableMessages::ProcessIbfMessage { peer_id, ibf_msg } => {
                 match ibf_msg.routing_state {
-                    RoutingState::PartialSync(partial_sync) => {
+                    crate::types::RoutingState::PartialSync(partial_sync) => {
                         if let Some(ibf_set) = self.peer_ibf_set.get(&peer_id) {
                             let seed = ibf_msg.seed;
                             let (edges_for_peer, unknown_edge_hashes, unknown_edges_count) = self
@@ -651,35 +637,37 @@ impl Handler<RoutingTableMessages> for RoutingTableActor {
                             let ibf_msg = if unknown_edges_count == 0
                                 && unknown_edge_hashes.len() > 0
                             {
-                                RoutingVersion2 {
+                                crate::types::RoutingVersion2 {
                                     known_edges: self.edges_info.len() as u64,
                                     seed,
                                     edges: edges_for_peer,
-                                    routing_state: RoutingState::RequestMissingEdges(
+                                    routing_state: crate::types::RoutingState::RequestMissingEdges(
                                         unknown_edge_hashes,
                                     ),
                                 }
                             } else if unknown_edges_count == 0 && unknown_edge_hashes.len() == 0 {
-                                RoutingVersion2 {
+                                crate::types::RoutingVersion2 {
                                     known_edges: self.edges_info.len() as u64,
                                     seed,
                                     edges: edges_for_peer,
-                                    routing_state: RoutingState::Done,
+                                    routing_state: crate::types::RoutingState::Done,
                                 }
                             } else {
                                 if let Some(new_ibf_level) = partial_sync.ibf_level.inc() {
                                     let ibf_vec = ibf_set.get_ibf_vec(new_ibf_level);
-                                    RoutingVersion2 {
+                                    crate::types::RoutingVersion2 {
                                         known_edges: self.edges_info.len() as u64,
                                         seed,
                                         edges: edges_for_peer,
-                                        routing_state: RoutingState::PartialSync(PartialSync {
-                                            ibf_level: new_ibf_level,
-                                            ibf: ibf_vec,
-                                        }),
+                                        routing_state: crate::types::RoutingState::PartialSync(
+                                            crate::types::PartialSync {
+                                                ibf_level: new_ibf_level,
+                                                ibf: ibf_vec,
+                                            },
+                                        ),
                                     }
                                 } else {
-                                    RoutingVersion2 {
+                                    crate::types::RoutingVersion2 {
                                         known_edges: self.edges_info.len() as u64,
                                         seed,
                                         edges: self
@@ -687,7 +675,7 @@ impl Handler<RoutingTableMessages> for RoutingTableActor {
                                             .iter()
                                             .map(|x| x.1.clone())
                                             .collect(),
-                                        routing_state: RoutingState::RequestAllEdges,
+                                        routing_state: crate::types::RoutingState::RequestAllEdges,
                                     }
                                 }
                             };
@@ -695,11 +683,11 @@ impl Handler<RoutingTableMessages> for RoutingTableActor {
                                 ibf_msg: Some(ibf_msg),
                             }
                         } else {
-                            error!(target: "network", "Peer not found {}", peer_id);
+                            tracing::error!(target: "network", "Peer not found {}", peer_id);
                             RoutingTableMessagesResponse::Empty
                         }
                     }
-                    RoutingState::InitializeIbf => {
+                    crate::types::RoutingState::InitializeIbf => {
                         self.peer_ibf_set.add_peer(
                             peer_id.clone(),
                             Some(ibf_msg.seed),
@@ -707,24 +695,27 @@ impl Handler<RoutingTableMessages> for RoutingTableActor {
                         );
                         if let Some(ibf_set) = self.peer_ibf_set.get(&peer_id) {
                             let seed = ibf_set.get_seed();
-                            let ibf_vec = ibf_set.get_ibf_vec(MIN_IBF_LEVEL);
+                            let ibf_vec =
+                                ibf_set.get_ibf_vec(crate::routing::ibf_peer_set::MIN_IBF_LEVEL);
                             RoutingTableMessagesResponse::ProcessIbfMessageResponse {
-                                ibf_msg: Some(RoutingVersion2 {
+                                ibf_msg: Some(crate::types::RoutingVersion2 {
                                     known_edges: self.edges_info.len() as u64,
                                     seed,
                                     edges: Default::default(),
-                                    routing_state: RoutingState::PartialSync(PartialSync {
-                                        ibf_level: MIN_IBF_LEVEL,
-                                        ibf: ibf_vec,
-                                    }),
+                                    routing_state: crate::types::RoutingState::PartialSync(
+                                        crate::types::PartialSync {
+                                            ibf_level: crate::routing::ibf_peer_set::MIN_IBF_LEVEL,
+                                            ibf: ibf_vec,
+                                        },
+                                    ),
                                 }),
                             }
                         } else {
-                            error!(target: "network", "Peer not found {}", peer_id);
+                            tracing::error!(target: "network", "Peer not found {}", peer_id);
                             RoutingTableMessagesResponse::Empty
                         }
                     }
-                    RoutingState::RequestMissingEdges(requested_edges) => {
+                    crate::types::RoutingState::RequestMissingEdges(requested_edges) => {
                         let seed = ibf_msg.seed;
                         let (edges_for_peer, _) =
                             self.split_edges_for_peer(&peer_id, &requested_edges);
@@ -734,27 +725,27 @@ impl Handler<RoutingTableMessages> for RoutingTableActor {
                             .filter_map(|x| self.edges_info.get(&x.key()).cloned())
                             .collect();
 
-                        let ibf_msg = RoutingVersion2 {
+                        let ibf_msg = crate::types::RoutingVersion2 {
                             known_edges: self.edges_info.len() as u64,
                             seed,
                             edges: edges_for_peer,
-                            routing_state: RoutingState::Done,
+                            routing_state: crate::types::RoutingState::Done,
                         };
                         RoutingTableMessagesResponse::ProcessIbfMessageResponse {
                             ibf_msg: Some(ibf_msg),
                         }
                     }
-                    RoutingState::RequestAllEdges => {
+                    crate::types::RoutingState::RequestAllEdges => {
                         RoutingTableMessagesResponse::ProcessIbfMessageResponse {
-                            ibf_msg: Some(RoutingVersion2 {
+                            ibf_msg: Some(crate::types::RoutingVersion2 {
                                 known_edges: self.edges_info.len() as u64,
                                 seed: ibf_msg.seed,
                                 edges: self.get_all_edges(),
-                                routing_state: RoutingState::Done,
+                                routing_state: crate::types::RoutingState::Done,
                             }),
                         }
                     }
-                    RoutingState::Done => {
+                    crate::types::RoutingState::Done => {
                         RoutingTableMessagesResponse::ProcessIbfMessageResponse { ibf_msg: None }
                     }
                 }

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -1,9 +1,5 @@
 use crate::peer::peer_actor::PeerActor;
 use crate::routing::edge::{Edge, EdgeInfo, SimpleEdge};
-#[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
-use crate::routing::ibf::IbfBox;
-#[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
-use crate::routing::ibf_peer_set::ValidIBFLevel;
 use crate::routing::routing::{GetRoutingTableResult, PeerRequestResult, RoutingTableInfo};
 use crate::PeerInfo;
 use actix::dev::{MessageResponse, ResponseChannel};
@@ -14,10 +10,6 @@ use conqueue::QueueSender;
 use deepsize::DeepSizeOf;
 use futures::future::BoxFuture;
 use futures::FutureExt;
-#[cfg(feature = "test_features")]
-use near_network_primitives::types::NetworkAdversarialMessage;
-#[cfg(feature = "sandbox")]
-use near_network_primitives::types::NetworkSandboxMessage;
 use near_network_primitives::types::{
     AccountIdOrPeerTrackingShard, AccountOrPeerIdOrHash, Ban, InboundTcpConnect, KnownProducer,
     OutboundTcpConnect, PartialEncodedChunkForwardMsg, PartialEncodedChunkRequestMsg,
@@ -38,8 +30,6 @@ use near_primitives::version::{
     ProtocolVersion, OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION, PROTOCOL_VERSION,
 };
 use near_primitives::views::QueryRequest;
-#[cfg(feature = "test_features")]
-use serde::Serialize;
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
 use std::sync::{Arc, Mutex, RwLock};
@@ -359,8 +349,8 @@ pub enum RoutingSyncV2 {
 #[cfg_attr(feature = "deepsize_feature", derive(DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Clone, Debug)]
 pub struct PartialSync {
-    pub(crate) ibf_level: ValidIBFLevel,
-    pub(crate) ibf: Vec<IbfBox>,
+    pub(crate) ibf_level: crate::routing::ibf_peer_set::ValidIBFLevel,
+    pub(crate) ibf: Vec<crate::routing::ibf::IbfBox>,
 }
 
 #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
@@ -495,7 +485,7 @@ impl Message for GetPeerId {
 }
 
 #[derive(MessageResponse, Debug)]
-#[cfg_attr(feature = "test_features", derive(Serialize))]
+#[cfg_attr(feature = "test_features", derive(serde::Serialize))]
 pub struct GetPeerIdResult {
     pub(crate) peer_id: PeerId,
 }
@@ -932,10 +922,10 @@ impl Message for NetworkRequests {
 #[allow(clippy::large_enum_variant)]
 pub enum NetworkClientMessages {
     #[cfg(feature = "test_features")]
-    Adversarial(NetworkAdversarialMessage),
+    Adversarial(near_network_primitives::types::NetworkAdversarialMessage),
 
     #[cfg(feature = "sandbox")]
-    Sandbox(NetworkSandboxMessage),
+    Sandbox(near_network_primitives::types::NetworkSandboxMessage),
 
     /// Received transaction.
     Transaction {

--- a/docs/style.md
+++ b/docs/style.md
@@ -81,8 +81,13 @@ imports and rely on `rustfmt` to sort them.
 
 ```rust
 // GOOD
+<<<<<<< HEAD
 use crate::types::KnownPeerState;
 use borsh::BorshSerialize;
+=======
+use borsh::BorshSerialize;
+use crate::types::KnownPeerState;
+>>>>>>> 28291a693... docs: document consistent import style (#5290)
 use near_primitives::utils::to_timestamp;
 use near_store::{ColPeers, Store};
 use rand::seq::SliceRandom;


### PR DESCRIPTION
We should improve code quality by removing conditional imports.

There are a few issues with conditional imports:
-  high maintenance  cost - modifying code under conditional flags, requires manually adding #[cfg(feature=)] for each import. Rust plugin for Intellij doesn't support them well.
- readability - this makes code more readable, it's good to see what's being imported when to feature flags are used. 
- fragility CI - I've seen a lot cases, where I submit PR, only to find out, something didn't compile with some subset of features.