### PR TITLE
chore(deny): drop explicit exception for old borsh version

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -95,12 +95,6 @@ skip = [
     # hashbrown uses an older version
     { name = "ahash", version = "=0.4.7" },
 
-    # zeropool-bn optionally uses the older borsh 0.8.2
-    { name = "borsh", version = "=0.8.2" },
-    { name = "borsh-derive", version = "=0.8.2" },
-    { name = "borsh-derive-internal", version = "=0.8.2" },
-    { name = "borsh-schema-derive-internal", version = "=0.8.2" },
-
     # wasmer-runtime-core-near and parity-secp256k1 use an older version
     { name = "arrayvec", version = "=0.5.2" },
 


### PR DESCRIPTION
Cleans up these:

```console
$ cargo deny check bans
warning[B007]: skipped crate was not encountered
   ┌─ /home/miraclx/projects/git/near/nearcore/deny.toml:99:5
   │
99 │     { name = "borsh", version = "=0.8.2" },
   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unmatched skip configuration

warning[B007]: skipped crate was not encountered
    ┌─ /home/miraclx/projects/git/near/nearcore/deny.toml:100:5
    │
100 │     { name = "borsh-derive", version = "=0.8.2" },
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unmatched skip configuration

warning[B007]: skipped crate was not encountered
    ┌─ /home/miraclx/projects/git/near/nearcore/deny.toml:101:5
    │
101 │     { name = "borsh-derive-internal", version = "=0.8.2" },
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unmatched skip configuration

warning[B007]: skipped crate was not encountered
    ┌─ /home/miraclx/projects/git/near/nearcore/deny.toml:102:5
    │
102 │     { name = "borsh-schema-derive-internal", version = "=0.8.2" },
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unmatched skip configuration
```