### PR TITLE
re: Make `rosetta-rpc` depend on `near-network-primitives`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3126,7 +3126,7 @@ dependencies = [
  "near-client",
  "near-client-primitives",
  "near-crypto",
- "near-network",
+ "near-network-primitives",
  "near-primitives",
  "paperclip",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1802,7 +1802,6 @@ dependencies = [
  "near-crypto",
  "near-epoch-manager",
  "near-jsonrpc",
- "near-network",
  "near-pool",
  "near-primitives",
  "near-store",

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -21,9 +21,7 @@ use near_chain::{
 };
 use near_chain_configs::ClientConfig;
 use near_chunks::{ProcessPartialEncodedChunkResult, ShardsManager};
-use near_network::types::{
-    FullPeerInfo, NetworkClientResponses, NetworkRequests, PeerManagerAdapter,
-};
+use near_network::types::{NetworkRequests, PeerManagerAdapter};
 use near_primitives::block::{Approval, ApprovalInner, ApprovalMessage, Block, BlockHeader, Tip};
 use near_primitives::challenge::{Challenge, ChallengeBody};
 use near_primitives::hash::CryptoHash;
@@ -46,7 +44,8 @@ use crate::{metrics, SyncStatus};
 use near_client_primitives::types::{Error, ShardSyncDownload, ShardSyncStatus};
 use near_network::types::PeerManagerMessageRequest;
 use near_network_primitives::types::{
-    PartialEncodedChunkForwardMsg, PartialEncodedChunkResponseMsg,
+    FullPeerInfo, NetworkClientResponses, PartialEncodedChunkForwardMsg,
+    PartialEncodedChunkResponseMsg,
 };
 use near_primitives::block_header::ApprovalType;
 use near_primitives::epoch_manager::RngSeed;

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -34,15 +34,14 @@ use near_client_primitives::types::{
     Error, GetNetworkInfo, NetworkInfoResponse, ShardSyncDownload, ShardSyncStatus, Status,
     StatusError, StatusSyncInfo, SyncStatus,
 };
-use near_network::types::{
-    NetworkClientMessages, NetworkClientResponses, NetworkInfo, NetworkRequests,
-    PeerManagerAdapter, PeerManagerMessageRequest,
-};
+use near_network::types::{NetworkRequests, PeerManagerAdapter, PeerManagerMessageRequest};
 #[cfg(feature = "test_features")]
 use near_network_primitives::types::NetworkAdversarialMessage;
 #[cfg(feature = "sandbox")]
 use near_network_primitives::types::NetworkSandboxMessage;
-use near_network_primitives::types::ReasonForBan;
+use near_network_primitives::types::{
+    NetworkClientMessages, NetworkClientResponses, NetworkInfo, ReasonForBan,
+};
 use near_performance_metrics;
 use near_performance_metrics_macros::{perf, perf_with_debug};
 use near_primitives::block_header::ApprovalType;

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -4,7 +4,7 @@ use ansi_term::Color::{Blue, Cyan, Green, White, Yellow};
 use log::info;
 use near_chain_configs::{ClientConfig, LogSummaryStyle};
 use near_client_primitives::types::ShardSyncStatus;
-use near_network::types::NetworkInfo;
+use near_network_primitives::types::NetworkInfo;
 use near_primitives::block::Tip;
 use near_primitives::network::PeerId;
 use near_primitives::serialize::to_base;

--- a/chain/client/src/sync.rs
+++ b/chain/client/src/sync.rs
@@ -14,7 +14,7 @@ use rand::seq::{IteratorRandom, SliceRandom};
 use rand::{thread_rng, Rng};
 
 use near_chain::{Chain, RuntimeAdapter};
-use near_network::types::{FullPeerInfo, NetworkRequests, NetworkResponses, PeerManagerAdapter};
+use near_network::types::{NetworkRequests, NetworkResponses, PeerManagerAdapter};
 use near_primitives::block::Tip;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
@@ -32,7 +32,7 @@ use near_client_primitives::types::{
     DownloadStatus, ShardSyncDownload, ShardSyncStatus, SyncStatus,
 };
 use near_network::types::PeerManagerMessageRequest;
-use near_network_primitives::types::AccountOrPeerIdOrHash;
+use near_network_primitives::types::{AccountOrPeerIdOrHash, FullPeerInfo};
 use near_primitives::shard_layout::ShardUId;
 
 /// Maximum number of block headers send over the network.

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -21,12 +21,11 @@ use near_chain::{
 use near_chain_configs::ClientConfig;
 use near_crypto::{InMemorySigner, KeyType, PublicKey};
 use near_network::test_utils::{MockPeerManagerAdapter, NetworkRecipient};
-use near_network::types::{
-    FullPeerInfo, NetworkClientMessages, NetworkClientResponses, NetworkRequests, NetworkResponses,
-    PeerManagerAdapter,
-};
+use near_network::types::{NetworkRequests, NetworkResponses, PeerManagerAdapter};
 use near_network::PeerManagerActor;
-use near_network_primitives::types::PartialEdgeInfo;
+use near_network_primitives::types::{
+    FullPeerInfo, NetworkClientMessages, NetworkClientResponses, NetworkInfo, PartialEdgeInfo,
+};
 use near_primitives::block::{ApprovalInner, Block, GenesisId};
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::merkle::{merklize, MerklePath};
@@ -53,7 +52,7 @@ use crate::{start_view_client, Client, ClientActor, SyncStatus, ViewClientActor}
 use near_chain::chain::{do_apply_chunks, BlockCatchUpRequest, StateSplitRequest};
 use near_chain::types::AcceptedBlock;
 use near_client_primitives::types::Error;
-use near_network::types::{NetworkInfo, PeerManagerMessageRequest, PeerManagerMessageResponse};
+use near_network::types::{PeerManagerMessageRequest, PeerManagerMessageResponse};
 use near_network_primitives::types::{
     AccountOrPeerIdOrHash, NetworkViewClientMessages, NetworkViewClientResponses,
     PartialEncodedChunkRequestMsg, PartialEncodedChunkResponseMsg, PeerChainInfoV2, PeerInfo,

--- a/chain/client/src/tests/bug_repros.rs
+++ b/chain/client/src/tests/bug_repros.rs
@@ -17,10 +17,9 @@ use near_crypto::{InMemorySigner, KeyType};
 use near_logger_utils::init_test_logger;
 use near_network::types::NetworkRequests::PartialEncodedChunkMessage;
 use near_network::types::{
-    NetworkClientMessages, NetworkRequests, NetworkResponses, PeerManagerMessageRequest,
-    PeerManagerMessageResponse,
+    NetworkRequests, NetworkResponses, PeerManagerMessageRequest, PeerManagerMessageResponse,
 };
-use near_network_primitives::types::PeerInfo;
+use near_network_primitives::types::{NetworkClientMessages, PeerInfo};
 use near_primitives::block::Block;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::AccountId;

--- a/chain/client/src/tests/catching_up.rs
+++ b/chain/client/src/tests/catching_up.rs
@@ -13,11 +13,9 @@ use near_chain::test_utils::account_id_to_shard_id;
 use near_chain_configs::TEST_STATE_SYNC_TIMEOUT;
 use near_crypto::{InMemorySigner, KeyType};
 use near_logger_utils::init_integration_logger;
-use near_network::types::{
-    NetworkClientMessages, NetworkRequests, NetworkResponses, PeerManagerMessageRequest,
-};
+use near_network::types::{NetworkRequests, NetworkResponses, PeerManagerMessageRequest};
 use near_network_primitives::types::{
-    AccountIdOrPeerTrackingShard, AccountOrPeerIdOrHash, PeerInfo,
+    AccountIdOrPeerTrackingShard, AccountOrPeerIdOrHash, NetworkClientMessages, PeerInfo,
 };
 use near_primitives::hash::{hash as hash_func, CryptoHash};
 use near_primitives::receipt::Receipt;

--- a/chain/client/src/tests/consensus.rs
+++ b/chain/client/src/tests/consensus.rs
@@ -9,10 +9,8 @@ use crate::{ClientActor, ViewClientActor};
 use near_actix_test_utils::run_actix;
 use near_chain::Block;
 use near_logger_utils::init_integration_logger;
-use near_network::types::{
-    NetworkClientMessages, NetworkRequests, NetworkResponses, PeerManagerMessageRequest,
-};
-use near_network_primitives::types::PeerInfo;
+use near_network::types::{NetworkRequests, NetworkResponses, PeerManagerMessageRequest};
+use near_network_primitives::types::{NetworkClientMessages, PeerInfo};
 use near_primitives::block::{Approval, ApprovalInner};
 use near_primitives::types::{AccountId, BlockHeight};
 

--- a/chain/client/src/tests/cross_shard_tx.rs
+++ b/chain/client/src/tests/cross_shard_tx.rs
@@ -12,10 +12,9 @@ use near_chain::test_utils::account_id_to_shard_id;
 use near_crypto::{InMemorySigner, KeyType};
 use near_logger_utils::init_integration_logger;
 use near_network::types::{
-    NetworkClientMessages, NetworkClientResponses, NetworkResponses, PeerManagerMessageRequest,
-    PeerManagerMessageResponse,
+    NetworkResponses, PeerManagerMessageRequest, PeerManagerMessageResponse,
 };
-use near_network_primitives::types::PeerInfo;
+use near_network_primitives::types::{NetworkClientMessages, NetworkClientResponses, PeerInfo};
 use near_primitives::hash::CryptoHash;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{AccountId, BlockReference};

--- a/chain/client/src/tests/query_client.rs
+++ b/chain/client/src/tests/query_client.rs
@@ -9,9 +9,9 @@ use near_actix_test_utils::run_actix;
 use near_crypto::{InMemorySigner, KeyType};
 use near_logger_utils::init_test_logger;
 use near_network::test_utils::MockPeerManagerAdapter;
-use near_network::types::{NetworkClientMessages, NetworkClientResponses};
 use near_network_primitives::types::{
-    NetworkViewClientMessages, NetworkViewClientResponses, PeerInfo,
+    NetworkClientMessages, NetworkClientResponses, NetworkViewClientMessages,
+    NetworkViewClientResponses, PeerInfo,
 };
 use near_primitives::block::{Block, BlockHeader};
 use near_primitives::time::Utc;

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -25,7 +25,7 @@ use near_jsonrpc_primitives::errors::RpcError;
 use near_jsonrpc_primitives::message::{Message, Request};
 use near_jsonrpc_primitives::types::config::RpcProtocolConfigResponse;
 use near_metrics::{Encoder, TextEncoder};
-use near_network::types::{NetworkClientMessages, NetworkClientResponses};
+use near_network_primitives::types::{NetworkClientMessages, NetworkClientResponses};
 use near_primitives::hash::CryptoHash;
 use near_primitives::serialize::BaseEncode;
 use near_primitives::transaction::SignedTransaction;
@@ -1132,7 +1132,7 @@ impl JsonRpcHandler {
     async fn adv_disable_header_sync(&self, _params: Option<Value>) -> Result<Value, RpcError> {
         actix::spawn(
             self.client_addr
-                .send(near_network::types::NetworkClientMessages::Adversarial(
+                .send(near_network_primitives::types::NetworkClientMessages::Adversarial(
                     near_network_primitives::types::NetworkAdversarialMessage::AdvDisableHeaderSync,
                 ))
                 .map(|_| ()),

--- a/chain/network-primitives/src/types.rs
+++ b/chain/network-primitives/src/types.rs
@@ -13,12 +13,15 @@ use actix::{Actor, Message};
 use borsh::{BorshDeserialize, BorshSerialize};
 use chrono::DateTime;
 use near_crypto::{SecretKey, Signature};
-use near_primitives::block::{Block, BlockHeader, GenesisId};
+use near_primitives::block::{Approval, Block, BlockHeader, GenesisId};
+use near_primitives::challenge::Challenge;
+use near_primitives::errors::InvalidTxError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::{AnnounceAccount, PeerId};
+use near_primitives::sharding::PartialEncodedChunk;
 use near_primitives::syncing::{EpochSyncFinalizationResponse, EpochSyncResponse};
 use near_primitives::time::{Clock, Utc};
-use near_primitives::transaction::ExecutionOutcomeWithIdAndProof;
+use near_primitives::transaction::{ExecutionOutcomeWithIdAndProof, SignedTransaction};
 use near_primitives::types::{AccountId, BlockHeight, EpochId, ShardId};
 use near_primitives::utils::{from_timestamp, to_timestamp};
 use near_primitives::views::{FinalExecutionOutcomeView, QueryResponse};
@@ -510,5 +513,127 @@ mod tests {
                 92, 92, 92, 92, 92, 92, 92, 92, 92, 92, 92, 92, 92, 92, 92, 92, 92, 92, 92, 0, 0,
             ],
         );
+    }
+}
+
+/// Combines peer address info, chain and edge information.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct FullPeerInfo {
+    pub peer_info: PeerInfo,
+    pub chain_info: PeerChainInfoV2,
+    pub partial_edge_info: PartialEdgeInfo,
+}
+
+#[derive(Debug)]
+pub struct NetworkInfo {
+    pub connected_peers: Vec<FullPeerInfo>,
+    pub num_connected_peers: usize,
+    pub peer_max_count: u32,
+    pub highest_height_peers: Vec<FullPeerInfo>,
+    pub sent_bytes_per_sec: u64,
+    pub received_bytes_per_sec: u64,
+    /// Accounts of known block and chunk producers from routing table.
+    pub known_producers: Vec<KnownProducer>,
+    pub peer_counter: usize,
+}
+
+impl<A, M> MessageResponse<A, M> for NetworkInfo
+where
+    A: Actor,
+    M: Message<Result = NetworkInfo>,
+{
+    fn handle<R: ResponseChannel<M>>(self, _: &mut A::Context, tx: Option<R>) {
+        if let Some(tx) = tx {
+            tx.send(self)
+        }
+    }
+}
+
+#[derive(Debug, strum::AsRefStr, AsStaticStr)]
+// TODO(#1313): Use Box
+#[allow(clippy::large_enum_variant)]
+pub enum NetworkClientMessages {
+    #[cfg(feature = "test_features")]
+    Adversarial(NetworkAdversarialMessage),
+
+    #[cfg(feature = "sandbox")]
+    Sandbox(NetworkSandboxMessage),
+
+    /// Received transaction.
+    Transaction {
+        transaction: SignedTransaction,
+        /// Whether the transaction is forwarded from other nodes.
+        is_forwarded: bool,
+        /// Whether the transaction needs to be submitted.
+        check_only: bool,
+    },
+    /// Received block, possibly requested.
+    Block(Block, PeerId, bool),
+    /// Received list of headers for syncing.
+    BlockHeaders(Vec<BlockHeader>, PeerId),
+    /// Block approval.
+    BlockApproval(Approval, PeerId),
+    /// State response.
+    StateResponse(StateResponseInfo),
+    /// Epoch Sync response for light client block request
+    EpochSyncResponse(PeerId, Box<EpochSyncResponse>),
+    /// Epoch Sync response for finalization request
+    EpochSyncFinalizationResponse(PeerId, Box<EpochSyncFinalizationResponse>),
+
+    /// Request chunk parts and/or receipts.
+    PartialEncodedChunkRequest(PartialEncodedChunkRequestMsg, CryptoHash),
+    /// Response to a request for  chunk parts and/or receipts.
+    PartialEncodedChunkResponse(PartialEncodedChunkResponseMsg),
+    /// Information about chunk such as its header, some subset of parts and/or incoming receipts
+    PartialEncodedChunk(PartialEncodedChunk),
+    /// Forwarding parts to those tracking the shard (so they don't need to send requests)
+    PartialEncodedChunkForward(PartialEncodedChunkForwardMsg),
+
+    /// A challenge to invalidate the block.
+    Challenge(Challenge),
+
+    NetworkInfo(NetworkInfo),
+}
+
+impl Message for NetworkClientMessages {
+    type Result = NetworkClientResponses;
+}
+
+// TODO(#1313): Use Box
+#[derive(Eq, PartialEq, Debug)]
+#[allow(clippy::large_enum_variant)]
+pub enum NetworkClientResponses {
+    /// Adv controls.
+    #[cfg(feature = "test_features")]
+    AdvResult(u64),
+
+    /// Sandbox controls
+    #[cfg(feature = "sandbox")]
+    SandboxResult(SandboxResponse),
+
+    /// No response.
+    NoResponse,
+    /// Valid transaction inserted into mempool as response to Transaction.
+    ValidTx,
+    /// Invalid transaction inserted into mempool as response to Transaction.
+    InvalidTx(InvalidTxError),
+    /// The request is routed to other shards
+    RequestRouted,
+    /// The node being queried does not track the shard needed and therefore cannot provide userful
+    /// response.
+    DoesNotTrackShard,
+    /// Ban peer for malicious behavior.
+    Ban { ban_reason: ReasonForBan },
+}
+
+impl<A, M> MessageResponse<A, M> for NetworkClientResponses
+where
+    A: Actor,
+    M: Message<Result = NetworkClientResponses>,
+{
+    fn handle<R: ResponseChannel<M>>(self, _: &mut A::Context, tx: Option<R>) {
+        if let Some(tx) = tx {
+            tx.send(self)
+        }
     }
 }

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -6,9 +6,8 @@ use crate::private_actix::{
 };
 use crate::stats::metrics::{self, NetworkMetrics};
 use crate::types::{
-    Handshake, HandshakeFailureReason, NetworkClientMessages, NetworkClientResponses,
-    NetworkRequests, NetworkResponses, PeerManagerMessageRequest, PeerMessage, PeerRequest,
-    PeerResponse, PeersResponse,
+    Handshake, HandshakeFailureReason, NetworkRequests, NetworkResponses,
+    PeerManagerMessageRequest, PeerMessage, PeerRequest, PeerResponse, PeersResponse,
 };
 use crate::PeerManagerActor;
 use actix::{
@@ -19,10 +18,10 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use lru::LruCache;
 use near_crypto::Signature;
 use near_network_primitives::types::{
-    Ban, NetworkViewClientMessages, NetworkViewClientResponses, PeerChainInfoV2, PeerIdOrHash,
-    PeerInfo, PeerManagerRequest, PeerStatsResult, PeerType, QueryPeerStats, ReasonForBan,
-    RoutedMessage, RoutedMessageBody, RoutedMessageFrom, StateResponseInfo,
-    UPDATE_INTERVAL_LAST_TIME_RECEIVED_MESSAGE,
+    Ban, NetworkClientMessages, NetworkClientResponses, NetworkViewClientMessages,
+    NetworkViewClientResponses, PeerChainInfoV2, PeerIdOrHash, PeerInfo, PeerManagerRequest,
+    PeerStatsResult, PeerType, QueryPeerStats, ReasonForBan, RoutedMessage, RoutedMessageBody,
+    RoutedMessageFrom, StateResponseInfo, UPDATE_INTERVAL_LAST_TIME_RECEIVED_MESSAGE,
 };
 use near_network_primitives::types::{Edge, PartialEdgeInfo};
 use near_performance_metrics::framed_write::{FramedWrite, WriteHandler};

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -13,9 +13,8 @@ use crate::routing::routing_table_view::{RoutingTableView, DELETE_PEERS_AFTER_TI
 use crate::stats::metrics;
 use crate::stats::metrics::NetworkMetrics;
 use crate::types::{
-    FullPeerInfo, NetworkClientMessages, NetworkInfo, NetworkRequests, NetworkResponses,
-    PeerManagerMessageRequest, PeerManagerMessageResponse, PeerMessage, PeerRequest, PeerResponse,
-    PeersResponse, RoutingTableUpdate,
+    NetworkRequests, NetworkResponses, PeerManagerMessageRequest, PeerManagerMessageResponse,
+    PeerMessage, PeerRequest, PeerResponse, PeersResponse, RoutingTableUpdate,
 };
 use actix::{
     Actor, ActorFuture, Addr, Arbiter, AsyncContext, Context, ContextFutureSpawner, Handler,
@@ -24,11 +23,12 @@ use actix::{
 use futures::task::Poll;
 use futures::{future, Stream, StreamExt};
 use near_network_primitives::types::{
-    AccountOrPeerIdOrHash, Ban, BlockedPorts, Edge, InboundTcpConnect, KnownPeerState,
-    KnownPeerStatus, KnownProducer, NetworkConfig, NetworkViewClientMessages,
-    NetworkViewClientResponses, OutboundTcpConnect, PeerIdOrHash, PeerInfo, PeerManagerRequest,
-    PeerType, Ping, Pong, QueryPeerStats, RawRoutedMessage, ReasonForBan, RoutedMessage,
-    RoutedMessageBody, RoutedMessageFrom, StateResponseInfo,
+    AccountOrPeerIdOrHash, Ban, BlockedPorts, Edge, FullPeerInfo, InboundTcpConnect,
+    KnownPeerState, KnownPeerStatus, KnownProducer, NetworkClientMessages, NetworkConfig,
+    NetworkInfo, NetworkViewClientMessages, NetworkViewClientResponses, OutboundTcpConnect,
+    PeerIdOrHash, PeerInfo, PeerManagerRequest, PeerType, Ping, Pong, QueryPeerStats,
+    RawRoutedMessage, ReasonForBan, RoutedMessage, RoutedMessageBody, RoutedMessageFrom,
+    StateResponseInfo,
 };
 use near_network_primitives::types::{EdgeState, PartialEdgeInfo};
 use near_performance_metrics::framed_write::FramedWrite;

--- a/chain/network/src/test_utils.rs
+++ b/chain/network/src/test_utils.rs
@@ -1,13 +1,12 @@
 use crate::types::{
-    NetworkInfo, NetworkResponses, PeerManagerAdapter, PeerManagerMessageRequest,
-    PeerManagerMessageResponse,
+    NetworkResponses, PeerManagerAdapter, PeerManagerMessageRequest, PeerManagerMessageResponse,
 };
 use crate::PeerManagerActor;
 use actix::{Actor, ActorContext, Context, Handler, MailboxError, Message, Recipient};
 use futures::future::BoxFuture;
 use futures::{future, FutureExt};
 use near_crypto::{KeyType, SecretKey};
-use near_network_primitives::types::{PeerInfo, ReasonForBan};
+use near_network_primitives::types::{NetworkInfo, PeerInfo, ReasonForBan};
 use near_primitives::hash::hash;
 use near_primitives::network::PeerId;
 use near_primitives::types::EpochId;
@@ -187,7 +186,7 @@ impl Message for GetInfo {
 }
 
 impl Handler<GetInfo> for PeerManagerActor {
-    type Result = crate::types::NetworkInfo;
+    type Result = near_network_primitives::types::NetworkInfo;
 
     fn handle(&mut self, _msg: GetInfo, _ctx: &mut Context<Self>) -> Self::Result {
         self.get_network_info()
@@ -276,12 +275,12 @@ impl MockPeerManagerAdapter {
 pub mod test_features {
     use crate::routing::routing_table_actor::{start_routing_table_actor, RoutingTableActor};
     use crate::test_utils::{convert_boot_nodes, open_port};
-    use crate::types::{NetworkClientMessages, NetworkClientResponses};
     use crate::PeerManagerActor;
     use actix::actors::mocker::Mocker;
     use actix::{Actor, Addr};
     use near_network_primitives::types::{
-        NetworkConfig, NetworkViewClientMessages, NetworkViewClientResponses,
+        NetworkClientMessages, NetworkClientResponses, NetworkConfig, NetworkViewClientMessages,
+        NetworkViewClientResponses,
     };
     use near_primitives::block::GenesisId;
     use near_primitives::network::PeerId;

--- a/chain/rosetta-rpc/Cargo.toml
+++ b/chain/rosetta-rpc/Cargo.toml
@@ -35,7 +35,7 @@ near-crypto = { path = "../../core/crypto" }
 near-chain-configs = { path = "../../core/chain-configs" }
 near-client = { path = "../client" }
 near-client-primitives = { path = "../client-primitives" }
-near-network = { path = "../network" }
+near-network-primitives = { path = "../network-primitives" }
 
 [dev-dependencies]
 insta = "1"

--- a/chain/rosetta-rpc/src/lib.rs
+++ b/chain/rosetta-rpc/src/lib.rs
@@ -739,22 +739,22 @@ async fn construction_submit(
 
     let transaction_hash = signed_transaction.as_ref().get_hash();
     let transaction_submittion = client_addr
-        .send(near_network::types::NetworkClientMessages::Transaction {
+        .send(near_network_primitives::types::NetworkClientMessages::Transaction {
             transaction: signed_transaction.into_inner(),
             is_forwarded: false,
             check_only: false,
         })
         .await?;
     match transaction_submittion {
-        near_network::types::NetworkClientResponses::ValidTx
-        | near_network::types::NetworkClientResponses::RequestRouted => {
+        near_network_primitives::types::NetworkClientResponses::ValidTx
+        | near_network_primitives::types::NetworkClientResponses::RequestRouted => {
             Ok(Json(models::TransactionIdentifierResponse {
                 transaction_identifier: models::TransactionIdentifier::transaction(
                     &transaction_hash,
                 ),
             }))
         }
-        near_network::types::NetworkClientResponses::InvalidTx(error) => {
+        near_network_primitives::types::NetworkClientResponses::InvalidTx(error) => {
             Err(errors::ErrorKind::InvalidInput(error.to_string()).into())
         }
         _ => Err(errors::ErrorKind::InternalInvariantError(format!(

--- a/genesis-tools/genesis-populate/Cargo.toml
+++ b/genesis-tools/genesis-populate/Cargo.toml
@@ -22,7 +22,6 @@ near-store = { path = "../../core/store" }
 near-chain = { path = "../../chain/chain" }
 near-client = { path = "../../chain/client" }
 near-pool = { path = "../../chain/pool" }
-near-network = { path = "../../chain/network" }
 near-jsonrpc = { path = "../../chain/jsonrpc" }
 near-telemetry = { path = "../../chain/telemetry" }
 near-epoch-manager = { path = "../../chain/epoch_manager" }

--- a/integration-tests/src/tests/client/chunks_management.rs
+++ b/integration-tests/src/tests/client/chunks_management.rs
@@ -17,8 +17,10 @@ use near_client::test_utils::setup_mock_all_validators;
 use near_client::{ClientActor, GetBlock, ViewClientActor};
 use near_logger_utils::init_test_logger;
 use near_network::types::PeerManagerMessageRequest;
-use near_network::types::{NetworkClientMessages, NetworkRequests, NetworkResponses};
-use near_network_primitives::types::{AccountIdOrPeerTrackingShard, PeerInfo};
+use near_network::types::{NetworkRequests, NetworkResponses};
+use near_network_primitives::types::{
+    AccountIdOrPeerTrackingShard, NetworkClientMessages, PeerInfo,
+};
 use near_primitives::hash::CryptoHash;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::AccountId;

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -26,11 +26,12 @@ use near_client::{Client, GetBlock, GetBlockWithMerkleTree};
 use near_crypto::{InMemorySigner, KeyType, PublicKey, Signature, Signer};
 use near_logger_utils::init_test_logger;
 use near_network::test_utils::{wait_or_panic, MockPeerManagerAdapter};
-use near_network::types::{
-    FullPeerInfo, NetworkClientMessages, NetworkClientResponses, NetworkRequests, NetworkResponses,
+use near_network::types::{NetworkRequests, NetworkResponses};
+use near_network::types::{PeerManagerMessageRequest, PeerManagerMessageResponse};
+use near_network_primitives::types::{
+    FullPeerInfo, NetworkClientMessages, NetworkClientResponses, NetworkInfo, PeerChainInfoV2,
+    PeerInfo, ReasonForBan,
 };
-use near_network::types::{NetworkInfo, PeerManagerMessageRequest, PeerManagerMessageResponse};
-use near_network_primitives::types::{PeerChainInfoV2, PeerInfo, ReasonForBan};
 use near_primitives::block::{Approval, ApprovalInner};
 use near_primitives::block_header::BlockHeader;
 use near_primitives::epoch_manager::RngSeed;

--- a/integration-tests/src/tests/nearcore/stake_nodes.rs
+++ b/integration-tests/src/tests/nearcore/stake_nodes.rs
@@ -15,7 +15,7 @@ use near_client::{ClientActor, GetBlock, Query, Status, ViewClientActor};
 use near_crypto::{InMemorySigner, KeyType};
 use near_logger_utils::init_integration_logger;
 use near_network::test_utils::{convert_boot_nodes, open_port, WaitOrTimeoutActor};
-use near_network::types::NetworkClientMessages;
+use near_network_primitives::types::NetworkClientMessages;
 use near_primitives::hash::CryptoHash;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{AccountId, BlockHeightDelta, BlockReference, NumSeats};

--- a/integration-tests/src/tests/nearcore/sync_nodes.rs
+++ b/integration-tests/src/tests/nearcore/sync_nodes.rs
@@ -14,7 +14,7 @@ use near_client::{ClientActor, GetBlock};
 use near_crypto::{InMemorySigner, KeyType};
 use near_logger_utils::init_integration_logger;
 use near_network::test_utils::{convert_boot_nodes, open_port, WaitOrTimeoutActor};
-use near_network::types::NetworkClientMessages;
+use near_network_primitives::types::NetworkClientMessages;
 use near_network_primitives::types::PeerInfo;
 use near_primitives::block::Approval;
 use near_primitives::merkle::PartialMerkleTree;

--- a/integration-tests/src/tests/network/infinite_loop.rs
+++ b/integration-tests/src/tests/network/infinite_loop.rs
@@ -12,12 +12,10 @@ use near_logger_utils::init_integration_logger;
 
 use near_network::routing::start_routing_table_actor;
 use near_network::test_utils::{convert_boot_nodes, open_port, GetInfo, WaitOrTimeoutActor};
-use near_network::types::{
-    NetworkClientResponses, NetworkRequests, PeerManagerMessageRequest, RoutingTableUpdate,
-};
+use near_network::types::{NetworkRequests, PeerManagerMessageRequest, RoutingTableUpdate};
 use near_network::PeerManagerActor;
 use near_network_primitives::types::{
-    NetworkConfig, NetworkViewClientMessages, NetworkViewClientResponses,
+    NetworkClientResponses, NetworkConfig, NetworkViewClientMessages, NetworkViewClientResponses,
 };
 use near_primitives::block::GenesisId;
 use near_primitives::network::{AnnounceAccount, PeerId};

--- a/integration-tests/src/tests/network/peer_handshake.rs
+++ b/integration-tests/src/tests/network/peer_handshake.rs
@@ -18,8 +18,8 @@ use near_network::routing::start_routing_table_actor;
 use near_network::test_utils::{
     convert_boot_nodes, open_port, GetInfo, StopSignal, WaitOrTimeoutActor,
 };
-use near_network::types::NetworkClientResponses;
 use near_network::PeerManagerActor;
+use near_network_primitives::types::NetworkClientResponses;
 use near_network_primitives::types::{
     NetworkConfig, NetworkViewClientMessages, NetworkViewClientResponses,
 };

--- a/integration-tests/src/tests/network/stress_network.rs
+++ b/integration-tests/src/tests/network/stress_network.rs
@@ -15,8 +15,8 @@ use near_network::routing::start_routing_table_actor;
 use near_network::test_utils::{
     convert_boot_nodes, open_port, GetInfo, StopSignal, WaitOrTimeoutActor,
 };
-use near_network::types::NetworkClientResponses;
 use near_network::PeerManagerActor;
+use near_network_primitives::types::NetworkClientResponses;
 use near_network_primitives::types::{
     NetworkConfig, NetworkViewClientMessages, NetworkViewClientResponses,
 };


### PR DESCRIPTION
Currently `rosetta-rpc` depends on `near-network`, because it needs access to `NetworkClientMessages` and `NetworkClientResponses`.

We can move those two types to `near-network-primitives` from `near-network`. This will allow us to remove dependency on `near-network`.

There are a lot of simplifications that can be done like this. However, let's do then one step at a time.