### PR TITLE
Pass epoch length in tests setup

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -5,7 +5,7 @@ use std::time::{Duration as TimeDuration, Instant};
 use borsh::BorshSerialize;
 use chrono::Duration;
 use itertools::Itertools;
-use near_primitives::time::{Clock, Utc};
+use near_primitives::time::Clock;
 use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
 use rand::SeedableRng;
@@ -4221,7 +4221,7 @@ impl<'a> ChainUpdate<'a> {
         F: FnMut(ChallengeBody),
     {
         // Refuse blocks from the too distant future.
-        if header.timestamp() > Utc::now() + Duration::seconds(ACCEPTABLE_TIME_DIFFERENCE) {
+        if header.timestamp() > Clock::utc() + Duration::seconds(ACCEPTABLE_TIME_DIFFERENCE) {
             return Err(ErrorKind::InvalidBlockFutureTime(header.timestamp()).into());
         }
 
@@ -4257,9 +4257,10 @@ impl<'a> ChainUpdate<'a> {
         let prev_header = self.get_previous_header(header)?.clone();
 
         // Check that epoch_id in the header does match epoch given previous header (only if previous header is present).
-        if &self.runtime_adapter.get_epoch_id_from_prev_block(header.prev_hash())?
-            != header.epoch_id()
-        {
+        let epoch_id_from_prev_block =
+            &self.runtime_adapter.get_epoch_id_from_prev_block(header.prev_hash())?;
+        let epoch_id_from_header = header.epoch_id();
+        if epoch_id_from_prev_block != epoch_id_from_header {
             return Err(ErrorKind::InvalidEpochHash.into());
         }
 

--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -416,7 +416,8 @@ mod tests {
     fn init() -> (Chain, StoreValidator) {
         let store = create_test_store();
         let chain_genesis = ChainGenesis::test();
-        let runtime_adapter = Arc::new(KeyValueRuntime::new(store.clone()));
+        let runtime_adapter =
+            Arc::new(KeyValueRuntime::new(store.clone(), chain_genesis.epoch_length));
         let mut genesis = GenesisConfig::default();
         genesis.genesis_height = 0;
         let chain =

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -111,8 +111,8 @@ fn create_receipt_nonce(
 }
 
 impl KeyValueRuntime {
-    pub fn new(store: Arc<Store>) -> Self {
-        Self::new_with_validators(store, vec![vec!["test".parse().unwrap()]], 1, 1, 5)
+    pub fn new(store: Arc<Store>, epoch_length: u64) -> Self {
+        Self::new_with_validators(store, vec![vec!["test".parse().unwrap()]], 1, 1, epoch_length)
     }
 
     pub fn new_with_validators(
@@ -1215,7 +1215,8 @@ pub fn setup_with_tx_validity_period(
     tx_validity_period: NumBlocks,
 ) -> (Chain, Arc<KeyValueRuntime>, Arc<InMemoryValidatorSigner>) {
     let store = create_test_store();
-    let runtime = Arc::new(KeyValueRuntime::new(store));
+    let epoch_length = 1000;
+    let runtime = Arc::new(KeyValueRuntime::new(store, epoch_length));
     let chain = Chain::new(
         runtime.clone(),
         &ChainGenesis {
@@ -1227,7 +1228,7 @@ pub fn setup_with_tx_validity_period(
             total_supply: 1_000_000_000,
             gas_price_adjustment_rate: Rational::from_integer(0),
             transaction_validity_period: tx_validity_period,
-            epoch_length: 10,
+            epoch_length,
             protocol_version: PROTOCOL_VERSION,
         },
         DoomslugThresholdMode::NoApprovals,

--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -36,6 +36,7 @@ fn build_chain() {
     let _mock_clock_guard = MockClockGuard::default();
     for i in 0..5 {
         Clock::add_utc(chrono::Utc.ymd(2020, 10, 1).and_hms_milli(0, 0, 3, 444 + i));
+        Clock::add_utc(chrono::Utc.ymd(2020, 10, 1).and_hms_milli(0, 0, 3, 444 + i));
     }
 
     let (mut chain, _, signer) = setup();
@@ -62,17 +63,17 @@ fn build_chain() {
     assert_eq!(chain.head().unwrap().height, 4);
     let count_instant = Clock::instant_call_count();
     let count_utc = Clock::utc_call_count();
-    assert_eq!(count_utc, 5);
+    assert_eq!(count_utc, 9);
     assert_eq!(count_instant, 0);
     #[cfg(feature = "nightly_protocol")]
     assert_eq!(
         chain.head().unwrap().last_block_hash,
-        CryptoHash::from_str("BNap11nsM7PEqYQertYU487g7gkCteQ8Fmee6QfyRdVQ").unwrap()
+        CryptoHash::from_str("JDNJcU8dbsY18Trzbts9gSphtQqw9C5fx1Abg3SzDdRZ").unwrap()
     );
     #[cfg(not(feature = "nightly_protocol"))]
     assert_eq!(
         chain.head().unwrap().last_block_hash,
-        CryptoHash::from_str("5pXLqgQe98JSdhtQ66VQFjQzBRPdZaEiMaTpdGuziF4H").unwrap()
+        CryptoHash::from_str("WX4b4czkxK8mXTEa9rXwz29rDus62ccwdkYCVMqkWu1").unwrap()
     );
 }
 

--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -34,7 +34,12 @@ fn empty_chain() {
 fn build_chain() {
     init_test_logger();
     let _mock_clock_guard = MockClockGuard::default();
-    for i in 0..5 {
+    // Adding first mock entry for genesis block
+    Clock::add_utc(chrono::Utc.ymd(2020, 10, 1).and_hms_milli(0, 0, 3, 444));
+    for i in 1..5 {
+        // two entries, because the clock is called 2 times per block
+        // - one time for creation of the block
+        // - one time for validating block header
         Clock::add_utc(chrono::Utc.ymd(2020, 10, 1).and_hms_milli(0, 0, 3, 444 + i));
         Clock::add_utc(chrono::Utc.ymd(2020, 10, 1).and_hms_milli(0, 0, 3, 444 + i));
     }
@@ -68,12 +73,12 @@ fn build_chain() {
     #[cfg(feature = "nightly_protocol")]
     assert_eq!(
         chain.head().unwrap().last_block_hash,
-        CryptoHash::from_str("JDNJcU8dbsY18Trzbts9gSphtQqw9C5fx1Abg3SzDdRZ").unwrap()
+        CryptoHash::from_str("BNap11nsM7PEqYQertYU487g7gkCteQ8Fmee6QfyRdVQ").unwrap()
     );
     #[cfg(not(feature = "nightly_protocol"))]
     assert_eq!(
         chain.head().unwrap().last_block_hash,
-        CryptoHash::from_str("WX4b4czkxK8mXTEa9rXwz29rDus62ccwdkYCVMqkWu1").unwrap()
+        CryptoHash::from_str("5pXLqgQe98JSdhtQ66VQFjQzBRPdZaEiMaTpdGuziF4H").unwrap()
     );
 }
 

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -1868,7 +1868,7 @@ mod test {
     /// should not request partial encoded chunk from self
     #[test]
     fn test_request_partial_encoded_chunk_from_self() {
-        let runtime_adapter = Arc::new(KeyValueRuntime::new(create_test_store()));
+        let runtime_adapter = Arc::new(KeyValueRuntime::new(create_test_store(), 5));
         let network_adapter = Arc::new(MockPeerManagerAdapter::default());
         let mut shards_manager = ShardsManager::new(
             Some("test".parse().unwrap()),


### PR DESCRIPTION
Fix `KeyValueRuntime` to take epoch length as parameter. It caused some bugs with epochs with different length then 5
Replace direct call of Utc::now with Clock::utc() so it can be mocked in tests