### PR TITLE
re: Refactor `PeerManagerActor` pt 1

### DIFF
--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -522,19 +522,14 @@ impl PeerManagerActor {
         });
     }
 
-    fn num_connected_peers(&self) -> usize {
-        self.connected_peers.len()
-    }
-
-    fn is_blacklisted(&self, addr: &SocketAddr) -> bool {
-        if let Some(blocked_ports) = self.config.blacklist.get(&addr.ip()) {
-            match blocked_ports {
-                BlockedPorts::All => true,
-                BlockedPorts::Some(ports) => ports.contains(&addr.port()),
-            }
-        } else {
-            false
-        }
+    fn is_blacklisted(
+        blacklist: &HashMap<std::net::IpAddr, BlockedPorts>,
+        addr: &SocketAddr,
+    ) -> bool {
+        blacklist.get(&addr.ip()).map_or(false, |blocked_ports| match blocked_ports {
+            BlockedPorts::All => true,
+            BlockedPorts::Some(ports) => ports.contains(&addr.port()),
+        })
     }
 
     #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
@@ -919,28 +914,16 @@ impl PeerManagerActor {
         });
     }
 
-    fn num_connected_outgoing_peers(&self) -> usize {
-        self.connected_peers
-            .values()
-            .filter(|active_peer| active_peer.peer_type == PeerType::Outbound)
-            .count()
-    }
-
-    fn num_archival_peers(&self) -> usize {
-        self.connected_peers
-            .values()
-            .filter(|active_peer| active_peer.full_peer_info.chain_info.archival)
-            .count()
-    }
-
     /// Check if it is needed to create a new outbound connection.
     /// If the number of active connections is less than `ideal_connections_lo` or
     /// (the number of outgoing connections is less than `minimum_outbound_peers`
     ///     and the total connections is less than `max_num_peers`)
     fn is_outbound_bootstrap_needed(&self) -> bool {
         let total_connections = self.connected_peers.len() + self.outgoing_peers.len();
-        let potential_outgoing_connections =
-            self.num_connected_outgoing_peers() + self.outgoing_peers.len();
+        let potential_outgoing_connections = (self.connected_peers.values())
+            .filter(|connected_peer| connected_peer.peer_type == PeerType::Outbound)
+            .count()
+            + self.outgoing_peers.len();
 
         (total_connections < self.config.ideal_connections_lo as usize
             || (total_connections < self.config.max_num_peers as usize
@@ -955,10 +938,8 @@ impl PeerManagerActor {
     /// Returns single random peer with close to the highest height
     fn highest_height_peers(&self) -> Vec<FullPeerInfo> {
         // This finds max height among peers, and returns one peer close to such height.
-        let max_height = match self
-            .connected_peers
-            .values()
-            .map(|active_peers| active_peers.full_peer_info.chain_info.height)
+        let max_height = match (self.connected_peers.values())
+            .map(|connected_peer| connected_peer.full_peer_info.chain_info.height)
             .max()
         {
             Some(height) => height,
@@ -1167,7 +1148,10 @@ impl PeerManagerActor {
         // Build safe set
         let mut safe_set = HashSet::new();
 
-        if self.num_connected_outgoing_peers() + self.outgoing_peers.len()
+        if (self.connected_peers.values())
+            .filter(|active_peer| active_peer.peer_type == PeerType::Outbound)
+            .count()
+            + self.outgoing_peers.len()
             <= self.config.minimum_outbound_peers as usize
         {
             for (peer, active) in self.connected_peers.iter() {
@@ -1178,7 +1162,9 @@ impl PeerManagerActor {
         }
 
         if self.config.archive
-            && self.num_archival_peers()
+            && (self.connected_peers.values())
+                .filter(|connected_peer| connected_peer.full_peer_info.chain_info.archival)
+                .count()
                 <= self.config.archival_peer_connections_lower_bound as usize
         {
             for (peer, active) in self.connected_peers.iter() {
@@ -1189,9 +1175,7 @@ impl PeerManagerActor {
         }
 
         // Find all recent connections
-        let mut recent_connections = self
-            .connected_peers
-            .iter()
+        let mut recent_connections = (self.connected_peers.iter())
             .filter_map(|(peer_id, active)| {
                 if active.last_time_received_message.elapsed() < self.config.peer_recent_time_window
                 {
@@ -1515,12 +1499,14 @@ impl PeerManagerActor {
     }
 
     // Determine if the given target is referring to us.
-    fn message_for_me(&mut self, target: &PeerIdOrHash) -> bool {
+    fn message_for_me(
+        routing_table_view: &mut RoutingTableView,
+        my_peer_id: &PeerId,
+        target: &PeerIdOrHash,
+    ) -> bool {
         match target {
-            PeerIdOrHash::PeerId(peer_id) => peer_id == &self.my_peer_id,
-            PeerIdOrHash::Hash(hash) => {
-                self.routing_table_view.compare_route_back(*hash, &self.my_peer_id)
-            }
+            PeerIdOrHash::PeerId(peer_id) => peer_id == my_peer_id,
+            PeerIdOrHash::Hash(hash) => routing_table_view.compare_route_back(*hash, my_peer_id),
         }
     }
 
@@ -1558,7 +1544,7 @@ impl PeerManagerActor {
     }
 
     /// Handle pong messages. Add pong temporary to the routing table, mostly used for testing.
-    fn handle_pong(&mut self, _ctx: &mut Context<Self>, pong: Pong) {
+    fn handle_pong(&mut self, pong: Pong) {
         self.routing_table_view.add_pong(pong);
     }
 
@@ -1570,7 +1556,7 @@ impl PeerManagerActor {
                 .values()
                 .map(|a| a.full_peer_info.clone())
                 .collect::<Vec<_>>(),
-            num_connected_peers: self.num_connected_peers(),
+            num_connected_peers: self.connected_peers.len(),
             peer_max_count: self.config.max_num_peers,
             highest_height_peers: self.highest_height_peers(),
             sent_bytes_per_sec,
@@ -2122,7 +2108,9 @@ impl PeerManagerActor {
         let _d = delay_detector::DelayDetector::new("consolidate".into());
 
         // Check if this is a blacklisted peer.
-        if msg.peer_info.addr.as_ref().map_or(true, |addr| self.is_blacklisted(addr)) {
+        if (msg.peer_info.addr.as_ref())
+            .map_or(true, |addr| Self::is_blacklisted(&self.config.blacklist, addr))
+        {
             debug!(target: "network", peer_info = ?msg.peer_info, "Dropping connection from blacklisted peer or unknown address");
             return RegisterPeerResponse::Reject;
         }
@@ -2329,12 +2317,12 @@ impl PeerManagerActor {
             self.routing_table_view.add_route_back(msg.hash(), from.clone());
         }
 
-        if self.message_for_me(&msg.target) {
+        if Self::message_for_me(&mut self.routing_table_view, &self.my_peer_id, &msg.target) {
             // Handle Ping and Pong message if they are for us without sending to client.
             // i.e. Return false in case of Ping and Pong
             match &msg.body {
                 RoutedMessageBody::Ping(ping) => self.handle_ping(ctx, ping.clone(), msg.hash()),
-                RoutedMessageBody::Pong(pong) => self.handle_pong(ctx, pong.clone()),
+                RoutedMessageBody::Pong(pong) => self.handle_pong(pong.clone()),
                 _ => return true,
             }
 


### PR DESCRIPTION
In order to improve readability of `PeerManagerActor`, we should remove the methods that don't really need `self`.

This can be done by either in-lining the code, or changing `self` method to be `Self` method.