### PR TITLE
re: `PeerManagerActor` Simplify `send_message`

### DIFF
--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -446,7 +446,6 @@ impl RoutingTableActor {
                     act.peers_to_ban.push(peer_id);
                 }
             })
-            .map(|_, _, _| ())
             .spawn(ctx);
 
         true


### PR DESCRIPTION
`send_message` function can be simplified in `PeerManagerActor` by changing it's signature from `self` to `Self`.

This is important step for adding tests to `PeerManagerActor` .