### PR TITLE
feat: Improve `neard` output while running `./target/debug/neard init`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3342,6 +3342,7 @@ dependencies = [
  "actix-rt",
  "actix-web",
  "actix_derive",
+ "anyhow",
  "awc",
  "borsh 0.9.1",
  "byteorder",
@@ -3393,6 +3394,7 @@ name = "neard"
 version = "0.0.0"
 dependencies = [
  "actix",
+ "anyhow",
  "clap 3.0.0-beta.2",
  "futures",
  "git-version",

--- a/chain/indexer/src/lib.rs
+++ b/chain/indexer/src/lib.rs
@@ -152,4 +152,5 @@ pub fn indexer_init_configs(dir: &std::path::PathBuf, params: InitConfigArgs) {
         params.boot_nodes.as_deref(),
         params.max_gas_burnt_view,
     )
+    .expect("indexer_init_configs")
 }

--- a/nearcore/Cargo.toml
+++ b/nearcore/Cargo.toml
@@ -8,11 +8,12 @@ rust-version = "1.56.0"
 edition = "2021"
 
 [dependencies]
-awc = "3.0.0-beta.5"
 actix = "=0.11.0-beta.2" # Pinned the version to avoid compilation errors
 actix_derive = "=0.6.0-beta.1" # Pinned dependency in addition to actix dependecy (remove this line once the pinning is not needed)
-actix-web = "=4.0.0-beta.6"
 actix-rt = "2"
+actix-web = "=4.0.0-beta.6"
+anyhow = "1"
+awc = "3.0.0-beta.5"
 byteorder = "1.2"
 easy-ext = "0.2"
 chrono = { version = "0.4.4", features = ["serde"] }

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 name = "neard"
 
 [dependencies]
+anyhow = "1"
 clap = "=3.0.0-beta.2"
 actix = "=0.11.0-beta.2"
 tracing = "0.1.13"

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -180,7 +180,7 @@ impl InitCmd {
             self.boot_nodes.as_deref(),
             self.max_gas_burnt_view,
         )
-        .with_context(|| "nearcore::init_configs")
+        .context("failed to initialize configuration")
     }
 }
 

--- a/neard/src/main.rs
+++ b/neard/src/main.rs
@@ -48,5 +48,5 @@ fn main() {
     openssl_probe::init_ssl_cert_env_vars();
     near_performance_metrics::process::schedule_printing_performance_stats(Duration::from_secs(60));
 
-    NeardCmd::parse_and_run()
+    NeardCmd::parse_and_run().expect("NeardCmd::parse_and_run failed")
 }

--- a/neard/src/main.rs
+++ b/neard/src/main.rs
@@ -42,11 +42,11 @@ static ALLOC: MyAllocator<tikv_jemallocator::Jemalloc> =
 #[global_allocator]
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     // We use it to automatically search the for root certificates to perform HTTPS calls
     // (sending telemetry and downloading genesis)
     openssl_probe::init_ssl_cert_env_vars();
     near_performance_metrics::process::schedule_printing_performance_stats(Duration::from_secs(60));
 
-    NeardCmd::parse_and_run().expect("NeardCmd::parse_and_run failed")
+    NeardCmd::parse_and_run()
 }

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -111,7 +111,8 @@ fn main() -> anyhow::Result<()> {
                 None,
                 None,
                 None,
-            );
+            )
+            .expect("init_configs");
 
             let near_config = load_config(&state_dump_path);
             let store = create_store(&get_store_path(&state_dump_path));

--- a/test-utils/state-viewer/src/cli.rs
+++ b/test-utils/state-viewer/src/cli.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 
 static DEFAULT_HOME: Lazy<PathBuf> = Lazy::new(|| get_default_home());
 
-#[derive(Clap)]
+#[derive(Clap, Debug)]
 pub struct StateViewerCmd {
     #[clap(flatten)]
     opts: StateViewerOpts,
@@ -46,7 +46,7 @@ impl StateViewerOpts {
     }
 }
 
