### PR TITLE
integration-tests: fix some expensive tests marking

### DIFF
--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -58,7 +58,6 @@ portpicker = "0.1.1"
 
 [features]
 performance_stats = ["nearcore/performance_stats", "near-network/performance_stats"]
-regression_tests = []
 expensive_tests = []
 test_features = ["nearcore/test_features"]
 protocol_feature_alt_bn128 = [

--- a/integration-tests/src/tests/nearcore/sync_state_nodes.rs
+++ b/integration-tests/src/tests/nearcore/sync_state_nodes.rs
@@ -104,11 +104,9 @@ fn sync_state_nodes() {
 }
 
 /// One client is in front, another must sync to it using state (fast) sync.
+#[cfg(feature = "expensive_tests")]
 #[test]
 fn sync_state_nodes_multishard() {
-    if !cfg!(feature = "expensive_tests") {
-        return;
-    }
     heavy_test(|| {
         init_integration_logger();
 

--- a/integration-tests/src/tests/test_catchup.rs
+++ b/integration-tests/src/tests/test_catchup.rs
@@ -1,6 +1,6 @@
 //! Checks that late validator can catch-up and start validating.
-#[test]
 #[cfg(feature = "expensive_tests")]
+#[test]
 fn test_catchup() {
     use std::time::Duration;
 

--- a/integration-tests/src/tests/test_tps_regression.rs
+++ b/integration-tests/src/tests/test_tps_regression.rs
@@ -2,7 +2,7 @@
 //! and verifies that the output tps is not much different from the input tps (makes sure there is
 //! no choking on transactions). The input tps -- is how fast the nodes can be accepting
 //! transactions. The output tps -- is how fast the nodes propagate transactions into the blocks.
-#[cfg(any(feature = "expensive_tests", feature = "regression_tests"))]
+#[cfg(feature = "expensive_tests")]
 #[cfg(test)]
 mod test {
     use std::io::stdout;

--- a/nightly/expensive.txt
+++ b/nightly/expensive.txt
@@ -141,3 +141,6 @@ expensive integration-tests integration_tests tests::test_simple::test::test_4_1
 expensive integration-tests integration_tests tests::test_simple::test::test_4_10_multiple_nodes --features nightly_protocol,nightly_protocol_features
 expensive integration-tests integration_tests tests::test_simple::test::test_7_10_multiple_nodes
 expensive integration-tests integration_tests tests::test_simple::test::test_7_10_multiple_nodes --features nightly_protocol,nightly_protocol_features
+
+expensive integration-tests integration_tests tests::nearcore::sync_state_nodes::sync_state_nodes_multishard
+expensive integration-tests integration_tests tests::nearcore::sync_state_nodes::sync_state_nodes_multishard --features nightly_protocol,nightly_protocol_features


### PR DESCRIPTION
Firstly, the proper way to denote a test as expensive is to use
`#[cfg]` directive before its definition rather than adding a return
inside of the function.  The latter will cause the test to show up in
list of tests and always pass giving people false sense that running
the test without `expensive_tests` feature actually does something.

After fixing `sync_state_nodes_multishard` also add it to nightly run.

Secondly, the `check_nightly.py` script is rather crude and the order
in which `#[cfg]` and `#[test]` attributes are applied do matter.
With `#[test]` being first, the script failed to recognise
`test_catchup` as an expensive test.

Thirdly, the `check_nightly.py` script also doesn’t understand
`#[cfg]` matching multiple features.  Because of that it does not
detect `test_highload` as an expensive test either.  Since we’re not
using `regression_tests` feature for anything simply remove it.

Issue: https://github.com/near/nearcore/issues/4490