### PR TITLE
re: chore: Fix unused `msg` paramater warnings in `near-network`

### DIFF
--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -691,7 +691,7 @@ impl Handler<GetNetworkInfo> for ClientActor {
     type Result = Result<NetworkInfoResponse, String>;
 
     #[perf]
-    fn handle(&mut self, msg: GetNetworkInfo, ctx: &mut Context<Self>) -> Self::Result {
+    fn handle(&mut self, _msg: GetNetworkInfo, ctx: &mut Context<Self>) -> Self::Result {
         #[cfg(feature = "delay_detector")]
         let _d = DelayDetector::new("client get network info".into());
         self.check_triggers(ctx);

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -1041,7 +1041,7 @@ impl Handler<QueryPeerStats> for PeerActor {
     type Result = PeerStatsResult;
 
     #[perf]
-    fn handle(&mut self, msg: QueryPeerStats, _: &mut Self::Context) -> Self::Result {
+    fn handle(&mut self, _msg: QueryPeerStats, _: &mut Self::Context) -> Self::Result {
         #[cfg(feature = "delay_detector")]
         let _d = delay_detector::DelayDetector::new("query peer stats".into());
         PeerStatsResult {

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -1996,7 +1996,7 @@ impl PeerManagerActor {
     #[perf]
     fn handle_msg_get_peer_id(
         &mut self,
-        msg: crate::private_actix::GetPeerId,
+        _msg: crate::private_actix::GetPeerId,
     ) -> crate::private_actix::GetPeerIdResult {
         crate::private_actix::GetPeerIdResult { peer_id: self.my_peer_id.clone() }
     }
@@ -2163,7 +2163,7 @@ impl PeerManagerActor {
     }
 
     #[perf]
-    fn handle_msg_peers_request(&mut self, msg: PeersRequest) -> PeerRequestResult {
+    fn handle_msg_peers_request(&mut self, _msg: PeersRequest) -> PeerRequestResult {
         #[cfg(feature = "delay_detector")]
         let _d = delay_detector::DelayDetector::new("peers request".into());
         PeerRequestResult {

--- a/utils/near-performance-metrics-macros/src/lib.rs
+++ b/utils/near-performance-metrics-macros/src/lib.rs
@@ -92,7 +92,7 @@ fn perf_internal(_attr: TokenStream, item: TokenStream, debug: bool) -> TokenStr
         } else {
             quote! (
                 {
-                    near_performance_metrics::stats::measure_performance(std::any::type_name::<Self>(), msg, move |msg| {
+                    near_performance_metrics::stats::measure_performance(std::any::type_name::<Self>(), (), move |_| {
                         #function_body
                     })
                 }


### PR DESCRIPTION
By making improvements to `near-performance-metrics-macros`, we can change the logic of `perf` derive not to use `msg` argument.
This will allow us to use `perf` for any function, even ones that don't contain `msg` argument.
Also, we will be able to fix warnings about unused `msg` agument.