### PR TITLE
re: Fix various issues in `near-network` docs

### DIFF
--- a/chain/network/src/peer/utils.rs
+++ b/chain/network/src/peer/utils.rs
@@ -1,9 +1,9 @@
 use tracing::error;
 
 /// Determines size of `PeerId` based on first byte of it's representation.
-/// Size of `PeerId` depends on type of `PublicMessage it stores`.
-/// PublicKey::ED25519 -> 1 + 32 bytes
-/// PublicKey::SECP256K1 -> 1 + 64 bytes
+/// Size of `PeerId` depends on type of `PublicMessage` it stores.
+/// `PublicKey::ED25519` -> `1 + 32 bytes`
+/// `PublicKey::SECP256K1` -> `1 + 64 bytes`
 fn peer_id_type_field_len(enum_var: u8) -> Option<usize> {
     // 1 byte for enum variant, then some number depending on the
     // public key type
@@ -17,7 +17,7 @@ fn peer_id_type_field_len(enum_var: u8) -> Option<usize> {
 /// Checks `bytes` represents `PeerMessage::Routed(RoutedMessage)`,
 /// and `RoutedMessage.body` has type of `RoutedMessageBody::ForwardTx`.
 ///
-/// This is done to avoid expensive borsch-deserializing.
+/// This is done to avoid expensive `borsh`-deserializing.
 pub(crate) fn is_forward_transaction(bytes: &[u8]) -> Option<bool> {
     // PeerMessage::Routed variant == 13
     let peer_message_variant = *bytes.get(0)?;

--- a/chain/network/src/routing/route_back_cache.rs
+++ b/chain/network/src/routing/route_back_cache.rs
@@ -13,7 +13,7 @@ const DEFAULT_REMOVE_BATCH_SIZE: usize = 100;
 
 /// Cache to store route back messages.
 ///
-/// The interface of the cache is similar to a regular HashMap:
+/// The interface of the cache is similar to a regular `HashMap`:
 /// elements can be inserted, fetched and removed.
 ///
 /// Motivation behind the following (complex) design:
@@ -37,7 +37,7 @@ const DEFAULT_REMOVE_BATCH_SIZE: usize = 100;
 /// 2. For every peer store how many message should be routed to it.
 ///
 /// First are removed messages that have been in the cache more time than
-/// EVICTED_TIMEOUT. If no message was removed, it is removed the oldest
+/// `EVICTED_TIMEOUT`. If no message was removed, it is removed the oldest
 /// message from the peer with more messages in the cache.
 ///
 /// Rationale:
@@ -45,7 +45,7 @@ const DEFAULT_REMOVE_BATCH_SIZE: usize = 100;
 /// - Old entries in the cache will be eventually removed (no memory leak).
 /// - If the cache is not at full capacity, all new records will be stored.
 /// - If a peer try to abuse the system, it will be able to allocate at most
-///     $capacity / number_of_active_connections$ entries.
+///     `capacity / number_of_active_connections` entries.
 pub struct RouteBackCache {
     /// Maximum number of records allowed in the cache.
     capacity: usize,

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -73,8 +73,8 @@ pub struct PeersResponse {
     pub(crate) peers: Vec<PeerInfo>,
 }
 
-/// List of all messages, which PeerManagerActor accepts through Actix. There is also another list
-/// which contains reply for each message to PeerManager.
+/// List of all messages, which `PeerManagerActor` accepts through `Actix`. There is also another list
+/// which contains reply for each message to `PeerManager`.
 /// There is 1 to 1 mapping between an entry in `PeerManagerMessageRequest` and `PeerManagerMessageResponse`.
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
 #[derive(Debug)]
@@ -123,7 +123,7 @@ impl Message for PeerManagerMessageRequest {
     type Result = PeerManagerMessageResponse;
 }
 
-/// List of all replies to messages to PeerManager. See `PeerManagerMessageRequest` for more details.
+/// List of all replies to messages to `PeerManager`. See `PeerManagerMessageRequest` for more details.
 #[derive(MessageResponse, Debug)]
 pub enum PeerManagerMessageResponse {
     RoutedMessageFrom(bool),
@@ -474,7 +474,7 @@ where
 }
 
 /// Adapter to break dependency of sub-components on the network requests.
-/// For tests use MockNetworkAdapter that accumulates the requests to network.
+/// For tests use `MockNetworkAdapter` that accumulates the requests to network.
 pub trait PeerManagerAdapter: Sync + Send {
     fn send(
         &self,


### PR DESCRIPTION
There are a couple places where ticks are missing in `near-network` docs. We should fix them.