### PR TITLE
re: Fix `clippy` warnings in `near-chain` 

### DIFF
--- a/chain/chain/src/doomslug.rs
+++ b/chain/chain/src/doomslug.rs
@@ -250,7 +250,7 @@ impl DoomslugApprovalsTrackersAtHeight {
                 .unwrap_or(false);
 
             if should_remove {
-                self.approval_trackers.remove(&last_parent);
+                self.approval_trackers.remove(last_parent);
             }
         }
 
@@ -513,13 +513,13 @@ impl Doomslug {
         let ret = self
             .approval_tracking
             .entry(approval.target_height)
-            .or_insert_with(|| DoomslugApprovalsTrackersAtHeight::new())
+            .or_insert_with(DoomslugApprovalsTrackersAtHeight::new)
             .process_approval(now, approval, stakes, threshold_mode);
 
-        if ret != DoomslugBlockProductionReadiness::NotReady {
-            if approval.target_height > self.largest_threshold_height {
-                self.largest_threshold_height = approval.target_height;
-            }
+        if ret != DoomslugBlockProductionReadiness::NotReady
+            && approval.target_height > self.largest_threshold_height
+        {
+            self.largest_threshold_height = approval.target_height;
         }
 
         ret
@@ -633,7 +633,7 @@ mod tests {
         ds.set_tip(now, hash(&[1]), 1, 1);
         assert_eq!(ds.process_timer(now + Duration::from_millis(399)).len(), 0);
         let approval =
-            ds.process_timer(now + Duration::from_millis(400)).into_iter().nth(0).unwrap();
+            ds.process_timer(now + Duration::from_millis(400)).into_iter().next().unwrap();
         assert_eq!(approval.inner, ApprovalInner::Endorsement(hash(&[1])));
         assert_eq!(approval.target_height, 2);
 
@@ -645,7 +645,7 @@ mod tests {
 
         // But one second should trigger the skip
         match ds.process_timer(now + Duration::from_millis(1000)) {
-            approvals if approvals.len() == 0 => assert!(false),
+            approvals if approvals.is_empty() => assert!(false),
             approvals => {
                 assert_eq!(approvals[0].inner, ApprovalInner::Skip(1));
                 assert_eq!(approvals[0].target_height, 3);
@@ -665,7 +665,7 @@ mod tests {
         // But at height 3 should (also neither block has finality set, keep last final at 0 for now)
         ds.set_tip(now, hash(&[3]), 3, 0);
         let approval =
-            ds.process_timer(now + Duration::from_millis(400)).into_iter().nth(0).unwrap();
+            ds.process_timer(now + Duration::from_millis(400)).into_iter().next().unwrap();
         assert_eq!(approval.inner, ApprovalInner::Endorsement(hash(&[3])));
         assert_eq!(approval.target_height, 4);
 
@@ -675,7 +675,7 @@ mod tests {
         assert_eq!(ds.process_timer(now + Duration::from_millis(199)), vec![]);
 
         match ds.process_timer(now + Duration::from_millis(200)) {
-            approvals if approvals.len() == 0 => assert!(false),
+            approvals if approvals.is_empty() => assert!(false),
             approvals if approvals.len() == 1 => {
                 assert_eq!(approvals[0].inner, ApprovalInner::Skip(3));
                 assert_eq!(approvals[0].target_height, 5);
@@ -690,7 +690,7 @@ mod tests {
         assert_eq!(ds.process_timer(now + Duration::from_millis(499)), vec![]);
 
         match ds.process_timer(now + Duration::from_millis(500)) {
-            approvals if approvals.len() == 0 => assert!(false),
+            approvals if approvals.is_empty() => assert!(false),
             approvals => {
                 assert_eq!(approvals[0].inner, ApprovalInner::Skip(3));
                 assert_eq!(approvals[0].target_height, 6);
@@ -704,7 +704,7 @@ mod tests {
         assert_eq!(ds.process_timer(now + Duration::from_millis(899)), vec![]);
 
         match ds.process_timer(now + Duration::from_millis(900)) {
-            approvals if approvals.len() == 0 => assert!(false),
+            approvals if approvals.is_empty() => assert!(false),
             approvals => {
                 assert_eq!(approvals[0].inner, ApprovalInner::Skip(3));
                 assert_eq!(approvals[0].target_height, 7);
@@ -735,7 +735,7 @@ mod tests {
         assert_eq!(ds.process_timer(now + Duration::from_millis(1099)), vec![]);
 
         match ds.process_timer(now + Duration::from_millis(1100)) {
-            approvals if approvals.len() == 0 => assert!(false),
+            approvals if approvals.is_empty() => assert!(false),
             approvals => {
                 assert_eq!(approvals[0].inner, ApprovalInner::Skip(6));
                 assert_eq!(approvals[0].target_height, 8);
@@ -779,7 +779,7 @@ mod tests {
             Duration::from_millis(1000),
             Duration::from_millis(100),
             Duration::from_millis(3000),
-            Some(signer.clone()),
+            Some(signer),
             DoomslugThresholdMode::TwoThirds,
         );
 

--- a/chain/chain/src/lightclient.rs
+++ b/chain/chain/src/lightclient.rs
@@ -50,14 +50,14 @@ pub fn create_light_client_block_view(
     };
     let inner_rest_hash = hash(&block_header.inner_rest_bytes());
 
-    let next_block_hash = chain_store.get_next_block_hash(&block_header.hash())?.clone();
+    let next_block_hash = *chain_store.get_next_block_hash(block_header.hash())?;
     let next_block_header = chain_store.get_block_header(&next_block_hash)?;
     let next_block_inner_hash = BlockHeader::compute_inner_hash(
         &next_block_header.inner_lite_bytes(),
         &next_block_header.inner_rest_bytes(),
     );
 
-    let after_next_block_hash = chain_store.get_next_block_hash(&next_block_hash)?.clone();
+    let after_next_block_hash = *chain_store.get_next_block_hash(&next_block_hash)?;
     let after_next_block_header = chain_store.get_block_header(&after_next_block_hash)?;
     let approvals_after_next = after_next_block_header.approvals().to_vec();
 

--- a/chain/chain/src/migrations.rs
+++ b/chain/chain/src/migrations.rs
@@ -29,7 +29,7 @@ pub fn check_if_block_is_first_with_chunk_of_version(
     if is_first_epoch_with_protocol_version(runtime_adapter, prev_block_hash)? {
         // Compare only epochs because we already know that current epoch is the first one with current protocol version
         // convert shard id to shard id of previous epoch because number of shards may change
-        let shard_id = runtime_adapter.get_prev_shard_ids(&prev_block_hash, vec![shard_id])?[0];
+        let shard_id = runtime_adapter.get_prev_shard_ids(prev_block_hash, vec![shard_id])?[0];
         let prev_epoch_id = chain_store.get_epoch_id_of_last_block_with_chunk(
             runtime_adapter,
             prev_block_hash,

--- a/chain/chain/src/missing_chunks.rs
+++ b/chain/chain/src/missing_chunks.rs
@@ -74,7 +74,7 @@ impl<Block: BlockLike> MissingChunksPool<Block> {
         if self.blocks_ready_to_process.is_empty() {
             return Vec::new();
         }
-        let heap = std::mem::replace(&mut self.blocks_ready_to_process, BinaryHeap::new());
+        let heap = std::mem::take(&mut self.blocks_ready_to_process);
         heap.into_sorted_vec().into_iter().map(|x| x.0).collect()
     }
 
@@ -223,7 +223,7 @@ mod test {
         let block = MockBlock::new(block_height);
         let chunk_hashes: Vec<ChunkHash> = (101..105).map(get_chunk_hash).collect();
 
-        pool.add_block_with_missing_chunks(block.clone(), chunk_hashes.clone());
+        pool.add_block_with_missing_chunks(block, chunk_hashes.clone());
         assert!(pool.contains(&block.hash));
 
         for chunk_hash in chunk_hashes.iter().skip(1) {
@@ -273,7 +273,7 @@ mod test {
         let block_height = 1;
         let block = MockBlock::new(block_height);
         let missing_chunk_hash = get_chunk_hash(200);
-        pool.add_block_with_missing_chunks(block.clone(), vec![missing_chunk_hash.clone()]);
+        pool.add_block_with_missing_chunks(block, vec![missing_chunk_hash.clone()]);
 
         let later_block = MockBlock::new(block_height + 1);
         let later_block_hash = later_block.hash;

--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -96,7 +96,7 @@ impl StoreValidator {
             me,
             config,
             runtime_adapter,
-            store: store.clone(),
+            store,
             inner: StoreValidatorCache::new(),
             timeout: None,
             start_time: Clock::instant(),
@@ -108,7 +108,7 @@ impl StoreValidator {
         self.timeout = Some(timeout)
     }
     pub fn is_failed(&self) -> bool {
-        self.tests == 0 || self.errors.len() > 0
+        self.tests == 0 || !self.errors.is_empty()
     }
     pub fn get_gc_counters(&self) -> Vec<(String, u64)> {
         let mut res = vec![];
@@ -422,7 +422,7 @@ mod tests {
         let chain =
             Chain::new(runtime_adapter.clone(), &chain_genesis, DoomslugThresholdMode::NoApprovals)
                 .unwrap();
-        (chain, StoreValidator::new(None, genesis.clone(), runtime_adapter, store))
+        (chain, StoreValidator::new(None, genesis, runtime_adapter, store))
     }
 
     #[test]
@@ -461,7 +461,7 @@ mod tests {
     fn test_db_not_found() {
         let (mut chain, mut sv) = init();
         let block = chain.get_block_by_height(0).unwrap();
-        assert!(validate::block_header_exists(&mut sv, &block.hash(), block).is_ok());
+        assert!(validate::block_header_exists(&mut sv, block.hash(), block).is_ok());
         match validate::block_header_exists(&mut sv, &CryptoHash::default(), block) {
             Err(StoreValidatorError::DBNotFound { .. }) => {}
             _ => assert!(false),

--- a/chain/chain/src/store_validator/validate.rs
+++ b/chain/chain/src/store_validator/validate.rs
@@ -231,7 +231,7 @@ pub(crate) fn block_indexed_by_height(
     .flatten()
     .cloned()
     .collect();
-    if !block_hashes.contains(&block_hash) {
+    if !block_hashes.contains(block_hash) {
         err!("Block {:?} is not found in ColBlockPerHeight", block);
     }
     Ok(())
@@ -349,7 +349,7 @@ pub(crate) fn chunk_tx_exists(
     for tx in shard_chunk.transactions().iter() {
         let tx_hash = tx.get_hash();
         unwrap_or_err_db!(
-            sv.store.get_ser::<SignedTransaction>(DBCol::ColTransactions, &tx_hash.as_ref()),
+            sv.store.get_ser::<SignedTransaction>(DBCol::ColTransactions, tx_hash.as_ref()),
             "Can't get Tx from storage for Tx Hash {:?}",
             tx_hash
         );
@@ -366,13 +366,13 @@ pub(crate) fn block_chunks_exist(
         if chunk_header.height_included() == block.header().height() {
             if let Some(me) = &sv.me {
                 let cares_about_shard = sv.runtime_adapter.cares_about_shard(
-                    Some(&me),
+                    Some(me),
                     block.header().prev_hash(),
                     chunk_header.shard_id(),
                     true,
                 );
                 let will_care_about_shard = sv.runtime_adapter.will_care_about_shard(
-                    Some(&me),
+                    Some(me),
                     block.header().prev_hash(),
                     chunk_header.shard_id(),
                     true,
@@ -569,7 +569,7 @@ pub(crate) fn trie_changes_chunk_extra_exists(
     // If the trie_changes we are checking are for the next epoch during sharding upgrade,
     // skip the checks about ShardChunk because there is no corresponding chunk for this shard_uid
     let shard_layout = unwrap_or_err!(
-        sv.runtime_adapter.get_shard_layout(&block.header().epoch_id()),
+        sv.runtime_adapter.get_shard_layout(block.header().epoch_id()),
         "Error getting shard layout"
     );
     if shard_layout.version() != shard_uid.version {
@@ -659,7 +659,7 @@ pub(crate) fn outcome_by_outcome_id_exists(
             "Can't get TransactionResult from storage with Outcome id {:?}",
             outcome_id
         );
-        if outcomes.iter().find(|outcome| &outcome.block_hash == block_hash).is_none() {
+        if !outcomes.iter().any(|outcome| &outcome.block_hash == block_hash) {
             panic!("Invalid TransactionResult {:?} stored", outcomes);
         }
     }
@@ -790,10 +790,8 @@ pub(crate) fn gc_col_count(
 ) -> Result<(), StoreValidatorError> {
     if SHOULD_COL_GC[*col as usize] {
         sv.inner.gc_col[*col as usize] = *count;
-    } else {
-        if *count > 0 {
-            err!("DBCol is cleared by mistake")
-        }
+    } else if *count > 0 {
+        err!("DBCol is cleared by mistake")
     }
     Ok(())
 }
@@ -803,12 +801,12 @@ pub(crate) fn tx_refcount(
     tx_hash: &CryptoHash,
     refcount: &u64,
 ) -> Result<(), StoreValidatorError> {
-    let expected = sv.inner.tx_refcount.get(tx_hash).map(|&rc| rc).unwrap_or_default();
+    let expected = sv.inner.tx_refcount.get(tx_hash).copied().unwrap_or_default();
     if *refcount != expected {
         err!("Invalid tx refcount, expected {:?}, found {:?}", expected, refcount)
     } else {
         sv.inner.tx_refcount.remove(tx_hash);
-        return Ok(());
+        Ok(())
     }
 }
 
@@ -817,12 +815,12 @@ pub(crate) fn receipt_refcount(
     receipt_id: &CryptoHash,
     refcount: &u64,
 ) -> Result<(), StoreValidatorError> {
-    let expected = sv.inner.receipt_refcount.get(receipt_id).map(|&rc| rc).unwrap_or_default();
+    let expected = sv.inner.receipt_refcount.get(receipt_id).copied().unwrap_or_default();
     if *refcount != expected {
         err!("Invalid receipt refcount, expected {:?}, found {:?}", expected, refcount)
     } else {
         sv.inner.receipt_refcount.remove(receipt_id);
-        return Ok(());
+        Ok(())
     }
 }
 
@@ -913,7 +911,7 @@ pub(crate) fn gc_col_count_final(sv: &mut StoreValidator) -> Result<(), StoreVal
     }
     let mut gc_col_count = 0;
     for gc_col in SHOULD_COL_GC.iter() {
-        if *gc_col == true {
+        if *gc_col {
             gc_col_count += 1;
         }
     }

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -208,7 +208,7 @@ impl KeyValueRuntime {
             return Ok(Some(headers_cache.get(hash).unwrap().clone()));
         }
         if let Some(result) = self.store.get_ser(ColBlockHeader, hash.as_ref())? {
-            headers_cache.insert(hash.clone(), result);
+            headers_cache.insert(*hash, result);
             return Ok(Some(headers_cache.get(hash).unwrap().clone()));
         }
         Ok(None)
@@ -235,10 +235,7 @@ impl KeyValueRuntime {
         let prev_prev_hash = *prev_block_header.prev_hash();
         let prev_epoch = hash_to_epoch.get(&prev_prev_hash);
         let prev_next_epoch = hash_to_next_epoch.get(&prev_prev_hash).unwrap();
-        let prev_valset = match prev_epoch {
-            Some(prev_epoch) => Some(*hash_to_valset.get(&prev_epoch).unwrap()),
-            None => None,
-        };
+        let prev_valset = prev_epoch.map(|prev_epoch| *hash_to_valset.get(prev_epoch).unwrap());
 
         let prev_epoch_start = *epoch_start_map.get(&prev_prev_hash).unwrap();
 
@@ -277,7 +274,7 @@ impl KeyValueRuntime {
 
         hash_to_next_epoch.insert(prev_hash, next_epoch.clone());
         hash_to_epoch.insert(prev_hash, epoch.clone());
-        hash_to_next_epoch_approvals_req.insert(prev_hash.clone(), needs_next_epoch_approvals);
+        hash_to_next_epoch_approvals_req.insert(prev_hash, needs_next_epoch_approvals);
         hash_to_valset.insert(epoch.clone(), valset);
         hash_to_valset.insert(next_epoch.clone(), valset + 1);
         epoch_start_map.insert(prev_hash, epoch_start);
@@ -391,7 +388,7 @@ impl RuntimeAdapter for KeyValueRuntime {
         let validators = &self.validators[self.get_valset_for_epoch(epoch_id)?];
         let message_to_sign = Approval::get_data_for_sig(
             &if prev_block_height + 1 == block_height {
-                ApprovalInner::Endorsement(prev_block_hash.clone())
+                ApprovalInner::Endorsement(*prev_block_hash)
             } else {
                 ApprovalInner::Skip(prev_block_height)
             },
@@ -426,8 +423,7 @@ impl RuntimeAdapter for KeyValueRuntime {
         &self,
         parent_hash: &CryptoHash,
     ) -> Result<Vec<(ApprovalStake, bool)>, Error> {
-        let (_cur_epoch, cur_valset, next_epoch) =
-            self.get_epoch_and_valset(parent_hash.clone())?;
+        let (_cur_epoch, cur_valset, next_epoch) = self.get_epoch_and_valset(*parent_hash)?;
         let mut validators = self.validators[cur_valset]
             .iter()
             .map(|x| x.get_approval_stake(false))
@@ -665,7 +661,7 @@ impl RuntimeAdapter for KeyValueRuntime {
         assert!(!generate_storage_proof);
         let mut tx_results = vec![];
 
-        let mut state = self.state.read().unwrap().get(&state_root).cloned().unwrap();
+        let mut state = self.state.read().unwrap().get(state_root).cloned().unwrap();
 
         let mut balance_transfers = vec![];
 
@@ -811,8 +807,8 @@ impl RuntimeAdapter for KeyValueRuntime {
         let data = state.try_to_vec()?;
         let state_size = data.len() as u64;
         let state_root = hash(&data);
-        self.state.write().unwrap().insert(state_root.clone(), state);
-        self.state_size.write().unwrap().insert(state_root.clone(), state_size);
+        self.state.write().unwrap().insert(state_root, state);
+        self.state_size.write().unwrap().insert(state_root, state_size);
 
         Ok(ApplyTransactionResult {
             trie_changes: WrappedTrieChanges::new(
@@ -820,7 +816,7 @@ impl RuntimeAdapter for KeyValueRuntime {
                 ShardUId { version: 0, shard_id: shard_id as u32 },
                 TrieChanges::empty(state_root),
                 Default::default(),
-                block_hash.clone(),
+                *block_hash,
             ),
             new_root: state_root,
             outcomes: tx_results,
@@ -870,7 +866,7 @@ impl RuntimeAdapter for KeyValueRuntime {
             QueryRequest::ViewAccount { account_id, .. } => Ok(QueryResponse {
                 kind: QueryResponseKind::ViewAccount(
                     Account::new(
-                        self.state.read().unwrap().get(&state_root).map_or_else(
+                        self.state.read().unwrap().get(state_root).map_or_else(
                             || 0,
                             |state| *state.amounts.get(account_id).unwrap_or(&0),
                         ),
@@ -937,7 +933,7 @@ impl RuntimeAdapter for KeyValueRuntime {
         if part_id != 0 {
             return Ok(vec![]);
         }
-        let state = self.state.read().unwrap().get(&state_root).unwrap().clone();
+        let state = self.state.read().unwrap().get(state_root).unwrap().clone();
         let data = state.try_to_vec().expect("should never fall");
         Ok(data)
     }
@@ -967,10 +963,10 @@ impl RuntimeAdapter for KeyValueRuntime {
             return Ok(());
         }
         let state = KVState::try_from_slice(data).unwrap();
-        self.state.write().unwrap().insert(state_root.clone(), state.clone());
+        self.state.write().unwrap().insert(*state_root, state.clone());
         let data = state.try_to_vec()?;
         let state_size = data.len() as u64;
-        self.state_size.write().unwrap().insert(state_root.clone(), state_size);
+        self.state_size.write().unwrap().insert(*state_root, state_size);
         Ok(())
     }
 
@@ -985,12 +981,12 @@ impl RuntimeAdapter for KeyValueRuntime {
                 .state
                 .read()
                 .unwrap()
-                .get(&state_root)
+                .get(state_root)
                 .unwrap()
                 .clone()
                 .try_to_vec()
                 .expect("should never fall"),
-            memory_usage: self.state_size.read().unwrap().get(&state_root).unwrap().clone(),
+            memory_usage: *self.state_size.read().unwrap().get(state_root).unwrap(),
         })
     }
 
@@ -1168,12 +1164,12 @@ impl RuntimeAdapter for KeyValueRuntime {
         &self,
         prev_block_hash: &CryptoHash,
     ) -> Result<EpochId, Error> {
-        let mut candidate_hash = prev_block_hash.clone();
+        let mut candidate_hash = *prev_block_hash;
         loop {
             let header = self
                 .get_block_header(&candidate_hash)?
                 .ok_or_else(|| ErrorKind::DBNotFoundErr(to_base(&candidate_hash)))?;
-            candidate_hash = header.prev_hash().clone();
+            candidate_hash = *header.prev_hash();
             if self.is_next_block_epoch_start(&candidate_hash)? {
                 break Ok(self.get_epoch_and_valset(candidate_hash)?.0);
             }
@@ -1322,7 +1318,7 @@ pub fn display_chain(me: &Option<AccountId>, chain: &mut Chain, tail: bool) {
             debug!("{: >3} {}", header.height(), format_hash(*header.hash()));
         } else {
             let parent_header = chain_store.get_block_header(header.prev_hash()).unwrap().clone();
-            let maybe_block = chain_store.get_block(&header.hash()).ok().cloned();
+            let maybe_block = chain_store.get_block(header.hash()).ok().cloned();
             let epoch_id =
                 runtime_adapter.get_epoch_id_from_prev_block(header.prev_hash()).unwrap();
             let block_producer =

--- a/chain/chain/src/tests/challenges.rs
+++ b/chain/chain/src/tests/challenges.rs
@@ -10,7 +10,7 @@ fn challenges_new_head_prev() {
     for i in 0..5 {
         let prev_hash = *chain.head_header().unwrap().hash();
         let prev = chain.get_block(&prev_hash).unwrap();
-        let block = Block::empty(&prev, &*signer);
+        let block = Block::empty(prev, &*signer);
         hashes.push(*block.hash());
         let tip = chain.process_block_test(&None, block).unwrap();
         assert_eq!(tip.unwrap().height, i + 1);
@@ -19,11 +19,11 @@ fn challenges_new_head_prev() {
     assert_eq!(chain.head().unwrap().height, 5);
 
     // The block to be added below after we invalidated fourth block.
-    let last_block = Block::empty(&chain.get_block(&hashes[3]).unwrap(), &*signer);
+    let last_block = Block::empty(chain.get_block(&hashes[3]).unwrap(), &*signer);
     assert_eq!(last_block.header().height(), 5);
 
     let prev = chain.get_block(&hashes[1]).unwrap();
-    let challenger_block = Block::empty_with_height(&prev, 3, &*signer);
+    let challenger_block = Block::empty_with_height(prev, 3, &*signer);
     let challenger_hash = *challenger_block.hash();
 
     let _ = chain.process_block_test(&None, challenger_block).unwrap();
@@ -55,7 +55,7 @@ fn challenges_new_head_prev() {
     let _ = chain.process_block_test(&None, b3.clone()).unwrap().unwrap();
 
     let b4 = Block::empty(&b3, &*signer);
-    let new_head = chain.process_block_test(&None, b4.clone()).unwrap().unwrap().last_block_hash;
+    let new_head = chain.process_block_test(&None, b4).unwrap().unwrap().last_block_hash;
 
     assert_eq!(chain.head_header().unwrap().hash(), &new_head);
 
@@ -69,7 +69,7 @@ fn challenges_new_head_prev() {
 
     assert_eq!(chain.head_header().unwrap().hash(), &new_head);
 
-    chain.mark_block_as_challenged(&new_head, &challenger_hash).unwrap();
+    chain.mark_block_as_challenged(&new_head, challenger_hash).unwrap();
 
     assert_eq!(chain.head_header().unwrap().hash(), challenger_hash);
 }
@@ -80,7 +80,7 @@ fn test_no_challenge_on_same_header() {
     let (mut chain, _, signer) = setup();
     let prev_hash = *chain.head_header().unwrap().hash();
     let prev = chain.get_block(&prev_hash).unwrap();
-    let block = Block::empty(&prev, &*signer);
+    let block = Block::empty(prev, &*signer);
     let tip = chain.process_block_test(&None, block.clone()).unwrap();
     assert_eq!(tip.unwrap().height, 1);
     if let Err(e) = chain.process_block_header(block.header(), |_| panic!("Unexpected Challenge")) {

--- a/chain/chain/src/tests/doomslug.rs
+++ b/chain/chain/src/tests/doomslug.rs
@@ -94,7 +94,7 @@ fn one_iter(
 
     let mut is_done = false;
     while !is_done {
-        now = now + Duration::from_millis(25);
+        now += Duration::from_millis(25);
         let mut new_approval_queue = vec![];
         let mut new_block_queue = vec![];
 
@@ -136,7 +136,7 @@ fn one_iter(
 
                         let last_block = block_infos.last().unwrap();
                         let prev_block_info = hash_to_block_info
-                            .get(&hash_to_prev_hash.get(&last_block.2).unwrap())
+                            .get(hash_to_prev_hash.get(&last_block.2).unwrap())
                             .unwrap();
 
                         if prev_block_info.0 as BlockHeight <= ds.get_tip().1 {
@@ -181,7 +181,7 @@ fn one_iter(
                             0
                         } else {
                             let prev_prev_hash = hash_to_prev_hash.get(&parent_hash).unwrap();
-                            hash_to_block_info.get(&prev_prev_hash).unwrap().0
+                            hash_to_block_info.get(prev_prev_hash).unwrap().0
                         };
 
                         let is_final =
@@ -228,7 +228,7 @@ fn one_iter(
 
                         if is_final && target_height != 2 {
                             blocks_with_finality.push((
-                                hash_to_prev_hash.get(&parent_hash).unwrap().clone(),
+                                *hash_to_prev_hash.get(&parent_hash).unwrap(),
                                 target_height - 2,
                             ));
                         }
@@ -280,7 +280,7 @@ fn one_iter(
     // doomslug final blocks
     for (block_hash, (block_height, _, _)) in hash_to_block_info.iter() {
         let mut seen_hashes = HashSet::new();
-        let mut block_hash = block_hash.clone();
+        let mut block_hash = *block_hash;
         seen_hashes.insert(block_hash);
 
         loop {

--- a/chain/chain/src/tests/gc.rs
+++ b/chain/chain/src/tests/gc.rs
@@ -26,7 +26,7 @@ fn get_chain_with_epoch_length_and_num_shards(
     let chain_genesis = ChainGenesis::test();
     let validators = vec![vec!["test1"]];
     let runtime_adapter = Arc::new(KeyValueRuntime::new_with_validators(
-        store.clone(),
+        store,
         validators
             .into_iter()
             .map(|inner| inner.into_iter().map(|account_id| account_id.parse().unwrap()).collect())
@@ -132,7 +132,7 @@ fn gc_fork_common(simple_chains: Vec<SimpleChain>, max_changes: usize) {
     let genesis1 = chain1.get_block_by_height(0).unwrap().clone();
     let mut states1 = vec![];
     states1.push((
-        genesis1.clone(),
+        genesis1,
         vec![Trie::empty_root(); num_shards as usize],
         vec![Vec::new(); num_shards as usize],
     ));
@@ -152,7 +152,7 @@ fn gc_fork_common(simple_chains: Vec<SimpleChain>, max_changes: usize) {
     }
 
     // GC execution
-    let clear_data = chain1.clear_data(tries1.clone(), 100);
+    let clear_data = chain1.clear_data(tries1, 100);
     if clear_data.is_err() {
         println!("clear data failed = {:?}", clear_data);
         assert!(false);

--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -1,6 +1,6 @@
 use crate::test_utils::setup;
 use crate::{Block, ChainStoreAccess, ErrorKind};
-use chrono;
+
 use chrono::TimeZone;
 use near_logger_utils::init_test_logger;
 use near_primitives::hash::CryptoHash;
@@ -55,7 +55,7 @@ fn build_chain() {
     for i in 0..4 {
         let prev_hash = *chain.head_header().unwrap().hash();
         let prev = chain.get_block(&prev_hash).unwrap();
-        let block = Block::empty(&prev, &*signer);
+        let block = Block::empty(prev, &*signer);
         let tip = chain.process_block_test(&None, block).unwrap();
         assert_eq!(tip.unwrap().height, i + 1);
     }
@@ -89,7 +89,7 @@ fn build_chain_with_orhpans() {
     let block = Block::produce(
         PROTOCOL_VERSION,
         PROTOCOL_VERSION,
-        &last_block.header(),
+        last_block.header(),
         10,
         last_block.header().block_ordinal() + 1,
         last_block.chunks().iter().cloned().collect(),
@@ -104,7 +104,7 @@ fn build_chain_with_orhpans() {
         vec![],
         vec![],
         &*signer,
-        last_block.header().next_bp_hash().clone(),
+        *last_block.header().next_bp_hash(),
         CryptoHash::default(),
     );
     assert_eq!(chain.process_block_test(&None, block).unwrap_err().kind(), ErrorKind::Orphan);
@@ -129,8 +129,8 @@ fn build_chain_with_skips_and_forks() {
     init_test_logger();
     let (mut chain, _, signer) = setup();
     let genesis = chain.get_block(&chain.genesis().hash().clone()).unwrap();
-    let b1 = Block::empty(&genesis, &*signer);
-    let b2 = Block::empty_with_height(&genesis, 2, &*signer);
+    let b1 = Block::empty(genesis, &*signer);
+    let b2 = Block::empty_with_height(genesis, 2, &*signer);
     let b3 = Block::empty_with_height(&b1, 3, &*signer);
     let b4 = Block::empty_with_height(&b2, 4, &*signer);
     let b5 = Block::empty(&b4, &*signer);
@@ -154,7 +154,7 @@ fn blocks_at_height() {
     let b_2 = Block::empty_with_height(&b_1, 2, &*signer);
     let b_3 = Block::empty_with_height(&b_2, 3, &*signer);
 
-    let c_1 = Block::empty_with_height(&genesis, 1, &*signer);
+    let c_1 = Block::empty_with_height(genesis, 1, &*signer);
     let c_3 = Block::empty_with_height(&c_1, 3, &*signer);
     let c_4 = Block::empty_with_height(&c_3, 4, &*signer);
     let c_5 = Block::empty_with_height(&c_4, 5, &*signer);
@@ -229,7 +229,7 @@ fn next_blocks() {
     init_test_logger();
     let (mut chain, _, signer) = setup();
     let genesis = chain.get_block(&chain.genesis().hash().clone()).unwrap();
-    let b1 = Block::empty(&genesis, &*signer);
+    let b1 = Block::empty(genesis, &*signer);
     let b2 = Block::empty_with_height(&b1, 2, &*signer);
     let b3 = Block::empty_with_height(&b1, 3, &*signer);
     let b4 = Block::empty_with_height(&b3, 4, &*signer);

--- a/chain/chain/src/validate.rs
+++ b/chain/chain/src/validate.rs
@@ -69,7 +69,7 @@ pub fn validate_chunk_proofs(
     }
     // 2c. Checking that chunk receipts are valid
     if height_created == 0 {
-        return Ok(receipts.len() == 0 && outgoing_receipts_root == CryptoHash::default());
+        return Ok(receipts.is_empty() && outgoing_receipts_root == CryptoHash::default());
     } else {
         let shard_layout = {
             let prev_block_hash = match chunk {
@@ -194,19 +194,19 @@ fn validate_double_sign(
     let left_block_header = BlockHeader::try_from_slice(&block_double_sign.left_block_header)?;
     let right_block_header = BlockHeader::try_from_slice(&block_double_sign.right_block_header)?;
     let block_producer = runtime_adapter
-        .get_block_producer(&left_block_header.epoch_id(), left_block_header.height())?;
+        .get_block_producer(left_block_header.epoch_id(), left_block_header.height())?;
     if left_block_header.hash() != right_block_header.hash()
         && left_block_header.height() == right_block_header.height()
         && runtime_adapter.verify_validator_signature(
-            &left_block_header.epoch_id(),
-            &left_block_header.prev_hash(),
+            left_block_header.epoch_id(),
+            left_block_header.prev_hash(),
             &block_producer,
             left_block_header.hash().as_ref(),
             left_block_header.signature(),
         )?
         && runtime_adapter.verify_validator_signature(
-            &right_block_header.epoch_id(),
-            &right_block_header.prev_hash(),
+            right_block_header.epoch_id(),
+            right_block_header.prev_hash(),
             &block_producer,
             right_block_header.hash().as_ref(),
             right_block_header.signature(),
@@ -269,7 +269,7 @@ fn validate_chunk_proofs_challenge(
     let account_to_slash_for_valid_challenge = Ok((*block_header.hash(), vec![chunk_producer]));
     if !Block::validate_chunk_header_proof(
         &chunk_header,
-        &block_header.chunk_headers_root(),
+        block_header.chunk_headers_root(),
         &chunk_proofs.merkle_proof,
     ) {
         // Merkle proof is invalid. It's a malicious challenge.
@@ -304,7 +304,7 @@ fn validate_chunk_proofs_challenge(
     }
 
     // The chunk is fine. It's a malicious challenge.
-    return Err(ErrorKind::MaliciousChallenge.into());
+    Err(ErrorKind::MaliciousChallenge.into())
 }
 
 fn validate_chunk_state_challenge(
@@ -320,7 +320,7 @@ fn validate_chunk_state_challenge(
     let _ = validate_chunk_authorship(runtime_adapter, &prev_chunk_header)?;
     if !Block::validate_chunk_header_proof(
         &prev_chunk_header,
-        &prev_block_header.chunk_headers_root(),
+        prev_block_header.chunk_headers_root(),
         &chunk_state.prev_merkle_proof,
     ) {
         return Err(ErrorKind::MaliciousChallenge.into());
@@ -331,7 +331,7 @@ fn validate_chunk_state_challenge(
     let chunk_producer = validate_chunk_authorship(runtime_adapter, &chunk_state.chunk_header)?;
     if !Block::validate_chunk_header_proof(
         &chunk_state.chunk_header,
-        &block_header.chunk_headers_root(),
+        block_header.chunk_headers_root(),
         &chunk_state.merkle_proof,
     ) {
         return Err(ErrorKind::MaliciousChallenge.into());
@@ -346,10 +346,10 @@ fn validate_chunk_state_challenge(
             &prev_chunk_header.prev_state_root(),
             block_header.height(),
             block_header.raw_timestamp(),
-            &block_header.prev_hash(),
-            &block_header.hash(),
-            &chunk_state.prev_chunk.receipts(),
-            &chunk_state.prev_chunk.transactions(),
+            block_header.prev_hash(),
+            block_header.hash(),
+            chunk_state.prev_chunk.receipts(),
+            chunk_state.prev_chunk.transactions(),
             ValidatorStakeIter::empty(),
             prev_block_header.gas_price(),
             prev_chunk_header.gas_limit(),


### PR DESCRIPTION
There are a couple code style fixing we can do in the `near-chain`.
In addition we can remove some unnecessary usages of `clone()`.

Split:
- https://github.com/near/nearcore/pull/5655
- https://github.com/near/nearcore/pull/5656
- https://github.com/near/nearcore/pull/5658