### PR TITLE
fe: Move `ActixMessageWrapper` from `near-network` to `near-rate-limiter`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3003,6 +3003,7 @@ dependencies = [
 name = "near-rate-limiter"
 version = "0.0.0"
 dependencies = [
+ "actix",
  "bytes",
  "futures-core",
  "log",

--- a/chain/network/src/common/mod.rs
+++ b/chain/network/src/common/mod.rs
@@ -1,1 +1,0 @@
-pub(crate) mod message_wrapper;

--- a/chain/network/src/lib.rs
+++ b/chain/network/src/lib.rs
@@ -7,7 +7,6 @@ pub use crate::stats::metrics;
 // TODO(#5307)
 pub use near_network_primitives::types::PeerInfo;
 
-pub(crate) mod common;
 mod network_protocol;
 mod peer;
 mod peer_manager;

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -1,4 +1,3 @@
-use crate::common::message_wrapper::ActixMessageWrapper;
 use crate::peer::codec::Codec;
 use crate::peer::tracker::Tracker;
 use crate::peer::utils;
@@ -37,7 +36,7 @@ use near_primitives::version::{
     ProtocolVersion, OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION, PROTOCOL_VERSION,
 };
 use near_primitives::{logging, unwrap_option_or_return};
-use near_rate_limiter::ThrottleController;
+use near_rate_limiter::{ActixMessageWrapper, ThrottleController};
 use near_rust_allocator_proxy::allocator::get_tid;
 use std::cmp::max;
 use std::fmt::Debug;

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -1,4 +1,3 @@
-use crate::common::message_wrapper::{ActixMessageResponse, ActixMessageWrapper};
 use crate::peer::codec::Codec;
 use crate::peer::peer_actor::PeerActor;
 use crate::peer_manager::peer_store::{PeerStore, TrustLevel};
@@ -45,7 +44,10 @@ use near_primitives::network::{AnnounceAccount, PeerId};
 use near_primitives::time::Clock;
 use near_primitives::types::{AccountId, ProtocolVersion};
 use near_primitives::utils::from_timestamp;
-use near_rate_limiter::{ThrottleController, ThrottleToken, ThrottledFrameRead};
+use near_rate_limiter::{
+    ActixMessageResponse, ActixMessageWrapper, ThrottleController, ThrottleToken,
+    ThrottledFrameRead,
+};
 use near_store::Store;
 use rand::seq::{IteratorRandom, SliceRandom};
 use rand::thread_rng;

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -1,4 +1,3 @@
-use crate::common::message_wrapper::{ActixMessageResponse, ActixMessageWrapper};
 use crate::metrics;
 use crate::routing::edge::{Edge, EdgeState};
 use crate::routing::edge_validator_actor::EdgeValidatorActor;
@@ -13,7 +12,7 @@ use near_performance_metrics_macros::perf;
 use near_primitives::borsh::BorshSerialize;
 use near_primitives::network::PeerId;
 use near_primitives::utils::index_to_bytes;
-use near_rate_limiter::ThrottleToken;
+use near_rate_limiter::{ActixMessageResponse, ActixMessageWrapper, ThrottleToken};
 use near_store::db::DBCol::{ColComponentEdges, ColLastComponentNonce, ColPeerComponent};
 use near_store::{Store, StoreUpdate};
 use std::collections::{HashMap, HashSet};

--- a/utils/near-rate-limiter/Cargo.toml
+++ b/utils/near-rate-limiter/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.0.0"
 publish = false
 
 [dependencies]
+actix = "=0.11.0-beta.2"
 bytes = "1.0.0"
 futures-core = "0.3.0"
 log = "0.4"

--- a/utils/near-rate-limiter/src/framed_read.rs
+++ b/utils/near-rate-limiter/src/framed_read.rs
@@ -397,7 +397,7 @@ mod tests {
         let max_messages_total_size = 500_000_000;
         let semaphore = PollSemaphore::new(Arc::new(Semaphore::new(0)));
         let mut throttle_controller =
-            ThrottleController::new(semaphore.clone(), 1000, max_messages_total_size);
+            ThrottleController::new(semaphore, 1000, max_messages_total_size);
 
         assert_eq!(throttle_controller.consume_msg_seen(), 0);
         throttle_controller.report_msg_seen();

--- a/utils/near-rate-limiter/src/lib.rs
+++ b/utils/near-rate-limiter/src/lib.rs
@@ -1,3 +1,6 @@
 #![doc = include_str!("../README.md")]
 pub(crate) mod framed_read;
+mod message_wrapper;
+pub use message_wrapper::{ActixMessageResponse, ActixMessageWrapper};
+
 pub use framed_read::{ThrottleController, ThrottleToken, ThrottledFrameRead};

--- a/utils/near-rate-limiter/src/message_wrapper.rs
+++ b/utils/near-rate-limiter/src/message_wrapper.rs
@@ -1,6 +1,6 @@
+use crate::{ThrottleController, ThrottleToken};
 use actix::dev::MessageResponse;
 use actix::Message;
-use near_rate_limiter::{ThrottleController, ThrottleToken};
 
 // Wrapper around Actix messages, used to track size of all messages sent to PeerManager.
 // TODO(#5155) Finish implementation of this.


### PR DESCRIPTION
We want to use `near-rate-limiter` across multiple crates. That implies, that we would have to use `ActixMessageWrapper` across mujltiple crates. However, `ActixMessageWrapper` currently is located in `near-network`. And we don't want other crates, to be directly importing from `near-network`.

I propose, we move `ActixMessageWrapper` to the same crate as `ThrottledFramedReader`, that is inside ` near-rate-limiter`.
Both `ActixMessageWrapper`, `ThrottledFramedReader` are meant to be used together, and it makes sense for them to be together.

Later, we may consider moving `near-rate-limiter`, to a new place. However, it's hard to say exactly where. 
Anyway, moving those two structs together, is definitely a good change. Let's do it now.

This is required for the next step. The plan will be added to https://github.com/near/nearcore/issues/5672. 