### PR TITLE
Add database cache settings to config.json

### DIFF
--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -20,7 +20,7 @@ use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{AccountId, BlockHeight, EpochId, GCCount};
 use near_primitives::utils::get_block_shard_id_rev;
 use near_store::{
-    decode_value_with_rc, DBCol, Store, TrieChanges, NUM_COLS, SHOULD_COL_GC, SKIP_COL_GC,
+    decode_value_with_rc, DBCol, Store, TrieChanges, NUM_DB_COLS, SHOULD_COL_GC, SKIP_COL_GC,
 };
 use validate::StoreValidatorError;
 
@@ -56,7 +56,7 @@ impl StoreValidatorCache {
             tail: 0,
             chunk_tail: 0,
             block_heights_less_tail: vec![],
-            gc_col: vec![0; NUM_COLS],
+            gc_col: vec![0; NUM_DB_COLS],
             tx_refcount: HashMap::new(),
             receipt_refcount: HashMap::new(),
             block_refcount: HashMap::new(),
@@ -355,7 +355,7 @@ impl StoreValidator {
             }
             if let Some(timeout) = self.timeout {
                 if self.start_time.elapsed() > Duration::from_millis(timeout) {
-                    warn!(target: "adversary", "Store validator hit timeout at {:?} ({:?}/{:?})", col, col as usize, NUM_COLS);
+                    warn!(target: "adversary", "Store validator hit timeout at {:?} ({:?}/{:?})", col, col as usize, NUM_DB_COLS);
                     return;
                 }
             }

--- a/chain/chain/src/store_validator/validate.rs
+++ b/chain/chain/src/store_validator/validate.rs
@@ -19,7 +19,7 @@ use near_store::{
     ColBlock, ColBlockHeader, ColBlockHeight, ColBlockInfo, ColBlockMisc, ColBlockPerHeight,
     ColChunkExtra, ColChunkHashesByHeight, ColChunks, ColHeaderHashesByHeight, ColOutcomeIds,
     ColStateHeaders, ColTransactionResult, DBCol, TrieChanges, TrieIterator, CHUNK_TAIL_KEY,
-    FORK_TAIL_KEY, HEADER_HEAD_KEY, HEAD_KEY, NUM_COLS, SHOULD_COL_GC, TAIL_KEY,
+    FORK_TAIL_KEY, HEADER_HEAD_KEY, HEAD_KEY, NUM_DB_COLS, SHOULD_COL_GC, TAIL_KEY,
 };
 
 use crate::StoreValidator;
@@ -908,7 +908,7 @@ pub(crate) fn gc_col_count_final(sv: &mut StoreValidator) -> Result<(), StoreVal
         }
     }
     // 1. All zeroes case is acceptable
-    if zeroes == NUM_COLS {
+    if zeroes == NUM_DB_COLS {
         return Ok(());
     }
     let mut gc_col_count = 0;
@@ -918,7 +918,7 @@ pub(crate) fn gc_col_count_final(sv: &mut StoreValidator) -> Result<(), StoreVal
         }
     }
     // 2. All columns are GCed case is acceptable
