### PR TITLE
re: `near-network` Move `PeerStatus` near `PeerActor`

### DIFF
--- a/chain/network-primitives/src/types.rs
+++ b/chain/network-primitives/src/types.rs
@@ -60,18 +60,6 @@ pub enum PeerType {
     Outbound,
 }
 
-/// Peer status.
-#[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum PeerStatus {
-    /// Waiting for handshake.
-    Connecting,
-    /// Ready to go.
-    Ready,
-    /// Banned, should shutdown this peer.
-    Banned(ReasonForBan),
-}
-
 /// Account route description
 /// Unused?
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
@@ -643,7 +631,6 @@ mod tests {
     #[test]
     fn test_enum_size() {
         assert_size!(PeerType);
-        assert_size!(PeerStatus);
         assert_size!(RoutedMessageBody);
         assert_size!(PeerIdOrHash);
         assert_size!(KnownPeerStatus);

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -21,9 +21,9 @@ use lru::LruCache;
 use near_crypto::Signature;
 use near_network_primitives::types::{
     Ban, NetworkViewClientMessages, NetworkViewClientResponses, PeerChainInfo, PeerChainInfoV2,
-    PeerIdOrHash, PeerInfo, PeerManagerRequest, PeerStatsResult, PeerStatus, PeerType,
-    QueryPeerStats, ReasonForBan, RoutedMessage, RoutedMessageBody, RoutedMessageFrom,
-    StateResponseInfo, UPDATE_INTERVAL_LAST_TIME_RECEIVED_MESSAGE,
+    PeerIdOrHash, PeerInfo, PeerManagerRequest, PeerStatsResult, PeerType, QueryPeerStats,
+    ReasonForBan, RoutedMessage, RoutedMessageBody, RoutedMessageFrom, StateResponseInfo,
+    UPDATE_INTERVAL_LAST_TIME_RECEIVED_MESSAGE,
 };
 use near_performance_metrics::framed_write::{FramedWrite, WriteHandler};
 use near_performance_metrics_macros::perf;
@@ -1083,4 +1083,15 @@ impl Handler<PeerManagerRequest> for PeerActor {
             }
         }
     }
+}
+
+/// Peer status.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum PeerStatus {
+    /// Waiting for handshake.
+    Connecting,
+    /// Ready to go.
+    Ready,
+    /// Banned, should shutdown this peer.
+    Banned(ReasonForBan),
 }


### PR DESCRIPTION
`PeerStatus`, which is currently in `near-network-primitives`, is only used by `PeerActor`. 
For that reason, we should move it to `near-network`, in the same file as `PeerActor`.