### PR TITLE
doc: Add `near-network` reference level documentation `Handshake`

### DIFF
--- a/docs/network.md
+++ b/docs/network.md
@@ -63,18 +63,230 @@ Responsibilities:
 It starts `RoutingTableActor`, which then starts `EdgeValidatorActor`.
 When connection incoming connection gets accepted, it starts a new `PeerActor` on its own thread.
 
-# 7. Adding new edges to routing tables
+# 4. NetworkConfig
+
+`near-network` reads configuration from `NetworkConfig`, which is a part `client config`.
+
+Here is a list of features read from config
+- `boot_nodes` - list of nodes to connect to on start
+- `addr` - listening address
+- `max_num_peers` - by default we connect up to 40 peers, current implementation supports upto 128 nodes.
+
+# 5. Connecting to other peers.
+
+Each peer maintains list of known peers. They are stored in the database.
+If database is empty, the list of peers, called boot nodes, will be read from `boot_nodes` option in config.
+Peer to connect to is chosen at random from list of known nodes by `PeerManagerActor::sample_random_peer` method.
+
+# 6. Edges & network - in code representation
+
+`P2P network` is represented by list of `peers`, where each `peer` is represented by structure `PeerId`,
+which is defined by `peer's` public key `PublicKey`.
+And a list of edges, where each edge is represented by the structure `Edge`.
+
+Both are defined below.
+
+# 6.1 PublicKey
+
+We use two types of public keys:
+- a 256 bit `ED25519` public key
+- a 512 bit `Secp256K1` public key
+
+Public keys are defined in `PublicKey` enum, which consists of those two variants.
+```rust
+pub struct ED25519PublicKey(pub [u8; 32]);
+pub struct Secp256K1PublicKey([u8; 64]);
+pub enum PublicKey {
+    ED25519(ED25519PublicKey),
+    SECP256K1(Secp256K1PublicKey),
+}
+```
+
+# 6.2 PeerId
+
+Each `peer` is uniquely defined by its `PublicKey`, and represented by `PeerId` struct.
+```rust
+pub struct PeerId(PublicKey);
+```
+
+# 6.3 Edge
+
+Each `edge` is represented by `Edge` structure. It contains the following
+- pair of nodes represented by their public keys.
+- `nonce` - a unique number representing state of an edge. Starting with 1.
+  Odd number represents an active edge.
+  Even number represent an edge in which one of nodes, confirmed that the edge is removed.
+- Signatures from both peers for active edges.
+- Signature from one peers in case an edge got removed.
+
+# 6.4 Graph representation
+
+`RoutingTableActor` is responsible for storing and maintaining set of all edges.
+They are kept in `edge_info` data structure of type `HashSet<Edge>`.
+
+```rust
+pub struct RoutingTableActor {
+    /// Collection of edges representing P2P network.
+    /// It's indexed by `Edge::key()` key and can be search through by called `get()` function
+    /// with `(PeerId, PeerId)` as argument.
+    pub edges_info: HashSet<Edge>,
+    /// ...
+}
+
+# 7. Code flow - connecting to a peer - handshake
+
+When `PeerManagerActor` starts it starts to listen to a specific port.
+
+## 7.1 - Step 1 - `monitor_peers_trigger` runs
+`PeerManager` checks if we need to connect to another peer by running `PeerManager::is_outbound_bootstrap_needed` method.
+If `true` we will try to connect to new node.
+Let's call current node, node `A`.
+
+## 7.2 - Step 2 - choosing node to connect to
+Method `PeerManager::sample_random_peer` will be called, and it returns node `B` that we will try to connect to.
+
+## 7.3 - Step 3 - `OutboundTcpConnect` message
+`PeerManagerActor` will send to itself a message `OutboundTcpConnect` in order to connect to node `B`.
+
+```rust
+pub struct OutboundTcpConnect {
+    /// Peer information of the outbound connection
+    pub target_peer_info: PeerInfo,
+}
+```
+
+## 7.4 - Step 4 - `OutboundTcpConnect` message
+On receiving the message `handle_msg_outbound_tcp_connect` method will be called, which calls
+`TcpStream::connect` to create new connection.
+
+## 7.5 - Step 5 - Connection gets established
+Once connection with outgoing peer gets established.
+`try_connect_peer` method will be called.
+And then new `PeerActor` will be created and started.
+Once `PeerActor` starts it will send `Handshake` message to outgoing node `B` over tcp connection.
+
+This message contains `protocol_version`, node's `A` metadata, as well as all information necessary to create `Edge`.
+
+```rust
+pub struct Handshake {
+    /// Current protocol version.
+    pub(crate) protocol_version: u32,
+    /// Oldest supported protocol version.
+    pub(crate) oldest_supported_version: u32,
+    /// Sender's peer id.
+    pub(crate) sender_peer_id: PeerId,
+    /// Receiver's peer id.
+    pub(crate) target_peer_id: PeerId,
+    /// Sender's listening addr.
+    pub(crate) sender_listen_port: Option<u16>,
+    /// Peer's chain information.
+    pub(crate) sender_chain_info: PeerChainInfoV2,
+    /// Represents new `edge`. Contains only `none` and `Signature` from the sender.
+    pub(crate) partial_edge_info: PartialEdgeInfo,
+}
+```
+
+## 7.6 - Step 6 - `Handshake` arrives at node `B`
+
+Node `B` receives `Handshake` message. Then it performs various validation checks.
+That includes:
+- Check signature of edge from the other peer.
+- Whenever, `nonce` is the edge send matches.
+- Check whenever the protocol is above the minimum `OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION`
+- Other node `view of chain` state
+
+If everything is successful, `PeerActor` will send `RegisterPeer` message to `PeerManagerActor`.
+This message contains everything needed to add `PeerActor` to list of active connections in `PeerManagerActor`.
+
+Otherwise, `PeerActor` will be stopped immediately or after some timeout.
+
+```rust
+pub struct RegisterPeer {
+    pub(crate) actor: Addr<PeerActor>,
+    pub(crate) peer_info: PeerInfo,
+    pub(crate) peer_type: PeerType,
+    pub(crate) chain_info: PeerChainInfoV2,
+    // Edge information from this node.
+    // If this is None it implies we are outbound connection, so we need to create our
+    // EdgeInfo part and send it to the other peer.
+    pub(crate) this_edge_info: Option<EdgeInfo>,
+    // Edge information from other node.
+    pub(crate) other_edge_info: EdgeInfo,
+    // Protocol version of new peer. May be higher than ours.
+    pub(crate) peer_protocol_version: ProtocolVersion,
+}
+```
+
+
+## 7.7 - Step 7 - `PeerManagerActor` receives `RegisterPeer` message - node `B`
+In `handle_msg_consolidate` method `RegisterPeer` message will be validated.
+If successful `register_peer` method will be called, which adds `PeerActor` to list of connected peers.
+
+Each connected peer is represented in `PeerActorManager` in `ActivePeer` data structure.
+
+TODO: Rename `ActivePeer` to `RegisterPeer`.
+
+```rust
+/// Contains information relevant to an active peer.
+struct ActivePeer { // will be renamed to `ConnectedPeer` see #5428
+    addr: Addr<PeerActor>,
+    full_peer_info: FullPeerInfo,
+    /// Number of bytes we've received from the peer.
+    received_bytes_per_sec: u64,
+    /// Number of bytes we've sent to the peer.
+    sent_bytes_per_sec: u64,
+    /// Last time requested peers.
+    last_time_peer_requested: Instant,
+    /// Last time we received a message from this peer.
+    last_time_received_message: Instant,
+    /// Time where the connection was established.
+    connection_established_time: Instant,
+    /// Who started connection. Inbound (other) or Outbound (us).
+    peer_type: PeerType,
+}
+```
+
+## 7.8 - Step 8 - Exchange routing table part 1 - node `B`
+At the end of `register_peer` method node `B` will performance `RoutingTableSync` sync.
+Sending list of known `edges` representing full graph, and list of known `AnnounceAccount`.
+Those will be covered later, in their dedicated sections see sections TODO1, TODO2.
+
+```rust, ignore
+message: PeerMessage::RoutingTableSync(SyncData::edge(new_edge)),
+```
+
+```rust
+/// Contains metadata used for routing messages to particular `PeerId` or `AccountId`.
+pub struct RoutingTableSync { // also known as `SyncData` (#5489)
+    /// List of known edges from `RoutingTableActor::edges_info`.
+    pub(crate) edges: Vec<Edge>,
+    /// List of known `account_id` to `PeerId` mappings.
+    /// Useful for `send_message_to_account` method, to route message to particular account.
+    pub(crate) accounts: Vec<AnnounceAccount>,
+}
+```
+
+
+## 7.9 - Step 9 -  Exchange routing table part 2 - node `A`
+Upon receiving `RoutingTableSync` message.
+Node `A` will reply with own `RoutingTableSync` message.
+
+## 7.10 - Step 10 -  Exchange routing table part 2 - node `B`
+Node `B` will get the message from `A` and update it's routing table.
+
+
+# 8. Adding new edges to routing tables
 
 This section covers the process of adding new edges, received from another nodes,
 to the routing table. It consists of several steps covered below.
 
-## 7.1 Step 1
+## 8.1 Step 1
 
 `PeerManagerActor` receives `RoutingTableSync` message containing list of new `edges` to add.
 `RoutingTableSync` contains list of edges of the P2P network.
 This message is then forwarded to `RoutingTableActor`.
 
-## 7.2 Step 2
+## 8.2 Step 2
 
 `PeerManagerActor` forwards those edges to `RoutingTableActor` inside of `ValidateEdgeList` struct.
 
@@ -82,7 +294,7 @@ This message is then forwarded to `RoutingTableActor`.
 - list of edges to verify
 - peer who send us the edges
 
-## 7.3 Step 3
+## 8.3 Step 3
 
 `RoutingTableActor` gets the `ValidateEdgeList` message.
 Filters out `edges` that have already been verified, those that are already in `RoutingTableActor::edges_info`.
@@ -92,7 +304,7 @@ be pruned from Routing Table (see section TODO).
 
 Then, after removing already validated edges, the modified message is forwarded to `EdgeValidatorActor`.
 
-## 7.4 Step 4
+## 8.4 Step 4
 
 `EdgeValidatorActor` goes through list of all edges.
 It checks whether all edges are valid (their cryptographic signatures match, etc.).
@@ -102,7 +314,7 @@ If any edge is not valid peer will be banned.
 Edges that are validated are written to a concurrent queue `ValidateEdgeList::sender`.
 This queue is used to transfer edges from `EdgeValidatorActor`, back to `PeerManagerActor`.
 
-## 7.5 Step 5
+## 8.5 Step 5
 
 `broadcast_validated_edges_trigger` runs, and gets validated edges from `EdgeVerifierActor`.
 
@@ -112,37 +324,37 @@ And then, all validated edges received from `EdgeVerifierActor` will be sent aga
 `AddVerifiedEdges`.
 
 
-## 7.5 Step 6
+## 8.5 Step 6
 
 When `RoutingTableActor` receives `RoutingTableMessages::AddVerifiedEdges`, the method`add_verified_edges_to_routing_table` will be called.
 It will add edges to `RoutingTableActor::edges_info` struct, and mark routing table, that it needs recalculation
 see `RoutingTableActor::needs_routing_table_recalculation`.
 
-# 8 Routing table computation
+# 9 Routing table computation
 
 Routing table computation does a few things:
 - For each peer `B`, calculates set of peers `|C_b|`, such that each peer is on the shortest path to `B`.
 - Removing unreachable edges from memory and storing them to disk.
 - The distance is calculated as the minimum number of nodes on the path from given node `A`, to each other node
-on the network. That is, `A` has a distance of `0` to itself. It's neighbors will have a distance of `1`.
-The neighbors of theirs neighbors will have a distance of `2`, etc.
+  on the network. That is, `A` has a distance of `0` to itself. It's neighbors will have a distance of `1`.
+  The neighbors of theirs neighbors will have a distance of `2`, etc.
 
-## 8.1 Step 1
+## 9.1 Step 1
 
 `PeerManagerActor` runs a `update_routing_table_trigger` every `UPDATE_ROUTING_TABLE_INTERVAL` seconds.
 
 `RoutingTableMessages::RoutingTableUpdate` message is sent to `RoutingTableActor` to request routing table re-computation.
 
-## 8.2 Step 2
+## 9.2 Step 2
 
 `RoutingTableActor` receives the message, and then
 - calls `recalculate_routing_table` method, which computes `RoutingTableActor::peer_forwarding: HashMap<PeerId, Vec<PeerId>>`.
-For each `PeerId` on the network, gives list of connected peers, which are on the shortest path to the destination.
-It marks reachable peers in `peer_last_time_reachable` struct.
+  For each `PeerId` on the network, gives list of connected peers, which are on the shortest path to the destination.
+  It marks reachable peers in `peer_last_time_reachable` struct.
 - calls `prune_edges` which removes from memory all edges, that were not reachable for at least 1 hour, based on `peer_last_time_reachable` data structure.
-Those edges are then stored to disk.
+  Those edges are then stored to disk.
 
-## 8.3 Step 3
+## 9.3 Step 3
 
 `RoutingTableActor` sends `RoutingTableUpdateResponse` message back to `PeerManagerActor`.
 
@@ -153,7 +365,7 @@ Those edges are then stored to disk.
 - `peers_to_ban` - list of peers to ban for sending us edges, which failed validation in `EdgeVerifierActor`.
 
 
-## 8.4 Step 4
+## 9.4 Step 4
 
 `PeerManagerActor` received `RoutingTableUpdateResponse` and then:
 - updates local copy of`peer_forwarding`, used for routing messages.


### PR DESCRIPTION
This is part of NetworkDocumentation.md it covers:

- Code flow - finding first peer to connect to.
- Edges & network - in code representation
-  Code flow - connecting to a peer - handshake

See https://github.com/near/NEPs/pull/274 for full PR