### PR TITLE
feat: Propagate `ActixMessageWrapper` between `PeerManagerActor` and `RoutingTableActor`

### DIFF
--- a/chain/network/src/common/message_wrapper.rs
+++ b/chain/network/src/common/message_wrapper.rs
@@ -17,8 +17,8 @@ pub struct ActixMessageWrapper<T> {
 }
 
 impl<T> ActixMessageWrapper<T> {
-    pub fn new_without_size(msg: T, throttle_controller: ThrottleController) -> Self {
-        Self { msg, throttle_token: ThrottleToken::new(throttle_controller, 0) }
+    pub fn new_without_size(msg: T, throttle_controller: Option<ThrottleController>) -> Self {
+        Self { msg, throttle_token: ThrottleToken::new_without_size(throttle_controller) }
     }
 
     #[allow(unused)]

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -748,7 +748,7 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for PeerActor {
                             PeerManagerMessageRequest::PeerRequest(PeerRequest::UpdatePeerInfo(
                                 peer_info,
                             )),
-                            self.throttle_controller.clone(),
+                            Some(self.throttle_controller.clone()),
                         ));
                     }
                 }
@@ -832,7 +832,7 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for PeerActor {
                         this_edge_info: self.partial_edge_info.clone(),
                         other_edge_info: handshake.partial_edge_info.clone(),
                         peer_protocol_version: self.protocol_version,
-                    }), self.throttle_controller.clone()))
+                    }), Some(self.throttle_controller.clone())))
                     .into_actor(self)
                     .then(move |res, act, ctx| {
                         match res.map(|f|f.into_inner().as_consolidate_response()) {
@@ -881,7 +881,7 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for PeerActor {
                             self.other_peer_id().unwrap().clone(),
                             edge.next(),
                         ))),
-                        self.throttle_controller.clone(),
+                        Some(self.throttle_controller.clone()),
                     ))
                     .into_actor(self)
                     .then(|res, act, ctx| {
@@ -906,7 +906,7 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for PeerActor {
             }
             (_, PeerStatus::Ready, PeerMessage::PeersRequest) => {
                 self.peer_manager_addr.send(ActixMessageWrapper::new_without_size(PeerManagerMessageRequest::PeersRequest(PeersRequest {}),
-                                                                     self.throttle_controller.clone(),
+                                                                     Some(self.throttle_controller.clone()),
 
                 )).into_actor(self).then(|res, act, _ctx| {
                     if let Ok(peers) = res.map(|f|f.into_inner().as_peers_request_result()) {
@@ -922,7 +922,7 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for PeerActor {
                 debug!(target: "network", "Received peers from {}: {} peers.", self.peer_info, peers.len());
                 self.peer_manager_addr.do_send(ActixMessageWrapper::new_without_size(
                     PeerManagerMessageRequest::PeersResponse(PeersResponse { peers }),
-                    self.throttle_controller.clone(),
+                    Some(self.throttle_controller.clone()),
                 ));
             }
             (_, PeerStatus::Ready, PeerMessage::RequestUpdateNonce(edge_info)) => self
@@ -969,7 +969,7 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for PeerActor {
                         peer_id: self.other_peer_id().unwrap().clone(),
                         sync_data,
                     }),
-                    self.throttle_controller.clone(),
+                    Some(self.throttle_controller.clone()),
                 ));
             }
             #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
@@ -984,7 +984,7 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for PeerActor {
                         peer_id: self.other_peer_id().unwrap().clone(),
                         ibf_msg: ibf_message,
                     }),
-                    self.throttle_controller.clone(),
+                    Some(self.throttle_controller.clone()),
                 ));
             }
             (_, PeerStatus::Ready, PeerMessage::Routed(routed_message)) => {
@@ -1000,7 +1000,7 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for PeerActor {
                                 msg: routed_message.clone(),
                                 from: self.other_peer_id().unwrap().clone(),
                             }),
