### PR TITLE
refactor: Split VMLogic and MemoryLike

### DIFF
--- a/runtime/near-vm-logic/src/lib.rs
+++ b/runtime/near-vm-logic/src/lib.rs
@@ -15,7 +15,7 @@ mod utils;
 
 pub use context::VMContext;
 pub use dependencies::{External, MemoryLike, ValuePtr};
-pub use logic::{VMLogic, VMOutcome};
+pub use logic::{VMLogic, VMLogicPlusMemory, VMOutcome};
 pub use near_primitives_core::config::*;
 pub use near_primitives_core::profile;
 pub use near_primitives_core::types::ProtocolVersion;

--- a/runtime/near-vm-logic/src/tests/context.rs
+++ b/runtime/near-vm-logic/src/tests/context.rs
@@ -27,10 +27,10 @@ macro_rules! decl_test_bytes {
         #[test]
         fn $testname() {
             let mut logic_builder = VMLogicBuilder::default();
-            let mut logic = logic_builder.build(create_context());
+            let mut l = logic_builder.build(create_context());
             let res = vec![0u8; $input.len()];
-            logic.$method(0).expect("read bytes into register from context should be ok");
-            logic.read_register(0, res.as_ptr() as _).expect("read register should be ok");
+            l.logic.$method(l.mem, 0).expect("read bytes into register from context should be ok");
+            l.logic.read_register(l.mem, 0, res.as_ptr() as _).expect("read register should be ok");
             assert_eq!(res, $input);
         }
     };
@@ -41,8 +41,8 @@ macro_rules! decl_test_u64 {
         #[test]
         fn $testname() {
             let mut logic_builder = VMLogicBuilder::default();
-            let mut logic = logic_builder.build(create_context());
-            let res = logic.$method().expect("read from context should be ok");
+            let mut l = logic_builder.build(create_context());
+            let res = l.logic.$method(l.mem).expect("read from context should be ok");
             assert_eq!(res, $input);
         }
     };
