### PR TITLE
fe: Remove warnings in`near-vm-runner-standalone`

### DIFF
--- a/runtime/near-vm-runner-standalone/src/main.rs
+++ b/runtime/near-vm-runner-standalone/src/main.rs
@@ -102,6 +102,8 @@ struct CliArgs {
     protocol_version: Option<ProtocolVersion>,
 }
 
+/// Used only for debug prints.
+#[allow(unused)]
 #[derive(Debug, Clone)]
 struct StandaloneOutput {
     pub outcome: Option<VMOutcome>,


### PR DESCRIPTION
New version of Rust `1.57.0` improved checking for unused code. (see https://github.com/near/nearcore/pull/5659). This causes a warnings in tests code. Rust marks `StandaloneOutput` struct as unused, because it's values are never read.
However, that seems like a compiler error, because those values are used inside `#[derive(Debug)]`.

However, rather than fixing compiler error, we can simply, start using `tracing` crate, and get even more benefits from it.

Any objects? Alternative suggetsions?

```
warning: field is never read: `outcome`
   --> runtime/near-vm-runner-standalone/src/main.rs:107:5
    |
107 |     pub outcome: Option<VMOutcome>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default

warning: field is never read: `err`
   --> runtime/near-vm-runner-standalone/src/main.rs:108:5
    |
108 |     pub err: Option<String>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^

warning: field is never read: `receipts`
   --> runtime/near-vm-runner-standalone/src/main.rs:109:5
    |
109 |     pub receipts: Vec<Receipt>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: field is never read: `state`
   --> runtime/near-vm-runner-standalone/src/main.rs:110:5
    |
110 |     pub state: State,
    |     ^^^^^^^^^^^^^^^^
```