### PR TITLE
Instrument gas usage rather than opcodes

### DIFF
--- a/runtime/near-vm-logic/src/gas_counter.rs
+++ b/runtime/near-vm-logic/src/gas_counter.rs
@@ -69,7 +69,6 @@ impl GasCounter {
     pub fn new(
         ext_costs_config: ExtCostsConfig,
         max_gas_burnt: Gas,
-        opcode_cost: u32,
         prepaid_gas: Gas,
         is_view: bool,
     ) -> Self {
@@ -81,7 +80,7 @@ impl GasCounter {
             fast_counter: FastGasCounter {
                 burnt_gas: 0,
                 gas_limit: min(max_gas_burnt, prepaid_gas),
-                opcode_cost: Gas::from(opcode_cost),
+                opcode_cost: 1,
             },
             max_gas_burnt: max_gas_burnt,
             promises_gas: 0,
@@ -153,11 +152,6 @@ impl GasCounter {
         } else {
             HostError::GasExceeded
         }
-    }
-
-    pub fn pay_wasm_gas(&mut self, opcodes: u32) -> Result<()> {
-        let value = Gas::from(opcodes) * self.fast_counter.opcode_cost;
-        self.burn_gas(value)
     }
 
     /// Very special function to get the gas counter pointer for generated machine code.
@@ -290,7 +284,7 @@ mod tests {
     use near_primitives_core::types::Gas;
 
     fn make_test_counter(max_burnt: Gas, prepaid: Gas, is_view: bool) -> super::GasCounter {
-        super::GasCounter::new(ExtCostsConfig::test(), max_burnt, 1, prepaid, is_view)
+        super::GasCounter::new(ExtCostsConfig::test(), max_burnt, prepaid, is_view)
     }
 
     #[test]

--- a/runtime/near-vm-runner/src/prepare.rs
+++ b/runtime/near-vm-runner/src/prepare.rs
@@ -108,7 +108,7 @@ impl<'a> ContractModule<'a> {
         if config.regular_op_cost == 0 {
             return Ok(Self { module, config });
         }
-        let gas_rules = pwasm_utils::rules::Set::new(1, Default::default())
+        let gas_rules = pwasm_utils::rules::Set::new(config.regular_op_cost, Default::default())
             .with_grow_cost(config.grow_mem_cost);
         let module = pwasm_utils::inject_gas_counter(module, &gas_rules, "env")
             .map_err(|_| PrepareError::GasInstrumentation)?;
@@ -276,8 +276,9 @@ mod pwasm_12 {
             if config.regular_op_cost == 0 {
                 return Ok(Self { module, config });
             }
-            let gas_rules = pwasm_utils::rules::Set::new(1, Default::default())
-                .with_grow_cost(config.grow_mem_cost);
+            let gas_rules =
+                pwasm_utils::rules::Set::new(config.regular_op_cost, Default::default())
+                    .with_grow_cost(config.grow_mem_cost);
             let module = pwasm_utils::inject_gas_counter(module, &gas_rules)
                 .map_err(|_| PrepareError::GasInstrumentation)?;
             Ok(Self { module, config })

--- a/runtime/near-vm-runner/src/prepare.rs
+++ b/runtime/near-vm-runner/src/prepare.rs
@@ -457,4 +457,28 @@ mod tests {
         assert_matches!(r, Err(Error::Instantiate));
         */
     }
+
+    #[test]
+    fn many_instructions_basic_block() {
+        let config = VMConfig::test();
+        let max_insn_in_block = u32::max_value() / config.regular_op_cost;
+        let r = parse_and_prepare_wat(&format!(
+            r#"(module
+            (func $main (export "main")
+                {}
+            )
+        )"#,
+            "(nop)\n".repeat(max_insn_in_block as usize)
+        ));
+        assert_matches!(r, Ok(_));
+        let r = parse_and_prepare_wat(&format!(
+            r#"(module
+            (func $main (export "main")
+                {}
+            )
+        )"#,
+            "(nop)\n".repeat(max_insn_in_block as usize + 1)
+        ));
+        assert_matches!(r, Err(PrepareError::GasInstrumentation));
+    }
 }

--- a/runtime/near-vm-runner/src/prepare.rs
+++ b/runtime/near-vm-runner/src/prepare.rs
@@ -108,8 +108,12 @@ impl<'a> ContractModule<'a> {
         if config.regular_op_cost == 0 {
             return Ok(Self { module, config });
         }
+        let mem_grow_cost = config
+            .grow_mem_cost
+            .checked_mul(config.regular_op_cost)
+            .ok_or(PrepareError::GasInstrumentation)?;
         let gas_rules = pwasm_utils::rules::Set::new(config.regular_op_cost, Default::default())
-            .with_grow_cost(config.grow_mem_cost);
+            .with_grow_cost(mem_grow_cost);
         let module = pwasm_utils::inject_gas_counter(module, &gas_rules, "env")
             .map_err(|_| PrepareError::GasInstrumentation)?;
         Ok(Self { module, config })
@@ -276,9 +280,13 @@ mod pwasm_12 {
             if config.regular_op_cost == 0 {
                 return Ok(Self { module, config });
             }
+            let mem_grow_cost = config
+                .grow_mem_cost
+                .checked_mul(config.regular_op_cost)
+                .ok_or(PrepareError::GasInstrumentation)?;
             let gas_rules =
                 pwasm_utils::rules::Set::new(config.regular_op_cost, Default::default())
-                    .with_grow_cost(config.grow_mem_cost);
+                    .with_grow_cost(mem_grow_cost);
             let module = pwasm_utils::inject_gas_counter(module, &gas_rules)
                 .map_err(|_| PrepareError::GasInstrumentation)?;
             Ok(Self { module, config })

--- a/runtime/near-vm-runner/src/wasmer2_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer2_runner.rs
@@ -231,7 +231,7 @@ impl Wasmer2Config {
 //  major version << 6
 //  minor version
 const WASMER2_CONFIG: Wasmer2Config = Wasmer2Config {
-    seed: (1 << 10) | (5 << 6) | 0,
+    seed: (1 << 10) | (6 << 6) | 0,
     engine: WasmerEngine::Universal,
     compiler: WasmerCompiler::Singlepass,
 };


### PR DESCRIPTION
Here we adjust the instrumentation to insert `gas(...)` where the argument
is the actual gas amount rather than the number of WASM instructions.

This results in larger number being passed to the `gas` function, and
therefore fewer instructions being possible per-block – with current
`regular_op_cost` that's about 5.5k instructions per block maximum.

As a benefit, however, this allows to remove a multiplication with
significant data dependencies every time gas cost is charged. This makes
sense, as the `regular_op_cost` won't change between protocol versions,
and therefore computing block's gas cost can be done once – at compile time.

Every time `regular_op_cost` changes, the contract has will already
change due to it including a hash of the `VMConfig`, so the contracts
previously compiled will naturally get “evicted” from the cache.

The limitation pertaining to instruction count could be dealt with by changing
instrumentation to emit calls to the newly added `gas64` function, or perhaps
by changing the `gas` function to accept the `u64` argument directly.

(Similar changes would be necessary for the intrinsic codegen implementation)

---

I'm sure I'm missing some details in this implementation, but I'm otherwise confident
we could make all the changes necessary to make this work. Potentially even without
a protocol break.