### PR TITLE
neard: fix RUST_LOG being ignored

### DIFF
--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -401,7 +401,7 @@ fn init_logging(verbose: Option<&str>) {
     const DEFAULT_RUST_LOG: &'static str =
         "tokio_reactor=info,near=info,stats=info,telemetry=info,\
          delay_detector=info,near-performance-metrics=info,\
-         near-rust-allocator-proxy=info";
+         near-rust-allocator-proxy=info,warn";
 
     let rust_log = env::var("RUST_LOG");
     let rust_log = rust_log.as_ref().map(String::as_str).unwrap_or(DEFAULT_RUST_LOG);
@@ -420,8 +420,6 @@ fn init_logging(verbose: Option<&str>) {
         } else {
             env_filter = env_filter.add_directive(format!("{}=debug", module).parse().unwrap());
         }
-    } else {
-        env_filter = env_filter.add_directive(LevelFilter::WARN.into());
     }
 
     tracing_subscriber::fmt::Subscriber::builder()


### PR DESCRIPTION
From EnvFilter documentation:

> If a filter directive is inserted that matches exactly the same
> spans and events as a previous filter, but sets a different level
> for those spans and events, the previous directive is overwritten.

This means, that adding a LevelFilter::WARN directive overwrites all
previous configuration.  (Confusingly, ‘foo=debug,warn’ works fine as
expected; I’m rather confused about EnvFilter to be honest).

In the meanwhile, commit be9331ee: ‘better respect RUST_LOG’ moved
where rules from RUST_LOG were applied.  Rather than happening after
WARN level filter, they happen before which means that we are
unconditionally overwriting anything that was set via RUST_LOG.

Rather than adding LevelFilter::WARN in separate step, add it to the
default RUST_LOG value.

Issue: https://github.com/near/nearcore/issues/6008