### PR TITLE
Fix docker run script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,4 @@ RUN apt-get update -qq && apt-get install -y \
 COPY scripts/run_docker.sh /usr/local/bin/run.sh
 COPY --from=build /tmp/target/release/neard /usr/local/bin
 
-CMD ["/usr/local/bin/run.sh"]
+ENTRYPOINT ["/usr/local/bin/run.sh"]

--- a/scripts/run_docker.sh
+++ b/scripts/run_docker.sh
@@ -1,22 +1,20 @@
-#!/usr/bin/env bash
+#!/bin/sh
 set -e
 
 export NEAR_HOME=/srv/near
 
-NEARD_FLAGS=${NEAR_HOME:+--home=$NEAR_HOME}
+NEARD_FLAGS=${NEAR_HOME:+--home="$NEAR_HOME"}
 
-if [[ -z {INIT} ]]
+if [ -n "$INIT" ]
 then
-    neard $NEARD_FLAGS init ${CHAIN_ID:+--chain-id=$CHAIN_ID} ${ACCOUNT_ID:+--account-id=$ACCOUNT_ID}
+    neard "$NEARD_FLAGS" init ${CHAIN_ID:+--chain-id="$CHAIN_ID"} ${ACCOUNT_ID:+--account-id="$ACCOUNT_ID"}
 fi
 
-if [[ -z {NODE_KEY} ]]
+if [ -n "$NODE_KEY" ]
 then
-
-    cat << EOF > ${NEAR_HOME}/node_key.json
+    cat << EOF > "$NEAR_HOME/node_key.json"
 {"account_id": "", "public_key": "", "secret_key": "$NODE_KEY"}
 EOF
-
 fi
 
 ulimit -c unlimited
@@ -24,4 +22,4 @@ ulimit -c unlimited
 echo "Telemetry: ${TELEMETRY_URL}"
 echo "Bootnodes: ${BOOT_NODES}"
 
-neard $NEARD_FLAGS run ${TELEMETRY_URL:+--telemetry-url=$TELEMETRY_URL} ${BOOT_NODES:+--boot-nodes=$BOOT_NODES}
+exec neard "$NEARD_FLAGS" run ${TELEMETRY_URL:+--telemetry-url="$TELEMETRY_URL"} ${BOOT_NODES:+--boot-nodes="$BOOT_NODES"} "$@"


### PR DESCRIPTION
Hello, I'd like to propose some fixes to the docker run script:

1. `if [[ -z {INIT} ]]`
I suppose this was a typo and the `$` was missing, otherwise bash interpret {INIT} has string and `-z` is always false. In this case the correct test should be `-n` (= check variable is NOT empty VS `-z` = the variable is empty)

2. `if [[ -z {NODE_KEY} ]]`
Same as above, missing `$`

3. `exec neard $NEARD_FLAGS ...`
I'm adding `exec` in order to not let bash as PID 1 in the docker container, which is a best practice for signal handling and potential zombie processes (example [here](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#entrypoint)) 

4. `$@`
This allows passing additional arguments to the main process (along with the next point)

5. `CMD => ENTRYPOINT`
Using the image on kubernetes this allows to uses the `args` field for additional field without bypassing the run_docker.sh. For example, adding `--disable-rpc` or any other options.