### PR TITLE
re: chore: Reduce visibility of HandshakeAutoDes in `near-network-primitives`

### DIFF
--- a/chain/network/src/network_protocol.rs
+++ b/chain/network/src/network_protocol.rs
@@ -46,17 +46,17 @@ pub struct Handshake {
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Clone, Debug)]
 struct HandshakeAutoDes {
     /// Protocol version.
-    version: u32,
+    protocol_version: u32,
     /// Oldest supported protocol version.
     oldest_supported_version: u32,
     /// Sender's peer id.
-    peer_id: PeerId,
+    sender_peer_id: PeerId,
     /// Receiver's peer id.
     target_peer_id: PeerId,
     /// Sender's listening addr.
-    listen_port: Option<u16>,
+    sender_listen_port: Option<u16>,
     /// Peer's chain information.
-    chain_info: PeerChainInfoV2,
+    sender_chain_info: PeerChainInfoV2,
     /// Info for new edge.
     partial_edge_info: PartialEdgeInfo,
 }
@@ -114,12 +114,12 @@ impl BorshDeserialize for Handshake {
 impl From<HandshakeAutoDes> for Handshake {
     fn from(handshake: HandshakeAutoDes) -> Self {
         Self {
-            protocol_version: handshake.version,
+            protocol_version: handshake.protocol_version,
             oldest_supported_version: handshake.oldest_supported_version,
-            sender_peer_id: handshake.peer_id,
+            sender_peer_id: handshake.sender_peer_id,
             target_peer_id: handshake.target_peer_id,
-            sender_listen_port: handshake.listen_port,
-            sender_chain_info: handshake.chain_info,
+            sender_listen_port: handshake.sender_listen_port,
+            sender_chain_info: handshake.sender_chain_info,
             partial_edge_info: handshake.partial_edge_info,
         }
     }

--- a/chain/network/src/network_protocol.rs
+++ b/chain/network/src/network_protocol.rs
@@ -44,21 +44,21 @@ pub struct Handshake {
 /// Struct describing the layout for Handshake.
 /// It is used to automatically derive BorshDeserialize.
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Clone, Debug)]
-pub(crate) struct HandshakeAutoDes {
+struct HandshakeAutoDes {
     /// Protocol version.
-    pub(crate) version: u32,
+    version: u32,
     /// Oldest supported protocol version.
-    pub(crate) oldest_supported_version: u32,
+    oldest_supported_version: u32,
     /// Sender's peer id.
-    pub(crate) peer_id: PeerId,
+    peer_id: PeerId,
     /// Receiver's peer id.
-    pub(crate) target_peer_id: PeerId,
+    target_peer_id: PeerId,
     /// Sender's listening addr.
-    pub(crate) listen_port: Option<u16>,
+    listen_port: Option<u16>,
     /// Peer's chain information.
-    pub(crate) chain_info: PeerChainInfoV2,
+    chain_info: PeerChainInfoV2,
     /// Info for new edge.
-    pub(crate) partial_edge_info: PartialEdgeInfo,
+    partial_edge_info: PartialEdgeInfo,
 }
 
 impl Handshake {


### PR DESCRIPTION
Visibility of `HandshakeAutoDes` can be decreased to private. It's better not to expose this structure outside.