### PR TITLE
feat: Differentiate code and data bytes

### DIFF
--- a/runtime/runtime-params-estimator/src/cost.rs
+++ b/runtime/runtime-params-estimator/src/cost.rs
@@ -243,10 +243,11 @@ pub enum Cost {
     ContractCompileBytesV2,
     /// The cost of contract deployment per byte, without the compilation cost.
     ///
-    /// Estimation: Measure the cost of two contract that have the same code but
-    /// include different data sections. One data section is significantly
-    /// larger. The cost difference is pure overhead of moving around bytes that
-    /// are not code. Divide this cost by the difference of bytes.
+    /// Estimation: Measure the deployment costs of two data-only contracts,
+    /// where one data sections is empty and the other is max size as allowed by
+    /// contract size limits. The cost difference is pure overhead of moving
+    /// around bytes that are not code. Divide this cost by the difference of
+    /// bytes.
     DeployBytes,
     GasMeteringBase,
     GasMeteringOp,

--- a/runtime/runtime-params-estimator/src/cost.rs
+++ b/runtime/runtime-params-estimator/src/cost.rs
@@ -241,6 +241,13 @@ pub enum Cost {
     /// produces the steepest line.
     ContractCompileBaseV2,
     ContractCompileBytesV2,
+    /// The cost of contract deployment per byte, without the compilation cost.
+    ///
+    /// Estimation: Measure the cost of two contract that have the same code but
+    /// include different data sections. One data section is significantly
+    /// larger. The cost difference is pure overhead of moving around bytes that
+    /// are not code. Divide this cost by the difference of bytes.
+    DeployBytes,
     GasMeteringBase,
     GasMeteringOp,
     /// Cost of inserting a new value directly into a RocksDB instance.

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -627,7 +627,6 @@ fn pure_deploy_bytes(ctx: &mut EstimatorContext) -> GasCost {
     let cost_4mb = deploy_contract_cost(ctx, large_code, Some(b"main"));
 
     if cost_4mb < cost_empty {
-        eprintln!("High variance in pure_deploy_bytes: Deployment cost of small contract is higher than large contract.");
         let mut cost = GasCost::zero(ctx.config.metric);
         cost.set_uncertain(true);
         cost

--- a/runtime/runtime-params-estimator/src/utils.rs
+++ b/runtime/runtime-params-estimator/src/utils.rs
@@ -8,6 +8,8 @@ use std::collections::HashMap;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::AccountId;
 use near_vm_logic::ExtCosts;
+use rand::distributions::Alphanumeric;
+use rand::Rng;
 
 pub fn read_resource(path: &str) -> Vec<u8> {
     let dir = env!("CARGO_MANIFEST_DIR");
@@ -222,4 +224,11 @@ pub(crate) fn generate_fn_name(index: usize, len: usize) -> Vec<u8> {
         name.push((b'A'..=b'Z').chain(b'a'..=b'z').nth(index % 52).unwrap());
     }
     name
+}
+
+/// Create a WASM module that is empty except for a main method and a single data entry with n characters
+pub(crate) fn generate_data_only_contract(data_size: usize) -> Vec<u8> {
+    let payload = rand::thread_rng().sample_iter(&Alphanumeric).take(data_size).collect::<String>();
+    let wat_code = format!("(module (data \"{}\") (func (export \"main\")))", payload);
+    wat::parse_str(wat_code).unwrap()
 }


### PR DESCRIPTION
The new deployment cost estimation now also treats data bytes and code
bytes differently  in the fromulas.
The new cost `DeployBytes` is there to assert the assumption that
compilation cost is the dominant factor.