### PR TITLE
`near-chain`: Fix `clippy::redundant-clone` issues.

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -348,7 +348,7 @@ impl Chain {
         let (store, state_roots) = runtime_adapter.genesis_state();
         let store = ChainStore::new(store, chain_genesis.height);
         let genesis_chunks = genesis_chunks(
-            state_roots.clone(),
+            state_roots,
             runtime_adapter.num_shards(&EpochId::default())?,
             chain_genesis.gas_limit,
             chain_genesis.height,
@@ -373,7 +373,7 @@ impl Chain {
             runtime_adapter,
             orphans: OrphanBlockPool::new(),
             blocks_with_missing_chunks: MissingChunksPool::new(),
-            genesis: genesis.clone(),
+            genesis: genesis,
             transaction_validity_period: chain_genesis.transaction_validity_period,
             epoch_length: chain_genesis.epoch_length,
             block_economics_config: BlockEconomicsConfig::from(chain_genesis),
@@ -1683,7 +1683,7 @@ impl Chain {
         );
         assert_eq!(&chunk_headers_root, sync_prev_block.header().chunk_headers_root());
 
-        let chunk = self.get_chunk_clone_from_header(&chunk_header.clone())?;
+        let chunk = self.get_chunk_clone_from_header(&chunk_header)?;
         let chunk_proof = chunk_proofs[shard_id as usize].clone();
         let block_header =
             self.get_header_on_chain_by_height(&sync_hash, chunk_header.height_included())?.clone();

--- a/chain/chain/src/doomslug.rs
+++ b/chain/chain/src/doomslug.rs
@@ -779,7 +779,7 @@ mod tests {
             Duration::from_millis(1000),
             Duration::from_millis(100),
             Duration::from_millis(3000),
-            Some(signer.clone()),
+            Some(signer),
             DoomslugThresholdMode::TwoThirds,
         );
 

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -2978,7 +2978,7 @@ mod tests {
         let chain_genesis = ChainGenesis::test();
         let validators = vec![vec!["test1"]];
         let runtime_adapter = Arc::new(KeyValueRuntime::new_with_validators(
-            store.clone(),
+            store,
             validators
                 .into_iter()
                 .map(|inner| {
@@ -3002,7 +3002,7 @@ mod tests {
             KeyType::ED25519,
             "test1",
         ));
-        let short_fork = vec![Block::empty_with_height(&genesis, 1, &*signer.clone())];
+        let short_fork = vec![Block::empty_with_height(&genesis, 1, &*signer)];
         let mut store_update = chain.mut_store().store_update();
         store_update.save_block_header(short_fork[0].header().clone()).unwrap();
         store_update.commit().unwrap();
@@ -3017,7 +3017,7 @@ mod tests {
             )
             .is_ok());
         let mut long_fork = vec![];
-        let mut prev_block = genesis.clone();
+        let mut prev_block = genesis;
         for i in 1..(transaction_validity_period + 3) {
             let mut store_update = chain.mut_store().store_update();
             let block = Block::empty_with_height(&prev_block, i, &*signer.clone());
@@ -3061,7 +3061,7 @@ mod tests {
             "test1",
         ));
         let mut blocks = vec![];
-        let mut prev_block = genesis.clone();
+        let mut prev_block = genesis;
         for i in 1..(transaction_validity_period + 2) {
             let mut store_update = chain.mut_store().store_update();
             let block = Block::empty_with_height(&prev_block, i, &*signer.clone());
@@ -3086,7 +3086,7 @@ mod tests {
         let new_block = Block::empty_with_height(
             &blocks.last().unwrap(),
             transaction_validity_period + 3,
-            &*signer.clone(),
+            &*signer,
         );
         let mut store_update = chain.mut_store().store_update();
         store_update.save_block_header(new_block.header().clone()).unwrap();
@@ -3164,7 +3164,7 @@ mod tests {
             KeyType::ED25519,
             "test1",
         ));
-        let block1 = Block::empty_with_height(&genesis, 1, &*signer.clone());
+        let block1 = Block::empty_with_height(&genesis, 1, &*signer);
         let mut block2 = block1.clone();
         block2.mut_header().get_mut().inner_lite.epoch_id = EpochId(hash(&[1, 2, 3]));
         block2.mut_header().resign(&*signer);
@@ -3209,7 +3209,7 @@ mod tests {
             KeyType::ED25519,
             "test1",
         ));
-        let mut prev_block = genesis.clone();
+        let mut prev_block = genesis;
         let mut blocks = vec![prev_block.clone()];
         for i in 1..15 {
             // This is a hack to make the KeyValueRuntime to have epoch information stored
@@ -3310,7 +3310,7 @@ mod tests {
             KeyType::ED25519,
             "test1",
         ));
-        let mut prev_block = genesis.clone();
+        let mut prev_block = genesis;
         let mut blocks = vec![prev_block.clone()];
         for i in 1..10 {
             // This is a hack to make the KeyValueRuntime to have epoch information stored

--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -96,7 +96,7 @@ impl StoreValidator {
             me,
             config,
             runtime_adapter,
-            store: store.clone(),
+            store: store,
             inner: StoreValidatorCache::new(),
             timeout: None,
             start_time: Clock::instant(),
@@ -422,7 +422,7 @@ mod tests {
         let chain =
             Chain::new(runtime_adapter.clone(), &chain_genesis, DoomslugThresholdMode::NoApprovals)
                 .unwrap();
-        (chain, StoreValidator::new(None, genesis.clone(), runtime_adapter, store))
+        (chain, StoreValidator::new(None, genesis, runtime_adapter, store))
     }
 
     #[test]

--- a/chain/chain/src/tests/challenges.rs
+++ b/chain/chain/src/tests/challenges.rs
@@ -55,7 +55,7 @@ fn challenges_new_head_prev() {
     let _ = chain.process_block_test(&None, b3.clone()).unwrap().unwrap();
 
     let b4 = Block::empty(&b3, &*signer);
-    let new_head = chain.process_block_test(&None, b4.clone()).unwrap().unwrap().last_block_hash;
+    let new_head = chain.process_block_test(&None, b4).unwrap().unwrap().last_block_hash;
 
     assert_eq!(chain.head_header().unwrap().hash(), &new_head);
 

--- a/chain/chain/src/tests/gc.rs
+++ b/chain/chain/src/tests/gc.rs
@@ -26,7 +26,7 @@ fn get_chain_with_epoch_length_and_num_shards(
     let chain_genesis = ChainGenesis::test();
     let validators = vec![vec!["test1"]];
     let runtime_adapter = Arc::new(KeyValueRuntime::new_with_validators(
-        store.clone(),
+        store,
         validators
             .into_iter()
             .map(|inner| inner.into_iter().map(|account_id| account_id.parse().unwrap()).collect())
@@ -132,7 +132,7 @@ fn gc_fork_common(simple_chains: Vec<SimpleChain>, max_changes: usize) {
     let genesis1 = chain1.get_block_by_height(0).unwrap().clone();
     let mut states1 = vec![];
     states1.push((
-        genesis1.clone(),
+        genesis1,
         vec![Trie::empty_root(); num_shards as usize],
         vec![Vec::new(); num_shards as usize],
     ));
@@ -152,7 +152,7 @@ fn gc_fork_common(simple_chains: Vec<SimpleChain>, max_changes: usize) {
     }
 
     // GC execution
-    let clear_data = chain1.clear_data(tries1.clone(), 100);
+    let clear_data = chain1.clear_data(tries1, 100);
     if clear_data.is_err() {
         println!("clear data failed = {:?}", clear_data);
         assert!(false);


### PR DESCRIPTION
Fix 'clippy::redundant-clone' clippy warnings in `near-chain`.

See https://github.com/near/nearcore/pull/5571