-                            self.throttle_controller.clone(),
+                            Some(self.throttle_controller.clone()),
                         ))
                         .into_actor(self)
                         .then(move |res, act, ctx| {

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -442,16 +442,20 @@ impl PeerManagerActor {
         peer_type: PeerType,
         addr: Addr<PeerActor>,
         ctx: &mut Context<Self>,
+        throttle_controller: Option<ThrottleController>,
     ) {
+        let throttle_controller_clone = throttle_controller.clone();
         near_performance_metrics::actix::run_later(ctx, WAIT_FOR_SYNC_DELAY, move |act, ctx| {
             if peer_type == PeerType::Inbound {
                 act.routing_table_addr
-                    .send(RoutingTableMessages::AddPeerIfMissing(peer_id, None))
+                    .send(ActixMessageWrapper::new_without_size(
+                        RoutingTableMessages::AddPeerIfMissing(peer_id, None),
+                        throttle_controller,
+                    ))
                     .into_actor(act)
-                    .map(move |response, act, ctx| match response {
-                        Ok(RoutingTableMessagesResponse::AddPeerResponse { seed }) => {
-                            act.start_routing_table_syncv2(ctx, addr, seed)
-                        }
+                    .map(move |response, act, ctx| match response.map(|x| x.into_inner()) {
+                        Ok(RoutingTableMessagesResponse::AddPeerResponse { seed }) => act
+                            .start_routing_table_syncv2(ctx, addr, seed, throttle_controller_clone),
                         _ => error!(target: "network", "expected AddIbfSetResponse"),
                     })
                     .spawn(ctx);
@@ -465,11 +469,15 @@ impl PeerManagerActor {
         ctx: &mut Context<Self>,
         addr: Addr<PeerActor>,
         seed: u64,
+        throttle_controller: Option<ThrottleController>,
     ) {
         self.routing_table_addr
-            .send(RoutingTableMessages::StartRoutingTableSync { seed })
+            .send(ActixMessageWrapper::new_without_size(
+                RoutingTableMessages::StartRoutingTableSync { seed },
+                throttle_controller,
+            ))
             .into_actor(self)
-            .map(move |response, _act, _ctx| match response {
+            .map(move |response, _act, _ctx| match response.map(|r| r.into_inner()) {
                 Ok(RoutingTableMessagesResponse::StartRoutingTableSyncResponse(response)) => {
                     let _ = addr.do_send(SendMessage { message: response });
                 }
@@ -492,6 +500,7 @@ impl PeerManagerActor {
         addr: Addr<PeerActor>,
         peer_protocol_version: ProtocolVersion,
         ctx: &mut Context<Self>,
+        throttle_controller: Option<ThrottleController>,
     ) {
         #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
         let peer_id = full_peer_info.peer_info.id.clone();
@@ -536,16 +545,25 @@ impl PeerManagerActor {
             RoutingExchangeAlgorithm,
             peer_protocol_version,
             {
-                self.initialize_routing_table_exchange(peer_id, peer_type, addr.clone(), ctx);
+                self.initialize_routing_table_exchange(
+                    peer_id,
+                    peer_type,
+                    addr.clone(),
+                    ctx,
+                    throttle_controller,
+                );
                 self.send_sync(peer_type, addr, ctx, target_peer_id, new_edge, Vec::new());
                 return;
             }
         );
         near_performance_metrics::actix::run_later(ctx, WAIT_FOR_SYNC_DELAY, move |act, ctx| {
             act.routing_table_addr
-                .send(RoutingTableMessages::RequestRoutingTable)
+                .send(ActixMessageWrapper::new_without_size(
+                    RoutingTableMessages::RequestRoutingTable,
+                    throttle_controller,
+                ))
                 .into_actor(act)
-                .map(move |response, act, ctx| match response {
+                .map(move |response, act, ctx| match response.map(|r| r.into_inner()) {
                     Ok(RoutingTableMessagesResponse::RequestRoutingTableResponse {
                         edges_info: routing_table,
                     }) => {
@@ -1186,20 +1204,24 @@ impl PeerManagerActor {
         _ctx: &mut Context<Self>,
         peer_id: PeerId,
         edges: Vec<Edge>,
+        throttle_controller: Option<ThrottleController>,
     ) {
         if edges.is_empty() {
             return;
         }
-        self.routing_table_addr.do_send(ValidateEdgeList {
-            source_peer_id: peer_id,
-            edges,
-            edges_info_shared: self.routing_table_exchange_helper.edges_info_shared.clone(),
-            sender: self.routing_table_exchange_helper.edges_to_add_sender.clone(),
-            #[cfg(feature = "test_features")]
-            adv_disable_edge_signature_verification: self
-                .adv_helper
-                .adv_disable_edge_signature_verification,
-        });
+        self.routing_table_addr.do_send(ActixMessageWrapper::new_without_size(
+            RoutingTableMessages::ValidateEdgeList(ValidateEdgeList {
+                source_peer_id: peer_id,
+                edges,
+                edges_info_shared: self.routing_table_exchange_helper.edges_info_shared.clone(),
+                sender: self.routing_table_exchange_helper.edges_to_add_sender.clone(),
+                #[cfg(feature = "test_features")]
+                adv_disable_edge_signature_verification: self
+                    .adv_helper
+                    .adv_disable_edge_signature_verification,
+            }),
+            throttle_controller,
+        ));
     }
 
     /// Broadcast message to all active peers.
@@ -1559,6 +1581,7 @@ impl PeerManagerActor {
         &mut self,
         msg: NetworkRequests,
         ctx: &mut Context<Self>,
+        throttle_controller: Option<ThrottleController>,
     ) -> NetworkResponses {
         #[cfg(feature = "delay_detector")]
         let _d =
@@ -1828,7 +1851,12 @@ impl PeerManagerActor {
                         actix::fut::ready(())
                     }).spawn(ctx);
 
-                self.validate_edges_and_add_to_routing_table(ctx, peer_id, edges);
+                self.validate_edges_and_add_to_routing_table(
+                    ctx,
+                    peer_id,
+                    edges,
+                    throttle_controller,
+                );
 
                 NetworkResponses::NoResponse
             }
@@ -1836,7 +1864,7 @@ impl PeerManagerActor {
             NetworkRequests::IbfMessage { peer_id, ibf_msg } => match ibf_msg {
                 RoutingSyncV2::Version2(ibf_msg) => {
                     if let Some(addr) = self.active_peers.get(&peer_id).map(|p| p.addr.clone()) {
-                        self.process_ibf_msg(ctx, &peer_id, ibf_msg, addr)
+                        self.process_ibf_msg(ctx, &peer_id, ibf_msg, addr, throttle_controller)
                     }
                     NetworkResponses::NoResponse
                 }
@@ -1912,10 +1940,17 @@ impl PeerManagerActor {
         &mut self,
         msg: crate::types::StartRoutingTableSync,
         ctx: &mut Context<Self>,
+        throttle_controller: Option<ThrottleController>,
     ) {
         if let Some(active_peer) = self.active_peers.get(&msg.peer_id) {
             let addr = active_peer.addr.clone();
-            self.initialize_routing_table_exchange(msg.peer_id, PeerType::Inbound, addr, ctx);
+            self.initialize_routing_table_exchange(
+                msg.peer_id,
+                PeerType::Inbound,
+                addr,
+                ctx,
+                throttle_controller,
+            );
         }
     }
 
@@ -2041,6 +2076,7 @@ impl PeerManagerActor {
         &mut self,
         msg: RegisterPeer,
         ctx: &mut Context<Self>,
+        throttle_controller: Option<ThrottleController>,
     ) -> RegisterPeerResponse {
         #[cfg(feature = "delay_detector")]
         let _d = delay_detector::DelayDetector::new("consolidate".into());
@@ -2119,6 +2155,7 @@ impl PeerManagerActor {
             msg.actor,
             msg.peer_protocol_version,
             ctx,
+            throttle_controller,
         );
 
         RegisterPeerResponse::Accept(edge_info_response)
@@ -2172,14 +2209,14 @@ impl Handler<ActixMessageWrapper<PeerManagerMessageRequest>> for PeerManagerActo
         // Unpack throttle controller
         let (msg, throttle_token) = msg.take();
 
-        let result = self.handle_peer_manager_message(
-            msg,
-            ctx,
-            Some(throttle_token.throttle_controller().clone()),
-        );
+        let throttle_controller = throttle_token.throttle_controller().cloned();
+        let result = self.handle_peer_manager_message(msg, ctx, throttle_controller);
 
         // TODO(#5155) Add support for DeepSizeOf to result
-        ActixMessageResponse::new(result, ThrottleToken::new(throttle_token.into_inner(), 0))
+        ActixMessageResponse::new(
+            result,
+            ThrottleToken::new_without_size(throttle_token.into_inner()),
+        )
     }
 }
 
@@ -2202,14 +2239,18 @@ impl PeerManagerActor {
                 PeerManagerMessageResponse::RoutedMessageFrom(self.handle_msg_routed_from(msg, ctx))
             }
             PeerManagerMessageRequest::NetworkRequests(msg) => {
-                PeerManagerMessageResponse::NetworkResponses(
-                    self.handle_msg_network_requests(msg, ctx),
-                )
+                PeerManagerMessageResponse::NetworkResponses(self.handle_msg_network_requests(
+                    msg,
+                    ctx,
+                    throttle_controller,
+                ))
             }
             PeerManagerMessageRequest::RegisterPeer(msg) => {
-                PeerManagerMessageResponse::RegisterPeerResponse(
-                    self.handle_msg_register_peer(msg, ctx),
-                )
+                PeerManagerMessageResponse::RegisterPeerResponse(self.handle_msg_register_peer(
+                    msg,
+                    ctx,
+                    throttle_controller,
+                ))
             }
             PeerManagerMessageRequest::PeersRequest(msg) => {
                 PeerManagerMessageResponse::PeerRequestResult(
@@ -2245,7 +2286,7 @@ impl PeerManagerActor {
             #[cfg(feature = "test_features")]
             #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
             PeerManagerMessageRequest::StartRoutingTableSync(msg) => {
-                self.handle_msg_start_routing_table_sync(msg, ctx);
+                self.handle_msg_start_routing_table_sync(msg, ctx, throttle_controller);
                 PeerManagerMessageResponse::StartRoutingTableSync(())
             }
             #[cfg(feature = "test_features")]
@@ -2344,26 +2385,37 @@ impl PeerManagerActor {
         peer_id: &PeerId,
         mut ibf_msg: RoutingVersion2,
         addr: Addr<PeerActor>,
+        throttle_controller: Option<ThrottleController>,
     ) {
         let mut edges: Vec<Edge> = Vec::new();
         std::mem::swap(&mut edges, &mut ibf_msg.edges);
-        self.validate_edges_and_add_to_routing_table(ctx, peer_id.clone(), edges);
+        self.validate_edges_and_add_to_routing_table(
+            ctx,
+            peer_id.clone(),
+            edges,
+            throttle_controller.clone(),
+        );
         self.routing_table_addr
-            .send(RoutingTableMessages::ProcessIbfMessage { peer_id: peer_id.clone(), ibf_msg })
+            .send(ActixMessageWrapper::new_without_size(
+                RoutingTableMessages::ProcessIbfMessage { peer_id: peer_id.clone(), ibf_msg },
+                throttle_controller,
+            ))
             .into_actor(self)
-            .map(move |response, _act: &mut PeerManagerActor, _ctx| match response {
-                Ok(RoutingTableMessagesResponse::ProcessIbfMessageResponse {
-                    ibf_msg: response_ibf_msg,
-                }) => {
-                    if let Some(response_ibf_msg) = response_ibf_msg {
-                        let _ = addr.do_send(SendMessage {
-                            message: PeerMessage::RoutingTableSyncV2(RoutingSyncV2::Version2(
-                                response_ibf_msg,
-                            )),
-                        });
+            .map(move |response, _act: &mut PeerManagerActor, _ctx| {
+                match response.map(|r| r.into_inner()) {
+                    Ok(RoutingTableMessagesResponse::ProcessIbfMessageResponse {
+                        ibf_msg: response_ibf_msg,
+                    }) => {
+                        if let Some(response_ibf_msg) = response_ibf_msg {
+                            let _ = addr.do_send(SendMessage {
+                                message: PeerMessage::RoutingTableSyncV2(RoutingSyncV2::Version2(
+                                    response_ibf_msg,
+                                )),
+                            });
+                        }
                     }
+                    _ => error!(target: "network", "expected ProcessIbfMessageResponse"),
                 }
-                _ => error!(target: "network", "expected ProcessIbfMessageResponse"),
             })
             .spawn(ctx);
     }

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -2215,7 +2215,7 @@ impl Handler<ActixMessageWrapper<PeerManagerMessageRequest>> for PeerManagerActo
         // TODO(#5155) Add support for DeepSizeOf to result
         ActixMessageResponse::new(
             result,
-            ThrottleToken::new_without_size(throttle_token.into_inner()),
+            ThrottleToken::new_without_size(throttle_token.throttle_controller().cloned()),
         )
     }
 }

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -773,7 +773,10 @@ impl Handler<ActixMessageWrapper<RoutingTableMessages>> for RoutingTableActor {
         let result = self.handle(msg, ctx);
 
         // TODO(#5155) Add support for DeepSizeOf to result
-        ActixMessageResponse::new(result, ThrottleToken::new(throttle_token.into_inner(), 0))
+        ActixMessageResponse::new(
+            result,
+            ThrottleToken::new(throttle_token.throttle_controller().cloned(), 0),
+        )
     }
 }
 

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -481,6 +481,9 @@ pub enum RoutingTableMessages {
         prune: Prune,
         prune_edges_not_reachable_for: Duration,
     },
+    // Gets list of edges to validate from another peer.
+    // Those edges will be filtered, by removing exising edges, and then
+    // those edges will be sent to `EdgeValidatorActor`.
     ValidateEdgeList(ValidateEdgeList),
 }
 

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -869,6 +869,12 @@ pub struct ValidateEdgeList {
     pub(crate) adv_disable_edge_signature_verification: bool,
 }
 
+impl Debug for ValidateEdgeList {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("source_peer_id").finish()
+    }
+}
+
 impl Message for ValidateEdgeList {
     type Result = bool;
 }

--- a/utils/near-rate-limiter/src/framed_read.rs
+++ b/utils/near-rate-limiter/src/framed_read.rs
@@ -76,6 +76,10 @@ impl ThrottleToken {
     pub fn into_inner(&self) -> ThrottleController {
         self.throttle_controller.clone()
     }
+
+    pub fn throttle_controller(&self) -> &ThrottleController {
+        &self.throttle_controller
+    }
 }
 
 impl Drop for ThrottleToken {

--- a/utils/near-rate-limiter/src/framed_read.rs
+++ b/utils/near-rate-limiter/src/framed_read.rs
@@ -62,29 +62,40 @@ pub struct ThrottleController {
 /// Only one instance of this struct should exist, that's why there is no close.
 pub struct ThrottleToken {
     /// Represents limits for `PeerActorManager`
-    throttle_controller: ThrottleController,
+    throttle_controller: Option<ThrottleController>,
     /// Size of message tracked.
     msg_len: usize,
 }
 
 impl ThrottleToken {
-    pub fn new(throttle_controller: ThrottleController, msg_len: usize) -> Self {
-        throttle_controller.add_msg(msg_len);
+    pub fn new(mut throttle_controller: Option<ThrottleController>, msg_len: usize) -> Self {
+        if let Some(th) = throttle_controller.as_mut() {
+            th.add_msg(msg_len);
+        };
         Self { throttle_controller, msg_len }
     }
 
-    pub fn into_inner(&self) -> ThrottleController {
+    pub fn new_without_size(mut throttle_controller: Option<ThrottleController>) -> Self {
+        if let Some(th) = throttle_controller.as_mut() {
+            th.add_msg(0);
+        };
+        Self { throttle_controller, msg_len: 0 }
+    }
+
+    pub fn into_inner(&self) -> Option<ThrottleController> {
         self.throttle_controller.clone()
     }
 
-    pub fn throttle_controller(&self) -> &ThrottleController {
-        &self.throttle_controller
+    pub fn throttle_controller(&self) -> Option<&ThrottleController> {
+        self.throttle_controller.as_ref()
     }
 }
 
 impl Drop for ThrottleToken {
     fn drop(&mut self) {
-        self.throttle_controller.remove_msg(self.msg_len)
+        if let Some(th) = self.throttle_controller.as_mut() {
+            th.remove_msg(self.msg_len);
+        };
     }
 }
 

--- a/utils/near-rate-limiter/src/framed_read.rs
+++ b/utils/near-rate-limiter/src/framed_read.rs
@@ -68,6 +68,7 @@ pub struct ThrottleToken {
 }
 
 impl ThrottleToken {
+    /// Creates Token with specified `msg_len`.
     pub fn new(mut throttle_controller: Option<ThrottleController>, msg_len: usize) -> Self {
         if let Some(th) = throttle_controller.as_mut() {
             th.add_msg(msg_len);
@@ -75,6 +76,7 @@ impl ThrottleToken {
         Self { throttle_controller, msg_len }
     }
 
+    /// Creates Token without specifying `msg_len`.
     pub fn new_without_size(mut throttle_controller: Option<ThrottleController>) -> Self {
         if let Some(th) = throttle_controller.as_mut() {
             th.add_msg(0);
@@ -82,10 +84,7 @@ impl ThrottleToken {
         Self { throttle_controller, msg_len: 0 }
     }
 
-    pub fn into_inner(&self) -> Option<ThrottleController> {
-        self.throttle_controller.clone()
-    }
-
+    /// Gets ThrottleController associated with `ThrottleToken`.
     pub fn throttle_controller(&self) -> Option<&ThrottleController> {
         self.throttle_controller.as_ref()
     }


### PR DESCRIPTION
We want to track count and sizes of messages arriving from `PeerActor`, while they  travel to `PeerManagerActor`, and then to `RoutingTableActor`.

This PR extends message tracking per peer, while they travel through `actix` `InBox` system.

Continuation of https://github.com/near/nearcore/pull/5198

TODO:
- [x] documentation for methods