### PR TITLE
cargo: enable ‘-D warnings’ by default

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@ steps:
   - label: "cargo test integration-tests*"
     command: |
       source ~/.cargo/env && set -eux
-      RUST_BACKTRACE=1 RUSTFLAGS='-D warnings' cargo test --locked -p 'integration-tests'
+      RUST_BACKTRACE=1 cargo test --locked -p 'integration-tests'
 
     timeout: 60
     agents:
@@ -12,7 +12,7 @@ steps:
   - label: "cargo test not integration-tests*"
     command: |
       source ~/.cargo/env && set -eux
-      RUST_BACKTRACE=1 RUSTFLAGS='-D warnings' cargo test --locked --workspace -p '*' --exclude 'integration-tests*'
+      RUST_BACKTRACE=1 cargo test --locked --workspace -p '*' --exclude 'integration-tests*'
 
     timeout: 60
     agents:
@@ -22,7 +22,7 @@ steps:
   - label: "cargo test nightly integration-tests*"
     command: |
       source ~/.cargo/env && set -eux
-      RUST_BACKTRACE=1 RUSTFLAGS='-D warnings' cargo test --features nightly_protocol,nightly_protocol_features,test_features -p 'integration-tests'
+      RUST_BACKTRACE=1 cargo test --features nightly_protocol,nightly_protocol_features,test_features -p 'integration-tests'
 
     timeout: 60
     agents:
@@ -32,7 +32,7 @@ steps:
   - label: "cargo test nightly not integration-tests*"
     command: |
       source ~/.cargo/env && set -eux
-      RUST_BACKTRACE=1 RUSTFLAGS='-D warnings' cargo test --workspace --features nightly_protocol,nightly_protocol_features,test_features,rosetta_rpc -p '*' --exclude 'integration-tests*'
+      RUST_BACKTRACE=1 cargo test --workspace --features nightly_protocol,nightly_protocol_features,test_features,rosetta_rpc -p '*' --exclude 'integration-tests*'
 
     timeout: 60
     agents:
@@ -43,15 +43,15 @@ steps:
     command: |
       source ~/.cargo/env && set -eux
       rustc --version && cargo --version
-      RUSTFLAGS='-D warnings' cargo run -p themis --release
+      cargo run -p themis --release
       if [ -e deny.toml ]; then
         cargo-deny --all-features check bans
       fi
-      RUSTFLAGS='-D warnings' cargo check --workspace --all-targets --all-features
-      RUSTFLAGS='-D warnings' cargo check -p neard --features test_features
-      RUSTFLAGS='-D warnings' cargo check -p neard --features sandbox
+      cargo check --workspace --all-targets --all-features
+      cargo check -p neard --features test_features
+      cargo check -p neard --features sandbox
 
-      RUSTFLAGS='-D warnings' cargo build -p neard --bin neard --features nightly_protocol,nightly_protocol_features
+      cargo build -p neard --bin neard --features nightly_protocol,nightly_protocol_features
       cd pytest
       python3 -m pip install --user -r requirements.txt
       python3 tests/sanity/spin_up_cluster.py
@@ -60,7 +60,7 @@ steps:
       # because spinning up non-nightly clusters is already covered
       # by other steps in the CI, e.g. upgradable.
 
-      RUSTFLAGS='-D warnings' cargo build -p neard --bin neard
+      cargo build -p neard --bin neard
       python3 scripts/state/update_res.py check
 
       python3 scripts/check_nightly.py
@@ -70,7 +70,7 @@ steps:
       ./scripts/formatting --check
 
       rm target/rpc_errors_schema.json
-      RUSTFLAGS='-D warnings' cargo check -p near-jsonrpc --features dump_errors_schema
+      cargo check -p near-jsonrpc --features dump_errors_schema
       if ! git --no-pager diff --no-index chain/jsonrpc/res/rpc_errors_schema.json target/rpc_errors_schema.json; then
           set +x
           echo 'The RPC errors schema reflects outdated typing structure; please run'
@@ -134,7 +134,7 @@ steps:
       cd runtime/runtime-params-estimator/test-contract
       ./build.sh
       cd ..
-      RUSTFLAGS='-D warnings' cargo run --release --package runtime-params-estimator --bin runtime-params-estimator -- --accounts-num 20000 --additional-accounts-num 200000 --iters 1 --warmup-iters 1 --metric time
+      cargo run --release --package runtime-params-estimator --bin runtime-params-estimator -- --accounts-num 20000 --additional-accounts-num 200000 --iters 1 --warmup-iters 1 --metric time
 
     branches: "!master !beta !stable"
     timeout: 60

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ['-D', 'warnings']

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 export CARGO_PROFILE_RELEASE_CODEGEN_UNITS = 1
 export CARGO_PROFILE_RELEASE_LTO = fat
 export DOCKER_BUILDKIT = 1
-export RUSTFLAGS = -D warnings
 export NEAR_RELEASE_BUILD = no
 export CARGO_TARGET_DIR = target
 


### PR DESCRIPTION
Making ‘-D warnings’ the default may be a minor annoyence to developers
who now will need to fix warnings even while they work on the feature
(as opposed to only having to do that once they are ready to send the
code for review) but it does simplify the code a small amount.

Issue: https://github.com/near/nearcore/issues/6226