### PR TITLE
re: `near-network` Remove unused `GetRoutingTable ` type

### DIFF
--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -1,6 +1,6 @@
 use crate::peer::peer_actor::PeerActor;
 use crate::routing::network_protocol::SimpleEdge;
-use crate::routing::routing::{GetRoutingTableResult, PeerRequestResult, RoutingTableInfo};
+use crate::routing::routing::{PeerRequestResult, RoutingTableInfo};
 use crate::PeerInfo;
 use actix::dev::{MessageResponse, ResponseChannel};
 use actix::{Actor, Addr, MailboxError, Message, Recipient};

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -110,14 +110,6 @@ pub struct GetPeerIdResult {
 }
 
 #[cfg_attr(feature = "deepsize_feature", derive(DeepSizeOf))]
-#[derive(Debug)]
-pub struct GetRoutingTable {}
-
-impl Message for GetRoutingTable {
-    type Result = GetRoutingTableResult;
-}
-
-#[cfg_attr(feature = "deepsize_feature", derive(DeepSizeOf))]
 #[derive(Clone, Debug)]
 #[cfg(feature = "test_features")]
 pub struct StartRoutingTableSync {


### PR DESCRIPTION
Let's remove currently unused  `GetRoutingTable` from `near-network::types`.

TODO:
- [x] remove `GetRoutingTableResult` - requires jsonrpc changes