### PR TITLE
re: Remove unused dependencies from `runtime-params-estimator`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1874,15 +1874,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
-name = "gnuplot"
-version = "0.0.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de437277a7ec10de5f34e3147c7da4c6d8b279c5d8ae1e33e842fd9432bb0f3"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "h2"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4412,10 +4403,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "chrono",
  "clap 3.0.0-beta.2",
- "csv",
  "genesis-populate",
- "glob",
- "gnuplot",
  "hex",
  "indicatif",
  "libc",
@@ -4435,9 +4423,7 @@ dependencies = [
  "rocksdb",
  "serde_json",
  "sha256",
- "state-viewer",
  "tempfile",
- "testlib",
  "walrus",
  "wat",
 ]

--- a/runtime/runtime-params-estimator/Cargo.toml
+++ b/runtime/runtime-params-estimator/Cargo.toml
@@ -16,9 +16,7 @@ indicatif = "0.15.0"
 tempfile = "3"
 rand = "0.7.3"
 rand_xorshift = "0.2"
-gnuplot = "0.0.37"
 serde_json = "1"
-csv = "1.1.3"
 clap = "=3.0.0-beta.2"
 borsh = "0.9"
 num-rational = "0.3"
@@ -36,11 +34,8 @@ near-store = { path = "../../core/store" }
 near-primitives = { path = "../../core/primitives" }
 near-test-contracts = { path = "../../runtime/near-test-contracts" }
 
-testlib = { path = "../../test-utils/testlib" }
-state-viewer = { path = "../../test-utils/state-viewer" }
 nearcore = { path = "../../nearcore" }
 rocksdb = "0.16.0"
-glob = "0.3.0"
 walrus = "0.18.0"
 hex = "0.4"
 cfg-if = "1"
@@ -62,7 +57,6 @@ protocol_feature_alt_bn128 = [
     "near-vm-logic/protocol_feature_alt_bn128",
     "near-vm-runner/protocol_feature_alt_bn128",
     "node-runtime/protocol_feature_alt_bn128",
-    "testlib/protocol_feature_alt_bn128",
     "nearcore/protocol_feature_alt_bn128",
 ]
-sandbox = ["node-runtime/sandbox", "state-viewer/sandbox"]
+sandbox = ["node-runtime/sandbox"]


### PR DESCRIPTION
There are a few unused dependencies in `runtime-params-estimator` that can be safely removed.