### PR TITLE
Export ED25519SecretKey

### DIFF
--- a/core/crypto/src/lib.rs
+++ b/core/crypto/src/lib.rs
@@ -1,8 +1,8 @@
 pub use errors::{ParseKeyError, ParseKeyTypeError, ParseSignatureError};
 pub use key_file::KeyFile;
 pub use signature::{
-    ED25519PublicKey, KeyType, PublicKey, Secp256K1PublicKey, Secp256K1Signature, SecretKey,
-    Signature,
+    ED25519PublicKey, ED25519SecretKey, KeyType, PublicKey, Secp256K1PublicKey, Secp256K1Signature,
+    SecretKey, Signature,
 };
 pub use signer::{EmptySigner, InMemorySigner, Signer};
 


### PR DESCRIPTION
The type `ED25519SecretKey` appears in multiple public APIs for `SecretKey` but it is not exported and therefore can only be used opaquely. Notably, there is no way to construct one apart from doing tricks with `FromStr`.