### PR TITLE
fix(network-primitives): pin actix-derive to fix isolated compilation issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2884,6 +2884,7 @@ name = "near-network-primitives"
 version = "0.0.0"
 dependencies = [
  "actix",
+ "actix_derive",
  "anyhow",
  "borsh",
  "chrono",

--- a/chain/network-primitives/Cargo.toml
+++ b/chain/network-primitives/Cargo.toml
@@ -13,6 +13,7 @@ publish = true
 [dependencies]
 anyhow = "1.0.51"
 actix = "=0.11.0-beta.2"
+actix_derive = "=0.6.0-beta.1" # Pinned dependency in addition to actix dependecy (remove this line once the pinning is not needed)
 borsh = "0.9"
 chrono = { version = "0.4.4", features = ["serde"] }
 deepsize = { version = "0.2.0", optional = true }


### PR DESCRIPTION
Context: https://buildkite.com/nearprotocol/nearcore-release/builds/1802#48b4d213-9613-462b-bb5d-350a3ad87d3a/106-1194

```console
$ cargo package -p near-network-primitives
   Compiling near-network-primitives v0.12.0 (/var/lib/buildkite-agent/builds/buildkite-i-08e77618f4765ff4c-1/nearprotocol/nearcore-release/target/package/near-network-primitives-0.12.0)
error[E0412]: cannot find type `OneshotSender` in module `actix::dev`
   --> src/types.rs:322:17
    |
322 | #[derive(Debug, actix::MessageResponse)]
    |                 ^^^^^^^^^^^^^^^^^^^^^^ not found in `actix::dev`
    |
    = note: this error originates in the derive macro `actix::MessageResponse` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0049]: method `handle` has 0 type parameters but its trait declaration has 1 type parameter
   --> src/types.rs:322:39
    |
322 | #[derive(Debug, actix::MessageResponse)]
    |                                       ^ found 0 type parameters, expected 1
    |
    = note: this error originates in the derive macro `actix::MessageResponse` (in Nightly builds, run with -Z macro-backtrace for more info)
```

We didn't have this issue before https://github.com/near/nearcore/pull/5945 which uses `actix_derive`.