### PR TITLE
feat: hint the position of invalidation for an Account ID

### DIFF
--- a/core/account-id/src/errors.rs
+++ b/core/account-id/src/errors.rs
@@ -38,13 +38,13 @@ pub enum ParseErrorKind {
     /// ends with or has separators immediately following each other.
     ///
     /// Cases: `jane.`, `angela__moss`, `tyrell..wellick`
-    RedundantSeparator,
+    RedundantSeparator(usize, char),
     /// The Account ID contains an invalid character.
     ///
     /// This variant would be returned if the Account ID contains an upper-case character, non-separating symbol or space.
     ///
     /// Cases: `ƒelicia.near`, `user@app.com`, `Emily.near`.
-    InvalidChar,
+    InvalidChar(usize, char),
 }
 
 impl fmt::Display for ParseErrorKind {
@@ -52,8 +52,13 @@ impl fmt::Display for ParseErrorKind {
         match self {
             ParseErrorKind::TooLong => "the Account ID is too long".fmt(f),
             ParseErrorKind::TooShort => "the Account ID is too short".fmt(f),
-            ParseErrorKind::RedundantSeparator => "the Account ID has a redundant separator".fmt(f),
-            _ => "the Account ID contains an invalid character".fmt(f),
+            ParseErrorKind::RedundantSeparator(i, c) => {
+                format!("the Account ID has a redundant separator {:?} at index {}", c, i).fmt(f)
+            }
+            ParseErrorKind::InvalidChar(i, c) => {
+                format!("the Account ID contains an invalid character {:?} at index {}", c, i)
+                    .fmt(f)
+            }
         }
     }
 }

--- a/core/account-id/src/errors.rs
+++ b/core/account-id/src/errors.rs
@@ -38,13 +38,13 @@ pub enum ParseErrorKind {
     /// ends with or has separators immediately following each other.
     ///
     /// Cases: `jane.`, `angela__moss`, `tyrell..wellick`
-    RedundantSeparator(usize, char),
+    RedundantSeparator { position: usize, separator: char },
     /// The Account ID contains an invalid character.
     ///
     /// This variant would be returned if the Account ID contains an upper-case character, non-separating symbol or space.
     ///
     /// Cases: `ƒelicia.near`, `user@app.com`, `Emily.near`.
-    InvalidChar(usize, char),
+    InvalidChar { position: usize, character: char },
 }
 
 impl fmt::Display for ParseErrorKind {
@@ -52,13 +52,16 @@ impl fmt::Display for ParseErrorKind {
         match self {
             ParseErrorKind::TooLong => "the Account ID is too long".fmt(f),
             ParseErrorKind::TooShort => "the Account ID is too short".fmt(f),
-            ParseErrorKind::RedundantSeparator(i, c) => {
-                format!("the Account ID has a redundant separator {:?} at index {}", c, i).fmt(f)
-            }
-            ParseErrorKind::InvalidChar(i, c) => {
-                format!("the Account ID contains an invalid character {:?} at index {}", c, i)
-                    .fmt(f)
-            }
+            ParseErrorKind::RedundantSeparator { position, separator } => format!(
+                "the Account ID has a redundant separator {:?} at index {}",
+                separator, position
+            )
+            .fmt(f),
+            ParseErrorKind::InvalidChar { position, character } => format!(
+                "the Account ID contains an invalid character {:?} at index {}",
+                character, position
+            )
+            .fmt(f),
         }
     }
 }


### PR DESCRIPTION
Merges into https://github.com/near/nearcore/pull/5660

Context: https://github.com/near/nearcore/pull/5660#discussion_r762553344

Wonder if it's useful to highlight which character and at what index was responsible for the error.. Something like;

`InvalidChar(2, 'ƒ')` from `tiƒƒany..near`
`RedundantSeparator(0, '_')` from `_root.near`

But, of course, when matching, you can discard that data with `RedundantSeparator(..)`.

- `fmt::Display` + `borsh`:
  - `invalid value: "alice.", the Account ID has a redundant separator '.' at index 5`
- `serde`:
  - `invalid value: "alice.", the Account ID has a redundant separator '.' at index 5 at line 4 column 9`