### PR TITLE
refactor: simplify callback handling in chain

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -862,14 +862,11 @@ impl Chain {
     }
 
     /// Process a block header received during "header first" propagation.
-    pub fn process_block_header<F>(
+    pub fn process_block_header(
         &mut self,
         header: &BlockHeader,
-        on_challenge: F,
-    ) -> Result<(), Error>
-    where
-        F: FnMut(ChallengeBody),
-    {
+        on_challenge: &mut dyn FnMut(ChallengeBody),
+    ) -> Result<(), Error> {
         // We create new chain update, but it's not going to be committed so it's read only.
         let mut chain_update = self.chain_update();
         chain_update.process_block_header(header, on_challenge)?;
@@ -889,22 +886,16 @@ impl Chain {
 
     /// Process a received or produced block, and unroll any orphans that may depend on it.
     /// Changes current state, and calls `block_accepted` callback in case block was successfully applied.
-    pub fn process_block<F, F1, F2, F3>(
+    pub fn process_block(
         &mut self,
         me: &Option<AccountId>,
         block: MaybeValidated<Block>,
         provenance: Provenance,
-        block_accepted: F,
-        block_misses_chunks: F1,
-        block_orphaned_with_missing_chunks: F2,
-        on_challenge: F3,
-    ) -> Result<Option<Tip>, Error>
-    where
-        F: Copy + FnMut(AcceptedBlock),
-        F1: Copy + FnMut(BlockMissingChunks),
-        F2: Copy + FnMut(OrphanMissingChunks),
-        F3: Copy + FnMut(ChallengeBody),
-    {
+        block_accepted: &mut dyn FnMut(AcceptedBlock),
+        block_misses_chunks: &mut dyn FnMut(BlockMissingChunks),
+        block_orphaned_with_missing_chunks: &mut dyn FnMut(OrphanMissingChunks),
+        on_challenge: &mut dyn FnMut(ChallengeBody),
+    ) -> Result<Option<Tip>, Error> {
         let block_hash = *block.hash();
         let res = self.process_block_single(
             me,
@@ -950,14 +941,11 @@ impl Chain {
     }
 
     /// Processes headers and adds them to store for syncing.
-    pub fn sync_block_headers<F>(
+    pub fn sync_block_headers(
         &mut self,
         mut headers: Vec<BlockHeader>,
-        on_challenge: F,
-    ) -> Result<(), Error>
-    where
-        F: Copy + FnMut(ChallengeBody),
-    {
+        on_challenge: &mut dyn FnMut(ChallengeBody),
+    ) -> Result<(), Error> {
         // Sort headers by heights if they are out of order.
         headers.sort_by_key(|left| left.height());
 
@@ -1120,21 +1108,15 @@ impl Chain {
 
     /// Set the new head after state sync was completed if it is indeed newer.
     /// Check for potentially unlocked orphans after this update.
-    pub fn reset_heads_post_state_sync<F, F1, F2, F3>(
+    pub fn reset_heads_post_state_sync(
         &mut self,
         me: &Option<AccountId>,
         sync_hash: CryptoHash,
-        block_accepted: F,
-        block_misses_chunks: F1,
-        orphan_misses_chunks: F2,
-        on_challenge: F3,
-    ) -> Result<(), Error>
-    where
-        F: Copy + FnMut(AcceptedBlock),
-        F1: Copy + FnMut(BlockMissingChunks),
-        F2: Copy + FnMut(OrphanMissingChunks),
-        F3: Copy + FnMut(ChallengeBody),
-    {
+        block_accepted: &mut dyn FnMut(AcceptedBlock),
+        block_misses_chunks: &mut dyn FnMut(BlockMissingChunks),
+        orphan_misses_chunks: &mut dyn FnMut(OrphanMissingChunks),
+        on_challenge: &mut dyn FnMut(ChallengeBody),
+    ) -> Result<(), Error> {
         // Get header we were syncing into.
         let header = self.get_block_header(&sync_hash)?;
         let hash = *header.prev_hash();
@@ -1218,22 +1200,16 @@ impl Chain {
 
     // Processes a single block, increments the metric for the number of blocks processing and also
     // for the number of blocks processed successfully (returns OK).
-    fn process_block_single<F, F1, F2, F3>(
+    fn process_block_single(
         &mut self,
         me: &Option<AccountId>,
         block: MaybeValidated<Block>,
         provenance: Provenance,
-        block_accepted: F,
-        block_misses_chunks: F1,
-        orphan_misses_chunks: F2,
-        on_challenge: F3,
-    ) -> Result<Option<Tip>, Error>
-    where
-        F: FnMut(AcceptedBlock),
-        F1: Copy + FnMut(BlockMissingChunks),
-        F2: Copy + FnMut(OrphanMissingChunks),
-        F3: FnMut(ChallengeBody),
-    {
+        block_accepted: &mut dyn FnMut(AcceptedBlock),
+        block_misses_chunks: &mut dyn FnMut(BlockMissingChunks),
+        orphan_misses_chunks: &mut dyn FnMut(OrphanMissingChunks),
+        on_challenge: &mut dyn FnMut(ChallengeBody),
+    ) -> Result<Option<Tip>, Error> {
         metrics::BLOCK_PROCESSING_ATTEMPTS_TOTAL.inc();
         metrics::NUM_ORPHANS.set(self.orphans.len() as i64);
         let success_timer = metrics::BLOCK_PROCESSING_TIME.start_timer();
@@ -1259,22 +1235,16 @@ impl Chain {
 
     // Block processing. Unlike process_block_single() this function doesn't update metrics for
     // successful blocks processing.
-    fn process_block_single_impl<F, F1, F2, F3>(
+    fn process_block_single_impl(
         &mut self,
         me: &Option<AccountId>,
         block: MaybeValidated<Block>,
         provenance: Provenance,
-        mut block_accepted: F,
-        mut block_misses_chunks: F1,
-        mut orphan_misses_chunks: F2,
-        on_challenge: F3,
-    ) -> Result<Option<Tip>, Error>
-    where
-        F: FnMut(AcceptedBlock),
-        F1: Copy + FnMut(BlockMissingChunks),
-        F2: Copy + FnMut(OrphanMissingChunks),
-        F3: FnMut(ChallengeBody),
-    {
+        block_accepted: &mut dyn FnMut(AcceptedBlock),
+        block_misses_chunks: &mut dyn FnMut(BlockMissingChunks),
+        orphan_misses_chunks: &mut dyn FnMut(OrphanMissingChunks),
+        on_challenge: &mut dyn FnMut(ChallengeBody),
+    ) -> Result<Option<Tip>, Error> {
         let prev_head = self.store.head()?;
         let mut chain_update = self.chain_update();
         let maybe_new_head = chain_update.process_block(me, &block, &provenance, on_challenge);
@@ -1513,19 +1483,14 @@ impl Chain {
     }
 
     /// Check if any block with missing chunk is ready to be processed
-    pub fn check_blocks_with_missing_chunks<F, F1, F2, F3>(
+    pub fn check_blocks_with_missing_chunks(
         &mut self,
         me: &Option<AccountId>,
-        block_accepted: F,
-        block_misses_chunks: F1,
-        orphan_misses_chunks: F2,
-        on_challenge: F3,
-    ) where
-        F: Copy + FnMut(AcceptedBlock),
-        F1: Copy + FnMut(BlockMissingChunks),
-        F2: Copy + FnMut(OrphanMissingChunks),
-        F3: Copy + FnMut(ChallengeBody),
-    {
+        block_accepted: &mut dyn FnMut(AcceptedBlock),
+        block_misses_chunks: &mut dyn FnMut(BlockMissingChunks),
+        orphan_misses_chunks: &mut dyn FnMut(OrphanMissingChunks),
+        on_challenge: &mut dyn FnMut(ChallengeBody),
+    ) {
         let mut new_blocks_accepted = vec![];
         let orphans = self.blocks_with_missing_chunks.ready_blocks();
         for orphan in orphans {
@@ -1571,21 +1536,15 @@ impl Chain {
     /// `orphan_misses_chunks`: callback to be called when it is ready to request missing chunks for
     ///                         an orphan
     /// `on_challenge`: callback to be called when an orphan should be challenged
-    pub fn check_orphans<F, F1, F2, F3>(
+    pub fn check_orphans(
         &mut self,
         me: &Option<AccountId>,
         prev_hash: CryptoHash,
-        block_accepted: F,
-        block_misses_chunks: F1,
-        mut orphan_misses_chunks: F2,
-        on_challenge: F3,
-    ) -> Option<Tip>
-    where
-        F: Copy + FnMut(AcceptedBlock),
-        F1: Copy + FnMut(BlockMissingChunks),
-        F2: Copy + FnMut(OrphanMissingChunks),
-        F3: Copy + FnMut(ChallengeBody),
-    {
+        block_accepted: &mut dyn FnMut(AcceptedBlock),
+        block_misses_chunks: &mut dyn FnMut(BlockMissingChunks),
+        orphan_misses_chunks: &mut dyn FnMut(OrphanMissingChunks),
+        on_challenge: &mut dyn FnMut(ChallengeBody),
+    ) -> Option<Tip> {
         let mut queue = vec![prev_hash];
         let mut queue_idx = 0;
 
@@ -2295,22 +2254,16 @@ impl Chain {
     }
 
     /// Apply transactions in chunks for the next epoch in blocks that were blocked on the state sync
-    pub fn finish_catchup_blocks<F, F1, F2, F3>(
+    pub fn finish_catchup_blocks(
         &mut self,
         me: &Option<AccountId>,
         epoch_first_block: &CryptoHash,
-        block_accepted: F,
-        block_misses_chunks: F1,
-        orphan_misses_chunks: F2,
-        on_challenge: F3,
+        block_accepted: &mut dyn FnMut(AcceptedBlock),
+        block_misses_chunks: &mut dyn FnMut(BlockMissingChunks),
+        orphan_misses_chunks: &mut dyn FnMut(OrphanMissingChunks),
+        on_challenge: &mut dyn FnMut(ChallengeBody),
         affected_blocks: &Vec<CryptoHash>,
-    ) -> Result<(), Error>
-    where
-        F: Copy + FnMut(AcceptedBlock),
-        F1: Copy + FnMut(BlockMissingChunks),
-        F2: Copy + FnMut(OrphanMissingChunks),
-        F3: Copy + FnMut(ChallengeBody),
-    {
+    ) -> Result<(), Error> {
         debug!(
             "Finishing catching up blocks after syncing pre {:?}, me: {:?}",
             epoch_first_block, me
@@ -3176,14 +3129,11 @@ impl<'a> ChainUpdate<'a> {
     /// We validate the header but we do not store it or update header head
     /// based on this. We will update these once we get the block back after
     /// requesting it.
-    pub fn process_block_header<F>(
+    pub fn process_block_header(
         &mut self,
         header: &BlockHeader,
-        on_challenge: F,
-    ) -> Result<(), Error>
-    where
-        F: FnMut(ChallengeBody),
-    {
+        on_challenge: &mut dyn FnMut(ChallengeBody),
+    ) -> Result<(), Error> {
         debug!(target: "chain", "Process block header: {} at {}", header.hash(), header.height());
 
         self.check_known(header.hash())?;
@@ -3966,16 +3916,13 @@ impl<'a> ChainUpdate<'a> {
     /// Runs the block processing, including validation and finding a place for the new block in the chain.
     /// Returns new head if chain head updated, as well as a boolean indicating if we need to start
     ///    fetching state for the next epoch.
-    fn process_block<F>(
+    fn process_block(
         &mut self,
         me: &Option<AccountId>,
         block: &MaybeValidated<Block>,
         provenance: &Provenance,
-        on_challenge: F,
-    ) -> Result<(Option<Tip>, bool), Error>
-    where
-        F: FnMut(ChallengeBody),
-    {
+        on_challenge: &mut dyn FnMut(ChallengeBody),
+    ) -> Result<(Option<Tip>, bool), Error> {
         let _span =
             tracing::debug_span!(target: "chain", "Process block", "#{}", block.header().height())
                 .entered();
@@ -4225,30 +4172,24 @@ impl<'a> ChainUpdate<'a> {
 
     /// Process a block header as part of processing a full block.
     /// We want to be sure the header is valid before processing the full block.
-    fn process_header_for_block<F>(
+    fn process_header_for_block(
         &mut self,
         header: &BlockHeader,
         provenance: &Provenance,
-        on_challenge: F,
-    ) -> Result<(), Error>
-    where
-        F: FnMut(ChallengeBody),
-    {
+        on_challenge: &mut dyn FnMut(ChallengeBody),
+    ) -> Result<(), Error> {
         self.validate_header(header, provenance, on_challenge)?;
         self.chain_store_update.save_block_header(header.clone())?;
         self.update_header_head_if_not_challenged(header)?;
         Ok(())
     }
 
-    fn validate_header<F>(
+    fn validate_header(
         &mut self,
         header: &BlockHeader,
         provenance: &Provenance,
-        mut on_challenge: F,
-    ) -> Result<(), Error>
-    where
-        F: FnMut(ChallengeBody),
-    {
+        on_challenge: &mut dyn FnMut(ChallengeBody),
+    ) -> Result<(), Error> {
         // Refuse blocks from the too distant future.
         if header.timestamp() > Clock::utc() + Duration::seconds(ACCEPTABLE_TIME_DIFFERENCE) {
             return Err(ErrorKind::InvalidBlockFutureTime(header.timestamp()).into());

--- a/chain/chain/src/tests/challenges.rs
+++ b/chain/chain/src/tests/challenges.rs
@@ -83,7 +83,9 @@ fn test_no_challenge_on_same_header() {
     let block = Block::empty(prev, &*signer);
     let tip = chain.process_block_test(&None, block.clone()).unwrap();
     assert_eq!(tip.unwrap().height, 1);
-    if let Err(e) = chain.process_block_header(block.header(), |_| panic!("Unexpected Challenge")) {
+    if let Err(e) =
+        chain.process_block_header(block.header(), &mut |_| panic!("Unexpected Challenge"))
+    {
         match e.kind() {
             ErrorKind::Unfit(_) => {}
             _ => panic!("Wrong error kind {}", e),

--- a/chain/chain/src/tests/mod.rs
+++ b/chain/chain/src/tests/mod.rs
@@ -21,10 +21,10 @@ impl Chain {
             me,
             MaybeValidated::from(block),
             Provenance::PRODUCED,
-            |_| {},
-            |_| {},
-            |_| {},
-            |_| {},
+            &mut |_| {},
+            &mut |_| {},
+            &mut |_| {},
+            &mut |_| {},
         )
     }
 }

--- a/chain/chain/src/tests/sync_chain.rs
+++ b/chain/chain/src/tests/sync_chain.rs
@@ -18,9 +18,10 @@ fn chain_sync_headers() {
         ));
     }
     chain
-        .sync_block_headers(blocks.drain(1..).map(|block| block.header().clone()).collect(), |_| {
-            panic!("Unexpected")
-        })
+        .sync_block_headers(
+            blocks.drain(1..).map(|block| block.header().clone()).collect(),
+            &mut |_| panic!("Unexpected"),
+        )
         .unwrap();
     assert_eq!(chain.header_head().unwrap().height, 4);
 }

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -2,7 +2,7 @@
 //! This client works completely synchronously and must be operated by some async actor outside.
 
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use log::{debug, error, info, warn};
@@ -684,9 +684,9 @@ impl Client {
         Ok(transactions)
     }
 
-    pub fn send_challenges(&mut self, challenges: Arc<RwLock<Vec<ChallengeBody>>>) {
-        if let Some(validator_signer) = self.validator_signer.as_ref() {
-            for body in challenges.write().unwrap().drain(..) {
+    pub fn send_challenges(&mut self, challenges: Vec<ChallengeBody>) {
+        if let Some(validator_signer) = &self.validator_signer {
+            for body in challenges {
                 let challenge = Challenge::produce(body, &**validator_signer);
                 self.challenges.insert(challenge.hash, challenge.clone());
                 self.network_adapter.do_send(PeerManagerMessageRequest::NetworkRequests(
@@ -720,11 +720,11 @@ impl Client {
                 Err(e) => return (vec![], Err(e)),
             }
         }
-        // TODO: replace to channels or cross beams here? we don't have multi-threading here so it's mostly to get around borrow checker.
-        let accepted_blocks = Arc::new(RwLock::new(vec![]));
-        let blocks_missing_chunks = Arc::new(RwLock::new(vec![]));
-        let orphans_missing_chunks = Arc::new(RwLock::new(vec![]));
-        let challenges = Arc::new(RwLock::new(vec![]));
+
+        let mut accepted_blocks = vec![];
+        let mut blocks_missing_chunks = vec![];
+        let mut orphans_missing_chunks = vec![];
+        let mut challenges = vec![];
 
         let result = {
             let me = self
@@ -735,14 +735,14 @@ impl Client {
                 &me,
                 block,
                 provenance,
-                |accepted_block| {
-                    accepted_blocks.write().unwrap().push(accepted_block);
+                &mut |accepted_block| {
+                    accepted_blocks.push(accepted_block);
                 },
-                |missing_chunks| blocks_missing_chunks.write().unwrap().push(missing_chunks),
-                |orphan_missing_chunks| {
-                    orphans_missing_chunks.write().unwrap().push(orphan_missing_chunks);
+                &mut |missing_chunks| blocks_missing_chunks.push(missing_chunks),
+                &mut |orphan_missing_chunks| {
+                    orphans_missing_chunks.push(orphan_missing_chunks);
                 },
-                |challenge| challenges.write().unwrap().push(challenge),
+                &mut |challenge| challenges.push(challenge),
             )
         };
 
@@ -782,8 +782,7 @@ impl Client {
         // Request any missing chunks
         self.request_missing_chunks(blocks_missing_chunks, orphans_missing_chunks);
 
-        let unwrapped_accepted_blocks = accepted_blocks.write().unwrap().drain(..).collect();
-        (unwrapped_accepted_blocks, result)
+        (accepted_blocks, result)
     }
 
     pub fn rebroadcast_block(&mut self, block: &Block) {
@@ -915,9 +914,8 @@ impl Client {
         &mut self,
         headers: Vec<BlockHeader>,
     ) -> Result<(), near_chain::Error> {
-        let challenges = Arc::new(RwLock::new(vec![]));
-        self.chain
-            .sync_block_headers(headers, |challenge| challenges.write().unwrap().push(challenge))?;
+        let mut challenges = vec![];
+        self.chain.sync_block_headers(headers, &mut |challenge| challenges.push(challenge))?;
         self.send_challenges(challenges);
         Ok(())
     }
@@ -1176,12 +1174,10 @@ impl Client {
 
     pub fn request_missing_chunks(
         &mut self,
-        blocks_missing_chunks: Arc<RwLock<Vec<BlockMissingChunks>>>,
-        orphans_missing_chunks: Arc<RwLock<Vec<OrphanMissingChunks>>>,
+        blocks_missing_chunks: Vec<BlockMissingChunks>,
+        orphans_missing_chunks: Vec<OrphanMissingChunks>,
     ) {
-        for BlockMissingChunks { prev_hash, missing_chunks } in
-            blocks_missing_chunks.write().unwrap().drain(..)
-        {
+        for BlockMissingChunks { prev_hash, missing_chunks } in blocks_missing_chunks {
             self.shards_mgr.request_chunks(
                 missing_chunks,
                 prev_hash,
@@ -1193,7 +1189,7 @@ impl Client {
         }
 
         for OrphanMissingChunks { missing_chunks, epoch_id, ancestor_hash } in
-            orphans_missing_chunks.write().unwrap().drain(..)
+            orphans_missing_chunks
         {
             self.shards_mgr.request_chunks_for_orphan(
                 missing_chunks,
@@ -1210,26 +1206,25 @@ impl Client {
     /// Check if any block with missing chunks is ready to be processed
     #[must_use]
     pub fn process_blocks_with_missing_chunks(&mut self) -> Vec<AcceptedBlock> {
-        let accepted_blocks = Arc::new(RwLock::new(vec![]));
-        let blocks_missing_chunks = Arc::new(RwLock::new(vec![]));
-        let orphans_missing_chunks = Arc::new(RwLock::new(vec![]));
-        let challenges = Arc::new(RwLock::new(vec![]));
+        let mut accepted_blocks = vec![];
+        let mut blocks_missing_chunks = vec![];
+        let mut orphans_missing_chunks = vec![];
+        let mut challenges = vec![];
         let me =
             self.validator_signer.as_ref().map(|validator_signer| validator_signer.validator_id());
         self.chain.check_blocks_with_missing_chunks(
             &me.map(|x| x.clone()),
-            |accepted_block| {
+            &mut |accepted_block| {
                 debug!(target: "client", "Block {} was missing chunks but now is ready to be processed", accepted_block.hash);
-                accepted_blocks.write().unwrap().push(accepted_block);
+                accepted_blocks.push(accepted_block);
             },
-            |missing_chunks| blocks_missing_chunks.write().unwrap().push(missing_chunks),
-            |orphan_missing_chunks| orphans_missing_chunks.write().unwrap().push(orphan_missing_chunks),
-            |challenge| challenges.write().unwrap().push(challenge));
+            &mut |missing_chunks| blocks_missing_chunks.push(missing_chunks),
+            &mut |orphan_missing_chunks| orphans_missing_chunks.push(orphan_missing_chunks),
+            &mut |challenge| challenges.push(challenge));
         self.send_challenges(challenges);
 
         self.request_missing_chunks(blocks_missing_chunks, orphans_missing_chunks);
-        let unwrapped_accepted_blocks = accepted_blocks.write().unwrap().drain(..).collect();
-        unwrapped_accepted_blocks
+        accepted_blocks
     }
 
     pub fn is_validator(&self, epoch_id: &EpochId, block_hash: &CryptoHash) -> bool {
@@ -1711,24 +1706,22 @@ impl Client {
                     )?;
 
                     if blocks_catch_up_state.is_finished() {
-                        let accepted_blocks = Arc::new(RwLock::new(vec![]));
-                        let blocks_missing_chunks = Arc::new(RwLock::new(vec![]));
-                        let orphans_missing_chunks = Arc::new(RwLock::new(vec![]));
-                        let challenges = Arc::new(RwLock::new(vec![]));
+                        let mut accepted_blocks = vec![];
+                        let mut blocks_missing_chunks = vec![];
+                        let mut orphans_missing_chunks = vec![];
+                        let mut challenges = vec![];
 
                         self.chain.finish_catchup_blocks(
                             me,
                             &sync_hash,
-                            |accepted_block| {
-                                accepted_blocks.write().unwrap().push(accepted_block);
+                            &mut |accepted_block| {
+                                accepted_blocks.push(accepted_block);
                             },
-                            |missing_chunks| {
-                                blocks_missing_chunks.write().unwrap().push(missing_chunks)
+                            &mut |missing_chunks| blocks_missing_chunks.push(missing_chunks),
+                            &mut |orphan_missing_chunks| {
+                                orphans_missing_chunks.push(orphan_missing_chunks)
                             },
-                            |orphan_missing_chunks| {
-                                orphans_missing_chunks.write().unwrap().push(orphan_missing_chunks)
-                            },
-                            |challenge| challenges.write().unwrap().push(challenge),
+                            &mut |challenge| challenges.push(challenge),
                             &blocks_catch_up_state.done_blocks,
                         )?;
 
@@ -1736,7 +1729,7 @@ impl Client {
 
                         self.request_missing_chunks(blocks_missing_chunks, orphans_missing_chunks);
 
-                        return Ok(accepted_blocks.write().unwrap().drain(..).collect());
+                        return Ok(accepted_blocks);
                     }
                 }
             }

--- a/chain/client/src/sync.rs
+++ b/chain/client/src/sync.rs
@@ -1327,10 +1327,10 @@ mod test {
                     &None,
                     block.into(),
                     Provenance::PRODUCED,
-                    |_| {},
-                    |_| {},
-                    |_| {},
-                    |_| {},
+                    &mut |_| {},
+                    &mut |_| {},
+                    &mut |_| {},
+                    &mut |_| {},
                 )
                 .unwrap();
         }
@@ -1343,10 +1343,10 @@ mod test {
                     &None,
                     block.into(),
                     Provenance::PRODUCED,
-                    |_| {},
-                    |_| {},
-                    |_| {},
-                    |_| {},
+                    &mut |_| {},
+                    &mut |_| {},
+                    &mut |_| {},
+                    &mut |_| {},
                 )
                 .unwrap();
         }
@@ -1587,7 +1587,7 @@ mod test {
         }
         let block_headers = blocks.iter().map(|b| b.header().clone()).collect::<Vec<_>>();
         let peer_infos = create_peer_infos(2);
-        env.clients[1].chain.sync_block_headers(block_headers, |_| unreachable!()).unwrap();
+        env.clients[1].chain.sync_block_headers(block_headers, &mut |_| unreachable!()).unwrap();
 
         for block in blocks.iter().take(5) {
             let is_state_sync =
@@ -1629,7 +1629,7 @@ mod test {
         }
         let block_headers = blocks.iter().map(|b| b.header().clone()).collect::<Vec<_>>();
         let peer_infos = create_peer_infos(2);
-        env.clients[1].chain.sync_block_headers(block_headers, |_| unreachable!()).unwrap();
+        env.clients[1].chain.sync_block_headers(block_headers, &mut |_| unreachable!()).unwrap();
         let is_state_sync = block_sync.block_sync(&mut env.clients[1].chain, &peer_infos).unwrap();
         assert!(!is_state_sync);
         let requested_block_hashes = collect_hashes_from_network_adapter(network_adapter.clone());

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -1780,7 +1780,14 @@ fn test_gc_tail_update() {
     store_update.commit().unwrap();
     env.clients[1]
         .chain
-        .reset_heads_post_state_sync(&None, *sync_block.hash(), |_| {}, |_| {}, |_| {}, |_| {})
+        .reset_heads_post_state_sync(
+            &None,
+            *sync_block.hash(),
+            &mut |_| {},
+            &mut |_| {},
+            &mut |_| {},
+            &mut |_| {},
+        )
         .unwrap();
     env.process_block(1, blocks.pop().unwrap(), Provenance::NONE);
     assert_eq!(env.clients[1].chain.store().tail().unwrap(), prev_sync_height);


### PR DESCRIPTION
This mechanically substitutes `dyn FnMut` for `F where F: FnMut`. The benefits would be: 

* net reduction in lines of code
* significantly simplified call-sites -- no more weird `Arc<RwLock>` shenanigans
* improved compile times -- now we don't need to monomorphize this stuff, so it is compiled once, in the definition crate

I think there might be further benefits to bunching up the callbacks into some kind of callback struct, but that'd be a slightly more invasive refactor. 