### PR TITLE
feat: record trie cache misses

### DIFF
--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -171,6 +171,7 @@ impl TrieStorage for TrieCachingStorage {
         if let Some(val) = guard.cache_get(hash) {
             Ok(val.clone())
         } else {
+            tracing::debug!(target: "runtime", "trie cache miss", hash = %hash);
             let key = Self::get_key_from_shard_uid_and_hash(self.shard_uid, hash);
             let val = self
                 .store

--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -171,7 +171,7 @@ impl TrieStorage for TrieCachingStorage {
         if let Some(val) = guard.cache_get(hash) {
             Ok(val.clone())
         } else {
-            tracing::debug!(target: "runtime", "trie cache miss", hash = %hash);
+            tracing::debug!(target: "runtime", "trie cache miss for hash {}", hash);
             let key = Self::get_key_from_shard_uid_and_hash(self.shard_uid, hash);
             let val = self
                 .store


### PR DESCRIPTION
We've noticed that storage get time spikes correspond to cache misses, so let's record them in debug logs.

## Testing

Existing tests.