### PR TITLE
pytest: make A/B tests against latest deployed mainnet binary

### DIFF
--- a/pytest/lib/branches.py
+++ b/pytest/lib/branches.py
@@ -5,9 +5,13 @@ import sys
 import tempfile
 import typing
 
+import requests
 import semver
 from configured_logger import logger
-from github import Github
+
+_UNAME = os.uname()[0]
+_IS_DARWIN = _UNAME == 'Darwin'
+_BASEHREF = 'https://s3-us-west-1.amazonaws.com/build.nearprotocol.com'
 
 
 def current_branch():
@@ -16,34 +20,22 @@ def current_branch():
     ]).strip().decode()
 
 
-def get_releases():
-    git = Github(None)
-    repo = git.get_repo("nearprotocol/nearcore")
-    releases = []
+def __get_latest_deploy(chain_id: str) -> typing.Tuple[str, str]:
+    """Returns latest (release, deploy) for given chain."""
+    basehref = f'{_BASEHREF}/nearcore-deploy/{chain_id}'
 
-    for release in repo.get_releases():
-        try:
-            # make sure that the version provided is a valid semver version
-            version = semver.VersionInfo.parse(release.title)
-            releases.append(release)
-        except Exception as e:
-            pass
+    def download(url: str) -> str:
+        res = requests.get(url)
+        res.raise_for_status()
+        return res.text
 
-    return sorted(releases,
-                  key=lambda release: semver.VersionInfo.parse(release.title),
-                  reverse=True)
+    release = download(basehref + '/latest_release')
+    if release != 'master':
+        # Make sure it parses as a version
+        release = str(semver.VersionInfo.parse(release).finalize_version())
+    deploy = download(basehref + '/latest_deploy')
 
-
-def latest_rc_branch():
-    releases = list(
-        filter(
-            lambda release: (semver.VersionInfo.parse(release.title).prerelease
-                             or "").startswith("rc"), get_releases()))
-
-    if not releases:
-        return None
-
-    return semver.VersionInfo.parse(releases[0].title).finalize_version()
+    return release, deploy
 
 
 class Executables(typing.NamedTuple):
@@ -94,7 +86,7 @@ def _compile_current(branch: str) -> Executables:
     return Executables(build_dir, neard, state_viewer)
 
 
