### PR TITLE
feat: Finish replacing `cached` with `lru`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,30 +350,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
-name = "async-mutex"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
-dependencies = [
- "event-listener",
-]
-
-[[package]]
 name = "async-recursion"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7d78656ba01f1b93024b7c3a0467f1608e4be67d725749fdcd7d2c7678fd7a2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "async-trait"
-version = "0.1.51"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -753,39 +733,6 @@ dependencies = [
  "cipher",
  "ppv-lite86",
 ]
-
-[[package]]
-name = "cached"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e2afe73808fbaac302e39c9754bfc3c4b4d0f99c9c240b9f4e4efc841ad1b74"
-dependencies = [
- "async-mutex",
- "async-trait",
- "cached_proc_macro",
- "cached_proc_macro_types",
- "futures",
- "hashbrown 0.9.1",
- "once_cell",
-]
-
-[[package]]
-name = "cached_proc_macro"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4230b8d9f5db741004bfaef172c5b2dbf0eb94f105204cc6147a220080daaa85"
-dependencies = [
- "cached_proc_macro_types",
- "darling",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "cached_proc_macro_types"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a4f925191b4367301851c6d99b09890311d74b0d43f274c0b34c86d308a3663"
 
 [[package]]
 name = "camino"
@@ -1509,12 +1456,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "2.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
-
-[[package]]
 name = "failure"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2112,7 +2053,6 @@ dependencies = [
  "assert_matches",
  "base64 0.11.0",
  "borsh 0.9.1",
- "cached",
  "chrono",
  "futures",
  "hex",
@@ -2139,9 +2079,11 @@ dependencies = [
  "near-vm-runner",
  "nearcore",
  "node-runtime",
+ "once_cell",
  "portpicker",
  "primitive-types",
  "rand 0.7.3",
+ "serde",
  "serde_json",
  "tempfile",
  "testlib",
@@ -2606,10 +2548,10 @@ version = "0.0.0"
 dependencies = [
  "actix",
  "borsh 0.9.1",
- "cached",
  "chrono",
  "futures",
  "log",
+ "lru",
  "near-chain",
  "near-chunks-primitives",
  "near-crypto",
@@ -2638,11 +2580,11 @@ dependencies = [
  "actix-rt",
  "ansi_term 0.12.1",
  "borsh 0.9.1",
- "cached",
  "chrono",
  "delay-detector",
  "futures",
  "log",
+ "lru",
  "near-actix-test-utils",
  "near-chain",
  "near-chain-configs",
@@ -2718,9 +2660,9 @@ name = "near-epoch-manager"
 version = "0.0.0"
 dependencies = [
  "borsh 0.9.1",
- "cached",
  "chrono",
  "log",
+ "lru",
  "near-chain",
  "near-chain-configs",
  "near-crypto",

--- a/chain/chunks/Cargo.toml
+++ b/chain/chunks/Cargo.toml
@@ -14,7 +14,7 @@ rand = "0.7"
 chrono = "0.4.6"
 log = "0.4"
 borsh = "0.9"
-cached = "0.23"
+lru = "0.6.5"
 reed-solomon-erasure = "4"
 
 near-crypto = { path = "../../core/crypto" }

--- a/chain/chunks/src/chunk_cache.rs
+++ b/chain/chunks/src/chunk_cache.rs
@@ -1,7 +1,5 @@
 use std::collections::{HashMap, HashSet};
 
-use cached::{Cached, SizedCache};
-
 use log::warn;
 use near_primitives::hash::CryptoHash;
 use near_primitives::sharding::{
@@ -68,7 +66,7 @@ pub struct EncodedChunksCache {
     incomplete_chunks: HashMap<CryptoHash, HashSet<ChunkHash>>,
     /// A sized cache mapping a block hash to the chunk headers that are ready
     /// to be included when producing the next block after the block
-    block_hash_to_chunk_headers: SizedCache<CryptoHash, HashMap<ShardId, ShardChunkHeader>>,
+    block_hash_to_chunk_headers: lru::LruCache<CryptoHash, HashMap<ShardId, ShardChunkHeader>>,
 }
 
 impl EncodedChunksCacheEntry {
@@ -105,7 +103,7 @@ impl EncodedChunksCache {
             encoded_chunks: HashMap::new(),
             height_map: HashMap::new(),
             incomplete_chunks: HashMap::new(),
-            block_hash_to_chunk_headers: SizedCache::with_size(NUM_BLOCK_HASH_TO_CHUNK_HEADER),
+            block_hash_to_chunk_headers: lru::LruCache::new(NUM_BLOCK_HASH_TO_CHUNK_HEADER),
         }
     }
 
@@ -252,11 +250,10 @@ impl EncodedChunksCache {
             let prev_block_hash = header.prev_block_hash();
             let mut block_hash_to_chunk_headers = self
                 .block_hash_to_chunk_headers
-                .cache_remove(&prev_block_hash)
+                .pop(&prev_block_hash)
                 .unwrap_or_else(|| HashMap::new());
             block_hash_to_chunk_headers.insert(shard_id, header);
-            self.block_hash_to_chunk_headers
-                .cache_set(prev_block_hash, block_hash_to_chunk_headers);
+            self.block_hash_to_chunk_headers.put(prev_block_hash, block_hash_to_chunk_headers);
         }
     }
 
@@ -266,15 +263,13 @@ impl EncodedChunksCache {
         &mut self,
         prev_block_hash: &CryptoHash,
     ) -> HashMap<ShardId, ShardChunkHeader> {
-        self.block_hash_to_chunk_headers
-            .cache_remove(prev_block_hash)
-            .unwrap_or_else(|| HashMap::new())
+        self.block_hash_to_chunk_headers.pop(prev_block_hash).unwrap_or_else(|| HashMap::new())
     }
 
     /// Returns number of chunks that are ready to be included in the next block
     pub fn num_chunks_for_block(&mut self, prev_block_hash: &CryptoHash) -> ShardId {
         self.block_hash_to_chunk_headers
-            .cache_get(prev_block_hash)
+            .get(prev_block_hash)
             .map(|x| x.len() as ShardId)
             .unwrap_or_else(|| 0)
     }

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -83,7 +83,6 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use borsh::BorshSerialize;
-use cached::{Cached, SizedCache};
 use chrono::DateTime;
 use log::{debug, error, warn};
 use near_primitives::time::Utc;
@@ -285,7 +284,7 @@ pub struct SealsManager {
 
     active_demurs: HashMap<ChunkHash, ActiveSealDemur>,
     past_seals: BTreeMap<BlockHeight, HashSet<ChunkHash>>,
-    dont_include_chunks_from: SizedCache<AccountId, ()>,
+    dont_include_chunks_from: lru::LruCache<AccountId, ()>,
 }
 
 impl SealsManager {
@@ -295,7 +294,7 @@ impl SealsManager {
             runtime_adapter,
             active_demurs: HashMap::new(),
             past_seals: BTreeMap::new(),
-            dont_include_chunks_from: SizedCache::with_size(CHUNK_PRODUCER_BLACKLIST_SIZE),
+            dont_include_chunks_from: lru::LruCache::new(CHUNK_PRODUCER_BLACKLIST_SIZE),
         }
     }
 
@@ -461,7 +460,7 @@ impl SealsManager {
     }*/
 
     fn should_trust_chunk_producer(&mut self, chunk_producer: &AccountId) -> bool {
-        self.dont_include_chunks_from.cache_get(chunk_producer).is_none()
+        self.dont_include_chunks_from.get(chunk_producer).is_none()
     }
 }
 
@@ -475,7 +474,7 @@ pub struct ShardsManager {
 
     encoded_chunks: EncodedChunksCache,
     requested_partial_encoded_chunks: RequestPool,
-    chunk_forwards_cache: SizedCache<ChunkHash, HashMap<u64, PartialEncodedChunkPart>>,
+    chunk_forwards_cache: lru::LruCache<ChunkHash, HashMap<u64, PartialEncodedChunkPart>>,
 
     seals_mgr: SealsManager,
     /// Useful to make tests deterministic and reproducible,
@@ -502,7 +501,7 @@ impl ShardsManager {
                 Duration::from_millis(CHUNK_REQUEST_SWITCH_TO_FULL_FETCH_MS),
                 Duration::from_millis(CHUNK_REQUEST_RETRY_MAX_MS),
             ),
-            chunk_forwards_cache: SizedCache::with_size(CHUNK_FORWARD_CACHE_SIZE),
+            chunk_forwards_cache: lru::LruCache::new(CHUNK_FORWARD_CACHE_SIZE),
             seals_mgr: SealsManager::new(me, runtime_adapter),
             rng_seed,
         }
@@ -1217,7 +1216,7 @@ impl ShardsManager {
     pub fn insert_forwarded_chunk(&mut self, forward: PartialEncodedChunkForwardMsg) {
         let chunk_hash = forward.chunk_hash.clone();
         let num_total_parts = self.runtime_adapter.num_total_parts() as u64;
-        match self.chunk_forwards_cache.cache_get_mut(&chunk_hash) {
+        match self.chunk_forwards_cache.get_mut(&chunk_hash) {
             None => {
                 // Never seen this chunk hash before, collect the parts and cache them
                 let parts = forward.parts.into_iter().filter_map(|part| {
@@ -1229,7 +1228,7 @@ impl ShardsManager {
                         Some((part_ord, part))
                     }
                 }).collect();
-                self.chunk_forwards_cache.cache_set(chunk_hash, parts);
+                self.chunk_forwards_cache.put(chunk_hash, parts);
             }
 
             Some(existing_parts) => {
@@ -1469,7 +1468,7 @@ impl ShardsManager {
         self.encoded_chunks.merge_in_partial_encoded_chunk(partial_encoded_chunk);
 
         // 3. Process the forwarded parts in chunk_forwards_cache
-        if let Some(forwarded_parts) = self.chunk_forwards_cache.cache_remove(&chunk_hash) {
+        if let Some(forwarded_parts) = self.chunk_forwards_cache.pop(&chunk_hash) {
             // We have the header now, and there were some parts we were forwarded earlier.
             // Let's process those parts now.
             let forwarded_chunk = PartialEncodedChunkV2 {

--- a/chain/client/Cargo.toml
+++ b/chain/client/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = "1"
 # Temporary workaround, fix with rust toolchain update.
 sysinfo = { git = "https://github.com/near/sysinfo", rev = "3cb97ee79a02754407d2f0f63628f247d7c65e7b" }
 strum = { version = "0.20", features = ["derive"] }
-cached = "0.23"
+lru = "0.6.5"
 once_cell = "1.5.2"
 borsh = "0.9"
 reed-solomon-erasure = "4"

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -5,7 +5,6 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
-use cached::{Cached, SizedCache};
 use log::{debug, error, info, warn};
 use near_primitives::time::Clock;
 
@@ -79,7 +78,8 @@ pub struct Client {
     /// Signer for block producer (if present).
     pub validator_signer: Option<Arc<dyn ValidatorSigner>>,
     /// Approvals for which we do not have the block yet
-    pub pending_approvals: SizedCache<ApprovalInner, HashMap<AccountId, (Approval, ApprovalType)>>,
+    pub pending_approvals:
+        lru::LruCache<ApprovalInner, HashMap<AccountId, (Approval, ApprovalType)>>,
     /// A mapping from a block for which a state sync is underway for the next epoch, and the object
     /// storing the current status of the state sync and blocks catch up
     pub catchup_state_syncs:
@@ -97,7 +97,7 @@ pub struct Client {
     /// A ReedSolomon instance to reconstruct shard.
     pub rs: ReedSolomonWrapper,
     /// Blocks that have been re-broadcast recently. They should not be broadcast again.
-    rebroadcasted_blocks: SizedCache<CryptoHash, ()>,
+    rebroadcasted_blocks: lru::LruCache<CryptoHash, ()>,
     /// Last time the head was updated, or our head was rebroadcasted. Used to re-broadcast the head
     /// again to prevent network from stalling if a large percentage of the network missed a block
     last_time_head_progress_made: Instant,
@@ -180,7 +180,7 @@ impl Client {
             shards_mgr,
             network_adapter,
             validator_signer,
-            pending_approvals: SizedCache::with_size(num_block_producer_seats),
+            pending_approvals: lru::LruCache::new(num_block_producer_seats),
             catchup_state_syncs: HashMap::new(),
             epoch_sync,
             header_sync,
@@ -188,7 +188,7 @@ impl Client {
             state_sync,
             challenges: Default::default(),
             rs: ReedSolomonWrapper::new(data_parts, parity_parts),
-            rebroadcasted_blocks: SizedCache::with_size(NUM_REBROADCAST_BLOCKS),
+            rebroadcasted_blocks: lru::LruCache::new(NUM_REBROADCAST_BLOCKS),
             last_time_head_progress_made: Clock::instant(),
             chunks_delay_tracker: Default::default(),
         })
@@ -787,11 +787,11 @@ impl Client {
     }
 
     pub fn rebroadcast_block(&mut self, block: &Block) {
-        if self.rebroadcasted_blocks.cache_get(block.hash()).is_none() {
+        if self.rebroadcasted_blocks.get(block.hash()).is_none() {
             self.network_adapter.do_send(PeerManagerMessageRequest::NetworkRequests(
                 NetworkRequests::Block { block: block.clone() },
             ));
-            self.rebroadcasted_blocks.cache_set(*block.hash(), ());
+            self.rebroadcasted_blocks.put(*block.hash(), ());
         }
     }
 
@@ -1006,11 +1006,11 @@ impl Client {
         if provenance == Provenance::NONE {
             let endorsements = self
                 .pending_approvals
-                .cache_remove(&ApprovalInner::Endorsement(block_hash))
+                .pop(&ApprovalInner::Endorsement(block_hash))
                 .unwrap_or_default();
             let skips = self
                 .pending_approvals
-                .cache_remove(&ApprovalInner::Skip(block.header().height()))
+                .pop(&ApprovalInner::Skip(block.header().height()))
                 .unwrap_or_default();
 
             for (_account_id, (approval, approval_type)) in
@@ -1282,12 +1282,10 @@ impl Client {
                     return;
                 }
             }
-            let mut entry = self
-                .pending_approvals
-                .cache_remove(&approval.inner)
-                .unwrap_or_else(|| HashMap::new());
+            let mut entry =
+                self.pending_approvals.pop(&approval.inner).unwrap_or_else(|| HashMap::new());
             entry.insert(approval.account_id.clone(), (approval.clone(), approval_type));
-            self.pending_approvals.cache_set(approval.inner.clone(), entry);
+            self.pending_approvals.put(approval.inner.clone(), entry);
         }
     }
 

--- a/chain/client/src/sync.rs
+++ b/chain/client/src/sync.rs
@@ -26,7 +26,6 @@ use near_primitives::types::{
 };
 use near_primitives::utils::to_timestamp;
 
-use cached::{Cached, SizedCache};
 use near_chain::chain::{ApplyStatePartsRequest, StateSplitRequest};
 use near_client_primitives::types::{
     DownloadStatus, ShardSyncDownload, ShardSyncStatus, SyncStatus,
@@ -605,7 +604,7 @@ pub struct StateSync {
 
     last_part_id_requested: HashMap<(AccountOrPeerIdOrHash, ShardId), PendingRequestStatus>,
     /// Map from which part we requested to whom.
-    requested_target: SizedCache<(u64, CryptoHash), AccountOrPeerIdOrHash>,
+    requested_target: lru::LruCache<(u64, CryptoHash), AccountOrPeerIdOrHash>,
 
     timeout: Duration,
 
@@ -623,7 +622,7 @@ impl StateSync {
             state_sync_time: Default::default(),
             last_time_block_requested: None,
             last_part_id_requested: Default::default(),
-            requested_target: SizedCache::with_size(MAX_PENDING_PART as usize),
+            requested_target: lru::LruCache::new(MAX_PENDING_PART as usize),
             timeout: Duration::from_std(timeout).unwrap(),
             state_parts_apply_results: HashMap::new(),
             split_state_roots: HashMap::new(),
@@ -967,7 +966,7 @@ impl StateSync {
         shard_id: ShardId,
         sync_hash: CryptoHash,
     ) {
-        self.requested_target.cache_set((part_id, sync_hash), target.clone());
+        self.requested_target.put((part_id, sync_hash), target.clone());
 
         let timeout = self.timeout;
         self.last_part_id_requested
@@ -985,7 +984,7 @@ impl StateSync {
         sync_hash: CryptoHash,
     ) {
         let key = (part_id, sync_hash);
-        if let Some(target) = self.requested_target.cache_get(&key) {
+        if let Some(target) = self.requested_target.get(&key) {
             if self.last_part_id_requested.get_mut(&(target.clone(), shard_id)).map_or(
                 false,
                 |request| {

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -9,7 +9,6 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
 use actix::{Actor, Addr, Handler, SyncArbiter, SyncContext};
-use cached::{Cached, SizedCache};
 use log::{debug, error, info, trace, warn};
 
 use near_chain::types::ValidatorInfoIdentifier;
@@ -70,15 +69,15 @@ const POISONED_LOCK_ERR: &str = "The lock was poisoned.";
 /// Request and response manager across all instances of ViewClientActor.
 pub struct ViewClientRequestManager {
     /// Transaction query that needs to be forwarded to other shards
-    pub tx_status_requests: SizedCache<CryptoHash, Instant>,
+    pub tx_status_requests: lru::LruCache<CryptoHash, Instant>,
     /// Transaction status response
-    pub tx_status_response: SizedCache<CryptoHash, FinalExecutionOutcomeView>,
+    pub tx_status_response: lru::LruCache<CryptoHash, FinalExecutionOutcomeView>,
     /// Query requests that need to be forwarded to other shards
-    pub query_requests: SizedCache<String, Instant>,
+    pub query_requests: lru::LruCache<String, Instant>,
     /// Query responses from other nodes (can be errors)
-    pub query_responses: SizedCache<String, Result<QueryResponse, String>>,
+    pub query_responses: lru::LruCache<String, Result<QueryResponse, String>>,
     /// Receipt outcome requests
-    pub receipt_outcome_requests: SizedCache<CryptoHash, Instant>,
+    pub receipt_outcome_requests: lru::LruCache<CryptoHash, Instant>,
 }
 
 #[cfg(feature = "test_features")]
@@ -107,11 +106,11 @@ pub struct ViewClientActor {
 impl ViewClientRequestManager {
     pub fn new() -> Self {
         Self {
-            tx_status_requests: SizedCache::with_size(QUERY_REQUEST_LIMIT),
-            tx_status_response: SizedCache::with_size(QUERY_REQUEST_LIMIT),
-            query_requests: SizedCache::with_size(QUERY_REQUEST_LIMIT),
-            query_responses: SizedCache::with_size(QUERY_REQUEST_LIMIT),
-            receipt_outcome_requests: SizedCache::with_size(QUERY_REQUEST_LIMIT),
+            tx_status_requests: lru::LruCache::new(QUERY_REQUEST_LIMIT),
+            tx_status_response: lru::LruCache::new(QUERY_REQUEST_LIMIT),
+            query_requests: lru::LruCache::new(QUERY_REQUEST_LIMIT),
+            query_responses: lru::LruCache::new(QUERY_REQUEST_LIMIT),
+            receipt_outcome_requests: lru::LruCache::new(QUERY_REQUEST_LIMIT),
         }
     }
 }
@@ -159,14 +158,14 @@ impl ViewClientActor {
         }
     }
 
-    fn need_request<K: Hash + Eq + Clone>(key: K, cache: &mut SizedCache<K, Instant>) -> bool {
+    fn need_request<K: Hash + Eq + Clone>(key: K, cache: &mut lru::LruCache<K, Instant>) -> bool {
         let now = Clock::instant();
-        let need_request = match cache.cache_get(&key) {
+        let need_request = match cache.get(&key) {
             Some(time) => now - *time > Duration::from_millis(REQUEST_WAIT_TIME),
             None => true,
         };
         if need_request {
-            cache.cache_set(key, now);
+            cache.put(key, now);
         }
         need_request
     }
@@ -363,8 +362,8 @@ impl ViewClientActor {
     ) -> Result<Option<FinalExecutionOutcomeViewEnum>, TxStatusError> {
         {
             let mut request_manager = self.request_manager.write().expect(POISONED_LOCK_ERR);
-            if let Some(res) = request_manager.tx_status_response.cache_remove(&tx_hash) {
-                request_manager.tx_status_requests.cache_remove(&tx_hash);
+            if let Some(res) = request_manager.tx_status_response.pop(&tx_hash) {
+                request_manager.tx_status_requests.pop(&tx_hash);
                 return Ok(Some(FinalExecutionOutcomeViewEnum::FinalExecutionOutcome(res)));
             }
         }
@@ -1018,8 +1017,8 @@ impl Handler<NetworkViewClientMessages> for ViewClientActor {
             NetworkViewClientMessages::TxStatusResponse(tx_result) => {
                 let tx_hash = tx_result.transaction_outcome.id;
                 let mut request_manager = self.request_manager.write().expect(POISONED_LOCK_ERR);
-                if request_manager.tx_status_requests.cache_remove(&tx_hash).is_some() {
-                    request_manager.tx_status_response.cache_set(tx_hash, *tx_result);
+                if request_manager.tx_status_requests.pop(&tx_hash).is_some() {
+                    request_manager.tx_status_response.put(tx_hash, *tx_result);
                 }
                 NetworkViewClientResponses::NoResponse
             }

--- a/chain/epoch_manager/Cargo.toml
+++ b/chain/epoch_manager/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 # Changing this version will lead to change to the protocol, as will change how validators get shuffled.
 protocol_defining_rand = { package = "rand", version = "0.6.5", default-features = false }
 log = "0.4"
-cached = "0.23"
+lru = "0.6.5"
 borsh = "0.9"
 rand = "0.7"
 serde_json = "1"

--- a/chain/epoch_manager/src/lib.rs
+++ b/chain/epoch_manager/src/lib.rs
@@ -1,7 +1,6 @@
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
 
-use cached::{Cached, SizedCache};
 use log::{debug, warn};
 use primitive_types::U256;
 
@@ -58,15 +57,15 @@ pub struct EpochManager {
     genesis_protocol_version: ProtocolVersion,
 
     /// Cache of epoch information.
-    epochs_info: SizedCache<EpochId, EpochInfo>,
+    epochs_info: lru::LruCache<EpochId, EpochInfo>,
     /// Cache of block information.
-    blocks_info: SizedCache<CryptoHash, BlockInfo>,
+    blocks_info: lru::LruCache<CryptoHash, BlockInfo>,
     /// Cache of epoch id to epoch start height
-    epoch_id_to_start: SizedCache<EpochId, BlockHeight>,
+    epoch_id_to_start: lru::LruCache<EpochId, BlockHeight>,
     /// Epoch validators ordered by `block_producer_settlement`.
-    epoch_validators_ordered: SizedCache<EpochId, Vec<(ValidatorStake, bool)>>,
+    epoch_validators_ordered: lru::LruCache<EpochId, Vec<(ValidatorStake, bool)>>,
     /// Unique validators ordered by `block_producer_settlement`.
-    epoch_validators_ordered_unique: SizedCache<EpochId, Vec<(ValidatorStake, bool)>>,
+    epoch_validators_ordered_unique: lru::LruCache<EpochId, Vec<(ValidatorStake, bool)>>,
     /// Aggregator that crunches data when we process block info
     epoch_info_aggregator: Option<EpochInfoAggregator>,
     /// Largest final height. Monotonically increasing.
@@ -104,11 +103,11 @@ impl EpochManager {
             config,
             reward_calculator,
             genesis_protocol_version,
-            epochs_info: SizedCache::with_size(EPOCH_CACHE_SIZE),
-            blocks_info: SizedCache::with_size(BLOCK_CACHE_SIZE),
-            epoch_id_to_start: SizedCache::with_size(EPOCH_CACHE_SIZE),
-            epoch_validators_ordered: SizedCache::with_size(EPOCH_CACHE_SIZE),
-            epoch_validators_ordered_unique: SizedCache::with_size(EPOCH_CACHE_SIZE),
+            epochs_info: lru::LruCache::new(EPOCH_CACHE_SIZE),
+            blocks_info: lru::LruCache::new(BLOCK_CACHE_SIZE),
+            epoch_id_to_start: lru::LruCache::new(EPOCH_CACHE_SIZE),
+            epoch_validators_ordered: lru::LruCache::new(EPOCH_CACHE_SIZE),
+            epoch_validators_ordered_unique: lru::LruCache::new(EPOCH_CACHE_SIZE),
             epoch_info_aggregator: None,
             largest_final_height: 0,
         };
@@ -606,7 +605,7 @@ impl EpochManager {
         last_known_block_hash: &CryptoHash,
     ) -> Result<&[(ValidatorStake, bool)], EpochError> {
         // TODO(3674): Revisit this when we enable slashing
-        if self.epoch_validators_ordered.cache_get(epoch_id).is_none() {
+        if self.epoch_validators_ordered.get(epoch_id).is_none() {
             let slashed = self.get_slashed_validators(last_known_block_hash)?.clone();
             let epoch_info = self.get_epoch_info(epoch_id)?;
             let mut settlement = Vec::with_capacity(epoch_info.block_producers_settlement().len());
@@ -615,9 +614,9 @@ impl EpochManager {
                 let is_slashed = slashed.contains_key(validator_stake.account_id());
                 settlement.push((validator_stake, is_slashed));
             }
-            self.epoch_validators_ordered.cache_set(epoch_id.clone(), settlement);
+            self.epoch_validators_ordered.put(epoch_id.clone(), settlement);
         }
-        Ok(self.epoch_validators_ordered.cache_get(epoch_id).unwrap())
+        Ok(self.epoch_validators_ordered.get(epoch_id).unwrap())
     }
 
     /// Returns all unique block producers in current epoch sorted by account_id, with indicator on whether they are slashed or not.
@@ -626,7 +625,7 @@ impl EpochManager {
         epoch_id: &EpochId,
         last_known_block_hash: &CryptoHash,
     ) -> Result<&[(ValidatorStake, bool)], EpochError> {
-        if self.epoch_validators_ordered_unique.cache_get(epoch_id).is_none() {
+        if self.epoch_validators_ordered_unique.get(epoch_id).is_none() {
             let settlement =
                 self.get_all_block_producers_settlement(epoch_id, last_known_block_hash)?;
             let mut result = vec![];
@@ -638,9 +637,9 @@ impl EpochManager {
                     result.push((validator_stake.clone(), *is_slashed));
                 }
             }
-            self.epoch_validators_ordered_unique.cache_set(epoch_id.clone(), result);
+            self.epoch_validators_ordered_unique.put(epoch_id.clone(), result);
         }
-        Ok(self.epoch_validators_ordered_unique.cache_get(epoch_id).unwrap())
+        Ok(self.epoch_validators_ordered_unique.get(epoch_id).unwrap())
     }
 
     /// get_heuristic_block_approvers_ordered: block producers for epoch
@@ -1283,7 +1282,7 @@ impl EpochManager {
     }
 
     pub fn get_epoch_info(&mut self, epoch_id: &EpochId) -> Result<&EpochInfo, EpochError> {
-        if !self.epochs_info.cache_get(epoch_id).is_some() {
+        if !self.epochs_info.get(epoch_id).is_some() {
             let epoch_info = self
                 .store
                 .get_ser(ColEpochInfo, epoch_id.as_ref())
@@ -1291,9 +1290,9 @@ impl EpochManager {
                 .and_then(|value| {
                     value.ok_or_else(|| EpochError::EpochOutOfBounds(epoch_id.clone()))
                 })?;
-            self.epochs_info.cache_set(epoch_id.clone(), epoch_info);
+            self.epochs_info.put(epoch_id.clone(), epoch_info);
         }
-        self.epochs_info.cache_get(epoch_id).ok_or(EpochError::EpochOutOfBounds(epoch_id.clone()))
+        self.epochs_info.get(epoch_id).ok_or(EpochError::EpochOutOfBounds(epoch_id.clone()))
     }
 
     fn has_epoch_info(&mut self, epoch_id: &EpochId) -> Result<bool, EpochError> {
@@ -1313,7 +1312,7 @@ impl EpochManager {
         store_update
             .set_ser(ColEpochInfo, epoch_id.as_ref(), &epoch_info)
             .map_err(EpochError::from)?;
-        self.epochs_info.cache_set(epoch_id.clone(), epoch_info);
+        self.epochs_info.put(epoch_id.clone(), epoch_info);
         Ok(())
     }
 
@@ -1352,15 +1351,15 @@ impl EpochManager {
     /// EpochError::IOErr if storage returned an error
     /// EpochError::MissingBlock if block is not in storage
     pub fn get_block_info(&mut self, hash: &CryptoHash) -> Result<&BlockInfo, EpochError> {
-        if self.blocks_info.cache_get(hash).is_none() {
+        if self.blocks_info.get(hash).is_none() {
             let block_info = self
                 .store
                 .get_ser(ColBlockInfo, hash.as_ref())
                 .map_err(EpochError::from)
                 .and_then(|value| value.ok_or_else(|| EpochError::MissingBlock(*hash)))?;
-            self.blocks_info.cache_set(*hash, block_info);
+            self.blocks_info.put(*hash, block_info);
         }
-        self.blocks_info.cache_get(hash).ok_or(EpochError::MissingBlock(*hash))
+        self.blocks_info.get(hash).ok_or(EpochError::MissingBlock(*hash))
     }
 
     fn save_block_info(
@@ -1372,7 +1371,7 @@ impl EpochManager {
         store_update
             .set_ser(ColBlockInfo, block_hash.as_ref(), &block_info)
             .map_err(EpochError::from)?;
-        self.blocks_info.cache_set(block_hash, block_info);
+        self.blocks_info.put(block_hash, block_info);
         Ok(())
     }
 
@@ -1385,7 +1384,7 @@ impl EpochManager {
         store_update
             .set_ser(ColEpochStart, epoch_id.as_ref(), &epoch_start)
             .map_err(EpochError::from)?;
-        self.epoch_id_to_start.cache_set(epoch_id.clone(), epoch_start);
+        self.epoch_id_to_start.put(epoch_id.clone(), epoch_start);
         Ok(())
     }
 
@@ -1393,7 +1392,7 @@ impl EpochManager {
         &mut self,
         epoch_id: &EpochId,
     ) -> Result<BlockHeight, EpochError> {
-        if self.epoch_id_to_start.cache_get(epoch_id).is_none() {
+        if self.epoch_id_to_start.get(epoch_id).is_none() {
             let epoch_start = self
                 .store
                 .get_ser(ColEpochStart, epoch_id.as_ref())
@@ -1401,9 +1400,9 @@ impl EpochManager {
                 .and_then(|value| {
                     value.ok_or_else(|| EpochError::EpochOutOfBounds(epoch_id.clone()))
                 })?;
-            self.epoch_id_to_start.cache_set(epoch_id.clone(), epoch_start);
+            self.epoch_id_to_start.put(epoch_id.clone(), epoch_start);
         }
-        Ok(*self.epoch_id_to_start.cache_get(epoch_id).unwrap())
+        Ok(*self.epoch_id_to_start.get(epoch_id).unwrap())
     }
 
     /// Get epoch info aggregator and update it to block info as of `last_block_hash`. If `epoch_id`
@@ -3990,21 +3989,21 @@ mod tests2 {
         for i in 1..4 {
             record_block(&mut epoch_manager, h[i - 1], h[i], i as u64, vec![]);
         }
-        assert_eq!(epoch_manager.epoch_validators_ordered.cache_size(), 0);
+        assert_eq!(epoch_manager.epoch_validators_ordered.len(), 0);
 
         let epoch_id = EpochId(h[2]);
         let epoch_validators =
             epoch_manager.get_all_block_producers_settlement(&epoch_id, &h[3]).unwrap().to_vec();
-        assert_eq!(epoch_manager.epoch_validators_ordered.cache_size(), 1);
+        assert_eq!(epoch_manager.epoch_validators_ordered.len(), 1);
         let epoch_validators_in_cache =
-            epoch_manager.epoch_validators_ordered.cache_get(&epoch_id).unwrap().clone();
+            epoch_manager.epoch_validators_ordered.get(&epoch_id).unwrap().clone();
         assert_eq!(epoch_validators, epoch_validators_in_cache);
 
-        assert_eq!(epoch_manager.epoch_validators_ordered_unique.cache_size(), 0);
+        assert_eq!(epoch_manager.epoch_validators_ordered_unique.len(), 0);
         let epoch_validators_unique =
             epoch_manager.get_all_block_producers_ordered(&epoch_id, &h[3]).unwrap().to_vec();
         let epoch_validators_unique_in_cache =
-            epoch_manager.epoch_validators_ordered_unique.cache_get(&epoch_id).unwrap().clone();
+            epoch_manager.epoch_validators_ordered_unique.get(&epoch_id).unwrap().clone();
         assert_eq!(epoch_validators_unique, epoch_validators_unique_in_cache);
     }
 }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -10,20 +10,21 @@ edition = "2021"
 [dependencies]
 actix = "=0.11.0-beta.2"
 actix-rt = "2"
+base64 = "0.11"
 borsh = "0.9"
-cached = "0.23"
 chrono = { version = "0.4.4", features = ["serde"] }
 futures = "0.3"
 hex = "0.4"
 hyper = { version = "0.14", features = ["full"] }
 log = "0.4"
+once_cell = "1.5"
 primitive-types = "0.10.1"
 rand = "0.7"
 serde_json = "1"
+serde = { version = "1", features = ["derive"] }
 tempfile = "3"
 tokio = { version = "1.1", features = ["net", "rt-multi-thread"] }
 tracing = "0.1.13"
-base64 = "0.11"
 wat = "1.0"
 
 near-actix-test-utils = { path = "../test-utils/actix-test-utils" }

--- a/integration-tests/src/test_helpers.rs
+++ b/integration-tests/src/test_helpers.rs
@@ -1,5 +1,5 @@
 use crate::node::Node;
-use cached::once_cell::sync::Lazy;
+use once_cell::sync::Lazy;
 use std::process::Output;
 use std::sync::{Arc, Mutex, RwLock};
 use std::thread;

--- a/integration-tests/src/tests/client/runtimes.rs
+++ b/integration-tests/src/tests/client/runtimes.rs
@@ -5,8 +5,6 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
-use cached::Cached;
-
 use near_chain::{ChainGenesis, RuntimeAdapter};
 use near_chain_configs::Genesis;
 use near_chunks::test_utils::ChunkForwardingTestFixture;
@@ -53,8 +51,7 @@ fn test_pending_approvals() {
     let approval = Approval::new(parent_hash, 0, 1, &signer);
     let peer_id = PeerId::random();
     env.clients[0].collect_block_approval(&approval, ApprovalType::PeerApproval(peer_id.clone()));
-    let approvals =
-        env.clients[0].pending_approvals.cache_remove(&ApprovalInner::Endorsement(parent_hash));
+    let approvals = env.clients[0].pending_approvals.pop(&ApprovalInner::Endorsement(parent_hash));
     let expected =
         vec![("test0".parse().unwrap(), (approval, ApprovalType::PeerApproval(peer_id)))]
             .into_iter()
@@ -76,14 +73,14 @@ fn test_invalid_approvals() {
     let approval = Approval::new(parent_hash, 1, 3, &signer);
     let peer_id = PeerId::random();
     env.clients[0].collect_block_approval(&approval, ApprovalType::PeerApproval(peer_id.clone()));
-    assert_eq!(env.clients[0].pending_approvals.cache_size(), 0);
+    assert_eq!(env.clients[0].pending_approvals.len(), 0);
     // Approval with invalid signature. Should be dropped
     let signer =
         InMemoryValidatorSigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "random");
     let genesis_hash = *env.clients[0].chain.genesis().hash();
     let approval = Approval::new(genesis_hash, 0, 1, &signer);
     env.clients[0].collect_block_approval(&approval, ApprovalType::PeerApproval(peer_id));
-    assert_eq!(env.clients[0].pending_approvals.cache_size(), 0);
+    assert_eq!(env.clients[0].pending_approvals.len(), 0);
 }
 
 #[test]


### PR DESCRIPTION
We are in the process of removing `cached`, see https://github.com/near/nearcore/issues/5527

This is the final step towards removing `cached`.

- `/chain/chunk`
- `/chain/client`
- `/chain/epoch-manager`
- `/itegration-tests`