### PR TITLE
Use the CPU features we require across neard and the runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ release: RUSTFLAGS+= -Ctarget-feature=+avx,+cmpxchg16b,+popcnt,+sse3,+ssse3,+sse
 release: CFLAGS = -mavx -mpopcnt -msse3 -mssse3 -msse4.1 -msse4.2 -msse4a -mcx16
 release: CXXFLAGS = ${CFLAGS}
 release:
-	cargo build -p neard --release
+	cargo build -p neard --release --features cpu_compatibility_checks
 	cargo build -p state-viewer --release
 	cargo build -p store-validator --release
 	cargo build -p runtime-params-estimator --release

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ docker-nearcore-nightly:
 	docker build -t nearcore-nightly -f Dockerfile --build-arg=features=nightly_protocol,nightly_protocol_features --progress=plain .
 
 release: NEAR_RELEASE_BUILD=release
+release: RUSTFLAGS+= -Ctarget-feature=+avx,+cmpxchg16b,+popcnt,+sse3,+ssse3,+sse4.1,+sse4.2,+sse4a
+release: CFLAGS = -mavx -mpopcnt -msse3 -mssse3 -msse4.1 -msse4.2 -msse4a -mcx16
+release: CXXFLAGS = ${CFLAGS}
 release:
 	cargo build -p neard --release
 	cargo build -p state-viewer --release

