### PR TITLE
re: Move types only used by `PeerStore` into the same file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2909,6 +2909,7 @@ dependencies = [
  "borsh 0.9.1",
  "bytes",
  "bytesize",
+ "chrono",
  "conqueue",
  "deepsize",
  "delay-detector",

--- a/chain/network-primitives/src/types.rs
+++ b/chain/network-primitives/src/types.rs
@@ -1,7 +1,6 @@
 use actix::dev::{MessageResponse, ResponseChannel};
 use actix::{Actor, Message};
 use borsh::{BorshDeserialize, BorshSerialize};
-use chrono::DateTime;
 #[cfg(feature = "deepsize_feature")]
 use deepsize::DeepSizeOf;
 use near_crypto::{KeyType, PublicKey, SecretKey, Signature};
@@ -17,10 +16,8 @@ use near_primitives::syncing::{
     EpochSyncFinalizationResponse, EpochSyncResponse, ShardStateSyncResponse,
     ShardStateSyncResponseV1,
 };
-use near_primitives::time::{Clock, Utc};
 use near_primitives::transaction::{ExecutionOutcomeWithIdAndProof, SignedTransaction};
 use near_primitives::types::{AccountId, BlockHeight, BlockReference, EpochId, ShardId};
-use near_primitives::utils::{from_timestamp, to_timestamp};
 use near_primitives::views::{FinalExecutionOutcomeView, QueryRequest, QueryResponse};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
@@ -648,52 +645,6 @@ impl FromStr for PatternAddr {
     }
 }
 
-/// Status of the known peers.
-#[derive(BorshSerialize, BorshDeserialize, Eq, PartialEq, Debug, Clone)]
-pub enum KnownPeerStatus {
-    Unknown,
-    NotConnected,
-    Connected,
-    Banned(ReasonForBan, u64),
-}
-
-impl KnownPeerStatus {
-    pub fn is_banned(&self) -> bool {
-        match self {
-            KnownPeerStatus::Banned(_, _) => true,
-            _ => false,
-        }
-    }
-}
-
-/// Information node stores about known peers.
-#[derive(BorshSerialize, BorshDeserialize, Debug, Clone)]
-pub struct KnownPeerState {
-    pub peer_info: PeerInfo,
-    pub status: KnownPeerStatus,
-    pub first_seen: u64,
-    pub last_seen: u64,
-}
-
-impl KnownPeerState {
-    pub fn new(peer_info: PeerInfo) -> Self {
-        KnownPeerState {
-            peer_info,
-            status: KnownPeerStatus::Unknown,
-            first_seen: to_timestamp(Clock::utc()),
-            last_seen: to_timestamp(Clock::utc()),
-        }
-    }
-
-    pub fn first_seen(&self) -> DateTime<Utc> {
-        from_timestamp(self.first_seen)
-    }
-
-    pub fn last_seen(&self) -> DateTime<Utc> {
-        from_timestamp(self.last_seen)
-    }
-}
-
 /// Actor message that holds the TCP stream from an inbound TCP connection
 #[derive(Message, Debug)]
 #[rtype(result = "()")]
@@ -1058,7 +1009,6 @@ mod tests {
         assert_size!(PeerStatus);
         assert_size!(RoutedMessageBody);
         assert_size!(PeerIdOrHash);
-        assert_size!(KnownPeerStatus);
         assert_size!(ReasonForBan);
         assert_size!(PeerManagerRequest);
     }
