### PR TITLE
neard: make build.rs work with git worktree

### DIFF
--- a/neard/build.rs
+++ b/neard/build.rs
@@ -8,6 +8,8 @@
 
 use anyhow::{anyhow, Result};
 
+use std::os::unix::ffi::OsStringExt;
+
 /// Returns value of given environment variable or error if missing.
 ///
 /// This also outputs necessary ‘cargo:rerun-if-env-changed’ tag to make sure
@@ -20,14 +22,24 @@ fn env(key: &str) -> Result<std::ffi::OsString> {
 /// Calls program with given arguments and returns its standard output.  If
 /// calling the program fails or it exits with non-zero exit status returns an
 /// error.
-fn command(prog: &str, args: &[&str]) -> Result<Vec<u8>> {
+fn command(prog: &str, args: &[&str], cwd: Option<std::path::PathBuf>) -> Result<Vec<u8>> {
     println!("cargo:rerun-if-env-changed=PATH");
-    let out = std::process::Command::new(prog)
-        .args(args)
-        .stderr(std::process::Stdio::inherit())
-        .output()?;
+    let mut cmd = std::process::Command::new(prog);
+    cmd.args(args);
+    cmd.stderr(std::process::Stdio::inherit());
+    if let Some(cwd) = cwd {
+        cmd.current_dir(cwd);
+    }
+    let out = cmd.output()?;
     if out.status.success() {
-        Ok(out.stdout)
+        let mut stdout = out.stdout;
+        if let Some(b'\n') = stdout.last() {
+            stdout.pop();
+            if let Some(b'\r') = stdout.last() {
+                stdout.pop();
+            }
+        }
+        Ok(stdout)
     } else if let Some(code) = out.status.code() {
         Err(anyhow!("{}: terminated with {}", prog, code))
     } else {
@@ -43,20 +55,34 @@ fn command(prog: &str, args: &[&str]) -> Result<Vec<u8>> {
 /// version will describe the commit by including its hash.  If the working
 /// directory isn’t clean, the version will include `-modified` suffix.
 fn get_git_version() -> Result<String> {
-    let git_dir = std::path::Path::new(&env("CARGO_MANIFEST_DIR")?).join("../.git");
+    // Figure out git directory.  Don’t just assume it’s ../.git because that
+    // doesn’t work with git worktrees so use `git rev-parse --git-dir` instead.
+    let pkg_dir = std::path::PathBuf::from(env("CARGO_MANIFEST_DIR")?);
+    let git_dir = command("git", &["rev-parse", "--git-dir"], Some(pkg_dir));
+    let git_dir = match git_dir {
+        Ok(git_dir) => std::path::PathBuf::from(std::ffi::OsString::from_vec(git_dir)),
+        Err(msg) => {
+            // We’re probably not inside of a git repository so report git
+            // version as unknown.
+            println!("cargo:warning=unable to determine git version (not in git repository?)");
+            println!("cargo:warning={}", msg);
+            return Ok("unknown".to_string());
+        }
+    };
+
+    // Make Cargo rerun us if currently checked out commit or the state of the
+    // working tree changes.  We try to accomplish that by looking at a few
+    // crucial git state files.  This probably may result in some false
+    // negatives but it’s best we’ve got.
     for subpath in ["HEAD", "logs/HEAD", "index"] {
         let path = git_dir.join(subpath).canonicalize()?;
         println!("cargo:rerun-if-changed={}", path.display());
     }
-    let out = command("git", &["describe", "--always", "--dirty=-modified"]);
-    match out.as_ref().map(|ver| String::from_utf8_lossy(&ver)) {
-        Ok(std::borrow::Cow::Borrowed(version)) => Ok(version.trim().to_string()),
-        Ok(std::borrow::Cow::Owned(version)) => Err(anyhow!("git: invalid output: {}", version)),
-        Err(msg) => {
-            println!("cargo:warning=unable to determine git version");
-            println!("cargo:warning={}", msg);
-            Ok("unknown".to_string())
-        }
+
+    let out = command("git", &["describe", "--always", "--dirty=-modified"], None)?;
+    match String::from_utf8_lossy(&out) {
+        std::borrow::Cow::Borrowed(version) => Ok(version.trim().to_string()),
+        std::borrow::Cow::Owned(version) => Err(anyhow!("git: invalid output: {}", version)),
     }
 }
 


### PR DESCRIPTION
The build.rs script for neard package assumes that git direcotry is
located in ../.git (relative to the package directory) which usually
is the case except whet git worktrees are used.  In that case .git is
a file rather than a directory and resolving paths relative to it
acuses an error.  Fix the isuse by using `git rev-parse --show-git-dir`
as the code should from the start.