### PR TITLE
chain: add space between block hash and validator status

### DIFF
--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -114,7 +114,7 @@ impl InfoHelper {
 
         let validator_info_log = validator_info.as_ref().map(|info| {
             format!(
-                "{}{} validator{}",
+                " {}{} validator{}",
                 if info.is_validator { "Validator | " } else { "" },
                 info.num_validators,
                 s(info.num_validators)


### PR DESCRIPTION
This changes status like:

    … 6Z3gNeGdPyvjcBYRu15yBHxZJukePjBiKBuBXYj2KoW8Validator | 1 validator …
                                                ^^^^ notice lack of space

into:

    … 6Z3gNeGdPyvjcBYRu15yBHxZJukePjBiKBuBXYj2KoW8 Validator | 1 validator …
                                                ^^^^ notice space

Sorry about this silly mistake.

Issue: https://github.com/near/nearcore/issues/2454