### PR TITLE
tests: fix flaky integration test

### DIFF
--- a/integration-tests/src/tests/test_download_file.rs
+++ b/integration-tests/src/tests/test_download_file.rs
@@ -1,8 +1,6 @@
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Request, Response, Server};
 use std::convert::Infallible;
-use std::fs::File;
-use std::io::Read;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::Barrier;
@@ -43,9 +41,6 @@ async fn test_file_download() {
     .await
     .unwrap();
 
-    let mut downloaded_file = File::open(tmp_downloaded_file_path).unwrap();
-    let mut downloaded_file_content: Vec<u8> = Vec::new();
-    downloaded_file.read_to_end(&mut downloaded_file_content).unwrap();
-
+    let downloaded_file_content = std::fs::read(tmp_downloaded_file_path).unwrap();
     assert_eq!(downloaded_file_content, [42; 1024].to_vec());
 }


### PR DESCRIPTION
the download_file() test might fail if download_file() runs before
the HTTP server gets a chance to start. Fix it by waiting until the server
is already listening to call download_file(). This requires moving the
tokio runtime block_on() call to a wrapper function so we don't have problems
starting a runtime inside a runtime in the test code