### PR TITLE
feat: Switch tests to use `pytest` instead of `python3` by default

### DIFF
--- a/pytest/tests/adversarial/fork_sync.py
+++ b/pytest/tests/adversarial/fork_sync.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Spins up four validating nodes. Wait until they produce 20 blocks.
 # Kill the first two nodes, let the rest two produce 30 blocks.
 # Kill the remaining two and restart the first two. Let them produce also 30 blocks

--- a/pytest/tests/adversarial/gc_rollback.py
+++ b/pytest/tests/adversarial/gc_rollback.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Builds the following graph:
 # -------
 #    \

--- a/pytest/tests/adversarial/malicious_chain.py
+++ b/pytest/tests/adversarial/malicious_chain.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 import sys, time
 import pathlib
 

--- a/pytest/tests/adversarial/start_from_genesis.py
+++ b/pytest/tests/adversarial/start_from_genesis.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 import sys, time
 import pathlib
 

--- a/pytest/tests/adversarial/wrong_sync_info.py
+++ b/pytest/tests/adversarial/wrong_sync_info.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Runs two nodes, waits until they create some blocks.
 # Launches a third observing node, makes it connect to an
 # adversarial node that reports inflated sync info. Makes

--- a/pytest/tests/contracts/deploy_call_smart_contract.py
+++ b/pytest/tests/contracts/deploy_call_smart_contract.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 """Deploy a smart contract on one node and call it on another."""
 
 import base58

--- a/pytest/tests/contracts/gibberish.py
+++ b/pytest/tests/contracts/gibberish.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Experiments with deploying gibberish contracts. Specifically,
 # 1. Deploys completely gibberish contracts
 # 2. Gets an existing wasm contract, and tries to arbitrarily pertrurb bytes in it

--- a/pytest/tests/contracts/infinite_loops.py
+++ b/pytest/tests/contracts/infinite_loops.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Spins up four nodes, deploy an smart contract to one node,
 # Call a smart contract method in another node
 import sys, time

--- a/pytest/tests/delete_remote_nodes.py
+++ b/pytest/tests/delete_remote_nodes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 
 # When script exit with traceback, remote node is not deleted. This script is
 # to delete remote machines so test can be rerun

--- a/pytest/tests/mocknet/bounce.py
+++ b/pytest/tests/mocknet/bounce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Stop all mocknet nodes, wait 1s, then start all nodes again.
 # Nodes should be responsive again after this operation.
 

--- a/pytest/tests/mocknet/helpers/genesis_updater.py
+++ b/pytest/tests/mocknet/helpers/genesis_updater.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 """
 Creates a genesis file from a template.
 This file is uploaded to each mocknet node and run on the node, producing identical genesis files across all nodes.

--- a/pytest/tests/mocknet/helpers/load_test_spoon_helper.py
+++ b/pytest/tests/mocknet/helpers/load_test_spoon_helper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 """
 Generates transactions on a mocknet node.
 This file is uploaded to each mocknet node and run there.

--- a/pytest/tests/mocknet/helpers/load_testing_add_and_delete_helper.py
+++ b/pytest/tests/mocknet/helpers/load_testing_add_and_delete_helper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # This file is uploaded to each mocknet node and run there.
 # It is responsible for making the node send many transactions
 # to itself.

--- a/pytest/tests/mocknet/load_test_spoon.py
+++ b/pytest/tests/mocknet/load_test_spoon.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 """
 Runs a loadtest on mocknet.
 

--- a/pytest/tests/rosetta/account-delete.py
+++ b/pytest/tests/rosetta/account-delete.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 import base58
 import json
 import os

--- a/pytest/tests/runtime/fuzz.py
+++ b/pytest/tests/runtime/fuzz.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 import os
 import subprocess
 import sys

--- a/pytest/tests/sandbox/patch_state.py
+++ b/pytest/tests/sandbox/patch_state.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Patch contract states in a sandbox node
 
 import sys, time

--- a/pytest/tests/sanity/backward_compatible.py
+++ b/pytest/tests/sanity/backward_compatible.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 """
 This script runs node from stable branch and from current branch and makes
 sure they are backward compatible.

--- a/pytest/tests/sanity/block_chunk_signature.py
+++ b/pytest/tests/sanity/block_chunk_signature.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Test for #3368
 #
 # Create a proxy that nullifies chunk signatures in blocks, test that blocks get rejected.

