### PR TITLE
chain: rosetta: introduce errors::Result type alias

### DIFF
--- a/chain/rosetta-rpc/src/adapters/mod.rs
+++ b/chain/rosetta-rpc/src/adapters/mod.rs
@@ -161,8 +161,7 @@ fn convert_block_changes_to_transactions(
         near_primitives::types::AccountId,
         near_primitives::views::AccountView,
     >,
-) -> crate::errors::Result<std::collections::HashMap<String, crate::models::Transaction>>
-{
+) -> crate::errors::Result<std::collections::HashMap<String, crate::models::Transaction>> {
     use near_primitives::views::StateChangeCauseView;
 
     let mut transactions = std::collections::HashMap::<String, crate::models::Transaction>::new();

--- a/chain/rosetta-rpc/src/adapters/mod.rs
+++ b/chain/rosetta-rpc/src/adapters/mod.rs
@@ -20,7 +20,7 @@ async fn convert_genesis_records_to_transaction(
     genesis: Arc<Genesis>,
     view_client_addr: Addr<ViewClientActor>,
     block: &near_primitives::views::BlockView,
-) -> Result<crate::models::Transaction, crate::errors::ErrorKind> {
+) -> crate::errors::Result<crate::models::Transaction> {
     let genesis_account_ids = genesis.records.as_ref().iter().filter_map(|record| {
         if let near_primitives::state_record::StateRecord::Account { account_id, .. } = record {
             Some(account_id)
@@ -107,7 +107,7 @@ async fn convert_genesis_records_to_transaction(
 pub(crate) async fn convert_block_to_transactions(
     view_client_addr: Addr<ViewClientActor>,
     block: &near_primitives::views::BlockView,
-) -> Result<Vec<crate::models::Transaction>, crate::errors::ErrorKind> {
+) -> crate::errors::Result<Vec<crate::models::Transaction>> {
     let state_changes = view_client_addr
         .send(near_client::GetStateChangesInBlock { block_hash: block.header.hash })
         .await?
@@ -161,7 +161,7 @@ fn convert_block_changes_to_transactions(
         near_primitives::types::AccountId,
         near_primitives::views::AccountView,
     >,
-) -> Result<std::collections::HashMap<String, crate::models::Transaction>, crate::errors::ErrorKind>
+) -> crate::errors::Result<std::collections::HashMap<String, crate::models::Transaction>>
 {
     use near_primitives::views::StateChangeCauseView;
 
@@ -394,7 +394,7 @@ pub(crate) async fn collect_transactions(
     genesis: Arc<Genesis>,
     view_client_addr: Addr<ViewClientActor>,
     block: &near_primitives::views::BlockView,
-) -> Result<Vec<crate::models::Transaction>, crate::errors::ErrorKind> {
+) -> crate::errors::Result<Vec<crate::models::Transaction>> {
     if block.header.prev_hash == Default::default() {
         Ok(vec![convert_genesis_records_to_transaction(genesis, view_client_addr, block).await?])
     } else {

--- a/chain/rosetta-rpc/src/adapters/validated_operations/mod.rs
+++ b/chain/rosetta-rpc/src/adapters/validated_operations/mod.rs
@@ -47,7 +47,7 @@ pub(crate) trait ValidatedOperation:
 
     fn validate_operation_type(
         operation_type: crate::models::OperationType,
-    ) -> Result<(), crate::errors::ErrorKind> {
+    ) -> crate::errors::Result<()> {
         if operation_type == Self::OPERATION_TYPE {
             Ok(())
         } else {

--- a/chain/rosetta-rpc/src/errors.rs
+++ b/chain/rosetta-rpc/src/errors.rs
@@ -8,6 +8,8 @@ pub(crate) enum ErrorKind {
     InternalError(String),
 }
 
+pub(crate) type Result<T> = std::result::Result<T, ErrorKind>;
+
 impl From<actix::MailboxError> for ErrorKind {
     fn from(err: actix::MailboxError) -> Self {
         Self::InternalError(format!(

--- a/chain/rosetta-rpc/src/utils.rs
+++ b/chain/rosetta-rpc/src/utils.rs
@@ -410,7 +410,7 @@ pub(crate) async fn query_access_key(
 pub(crate) async fn query_protocol_config(
     block_hash: near_primitives::hash::CryptoHash,
     view_client_addr: &Addr<ViewClientActor>,
-) -> Result<ProtocolConfigView, crate::errors::ErrorKind> {
+) -> crate::errors::Result<ProtocolConfigView> {
     view_client_addr
         .send(near_client::GetProtocolConfig(near_primitives::types::BlockReference::from(
             near_primitives::types::BlockId::Hash(block_hash),
@@ -438,7 +438,7 @@ where
         Self { error_message, known_value: None }
     }
 
-    pub fn try_set(&mut self, new_value: &T) -> Result<(), crate::errors::ErrorKind> {
+    pub fn try_set(&mut self, new_value: &T) -> crate::errors::Result<()> {
         if let Some(ref known_value) = self.known_value {
             if new_value != known_value {
                 Err(crate::errors::ErrorKind::InvalidInput(format!(


### PR DESCRIPTION
This saves a few kestrokes and I hear defining one’s own Result is
quite rustic.