### PR TITLE
chain: demonstrate failure in `assign_shards` function

### DIFF
--- a/chain/epoch_manager/src/shard_assignment.rs
+++ b/chain/epoch_manager/src/shard_assignment.rs
@@ -216,7 +216,7 @@ mod tests {
     ///
     /// TODO(#5932): This needs to be fixed.
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "cp_iter should contain enough elements to minimally fill each shard")]
     fn test_duplicate_validator() {
         test_distribution_common(&EXPONENTIAL_STAKES[..3], 2, 3);
     }

--- a/chain/epoch_manager/src/shard_assignment.rs
+++ b/chain/epoch_manager/src/shard_assignment.rs
@@ -216,7 +216,9 @@ mod tests {
     ///
     /// TODO(#5932): This needs to be fixed.
     #[test]
-    #[should_panic(expected = "cp_iter should contain enough elements to minimally fill each shard")]
+    #[should_panic(
+        expected = "cp_iter should contain enough elements to minimally fill each shard"
+    )]
     fn test_duplicate_validator() {
         test_distribution_common(&EXPONENTIAL_STAKES[..3], 2, 3);
     }

--- a/chain/epoch_manager/src/shard_assignment.rs
+++ b/chain/epoch_manager/src/shard_assignment.rs
@@ -116,13 +116,12 @@ fn assign_with_possible_repeats<T: HasStake + Eq, I: Iterator<Item = (usize, T)>
             .expect("cp_iter should contain enough elements to minimally fill each shard");
         let (least_validator_count, shard_stake, shard_id) =
             shard_index.pop().expect("shard_index should never be empty");
-        let shard_pos = usize::try_from(shard_id).unwrap();
 
         if assignment_index < num_chunk_producers {
             // no need to worry about duplicates yet; still on first pass through validators
             shard_index.push((least_validator_count + 1, shard_stake + cp.get_stake(), shard_id));
-            result[shard_pos].push(cp);
-        } else if result[shard_pos].contains(&cp) {
+            result[usize::try_from(shard_id).unwrap()].push(cp);
+        } else if result[usize::try_from(shard_id).unwrap()].contains(&cp) {
             // `cp` is already assigned to this shard, need to assign elsewhere
 
             // `buffer` tracks shards `cp` is already in, these will need to be pushed back into
@@ -136,7 +135,7 @@ fn assign_with_possible_repeats<T: HasStake + Eq, I: Iterator<Item = (usize, T)>
                 // assign a chunk producer right now.
                 let (least_validator_count, shard_stake, shard_id) =
                     shard_index.pop().expect("shard_index should never be empty");
-                if result[shard_pos].contains(&cp) {
+                if result[usize::try_from(shard_id).unwrap()].contains(&cp) {
                     buffer.push((least_validator_count, shard_stake, shard_id))
                 } else {
                     shard_index.push((
@@ -144,7 +143,7 @@ fn assign_with_possible_repeats<T: HasStake + Eq, I: Iterator<Item = (usize, T)>
                         shard_stake + cp.get_stake(),
                         shard_id,
                     ));
-                    result[shard_pos].push(cp);
+                    result[usize::try_from(shard_id).unwrap()].push(cp);
                     break;
                 }
             }
@@ -153,7 +152,7 @@ fn assign_with_possible_repeats<T: HasStake + Eq, I: Iterator<Item = (usize, T)>
             }
         } else {
             shard_index.push((least_validator_count + 1, shard_stake + cp.get_stake(), shard_id));
-            result[shard_pos].push(cp);
+            result[usize::try_from(shard_id).unwrap()].push(cp);
         }
     }
 }

--- a/chain/epoch_manager/src/shard_assignment.rs
+++ b/chain/epoch_manager/src/shard_assignment.rs
@@ -184,19 +184,41 @@ mod tests {
     #[test]
     fn test_exponential_distribution_few_shards() {
         // algorithm works well when there are few shards relative to the number of chunk producers
-        test_exponential_distribution_common(3, 3);
+        test_distribution_common(&EXPONENTIAL_STAKES, 3, 3);
     }
 
     #[test]
     fn test_exponential_distribution_several_shards() {
         // algorithm performs less well when there are more shards
-        test_exponential_distribution_common(6, 13);
+        test_distribution_common(&EXPONENTIAL_STAKES, 6, 13);
     }
 
     #[test]
     fn test_exponential_distribution_many_shards() {
         // algorithm performs even worse when there are many shards
-        test_exponential_distribution_common(24, 41);
+        test_distribution_common(&EXPONENTIAL_STAKES, 24, 41);
+    }
+
+    /// Tests situation where assigning with possible repeats encounters a state
+    /// in which the same validator would end up assigned to the same shard
+    /// twice.
+    ///
+    /// The way this scenario works is as follows.  There are three validators
+    /// [100, 90, 81] and they are distributed among two shards.  First the code
+    /// will assign 100 to shard 0 and then 90 to shard 1.  At that point, both
+    /// shards will have one validator but shard 1 will have less total stake so
+    /// the code will assign validator 81 to it.  In the last step, shard 0 will
+    /// have only one validator so the code will try to assign validator 100 to
+    /// it.  However, that validator is already assigned to that shard.
+    ///
+    /// Note that this case is currently broken and hence marking it as
+    /// `should_panic`.
+    ///
+    /// TODO(#5932): This needs to be fixed.
+    #[test]
+    #[should_panic]
+    fn test_duplicate_validator() {
+        test_distribution_common(&EXPONENTIAL_STAKES[..3], 2, 3);
     }
 
     #[test]
@@ -235,8 +257,7 @@ mod tests {
         assert_eq!(stake_1, 90);
     }
 
-    fn test_exponential_distribution_common(num_shards: NumShards, diff_tolerance: i128) {
-        let stakes = &EXPONENTIAL_STAKES;
+    fn test_distribution_common(stakes: &[Balance], num_shards: NumShards, diff_tolerance: i128) {
         let chunk_producers = make_validators(stakes);
         let min_validators_per_shard = 2;
 


### PR DESCRIPTION
Introduce a test case which demonstrates a failure in the code.
Upcoming changes will fix the issue.

Issue: https://github.com/near/nearcore/issues/5932
