### PR TITLE
refactor: remove unused RPC error

### DIFF
--- a/chain/jsonrpc/res/rpc_errors_schema.json
+++ b/chain/jsonrpc/res/rpc_errors_schema.json
@@ -520,15 +520,6 @@
         "tx_burnt_amount": ""
       }
     },
-    "ContractCallError": {
-      "name": "ContractCallError",
-      "subtypes": [
-        "MethodResolveError",
-        "CompilationError",
-        "ExecutionError"
-      ],
-      "props": {}
-    },
     "CostOverflow": {
       "name": "CostOverflow",
       "subtypes": [],
@@ -582,13 +573,6 @@
       "name": "DepositWithFunctionCall",
       "subtypes": [],
       "props": {}
-    },
-    "ExecutionError": {
-      "name": "ExecutionError",
-      "subtypes": [],
-      "props": {
-        "msg": ""
-      }
     },
     "Expired": {
       "name": "Expired",

--- a/core/primitives/src/errors.rs
+++ b/core/primitives/src/errors.rs
@@ -321,7 +321,7 @@ pub struct ActionError {
 }
 
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
-#[derive(Debug, Clone, PartialEq, Eq, RpcError)]
+#[derive(Debug)]
 pub enum ContractCallError {
     MethodResolveError(MethodResolveError),
     CompilationError(CompilationError),


### PR DESCRIPTION
ContractCallError was never exposed through RPC (it is intentionally not
serialize), so we shouldn't make it an RpcError.