### PR TITLE
refactor: Runtime structure now contains VMConfig

### DIFF
--- a/runtime/near-vm-runner-standalone/src/script.rs
+++ b/runtime/near-vm-runner-standalone/src/script.rs
@@ -127,7 +127,6 @@ impl Script {
                         &step.method,
                         &mut external,
                         step.vm_context.clone(),
-                        &self.vm_config,
                         runtime_fees_config,
                         &step.promise_results,
                         self.protocol_version,

--- a/runtime/near-vm-runner/fuzz/fuzz_targets/runner.rs
+++ b/runtime/near-vm-runner/fuzz/fuzz_targets/runner.rs
@@ -26,12 +26,11 @@ fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> (Option<VMOutcome>, Option<
     let promise_results = vec![];
 
     let method_name = find_entry_point(code).unwrap_or_else(|| "main".to_string());
-    vm_kind.runtime(config.clone()).unwrap().run(
+    vm_kind.runtime(config).unwrap().run(
         code,
         &method_name,
         &mut fake_external,
         context,
-        &config,
         &fees,
         &promise_results,
         PROTOCOL_VERSION,

--- a/runtime/near-vm-runner/src/runner.rs
+++ b/runtime/near-vm-runner/src/runner.rs
@@ -41,7 +41,6 @@ pub fn run(
             method_name,
             ext,
             context,
-            wasm_config,
             fees_config,
             promise_results,
             current_protocol_version,
@@ -69,7 +68,6 @@ pub trait VM {
         method_name: &str,
         ext: &mut dyn External,
         context: VMContext,
-        wasm_config: &VMConfig,
         fees_config: &RuntimeFeesConfig,
         promise_results: &[PromiseResult],
         current_protocol_version: ProtocolVersion,
@@ -84,7 +82,6 @@ pub trait VM {
         &self,
         code: &[u8],
         code_hash: &CryptoHash,
-        wasm_config: &VMConfig,
         cache: &dyn CompiledContractCache,
     ) -> Option<VMError>;
 
@@ -101,20 +98,11 @@ impl VMKind {
     pub fn runtime(&self, config: VMConfig) -> Option<Box<dyn VM>> {
         match self {
             #[cfg(feature = "wasmer0_vm")]
-            Self::Wasmer0 => {
-                use crate::wasmer_runner::Wasmer0VM;
-                Some(Box::new(Wasmer0VM))
-            }
+            Self::Wasmer0 => Some(Box::new(crate::wasmer_runner::Wasmer0VM::new(config))),
             #[cfg(feature = "wasmtime_vm")]
-            Self::Wasmtime => {
-                use crate::wasmtime_runner::WasmtimeVM;
-                Some(Box::new(WasmtimeVM))
-            }
+            Self::Wasmtime => Some(Box::new(crate::wasmtime_runner::WasmtimeVM::new(config))),
             #[cfg(feature = "wasmer2_vm")]
-            Self::Wasmer2 => {
-                use crate::wasmer2_runner::Wasmer2VM;
-                Some(Box::new(Wasmer2VM::new(config)))
-            }
+            Self::Wasmer2 => Some(Box::new(crate::wasmer2_runner::Wasmer2VM::new(config))),
             #[allow(unreachable_patterns)] // reachable when some of the VMs are disabled.
             _ => None,
         }

--- a/runtime/near-vm-runner/src/tests.rs
+++ b/runtime/near-vm-runner/src/tests.rs
@@ -70,13 +70,12 @@ fn make_simple_contract_call_with_gas_vm(
     let promise_results = vec![];
 
     let code = ContractCode::new(code.to_vec(), None);
-    let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
+    let runtime = vm_kind.runtime(config).expect("runtime has not been compiled");
     runtime.run(
         &code,
         method_name,
         &mut fake_external,
         context,
-        &config,
         &fees,
         &promise_results,
         LATEST_PROTOCOL_VERSION,
@@ -94,9 +93,9 @@ fn make_simple_contract_call_with_protocol_version_vm(
     let context = create_context(vec![]);
     let runtime_config_store = RuntimeConfigStore::new(None);
     let runtime_config = runtime_config_store.get_config(protocol_version);
-    let config = &runtime_config.wasm_config;
     let fees = &runtime_config.transaction_costs;
-    let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
+    let runtime =
+        vm_kind.runtime(runtime_config.wasm_config.clone()).expect("runtime has not been compiled");
 
     let promise_results = vec![];
     let code = ContractCode::new(code.to_vec(), None);
@@ -105,7 +104,6 @@ fn make_simple_contract_call_with_protocol_version_vm(
         method_name,
         &mut fake_external,
         context,
-        config,
         fees,
         &promise_results,
         protocol_version,

--- a/runtime/near-vm-runner/src/tests/cache.rs
+++ b/runtime/near-vm-runner/src/tests/cache.rs
@@ -71,14 +71,12 @@ fn make_cached_contract_call_vm(
     let promise_results = vec![];
     context.prepaid_gas = prepaid_gas;
     let code = ContractCode::new(code.to_vec(), None);
-    let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
-
+    let runtime = vm_kind.runtime(config).expect("runtime has not been compiled");
     runtime.run(
         &code,
         method_name,
         &mut fake_external,
         context.clone(),
-        &config,
         &fees,
         &promise_results,
         LATEST_PROTOCOL_VERSION,

--- a/runtime/near-vm-runner/src/tests/contract_preload.rs
+++ b/runtime/near-vm-runner/src/tests/contract_preload.rs
@@ -138,14 +138,13 @@ fn test_vm_runner(preloaded: bool, vm_kind: VMKind, repeat: i32) {
             errs += err;
         }
     } else {
-        let runtime = vm_kind.runtime(vm_config.clone()).expect("runtime is has not been compiled");
+        let runtime = vm_kind.runtime(vm_config).expect("runtime is has not been compiled");
         for _ in 0..repeat {
             let result1 = runtime.run(
                 &code1,
                 method_name1,
                 &mut fake_external,
                 context.clone(),
-                &vm_config,
                 &fees,
                 &promise_results,
                 ProtocolVersion::MAX,
@@ -159,7 +158,6 @@ fn test_vm_runner(preloaded: bool, vm_kind: VMKind, repeat: i32) {
                 method_name1,
                 &mut fake_external,
                 context.clone(),
-                &vm_config,
                 &fees,
                 &promise_results,
                 ProtocolVersion::MAX,

--- a/runtime/near-vm-runner/src/tests/rs_contract.rs
+++ b/runtime/near-vm-runner/src/tests/rs_contract.rs
@@ -61,13 +61,12 @@ pub fn test_read_write() {
         let fees = RuntimeFeesConfig::test();
 
         let promise_results = vec![];
-        let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
+        let runtime = vm_kind.runtime(config).expect("runtime has not been compiled");
         let result = runtime.run(
             &code,
             "write_key_value",
             &mut fake_external,
             context,
-            &config,
             &fees,
             &promise_results,
             LATEST_PROTOCOL_VERSION,
@@ -81,7 +80,6 @@ pub fn test_read_write() {
             "read_value",
             &mut fake_external,
             context,
-            &config,
             &fees,
             &promise_results,
             LATEST_PROTOCOL_VERSION,
@@ -102,13 +100,12 @@ pub fn test_stablized_host_function() {
         let fees = RuntimeFeesConfig::test();
 
         let promise_results = vec![];
-        let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
+        let runtime = vm_kind.runtime(config).expect("runtime has not been compiled");
         let result = runtime.run(
             &code,
             "do_ripemd",
             &mut fake_external,
             context.clone(),
-            &config,
             &fees,
             &promise_results,
             LATEST_PROTOCOL_VERSION,
@@ -121,7 +118,6 @@ pub fn test_stablized_host_function() {
             "do_ripemd",
             &mut fake_external,
             context,
-            &config,
             &fees,
             &promise_results,
             ProtocolFeature::MathExtension.protocol_version() - 1,
@@ -175,14 +171,13 @@ fn run_test_ext(
     let config = VMConfig::test();
     let fees = RuntimeFeesConfig::test();
     let context = create_context(input.to_vec());
-    let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
+    let runtime = vm_kind.runtime(config).expect("runtime has not been compiled");
 
     let (outcome, err) = runtime.run(
         &code,
         method,
         &mut fake_external,
         context,
-        &config,
         &fees,
         &[],
         LATEST_PROTOCOL_VERSION,
@@ -309,7 +304,7 @@ pub fn test_out_of_memory() {
         let context = create_context(Vec::new());
         let config = VMConfig::free();
         let fees = RuntimeFeesConfig::free();
-        let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
+        let runtime = vm_kind.runtime(config).expect("runtime has not been compiled");
 
         let promise_results = vec![];
         let result = runtime.run(
@@ -317,7 +312,6 @@ pub fn test_out_of_memory() {
             "out_of_memory",
             &mut fake_external,
             context,
-            &config,
             &fees,
             &promise_results,
             LATEST_PROTOCOL_VERSION,

--- a/runtime/near-vm-runner/src/tests/ts_contract.rs
+++ b/runtime/near-vm-runner/src/tests/ts_contract.rs
@@ -20,13 +20,12 @@ pub fn test_ts_contract() {
 
         // Call method that panics.
         let promise_results = vec![];
-        let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
+        let runtime = vm_kind.runtime(config).expect("runtime has not been compiled");
         let result = runtime.run(
             &code,
             "try_panic",
             &mut fake_external,
             context,
-            &config,
             &fees,
             &promise_results,
             LATEST_PROTOCOL_VERSION,
@@ -47,7 +46,6 @@ pub fn test_ts_contract() {
                 "try_storage_write",
                 &mut fake_external,
                 context,
-                &config,
                 &fees,
                 &promise_results,
                 LATEST_PROTOCOL_VERSION,
@@ -71,7 +69,6 @@ pub fn test_ts_contract() {
             "try_storage_read",
             &mut fake_external,
             context,
-            &config,
             &fees,
             &promise_results,
             LATEST_PROTOCOL_VERSION,

--- a/runtime/near-vm-runner/src/wasmer2_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer2_runner.rs
@@ -521,7 +521,6 @@ impl crate::runner::VM for Wasmer2VM {
         method_name: &str,
         ext: &mut dyn External,
         context: VMContext,
-        wasm_config: &VMConfig,
         fees_config: &RuntimeFeesConfig,
         promise_results: &[PromiseResult],
         current_protocol_version: ProtocolVersion,
@@ -544,15 +543,15 @@ impl crate::runner::VM for Wasmer2VM {
             );
         }
         let artifact =
-            cache::wasmer2_cache::compile_module_cached_wasmer2(code, wasm_config, cache);
+            cache::wasmer2_cache::compile_module_cached_wasmer2(code, &self.config, cache);
         let artifact = match into_vm_result(artifact) {
             Ok(it) => it,
             Err(err) => return (None, Some(err)),
         };
 
         let mut memory = Wasmer2Memory::new(
-            wasm_config.limit_config.initial_memory_pages,
-            wasm_config.limit_config.max_memory_pages,
+            self.config.limit_config.initial_memory_pages,
+            self.config.limit_config.max_memory_pages,
         )
         .expect("Cannot create memory for a contract call");
 
@@ -562,7 +561,7 @@ impl crate::runner::VM for Wasmer2VM {
         let mut logic = VMLogic::new_with_protocol_version(
             ext,
             context,
-            wasm_config,
+            &self.config,
             fees_config,
             promise_results,
             &mut memory,
@@ -589,13 +588,12 @@ impl crate::runner::VM for Wasmer2VM {
         &self,
         code: &[u8],
         code_hash: &near_primitives::hash::CryptoHash,
-        wasm_config: &VMConfig,
         cache: &dyn CompiledContractCache,
     ) -> Option<VMError> {
         let result = crate::cache::wasmer2_cache::compile_and_serialize_wasmer2(
             code,
             code_hash,
-            wasm_config,
+            &self.config,
             cache,
         );
         into_vm_result(result).err()

--- a/runtime/runtime-params-estimator/src/function_call.rs
+++ b/runtime/runtime-params-estimator/src/function_call.rs
@@ -103,7 +103,7 @@ pub fn compute_function_call_cost(
     let config_store = RuntimeConfigStore::new(None);
     let runtime_config = config_store.get_config(protocol_version).as_ref();
     let vm_config = runtime_config.wasm_config.clone();
-    let runtime = vm_kind.runtime(vm_config.clone()).expect("runtime has not been enabled");
+    let runtime = vm_kind.runtime(vm_config).expect("runtime has not been enabled");
     let fees = runtime_config.transaction_costs.clone();
     let mut fake_external = MockedExternal::new();
     let fake_context = create_context(vec![]);
@@ -116,7 +116,6 @@ pub fn compute_function_call_cost(
             "hello0",
             &mut fake_external,
             fake_context.clone(),
-            &vm_config,
             &fees,
             &promise_results,
             protocol_version,
@@ -132,7 +131,6 @@ pub fn compute_function_call_cost(
             "hello0",
             &mut fake_external,
             fake_context.clone(),
-            &vm_config,
             &fees,
             &promise_results,
             protocol_version,

--- a/runtime/runtime-params-estimator/src/gas_metering.rs
+++ b/runtime/runtime-params-estimator/src/gas_metering.rs
@@ -145,7 +145,7 @@ pub fn compute_gas_metering_cost(
     let config_store = RuntimeConfigStore::new(None);
     let runtime_config = config_store.get_config(PROTOCOL_VERSION).as_ref();
     let vm_config_gas = runtime_config.wasm_config.clone();
-    let runtime = vm_kind.runtime(vm_config_gas.clone()).expect("runtime has not been enabled");
+    let runtime = vm_kind.runtime(vm_config_gas).expect("runtime has not been enabled");
     let fees = runtime_config.transaction_costs.clone();
     let mut fake_external = MockedExternal::new();
     let fake_context = create_context(vec![]);
@@ -157,7 +157,6 @@ pub fn compute_gas_metering_cost(
         "hello",
         &mut fake_external,
         fake_context.clone(),
-        &vm_config_gas,
         &fees,
         &promise_results,
         PROTOCOL_VERSION,
@@ -177,7 +176,6 @@ pub fn compute_gas_metering_cost(
             "hello",
             &mut fake_external,
             fake_context.clone(),
-            &vm_config_gas,
             &fees,
             &promise_results,
             PROTOCOL_VERSION,
@@ -188,12 +186,12 @@ pub fn compute_gas_metering_cost(
     let total_raw_with_gas = start.elapsed().to_gas();
 
     let vm_config_no_gas = VMConfig::free();
+    let runtime = vm_kind.runtime(vm_config_no_gas).expect("runtime has not been enabled");
     let result = runtime.run(
         contract,
         "hello",
         &mut fake_external,
         fake_context.clone(),
-        &vm_config_no_gas,
         &fees,
         &promise_results,
         PROTOCOL_VERSION,
@@ -207,7 +205,6 @@ pub fn compute_gas_metering_cost(
             "hello",
             &mut fake_external,
             fake_context.clone(),
-            &vm_config_no_gas,
             &fees,
             &promise_results,
             PROTOCOL_VERSION,

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -617,7 +617,6 @@ fn wasm_instruction(ctx: &mut EstimatorContext) -> GasCost {
             "cpu_ram_soak_test",
             &mut fake_external,
             context,
-            &config,
             &fees,
             &promise_results,
             PROTOCOL_VERSION,

--- a/runtime/runtime-params-estimator/src/vm_estimator.rs
+++ b/runtime/runtime-params-estimator/src/vm_estimator.rs
@@ -271,7 +271,7 @@ fn test_many_contracts_call(gas_metric: GasMetric, vm_kind: VMKind) {
     let fees = RuntimeFeesConfig::test();
 
     let start = GasCost::measure(gas_metric);
-    if let Some(runtime) = vm_kind.runtime(vm_config.clone()) {
+    if let Some(runtime) = vm_kind.runtime(vm_config) {
         for contract in &contracts {
             let promise_results = vec![];
             let result = runtime.run(
@@ -279,7 +279,6 @@ fn test_many_contracts_call(gas_metric: GasMetric, vm_kind: VMKind) {
                 "hello",
                 &mut fake_external,
                 fake_context.clone(),
-                &vm_config,
                 &fees,
                 &promise_results,
                 ProtocolVersion::MAX,


### PR DESCRIPTION
Conceptually this matches what is happening somewhat better – VM is
constructed as configured in some specific way and then can be used to
run multiple contracts or somesuch, as long as the configuration
matches.

This kind of construction can help, in the future, to reuse more state
between contract invocations. Since `VMConfig` doesn't change within the
same run of `neard` typically, we could reuse the same memory map to
hold the contract code and cache the allocation of the working memory as
well (so long as we clear it between contract invocations), thus saving
on page faults and similar cost centres.