### PR TITLE
re: Remove unused dependencies for `near-network`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3074,7 +3074,6 @@ dependencies = [
  "reed-solomon-erasure",
  "serde",
  "serde_json",
- "sha2",
  "smart-default",
 ]
 
@@ -3141,7 +3140,6 @@ dependencies = [
 name = "near-rpc-error-core"
 version = "0.0.0"
 dependencies = [
- "proc-macro2",
  "quote",
  "serde",
  "serde_json",
@@ -3153,8 +3151,6 @@ name = "near-rpc-error-macro"
 version = "0.0.0"
 dependencies = [
  "near-rpc-error-core",
- "proc-macro2",
- "quote",
  "serde",
  "serde_json",
  "syn",
@@ -3188,16 +3184,13 @@ dependencies = [
  "derive_more",
  "elastic-array",
  "fs2",
- "lazy_static",
  "lru",
  "near-crypto",
  "near-primitives",
  "num_cpus",
  "rand 0.7.3",
  "rocksdb",
- "serde",
  "serde_json",
- "smart-default",
  "strum",
  "tempfile",
  "thiserror",
@@ -3234,7 +3227,6 @@ version = "0.0.0"
 dependencies = [
  "borsh 0.9.1",
  "deepsize",
- "hex",
  "near-account-id",
  "near-rpc-error-macro",
  "serde",

--- a/core/primitives-core/Cargo.toml
+++ b/core/primitives-core/Cargo.toml
@@ -19,11 +19,13 @@ bs58 = "0.4"
 derive_more = "0.99.3"
 num-rational = { version = "0.3.1", features = ["serde"]}
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
 sha2 = "0.9"
 deepsize = { version = "0.2.0", optional = true }
 
 near-account-id = { path = "../account-id" }
+
+[dev-dependencies]
+serde_json = "1"
 
 [features]
 default = []

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -18,7 +18,6 @@ bytesize = "1.1"
 chrono = { version = "0.4.4", features = ["serde"] }
 derive_more = "0.99.3"
 easy-ext = "0.2"
-sha2 = "0.9"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 smart-default = "0.6"

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -13,9 +13,7 @@ byteorder = "1.2"
 bytesize = "1.1"
 derive_more = "0.99.3"
 elastic-array = "0.11"
-lazy_static = "1.4"
 rocksdb = "0.16.0"
-serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 num_cpus = "1.11"
 rand = "0.7"
@@ -24,7 +22,6 @@ fs2 = "0.4"
 tracing = "0.1"
 borsh = "0.9"
 thiserror = "1"
-smart-default = "0.6"
 lru = "0.6.5"
 
 near-crypto = { path = "../crypto" }

--- a/runtime/near-vm-errors/Cargo.toml
+++ b/runtime/near-vm-errors/Cargo.toml
@@ -15,7 +15,6 @@ Error that can occur inside Near Runtime encapsulated in a separate crate. Might
 """
 
 [dependencies]
-hex = "0.4"
 serde = { version = "1", features = ["derive"] }
 
 borsh = "0.9"

--- a/tools/rpctypegen/core/Cargo.toml
+++ b/tools/rpctypegen/core/Cargo.toml
@@ -16,7 +16,6 @@ This crate generates schema for Rust structs which can be used by TypeScript.
 serde = { version = "1.0", features = ["derive"] }
 syn = { version = "1.0", features = ["full", "extra-traits"]}
 quote = "1.0"
-proc-macro2 = "1.0"
 
 [dev-dependencies]
 serde_json = {version = "1.0", features = ["preserve_order"]}

--- a/tools/rpctypegen/macro/Cargo.toml
+++ b/tools/rpctypegen/macro/Cargo.toml
@@ -17,13 +17,11 @@ proc-macro = true
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-serde_json = {version = "1.0", features = ["preserve_order"]}
+serde_json = {version = "1.0", features = ["preserve_order"], optional = true}
 syn = { version = "1.0", features = ["full", "extra-traits"]}
-quote = "1.0"
-proc-macro2 = "1.0"
 
 near-rpc-error-core = { path = "../core" }
 
 [features]
 test = []
-dump_errors_schema = ["near-rpc-error-core/dump_errors_schema"]
+dump_errors_schema = ["near-rpc-error-core/dump_errors_schema", "serde_json"]

--- a/utils/near-rate-limiter/Cargo.toml
+++ b/utils/near-rate-limiter/Cargo.toml
@@ -12,7 +12,9 @@ actix = "=0.11.0-beta.2"
 bytes = "1.0.0"
 futures-core = "0.3.0"
 pin-project-lite = "0.2.0"
-tokio-stream = { version = "0.1.2", features = ["net"] }
 tokio-util = { version = "0.6.9", features = ["io", "codec"] }
 tokio = { version = "1.1", features = ["sync", "rt", "macros"] }
 tracing = "0.1"
+
+[dev-dependencies]
+tokio-stream = { version = "0.1.2", features = ["net"] }


### PR DESCRIPTION
Remove recursive unused dependencies, which may slow down compilation of  `near-network`

```shell
L .~/r/nearcore master NO_REMOTE r cargo unused-deps --packages near-network
INFO cargo:191          package.name="near-primitives" package_path="core/primitives"
INFO cargo:194          unused dependency x.name="sha2"
INFO cargo:191          package.name="near-store" package_path="core/store"
INFO cargo:194          unused dependency x.name="lazy_static"
INFO cargo:194          unused dependency x.name="serde"
INFO cargo:194          unused dependency x.name="smart-default"
INFO cargo:191          package.name="near-vm-errors" package_path="runtime/near-vm-errors"
INFO cargo:194          unused dependency x.name="hex"
INFO cargo:191          package.name="near-rpc-error-core" package_path="tools/rpctypegen/core"
INFO cargo:194          unused dependency x.name="proc-macro2"
INFO cargo:191          package.name="near-rpc-error-macro" package_path="tools/rpctypegen/macro"
INFO cargo:194          unused dependency x.name="proc-macro2"
INFO cargo:194          unused dependency x.name="quote"
INFO cargo:191          package.name="near-performance-metrics" package_path="utils/near-performance-metrics"
INFO cargo:194          unused dependency x.name="nix"
INFO cargo:208          to remove! unused_import="nix"
INFO cargo:208          to remove! unused_import="proc-macro2"
```