### PR TITLE
chore(compliance): specify a MSRV for all crates

### DIFF
--- a/utils/near-cache/Cargo.toml
+++ b/utils/near-cache/Cargo.toml
@@ -3,6 +3,8 @@ name = "near-cache"
 version = "0.0.0"
 edition = "2021"
 publish = false
+# Please update rust-toolchain.toml as well when changing version here:
+rust-version = "1.56.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Tracking issue: https://github.com/near/nearcore/issues/5763

All crates must explicitly specify a Minimum Supported Rust Version.

Resolves:

```console
(i) These packages should specify a Minimum Supported Rust Version (MSRV):
 • near-cache v0.0.0 (utils/near-cache/Cargo.toml)
```