### PR TITLE
feat: `near` Print an error if the number of `peers` specified in config is higher than allowed.

### DIFF
--- a/chain/network-primitives/src/types.rs
+++ b/chain/network-primitives/src/types.rs
@@ -39,6 +39,8 @@ pub const ROUTED_MESSAGE_TTL: u8 = 100;
 /// but wait some "small" timeout between updates to avoid a lot of messages between
 /// Peer and PeerManager.
 pub const UPDATE_INTERVAL_LAST_TIME_RECEIVED_MESSAGE: Duration = Duration::from_secs(60);
+/// Due to implementation limits of `Graph` in `near-network`, we support up to 128 client.
+pub const MAX_NUM_PEERS: usize = 128;
 
 /// Peer information.
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
@@ -593,6 +595,13 @@ impl NetworkConfig {
             error!(target: "network",
                 "max_num_peers({}) is below ideal_connections_hi({}) which may lead to connection saturation and declining new connections.",
                 self.max_num_peers, self.ideal_connections_hi
+            );
+        }
+
+        if self.max_num_peers as usize >= MAX_NUM_PEERS {
+            error!(target: "network",
+                "max_num_peers({}) is higher than MAX_NUM_PEERS({}) due to implementation limits",
+                self.max_num_peers, MAX_NUM_PEERS
             );
         }
 

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -8,7 +8,7 @@ use crate::private_actix::{
 };
 use crate::routing::edge_validator_actor::EdgeValidatorHelper;
 use crate::routing::network_protocol::Edge;
-use crate::routing::routing::{RoutingTableView, DELETE_PEERS_AFTER_TIME, MAX_NUM_PEERS};
+use crate::routing::routing::{RoutingTableView, DELETE_PEERS_AFTER_TIME};
 use crate::routing::routing_table_actor::{
     Prune, RoutingTableActor, RoutingTableMessages, RoutingTableMessagesResponse,
 };
@@ -219,10 +219,6 @@ impl PeerManagerActor {
         view_client_addr: Recipient<NetworkViewClientMessages>,
         routing_table_addr: Addr<RoutingTableActor>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        if config.max_num_peers as usize > MAX_NUM_PEERS {
-            panic!("Exceeded max peer limit: {}", MAX_NUM_PEERS);
-        }
-
         let peer_store = PeerStore::new(store.clone(), &config.boot_nodes)?;
         debug!(target: "network", "Found known peers: {} (boot nodes={})", peer_store.len(), config.boot_nodes.len());
         debug!(target: "network", "Blacklist: {:?}", config.blacklist);

--- a/chain/network/src/routing/routing.rs
+++ b/chain/network/src/routing/routing.rs
@@ -1,7 +1,7 @@
 use crate::network_protocol::Edge;
 use crate::routing::route_back_cache::RouteBackCache;
 use lru::LruCache;
-use near_network_primitives::types::{PeerIdOrHash, Ping, Pong};
+use near_network_primitives::types::{PeerIdOrHash, Ping, Pong, MAX_NUM_PEERS};
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::{AnnounceAccount, PeerId};
 use near_primitives::time::Clock;
@@ -22,8 +22,6 @@ const ROUND_ROBIN_NONCE_CACHE_SIZE: usize = 10_000;
 /// seconds will be removed from cache and persisted in disk.
 pub const SAVE_PEERS_MAX_TIME: Duration = Duration::from_secs(7_200);
 pub const DELETE_PEERS_AFTER_TIME: Duration = Duration::from_secs(3_600);
-/// Graph implementation supports up to 128 peers.
-pub const MAX_NUM_PEERS: usize = 128;
 
 pub struct RoutingTableView {
     /// PeerId associated with this instance.


### PR DESCRIPTION
`neard` binary reads a `client config` which contains `max_num_peers` peers parameter.
Internally `near-network` disallows having higher number of peers than `128`. 

It's a good idea to add this error to `CLI` directly in `verify()` method of `NetworkConfig`.