### PR TITLE
re: `near-network`: Remove `clone()` from `Edge::partial_verify`

### DIFF
--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -796,8 +796,8 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for PeerActor {
 
                 // Verify signature of the new edge in handshake.
                 if !Edge::partial_verify(
-                    self.my_node_id().clone(),
-                    handshake.sender_peer_id.clone(),
+                    self.my_node_id(),
+                    &handshake.sender_peer_id,
                     &handshake.partial_edge_info,
                 ) {
                     warn!(target: "network", "Received invalid signature on handshake. Disconnecting peer {}", handshake.sender_peer_id);

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -1874,7 +1874,7 @@ impl PeerManagerActor {
                 NetworkResponses::NoResponse
             }
             NetworkRequests::RequestUpdateNonce(peer_id, edge_info) => {
-                if Edge::partial_verify(self.my_peer_id.clone(), peer_id.clone(), &edge_info) {
+                if Edge::partial_verify(&self.my_peer_id, &peer_id, &edge_info) {
                     if let Some(cur_edge) =
                         self.routing_table_view.get_edge(self.my_peer_id.clone(), peer_id.clone())
                     {

--- a/chain/network/src/routing/edge.rs
+++ b/chain/network/src/routing/edge.rs
@@ -108,12 +108,12 @@ impl Edge {
 
     /// Helper function when adding a new edge and we receive information from new potential peer
     /// to verify the signature.
-    pub fn partial_verify(peer0: PeerId, peer1: PeerId, edge_info: &PartialEdgeInfo) -> bool {
+    pub fn partial_verify(peer0: &PeerId, peer1: &PeerId, edge_info: &PartialEdgeInfo) -> bool {
         let pk = peer1.public_key();
         let data = if peer0 < peer1 {
-            Edge::build_hash(&peer0, &peer1, edge_info.nonce)
+            Edge::build_hash(peer0, peer1, edge_info.nonce)
         } else {
-            Edge::build_hash(&peer1, &peer0, edge_info.nonce)
+            Edge::build_hash(peer1, peer0, edge_info.nonce)
         };
         edge_info.signature.verify(data.as_ref(), pk)
     }


### PR DESCRIPTION
Let's change `Edge::partial_verify` signature, to pass arguments as reference.