### PR TITLE
pytest: fuzz: fix test not killing fuzz processes correctly

### DIFF
--- a/pytest/requirements.txt
+++ b/pytest/requirements.txt
@@ -5,6 +5,7 @@ deepdiff
 ed25519
 numpy
 prometheus-client
+psutil
 pynacl
 python-rc==0.3.9
 requests

--- a/pytest/tests/fuzz.py
+++ b/pytest/tests/fuzz.py
@@ -46,7 +46,7 @@ def _kill_process_tree(pid: int) -> None:
 
     proc = psutil.Process(pid)
     procs = proc.children(recursive=True) + [proc]
-    for proc in procss:
+    for proc in procs:
         try:
             proc.send_signal(signal.SIGKILL)
         except psutil.NoSuchProcess:

--- a/pytest/tests/fuzz.py
+++ b/pytest/tests/fuzz.py
@@ -2,27 +2,60 @@
 
 import os
 import pathlib
+import signal
 import subprocess
 import sys
 import typing
 
+import psutil
 
-def run(directory: str, fuzz_target: str) -> int:
+
+def run(directory: str, fuzz_target: str, timeout=typing.Optional[int]) -> int:
     cwd = pathlib.Path(__file__).resolve().parents[2] / directory
     args = ('cargo', 'fuzz', 'run', fuzz_target, '--', '-len_control=0'
             '-prefer_small=0', '-max_len=4000000', '-rss_limit_mb=10240')
     os.environ['RUSTC_BOOTSTRAP'] = '1'
-    try:
-        # libfuzzer has a -max_total_time flag however it does not measure time
-        # compilation takes.  Because of that, rather than using that option
-        # we’re handling timeout over the entire command ourselves.
-        return subprocess.call(args, cwd=cwd, timeout=_get_timeout())
-    except subprocess.TimeoutExpired:
-        print('No failures found.')
-        return 0
+
+    # libfuzzer has a -max_total_time flag however it does not measure time
+    # compilation takes.  Because of that, rather than relying on that option
+    # we’re handling timeout over the entire command ourselves.  We’re still
+    # using the option though just to make sure the process terminates if we
+    # don’t handle timeout correctly.
+    if timeout:
+        args += (f'-max_total_time={timeout}',)
+
+    # Secondly, we’re not using `subprocess.call(..., timeout=...)` because that
+    # sends KILL signal only to the process spawned by the call and doesn’t kill
+    # its children.  So instead, we’re handling the timeout ourselves and
+    # killing the whole process tree.
+    with subprocess.Popen(args, cwd=cwd) as proc:
+        try:
+            return proc.wait(timeout=timeout)
+        except (KeyboardInterrupt, subprocess.TimeoutExpired):
+            _kill_process_tree(proc.pid)
+            print('No failures found.')
+            return 0
+
+
+def _kill_process_tree(pid: int) -> None:
+    """Kills a process tree (i.e. process and all its decedents)."""
+
+    proc = psutil.Process(pid)
+    procs = proc.children(recursive=True) + [proc]
+    for proc in procss:
+        try:
+            proc.send_signal(signal.SIGKILL)
+        except psutil.NoSuchProcess:
+            pass
 
 
 def _get_timeout() -> typing.Optional[int]:
+    """Returns test timeout configured on NayDuck
+
+    When run on NayDuck, returns timeout that NayDuck gives us to execute.  If
+    we run over that time, the test will be reported as timed out.  When not
+    running on NayDuck, returns None denoting no timeout.
+    """
     timeout = os.environ.get('NAYDUCK_TIMEOUT')
     if timeout:
         try:
@@ -46,7 +79,7 @@ def main(argv: typing.Sequence[str]) -> typing.Union[int, str, None]:
     if len(argv) != 3:
         return f'usage: {argv[0]} <directory> <fuzz-target>'
     _, directory, fuzz_target = argv
-    return run(directory, fuzz_target)
+    return run(directory, fuzz_target, timeout=_get_timeout())
 
 
 if __name__ == '__main__':

--- a/pytest/tests/fuzz.py
+++ b/pytest/tests/fuzz.py
@@ -75,9 +75,10 @@ def _kill_process_tree(pid: int) -> None:
 def _get_timeout() -> typing.Optional[int]:
     """Returns test timeout configured on NayDuck
 
-    When run on NayDuck, returns timeout in seconds that NayDuck gives us to
-    execute.  If we run over that time, the test will be reported as timed out.
-    When not running on NayDuck, returns None denoting no timeout.
+    Returns:
+        When run on NayDuck, returns timeout in seconds that NayDuck gives us to
+        execute.  If we run over that time, the test will be reported as timed
+        out.  When not running on NayDuck, returns None denoting no timeout.
     """
     timeout = os.environ.get('NAYDUCK_TIMEOUT')
     if timeout:

--- a/pytest/tests/fuzz.py
+++ b/pytest/tests/fuzz.py
@@ -2,6 +2,7 @@
 
 import os
 import pathlib
+import shlex
 import signal
 import subprocess
 import sys
@@ -23,6 +24,9 @@ def run(directory: str, fuzz_target: str, timeout=typing.Optional[int]) -> int:
     # don’t handle timeout correctly.
     if timeout:
         args += (f'-max_total_time={timeout}',)
+
+    cmd = ' '.join(shlex.quote(str(arg)) for arg in args)
+    sys.stderr.write(f'+ ( cd {shlex.quote(str(cwd))} && {cmd} )\n')
 
     # Secondly, we’re not using `subprocess.call(..., timeout=...)` because that
     # sends KILL signal only to the process spawned by the call and doesn’t kill


### PR DESCRIPTION
`subprocess.call(..., timeout=...)` will send KILL signal to the
process that has been spawned once the timeout passes but that may
leave its descendants still running.  To cover that case, handle
timeout ourselves by waiting and then killing the entire process tree.