### PR TITLE
State-viewer uses read-only RocksDB

### DIFF
--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -300,6 +300,11 @@ pub fn create_store(path: &Path) -> Store {
     Store::new(db)
 }
 
+pub fn create_read_only_store(path: &Path) -> Store {
+    let db = Arc::new(RocksDB::new_read_only(path).expect("Failed to open the database"));
+    Store::new(db)
+}
+
 /// Reads an object from Trie.
 /// # Errors
 /// see StorageError

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -9,7 +9,7 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::sharding::ChunkHash;
 use near_primitives::types::{BlockHeight, ShardId};
 use near_primitives::version::{DB_VERSION, PROTOCOL_VERSION};
-use near_store::{create_store, Store};
+use near_store::{create_read_only_store, Store};
 use nearcore::{get_default_home, get_store_path, load_config, NearConfig};
 use once_cell::sync::Lazy;
 use std::path::{Path, PathBuf};
@@ -109,7 +109,7 @@ pub enum StateViewerSubCommand {
 impl StateViewerSubCommand {
     pub fn run(self, home_dir: &Path, genesis_validation: GenesisValidationMode) {
         let near_config = load_config(home_dir, genesis_validation);
-        let store = create_store(&get_store_path(home_dir));
+        let store = create_read_only_store(&get_store_path(home_dir));
         match self {
             StateViewerSubCommand::Peers => peers(store),
             StateViewerSubCommand::State => state(home_dir, near_config, store),


### PR DESCRIPTION
Fix #5194

Tested by running 1.21, 1.22, 1.23 and 1.24 versions in localnet and attempting to dump their state.

Without this change, attempting to dump state can add a column (col49) which makes it impossible to dump state with state-viewer of the corresponding version.
With this change, state-viewer panics earlier and state-viewer of the corresponding version remains able to dump state:

```
Tue 14:17:50 ~/code/nearcore-rocksdb18-2 % RUST_BACKTRACE=all ./target/release/neard --home ~/.near/localnet/node0/ view_state dump_state
thread 'main' panicked at 'Failed to start Epoch Manager: IOErr(Unexpected length of input)', nearcore/src/runtime/mod.rs:198:18
stack backtrace:
   0: rust_begin_unwind
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/panicking.rs:498:5
   1: core::panicking::panic_fmt
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/core/src/panicking.rs:107:14
   2: core::result::unwrap_failed
             at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/core/src/result.rs:1613:5
   3: nearcore::runtime::NightshadeRuntime::new
   4: nearcore::runtime::NightshadeRuntime::with_config
   5: state_viewer::commands::load_trie_stop_at_height
   6: state_viewer::commands::dump_state
   7: state_viewer::cli::StateViewerSubCommand::run
   8: neard::cli::NeardCmd::parse_and_run
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```