### PR TITLE
re: Implement `ProjectedHashMap`

### DIFF
--- a/chain/network/src/routing/mod.rs
+++ b/chain/network/src/routing/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod ibf_peer_set;
 #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
 pub(crate) mod ibf_set;
 pub(crate) mod network_protocol;
+pub(crate) mod projected_hash_map;
 mod route_back_cache;
 pub use crate::network_protocol::{Edge, EdgeState, PartialEdgeInfo, SimpleEdge};
 #[cfg(feature = "test_features")]

--- a/chain/network/src/routing/network_protocol.rs
+++ b/chain/network/src/routing/network_protocol.rs
@@ -1,9 +1,9 @@
+use crate::routing::projected_hash_map::ProjectedMapKey;
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_crypto::{KeyType, SecretKey, Signature};
 use near_primitives::borsh::maybestd::sync::Arc;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
-use std::borrow::Borrow;
 
 /// Information that will be ultimately used to create a new edge.
 /// It contains nonce proposed for the edge with signature from peer.
@@ -219,8 +219,8 @@ impl Edge {
     }
 }
 
-impl Borrow<(PeerId, PeerId)> for Edge {
-    fn borrow(&self) -> &(PeerId, PeerId) {
+impl ProjectedMapKey<(PeerId, PeerId)> for Edge {
+    fn projected_map_key(&self) -> &(PeerId, PeerId) {
         self.key()
     }
 }

--- a/chain/network/src/routing/network_protocol.rs
+++ b/chain/network/src/routing/network_protocol.rs
@@ -3,6 +3,7 @@ use near_crypto::{KeyType, SecretKey, Signature};
 use near_primitives::borsh::maybestd::sync::Arc;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
+use std::borrow::Borrow;
 
 /// Information that will be ultimately used to create a new edge.
 /// It contains nonce proposed for the edge with signature from peer.
@@ -64,8 +65,9 @@ impl Edge {
     }
 
     pub fn make_fake_edge(peer0: PeerId, peer1: PeerId, nonce: u64) -> Self {
+        let key = Edge::make_key(peer0, peer1);
         Self(Arc::new(EdgeInner {
-            key: (peer0, peer1),
+            key,
             nonce,
             signature0: Signature::empty(KeyType::ED25519),
             signature1: Signature::empty(KeyType::ED25519),
@@ -214,6 +216,12 @@ impl Edge {
         } else {
             None
         }
+    }
+}
+
+impl Borrow<(PeerId, PeerId)> for Edge {
+    fn borrow(&self) -> &(PeerId, PeerId) {
+        self.key()
     }
 }
 

--- a/chain/network/src/routing/projected_hash_map.rs
+++ b/chain/network/src/routing/projected_hash_map.rs
@@ -1,0 +1,147 @@
+use near_primitives::borsh::maybestd::borrow::Borrow;
+use std::collections::HashSet;
+use std::hash::{Hash, Hasher};
+use std::marker::PhantomData;
+
+/// Wraps around `Edge` struct. The main feature of this struct, is that it's hashed by
+/// `(Edge::key.0, Edge::key.1)` pair instead of `(Edge::key.0, Edge::key.1, Edge::nonce)`
+/// triple.
+#[derive(std::cmp::Eq)]
+pub struct HashMapHelper<T, V>
+where
+    V: Borrow<T>,
+    T: Hash + PartialEq + Eq,
+{
+    inner: V,
+    pd: PhantomData<T>,
+}
+
+impl<T, V> Borrow<T> for HashMapHelper<T, V>
+where
+    V: Borrow<T>,
+    T: Hash + PartialEq + Eq,
+{
+    fn borrow(&self) -> &T {
+        self.inner.borrow()
+    }
+}
+
+impl<T, V> PartialEq for HashMapHelper<T, V>
+where
+    V: Borrow<T>,
+    T: Hash + PartialEq + Eq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.inner.borrow() == other.inner.borrow()
+    }
+}
+
+impl<T, V> Hash for HashMapHelper<T, V>
+where
+    V: Borrow<T>,
+    T: Hash + PartialEq + Eq,
+{
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.inner.borrow().hash(state)
+    }
+}
+
+pub(crate) struct ProjectedHashMap<T, V>
+where
+    V: Borrow<T>,
+    T: Hash + PartialEq + Eq,
+{
+    repr: HashSet<HashMapHelper<T, V>>,
+    pd: PhantomData<T>,
+}
+
+impl<T, V> Default for ProjectedHashMap<T, V>
+where
+    V: Borrow<T>,
+    T: Hash + PartialEq + Eq,
+{
+    fn default() -> Self {
+        Self { repr: HashSet::new(), pd: PhantomData }
+    }
+}
+
+impl<T, V> ProjectedHashMap<T, V>
+where
+    V: Borrow<T>,
+    T: Hash + PartialEq + Eq,
+    HashMapHelper<T, V>: Eq,
+{
+    /// Note: We need to remove the value first.
+    /// The insert inside HashSet, will not remove existing element if it has the same key.
+    pub(crate) fn insert(&mut self, edge: V) {
+        self.repr.replace(HashMapHelper { inner: edge, pd: PhantomData });
+    }
+
+    pub(crate) fn get(&self, key: &T) -> Option<&V> {
+        self.repr.get(key).map(|v| &v.inner)
+    }
+
+    pub(crate) fn remove(&mut self, key: &T) -> bool {
+        self.repr.remove(key)
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &V> + '_ {
+        self.repr.iter().map(|it| &it.inner)
+    }
+
+    #[allow(unused)]
+    pub(crate) fn len(&self) -> usize {
+        self.repr.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::routing::projected_hash_map::ProjectedHashMap;
+    use crate::routing::Edge;
+    use near_primitives::network::PeerId;
+
+    #[test]
+    fn test_remove_key() {
+        let p1 = PeerId::random();
+        let p2 = PeerId::random();
+        let p3 = PeerId::random();
+        let p4 = PeerId::random();
+        let e1 = Edge::make_fake_edge(p1, p2, 1);
+        let e2 = Edge::make_fake_edge(p3, p4, 1);
+        let mut se = ProjectedHashMap::default();
+        se.insert(e2.clone());
+
+        let key = e1.key().clone();
+        se.insert(e1.clone());
+        assert_eq!(se.get(&key).unwrap(), &e1);
+        se.remove(e1.key());
+        assert_eq!(se.get(&key), None);
+
+        let key2 = e2.key().clone();
+        assert_eq!(se.get(&key2).unwrap(), &e2);
+    }
+
+    #[test]
+    fn test_hashset() {
+        let p1 = PeerId::random();
+        let p2 = PeerId::random();
+        let p3 = PeerId::random();
+        let e0 = Edge::make_fake_edge(p1.clone(), p3, 1);
+        let e1 = Edge::make_fake_edge(p1.clone(), p2.clone(), 1);
+        let e2 = Edge::make_fake_edge(p1.clone(), p2.clone(), 2);
+        let e3 = Edge::make_fake_edge(p2, p1, 3);
+
+        let mut se = ProjectedHashMap::default();
+        se.insert(e0.clone());
+        se.insert(e1);
+        se.insert(e2);
+        se.insert(e3.clone());
+
+        let key3 = e3.key().clone();
+        let key0 = e0.key().clone();
+
+        assert_eq!(se.get(&key3).unwrap(), &e3);
+        assert_eq!(se.get(&key0).unwrap(), &e0);
+    }
+}

--- a/chain/network/src/routing/projected_hash_map.rs
+++ b/chain/network/src/routing/projected_hash_map.rs
@@ -6,8 +6,7 @@ use std::marker::PhantomData;
 /// Wraps around `Edge` struct. The main feature of this struct, is that it's hashed by
 /// `(Edge::key.0, Edge::key.1)` pair instead of `(Edge::key.0, Edge::key.1, Edge::nonce)`
 /// triple.
-#[derive(std::cmp::Eq)]
-pub struct HashMapHelper<T, V>
+struct HashMapHelper<T, V>
 where
     V: Borrow<T>,
     T: Hash + PartialEq + Eq,
@@ -34,6 +33,13 @@ where
     fn eq(&self, other: &Self) -> bool {
         self.inner.borrow() == other.inner.borrow()
     }
+}
+
+impl<T, V> Eq for HashMapHelper<T, V>
+where
+    V: Borrow<T>,
+    T: Hash + PartialEq + Eq,
+{
 }
 
 impl<T, V> Hash for HashMapHelper<T, V>
@@ -69,7 +75,6 @@ impl<T, V> ProjectedHashMap<T, V>
 where
     V: Borrow<T>,
     T: Hash + PartialEq + Eq,
-    HashMapHelper<T, V>: Eq,
 {
     /// Note: We need to remove the value first.
     /// The insert inside HashSet, will not remove existing element if it has the same key.

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -2,6 +2,7 @@ use crate::network_protocol::{Edge, EdgeState};
 use crate::private_actix::{StopMsg, ValidateEdgeList};
 use crate::routing::edge_validator_actor::EdgeValidatorActor;
 use crate::routing::graph::Graph;
+use crate::routing::projected_hash_map::ProjectedHashMap;
 use crate::routing::routing_table_view::SAVE_PEERS_MAX_TIME;
 use crate::stats::metrics;
 use actix::dev::MessageResponse;
@@ -44,18 +45,20 @@ pub enum Prune {
 ///   - store removed edges to disk
 ///   - we currently don't store active edges to disk
 pub struct RoutingTableActor {
-    /// Data structure with all edges. It's guaranteed that `peer.0` < `peer.1`.
-    pub edges_info: HashMap<(PeerId, PeerId), Edge>,
+    /// Collection of edges representing P2P network.
+    /// It's indexed by `Edge::key()` key and can be search through by called `get()` function
+    /// with `(PeerId, PeerId)` as argument.
+    pub(crate) edges_info: ProjectedHashMap<(PeerId, PeerId), Edge>,
     /// Data structure used for exchanging routing tables.
     #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
-    pub peer_ibf_set: crate::routing::ibf_peer_set::IbfPeerSet,
+    pub(crate) peer_ibf_set: crate::routing::ibf_peer_set::IbfPeerSet,
     /// Current view of the network represented by undirected graph.
     /// Nodes are Peers and edges are active connections.
-    pub raw_graph: Graph,
+    pub(crate) raw_graph: Graph,
     /// Active PeerId that are part of the shortest path to each PeerId.
-    pub peer_forwarding: Arc<HashMap<PeerId, Vec<PeerId>>>,
+    pub(crate) peer_forwarding: Arc<HashMap<PeerId, Vec<PeerId>>>,
     /// Last time a peer was reachable through active edges.
-    pub peer_last_time_reachable: HashMap<PeerId, Instant>,
+    pub(crate) peer_last_time_reachable: HashMap<PeerId, Instant>,
     /// Everytime a group of peers becomes unreachable at the same time; We store edges belonging to
     /// them in components. We remove all of those edges from memory, and save them to database,
     /// If any of them become reachable again, we re-add whole component.
@@ -69,7 +72,7 @@ pub struct RoutingTableActor {
     ///                          exists one it belongs to.
     store: Arc<Store>,
     /// First component nonce id that hasn't been used. Used for creating new components.
-    pub next_available_component_nonce: u64,
+    pub(crate) next_available_component_nonce: u64,
     /// True if edges were changed and we need routing table recalculation.
     pub needs_routing_table_recalculation: bool,
     /// EdgeValidatorActor, which is responsible for validating edges.
@@ -115,7 +118,7 @@ impl RoutingTableActor {
         self.peer_ibf_set.remove_edge(&edge.to_simple_edge());
 
         let key = edge.key();
-        if self.edges_info.remove(key).is_some() {
+        if self.edges_info.remove(key) {
             self.raw_graph.remove_edge(&edge.key().0, &edge.key().1);
             self.needs_routing_table_recalculation = true;
         }
@@ -140,7 +143,7 @@ impl RoutingTableActor {
             }
             #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
             self.peer_ibf_set.add_edge(&edge.to_simple_edge());
-            self.edges_info.insert(key.clone(), edge);
+            self.edges_info.insert(edge);
             true
         }
     }
@@ -326,8 +329,10 @@ impl RoutingTableActor {
         let edges_to_remove = self
             .edges_info
             .iter()
-            .filter_map(|(key, edge)| {
-                if peers_to_remove.contains(&key.0) || peers_to_remove.contains(&key.1) {
+            .filter_map(|edge| {
+                if peers_to_remove.contains(&edge.key().0)
+                    || peers_to_remove.contains(&edge.key().1)
+                {
                     Some(edge.clone())
                 } else {
                     None
@@ -375,7 +380,7 @@ impl RoutingTableActor {
     }
 
     pub fn get_all_edges(&self) -> Vec<Edge> {
-        self.edges_info.iter().map(|x| x.1.clone()).collect()
+        self.edges_info.iter().cloned().collect()
     }
 }
 
@@ -588,7 +593,7 @@ impl Handler<RoutingTableMessages> for RoutingTableActor {
             }
             RoutingTableMessages::RequestRoutingTable => {
                 RoutingTableMessagesResponse::RequestRoutingTableResponse {
-                    edges_info: self.edges_info.iter().map(|(_k, v)| v.clone()).collect(),
+                    edges_info: self.edges_info.iter().cloned().collect(),
                 }
             }
             #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
@@ -656,7 +661,7 @@ impl Handler<RoutingTableMessages> for RoutingTableActor {
                                 crate::types::RoutingVersion2 {
                                     known_edges: self.edges_info.len() as u64,
                                     seed,
-                                    edges: self.edges_info.iter().map(|x| x.1.clone()).collect(),
+                                    edges: self.edges_info.iter().cloned().collect(),
                                     routing_state: crate::types::RoutingState::RequestAllEdges,
                                 }
                             };


### PR DESCRIPTION
We talked before about replacing `HashMap` with `HashSet` in https://github.com/near/nearcore/pull/5475

I think it would be better to have a generic implementation, that doesn't depend on `PeerId` or `Edge`. The code will be much cleaner that way.

