### PR TITLE
re: Use `Ordering::Relaxed` in `near-network`

### DIFF
--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -233,11 +233,11 @@ impl Actor for PeerManagerActor {
 
                     ctx.add_message_stream(incoming.filter_map(move |conn| {
                         if let Ok(conn) = conn {
-                            if pending_incoming_connections_counter.load(Ordering::SeqCst)
-                                + peer_counter.load(Ordering::SeqCst)
+                            if pending_incoming_connections_counter.load(Ordering::Relaxed)
+                                + peer_counter.load(Ordering::Relaxed)
                                 < max_num_peers + LIMIT_PENDING_PEERS
                             {
-                                pending_incoming_connections_counter.fetch_add(1, Ordering::SeqCst);
+                                pending_incoming_connections_counter.fetch_add(1, Ordering::Relaxed);
                                 return future::ready(Some(
                                     PeerManagerMessageRequest::InboundTcpConnect(
                                         InboundTcpConnect::new(conn),
@@ -883,7 +883,7 @@ impl PeerManagerActor {
         // Start every peer actor on separate thread.
         let arbiter = Arbiter::new();
         let peer_counter = self.peer_counter.clone();
-        peer_counter.fetch_add(1, Ordering::SeqCst);
+        peer_counter.fetch_add(1, Ordering::Relaxed);
 
         PeerActor::start_in_arbiter(&arbiter.handle(), move |ctx| {
             let (read, write) = tokio::io::split(stream);
@@ -1600,7 +1600,7 @@ impl PeerManagerActor {
                     addr: None,
                 })
                 .collect(),
-            peer_counter: self.peer_counter.load(Ordering::SeqCst),
+            peer_counter: self.peer_counter.load(Ordering::Relaxed),
         }
     }
 
@@ -2060,7 +2060,7 @@ impl PeerManagerActor {
             // TODO(1896): Gracefully drop inbound connection for other peer.
             debug!(target: "network", "Inbound connection dropped (network at max capacity).");
         }
-        self.pending_incoming_connections_counter.fetch_sub(1, Ordering::SeqCst);
+        self.pending_incoming_connections_counter.fetch_sub(1, Ordering::Relaxed);
     }
 
     #[cfg(feature = "test_features")]

--- a/chain/network/src/test_utils.rs
+++ b/chain/network/src/test_utils.rs
@@ -346,7 +346,7 @@ pub mod test_features {
             match msg {
                 NetworkViewClientMessages::AnnounceAccount(accounts) => {
                     if !accounts.is_empty() {
-                        counter1.fetch_add(1, Ordering::SeqCst);
+                        counter1.fetch_add(1, Ordering::Relaxed);
                     }
                     Box::new(Some(NetworkViewClientResponses::AnnounceAccount(
                         accounts.clone().into_iter().map(|obj| obj.0).collect(),


### PR DESCRIPTION
Orderings other than `Relaxed` makes sense to use only if the atomic value is meant to be used a memory barrier.
For the purpose of `near-network` only `Ordering::Relaxed` makes sense.

There is no  performance difference on `x86_64`, but this is not done for performance, but code readability.