### PR TITLE
chain: replace O(N) with O(1) hash lookup in assign_with_possible_reats

### DIFF
--- a/chain/epoch_manager/src/shard_assignment.rs
+++ b/chain/epoch_manager/src/shard_assignment.rs
@@ -45,7 +45,7 @@ pub fn assign_shards<T: HasStake + Eq + Clone>(
     // First, distribute chunk producers until all shards have at least the
     // minimum requested number.  If there are not enough validators to satisfy
     // that requirement, assign some of the validators to multiple shards.
-    let mut chunk_producers = chunk_producers.into_iter().cycle();
+    let mut chunk_producers = chunk_producers.into_iter().enumerate().cycle();
     assign_with_possible_repeats(
         &mut shard_index,
         &mut result,
@@ -64,7 +64,7 @@ pub fn assign_shards<T: HasStake + Eq + Clone>(
             .map(|(count, stake, shard_id)| (stake, count, shard_id))
             .collect();
 
-        for cp in chunk_producers.take(remaining_producers) {
+        for (_, cp) in chunk_producers.take(remaining_producers) {
             let (least_stake, least_validator_count, shard_id) =
                 shard_index.pop().expect("shard_index should never be empty");
             shard_index.push((least_stake + cp.get_stake(), least_validator_count + 1, shard_id));
@@ -75,16 +75,19 @@ pub fn assign_shards<T: HasStake + Eq + Clone>(
     Ok(result)
 }
 
-fn assign_with_possible_repeats<T: HasStake + Eq, I: Iterator<Item = T>>(
+fn assign_with_possible_repeats<T: HasStake + Eq, I: Iterator<Item = (usize, T)>>(
     shard_index: &mut MinHeap<(usize, Balance, ShardId)>,
     result: &mut Vec<Vec<T>>,
     cp_iter: &mut I,
     min_validators_per_shard: usize,
 ) {
     let mut buffer = Vec::with_capacity(shard_index.len());
+    let mut seen = std::collections::HashSet::<(ShardId, usize)>::with_capacity(
+        result.len() * min_validators_per_shard,
+    );
 
     while shard_index.peek().unwrap().0 < min_validators_per_shard {
-        let cp = cp_iter
+        let (cp_index, cp) = cp_iter
             .next()
             .expect("cp_iter should contain enough elements to minimally fill each shard");
         // Decide which shard to assign this chunk producer to.  We mustn’t
@@ -103,19 +106,7 @@ fn assign_with_possible_repeats<T: HasStake + Eq, I: Iterator<Item = T>>(
                     // one to any shard and move to next cp.
                     break;
                 }
-                Some(top) if result[usize::try_from(top.2).unwrap()].contains(&cp) => {
-                    // This chunk producer is already assigned to this shard.
-                    // Pop the shard from the heap for now and try assigning the
-                    // producer to the next shard.  (We’ll look back at the
-                    // shard once we figure out what to do with current `cp`).
-                    //
-                    // TODO(mina86): The contains check in the condition makes
-                    // this an O(N^2) algorithm.  At the moment there aren’t too
-                    // many chunk producers so it should be fine but if that’s
-                    // becomes an issue we should switch to a hash set.
-                    buffer.push(PeekMut::pop(top));
-                }
-                Some(mut top) => {
+                Some(mut top) if seen.insert((top.2, cp_index)) => {
                     // Chunk producer is not yet assigned to the shard and the
                     // shard still needs more producers.  Assign `cp` to it and
                     // move to next one.
@@ -123,6 +114,13 @@ fn assign_with_possible_repeats<T: HasStake + Eq, I: Iterator<Item = T>>(
                     top.1 += cp.get_stake();
                     result[usize::try_from(top.2).unwrap()].push(cp);
                     break;
+                }
+                Some(top) => {
+                    // This chunk producer is already assigned to this shard.
+                    // Pop the shard from the heap for now and try assigning the
+                    // producer to the next shard.  (We’ll look back at the
+                    // shard once we figure out what to do with current `cp`).
+                    buffer.push(PeekMut::pop(top));
                 }
             }
         }


### PR DESCRIPTION
To avoid adding chunk producer to a shard multiple times, the code
would go through the list of already assigned producers and look for
the one being considered.  This means a O(N) lookup each time so
overall a O(N²) algorithm.

Replace the linear scan with a hash set offering O(1) lookup which
reduces complexity of the algorithm.