### PR TITLE
nightly: disable consistently failing tests

### DIFF
--- a/nightly/pytest-sanity.txt
+++ b/nightly/pytest-sanity.txt
@@ -23,8 +23,10 @@ pytest --timeout=600 sanity/state_sync.py onetx 265
 pytest --timeout=600 sanity/state_sync.py onetx 265 --features nightly_protocol,nightly_protocol_features
 pytest --timeout=240 sanity/state_sync1.py
 pytest --timeout=240 sanity/state_sync1.py --features nightly_protocol,nightly_protocol_features
-pytest --timeout=900 sanity/state_sync2.py
-pytest --timeout=900 sanity/state_sync2.py nightly --features nightly_protocol,nightly_protocol_features
+# TODO(#4618): Those tests are currently broken.  Comment out while we’re
+# working on a fix / deciding whether to remove them.
+#pytest --timeout=900 sanity/state_sync2.py
+#pytest --timeout=900 sanity/state_sync2.py nightly --features nightly_protocol,nightly_protocol_features
 pytest --timeout=1200 sanity/state_sync3.py
 pytest --timeout=1200 sanity/state_sync3.py --features nightly_protocol,nightly_protocol_features
 pytest --timeout=240 sanity/state_sync4.py
@@ -34,8 +36,10 @@ pytest --timeout=240 sanity/state_sync5.py --features nightly_protocol,nightly_p
 pytest --timeout=480 sanity/routing_table_sync.py --features nightly_protocol,nightly_protocol_features
 pytest --timeout=600 sanity/state_sync_routed.py manytx 115
 pytest --timeout=600 sanity/state_sync_routed.py manytx 115 --features nightly_protocol,nightly_protocol_features
-pytest --timeout=300 sanity/state_sync_late.py notx
-pytest --timeout=300 sanity/state_sync_late.py notx --features nightly_protocol,nightly_protocol_features
+# TODO(#4618): Those tests are currently broken.  Comment out while we’re
+# working on a fix / deciding whether to remove them.
+#pytest --timeout=300 sanity/state_sync_late.py notx
+#pytest --timeout=300 sanity/state_sync_late.py notx --features nightly_protocol,nightly_protocol_features
 
 pytest --timeout=3600 sanity/state_sync_massive.py
 pytest --timeout=3600 sanity/state_sync_massive.py --features nightly_protocol,nightly_protocol_features


### PR DESCRIPTION
state_sync2 and state_sync_late tests are consistently failing.
Remove them from nightly run while working on a fix.

Issue: https://github.com/near/nearcore/issues/4618