### PR TITLE
Update code owners for `/utils`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,7 +9,7 @@
 /chain/jsonrpc-primitives/ @khorolets @miraclx @chefsale
 /chain/indexer/ @khorolets
 /chain/rosetta-rpc/ @frol @mina86
-/utils @pmnoxx
+/utils @pmnoxx @mm-near
 
 /runtime/ @bowenwang1996 @EgorKulikov @mzhangmzz @mm-near
 /runtime/runtime-params-estimator/ @olonho @matklad

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,6 +9,7 @@
 /chain/jsonrpc-primitives/ @khorolets @miraclx @chefsale
 /chain/indexer/ @khorolets
 /chain/rosetta-rpc/ @frol @mina86
+/utils @pmnoxx
 
 /runtime/ @bowenwang1996 @EgorKulikov @mzhangmzz @mm-near
 /runtime/runtime-params-estimator/ @olonho @matklad


### PR DESCRIPTION
I added `/utils` a while back. We have code there that's used in production, and it's better to make sure I review all changes to it.