### PR TITLE
Update `near-rust-allocator-proxy ` to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3030,15 +3030,13 @@ dependencies = [
 
 [[package]]
 name = "near-rust-allocator-proxy"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f7efdf6d23964df1003d7784e3c2d99302f28eeeb19e1c19db75a0f886c358"
+checksum = "be44da452581a4f2e7870d86886f50605853943ded9b6a7975495914645cdca4"
 dependencies = [
  "backtrace",
- "libc",
- "log",
  "nix",
- "rand 0.7.3",
+ "tracing",
 ]
 
 [[package]]

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -17,7 +17,7 @@ deepsize = { version = "0.2.0", optional = true }
 futures = "0.3"
 itertools = "0.10.3"
 lru = "0.7.2"
-near-rust-allocator-proxy = { version = "0.3.0", optional = true }
+near-rust-allocator-proxy = { version = "0.4", optional = true }
 once_cell = "1.5.2"
 rand = "0.7"
 serde = { version = "1", features = ["alloc", "derive", "rc"], optional = true }

--- a/chain/network/src/peer/codec.rs
+++ b/chain/network/src/peer/codec.rs
@@ -54,7 +54,7 @@ impl Encoder<Vec<u8>> for Codec {
                 && item.len() + 4 + buf.len() > buf.capacity()
             {
                 #[cfg(feature = "performance_stats")]
-                let tid = near_rust_allocator_proxy::allocator::get_tid();
+                let tid = near_rust_allocator_proxy::get_tid();
                 #[cfg(not(feature = "performance_stats"))]
                 let tid = 0;
                 error!(target: "network", "{} throwing away message, because buffer is full item.len(): {} buf.capacity: {}", 

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -172,7 +172,7 @@ impl PeerActor {
                 let bytes_len = bytes.len();
                 if !self.framed.write(bytes) {
                     #[cfg(feature = "performance_stats")]
-                    let tid = near_rust_allocator_proxy::allocator::get_tid();
+                    let tid = near_rust_allocator_proxy::get_tid();
                     #[cfg(not(feature = "performance_stats"))]
                     let tid = 0;
                     error!(

--- a/nearcore/Cargo.toml
+++ b/nearcore/Cargo.toml
@@ -31,7 +31,7 @@ tokio = { version = "1.1", features = ["fs"] }
 tracing = "0.1.13"
 smart-default = "0.6"
 num-rational = { version = "0.3", features = ["serde"] }
-near-rust-allocator-proxy = { version = "0.3.0", optional = true }
+near-rust-allocator-proxy = { version = "0.4", optional = true }
 lazy-static-include = "3"
 tempfile = "3"
 indicatif = "0.15.0"

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -7,7 +7,7 @@ use actix_rt::ArbiterHandle;
 use actix_web;
 use anyhow::Context;
 #[cfg(feature = "performance_stats")]
-use near_rust_allocator_proxy::allocator::reset_memory_usage_max;
+use near_rust_allocator_proxy::reset_memory_usage_max;
 use tracing::{error, info, trace};
 
 use near_chain::ChainGenesis;

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -19,7 +19,7 @@ tracing = "0.1.13"
 git-version = "0.3.1"
 tracing-subscriber = "0.2.4"
 openssl-probe = "0.1.2"
-near-rust-allocator-proxy = { version = "0.3", optional = true }
+near-rust-allocator-proxy = { version = "0.4", optional = true }
 once_cell = "1.5.2"
 tokio = "1.1"
 futures = "0.3"

--- a/neard/src/main.rs
+++ b/neard/src/main.rs
@@ -6,8 +6,6 @@ use self::cli::NeardCmd;
 use clap::crate_version;
 use git_version::git_version;
 use near_primitives::version::{Version, DB_VERSION, PROTOCOL_VERSION};
-#[cfg(feature = "memory_stats")]
-use near_rust_allocator_proxy::allocator::MyAllocator;
 use nearcore::get_default_home;
 use once_cell::sync::Lazy;
 use std::path::PathBuf;
@@ -34,14 +32,16 @@ static DEFAULT_HOME: Lazy<PathBuf> = Lazy::new(get_default_home);
 
 #[cfg(feature = "memory_stats")]
 #[global_allocator]
-static ALLOC: MyAllocator<tikv_jemallocator::Jemalloc> =
-    MyAllocator::new(tikv_jemallocator::Jemalloc);
+static ALLOC: near_rust_allocator_proxy::ProxyAllocator<tikv_jemallocator::Jemalloc> =
+    near_rust_allocator_proxy::ProxyAllocator::new(tikv_jemallocator::Jemalloc);
 
 #[cfg(all(not(feature = "memory_stats"), feature = "jemalloc"))]
 #[global_allocator]
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 fn main() {
+    #[cfg(feature = "memory_stats")]
+    ALLOC.set_report_usage_interval(512 << 20).enable_stack_trace(true);
     // We use it to automatically search the for root certificates to perform HTTPS calls
     // (sending telemetry and downloading genesis)
     openssl_probe::init_ssl_cert_env_vars();

--- a/utils/near-performance-metrics/Cargo.toml
+++ b/utils/near-performance-metrics/Cargo.toml
@@ -15,7 +15,7 @@ bytesize = "1.1"
 futures = "0.3.5"
 libc = "0.2"
 log = "0.4"
-near-rust-allocator-proxy = { version = "0.3.0", optional = true }
+near-rust-allocator-proxy = { version = "0.4", optional = true }
 once_cell = "1.5.2"
 strum = "0.20"
 tokio = { version = "1.1", features = ["net", "rt-multi-thread"] }

--- a/utils/near-performance-metrics/src/actix_enabled.rs
+++ b/utils/near-performance-metrics/src/actix_enabled.rs
@@ -1,6 +1,6 @@
 use crate::stats_enabled::{get_thread_stats_logger, MyFuture, REF_COUNTER, SLOW_CALL_THRESHOLD};
 use log::warn;
-use near_rust_allocator_proxy::allocator::get_tid;
+use near_rust_allocator_proxy::get_tid;
 use std::panic::Location;
 use std::time::{Duration, Instant};
 

--- a/utils/near-performance-metrics/src/stats_enabled.rs
+++ b/utils/near-performance-metrics/src/stats_enabled.rs
@@ -2,7 +2,7 @@ use bytesize::ByteSize;
 use futures;
 use futures::task::Context;
 use log::{info, warn};
-use near_rust_allocator_proxy::allocator::{
+use near_rust_allocator_proxy::{
     current_thread_memory_usage, current_thread_peak_memory_usage, get_tid, reset_memory_usage_max,
     thread_memory_count, thread_memory_usage, total_memory_usage,
 };


### PR DESCRIPTION
Upgrade `near-rust-allocator-proxy` to `0.4.0`, this version is can be used with `rust-memory-analyzer` (https://crates.io/crates/rust-memory-analyzer)

```shell
cargo build -p neard --features memory_stats

... // start neard 

cargo install rust-memory-analyzer
sudo $(which rust-memory-analyzer) analyze --pid `pidof neard`
```

Same, thing for `indexer-example`.