### PR TITLE
re: Fix `clippy::redundant_clone `

### DIFF
--- a/chain/chunks/src/test_utils.rs
+++ b/chain/chunks/src/test_utils.rs
@@ -203,7 +203,7 @@ impl Default for ChunkForwardingTestFixture {
 
         const TEST_SEED: RngSeed = [3; 32];
         let mut producer_shard_manager = ShardsManager::new(
-            Some(mock_chunk_producer.clone()),
+            Some(mock_chunk_producer),
             mock_runtime.clone(),
             mock_network.clone(),
             TEST_SEED,
@@ -242,11 +242,8 @@ impl Default for ChunkForwardingTestFixture {
                 mock_runtime.get_part_owner(&mock_parent_hash, *p).unwrap() == mock_chunk_part_owner
             })
             .collect();
-        let encoded_chunk = mock_chunk.create_partial_encoded_chunk(
-            all_part_ords.clone(),
-            Vec::new(),
-            &mock_merkles,
-        );
+        let encoded_chunk =
+            mock_chunk.create_partial_encoded_chunk(all_part_ords, Vec::new(), &mock_merkles);
         let chain_store = ChainStore::new(store, 0);
 
         ChunkForwardingTestFixture {

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -438,7 +438,7 @@ impl Client {
         let next_bp_hash = if prev_epoch_id != epoch_id {
             Chain::compute_bp_hash(
                 &*self.runtime_adapter,
-                next_epoch_id.clone(),
+                next_epoch_id,
                 epoch_id.clone(),
                 &prev_hash,
             )?
@@ -959,7 +959,7 @@ impl Client {
         if Some(&next_block_producer) == self.validator_signer.as_ref().map(|x| x.validator_id()) {
             self.collect_block_approval(&approval, ApprovalType::SelfApproval);
         } else {
-            debug!(target: "client", "Sending an approval {:?} from {} to {} for {}", approval.inner, approval.account_id, next_block_producer.clone(), approval.target_height);
+            debug!(target: "client", "Sending an approval {:?} from {} to {} for {}", approval.inner, approval.account_id, next_block_producer, approval.target_height);
             let approval_message = ApprovalMessage::new(approval, next_block_producer);
             self.network_adapter.do_send(PeerManagerMessageRequest::NetworkRequests(
                 NetworkRequests::Approval { approval_message },

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -235,7 +235,7 @@ fn display_sync_status(
             )
         }
         SyncStatus::StateSync(sync_hash, shard_statuses) => {
-            let mut res = format!("State {:?}", sync_hash).to_string();
+            let mut res = format!("State {:?}", sync_hash);
             let mut shard_statuses: Vec<_> = shard_statuses.iter().collect();
             shard_statuses.sort_by_key(|(shard_id, _)| *shard_id);
             for (shard_id, shard_status) in shard_statuses {

--- a/chain/client/src/sync.rs
+++ b/chain/client/src/sync.rs
@@ -119,7 +119,7 @@ impl EpochSync {
             peer_to_last_request_time: HashMap::new(),
             peers_reporting_up_to_date: HashSet::new(),
             current_epoch_id: genesis_epoch_id.clone(),
-            next_epoch_id: genesis_next_epoch_id.clone(),
+            next_epoch_id: genesis_next_epoch_id,
             next_block_producers: first_epoch_block_producers,
             requested_epoch_id: genesis_epoch_id,
             last_request_time: Clock::utc(),
@@ -1620,7 +1620,7 @@ mod test {
             env.process_block(1, blocks[i - 1].clone(), Provenance::NONE);
         }
         block_sync.block_sync(&mut env.clients[1].chain, &peer_infos).unwrap();
-        let requested_block_hashes = collect_hashes_from_network_adapter(network_adapter.clone());
+        let requested_block_hashes = collect_hashes_from_network_adapter(network_adapter);
         assert!(requested_block_hashes.is_empty());
     }
 
@@ -1653,7 +1653,7 @@ mod test {
         }
         let is_state_sync = block_sync.block_sync(&mut env.clients[1].chain, &peer_infos).unwrap();
         assert!(!is_state_sync);
-        let requested_block_hashes = collect_hashes_from_network_adapter(network_adapter.clone());
+        let requested_block_hashes = collect_hashes_from_network_adapter(network_adapter);
         assert_eq!(
             requested_block_hashes,
             blocks.iter().take(1).map(|b| *b.hash()).collect::<HashSet<_>>()

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -226,10 +226,10 @@ pub fn setup_only_view(
 
     start_view_client(
         Some(signer.validator_id().clone()),
-        chain_genesis.clone(),
-        runtime.clone(),
+        chain_genesis,
+        runtime,
         network_adapter.clone(),
-        config.clone(),
+        config,
         #[cfg(feature = "test_features")]
         adv.clone(),
     )
@@ -1277,7 +1277,7 @@ impl TestEnvBuilder {
                         };
                         setup_client_with_runtime(
                             u64::try_from(num_validators).unwrap(),
-                            Some(account_id.clone()),
+                            Some(account_id),
                             false,
                             network_adapter.clone(),
                             chain_genesis.clone(),

--- a/chain/client/src/tests/bug_repros.rs
+++ b/chain/client/src/tests/bug_repros.rs
@@ -52,7 +52,7 @@ fn repro_1183() {
         let delayed_one_parts: Arc<RwLock<Vec<NetworkRequests>>> = Arc::new(RwLock::new(vec![]));
         let (_, conn, _) = setup_mock_all_validators(
             validators.clone(),
-            key_pairs.clone(),
+            key_pairs,
             validator_groups,
             true,
             200,

--- a/chain/client/src/tests/chunks_management.rs
+++ b/chain/client/src/tests/chunks_management.rs
@@ -174,12 +174,12 @@ fn store_partial_encoded_chunk_sanity() {
     assert_eq!(partial_encoded_chunks[&0], vec![partial_encoded_chunk.clone()]);
     assert_eq!(
         partial_encoded_chunks[&173465755],
-        vec![partial_encoded_chunk2.clone(), partial_encoded_chunk3.clone()]
+        vec![partial_encoded_chunk2, partial_encoded_chunk3]
     );
 
     // Check horizon
     env.produce_block(0, 3);
-    let mut partial_encoded_chunk3 = partial_encoded_chunk.clone();
+    let mut partial_encoded_chunk3 = partial_encoded_chunk;
     let mut h = ShardChunkHeader::V2(ShardChunkHeaderV2::new(
         CryptoHash::default(),
         CryptoHash::default(),
@@ -208,9 +208,7 @@ fn store_partial_encoded_chunk_sanity() {
         .store_partial_encoded_chunk(block.header(), partial_encoded_chunk3.clone());
     assert_eq!(env.clients[0].shards_mgr.pop_stored_partial_encoded_chunks(9).len(), 0);
     h = update_chunk_height_created(h, 5);
-    partial_encoded_chunk3.header = h.clone();
-    env.clients[0]
-        .shards_mgr
-        .store_partial_encoded_chunk(block.header(), partial_encoded_chunk3.clone());
+    partial_encoded_chunk3.header = h;
+    env.clients[0].shards_mgr.store_partial_encoded_chunk(block.header(), partial_encoded_chunk3);
     assert_eq!(env.clients[0].shards_mgr.pop_stored_partial_encoded_chunks(5).len(), 1);
 }

--- a/chain/client/src/tests/cross_shard_tx.rs
+++ b/chain/client/src/tests/cross_shard_tx.rs
@@ -46,7 +46,7 @@ fn test_keyvalue_runtime_balances() {
 
         let (_, conn, _) = setup_mock_all_validators(
             validators.clone(),
-            key_pairs.clone(),
+            key_pairs,
             validator_groups,
             true,
             100,

--- a/chain/epoch_manager/src/lib.rs
+++ b/chain/epoch_manager/src/lib.rs
@@ -1857,11 +1857,11 @@ mod tests2 {
             stake("test2".parse().unwrap(), amount_staked),
         ];
         let mut epoch_manager = EpochManager::new(
-            store.clone(),
-            config.clone(),
+            store,
+            config,
             PROTOCOL_VERSION,
             default_reward_calculator(),
-            validators.clone(),
+            validators,
         )
         .unwrap();
         let h = hash_range(8);
@@ -1927,11 +1927,11 @@ mod tests2 {
             stake("test2".parse().unwrap(), amount_staked),
         ];
         let mut epoch_manager = EpochManager::new(
-            store.clone(),
-            config.clone(),
+            store,
+            config,
             PROTOCOL_VERSION,
             default_reward_calculator(),
-            validators.clone(),
+            validators,
         )
         .unwrap();
 
@@ -1999,11 +1999,11 @@ mod tests2 {
             stake("test2".parse().unwrap(), amount_staked),
         ];
         let mut epoch_manager = EpochManager::new(
-            store.clone(),
-            config.clone(),
+            store,
+            config,
             PROTOCOL_VERSION,
             default_reward_calculator(),
-            validators.clone(),
+            validators,
         )
         .unwrap();
 
@@ -3673,14 +3673,8 @@ mod tests2 {
             stake("test1".parse().unwrap(), amount_staked),
             stake("test2".parse().unwrap(), amount_staked),
         ];
-        let mut epoch_manager = EpochManager::new(
-            store.clone(),
-            config.clone(),
-            0,
-            default_reward_calculator(),
-            validators.clone(),
-        )
-        .unwrap();
+        let mut epoch_manager =
+            EpochManager::new(store, config, 0, default_reward_calculator(), validators).unwrap();
         let h = hash_range(8);
         record_block(&mut epoch_manager, CryptoHash::default(), h[0], 0, vec![]);
         let mut block_info1 =
@@ -3719,11 +3713,11 @@ mod tests2 {
         ];
         let new_protocol_version = SimpleNightshade.protocol_version();
         let mut epoch_manager = EpochManager::new(
-            store.clone(),
-            config.clone(),
+            store,
+            config,
             new_protocol_version - 1,
             default_reward_calculator(),
-            validators.clone(),
+            validators,
         )
         .unwrap();
         let h = hash_range(8);
@@ -3810,14 +3804,8 @@ mod tests2 {
             stake("test1".parse().unwrap(), amount_staked),
             stake("test2".parse().unwrap(), amount_staked / 5),
         ];
-        let mut epoch_manager = EpochManager::new(
-            store.clone(),
-            config.clone(),
-            0,
-            default_reward_calculator(),
-            validators.clone(),
-        )
-        .unwrap();
+        let mut epoch_manager =
+            EpochManager::new(store, config, 0, default_reward_calculator(), validators).unwrap();
         let h = hash_range(50);
         record_block(&mut epoch_manager, CryptoHash::default(), h[0], 0, vec![]);
         let mut block_info1 =
@@ -3848,11 +3836,11 @@ mod tests2 {
             stake("test2".parse().unwrap(), amount_staked),
         ];
         let mut epoch_manager = EpochManager::new(
-            store.clone(),
-            config.clone(),
+            store,
+            config,
             UPGRADABILITY_FIX_PROTOCOL_VERSION,
             default_reward_calculator(),
-            validators.clone(),
+            validators,
         )
         .unwrap();
         let h = hash_range(5 * epoch_length);

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -93,10 +93,7 @@ impl AllEpochConfig {
             config.avg_hidden_validator_seats_per_shard = avg_hidden_validator_seats_per_shard;
             config.shard_layout = shard_layout;
         }
-        Self {
-            genesis_epoch_config: genesis_epoch_config.clone(),
-            simple_nightshade_epoch_config: config,
-        }
+        Self { genesis_epoch_config: genesis_epoch_config, simple_nightshade_epoch_config: config }
     }
 
     pub fn for_protocol_version(&self, protocol_version: ProtocolVersion) -> &EpochConfig {

--- a/core/primitives/src/runtime/config_store.rs
+++ b/core/primitives/src/runtime/config_store.rs
@@ -49,7 +49,7 @@ impl RuntimeConfigStore {
             store.insert(0, Arc::new(config.clone()));
 
             config.storage_amount_per_byte = 10u128.pow(19);
-            store.insert(42, Arc::new(config.clone()));
+            store.insert(42, Arc::new(config));
         }
 
         Self { store }

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -170,7 +170,7 @@ impl StoreUpdate {
     pub fn new_with_tries(tries: ShardTries) -> Self {
         let storage = tries.get_store().storage.clone();
         let transaction = storage.transaction();
-        StoreUpdate { storage, transaction, tries: Some(tries.clone()) }
+        StoreUpdate { storage, transaction, tries: Some(tries) }
     }
 
     pub fn update_refcount(&mut self, column: DBCol, key: &[u8], value: &[u8], rc_delta: i64) {

--- a/integration-tests/src/tests/client/challenges.rs
+++ b/integration-tests/src/tests/client/challenges.rs
@@ -479,7 +479,7 @@ fn test_receive_invalid_chunk_as_chunk_producer() {
         env.clients[0].runtime_adapter.build_receipts_hashes(&receipts, &shard_layout);
     let (_receipts_root, receipts_proofs) = merklize(&receipts_hashes);
     let receipts_by_shard =
-        env.clients[0].shards_mgr.group_receipts_by_shard(receipts.clone(), &shard_layout);
+        env.clients[0].shards_mgr.group_receipts_by_shard(receipts, &shard_layout);
     let one_part_receipt_proofs = env.clients[0].shards_mgr.receipts_recipient_filter(
         0,
         Vec::default(),
@@ -495,7 +495,7 @@ fn test_receive_invalid_chunk_as_chunk_producer() {
     assert!(env.clients[1]
         .process_partial_encoded_chunk(MaybeValidated::from(partial_encoded_chunk))
         .is_ok());
-    env.process_block(1, block.clone(), Provenance::NONE);
+    env.process_block(1, block, Provenance::NONE);
 
     // At this point we should create a challenge and send it out.
     let last_message = env.network_adapters[0].pop().unwrap().as_network_requests();
@@ -622,12 +622,12 @@ fn test_challenge_in_different_epoch() {
     let runtime1 = Arc::new(nearcore::NightshadeRuntime::test(
         Path::new("../../../.."),
         create_test_store(),
-        &genesis.clone(),
+        &genesis,
     ));
     let runtime2 = Arc::new(nearcore::NightshadeRuntime::test(
         Path::new("../../../.."),
         create_test_store(),
-        &genesis.clone(),
+        &genesis,
     ));
     let mut chain_genesis = ChainGenesis::test();
     chain_genesis.epoch_length = 3;

--- a/integration-tests/src/tests/client/chunks_management.rs
+++ b/integration-tests/src/tests/client/chunks_management.rs
@@ -36,7 +36,7 @@ fn chunks_produced_and_distributed_common(
     let connectors: Arc<RwLock<Vec<(Addr<ClientActor>, Addr<ViewClientActor>)>>> =
         Arc::new(RwLock::new(vec![]));
     let heights = Arc::new(RwLock::new(HashMap::new()));
-    let heights1 = heights.clone();
+    let heights1 = heights;
 
     let height_to_hash = Arc::new(RwLock::new(HashMap::new()));
     let height_to_epoch = Arc::new(RwLock::new(HashMap::new()));
@@ -72,7 +72,7 @@ fn chunks_produced_and_distributed_common(
 
     let (_, conn, _) = setup_mock_all_validators(
         validators.clone(),
-        key_pairs.clone(),
+        key_pairs,
         validator_groups,
         true,
         block_timeout,

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -676,14 +676,14 @@ fn invalid_blocks_common(is_requested: bool) {
             ));
 
             // Send proper block.
-            let block2 = valid_block.clone();
+            let block2 = valid_block;
             client.do_send(NetworkClientMessages::Block(
                 block2.clone(),
                 PeerInfo::random().id,
                 is_requested,
             ));
             if is_requested {
-                let mut block3 = block2.clone();
+                let mut block3 = block2;
                 block3.mut_header().get_mut().inner_rest.chunk_headers_root = hash(&[1]);
                 block3.mut_header().get_mut().init();
                 client.do_send(NetworkClientMessages::Block(
@@ -962,7 +962,7 @@ fn client_sync_headers() {
             num_connected_peers: 1,
             peer_max_count: 1,
             highest_height_peers: vec![FullPeerInfo {
-                peer_info: peer_info2.clone(),
+                peer_info: peer_info2,
                 chain_info: PeerChainInfoV2 {
                     genesis_id: Default::default(),
                     height: 5,
@@ -1480,7 +1480,7 @@ fn test_gc_chunk_tail() {
     let mut chain_genesis = ChainGenesis::test();
     let epoch_length = 100;
     chain_genesis.epoch_length = epoch_length;
-    let mut env = TestEnv::builder(chain_genesis.clone()).build();
+    let mut env = TestEnv::builder(chain_genesis).build();
     let mut chunk_tail = 0;
     for i in (1..10).chain(101..epoch_length * 6) {
         env.produce_block(0, i);
@@ -1641,8 +1641,7 @@ fn test_gc_fork_tail() {
 fn test_tx_forwarding() {
     let mut chain_genesis = ChainGenesis::test();
     chain_genesis.epoch_length = 100;
-    let mut env =
-        TestEnv::builder(chain_genesis.clone()).clients_count(50).validator_seats(50).build();
+    let mut env = TestEnv::builder(chain_genesis).clients_count(50).validator_seats(50).build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     let genesis_hash = *genesis_block.hash();
     // forward to 2 chunk producers
@@ -1654,8 +1653,7 @@ fn test_tx_forwarding() {
 fn test_tx_forwarding_no_double_forwarding() {
     let mut chain_genesis = ChainGenesis::test();
     chain_genesis.epoch_length = 100;
-    let mut env =
-        TestEnv::builder(chain_genesis.clone()).clients_count(50).validator_seats(50).build();
+    let mut env = TestEnv::builder(chain_genesis).clients_count(50).validator_seats(50).build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     let genesis_hash = *genesis_block.hash();
     env.clients[0].process_tx(SignedTransaction::empty(genesis_hash), true, false);
@@ -2098,7 +2096,7 @@ fn test_not_process_height_twice() {
 fn test_block_height_processed_orphan() {
     let mut env = TestEnv::builder(ChainGenesis::test()).build();
     let block = env.clients[0].produce_block(1).unwrap().unwrap();
-    let mut orphan_block = block.clone();
+    let mut orphan_block = block;
     let validator_signer =
         InMemoryValidatorSigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
     orphan_block.mut_header().get_mut().prev_hash = hash(&[1]);
@@ -2641,7 +2639,7 @@ fn test_wasmer2_upgrade() {
         let block_producer =
             env.clients[0].runtime_adapter.get_block_producer(&epoch_id, tip.height).unwrap();
         let mut block = env.clients[0].produce_block(tip.height + 1).unwrap().unwrap();
-        set_block_protocol_version(&mut block, block_producer.clone(), new_protocol_version);
+        set_block_protocol_version(&mut block, block_producer, new_protocol_version);
         let (_, res) = env.clients[0].process_block(block.clone().into(), Provenance::NONE);
         assert!(res.is_ok());
     }
@@ -2908,7 +2906,7 @@ fn test_query_final_state() {
         .unwrap();
     let fork2_block = env.clients[0].produce_block(6).unwrap().unwrap();
     assert_eq!(fork1_block.header().prev_hash(), fork2_block.header().prev_hash());
-    env.process_block(0, fork1_block.clone(), Provenance::NONE);
+    env.process_block(0, fork1_block, Provenance::NONE);
     assert_eq!(env.clients[0].chain.head().unwrap().height, 5);
 
     let runtime_adapter = env.clients[0].runtime_adapter.clone();
@@ -2918,7 +2916,7 @@ fn test_query_final_state() {
         "test0".parse().unwrap(),
     );
 
-    env.process_block(0, fork2_block.clone(), Provenance::NONE);
+    env.process_block(0, fork2_block, Provenance::NONE);
     assert_eq!(env.clients[0].chain.head().unwrap().height, 6);
 
     let runtime_adapter = env.clients[0].runtime_adapter.clone();
@@ -3379,7 +3377,7 @@ fn test_limit_contract_functions_number_upgrade() {
         let block_producer =
             env.clients[0].runtime_adapter.get_block_producer(&epoch_id, tip.height).unwrap();
         let mut block = env.clients[0].produce_block(tip.height + 1).unwrap().unwrap();
-        set_block_protocol_version(&mut block, block_producer.clone(), new_protocol_version);
+        set_block_protocol_version(&mut block, block_producer, new_protocol_version);
         let (_, res) = env.clients[0].process_block(block.clone().into(), Provenance::NONE);
         assert!(res.is_ok());
     }
@@ -3388,7 +3386,7 @@ fn test_limit_contract_functions_number_upgrade() {
     let new_outcome = {
         let tip = env.clients[0].chain.head().unwrap();
         let signed_transaction =
-            Transaction { nonce: 11, block_hash: tip.last_block_hash, ..tx.clone() }.sign(&signer);
+            Transaction { nonce: 11, block_hash: tip.last_block_hash, ..tx }.sign(&signer);
         let tx_hash = signed_transaction.get_hash();
         env.clients[0].process_tx(signed_transaction, false, false);
         for i in 0..3 {
@@ -3550,7 +3548,7 @@ mod access_key_nonce_range_tests {
         // Check that sending money from implicit account with correct nonce is still valid.
         let send_money_from_implicit_account_tx = SignedTransaction::send_money(
             (height - 1) * AccessKey::ACCESS_KEY_NONCE_RANGE_MULTIPLIER,
-            implicit_account_id.clone(),
+            implicit_account_id,
             "test0".parse().unwrap(),
             &implicit_account_signer,
             100,
@@ -3676,7 +3674,7 @@ mod access_key_nonce_range_tests {
         let epoch_length = 10;
 
         let accounts: Vec<AccountId> =
-            (0..num_clients).map(|i| format!("test{}", i).to_string().parse().unwrap()).collect();
+            (0..num_clients).map(|i| format!("test{}", i).parse().unwrap()).collect();
         let mut genesis = Genesis::test(accounts, num_validators);
         genesis.config.epoch_length = epoch_length;
         let chain_genesis = ChainGenesis::from(&genesis);

--- a/integration-tests/src/tests/client/runtimes.rs
+++ b/integration-tests/src/tests/client/runtimes.rs
@@ -68,7 +68,7 @@ fn test_invalid_approvals() {
     let network_adapter = Arc::new(MockPeerManagerAdapter::default());
     let mut env = TestEnv::builder(ChainGenesis::test())
         .runtime_adapters(create_runtimes(1))
-        .network_adapters(vec![network_adapter.clone()])
+        .network_adapters(vec![network_adapter])
         .build();
     let signer =
         InMemoryValidatorSigner::from_seed("random".parse().unwrap(), KeyType::ED25519, "random");

--- a/integration-tests/src/tests/client/sharding_upgrade.rs
+++ b/integration-tests/src/tests/client/sharding_upgrade.rs
@@ -58,9 +58,8 @@ impl TestShardUpgradeEnv {
         gas_limit: Option<u64>,
     ) -> Self {
         let mut rng = thread_rng();
-        let validators: Vec<AccountId> = (0..num_validators)
-            .map(|i| format!("test{}", i).to_string().parse().unwrap())
-            .collect();
+        let validators: Vec<AccountId> =
+            (0..num_validators).map(|i| format!("test{}", i).parse().unwrap()).collect();
         let initial_accounts =
             [validators, gen_unique_accounts(&mut rng, num_init_accounts)].concat();
         let genesis =
@@ -585,7 +584,7 @@ fn setup_test_env_with_cross_contract_txs(
                         nonce,
                         &genesis_hash,
                     );
-                    new_accounts.insert(tx.get_hash(), account_id.clone());
+                    new_accounts.insert(tx.get_hash(), account_id);
                     return tx;
                 }
             })

--- a/integration-tests/src/tests/nearcore/stake_nodes.rs
+++ b/integration-tests/src/tests/nearcore/stake_nodes.rs
@@ -385,7 +385,7 @@ fn test_validator_join() {
 
             let (done1, done2) =
                 (Arc::new(AtomicBool::new(false)), Arc::new(AtomicBool::new(false)));
-            let (done1_copy1, done2_copy1) = (done1.clone(), done2.clone());
+            let (done1_copy1, done2_copy1) = (done1, done2);
             WaitOrTimeoutActor::new(
                 Box::new(move |_ctx| {
                     let test_nodes = test_nodes.clone();
@@ -488,7 +488,7 @@ fn test_inflation() {
 
             let (done1, done2) =
                 (Arc::new(AtomicBool::new(false)), Arc::new(AtomicBool::new(false)));
-            let (done1_copy1, done2_copy1) = (done1.clone(), done2.clone());
+            let (done1_copy1, done2_copy1) = (done1, done2);
             WaitOrTimeoutActor::new(
                 Box::new(move |_ctx| {
                     let (done1_copy2, done2_copy2) = (done1_copy1.clone(), done2_copy1.clone());

--- a/integration-tests/src/tests/nearcore/sync_nodes.rs
+++ b/integration-tests/src/tests/nearcore/sync_nodes.rs
@@ -286,7 +286,7 @@ fn sync_state_stake_change() {
             let started = Arc::new(AtomicBool::new(false));
             let dir2_path = dir2.path().to_path_buf();
             let arbiters_holder = Arc::new(RwLock::new(vec![]));
-            let arbiters_holder2 = arbiters_holder.clone();
+            let arbiters_holder2 = arbiters_holder;
             WaitOrTimeoutActor::new(
                 Box::new(move |_ctx| {
                     let started_copy = started.clone();

--- a/integration-tests/src/tests/nearcore/sync_state_nodes.rs
+++ b/integration-tests/src/tests/nearcore/sync_state_nodes.rs
@@ -32,7 +32,7 @@ fn sync_state_nodes() {
 
             let view_client2_holder = Arc::new(RwLock::new(None));
             let arbiters_holder = Arc::new(RwLock::new(vec![]));
-            let arbiters_holder2 = arbiters_holder.clone();
+            let arbiters_holder2 = arbiters_holder;
 
             WaitOrTimeoutActor::new(
                 Box::new(move |_ctx| {
@@ -167,7 +167,7 @@ fn sync_state_nodes_multishard() {
 
             let view_client2_holder = Arc::new(RwLock::new(None));
             let arbiter_holder = Arc::new(RwLock::new(vec![]));
-            let arbiter_holder2 = arbiter_holder.clone();
+            let arbiter_holder2 = arbiter_holder;
 
             WaitOrTimeoutActor::new(
                 Box::new(move |_ctx| {
@@ -285,7 +285,7 @@ fn sync_empty_state() {
 
             let view_client2_holder = Arc::new(RwLock::new(None));
             let arbiters_holder = Arc::new(RwLock::new(vec![]));
-            let arbiters_holder2 = arbiters_holder.clone();
+            let arbiters_holder2 = arbiters_holder;
 
             WaitOrTimeoutActor::new(
                 Box::new(move |_ctx| {

--- a/integration-tests/src/tests/network/infinite_loop.rs
+++ b/integration-tests/src/tests/network/infinite_loop.rs
@@ -67,7 +67,7 @@ pub fn make_peer_manager(
 
     let net_config = NetworkConfig::from_seed(seed, port);
     let routing_table_addr =
-        start_routing_table_actor(PeerId::new(net_config.public_key.clone()), store.clone());
+        start_routing_table_actor(PeerId::new(net_config.public_key), store.clone());
 
     let peer_id = PeerId::new(config.public_key.clone());
     (
@@ -107,10 +107,10 @@ fn test_infinite_loop() {
             }]),
         };
         let request2 = NetworkRequests::SyncRoutingTable {
-            peer_id: peer_id1.clone(),
+            peer_id: peer_id1,
             routing_table_update: RoutingTableUpdate::from_accounts(vec![AnnounceAccount {
                 account_id: "near".parse().unwrap(),
-                peer_id: peer_id2.clone(),
+                peer_id: peer_id2,
                 epoch_id: Default::default(),
                 signature: Default::default(),
             }]),

--- a/integration-tests/src/tests/network/peer_handshake.rs
+++ b/integration-tests/src/tests/network/peer_handshake.rs
@@ -173,7 +173,7 @@ fn peer_recover() {
                         actix::spawn(pm0.send(GetInfo {}).then(move |res| {
                             if let Ok(info) = res {
                                 if info.connected_peers.len() == 1 {
-                                    flag1.clone().store(true, Ordering::Relaxed);
+                                    flag1.store(true, Ordering::Relaxed);
                                 }
                             }
                             future::ready(())

--- a/integration-tests/src/tests/network/runner.rs
+++ b/integration-tests/src/tests/network/runner.rs
@@ -55,13 +55,8 @@ pub fn setup_network_node(
 
     let num_validators = validators.len() as ValidatorId;
 
-    let runtime = Arc::new(KeyValueRuntime::new_with_validators(
-        store.clone(),
-        vec![validators.clone()],
-        1,
-        1,
-        5,
-    ));
+    let runtime =
+        Arc::new(KeyValueRuntime::new_with_validators(store.clone(), vec![validators], 1, 1, 5));
     let signer = Arc::new(InMemoryValidatorSigner::from_seed(
         account_id.clone(),
         KeyType::ED25519,
@@ -97,7 +92,7 @@ pub fn setup_network_node(
             config.account_id.clone(),
             chain_genesis.clone(),
             runtime.clone(),
-            network_adapter.clone(),
+            network_adapter,
             client_config,
             #[cfg(feature = "test_features")]
             adv.clone(),

--- a/integration-tests/src/tests/network/stress_network.rs
+++ b/integration-tests/src/tests/network/stress_network.rs
@@ -51,7 +51,7 @@ fn make_peer_manager(seed: &str, port: u16, boot_nodes: Vec<(&str, u16)>) -> Pee
     .start();
     let net_config = NetworkConfig::from_seed(seed, port);
     let routing_table_addr =
-        start_routing_table_actor(PeerId::new(net_config.public_key.clone()), store.clone());
+        start_routing_table_actor(PeerId::new(net_config.public_key), store.clone());
 
     PeerManagerActor::new(
         store,

--- a/integration-tests/src/tests/runtime/test_evil_contracts.rs
+++ b/integration-tests/src/tests/runtime/test_evil_contracts.rs
@@ -21,7 +21,7 @@ fn setup_test_contract(wasm_binary: &[u8]) -> RuntimeNode {
     let node_user = node.user();
     let transaction_result = node_user
         .create_account(
-            account_id.clone(),
+            account_id,
             "test_contract".parse().unwrap(),
             node.signer().public_key(),
             TESTING_INIT_BALANCE / 2,

--- a/integration-tests/src/tests/standard_cases/mod.rs
+++ b/integration-tests/src/tests/standard_cases/mod.rs
@@ -32,10 +32,7 @@ use testlib::runtime_utils::{
 const FUNCTION_CALL_AMOUNT: Balance = TESTING_INIT_BALANCE / 10;
 
 fn fee_helper(node: &impl Node) -> FeeHelper {
-    FeeHelper::new(
-        RuntimeConfig::test().transaction_costs.clone(),
-        node.genesis().config.min_gas_price,
-    )
+    FeeHelper::new(RuntimeConfig::test().transaction_costs, node.genesis().config.min_gas_price)
 }
 
 /// Adds given access key to the given account_id using signer2.

--- a/integration-tests/src/user/mod.rs
+++ b/integration-tests/src/user/mod.rs
@@ -214,7 +214,7 @@ pub trait User {
         beneficiary_id: AccountId,
     ) -> Result<FinalExecutionOutcomeView, ServerError> {
         self.sign_and_commit_actions(
-            signer_id.clone(),
+            signer_id,
             receiver_id,
             vec![Action::DeleteAccount(DeleteAccountAction { beneficiary_id })],
         )

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -299,8 +299,7 @@ impl NightshadeRuntime {
             }
         });
         assert!(has_protocol_account, "Genesis spec doesn't have protocol treasury account");
-        let tries =
-            ShardTries::new(store.clone(), genesis.config.shard_layout.version(), num_shards);
+        let tries = ShardTries::new(store, genesis.config.shard_layout.version(), num_shards);
         let runtime = Runtime::new();
         let runtime_config_store =
             NightshadeRuntime::create_runtime_config_store(&genesis.config.chain_id);
@@ -647,7 +646,7 @@ fn apply_delayed_receipts<'a>(
     let orig_trie_update = tries.new_trie_update_view(orig_shard_uid.clone(), orig_state_root);
 
     let mut start_index = None;
-    let mut new_state_roots = state_roots.clone();
+    let mut new_state_roots = state_roots;
     while let Some((next_index, receipts)) =
         get_delayed_receipts(&orig_trie_update, start_index, STATE_PART_MEMORY_LIMIT)?
     {
@@ -1693,7 +1692,7 @@ impl RuntimeAdapter for NightshadeRuntime {
             let trie_items = trie.get_trie_items_for_part(part_id, num_parts, state_root)?;
             let (store_update, new_state_roots) = self.tries.add_values_to_split_states(
                 &state_roots,
-                trie_items.into_iter().map(|(key, value)| (key, Some(value.clone()))).collect(),
+                trie_items.into_iter().map(|(key, value)| (key, Some(value))).collect(),
                 &checked_account_id_to_shard_id,
             )?;
             state_roots = new_state_roots;
@@ -2637,7 +2636,7 @@ mod test {
             env.runtime.obtain_state_part(0, &block_hash, &env.state_roots[0], 0, 1).unwrap();
         let root_node =
             env.runtime.get_state_root_node(0, &block_hash, &env.state_roots[0]).unwrap();
-        let mut new_env = TestEnv::new("test_state_sync", vec![validators.clone()], 2, false);
+        let mut new_env = TestEnv::new("test_state_sync", vec![validators], 2, false);
         for i in 1..=2 {
             let prev_hash = hash(&[new_env.head.height as u8]);
             let cur_hash = hash(&[(new_env.head.height + 1) as u8]);
@@ -2678,7 +2677,7 @@ mod test {
             new_env.time += 10u64.pow(9);
         }
         assert!(new_env.runtime.validate_state_root_node(&root_node, &env.state_roots[0]));
-        let mut root_node_wrong = root_node.clone();
+        let mut root_node_wrong = root_node;
         root_node_wrong.memory_usage += 1;
         assert!(!new_env.runtime.validate_state_root_node(&root_node_wrong, &env.state_roots[0]));
         root_node_wrong.data = vec![123];
@@ -2786,7 +2785,7 @@ mod test {
             response,
             EpochValidatorInfo {
                 current_validators: current_epoch_validator_info.clone(),
-                next_validators: next_epoch_validator_info.clone(),
+                next_validators: next_epoch_validator_info,
                 current_fishermen: vec![],
                 next_fishermen: vec![],
                 current_proposals: vec![ValidatorStake::new(
@@ -3107,7 +3106,7 @@ mod test {
         let validators = (0..num_nodes)
             .map(|i| AccountId::try_from(format!("test{}", i + 1)).unwrap())
             .collect::<Vec<_>>();
-        let mut env = TestEnv::new("test_challenges", vec![validators.clone()], 5, false);
+        let mut env = TestEnv::new("test_challenges", vec![validators], 5, false);
         env.step(
             vec![vec![]],
             vec![true],

--- a/nearcore/src/shard_tracker.rs
+++ b/nearcore/src/shard_tracker.rs
@@ -315,7 +315,7 @@ mod tests {
         let shard_config = ShardConfig {
             num_block_producer_seats_per_shard: get_num_seats_per_shard(4, 2),
             avg_hidden_validator_seats_per_shard: get_num_seats_per_shard(4, 0),
-            shard_layout: shard_layout.clone(),
+            shard_layout: shard_layout,
         };
         let epoch_manager = Arc::new(RwLock::new(get_epoch_manager(
             simple_nightshade_version - 1,

--- a/nearcore/tests/economics.rs
+++ b/nearcore/tests/economics.rs
@@ -77,8 +77,7 @@ fn test_burn_mint() {
         .get_protocol_config(&EpochId::default())
         .unwrap()
         .runtime_config
-        .transaction_costs
-        .clone();
+        .transaction_costs;
     let fee_helper = FeeHelper::new(transaction_costs, genesis.config.min_gas_price);
     let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
     let initial_total_supply = env.chain_genesis.total_supply;

--- a/runtime/near-vm-logic/src/tests/miscs.rs
+++ b/runtime/near-vm-logic/src/tests/miscs.rs
@@ -16,7 +16,7 @@ fn test_valid_utf8() {
     let len = string_bytes.len() as u64;
     logic.log_utf8(len, string_bytes.as_ptr() as _).expect("Valid utf-8 string_bytes");
     let outcome = logic.outcome();
-    assert_eq!(outcome.logs[0], String::from_utf8(string_bytes.clone()).unwrap());
+    assert_eq!(outcome.logs[0], String::from_utf8(string_bytes).unwrap());
     assert_costs(map! {
         ExtCosts::base: 1,
         ExtCosts::log_base:  1,

--- a/runtime/runtime/tests/test_async_calls.rs
+++ b/runtime/runtime/tests/test_async_calls.rs
@@ -27,7 +27,7 @@ fn test_simple_func_call() {
     let signed_transaction = SignedTransaction::from_actions(
         1,
         signer_sender.account_id.clone(),
-        signer_receiver.account_id.clone(),
+        signer_receiver.account_id,
         &signer_sender,
         vec![Action::FunctionCall(FunctionCallAction {
             method_name: "sum_n".to_string(),
@@ -73,7 +73,7 @@ fn test_single_promise_no_callback() {
     let signed_transaction = SignedTransaction::from_actions(
         1,
         signer_sender.account_id.clone(),
-        signer_receiver.account_id.clone(),
+        signer_receiver.account_id,
         &signer_sender,
         vec![Action::FunctionCall(FunctionCallAction {
             method_name: "call_promise".to_string(),
@@ -139,7 +139,7 @@ fn test_single_promise_with_callback() {
     let signed_transaction = SignedTransaction::from_actions(
         1,
         signer_sender.account_id.clone(),
-        signer_receiver.account_id.clone(),
+        signer_receiver.account_id,
         &signer_sender,
         vec![Action::FunctionCall(FunctionCallAction {
             method_name: "call_promise".to_string(),
@@ -223,7 +223,7 @@ fn test_two_promises_no_callbacks() {
     let signed_transaction = SignedTransaction::from_actions(
         1,
         signer_sender.account_id.clone(),
-        signer_receiver.account_id.clone(),
+        signer_receiver.account_id,
         &signer_sender,
         vec![Action::FunctionCall(FunctionCallAction {
             method_name: "call_promise".to_string(),
@@ -317,7 +317,7 @@ fn test_two_promises_with_two_callbacks() {
     let signed_transaction = SignedTransaction::from_actions(
         1,
         signer_sender.account_id.clone(),
-        signer_receiver.account_id.clone(),
+        signer_receiver.account_id,
         &signer_sender,
         vec![Action::FunctionCall(FunctionCallAction {
             method_name: "call_promise".to_string(),
@@ -408,7 +408,7 @@ fn test_single_promise_no_callback_batch() {
     let signed_transaction = SignedTransaction::from_actions(
         1,
         signer_sender.account_id.clone(),
-        signer_receiver.account_id.clone(),
+        signer_receiver.account_id,
         &signer_sender,
         vec![Action::FunctionCall(FunctionCallAction {
             method_name: "call_promise".to_string(),
@@ -480,7 +480,7 @@ fn test_single_promise_with_callback_batch() {
     let signed_transaction = SignedTransaction::from_actions(
         1,
         signer_sender.account_id.clone(),
-        signer_receiver.account_id.clone(),
+        signer_receiver.account_id,
         &signer_sender,
         vec![Action::FunctionCall(FunctionCallAction {
             method_name: "call_promise".to_string(),
@@ -554,7 +554,7 @@ fn test_simple_transfer() {
     let signed_transaction = SignedTransaction::from_actions(
         1,
         signer_sender.account_id.clone(),
-        signer_receiver.account_id.clone(),
+        signer_receiver.account_id,
         &signer_sender,
         vec![Action::FunctionCall(FunctionCallAction {
             method_name: "call_promise".to_string(),
@@ -621,7 +621,7 @@ fn test_create_account_with_transfer_and_full_key() {
     let signed_transaction = SignedTransaction::from_actions(
         1,
         signer_sender.account_id.clone(),
-        signer_receiver.account_id.clone(),
+        signer_receiver.account_id,
         &signer_sender,
         vec![Action::FunctionCall(FunctionCallAction {
             method_name: "call_promise".to_string(),
@@ -879,7 +879,7 @@ fn test_create_account_add_key_call_delete_key_delete_account() {
     let signed_transaction = SignedTransaction::from_actions(
         1,
         signer_sender.account_id.clone(),
-        signer_receiver.account_id.clone(),
+        signer_receiver.account_id,
         &signer_sender,
         vec![Action::FunctionCall(FunctionCallAction {
             method_name: "call_promise".to_string(),
@@ -973,7 +973,7 @@ fn test_transfer_64len_hex() {
     let signed_transaction = SignedTransaction::from_actions(
         1,
         signer_sender.account_id.clone(),
-        signer_receiver.account_id.clone(),
+        signer_receiver.account_id,
         &signer_sender,
         vec![Action::FunctionCall(FunctionCallAction {
             method_name: "call_promise".to_string(),
@@ -1039,7 +1039,7 @@ fn test_create_transfer_64len_hex_fail() {
     let signed_transaction = SignedTransaction::from_actions(
         1,
         signer_sender.account_id.clone(),
-        signer_receiver.account_id.clone(),
+        signer_receiver.account_id,
         &signer_sender,
         vec![Action::FunctionCall(FunctionCallAction {
             method_name: "call_promise".to_string(),

--- a/test-utils/store-validator/src/main.rs
+++ b/test-utils/store-validator/src/main.rs
@@ -43,9 +43,9 @@ fn main() {
 
     let mut store_validator = StoreValidator::new(
         near_config.validator_signer.as_ref().map(|x| x.validator_id().clone()),
-        near_config.genesis.config.clone(),
+        near_config.genesis.config,
         runtime_adapter.clone(),
-        store.clone(),
+        store,
     );
     store_validator.validate();
 

--- a/tools/restored-receipts-verifier/src/main.rs
+++ b/tools/restored-receipts-verifier/src/main.rs
@@ -149,7 +149,7 @@ mod tests {
         assert_eq!(receipt_hashes_not_verified, vec![extra_hash]);
         assert!(receipt_hashes_still_missing.is_empty());
 
-        let mut receipt_hashes_missing = receipt_hashes_in_repo.clone();
+        let mut receipt_hashes_missing = receipt_hashes_in_repo;
         receipt_hashes_missing.push(CryptoHash::default());
         let (receipt_hashes_not_verified, receipt_hashes_still_missing) =
             get_differences_with_hashes_from_repo(receipt_hashes_missing);


### PR DESCRIPTION
Refactor `near-client`, fixes clippy issues in files touched by https://github.com/near/nearcore/pull/5872
