### PR TITLE
re: `near-network` Split private actix types of out `types.rs`

### DIFF
--- a/chain/jsonrpc-adversarial-primitives/src/lib.rs
+++ b/chain/jsonrpc-adversarial-primitives/src/lib.rs
@@ -2,8 +2,7 @@
 use deepsize::DeepSizeOf;
 #[cfg(feature = "ser_de")]
 use near_jsonrpc_primitives::errors::RpcError;
-use near_network::routing::SimpleEdge;
-use near_network::types::Edge;
+use near_network::routing::{Edge, SimpleEdge};
 use near_primitives::network::PeerId;
 #[cfg(feature = "ser_de")]
 use serde::Deserialize;

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -284,7 +284,7 @@ impl JsonRpcHandler {
                     self.peer_manager_addr
                         .send(
                             near_network::types::PeerManagerMessageRequest::StartRoutingTableSync(
-                                near_network::types::StartRoutingTableSync {
+                                near_network::private_actix::StartRoutingTableSync {
                                     peer_id: params.peer_id,
                                 },
                             ),
@@ -299,7 +299,7 @@ impl JsonRpcHandler {
                     let response = self
                         .peer_manager_addr
                         .send(near_network::types::PeerManagerMessageRequest::GetPeerId(
-                            near_network::types::GetPeerId {},
+                            near_network::private_actix::GetPeerId {},
                         ))
                         .await?;
                     Some(

--- a/chain/network/benches/routing_table_actor.rs
+++ b/chain/network/benches/routing_table_actor.rs
@@ -2,15 +2,14 @@
 extern crate bencher;
 
 use bencher::{black_box, Bencher};
-use std::collections::HashMap;
-use std::sync::Arc;
-
 use near_crypto::{KeyType, SecretKey, Signature};
+use near_network::routing::Edge;
 use near_network::test_utils::random_peer_id;
-use near_network::types::Edge;
 use near_network::RoutingTableActor;
 use near_primitives::network::PeerId;
 use near_store::test_utils::create_test_store;
+use std::collections::HashMap;
+use std::sync::Arc;
 
 fn build_graph(depth: usize, size: usize) -> RoutingTableActor {
     let source = random_peer_id();

--- a/chain/network/src/lib.rs
+++ b/chain/network/src/lib.rs
@@ -12,6 +12,10 @@ pub use near_network_primitives::types::PeerInfo;
 mod network_protocol;
 mod peer;
 mod peer_manager;
+#[cfg(feature = "test_features")]
+pub mod private_actix;
+#[cfg(not(feature = "test_features"))]
+pub(crate) mod private_actix;
 pub mod routing;
 pub(crate) mod stats;
 pub mod test_utils;

--- a/chain/network/src/network_protocol.rs
+++ b/chain/network/src/network_protocol.rs
@@ -3,7 +3,7 @@
 /// WARNING WARNING WARNING
 /// WARNING WARNING WARNING
 /// We need to maintain backwards compatibility, all changes to this file needs to be reviews.
-pub use crate::routing::network_protocol::{Edge, PartialEdgeInfo};
+pub use crate::routing::network_protocol::{Edge, EdgeState, PartialEdgeInfo, SimpleEdge};
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_network_primitives::types::{
     PeerChainInfo, PeerChainInfoV2, PeerInfo, RoutedMessage, RoutedMessageBody,

--- a/chain/network/src/peer/codec.rs
+++ b/chain/network/src/peer/codec.rs
@@ -103,8 +103,7 @@ mod test {
         Handshake, HandshakeFailureReason, HandshakeV2, PeerMessage, RoutingTableUpdate,
     };
     use crate::PeerInfo;
-    use borsh::BorshDeserialize;
-    use borsh::BorshSerialize;
+    use borsh::{BorshDeserialize, BorshSerialize};
     use bytes::{BufMut, BytesMut};
     use near_crypto::{KeyType, PublicKey, SecretKey};
     use near_network_primitives::types::{

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -1,21 +1,22 @@
+use crate::network_protocol::{Edge, PartialEdgeInfo};
 use crate::peer::codec::Codec;
 use crate::peer::tracker::Tracker;
 use crate::peer::utils;
-use crate::routing::network_protocol::{Edge, PartialEdgeInfo};
+use crate::private_actix::{
+    PeersRequest, RegisterPeer, RegisterPeerResponse, SendMessage, Unregister,
+};
 use crate::stats::metrics::{self, NetworkMetrics};
 use crate::types::{
     Handshake, HandshakeFailureReason, HandshakeV2, NetworkClientMessages, NetworkClientResponses,
     NetworkRequests, NetworkResponses, PeerManagerMessageRequest, PeerMessage, PeerRequest,
-    PeerResponse, PeersRequest, PeersResponse, RegisterPeer, RegisterPeerResponse, SendMessage,
-    Unregister,
+    PeerResponse, PeersResponse,
 };
 use crate::PeerManagerActor;
 use actix::{
     Actor, ActorContext, ActorFuture, Addr, Arbiter, AsyncContext, Context, ContextFutureSpawner,
     Handler, Recipient, Running, StreamHandler, WrapFuture,
 };
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+use borsh::{BorshDeserialize, BorshSerialize};
 use lru::LruCache;
 use near_crypto::Signature;
 use near_network_primitives::types::{

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -947,7 +947,7 @@ impl PeerManagerActor {
     fn adv_remove_edges_from_routing_table(
         &mut self,
         ctx: &mut Context<Self>,
-        edges: Vec<SimpleEdge>,
+        edges: Vec<crate::network_protocol::SimpleEdge>,
     ) {
         // Create fake edges with no signature for unit test purposes
         let edges: Vec<Edge> = edges

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -7,7 +7,7 @@ use crate::private_actix::{
     Unregister, ValidateEdgeList,
 };
 use crate::routing::edge_validator_actor::EdgeValidatorHelper;
-use crate::routing::network_protocol::{Edge, SimpleEdge};
+use crate::routing::network_protocol::Edge;
 use crate::routing::routing::{RoutingTableView, DELETE_PEERS_AFTER_TIME, MAX_NUM_PEERS};
 use crate::routing::routing_table_actor::{
     Prune, RoutingTableActor, RoutingTableMessages, RoutingTableMessagesResponse,

--- a/chain/network/src/peer_manager/peer_store.rs
+++ b/chain/network/src/peer_manager/peer_store.rs
@@ -162,7 +162,7 @@ impl PeerStore {
         peer_state: &KnownPeerState,
     ) -> Result<(), Box<dyn Error>> {
         let mut store_update = store.store_update();
-        store_update.set_ser(ColPeers, &peer_id, peer_state)?;
+        store_update.set_ser(ColPeers, peer_id, peer_state)?;
         store_update.commit().map_err(|err| err.into())
     }
 
@@ -375,7 +375,7 @@ where
     F: Fn((&PeerId, &KnownPeerState)),
 {
     let peer_store = PeerStore::new(store, &[]).unwrap();
-    peer_store.iter().for_each(|x| f(x));
+    peer_store.iter().for_each(f);
 }
 
 #[cfg(test)]

--- a/chain/network/src/private_actix.rs
+++ b/chain/network/src/private_actix.rs
@@ -1,0 +1,174 @@
+/// This file is contains all types used for communication between `Actors` within this crate.
+/// They are not meant to be used outside.
+use crate::network_protocol::PeerMessage;
+use crate::network_protocol::{Edge, PartialEdgeInfo, SimpleEdge};
+use crate::peer::peer_actor::PeerActor;
+use crate::PeerInfo;
+use actix::dev::{MessageResponse, ResponseChannel};
+use actix::{Actor, Addr, Message};
+use conqueue::QueueSender;
+use near_network_primitives::types::{PeerChainInfoV2, PeerType};
+use near_primitives::network::PeerId;
+use near_primitives::version::ProtocolVersion;
+use near_rate_limiter::ThrottleController;
+use std::collections::HashMap;
+use std::fmt;
+use std::fmt::{Debug, Formatter};
+use std::sync::{Arc, Mutex};
+
+/// Actor message which asks `PeerManagerActor` to register peer.
+/// Returns `RegisterPeerResult` with `Accepted` if connection should be kept
+/// or a reject response otherwise.
+#[derive(Clone, Debug)]
+pub struct RegisterPeer {
+    pub(crate) actor: Addr<PeerActor>,
+    pub(crate) peer_info: PeerInfo,
+    pub(crate) peer_type: PeerType,
+    pub(crate) chain_info: PeerChainInfoV2,
+    /// Edge information from this node.
+    /// If this is None it implies we are outbound connection, so we need to create our
+    /// EdgeInfo part and send it to the other peer.
+    pub(crate) this_edge_info: Option<PartialEdgeInfo>,
+    /// Edge information from other node.
+    pub(crate) other_edge_info: PartialEdgeInfo,
+    /// Protocol version of new peer. May be higher than ours.
+    pub(crate) peer_protocol_version: ProtocolVersion,
+    /// A helper data structure for limiting reading, reporting bandwidth stats.
+    pub(crate) throttle_controller: ThrottleController,
+}
+
+/// Addr<PeerActor> doesn't implement `DeepSizeOf` waiting for `deepsize` > 0.2.0.
+#[cfg(feature = "deepsize_feature")]
+impl deepsize::DeepSizeOf for RegisterPeer {
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        self.peer_info.deep_size_of_children(context)
+            + self.peer_type.deep_size_of_children(context)
+            + self.chain_info.deep_size_of_children(context)
+            + self.this_edge_info.deep_size_of_children(context)
+            + self.other_edge_info.deep_size_of_children(context)
+            + self.peer_protocol_version.deep_size_of_children(context)
+    }
+}
+
+impl Message for RegisterPeer {
+    type Result = RegisterPeerResponse;
+}
+
+#[derive(MessageResponse, Debug)]
+pub enum RegisterPeerResponse {
+    Accept(Option<PartialEdgeInfo>),
+    InvalidNonce(Box<Edge>),
+    Reject,
+}
+
+/// Unregister message from Peer to PeerManager.
+#[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
+#[derive(Message, Debug)]
+#[rtype(result = "()")]
+pub struct Unregister {
+    pub(crate) peer_id: PeerId,
+    pub(crate) peer_type: PeerType,
+    pub(crate) remove_from_peer_store: bool,
+}
+
+/// Requesting peers from peer manager to communicate to a peer.
+#[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
+#[derive(Clone, Debug)]
+pub struct PeersRequest {}
+
+impl Message for PeersRequest {
+    type Result = PeerRequestResult;
+}
+
+#[derive(Debug)]
+pub struct PeerRequestResult {
+    pub peers: Vec<PeerInfo>,
+}
+
+impl<A, M> MessageResponse<A, M> for PeerRequestResult
+where
+    A: Actor,
+    M: Message<Result = PeerRequestResult>,
+{
+    fn handle<R: ResponseChannel<M>>(self, _: &mut A::Context, tx: Option<R>) {
+        if let Some(tx) = tx {
+            tx.send(self)
+        }
+    }
+}
+
+#[derive(Message)]
+#[rtype(result = "()")]
+pub(crate) struct StopMsg {}
+
+#[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
+#[derive(Clone, Debug)]
+#[cfg(feature = "test_features")]
+pub struct StartRoutingTableSync {
+    pub peer_id: PeerId,
+}
+
+#[cfg(feature = "test_features")]
+impl Message for StartRoutingTableSync {
+    type Result = ();
+}
+
+#[cfg(feature = "test_features")]
+#[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
+#[derive(Clone, Debug)]
+pub struct GetPeerId {}
+
+#[cfg(feature = "test_features")]
+impl Message for GetPeerId {
+    type Result = GetPeerIdResult;
+}
+
+#[derive(Message, Clone, Debug)]
+#[rtype(result = "()")]
+pub struct SendMessage {
+    pub(crate) message: PeerMessage,
+}
+
+#[cfg(feature = "test_features")]
+#[derive(MessageResponse, Debug, serde::Serialize)]
+pub struct GetPeerIdResult {
+    pub(crate) peer_id: PeerId,
+}
+
+impl Debug for ValidateEdgeList {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("source_peer_id").finish()
+    }
+}
+
+/// List of `Edges`, which we received from `source_peer_id` gor purpose of validation.
+/// Those are list of edges received through `NetworkRequests::Sync` or `NetworkRequests::IbfMessage`.
+pub struct ValidateEdgeList {
+    /// The list of edges is provided by `source_peer_id`, that peer will be banned
+    ///if any of these edges are invalid.
+    pub(crate) source_peer_id: PeerId,
+    /// List of Edges, which will be sent to `EdgeValidatorActor`.
+    pub(crate) edges: Vec<Edge>,
+    /// A set of edges, which have been verified. This is a cache with all verified edges.
+    /// `EdgeValidatorActor`, and is a source of memory leak.
+    /// TODO(#5254): Simplify this process.
+    pub(crate) edges_info_shared: Arc<Mutex<HashMap<(PeerId, PeerId), u64>>>,
+    /// A concurrent queue. After edge become validated it will be sent from `EdgeValidatorActor` back to
+    /// `PeerManagetActor`, and then send to `RoutingTableActor`. And then `RoutingTableActor`
+    /// will add them.
+    /// TODO(#5254): Simplify this process.
+    pub(crate) sender: QueueSender<Edge>,
+    #[cfg(feature = "test_features")]
+    /// Feature to disable edge validation for purpose of testing.
+    pub(crate) adv_disable_edge_signature_verification: bool,
+}
+
+impl Message for ValidateEdgeList {
+    type Result = bool;
+}
+
+#[derive(MessageResponse, Debug)]
+#[cfg_attr(feature = "test_features", derive(serde::Serialize))]
+pub struct GetRoutingTableResult {
+    pub edges_info: Vec<SimpleEdge>,
+}

--- a/chain/network/src/routing/edge_validator_actor.rs
+++ b/chain/network/src/routing/edge_validator_actor.rs
@@ -1,5 +1,5 @@
-use crate::routing::network_protocol::Edge;
-use crate::types::{StopMsg, ValidateEdgeList};
+use crate::network_protocol::Edge;
+use crate::private_actix::{StopMsg, ValidateEdgeList};
 use actix::{Actor, Handler, SyncContext, System};
 use conqueue::{QueueReceiver, QueueSender};
 use near_performance_metrics_macros::perf;

--- a/chain/network/src/routing/ibf_peer_set.rs
+++ b/chain/network/src/routing/ibf_peer_set.rs
@@ -166,8 +166,7 @@ impl IbfPeerSet {
 
 #[cfg(test)]
 mod test {
-    use crate::routing::ibf_peer_set::ValidIBFLevel;
-    use crate::routing::ibf_peer_set::{IbfPeerSet, SlotMap};
+    use crate::routing::ibf_peer_set::{IbfPeerSet, SlotMap, ValidIBFLevel};
     use crate::routing::ibf_set::IbfSet;
     use crate::routing::network_protocol::{Edge, SimpleEdge};
     use crate::test_utils::random_peer_id;

--- a/chain/network/src/routing/ibf_set.rs
+++ b/chain/network/src/routing/ibf_set.rs
@@ -1,6 +1,5 @@
 use crate::routing::ibf::{Ibf, IbfBox};
-use crate::routing::ibf_peer_set::SlotMapId;
-use crate::routing::ibf_peer_set::{ValidIBFLevel, MAX_IBF_LEVEL, MIN_IBF_LEVEL};
+use crate::routing::ibf_peer_set::{SlotMapId, ValidIBFLevel, MAX_IBF_LEVEL, MIN_IBF_LEVEL};
 use near_stable_hasher::StableHasher;
 use std::collections::HashMap;
 use std::fmt;
@@ -102,8 +101,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::routing::ibf_peer_set::SlotMapId;
-    use crate::routing::ibf_peer_set::ValidIBFLevel;
+    use crate::routing::ibf_peer_set::{SlotMapId, ValidIBFLevel};
     use crate::routing::ibf_set::IbfSet;
 
     #[test]

--- a/chain/network/src/routing/mod.rs
+++ b/chain/network/src/routing/mod.rs
@@ -10,13 +10,13 @@ mod route_back_cache;
 pub(crate) mod routing;
 pub(crate) mod routing_table_actor;
 
+pub use crate::network_protocol::{Edge, EdgeState, PartialEdgeInfo, SimpleEdge};
+#[cfg(feature = "test_features")]
+pub use crate::private_actix::GetRoutingTableResult;
 #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
 pub use crate::routing::ibf_peer_set::SlotMapId;
 #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
 pub use crate::routing::ibf_set::IbfSet;
-pub use crate::routing::network_protocol::{EdgeState, SimpleEdge};
-#[cfg(feature = "test_features")]
-pub use crate::routing::routing::GetRoutingTableResult;
 pub use crate::routing::routing::{
     Graph, RoutingTableView, DELETE_PEERS_AFTER_TIME, SAVE_PEERS_MAX_TIME,
 };

--- a/chain/network/src/routing/routing.rs
+++ b/chain/network/src/routing/routing.rs
@@ -1,8 +1,5 @@
-use crate::routing::network_protocol::{Edge, SimpleEdge};
+use crate::network_protocol::Edge;
 use crate::routing::route_back_cache::RouteBackCache;
-use crate::PeerInfo;
-use actix::dev::{MessageResponse, ResponseChannel};
-use actix::{Actor, Message};
 use lru::LruCache;
 use near_network_primitives::types::{PeerIdOrHash, Ping, Pong};
 use near_primitives::hash::CryptoHash;
@@ -27,29 +24,6 @@ pub const SAVE_PEERS_MAX_TIME: Duration = Duration::from_secs(7_200);
 pub const DELETE_PEERS_AFTER_TIME: Duration = Duration::from_secs(3_600);
 /// Graph implementation supports up to 128 peers.
 pub const MAX_NUM_PEERS: usize = 128;
-
-#[derive(Debug)]
-pub struct PeerRequestResult {
-    pub peers: Vec<PeerInfo>,
-}
-
-impl<A, M> MessageResponse<A, M> for PeerRequestResult
-where
-    A: Actor,
-    M: Message<Result = PeerRequestResult>,
-{
-    fn handle<R: ResponseChannel<M>>(self, _: &mut A::Context, tx: Option<R>) {
-        if let Some(tx) = tx {
-            tx.send(self)
-        }
-    }
-}
-
-#[derive(MessageResponse, Debug)]
-#[cfg_attr(feature = "test_features", derive(serde::Serialize))]
-pub struct GetRoutingTableResult {
-    pub edges_info: Vec<SimpleEdge>,
-}
 
 pub struct RoutingTableView {
     /// PeerId associated with this instance.

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -1,8 +1,8 @@
+use crate::network_protocol::{Edge, EdgeState};
+use crate::private_actix::{StopMsg, ValidateEdgeList};
 use crate::routing::edge_validator_actor::EdgeValidatorActor;
-use crate::routing::network_protocol::{Edge, EdgeState};
 use crate::routing::routing::{Graph, SAVE_PEERS_MAX_TIME};
 use crate::stats::metrics;
-use crate::types::{StopMsg, ValidateEdgeList};
 use actix::dev::MessageResponse;
 use actix::{
     Actor, ActorFuture, Addr, Context, ContextFutureSpawner, Handler, Message, Running,

--- a/chain/network/src/test_utils.rs
+++ b/chain/network/src/test_utils.rs
@@ -2,8 +2,7 @@ use crate::types::{
     NetworkInfo, NetworkResponses, PeerManagerAdapter, PeerManagerMessageRequest,
     PeerManagerMessageResponse,
 };
-use crate::PeerInfo;
-use crate::PeerManagerActor;
+use crate::{PeerInfo, PeerManagerActor};
 use actix::{Actor, ActorContext, Context, Handler, MailboxError, Message};
 use futures::future::BoxFuture;
 use futures::{future, FutureExt};

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -1,10 +1,19 @@
-use crate::peer::peer_actor::PeerActor;
-use crate::routing::network_protocol::SimpleEdge;
-use crate::routing::routing::{PeerRequestResult, RoutingTableInfo};
+/// Type that belong to the network protocol.
+pub use crate::network_protocol::{
+    Edge, Handshake, HandshakeFailureReason, HandshakeV2, PartialEdgeInfo, PeerMessage,
+    RoutingTableUpdate, SimpleEdge,
+};
+#[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
+pub use crate::network_protocol::{PartialSync, RoutingState, RoutingSyncV2, RoutingVersion2};
+#[cfg(feature = "test_features")]
+use crate::private_actix::{GetPeerId, GetPeerIdResult, StartRoutingTableSync};
+use crate::private_actix::{
+    PeerRequestResult, PeersRequest, RegisterPeer, RegisterPeerResponse, Unregister,
+};
+use crate::routing::routing::RoutingTableInfo;
 use crate::PeerInfo;
 use actix::dev::{MessageResponse, ResponseChannel};
-use actix::{Actor, Addr, MailboxError, Message, Recipient};
-use conqueue::QueueSender;
+use actix::{Actor, MailboxError, Message, Recipient};
 #[cfg(feature = "deepsize_feature")]
 use deepsize::DeepSizeOf;
 use futures::future::BoxFuture;
@@ -12,8 +21,8 @@ use futures::FutureExt;
 use near_network_primitives::types::{
     AccountIdOrPeerTrackingShard, AccountOrPeerIdOrHash, Ban, InboundTcpConnect, KnownProducer,
     OutboundTcpConnect, PartialEncodedChunkForwardMsg, PartialEncodedChunkRequestMsg,
-    PartialEncodedChunkResponseMsg, PeerChainInfoV2, PeerType, Ping, Pong, ReasonForBan,
-    RoutedMessageBody, RoutedMessageFrom, StateResponseInfo,
+    PartialEncodedChunkResponseMsg, PeerChainInfoV2, Ping, Pong, ReasonForBan, RoutedMessageBody,
+    RoutedMessageFrom, StateResponseInfo,
 };
 use near_primitives::block::{Approval, ApprovalMessage, Block, BlockHeader};
 use near_primitives::challenge::Challenge;
@@ -25,96 +34,11 @@ use near_primitives::syncing::{EpochSyncFinalizationResponse, EpochSyncResponse}
 use near_primitives::time::Instant;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{AccountId, BlockReference, EpochId, ShardId};
-use near_primitives::version::ProtocolVersion;
 use near_primitives::views::QueryRequest;
-use near_rate_limiter::ThrottleController;
 use std::collections::HashMap;
-use std::fmt;
-use std::fmt::{Debug, Formatter};
-use std::sync::{Arc, Mutex, RwLock};
+use std::fmt::Debug;
+use std::sync::RwLock;
 use strum::AsStaticStr;
-
-/// Type that belong to the network protocol.
-pub use crate::network_protocol::{
-    Edge, Handshake, HandshakeFailureReason, HandshakeV2, PartialEdgeInfo, PeerMessage,
-    RoutingTableUpdate,
-};
-#[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
-pub use crate::network_protocol::{PartialSync, RoutingState, RoutingSyncV2, RoutingVersion2};
-
-#[derive(Message, Clone, Debug)]
-#[rtype(result = "()")]
-pub struct SendMessage {
-    pub(crate) message: PeerMessage,
-}
-
-/// Actor message which asks `PeerManagerActor` to register peer.
-/// Returns `RegisterPeerResult` with `Accepted` if connection should be kept
-/// or a reject response otherwise.
-#[derive(Clone, Debug)]
-pub struct RegisterPeer {
-    pub(crate) actor: Addr<PeerActor>,
-    pub(crate) peer_info: PeerInfo,
-    pub(crate) peer_type: PeerType,
-    pub(crate) chain_info: PeerChainInfoV2,
-    /// Edge information from this node.
-    /// If this is None it implies we are outbound connection, so we need to create our
-    /// EdgeInfo part and send it to the other peer.
-    pub(crate) this_edge_info: Option<PartialEdgeInfo>,
-    /// Edge information from other node.
-    pub(crate) other_edge_info: PartialEdgeInfo,
-    /// Protocol version of new peer. May be higher than ours.
-    pub(crate) peer_protocol_version: ProtocolVersion,
-    /// A helper data structure for limiting reading, reporting bandwidth stats.
-    pub(crate) throttle_controller: ThrottleController,
-}
-
-/// Addr<PeerActor> doesn't implement `DeepSizeOf` waiting for `deepsize` > 0.2.0.
-#[cfg(feature = "deepsize_feature")]
-impl deepsize::DeepSizeOf for RegisterPeer {
-    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
-        self.peer_info.deep_size_of_children(context)
-            + self.peer_type.deep_size_of_children(context)
-            + self.chain_info.deep_size_of_children(context)
-            + self.this_edge_info.deep_size_of_children(context)
-            + self.other_edge_info.deep_size_of_children(context)
-            + self.peer_protocol_version.deep_size_of_children(context)
-    }
-}
-
-impl Message for RegisterPeer {
-    type Result = RegisterPeerResponse;
-}
-
-#[derive(MessageResponse, Debug)]
-pub enum RegisterPeerResponse {
-    Accept(Option<PartialEdgeInfo>),
-    InvalidNonce(Box<Edge>),
-    Reject,
-}
-
-#[cfg(feature = "test_features")]
-#[cfg_attr(feature = "deepsize_feature", derive(DeepSizeOf))]
-#[derive(Clone, Debug)]
-pub struct GetPeerId {}
-
-#[cfg(feature = "test_features")]
-impl Message for GetPeerId {
-    type Result = GetPeerIdResult;
-}
-
-#[cfg(feature = "test_features")]
-#[derive(MessageResponse, Debug, serde::Serialize)]
-pub struct GetPeerIdResult {
-    pub(crate) peer_id: PeerId,
-}
-
-#[cfg_attr(feature = "deepsize_feature", derive(DeepSizeOf))]
-#[derive(Clone, Debug)]
-#[cfg(feature = "test_features")]
-pub struct StartRoutingTableSync {
-    pub peer_id: PeerId,
-}
 
 #[cfg_attr(feature = "deepsize_feature", derive(DeepSizeOf))]
 #[derive(Clone, Debug)]
@@ -130,25 +54,6 @@ pub struct SetAdvOptions {
 impl Message for SetAdvOptions {
     type Result = ();
 }
-
-#[cfg(feature = "test_features")]
-impl Message for StartRoutingTableSync {
-    type Result = ();
-}
-
-/// Unregister message from Peer to PeerManager.
-#[cfg_attr(feature = "deepsize_feature", derive(DeepSizeOf))]
-#[derive(Message, Debug)]
-#[rtype(result = "()")]
-pub struct Unregister {
-    pub(crate) peer_id: PeerId,
-    pub(crate) peer_type: PeerType,
-    pub(crate) remove_from_peer_store: bool,
-}
-
-#[derive(Message)]
-#[rtype(result = "()")]
-pub(crate) struct StopMsg {}
 
 /// Message from peer to peer manager
 #[derive(strum::AsRefStr, Clone, Debug)]
@@ -181,15 +86,6 @@ impl Message for PeerRequest {
 pub enum PeerResponse {
     NoResponse,
     UpdatedEdge(PartialEdgeInfo),
-}
-
-/// Requesting peers from peer manager to communicate to a peer.
-#[cfg_attr(feature = "deepsize_feature", derive(DeepSizeOf))]
-#[derive(Clone, Debug)]
-pub struct PeersRequest {}
-
-impl Message for PeersRequest {
-    type Result = PeerRequestResult;
 }
 
 /// Received new peers from another peer.
@@ -326,6 +222,12 @@ impl PeerManagerMessageResponse {
     }
 }
 
+impl From<NetworkResponses> for PeerManagerMessageResponse {
+    fn from(msg: NetworkResponses) -> Self {
+        PeerManagerMessageResponse::NetworkResponses(msg)
+    }
+}
+
 // TODO(#1313): Use Box
 #[cfg_attr(feature = "deepsize_feature", derive(DeepSizeOf))]
 #[derive(Clone, strum::AsRefStr, Debug, Eq, PartialEq)]
@@ -446,38 +348,6 @@ pub enum NetworkRequests {
     },
 }
 
-/// List of `Edges`, which we received from `source_peer_id` gor purpose of validation.
-/// Those are list of edges received through `NetworkRequests::Sync` or `NetworkRequests::IbfMessage`.
-pub struct ValidateEdgeList {
-    /// The list of edges is provided by `source_peer_id`, that peer will be banned
-    ///if any of these edges are invalid.
-    pub(crate) source_peer_id: PeerId,
-    /// List of Edges, which will be sent to `EdgeValidatorActor`.
-    pub(crate) edges: Vec<Edge>,
-    /// A set of edges, which have been verified. This is a cache with all verified edges.
-    /// `EdgeValidatorActor`, and is a source of memory leak.
-    /// TODO(#5254): Simplify this process.
-    pub(crate) edges_info_shared: Arc<Mutex<HashMap<(PeerId, PeerId), u64>>>,
-    /// A concurrent queue. After edge become validated it will be sent from `EdgeValidatorActor` back to
-    /// `PeerManagetActor`, and then send to `RoutingTableActor`. And then `RoutingTableActor`
-    /// will add them.
-    /// TODO(#5254): Simplify this process.
-    pub(crate) sender: QueueSender<Edge>,
-    #[cfg(feature = "test_features")]
-    /// Feature to disable edge validation for purpose of testing.
-    pub(crate) adv_disable_edge_signature_verification: bool,
-}
-
-impl Debug for ValidateEdgeList {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.debug_struct("source_peer_id").finish()
-    }
-}
-
-impl Message for ValidateEdgeList {
-    type Result = bool;
-}
-
 /// Combines peer address info, chain and edge information.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct FullPeerInfo {
@@ -519,12 +389,6 @@ pub enum NetworkResponses {
     BanPeer(ReasonForBan),
     EdgeUpdate(Box<Edge>),
     RouteNotFound,
-}
-
-impl From<NetworkResponses> for PeerManagerMessageResponse {
-    fn from(msg: NetworkResponses) -> Self {
-        PeerManagerMessageResponse::NetworkResponses(msg)
-    }
 }
 
 impl<A, M> MessageResponse<A, M> for NetworkResponses
@@ -589,6 +453,10 @@ pub enum NetworkClientMessages {
     NetworkInfo(NetworkInfo),
 }
 
+impl Message for NetworkClientMessages {
+    type Result = NetworkClientResponses;
+}
+
 // TODO(#1313): Use Box
 #[derive(Eq, PartialEq, Debug)]
 #[allow(clippy::large_enum_variant)]
@@ -626,10 +494,6 @@ where
             tx.send(self)
         }
     }
-}
-
-impl Message for NetworkClientMessages {
-    type Result = NetworkClientResponses;
 }
 
 /// Adapter to break dependency of sub-components on the network requests.
@@ -726,7 +590,6 @@ mod tests {
         assert_size!(Ping);
         assert_size!(Pong);
         assert_size!(RoutingTableUpdate);
-        assert_size!(SendMessage);
         assert_size!(RegisterPeer);
         assert_size!(FullPeerInfo);
         assert_size!(NetworkInfo);

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -5,8 +5,6 @@ pub use crate::network_protocol::{
 };
 #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
 pub use crate::network_protocol::{PartialSync, RoutingState, RoutingSyncV2, RoutingVersion2};
-#[cfg(feature = "test_features")]
-use crate::private_actix::{GetPeerId, GetPeerIdResult, StartRoutingTableSync};
 use crate::private_actix::{
     PeerRequestResult, PeersRequest, RegisterPeer, RegisterPeerResponse, Unregister,
 };
@@ -14,8 +12,6 @@ use crate::routing::routing::RoutingTableInfo;
 use crate::PeerInfo;
 use actix::dev::{MessageResponse, ResponseChannel};
 use actix::{Actor, MailboxError, Message, Recipient};
-#[cfg(feature = "deepsize_feature")]
-use deepsize::DeepSizeOf;
 use futures::future::BoxFuture;
 use futures::FutureExt;
 use near_network_primitives::types::{
@@ -40,7 +36,7 @@ use std::fmt::Debug;
 use std::sync::RwLock;
 use strum::AsStaticStr;
 
-#[cfg_attr(feature = "deepsize_feature", derive(DeepSizeOf))]
+#[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
 #[derive(Clone, Debug)]
 #[cfg(feature = "test_features")]
 pub struct SetAdvOptions {
@@ -89,7 +85,7 @@ pub enum PeerResponse {
 }
 
 /// Received new peers from another peer.
-#[cfg_attr(feature = "deepsize_feature", derive(DeepSizeOf))]
+#[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
 #[derive(Message, Debug, Clone)]
 #[rtype(result = "()")]
 pub struct PeersResponse {
@@ -99,7 +95,7 @@ pub struct PeersResponse {
 /// List of all messages, which PeerManagerActor accepts through Actix. There is also another list
 /// which contains reply for each message to PeerManager.
 /// There is 1 to 1 mapping between an entry in `PeerManagerMessageRequest` and `PeerManagerMessageResponse`.
-#[cfg_attr(feature = "deepsize_feature", derive(DeepSizeOf))]
+#[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
 #[derive(Debug)]
 pub enum PeerManagerMessageRequest {
     RoutedMessageFrom(RoutedMessageFrom),
@@ -109,14 +105,14 @@ pub enum PeerManagerMessageRequest {
     PeersResponse(PeersResponse),
     PeerRequest(PeerRequest),
     #[cfg(feature = "test_features")]
-    GetPeerId(GetPeerId),
+    GetPeerId(crate::private_actix::GetPeerId),
     OutboundTcpConnect(OutboundTcpConnect),
     InboundTcpConnect(InboundTcpConnect),
     Unregister(Unregister),
     Ban(Ban),
     #[cfg(feature = "test_features")]
     #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
-    StartRoutingTableSync(StartRoutingTableSync),
+    StartRoutingTableSync(crate::private_actix::StartRoutingTableSync),
     #[cfg(feature = "test_features")]
     SetAdvOptions(SetAdvOptions),
     #[cfg(feature = "test_features")]
@@ -156,7 +152,7 @@ pub enum PeerManagerMessageResponse {
     PeersResponseResult(()),
     PeerResponse(PeerResponse),
     #[cfg(feature = "test_features")]
-    GetPeerIdResult(GetPeerIdResult),
+    GetPeerIdResult(crate::private_actix::GetPeerIdResult),
     OutboundTcpConnect(()),
     InboundTcpConnect(()),
     Unregister(()),
@@ -213,7 +209,7 @@ impl PeerManagerMessageResponse {
     }
 
     #[cfg(feature = "test_features")]
-    pub fn as_peer_id_result(self) -> GetPeerIdResult {
+    pub fn as_peer_id_result(self) -> crate::private_actix::GetPeerIdResult {
         if let PeerManagerMessageResponse::GetPeerIdResult(item) = self {
             item
         } else {
@@ -229,7 +225,7 @@ impl From<NetworkResponses> for PeerManagerMessageResponse {
 }
 
 // TODO(#1313): Use Box
-#[cfg_attr(feature = "deepsize_feature", derive(DeepSizeOf))]
+#[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
 #[derive(Clone, strum::AsRefStr, Debug, Eq, PartialEq)]
 #[allow(clippy::large_enum_variant)]
 pub enum NetworkRequests {
@@ -545,7 +541,7 @@ impl PeerManagerAdapter for NetworkRecipient {
     }
 }
 
-#[cfg_attr(feature = "deepsize_feature", derive(DeepSizeOf))]
+#[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
 #[derive(Message, Clone, Debug)]
 #[rtype(result = "()")]
 pub struct SetRoutingTable {


### PR DESCRIPTION
In order to more clearly define the public interface of `near-network`. 
We should move all actix messages, that are meat to be used only within the `near-network` to a separate `private_actix.rs` file.