### PR TITLE
fix: `PeerActorManager`: Remove hidden overflows

### DIFF
--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -838,7 +838,11 @@ impl PeerManagerActor {
         self.active_peers
             .values()
             .filter_map(|active_peer| {
-                if active_peer.full_peer_info.chain_info.height + self.config.highest_peer_horizon
+                if active_peer
+                    .full_peer_info
+                    .chain_info
+                    .height
+                    .saturating_add(self.config.highest_peer_horizon)
                     >= max_height
                 {
                     Some(active_peer.full_peer_info.clone())


### PR DESCRIPTION
Adding a value to `active_peer.full_peer_info.chain_info.height`  could potentially cause an overflow error. It's better to use saturating add.

Refactor afterwards: https://github.com/near/nearcore/pull/5524