### PR TITLE
chain: rosetta: fix make Construction and Data APIs ids match

### DIFF
--- a/chain/rosetta-rpc/src/adapters/mod.rs
+++ b/chain/rosetta-rpc/src/adapters/mod.rs
@@ -4,7 +4,6 @@ use actix::Addr;
 
 use near_chain_configs::Genesis;
 use near_client::ViewClientActor;
-use near_primitives::serialize::BaseEncode;
 
 use validated_operations::ValidatedOperation;
 
@@ -94,9 +93,10 @@ async fn convert_genesis_records_to_transaction(
     }
 
     Ok(crate::models::Transaction {
-        transaction_identifier: crate::models::TransactionIdentifier {
-            hash: format!("block:{}", block.header.hash),
-        },
+        transaction_identifier: crate::models::TransactionIdentifier::new(
+            "block",
+            &block.header.hash,
+        ),
         operations,
         metadata: crate::models::TransactionMetadata {
             type_: crate::models::TransactionType::Block,
@@ -167,22 +167,24 @@ fn convert_block_changes_to_transactions(
 
     let mut transactions = std::collections::HashMap::<String, crate::models::Transaction>::new();
     for account_change in accounts_changes {
-        let transaction_hash = match account_change.cause {
+        let transaction_identifier = match account_change.cause {
             StateChangeCauseView::TransactionProcessing { tx_hash } => {
-                format!("tx:{}", tx_hash.to_base())
+                crate::models::TransactionIdentifier::transaction(&tx_hash)
             }
             StateChangeCauseView::ActionReceiptProcessingStarted { receipt_hash }
             | StateChangeCauseView::ActionReceiptGasReward { receipt_hash }
             | StateChangeCauseView::ReceiptProcessing { receipt_hash }
             | StateChangeCauseView::PostponedReceipt { receipt_hash } => {
-                format!("receipt:{}", receipt_hash.to_base())
+                crate::models::TransactionIdentifier::receipt(&receipt_hash)
             }
-            StateChangeCauseView::InitialState => format!("block:{}", block_hash),
+            StateChangeCauseView::InitialState => {
+                crate::models::TransactionIdentifier::new("block", block_hash)
+            }
             StateChangeCauseView::ValidatorAccountsUpdate => {
-                format!("block-validators-update:{}", block_hash)
+                crate::models::TransactionIdentifier::new("block-validators-update", block_hash)
             }
             StateChangeCauseView::UpdatedDelayedReceipts => {
-                format!("block-delayed-receipts:{}", block_hash)
+                crate::models::TransactionIdentifier::new("block-delayed-receipts", block_hash)
             }
             StateChangeCauseView::NotWritableToDisk => {
                 return Err(crate::errors::ErrorKind::InternalInvariantError(
@@ -190,7 +192,7 @@ fn convert_block_changes_to_transactions(
                 ));
             }
             StateChangeCauseView::Migration => {
-                format!("migration:{}", block_hash)
+                crate::models::TransactionIdentifier::new("migration", block_hash)
             }
             StateChangeCauseView::Resharding => {
                 return Err(crate::errors::ErrorKind::InternalInvariantError(
@@ -199,17 +201,14 @@ fn convert_block_changes_to_transactions(
             }
         };
 
-        let current_transaction =
-            transactions.entry(transaction_hash.clone()).or_insert_with(move || {
-                crate::models::Transaction {
-                    transaction_identifier: crate::models::TransactionIdentifier {
-                        hash: transaction_hash,
-                    },
-                    operations: vec![],
-                    metadata: crate::models::TransactionMetadata {
-                        type_: crate::models::TransactionType::Transaction,
-                    },
-                }
+        let current_transaction = transactions
+            .entry(transaction_identifier.hash.clone())
+            .or_insert_with(move || crate::models::Transaction {
+                transaction_identifier,
+                operations: vec![],
+                metadata: crate::models::TransactionMetadata {
+                    type_: crate::models::TransactionType::Transaction,
+                },
             });
 
         let operations = &mut current_transaction.operations;

--- a/chain/rosetta-rpc/src/adapters/mod.rs
+++ b/chain/rosetta-rpc/src/adapters/mod.rs
@@ -93,7 +93,7 @@ async fn convert_genesis_records_to_transaction(
     }
 
     Ok(crate::models::Transaction {
-        transaction_identifier: crate::models::TransactionIdentifier::new(
+        transaction_identifier: crate::models::TransactionIdentifier::block_event(
             "block",
             &block.header.hash,
         ),
@@ -178,13 +178,19 @@ fn convert_block_changes_to_transactions(
                 crate::models::TransactionIdentifier::receipt(&receipt_hash)
             }
             StateChangeCauseView::InitialState => {
-                crate::models::TransactionIdentifier::new("block", block_hash)
+                crate::models::TransactionIdentifier::block_event("block", block_hash)
             }
             StateChangeCauseView::ValidatorAccountsUpdate => {
-                crate::models::TransactionIdentifier::new("block-validators-update", block_hash)
+                crate::models::TransactionIdentifier::block_event(
+                    "block-validators-update",
+                    block_hash,
+                )
             }
             StateChangeCauseView::UpdatedDelayedReceipts => {
-                crate::models::TransactionIdentifier::new("block-delayed-receipts", block_hash)
+                crate::models::TransactionIdentifier::block_event(
+                    "block-delayed-receipts",
+                    block_hash,
+                )
             }
             StateChangeCauseView::NotWritableToDisk => {
                 return Err(crate::errors::ErrorKind::InternalInvariantError(
@@ -192,7 +198,7 @@ fn convert_block_changes_to_transactions(
                 ));
             }
             StateChangeCauseView::Migration => {
-                crate::models::TransactionIdentifier::new("migration", block_hash)
+                crate::models::TransactionIdentifier::block_event("migration", block_hash)
             }
             StateChangeCauseView::Resharding => {
                 return Err(crate::errors::ErrorKind::InternalInvariantError(

--- a/chain/rosetta-rpc/src/lib.rs
+++ b/chain/rosetta-rpc/src/lib.rs
@@ -808,9 +808,9 @@ async fn construction_hash(
     }
 
     Ok(Json(models::TransactionIdentifierResponse {
-        transaction_identifier: models::TransactionIdentifier {
-            hash: signed_transaction.as_ref().get_hash().to_base(),
-        },
+        transaction_identifier: models::TransactionIdentifier::transaction(
+            &signed_transaction.as_ref().get_hash(),
+        ),
     }))
 }
 
@@ -842,7 +842,7 @@ async fn construction_submit(
         });
     }
 
-    let transaction_hash = signed_transaction.as_ref().get_hash().to_base();
+    let transaction_hash = signed_transaction.as_ref().get_hash();
     let transaction_submittion = client_addr
         .send(near_network::types::NetworkClientMessages::Transaction {
             transaction: signed_transaction.into_inner(),
@@ -854,7 +854,9 @@ async fn construction_submit(
         near_network::types::NetworkClientResponses::ValidTx
         | near_network::types::NetworkClientResponses::RequestRouted => {
             Ok(Json(models::TransactionIdentifierResponse {
-                transaction_identifier: models::TransactionIdentifier { hash: transaction_hash },
+                transaction_identifier: models::TransactionIdentifier::transaction(
+                    &transaction_hash,
+                ),
             }))
         }
         near_network::types::NetworkClientResponses::InvalidTx(error) => {

--- a/chain/rosetta-rpc/src/models.rs
+++ b/chain/rosetta-rpc/src/models.rs
@@ -982,27 +982,27 @@ pub(crate) struct TransactionIdentifier {
 impl TransactionIdentifier {
     /// Returns an identifier for a NEAR transaction with given hash.
     pub(crate) fn transaction(tx_hash: &near_primitives::hash::CryptoHash) -> Self {
-        Self::construct("tx", tx_hash.to_base())
+        Self::from_prefix_and_hash("tx", tx_hash.to_base())
     }
 
     /// Returns an identifier for a NEAR receipt with given hash.
     pub(crate) fn receipt(receipt_hash: &near_primitives::hash::CryptoHash) -> Self {
-        Self::construct("receipt", receipt_hash.to_base())
+        Self::from_prefix_and_hash("receipt", receipt_hash.to_base())
     }
 
-    /// Returns an identifier constructed as <prefix>:<hash>.
+    /// Returns an identifier for block events constructed as <prefix>:<hash>.
     ///
     /// Note: If constructing identifiers for transactions or receipts, use
     /// [`transaction`] or [`receipt`] methods instead (this method will give
     /// the wrong result).
-    pub(crate) fn new(
+    pub(crate) fn block_event(
         prefix: &'static str,
         block_hash: &near_primitives::hash::CryptoHash,
     ) -> Self {
-        Self::construct(prefix, block_hash)
+        Self::from_prefix_and_hash(prefix, block_hash)
     }
 
-    pub fn construct(prefix: &'static str, hash: impl std::fmt::Display) -> Self {
+    fn from_prefix_and_hash(prefix: &'static str, hash: impl std::fmt::Display) -> Self {
         Self { hash: format!("{}:{}", prefix, hash) }
     }
 }

--- a/chain/rosetta-rpc/src/models.rs
+++ b/chain/rosetta-rpc/src/models.rs
@@ -979,6 +979,34 @@ pub(crate) struct TransactionIdentifier {
     pub hash: String,
 }
 
+impl TransactionIdentifier {
+    /// Returns an identifier for a NEAR transaction with given hash.
+    pub(crate) fn transaction(tx_hash: &near_primitives::hash::CryptoHash) -> Self {
+        Self::construct("tx", tx_hash.to_base())
+    }
+
+    /// Returns an identifier for a NEAR receipt with given hash.
+    pub(crate) fn receipt(receipt_hash: &near_primitives::hash::CryptoHash) -> Self {
+        Self::construct("receipt", receipt_hash.to_base())
+    }
+
+    /// Returns an identifier constructed as <prefix>:<hash>.
+    ///
+    /// Note: If constructing identifiers for transactions or receipts, use
+    /// [`transaction`] or [`receipt`] methods instead (this method will give
+    /// the wrong result).
+    pub(crate) fn new(
+        prefix: &'static str,
+        block_hash: &near_primitives::hash::CryptoHash,
+    ) -> Self {
+        Self::construct(prefix, block_hash)
+    }
+
+    pub fn construct(prefix: &'static str, hash: impl std::fmt::Display) -> Self {
+        Self { hash: format!("{}:{}", prefix, hash) }
+    }
+}
+
 /// The Version object is utilized to inform the client of the versions of
 /// different components of the Rosetta implementation.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]


### PR DESCRIPTION
Currently /construction/hash and /construction/submit APIs return
transaction identifiers where hash is simply the hash of the
transaction.  This does not match identifier returned by Data API
which prefixes the hashes with a ‘tx:’ (to distinguish them from
Rosetta transaction created as a result of other NEAR changes).

Introduce constructors for models::TransactionIdentifier and use them
throughout the code to make sure all places agree how the identifiers
are formatted.

Issue: https://github.com/near/nearcore/issues/5173