### PR TITLE
nearcore: use tempfile to create temporary files when downloading

### DIFF
--- a/nearcore/Cargo.toml
+++ b/nearcore/Cargo.toml
@@ -30,6 +30,7 @@ smart-default = "0.6"
 num-rational = { version = "0.3", features = ["serde"] }
 near-rust-allocator-proxy = "0.3.0"
 lazy-static-include = "3"
+tempfile = "3"
 
 near-crypto = { path = "../core/crypto" }
 near-primitives = { path = "../core/primitives" }


### PR DESCRIPTION
We are already using tempfile crate in other parts of the code so
use it in download_file as well rather than having an arguably less
safe way of creating temporary files (i.e. blindly using predefined
extension).

Issue: https://github.com/near/nearcore/issues/4951