### PR TITLE
fix: Fix database leak in `near-network::fetch_edges_for_peer_from_disk`

### DIFF
--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -189,12 +189,17 @@ impl RoutingTableActor {
             let mut update = self.store.store_update();
 
             // Load all edges that were persisted in database in the cell - and add them to the current graph.
+            let mut visited: HashSet<PeerId> = HashSet::new();
             if let Ok(edges) = self.get_and_remove_component_edges(component_nonce, &mut update) {
                 for edge in edges {
                     for &peer_id in vec![&edge.key().0, &edge.key().1].iter() {
                         if peer_id == &my_peer_id {
                             continue;
                         }
+                        if visited.contains(peer_id) {
+                            continue;
+                        }
+                        visited.insert(peer_id.clone());
 
                         // `edge = (peer_id, other_peer_id)` belongs to component that we loaded from database.
                         if let Ok(cur_nonce) = self.component_nonce_from_peer(peer_id) {

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -192,9 +192,7 @@ impl RoutingTableActor {
             if let Ok(edges) = self.get_and_remove_component_edges(component_nonce, &mut update) {
                 for edge in edges {
                     for &peer_id in vec![&edge.key().0, &edge.key().1].iter() {
-                        if peer_id == &my_peer_id
-                            || self.peer_last_time_reachable.contains_key(peer_id)
-                        {
+                        if peer_id == &my_peer_id {
                             continue;
                         }
 
@@ -203,8 +201,12 @@ impl RoutingTableActor {
                             // If `peer_id` belongs to current component
                             if cur_nonce == component_nonce {
                                 // Mark it as reachable and delete from database.
-                                self.peer_last_time_reachable
-                                    .insert(peer_id.clone(), Instant::now() - SAVE_PEERS_MAX_TIME);
+                                if !self.peer_last_time_reachable.contains_key(peer_id) {
+                                    self.peer_last_time_reachable.insert(
+                                        peer_id.clone(),
+                                        Instant::now() - SAVE_PEERS_MAX_TIME,
+                                    );
+                                }
                                 update.delete(
                                     ColPeerComponent,
                                     peer_id.try_to_vec().unwrap().as_ref(),


### PR DESCRIPTION
There is a small disk space leak in database.

Whenever we store a component of deleted edges on disk, we have a mapping peer_id -> compoment.


If we ever add edge, let's say (A, B), such that `B` is in that component, we will bring all edges back.
However, we will not delete mapping from `B -> compoment`.
This PR should fix that. 

Related to the issue: https://github.com/near/nearcore/pull/5566

See https://github.com/near/nearcore/issues/5563