### PR TITLE
Fix near-test-contracts build script to work if CARGO_TARGET_DIR is set.

### DIFF
--- a/runtime/near-test-contracts/build.rs
+++ b/runtime/near-test-contracts/build.rs
@@ -32,7 +32,8 @@ fn build_contract(dir: &str, args: &[&str], output: &str) -> io::Result<()> {
     cmd.current_dir(dir);
     check_status(cmd)?;
 
-    let target_dir = shared_target_dir().unwrap_or_else(|| format!("./{}/target", dir).into());
+    let target_dir =
+        Path::new(dir).join(shared_target_dir().unwrap_or(Path::new("target").to_path_buf()));
     fs::copy(
         target_dir.join(format!("wasm32-unknown-unknown/release/{}.wasm", dir.replace('-', "_"))),
         format!("./res/{}.wasm", output),


### PR DESCRIPTION
This will fix the nightly build which in turn will let `nearup` download binaries again.

Tested by running `make nightly-release` with and without `CARGO_TARGET_DIR` environment variable.