### PR TITLE
re: Fix clippy warnings in near-network

### DIFF
--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -117,6 +117,7 @@ impl Debug for PeerActor {
 }
 
 impl PeerActor {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         my_node_info: PeerInfo,
         peer_addr: SocketAddr,
@@ -557,7 +558,7 @@ impl PeerActor {
 
     /// Check whenever we exceeded number of transactions we got since last block.
     /// If so, drop the transaction.
-    fn should_we_drop_msg_without_decoding(&self, msg: &Vec<u8>) -> bool {
+    fn should_we_drop_msg_without_decoding(&self, msg: &[u8]) -> bool {
         if utils::is_forward_transaction(msg).unwrap_or(false) {
             let r = self.txns_since_last_block.load(Ordering::Acquire);
             if r > MAX_TRANSACTIONS_PER_BLOCK_MESSAGE {
@@ -569,7 +570,7 @@ impl PeerActor {
 
     // Checks errors from decoding a message.
     // We may send `HandshakeFailure` to the other peer.
-    fn handle_peer_message_decode_error(&mut self, msg: &Vec<u8>, err: Error) {
+    fn handle_peer_message_decode_error(&mut self, msg: &[u8], err: Error) {
         if let Some(version) = err
             .get_ref()
             .and_then(|err| err.downcast_ref::<HandshakeFailureReason>())
@@ -887,12 +888,11 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for PeerActor {
                     ))
                     .into_actor(self)
                     .then(|res, act, ctx| {
-                        match res.map(|f| f.into_inner().as_peer_response()) {
-                            Ok(PeerResponse::UpdatedEdge(edge_info)) => {
-                                act.partial_edge_info = Some(edge_info);
-                                act.send_handshake(ctx);
-                            }
-                            _ => {}
+                        if let Ok(PeerResponse::UpdatedEdge(edge_info)) =
+                            res.map(|f| f.into_inner().as_peer_response())
+                        {
+                            act.partial_edge_info = Some(edge_info);
+                            act.send_handshake(ctx);
                         }
                         actix::fut::ready(())
                     })
@@ -956,11 +956,10 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for PeerActor {
                 ))
                 .into_actor(self)
                 .then(|res, act, ctx| {
-                    match res.map(|f| f.as_network_response()) {
-                        Ok(NetworkResponses::BanPeer(reason_for_ban)) => {
-                            act.ban_peer(ctx, reason_for_ban);
-                        }
-                        _ => {}
+                    if let Ok(NetworkResponses::BanPeer(reason_for_ban)) =
+                        res.map(|f| f.as_network_response())
+                    {
+                        act.ban_peer(ctx, reason_for_ban);
                     }
                     actix::fut::ready(())
                 })

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -412,22 +412,14 @@ impl PeerManagerActor {
                     // We belong to this edge.
                     if self.connected_peers.contains_key(other_peer) {
                         // This is an active connection.
-                        match edge.edge_type() {
-                            EdgeState::Removed => {
-                                self.maybe_remove_connected_peer(ctx, edge.clone(), other_peer);
-                            }
-                            _ => {}
+                        if edge.edge_type() == EdgeState::Removed {
+                            self.maybe_remove_connected_peer(ctx, edge.clone(), other_peer);
                         }
-                    } else {
-                        match edge.edge_type() {
-                            EdgeState::Active => {
-                                // We are not connected to this peer, but routing table contains
-                                // information that we do. We should wait and remove that peer
-                                // from routing table
-                                self.wait_peer_or_remove(ctx, edge.clone());
-                            }
-                            _ => {}
-                        }
+                    } else if edge.edge_type() == EdgeState::Active {
+                        // We are not connected to this peer, but routing table contains
+                        // information that we do. We should wait and remove that peer
+                        // from routing table
+                        self.wait_peer_or_remove(ctx, edge.clone());
                     }
                 }
             }
@@ -519,6 +511,7 @@ impl PeerManagerActor {
     /// To build new edge between this pair of nodes both signatures are required.
     /// Signature from this node is passed in `edge_info`
     /// Signature from the other node is passed in `full_peer_info.edge_info`.
+    #[allow(clippy::too_many_arguments)]
     fn register_peer(
         &mut self,
         full_peer_info: FullPeerInfo,

--- a/chain/network/src/peer_manager/peer_store.rs
+++ b/chain/network/src/peer_manager/peer_store.rs
@@ -313,13 +313,15 @@ impl PeerStore {
                     // If this peer already exists with a signed connection ignore this update.
                     // Warning: This is a problem for nodes that changes its address without changing peer_id.
                     //          It is recommended to change peer_id if address is changed.
-                    if self.peer_states.get(&peer_info.id).map_or(false, |peer_state| {
-                        peer_state.peer_info.addr.map_or(false, |current_addr| {
-                            self.addr_peers.get(&current_addr).map_or(false, |verified_peer| {
-                                verified_peer.trust_level == TrustLevel::Signed
+                    let is_peer_trusted =
+                        self.peer_states.get(&peer_info.id).map_or(false, |peer_state| {
+                            peer_state.peer_info.addr.map_or(false, |current_addr| {
+                                self.addr_peers.get(&current_addr).map_or(false, |verified_peer| {
+                                    verified_peer.trust_level == TrustLevel::Signed
+                                })
                             })
-                        })
-                    }) {
+                        });
+                    if is_peer_trusted {
                         return Ok(());
                     }
 

--- a/chain/network/src/routing/edge_validator_actor.rs
+++ b/chain/network/src/routing/edge_validator_actor.rs
@@ -53,7 +53,7 @@ impl Handler<ValidateEdgeList> for EdgeValidatorActor {
                 let mut guard = msg.edges_info_shared.lock().unwrap();
                 let entry = guard.entry(key.clone());
 
-                let cur_nonce = entry.or_insert(edge.nonce());
+                let cur_nonce = entry.or_insert_with(|| edge.nonce());
                 *cur_nonce = max(*cur_nonce, edge.nonce());
             }
             msg.sender.push(edge);

--- a/chain/network/src/routing/mod.rs
+++ b/chain/network/src/routing/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod ibf_peer_set;
 pub(crate) mod ibf_set;
 pub(crate) mod network_protocol;
 mod route_back_cache;
+#[allow(clippy::module_inception)]
 pub(crate) mod routing;
 pub(crate) mod routing_table_actor;
 

--- a/chain/network/src/routing/routing.rs
+++ b/chain/network/src/routing/routing.rs
@@ -161,7 +161,7 @@ impl RoutingTableView {
         })
     }
 
-    pub fn remove_local_edges(&mut self, edges: &Vec<Edge>) {
+    pub fn remove_local_edges(&mut self, edges: &[Edge]) {
         for edge in edges.iter() {
             if let Some(other_peer) = edge.other(&self.my_peer_id) {
                 self.local_edges_info.remove(other_peer);
@@ -471,7 +471,7 @@ impl Graph {
         }
 
         // This takes 75% of the total time computation time of this function.
-        self.compute_result(&mut routes, &distance)
+        self.compute_result(&routes, &distance)
     }
 
     /// Converts representation of the result, from an array representation, to

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -523,8 +523,7 @@ impl RoutingTableActor {
     ) -> (Vec<crate::routing::SimpleEdge>, Vec<u64>, u64) {
         let ibf = ibf_set.get_ibf(ibf_level);
 
-        let mut new_ibf =
-            crate::routing::ibf::Ibf::from_vec(ibf_vec.clone(), seed ^ (ibf_level.0 as u64));
+        let mut new_ibf = crate::routing::ibf::Ibf::from_vec(ibf_vec, seed ^ (ibf_level.0 as u64));
 
         if !new_ibf.merge(&ibf.data, seed ^ (ibf_level.0 as u64)) {
             tracing::error!(target: "network", "exchange routing tables failed with peer {}", peer_id);


### PR DESCRIPTION
Fixed:
- Use slice instead of `Vec`, as a function argument
- `compute_result` doesn't need mutable reference.
- use of `or_insert` followed by a function call