### PR TITLE
pytest: fix failure with tests that use LogTracker

### DIFF
--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -382,12 +382,14 @@ class LocalNode(BaseNode):
         cmd = self._get_command_line(self.near_root, self.node_dir, boot_node,
                                      self.binary_name)
         node_dir = pathlib.Path(self.node_dir)
-        stdout, stderr = node_dir / 'stdout', node_dir / 'stderr'
-        with open(stdout, 'ab') as stdout_fd, open(stderr, 'ab') as stderr_fd:
+        self.stdout_name = node_dir / 'stdout'
+        self.stderr_name = node_dir / 'stderr'
+        with open(self.stdout_name, 'ab') as stdout, \
+             open(self.stderr_name, 'ab') as stderr:
             self.pid.value = subprocess.Popen(cmd,
                                               stdin=subprocess.DEVNULL,
-                                              stdout=stdout_fd,
-                                              stderr=stderr_fd,
+                                              stdout=stdout,
+                                              stderr=stderr,
                                               env=env).pid
 
         if not skip_starting_proxy:


### PR DESCRIPTION
Commit ‘close stdout and stderr when local node is cleaned up’ removed
`stdout_name` and `stderr_name` fields from the LocalNode object but
as it turns out utils.LogTracker uses the latter.  In effect, that
change caused tests which use LogTracker to start failing at the
following:

      File "/datadrive/nearcore/pytest/lib/utils.py", line 77, in __init__
        self.fname = node.stderr_name
    AttributeError: 'LocalNode' object has no attribute 'stderr_name'

Fix the issue by bringing the two fields back to LocalNode class.