### PR TITLE
chain: indexer: avoid vector reallocation

### DIFF
--- a/chain/indexer/src/streamer/mod.rs
+++ b/chain/indexer/src/streamer/mod.rs
@@ -65,11 +65,9 @@ async fn build_streamer_message(
         as near_primitives::types::NumShards;
 
     let mut shards_outcomes = fetch_outcomes(&client, block.header.hash).await?;
-    let mut indexer_shards = (0..num_shards).map(|shard_id| IndexerShard {
-        shard_id,
-        chunk: None,
-        receipt_execution_outcomes: vec![],
-    }).collect::<Vec<_>>();
+    let mut indexer_shards = (0..num_shards)
+        .map(|shard_id| IndexerShard { shard_id, chunk: None, receipt_execution_outcomes: vec![] })
+        .collect::<Vec<_>>();
 
     for chunk in chunks {
         let views::ChunkView { transactions, author, header, receipts: chunk_non_local_receipts } =

--- a/chain/indexer/src/streamer/mod.rs
+++ b/chain/indexer/src/streamer/mod.rs
@@ -65,15 +65,11 @@ async fn build_streamer_message(
         as near_primitives::types::NumShards;
 
     let mut shards_outcomes = fetch_outcomes(&client, block.header.hash).await?;
-    let mut indexer_shards: Vec<IndexerShard> = vec![];
-
-    for shard_id in 0..num_shards {
-        indexer_shards.push(IndexerShard {
-            shard_id,
-            chunk: None,
-            receipt_execution_outcomes: vec![],
-        })
-    }
+    let mut indexer_shards = (0..num_shards).map(|shard_id| IndexerShard {
+        shard_id,
+        chunk: None,
+        receipt_execution_outcomes: vec![],
+    }).collect::<Vec<_>>();
 
     for chunk in chunks {
         let views::ChunkView { transactions, author, header, receipts: chunk_non_local_receipts } =


### PR DESCRIPTION
Micro-optimisation creating a vector using `collect` iterator method
rather than pushing in a loop.  The former can use size hints to
figure out size of the vector.