@@ -53,10 +53,10 @@ macro_rules! decl_test_u128 {
         #[test]
         fn $testname() {
             let mut logic_builder = VMLogicBuilder::default();
-            let mut logic = logic_builder.build(create_context());
+            let mut l = logic_builder.build(create_context());
             let buf = [0u8; std::mem::size_of::<u128>()];
 
-            logic.$method(buf.as_ptr() as _).expect("read from context should be ok");
+            l.logic.$method(l.mem, buf.as_ptr() as _).expect("read from context should be ok");
             let res = u128::from_le_bytes(buf);
             assert_eq!(res, $input);
         }

--- a/runtime/near-vm-logic/src/tests/gas_counter.rs
+++ b/runtime/near-vm-logic/src/tests/gas_counter.rs
@@ -2,19 +2,19 @@ use crate::tests::fixtures::get_context;
 use crate::tests::helpers::*;
 use crate::tests::vm_logic_builder::VMLogicBuilder;
 use crate::types::Gas;
-use crate::{VMConfig, VMLogic};
+use crate::{VMConfig, VMLogicPlusMemory};
 
 #[test]
 fn test_dont_burn_gas_when_exceeding_attached_gas_limit() {
     let gas_limit = 10u64.pow(14);
 
     let mut logic_builder = VMLogicBuilder::default().max_gas_burnt(gas_limit * 2);
-    let mut logic = logic_builder.build_with_prepaid_gas(gas_limit);
+    let mut l = logic_builder.build_with_prepaid_gas(gas_limit);
 
-    let index = promise_create(&mut logic, b"rick.test", 0, 0).expect("should create a promise");
-    promise_batch_action_function_call(&mut logic, index, 0, gas_limit * 2)
+    let index = promise_create(&mut l, b"rick.test", 0, 0).expect("should create a promise");
+    promise_batch_action_function_call(&mut l, index, 0, gas_limit * 2)
         .expect_err("should fail with gas limit");
-    let outcome = logic.outcome();
+    let outcome = l.logic.outcome();
 
     // Just avoid hard-coding super-precise amount of gas burnt.
     assert!(outcome.burnt_gas < gas_limit / 2);
@@ -27,13 +27,13 @@ fn test_limit_wasm_gas_after_attaching_gas() {
     let op_limit = op_limit(gas_limit);
 
     let mut logic_builder = VMLogicBuilder::default().max_gas_burnt(gas_limit * 2);
-    let mut logic = logic_builder.build_with_prepaid_gas(gas_limit);
+    let mut l = logic_builder.build_with_prepaid_gas(gas_limit);
 
-    let index = promise_create(&mut logic, b"rick.test", 0, 0).expect("should create a promise");
-    promise_batch_action_function_call(&mut logic, index, 0, gas_limit / 2)
+    let index = promise_create(&mut l, b"rick.test", 0, 0).expect("should create a promise");
+    promise_batch_action_function_call(&mut l, index, 0, gas_limit / 2)
         .expect("should add action to receipt");
-    logic.gas((op_limit / 2) as u32).expect_err("should fail with gas limit");
-    let outcome = logic.outcome();
+    l.logic.gas(l.mem, (op_limit / 2) as u32).expect_err("should fail with gas limit");
+    let outcome = l.logic.outcome();
 
     assert_eq!(outcome.used_gas, gas_limit);
     assert!(gas_limit / 2 < outcome.burnt_gas);
@@ -46,10 +46,10 @@ fn test_cant_burn_more_than_max_gas_burnt_gas() {
     let op_limit = op_limit(gas_limit);
 
     let mut logic_builder = VMLogicBuilder::default().max_gas_burnt(gas_limit);
-    let mut logic = logic_builder.build_with_prepaid_gas(gas_limit * 2);
+    let mut l = logic_builder.build_with_prepaid_gas(gas_limit * 2);
 
-    logic.gas(op_limit * 3).expect_err("should fail with gas limit");
-    let outcome = logic.outcome();
+    l.logic.gas(l.mem, op_limit * 3).expect_err("should fail with gas limit");
+    let outcome = l.logic.outcome();
 
     assert_eq!(outcome.burnt_gas, gas_limit);
     assert_eq!(outcome.used_gas, gas_limit * 2);
@@ -61,10 +61,10 @@ fn test_cant_burn_more_than_prepaid_gas() {
     let op_limit = op_limit(gas_limit);
 
     let mut logic_builder = VMLogicBuilder::default().max_gas_burnt(gas_limit * 2);
-    let mut logic = logic_builder.build_with_prepaid_gas(gas_limit);
+    let mut l = logic_builder.build_with_prepaid_gas(gas_limit);
 
-    logic.gas(op_limit * 3).expect_err("should fail with gas limit");
-    let outcome = logic.outcome();
+    l.logic.gas(l.mem, op_limit * 3).expect_err("should fail with gas limit");
+    let outcome = l.logic.outcome();
 
     assert_eq!(outcome.burnt_gas, gas_limit);
     assert_eq!(outcome.used_gas, gas_limit);
@@ -76,11 +76,11 @@ fn test_hit_max_gas_burnt_limit() {
     let op_limit = op_limit(gas_limit);
 
     let mut logic_builder = VMLogicBuilder::default().max_gas_burnt(gas_limit);
-    let mut logic = logic_builder.build_with_prepaid_gas(gas_limit * 3);
+    let mut l = logic_builder.build_with_prepaid_gas(gas_limit * 3);
 
-    promise_create(&mut logic, b"rick.test", 0, gas_limit / 2).expect("should create a promise");
-    logic.gas(op_limit * 2).expect_err("should fail with gas limit");
-    let outcome = logic.outcome();
+    promise_create(&mut l, b"rick.test", 0, gas_limit / 2).expect("should create a promise");
+    l.logic.gas(l.mem, op_limit * 2).expect_err("should fail with gas limit");
+    let outcome = l.logic.outcome();
 
     assert_eq!(outcome.burnt_gas, gas_limit);
     assert!(outcome.used_gas > gas_limit * 2);
@@ -92,11 +92,11 @@ fn test_hit_prepaid_gas_limit() {
     let op_limit = op_limit(gas_limit);
 
     let mut logic_builder = VMLogicBuilder::default().max_gas_burnt(gas_limit * 3);
-    let mut logic = logic_builder.build_with_prepaid_gas(gas_limit);
+    let mut l = logic_builder.build_with_prepaid_gas(gas_limit);
 
-    promise_create(&mut logic, b"rick.test", 0, gas_limit / 2).expect("should create a promise");
-    logic.gas(op_limit * 2).expect_err("should fail with gas limit");
-    let outcome = logic.outcome();
+    promise_create(&mut l, b"rick.test", 0, gas_limit / 2).expect("should create a promise");
+    l.logic.gas(l.mem, op_limit * 2).expect_err("should fail with gas limit");
+    let outcome = l.logic.outcome();
 
     assert_eq!(outcome.burnt_gas, gas_limit);
     assert_eq!(outcome.used_gas, gas_limit);
@@ -108,7 +108,7 @@ impl VMLogicBuilder {
         self
     }
 
-    fn build_with_prepaid_gas(&mut self, prepaid_gas: Gas) -> VMLogic<'_> {
+    fn build_with_prepaid_gas(&mut self, prepaid_gas: Gas) -> VMLogicPlusMemory<'_> {
         let mut context = get_context(vec![], false);
         context.prepaid_gas = prepaid_gas;
         self.build(context)

--- a/runtime/near-vm-logic/src/tests/helpers.rs
+++ b/runtime/near-vm-logic/src/tests/helpers.rs
@@ -1,4 +1,4 @@
-use crate::{with_ext_cost_counter, VMLogic};
+use crate::{with_ext_cost_counter, VMLogicPlusMemory};
 use near_primitives_core::{config::ExtCosts, types::Gas};
 use near_vm_errors::VMLogicError;
 use std::collections::HashMap;
@@ -8,14 +8,15 @@ type Result<T> = ::std::result::Result<T, VMLogicError>;
 
 #[allow(dead_code)]
 pub fn promise_create(
-    logic: &mut crate::VMLogic<'_>,
+    l: &mut crate::VMLogicPlusMemory<'_>,
     account_id: &[u8],
     amount: u128,
     gas: Gas,
 ) -> Result<u64> {
     let method = b"promise_create";
     let args = b"args";
-    logic.promise_create(
+    l.logic.promise_create(
+        l.mem,
         account_id.len() as _,
         account_id.as_ptr() as _,
         method.len() as _,
@@ -29,7 +30,7 @@ pub fn promise_create(
 
 #[allow(dead_code)]
 pub fn promise_batch_action_function_call(
-    logic: &mut VMLogic<'_>,
+    l: &mut VMLogicPlusMemory<'_>,
     promise_index: u64,
     amount: u128,
     gas: Gas,
@@ -37,7 +38,8 @@ pub fn promise_batch_action_function_call(
     let method_id = b"promise_batch_action";
     let args = b"promise_batch_action_args";
 
-    logic.promise_batch_action_function_call(
+    l.logic.promise_batch_action_function_call(
+        l.mem,
         promise_index,
         method_id.len() as _,
         method_id.as_ptr() as _,
@@ -50,7 +52,7 @@ pub fn promise_batch_action_function_call(
 
 #[allow(dead_code)]
 pub fn promise_batch_action_add_key_with_function_call(
-    logic: &mut VMLogic<'_>,
+    l: &mut VMLogicPlusMemory<'_>,
     promise_index: u64,
     public_key: &[u8],
     nonce: u64,
@@ -58,7 +60,8 @@ pub fn promise_batch_action_add_key_with_function_call(
     receiver_id: &[u8],
     method_names: &[u8],
 ) -> Result<()> {
-    logic.promise_batch_action_add_key_with_function_call(
+    l.logic.promise_batch_action_add_key_with_function_call(
+        l.mem,
         promise_index,
         public_key.len() as _,
         public_key.as_ptr() as _,

--- a/runtime/near-vm-logic/src/tests/iterators.rs
+++ b/runtime/near-vm-logic/src/tests/iterators.rs
@@ -6,23 +6,23 @@ use near_vm_errors::{HostError, VMLogicError};
 fn test_iterator_deprecated() {
     let context = get_context(vec![], false);
     let mut logic_builder = VMLogicBuilder::default();
-    let mut logic = logic_builder.build(context);
+    let mut l = logic_builder.build(context);
     assert_eq!(
         Err(VMLogicError::HostError(HostError::Deprecated {
             method_name: "storage_iter_prefix".to_string()
         })),
-        logic.storage_iter_prefix(1, b"a".as_ptr() as _)
+        l.logic.storage_iter_prefix(l.mem, 1, b"a".as_ptr() as _)
     );
     assert_eq!(
         Err(VMLogicError::HostError(HostError::Deprecated {
             method_name: "storage_iter_range".to_string()
         })),
-        logic.storage_iter_range(1, b"a".as_ptr() as _, 1, b"b".as_ptr() as _)
+        l.logic.storage_iter_range(l.mem, 1, b"a".as_ptr() as _, 1, b"b".as_ptr() as _)
     );
     assert_eq!(
         Err(VMLogicError::HostError(HostError::Deprecated {
             method_name: "storage_iter_next".to_string()
         })),
-        logic.storage_iter_next(0, 0, 1)
+        l.logic.storage_iter_next(l.mem, 0, 0, 1)
     );
 }

--- a/runtime/near-vm-logic/src/tests/registers.rs
+++ b/runtime/near-vm-logic/src/tests/registers.rs
@@ -6,24 +6,24 @@ use near_vm_errors::{HostError, VMLogicError};
 #[test]
 fn test_one_register() {
     let mut logic_builder = VMLogicBuilder::default();
-    let mut logic = logic_builder.build(get_context(vec![], false));
+    let mut l = logic_builder.build(get_context(vec![], false));
 
-    logic.wrapped_internal_write_register(0, &vec![0, 1, 2]).unwrap();
-    assert_eq!(logic.register_len(0).unwrap(), 3u64);
+    l.logic.wrapped_internal_write_register(0, &vec![0, 1, 2]).unwrap();
+    assert_eq!(l.logic.register_len(l.mem, 0).unwrap(), 3u64);
     let buffer = [0u8; 3];
-    logic.read_register(0, buffer.as_ptr() as u64).unwrap();
+    l.logic.read_register(l.mem, 0, buffer.as_ptr() as u64).unwrap();
     assert_eq!(buffer, [0u8, 1, 2]);
 }
 
 #[test]
 fn test_non_existent_register() {
     let mut logic_builder = VMLogicBuilder::default();
-    let mut logic = logic_builder.build(get_context(vec![], false));
+    let mut l = logic_builder.build(get_context(vec![], false));
 
-    assert_eq!(logic.register_len(0), Ok(u64::MAX) as Result<u64, VMLogicError>);
+    assert_eq!(l.logic.register_len(l.mem, 0), Ok(u64::MAX) as Result<u64, VMLogicError>);
     let buffer = [0u8; 3];
     assert_eq!(
-        logic.read_register(0, buffer.as_ptr() as u64),
+        l.logic.read_register(l.mem, 0, buffer.as_ptr() as u64),
         Err(HostError::InvalidRegisterId { register_id: 0 }.into())
     );
 }
@@ -32,20 +32,20 @@ fn test_non_existent_register() {
 fn test_many_registers() {
     let mut logic_builder = VMLogicBuilder::default();
     let max_registers = logic_builder.config.limit_config.max_number_registers;
-    let mut logic = logic_builder.build(get_context(vec![], false));
+    let mut l = logic_builder.build(get_context(vec![], false));
 
     for i in 0..max_registers {
         let value = (i * 10).to_le_bytes();
-        logic.wrapped_internal_write_register(i, &value).unwrap();
+        l.logic.wrapped_internal_write_register(i, &value).unwrap();
 
         let buffer = [0u8; std::mem::size_of::<u64>()];
-        logic.read_register(i, buffer.as_ptr() as u64).unwrap();
+        l.logic.read_register(l.mem, i, buffer.as_ptr() as u64).unwrap();
         assert_eq!(i * 10, u64::from_le_bytes(buffer));
     }
 
     // One more register hits the boundary check.
     assert_eq!(
-        logic.wrapped_internal_write_register(max_registers, &[]),
+        l.logic.wrapped_internal_write_register(max_registers, &[]),
         Err(HostError::MemoryAccessViolation.into())
     )
 }
@@ -54,12 +54,12 @@ fn test_many_registers() {
 fn test_max_register_size() {
     let mut logic_builder = VMLogicBuilder::free();
     let max_register_size = logic_builder.config.limit_config.max_register_size;
-    let mut logic = logic_builder.build(get_context(vec![], false));
+    let mut l = logic_builder.build(get_context(vec![], false));
 
     let value = vec![0u8; (max_register_size + 1) as usize];
 
     assert_eq!(
-        logic.wrapped_internal_write_register(0, &value),
+        l.logic.wrapped_internal_write_register(0, &value),
         Err(HostError::MemoryAccessViolation.into())
     );
 }
@@ -69,18 +69,18 @@ fn test_max_register_memory_limit() {
     let mut logic_builder = VMLogicBuilder::free();
     let config = VMConfig::free();
     logic_builder.config = config.clone();
-    let mut logic = logic_builder.build(get_context(vec![], false));
+    let mut l = logic_builder.build(get_context(vec![], false));
 
     let max_registers =
         config.limit_config.registers_memory_limit / config.limit_config.max_register_size;
 
     for i in 0..max_registers {
         let value = vec![1u8; config.limit_config.max_register_size as usize];
-        logic.wrapped_internal_write_register(i, &value).expect("should be written successfully");
+        l.logic.wrapped_internal_write_register(i, &value).expect("should be written successfully");
     }
     let last = vec![1u8; config.limit_config.max_register_size as usize];
     assert_eq!(
-        logic.wrapped_internal_write_register(max_registers, &last),
+        l.logic.wrapped_internal_write_register(max_registers, &last),
         Err(HostError::MemoryAccessViolation.into())
     );
 }
@@ -88,6 +88,6 @@ fn test_max_register_memory_limit() {
 #[test]
 fn test_register_is_not_used() {
     let mut logic_builder = VMLogicBuilder::default();
-    let mut logic = logic_builder.build(get_context(vec![], false));
-    assert_eq!(logic.register_len(0), Ok(u64::MAX));
+    let mut l = logic_builder.build(get_context(vec![], false));
+    assert_eq!(l.logic.register_len(l.mem, 0), Ok(u64::MAX));
 }

--- a/runtime/near-vm-logic/src/tests/storage_read_write.rs
+++ b/runtime/near-vm-logic/src/tests/storage_read_write.rs
@@ -5,15 +5,15 @@ use crate::External;
 #[test]
 fn test_storage_write_with_register() {
     let mut logic_builder = VMLogicBuilder::default();
-    let mut logic = logic_builder.build(get_context(vec![], false));
+    let mut l = logic_builder.build(get_context(vec![], false));
 
     let key: &[u8] = b"foo";
     let val: &[u8] = b"bar";
 
-    logic.wrapped_internal_write_register(1, key).unwrap();
-    logic.wrapped_internal_write_register(2, val).unwrap();
+    l.logic.wrapped_internal_write_register(1, key).unwrap();
+    l.logic.wrapped_internal_write_register(2, val).unwrap();
 
-    logic.storage_write(u64::MAX, 1 as _, u64::MAX, 2 as _, 0).expect("storage write ok");
+    l.logic.storage_write(l.mem, u64::MAX, 1 as _, u64::MAX, 2 as _, 0).expect("storage write ok");
 
     let value_ptr = logic_builder.ext.storage_get(key).unwrap().unwrap();
     assert_eq!(value_ptr.deref().unwrap(), val.to_vec());
@@ -27,13 +27,13 @@ fn test_storage_read_with_register() {
     let val: &[u8] = b"bar";
 
     logic_builder.ext.storage_set(key, val).unwrap();
-    let mut logic = logic_builder.build(get_context(vec![], false));
+    let mut l = logic_builder.build(get_context(vec![], false));
 
-    logic.wrapped_internal_write_register(1, key).unwrap();
+    l.logic.wrapped_internal_write_register(1, key).unwrap();
 
-    logic.storage_read(u64::MAX, 1 as _, 0).expect("storage read ok");
+    l.logic.storage_read(l.mem, u64::MAX, 1 as _, 0).expect("storage read ok");
     let res = [0u8; 3];
-    logic.read_register(0, res.as_ptr() as _).unwrap();
+    l.logic.read_register(l.mem, 0, res.as_ptr() as _).unwrap();
     assert_eq!(&res, b"bar");
 }
 
@@ -44,16 +44,23 @@ fn test_storage_remove_with_register() {
     let key: &[u8] = b"foo";
     let val: &[u8] = b"bar";
 
-    let mut logic = logic_builder.build(get_context(vec![], false));
-    logic
-        .storage_write(key.len() as _, key.as_ptr() as _, val.len() as _, val.as_ptr() as _, 0)
+    let mut l = logic_builder.build(get_context(vec![], false));
+    l.logic
+        .storage_write(
+            l.mem,
+            key.len() as _,
+            key.as_ptr() as _,
+            val.len() as _,
+            val.as_ptr() as _,
+            0,
+        )
         .expect("storage write ok");
 
-    logic.wrapped_internal_write_register(1, key).unwrap();
+    l.logic.wrapped_internal_write_register(1, key).unwrap();
 
-    logic.storage_remove(u64::MAX, 1 as _, 0).expect("storage remove ok");
+    l.logic.storage_remove(l.mem, u64::MAX, 1 as _, 0).expect("storage remove ok");
     let res = [0u8; 3];
-    logic.read_register(0, res.as_ptr() as _).unwrap();
+    l.logic.read_register(l.mem, 0, res.as_ptr() as _).unwrap();
     assert_eq!(&res, b"bar");
 }
 
@@ -65,9 +72,9 @@ fn test_storage_has_key_with_register() {
     let val: &[u8] = b"bar";
     logic_builder.ext.storage_set(key, val).unwrap();
 
-    let mut logic = logic_builder.build(get_context(vec![], false));
+    let mut l = logic_builder.build(get_context(vec![], false));
 
-    logic.wrapped_internal_write_register(1, key).unwrap();
+    l.logic.wrapped_internal_write_register(1, key).unwrap();
 
-    assert_eq!(logic.storage_has_key(u64::MAX, 1 as _), Ok(1));
+    assert_eq!(l.logic.storage_has_key(l.mem, u64::MAX, 1 as _), Ok(1));
 }

--- a/runtime/near-vm-logic/src/tests/storage_usage.rs
+++ b/runtime/near-vm-logic/src/tests/storage_usage.rs
@@ -5,41 +5,62 @@ use crate::tests::vm_logic_builder::VMLogicBuilder;
 fn test_storage_write_counter() {
     let mut logic_builder = VMLogicBuilder::default();
     let data_record_cost = logic_builder.fees_config.storage_usage_config.num_extra_bytes_record;
-    let mut logic = logic_builder.build(get_context(vec![], false));
+    let mut l = logic_builder.build(get_context(vec![], false));
     let key = b"foo";
     let val = b"bar";
 
-    logic
-        .storage_write(key.len() as _, key.as_ptr() as _, val.len() as _, val.as_ptr() as _, 0)
+    l.logic
+        .storage_write(
+            l.mem,
+            key.len() as _,
+            key.as_ptr() as _,
+            val.len() as _,
+            val.as_ptr() as _,
+            0,
+        )
         .expect("storage write ok");
 
     let cost_expected = (data_record_cost as usize + key.len() + val.len()) as u64;
 
-    assert_eq!(logic.storage_usage().unwrap(), cost_expected);
+    assert_eq!(l.logic.storage_usage(l.mem).unwrap(), cost_expected);
 
     let key = b"foo";
     let val = b"bar";
 
-    logic
-        .storage_write(key.len() as _, key.as_ptr() as _, val.len() as _, val.as_ptr() as _, 0)
+    l.logic
+        .storage_write(
+            l.mem,
+            key.len() as _,
+            key.as_ptr() as _,
+            val.len() as _,
+            val.as_ptr() as _,
+            0,
+        )
         .expect("storage write ok");
 
-    assert_eq!(logic.storage_usage().unwrap(), cost_expected);
+    assert_eq!(l.logic.storage_usage(l.mem).unwrap(), cost_expected);
 }
 
 #[test]
 fn test_storage_remove() {
     let mut logic_builder = VMLogicBuilder::default();
-    let mut logic = logic_builder.build(get_context(vec![], false));
+    let mut l = logic_builder.build(get_context(vec![], false));
 
     let key = b"foo";
     let val = b"bar";
 
-    logic
-        .storage_write(key.len() as _, key.as_ptr() as _, val.len() as _, val.as_ptr() as _, 0)
+    l.logic
+        .storage_write(
+            l.mem,
+            key.len() as _,
+            key.as_ptr() as _,
+            val.len() as _,
+            val.as_ptr() as _,
+            0,
+        )
         .expect("storage write ok");
 
-    logic.storage_remove(key.len() as _, key.as_ptr() as _, 0).expect("storage remove ok");
+    l.logic.storage_remove(l.mem, key.len() as _, key.as_ptr() as _, 0).expect("storage remove ok");
 
-    assert_eq!(logic.storage_usage().unwrap(), 0u64);
+    assert_eq!(l.logic.storage_usage(l.mem).unwrap(), 0u64);
 }

--- a/runtime/near-vm-logic/src/tests/view_method.rs
+++ b/runtime/near-vm-logic/src/tests/view_method.rs
@@ -5,10 +5,10 @@ macro_rules! test_prohibited {
     ($f: ident $(, $arg: expr )* ) => {
         let mut logic_builder = VMLogicBuilder::default();
         #[allow(unused_mut)]
-        let mut logic = logic_builder.build(get_context(vec![], true));
+        let mut l = logic_builder.build(get_context(vec![], true));
 
         let name = stringify!($f);
-        logic.$f($($arg, )*).expect_err(&format!("{} is not allowed in view calls", name))
+        l.logic.$f(l.mem, $($arg, )*).expect_err(&format!("{} is not allowed in view calls", name))
     };
 }
 
@@ -45,6 +45,6 @@ fn test_prohibited_view_methods() {
 fn test_allowed_view_method() {
     let mut logic_builder = VMLogicBuilder::default();
     let context = get_context(vec![], true);
-    let mut logic = logic_builder.build(context.clone());
-    assert_eq!(logic.block_index().unwrap(), context.block_index);
+    let mut l = logic_builder.build(context.clone());
+    assert_eq!(l.logic.block_index(l.mem).unwrap(), context.block_index);
 }

--- a/runtime/near-vm-logic/src/tests/vm_logic_builder.rs
+++ b/runtime/near-vm-logic/src/tests/vm_logic_builder.rs
@@ -1,8 +1,8 @@
 use crate::mocks::mock_external::MockedExternal;
 use crate::mocks::mock_memory::MockedMemory;
 use crate::types::PromiseResult;
-use crate::VMContext;
 use crate::{VMConfig, VMLogic};
+use crate::{VMContext, VMLogicPlusMemory};
 use near_primitives_core::runtime::fees::RuntimeFeesConfig;
 use near_primitives_core::types::ProtocolVersion;
 
@@ -31,16 +31,18 @@ impl Default for VMLogicBuilder {
 }
 
 impl VMLogicBuilder {
-    pub fn build(&mut self, context: VMContext) -> VMLogic<'_> {
-        VMLogic::new_with_protocol_version(
-            &mut self.ext,
-            context,
-            &self.config,
-            &self.fees_config,
-            &self.promise_results,
-            &mut self.memory,
-            self.current_protocol_version,
-        )
+    pub fn build(&mut self, context: VMContext) -> VMLogicPlusMemory<'_> {
+        VMLogicPlusMemory {
+            logic: VMLogic::new_with_protocol_version(
+                &mut self.ext,
+                context,
+                &self.config,
+                &self.fees_config,
+                &self.promise_results,
+                self.current_protocol_version,
+            ),
+            mem: &mut self.memory,
+        }
     }
     #[allow(dead_code)]
     pub fn free() -> Self {


### PR DESCRIPTION
This gets us ready for an (upcoming) PR that will bump wasmtime, as such
a PR will need a different &dyn MemoryLike depending on whether we're in
the host before calling into wasm, or in a host function called by wasm
code.

For now, for convenience VMLogicPlusMemory has been added. Future work
could consider removing it, though wasmer code will probably keep
needing it for now.

-----

I'll undraft the PR once the wasmtime bump PR will be ready and confirmed to work well with this refactor