### PR TITLE
pytest: allow empty header reads in `proxy.bridge`

### DIFF
--- a/pytest/lib/proxy.py
+++ b/pytest/lib/proxy.py
@@ -203,16 +203,13 @@ def check_finish(server, global_stopped, local_stopped, error):
         local_stopped.value = 2
 
 
-async def _read_exact(reader, length):
+async def _read_exact(reader, length, *, allow_eof=False):
     """Reads exactly `length` bytes from reader."""
-    data = b''
-    while True:
-        buf = await reader.read(length - len(data))
-        if not buf:
-            raise RuntimeError('Endpoint closed')
-        data += buf
-        if len(data) >= length:
-            return data
+    data = await reader.read(length)
+    if data or not allow_eof:
+        while len(data) < length:
+            data += await reader.read(length - len(data))
+    return data
 
 
 async def bridge(reader, writer, handler_fn, global_stopped, local_stopped,
@@ -223,14 +220,13 @@ async def bridge(reader, writer, handler_fn, global_stopped, local_stopped,
     try:
         while 0 == global_stopped.value and 0 >= local_stopped.value and 0 == error.value and 0 == bridge_stopped[
                 0]:
-            header = await _read_exact(reader, 4)
+            header = await _read_exact(reader, 4, allow_eof=True)
             if not header:
                 logging.debug(
                     f"Endpoint closed (Reader). port={_MY_PORT} bridge_id={bridge_id}"
                 )
                 break
 
-            assert len(header) == 4, header
             raw_message_len = struct.unpack('I', header)[0]
             raw_message = await _read_exact(reader, raw_message_len)
 


### PR DESCRIPTION
The behaviour of `proxy.bridge` has been changed in recent commit such
that reading header always reads four bytes making it such that empty
read was never possible.  Previously, the loop in `bridge` function
would stop if empty read happened.

This change broke `sanity/proxy_restart.py` and `stress/stress.py 3 3
3 0 staking transactions node_restart packets_drop` tests.

Make empty reads when reading header possible again to fix the tests.
