### PR TITLE
docs: document structural logging style

### DIFF
--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -370,10 +370,11 @@ impl PeerManagerActor {
                 || total_msg_received_count > REPORT_BANDWIDTH_THRESHOLD_COUNT
             {
                 warn!(
-                    message = "Peer bandwidth exceeded threshold",
                     ?peer_id,
                     bandwidth_used,
-                    msg_received_count
+                    msg_received_count = active_peer.throttle_controller.consume_msg_seen(),
+                    "Peer bandwidth exceeded threshold (thershold is {})",
+                    REPORT_BANDWIDTH_THRESHOLD_BYTES
                 );
             }
             total_bandwidth_used_by_all_peers += bandwidth_used;

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -371,10 +371,7 @@ impl PeerManagerActor {
             {
                 warn!(
                     ?peer_id,
-                    bandwidth_used,
-                    msg_received_count = active_peer.throttle_controller.consume_msg_seen(),
-                    "Peer bandwidth exceeded threshold (thershold is {})",
-                    REPORT_BANDWIDTH_THRESHOLD_BYTES
+                    bandwidth_used, msg_received_count, "Peer bandwidth exceeded threshold",
                 );
             }
             total_bandwidth_used_by_all_peers += bandwidth_used;
@@ -384,10 +381,8 @@ impl PeerManagerActor {
         }
 
         info!(
-            message = "Bandwidth stats",
             total_bandwidth_used_by_all_peers,
-            total_msg_received_count,
-            max_max_record_num_messages_in_progress
+            total_msg_received_count, max_max_record_num_messages_in_progress, "Bandwidth stats"
         );
 
         near_performance_metrics::actix::run_later(ctx, every, move |act, ctx| {
@@ -1080,9 +1075,10 @@ impl PeerManagerActor {
     ///             find the one we connected earlier and add it to the safe set.
     ///         else break
     fn try_stop_active_connection(&self) {
-        debug!(target: "network", message = "Trying to stop an active connection.",
+        debug!(target: "network",
             connected_peers_len = self.connected_peers.len(),
             ideal_connections_hi = self.config.ideal_connections_hi,
+            "Trying to stop an active connection.",
         );
 
         // Build safe set
@@ -1582,7 +1578,7 @@ impl Actor for PeerManagerActor {
         self.push_network_info_trigger(ctx, self.config.push_info_period);
 
         // Periodically starts peer monitoring.
-        debug!(target: "network", message = "monitor_peers_trigger", interval = ?self.config.bootstrap_peers_period);
+        debug!(target: "network", interval = ?self.config.bootstrap_peers_period, "monitor_peers_trigger");
         self.monitor_peers_trigger(ctx, self.config.bootstrap_peers_period);
 
         // Periodically starts active peer stats querying.
@@ -2167,9 +2163,10 @@ impl PeerManagerActor {
 
         if msg.peer_type == PeerType::Inbound && !self.is_inbound_allowed() {
             // TODO(1896): Gracefully drop inbound connection for other peer.
-            debug!(target: "network", message = "Inbound connection dropped (network at max capacity).",
+            debug!(target: "network",
                 active_peers = self.connected_peers.len(), outgoing_peers = self.outgoing_peers.len(),
-                max_num_peers = self.config.max_num_peers
+                max_num_peers = self.config.max_num_peers,
+                "Inbound connection dropped (network at max capacity)."
             );
             return RegisterPeerResponse::Reject;
         }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -166,11 +166,13 @@ tracing::warn!(
     bandwidth_used,
     // Use `fmt::Debug` to format the value.
     ?peer_id,
-    // Free form `format!`-like arguments.
-    "Peer bandwidth exceeded threshold (threshold is {})",
-    REPORT_BANDWIDTH_THRESHOLD_BYTES
+    // Free form string
+    "Peer bandwidth exceeded threshold",
 );
 ```
+
+Qualified `tracing::warn!` syntax is preferred to reduce the amount of imports.
+Tracing supports `format!`-like arguments, but prefer `key=value` paris instead.
 
 The [span! API](https://tracing.rs/tracing/macro.debug_span.html) is used to
 measure durations of long-running operations:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -159,7 +159,7 @@ strings, and can log key-value pairs. Keys go *before* free-form message, and
 support various shortcut syntaxes:
 
 ```rust
-warn!(
+tracing::warn!(
     // Explicit `key = value` syntax.
     msg_received_count = active_peer.throttle_controller.consume_msg_seen(),
     // Shorthand for `bandwidth_used = bandwidth_used`.
@@ -182,7 +182,8 @@ fn compile_and_serialize_wasmer(code: &[u8]) -> Result<wasmer::Module> {
 }
 ```
 
-This will record when the `_span` object is created and dropped, logging the time diff between the two events:
+This will record when the `_span` object is created and dropped, logging the
+time diff between the two events:
 
 ```
 May 19 21:05:07.516 DEBUG run_vm:compile_and_serialize_wasmer:  close time.busy=5ms time.idle=6ns
@@ -190,6 +191,7 @@ May 19 21:05:07.516 DEBUG run_vm:compile_and_serialize_wasmer:  close time.busy=
 
 Always specify the `target` explicitly.
 
-The `INFO` level is enabled by default, use it for information useful for node operators.
-The `DEBUG` level is enabled on the canary nodes, use it for information useful in debugging testnet failures.
-The `TRACE` level is not generally enabled, use it for arbitrary debug output.
+The `INFO` level is enabled by default, use it for information useful for node
+operators. The `DEBUG` level is enabled on the canary nodes, use it for
+information useful in debugging testnet failures. The `TRACE` level is not
+generally enabled, use it for arbitrary debug output.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -54,7 +54,7 @@ Note that we usually use `TrieUpdate` to interact with the state.
 
 ### `chain/chain`
 
-This crate contains most of the chain logic (consensus, block processing, etc). 
+This crate contains most of the chain logic (consensus, block processing, etc).
 `ChainUpdate::process_block` is where most of the block processing logic happens.
 
 **Architecture Invariant**: interface between chain and runtime is defined by `RuntimeAdapter`.
@@ -85,7 +85,7 @@ This crate defines two important structs, `Client` and `ViewClient`.
 
 This crate contains the entire implementation of the p2p network used by NEAR blockchain nodes.
 
-Two important structs here: `PeerManagerActor` and `Peer`. 
+Two important structs here: `PeerManagerActor` and `Peer`.
 Peer manager orchestrates all the communications from network to other components and from other components to network.
 `Peer` is responsible for low-level network communications from and to a given peer.
 Peer manager runs in one thread while each `Peer` runs in its own thread.
@@ -108,15 +108,15 @@ Transactions, on the other hand, are sent to `ClientActor` for further processin
 
 ### `runtime/runtime`
 
-This crate contains the main entry point to runtime -- `Runtime::apply`. 
+This crate contains the main entry point to runtime -- `Runtime::apply`.
 This function takes `ApplyState`, which contains necessary information passed from chain to runtime, and a list of `SignedTransaction` and a list of `Receipt`, and returns a `ApplyResult`, which includes state changes, execution outcomes, etc.
 
-**Architecture Invariant**: The state update is only finalized at the end of `apply`. 
+**Architecture Invariant**: The state update is only finalized at the end of `apply`.
 During all intermediate steps state changes can be reverted.
 
 ### `runtime/near-vm-logic`
 
-`VMLogic` contains all the implementations of host functions and is the interface between runtime and wasm. 
+`VMLogic` contains all the implementations of host functions and is the interface between runtime and wasm.
 `VMLogic` is constructed when runtime applies function call actions.
 In `VMLogic`, interaction with NEAR blockchain happens in the following two ways:
 - `VMContext`, which contains lightweight information such as current block hash, current block height, epoch id, etc.
@@ -154,7 +154,26 @@ tracing::warn!(
 );
 ```
 
-The [span! API](https://tracing.rs/tracing/macro.debug_span.html) is used to measure durations of long-running operations:
+tracing supports structured logging. That is, you are not restricted to logging
+strings, and can log key-value pairs. Keys go *before* free-form message, and
+support various shortcut syntaxes:
+
+```rust
+warn!(
+    // Explicit `key = value` syntax.
+    msg_received_count = active_peer.throttle_controller.consume_msg_seen(),
+    // Shorthand for `bandwidth_used = bandwidth_used`.
+    bandwidth_used,
+    // Use `fmt::Debug` to format the value.
+    ?peer_id,
+    // Free form `format!`-like arguments.
+    "Peer bandwidth exceeded threshold (threshold is {})",
+    REPORT_BANDWIDTH_THRESHOLD_BYTES
+);
+```
+
+The [span! API](https://tracing.rs/tracing/macro.debug_span.html) is used to
+measure durations of long-running operations:
 
 ```rust
 fn compile_and_serialize_wasmer(code: &[u8]) -> Result<wasmer::Module> {

--- a/integration-tests/tests/network/runner.rs
+++ b/integration-tests/tests/network/runner.rs
@@ -172,7 +172,7 @@ impl StateMachine {
                           _ctx: &mut Context<WaitOrTimeoutActor>,
                           _runner| {
                         if can_write_log.swap(false, Ordering::Relaxed) == true {
-                            debug!(target: "network", message = "runner.rs: Action", num_prev_actions, action = ?action_clone);
+                            debug!(target: "network", num_prev_actions, action = ?action_clone, "runner.rs: Action");
                         }
                         let addr = info.read().unwrap().pm_addr[target].clone();
                         actix::spawn(
@@ -202,7 +202,7 @@ impl StateMachine {
                           _ctx: &mut Context<WaitOrTimeoutActor>,
                           _runner| {
                         if can_write_log.swap(false, Ordering::Relaxed) == true {
-                            debug!(target: "network", message = "runner.rs: Action", num_prev_actions, action = ?action_clone);
+                            debug!(target: "network", num_prev_actions, action = ?action_clone, "runner.rs: Action");
                         }
 
                         let addr = info.read().unwrap().pm_addr[u].clone();
@@ -230,7 +230,7 @@ impl StateMachine {
                       _ctx: &mut Context<WaitOrTimeoutActor>,
                       _runner| {
                     if can_write_log.swap(false, Ordering::Relaxed) == true {
-                        debug!(target: "network", message = "runner.rs: Action", num_prev_actions, action = ?action_clone);
+                        debug!(target: "network", num_prev_actions, action = ?action_clone, "runner.rs: Action");
                     }
 
                     let expected = expected
@@ -281,7 +281,7 @@ impl StateMachine {
                           _ctx: &mut Context<WaitOrTimeoutActor>,
                           _runner| {
                         if can_write_log.swap(false, Ordering::Relaxed) == true {
-                            debug!(target: "network", message = "runner.rs: Action", num_prev_actions, action = ?action_clone);
+                            debug!(target: "network", num_prev_actions, action = ?action_clone, "runner.rs: Action");
                         }
 
                         let expected_known: Vec<_> = known_validators
@@ -324,7 +324,7 @@ impl StateMachine {
                           _ctx: &mut Context<WaitOrTimeoutActor>,
                           _runner| {
                         if can_write_log.swap(false, Ordering::Relaxed) == true {
-                            debug!(target: "network", message = "runner.rs: Action", num_prev_actions, action = ?action_clone);
+                            debug!(target: "network", num_prev_actions, action = ?action_clone, "runner.rs: Action");
                         }
 
                         let target = info.read().unwrap().peers_info[target].id.clone();
@@ -344,7 +344,7 @@ impl StateMachine {
                           _ctx: &mut Context<WaitOrTimeoutActor>,
                           _runner| {
                         if can_write_log.swap(false, Ordering::Relaxed) == true {
-                            debug!(target: "network", message = "runner.rs: Action", num_prev_actions, action = ?action_clone);
+                            debug!(target: "network", num_prev_actions, action = ?action_clone, "runner.rs: Action");
                         }
 
                         actix::spawn(
@@ -371,7 +371,7 @@ impl StateMachine {
                           ctx: &mut Context<WaitOrTimeoutActor>,
                           _runner| {
                         if can_write_log.swap(false, Ordering::Relaxed) == true {
-                            debug!(target: "network", message = "runner.rs: Action", num_prev_actions, action = ?action_clone);
+                            debug!(target: "network", num_prev_actions, action = ?action_clone, "runner.rs: Action");
                         }
 
                         ctx.run_later(Duration::from_millis(time as u64), move |_, _| {
@@ -387,7 +387,7 @@ impl StateMachine {
                           _ctx: &mut Context<WaitOrTimeoutActor>,
                           _runner| {
                         if can_write_log.swap(false, Ordering::Relaxed) == true {
-                            debug!(target: "network", message = "runner.rs: Action", num_prev_actions, action = ?action_clone);
+                            debug!(target: "network", num_prev_actions, action = ?action_clone, "runner.rs: Action");
                         }
 
                         let pings_expected: Vec<_> = pings
@@ -797,7 +797,7 @@ pub fn check_expected_connections(
               _ctx: &mut Context<WaitOrTimeoutActor>,
               _runner| {
             if can_write_log.swap(false, Ordering::Relaxed) == true {
-                debug!(target: "network", message = "runner.rs: check_expected_connections", node_id, expected_connections_lo, ?expected_connections_hi);
+                debug!(target: "network", node_id, expected_connections_lo, ?expected_connections_hi, "runner.rs: check_expected_connections");
             }
 
             actix::spawn(
@@ -845,7 +845,7 @@ pub fn check_direct_connection(node_id: usize, target_id: usize) -> ActionFn {
             let info = info.read().unwrap();
             let target_peer_id = info.peers_info[target_id].id.clone();
             if can_write_log.swap(false, Ordering::Relaxed) == true {
-                debug!(target: "network",  message = "runner.rs: check_direct_connection", node_id, ?target_id);
+                debug!(target: "network",  node_id, ?target_id, "runner.rs: check_direct_connection");
             }
             let can_write_log2 = can_write_log2.clone();
             let can_write_log3 = can_write_log3.clone();
@@ -868,16 +868,19 @@ pub fn check_direct_connection(node_id: usize, target_id: usize) -> ActionFn {
                                     flag.store(true, Ordering::Relaxed);
                                 }
                                 if can_write_log2.swap(false, Ordering::Relaxed) == true {
-                                    debug!(target: "network",  message = "runner.rs: check_direct_connection", 
+                                    debug!(target: "network",
                                         ?target_peer_id, ?routes, flag = flag.load(Ordering::Relaxed),
-                                        node_id, target_id);
+                                        node_id, target_id,
+                                        "runner.rs: check_direct_connection",
+                                    );
                                 }
                             }
                             else {
                                 if can_write_log3.swap(false, Ordering::Relaxed) == true {
-                                    debug!(target: "network",  message = "runner.rs: check_direct_connection NO ROUTES!", 
+                                    debug!(target: "network",
                                         ?target_peer_id, flag = flag.load(Ordering::Relaxed),
                                         node_id, target_id,
+                                        "runner.rs: check_direct_connection NO ROUTES!",
                                     );
                                 }
                             }
@@ -901,7 +904,7 @@ pub fn restart(node_id: usize) -> ActionFn {
               _ctx: &mut Context<WaitOrTimeoutActor>,
               runner: Addr<Runner>| {
             if can_write_log.swap(false, Ordering::Relaxed) == true {
-                debug!(target: "network", message = "runner.rs: restart", ?node_id);
+                debug!(target: "network", ?node_id, "runner.rs: restart");
             }
             actix::spawn(
                 runner
@@ -926,7 +929,7 @@ pub fn ban_peer(target_peer: usize, banned_peer: usize) -> ActionFn {
               _ctx: &mut Context<WaitOrTimeoutActor>,
               _runner| {
             if can_write_log.swap(false, Ordering::Relaxed) == true {
-                debug!(target: "network", message = "runner.rs: ban_peer", target_peer, banned_peer);
+                debug!(target: "network", target_peer, banned_peer, "runner.rs: ban_peer");
             }
             let info = info.read().unwrap();
             let banned_peer_id = info.peers_info[banned_peer].id.clone();
@@ -956,7 +959,7 @@ pub fn change_account_id(node_id: usize, account_id: AccountId) -> ActionFn {
               _ctx: &mut Context<WaitOrTimeoutActor>,
               runner: Addr<Runner>| {
             if can_write_log.swap(false, Ordering::Relaxed) == true {
-                debug!(target: "network",  message = "runner.rs: change_account_id", ?node_id, ?account_id);
+                debug!(target: "network",  ?node_id, ?account_id, "runner.rs: change_account_id");
             }
             actix::spawn(
                 runner


### PR DESCRIPTION
We stater using structured (key/value) logging that tracing provides, but there's more than one way to use it. Let's document our preferred style (the simplest one, and the one advertised by the upstream docs). 