### PR TITLE
re: Derive `MessageResponse` instead of implementing it

### DIFF
--- a/chain/network/src/private_actix.rs
+++ b/chain/network/src/private_actix.rs
@@ -2,8 +2,7 @@
 /// They are not meant to be used outside.
 use crate::network_protocol::PeerMessage;
 use crate::peer::peer_actor::PeerActor;
-use actix::dev::{MessageResponse, ResponseChannel};
-use actix::{Actor, Addr, Message};
+use actix::{Addr, Message};
 use conqueue::QueueSender;
 use near_network_primitives::types::{
     Edge, PartialEdgeInfo, PeerChainInfoV2, PeerInfo, PeerType, SimpleEdge,
@@ -54,7 +53,7 @@ impl Message for RegisterPeer {
     type Result = RegisterPeerResponse;
 }
 
-#[derive(MessageResponse, Debug)]
+#[derive(actix::MessageResponse, Debug)]
 pub enum RegisterPeerResponse {
     Accept(Option<PartialEdgeInfo>),
     InvalidNonce(Box<Edge>),
@@ -80,21 +79,9 @@ impl Message for PeersRequest {
     type Result = PeerRequestResult;
 }
 
-#[derive(Debug)]
+#[derive(Debug, actix::MessageResponse)]
 pub struct PeerRequestResult {
     pub peers: Vec<PeerInfo>,
-}
-
-impl<A, M> MessageResponse<A, M> for PeerRequestResult
-where
-    A: Actor,
-    M: Message<Result = PeerRequestResult>,
-{
-    fn handle<R: ResponseChannel<M>>(self, _: &mut A::Context, tx: Option<R>) {
-        if let Some(tx) = tx {
-            tx.send(self)
-        }
-    }
 }
 
 #[derive(Message)]
@@ -130,7 +117,7 @@ pub struct SendMessage {
 }
 
 #[cfg(feature = "test_features")]
-#[derive(MessageResponse, Debug, serde::Serialize)]
+#[derive(actix::MessageResponse, Debug, serde::Serialize)]
 pub struct GetPeerIdResult {
     pub(crate) peer_id: PeerId,
 }
@@ -167,7 +154,7 @@ impl Message for ValidateEdgeList {
     type Result = bool;
 }
 
-#[derive(MessageResponse, Debug)]
+#[derive(actix::MessageResponse, Debug)]
 #[cfg_attr(feature = "test_features", derive(serde::Serialize))]
 pub struct GetRoutingTableResult {
     pub edges_info: Vec<SimpleEdge>,

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -3,7 +3,6 @@ use crate::routing::edge_validator_actor::EdgeValidatorActor;
 use crate::routing::graph::Graph;
 use crate::routing::routing_table_view::SAVE_PEERS_MAX_TIME;
 use crate::stats::metrics;
-use actix::dev::MessageResponse;
 use actix::{
     Actor, ActorFuture, Addr, Context, ContextFutureSpawner, Handler, Message, Running,
     SyncArbiter, System, WrapFuture,
@@ -489,7 +488,7 @@ impl Message for RoutingTableMessages {
     type Result = RoutingTableMessagesResponse;
 }
 
-#[derive(MessageResponse, Debug)]
+#[derive(actix::MessageResponse, Debug)]
 pub enum RoutingTableMessagesResponse {
     #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
     AddPeerResponse {

--- a/utils/near-rate-limiter/src/message_wrapper.rs
+++ b/utils/near-rate-limiter/src/message_wrapper.rs
@@ -1,5 +1,4 @@
 use crate::{ThrottleController, ThrottleToken};
-use actix::dev::MessageResponse;
 use actix::Message;
 
 // Wrapper around Actix messages, used to track size of all messages sent to PeerManager.
@@ -36,7 +35,7 @@ impl<T: Message> Message for ActixMessageWrapper<T> {
     type Result = ActixMessageResponse<T::Result>;
 }
 
-#[derive(MessageResponse)]
+#[derive(actix::MessageResponse)]
 pub struct ActixMessageResponse<T> {
     msg: T,
     /// Ignore the warning, this code is used. We decrease counters `throttle_controller` when


### PR DESCRIPTION
We can refactor code related to `MessageResponse`. We don't need to implement the trait, we can simply derive it.