### PR TITLE
cleanup: remove ToEnvelope trait bound on create_sync_job_scheduler()

### DIFF
--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -5,7 +5,6 @@ use crate::info::{get_validator_epoch_stats, InfoHelper, ValidatorInfoHelper};
 use crate::sync::{StateSync, StateSyncResult};
 use crate::StatusResponse;
 use actix::dev::SendError;
-use actix::dev::ToEnvelope;
 use actix::{Actor, Addr, Arbiter, AsyncContext, Context, Handler, Message};
 use actix_rt::ArbiterHandle;
 use borsh::BorshSerialize;
@@ -197,7 +196,6 @@ where
     M: Message + Send + 'static,
     M::Result: Send,
     SyncJobsActor: Handler<M>,
-    Context<SyncJobsActor>: ToEnvelope<SyncJobsActor, M>,
 {
     Box::new(move |msg: M| {
         if let Err(err) = address.try_send(msg) {


### PR DESCRIPTION
The first three already imply ToEnvelope because of a blanket impl:
https://github.com/actix/actix/blob/v0.11.0-beta.2/actix/src/address/envelope.rs#L22-L31

So this allows a bit of simplification and avoids having to refer to a sort of less
public part of actix