### PR TITLE
feat: Don't hide errors with parsing `network config`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2995,6 +2995,7 @@ name = "near-network-primitives"
 version = "0.0.0"
 dependencies = [
  "actix",
+ "anyhow",
  "borsh 0.9.1",
  "chrono",
  "deepsize",

--- a/chain/indexer/src/lib.rs
+++ b/chain/indexer/src/lib.rs
@@ -1,8 +1,8 @@
 #![doc = include_str!("../README.md")]
 
+use anyhow::Context;
 use tokio::sync::mpsc;
 
-use anyhow::Result;
 pub use near_primitives;
 use near_primitives::types::Gas;
 pub use nearcore::{get_default_home, init_configs, NearConfig};
@@ -89,7 +89,7 @@ pub struct Indexer {
 
 impl Indexer {
     /// Initialize Indexer by configuring `nearcore`
-    pub fn new(indexer_config: IndexerConfig) -> Self {
+    pub fn new(indexer_config: IndexerConfig) -> Result<Self, anyhow::Error> {
         tracing::info!(
             target: INDEXER,
             "Load config from {}...",
@@ -107,8 +107,9 @@ impl Indexer {
             indexer_config.home_dir.join("config.json").display()
         );
         let nearcore::NearNode { client, view_client, .. } =
-            nearcore::start_with_config(&indexer_config.home_dir, near_config.clone());
-        Self { view_client, client, near_config, indexer_config }
+            nearcore::start_with_config(&indexer_config.home_dir, near_config.clone())
+                .with_context(|| "start_with_config")?;
+        Ok(Self { view_client, client, near_config, indexer_config })
     }
 
     /// Boots up `near_indexer::streamer`, so it monitors the new blocks with chunks, transactions, receipts, and execution outcomes inside. The returned stream handler should be drained and handled on the user side.
@@ -138,7 +139,10 @@ impl Indexer {
 
 /// Function that initializes configs for the node which
 /// accepts `InitConfigWrapper` and calls original `init_configs` from `neard`
-pub fn indexer_init_configs(dir: &std::path::PathBuf, params: InitConfigArgs) -> Result<()> {
+pub fn indexer_init_configs(
+    dir: &std::path::PathBuf,
+    params: InitConfigArgs,
+) -> Result<(), anyhow::Error> {
     init_configs(
         dir,
         params.chain_id.as_deref(),

--- a/chain/network-primitives/Cargo.toml
+++ b/chain/network-primitives/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/near/nearcore"
 description = "This crate hosts NEAR network-related primitive types"
 
 [dependencies]
+anyhow = "1.0.51"
 actix = "=0.11.0-beta.2"
 borsh = "0.9"
 chrono = { version = "0.4.4", features = ["serde"] }

--- a/chain/network-primitives/src/config.rs
+++ b/chain/network-primitives/src/config.rs
@@ -82,7 +82,7 @@ impl NetworkConfig {
             handshake_timeout: Duration::from_secs(60),
             reconnect_delay: Duration::from_secs(60),
             bootstrap_peers_period: Duration::from_millis(100),
-            max_num_peers: 10,
+            max_num_peers: 40,
             minimum_outbound_peers: 5,
             ideal_connections_lo: 30,
             ideal_connections_hi: 35,
@@ -104,26 +104,28 @@ impl NetworkConfig {
         }
     }
 
-    pub fn verify(&self) {
-        if self.ideal_connections_lo + 1 >= self.ideal_connections_hi {
-            tracing::error!(target: "network",
-            "Invalid ideal_connections values. lo({}) > hi({}).",
-            self.ideal_connections_lo, self.ideal_connections_hi);
+    pub fn verify(&self) -> Result<(), anyhow::Error> {
+        if !(self.ideal_connections_lo <= self.ideal_connections_hi) {
+            anyhow::bail!(
+                "Invalid ideal_connections values. lo({}) > hi({}).",
+                self.ideal_connections_lo,
+                self.ideal_connections_hi
+            );
         }
 
-        if self.ideal_connections_hi >= self.max_num_peers {
-            tracing::error!(target: "network",
+        if !(self.ideal_connections_hi < self.max_num_peers) {
+            anyhow::bail!(
                 "max_num_peers({}) is below ideal_connections_hi({}) which may lead to connection saturation and declining new connections.",
                 self.max_num_peers, self.ideal_connections_hi
             );
         }
 
         if self.outbound_disabled {
-            tracing::warn!(target: "network", "Outbound connections are disabled.");
+            anyhow::bail!("Outbound connections are disabled.");
         }
 
-        if self.safe_set_size <= self.minimum_outbound_peers {
-            tracing::error!(target: "network",
+        if !(self.safe_set_size > self.minimum_outbound_peers) {
+            anyhow::bail!(
                 "safe_set_size({}) must be larger than minimum_outbound_peers({}).",
                 self.safe_set_size,
                 self.minimum_outbound_peers
@@ -131,12 +133,12 @@ impl NetworkConfig {
         }
 
         if UPDATE_INTERVAL_LAST_TIME_RECEIVED_MESSAGE * 2 > self.peer_recent_time_window {
-            tracing::error!(
-                target: "network",
+            anyhow::bail!(
                 "Very short peer_recent_time_window({}). it should be at least twice update_interval_last_time_received_message({}).",
                 self.peer_recent_time_window.as_secs(), UPDATE_INTERVAL_LAST_TIME_RECEIVED_MESSAGE.as_secs()
             );
         }
+        Ok(())
     }
 }
 
@@ -208,3 +210,34 @@ impl FromStr for PatternAddr {
 /// but wait some "small" timeout between updates to avoid a lot of messages between
 /// Peer and PeerManager.
 pub const UPDATE_INTERVAL_LAST_TIME_RECEIVED_MESSAGE: Duration = Duration::from_secs(60);
+
+#[cfg(test)]
+mod test {
+    use crate::types::{NetworkConfig, UPDATE_INTERVAL_LAST_TIME_RECEIVED_MESSAGE};
+
+    #[test]
+    fn test_network_config() {
+        let nc = NetworkConfig::from_seed("123", 213);
+        assert!(nc.verify().is_ok());
+
+        let mut nc = NetworkConfig::from_seed("123", 213);
+        nc.ideal_connections_lo = nc.ideal_connections_hi + 1;
+        let res = nc.verify();
+        assert!(res.is_err(), "{:?}", res);
+
+        let mut nc = NetworkConfig::from_seed("123", 213);
+        nc.ideal_connections_hi = nc.max_num_peers;
+        let res = nc.verify();
+        assert!(res.is_err(), "{:?}", res);
+
+        let mut nc = NetworkConfig::from_seed("123", 213);
+        nc.safe_set_size = nc.minimum_outbound_peers;
+        let res = nc.verify();
+        assert!(res.is_err(), "{:?}", res);
+
+        let mut nc = NetworkConfig::from_seed("123", 213);
+        nc.peer_recent_time_window = UPDATE_INTERVAL_LAST_TIME_RECEIVED_MESSAGE;
+        let res = nc.verify();
+        assert!(res.is_err(), "{:?}", res);
+    }
+}

--- a/integration-tests/src/node/thread_node.rs
+++ b/integration-tests/src/node/thread_node.rs
@@ -25,7 +25,7 @@ pub struct ThreadNode {
 
 fn start_thread(config: NearConfig, path: PathBuf) -> ShutdownableThread {
     ShutdownableThread::start("test", move || {
-        start_with_config(&path, config);
+        start_with_config(&path, config).expect("start_with_config");
     })
 }
 

--- a/integration-tests/src/tests/nearcore/node_cluster.rs
+++ b/integration-tests/src/tests/nearcore/node_cluster.rs
@@ -59,7 +59,7 @@ pub fn start_nodes(
     let mut res = vec![];
     for (i, near_config) in near_configs.into_iter().enumerate() {
         let nearcore::NearNode { client, view_client, arbiters, .. } =
-            start_with_config(dirs[i].path(), near_config);
+            start_with_config(dirs[i].path(), near_config).expect("start_with_config");
         res.push((client, view_client, arbiters))
     }
     (genesis, rpc_addrs, res)

--- a/integration-tests/src/tests/nearcore/stake_nodes.rs
+++ b/integration-tests/src/tests/nearcore/stake_nodes.rs
@@ -77,7 +77,7 @@ fn init_test_staking(
         .map(|(i, config)| {
             let genesis_hash = genesis_hash(&config.genesis);
             let nearcore::NearNode { client, view_client, .. } =
-                start_with_config(paths[i], config.clone());
+                start_with_config(paths[i], config.clone()).expect("start_with_config");
             let account_id = format!("near.{}", i).parse::<AccountId>().unwrap();
             let signer = Arc::new(InMemorySigner::from_seed(
                 account_id.clone(),

--- a/integration-tests/src/tests/nearcore/sync_nodes.rs
+++ b/integration-tests/src/tests/nearcore/sync_nodes.rs
@@ -134,7 +134,8 @@ fn sync_nodes() {
 
         run_actix(async move {
             let dir1 = tempfile::Builder::new().prefix("sync_nodes_1").tempdir().unwrap();
-            let nearcore::NearNode { client: client1, .. } = start_with_config(dir1.path(), near1);
+            let nearcore::NearNode { client: client1, .. } =
+                start_with_config(dir1.path(), near1).expect("start_with_config");
 
             let signer = InMemoryValidatorSigner::from_seed(
                 "other".parse().unwrap(),
@@ -146,7 +147,7 @@ fn sync_nodes() {
 
             let dir2 = tempfile::Builder::new().prefix("sync_nodes_2").tempdir().unwrap();
             let nearcore::NearNode { view_client: view_client2, .. } =
-                start_with_config(dir2.path(), near2);
+                start_with_config(dir2.path(), near2).expect("start_with_config");
 
             WaitOrTimeoutActor::new(
                 Box::new(move |_ctx| {
@@ -178,11 +179,12 @@ fn sync_after_sync_nodes() {
 
         run_actix(async move {
             let dir1 = tempfile::Builder::new().prefix("sync_nodes_1").tempdir().unwrap();
-            let nearcore::NearNode { client: client1, .. } = start_with_config(dir1.path(), near1);
+            let nearcore::NearNode { client: client1, .. } =
+                start_with_config(dir1.path(), near1).expect("start_with_config");
 
             let dir2 = tempfile::Builder::new().prefix("sync_nodes_2").tempdir().unwrap();
             let nearcore::NearNode { view_client: view_client2, .. } =
-                start_with_config(dir2.path(), near2);
+                start_with_config(dir2.path(), near2).expect("start_with_config");
 
             let signer = InMemoryValidatorSigner::from_seed(
                 "other".parse().unwrap(),
@@ -260,7 +262,7 @@ fn sync_state_stake_change() {
             let dir2 =
                 tempfile::Builder::new().prefix("sync_state_stake_change_2").tempdir().unwrap();
             let nearcore::NearNode { client: client1, view_client: view_client1, .. } =
-                start_with_config(dir1.path(), near1.clone());
+                start_with_config(dir1.path(), near1.clone()).expect("start_with_config");
 
             let genesis_hash = *genesis_block(&genesis).hash();
             let signer = Arc::new(InMemorySigner::from_seed(
@@ -302,7 +304,8 @@ fn sync_state_stake_change() {
                         if !started_copy.load(Ordering::SeqCst) && latest_height > 10 {
                             started_copy.store(true, Ordering::SeqCst);
                             let nearcore::NearNode { view_client: view_client2, arbiters, .. } =
-                                start_with_config(&dir2_path_copy, near2_copy);
+                                start_with_config(&dir2_path_copy, near2_copy)
+                                    .expect("start_with_config");
                             *arbiters_holder2.write().unwrap() = arbiters;
 
                             WaitOrTimeoutActor::new(

--- a/integration-tests/src/tests/nearcore/sync_state_nodes.rs
+++ b/integration-tests/src/tests/nearcore/sync_state_nodes.rs
@@ -29,7 +29,7 @@ fn sync_state_nodes() {
         run_actix(async move {
             let dir1 = tempfile::Builder::new().prefix("sync_nodes_1").tempdir().unwrap();
             let nearcore::NearNode { view_client: view_client1, .. } =
-                start_with_config(dir1.path(), near1);
+                start_with_config(dir1.path(), near1).expect("start_with_config");
 
             let view_client2_holder = Arc::new(RwLock::new(None));
             let arbiters_holder = Arc::new(RwLock::new(vec![]));
@@ -66,7 +66,8 @@ fn sync_state_nodes() {
                                             view_client: view_client2,
                                             arbiters,
                                             ..
-                                        } = start_with_config(dir2.path(), near2);
+                                        } = start_with_config(dir2.path(), near2)
+                                            .expect("start_with_config");
                                         *view_client2_holder2 = Some(view_client2);
                                         *arbiters_holder2 = arbiters;
                                     }
@@ -157,13 +158,13 @@ fn sync_state_nodes_multishard() {
 
             let dir1 = tempfile::Builder::new().prefix("sync_nodes_1").tempdir().unwrap();
             let nearcore::NearNode { view_client: view_client1, .. } =
-                start_with_config(dir1.path(), near1);
+                start_with_config(dir1.path(), near1).expect("start_with_config");
 
             let dir3 = tempfile::Builder::new().prefix("sync_nodes_3").tempdir().unwrap();
-            start_with_config(dir3.path(), near3);
+            start_with_config(dir3.path(), near3).expect("start_with_config");
 
             let dir4 = tempfile::Builder::new().prefix("sync_nodes_4").tempdir().unwrap();
-            start_with_config(dir4.path(), near4);
+            start_with_config(dir4.path(), near4).expect("start_with_config");
 
             let view_client2_holder = Arc::new(RwLock::new(None));
             let arbiter_holder = Arc::new(RwLock::new(vec![]));
@@ -206,7 +207,8 @@ fn sync_state_nodes_multishard() {
                                             view_client: view_client2,
                                             arbiters,
                                             ..
-                                        } = start_with_config(dir2.path(), near2);
+                                        } = start_with_config(dir2.path(), near2)
+                                            .expect("start_with_config");
                                         *view_client2_holder2 = Some(view_client2);
                                         *arbiter_holder2 = arbiters;
                                     }
@@ -281,7 +283,7 @@ fn sync_empty_state() {
 
             let dir1 = tempfile::Builder::new().prefix("sync_nodes_1").tempdir().unwrap();
             let nearcore::NearNode { view_client: view_client1, .. } =
-                start_with_config(dir1.path(), near1);
+                start_with_config(dir1.path(), near1).expect("start_with_config");
             let dir2 = Arc::new(tempfile::Builder::new().prefix("sync_nodes_2").tempdir().unwrap());
 
             let view_client2_holder = Arc::new(RwLock::new(None));
@@ -325,7 +327,8 @@ fn sync_empty_state() {
                                             view_client: view_client2,
                                             arbiters,
                                             ..
-                                        } = start_with_config(dir2.path(), near2);
+                                        } = start_with_config(dir2.path(), near2)
+                                            .expect("start_with_config");
                                         *view_client2_holder2 = Some(view_client2);
                                         *arbiters_holder2 = arbiters;
                                     }

--- a/nearcore/Cargo.toml
+++ b/nearcore/Cargo.toml
@@ -8,6 +8,7 @@ rust-version = "1.56.0"
 edition = "2021"
 
 [dependencies]
+anyhow = "1.0.51"
 awc = "3.0.0-beta.5"
 actix = "=0.11.0-beta.2" # Pinned the version to avoid compilation errors
 actix_derive = "=0.6.0-beta.1" # Pinned dependency in addition to actix dependecy (remove this line once the pinning is not needed)
@@ -33,7 +34,6 @@ num-rational = { version = "0.3", features = ["serde"] }
 near-rust-allocator-proxy = { version = "0.3.0", optional = true }
 lazy-static-include = "3"
 tempfile = "3"
-anyhow = "1.0.51"
 indicatif = "0.15.0"
 
 near-crypto = { path = "../core/crypto" }

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -351,7 +351,7 @@ impl RunCmd {
         let sys = actix::System::new();
         sys.block_on(async move {
             let nearcore::NearNode { rpc_servers, .. } =
-                nearcore::start_with_config(home_dir, near_config);
+                nearcore::start_with_config(home_dir, near_config).expect("start_with_config");
 
             let sig = if cfg!(unix) {
                 use tokio::signal::unix::{signal, SignalKind};

--- a/tools/indexer/example/src/main.rs
+++ b/tools/indexer/example/src/main.rs
@@ -276,7 +276,7 @@ fn main() -> Result<()> {
             };
             let system = actix::System::new();
             system.block_on(async move {
-                let indexer = near_indexer::Indexer::new(indexer_config);
+                let indexer = near_indexer::Indexer::new(indexer_config).expect("Indexer::new()");
                 let stream = indexer.streamer();
                 actix::spawn(listen_blocks(stream));
             });


### PR DESCRIPTION
`client config` contains a sections for `near-network` called `NearNetworkConfig`.

In function `validate()` of `NearNetworkConfig` we verify all argument. However, if any argument is invalid, we will print an error an continue running an normal. 

The proper solution is to, throw an error, and make let the caller know, that the `network_config` is invalid. Btw, we don't check whenever the number of peers allowed is to high. See https://github.com/near/nearcore/pull/5703