### PR TITLE
Synchronize block and chunk production

### DIFF
--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -25,7 +25,7 @@ fn empty_chain() {
     #[cfg(feature = "nightly_protocol")]
     assert_eq!(hash, CryptoHash::from_str("DHFJfDH25yEPmEpKrUN9upXY3gFcCmsGyHMTk2sugyXd").unwrap());
     #[cfg(not(feature = "nightly_protocol"))]
-    assert_eq!(hash, CryptoHash::from_str("BkrZeGCDnYJGAdc3G1fb1P8FMbnNDhBn6w5DjhQeNAdp").unwrap());
+    assert_eq!(hash, CryptoHash::from_str("7mewJ6tbV1hZBg47qaCjtRfPQG4fBHykg2mzBjEbXwv9").unwrap());
     assert_eq!(count_utc, 1);
     assert_eq!(count_instant, 0);
 }
@@ -49,7 +49,7 @@ fn build_chain() {
     #[cfg(not(feature = "nightly_protocol"))]
     assert_eq!(
         prev_hash,
-        CryptoHash::from_str("6C474NRQK1cLkGYrdaCpeVPKbBbsTxGeB7ZZWkdbD3uL").unwrap()
+        CryptoHash::from_str("HdzZUsY2p3hmursbjgcG2PdYaw3UgchA9rXnFoEJLGH1").unwrap()
     );
 
     for i in 0..4 {
@@ -72,7 +72,7 @@ fn build_chain() {
     #[cfg(not(feature = "nightly_protocol"))]
     assert_eq!(
         chain.head().unwrap().last_block_hash,
-        CryptoHash::from_str("5pXLqgQe98JSdhtQ66VQFjQzBRPdZaEiMaTpdGuziF4H").unwrap()
+        CryptoHash::from_str("3vG7bLc3AjfYKdESnu5qNX24gjD6SKB1PuiRBDpcBjWC").unwrap()
     );
 }
 

--- a/chain/epoch_manager/src/validator_selection.rs
+++ b/chain/epoch_manager/src/validator_selection.rs
@@ -546,13 +546,11 @@ mod tests {
             let bp = epoch_info.sample_block_producer(h);
             for shard_id in 0..num_shards {
                 let cp = epoch_info.sample_chunk_producer(h, shard_id);
-                if checked_feature!("stable", SynchronizeBlockChunkProduction, PROTOCOL_VERSION)
-                    && !checked_feature!(
-                        "protocol_feature_chunk_only_producers",
-                        ChunkOnlyProducers,
-                        PROTOCOL_VERSION
-                    )
-                {
+                if !checked_feature!(
+                    "protocol_feature_chunk_only_producers",
+                    ChunkOnlyProducers,
+                    PROTOCOL_VERSION
+                ) {
                     assert_eq!(bp, cp);
                 }
             }

--- a/chain/epoch_manager/src/validator_selection.rs
+++ b/chain/epoch_manager/src/validator_selection.rs
@@ -511,8 +511,9 @@ mod tests {
 
     #[test]
     fn test_block_producer_sampling() {
+        let num_shards = 2;
         let epoch_config = create_epoch_config(
-            1,
+            num_shards,
             2,
             0,
             ValidatorSelectionConfig {
@@ -543,6 +544,18 @@ mod tests {
         let mut counts: [i32; 2] = [0, 0];
         for h in 0..100_000 {
             let bp = epoch_info.sample_block_producer(h);
+            for shard_id in 0..num_shards {
+                let cp = epoch_info.sample_chunk_producer(h, shard_id);
+                if checked_feature!("stable", SynchronizeBlockChunkProduction, PROTOCOL_VERSION)
+                    && !checked_feature!(
+                        "protocol_feature_chunk_only_producers",
+                        ChunkOnlyProducers,
+                        PROTOCOL_VERSION
+                    )
+                {
+                    assert_eq!(bp, cp);
+                }
+            }
             counts[bp as usize] += 1;
         }
         let diff = (2 * counts[1] - counts[0]).abs();
@@ -761,7 +774,7 @@ mod tests {
         EpochConfig {
             epoch_length: 10,
             num_block_producer_seats,
-            num_block_producer_seats_per_shard: vec![0; num_shards as usize],
+            num_block_producer_seats_per_shard: vec![num_block_producer_seats; num_shards as usize],
             avg_hidden_validator_seats_per_shard: vec![0; num_shards as usize],
             block_producer_kickout_threshold: 0,
             chunk_producer_kickout_threshold: 0,

--- a/chain/epoch_manager/src/validator_selection.rs
+++ b/chain/epoch_manager/src/validator_selection.rs
@@ -511,7 +511,7 @@ mod tests {
 
     #[test]
     fn test_block_producer_sampling() {
-        let num_shards = 2;
+        let num_shards = 4;
         let epoch_config = create_epoch_config(
             num_shards,
             2,

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -827,15 +827,15 @@ pub mod epoch_info {
                     shard_cps[(height as u64 % (shard_cps.len() as u64)) as usize]
                 }
                 Self::V3(v3) => {
-                    let protocol_verstion = self.protocol_version();
+                    let protocol_version = self.protocol_version();
                     let seed = if checked_feature!(
                         "stable",
                         SynchronizeBlockChunkProduction,
-                        protocol_verstion
+                        protocol_version
                     ) && !checked_feature!(
                         "protocol_feature_chunk_only_producers",
                         ChunkOnlyProducers,
-                        protocol_verstion
+                        protocol_version
                     ) {
                         // This is same seed that used for determining block producer
                         Self::block_produce_seed(height, &v3.rng_seed)

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -843,6 +843,7 @@ pub mod epoch_info {
                         protocol_verstion
                     ) {
                         // 32 bytes from epoch_seed, 8 bytes from height
+                        // This is same seed that used for determining block producer
                         let mut buffer = [0u8; 40];
                         buffer[0..32].copy_from_slice(&v3.rng_seed);
                         buffer[32..40].copy_from_slice(&height.to_le_bytes());

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -128,6 +128,7 @@ pub enum ProtocolFeature {
     /// https://github.com/near/NEPs/pull/167 for general description, note that we would not
     /// introduce chunk-only validators with this feature
     AliasValidatorSelectionAlgorithm,
+    SynchronizeBlockChunkProduction,
 
     // nightly features
     #[cfg(feature = "protocol_feature_alt_bn128")]
@@ -142,7 +143,7 @@ pub enum ProtocolFeature {
 /// Some features (e. g. FixStorageUsage) require that there is at least one epoch with exactly
 /// the corresponding version
 #[cfg(not(feature = "nightly_protocol"))]
-pub const PROTOCOL_VERSION: ProtocolVersion = 49;
+pub const PROTOCOL_VERSION: ProtocolVersion = 50;
 
 /// Current latest nightly version of the protocol.
 #[cfg(feature = "nightly_protocol")]
@@ -173,6 +174,7 @@ impl ProtocolFeature {
             | ProtocolFeature::LimitContractFunctionsNumber
             | ProtocolFeature::BlockHeaderV3
             | ProtocolFeature::AliasValidatorSelectionAlgorithm => 49,
+            ProtocolFeature::SynchronizeBlockChunkProduction => 50,
 
             // Nightly features
             #[cfg(feature = "protocol_feature_alt_bn128")]

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -128,6 +128,8 @@ pub enum ProtocolFeature {
     /// https://github.com/near/NEPs/pull/167 for general description, note that we would not
     /// introduce chunk-only validators with this feature
     AliasValidatorSelectionAlgorithm,
+    /// Make block producers produce chunks for the same block they would later produce to avoid
+    /// network delays
     SynchronizeBlockChunkProduction,
 
     // nightly features

--- a/nearcore/res/genesis_config.json
+++ b/nearcore/res/genesis_config.json
@@ -1,5 +1,5 @@
 {
-  "protocol_version": 49,
+  "protocol_version": 50,
   "genesis_time": "1970-01-01T00:00:00.000000000Z",
   "chain_id": "sample",
   "genesis_height": 0,


### PR DESCRIPTION
Hotfix to address #5688
While all chunk producers are block producers we should use same validator to produce chunks that would later produce block out of them, to avoid network delays