### PR TITLE
scripts: accept NEAR_HOME from environment and other minor improvements

### DIFF
--- a/scripts/run_docker.sh
+++ b/scripts/run_docker.sh
@@ -1,18 +1,15 @@
 #!/bin/sh
 set -e
 
-NEAR_HOME=/srv/near
+NEAR_HOME=${NEAR_HOME:-/srv/near}
 export NEAR_HOME
 
-NEARD_FLAGS=${NEAR_HOME:+--home="$NEAR_HOME"}
-
-if [ -n "$INIT" ]
-then
-    neard "$NEARD_FLAGS" init ${CHAIN_ID:+--chain-id="$CHAIN_ID"} ${ACCOUNT_ID:+--account-id="$ACCOUNT_ID"}
+if [ -n "$INIT" ]; then
+    neard init ${CHAIN_ID:+--chain-id="$CHAIN_ID"} \
+               ${ACCOUNT_ID:+--account-id="$ACCOUNT_ID"}
 fi
 
-if [ -n "$NODE_KEY" ]
-then
+if [ -n "$NODE_KEY" ]; then
     cat << EOF > "$NEAR_HOME/node_key.json"
 {"account_id": "", "public_key": "", "secret_key": "$NODE_KEY"}
 EOF
@@ -23,4 +20,5 @@ ulimit -c unlimited
 echo "Telemetry: ${TELEMETRY_URL}"
 echo "Bootnodes: ${BOOT_NODES}"
 
-exec neard "$NEARD_FLAGS" run ${TELEMETRY_URL:+--telemetry-url="$TELEMETRY_URL"} ${BOOT_NODES:+--boot-nodes="$BOOT_NODES"} "$@"
+exec neard run ${TELEMETRY_URL:+--telemetry-url="$TELEMETRY_URL"} \
+               ${BOOT_NODES:+--boot-nodes="$BOOT_NODES"} "$@"


### PR DESCRIPTION
run_docker.sh unconditionally sets value of NEAR_HOME environment
variable to /srv/near which means that running `docker run -e
NEAR_HOME=/home/near ... nearcore` has no effect.  To be fair, user
probably won’t need to set near home directory inside of the container
since really what matters is path outside of the container which is
set via `docker run -v/path/outside/of/container:/srv/near ...` but at
the same time there’s no reason not to respect the path.

Speaking of NEAR_HOME, since neard reads that environment variable
there is no need to specify --home argument if its exported.  Since
run_docker.sh does export it the argument can be skipped simplifying
the script.

Lastly, reformat the script a little so it reads better (most notably
wrap long lines).