### PR TITLE
pytest: skip_epoch.py: don't refetch status when printing error msg

### DIFF
--- a/pytest/tests/sanity/skip_epoch.py
+++ b/pytest/tests/sanity/skip_epoch.py
@@ -167,7 +167,8 @@ tx = sign_staking_tx(node2.signer_key, node2.validator_key,
                      base58.b58decode(hash_.encode('utf8')))
 boot_node.send_tx(tx)
 
-assert (get_validators() == set(["test0", "test2", "test3"])), get_validators()
+validators = get_validators()
+assert validators == set(["test0", "test2", "test3"]), validators
 
 while True:
     if time.time() - started > TIMEOUT:


### PR DESCRIPTION
if get_validators() doesn't give what is expected, it's best to print
out the bad output itself. Subsequent calls might give different info