### PR TITLE
feat: Change actix not to block sender.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,11 +5,11 @@ version = 3
 [[package]]
 name = "actix"
 version = "0.11.0-beta.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb78f9871feb3519e06b947c2becbf2cc7f67ce786e510e6bd3f9a27da3dbf1"
+source = "git+https://github.com/pmnoxx/actix-patched?rev=5e170d58e82ac01981c628fd74da1415a88c5275#5e170d58e82ac01981c628fd74da1415a88c5275"
 dependencies = [
  "actix-rt",
  "actix_derive",
+ "backtrace",
  "bitflags",
  "bytes",
  "crossbeam-channel",

--- a/chain/chain/Cargo.toml
+++ b/chain/chain/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.56.0"
 edition = "2021"
 
 [dependencies]
-actix = "=0.11.0-beta.2"
+actix = { git = "https://github.com/pmnoxx/actix-patched", rev = "5e170d58e82ac01981c628fd74da1415a88c5275" }
 borsh = "0.9"
 chrono = { version = "0.4.4", features = ["serde"] }
 failure = "0.1"

--- a/chain/chunks/Cargo.toml
+++ b/chain/chunks/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.56.0"
 edition = "2021"
 
 [dependencies]
-actix = "=0.11.0-beta.2"
+actix = { git = "https://github.com/pmnoxx/actix-patched", rev = "5e170d58e82ac01981c628fd74da1415a88c5275" }
 futures = "0.3"
 rand = "0.7"
 chrono = "0.4.6"

--- a/chain/client-primitives/Cargo.toml
+++ b/chain/client-primitives/Cargo.toml
@@ -13,7 +13,7 @@ description = "This crate hosts NEAR client-related error types"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix = "=0.11.0-beta.2"
+actix = { git = "https://github.com/pmnoxx/actix-patched", rev = "5e170d58e82ac01981c628fd74da1415a88c5275" }
 chrono = { version = "0.4.4", features = ["serde"] }
 strum = { version = "0.20", features = ["derive"] }
 thiserror = "1.0"

--- a/chain/client/Cargo.toml
+++ b/chain/client/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 
 [dependencies]
 ansi_term = "0.12"
-actix = "=0.11.0-beta.2"
+actix = { git = "https://github.com/pmnoxx/actix-patched", rev = "5e170d58e82ac01981c628fd74da1415a88c5275" }
 actix-rt = "2"
 futures = "0.3"
 chrono = { version = "0.4.4", features = ["serde"] }

--- a/chain/indexer/Cargo.toml
+++ b/chain/indexer/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.56.0"
 edition = "2021"
 
 [dependencies]
-actix = "=0.11.0-beta.2"
+actix = { git = "https://github.com/pmnoxx/actix-patched", rev = "5e170d58e82ac01981c628fd74da1415a88c5275" }
 anyhow = "1.0.51"
 async-recursion = "0.3.2"
 tracing = "0.1.13"

--- a/chain/jsonrpc-primitives/Cargo.toml
+++ b/chain/jsonrpc-primitives/Cargo.toml
@@ -13,7 +13,7 @@ description = "This crate hosts structures for the NEAR JSON RPC Requests, Respo
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix = "=0.11.0-beta.2"
+actix = { git = "https://github.com/pmnoxx/actix-patched", rev = "5e170d58e82ac01981c628fd74da1415a88c5275" }
 once_cell = "1.5.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/chain/jsonrpc/Cargo.toml
+++ b/chain/jsonrpc/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.56.0"
 edition = "2021"
 
 [dependencies]
-actix = "=0.11.0-beta.2"
+actix = { git = "https://github.com/pmnoxx/actix-patched", rev = "5e170d58e82ac01981c628fd74da1415a88c5275" }
 actix-web = "=4.0.0-beta.6"
 actix-cors = { git = "https://github.com/near/actix-extras.git", branch="actix-web-4-beta.6" }
 easy-ext = "0.2"

--- a/chain/jsonrpc/fuzz/Cargo.toml
+++ b/chain/jsonrpc/fuzz/Cargo.toml
@@ -13,7 +13,7 @@ cargo-fuzz = true
 
 [dependencies]
 awc = "3.0.0-beta.5"
-actix = "=0.11.0-beta.2"
+actix = { git = "https://github.com/pmnoxx/actix-patched", rev = "5e170d58e82ac01981c628fd74da1415a88c5275" }
 actix_derive = "=0.6.0-beta.1" # Pinned dependency in addition to actix dependecy (remove this line once the pinning is not needed)
 arbitrary = { version = "1", features = ["derive"] }
 base64 = "0.13"

--- a/chain/jsonrpc/jsonrpc-tests/Cargo.toml
+++ b/chain/jsonrpc/jsonrpc-tests/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.56.0"
 edition = "2021"
 
 [dependencies]
-actix = "=0.11.0-beta.2"
+actix = { git = "https://github.com/pmnoxx/actix-patched", rev = "5e170d58e82ac01981c628fd74da1415a88c5275" }
 awc = "3.0.0-beta.5"
 once_cell = "1.5.2"
 futures = "0.3"

--- a/chain/network-primitives/Cargo.toml
+++ b/chain/network-primitives/Cargo.toml
@@ -12,7 +12,7 @@ publish = true
 
 [dependencies]
 anyhow = "1.0.51"
-actix = "=0.11.0-beta.2"
+actix = { git = "https://github.com/pmnoxx/actix-patched", rev = "5e170d58e82ac01981c628fd74da1415a88c5275" }
 borsh = "0.9"
 chrono = { version = "0.4.4", features = ["serde"] }
 deepsize = { version = "0.2.0", optional = true }

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.56.0"
 publish = false
 
 [dependencies]
-actix = "=0.11.0-beta.2"
+actix = { git = "https://github.com/pmnoxx/actix-patched", rev = "5e170d58e82ac01981c628fd74da1415a88c5275" }
 borsh = { version = "0.9", features = ["rc"] }
 bytes = "1"
 bytesize = "1.1"

--- a/chain/rosetta-rpc/Cargo.toml
+++ b/chain/rosetta-rpc/Cargo.toml
@@ -16,7 +16,7 @@ lazy_static = "1.4"
 strum = { version = "0.20", features = ["derive"] }
 
 awc = "3.0.0-beta.5"
-actix = "=0.11.0-beta.2"
+actix = { git = "https://github.com/pmnoxx/actix-patched", rev = "5e170d58e82ac01981c628fd74da1415a88c5275" }
 actix-web = "=4.0.0-beta.6"
 actix-http = "=3.0.0-beta.6"
 actix-cors = { git = "https://github.com/near/actix-extras.git", branch="actix-web-4-beta.6" }

--- a/chain/telemetry/Cargo.toml
+++ b/chain/telemetry/Cargo.toml
@@ -12,7 +12,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 awc = "3.0.0-beta.5"
 actix-web = { version = "=4.0.0-beta.6", features = [ "openssl" ] }
 futures = "0.3"
-actix = "=0.11.0-beta.2"
+actix = { git = "https://github.com/pmnoxx/actix-patched", rev = "5e170d58e82ac01981c628fd74da1415a88c5275" }
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 tracing = "0.1.13"

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.56.0"
 edition = "2021"
 
 [dependencies]
-actix = "=0.11.0-beta.2"
+actix = { git = "https://github.com/pmnoxx/actix-patched", rev = "5e170d58e82ac01981c628fd74da1415a88c5275" }
 actix-rt = "2"
 borsh = "0.9"
 cached = "0.23"

--- a/nearcore/Cargo.toml
+++ b/nearcore/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.51"
 awc = "3.0.0-beta.5"
-actix = "=0.11.0-beta.2" # Pinned the version to avoid compilation errors
+actix = { git = "https://github.com/pmnoxx/actix-patched", rev = "5e170d58e82ac01981c628fd74da1415a88c5275" }
 actix_derive = "=0.6.0-beta.1" # Pinned dependency in addition to actix dependecy (remove this line once the pinning is not needed)
 actix-web = "=4.0.0-beta.6"
 actix-rt = "2"

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -14,7 +14,7 @@ name = "neard"
 
 [dependencies]
 clap = "=3.0.0-beta.2"
-actix = "=0.11.0-beta.2"
+actix = { git = "https://github.com/pmnoxx/actix-patched", rev = "5e170d58e82ac01981c628fd74da1415a88c5275" }
 tracing = "0.1.13"
 git-version = "0.3.1"
 tracing-subscriber = "0.2.4"

--- a/tools/indexer/example/Cargo.toml
+++ b/tools/indexer/example/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.56.0"
 edition = "2021"
 
 [dependencies]
-actix = "=0.11.0-beta.2"
+actix = { git = "https://github.com/pmnoxx/actix-patched", rev = "5e170d58e82ac01981c628fd74da1415a88c5275" }
 clap = "3.0.0-beta.1"
 openssl-probe = "0.1.2"
 serde_json = "1.0.55"

--- a/utils/near-performance-metrics/Cargo.toml
+++ b/utils/near-performance-metrics/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.56.0"
 publish = false
 
 [dependencies]
-actix = "=0.11.0-beta.2"
+actix = { git = "https://github.com/pmnoxx/actix-patched", rev = "5e170d58e82ac01981c628fd74da1415a88c5275" }
 bitflags = "1.2"
 bytes = "1"
 bytesize = "1.1"

--- a/utils/near-rate-limiter/Cargo.toml
+++ b/utils/near-rate-limiter/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.56.0"
 publish = false
 
 [dependencies]
-actix = "=0.11.0-beta.2"
+actix = { git = "https://github.com/pmnoxx/actix-patched", rev = "5e170d58e82ac01981c628fd74da1415a88c5275" }
 bytes = "1.0.0"
 futures-core = "0.3.0"
 pin-project-lite = "0.2.0"


### PR DESCRIPTION
In this PR, we will start using a patched version of `Actix`, which doesn't block the Actors, when their queues are full, and prints a stack trace every time the queue size is `0 mod 1024`, and `>= 1024`.

This is still WIP, but it's worth trying to see if that fixes the memory issue.