### PR TITLE
refactor: don't abuse serialization for type erasure

### DIFF
--- a/core/primitives/src/errors.rs
+++ b/core/primitives/src/errors.rs
@@ -7,7 +7,9 @@ use std::fmt::{Debug, Display};
 
 use crate::hash::CryptoHash;
 use near_rpc_error_macro::RpcError;
-use near_vm_errors::{CompilationError, FunctionCallErrorSer, MethodResolveError, VMLogicError};
+use near_vm_errors::{
+    AnyError, CompilationError, FunctionCallErrorSer, MethodResolveError, VMLogicError,
+};
 
 /// Error returned in the ExecutionOutcome in case of failure
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
@@ -61,9 +63,8 @@ pub enum RuntimeError {
     ValidatorError(EpochError),
 }
 
-/// Error used by `RuntimeExt`. This error has to be serializable, because it's transferred through
-/// the `VMLogicError`, which isn't aware of internal Runtime errors.
-#[derive(BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
+/// Error used by `RuntimeExt`.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ExternalError {
     /// Unexpected error which is typically related to the node storage corruption.
     /// It's possible the input state is invalid or malicious.
@@ -74,12 +75,12 @@ pub enum ExternalError {
 
 impl From<ExternalError> for VMLogicError {
     fn from(err: ExternalError) -> Self {
-        VMLogicError::ExternalError(err.try_to_vec().expect("Borsh serialize cannot fail"))
+        VMLogicError::ExternalError(AnyError::new(err))
     }
 }
 
 /// Internal
-#[derive(BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StorageError {
     /// Key-value db internal failure
     StorageInternalError,
@@ -742,7 +743,7 @@ impl Display for ActionErrorKind {
     }
 }
 
-#[derive(Eq, PartialEq, BorshSerialize, BorshDeserialize, Clone)]
+#[derive(Eq, PartialEq, Clone)]
 pub enum EpochError {
     /// Error calculating threshold from given stakes for given number of seats.
     /// Only should happened if calling code doesn't check for integer value of stake > number of seats.

--- a/runtime/near-vm-errors/src/lib.rs
+++ b/runtime/near-vm-errors/src/lib.rs
@@ -488,30 +488,6 @@ impl<T: Any + Eq + Sized + Send + Sync> AnyEq for T {
     }
 }
 
-pub mod hex_format {
-    use hex::{decode, encode};
-
-    use serde::de;
-    use serde::{Deserialize, Deserializer, Serializer};
-
-    pub fn serialize<S, T>(data: T, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-        T: AsRef<[u8]>,
-    {
-        serializer.serialize_str(&encode(data))
-    }
-
-    pub fn deserialize<'de, D, T>(deserializer: D) -> Result<T, D::Error>
-    where
-        D: Deserializer<'de>,
-        T: From<Vec<u8>>,
-    {
-        let s = String::deserialize(deserializer)?;
-        decode(&s).map_err(|err| de::Error::custom(err.to_string())).map(Into::into)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use crate::{CompilationError, FunctionCallError, MethodResolveError, PrepareError, VMError};

--- a/runtime/near-vm-runner/src/wasmer2_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer2_runner.rs
@@ -116,7 +116,7 @@ impl IntoVMError for wasmer::RuntimeError {
         let error_msg = self.message();
         let trap_code = self.clone().to_trap();
         if let Ok(e) = self.downcast::<VMLogicError>() {
-            return (&e).into();
+            return e.into();
         }
         // If we panic here - it means we encountered an issue in Wasmer.
         let trap_code = trap_code.unwrap_or_else(|| panic!("Unknown error: {}", error_msg));

--- a/runtime/near-vm-runner/src/wasmtime_runner.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner.rs
@@ -74,12 +74,10 @@ fn trap_to_error(trap: &wasmtime::Trap) -> VMError {
     if trap.i32_exit_status() == Some(239) {
         match imports::wasmtime::last_error() {
             Some(VMLogicError::HostError(h)) => {
-                VMError::FunctionCallError(FunctionCallError::HostError(h.clone()))
+                VMError::FunctionCallError(FunctionCallError::HostError(h))
             }
-            Some(VMLogicError::ExternalError(s)) => VMError::ExternalError(s.clone()),
-            Some(VMLogicError::InconsistentStateError(e)) => {
-                VMError::InconsistentStateError(e.clone())
-            }
+            Some(VMLogicError::ExternalError(s)) => VMError::ExternalError(s),
+            Some(VMLogicError::InconsistentStateError(e)) => VMError::InconsistentStateError(e),
             None => panic!("Error is not properly set"),
         }
     } else {

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -202,9 +202,9 @@ pub(crate) fn action_function_call(
             }
             FunctionCallError::_EVMError => unreachable!(),
         },
-        Some(VMError::ExternalError(serialized_error)) => {
-            let err: ExternalError = borsh::BorshDeserialize::try_from_slice(&serialized_error)
-                .expect("External error deserialization shouldn't fail");
+        Some(VMError::ExternalError(any_err)) => {
+            let err: ExternalError =
+                any_err.downcast().expect("Downcasting AnyError should not fail");
             return match err {
                 ExternalError::StorageError(err) => Err(err.into()),
                 ExternalError::ValidatorError(err) => Err(RuntimeError::ValidatorError(err)),

--- a/runtime/runtime/src/ext.rs
+++ b/runtime/runtime/src/ext.rs
@@ -140,10 +140,7 @@ impl<'a> RuntimeExt<'a> {
 }
 
 fn wrap_storage_error(error: StorageError) -> VMLogicError {
-    VMLogicError::ExternalError(
-        borsh::BorshSerialize::try_to_vec(&ExternalError::StorageError(error))
-            .expect("Borsh serialize cannot fail"),
-    )
+    VMLogicError::from(ExternalError::StorageError(error))
 }
 
 type ExtResult<T> = ::std::result::Result<T, VMLogicError>;


### PR DESCRIPTION
vm-logic is "generic" over External implementation. We don't want
however to literally add a type parameter to it, so we use `dyn
External`. This creates a problem that, when a particular external
fails, we need to report the error, but we don't know error's concrete
types. So let's use `Box<dyn Any>` for that, and a bit of down-casting.

The previous impl did roughly equivalent thing, but via
serialize/deserialize route, which is more complicated than what we need
here.

As a result, we eliminate a couple of BorshSerializes and clones.