### PR TITLE
bug: Disable broken `pytest/tests/sanity/upgradable.py` test 

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -109,6 +109,7 @@ steps:
       source ~/.cargo/env && set -eux
       cd pytest
       pip3 install --user -r requirements.txt
+      # TODO(#5822) Disabled, because it blocks production
       # python3 tests/sanity/upgradable.py
     branches: "!master"
     timeout: 30

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -109,7 +109,7 @@ steps:
       source ~/.cargo/env && set -eux
       cd pytest
       pip3 install --user -r requirements.txt
-      python3 tests/sanity/upgradable.py
+      # python3 tests/sanity/upgradable.py
     branches: "!master"
     timeout: 30
     agents:

--- a/nightly/pytest-sanity.txt
+++ b/nightly/pytest-sanity.txt
@@ -137,3 +137,6 @@ pytest sanity/restart.py --features nightly_protocol,nightly_protocol_features
 # Rosetta RPC tests
 pytest sanity/rosetta.py
 pytest sanity/rosetta.py --features nightly_protocol,nightly_protocol_features
+
+# Disabled, because it's flunky
+pytest sanity/upgradable.py


### PR DESCRIPTION
`pytest/tests/sanity/upgradable.py` is broken. It has been failing consistently. 

On adding a print:
```
{'jsonrpc': '2.0', 'error': {'name': 'HANDLER_ERROR', 'cause': {'name': 'UNAVAILABLE_SHARD', 'info': {'requested_shard_id': 0}}, 'code': -32000, 'message': 'Server error', 'data': 'The node does not track the shard ID 0'}, 'id': 'dontcare'}
```

Let's disable it for now to unlock production.

See https://github.com/near/nearcore/issues/5821