### PR TITLE
doc: Add `near-network` reference level documentation `Adding new edges to routing tables`

### DIFF
--- a/docs/network.md
+++ b/docs/network.md
@@ -95,7 +95,7 @@ Then, after removing already validated edges, the modified message is forwarded 
 ## 7.4 Step 4
 
 `EdgeValidatorActor` goes through list of all edges.
-It checks whenever all edges are valid (their cryptographic signatures match, etc.).
+It checks whether all edges are valid (their cryptographic signatures match, etc.).
 
 If any edge is not valid peer will be banned.
 


### PR DESCRIPTION
This is part of NetworkDocumentation.md it covers:

-  Adding new edges to routing tables.

See https://github.com/near/nearcore/issues/5156