### PR TITLE
fix: increase trie cache size

### DIFF
--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -118,6 +118,10 @@ impl TrieStorage for TrieMemoryPartialStorage {
 }
 
 /// Maximum number of cache entries.
+/// It was chosen to fit into RAM well. RAM spend on trie cache should not exceed
+/// 50_000 * 4 (number of shards) * TRIE_LIMIT_CACHED_VALUE_SIZE = 800 MB.
+/// In our tests on a single shard, it barely occupied 40 MB, which is dominated by state cache size
+/// with 512 MB limit. The total RAM usage for a single shard was 1 GB.
 #[cfg(not(feature = "no_cache"))]
 const TRIE_MAX_CACHE_SIZE: usize = 50000;
 

--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -119,14 +119,14 @@ impl TrieStorage for TrieMemoryPartialStorage {
 
 /// Maximum number of cache entries.
 #[cfg(not(feature = "no_cache"))]
-const TRIE_MAX_CACHE_SIZE: usize = 100000;
+const TRIE_MAX_CACHE_SIZE: usize = 50000;
 
 #[cfg(feature = "no_cache")]
 const TRIE_MAX_CACHE_SIZE: usize = 1;
 
 /// Values above this size (in bytes) are never cached.
 /// Note that Trie inner nodes are always smaller than this.
-const TRIE_LIMIT_CACHED_VALUE_SIZE: usize = 1000;
+const TRIE_LIMIT_CACHED_VALUE_SIZE: usize = 4000;
 
 pub struct TrieCachingStorage {
     pub(crate) store: Arc<Store>,

--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -119,14 +119,14 @@ impl TrieStorage for TrieMemoryPartialStorage {
 
 /// Maximum number of cache entries.
 #[cfg(not(feature = "no_cache"))]
-const TRIE_MAX_CACHE_SIZE: usize = 10000;
+const TRIE_MAX_CACHE_SIZE: usize = 100000;
 
 #[cfg(feature = "no_cache")]
 const TRIE_MAX_CACHE_SIZE: usize = 1;
 
 /// Values above this size (in bytes) are never cached.
 /// Note that Trie inner nodes are always smaller than this.
-const TRIE_LIMIT_CACHED_VALUE_SIZE: usize = 4000;
+const TRIE_LIMIT_CACHED_VALUE_SIZE: usize = 1000;
 
 pub struct TrieCachingStorage {
     pub(crate) store: Arc<Store>,


### PR DESCRIPTION
Increase trie cache size to mitigate receipts undercharging issue.

## Validity

We can increase cache size to 50_000, so the theoretical occupied size is 50_000 * 4 (num_shards) * 4_000 = 800 MB.

In reality, `/usr/bin/time -v ` shows **520 -> 1070 MB** RAM growth which seem to be caused by https://github.com/near/nearcore/pull/5212. This change have an impact like 30 MB.
I've additionally checked that cache is full on my runs.

## Speedup

On the sample of 30 receipts we considered, we have the following characteristics:

```
default settings: summary time = 3.3s, avg undercharging = 101
increase state cache size: summary time = 0.67s, avg undercharging = 21
increase state cache size + trie cache size = 50k: summary time = 0.5s, avg undercharging = 11.5
increase state cache size + trie cache size = 100k + reduce max value size to 1k: summary time = 0.3s, avg undercharging = 6.9
```

For now, let's just increase cache size. On this sample we reduce undercharging 2x and summary execution time 1.3x.

## Testing

* checking that cache is full;
* existing tests,
* estimating `/usr/bin/time -v ./state-viewer apply_range --start_index 54051433 --end_index 54053438 --shard_id 3`