### PR TITLE
Revert the changes to use low level wasmer2 implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,7 +439,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.23.0",
  "rustc-demangle",
 ]
 
@@ -2243,6 +2243,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3270,7 +3279,6 @@ dependencies = [
  "assert_matches",
  "base64 0.13.0",
  "borsh 0.9.1",
- "loupe",
  "memoffset",
  "near-cache",
  "near-primitives",
@@ -3284,10 +3292,9 @@ dependencies = [
  "serde",
  "threadpool",
  "tracing",
- "wasmer-compiler-near",
  "wasmer-compiler-singlepass-near",
- "wasmer-engine-near",
  "wasmer-engine-universal-near",
+ "wasmer-near",
  "wasmer-runtime-core-near",
  "wasmer-runtime-near",
  "wasmer-types-near",
@@ -3539,6 +3546,17 @@ checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
 dependencies = [
  "crc32fast",
  "indexmap",
+]
+
+[[package]]
+name = "object"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+dependencies = [
+ "crc32fast",
+ "indexmap",
+ "memchr",
 ]
 
 [[package]]
@@ -5298,6 +5316,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
  "cfg-if 1.0.0",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -5648,6 +5667,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmer-compiler"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f7a9201a79b68fe6427afa7835828b23647ef75f8a7aa212ec112f1625eeb1"
+dependencies = [
+ "enumset",
+ "loupe",
+ "rkyv",
+ "serde",
+ "serde_bytes",
+ "smallvec",
+ "target-lexicon 0.12.2",
+ "thiserror",
+ "wasmer-types",
+ "wasmer-vm",
+ "wasmparser 0.78.2",
+]
+
+[[package]]
 name = "wasmer-compiler-near"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5684,6 +5722,63 @@ dependencies = [
  "wasmer-compiler-near",
  "wasmer-types-near",
  "wasmer-vm-near",
+]
+
+[[package]]
+name = "wasmer-derive-near"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c3fcfc8f5838baf311380dcf3ef9843120967ddb073273aa514a4009f50f052"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasmer-engine"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae9202a77333cfad9a32d33862dda7c1a981c3f17139f3da44a447df6b56ae4d"
+dependencies = [
+ "backtrace",
+ "enumset",
+ "lazy_static",
+ "loupe",
+ "memmap2 0.5.0",
+ "more-asserts",
+ "rustc-demangle",
+ "serde",
+ "serde_bytes",
+ "target-lexicon 0.12.2",
+ "thiserror",
+ "wasmer-compiler",
+ "wasmer-types",
+ "wasmer-vm",
+]
+
+[[package]]
+name = "wasmer-engine-dylib"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d633a81aa4278720ef476f9800efafccc4616d55f6e4fb079f6f268bd2df0a5c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "enumset",
+ "leb128",
+ "libloading",
+ "loupe",
+ "rkyv",
+ "serde",
+ "tempfile",
+ "tracing",
+ "wasmer-compiler",
+ "wasmer-engine",
+ "wasmer-object",
+ "wasmer-types",
+ "wasmer-vm",
+ "which",
 ]
 
 [[package]]
@@ -5725,6 +5820,43 @@ dependencies = [
  "wasmer-types-near",
  "wasmer-vm-near",
  "winapi",
+]
+
+[[package]]
+name = "wasmer-near"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b1428287e6fff52908b7c74e88f49b557d3e71b6b94b67ce532bcd5f872194"
+dependencies = [
+ "cfg-if 1.0.0",
+ "indexmap",
+ "js-sys",
+ "loupe",
+ "more-asserts",
+ "target-lexicon 0.12.2",
+ "thiserror",
+ "wasm-bindgen",
+ "wasmer-compiler-near",
+ "wasmer-compiler-singlepass-near",
+ "wasmer-derive-near",
+ "wasmer-engine-dylib",
+ "wasmer-engine-near",
+ "wasmer-engine-universal-near",
+ "wasmer-types-near",
+ "wasmer-vm-near",
+ "winapi",
+]
+
+[[package]]
+name = "wasmer-object"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a94c41ae3e6df06eec59bf781043119b85d50da3e9886c2c4bf5d2e64d3532d8"
+dependencies = [
+ "object 0.27.1",
+ "thiserror",
+ "wasmer-compiler",
+ "wasmer-types",
 ]
 
 [[package]]
@@ -5792,6 +5924,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmer-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "191ca11a0b1635690bbdfa1d8b677c0717a307b57064de4c8d7b579ce960fd57"
+dependencies = [
+ "indexmap",
+ "loupe",
+ "rkyv",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "wasmer-types-near"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5802,6 +5947,28 @@ dependencies = [
  "rkyv",
  "serde",
  "thiserror",
+]
+
+[[package]]
+name = "wasmer-vm"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721f7570037d25e5215f74e44af6d644a8cee10cc3df7825d03ff4179a8f6004"
+dependencies = [
+ "backtrace",
+ "cc",
+ "cfg-if 1.0.0",
+ "indexmap",
+ "libc",
+ "loupe",
+ "memoffset",
+ "more-asserts",
+ "region 3.0.0",
+ "rkyv",
+ "serde",
+ "thiserror",
+ "wasmer-types",
+ "winapi",
 ]
 
 [[package]]
@@ -5911,7 +6078,7 @@ dependencies = [
  "anyhow",
  "gimli",
  "more-asserts",
- "object",
+ "object 0.23.0",
  "target-lexicon 0.11.2",
  "thiserror",
  "wasmparser 0.76.0",
@@ -5956,7 +6123,7 @@ dependencies = [
  "gimli",
  "log",
  "more-asserts",
- "object",
+ "object 0.23.0",
  "region 2.2.0",
  "serde",
  "target-lexicon 0.11.2",
@@ -5992,7 +6159,7 @@ checksum = "a79fa098a3be8fabc50f5be60f8e47694d569afdc255de37850fc80295485012"
 dependencies = [
  "anyhow",
  "more-asserts",
- "object",
+ "object 0.23.0",
  "target-lexicon 0.11.2",
  "wasmtime-debug",
  "wasmtime-environ",
@@ -6054,6 +6221,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcfaeb27e2578d2c6271a45609f4a055e6d7ba3a12eff35b1fd5ba147bdf046"
 dependencies = [
  "wast",
+]
+
+[[package]]
+name = "which"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea187a8ef279bc014ec368c27a920da2024d2a711109bfbe3440585d5cf27ad9"
+dependencies = [
+ "either",
+ "lazy_static",
+ "libc",
 ]
 
 [[package]]

--- a/runtime/near-vm-runner-standalone/src/script.rs
+++ b/runtime/near-vm-runner-standalone/src/script.rs
@@ -119,7 +119,7 @@ impl Script {
         let config_store = RuntimeConfigStore::new(None);
         let runtime_fees_config = &config_store.get_config(self.protocol_version).transaction_costs;
         let mut outcomes = Vec::new();
-        if let Some(runtime) = self.vm_kind.runtime(self.vm_config.clone()) {
+        if let Some(runtime) = self.vm_kind.runtime() {
             for step in &self.steps {
                 for _ in 0..step.repeat {
                     let res = runtime.run(

--- a/runtime/near-vm-runner-standalone/src/script.rs
+++ b/runtime/near-vm-runner-standalone/src/script.rs
@@ -127,6 +127,7 @@ impl Script {
                         &step.method,
                         &mut external,
                         step.vm_context.clone(),
+                        &self.vm_config,
                         runtime_fees_config,
                         &step.promise_results,
                         self.protocol_version,

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -23,18 +23,17 @@ wasmparser = "0.78"
 memoffset = "0.6"
 
 # Use the following for development versions of Wasmer.
+# wasmer = { package = "wasmer-near", git = "https://github.com/near/wasmer", branch = "near-main", optional = true, default-features = false, features = ["singlepass", "universal"] }
 # wasmer-types = { package = "wasmer-types-near", git = "https://github.com/near/wasmer", branch = "near-main", optional = true }
 # wasmer-compiler-singlepass = { package = "wasmer-compiler-singlepass-near", git = "https://github.com/near/wasmer", branch = "near-main", optional = true }
 # wasmer-engine-universal = { package = "wasmer-engine-universal-near", git = "https://github.com/near/wasmer", branch = "near-main", optional = true }
 # wasmer-vm = { package = "wasmer-vm-near", git = "https://github.com/near/wasmer", branch = "near-main" }
-wasmer-compiler = { package = "wasmer-compiler-near", version = "=2.1.2", optional = true }
-wasmer-compiler-singlepass = { package = "wasmer-compiler-singlepass-near", version = "=2.1.2", optional = true }
-wasmer-engine = { package = "wasmer-engine-near", version = "=2.1.2", optional = true }
-wasmer-engine-universal = { package = "wasmer-engine-universal-near", version = "=2.1.2", optional = true, features = ["compiler"] }
+wasmer = { package = "wasmer-near", version = "=2.1.2", optional = true, default-features = false, features = ["singlepass", "universal"] }
 wasmer-types = { package = "wasmer-types-near", version = "=2.1.2", optional = true }
-wasmer-vm = { package = "wasmer-vm-near", version = "=2.1.2", optional = true }
+wasmer-compiler-singlepass = { package = "wasmer-compiler-singlepass-near", version = "=2.1.2", optional = true }
+wasmer-engine-universal = { package = "wasmer-engine-universal-near", version = "=2.1.2", optional = true }
+wasmer-vm = { package = "wasmer-vm-near", version = "=2.1.2" }
 
-loupe = "0.1"
 once_cell = "1.5.2"
 pwasm-utils = "0.12"
 parity-wasm = "0.41"
@@ -59,14 +58,7 @@ base64 = "0.13"
 default = ["wasmer0_vm", "wasmtime_vm", "wasmer2_vm"]
 wasmer0_vm = [ "wasmer-runtime", "wasmer-runtime-core" ]
 wasmtime_vm = [ "wasmtime", "anyhow"]
-wasmer2_vm = [
-    "wasmer-compiler",
-    "wasmer-compiler-singlepass",
-    "wasmer-engine",
-    "wasmer-engine-universal",
-    "wasmer-types",
-    "wasmer-vm"
-]
+wasmer2_vm = [ "wasmer", "wasmer-types", "wasmer-compiler-singlepass",  "wasmer-engine-universal", ]
 
 # Force usage of a specific wasm vm irrespective of protocol version.
 force_wasmer0 = ["wasmer0_vm"]

--- a/runtime/near-vm-runner/fuzz/fuzz_targets/runner.rs
+++ b/runtime/near-vm-runner/fuzz/fuzz_targets/runner.rs
@@ -26,11 +26,12 @@ fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> (Option<VMOutcome>, Option<
     let promise_results = vec![];
 
     let method_name = find_entry_point(code).unwrap_or_else(|| "main".to_string());
-    vm_kind.runtime(config).unwrap().run(
+    vm_kind.runtime(config.clone()).unwrap().run(
         code,
         &method_name,
         &mut fake_external,
         context,
+        &config,
         &fees,
         &promise_results,
         PROTOCOL_VERSION,

--- a/runtime/near-vm-runner/fuzz/fuzz_targets/runner.rs
+++ b/runtime/near-vm-runner/fuzz/fuzz_targets/runner.rs
@@ -26,7 +26,7 @@ fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> (Option<VMOutcome>, Option<
     let promise_results = vec![];
 
     let method_name = find_entry_point(code).unwrap_or_else(|| "main".to_string());
-    vm_kind.runtime(config.clone()).unwrap().run(
+    vm_kind.runtime().unwrap().run(
         code,
         &method_name,
         &mut fake_external,

--- a/runtime/near-vm-runner/src/imports.rs
+++ b/runtime/near-vm-runner/src/imports.rs
@@ -54,7 +54,7 @@ macro_rules! imports {
         $func:ident < [ $( $arg_name:ident : $arg_type:ident ),* ] -> [ $( $returns:ident ),* ] >,)*
     ) => {
         macro_rules! for_each_available_import {
-            ($protocol_version:expr, $M:ident) => {$(
+            ($protocol_version:ident, $M:ident) => {$(
                 $(#[cfg(feature = $feature_name)])*
                 if true
                     $(&& near_primitives::checked_feature!($feature_name, $feature, $protocol_version))*
@@ -274,155 +274,55 @@ pub(crate) mod wasmer {
 
 #[cfg(feature = "wasmer2_vm")]
 pub(crate) mod wasmer2 {
-    use std::sync::Arc;
-
     use super::str_eq;
-    use near_vm_logic::{ProtocolVersion, VMLogic};
-    use wasmer_engine::{ExportFunction, ExportFunctionMetadata, Resolver};
-    use wasmer_vm::{VMFunction, VMFunctionKind, VMMemory};
+    use near_vm_logic::{ProtocolVersion, VMLogic, VMLogicError};
 
-    pub(crate) struct Wasmer2Imports<'vmlogic, 'vmlogic_refs> {
-        pub(crate) memory: VMMemory,
-        // Note: this same object is also referenced by the `metadata` field!
-        pub(crate) vmlogic: &'vmlogic mut VMLogic<'vmlogic_refs>,
-        pub(crate) metadata: Arc<ExportFunctionMetadata>,
-        pub(crate) protocol_version: ProtocolVersion,
+    #[derive(wasmer::WasmerEnv, Clone)]
+    struct NearWasmerEnv {
+        /// Hack to allow usage of non-'static VMLogic as an environment in host
+        /// functions. Strictly speaking, this is unsound, but this is only
+        /// accessible to `near_vm_runner` crate, where we ensure that `VMLogic`
+        /// reference does not dangle. Still, would be great to fix this properly
+        /// one day.
+        logic: *mut (),
     }
+    unsafe impl Send for NearWasmerEnv {}
+    unsafe impl Sync for NearWasmerEnv {}
 
-    trait Wasmer2Type {
-        type Wasmer;
-        fn to_wasmer(self) -> Self::Wasmer;
-        fn ty() -> wasmer_types::Type;
-    }
-    macro_rules! wasmer_types {
-        ($($native:ty as $wasmer:ty => $type_expr:expr;)*) => {
-            $(impl Wasmer2Type for $native {
-                type Wasmer = $wasmer;
-                fn to_wasmer(self) -> $wasmer {
-                    self as _
-                }
-                fn ty() -> wasmer_types::Type {
-                    $type_expr
-                }
-            })*
-        }
-    }
-    wasmer_types! {
-        u32 as i32 => wasmer_types::Type::I32;
-        u64 as i64 => wasmer_types::Type::I64;
-    }
-
-    macro_rules! return_ty {
-        ($return_type: ident = [ ]) => {
-            type $return_type = ();
-            fn make_ret() -> () {}
-        };
-        ($return_type: ident = [ $($returns: ident),* ]) => {
-            #[repr(C)]
-            struct $return_type($(<$returns as Wasmer2Type>::Wasmer),*);
-            fn make_ret($($returns: $returns),*) -> Ret { Ret($($returns.to_wasmer()),*) }
-        }
-    }
-
-    impl<'vmlogic, 'vmlogic_refs> Resolver for Wasmer2Imports<'vmlogic, 'vmlogic_refs> {
-        fn resolve(&self, _index: u32, module: &str, field: &str) -> Option<wasmer_engine::Export> {
-            if module != "env" {
-                return None;
-            }
-            if field == "memory" {
-                return Some(wasmer_engine::Export::Memory(self.memory.clone()));
-            }
-
-            macro_rules! add_import {
-                (
-                  $func:ident <
-                    [ $( $arg_name:ident : $arg_type:ident ),* ]
-                    -> [ $( $returns:ident ),* ]
-                  >
-                ) => {
-                    return_ty!(Ret = [ $($returns),* ]);
-
-                    extern "C" fn $func(env: *mut VMLogic<'_>, $( $arg_name: $arg_type ),* )
-                    -> Ret {
-                        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                            const IS_GAS: bool = str_eq(stringify!($func), "gas");
-                            let _span = if IS_GAS {
-                                None
-                            } else {
-                                Some(tracing::trace_span!(
-                                    target: "host-function",
-                                    stringify!($func)
-                                ).entered())
-                            };
-
-                            // SAFETY: This code should only be executable within `'vmlogic`
-                            // lifetime and so it is safe to dereference the `env` pointer which is
-                            // known to be derived from a valid `&'vmlogic mut VMLogic<'_>` in the
-                            // first place.
-                            unsafe { (*env).$func( $( $arg_name, )* ) }
-                        }));
-                        // We want to ensure that the only kind of error that host function calls
-                        // return are VMLogicError. This is important because we later attempt to
-                        // downcast the `RuntimeError`s into `VMLogicError`.
-                        let result: Result<Result<_, near_vm_errors::VMLogicError>, _>  = result;
-                        #[allow(unused_parens)]
-                        match result {
-                            Ok(Ok(($($returns),*))) => make_ret($($returns),*),
-                            Ok(Err(trap)) => unsafe {
-                                // SAFETY: this can only be called by a WASM contract, so all the
-                                // necessary hooks are known to be in place.
-                                wasmer_vm::raise_user_trap(Box::new(trap))
-                            },
-                            Err(e) => unsafe {
-                                // SAFETY: this can only be called by a WASM contract, so all the
-                                // necessary hooks are known to be in place.
-                                wasmer_vm::resume_panic(e)
-                            },
-                        }
-                    }
-                    // TODO: a phf hashmap would probably work better here.
-                    if field == stringify!($func) {
-                        return Some(wasmer_engine::Export::Function(ExportFunction {
-                            vm_function: VMFunction {
-                                address: $func as *const _,
-                                // SAFETY: here we erase the lifetime of the `vmlogic` reference,
-                                // but we believe that the lifetimes on `Wasmer2Imports` enforce
-                                // sufficiently that it isn't possible to call this exported
-                                // function when vmlogic is no loger live.
-                                vmctx: wasmer_vm::VMFunctionEnvironment {
-                                    host_env: self.vmlogic as *const _ as *mut _
-                                },
-                                signature: wasmer_types::FunctionType::new([
-                                    $(<$arg_type as Wasmer2Type>::ty()),*
-                                ], [
-                                    $(<$returns as Wasmer2Type>::ty()),*
-                                ]),
-                                kind: VMFunctionKind::Static,
-                                call_trampoline: None,
-                                instance_ref: None,
-                            },
-                            metadata: Some(Arc::clone(&self.metadata)),
-                        }));
-                    }
-                };
-            }
-            for_each_available_import!(self.protocol_version, add_import);
-            return None;
-        }
-    }
-
-    pub(crate) fn build<'a, 'b>(
-        memory: VMMemory,
-        logic: &'a mut VMLogic<'b>,
+    pub(crate) fn build(
+        store: &wasmer::Store,
+        memory: wasmer::Memory,
+        logic: &mut VMLogic<'_>,
         protocol_version: ProtocolVersion,
-    ) -> Wasmer2Imports<'a, 'b> {
-        let metadata = unsafe {
-            // SAFETY: the functions here are thread-safe. We ensure that the lifetime of `VMLogic`
-            // is sufficiently long by tying the lifetime of VMLogic to the return type which
-            // contains this metadata.
-            ExportFunctionMetadata::new(logic as *mut _ as *mut _, None, |ptr| ptr, |_| {})
-        };
-        Wasmer2Imports { memory, vmlogic: logic, metadata: Arc::new(metadata), protocol_version }
+    ) -> wasmer::ImportObject {
+        let env = NearWasmerEnv { logic: logic as *mut _ as *mut () };
+        let mut import_object = wasmer::ImportObject::new();
+        let mut namespace = wasmer::Exports::new();
+        namespace.insert("memory", memory);
+
+        macro_rules! add_import {
+            (
+              $func:ident < [ $( $arg_name:ident : $arg_type:ident ),* ] -> [ $( $returns:ident ),* ] >
+            ) => {
+                #[allow(unused_parens)]
+                fn $func(env: &NearWasmerEnv, $( $arg_name: $arg_type ),* ) -> Result<($( $returns ),*), VMLogicError> {
+                    const IS_GAS: bool = str_eq(stringify!($func), "gas");
+                    let _span = if IS_GAS {
+                        None
+                    } else {
+                        Some(tracing::trace_span!(target: "host-function", stringify!($func)).entered())
+                    };
+                    let logic: &mut VMLogic = unsafe { &mut *(env.logic as *mut VMLogic<'_>) };
+                    logic.$func( $( $arg_name, )* )
+                }
+
+                namespace.insert(stringify!($func), wasmer::Function::new_native_with_env(&store, env.clone(), $func));
+            };
+        }
+        for_each_available_import!(protocol_version, add_import);
+
+        import_object.register("env", namespace);
+        import_object
     }
 }
 

--- a/runtime/near-vm-runner/src/preload.rs
+++ b/runtime/near-vm-runner/src/preload.rs
@@ -14,19 +14,25 @@ use crate::cache::{self, into_vm_result};
 use crate::memory::WasmerMemory;
 use crate::preload::VMModule::{Wasmer0, Wasmer2};
 use crate::vm_kind::VMKind;
-use crate::wasmer2_runner::{Wasmer2Memory, Wasmer2VM};
+use crate::wasmer2_runner::{default_wasmer2_store, run_wasmer2_module, Wasmer2Memory};
 use crate::wasmer_runner::run_wasmer0_module;
 
 const SHARE_MEMORY_INSTANCE: bool = false;
 
 enum VMModule {
     Wasmer0(wasmer_runtime::Module),
-    Wasmer2(crate::wasmer2_runner::VMArtifact),
+    Wasmer2(wasmer::Module),
 }
 
 enum VMDataPrivate {
     Wasmer0(Option<WasmerMemory>),
     Wasmer2(Option<Wasmer2Memory>),
+}
+
+#[derive(Clone)]
+enum VMDataShared {
+    Wasmer0,
+    Wasmer2(wasmer::Store),
 }
 
 struct VMCallData {
@@ -51,34 +57,46 @@ pub struct ContractCaller {
     vm_kind: VMKind,
     vm_config: VMConfig,
     vm_data_private: VMDataPrivate,
+    vm_data_shared: VMDataShared,
     preloaded: Vec<CallInner>,
 }
 
 impl ContractCaller {
     pub fn new(num_threads: usize, vm_kind: VMKind, vm_config: VMConfig) -> ContractCaller {
-        let private = match vm_kind {
-            VMKind::Wasmer0 => VMDataPrivate::Wasmer0(if SHARE_MEMORY_INSTANCE {
-                Some(
-                    WasmerMemory::new(
-                        vm_config.limit_config.initial_memory_pages,
-                        vm_config.limit_config.max_memory_pages,
+        let (shared, private) = match vm_kind {
+            VMKind::Wasmer0 => (
+                VMDataShared::Wasmer0,
+                VMDataPrivate::Wasmer0(if SHARE_MEMORY_INSTANCE {
+                    Some(
+                        WasmerMemory::new(
+                            vm_config.limit_config.initial_memory_pages,
+                            vm_config.limit_config.max_memory_pages,
+                        )
+                        .unwrap(),
                     )
-                    .unwrap(),
+                } else {
+                    None
+                }),
+            ),
+            VMKind::Wasmer2 => {
+                let store = default_wasmer2_store();
+                let store_clone = store.clone();
+                (
+                    VMDataShared::Wasmer2(store),
+                    VMDataPrivate::Wasmer2(if SHARE_MEMORY_INSTANCE {
+                        Some(
+                            Wasmer2Memory::new(
+                                &store_clone,
+                                vm_config.limit_config.initial_memory_pages,
+                                vm_config.limit_config.max_memory_pages,
+                            )
+                            .unwrap(),
+                        )
+                    } else {
+                        None
+                    }),
                 )
-            } else {
-                None
-            }),
-            VMKind::Wasmer2 => VMDataPrivate::Wasmer2(if SHARE_MEMORY_INSTANCE {
-                Some(
-                    Wasmer2Memory::new(
-                        vm_config.limit_config.initial_memory_pages,
-                        vm_config.limit_config.max_memory_pages,
-                    )
-                    .unwrap(),
-                )
-            } else {
-                None
-            }),
+            }
             VMKind::Wasmtime => panic!("Not currently supported"),
         };
         ContractCaller {
@@ -86,6 +104,7 @@ impl ContractCaller {
             vm_kind,
             vm_config,
             vm_data_private: private,
+            vm_data_shared: shared,
             preloaded: Vec::new(),
         }
     }
@@ -102,8 +121,9 @@ impl ContractCaller {
             self.pool.execute({
                 let tx = tx.clone();
                 let vm_config = self.vm_config.clone();
+                let vm_data_shared = self.vm_data_shared.clone();
                 let vm_kind = self.vm_kind.clone();
-                move || preload_in_thread(request, vm_kind, vm_config, tx)
+                move || preload_in_thread(request, vm_kind, vm_config, vm_data_shared, tx)
             });
             result.push(ContractCallPrepareResult { handle: index });
         }
@@ -125,54 +145,67 @@ impl ContractCaller {
                 let call_data = call.rx.recv().unwrap();
                 match call_data.result {
                     Err(err) => (None, Some(err)),
-                    Ok(module) => match (&module, &mut self.vm_data_private) {
-                        (Wasmer0(module), VMDataPrivate::Wasmer0(memory)) => {
-                            let mut new_memory;
-                            run_wasmer0_module(
-                                module.clone(),
-                                if memory.is_some() {
-                                    memory.as_mut().unwrap()
-                                } else {
-                                    new_memory = WasmerMemory::new(
-                                        self.vm_config.limit_config.initial_memory_pages,
-                                        self.vm_config.limit_config.max_memory_pages,
-                                    )
-                                    .unwrap();
-                                    &mut new_memory
-                                },
-                                method_name,
-                                ext,
-                                context,
-                                &self.vm_config,
-                                fees_config,
-                                promise_results,
-                                current_protocol_version,
-                            )
+                    Ok(module) => {
+                        match (&module, &mut self.vm_data_private, &self.vm_data_shared) {
+                            (
+                                Wasmer0(module),
+                                VMDataPrivate::Wasmer0(memory),
+                                VMDataShared::Wasmer0,
+                            ) => {
+                                let mut new_memory;
+                                run_wasmer0_module(
+                                    module.clone(),
+                                    if memory.is_some() {
+                                        memory.as_mut().unwrap()
+                                    } else {
+                                        new_memory = WasmerMemory::new(
+                                            self.vm_config.limit_config.initial_memory_pages,
+                                            self.vm_config.limit_config.max_memory_pages,
+                                        )
+                                        .unwrap();
+                                        &mut new_memory
+                                    },
+                                    method_name,
+                                    ext,
+                                    context,
+                                    &self.vm_config,
+                                    fees_config,
+                                    promise_results,
+                                    current_protocol_version,
+                                )
+                            }
+                            (
+                                Wasmer2(module),
+                                VMDataPrivate::Wasmer2(memory),
+                                VMDataShared::Wasmer2(store),
+                            ) => {
+                                let mut new_memory;
+                                run_wasmer2_module(
+                                    module,
+                                    store,
+                                    if memory.is_some() {
+                                        memory.as_mut().unwrap()
+                                    } else {
+                                        new_memory = Wasmer2Memory::new(
+                                            store,
+                                            self.vm_config.limit_config.initial_memory_pages,
+                                            self.vm_config.limit_config.max_memory_pages,
+                                        )
+                                        .unwrap();
+                                        &mut new_memory
+                                    },
+                                    method_name,
+                                    ext,
+                                    context,
+                                    &self.vm_config,
+                                    fees_config,
+                                    promise_results,
+                                    current_protocol_version,
+                                )
+                            }
+                            _ => panic!("Incorrect logic"),
                         }
-                        (Wasmer2(module), VMDataPrivate::Wasmer2(memory)) => {
-                            let mut new_memory;
-                            Wasmer2VM::new(self.vm_config.clone()).run_module(
-                                &module,
-                                if memory.is_some() {
-                                    memory.as_mut().unwrap()
-                                } else {
-                                    new_memory = Wasmer2Memory::new(
-                                        self.vm_config.limit_config.initial_memory_pages,
-                                        self.vm_config.limit_config.max_memory_pages,
-                                    )
-                                    .unwrap();
-                                    &mut new_memory
-                                },
-                                method_name,
-                                ext,
-                                context,
-                                fees_config,
-                                promise_results,
-                                current_protocol_version,
-                            )
-                        }
-                        _ => panic!("Incorrect logic"),
-                    },
+                    }
                 }
             }
             None => panic!("Must be valid"),
@@ -190,11 +223,12 @@ fn preload_in_thread(
     request: ContractCallPrepareRequest,
     vm_kind: VMKind,
     vm_config: VMConfig,
+    vm_data_shared: VMDataShared,
     tx: Sender<VMCallData>,
 ) {
     let cache = request.cache.as_deref();
-    let result = match vm_kind {
-        VMKind::Wasmer0 => {
+    let result = match (vm_kind, vm_data_shared) {
+        (VMKind::Wasmer0, VMDataShared::Wasmer0) => {
             let module = cache::wasmer0_cache::compile_module_cached_wasmer0(
                 &request.code,
                 &vm_config,
@@ -202,11 +236,12 @@ fn preload_in_thread(
             );
             into_vm_result(module).map(VMModule::Wasmer0)
         }
-        VMKind::Wasmer2 => {
+        (VMKind::Wasmer2, VMDataShared::Wasmer2(store)) => {
             let module = cache::wasmer2_cache::compile_module_cached_wasmer2(
                 &request.code,
                 &vm_config,
                 cache,
+                &store,
             );
             into_vm_result(module).map(VMModule::Wasmer2)
         }

--- a/runtime/near-vm-runner/src/runner.rs
+++ b/runtime/near-vm-runner/src/runner.rs
@@ -35,7 +35,7 @@ pub fn run(
     cache: Option<&dyn CompiledContractCache>,
 ) -> (Option<VMOutcome>, Option<VMError>) {
     let vm_kind = VMKind::for_protocol_version(current_protocol_version);
-    if let Some(runtime) = vm_kind.runtime(wasm_config.clone()) {
+    if let Some(runtime) = vm_kind.runtime() {
         runtime.run(
             code,
             method_name,
@@ -98,22 +98,22 @@ impl VMKind {
     /// Make a [`Runtime`] for this [`VMKind`].
     ///
     /// This is not intended to be used by code other than standalone-vm-runner.
-    pub fn runtime(&self, config: VMConfig) -> Option<Box<dyn VM>> {
+    pub fn runtime(&self) -> Option<&'static dyn VM> {
         match self {
             #[cfg(feature = "wasmer0_vm")]
             Self::Wasmer0 => {
                 use crate::wasmer_runner::Wasmer0VM;
-                Some(Box::new(Wasmer0VM))
+                Some(&Wasmer0VM as &'static dyn VM)
             }
             #[cfg(feature = "wasmtime_vm")]
             Self::Wasmtime => {
                 use crate::wasmtime_runner::WasmtimeVM;
-                Some(Box::new(WasmtimeVM))
+                Some(&WasmtimeVM as &'static dyn VM)
             }
             #[cfg(feature = "wasmer2_vm")]
             Self::Wasmer2 => {
                 use crate::wasmer2_runner::Wasmer2VM;
-                Some(Box::new(Wasmer2VM::new(config)))
+                Some(&Wasmer2VM as &'static dyn VM)
             }
             #[allow(unreachable_patterns)] // reachable when some of the VMs are disabled.
             _ => None,

--- a/runtime/near-vm-runner/src/tests.rs
+++ b/runtime/near-vm-runner/src/tests.rs
@@ -70,7 +70,7 @@ fn make_simple_contract_call_with_gas_vm(
     let promise_results = vec![];
 
     let code = ContractCode::new(code.to_vec(), None);
-    let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
+    let runtime = vm_kind.runtime().expect("runtime has not been compiled");
     runtime.run(
         &code,
         method_name,
@@ -96,7 +96,7 @@ fn make_simple_contract_call_with_protocol_version_vm(
     let runtime_config = runtime_config_store.get_config(protocol_version);
     let config = &runtime_config.wasm_config;
     let fees = &runtime_config.transaction_costs;
-    let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
+    let runtime = vm_kind.runtime().expect("runtime has not been compiled");
 
     let promise_results = vec![];
     let code = ContractCode::new(code.to_vec(), None);

--- a/runtime/near-vm-runner/src/tests.rs
+++ b/runtime/near-vm-runner/src/tests.rs
@@ -70,12 +70,13 @@ fn make_simple_contract_call_with_gas_vm(
     let promise_results = vec![];
 
     let code = ContractCode::new(code.to_vec(), None);
-    let runtime = vm_kind.runtime(config).expect("runtime has not been compiled");
+    let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
     runtime.run(
         &code,
         method_name,
         &mut fake_external,
         context,
+        &config,
         &fees,
         &promise_results,
         LATEST_PROTOCOL_VERSION,
@@ -93,9 +94,9 @@ fn make_simple_contract_call_with_protocol_version_vm(
     let context = create_context(vec![]);
     let runtime_config_store = RuntimeConfigStore::new(None);
     let runtime_config = runtime_config_store.get_config(protocol_version);
+    let config = &runtime_config.wasm_config;
     let fees = &runtime_config.transaction_costs;
-    let runtime =
-        vm_kind.runtime(runtime_config.wasm_config.clone()).expect("runtime has not been compiled");
+    let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
 
     let promise_results = vec![];
     let code = ContractCode::new(code.to_vec(), None);
@@ -104,6 +105,7 @@ fn make_simple_contract_call_with_protocol_version_vm(
         method_name,
         &mut fake_external,
         context,
+        config,
         fees,
         &promise_results,
         protocol_version,

--- a/runtime/near-vm-runner/src/tests/cache.rs
+++ b/runtime/near-vm-runner/src/tests/cache.rs
@@ -71,7 +71,7 @@ fn make_cached_contract_call_vm(
     let promise_results = vec![];
     context.prepaid_gas = prepaid_gas;
     let code = ContractCode::new(code.to_vec(), None);
-    let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
+    let runtime = vm_kind.runtime().expect("runtime has not been compiled");
 
     runtime.run(
         &code,

--- a/runtime/near-vm-runner/src/tests/cache.rs
+++ b/runtime/near-vm-runner/src/tests/cache.rs
@@ -71,12 +71,14 @@ fn make_cached_contract_call_vm(
     let promise_results = vec![];
     context.prepaid_gas = prepaid_gas;
     let code = ContractCode::new(code.to_vec(), None);
-    let runtime = vm_kind.runtime(config).expect("runtime has not been compiled");
+    let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
+
     runtime.run(
         &code,
         method_name,
         &mut fake_external,
         context.clone(),
+        &config,
         &fees,
         &promise_results,
         LATEST_PROTOCOL_VERSION,

--- a/runtime/near-vm-runner/src/tests/contract_preload.rs
+++ b/runtime/near-vm-runner/src/tests/contract_preload.rs
@@ -138,7 +138,7 @@ fn test_vm_runner(preloaded: bool, vm_kind: VMKind, repeat: i32) {
             errs += err;
         }
     } else {
-        let runtime = vm_kind.runtime(vm_config.clone()).expect("runtime is has not been compiled");
+        let runtime = vm_kind.runtime().expect("runtime is has not been compiled");
         for _ in 0..repeat {
             let result1 = runtime.run(
                 &code1,

--- a/runtime/near-vm-runner/src/tests/contract_preload.rs
+++ b/runtime/near-vm-runner/src/tests/contract_preload.rs
@@ -138,13 +138,14 @@ fn test_vm_runner(preloaded: bool, vm_kind: VMKind, repeat: i32) {
             errs += err;
         }
     } else {
-        let runtime = vm_kind.runtime(vm_config).expect("runtime is has not been compiled");
+        let runtime = vm_kind.runtime(vm_config.clone()).expect("runtime is has not been compiled");
         for _ in 0..repeat {
             let result1 = runtime.run(
                 &code1,
                 method_name1,
                 &mut fake_external,
                 context.clone(),
+                &vm_config,
                 &fees,
                 &promise_results,
                 ProtocolVersion::MAX,
@@ -158,6 +159,7 @@ fn test_vm_runner(preloaded: bool, vm_kind: VMKind, repeat: i32) {
                 method_name1,
                 &mut fake_external,
                 context.clone(),
+                &vm_config,
                 &fees,
                 &promise_results,
                 ProtocolVersion::MAX,

--- a/runtime/near-vm-runner/src/tests/rs_contract.rs
+++ b/runtime/near-vm-runner/src/tests/rs_contract.rs
@@ -61,12 +61,13 @@ pub fn test_read_write() {
         let fees = RuntimeFeesConfig::test();
 
         let promise_results = vec![];
-        let runtime = vm_kind.runtime(config).expect("runtime has not been compiled");
+        let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
         let result = runtime.run(
             &code,
             "write_key_value",
             &mut fake_external,
             context,
+            &config,
             &fees,
             &promise_results,
             LATEST_PROTOCOL_VERSION,
@@ -80,6 +81,7 @@ pub fn test_read_write() {
             "read_value",
             &mut fake_external,
             context,
+            &config,
             &fees,
             &promise_results,
             LATEST_PROTOCOL_VERSION,
@@ -100,12 +102,13 @@ pub fn test_stablized_host_function() {
         let fees = RuntimeFeesConfig::test();
 
         let promise_results = vec![];
-        let runtime = vm_kind.runtime(config).expect("runtime has not been compiled");
+        let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
         let result = runtime.run(
             &code,
             "do_ripemd",
             &mut fake_external,
             context.clone(),
+            &config,
             &fees,
             &promise_results,
             LATEST_PROTOCOL_VERSION,
@@ -118,6 +121,7 @@ pub fn test_stablized_host_function() {
             "do_ripemd",
             &mut fake_external,
             context,
+            &config,
             &fees,
             &promise_results,
             ProtocolFeature::MathExtension.protocol_version() - 1,
@@ -171,13 +175,14 @@ fn run_test_ext(
     let config = VMConfig::test();
     let fees = RuntimeFeesConfig::test();
     let context = create_context(input.to_vec());
-    let runtime = vm_kind.runtime(config).expect("runtime has not been compiled");
+    let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
 
     let (outcome, err) = runtime.run(
         &code,
         method,
         &mut fake_external,
         context,
+        &config,
         &fees,
         &[],
         LATEST_PROTOCOL_VERSION,
@@ -304,7 +309,7 @@ pub fn test_out_of_memory() {
         let context = create_context(Vec::new());
         let config = VMConfig::free();
         let fees = RuntimeFeesConfig::free();
-        let runtime = vm_kind.runtime(config).expect("runtime has not been compiled");
+        let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
 
         let promise_results = vec![];
         let result = runtime.run(
@@ -312,6 +317,7 @@ pub fn test_out_of_memory() {
             "out_of_memory",
             &mut fake_external,
             context,
+            &config,
             &fees,
             &promise_results,
             LATEST_PROTOCOL_VERSION,

--- a/runtime/near-vm-runner/src/tests/rs_contract.rs
+++ b/runtime/near-vm-runner/src/tests/rs_contract.rs
@@ -61,7 +61,7 @@ pub fn test_read_write() {
         let fees = RuntimeFeesConfig::test();
 
         let promise_results = vec![];
-        let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
+        let runtime = vm_kind.runtime().expect("runtime has not been compiled");
         let result = runtime.run(
             &code,
             "write_key_value",
@@ -102,7 +102,7 @@ pub fn test_stablized_host_function() {
         let fees = RuntimeFeesConfig::test();
 
         let promise_results = vec![];
-        let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
+        let runtime = vm_kind.runtime().expect("runtime has not been compiled");
         let result = runtime.run(
             &code,
             "do_ripemd",
@@ -175,7 +175,7 @@ fn run_test_ext(
     let config = VMConfig::test();
     let fees = RuntimeFeesConfig::test();
     let context = create_context(input.to_vec());
-    let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
+    let runtime = vm_kind.runtime().expect("runtime has not been compiled");
 
     let (outcome, err) = runtime.run(
         &code,
@@ -309,7 +309,7 @@ pub fn test_out_of_memory() {
         let context = create_context(Vec::new());
         let config = VMConfig::free();
         let fees = RuntimeFeesConfig::free();
-        let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
+        let runtime = vm_kind.runtime().expect("runtime has not been compiled");
 
         let promise_results = vec![];
         let result = runtime.run(

--- a/runtime/near-vm-runner/src/tests/ts_contract.rs
+++ b/runtime/near-vm-runner/src/tests/ts_contract.rs
@@ -20,7 +20,7 @@ pub fn test_ts_contract() {
 
         // Call method that panics.
         let promise_results = vec![];
-        let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
+        let runtime = vm_kind.runtime().expect("runtime has not been compiled");
         let result = runtime.run(
             &code,
             "try_panic",

--- a/runtime/near-vm-runner/src/tests/ts_contract.rs
+++ b/runtime/near-vm-runner/src/tests/ts_contract.rs
@@ -20,12 +20,13 @@ pub fn test_ts_contract() {
 
         // Call method that panics.
         let promise_results = vec![];
-        let runtime = vm_kind.runtime(config).expect("runtime has not been compiled");
+        let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
         let result = runtime.run(
             &code,
             "try_panic",
             &mut fake_external,
             context,
+            &config,
             &fees,
             &promise_results,
             LATEST_PROTOCOL_VERSION,
@@ -46,6 +47,7 @@ pub fn test_ts_contract() {
                 "try_storage_write",
                 &mut fake_external,
                 context,
+                &config,
                 &fees,
                 &promise_results,
                 LATEST_PROTOCOL_VERSION,
@@ -69,6 +71,7 @@ pub fn test_ts_contract() {
             "try_storage_read",
             &mut fake_external,
             context,
+            &config,
             &fees,
             &promise_results,
             LATEST_PROTOCOL_VERSION,

--- a/runtime/near-vm-runner/src/wasmer2_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer2_runner.rs
@@ -521,6 +521,7 @@ impl crate::runner::VM for Wasmer2VM {
         method_name: &str,
         ext: &mut dyn External,
         context: VMContext,
+        wasm_config: &VMConfig,
         fees_config: &RuntimeFeesConfig,
         promise_results: &[PromiseResult],
         current_protocol_version: ProtocolVersion,
@@ -543,15 +544,15 @@ impl crate::runner::VM for Wasmer2VM {
             );
         }
         let artifact =
-            cache::wasmer2_cache::compile_module_cached_wasmer2(code, &self.config, cache);
+            cache::wasmer2_cache::compile_module_cached_wasmer2(code, wasm_config, cache);
         let artifact = match into_vm_result(artifact) {
             Ok(it) => it,
             Err(err) => return (None, Some(err)),
         };
 
         let mut memory = Wasmer2Memory::new(
-            self.config.limit_config.initial_memory_pages,
-            self.config.limit_config.max_memory_pages,
+            wasm_config.limit_config.initial_memory_pages,
+            wasm_config.limit_config.max_memory_pages,
         )
         .expect("Cannot create memory for a contract call");
 
@@ -561,7 +562,7 @@ impl crate::runner::VM for Wasmer2VM {
         let mut logic = VMLogic::new_with_protocol_version(
             ext,
             context,
-            &self.config,
+            wasm_config,
             fees_config,
             promise_results,
             &mut memory,
@@ -588,12 +589,13 @@ impl crate::runner::VM for Wasmer2VM {
         &self,
         code: &[u8],
         code_hash: &near_primitives::hash::CryptoHash,
+        wasm_config: &VMConfig,
         cache: &dyn CompiledContractCache,
     ) -> Option<VMError> {
         let result = crate::cache::wasmer2_cache::compile_and_serialize_wasmer2(
             code,
             code_hash,
-            &self.config,
+            wasm_config,
             cache,
         );
         into_vm_result(result).err()

--- a/runtime/near-vm-runner/src/wasmer2_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer2_runner.rs
@@ -1,28 +1,31 @@
 use crate::cache::into_vm_result;
-use crate::imports::wasmer2::Wasmer2Imports;
+use crate::errors::IntoVMError;
 use crate::prepare::WASM_FEATURES;
 use crate::{cache, imports};
 use memoffset::offset_of;
 use near_primitives::contract::ContractCode;
 use near_primitives::runtime::fees::RuntimeFeesConfig;
 use near_primitives::types::CompiledContractCache;
-use near_stable_hasher::StableHasher;
-use near_vm_errors::{CompilationError, FunctionCallError, MethodResolveError, VMError, WasmTrap};
-use near_vm_logic::gas_counter::FastGasCounter;
+use near_vm_errors::{
+    CompilationError, FunctionCallError, HostError, MethodResolveError, PrepareError, VMError,
+    WasmTrap,
+};
 use near_vm_logic::types::{PromiseResult, ProtocolVersion};
-use near_vm_logic::{External, MemoryLike, VMConfig, VMContext, VMLogic, VMOutcome};
+use near_vm_logic::{External, MemoryLike, VMConfig, VMContext, VMLogic, VMLogicError, VMOutcome};
 use std::hash::{Hash, Hasher};
 use std::mem::size_of;
-use std::sync::Arc;
-use wasmer_compiler_singlepass::Singlepass;
-use wasmer_engine::{DeserializeError, Engine};
-use wasmer_engine_universal::{Universal, UniversalEngine};
-use wasmer_types::{
-    ExportIndex, Features, FunctionIndex, InstanceConfig, MemoryType, Pages, WASM_PAGE_SIZE,
+use wasmer::{
+    Bytes, ImportObject, Instance, InstantiationError, Memory, MemoryType, Module, Pages,
+    RuntimeError, Store,
 };
-use wasmer_vm::{LinearMemory, LinearTable, Memory, MemoryStyle, TrapCode, VMExtern, VMMemory};
 
-const WASMER_FEATURES: Features = Features {
+use near_stable_hasher::StableHasher;
+use near_vm_logic::gas_counter::FastGasCounter;
+use wasmer_compiler_singlepass::Singlepass;
+use wasmer_types::InstanceConfig;
+use wasmer_vm::TrapCode;
+
+const WASMER_FEATURES: wasmer::Features = wasmer::Features {
     threads: WASM_FEATURES.threads,
     reference_types: WASM_FEATURES.reference_types,
     simd: WASM_FEATURES.simd,
@@ -37,104 +40,142 @@ const WASMER_FEATURES: Features = Features {
     signal_less: true,
 };
 
-#[derive(Clone)]
-pub struct Wasmer2Memory(Arc<LinearMemory>);
+pub struct Wasmer2Memory(Memory);
 
 impl Wasmer2Memory {
-    pub(crate) fn new(initial_memory_pages: u32, max_memory_pages: u32) -> Result<Self, VMError> {
-        let max_pages = Pages(max_memory_pages);
-        Ok(Wasmer2Memory(Arc::new(
-            LinearMemory::new(
-                &MemoryType::new(Pages(initial_memory_pages), Some(max_pages), false),
-                &MemoryStyle::Static {
-                    bound: max_pages,
-                    offset_guard_size: wasmer_types::WASM_PAGE_SIZE as u64,
-                },
+    pub fn new(
+        store: &Store,
+        initial_memory_pages: u32,
+        max_memory_pages: u32,
+    ) -> Result<Self, VMError> {
+        Ok(Wasmer2Memory(
+            Memory::new(
+                store,
+                MemoryType::new(Pages(initial_memory_pages), Some(Pages(max_memory_pages)), false),
             )
-            .expect("creating memory must not fail"),
-        )))
+            .expect("TODO creating memory cannot fail"),
+        ))
     }
 
-    // Returns the pointer to memory at the specified offset and the size of the buffer starting at
-    // the returned pointer.
-    fn data_offset(&self, offset: u64) -> Option<(*mut u8, usize)> {
-        let size = self.0.size().bytes().0;
-        let offset = usize::try_from(offset).ok()?;
-        // `checked_sub` here verifies that offsetting the buffer by offset still lands us
-        // in-bounds of the allocated object.
-        let remaining = size.checked_sub(offset)?;
-        Some(unsafe {
-            // SAFETY: we verified that offsetting the base pointer by `offset` still lands us
-            // in-bounds of the original object.
-            (self.0.vmmemory().as_ref().base.add(offset), remaining)
-        })
-    }
-
-    fn get_memory_buffer(&self, offset: u64, len: usize) -> *mut u8 {
-        let memory = self.data_offset(offset).map(|(data, remaining)| (data, len <= remaining));
-        if let Some((ptr, true)) = memory {
-            ptr
-        } else {
-            panic!("memory access out of bounds")
-        }
-    }
-
-    pub(crate) fn vm(&self) -> VMMemory {
-        VMMemory { from: self.0.clone(), instance_ref: None }
+    pub fn clone(&self) -> Memory {
+        self.0.clone()
     }
 }
 
 impl MemoryLike for Wasmer2Memory {
     fn fits_memory(&self, offset: u64, len: u64) -> bool {
-        self.data_offset(offset)
-            .and_then(|(_, remaining)| {
-                let len = usize::try_from(len).ok()?;
-                Some(len <= remaining)
-            })
-            .unwrap_or(false)
+        match offset.checked_add(len) {
+            None => false,
+            Some(end) => self.0.size().bytes() >= Bytes(end as usize),
+        }
     }
 
     fn read_memory(&self, offset: u64, buffer: &mut [u8]) {
-        unsafe {
-            let memory = self.get_memory_buffer(offset, buffer.len());
-            // SAFETY: we verified indices into are valid and the pointer will always be valid as
-            // well. Our runtime is currently only executing Wasm code on a single thread, so data
-            // races aren't a concern here.
-            std::ptr::copy_nonoverlapping(memory, buffer.as_mut_ptr(), buffer.len());
+        let offset = offset as usize;
+        for (i, cell) in self.0.view()[offset..(offset + buffer.len())].iter().enumerate() {
+            buffer[i] = cell.get();
         }
     }
 
     fn read_memory_u8(&self, offset: u64) -> u8 {
-        unsafe { *self.get_memory_buffer(offset, 1) }
+        self.0.view()[offset as usize].get()
     }
 
     fn write_memory(&mut self, offset: u64, buffer: &[u8]) {
-        unsafe {
-            let memory = self.get_memory_buffer(offset, buffer.len());
-            // SAFETY: we verified indices into are valid and the pointer will always be valid as
-            // well. Our runtime is currently only executing Wasm code on a single thread, so data
-            // races aren't a concern here.
-            std::ptr::copy_nonoverlapping(buffer.as_ptr(), memory, buffer.len());
+        let offset = offset as usize;
+        self.0.view()[offset..(offset + buffer.len())]
+            .iter()
+            .zip(buffer.iter())
+            .for_each(|(cell, v)| cell.set(*v));
+    }
+}
+
+impl IntoVMError for wasmer::InstantiationError {
+    fn into_vm_error(self) -> VMError {
+        match self {
+            wasmer::InstantiationError::Link(e) => {
+                VMError::FunctionCallError(FunctionCallError::LinkError { msg: e.to_string() })
+            }
+            wasmer::InstantiationError::CpuFeature(e) => {
+                panic!("host does not support the CPU features required to run contracts: {}", e)
+            }
+            wasmer::InstantiationError::Start(e) => e.into_vm_error(),
+            wasmer::InstantiationError::HostEnvInitialization(_) => {
+                VMError::FunctionCallError(FunctionCallError::CompilationError(
+                    CompilationError::PrepareError(PrepareError::Instantiate),
+                ))
+            }
         }
     }
 }
 
-fn get_entrypoint_index(
-    artifact: &dyn wasmer_engine::Artifact,
-    method_name: &str,
-) -> Result<FunctionIndex, VMError> {
-    if method_name.is_empty() {
-        // Do we really need this code?
-        return Err(VMError::FunctionCallError(FunctionCallError::MethodResolveError(
-            MethodResolveError::MethodEmptyName,
-        )));
+impl IntoVMError for wasmer::RuntimeError {
+    fn into_vm_error(self) -> VMError {
+        // These vars are not used in every cases, however, downcast below use Arc::try_unwrap
+        // so we cannot clone self
+        let error_msg = self.message();
+        let trap_code = self.clone().to_trap();
+        if let Ok(e) = self.downcast::<VMLogicError>() {
+            return e.into();
+        }
+        // If we panic here - it means we encountered an issue in Wasmer.
+        let trap_code = trap_code.unwrap_or_else(|| panic!("Unknown error: {}", error_msg));
+        let error = match trap_code {
+            TrapCode::StackOverflow => FunctionCallError::WasmTrap(WasmTrap::StackOverflow),
+            TrapCode::HeapAccessOutOfBounds => {
+                FunctionCallError::WasmTrap(WasmTrap::MemoryOutOfBounds)
+            }
+            TrapCode::HeapMisaligned => {
+                FunctionCallError::WasmTrap(WasmTrap::MisalignedAtomicAccess)
+            }
+            TrapCode::TableAccessOutOfBounds => {
+                FunctionCallError::WasmTrap(WasmTrap::MemoryOutOfBounds)
+            }
+            TrapCode::OutOfBounds => FunctionCallError::WasmTrap(WasmTrap::MemoryOutOfBounds),
+            TrapCode::IndirectCallToNull => {
+                FunctionCallError::WasmTrap(WasmTrap::IndirectCallToNull)
+            }
+            TrapCode::BadSignature => {
+                FunctionCallError::WasmTrap(WasmTrap::IncorrectCallIndirectSignature)
+            }
+            TrapCode::IntegerOverflow => FunctionCallError::WasmTrap(WasmTrap::IllegalArithmetic),
+            TrapCode::IntegerDivisionByZero => {
+                FunctionCallError::WasmTrap(WasmTrap::IllegalArithmetic)
+            }
+            TrapCode::BadConversionToInteger => {
+                FunctionCallError::WasmTrap(WasmTrap::IllegalArithmetic)
+            }
+            TrapCode::UnreachableCodeReached => FunctionCallError::WasmTrap(WasmTrap::Unreachable),
+            TrapCode::UnalignedAtomic => {
+                FunctionCallError::WasmTrap(WasmTrap::MisalignedAtomicAccess)
+            }
+            TrapCode::GasExceeded => FunctionCallError::HostError(HostError::GasExceeded),
+        };
+        VMError::FunctionCallError(error)
     }
-    let module = artifact.module_ref();
-    if let Some(ExportIndex::Function(index)) = module.exports.get(method_name) {
-        let func = module.functions.get(index.clone()).unwrap();
-        let sig = module.signatures.get(func.clone()).unwrap();
+}
+
+impl IntoVMError for wasmer::ExportError {
+    fn into_vm_error(self) -> VMError {
+        match self {
+            wasmer::ExportError::IncompatibleType => VMError::FunctionCallError(
+                FunctionCallError::MethodResolveError(MethodResolveError::MethodInvalidSignature),
+            ),
+            wasmer::ExportError::Missing(_) => VMError::FunctionCallError(
+                FunctionCallError::MethodResolveError(MethodResolveError::MethodNotFound),
+            ),
+        }
+    }
+}
+
+fn check_method(module: &Module, method_name: &str) -> Result<(), VMError> {
+    let info = module.info();
+    use wasmer_types::ExportIndex::Function;
+    if let Some(Function(index)) = info.exports.get(method_name) {
+        let func = info.functions.get(index.clone()).unwrap();
+        let sig = info.signatures.get(func.clone()).unwrap();
         if sig.params().is_empty() && sig.results().is_empty() {
-            Ok(*index)
+            Ok(())
         } else {
             Err(VMError::FunctionCallError(FunctionCallError::MethodResolveError(
                 MethodResolveError::MethodInvalidSignature,
@@ -147,52 +188,72 @@ fn get_entrypoint_index(
     }
 }
 
-fn translate_instantiation_error(
-    err: wasmer_engine::InstantiationError,
-    logic: &mut VMLogic,
-) -> VMError {
-    use wasmer_engine::InstantiationError::*;
+fn translate_instantiation_error(err: InstantiationError, logic: &mut VMLogic) -> VMError {
     match err {
-        Start(err) => translate_runtime_error(err, logic),
-        Link(e) => VMError::FunctionCallError(FunctionCallError::LinkError { msg: e.to_string() }),
-        CpuFeature(e) => {
-            panic!("host does not support the CPU features required to run contracts: {}", e)
-        }
+        InstantiationError::Start(err) => translate_runtime_error(err, logic),
+        _ => err.into_vm_error(),
     }
 }
 
-fn translate_runtime_error(error: wasmer_engine::RuntimeError, logic: &mut VMLogic) -> VMError {
-    // Errors produced by host function calls also become `RuntimeError`s that wrap a dynamic
-    // instance of `VMLogicError` internally. See the implementation of `Wasmer2Imports`.
-    let error = match error.downcast::<near_vm_errors::VMLogicError>() {
-        Ok(vm_logic) => return vm_logic.into(),
-        Err(original) => original,
+fn translate_runtime_error(err: RuntimeError, logic: &mut VMLogic) -> VMError {
+    match err.clone().to_trap() {
+        Some(TrapCode::GasExceeded) => {
+            VMError::FunctionCallError(FunctionCallError::HostError(logic.process_gas_limit()))
+        }
+        _ => err.into_vm_error(),
+    }
+}
+
+fn run_method(
+    module: &Module,
+    import: &ImportObject,
+    method_name: &str,
+    logic: &mut VMLogic,
+) -> Result<(), VMError> {
+    let _span = tracing::debug_span!(target: "vm", "run_method").entered();
+
+    // FastGasCounter in Nearcore and Wasmer must match in layout.
+    assert_eq!(size_of::<FastGasCounter>(), size_of::<wasmer_types::FastGasCounter>());
+    assert_eq!(
+        offset_of!(FastGasCounter, burnt_gas),
+        offset_of!(wasmer_types::FastGasCounter, burnt_gas)
+    );
+    assert_eq!(
+        offset_of!(FastGasCounter, gas_limit),
+        offset_of!(wasmer_types::FastGasCounter, gas_limit)
+    );
+    assert_eq!(
+        offset_of!(FastGasCounter, opcode_cost),
+        offset_of!(wasmer_types::FastGasCounter, opcode_cost)
+    );
+
+    let instance = {
+        let _span = tracing::debug_span!(target: "vm", "run_method/instantiate").entered();
+        Instance::new_with_config(
+            module,
+            unsafe {
+                InstanceConfig::new_with_counter(
+                    logic.gas_counter_pointer() as *mut wasmer_types::FastGasCounter
+                )
+            },
+            &import,
+        )
+        .map_err(|err| translate_instantiation_error(err, logic))?
     };
-    let msg = error.message();
-    let trap_code = error.to_trap().unwrap_or_else(|| {
-        panic!("runtime error is not a trap: {}", msg);
-    });
-    VMError::FunctionCallError(match trap_code {
-        TrapCode::GasExceeded => FunctionCallError::HostError(logic.process_gas_limit()),
-        TrapCode::StackOverflow => FunctionCallError::WasmTrap(WasmTrap::StackOverflow),
-        TrapCode::HeapAccessOutOfBounds => FunctionCallError::WasmTrap(WasmTrap::MemoryOutOfBounds),
-        TrapCode::HeapMisaligned => FunctionCallError::WasmTrap(WasmTrap::MisalignedAtomicAccess),
-        TrapCode::TableAccessOutOfBounds => {
-            FunctionCallError::WasmTrap(WasmTrap::MemoryOutOfBounds)
-        }
-        TrapCode::OutOfBounds => FunctionCallError::WasmTrap(WasmTrap::MemoryOutOfBounds),
-        TrapCode::IndirectCallToNull => FunctionCallError::WasmTrap(WasmTrap::IndirectCallToNull),
-        TrapCode::BadSignature => {
-            FunctionCallError::WasmTrap(WasmTrap::IncorrectCallIndirectSignature)
-        }
-        TrapCode::IntegerOverflow => FunctionCallError::WasmTrap(WasmTrap::IllegalArithmetic),
-        TrapCode::IntegerDivisionByZero => FunctionCallError::WasmTrap(WasmTrap::IllegalArithmetic),
-        TrapCode::BadConversionToInteger => {
-            FunctionCallError::WasmTrap(WasmTrap::IllegalArithmetic)
-        }
-        TrapCode::UnreachableCodeReached => FunctionCallError::WasmTrap(WasmTrap::Unreachable),
-        TrapCode::UnalignedAtomic => FunctionCallError::WasmTrap(WasmTrap::MisalignedAtomicAccess),
-    })
+    let f = instance.exports.get_function(method_name).map_err(|err| err.into_vm_error())?;
+    let f = f.native::<(), ()>().map_err(|err| err.into_vm_error())?;
+
+    {
+        let _span = tracing::debug_span!(target: "vm", "run_method/call").entered();
+        f.call().map_err(|err| translate_runtime_error(err, logic))?
+    }
+
+    {
+        let _span = tracing::debug_span!(target: "vm", "run_method/drop_instance").entered();
+        drop(instance)
+    }
+
+    Ok(())
 }
 
 #[derive(Hash, PartialEq, Debug)]
@@ -240,279 +301,79 @@ pub(crate) fn wasmer2_vm_hash() -> u64 {
     WASMER2_CONFIG.config_hash()
 }
 
-#[derive(Clone)]
-pub(crate) struct VMArtifact {
-    artifact: Arc<dyn wasmer_engine::Artifact>,
-    // FIXME(nagisa): Creating an artifact currently allocates data in the arena owned by the
-    // `UniversalEngine`. We cache artifacts in memory that outlive the VM they are part of, so for
-    // the time being lets keep a reference to the engine with each artifact.
-    //
-    // There are two outstanding tasks that we may want to resolve which will allow removing this
-    // specific field: first is removing the in-memory cache (and/or making sure that the VM
-    // lifetime outlives the VM cache). The second is removing the allocations in question – those
-    // allocate data such as trampolines and should only occur when an instantiation happens.
-    _engine: UniversalEngine,
+pub(crate) fn default_wasmer2_store() -> Store {
+    // We only support singlepass compiler at the moment.
+    assert_eq!(WASMER2_CONFIG.compiler, WasmerCompiler::Singlepass);
+    let compiler = Singlepass::new();
+    // We only support universal engine at the moment.
+    assert_eq!(WASMER2_CONFIG.engine, WasmerEngine::Universal);
+    let target_features = if cfg!(feature = "no_cpu_compatibility_checks") {
+        let mut fs = wasmer::CpuFeature::set();
+        // These features should be sufficient to run the single pass compiler.
+        fs.insert(wasmer::CpuFeature::SSE2);
+        fs.insert(wasmer::CpuFeature::SSE3);
+        fs.insert(wasmer::CpuFeature::SSSE3);
+        fs.insert(wasmer::CpuFeature::SSE41);
+        fs.insert(wasmer::CpuFeature::SSE42);
+        fs.insert(wasmer::CpuFeature::POPCNT);
+        fs.insert(wasmer::CpuFeature::AVX);
+        fs
+    } else {
+        wasmer::CpuFeature::for_host()
+    };
+    let engine = wasmer::Universal::new(compiler)
+        .features(WASMER_FEATURES)
+        .target(wasmer::Target::new(wasmer::Triple::host(), target_features))
+        .engine();
+    Store::new(&engine)
 }
 
-impl VMArtifact {
-    pub(crate) fn artifact(&self) -> &dyn wasmer_engine::Artifact {
-        &*self.artifact
-    }
-}
-
-#[derive(loupe::MemoryUsage)]
-pub(crate) struct Wasmer2VM {
-    #[loupe(skip)]
-    config: VMConfig,
-    engine: UniversalEngine,
-}
-
-impl Wasmer2VM {
-    pub(crate) fn new(config: VMConfig) -> Self {
-        use wasmer_compiler::{CpuFeature, Target, Triple};
-        // We only support singlepass compiler at the moment.
-        assert_eq!(WASMER2_CONFIG.compiler, WasmerCompiler::Singlepass);
-        let compiler = Singlepass::new();
-        // We only support universal engine at the moment.
-        assert_eq!(WASMER2_CONFIG.engine, WasmerEngine::Universal);
-        let target_features = if cfg!(feature = "no_cpu_compatibility_checks") {
-            let mut fs = CpuFeature::set();
-            // These features should be sufficient to run the single pass compiler.
-            fs.insert(CpuFeature::SSE2);
-            fs.insert(CpuFeature::SSE3);
-            fs.insert(CpuFeature::SSSE3);
-            fs.insert(CpuFeature::SSE41);
-            fs.insert(CpuFeature::SSE42);
-            fs.insert(CpuFeature::POPCNT);
-            fs.insert(CpuFeature::AVX);
-            fs
-        } else {
-            CpuFeature::for_host()
-        };
-        Self {
-            config,
-            engine: Universal::new(compiler)
-                .target(Target::new(Triple::host(), target_features))
-                .features(WASMER_FEATURES)
-                .engine(),
-        }
-    }
-
-    pub(crate) fn compile_uncached(&self, code: &[u8]) -> Result<VMArtifact, CompilationError> {
-        self.engine
-            .validate(code)
-            .map_err(|e| CompilationError::WasmerCompileError { msg: e.to_string() })?;
-        Ok(VMArtifact {
-            artifact: self
-                .engine
-                .compile(code, &self)
-                .map_err(|e| CompilationError::WasmerCompileError { msg: e.to_string() })?,
-            _engine: self.engine.clone(),
-        })
-    }
-
-    pub(crate) unsafe fn deserialize(
-        &self,
-        serialized: &[u8],
-    ) -> Result<VMArtifact, DeserializeError> {
-        Ok(VMArtifact {
-            artifact: self.engine.deserialize(serialized)?,
-            _engine: self.engine.clone(),
-        })
-    }
-
-    fn run_method<'vmlogic, 'vmlogic_refs>(
-        &self,
-        artifact: &VMArtifact,
-        mut import: Wasmer2Imports<'vmlogic, 'vmlogic_refs>,
-        method_name: &str,
-    ) -> Result<(), VMError> {
-        let _span = tracing::debug_span!(target: "vm", "run_method").entered();
-
-        // FastGasCounter in Nearcore and Wasmer must match in layout.
-        assert_eq!(size_of::<FastGasCounter>(), size_of::<wasmer_types::FastGasCounter>());
-        assert_eq!(
-            offset_of!(FastGasCounter, burnt_gas),
-            offset_of!(wasmer_types::FastGasCounter, burnt_gas)
+pub(crate) fn run_wasmer2_module<'a>(
+    module: &Module,
+    store: &Store,
+    memory: &mut Wasmer2Memory,
+    method_name: &str,
+    ext: &mut dyn External,
+    context: VMContext,
+    wasm_config: &'a VMConfig,
+    fees_config: &'a RuntimeFeesConfig,
+    promise_results: &'a [PromiseResult],
+    current_protocol_version: ProtocolVersion,
+) -> (Option<VMOutcome>, Option<VMError>) {
+    // Do we really need that code?
+    if method_name.is_empty() {
+        return (
+            None,
+            Some(VMError::FunctionCallError(FunctionCallError::MethodResolveError(
+                MethodResolveError::MethodEmptyName,
+            ))),
         );
-        assert_eq!(
-            offset_of!(FastGasCounter, gas_limit),
-            offset_of!(wasmer_types::FastGasCounter, gas_limit)
-        );
-        assert_eq!(
-            offset_of!(FastGasCounter, opcode_cost),
-            offset_of!(wasmer_types::FastGasCounter, opcode_cost)
-        );
-        let gas = import.vmlogic.gas_counter_pointer() as *mut wasmer_types::FastGasCounter;
-
-        let entrypoint = get_entrypoint_index(&*artifact.artifact, method_name)?;
-        unsafe {
-            let instance = {
-                let _span = tracing::debug_span!(target: "vm", "run_method/instantiate").entered();
-                // SAFETY/FIXME: this transmute shouldn't be necessary, but we are limited by
-                // wasmer's API right now.
-                //
-                // An important caveat is that the `'static` lifetime here refers to the lifetime
-                // of `VMLogic` reference to which is retained by the `InstanceHandle` we create.
-                // However this `InstanceHandle` only lives during the execution of this body, so
-                // we can be sure that `VMLogic` remains live and valid at any time.
-                let import = std::mem::transmute::<
-                    &mut Wasmer2Imports<'vmlogic, 'vmlogic_refs>,
-                    &mut Wasmer2Imports<'static, 'static>,
-                >(&mut import);
-                // SAFETY: we ensure that the tables are valid during the lifetime of this instance
-                // by retaining an instance to `UniversalEngine` which holds the allocations.
-                let handle = artifact
-                    .artifact
-                    .instantiate(
-                        &self,
-                        import,
-                        Box::new(()),
-                        // SAFETY: We have verified that the `FastGasCounter` layout matches the
-                        // expected layout. `gas` remains dereferenceable throughout this function
-                        // by the virtue of it being contained within `import` which lives for the
-                        // entirety of this function.
-                        InstanceConfig::new_with_counter(gas),
-                    )
-                    .map_err(|err| translate_instantiation_error(err, import.vmlogic))?;
-                // SAFETY: being called immediately after instantiation.
-                artifact
-                    .artifact
-                    .finish_instantiation(self, &handle)
-                    .map_err(|err| translate_instantiation_error(err, import.vmlogic))?;
-                handle
-            };
-            let external = instance.lookup_by_declaration(&ExportIndex::Function(entrypoint));
-            if let VMExtern::Function(f) = external {
-                let _span = tracing::debug_span!(target: "vm", "run_method/call").entered();
-                // Signature for the entry point should be `() -> ()`. This is only a sanity check
-                // – this should've been already checked by `get_entrypoint_index`.
-                if f.signature.params().is_empty() && f.signature.results().is_empty() {
-                    let trampoline = f.call_trampoline.expect("externs always have a trampoline");
-                    // SAFETY: we double-checked the signature, and all of the remaining arguments
-                    // come from an exported function definition which must be valid since it comes
-                    // from wasmer itself.
-                    wasmer_vm::wasmer_call_trampoline(
-                        self,
-                        f.vmctx,
-                        trampoline,
-                        f.address,
-                        [].as_mut_ptr() as *mut _,
-                    )
-                    .map_err(|e| {
-                        translate_runtime_error(
-                            wasmer_engine::RuntimeError::from_trap(e),
-                            import.vmlogic,
-                        )
-                    })?;
-                } else {
-                    panic!("signature should've already been checked by `get_entrypoint_index`")
-                }
-            } else {
-                panic!("signature should've already been checked by `get_entrypoint_index`")
-            }
-
-            {
-                let _span =
-                    tracing::debug_span!(target: "vm", "run_method/drop_instance").entered();
-                drop(instance)
-            }
-        }
-
-        Ok(())
     }
 
-    pub(crate) fn run_module<'a>(
-        &self,
-        artifact: &VMArtifact,
-        memory: &mut Wasmer2Memory,
-        method_name: &str,
-        ext: &mut dyn External,
-        context: VMContext,
-        fees_config: &'a RuntimeFeesConfig,
-        promise_results: &'a [PromiseResult],
-        current_protocol_version: ProtocolVersion,
-    ) -> (Option<VMOutcome>, Option<VMError>) {
-        let vmmemory = memory.vm();
-        let mut logic = VMLogic::new_with_protocol_version(
-            ext,
-            context,
-            &self.config,
-            fees_config,
-            promise_results,
-            memory,
-            current_protocol_version,
-        );
-        let import = imports::wasmer2::build(vmmemory, &mut logic, current_protocol_version);
-        if let Err(e) = get_entrypoint_index(&*artifact.artifact, method_name) {
-            return (None, Some(e));
-        }
-        let err = self.run_method(artifact, import, method_name).err();
-        (Some(logic.outcome()), err)
+    // Note that we don't clone the actual backing memory, just increase the RC.
+    let memory_copy = memory.clone();
+
+    let mut logic = VMLogic::new_with_protocol_version(
+        ext,
+        context,
+        wasm_config,
+        fees_config,
+        promise_results,
+        memory,
+        current_protocol_version,
+    );
+
+    let import = imports::wasmer2::build(store, memory_copy, &mut logic, current_protocol_version);
+
+    if let Err(e) = check_method(module, method_name) {
+        return (None, Some(e));
     }
+
+    let err = run_method(module, &import, method_name, &mut logic).err();
+    (Some(logic.outcome()), err)
 }
 
-unsafe impl wasmer_vm::TrapHandler for Wasmer2VM {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
-    fn custom_trap_handler(&self, _: &dyn Fn(&wasmer_vm::TrapHandlerFn) -> bool) -> bool {
-        false
-    }
-}
-
-impl wasmer_engine::Tunables for &Wasmer2VM {
-    fn memory_style(&self, memory: &MemoryType) -> MemoryStyle {
-        MemoryStyle::Static {
-            bound: memory.maximum.unwrap_or(Pages(self.config.limit_config.max_memory_pages)),
-            offset_guard_size: WASM_PAGE_SIZE as u64,
-        }
-    }
-
-    fn table_style(&self, _table: &wasmer_types::TableType) -> wasmer_vm::TableStyle {
-        wasmer_vm::TableStyle::CallerChecksSignature
-    }
-
-    fn create_host_memory(
-        &self,
-        ty: &MemoryType,
-        _style: &MemoryStyle,
-    ) -> Result<std::sync::Arc<dyn Memory>, wasmer_vm::MemoryError> {
-        // We do not support arbitrary Host memories. The only memory contracts may use is the
-        // memory imported via `env.memory`.
-        Err(wasmer_vm::MemoryError::CouldNotGrow { current: Pages(0), attempted_delta: ty.minimum })
-    }
-
-    unsafe fn create_vm_memory(
-        &self,
-        ty: &MemoryType,
-        _style: &MemoryStyle,
-        _vm_definition_location: std::ptr::NonNull<wasmer_vm::VMMemoryDefinition>,
-    ) -> Result<std::sync::Arc<dyn Memory>, wasmer_vm::MemoryError> {
-        // We do not support VM memories. The only memory contracts may use is the memory imported
-        // via `env.memory`.
-        Err(wasmer_vm::MemoryError::CouldNotGrow { current: Pages(0), attempted_delta: ty.minimum })
-    }
-
-    fn create_host_table(
-        &self,
-        _ty: &wasmer_types::TableType,
-        _style: &wasmer_vm::TableStyle,
-    ) -> Result<std::sync::Arc<dyn wasmer_vm::Table>, String> {
-        panic!("should never be called")
-    }
-
-    unsafe fn create_vm_table(
-        &self,
-        ty: &wasmer_types::TableType,
-        style: &wasmer_vm::TableStyle,
-        vm_definition_location: std::ptr::NonNull<wasmer_vm::VMTableDefinition>,
-    ) -> Result<std::sync::Arc<dyn wasmer_vm::Table>, String> {
-        // This is called when instantiating a module.
-        Ok(Arc::new(LinearTable::from_definition(&ty, &style, vm_definition_location)?))
-    }
-}
+pub(crate) struct Wasmer2VM;
 
 impl crate::runner::VM for Wasmer2VM {
     fn run(
@@ -543,22 +404,24 @@ impl crate::runner::VM for Wasmer2VM {
                 ))),
             );
         }
-        let artifact =
-            cache::wasmer2_cache::compile_module_cached_wasmer2(code, wasm_config, cache);
-        let artifact = match into_vm_result(artifact) {
+
+        let store = default_wasmer2_store();
+        let module =
+            cache::wasmer2_cache::compile_module_cached_wasmer2(code, wasm_config, cache, &store);
+        let module = match into_vm_result(module) {
             Ok(it) => it,
             Err(err) => return (None, Some(err)),
         };
 
         let mut memory = Wasmer2Memory::new(
+            &store,
             wasm_config.limit_config.initial_memory_pages,
             wasm_config.limit_config.max_memory_pages,
         )
         .expect("Cannot create memory for a contract call");
-
-        // FIXME: this mostly duplicates the `run_module` method.
         // Note that we don't clone the actual backing memory, just increase the RC.
-        let vmmemory = memory.vm();
+        let memory_copy = memory.clone();
+
         let mut logic = VMLogic::new_with_protocol_version(
             ext,
             context,
@@ -568,6 +431,7 @@ impl crate::runner::VM for Wasmer2VM {
             &mut memory,
             current_protocol_version,
         );
+
         // TODO: remove, as those costs are incorrectly computed, and we shall account it on deployment.
         if logic.add_contract_compile_fee(code.code().len() as u64).is_err() {
             return (
@@ -577,11 +441,15 @@ impl crate::runner::VM for Wasmer2VM {
                 ))),
             );
         }
-        let import = imports::wasmer2::build(vmmemory, &mut logic, current_protocol_version);
-        if let Err(e) = get_entrypoint_index(&*artifact.artifact, method_name) {
+
+        let import_object =
+            imports::wasmer2::build(&store, memory_copy, &mut logic, current_protocol_version);
+
+        if let Err(e) = check_method(&module, method_name) {
             return (None, Some(e));
         }
-        let err = self.run_method(&artifact, import, method_name).err();
+
+        let err = run_method(&module, &import_object, method_name, &mut logic).err();
         (Some(logic.outcome()), err)
     }
 
@@ -592,105 +460,19 @@ impl crate::runner::VM for Wasmer2VM {
         wasm_config: &VMConfig,
         cache: &dyn CompiledContractCache,
     ) -> Option<VMError> {
+        let store = crate::wasmer2_runner::default_wasmer2_store();
         let result = crate::cache::wasmer2_cache::compile_and_serialize_wasmer2(
             code,
             code_hash,
             wasm_config,
             cache,
+            &store,
         );
         into_vm_result(result).err()
     }
 
     fn check_compile(&self, code: &Vec<u8>) -> bool {
-        self.compile_uncached(code).is_ok()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use assert_matches::assert_matches;
-    use wasmer_types::WASM_PAGE_SIZE;
-
-    #[test]
-    fn get_memory_buffer() {
-        let memory = super::Wasmer2Memory::new(1, 1).unwrap();
-        // these should not panic with memory out of bounds
-        memory.get_memory_buffer(0, WASM_PAGE_SIZE);
-        memory.get_memory_buffer(WASM_PAGE_SIZE as u64 - 1, 1);
-        memory.get_memory_buffer(WASM_PAGE_SIZE as u64, 0);
-    }
-
-    #[test]
-    #[should_panic]
-    fn get_memory_buffer_oob1() {
-        let memory = super::Wasmer2Memory::new(1, 1).unwrap();
-        memory.get_memory_buffer(1 + WASM_PAGE_SIZE as u64, 0);
-    }
-
-    #[test]
-    #[should_panic]
-    fn get_memory_buffer_oob2() {
-        let memory = super::Wasmer2Memory::new(1, 1).unwrap();
-        memory.get_memory_buffer(WASM_PAGE_SIZE as u64, 1);
-    }
-
-    #[test]
-    fn memory_data_offset() {
-        let memory = super::Wasmer2Memory::new(1, 1).unwrap();
-        assert_matches!(memory.data_offset(0), Some((_, size)) => assert_eq!(size, WASM_PAGE_SIZE));
-        assert_matches!(memory.data_offset(WASM_PAGE_SIZE as u64), Some((_, size)) => {
-            assert_eq!(size, 0)
-        });
-        assert_matches!(memory.data_offset(WASM_PAGE_SIZE as u64 + 1), None);
-        assert_matches!(memory.data_offset(0xFFFF_FFFF_FFFF_FFFF), None);
-    }
-
-    #[test]
-    fn memory_read() {
-        let memory = super::Wasmer2Memory::new(1, 1).unwrap();
-        let mut buffer = vec![42; WASM_PAGE_SIZE];
-        near_vm_logic::MemoryLike::read_memory(&memory, 0, &mut buffer);
-        // memory should be zeroed at creation.
-        assert!(buffer.iter().all(|&v| v == 0));
-    }
-
-    #[test]
-    #[should_panic]
-    fn memory_read_oob() {
-        let memory = super::Wasmer2Memory::new(1, 1).unwrap();
-        let mut buffer = vec![42; WASM_PAGE_SIZE + 1];
-        near_vm_logic::MemoryLike::read_memory(&memory, 0, &mut buffer);
-    }
-
-    #[test]
-    fn memory_write() {
-        let mut memory = super::Wasmer2Memory::new(1, 1).unwrap();
-        let mut buffer = vec![42; WASM_PAGE_SIZE];
-        near_vm_logic::MemoryLike::write_memory(
-            &mut memory,
-            WASM_PAGE_SIZE as u64 / 2,
-            &buffer[..WASM_PAGE_SIZE / 2],
-        );
-        near_vm_logic::MemoryLike::read_memory(&memory, 0, &mut buffer);
-        assert!(buffer[..WASM_PAGE_SIZE / 2].iter().all(|&v| v == 0));
-        assert!(buffer[WASM_PAGE_SIZE / 2..].iter().all(|&v| v == 42));
-        // Now the buffer is half 0s and half 42s
-
-        near_vm_logic::MemoryLike::write_memory(
-            &mut memory,
-            0,
-            &buffer[WASM_PAGE_SIZE / 4..3 * (WASM_PAGE_SIZE / 4)],
-        );
-        near_vm_logic::MemoryLike::read_memory(&memory, 0, &mut buffer);
-        assert!(buffer[..WASM_PAGE_SIZE / 4].iter().all(|&v| v == 0));
-        assert!(buffer[WASM_PAGE_SIZE / 4..].iter().all(|&v| v == 42));
-    }
-
-    #[test]
-    #[should_panic]
-    fn memory_write_oob() {
-        let mut memory = super::Wasmer2Memory::new(1, 1).unwrap();
-        let mut buffer = vec![42; WASM_PAGE_SIZE + 1];
-        near_vm_logic::MemoryLike::write_memory(&mut memory, 0, &mut buffer);
+        let store = default_wasmer2_store();
+        Module::new(&store, code).is_ok()
     }
 }

--- a/runtime/near-vm-runner/src/wasmer_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer_runner.rs
@@ -269,15 +269,7 @@ pub(crate) fn wasmer0_vm_hash() -> u64 {
     42
 }
 
-pub(crate) struct Wasmer0VM {
-    config: VMConfig,
-}
-
-impl Wasmer0VM {
-    pub(crate) fn new(config: VMConfig) -> Self {
-        Self { config }
-    }
-}
+pub(crate) struct Wasmer0VM;
 
 impl crate::runner::VM for Wasmer0VM {
     fn run(
@@ -286,6 +278,7 @@ impl crate::runner::VM for Wasmer0VM {
         method_name: &str,
         ext: &mut dyn External,
         context: VMContext,
+        wasm_config: &VMConfig,
         fees_config: &RuntimeFeesConfig,
         promise_results: &[PromiseResult],
         current_protocol_version: ProtocolVersion,
@@ -320,14 +313,14 @@ impl crate::runner::VM for Wasmer0VM {
         }
 
         // TODO: consider using get_module() here, once we'll go via deployment path.
-        let module = cache::wasmer0_cache::compile_module_cached_wasmer0(code, &self.config, cache);
+        let module = cache::wasmer0_cache::compile_module_cached_wasmer0(code, wasm_config, cache);
         let module = match into_vm_result(module) {
             Ok(x) => x,
             Err(err) => return (None, Some(err)),
         };
         let mut memory = WasmerMemory::new(
-            self.config.limit_config.initial_memory_pages,
-            self.config.limit_config.max_memory_pages,
+            wasm_config.limit_config.initial_memory_pages,
+            wasm_config.limit_config.max_memory_pages,
         )
         .expect("Cannot create memory for a contract call");
         // Note that we don't clone the actual backing memory, just increase the RC.
@@ -336,7 +329,7 @@ impl crate::runner::VM for Wasmer0VM {
         let mut logic = VMLogic::new_with_protocol_version(
             ext,
             context,
-            &self.config,
+            wasm_config,
             fees_config,
             promise_results,
             &mut memory,
@@ -368,11 +361,12 @@ impl crate::runner::VM for Wasmer0VM {
         &self,
         code: &[u8],
         code_hash: &near_primitives::hash::CryptoHash,
+        wasm_config: &VMConfig,
         cache: &dyn CompiledContractCache,
     ) -> Option<VMError> {
         let result = crate::cache::wasmer0_cache::compile_and_serialize_wasmer(
             code,
-            &self.config,
+            wasm_config,
             code_hash,
             cache,
         );

--- a/runtime/runtime-params-estimator/src/function_call.rs
+++ b/runtime/runtime-params-estimator/src/function_call.rs
@@ -95,6 +95,7 @@ pub fn compute_function_call_cost(
     repeats: u64,
     contract: &ContractCode,
 ) -> Gas {
+    let runtime = vm_kind.runtime().expect("runtime has not been enabled");
     let workdir = tempfile::Builder::new().prefix("runtime_testbed").tempdir().unwrap();
     let store = create_store(&get_store_path(workdir.path()));
     let cache_store = Arc::new(StoreCompiledContractCache { store });
@@ -103,7 +104,6 @@ pub fn compute_function_call_cost(
     let config_store = RuntimeConfigStore::new(None);
     let runtime_config = config_store.get_config(protocol_version).as_ref();
     let vm_config = runtime_config.wasm_config.clone();
-    let runtime = vm_kind.runtime(vm_config.clone()).expect("runtime has not been enabled");
     let fees = runtime_config.transaction_costs.clone();
     let mut fake_external = MockedExternal::new();
     let fake_context = create_context(vec![]);

--- a/runtime/runtime-params-estimator/src/function_call.rs
+++ b/runtime/runtime-params-estimator/src/function_call.rs
@@ -103,7 +103,7 @@ pub fn compute_function_call_cost(
     let config_store = RuntimeConfigStore::new(None);
     let runtime_config = config_store.get_config(protocol_version).as_ref();
     let vm_config = runtime_config.wasm_config.clone();
-    let runtime = vm_kind.runtime(vm_config).expect("runtime has not been enabled");
+    let runtime = vm_kind.runtime(vm_config.clone()).expect("runtime has not been enabled");
     let fees = runtime_config.transaction_costs.clone();
     let mut fake_external = MockedExternal::new();
     let fake_context = create_context(vec![]);
@@ -116,6 +116,7 @@ pub fn compute_function_call_cost(
             "hello0",
             &mut fake_external,
             fake_context.clone(),
+            &vm_config,
             &fees,
             &promise_results,
             protocol_version,
@@ -131,6 +132,7 @@ pub fn compute_function_call_cost(
             "hello0",
             &mut fake_external,
             fake_context.clone(),
+            &vm_config,
             &fees,
             &promise_results,
             protocol_version,

--- a/runtime/runtime-params-estimator/src/gas_metering.rs
+++ b/runtime/runtime-params-estimator/src/gas_metering.rs
@@ -138,6 +138,7 @@ pub fn compute_gas_metering_cost(
     repeats: i32,
     contract: &ContractCode,
 ) -> u64 {
+    let runtime = vm_kind.runtime().expect("runtime has not been enabled");
     let workdir = tempfile::Builder::new().prefix("runtime_testbed").tempdir().unwrap();
     let store = create_store(&get_store_path(workdir.path()));
     let cache_store = Arc::new(StoreCompiledContractCache { store });
@@ -145,7 +146,6 @@ pub fn compute_gas_metering_cost(
     let config_store = RuntimeConfigStore::new(None);
     let runtime_config = config_store.get_config(PROTOCOL_VERSION).as_ref();
     let vm_config_gas = runtime_config.wasm_config.clone();
-    let runtime = vm_kind.runtime(vm_config_gas.clone()).expect("runtime has not been enabled");
     let fees = runtime_config.transaction_costs.clone();
     let mut fake_external = MockedExternal::new();
     let fake_context = create_context(vec![]);

--- a/runtime/runtime-params-estimator/src/gas_metering.rs
+++ b/runtime/runtime-params-estimator/src/gas_metering.rs
@@ -145,7 +145,7 @@ pub fn compute_gas_metering_cost(
     let config_store = RuntimeConfigStore::new(None);
     let runtime_config = config_store.get_config(PROTOCOL_VERSION).as_ref();
     let vm_config_gas = runtime_config.wasm_config.clone();
-    let runtime = vm_kind.runtime(vm_config_gas).expect("runtime has not been enabled");
+    let runtime = vm_kind.runtime(vm_config_gas.clone()).expect("runtime has not been enabled");
     let fees = runtime_config.transaction_costs.clone();
     let mut fake_external = MockedExternal::new();
     let fake_context = create_context(vec![]);
@@ -157,6 +157,7 @@ pub fn compute_gas_metering_cost(
         "hello",
         &mut fake_external,
         fake_context.clone(),
+        &vm_config_gas,
         &fees,
         &promise_results,
         PROTOCOL_VERSION,
@@ -176,6 +177,7 @@ pub fn compute_gas_metering_cost(
             "hello",
             &mut fake_external,
             fake_context.clone(),
+            &vm_config_gas,
             &fees,
             &promise_results,
             PROTOCOL_VERSION,
@@ -186,12 +188,12 @@ pub fn compute_gas_metering_cost(
     let total_raw_with_gas = start.elapsed().to_gas();
 
     let vm_config_no_gas = VMConfig::free();
-    let runtime = vm_kind.runtime(vm_config_no_gas).expect("runtime has not been enabled");
     let result = runtime.run(
         contract,
         "hello",
         &mut fake_external,
         fake_context.clone(),
+        &vm_config_no_gas,
         &fees,
         &promise_results,
         PROTOCOL_VERSION,
@@ -205,6 +207,7 @@ pub fn compute_gas_metering_cost(
             "hello",
             &mut fake_external,
             fake_context.clone(),
+            &vm_config_no_gas,
             &fees,
             &promise_results,
             PROTOCOL_VERSION,

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -617,6 +617,7 @@ fn wasm_instruction(ctx: &mut EstimatorContext) -> GasCost {
             "cpu_ram_soak_test",
             &mut fake_external,
             context,
+            &config,
             &fees,
             &promise_results,
             PROTOCOL_VERSION,

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -612,7 +612,7 @@ fn wasm_instruction(ctx: &mut EstimatorContext) -> GasCost {
 
     let mut run = || {
         let context = create_context(vec![]);
-        let (outcome, err) = vm_kind.runtime(config.clone()).unwrap().run(
+        let (outcome, err) = vm_kind.runtime().unwrap().run(
             &code,
             "cpu_ram_soak_test",
             &mut fake_external,

--- a/runtime/runtime-params-estimator/src/vm_estimator.rs
+++ b/runtime/runtime-params-estimator/src/vm_estimator.rs
@@ -271,7 +271,7 @@ fn test_many_contracts_call(gas_metric: GasMetric, vm_kind: VMKind) {
     let fees = RuntimeFeesConfig::test();
 
     let start = GasCost::measure(gas_metric);
-    if let Some(runtime) = vm_kind.runtime(vm_config.clone()) {
+    if let Some(runtime) = vm_kind.runtime() {
         for contract in &contracts {
             let promise_results = vec![];
             let result = runtime.run(

--- a/runtime/runtime-params-estimator/src/vm_estimator.rs
+++ b/runtime/runtime-params-estimator/src/vm_estimator.rs
@@ -271,7 +271,7 @@ fn test_many_contracts_call(gas_metric: GasMetric, vm_kind: VMKind) {
     let fees = RuntimeFeesConfig::test();
 
     let start = GasCost::measure(gas_metric);
-    if let Some(runtime) = vm_kind.runtime(vm_config) {
+    if let Some(runtime) = vm_kind.runtime(vm_config.clone()) {
         for contract in &contracts {
             let promise_results = vec![];
             let result = runtime.run(
@@ -279,6 +279,7 @@ fn test_many_contracts_call(gas_metric: GasMetric, vm_kind: VMKind) {
                 "hello",
                 &mut fake_external,
                 fake_context.clone(),
+                &vm_config,
                 &fees,
                 &promise_results,
                 ProtocolVersion::MAX,


### PR DESCRIPTION
It broke betanet. The breakage is related to the memory sizes, wherein we trigger the first assert in [this section of code](https://github.com/near/wasmer/blob/68da83cfb903ae14093b84cc041048cd0f21e48b/lib/engine/src/resolver.rs#L242-L275)

Looks like there is a contract that is attempting to import 65536 pages worth of memory whereas our limits config specifies a 2048 maximum. Presumably the preparation code should standardize these sizes, so not sure how the larger numbers end up reaching wasmer.

Reverting to give us time to investigate.