### PR TITLE
re: chore: Refactor decode in `near-network::Codec`

### DIFF
--- a/chain/network/src/peer/codec.rs
+++ b/chain/network/src/peer/codec.rs
@@ -15,8 +15,8 @@ use tokio_util::codec::{Decoder, Encoder};
 use tracing::error;
 
 /// Maximum size of network message in encoded format.
-/// The size of message is stored as `u32`, so the limit has type `u32`
-const NETWORK_MESSAGE_MAX_SIZE_BYTES: u32 = 512 * MIB as u32;
+/// We encode length as `u32`, and therefore maximum size can't be larger than `u32::MAX`.
+const NETWORK_MESSAGE_MAX_SIZE_BYTES: usize = 512 * MIB as usize;
 /// Maximum capacity of write buffer in bytes.
 const MAX_WRITE_BUFFER_CAPACITY_BYTES: usize = GIB as usize;
 
@@ -38,7 +38,7 @@ impl Encoder<Vec<u8>> for Codec {
     type Error = Error;
 
     fn encode(&mut self, item: Vec<u8>, buf: &mut BytesMut) -> Result<(), Error> {
-        if item.len() > NETWORK_MESSAGE_MAX_SIZE_BYTES as usize {
+        if item.len() > NETWORK_MESSAGE_MAX_SIZE_BYTES {
             Err(Error::new(ErrorKind::InvalidInput, "Input is too long"))
         } else {
             #[cfg(feature = "performance_stats")]
@@ -83,23 +83,22 @@ impl Decoder for Codec {
             return Ok(None);
         }
 
-        let len = u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]);
+        let len = u32::from_le_bytes(buf[..4].try_into().unwrap()) as usize;
         if len > NETWORK_MESSAGE_MAX_SIZE_BYTES {
             // If this point is reached, abusive peer is banned.
             return Ok(Some(Err(ReasonForBan::Abusive)));
         }
 
-        if buf.len() < 4 + len as usize {
-            // not enough bytes, keep waiting
-            Ok(None)
-        } else {
-            let res = Some(Ok(buf[4..4 + len as usize].to_vec()));
-            buf.advance(4 + len as usize);
-            // Fix memory leak see (#6173)
+        if 4 + len <= buf.len() {
+            let res = Some(Ok(buf[4..4 + len].to_vec()));
+            buf.advance(4 + len);
             if buf.is_empty() && buf.capacity() > 0 {
                 *buf = BytesMut::new();
             }
             Ok(res)
+        } else {
+            // not enough bytes, keep waiting
+            Ok(None)
         }
     }
 }
@@ -210,7 +209,7 @@ mod test {
         let mut codec = Codec::default();
         let mut buffer = BytesMut::new();
         buffer.reserve(4);
-        buffer.put_u32_le(NETWORK_MESSAGE_MAX_SIZE_BYTES + 1);
+        buffer.put_u32_le(NETWORK_MESSAGE_MAX_SIZE_BYTES as u32 + 1);
         assert_eq!(codec.decode(&mut buffer).unwrap(), Some(Err(ReasonForBan::Abusive)));
     }
 
@@ -219,7 +218,7 @@ mod test {
         let mut codec = Codec::default();
         let mut buffer = BytesMut::new();
         buffer.reserve(4);
-        buffer.put_u32_le(NETWORK_MESSAGE_MAX_SIZE_BYTES);
+        buffer.put_u32_le(NETWORK_MESSAGE_MAX_SIZE_BYTES as u32);
         assert_ne!(codec.decode(&mut buffer).unwrap(), Some(Err(ReasonForBan::Abusive)));
     }
 }

--- a/chain/network/src/peer_manager/peer_store.rs
+++ b/chain/network/src/peer_manager/peer_store.rs
@@ -378,6 +378,7 @@ mod test {
     use near_crypto::{KeyType, SecretKey};
     use near_store::create_store;
     use near_store::test_utils::create_test_store;
+    use std::net::{Ipv4Addr, SocketAddrV4};
 
     use super::*;
 
@@ -385,15 +386,15 @@ mod test {
         PeerId::new(SecretKey::from_seed(KeyType::ED25519, seed.as_str()).public_key())
     }
 
-    fn get_addr(port: u8) -> SocketAddr {
-        format!("127.0.0.1:{}", port).parse().unwrap()
+    fn get_addr(port: u16) -> SocketAddr {
+        SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), port).into()
     }
 
     fn get_peer_info(peer_id: PeerId, addr: Option<SocketAddr>) -> PeerInfo {
         PeerInfo { id: peer_id, addr, account_id: None }
     }
 
-    fn gen_peer_info(port: u8) -> PeerInfo {
+    fn gen_peer_info(port: u16) -> PeerInfo {
         PeerInfo {
             id: PeerId::new(SecretKey::from_random(KeyType::ED25519).public_key()),
             addr: Some(get_addr(port)),


### PR DESCRIPTION
`near-network::Codec::decode` method can be written in a cleaner way, by reducing the number of casts to `usize`.
And also writing code which gets length in a cleaner way as:
```rust
let len = u32::from_le_bytes(buf[..4].try_into().unwrap()) as usize;
```

We also change `fn gen_peer_info(port: u16)` api from `fn gen_peer_info(port: u8)`.
Ports are represented by `u16` in operating systems, and let's use correct type for consistency.