### PR TITLE
re: Rename `EdgeType` to `EdgeState` in `near-network`

### DIFF
--- a/chain/network/src/routing/mod.rs
+++ b/chain/network/src/routing/mod.rs
@@ -11,7 +11,7 @@ pub(crate) mod routing;
 pub(crate) mod routing_table_actor;
 mod utils;
 
-pub use crate::routing::edge::{Edge, EdgeType, PartialEdgeInfo, SimpleEdge};
+pub use crate::routing::edge::{Edge, EdgeState, PartialEdgeInfo, SimpleEdge};
 #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
 pub use crate::routing::ibf_peer_set::SlotMapId;
 #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -1,6 +1,6 @@
 use crate::common::message_wrapper::{ActixMessageResponse, ActixMessageWrapper};
 use crate::metrics;
-use crate::routing::edge::{Edge, EdgeType};
+use crate::routing::edge::{Edge, EdgeState};
 use crate::routing::edge_validator_actor::EdgeValidatorActor;
 use crate::routing::routing::{Graph, SAVE_PEERS_MAX_TIME};
 use crate::types::{StopMsg, ValidateEdgeList};
@@ -132,10 +132,10 @@ impl RoutingTableActor {
         } else {
             self.needs_routing_table_recalculation = true;
             match edge.edge_type() {
-                EdgeType::Added => {
+                EdgeState::Active => {
                     self.raw_graph.add_edge(&key.0, &key.1);
                 }
-                EdgeType::Removed => {
+                EdgeState::Removed => {
                     self.raw_graph.remove_edge(&key.0, &key.1);
                 }
             }

--- a/chain/network/src/tests/cache_edges.rs
+++ b/chain/network/src/tests/cache_edges.rs
@@ -1,4 +1,4 @@
-use crate::routing::{Edge, EdgeType, Prune, DELETE_PEERS_AFTER_TIME, SAVE_PEERS_MAX_TIME};
+use crate::routing::{Edge, EdgeState, Prune, DELETE_PEERS_AFTER_TIME, SAVE_PEERS_MAX_TIME};
 use crate::test_utils::random_peer_id;
 use crate::RoutingTableActor;
 use actix::System;
@@ -13,12 +13,12 @@ use std::sync::Arc;
 use std::time::Instant;
 
 #[derive(Eq, PartialEq, Hash)]
-struct EdgeDescription(usize, usize, EdgeType);
+struct EdgeDescription(usize, usize, EdgeState);
 
 impl EdgeDescription {
     fn from(data: (usize, usize, bool)) -> Self {
         let (u, v, t) = data;
-        Self(u, v, if t { EdgeType::Added } else { EdgeType::Removed })
+        Self(u, v, if t { EdgeState::Active } else { EdgeState::Removed })
     }
 }
 
@@ -112,7 +112,7 @@ impl RoutingTableTest {
         }
         let active_edges = on_memory
             .iter()
-            .filter_map(|x| if x.2 == EdgeType::Added { Some(1) } else { None })
+            .filter_map(|x| if x.2 == EdgeState::Active { Some(1) } else { None })
             .count();
 
         assert_eq!(active_edges, self.routing_table.raw_graph.total_active_edges() as usize);


### PR DESCRIPTION
Add documentation to `EdgeType`/`EdgeState`. I'm proposing to rename `EdgeType` to `EdgeState` in order to make code more understandable.

It's easier to think about edges, by saying that each edge is in one of the two states. Starts in `Active` state, and it's state can change from `Removed` to `Active`, and vice-versa, each type increasing `nonce` by exactly 1.

Also, it's worth renaming `Added` to `Active`. Term "active state` is more self descriptive.