### PR TITLE
fuzz: adjust branches with the latest release

### DIFF
--- a/nightly/fuzz.toml
+++ b/nightly/fuzz.toml
@@ -3,11 +3,11 @@ name = "master"
 weight = 10
 
 [[branch]]
-name = "1.24.0"
+name = "1.25.0"
 weight = 10
 
 [[branch]]
-name = "1.23.1"
+name = "1.24.0"
 weight = 10
 
 [[target]]


### PR DESCRIPTION
1.25.0-rc.1 was cut recently and 1.24.0 is currently on mainnet, so we no longer need to fuzz 1.23.1 but we do need to fuzz 1.25.0