### PR TITLE
feat: Resolve `large_enum_variant` warning

### DIFF
--- a/chain/network-primitives/src/types.rs
+++ b/chain/network-primitives/src/types.rs
@@ -951,9 +951,9 @@ pub enum NetworkViewClientResponses {
     /// Valid announce accounts.
     AnnounceAccount(Vec<AnnounceAccount>),
     /// A response to a request for a light client block during Epoch Sync
-    EpochSyncResponse(EpochSyncResponse),
+    EpochSyncResponse(Box<EpochSyncResponse>),
     /// A response to a request for headers and proofs during Epoch Sync
-    EpochSyncFinalizationResponse(EpochSyncFinalizationResponse),
+    EpochSyncFinalizationResponse(Box<EpochSyncFinalizationResponse>),
     /// Ban peer for malicious behavior.
     Ban { ban_reason: ReasonForBan },
     /// Response not needed

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -327,9 +327,9 @@ pub enum PeerMessage {
     HandshakeV2(HandshakeV2),
 
     EpochSyncRequest(EpochId),
-    EpochSyncResponse(EpochSyncResponse),
+    EpochSyncResponse(Box<EpochSyncResponse>),
     EpochSyncFinalizationRequest(EpochId),
-    EpochSyncFinalizationResponse(Box<EpochSyncFinalizationResponse>),
+    EpochSyncFinalizationResponse(EpochSyncFinalizationResponse),
 
     #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
     RoutingTableSyncV2(RoutingSyncV2),

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -327,7 +327,7 @@ pub enum PeerMessage {
     HandshakeV2(HandshakeV2),
 
     EpochSyncRequest(EpochId),
-    EpochSyncResponse(Box<EpochSyncResponse>),
+    EpochSyncResponse(EpochSyncResponse),
     EpochSyncFinalizationRequest(EpochId),
     EpochSyncFinalizationResponse(EpochSyncFinalizationResponse),
 

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -327,9 +327,9 @@ pub enum PeerMessage {
     HandshakeV2(HandshakeV2),
 
     EpochSyncRequest(EpochId),
-    EpochSyncResponse(EpochSyncResponse),
+    EpochSyncResponse(Box<EpochSyncResponse>),
     EpochSyncFinalizationRequest(EpochId),
-    EpochSyncFinalizationResponse(EpochSyncFinalizationResponse),
+    EpochSyncFinalizationResponse(Box<EpochSyncFinalizationResponse>),
 
     #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
     RoutingTableSyncV2(RoutingSyncV2),
@@ -941,9 +941,9 @@ pub enum NetworkClientMessages {
     /// State response.
     StateResponse(StateResponseInfo),
     /// Epoch Sync response for light client block request
-    EpochSyncResponse(PeerId, EpochSyncResponse),
+    EpochSyncResponse(PeerId, Box<EpochSyncResponse>),
     /// Epoch Sync response for finalization request
-    EpochSyncFinalizationResponse(PeerId, EpochSyncFinalizationResponse),
+    EpochSyncFinalizationResponse(PeerId, Box<EpochSyncFinalizationResponse>),
 
     /// Request chunk parts and/or receipts.
     PartialEncodedChunkRequest(PartialEncodedChunkRequestMsg, CryptoHash),

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -299,7 +299,6 @@ impl SyncData {
     strum::EnumVariantNames,
 )]
 // TODO(#1313): Use Box
-#[allow(clippy::large_enum_variant)]
 pub enum PeerMessage {
     Handshake(Handshake),
     HandshakeFailure(PeerInfo, HandshakeFailureReason),
@@ -330,7 +329,7 @@ pub enum PeerMessage {
     EpochSyncRequest(EpochId),
     EpochSyncResponse(EpochSyncResponse),
     EpochSyncFinalizationRequest(EpochId),
-    EpochSyncFinalizationResponse(EpochSyncFinalizationResponse),
+    EpochSyncFinalizationResponse(Box<EpochSyncFinalizationResponse>),
 
     #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
     RoutingTableSyncV2(RoutingSyncV2),


### PR DESCRIPTION
In `NetworkViewClientResponses`, `PeerMessage` `enum`'s we have variants that can be quite large. This is bad, because size of enum is determined, by size of the largest variant. By putting `EpochSyncResponse` and `EpochSyncFinalizationResponse` inside `Box`, we minimize the size of the enum.



```
    /// ### Why is this bad?
    /// Enum size is bounded by the largest variant. Having a
    /// large variant can penalize the memory layout of that enum.
    ///
    /// ### Known problems
    /// This lint obviously cannot take the distribution of
    /// variants in your running program into account. It is possible that the
    /// smaller variants make up less than 1% of all instances, in which case
    /// the overhead is negligible and the boxing is counter-productive. Always
    /// measure the change this lint suggests.
```