### PR TITLE
feat: Optimize `find_route_from_peer_id` in `near-network`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2103,9 +2103,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
@@ -2844,6 +2844,7 @@ dependencies = [
  "deepsize",
  "delay-detector",
  "futures",
+ "itertools",
  "lru",
  "near-crypto",
  "near-metrics",

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -15,15 +15,16 @@ bytesize = "1.1"
 conqueue = "0.4.0"
 deepsize = { version = "0.2.0", optional = true }
 futures = "0.3"
+itertools = "0.10.3"
 lru = "0.6.5"
 near-rust-allocator-proxy = { version = "0.3.0", optional = true }
 once_cell = "1.5.2"
 rand = "0.7"
 serde = { version = "1", features = ["alloc", "derive", "rc"], optional = true }
 strum = { version = "0.20", features = ["derive"] }
-tokio = { version = "1.1", features = ["net", "rt-multi-thread"] }
 tokio-stream = { version = "0.1.2", features = ["net"] }
 tokio-util = { version = "0.6", features = ["codec"] }
+tokio = { version = "1.1", features = ["net", "rt-multi-thread"] }
 tracing = "0.1.13"
 
 delay-detector = { path = "../../tools/delay_detector", optional = true }

--- a/chain/network/src/routing/routing_table_view.rs
+++ b/chain/network/src/routing/routing_table_view.rs
@@ -103,11 +103,10 @@ impl RoutingTableView {
                     // max nonce - threshold.
                     self.route_nonce.put(
                         next_hop.clone(),
-                        // TODO, should be max(min_v + 1, max_v.saturating_sub(ROUND_ROBIN_MAX_NONCE_DIFFERENCE_ALLOWED))
                         std::cmp::max(
-                            min_v,
+                            min_v + 1,
                             max_v.saturating_sub(ROUND_ROBIN_MAX_NONCE_DIFFERENCE_ALLOWED),
-                        ) + 1,
+                        ),
                     );
 
                     Ok(next_hop.clone())

--- a/chain/network/src/routing/routing_table_view.rs
+++ b/chain/network/src/routing/routing_table_view.rs
@@ -1,4 +1,5 @@
 use crate::routing::route_back_cache::RouteBackCache;
+use itertools::Itertools;
 use lru::LruCache;
 use near_network_primitives::types::{Edge, PeerIdOrHash, Ping, Pong};
 use near_primitives::hash::CryptoHash;
@@ -85,31 +86,33 @@ impl RoutingTableView {
     /// Find peer that is connected to `source` and belong to the shortest path
     /// from `source` to `peer_id`.
     pub fn find_route_from_peer_id(&mut self, peer_id: &PeerId) -> Result<PeerId, FindRouteError> {
-        if let Some(routes) = self.peer_forwarding.get(peer_id).cloned() {
-            if routes.is_empty() {
-                return Err(FindRouteError::Disconnected);
+        if let Some(routes) = self.peer_forwarding.get(peer_id) {
+            match (routes.iter())
+                .map(|peer_id| {
+                    (self.route_nonce.get(peer_id).cloned().unwrap_or_default(), peer_id)
+                })
+                .minmax()
+                .into_option()
+            {
+                None => Err(FindRouteError::Disconnected),
+                // Neighbor with minimum and maximum nonce respectively.
+                Some(((min_v, next_hop), (max_v, _))) => {
+                    // Strategy similar to Round Robin. Select node with least nonce and send it. Increase its
+                    // nonce by one. Additionally if the difference between the highest nonce and the lowest
+                    // nonce is greater than some threshold increase the lowest nonce to be at least
+                    // max nonce - threshold.
+                    self.route_nonce.put(
+                        next_hop.clone(),
+                        // TODO, should be max(min_v + 1, max_v.saturating_sub(ROUND_ROBIN_MAX_NONCE_DIFFERENCE_ALLOWED))
+                        std::cmp::max(
+                            min_v,
+                            max_v.saturating_sub(ROUND_ROBIN_MAX_NONCE_DIFFERENCE_ALLOWED),
+                        ) + 1,
+                    );
+
+                    Ok(next_hop.clone())
+                }
             }
-
-            // Strategy similar to Round Robin. Select node with least nonce and send it. Increase its
-            // nonce by one. Additionally if the difference between the highest nonce and the lowest
-            // nonce is greater than some threshold increase the lowest nonce to be at least
-            // max nonce - threshold.
-            let nonce_peer = routes
-                .iter()
-                .map(|peer_id| (self.route_nonce.get(peer_id).cloned().unwrap_or(0), peer_id))
-                .collect::<Vec<_>>();
-
-            // Neighbor with minimum and maximum nonce respectively.
-            let (mut min_v, next_hop) = nonce_peer.iter().min().cloned().unwrap();
-            let (max_v, _) = nonce_peer.into_iter().max().unwrap();
-
-            min_v = std::cmp::max(
-                min_v,
-                max_v.saturating_sub(ROUND_ROBIN_MAX_NONCE_DIFFERENCE_ALLOWED),
-            );
-            self.route_nonce.put(next_hop.clone(), min_v + 1);
-
-            Ok(next_hop.clone())
         } else {
             Err(FindRouteError::PeerNotFound)
         }


### PR DESCRIPTION
`find_route_from_peer_id` can be written without doing extra `clone`, memory allocations `Vec` nor `unwraps`.