### PR TITLE
Improve history playback functionalty

### DIFF
--- a/test-utils/state-viewer/README.md
+++ b/test-utils/state-viewer/README.md
@@ -87,3 +87,14 @@ Saves the current state of the network in a new genesis file.
 Flags:
 
 * `--height` takes state from the genesis up to and including the given height. By default, dumps all available state.
+
+#### Running on macOS
+
+```bash
+brew install --cask google-cloud-sdk
+export PATH=/usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin:$PATH
+gcloud beta compute ssh --zone "europe-west4-a" "<machine>"  --project "rpc-prod"
+```
+
+Check running instances at <https://console.cloud.google.com/compute/instances?project=rpc-prod> to see the machine
+name and datacenter.

--- a/test-utils/state-viewer/src/apply_chain_range.rs
+++ b/test-utils/state-viewer/src/apply_chain_range.rs
@@ -178,12 +178,7 @@ pub fn apply_chain_range(
                     for tx in chunk.transactions() {
                         for action in &tx.transaction.actions {
                             has_contracts = has_contracts || match action {
-                                Action::FunctionCall(_) => {
-                                    true
-                                }
-                                Action::DeployContract(_) => {
-                                    true
-                                }
+                                Action::FunctionCall(_) | Action::DeployContract(_) => true,
                                 _ => {
                                     false
                                 }

--- a/test-utils/state-viewer/src/cli.rs
+++ b/test-utils/state-viewer/src/cli.rs
@@ -154,6 +154,8 @@ pub struct ApplyRangeCmd {
     verbose_output: bool,
     #[clap(long, parse(from_os_str))]
     csv_file: Option<PathBuf>,
+    #[clap(long)]
+    only_contracts: bool,
 }
 
 impl ApplyRangeCmd {
@@ -167,6 +169,7 @@ impl ApplyRangeCmd {
             home_dir,
             near_config,
             store,
+            self.only_contracts,
         );
     }
 }

--- a/test-utils/state-viewer/src/commands.rs
+++ b/test-utils/state-viewer/src/commands.rs
@@ -83,6 +83,7 @@ pub(crate) fn apply_range(
     home_dir: &Path,
     near_config: NearConfig,
     store: Arc<Store>,
+    only_contracts: bool,
 ) {
     let mut csv_file = csv_file.map(|filename| std::fs::File::create(filename).unwrap());
 
@@ -102,6 +103,7 @@ pub(crate) fn apply_range(
         runtime,
         verbose_output,
         csv_file.as_mut(),
+        only_contracts,
     );
 }
 


### PR DESCRIPTION
Add improved logging of history playback and switch allowing to ignore all transactions but ones related to contracts with
--only-contracts CLI switch.

Also allow playback for cases where database was migrated and so outcome varies in versions.

This way we hope to have improved playback performance, although still to playback the whole mainnet history of 40M blocks with current performance of 7-10 blocks per second would take ~2 months.
