### PR TITLE
re: Move `SandboxResponse` from `near-network` to `near-network-primivites`

### DIFF
--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -28,8 +28,6 @@ use near_chain_configs::ClientConfig;
 #[cfg(feature = "test_features")]
 use near_chain_configs::GenesisConfig;
 use near_crypto::Signature;
-#[cfg(feature = "sandbox")]
-use near_network::types::SandboxResponse;
 use near_network::types::{
     NetworkClientMessages, NetworkClientResponses, NetworkInfo, NetworkRequests,
     PeerManagerAdapter, PeerManagerMessageRequest,
@@ -365,7 +363,7 @@ impl Handler<NetworkClientMessages> for ClientActor {
                     }
                     NetworkSandboxMessage::SandboxPatchStateStatus => {
                         NetworkClientResponses::SandboxResult(
-                            SandboxResponse::SandboxPatchStateFinished(
+                            near_network_primitives::types::SandboxResponse::SandboxPatchStateFinished(
                                 !self.client.chain.patch_state_in_progress(),
                             ),
                         )

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -1098,7 +1098,7 @@ impl JsonRpcHandler {
                     ))
                     .await;
                 if let Ok(NetworkClientResponses::SandboxResult(
-                              near_network::types::SandboxResponse::SandboxPatchStateFinished(true),
+                              near_network_primitives::types::SandboxResponse::SandboxPatchStateFinished(true),
                 )) = patch_state_finished
                 {
                     break;

--- a/chain/network-primitives/src/types.rs
+++ b/chain/network-primitives/src/types.rs
@@ -896,6 +896,12 @@ pub enum NetworkSandboxMessage {
     SandboxPatchStateStatus,
 }
 
+#[cfg(feature = "sandbox")]
+#[derive(Eq, PartialEq, Debug)]
+pub enum SandboxResponse {
+    SandboxPatchStateFinished(bool),
+}
+
 #[derive(AsStaticStr)]
 pub enum NetworkViewClientMessages {
     #[cfg(feature = "test_features")]
@@ -1029,7 +1035,7 @@ pub struct PartialEncodedChunkResponseMsg {
 }
 
 /// Message for chunk part owners to forward their parts to validators tracking that shard.
-/// This reduces the number of requests a node tracking a shard needs to send to obtain enough
+// This reduces the number of requests a node tracking a shard needs to send to obtain enough
 /// parts to reconstruct the message (in the best case no such requests are needed).
 #[cfg_attr(feature = "deepsize_feature", derive(DeepSizeOf))]
 #[derive(Clone, Debug, Eq, PartialEq, BorshSerialize, BorshDeserialize)]

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -606,7 +606,7 @@ pub enum NetworkClientResponses {
 
     /// Sandbox controls
     #[cfg(feature = "sandbox")]
-    SandboxResult(SandboxResponse),
+    SandboxResult(near_network_primitives::types::SandboxResponse),
 
     /// No response.
     NoResponse,
@@ -621,12 +621,6 @@ pub enum NetworkClientResponses {
     DoesNotTrackShard,
     /// Ban peer for malicious behavior.
     Ban { ban_reason: ReasonForBan },
-}
-
-#[cfg(feature = "sandbox")]
-#[derive(Eq, PartialEq, Debug)]
-pub enum SandboxResponse {
-    SandboxPatchStateFinished(bool),
 }
 
 impl<A, M> MessageResponse<A, M> for NetworkClientResponses


### PR DESCRIPTION
Move `SandboxResonse` from `near-network` to `near-network-primivites`.

Current `NetworkSandboxMessage` is inside `near-network-primitives`, while `NetworkSandboxResponse` is in `near-network`.
Let's put those two together.
```
#[cfg(feature = "sandbox")]
#[derive(Debug)]
pub enum NetworkSandboxMessage {
    SandboxPatchState(Vec<near_primitives::state_record::StateRecord>),
    SandboxPatchStateStatus,
}
```