--- a/pytest/tests/sanity/block_production.py
+++ b/pytest/tests/sanity/block_production.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Spins up four nodes, and waits until they produce 50 blocks.
 # Ensures that the nodes remained in sync throughout the process
 # Sets epoch length to 10

--- a/pytest/tests/sanity/block_sync.py
+++ b/pytest/tests/sanity/block_sync.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Spins up two validating nodes. Make one validator produce block every 100 seconds.
 # Let the validators produce blocks for a while and then shut one of them down, remove data and restart.
 # Check that it can sync to the validator through block sync.

--- a/pytest/tests/sanity/block_sync_archival.py
+++ b/pytest/tests/sanity/block_sync_archival.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Spins up one validating node and one non-validating node that is archival. Let the validating node run
 # for a while and make sure that the archival node will sync all blocks.
 

--- a/pytest/tests/sanity/concurrent_function_calls.py
+++ b/pytest/tests/sanity/concurrent_function_calls.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Spins up four nodes, deploy an smart contract to one node,
 # Call a smart contract method in another node
 

--- a/pytest/tests/sanity/epoch_switches.py
+++ b/pytest/tests/sanity/epoch_switches.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Spins up four nodes, and alternates [test1, test2] and [test3, test4] as block producers every epoch
 # Makes sure that before the epoch switch each block is signed by all four
 

--- a/pytest/tests/sanity/garbage_collection.py
+++ b/pytest/tests/sanity/garbage_collection.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Spins up two validating nodes. Stop one of them and make another one produce
 # sufficient number of blocks. Restart the stopped node and check that it can
 # still sync.

--- a/pytest/tests/sanity/garbage_collection1.py
+++ b/pytest/tests/sanity/garbage_collection1.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Spins up three validating nodes with stake distribution 11, 5, 5.
 # Stop the two nodes with stake 2
 # Wait for sufficient number of blocks.

--- a/pytest/tests/sanity/garbage_collection_sharding_upgrade.py
+++ b/pytest/tests/sanity/garbage_collection_sharding_upgrade.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Spins up two validating nodes. The nodes start with 1 shard and will update to 4 shards
 # Stop one of them and make another one produce
 # sufficient number of blocks. Restart the stopped node and check that it can

--- a/pytest/tests/sanity/gc_after_sync.py
+++ b/pytest/tests/sanity/gc_after_sync.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Spins up three validating nodes. Stop one of them and make another one produce
 # sufficient number of blocks. Restart the stopped node and check that it can
 # still sync. Then check all old data is removed.

--- a/pytest/tests/sanity/gc_after_sync1.py
+++ b/pytest/tests/sanity/gc_after_sync1.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Spin up one validating node and one nonvalidating node
 # stop the nonvalidating node in the second epoch and
 # restart it in the fourth epoch to trigger state sync

--- a/pytest/tests/sanity/gc_sync_after_sync.py
+++ b/pytest/tests/sanity/gc_sync_after_sync.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Spins up three validating nodes. Stop one of them and make another one produce
 # sufficient number of blocks. Restart the stopped node and check that it can
 # still sync. Repeat. Then check all old data is removed.

