### PR TITLE
re: Remove unused dependencies from `near-primitives`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2950,10 +2950,8 @@ dependencies = [
 name = "near-primitives"
 version = "0.0.0"
 dependencies = [
- "base64 0.13.0",
  "bencher",
  "borsh 0.9.1",
- "bs58",
  "byteorder",
  "bytesize",
  "chrono",

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -11,8 +11,6 @@ This crate provides the base set of primitives used by other nearcore crates
 """
 
 [dependencies]
-bs58 = "0.4"
-base64 = "0.13"
 byteorder = "1.3"
 bytesize = "1.1"
 chrono = { version = "0.4.4", features = ["serde"] }


### PR DESCRIPTION
We are not using the following dependencies in `near-primitives`:

```
bs58 = "0.4"
base64 = "0.13"
```