### PR TITLE
re: Replace `Arc<Store>` with `Store`

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1634,7 +1634,7 @@ impl Chain {
     ) -> Result<ShardStateSyncResponseHeader, Error> {
         // Check cache
         let key = StateHeaderKey(shard_id, sync_hash).try_to_vec()?;
-        if let Ok(Some(header)) = self.store.owned_store().get_ser(ColStateHeaders, &key) {
+        if let Ok(Some(header)) = self.store.store().get_ser(ColStateHeaders, &key) {
             return Ok(header);
         }
 
@@ -1805,7 +1805,7 @@ impl Chain {
         };
 
         // Saving the header data
-        let mut store_update = self.store.owned_store().store_update();
+        let mut store_update = self.store.store().store_update();
         store_update.set_ser(ColStateHeaders, &key, &shard_state_header)?;
         store_update.commit()?;
 
@@ -1820,7 +1820,7 @@ impl Chain {
     ) -> Result<Vec<u8>, Error> {
         // Check cache
         let key = StatePartKey(sync_hash, shard_id, part_id).try_to_vec()?;
-        if let Ok(Some(state_part)) = self.store.owned_store().get(ColStateParts, &key) {
+        if let Ok(Some(state_part)) = self.store.store().get(ColStateParts, &key) {
             return Ok(state_part);
         }
 
@@ -1862,7 +1862,7 @@ impl Chain {
         self.get_state_response_header(shard_id, sync_hash)?;
 
         // Saving the part data
-        let mut store_update = self.store.owned_store().store_update();
+        let mut store_update = self.store.store().store_update();
         store_update.set(ColStateParts, &key, &state_part);
         store_update.commit()?;
 
@@ -2035,7 +2035,7 @@ impl Chain {
         }
 
         // Saving the header data.
-        let mut store_update = self.store.owned_store().store_update();
+        let mut store_update = self.store.store().store_update();
         let key = StateHeaderKey(shard_id, sync_hash).try_to_vec()?;
         store_update.set_ser(ColStateHeaders, &key, &shard_state_header)?;
         store_update.commit()?;
@@ -2071,7 +2071,7 @@ impl Chain {
         }
 
         // Saving the part data.
-        let mut store_update = self.store.owned_store().store_update();
+        let mut store_update = self.store.store().store_update();
         let key = StatePartKey(sync_hash, shard_id, part_id).try_to_vec()?;
         store_update.set(ColStateParts, &key, data);
         store_update.commit()?;

--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -76,7 +76,7 @@ pub struct StoreValidator {
     me: Option<AccountId>,
     config: GenesisConfig,
     runtime_adapter: Arc<dyn RuntimeAdapter>,
-    store: Arc<Store>,
+    store: Store,
     inner: StoreValidatorCache,
     timeout: Option<u64>,
     start_time: Instant,
@@ -90,7 +90,7 @@ impl StoreValidator {
         me: Option<AccountId>,
         config: GenesisConfig,
         runtime_adapter: Arc<dyn RuntimeAdapter>,
-        store: Arc<Store>,
+        store: Store,
     ) -> Self {
         StoreValidator {
             me,
@@ -409,7 +409,7 @@ mod tests {
     use near_store::test_utils::create_test_store;
 
     use crate::test_utils::KeyValueRuntime;
-    use crate::{Chain, ChainGenesis, DoomslugThresholdMode};
+    use crate::{Chain, ChainGenesis, ChainStoreAccess, DoomslugThresholdMode};
 
     use super::*;
 
@@ -429,7 +429,7 @@ mod tests {
     #[test]
     fn test_io_error() {
         let (mut chain, mut sv) = init();
-        let mut store_update = chain.store().owned_store().store_update();
+        let mut store_update = chain.store().store().store_update();
         assert!(sv.validate_col(DBCol::ColBlock).is_ok());
         store_update
             .set_ser::<Vec<u8>>(
@@ -448,7 +448,7 @@ mod tests {
     #[test]
     fn test_db_corruption() {
         let (chain, mut sv) = init();
-        let mut store_update = chain.store().owned_store().store_update();
+        let mut store_update = chain.store().store().store_update();
         assert!(sv.validate_col(DBCol::ColTrieChanges).is_ok());
         store_update.set_ser::<Vec<u8>>(DBCol::ColTrieChanges, "567".as_ref(), &vec![123]).unwrap();
         store_update.commit().unwrap();

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -68,7 +68,7 @@ struct KVState {
 
 /// Simple key value runtime for tests.
 pub struct KeyValueRuntime {
-    store: Arc<Store>,
+    store: Store,
     tries: ShardTries,
     validators: Vec<Vec<ValidatorStake>>,
     validator_groups: u64,
@@ -111,12 +111,12 @@ fn create_receipt_nonce(
 }
 
 impl KeyValueRuntime {
-    pub fn new(store: Arc<Store>, epoch_length: u64) -> Self {
+    pub fn new(store: Store, epoch_length: u64) -> Self {
         Self::new_with_validators(store, vec![vec!["test".parse().unwrap()]], 1, 1, epoch_length)
     }
 
     pub fn new_with_validators(
-        store: Arc<Store>,
+        store: Store,
         validators: Vec<Vec<AccountId>>,
         validator_groups: u64,
         num_shards: NumShards,
@@ -133,7 +133,7 @@ impl KeyValueRuntime {
     }
 
     pub fn new_with_validators_and_no_gc(
-        store: Arc<Store>,
+        store: Store,
         validators: Vec<Vec<AccountId>>,
         validator_groups: u64,
         num_shards: NumShards,
@@ -300,11 +300,11 @@ impl KeyValueRuntime {
 }
 
 impl RuntimeAdapter for KeyValueRuntime {
-    fn genesis_state(&self) -> (Arc<Store>, Vec<StateRoot>) {
+    fn genesis_state(&self) -> (Store, Vec<StateRoot>) {
         (self.store.clone(), ((0..self.num_shards).map(|_| StateRoot::default()).collect()))
     }
 
-    fn get_store(&self) -> Arc<Store> {
+    fn get_store(&self) -> Store {
         self.store.clone()
     }
 
@@ -1314,7 +1314,7 @@ pub fn display_chain(me: &Option<AccountId>, chain: &mut Chain, tail: bool) {
         head.last_block_hash
     );
     let mut headers = vec![];
-    for (key, _) in chain_store.owned_store().iter(ColBlockHeader) {
+    for (key, _) in chain_store.store().clone().iter(ColBlockHeader) {
         let header = chain_store
             .get_block_header(&CryptoHash::try_from(key.as_ref()).unwrap())
             .unwrap()

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -1,6 +1,5 @@
 use std::cmp::Ordering;
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use chrono::DateTime;
@@ -257,11 +256,11 @@ where
 /// Additionally handles validators.
 pub trait RuntimeAdapter: Send + Sync {
     /// Get store and genesis state roots
-    fn genesis_state(&self) -> (Arc<Store>, Vec<StateRoot>);
+    fn genesis_state(&self) -> (Store, Vec<StateRoot>);
 
     fn get_tries(&self) -> ShardTries;
 
-    fn get_store(&self) -> Arc<Store>;
+    fn get_store(&self) -> Store;
 
     /// Returns trie. Since shard layout may change from epoch to epoch, `shard_id` itself is
     /// not enough to identify the trie. `prev_hash` is used to identify the epoch the given

--- a/chain/chunks/src/test_utils.rs
+++ b/chain/chunks/src/test_utils.rs
@@ -41,8 +41,7 @@ impl Default for SealsManagerTestFixture {
         let store = near_store::test_utils::create_test_store();
         // 12 validators, 3 shards => 4 validators per shard
         let validators = make_validators(12);
-        let mock_runtime =
-            KeyValueRuntime::new_with_validators(Arc::clone(&store), validators, 1, 3, 5);
+        let mock_runtime = KeyValueRuntime::new_with_validators(store.clone(), validators, 1, 3, 5);
 
         let mock_parent_hash = CryptoHash::default();
         let mock_height: BlockHeight = 1;
@@ -91,7 +90,7 @@ impl Default for SealsManagerTestFixture {
 }
 
 impl SealsManagerTestFixture {
-    fn store_block_header(store: Arc<Store>, header: BlockHeader) {
+    fn store_block_header(store: Store, header: BlockHeader) {
         let mut chain_store = ChainStore::new(store, header.height());
         let mut update = chain_store.store_update();
         update.save_block_header(header).unwrap();
@@ -150,7 +149,7 @@ impl Default for ChunkForwardingTestFixture {
         // 12 validators, 3 shards => 4 validators per shard
         let validators = make_validators(12);
         let mock_runtime = Arc::new(KeyValueRuntime::new_with_validators(
-            Arc::clone(&store),
+            store.clone(),
             validators.clone(),
             1,
             3,

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -336,7 +336,7 @@ impl Handler<NetworkClientMessages> for ClientActor {
                             self.client.validator_signer.as_ref().map(|x| x.validator_id().clone()),
                             genesis,
                             self.client.runtime_adapter.clone(),
-                            self.client.chain.store().owned_store(),
+                            self.client.chain.store().store().clone(),
                         );
                         store_validator.set_timeout(timeout);
                         store_validator.validate();

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -1093,7 +1093,7 @@ pub fn setup_client_with_runtime(
 }
 
 pub fn setup_client(
-    store: Arc<Store>,
+    store: Store,
     validators: Vec<Vec<AccountId>>,
     validator_groups: u64,
     num_shards: NumShards,
@@ -1514,7 +1514,7 @@ impl TestEnv {
     /// this `TestEnv` was created with custom runtime adapters that
     /// customisation will be lost.
     pub fn restart(&mut self, idx: usize) {
-        let store = self.clients[idx].chain.store().owned_store();
+        let store = self.clients[idx].chain.store().store().clone();
         let account_id = self.get_client_id(idx).clone();
         let rng_seed = match self.seeds.get(&account_id) {
             Some(seed) => *seed,

--- a/chain/epoch_manager/src/lib.rs
+++ b/chain/epoch_manager/src/lib.rs
@@ -1,6 +1,5 @@
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::sync::Arc;
 
 use cached::{Cached, SizedCache};
 use log::{debug, warn};
@@ -51,7 +50,7 @@ const AGGREGATOR_SAVE_PERIOD: u64 = 1000;
 /// Tracks epoch information across different forks, such as validators.
 /// Note: that even after garbage collection, the data about genesis epoch should be in the store.
 pub struct EpochManager {
-    store: Arc<Store>,
+    store: Store,
     /// Current epoch config.
     config: AllEpochConfig,
     reward_calculator: RewardCalculator,
@@ -76,7 +75,7 @@ pub struct EpochManager {
 
 impl EpochManager {
     pub fn new_from_genesis_config(
-        store: Arc<Store>,
+        store: Store,
         genesis_config: &GenesisConfig,
     ) -> Result<Self, EpochError> {
         let reward_calculator = RewardCalculator::new(genesis_config);
@@ -91,7 +90,7 @@ impl EpochManager {
     }
 
     pub fn new(
-        store: Arc<Store>,
+        store: Store,
         config: AllEpochConfig,
         genesis_protocol_version: ProtocolVersion,
         reward_calculator: RewardCalculator,

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -296,7 +296,7 @@ impl Actor for PeerManagerActor {
 
 impl PeerManagerActor {
     pub fn new(
-        store: Arc<Store>,
+        store: Store,
         config: NetworkConfig,
         client_addr: Recipient<NetworkClientMessages>,
         view_client_addr: Recipient<NetworkViewClientMessages>,

--- a/chain/network/src/peer_manager/peer_store.rs
+++ b/chain/network/src/peer_manager/peer_store.rs
@@ -13,7 +13,6 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::net::SocketAddr;
 use std::ops::Not;
-use std::sync::Arc;
 use tracing::{debug, error};
 
 /// Level of trust we have about a new (PeerId, Addr) pair.
@@ -44,7 +43,7 @@ impl VerifiedPeer {
 
 /// Known peers store, maintaining cache of known peers and connection to storage to save/load them.
 pub struct PeerStore {
-    store: Arc<Store>,
+    store: Store,
     peer_states: HashMap<PeerId, KnownPeerState>,
     // This is a reverse index, from physical address to peer_id
     // It can happens that some peers don't have known address, so
@@ -54,7 +53,7 @@ pub struct PeerStore {
 
 impl PeerStore {
     pub(crate) fn new(
-        store: Arc<Store>,
+        store: Store,
         boot_nodes: &[PeerInfo],
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let mut peer_states = HashMap::default();
@@ -158,7 +157,7 @@ impl PeerStore {
     }
 
     fn save_to_db(
-        store: &Arc<Store>,
+        store: &Store,
         peer_id: &[u8],
         peer_state: &KnownPeerState,
     ) -> Result<(), Box<dyn Error>> {
@@ -366,7 +365,7 @@ impl PeerStore {
 }
 
 /// Public method used to iterate through all peers stored in the database.
-pub fn iter_peers_from_store<F>(store: Arc<Store>, f: F)
+pub fn iter_peers_from_store<F>(store: Store, f: F)
 where
     F: Fn((&PeerId, &KnownPeerState)),
 {

--- a/chain/network/src/routing/routing.rs
+++ b/chain/network/src/routing/routing.rs
@@ -65,7 +65,7 @@ pub struct RoutingTableView {
     /// Hash of messages that requires routing back to respective previous hop.
     pub route_back: RouteBackCache,
     /// Access to store on disk
-    store: Arc<Store>,
+    store: Store,
     /// Number of times each active connection was used to route a message.
     /// If there are several options use route with minimum nonce.
     /// New routes are added with minimum nonce.
@@ -89,7 +89,7 @@ pub enum FindRouteError {
 }
 
 impl RoutingTableView {
-    pub fn new(my_peer_id: PeerId, store: Arc<Store>) -> Self {
+    pub fn new(my_peer_id: PeerId, store: Store) -> Self {
         // Find greater nonce on disk and set `component_nonce` to this value.
 
         Self {

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -67,7 +67,7 @@ pub struct RoutingTableActor {
     /// ColComponentEdges     -> Mapping from `component_nonce` to list of edges
     /// ColPeerComponent      -> Mapping from `peer_id` to last component nonce if there
     ///                          exists one it belongs to.
-    store: Arc<Store>,
+    store: Store,
     /// First component nonce id that hasn't been used. Used for creating new components.
     pub next_available_component_nonce: u64,
     /// True if edges were changed and we need routing table recalculation.
@@ -82,7 +82,7 @@ pub struct RoutingTableActor {
 }
 
 impl RoutingTableActor {
-    pub fn new(my_peer_id: PeerId, store: Arc<Store>) -> Self {
+    pub fn new(my_peer_id: PeerId, store: Store) -> Self {
         let component_nonce = store
             .get_ser::<u64>(ColLastComponentNonce, &[])
             .unwrap_or(None)
@@ -772,6 +772,6 @@ impl Handler<ActixMessageWrapper<RoutingTableMessages>> for RoutingTableActor {
     }
 }
 
-pub fn start_routing_table_actor(peer_id: PeerId, store: Arc<Store>) -> Addr<RoutingTableActor> {
+pub fn start_routing_table_actor(peer_id: PeerId, store: Store) -> Addr<RoutingTableActor> {
     RoutingTableActor::new(peer_id, store).start()
 }

--- a/chain/network/src/routing/routing_table_view.rs
+++ b/chain/network/src/routing/routing_table_view.rs
@@ -31,7 +31,7 @@ pub struct RoutingTableView {
     /// Hash of messages that requires routing back to respective previous hop.
     pub route_back: RouteBackCache,
     /// Access to store on disk
-    store: Arc<Store>,
+    store: Store,
     /// Number of times each active connection was used to route a message.
     /// If there are several options use route with minimum nonce.
     /// New routes are added with minimum nonce.
@@ -55,7 +55,7 @@ pub enum FindRouteError {
 }
 
 impl RoutingTableView {
-    pub fn new(store: Arc<Store>) -> Self {
+    pub fn new(store: Store) -> Self {
         // Find greater nonce on disk and set `component_nonce` to this value.
 
         Self {

--- a/chain/network/src/test_utils.rs
+++ b/chain/network/src/test_utils.rs
@@ -319,7 +319,7 @@ pub mod test_features {
     //    Arc<AtomicUsize> - shared pointer for counting the number of received
     //                       `NetworkViewClientMessages::AnnounceAccount` messages
     pub fn make_peer_manager(
-        store: Arc<Store>,
+        store: Store,
         mut config: NetworkConfig,
         boot_nodes: Vec<(&str, u16)>,
         peer_max_count: u32,

--- a/chain/network/src/tests/cache_edges.rs
+++ b/chain/network/src/tests/cache_edges.rs
@@ -11,7 +11,6 @@ use near_primitives::time::Clock;
 use near_store::test_utils::create_test_store;
 use near_store::{ColComponentEdges, ColPeerComponent, Store};
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
 use std::time::Instant;
 
 type SimpleEdgeDescription = (usize, usize, bool);
@@ -28,7 +27,7 @@ impl EdgeDescription {
 
 struct RoutingTableTest {
     routing_table: RoutingTableActor,
-    store: Arc<Store>,
+    store: Store,
     peers: Vec<PeerId>,
     rev_peers: HashMap<PeerId, usize>,
     times: Vec<Instant>,

--- a/core/store/benches/store_bench.rs
+++ b/core/store/benches/store_bench.rs
@@ -2,7 +2,6 @@
 extern crate bencher;
 
 use bencher::{black_box, Bencher};
-use near_primitives::borsh::maybestd::sync::Arc;
 use near_primitives::errors::StorageError;
 use near_store::db::DBCol::ColBlockMerkleTree;
 use near_store::{create_store, DBCol, Store};
@@ -38,7 +37,7 @@ fn benchmark_write_then_read_successful(
 }
 
 /// Create `Store` in a random folder.
-fn create_store_in_random_folder() -> Arc<Store> {
+fn create_store_in_random_folder() -> Store {
     let tmp_dir = tempfile::Builder::new().prefix("_test_clear_column").tempdir().unwrap();
     let store = create_store(tmp_dir.path());
     store
@@ -57,7 +56,7 @@ fn generate_keys(count: usize, key_size: usize) -> Vec<Vec<u8>> {
 
 /// Read from DB value for given `kyes` in random order for `col`.
 /// Works only for column configured without reference counting, that is `.is_rc() == false`.
-fn read_from_db(store: &Arc<Store>, keys: &Vec<Vec<u8>>, col: DBCol) -> usize {
+fn read_from_db(store: &Store, keys: &Vec<Vec<u8>>, col: DBCol) -> usize {
     let mut read = 0;
     for _k in 0..keys.len() {
         let r = rand::random::<u32>() % (keys.len() as u32);
@@ -76,7 +75,7 @@ fn read_from_db(store: &Arc<Store>, keys: &Vec<Vec<u8>>, col: DBCol) -> usize {
 /// Write random value of size between `0` and `max_value_size` to given `keys` at specific column
 /// `col.`
 /// Works only for column configured without reference counting, that is `.is_rc() == false`.
-fn write_to_db(store: &Arc<Store>, keys: &[Vec<u8>], max_value_size: usize, col: DBCol) {
+fn write_to_db(store: &Store, keys: &[Vec<u8>], max_value_size: usize, col: DBCol) {
     let mut store_update = store.store_update();
     for key in keys.iter() {
         let x: usize = rand::random::<usize>() % max_value_size;

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -2,7 +2,6 @@
 use std::cmp;
 use std::collections::HashMap;
 use std::io;
-use std::marker::PhantomPinned;
 use std::sync::RwLock;
 
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -446,8 +445,6 @@ pub struct RocksDB {
     check_free_space_counter: std::sync::atomic::AtomicU16,
     check_free_space_interval: u16,
     free_space_threshold: bytesize::ByteSize,
-
-    _pin: PhantomPinned,
 }
 
 // DB was already Send+Sync. cf and read_options are const pointers using only functions in
@@ -535,7 +532,6 @@ impl RocksDBOptions {
         Ok(RocksDB {
             db,
             cfs,
-            _pin: PhantomPinned,
             check_free_space_interval: self.check_free_space_interval,
             check_free_space_counter: std::sync::atomic::AtomicU16::new(0),
             free_space_threshold: self.free_space_threshold,
@@ -575,7 +571,6 @@ impl RocksDBOptions {
         Ok(RocksDB {
             db,
             cfs,
-            _pin: PhantomPinned,
             check_free_space_interval: self.check_free_space_interval,
             check_free_space_counter: std::sync::atomic::AtomicU16::new(0),
             free_space_threshold: self.free_space_threshold,

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -2,7 +2,6 @@ use std::fs::File;
 use std::io::{BufReader, Read, Write};
 use std::ops::Deref;
 use std::path::Path;
-use std::pin::Pin;
 use std::sync::Arc;
 use std::{fmt, io};
 
@@ -31,10 +30,11 @@ use crate::db::refcount::encode_value_with_rc;
 use crate::db::{
     DBOp, DBTransaction, Database, RocksDB, GENESIS_JSON_HASH_KEY, GENESIS_STATE_ROOTS_KEY,
 };
+pub use crate::trie::iterator::TrieIterator;
+pub use crate::trie::update::{TrieUpdate, TrieUpdateIterator, TrieUpdateValuePtr};
 pub use crate::trie::{
-    iterator::TrieIterator, split_state, update::TrieUpdate, update::TrieUpdateIterator,
-    update::TrieUpdateValuePtr, ApplyStatePartResult, KeyForStateChanges, PartialStorage,
-    ShardTries, Trie, TrieChanges, WrappedTrieChanges,
+    split_state, ApplyStatePartResult, KeyForStateChanges, PartialStorage, ShardTries, Trie,
+    TrieChanges, WrappedTrieChanges,
 };
 
 pub mod db;
@@ -44,11 +44,11 @@ mod trie;
 
 #[derive(Clone)]
 pub struct Store {
-    storage: Pin<Arc<dyn Database>>,
+    storage: Arc<dyn Database>,
 }
 
 impl Store {
-    pub fn new(storage: Pin<Arc<dyn Database>>) -> Store {
+    pub fn new(storage: Arc<dyn Database>) -> Store {
         Store { storage }
     }
 
@@ -155,14 +155,14 @@ impl Store {
 
 /// Keeps track of current changes to the database and can commit all of them to the database.
 pub struct StoreUpdate {
-    storage: Pin<Arc<dyn Database>>,
+    storage: Arc<dyn Database>,
     transaction: DBTransaction,
     /// Optionally has reference to the trie to clear cache on the commit.
     tries: Option<ShardTries>,
 }
 
 impl StoreUpdate {
-    pub fn new(storage: Pin<Arc<dyn Database>>) -> Self {
+    pub fn new(storage: Arc<dyn Database>) -> Self {
         let transaction = storage.transaction();
         StoreUpdate { storage, transaction, tries: None }
     }
@@ -295,9 +295,9 @@ pub fn read_with_cache<'a, T: BorshDeserialize + 'a>(
     Ok(None)
 }
 
-pub fn create_store(path: &Path) -> Arc<Store> {
-    let db = Arc::pin(RocksDB::new(path).expect("Failed to open the database"));
-    Arc::new(Store::new(db))
+pub fn create_store(path: &Path) -> Store {
+    let db = Arc::new(RocksDB::new(path).expect("Failed to open the database"));
+    Store::new(db)
 }
 
 /// Reads an object from Trie.
@@ -503,7 +503,7 @@ pub fn set_genesis_state_roots(store_update: &mut StoreUpdate, genesis_roots: &V
 }
 
 pub struct StoreCompiledContractCache {
-    pub store: Arc<Store>,
+    pub store: Store,
 }
 
 /// Cache for compiled contracts code using Store for keeping data.

--- a/core/store/src/migrations.rs
+++ b/core/store/src/migrations.rs
@@ -137,7 +137,7 @@ fn recompute_block_ordinal(store: &Store) {
 }
 
 pub fn migrate_6_to_7(path: &Path) {
-    let db = Arc::pin(RocksDB::new_v6(path).expect("Failed to open the database"));
+    let db = Arc::new(RocksDB::new_v6(path).expect("Failed to open the database"));
     let store = Store::new(db);
     let mut store_update = store.store_update();
     col_state_refcount_8byte(&store, &mut store_update);
@@ -659,8 +659,7 @@ pub fn migrate_20_to_21(path: &Path) {
 }
 
 pub fn migrate_21_to_22(path: &Path) {
-    use near_primitives::epoch_manager::BlockInfoV1;
-    use near_primitives::epoch_manager::SlashState;
+    use near_primitives::epoch_manager::{BlockInfoV1, SlashState};
     use near_primitives::types::validator_stake::ValidatorStakeV1;
     use near_primitives::types::{BlockHeight, EpochId};
     use near_primitives::version::ProtocolVersion;
@@ -735,7 +734,7 @@ pub fn migrate_25_to_26(path: &Path) {
 pub fn migrate_26_to_27(path: &Path, is_archival: bool) {
     let store = create_store(path);
     if is_archival {
-        recompute_block_ordinal(store.as_ref());
+        recompute_block_ordinal(&store);
     }
     set_store_version(&store, 27);
 }

--- a/core/store/src/test_utils.rs
+++ b/core/store/src/test_utils.rs
@@ -14,9 +14,9 @@ use near_primitives::types::NumShards;
 use std::str::from_utf8;
 
 /// Creates an in-memory database.
-pub fn create_test_store() -> Arc<Store> {
-    let db = Arc::pin(TestDB::new());
-    Arc::new(Store::new(db))
+pub fn create_test_store() -> Store {
+    let db = Arc::new(TestDB::new());
+    Store::new(db)
 }
 
 /// Creates a Trie using an in-memory database.

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -3,7 +3,6 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt;
 use std::io::{Cursor, Read, Write};
-use std::sync::Arc;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
@@ -479,7 +478,7 @@ impl Trie {
         let storage =
             self.storage.as_caching_storage().expect("Storage should be TrieCachingStorage");
         let storage = TrieRecordingStorage {
-            store: Arc::clone(&storage.store),
+            store: storage.store.clone(),
             shard_uid: storage.shard_uid,
             recorded: RefCell::new(Default::default()),
         };

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -17,7 +17,7 @@ use crate::trie::{TrieRefcountChange, POISONED_LOCK_ERR};
 use crate::{StorageError, Store, StoreUpdate, Trie, TrieChanges, TrieUpdate};
 
 struct ShardTriesInner {
-    store: Arc<Store>,
+    store: Store,
     /// Cache reserved for client actor to use
     caches: RwLock<HashMap<ShardUId, TrieCache>>,
     /// Cache for readers.
@@ -32,7 +32,7 @@ impl ShardTries {
         shards.iter().map(|&shard_id| (shard_id, TrieCache::new())).collect()
     }
 
-    pub fn new(store: Arc<Store>, shard_version: ShardVersion, num_shards: NumShards) -> Self {
+    pub fn new(store: Store, shard_version: ShardVersion, num_shards: NumShards) -> Self {
         assert_ne!(num_shards, 0);
         let shards: Vec<_> = (0..num_shards)
             .map(|shard_id| ShardUId { version: shard_version, shard_id: shard_id as u32 })
@@ -74,7 +74,7 @@ impl ShardTries {
         self.get_trie_for_shard_internal(shard_uid, true)
     }
 
-    pub fn get_store(&self) -> Arc<Store> {
+    pub fn get_store(&self) -> Store {
         self.0.store.clone()
     }
 

--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -64,7 +64,7 @@ pub trait TrieStorage {
 /// Records every value read by retrieve_raw_bytes.
 /// Used for obtaining state parts (and challenges in the future).
 pub struct TrieRecordingStorage {
-    pub(crate) store: Arc<Store>,
+    pub(crate) store: Store,
     pub(crate) shard_uid: ShardUId,
     pub(crate) recorded: RefCell<HashMap<CryptoHash, Vec<u8>>>,
 }
@@ -132,13 +132,13 @@ const TRIE_MAX_CACHE_SIZE: usize = 1;
 const TRIE_LIMIT_CACHED_VALUE_SIZE: usize = 4000;
 
 pub struct TrieCachingStorage {
-    pub(crate) store: Arc<Store>,
+    pub(crate) store: Store,
     pub(crate) cache: TrieCache,
     pub(crate) shard_uid: ShardUId,
 }
 
 impl TrieCachingStorage {
-    pub fn new(store: Arc<Store>, cache: TrieCache, shard_uid: ShardUId) -> TrieCachingStorage {
+    pub fn new(store: Store, cache: TrieCache, shard_uid: ShardUId) -> TrieCachingStorage {
         TrieCachingStorage { store, cache, shard_uid }
     }
 

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -38,7 +38,7 @@ pub struct GenesisBuilder {
     #[allow(dead_code)]
     tmpdir: tempfile::TempDir,
     genesis: Arc<Genesis>,
-    store: Arc<Store>,
+    store: Store,
     runtime: NightshadeRuntime,
     unflushed_records: BTreeMap<ShardId, Vec<StateRecord>>,
     roots: BTreeMap<ShardId, StateRoot>,
@@ -53,11 +53,7 @@ pub struct GenesisBuilder {
 }
 
 impl GenesisBuilder {
-    pub fn from_config_and_store(
-        home_dir: &Path,
-        genesis: Arc<Genesis>,
-        store: Arc<Store>,
-    ) -> Self {
+    pub fn from_config_and_store(home_dir: &Path, genesis: Arc<Genesis>, store: Store) -> Self {
         let tmpdir = tempfile::Builder::new().prefix("storage").tempdir().unwrap();
         let runtime = NightshadeRuntime::new(
             tmpdir.path(),

--- a/genesis-tools/genesis-populate/src/state_dump.rs
+++ b/genesis-tools/genesis-populate/src/state_dump.rs
@@ -6,13 +6,12 @@ use std::path::{Path, PathBuf};
 use near_primitives::types::StateRoot;
 use near_store::db::DBCol::ColState;
 use near_store::{create_store, Store};
-use std::sync::Arc;
 
 const STATE_DUMP_FILE: &str = "state_dump";
 const GENESIS_ROOTS_FILE: &str = "genesis_roots";
 
 pub struct StateDump {
-    pub store: Arc<Store>,
+    pub store: Store,
     pub roots: Vec<StateRoot>,
 }
 

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -1327,7 +1327,7 @@ fn test_bad_chunk_mask() {
             create_chunk_on_height(&mut clients[chunk_producer], height);
         for client in clients.iter_mut() {
             let mut chain_store =
-                ChainStore::new(client.chain.store().owned_store(), chain_genesis.height);
+                ChainStore::new(client.chain.store().store().clone(), chain_genesis.height);
             client
                 .shards_mgr
                 .distribute_encoded_chunk(
@@ -2216,7 +2216,7 @@ fn test_validate_chunk_extra() {
 
     // Process the previously unavailable chunk. This causes two blocks to be accepted.
     let mut chain_store =
-        ChainStore::new(env.clients[0].chain.store().owned_store(), genesis_height);
+        ChainStore::new(env.clients[0].chain.store().store().clone(), genesis_height);
     let chunk_header = encoded_chunk.cloned_header();
     env.clients[0]
         .shards_mgr
@@ -2818,7 +2818,7 @@ fn test_epoch_protocol_version_change() {
 
         for j in 0..2 {
             let mut chain_store =
-                ChainStore::new(env.clients[j].chain.store().owned_store(), genesis_height);
+                ChainStore::new(env.clients[j].chain.store().store().clone(), genesis_height);
             env.clients[j]
                 .shards_mgr
                 .distribute_encoded_chunk(
@@ -3631,7 +3631,7 @@ mod access_key_nonce_range_tests {
         let (encoded_shard_chunk, merkle_path, receipts, block) =
             create_chunk_with_transactions(&mut env.clients[0], vec![tx]);
         let mut chain_store = ChainStore::new(
-            env.clients[0].chain.store().owned_store(),
+            env.clients[0].chain.store().store().clone(),
             genesis_block.header().height(),
         );
         env.clients[0]
@@ -4211,7 +4211,7 @@ mod contract_precompilation_tests {
     #[test]
     fn test_sync_and_call_cached_contract() {
         let num_clients = 2;
-        let stores: Vec<Arc<Store>> = (0..num_clients).map(|_| create_test_store()).collect();
+        let stores: Vec<Store> = (0..num_clients).map(|_| create_test_store()).collect();
         let mut genesis =
             Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
         genesis.config.epoch_length = EPOCH_LENGTH;
@@ -4314,7 +4314,7 @@ mod contract_precompilation_tests {
     #[test]
     fn test_two_deployments() {
         let num_clients = 2;
-        let stores: Vec<Arc<Store>> = (0..num_clients).map(|_| create_test_store()).collect();
+        let stores: Vec<Store> = (0..num_clients).map(|_| create_test_store()).collect();
         let mut genesis =
             Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
         genesis.config.epoch_length = EPOCH_LENGTH;
@@ -4397,7 +4397,7 @@ mod contract_precompilation_tests {
     #[test]
     fn test_sync_after_delete_account() {
         let num_clients = 3;
-        let stores: Vec<Arc<Store>> = (0..num_clients).map(|_| create_test_store()).collect();
+        let stores: Vec<Store> = (0..num_clients).map(|_| create_test_store()).collect();
         let mut genesis = Genesis::test(
             vec!["test0".parse().unwrap(), "test1".parse().unwrap(), "test2".parse().unwrap()],
             1,

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -276,7 +276,7 @@ pub fn apply_store_migrations(path: &Path, near_config: &NearConfig) {
     }
 }
 
-pub fn init_and_migrate_store(home_dir: &Path, near_config: &NearConfig) -> Arc<Store> {
+pub fn init_and_migrate_store(home_dir: &Path, near_config: &NearConfig) -> Store {
     let path = get_store_path(home_dir);
     let store_exists = store_path_exists(&path);
     if store_exists {
@@ -301,7 +301,7 @@ pub fn start_with_config(home_dir: &Path, config: NearConfig) -> Result<NearNode
 
     let runtime = Arc::new(NightshadeRuntime::with_config(
         home_dir,
-        Arc::clone(&store),
+        store.clone(),
         &config,
         config.client_config.trie_viewer_state_size_limit,
         config.client_config.max_gas_burnt_view,

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -133,7 +133,7 @@ pub struct NightshadeRuntime {
     genesis_config: GenesisConfig,
     runtime_config_store: RuntimeConfigStore,
 
-    store: Arc<Store>,
+    store: Store,
     tries: ShardTries,
     trie_viewer: TrieViewer,
     pub runtime: Runtime,
@@ -146,7 +146,7 @@ pub struct NightshadeRuntime {
 impl NightshadeRuntime {
     pub fn with_config(
         home_dir: &Path,
-        store: Arc<Store>,
+        store: Store,
         config: &NearConfig,
         trie_viewer_state_size_limit: Option<u64>,
         max_gas_burnt_view: Option<Gas>,
@@ -164,7 +164,7 @@ impl NightshadeRuntime {
 
     pub fn new(
         home_dir: &Path,
-        store: Arc<Store>,
+        store: Store,
         genesis: &Genesis,
         tracked_config: TrackedConfig,
         trie_viewer_state_size_limit: Option<u64>,
@@ -214,7 +214,7 @@ impl NightshadeRuntime {
 
     pub fn test_with_runtime_config_store(
         home_dir: &Path,
-        store: Arc<Store>,
+        store: Store,
         genesis: &Genesis,
         tracked_config: TrackedConfig,
         runtime_config_store: RuntimeConfigStore,
@@ -222,7 +222,7 @@ impl NightshadeRuntime {
         Self::new(home_dir, store, genesis, tracked_config, None, None, Some(runtime_config_store))
     }
 
-    pub fn test(home_dir: &Path, store: Arc<Store>, genesis: &Genesis) -> Self {
+    pub fn test(home_dir: &Path, store: Store, genesis: &Genesis) -> Self {
         Self::test_with_runtime_config_store(
             home_dir,
             store,
@@ -254,7 +254,7 @@ impl NightshadeRuntime {
         }
     }
 
-    fn genesis_state_from_dump(store: Arc<Store>, home_dir: &Path) -> Vec<StateRoot> {
+    fn genesis_state_from_dump(store: Store, home_dir: &Path) -> Vec<StateRoot> {
         error!(target: "near", "Loading genesis from a state dump file. Do not use this outside of genesis-tools");
         let mut state_file = home_dir.to_path_buf();
         state_file.push(STATE_DUMP_FILE);
@@ -267,7 +267,7 @@ impl NightshadeRuntime {
         state_roots
     }
 
-    fn genesis_state_from_records(store: Arc<Store>, genesis: &Genesis) -> Vec<StateRoot> {
+    fn genesis_state_from_records(store: Store, genesis: &Genesis) -> Vec<StateRoot> {
         if !genesis.records.as_ref().is_empty() {
             info!(target: "runtime", "Genesis state has {} records, computing state roots", genesis.records.0.len());
         } else {
@@ -330,7 +330,7 @@ impl NightshadeRuntime {
     /// After that: return genesis state roots. The state is not guaranteed to be in storage, as
     /// GC and state sync are allowed to delete it.
     pub fn initialize_genesis_state_if_needed(
-        store: Arc<Store>,
+        store: Store,
         home_dir: &Path,
         genesis: &Genesis,
     ) -> Vec<StateRoot> {
@@ -353,7 +353,7 @@ impl NightshadeRuntime {
     }
 
     pub fn initialize_genesis_state(
-        store: Arc<Store>,
+        store: Store,
         home_dir: &Path,
         genesis: &Genesis,
     ) -> Vec<StateRoot> {
@@ -659,11 +659,11 @@ pub fn state_record_to_shard_id(state_record: &StateRecord, shard_layout: &Shard
 }
 
 impl RuntimeAdapter for NightshadeRuntime {
-    fn genesis_state(&self) -> (Arc<Store>, Vec<StateRoot>) {
+    fn genesis_state(&self) -> (Store, Vec<StateRoot>) {
         (self.store.clone(), self.genesis_state_roots.clone())
     }
 
-    fn get_store(&self) -> Arc<Store> {
+    fn get_store(&self) -> Store {
         self.store.clone()
     }
 

--- a/test-utils/state-viewer/src/apply_chain_range.rs
+++ b/test-utils/state-viewer/src/apply_chain_range.rs
@@ -47,7 +47,7 @@ fn inc_and_report_progress(cnt: &AtomicU64, ts: &AtomicU64, all: u64, skipped: &
 }
 
 fn old_outcomes(
-    store: Arc<Store>,
+    store: Store,
     new_outcomes: &Vec<ExecutionOutcomeWithId>,
 ) -> Vec<ExecutionOutcomeWithId> {
     new_outcomes
@@ -74,7 +74,7 @@ fn maybe_add_to_csv(csv_file_mutex: &Mutex<Option<&mut File>>, s: &str) {
 }
 
 pub fn apply_chain_range(
-    store: Arc<Store>,
+    store: Store,
     genesis: &Genesis,
     start_height: Option<BlockHeight>,
     end_height: Option<BlockHeight>,
@@ -331,7 +331,7 @@ mod test {
 
     use crate::apply_chain_range::apply_chain_range;
 
-    fn setup(epoch_length: NumBlocks) -> (Arc<Store>, Genesis, TestEnv) {
+    fn setup(epoch_length: NumBlocks) -> (Store, Genesis, TestEnv) {
         let mut genesis =
             Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
         genesis.config.num_block_producer_seats = 2;

--- a/test-utils/state-viewer/src/cli.rs
+++ b/test-utils/state-viewer/src/cli.rs
@@ -14,7 +14,6 @@ use nearcore::{get_default_home, get_store_path, load_config, NearConfig};
 use once_cell::sync::Lazy;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use std::sync::Arc;
 
 static DEFAULT_HOME: Lazy<PathBuf> = Lazy::new(|| get_default_home());
 
@@ -151,7 +150,7 @@ pub struct DumpStateCmd {
 }
 
 impl DumpStateCmd {
-    pub fn run(self, home_dir: &Path, near_config: NearConfig, store: Arc<Store>) {
+    pub fn run(self, home_dir: &Path, near_config: NearConfig, store: Store) {
         dump_state(self.height, self.stream, self.file, home_dir, near_config, store);
     }
 }
@@ -165,7 +164,7 @@ pub struct ChainCmd {
 }
 
 impl ChainCmd {
-    pub fn run(self, home_dir: &Path, near_config: NearConfig, store: Arc<Store>) {
+    pub fn run(self, home_dir: &Path, near_config: NearConfig, store: Store) {
         print_chain(self.start_index, self.end_index, home_dir, near_config, store);
     }
 }
@@ -179,7 +178,7 @@ pub struct ReplayCmd {
 }
 
 impl ReplayCmd {
-    pub fn run(self, home_dir: &Path, near_config: NearConfig, store: Arc<Store>) {
+    pub fn run(self, home_dir: &Path, near_config: NearConfig, store: Store) {
         replay_chain(self.start_index, self.end_index, home_dir, near_config, store);
     }
 }
@@ -201,7 +200,7 @@ pub struct ApplyRangeCmd {
 }
 
 impl ApplyRangeCmd {
-    pub fn run(self, home_dir: &Path, near_config: NearConfig, store: Arc<Store>) {
+    pub fn run(self, home_dir: &Path, near_config: NearConfig, store: Store) {
         apply_range(
             self.start_index,
             self.end_index,
@@ -225,7 +224,7 @@ pub struct ApplyCmd {
 }
 
 impl ApplyCmd {
-    pub fn run(self, home_dir: &Path, near_config: NearConfig, store: Arc<Store>) {
+    pub fn run(self, home_dir: &Path, near_config: NearConfig, store: Store) {
         apply_block_at_height(self.height, self.shard_id, home_dir, near_config, store);
     }
 }
@@ -241,7 +240,7 @@ pub struct ViewChainCmd {
 }
 
 impl ViewChainCmd {
-    pub fn run(self, near_config: NearConfig, store: Arc<Store>) {
+    pub fn run(self, near_config: NearConfig, store: Store) {
         view_chain(self.height, self.block, self.chunk, near_config, store);
     }
 }
@@ -255,7 +254,7 @@ pub struct DumpCodeCmd {
 }
 
 impl DumpCodeCmd {
-    pub fn run(self, home_dir: &Path, near_config: NearConfig, store: Arc<Store>) {
+    pub fn run(self, home_dir: &Path, near_config: NearConfig, store: Store) {
         dump_code(self.account_id, &self.output, home_dir, near_config, store);
     }
 }
@@ -273,7 +272,7 @@ pub struct DumpAccountStorageCmd {
 }
 
 impl DumpAccountStorageCmd {
-    pub fn run(self, home_dir: &Path, near_config: NearConfig, store: Arc<Store>) {
+    pub fn run(self, home_dir: &Path, near_config: NearConfig, store: Store) {
         dump_account_storage(
             self.account_id,
             self.storage_key,
@@ -295,7 +294,7 @@ pub struct EpochInfoCmd {
 }
 
 impl EpochInfoCmd {
-    pub fn run(self, home_dir: &Path, near_config: NearConfig, store: Arc<Store>) {
+    pub fn run(self, home_dir: &Path, near_config: NearConfig, store: Store) {
         print_epoch_info(
             self.epoch_selection,
             self.validator_account_id.map(|s| AccountId::from_str(&s).unwrap()),
@@ -326,7 +325,7 @@ pub struct ReceiptsCmd {
 }
 
 impl ReceiptsCmd {
-    pub fn run(self, near_config: NearConfig, store: Arc<Store>) {
+    pub fn run(self, near_config: NearConfig, store: Store) {
         get_receipt(CryptoHash::from_str(&self.receipt_id).unwrap(), near_config, store)
     }
 }
@@ -338,7 +337,7 @@ pub struct ChunksCmd {
 }
 
 impl ChunksCmd {
-    pub fn run(self, near_config: NearConfig, store: Arc<Store>) {
+    pub fn run(self, near_config: NearConfig, store: Store) {
         let chunk_hash = ChunkHash::from(CryptoHash::from_str(&self.chunk_hash).unwrap());
         get_chunk(chunk_hash, near_config, store)
     }
@@ -350,7 +349,7 @@ pub struct PartialChunksCmd {
 }
 
 impl PartialChunksCmd {
-    pub fn run(self, near_config: NearConfig, store: Arc<Store>) {
+    pub fn run(self, near_config: NearConfig, store: Store) {
         let partial_chunk_hash =
             ChunkHash::from(CryptoHash::from_str(&self.partial_chunk_hash).unwrap());
         get_partial_chunk(partial_chunk_hash, near_config, store)

--- a/test-utils/state-viewer/src/commands.rs
+++ b/test-utils/state-viewer/src/commands.rs
@@ -28,13 +28,13 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-pub(crate) fn peers(store: Arc<Store>) {
+pub(crate) fn peers(store: Store) {
     iter_peers_from_store(store, |(peer_id, peer_info)| {
         println!("{} {:?}", peer_id, peer_info);
     })
 }
 
-pub(crate) fn state(home_dir: &Path, near_config: NearConfig, store: Arc<Store>) {
+pub(crate) fn state(home_dir: &Path, near_config: NearConfig, store: Store) {
     let (runtime, state_roots, header) = load_trie(store, home_dir, &near_config);
     println!("Storage roots are {:?}, block height is {}", state_roots, header.height());
     for (shard_id, state_root) in state_roots.iter().enumerate() {
@@ -55,7 +55,7 @@ pub(crate) fn dump_state(
     file: Option<PathBuf>,
     home_dir: &Path,
     near_config: NearConfig,
-    store: Arc<Store>,
+    store: Store,
 ) {
     let mode = match height {
         Some(h) => LoadTrieMode::LastFinalFromHeight(h),
@@ -89,7 +89,7 @@ pub(crate) fn apply_range(
     csv_file: Option<PathBuf>,
     home_dir: &Path,
     near_config: NearConfig,
-    store: Arc<Store>,
+    store: Store,
     only_contracts: bool,
 ) {
     let mut csv_file = csv_file.map(|filename| std::fs::File::create(filename).unwrap());
@@ -119,7 +119,7 @@ pub(crate) fn dump_code(
     output: &Path,
     home_dir: &Path,
     near_config: NearConfig,
-    store: Arc<Store>,
+    store: Store,
 ) {
     let (runtime, state_roots, header) = load_trie(store, home_dir, &near_config);
     let epoch_id = &runtime.get_epoch_id(header.hash()).unwrap();
@@ -149,7 +149,7 @@ pub(crate) fn dump_account_storage(
     block_height: String,
     home_dir: &Path,
     near_config: NearConfig,
-    store: Arc<Store>,
+    store: Store,
 ) {
     let block_height = if block_height == "latest" {
         LoadTrieMode::Latest
@@ -194,7 +194,7 @@ pub(crate) fn print_chain(
     end_height: BlockHeight,
     home_dir: &Path,
     near_config: NearConfig,
-    store: Arc<Store>,
+    store: Store,
 ) {
     let mut chain_store = ChainStore::new(store.clone(), near_config.genesis.config.genesis_height);
     let runtime = NightshadeRuntime::with_config(
@@ -262,7 +262,7 @@ pub(crate) fn replay_chain(
     end_height: BlockHeight,
     home_dir: &Path,
     near_config: NearConfig,
-    store: Arc<Store>,
+    store: Store,
 ) {
     let mut chain_store = ChainStore::new(store, near_config.genesis.config.genesis_height);
     let new_store = create_test_store();
@@ -294,7 +294,7 @@ pub(crate) fn apply_block_at_height(
     shard_id: ShardId,
     home_dir: &Path,
     near_config: NearConfig,
-    store: Arc<Store>,
+    store: Store,
 ) {
     let mut chain_store = ChainStore::new(store.clone(), near_config.genesis.config.genesis_height);
     let runtime_adapter: Arc<dyn RuntimeAdapter> = Arc::new(NightshadeRuntime::with_config(
@@ -404,7 +404,7 @@ pub(crate) fn view_chain(
     view_block: bool,
     view_chunks: bool,
     near_config: NearConfig,
-    store: Arc<Store>,
+    store: Store,
 ) {
     let mut chain_store = ChainStore::new(store.clone(), near_config.genesis.config.genesis_height);
     let block = {
@@ -469,7 +469,7 @@ pub(crate) fn view_chain(
     }
 }
 
-pub(crate) fn check_block_chunk_existence(store: Arc<Store>, near_config: NearConfig) {
+pub(crate) fn check_block_chunk_existence(store: Store, near_config: NearConfig) {
     let genesis_height = near_config.genesis.config.genesis_height;
     let mut chain_store = ChainStore::new(store.clone(), genesis_height);
     let head = chain_store.head().unwrap();
@@ -500,7 +500,7 @@ pub(crate) fn print_epoch_info(
     validator_account_id: Option<AccountId>,
     home_dir: &Path,
     near_config: NearConfig,
-    store: Arc<Store>,
+    store: Store,
 ) {
     let genesis_height = near_config.genesis.config.genesis_height;
     let mut chain_store = ChainStore::new(store.clone(), genesis_height);
@@ -525,13 +525,13 @@ pub(crate) fn print_epoch_info(
     );
 }
 
-pub(crate) fn get_receipt(receipt_id: CryptoHash, near_config: NearConfig, store: Arc<Store>) {
+pub(crate) fn get_receipt(receipt_id: CryptoHash, near_config: NearConfig, store: Store) {
     let mut chain_store = ChainStore::new(store.clone(), near_config.genesis.config.genesis_height);
     let receipt = chain_store.get_receipt(&receipt_id);
     println!("Receipt: {:#?}", receipt);
 }
 
-pub(crate) fn get_chunk(chunk_hash: ChunkHash, near_config: NearConfig, store: Arc<Store>) {
+pub(crate) fn get_chunk(chunk_hash: ChunkHash, near_config: NearConfig, store: Store) {
     let mut chain_store = ChainStore::new(store.clone(), near_config.genesis.config.genesis_height);
     let chunk = chain_store.get_chunk(&chunk_hash);
     println!("Chunk: {:#?}", chunk);
@@ -540,9 +540,9 @@ pub(crate) fn get_chunk(chunk_hash: ChunkHash, near_config: NearConfig, store: A
 pub(crate) fn get_partial_chunk(
     partial_chunk_hash: ChunkHash,
     near_config: NearConfig,
-    store: Arc<Store>,
+    store: Store,
 ) {
-    let mut chain_store = ChainStore::new(store.clone(), near_config.genesis.config.genesis_height);
+    let mut chain_store = ChainStore::new(store, near_config.genesis.config.genesis_height);
     let partial_chunk = chain_store.get_partial_chunk(&partial_chunk_hash);
     println!("Partial chunk: {:#?}", partial_chunk);
 }
@@ -558,7 +558,7 @@ enum LoadTrieMode {
 }
 
 fn load_trie(
-    store: Arc<Store>,
+    store: Store,
     home_dir: &Path,
     near_config: &NearConfig,
 ) -> (NightshadeRuntime, Vec<StateRoot>, BlockHeader) {
@@ -566,7 +566,7 @@ fn load_trie(
 }
 
 fn load_trie_stop_at_height(
-    store: Arc<Store>,
+    store: Store,
     home_dir: &Path,
     near_config: &NearConfig,
     mode: LoadTrieMode,

--- a/test-utils/state-viewer/src/epoch_info.rs
+++ b/test-utils/state-viewer/src/epoch_info.rs
@@ -33,7 +33,7 @@ pub(crate) enum EpochSelection {
 pub(crate) fn print_epoch_info(
     epoch_selection: EpochSelection,
     validator_account_id: Option<AccountId>,
-    store: Arc<Store>,
+    store: Store,
     chain_store: &mut ChainStore,
     epoch_manager: &mut EpochManager,
     runtime_adapter: Arc<dyn RuntimeAdapter>,
@@ -105,7 +105,7 @@ fn get_block_height_range(
 // Converts a bunch of optional filtering options into a vector of EpochIds.
 fn get_epoch_ids(
     epoch_selection: EpochSelection,
-    store: Arc<Store>,
+    store: Store,
     chain_store: &mut ChainStore,
     epoch_manager: &mut EpochManager,
 ) -> Vec<EpochId> {
@@ -149,7 +149,7 @@ fn get_epoch_ids(
 
 // Iterates over the ColEpochInfo column, ignores AGGREGATOR_KEY and returns deserialized EpochId
 // for EpochInfos that satisfy the given predicate.
-fn iterate_and_filter(store: Arc<Store>, predicate: impl Fn(EpochInfo) -> bool) -> Vec<EpochId> {
+fn iterate_and_filter(store: Store, predicate: impl Fn(EpochInfo) -> bool) -> Vec<EpochId> {
     store
         .iter(DBCol::ColEpochInfo)
         .filter_map(|(key, value)| {

--- a/test-utils/state-viewer/src/state_dump.rs
+++ b/test-utils/state-viewer/src/state_dump.rs
@@ -176,7 +176,7 @@ mod test {
         epoch_length: NumBlocks,
         protocol_version: ProtocolVersion,
         simple_nightshade_layout: Option<ShardLayout>,
-    ) -> (Arc<Store>, Genesis, TestEnv, NearConfig) {
+    ) -> (Store, Genesis, TestEnv, NearConfig) {
         let mut genesis =
             Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
         genesis.config.num_block_producer_seats = 2;


### PR DESCRIPTION
I was always curious, why we need `Pin` inside `Store`. It looks like we don't, and we can change
```
#[derive(Clone)]
pub struct Store {
    storage: Pin<Arc<dyn Database>>,
}
```
to
```
#[derive(Clone)]
pub struct Store {
    storage: Arc<dyn Database>,
}
```

Closes #4837