### PR TITLE
re: `near-network` Inline one line methods to improve readability.

### DIFF
--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -26,11 +26,11 @@ use futures::task::Poll;
 use futures::FutureExt;
 use futures::{future, Stream, StreamExt};
 use near_network_primitives::types::{
-    AccountOrPeerIdOrHash, Ban, BlockedPorts, Edge, InboundTcpConnect, KnownPeerState,
-    KnownPeerStatus, KnownProducer, NetworkConfig, NetworkViewClientMessages,
-    NetworkViewClientResponses, OutboundTcpConnect, PeerIdOrHash, PeerInfo, PeerManagerRequest,
-    PeerType, Ping, Pong, QueryPeerStats, RawRoutedMessage, ReasonForBan, RoutedMessage,
-    RoutedMessageBody, RoutedMessageFrom, StateResponseInfo,
+    AccountOrPeerIdOrHash, Ban, BlockedPorts, Edge, InboundTcpConnect, KnownPeerStatus,
+    KnownProducer, NetworkConfig, NetworkViewClientMessages, NetworkViewClientResponses,
+    OutboundTcpConnect, PeerIdOrHash, PeerInfo, PeerManagerRequest, PeerType, Ping, Pong,
+    QueryPeerStats, RawRoutedMessage, ReasonForBan, RoutedMessage, RoutedMessageBody,
+    RoutedMessageFrom, StateResponseInfo,
 };
 use near_network_primitives::types::{EdgeState, PartialEdgeInfo};
 use near_performance_metrics::framed_write::FramedWrite;
@@ -954,11 +954,6 @@ impl PeerManagerActor {
             .collect::<Vec<_>>()
     }
 
-    /// Get a random peer we are not connected to from the known list.
-    fn sample_random_peer(&self, ignore_fn: impl Fn(&KnownPeerState) -> bool) -> Option<PeerInfo> {
-        self.peer_store.unconnected_peer(ignore_fn)
-    }
-
     /// Query current peers for more peers.
     fn query_active_peers_for_more_peers(&mut self) {
         let mut requests = futures::stream::FuturesUnordered::new();
@@ -1238,7 +1233,7 @@ impl PeerManagerActor {
         }
 
         if self.is_outbound_bootstrap_needed() {
-            if let Some(peer_info) = self.sample_random_peer(|peer_state| {
+            if let Some(peer_info) = self.peer_store.unconnected_peer(|peer_state| {
                 // Ignore connecting to ourself
                 self.my_peer_id == peer_state.peer_info.id
                     || self.config.addr == peer_state.peer_info.addr


### PR DESCRIPTION
Code inside `get_total_bytes_per_sec`/`sample_random_peer` can be inline for better readability.