### PR TITLE
fix: use pwasm-utils 0.18 for more correct stack accounting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3287,8 +3287,9 @@ dependencies = [
  "near-vm-errors",
  "near-vm-logic",
  "once_cell",
- "parity-wasm",
- "pwasm-utils",
+ "parity-wasm 0.41.0",
+ "pwasm-utils 0.12.0",
+ "pwasm-utils 0.18.2",
  "serde",
  "threadpool",
  "tracing",
@@ -3747,6 +3748,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc878dac00da22f8f61e7af3157988424567ab01d9920b962ef7dcbd7cd865"
 
 [[package]]
+name = "parity-wasm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
+
+[[package]]
 name = "parking_lot"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3999,7 +4006,18 @@ checksum = "4f7a12f176deee919f4ba55326ee17491c8b707d0987aed822682c821b660192"
 dependencies = [
  "byteorder",
  "log",
- "parity-wasm",
+ "parity-wasm 0.41.0",
+]
+
+[[package]]
+name = "pwasm-utils"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "880b3384fb00b8f6ecccd5d358b93bd2201900ae3daad213791d1864f6441f5c"
+dependencies = [
+ "byteorder",
+ "log",
+ "parity-wasm 0.42.2",
 ]
 
 [[package]]

--- a/core/primitives-core/src/config.rs
+++ b/core/primitives-core/src/config.rs
@@ -31,6 +31,8 @@ pub struct VMLimitConfig {
     /// See <https://wiki.parity.io/WebAssembly-StackHeight> to find out
     /// how the stack frame cost is calculated.
     pub max_stack_height: u32,
+    /// Whether a legacy version of stack limiting should be used, see
+    /// [`StackLimiterVersion`].
     #[serde(default = "StackLimiterVersion::v0")]
     pub stack_limiter_version: StackLimiterVersion,
 
@@ -84,9 +86,18 @@ pub struct VMLimitConfig {
     pub max_functions_number_per_contract: Option<u64>,
 }
 
+/// Our original code for limiting WASM stack was buggy. We fixed that, but we
+/// still have to use old (`V0`) limiter for old protocol versions.
+///
+/// This struct here exists to enforce that the value in the config is either
+/// `0` or `1`. We could have used a `bool` instead, but there's a chance that
+/// our current impl isn't perfect either and would need further tweaks in the
+/// future.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub enum StackLimiterVersion {
+    /// Old, buggy version, don't use it unless specifically to support old protocol version.
     V0,
+    /// What we use in today's protocol.
     V1,
 }
 

--- a/core/primitives-core/src/config.rs
+++ b/core/primitives-core/src/config.rs
@@ -31,6 +31,8 @@ pub struct VMLimitConfig {
     /// See <https://wiki.parity.io/WebAssembly-StackHeight> to find out
     /// how the stack frame cost is calculated.
     pub max_stack_height: u32,
+    #[serde(default = "StackLimiterVersion::v0")]
+    pub stack_limiter_version: StackLimiterVersion,
 
     /// The initial number of memory pages.
     /// NOTE: It's not a limiter itself, but it's a value we use for initial_memory_pages.
@@ -82,6 +84,53 @@ pub struct VMLimitConfig {
     pub max_functions_number_per_contract: Option<u64>,
 }
 
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum StackLimiterVersion {
+    V0,
+    V1,
+}
+
+impl StackLimiterVersion {
+    fn v0() -> StackLimiterVersion {
+        StackLimiterVersion::V0
+    }
+    fn repr(self) -> u32 {
+        match self {
+            StackLimiterVersion::V0 => 0,
+            StackLimiterVersion::V1 => 1,
+        }
+    }
+    fn from_repr(repr: u32) -> Option<StackLimiterVersion> {
+        let res = match repr {
+            0 => StackLimiterVersion::V0,
+            1 => StackLimiterVersion::V1,
+            _ => return None,
+        };
+        Some(res)
+    }
+}
+
+impl Serialize for StackLimiterVersion {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.repr().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for StackLimiterVersion {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        u32::deserialize(deserializer).and_then(|repr| {
+            StackLimiterVersion::from_repr(repr)
+                .ok_or_else(|| serde::de::Error::custom("invalid stack_limiter_version"))
+        })
+    }
+}
+
 impl VMConfig {
     pub fn test() -> VMConfig {
         VMConfig {
@@ -118,7 +167,8 @@ impl VMLimitConfig {
 
             // NOTE: Stack height has to be 16K, otherwise Wasmer produces non-deterministic results.
             // For experimentation try `test_stack_overflow`.
-            max_stack_height: 16 * 1024,        // 16Kib of stack.
+            max_stack_height: 16 * 1024, // 16Kib of stack.
+            stack_limiter_version: StackLimiterVersion::V1,
             initial_memory_pages: 2u32.pow(10), // 64Mib of memory.
             max_memory_pages: 2u32.pow(11),     // 128Mib of memory.
 

--- a/core/primitives/res/runtime_configs/50.json
+++ b/core/primitives/res/runtime_configs/50.json
@@ -1,0 +1,193 @@
+{
+  "storage_amount_per_byte": "10000000000000000000",
+  "transaction_costs": {
+    "action_receipt_creation_config": {
+      "send_sir": 108059500000,
+      "send_not_sir": 108059500000,
+      "execution": 108059500000
+    },
+    "data_receipt_creation_config": {
+      "base_cost": {
+        "send_sir": 36486732312,
+        "send_not_sir": 36486732312,
+        "execution": 36486732312
+      },
+      "cost_per_byte": {
+        "send_sir": 17212011,
+        "send_not_sir": 17212011,
+        "execution": 17212011
+      }
+    },
+    "action_creation_config": {
+      "create_account_cost": {
+        "send_sir": 99607375000,
+        "send_not_sir": 99607375000,
+        "execution": 99607375000
+      },
+      "deploy_contract_cost": {
+        "send_sir": 184765750000,
+        "send_not_sir": 184765750000,
+        "execution": 184765750000
+      },
+      "deploy_contract_cost_per_byte": {
+        "send_sir": 6812999,
+        "send_not_sir": 6812999,
+        "execution": 6812999
+      },
+      "function_call_cost": {
+        "send_sir": 2319861500000,
+        "send_not_sir": 2319861500000,
+        "execution": 2319861500000
+      },
+      "function_call_cost_per_byte": {
+        "send_sir": 2235934,
+        "send_not_sir": 2235934,
+        "execution": 2235934
+      },
+      "transfer_cost": {
+        "send_sir": 115123062500,
+        "send_not_sir": 115123062500,
+        "execution": 115123062500
+      },
+      "stake_cost": {
+        "send_sir": 141715687500,
+        "send_not_sir": 141715687500,
+        "execution": 102217625000
+      },
+      "add_key_cost": {
+        "full_access_cost": {
+          "send_sir": 101765125000,
+          "send_not_sir": 101765125000,
+          "execution": 101765125000
+        },
+        "function_call_cost": {
+          "send_sir": 102217625000,
+          "send_not_sir": 102217625000,
+          "execution": 102217625000
+        },
+        "function_call_cost_per_byte": {
+          "send_sir": 1925331,
+          "send_not_sir": 1925331,
+          "execution": 1925331
+        }
+      },
+      "delete_key_cost": {
+        "send_sir": 94946625000,
+        "send_not_sir": 94946625000,
+        "execution": 94946625000
+      },
+      "delete_account_cost": {
+        "send_sir": 147489000000,
+        "send_not_sir": 147489000000,
+        "execution": 147489000000
+      }
+    },
+    "storage_usage_config": {
+      "num_bytes_account": 100,
+      "num_extra_bytes_record": 40
+    },
+    "burnt_gas_reward": [
+      3,
+      10
+    ],
+    "pessimistic_gas_price_inflation_ratio": [
+      103,
+      100
+    ]
+  },
+  "wasm_config": {
+    "ext_costs": {
+      "base": 264768111,
+      "contract_compile_base": 35445963,
+      "contract_compile_bytes": 216750,
+      "read_memory_base": 2609863200,
+      "read_memory_byte": 3801333,
+      "write_memory_base": 2803794861,
+      "write_memory_byte": 2723772,
+      "read_register_base": 2517165186,
+      "read_register_byte": 98562,
+      "write_register_base": 2865522486,
+      "write_register_byte": 3801564,
+      "utf8_decoding_base": 3111779061,
+      "utf8_decoding_byte": 291580479,
+      "utf16_decoding_base": 3543313050,
+      "utf16_decoding_byte": 163577493,
+      "sha256_base": 4540970250,
+      "sha256_byte": 24117351,
+      "keccak256_base": 5879491275,
+      "keccak256_byte": 21471105,
+      "keccak512_base": 5811388236,
+      "keccak512_byte": 36649701,
+      "ripemd160_base": 853675086,
+      "ripemd160_block": 680107584,
+      "ecrecover_base": 278821988457,
+      "log_base": 3543313050,
+      "log_byte": 13198791,
+      "storage_write_base": 64196736000,
+      "storage_write_key_byte": 70482867,
+      "storage_write_value_byte": 31018539,
+      "storage_write_evicted_byte": 32117307,
+      "storage_read_base": 56356845750,
+      "storage_read_key_byte": 30952533,
+      "storage_read_value_byte": 5611005,
+      "storage_remove_base": 53473030500,
+      "storage_remove_key_byte": 38220384,
+      "storage_remove_ret_value_byte": 11531556,
+      "storage_has_key_base": 54039896625,
+      "storage_has_key_byte": 30790845,
+      "storage_iter_create_prefix_base": 0,
+      "storage_iter_create_prefix_byte": 0,
+      "storage_iter_create_range_base": 0,
+      "storage_iter_create_from_byte": 0,
+      "storage_iter_create_to_byte": 0,
+      "storage_iter_next_base": 0,
+      "storage_iter_next_key_byte": 0,
+      "storage_iter_next_value_byte": 0,
+      "touching_trie_node": 16101955926,
+      "promise_and_base": 1465013400,
+      "promise_and_per_promise": 5452176,
+      "promise_return": 560152386,
+      "validator_stake_base": 911834726400,
+      "validator_total_stake_base": 911834726400,
+      "alt_bn128_g1_multiexp_base": 713006929500,
+      "alt_bn128_g1_multiexp_byte": 3335092461,
+      "alt_bn128_g1_multiexp_sublinear": 4325094,
+      "alt_bn128_pairing_check_base": 9685508901000,
+      "alt_bn128_pairing_check_byte": 26575188546,
+      "alt_bn128_g1_sum_base": 3175314375,
+      "alt_bn128_g1_sum_byte": 76218543
+    },
+    "grow_mem_cost": 1,
+    "regular_op_cost": 822756,
+    "limit_config": {
+      "max_gas_burnt": 200000000000000,
+      "max_gas_burnt_view": 200000000000000,
+      "max_stack_height": 16384,
+      "stack_limiter_version": 1,
+      "initial_memory_pages": 1024,
+      "max_memory_pages": 2048,
+      "registers_memory_limit": 1073741824,
+      "max_register_size": 104857600,
+      "max_number_registers": 100,
+      "max_number_logs": 100,
+      "max_total_log_length": 16384,
+      "max_total_prepaid_gas": 300000000000000,
+      "max_actions_per_receipt": 100,
+      "max_number_bytes_method_names": 2000,
+      "max_length_method_name": 256,
+      "max_arguments_length": 4194304,
+      "max_length_returned_data": 4194304,
+      "max_contract_size": 4194304,
+      "max_transaction_size": 4194304,
+      "max_length_storage_key": 4194304,
+      "max_length_storage_value": 4194304,
+      "max_promises_per_function_call_action": 1024,
+      "max_number_input_data_dependencies": 128,
+      "max_functions_number_per_contract": 10000
+    }
+  },
+  "account_creation_config": {
+    "min_allowed_top_level_account_length": 32,
+    "registrar_account_id": "registrar"
+  }
+}

--- a/core/primitives/src/runtime/config_store.rs
+++ b/core/primitives/src/runtime/config_store.rs
@@ -19,6 +19,7 @@ static CONFIGS: &[(ProtocolVersion, &[u8])] = &[
     (42, include_config!("42.json")),
     (48, include_config!("48.json")),
     (49, include_config!("49.json")),
+    (50, include_config!("50.json")),
 ];
 
 pub static INITIAL_TESTNET_CONFIG: &[u8] = include_config!("29_testnet.json");
@@ -117,6 +118,7 @@ mod tests {
             "97UzHtVFBc4235jdur3DgNSUGNfGQfzRDLmAkYdZ19Re",
             "C6uw6BoeXr3KoKpVP34hBA7TqoywMbwMtJgqbTpPCiSB",
             "2cuq2HvuHT7Z27LUbgEtMxP2ejqrHK34J2V1GL1joiMn",
+            "Yov9YJ5wdLGy4ueKxX2xQZXUSswEKs2zcEwEZYNRcXK",
         ];
         let actual_hashes = CONFIGS
             .iter()

--- a/core/primitives/src/runtime/config_store.rs
+++ b/core/primitives/src/runtime/config_store.rs
@@ -118,7 +118,7 @@ mod tests {
             "97UzHtVFBc4235jdur3DgNSUGNfGQfzRDLmAkYdZ19Re",
             "C6uw6BoeXr3KoKpVP34hBA7TqoywMbwMtJgqbTpPCiSB",
             "2cuq2HvuHT7Z27LUbgEtMxP2ejqrHK34J2V1GL1joiMn",
-            "Yov9YJ5wdLGy4ueKxX2xQZXUSswEKs2zcEwEZYNRcXK",
+            "HFetcNKaC5s8Mj7bQz7jGMF7Rsvtuc3kjZRevWQ334n4",
         ];
         let actual_hashes = CONFIGS
             .iter()

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -128,6 +128,9 @@ pub enum ProtocolFeature {
     /// Make block producers produce chunks for the same block they would later produce to avoid
     /// network delays
     SynchronizeBlockChunkProduction,
+    /// Change the algorithm to count WASM stack usage to avoid undercounting in
+    /// some cases.
+    CorrectStackLimit,
     /// Add `AccessKey` nonce range for implicit accounts, as in `AccessKeyNonceRange` feature.
     AccessKeyNonceForImplicitAccounts,
 
@@ -181,7 +184,8 @@ impl ProtocolFeature {
             | ProtocolFeature::LimitContractFunctionsNumber
             | ProtocolFeature::BlockHeaderV3
             | ProtocolFeature::AliasValidatorSelectionAlgorithm => 49,
-            ProtocolFeature::SynchronizeBlockChunkProduction => 50,
+            ProtocolFeature::SynchronizeBlockChunkProduction
+            | ProtocolFeature::CorrectStackLimit => 50,
             ProtocolFeature::AccessKeyNonceForImplicitAccounts => 51,
 
             // Nightly features

--- a/deny.toml
+++ b/deny.toml
@@ -52,6 +52,10 @@ skip = [
     { name = "wasmparser", version = "=0.76.0" },
     # Wasmtime 0.17 use older target-lexicon.
     { name = "target-lexicon", version = "=0.11.2" },
+    # Need this specific version of pwasm-utils for backwards-compatible
+    # stack limiting.
+    { name = "pwasm-utils", version = "=0.12.0" },
+    { name = "parity-wasm", version = "=0.41.0" },
 
     # param estimator uses newer imports, but it's not part of neard
     { name = "indicatif", version = "=0.15.0" },

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -35,8 +35,7 @@ wasmer-engine-universal = { package = "wasmer-engine-universal-near", version = 
 wasmer-vm = { package = "wasmer-vm-near", version = "=2.1.2" }
 
 once_cell = "1.5.2"
-pwasm-utils = "0.12"
-parity-wasm = "0.41"
+pwasm-utils = "0.18"
 wasmtime = { version = "0.25.0", default-features = false, optional = true }
 anyhow = { version = "1.0.19", optional = true }
 near-cache = { path = "../../utils/near-cache" }
@@ -46,6 +45,12 @@ near-primitives = { path = "../../core/primitives" }
 near-stable-hasher = { path = "../../utils/near-stable-hasher" }
 tracing = { version = "0.1", default-features = false }
 threadpool = "1.8.1"
+
+# Old versions of pwasm-utils we need to preserve backbwards compatability under
+# old protocol versions.
+pwasm-utils_12 = { package = "pwasm-utils", version = "0.12" }
+parity-wasm_41 = { package = "parity-wasm", version = "0.41" }
+
 
 [dev-dependencies]
 near-test-contracts = { path = "../near-test-contracts" }

--- a/runtime/near-vm-runner/src/prepare.rs
+++ b/runtime/near-vm-runner/src/prepare.rs
@@ -39,6 +39,10 @@ pub fn prepare_contract(original_code: &[u8], config: &VMConfig) -> Result<Vec<u
         .map_err(|_| PrepareError::Deserialization)?;
 
     match config.limit_config.stack_limiter_version {
+        // Support for old protocol versions, where we incorrectly didn't
+        // account for many locals of the same type.
+        //
+        // See `test_stack_instrumentation_protocol_upgrade` test.
         near_vm_logic::StackLimiterVersion::V0 => pwasm_12::prepare_contract(original_code, config),
         near_vm_logic::StackLimiterVersion::V1 => ContractModule::init(original_code, config)?
             .validate_functions_number()?
@@ -197,7 +201,7 @@ impl<'a> ContractModule<'a> {
     }
 }
 
-/// Legacy validation for old protocol versions
+/// Legacy validation for old protocol versions.
 mod pwasm_12 {
     use near_vm_errors::PrepareError;
     use near_vm_logic::VMConfig;

--- a/runtime/near-vm-runner/src/prepare.rs
+++ b/runtime/near-vm-runner/src/prepare.rs
@@ -1,12 +1,10 @@
 //! Module that takes care of loading, checking and preprocessing of a
 //! wasm module before execution.
 
-use parity_wasm::builder;
-use parity_wasm::elements::{self, External, MemorySection, Type};
-use pwasm_utils::{self, rules};
-
 use near_vm_errors::PrepareError;
 use near_vm_logic::VMConfig;
+use pwasm_utils::parity_wasm::builder;
+use pwasm_utils::parity_wasm::elements::{self, External, MemorySection};
 
 pub(crate) const WASM_FEATURES: wasmparser::WasmFeatures = wasmparser::WasmFeatures {
     reference_types: false,
@@ -23,6 +21,36 @@ pub(crate) const WASM_FEATURES: wasmparser::WasmFeatures = wasmparser::WasmFeatu
     memory64: false,
 };
 
+/// Loads the given module given in `original_code`, performs some checks on it and
+/// does some preprocessing.
+///
+/// The checks are:
+///
+/// - module doesn't define an internal memory instance,
+/// - imported memory (if any) doesn't reserve more memory than permitted by the `config`,
+/// - all imported functions from the external environment matches defined by `env` module,
+/// - functions number does not exceed limit specified in VMConfig,
+///
+/// The preprocessing includes injecting code for gas metering and metering the height of stack.
+pub fn prepare_contract(original_code: &[u8], config: &VMConfig) -> Result<Vec<u8>, PrepareError> {
+    wasmparser::Validator::new()
+        .wasm_features(WASM_FEATURES)
+        .validate_all(original_code)
+        .map_err(|_| PrepareError::Deserialization)?;
+
+    match config.limit_config.stack_limiter_version {
+        near_vm_logic::StackLimiterVersion::V0 => pwasm_12::prepare_contract(original_code, config),
+        near_vm_logic::StackLimiterVersion::V1 => ContractModule::init(original_code, config)?
+            .validate_functions_number()?
+            .standardize_mem()
+            .ensure_no_internal_memory()?
+            .inject_gas_metering()?
+            .inject_stack_height_metering()?
+            .scan_imports()?
+            .into_wasm_code(),
+    }
+}
+
 struct ContractModule<'a> {
     module: elements::Module,
     config: &'a VMConfig,
@@ -30,11 +58,7 @@ struct ContractModule<'a> {
 
 impl<'a> ContractModule<'a> {
     fn init(original_code: &[u8], config: &'a VMConfig) -> Result<Self, PrepareError> {
-        wasmparser::Validator::new()
-            .wasm_features(WASM_FEATURES)
-            .validate_all(original_code)
-            .map_err(|_| PrepareError::Deserialization)?;
-        let module = elements::deserialize_buffer(original_code)
+        let module = pwasm_utils::parity_wasm::deserialize_buffer(original_code)
             .map_err(|_| PrepareError::Deserialization)?;
         Ok(ContractModule { module, config })
     }
@@ -80,8 +104,9 @@ impl<'a> ContractModule<'a> {
         if config.regular_op_cost == 0 {
             return Ok(Self { module, config });
         }
-        let gas_rules = rules::Set::new(1, Default::default()).with_grow_cost(config.grow_mem_cost);
-        let module = pwasm_utils::inject_gas_counter(module, &gas_rules)
+        let gas_rules = pwasm_utils::rules::Set::new(1, Default::default())
+            .with_grow_cost(config.grow_mem_cost);
+        let module = pwasm_utils::inject_gas_counter(module, &gas_rules, "env")
             .map_err(|_| PrepareError::GasInstrumentation)?;
         Ok(Self { module, config })
     }
@@ -126,7 +151,7 @@ impl<'a> ContractModule<'a> {
                 _ => continue,
             };
 
-            let Type::Function(ref _func_ty) =
+            let elements::Type::Function(ref _func_ty) =
                 types.get(*type_idx as usize).ok_or(PrepareError::Instantiate)?;
 
             // TODO: Function type check with Env
@@ -172,26 +197,175 @@ impl<'a> ContractModule<'a> {
     }
 }
 
-/// Loads the given module given in `original_code`, performs some checks on it and
-/// does some preprocessing.
-///
-/// The checks are:
-///
-/// - module doesn't define an internal memory instance,
-/// - imported memory (if any) doesn't reserve more memory than permitted by the `config`,
-/// - all imported functions from the external environment matches defined by `env` module,
-/// - functions number does not exceed limit specified in VMConfig,
-///
-/// The preprocessing includes injecting code for gas metering and metering the height of stack.
-pub fn prepare_contract(original_code: &[u8], config: &VMConfig) -> Result<Vec<u8>, PrepareError> {
-    ContractModule::init(original_code, config)?
-        .validate_functions_number()?
-        .standardize_mem()
-        .ensure_no_internal_memory()?
-        .inject_gas_metering()?
-        .inject_stack_height_metering()?
-        .scan_imports()?
-        .into_wasm_code()
+/// Legacy validation for old protocol versions
+mod pwasm_12 {
+    use near_vm_errors::PrepareError;
+    use near_vm_logic::VMConfig;
+    use parity_wasm_41::builder;
+    use parity_wasm_41::elements::{self, External, MemorySection, Type};
+    use pwasm_utils_12 as pwasm_utils;
+
+    pub fn prepare_contract(
+        original_code: &[u8],
+        config: &VMConfig,
+    ) -> Result<Vec<u8>, PrepareError> {
+        ContractModule::init(original_code, config)?
+            .validate_functions_number()?
+            .standardize_mem()
+            .ensure_no_internal_memory()?
+            .inject_gas_metering()?
+            .inject_stack_height_metering()?
+            .scan_imports()?
+            .into_wasm_code()
+    }
+
+    struct ContractModule<'a> {
+        module: elements::Module,
+        config: &'a VMConfig,
+    }
+
+    impl<'a> ContractModule<'a> {
+        fn init(original_code: &[u8], config: &'a VMConfig) -> Result<Self, PrepareError> {
+            let module = elements::deserialize_buffer(original_code)
+                .map_err(|_| PrepareError::Deserialization)?;
+            Ok(ContractModule { module, config })
+        }
+
+        fn standardize_mem(self) -> Self {
+            let Self { mut module, config } = self;
+
+            let mut tmp = MemorySection::default();
+
+            module.memory_section_mut().unwrap_or(&mut tmp).entries_mut().pop();
+
+            let entry = elements::MemoryType::new(
+                config.limit_config.initial_memory_pages,
+                Some(config.limit_config.max_memory_pages),
+            );
+
+            let mut builder = builder::from_module(module);
+            builder.push_import(elements::ImportEntry::new(
+                "env".to_string(),
+                "memory".to_string(),
+                elements::External::Memory(entry),
+            ));
+
+            Self { module: builder.build(), config }
+        }
+
+        /// Ensures that module doesn't declare internal memories.
+        ///
+        /// In this runtime we only allow wasm module to import memory from the environment.
+        /// Memory section contains declarations of internal linear memories, so if we find one
+        /// we reject such a module.
+        fn ensure_no_internal_memory(self) -> Result<Self, PrepareError> {
+            if self.module.memory_section().map_or(false, |ms| !ms.entries().is_empty()) {
+                Err(PrepareError::InternalMemoryDeclared)
+            } else {
+                Ok(self)
+            }
+        }
+
+        fn inject_gas_metering(self) -> Result<Self, PrepareError> {
+            let Self { module, config } = self;
+            // Free config, no need for gas metering.
+            if config.regular_op_cost == 0 {
+                return Ok(Self { module, config });
+            }
+            let gas_rules = pwasm_utils::rules::Set::new(1, Default::default())
+                .with_grow_cost(config.grow_mem_cost);
+            let module = pwasm_utils::inject_gas_counter(module, &gas_rules)
+                .map_err(|_| PrepareError::GasInstrumentation)?;
+            Ok(Self { module, config })
+        }
+
+        fn inject_stack_height_metering(self) -> Result<Self, PrepareError> {
+            let Self { module, config } = self;
+            let module = pwasm_utils::stack_height::inject_limiter(
+                module,
+                config.limit_config.max_stack_height,
+            )
+            .map_err(|_| PrepareError::StackHeightInstrumentation)?;
+            Ok(Self { module, config })
+        }
+
+        /// Scan an import section if any.
+        ///
+        /// This accomplishes two tasks:
+        ///
+        /// - checks any imported function against defined host functions set, incl.
+        ///   their signatures.
+        /// - if there is a memory import, returns it's descriptor
+        fn scan_imports(self) -> Result<Self, PrepareError> {
+            let Self { module, config } = self;
+
+            let types = module.type_section().map(elements::TypeSection::types).unwrap_or(&[]);
+            let import_entries =
+                module.import_section().map(elements::ImportSection::entries).unwrap_or(&[]);
+
+            let mut imported_mem_type = None;
+
+            for import in import_entries {
+                if import.module() != "env" {
+                    // This import tries to import something from non-"env" module,
+                    // but all imports are located in "env" at the moment.
+                    return Err(PrepareError::Instantiate);
+                }
+
+                let type_idx = match *import.external() {
+                    External::Function(ref type_idx) => type_idx,
+                    External::Memory(ref memory_type) => {
+                        imported_mem_type = Some(memory_type);
+                        continue;
+                    }
+                    _ => continue,
+                };
+
+                let Type::Function(ref _func_ty) =
+                    types.get(*type_idx as usize).ok_or(PrepareError::Instantiate)?;
+
+                // TODO: Function type check with Env
+                /*
+
+                let ext_func = env
+                    .funcs
+                    .get(import.field().as_bytes())
+                    .ok_or_else(|| Error::Instantiate)?;
+                if !ext_func.func_type_matches(func_ty) {
+                    return Err(Error::Instantiate);
+                }
+                */
+            }
+            if let Some(memory_type) = imported_mem_type {
+                // Inspect the module to extract the initial and maximum page count.
+                let limits = memory_type.limits();
+                if limits.initial() != config.limit_config.initial_memory_pages
+                    || limits.maximum() != Some(config.limit_config.max_memory_pages)
+                {
+                    return Err(PrepareError::Memory);
+                }
+            } else {
+                return Err(PrepareError::Memory);
+            };
+            Ok(Self { module, config })
+        }
+
+        fn validate_functions_number(self) -> Result<Self, PrepareError> {
+            if let Some(max_functions_number) =
+                self.config.limit_config.max_functions_number_per_contract
+            {
+                let functions_number = self.module.functions_space() as u64;
+                if functions_number > max_functions_number {
+                    return Err(PrepareError::TooManyFunctions);
+                }
+            }
+            Ok(self)
+        }
+
+        fn into_wasm_code(self) -> Result<Vec<u8>, PrepareError> {
+            elements::serialize(self.module).map_err(|_| PrepareError::Serialization)
+        }
+    }
 }
 
 #[cfg(test)]

--- a/runtime/near-vm-runner/src/tests.rs
+++ b/runtime/near-vm-runner/src/tests.rs
@@ -120,3 +120,21 @@ fn make_simple_contract_call_vm(
 ) -> (Option<VMOutcome>, Option<VMError>) {
     make_simple_contract_call_with_gas_vm(code, method_name, 10u64.pow(14), vm_kind)
 }
+
+#[track_caller]
+fn gas_and_error_match(
+    outcome_and_error: (Option<VMOutcome>, Option<VMError>),
+    expected_gas: Option<u64>,
+    expected_error: Option<VMError>,
+) {
+    match expected_gas {
+        Some(gas) => {
+            let outcome = outcome_and_error.0.unwrap();
+            assert_eq!(outcome.used_gas, gas, "used gas differs");
+            assert_eq!(outcome.burnt_gas, gas, "burnt gas differs");
+        }
+        None => assert!(outcome_and_error.0.is_none()),
+    }
+
+    assert_eq!(outcome_and_error.1, expected_error);
+}

--- a/runtime/near-vm-runner/src/tests/runtime_errors.rs
+++ b/runtime/near-vm-runner/src/tests/runtime_errors.rs
@@ -1,30 +1,14 @@
+use super::gas_and_error_match;
 use crate::tests::{
-    make_simple_contract_call_vm, make_simple_contract_call_with_gas_vm, with_vm_variants,
+    make_simple_contract_call_vm, make_simple_contract_call_with_gas_vm,
+    make_simple_contract_call_with_protocol_version_vm, with_vm_variants,
 };
 use crate::vm_kind::VMKind;
+use near_primitives::version::ProtocolFeature;
 use near_vm_errors::{
     CompilationError, FunctionCallError, HostError, MethodResolveError, PrepareError, VMError,
     WasmTrap,
 };
-use near_vm_logic::VMOutcome;
-
-#[track_caller]
-fn gas_and_error_match(
-    outcome_and_error: (Option<VMOutcome>, Option<VMError>),
-    expected_gas: Option<u64>,
-    expected_error: Option<VMError>,
-) {
-    match expected_gas {
-        Some(gas) => {
-            let outcome = outcome_and_error.0.unwrap();
-            assert_eq!(outcome.used_gas, gas, "used gas differs");
-            assert_eq!(outcome.burnt_gas, gas, "burnt gas differs");
-        }
-        None => assert!(outcome_and_error.0.is_none()),
-    }
-
-    assert_eq!(outcome_and_error.1, expected_error);
-}
 
 fn infinite_initializer_contract() -> Vec<u8> {
     wat::parse_str(
@@ -472,6 +456,80 @@ fn test_stack_overflow() {
             ),
             VMKind::Wasmtime => {}
         }
+    });
+}
+
+fn stack_overflow_many_locals() -> Vec<u8> {
+    wat::parse_str(
+        r#"
+            (module
+              (func $f1 (export "f1")
+                (local i32)
+                (call $f1))
+              (func $f2 (export "f2")
+                (local i32 i32 i32 i32)
+                (call $f2))
+            )"#,
+    )
+    .unwrap()
+}
+
+#[test]
+fn test_stack_instrumentation_protocol_upgrade() {
+    with_vm_variants(|vm_kind: VMKind| {
+        match vm_kind {
+            VMKind::Wasmer0 | VMKind::Wasmer2 => {}
+            // All contracts leading to hardware traps can not run concurrently on Wasmtime and Wasmer,
+            // Restore, once get rid of Wasmer 0.x.
+            VMKind::Wasmtime => return,
+        }
+        let code = stack_overflow_many_locals();
+
+        let res = make_simple_contract_call_with_protocol_version_vm(
+            &code,
+            "f1",
+            ProtocolFeature::CorrectStackLimit.protocol_version() - 1,
+            vm_kind,
+        );
+        gas_and_error_match(
+            res,
+            Some(6789985365),
+            Some(VMError::FunctionCallError(FunctionCallError::WasmTrap(WasmTrap::Unreachable))),
+        );
+        let res = make_simple_contract_call_with_protocol_version_vm(
+            &code,
+            "f2",
+            ProtocolFeature::CorrectStackLimit.protocol_version() - 1,
+            vm_kind,
+        );
+        gas_and_error_match(
+            res,
+            Some(6789985365),
+            Some(VMError::FunctionCallError(FunctionCallError::WasmTrap(WasmTrap::Unreachable))),
+        );
+
+        let res = make_simple_contract_call_with_protocol_version_vm(
+            &code,
+            "f1",
+            ProtocolFeature::CorrectStackLimit.protocol_version(),
+            vm_kind,
+        );
+        gas_and_error_match(
+            res,
+            Some(6789985365),
+            Some(VMError::FunctionCallError(FunctionCallError::WasmTrap(WasmTrap::Unreachable))),
+        );
+        let res = make_simple_contract_call_with_protocol_version_vm(
+            &code,
+            "f2",
+            ProtocolFeature::CorrectStackLimit.protocol_version(),
+            vm_kind,
+        );
+        gas_and_error_match(
+            res,
+            Some(2745316869),
+            Some(VMError::FunctionCallError(FunctionCallError::WasmTrap(WasmTrap::Unreachable))),
+        );
     });
 }
 


### PR DESCRIPTION
This forward-ports the change from 1.23.1

We upgrade our version of pwasm-utils -- the old one severely
undercounted stack usage in some cases. As this is a protocol change, we
keep the old implementation around

Test Plan
=========

* added test for stack overflow behavior for the bad case
* added test for protocol upgrade related to stack overflow
* fuzzed new pwasm utils implementation locally, confirmed that it only
  differs for calls which stack overflow