### PR TITLE
fix: replace pop with get in `TrieCachingStorage`

### DIFF
--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -167,7 +167,7 @@ impl TrieCachingStorage {
 impl TrieStorage for TrieCachingStorage {
     fn retrieve_raw_bytes(&self, hash: &CryptoHash) -> Result<Vec<u8>, StorageError> {
         let mut guard = self.cache.0.lock().expect(POISONED_LOCK_ERR);
-        if let Some(val) = guard.pop(hash) {
+        if let Some(val) = guard.get(hash) {
             Ok(val.clone())
         } else {
             let key = Self::get_key_from_shard_uid_and_hash(self.shard_uid, hash);


### PR DESCRIPTION
While working with https://github.com/near/nearcore/pull/5871, because of a typo (?) we replaced some `cache_get` with `pop`, so we remove each entry from `TrieCachingStorage` on read: https://github.com/near/nearcore/pull/5871/files#diff-e073548a40d97af14f75cf143fab41a1cffe61d159e0b9a6297daeab0b2a5d45L171

Here we restore the original behaviour.

## Test plan

Existing tests.