### PR TITLE
fix: don't log host functions by default

### DIFF
--- a/runtime/near-vm-runner/src/imports.rs
+++ b/runtime/near-vm-runner/src/imports.rs
@@ -256,7 +256,7 @@ pub(crate) mod wasmer {
                     let _span = if IS_GAS {
                         None
                     } else {
-                        Some(tracing::debug_span!(target: "host-function", stringify!($func)).entered())
+                        Some(tracing::trace_span!(target: "host-function", stringify!($func)).entered())
                     };
                     let logic: &mut VMLogic<'_> = unsafe { &mut *(ctx.data as *mut VMLogic<'_>) };
                     logic.$func( $( $arg_name, )* )
@@ -310,7 +310,7 @@ pub(crate) mod wasmer2 {
                     let _span = if IS_GAS {
                         None
                     } else {
-                        Some(tracing::debug_span!(target: "host-function", stringify!($func)).entered())
+                        Some(tracing::trace_span!(target: "host-function", stringify!($func)).entered())
                     };
                     let logic: &mut VMLogic = unsafe { &mut *(env.logic as *mut VMLogic<'_>) };
                     logic.$func( $( $arg_name, )* )
@@ -374,7 +374,7 @@ pub(crate) mod wasmtime {
                     let _span = if IS_GAS {
                         None
                     } else {
-                        Some(tracing::debug_span!(target: "host-function", stringify!($func)).entered())
+                        Some(tracing::trace_span!(target: "host-function", stringify!($func)).entered())
                     };
                     let data = CALLER_CONTEXT.with(|caller_context| {
                         unsafe {


### PR DESCRIPTION
We received feedback that near_vm_runner produces too much output couple
of times. At the same time, there was once instance where having a log
line for something as trivial `read_register` was useful.

So, let's downgrade the logging here to trace for now, and maybe revisit
in the future when we have a clearer understanding of which amount of
logs is acceptable.