### PR TITLE
fix(CI): exclude neard from being versioned by cargo-workspaces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ members = [
 
 [workspace.metadata.workspaces]
 version = "0.12.0"
+exclude = [ "neard" ]
 
 [patch.crates-io]
 


### PR DESCRIPTION
`neard` marked "independent" since https://github.com/near/nearcore/pull/6202 resulted in `cargo-workspaces` falling back to interactive mode for it to be versioned.

Context: https://buildkite.com/nearprotocol/nearcore-release/builds/1784#260c2987-b154-4d5b-acb5-85a9ca1259b9

This excludes `neard` entirely from the versioning process.