### PR TITLE
re: `near-network` Limit visibility of types outside of crate

### DIFF
--- a/chain/network/src/lib.rs
+++ b/chain/network/src/lib.rs
@@ -1,9 +1,11 @@
 pub use crate::peer_manager::peer_manager_actor::PeerManagerActor;
 pub use crate::peer_manager::peer_store::iter_peers_from_store;
-pub use crate::routing::routing_table_actor::{
-    RoutingTableActor, RoutingTableMessages, RoutingTableMessagesResponse,
-};
-pub use crate::stats::metrics;
+/// For benchmarks only
+pub use crate::routing::routing_table_actor::RoutingTableActor;
+#[cfg(feature = "test_features")]
+pub use crate::routing::routing_table_actor::{RoutingTableMessages, RoutingTableMessagesResponse};
+#[cfg(feature = "test_features")]
+pub use crate::stats::metrics::RECEIVED_INFO_ABOUT_ITSELF;
 // TODO(#5307)
 pub use near_network_primitives::types::PeerInfo;
 
@@ -11,7 +13,7 @@ mod network_protocol;
 mod peer;
 mod peer_manager;
 pub mod routing;
-mod stats;
+pub(crate) mod stats;
 pub mod test_utils;
 #[cfg(test)]
 mod tests;

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -11,7 +11,9 @@ use crate::routing::edge_validator_actor::EdgeValidatorHelper;
 use crate::routing::routing::{
     PeerRequestResult, RoutingTableView, DELETE_PEERS_AFTER_TIME, MAX_NUM_PEERS,
 };
-use crate::routing::routing_table_actor::Prune;
+use crate::routing::routing_table_actor::{
+    Prune, RoutingTableActor, RoutingTableMessages, RoutingTableMessagesResponse,
+};
 use crate::stats::metrics;
 use crate::stats::metrics::NetworkMetrics;
 use crate::types::{FullPeerInfo, NetworkClientMessages, NetworkRequests, NetworkResponses};
@@ -22,7 +24,7 @@ use crate::types::{
 };
 #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
 use crate::types::{RoutingSyncV2, RoutingVersion2};
-use crate::{PeerInfo, RoutingTableActor, RoutingTableMessages, RoutingTableMessagesResponse};
+use crate::PeerInfo;
 use actix::{
     Actor, ActorFuture, Addr, Arbiter, AsyncContext, Context, ContextFutureSpawner, Handler,
     Recipient, Running, StreamHandler, WrapFuture,
@@ -524,7 +526,9 @@ impl PeerManagerActor {
             .into_actor(self)
             .map(move |response, _act, _ctx| match response.map(|r| r.into_inner()) {
                 Ok(RoutingTableMessagesResponse::StartRoutingTableSyncResponse(response)) => {
-                    let _ = addr.do_send(SendMessage { message: response });
+                    let _ = addr.do_send(SendMessage {
+                        message: crate::types::PeerMessage::RoutingTableSyncV2(response),
+                    });
                 }
                 _ => error!(target: "network", "expected StartRoutingTableSyncResponse"),
             })

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -1,7 +1,7 @@
-use crate::metrics;
 use crate::routing::edge::{Edge, EdgeState};
 use crate::routing::edge_validator_actor::EdgeValidatorActor;
 use crate::routing::routing::{Graph, SAVE_PEERS_MAX_TIME};
+use crate::stats::metrics;
 use crate::types::{StopMsg, ValidateEdgeList};
 use actix::dev::MessageResponse;
 use actix::{
@@ -499,7 +499,7 @@ pub enum RoutingTableMessagesResponse {
     },
     AddVerifiedEdgesResponse(Vec<Edge>),
     #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
-    StartRoutingTableSyncResponse(crate::types::PeerMessage),
+    StartRoutingTableSyncResponse(crate::types::RoutingSyncV2),
     RoutingTableUpdateResponse {
         /// PeerManager maintains list of local edges. We will notify `PeerManager`
         /// to remove those edges.
@@ -582,14 +582,12 @@ impl Handler<RoutingTableMessages> for RoutingTableActor {
             #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
             RoutingTableMessages::StartRoutingTableSync { seed } => {
                 RoutingTableMessagesResponse::StartRoutingTableSyncResponse(
-                    crate::types::PeerMessage::RoutingTableSyncV2(
-                        crate::types::RoutingSyncV2::Version2(crate::types::RoutingVersion2 {
-                            known_edges: self.edges_info.len() as u64,
-                            seed,
-                            edges: Default::default(),
-                            routing_state: crate::types::RoutingState::InitializeIbf,
-                        }),
-                    ),
+                    crate::types::RoutingSyncV2::Version2(crate::types::RoutingVersion2 {
+                        known_edges: self.edges_info.len() as u64,
+                        seed,
+                        edges: Default::default(),
+                        routing_state: crate::types::RoutingState::InitializeIbf,
+                    }),
                 )
             }
             #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]

--- a/chain/network/src/test_utils.rs
+++ b/chain/network/src/test_utils.rs
@@ -279,10 +279,10 @@ impl MockPeerManagerAdapter {
 
 #[cfg(feature = "test_features")]
 pub mod test_features {
-    use crate::routing::routing_table_actor::start_routing_table_actor;
+    use crate::routing::routing_table_actor::{start_routing_table_actor, RoutingTableActor};
     use crate::test_utils::{convert_boot_nodes, open_port};
     use crate::types::{NetworkClientMessages, NetworkClientResponses};
-    use crate::{PeerManagerActor, RoutingTableActor};
+    use crate::PeerManagerActor;
     use actix::actors::mocker::Mocker;
     use actix::{Actor, Addr};
     use near_network_primitives::types::{

--- a/integration-tests/tests/network/peer_handshake.rs
+++ b/integration-tests/tests/network/peer_handshake.rs
@@ -233,7 +233,8 @@ fn check_connection_with_new_identity() {
     runner.push(Action::Wait(2000));
 
     // Check the no node tried to connect to itself in this process.
-    runner.push_action(wait_for(|| near_network::metrics::RECEIVED_INFO_ABOUT_ITSELF.get() == 0));
+    #[cfg(feature = "test_features")]
+    runner.push_action(wait_for(|| near_network::RECEIVED_INFO_ABOUT_ITSELF.get() == 0));
 
     start_test(runner);
 }

--- a/integration-tests/tests/network/runner.rs
+++ b/integration-tests/tests/network/runner.rs
@@ -973,6 +973,7 @@ pub fn change_account_id(node_id: usize, account_id: AccountId) -> ActionFn {
 }
 
 /// Wait for predicate to return True.
+#[cfg(feature = "test_features")]
 pub fn wait_for<T>(predicate: T) -> ActionFn
 where
     T: 'static + Fn() -> bool,


### PR DESCRIPTION
We can further isolate `near-network` by:
- making `crate::routing` available only for `test_features` only
- making `crate::stats` only available pub(crate) only
- making `PeerActorMessages` pub(crate) only

`near-network` still exports the following to outside world:
- `PeerManaagerActor`
- `PeerManagerActor` related messages
- some borsh serializable messages (split between `near-network`, `near-network-primitives`)

Doesn't for
- `PeerActor`
- `RoutingTableActor`
- `EdgeValidatorActor`

`near-network-primitives`
- `ClientActor`related messages
- `ViewClientActor`related messages
- some borsh serializable messages (split between `near-network`, `near-network-primitives`)