### PR TITLE
fix(chain): fix `test_clear_old_data_too_many_heights` test

### DIFF
--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -3415,8 +3415,8 @@ mod tests {
             let mut store_update = chain.mut_store().store_update();
             store_update.save_block(block.clone());
             store_update.inc_block_refcount(block.header().prev_hash()).unwrap();
-            store_update.save_head(&Tip::from_header(&block.header())).unwrap();
             store_update.save_block_header(block.header().clone()).unwrap();
+            store_update.save_head(&Tip::from_header(&block.header())).unwrap();
             {
                 let mut store_update = store_update.store().store_update();
                 let block_info = BlockInfo::default();


### PR DESCRIPTION
Commit 3179d756: ‘fix block ordinal computation’ broke the tests which
wasn’t caught immediately by CI because it’s an expensive test and
those are only run nightly.

Fix the test the same way `test_clear_old_data_fixed_height` was fixed
in the aforementioned commit.