-#[derive(Clap)]
+#[derive(Clap, Debug)]
 #[clap(setting = AppSettings::SubcommandRequiredElseHelp)]
 pub enum StateViewerSubCommand {
     #[clap(name = "peers")]
@@ -106,7 +106,7 @@ impl StateViewerSubCommand {
     }
 }
 
-#[derive(Clap)]
+#[derive(Clap, Debug)]
 pub struct DumpStateCmd {
     /// Optionally, can specify at which height to dump state.
     #[clap(long)]
@@ -130,7 +130,7 @@ impl DumpStateCmd {
     }
 }
 
-#[derive(Clap)]
+#[derive(Clap, Debug)]
 pub struct ChainCmd {
     #[clap(long)]
     start_index: BlockHeight,
@@ -144,7 +144,7 @@ impl ChainCmd {
     }
 }
 
-#[derive(Clap)]
+#[derive(Clap, Debug)]
 pub struct ReplayCmd {
     #[clap(long)]
     start_index: BlockHeight,
@@ -158,7 +158,7 @@ impl ReplayCmd {
     }
 }
 
-#[derive(Clap)]
+#[derive(Clap, Debug)]
 pub struct ApplyRangeCmd {
     #[clap(long)]
     start_index: Option<BlockHeight>,
@@ -190,7 +190,7 @@ impl ApplyRangeCmd {
     }
 }
 
-#[derive(Clap)]
+#[derive(Clap, Debug)]
 pub struct ApplyCmd {
     #[clap(long)]
     height: BlockHeight,
@@ -204,7 +204,7 @@ impl ApplyCmd {
     }
 }
 
-#[derive(Clap)]
+#[derive(Clap, Debug)]
 pub struct ViewChainCmd {
     #[clap(long)]
     height: Option<BlockHeight>,
@@ -220,7 +220,7 @@ impl ViewChainCmd {
     }
 }
 
-#[derive(Clap)]
+#[derive(Clap, Debug)]
 pub struct DumpCodeCmd {
     #[clap(long)]
     account_id: String,
@@ -234,7 +234,7 @@ impl DumpCodeCmd {
     }
 }
 
-#[derive(Clap)]
+#[derive(Clap, Debug)]
 pub struct DumpAccountStorageCmd {
     #[clap(long)]
     account_id: String,
@@ -259,7 +259,7 @@ impl DumpAccountStorageCmd {
         );
     }
 }
-#[derive(Clap)]
+#[derive(Clap, Debug)]
 pub struct EpochInfoCmd {
     #[clap(flatten)]
     epoch_selection: epoch_info::EpochSelection,


### PR DESCRIPTION
I tried running `neard init`. I think that the output can be improved a little bit in case of failure.

I did it for one case, as an example:

```
L .~/r/nearcore.master piotr-improve-neard (1/0/0) cargo build -p neard && ./target/debug/neard init
Dec 15 08:39:52.430  INFO neard: Version: trunk, Build: aab139777-modified, Latest Protocol: 50
thread 'main' panicked at 'NeardCmd::parse_and_run failed: Init command failed InitCmd { download_genesis: false, download_config: false, fast: false, account_id: None, chain_id: None, download_genesis_url: None, download_config_url: None, genesis: None, boot_nodes: None, num_shards: 1, test_seed: None, max_gas_burnt_view: None }

Caused by:
    0: nearcore::init_configs
    1: Can't create new config, it already exists.
                    Use `neard unsafe_reset_all` to delete it.
                    folder = "/home/pmnoxx/.near"
                    chain_id = "test-chain-1ORDx"
                    path = "/home/pmnoxx/.near/genesis.json"', neard/src/main.rs:51:31
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I'm debugging, why node doesn't start on my machine. And, it's hard to figure out why, without reading the code deeply. I'm adding information to code paths, which failed for me.