### PR TITLE
Disable fetching chunks for multiple blocks

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -78,7 +78,7 @@ const MAX_ORPHAN_AGE_SECS: u64 = 300;
 // Number of orphan ancestors should be checked to request chunks
 // Orphans for which we will request for missing chunks must satisfy,
 // its NUM_ORPHAN_ANCESTORS_CHECK'th ancestor has been accepted
-pub const NUM_ORPHAN_ANCESTORS_CHECK: u64 = 2;
+pub const NUM_ORPHAN_ANCESTORS_CHECK: u64 = 1;
 
 // Maximum number of orphans that we can request missing chunks
 // Note that if there are no forks, the maximum number of orphans we would

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -3696,6 +3696,12 @@ mod access_key_nonce_range_tests {
     fn test_request_chunks_for_orphan() {
         init_test_logger();
 
+        // Skip the test if NUM_ORPHAN_ANCESTORS_CHECK is 1, which effectively disables
+        // fetching chunks for orphan
+        if NUM_ORPHAN_ANCESTORS_CHECK == 1 {
+            return;
+        }
+
         let num_clients = 2;
         let num_validators = 1;
         let epoch_length = 10;


### PR DESCRIPTION
Disable it for now. Fetching chunks for even two blocks at a time may cause OOM