### PR TITLE
chore: update crates to use single hashbrown version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ dependencies = [
  "actix-service",
  "actix-tls",
  "actix-utils",
- "ahash 0.7.6",
+ "ahash",
  "base64 0.13.0",
  "bitflags",
  "brotli2",
@@ -205,7 +205,7 @@ dependencies = [
  "actix-tls",
  "actix-utils",
  "actix-web-codegen",
- "ahash 0.7.6",
+ "ahash",
  "bytes",
  "cookie",
  "derive_more",
@@ -265,12 +265,6 @@ name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
-name = "ahash"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
 
 [[package]]
 name = "ahash"
@@ -538,45 +532,22 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "borsh"
-version = "0.8.2"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a7111f797cc721407885a323fb071636aee57f750b1a4ddc27397eba168a74"
+checksum = "4c9d0958efb8301e1626692ea879cbff622ef45cf731807ec8d488b34be98cb8"
 dependencies = [
- "borsh-derive 0.8.2",
- "hashbrown 0.9.1",
-]
-
-[[package]]
-name = "borsh"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dda7dc709193c0d86a1a51050a926dc3df1cf262ec46a23a25dba421ea1924"
-dependencies = [
- "borsh-derive 0.9.1",
- "hashbrown 0.9.1",
+ "borsh-derive",
+ "hashbrown",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "0.8.2"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307f3740906bac2c118a8122fe22681232b244f1369273e45f1156b45c43d2dd"
+checksum = "325164710ad57bae6d32455ce3bd384f95768464a927ce145626dc3390a7f9fe"
 dependencies = [
- "borsh-derive-internal 0.8.2",
- "borsh-schema-derive-internal 0.8.2",
- "proc-macro-crate 0.1.5",
- "proc-macro2",
- "syn",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "684155372435f578c0fa1acd13ebbb182cc19d6b38b64ae7901da4393217d264"
-dependencies = [
- "borsh-derive-internal 0.9.1",
- "borsh-schema-derive-internal 0.9.1",
+ "borsh-derive-internal",
+ "borsh-schema-derive-internal",
  "proc-macro-crate 0.1.5",
  "proc-macro2",
  "syn",
@@ -584,20 +555,9 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive-internal"
-version = "0.8.2"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2104c73179359431cc98e016998f2f23bc7a05bc53e79741bcba705f30047bc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "borsh-derive-internal"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2102f62f8b6d3edeab871830782285b64cc1830168094db05c8e458f209bc5c3"
+checksum = "f74159f43b231f4af8c4ce4967fef76e4e59725acf51706ddb9268c94348d15c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -606,20 +566,9 @@ dependencies = [
 
 [[package]]
 name = "borsh-schema-derive-internal"
-version = "0.8.2"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae29eb8418fcd46f723f8691a2ac06857d31179d33d2f2d91eb13967de97c728"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "borsh-schema-derive-internal"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196c978c4c9b0b142d446ef3240690bf5a8a33497074a113ff9a337ccb750483"
+checksum = "99b2a77771907a820a860d200d193a0787c79a7890c8e253c462fa0f51ad58b6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1695,7 +1644,7 @@ dependencies = [
 name = "genesis-populate"
 version = "0.0.0"
 dependencies = [
- "borsh 0.9.1",
+ "borsh",
  "clap 2.33.3",
  "indicatif",
  "near-chain",
@@ -1790,20 +1739,11 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
-dependencies = [
- "ahash 0.4.7",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash 0.7.6",
+ "ahash",
 ]
 
 [[package]]
@@ -1998,12 +1938,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg 1.0.1",
- "hashbrown 0.9.1",
+ "hashbrown",
  "serde",
 ]
 
@@ -2052,7 +1992,7 @@ dependencies = [
  "actix-rt",
  "assert_matches",
  "base64 0.11.0",
- "borsh 0.9.1",
+ "borsh",
  "chrono",
  "futures",
  "hex",
@@ -2298,11 +2238,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.6.5"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f374d42cdfc1d7dbf3d3dec28afab2eb97ffbf43a3234d795b5986dbf4b90ba"
+checksum = "274353858935c992b13c0ca408752e2121da852d07dec7ce5f108c77dfa14d1f"
 dependencies = [
- "hashbrown 0.9.1",
+ "hashbrown",
 ]
 
 [[package]]
@@ -2450,7 +2390,7 @@ dependencies = [
 name = "near-account-id"
 version = "0.0.0"
 dependencies = [
- "borsh 0.9.1",
+ "borsh",
  "deepsize",
  "serde",
  "serde_json",
@@ -2460,7 +2400,7 @@ dependencies = [
 name = "near-account-id-fuzz"
 version = "0.0.0"
 dependencies = [
- "borsh 0.9.1",
+ "borsh",
  "libfuzzer-sys",
  "near-account-id",
  "serde_json",
@@ -2488,7 +2428,7 @@ name = "near-chain"
 version = "0.0.0"
 dependencies = [
  "actix",
- "borsh 0.9.1",
+ "borsh",
  "chrono",
  "delay-detector",
  "failure",
@@ -2547,7 +2487,7 @@ name = "near-chunks"
 version = "0.0.0"
 dependencies = [
  "actix",
- "borsh 0.9.1",
+ "borsh",
  "chrono",
  "futures",
  "log",
@@ -2579,7 +2519,7 @@ dependencies = [
  "actix",
  "actix-rt",
  "ansi_term 0.12.1",
- "borsh 0.9.1",
+ "borsh",
  "chrono",
  "delay-detector",
  "futures",
@@ -2633,7 +2573,7 @@ version = "0.0.0"
 dependencies = [
  "arrayref",
  "blake2",
- "borsh 0.9.1",
+ "borsh",
  "bs58",
  "c2-chacha",
  "curve25519-dalek",
@@ -2659,7 +2599,7 @@ dependencies = [
 name = "near-epoch-manager"
 version = "0.0.0"
 dependencies = [
- "borsh 0.9.1",
+ "borsh",
  "chrono",
  "log",
  "lru",
@@ -2798,7 +2738,7 @@ version = "0.0.0"
 dependencies = [
  "actix",
  "awc",
- "borsh 0.9.1",
+ "borsh",
  "futures",
  "near-actix-test-utils",
  "near-chain-configs",
@@ -2837,7 +2777,7 @@ version = "0.0.0"
 dependencies = [
  "actix",
  "bencher",
- "borsh 0.9.1",
+ "borsh",
  "bytes",
  "bytesize",
  "conqueue",
@@ -2873,7 +2813,7 @@ version = "0.0.0"
 dependencies = [
  "actix",
  "anyhow",
- "borsh 0.9.1",
+ "borsh",
  "chrono",
  "deepsize",
  "near-crypto",
@@ -2914,7 +2854,7 @@ dependencies = [
 name = "near-pool"
 version = "0.0.0"
 dependencies = [
- "borsh 0.9.1",
+ "borsh",
  "near-crypto",
  "near-metrics",
  "near-primitives",
@@ -2927,7 +2867,7 @@ name = "near-primitives"
 version = "0.0.0"
 dependencies = [
  "bencher",
- "borsh 0.9.1",
+ "borsh",
  "byteorder",
  "bytesize",
  "chrono",
@@ -2953,7 +2893,7 @@ name = "near-primitives-core"
 version = "0.0.0"
 dependencies = [
  "base64 0.11.0",
- "borsh 0.9.1",
+ "borsh",
  "bs58",
  "deepsize",
  "derive_more",
@@ -3049,7 +2989,7 @@ name = "near-store"
 version = "0.0.0"
 dependencies = [
  "bencher",
- "borsh 0.9.1",
+ "borsh",
  "byteorder",
  "bytesize",
  "derive_more",
@@ -3096,7 +3036,7 @@ dependencies = [
 name = "near-vm-errors"
 version = "0.0.0"
 dependencies = [
- "borsh 0.9.1",
+ "borsh",
  "deepsize",
  "near-account-id",
  "near-rpc-error-macro",
@@ -3108,7 +3048,7 @@ name = "near-vm-logic"
 version = "0.0.0"
 dependencies = [
  "base64 0.13.0",
- "borsh 0.9.1",
+ "borsh",
  "bs58",
  "byteorder",
  "hex",
@@ -3132,7 +3072,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "base64 0.13.0",
- "borsh 0.9.1",
+ "borsh",
  "loupe",
  "memoffset",
  "near-cache",
@@ -3203,7 +3143,7 @@ dependencies = [
  "actix_derive",
  "anyhow",
  "awc",
- "borsh 0.9.1",
+ "borsh",
  "byteorder",
  "chrono",
  "delay-detector",
@@ -3291,7 +3231,7 @@ version = "0.0.0"
 dependencies = [
  "assert_matches",
  "base64 0.11.0",
- "borsh 0.9.1",
+ "borsh",
  "byteorder",
  "hex",
  "indicatif",
@@ -4247,7 +4187,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66bf572c17c77322f4d858c214def56b13a3c32b8d833cd6d28a92de8325ac5f"
 dependencies = [
  "bytecheck",
- "hashbrown 0.11.2",
+ "hashbrown",
  "ptr_meta",
  "rend",
  "rkyv_derive",
@@ -4280,7 +4220,7 @@ name = "runtime-params-estimator"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "borsh 0.9.1",
+ "borsh",
  "bytesize",
  "cfg-if 1.0.0",
  "chrono",
@@ -4694,7 +4634,7 @@ version = "0.0.0"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",
- "borsh 0.9.1",
+ "borsh",
  "clap 3.0.0-beta.2",
  "near-chain",
  "near-chain-configs",
@@ -5604,7 +5544,7 @@ checksum = "2cf26de331c8ef4257bef33649b4665535b105c927ab2e00715f17891362efe8"
 dependencies = [
  "bincode",
  "blake3",
- "borsh 0.9.1",
+ "borsh",
  "cc",
  "digest 0.8.1",
  "errno",
@@ -5647,7 +5587,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6edd0ba6c0bcf9b279186d4dbe81649dda3e5ef38f586865943de4dcd653f8"
 dependencies = [
  "bincode",
- "borsh 0.9.1",
+ "borsh",
  "byteorder",
  "dynasm",
  "dynasmrt",
@@ -5946,11 +5886,11 @@ dependencies = [
 
 [[package]]
 name = "zeropool-bn"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756e713befb81061c2eb8ad800c9c41ddfa2bbf4ea58da637aff31d47b937bf2"
+checksum = "71e61de68ede9ffdd69c01664f65a178c5188b73f78faa21f0936016a888ff7c"
 dependencies = [
- "borsh 0.8.2",
+ "borsh",
  "byteorder",
  "crunchy",
  "lazy_static",

--- a/chain/chain/Cargo.toml
+++ b/chain/chain/Cargo.toml
@@ -14,7 +14,7 @@ chrono = { version = "0.4.4", features = ["serde"] }
 failure = "0.1"
 failure_derive = "0.1"
 itertools = "0.10.0"
-lru = "0.6.5"
+lru = "0.7.2"
 num-rational = "0.3"
 once_cell = "1.5.2"
 rand = "0.7"

--- a/chain/chunks/Cargo.toml
+++ b/chain/chunks/Cargo.toml
@@ -14,7 +14,7 @@ rand = "0.7"
 chrono = "0.4.6"
 log = "0.4"
 borsh = "0.9"
-lru = "0.6.5"
+lru = "0.7.2"
 reed-solomon-erasure = "4"
 
 near-crypto = { path = "../../core/crypto" }

--- a/chain/client/Cargo.toml
+++ b/chain/client/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = "1"
 # Temporary workaround, fix with rust toolchain update.
 sysinfo = { git = "https://github.com/near/sysinfo", rev = "3cb97ee79a02754407d2f0f63628f247d7c65e7b" }
 strum = { version = "0.20", features = ["derive"] }
-lru = "0.6.5"
+lru = "0.7.2"
 once_cell = "1.5.2"
 borsh = "0.9"
 reed-solomon-erasure = "4"

--- a/chain/epoch_manager/Cargo.toml
+++ b/chain/epoch_manager/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 # Changing this version will lead to change to the protocol, as will change how validators get shuffled.
 protocol_defining_rand = { package = "rand", version = "0.6.5", default-features = false }
 log = "0.4"
-lru = "0.6.5"
+lru = "0.7.2"
 borsh = "0.9"
 rand = "0.7"
 serde_json = "1"

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -16,7 +16,7 @@ conqueue = "0.4.0"
 deepsize = { version = "0.2.0", optional = true }
 futures = "0.3"
 itertools = "0.10.3"
-lru = "0.6.5"
+lru = "0.7.2"
 near-rust-allocator-proxy = { version = "0.3.0", optional = true }
 once_cell = "1.5.2"
 rand = "0.7"

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -22,7 +22,7 @@ fs2 = "0.4"
 tracing = "0.1"
 borsh = "0.9"
 thiserror = "1"
-lru = "0.6.5"
+lru = "0.7.2"
 
 near-crypto = { path = "../crypto" }
 near-primitives = { path = "../primitives" }

--- a/deny.toml
+++ b/deny.toml
@@ -21,9 +21,6 @@ skip = [
     { name = "humantime", version = "=2.1.0" },
     { name = "textwrap", version = "=0.12.1" },
 
-    # many crates (borsh, indexmap, cached, ...) use this older version
-    { name = "hashbrown", version = "=0.9.1" },
-
     # insta uses older version of console
     { name = "console", version = "=0.14.1" },
     # near-epoch-manager fixed the rand version to ensure protocol stability
@@ -90,15 +87,6 @@ skip = [
     # criterion and criterion-plot use conflicting versions
     { name = "semver-parser", version = "=0.7.0" },
     { name = "semver", version = "=0.9.0" },
-
-    # hashbrown uses an older version
-    { name = "ahash", version = "=0.4.7" },
-
-    # zeropool-bn optionally uses the older borsh 0.8.2
-    { name = "borsh", version = "=0.8.2" },
-    { name = "borsh-derive", version = "=0.8.2" },
-    { name = "borsh-derive-internal", version = "=0.8.2" },
-    { name = "borsh-schema-derive-internal", version = "=0.8.2" },
 
     # wasmer-runtime-core-near and parity-secp256k1 use an older version
     { name = "arrayvec", version = "=0.5.2" },

--- a/runtime/near-vm-logic/Cargo.toml
+++ b/runtime/near-vm-logic/Cargo.toml
@@ -30,7 +30,7 @@ near-primitives = { path = "../../core/primitives" }
 near-primitives-core = { path = "../../core/primitives-core" }
 near-vm-errors = { path = "../near-vm-errors" }
 
-bn = { package = "zeropool-bn", version = "0.5.9", features = [], optional = true }
+bn = { package = "zeropool-bn", version = "0.5.11", features = [], optional = true }
 
 [dev-dependencies]
 hex = { version = "0.4", features = ["serde"] }

--- a/utils/near-cache/Cargo.toml
+++ b/utils/near-cache/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.56.0"
 publish = false
 
 [dependencies]
-lru = "0.6.5"
+lru = "0.7.2"
 
 [dev-dependencies]
 bencher = "0.1.5"


### PR DESCRIPTION
This upgrades:

* borsh
* bn
* lru

which together ensures that we have only one version of hashbrown -- a
sizable crate we don't want to have duplicates of.