### PR TITLE
feat: Remove `Copy` trait from `Cryptohash`

### DIFF
--- a/chain/chain/src/doomslug.rs
+++ b/chain/chain/src/doomslug.rs
@@ -317,7 +317,7 @@ impl Doomslug {
 
     /// Returns the `(hash, height)` of the current tip. Currently is only used by tests.
     pub fn get_tip(&self) -> (CryptoHash, BlockHeight) {
-        (self.tip.block_hash, self.tip.height)
+        (self.tip.block_hash.clone(), self.tip.height)
     }
 
     /// Returns the largest height for which we have enough approvals to be theoretically able to
@@ -410,7 +410,7 @@ impl Doomslug {
 
     pub fn create_approval(&self, target_height: BlockHeight) -> Option<Approval> {
         self.signer.as_ref().map(|signer| {
-            Approval::new(self.tip.block_hash, self.tip.height, target_height, &**signer)
+            Approval::new(self.tip.block_hash.clone(), self.tip.height, target_height, &**signer)
         })
     }
 

--- a/chain/chain/src/lightclient.rs
+++ b/chain/chain/src/lightclient.rs
@@ -39,14 +39,14 @@ pub fn create_light_client_block_view(
 ) -> Result<LightClientBlockView, Error> {
     let inner_lite_view = BlockHeaderInnerLiteView {
         height: block_header.height(),
-        epoch_id: block_header.epoch_id().0,
-        next_epoch_id: block_header.next_epoch_id().0,
-        prev_state_root: *block_header.prev_state_root(),
-        outcome_root: *block_header.outcome_root(),
+        epoch_id: block_header.epoch_id().0.clone(),
+        next_epoch_id: block_header.next_epoch_id().0.clone(),
+        prev_state_root: block_header.prev_state_root().clone(),
+        outcome_root: block_header.outcome_root().clone(),
         timestamp: block_header.raw_timestamp(),
         timestamp_nanosec: block_header.raw_timestamp(),
-        next_bp_hash: *block_header.next_bp_hash(),
-        block_merkle_root: *block_header.block_merkle_root(),
+        next_bp_hash: block_header.next_bp_hash().clone(),
+        block_merkle_root: block_header.block_merkle_root().clone(),
     };
     let inner_rest_hash = hash(&block_header.inner_rest_bytes());
 
@@ -62,7 +62,7 @@ pub fn create_light_client_block_view(
     let approvals_after_next = after_next_block_header.approvals().to_vec();
 
     Ok(LightClientBlockView {
-        prev_block_hash: *block_header.prev_hash(),
+        prev_block_hash: block_header.prev_hash().clone(),
         next_block_inner_hash,
         inner_lite: inner_lite_view,
         inner_rest_hash,

--- a/chain/chain/src/tests/challenges.rs
+++ b/chain/chain/src/tests/challenges.rs
@@ -8,10 +8,10 @@ fn challenges_new_head_prev() {
     let (mut chain, _, signer) = setup();
     let mut hashes = vec![];
     for i in 0..5 {
-        let prev_hash = *chain.head_header().unwrap().hash();
+        let prev_hash = chain.head_header().unwrap().hash().clone();
         let prev = chain.get_block(&prev_hash).unwrap();
         let block = Block::empty(&prev, &*signer);
-        hashes.push(*block.hash());
+        hashes.push(block.hash().clone());
         let tip = chain.process_block_test(&None, block).unwrap();
         assert_eq!(tip.unwrap().height, i + 1);
     }
@@ -24,7 +24,7 @@ fn challenges_new_head_prev() {
 
     let prev = chain.get_block(&hashes[1]).unwrap();
     let challenger_block = Block::empty_with_height(&prev, 3, &*signer);
-    let challenger_hash = *challenger_block.hash();
+    let challenger_hash = challenger_block.hash().clone();
 
     let _ = chain.process_block_test(&None, challenger_block).unwrap();
 
@@ -78,7 +78,7 @@ fn challenges_new_head_prev() {
 fn test_no_challenge_on_same_header() {
     init_test_logger();
     let (mut chain, _, signer) = setup();
-    let prev_hash = *chain.head_header().unwrap().hash();
+    let prev_hash = chain.head_header().unwrap().hash().clone();
     let prev = chain.get_block(&prev_hash).unwrap();
     let block = Block::empty(&prev, &*signer);
     let tip = chain.process_block_test(&None, block.clone()).unwrap();

--- a/chain/chain/src/tests/doomslug.rs
+++ b/chain/chain/src/tests/doomslug.rs
@@ -142,7 +142,7 @@ fn one_iter(
                         if prev_block_info.0 as BlockHeight <= ds.get_tip().1 {
                             break;
                         }
-                        block_infos.push(*prev_block_info);
+                        block_infos.push(prev_block_info.clone());
                     }
 
                     for block_info in block_infos.into_iter().rev() {
@@ -213,18 +213,20 @@ fn one_iter(
                                 whom,
                                 last_final_height,
                                 get_msg_delivery_time(now, gst, delta),
-                                block_hash,
+                                block_hash.clone(),
                             );
                             block_queue.push(block_info);
                         }
 
-                        hash_to_block_info
-                            .insert(block_hash, (target_height, last_final_height, block_hash));
-                        hash_to_prev_hash.insert(block_hash, parent_hash);
+                        hash_to_block_info.insert(
+                            block_hash.clone(),
+                            (target_height, last_final_height, block_hash.clone()),
+                        );
+                        hash_to_prev_hash.insert(block_hash.clone(), parent_hash.clone());
 
                         assert!(chain_lengths.get(&block_hash).is_none());
                         let prev_length = *chain_lengths.get(&ds.get_tip().0).unwrap();
-                        chain_lengths.insert(block_hash, prev_length + 1);
+                        chain_lengths.insert(block_hash.clone(), prev_length + 1);
 
                         if is_final && target_height != 2 {
                             blocks_with_finality.push((
@@ -246,7 +248,7 @@ fn one_iter(
                         if block_ord + 1 == num_blocks_to_produce {
                             ds.set_tip(
                                 now,
-                                block_hash,
+                                block_hash.clone(),
                                 target_height as BlockHeight,
                                 last_final_height,
                             );
@@ -281,14 +283,14 @@ fn one_iter(
     for (block_hash, (block_height, _, _)) in hash_to_block_info.iter() {
         let mut seen_hashes = HashSet::new();
         let mut block_hash = block_hash.clone();
-        seen_hashes.insert(block_hash);
+        seen_hashes.insert(block_hash.clone());
 
         loop {
             match hash_to_prev_hash.get(&block_hash) {
                 None => break,
                 Some(prev_block_hash) => {
-                    block_hash = *prev_block_hash;
-                    seen_hashes.insert(block_hash);
+                    block_hash = prev_block_hash.clone();
+                    seen_hashes.insert(block_hash.clone());
                 }
             }
         }

--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -40,7 +40,7 @@ fn build_chain() {
 
     let (mut chain, _, signer) = setup();
 
-    let prev_hash = *chain.head_header().unwrap().hash();
+    let prev_hash = chain.head_header().unwrap().hash().clone();
     #[cfg(feature = "nightly_protocol")]
     assert_eq!(
         prev_hash,
@@ -53,7 +53,7 @@ fn build_chain() {
     );
 
     for i in 0..4 {
-        let prev_hash = *chain.head_header().unwrap().hash();
+        let prev_hash = chain.head_header().unwrap().hash().clone().clone();
         let prev = chain.get_block(&prev_hash).unwrap();
         let block = Block::empty(&prev, &*signer);
         let tip = chain.process_block_test(&None, block).unwrap();
@@ -165,20 +165,20 @@ fn blocks_at_height() {
 
     let e_7 = Block::empty_with_height(&b_1, 7, &*signer);
 
-    let b_1_hash = *b_1.hash();
-    let b_2_hash = *b_2.hash();
-    let b_3_hash = *b_3.hash();
+    let b_1_hash = b_1.hash().clone();
+    let b_2_hash = b_2.hash().clone();
+    let b_3_hash = b_3.hash().clone();
 
-    let c_1_hash = *c_1.hash();
-    let c_3_hash = *c_3.hash();
-    let c_4_hash = *c_4.hash();
-    let c_5_hash = *c_5.hash();
+    let c_1_hash = c_1.hash().clone();
+    let c_3_hash = c_3.hash().clone();
+    let c_4_hash = c_4.hash().clone();
+    let c_5_hash = c_5.hash().clone();
 
-    let d_3_hash = *d_3.hash();
-    let d_4_hash = *d_4.hash();
-    let d_6_hash = *d_6.hash();
+    let d_3_hash = d_3.hash().clone();
+    let d_4_hash = d_4.hash().clone();
+    let d_6_hash = d_6.hash().clone();
 
-    let e_7_hash = *e_7.hash();
+    let e_7_hash = e_7.hash().clone();
 
     assert_ne!(d_3_hash, b_3_hash);
 
@@ -233,10 +233,10 @@ fn next_blocks() {
     let b2 = Block::empty_with_height(&b1, 2, &*signer);
     let b3 = Block::empty_with_height(&b1, 3, &*signer);
     let b4 = Block::empty_with_height(&b3, 4, &*signer);
-    let b1_hash = *b1.hash();
-    let b2_hash = *b2.hash();
-    let b3_hash = *b3.hash();
-    let b4_hash = *b4.hash();
+    let b1_hash = b1.hash().clone();
+    let b2_hash = b2.hash().clone();
+    let b3_hash = b3.hash().clone();
+    let b4_hash = b4.hash().clone();
     assert!(chain.process_block_test(&None, b1).is_ok());
     assert!(chain.process_block_test(&None, b2).is_ok());
     assert_eq!(chain.mut_store().get_next_block_hash(&b1_hash).unwrap(), &b2_hash);

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -142,12 +142,12 @@ pub struct BlockHeaderInfo {
 impl BlockHeaderInfo {
     pub fn new(header: &BlockHeader, last_finalized_height: u64) -> Self {
         Self {
-            hash: *header.hash(),
-            prev_hash: *header.prev_hash(),
+            hash: header.hash().clone(),
+            prev_hash: header.prev_hash().clone(),
             height: header.height(),
-            random_value: *header.random_value(),
+            random_value: header.random_value().clone(),
             last_finalized_height,
-            last_finalized_block_hash: *header.last_final_block(),
+            last_finalized_block_hash: header.last_final_block().clone(),
             proposals: header.validator_proposals().collect(),
             slashed_validators: vec![],
             chunk_mask: header.chunk_mask().to_vec(),
@@ -849,15 +849,15 @@ mod tests {
             KeyType::ED25519,
             "other2",
         );
-        let approvals = vec![Some(Approval::new(*b1.hash(), 1, 2, &other_signer).signature)];
+        let approvals = vec![Some(Approval::new(b1.hash().clone(), 1, 2, &other_signer).signature)];
         let b2 = Block::empty_with_approvals(
             &b1,
             2,
             b1.header().epoch_id().clone(),
-            EpochId(*genesis.hash()),
+            EpochId(genesis.hash().clone()),
             approvals,
             &signer,
-            *genesis.header().next_bp_hash(),
+            genesis.header().next_bp_hash().clone(),
             CryptoHash::default(),
         );
         b2.header().verify_block_producer(&signer.public_key());
@@ -892,7 +892,7 @@ mod tests {
         let outcomes = vec![outcome1, outcome2];
         let (outcome_root, paths) = ApplyTransactionResult::compute_outcomes_proof(&outcomes);
         for (outcome_with_id, path) in outcomes.into_iter().zip(paths.into_iter()) {
-            assert!(verify_path(outcome_root, &path, &outcome_with_id.to_hashes()));
+            assert!(verify_path(outcome_root.clone(), &path, &outcome_with_id.to_hashes()));
         }
     }
 }

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -662,7 +662,7 @@ impl ShardsManager {
             chunk_hash.clone(),
             ChunkRequestInfo {
                 height,
-                parent_hash,
+                parent_hash: parent_hash.clone(),
                 shard_id,
                 last_requested: Clock::instant(),
                 added: Clock::instant(),
@@ -1068,7 +1068,7 @@ impl ShardsManager {
         // check part merkle proofs
         let num_total_parts = self.runtime_adapter.num_total_parts();
         for part_info in forward.parts.iter() {
-            self.validate_part(forward.merkle_root, part_info, num_total_parts)?;
+            self.validate_part(forward.merkle_root.clone(), part_info, num_total_parts)?;
         }
 
         // check signature
@@ -1223,7 +1223,7 @@ impl ShardsManager {
             if let Ok(hash) = chain_store
                 .get_any_chunk_hash_by_height_shard(header.height_created(), header.shard_id())
             {
-                if *hash != chunk_hash {
+                if hash.clone() != chunk_hash {
                     warn!(target: "client", "Rejecting unrequested chunk {:?}, height {}, shard_id {}, because of having {:?}", chunk_hash, header.height_created(), header.shard_id(), hash);
                     return Err(Error::DuplicateChunkHeight.into());
                 }

--- a/chain/chunks/src/test_utils.rs
+++ b/chain/chunks/src/test_utils.rs
@@ -214,7 +214,7 @@ impl Default for ChunkForwardingTestFixture {
         let (receipts_root, _) = merkle::merklize(&receipts_hashes);
         let (mock_chunk, mock_merkles) = producer_shard_manager
             .create_encoded_shard_chunk(
-                mock_parent_hash,
+                mock_parent_hash.clone(),
                 Default::default(),
                 Default::default(),
                 mock_height,

--- a/chain/client/src/tests/bug_repros.rs
+++ b/chain/client/src/tests/bug_repros.rs
@@ -117,7 +117,7 @@ fn repro_1183() {
                                                 from.as_ref(),
                                             ),
                                             1,
-                                            *block.header().prev_hash(),
+                                            block.header().prev_hash().clone(),
                                         ),
                                         is_forwarded: false,
                                         check_only: false,
@@ -225,7 +225,7 @@ fn test_sync_from_achival_node() {
                                 }
                             }
                             if block.header().height() <= 10 {
-                                blocks.write().unwrap().insert(*block.hash(), block.clone());
+                                blocks.write().unwrap().insert(block.hash().clone(), block.clone());
                             }
                             (NetworkResponses::NoResponse.into(), false)
                         }

--- a/chain/client/src/tests/catching_up.rs
+++ b/chain/client/src/tests/catching_up.rs
@@ -195,7 +195,7 @@ fn test_catchup_receipts_sync_common(wait_till: u64, send: u64, sync_hold: bool)
                                             account_to.clone(),
                                             111,
                                             1,
-                                            *block.header().prev_hash(),
+                                            block.header().prev_hash().clone(),
                                         );
                                     }
                                     *phase = ReceiptsSyncPhases::WaitingForSecondBlock;
@@ -260,7 +260,7 @@ fn test_catchup_receipts_sync_common(wait_till: u64, send: u64, sync_hold: bool)
                                 if sync_hold {
                                     let srs = StateRequestStruct {
                                         shard_id: *shard_id,
-                                        sync_hash: *sync_hash,
+                                        sync_hash: sync_hash.clone(),
                                         part_id: None,
                                         target: target.clone(),
                                     };
@@ -283,7 +283,7 @@ fn test_catchup_receipts_sync_common(wait_till: u64, send: u64, sync_hold: bool)
                                 if sync_hold {
                                     let srs = StateRequestStruct {
                                         shard_id: *shard_id,
-                                        sync_hash: *sync_hash,
+                                        sync_hash: sync_hash.clone(),
                                         part_id: Some(*part_id),
                                         target: target.clone(),
                                     };
@@ -505,7 +505,7 @@ fn test_catchup_random_single_part_sync_common(skip_15: bool, non_zero: bool, he
                                                     validator2.clone(),
                                                     amount,
                                                     (12345 + tx_count) as u64,
-                                                    *block.header().prev_hash(),
+                                                    block.header().prev_hash().clone(),
                                                 );
                                             }
                                             tx_count += 1;
@@ -659,12 +659,18 @@ fn test_catchup_sanity_blocks_produced() {
                 move |_account_id: _, msg: &PeerManagerMessageRequest| {
                     let msg = msg.as_network_requests_ref();
                     let propagate = if let NetworkRequests::Block { block } = msg {
-                        check_height(*block.hash(), block.header().height());
+                        check_height(block.hash().clone(), block.header().height());
 
                         if block.header().height() % 10 == 5 {
-                            check_height(*block.header().prev_hash(), block.header().height() - 2);
+                            check_height(
+                                block.header().prev_hash().clone(),
+                                block.header().height() - 2,
+                            );
                         } else {
-                            check_height(*block.header().prev_hash(), block.header().height() - 1);
+                            check_height(
+                                block.header().prev_hash().clone(),
+                                block.header().height() - 1,
+                            );
                         }
 
                         if block.header().height() >= 25 {
@@ -763,7 +769,7 @@ fn test_chunk_grieving() {
                             if let NetworkRequests::Block { block } = msg {
                                 if block.header().height() == 12 {
                                     println!("BLOCK {:?}", block);
-                                    *unaccepted_block_hash = *block.header().hash();
+                                    *unaccepted_block_hash = block.header().hash().clone();
                                     assert_eq!(4, block.header().chunks_included());
                                     *phase = ChunkGrievingPhases::SecondAttack;
                                 }

--- a/chain/client/src/tests/chunks_management.rs
+++ b/chain/client/src/tests/chunks_management.rs
@@ -119,7 +119,7 @@ fn store_partial_encoded_chunk_sanity() {
         parts: vec![],
         receipts: vec![],
     };
-    let block_hash = *env.clients[0].chain.genesis().hash();
+    let block_hash = env.clients[0].chain.genesis().hash().clone();
     let block = env.clients[0].chain.get_block(&block_hash).unwrap().clone();
     assert_eq!(env.clients[0].shards_mgr.pop_stored_partial_encoded_chunks(1).len(), 0);
     env.clients[0]

--- a/chain/client/src/tests/consensus.rs
+++ b/chain/client/src/tests/consensus.rs
@@ -106,8 +106,9 @@ fn test_consensus_with_epoch_switches() {
                                 );
                             }
                             all_blocks.insert(block.header().height(), block.clone());
-                            block_to_prev_block.insert(*block.hash(), *block.header().prev_hash());
-                            block_to_height.insert(*block.hash(), block.header().height());
+                            block_to_prev_block
+                                .insert(block.hash().clone(), block.header().prev_hash().clone());
+                            block_to_height.insert(block.hash().clone(), block.header().height());
 
                             if *largest_block_height / 20 < block.header().height() / 20 {
                                 // Periodically verify the finality
@@ -167,7 +168,7 @@ fn test_consensus_with_epoch_switches() {
                             *delayed_blocks = new_delayed_blocks;
 
                             let mut heights = vec![];
-                            let mut cur_hash = *block.hash();
+                            let mut cur_hash = block.hash().clone();
                             while let Some(height) = block_to_height.get(&cur_hash) {
                                 heights.push(height);
                                 cur_hash = block_to_prev_block.get(&cur_hash).unwrap().clone();

--- a/chain/client/src/tests/cross_shard_tx.rs
+++ b/chain/client/src/tests/cross_shard_tx.rs
@@ -119,7 +119,7 @@ fn send_tx(
                     to.clone(),
                     &signer,
                     amount,
-                    block_hash,
+                    block_hash.clone(),
                 ),
                 is_forwarded: false,
                 check_only: false,
@@ -262,7 +262,7 @@ fn test_cross_shard_tx_callback(
                     validators[to].clone(),
                     amount,
                     next_nonce as u64,
-                    block_hash,
+                    block_hash.clone(),
                 );
 
                 let connectors_ = connectors.write().unwrap();
@@ -287,6 +287,7 @@ fn test_cross_shard_tx_callback(
                     let presumable_epoch1 = presumable_epoch.clone();
                     let account_id1 = validators[i].clone();
                     let block_stats1 = block_stats.clone();
+                    let block_hash = block_hash.clone();
                     actix::spawn(
                         connectors_[account_id_to_shard_id(&validators[i], 8) as usize
                             + (*presumable_epoch.read().unwrap() * 8) % 24]
@@ -309,7 +310,7 @@ fn test_cross_shard_tx_callback(
                                     observed_balances1,
                                     presumable_epoch1,
                                     num_iters,
-                                    block_hash,
+                                    block_hash.clone(),
                                     block_stats1,
                                     min_ratio,
                                     max_ratio,
@@ -361,7 +362,7 @@ fn test_cross_shard_tx_callback(
                             observed_balances,
                             presumable_epoch1,
                             num_iters,
-                            block_hash,
+                            block_hash.clone(),
                             block_stats,
                             min_ratio,
                             max_ratio,
@@ -449,7 +450,7 @@ fn test_cross_shard_tx_common(
             ))),
         );
         *connectors.write().unwrap() = conn;
-        let block_hash = *genesis_block.hash();
+        let block_hash = genesis_block.hash().clone();
 
         let connectors_ = connectors.write().unwrap();
         let iteration = Arc::new(AtomicUsize::new(0));
@@ -470,6 +471,7 @@ fn test_cross_shard_tx_common(
             let presumable_epoch1 = presumable_epoch.clone();
             let account_id1 = flat_validators[i].clone();
             let block_stats1 = block_stats.clone();
+            let block_hash_clone = block_hash.clone();
             actix::spawn(
                 connectors_[account_id_to_shard_id(&flat_validators[i], 8) as usize
                     + *presumable_epoch.read().unwrap() * 8]
@@ -492,7 +494,7 @@ fn test_cross_shard_tx_common(
                             observed_balances1,
                             presumable_epoch1,
                             num_iters,
-                            block_hash,
+                            block_hash_clone,
                             block_stats1,
                             min_ratio,
                             max_ratio,

--- a/chain/client/src/tests/query_client.rs
+++ b/chain/client/src/tests/query_client.rs
@@ -63,7 +63,7 @@ fn query_status_not_crash() {
         actix::spawn(view_client.send(GetBlockWithMerkleTree::latest()).then(move |res| {
             let (block, mut block_merkle_tree) = res.unwrap().unwrap();
             let header: BlockHeader = block.header.clone().into();
-            block_merkle_tree.insert(*header.hash());
+            block_merkle_tree.insert(header.hash().clone());
             let mut next_block = Block::produce(
                 PROTOCOL_VERSION,
                 PROTOCOL_VERSION,
@@ -142,7 +142,7 @@ fn test_execution_outcome_for_chunk() {
             actix::clock::sleep(Duration::from_millis(500)).await;
             let execution_outcome = view_client
                 .send(TxStatus {
-                    tx_hash,
+                    tx_hash: tx_hash.clone(),
                     signer_account_id: "test".parse().unwrap(),
                     fetch_receipt: false,
                 })
@@ -205,7 +205,7 @@ fn test_state_request() {
                 let res = view_client
                     .send(NetworkViewClientMessages::StateRequestHeader {
                         shard_id: 0,
-                        sync_hash: block_hash,
+                        sync_hash: block_hash.clone(),
                     })
                     .await
                     .unwrap();
@@ -216,7 +216,7 @@ fn test_state_request() {
             let res = view_client
                 .send(NetworkViewClientMessages::StateRequestHeader {
                     shard_id: 0,
-                    sync_hash: block_hash,
+                    sync_hash: block_hash.clone(),
                 })
                 .await
                 .unwrap();

--- a/chain/epoch_manager/src/test_utils.rs
+++ b/chain/epoch_manager/src/test_utils.rs
@@ -313,7 +313,7 @@ pub fn record_block_with_slashes(
                 cur_h,
                 height,
                 height.saturating_sub(2),
-                prev_h,
+                prev_h.clone(),
                 prev_h,
                 proposals,
                 vec![],

--- a/chain/indexer/src/streamer/fetchers.rs
+++ b/chain/indexer/src/streamer/fetchers.rs
@@ -96,7 +96,7 @@ pub(crate) async fn fetch_outcomes(
     for (shard_id, shard_outcomes) in outcomes {
         let mut outcomes_with_receipts: Vec<IndexerExecutionOutcomeWithOptionalReceipt> = vec![];
         for outcome in shard_outcomes {
-            let receipt = match fetch_receipt_by_id(&client, outcome.id).await {
+            let receipt = match fetch_receipt_by_id(&client, outcome.id.clone()).await {
                 Ok(res) => res,
                 Err(e) => {
                     warn!(

--- a/chain/indexer/src/streamer/utils.rs
+++ b/chain/indexer/src/streamer/utils.rs
@@ -13,53 +13,58 @@ pub(crate) async fn convert_transactions_sir_into_local_receipts(
     txs: Vec<&IndexerTransactionWithOutcome>,
     block: &views::BlockView,
 ) -> Result<Vec<views::ReceiptView>, FailedToFetchData> {
-    let prev_block = fetch_block_by_hash(&client, block.header.prev_hash).await?;
+    let prev_block = fetch_block_by_hash(&client, block.header.prev_hash.clone()).await?;
     let prev_block_gas_price = prev_block.header.gas_price;
 
-    let local_receipts: Vec<views::ReceiptView> =
-        txs.into_iter()
-            .map(|tx| {
-                let cost = tx_cost(
-                    &protocol_config.runtime_config.transaction_costs,
-                    &near_primitives::transaction::Transaction {
-                        signer_id: tx.transaction.signer_id.clone(),
-                        public_key: tx.transaction.public_key.clone(),
-                        nonce: tx.transaction.nonce,
-                        receiver_id: tx.transaction.receiver_id.clone(),
-                        block_hash: block.header.hash,
-                        actions: tx
-                            .transaction
-                            .actions
-                            .clone()
-                            .into_iter()
-                            .map(|action| {
-                                near_primitives::transaction::Action::try_from(action).unwrap()
-                            })
-                            .collect(),
-                    },
-                    prev_block_gas_price,
-                    true,
-                    protocol_config.protocol_version.clone(),
-                );
-                views::ReceiptView {
-                    predecessor_id: tx.transaction.signer_id.clone(),
+    let local_receipts: Vec<views::ReceiptView> = txs
+        .into_iter()
+        .map(|tx| {
+            let cost = tx_cost(
+                &protocol_config.runtime_config.transaction_costs,
+                &near_primitives::transaction::Transaction {
+                    signer_id: tx.transaction.signer_id.clone(),
+                    public_key: tx.transaction.public_key.clone(),
+                    nonce: tx.transaction.nonce,
                     receiver_id: tx.transaction.receiver_id.clone(),
-                    receipt_id: *tx.outcome.execution_outcome.outcome.receipt_ids.first().expect(
-                        "The transaction ExecutionOutcome should have one receipt id in vec",
-                    ),
-                    receipt: views::ReceiptEnumView::Action {
-                        signer_id: tx.transaction.signer_id.clone(),
-                        signer_public_key: tx.transaction.public_key.clone(),
-                        gas_price: cost
-                            .expect("TransactionCost returned IntegerOverflowError")
-                            .receipt_gas_price,
-                        output_data_receivers: vec![],
-                        input_data_ids: vec![],
-                        actions: tx.transaction.actions.clone(),
-                    },
-                }
-            })
-            .collect();
+                    block_hash: block.header.hash.clone(),
+                    actions: tx
+                        .transaction
+                        .actions
+                        .clone()
+                        .into_iter()
+                        .map(|action| {
+                            near_primitives::transaction::Action::try_from(action).unwrap()
+                        })
+                        .collect(),
+                },
+                prev_block_gas_price,
+                true,
+                protocol_config.protocol_version.clone(),
+            );
+            views::ReceiptView {
+                predecessor_id: tx.transaction.signer_id.clone(),
+                receiver_id: tx.transaction.receiver_id.clone(),
+                receipt_id: tx
+                    .outcome
+                    .execution_outcome
+                    .outcome
+                    .receipt_ids
+                    .first()
+                    .expect("The transaction ExecutionOutcome should have one receipt id in vec")
+                    .clone(),
+                receipt: views::ReceiptEnumView::Action {
+                    signer_id: tx.transaction.signer_id.clone(),
+                    signer_public_key: tx.transaction.public_key.clone(),
+                    gas_price: cost
+                        .expect("TransactionCost returned IntegerOverflowError")
+                        .receipt_gas_price,
+                    output_data_receivers: vec![],
+                    input_data_ids: vec![],
+                    actions: tx.transaction.actions.clone(),
+                },
+            }
+        })
+        .collect();
 
     Ok(local_receipts)
 }

--- a/chain/jsonrpc/jsonrpc-tests/tests/rpc_query.rs
+++ b/chain/jsonrpc/jsonrpc-tests/tests/rpc_query.rs
@@ -55,7 +55,7 @@ fn test_block_query() {
         let block_response1 =
             client.block(BlockReference::BlockId(BlockId::Height(0))).await.unwrap();
         let block_response2 = client
-            .block(BlockReference::BlockId(BlockId::Hash(block_response1.header.hash)))
+            .block(BlockReference::BlockId(BlockId::Hash(block_response1.header.hash.clone())))
             .await
             .unwrap();
         let block_response3 = client.block(BlockReference::latest()).await.unwrap();
@@ -109,7 +109,8 @@ fn test_chunk_by_hash() {
         assert_eq!(chunk.header.tx_root.as_ref(), &[0; 32]);
         assert_eq!(chunk.header.validator_proposals, vec![]);
         assert_eq!(chunk.header.validator_reward, 0);
-        let same_chunk = client.chunk(ChunkId::Hash(chunk.header.chunk_hash)).await.unwrap();
+        let same_chunk =
+            client.chunk(ChunkId::Hash(chunk.header.chunk_hash.clone())).await.unwrap();
         assert_eq!(chunk.header.chunk_hash, same_chunk.header.chunk_hash);
     });
 }
@@ -174,7 +175,7 @@ fn test_query_account() {
             .unwrap();
         let query_response_3 = client
             .query(near_jsonrpc_primitives::types::query::RpcQueryRequest {
-                block_reference: BlockReference::BlockId(BlockId::Hash(block_hash)),
+                block_reference: BlockReference::BlockId(BlockId::Hash(block_hash.clone())),
                 request: QueryRequest::ViewAccount { account_id: "test".parse().unwrap() },
             })
             .await
@@ -717,7 +718,8 @@ fn test_get_chunk_with_object_in_params() {
         assert_eq!(chunk.header.tx_root.as_ref(), &[0; 32]);
         assert_eq!(chunk.header.validator_proposals, vec![]);
         assert_eq!(chunk.header.validator_reward, 0);
-        let same_chunk = client.chunk(ChunkId::Hash(chunk.header.chunk_hash)).await.unwrap();
+        let same_chunk =
+            client.chunk(ChunkId::Hash(chunk.header.chunk_hash.clone())).await.unwrap();
         assert_eq!(chunk.header.chunk_hash, same_chunk.header.chunk_hash);
     });
 }

--- a/chain/jsonrpc/jsonrpc-tests/tests/rpc_transactions.rs
+++ b/chain/jsonrpc/jsonrpc-tests/tests/rpc_transactions.rs
@@ -56,7 +56,7 @@ fn test_send_tx_async() {
         WaitOrTimeoutActor::new(
             Box::new(move |_| {
                 let signer_account_id = "test1".parse().unwrap();
-                if let Some(tx_hash) = *tx_hash2_2.lock().unwrap() {
+                if let Some(tx_hash) = tx_hash2_2.lock().unwrap().clone() {
                     actix::spawn(
                         client1
                             .tx(tx_hash.to_string(), signer_account_id)
@@ -154,7 +154,7 @@ fn test_expired_tx() {
                             }
                         }
                     } else {
-                        *block_hash.lock().unwrap() = Some(header.hash);
+                        *block_hash.clone().lock().unwrap() = Some(header.hash.clone());
                         *block_height.lock().unwrap() = Some(header.height);
                     };
                     future::ready(())

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -588,7 +588,7 @@ impl JsonRpcHandler {
                 match self
                     .view_client_addr
                     .send(TxStatus {
-                        tx_hash,
+                        tx_hash: tx_hash.clone(),
                         signer_account_id: signer_account_id.clone(),
                         fetch_receipt: false,
                     })
@@ -632,14 +632,14 @@ impl JsonRpcHandler {
             near_jsonrpc_primitives::types::transactions::TransactionInfo::TransactionId {
                 hash,
                 account_id,
-            } => (*hash, account_id.clone()),
+            } => (hash.clone(), account_id.clone()),
         };
         timeout(self.polling_config.polling_timeout, async {
             loop {
                 let tx_status_result = self
                     .view_client_addr
                     .send(TxStatus {
-                        tx_hash,
+                        tx_hash: tx_hash.clone(),
                         signer_account_id: account_id.clone(),
                         fetch_receipt,
                     })
@@ -938,7 +938,7 @@ impl JsonRpcHandler {
     > {
         match self
             .view_client_addr
-            .send(GetReceipt { receipt_id: request_data.receipt_reference.receipt_id })
+            .send(GetReceipt { receipt_id: request_data.receipt_reference.receipt_id.clone() })
             .await??
         {
             Some(receipt_view) => {
@@ -946,7 +946,7 @@ impl JsonRpcHandler {
             }
             None => {
                 Err(near_jsonrpc_primitives::types::receipts::RpcReceiptError::UnknownReceipt {
-                    receipt_id: request_data.receipt_reference.receipt_id,
+                    receipt_id: request_data.receipt_reference.receipt_id.clone(),
                 })
             }
         }
@@ -1026,13 +1026,13 @@ impl JsonRpcHandler {
         let block_proof = self
             .view_client_addr
             .send(GetBlockProof {
-                block_hash: execution_outcome_proof.outcome_proof.block_hash,
+                block_hash: execution_outcome_proof.outcome_proof.block_hash.clone(),
                 head_block_hash: light_client_head,
             })
             .await??;
 
         Ok(near_jsonrpc_primitives::types::light_client::RpcLightClientExecutionProofResponse {
-            outcome_proof: execution_outcome_proof.outcome_proof,
+            outcome_proof: execution_outcome_proof.outcome_proof.clone(),
             outcome_root_proof: execution_outcome_proof.outcome_root_proof,
             block_header_lite: block_proof.block_header_lite,
             block_proof: block_proof.proof,

--- a/chain/network-primitives/src/types.rs
+++ b/chain/network-primitives/src/types.rs
@@ -370,7 +370,7 @@ impl AccountOrPeerIdOrHash {
         match self {
             AccountOrPeerIdOrHash::AccountId(_) => None,
             AccountOrPeerIdOrHash::PeerId(peer_id) => Some(PeerIdOrHash::PeerId(peer_id.clone())),
-            AccountOrPeerIdOrHash::Hash(hash) => Some(PeerIdOrHash::Hash(*hash)),
+            AccountOrPeerIdOrHash::Hash(hash) => Some(PeerIdOrHash::Hash(hash.clone())),
         }
     }
 }
@@ -863,8 +863,8 @@ impl StateResponseInfo {
 
     pub fn sync_hash(&self) -> CryptoHash {
         match self {
-            Self::V1(info) => info.sync_hash,
-            Self::V2(info) => info.sync_hash,
+            Self::V1(info) => info.sync_hash.clone(),
+            Self::V2(info) => info.sync_hash.clone(),
         }
     }
 
@@ -1061,7 +1061,7 @@ impl PartialEncodedChunkForwardMsg {
     }
 
     pub fn is_valid_hash(&self) -> bool {
-        let correct_hash = combine_hash(self.inner_header_hash, self.merkle_root);
+        let correct_hash = combine_hash(self.inner_header_hash.clone(), self.merkle_root.clone());
         ChunkHash(correct_hash) == self.chunk_hash
     }
 }

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -171,7 +171,7 @@ impl PeerActor {
         // Record block requests in tracker.
         match msg {
             PeerMessage::Block(b) if self.tracker.has_received(b.hash()) => return,
-            PeerMessage::BlockRequest(h) => self.tracker.push_request(*h),
+            PeerMessage::BlockRequest(h) => self.tracker.push_request(h.clone()),
             _ => (),
         };
 
@@ -404,8 +404,8 @@ impl PeerActor {
         let network_client_msg = match msg {
             PeerMessage::Block(block) => {
                 metrics::PEER_BLOCK_RECEIVED_TOTAL.inc();
-                let block_hash = *block.hash();
-                self.tracker.push_received(block_hash);
+                let block_hash = block.hash().clone();
+                self.tracker.push_received(block_hash.clone());
                 self.chain_info.height = max(self.chain_info.height, block.header().height());
                 NetworkClientMessages::Block(block, peer_id, self.tracker.has_request(&block_hash))
             }

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -1396,7 +1396,7 @@ impl PeerManagerActor {
         match target {
             PeerIdOrHash::PeerId(peer_id) => peer_id == &self.my_peer_id,
             PeerIdOrHash::Hash(hash) => {
-                self.routing_table_view.compare_route_back(*hash, &self.my_peer_id)
+                self.routing_table_view.compare_route_back(hash.clone(), &self.my_peer_id)
             }
         }
     }

--- a/chain/network/src/routing/route_back_cache.rs
+++ b/chain/network/src/routing/route_back_cache.rs
@@ -188,7 +188,7 @@ impl RouteBackCache {
 
             // Remove current hash from the list associated with `record_par_target`
             if let Some(records) = self.record_per_target.get_mut(&target) {
-                records.remove(&(time, *hash));
+                records.remove(&(time, hash.clone()));
             }
 
             // Calculate new size
@@ -217,7 +217,7 @@ impl RouteBackCache {
 
         let now = Clock::instant();
 
-        self.main.insert(hash, (now, target.clone()));
+        self.main.insert(hash.clone(), (now, target.clone()));
 
         let mut size = self.record_per_target.get(&target).map_or(0, |x| x.len());
 
@@ -274,7 +274,7 @@ mod test {
 
         check_consistency(&cache);
         assert_eq!(cache.get(&hash0), None);
-        cache.insert(hash0, peer0.clone());
+        cache.insert(hash0.clone(), peer0.clone());
         check_consistency(&cache);
         assert_eq!(cache.get(&hash0), Some(&peer0));
         assert_eq!(cache.remove(&hash0), Some(peer0));
@@ -288,7 +288,7 @@ mod test {
         let mut cache = RouteBackCache::new(1, Duration::from_millis(1), 1);
         let (peer0, hash0) = create_message(0);
 
-        cache.insert(hash0, peer0.clone());
+        cache.insert(hash0.clone(), peer0.clone());
         check_consistency(&cache);
         assert_eq!(cache.get(&hash0), Some(&peer0));
         thread::sleep(Duration::from_millis(2));
@@ -304,11 +304,11 @@ mod test {
         let (peer0, hash0) = create_message(0);
         let (peer1, hash1) = create_message(1);
 
-        cache.insert(hash0, peer0.clone());
+        cache.insert(hash0.clone(), peer0.clone());
         check_consistency(&cache);
         assert_eq!(cache.get(&hash0), Some(&peer0));
         thread::sleep(Duration::from_millis(2));
-        cache.insert(hash1, peer1.clone());
+        cache.insert(hash1.clone(), peer1.clone());
         check_consistency(&cache);
         assert_eq!(cache.get(&hash1), Some(&peer1));
         assert_eq!(cache.get(&hash0), None);
@@ -321,11 +321,11 @@ mod test {
         let (peer0, hash0) = create_message(0);
         let (peer1, hash1) = create_message(1);
 
-        cache.insert(hash0, peer0.clone());
+        cache.insert(hash0.clone(), peer0.clone());
         check_consistency(&cache);
         assert_eq!(cache.get(&hash0), Some(&peer0));
         thread::sleep(Duration::from_millis(2));
-        cache.insert(hash1, peer1.clone());
+        cache.insert(hash1.clone(), peer1.clone());
         check_consistency(&cache);
         assert_eq!(cache.get(&hash1), Some(&peer1));
         assert_eq!(cache.get(&hash0), None);
@@ -341,11 +341,11 @@ mod test {
         let (_, hash2) = create_message(2);
         let (peer3, hash3) = create_message(3);
 
-        cache.insert(hash0, peer0);
+        cache.insert(hash0.clone(), peer0);
         thread::sleep(Duration::from_millis(1100));
-        cache.insert(hash1, peer1.clone());
-        cache.insert(hash2, peer1);
-        cache.insert(hash3, peer3);
+        cache.insert(hash1.clone(), peer1.clone());
+        cache.insert(hash2.clone(), peer1);
+        cache.insert(hash3.clone(), peer3);
         check_consistency(&cache);
 
         assert!(cache.get(&hash0).is_none()); // This is removed because it was evicted
@@ -364,11 +364,11 @@ mod test {
         let (_, hash2) = create_message(2);
         let (peer3, hash3) = create_message(3);
 
-        cache.insert(hash0, peer0);
+        cache.insert(hash0.clone(), peer0);
         thread::sleep(Duration::from_millis(1000));
-        cache.insert(hash1, peer1.clone());
-        cache.insert(hash2, peer1);
-        cache.insert(hash3, peer3);
+        cache.insert(hash1.clone(), peer1.clone());
+        cache.insert(hash2.clone(), peer1);
+        cache.insert(hash3.clone(), peer3);
         check_consistency(&cache);
 
         assert!(cache.get(&hash0).is_some());
@@ -387,11 +387,11 @@ mod test {
         let (_, hash2) = create_message(2);
         let (peer3, hash3) = create_message(3);
 
-        cache.insert(hash0, peer0);
+        cache.insert(hash0.clone(), peer0);
         thread::sleep(Duration::from_millis(1000));
-        cache.insert(hash1, peer1.clone());
-        cache.insert(hash2, peer1);
-        cache.insert(hash3, peer3);
+        cache.insert(hash1.clone(), peer1.clone());
+        cache.insert(hash2.clone(), peer1);
+        cache.insert(hash3.clone(), peer3);
         check_consistency(&cache);
 
         assert!(cache.get(&hash0).is_some());

--- a/chain/network/src/routing/routing.rs
+++ b/chain/network/src/routing/routing.rs
@@ -157,7 +157,7 @@ impl RoutingTableView {
         match target {
             PeerIdOrHash::PeerId(peer_id) => self.find_route_from_peer_id(peer_id),
             PeerIdOrHash::Hash(hash) => {
-                self.fetch_route_back(*hash).ok_or(FindRouteError::RouteBackNotFound)
+                self.fetch_route_back(hash.clone()).ok_or(FindRouteError::RouteBackNotFound)
             }
         }
     }

--- a/chain/rosetta-rpc/src/adapters/mod.rs
+++ b/chain/rosetta-rpc/src/adapters/mod.rs
@@ -30,14 +30,15 @@ async fn convert_genesis_records_to_transaction(
         }
     });
     let genesis_accounts = crate::utils::query_accounts(
-        &near_primitives::types::BlockId::Hash(block.header.hash).into(),
+        &near_primitives::types::BlockId::Hash(block.header.hash.clone()).into(),
         genesis_account_ids,
         &view_client_addr,
     )
     .await?;
-    let runtime_config = crate::utils::query_protocol_config(block.header.hash, &view_client_addr)
-        .await?
-        .runtime_config;
+    let runtime_config =
+        crate::utils::query_protocol_config(block.header.hash.clone(), &view_client_addr)
+            .await?
+            .runtime_config;
 
     let mut operations = Vec::new();
     for (account_id, account) in genesis_accounts {
@@ -109,7 +110,7 @@ pub(crate) async fn convert_block_to_transactions(
     block: &near_primitives::views::BlockView,
 ) -> Result<Vec<crate::models::Transaction>, crate::errors::ErrorKind> {
     let state_changes = view_client_addr
-        .send(near_client::GetStateChangesInBlock { block_hash: block.header.hash })
+        .send(near_client::GetStateChangesInBlock { block_hash: block.header.hash.clone() })
         .await?
         .unwrap();
 
@@ -125,7 +126,7 @@ pub(crate) async fn convert_block_to_transactions(
         .collect::<std::collections::HashSet<_>>();
 
     let prev_block_id = near_primitives::types::BlockReference::from(
-        near_primitives::types::BlockId::Hash(block.header.prev_hash),
+        near_primitives::types::BlockId::Hash(block.header.prev_hash.clone()),
     );
     let accounts_previous_state =
         crate::utils::query_accounts(&prev_block_id, touched_account_ids.iter(), &view_client_addr)
@@ -133,7 +134,7 @@ pub(crate) async fn convert_block_to_transactions(
 
     let accounts_changes = view_client_addr
         .send(near_client::GetStateChanges {
-            block_hash: block.header.hash,
+            block_hash: block.header.hash.clone(),
             state_changes_request:
                 near_primitives::views::StateChangesRequestView::AccountChanges {
                     account_ids: touched_account_ids.into_iter().collect(),
@@ -141,9 +142,10 @@ pub(crate) async fn convert_block_to_transactions(
         })
         .await??;
 
-    let runtime_config = crate::utils::query_protocol_config(block.header.hash, &view_client_addr)
-        .await?
-        .runtime_config;
+    let runtime_config =
+        crate::utils::query_protocol_config(block.header.hash.clone(), &view_client_addr)
+            .await?
+            .runtime_config;
     let transactions = convert_block_changes_to_transactions(
         &runtime_config,
         &block.header.hash,
@@ -933,7 +935,7 @@ mod tests {
             },
             near_primitives::views::StateChangeWithCauseView {
                 cause: near_primitives::views::StateChangeCauseView::ReceiptProcessing {
-                    receipt_hash: nfvalidator1_receipt_processing_hash,
+                    receipt_hash: nfvalidator1_receipt_processing_hash.clone(),
                 },
                 value: near_primitives::views::StateChangeValueView::AccountUpdate {
                     account_id: "nfvalidator1.near".parse().unwrap(),
@@ -961,7 +963,7 @@ mod tests {
             },
             near_primitives::views::StateChangeWithCauseView {
                 cause: near_primitives::views::StateChangeCauseView::ActionReceiptGasReward {
-                    receipt_hash: nfvalidator2_action_receipt_gas_reward_hash,
+                    receipt_hash: nfvalidator2_action_receipt_gas_reward_hash.clone(),
                 },
                 value: near_primitives::views::StateChangeValueView::AccountUpdate {
                     account_id: "nfvalidator2.near".parse().unwrap(),

--- a/chain/rosetta-rpc/src/lib.rs
+++ b/chain/rosetta-rpc/src/lib.rs
@@ -221,7 +221,7 @@ async fn block_details(
     } else {
         let parent_block = view_client_addr
             .send(near_client::GetBlock(
-                near_primitives::types::BlockId::Hash(block.header.prev_hash).into(),
+                near_primitives::types::BlockId::Hash(block.header.prev_hash.clone()).into(),
             ))
             .await?
             .map_err(|err| errors::ErrorKind::InternalError(err.to_string()))?;
@@ -370,7 +370,7 @@ async fn account_balance(
         .await?
         .map_err(|err| errors::ErrorKind::NotFound(err.to_string()))?;
     let runtime_config =
-        crate::utils::query_protocol_config(block.header.hash, view_client_addr.get_ref())
+        crate::utils::query_protocol_config(block.header.hash.clone(), view_client_addr.get_ref())
             .await?
             .runtime_config;
 

--- a/core/primitives-core/src/account.rs
+++ b/core/primitives-core/src/account.rs
@@ -66,7 +66,7 @@ impl Account {
 
     #[inline]
     pub fn code_hash(&self) -> CryptoHash {
-        self.code_hash
+        self.code_hash.clone()
     }
 
     #[inline]
@@ -137,7 +137,7 @@ impl BorshSerialize for Account {
             AccountVersion::V1 => LegacyAccount {
                 amount: self.amount,
                 locked: self.locked,
-                code_hash: self.code_hash,
+                code_hash: self.code_hash.clone(),
                 storage_usage: self.storage_usage,
             }
             .serialize(writer),

--- a/core/primitives-core/src/hash.rs
+++ b/core/primitives-core/src/hash.rs
@@ -11,7 +11,7 @@ use crate::logging::pretty_hash;
 use crate::serialize::{from_base, to_base, BaseDecode};
 
 #[cfg_attr(feature = "deepsize_feature", derive(DeepSizeOf))]
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, derive_more::AsRef, derive_more::AsMut)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, derive_more::AsRef, derive_more::AsMut)]
 #[as_ref(forward)]
 #[as_mut(forward)]
 pub struct CryptoHash(pub [u8; 32]);

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -402,7 +402,10 @@ impl Block {
     }
 
     pub fn compute_challenges_root(challenges: &Challenges) -> CryptoHash {
-        merklize(&challenges.iter().map(|challenge| challenge.hash).collect::<Vec<CryptoHash>>()).0
+        merklize(
+            &challenges.iter().map(|challenge| challenge.hash.clone()).collect::<Vec<CryptoHash>>(),
+        )
+        .0
     }
 
     pub fn compute_gas_used<'a, T: IntoIterator<Item = &'a ShardChunkHeader>>(
@@ -437,7 +440,7 @@ impl Block {
         merkle_path: &MerklePath,
     ) -> bool {
         verify_path(
-            *chunk_root,
+            chunk_root.clone(),
             merkle_path,
             &ChunkHashHeight(chunk.chunk_hash(), chunk.height_included()),
         )

--- a/core/primitives/src/block_header.rs
+++ b/core/primitives/src/block_header.rs
@@ -252,7 +252,7 @@ pub struct BlockHeaderV1 {
 impl BlockHeaderV1 {
     pub fn init(&mut self) {
         self.hash = BlockHeader::compute_hash(
-            self.prev_hash,
+            self.prev_hash.clone(),
             &self.inner_lite.try_to_vec().expect("Failed to serialize"),
             &self.inner_rest.try_to_vec().expect("Failed to serialize"),
         );
@@ -303,7 +303,7 @@ pub struct BlockHeaderV3 {
 impl BlockHeaderV2 {
     pub fn init(&mut self) {
         self.hash = BlockHeader::compute_hash(
-            self.prev_hash,
+            self.prev_hash.clone(),
             &self.inner_lite.try_to_vec().expect("Failed to serialize"),
             &self.inner_rest.try_to_vec().expect("Failed to serialize"),
         );
@@ -313,7 +313,7 @@ impl BlockHeaderV2 {
 impl BlockHeaderV3 {
     pub fn init(&mut self) {
         self.hash = BlockHeader::compute_hash(
-            self.prev_hash,
+            self.prev_hash.clone(),
             &self.inner_lite.try_to_vec().expect("Failed to serialize"),
             &self.inner_rest.try_to_vec().expect("Failed to serialize"),
         );
@@ -407,12 +407,12 @@ impl BlockHeader {
                 latest_protocol_version: PROTOCOL_VERSION,
             };
             let (hash, signature) = signer.sign_block_header_parts(
-                prev_hash,
+                prev_hash.clone(),
                 &inner_lite.try_to_vec().expect("Failed to serialize"),
                 &inner_rest.try_to_vec().expect("Failed to serialize"),
             );
             Self::BlockHeaderV1(Box::new(BlockHeaderV1 {
-                prev_hash,
+                prev_hash: prev_hash.clone(),
                 inner_lite,
                 inner_rest,
                 signature,
@@ -436,7 +436,7 @@ impl BlockHeader {
                 latest_protocol_version: PROTOCOL_VERSION,
             };
             let (hash, signature) = signer.sign_block_header_parts(
-                prev_hash,
+                prev_hash.clone(),
                 &inner_lite.try_to_vec().expect("Failed to serialize"),
                 &inner_rest.try_to_vec().expect("Failed to serialize"),
             );
@@ -468,7 +468,7 @@ impl BlockHeader {
                 latest_protocol_version: PROTOCOL_VERSION,
             };
             let (hash, signature) = signer.sign_block_header_parts(
-                prev_hash,
+                prev_hash.clone(),
                 &inner_lite.try_to_vec().expect("Failed to serialize"),
                 &inner_rest.try_to_vec().expect("Failed to serialize"),
             );
@@ -851,7 +851,7 @@ impl BlockHeader {
         match self {
             BlockHeader::BlockHeaderV1(_) => None,
             BlockHeader::BlockHeaderV2(_) => None,
-            BlockHeader::BlockHeaderV3(header) => header.inner_rest.epoch_sync_data_hash,
+            BlockHeader::BlockHeaderV3(header) => header.inner_rest.epoch_sync_data_hash.clone(),
         }
     }
 

--- a/core/primitives/src/receipt.rs
+++ b/core/primitives/src/receipt.rs
@@ -40,7 +40,7 @@ impl Borrow<CryptoHash> for Receipt {
 impl Receipt {
     /// It's not a content hash, but receipt_id is unique.
     pub fn get_hash(&self) -> CryptoHash {
-        self.receipt_id
+        self.receipt_id.clone()
     }
 
     /// Generates a receipt with a transfer from system for a given balance without a receipt_id.

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -3,6 +3,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use deepsize::DeepSizeOf;
 use reed_solomon_erasure::galois_8::{Field, ReedSolomon};
 use serde::{Deserialize, Serialize};
+use std::hash::Hash;
 
 use near_crypto::Signature;
 
@@ -110,7 +111,7 @@ impl ShardChunkHeaderV2 {
         let inner_bytes = inner.try_to_vec().expect("Failed to serialize");
         let inner_hash = hash(&inner_bytes);
 
-        ChunkHash(combine_hash(inner_hash, inner.encoded_merkle_root))
+        ChunkHash(combine_hash(inner_hash, inner.encoded_merkle_root.clone()))
     }
 
     pub fn new(
@@ -175,7 +176,7 @@ impl ShardChunkHeaderV3 {
         let inner_bytes = inner.try_to_vec().expect("Failed to serialize");
         let inner_hash = hash(&inner_bytes);
 
-        ChunkHash(combine_hash(inner_hash, *inner.encoded_merkle_root()))
+        ChunkHash(combine_hash(inner_hash, inner.encoded_merkle_root().clone()))
     }
 
     pub fn new(
@@ -290,27 +291,27 @@ impl ShardChunkHeader {
     #[inline]
     pub fn prev_state_root(&self) -> StateRoot {
         match self {
-            Self::V1(header) => header.inner.prev_state_root,
-            Self::V2(header) => header.inner.prev_state_root,
-            Self::V3(header) => *header.inner.prev_state_root(),
+            Self::V1(header) => header.inner.prev_state_root.clone(),
+            Self::V2(header) => header.inner.prev_state_root.clone(),
+            Self::V3(header) => header.inner.prev_state_root().clone(),
         }
     }
 
     #[inline]
     pub fn prev_block_hash(&self) -> CryptoHash {
         match self {
-            Self::V1(header) => header.inner.prev_block_hash,
-            Self::V2(header) => header.inner.prev_block_hash,
-            Self::V3(header) => *header.inner.prev_block_hash(),
+            Self::V1(header) => header.inner.prev_block_hash.clone(),
+            Self::V2(header) => header.inner.prev_block_hash.clone(),
+            Self::V3(header) => header.inner.prev_block_hash().clone(),
         }
     }
 
     #[inline]
     pub fn encoded_merkle_root(&self) -> CryptoHash {
         match self {
-            Self::V1(header) => header.inner.encoded_merkle_root,
-            Self::V2(header) => header.inner.encoded_merkle_root,
-            Self::V3(header) => *header.inner.encoded_merkle_root(),
+            Self::V1(header) => header.inner.encoded_merkle_root.clone(),
+            Self::V2(header) => header.inner.encoded_merkle_root.clone(),
+            Self::V3(header) => header.inner.encoded_merkle_root().clone(),
         }
     }
 
@@ -362,27 +363,27 @@ impl ShardChunkHeader {
     #[inline]
     pub fn outgoing_receipts_root(&self) -> CryptoHash {
         match &self {
-            ShardChunkHeader::V1(header) => header.inner.outgoing_receipts_root,
-            ShardChunkHeader::V2(header) => header.inner.outgoing_receipts_root,
-            ShardChunkHeader::V3(header) => *header.inner.outgoing_receipts_root(),
+            ShardChunkHeader::V1(header) => header.inner.outgoing_receipts_root.clone(),
+            ShardChunkHeader::V2(header) => header.inner.outgoing_receipts_root.clone(),
+            ShardChunkHeader::V3(header) => header.inner.outgoing_receipts_root().clone(),
         }
     }
 
     #[inline]
     pub fn outcome_root(&self) -> CryptoHash {
         match &self {
-            ShardChunkHeader::V1(header) => header.inner.outcome_root,
-            ShardChunkHeader::V2(header) => header.inner.outcome_root,
-            ShardChunkHeader::V3(header) => *header.inner.outcome_root(),
+            ShardChunkHeader::V1(header) => header.inner.outcome_root.clone(),
+            ShardChunkHeader::V2(header) => header.inner.outcome_root.clone(),
+            ShardChunkHeader::V3(header) => header.inner.outcome_root().clone(),
         }
     }
 
     #[inline]
     pub fn tx_root(&self) -> CryptoHash {
         match &self {
-            ShardChunkHeader::V1(header) => header.inner.tx_root,
-            ShardChunkHeader::V2(header) => header.inner.tx_root,
-            ShardChunkHeader::V3(header) => *header.inner.tx_root(),
+            ShardChunkHeader::V1(header) => header.inner.tx_root.clone(),
+            ShardChunkHeader::V2(header) => header.inner.tx_root.clone(),
+            ShardChunkHeader::V3(header) => header.inner.tx_root().clone(),
         }
     }
 
@@ -705,7 +706,7 @@ impl ShardChunk {
     #[inline]
     pub fn prev_state_root(&self) -> StateRoot {
         match self {
-            Self::V1(chunk) => chunk.header.inner.prev_state_root,
+            Self::V1(chunk) => chunk.header.inner.prev_state_root.clone(),
             Self::V2(chunk) => chunk.header.prev_state_root(),
         }
     }
@@ -713,7 +714,7 @@ impl ShardChunk {
     #[inline]
     pub fn tx_root(&self) -> CryptoHash {
         match self {
-            Self::V1(chunk) => chunk.header.inner.tx_root,
+            Self::V1(chunk) => chunk.header.inner.tx_root.clone(),
             Self::V2(chunk) => chunk.header.tx_root(),
         }
     }
@@ -721,7 +722,7 @@ impl ShardChunk {
     #[inline]
     pub fn outgoing_receipts_root(&self) -> CryptoHash {
         match self {
-            Self::V1(chunk) => chunk.header.inner.outgoing_receipts_root,
+            Self::V1(chunk) => chunk.header.inner.outgoing_receipts_root.clone(),
             Self::V2(chunk) => chunk.header.outgoing_receipts_root(),
         }
     }
@@ -888,7 +889,7 @@ impl EncodedShardChunk {
     #[inline]
     pub fn encoded_merkle_root(&self) -> CryptoHash {
         match self {
-            Self::V1(chunk) => chunk.header.inner.encoded_merkle_root,
+            Self::V1(chunk) => chunk.header.inner.encoded_merkle_root.clone(),
             Self::V2(chunk) => chunk.header.encoded_merkle_root(),
         }
     }

--- a/core/primitives/src/syncing.rs
+++ b/core/primitives/src/syncing.rs
@@ -96,7 +96,7 @@ impl ShardStateSyncResponseHeader {
     #[inline]
     pub fn chunk_prev_state_root(&self) -> StateRoot {
         match self {
-            Self::V1(header) => header.chunk.header.inner.prev_state_root,
+            Self::V1(header) => header.chunk.header.inner.prev_state_root.clone(),
             Self::V2(header) => header.chunk.prev_state_root(),
         }
     }

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -281,7 +281,7 @@ impl BlockHeader {
 
     pub fn resign(&mut self, signer: &dyn ValidatorSigner) {
         let (hash, signature) = signer.sign_block_header_parts(
-            *self.prev_hash(),
+            self.prev_hash().clone(),
             &self.inner_lite_bytes(),
             &self.inner_rest_bytes(),
         );
@@ -342,7 +342,7 @@ impl Block {
         signer: &dyn ValidatorSigner,
         block_merkle_tree: &mut PartialMerkleTree,
     ) -> Self {
-        block_merkle_tree.insert(*prev.hash());
+        block_merkle_tree.insert(prev.hash().clone());
         Self::empty_with_approvals(
             prev,
             height,
@@ -379,11 +379,11 @@ impl Block {
             height,
             prev.header().epoch_id().clone(),
             if prev.header().prev_hash() == &CryptoHash::default() {
-                EpochId(*prev.hash())
+                EpochId(prev.hash().clone())
             } else {
                 prev.header().next_epoch_id().clone()
             },
-            *prev.header().next_bp_hash(),
+            prev.header().next_bp_hash().clone(),
             signer,
             block_merkle_tree,
         )

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -241,7 +241,7 @@ impl SignedTransaction {
     }
 
     pub fn get_hash(&self) -> CryptoHash {
-        self.hash
+        self.hash.clone()
     }
 
     pub fn get_size(&self) -> u64 {
@@ -422,7 +422,7 @@ pub struct ExecutionOutcomeWithId {
 
 impl ExecutionOutcomeWithId {
     pub fn to_hashes(&self) -> Vec<CryptoHash> {
-        let mut result = vec![self.id];
+        let mut result = vec![self.id.clone()];
         result.extend(self.outcome.to_hashes());
         result
     }

--- a/core/primitives/src/validator_signer.rs
+++ b/core/primitives/src/validator_signer.rs
@@ -174,7 +174,7 @@ impl ValidatorSigner for InMemoryValidatorSigner {
         inner_rest: &[u8],
     ) -> (CryptoHash, Signature) {
         let hash = BlockHeader::compute_hash(prev_hash, inner_lite, inner_rest);
-        (hash, self.signer.sign(hash.as_ref()))
+        (hash.clone(), self.signer.sign(hash.as_ref()))
     }
 
     fn sign_chunk_hash(&self, chunk_hash: &ChunkHash) -> Signature {

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -115,7 +115,7 @@ impl From<Account> for AccountView {
 
 impl From<&AccountView> for Account {
     fn from(view: &AccountView) -> Self {
-        Account::new(view.amount, view.locked, view.code_hash, view.storage_usage)
+        Account::new(view.amount, view.locked, view.code_hash.clone(), view.storage_usage)
     }
 }
 
@@ -127,7 +127,7 @@ impl From<AccountView> for Account {
 
 impl From<ContractCode> for ContractCodeView {
     fn from(contract_code: ContractCode) -> Self {
-        let hash = *contract_code.hash();
+        let hash = contract_code.hash().clone();
         let code = contract_code.into_code();
         ContractCodeView { code, hash }
     }
@@ -405,8 +405,8 @@ impl From<BlockHeader> for BlockHeaderView {
         Self {
             height: header.height(),
             prev_height: header.prev_height(),
-            epoch_id: header.epoch_id().0,
-            next_epoch_id: header.next_epoch_id().0,
+            epoch_id: header.epoch_id().0.clone(),
+            next_epoch_id: header.next_epoch_id().0.clone(),
             hash: header.hash().clone(),
             prev_hash: header.prev_hash().clone(),
             prev_state_root: header.prev_state_root().clone(),
@@ -665,10 +665,10 @@ impl From<ShardChunkHeader> for ChunkHeaderView {
         let inner = chunk.take_inner();
         ChunkHeaderView {
             chunk_hash: hash.0,
-            prev_block_hash: *inner.prev_block_hash(),
-            outcome_root: *inner.outcome_root(),
-            prev_state_root: *inner.prev_state_root(),
-            encoded_merkle_root: *inner.encoded_merkle_root(),
+            prev_block_hash: inner.prev_block_hash().clone(),
+            outcome_root: inner.outcome_root().clone(),
+            prev_state_root: inner.prev_state_root().clone(),
+            encoded_merkle_root: inner.encoded_merkle_root().clone(),
             encoded_length: inner.encoded_length(),
             height_created: inner.height_created(),
             height_included,
@@ -678,8 +678,8 @@ impl From<ShardChunkHeader> for ChunkHeaderView {
             rent_paid: 0,
             validator_reward: 0,
             balance_burnt: inner.balance_burnt(),
-            outgoing_receipts_root: *inner.outgoing_receipts_root(),
-            tx_root: *inner.tx_root(),
+            outgoing_receipts_root: inner.outgoing_receipts_root().clone().clone(),
+            tx_root: inner.tx_root().clone().clone(),
             validator_proposals: inner.validator_proposals().map(Into::into).collect(),
             signature,
         }

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -358,7 +358,7 @@ pub fn get_received_data(
 pub fn set_postponed_receipt(state_update: &mut TrieUpdate, receipt: &Receipt) {
     let key = TrieKey::PostponedReceipt {
         receiver_id: receipt.receiver_id.clone(),
-        receipt_id: receipt.receipt_id,
+        receipt_id: receipt.receipt_id.clone(),
     };
     set(state_update, key, receipt);
 }

--- a/core/store/src/migrations/v6_to_v7.rs
+++ b/core/store/src/migrations/v6_to_v7.rs
@@ -93,7 +93,10 @@ pub(crate) fn migrate_receipts_refcount(store: &Store, store_update: &mut StoreU
     let mut receipts: HashMap<CryptoHash, (Receipt, i64)> = HashMap::new();
     for chunk in chunks {
         for rx in chunk.receipts {
-            receipts.entry(rx.receipt_id).and_modify(|(_receipt, rc)| *rc += 1).or_insert((rx, 1));
+            receipts
+                .entry(rx.receipt_id.clone())
+                .and_modify(|(_receipt, rc)| *rc += 1)
+                .or_insert((rx, 1));
         }
     }
 

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -175,7 +175,7 @@ impl ShardTries {
                 &mut store_update,
             )?;
         }
-        Ok((store_update, trie_changes.new_root))
+        Ok((store_update, trie_changes.new_root.clone()))
     }
 
     pub fn apply_insertions(

--- a/core/store/src/trie/split_state.rs
+++ b/core/store/src/trie/split_state.rs
@@ -353,7 +353,7 @@ mod tests {
         shard_uid: &ShardUId,
         state_root: &StateRoot,
     ) -> Vec<Receipt> {
-        let state_update = &tries.new_trie_update(*shard_uid, *state_root);
+        let state_update = &tries.new_trie_update(*shard_uid, state_root.clone());
         let mut delayed_receipt_indices = get_delayed_receipt_indices(state_update).unwrap();
 
         let mut receipts = vec![];

--- a/core/store/src/trie/state_parts.rs
+++ b/core/store/src/trie/state_parts.rs
@@ -230,7 +230,7 @@ impl Trie {
         Ok(ApplyStatePartResult {
             trie_changes: TrieChanges {
                 old_root: CryptoHash::default(),
-                new_root: *state_root,
+                new_root: state_root.clone(),
                 insertions,
                 deletions,
             },
@@ -301,7 +301,7 @@ mod tests {
                     *rc += 1;
                 } else {
                     let bytes = trie.storage.retrieve_raw_bytes(hash)?;
-                    insertions.insert(*hash, (bytes, 1));
+                    insertions.insert(hash.clone(), (bytes, 1));
                 }
                 Ok(())
             })?;
@@ -316,7 +316,7 @@ mod tests {
             insertions.sort();
             Ok(TrieChanges {
                 old_root: Default::default(),
-                new_root: *state_root,
+                new_root: state_root.clone(),
                 insertions,
                 deletions: vec![],
             })
@@ -333,7 +333,7 @@ mod tests {
             }
             let mut stack: Vec<(CryptoHash, TrieNodeWithSize, CrumbStatus)> = Vec::new();
             let root_node = self.retrieve_node(root)?;
-            stack.push((*root, root_node, CrumbStatus::Entering));
+            stack.push((root.clone(), root_node, CrumbStatus::Entering));
             while let Some((hash, node, position)) = stack.pop() {
                 if let CrumbStatus::Entering = position {
                     on_enter(&hash)?;
@@ -590,7 +590,7 @@ mod tests {
         if changes.is_empty() {
             return TrieChanges::empty(CryptoHash::default());
         }
-        let new_root = changes[0].new_root;
+        let new_root = changes[0].new_root.clone();
         let mut map = HashMap::new();
         for changes_set in changes {
             assert!(changes_set.deletions.is_empty(), "state parts only have insertions");

--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -81,7 +81,7 @@ impl TrieStorage for TrieRecordingStorage {
             .get(ColState, key.as_ref())
             .map_err(|_| StorageError::StorageInternalError)?;
         if let Some(val) = val {
-            self.recorded.borrow_mut().insert(*hash, val.clone());
+            self.recorded.borrow_mut().insert(hash.clone(), val.clone());
             Ok(val)
         } else {
             Err(StorageError::StorageInconsistentState("Trie node missing".to_string()))
@@ -107,7 +107,7 @@ impl TrieStorage for TrieMemoryPartialStorage {
             .get(hash)
             .map_or_else(|| Err(StorageError::TrieNodeMissing), |val| Ok(val.clone()));
         if result.is_ok() {
-            self.visited_nodes.borrow_mut().insert(*hash);
+            self.visited_nodes.borrow_mut().insert(hash.clone());
         }
         result
     }
@@ -174,7 +174,7 @@ impl TrieStorage for TrieCachingStorage {
                 .map_err(|_| StorageError::StorageInternalError)?;
             if let Some(val) = val {
                 if val.len() < TRIE_LIMIT_CACHED_VALUE_SIZE {
-                    guard.cache_set(*hash, val.clone());
+                    guard.cache_set(hash.clone(), val.clone());
                 }
                 Ok(val)
             } else {

--- a/core/store/src/trie/trie_tests.rs
+++ b/core/store/src/trie/trie_tests.rs
@@ -38,7 +38,7 @@ impl TrieStorage for IncompletePartialStorage {
             .map_or_else(|| Err(StorageError::TrieNodeMissing), |val| Ok(val.clone()));
 
         if result.is_ok() {
-            self.visited_nodes.borrow_mut().insert(*hash);
+            self.visited_nodes.borrow_mut().insert(hash.clone());
         }
 
         if self.visited_nodes.borrow().len() > self.node_count_to_fail_after {
@@ -118,7 +118,7 @@ fn test_reads_with_incomplete_storage() {
             let key_prefix = &key[0..rng.gen_range(0, key.len() + 1)];
             println!("Testing TrieUpdateIterator over prefix {:?}", key_prefix);
             let trie_update_keys = |trie: Rc<Trie>| -> Result<_, StorageError> {
-                let trie_update = TrieUpdate::new(trie, state_root);
+                let trie_update = TrieUpdate::new(trie, state_root.clone());
                 let keys = trie_update.iter(key_prefix)?.collect::<Result<Vec<_>, _>>()?;
                 Ok(keys)
             };

--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -167,7 +167,7 @@ impl TrieUpdate {
     }
 
     pub fn get_root(&self) -> CryptoHash {
-        self.root
+        self.root.clone()
     }
 }
 
@@ -436,7 +436,7 @@ mod tests {
         let (store_update, new_root) = tries.apply_all(&trie_changes, ShardUId::default()).unwrap();
         store_update.commit().unwrap();
 
-        let mut trie_update = tries.new_trie_update(ShardUId::default(), new_root);
+        let mut trie_update = tries.new_trie_update(ShardUId::default(), new_root.clone());
         trie_update.set(test_key(b"dog2".to_vec()), b"puppy".to_vec());
         trie_update.set(test_key(b"xxx".to_vec()), b"puppy".to_vec());
 
@@ -453,14 +453,14 @@ mod tests {
             trie_update.iter(&test_key(b"dog".to_vec()).to_vec()).unwrap().collect();
         assert_eq!(values.unwrap(), vec![test_key(b"dog".to_vec()).to_vec()]);
 
-        let mut trie_update = tries.new_trie_update(ShardUId::default(), new_root);
+        let mut trie_update = tries.new_trie_update(ShardUId::default(), new_root.clone());
         trie_update.remove(test_key(b"dog".to_vec()));
 
         let values: Result<Vec<Vec<u8>>, _> =
             trie_update.iter(&test_key(b"dog".to_vec()).to_vec()).unwrap().collect();
         assert_eq!(values.unwrap().len(), 0);
 
-        let mut trie_update = tries.new_trie_update(ShardUId::default(), new_root);
+        let mut trie_update = tries.new_trie_update(ShardUId::default(), new_root.clone());
         trie_update.set(test_key(b"dog2".to_vec()), b"puppy".to_vec());
         trie_update
             .commit(StateChangeCause::TransactionProcessing { tx_hash: CryptoHash::default() });
@@ -470,7 +470,7 @@ mod tests {
             trie_update.iter(&test_key(b"dog".to_vec()).to_vec()).unwrap().collect();
         assert_eq!(values.unwrap(), vec![test_key(b"dog".to_vec()).to_vec()]);
 
-        let mut trie_update = tries.new_trie_update(ShardUId::default(), new_root);
+        let mut trie_update = tries.new_trie_update(ShardUId::default(), new_root.clone());
         trie_update.set(test_key(b"dog2".to_vec()), b"puppy".to_vec());
         trie_update
             .commit(StateChangeCause::TransactionProcessing { tx_hash: CryptoHash::default() });

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -120,7 +120,7 @@ impl GenesisBuilder {
                     *shard_idx,
                     self.runtime.get_tries().new_trie_update(
                         ShardUId { version: genesis_shard_version, shard_id: *shard_idx as u32 },
-                        *root,
+                        root.clone(),
                     ),
                 )
             })
@@ -263,7 +263,7 @@ impl GenesisBuilder {
         let account = Account::new(
             testing_init_balance,
             testing_init_stake,
-            self.additional_accounts_code_hash,
+            self.additional_accounts_code_hash.clone(),
             0,
         );
         set_account(&mut state_update, account_id.clone(), &account);

--- a/integration-tests/src/genesis_helpers.rs
+++ b/integration-tests/src/genesis_helpers.rs
@@ -11,7 +11,7 @@ use nearcore::NightshadeRuntime;
 
 /// Compute genesis hash from genesis.
 pub fn genesis_hash(genesis: &Genesis) -> CryptoHash {
-    *genesis_header(genesis).hash()
+    genesis_header(genesis).hash().clone()
 }
 
 /// Utility to generate genesis header from config for testing purposes.

--- a/integration-tests/src/user/runtime_user.rs
+++ b/integration-tests/src/user/runtime_user.rs
@@ -37,7 +37,7 @@ pub struct MockClient {
 
 impl MockClient {
     pub fn get_state_update(&self) -> TrieUpdate {
-        self.tries.new_trie_update(ShardUId::default(), self.state_root)
+        self.tries.new_trie_update(ShardUId::default(), self.state_root.clone())
     }
 }
 
@@ -92,7 +92,7 @@ impl RuntimeUser {
                 .runtime
                 .apply(
                     client.tries.get_trie_for_shard(ShardUId::default()),
-                    client.state_root,
+                    client.state_root.clone(),
                     &None,
                     &apply_state,
                     &receipts,
@@ -129,7 +129,7 @@ impl RuntimeUser {
                 return Ok(());
             }
             for receipt in apply_result.outgoing_receipts.iter() {
-                self.receipts.borrow_mut().insert(receipt.receipt_id, receipt.clone());
+                self.receipts.borrow_mut().insert(receipt.receipt_id.clone(), receipt.clone());
             }
             receipts = apply_result.outgoing_receipts;
             txs = vec![];
@@ -163,7 +163,7 @@ impl RuntimeUser {
         let outcome = self.get_transaction_result(hash);
         let receipt_ids = outcome.receipt_ids.clone();
         let mut transactions = vec![ExecutionOutcomeWithIdView {
-            id: *hash,
+            id: hash.clone(),
             outcome,
             proof: vec![],
             block_hash: Default::default(),
@@ -177,7 +177,7 @@ impl RuntimeUser {
 
     fn get_final_transaction_result(&self, hash: &CryptoHash) -> FinalExecutionOutcomeView {
         let mut outcomes = self.get_recursive_transaction_results(hash);
-        let mut looking_for_id = (*hash).into();
+        let mut looking_for_id = (hash.clone()).into();
         let num_outcomes = outcomes.len();
         let status = outcomes
             .iter()
@@ -322,7 +322,7 @@ impl User for RuntimeUser {
     }
 
     fn get_state_root(&self) -> CryptoHash {
-        self.client.read().expect(POISONED_LOCK_ERR).state_root.into()
+        self.client.read().expect(POISONED_LOCK_ERR).state_root.clone().into()
     }
 
     fn get_access_key(

--- a/integration-tests/tests/client/challenges.rs
+++ b/integration-tests/tests/client/challenges.rs
@@ -46,7 +46,7 @@ fn test_verify_block_double_sign_challenge() {
     let signer =
         InMemoryValidatorSigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
     let mut block_merkle_tree = PartialMerkleTree::default();
-    block_merkle_tree.insert(*genesis.hash());
+    block_merkle_tree.insert(genesis.hash().clone());
     let b2 = Block::produce(
         PROTOCOL_VERSION,
         PROTOCOL_VERSION,
@@ -137,7 +137,7 @@ fn test_verify_chunk_invalid_proofs_challenge() {
     let shard_id = chunk.shard_id();
     let challenge_result =
         challenge(env, shard_id as usize, MaybeEncodedShardChunk::Encoded(chunk), &block);
-    assert_eq!(challenge_result.unwrap(), (*block.hash(), vec!["test0".parse().unwrap()]));
+    assert_eq!(challenge_result.unwrap(), (block.hash().clone(), vec!["test0".parse().unwrap()]));
 }
 
 #[test]
@@ -152,7 +152,7 @@ fn test_verify_chunk_invalid_proofs_challenge_decoded_chunk() {
     let shard_id = chunk.shard_id();
     let challenge_result =
         challenge(env, shard_id as usize, MaybeEncodedShardChunk::Decoded(chunk), &block);
-    assert_eq!(challenge_result.unwrap(), (*block.hash(), vec!["test0".parse().unwrap()]));
+    assert_eq!(challenge_result.unwrap(), (block.hash().clone(), vec!["test0".parse().unwrap()]));
 }
 
 #[test]
@@ -173,7 +173,7 @@ fn test_verify_chunk_proofs_malicious_challenge_valid_order_transactions() {
     let mut env = TestEnv::builder(ChainGenesis::test()).build();
     env.produce_block(0, 1);
 
-    let genesis_hash = *env.clients[0].chain.genesis().hash();
+    let genesis_hash = env.clients[0].chain.genesis().hash().clone();
     let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
 
     let (chunk, _merkle_paths, _receipts, block) = create_chunk_with_transactions(
@@ -185,7 +185,7 @@ fn test_verify_chunk_proofs_malicious_challenge_valid_order_transactions() {
                 "test1".parse().unwrap(),
                 &signer,
                 1000,
-                genesis_hash,
+                genesis_hash.clone(),
             ),
             SignedTransaction::send_money(
                 2,
@@ -209,7 +209,7 @@ fn test_verify_chunk_proofs_challenge_transaction_order() {
     let mut env = TestEnv::builder(ChainGenesis::test()).build();
     env.produce_block(0, 1);
 
-    let genesis_hash = *env.clients[0].chain.genesis().hash();
+    let genesis_hash = env.clients[0].chain.genesis().hash().clone();
     let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
 
     let (chunk, _merkle_paths, _receipts, block) = create_chunk_with_transactions(
@@ -221,7 +221,7 @@ fn test_verify_chunk_proofs_challenge_transaction_order() {
                 "test1".parse().unwrap(),
                 &signer,
                 1000,
-                genesis_hash,
+                genesis_hash.clone(),
             ),
             SignedTransaction::send_money(
                 1,
@@ -237,7 +237,7 @@ fn test_verify_chunk_proofs_challenge_transaction_order() {
     let shard_id = chunk.shard_id();
     let challenge_result =
         challenge(env, shard_id as usize, MaybeEncodedShardChunk::Encoded(chunk), &block);
-    assert_eq!(challenge_result.unwrap(), (*block.hash(), vec!["test0".parse().unwrap()]));
+    assert_eq!(challenge_result.unwrap(), (block.hash().clone(), vec!["test0".parse().unwrap()]));
 }
 
 fn challenge(
@@ -279,7 +279,7 @@ fn test_verify_chunk_invalid_state_challenge() {
     let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
     let validator_signer =
         InMemoryValidatorSigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
-    let genesis_hash = *env.clients[0].chain.genesis().hash();
+    let genesis_hash = env.clients[0].chain.genesis().hash().clone();
     let genesis_block = env.clients[0].chain.genesis_block().clone();
     env.produce_block(0, 1);
     env.clients[0].process_tx(
@@ -306,7 +306,7 @@ fn test_verify_chunk_invalid_state_challenge() {
     let (mut invalid_chunk, merkle_paths) = env.clients[0]
         .shards_mgr
         .create_encoded_shard_chunk(
-            *last_block.hash(),
+            last_block.hash().clone(),
             StateRoot::default(),
             CryptoHash::default(),
             last_block.header().height() + 1,
@@ -348,7 +348,7 @@ fn test_verify_chunk_invalid_state_challenge() {
     }
     let mut block_merkle_tree =
         client.chain.mut_store().get_block_merkle_tree(&last_block.hash()).unwrap().clone();
-    block_merkle_tree.insert(*last_block.hash());
+    block_merkle_tree.insert(last_block.hash().clone());
     let block = Block::produce(
         PROTOCOL_VERSION,
         PROTOCOL_VERSION,
@@ -367,7 +367,7 @@ fn test_verify_chunk_invalid_state_challenge() {
         vec![],
         vec![],
         &validator_signer,
-        *last_block.header().next_bp_hash(),
+        last_block.header().next_bp_hash().clone(),
         block_merkle_tree.root(),
     );
 
@@ -430,7 +430,7 @@ fn test_verify_chunk_invalid_state_challenge() {
             &challenge,
         )
         .unwrap(),
-        (*block.hash(), vec!["test0".parse().unwrap()])
+        (block.hash().clone(), vec!["test0".parse().unwrap()])
     );
 
     // Process the block with invalid chunk and make sure it's marked as invalid at the end.
@@ -572,7 +572,7 @@ fn test_fishermen_challenge() {
         .runtime_adapters(vec![runtime1, runtime2, runtime3])
         .build();
     let signer = InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1");
-    let genesis_hash = *env.clients[0].chain.genesis().hash();
+    let genesis_hash = env.clients[0].chain.genesis().hash().clone();
     let stake_transaction = SignedTransaction::stake(
         1,
         "test1".parse().unwrap(),

--- a/integration-tests/tests/client/chunks_management.rs
+++ b/integration-tests/tests/client/chunks_management.rs
@@ -88,13 +88,16 @@ fn chunks_produced_and_distributed_common(
                 let msg = msg.as_network_requests_ref();
                 match msg {
                     NetworkRequests::Block { block } => {
-                        check_height(*block.hash(), block.header().height());
-                        check_height(*block.header().prev_hash(), block.header().height() - 1);
+                        check_height(block.hash().clone(), block.header().height());
+                        check_height(
+                            block.header().prev_hash().clone(),
+                            block.header().height() - 1,
+                        );
 
                         let h = block.header().height();
 
                         let mut height_to_hash = height_to_hash.write().unwrap();
-                        height_to_hash.insert(h, *block.hash());
+                        height_to_hash.insert(h, block.hash().clone());
 
                         let mut height_to_epoch = height_to_epoch.write().unwrap();
                         height_to_epoch.insert(h, block.header().epoch_id().clone());
@@ -221,12 +224,12 @@ fn chunks_produced_and_distributed_common(
         let block_hash = res.unwrap().unwrap().header.hash;
         let connectors_ = connectors.write().unwrap();
         connectors_[0].0.do_send(NetworkClientMessages::Transaction {
-            transaction: SignedTransaction::empty(block_hash),
+            transaction: SignedTransaction::empty(block_hash.clone()),
             is_forwarded: false,
             check_only: false,
         });
         connectors_[1].0.do_send(NetworkClientMessages::Transaction {
-            transaction: SignedTransaction::empty(block_hash),
+            transaction: SignedTransaction::empty(block_hash.clone()),
             is_forwarded: false,
             check_only: false,
         });

--- a/integration-tests/tests/client/runtimes.rs
+++ b/integration-tests/tests/client/runtimes.rs
@@ -51,7 +51,7 @@ fn test_pending_approvals() {
     let signer =
         InMemoryValidatorSigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
     let parent_hash = hash(&[1]);
-    let approval = Approval::new(parent_hash, 0, 1, &signer);
+    let approval = Approval::new(parent_hash.clone(), 0, 1, &signer);
     let peer_id = PeerId::random();
     env.clients[0].collect_block_approval(&approval, ApprovalType::PeerApproval(peer_id.clone()));
     let approvals =
@@ -81,7 +81,7 @@ fn test_invalid_approvals() {
     // Approval with invalid signature. Should be dropped
     let signer =
         InMemoryValidatorSigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "random");
-    let genesis_hash = *env.clients[0].chain.genesis().hash();
+    let genesis_hash = env.clients[0].chain.genesis().hash().clone();
     let approval = Approval::new(genesis_hash, 0, 1, &signer);
     env.clients[0].collect_block_approval(&approval, ApprovalType::PeerApproval(peer_id));
     assert_eq!(env.clients[0].pending_approvals.cache_size(), 0);

--- a/integration-tests/tests/client/sharding_upgrade.rs
+++ b/integration-tests/tests/client/sharding_upgrade.rs
@@ -638,7 +638,7 @@ fn test_shard_layout_upgrade_cross_contract_calls() {
             let trie_update = client
                 .runtime_adapter
                 .get_tries()
-                .new_trie_update_view(ShardUId::default(), *chunk_extra.state_root());
+                .new_trie_update_view(ShardUId::default(), chunk_extra.state_root().clone());
             let delayed_receipt_indices = get_delayed_receipt_indices(&trie_update).unwrap();
             assert_ne!(
                 delayed_receipt_indices.first_index,

--- a/integration-tests/tests/nearcore/rpc_error_structs.rs
+++ b/integration-tests/tests/nearcore/rpc_error_structs.rs
@@ -345,7 +345,7 @@ fn test_tx_invalid_tx_error() {
     cluster.exec_until_stop(|genesis, rpc_addrs, clients| async move {
         let view_client = clients[0].1.clone();
 
-        let genesis_hash = *genesis_block(&genesis).hash();
+        let genesis_hash = genesis_block(&genesis).hash().clone();
         let signer =
             InMemorySigner::from_seed("near.5".parse().unwrap(), KeyType::ED25519, "near.5");
         let transaction = SignedTransaction::send_money(

--- a/integration-tests/tests/nearcore/rpc_nodes.rs
+++ b/integration-tests/tests/nearcore/rpc_nodes.rs
@@ -74,7 +74,9 @@ fn outcome_view_to_hashes(outcome: &ExecutionOutcomeView) -> Vec<CryptoHash> {
             PartialExecutionStatus::SuccessValue(from_base64(s).unwrap())
         }
         ExecutionStatusView::Failure(_) => PartialExecutionStatus::Failure,
-        ExecutionStatusView::SuccessReceiptId(id) => PartialExecutionStatus::SuccessReceiptId(*id),
+        ExecutionStatusView::SuccessReceiptId(id) => {
+            PartialExecutionStatus::SuccessReceiptId(id.clone())
+        }
     };
     let mut result = vec![hash(
         &(
@@ -106,7 +108,7 @@ fn test_get_execution_outcome(is_tx_successful: bool) {
     cluster.exec_until_stop(|genesis, rpc_addrs, clients| async move {
         let view_client = clients[0].1.clone();
 
-        let genesis_hash = *genesis_block(&genesis).hash();
+        let genesis_hash = genesis_block(&genesis).hash().clone();
         let signer =
             InMemorySigner::from_seed("near.0".parse().unwrap(), KeyType::ED25519, "near.0");
         let transaction = if is_tx_successful {
@@ -352,7 +354,7 @@ fn test_tx_not_enough_balance_must_return_error() {
     cluster.exec_until_stop(|genesis, rpc_addrs, clients| async move {
         let view_client = clients[0].1.clone();
 
-        let genesis_hash = *genesis_block(&genesis).hash();
+        let genesis_hash = genesis_block(&genesis).hash().clone().clone();
         let signer =
             InMemorySigner::from_seed("near.0".parse().unwrap(), KeyType::ED25519, "near.0");
         let transaction = SignedTransaction::send_money(
@@ -414,7 +416,7 @@ fn test_send_tx_sync_returns_transaction_hash() {
     cluster.exec_until_stop(|genesis, rpc_addrs, clients| async move {
         let view_client = clients[0].1.clone();
 
-        let genesis_hash = *genesis_block(&genesis).hash();
+        let genesis_hash = genesis_block(&genesis).hash().clone().clone();
         let signer =
             InMemorySigner::from_seed("near.0".parse().unwrap(), KeyType::ED25519, "near.0");
         let transaction = SignedTransaction::send_money(
@@ -462,7 +464,7 @@ fn test_send_tx_sync_to_lightclient_must_be_routed() {
     cluster.exec_until_stop(|genesis, rpc_addrs, clients| async move {
         let view_client = clients[0].1.clone();
 
-        let genesis_hash = *genesis_block(&genesis).hash();
+        let genesis_hash = genesis_block(&genesis).hash().clone();
         let signer =
             InMemorySigner::from_seed("near.1".parse().unwrap(), KeyType::ED25519, "near.1");
         let transaction = SignedTransaction::send_money(
@@ -471,7 +473,7 @@ fn test_send_tx_sync_to_lightclient_must_be_routed() {
             "near.1".parse().unwrap(),
             &signer,
             10000,
-            genesis_hash,
+            genesis_hash.clone(),
         );
 
         let client = new_client(&format!("http://{}", rpc_addrs[1]));
@@ -520,7 +522,7 @@ fn test_check_unknown_tx_must_return_error() {
     cluster.exec_until_stop(|genesis, rpc_addrs, clients| async move {
         let view_client = clients[0].1.clone();
 
-        let genesis_hash = *genesis_block(&genesis).hash();
+        let genesis_hash = genesis_block(&genesis).hash().clone();
         let signer =
             InMemorySigner::from_seed("near.0".parse().unwrap(), KeyType::ED25519, "near.0");
         let transaction = SignedTransaction::send_money(
@@ -529,7 +531,7 @@ fn test_check_unknown_tx_must_return_error() {
             "near.0".parse().unwrap(),
             &signer,
             10000,
-            genesis_hash,
+            genesis_hash.clone(),
         );
 
         let client = new_client(&format!("http://{}", rpc_addrs[0]));
@@ -578,7 +580,7 @@ fn test_check_tx_on_lightclient_must_return_does_not_track_shard() {
     cluster.exec_until_stop(|genesis, rpc_addrs, clients| async move {
         let view_client = clients[0].1.clone();
 
-        let genesis_hash = *genesis_block(&genesis).hash();
+        let genesis_hash = genesis_block(&genesis).hash().clone();
         let signer = InMemorySigner::from_seed("near.1".parse().unwrap(), KeyType::ED25519, "near.1");
         let transaction = SignedTransaction::send_money(
             1,
@@ -586,7 +588,7 @@ fn test_check_tx_on_lightclient_must_return_does_not_track_shard() {
             "near.1".parse().unwrap(),
             &signer,
             10000,
-            genesis_hash,
+            genesis_hash.clone(),
         );
 
         let client = new_client(&format!("http://{}", rpc_addrs[1]));

--- a/integration-tests/tests/nearcore/stake_nodes.rs
+++ b/integration-tests/tests/nearcore/stake_nodes.rs
@@ -119,7 +119,7 @@ fn test_stake_nodes() {
                 &*test_nodes[1].signer,
                 TESTING_INIT_STAKE,
                 test_nodes[1].config.validator_signer.as_ref().unwrap().public_key(),
-                test_nodes[1].genesis_hash,
+                test_nodes[1].genesis_hash.clone(),
             );
             actix::spawn(
                 test_nodes[0]
@@ -204,7 +204,7 @@ fn test_validator_kickout() {
                     &*signer,
                     stake,
                     test_node.config.validator_signer.as_ref().unwrap().public_key(),
-                    test_node.genesis_hash,
+                    test_node.genesis_hash.clone(),
                 )
             });
 
@@ -347,7 +347,7 @@ fn test_validator_join() {
                 &*signer,
                 0,
                 test_nodes[1].config.validator_signer.as_ref().unwrap().public_key(),
-                test_nodes[1].genesis_hash,
+                test_nodes[1].genesis_hash.clone(),
             );
 
             let signer = Arc::new(InMemorySigner::from_seed(
@@ -361,7 +361,7 @@ fn test_validator_join() {
                 &*signer,
                 TESTING_INIT_STAKE,
                 test_nodes[2].config.validator_signer.as_ref().unwrap().public_key(),
-                test_nodes[2].genesis_hash,
+                test_nodes[2].genesis_hash.clone(),
             );
 
             actix::spawn(

--- a/integration-tests/tests/nearcore/sync_nodes.rs
+++ b/integration-tests/tests/nearcore/sync_nodes.rs
@@ -38,17 +38,19 @@ fn add_blocks(
     let mut prev = &blocks[blocks.len() - 1];
     let mut block_merkle_tree = PartialMerkleTree::default();
     for block in blocks.iter() {
-        block_merkle_tree.insert(*block.hash());
+        block_merkle_tree.insert(block.hash().clone());
     }
     for _ in 0..num {
         let epoch_id = match prev.header().height() + 1 {
             height if height <= epoch_length => EpochId::default(),
-            height => {
-                EpochId(*blocks[(((height - 1) / epoch_length - 1) * epoch_length) as usize].hash())
-            }
+            height => EpochId(
+                blocks[(((height - 1) / epoch_length - 1) * epoch_length) as usize].hash().clone(),
+            ),
         };
         let next_epoch_id = EpochId(
-            *blocks[(((prev.header().height()) / epoch_length) * epoch_length) as usize].hash(),
+            blocks[(((prev.header().height()) / epoch_length) * epoch_length) as usize]
+                .hash()
+                .clone(),
         );
         #[cfg(feature = "protocol_feature_chunk_only_producers")]
         let next_bp_hash = Chain::compute_collection_hash(vec![ValidatorStake::new(
@@ -77,7 +79,7 @@ fn add_blocks(
             None,
             vec![Some(
                 Approval::new(
-                    *prev.hash(),
+                    prev.hash().clone(),
                     prev.header().height(),
                     prev.header().height() + 1,
                     signer,
@@ -94,7 +96,7 @@ fn add_blocks(
             next_bp_hash,
             block_merkle_tree.root(),
         );
-        block_merkle_tree.insert(*block.hash());
+        block_merkle_tree.insert(block.hash().clone());
         let _ = client.do_send(NetworkClientMessages::Block(
             block.clone(),
             PeerInfo::random().id,
@@ -259,7 +261,7 @@ fn sync_state_stake_change() {
             let nearcore::NearNode { client: client1, view_client: view_client1, .. } =
                 start_with_config(dir1.path(), near1.clone());
 
-            let genesis_hash = *genesis_block(&genesis).hash();
+            let genesis_hash = genesis_block(&genesis).hash().clone();
             let signer = Arc::new(InMemorySigner::from_seed(
                 "test1".parse().unwrap(),
                 KeyType::ED25519,

--- a/integration-tests/tests/nearcore/track_shards.rs
+++ b/integration-tests/tests/nearcore/track_shards.rs
@@ -27,7 +27,7 @@ fn track_shards() {
         let last_block_hash: Arc<RwLock<Option<CryptoHash>>> = Arc::new(RwLock::new(None));
         WaitOrTimeoutActor::new(
             Box::new(move |_ctx| {
-                let bh = last_block_hash.read().unwrap().map(|h| h.clone());
+                let bh = last_block_hash.read().unwrap().clone().map(|h| h.clone());
                 if let Some(block_hash) = bh {
                     spawn_interruptible(view_client.send(GetChunk::BlockHash(block_hash, 3)).then(
                         move |res| {

--- a/integration-tests/tests/standard_cases/main.rs
+++ b/integration-tests/tests/standard_cases/main.rs
@@ -831,7 +831,7 @@ fn assert_access_key(
     user: &dyn User,
 ) {
     let mut key = access_key.clone();
-    let block = user.get_block_by_hash(result.transaction_outcome.block_hash);
+    let block = user.get_block_by_hash(result.transaction_outcome.block_hash.clone());
     if let Some(b) = block {
         key.nonce = (b.header.height - 1) * AccessKey::ACCESS_KEY_NONCE_RANGE_MULTIPLIER;
     }

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -50,7 +50,7 @@ fn apply_block_at_height(
     let mut chain_store_update = ChainStoreUpdate::new(chain_store);
     let receipt_proof_response = chain_store_update.get_incoming_receipts_for_shard(
         shard_id,
-        block_hash,
+        block_hash.clone(),
         prev_block.chunks()[shard_id as usize].height_included(),
     )?;
     let is_first_block_with_chunk_of_version = check_if_block_is_first_with_chunk_of_version(
@@ -77,7 +77,7 @@ fn apply_block_at_height(
             prev_block.header().gas_price(),
             chunk_header.gas_limit(),
             &block.header().challenges_result(),
-            *block.header().random_value(),
+            block.header().random_value().clone(),
             true,
             is_first_block_with_chunk_of_version,
             None,
@@ -87,8 +87,12 @@ fn apply_block_at_height(
 
     for (outcome_with_id, proof) in apply_result.outcomes.into_iter().zip(outcome_paths.into_iter())
     {
-        let id = outcome_with_id.id;
-        let outcome = vec![ExecutionOutcomeWithIdAndProof { proof, block_hash, outcome_with_id }];
+        let id = outcome_with_id.id.clone();
+        let outcome = vec![ExecutionOutcomeWithIdAndProof {
+            proof,
+            block_hash: block_hash.clone(),
+            outcome_with_id,
+        }];
         store_update.set_ser(DBCol::ColTransactionResult, id.as_ref(), &outcome)?;
     }
     Ok(())
@@ -242,7 +246,7 @@ pub fn migrate_19_to_20(path: &Path, near_config: &NearConfig) {
                             block.header().gas_price(),
                             new_extra.gas_limit(),
                             &block.header().challenges_result(),
-                            *block.header().random_value(),
+                            block.header().random_value().clone(),
                             // doesn't really matter here since the old blocks are on the old version
                             false,
                             false,
@@ -311,7 +315,7 @@ pub fn migrate_22_to_23(path: &Path, near_config: &NearConfig) {
                         block.header().gas_price(),
                         chunk_header.gas_limit(),
                         &block.header().challenges_result(),
-                        *block.header().random_value(),
+                        block.header().random_value().clone(),
                         true,
                         false,
                         None,

--- a/nearcore/src/shard_tracker.rs
+++ b/nearcore/src/shard_tracker.rs
@@ -225,7 +225,7 @@ mod tests {
                     cur_h,
                     height,
                     0,
-                    prev_h,
+                    prev_h.clone(),
                     prev_h,
                     proposals,
                     vec![],
@@ -336,7 +336,7 @@ mod tests {
             record_block(
                 &mut epoch_manager,
                 CryptoHash::default(),
-                h[0],
+                h[0].clone(),
                 0,
                 vec![],
                 simple_nightshade_version,
@@ -344,19 +344,19 @@ mod tests {
             for i in 1..8 {
                 record_block(
                     &mut epoch_manager,
-                    h[i - 1],
-                    h[i],
+                    h[i - 1].clone(),
+                    h[i].clone(),
                     i as u64,
                     vec![],
                     simple_nightshade_version,
                 );
             }
             assert_eq!(
-                epoch_manager.get_epoch_info(&EpochId(h[0])).unwrap().protocol_version(),
+                epoch_manager.get_epoch_info(&EpochId(h[0].clone())).unwrap().protocol_version(),
                 simple_nightshade_version - 1
             );
             assert_eq!(
-                epoch_manager.get_epoch_info(&EpochId(h[1])).unwrap().protocol_version(),
+                epoch_manager.get_epoch_info(&EpochId(h[1].clone())).unwrap().protocol_version(),
                 simple_nightshade_version
             );
         }

--- a/nearcore/tests/economics.rs
+++ b/nearcore/tests/economics.rs
@@ -82,7 +82,7 @@ fn test_burn_mint() {
     let fee_helper = FeeHelper::new(transaction_costs, genesis.config.min_gas_price);
     let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
     let initial_total_supply = env.chain_genesis.total_supply;
-    let genesis_hash = *env.clients[0].chain.genesis().hash();
+    let genesis_hash = env.clients[0].chain.genesis().hash().clone();
     env.clients[0].process_tx(
         SignedTransaction::send_money(
             1,

--- a/runtime/near-vm-runner/src/cache.rs
+++ b/runtime/near-vm-runner/src/cache.rs
@@ -50,7 +50,7 @@ pub fn get_contract_cache_key(
 ) -> CryptoHash {
     let _span = tracing::debug_span!(target: "vm", "get_key").entered();
     let key = ContractCacheKey::Version4 {
-        code_hash: *code.hash(),
+        code_hash: code.hash().clone(),
         vm_config_non_crypto_hash: config.non_crypto_hash(),
         vm_kind,
         vm_hash: vm_hash(vm_kind),
@@ -214,7 +214,7 @@ pub mod wasmer0_cache {
         MODULES: SizedCache<CryptoHash, Result<Result<wasmer_runtime::Module, CompilationError>, CacheError>>
             = SizedCache::with_size(CACHE_SIZE);
         Key = {
-            key
+            key.clone()
         };
 
         fn memcache_compile_module_cached_wasmer(
@@ -223,7 +223,7 @@ pub mod wasmer0_cache {
             config: &VMConfig,
             cache: Option<&dyn CompiledContractCache>
         ) -> Result<Result<wasmer_runtime::Module, CompilationError>, CacheError> = {
-            compile_module_cached_wasmer_impl(key, wasm_code, config, cache)
+            compile_module_cached_wasmer_impl(key.clone(), wasm_code, config, cache)
         }
     }
 
@@ -343,7 +343,7 @@ pub mod wasmer2_cache {
         MODULES: SizedCache<CryptoHash, Result<Result<wasmer::Module, CompilationError>, CacheError>>
             = SizedCache::with_size(CACHE_SIZE);
         Key = {
-            key
+            key.clone()
         };
 
         fn memcache_compile_module_cached_wasmer2(
@@ -353,7 +353,7 @@ pub mod wasmer2_cache {
             cache: Option<&dyn CompiledContractCache>,
             store: &wasmer::Store
         ) -> Result<Result<wasmer::Module, CompilationError>, CacheError> = {
-            compile_module_cached_wasmer2_impl(key, wasm_code, config, cache, store)
+            compile_module_cached_wasmer2_impl(key.clone(), wasm_code, config, cache, store)
         }
     }
 

--- a/runtime/runtime-params-estimator/src/testbed.rs
+++ b/runtime/runtime-params-estimator/src/testbed.rs
@@ -35,7 +35,7 @@ impl RuntimeTestbed {
 
         assert!(roots.len() <= 1, "Parameter estimation works with one shard only.");
         assert!(!roots.is_empty(), "No state roots found.");
-        let root = roots[0];
+        let root = roots[0].clone();
 
         let mut runtime_config =
             RuntimeConfigStore::new(None).get_config(PROTOCOL_VERSION).as_ref().clone();
@@ -102,7 +102,7 @@ impl RuntimeTestbed {
             .runtime
             .apply(
                 self.tries.get_trie_for_shard(ShardUId::default()),
-                self.root,
+                self.root.clone(),
                 &None,
                 &self.apply_state,
                 &self.prev_receipts,

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -77,9 +77,9 @@ pub(crate) fn execute_function_call(
         vec![]
     };
     let random_seed = create_random_seed(
-        apply_state.current_protocol_version,
-        *action_hash,
-        apply_state.random_seed,
+        apply_state.current_protocol_version.clone(),
+        action_hash.clone(),
+        apply_state.random_seed.clone(),
     );
     let context = VMContext {
         current_account_id: runtime_ext.account_id().clone(),
@@ -456,7 +456,7 @@ pub(crate) fn action_deploy_contract(
             ))
         })?,
     );
-    account.set_code_hash(*code.hash());
+    account.set_code_hash(code.hash().clone());
     set_code(state_update, account_id.clone(), &code);
     // Precompile the contract and store result (compiled code or error) in the database.
     // Note, that contract compilation costs are already accounted in deploy cost using
@@ -838,7 +838,7 @@ mod tests {
         storage_usage: u64,
         state_update: &mut TrieUpdate,
     ) -> ActionResult {
-        let mut account = Some(Account::new(100, 0, *code_hash, storage_usage));
+        let mut account = Some(Account::new(100, 0, code_hash.clone(), storage_usage));
         let mut actor_id = account_id.clone();
         let mut action_result = ActionResult::default();
         let receipt = Receipt::new_balance_refund(&"alice.near".parse().unwrap(), 0);

--- a/runtime/runtime/src/ext.rs
+++ b/runtime/runtime/src/ext.rs
@@ -90,8 +90,8 @@ impl<'a> RuntimeExt<'a> {
         code_hash: CryptoHash,
     ) -> Result<Option<Arc<ContractCode>>, StorageError> {
         debug!(target:"runtime", "Calling the contract at account {}", self.account_id);
-        let code = || get_code(self.trie_update, self.account_id, Some(code_hash));
-        crate::cache::get_code(code_hash, code)
+        let code = || get_code(self.trie_update, self.account_id, Some(code_hash.clone()));
+        crate::cache::get_code(code_hash.clone(), code)
     }
 
     pub fn create_storage_key(&self, key: &[u8]) -> TrieKey {
@@ -218,8 +218,8 @@ impl<'a> External for RuntimeExt<'a> {
                 .ok_or_else(|| HostError::InvalidReceiptIndex { receipt_index })?
                 .1
                 .output_data_receivers
-                .push(DataReceiver { data_id, receiver_id: receiver_id.clone() });
-            input_data_ids.push(data_id);
+                .push(DataReceiver { data_id: data_id.clone(), receiver_id: receiver_id.clone() });
+            input_data_ids.push(data_id.clone());
         }
 
         let new_receipt = ActionReceipt {

--- a/runtime/runtime/src/genesis.rs
+++ b/runtime/runtime/src/genesis.rs
@@ -101,7 +101,7 @@ impl GenesisStateApplier {
         genesis: &Genesis,
         batch_account_ids: HashSet<&AccountId>,
     ) {
-        let mut state_update = tries.new_trie_update(shard_uid, *current_state_root);
+        let mut state_update = tries.new_trie_update(shard_uid, current_state_root.clone());
         let mut postponed_receipts: Vec<Receipt> = vec![];
 
         let mut storage_computer = StorageComputer::new(config);
@@ -171,7 +171,7 @@ impl GenesisStateApplier {
             // Logic similar to `apply_receipt`
             let mut pending_data_count: u32 = 0;
             for data_id in &action_receipt.input_data_ids {
-                if get_received_data(&state_update, account_id, *data_id)
+                if get_received_data(&state_update, account_id, data_id.clone())
                     .expect("Genesis storage error")
                     .is_none()
                 {
@@ -180,7 +180,7 @@ impl GenesisStateApplier {
                         &mut state_update,
                         TrieKey::PostponedReceiptId {
                             receiver_id: account_id.clone(),
-                            data_id: *data_id,
+                            data_id: data_id.clone(),
                         },
                         &receipt.receipt_id,
                     )
@@ -193,7 +193,7 @@ impl GenesisStateApplier {
                     &mut state_update,
                     TrieKey::PendingDataCount {
                         receiver_id: account_id.clone(),
-                        receipt_id: receipt.receipt_id,
+                        receipt_id: receipt.receipt_id.clone(),
                     },
                     &pending_data_count,
                 );
@@ -221,7 +221,7 @@ impl GenesisStateApplier {
         tries: &mut ShardTries,
         shard_uid: ShardUId,
     ) {
-        let mut state_update = tries.new_trie_update(shard_uid, *current_state_root);
+        let mut state_update = tries.new_trie_update(shard_uid, current_state_root.clone());
 
         if delayed_receipts_indices != DelayedReceiptIndices::default() {
             set(&mut state_update, TrieKey::DelayedReceiptIndices, &delayed_receipts_indices);

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -199,8 +199,8 @@ impl TrieViewer {
         let apply_state = ApplyState {
             block_index: view_state.block_height,
             // Used for legacy reasons
-            prev_block_hash: view_state.prev_block_hash,
-            block_hash: view_state.block_hash,
+            prev_block_hash: view_state.prev_block_hash.clone(),
+            block_hash: view_state.block_hash.clone(),
             epoch_id: view_state.epoch_id.clone(),
             epoch_height: view_state.epoch_height,
             gas_price: 0,

--- a/runtime/runtime/tests/runtime_group_tools/mod.rs
+++ b/runtime/runtime/tests/runtime_group_tools/mod.rs
@@ -118,7 +118,7 @@ impl StandaloneRuntime {
             .runtime
             .apply(
                 self.tries.get_trie_for_shard(ShardUId::default()),
-                self.root,
+                self.root.clone(),
                 &None,
                 &self.apply_state,
                 receipts,
@@ -211,7 +211,12 @@ impl RuntimeGroup {
             if (i as u64) < num_existing_accounts {
                 state_records.push(StateRecord::Account {
                     account_id: account_id.clone(),
-                    account: Account::new(TESTING_INIT_BALANCE, TESTING_INIT_STAKE, code_hash, 0),
+                    account: Account::new(
+                        TESTING_INIT_BALANCE,
+                        TESTING_INIT_STAKE,
+                        code_hash.clone(),
+                        0,
+                    ),
                 });
                 state_records.push(StateRecord::AccessKey {
                     account_id: account_id.clone(),

--- a/test-utils/runtime-tester/src/run_test.rs
+++ b/test-utils/runtime-tester/src/run_test.rs
@@ -165,7 +165,7 @@ impl TransactionConfig {
             self.receiver_id.clone(),
             &self.signer,
             self.actions.clone(),
-            *last_block.hash(),
+            last_block.hash().clone(),
         )
     }
 }

--- a/test-utils/state-viewer/src/apply_chain_range.rs
+++ b/test-utils/state-viewer/src/apply_chain_range.rs
@@ -101,7 +101,7 @@ pub fn apply_chain_range(
 
             let block_author = runtime_adapter.get_block_producer(&block.header().epoch_id(), block.header().height()).unwrap();
 
-            let apply_result = if *block.header().prev_hash() == CryptoHash::default() {
+            let apply_result = if block.header().prev_hash().clone() == CryptoHash::default() {
                 if verbose_output {
                     println!("Skipping the genesis block #{}.", height);
                 }
@@ -133,7 +133,7 @@ pub fn apply_chain_range(
                 let receipt_proof_response = chain_store_update
                     .get_incoming_receipts_for_shard(
                         shard_id,
-                        block_hash,
+                        block_hash.clone(),
                         prev_block.chunks()[shard_id as usize].height_included(),
                     )
                     .unwrap();
@@ -165,7 +165,7 @@ pub fn apply_chain_range(
                         prev_block.header().gas_price(),
                         chunk_inner.gas_limit(),
                         &block.header().challenges_result(),
-                        *block.header().random_value(),
+                        block.header().random_value().clone(),
                         true,
                         is_first_block_with_chunk_of_version,
                         None,
@@ -190,7 +190,7 @@ pub fn apply_chain_range(
                         block.header().gas_price(),
                         chunk_extra.gas_limit(),
                         &block.header().challenges_result(),
-                        *block.header().random_value(),
+                        block.header().random_value().clone(),
                         false,
                         false,
                         None,
@@ -209,7 +209,7 @@ pub fn apply_chain_range(
                 apply_result.total_balance_burnt,
             );
 
-            let state_update = runtime_adapter.get_tries().new_trie_update(shard_uid, *chunk_extra.state_root());
+            let state_update = runtime_adapter.get_tries().new_trie_update(shard_uid, chunk_extra.state_root().clone());
             let delayed_indices = get::<DelayedReceiptIndices>(&state_update, &TrieKey::DelayedReceiptIndices).unwrap();
 
         match existing_chunk_extra {
@@ -313,7 +313,7 @@ mod test {
     fn test_apply_chain_range() {
         let epoch_length = 4;
         let (store, genesis, mut env) = setup(epoch_length);
-        let genesis_hash = *env.clients[0].chain.genesis().hash();
+        let genesis_hash = env.clients[0].chain.genesis().hash().clone();
         let signer = InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1");
         let tx = SignedTransaction::stake(
             1,
@@ -335,7 +335,7 @@ mod test {
     fn test_apply_chain_range_no_chunks() {
         let epoch_length = 4;
         let (store, genesis, mut env) = setup(epoch_length);
-        let genesis_hash = *env.clients[0].chain.genesis().hash();
+        let genesis_hash = env.clients[0].chain.genesis().hash().clone();
         let signer = InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1");
         let tx = SignedTransaction::stake(
             1,

--- a/test-utils/state-viewer/src/commands.rs
+++ b/test-utils/state-viewer/src/commands.rs
@@ -204,7 +204,7 @@ pub(crate) fn print_chain(
         if let Ok(block_hash) = chain_store.get_block_hash_by_height(height) {
             let header = chain_store.get_block_header(&block_hash).unwrap().clone();
             if height == 0 {
-                println!("{: >3} {}", header.height(), format_hash(*header.hash()));
+                println!("{: >3} {}", header.height(), format_hash(header.hash().clone()));
             } else {
                 let parent_header = chain_store.get_block_header(header.prev_hash()).unwrap();
                 let epoch_id = runtime.get_epoch_id_from_prev_block(header.prev_hash()).unwrap();
@@ -214,7 +214,7 @@ pub(crate) fn print_chain(
                     account_id_to_blocks = HashMap::new();
                     println!(
                         "Epoch {} Validators {:?}",
-                        format_hash(epoch_id.0),
+                        format_hash(epoch_id.0.clone()),
                         runtime
                             .get_epoch_block_producers_ordered(&epoch_id, &header.hash())
                             .unwrap()
@@ -229,10 +229,10 @@ pub(crate) fn print_chain(
                 println!(
                     "{: >3} {} | {: >10} | parent: {: >3} {}",
                     header.height(),
-                    format_hash(*header.hash()),
+                    format_hash(header.hash().clone()),
                     block_producer,
                     parent_header.height(),
-                    format_hash(*parent_header.hash()),
+                    format_hash(parent_header.hash().clone()),
                 );
             }
         } else {
@@ -309,7 +309,7 @@ pub(crate) fn apply_block_at_height(
         let receipt_proof_response = chain_store_update
             .get_incoming_receipts_for_shard(
                 shard_id,
-                block_hash,
+                block_hash.clone(),
                 prev_block.chunks()[shard_id as usize].height_included(),
             )
             .unwrap();
@@ -337,7 +337,7 @@ pub(crate) fn apply_block_at_height(
                 prev_block.header().gas_price(),
                 chunk_inner.gas_limit(),
                 &block.header().challenges_result(),
-                *block.header().random_value(),
+                block.header().random_value().clone(),
                 true,
                 is_first_block_with_chunk_of_version,
                 None,
@@ -361,7 +361,7 @@ pub(crate) fn apply_block_at_height(
                 block.header().gas_price(),
                 chunk_extra.gas_limit(),
                 &block.header().challenges_result(),
-                *block.header().random_value(),
+                block.header().random_value().clone(),
                 false,
                 false,
                 None,
@@ -537,8 +537,11 @@ fn load_trie_stop_at_height(
                         continue;
                     }
                 };
-                let last_final_block_hash =
-                    *chain_store.get_block_header(&cur_block_hash).unwrap().last_final_block();
+                let last_final_block_hash = chain_store
+                    .get_block_header(&cur_block_hash)
+                    .unwrap()
+                    .last_final_block()
+                    .clone();
                 let last_final_block = chain_store.get_block(&last_final_block_hash).unwrap();
                 if last_final_block.header().height() >= height {
                     break last_final_block.clone();

--- a/test-utils/state-viewer/src/state_dump.rs
+++ b/test-utils/state-viewer/src/state_dump.rs
@@ -194,7 +194,7 @@ mod test {
     fn test_dump_state_preserve_validators() {
         let epoch_length = 4;
         let (store, genesis, mut env, near_config) = setup(epoch_length, PROTOCOL_VERSION, None);
-        let genesis_hash = *env.clients[0].chain.genesis().hash();
+        let genesis_hash = env.clients[0].chain.genesis().hash().clone();
         let signer = InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1");
         let tx = SignedTransaction::stake(
             1,
@@ -209,7 +209,7 @@ mod test {
         safe_produce_blocks(&mut env, 1, epoch_length * 2 + 1);
 
         let head = env.clients[0].chain.head().unwrap();
-        let last_block_hash = head.last_block_hash;
+        let last_block_hash = head.last_block_hash.clone();
         let cur_epoch_id = head.epoch_id;
         let block_producers = env.clients[0]
             .runtime_adapter
@@ -240,7 +240,7 @@ mod test {
     fn test_dump_state_return_locked() {
         let epoch_length = 4;
         let (store, genesis, mut env, near_config) = setup(epoch_length, PROTOCOL_VERSION, None);
-        let genesis_hash = *env.clients[0].chain.genesis().hash();
+        let genesis_hash = env.clients[0].chain.genesis().hash().clone();
         let signer = InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1");
         let tx = SignedTransaction::stake(
             1,
@@ -342,7 +342,7 @@ mod test {
                 Arc::new(create_runtime(store2.clone())),
             ])
             .build();
-        let genesis_hash = *env.clients[0].chain.genesis().hash();
+        let genesis_hash = env.clients[0].chain.genesis().hash().clone();
         let signer = InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1");
         let tx = SignedTransaction::send_money(
             1,
@@ -409,7 +409,7 @@ mod test {
             .validator_seats(2)
             .runtime_adapters(vec![Arc::new(nightshade_runtime)])
             .build();
-        let genesis_hash = *env.clients[0].chain.genesis().hash();
+        let genesis_hash = env.clients[0].chain.genesis().hash().clone();
         let signer = InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1");
         let tx = SignedTransaction::stake(
             1,
@@ -437,7 +437,7 @@ mod test {
             ))),
         );
         let head = env.clients[0].chain.head().unwrap();
-        let last_block_hash = head.last_block_hash;
+        let last_block_hash = head.last_block_hash.clone();
         let cur_epoch_id = head.epoch_id;
         let block_producers = env.clients[0]
             .runtime_adapter

--- a/test-utils/testlib/src/runtime_utils.rs
+++ b/test-utils/testlib/src/runtime_utils.rs
@@ -30,14 +30,14 @@ pub fn add_test_contract(genesis: &mut Genesis, account_id: &AccountId) {
         if let StateRecord::Account { account_id: record_account_id, ref mut account } = record {
             if record_account_id == account_id {
                 is_account_record_found = true;
-                account.set_code_hash(*DEFAULT_TEST_CONTRACT_HASH);
+                account.set_code_hash(DEFAULT_TEST_CONTRACT_HASH.clone());
             }
         }
     }
     if !is_account_record_found {
         genesis.records.as_mut().push(StateRecord::Account {
             account_id: account_id.clone(),
-            account: Account::new(0, 0, *DEFAULT_TEST_CONTRACT_HASH, 0),
+            account: Account::new(0, 0, DEFAULT_TEST_CONTRACT_HASH.clone(), 0),
         });
     }
     genesis.records.as_mut().push(StateRecord::Contract {

--- a/tools/restored-receipts-verifier/src/main.rs
+++ b/tools/restored-receipts-verifier/src/main.rs
@@ -100,7 +100,7 @@ fn main() -> Result<()> {
                 block.header().gas_price(),
                 chunk_extra.gas_limit(),
                 &block.header().challenges_result(),
-                *block.header().random_value(),
+                block.header().random_value().clone(),
                 false,
                 false, // because fix was not applied in for the blocks analyzed here
                 None,


### PR DESCRIPTION
Rust is built around the concept of “zero cost abstraction”. I noticed that in our code base we do a lot of hidden copies, when it comes to `Cryptohash`.

`Cryptohash` currently uses `Copy` derive, which hides all copies of that structs. We could have avoided doing those copy operations, and also improved performance of our code.

My proposal is to remove `Copy` trait from `Cryptohash`.

We can continue doing that, until all crates no longer rely on `Copy` trait, and then simply remove it.

Part 1:
- No signature changes, no optimizations, this is just made so we can use `CryptoHash` without `Copy`

Part 2:
- Optimizations. That's optional, it will be up to individual code owner to decide to do them or not. This can be done later, or just after pt1.