--- a/pytest/tests/sanity/handshake_tie_resolution.py
+++ b/pytest/tests/sanity/handshake_tie_resolution.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 """
 Spawn a cluster with four nodes. Check that no node tries to
 connect to another node that is currently connected.

--- a/pytest/tests/sanity/large_messages.py
+++ b/pytest/tests/sanity/large_messages.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 import sys, time
 import socket, struct, multiprocessing
 import pathlib

--- a/pytest/tests/sanity/lightclnt.py
+++ b/pytest/tests/sanity/lightclnt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Generates three epochs worth of blocks
 # Requests next light client block until it reaches the last final block.
 # Verifies that the returned blocks are what we expect, and runs the validation on them

--- a/pytest/tests/sanity/network_drop_package.py
+++ b/pytest/tests/sanity/network_drop_package.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 import sys, time, random
 import multiprocessing
 import logging

--- a/pytest/tests/sanity/one_val.py
+++ b/pytest/tests/sanity/one_val.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Creates a genesis config with two block producers, and kills one right away after
 # launch. Makes sure that the other block producer can produce blocks with chunks and
 # process transactions. Makes large-ish number of block producers per shard to minimize

--- a/pytest/tests/sanity/proxy_example.py
+++ b/pytest/tests/sanity/proxy_example.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # This test is an example about how to use the proxy features.
 #
 # Create two nodes and add a proxy between them.

--- a/pytest/tests/sanity/proxy_restart.py
+++ b/pytest/tests/sanity/proxy_restart.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Start two nodes. Proxify both nodes. Kill one of them, restart it
 # and wait until block at height >= 20.
 import sys, time

--- a/pytest/tests/sanity/proxy_simple.py
+++ b/pytest/tests/sanity/proxy_simple.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Start two nodes. Proxify both nodes
 # and wait until block at height >= 10 pass through the proxy.
 import sys, time

--- a/pytest/tests/sanity/repro_2916.py
+++ b/pytest/tests/sanity/repro_2916.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Spins up two nodes with two shards, waits for couple blocks, snapshots the
 # latest chunks, and requests both chunks from the first node, asking for
 # receipts for both shards in both requests. We expect the first node to

--- a/pytest/tests/sanity/restaked.py
+++ b/pytest/tests/sanity/restaked.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Spins up four validating nodes, and kills one of them.
 # Starts a restaking service that keeps this node still as an active validator as it gets kicked out.
 # Ensures that this node is current validator after 5 epochs.

--- a/pytest/tests/sanity/restart.py
+++ b/pytest/tests/sanity/restart.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Spins up two nodes, and waits until they produce 20 blocks.
 # Kills the nodes, restarts them, makes sure they produce 20 more blocks
 # Sets epoch length to 10

--- a/pytest/tests/sanity/routing_table_sync.py
+++ b/pytest/tests/sanity/routing_table_sync.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Simulates routing table exchange with two nodes A, B. We are testing a few test cases depending on the number of
 # edges A, has but B doesn't and vise-versa. For each configuration, we simulate doing routing table exchange, and
 # we check whenever both have the same version of routing table at the end.

--- a/pytest/tests/sanity/rpc_finality.py
+++ b/pytest/tests/sanity/rpc_finality.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # The test launches two validating node out of three validators.
 # Transfer some tokens between two accounts (thus changing state).
 # Query for no finality, doomslug finality

--- a/pytest/tests/sanity/rpc_light_client_execution_outcome_proof.py
+++ b/pytest/tests/sanity/rpc_light_client_execution_outcome_proof.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Spins up two nodes, deploy a smart contract to one node,
 # Send a transaction to call a contract method. Check that
 # the transaction and receipts execution outcome proof for

--- a/pytest/tests/sanity/rpc_max_gas_burnt.py
+++ b/pytest/tests/sanity/rpc_max_gas_burnt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 """Test max_gas_burnt_view client configuration.
 
 Spins up two nodes with different max_gas_burnt_view client configuration,

--- a/pytest/tests/sanity/rpc_state_changes.py
+++ b/pytest/tests/sanity/rpc_state_changes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Spins up four nodes, deploy a smart contract to one node,
 # and call various scenarios to trigger store changes.
 # Check that the key changes are observable via `changes` RPC call.

--- a/pytest/tests/sanity/rpc_tx_forwarding.py
+++ b/pytest/tests/sanity/rpc_tx_forwarding.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # The test launches two validating node and two observers
 # The first observer tracks no shards, the second observer tracks all shards
 # The second observer is used to query balances

--- a/pytest/tests/sanity/rpc_tx_status.py
+++ b/pytest/tests/sanity/rpc_tx_status.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 import base58
 import json
 import struct

--- a/pytest/tests/sanity/rpc_tx_submission.py
+++ b/pytest/tests/sanity/rpc_tx_submission.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # test various ways of submitting transactions (broadcast_tx_async, broadcast_tx_sync, broadcast_tx_commit)
 
 import sys, time, base58, base64

--- a/pytest/tests/sanity/skip_epoch.py
+++ b/pytest/tests/sanity/skip_epoch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Tests a situation when in a given shard has all BPs offline
 # Two specific cases:
 #  - BPs never showed up to begin with, since genesis

--- a/pytest/tests/sanity/spin_up_cluster.py
+++ b/pytest/tests/sanity/spin_up_cluster.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 """Spins up a two-node cluster and wait for a few blocks to be produced."""
 
 import sys

--- a/pytest/tests/sanity/staking1.py
+++ b/pytest/tests/sanity/staking1.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Spins up with two validators, and one non-validator
 # Stakes for the non-validators, ensures it becomes a validator
 # Unstakes for them, makes sure they stop being a validator

