### PR TITLE
chore: bump version to 0.12.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ members = [
 ]
 
 [workspace.metadata.workspaces]
-version = "0.11.0"
+version = "0.12.0"
 
 [patch.crates-io]
 


### PR DESCRIPTION
Tagged: https://github.com/near/nearcore/releases/tag/crates-0.12.0

Notable changes:

- https://github.com/near/nearcore/pull/6179
- https://github.com/near/nearcore/pull/6158

Check here for a full changelog: https://github.com/near/nearcore/compare/crates-0.11.0...crates-0.12.0