### PR TITLE
Write `poll_next` in a cleaner way

### DIFF
--- a/utils/near-rate-limiter/src/framed_read.rs
+++ b/utils/near-rate-limiter/src/framed_read.rs
@@ -264,7 +264,7 @@ where
             while !pinned.throttle_controller.is_ready() {
                 // This will cause us to subscribe to notifier when something gets pushed to
                 // `pinned.receiver`. If there is an element in the queue, we will check again.
-                ready!(PollSemaphore::poll_next(Pin::new(pinned.semaphore), cx));
+                ready!(pinned.semaphore.poll_acquire(cx));
             }
 
             // Repeatedly call `decode` or `decode_eof` as long as it is


### PR DESCRIPTION
`ReadFrame`'s `poll_next` method can be written in a shorter, cleaner way.

There is no reason why not to do it.

This is a response to https://github.com/near/nearcore/pull/5758#discussion_r768648859