### PR TITLE
re: Group imports in `near-vm-runner`

### DIFF
--- a/runtime/near-vm-runner/src/lib.rs
+++ b/runtime/near-vm-runner/src/lib.rs
@@ -21,10 +21,9 @@ mod wasmtime_runner;
 pub use near_vm_errors::VMError;
 pub use near_vm_logic::with_ext_cost_counter;
 
-pub use cache::get_contract_cache_key;
-pub use cache::precompile_contract;
-pub use cache::precompile_contract_vm;
-pub use cache::MockCompiledContractCache;
+pub use cache::{
+    get_contract_cache_key, precompile_contract, precompile_contract_vm, MockCompiledContractCache,
+};
 pub use preload::{ContractCallPrepareRequest, ContractCallPrepareResult, ContractCaller};
 pub use runner::{run, VM};
 

--- a/runtime/near-vm-runner/src/runner.rs
+++ b/runtime/near-vm-runner/src/runner.rs
@@ -1,7 +1,9 @@
+use near_primitives::config::VMConfig;
 use near_primitives::contract::ContractCode;
 use near_primitives::hash::CryptoHash;
 use near_primitives::runtime::fees::RuntimeFeesConfig;
-use near_primitives::{config::VMConfig, types::CompiledContractCache, version::ProtocolVersion};
+use near_primitives::types::CompiledContractCache;
+use near_primitives::version::ProtocolVersion;
 use near_vm_errors::VMError;
 use near_vm_logic::types::PromiseResult;
 use near_vm_logic::{External, VMContext, VMOutcome};

--- a/runtime/near-vm-runner/src/tests/rs_contract.rs
+++ b/runtime/near-vm-runner/src/tests/rs_contract.rs
@@ -4,7 +4,8 @@ use near_primitives::types::Balance;
 use near_primitives::version::ProtocolFeature;
 use near_vm_errors::{FunctionCallError, VMError, WasmTrap};
 use near_vm_logic::mocks::mock_external::MockedExternal;
-use near_vm_logic::{types::ReturnData, VMConfig, VMOutcome};
+use near_vm_logic::types::ReturnData;
+use near_vm_logic::{VMConfig, VMOutcome};
 use std::mem::size_of;
 
 use crate::tests::{

--- a/runtime/near-vm-runner/src/wasmer_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer_runner.rs
@@ -3,9 +3,11 @@ use crate::errors::IntoVMError;
 use crate::memory::WasmerMemory;
 use crate::prepare::WASM_FEATURES;
 use crate::{cache, imports};
+use near_primitives::config::VMConfig;
 use near_primitives::contract::ContractCode;
 use near_primitives::runtime::fees::RuntimeFeesConfig;
-use near_primitives::{config::VMConfig, types::CompiledContractCache, version::ProtocolVersion};
+use near_primitives::types::CompiledContractCache;
+use near_primitives::version::ProtocolVersion;
 use near_vm_errors::{CompilationError, FunctionCallError, MethodResolveError, VMError, WasmTrap};
 use near_vm_logic::types::PromiseResult;
 use near_vm_logic::{External, VMContext, VMLogic, VMLogicError, VMOutcome};
@@ -83,8 +85,7 @@ impl IntoVMError for wasmer_runtime::error::ResolveError {
 
 impl IntoVMError for wasmer_runtime::error::RuntimeError {
     fn into_vm_error(self) -> VMError {
-        use wasmer_runtime::error::InvokeError;
-        use wasmer_runtime::error::RuntimeError;
+        use wasmer_runtime::error::{InvokeError, RuntimeError};
         match &self {
             RuntimeError::InvokeError(invoke_error) => match invoke_error {
                 // Indicates an exceptional circumstance such as a bug in Wasmer


### PR DESCRIPTION
Let's group imports properly in `near-vm-runner`.