### PR TITLE
re: Improve handling errors in `scripts/test_nearlib.sh`.

### DIFF
--- a/scripts/waitonserver.sh
+++ b/scripts/waitonserver.sh
@@ -1,12 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-if [[ -z "${NEAR_PID}" ]]; then
-  echo "NEAR_PID is undefined"
-  exit 1
-fi
-
-echo "waiting on healthcheck NEAR_PID = ${NEAR_PID}" >&2
+echo "waiting on health check; NEAR_PID = ${NEAR_PID:?undefined}" >&2
 
 for _ in {1..500}; do
     echo -n '.' >&2

--- a/scripts/waitonserver.sh
+++ b/scripts/waitonserver.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
+set -e
 
-echo 'waiting on healthcheck' >&2
+if [[ -z "${NEAR_PID}" ]]; then
+  echo "NEAR_PID is undefined"
+  exit 1
+fi
+
+echo "waiting on healthcheck NEAR_PID = ${NEAR_PID}" >&2
 
 for _ in {1..500}; do
     echo -n '.' >&2
-    kill -0 $NEAR_PID > /dev/null 2>&1 || exit 1
+    kill -0 "$NEAR_PID" > /dev/null 2>&1 || exit 1
     if [[ "$(curl -s -o /dev/null -w '%{http_code}' http://localhost:3030/status)" == "200" ]]; then
         exit 0
     fi


### PR DESCRIPTION
We are missing a check whenever `NEAR_PID` is defined in `scripts/test_nearlib.sh`.

It's better to add those checks ahead of the time, that will make debugging easier in case an issue happens.