### PR TITLE
refactor: use the lower level wasmer APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,7 +439,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
- "object 0.23.0",
+ "object",
  "rustc-demangle",
 ]
 
@@ -2243,15 +2243,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "js-sys"
-version = "0.3.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
-dependencies = [
- "wasm-bindgen",
-]
-
-[[package]]
 name = "keccak"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3279,6 +3270,7 @@ dependencies = [
  "assert_matches",
  "base64 0.13.0",
  "borsh 0.9.1",
+ "loupe",
  "memoffset",
  "near-cache",
  "near-primitives",
@@ -3292,9 +3284,10 @@ dependencies = [
  "serde",
  "threadpool",
  "tracing",
+ "wasmer-compiler-near",
  "wasmer-compiler-singlepass-near",
+ "wasmer-engine-near",
  "wasmer-engine-universal-near",
- "wasmer-near",
  "wasmer-runtime-core-near",
  "wasmer-runtime-near",
  "wasmer-types-near",
@@ -3546,17 +3539,6 @@ checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
 dependencies = [
  "crc32fast",
  "indexmap",
-]
-
-[[package]]
-name = "object"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
-dependencies = [
- "crc32fast",
- "indexmap",
- "memchr",
 ]
 
 [[package]]
@@ -5316,7 +5298,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
  "cfg-if 1.0.0",
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -5667,25 +5648,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmer-compiler"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0f7a9201a79b68fe6427afa7835828b23647ef75f8a7aa212ec112f1625eeb1"
-dependencies = [
- "enumset",
- "loupe",
- "rkyv",
- "serde",
- "serde_bytes",
- "smallvec",
- "target-lexicon 0.12.2",
- "thiserror",
- "wasmer-types",
- "wasmer-vm",
- "wasmparser 0.78.2",
-]
-
-[[package]]
 name = "wasmer-compiler-near"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5722,63 +5684,6 @@ dependencies = [
  "wasmer-compiler-near",
  "wasmer-types-near",
  "wasmer-vm-near",
-]
-
-[[package]]
-name = "wasmer-derive-near"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3fcfc8f5838baf311380dcf3ef9843120967ddb073273aa514a4009f50f052"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "wasmer-engine"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae9202a77333cfad9a32d33862dda7c1a981c3f17139f3da44a447df6b56ae4d"
-dependencies = [
- "backtrace",
- "enumset",
- "lazy_static",
- "loupe",
- "memmap2 0.5.0",
- "more-asserts",
- "rustc-demangle",
- "serde",
- "serde_bytes",
- "target-lexicon 0.12.2",
- "thiserror",
- "wasmer-compiler",
- "wasmer-types",
- "wasmer-vm",
-]
-
-[[package]]
-name = "wasmer-engine-dylib"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d633a81aa4278720ef476f9800efafccc4616d55f6e4fb079f6f268bd2df0a5c"
-dependencies = [
- "cfg-if 1.0.0",
- "enumset",
- "leb128",
- "libloading",
- "loupe",
- "rkyv",
- "serde",
- "tempfile",
- "tracing",
- "wasmer-compiler",
- "wasmer-engine",
- "wasmer-object",
- "wasmer-types",
- "wasmer-vm",
- "which",
 ]
 
 [[package]]
@@ -5820,43 +5725,6 @@ dependencies = [
  "wasmer-types-near",
  "wasmer-vm-near",
  "winapi",
-]
-
-[[package]]
-name = "wasmer-near"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b1428287e6fff52908b7c74e88f49b557d3e71b6b94b67ce532bcd5f872194"
-dependencies = [
- "cfg-if 1.0.0",
- "indexmap",
- "js-sys",
- "loupe",
- "more-asserts",
- "target-lexicon 0.12.2",
- "thiserror",
- "wasm-bindgen",
- "wasmer-compiler-near",
- "wasmer-compiler-singlepass-near",
- "wasmer-derive-near",
- "wasmer-engine-dylib",
- "wasmer-engine-near",
- "wasmer-engine-universal-near",
- "wasmer-types-near",
- "wasmer-vm-near",
- "winapi",
-]
-
-[[package]]
-name = "wasmer-object"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a94c41ae3e6df06eec59bf781043119b85d50da3e9886c2c4bf5d2e64d3532d8"
-dependencies = [
- "object 0.27.1",
- "thiserror",
- "wasmer-compiler",
- "wasmer-types",
 ]
 
 [[package]]
@@ -5924,19 +5792,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmer-types"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "191ca11a0b1635690bbdfa1d8b677c0717a307b57064de4c8d7b579ce960fd57"
-dependencies = [
- "indexmap",
- "loupe",
- "rkyv",
- "serde",
- "thiserror",
-]
-
-[[package]]
 name = "wasmer-types-near"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5947,28 +5802,6 @@ dependencies = [
  "rkyv",
  "serde",
  "thiserror",
-]
-
-[[package]]
-name = "wasmer-vm"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721f7570037d25e5215f74e44af6d644a8cee10cc3df7825d03ff4179a8f6004"
-dependencies = [
- "backtrace",
- "cc",
- "cfg-if 1.0.0",
- "indexmap",
- "libc",
- "loupe",
- "memoffset",
- "more-asserts",
- "region 3.0.0",
- "rkyv",
- "serde",
- "thiserror",
- "wasmer-types",
- "winapi",
 ]
 
 [[package]]
@@ -6078,7 +5911,7 @@ dependencies = [
  "anyhow",
  "gimli",
  "more-asserts",
- "object 0.23.0",
+ "object",
  "target-lexicon 0.11.2",
  "thiserror",
  "wasmparser 0.76.0",
@@ -6123,7 +5956,7 @@ dependencies = [
  "gimli",
  "log",
  "more-asserts",
- "object 0.23.0",
+ "object",
  "region 2.2.0",
  "serde",
  "target-lexicon 0.11.2",
@@ -6159,7 +5992,7 @@ checksum = "a79fa098a3be8fabc50f5be60f8e47694d569afdc255de37850fc80295485012"
 dependencies = [
  "anyhow",
  "more-asserts",
- "object 0.23.0",
+ "object",
  "target-lexicon 0.11.2",
  "wasmtime-debug",
  "wasmtime-environ",
@@ -6221,17 +6054,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcfaeb27e2578d2c6271a45609f4a055e6d7ba3a12eff35b1fd5ba147bdf046"
 dependencies = [
  "wast",
-]
-
-[[package]]
-name = "which"
-version = "4.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea187a8ef279bc014ec368c27a920da2024d2a711109bfbe3440585d5cf27ad9"
-dependencies = [
- "either",
- "lazy_static",
- "libc",
 ]
 
 [[package]]

--- a/runtime/near-vm-runner-standalone/src/script.rs
+++ b/runtime/near-vm-runner-standalone/src/script.rs
@@ -119,7 +119,7 @@ impl Script {
         let config_store = RuntimeConfigStore::new(None);
         let runtime_fees_config = &config_store.get_config(self.protocol_version).transaction_costs;
         let mut outcomes = Vec::new();
-        if let Some(runtime) = self.vm_kind.runtime() {
+        if let Some(runtime) = self.vm_kind.runtime(self.vm_config.clone()) {
             for step in &self.steps {
                 for _ in 0..step.repeat {
                     let res = runtime.run(

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -23,17 +23,18 @@ wasmparser = "0.78"
 memoffset = "0.6"
 
 # Use the following for development versions of Wasmer.
-# wasmer = { package = "wasmer-near", git = "https://github.com/near/wasmer", branch = "near-main", optional = true, default-features = false, features = ["singlepass", "universal"] }
 # wasmer-types = { package = "wasmer-types-near", git = "https://github.com/near/wasmer", branch = "near-main", optional = true }
 # wasmer-compiler-singlepass = { package = "wasmer-compiler-singlepass-near", git = "https://github.com/near/wasmer", branch = "near-main", optional = true }
 # wasmer-engine-universal = { package = "wasmer-engine-universal-near", git = "https://github.com/near/wasmer", branch = "near-main", optional = true }
 # wasmer-vm = { package = "wasmer-vm-near", git = "https://github.com/near/wasmer", branch = "near-main" }
-wasmer = { package = "wasmer-near", version = "=2.1.2", optional = true, default-features = false, features = ["singlepass", "universal"] }
-wasmer-types = { package = "wasmer-types-near", version = "=2.1.2", optional = true }
+wasmer-compiler = { package = "wasmer-compiler-near", version = "=2.1.2", optional = true }
 wasmer-compiler-singlepass = { package = "wasmer-compiler-singlepass-near", version = "=2.1.2", optional = true }
-wasmer-engine-universal = { package = "wasmer-engine-universal-near", version = "=2.1.2", optional = true }
-wasmer-vm = { package = "wasmer-vm-near", version = "=2.1.2" }
+wasmer-engine = { package = "wasmer-engine-near", version = "=2.1.2", optional = true }
+wasmer-engine-universal = { package = "wasmer-engine-universal-near", version = "=2.1.2", optional = true, features = ["compiler"] }
+wasmer-types = { package = "wasmer-types-near", version = "=2.1.2", optional = true }
+wasmer-vm = { package = "wasmer-vm-near", version = "=2.1.2", optional = true }
 
+loupe = "0.1"
 once_cell = "1.5.2"
 pwasm-utils = "0.12"
 parity-wasm = "0.41"
@@ -58,7 +59,14 @@ base64 = "0.13"
 default = ["wasmer0_vm", "wasmtime_vm", "wasmer2_vm"]
 wasmer0_vm = [ "wasmer-runtime", "wasmer-runtime-core" ]
 wasmtime_vm = [ "wasmtime", "anyhow"]
-wasmer2_vm = [ "wasmer", "wasmer-types", "wasmer-compiler-singlepass",  "wasmer-engine-universal", ]
+wasmer2_vm = [
+    "wasmer-compiler",
+    "wasmer-compiler-singlepass",
+    "wasmer-engine",
+    "wasmer-engine-universal",
+    "wasmer-types",
+    "wasmer-vm"
+]
 
 # Force usage of a specific wasm vm irrespective of protocol version.
 force_wasmer0 = ["wasmer0_vm"]

--- a/runtime/near-vm-runner/fuzz/fuzz_targets/runner.rs
+++ b/runtime/near-vm-runner/fuzz/fuzz_targets/runner.rs
@@ -26,7 +26,7 @@ fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> (Option<VMOutcome>, Option<
     let promise_results = vec![];
 
     let method_name = find_entry_point(code).unwrap_or_else(|| "main".to_string());
-    vm_kind.runtime().unwrap().run(
+    vm_kind.runtime(config.clone()).unwrap().run(
         code,
         &method_name,
         &mut fake_external,

--- a/runtime/near-vm-runner/src/cache.rs
+++ b/runtime/near-vm-runner/src/cache.rs
@@ -118,7 +118,10 @@ static WASMER_CACHE: once_cell::sync::Lazy<
 
 #[cfg(not(feature = "no_cache"))]
 static WASMER2_CACHE: once_cell::sync::Lazy<
-    near_cache::SyncLruCache<CryptoHash, Result<crate::wasmer2_runner::VMArtifact, CompilationError>>,
+    near_cache::SyncLruCache<
+        CryptoHash,
+        Result<crate::wasmer2_runner::VMArtifact, CompilationError>,
+    >,
 > = once_cell::sync::Lazy::new(|| near_cache::SyncLruCache::new(CACHE_SIZE));
 
 #[cfg(feature = "wasmer0_vm")]

--- a/runtime/near-vm-runner/src/cache.rs
+++ b/runtime/near-vm-runner/src/cache.rs
@@ -1,7 +1,7 @@
 use crate::errors::ContractPrecompilatonResult;
 use crate::prepare;
 use crate::vm_kind::VMKind;
-use crate::wasmer2_runner::{default_wasmer2_store, wasmer2_vm_hash};
+use crate::wasmer2_runner::wasmer2_vm_hash;
 use crate::wasmer_runner::wasmer0_vm_hash;
 use crate::wasmtime_runner::wasmtime_vm_hash;
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -118,7 +118,7 @@ static WASMER_CACHE: once_cell::sync::Lazy<
 
 #[cfg(not(feature = "no_cache"))]
 static WASMER2_CACHE: once_cell::sync::Lazy<
-    near_cache::SyncLruCache<CryptoHash, Result<wasmer::Module, CompilationError>>,
+    near_cache::SyncLruCache<CryptoHash, Result<crate::wasmer2_runner::VMArtifact, CompilationError>>,
 > = once_cell::sync::Lazy::new(|| near_cache::SyncLruCache::new(CACHE_SIZE));
 
 #[cfg(feature = "wasmer0_vm")]
@@ -236,6 +236,7 @@ pub mod wasmer0_cache {
 
 #[cfg(feature = "wasmer2_vm")]
 pub mod wasmer2_cache {
+    use crate::wasmer2_runner::{VMArtifact, Wasmer2VM};
     use near_primitives::contract::ContractCode;
 
     use super::*;
@@ -243,32 +244,11 @@ pub mod wasmer2_cache {
     fn compile_module_wasmer2(
         code: &[u8],
         config: &VMConfig,
-        store: &wasmer::Store,
-    ) -> Result<wasmer::Module, CompilationError> {
+    ) -> Result<VMArtifact, CompilationError> {
         let _span = tracing::debug_span!(target: "vm", "compile_module_wasmer2").entered();
-
         let prepared_code =
             prepare::prepare_contract(code, config).map_err(CompilationError::PrepareError)?;
-        wasmer::Module::new(store, prepared_code).map_err(|err| match err {
-            wasmer::CompileError::Wasm(_) => {
-                CompilationError::WasmerCompileError { msg: err.to_string() }
-            }
-            wasmer::CompileError::Codegen(_) => {
-                CompilationError::WasmerCompileError { msg: err.to_string() }
-            }
-            wasmer::CompileError::Validate(_) => {
-                CompilationError::WasmerCompileError { msg: err.to_string() }
-            }
-            wasmer::CompileError::UnsupportedFeature(_) => {
-                CompilationError::WasmerCompileError { msg: err.to_string() }
-            }
-            wasmer::CompileError::UnsupportedTarget(_) => {
-                CompilationError::WasmerCompileError { msg: err.to_string() }
-            }
-            wasmer::CompileError::Resource(_) => {
-                CompilationError::WasmerCompileError { msg: err.to_string() }
-            }
-        })
+        Wasmer2VM::new(config.clone()).compile_uncached(&prepared_code)
     }
 
     pub(crate) fn compile_and_serialize_wasmer2(
@@ -276,11 +256,10 @@ pub mod wasmer2_cache {
         key: &CryptoHash,
         config: &VMConfig,
         cache: &dyn CompiledContractCache,
-        store: &wasmer::Store,
-    ) -> Result<Result<wasmer::Module, CompilationError>, CacheError> {
+    ) -> Result<Result<VMArtifact, CompilationError>, CacheError> {
         let _span = tracing::debug_span!(target: "vm", "compile_and_serialize_wasmer2").entered();
 
-        let module = match compile_module_wasmer2(wasm_code, config, store) {
+        let module = match compile_module_wasmer2(wasm_code, config) {
             Ok(module) => module,
             Err(err) => {
                 cache_error(&err, key, cache)?;
@@ -288,8 +267,10 @@ pub mod wasmer2_cache {
             }
         };
 
-        let code =
-            module.serialize().map_err(|_e| CacheError::SerializationError { hash: key.0 })?;
+        let code = module
+            .artifact()
+            .serialize()
+            .map_err(|_e| CacheError::SerializationError { hash: key.0 })?;
         let serialized = CacheRecord::Code(code).try_to_vec().unwrap();
         cache.put(key.as_ref(), &serialized).map_err(|_io_err| CacheError::WriteError)?;
         Ok(Ok(module))
@@ -297,8 +278,8 @@ pub mod wasmer2_cache {
 
     fn deserialize_wasmer2(
         serialized: &[u8],
-        store: &wasmer::Store,
-    ) -> Result<Result<wasmer::Module, CompilationError>, CacheError> {
+        config: &VMConfig,
+    ) -> Result<Result<VMArtifact, CompilationError>, CacheError> {
         let _span = tracing::debug_span!(target: "vm", "deserialize_wasmer2").entered();
 
         let record = CacheRecord::try_from_slice(serialized)
@@ -308,8 +289,19 @@ pub mod wasmer2_cache {
             CacheRecord::Code(code) => code,
         };
         unsafe {
-            Ok(Ok(wasmer::Module::deserialize(store, serialized_module.as_slice())
-                .map_err(|_e| CacheError::DeserializationError)?))
+            // (UN-)SAFETY: the `serialized_module` must have been produced by a prior call to
+            // `serialize`.
+            //
+            // In practice this is not necessarily true. One could have forgotten to change the
+            // cache key when upgrading the version of the wasmer library or the database could
+            // have had its data corrupted while at rest.
+            //
+            // There should definitely be some validation in wasmer to ensure we load what we think
+            // we load.
+            let artifact = Wasmer2VM::new(config.clone())
+                .deserialize(&serialized_module)
+                .map_err(|_| CacheError::DeserializationError)?;
+            Ok(Ok(artifact))
         }
     }
 
@@ -318,15 +310,14 @@ pub mod wasmer2_cache {
         code: &ContractCode,
         config: &VMConfig,
         cache: Option<&dyn CompiledContractCache>,
-        store: &wasmer::Store,
-    ) -> Result<Result<wasmer::Module, CompilationError>, CacheError> {
+    ) -> Result<Result<VMArtifact, CompilationError>, CacheError> {
         match cache {
-            None => Ok(compile_module_wasmer2(code.code(), config, store)),
+            None => Ok(compile_module_wasmer2(code.code(), config)),
             Some(cache) => {
                 let serialized = cache.get(&key.0).map_err(|_io_err| CacheError::ReadError)?;
                 match serialized {
-                    Some(serialized) => deserialize_wasmer2(serialized.as_slice(), store),
-                    None => compile_and_serialize_wasmer2(code.code(), &key, config, cache, store),
+                    Some(serialized) => deserialize_wasmer2(serialized.as_slice(), config),
+                    None => compile_and_serialize_wasmer2(code.code(), &key, config, cache),
                 }
             }
         }
@@ -336,17 +327,16 @@ pub mod wasmer2_cache {
         code: &ContractCode,
         config: &VMConfig,
         cache: Option<&dyn CompiledContractCache>,
-        store: &wasmer::Store,
-    ) -> Result<Result<wasmer::Module, CompilationError>, CacheError> {
+    ) -> Result<Result<VMArtifact, CompilationError>, CacheError> {
         let key = get_contract_cache_key(code, VMKind::Wasmer2, config);
 
         #[cfg(not(feature = "no_cache"))]
         return WASMER2_CACHE.get_or_try_put(key, |key| {
-            compile_module_cached_wasmer2_impl(*key, code, config, cache, store)
+            compile_module_cached_wasmer2_impl(*key, code, config, cache)
         });
 
         #[cfg(feature = "no_cache")]
-        return compile_module_cached_wasmer2_impl(key, code, config, cache, store);
+        return compile_module_cached_wasmer2_impl(key, code, config, cache);
     }
 }
 
@@ -373,15 +363,8 @@ pub fn precompile_contract_vm(
                 .map(|_module| ())
         }
         VMKind::Wasmer2 => {
-            let store = default_wasmer2_store();
-            wasmer2_cache::compile_and_serialize_wasmer2(
-                wasm_code.code(),
-                &key,
-                config,
-                cache,
-                &store,
-            )?
-            .map(|_module| ())
+            wasmer2_cache::compile_and_serialize_wasmer2(wasm_code.code(), &key, config, cache)?
+                .map(|_module| ())
         }
         VMKind::Wasmtime => {
             panic!("Not yet supported")

--- a/runtime/near-vm-runner/src/imports.rs
+++ b/runtime/near-vm-runner/src/imports.rs
@@ -54,7 +54,7 @@ macro_rules! imports {
         $func:ident < [ $( $arg_name:ident : $arg_type:ident ),* ] -> [ $( $returns:ident ),* ] >,)*
     ) => {
         macro_rules! for_each_available_import {
-            ($protocol_version:ident, $M:ident) => {$(
+            ($protocol_version:expr, $M:ident) => {$(
                 $(#[cfg(feature = $feature_name)])*
                 if true
                     $(&& near_primitives::checked_feature!($feature_name, $feature, $protocol_version))*
@@ -274,55 +274,150 @@ pub(crate) mod wasmer {
 
 #[cfg(feature = "wasmer2_vm")]
 pub(crate) mod wasmer2 {
+    use std::sync::Arc;
+
     use super::str_eq;
-    use near_vm_logic::{ProtocolVersion, VMLogic, VMLogicError};
+    use near_vm_logic::{ProtocolVersion, VMLogic};
+    use wasmer_engine::{ExportFunction, ExportFunctionMetadata, Resolver};
+    use wasmer_vm::{VMFunction, VMFunctionKind, VMMemory};
 
-    #[derive(wasmer::WasmerEnv, Clone)]
-    struct NearWasmerEnv {
-        /// Hack to allow usage of non-'static VMLogic as an environment in host
-        /// functions. Strictly speaking, this is unsound, but this is only
-        /// accessible to `near_vm_runner` crate, where we ensure that `VMLogic`
-        /// reference does not dangle. Still, would be great to fix this properly
-        /// one day.
-        logic: *mut (),
+    pub(crate) struct Wasmer2Imports<'vmlogic, 'vmlogic_refs> {
+        pub(crate) memory: VMMemory,
+        // Note: this same object is also referenced by the `metadata` field!
+        pub(crate) vmlogic: &'vmlogic mut VMLogic<'vmlogic_refs>,
+        pub(crate) metadata: Arc<ExportFunctionMetadata>,
+        pub(crate) protocol_version: ProtocolVersion,
     }
-    unsafe impl Send for NearWasmerEnv {}
-    unsafe impl Sync for NearWasmerEnv {}
 
-    pub(crate) fn build(
-        store: &wasmer::Store,
-        memory: wasmer::Memory,
-        logic: &mut VMLogic<'_>,
-        protocol_version: ProtocolVersion,
-    ) -> wasmer::ImportObject {
-        let env = NearWasmerEnv { logic: logic as *mut _ as *mut () };
-        let mut import_object = wasmer::ImportObject::new();
-        let mut namespace = wasmer::Exports::new();
-        namespace.insert("memory", memory);
-
-        macro_rules! add_import {
-            (
-              $func:ident < [ $( $arg_name:ident : $arg_type:ident ),* ] -> [ $( $returns:ident ),* ] >
-            ) => {
-                #[allow(unused_parens)]
-                fn $func(env: &NearWasmerEnv, $( $arg_name: $arg_type ),* ) -> Result<($( $returns ),*), VMLogicError> {
-                    const IS_GAS: bool = str_eq(stringify!($func), "gas");
-                    let _span = if IS_GAS {
-                        None
-                    } else {
-                        Some(tracing::trace_span!(target: "host-function", stringify!($func)).entered())
-                    };
-                    let logic: &mut VMLogic = unsafe { &mut *(env.logic as *mut VMLogic<'_>) };
-                    logic.$func( $( $arg_name, )* )
+    trait Wasmer2Type {
+        type Wasmer;
+        fn to_wasmer(self) -> Self::Wasmer;
+        fn ty() -> wasmer_types::Type;
+    }
+    macro_rules! wasmer_types {
+        ($($native:ty as $wasmer:ty => $type_expr:expr;)*) => {
+            $(impl Wasmer2Type for $native {
+                type Wasmer = $wasmer;
+                fn to_wasmer(self) -> $wasmer {
+                    self as _
                 }
-
-                namespace.insert(stringify!($func), wasmer::Function::new_native_with_env(&store, env.clone(), $func));
-            };
+                fn ty() -> wasmer_types::Type {
+                    $type_expr
+                }
+            })*
         }
-        for_each_available_import!(protocol_version, add_import);
+    }
+    wasmer_types! {
+        u32 as i32 => wasmer_types::Type::I32;
+        u64 as i64 => wasmer_types::Type::I64;
+    }
 
-        import_object.register("env", namespace);
-        import_object
+    macro_rules! return_ty {
+        () => {
+            type Ret = ();
+            fn make_ret() -> () {}
+        };
+        ($($return: ident),*) => {
+            #[repr(C)]
+            struct Ret($(<$return as Wasmer2Type>::Wasmer),*);
+            fn make_ret($($return: $return),*) -> Ret { Ret($($return.to_wasmer()),*) }
+        }
+    }
+
+    impl<'vmlogic, 'vmlogic_refs> Resolver for Wasmer2Imports<'vmlogic, 'vmlogic_refs> {
+        fn resolve(&self, _index: u32, module: &str, field: &str) -> Option<wasmer_engine::Export> {
+            if module != "env" {
+                return None;
+            }
+            if field == "memory" {
+                return Some(wasmer_engine::Export::Memory(self.memory.clone()));
+            }
+
+            macro_rules! add_import {
+                (
+                  $func:ident <
+                    [ $( $arg_name:ident : $arg_type:ident ),* ]
+                    -> [ $( $returns:ident ),* ]
+                  >
+                ) => {
+                    return_ty!($($returns),*);
+
+                    extern "C" fn $func(env: *mut VMLogic<'_>, $( $arg_name: $arg_type ),* )
+                    -> Ret {
+                        // SAFETY: This function should only be executable within `'vmlogic`
+                        // lifetime and so it is safe to dereference the `env` pointer which is
+                        // known to be derived from a valid reference in the first place.
+                        let env = unsafe { &mut *env };
+                        const IS_GAS: bool = str_eq(stringify!($func), "gas");
+                        let _span = if IS_GAS {
+                            None
+                        } else {
+                            Some(tracing::trace_span!(
+                                target: "host-function",
+                                stringify!($func)
+                            ).entered())
+                        };
+                        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                            env.$func( $( $arg_name, )* )
+                        }));
+                        #[allow(unused_parens)]
+                        match result {
+                            Ok(Ok(($($returns),*))) => make_ret($($returns),*),
+                            Ok(Err(trap)) => unsafe {
+                                // SAFETY: this can only be called by a WASM contract, so all the
+                                // necessary hooks are known to be in place.
+                                wasmer_vm::raise_user_trap(Box::new(trap))
+                            },
+                            Err(e) => unsafe {
+                                // SAFETY: this can only be called by a WASM contract, so all the
+                                // necessary hooks are known to be in place.
+                                wasmer_vm::resume_panic(e)
+                            },
+                        }
+                    }
+                    // TODO: a phf hashmap would probably work better here.
+                    if field == stringify!($func) {
+                        return Some(wasmer_engine::Export::Function(ExportFunction {
+                            vm_function: VMFunction {
+                                address: $func as *const _,
+                                // SAFETY: here we erase the lifetime of the `vmlogic` reference,
+                                // but we believe that the lifetimes on `Wasmer2Imports` enforce
+                                // sufficiently that it isn't possible to call this exported
+                                // function when vmlogic is no loger live.
+                                vmctx: wasmer_vm::VMFunctionEnvironment {
+                                    host_env: self.vmlogic as *const _ as *mut _
+                                },
+                                signature: wasmer_types::FunctionType::new([
+                                    $(<$arg_type as Wasmer2Type>::ty()),*
+                                ], [
+                                    $(<$returns as Wasmer2Type>::ty()),*
+                                ]),
+                                kind: VMFunctionKind::Static,
+                                call_trampoline: None,
+                                instance_ref: None,
+                            },
+                            metadata: Some(Arc::clone(&self.metadata)),
+                        }));
+                    }
+                };
+            }
+            for_each_available_import!(self.protocol_version, add_import);
+            return None;
+        }
+    }
+
+    pub(crate) fn build<'a, 'b>(
+        memory: VMMemory,
+        logic: &'a mut VMLogic<'b>,
+        protocol_version: ProtocolVersion,
+    ) -> Wasmer2Imports<'a, 'b> {
+        let metadata = unsafe {
+            // SAFETY: the functions here are thread-safe. We ensure that the lifetime of `VMLogic`
+            // is sufficiently long by tying the lifetime of VMLogic to the return type which
+            // contains this metadata.
+            ExportFunctionMetadata::new(logic as *mut _ as *mut _, None, |ptr| ptr, |_| {})
+        };
+        Wasmer2Imports { memory, vmlogic: logic, metadata: Arc::new(metadata), protocol_version }
     }
 }
 

--- a/runtime/near-vm-runner/src/imports.rs
+++ b/runtime/near-vm-runner/src/imports.rs
@@ -361,6 +361,10 @@ pub(crate) mod wasmer2 {
                             // first place.
                             unsafe { (*env).$func( $( $arg_name, )* ) }
                         }));
+                        // We want to ensure that the only kind of error that host function calls
+                        // return are VMLogicError. This is important because we later attempt to
+                        // downcast the `RuntimeError`s into `VMLogicError`.
+                        let result: Result<Result<_, near_vm_errors::VMLogicError>, _>  = result;
                         #[allow(unused_parens)]
                         match result {
                             Ok(Ok(($($returns),*))) => make_ret($($returns),*),

--- a/runtime/near-vm-runner/src/preload.rs
+++ b/runtime/near-vm-runner/src/preload.rs
@@ -14,25 +14,19 @@ use crate::cache::{self, into_vm_result};
 use crate::memory::WasmerMemory;
 use crate::preload::VMModule::{Wasmer0, Wasmer2};
 use crate::vm_kind::VMKind;
-use crate::wasmer2_runner::{default_wasmer2_store, run_wasmer2_module, Wasmer2Memory};
+use crate::wasmer2_runner::{Wasmer2Memory, Wasmer2VM};
 use crate::wasmer_runner::run_wasmer0_module;
 
 const SHARE_MEMORY_INSTANCE: bool = false;
 
 enum VMModule {
     Wasmer0(wasmer_runtime::Module),
-    Wasmer2(wasmer::Module),
+    Wasmer2(crate::wasmer2_runner::VMArtifact),
 }
 
 enum VMDataPrivate {
     Wasmer0(Option<WasmerMemory>),
     Wasmer2(Option<Wasmer2Memory>),
-}
-
-#[derive(Clone)]
-enum VMDataShared {
-    Wasmer0,
-    Wasmer2(wasmer::Store),
 }
 
 struct VMCallData {
@@ -57,46 +51,34 @@ pub struct ContractCaller {
     vm_kind: VMKind,
     vm_config: VMConfig,
     vm_data_private: VMDataPrivate,
-    vm_data_shared: VMDataShared,
     preloaded: Vec<CallInner>,
 }
 
 impl ContractCaller {
     pub fn new(num_threads: usize, vm_kind: VMKind, vm_config: VMConfig) -> ContractCaller {
-        let (shared, private) = match vm_kind {
-            VMKind::Wasmer0 => (
-                VMDataShared::Wasmer0,
-                VMDataPrivate::Wasmer0(if SHARE_MEMORY_INSTANCE {
-                    Some(
-                        WasmerMemory::new(
-                            vm_config.limit_config.initial_memory_pages,
-                            vm_config.limit_config.max_memory_pages,
-                        )
-                        .unwrap(),
+        let private = match vm_kind {
+            VMKind::Wasmer0 => VMDataPrivate::Wasmer0(if SHARE_MEMORY_INSTANCE {
+                Some(
+                    WasmerMemory::new(
+                        vm_config.limit_config.initial_memory_pages,
+                        vm_config.limit_config.max_memory_pages,
                     )
-                } else {
-                    None
-                }),
-            ),
-            VMKind::Wasmer2 => {
-                let store = default_wasmer2_store();
-                let store_clone = store.clone();
-                (
-                    VMDataShared::Wasmer2(store),
-                    VMDataPrivate::Wasmer2(if SHARE_MEMORY_INSTANCE {
-                        Some(
-                            Wasmer2Memory::new(
-                                &store_clone,
-                                vm_config.limit_config.initial_memory_pages,
-                                vm_config.limit_config.max_memory_pages,
-                            )
-                            .unwrap(),
-                        )
-                    } else {
-                        None
-                    }),
+                    .unwrap(),
                 )
-            }
+            } else {
+                None
+            }),
+            VMKind::Wasmer2 => VMDataPrivate::Wasmer2(if SHARE_MEMORY_INSTANCE {
+                Some(
+                    Wasmer2Memory::new(
+                        vm_config.limit_config.initial_memory_pages,
+                        vm_config.limit_config.max_memory_pages,
+                    )
+                    .unwrap(),
+                )
+            } else {
+                None
+            }),
             VMKind::Wasmtime => panic!("Not currently supported"),
         };
         ContractCaller {
@@ -104,7 +86,6 @@ impl ContractCaller {
             vm_kind,
             vm_config,
             vm_data_private: private,
-            vm_data_shared: shared,
             preloaded: Vec::new(),
         }
     }
@@ -121,9 +102,8 @@ impl ContractCaller {
             self.pool.execute({
                 let tx = tx.clone();
                 let vm_config = self.vm_config.clone();
-                let vm_data_shared = self.vm_data_shared.clone();
                 let vm_kind = self.vm_kind.clone();
-                move || preload_in_thread(request, vm_kind, vm_config, vm_data_shared, tx)
+                move || preload_in_thread(request, vm_kind, vm_config, tx)
             });
             result.push(ContractCallPrepareResult { handle: index });
         }
@@ -145,67 +125,54 @@ impl ContractCaller {
                 let call_data = call.rx.recv().unwrap();
                 match call_data.result {
                     Err(err) => (None, Some(err)),
-                    Ok(module) => {
-                        match (&module, &mut self.vm_data_private, &self.vm_data_shared) {
-                            (
-                                Wasmer0(module),
-                                VMDataPrivate::Wasmer0(memory),
-                                VMDataShared::Wasmer0,
-                            ) => {
-                                let mut new_memory;
-                                run_wasmer0_module(
-                                    module.clone(),
-                                    if memory.is_some() {
-                                        memory.as_mut().unwrap()
-                                    } else {
-                                        new_memory = WasmerMemory::new(
-                                            self.vm_config.limit_config.initial_memory_pages,
-                                            self.vm_config.limit_config.max_memory_pages,
-                                        )
-                                        .unwrap();
-                                        &mut new_memory
-                                    },
-                                    method_name,
-                                    ext,
-                                    context,
-                                    &self.vm_config,
-                                    fees_config,
-                                    promise_results,
-                                    current_protocol_version,
-                                )
-                            }
-                            (
-                                Wasmer2(module),
-                                VMDataPrivate::Wasmer2(memory),
-                                VMDataShared::Wasmer2(store),
-                            ) => {
-                                let mut new_memory;
-                                run_wasmer2_module(
-                                    module,
-                                    store,
-                                    if memory.is_some() {
-                                        memory.as_mut().unwrap()
-                                    } else {
-                                        new_memory = Wasmer2Memory::new(
-                                            store,
-                                            self.vm_config.limit_config.initial_memory_pages,
-                                            self.vm_config.limit_config.max_memory_pages,
-                                        )
-                                        .unwrap();
-                                        &mut new_memory
-                                    },
-                                    method_name,
-                                    ext,
-                                    context,
-                                    &self.vm_config,
-                                    fees_config,
-                                    promise_results,
-                                    current_protocol_version,
-                                )
-                            }
-                            _ => panic!("Incorrect logic"),
+                    Ok(module) => match (&module, &mut self.vm_data_private) {
+                        (Wasmer0(module), VMDataPrivate::Wasmer0(memory)) => {
+                            let mut new_memory;
+                            run_wasmer0_module(
+                                module.clone(),
+                                if memory.is_some() {
+                                    memory.as_mut().unwrap()
+                                } else {
+                                    new_memory = WasmerMemory::new(
+                                        self.vm_config.limit_config.initial_memory_pages,
+                                        self.vm_config.limit_config.max_memory_pages,
+                                    )
+                                    .unwrap();
+                                    &mut new_memory
+                                },
+                                method_name,
+                                ext,
+                                context,
+                                &self.vm_config,
+                                fees_config,
+                                promise_results,
+                                current_protocol_version,
+                            )
                         }
-                    }
+                        (Wasmer2(module), VMDataPrivate::Wasmer2(memory)) => {
+                            let mut new_memory;
+                            Wasmer2VM::new(self.vm_config.clone()).run_module(
+                                &module,
+                                if memory.is_some() {
+                                    memory.as_mut().unwrap()
+                                } else {
+                                    new_memory = Wasmer2Memory::new(
+                                        self.vm_config.limit_config.initial_memory_pages,
+                                        self.vm_config.limit_config.max_memory_pages,
+                                    )
+                                    .unwrap();
+                                    &mut new_memory
+                                },
+                                method_name,
+                                ext,
+                                context,
+                                fees_config,
+                                promise_results,
+                                current_protocol_version,
+                            )
+                        }
+                        _ => panic!("Incorrect logic"),
+                    },
                 }
             }
             None => panic!("Must be valid"),
@@ -223,12 +190,11 @@ fn preload_in_thread(
     request: ContractCallPrepareRequest,
     vm_kind: VMKind,
     vm_config: VMConfig,
-    vm_data_shared: VMDataShared,
     tx: Sender<VMCallData>,
 ) {
     let cache = request.cache.as_deref();
-    let result = match (vm_kind, vm_data_shared) {
-        (VMKind::Wasmer0, VMDataShared::Wasmer0) => {
+    let result = match vm_kind {
+        VMKind::Wasmer0 => {
             let module = cache::wasmer0_cache::compile_module_cached_wasmer0(
                 &request.code,
                 &vm_config,
@@ -236,12 +202,11 @@ fn preload_in_thread(
             );
             into_vm_result(module).map(VMModule::Wasmer0)
         }
-        (VMKind::Wasmer2, VMDataShared::Wasmer2(store)) => {
+        VMKind::Wasmer2 => {
             let module = cache::wasmer2_cache::compile_module_cached_wasmer2(
                 &request.code,
                 &vm_config,
                 cache,
-                &store,
             );
             into_vm_result(module).map(VMModule::Wasmer2)
         }

--- a/runtime/near-vm-runner/src/tests.rs
+++ b/runtime/near-vm-runner/src/tests.rs
@@ -70,7 +70,7 @@ fn make_simple_contract_call_with_gas_vm(
     let promise_results = vec![];
 
     let code = ContractCode::new(code.to_vec(), None);
-    let runtime = vm_kind.runtime().expect("runtime has not been compiled");
+    let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
     runtime.run(
         &code,
         method_name,
@@ -96,7 +96,7 @@ fn make_simple_contract_call_with_protocol_version_vm(
     let runtime_config = runtime_config_store.get_config(protocol_version);
     let config = &runtime_config.wasm_config;
     let fees = &runtime_config.transaction_costs;
-    let runtime = vm_kind.runtime().expect("runtime has not been compiled");
+    let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
 
     let promise_results = vec![];
     let code = ContractCode::new(code.to_vec(), None);

--- a/runtime/near-vm-runner/src/tests/cache.rs
+++ b/runtime/near-vm-runner/src/tests/cache.rs
@@ -71,7 +71,7 @@ fn make_cached_contract_call_vm(
     let promise_results = vec![];
     context.prepaid_gas = prepaid_gas;
     let code = ContractCode::new(code.to_vec(), None);
-    let runtime = vm_kind.runtime().expect("runtime has not been compiled");
+    let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
 
     runtime.run(
         &code,

--- a/runtime/near-vm-runner/src/tests/contract_preload.rs
+++ b/runtime/near-vm-runner/src/tests/contract_preload.rs
@@ -138,7 +138,7 @@ fn test_vm_runner(preloaded: bool, vm_kind: VMKind, repeat: i32) {
             errs += err;
         }
     } else {
-        let runtime = vm_kind.runtime().expect("runtime is has not been compiled");
+        let runtime = vm_kind.runtime(vm_config.clone()).expect("runtime is has not been compiled");
         for _ in 0..repeat {
             let result1 = runtime.run(
                 &code1,

--- a/runtime/near-vm-runner/src/tests/rs_contract.rs
+++ b/runtime/near-vm-runner/src/tests/rs_contract.rs
@@ -61,7 +61,7 @@ pub fn test_read_write() {
         let fees = RuntimeFeesConfig::test();
 
         let promise_results = vec![];
-        let runtime = vm_kind.runtime().expect("runtime has not been compiled");
+        let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
         let result = runtime.run(
             &code,
             "write_key_value",
@@ -102,7 +102,7 @@ pub fn test_stablized_host_function() {
         let fees = RuntimeFeesConfig::test();
 
         let promise_results = vec![];
-        let runtime = vm_kind.runtime().expect("runtime has not been compiled");
+        let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
         let result = runtime.run(
             &code,
             "do_ripemd",
@@ -175,7 +175,7 @@ fn run_test_ext(
     let config = VMConfig::test();
     let fees = RuntimeFeesConfig::test();
     let context = create_context(input.to_vec());
-    let runtime = vm_kind.runtime().expect("runtime has not been compiled");
+    let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
 
     let (outcome, err) = runtime.run(
         &code,
@@ -309,7 +309,7 @@ pub fn test_out_of_memory() {
         let context = create_context(Vec::new());
         let config = VMConfig::free();
         let fees = RuntimeFeesConfig::free();
-        let runtime = vm_kind.runtime().expect("runtime has not been compiled");
+        let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
 
         let promise_results = vec![];
         let result = runtime.run(

--- a/runtime/near-vm-runner/src/tests/ts_contract.rs
+++ b/runtime/near-vm-runner/src/tests/ts_contract.rs
@@ -20,7 +20,7 @@ pub fn test_ts_contract() {
 
         // Call method that panics.
         let promise_results = vec![];
-        let runtime = vm_kind.runtime().expect("runtime has not been compiled");
+        let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
         let result = runtime.run(
             &code,
             "try_panic",

--- a/runtime/near-vm-runner/src/wasmer2_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer2_runner.rs
@@ -49,7 +49,10 @@ impl Wasmer2Memory {
         Ok(Wasmer2Memory(Arc::new(
             LinearMemory::new(
                 &MemoryType::new(Pages(initial_memory_pages), Some(max_pages), false),
-                &MemoryStyle::Static { bound: max_pages, offset_guard_size: 0x1000 },
+                &MemoryStyle::Static {
+                    bound: max_pages,
+                    offset_guard_size: wasmer_types::WASM_PAGE_SIZE as u64,
+                },
             )
             .expect("creating memory must not fail"),
         )))

--- a/runtime/near-vm-runner/src/wasmer2_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer2_runner.rs
@@ -1,31 +1,31 @@
 use crate::cache::into_vm_result;
 use crate::errors::IntoVMError;
+use crate::imports::wasmer2::Wasmer2Imports;
 use crate::prepare::WASM_FEATURES;
 use crate::{cache, imports};
 use memoffset::offset_of;
 use near_primitives::contract::ContractCode;
 use near_primitives::runtime::fees::RuntimeFeesConfig;
 use near_primitives::types::CompiledContractCache;
+use near_stable_hasher::StableHasher;
 use near_vm_errors::{
-    CompilationError, FunctionCallError, HostError, MethodResolveError, PrepareError, VMError,
-    WasmTrap,
+    CompilationError, FunctionCallError, HostError, MethodResolveError, VMError, WasmTrap,
 };
+use near_vm_logic::gas_counter::FastGasCounter;
 use near_vm_logic::types::{PromiseResult, ProtocolVersion};
 use near_vm_logic::{External, MemoryLike, VMConfig, VMContext, VMLogic, VMLogicError, VMOutcome};
 use std::hash::{Hash, Hasher};
 use std::mem::size_of;
-use wasmer::{
-    Bytes, ImportObject, Instance, InstantiationError, Memory, MemoryType, Module, Pages,
-    RuntimeError, Store,
-};
-
-use near_stable_hasher::StableHasher;
-use near_vm_logic::gas_counter::FastGasCounter;
+use std::sync::Arc;
 use wasmer_compiler_singlepass::Singlepass;
-use wasmer_types::InstanceConfig;
-use wasmer_vm::TrapCode;
+use wasmer_engine::{Artifact, DeserializeError, Engine, InstantiationError, RuntimeError};
+use wasmer_engine_universal::{Universal, UniversalEngine};
+use wasmer_types::{
+    Bytes, ExportIndex, Features, FunctionIndex, InstanceConfig, MemoryType, MemoryView, Pages,
+};
+use wasmer_vm::{LinearMemory, LinearTable, Memory, MemoryStyle, TrapCode, VMExtern, VMMemory};
 
-const WASMER_FEATURES: wasmer::Features = wasmer::Features {
+const WASMER_FEATURES: Features = Features {
     threads: WASM_FEATURES.threads,
     reference_types: WASM_FEATURES.reference_types,
     simd: WASM_FEATURES.simd,
@@ -40,25 +40,36 @@ const WASMER_FEATURES: wasmer::Features = wasmer::Features {
     signal_less: true,
 };
 
-pub struct Wasmer2Memory(Memory);
+#[derive(Clone)]
+pub struct Wasmer2Memory(Arc<LinearMemory>);
 
 impl Wasmer2Memory {
-    pub fn new(
-        store: &Store,
-        initial_memory_pages: u32,
-        max_memory_pages: u32,
-    ) -> Result<Self, VMError> {
-        Ok(Wasmer2Memory(
-            Memory::new(
-                store,
-                MemoryType::new(Pages(initial_memory_pages), Some(Pages(max_memory_pages)), false),
+    pub(crate) fn new(initial_memory_pages: u32, max_memory_pages: u32) -> Result<Self, VMError> {
+        let max_pages = Pages(max_memory_pages);
+        Ok(Wasmer2Memory(Arc::new(
+            LinearMemory::new(
+                &MemoryType::new(Pages(initial_memory_pages), Some(max_pages), false),
+                &MemoryStyle::Static { bound: max_pages, offset_guard_size: 0x1000 },
             )
-            .expect("TODO creating memory cannot fail"),
-        ))
+            .expect("creating memory must not fail"),
+        )))
     }
 
-    pub fn clone(&self) -> Memory {
-        self.0.clone()
+    fn view(&self) -> MemoryView<u8> {
+        let size = u32::try_from(self.0.size().bytes().0).expect("memory size must fit into u32");
+        let base = self.0.vmmemory();
+        unsafe {
+            // SAFETY: We have successfully created this as host memory during construction, so the
+            // base pointer must be a valid owned value of `VMMemoryDefinition`.
+            let base = base.as_ref().base;
+            // SAFETY: the `base` pointer is valid, since it has been read from an initialized
+            // `VMMemoryDefinition`.
+            MemoryView::new(base, size)
+        }
+    }
+
+    pub(crate) fn vm(&self) -> VMMemory {
+        VMMemory { from: self.0.clone(), instance_ref: None }
     }
 }
 
@@ -72,44 +83,39 @@ impl MemoryLike for Wasmer2Memory {
 
     fn read_memory(&self, offset: u64, buffer: &mut [u8]) {
         let offset = offset as usize;
-        for (i, cell) in self.0.view()[offset..(offset + buffer.len())].iter().enumerate() {
+        for (i, cell) in self.view()[offset..(offset + buffer.len())].iter().enumerate() {
             buffer[i] = cell.get();
         }
     }
 
     fn read_memory_u8(&self, offset: u64) -> u8 {
-        self.0.view()[offset as usize].get()
+        self.view()[offset as usize].get()
     }
 
     fn write_memory(&mut self, offset: u64, buffer: &[u8]) {
         let offset = offset as usize;
-        self.0.view()[offset..(offset + buffer.len())]
+        self.view()[offset..(offset + buffer.len())]
             .iter()
             .zip(buffer.iter())
             .for_each(|(cell, v)| cell.set(*v));
     }
 }
 
-impl IntoVMError for wasmer::InstantiationError {
+impl IntoVMError for InstantiationError {
     fn into_vm_error(self) -> VMError {
         match self {
-            wasmer::InstantiationError::Link(e) => {
+            InstantiationError::Link(e) => {
                 VMError::FunctionCallError(FunctionCallError::LinkError { msg: e.to_string() })
             }
-            wasmer::InstantiationError::CpuFeature(e) => {
+            InstantiationError::CpuFeature(e) => {
                 panic!("host does not support the CPU features required to run contracts: {}", e)
             }
-            wasmer::InstantiationError::Start(e) => e.into_vm_error(),
-            wasmer::InstantiationError::HostEnvInitialization(_) => {
-                VMError::FunctionCallError(FunctionCallError::CompilationError(
-                    CompilationError::PrepareError(PrepareError::Instantiate),
-                ))
-            }
+            InstantiationError::Start(e) => e.into_vm_error(),
         }
     }
 }
 
-impl IntoVMError for wasmer::RuntimeError {
+impl IntoVMError for RuntimeError {
     fn into_vm_error(self) -> VMError {
         // These vars are not used in every cases, however, downcast below use Arc::try_unwrap
         // so we cannot clone self
@@ -155,27 +161,22 @@ impl IntoVMError for wasmer::RuntimeError {
     }
 }
 
-impl IntoVMError for wasmer::ExportError {
-    fn into_vm_error(self) -> VMError {
-        match self {
-            wasmer::ExportError::IncompatibleType => VMError::FunctionCallError(
-                FunctionCallError::MethodResolveError(MethodResolveError::MethodInvalidSignature),
-            ),
-            wasmer::ExportError::Missing(_) => VMError::FunctionCallError(
-                FunctionCallError::MethodResolveError(MethodResolveError::MethodNotFound),
-            ),
-        }
+fn get_entrypoint_index(
+    artifact: &dyn Artifact,
+    method_name: &str,
+) -> Result<FunctionIndex, VMError> {
+    if method_name.is_empty() {
+        // Do we really need this code?
+        return Err(VMError::FunctionCallError(FunctionCallError::MethodResolveError(
+            MethodResolveError::MethodEmptyName,
+        )));
     }
-}
-
-fn check_method(module: &Module, method_name: &str) -> Result<(), VMError> {
-    let info = module.info();
-    use wasmer_types::ExportIndex::Function;
-    if let Some(Function(index)) = info.exports.get(method_name) {
-        let func = info.functions.get(index.clone()).unwrap();
-        let sig = info.signatures.get(func.clone()).unwrap();
+    let module = artifact.module_ref();
+    if let Some(ExportIndex::Function(index)) = module.exports.get(method_name) {
+        let func = module.functions.get(index.clone()).unwrap();
+        let sig = module.signatures.get(func.clone()).unwrap();
         if sig.params().is_empty() && sig.results().is_empty() {
-            Ok(())
+            Ok(*index)
         } else {
             Err(VMError::FunctionCallError(FunctionCallError::MethodResolveError(
                 MethodResolveError::MethodInvalidSignature,
@@ -202,58 +203,6 @@ fn translate_runtime_error(err: RuntimeError, logic: &mut VMLogic) -> VMError {
         }
         _ => err.into_vm_error(),
     }
-}
-
-fn run_method(
-    module: &Module,
-    import: &ImportObject,
-    method_name: &str,
-    logic: &mut VMLogic,
-) -> Result<(), VMError> {
-    let _span = tracing::debug_span!(target: "vm", "run_method").entered();
-
-    // FastGasCounter in Nearcore and Wasmer must match in layout.
-    assert_eq!(size_of::<FastGasCounter>(), size_of::<wasmer_types::FastGasCounter>());
-    assert_eq!(
-        offset_of!(FastGasCounter, burnt_gas),
-        offset_of!(wasmer_types::FastGasCounter, burnt_gas)
-    );
-    assert_eq!(
-        offset_of!(FastGasCounter, gas_limit),
-        offset_of!(wasmer_types::FastGasCounter, gas_limit)
-    );
-    assert_eq!(
-        offset_of!(FastGasCounter, opcode_cost),
-        offset_of!(wasmer_types::FastGasCounter, opcode_cost)
-    );
-
-    let instance = {
-        let _span = tracing::debug_span!(target: "vm", "run_method/instantiate").entered();
-        Instance::new_with_config(
-            module,
-            unsafe {
-                InstanceConfig::new_with_counter(
-                    logic.gas_counter_pointer() as *mut wasmer_types::FastGasCounter
-                )
-            },
-            &import,
-        )
-        .map_err(|err| translate_instantiation_error(err, logic))?
-    };
-    let f = instance.exports.get_function(method_name).map_err(|err| err.into_vm_error())?;
-    let f = f.native::<(), ()>().map_err(|err| err.into_vm_error())?;
-
-    {
-        let _span = tracing::debug_span!(target: "vm", "run_method/call").entered();
-        f.call().map_err(|err| translate_runtime_error(err, logic))?
-    }
-
-    {
-        let _span = tracing::debug_span!(target: "vm", "run_method/drop_instance").entered();
-        drop(instance)
-    }
-
-    Ok(())
 }
 
 #[derive(Hash, PartialEq, Debug)]
@@ -301,79 +250,266 @@ pub(crate) fn wasmer2_vm_hash() -> u64 {
     WASMER2_CONFIG.config_hash()
 }
 
-pub(crate) fn default_wasmer2_store() -> Store {
-    // We only support singlepass compiler at the moment.
-    assert_eq!(WASMER2_CONFIG.compiler, WasmerCompiler::Singlepass);
-    let compiler = Singlepass::new();
-    // We only support universal engine at the moment.
-    assert_eq!(WASMER2_CONFIG.engine, WasmerEngine::Universal);
-    let target_features = if cfg!(feature = "no_cpu_compatibility_checks") {
-        let mut fs = wasmer::CpuFeature::set();
-        // These features should be sufficient to run the single pass compiler.
-        fs.insert(wasmer::CpuFeature::SSE2);
-        fs.insert(wasmer::CpuFeature::SSE3);
-        fs.insert(wasmer::CpuFeature::SSSE3);
-        fs.insert(wasmer::CpuFeature::SSE41);
-        fs.insert(wasmer::CpuFeature::SSE42);
-        fs.insert(wasmer::CpuFeature::POPCNT);
-        fs.insert(wasmer::CpuFeature::AVX);
-        fs
-    } else {
-        wasmer::CpuFeature::for_host()
-    };
-    let engine = wasmer::Universal::new(compiler)
-        .features(WASMER_FEATURES)
-        .target(wasmer::Target::new(wasmer::Triple::host(), target_features))
-        .engine();
-    Store::new(&engine)
+#[derive(Clone)]
+pub(crate) struct VMArtifact {
+    artifact: Arc<dyn Artifact>,
+    _engine: UniversalEngine,
 }
 
-pub(crate) fn run_wasmer2_module<'a>(
-    module: &Module,
-    store: &Store,
-    memory: &mut Wasmer2Memory,
-    method_name: &str,
-    ext: &mut dyn External,
-    context: VMContext,
-    wasm_config: &'a VMConfig,
-    fees_config: &'a RuntimeFeesConfig,
-    promise_results: &'a [PromiseResult],
-    current_protocol_version: ProtocolVersion,
-) -> (Option<VMOutcome>, Option<VMError>) {
-    // Do we really need that code?
-    if method_name.is_empty() {
-        return (
-            None,
-            Some(VMError::FunctionCallError(FunctionCallError::MethodResolveError(
-                MethodResolveError::MethodEmptyName,
-            ))),
+impl VMArtifact {
+    pub(crate) fn artifact(&self) -> &dyn Artifact {
+        &*self.artifact
+    }
+}
+
+#[derive(loupe::MemoryUsage)]
+pub(crate) struct Wasmer2VM {
+    #[loupe(skip)]
+    config: VMConfig,
+    engine: UniversalEngine,
+}
+
+impl Wasmer2VM {
+    pub(crate) fn new(config: VMConfig) -> Self {
+        use wasmer_compiler::{CpuFeature, Target, Triple};
+        // We only support singlepass compiler at the moment.
+        assert_eq!(WASMER2_CONFIG.compiler, WasmerCompiler::Singlepass);
+        let compiler = Singlepass::new();
+        // We only support universal engine at the moment.
+        assert_eq!(WASMER2_CONFIG.engine, WasmerEngine::Universal);
+        let target_features = if cfg!(feature = "no_cpu_compatibility_checks") {
+            let mut fs = CpuFeature::set();
+            // These features should be sufficient to run the single pass compiler.
+            fs.insert(CpuFeature::SSE2);
+            fs.insert(CpuFeature::SSE3);
+            fs.insert(CpuFeature::SSSE3);
+            fs.insert(CpuFeature::SSE41);
+            fs.insert(CpuFeature::SSE42);
+            fs.insert(CpuFeature::POPCNT);
+            fs.insert(CpuFeature::AVX);
+            fs
+        } else {
+            CpuFeature::for_host()
+        };
+        Self {
+            config,
+            engine: Universal::new(compiler)
+                .target(Target::new(Triple::host(), target_features))
+                .features(WASMER_FEATURES)
+                .engine(),
+        }
+    }
+
+    pub(crate) fn compile_uncached(&self, code: &[u8]) -> Result<VMArtifact, CompilationError> {
+        self.engine
+            .validate(code)
+            .map_err(|e| CompilationError::WasmerCompileError { msg: e.to_string() })?;
+        Ok(VMArtifact {
+            artifact: self
+                .engine
+                .compile(code, &self)
+                .map_err(|e| CompilationError::WasmerCompileError { msg: e.to_string() })?,
+            _engine: self.engine.clone(),
+        })
+    }
+
+    pub(crate) unsafe fn deserialize(
+        &self,
+        serialized: &[u8],
+    ) -> Result<VMArtifact, DeserializeError> {
+        Ok(VMArtifact {
+            artifact: self.engine.deserialize(serialized)?,
+            _engine: self.engine.clone(),
+        })
+    }
+
+    fn run_method(
+        &self,
+        artifact: &VMArtifact,
+        mut import: Wasmer2Imports<'_, '_>,
+        method_name: &str,
+    ) -> Result<(), VMError> {
+        let _span = tracing::debug_span!(target: "vm", "run_method").entered();
+
+        // FastGasCounter in Nearcore and Wasmer must match in layout.
+        assert_eq!(size_of::<FastGasCounter>(), size_of::<wasmer_types::FastGasCounter>());
+        assert_eq!(
+            offset_of!(FastGasCounter, burnt_gas),
+            offset_of!(wasmer_types::FastGasCounter, burnt_gas)
         );
+        assert_eq!(
+            offset_of!(FastGasCounter, gas_limit),
+            offset_of!(wasmer_types::FastGasCounter, gas_limit)
+        );
+        assert_eq!(
+            offset_of!(FastGasCounter, opcode_cost),
+            offset_of!(wasmer_types::FastGasCounter, opcode_cost)
+        );
+        let gas = import.vmlogic.gas_counter_pointer() as *mut wasmer_types::FastGasCounter;
+
+        let entrypoint = get_entrypoint_index(&*artifact.artifact, method_name)?;
+        unsafe {
+            let instance = {
+                let _span = tracing::debug_span!(target: "vm", "run_method/instantiate").entered();
+                // SAFETY/FIXME: this transmute shouldn't be necessary, but we are limited by
+                // wasmer's API right now.
+                //
+                // An important caveat is that the `'static` lifetime here refers to the lifetime
+                // of `VMLogic` reference to which is retained by the `InstanceHandle` we create.
+                // However this `InstanceHandle` only lives during the execution of this body, so
+                // we can be sure that `VMLogic` remains live and valid at any time.
+                let import =
+                    std::mem::transmute::<_, &mut Wasmer2Imports<'static, 'static>>(&mut import);
+                // SAFETY: we ensure that the tables are valid during the lifetime of this instance
+                // by retaining an instance to `UniversalEngine` which holds the allocations.
+                let handle = artifact
+                    .artifact
+                    .instantiate(
+                        &self,
+                        import,
+                        Box::new(()),
+                        // SAFETY: We have verified that the `FastGasCounter` layout matches the
+                        // expected layout. `gas` remains dereferenceable throughout this function
+                        // by the virtue of it being contained within `import` which lives for the
+                        // entirety of this function.
+                        InstanceConfig::new_with_counter(gas),
+                    )
+                    .map_err(|err| translate_instantiation_error(err, import.vmlogic))?;
+                // SAFETY: being called immediately after instantiation.
+                artifact
+                    .artifact
+                    .finish_instantiation(self, &handle)
+                    .map_err(|err| translate_instantiation_error(err, import.vmlogic))?;
+                handle
+            };
+            let external = instance.lookup_by_declaration(&ExportIndex::Function(entrypoint));
+            if let VMExtern::Function(f) = external {
+                let _span = tracing::debug_span!(target: "vm", "run_method/call").entered();
+                // Signature for the entry point should be `() -> ()`. This is only a sanity check
+                // – this should've been already checked by `get_entrypoint_index`.
+                if f.signature.params().is_empty() && f.signature.results().is_empty() {
+                    let trampoline = f.call_trampoline.expect("externs always have a trampoline");
+                    // SAFETY: we double-checked the signature, and all of the remaining arguments
+                    // come from an exported function definition which must be valid since it comes
+                    // from wasmer itself.
+                    wasmer_vm::wasmer_call_trampoline(
+                        self,
+                        f.vmctx,
+                        trampoline,
+                        f.address,
+                        [].as_mut_ptr() as *mut _,
+                    )
+                    .map_err(|e| {
+                        translate_runtime_error(RuntimeError::from_trap(e), import.vmlogic)
+                    })?;
+                } else {
+                    panic!("signature should've already been checked by `get_entrypoint_index`")
+                }
+            } else {
+                panic!("signature should've already been checked by `get_entrypoint_index`")
+            }
+
+            {
+                let _span =
+                    tracing::debug_span!(target: "vm", "run_method/drop_instance").entered();
+                drop(instance)
+            }
+        }
+
+        Ok(())
     }
 
-    // Note that we don't clone the actual backing memory, just increase the RC.
-    let memory_copy = memory.clone();
-
-    let mut logic = VMLogic::new_with_protocol_version(
-        ext,
-        context,
-        wasm_config,
-        fees_config,
-        promise_results,
-        memory,
-        current_protocol_version,
-    );
-
-    let import = imports::wasmer2::build(store, memory_copy, &mut logic, current_protocol_version);
-
-    if let Err(e) = check_method(module, method_name) {
-        return (None, Some(e));
+    pub(crate) fn run_module<'a>(
+        &self,
+        artifact: &VMArtifact,
+        memory: &mut Wasmer2Memory,
+        method_name: &str,
+        ext: &mut dyn External,
+        context: VMContext,
+        fees_config: &'a RuntimeFeesConfig,
+        promise_results: &'a [PromiseResult],
+        current_protocol_version: ProtocolVersion,
+    ) -> (Option<VMOutcome>, Option<VMError>) {
+        let vmmemory = memory.vm();
+        let mut logic = VMLogic::new_with_protocol_version(
+            ext,
+            context,
+            &self.config,
+            fees_config,
+            promise_results,
+            memory,
+            current_protocol_version,
+        );
+        let import = imports::wasmer2::build(vmmemory, &mut logic, current_protocol_version);
+        if let Err(e) = get_entrypoint_index(&*artifact.artifact, method_name) {
+            return (None, Some(e));
+        }
+        let err = self.run_method(artifact, import, method_name).err();
+        (Some(logic.outcome()), err)
     }
-
-    let err = run_method(module, &import, method_name, &mut logic).err();
-    (Some(logic.outcome()), err)
 }
 
-pub(crate) struct Wasmer2VM;
+unsafe impl wasmer_vm::TrapHandler for Wasmer2VM {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn custom_trap_handler(&self, _: &dyn Fn(&wasmer_vm::TrapHandlerFn) -> bool) -> bool {
+        false
+    }
+}
+
+impl wasmer_engine::Tunables for &Wasmer2VM {
+    fn memory_style(&self, memory: &MemoryType) -> MemoryStyle {
+        MemoryStyle::Static {
+            bound: memory.maximum.unwrap_or(Pages(self.config.limit_config.max_memory_pages)),
+            offset_guard_size: 0x1000,
+        }
+    }
+
+    fn table_style(&self, _table: &wasmer_types::TableType) -> wasmer_vm::TableStyle {
+        wasmer_vm::TableStyle::CallerChecksSignature
+    }
+
+    fn create_host_memory(
+        &self,
+        ty: &MemoryType,
+        _style: &MemoryStyle,
+    ) -> Result<std::sync::Arc<dyn Memory>, wasmer_vm::MemoryError> {
+        // We do not support arbitrary Host memories. The only memory contracts may use is the
+        // memory imported via `env.memory`.
+        Err(wasmer_vm::MemoryError::CouldNotGrow { current: Pages(0), attempted_delta: ty.minimum })
+    }
+
+    unsafe fn create_vm_memory(
+        &self,
+        ty: &MemoryType,
+        _style: &MemoryStyle,
+        _vm_definition_location: std::ptr::NonNull<wasmer_vm::VMMemoryDefinition>,
+    ) -> Result<std::sync::Arc<dyn Memory>, wasmer_vm::MemoryError> {
+        // We do not support VM memories. The only memory contracts may use is the memory imported
+        // via `env.memory`.
+        Err(wasmer_vm::MemoryError::CouldNotGrow { current: Pages(0), attempted_delta: ty.minimum })
+    }
+
+    fn create_host_table(
+        &self,
+        _ty: &wasmer_types::TableType,
+        _style: &wasmer_vm::TableStyle,
+    ) -> Result<std::sync::Arc<dyn wasmer_vm::Table>, String> {
+        panic!("should never be called")
+    }
+
+    unsafe fn create_vm_table(
+        &self,
+        ty: &wasmer_types::TableType,
+        style: &wasmer_vm::TableStyle,
+        vm_definition_location: std::ptr::NonNull<wasmer_vm::VMTableDefinition>,
+    ) -> Result<std::sync::Arc<dyn wasmer_vm::Table>, String> {
+        // This is called when instantiating a module.
+        Ok(Arc::new(LinearTable::from_definition(&ty, &style, vm_definition_location)?))
+    }
+}
 
 impl crate::runner::VM for Wasmer2VM {
     fn run(
@@ -404,24 +540,22 @@ impl crate::runner::VM for Wasmer2VM {
                 ))),
             );
         }
-
-        let store = default_wasmer2_store();
-        let module =
-            cache::wasmer2_cache::compile_module_cached_wasmer2(code, wasm_config, cache, &store);
-        let module = match into_vm_result(module) {
+        let artifact =
+            cache::wasmer2_cache::compile_module_cached_wasmer2(code, wasm_config, cache);
+        let artifact = match into_vm_result(artifact) {
             Ok(it) => it,
             Err(err) => return (None, Some(err)),
         };
 
         let mut memory = Wasmer2Memory::new(
-            &store,
             wasm_config.limit_config.initial_memory_pages,
             wasm_config.limit_config.max_memory_pages,
         )
         .expect("Cannot create memory for a contract call");
-        // Note that we don't clone the actual backing memory, just increase the RC.
-        let memory_copy = memory.clone();
 
+        // FIXME: this mostly duplicates the `run_module` method.
+        // Note that we don't clone the actual backing memory, just increase the RC.
+        let vmmemory = memory.vm();
         let mut logic = VMLogic::new_with_protocol_version(
             ext,
             context,
@@ -431,7 +565,6 @@ impl crate::runner::VM for Wasmer2VM {
             &mut memory,
             current_protocol_version,
         );
-
         // TODO: remove, as those costs are incorrectly computed, and we shall account it on deployment.
         if logic.add_contract_compile_fee(code.code().len() as u64).is_err() {
             return (
@@ -441,15 +574,11 @@ impl crate::runner::VM for Wasmer2VM {
                 ))),
             );
         }
-
-        let import_object =
-            imports::wasmer2::build(&store, memory_copy, &mut logic, current_protocol_version);
-
-        if let Err(e) = check_method(&module, method_name) {
+        let import = imports::wasmer2::build(vmmemory, &mut logic, current_protocol_version);
+        if let Err(e) = get_entrypoint_index(&*artifact.artifact, method_name) {
             return (None, Some(e));
         }
-
-        let err = run_method(&module, &import_object, method_name, &mut logic).err();
+        let err = self.run_method(&artifact, import, method_name).err();
         (Some(logic.outcome()), err)
     }
 
@@ -460,19 +589,16 @@ impl crate::runner::VM for Wasmer2VM {
         wasm_config: &VMConfig,
         cache: &dyn CompiledContractCache,
     ) -> Option<VMError> {
-        let store = crate::wasmer2_runner::default_wasmer2_store();
         let result = crate::cache::wasmer2_cache::compile_and_serialize_wasmer2(
             code,
             code_hash,
             wasm_config,
             cache,
-            &store,
         );
         into_vm_result(result).err()
     }
 
     fn check_compile(&self, code: &Vec<u8>) -> bool {
-        let store = default_wasmer2_store();
-        Module::new(&store, code).is_ok()
+        self.compile_uncached(code).is_ok()
     }
 }

--- a/runtime/runtime-params-estimator/src/function_call.rs
+++ b/runtime/runtime-params-estimator/src/function_call.rs
@@ -95,7 +95,6 @@ pub fn compute_function_call_cost(
     repeats: u64,
     contract: &ContractCode,
 ) -> Gas {
-    let runtime = vm_kind.runtime().expect("runtime has not been enabled");
     let workdir = tempfile::Builder::new().prefix("runtime_testbed").tempdir().unwrap();
     let store = create_store(&get_store_path(workdir.path()));
     let cache_store = Arc::new(StoreCompiledContractCache { store });
@@ -104,6 +103,7 @@ pub fn compute_function_call_cost(
     let config_store = RuntimeConfigStore::new(None);
     let runtime_config = config_store.get_config(protocol_version).as_ref();
     let vm_config = runtime_config.wasm_config.clone();
+    let runtime = vm_kind.runtime(vm_config.clone()).expect("runtime has not been enabled");
     let fees = runtime_config.transaction_costs.clone();
     let mut fake_external = MockedExternal::new();
     let fake_context = create_context(vec![]);

--- a/runtime/runtime-params-estimator/src/gas_metering.rs
+++ b/runtime/runtime-params-estimator/src/gas_metering.rs
@@ -138,7 +138,6 @@ pub fn compute_gas_metering_cost(
     repeats: i32,
     contract: &ContractCode,
 ) -> u64 {
-    let runtime = vm_kind.runtime().expect("runtime has not been enabled");
     let workdir = tempfile::Builder::new().prefix("runtime_testbed").tempdir().unwrap();
     let store = create_store(&get_store_path(workdir.path()));
     let cache_store = Arc::new(StoreCompiledContractCache { store });
@@ -146,6 +145,7 @@ pub fn compute_gas_metering_cost(
     let config_store = RuntimeConfigStore::new(None);
     let runtime_config = config_store.get_config(PROTOCOL_VERSION).as_ref();
     let vm_config_gas = runtime_config.wasm_config.clone();
+    let runtime = vm_kind.runtime(vm_config_gas.clone()).expect("runtime has not been enabled");
     let fees = runtime_config.transaction_costs.clone();
     let mut fake_external = MockedExternal::new();
     let fake_context = create_context(vec![]);

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -612,7 +612,7 @@ fn wasm_instruction(ctx: &mut EstimatorContext) -> GasCost {
 
     let mut run = || {
         let context = create_context(vec![]);
-        let (outcome, err) = vm_kind.runtime().unwrap().run(
+        let (outcome, err) = vm_kind.runtime(config.clone()).unwrap().run(
             &code,
             "cpu_ram_soak_test",
             &mut fake_external,

--- a/runtime/runtime-params-estimator/src/vm_estimator.rs
+++ b/runtime/runtime-params-estimator/src/vm_estimator.rs
@@ -271,7 +271,7 @@ fn test_many_contracts_call(gas_metric: GasMetric, vm_kind: VMKind) {
     let fees = RuntimeFeesConfig::test();
 
     let start = GasCost::measure(gas_metric);
-    if let Some(runtime) = vm_kind.runtime() {
+    if let Some(runtime) = vm_kind.runtime(vm_config.clone()) {
         for contract in &contracts {
             let promise_results = vec![];
             let result = runtime.run(


### PR DESCRIPTION
This is intended to be a non-functional change.

Here we replace the use of the `wasmer` crate and the wrappers it
provides with the lower level APIs exposed by various wasmer subcrates
such as `wasmer-engine`, `wasmer-vm`, etc.

These changes are primarily intended to reduce the burden of maintaining
and publishing the `wasmer-near` crate. Since our requirements for a
runtime are scoped to very narrow portion of what the `wasmer` crate
provides, the complexity of the code in `nearcore` didn't
change as much as I feared it would, while also making certain portions
of the codebase significantly more straightforward.

The `imports`-related code is perhaps the highest gain in complexity of
the code, as it has become necessary to take care of ensuring a matching
ABI. On the other hand, the changes there also reduced non-local
assumptions about the lifetime of the `VMLogic` by moving it this concern
entirely to the funcition which handles instantiations.

There are definitely more opportunities for simplifying the code around
this part of the codebase, but these will need to happen as a follow up
as this one is already getting quite large, and some of the changes
would touch other runners, not just Wasmer2.