### PR TITLE
Increase timeout for `get_status` to `4s` from `2s`

### DIFF
--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -149,7 +149,7 @@ class BaseNode(object):
                              [base64.b64encode(signed_tx).decode('utf8')],
                              timeout=timeout)
 
-    def get_status(self, check_storage=True, timeout=2):
+    def get_status(self, check_storage=True, timeout=4):
         r = requests.get("http://%s:%s/status" % self.rpc_addr(),
                          timeout=timeout)
         r.raise_for_status()


### PR DESCRIPTION
We are tests timeout often in `get_status`. Let's increase timeout from `2s` to `4s`.

This is blocking CI in production.