### PR TITLE
Prefer `&str` to `&String`

### DIFF
--- a/genesis-tools/genesis-csv-to-json/src/csv_to_json_configs.rs
+++ b/genesis-tools/genesis-csv-to-json/src/csv_to_json_configs.rs
@@ -17,7 +17,7 @@ use nearcore::NEAR_BASE;
 const ACCOUNTS_FILE: &str = "accounts.csv";
 const NUM_SHARDS: NumShards = 8;
 
-fn verify_total_supply(total_supply: Balance, chain_id: &String) {
+fn verify_total_supply(total_supply: Balance, chain_id: &str) {
     if chain_id == "mainnet" {
         assert_eq!(
             total_supply,

--- a/integration-tests/src/tests/nearcore/node_cluster.rs
+++ b/integration-tests/src/tests/nearcore/node_cluster.rs
@@ -42,7 +42,7 @@ pub fn start_nodes(
             if i == 0 { first_node } else { open_port() },
             genesis.clone(),
         );
-        rpc_addrs.push(near_config.rpc_addr().unwrap().clone());
+        rpc_addrs.push(near_config.rpc_addr().unwrap().to_owned());
         near_config.client_config.min_num_peers = num_nodes - 1;
         if i > 0 {
             near_config.network_config.boot_nodes =

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -479,7 +479,7 @@ impl Config {
         }
     }
 
-    pub fn rpc_addr(&self) -> Option<&String> {
+    pub fn rpc_addr(&self) -> Option<&str> {
         #[cfg(feature = "json_rpc")]
         if let Some(rpc) = &self.rpc {
             return Some(&rpc.addr);
@@ -621,7 +621,7 @@ impl NearConfig {
             client_config: ClientConfig {
                 version: Default::default(),
                 chain_id: genesis.config.chain_id.clone(),
-                rpc_addr: config.rpc_addr().map(|addr| addr.clone()),
+                rpc_addr: config.rpc_addr().map(|addr| addr.to_owned()),
                 block_production_tracking_delay: config.consensus.block_production_tracking_delay,
                 min_block_production_delay: config.consensus.min_block_production_delay,
                 max_block_production_delay: config.consensus.max_block_production_delay,
@@ -717,7 +717,7 @@ impl NearConfig {
         }
     }
 
-    pub fn rpc_addr(&self) -> Option<&String> {
+    pub fn rpc_addr(&self) -> Option<&str> {
         #[cfg(feature = "json_rpc")]
         if let Some(rpc) = &self.rpc_config {
             return Some(&rpc.addr);
@@ -1078,14 +1078,14 @@ pub fn init_testnet_configs(
     }
 }
 
-pub fn get_genesis_url(chain_id: &String) -> String {
+pub fn get_genesis_url(chain_id: &str) -> String {
     format!(
         "https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore-deploy/{}/genesis.json",
         chain_id,
     )
 }
 
-pub fn get_config_url(chain_id: &String) -> String {
+pub fn get_config_url(chain_id: &str) -> String {
     format!(
         "https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore-deploy/{}/config.json",
         chain_id,
@@ -1155,13 +1155,13 @@ pub fn download_file(url: &str, path: &Path) -> Result<(), FileDownloadError> {
     })
 }
 
-pub fn download_genesis(url: &String, path: &Path) {
+pub fn download_genesis(url: &str, path: &Path) {
     info!(target: "near", "Downloading genesis file from: {} ...", url);
     download_file(url, path).expect("Failed to download the genesis file");
     info!(target: "near", "Saved the genesis file to: {} ...", path.display());
 }
 
-pub fn download_config(url: &String, path: &Path) {
+pub fn download_config(url: &str, path: &Path) {
     info!(target: "near", "Downloading config file from: {} ...", url);
     download_file(url, path).expect("Failed to download the configuration file");
     info!(target: "near", "Saved the config file to: {} ...", path.display());

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -490,7 +490,7 @@ lazy_static_include::lazy_static_include_bytes! {
 /// between 4 and 4.5s. We do not want to process any receipts in this block
 const GAS_USED_FOR_STORAGE_USAGE_DELTA_MIGRATION: Gas = 1_000_000_000_000_000;
 
-pub fn load_migration_data(chain_id: &String) -> MigrationData {
+pub fn load_migration_data(chain_id: &str) -> MigrationData {
     let is_mainnet = chain_id == "mainnet";
     MigrationData {
         storage_usage_delta: if is_mainnet {
@@ -524,9 +524,9 @@ mod tests {
             to_base(&hash(&MAINNET_STORAGE_USAGE_DELTA)),
             "6CFkdSZZVj4v83cMPD3z6Y8XSQhDh3EQjFh3PRAqFEAx"
         );
-        let mainnet_migration_data = load_migration_data(&"mainnet".to_string());
+        let mainnet_migration_data = load_migration_data("mainnet");
         assert_eq!(mainnet_migration_data.storage_usage_delta.len(), 3112);
-        let testnet_migration_data = load_migration_data(&"testnet".to_string());
+        let testnet_migration_data = load_migration_data("testnet");
         assert_eq!(testnet_migration_data.storage_usage_delta.len(), 0);
     }
 
@@ -536,9 +536,9 @@ mod tests {
             to_base(&hash(&MAINNET_RESTORED_RECEIPTS)),
             "3ZHK51a2zVnLnG8Pq1y7fLaEhP9SGU1CGCmspcBUi5vT"
         );
-        let mainnet_migration_data = load_migration_data(&"mainnet".to_string());
+        let mainnet_migration_data = load_migration_data("mainnet");
         assert_eq!(mainnet_migration_data.restored_receipts.get(&0u64).unwrap().len(), 383);
-        let testnet_migration_data = load_migration_data(&"testnet".to_string());
+        let testnet_migration_data = load_migration_data("testnet");
         assert!(testnet_migration_data.restored_receipts.is_empty());
     }
 }

--- a/test-utils/runtime-tester/src/fuzzing.rs
+++ b/test-utils/runtime-tester/src/fuzzing.rs
@@ -244,7 +244,7 @@ impl TransactionConfig {
             let signer = scope.function_call_signer(
                 u,
                 &signer_account,
-                &receiver_account.id.clone().into(),
+                &receiver_account.id,
             )?;
 
             let mut receiver_functions = vec![];
@@ -594,7 +594,7 @@ impl Scope {
         &self,
         u: &mut Unstructured,
         account: &Account,
-        receiver_id: &String,
+        receiver_id: &str,
     ) -> Result<InMemorySigner> {
         let account_idx = self.usize_id(account);
         let possible_signers = self.accounts[account_idx].function_call_keys(receiver_id);
@@ -655,13 +655,13 @@ impl Account {
         full_access_keys
     }
 
-    pub fn function_call_keys(&self, receiver_id: &String) -> Vec<InMemorySigner> {
+    pub fn function_call_keys(&self, receiver_id: &str) -> Vec<InMemorySigner> {
         let mut function_call_keys = vec![];
         for (_, key) in &self.keys {
             match &key.access_key.permission {
                 AccessKeyPermission::FullAccess => function_call_keys.push(key.signer.clone()),
                 AccessKeyPermission::FunctionCall(function_call_permission) => {
-                    if function_call_permission.receiver_id == *receiver_id {
+                    if function_call_permission.receiver_id == receiver_id {
                         function_call_keys.push(key.signer.clone())
                     }
                 }

--- a/test-utils/runtime-tester/src/fuzzing.rs
+++ b/test-utils/runtime-tester/src/fuzzing.rs
@@ -241,11 +241,7 @@ impl TransactionConfig {
                 }
             };
 
-            let signer = scope.function_call_signer(
-                u,
-                &signer_account,
-                &receiver_account.id,
-            )?;
+            let signer = scope.function_call_signer(u, &signer_account, &receiver_account.id)?;
 
             let mut receiver_functions = vec![];
             if let Some(contract_id) = receiver_account.deployed_contract {

--- a/tools/restored-receipts-verifier/src/main.rs
+++ b/tools/restored-receipts-verifier/src/main.rs
@@ -12,7 +12,7 @@ use nearcore::migrations::load_migration_data;
 use nearcore::{get_default_home, get_store_path, load_config, NightshadeRuntime, TrackedConfig};
 
 fn get_receipt_hashes_in_repo() -> Vec<CryptoHash> {
-    let receipt_result = load_migration_data(&"mainnet".to_string()).restored_receipts;
+    let receipt_result = load_migration_data("mainnet").restored_receipts;
     let receipts = receipt_result.get(&0u64).unwrap();
     receipts.into_iter().map(|receipt| receipt.get_hash()).collect()
 }


### PR DESCRIPTION
Taking `&String` argument limits how function can be used without
providing any additional features.  Specifically, when caller has
a string slice they have to make unnecessary conversion to String
before passing it to the function.

Similarly, returning `&String` doesn’t offer benefits over returning
`&str` since there’s nothing that can be done with the former that
cannot be done with the latter as well.

As such, prefer using `&str` instead of `&String`.
