### PR TITLE
Dockerfile: change back from ENTRYPOINT to CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,4 @@ RUN apt-get update -qq && apt-get install -y \
 COPY scripts/run_docker.sh /usr/local/bin/run.sh
 COPY --from=build /tmp/target/release/neard /usr/local/bin/
 
-ENTRYPOINT ["/usr/local/bin/run.sh"]
+CMD ["/usr/local/bin/run.sh"]

--- a/scripts/run_docker.sh
+++ b/scripts/run_docker.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 set -e
 
-export NEAR_HOME=/srv/near
+NEAR_HOME=/srv/near
+export NEAR_HOME
 
 NEARD_FLAGS=${NEAR_HOME:+--home="$NEAR_HOME"}
 


### PR DESCRIPTION
Commit [c46de252: ‘run_docker.sh improvements and fixes’] changed
Dockerfile to use ENTRYPOINT rather than CMD.  The idea was to make
it simple to pass arguments to the `run_docker.sh` script (i.e. they
would just need to be passed to the docker invocation).

Unfortunately, this was a backwards incompatible change and this
wasn’t realised back then.  As a result, previously working commands
such as:

    docker run nearprotocol/nearcore:latest \
        sh -c 'neard --verbose --home=/home/ubuntu/.near run'

stopped working.

Change the Dockerfile back from ENTRYPOINT to CMD to bring back the
old behaviour.

Other changes in the run_docker.sh script can be left as is since they
are still compatible.  One fix though is to use a POSIX-compliant export
command since the script now uses /bin/sh.