### PR TITLE
re: `PeerManager`: Refactor`find_peers` 

### DIFF
--- a/chain/network-primitives/src/types.rs
+++ b/chain/network-primitives/src/types.rs
@@ -583,6 +583,10 @@ impl NetworkConfig {
     }
 
     pub fn verify(&self) {
+        if self.max_send_peers == 0 {
+            panic!("max_send_peers can't be 0");
+        }
+
         if self.ideal_connections_lo + 1 >= self.ideal_connections_hi {
             error!(target: "network",
             "Invalid ideal_connections values. lo({}) > hi({}).",

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -2246,7 +2246,9 @@ impl PeerManagerActor {
     ) -> PeerRequestResult {
         #[cfg(feature = "delay_detector")]
         let _d = delay_detector::DelayDetector::new("peers request".into());
-        PeerRequestResult { peers: self.peer_store.healthy_peers(self.config.max_send_peers) }
+        PeerRequestResult {
+            peers: self.peer_store.healthy_peers(self.config.max_send_peers as usize),
+        }
     }
 
     fn handle_msg_peers_response(&mut self, msg: PeersResponse, _ctx: &mut Context<Self>) {

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -920,8 +920,7 @@ impl PeerManagerActor {
 
     /// Get a random peer we are not connected to from the known list.
     fn sample_random_peer(&self, ignore_fn: impl Fn(&KnownPeerState) -> bool) -> Option<PeerInfo> {
-        let res = self.peer_store.unconnected_peers(ignore_fn, 1);
-        res.get(0).cloned()
+        self.peer_store.unconnected_peers(ignore_fn, 1).get(0).cloned()
     }
 
     /// Query current peers for more peers.

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -920,7 +920,7 @@ impl PeerManagerActor {
 
     /// Get a random peer we are not connected to from the known list.
     fn sample_random_peer(&self, ignore_fn: impl Fn(&KnownPeerState) -> bool) -> Option<PeerInfo> {
-        self.peer_store.unconnected_peers(ignore_fn, 1).get(0).cloned()
+        self.peer_store.unconnected_peer(ignore_fn)
     }
 
     /// Query current peers for more peers.

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -920,8 +920,8 @@ impl PeerManagerActor {
 
     /// Get a random peer we are not connected to from the known list.
     fn sample_random_peer(&self, ignore_fn: impl Fn(&KnownPeerState) -> bool) -> Option<PeerInfo> {
-        let unconnected_peers = self.peer_store.unconnected_peers(ignore_fn, 1);
-        unconnected_peers.choose(&mut rand::thread_rng()).cloned()
+        let res = self.peer_store.unconnected_peers(ignore_fn, 1);
+        res.get(0).cloned()
     }
 
     /// Query current peers for more peers.

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -920,7 +920,7 @@ impl PeerManagerActor {
 
     /// Get a random peer we are not connected to from the known list.
     fn sample_random_peer(&self, ignore_fn: impl Fn(&KnownPeerState) -> bool) -> Option<PeerInfo> {
-        let unconnected_peers = self.peer_store.unconnected_peers(ignore_fn);
+        let unconnected_peers = self.peer_store.unconnected_peers(ignore_fn, 1);
         unconnected_peers.choose(&mut rand::thread_rng()).cloned()
     }
 

--- a/chain/network/src/peer_manager/peer_store.rs
+++ b/chain/network/src/peer_manager/peer_store.rs
@@ -196,6 +196,7 @@ impl PeerStore {
     pub(crate) fn unconnected_peers(
         &self,
         ignore_fn: impl Fn(&KnownPeerState) -> bool,
+        count: usize,
     ) -> Vec<PeerInfo> {
         self.find_peers(
             |p| {
@@ -203,7 +204,7 @@ impl PeerStore {
                     && !ignore_fn(p)
                     && p.peer_info.addr.is_some()
             },
-            usize::MAX,
+            count,
         )
     }
 

--- a/chain/network/src/peer_manager/peer_store.rs
+++ b/chain/network/src/peer_manager/peer_store.rs
@@ -186,9 +186,10 @@ impl PeerStore {
         let peers: Vec<_> =
             self.peer_states.values().filter(filter).map(|p| &p.peer_info).collect();
         if count >= peers.len() {
-            return peers.iter().cloned().cloned().collect();
+            peers.iter().cloned().cloned().collect()
+        } else {
+            peers.choose_multiple(&mut thread_rng(), count).cloned().cloned().collect()
         }
-        peers.choose_multiple(&mut thread_rng(), count).cloned().cloned().collect()
     }
 
     /// Return unconnected or peers with unknown status that we can try to connect to.

--- a/chain/network/src/peer_manager/peer_store.rs
+++ b/chain/network/src/peer_manager/peer_store.rs
@@ -186,7 +186,7 @@ impl PeerStore {
         let peers: Vec<_> =
             self.peer_states.values().filter(filter).map(|p| &p.peer_info).collect();
         if count >= peers.len() {
-            return peers.iter().cloned().collect();
+            return peers.iter().cloned().cloned().collect();
         }
         peers.choose_multiple(&mut thread_rng(), count).cloned().cloned().collect()
     }

--- a/chain/network/src/peer_manager/peer_store.rs
+++ b/chain/network/src/peer_manager/peer_store.rs
@@ -430,7 +430,7 @@ mod test {
         let tmp_dir = tempfile::Builder::new().prefix("_test_store_ban").tempdir().unwrap();
         let peer_info_a = gen_peer_info(0);
         let peer_info_to_ban = gen_peer_info(1);
-        let boot_nodes = vec![peer_info_a, peer_info_to_ban.clone()];
+        let boot_nodes = vec![peer_info_a, peer_info_to_ban];
         {
             let store = create_store(tmp_dir.path());
             let peer_store = PeerStore::new(store, &boot_nodes).unwrap();

--- a/chain/network/src/peer_manager/peer_store.rs
+++ b/chain/network/src/peer_manager/peer_store.rs
@@ -185,6 +185,9 @@ impl PeerStore {
     {
         let peers: Vec<_> =
             self.peer_states.values().filter(filter).map(|p| &p.peer_info).collect();
+        if count >= peers.len() {
+            return peers.iter().cloned().collect();
+        }
         peers.choose_multiple(&mut thread_rng(), count).cloned().cloned().collect()
     }
 


### PR DESCRIPTION
`find_peers` is used to sample connected peers. It can be written in a more efficient way:
- avoiding cloning whole array, when less elements than max are requested
- splitting `filter_map` to `filter` and `map`.