### PR TITLE
chain: include information whether node is a validator in status line

### DIFF
--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -112,9 +112,14 @@ impl InfoHelper {
 
         let sync_status_log = Some(display_sync_status(sync_status, head, genesis_height));
 
-        let validator_info_log = validator_info
-            .as_ref()
-            .map(|info| format!(" {} validator{}", info.num_validators, s(info.num_validators)));
+        let validator_info_log = validator_info.as_ref().map(|info| {
+            format!(
+                "{}{} validator{}",
+                if info.is_validator { "Validator | " } else { "" },
+                info.num_validators,
+                s(info.num_validators)
+            )
+        });
 
         let network_info_log = Some(format!(
             " {} peer{} ⬇ {} ⬆ {}",


### PR DESCRIPTION
The status line has recently been simplified with many unnecessary
pieces of information being removed.  Among those was flag denoting
whether node was a validator.  Turns out that that particular piece of
information is desired to be kept.  Add it back.

Right now the status line will be:
- `42 validators 24 peers` if node is not a validator and
- `Validator | 42 validators 24 peers` if it is.

Fixes: https://github.com/near/nearcore/issues/2454