### PR TITLE
re: Rewrite `compute_result` in `near-network::Graph`

### DIFF
--- a/chain/network/benches/graph.rs
+++ b/chain/network/benches/graph.rs
@@ -67,6 +67,6 @@ benchmark_group!(
 benchmark_main!(benches);
 
 // running 3 tests
-// test calculate_distance_10_10  ... bench:      12,442 ns/iter (+/- 307)
-// test calculate_distance_10_100 ... bench:   1,337,039 ns/iter (+/- 74,565)
-// test calculate_distance_3_3    ... bench:         636 ns/iter (+/- 12)
+// test calculate_distance_10_10  ... bench:      14,508 ns/iter (+/- 133)
+// test calculate_distance_10_100 ... bench:     877,288 ns/iter (+/- 28,752)
+// test calculate_distance_3_3    ... bench:         629 ns/iter (+/- 6)


### PR DESCRIPTION
We can rewrite `compute_result` to be written in a more functional style.
This will improve performance by 50%.