### PR TITLE
client: add GetBlockHash request and use it in Rosetta RPC

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2727,6 +2727,12 @@ impl Chain {
         self.store.get_block(&hash)
     }
 
+    /// Gets block hash from the current chain by height.
+    #[inline]
+    pub fn get_block_hash_by_height(&mut self, height: BlockHeight) -> Result<CryptoHash, Error> {
+        self.store.get_block_hash_by_height(height)
+    }
+
     /// Gets a block header by hash.
     #[inline]
     pub fn get_block_header(&mut self, hash: &CryptoHash) -> Result<&BlockHeader, Error> {

--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -19,7 +19,7 @@ use near_primitives::types::{
 use near_primitives::utils::generate_random_string;
 use near_primitives::views::validator_stake_view::ValidatorStakeView;
 use near_primitives::views::{
-    BlockHeaderView, BlockView, ChunkView, EpochValidatorInfo, ExecutionOutcomeWithIdView,
+    BlockView, ChunkView, EpochValidatorInfo, ExecutionOutcomeWithIdView,
     FinalExecutionOutcomeViewEnum, GasPriceView, LightClientBlockLiteView, LightClientBlockView,
     QueryRequest, QueryResponse, ReceiptView, StateChangesKindsView, StateChangesRequestView,
     StateChangesView,
@@ -211,14 +211,11 @@ impl Message for GetBlock {
     type Result = Result<BlockView, GetBlockError>;
 }
 
-/// Actor message requesting block header by id, hash or sync state.  This is
-/// similar to [`GetBlock`] but fewer information is returned.  This is
-/// especially useful because blocks are garbage collected but block headers
-/// aren’t.
-pub struct GetBlockHeader(pub BlockReference);
+/// Actor message requesting block hash by id, hash or sync state.
+pub struct GetBlockHash(pub BlockReference);
 
-impl Message for GetBlockHeader {
-    type Result = Result<BlockHeaderView, GetBlockError>;
+impl Message for GetBlockHash {
+    type Result = Result<CryptoHash, GetBlockError>;
 }
 
 /// Get block with the block merkle tree. Used for testing

--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -19,7 +19,7 @@ use near_primitives::types::{
 use near_primitives::utils::generate_random_string;
 use near_primitives::views::validator_stake_view::ValidatorStakeView;
 use near_primitives::views::{
-    BlockView, ChunkView, EpochValidatorInfo, ExecutionOutcomeWithIdView,
+    BlockHeaderView, BlockView, ChunkView, EpochValidatorInfo, ExecutionOutcomeWithIdView,
     FinalExecutionOutcomeViewEnum, GasPriceView, LightClientBlockLiteView, LightClientBlockView,
     QueryRequest, QueryResponse, ReceiptView, StateChangesKindsView, StateChangesRequestView,
     StateChangesView,
@@ -168,7 +168,7 @@ impl SyncStatus {
     }
 }
 
-/// Actor message requesting block by id or hash.
+/// Actor message requesting block by id, hash or sync state.
 pub struct GetBlock(pub BlockReference);
 
 #[derive(thiserror::Error, Debug)]
@@ -209,6 +209,16 @@ impl GetBlock {
 
 impl Message for GetBlock {
     type Result = Result<BlockView, GetBlockError>;
+}
+
+/// Actor message requesting block header by id, hash or sync state.  This is
+/// similar to [`GetBlock`] but fewer information is returned.  This is
+/// especially useful because blocks are garbage collected but block headers
+/// aren’t.
+pub struct GetBlockHeader(pub BlockReference);
+
+impl Message for GetBlockHeader {
+    type Result = Result<BlockHeaderView, GetBlockError>;
 }
 
 /// Get block with the block merkle tree. Used for testing

--- a/chain/client/src/lib.rs
+++ b/chain/client/src/lib.rs
@@ -1,9 +1,10 @@
 pub use near_client_primitives::types::{
-    Error, GetBlock, GetBlockProof, GetBlockProofResponse, GetBlockWithMerkleTree, GetChunk,
-    GetExecutionOutcome, GetExecutionOutcomeResponse, GetExecutionOutcomesForBlock, GetGasPrice,
-    GetNetworkInfo, GetNextLightClientBlock, GetProtocolConfig, GetReceipt, GetStateChanges,
-    GetStateChangesInBlock, GetStateChangesWithCauseInBlock, GetValidatorInfo, GetValidatorOrdered,
-    Query, QueryError, Status, StatusResponse, SyncStatus, TxStatus, TxStatusError,
+    Error, GetBlock, GetBlockHeader, GetBlockProof, GetBlockProofResponse, GetBlockWithMerkleTree,
+    GetChunk, GetExecutionOutcome, GetExecutionOutcomeResponse, GetExecutionOutcomesForBlock,
+    GetGasPrice, GetNetworkInfo, GetNextLightClientBlock, GetProtocolConfig, GetReceipt,
+    GetStateChanges, GetStateChangesInBlock, GetStateChangesWithCauseInBlock, GetValidatorInfo,
+    GetValidatorOrdered, Query, QueryError, Status, StatusResponse, SyncStatus, TxStatus,
+    TxStatusError,
 };
 
 pub use crate::client::Client;

--- a/chain/client/src/lib.rs
+++ b/chain/client/src/lib.rs
@@ -1,5 +1,5 @@
 pub use near_client_primitives::types::{
-    Error, GetBlock, GetBlockHeader, GetBlockProof, GetBlockProofResponse, GetBlockWithMerkleTree,
+    Error, GetBlock, GetBlockHash, GetBlockProof, GetBlockProofResponse, GetBlockWithMerkleTree,
     GetChunk, GetExecutionOutcome, GetExecutionOutcomeResponse, GetExecutionOutcomesForBlock,
     GetGasPrice, GetNetworkInfo, GetNextLightClientBlock, GetProtocolConfig, GetReceipt,
     GetStateChanges, GetStateChangesInBlock, GetStateChangesWithCauseInBlock, GetValidatorInfo,

--- a/chain/rosetta-rpc/src/lib.rs
+++ b/chain/rosetta-rpc/src/lib.rs
@@ -102,9 +102,9 @@ async fn network_status(
     let status = check_network_identifier(&client_addr, network_identifier).await?;
 
     let genesis_height = genesis.config.genesis_height;
-    let (network_info, genesis_header, earliest_block) = tokio::try_join!(
+    let (network_info, genesis_hash, earliest_block) = tokio::try_join!(
         client_addr.send(near_client::GetNetworkInfo {}),
-        view_client_addr.send(near_client::GetBlockHeader(
+        view_client_addr.send(near_client::GetBlockHash(
             near_primitives::types::BlockId::Height(genesis_height).into(),
         )),
         view_client_addr.send(near_client::GetBlock(
@@ -114,11 +114,12 @@ async fn network_status(
         )),
     )?;
     let network_info = network_info.map_err(errors::ErrorKind::InternalError)?;
-    let genesis_header =
-        genesis_header.map_err(|err| errors::ErrorKind::InternalInvariantError(err.to_string()))?;
-    let earliest_block = earliest_block;
-
-    let genesis_block_identifier: models::BlockIdentifier = (&genesis_header).into();
+    let genesis_hash =
+        genesis_hash.map_err(|err| errors::ErrorKind::InternalInvariantError(err.to_string()))?;
+    let genesis_block_identifier = models::BlockIdentifier {
+        index: genesis_height.try_into().unwrap(),
+        hash: genesis_hash.to_base(),
+    };
     let oldest_block_identifier: models::BlockIdentifier = earliest_block
         .ok()
         .map(|block| (&block.header).into())

--- a/chain/rosetta-rpc/src/lib.rs
+++ b/chain/rosetta-rpc/src/lib.rs
@@ -102,9 +102,9 @@ async fn network_status(
     let status = check_network_identifier(&client_addr, network_identifier).await?;
 
     let genesis_height = genesis.config.genesis_height;
-    let (network_info, genesis_block, earliest_block) = tokio::try_join!(
+    let (network_info, genesis_header, earliest_block) = tokio::try_join!(
         client_addr.send(near_client::GetNetworkInfo {}),
-        view_client_addr.send(near_client::GetBlock(
+        view_client_addr.send(near_client::GetBlockHeader(
             near_primitives::types::BlockId::Height(genesis_height).into(),
         )),
         view_client_addr.send(near_client::GetBlock(
@@ -114,11 +114,11 @@ async fn network_status(
         )),
     )?;
     let network_info = network_info.map_err(errors::ErrorKind::InternalError)?;
-    let genesis_block =
-        genesis_block.map_err(|err| errors::ErrorKind::InternalInvariantError(err.to_string()))?;
+    let genesis_header =
+        genesis_header.map_err(|err| errors::ErrorKind::InternalInvariantError(err.to_string()))?;
     let earliest_block = earliest_block;
 
-    let genesis_block_identifier: models::BlockIdentifier = (&genesis_block.header).into();
+    let genesis_block_identifier: models::BlockIdentifier = (&genesis_header).into();
     let oldest_block_identifier: models::BlockIdentifier = earliest_block
         .ok()
         .map(|block| (&block.header).into())


### PR DESCRIPTION
The `/network/status` Rosetta RPC returns, among other things, height
and hash of the genesis block.  Currently, it does it by fetching the
genesis block.  Sadly, in non-archival nodes, genesis block is usually
unavailable which leads to failures in serving the RPC.  To address
this issue, introduce a `GetBlockHash` request which returns only the
hash of a block.  Since height→hash mapping is not garbage collected,
this request will always work even for garbage collected blocks.
