### PR TITLE
pytest: close stdout and stderr when local node is cleaned up

### DIFF
--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -379,14 +379,16 @@ class LocalNode(BaseNode):
         env["RUST_LOG"] = "actix_web=warn,mio=warn,tokio_util=warn,actix_server=warn,actix_http=warn," + env.get(
             "RUST_LOG", "debug")
 
-        self._stdout = open(os.path.join(self.node_dir, 'stdout'), 'a')
-        self._stderr = open(os.path.join(self.node_dir, 'stderr'), 'a')
         cmd = self._get_command_line(self.near_root, self.node_dir, boot_node,
                                      self.binary_name)
-        self.pid.value = subprocess.Popen(cmd,
-                                          stdout=self._stdout,
-                                          stderr=self._stderr,
-                                          env=env).pid
+        node_dir = pathlib.Path(self.node_dir)
+        stdout, stderr = node_dir / 'stdout', node_dir / 'stderr'
+        with open(stdout, 'ab') as stdout_fd, open(stderr, 'ab') as stderr_fd:
+            self.pid.value = subprocess.Popen(cmd,
+                                              stdin=subprocess.DEVNULL,
+                                              stdout=stdout_fd,
+                                              stderr=stderr_fd,
+                                              env=env).pid
 
         if not skip_starting_proxy:
             self.start_proxy_if_needed()
@@ -398,15 +400,9 @@ class LocalNode(BaseNode):
                 '=== failed to start node, rpc does not ready in 10 seconds')
             if os.environ.get('BUILDKITE'):
                 logger.info('=== stdout: ')
-                self._stdout.seek(0)
-                logger.info(self._stdout.read())
+                logger.info(stdout.read_text('utf-8', 'replace'))
                 logger.info('=== stderr: ')
-                self._stderr.seek(0)
-                logger.info(self._stdout.read())
-            self._stdout.close()
-            self._stderr.close()
-            self._stdout = None
-            self._stderr = None
+                logger.info(stderr.read_text('utf-8', 'replace'))
 
     def kill(self):
         if self.pid.value != 0:
@@ -440,12 +436,6 @@ class LocalNode(BaseNode):
             self.kill()
         except:
             logger.critical('Kill failed on cleanup!', exc_info=sys.exc_info())
-
-        if self._stdout:
-            self._stdout.close()
-            self._stderr.close()
-            self._stdout = None
-            self._stderr = None
 
         # move the node dir to avoid weird interactions with multiple serial test invocations
         target_path = self.node_dir + '_finished'


### PR DESCRIPTION
This fixes the following warning when trying to run tests with
unittest fixture:

    sys:1: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/mpn/.near/test0/stdout' mode='a' encoding='UTF-8'>
    sys:1: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/mpn/.near/test0/stderr' mode='a' encoding='UTF-8'>

Issue: https://github.com/near/nearcore/issues/3186
Issue: https://github.com/near/nearcore/issues/4618