### PR TITLE
refactor(themis): dyn error handling case analysis

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,6 +18,7 @@
 
 /genesis-tools/ @nikurt
 /tools/indexer/ @khorolets
+/tools/themis/ @miraclx
 
 /core/  @bowenwang1996 @matklad @mm-near
 /core/store/src/trie @mzhangmzz @longarithm

--- a/tools/themis/Cargo.toml
+++ b/tools/themis/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Near Inc <hello@nearprotocol.com>", "Miraculous Owonubi <omiraculous
 edition = "2021"
 rust-version = "1.56.0"
 publish = false
-license = "Apache-2.0 OR MIT"
+license = "MIT OR Apache-2.0"
 description = "https://en.wikipedia.org/wiki/Themis"
 
 [dependencies]

--- a/tools/themis/src/rules.rs
+++ b/tools/themis/src/rules.rs
@@ -1,18 +1,21 @@
 use std::collections::HashMap;
 
-use super::{style, utils, Error, Expected, PackageOutcome, Workspace};
+use anyhow::bail;
+
+use super::types::{ComplianceError, Expected, PackageOutcome, Workspace};
+use super::{style, utils};
 
 /// Ensure all crates have the `publish = <true/false>` specification
-pub fn has_publish_spec(workspace: &Workspace) -> Result<(), Error> {
+pub fn has_publish_spec(workspace: &Workspace) -> anyhow::Result<()> {
     let outliers: Vec<_> = workspace
         .members
         .iter()
         .filter(|pkg| pkg.raw["package"].get("publish").is_none())
-        .map(|pkg| PackageOutcome { pkg, value: None })
+        .map(|pkg| PackageOutcome { pkg: pkg.clone(), value: None })
         .collect();
 
     if !outliers.is_empty() {
-        return Err(Error::OutcomeError {
+        bail!(ComplianceError {
             msg: "These packages should have the `publish` specification".to_string(),
             expected: Some(Expected { value: "publish = <true/false>".to_string(), reason: None }),
             outliers,
@@ -23,16 +26,16 @@ pub fn has_publish_spec(workspace: &Workspace) -> Result<(), Error> {
 }
 
 /// Ensure all crates specify a MSRV
-pub fn has_rust_version(workspace: &Workspace) -> Result<(), Error> {
+pub fn has_rust_version(workspace: &Workspace) -> anyhow::Result<()> {
     let outliers: Vec<_> = workspace
         .members
         .iter()
         .filter(|pkg| pkg.raw["package"].get("rust-version").is_none())
-        .map(|pkg| PackageOutcome { pkg, value: None })
+        .map(|pkg| PackageOutcome { pkg: pkg.clone(), value: None })
         .collect();
 
     if !outliers.is_empty() {
-        return Err(Error::OutcomeError {
+        bail!(ComplianceError {
             msg: "These packages should specify a Minimum Supported Rust Version (MSRV)"
                 .to_string(),
             expected: None,
@@ -44,16 +47,16 @@ pub fn has_rust_version(workspace: &Workspace) -> Result<(), Error> {
 }
 
 /// Ensure all crates are versioned to v0.0.0
-pub fn is_unversioned(workspace: &Workspace) -> Result<(), Error> {
+pub fn is_unversioned(workspace: &Workspace) -> anyhow::Result<()> {
     let outliers = workspace
         .members
         .iter()
         .filter(|pkg| pkg.parsed.version != semver::Version::new(0, 0, 0))
-        .map(|pkg| PackageOutcome { pkg, value: Some(pkg.parsed.version.to_string()) })
+        .map(|pkg| PackageOutcome { pkg: pkg.clone(), value: Some(pkg.parsed.version.to_string()) })
         .collect::<Vec<_>>();
 
     if !outliers.is_empty() {
-        return Err(Error::OutcomeError {
+        bail!(ComplianceError {
             msg: "These packages shouldn't be versioned".to_string(),
             expected: Some(Expected { value: "0.0.0".to_string(), reason: None }),
             outliers,
@@ -65,7 +68,7 @@ pub fn is_unversioned(workspace: &Workspace) -> Result<(), Error> {
 
 /// Ensures all crates have a rust-version spec less than
 /// or equal to the version defined in rust-toolchain.toml
-pub fn has_debuggable_rust_version(workspace: &Workspace) -> Result<(), Error> {
+pub fn has_debuggable_rust_version(workspace: &Workspace) -> anyhow::Result<()> {
     let rust_toolchain =
         utils::parse_toml::<toml::Value>(&workspace.root.join("rust-toolchain.toml"))?;
     let rust_toolchain = rust_toolchain["toolchain"]["channel"].as_str().unwrap().to_owned();
@@ -95,12 +98,12 @@ pub fn has_debuggable_rust_version(workspace: &Workspace) -> Result<(), Error> {
         };
 
         if !rust_version.matches(&rust_toolchain) {
-            outliers.push(PackageOutcome { pkg, value: Some(raw.to_owned()) });
+            outliers.push(PackageOutcome { pkg: pkg.clone(), value: Some(raw.to_owned()) });
         }
     }
 
     if !outliers.is_empty() {
-        return Err(Error::OutcomeError {
+        bail!(ComplianceError {
             msg: "These packages have an incompatible `rust-version`".to_string(),
             expected: Some(Expected {
                 value: format!("<={}", rust_toolchain),
@@ -114,7 +117,7 @@ pub fn has_debuggable_rust_version(workspace: &Workspace) -> Result<(), Error> {
 }
 
 /// Ensure all crates share the same rust edition
-pub fn has_unified_rust_edition(workspace: &Workspace) -> Result<(), Error> {
+pub fn has_unified_rust_edition(workspace: &Workspace) -> anyhow::Result<()> {
     let mut edition_groups = HashMap::new();
 
     for pkg in &workspace.members {
@@ -128,11 +131,11 @@ pub fn has_unified_rust_edition(workspace: &Workspace) -> Result<(), Error> {
         .members
         .iter()
         .filter(|pkg| pkg.parsed.edition != *most_common_edition)
-        .map(|pkg| PackageOutcome { pkg, value: Some(pkg.parsed.edition.clone()) })
+        .map(|pkg| PackageOutcome { pkg: pkg.clone(), value: Some(pkg.parsed.edition.clone()) })
         .collect::<Vec<_>>();
 
     if !outliers.is_empty() {
-        return Err(Error::OutcomeError {
+        bail!(ComplianceError {
             msg: "These packages have an unexpected rust edition".to_string(),
             expected: Some(Expected {
                 value: most_common_edition.clone(),
@@ -148,16 +151,19 @@ pub fn has_unified_rust_edition(workspace: &Workspace) -> Result<(), Error> {
 const EXPECTED_AUTHOR: &str = "Near Inc <hello@nearprotocol.com>";
 
 /// Ensure all crates have the appropriate author, non-exclusively of course.
-pub fn author_is_near(workspace: &Workspace) -> Result<(), Error> {
+pub fn author_is_near(workspace: &Workspace) -> anyhow::Result<()> {
     let outliers = workspace
         .members
         .iter()
         .filter(|pkg| !pkg.parsed.authors.iter().any(|author| author == EXPECTED_AUTHOR))
-        .map(|pkg| PackageOutcome { pkg, value: Some(format!("{:?}", pkg.parsed.authors)) })
+        .map(|pkg| PackageOutcome {
+            pkg: pkg.clone(),
+            value: Some(format!("{:?}", pkg.parsed.authors)),
+        })
         .collect::<Vec<_>>();
 
     if !outliers.is_empty() {
-        return Err(Error::OutcomeError {
+        bail!(ComplianceError {
             msg: "These packages need to be correctly authored".to_string(),
             expected: Some(Expected { value: EXPECTED_AUTHOR.to_string(), reason: None }),
             outliers,
@@ -168,7 +174,7 @@ pub fn author_is_near(workspace: &Workspace) -> Result<(), Error> {
 }
 
 /// Ensure all non-private crates have a license
-pub fn publishable_has_license(workspace: &Workspace) -> Result<(), Error> {
+pub fn publishable_has_license(workspace: &Workspace) -> anyhow::Result<()> {
     let outliers = workspace
         .members
         .iter()
@@ -176,11 +182,11 @@ pub fn publishable_has_license(workspace: &Workspace) -> Result<(), Error> {
             utils::is_publishable(pkg)
                 && !(pkg.parsed.license.is_some() || pkg.parsed.license_file.is_some())
         })
-        .map(|pkg| PackageOutcome { pkg, value: None })
+        .map(|pkg| PackageOutcome { pkg: pkg.clone(), value: None })
         .collect::<Vec<_>>();
 
     if !outliers.is_empty() {
-        return Err(Error::OutcomeError {
+        bail!(ComplianceError {
             msg: "These non-private packages should have a `license` specification".to_string(),
             expected: None,
             outliers,
@@ -194,7 +200,7 @@ pub fn publishable_has_license(workspace: &Workspace) -> Result<(), Error> {
 ///
 /// Checks for either one LICENSE file, or two LICENSE files, one of which
 /// is the Apache License 2.0 and the other is the MIT license.
-pub fn publishable_has_license_file(workspace: &Workspace) -> Result<(), Error> {
+pub fn publishable_has_license_file(workspace: &Workspace) -> anyhow::Result<()> {
     let outliers = workspace
         .members
         .iter()
@@ -207,13 +213,13 @@ pub fn publishable_has_license_file(workspace: &Workspace) -> Result<(), Error> 
                         .license_file, Some(ref l) if utils::exists(pkg, l.as_str())))
         })
         .map(|pkg| PackageOutcome {
-            pkg,
-            value: pkg.parsed.license_file.as_ref().map(|l| l.to_string()),
+            pkg: pkg.clone(),
+            value: pkg.parsed.license_file.as_ref().map(ToString::to_string),
         })
         .collect::<Vec<_>>();
 
     if !outliers.is_empty() {
-        return Err(Error::OutcomeError {
+        bail!(ComplianceError {
             msg: "These non-private packages should have a license file".to_string(),
             expected: None,
             outliers,
@@ -226,7 +232,7 @@ pub fn publishable_has_license_file(workspace: &Workspace) -> Result<(), Error> 
 const EXPECTED_LICENSE: &str = "MIT OR Apache-2.0";
 
 /// Ensure all non-private crates use the the same expected license
-pub fn publishable_has_unified_license(workspace: &Workspace) -> Result<(), Error> {
+pub fn publishable_has_unified_license(workspace: &Workspace) -> anyhow::Result<()> {
     let outliers = workspace
         .members
         .iter()
@@ -235,13 +241,13 @@ pub fn publishable_has_unified_license(workspace: &Workspace) -> Result<(), Erro
                 && matches!(pkg.parsed.license, Some(ref l) if l != EXPECTED_LICENSE)
         })
         .map(|pkg| PackageOutcome {
-            pkg,
-            value: pkg.parsed.license.as_ref().map(|l| l.to_string()),
+            pkg: pkg.clone(),
+            value: pkg.parsed.license.as_ref().map(ToString::to_string),
         })
         .collect::<Vec<_>>();
 
     if !outliers.is_empty() {
-        return Err(Error::OutcomeError {
+        bail!(ComplianceError {
             msg: "These non-private packages have an unexpected license".to_string(),
             expected: Some(Expected { value: EXPECTED_LICENSE.to_string(), reason: None }),
             outliers,
@@ -252,16 +258,16 @@ pub fn publishable_has_unified_license(workspace: &Workspace) -> Result<(), Erro
 }
 
 /// Ensure all non-private crates have a description
-pub fn publishable_has_description(workspace: &Workspace) -> Result<(), Error> {
+pub fn publishable_has_description(workspace: &Workspace) -> anyhow::Result<()> {
     let outliers = workspace
         .members
         .iter()
         .filter(|pkg| utils::is_publishable(pkg) && pkg.parsed.description.is_none())
-        .map(|pkg| PackageOutcome { pkg, value: None })
+        .map(|pkg| PackageOutcome { pkg: pkg.clone(), value: None })
         .collect::<Vec<_>>();
 
     if !outliers.is_empty() {
-        return Err(Error::OutcomeError {
+        bail!(ComplianceError {
             msg: "These non-private packages should have a `description`".to_string(),
             expected: None,
             outliers,
@@ -272,7 +278,7 @@ pub fn publishable_has_description(workspace: &Workspace) -> Result<(), Error> {
 }
 
 /// Ensure all non-private crates have a README file
-pub fn publishable_has_readme(workspace: &Workspace) -> Result<(), Error> {
+pub fn publishable_has_readme(workspace: &Workspace) -> anyhow::Result<()> {
     let outliers = workspace
         .members
         .iter()
@@ -281,11 +287,14 @@ pub fn publishable_has_readme(workspace: &Workspace) -> Result<(), Error> {
                 && !(utils::exists(pkg, "README.md")
                     || matches!(pkg.parsed.readme, Some(ref r) if utils::exists(pkg, r.as_str())))
         })
-        .map(|pkg| PackageOutcome { pkg, value: pkg.parsed.readme.as_ref().map(|r| r.to_string()) })
+        .map(|pkg| PackageOutcome {
+            pkg: pkg.clone(),
+            value: pkg.parsed.readme.as_ref().map(ToString::to_string),
+        })
         .collect::<Vec<_>>();
 
     if !outliers.is_empty() {
-        return Err(Error::OutcomeError {
+        bail!(ComplianceError {
             msg: "These non-private packages should have a readme file".to_string(),
             expected: None,
             outliers,
@@ -298,7 +307,7 @@ pub fn publishable_has_readme(workspace: &Workspace) -> Result<(), Error> {
 const EXPECTED_LINK: &str = "https://github.com/near/nearcore";
 
 /// Ensure all non-private crates have appropriate repository links
-pub fn publishable_has_near_link(workspace: &Workspace) -> Result<(), Error> {
+pub fn publishable_has_near_link(workspace: &Workspace) -> anyhow::Result<()> {
     let outliers = workspace
         .members
         .iter()
@@ -307,13 +316,13 @@ pub fn publishable_has_near_link(workspace: &Workspace) -> Result<(), Error> {
                 && !matches!(pkg.parsed.repository, Some(ref r) if r == EXPECTED_LINK)
         })
         .map(|pkg| PackageOutcome {
-            pkg,
-            value: pkg.parsed.repository.as_ref().map(|r| r.to_string()),
+            pkg: pkg.clone(),
+            value: pkg.parsed.repository.as_ref().map(ToString::to_string),
         })
         .collect::<Vec<_>>();
 
     if !outliers.is_empty() {
-        return Err(Error::OutcomeError {
+        bail!(ComplianceError {
             msg: "These non-private packages need to have the appropriate `repository` link"
                 .to_string(),
             expected: Some(Expected { value: EXPECTED_LINK.to_string(), reason: None }),

--- a/tools/themis/src/style.rs
+++ b/tools/themis/src/style.rs
@@ -1,5 +1,8 @@
-// https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit
+/// ANSI Color Codes
+///
+/// https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit
 #[allow(dead_code)]
+#[derive(Eq, Copy, Debug, Clone, PartialEq)]
 pub enum Color {
     Black,
     Red,
@@ -14,7 +17,7 @@ pub enum Color {
 }
 
 impl Color {
-    pub fn as_ansi(&self, foreground: bool) -> String {
+    pub fn as_ansi(self, foreground: bool) -> String {
         let color = match self {
             Color::Gray { shade } => return Color::Color256(0xE8 + shade).as_ansi(foreground),
             Color::Color256(n) => {

--- a/tools/themis/src/types.rs
+++ b/tools/themis/src/types.rs
@@ -1,0 +1,93 @@
+use std::fmt;
+use std::sync::Arc;
+
+use cargo_metadata::camino::Utf8PathBuf;
+
+use super::style;
+
+#[derive(Debug)]
+pub struct Package {
+    pub parsed: cargo_metadata::Package,
+    pub raw: toml::Value,
+}
+
+#[derive(Debug)]
+pub struct Workspace {
+    pub root: Utf8PathBuf,
+    pub members: Vec<Arc<Package>>,
+}
+
+#[derive(Debug)]
+pub struct PackageOutcome {
+    pub pkg: Arc<Package>,
+    pub value: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct Expected {
+    pub value: String,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct ComplianceError {
+    pub msg: String,
+    pub expected: Option<Expected>,
+    pub outliers: Vec<PackageOutcome>,
+}
+
+impl fmt::Display for ComplianceError {
+    fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
+        unimplemented!()
+    }
+}
+
+impl std::error::Error for ComplianceError {}
+
+impl ComplianceError {
+    pub fn report(&self, workspace: &Workspace) {
+        let mut report = format!(
+            "{c_heading}(i) {}:{c_none}{}",
+            self.msg,
+            match &self.expected {
+                None => "".to_string(),
+                Some(Expected { value, reason }) => format!(
+                    " [expected: {c_expected}{}{c_none}{}]",
+                    value,
+                    reason.as_ref().map_or("".to_string(), |reason| format!(", {}", reason)),
+                    c_expected = style::fg(style::Color::Color256(35))
+                        + &style::bg(style::Color::Gray { shade: 3 })
+                        + style::bold(),
+                    c_none = style::reset()
+                ),
+            },
+            c_heading = style::fg(style::Color::Color256(172)) + style::bold(),
+            c_none = style::reset()
+        );
+
+        for PackageOutcome { pkg, value } in &self.outliers {
+            let Package { parsed: pkg, .. } = &**pkg;
+            report.push_str(&format!(
+                "\n \u{2022} {c_name}{}{c_none} v{} {c_path}({}){c_none}{}",
+                pkg.name,
+                pkg.version,
+                pkg.manifest_path.strip_prefix(&workspace.root).unwrap(),
+                match value {
+                    None => "".to_string(),
+                    Some(value) => format!(
+                        " [found: {c_found}{}{c_none}]",
+                        value,
+                        c_found = style::fg(style::Color::White)
+                            + &style::bg(style::Color::Red)
+                            + style::bold(),
+                        c_none = style::reset()
+                    ),
+                },
+                c_name = style::fg(style::Color::Color256(39)) + style::bold(),
+                c_path = style::fg(style::Color::Gray { shade: 12 }),
+                c_none = style::reset(),
+            ));
+        }
+        eprintln!("{}", report);
+    }
+}

--- a/tools/themis/src/utils.rs
+++ b/tools/themis/src/utils.rs
@@ -1,9 +1,10 @@
 use std::fs;
+use std::sync::Arc;
 
 use cargo_metadata::{camino::Utf8PathBuf, CargoOpt, MetadataCommand};
 use serde::de::DeserializeOwned;
 
-use super::{style, Error, Expected, Package, PackageOutcome, Workspace};
+use super::types::{Package, Workspace};
 
 macro_rules! _warn {
     ($msg:literal $($arg:tt)*) => {
@@ -33,58 +34,11 @@ pub fn parse_workspace() -> anyhow::Result<Workspace> {
         .filter(|package| metadata.workspace_members.contains(&package.id))
         .map(|package| {
             let raw = parse_toml(&package.manifest_path)?;
-            Ok(Package { parsed: package, raw })
+            Ok(Arc::new(Package { parsed: package, raw }))
         })
-        .collect::<anyhow::Result<Vec<Package>>>()?;
+        .collect::<anyhow::Result<_>>()?;
 
     Ok(Workspace { root: metadata.workspace_root, members })
-}
-
-/// Returns true if the rule failed, false if otherwise
-pub fn check_and_report(outcome: Result<(), Error>, workspace: &Workspace) -> anyhow::Result<bool> {
-    match outcome {
-        Err(Error::RuntimeError(err)) => Err(err),
-        Err(Error::OutcomeError { msg, expected, outliers }) => {
-            let mut report = format!(
-                "{c_heading}(i) {}:{c_none}{}",
-                msg,
-                expected.map_or("".to_string(), |Expected { value, reason }| format!(
-                    " [expected: {c_expected}{}{c_none}{}]",
-                    value,
-                    reason.map_or("".to_string(), |reason| format!(", {}", reason)),
-                    c_expected = style::fg(style::Color::Color256(35))
-                        + &style::bg(style::Color::Gray { shade: 3 })
-                        + style::bold(),
-                    c_none = style::reset()
-                )),
-                c_heading = style::fg(style::Color::Color256(172)) + style::bold(),
-                c_none = style::reset()
-            );
-
-            for PackageOutcome { pkg: Package { parsed: pkg, .. }, value } in outliers {
-                report.push_str(&format!(
-                    "\n \u{2022} {c_name}{}{c_none} v{} {c_path}({}){c_none}{}",
-                    pkg.name,
-                    pkg.version,
-                    pkg.manifest_path.strip_prefix(&workspace.root).unwrap(),
-                    value.map_or("".to_string(), |v| format!(
-                        " [found: {c_found}{}{c_none}]",
-                        v,
-                        c_found = style::fg(style::Color::White)
-                            + &style::bg(style::Color::Red)
-                            + style::bold(),
-                        c_none = style::reset()
-                    )),
-                    c_name = style::fg(style::Color::Color256(39)) + style::bold(),
-                    c_path = style::fg(style::Color::Gray { shade: 12 }),
-                    c_none = style::reset(),
-                ));
-            }
-            eprintln!("{}", report);
-            Ok(true)
-        }
-        _ => Ok(false),
-    }
 }
 
 /// Checks if the crate specified is explicitly publishable

--- a/tools/themis/src/utils.rs
+++ b/tools/themis/src/utils.rs
@@ -1,5 +1,4 @@
 use std::fs;
-use std::sync::Arc;
 
 use cargo_metadata::{camino::Utf8PathBuf, CargoOpt, MetadataCommand};
 use serde::de::DeserializeOwned;
@@ -34,7 +33,7 @@ pub fn parse_workspace() -> anyhow::Result<Workspace> {
         .filter(|package| metadata.workspace_members.contains(&package.id))
         .map(|package| {
             let raw = parse_toml(&package.manifest_path)?;
-            Ok(Arc::new(Package { parsed: package, raw }))
+            Ok(Package { parsed: package, raw })
         })
         .collect::<anyhow::Result<_>>()?;
 


### PR DESCRIPTION
Context: https://github.com/near/nearcore/pull/5724#discussion_r766659405

cc. @matklad

#### Interface Change

Thanks for the cleanup hints @matklad

##### Before

```console
(i) These packages have an incompatible `rust-version`: [expected: <=1.57.0, as defined in the `rust-toolchain`]
 • near-cache v0.0.0 (utils/near-cache/Cargo.toml) [found: 1.58.0]
```

##### After

```console
(i) These packages have an incompatible `rust-version`: [expected: <=1.57.0, as defined in the `rust-toolchain`]
 ↳ utils/near-cache/Cargo.toml (found: 1.58.0)
```