--- a/pytest/tests/sanity/staking2.py
+++ b/pytest/tests/sanity/staking2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Runs randomized staking transactions and makes some basic checks on the final `staked` values
 # In each epoch sends two sets of staking transactions, one when (last_height % 12 == 4), called "fake", and
 # one when (last_height % 12 == 7), called "real" (because the former will be overwritten by the later).

--- a/pytest/tests/sanity/staking_repro1.py
+++ b/pytest/tests/sanity/staking_repro1.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # reproduces one of the bugs discovered by `staking2.py`
 
 from staking2 import doit

--- a/pytest/tests/sanity/staking_repro2.py
+++ b/pytest/tests/sanity/staking_repro2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # reproduces one of the bugs discovered by `staking2.py`
 
 from staking2 import doit

--- a/pytest/tests/sanity/state_sync.py
+++ b/pytest/tests/sanity/state_sync.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Spins up a node, then waits for couple epochs
 # and spins up another node
 # Makes sure that eventually the second node catches up

--- a/pytest/tests/sanity/state_sync1.py
+++ b/pytest/tests/sanity/state_sync1.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Spins up two out of three validating nodes. Waits until they reach height 40.
 # Start the last validating node and check that the second node can sync up before
 # the end of epoch and produce blocks and chunks.

--- a/pytest/tests/sanity/state_sync2.py
+++ b/pytest/tests/sanity/state_sync2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Spins up two block producing nodes. Uses a large number of block producer seats to ensure
 # both block producers are validating both shards.
 # Gets to 105 blocks and nukes + wipes one of the block producers. Makes sure it can recover

--- a/pytest/tests/sanity/state_sync3.py
+++ b/pytest/tests/sanity/state_sync3.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Spin up one validating node and make it produce blocks for more than one epoch
 # spin up another node that tracks the shard, make sure that it can state sync into the first node
 

--- a/pytest/tests/sanity/state_sync4.py
+++ b/pytest/tests/sanity/state_sync4.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Spin up one node and create some accounts and make them stake
 # Spin up another node that syncs from the first node.
 # Check that the second node doesn't crash (with trie node missing)

--- a/pytest/tests/sanity/state_sync5.py
+++ b/pytest/tests/sanity/state_sync5.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Spin up one validator node and let it run for a while
 # Spin up another node that does state sync. Keep sending
 # transactions to that node and make sure it doesn't crash.

--- a/pytest/tests/sanity/state_sync_fail.py
+++ b/pytest/tests/sanity/state_sync_fail.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Spins up a node, wait until sharding is upgrade
 # and spins up another node
 # check that the node can't be started because it cannot state sync to the epoch

--- a/pytest/tests/sanity/state_sync_late.py
+++ b/pytest/tests/sanity/state_sync_late.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Spins up a node, then waits for five+ epochs
 # and spins up another node
 # Makes sure that eventually the second node catches up

--- a/pytest/tests/sanity/state_sync_massive.py
+++ b/pytest/tests/sanity/state_sync_massive.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Survive massive state sync
 #
 # Create 3 nodes, 1 validator and 2 observers tracking the single shard 0.

--- a/pytest/tests/sanity/state_sync_massive_validator.py
+++ b/pytest/tests/sanity/state_sync_massive_validator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 """
 Survive massive state sync for validator
 

--- a/pytest/tests/sanity/state_sync_routed.py
+++ b/pytest/tests/sanity/state_sync_routed.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Spins two block producers and two observers.
 # Wait several epochs and spin up another observer that
 # is blacklisted by both block producers.

--- a/pytest/tests/sanity/switch_node_key.py
+++ b/pytest/tests/sanity/switch_node_key.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Spin up two validating nodes. Stop one of them after one epoch, switch node key (peer id), and restart.
 # Make sure that both node can still produce blocks.
 

--- a/pytest/tests/sanity/sync_ban.py
+++ b/pytest/tests/sanity/sync_ban.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Spin up a validator node and a nonvalidator node.
 # Stop the nonvalidator node and wait until the validator node reach height 100
 # sync the nonvalidator node with controlled message passing between nodes.

--- a/pytest/tests/sanity/sync_chunks_from_archival.py
+++ b/pytest/tests/sanity/sync_chunks_from_archival.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Spins up two nodes; Let's them build the chain for several epochs;
 # Spins up two more nodes, and makes the two new nodes to stake, and the old two to unstake;
 # Makes the two new nodes to build for couple more epochs;

--- a/pytest/tests/sanity/transactions.py
+++ b/pytest/tests/sanity/transactions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Consists of a small sanity test that verifies that a single transaction
 # gets properly processed (to simplify debugging when the code is completely
 # broken). If one transaction goes through, sends batches of transactions

--- a/pytest/tests/sanity/upgradable.py
+++ b/pytest/tests/sanity/upgradable.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 """Test if the node is backwards compatible with the latest release."""
 
 import base58

--- a/pytest/tests/sanity/validator_switch.py
+++ b/pytest/tests/sanity/validator_switch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Starts three validating nodes and one non-validating node
 # Make the validating nodes unstake and the non-validating node stake
 # so that the next epoch block producers set is completely different

--- a/pytest/tests/sanity/validator_switch_key.py
+++ b/pytest/tests/sanity/validator_switch_key.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Starts two validating nodes and one non-validating node
 # Set a new validator key that has the same account id as one of
 # the validating nodes. Stake that account with the new key

--- a/pytest/tests/spec/network/future_handshake.py
+++ b/pytest/tests/spec/network/future_handshake.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 """
 Handshake from the Future
 

