### PR TITLE
refactor: test contract build script $PWD agnostic

### DIFF
--- a/runtime/runtime-params-estimator/test-contract/build.sh
+++ b/runtime/runtime-params-estimator/test-contract/build.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -ex
 
+# Make sure we're executing from the directory with the contract (this script invokes
+# $PWD-sensitive commands)
+cd "$(dirname $0)"
+
 features_with_arg=""
 features_with_comma=""
 


### PR DESCRIPTION
The scripts runs a couple of dangerous commands (such as `rm -rf`) with
relative directory arguments. This can result in an unintended data
loss. Make sure the script has $PWD set to an expected location before
doing anything else.