### PR TITLE
re: chore: Refactor code in `PeerManager` related to removing local edges

### DIFF
--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -347,7 +347,7 @@ impl PeerManagerActor {
                     peer_forwarding,
                     peers_to_ban,
                 }) => {
-                    act.routing_table_view.remove_local_edges(&local_edges_to_remove);
+                    act.routing_table_view.remove_local_edges(local_edges_to_remove.iter());
                     act.routing_table_view.peer_forwarding = peer_forwarding;
                     for peer in peers_to_ban {
                         act.ban_peer(ctx, &peer, ReasonForBan::InvalidEdge);
@@ -1029,7 +1029,8 @@ impl PeerManagerActor {
                 )
             })
             .collect();
-        self.routing_table_view.remove_local_edges(&edges);
+        self.routing_table_view
+            .remove_local_edges(edges.iter().filter_map(|e| e.other(&self.my_peer_id)));
         self.routing_table_addr
             .send(RoutingTableMessages::AdvRemoveEdges(edges))
             .into_actor(self)

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -307,7 +307,7 @@ impl PeerManagerActor {
         debug!(target: "network", blacklist = ?config.blacklist, "Blacklist");
 
         let my_peer_id: PeerId = PeerId::new(config.public_key.clone());
-        let routing_table = RoutingTableView::new(my_peer_id.clone(), store);
+        let routing_table = RoutingTableView::new(store);
 
         let txns_since_last_block = Arc::new(AtomicUsize::new(0));
 

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -520,7 +520,7 @@ pub enum RoutingTableMessagesResponse {
     RoutingTableUpdateResponse {
         /// PeerManager maintains list of local edges. We will notify `PeerManager`
         /// to remove those edges.
-        local_edges_to_remove: Vec<Edge>,
+        local_edges_to_remove: Vec<PeerId>,
         /// Active PeerId that are part of the shortest path to each PeerId.
         peer_forwarding: Arc<HashMap<PeerId, Vec<PeerId>>>,
         /// List of peers to ban for sending invalid edges.
@@ -577,19 +577,19 @@ impl Handler<RoutingTableMessages> for RoutingTableActor {
                     prune = Prune::Disable;
                 }
 
-                let mut edges_removed =
-                    if self.needs_routing_table_recalculation || prune == Prune::Now {
-                        self.needs_routing_table_recalculation = false;
-                        self.recalculate_routing_table();
-                        self.prune_edges(prune, prune_edges_not_reachable_for)
-                    } else {
-                        Vec::new()
-                    };
-                // Only keep local edges
-                edges_removed.retain(|p| p.contains_peer(self.my_peer_id()));
-
+                let edges_removed = if self.needs_routing_table_recalculation || prune == Prune::Now
+                {
+                    self.needs_routing_table_recalculation = false;
+                    self.recalculate_routing_table();
+                    self.prune_edges(prune, prune_edges_not_reachable_for)
+                } else {
+                    Vec::new()
+                };
                 RoutingTableMessagesResponse::RoutingTableUpdateResponse {
-                    local_edges_to_remove: edges_removed,
+                    local_edges_to_remove: (edges_removed.iter())
+                        .filter_map(|e| e.other(self.my_peer_id()))
+                        .cloned()
+                        .collect(),
                     peer_forwarding: self.peer_forwarding.clone(),
                     peers_to_ban: std::mem::take(&mut self.peers_to_ban),
                 }

--- a/chain/network/src/routing/routing_table_view.rs
+++ b/chain/network/src/routing/routing_table_view.rs
@@ -154,8 +154,8 @@ impl RoutingTableView {
         })
     }
 
-    pub fn remove_local_edges(&mut self, peers: &[PeerId]) {
-        for other_peer in peers.iter() {
+    pub fn remove_local_edges<'a>(&mut self, peers: impl Iterator<Item = &'a PeerId>) {
+        for other_peer in peers {
             self.local_edges_info.remove(other_peer);
         }
     }

--- a/chain/network/src/routing/routing_table_view.rs
+++ b/chain/network/src/routing/routing_table_view.rs
@@ -22,8 +22,6 @@ pub const SAVE_PEERS_MAX_TIME: Duration = Duration::from_secs(7_200);
 pub const DELETE_PEERS_AFTER_TIME: Duration = Duration::from_secs(3_600);
 
 pub struct RoutingTableView {
-    /// PeerId associated with this instance.
-    my_peer_id: PeerId,
     /// PeerId associated for every known account id.
     account_peers: LruCache<AccountId, AnnounceAccount>,
     /// Active PeerId that are part of the shortest path to each PeerId.
@@ -57,11 +55,10 @@ pub enum FindRouteError {
 }
 
 impl RoutingTableView {
-    pub fn new(my_peer_id: PeerId, store: Arc<Store>) -> Self {
+    pub fn new(store: Arc<Store>) -> Self {
         // Find greater nonce on disk and set `component_nonce` to this value.
 
         Self {
-            my_peer_id,
             account_peers: LruCache::new(ANNOUNCE_ACCOUNT_CACHE_SIZE),
             peer_forwarding: Default::default(),
             local_edges_info: Default::default(),
@@ -157,13 +154,9 @@ impl RoutingTableView {
         })
     }
 
-    pub fn remove_local_edges(&mut self, edges: &[Edge]) {
-        for edge in edges.iter() {
-            if let Some(other_peer) = edge.other(&self.my_peer_id) {
-                self.local_edges_info.remove(other_peer);
-            } else {
-                panic!("We tried to remove non-local edge");
-            }
+    pub fn remove_local_edges(&mut self, peers: &[PeerId]) {
+        for other_peer in peers.iter() {
+            self.local_edges_info.remove(other_peer);
         }
     }
 

--- a/chain/network/src/tests/cache.rs
+++ b/chain/network/src/tests/cache.rs
@@ -12,7 +12,7 @@ fn announcement_same_epoch() {
     let peer_id1 = random_peer_id();
     let epoch_id0 = random_epoch_id();
 
-    let mut routing_table = RoutingTableView::new(peer_id0.clone(), store);
+    let mut routing_table = RoutingTableView::new(store);
 
     let announce0 = AnnounceAccount {
         account_id: "near0".parse().unwrap(),
@@ -48,7 +48,7 @@ fn dont_load_on_build() {
     let epoch_id0 = random_epoch_id();
     let epoch_id1 = random_epoch_id();
 
-    let mut routing_table = RoutingTableView::new(peer_id0.clone(), store.clone());
+    let mut routing_table = RoutingTableView::new(store.clone());
 
     let announce0 = AnnounceAccount {
         account_id: "near0".parse().unwrap(),
@@ -71,7 +71,7 @@ fn dont_load_on_build() {
     assert!(vec![announce0, announce1].iter().all(|announce| { accounts.contains(announce) }));
     assert_eq!(routing_table.get_announce_accounts().len(), 2);
 
-    let mut routing_table1 = RoutingTableView::new(peer_id0, store);
+    let mut routing_table1 = RoutingTableView::new(store);
     assert!(routing_table1.get_announce_accounts().is_empty());
 }
 
@@ -82,8 +82,8 @@ fn load_from_disk() {
     let peer_id0 = random_peer_id();
     let epoch_id0 = random_epoch_id();
 
-    let mut routing_table = RoutingTableView::new(peer_id0.clone(), store.clone());
-    let mut routing_table1 = RoutingTableView::new(peer_id0.clone(), store);
+    let mut routing_table = RoutingTableView::new(store.clone());
+    let mut routing_table1 = RoutingTableView::new(store);
 
     let announce0 = AnnounceAccount {
         account_id: "near0".parse().unwrap(),


### PR DESCRIPTION
Code related to removing local edges can be written in a much simpler way. There is no need to pass list of edges. 