### PR TITLE
feat: upgrade rust `1.57.0`

### DIFF
--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -105,6 +105,7 @@ impl Message for GetPeerId {
 #[cfg(feature = "test_features")]
 #[derive(MessageResponse, Debug, serde::Serialize)]
 pub struct GetPeerIdResult {
+    #[allow(unused)]
     pub(crate) peer_id: PeerId,
 }
 

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -105,7 +105,6 @@ impl Message for GetPeerId {
 #[cfg(feature = "test_features")]
 #[derive(MessageResponse, Debug, serde::Serialize)]
 pub struct GetPeerIdResult {
-    #[allow(unused)]
     pub(crate) peer_id: PeerId,
 }
 

--- a/runtime/near-vm-runner-standalone/src/main.rs
+++ b/runtime/near-vm-runner-standalone/src/main.rs
@@ -102,6 +102,7 @@ struct CliArgs {
     protocol_version: Option<ProtocolVersion>,
 }
 
+#[allow(unused)]
 #[derive(Debug, Clone)]
 struct StandaloneOutput {
     pub outcome: Option<VMOutcome>,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,10 @@
 [toolchain]
-# Please update rust-version in **/Cargo.toml files when changing channel:
-channel = "1.56.0"
+# This specified the version we use to build.
+channel = "1.57.0"
+# In order to provide provide backward compatibility, we define minimum version.
+# Current minimum version is "1.56.0", please change rust-version in `**/Cargo.toml`.
+# The minimum supported version is important for outside packages, importing packages
+# from `near/nearcore`. That means we are limited to features available in `1.56.0`.
+# However, we can still benifit from compiler optimizations, improved `cargofmt`, `clippy`, etc.
 components = [ "rustfmt" ]
 targets = [ "wasm32-unknown-unknown" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,10 +1,7 @@
 [toolchain]
-# This specified the version we use to build.
+# This specifies the version of Rust we use to build.
+# Invidual crates in the project may support lower version, indicated by `rust-version` field of `Cargo.toml`.
+# The version specified below, should be at least as high as maximum `rust-version` out of all `**/Cargo.toml` files.
 channel = "1.57.0"
-# In order to provide provide backward compatibility, we define minimum version.
-# Current minimum version is "1.56.0", please change rust-version in `**/Cargo.toml`.
-# The minimum supported version is important for outside packages, importing packages
-# from `near/nearcore`. That means we are limited to features available in `1.56.0`.
-# However, we can still benifit from compiler optimizations, improved `cargofmt`, `clippy`, etc.
 components = [ "rustfmt" ]
 targets = [ "wasm32-unknown-unknown" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # This specifies the version of Rust we use to build.
-# Invidual crates in the project may support lower version, indicated by `rust-version` field of `Cargo.toml`.
+# Individual crates in the workspace may support a lower version, as indicated by `rust-version` field in each crate's `Cargo.toml`.
 # The version specified below, should be at least as high as the maximum `rust-version` within the workspace.
 channel = "1.57.0"
 components = [ "rustfmt" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 [toolchain]
 # This specifies the version of Rust we use to build.
 # Invidual crates in the project may support lower version, indicated by `rust-version` field of `Cargo.toml`.
-# The version specified below, should be at least as high as maximum `rust-version` out of all `**/Cargo.toml` files.
+# The version specified below, should be at least as high as the maximum `rust-version` within the workspace.
 channel = "1.57.0"
 components = [ "rustfmt" ]
 targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
Rust `1.57.0` has been announced https://blog.rust-lang.org/2021/12/02/Rust-1.57.0.html

Perhaps. we should consider upgrading at some point.

Related PR's:
- #5663 
- #5674 
- #5675 
 
`1.57.0` introduces `panic! in const contexts`.

```
panic! in const contexts
With previous versions of Rust, the panic! macro was not usable in const fn and other compile-time contexts. Now, this has been stabilized. Together with the stabilization of panic!, several other standard library APIs are now usable in const, such as assert!.

This stabilization does not yet include the full formatting infrastructure, so the panic! macro must be called with either a static string (panic!("...")), or with a single &str interpolated value (panic!("{}", a)) which must be used with {} (no format specifiers or other traits).

It is expected that in the future this support will expand, but this minimal stabilization already enables straightforward compile-time assertions, for example to verify the size of a type:

const _: () = assert!(std::mem::size_of::<u64>() == 8);
const _: () = assert!(std::mem::size_of::<u8>() == 1);
```

I want to add asserts, in `near-network`, on sizes of enums, to make sure we don't increases their size too much. 
In `Rust` size of enum, is determined, by the worst variant; Adding a large enum variant can decrease the performance. 