-    if zeroes == NUM_COLS - gc_col_count {
+    if zeroes == NUM_DB_COLS - gc_col_count {
         return Ok(());
     }
     // TODO #2861 build a graph of dependencies or make it better in another way

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -49,6 +49,8 @@ impl Into<io::Error> for DBError {
 /// This enum holds the information about the columns that we use within the RocksDB storage.
 /// You can think about our storage as 2-dimensional table (with key and column as indexes/coordinates).
 // TODO(mm-near): add info about the RC in the columns.
+pub const NUM_DB_COLS: usize = 50;
+
 #[derive(PartialEq, Debug, Copy, Clone, EnumIter, BorshDeserialize, BorshSerialize, Hash, Eq)]
 pub enum DBCol {
     /// Column to indicate which version of database this is.
@@ -201,9 +203,6 @@ pub enum DBCol {
     ColStateChangesForSplitStates = 49,
 }
 
-// Do not move this line from enum DBCol
-pub const NUM_COLS: usize = 50;
-
 impl std::fmt::Display for DBCol {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         let desc = match self {
@@ -272,8 +271,8 @@ impl DBCol {
 
 // List of columns for which GC should be implemented
 
-pub static SHOULD_COL_GC: [bool; NUM_COLS] = {
-    let mut col_gc = [true; NUM_COLS];
+pub static SHOULD_COL_GC: [bool; NUM_DB_COLS] = {
+    let mut col_gc = [true; NUM_DB_COLS];
     col_gc[DBCol::ColDbVersion as usize] = false; // DB version is unrelated to GC
     col_gc[DBCol::ColBlockMisc as usize] = false;
     // TODO #3488 remove
@@ -297,8 +296,8 @@ pub static SHOULD_COL_GC: [bool; NUM_COLS] = {
 
 // List of columns for which GC may not be executed even in fully operational node
 
-pub static SKIP_COL_GC: [bool; NUM_COLS] = {
-    let mut col_gc = [false; NUM_COLS];
+pub static SKIP_COL_GC: [bool; NUM_DB_COLS] = {
+    let mut col_gc = [false; NUM_DB_COLS];
     // A node may never restarted
     col_gc[DBCol::ColStateHeaders as usize] = true;
     // True until #2515
@@ -308,8 +307,8 @@ pub static SKIP_COL_GC: [bool; NUM_COLS] = {
 
 // List of reference counted columns
 
-pub static IS_COL_RC: [bool; NUM_COLS] = {
-    let mut col_rc = [false; NUM_COLS];
+pub static IS_COL_RC: [bool; NUM_DB_COLS] = {
+    let mut col_rc = [false; NUM_DB_COLS];
     col_rc[DBCol::ColState as usize] = true;
     col_rc[DBCol::ColTransactions as usize] = true;
     col_rc[DBCol::ColReceipts as usize] = true;
@@ -475,7 +474,11 @@ impl RocksDBOptions {
     }
 
     /// Opens the database in read/write mode.
-    pub fn read_write<P: AsRef<std::path::Path>>(self, path: P) -> Result<RocksDB, DBError> {
+    pub fn read_write<P: AsRef<std::path::Path>>(
+        self,
+        path: P,
+        extra_db_memory: usize,
+    ) -> Result<RocksDB, DBError> {
         use strum::IntoEnumIterator;
         let options = self.rocksdb_options.unwrap_or_else(rocksdb_options);
         let cf_names = self
@@ -486,7 +489,7 @@ impl RocksDBOptions {
                 .map(|col| {
                     ColumnFamilyDescriptor::new(
                         format!("col{}", col as usize),
-                        rocksdb_column_options(col),
+                        rocksdb_column_options(col, extra_db_memory),
                     )
                 })
                 .collect()
@@ -751,11 +754,15 @@ fn choose_cache_size(col: DBCol) -> usize {
     }
 }
 
-fn rocksdb_column_options(col: DBCol) -> Options {
+fn rocksdb_column_options(col: DBCol, extra_db_memory: usize) -> Options {
     let mut opts = Options::default();
     opts.set_level_compaction_dynamic_level_bytes(true);
-    let cache_size = choose_cache_size(col);
-    opts.set_block_based_table_factory(&rocksdb_block_based_options(cache_size));
+
+    // In config there is `extra_db_memory_bytes` setting. It specifies extra memory tht can be used
+    // to improve database performance. For now, let's simply add the same cache size for each column.
+    // We can add a better way of using extra memory later.
+    let cache_size = choose_cache_size(col) + extra_db_memory / NUM_DB_COLS;
+    opts.set_block_based_table_factory(&rocksdb_block_based_options(cache_size as usize));
     opts.optimize_level_style_compaction(128 * bytesize::MIB as usize);
     opts.set_target_file_size_base(64 * bytesize::MIB);
     opts.set_compression_per_level(&[]);
@@ -783,8 +790,11 @@ impl RocksDB {
         RocksDBOptions::default().read_only(path)
     }
 
-    pub fn new<P: AsRef<std::path::Path>>(path: P) -> Result<Self, DBError> {
-        RocksDBOptions::default().read_write(path)
+    pub fn new<P: AsRef<std::path::Path>>(
+        path: P,
+        extra_db_memory: usize,
+    ) -> Result<Self, DBError> {
+        RocksDBOptions::default().read_write(path, extra_db_memory)
     }
 
     /// Checks if there is enough memory left to perform a write. Not having enough memory left can
@@ -850,7 +860,7 @@ impl Drop for RocksDB {
 
 impl TestDB {
     pub fn new() -> Self {
-        let db: Vec<_> = (0..NUM_COLS).map(|_| HashMap::new()).collect();
+        let db: Vec<_> = (0..NUM_DB_COLS).map(|_| HashMap::new()).collect();
         Self { db: RwLock::new(db) }
     }
 }
@@ -886,7 +896,7 @@ mod tests {
     #[test]
     fn test_prewrite_check() {
         let tmp_dir = tempfile::Builder::new().prefix("_test_prewrite_check").tempdir().unwrap();
-        let store = RocksDB::new(tmp_dir).unwrap();
+        let store = RocksDB::new(tmp_dir, 0).unwrap();
         store.pre_write_check().unwrap()
     }
 

--- a/core/store/src/db/v6_to_v7.rs
+++ b/core/store/src/db/v6_to_v7.rs
@@ -73,6 +73,7 @@ impl RocksDB {
                     })
                     .collect(),
             )
-            .read_write(path, extra_db_memory)
+            .extra_db_memory(extra_db_memory)
+            .read_write(path)
     }
 }

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -13,7 +13,7 @@ use cached::{Cached, SizedCache};
 pub use db::DBCol::{self, *};
 pub use db::{
     CHUNK_TAIL_KEY, FINAL_HEAD_KEY, FORK_TAIL_KEY, HEADER_HEAD_KEY, HEAD_KEY,
-    LARGEST_TARGET_HEIGHT_KEY, LATEST_KNOWN_KEY, NUM_COLS, SHOULD_COL_GC, SKIP_COL_GC, TAIL_KEY,
+    LARGEST_TARGET_HEIGHT_KEY, LATEST_KNOWN_KEY, NUM_DB_COLS, SHOULD_COL_GC, SKIP_COL_GC, TAIL_KEY,
 };
 use near_crypto::PublicKey;
 use near_primitives::account::{AccessKey, Account};
@@ -296,7 +296,12 @@ pub fn read_with_cache<'a, T: BorshDeserialize + 'a>(
 }
 
 pub fn create_store(path: &Path) -> Arc<Store> {
-    let db = Arc::pin(RocksDB::new(path).expect("Failed to open the database"));
+    let db = Arc::pin(RocksDB::new(path, 0).expect("Failed to open the database"));
+    Arc::new(Store::new(db))
+}
+
+pub fn create_store_with_extra_cache(path: &Path, extra_db_memory: usize) -> Arc<Store> {
+    let db = Arc::pin(RocksDB::new(path, extra_db_memory).expect("Failed to open the database"));
     Arc::new(Store::new(db))
 }
 

--- a/core/store/src/migrations.rs
+++ b/core/store/src/migrations.rs
@@ -137,7 +137,7 @@ fn recompute_block_ordinal(store: &Store) {
 }
 
 pub fn migrate_6_to_7(path: &Path) {
-    let db = Arc::pin(RocksDB::new_v6(path).expect("Failed to open the database"));
+    let db = Arc::pin(RocksDB::new_v6(path, 0).expect("Failed to open the database"));
     let store = Store::new(db);
     let mut store_update = store.store_update();
     col_state_refcount_8byte(&store, &mut store_update);

--- a/genesis-tools/genesis-populate/src/main.rs
+++ b/genesis-tools/genesis-populate/src/main.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use clap::{App, Arg};
 
-use near_store::create_store;
+use near_store::create_store_with_extra_cache;
 use nearcore::{get_default_home, get_store_path, load_config};
 
 use genesis_populate::GenesisBuilder;
@@ -28,7 +28,10 @@ fn main() {
         .unwrap();
     let near_config = load_config(home_dir);
 
-    let store = create_store(&get_store_path(home_dir));
+    let store = create_store_with_extra_cache(
+        &get_store_path(home_dir),
+        near_config.config.extra_db_memory_bytes,
+    );
     GenesisBuilder::from_config_and_store(home_dir, Arc::new(near_config.genesis), store)
         .add_additional_accounts(additional_accounts_num)
         .add_additional_accounts_contract(near_test_contracts::trivial_contract().to_vec())

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -433,6 +433,8 @@ pub struct Config {
     /// If set, overrides value in genesis configuration.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_gas_burnt_view: Option<Gas>,
+    /// Extra memory database can use for purpose of caches.
+    pub extra_db_memory_bytes: usize,
 }
 
 impl Default for Config {
@@ -459,6 +461,7 @@ impl Default for Config {
             view_client_throttle_period: default_view_client_throttle_period(),
             trie_viewer_state_size_limit: default_trie_viewer_state_size_limit(),
             max_gas_burnt_view: None,
+            extra_db_memory_bytes: 0,
         }
     }
 }

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -26,7 +26,7 @@ use near_store::migrations::{
     migrate_21_to_22, migrate_25_to_26, migrate_26_to_27, migrate_28_to_29, migrate_29_to_30,
     migrate_6_to_7, migrate_7_to_8, migrate_8_to_9, migrate_9_to_10, set_store_version,
 };
-use near_store::{create_store, Store};
+use near_store::{create_store, create_store_with_extra_cache, Store};
 use near_telemetry::TelemetryActor;
 
 pub use crate::config::{init_configs, load_config, load_test_config, NearConfig, NEAR_BASE};
@@ -281,7 +281,7 @@ pub fn init_and_migrate_store(home_dir: &Path, near_config: &NearConfig) -> Arc<
     if store_exists {
         apply_store_migrations(&path, near_config);
     }
-    let store = create_store(&path);
+    let store = create_store_with_extra_cache(&path, near_config.config.extra_db_memory_bytes);
     if !store_exists {
         set_store_version(&store, near_primitives::version::DB_VERSION);
     }

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use clap::Clap;
 use genesis_populate::GenesisBuilder;
 use near_primitives::version::PROTOCOL_VERSION;
-use near_store::create_store_with_extra_cache;
+use near_store::create_store;
 use near_vm_runner::internal::VMKind;
 use nearcore::{get_store_path, load_config};
 use runtime_params_estimator::config::{Config, GasMetric};
@@ -120,10 +120,7 @@ fn main() -> anyhow::Result<()> {
             .expect("failed to init config");
 
             let near_config = load_config(&state_dump_path);
-            let store = create_store_with_extra_cache(
-                &get_store_path(&state_dump_path),
-                near_config.config.extra_db_memory_bytes,
-            );
+            let store = create_store(&get_store_path(&state_dump_path));
             GenesisBuilder::from_config_and_store(
                 &state_dump_path,
                 Arc::new(near_config.genesis),

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use clap::Clap;
 use genesis_populate::GenesisBuilder;
 use near_primitives::version::PROTOCOL_VERSION;
-use near_store::create_store;
+use near_store::create_store_with_extra_cache;
 use near_vm_runner::internal::VMKind;
 use nearcore::{get_store_path, load_config};
 use runtime_params_estimator::config::{Config, GasMetric};
@@ -120,7 +120,10 @@ fn main() -> anyhow::Result<()> {
             .expect("failed to init config");
 
             let near_config = load_config(&state_dump_path);
-            let store = create_store(&get_store_path(&state_dump_path));
+            let store = create_store_with_extra_cache(
+                &get_store_path(&state_dump_path),
+                near_config.config.extra_db_memory_bytes,
+            );
             GenesisBuilder::from_config_and_store(
                 &state_dump_path,
                 Arc::new(near_config.genesis),

--- a/test-utils/store-validator/src/main.rs
+++ b/test-utils/store-validator/src/main.rs
@@ -8,7 +8,7 @@ use clap::{App, Arg, SubCommand};
 use near_chain::store_validator::StoreValidator;
 use near_chain::RuntimeAdapter;
 use near_logger_utils::init_integration_logger;
-use near_store::create_store;
+use near_store::create_store_with_extra_cache;
 use nearcore::{get_default_home, get_store_path, load_config, TrackedConfig};
 
 fn main() {
@@ -29,7 +29,10 @@ fn main() {
     let home_dir = matches.value_of("home").map(Path::new).unwrap();
     let near_config = load_config(home_dir);
 
-    let store = create_store(&get_store_path(home_dir));
+    let store = create_store_with_extra_cache(
+        &get_store_path(home_dir),
+        near_config.config.extra_db_memory_bytes,
+    );
 
     let runtime_adapter: Arc<dyn RuntimeAdapter> = Arc::new(nearcore::NightshadeRuntime::new(
         home_dir,

--- a/tools/restored-receipts-verifier/src/main.rs
+++ b/tools/restored-receipts-verifier/src/main.rs
@@ -7,7 +7,7 @@ use clap::{App, Arg};
 use near_chain::{ChainStore, ChainStoreAccess, RuntimeAdapter};
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::Receipt;
-use near_store::create_store;
+use near_store::create_store_with_extra_cache;
 use nearcore::migrations::load_migration_data;
 use nearcore::{get_default_home, get_store_path, load_config, NightshadeRuntime, TrackedConfig};
 
@@ -45,7 +45,10 @@ fn main() -> Result<()> {
     let shard_id = 0u64;
     let home_dir = matches.value_of("home").map(Path::new).unwrap();
     let near_config = load_config(home_dir);
-    let store = create_store(&get_store_path(home_dir));
+    let store = create_store_with_extra_cache(
+        &get_store_path(home_dir),
+        near_config.config.extra_db_memory_bytes,
+    );
     let mut chain_store = ChainStore::new(store.clone(), near_config.genesis.config.genesis_height);
     let runtime = NightshadeRuntime::new(
         home_dir,


### PR DESCRIPTION
Hey, this is another epic change. We will add cache configuration for our store. to `config.json`
However, some big changes are needed.

This will allow us to specify cache, for db columns, etc. 

Resolves https://github.com/near/nearcore/issues/5255

TODO
- [x] Test on a node