### PR TITLE
feat: Make jsonrpc-primitives types derive `Debug`

### DIFF
--- a/chain/jsonrpc-primitives/src/types/chunks.rs
+++ b/chain/jsonrpc-primitives/src/types/chunks.rs
@@ -13,13 +13,13 @@ pub enum ChunkReference {
     },
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct RpcChunkRequest {
     #[serde(flatten)]
     pub chunk_reference: ChunkReference,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct RpcChunkResponse {
     #[serde(flatten)]
     pub chunk_view: near_primitives::views::ChunkView,

--- a/chain/jsonrpc-primitives/src/types/config.rs
+++ b/chain/jsonrpc-primitives/src/types/config.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct RpcProtocolConfigRequest {
     #[serde(flatten)]
     pub block_reference: near_primitives::types::BlockReference,
@@ -16,7 +16,7 @@ impl RpcProtocolConfigRequest {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct RpcProtocolConfigResponse {
     #[serde(flatten)]
     pub config_view: near_chain_configs::ProtocolConfigView,

--- a/chain/jsonrpc-primitives/src/types/gas_price.rs
+++ b/chain/jsonrpc-primitives/src/types/gas_price.rs
@@ -3,13 +3,13 @@ use near_primitives::types::MaybeBlockId;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct RpcGasPriceRequest {
     #[serde(flatten)]
     pub block_id: MaybeBlockId,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct RpcGasPriceResponse {
     #[serde(flatten)]
     pub gas_price_view: near_primitives::views::GasPriceView,

--- a/chain/jsonrpc-primitives/src/types/query.rs
+++ b/chain/jsonrpc-primitives/src/types/query.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 /// Max size of the query path (soft-deprecated)
 const QUERY_DATA_MAX_SIZE: usize = 10 * 1024;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct RpcQueryRequest {
     #[serde(flatten)]
     pub block_reference: near_primitives::types::BlockReference,
@@ -63,7 +63,7 @@ pub enum RpcQueryError {
     InternalError { error_message: String },
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct RpcQueryResponse {
     #[serde(flatten)]
     pub kind: QueryResponseKind,

--- a/chain/jsonrpc-primitives/src/types/receipts.rs
+++ b/chain/jsonrpc-primitives/src/types/receipts.rs
@@ -6,13 +6,13 @@ pub struct ReceiptReference {
     pub receipt_id: near_primitives::hash::CryptoHash,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct RpcReceiptRequest {
     #[serde(flatten)]
     pub receipt_reference: ReceiptReference,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct RpcReceiptResponse {
     #[serde(flatten)]
     pub receipt_view: near_primitives::views::ReceiptView,

--- a/chain/jsonrpc-primitives/src/types/sandbox.rs
+++ b/chain/jsonrpc-primitives/src/types/sandbox.rs
@@ -2,7 +2,7 @@ use near_primitives::state_record::StateRecord;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 pub struct RpcSandboxPatchStateRequest {
     pub records: Vec<StateRecord>,
 }
@@ -13,7 +13,7 @@ impl RpcSandboxPatchStateRequest {
     }
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 pub struct RpcSandboxPatchStateResponse {}
 
 #[derive(thiserror::Error, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
This PR just adds `Debug` derivations to all jsonrpc-primitives types as we need them to be able to print RPC debug logs in [workspaces-rs](https://github.com/near/workspaces-rs).