### PR TITLE
feat: Move `RoutedMessage` inside `Box` to reduce `PeerMessage` enum size

### DIFF
--- a/chain/network-primitives/src/types.rs
+++ b/chain/network-primitives/src/types.rs
@@ -115,11 +115,11 @@ impl RawRoutedMessage {
         author: PeerId,
         secret_key: &SecretKey,
         routed_message_ttl: u8,
-    ) -> RoutedMessage {
+    ) -> Box<RoutedMessage> {
         let target = self.target.peer_id_or_hash().unwrap();
         let hash = RoutedMessage::build_hash(&target, &author, &self.body);
         let signature = secret_key.sign(hash.as_ref());
-        RoutedMessage { target, author, signature, ttl: routed_message_ttl, body: self.body }
+        RoutedMessage { target, author, signature, ttl: routed_message_ttl, body: self.body }.into()
     }
 }
 
@@ -129,7 +129,7 @@ impl RawRoutedMessage {
 #[rtype(result = "bool")]
 pub struct RoutedMessageFrom {
     /// Routed messages.
-    pub msg: RoutedMessage,
+    pub msg: Box<RoutedMessage>,
     /// Previous hop in the route. Used for messages that needs routing back.
     pub from: PeerId,
 }

--- a/chain/network/src/network_protocol.rs
+++ b/chain/network/src/network_protocol.rs
@@ -153,6 +153,10 @@ pub enum HandshakeFailureReason {
     GenesisMismatch(GenesisId),
     InvalidTarget,
 }
+const _: () = assert!(
+    std::mem::size_of::<HandshakeFailureReason>() <= 64,
+    "HandshakeFailureReason > 64 bytes"
+);
 
 impl fmt::Display for HandshakeFailureReason {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
@@ -198,7 +202,7 @@ pub enum PeerMessage {
     Block(Block),
 
     Transaction(SignedTransaction),
-    Routed(RoutedMessage),
+    Routed(Box<RoutedMessage>),
 
     /// Gracefully disconnect from other peer.
     Disconnect,
@@ -212,6 +216,7 @@ pub enum PeerMessage {
     #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
     RoutingTableSyncV2(RoutingSyncV2),
 }
+const _: () = assert!(std::mem::size_of::<PeerMessage>() <= 1144, "PeerMessage > 1144 bytes");
 
 #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
@@ -219,6 +224,8 @@ pub enum PeerMessage {
 pub enum RoutingSyncV2 {
     Version2(RoutingVersion2),
 }
+#[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
+const _: () = assert!(std::mem::size_of::<RoutingSyncV2>() <= 80, "RoutingSyncV2 > 80 bytes");
 
 #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]

--- a/chain/network/src/peer/codec.rs
+++ b/chain/network/src/peer/codec.rs
@@ -180,18 +180,21 @@ mod test {
         let hash = CryptoHash::default();
         let signature = sk.sign(hash.as_ref());
 
-        let msg = PeerMessage::Routed(RoutedMessage {
-            target: PeerIdOrHash::PeerId(PeerId::new(sk.public_key())),
-            author: PeerId::new(sk.public_key()),
-            signature: signature.clone(),
-            ttl: 100,
-            body: RoutedMessageBody::BlockApproval(Approval {
-                account_id: "test2".parse().unwrap(),
-                inner: ApprovalInner::Endorsement(CryptoHash::default()),
-                target_height: 1,
-                signature,
-            }),
-        });
+        let msg = PeerMessage::Routed(
+            RoutedMessage {
+                target: PeerIdOrHash::PeerId(PeerId::new(sk.public_key())),
+                author: PeerId::new(sk.public_key()),
+                signature: signature.clone(),
+                ttl: 100,
+                body: RoutedMessageBody::BlockApproval(Approval {
+                    account_id: "test2".parse().unwrap(),
+                    inner: ApprovalInner::Endorsement(CryptoHash::default()),
+                    target_height: 1,
+                    signature,
+                }),
+            }
+            .into(),
+        );
         test_codec(msg);
     }
 

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -680,15 +680,10 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for PeerActor {
             self.routed_message_cache.put(key, now);
         }
         if let PeerMessage::Routed(routed) = &peer_msg {
-            match routed.as_ref() {
-                RoutedMessage { body: RoutedMessageBody::ForwardTx(_), .. } => {
-                    self.txns_since_last_block.fetch_add(1, Ordering::AcqRel);
-                }
-                _ => {
-                    self.txns_since_last_block.store(0, Ordering::Release);
-                }
+            if let RoutedMessage { body: RoutedMessageBody::ForwardTx(_), .. } = routed.as_ref() {
+                self.txns_since_last_block.fetch_add(1, Ordering::AcqRel);
             }
-        } else {
+        } else if let PeerMessage::Block(_) = &peer_msg {
             self.txns_since_last_block.store(0, Ordering::Release);
         }
 

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -679,12 +679,16 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for PeerActor {
             }
             self.routed_message_cache.put(key, now);
         }
-        if let PeerMessage::Routed(RoutedMessage {
-            body: RoutedMessageBody::ForwardTx(_), ..
-        }) = &peer_msg
-        {
-            self.txns_since_last_block.fetch_add(1, Ordering::AcqRel);
-        } else if let PeerMessage::Block(_) = &peer_msg {
+        if let PeerMessage::Routed(routed) = &peer_msg {
+            match routed.as_ref() {
+                RoutedMessage { body: RoutedMessageBody::ForwardTx(_), .. } => {
+                    self.txns_since_last_block.fetch_add(1, Ordering::AcqRel);
+                }
+                _ => {
+                    self.txns_since_last_block.store(0, Ordering::Release);
+                }
+            }
+        } else {
             self.txns_since_last_block.store(0, Ordering::Release);
         }
 

--- a/chain/network/src/peer/utils.rs
+++ b/chain/network/src/peer/utils.rs
@@ -138,13 +138,16 @@ mod tests {
             )
         };
 
-        PeerMessage::Routed(RoutedMessage {
-            target,
-            author,
-            signature,
-            ttl: 99,
-            body: RoutedMessageBody::ForwardTx(tx),
-        })
+        PeerMessage::Routed(
+            RoutedMessage {
+                target,
+                author,
+                signature,
+                ttl: 99,
+                body: RoutedMessageBody::ForwardTx(tx),
+            }
+            .into(),
+        )
     }
 
     #[test]

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -1333,7 +1333,7 @@ impl PeerManagerActor {
 
     /// Route signed message to target peer.
     /// Return whether the message is sent or not.
-    fn send_signed_message_to_peer(&mut self, msg: RoutedMessage) -> bool {
+    fn send_signed_message_to_peer(&mut self, msg: Box<RoutedMessage>) -> bool {
         // Check if the message is for myself and don't try to send it in that case.
         if let PeerIdOrHash::PeerId(target) = &msg.target {
             if target == &self.my_peer_id {
@@ -1402,7 +1402,7 @@ impl PeerManagerActor {
         self.send_message_to_peer(msg)
     }
 
-    fn sign_routed_message(&self, msg: RawRoutedMessage, my_peer_id: PeerId) -> RoutedMessage {
+    fn sign_routed_message(&self, msg: RawRoutedMessage, my_peer_id: PeerId) -> Box<RoutedMessage> {
         msg.sign(my_peer_id, &self.config.secret_key, self.config.routed_message_ttl)
     }
 


### PR DESCRIPTION
We should reduce size of `PeerMessage` enum to 64 bytes or less.
We can start by doing this for `PeerMessage::Routed` variant.

See #1313 

TODO
- [ ] variant `Challenge`: 1143 bytes                                                                                                                                                                                         
- [ ] variant `Transaction`: 287 bytes 
- [ ] variant `Handshake`: 215 bytes
- [ ] variant `HandshakeV2`: 207 bytes 
- [ ] variant `HandshakeFailure`: 127 bytes
- [ ] variant `RequestUpdateNonce`: 87 bytes