### PR TITLE
`near-network` Try using `anyhow ` with `test_slot_map` test.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.44"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+checksum = "8b26702f315f53b6071259e15dd9d64528213b44d61de1ec926eca7715d62203"
 
 [[package]]
 name = "arbitrary"
@@ -2877,6 +2877,7 @@ name = "near-network"
 version = "0.0.0"
 dependencies = [
  "actix",
+ "anyhow",
  "bencher",
  "borsh 0.9.1",
  "bytes",

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -8,6 +8,7 @@ rust-version = "1.56.0"
 edition = "2021"
 
 [dependencies]
+anyhow = "1.0.51"
 actix = "=0.11.0-beta.2"
 borsh = { version = "0.9", features = ["rc"] }
 bytes = "1"

--- a/chain/network/src/routing/ibf_peer_set.rs
+++ b/chain/network/src/routing/ibf_peer_set.rs
@@ -171,11 +171,12 @@ mod test {
     use crate::routing::ibf_peer_set::{IbfPeerSet, SlotMap};
     use crate::routing::ibf_set::IbfSet;
     use crate::test_utils::random_peer_id;
+    use anyhow::{Context, Result};
     use near_primitives::network::PeerId;
     use std::collections::HashMap;
 
     #[test]
-    fn test_slot_map() {
+    fn test_slot_map() -> Result<()> {
         let p0 = random_peer_id();
         let p1 = random_peer_id();
         let p2 = random_peer_id();
@@ -185,12 +186,12 @@ mod test {
         let e2 = SimpleEdge::new(p1, p2, 3);
 
         let mut sm = SlotMap::default();
-        assert_eq!(0_u64, sm.insert(&e0).unwrap());
+        assert_eq!(0_u64, sm.insert(&e0).with_context(|| format!("failed with {:?}", &e0))?);
 
         assert!(sm.insert(&e0).is_none());
 
-        assert_eq!(1_u64, sm.insert(&e1).unwrap());
-        assert_eq!(2_u64, sm.insert(&e2).unwrap());
+        assert_eq!(1_u64, sm.insert(&e1).with_context(|| format!("failed with {:?}", &e1))?);
+        assert_eq!(2_u64, sm.insert(&e2).with_context(|| format!("failed with {:?}", &e2))?);
 
         assert_eq!(Some(2_u64), sm.pop(&e2));
         assert_eq!(None, sm.pop(&e2));
@@ -206,11 +207,12 @@ mod test {
         assert_eq!(None, sm.get(&e1));
         assert_eq!(None, sm.pop(&e1));
 
-        assert_eq!(3_u64, sm.insert(&e2).unwrap());
+        assert_eq!(3_u64, sm.insert(&e2).with_context(|| format!("failed with {:?}", &e2))?);
         assert_eq!(Some(3_u64), sm.pop(&e2));
 
         assert_eq!(None, sm.get_by_id(&1_u64));
         assert_eq!(None, sm.get_by_id(&1000_u64));
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
Usually, our tests don't handle panics well.

For example:
- https://github.com/near/nearcore/issues/5649
- https://github.com/near/nearcore/issues/5628
- https://github.com/near/nearcore/issues/5503
- ...

Let's see if it works with an example test `test_slot_map`.