### PR TITLE
re: Reformat `Cargo.toml` for `near-network` related packages

### DIFF
--- a/chain/network-primitives/Cargo.toml
+++ b/chain/network-primitives/Cargo.toml
@@ -2,27 +2,28 @@
 name = "near-network-primitives"
 version = "0.0.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
-publish = true
+edition = "2021"
 # Please update rust-toolchain.toml as well when changing version here:
 rust-version = "1.56.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/near/nearcore"
 description = "This crate hosts NEAR network-related primitive types"
+repository = "https://github.com/near/nearcore"
+license = "MIT OR Apache-2.0"
+publish = true
 
 [dependencies]
 actix = "=0.11.0-beta.2"
 borsh = "0.9"
 chrono = { version = "0.4.4", features = ["serde"] }
 deepsize = { version = "0.2.0", optional = true }
-near-crypto = { path = "../../core/crypto" }
-near-primitives = { path = "../../core/primitives" }
-serde = { version = "1", features = ["derive", "rc", "alloc"], optional=true }
+serde = { version = "1", features = ["alloc", "derive", "rc"], optional = true }
 strum = { version = "0.20", features = ["derive"] }
 tokio = { version = "1.1", features = ["net", "rt-multi-thread"] }
 tracing = "0.1.13"
 
+near-crypto = { path = "../../core/crypto" }
+near-primitives = { path = "../../core/primitives" }
+
 [features]
-test_features = ["serde"]
-sandbox = []
 deepsize_feature = ["deepsize", "near-primitives/deepsize_feature"]
+sandbox = []
+test_features = ["serde"]

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -2,10 +2,10 @@
 name = "near-network"
 version = "0.0.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
-publish = false
+edition = "2021"
 # Please update rust-toolchain.toml as well when changing version here:
 rust-version = "1.56.0"
-edition = "2021"
+publish = false
 
 [dependencies]
 actix = "=0.11.0-beta.2"
@@ -13,18 +13,18 @@ borsh = { version = "0.9", features = ["rc"] }
 bytes = "1"
 bytesize = "1.1"
 conqueue = "0.4.0"
+deepsize = { version = "0.2.0", optional = true }
 futures = "0.3"
 lru = "0.6.5"
 near-rust-allocator-proxy = { version = "0.3.0", optional = true }
 once_cell = "1.5.2"
 rand = "0.7"
-serde = { version = "1", features = ["derive", "rc", "alloc"], optional=true }
+serde = { version = "1", features = ["alloc", "derive", "rc"], optional = true }
 strum = { version = "0.20", features = ["derive"] }
 tokio = { version = "1.1", features = ["net", "rt-multi-thread"] }
 tokio-stream = { version = "0.1.2", features = ["net"] }
 tokio-util = { version = "0.6", features = ["codec"] }
 tracing = "0.1.13"
-deepsize = { version = "0.2.0", optional = true }
 
 delay-detector = { path = "../../tools/delay_detector", optional = true }
 near-crypto = { path = "../../core/crypto" }
@@ -42,12 +42,23 @@ bencher = "0.1.5"
 tempfile = "3"
 
 [features]
+deepsize_feature = [
+    "deepsize",
+    "near-crypto/deepsize_feature",
+    "near-network-primitives/deepsize_feature",
+    "near-primitives/deepsize_feature",
+]
 delay_detector = ["delay-detector"]
-performance_stats = ["near-performance-metrics/performance_stats", "near-rust-allocator-proxy"]
-protocol_feature_routing_exchange_algorithm = ["near-primitives/protocol_feature_routing_exchange_algorithm", "near-stable-hasher"]
+performance_stats = [
+    "near-performance-metrics/performance_stats",
+    "near-rust-allocator-proxy",
+]
+protocol_feature_routing_exchange_algorithm = [
+    "near-primitives/protocol_feature_routing_exchange_algorithm",
+    "near-stable-hasher",
+]
 sandbox = ["near-network-primitives/sandbox"]
 test_features = ["near-network-primitives/test_features", "serde"]
-deepsize_feature = ["deepsize", "near-primitives/deepsize_feature", "near-crypto/deepsize_feature", "near-network-primitives/deepsize_feature"]
 
 [[bench]]
 name = "graph"

--- a/utils/near-cache/Cargo.toml
+++ b/utils/near-cache/Cargo.toml
@@ -3,11 +3,9 @@ name = "near-cache"
 version = "0.0.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
-publish = false
 # Please update rust-toolchain.toml as well when changing version here:
 rust-version = "1.56.0"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
 lru = "0.6.5"
@@ -19,4 +17,3 @@ rand = "0.7"
 [[bench]]
 name = "cache"
 harness = false
-

--- a/utils/near-performance-metrics-macros/Cargo.toml
+++ b/utils/near-performance-metrics-macros/Cargo.toml
@@ -1,17 +1,15 @@
 [package]
 name = "near-performance-metrics-macros"
 version = "0.0.0"
-authors = ["Near Inc <hello@nearprotocol.com>", "Piotr Mikulski <piotr@near.org"]
-publish = false
+authors = ["Near Inc <hello@nearprotocol.com>"]
+edition = "2021"
 # Please update rust-toolchain.toml as well when changing version here:
 rust-version = "1.56.0"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
