### PR TITLE
feat: Optimize `RoutingTableView` iterators

### DIFF
--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -676,7 +676,7 @@ impl PeerManagerActor {
             addr.do_send(SendMessage {
                 message: PeerMessage::SyncRoutingTable(RoutingTableUpdate::new(
                     known_edges,
-                    known_accounts,
+                    known_accounts.cloned().collect(),
                 )),
             });
 
@@ -1393,7 +1393,7 @@ impl PeerManagerActor {
                        reason = ?find_route_error,
                        ?msg,"Drop message",
                 );
-                trace!(target: "network", known_peers = ?self.routing_table_view.get_accounts_keys());
+                trace!(target: "network", known_peers = ?self.routing_table_view.get_accounts_keys().collect::<Vec<_>>(), "Known peers");
                 return false;
             }
         };
@@ -1471,7 +1471,6 @@ impl PeerManagerActor {
             known_producers: self
                 .routing_table_view
                 .get_announce_accounts()
-                .iter()
                 .map(|announce_account| KnownProducer {
                     account_id: announce_account.account_id.clone(),
                     peer_id: announce_account.peer_id.clone(),

--- a/chain/network/src/tests/cache.rs
+++ b/chain/network/src/tests/cache.rs
@@ -32,10 +32,10 @@ fn announcement_same_epoch() {
     routing_table.add_account(announce0.clone());
     assert!(routing_table.contains_account(&announce0));
     assert!(routing_table.contains_account(&announce1));
-    assert_eq!(routing_table.get_announce_accounts().len(), 1);
+    assert_eq!(routing_table.get_announce_accounts().count(), 1);
     assert_eq!(routing_table.account_owner(&announce0.account_id).unwrap(), peer_id0);
     routing_table.add_account(announce1.clone());
-    assert_eq!(routing_table.get_announce_accounts().len(), 1);
+    assert_eq!(routing_table.get_announce_accounts().count(), 1);
     assert_eq!(routing_table.account_owner(&announce1.account_id).unwrap(), peer_id1);
 }
 
@@ -67,12 +67,12 @@ fn dont_load_on_build() {
 
     routing_table.add_account(announce0.clone());
     routing_table.add_account(announce1.clone());
-    let accounts = routing_table.get_announce_accounts();
-    assert!(vec![announce0, announce1].iter().all(|announce| { accounts.contains(announce) }));
-    assert_eq!(routing_table.get_announce_accounts().len(), 2);
+    let accounts: Vec<&AnnounceAccount> = routing_table.get_announce_accounts().collect();
+    assert!(vec![announce0, announce1].iter().all(|announce| { accounts.contains(&announce) }));
+    assert_eq!(accounts.len(), 2);
 
     let routing_table1 = RoutingTableView::new(store);
-    assert!(routing_table1.get_announce_accounts().is_empty());
+    assert_eq!(routing_table1.get_announce_accounts().count(), 0);
 }
 
 #[test]
@@ -94,11 +94,11 @@ fn load_from_disk() {
 
     // Announcement is added to cache of the first routing table and to disk
     routing_table.add_account(announce0.clone());
-    assert_eq!(routing_table.get_announce_accounts().len(), 1);
+    assert_eq!(routing_table.get_announce_accounts().count(), 1);
     // Cache of second routing table is empty
-    assert_eq!(routing_table1.get_announce_accounts().len(), 0);
+    assert_eq!(routing_table1.get_announce_accounts().count(), 0);
     // Try to find this peer and load it from disk
     assert_eq!(routing_table1.account_owner(&announce0.account_id).unwrap(), peer_id0);
     // Cache of second routing table should contain account loaded from disk
-    assert_eq!(routing_table1.get_announce_accounts().len(), 1);
+    assert_eq!(routing_table1.get_announce_accounts().count(), 1);
 }


### PR DESCRIPTION
I'm trying to improve `pub fn get_accounts_keys(&mut self)`.

Is there a way to avoid doing memory allocation here?