### PR TITLE
Update to wasmer-near 2.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5517,9 +5517,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-near"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2992fc265c0207ea423d6565a27adf1a01210eae4bb4db7aa18778a2b84f588d"
+checksum = "c11074b5b8f4170b5ebf0744e811728befb01a70757395c43b528b6441e9c924"
 dependencies = [
  "enumset",
  "loupe",
@@ -5536,9 +5536,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass-near"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d821094fe6e9371d528c27b0006de76b1411cf5341d7b56b1b78bf0809119313"
+checksum = "c95dc7a193f0b607ce19c3a71418ea0d325696087a53755b4610b5b5b02b335b"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -5556,9 +5556,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-near"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3234ef4ddd114bf4cf77b3b719d9c8727372cf05ec79d574ba447b169438eb9f"
+checksum = "55090b4c4cffc8460478fa0b0355d81044750655986a8be93e769f9df3caa6bf"
 dependencies = [
  "backtrace",
  "enumset",
@@ -5578,9 +5578,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal-near"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e12a0d35b4ed05e8c881a6e04c4f5c0e66ed11a42e8a9b012482c7d0d92231"
+checksum = "37d2a5c1153cf6d9441e3d05101559071a3fb7f44e343f398d5ec89f2f5748f4"
 dependencies = [
  "cfg-if 1.0.0",
  "enumset",
@@ -5661,9 +5661,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types-near"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bced21cd7e4b8a35ff58e19645000b9097ed81febba790900031c32553009464"
+checksum = "b4fae5b0041c76c1b114b3286503a54d42c38eb88146724919b5610c66ecd548"
 dependencies = [
  "indexmap",
  "loupe",
@@ -5674,9 +5674,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm-near"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d6848605c8cc6821314f9099a34c7163ee56e82524ebb9080b82baa3895d257"
+checksum = "db06e0c8e20945000c075237f1b5afb682bf80e2bec875ed9b9a633ef41960c7"
 dependencies = [
  "backtrace",
  "cc",

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -27,12 +27,12 @@ memoffset = "0.6"
 # wasmer-compiler-singlepass = { package = "wasmer-compiler-singlepass-near", git = "https://github.com/near/wasmer", branch = "near-main", optional = true }
 # wasmer-engine-universal = { package = "wasmer-engine-universal-near", git = "https://github.com/near/wasmer", branch = "near-main", optional = true }
 # wasmer-vm = { package = "wasmer-vm-near", git = "https://github.com/near/wasmer", branch = "near-main" }
-wasmer-compiler = { package = "wasmer-compiler-near", version = "=2.1.2", optional = true }
-wasmer-compiler-singlepass = { package = "wasmer-compiler-singlepass-near", version = "=2.1.2", optional = true }
-wasmer-engine = { package = "wasmer-engine-near", version = "=2.1.2", optional = true }
-wasmer-engine-universal = { package = "wasmer-engine-universal-near", version = "=2.1.2", optional = true, features = ["compiler"] }
-wasmer-types = { package = "wasmer-types-near", version = "=2.1.2", optional = true }
-wasmer-vm = { package = "wasmer-vm-near", version = "=2.1.2", optional = true }
+wasmer-compiler = { package = "wasmer-compiler-near", version = "=2.2.0", optional = true }
+wasmer-compiler-singlepass = { package = "wasmer-compiler-singlepass-near", version = "=2.2.0", optional = true }
+wasmer-engine = { package = "wasmer-engine-near", version = "=2.2.0", optional = true }
+wasmer-engine-universal = { package = "wasmer-engine-universal-near", version = "=2.2.0", optional = true, features = ["compiler"] }
+wasmer-types = { package = "wasmer-types-near", version = "=2.2.0", optional = true }
+wasmer-vm = { package = "wasmer-vm-near", version = "=2.2.0", optional = true }
 
 loupe = "0.1"
 once_cell = "1.5.2"

--- a/runtime/near-vm-runner/src/tests/cache.rs
+++ b/runtime/near-vm-runner/src/tests/cache.rs
@@ -107,7 +107,7 @@ fn test_wasmer2_artifact_output_stability() {
     let artifact = vm.compile_uncached(&prepared_code).unwrap();
     let serialized = artifact.artifact().serialize().unwrap();
     serialized.hash(&mut hasher);
-    assert_eq!(hasher.finish(), 18352148442716835594, "WASMER2_CONFIG needs version change");
+    assert_eq!(hasher.finish(), 16203733374745522118, "WASMER2_CONFIG needs version change");
 }
 
 /// [`CompiledContractCache`] which simulates failures in the underlying

--- a/runtime/near-vm-runner/src/wasmer2_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer2_runner.rs
@@ -231,7 +231,7 @@ impl Wasmer2Config {
 //  major version << 6
 //  minor version
 const WASMER2_CONFIG: Wasmer2Config = Wasmer2Config {
-    seed: (1 << 10) | (5 << 6) | 0,
+    seed: (1 << 10) | (6 << 6) | 0,
     engine: WasmerEngine::Universal,
     compiler: WasmerCompiler::Singlepass,
 };

--- a/runtime/near-vm-runner/src/wasmer2_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer2_runner.rs
@@ -373,7 +373,7 @@ impl Wasmer2VM {
                         // expected layout. `gas` remains dereferenceable throughout this function
                         // by the virtue of it being contained within `import` which lives for the
                         // entirety of this function.
-                        InstanceConfig::new_with_counter(gas),
+                        InstanceConfig::default().with_counter(gas),
                     )
                     .map_err(|err| translate_instantiation_error(err, import.vmlogic))?;
                 // SAFETY: being called immediately after instantiation.


### PR DESCRIPTION
This pulls in a fair amount of development that has occurred in the fork
over the past couple weeks.

Most notably it has a fix for a crash, functionality to simplify
profiling of the code generated by JIT, a stack limiting safeguard, and
a removal of baked in CPU capability checks at instantiation time, 
thus allowing cost estimation work again.

cc @jakmeier @olonho 