### PR TITLE
feat: add metrics about chunk fullness

### DIFF
--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -983,6 +983,9 @@ impl ClientActor {
 
             let last_final_hash = *block.header().last_final_block();
 
+            for chunk in block.chunks().iter() {
+                self.info_helper.chunk_processed(chunk.shard_id(), chunk.gas_used());
+            }
             self.info_helper.block_processed(gas_used, chunks_in_block as u64);
             self.check_send_announce_account(last_final_hash);
         }

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -983,9 +983,16 @@ impl ClientActor {
 
             let last_final_hash = *block.header().last_final_block();
 
-            for chunk in block.chunks().iter() {
+            let chunks = block.chunks();
+            let included_chunks = chunks
+                .iter()
+                .zip(block.header().chunk_mask().iter())
+                .filter(|(_, mask)| **mask)
+                .map(|(chunk, _)| chunk);
+            for chunk in included_chunks {
                 self.info_helper.chunk_processed(chunk.shard_id(), chunk.gas_used());
             }
+
             self.info_helper.block_processed(gas_used, chunks_in_block as u64);
             self.check_send_announce_account(last_final_hash);
         }

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -12,7 +12,7 @@ use near_primitives::telemetry::{
     TelemetryAgentInfo, TelemetryChainInfo, TelemetryInfo, TelemetrySystemInfo,
 };
 use near_primitives::time::{Clock, Instant};
-use near_primitives::types::{AccountId, BlockHeight, EpochHeight, Gas, NumBlocks};
+use near_primitives::types::{AccountId, BlockHeight, EpochHeight, Gas, NumBlocks, ShardId};
 use near_primitives::validator_signer::ValidatorSigner;
 use near_primitives::version::{Version, DB_VERSION, PROTOCOL_VERSION};
 use near_primitives::views::{CurrentEpochValidatorInfo, EpochValidatorInfo, ValidatorKickoutView};
@@ -20,6 +20,8 @@ use near_telemetry::{telemetry, TelemetryActor};
 use std::cmp::min;
 use std::sync::Arc;
 use sysinfo::{get_current_pid, set_open_files_limit, Pid, ProcessExt, System, SystemExt};
+
+const TERAGAS: f64 = 1_000_000_000_000_f64;
 
 pub struct ValidatorInfoHelper {
     pub is_validator: bool,
@@ -69,6 +71,12 @@ impl InfoHelper {
             validator_signer,
             log_summary_style: client_config.log_summary_style,
         }
+    }
+
+    pub fn chunk_processed(&mut self, shard: ShardId, gas_used: Gas) {
+        metrics::TGAS_USAGE_HIST
+            .with_label_values(&[&format!("{}", shard)])
+            .observe(gas_used as f64 / TERAGAS);
     }
 
     pub fn block_processed(&mut self, gas_used: Gas, num_chunks: u64) {
@@ -166,8 +174,7 @@ impl InfoHelper {
         (metrics::CHUNKS_PER_BLOCK_MILLIS.set((1000. * chunks_per_block) as i64));
         (metrics::CPU_USAGE.set(cpu_usage as i64));
         (metrics::MEMORY_USAGE.set((memory_usage * 1024) as i64));
-        let teragas = 1_000_000_000_000u64;
-        (metrics::AVG_TGAS_USAGE.set((avg_gas_used as f64 / teragas as f64).round() as i64));
+        (metrics::AVG_TGAS_USAGE.set((avg_gas_used as f64 / TERAGAS).round() as i64));
         (metrics::EPOCH_HEIGHT.set(epoch_height as i64));
         (metrics::PROTOCOL_UPGRADE_BLOCK_HEIGHT.set(protocol_upgrade_block_height as i64));
         (metrics::NODE_PROTOCOL_VERSION.set(PROTOCOL_VERSION as i64));

--- a/chain/client/src/metrics.rs
+++ b/chain/client/src/metrics.rs
@@ -1,6 +1,6 @@
 use near_metrics::{
-    try_create_histogram, try_create_int_counter, try_create_int_gauge, Histogram, IntCounter,
-    IntGauge, IntGaugeVec,
+    try_create_histogram, try_create_histogram_vec, try_create_int_counter, try_create_int_gauge,
+    Histogram, HistogramVec, IntCounter, IntGauge, IntGaugeVec,
 };
 use once_cell::sync::Lazy;
 
@@ -58,6 +58,18 @@ pub static AVG_TGAS_USAGE: Lazy<IntGauge> = Lazy::new(|| {
     try_create_int_gauge(
         "near_chunk_tgas_used",
         "Number of Tgas (10^12 of gas) used by the last processed chunk",
+    )
+    .unwrap()
+});
+pub static TGAS_USAGE_HIST: Lazy<HistogramVec> = Lazy::new(|| {
+    try_create_histogram_vec(
+        "near_chunk_tgas_used_hist",
+        "Number of Tgas (10^12 of gas) used by processed chunks, as a histogram",
+        &["shard"],
+        Some(vec![
+            50., 100., 300., 500., 700., 800., 900., 950., 1000., 1050., 1100., 1150., 1200.,
+            1250., 1300.,
+        ]),
     )
     .unwrap()
 });


### PR DESCRIPTION
The metrics added look like this on a localnet node without transactions:
```
near_chunk_tgas_used_hist_bucket{shard="0",le="50"} 12
near_chunk_tgas_used_hist_bucket{shard="0",le="100"} 12
near_chunk_tgas_used_hist_bucket{shard="0",le="300"} 12
near_chunk_tgas_used_hist_bucket{shard="0",le="500"} 12
near_chunk_tgas_used_hist_bucket{shard="0",le="700"} 12
near_chunk_tgas_used_hist_bucket{shard="0",le="800"} 12
near_chunk_tgas_used_hist_bucket{shard="0",le="900"} 12
near_chunk_tgas_used_hist_bucket{shard="0",le="950"} 12
near_chunk_tgas_used_hist_bucket{shard="0",le="1000"} 12
near_chunk_tgas_used_hist_bucket{shard="0",le="1050"} 12
near_chunk_tgas_used_hist_bucket{shard="0",le="1100"} 12
near_chunk_tgas_used_hist_bucket{shard="0",le="1150"} 12
near_chunk_tgas_used_hist_bucket{shard="0",le="1200"} 12
near_chunk_tgas_used_hist_bucket{shard="0",le="1250"} 12
near_chunk_tgas_used_hist_bucket{shard="0",le="1300"} 12
near_chunk_tgas_used_hist_bucket{shard="0",le="+Inf"} 12
near_chunk_tgas_used_hist_sum{shard="0"} 0
near_chunk_tgas_used_hist_count{shard="0"} 12
```

Grafana is able to display that as a heatmap: https://grafana.com/docs/grafana/latest/visualizations/heatmap/