### PR TITLE
chore: reformat Cargo.toml lists with many elements in one line

### DIFF
--- a/chain/chain/Cargo.toml
+++ b/chain/chain/Cargo.toml
@@ -45,6 +45,10 @@ no_cache = ["near-store/no_cache"]
 protocol_feature_chunk_only_producers = ["near-chain-configs/protocol_feature_chunk_only_producers", "near-primitives/protocol_feature_chunk_only_producers"]
 
 protocol_feature_routing_exchange_algorithm = []
-nightly_protocol_features = ["nightly_protocol", "protocol_feature_chunk_only_producers", "protocol_feature_routing_exchange_algorithm"]
+nightly_protocol_features = [
+  "nightly_protocol",
+  "protocol_feature_chunk_only_producers",
+  "protocol_feature_routing_exchange_algorithm",
+]
 nightly_protocol = ["near-store/nightly_protocol", "near-primitives/nightly_protocol"]
 sandbox = []

--- a/chain/chain/Cargo.toml
+++ b/chain/chain/Cargo.toml
@@ -42,7 +42,10 @@ expensive_tests = []
 test_features = []
 delay_detector = ["delay-detector"]
 no_cache = ["near-store/no_cache"]
-protocol_feature_chunk_only_producers = ["near-chain-configs/protocol_feature_chunk_only_producers", "near-primitives/protocol_feature_chunk_only_producers"]
+protocol_feature_chunk_only_producers = [
+  "near-chain-configs/protocol_feature_chunk_only_producers",
+  "near-primitives/protocol_feature_chunk_only_producers",
+]
 
 protocol_feature_routing_exchange_algorithm = []
 nightly_protocol_features = [
@@ -50,5 +53,8 @@ nightly_protocol_features = [
   "protocol_feature_chunk_only_producers",
   "protocol_feature_routing_exchange_algorithm",
 ]
-nightly_protocol = ["near-store/nightly_protocol", "near-primitives/nightly_protocol"]
+nightly_protocol = [
+  "near-store/nightly_protocol",
+  "near-primitives/nightly_protocol",
+]
 sandbox = []

--- a/chain/client/Cargo.toml
+++ b/chain/client/Cargo.toml
@@ -50,13 +50,19 @@ near-actix-test-utils = { path = "../../test-utils/actix-test-utils" }
 # if enabled, we assert in most situations that are impossible unless some byzantine behavior is observed.
 byzantine_asserts = ["near-chain/byzantine_asserts"]
 expensive_tests = []
-test_features = ["near-network/test_features", "near-chain/test_features"]
+test_features = [
+  "near-network/test_features",
+  "near-chain/test_features",
+]
 delay_detector = [
   "near-chain/delay_detector",
   "near-network/delay_detector",
   "delay-detector",
 ]
-protocol_feature_chunk_only_producers = ["near-primitives/protocol_feature_chunk_only_producers", "near-chain/protocol_feature_chunk_only_producers"]
+protocol_feature_chunk_only_producers = [
+  "near-primitives/protocol_feature_chunk_only_producers",
+  "near-chain/protocol_feature_chunk_only_producers",
+]
 protocol_feature_routing_exchange_algorithm = [
   "near-network/protocol_feature_routing_exchange_algorithm",
   "near-chain/protocol_feature_routing_exchange_algorithm",
@@ -68,4 +74,7 @@ nightly_protocol_features = [
   "near-chain/nightly_protocol_features",
   "protocol_feature_routing_exchange_algorithm",
 ]
-sandbox = ["near-network/sandbox", "near-chain/sandbox"]
+sandbox = [
+  "near-network/sandbox",
+  "near-chain/sandbox",
+]

--- a/chain/client/Cargo.toml
+++ b/chain/client/Cargo.toml
@@ -51,9 +51,21 @@ near-actix-test-utils = { path = "../../test-utils/actix-test-utils" }
 byzantine_asserts = ["near-chain/byzantine_asserts"]
 expensive_tests = []
 test_features = ["near-network/test_features", "near-chain/test_features"]
-delay_detector = ["near-chain/delay_detector", "near-network/delay_detector", "delay-detector"]
+delay_detector = [
+  "near-chain/delay_detector",
+  "near-network/delay_detector",
+  "delay-detector",
+]
 protocol_feature_chunk_only_producers = ["near-primitives/protocol_feature_chunk_only_producers", "near-chain/protocol_feature_chunk_only_producers"]
-protocol_feature_routing_exchange_algorithm = ["near-network/protocol_feature_routing_exchange_algorithm", "near-chain/protocol_feature_routing_exchange_algorithm", "near-primitives/protocol_feature_routing_exchange_algorithm"]
+protocol_feature_routing_exchange_algorithm = [
+  "near-network/protocol_feature_routing_exchange_algorithm",
+  "near-chain/protocol_feature_routing_exchange_algorithm",
+  "near-primitives/protocol_feature_routing_exchange_algorithm",
+]
 nightly_protocol = []
-nightly_protocol_features = ["nightly_protocol", "near-chain/nightly_protocol_features", "protocol_feature_routing_exchange_algorithm"]
+nightly_protocol_features = [
+  "nightly_protocol",
+  "near-chain/nightly_protocol_features",
+  "protocol_feature_routing_exchange_algorithm",
+]
 sandbox = ["near-network/sandbox", "near-chain/sandbox"]

--- a/chain/epoch_manager/Cargo.toml
+++ b/chain/epoch_manager/Cargo.toml
@@ -29,8 +29,17 @@ near-chain-configs = { path = "../../core/chain-configs" }
 
 [features]
 expensive_tests = []
-protocol_feature_chunk_only_producers = ["near-primitives/protocol_feature_chunk_only_producers", "near-chain-configs/protocol_feature_chunk_only_producers", "near-chain/protocol_feature_chunk_only_producers"]
+protocol_feature_chunk_only_producers = [
+  "near-primitives/protocol_feature_chunk_only_producers",
+  "near-chain-configs/protocol_feature_chunk_only_producers",
+  "near-chain/protocol_feature_chunk_only_producers",
+]
 protocol_feature_fix_staking_threshold = ["near-primitives/protocol_feature_fix_staking_threshold"]
-nightly_protocol_features = ["nightly_protocol", "near-primitives/nightly_protocol_features", "protocol_feature_chunk_only_producers", "protocol_feature_fix_staking_threshold"]
+nightly_protocol_features = [
+  "nightly_protocol",
+  "near-primitives/nightly_protocol_features",
+  "protocol_feature_chunk_only_producers",
+  "protocol_feature_fix_staking_threshold",
+]
 nightly_protocol = ["near-primitives/nightly_protocol"]
 no_cache = []

--- a/chain/jsonrpc/Cargo.toml
+++ b/chain/jsonrpc/Cargo.toml
@@ -33,7 +33,16 @@ near-network-primitives = { path = "../network-primitives" }
 
 [features]
 dump_errors_schema = ["near-rpc-error-macro/dump_errors_schema"]
-test_features = ["near-client/test_features", "near-network/test_features", "near-jsonrpc-primitives/test_features", "near-jsonrpc-adversarial-primitives/ser_de"]
+test_features = [
+  "near-client/test_features",
+  "near-network/test_features",
+  "near-jsonrpc-primitives/test_features",
+  "near-jsonrpc-adversarial-primitives/ser_de",
+]
 nightly_protocol = ["near-primitives/nightly_protocol"]
 sandbox = ["near-network/sandbox", "near-client/sandbox"]
-protocol_feature_routing_exchange_algorithm = ["near-network/protocol_feature_routing_exchange_algorithm", "near-client/protocol_feature_routing_exchange_algorithm", "near-primitives/protocol_feature_routing_exchange_algorithm"]
+protocol_feature_routing_exchange_algorithm = [
+  "near-network/protocol_feature_routing_exchange_algorithm",
+  "near-client/protocol_feature_routing_exchange_algorithm",
+  "near-primitives/protocol_feature_routing_exchange_algorithm",
+]

--- a/chain/jsonrpc/Cargo.toml
+++ b/chain/jsonrpc/Cargo.toml
@@ -40,7 +40,10 @@ test_features = [
   "near-jsonrpc-adversarial-primitives/ser_de",
 ]
 nightly_protocol = ["near-primitives/nightly_protocol"]
-sandbox = ["near-network/sandbox", "near-client/sandbox"]
+sandbox = [
+  "near-network/sandbox",
+  "near-client/sandbox",
+]
 protocol_feature_routing_exchange_algorithm = [
   "near-network/protocol_feature_routing_exchange_algorithm",
   "near-client/protocol_feature_routing_exchange_algorithm",

--- a/chain/network-primitives/Cargo.toml
+++ b/chain/network-primitives/Cargo.toml
@@ -25,6 +25,9 @@ near-crypto = { path = "../../core/crypto" }
 near-primitives = { path = "../../core/primitives" }
 
 [features]
-deepsize_feature = ["deepsize", "near-primitives/deepsize_feature"]
+deepsize_feature = [
+  "deepsize",
+  "near-primitives/deepsize_feature",
+]
 sandbox = []
 test_features = ["serde"]

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -59,7 +59,10 @@ protocol_feature_routing_exchange_algorithm = [
     "near-stable-hasher",
 ]
 sandbox = ["near-network-primitives/sandbox"]
-test_features = ["near-network-primitives/test_features", "serde"]
+test_features = [
+  "near-network-primitives/test_features",
+  "serde",
+]
 
 [[bench]]
 name = "graph"

--- a/chain/rosetta-rpc/Cargo.toml
+++ b/chain/rosetta-rpc/Cargo.toml
@@ -41,4 +41,8 @@ near-network = { path = "../network" }
 insta = "1"
 
 [features]
-protocol_feature_chunk_only_producers = ["near-primitives/protocol_feature_chunk_only_producers", "near-client/protocol_feature_chunk_only_producers", "near-chain-configs/protocol_feature_chunk_only_producers"]
+protocol_feature_chunk_only_producers = [
+  "near-primitives/protocol_feature_chunk_only_producers",
+  "near-client/protocol_feature_chunk_only_producers",
+  "near-chain-configs/protocol_feature_chunk_only_producers",
+]

--- a/core/crypto/Cargo.toml
+++ b/core/crypto/Cargo.toml
@@ -37,5 +37,8 @@ hex-literal = "0.2"
 sha2 = ">=0.8,<0.10"
 
 [features]
-deepsize_feature = ["deepsize", "near-account-id/deepsize_feature"]
+deepsize_feature = [
+  "deepsize",
+  "near-account-id/deepsize_feature",
+]
 

--- a/core/primitives-core/Cargo.toml
+++ b/core/primitives-core/Cargo.toml
@@ -31,4 +31,7 @@ serde_json = "1"
 default = []
 protocol_feature_alt_bn128 = []
 protocol_feature_routing_exchange_algorithm = []
-deepsize_feature = ["deepsize", "near-account-id/deepsize_feature"]
+deepsize_feature = [
+  "deepsize",
+  "near-account-id/deepsize_feature",
+]

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -37,7 +37,10 @@ near-rpc-error-macro = { path = "../../tools/rpctypegen/macro" }
 
 [features]
 dump_errors_schema = ["near-rpc-error-macro/dump_errors_schema"]
-protocol_feature_alt_bn128 = ["near-primitives-core/protocol_feature_alt_bn128", "near-vm-errors/protocol_feature_alt_bn128"]
+protocol_feature_alt_bn128 = [
+  "near-primitives-core/protocol_feature_alt_bn128",
+  "near-vm-errors/protocol_feature_alt_bn128",
+]
 protocol_feature_chunk_only_producers = []
 protocol_feature_routing_exchange_algorithm = ["near-primitives-core/protocol_feature_routing_exchange_algorithm"]
 protocol_feature_access_key_nonce_for_implicit_accounts = []

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -42,9 +42,21 @@ protocol_feature_chunk_only_producers = []
 protocol_feature_routing_exchange_algorithm = ["near-primitives-core/protocol_feature_routing_exchange_algorithm"]
 protocol_feature_access_key_nonce_for_implicit_accounts = []
 protocol_feature_fix_staking_threshold = []
-nightly_protocol_features = ["nightly_protocol", "protocol_feature_alt_bn128", "protocol_feature_chunk_only_producers", "protocol_feature_routing_exchange_algorithm", "protocol_feature_access_key_nonce_for_implicit_accounts", "protocol_feature_fix_staking_threshold"]
+nightly_protocol_features = [
+  "nightly_protocol",
+  "protocol_feature_alt_bn128",
+  "protocol_feature_chunk_only_producers",
+  "protocol_feature_routing_exchange_algorithm",
+  "protocol_feature_access_key_nonce_for_implicit_accounts",
+  "protocol_feature_fix_staking_threshold",
+]
 nightly_protocol = []
-deepsize_feature = ["deepsize", "near-vm-errors/deepsize_feature", "near-primitives-core/deepsize_feature", "near-crypto/deepsize_feature"]
+deepsize_feature = [
+  "deepsize",
+  "near-vm-errors/deepsize_feature",
+  "near-primitives-core/deepsize_feature",
+  "near-crypto/deepsize_feature",
+]
 
 [dev-dependencies]
 bencher = "0.1.5"

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -47,4 +47,7 @@ single_thread_rocksdb = [] # Deactivate RocksDB IO background threads
 test_features = []
 protocol_feature_chunk_only_producers = []
 nightly_protocol = []
-nightly_protocol_features = ["nightly_protocol", "protocol_feature_chunk_only_producers"]
+nightly_protocol_features = [
+  "nightly_protocol",
+  "protocol_feature_chunk_only_producers",
+]

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -65,7 +65,17 @@ protocol_feature_alt_bn128 = [
 ]
 protocol_feature_chunk_only_producers = ["near-client/protocol_feature_chunk_only_producers", "near-primitives/protocol_feature_chunk_only_producers"]
 protocol_feature_access_key_nonce_for_implicit_accounts = ["near-primitives/protocol_feature_access_key_nonce_for_implicit_accounts", "node-runtime/protocol_feature_access_key_nonce_for_implicit_accounts"]
-nightly_protocol_features = ["nearcore/nightly_protocol_features", "protocol_feature_alt_bn128", "protocol_feature_chunk_only_producers", "protocol_feature_access_key_nonce_for_implicit_accounts"]
+nightly_protocol_features = [
+  "nearcore/nightly_protocol_features",
+  "protocol_feature_alt_bn128",
+  "protocol_feature_chunk_only_producers",
+  "protocol_feature_access_key_nonce_for_implicit_accounts",
+]
 nightly_protocol = ["nearcore/nightly_protocol"]
-sandbox = ["near-network/sandbox", "near-chain/sandbox", "node-runtime/sandbox", "near-client/sandbox"]
+sandbox = [
+  "near-network/sandbox",
+  "near-chain/sandbox",
+  "node-runtime/sandbox",
+  "near-client/sandbox",
+]
 no_cache = ["nearcore/no_cache"]

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -55,7 +55,10 @@ near-logger-utils = { path = "../test-utils/logger" }
 portpicker = "0.1.1"
 
 [features]
-performance_stats = ["nearcore/performance_stats", "near-network/performance_stats"]
+performance_stats = [
+  "nearcore/performance_stats",
+  "near-network/performance_stats",
+]
 expensive_tests = []
 test_features = ["nearcore/test_features"]
 protocol_feature_alt_bn128 = [
@@ -63,8 +66,14 @@ protocol_feature_alt_bn128 = [
     "node-runtime/protocol_feature_alt_bn128",
     "near-vm-errors/protocol_feature_alt_bn128",
 ]
-protocol_feature_chunk_only_producers = ["near-client/protocol_feature_chunk_only_producers", "near-primitives/protocol_feature_chunk_only_producers"]
-protocol_feature_access_key_nonce_for_implicit_accounts = ["near-primitives/protocol_feature_access_key_nonce_for_implicit_accounts", "node-runtime/protocol_feature_access_key_nonce_for_implicit_accounts"]
+protocol_feature_chunk_only_producers = [
+  "near-client/protocol_feature_chunk_only_producers",
+  "near-primitives/protocol_feature_chunk_only_producers",
+]
+protocol_feature_access_key_nonce_for_implicit_accounts = [
+  "near-primitives/protocol_feature_access_key_nonce_for_implicit_accounts",
+  "node-runtime/protocol_feature_access_key_nonce_for_implicit_accounts",
+]
 nightly_protocol_features = [
   "nearcore/nightly_protocol_features",
   "protocol_feature_alt_bn128",

--- a/nearcore/Cargo.toml
+++ b/nearcore/Cargo.toml
@@ -67,7 +67,10 @@ primitive-types = "0.10"
 [features]
 default = ["json_rpc"]
 
-performance_stats = ["near-performance-metrics/performance_stats", "near-rust-allocator-proxy"]
+performance_stats = [
+  "near-performance-metrics/performance_stats",
+  "near-rust-allocator-proxy",
+]
 memory_stats = ["near-performance-metrics/memory_stats"]
 c_memory_stats = ["near-performance-metrics/c_memory_stats"]
 test_features = [
@@ -90,7 +93,10 @@ no_cache = [
 delay_detector = ["near-client/delay_detector"]
 rosetta_rpc = ["near-rosetta-rpc"]
 json_rpc = ["near-jsonrpc"]
-protocol_feature_alt_bn128 = ["near-primitives/protocol_feature_alt_bn128", "node-runtime/protocol_feature_alt_bn128"]
+protocol_feature_alt_bn128 = [
+  "near-primitives/protocol_feature_alt_bn128",
+  "node-runtime/protocol_feature_alt_bn128",
+]
 protocol_feature_chunk_only_producers = [
   "near-chain-configs/protocol_feature_chunk_only_producers",
   "near-epoch-manager/protocol_feature_chunk_only_producers",
@@ -107,8 +113,14 @@ protocol_feature_routing_exchange_algorithm = [
   "near-client/protocol_feature_routing_exchange_algorithm",
   "near-jsonrpc/protocol_feature_routing_exchange_algorithm",
 ]
-protocol_feature_access_key_nonce_for_implicit_accounts = ["near-primitives/protocol_feature_access_key_nonce_for_implicit_accounts", "node-runtime/protocol_feature_access_key_nonce_for_implicit_accounts"]
-protocol_feature_fix_staking_threshold = ["near-primitives/protocol_feature_fix_staking_threshold", "near-epoch-manager/protocol_feature_fix_staking_threshold"]
+protocol_feature_access_key_nonce_for_implicit_accounts = [
+  "near-primitives/protocol_feature_access_key_nonce_for_implicit_accounts",
+  "node-runtime/protocol_feature_access_key_nonce_for_implicit_accounts",
+]
+protocol_feature_fix_staking_threshold = [
+  "near-primitives/protocol_feature_fix_staking_threshold",
+  "near-epoch-manager/protocol_feature_fix_staking_threshold",
+]
 nightly_protocol_features = [
   "nightly_protocol",
   "near-primitives/nightly_protocol_features",
@@ -121,7 +133,10 @@ nightly_protocol_features = [
   "protocol_feature_access_key_nonce_for_implicit_accounts",
   "protocol_feature_fix_staking_threshold",
 ]
-nightly_protocol = ["near-primitives/nightly_protocol", "near-jsonrpc/nightly_protocol"]
+nightly_protocol = [
+  "near-primitives/nightly_protocol",
+  "near-jsonrpc/nightly_protocol",
+]
 
 # Force usage of a specific wasm vm irrespective of protocol version.
 force_wasmer2 = ["near-vm-runner/force_wasmer2"]

--- a/nearcore/Cargo.toml
+++ b/nearcore/Cargo.toml
@@ -70,18 +70,57 @@ default = ["json_rpc"]
 performance_stats = ["near-performance-metrics/performance_stats", "near-rust-allocator-proxy"]
 memory_stats = ["near-performance-metrics/memory_stats"]
 c_memory_stats = ["near-performance-metrics/c_memory_stats"]
-test_features = ["near-client/test_features", "near-network/test_features", "near-store/test_features", "near-jsonrpc/test_features"]
-expensive_tests = ["near-client/expensive_tests", "near-epoch-manager/expensive_tests", "near-chain/expensive_tests"]
-no_cache = ["node-runtime/no_cache", "near-store/no_cache", "near-chain/no_cache", "near-epoch-manager/no_cache"]
+test_features = [
+  "near-client/test_features",
+  "near-network/test_features",
+  "near-store/test_features",
+  "near-jsonrpc/test_features",
+]
+expensive_tests = [
+  "near-client/expensive_tests",
+  "near-epoch-manager/expensive_tests",
+  "near-chain/expensive_tests",
+]
+no_cache = [
+  "node-runtime/no_cache",
+  "near-store/no_cache",
+  "near-chain/no_cache",
+  "near-epoch-manager/no_cache",
+]
 delay_detector = ["near-client/delay_detector"]
 rosetta_rpc = ["near-rosetta-rpc"]
 json_rpc = ["near-jsonrpc"]
 protocol_feature_alt_bn128 = ["near-primitives/protocol_feature_alt_bn128", "node-runtime/protocol_feature_alt_bn128"]
-protocol_feature_chunk_only_producers = ["near-chain-configs/protocol_feature_chunk_only_producers", "near-epoch-manager/protocol_feature_chunk_only_producers", "near-chain/protocol_feature_chunk_only_producers", "near-client/protocol_feature_chunk_only_producers", "node-runtime/protocol_feature_chunk_only_producers", "near-rosetta-rpc/protocol_feature_chunk_only_producers", "near-primitives/protocol_feature_chunk_only_producers"]
-protocol_feature_routing_exchange_algorithm = ["near-primitives/protocol_feature_routing_exchange_algorithm", "near-chain/protocol_feature_routing_exchange_algorithm", "near-network/protocol_feature_routing_exchange_algorithm", "near-client/protocol_feature_routing_exchange_algorithm", "near-jsonrpc/protocol_feature_routing_exchange_algorithm"]
+protocol_feature_chunk_only_producers = [
+  "near-chain-configs/protocol_feature_chunk_only_producers",
+  "near-epoch-manager/protocol_feature_chunk_only_producers",
+  "near-chain/protocol_feature_chunk_only_producers",
+  "near-client/protocol_feature_chunk_only_producers",
+  "node-runtime/protocol_feature_chunk_only_producers",
+  "near-rosetta-rpc/protocol_feature_chunk_only_producers",
+  "near-primitives/protocol_feature_chunk_only_producers",
+]
+protocol_feature_routing_exchange_algorithm = [
+  "near-primitives/protocol_feature_routing_exchange_algorithm",
+  "near-chain/protocol_feature_routing_exchange_algorithm",
+  "near-network/protocol_feature_routing_exchange_algorithm",
+  "near-client/protocol_feature_routing_exchange_algorithm",
+  "near-jsonrpc/protocol_feature_routing_exchange_algorithm",
+]
 protocol_feature_access_key_nonce_for_implicit_accounts = ["near-primitives/protocol_feature_access_key_nonce_for_implicit_accounts", "node-runtime/protocol_feature_access_key_nonce_for_implicit_accounts"]
 protocol_feature_fix_staking_threshold = ["near-primitives/protocol_feature_fix_staking_threshold", "near-epoch-manager/protocol_feature_fix_staking_threshold"]
-nightly_protocol_features = ["nightly_protocol", "near-primitives/nightly_protocol_features", "near-client/nightly_protocol_features", "near-epoch-manager/nightly_protocol_features", "near-store/nightly_protocol_features", "protocol_feature_alt_bn128", "protocol_feature_chunk_only_producers", "protocol_feature_routing_exchange_algorithm", "protocol_feature_access_key_nonce_for_implicit_accounts", "protocol_feature_fix_staking_threshold"]
+nightly_protocol_features = [
+  "nightly_protocol",
+  "near-primitives/nightly_protocol_features",
+  "near-client/nightly_protocol_features",
+  "near-epoch-manager/nightly_protocol_features",
+  "near-store/nightly_protocol_features",
+  "protocol_feature_alt_bn128",
+  "protocol_feature_chunk_only_producers",
+  "protocol_feature_routing_exchange_algorithm",
+  "protocol_feature_access_key_nonce_for_implicit_accounts",
+  "protocol_feature_fix_staking_threshold",
+]
 nightly_protocol = ["near-primitives/nightly_protocol", "near-jsonrpc/nightly_protocol"]
 
 # Force usage of a specific wasm vm irrespective of protocol version.
@@ -89,4 +128,8 @@ force_wasmer2 = ["near-vm-runner/force_wasmer2"]
 force_wasmer0 = ["near-vm-runner/force_wasmer0"]
 force_wasmtime = ["near-vm-runner/force_wasmtime"]
 
-sandbox = ["near-client/sandbox", "node-runtime/sandbox", "near-jsonrpc/sandbox"]
+sandbox = [
+  "near-client/sandbox",
+  "node-runtime/sandbox",
+  "near-jsonrpc/sandbox",
+]

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -50,7 +50,10 @@ delay_detector = ["nearcore/delay_detector"]
 rosetta_rpc = ["nearcore/rosetta_rpc"]
 json_rpc = ["nearcore/json_rpc"]
 protocol_feature_alt_bn128 = ["nearcore/protocol_feature_alt_bn128"]
-protocol_feature_chunk_only_producers = ["nearcore/protocol_feature_chunk_only_producers", "near-primitives/protocol_feature_chunk_only_producers"]
+protocol_feature_chunk_only_producers = [
+  "nearcore/protocol_feature_chunk_only_producers",
+  "near-primitives/protocol_feature_chunk_only_producers",
+]
 protocol_feature_routing_exchange_algorithm = ["nearcore/protocol_feature_routing_exchange_algorithm"]
 protocol_feature_fix_staking_threshold = ["nearcore/protocol_feature_fix_staking_threshold"]
 nightly_protocol_features = ["nearcore/nightly_protocol_features"]

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -37,7 +37,11 @@ default = ["json_rpc", "jemalloc"]
 
 jemalloc = ["tikv-jemallocator"]
 performance_stats = ["nearcore/performance_stats"]
-memory_stats = ["nearcore/memory_stats", "near-rust-allocator-proxy", "jemalloc"]
+memory_stats = [
+  "nearcore/memory_stats",
+  "near-rust-allocator-proxy",
+  "jemalloc",
+]
 c_memory_stats = ["nearcore/c_memory_stats"]
 test_features = ["nearcore/test_features"]
 expensive_tests = ["nearcore/expensive_tests"]

--- a/runtime/near-vm-errors/Cargo.toml
+++ b/runtime/near-vm-errors/Cargo.toml
@@ -25,4 +25,7 @@ near-rpc-error-macro = { path = "../../tools/rpctypegen/macro" }
 [features]
 dump_errors_schema = ["near-rpc-error-macro/dump_errors_schema"]
 protocol_feature_alt_bn128 = []
-deepsize_feature = ["deepsize", "near-account-id/deepsize_feature"]
+deepsize_feature = [
+  "deepsize",
+  "near-account-id/deepsize_feature",
+]

--- a/runtime/near-vm-logic/Cargo.toml
+++ b/runtime/near-vm-logic/Cargo.toml
@@ -38,7 +38,11 @@ serde_json = { version = "1", features = ["preserve_order"] }
 
 [features]
 default = []
-protocol_feature_alt_bn128 = ["bn", "near-primitives-core/protocol_feature_alt_bn128", "near-vm-errors/protocol_feature_alt_bn128"]
+protocol_feature_alt_bn128 = [
+  "bn",
+  "near-primitives-core/protocol_feature_alt_bn128",
+  "near-vm-errors/protocol_feature_alt_bn128",
+]
 
 # Use this feature to enable counting of fees and costs applied.
 costs_counting = []

--- a/runtime/near-vm-runner-standalone/Cargo.toml
+++ b/runtime/near-vm-runner-standalone/Cargo.toml
@@ -40,7 +40,10 @@ near-test-contracts = { path = "../near-test-contracts" }
 [features]
 default = []
 no_cache = ["near-vm-runner/no_cache"]
-protocol_feature_alt_bn128 = ["near-vm-logic/protocol_feature_alt_bn128", "near-vm-runner/protocol_feature_alt_bn128"]
+protocol_feature_alt_bn128 = [
+  "near-vm-logic/protocol_feature_alt_bn128",
+  "near-vm-runner/protocol_feature_alt_bn128",
+]
 nightly_protocol_features = [
   "nightly_protocol",
   "near-primitives/nightly_protocol_features",

--- a/runtime/near-vm-runner-standalone/Cargo.toml
+++ b/runtime/near-vm-runner-standalone/Cargo.toml
@@ -41,5 +41,9 @@ near-test-contracts = { path = "../near-test-contracts" }
 default = []
 no_cache = ["near-vm-runner/no_cache"]
 protocol_feature_alt_bn128 = ["near-vm-logic/protocol_feature_alt_bn128", "near-vm-runner/protocol_feature_alt_bn128"]
-nightly_protocol_features = ["nightly_protocol", "near-primitives/nightly_protocol_features", "protocol_feature_alt_bn128"]
+nightly_protocol_features = [
+  "nightly_protocol",
+  "near-primitives/nightly_protocol_features",
+  "protocol_feature_alt_bn128",
+]
 nightly_protocol = ["near-primitives/nightly_protocol"]

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -63,7 +63,11 @@ base64 = "0.13"
 
 [features]
 # all vms enabled for now
-default = ["wasmer0_vm", "wasmtime_vm", "wasmer2_vm"]
+default = [
+  "wasmer0_vm",
+  "wasmtime_vm",
+  "wasmer2_vm",
+]
 wasmer0_vm = [ "wasmer-runtime", "wasmer-runtime-core" ]
 wasmtime_vm = [ "wasmtime", "anyhow"]
 wasmer2_vm = [

--- a/runtime/runtime-params-estimator/Cargo.toml
+++ b/runtime/runtime-params-estimator/Cargo.toml
@@ -49,7 +49,11 @@ wat = "1.0"
 default = ["costs_counting"]
 costs_counting = ["near-vm-logic/costs_counting"]
 # Required feature for proper config, but can't be enabled by default because it is leaked to other release crates.
-required = ["costs_counting", "near-vm-runner/no_cpu_compatibility_checks", "no_cache"]
+required = [
+  "costs_counting",
+  "near-vm-runner/no_cpu_compatibility_checks",
+  "no_cache",
+]
 no_cache = ["node-runtime/no_cache", "near-store/no_cache"]
 wasmtime = ["near-vm-runner/force_wasmtime"]
 nightly_protocol = ["near-primitives/nightly_protocol"]

--- a/runtime/runtime-params-estimator/Cargo.toml
+++ b/runtime/runtime-params-estimator/Cargo.toml
@@ -54,7 +54,10 @@ required = [
   "near-vm-runner/no_cpu_compatibility_checks",
   "no_cache",
 ]
-no_cache = ["node-runtime/no_cache", "near-store/no_cache"]
+no_cache = [
+  "node-runtime/no_cache",
+  "near-store/no_cache",
+]
 wasmtime = ["near-vm-runner/force_wasmtime"]
 nightly_protocol = ["near-primitives/nightly_protocol"]
 nightly_protocol_features = ["protocol_feature_alt_bn128"]

--- a/runtime/runtime/Cargo.toml
+++ b/runtime/runtime/Cargo.toml
@@ -37,7 +37,11 @@ near-vm-errors = { path = "../../runtime/near-vm-errors" }
 [features]
 default = []
 dump_errors_schema = ["near-vm-errors/dump_errors_schema"]
-protocol_feature_chunk_only_producers = ["near-primitives/protocol_feature_chunk_only_producers", "near-store/protocol_feature_chunk_only_producers", "near-chain-configs/protocol_feature_chunk_only_producers"]
+protocol_feature_chunk_only_producers = [
+  "near-primitives/protocol_feature_chunk_only_producers",
+  "near-store/protocol_feature_chunk_only_producers",
+  "near-chain-configs/protocol_feature_chunk_only_producers",
+]
 protocol_feature_access_key_nonce_for_implicit_accounts = ["near-primitives/protocol_feature_access_key_nonce_for_implicit_accounts"]
 no_cpu_compatibility_checks = ["near-vm-runner/no_cpu_compatibility_checks"]
 

--- a/runtime/runtime/Cargo.toml
+++ b/runtime/runtime/Cargo.toml
@@ -45,7 +45,10 @@ protocol_feature_chunk_only_producers = [
 protocol_feature_access_key_nonce_for_implicit_accounts = ["near-primitives/protocol_feature_access_key_nonce_for_implicit_accounts"]
 no_cpu_compatibility_checks = ["near-vm-runner/no_cpu_compatibility_checks"]
 
-no_cache = ["near-vm-runner/no_cache", "near-store/no_cache"]
+no_cache = [
+  "near-vm-runner/no_cache",
+  "near-store/no_cache",
+]
 
 protocol_feature_alt_bn128 = [
     "near-primitives/protocol_feature_alt_bn128",

--- a/test-utils/state-viewer/Cargo.toml
+++ b/test-utils/state-viewer/Cargo.toml
@@ -36,6 +36,11 @@ near-client = { path = "../../chain/client" }
 testlib = { path = "../../test-utils/testlib" }
 
 [features]
-sandbox = ["node-runtime/sandbox", "near-chain/sandbox", "near-network/sandbox", "near-client/sandbox"]
+sandbox = [
+  "node-runtime/sandbox",
+  "near-chain/sandbox",
+  "near-network/sandbox",
+  "near-client/sandbox",
+]
 nightly_protocol_features = ["nearcore/nightly_protocol_features"]
 nightly_protocol = ["nearcore/nightly_protocol"]

--- a/test-utils/testlib/Cargo.toml
+++ b/test-utils/testlib/Cargo.toml
@@ -27,5 +27,9 @@ protocol_feature_chunk_only_producers = [
     "near-chain/protocol_feature_chunk_only_producers",
     "near-primitives/protocol_feature_chunk_only_producers",
 ]
-nightly_protocol_features = ["nightly_protocol", "protocol_feature_chunk_only_producers", "protocol_feature_alt_bn128"]
+nightly_protocol_features = [
+  "nightly_protocol",
+  "protocol_feature_chunk_only_producers",
+  "protocol_feature_alt_bn128",
+]
 nightly_protocol = []


### PR DESCRIPTION
this will make them easier to edit and the git diffs will be nicer.
Done with a python script that basically says:

  if len(list) > 1:
     reformat(list)

Issue: https://github.com/near/nearcore/issues/5328