### PR TITLE
refactor: drop unused serializes from some errors

### DIFF
--- a/runtime/near-vm-errors/src/lib.rs
+++ b/runtime/near-vm-errors/src/lib.rs
@@ -229,7 +229,7 @@ pub enum HostError {
     AltBn128SerializationError { msg: String },
 }
 
-#[derive(Debug, Clone, PartialEq, BorshDeserialize, BorshSerialize, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum VMLogicError {
     /// Errors coming from native Wasm VM.
     HostError(HostError),
@@ -243,7 +243,7 @@ impl std::error::Error for VMLogicError {}
 
 /// An error that is caused by an operation on an inconsistent state.
 /// E.g. a deserialization error or an integer overflow.
-#[derive(Debug, Clone, PartialEq, Eq, BorshDeserialize, BorshSerialize, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InconsistentStateError {
     StorageError(String),
     /// Math operation with a value from the state resulted in a integer overflow.


### PR DESCRIPTION
I am looking into finally untangling vm errors and removing all
serialization concerns from the VM layer. While doing that, I've noticed
that we can easily drop the two serializes.

Test Plan
---------

Drops unused code, so `cargo check`