### PR TITLE
Fix copy path in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,6 @@ RUN apt-get update -qq && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 COPY scripts/run_docker.sh /usr/local/bin/run.sh
-COPY --from=build /tmp/target/release/neard /usr/local/bin
+COPY --from=build /tmp/target/release/neard /usr/local/bin/
 
 ENTRYPOINT ["/usr/local/bin/run.sh"]


### PR DESCRIPTION
Address ‘When using COPY with more than one source file, the destination
must be a directory and end with a /’ warning showing up when building
Docker image.