-syn = { version = "1.0.54", features = ["full"] }
 quote = "1.0"
+syn = { version = "1.0.54", features = ["full"] }
 
 [lib]
 proc-macro = true

--- a/utils/near-performance-metrics-macros/src/lib.rs
+++ b/utils/near-performance-metrics-macros/src/lib.rs
@@ -79,41 +79,28 @@ fn perf_internal(_attr: TokenStream, item: TokenStream, debug: bool) -> TokenStr
     let item: syn::Item = syn::parse(item).expect("failed to parse input");
 
     if let syn::Item::Fn(mut func) = item {
-        let block = func.clone().block;
-
-        let function_body = quote! { #block };
+        let function_body = func.block;
 
         let new_body: TokenStream = if debug {
-            let b: TokenStream = quote! {
-                fn xxx() {
-                    use near_performance_metrics::stats::measure_performance_with_debug;
+            quote! (
+                {
                     near_performance_metrics::stats::measure_performance_with_debug(std::any::type_name::<Self>(), msg, move |msg| {
                         #function_body
                     })
                 }
-            }.into();
-            b
+            ).into()
         } else {
-            let b: TokenStream = quote! {
-                fn xxx() {
-                    use near_performance_metrics::stats::measure_performance;
+            quote! (
+                {
                     near_performance_metrics::stats::measure_performance(std::any::type_name::<Self>(), msg, move |msg| {
                         #function_body
                     })
                 }
-             }.into();
-            b
+             ).into()
         };
+        func.block = syn::parse::<syn::Block>(new_body).expect("failed to parse input").into();
 
-        if let syn::Item::Fn(func2) = syn::parse(new_body).expect("failed to parse input") {
-            func.block = func2.block;
-        } else {
-            panic!("failed to parse example function");
-        }
-
-        let result_item = syn::Item::Fn(func);
-        let output = quote! { #result_item };
-        output.into()
+        quote! ( #func ).into()
     } else {
         panic!("not a function");
     }

--- a/utils/near-performance-metrics/Cargo.toml
+++ b/utils/near-performance-metrics/Cargo.toml
@@ -1,29 +1,27 @@
 [package]
 name = "near-performance-metrics"
 version = "0.0.0"
-authors = ["Near Inc <hello@nearprotocol.com>", "Piotr Mikulski <piotr@near.org"]
-publish = false
+authors = ["Near Inc <hello@nearprotocol.com>"]
+edition = "2021"
 # Please update rust-toolchain.toml as well when changing version here:
 rust-version = "1.56.0"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
 actix = "=0.11.0-beta.2"
+bitflags = "1.2"
+bytes = "1"
+bytesize = "1.1"
 futures = "0.3.5"
+libc = "0.2"
 log = "0.4"
+near-rust-allocator-proxy = { version = "0.3.0", optional = true }
 once_cell = "1.5.2"
 strum = "0.20"
-near-rust-allocator-proxy = { version = "0.3.0", optional = true }
-libc = "0.2"
-bytesize = "1.1"
 tokio = { version = "1.1", features = ["net", "rt-multi-thread"] }
 tokio-util = { version = "0.6", features = ["codec"] }
-bytes = "1"
-bitflags = "1.2"
 
 [features]
-performance_stats = [ "near-rust-allocator-proxy" ]
-memory_stats = []
 c_memory_stats = []
+memory_stats = []
+performance_stats = ["near-rust-allocator-proxy"]

--- a/utils/near-rate-limiter/Cargo.toml
+++ b/utils/near-rate-limiter/Cargo.toml
@@ -2,18 +2,18 @@
 name = "near-rate-limiter"
 version = "0.0.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
-publish = false
+edition = "2021"
 # Please update rust-toolchain.toml as well when changing version here:
 rust-version = "1.56.0"
-edition = "2021"
+publish = false
 
 [dependencies]
 actix = "=0.11.0-beta.2"
 bytes = "1.0.0"
 futures-core = "0.3.0"
 pin-project-lite = "0.2.0"
-tokio-util = { version = "0.6.9", features = ["io", "codec"] }
-tokio = { version = "1.1", features = ["sync", "rt", "macros"] }
+tokio = { version = "1.1", features = ["macros", "rt", "sync"] }
+tokio-util = { version = "0.6.9", features = ["codec", "io"] }
 tracing = "0.1"
 
 [dev-dependencies]

--- a/utils/near-stable-hasher/Cargo.toml
+++ b/utils/near-stable-hasher/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "near-stable-hasher"
 version = "0.0.0"
-authors = ["Near Inc <hello@nearprotocol.com>", "Piotr Mikulski <piotr@near.org"]
-publish = false
+authors = ["Near Inc <hello@nearprotocol.com>"]
+edition = "2021"
 # Please update rust-toolchain.toml as well when changing version here:
 rust-version = "1.56.0"
-edition = "2021"
+publish = false


### PR DESCRIPTION
Let's format `Cargo.toml` files properly with order following https://doc.rust-lang.org/cargo/reference/manifest.html