### PR TITLE
feat: increase `OLDEST_PROTOCOL_VERSION`  from `34` to `LATEST - 1`

### DIFF
--- a/chain/network/src/network_protocol.rs
+++ b/chain/network/src/network_protocol.rs
@@ -15,7 +15,7 @@ use near_primitives::network::{AnnounceAccount, PeerId};
 use near_primitives::syncing::{EpochSyncFinalizationResponse, EpochSyncResponse};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{EpochId, ProtocolVersion};
-use near_primitives::version::{OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION, PROTOCOL_VERSION};
+use near_primitives::version::{PEER_MIN_ALLOWED_PROTOCOL_VERSION, PROTOCOL_VERSION};
 use std::fmt::Formatter;
 use std::{fmt, io};
 
@@ -73,7 +73,7 @@ impl Handshake {
     ) -> Self {
         Handshake {
             protocol_version: version,
-            oldest_supported_version: OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION,
+            oldest_supported_version: PEER_MIN_ALLOWED_PROTOCOL_VERSION,
             sender_peer_id: peer_id,
             target_peer_id,
             sender_listen_port: listen_port,
@@ -97,7 +97,7 @@ impl BorshDeserialize for Handshake {
 
         let version = u32::from_le_bytes(buf[..4].try_into().unwrap());
 
-        if OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION <= version && version <= PROTOCOL_VERSION {
+        if PEER_MIN_ALLOWED_PROTOCOL_VERSION <= version && version <= PROTOCOL_VERSION {
             // If we support this version, then try to deserialize with custom deserializer
             HandshakeAutoDes::deserialize(buf).map(Into::into)
         } else {
@@ -158,7 +158,7 @@ impl HandshakeV2 {
     ) -> Self {
         Self {
             protocol_version: version,
-            oldest_supported_version: OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION,
+            oldest_supported_version: PEER_MIN_ALLOWED_PROTOCOL_VERSION,
             sender_peer_id: peer_id,
             target_peer_id,
             sender_listen_port,
@@ -196,7 +196,7 @@ impl BorshDeserialize for HandshakeV2 {
         let version = u32::from_le_bytes(buf[..4].try_into().unwrap());
         let oldest_supported_version = u32::from_le_bytes(buf[4..8].try_into().unwrap());
 
-        if OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION <= version && version <= PROTOCOL_VERSION {
+        if PEER_MIN_ALLOWED_PROTOCOL_VERSION <= version && version <= PROTOCOL_VERSION {
             // If we support this version, then try to deserialize with custom deserializer
             HandshakeV2AutoDes::deserialize(buf).map(Into::into)
         } else {

--- a/chain/network/src/peer/codec.rs
+++ b/chain/network/src/peer/codec.rs
@@ -114,7 +114,7 @@ mod test {
     use near_primitives::hash::CryptoHash;
     use near_primitives::network::{AnnounceAccount, PeerId};
     use near_primitives::types::EpochId;
-    use near_primitives::version::{OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION, PROTOCOL_VERSION};
+    use near_primitives::version::{PEER_MIN_ALLOWED_PROTOCOL_VERSION, PROTOCOL_VERSION};
     use tokio_util::codec::{Decoder, Encoder};
 
     fn test_codec(msg: PeerMessage) {
@@ -130,7 +130,7 @@ mod test {
         let peer_info = PeerInfo::random();
         let fake_handshake = Handshake {
             protocol_version: PROTOCOL_VERSION,
-            oldest_supported_version: OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION,
+            oldest_supported_version: PEER_MIN_ALLOWED_PROTOCOL_VERSION,
             sender_peer_id: peer_info.id.clone(),
             target_peer_id: peer_info.id,
             sender_listen_port: None,
@@ -151,7 +151,7 @@ mod test {
         let peer_info = PeerInfo::random();
         let fake_handshake = HandshakeV2 {
             protocol_version: PROTOCOL_VERSION,
-            oldest_supported_version: OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION,
+            oldest_supported_version: PEER_MIN_ALLOWED_PROTOCOL_VERSION,
             sender_peer_id: peer_info.id.clone(),
             target_peer_id: peer_info.id,
             sender_listen_port: None,

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -34,7 +34,7 @@ use near_primitives::sharding::PartialEncodedChunk;
 use near_primitives::time::Clock;
 use near_primitives::utils::DisplayOption;
 use near_primitives::version::{
-    ProtocolVersion, OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION, PROTOCOL_VERSION,
+    ProtocolVersion, PEER_MIN_ALLOWED_PROTOCOL_VERSION, PROTOCOL_VERSION,
 };
 use near_primitives::{logging, unwrap_option_or_return};
 use near_rate_limiter::{ActixMessageWrapper, ThrottleController};
@@ -586,7 +586,7 @@ impl PeerActor {
                 self.my_node_info.clone(),
                 HandshakeFailureReason::ProtocolVersionMismatch {
                     version: PROTOCOL_VERSION,
-                    oldest_supported_version: OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION,
+                    oldest_supported_version: PEER_MIN_ALLOWED_PROTOCOL_VERSION,
                 },
             ));
         } else {
@@ -732,7 +732,7 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for PeerActor {
                         if target_version
                             >= std::cmp::max(
                                 oldest_supported_version,
-                                OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION,
+                                PEER_MIN_ALLOWED_PROTOCOL_VERSION,
                             )
                         {
                             // Use target_version as protocol_version to talk with this peer
@@ -740,7 +740,7 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for PeerActor {
                             self.send_handshake(ctx);
                             return;
                         } else {
-                            warn!(target: "network", "Unable to connect to a node ({}) due to a network protocol version mismatch. Our version: {:?}, their: {:?}", peer_info, (PROTOCOL_VERSION, OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION), (version, oldest_supported_version));
+                            warn!(target: "network", "Unable to connect to a node ({}) due to a network protocol version mismatch. Our version: {:?}, their: {:?}", peer_info, (PROTOCOL_VERSION, PEER_MIN_ALLOWED_PROTOCOL_VERSION), (version, oldest_supported_version));
                         }
                     }
                     HandshakeFailureReason::InvalidTarget => {
@@ -759,7 +759,7 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for PeerActor {
                 debug!(target: "network", "{:?}: Received handshake {:?}", self.my_node_info.id, handshake);
 
                 debug_assert!(
-                    OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION <= handshake.protocol_version
+                    PEER_MIN_ALLOWED_PROTOCOL_VERSION <= handshake.protocol_version
                         && handshake.protocol_version <= PROTOCOL_VERSION
                 );
 

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -21,9 +21,6 @@ pub const DB_VERSION: DbVersion = 30;
 /// Protocol version type.
 pub use near_primitives_core::types::ProtocolVersion;
 
-/// Oldest supported version by this client.
-pub const OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION: ProtocolVersion = 34;
-
 /// Minimum gas price proposed in NEP 92 and the associated protocol version
 pub const MIN_GAS_PRICE_NEP_92: Balance = 1_000_000_000;
 pub const MIN_PROTOCOL_VERSION_NEP_92: ProtocolVersion = 31;
@@ -142,15 +139,23 @@ pub enum ProtocolFeature {
     RoutingExchangeAlgorithm,
 }
 
-/// Current latest stable version of the protocol.
+/// Both, outgoing and incoming tcp connections to peers, will be rejected if `peer's`
+/// protocol version is lower than this.
+pub const PEER_MIN_ALLOWED_PROTOCOL_VERSION: ProtocolVersion = MAIN_NET_PROTOCOL_VERSION - 1;
+
+/// Current protocol version used on the main net.
 /// Some features (e. g. FixStorageUsage) require that there is at least one epoch with exactly
 /// the corresponding version
-#[cfg(not(feature = "nightly_protocol"))]
-pub const PROTOCOL_VERSION: ProtocolVersion = 50;
+const MAIN_NET_PROTOCOL_VERSION: ProtocolVersion = 50;
 
 /// Current latest nightly version of the protocol.
+const TEST_NET_PROTOCOL_VERSION: ProtocolVersion = 125;
+
+/// Version used by this binary.
+#[cfg(not(feature = "nightly_protocol"))]
+pub const PROTOCOL_VERSION: ProtocolVersion = MAIN_NET_PROTOCOL_VERSION;
 #[cfg(feature = "nightly_protocol")]
-pub const PROTOCOL_VERSION: ProtocolVersion = 125;
+pub const PROTOCOL_VERSION: ProtocolVersion = TEST_NET_PROTOCOL_VERSION;
 
 impl ProtocolFeature {
     pub const fn protocol_version(self) -> ProtocolVersion {

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -148,14 +148,12 @@ pub const PEER_MIN_ALLOWED_PROTOCOL_VERSION: ProtocolVersion = MAIN_NET_PROTOCOL
 /// the corresponding version
 const MAIN_NET_PROTOCOL_VERSION: ProtocolVersion = 50;
 
-/// Current latest nightly version of the protocol.
-const TEST_NET_PROTOCOL_VERSION: ProtocolVersion = 125;
-
 /// Version used by this binary.
 #[cfg(not(feature = "nightly_protocol"))]
 pub const PROTOCOL_VERSION: ProtocolVersion = MAIN_NET_PROTOCOL_VERSION;
+/// Current latest nightly version of the protocol.
 #[cfg(feature = "nightly_protocol")]
-pub const PROTOCOL_VERSION: ProtocolVersion = TEST_NET_PROTOCOL_VERSION;
+pub const PROTOCOL_VERSION: ProtocolVersion = 125;
 
 impl ProtocolFeature {
     pub const fn protocol_version(self) -> ProtocolVersion {


### PR DESCRIPTION
We haven't bumped minimum required version for more than a year, since 2020/10/01.

Let's upgrade minimum protocol version from `34` to `39`. This will allow us to drop deprecated code in `HandshakeV2`.

The current stable version used is '49`.

Follow up:
- [x] https://github.com/near/nearcore/pull/5611