### PR TITLE
re+doc(account-id): refactor and fully document near-account-id

### DIFF
--- a/core/account-id/Cargo.toml
+++ b/core/account-id/Cargo.toml
@@ -16,7 +16,7 @@ deepsize_feature = ["deepsize"]
 [dependencies]
 borsh = { version = "0.9", optional = true }
 serde = { version = "1", optional = true }
-deepsize = { version = "0.2.0", optional=true }
+deepsize = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
 serde_json = "1"

--- a/core/account-id/README.md
+++ b/core/account-id/README.md
@@ -1,0 +1,50 @@
+# near-account-id
+
+This crate provides a type for representing a valid, unique account identifier on the [NEAR](https://near.org) network.
+
+[![crates.io](https://img.shields.io/crates/v/near-account-id?label=latest)](https://crates.io/crates/near-account-id)
+[![Documentation](https://docs.rs/near-account-id/badge.svg)](https://docs.rs/near-account-id)
+[![Version](https://img.shields.io/badge/rustc-1.56+-ab6000.svg)](https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html)
+[![Apache 2.0 licensed](https://img.shields.io/crates/l/near-account-id.svg)](https://github.com/near/nearcore/blob/master/licenses/LICENSE-APACHE)
+
+## Usage
+
+```rust
+use near_account_id::AccountId;
+
+let alice: AccountId = "alice.near".parse().unwrap();
+
+// Basic reports for why validation failed
+assert!(
+  matches!(
+    "z".parse::<AccountId>(),
+    Err(err) if err.kind().is_too_short()
+  )
+);
+
+assert!(
+  matches!(
+    "bob__carol".parse::<AccountId>(),
+    Err(err) if err.kind().is_invalid()
+  )
+);
+```
+
+## Account ID Rules
+
+- Minimum length is `2`
+- Maximum length is `64`
+- An Account ID consists of Account ID parts separated by `.`, example:
+  - `root` ✔
+  - `alice.near` ✔
+  - `bob.stage.testnet` ✔
+- Must not start or end with separators (`_`, `-` or `.`):
+  - `_alice.` ✗
+  - `.bob.near-` ✗
+- Each part of the Account ID consists of lowercase alphanumeric symbols separated either by `_` or `-`, example:
+  - `1_4m_n0t-al1c3.near` ✔
+- Separators are not permitted to immediately follow each other, example:
+  - `alice..near` ✗
+  - `not-_alice.near` ✗
+
+Learn more here: <https://docs.near.org/docs/concepts/account#account-id-rules>

--- a/core/account-id/README.md
+++ b/core/account-id/README.md
@@ -24,7 +24,24 @@ assert!(
 
 assert!(
   matches!(
+    // no caps
+    "MelissaCarver.near".parse::<AccountId>(),
+    Err(err) if err.kind().is_invalid()
+  )
+);
+
+assert!(
+  matches!(
+    // separators cannot immediately follow each other
     "bob__carol".parse::<AccountId>(),
+    Err(err) if err.kind().is_invalid()
+  )
+);
+
+assert!(
+  matches!(
+    // each part must be alphanumeric only (ƒ is not f)
+    "ƒelicia.near".parse::<AccountId>(),
     Err(err) if err.kind().is_invalid()
   )
 );
@@ -34,17 +51,19 @@ assert!(
 
 - Minimum length is `2`
 - Maximum length is `64`
-- An Account ID consists of Account ID parts separated by `.`, example:
-  - `root` ✔
-  - `alice.near` ✔
-  - `bob.stage.testnet` ✔
+- An **Account ID** consists of **Account ID parts** separated by `.`, example:
+  - `root` ✓
+  - `alice.near` ✓
+  - `app.stage.testnet` ✓
 - Must not start or end with separators (`_`, `-` or `.`):
   - `_alice.` ✗
   - `.bob.near-` ✗
-- Each part of the Account ID consists of lowercase alphanumeric symbols separated either by `_` or `-`, example:
-  - `1_4m_n0t-al1c3.near` ✔
+- Each part of the **Account ID** consists of lowercase alphanumeric symbols separated either by `_` or `-`, example:
+  - `ƒelicia.near` ✗ (`ƒ` is not `f`)
+  - `1_4m_n0t-al1c3.near` ✓
 - Separators are not permitted to immediately follow each other, example:
   - `alice..near` ✗
   - `not-_alice.near` ✗
+- An **Account ID** that is 64 characters long and consists of lowercase hex characters is a specific **implicit account ID**
 
 Learn more here: <https://docs.near.org/docs/concepts/account#account-id-rules>

--- a/core/account-id/fuzz/Cargo.lock
+++ b/core/account-id/fuzz/Cargo.lock
@@ -16,9 +16,9 @@ checksum = "237430fd6ed3740afe94eefcc278ae21e050285be882804e0d6e8695f0c94691"
 
 [[package]]
 name = "borsh"
-version = "0.8.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a7111f797cc721407885a323fb071636aee57f750b1a4ddc27397eba168a74"
+checksum = "18dda7dc709193c0d86a1a51050a926dc3df1cf262ec46a23a25dba421ea1924"
 dependencies = [
  "borsh-derive",
  "hashbrown",
@@ -26,9 +26,9 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "0.8.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307f3740906bac2c118a8122fe22681232b244f1369273e45f1156b45c43d2dd"
+checksum = "684155372435f578c0fa1acd13ebbb182cc19d6b38b64ae7901da4393217d264"
 dependencies = [
  "borsh-derive-internal",
  "borsh-schema-derive-internal",
@@ -39,9 +39,9 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive-internal"
-version = "0.8.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2104c73179359431cc98e016998f2f23bc7a05bc53e79741bcba705f30047bc"
+checksum = "2102f62f8b6d3edeab871830782285b64cc1830168094db05c8e458f209bc5c3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -50,9 +50,9 @@ dependencies = [
 
 [[package]]
 name = "borsh-schema-derive-internal"
-version = "0.8.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae29eb8418fcd46f723f8691a2ac06857d31179d33d2f2d91eb13967de97c728"
+checksum = "196c978c4c9b0b142d446ef3240690bf5a8a33497074a113ff9a337ccb750483"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "near-account-id"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "borsh",
  "serde",

--- a/core/account-id/fuzz/README.md
+++ b/core/account-id/fuzz/README.md
@@ -1,0 +1,19 @@
+# Fuzzing `near-account-id`
+
+## Setup
+
+First, ensure `cargo-fuzz` is installed:
+
+```console
+cargo install cargo-fuzz
+```
+
+## Execution
+
+Finally, there are two fuzzing targets available: one for [`serde`](https://github.com/serde-rs/serde) and another for [`borsh`](https://github.com/near/borsh-rs). You can run both tests with:
+
+```console
+cd core/account-id/fuzz
+RUSTC_BOOTSTRAP=1 cargo fuzz run serde
+RUSTC_BOOTSTRAP=1 cargo fuzz run borsh
+```

--- a/core/account-id/fuzz/README.md
+++ b/core/account-id/fuzz/README.md
@@ -1,14 +1,14 @@
-# Fuzzing `near-account-id`
+## Fuzzing `near-account-id`
 
-## Setup
+### Setup
 
-First, ensure `cargo-fuzz` is installed:
+First, ensure [`cargo-fuzz`](https://github.com/rust-fuzz/cargo-fuzz) is installed:
 
 ```console
 cargo install cargo-fuzz
 ```
 
-## Execution
+### Execution
 
 Finally, there are two fuzzing targets available: one for [`serde`](https://github.com/serde-rs/serde) and another for [`borsh`](https://github.com/near/borsh-rs). You can run both tests with:
 
@@ -16,4 +16,11 @@ Finally, there are two fuzzing targets available: one for [`serde`](https://gith
 cd core/account-id/fuzz
 RUSTC_BOOTSTRAP=1 cargo fuzz run serde
 RUSTC_BOOTSTRAP=1 cargo fuzz run borsh
+```
+
+By default each fuzz test runs infinitely. To specify how many runs each test is allowed, you can use this:
+
+```console
+RUSTC_BOOTSTRAP=1 cargo fuzz run serde -runs=1000000000
+RUSTC_BOOTSTRAP=1 cargo fuzz run borsh -runs=1000000000
 ```

--- a/core/account-id/src/error.rs
+++ b/core/account-id/src/error.rs
@@ -1,14 +1,16 @@
 use std::fmt;
 
 /// An error occurred when parsing an invalid Account ID with [`AccountId::validate`](crate::AccountId::validate).
-#[derive(Eq, Hash, Clone, Debug, PartialEq)]
+#[derive(Eq, Clone, Debug, PartialEq)]
 pub struct ParseAccountError(pub(crate) ParseErrorKind, pub(crate) String);
 
 impl ParseAccountError {
+    /// Returns the corresponding [`ParseErrorKind`] for this error.
     pub fn kind(&self) -> &ParseErrorKind {
         &self.0
     }
 
+    /// Returns the corresponding [`AccountId`](crate::AccountId) for this error.
     pub fn get_account_id(self) -> String {
         self.1
     }
@@ -22,7 +24,8 @@ impl fmt::Display for ParseAccountError {
 }
 
 /// A list of errors that occur when parsing an invalid Account ID.
-#[derive(Eq, Hash, Clone, Debug, PartialEq)]
+#[non_exhaustive]
+#[derive(Eq, Clone, Debug, PartialEq)]
 pub enum ParseErrorKind {
     TooLong,
     TooShort,
@@ -30,14 +33,23 @@ pub enum ParseErrorKind {
 }
 
 impl ParseErrorKind {
+    /// Returns `true` if the Account Id was too long.
     pub fn is_too_long(&self) -> bool {
         matches!(self, ParseErrorKind::TooLong)
     }
 
+    /// Returns `true` if the Account Id was too short.
     pub fn is_too_short(&self) -> bool {
         matches!(self, ParseErrorKind::TooShort)
     }
 
+    /// Returns `true` if the Account Id was marked invalid.
+    ///
+    /// This can happen for the following reasons:
+    ///
+    /// - An invalid character was detected (could be an uppercase character, symbol or space).
+    /// - Separators immediately follow each other.
+    /// - Separators begin or end the Account ID.
     pub fn is_invalid(&self) -> bool {
         matches!(self, ParseErrorKind::Invalid)
     }
@@ -46,9 +58,9 @@ impl ParseErrorKind {
 impl fmt::Display for ParseErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            ParseErrorKind::TooLong => write!(f, "the value is too long for account ID"),
-            ParseErrorKind::TooShort => write!(f, "the value is too short for account ID"),
-            ParseErrorKind::Invalid => write!(f, "the value has invalid characters for account ID"),
+            ParseErrorKind::TooLong => write!(f, "the account ID is too long"),
+            ParseErrorKind::TooShort => write!(f, "the account ID is too short"),
+            _ => write!(f, "the account ID has an invalid format"),
         }
     }
 }

--- a/core/account-id/src/errors.rs
+++ b/core/account-id/src/errors.rs
@@ -33,17 +33,17 @@ pub enum ParseErrorKind {
 }
 
 impl ParseErrorKind {
-    /// Returns `true` if the Account Id was too long.
+    /// Returns `true` if the Account ID was too long.
     pub fn is_too_long(&self) -> bool {
         matches!(self, ParseErrorKind::TooLong)
     }
 
-    /// Returns `true` if the Account Id was too short.
+    /// Returns `true` if the Account ID was too short.
     pub fn is_too_short(&self) -> bool {
         matches!(self, ParseErrorKind::TooShort)
     }
 
-    /// Returns `true` if the Account Id was marked invalid.
+    /// Returns `true` if the Account ID was marked invalid.
     ///
     /// This can happen for the following reasons:
     ///

--- a/core/account-id/src/lib.rs
+++ b/core/account-id/src/lib.rs
@@ -63,7 +63,7 @@
 
 use std::{fmt, str::FromStr};
 
-mod error;
+mod errors;
 
 #[cfg(feature = "borsh")]
 mod borsh;
@@ -72,7 +72,7 @@ mod serde;
 
 #[cfg(feature = "deepsize_feature")]
 use deepsize::DeepSizeOf;
-pub use error::{ParseAccountError, ParseErrorKind};
+pub use errors::{ParseAccountError, ParseErrorKind};
 
 /// Smallest valid length for a NEAR Account ID.
 pub const MIN_ACCOUNT_ID_LEN: usize = 2;
@@ -139,7 +139,7 @@ impl AccountId {
     /// let carol: AccountId = "carol.near".parse().unwrap();
     /// assert_eq!(10, carol.len());
     /// ```
-
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.0.len()
     }
@@ -291,6 +291,7 @@ impl AccountId {
     /// You can use the [`AccountId::validate`] function sometime after its creation but before it's use.
     ///
     /// ## Examples
+    ///
     /// ```
     /// use near_account_id::AccountId;
     ///

--- a/core/account-id/src/lib.rs
+++ b/core/account-id/src/lib.rs
@@ -1,3 +1,47 @@
+//! This crate provides a type for representing a valid, unique account identifier on the [NEAR](https://near.org) network.
+//!
+//! ## Usage
+//!
+//! ```rust
+//! use near_account_id::AccountId;
+//!
+//! let alice: AccountId = "alice.near".parse().unwrap();
+//!
+//! // Basic reports for why validation failed
+//! assert!(
+//!   matches!(
+//!     "z".parse::<AccountId>(),
+//!     Err(err) if err.kind().is_too_short()
+//!   )
+//! );
+//!
+//! assert!(
+//!   matches!(
+//!     "bob__carol".parse::<AccountId>(),
+//!     Err(err) if err.kind().is_invalid()
+//!   )
+//! );
+//! ```
+//!
+//! ## Account ID Rules
+//!
+//! - Minimum length is `2`
+//! - Maximum length is `64`
+//! - An Account ID consists of Account ID parts separated by `.`, example:
+//!   - `root` ✔
+//!   - `alice.near` ✔
+//!   - `bob.stage.testnet` ✔
+//! - Must not start or end with separators (`_`, `-` or `.`):
+//!   - `_alice.` ✗
+//!   - `.bob.near-` ✗
+//! - Each part of the Account ID consists of lowercase alphanumeric symbols separated either by `_` or `-`, example:
+//!   - `1_4m_n0t-al1c3.near` ✔
+//! - Separators are not permitted to immediately follow each other, example:
+//!   - `alice..near` ✗
+//!   - `not-_alice.near` ✗
+//!
+//! Learn more here: https://docs.near.org/docs/concepts/account#account-id-rules
+
 use std::{fmt, str::FromStr};
 
 mod error;

--- a/core/account-id/src/lib.rs
+++ b/core/account-id/src/lib.rs
@@ -208,7 +208,9 @@ impl AccountId {
     /// let alice: AccountId = "alice.near".parse().unwrap();
     /// assert!(!alice.is_implicit());
     ///
-    /// let rando: AccountId = "98793cd91a3f870fb126f66285808c7e094afcfc4eda8a970f6648cdf0dbd6de".parse().unwrap();
+    /// let rando = "98793cd91a3f870fb126f66285808c7e094afcfc4eda8a970f6648cdf0dbd6de"
+    ///     .parse::<AccountId>()
+    ///     .unwrap();
     /// assert!(rando.is_implicit());
     /// ```
     pub fn is_implicit(&self) -> bool {

--- a/runtime/near-vm-logic/src/logic.rs
+++ b/runtime/near-vm-logic/src/logic.rs
@@ -1580,7 +1580,7 @@ impl<'a> VMLogic<'a> {
         let receiver_id = self.get_account_by_receipt(&receipt_idx);
         let is_receiver_implicit =
             is_implicit_account_creation_enabled(self.current_protocol_version)
-                && AccountId::is_implicit(receiver_id.as_ref());
+                && receiver_id.is_implicit();
 
         let send_fee =
             transfer_send_fee(&self.fees_config.action_creation_config, sir, is_receiver_implicit);

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -396,7 +396,7 @@ pub(crate) fn action_implicit_account_creation_transfer(
     current_protocol_version: ProtocolVersion,
 ) {
     // NOTE: The account_id is hex like, because we've checked the permissions before.
-    debug_assert!(AccountId::is_implicit(account_id.as_ref()));
+    debug_assert!(account_id.is_implicit());
 
     *actor_id = account_id.clone();
 
@@ -659,7 +659,7 @@ pub(crate) fn check_account_existence(
                 .into());
             } else {
                 if is_implicit_account_creation_enabled(current_protocol_version)
-                    && AccountId::is_implicit(account_id.as_ref())
+                    && account_id.is_implicit()
                 {
                     // If the account doesn't exist and it's 64-length hex account ID, then you
                     // should only be able to create it using single transfer action.
@@ -681,7 +681,7 @@ pub(crate) fn check_account_existence(
             if account.is_none() {
                 return if is_implicit_account_creation_enabled(current_protocol_version)
                     && is_the_only_action
-                    && AccountId::is_implicit(account_id.as_ref())
+                    && account_id.is_implicit()
                     && !is_refund
                 {
                     // OK. It's implicit account creation.

--- a/runtime/runtime/src/config.rs
+++ b/runtime/runtime/src/config.rs
@@ -95,7 +95,7 @@ pub fn total_send_fees(
                 // Account for implicit account creation
                 let is_receiver_implicit =
                     is_implicit_account_creation_enabled(current_protocol_version)
-                        && AccountId::is_implicit(receiver_id.as_ref());
+                        && receiver_id.is_implicit();
                 transfer_send_fee(cfg, sender_is_receiver, is_receiver_implicit)
             }
             Stake(_) => cfg.stake_cost.send_fee(sender_is_receiver),
@@ -153,7 +153,7 @@ pub fn exec_fee(
             // Account for implicit account creation
             let is_receiver_implicit =
                 is_implicit_account_creation_enabled(current_protocol_version)
-                    && AccountId::is_implicit(receiver_id.as_ref());
+                    && receiver_id.is_implicit();
             transfer_exec_fee(cfg, is_receiver_implicit)
         }
         Stake(_) => cfg.stake_cost.exec_fee(),


### PR DESCRIPTION
Exhaustively documents `near-account-id` including fuzz tests and refactors the API a bit.

What's different on the API?:

- `AccountId::is_implicit` is now a method on an already validated `AccountId`, no longer an associated method.

    ```rust
    // before
    AccountId::is_implicit("6bf3a4a59f8a23edc2fb96a94fc14be697353f49f3ec49b02a4764a5648fa4a5");

    // after
    "6bf3a4a59f8a23edc2fb96a94fc14be697353f49f3ec49b02a4764a5648fa4a5"
        .parse::<AccountId>()?
        .is_implicit();
    ```

cc @mm-near