### PR TITLE
feat: Print cargo test output only on error.

### DIFF
--- a/test-utils/logger/src/lib.rs
+++ b/test-utils/logger/src/lib.rs
@@ -20,7 +20,7 @@ fn setup_subscriber_from_filter(mut env_filter: EnvFilter) {
     let _ = tracing_subscriber::fmt::Subscriber::builder()
         .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
         .with_env_filter(env_filter)
-        .with_writer(std::io::stderr)
+        .with_writer(tracing_subscriber::fmt::TestWriter::new())
         .try_init();
 }
 


### PR DESCRIPTION
Change logger to print output of `cargo test` correctly.

https://github.com/near/nearcore/issues/4490#issuecomment-1007554120