--- a/pytest/tests/spec/network/handshake.py
+++ b/pytest/tests/spec/network/handshake.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 """
 Handshake
 

--- a/pytest/tests/spec/network/peers_request.py
+++ b/pytest/tests/spec/network/peers_request.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 """
 PeersRequest
 

--- a/pytest/tests/stress/hundred_nodes/100_node_block_production.py
+++ b/pytest/tests/stress/hundred_nodes/100_node_block_production.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 import sys, time
 import subprocess
 from rc import pmap

--- a/pytest/tests/stress/hundred_nodes/block_chunks.py
+++ b/pytest/tests/stress/hundred_nodes/block_chunks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 import sys, time
 import subprocess
 from rc import pmap

--- a/pytest/tests/stress/hundred_nodes/collect_logs.py
+++ b/pytest/tests/stress/hundred_nodes/collect_logs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 from rc import gcloud, pmap
 from distutils.util import strtobool
 import sys

--- a/pytest/tests/stress/hundred_nodes/create_gcloud_image.py
+++ b/pytest/tests/stress/hundred_nodes/create_gcloud_image.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 from utils import user_name
 import sys
 import os

--- a/pytest/tests/stress/hundred_nodes/node_rotation.py
+++ b/pytest/tests/stress/hundred_nodes/node_rotation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 import base58
 from enum import Enum
 import os

--- a/pytest/tests/stress/hundred_nodes/start_100_nodes.py
+++ b/pytest/tests/stress/hundred_nodes/start_100_nodes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 from rc import run, gcloud, pmap
 import json
 import datetime

--- a/pytest/tests/stress/hundred_nodes/watch_fork.py
+++ b/pytest/tests/stress/hundred_nodes/watch_fork.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 
 import sys
 import pathlib

--- a/pytest/tests/stress/network_stress.py
+++ b/pytest/tests/stress/network_stress.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 import sys, random, time, base58, requests
 import pathlib
 

--- a/pytest/tests/stress/saturate_routing_table.py
+++ b/pytest/tests/stress/saturate_routing_table.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 """
 Saturate routing table with edges.
 

--- a/pytest/tests/stress/stress.py
+++ b/pytest/tests/stress/stress.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env pytest
 # Chaos Monkey test. Simulates random events and failures and makes sure the blockchain continues operating as expected
 #
 #     _.-._         ..-..         _.-._


### PR DESCRIPTION
Currently we execute all tests with `shebang`
```
#!/usr/bin/env python3
```

We could use `pytest` instead:
```
#!/usr/bin/env pytest
```

Motivation:
- this allows us to use pytest options when running tests: (https://manpages.debian.org/testing/python-pytest/pytest.1)
a) `./tests/sanity/routing_table_sync.py --maxfail=2`, we can use retry for flunky tests
b) `./tests/sanity/routing_table_sync.py` - no output unless a failure occurs
c) `./tests/sanity/routing_table_sync.py -s` don't capture output, just print everything to stdout
d) `./tests/sanity/routing_table_sync.py --timeout=300` see https://pypi.org/project/pytest-timeout/
- `pytest` supports having multiple tests in one file
- works with existing files, without any modifications
- this will allow us to get rid of hacks like `sys.path.append` - python3 forbids `implicit local imports` - see https://docs.python.org/3/reference/import.html

Edit: after https://github.com/near/nearcore/pull/5496
We will be able to use `./pytest/tests/sanity/routing_table_sync.py`