### PR TITLE
Fix crash in `near-network` benches

### DIFF
--- a/chain/network/benches/routing_table_actor.rs
+++ b/chain/network/benches/routing_table_actor.rs
@@ -1,5 +1,6 @@
 #[macro_use]
 extern crate bencher;
+extern crate actix;
 
 use bencher::{black_box, Bencher};
 use near_crypto::{KeyType, SecretKey, Signature};
@@ -12,6 +13,10 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 fn build_graph(depth: usize, size: usize) -> RoutingTableActor {
+    // This is needed for `RoutingTableActor` not to crash.
+    // `RoutingTableActor` stats `EdgeValidatorActor.
+    let _system = actix::System::new();
+
     let source = random_peer_id();
     let nodes: Vec<_> = (0..depth * size).map(|_| random_peer_id()).collect();
 


### PR DESCRIPTION
Due to recent changes. `chain/network/benches/routing_table_actor.rs` started crashing while `RoutingTableActor` due to the fact, that now it starts `EdgeValidatorActor` and `actix` System has not been running.