### PR TITLE
feat: replace `Vec<u8>` with `Arc<[u8]>` in trie cache

### DIFF
--- a/core/store/benches/trie_bench.rs
+++ b/core/store/benches/trie_bench.rs
@@ -30,7 +30,7 @@ fn trie_lookup(bench: &mut Bencher) {
     state_update.commit().expect("Failed to commit");
 
     bench.iter(|| {
-        for _ in 0..1 {
+        for _ in 0..2 {
             for (key, _) in other_changes.iter() {
                 trie.get(&root, key).unwrap();
             }

--- a/core/store/benches/trie_bench.rs
+++ b/core/store/benches/trie_bench.rs
@@ -29,13 +29,14 @@ fn trie_lookup(bench: &mut Bencher) {
     let (state_update, root) = tries.apply_all(&trie_changes, ShardUId::single_shard()).unwrap();
     state_update.commit().expect("Failed to commit");
 
-    bench.bench_n(2, |bench| {
-        bench.iter(|| {
-            for (key, _) in other_changes.iter() {
-                trie.get(&root, key).unwrap();
-            }
-        })
-    });
+    let f = || {
+        for (key, _) in other_changes.iter() {
+            trie.get(&root, key).unwrap();
+        }
+    };
+    for _ in 0..2 {
+        bench.iter(f);
+    }
 }
 
 fn trie_update(bench: &mut Bencher) {

--- a/core/store/benches/trie_bench.rs
+++ b/core/store/benches/trie_bench.rs
@@ -17,7 +17,7 @@ fn trie_lookup(bench: &mut Bencher) {
     let trie = tries.get_trie_for_shard(ShardUId::single_shard());
     let root = Trie::empty_root();
     let mut changes = vec![];
-    for _ in 0..100 {
+    for _ in 0..1000 {
         changes.push((rand_bytes(), Some(rand_bytes())));
     }
     let other_changes = changes.clone();

--- a/core/store/benches/trie_bench.rs
+++ b/core/store/benches/trie_bench.rs
@@ -3,6 +3,7 @@ extern crate bencher;
 
 use bencher::Bencher;
 use rand::random;
+use std::time::Instant;
 
 use near_primitives::shard_layout::ShardUId;
 use near_store::test_utils::create_tries;
@@ -34,9 +35,12 @@ fn trie_lookup(bench: &mut Bencher) {
             trie.get(&root, key).unwrap();
         }
     };
-    for _ in 0..2 {
-        bench.iter(move || f());
-    }
+    bench.iter(move || {
+        let start = Instant::now();
+        f();
+        let took = start.elapsed();
+        println!("took {:?}", took);
+    });
 }
 
 fn trie_update(bench: &mut Bencher) {

--- a/core/store/benches/trie_bench.rs
+++ b/core/store/benches/trie_bench.rs
@@ -12,13 +12,17 @@ fn rand_bytes() -> Vec<u8> {
     (0..10).map(|_| random::<u8>()).collect()
 }
 
+fn long_rand_bytes() -> Vec<u8> {
+    (0..1000).map(|_| random::<u8>()).collect()
+}
+
 fn trie_lookup(bench: &mut Bencher) {
     let tries = create_tries();
     let trie = tries.get_trie_for_shard(ShardUId::single_shard());
     let root = Trie::empty_root();
     let mut changes = vec![];
     for _ in 0..1000 {
-        changes.push((rand_bytes(), Some(rand_bytes())));
+        changes.push((rand_bytes(), Some(long_rand_bytes())));
     }
     let other_changes = changes.clone();
     let trie_changes = trie.update(&root, changes.drain(..)).unwrap();

--- a/core/store/benches/trie_bench.rs
+++ b/core/store/benches/trie_bench.rs
@@ -35,7 +35,7 @@ fn trie_lookup(bench: &mut Bencher) {
         }
     };
     for _ in 0..2 {
-        bench.iter(f);
+        bench.iter(move || f());
     }
 }
 

--- a/core/store/benches/trie_bench.rs
+++ b/core/store/benches/trie_bench.rs
@@ -2,7 +2,7 @@
 extern crate bencher;
 
 use bencher::Bencher;
-use rand::random;
+use rand::{random, Rng};
 use std::time::Instant;
 
 use near_primitives::shard_layout::ShardUId;
@@ -11,6 +11,12 @@ use near_store::Trie;
 
 fn rand_bytes() -> Vec<u8> {
     (0..10).map(|_| random::<u8>()).collect()
+}
+
+fn rand_nibbles() -> Vec<u8> {
+    (0..10)
+        .map(|_| rand::thread_rng().gen_range(0, 2) + 16 * rand::thread_rng().gen_range(0, 2))
+        .collect()
 }
 
 fn long_rand_bytes() -> Vec<u8> {
@@ -22,8 +28,8 @@ fn trie_lookup(bench: &mut Bencher) {
     let trie = tries.get_trie_for_shard(ShardUId::single_shard());
     let root = Trie::empty_root();
     let mut changes = vec![];
-    for _ in 0..1000 {
-        changes.push((rand_bytes(), Some(long_rand_bytes())));
+    for _ in 0..3000 {
+        changes.push((rand_nibbles(), Some(long_rand_bytes())));
     }
     let other_changes = changes.clone();
     let trie_changes = trie.update(&root, changes.drain(..)).unwrap();

--- a/core/store/benches/trie_bench.rs
+++ b/core/store/benches/trie_bench.rs
@@ -29,7 +29,7 @@ fn trie_lookup(bench: &mut Bencher) {
     let root = Trie::empty_root();
     let mut changes = vec![];
     for _ in 0..3000 {
-        changes.push((rand_nibbles(), Some(long_rand_bytes())));
+        changes.push((rand_nibbles(), Some(rand_bytes())));
     }
     let other_changes = changes.clone();
     let trie_changes = trie.update(&root, changes.drain(..)).unwrap();

--- a/core/store/benches/trie_bench.rs
+++ b/core/store/benches/trie_bench.rs
@@ -29,12 +29,12 @@ fn trie_lookup(bench: &mut Bencher) {
     let (state_update, root) = tries.apply_all(&trie_changes, ShardUId::single_shard()).unwrap();
     state_update.commit().expect("Failed to commit");
 
-    bench.iter(|| {
-        for _ in 0..2 {
+    bench.bench_n(2, |bench| {
+        bench.iter(|| {
             for (key, _) in other_changes.iter() {
                 trie.get(&root, key).unwrap();
             }
-        }
+        })
     });
 }
 

--- a/core/store/benches/trie_bench.rs
+++ b/core/store/benches/trie_bench.rs
@@ -2,8 +2,7 @@
 extern crate bencher;
 
 use bencher::Bencher;
-use rand::{random, Rng};
-use std::time::Instant;
+use rand::random;
 
 use near_primitives::shard_layout::ShardUId;
 use near_store::test_utils::create_tries;
@@ -13,39 +12,25 @@ fn rand_bytes() -> Vec<u8> {
     (0..10).map(|_| random::<u8>()).collect()
 }
 
-fn rand_nibbles() -> Vec<u8> {
-    (0..10)
-        .map(|_| rand::thread_rng().gen_range(0, 2) + 16 * rand::thread_rng().gen_range(0, 2))
-        .collect()
-}
-
-fn long_rand_bytes() -> Vec<u8> {
-    (0..1000).map(|_| random::<u8>()).collect()
-}
-
 fn trie_lookup(bench: &mut Bencher) {
     let tries = create_tries();
     let trie = tries.get_trie_for_shard(ShardUId::single_shard());
     let root = Trie::empty_root();
     let mut changes = vec![];
-    for _ in 0..3000 {
-        changes.push((rand_nibbles(), Some(rand_bytes())));
+    for _ in 0..100 {
+        changes.push((rand_bytes(), Some(rand_bytes())));
     }
     let other_changes = changes.clone();
     let trie_changes = trie.update(&root, changes.drain(..)).unwrap();
     let (state_update, root) = tries.apply_all(&trie_changes, ShardUId::single_shard()).unwrap();
     state_update.commit().expect("Failed to commit");
 
-    let f = || {
-        for (key, _) in other_changes.iter() {
-            trie.get(&root, key).unwrap();
+    bench.iter(|| {
+        for _ in 0..1 {
+            for (key, _) in other_changes.iter() {
+                trie.get(&root, key).unwrap();
+            }
         }
-    };
-    bench.iter(move || {
-        let start = Instant::now();
-        f();
-        let took = start.elapsed();
-        println!("took {:?}", took);
     });
 }
 

--- a/core/store/src/trie/iterator.rs
+++ b/core/store/src/trie/iterator.rs
@@ -321,7 +321,9 @@ impl<'a> Iterator for TrieIterator<'a> {
                 IterStep::Continue => {}
                 IterStep::Value(hash) => {
                     return Some(
-                        self.trie.retrieve_raw_bytes(&hash).map(|value| (self.key(), value)),
+                        self.trie
+                            .retrieve_raw_bytes(&hash)
+                            .map(|value| (self.key(), value.to_vec())),
                     )
                 }
             }

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -3,6 +3,7 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt;
 use std::io::{Cursor, Read, Write};
+use std::sync::Arc;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
@@ -611,7 +612,10 @@ impl Trie {
         }
     }
 
-    pub(crate) fn retrieve_raw_bytes(&self, hash: &CryptoHash) -> Result<Vec<u8>, StorageError> {
+    pub(crate) fn retrieve_raw_bytes(
+        &self,
+        hash: &CryptoHash,
+    ) -> Result<Arc<Vec<u8>>, StorageError> {
         self.counter.increment();
         self.storage.retrieve_raw_bytes(hash)
     }
@@ -624,7 +628,7 @@ impl Trie {
         match RawTrieNodeWithSize::decode(&data) {
             Ok(value) => {
                 let memory_usage = TrieNodeWithSize::from_raw(value).memory_usage;
-                Ok(StateRootNode { data, memory_usage })
+                Ok(StateRootNode { data: data.to_vec(), memory_usage })
             }
             Err(_) => Err(StorageError::StorageInconsistentState(format!(
                 "Failed to decode node {}",
@@ -699,7 +703,9 @@ impl Trie {
 
     pub fn get(&self, root: &CryptoHash, key: &[u8]) -> Result<Option<Vec<u8>>, StorageError> {
         match self.get_ref(root, key)? {
-            Some((_length, hash)) => self.retrieve_raw_bytes(&hash).map(Some),
+            Some((_length, hash)) => {
+                self.retrieve_raw_bytes(&hash).map(|bytes| Some(bytes.to_vec()))
+            }
             None => Ok(None),
         }
     }

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -612,10 +612,7 @@ impl Trie {
         }
     }
 
-    pub(crate) fn retrieve_raw_bytes(
-        &self,
-        hash: &CryptoHash,
-    ) -> Result<Arc<Vec<u8>>, StorageError> {
+    pub(crate) fn retrieve_raw_bytes(&self, hash: &CryptoHash) -> Result<Arc<[u8]>, StorageError> {
         self.counter.increment();
         self.storage.retrieve_raw_bytes(hash)
     }

--- a/core/store/src/trie/state_parts.rs
+++ b/core/store/src/trie/state_parts.rs
@@ -222,7 +222,7 @@ impl Trie {
             map.entry(hash).or_insert_with(|| (value.clone(), 0)).1 += 1;
             if let Some(trie_key) = key {
                 if is_contract_code_key(&trie_key) {
-                    contract_codes.push(ContractCode::new(value, None));
+                    contract_codes.push(ContractCode::new(value.to_vec(), None));
                 }
             }
         }
@@ -301,7 +301,7 @@ mod tests {
                     *rc += 1;
                 } else {
                     let bytes = trie.storage.retrieve_raw_bytes(hash)?;
-                    insertions.insert(*hash, (bytes, 1));
+                    insertions.insert(*hash, (bytes.to_vec(), 1));
                 }
                 Ok(())
             })?;

--- a/core/store/src/trie/state_parts.rs
+++ b/core/store/src/trie/state_parts.rs
@@ -219,7 +219,7 @@ impl Trie {
         let mut contract_codes = Vec::new();
         for TrieTraversalItem { hash, key } in trie_traversal_items {
             let value = trie.retrieve_raw_bytes(&hash)?;
-            map.entry(hash).or_insert_with(|| (value.clone(), 0)).1 += 1;
+            map.entry(hash).or_insert_with(|| (value.to_vec(), 0)).1 += 1;
             if let Some(trie_key) = key {
                 if is_contract_code_key(&trie_key) {
                     contract_codes.push(ContractCode::new(value.to_vec(), None));

--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -178,9 +178,9 @@ impl TrieStorage for TrieCachingStorage {
             if let Some(val) = val {
                 let val: Arc<[u8]> = val.into();
                 if val.len() < TRIE_LIMIT_CACHED_VALUE_SIZE {
-                    guard.put(*hash, val);
+                    guard.put(*hash, val.clone());
                 }
-                Ok(val.clone())
+                Ok(val)
             } else {
                 // not StorageError::TrieNodeMissing because it's only for TrieMemoryPartialStorage
                 Err(StorageError::StorageInconsistentState("Trie node missing".to_string()))

--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -72,7 +72,7 @@ pub struct TrieRecordingStorage {
 impl TrieStorage for TrieRecordingStorage {
     fn retrieve_raw_bytes(&self, hash: &CryptoHash) -> Result<Arc<[u8]>, StorageError> {
         if let Some(val) = self.recorded.borrow().get(hash) {
-            return Ok(val.into());
+            return Ok(val.as_slice().into());
         }
         let key = TrieCachingStorage::get_key_from_shard_uid_and_hash(self.shard_uid, hash);
         let val = self
@@ -104,7 +104,7 @@ impl TrieStorage for TrieMemoryPartialStorage {
         let result = self
             .recorded_storage
             .get(hash)
-            .map_or_else(|| Err(StorageError::TrieNodeMissing), |val| Ok(val.into()));
+            .map_or_else(|| Err(StorageError::TrieNodeMissing), |val| Ok(val.as_slice().into()));
         if result.is_ok() {
             self.visited_nodes.borrow_mut().insert(*hash);
         }

--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -13,7 +13,7 @@ use std::cell::RefCell;
 use std::io::ErrorKind;
 
 #[derive(Clone)]
-pub struct TrieCache(Arc<Mutex<LruCache<CryptoHash, Vec<u8>>>>);
+pub struct TrieCache(Arc<Mutex<LruCache<CryptoHash, Arc<Vec<u8>>>>>);
 
 impl TrieCache {
     pub fn new() -> Self {
@@ -30,7 +30,7 @@ impl TrieCache {
             if let Some(value_rc) = opt_value_rc {
                 if let (Some(value), _rc) = decode_value_with_rc(&value_rc) {
                     if value.len() < TRIE_LIMIT_CACHED_VALUE_SIZE {
-                        guard.put(hash, value.to_vec());
+                        guard.put(hash, Arc::new(value.to_vec()));
                     }
                 } else {
                     guard.pop(&hash);
@@ -46,7 +46,7 @@ pub trait TrieStorage {
     /// Get bytes of a serialized TrieNode.
     /// # Errors
     /// StorageError if the storage fails internally or the hash is not present.
-    fn retrieve_raw_bytes(&self, hash: &CryptoHash) -> Result<Vec<u8>, StorageError>;
+    fn retrieve_raw_bytes(&self, hash: &CryptoHash) -> Result<Arc<Vec<u8>>, StorageError>;
 
     fn as_caching_storage(&self) -> Option<&TrieCachingStorage> {
         None
@@ -70,9 +70,9 @@ pub struct TrieRecordingStorage {
 }
 
 impl TrieStorage for TrieRecordingStorage {
-    fn retrieve_raw_bytes(&self, hash: &CryptoHash) -> Result<Vec<u8>, StorageError> {
+    fn retrieve_raw_bytes(&self, hash: &CryptoHash) -> Result<Arc<Vec<u8>>, StorageError> {
         if let Some(val) = self.recorded.borrow().get(hash) {
-            return Ok(val.clone());
+            return Ok(Arc::new(val.clone()));
         }
         let key = TrieCachingStorage::get_key_from_shard_uid_and_hash(self.shard_uid, hash);
         let val = self
@@ -81,7 +81,7 @@ impl TrieStorage for TrieRecordingStorage {
             .map_err(|_| StorageError::StorageInternalError)?;
         if let Some(val) = val {
             self.recorded.borrow_mut().insert(*hash, val.clone());
-            Ok(val)
+            Ok(Arc::new(val))
         } else {
             Err(StorageError::StorageInconsistentState("Trie node missing".to_string()))
         }
@@ -100,11 +100,11 @@ pub struct TrieMemoryPartialStorage {
 }
 
 impl TrieStorage for TrieMemoryPartialStorage {
-    fn retrieve_raw_bytes(&self, hash: &CryptoHash) -> Result<Vec<u8>, StorageError> {
+    fn retrieve_raw_bytes(&self, hash: &CryptoHash) -> Result<Arc<Vec<u8>>, StorageError> {
         let result = self
             .recorded_storage
             .get(hash)
-            .map_or_else(|| Err(StorageError::TrieNodeMissing), |val| Ok(val.clone()));
+            .map_or_else(|| Err(StorageError::TrieNodeMissing), |val| Ok(Arc::new(val.clone())));
         if result.is_ok() {
             self.visited_nodes.borrow_mut().insert(*hash);
         }
@@ -165,7 +165,7 @@ impl TrieCachingStorage {
 }
 
 impl TrieStorage for TrieCachingStorage {
-    fn retrieve_raw_bytes(&self, hash: &CryptoHash) -> Result<Vec<u8>, StorageError> {
+    fn retrieve_raw_bytes(&self, hash: &CryptoHash) -> Result<Arc<Vec<u8>>, StorageError> {
         let mut guard = self.cache.0.lock().expect(POISONED_LOCK_ERR);
         if let Some(val) = guard.get(hash) {
             Ok(val.clone())
@@ -176,6 +176,7 @@ impl TrieStorage for TrieCachingStorage {
                 .get(ColState, key.as_ref())
                 .map_err(|_| StorageError::StorageInternalError)?;
             if let Some(val) = val {
+                let val = Arc::new(val);
                 if val.len() < TRIE_LIMIT_CACHED_VALUE_SIZE {
                     guard.put(*hash, val.clone());
                 }

--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -13,7 +13,7 @@ use std::cell::RefCell;
 use std::io::ErrorKind;
 
 #[derive(Clone)]
-pub struct TrieCache(Arc<Mutex<LruCache<CryptoHash, Arc<Vec<u8>>>>>);
+pub struct TrieCache(Arc<Mutex<LruCache<CryptoHash, Arc<[u8]>>>>);
 
 impl TrieCache {
     pub fn new() -> Self {
@@ -30,7 +30,7 @@ impl TrieCache {
             if let Some(value_rc) = opt_value_rc {
                 if let (Some(value), _rc) = decode_value_with_rc(&value_rc) {
                     if value.len() < TRIE_LIMIT_CACHED_VALUE_SIZE {
-                        guard.put(hash, Arc::new(value.to_vec()));
+                        guard.put(hash, value.into());
                     }
                 } else {
                     guard.pop(&hash);
@@ -46,7 +46,7 @@ pub trait TrieStorage {
     /// Get bytes of a serialized TrieNode.
     /// # Errors
     /// StorageError if the storage fails internally or the hash is not present.
-    fn retrieve_raw_bytes(&self, hash: &CryptoHash) -> Result<Arc<Vec<u8>>, StorageError>;
+    fn retrieve_raw_bytes(&self, hash: &CryptoHash) -> Result<Arc<[u8]>, StorageError>;
 
     fn as_caching_storage(&self) -> Option<&TrieCachingStorage> {
         None
@@ -70,9 +70,9 @@ pub struct TrieRecordingStorage {
 }
 
 impl TrieStorage for TrieRecordingStorage {
-    fn retrieve_raw_bytes(&self, hash: &CryptoHash) -> Result<Arc<Vec<u8>>, StorageError> {
+    fn retrieve_raw_bytes(&self, hash: &CryptoHash) -> Result<Arc<[u8]>, StorageError> {
         if let Some(val) = self.recorded.borrow().get(hash) {
-            return Ok(Arc::new(val.clone()));
+            return Ok(val.into());
         }
         let key = TrieCachingStorage::get_key_from_shard_uid_and_hash(self.shard_uid, hash);
         let val = self
@@ -81,7 +81,7 @@ impl TrieStorage for TrieRecordingStorage {
             .map_err(|_| StorageError::StorageInternalError)?;
         if let Some(val) = val {
             self.recorded.borrow_mut().insert(*hash, val.clone());
-            Ok(Arc::new(val))
+            Ok(val.into())
         } else {
             Err(StorageError::StorageInconsistentState("Trie node missing".to_string()))
         }
@@ -100,11 +100,11 @@ pub struct TrieMemoryPartialStorage {
 }
 
 impl TrieStorage for TrieMemoryPartialStorage {
-    fn retrieve_raw_bytes(&self, hash: &CryptoHash) -> Result<Arc<Vec<u8>>, StorageError> {
+    fn retrieve_raw_bytes(&self, hash: &CryptoHash) -> Result<Arc<[u8]>, StorageError> {
         let result = self
             .recorded_storage
             .get(hash)
-            .map_or_else(|| Err(StorageError::TrieNodeMissing), |val| Ok(Arc::new(val.clone())));
+            .map_or_else(|| Err(StorageError::TrieNodeMissing), |val| Ok(val.into()));
         if result.is_ok() {
             self.visited_nodes.borrow_mut().insert(*hash);
         }
@@ -165,7 +165,7 @@ impl TrieCachingStorage {
 }
 
 impl TrieStorage for TrieCachingStorage {
-    fn retrieve_raw_bytes(&self, hash: &CryptoHash) -> Result<Arc<Vec<u8>>, StorageError> {
+    fn retrieve_raw_bytes(&self, hash: &CryptoHash) -> Result<Arc<[u8]>, StorageError> {
         let mut guard = self.cache.0.lock().expect(POISONED_LOCK_ERR);
         if let Some(val) = guard.get(hash) {
             Ok(val.clone())
@@ -176,11 +176,11 @@ impl TrieStorage for TrieCachingStorage {
                 .get(ColState, key.as_ref())
                 .map_err(|_| StorageError::StorageInternalError)?;
             if let Some(val) = val {
-                let val = Arc::new(val);
+                let val: Arc<[u8]> = val.into();
                 if val.len() < TRIE_LIMIT_CACHED_VALUE_SIZE {
-                    guard.put(*hash, val.clone());
+                    guard.put(*hash, val);
                 }
-                Ok(val)
+                Ok(val.clone())
             } else {
                 // not StorageError::TrieNodeMissing because it's only for TrieMemoryPartialStorage
                 Err(StorageError::StorageInconsistentState("Trie node missing".to_string()))

--- a/core/store/src/trie/trie_tests.rs
+++ b/core/store/src/trie/trie_tests.rs
@@ -32,11 +32,11 @@ impl IncompletePartialStorage {
 }
 
 impl TrieStorage for IncompletePartialStorage {
-    fn retrieve_raw_bytes(&self, hash: &CryptoHash) -> Result<Arc<Vec<u8>>, StorageError> {
+    fn retrieve_raw_bytes(&self, hash: &CryptoHash) -> Result<Arc<[u8]>, StorageError> {
         let result = self
             .recorded_storage
             .get(hash)
-            .map_or_else(|| Err(StorageError::TrieNodeMissing), |val| Ok(Arc::new(val.clone())));
+            .map_or_else(|| Err(StorageError::TrieNodeMissing), |val| Ok(val.into()));
 
         if result.is_ok() {
             self.visited_nodes.borrow_mut().insert(*hash);

--- a/core/store/src/trie/trie_tests.rs
+++ b/core/store/src/trie/trie_tests.rs
@@ -10,6 +10,7 @@ use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::rc::Rc;
+use std::sync::Arc;
 
 /// TrieMemoryPartialStorage, but contains only the first n requested nodes.
 pub struct IncompletePartialStorage {
@@ -31,11 +32,11 @@ impl IncompletePartialStorage {
 }
 
 impl TrieStorage for IncompletePartialStorage {
-    fn retrieve_raw_bytes(&self, hash: &CryptoHash) -> Result<Vec<u8>, StorageError> {
+    fn retrieve_raw_bytes(&self, hash: &CryptoHash) -> Result<Arc<Vec<u8>>, StorageError> {
         let result = self
             .recorded_storage
             .get(hash)
-            .map_or_else(|| Err(StorageError::TrieNodeMissing), |val| Ok(val.clone()));
+            .map_or_else(|| Err(StorageError::TrieNodeMissing), |val| Ok(Arc::new(val.clone())));
 
         if result.is_ok() {
             self.visited_nodes.borrow_mut().insert(*hash);

--- a/core/store/src/trie/trie_tests.rs
+++ b/core/store/src/trie/trie_tests.rs
@@ -36,7 +36,7 @@ impl TrieStorage for IncompletePartialStorage {
         let result = self
             .recorded_storage
             .get(hash)
-            .map_or_else(|| Err(StorageError::TrieNodeMissing), |val| Ok(val.into()));
+            .map_or_else(|| Err(StorageError::TrieNodeMissing), |val| Ok(val.as_slice().into()));
 
         if result.is_ok() {
             self.visited_nodes.borrow_mut().insert(*hash);

--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -46,7 +46,9 @@ impl<'a> TrieUpdateValuePtr<'a> {
     pub fn deref_value(&self) -> Result<Vec<u8>, StorageError> {
         match self {
             TrieUpdateValuePtr::MemoryRef(value) => Ok((*value).clone()),
-            TrieUpdateValuePtr::HashAndSize(trie, _, hash) => trie.retrieve_raw_bytes(hash),
+            TrieUpdateValuePtr::HashAndSize(trie, _, hash) => {
+                trie.retrieve_raw_bytes(hash).to_vec()
+            }
         }
     }
 }

--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -47,7 +47,7 @@ impl<'a> TrieUpdateValuePtr<'a> {
         match self {
             TrieUpdateValuePtr::MemoryRef(value) => Ok((*value).clone()),
             TrieUpdateValuePtr::HashAndSize(trie, _, hash) => {
-                trie.retrieve_raw_bytes(hash).to_vec()
+                trie.retrieve_raw_bytes(hash).map(|bytes| bytes.to_vec())
             }
         }
     }


### PR DESCRIPTION
https://github.com/near/nearcore/issues/6270

Currently, `retrieve_raw_bytes` returns `Vec<u8>`, but in fact we don't need it, and sometimes it leads to unnecessary clones. Here we replace it with `Arc<[u8]>`. We can't use `&[u8]` at least for now, because trie cache may be used by different clients (i.e. view clients).

## Benchmarking

I tried two approaches to benchmark this:

### Running state-viewer `apply_range` on Aurora shard

I couldn't see significant performance improvement here.

### Running near-store `trie_lookup` benchmark. 

The difference is still negligible, though the version in PR always gave smaller time.
However, in current bench implementation
* keys are random `Vec<u8>`s, so the number of intermediate visited nodes should be small relatively to the number of values;
* perhaps on the long distance, running bench with the same set of kv pairs gives the same results.

So I modified benchmark https://github.com/near/nearcore/compare/master...trie-bench and looked at the first time estimations:

```
master

test trie_lookup ... took 13.026505ms
took 12.420749ms
took 11.799348ms
took 11.420096ms
took 11.310058ms
took 12.060703ms
took 11.923342ms
took 11.418761ms
took 11.250021ms
took 12.76402ms
took 11.329514ms
took 11.303166ms

cache-arc-test

test trie_lookup ... took 11.316463ms
took 10.719466ms
took 10.952066ms
took 10.971129ms
took 10.921156ms
took 10.979292ms
took 11.390993ms
took 12.171543ms
took 10.805069ms
took 10.880024ms
took 11.095865ms
took 10.831956ms
```

I think this is enough to prove the usefulness of the change. Also this should help to extend TrieCache with new chunk cache.
## Testing

Existing tests.