### PR TITLE
chore: mark near-cache unpublishable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2537,7 +2537,7 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "bencher",
  "lru",

--- a/utils/near-cache/Cargo.toml
+++ b/utils/near-cache/Cargo.toml
@@ -2,6 +2,7 @@
 name = "near-cache"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/utils/near-cache/Cargo.toml
+++ b/utils/near-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cache"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
`near-cache`, introduced in #5259, should be a private crate.

Context: this fixes CI on master - https://buildkite.com/nearprotocol/nearcore-release/builds/1381#b7c93adf-148e-4fa3-970d-8043a58a81a7