### PR TITLE
Change `PEER_MIN_ALLOWED_PROTOCOL_VERSION` to `MAIN_NET_PROTOCOL_VERSION - 2`

### DIFF
--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -139,7 +139,7 @@ pub enum ProtocolFeature {
 
 /// Both, outgoing and incoming tcp connections to peers, will be rejected if `peer's`
 /// protocol version is lower than this.
-pub const PEER_MIN_ALLOWED_PROTOCOL_VERSION: ProtocolVersion = MAIN_NET_PROTOCOL_VERSION - 1;
+pub const PEER_MIN_ALLOWED_PROTOCOL_VERSION: ProtocolVersion = MAIN_NET_PROTOCOL_VERSION - 2;
 
 /// Current protocol version used on the main net.
 /// Some features (e. g. FixStorageUsage) require that there is at least one epoch with exactly


### PR DESCRIPTION
Recently we changed `PEER_MIN_ALLOWED_PROTOCOL_VERSION` to `MAIN_NET_PROTOCOL_VERSION - 1`.
However, that can lead to situation, where the version on the master branch is 2 versions behind the version running on the mainnet. 

This PR resolved the issue by changing  `PEER_MIN_ALLOWED_PROTOCOL_VERSION` to `MAIN_NET_PROTOCOL_VERSION - 2`.

Closes #5853