### PR TITLE
Revert "chore: Upgrade rust-rocksdb 0.16 to 0.18 (#6289)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.59.2"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
+checksum = "fd4865004a46a0aafb2a0a5eb19d3c9fc46ee5f063a6cfc605c69ac9ecf5263d"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -674,17 +674,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bzip2-sys"
-version = "0.1.11+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "c2-chacha"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,9 +734,9 @@ dependencies = [
 
 [[package]]
 name = "cexpr"
-version = "0.6.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
 dependencies = [
  "nom",
 ]
@@ -2196,28 +2185,14 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.6.1+6.28.2"
+version = "6.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bc587013734dadb7cf23468e531aa120788b87243648be42e2d3a072186291"
+checksum = "5da125e1c0f22c7cae785982115523a0738728498547f415c9054cb17c7e89f9"
 dependencies = [
  "bindgen",
- "bzip2-sys",
  "cc",
  "glob",
  "libc",
- "libz-sys",
- "zstd-sys",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
-dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -2403,12 +2378,6 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -3352,12 +3321,11 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.0"
+version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
  "memchr",
- "minimal-lexical",
  "version_check",
 ]
 
@@ -4333,9 +4301,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.18.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "620f4129485ff1a7128d184bc687470c21c7951b64779ebc9cfdad3dcd920290"
+checksum = "c749134fda8bfc90d0de643d59bfc841dcb3ac8a1062e12b6754bd60235c48b3"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -4695,9 +4663,9 @@ checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
 
 [[package]]
 name = "shlex"
-version = "1.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "signal-hook-registry"
@@ -6082,14 +6050,4 @@ dependencies = [
  "lazy_static",
  "rand 0.8.4",
  "rustc-hex",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "1.6.3+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc49afa5c8d634e75761feda8c592051e7eeb4683ba827211eb0d731d3402ea8"
-dependencies = [
- "cc",
- "libc",
 ]

--- a/chain/indexer/Cargo.toml
+++ b/chain/indexer/Cargo.toml
@@ -13,7 +13,7 @@ anyhow = "1.0.51"
 async-recursion = "0.3.2"
 tracing = "0.1.13"
 futures = "0.3.5"
-rocksdb = { version = "0.18.0", default-features = false, features = ["snappy", "lz4", "zstd", "zlib"] }
+rocksdb = "0.16.0"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1.0.55"
 tokio = { version = "1.1", features = ["time", "sync"] }

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -13,7 +13,7 @@ byteorder = "1.2"
 bytesize = "1.1"
 derive_more = "0.99.3"
 elastic-array = "0.11"
-rocksdb = { version = "0.18.0", default-features = false, features = ["snappy", "lz4", "zstd", "zlib"] }
+rocksdb = "0.16.0"
 serde_json = "1"
 num_cpus = "1.11"
 rand = "0.7"

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -802,7 +802,7 @@ fn rocksdb_block_based_options(cache_size: usize) -> BlockBasedOptions {
     block_opts.set_block_cache(&Cache::new_lru_cache(cache_size).unwrap());
     block_opts.set_pin_l0_filter_and_index_blocks_in_cache(true);
     block_opts.set_cache_index_and_filter_blocks(true);
-    block_opts.set_bloom_filter(10.0, true);
+    block_opts.set_bloom_filter(10, true);
     block_opts
 }
 

--- a/core/store/src/db/refcount.rs
+++ b/core/store/src/db/refcount.rs
@@ -85,7 +85,7 @@ impl RocksDB {
     pub(crate) fn refcount_merge(
         _new_key: &[u8],
         existing_val: Option<&[u8]>,
-        operands: &MergeOperands,
+        operands: &mut MergeOperands,
     ) -> Option<Vec<u8>> {
         let mut result = vec![];
         if let Some(val) = existing_val {

--- a/core/store/src/db/v6_to_v7.rs
+++ b/core/store/src/db/v6_to_v7.rs
@@ -10,7 +10,7 @@ use crate::DBCol;
 fn refcount_merge_v6(
     _new_key: &[u8],
     existing_val: Option<&[u8]>,
-    operands: &MergeOperands,
+    operands: &mut MergeOperands,
 ) -> Option<Vec<u8>> {
     let mut result = vec![];
     if let Some(val) = existing_val {

--- a/runtime/runtime-params-estimator/Cargo.toml
+++ b/runtime/runtime-params-estimator/Cargo.toml
@@ -37,7 +37,7 @@ near-store = { path = "../../core/store" }
 near-primitives = { path = "../../core/primitives" }
 
 nearcore = { path = "../../nearcore" }
-rocksdb = { version = "0.18.0", default-features = false, features = ["snappy", "lz4", "zstd", "zlib"] }
+rocksdb = "0.16.0"
 walrus = "0.18.0"
 hex = "0.4"
 cfg-if = "1"


### PR DESCRIPTION
This reverts commit 6a0349f31a6b681e825ae98015d0d842d54fd21c.