### PR TITLE
fix: Add debug logs to `upgradable.py` in case of failure.

### DIFF
--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -229,13 +229,14 @@ class BaseNode(object):
     def get_validators(self):
         return self.json_rpc('validators', [None])
 
-    def get_account(self, acc, finality='optimistic'):
+    def get_account(self, acc, finality='optimistic', do_assert=True):
         res = self.json_rpc('query', {
             "request_type": "view_account",
             "account_id": acc,
             "finality": finality
         })
-        assert 'error' not in res, res
+        if do_assert:
+            assert 'error' not in res, res
 
         return res
 

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -230,11 +230,14 @@ class BaseNode(object):
         return self.json_rpc('validators', [None])
 
     def get_account(self, acc, finality='optimistic'):
-        return self.json_rpc('query', {
+        res = self.json_rpc('query', {
             "request_type": "view_account",
             "account_id": acc,
             "finality": finality
         })
+        assert 'error' not in res, res
+
+        return res
 
     def call_function(self,
                       acc,

--- a/pytest/tests/sanity/rosetta.py
+++ b/pytest/tests/sanity/rosetta.py
@@ -326,7 +326,7 @@ class RosettaTestCase(unittest.TestCase):
             require: If True, require that the account exists.
         """
         account_id = account.account_id
-        result = self.node.get_account(account_id)
+        result = self.node.get_account(account_id, do_assert=False)
         error = result.get('error')
         if error is None:
             amount = int(result['result']['amount'])


### PR DESCRIPTION
We've been experiencing random test failures of `upgradable.py` see https://github.com/near/nearcore/pull/5524

'query' jsonrpc return an 'account' information, or an error json response, in case account is not found.
Let's start by printing the full response, this will allow us to see what the issue is.