### PR TITLE
re: chore: Refactor `PeerManagerActor` before big changes

### DIFF
--- a/chain/network/src/test_utils.rs
+++ b/chain/network/src/test_utils.rs
@@ -232,9 +232,9 @@ impl BanPeerSignal {
 impl Handler<BanPeerSignal> for PeerManagerActor {
     type Result = ();
 
-    fn handle(&mut self, msg: BanPeerSignal, ctx: &mut Self::Context) -> Self::Result {
+    fn handle(&mut self, msg: BanPeerSignal, _ctx: &mut Self::Context) -> Self::Result {
         debug!(target: "network", "Ban peer: {:?}", msg.peer_id);
-        self.try_ban_peer(ctx, &msg.peer_id, msg.ban_reason);
+        self.try_ban_peer(&msg.peer_id, msg.ban_reason);
     }
 }
 


### PR DESCRIPTION
`broadcast_validated_edges_trigger` in `PeerManagerActor` should be rewritten in such a way, that the amount of work done my `PeerManagerActor` is constant.

The plan is to move the work inside `routing_table_actor`. More PRs are needed, this is a refactor, which will make the next change easier.