### PR TITLE
fix: validate functions number after initialization

### DIFF
--- a/runtime/near-vm-runner/src/prepare.rs
+++ b/runtime/near-vm-runner/src/prepare.rs
@@ -185,12 +185,12 @@ impl<'a> ContractModule<'a> {
 /// The preprocessing includes injecting code for gas metering and metering the height of stack.
 pub fn prepare_contract(original_code: &[u8], config: &VMConfig) -> Result<Vec<u8>, PrepareError> {
     ContractModule::init(original_code, config)?
+        .validate_functions_number()?
         .standardize_mem()
         .ensure_no_internal_memory()?
         .inject_gas_metering()?
         .inject_stack_height_metering()?
         .scan_imports()?
-        .validate_functions_number()?
         .into_wasm_code()
 }
 

--- a/runtime/near-vm-runner/src/tests/compile_errors.rs
+++ b/runtime/near-vm-runner/src/tests/compile_errors.rs
@@ -159,7 +159,7 @@ fn test_limit_contract_functions_number() {
         let functions_number_limit: u32 = 10_000;
         let method_name = "main";
 
-        let code = near_test_contracts::many_functions_contract(functions_number_limit + 10);
+        let code = near_test_contracts::many_functions_contract(functions_number_limit + 1);
         let (_, err) = make_simple_contract_call_with_protocol_version_vm(
             &code,
             method_name,
@@ -168,7 +168,7 @@ fn test_limit_contract_functions_number() {
         );
         assert_eq!(err, None);
 
-        let code = near_test_contracts::many_functions_contract(functions_number_limit - 10);
+        let code = near_test_contracts::many_functions_contract(functions_number_limit);
         let (_, err) = make_simple_contract_call_with_protocol_version_vm(
             &code,
             method_name,
@@ -177,7 +177,7 @@ fn test_limit_contract_functions_number() {
         );
         assert_eq!(err, None);
 
-        let code = near_test_contracts::many_functions_contract(functions_number_limit + 10);
+        let code = near_test_contracts::many_functions_contract(functions_number_limit + 1);
         let (_, err) = make_simple_contract_call_with_protocol_version_vm(
             &code,
             method_name,


### PR DESCRIPTION
We've noticed that if we validate functions number just after initialization, it speeds up the contract processing.

Also we want to do this before release, because number of functions computed **before** and **after** the change is actually different. I'm working on the repro.

## Test plan

- existing tests,
- adjust `test_limit_contract_functions_number` so that it checks precise limit now.