-def download_file_if_missing(filename: pathlib.Path, url: str) -> None:
+def __download_file_if_missing(filename: pathlib.Path, url: str) -> None:
     """Downloads a file from given URL if it does not exist already.
 
     Does nothing if file `filename` already exists.  Otherwise, downloads data
@@ -112,13 +104,14 @@ def download_file_if_missing(filename: pathlib.Path, url: str) -> None:
             sys.exit(f'{filename} exists but is not a file')
         return
 
-    proto = '"=https"' if os.uname()[0] == 'Darwin' else '=https'
+    proto = '"=https"' if _IS_DARWIN else '=https'
     cmd = ('curl', '--proto', proto, '--tlsv1.2', '-sSfL', url)
     name = None
     try:
         with tempfile.NamedTemporaryFile(dir=filename.parent,
                                          delete=False) as tmp:
             name = pathlib.Path(tmp.name)
+            logger.debug('Executing ' + ' '.join(cmd))
             subprocess.check_call(cmd, stdout=tmp)
         name.chmod(0o555)
         name.rename(filename)
@@ -128,34 +121,44 @@ def download_file_if_missing(filename: pathlib.Path, url: str) -> None:
             name.unlink()
 
 
-def download_binary(uname, branch):
-    """Download binary for given platform and branch."""
-    logger.info(f'Getting near & state-viewer for {branch}@{uname}')
+def __download_binary(release: str, deploy: str) -> Executables:
+    """Download binary for given release and deploye."""
+    logger.info(f'Getting neard and state-viewer for {release}@{_UNAME} '
+                f'(deploy={deploy})')
     outdir = pathlib.Path('../target/debug')
-    basehref = ('https://s3-us-west-1.amazonaws.com/build.nearprotocol.com'
-                f'/nearcore/{uname}/{branch}/')
-    neard = outdir / f'neard-{branch}'
-    state_viewer = outdir / f'state-viewer-{branch}'
-    download_file_if_missing(neard, basehref + 'neard')
-    download_file_if_missing(state_viewer, basehref + 'state-viewer')
+    neard = outdir / f'neard-{release}-{deploy}'
+    state_viewer = outdir / f'state-viewer-{release}-{deploy}'
+    basehref = f'{_BASEHREF}/nearcore/{_UNAME}/{release}/{deploy}'
+    __download_file_if_missing(neard, basehref + '/neard')
+    __download_file_if_missing(state_viewer, basehref + '/state-viewer')
     return Executables(outdir, neard, state_viewer)
 
 
 class ABExecutables(typing.NamedTuple):
     stable: Executables
     current: Executables
+    release: str
+    deploy: str
 
 
-def prepare_ab_test(stable_branch):
-    # Use NEAR_AB_BINARY_EXISTS to avoid rebuild / re-download when testing locally.
-    #if not os.environ.get('NEAR_AB_BINARY_EXISTS'):
-    #    _compile_current(current_branch())
-    #    uname = os.uname()[0]
-    #    if stable_branch in ['master', 'beta', 'stable'] and uname in ['Linux', 'Darwin']:
-    #        download_binary(uname, stable_branch)
-    #    else:
+def prepare_ab_test(chain_id: str = 'mainnet') -> ABExecutables:
+    """Prepares executable at HEAD and latest deploy at given chain.
+
+    Args:
+        chain_id: Chain id to get latest deployed executable for.  Can be
+            ‘master’, ‘testnet’ or ‘betanet’.
+    Returns:
+        An ABExecutables object where `current` describes executable built at
+        current HEAD while `stable` points at executable which is deployed in
+        production at given chain.  `release` and `deploy` of the returned
+        object specify, well, the latest release and deploy running in
+        production at the chain.
+    """
+    if chain_id not in ('mainnet', 'testnet', 'betanet'):
+        raise ValueError(f'Unexpected chain_id: {chain_id}; '
+                         'expected mainnet, testnet or betanet')
+
     is_nayduck = bool(os.getenv('NAYDUCK'))
-
     if is_nayduck:
         # On NayDuck the file is fetched from a builder host so there’s no need
         # to build it.
@@ -164,10 +167,15 @@ def prepare_ab_test(stable_branch):
     else:
         current = _compile_current(current_branch())
 
+    release, deploy = __get_latest_deploy(chain_id)
     try:
-        stable = download_binary(os.uname()[0], stable_branch)
-    except Exception:
+        stable = __download_binary(release, deploy)
+    except Exception as e:
         if is_nayduck:
-            sys.exit('RC binary should be downloaded for NayDuck.')
-        stable = _compile_binary(str(stable_branch))
-    return ABExecutables(stable=stable, current=current)
+            logger.exception('RC binary should be downloaded for NayDuck.', e)
+        stable = _compile_binary(release)
+
+    return ABExecutables(stable=stable,
+                         current=current,
+                         release=release,
+                         deploy=deploy)

--- a/pytest/lib/branches.py
+++ b/pytest/lib/branches.py
@@ -21,19 +21,24 @@ def current_branch():
 
 
 def __get_latest_deploy(chain_id: str) -> typing.Tuple[str, str]:
-    """Returns latest (release, deploy) for given chain."""
-    basehref = f'{_BASEHREF}/nearcore-deploy/{chain_id}'
+    """Returns latest (release, deploy) for given chain.
+
+    Gets latest release and deploy identifier from S3 for given chain.  Those
+    can be used to uniquely identify a neard executable running on the chain.
+    """
 
     def download(url: str) -> str:
         res = requests.get(url)
         res.raise_for_status()
         return res.text
 
-    release = download(basehref + '/latest_release')
+    basehref = f'{_BASEHREF}/nearcore-deploy/{chain_id}'
+    release = download(f'{basehref}/latest_release')
+    deploy = download(f'{basehref}/latest_deploy')
+
     if release != 'master':
         # Make sure it parses as a version
         release = str(semver.VersionInfo.parse(release).finalize_version())
-    deploy = download(basehref + '/latest_deploy')
 
     return release, deploy
 
@@ -129,8 +134,8 @@ def __download_binary(release: str, deploy: str) -> Executables:
     neard = outdir / f'neard-{release}-{deploy}'
     state_viewer = outdir / f'state-viewer-{release}-{deploy}'
     basehref = f'{_BASEHREF}/nearcore/{_UNAME}/{release}/{deploy}'
-    __download_file_if_missing(neard, basehref + '/neard')
-    __download_file_if_missing(state_viewer, basehref + '/state-viewer')
+    __download_file_if_missing(neard, f'{basehref}/neard')
+    __download_file_if_missing(state_viewer, f'{basehref}/state-viewer')
     return Executables(outdir, neard, state_viewer)
 
 

--- a/pytest/tests/sanity/backward_compatible.py
+++ b/pytest/tests/sanity/backward_compatible.py
@@ -21,8 +21,7 @@ from transaction import sign_deploy_contract_tx, sign_function_call_tx, sign_pay
 
 def main():
     node_root = get_near_tempdir('backward', clean=True)
-    branch = branches.latest_rc_branch()
-    executables = branches.prepare_ab_test(branch)
+    executables = branches.prepare_ab_test()
 
     # Setup local network.
     subprocess.check_call([

--- a/pytest/tests/sanity/db_migration.py
+++ b/pytest/tests/sanity/db_migration.py
@@ -54,7 +54,7 @@ def send_some_tx(node):
 
 
 def main():
-    executables = branches.prepare_ab_test('master')
+    executables = branches.prepare_ab_test()
     node_root = get_near_tempdir('db_migration', clean=True)
 
     logging.info(f"The near root is {executables.stable.root}...")

--- a/pytest/tests/sanity/state_migration.py
+++ b/pytest/tests/sanity/state_migration.py
@@ -24,7 +24,7 @@ from utils import wait_for_blocks_or_timeout, get_near_tempdir
 
 def main():
     node_root = get_near_tempdir('state_migration', clean=True)
-    executables = branches.prepare_ab_test('beta')
+    executables = branches.prepare_ab_test('betanet')
 
     # Run stable node for few blocks.
     subprocess.call([

--- a/pytest/tests/sanity/upgradable.py
+++ b/pytest/tests/sanity/upgradable.py
@@ -25,9 +25,8 @@ _EXECUTABLES = None
 def get_executables() -> branches.ABExecutables:
     global _EXECUTABLES
     if _EXECUTABLES is None:
-        branch = branches.latest_rc_branch()
-        logger.info(f"Latest rc release branch is {branch}")
-        _EXECUTABLES = branches.prepare_ab_test(branch)
+        _EXECUTABLES = branches.prepare_ab_test()
+        logger.info(f"Latest mainnet release is {_EXECUTABLES.release}")
     return _EXECUTABLES
 
 


### PR DESCRIPTION
Use latest_release and latest_deploy data stored on S3 rather than
relying on GitHub releases to figure out what is the latest binary run
on mainnet for performing A/B tests.

This fixes issues around release time when our CI suddenly breaks when
a new rc is made without it yet being released on either testnet or
mainnet.

For example, once 1.42.0-rc1 is release on GitHub, the code expects to
download a 1.42.0 binary from S3 regardless of whether such release
has been deployed or not.  With this change, the code will look at the
actual executable that is running in production on mainnet.

This also makes sure that all our tests are performed against what is
running on mainnet so that we can confirm that upgrading from mainnet
to current HEAD is possible.

Fixes: https://github.com/near/nearcore/issues/4956