### PR TITLE
re: WIP: Remove imports of `lazy_static`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2096,7 +2096,6 @@ dependencies = [
  "futures",
  "hex",
  "hyper",
- "lazy_static",
  "log",
  "near-actix-test-utils",
  "near-chain",
@@ -2839,7 +2838,6 @@ dependencies = [
 name = "near-metrics"
 version = "0.0.0"
 dependencies = [
- "lazy_static",
  "log",
  "prometheus",
 ]
@@ -2860,7 +2858,6 @@ dependencies = [
  "deepsize",
  "delay-detector",
  "futures",
- "lazy_static",
  "near-actix-test-utils",
  "near-chain",
  "near-crypto",
@@ -3008,7 +3005,6 @@ dependencies = [
  "futures",
  "hex",
  "insta",
- "lazy_static",
  "near-account-id",
  "near-chain-configs",
  "near-client",
@@ -3076,7 +3072,6 @@ dependencies = [
  "derive_more",
  "elastic-array",
  "fs2",
- "lazy_static",
  "near-crypto",
  "near-primitives",
  "num_cpus",

--- a/chain/jsonrpc/fuzz/Cargo.toml
+++ b/chain/jsonrpc/fuzz/Cargo.toml
@@ -15,7 +15,6 @@ actix = "=0.11.0-beta.2"
 actix_derive = "=0.6.0-beta.1" # Pinned dependency in addition to actix dependecy (remove this line once the pinning is not needed)
 arbitrary = { version = "0.4.7", features = ["derive"] }
 base64 = "0.13"
-lazy_static = "1.4"
 libfuzzer-sys = { version = "0.4", features = ["arbitrary-derive"] }
 once_cell = "1.5.2"
 rust-base58 = "0.0.4"

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -15,7 +15,6 @@ cached = "0.23"
 chrono = { version = "0.4.4", features = ["serde"] }
 conqueue = "0.4.0"
 futures = "0.3"
-lazy_static = "1.4"
 near-rust-allocator-proxy = "0.3.0"
 once_cell = "1.5.2"
 rand = "0.7"

--- a/chain/rosetta-rpc/Cargo.toml
+++ b/chain/rosetta-rpc/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2021"
 [dependencies]
 derive_more = "0.99.9"
 hex = "0.4"
-lazy_static = "1.4"
 strum = { version = "0.20", features = ["derive"] }
 
 awc = "3.0.0-beta.5"

--- a/core/metrics/Cargo.toml
+++ b/core/metrics/Cargo.toml
@@ -9,6 +9,5 @@ homepage = "https://github.com/near/nearcore"
 description = "A fork of the lighthouse_metrics crate used to implement prometheus"
 
 [dependencies]
-lazy_static = "1.4"
 prometheus = "0.11"
 log = "0.4"

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -11,7 +11,6 @@ byteorder = "1.2"
 bytesize = "1.1"
 derive_more = "0.99.3"
 elastic-array = "0.11"
-lazy_static = "1.4"
 rocksdb = "0.16.0"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -16,7 +16,6 @@ funty = "=1.1.0" # Pin dependency to avoid compilation errors: https://github.co
 futures = "0.3"
 hex = "0.4"
 hyper = { version = "0.14", features = ["full"] }
-lazy_static = "1.4"
 log = "0.4"
 portpicker = "0.1.1"
 primitive-types = "0.10.1"


### PR DESCRIPTION
Imports of `lazy_static` are no longer needed.

Blocked by #5374