### PR TITLE
re: Refactor `near-network::private_actix` 

### DIFF
--- a/chain/network/src/private_actix.rs
+++ b/chain/network/src/private_actix.rs
@@ -18,7 +18,8 @@ use std::sync::{Arc, Mutex};
 /// Actor message which asks `PeerManagerActor` to register peer.
 /// Returns `RegisterPeerResult` with `Accepted` if connection should be kept
 /// or a reject response otherwise.
-#[derive(Clone, Debug)]
+#[derive(Message, Clone, Debug)]
+#[rtype(result = "RegisterPeerResponse")]
 pub struct RegisterPeer {
     pub(crate) actor: Addr<PeerActor>,
     pub(crate) peer_info: PeerInfo,
@@ -49,10 +50,6 @@ impl deepsize::DeepSizeOf for RegisterPeer {
     }
 }
 
-impl Message for RegisterPeer {
-    type Result = RegisterPeerResponse;
-}
-
 #[derive(actix::MessageResponse, Debug)]
 pub enum RegisterPeerResponse {
     Accept(Option<PartialEdgeInfo>),
@@ -72,14 +69,11 @@ pub struct Unregister {
 
 /// Requesting peers from peer manager to communicate to a peer.
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
-#[derive(Clone, Debug)]
+#[derive(Message, Clone, Debug)]
+#[rtype(result = "PeerRequestResult")]
 pub struct PeersRequest {}
 
-impl Message for PeersRequest {
-    type Result = PeerRequestResult;
-}
-
-#[derive(Debug, actix::MessageResponse)]
+#[derive(actix::MessageResponse, Debug)]
 pub struct PeerRequestResult {
     pub peers: Vec<PeerInfo>,
 }
@@ -122,14 +116,10 @@ pub struct GetPeerIdResult {
     pub(crate) peer_id: PeerId,
 }
 
-impl Debug for ValidateEdgeList {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.debug_struct("source_peer_id").finish()
-    }
-}
-
 /// List of `Edges`, which we received from `source_peer_id` gor purpose of validation.
 /// Those are list of edges received through `NetworkRequests::Sync` or `NetworkRequests::IbfMessage`.
+#[derive(Message)]
+#[rtype(result = "bool")]
 pub struct ValidateEdgeList {
     /// The list of edges is provided by `source_peer_id`, that peer will be banned
     ///if any of these edges are invalid.
@@ -150,8 +140,10 @@ pub struct ValidateEdgeList {
     pub(crate) adv_disable_edge_signature_verification: bool,
 }
 
-impl Message for ValidateEdgeList {
-    type Result = bool;
+impl Debug for ValidateEdgeList {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("source_peer_id").finish()
+    }
 }
 
 #[derive(actix::MessageResponse, Debug)]


### PR DESCRIPTION
`Actix` uses messages for communication between actors. All messages need to implement `Message` or `MessageResponse` traits to be used in actix.

We can make code cleaner, by deriving those traits, instead of implementing them directly. We can start by fixing `near-network::private_actix` 

See https://github.com/near/nearcore/issues/6075