### PR TITLE
chain: indexer: avoid base58→string conversion

### DIFF
--- a/chain/indexer/src/streamer/mod.rs
+++ b/chain/indexer/src/streamer/mod.rs
@@ -32,12 +32,35 @@ mod types;
 mod utils;
 
 const INTERVAL: Duration = Duration::from_millis(500);
-// Blocks #47317863 and #47317864
-// with restored receipts
-const PROBLEMATIC_BLOKS: [&'static str; 2] = [
-    "ErdT2vLmiMjkRoSUfgowFYXvhGaLJZUWrgimHRkousrK",
-    "2Fr7dVAZGoPYgpwj6dfASSde6Za34GNUJb4CkZ8NSQqw",
+
+/// Blocks #47317863 and #47317864 with restored receipts.
+const PROBLEMATIC_BLOKS: [CryptoHash; 2] = [
+    CryptoHash(
+        *b"\xcd\xde\x9a\x3f\x5d\xdf\xb4\x2c\xb9\x9b\xf4\x8c\x04\x95\x6f\x5b\
+           \xa0\xb7\x29\xe2\xa5\x04\xf8\xbd\x9c\x86\x92\xd6\x16\x8c\xcf\x14",
+    ),
+    CryptoHash(
+        *b"\x12\xa9\x5a\x1a\x3d\x14\xa7\x36\xb3\xce\xe6\xea\x07\x20\x8e\x75\
+           \x4e\xb5\xc2\xd7\xf9\x11\xca\x29\x09\xe0\xb8\x85\xb5\x2b\x95\x6a",
+    ),
 ];
+
+/// Tests whether raw hashes in [`PROBLEMATIC_BLOKS`] match expected
+/// user-readable hashes.  Ideally we would compute the hashes at compile time
+/// but there’s no const function for base58→bytes conversion so instead we’re
+/// hard-coding the raw base in [`PROBLEMATIC_BLOKS`] and have this test to
+/// confirm the raw values are correct.
+#[test]
+fn test_problematic_blocks_hash() {
+    let got: Vec<String> = PROBLEMATIC_BLOKS.iter().map(std::string::ToString::to_string).collect();
+    assert_eq!(
+        vec![
+            "ErdT2vLmiMjkRoSUfgowFYXvhGaLJZUWrgimHRkousrK",
+            "2Fr7dVAZGoPYgpwj6dfASSde6Za34GNUJb4CkZ8NSQqw"
+        ],
+        got
+    );
+}
 
 /// This function supposed to return the entire `StreamerMessage`.
 /// It fetches the block and all related parts (chunks, outcomes, state changes etc.)
@@ -168,7 +191,7 @@ async fn build_streamer_message(
         // so it was decided to artificially include the Receipts into the Chunk of the Block where
         // ExecutionOutcomes appear.
         // ref: https://github.com/near/nearcore/pull/4248
-        if PROBLEMATIC_BLOKS.contains(&block.header.hash.to_string().as_str()) {
+        if PROBLEMATIC_BLOKS.contains(&block.header.hash) {
             let protocol_config =
                 fetchers::fetch_protocol_config(&client, block.header.hash).await?;
 


### PR DESCRIPTION
Rather than storing base58 hashes of problematic blocks store
`CryptoHash` objects.  This avoids base58→string conversion each time
the `PROBLEMATIC_BLOKS` array is read.