### PR TITLE
chain: simplify `.mut_store().store_update().store().store_update()`

### DIFF
--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -3401,7 +3401,7 @@ mod tests {
         let mut prev_block = genesis.clone();
         let mut blocks = vec![prev_block.clone()];
         {
-            let mut store_update = chain.mut_store().store_update().store().store_update();
+            let mut store_update = chain.store().store().store_update();
             let block_info = BlockInfo::default();
             store_update
                 .set_ser(DBCol::ColBlockInfo, genesis.hash().as_ref(), &block_info)


### PR DESCRIPTION
First of all, the `mut_store()` call is not necessary and instead
`store()` is sufficient.

Secend of all, `store_update().store()` is just a convoluted way to
get to the `Store` from a `ChainStore`.  The same can be achieved by
calling `store()` directly on `ChainStore` object.