### PR TITLE
feat: Move `cargo check` to be first in `pipeline.yml`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,44 +1,4 @@
 steps:
-  - label: "cargo test integration-tests*"
-    command: |
-      source ~/.cargo/env && set -eux
-      RUST_BACKTRACE=1 RUSTFLAGS='-D warnings' cargo test --locked -p 'integration-tests'
-
-    timeout: 60
-    agents:
-    - "distro=amazonlinux"
-    branches: "!master"
-
-  - label: "cargo test not integration-tests*"
-    command: |
-      source ~/.cargo/env && set -eux
-      RUST_BACKTRACE=1 RUSTFLAGS='-D warnings' cargo test --locked --workspace -p '*' --exclude 'integration-tests*'
-
-    timeout: 60
-    agents:
-    - "distro=amazonlinux"
-    branches: "!master"
-
-  - label: "cargo test nightly integration-tests*"
-    command: |
-      source ~/.cargo/env && set -eux
-      RUST_BACKTRACE=1 RUSTFLAGS='-D warnings' cargo test --features nightly_protocol,nightly_protocol_features,test_features -p 'integration-tests'
-
-    timeout: 60
-    agents:
-    - "distro=amazonlinux"
-    branches: "!master"
-
-  - label: "cargo test nightly not integration-tests*"
-    command: |
-      source ~/.cargo/env && set -eux
-      RUST_BACKTRACE=1 RUSTFLAGS='-D warnings' cargo test --workspace --features nightly_protocol,nightly_protocol_features,test_features,rosetta_rpc -p '*' --exclude 'integration-tests*'
-
-    timeout: 60
-    agents:
-    - "distro=amazonlinux"
-    branches: "!master"
-
   - label: "sanity checks"
     command: |
       source ~/.cargo/env && set -eux
@@ -76,6 +36,46 @@ steps:
           exit 1
       fi >&2
     timeout: 30
+    agents:
+    - "distro=amazonlinux"
+    branches: "!master"
+
+  - label: "cargo test integration-tests*"
+    command: |
+      source ~/.cargo/env && set -eux
+      RUST_BACKTRACE=1 RUSTFLAGS='-D warnings' cargo test --locked -p 'integration-tests'
+
+    timeout: 60
+    agents:
+    - "distro=amazonlinux"
+    branches: "!master"
+
+  - label: "cargo test not integration-tests*"
+    command: |
+      source ~/.cargo/env && set -eux
+      RUST_BACKTRACE=1 RUSTFLAGS='-D warnings' cargo test --locked --workspace -p '*' --exclude 'integration-tests*'
+
+    timeout: 60
+    agents:
+    - "distro=amazonlinux"
+    branches: "!master"
+
+  - label: "cargo test nightly integration-tests*"
+    command: |
+      source ~/.cargo/env && set -eux
+      RUST_BACKTRACE=1 RUSTFLAGS='-D warnings' cargo test --features nightly_protocol,nightly_protocol_features,test_features -p 'integration-tests'
+
+    timeout: 60
+    agents:
+    - "distro=amazonlinux"
+    branches: "!master"
+
+  - label: "cargo test nightly not integration-tests*"
+    command: |
+      source ~/.cargo/env && set -eux
+      RUST_BACKTRACE=1 RUSTFLAGS='-D warnings' cargo test --workspace --features nightly_protocol,nightly_protocol_features,test_features,rosetta_rpc -p '*' --exclude 'integration-tests*'
+
+    timeout: 60
     agents:
     - "distro=amazonlinux"
     branches: "!master"


### PR DESCRIPTION
Jobs in CI are started in order.
Sanity checks are slowest, and should be moved first.