### PR TITLE
re: Fix Clion false error in `near_network.rs`

### DIFF
--- a/chain/network/src/network_protocol.rs
+++ b/chain/network/src/network_protocol.rs
@@ -98,7 +98,7 @@ impl BorshDeserialize for Handshake {
 
         if PEER_MIN_ALLOWED_PROTOCOL_VERSION <= version && version <= PROTOCOL_VERSION {
             // If we support this version, then try to deserialize with custom deserializer
-            HandshakeAutoDes::deserialize(buf).map(Into::into)
+            <HandshakeAutoDes as BorshDeserialize>::deserialize(buf).map(Into::into)
         } else {
             Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,


### PR DESCRIPTION
Clion Rust plugin for Intellij gives a false error. Let's fix it. Maybe we should inform the rust clion plugin team?

```
mismatches types [E308]
expected `&HandshakeAutoDes`, for `&mut &[u8]`.
```

This issue is not too important to fix. I reported the issue to `intelij-rust`, and this PR can be helpful in fixing the issue in the plugin.