### PR TITLE
chain: make status line more descriptive

### DIFF
--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -98,14 +98,12 @@ impl InfoHelper {
         let sync_status_log = Some(display_sync_status(sync_status, head, genesis_height));
 
         let validator_info_log = validator_info.as_ref().map(|info| {
-            format!(" {}/{}", if info.is_validator { "V" } else { "-" }, info.num_validators)
+            format!(" {} validators", info.num_validators)
         });
 
         let network_info_log = Some(format!(
-            " {:2}/{:?}/{:2} peers ⬇ {} ⬆ {}",
+            " {} peers ⬇ {} ⬆ {}",
             network_info.num_connected_peers,
-            network_info.highest_height_peers.len(),
-            network_info.peer_max_count,
             pretty_bytes_per_sec(network_info.received_bytes_per_sec),
             pretty_bytes_per_sec(network_info.sent_bytes_per_sec)
         ));

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -95,14 +95,18 @@ impl InfoHelper {
             Some(text) => ansi_term::Style::default().paint(text),
         };
 
+        let s = |num| if num == 1 { "" } else { "s" };
+
         let sync_status_log = Some(display_sync_status(sync_status, head, genesis_height));
 
-        let validator_info_log =
-            validator_info.as_ref().map(|info| format!(" {} validators", info.num_validators));
+        let validator_info_log = validator_info
+            .as_ref()
+            .map(|info| format!(" {} validator{}", info.num_validators, s(info.num_validators)));
 
         let network_info_log = Some(format!(
-            " {} peers ⬇ {} ⬆ {}",
+            " {} peer{} ⬇ {} ⬆ {}",
             network_info.num_connected_peers,
+            s(network_info.num_connected_peers),
             pretty_bytes_per_sec(network_info.received_bytes_per_sec),
             pretty_bytes_per_sec(network_info.sent_bytes_per_sec)
         ));

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -97,9 +97,8 @@ impl InfoHelper {
 
         let sync_status_log = Some(display_sync_status(sync_status, head, genesis_height));
 
-        let validator_info_log = validator_info.as_ref().map(|info| {
-            format!(" {} validators", info.num_validators)
-        });
+        let validator_info_log =
+            validator_info.as_ref().map(|info| format!(" {} validators", info.num_validators));
 
         let network_info_log = Some(format!(
             " {} peers ⬇ {} ⬆ {}",


### PR DESCRIPTION
Remove some overly verbose information from status line and at the
same time make the status more descriptive.

Before: `-/4 7/7/40 peers`
 After: `4 validators 7 peers`

Information that this commit removes:
* the ‘-’ indicating whether node was validator or not,
* second ‘7’ indicating the number of peers that have highest height
  close to the node and
* ‘40’ indicating maximum number of peers.

Fixes: https://github.com/near/nearcore/issues/2454