### PR TITLE
Makefile: fix sandbox target not building in sandbox directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ export CARGO_PROFILE_RELEASE_LTO = fat
 export DOCKER_BUILDKIT = 1
 export RUSTFLAGS = -D warnings
 export NEAR_RELEASE_BUILD = no
+export CARGO_TARGET_DIR = target
 
 
 # By default, build a regular release


### PR DESCRIPTION
Commit adf23731: ‘Use make targets when building docker images’
changed sandbox and sandbox-release rules from assigning the
CARGO_TARGET_DIR environment variable within the shell command to
using a Makefile variable.  However, the commit did not export that
variable which means that the setting was never picked up by cargo.

As a result, running ‘make sandbox’ would build within ‘target’
directory overriding anything there and in the end fail (because it
expects to be able to link files from ‘sandbox’ directory to ‘target’
directory).

Fix by exporting the variable.

Note: It would be better to use rule-level export directive (as in
`sandbox: export CARGE_TARGET_DIRE=sandbox`) but, as far as
I gathered, that syntax isn’t supported by macOS make.

Issue: https://github.com/near/nearcore/issues/5969