### PR TITLE
feat: Reintroduce single_thread_rocksdb

### DIFF
--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -46,6 +46,7 @@ harness = false
 [features]
 default = []
 no_cache = []
+single_thread_rocksdb = []
 test_features = []
 protocol_feature_chunk_only_producers = []
 nightly_protocol = []

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -46,7 +46,7 @@ harness = false
 [features]
 default = []
 no_cache = []
-single_thread_rocksdb = []
+single_thread_rocksdb = [] # Deactivate RocksDB IO background threads
 test_features = []
 protocol_feature_chunk_only_producers = []
 nightly_protocol = []


### PR DESCRIPTION
This has been temporarily removed from Cargo.toml to wait for
a rocksdb release (see #3835)

Test plan
---------
Running existing store tests but with --features single_thread_rocksdb