### PR TITLE
Re: Replace `or_insert_with(|| vec![])` with `or_default()`

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -186,11 +186,10 @@ impl OrphanBlockPool {
     /// `requested_missing_chunks`: whether missing chunks has been requested for the orphan
     fn add(&mut self, orphan: Orphan, requested_missing_chunks: bool) {
         let block_hash = *orphan.block.hash();
-        let height_hashes =
-            self.height_idx.entry(orphan.block.header().height()).or_insert_with(|| vec![]);
+        let height_hashes = self.height_idx.entry(orphan.block.header().height()).or_default();
         height_hashes.push(*orphan.block.hash());
         let prev_hash_entries =
-            self.prev_hash_idx.entry(*orphan.block.header().prev_hash()).or_insert_with(|| vec![]);
+            self.prev_hash_idx.entry(*orphan.block.header().prev_hash()).or_default();
         prev_hash_entries.push(block_hash.clone());
         self.orphans.insert(block_hash.clone(), orphan);
         if requested_missing_chunks {

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -463,7 +463,7 @@ impl ShardsManager {
         request_own_parts_from_others: bool,
         request_from_archival: bool,
     ) -> Result<(), near_chain::Error> {
-        let mut bp_to_parts = HashMap::new();
+        let mut bp_to_parts = HashMap::<_, Vec<u64>>::new();
 
         let cache_entry = self.encoded_chunks.get(chunk_hash);
 
@@ -524,7 +524,7 @@ impl ShardsManager {
                     }
                 };
 
-                bp_to_parts.entry(fetch_from).or_insert_with(|| vec![]).push(part_ord);
+                bp_to_parts.entry(fetch_from).or_default().push(part_ord);
             }
         }
 
@@ -537,7 +537,7 @@ impl ShardsManager {
         //     for some subset of shards, even if we don't need to request any parts from the original
         //     chunk producer.
         if !shards_to_fetch_receipts.is_empty() {
-            bp_to_parts.entry(shard_representative_target.clone()).or_insert_with(|| vec![]);
+            bp_to_parts.entry(shard_representative_target.clone()).or_default();
         }
 
         let no_account_id = me.is_none();

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -2206,10 +2206,10 @@ mod test {
                 .commit()
                 .unwrap();
             let shard_layout = self.runtime.get_shard_layout_from_prev_block(&new_hash).unwrap();
-            let mut new_receipts = HashMap::new();
+            let mut new_receipts = HashMap::<_, Vec<Receipt>>::new();
             for receipt in all_receipts {
                 let shard_id = account_id_to_shard_id(&receipt.receiver_id, &shard_layout);
-                new_receipts.entry(shard_id).or_insert_with(|| vec![]).push(receipt);
+                new_receipts.entry(shard_id).or_default().push(receipt);
             }
             self.last_receipts = new_receipts;
             self.last_proposals = all_proposals;


### PR DESCRIPTION
We can improve code quality by  replacing `or_insert_with(|| vec![])` with `or_default()`

See https://github.com/near/nearcore/pull/5571