### PR TITLE
re: Remove usage of `serde` from `near-network-primitives`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2914,7 +2914,6 @@ dependencies = [
  "deepsize",
  "near-crypto",
  "near-primitives",
- "serde",
  "strum",
  "tokio",
  "tracing",

--- a/chain/jsonrpc-primitives/src/types/network_info.rs
+++ b/chain/jsonrpc-primitives/src/types/network_info.rs
@@ -1,15 +1,32 @@
 use near_network_primitives::types::{KnownProducer, PeerInfo};
+use near_primitives::network::PeerId;
+use near_primitives::types::AccountId;
 use serde::{Deserialize, Serialize};
+use std::net::SocketAddr;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct RpcPeerInfo {
+    pub id: PeerId,
+    pub addr: Option<SocketAddr>,
+    pub account_id: Option<AccountId>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct RpcKnownProducer {
+    pub account_id: AccountId,
+    pub addr: Option<SocketAddr>,
+    pub peer_id: PeerId,
+}
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct RpcNetworkInfoResponse {
-    pub active_peers: Vec<PeerInfo>,
+    pub active_peers: Vec<RpcPeerInfo>,
     pub num_active_peers: usize,
     pub peer_max_count: u32,
     pub sent_bytes_per_sec: u64,
     pub received_bytes_per_sec: u64,
     /// Accounts of known block and chunk producers from routing table.
-    pub known_producers: Vec<KnownProducer>,
+    pub known_producers: Vec<RpcKnownProducer>,
 }
 
 #[derive(thiserror::Error, Debug, Serialize, Deserialize)]
@@ -19,15 +36,39 @@ pub enum RpcNetworkInfoError {
     InternalError { error_message: String },
 }
 
+impl From<PeerInfo> for RpcPeerInfo {
+    fn from(peer_info: PeerInfo) -> Self {
+        Self { id: peer_info.id, addr: peer_info.addr, account_id: peer_info.account_id }
+    }
+}
+
+impl From<KnownProducer> for RpcKnownProducer {
+    fn from(known_producer: KnownProducer) -> Self {
+        Self {
+            account_id: known_producer.account_id,
+            addr: known_producer.addr,
+            peer_id: known_producer.peer_id,
+        }
+    }
+}
+
 impl From<near_client_primitives::types::NetworkInfoResponse> for RpcNetworkInfoResponse {
     fn from(network_info_response: near_client_primitives::types::NetworkInfoResponse) -> Self {
         Self {
-            active_peers: network_info_response.connected_peers,
+            active_peers: network_info_response
+                .connected_peers
+                .iter()
+                .map(|pi| pi.clone().into())
+                .collect(),
             num_active_peers: network_info_response.num_connected_peers,
             peer_max_count: network_info_response.peer_max_count,
             sent_bytes_per_sec: network_info_response.sent_bytes_per_sec,
             received_bytes_per_sec: network_info_response.received_bytes_per_sec,
-            known_producers: network_info_response.known_producers,
+            known_producers: network_info_response
+                .known_producers
+                .iter()
+                .map(|kp| kp.clone().into())
+                .collect(),
         }
     }
 }

--- a/chain/network-primitives/Cargo.toml
+++ b/chain/network-primitives/Cargo.toml
@@ -15,7 +15,6 @@ actix = "=0.11.0-beta.2"
 tokio = { version = "1.1", features = ["full"] }
 chrono = { version = "0.4.4", features = ["serde"] }
 borsh = "0.9"
-serde = { version = "1", features = ["derive", "rc", "alloc"] }
 strum = { version = "0.20", features = ["derive"] }
 tracing = "0.1.13"
 deepsize = { version = "0.2.0", optional = true }

--- a/chain/network-primitives/src/types.rs
+++ b/chain/network-primitives/src/types.rs
@@ -22,7 +22,6 @@ use near_primitives::transaction::{ExecutionOutcomeWithIdAndProof, SignedTransac
 use near_primitives::types::{AccountId, BlockHeight, BlockReference, EpochId, ShardId};
 use near_primitives::utils::{from_timestamp, to_timestamp};
 use near_primitives::views::{FinalExecutionOutcomeView, QueryRequest, QueryResponse};
-use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::fmt::{Debug, Error, Formatter};
@@ -44,7 +43,7 @@ pub const ROUTED_MESSAGE_TTL: u8 = 100;
 pub const UPDATE_INTERVAL_LAST_TIME_RECEIVED_MESSAGE: Duration = Duration::from_secs(60);
 
 /// Peer information.
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 pub struct PeerInfo {
     pub id: PeerId,
     pub addr: Option<SocketAddr>,
@@ -167,7 +166,7 @@ impl From<PeerChainInfo> for PeerChainInfoV2 {
 
 /// Peer type.
 #[cfg_attr(feature = "deepsize_feature", derive(DeepSizeOf))]
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum PeerType {
     /// Inbound session
     Inbound,
@@ -650,7 +649,7 @@ impl FromStr for PatternAddr {
 }
 
 /// Status of the known peers.
-#[derive(BorshSerialize, BorshDeserialize, Serialize, Eq, PartialEq, Debug, Clone)]
+#[derive(BorshSerialize, BorshDeserialize, Eq, PartialEq, Debug, Clone)]
 pub enum KnownPeerStatus {
     Unknown,
     NotConnected,
@@ -776,7 +775,7 @@ where
 
 /// Ban reason.
 #[cfg_attr(feature = "deepsize_feature", derive(DeepSizeOf))]
-#[derive(BorshSerialize, BorshDeserialize, Serialize, Debug, Clone, PartialEq, Eq, Copy)]
+#[derive(BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq, Copy)]
 pub enum ReasonForBan {
     None = 0,
     BadBlock = 1,
@@ -817,7 +816,7 @@ pub enum PeerManagerRequest {
 #[rtype(result = "()")]
 pub enum PeerRequest {}
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct KnownProducer {
     pub account_id: AccountId,
     pub addr: Option<SocketAddr>,

--- a/chain/network/src/routing/routing.rs
+++ b/chain/network/src/routing/routing.rs
@@ -30,7 +30,6 @@ pub const DELETE_PEERS_AFTER_TIME: Duration = Duration::from_secs(3_600);
 pub const MAX_NUM_PEERS: usize = 128;
 
 #[derive(Debug)]
-#[cfg_attr(feature = "test_features", derive(serde::Serialize))]
 pub struct PeerRequestResult {
     pub peers: Vec<PeerInfo>,
 }


### PR DESCRIPTION
We are planning to separate `jsonrpc` types from rest of the code base. We can start by separating types from `near-network-primitives` from `jsonrpc` by removing direct usage of `serde` from that crate.

See https://github.com/near/nearcore/issues/5516

TODO: (next PR)
- Fix database memory leak.