### PR TITLE
feat: Run clippy on `near-network` and related packages - WIP

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -144,7 +144,7 @@ steps:
   - label: "clippy"
     command: |
       source ~/.cargo/env && set -eux
-      cargo clippy --no-deps -p near-network -p near-network-primitives -p near-cache -p near-performance-metrics -p near-rate-limiter -p -near-stable-hasher -- -D clippy::all
+      cargo clippy --no-deps -p near-network -p near-network-primitives -p near-cache -p near-performance-metrics -p near-rate-limiter -p near-stable-hasher -- -D clippy::all
 
     branches: "!master !beta !stable"
     timeout: 60

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -141,6 +141,16 @@ steps:
     agents:
     - "distro=amazonlinux"
 
+  - label: "clippy"
+    command: |
+      source ~/.cargo/env && set -eux
+      cargo clippy --no-deps -p near-network -p near-network-primitives -p near-cache -p near-performance-metrics -p near-rate-limiter -p -near-stable-hasher -- -D clippy::all
+
+    branches: "!master !beta !stable"
+    timeout: 60
+    agents:
+    - "distro=amazonlinux"
+
   #- label: "near-sdk-rs tests"
   #  trigger: "near-sdk-rs"
   #  branches: "!master"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,5 +3,5 @@
 # Individual crates in the workspace may support a lower version, as indicated by `rust-version` field in each crate's `Cargo.toml`.
 # The version specified below, should be at least as high as the maximum `rust-version` within the workspace.
 channel = "1.57.0"
-components = [ "rustfmt" ]
+components = [ "rustfmt", "clippy" ]
 targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
We should deny `clippy` warnings on all `near-network` related packages.

We can start by adding checks to:
- near-network 
- near-network-primitives
- near-cache 
- near-performance-metrics 
- near-rate-limiter
- near-stable-hasher

See https://github.com/near/nearcore/pull/5894