### PR TITLE
feat: Use `criterion` instead of `bencher`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2839,7 +2839,6 @@ dependencies = [
  "borsh",
  "bytes",
  "bytesize",
- "cast",
  "conqueue",
  "criterion",
  "deepsize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,6 +715,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc38c385bfd7e444464011bb24820f40dd1c76bcdfa1b78611cb7c2e5cafab75"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1024,6 +1033,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "criterion"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
+dependencies = [
+ "atty",
+ "cast",
+ "clap 2.33.3",
+ "criterion-plot",
+ "csv",
+ "itertools",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_cbor",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
+dependencies = [
+ "cast",
+ "itertools",
 ]
 
 [[package]]
@@ -1738,6 +1783,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2063,6 +2114,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2776,11 +2836,12 @@ name = "near-network"
 version = "0.0.0"
 dependencies = [
  "actix",
- "bencher",
  "borsh",
  "bytes",
  "bytesize",
+ "cast",
  "conqueue",
+ "criterion",
  "deepsize",
  "delay-detector",
  "futures",
@@ -3355,6 +3416,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3644,6 +3711,34 @@ name = "pkg-config"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c9b1041b4387893b91ee6746cddfc28516aff326a3519fb2adf820932c5e6cb"
+
+[[package]]
+name = "plotters"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d88417318da0eaf0fdcdb51a0ee6c3bed624333bff8f946733049380be67ac1c"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portpicker"
@@ -4335,6 +4430,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4428,6 +4532,16 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half",
  "serde",
 ]
 
@@ -5017,6 +5131,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5332,6 +5456,17 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
 
 [[package]]
 name = "walrus"
@@ -5815,6 +5950,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcfaeb27e2578d2c6271a45609f4a055e6d7ba3a12eff35b1fd5ba147bdf046"
 dependencies = [
  "wast",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -39,7 +39,6 @@ near-stable-hasher = { path = "../../utils/near-stable-hasher", optional = true 
 near-store = { path = "../../core/store" }
 
 [dev-dependencies]
-cast = "0.2.5"
 criterion = { version = "0.3.5", default_features = false, features = ["html_reports", "cargo_bench_support"] }
 tempfile = "3"
 

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -39,7 +39,8 @@ near-stable-hasher = { path = "../../utils/near-stable-hasher", optional = true 
 near-store = { path = "../../core/store" }
 
 [dev-dependencies]
-bencher = "0.1.5"
+cast = "0.2.5"
+criterion = { version = "0.3.5", default_features = false, features = ["html_reports", "cargo_bench_support"] }
 tempfile = "3"
 
 [features]

--- a/chain/network/benches/graph.rs
+++ b/chain/network/benches/graph.rs
@@ -1,8 +1,8 @@
 #[macro_use]
-extern crate bencher;
+extern crate criterion;
 
-use bencher::Bencher;
-use near_network::routing::graph::Graph;
+use criterion::{black_box, Criterion};
+use near_network::routing::Graph;
 
 use near_network::test_utils::random_peer_id;
 
@@ -27,36 +27,44 @@ fn build_graph(depth: usize, size: usize) -> Graph {
     graph
 }
 
-fn calculate_distance_3_3(bench: &mut Bencher) {
+fn calculate_distance_3_3(c: &mut Criterion) {
     let graph = build_graph(3, 3);
-    bench.iter(|| {
-        let _ = graph.calculate_distance();
+    c.bench_function("calculate_distance_3_3", |bench| {
+        bench.iter(|| {
+            black_box(graph.calculate_distance());
+        })
     });
 }
 
-fn calculate_distance_10_10(bench: &mut Bencher) {
+fn calculate_distance_10_10(c: &mut Criterion) {
     let graph = build_graph(10, 10);
-    bench.iter(|| {
-        let _ = graph.calculate_distance();
+    c.bench_function("calculate_distance_10_10", |bench| {
+        bench.iter(|| {
+            black_box(graph.calculate_distance());
+        })
     });
 }
 
-fn calculate_distance_10_100(bench: &mut Bencher) {
-    let graph = build_graph(10, 100);
-    bench.iter(|| {
-        let _ = graph.calculate_distance();
+fn calculate_distance_10_100(c: &mut Criterion) {
+    c.bench_function("calculate_distance_10_100", |bench| {
+        let graph = build_graph(10, 100);
+        bench.iter(|| {
+            black_box(graph.calculate_distance());
+        })
     });
 }
 
 #[allow(dead_code)]
-fn calculate_distance_100_100(bench: &mut Bencher) {
+fn calculate_distance_100_100(c: &mut Criterion) {
     let graph = build_graph(100, 100);
-    bench.iter(|| {
-        let _ = graph.calculate_distance();
+    c.bench_function("calculate_distance_100_100", |bench| {
+        bench.iter(|| {
+            black_box(graph.calculate_distance());
+        })
     });
 }
 
-benchmark_group!(
+criterion_group!(
     benches,
     calculate_distance_3_3,
     calculate_distance_10_10,
@@ -64,9 +72,9 @@ benchmark_group!(
     calculate_distance_10_100
 );
 
-benchmark_main!(benches);
+criterion_main!(benches);
 
 // running 3 tests
-// test calculate_distance_10_10  ... bench:      14,508 ns/iter (+/- 133)
-// test calculate_distance_10_100 ... bench:     877,288 ns/iter (+/- 28,752)
-// test calculate_distance_3_3    ... bench:         629 ns/iter (+/- 6)
+// calculate_distance_3_3    time:   [566.42 ns 571.50 ns 578.62 ns]
+// calculate_distance_10_10  time:   [10.631 us 10.651 us 10.679 us]
+// calculate_distance_10_100 time:   [607.36 us 610.44 us 613.75 us]

--- a/chain/network/benches/graph.rs
+++ b/chain/network/benches/graph.rs
@@ -2,8 +2,7 @@
 extern crate criterion;
 
 use criterion::{black_box, Criterion};
-use near_network::routing::Graph;
-
+use near_network::routing::graph::Graph;
 use near_network::test_utils::random_peer_id;
 
 fn build_graph(depth: usize, size: usize) -> Graph {

--- a/chain/network/benches/routing_table_actor.rs
+++ b/chain/network/benches/routing_table_actor.rs
@@ -1,8 +1,7 @@
 #[macro_use]
-extern crate bencher;
-extern crate actix;
+extern crate criterion;
 
-use bencher::{black_box, Bencher};
+use criterion::{black_box, Criterion};
 use near_crypto::{KeyType, SecretKey, Signature};
 use near_network::test_utils::random_peer_id;
 use near_network::RoutingTableActor;
@@ -43,17 +42,19 @@ fn build_graph(depth: usize, size: usize) -> RoutingTableActor {
 }
 
 #[allow(dead_code)]
-fn get_all_edges_bench_old(bench: &mut Bencher) {
+fn get_all_edges_bench_old(c: &mut Criterion) {
     // 1000 nodes, 10m edges
     let routing_table_actor = build_graph(10, 100);
-    bench.iter(|| {
-        let result = routing_table_actor.get_all_edges();
-        black_box(result);
+    c.bench_function("get_all_edges_bench_old", |bench| {
+        bench.iter(|| {
+            let result = routing_table_actor.get_all_edges();
+            black_box(result);
+        })
     });
 }
 
 #[allow(dead_code)]
-fn get_all_edges_bench_new2(bench: &mut Bencher) {
+fn get_all_edges_bench_new2(c: &mut Criterion) {
     // this is how we efficient we could make get_all_edges by using Arc
 
     // 1000 nodes, 10m edges
@@ -72,14 +73,16 @@ fn get_all_edges_bench_new2(bench: &mut Bencher) {
         new_edges_info.insert(edge.key.clone(), Arc::new(edge));
     }
 
-    bench.iter(|| {
-        let result: Vec<Arc<EdgeNew>> = new_edges_info.iter().map(|x| x.1.clone()).collect();
-        black_box(result);
+    c.bench_function("get_all_edges_bench_new2", |bench| {
+        bench.iter(|| {
+            let result: Vec<Arc<EdgeNew>> = new_edges_info.iter().map(|x| x.1.clone()).collect();
+            black_box(result);
+        })
     });
 }
 
 #[allow(dead_code)]
-fn get_all_edges_bench_new3(bench: &mut Bencher) {
+fn get_all_edges_bench_new3(c: &mut Criterion) {
     // this is how we efficient we could make get_all_edges by using Arc
 
     // 1000 nodes, 10m edges
@@ -98,26 +101,30 @@ fn get_all_edges_bench_new3(bench: &mut Bencher) {
         new_edges_info.insert(edge.key.clone(), Arc::new(edge));
     }
 
-    bench.iter(|| {
-        let result: Vec<Arc<EdgeNew2>> = new_edges_info.iter().map(|x| x.1.clone()).collect();
-        black_box(result);
+    c.bench_function("get_all_edges_bench3", |bench| {
+        bench.iter(|| {
+            let result: Vec<Arc<EdgeNew2>> = new_edges_info.iter().map(|x| x.1.clone()).collect();
+            black_box(result);
+        })
     });
 }
 
 #[allow(dead_code)]
-fn benchmark_sign_edge(bench: &mut Bencher) {
+fn benchmark_sign_edge(c: &mut Criterion) {
     let sk = SecretKey::from_seed(KeyType::ED25519, "1234");
 
     let p0 = PeerId::new(sk.public_key());
     let p1 = PeerId::random();
 
-    bench.iter(|| {
-        let ei = Edge::build_hash(&p0, &p1, 123);
-        black_box(ei);
+    c.bench_function("benchmark_sign_edge", |bench| {
+        bench.iter(|| {
+            let ei = Edge::build_hash(&p0, &p1, 123);
+            black_box(ei);
+        })
     });
 }
 
-benchmark_group!(
+criterion_group!(
     benches,
     get_all_edges_bench_old,
     get_all_edges_bench_new2,
@@ -125,7 +132,7 @@ benchmark_group!(
     benchmark_sign_edge
 );
 
-benchmark_main!(benches);
+criterion_main!(benches);
 
 // running 3 tests
 // test get_all_edges_bench_old  ... bench:   1,296,045 ns/iter (+/- 601,626)


### PR DESCRIPTION
We are currently using `bencher` for bench-marking. We should switch to `criterion`.
In this PR we will switch `near-network` to use `criterion`.

Reasoning:
- `bencher` hasn't been updated since Jan 2018.
- `criterion` provides a statistically correct data on samples
- `criterion` provides various profiling tools, etc:

https://nickb.dev/blog/guidelines-on-benchmarking-and-rust

