### PR TITLE
Show a help message if `neard view_state` is called withouta subcommand.

### DIFF
--- a/test-utils/state-viewer/src/cli.rs
+++ b/test-utils/state-viewer/src/cli.rs
@@ -15,7 +15,6 @@ use crate::commands::*;
 static DEFAULT_HOME: Lazy<PathBuf> = Lazy::new(|| get_default_home());
 
 #[derive(Clap)]
-#[clap(setting = AppSettings::SubcommandRequiredElseHelp)]
 pub struct StateViewerCmd {
     #[clap(flatten)]
     opts: StateViewerOpts,
@@ -48,6 +47,7 @@ impl StateViewerOpts {
 }
 
 #[derive(Clap)]
+#[clap(setting = AppSettings::SubcommandRequiredElseHelp)]
 pub enum StateViewerSubCommand {
     #[clap(name = "peers")]
     Peers,


### PR DESCRIPTION
Fix #5483 