### PR TITLE
Remove `From<Vec<u8>>` for `CryptoHash`

### DIFF
--- a/chain/rosetta-rpc/src/adapters/mod.rs
+++ b/chain/rosetta-rpc/src/adapters/mod.rs
@@ -917,10 +917,9 @@ mod tests {
     fn test_convert_block_changes_to_transactions() {
         let runtime_config = near_primitives::runtime::config::RuntimeConfig::test();
         let block_hash = near_primitives::hash::CryptoHash::default();
-        let nfvalidator1_receipt_processing_hash =
-            near_primitives::hash::CryptoHash::try_from(vec![1u8; 32]).unwrap();
+        let nfvalidator1_receipt_processing_hash = near_primitives::hash::CryptoHash([1u8; 32]);
         let nfvalidator2_action_receipt_gas_reward_hash =
-            near_primitives::hash::CryptoHash::try_from(vec![2u8; 32]).unwrap();
+            near_primitives::hash::CryptoHash([2u8; 32]);
         let accounts_changes = vec![
             near_primitives::views::StateChangeWithCauseView {
                 cause: near_primitives::views::StateChangeCauseView::ValidatorAccountsUpdate,

--- a/core/primitives-core/src/hash.rs
+++ b/core/primitives-core/src/hash.rs
@@ -68,7 +68,7 @@ impl<'de> Deserialize<'de> for CryptoHash {
             return Err(serde::de::Error::custom("incorrect length for hash"));
         }
         from_base(&s)
-            .and_then(CryptoHash::try_from)
+            .and_then(|f| CryptoHash::try_from(f.as_slice()))
             .map_err(|err| serde::de::Error::custom(err.to_string()))
     }
 }
@@ -78,7 +78,7 @@ impl std::str::FromStr for CryptoHash {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let bytes = from_base(s).map_err::<Self::Err, _>(|e| e.to_string().into())?;
-        Self::try_from(bytes)
+        Self::try_from(bytes.as_slice())
     }
 }
 
@@ -87,14 +87,6 @@ impl TryFrom<&[u8]> for CryptoHash {
 
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
         Ok(CryptoHash(bytes.try_into()?))
-    }
-}
-
-impl TryFrom<Vec<u8>> for CryptoHash {
-    type Error = Box<dyn std::error::Error>;
-
-    fn try_from(v: Vec<u8>) -> Result<Self, Self::Error> {
-        <Self as TryFrom<&[u8]>>::try_from(v.as_ref())
     }
 }
 

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -325,8 +325,7 @@ pub fn get_block_shard_uid_rev(
             std::io::Error::new(std::io::ErrorKind::InvalidInput, "Invalid key length").into()
         );
     }
-    let block_hash_vec: Vec<u8> = key[0..32].to_vec();
-    let block_hash = CryptoHash::try_from(block_hash_vec)?;
+    let block_hash = CryptoHash::try_from(&key[..32])?;
     let shard_id = ShardUId::try_from(&key[32..])?;
     Ok((block_hash, shard_id))
 }

--- a/core/primitives/src/utils.rs
+++ b/core/primitives/src/utils.rs
@@ -191,8 +191,7 @@ pub fn get_block_shard_id_rev(
             std::io::Error::new(std::io::ErrorKind::InvalidInput, "Invalid key length").into()
         );
     }
-    let block_hash_vec: Vec<u8> = key[0..32].to_vec();
-    let block_hash = CryptoHash::try_from(block_hash_vec)?;
+    let block_hash = CryptoHash::try_from(&key[..32])?;
     let mut shard_id_arr: [u8; 8] = Default::default();
     shard_id_arr.copy_from_slice(&key[key.len() - 8..]);
     let shard_id = ShardId::from_le_bytes(shard_id_arr);

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -353,7 +353,7 @@ impl RawTrieNode {
                 let value_length = cursor.read_u32::<LittleEndian>()?;
                 let mut arr = [0; 32];
                 cursor.read_exact(&mut arr)?;
-                let value_hash = CryptoHash::try_from(&arr[..]).unwrap();
+                let value_hash = CryptoHash(arr);
                 Ok(RawTrieNode::Leaf(key, value_length, value_hash))
             }
             BRANCH_NODE_NO_VALUE => {
@@ -364,7 +364,7 @@ impl RawTrieNode {
                 let value_length = cursor.read_u32::<LittleEndian>()?;
                 let mut arr = [0; 32];
                 cursor.read_exact(&mut arr)?;
-                let value_hash = CryptoHash::try_from(&arr[..]).unwrap();
+                let value_hash = CryptoHash(arr);
                 let children = decode_children(&mut cursor)?;
                 Ok(RawTrieNode::Branch(children, Some((value_length, value_hash))))
             }
@@ -372,9 +372,9 @@ impl RawTrieNode {
                 let key_length = cursor.read_u32::<LittleEndian>()?;
                 let mut key = vec![0; key_length as usize];
                 cursor.read_exact(&mut key)?;
-                let mut child = vec![0; 32];
+                let mut child = [0; 32];
                 cursor.read_exact(&mut child)?;
-                Ok(RawTrieNode::Extension(key, CryptoHash::try_from(child).unwrap()))
+                Ok(RawTrieNode::Extension(key, CryptoHash(child)))
             }
             _ => Err(std::io::Error::new(std::io::ErrorKind::Other, "Wrong type")),
         }

--- a/test-utils/state-viewer/src/commands.rs
+++ b/test-utils/state-viewer/src/commands.rs
@@ -2,7 +2,6 @@ use crate::apply_chain_range::apply_chain_range;
 use crate::epoch_info;
 use crate::state_dump::state_dump;
 use ansi_term::Color::Red;
-use borsh::BorshSerialize;
 use near_chain::chain::collect_receipts_from_response;
 use near_chain::migrations::check_if_block_is_first_with_chunk_of_version;
 use near_chain::types::{ApplyTransactionResult, BlockHeaderInfo};
@@ -125,13 +124,10 @@ pub(crate) fn dump_code(
     let epoch_id = &runtime.get_epoch_id(header.hash()).unwrap();
 
     for (shard_id, state_root) in state_roots.iter().enumerate() {
-        let state_root_vec: Vec<u8> = state_root.try_to_vec().unwrap();
         let shard_uid = runtime.shard_id_to_uid(shard_id as u64, epoch_id).unwrap();
-        if let Ok(contract_code) = runtime.view_contract_code(
-            &shard_uid,
-            CryptoHash::try_from(state_root_vec).unwrap(),
-            &account_id.parse().unwrap(),
-        ) {
+        if let Ok(contract_code) =
+            runtime.view_contract_code(&shard_uid, *state_root, &account_id.parse().unwrap())
+        {
             let mut file = File::create(output).unwrap();
             file.write_all(contract_code.code()).unwrap();
             println!("Dump contract of account {} into file {}", account_id, output.display());


### PR DESCRIPTION
We can remove `impl TryFrom<Vec<u8>>` for `CryptoHash`
This will remove extra memory allocations and make code shorter.