### PR TITLE
feat: more descriptive `AccountId` error kinds

### DIFF
--- a/core/account-id/src/errors.rs
+++ b/core/account-id/src/errors.rs
@@ -18,8 +18,7 @@ impl ParseAccountError {
 impl std::error::Error for ParseAccountError {}
 impl fmt::Display for ParseAccountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut buf = String::new();
-        buf.push_str(&self.kind.to_string());
+        let mut buf = self.kind.to_string();
         if let Some((idx, char)) = self.char {
             write!(buf, " {:?} at index {}", char, idx)?
         }

--- a/core/account-id/src/errors.rs
+++ b/core/account-id/src/errors.rs
@@ -1,20 +1,29 @@
 use std::fmt;
+use std::fmt::Write;
 
 /// An error which can be returned when parsing a NEAR Account ID.
 #[derive(Eq, Clone, Debug, PartialEq)]
-pub struct ParseAccountError(pub(crate) ParseErrorKind);
+pub struct ParseAccountError {
+    pub(crate) kind: ParseErrorKind,
+    pub(crate) char: Option<(usize, char)>,
+}
 
 impl ParseAccountError {
     /// Returns the specific cause why parsing the Account ID failed.
     pub fn kind(&self) -> &ParseErrorKind {
-        &self.0
+        &self.kind
     }
 }
 
 impl std::error::Error for ParseAccountError {}
 impl fmt::Display for ParseAccountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(&self.0, f)
+        let mut buf = String::new();
+        buf.push_str(&self.kind.to_string());
+        if let Some((idx, char)) = self.char {
+            write!(buf, " {:?} at index {}", char, idx)?
+        }
+        buf.fmt(f)
     }
 }
 
@@ -53,7 +62,7 @@ impl fmt::Display for ParseErrorKind {
             ParseErrorKind::TooLong => "the Account ID is too long".fmt(f),
             ParseErrorKind::TooShort => "the Account ID is too short".fmt(f),
             ParseErrorKind::RedundantSeparator => "the Account ID has a redundant separator".fmt(f),
-            _ => "the Account ID contains an invalid character".fmt(f),
+            ParseErrorKind::InvalidChar => "the Account ID contains an invalid character".fmt(f),
         }
     }
 }

--- a/core/account-id/src/errors.rs
+++ b/core/account-id/src/errors.rs
@@ -50,12 +50,10 @@ pub enum ParseErrorKind {
 impl fmt::Display for ParseErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            ParseErrorKind::TooLong => write!(f, "the Account ID is too long"),
-            ParseErrorKind::TooShort => write!(f, "the Account ID is too short"),
-            ParseErrorKind::RedundantSeparator => {
-                write!(f, "the Account ID has a redundant separator")
-            }
-            _ => write!(f, "the Account ID contains an invalid character"),
+            ParseErrorKind::TooLong => "the Account ID is too long".fmt(f),
+            ParseErrorKind::TooShort => "the Account ID is too short".fmt(f),
+            ParseErrorKind::RedundantSeparator => "the Account ID has a redundant separator".fmt(f),
+            _ => "the Account ID contains an invalid character".fmt(f),
         }
     }
 }

--- a/core/account-id/src/errors.rs
+++ b/core/account-id/src/errors.rs
@@ -19,20 +19,43 @@ impl fmt::Display for ParseAccountError {
 }
 
 /// A list of errors that occur when parsing an invalid Account ID.
+///
+/// Also see [Error kind precedence](crate::AccountId#error-kind-precedence).
 #[non_exhaustive]
 #[derive(Eq, Clone, Debug, PartialEq)]
 pub enum ParseErrorKind {
+    /// The Account ID is too long.
+    ///
+    /// Returned if the `AccountId` is longer than [`AccountId::MAX_LEN`](crate::AccountId::MAX_LEN).
     TooLong,
+    /// The Account ID is too short.
+    ///
+    /// Returned if the `AccountId` is shorter than [`AccountId::MIN_LEN`](crate::AccountId::MIN_LEN).
     TooShort,
-    Invalid,
+    /// The Account ID has a redundant separator.
+    ///
+    /// This variant would be returned if the Account ID either begins with,
+    /// ends with or has separators immediately following each other.
+    ///
+    /// Cases: `jane.`, `angela__moss`, `tyrell..wellick`
+    RedundantSeparator,
+    /// The Account ID contains an invalid character.
+    ///
+    /// This variant would be returned if the Account ID contains an upper-case character, non-separating symbol or space.
+    ///
+    /// Cases: `ƒelicia.near`, `user@app.com`, `Emily.near`.
+    InvalidChar,
 }
 
 impl fmt::Display for ParseErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            ParseErrorKind::TooLong => write!(f, "the account ID is too long"),
-            ParseErrorKind::TooShort => write!(f, "the account ID is too short"),
-            _ => write!(f, "the account ID has an invalid format"),
+            ParseErrorKind::TooLong => write!(f, "the Account ID is too long"),
+            ParseErrorKind::TooShort => write!(f, "the Account ID is too short"),
+            ParseErrorKind::RedundantSeparator => {
+                write!(f, "the Account ID has a redundant separator")
+            }
+            _ => write!(f, "the Account ID contains an invalid character"),
         }
     }
 }


### PR DESCRIPTION
Based on https://github.com/near/nearcore/pull/5581. 

Previously, `ParseErrorKind::Invalid` was returned as the error kind for four parsing cases:
- either the ID started with a separator (`.a`)
- ended with one (`b.`)
- had separators following each other in quick succession (`a..b`)
- or had invalid characters (caps, symbols, or spaces).

We can and should split those up. Context: https://github.com/near/nearcore/pull/5575#discussion_r762530320

This resolves to having these two variants:

- `RedundantSeparator`: for IDs starting or ending with separators, as well as for separators following each other consecutively.
- `InvalidChar`: for non-lowercase, non-alphanumeric characters. (caps, symbols, or spaces).