### PR TITLE
re: `near-network` elide casts to `usize`

### DIFF
--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -478,7 +478,7 @@ impl From<near_chain_primitives::Error> for GetGasPriceError {
 pub struct NetworkInfoResponse {
     pub connected_peers: Vec<PeerInfo>,
     pub num_connected_peers: usize,
-    pub peer_max_count: u32,
+    pub peer_max_count: usize,
     pub sent_bytes_per_sec: u64,
     pub received_bytes_per_sec: u64,
     /// Accounts of known block and chunk producers from routing table.

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -584,7 +584,7 @@ pub fn setup_mock_all_validators(
                         let info = NetworkInfo {
                             connected_peers: peers,
                             num_connected_peers: key_pairs1.len(),
-                            peer_max_count: key_pairs1.len() as u32,
+                            peer_max_count: key_pairs1.len(),
                             highest_height_peers: peers2,
                             sent_bytes_per_sec: 0,
                             received_bytes_per_sec: 0,

--- a/chain/jsonrpc-primitives/src/types/network_info.rs
+++ b/chain/jsonrpc-primitives/src/types/network_info.rs
@@ -22,7 +22,7 @@ pub struct RpcKnownProducer {
 pub struct RpcNetworkInfoResponse {
     pub active_peers: Vec<RpcPeerInfo>,
     pub num_active_peers: usize,
-    pub peer_max_count: u32,
+    pub peer_max_count: usize,
     pub sent_bytes_per_sec: u64,
     pub received_bytes_per_sec: u64,
     /// Accounts of known block and chunk producers from routing table.

--- a/chain/network-primitives/src/config.rs
+++ b/chain/network-primitives/src/config.rs
@@ -18,27 +18,27 @@ pub struct NetworkConfig {
     pub reconnect_delay: Duration,
     pub bootstrap_peers_period: Duration,
     /// Maximum number of active peers. Hard limit.
-    pub max_num_peers: u32,
+    pub max_num_peers: usize,
     /// Minimum outbound connections a peer should have to avoid eclipse attacks.
-    pub minimum_outbound_peers: u32,
+    pub minimum_outbound_peers: usize,
     /// Lower bound of the ideal number of connections.
-    pub ideal_connections_lo: u32,
+    pub ideal_connections_lo: usize,
     /// Upper bound of the ideal number of connections.
-    pub ideal_connections_hi: u32,
+    pub ideal_connections_hi: usize,
     /// Peers which last message is was within this period of time are considered active recent peers.
     pub peer_recent_time_window: Duration,
     /// Number of peers to keep while removing a connection.
     /// Used to avoid disconnecting from peers we have been connected since long time.
-    pub safe_set_size: u32,
+    pub safe_set_size: usize,
     /// Lower bound of the number of connections to archival peers to keep
     /// if we are an archival node.
-    pub archival_peer_connections_lower_bound: u32,
+    pub archival_peer_connections_lower_bound: usize,
     /// Duration of the ban for misbehaving peers.
     pub ban_window: Duration,
     /// Remove expired peers.
     pub peer_expiration_duration: Duration,
     /// Maximum number of peer addresses we should ever send on PeersRequest.
-    pub max_send_peers: u32,
+    pub max_send_peers: usize,
     /// Duration for checking on stats from the peers.
     pub peer_stats_period: Duration,
     /// Time to persist Accounts Id in the router without removing them.

--- a/chain/network/src/test_utils.rs
+++ b/chain/network/src/test_utils.rs
@@ -329,7 +329,7 @@ pub mod test_features {
         store: Arc<Store>,
         mut config: NetworkConfig,
         boot_nodes: Vec<(&str, u16)>,
-        peer_max_count: u32,
+        peer_max_count: usize,
         routing_table_addr: Addr<RoutingTableActor>,
     ) -> (PeerManagerActor, PeerId, Arc<AtomicUsize>) {
         config.boot_nodes = convert_boot_nodes(boot_nodes);
@@ -430,7 +430,7 @@ pub struct SetAdvOptions {
     pub disable_edge_signature_verification: Option<bool>,
     pub disable_edge_propagation: Option<bool>,
     pub disable_edge_pruning: Option<bool>,
-    pub set_max_peers: Option<u64>,
+    pub set_max_peers: Option<usize>,
 }
 
 #[cfg(feature = "test_features")]

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -337,7 +337,7 @@ pub struct FullPeerInfo {
 pub struct NetworkInfo {
     pub connected_peers: Vec<FullPeerInfo>,
     pub num_connected_peers: usize,
-    pub peer_max_count: u32,
+    pub peer_max_count: usize,
     pub highest_height_peers: Vec<FullPeerInfo>,
     pub sent_bytes_per_sec: u64,
     pub received_bytes_per_sec: u64,

--- a/integration-tests/src/tests/network/full_network.rs
+++ b/integration-tests/src/tests/network/full_network.rs
@@ -9,9 +9,9 @@ use std::cmp::min;
 /// active peers and start new node. Wait until new node is connected.
 pub fn connect_at_max_capacity(
     num_node: usize,
-    ideal_lo: u32,
-    ideal_hi: u32,
-    max_num_peers: u32,
+    ideal_lo: usize,
+    ideal_hi: usize,
+    max_num_peers: usize,
     expected_connections: usize,
     extra_nodes: usize,
 ) {

--- a/integration-tests/src/tests/network/infinite_loop.rs
+++ b/integration-tests/src/tests/network/infinite_loop.rs
@@ -29,7 +29,7 @@ pub fn make_peer_manager(
     seed: &str,
     port: u16,
     boot_nodes: Vec<(&str, u16)>,
-    peer_max_count: u32,
+    peer_max_count: usize,
 ) -> (PeerManagerActor, PeerId, Arc<AtomicUsize>) {
     let store = create_test_store();
     let mut config = NetworkConfig::from_seed(seed, port);

--- a/integration-tests/src/tests/network/peer_handshake.rs
+++ b/integration-tests/src/tests/network/peer_handshake.rs
@@ -36,7 +36,7 @@ fn make_peer_manager(
     seed: &str,
     port: u16,
     boot_nodes: Vec<(&str, u16)>,
-    peer_max_count: u32,
+    peer_max_count: usize,
 ) -> PeerManagerActor {
     let store = create_test_store();
     let mut config = NetworkConfig::from_seed(seed, port);

--- a/integration-tests/src/tests/network/runner.rs
+++ b/integration-tests/src/tests/network/runner.rs
@@ -131,7 +131,7 @@ pub enum Action {
     #[cfg(feature = "test_features")]
     SetOptions {
         target: usize,
-        max_num_peers: Option<u64>,
+        max_num_peers: Option<usize>,
     },
 }
 
@@ -452,15 +452,15 @@ impl StateMachine {
 }
 
 struct TestConfig {
-    max_num_peers: u32,
+    max_num_peers: usize,
     routed_message_ttl: u8,
     boot_nodes: Vec<usize>,
     blacklist: HashSet<Option<usize>>,
     outbound_disabled: bool,
     ban_window: Duration,
-    ideal_connections: Option<(u32, u32)>,
-    minimum_outbound_peers: Option<u32>,
-    safe_set_size: Option<u32>,
+    ideal_connections: Option<(usize, usize)>,
+    minimum_outbound_peers: Option<usize>,
+    safe_set_size: Option<usize>,
     archive: bool,
 }
 
@@ -541,8 +541,8 @@ impl Runner {
 
     pub fn ideal_connections(
         mut self,
-        ideal_connections_lo: u32,
-        ideal_connections_hi: u32,
+        ideal_connections_lo: usize,
+        ideal_connections_hi: usize,
     ) -> Self {
         self.apply_all(move |test_config| {
             test_config.ideal_connections = Some((ideal_connections_lo, ideal_connections_hi));
@@ -550,21 +550,21 @@ impl Runner {
         self
     }
 
-    pub fn minimum_outbound_peers(mut self, minimum_outbound_peers: u32) -> Self {
+    pub fn minimum_outbound_peers(mut self, minimum_outbound_peers: usize) -> Self {
         self.apply_all(move |test_config| {
             test_config.minimum_outbound_peers = Some(minimum_outbound_peers);
         });
         self
     }
 
-    pub fn safe_set_size(mut self, safe_set_size: u32) -> Self {
+    pub fn safe_set_size(mut self, safe_set_size: usize) -> Self {
         self.apply_all(move |test_config| {
             test_config.safe_set_size = Some(safe_set_size);
         });
         self
     }
 
-    pub fn max_num_peers(mut self, max_num_peers: u32) -> Self {
+    pub fn max_num_peers(mut self, max_num_peers: usize) -> Self {
         self.apply_all(move |test_config| {
             test_config.max_num_peers = max_num_peers;
         });

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -154,19 +154,19 @@ pub const MAX_INFLATION_RATE: Rational = Rational::new_raw(1, 20);
 pub const PROTOCOL_UPGRADE_STAKE_THRESHOLD: Rational = Rational::new_raw(4, 5);
 
 /// Maximum number of active peers. Hard limit.
-fn default_max_num_peers() -> u32 {
+fn default_max_num_peers() -> usize {
     40
 }
 /// Minimum outbound connections a peer should have to avoid eclipse attacks.
-fn default_minimum_outbound_connections() -> u32 {
+fn default_minimum_outbound_connections() -> usize {
     5
 }
 /// Lower bound of the ideal number of connections.
-fn default_ideal_connections_lo() -> u32 {
+fn default_ideal_connections_lo() -> usize {
     30
 }
 /// Upper bound of the ideal number of connections.
-fn default_ideal_connections_hi() -> u32 {
+fn default_ideal_connections_hi() -> usize {
     35
 }
 /// Peers which last message is was within this period of time are considered active recent peers.
@@ -175,12 +175,12 @@ fn default_peer_recent_time_window() -> Duration {
 }
 /// Number of peers to keep while removing a connection.
 /// Used to avoid disconnecting from peers we have been connected since long time.
-fn default_safe_set_size() -> u32 {
+fn default_safe_set_size() -> usize {
     20
 }
 /// Lower bound of the number of connections to archival peers to keep
 /// if we are an archival node.
-fn default_archival_peer_connections_lower_bound() -> u32 {
+fn default_archival_peer_connections_lower_bound() -> usize {
     10
 }
 /// Time to persist Accounts Id in the router without removing them in seconds.
@@ -203,27 +203,27 @@ pub struct Network {
     pub boot_nodes: String,
     /// Maximum number of active peers. Hard limit.
     #[serde(default = "default_max_num_peers")]
-    pub max_num_peers: u32,
+    pub max_num_peers: usize,
     /// Minimum outbound connections a peer should have to avoid eclipse attacks.
     #[serde(default = "default_minimum_outbound_connections")]
-    pub minimum_outbound_peers: u32,
+    pub minimum_outbound_peers: usize,
     /// Lower bound of the ideal number of connections.
     #[serde(default = "default_ideal_connections_lo")]
-    pub ideal_connections_lo: u32,
+    pub ideal_connections_lo: usize,
     /// Upper bound of the ideal number of connections.
     #[serde(default = "default_ideal_connections_hi")]
-    pub ideal_connections_hi: u32,
+    pub ideal_connections_hi: usize,
     /// Peers which last message is was within this period of time are considered active recent peers (in seconds).
     #[serde(default = "default_peer_recent_time_window")]
     pub peer_recent_time_window: Duration,
     /// Number of peers to keep while removing a connection.
     /// Used to avoid disconnecting from peers we have been connected since long time.
     #[serde(default = "default_safe_set_size")]
-    pub safe_set_size: u32,
+    pub safe_set_size: usize,
     /// Lower bound of the number of connections to archival peers to keep
     /// if we are an archival node.
     #[serde(default = "default_archival_peer_connections_lower_bound")]
-    pub archival_peer_connections_lower_bound: u32,
+    pub archival_peer_connections_lower_bound: usize,
     /// Handshake timeout.
     pub handshake_timeout: Duration,
     /// Duration before trying to reconnect to a peer.


### PR DESCRIPTION
There are a few places in `near-network`, where we have to cast types to `usize`. We can simplify the code by keeping certain types as `usize`.