### PR TITLE
refactor: Generalize parameter estimator 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4440,6 +4440,7 @@ dependencies = [
  "rand_xorshift 0.2.0",
  "rocksdb",
  "serde_json",
+ "sha256",
  "state-viewer",
  "tempfile",
  "testlib",
@@ -4692,6 +4693,16 @@ dependencies = [
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
+]
+
+[[package]]
+name = "sha256"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e84a7f596c081d359de5e06a83877138bc3c4483591e1af1916e1472e6e146e"
+dependencies = [
+ "hex",
+ "sha2",
 ]
 
 [[package]]

--- a/runtime/runtime-params-estimator/Cargo.toml
+++ b/runtime/runtime-params-estimator/Cargo.toml
@@ -24,6 +24,7 @@ borsh = "0.9"
 num-rational = "0.3"
 anyhow = "1"
 chrono = "0.4"
+sha256 = "1.0.2"
 
 genesis-populate = { path = "../../genesis-tools/genesis-populate"}
 near-chain-configs = { path = "../../core/chain-configs" }

--- a/runtime/runtime-params-estimator/src/config.rs
+++ b/runtime/runtime-params-estimator/src/config.rs
@@ -1,16 +1,5 @@
-use near_primitives::types::AccountId;
 use near_vm_runner::internal::VMKind;
 use std::path::PathBuf;
-
-/// Get account id from its index.
-pub fn get_account_id(account_index: usize) -> AccountId {
-    AccountId::try_from(format!("near_{}_{}", account_index, account_index)).unwrap()
-}
-
-/// Total number of transactions that we need to prepare.
-pub fn total_transactions(config: &Config) -> usize {
-    config.block_sizes.iter().sum::<usize>() * config.iter_per_block
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GasMetric {
@@ -37,6 +26,6 @@ pub struct Config {
     pub metric: GasMetric,
     /// VMKind used
     pub vm_kind: VMKind,
-    /// When non-none, only the specified metrics will be measured.
-    pub metrics_to_measure: Option<Vec<String>>,
+    /// When non-none, only the specified costs will be measured.
+    pub costs_to_measure: Option<Vec<String>>,
 }

--- a/runtime/runtime-params-estimator/src/cost.rs
+++ b/runtime/runtime-params-estimator/src/cost.rs
@@ -87,6 +87,8 @@ pub enum Cost {
     AltBn128G1SumByte,
 
     // Costs used only in estimator
+    ContractCompileBase, // TODO: Needs estimation function
+    ContractCompileBytes, // TODO: Needs estimation function
     GasMeteringBase,
     GasMeteringOp,
     IoReadByte,

--- a/runtime/runtime-params-estimator/src/cost.rs
+++ b/runtime/runtime-params-estimator/src/cost.rs
@@ -26,10 +26,6 @@ pub enum Cost {
     ActionDeleteKey,
     ActionDeleteAccount,
 
-    // TODO: Remove these two, compilation is a part of `ActionDeploy`.
-    ContractCompileBase,
-    ContractCompileBytes,
-
     HostFunctionCall,
     WasmInstruction,
     ReadMemoryBase,
@@ -89,6 +85,15 @@ pub enum Cost {
     AltBn128PairingCheckByte,
     AltBn128G1SumBase,
     AltBn128G1SumByte,
+
+    // Costs used only in estimator
+    GasMeteringBase,
+    GasMeteringOp,
+    IoReadByte,
+    IoWriteByte,
+    CpuBenchmarkSha256,
+    OneCPUInstruction,
+    OneNanosecond,
 
     __Count,
 }

--- a/runtime/runtime-params-estimator/src/cost.rs
+++ b/runtime/runtime-params-estimator/src/cost.rs
@@ -87,7 +87,7 @@ pub enum Cost {
     AltBn128G1SumByte,
 
     // Costs used only in estimator
-    ContractCompileBase, // TODO: Needs estimation function
+    ContractCompileBase,  // TODO: Needs estimation function
     ContractCompileBytes, // TODO: Needs estimation function
     GasMeteringBase,
     GasMeteringOp,

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -3,9 +3,10 @@ use std::collections::HashMap;
 use near_primitives::transaction::SignedTransaction;
 use near_vm_logic::ExtCosts;
 
+use crate::config::Config;
 use crate::gas_cost::GasCost;
+use crate::get_account_id;
 use crate::testbed::RuntimeTestbed;
-use crate::testbed_runners::{get_account_id, Config};
 
 use super::transaction_builder::TransactionBuilder;
 
@@ -25,6 +26,7 @@ pub(crate) struct CachedCosts {
     pub(crate) storage_read_base: Option<GasCost>,
     pub(crate) action_function_call_base_per_byte_v2: Option<(GasCost, GasCost)>,
     pub(crate) compile_cost_base_per_byte: Option<(GasCost, GasCost)>,
+    pub(crate) gas_metering_cost_base_per_op: Option<(GasCost, GasCost)>,
 }
 
 impl<'c> EstimatorContext<'c> {

--- a/runtime/runtime-params-estimator/src/estimator_params.rs
+++ b/runtime/runtime-params-estimator/src/estimator_params.rs
@@ -1,0 +1,55 @@
+//! Some parameters are use within the estimator to transform measurements to gas costs.
+//! These parameters have been estimated manually and are now hard-coded for a more deterministic estimation of runtime parameters.
+//! This module contains the hard-coded constants as well as the code to manually re-estimate them.
+
+use num_rational::Ratio;
+
+use crate::{config::GasMetric, gas_cost::GasCost};
+
+// All constant below are measured in Gas, respectively, in fractions thereof.
+
+/// How much gas there is in a nanosecond worth of computation.
+pub(crate) const ONE_NANOSECOND: Ratio<u64> = Ratio::new_raw(1_000_000, 1);
+// We use factor of 8 to approximately match the price of SHA256 operation between
+// time-based and icount-based metric as measured on 3.2Ghz Core i5.
+pub(crate) const ONE_CPU_INSTRUCTION: Ratio<u64> = Ratio::new_raw(1_000_000, 8);
+
+// See runtime/runtime-params-estimator/emu-cost/README.md for the motivation of constant values.
+pub(crate) const IO_READ_BYTE_COST: Ratio<u64> = Ratio::new_raw(27_000_000, 8);
+pub(crate) const IO_WRITE_BYTE_COST: Ratio<u64> = Ratio::new_raw(47_000_000, 8);
+
+/// Measure the cost for running a sha256 Rust implementation (on an arbitrary input).
+///
+/// This runs outside the WASM runtime and is intended to measure the overall hardware capabilities of the test system.
+/// (The motivation is to stay as close as possible to original estimations done with this code:
+/// https://github.com/near/calibrator/blob/c6fbb170a905fbc630ebd84ebc97f7226ec87ead/src/main.rs#L8-L21)
+pub(crate) fn sha256_cost(metric: GasMetric, repeats: u64) -> GasCost {
+    let cpu = measure_operation(repeats, metric, exec_sha256);
+    let cpu_per_rep = cpu / repeats;
+    cpu_per_rep
+}
+
+fn exec_sha256(repeats: u64) -> i64 {
+    use sha256::digest;
+    let mut result = 0;
+    for index in 0..repeats {
+        let input = "what should I do but tend upon the hours, and times of your desire";
+        let val = digest(input);
+        assert_eq!(val, "9b4d38fd42c985baec11564a84366de0cbd26d3425ec4ce1266e26b7b951ac08");
+        result += val.as_bytes()[(index % 64) as usize] as i64;
+    }
+    result
+}
+
+#[used]
+static mut SINK: i64 = 0;
+
+fn measure_operation<F: FnOnce(u64) -> i64>(count: u64, metric: GasMetric, op: F) -> GasCost {
+    let start = GasCost::measure(metric);
+    let value = op(count);
+    let result = start.elapsed();
+    unsafe {
+        SINK = value;
+    }
+    result
+}

--- a/runtime/runtime-params-estimator/src/estimator_params.rs
+++ b/runtime/runtime-params-estimator/src/estimator_params.rs
@@ -2,6 +2,7 @@
 //! These parameters have been estimated manually and are now hard-coded for a more deterministic estimation of runtime parameters.
 //! This module contains the hard-coded constants as well as the code to manually re-estimate them.
 
+use near_primitives::types::Gas;
 use num_rational::Ratio;
 
 use crate::{config::GasMetric, gas_cost::GasCost};
@@ -9,14 +10,14 @@ use crate::{config::GasMetric, gas_cost::GasCost};
 // All constant below are measured in Gas, respectively, in fractions thereof.
 
 /// How much gas there is in a nanosecond worth of computation.
-pub(crate) const ONE_NANOSECOND: Ratio<u64> = Ratio::new_raw(1_000_000, 1);
+pub(crate) const GAS_IN_NS: Ratio<Gas> = Ratio::new_raw(1_000_000, 1);
 // We use factor of 8 to approximately match the price of SHA256 operation between
 // time-based and icount-based metric as measured on 3.2Ghz Core i5.
-pub(crate) const ONE_CPU_INSTRUCTION: Ratio<u64> = Ratio::new_raw(1_000_000, 8);
+pub(crate) const GAS_IN_INSTR: Ratio<Gas> = Ratio::new_raw(1_000_000, 8);
 
 // See runtime/runtime-params-estimator/emu-cost/README.md for the motivation of constant values.
-pub(crate) const IO_READ_BYTE_COST: Ratio<u64> = Ratio::new_raw(27_000_000, 8);
-pub(crate) const IO_WRITE_BYTE_COST: Ratio<u64> = Ratio::new_raw(47_000_000, 8);
+pub(crate) const IO_READ_BYTE_COST: Ratio<Gas> = Ratio::new_raw(27_000_000, 8);
+pub(crate) const IO_WRITE_BYTE_COST: Ratio<Gas> = Ratio::new_raw(47_000_000, 8);
 
 /// Measure the cost for running a sha256 Rust implementation (on an arbitrary input).
 ///

--- a/runtime/runtime-params-estimator/src/function_call.rs
+++ b/runtime/runtime-params-estimator/src/function_call.rs
@@ -1,15 +1,14 @@
-use crate::gas_cost::{ratio_to_gas_signed, GasCost};
-use crate::testbed_runners::GasMetric;
+use crate::config::GasMetric;
+use crate::gas_cost::GasCost;
 use crate::vm_estimator::{create_context, least_squares_method};
 use near_primitives::contract::ContractCode;
 use near_primitives::runtime::config_store::RuntimeConfigStore;
-use near_primitives::types::{CompiledContractCache, ProtocolVersion};
+use near_primitives::types::{CompiledContractCache, Gas, ProtocolVersion};
 use near_store::{create_store, StoreCompiledContractCache};
 use near_vm_logic::mocks::mock_external::MockedExternal;
 use near_vm_runner::internal::VMKind;
 use nearcore::get_store_path;
 use num_rational::Ratio;
-use num_traits::ToPrimitive;
 use std::fmt::Write;
 use std::sync::Arc;
 
@@ -31,11 +30,9 @@ pub(crate) fn test_function_call(metric: GasMetric, vm_kind: VMKind) -> (Ratio<i
     }
 
     let (cost_base, cost_byte, _) = least_squares_method(&xs, &ys);
-    let gas_cost_base = ratio_to_gas_signed(metric, cost_base);
-    let gas_cost_byte = ratio_to_gas_signed(metric, cost_byte);
     println!(
         "{:?} {:?} function call base {} gas, per byte {} gas",
-        vm_kind, metric, gas_cost_base, gas_cost_byte,
+        vm_kind, metric, cost_base, cost_byte,
     );
     (cost_base, cost_byte)
 }
@@ -97,7 +94,7 @@ pub fn compute_function_call_cost(
     vm_kind: VMKind,
     repeats: u64,
     contract: &ContractCode,
-) -> u64 {
+) -> Gas {
     let runtime = vm_kind.runtime().expect("runtime has not been enabled");
     let workdir = tempfile::Builder::new().prefix("runtime_testbed").tempdir().unwrap();
     let store = create_store(&get_store_path(workdir.path()));
@@ -143,9 +140,5 @@ pub fn compute_function_call_cost(
         );
         assert!(result.1.is_none());
     }
-    let total_raw = start.elapsed().scalar_cost().to_i128().unwrap();
-
-    println!("cost is {}", total_raw);
-
-    total_raw as u64
+    start.elapsed().to_gas()
 }

--- a/runtime/runtime-params-estimator/src/gas_cost.rs
+++ b/runtime/runtime-params-estimator/src/gas_cost.rs
@@ -7,9 +7,7 @@ use num_rational::Ratio;
 use num_traits::ToPrimitive;
 
 use crate::config::GasMetric;
-use crate::estimator_params::{
-    IO_READ_BYTE_COST, IO_WRITE_BYTE_COST, ONE_CPU_INSTRUCTION, ONE_NANOSECOND,
-};
+use crate::estimator_params::{GAS_IN_INSTR, GAS_IN_NS, IO_READ_BYTE_COST, IO_WRITE_BYTE_COST};
 use crate::qemu::QemuMeasurement;
 
 /// Result of cost estimation.
@@ -62,13 +60,13 @@ impl GasCost {
         GasClock { start, metric }
     }
 
-    /// Creates `GasCost` out of raw numeric value. This is required mostly for
+    /// Creates `GasCost` out of raw numeric value of gas. This is required mostly for
     /// compatibility with existing code, prefer using `measure` instead.
-    pub(crate) fn from_raw(raw: Ratio<u64>, metric: GasMetric) -> GasCost {
+    pub(crate) fn from_gas(raw: Ratio<u64>, metric: GasMetric) -> GasCost {
         let mut result = GasCost::zero(metric);
         match metric {
-            GasMetric::ICount => result.instructions = raw / ONE_CPU_INSTRUCTION,
-            GasMetric::Time => result.time_ns = raw / ONE_NANOSECOND,
+            GasMetric::ICount => result.instructions = raw / GAS_IN_INSTR,
+            GasMetric::Time => result.time_ns = raw / GAS_IN_NS,
         }
         result
     }
@@ -199,11 +197,11 @@ impl GasCost {
     pub(crate) fn to_gas(&self) -> Gas {
         match self.metric {
             GasMetric::ICount => {
-                self.instructions * ONE_CPU_INSTRUCTION
+                self.instructions * GAS_IN_INSTR
                     + self.io_r_bytes * IO_READ_BYTE_COST
                     + self.io_w_bytes * IO_WRITE_BYTE_COST
             }
-            GasMetric::Time => self.time_ns * ONE_NANOSECOND,
+            GasMetric::Time => self.time_ns * GAS_IN_NS,
         }
         .to_integer()
     }

--- a/runtime/runtime-params-estimator/src/gas_metering.rs
+++ b/runtime/runtime-params-estimator/src/gas_metering.rs
@@ -24,16 +24,12 @@ pub(crate) fn gas_metering_cost(metric: GasMetric, vm_kind: VMKind) -> (Gas, Gas
             // Here we test gas metering costs for forward branch cases.
             let nested_contract = make_deeply_nested_blocks_contact(depth);
             let cost = compute_gas_metering_cost(metric, vm_kind, REPEATS, &nested_contract);
-            #[cfg(test)]
-            println!("nested {} {}", depth, cost / (REPEATS as u64));
             xs1.push(depth as u64);
             ys1.push(cost);
         }
         if true {
             let loop_contract = make_simple_loop_contact(depth);
             let cost = compute_gas_metering_cost(metric, vm_kind, REPEATS, &loop_contract);
-            #[cfg(test)]
-            println!("loop {} {}", depth, cost / (REPEATS as u64));
             xs2.push(depth as u64);
             ys2.push(cost);
         }
@@ -55,25 +51,6 @@ pub(crate) fn gas_metering_cost(metric: GasMetric, vm_kind: VMKind) -> (Gas, Gas
     let cost_base = std::cmp::max(cost1_base, cost2_base).round().to_integer() as u64;
     let cost_op = std::cmp::max(cost1_op, cost2_op).round().to_integer() as u64;
     (cost_base, cost_op)
-}
-
-#[test]
-fn test_gas_metering_cost_time() {
-    // Run with
-    // cargo test --release --lib gas_metering::test_gas_metering_cost_time -- --exact --nocapture
-    gas_metering_cost(GasMetric::Time, VMKind::Wasmer0);
-}
-
-#[test]
-fn test_gas_metering_cost_icount() {
-    // Use smth like
-    // CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER=./runner.sh \
-    // cargo test --release --features no_cpu_compatibility_checks \
-    // --lib gas_metering::test_gas_metering_cost_icount -- --exact --nocapture
-    // Where runner.sh is
-    // /host/nearcore/runtime/runtime-params-estimator/emu-cost/counter_plugin/qemu-x86_64 \
-    // -cpu Westmere-v1 -plugin file=/host/nearcore/runtime/runtime-params-estimator/emu-cost/counter_plugin/libcounter.so $@
-    gas_metering_cost(GasMetric::ICount, VMKind::Wasmer0);
 }
 
 fn make_deeply_nested_blocks_contact(depth: i32) -> ContractCode {

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -489,8 +489,8 @@ fn compilation_cost_base_per_byte(ctx: &mut EstimatorContext) -> (GasCost, GasCo
     let (base, byte) = compute_compile_cost_vm(ctx.config.metric, ctx.config.vm_kind, verbose);
 
     let base_byte_cost = (
-        GasCost::from_raw(base.into(), ctx.config.metric),
-        GasCost::from_raw(byte.into(), ctx.config.metric),
+        GasCost::from_gas(base.into(), ctx.config.metric),
+        GasCost::from_gas(byte.into(), ctx.config.metric),
     );
 
     ctx.cached.compile_cost_base_per_byte = Some(base_byte_cost.clone());
@@ -540,8 +540,8 @@ fn action_function_call_base_per_byte_v2(ctx: &mut EstimatorContext) -> (GasCost
         Ratio::new((*r.numer()).try_into().unwrap(), (*r.denom()).try_into().unwrap())
     };
     let base_byte_cost = (
-        GasCost::from_raw(convert_ratio(base), ctx.config.metric),
-        GasCost::from_raw(convert_ratio(byte), ctx.config.metric),
+        GasCost::from_gas(convert_ratio(base), ctx.config.metric),
+        GasCost::from_gas(convert_ratio(byte), ctx.config.metric),
     );
 
     ctx.cached.action_function_call_base_per_byte_v2 = Some(base_byte_cost.clone());
@@ -941,8 +941,8 @@ fn gas_metering(ctx: &mut EstimatorContext) -> (GasCost, GasCost) {
         return cached;
     }
     let (base, byte) = gas_metering_cost(ctx.config.metric, ctx.config.vm_kind);
-    let base = GasCost::from_raw(base.into(), ctx.config.metric);
-    let byte = GasCost::from_raw(byte.into(), ctx.config.metric);
+    let base = GasCost::from_gas(base.into(), ctx.config.metric);
+    let byte = GasCost::from_gas(byte.into(), ctx.config.metric);
     ctx.cached.gas_metering_cost_base_per_op = Some((base.clone(), byte.clone()));
     (base, byte)
 }
@@ -955,7 +955,7 @@ fn cpu_benchmark_sha256(ctx: &mut EstimatorContext) -> GasCost {
 /// Estimate how much gas is charged for 1 CPU instruction. (Using given runtime parameters, on the specific system this is being run on.)
 fn one_cpu_instruction(ctx: &mut EstimatorContext) -> GasCost {
     eprintln!("Cannot estimate ONE_CPU_INSTRUCTION like any other cost. The result will only show the constant value currently used in the estimator.");
-    GasCost::from_raw(estimator_params::ONE_CPU_INSTRUCTION, ctx.config.metric)
+    GasCost::from_gas(estimator_params::GAS_IN_INSTR, ctx.config.metric)
 }
 
 /// Estimate how much gas is charged for 1 nanosecond of computation. (Using given runtime parameters, on the specific system this is being run on.)
@@ -963,7 +963,7 @@ fn one_nanosecond(ctx: &mut EstimatorContext) -> GasCost {
     // Currently we don't have a test for this, yet. 1 gas has just always been 1ns.
     // But it would be useful to go backwards and see how expensive computation time is on specific hardware.
     eprintln!("Cannot estimate ONE_NANOSECOND like any other cost. The result will only show the constant value currently used in the estimator.");
-    GasCost::from_raw(estimator_params::ONE_NANOSECOND, ctx.config.metric)
+    GasCost::from_gas(estimator_params::GAS_IN_NS, ctx.config.metric)
 }
 
 // Helpers

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -88,6 +88,7 @@ use crate::vm_estimator::create_context;
 pub use crate::cost::Cost;
 pub use crate::cost_table::CostTable;
 pub use crate::costs_to_runtime_config::costs_to_runtime_config;
+pub use crate::qemu::QemuCommandBuilder;
 
 static ALL_COSTS: &[(Cost, fn(&mut EstimatorContext) -> GasCost)] = &[
     (Cost::ActionReceiptCreation, action_receipt_creation),

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -940,7 +940,7 @@ fn gas_metering(ctx: &mut EstimatorContext) -> (GasCost, GasCost) {
     if let Some(cached) = ctx.cached.gas_metering_cost_base_per_op.clone() {
         return cached;
     }
-    let (base, byte) = gas_metering_cost(ctx.config.metric);
+    let (base, byte) = gas_metering_cost(ctx.config.metric, ctx.config.vm_kind);
     let base = GasCost::from_raw(base.into(), ctx.config.metric);
     let byte = GasCost::from_raw(byte.into(), ctx.config.metric);
     ctx.cached.gas_metering_cost_base_per_op = Some((base.clone(), byte.clone()));

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -7,11 +7,10 @@ use near_primitives::version::PROTOCOL_VERSION;
 use near_store::create_store;
 use near_vm_runner::internal::VMKind;
 use nearcore::{get_store_path, load_config};
-use runtime_params_estimator::costs_to_runtime_config;
+use runtime_params_estimator::config::{Config, GasMetric};
 use runtime_params_estimator::read_resource;
-use runtime_params_estimator::testbed_runners::Config;
-use runtime_params_estimator::testbed_runners::GasMetric;
 use runtime_params_estimator::CostTable;
+use runtime_params_estimator::{costs_to_runtime_config};
 use std::env;
 use std::fmt::Write;
 use std::fs;
@@ -56,7 +55,7 @@ struct CliArgs {
     compare_to: Option<PathBuf>,
     /// Only measure the specified metrics, computing a subset of costs.
     #[clap(long)]
-    metrics_to_measure: Option<String>,
+    costs: Option<String>,
     /// Build and run the estimator inside a docker container via QEMU.
     #[clap(long)]
     docker: bool,
@@ -183,8 +182,7 @@ fn main() -> anyhow::Result<()> {
         None => VMKind::for_protocol_version(PROTOCOL_VERSION),
         Some(other) => unreachable!("Unknown vm_kind {}", other),
     };
-    let metrics_to_measure =
-        cli_args.metrics_to_measure.map(|it| it.split(',').map(str::to_string).collect());
+    let costs_to_measure = cli_args.costs.map(|it| it.split(',').map(str::to_string).collect());
 
     let config = Config {
         warmup_iters_per_block,
@@ -194,7 +192,7 @@ fn main() -> anyhow::Result<()> {
         state_dump_path: state_dump_path.clone(),
         metric,
         vm_kind,
-        metrics_to_measure,
+        costs_to_measure,
     };
     let cost_table = runtime_params_estimator::run(config);
 

--- a/runtime/runtime-params-estimator/src/qemu.rs
+++ b/runtime/runtime-params-estimator/src/qemu.rs
@@ -1,6 +1,8 @@
 //! QEMU instrumentation code to get used resources as measured by the QEMU plugin.
 
+use std::fmt::Write;
 use std::os::raw::c_void;
+use std::process::Command;
 
 // We use several "magical" file descriptors to interact with the plugin in QEMU
 // intercepting read syscall. Plugin counts instructions executed and amount of data transferred
@@ -38,4 +40,73 @@ fn hypercall(index: u32) -> u64 {
         libc::read((CATCH_BASE + index) as i32, &mut result as *mut _ as *mut c_void, 8);
     }
     result
+}
+
+/// Create a command to be executed inside QEMU with the custom counter plugin.
+pub struct QemuCommandBuilder {
+    started: bool,
+    on_every_close: bool,
+    count_per_thread: bool,
+    plugin_log: bool,
+}
+
+impl QemuCommandBuilder {
+    /// Start measurement immediately, without having to call `start_count_instructions` first.
+    pub fn started(mut self, started: bool) -> Self {
+        self.started = started;
+        self
+    }
+    /// Print the counters on every close() syscall
+    pub fn print_on_every_close(mut self, on_every_close: bool) -> Self {
+        self.on_every_close = on_every_close;
+        self
+    }
+    /// Instantiate different counters for each thread
+    pub fn count_per_thread(mut self, count_per_thread: bool) -> Self {
+        self.count_per_thread = count_per_thread;
+        self
+    }
+
+    /// Enable plugin log output to stderr
+    pub fn plugin_log(mut self, enable: bool) -> Self {
+        self.plugin_log = enable;
+        self
+    }
+
+    /// Create the final command line
+    pub fn build(&self, inner_cmd: &str) -> anyhow::Result<Command> {
+        let mut cmd = Command::new(
+            "/host/nearcore/runtime/runtime-params-estimator/emu-cost/counter_plugin/qemu-x86_64",
+        );
+
+        let plugin_path =
+            "/host/nearcore/runtime/runtime-params-estimator/emu-cost/counter_plugin/libcounter.so";
+
+        let mut buf = format!("file={}", plugin_path);
+        if self.started {
+            write!(buf, ",arg=\"started\"")?;
+        }
+        if self.count_per_thread {
+            write!(buf, ",arg=\"count_per_thread\"")?;
+        }
+        if self.on_every_close {
+            write!(buf, ",arg=\"on_every_close\"")?;
+        }
+        cmd.args(&["-plugin", &buf]);
+
+        if self.plugin_log {
+            cmd.args(&["-d", "plugin"]);
+        }
+
+        cmd.args(&["-cpu", "Westmere-v1"]);
+        cmd.arg(inner_cmd);
+
+        Ok(cmd)
+    }
+}
+
+impl Default for QemuCommandBuilder {
+    fn default() -> Self {
+        Self { started: false, on_every_close: false, count_per_thread: false, plugin_log: false }
+    }
 }

--- a/runtime/runtime-params-estimator/src/qemu.rs
+++ b/runtime/runtime-params-estimator/src/qemu.rs
@@ -52,24 +52,24 @@ pub struct QemuCommandBuilder {
 
 impl QemuCommandBuilder {
     /// Start measurement immediately, without having to call `start_count_instructions` first.
-    pub fn started(mut self, started: bool) -> Self {
-        self.started = started;
+    pub fn started(mut self, yes: bool) -> Self {
+        self.started = yes;
         self
     }
     /// Print the counters on every close() syscall
-    pub fn print_on_every_close(mut self, on_every_close: bool) -> Self {
-        self.on_every_close = on_every_close;
+    pub fn print_on_every_close(mut self, yes: bool) -> Self {
+        self.on_every_close = yes;
         self
     }
     /// Instantiate different counters for each thread
-    pub fn count_per_thread(mut self, count_per_thread: bool) -> Self {
-        self.count_per_thread = count_per_thread;
+    pub fn count_per_thread(mut self, yes: bool) -> Self {
+        self.count_per_thread = yes;
         self
     }
 
     /// Enable plugin log output to stderr
-    pub fn plugin_log(mut self, enable: bool) -> Self {
-        self.plugin_log = enable;
+    pub fn plugin_log(mut self, yes: bool) -> Self {
+        self.plugin_log = yes;
         self
     }
 

--- a/runtime/runtime-params-estimator/src/transaction_builder.rs
+++ b/runtime/runtime-params-estimator/src/transaction_builder.rs
@@ -7,7 +7,7 @@ use near_primitives::types::AccountId;
 use rand::prelude::ThreadRng;
 use rand::Rng;
 
-use crate::testbed_runners::get_account_id;
+use crate::get_account_id;
 
 /// A helper to create transaction for processing by a `TestBed`.
 #[derive(Clone)]

--- a/runtime/runtime-params-estimator/src/vm_estimator.rs
+++ b/runtime/runtime-params-estimator/src/vm_estimator.rs
@@ -1,5 +1,5 @@
-use crate::gas_cost::{ratio_to_gas_signed, GasCost};
-use crate::testbed_runners::GasMetric;
+use crate::config::GasMetric;
+use crate::gas_cost::GasCost;
 use near_primitives::contract::ContractCode;
 use near_primitives::runtime::config_store::RuntimeConfigStore;
 use near_primitives::runtime::fees::RuntimeFeesConfig;
@@ -7,16 +7,14 @@ use near_primitives::types::{CompiledContractCache, Gas, ProtocolVersion};
 use near_primitives::version::PROTOCOL_VERSION;
 use near_store::{create_store, StoreCompiledContractCache};
 use near_vm_logic::mocks::mock_external::MockedExternal;
-use near_vm_logic::{VMConfig, VMContext, VMOutcome};
+use near_vm_logic::{VMConfig, VMContext};
 use near_vm_runner::internal::VMKind;
-use near_vm_runner::{precompile_contract_vm, prepare, VMError};
+use near_vm_runner::precompile_contract_vm;
 use nearcore::get_store_path;
 use num_rational::Ratio;
 use num_traits::ToPrimitive;
-use std::fs;
-use std::path::PathBuf;
 use std::sync::Arc;
-use walrus::{Module, Result};
+use walrus::Result;
 
 const CURRENT_ACCOUNT_ID: &str = "alice";
 const SIGNER_ACCOUNT_ID: &str = "bob";
@@ -44,113 +42,20 @@ pub(crate) fn create_context(input: Vec<u8>) -> VMContext {
     }
 }
 
-fn call(code: &ContractCode) -> (Option<VMOutcome>, Option<VMError>) {
-    let mut fake_external = MockedExternal::new();
-    let context = create_context(vec![]);
-    let config_store = RuntimeConfigStore::new(None);
-    let runtime_config = config_store.get_config(PROTOCOL_VERSION).as_ref();
-    let config = runtime_config.wasm_config.clone();
-    let fees = runtime_config.transaction_costs.clone();
-
-    let promise_results = vec![];
-
-    near_vm_runner::run(
-        code,
-        "cpu_ram_soak_test",
-        &mut fake_external,
-        context,
-        &config,
-        &fees,
-        &promise_results,
-        PROTOCOL_VERSION,
-        None,
-    )
-}
-
-const NUM_ITERATIONS: u64 = 10;
-
-/// Cost of the most CPU demanding operation.
-pub fn cost_per_op(gas_metric: GasMetric, code: &ContractCode) -> Gas {
-    let config_store = RuntimeConfigStore::new(None);
-    let runtime_config = config_store.get_config(PROTOCOL_VERSION).as_ref();
-    let vm_config = runtime_config.wasm_config.clone();
-
-    // Call once for the warmup.
-    let (outcome, _) = call(code);
-    let outcome = outcome.unwrap();
-    let clock = GasCost::measure(gas_metric);
-    for _ in 0..NUM_ITERATIONS {
-        call(code);
-    }
-    let measured = clock.elapsed().instructions();
-    // We are given by measurement burnt gas
-    //   gas_burned(call) = outcome.burnt_gas
-    // and raw 'measured' value counting x86 insns.
-    // And know that
-    //   measured = NUM_ITERATIONS * x86_insns(call)
-    // Gas that was burned could be computed in two ways:
-    // As number of WASM instructions by cost of a single instruction.
-    //   gas_burned(call) = gas_cost_per_wasm_op * wasm_insns(call)
-    // and as normalized x86 insns count.
-    //   gas_burned(call) = measured * GAS_IN_MEASURE_UNIT / DIVISOR
-    // Divisor here is essentially a normalizing factor matching insn count
-    // to the notion of 1M gas as nanosecond of computations.
-    // So
-    //   outcome.burnt_gas = wasm_insns(call) *
-    //       vm_config.regular_op_cost
-    //   gas_cost_per_wasm_op = (measured * GAS_IN_MEASURE_UNIT *
-    //       vm_config.regular_op_cost) /
-    //       (DIVISOR * NUM_ITERATIONS * outcome.burnt_gas)
-    // Enough to return just
-    //    (measured * vm_config.regular_op_cost) /
-    //       (outcome.burnt_gas * NUM_ITERATIONS),
-    // as remaining can be computed with ratio_to_gas().
-    (measured * vm_config.regular_op_cost as u64 / NUM_ITERATIONS / outcome.burnt_gas).to_integer()
-}
-
-type CompileCost = (u64, Ratio<u64>);
-
-fn compile(code: &[u8], gas_metric: GasMetric, vm_kind: VMKind) -> Option<CompileCost> {
-    let runtime = vm_kind.runtime().expect("runtime has not been enabled");
-    let clock = GasCost::measure(gas_metric);
-    for _ in 0..NUM_ITERATIONS {
-        let prepared_code = prepare::prepare_contract(code, &VMConfig::test()).unwrap();
-        if runtime.check_compile(&prepared_code) {
-            return None;
-        }
-    }
-    let measured = clock.elapsed().scalar_cost();
-    Some((code.len() as u64, measured / NUM_ITERATIONS))
-}
-
-pub fn load_and_compile(
-    path: &PathBuf,
-    gas_metric: GasMetric,
-    vm_kind: VMKind,
-) -> Option<CompileCost> {
-    match fs::read(path) {
-        Ok(mut code) => match delete_all_data(&mut code) {
-            Ok(code) => compile(code, gas_metric, vm_kind),
-            _ => None,
-        },
-        _ => None,
-    }
-}
-
 fn measure_contract(
     vm_kind: VMKind,
     gas_metric: GasMetric,
     contract: &ContractCode,
     cache: Option<&dyn CompiledContractCache>,
-) -> u64 {
+) -> Gas {
     let config_store = RuntimeConfigStore::new(None);
     let runtime_config = config_store.get_config(PROTOCOL_VERSION).as_ref();
     let vm_config = runtime_config.wasm_config.clone();
     let start = GasCost::measure(gas_metric);
     let result = precompile_contract_vm(vm_kind, contract, &vm_config, cache);
-    let end = start.elapsed().scalar_cost();
+    let end = start.elapsed();
     assert!(result.is_ok(), "Compilation failed");
-    end.to_integer()
+    end.to_gas()
 }
 
 #[derive(Default, Clone)]
@@ -282,10 +187,10 @@ pub(crate) fn compute_compile_cost_vm(
     metric: GasMetric,
     vm_kind: VMKind,
     verbose: bool,
-) -> (u64, u64) {
+) -> (Gas, Gas) {
     let (a, b) = precompilation_cost(metric, vm_kind);
-    let base = ratio_to_gas_signed(metric, a);
-    let per_byte = ratio_to_gas_signed(metric, b);
+    let base = a.to_integer();
+    let per_byte = b.to_integer();
     if verbose {
         println!(
             "{:?} using {:?}: in a + b * x: a = {} ({}) b = {}({}) base = {} per_byte = {}",
@@ -385,15 +290,9 @@ fn test_many_contracts_call(gas_metric: GasMetric, vm_kind: VMKind) {
     } else {
         panic!("the {:?} runtime has not been enabled at compile time", vm_kind);
     }
-    let total_raw = start.elapsed().scalar_cost().to_i128().unwrap();
-
-    let total_gas = ratio_to_gas_signed(gas_metric, Ratio::new(total_raw, 1));
-    let raw_per_call = total_raw / count;
-    let gas_per_call = ratio_to_gas_signed(gas_metric, Ratio::new(total_raw, count as i128));
-    println!(
-        "{} calls: {} ({} per call) raw {:?}, {} gas ({} per call)",
-        count, total_raw, raw_per_call, gas_metric, total_gas, gas_per_call
-    );
+    let total_gas = start.elapsed().to_gas();
+    let gas_per_call = Ratio::new(total_gas, count);
+    println!("{} calls: {:?}, {} gas ({} per call)", count, gas_metric, total_gas, gas_per_call);
 }
 
 #[test]
@@ -411,13 +310,4 @@ fn test_many_contracts_call_icount() {
     // /host/nearcore/runtime/runtime-params-estimator/emu-cost/counter_plugin/qemu-x86_64 \
     // -cpu Westmere-v1 -plugin file=/host/nearcore/runtime/runtime-params-estimator/emu-cost/counter_plugin/libcounter.so $@
     test_many_contracts_call(GasMetric::ICount, VMKind::Wasmer0)
-}
-
-fn delete_all_data(wasm_bin: &mut Vec<u8>) -> Result<&Vec<u8>> {
-    let m = &mut Module::from_buffer(wasm_bin)?;
-    for id in m.data.iter().map(|t| t.id()).collect::<Vec<_>>() {
-        m.data.delete(id);
-    }
-    *wasm_bin = m.emit_wasm();
-    Ok(wasm_bin)
 }


### PR DESCRIPTION
- Change function interfaces to use Gas as a common unit
- Integrate CPU benchmark used to estimate x86 op cost
- Integrate gas metering estimation
- Preparation for more general estimation cases to be added
- Remove unused code