### PR TITLE
re: Improve `near-network` code quality with `matches!`

### DIFF
--- a/chain/network-primitives/src/types.rs
+++ b/chain/network-primitives/src/types.rs
@@ -670,10 +670,7 @@ pub enum KnownPeerStatus {
 
 impl KnownPeerStatus {
     pub fn is_banned(&self) -> bool {
-        match self {
-            KnownPeerStatus::Banned(_, _) => true,
-            _ => false,
-        }
+        matches!(self, KnownPeerStatus::Banned(_, _))
     }
 }
 

--- a/chain/network-primitives/src/types.rs
+++ b/chain/network-primitives/src/types.rs
@@ -448,16 +448,16 @@ impl RoutedMessage {
     }
 
     pub fn expect_response(&self) -> bool {
-        match self.body {
+        matches!(
+            self.body,
             RoutedMessageBody::Ping(_)
-            | RoutedMessageBody::TxStatusRequest(_, _)
-            | RoutedMessageBody::StateRequestHeader(_, _)
-            | RoutedMessageBody::StateRequestPart(_, _, _)
-            | RoutedMessageBody::PartialEncodedChunkRequest(_)
-            | RoutedMessageBody::QueryRequest { .. }
-            | RoutedMessageBody::ReceiptOutcomeRequest(_) => true,
-            _ => false,
-        }
+                | RoutedMessageBody::TxStatusRequest(_, _)
+                | RoutedMessageBody::StateRequestHeader(_, _)
+                | RoutedMessageBody::StateRequestPart(_, _, _)
+                | RoutedMessageBody::PartialEncodedChunkRequest(_)
+                | RoutedMessageBody::QueryRequest { .. }
+                | RoutedMessageBody::ReceiptOutcomeRequest(_)
+        )
     }
 
     /// Return true if ttl is positive after decreasing ttl by one, false otherwise.

--- a/chain/network/src/network_protocol.rs
+++ b/chain/network/src/network_protocol.rs
@@ -388,34 +388,34 @@ impl PeerMessage {
             | PeerMessage::Challenge(_)
             | PeerMessage::EpochSyncResponse(_)
             | PeerMessage::EpochSyncFinalizationResponse(_) => true,
-            PeerMessage::Routed(r) => match r.body {
+            PeerMessage::Routed(r) => matches!(
+                r.body,
                 RoutedMessageBody::BlockApproval(_)
-                | RoutedMessageBody::ForwardTx(_)
-                | RoutedMessageBody::PartialEncodedChunk(_)
-                | RoutedMessageBody::PartialEncodedChunkRequest(_)
-                | RoutedMessageBody::PartialEncodedChunkResponse(_)
-                | RoutedMessageBody::StateResponse(_)
-                | RoutedMessageBody::VersionedPartialEncodedChunk(_)
-                | RoutedMessageBody::VersionedStateResponse(_) => true,
-                RoutedMessageBody::PartialEncodedChunkForward(_) => true,
-                _ => false,
-            },
+                    | RoutedMessageBody::ForwardTx(_)
+                    | RoutedMessageBody::PartialEncodedChunk(_)
+                    | RoutedMessageBody::PartialEncodedChunkRequest(_)
+                    | RoutedMessageBody::PartialEncodedChunkResponse(_)
+                    | RoutedMessageBody::StateResponse(_)
+                    | RoutedMessageBody::VersionedPartialEncodedChunk(_)
+                    | RoutedMessageBody::VersionedStateResponse(_)
+                    | RoutedMessageBody::PartialEncodedChunkForward(_),
+            ),
             _ => false,
         }
     }
 
     pub(crate) fn is_view_client_message(&self) -> bool {
         match self {
-            PeerMessage::Routed(r) => match r.body {
+            PeerMessage::Routed(r) => matches!(
+                r.body,
                 RoutedMessageBody::QueryRequest { .. }
-                | RoutedMessageBody::QueryResponse { .. }
-                | RoutedMessageBody::TxStatusRequest(_, _)
-                | RoutedMessageBody::TxStatusResponse(_)
-                | RoutedMessageBody::ReceiptOutcomeRequest(_)
-                | RoutedMessageBody::StateRequestHeader(_, _)
-                | RoutedMessageBody::StateRequestPart(_, _, _) => true,
-                _ => false,
-            },
+                    | RoutedMessageBody::QueryResponse { .. }
+                    | RoutedMessageBody::TxStatusRequest(_, _)
+                    | RoutedMessageBody::TxStatusResponse(_)
+                    | RoutedMessageBody::ReceiptOutcomeRequest(_)
+                    | RoutedMessageBody::StateRequestHeader(_, _)
+                    | RoutedMessageBody::StateRequestPart(_, _, _)
+            ),
             PeerMessage::BlockHeadersRequest(_) => true,
             PeerMessage::BlockRequest(_) => true,
             PeerMessage::EpochSyncRequest(_) => true,

--- a/chain/network/src/peer_manager/peer_store.rs
+++ b/chain/network/src/peer_manager/peer_store.rs
@@ -12,6 +12,7 @@ use std::collections::hash_map::{Entry, Iter};
 use std::collections::HashMap;
 use std::error::Error;
 use std::net::SocketAddr;
+use std::ops::Not;
 use std::sync::Arc;
 use tracing::{debug, error};
 
@@ -212,13 +213,7 @@ impl PeerStore {
 
     /// Return healthy known peers up to given amount.
     pub(crate) fn healthy_peers(&self, max_count: usize) -> Vec<PeerInfo> {
-        self.find_peers(
-            |p| match p.status {
-                KnownPeerStatus::Banned(_, _) => false,
-                _ => true,
-            },
-            max_count,
-        )
+        self.find_peers(|p| matches!(p.status, KnownPeerStatus::Banned(_, _)).not(), max_count)
     }
 
     /// Return iterator over all known peers.


### PR DESCRIPTION
We can replace `match` with `matches!` in `near-network`

Why is this bad?
- Readability and needless complexity.

See https://rust-lang.github.io/rust-clippy/master/index.html#match_like_matches_macro 