### PR TITLE
chore: add Longarithm to test-contract owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,7 +13,7 @@
 
 /runtime/ @bowenwang1996 @EgorKulikov @mzhangmzz @mm-near
 /runtime/runtime-params-estimator/ @olonho @matklad @jakmeier
-/runtime/near-test-contracts/ @olonho @matklad
+/runtime/near-test-contracts/ @olonho @matklad @Longarithm
 /runtime/near-vm-runner-standalone/ @olonho @matklad @nagisa
 /runtime/near-vm-runner/ @olonho @matklad @nagisa
 


### PR DESCRIPTION
Test contracts is something transaction runtime might want to use as
well, so it makes sense to make ownership more cross-team.