### PR TITLE
feat: Add warning to `near` binary

### DIFF
--- a/neard/src/main.rs
+++ b/neard/src/main.rs
@@ -59,6 +59,7 @@ fn main() {
         println!("WARNING WARNING WARNING");
         println!("Usage of `./near` binary is deprecated since May 2020!!!");
         println!("Use `./neard` instead");
+        panic!("Use ./neard build target");
     }
 
     // We use it to automatically search the for root certificates to perform HTTPS calls

--- a/neard/src/main.rs
+++ b/neard/src/main.rs
@@ -42,7 +42,25 @@ static ALLOC: MyAllocator<tikv_jemallocator::Jemalloc> =
 #[global_allocator]
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
+fn prog() -> Option<String> {
+    env::args()
+        .next()
+        .as_ref()
+        .map(std::path::Path::new)
+        .and_then(std::path::Path::file_name)
+        .and_then(std::ffi::OsStr::to_str)
+        .map(String::from)
+}
+
 fn main() {
+    if prog().map(|name| name == "near").unwrap_or_default() {
+        println!("WARNING WARNING WARNING");
+        println!("WARNING WARNING WARNING");
+        println!("WARNING WARNING WARNING");
+        println!("Usage of `./near` binary is deprecated since May 2020!!!");
+        println!("Use `./neard` instead");
+    }
+
     // We use it to automatically search the for root certificates to perform HTTPS calls
     // (sending telemetry and downloading genesis)
     openssl_probe::init_ssl_cert_env_vars();

--- a/neard/src/main.rs
+++ b/neard/src/main.rs
@@ -1,6 +1,6 @@
 mod cli;
 
-use std::env;
+use std::{env, thread};
 
 use self::cli::NeardCmd;
 use clap::crate_version;
@@ -57,9 +57,16 @@ fn main() {
         println!("WARNING WARNING WARNING");
         println!("WARNING WARNING WARNING");
         println!("WARNING WARNING WARNING");
+        println!("WARNING WARNING WARNING");
+        println!("WARNING WARNING WARNING");
+        println!("WARNING WARNING WARNING");
+        println!("WARNING WARNING WARNING");
+        println!("WARNING WARNING WARNING");
+        println!("WARNING WARNING WARNING");
         println!("Usage of `./near` binary is deprecated since May 2020!!!");
         println!("Use `./neard` instead");
-        panic!("Use ./neard build target");
+        println!("Use ./neard build target");
+        thread::sleep(Duration::from_secs(30));
     }
 
     // We use it to automatically search the for root certificates to perform HTTPS calls


### PR DESCRIPTION
We should phase out usage of `near` binary. We created a new `neard` build target back in May 2020.
We can start by adding a warning and `panic!`.

Once we ship this PR, we will have to wait for 1-2 protocol updates. After that, it will be guaranteed, that anyone connecting to MAINNET will have fixed their scripts.

The main advantage of adding `panic!` is that it allow people to quickly find out that they use wrong binary in their scripts. It's better than using outdated binary by accident.

After, we make sure noone uses `near`, we will be able to safely drop it.

See https://github.com/near/nearcore/issues/5840

The alternative, would be to remove `near` right way.