### PR TITLE
Add `debug_assert` to `Edge::build_hash`

### DIFF
--- a/chain/network/src/routing/network_protocol.rs
+++ b/chain/network/src/routing/network_protocol.rs
@@ -95,6 +95,7 @@ impl Edge {
     /// Build the hash of the edge given its content.
     /// It is important that peer0 < peer1 at this point.
     pub fn build_hash(peer0: &PeerId, peer1: &PeerId, nonce: u64) -> CryptoHash {
+        debug_assert!(peer0 < peer1);
         CryptoHash::hash_borsh(&(peer0, peer1, nonce))
     }
 


### PR DESCRIPTION
Add `debug_assert` to `Edge::build_hash`.
We make an assumption when calling `build_hash`, it's safe to add an assert.