### PR TITLE
Make `delay-detector` required, and make it's functionality flag dependent.

### DIFF
--- a/chain/chain/Cargo.toml
+++ b/chain/chain/Cargo.toml
@@ -23,7 +23,7 @@ strum = "0.20"
 thiserror = "1.0"
 tracing = "0.1.13"
 
-delay-detector = { path = "../../tools/delay_detector", optional = true}
+delay-detector = { path = "../../tools/delay_detector"}
 near-chain-configs = { path = "../../core/chain-configs" }
 near-chain-primitives = { path = "../chain-primitives" }
 near-crypto = { path = "../../core/crypto" }
@@ -40,7 +40,7 @@ near-logger-utils = {path = "../../test-utils/logger"}
 byzantine_asserts = []
 expensive_tests = []
 test_features = []
-delay_detector = ["delay-detector"]
+delay_detector = ["delay-detector/delay_detector"]
 no_cache = ["near-store/no_cache"]
 protocol_feature_chunk_only_producers = [
   "near-chain-configs/protocol_feature_chunk_only_producers",

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -64,7 +64,6 @@ use crate::validate::{
 use crate::{byzantine_assert, create_light_client_block_view, Doomslug};
 use crate::{metrics, DoomslugThresholdMode};
 use actix::Message;
-#[cfg(feature = "delay_detector")]
 use delay_detector::DelayDetector;
 use near_primitives::shard_layout::{
     account_id_to_shard_id, account_id_to_shard_uid, ShardLayout, ShardUId,
@@ -773,8 +772,7 @@ impl Chain {
         tries: ShardTries,
         gc_blocks_limit: NumBlocks,
     ) -> Result<(), Error> {
-        #[cfg(feature = "delay_detector")]
-        let _d = DelayDetector::new("GC".into());
+        let _d = DelayDetector::new(|| "GC".into());
 
         let head = self.store.head()?;
         let tail = self.store.tail()?;

--- a/chain/client/Cargo.toml
+++ b/chain/client/Cargo.toml
@@ -39,7 +39,7 @@ near-chunks = { path = "../chunks" }
 near-telemetry = { path = "../telemetry" }
 near-performance-metrics = { path = "../../utils/near-performance-metrics" }
 near-performance-metrics-macros = { path = "../../utils/near-performance-metrics-macros" }
-delay-detector = { path = "../../tools/delay_detector", optional = true }
+delay-detector = { path = "../../tools/delay_detector" }
 near-network-primitives = { path = "../network-primitives" }
 
 [dev-dependencies]
@@ -57,7 +57,7 @@ test_features = [
 delay_detector = [
   "near-chain/delay_detector",
   "near-network/delay_detector",
-  "delay-detector",
+  "delay-detector/delay_detector",
 ]
 protocol_feature_chunk_only_producers = [
   "near-primitives/protocol_feature_chunk_only_producers",

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -239,10 +239,9 @@ impl Handler<NetworkClientMessages> for ClientActor {
 
     #[perf_with_debug]
     fn handle(&mut self, msg: NetworkClientMessages, ctx: &mut Context<Self>) -> Self::Result {
-        #[cfg(feature = "delay_detector")]
-        let _d = delay_detector::DelayDetector::new(
-            format!("NetworkClientMessage {}", msg.as_ref()).into(),
-        );
+        let _d = delay_detector::DelayDetector::new(|| {
+            format!("NetworkClientMessage {}", msg.as_ref()).into()
+        });
         self.check_triggers(ctx);
 
         match msg {
@@ -605,8 +604,7 @@ impl Handler<Status> for ClientActor {
 
     #[perf]
     fn handle(&mut self, msg: Status, ctx: &mut Context<Self>) -> Self::Result {
-        #[cfg(feature = "delay_detector")]
-        let _d = delay_detector::DelayDetector::new("client status".to_string().into());
+        let _d = delay_detector::DelayDetector::new(|| "client status".into());
         self.check_triggers(ctx);
 
         let head = self.client.chain.head()?;
@@ -688,8 +686,7 @@ impl Handler<GetNetworkInfo> for ClientActor {
 
     #[perf]
     fn handle(&mut self, _msg: GetNetworkInfo, ctx: &mut Context<Self>) -> Self::Result {
-        #[cfg(feature = "delay_detector")]
-        let _d = delay_detector::DelayDetector::new("client get network info".into());
+        let _d = delay_detector::DelayDetector::new(|| "client get network info".into());
         self.check_triggers(ctx);
 
         Ok(NetworkInfoResponse {
@@ -839,8 +836,7 @@ impl ClientActor {
         // will prioritize processing messages until mailbox is empty. Execution of any other task
         // scheduled with run_later will be delayed.
 
-        #[cfg(feature = "delay_detector")]
-        let _d = delay_detector::DelayDetector::new("client triggers".into());
+        let _d = delay_detector::DelayDetector::new(|| "client triggers".into());
 
         let mut delay = Duration::from_secs(1);
         let now = Utc::now();
@@ -1246,8 +1242,7 @@ impl ClientActor {
     /// Runs catchup on repeat, if this client is a validator.
     /// Schedules itself again if it was not ran as response to state parts job result
     fn catchup(&mut self, ctx: &mut Context<ClientActor>) {
-        #[cfg(feature = "delay_detector")]
-        let _d = delay_detector::DelayDetector::new("client catchup".into());
+        let _d = delay_detector::DelayDetector::new(|| "client catchup".into());
         match self.client.run_catchup(
             &self.network_info.highest_height_peers,
             &self.state_parts_task_scheduler,
@@ -1295,8 +1290,7 @@ impl ClientActor {
     /// Runs itself iff it was not ran as reaction for message with results of
     /// finishing state part job
     fn sync(&mut self, ctx: &mut Context<ClientActor>) {
-        #[cfg(feature = "delay_detector")]
-        let _d = delay_detector::DelayDetector::new("client sync".into());
+        let _d = delay_detector::DelayDetector::new(|| "client sync".into());
         // Macro to schedule to call this function later if error occurred.
         macro_rules! unwrap_or_run_later (($obj: expr) => (match $obj {
             Ok(v) => v,
@@ -1468,8 +1462,7 @@ impl ClientActor {
             ctx,
             self.client.config.log_summary_period,
             move |act, ctx| {
-                #[cfg(feature = "delay_detector")]
-                let _d = delay_detector::DelayDetector::new("client log summary".into());
+                let _d = delay_detector::DelayDetector::new(|| "client log summary".into());
                 let is_syncing = act.client.sync_status.is_syncing();
                 let head = unwrap_or_return!(act.client.chain.head(), act.log_summary(ctx));
                 let validator_info = if !is_syncing {

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -27,7 +27,7 @@ tokio-util = { version = "0.6", features = ["codec"] }
 tokio = { version = "1.1", features = ["net", "rt-multi-thread"] }
 tracing = "0.1.13"
 
-delay-detector = { path = "../../tools/delay_detector", optional = true }
+delay-detector = { path = "../../tools/delay_detector" }
 near-crypto = { path = "../../core/crypto" }
 near-metrics = { path = "../../core/metrics" }
 near-network-primitives = { path = "../network-primitives" }
@@ -49,7 +49,7 @@ deepsize_feature = [
     "near-network-primitives/deepsize_feature",
     "near-primitives/deepsize_feature",
 ]
-delay_detector = ["delay-detector"]
+delay_detector = ["delay-detector/delay_detector"]
 performance_stats = [
     "near-performance-metrics/performance_stats",
     "near-rust-allocator-proxy",

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -1010,8 +1010,7 @@ impl Handler<SendMessage> for PeerActor {
 
     #[perf]
     fn handle(&mut self, msg: SendMessage, _: &mut Self::Context) {
-        #[cfg(feature = "delay_detector")]
-        let _d = delay_detector::DelayDetector::new("send message".into());
+        let _d = delay_detector::DelayDetector::new(|| "send message".into());
         self.send_message(&msg.message);
     }
 }
@@ -1021,8 +1020,7 @@ impl Handler<Arc<SendMessage>> for PeerActor {
 
     #[perf]
     fn handle(&mut self, msg: Arc<SendMessage>, _: &mut Self::Context) {
-        #[cfg(feature = "delay_detector")]
-        let _d = delay_detector::DelayDetector::new("send message".into());
+        let _d = delay_detector::DelayDetector::new(|| "send message".into());
         self.send_message(&msg.as_ref().message);
     }
 }
@@ -1032,8 +1030,7 @@ impl Handler<QueryPeerStats> for PeerActor {
 
     #[perf]
     fn handle(&mut self, _msg: QueryPeerStats, _: &mut Self::Context) -> Self::Result {
-        #[cfg(feature = "delay_detector")]
-        let _d = delay_detector::DelayDetector::new("query peer stats".into());
+        let _d = delay_detector::DelayDetector::new(|| "query peer stats".into());
 
         // TODO(#5218) Refactor this code to use `SystemTime`
         let now = Instant::now();
@@ -1061,9 +1058,8 @@ impl Handler<PeerManagerRequest> for PeerActor {
 
     #[perf]
     fn handle(&mut self, msg: PeerManagerRequest, ctx: &mut Self::Context) -> Self::Result {
-        #[cfg(feature = "delay_detector")]
         let _d =
-            delay_detector::DelayDetector::new(format!("peer manager request {:?}", msg).into());
+            delay_detector::DelayDetector::new(|| format!("peer manager request {:?}", msg).into());
         match msg {
             PeerManagerRequest::BanPeer(ban_reason) => {
                 self.ban_peer(ctx, ban_reason);

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -257,8 +257,7 @@ impl RoutingTableActor {
 
     /// Recalculate routing table and update list of reachable peers.
     pub fn recalculate_routing_table(&mut self) {
-        #[cfg(feature = "delay_detector")]
-        let _d = delay_detector::DelayDetector::new("routing table update".into());
+        let _d = delay_detector::DelayDetector::new(|| "routing table update".into());
         let _routing_table_recalculation =
             metrics::ROUTING_TABLE_RECALCULATION_HISTOGRAM.start_timer();
 
@@ -288,8 +287,7 @@ impl RoutingTableActor {
             return Vec::new();
         }
 
-        #[cfg(feature = "delay_detector")]
-        let _d = delay_detector::DelayDetector::new("pruning edges".into());
+        let _d = delay_detector::DelayDetector::new(|| "pruning edges".into());
 
         let edges_to_remove = self.prune_unreachable_edges_and_save_to_db(
             prune == Prune::Now,

--- a/nearcore/Cargo.toml
+++ b/nearcore/Cargo.toml
@@ -55,7 +55,7 @@ near-performance-metrics = { path = "../utils/near-performance-metrics" }
 near-vm-runner = { path = "../runtime/near-vm-runner"}
 near-network-primitives = { path = "../chain/network-primitives" }
 
-delay-detector = { path = "../tools/delay_detector", optional = true }
+delay-detector = { path = "../tools/delay_detector" }
 
 [dev-dependencies]
 near-logger-utils = { path = "../test-utils/logger" }
@@ -90,7 +90,7 @@ no_cache = [
   "near-chain/no_cache",
   "near-epoch-manager/no_cache",
 ]
-delay_detector = ["near-client/delay_detector"]
+delay_detector = ["near-client/delay_detector", "delay-detector/delay_detector"]
 rosetta_rpc = ["near-rosetta-rpc"]
 json_rpc = ["near-jsonrpc"]
 protocol_feature_alt_bn128 = [

--- a/tools/delay_detector/Cargo.toml
+++ b/tools/delay_detector/Cargo.toml
@@ -10,3 +10,6 @@ edition = "2021"
 [dependencies]
 tracing = "0.1.13"
 cpu-time = "1.0"
+
+[features]
+delay_detector = []

--- a/tools/delay_detector/src/lib.rs
+++ b/tools/delay_detector/src/lib.rs
@@ -1,76 +1,96 @@
-use cpu_time::ProcessTime;
-use std::borrow::Cow;
-use std::time::{Duration, Instant};
-use tracing::{info, warn};
+#[cfg(not(feature = "delay_detector"))]
+pub use disabled::DelayDetector;
+#[cfg(feature = "delay_detector")]
+pub use enabled::DelayDetector;
 
-struct Snapshot {
-    real_time: Duration,
-    cpu_time: Duration,
-}
+#[cfg(not(feature = "delay_detector"))]
+mod disabled {
+    use std::borrow::Cow;
+    pub struct DelayDetector {}
 
-struct SnapshotInstant {
-    real_time: Instant,
-    cpu_time: ProcessTime,
-}
-
-pub struct DelayDetector<'a> {
-    min_delay: Duration,
-    msg: Cow<'a, str>,
-    started: Instant,
-    started_cpu_time: ProcessTime,
-    snapshots: Vec<((String, String), Snapshot)>,
-    last_snapshot: Option<(String, SnapshotInstant)>,
-}
-
-impl<'a> DelayDetector<'a> {
-    pub fn new(msg: Cow<'a, str>) -> Self {
-        Self {
-            msg,
-            started: Instant::now(),
-            started_cpu_time: ProcessTime::now(),
-            snapshots: vec![],
-            last_snapshot: None,
-            min_delay: Duration::from_millis(50),
+    impl DelayDetector {
+        pub fn new<'a>(_msg: impl FnOnce() -> Cow<'a, str>) -> Self {
+            Self {}
         }
     }
-
-    pub fn min_delay(mut self, min_delay: Duration) -> Self {
-        self.min_delay = min_delay;
-        self
-    }
-
-    pub fn snapshot(&mut self, msg: &str) {
-        let now = Instant::now();
-        let cpu_time = ProcessTime::now();
-        if let Some((s, started)) = self.last_snapshot.take() {
-            self.snapshots.push((
-                (s, msg.to_string()),
-                Snapshot {
-                    real_time: now - started.real_time,
-                    cpu_time: started.cpu_time.elapsed(),
-                },
-            ));
-        }
-        self.last_snapshot = Some((msg.to_string(), SnapshotInstant { real_time: now, cpu_time }));
-    }
 }
 
-impl<'a> Drop for DelayDetector<'a> {
-    fn drop(&mut self) {
-        let elapsed = self.started_cpu_time.elapsed();
-        let elapsed_real = self.started.elapsed();
-        let long_delay = self.min_delay * 10;
-        if self.min_delay < elapsed && elapsed <= long_delay {
-            info!(target: "delay_detector", "Took {:?} cpu_time, {:?} real_time processing {}", elapsed, elapsed_real, self.msg);
-        }
-        if elapsed > long_delay {
-            warn!(target: "delay_detector", "LONG DELAY! Took {:?} cpu_time, {:?} real_time processing {}", elapsed, elapsed_real, self.msg);
-            if self.last_snapshot.is_some() {
-                self.snapshot("end");
+#[cfg(feature = "delay_detector")]
+mod enabled {
+    use cpu_time::ProcessTime;
+    use std::borrow::Cow;
+    use std::time::{Duration, Instant};
+    use tracing::{info, warn};
+    struct Snapshot {
+        real_time: Duration,
+        cpu_time: Duration,
+    }
+
+    struct SnapshotInstant {
+        real_time: Instant,
+        cpu_time: ProcessTime,
+    }
+
+    pub struct DelayDetector<'a> {
+        min_delay: Duration,
+        msg: Cow<'a, str>,
+        started: Instant,
+        started_cpu_time: ProcessTime,
+        snapshots: Vec<((String, String), Snapshot)>,
+        last_snapshot: Option<(String, SnapshotInstant)>,
+    }
+
+    impl<'a> DelayDetector<'a> {
+        pub fn new(msg: impl FnOnce() -> Cow<'a, str>) -> Self {
+            Self {
+                msg: msg(),
+                started: Instant::now(),
+                started_cpu_time: ProcessTime::now(),
+                snapshots: vec![],
+                last_snapshot: None,
+                min_delay: Duration::from_millis(50),
             }
-            self.snapshots.sort_by(|a, b| b.1.cpu_time.cmp(&a.1.cpu_time));
-            for ((s1, s2), Snapshot { cpu_time, real_time }) in self.snapshots.drain(..) {
-                info!(target: "delay_detector", "Took {:?} cpu_time, {:?} real_time between {} and {}", cpu_time, real_time, s1, s2);
+        }
+
+        pub fn min_delay(mut self, min_delay: Duration) -> Self {
+            self.min_delay = min_delay;
+            self
+        }
+
+        pub fn snapshot(&mut self, msg: &str) {
+            let now = Instant::now();
+            let cpu_time = ProcessTime::now();
+            if let Some((s, started)) = self.last_snapshot.take() {
+                self.snapshots.push((
+                    (s, msg.to_string()),
+                    Snapshot {
+                        real_time: now - started.real_time,
+                        cpu_time: started.cpu_time.elapsed(),
+                    },
+                ));
+            }
+            self.last_snapshot =
+                Some((msg.to_string(), SnapshotInstant { real_time: now, cpu_time }));
+        }
+    }
+
+    impl<'a> Drop for DelayDetector<'a> {
+        fn drop(&mut self) {
+            let elapsed = self.started_cpu_time.elapsed();
+            let elapsed_real = self.started.elapsed();
+            let long_delay = self.min_delay * 10;
+            if self.min_delay < elapsed && elapsed <= long_delay {
+                info!(target: "delay_detector", "Took {:?} cpu_time, {:?} real_time processing {}", elapsed, elapsed_real, self.msg);
+            }
+            if elapsed > long_delay {
+                warn!(target: "delay_detector", "LONG DELAY! Took {:?} cpu_time, {:?} real_time processing {}", elapsed, elapsed_real, self.msg);
+                if self.last_snapshot.is_some() {
+                    self.snapshot("end");
+                }
+                self.snapshots.sort_by(|a, b| b.1.cpu_time.cmp(&a.1.cpu_time));
+                for ((s1, s2), Snapshot { cpu_time, real_time }) in self.snapshots.drain(..) {
+                    info!(target: "delay_detector", "Took {:?} cpu_time, {:?} real_time between {} and {}", cpu_time, real_time, s1, s2);
+                }
             }
         }
     }


### PR DESCRIPTION
We can get rid of conditional imports from our code by making `delay-detected` a required dependency. However, it's functionality will be put under `delay_detector` flag.