### PR TITLE
re: Disable flunky test `test_file_download`

### DIFF
--- a/integration-tests/src/tests/test_download_file.rs
+++ b/integration-tests/src/tests/test_download_file.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use tokio::sync::Barrier;
 
 #[tokio::test]
+#[ignore]
 async fn test_file_download() {
     let port = portpicker::pick_unused_port().expect("No ports free");
 


### PR DESCRIPTION
This tests keep randomly failing and blocking CI. Let's disable it.

For example:
https://buildkite.com/nearprotocol/nearcore/builds/12506#68bdfc6a-0ab8-475b-8fc2-3dc8c1e5c6f7