### PR TITLE
feat: cache chunk nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3090,6 +3090,7 @@ version = "0.0.0"
 name = "near-store"
 version = "0.0.0"
 dependencies = [
+ "assert_matches",
  "bencher",
  "borsh",
  "byteorder",

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -626,9 +626,3 @@ impl Tip {
         }
     }
 }
-
-#[derive(Debug)]
-pub enum CacheState {
-    CachingShard,
-    CachingChunk,
-}

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -626,3 +626,9 @@ impl Tip {
         }
     }
 }
+
+#[derive(Debug)]
+pub enum CacheState {
+    CachingShard,
+    CachingChunk,
+}

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -962,3 +962,13 @@ pub trait EpochInfoProvider {
 
     fn minimum_stake(&self, prev_block_hash: &CryptoHash) -> Result<Balance, EpochError>;
 }
+
+/// State of the trie cache.
+#[derive(Debug)]
+pub enum TrieCacheState {
+    /// We put each visited node to LRU cache. It generally saves time, but existence of any node is not guaranteed;
+    CachingShard,
+    /// We put each visited node to the hash map. On the chunk processing, we guarantee that all nodes visited on such
+    /// state will be presented in the trie cache.
+    CachingChunk,
+}

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -31,6 +31,7 @@ near-primitives = { path = "../primitives" }
 tempfile = "3"
 bencher = "0.1.5"
 rand = "0.7"
+assert_matches = "1.5.0"
 
 [[bench]]
 name = "trie_bench"

--- a/core/store/src/migrations.rs
+++ b/core/store/src/migrations.rs
@@ -39,7 +39,7 @@ use crate::migrations::v6_to_v7::{
 use crate::migrations::v8_to_v9::{
     recompute_col_rc, repair_col_receipt_id_to_shard_id, repair_col_transactions,
 };
-use crate::trie::{TrieCache, TrieCachingStorage};
+use crate::trie::{SyncTrieCache, TrieCachingStorage};
 use crate::{create_store, Store, StoreUpdate, Trie, TrieUpdate, FINAL_HEAD_KEY, HEAD_KEY};
 use std::path::Path;
 
@@ -425,7 +425,7 @@ pub fn migrate_14_to_15(path: &Path) {
     let store = create_store(path);
     let trie_store = Box::new(TrieCachingStorage::new(
         store.clone(),
-        TrieCache::new(),
+        SyncTrieCache::new(),
         ShardUId::single_shard(),
     ));
     let trie = Rc::new(Trie::new(trie_store, ShardUId::single_shard()));

--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -228,14 +228,14 @@ impl TrieStorage for TrieMemoryPartialStorage {
 
 /// Maximum number of cache entries.
 /// It was chosen to fit into RAM well. RAM spend on trie cache should not exceed
-/// 50_000 * 4 (number of shards) * TRIE_LIMIT_CACHED_VALUE_SIZE = 800 MB.
+/// 50_000 * 4 (number of shards) * TRIE_LIMIT_CACHED_VALUE_SIZE * 2 (number of caches - for regular and view client) = 1.6 GB.
 /// In our tests on a single shard, it barely occupied 40 MB, which is dominated by state cache size
 /// with 512 MB limit. The total RAM usage for a single shard was 1 GB.
 #[cfg(not(feature = "no_cache"))]
-const TRIE_MAX_CACHE_SIZE: usize = 50000;
+const TRIE_MAX_SHARD_CACHE_SIZE: usize = 50000;
 
 #[cfg(feature = "no_cache")]
-const TRIE_MAX_CACHE_SIZE: usize = 1;
+const TRIE_MAX_SHARD_CACHE_SIZE: usize = 1;
 
 /// Values above this size (in bytes) are never cached.
 /// Note that Trie inner nodes are always smaller than this.

--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -19,6 +19,7 @@ pub struct SyncTrieCache(Arc<Mutex<TrieCache>>);
 /// Cache for Trie nodes.
 /// Maps hash of the encoded node to the encoded node bytes.
 /// Note that "node" here means both the trie node and the value stored in trie.
+/// TODO (#5920): enable chunk nodes caching in Runtime::apply.
 pub(crate) struct TrieCache {
     pub(crate) cache_state: TrieCacheState,
     shard_cache: LruCache<CryptoHash, Vec<u8>>,


### PR DESCRIPTION
Extend existing trie cache to support caching nodes visiting on a chunk.

Suggested model:
* By default, we are in the `CachingShard` mode.
* On funcall execution, we temporarily enable `CachingChunk` mode.

Because all nodes touched in such mode will be charged with 16 Ggas, the chunk cache size will be limited by 500 Tgas / 16 Ggas = 31250 elements. For each such node, we charge for touching it only once - on putting it into the cache.

The current implementation does not have effect on costs, because the way of enabling `CachingChunk` state is under discussion. With enabled costs, it will save ~33% of the cost for Aurora and ~87.5% of the touching trie node cost in particular.

The difference of receipt processing times is 2%, but this can be mitigated later, see https://near.zulipchat.com/#narrow/stream/295558-nearinc.2Fcore/topic/chunk.20nodes.20cache.20prototype for more details.

## Testing

* new trie cache tests in `trie_storage` 