### PR TITLE
re: Add documentation to `near-network::ValidateEdgeList`

### DIFF
--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -1191,6 +1191,7 @@ impl PeerManagerActor {
             return;
         }
         self.routing_table_addr.do_send(ValidateEdgeList {
+            source_peer_id: peer_id,
             edges,
             edges_info_shared: self.routing_table_exchange_helper.edges_info_shared.clone(),
             sender: self.routing_table_exchange_helper.edges_to_add_sender.clone(),
@@ -1198,7 +1199,6 @@ impl PeerManagerActor {
             adv_disable_edge_signature_verification: self
                 .adv_helper
                 .adv_disable_edge_signature_verification,
-            source_peer_id: peer_id,
         });
     }
 

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -1198,7 +1198,7 @@ impl PeerManagerActor {
             adv_disable_edge_signature_verification: self
                 .adv_helper
                 .adv_disable_edge_signature_verification,
-            peer_id,
+            source_peer_id: peer_id,
         });
     }
 

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -422,7 +422,7 @@ impl Handler<ValidateEdgeList> for RoutingTableActor {
         self.edge_validator_requests_in_progress += 1;
         let mut msg = msg;
         msg.edges.retain(|x| self.is_edge_newer(x.key(), x.nonce()));
-        let peer_id = msg.peer_id.clone();
+        let peer_id = msg.source_peer_id.clone();
         self.edge_validator_pool
             .send(msg)
             .into_actor(self)

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -838,10 +838,12 @@ pub enum NetworkRequests {
     },
 }
 
+/// List of `Edges`, which we received from `source_peer_id` gor purpose of validation.
+/// Those are list of edges received through `NetworkRequests::Sync` or `NetworkRequests::IbfMessage`.
 pub struct ValidateEdgeList {
     /// List of Edges, which will be sent to `EdgeValidatorActor`.
     pub(crate) edges: Vec<Edge>,
-    /// A set of edges, which have been verified. This is used to avoid doing duplicated work by
+    /// A set of edges, which have been verified. This is a cache with all verified edges.
     /// `EdgeValidatorActor`, and is a source of memory leak.
     /// TODO(#5254): Simplify this process.
     pub(crate) edges_info_shared: Arc<Mutex<HashMap<(PeerId, PeerId), u64>>>,
@@ -853,7 +855,8 @@ pub struct ValidateEdgeList {
     #[cfg(feature = "test_features")]
     /// Feature to disable edge validation for purpose of testing.
     pub(crate) adv_disable_edge_signature_verification: bool,
-    /// Peer that may be banned if any of the edges are found to be invalid.
+    /// The list of edges is provided by `source_peer_id`, that peer will be banned
+    ///if any of these edges are invalid.
     pub(crate) source_peer_id: PeerId,
 }
 

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -845,7 +845,7 @@ pub struct ValidateEdgeList {
     /// `EdgeValidatorActor`, and is a source of memory leak.
     /// TODO(#5254): Simplify this process.
     pub(crate) edges_info_shared: Arc<Mutex<HashMap<(PeerId, PeerId), u64>>>,
-    /// A concurrent queue. After edge become validated. They will be sent from `EdgeValidatorActor` back to
+    /// A concurrent queue. After edge become validated it will be sent from `EdgeValidatorActor` back to
     /// `PeerManagetActor`, and then send to `RoutingTableActor`. And then `RoutingTableActor`
     /// will add them.
     /// TODO(#5254): Simplify this process.

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -841,6 +841,9 @@ pub enum NetworkRequests {
 /// List of `Edges`, which we received from `source_peer_id` gor purpose of validation.
 /// Those are list of edges received through `NetworkRequests::Sync` or `NetworkRequests::IbfMessage`.
 pub struct ValidateEdgeList {
+    /// The list of edges is provided by `source_peer_id`, that peer will be banned
+    ///if any of these edges are invalid.
+    pub(crate) source_peer_id: PeerId,
     /// List of Edges, which will be sent to `EdgeValidatorActor`.
     pub(crate) edges: Vec<Edge>,
     /// A set of edges, which have been verified. This is a cache with all verified edges.
@@ -855,9 +858,6 @@ pub struct ValidateEdgeList {
     #[cfg(feature = "test_features")]
     /// Feature to disable edge validation for purpose of testing.
     pub(crate) adv_disable_edge_signature_verification: bool,
-    /// The list of edges is provided by `source_peer_id`, that peer will be banned
-    ///if any of these edges are invalid.
-    pub(crate) source_peer_id: PeerId,
 }
 
 impl Message for ValidateEdgeList {

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -839,13 +839,13 @@ pub enum NetworkRequests {
 }
 
 pub struct ValidateEdgeList {
-    /// List of Edges, which will be sent to `EdgeVerifierActor`.
+    /// List of Edges, which will be sent to `EdgeValidatorActor`.
     pub(crate) edges: Vec<Edge>,
     /// A set of edges, which have been verified. This is used to avoid doing duplicated work by
-    /// `EdgeVerifierActor`, and is a source of memory leak.
+    /// `EdgeValidatorActor`, and is a source of memory leak.
     /// TODO(#5254): Simplify this process.
     pub(crate) edges_info_shared: Arc<Mutex<HashMap<(PeerId, PeerId), u64>>>,
-    /// A concurrent queue. After edge become validated. They will be sent from `EdgeVerifierActor` back to
+    /// A concurrent queue. After edge become validated. They will be sent from `EdgeValidatorActor` back to
     /// `PeerManagetActor`, and then send to `RoutingTableActor`. And then `RoutingTableActor`
     /// will add them.
     /// TODO(#5254): Simplify this process.

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -839,12 +839,22 @@ pub enum NetworkRequests {
 }
 
 pub struct ValidateEdgeList {
+    /// List of Edges, which will be sent to `EdgeVerifierActor`.
     pub(crate) edges: Vec<Edge>,
+    /// A set of edges, which have been verified. This is used to avoid doing duplicated work by
+    /// `EdgeVerifierActor`, and is a source of memory leak.
+    /// TODO(#5254): Simplify this process.
     pub(crate) edges_info_shared: Arc<Mutex<HashMap<(PeerId, PeerId), u64>>>,
+    /// A concurrent queue. After edge become validated. They will be sent from `EdgeVerifierActor` back to
+    /// `PeerManagetActor`, and then send to `RoutingTableActor`. And then `RoutingTableActor`
+    /// will add them.
+    /// TODO(#5254): Simplify this process.
     pub(crate) sender: QueueSender<Edge>,
     #[cfg(feature = "test_features")]
+    /// Feature to disable edge validation for purpose of testing.
     pub(crate) adv_disable_edge_signature_verification: bool,
-    pub(crate) peer_id: PeerId,
+    /// Peer that may be banned if any of the edges are found to be invalid.
+    pub(crate) source_peer_id: PeerId,
 }
 
 impl Message for ValidateEdgeList {


### PR DESCRIPTION
`ValidateEdgeList` doesn't have documentation. It will be easier to explain what it does once we add it.

That's useful for https://github.com/near/nearcore/issues/5156