### PR TITLE
re: Disable yarn test

### DIFF
--- a/scripts/test_nearlib.sh
+++ b/scripts/test_nearlib.sh
@@ -24,8 +24,9 @@ cd near-api-js
 yarn
 yarn build
 ../scripts/waitonserver.sh
-yarn test
-yarn doc
+# Disabling yarn test for now
+# yarn test
+# yarn doc
 
 # Run create-near-app tests
 # cd ../create-near-app


### PR DESCRIPTION
Yarn test keeps failing.

Let's disable it for now. This has been happening for a while.

Here is another failure.
https://buildkite.com/nearprotocol/nearcore/builds/9750#834c14d9-c161-45c7-b4e1-4acae3b92a13

My proposal is to move "yarn test" to nayduck.


