### PR TITLE
pytest: remove `utils.Unbuffered`

### DIFF
--- a/pytest/lib/utils.py
+++ b/pytest/lib/utils.py
@@ -214,27 +214,6 @@ def user_name():
     return username
 
 
-# from https://stackoverflow.com/questions/107705/disable-output-buffering
-# this class allows making print always flush by executing
-#
-#     sys.stdout = Unbuffered(sys.stdout)
-class Unbuffered(object):
-
-    def __init__(self, stream):
-        self.stream = stream
-
-    def write(self, data):
-        self.stream.write(data)
-        self.stream.flush()
-
-    def writelines(self, datas):
-        self.stream.writelines(datas)
-        self.stream.flush()
-
-    def __getattr__(self, attr):
-        return getattr(self.stream, attr)
-
-
 def collect_gcloud_config(num_nodes):
     tempdir = get_near_tempdir()
     keys = []

--- a/pytest/tests/stress/stress.py
+++ b/pytest/tests/stress/stress.py
@@ -34,11 +34,9 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
 
 from cluster import init_cluster, spin_up_node, load_config
 from configured_logger import logger
-from utils import TxContext, Unbuffered
 from transaction import sign_payment_tx, sign_staking_tx
 from proxy_instances import RejectListProxy
 
-sys.stdout = Unbuffered(sys.stdout)
 logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
 
 TIMEOUT = 1500  # after how much time to shut down the test
@@ -79,9 +77,8 @@ def stress_process(func):
     def wrapper(stopped, error, *args):
         try:
             func(stopped, error, *args)
-        except Exception as e:
-            traceback.print_exc()
-            logger.info(f"Process {func.__name__} failed with {repr(e)}")
+        except Exception as ex:
+            logger.info(f'Process {func.__name__} failed', exc_info=ex)
             error.value = 1
 
     wrapper.__name__ = func.__name__


### PR DESCRIPTION
The tests use logging which writes to standard error so making
standard output unbuffered doesn’t do anything.  Furthermore, there is
no reason to make test’s output unbuffered.