--- a/core/primitives/src/cpu.rs
+++ b/core/primitives/src/cpu.rs
@@ -1,41 +1,93 @@
+#[derive(Debug)]
+pub enum Error {
+    /// Unsupported architecture
+    Architecture,
+    /// The following required features are not supported by the CPU.
+    MissingFeatures(Vec<&'static str>),
+    /// SSE is available but disabled.
+    SSEDisabled,
+    /// AVX is available but disabled.
+    AVXDisabled,
+}
+
+impl Error {
+    pub const NOTE: &'static str = "confirm hardware requirements at \
+        <https://docs.near.org/docs/develop/node/validator/hardware>.";
+
+    pub fn terminate(&self) -> ! {
+        eprintln!("error: {}\nnote: {}", self, Self::NOTE);
+        std::process::exit(1);
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use Error::*;
+        match self {
+            Architecture => f.write_str("unsupported CPU architecture")?,
+            SSEDisabled => f.write_str("SSE CPU feature is supported but disabled")?,
+            AVXDisabled => f.write_str("AVX CPU feature is supported but disabled")?,
+            MissingFeatures(features) => {
+                f.write_str("required CPU features are missing: ")?;
+                let mut features = features.iter().peekable();
+                while let Some(feature) = features.next() {
+                    f.write_str(feature)?;
+                    if features.peek().is_some() {
+                        f.write_str(", ")?;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
 /// Try to ensure that the required CPU features are available and enabled for the current CPU.
+///
+/// If any of the features are not available, the returned error will specify which ones are
+/// missing.
 ///
 /// Note that this is a best-effort kind of thing. If these features are already enabled when
 /// compiling the program, then we may very well end up executing some unsupported instruction
 /// before we even get to executing this code.
-pub fn ensure_cpu_compatibility(force: bool) {
-    if cfg!(near_production) || force {
-        imp::ensure_cpu_compatibility();
-    } else {
-        // Intentionally empty: allow execution without verifying the properties of the CPU.
-    }
+pub fn verify_cpu_compatibility() -> Result<(), Error> {
+    imp::verify_cpu_compatibility()
 }
 
 mod imp {
-    const NOTE: &str = "confirm hardware requirements at \
-        <https://docs.near.org/docs/develop/node/validator/hardware>.";
-
     #[cfg(not(target_arch = "x86_64"))]
-    pub fn ensure_cpu_compatibility() {
-        eprintln!("error: processor running a x86_64 instruction set is required.\nnote: {}", NOTE);
-        std::process::exit(1);
+    pub fn verify_cpu_compatibility() -> Result<(), super::Error> {
+        Err(super::Error::Architecture)
     }
 
     #[cfg(target_arch = "x86_64")]
-    pub fn ensure_cpu_compatibility() {
-        // SAFETY: this is “just” a CPUID. Some very ancient chips don't support this instruction
-        // and may do anything else with the opcode.
-        //
-        // As an implementation note, we cannot use `is_*_feature_available!` macro from libstd
-        // here, because it will unconditionally return `true` when `cfg(target_feature="...")` is
-        // true.
-        let cpuid01 = unsafe { std::arch::x86_64::__cpuid(0x01) };
-        ensure_cpuid01(cpuid01.ecx, cpuid01.edx);
-        let cpuid0d = unsafe { std::arch::x86_64::__cpuid(0x0d) };
-        ensure_cpuid0d(cpuid0d.eax);
+    pub fn verify_cpu_compatibility() -> Result<(), super::Error> {
+        ensure_cpu_info()?;
+        ensure_cpu_state()
     }
 
-    fn ensure_cpuid01(ecx: u32, edx: u32) {
+    // NB: You can search for the CPUID flags by searching for `CPUID.01H` in the Intel® 64 and
+    // IA-32 architectures software developer’s manual combined volumes: 1, 2A, 2B, 2C, 2D, 3A, 3B,
+    // 3C, 3D, and 4, available for a download at
+    // <https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html>.
+    //
+    // Alternatively a resource such as https://www.felixcloutier.com/x86/cpuid may be more
+    // convenient as it provides all the information in a single table.
+    fn ensure_cpu_info() -> Result<(), super::Error> {
+        let cpu_info = unsafe {
+            const CPUID_LEAF_PROCESSOR_INFO: u32 = 0x01;
+            // SAFETY: this is “just” a CPUID instruction. Some very ancient chips don't support
+            // this instruction and may do anything else with the opcode, but at that point che CPU
+            // is very significantly outside of the hardware requirements specified by us.
+            //
+            // As an implementation note, we cannot use `is_*_feature_available!` macro from libstd
+            // here, because it will unconditionally return `true` when
+            // `cfg!(target_feature="...")` is true.
+            std::arch::x86_64::__cpuid(CPUID_LEAF_PROCESSOR_INFO)
+        };
+        let (ecx, edx) = (cpu_info.ecx, cpu_info.edx);
         const SSE_EDX_FLAG: u32 = 1 << 25;
         const SSE2_EDX_FLAG: u32 = 1 << 26;
         const SSE3_ECX_FLAG: u32 = 1 << 0;
@@ -75,23 +127,32 @@ mod imp {
         }
 
         if !features.is_empty() {
-            let joined = features.join(", ");
-            eprintln!("error: processor does not support these required CPU features: {}.", joined);
-            eprintln!("note: {}", NOTE);
-            std::process::exit(1);
+            return Err(super::Error::MissingFeatures(features));
         }
+        Ok(())
     }
 
-    fn ensure_cpuid0d(eax: u32) {
+    // NB: See the comment for `ensure_cpu_info`.
+    fn ensure_cpu_state() -> Result<(), super::Error> {
+        let cpu_state = unsafe {
+            const CPUID_LEAF_PROCESSOR_EXTENDED_STATE: u32 = 0x0D;
+            // SAFETY: this is “just” a CPUID instruction. Some very ancient chips don't support
+            // this instruction and may do anything else with the opcode, but at that point che CPU
+            // is very significantly outside of the hardware requirements specified by us.
+            //
+            // As an implementation note, we cannot use `is_*_feature_available!` macro from libstd
+            // here, because it will unconditionally return `true` when
+            // `cfg!(target_feature="...")` is true.
+            std::arch::x86_64::__cpuid(CPUID_LEAF_PROCESSOR_EXTENDED_STATE)
+        };
         const SSE_EAX_FLAG: u32 = 1 << 1;
-        if eax & SSE_EAX_FLAG != SSE_EAX_FLAG {
-            eprintln!("error: SSE CPU feature is not enabled.\nnote: {}", NOTE);
-            std::process::exit(1);
+        if cpu_state.eax & SSE_EAX_FLAG != SSE_EAX_FLAG {
+            return Err(super::Error::SSEDisabled);
         }
         const AVX_EAX_FLAG: u32 = 1 << 2;
-        if eax & AVX_EAX_FLAG != AVX_EAX_FLAG {
-            eprintln!("error: AVX CPU feature is not enabled.\nnote: {}", NOTE);
-            std::process::exit(1);
+        if cpu_state.eax & AVX_EAX_FLAG != AVX_EAX_FLAG {
+            return Err(super::Error::AVXDisabled);
         }
+        Ok(())
     }
 }

--- a/core/primitives/src/cpu.rs
+++ b/core/primitives/src/cpu.rs
@@ -1,0 +1,97 @@
+/// Try to ensure that the required CPU features are available and enabled for the current CPU.
+///
+/// Note that this is a best-effort kind of thing. If these features are already enabled when
+/// compiling the program, then we may very well end up executing some unsupported instruction
+/// before we even get to executing this code.
+pub fn ensure_cpu_compatibility(force: bool) {
+    if cfg!(near_production) || force {
+        imp::ensure_cpu_compatibility();
+    } else {
+        // Intentionally empty: allow execution without verifying the properties of the CPU.
+    }
+}
+
+mod imp {
+    const NOTE: &str = "confirm hardware requirements at \
+        <https://docs.near.org/docs/develop/node/validator/hardware>.";
+
+    #[cfg(not(target_arch = "x86_64"))]
+    pub fn ensure_cpu_compatibility() {
+        eprintln!("error: processor running a x86_64 instruction set is required.\nnote: {}", NOTE);
+        std::process::exit(1);
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    pub fn ensure_cpu_compatibility() {
+        // SAFETY: this is “just” a CPUID. Some very ancient chips don't support this instruction
+        // and may do anything else with the opcode.
+        //
+        // As an implementation note, we cannot use `is_*_feature_available!` macro from libstd
+        // here, because it will unconditionally return `true` when `cfg(target_feature="...")` is
+        // true.
+        let cpuid01 = unsafe { std::arch::x86_64::__cpuid(0x01) };
+        ensure_cpuid01(cpuid01.ecx, cpuid01.edx);
+        let cpuid0d = unsafe { std::arch::x86_64::__cpuid(0x0d) };
+        ensure_cpuid0d(cpuid0d.eax);
+    }
+
+    fn ensure_cpuid01(ecx: u32, edx: u32) {
+        const SSE_EDX_FLAG: u32 = 1 << 25;
+        const SSE2_EDX_FLAG: u32 = 1 << 26;
+        const SSE3_ECX_FLAG: u32 = 1 << 0;
+        const SSSE3_ECX_FLAG: u32 = 1 << 9;
+        const CMPXCHG16B_ECX_FLAG: u32 = 1 << 13;
+        const SSE41_ECX_FLAG: u32 = 1 << 19;
+        const SSE42_ECX_FLAG: u32 = 1 << 20;
+        const POPCNT_ECX_FLAG: u32 = 1 << 23;
+        const AVX_ECX_FLAG: u32 = 1 << 28;
+        let mut features = Vec::new();
+        if edx & SSE_EDX_FLAG != SSE_EDX_FLAG {
+            features.push("SSE");
+        }
+        if edx & SSE2_EDX_FLAG != SSE2_EDX_FLAG {
+            features.push("SSE2");
+        }
+        if ecx & SSE3_ECX_FLAG != SSE3_ECX_FLAG {
+            features.push("SSE3");
+        }
+        if ecx & SSSE3_ECX_FLAG != SSSE3_ECX_FLAG {
+            features.push("SSSE3");
+        }
+        if ecx & CMPXCHG16B_ECX_FLAG != CMPXCHG16B_ECX_FLAG {
+            features.push("CMPXCHG16B");
+        }
+        if ecx & SSE41_ECX_FLAG != SSE41_ECX_FLAG {
+            features.push("SSE4.1");
+        }
+        if ecx & SSE42_ECX_FLAG != SSE42_ECX_FLAG {
+            features.push("SSE4.2");
+        }
+        if ecx & POPCNT_ECX_FLAG != POPCNT_ECX_FLAG {
+            features.push("POPCNT");
+        }
+        if ecx & AVX_ECX_FLAG != AVX_ECX_FLAG {
+            features.push("AVX");
+        }
+
+        if !features.is_empty() {
+            let joined = features.join(", ");
+            eprintln!("error: processor does not support these required CPU features: {}.", joined);
+            eprintln!("note: {}", NOTE);
+            std::process::exit(1);
+        }
+    }
+
+    fn ensure_cpuid0d(eax: u32) {
+        const SSE_EAX_FLAG: u32 = 1 << 1;
+        if eax & SSE_EAX_FLAG != SSE_EAX_FLAG {
+            eprintln!("error: SSE CPU feature is not enabled.\nnote: {}", NOTE);
+            std::process::exit(1);
+        }
+        const AVX_EAX_FLAG: u32 = 1 << 2;
+        if eax & AVX_EAX_FLAG != AVX_EAX_FLAG {
+            eprintln!("error: AVX CPU feature is not enabled.\nnote: {}", NOTE);
+            std::process::exit(1);
+        }
+    }
+}

--- a/core/primitives/src/lib.rs
+++ b/core/primitives/src/lib.rs
@@ -1,19 +1,20 @@
-pub use near_primitives_core::borsh;
-pub use near_primitives_core::num_rational;
-
 pub use near_primitives_core::account;
+pub use near_primitives_core::borsh;
+pub use near_primitives_core::config;
+pub use near_primitives_core::contract;
+pub use near_primitives_core::hash;
+pub use near_primitives_core::logging;
+pub use near_primitives_core::num_rational;
+pub use near_primitives_core::profile;
+
 pub mod block;
 pub mod block_header;
 pub mod challenge;
-pub use near_primitives_core::config;
-pub use near_primitives_core::contract;
+pub mod cpu;
 pub mod epoch_manager;
 pub mod errors;
-pub use near_primitives_core::hash;
-pub use near_primitives_core::logging;
 pub mod merkle;
 pub mod network;
-pub use near_primitives_core::profile;
 pub mod rand;
 pub mod receipt;
 pub mod runtime;

--- a/nearcore/Cargo.toml
+++ b/nearcore/Cargo.toml
@@ -81,6 +81,7 @@ protocol_feature_routing_exchange_algorithm = ["near-primitives/protocol_feature
 protocol_feature_access_key_nonce_for_implicit_accounts = ["near-primitives/protocol_feature_access_key_nonce_for_implicit_accounts", "node-runtime/protocol_feature_access_key_nonce_for_implicit_accounts"]
 nightly_protocol_features = ["nightly_protocol", "near-primitives/nightly_protocol_features", "near-client/nightly_protocol_features", "near-epoch-manager/nightly_protocol_features", "near-store/nightly_protocol_features", "protocol_feature_alt_bn128", "protocol_feature_chunk_only_producers", "protocol_feature_routing_exchange_algorithm", "protocol_feature_access_key_nonce_for_implicit_accounts"]
 nightly_protocol = ["near-primitives/nightly_protocol", "near-jsonrpc/nightly_protocol"]
+cpu_compatibility_checks = ["near-vm-runner/cpu_compatibility_checks"]
 
 # Force usage of a specific wasm vm irrespective of protocol version.
 force_wasmer2 = ["near-vm-runner/force_wasmer2"]

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -48,6 +48,8 @@ protocol_feature_chunk_only_producers = ["nearcore/protocol_feature_chunk_only_p
 protocol_feature_routing_exchange_algorithm = ["nearcore/protocol_feature_routing_exchange_algorithm"]
 nightly_protocol_features = ["nearcore/nightly_protocol_features"]
 nightly_protocol = ["nearcore/nightly_protocol"]
+cpu_compatibility_checks = ["nearcore/cpu_compatibility_checks"]
+
 
 sandbox = ["nearcore/sandbox"]
 

--- a/neard/src/main.rs
+++ b/neard/src/main.rs
@@ -42,7 +42,14 @@ static ALLOC: MyAllocator<tikv_jemallocator::Jemalloc> =
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 fn main() {
-    near_primitives::cpu::ensure_cpu_compatibility(false);
+    if let Err(e) = near_primitives::cpu::verify_cpu_compatibility() {
+        if cfg!(feature = "cpu_compatibility_checks") {
+            eprintln!("error: {}\nnote: {}", e, near_primitives::cpu::Error::NOTE);
+            std::process::exit(1);
+        } else {
+            eprintln!("warning: {}\nnote: {}", e, near_primitives::cpu::Error::NOTE);
+        }
+    }
 
     // We use it to automatically search the for root certificates to perform HTTPS calls
     // (sending telemetry and downloading genesis)

--- a/neard/src/main.rs
+++ b/neard/src/main.rs
@@ -42,6 +42,8 @@ static ALLOC: MyAllocator<tikv_jemallocator::Jemalloc> =
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 fn main() {
+    near_primitives::cpu::ensure_cpu_compatibility(false);
+
     // We use it to automatically search the for root certificates to perform HTTPS calls
     // (sending telemetry and downloading genesis)
     openssl_probe::init_ssl_cert_env_vars();

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -55,7 +55,7 @@ base64 = "0.13"
 
 [features]
 # all vms enabled for now
-default = ["wasmer0_vm", "wasmtime_vm", "wasmer2_vm", "cpu_compatibility_checks"]
+default = ["wasmer0_vm", "wasmtime_vm", "wasmer2_vm"]
 wasmer0_vm = [ "wasmer-runtime", "wasmer-runtime-core" ]
 wasmtime_vm = [ "wasmtime", "anyhow"]
 wasmer2_vm = [ "wasmer", "wasmer-types", "wasmer-compiler-singlepass",  "wasmer-engine-universal", ]

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -55,7 +55,7 @@ base64 = "0.13"
 
 [features]
 # all vms enabled for now
-default = ["wasmer0_vm", "wasmtime_vm", "wasmer2_vm"]
+default = ["wasmer0_vm", "wasmtime_vm", "wasmer2_vm", "cpu_compatibility_checks"]
 wasmer0_vm = [ "wasmer-runtime", "wasmer-runtime-core" ]
 wasmtime_vm = [ "wasmtime", "anyhow"]
 wasmer2_vm = [ "wasmer", "wasmer-types", "wasmer-compiler-singlepass",  "wasmer-engine-universal", ]
@@ -66,7 +66,7 @@ force_wasmtime = ["wasmtime_vm"]
 force_wasmer2 = ["wasmer2_vm"]
 
 lightbeam = ["wasmtime/lightbeam"]
-no_cpu_compatibility_checks = []
+cpu_compatibility_checks = []
 
 no_cache = []
 

--- a/runtime/near-vm-runner/src/wasmer2_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer2_runner.rs
@@ -307,7 +307,9 @@ pub(crate) fn default_wasmer2_store() -> Store {
     let compiler = Singlepass::new();
     // We only support universal engine at the moment.
     assert_eq!(WASMER2_CONFIG.engine, WasmerEngine::Universal);
-    let target_features = if cfg!(feature = "no_cpu_compatibility_checks") {
+    let target_features = if cfg!(feature = "cpu_compatibility_checks") {
+        wasmer::CpuFeature::for_host()
+    } else {
         let mut fs = wasmer::CpuFeature::set();
         // These features should be sufficient to run the single pass compiler.
         fs.insert(wasmer::CpuFeature::SSE2);
@@ -318,8 +320,6 @@ pub(crate) fn default_wasmer2_store() -> Store {
         fs.insert(wasmer::CpuFeature::POPCNT);
         fs.insert(wasmer::CpuFeature::AVX);
         fs
-    } else {
-        wasmer::CpuFeature::for_host()
     };
     let engine = wasmer::Universal::new(compiler)
         .features(WASMER_FEATURES)

--- a/runtime/near-vm-runner/src/wasmer2_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer2_runner.rs
@@ -395,7 +395,6 @@ impl crate::runner::VM for Wasmer2VM {
             %method_name
         )
         .entered();
-
         if method_name.is_empty() {
             return (
                 None,

--- a/runtime/near-vm-runner/src/wasmer_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer_runner.rs
@@ -299,10 +299,8 @@ impl crate::runner::VM for Wasmer0VM {
                  architectures."
             );
         }
-        #[cfg(not(feature = "no_cpu_compatibility_checks"))]
-        if !is_x86_feature_detected!("avx") {
-            panic!("AVX support is required in order to run Wasmer VM Singlepass backend.");
-        }
+        near_primitives::cpu::ensure_cpu_compatibility(true);
+
         if method_name.is_empty() {
             return (
                 None,

--- a/runtime/near-vm-runner/src/wasmer_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer_runner.rs
@@ -299,7 +299,7 @@ impl crate::runner::VM for Wasmer0VM {
                  architectures."
             );
         }
-        near_primitives::cpu::ensure_cpu_compatibility(true);
+        near_primitives::cpu::ensure_cpu_compatibility(cfg!(feature = "cpu_compatibility_checks"));
 
         if method_name.is_empty() {
             return (

--- a/runtime/near-vm-runner/src/wasmer_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer_runner.rs
@@ -299,7 +299,8 @@ impl crate::runner::VM for Wasmer0VM {
                  architectures."
             );
         }
-        near_primitives::cpu::ensure_cpu_compatibility(cfg!(feature = "cpu_compatibility_checks"));
+        #[cfg(feature = "cpu_compatibility_checks")]
+        let _ = near_primitives::cpu::verify_cpu_compatibility().map_err(|e| e.terminate());
 
         if method_name.is_empty() {
             return (

--- a/runtime/runtime-params-estimator/Cargo.toml
+++ b/runtime/runtime-params-estimator/Cargo.toml
@@ -30,7 +30,7 @@ genesis-populate = { path = "../../genesis-tools/genesis-populate"}
 near-chain-configs = { path = "../../core/chain-configs" }
 near-crypto = { path = "../../core/crypto" }
 near-vm-logic = {path = "../../runtime/near-vm-logic"  }
-near-vm-runner = {path = "../../runtime/near-vm-runner" }
+near-vm-runner = {path = "../../runtime/near-vm-runner", default-features = false }
 node-runtime = { path = "../../runtime/runtime" }
 near-store = { path = "../../core/store" }
 near-primitives = { path = "../../core/primitives" }
@@ -52,7 +52,7 @@ wat = "1.0"
 default = ["costs_counting"]
 costs_counting = ["near-vm-logic/costs_counting"]
 # Required feature for proper config, but can't be enabled by default because it is leaked to other release crates.
-required = ["costs_counting", "near-vm-runner/no_cpu_compatibility_checks", "no_cache"]
+required = ["costs_counting", "no_cache"]
 no_cache = ["node-runtime/no_cache", "near-store/no_cache"]
 wasmtime = ["near-vm-runner/force_wasmtime"]
 lightbeam = ["wasmtime", "near-vm-runner/lightbeam"]

--- a/runtime/runtime-params-estimator/Cargo.toml
+++ b/runtime/runtime-params-estimator/Cargo.toml
@@ -30,7 +30,7 @@ genesis-populate = { path = "../../genesis-tools/genesis-populate"}
 near-chain-configs = { path = "../../core/chain-configs" }
 near-crypto = { path = "../../core/crypto" }
 near-vm-logic = {path = "../../runtime/near-vm-logic"  }
-near-vm-runner = {path = "../../runtime/near-vm-runner", default-features = false }
+near-vm-runner = {path = "../../runtime/near-vm-runner" }
 node-runtime = { path = "../../runtime/runtime" }
 near-store = { path = "../../core/store" }
 near-primitives = { path = "../../core/primitives" }

--- a/runtime/runtime-params-estimator/src/function_call.rs
+++ b/runtime/runtime-params-estimator/src/function_call.rs
@@ -51,7 +51,7 @@ fn test_function_call_time() {
 fn test_function_call_icount() {
     // Use smth like
     // CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER=./runner.sh \
-    // cargo test --release --features no_cpu_compatibility_checks,required  \
+    // cargo test --release --features required  \
     // --lib function_call::test_function_call_icount -- --exact --nocapture
     // Where runner.sh is
     // /host/nearcore/runtime/runtime-params-estimator/emu-cost/counter_plugin/qemu-x86_64 \

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -305,7 +305,14 @@ cargo build --manifest-path /host/nearcore/Cargo.toml \
         .args(&["--mount", "source=rust-emu-target-dir,target=/host/nearcore/target"])
         .args(&["--mount", "source=rust-emu-cargo-dir,target=/usr/local/cargo"])
         .args(&["--interactive", "--tty"])
-        .args(&["--env", "RUST_BACKTRACE=full"]);
+        .args(&["--env", "RUST_BACKTRACE=full"])
+        .args(&["--env", "CFLAGS=-mavx -mpopcnt -msse3 -mssse3 -msse4.1 -msse4.2 -msse4a -mcx16"])
+        .args(&["--env", "CXXFLAGS=-mavx -mpopcnt -msse3 -mssse3 -msse4.1 -msse4.2 -msse4a -mcx16"])
+        .args(&[
+            "--env",
+            "RUSTFLAGS=-D warnings -Ctarget-feature=\
+                       +avx,+cmpxchg16b,+popcnt,+sse3,+ssse3,+sse4.1,+sse4.2,+sse4a",
+        ]);
     if full {
         cmd.args(&["--env", "CARGO_PROFILE_RELEASE_LTO=fat"])
             .args(&["--env", "CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1"]);

--- a/runtime/runtime-params-estimator/src/vm_estimator.rs
+++ b/runtime/runtime-params-estimator/src/vm_estimator.rs
@@ -304,7 +304,6 @@ fn test_many_contracts_call_time() {
 fn test_many_contracts_call_icount() {
     // Use smth like
     // CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER=./runner.sh cargo test --release \
-    // --features near-vm-runner/no_cpu_compatibility_checks \
     // --lib vm_estimator::test_many_contracts_call_icount --no-fail-fast -- --exact --nocapture
     // Where runner.sh is
     // /host/nearcore/runtime/runtime-params-estimator/emu-cost/counter_plugin/qemu-x86_64 \

--- a/runtime/runtime/Cargo.toml
+++ b/runtime/runtime/Cargo.toml
@@ -35,11 +35,11 @@ near-vm-runner = { path = "../../runtime/near-vm-runner" }
 near-vm-errors = { path = "../../runtime/near-vm-errors" }
 
 [features]
-default = []
+default = ["cpu_compatibility_checks"]
 dump_errors_schema = ["near-vm-errors/dump_errors_schema"]
 protocol_feature_chunk_only_producers = ["near-primitives/protocol_feature_chunk_only_producers", "near-store/protocol_feature_chunk_only_producers", "near-chain-configs/protocol_feature_chunk_only_producers"]
 protocol_feature_access_key_nonce_for_implicit_accounts = ["near-primitives/protocol_feature_access_key_nonce_for_implicit_accounts"]
-no_cpu_compatibility_checks = ["near-vm-runner/no_cpu_compatibility_checks"]
+cpu_compatibility_checks = ["near-vm-runner/cpu_compatibility_checks"]
 
 no_cache = ["near-vm-runner/no_cache", "near-store/no_cache"]
 

--- a/runtime/runtime/Cargo.toml
+++ b/runtime/runtime/Cargo.toml
@@ -31,18 +31,16 @@ near-primitives = { path = "../../core/primitives" }
 near-store = { path = "../../core/store" }
 near-metrics = { path = "../../core/metrics" }
 near-vm-logic = { path = "../../runtime/near-vm-logic" }
-near-vm-runner = { path = "../../runtime/near-vm-runner" }
+near-vm-runner = { path = "../../runtime/near-vm-runner", default-features = false }
 near-vm-errors = { path = "../../runtime/near-vm-errors" }
 
 [features]
-default = ["cpu_compatibility_checks"]
+default = []
+cpu_compatibility_checks = ["near-vm-runner/cpu_compatibility_checks"]
 dump_errors_schema = ["near-vm-errors/dump_errors_schema"]
 protocol_feature_chunk_only_producers = ["near-primitives/protocol_feature_chunk_only_producers", "near-store/protocol_feature_chunk_only_producers", "near-chain-configs/protocol_feature_chunk_only_producers"]
 protocol_feature_access_key_nonce_for_implicit_accounts = ["near-primitives/protocol_feature_access_key_nonce_for_implicit_accounts"]
-cpu_compatibility_checks = ["near-vm-runner/cpu_compatibility_checks"]
-
 no_cache = ["near-vm-runner/no_cache", "near-store/no_cache"]
-
 protocol_feature_alt_bn128 = [
     "near-primitives/protocol_feature_alt_bn128",
     "near-vm-logic/protocol_feature_alt_bn128",

--- a/runtime/runtime/Cargo.toml
+++ b/runtime/runtime/Cargo.toml
@@ -31,7 +31,7 @@ near-primitives = { path = "../../core/primitives" }
 near-store = { path = "../../core/store" }
 near-metrics = { path = "../../core/metrics" }
 near-vm-logic = { path = "../../runtime/near-vm-logic" }
-near-vm-runner = { path = "../../runtime/near-vm-runner", default-features = false }
+near-vm-runner = { path = "../../runtime/near-vm-runner" }
 near-vm-errors = { path = "../../runtime/near-vm-errors" }
 
 [features]


### PR DESCRIPTION
This changeset does a couple different things. First and foremost it
makes `neard` verify the environment it is running in. It'll do so only
for production builds by default, making regular `cargo run` or `cargo
build` workflows work as usual.

However in production artifacts (as produced by `make release`, the
`cfg(near_production)` will be set, various CPU features will be enabled
for LLVM codegen purposes and the `neard` itself will verify that the
prerequisite features are available before it does anything else.

Note however, that there is no guarantee that the code, which runs before
`main` is invoked, avoids use of these potentially unsupported features,
possibly leading to less than stellar failure modes on machines which
wouldn't be able to run `neard` either way.

This may have an effect on gas costs for host functions, and for that
reason this change must not be merged before we quantify those changes.
As a less obvious outcome, this may also cause cost estimations done on
the production build differ from cost estimations done with a regular
`cargo built` code.