### PR TITLE
buf: Fix `RoutedMessage` `canonicity` in `PartialEncodedChunkRequestMsg`

### DIFF
--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -568,9 +568,9 @@ impl ShardsManager {
                     chunk_hash: chunk_hash.clone(),
                     part_ords,
                     tracking_shards: if target_account == shard_representative_target {
-                        shards_to_fetch_receipts.clone()
+                        shards_to_fetch_receipts.iter().cloned().collect()
                     } else {
-                        HashSet::new()
+                        Default::default()
                     },
                 };
                 let target = AccountIdOrPeerTrackingShard {

--- a/chain/client/src/tests/chunks_management.rs
+++ b/chain/client/src/tests/chunks_management.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use crate::test_utils::TestEnv;
 use near_chain::ChainGenesis;
 use near_crypto::KeyType;
@@ -25,7 +23,7 @@ fn test_request_chunk_restart() {
     let request = PartialEncodedChunkRequestMsg {
         chunk_hash: block1.chunks()[0].chunk_hash(),
         part_ords: vec![0],
-        tracking_shards: HashSet::default(),
+        tracking_shards: Default::default(),
     };
     let client = &mut env.clients[0];
     client.shards_mgr.process_partial_encoded_chunk_request(

--- a/chain/network-primitives/src/types.rs
+++ b/chain/network-primitives/src/types.rs
@@ -995,7 +995,7 @@ impl Message for QueryPeerStats {
 pub struct PartialEncodedChunkRequestMsg {
     pub chunk_hash: ChunkHash,
     pub part_ords: Vec<u64>,
-    pub tracking_shards: HashSet<ShardId>,
+    pub tracking_shards: Vec<ShardId>,
 }
 
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]


### PR DESCRIPTION
`PartialEncodedChunkRequestMsg` is part of our protocol. It can be encoded in multiple ways. We should change `tracking_shards` from `HashSet<...>` to `Vec<...>`. Fortunately, both have the same representation in `borsh`.

Side notes
- As a side effect, we will use less memory, and code became more efficient.

TODO:
- write a script, that verified canonicity of all messages in network protocol