### PR TITLE
refactor: use `decode_value_with_rc` logic for `RawTrieNodeWithSize`

### DIFF
--- a/core/store/src/db/refcount.rs
+++ b/core/store/src/db/refcount.rs
@@ -78,6 +78,13 @@ pub(crate) fn encode_value_with_rc(data: &[u8], rc: i64) -> Vec<u8> {
     cursor.into_inner()
 }
 
+pub(crate) fn encode_value_with_rc_inplace(
+    data: &mut Vec<u8>,
+    rc: i64,
+) -> Result<(), std::io::Error> {
+    data.write_i64::<LittleEndian>(rc)
+}
+
 impl RocksDB {
     /// ColState has refcounted values.
     /// Merge adds refcounts, zero refcount becomes empty value.

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -14,6 +14,7 @@ use near_primitives::hash::{hash, CryptoHash};
 pub use near_primitives::shard_layout::ShardUId;
 use near_primitives::types::{StateRoot, StateRootNode};
 
+use crate::db::refcount::encode_value_with_rc_inplace;
 use crate::trie::insert_delete::NodesStorage;
 use crate::trie::iterator::TrieIterator;
 use crate::trie::nibble_slice::NibbleSlice;
@@ -384,7 +385,7 @@ impl RawTrieNode {
 impl RawTrieNodeWithSize {
     fn encode_into(&self, out: &mut Vec<u8>) -> Result<(), std::io::Error> {
         self.node.encode_into(out)?;
-        out.write_u64::<LittleEndian>(self.memory_usage)
+        encode_value_with_rc_inplace(out, self.memory_usage as i64)
     }
 
     #[allow(dead_code)]


### PR DESCRIPTION
We have similar logic for decoding/encoding DB key-value pairs and trie nodes, but it is implemented by different code, and I find it confusing.

I propose to unify this logic by reusing `decode_value_with_rc` function which shouldn't give overhead and makes it easier to understand.

The only problem could be that on encoding/decoding `rc` (refcount), we are switching from `u64` to `i64`. But decoding `i64` which was encoded as `u64` is correct because our refcount couldn't exceed `2**62` by absolute value.

There is a separate issue that we don't have strict logic of storing refcounts and handling negative values - at least it is not reflected in the code. But IMO it's better to have the same logic in all places.

## Testing 

Existing tests.