@@ -1076,7 +1026,6 @@ mod tests {
         assert_size!(RoutedMessage);
         assert_size!(RoutedMessageFrom);
         assert_size!(NetworkConfig);
-        assert_size!(KnownPeerState);
         assert_size!(InboundTcpConnect);
         assert_size!(OutboundTcpConnect);
         assert_size!(Unregister);

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -13,6 +13,7 @@ borsh = { version = "0.9", features = ["rc"] }
 bytes = "1"
 bytesize = "1.1"
 conqueue = "0.4.0"
+chrono = "0.4.6"
 futures = "0.3"
 lru = "0.6.5"
 near-rust-allocator-proxy = "0.3.0"

--- a/chain/network/src/peer_manager/db_types.rs
+++ b/chain/network/src/peer_manager/db_types.rs
@@ -1,0 +1,51 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+use chrono::{DateTime, Utc};
+use near_network_primitives::types::{PeerInfo, ReasonForBan};
+use near_primitives::time::Clock;
+use near_primitives::utils::{from_timestamp, to_timestamp};
+
+/// Status of the known peers.
+#[derive(BorshSerialize, BorshDeserialize, Eq, PartialEq, Debug, Clone)]
+pub enum KnownPeerStatus {
+    Unknown,
+    NotConnected,
+    Connected,
+    Banned(ReasonForBan, u64),
+}
+
+impl KnownPeerStatus {
+    pub fn is_banned(&self) -> bool {
+        match self {
+            KnownPeerStatus::Banned(_, _) => true,
+            _ => false,
+        }
+    }
+}
+
+/// Information node stores about known peers.
+#[derive(BorshSerialize, BorshDeserialize, Debug, Clone)]
+pub struct KnownPeerState {
+    pub peer_info: PeerInfo,
+    pub status: KnownPeerStatus,
+    pub first_seen: u64,
+    pub last_seen: u64,
+}
+
+impl KnownPeerState {
+    pub fn new(peer_info: PeerInfo) -> Self {
+        KnownPeerState {
+            peer_info,
+            status: KnownPeerStatus::Unknown,
+            first_seen: to_timestamp(Clock::utc()),
+            last_seen: to_timestamp(Clock::utc()),
+        }
+    }
+
+    pub fn first_seen(&self) -> DateTime<Utc> {
+        from_timestamp(self.first_seen)
+    }
+
+    pub fn last_seen(&self) -> DateTime<Utc> {
+        from_timestamp(self.last_seen)
+    }
+}

--- a/chain/network/src/peer_manager/db_types.rs
+++ b/chain/network/src/peer_manager/db_types.rs
@@ -5,6 +5,7 @@ use near_primitives::time::Clock;
 use near_primitives::utils::{from_timestamp, to_timestamp};
 
 /// Status of the known peers.
+/// `pub` is used by `test-utils` in `iter_peers_from_store`
 #[derive(BorshSerialize, BorshDeserialize, Eq, PartialEq, Debug, Clone)]
 pub enum KnownPeerStatus {
     Unknown,
@@ -23,6 +24,7 @@ impl KnownPeerStatus {
 }
 
 /// Information node stores about known peers.
+/// `pub` is used by `test-utils` in `iter_peers_from_store`
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone)]
 pub struct KnownPeerState {
     pub peer_info: PeerInfo,

--- a/chain/network/src/peer_manager/mod.rs
+++ b/chain/network/src/peer_manager/mod.rs
@@ -1,2 +1,3 @@
+pub(crate) mod db_types;
 pub(crate) mod peer_manager_actor;
 pub(crate) mod peer_store;

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -1,5 +1,6 @@
 use crate::peer::codec::Codec;
 use crate::peer::peer_actor::PeerActor;
+use crate::peer_manager::db_types::{KnownPeerState, KnownPeerStatus};
 use crate::peer_manager::peer_store::{PeerStore, TrustLevel};
 use crate::routing::edge_validator_actor::EdgeValidatorHelper;
 #[cfg(all(
@@ -32,11 +33,10 @@ use actix::{
 use futures::task::Poll;
 use futures::{future, Stream, StreamExt};
 use near_network_primitives::types::{
-    AccountOrPeerIdOrHash, Ban, BlockedPorts, InboundTcpConnect, KnownPeerState, KnownPeerStatus,
-    KnownProducer, NetworkConfig, NetworkViewClientMessages, NetworkViewClientResponses,
-    OutboundTcpConnect, PeerIdOrHash, PeerManagerRequest, PeerType, Ping, Pong, QueryPeerStats,
-    RawRoutedMessage, ReasonForBan, RoutedMessage, RoutedMessageBody, RoutedMessageFrom,
-    StateResponseInfo,
+    AccountOrPeerIdOrHash, Ban, BlockedPorts, InboundTcpConnect, KnownProducer, NetworkConfig,
+    NetworkViewClientMessages, NetworkViewClientResponses, OutboundTcpConnect, PeerIdOrHash,
+    PeerManagerRequest, PeerType, Ping, Pong, QueryPeerStats, RawRoutedMessage, ReasonForBan,
+    RoutedMessage, RoutedMessageBody, RoutedMessageFrom, StateResponseInfo,
 };
 use near_performance_metrics::framed_write::FramedWrite;
 use near_performance_metrics_macros::perf;

--- a/chain/network/src/peer_manager/peer_store.rs
+++ b/chain/network/src/peer_manager/peer_store.rs
@@ -1,7 +1,6 @@
+use crate::peer_manager::db_types::{KnownPeerState, KnownPeerStatus};
 use borsh::{BorshDeserialize, BorshSerialize};
-use near_network_primitives::types::{
-    KnownPeerState, KnownPeerStatus, NetworkConfig, PeerInfo, ReasonForBan,
-};
+use near_network_primitives::types::{NetworkConfig, PeerInfo, ReasonForBan};
 use near_primitives::network::PeerId;
 use near_primitives::time::Utc;
 use near_primitives::utils::to_timestamp;


### PR DESCRIPTION
`KnownPeerState` and `KnownPeerStatus` are only used by `PeerStore`.
It makes sense to move them from `near-network-primitives` inside `peer_store.rs`.