### PR TITLE
fix: Fix race condition in tests related `open_port` 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2874,6 +2874,7 @@ name = "near-network"
 version = "0.0.0"
 dependencies = [
  "actix",
+ "anyhow",
  "bencher",
  "borsh 0.9.1",
  "bytes",

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -25,6 +25,7 @@ tokio-stream = { version = "0.1.2", features = ["net"] }
 tokio-util = { version = "0.6", features = ["codec"] }
 tracing = "0.1.13"
 deepsize = { version = "0.2.0", optional = true }
+anyhow = "1.0.44"
 
 delay-detector = { path = "../../tools/delay_detector", optional = true }
 near-crypto = { path = "../../core/crypto" }

--- a/chain/network/src/peer/codec.rs
+++ b/chain/network/src/peer/codec.rs
@@ -104,8 +104,7 @@ mod test {
         Handshake, HandshakeFailureReason, HandshakeV2, PeerMessage, RoutingTableUpdate,
     };
     use crate::PeerInfo;
-    use borsh::BorshDeserialize;
-    use borsh::BorshSerialize;
+    use borsh::{BorshDeserialize, BorshSerialize};
     use bytes::{BufMut, BytesMut};
     use near_crypto::{KeyType, PublicKey, SecretKey};
     use near_network_primitives::types::{

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -14,8 +14,7 @@ use actix::{
     Actor, ActorContext, ActorFuture, Addr, Arbiter, AsyncContext, Context, ContextFutureSpawner,
     Handler, Recipient, Running, StreamHandler, WrapFuture,
 };
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+use borsh::{BorshDeserialize, BorshSerialize};
 use lru::LruCache;
 use near_crypto::Signature;
 use near_network_primitives::types::{

--- a/chain/network/src/routing/ibf_peer_set.rs
+++ b/chain/network/src/routing/ibf_peer_set.rs
@@ -167,8 +167,7 @@ impl IbfPeerSet {
 #[cfg(test)]
 mod test {
     use crate::routing::edge::{Edge, SimpleEdge};
-    use crate::routing::ibf_peer_set::ValidIBFLevel;
-    use crate::routing::ibf_peer_set::{IbfPeerSet, SlotMap};
+    use crate::routing::ibf_peer_set::{IbfPeerSet, SlotMap, ValidIBFLevel};
     use crate::routing::ibf_set::IbfSet;
     use crate::test_utils::random_peer_id;
     use near_primitives::network::PeerId;

--- a/chain/network/src/routing/ibf_set.rs
+++ b/chain/network/src/routing/ibf_set.rs
@@ -1,6 +1,5 @@
 use crate::routing::ibf::{Ibf, IbfBox};
-use crate::routing::ibf_peer_set::SlotMapId;
-use crate::routing::ibf_peer_set::{ValidIBFLevel, MAX_IBF_LEVEL, MIN_IBF_LEVEL};
+use crate::routing::ibf_peer_set::{SlotMapId, ValidIBFLevel, MAX_IBF_LEVEL, MIN_IBF_LEVEL};
 use near_stable_hasher::StableHasher;
 use std::collections::HashMap;
 use std::fmt;
@@ -102,8 +101,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::routing::ibf_peer_set::SlotMapId;
-    use crate::routing::ibf_peer_set::ValidIBFLevel;
+    use crate::routing::ibf_peer_set::{SlotMapId, ValidIBFLevel};
     use crate::routing::ibf_set::IbfSet;
 
     #[test]

--- a/integration-tests/tests/network/infinite_loop.rs
+++ b/integration-tests/tests/network/infinite_loop.rs
@@ -77,6 +77,7 @@ pub fn make_peer_manager(
             client_addr.recipient(),
             view_client_addr.recipient(),
             routing_table_addr,
+            None,
         )
         .unwrap(),
         peer_id,

--- a/integration-tests/tests/network/peer_handshake.rs
+++ b/integration-tests/tests/network/peer_handshake.rs
@@ -70,6 +70,7 @@ fn make_peer_manager(
         client_addr.recipient(),
         view_client_addr.recipient(),
         routing_table_addr,
+        None,
     )
     .unwrap()
 }

--- a/integration-tests/tests/network/stress_network.rs
+++ b/integration-tests/tests/network/stress_network.rs
@@ -59,6 +59,7 @@ fn make_peer_manager(seed: &str, port: u16, boot_nodes: Vec<(&str, u16)>) -> Pee
         client_addr.recipient(),
         view_client_addr.recipient(),
         routing_table_addr,
+        None,
     )
     .unwrap()
 }

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -363,6 +363,7 @@ pub fn start_with_config(home_dir: &Path, config: NearConfig) -> NearNode {
             client_actor1,
             view_client1,
             routing_table_addr,
+            None,
         )
         .unwrap()
     });


### PR DESCRIPTION
While stress testing `archival_node` test I found out that there is a rare condition, which can cause test to fail.

In that test we all `open_port` function. It's possible that the test will crash, if any other service starts using given port, in between `open_port` is called, and the time `PeerManagerActor` calls `started()`.

Let's fix the race condition for `integration-tests/tests/network/src/runner.rs`

Something to consider:
- maybe fix other places that use `open_port`.