### PR TITLE
buf: Fix `near-rate-limiter` tests not compiling

### DIFF
--- a/utils/near-rate-limiter/Cargo.toml
+++ b/utils/near-rate-limiter/Cargo.toml
@@ -9,5 +9,5 @@ bytes = "1.0.0"
 futures-core = "0.3.0"
 log = "0.4"
 pin-project-lite = "0.2.0"
-tokio = { version = "1.0.0", features = ["sync"] }
+tokio = { version = "1.1", features = ["sync", "macros", "rt"] }
 tokio-util = { version = "0.6.9", features = ["io", "codec"] }


### PR DESCRIPTION
Tests for `near-rate-limiter` were not compiling, when building tests just for this crate.