### PR TITLE
Fix handling eof in `_read_exact`

### DIFF
--- a/pytest/lib/proxy.py
+++ b/pytest/lib/proxy.py
@@ -208,7 +208,10 @@ async def _read_exact(reader, length, *, allow_eof=False):
     data = await reader.read(length)
     if data or not allow_eof:
         while len(data) < length:
-            data += await reader.read(length - len(data))
+            new_data = await reader.read(length - len(data))
+            if not new_data:
+                break
+            data += new_data
     return data
 
 


### PR DESCRIPTION
In python `if [0]:` returns false. We should check whenever the header wasn't ready, by checking whenever
the result of `await reader.read` has length of 0 instead of checking if all bytes are 0.

I think this way of handling the `EOF` should fix the issue.