### PR TITLE
bug: Change the way listening on port happens for `PeerManagerActor`

### DIFF
--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -209,6 +209,9 @@ impl Actor for PeerManagerActor {
                                 ),
                             );
                             debug!(target: "network", from = ?client_addr, "got new connection");
+                        } else {
+                            info!(at = ?server_addr, "Stopping listening");
+                            break;
                         }
                     },
                     Err(e) => {

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -210,7 +210,7 @@ impl Actor for PeerManagerActor {
                             );
                             debug!(target: "network", from = ?client_addr, "got new connection");
                         } else {
-                            info!(at = ?server_addr, "Stopping listening");
+                            debug!(at = ?server_addr, "stopping listening");
                             break;
                         }
                     },


### PR DESCRIPTION
According to the official documentation in tokio https://docs.rs/tokio/latest/tokio/net/struct.TcpListener.html
You are supposed to stop the `loop` on the first error inside `listener.accept()` loop.

Let's change our code, to follow the official guidelines.