### PR TITLE
re: Fix remaining `clippy` warnings in `intergration-tests`

### DIFF
--- a/integration-tests/src/node/mod.rs
+++ b/integration-tests/src/node/mod.rs
@@ -156,9 +156,9 @@ pub fn create_nodes_from_seeds(seeds: Vec<String>) -> Vec<NodeConfig> {
         for record in genesis.records.as_mut() {
             if let StateRecord::Account { account_id: record_account_id, ref mut account } = record
             {
-                if record_account_id.as_ref() == &seed {
+                if record_account_id.as_ref() == seed {
                     is_account_record_found = true;
-                    account.set_code_hash(ContractCode::new(code.to_vec(), None).hash().clone());
+                    account.set_code_hash(*ContractCode::new(code.to_vec(), None).hash());
                 }
             }
         }

--- a/integration-tests/src/node/process_node.rs
+++ b/integration-tests/src/node/process_node.rs
@@ -38,10 +38,7 @@ impl Node for ProcessNode {
     }
 
     fn account_id(&self) -> Option<AccountId> {
-        match &self.config.validator_signer {
-            Some(vs) => Some(vs.validator_id().clone()),
-            None => None,
-        }
+        self.config.validator_signer.as_ref().map(|vs| vs.validator_id().clone())
     }
 
     fn start(&mut self) {
@@ -132,7 +129,7 @@ impl ProcessNode {
 
     /// Side effect: writes chain spec file
     pub fn get_start_node_command(&self) -> Command {
-        if let Err(_) = std::env::var("NIGHTLY_RUNNER") {
+        if std::env::var("NIGHTLY_RUNNER").is_err() {
             let mut command = Command::new("cargo");
             command.args(&["run", "-p", "neard"]);
             #[cfg(feature = "nightly_protocol")]

--- a/integration-tests/src/node/thread_node.rs
+++ b/integration-tests/src/node/thread_node.rs
@@ -35,10 +35,7 @@ impl Node for ThreadNode {
     }
 
     fn account_id(&self) -> Option<AccountId> {
-        match &self.config.validator_signer {
-            Some(vs) => Some(vs.validator_id().clone()),
-            None => None,
-        }
+        self.config.validator_signer.as_ref().map(|vs| vs.validator_id().clone())
     }
 
     fn start(&mut self) {

--- a/integration-tests/src/test_helpers.rs
+++ b/integration-tests/src/test_helpers.rs
@@ -9,7 +9,7 @@ static HEAVY_TESTS_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
 pub fn heavy_test<F>(f: F)
 where
-    F: FnOnce() -> (),
+    F: FnOnce(),
 {
     let _guard = HEAVY_TESTS_LOCK.lock();
     f();

--- a/integration-tests/src/user/mod.rs
+++ b/integration-tests/src/user/mod.rs
@@ -89,7 +89,7 @@ pub trait User {
         receiver_id: AccountId,
         actions: Vec<Action>,
     ) -> Result<FinalExecutionOutcomeView, ServerError> {
-        let block_hash = self.get_best_block_hash().unwrap_or_else(CryptoHash::default);
+        let block_hash = self.get_best_block_hash().unwrap_or_default();
         let signed_transaction = SignedTransaction::from_actions(
             self.get_access_key_nonce_for_signer(&signer_id).unwrap_or_default() + 1,
             signer_id,

--- a/integration-tests/src/user/rpc_user.rs
+++ b/integration-tests/src/user/rpc_user.rs
@@ -146,7 +146,7 @@ impl User for RpcUser {
     }
 
     fn get_best_block_hash(&self) -> Option<CryptoHash> {
-        self.get_status().map(|status| status.sync_info.latest_block_hash.into())
+        self.get_status().map(|status| status.sync_info.latest_block_hash)
     }
 
     fn get_block(&self, height: BlockHeight) -> Option<BlockView> {

--- a/integration-tests/src/user/runtime_user.rs
+++ b/integration-tests/src/user/runtime_user.rs
@@ -169,7 +169,7 @@ impl RuntimeUser {
             block_hash: Default::default(),
         }];
         for hash in &receipt_ids {
-            transactions.extend(self.get_recursive_transaction_results(&(*hash)).into_iter());
+            transactions.extend(self.get_recursive_transaction_results(hash).into_iter());
         }
         transactions
     }

--- a/integration-tests/src/user/runtime_user.rs
+++ b/integration-tests/src/user/runtime_user.rs
@@ -169,8 +169,7 @@ impl RuntimeUser {
             block_hash: Default::default(),
         }];
         for hash in &receipt_ids {
-            transactions
-                .extend(self.get_recursive_transaction_results(&(*hash)).into_iter());
+            transactions.extend(self.get_recursive_transaction_results(&(*hash)).into_iter());
         }
         transactions
     }

--- a/integration-tests/src/user/runtime_user.rs
+++ b/integration-tests/src/user/runtime_user.rs
@@ -170,14 +170,14 @@ impl RuntimeUser {
         }];
         for hash in &receipt_ids {
             transactions
-                .extend(self.get_recursive_transaction_results(&hash.clone().into()).into_iter());
+                .extend(self.get_recursive_transaction_results(&(*hash)).into_iter());
         }
         transactions
     }
 
     fn get_final_transaction_result(&self, hash: &CryptoHash) -> FinalExecutionOutcomeView {
         let mut outcomes = self.get_recursive_transaction_results(hash);
-        let mut looking_for_id = (*hash).into();
+        let mut looking_for_id = *hash;
         let num_outcomes = outcomes.len();
         let status = outcomes
             .iter()
@@ -195,7 +195,7 @@ impl RuntimeUser {
                             Some(FinalExecutionStatus::SuccessValue(v.clone()))
                         }
                         ExecutionStatusView::SuccessReceiptId(id) => {
-                            looking_for_id = id.clone();
+                            looking_for_id = *id;
                             None
                         }
                     }
@@ -322,7 +322,7 @@ impl User for RuntimeUser {
     }
 
     fn get_state_root(&self) -> CryptoHash {
-        self.client.read().expect(POISONED_LOCK_ERR).state_root.into()
+        self.client.read().expect(POISONED_LOCK_ERR).state_root
     }
 
     fn get_access_key(

--- a/test-utils/store-validator/src/main.rs
+++ b/test-utils/store-validator/src/main.rs
@@ -26,7 +26,7 @@ fn main() {
         .subcommand(SubCommand::with_name("validate"))
         .get_matches();
 
-    let home_dir = matches.value_of("home").map(|dir| Path::new(dir)).unwrap();
+    let home_dir = matches.value_of("home").map(Path::new).unwrap();
     let near_config = load_config(home_dir);
 
     let store = create_store(&get_store_path(home_dir));

--- a/tools/restaked/src/main.rs
+++ b/tools/restaked/src/main.rs
@@ -58,7 +58,7 @@ fn main() {
         )
         .get_matches();
 
-    let home_dir = matches.value_of("home").map(|dir| Path::new(dir)).unwrap();
+    let home_dir = matches.value_of("home").map(Path::new).unwrap();
     let wait_period = matches
         .value_of("wait-period")
         .map(|s| s.parse().expect("Wait period must be a number"))

--- a/tools/restored-receipts-verifier/src/main.rs
+++ b/tools/restored-receipts-verifier/src/main.rs
@@ -14,7 +14,7 @@ use nearcore::{get_default_home, get_store_path, load_config, NightshadeRuntime,
 fn get_receipt_hashes_in_repo() -> Vec<CryptoHash> {
     let receipt_result = load_migration_data(&"mainnet".to_string()).restored_receipts;
     let receipts = receipt_result.get(&0u64).unwrap();
-    receipts.into_iter().map(|receipt| receipt.get_hash()).collect()
+    receipts.iter().map(|receipt| receipt.get_hash()).collect()
 }
 
 fn get_differences_with_hashes_from_repo(


### PR DESCRIPTION
There are still a few `clippy` warnings that need to be fixed in `integration-tests`.

