### PR TITLE
feat: trace node counter on receipt processing

### DIFF
--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -205,10 +205,6 @@ impl TouchedNodesCounter {
         self.counter.fetch_add(1, Ordering::SeqCst);
     }
 
-    pub fn reset(&self) {
-        self.counter.store(0, Ordering::SeqCst);
-    }
-
     pub fn get(&self) -> u64 {
         self.counter.load(Ordering::SeqCst)
     }

--- a/runtime/near-vm-logic/src/dependencies.rs
+++ b/runtime/near-vm-logic/src/dependencies.rs
@@ -478,9 +478,6 @@ pub trait External {
     /// Returns amount of touched trie nodes by storage operations
     fn get_touched_nodes_count(&self) -> u64;
 
-    /// Resets amount of touched trie nodes by storage operations
-    fn reset_touched_nodes_counter(&mut self);
-
     /// Returns the validator stake for given account in the current epoch.
     /// If the account is not a validator, returns `None`.
     fn validator_stake(&self, account_id: &AccountId) -> Result<Option<Balance>>;

--- a/runtime/near-vm-logic/src/logic.rs
+++ b/runtime/near-vm-logic/src/logic.rs
@@ -108,7 +108,6 @@ impl<'a> VMLogic<'a> {
         memory: &'a mut dyn MemoryLike,
         current_protocol_version: ProtocolVersion,
     ) -> Self {
-        ext.reset_touched_nodes_counter();
         // Overflow should be checked before calling VMLogic.
         let current_account_balance = context.account_balance + context.attached_deposit;
         let current_storage_usage = context.storage_usage;

--- a/runtime/near-vm-logic/src/mocks/mock_external.rs
+++ b/runtime/near-vm-logic/src/mocks/mock_external.rs
@@ -202,8 +202,6 @@ impl External for MockedExternal {
         0
     }
 
-    fn reset_touched_nodes_counter(&mut self) {}
-
     fn validator_stake(&self, account_id: &AccountId) -> Result<Option<Balance>> {
         Ok(self.validators.get(account_id).cloned())
     }

--- a/runtime/runtime/src/ext.rs
+++ b/runtime/runtime/src/ext.rs
@@ -373,10 +373,6 @@ impl<'a> External for RuntimeExt<'a> {
         self.trie_update.trie.counter.get()
     }
 
-    fn reset_touched_nodes_counter(&mut self) {
-        self.trie_update.trie.counter.reset()
-    }
-
     fn validator_stake(&self, account_id: &AccountId) -> ExtResult<Option<Balance>> {
         self.epoch_info_provider
             .validator_stake(self.epoch_id, self.prev_block_hash, account_id)

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1274,8 +1274,7 @@ impl Runtime {
                                    state_update: &mut TrieUpdate,
                                    total_gas_burnt: &mut Gas|
          -> Result<_, RuntimeError> {
-            let _span = tracing::debug_span!(target: "runtime", "Runtime::process_receipt", receipt_id = %receipt.receipt_id).entered();
-            tracing::debug!(target: "runtime", node_counter = state_update.trie.counter.get());
+            let _span = tracing::debug_span!(target: "runtime", "Runtime::process_receipt", receipt_id = %receipt.receipt_id, node_counter = state_update.trie.counter.get()).entered();
             let result = self.process_receipt(
                 state_update,
                 apply_state,

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1274,7 +1274,7 @@ impl Runtime {
                                    state_update: &mut TrieUpdate,
                                    total_gas_burnt: &mut Gas|
          -> Result<_, RuntimeError> {
-            let _span = tracing::debug_span!(target: "runtime", "Runtime::process_receipt", receipt_id = tracing::field::display(receipt.receipt_id)).entered();
+            let _span = tracing::debug_span!(target: "runtime", "Runtime::process_receipt", receipt_id = %receipt.receipt_id).entered();
             tracing::debug!(target: "runtime", node_counter = state_update.trie.counter.get());
             let result = self.process_receipt(
                 state_update,


### PR DESCRIPTION
We need to track touched nodes quite frequently, this should simplify debugging.

Also disable `ext.reset_touched_nodes_counter()` on `VMLogic` creation. It should not affect the result because only counter differences matter, but it made counter harder to debug.

## Testing

Existing tests.