### PR TITLE
re: `near-network` Change `Ordering` to `Relaxed`

### DIFF
--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -556,7 +556,7 @@ impl PeerActor {
     /// If so, drop the transaction.
     fn should_we_drop_msg_without_decoding(&self, msg: &[u8]) -> bool {
         if utils::is_forward_transaction(msg).unwrap_or(false) {
-            let r = self.txns_since_last_block.load(Ordering::Acquire);
+            let r = self.txns_since_last_block.load(Ordering::Relaxed);
             if r > MAX_TRANSACTIONS_PER_BLOCK_MESSAGE {
                 return true;
             }
@@ -617,7 +617,7 @@ impl Actor for PeerActor {
     }
 
     fn stopping(&mut self, _: &mut Self::Context) -> Running {
-        self.peer_counter.fetch_sub(1, Ordering::SeqCst);
+        self.peer_counter.fetch_sub(1, Ordering::Relaxed);
         metrics::PEER_CONNECTIONS_TOTAL.dec();
         debug!(target: "network", "{:?}: Peer {} disconnected. {:?}", self.my_node_info.id, self.peer_info, self.peer_status);
         if let Some(peer_info) = self.peer_info.as_ref() {
@@ -693,9 +693,9 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for PeerActor {
             body: RoutedMessageBody::ForwardTx(_), ..
         }) = &peer_msg
         {
-            self.txns_since_last_block.fetch_add(1, Ordering::AcqRel);
+            self.txns_since_last_block.fetch_add(1, Ordering::Relaxed);
         } else if let PeerMessage::Block(_) = &peer_msg {
-            self.txns_since_last_block.store(0, Ordering::Release);
+            self.txns_since_last_block.store(0, Ordering::Relaxed);
         }
 
         trace!(target: "network", "Received message: {}", peer_msg);

--- a/chain/network/src/test_utils.rs
+++ b/chain/network/src/test_utils.rs
@@ -346,7 +346,7 @@ pub mod test_features {
             match msg {
                 NetworkViewClientMessages::AnnounceAccount(accounts) => {
                     if !accounts.is_empty() {
-                        counter1.fetch_add(1, Ordering::SeqCst);
+                        counter1.fetch_add(1, Ordering::Relaxed);
                     }
                     Box::new(Some(NetworkViewClientResponses::AnnounceAccount(
                         accounts.clone().into_iter().map(|obj| obj.0).collect(),


### PR DESCRIPTION
`near-network` is not using any advanced synchronizations techniques. Therefore, we should use `Ordering::Relaxed` by default. This will improve code readability.