### PR TITLE
Redirect to the 0-copy wasmer branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,7 +543,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c9d0958efb8301e1626692ea879cbff622ef45cf731807ec8d488b34be98cb8"
 dependencies = [
  "borsh-derive",
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -1823,12 +1823,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c21d40587b92fa6a6c6e3c1bdbf87d75511db5672f9c93175574b3a00df1758"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
 name = "hashlink"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -2028,7 +2037,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg 1.1.0",
- "hashbrown",
+ "hashbrown 0.11.2",
  "serde",
 ]
 
@@ -2357,7 +2366,6 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6a72dfa44fe15b5e76b94307eeb2ff995a8c5b283b55008940c02e0c5b634d"
 dependencies = [
- "indexmap",
  "loupe-derive",
  "rustversion",
 ]
@@ -2378,7 +2386,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "274353858935c992b13c0ca408752e2121da852d07dec7ce5f108c77dfa14d1f"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -3255,6 +3263,7 @@ name = "near-vm-runner"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "arbitrary",
  "assert_matches",
  "base64 0.13.0",
  "borsh",
@@ -3270,9 +3279,11 @@ dependencies = [
  "parity-wasm 0.41.0",
  "pwasm-utils 0.12.0",
  "pwasm-utils 0.18.2",
+ "rand 0.8.4",
  "serde",
  "threadpool",
  "tracing",
+ "wasm-smith",
  "wasmer-compiler-near",
  "wasmer-compiler-singlepass-near",
  "wasmer-engine-near",
@@ -4403,9 +4414,9 @@ dependencies = [
 
 [[package]]
 name = "rend"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1033f6fe7ce48c8333e5412891b933e85d6a3a09728c4883240edf64e7a6f11a"
+checksum = "79af64b4b6362ffba04eef3a4e10829718a4896dac19daa741851c86781edf95"
 dependencies = [
  "bytecheck",
 ]
@@ -4484,12 +4495,12 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.7.26"
+version = "0.7.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66bf572c17c77322f4d858c214def56b13a3c32b8d833cd6d28a92de8325ac5f"
+checksum = "1f08c8062c1fe1253064043b8fc07bfea1b9702b71b4a86c11ea3588183b12e1"
 dependencies = [
  "bytecheck",
- "hashbrown",
+ "hashbrown 0.12.0",
  "ptr_meta",
  "rend",
  "rkyv_derive",
@@ -4498,9 +4509,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.26"
+version = "0.7.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3eca50f172b8e59e2080810fb41b65f047960c197149564d4bd0680af1888e"
+checksum = "e289706df51226e84814bf6ba1a9e1013112ae29bc7a9878f73fce360520c403"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5876,12 +5887,11 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-near"
-version = "2.2.2"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b836e89dcfdc39c6ff7b26c5f2c7ae27b9bd92a74aed940f09c24ba9d4e32973"
+checksum = "c60244fe7afb343ada73aff39452852c70e295031eab762b9f8ec77a5f3425cd"
 dependencies = [
  "enumset",
- "loupe",
  "rkyv",
  "serde",
  "serde_bytes",
@@ -5895,15 +5905,14 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass-near"
-version = "2.2.2"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb2995c6705f7ab2ef83888b41c4ffba9a4b9ceea790b2982d667d9dd43846f"
+checksum = "f84137bc13dfb61a4bd55a47852107caadd3b2025329d6678f6108995b5e866d"
 dependencies = [
  "byteorder",
  "dynasm",
  "dynasmrt",
  "lazy_static",
- "loupe",
  "memoffset",
  "more-asserts",
  "rayon",
@@ -5915,14 +5924,13 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-near"
-version = "2.2.2"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15cc33ca0168a79244345834c73c408cf1151cfcbe40b42dfa5409aa1d42f13c"
+checksum = "fef11b966113dee907a8f5d38c01293a966e8dc1dd54bc27dcc0f3dd4638459c"
 dependencies = [
  "backtrace",
  "enumset",
  "lazy_static",
- "loupe",
  "memmap2 0.5.0",
  "more-asserts",
  "rustc-demangle",
@@ -5937,16 +5945,16 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal-near"
-version = "2.2.2"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbf42534f4c05800dcb07686321ea33dcf815af82c3d57150a6d13a25bec55d"
+checksum = "d2e5c98c64fa124bd62f811405ec86ab85fa619c86f68ca3ba9c658720b73f9e"
 dependencies = [
  "cfg-if 1.0.0",
  "enumset",
  "leb128",
- "loupe",
  "region 3.0.0",
  "rkyv",
+ "thiserror",
  "wasmer-compiler-near",
  "wasmer-engine-near",
  "wasmer-types-near",
@@ -6020,12 +6028,11 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types-near"
-version = "2.2.2"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74a34b18bef672dd578b18ec10b157edbda31123f20a6cbf0d160cbd341fe8de"
+checksum = "de9f6d7755e259a5575b9739cd226c40730726d72a84ed5573f71b8932fed246"
 dependencies = [
  "indexmap",
- "loupe",
  "rkyv",
  "serde",
  "thiserror",
@@ -6033,16 +6040,15 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm-near"
-version = "2.2.2"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd58bc505063fe59c224c6263afc4e64e72dff29636ca9fcb912bfbf742a995"
+checksum = "597d871efa338883fb1d415e0c7163749042a3637e43cfe7204146e93a29d88f"
 dependencies = [
  "backtrace",
  "cc",
  "cfg-if 1.0.0",
  "indexmap",
  "libc",
- "loupe",
  "memoffset",
  "more-asserts",
  "region 3.0.0",

--- a/deny.toml
+++ b/deny.toml
@@ -103,4 +103,8 @@ skip = [
     { name = "itoa", version = "=0.4.8" },
     { name = "time", version = "=0.2.27" },
     { name = "tokio-util", version = "=0.6.9" },
+
+    # Wasmer requires a newer version and the rest of the ecosystem hasn't caught up yet.
+    { name = "hashbrown", version = "0.11.0" },
+
 ]

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1", features = ["derive"] }
 wasmparser = "0.78"
 memoffset = "0.6"
 
+
 loupe = "0.1"
 once_cell = "1.5.2"
 pwasm-utils = "0.18"
@@ -47,16 +48,19 @@ wasmer-runtime-core = { version = "0.18.2", package = "wasmer-runtime-core-near"
 # wasmer-compiler-singlepass = { package = "wasmer-compiler-singlepass-near", git = "https://github.com/near/wasmer", branch = "near-main", optional = true }
 # wasmer-engine-universal = { package = "wasmer-engine-universal-near", git = "https://github.com/near/wasmer", branch = "near-main", optional = true }
 # wasmer-vm = { package = "wasmer-vm-near", git = "https://github.com/near/wasmer", branch = "near-main" }
-wasmer-compiler = { package = "wasmer-compiler-near", version = "=2.2.2", optional = true }
-wasmer-compiler-singlepass = { package = "wasmer-compiler-singlepass-near", version = "=2.2.2", optional = true }
-wasmer-engine = { package = "wasmer-engine-near", version = "=2.2.2", optional = true }
-wasmer-engine-universal = { package = "wasmer-engine-universal-near", version = "=2.2.2", optional = true, features = ["compiler"] }
-wasmer-types = { package = "wasmer-types-near", version = "=2.2.2", optional = true }
-wasmer-vm = { package = "wasmer-vm-near", version = "=2.2.2", optional = true }
+wasmer-compiler = { package = "wasmer-compiler-near", version = "=2.3.0", optional = true }
+wasmer-compiler-singlepass = { package = "wasmer-compiler-singlepass-near", version = "=2.3.0", optional = true }
+wasmer-engine = { package = "wasmer-engine-near", version = "=2.3.0", optional = true }
+wasmer-engine-universal = { package = "wasmer-engine-universal-near", version = "=2.3.0", optional = true, features = ["compiler"] }
+wasmer-types = { package = "wasmer-types-near", version = "=2.3.0", optional = true }
+wasmer-vm = { package = "wasmer-vm-near", version = "=2.3.0", optional = true }
 
 
 [dev-dependencies]
 near-test-contracts = { path = "../near-test-contracts" }
+rand = "0.8"
+arbitrary = "1"
+wasm-smith = "0.9.1"
 assert_matches = "1.3"
 wat = "1.0.40"
 base64 = "0.13"

--- a/runtime/near-vm-runner/src/cache.rs
+++ b/runtime/near-vm-runner/src/cache.rs
@@ -338,7 +338,7 @@ pub mod wasmer2_cache {
                 vm.engine
                     .load_universal_executable(&executable)
                     .map(|v| Arc::new(v) as _)
-                    .map_err(|err| CompilationError::WasmerCompileError { msg: err.to_string() })
+                    .map_err(|err| panic!("could not load the executable: {}", err.to_string()))
             })),
             Some(cache) => {
                 let serialized = cache.get(&key.0).map_err(|_io_err| CacheError::ReadError)?;

--- a/runtime/near-vm-runner/src/cache.rs
+++ b/runtime/near-vm-runner/src/cache.rs
@@ -253,17 +253,19 @@ pub mod wasmer0_cache {
 pub mod wasmer2_cache {
     use crate::wasmer2_runner::{VMArtifact, Wasmer2VM};
     use near_primitives::contract::ContractCode;
+    use wasmer_engine::Executable;
 
     use super::*;
 
     pub(crate) fn compile_module_wasmer2(
+        vm: &Wasmer2VM,
         code: &[u8],
         config: &VMConfig,
-    ) -> Result<VMArtifact, CompilationError> {
+    ) -> Result<wasmer_engine_universal::UniversalExecutable, CompilationError> {
         let _span = tracing::debug_span!(target: "vm", "compile_module_wasmer2").entered();
         let prepared_code =
             prepare::prepare_contract(code, config).map_err(CompilationError::PrepareError)?;
-        Wasmer2VM::new(config.clone()).compile_uncached(&prepared_code)
+        vm.compile_uncached(&prepared_code)
     }
 
     pub(crate) fn compile_and_serialize_wasmer2(
@@ -273,22 +275,26 @@ pub mod wasmer2_cache {
         cache: &dyn CompiledContractCache,
     ) -> Result<Result<VMArtifact, CompilationError>, CacheError> {
         let _span = tracing::debug_span!(target: "vm", "compile_and_serialize_wasmer2").entered();
-
-        let module = match compile_module_wasmer2(wasm_code, config) {
+        let vm = Wasmer2VM::new(config.clone());
+        let executable = match compile_module_wasmer2(&vm, wasm_code, config) {
             Ok(module) => module,
             Err(err) => {
                 cache_error(&err, key, cache)?;
                 return Ok(Err(err));
             }
         };
-
-        let code = module
-            .artifact()
-            .serialize()
-            .map_err(|_e| CacheError::SerializationError { hash: key.0 })?;
+        let code =
+            executable.serialize().map_err(|_e| CacheError::SerializationError { hash: key.0 })?;
         let serialized = CacheRecord::Code(code).try_to_vec().unwrap();
         cache.put(key.as_ref(), &serialized).map_err(|_io_err| CacheError::WriteError)?;
-        Ok(Ok(module))
+        match vm.engine.load_universal_executable(&executable) {
+            Ok(artifact) => Ok(Ok(Arc::new(artifact) as _)),
+            Err(err) => {
+                let err = CompilationError::WasmerCompileError { msg: err.to_string() };
+                cache_error(&err, key, cache)?;
+                Ok(Err(err))
+            }
+        }
     }
 
     fn deserialize_wasmer2(
@@ -326,8 +332,14 @@ pub mod wasmer2_cache {
         config: &VMConfig,
         cache: Option<&dyn CompiledContractCache>,
     ) -> Result<Result<VMArtifact, CompilationError>, CacheError> {
+        let vm = Wasmer2VM::new(config.clone());
         match cache {
-            None => Ok(compile_module_wasmer2(code.code(), config)),
+            None => Ok(compile_module_wasmer2(&vm, code.code(), config).and_then(|executable| {
+                vm.engine
+                    .load_universal_executable(&executable)
+                    .map(|v| Arc::new(v) as _)
+                    .map_err(|err| CompilationError::WasmerCompileError { msg: err.to_string() })
+            })),
             Some(cache) => {
                 let serialized = cache.get(&key.0).map_err(|_io_err| CacheError::ReadError)?;
                 match serialized {

--- a/runtime/near-vm-runner/src/imports.rs
+++ b/runtime/near-vm-runner/src/imports.rs
@@ -293,15 +293,19 @@ pub(crate) mod wasmer2 {
 
     use super::str_eq;
     use near_vm_logic::{ProtocolVersion, VMLogic};
-    use wasmer_engine::{ExportFunction, ExportFunctionMetadata, Resolver};
-    use wasmer_vm::{VMFunction, VMFunctionKind, VMMemory};
+    use wasmer_engine::Engine;
+    use wasmer_engine_universal::UniversalEngine;
+    use wasmer_vm::{
+        ExportFunction, ExportFunctionMetadata, Resolver, VMFunction, VMFunctionKind, VMMemory,
+    };
 
-    pub(crate) struct Wasmer2Imports<'vmlogic, 'vmlogic_refs> {
+    pub(crate) struct Wasmer2Imports<'engine, 'vmlogic, 'vmlogic_refs> {
         pub(crate) memory: VMMemory,
         // Note: this same object is also referenced by the `metadata` field!
         pub(crate) vmlogic: &'vmlogic mut VMLogic<'vmlogic_refs>,
         pub(crate) metadata: Arc<ExportFunctionMetadata>,
         pub(crate) protocol_version: ProtocolVersion,
+        pub(crate) engine: &'engine UniversalEngine,
     }
 
     trait Wasmer2Type {
@@ -339,13 +343,13 @@ pub(crate) mod wasmer2 {
         }
     }
 
-    impl<'vmlogic, 'vmlogic_refs> Resolver for Wasmer2Imports<'vmlogic, 'vmlogic_refs> {
-        fn resolve(&self, _index: u32, module: &str, field: &str) -> Option<wasmer_engine::Export> {
+    impl<'e, 'l, 'lr> Resolver for Wasmer2Imports<'e, 'l, 'lr> {
+        fn resolve(&self, _index: u32, module: &str, field: &str) -> Option<wasmer_vm::Export> {
             if module != "env" {
                 return None;
             }
             if field == "memory" {
-                return Some(wasmer_engine::Export::Memory(self.memory.clone()));
+                return Some(wasmer_vm::Export::Memory(self.memory.clone()));
             }
 
             macro_rules! add_import {
@@ -397,7 +401,11 @@ pub(crate) mod wasmer2 {
                     }
                     // TODO: a phf hashmap would probably work better here.
                     if field == stringify!($func) {
-                        return Some(wasmer_engine::Export::Function(ExportFunction {
+                        let args = [$(<$arg_type as Wasmer2Type>::ty()),*];
+                        let rets = [$(<$returns as Wasmer2Type>::ty()),*];
+                        let signature = wasmer_types::FunctionTypeRef::new(&args[..], &rets[..]);
+                        let signature = self.engine.register_signature(signature);
+                        return Some(wasmer_vm::Export::Function(ExportFunction {
                             vm_function: VMFunction {
                                 address: $func as *const _,
                                 // SAFETY: here we erase the lifetime of the `vmlogic` reference,
@@ -407,11 +415,7 @@ pub(crate) mod wasmer2 {
                                 vmctx: wasmer_vm::VMFunctionEnvironment {
                                     host_env: self.vmlogic as *const _ as *mut _
                                 },
-                                signature: wasmer_types::FunctionType::new([
-                                    $(<$arg_type as Wasmer2Type>::ty()),*
-                                ], [
-                                    $(<$returns as Wasmer2Type>::ty()),*
-                                ]),
+                                signature,
                                 kind: VMFunctionKind::Static,
                                 call_trampoline: None,
                                 instance_ref: None,
@@ -426,18 +430,25 @@ pub(crate) mod wasmer2 {
         }
     }
 
-    pub(crate) fn build<'a, 'b>(
+    pub(crate) fn build<'e, 'a, 'b>(
         memory: VMMemory,
         logic: &'a mut VMLogic<'b>,
         protocol_version: ProtocolVersion,
-    ) -> Wasmer2Imports<'a, 'b> {
+        engine: &'e UniversalEngine,
+    ) -> Wasmer2Imports<'e, 'a, 'b> {
         let metadata = unsafe {
             // SAFETY: the functions here are thread-safe. We ensure that the lifetime of `VMLogic`
             // is sufficiently long by tying the lifetime of VMLogic to the return type which
             // contains this metadata.
             ExportFunctionMetadata::new(logic as *mut _ as *mut _, None, |ptr| ptr, |_| {})
         };
-        Wasmer2Imports { memory, vmlogic: logic, metadata: Arc::new(metadata), protocol_version }
+        Wasmer2Imports {
+            memory,
+            vmlogic: logic,
+            metadata: Arc::new(metadata),
+            protocol_version,
+            engine,
+        }
     }
 }
 

--- a/runtime/near-vm-runner/src/tests/cache.rs
+++ b/runtime/near-vm-runner/src/tests/cache.rs
@@ -18,6 +18,7 @@ use std::hash::{Hash, Hasher};
 use std::io;
 use std::sync::atomic::{AtomicBool, Ordering};
 use wasmer_compiler::{CpuFeature, Target};
+use wasmer_engine::Executable;
 
 #[test]
 fn test_caches_compilation_error() {
@@ -111,10 +112,10 @@ fn test_wasmer2_artifact_output_stability() {
     let triple = "x86_64-unknown-linux-gnu".parse().unwrap();
     let target = Target::new(triple, features);
     let vm = Wasmer2VM::new_for_target(config, target);
-    let artifact = vm.compile_uncached(&prepared_code).unwrap();
-    let serialized = artifact.artifact().serialize().unwrap();
+    let executable = vm.compile_uncached(&prepared_code).unwrap();
+    let serialized = executable.serialize().unwrap();
     serialized.hash(&mut hasher);
-    assert_eq!(hasher.finish(), 16203733374745522118, "WASMER2_CONFIG needs version change");
+    assert_eq!(hasher.finish(), 2128441495928970645, "WASMER2_CONFIG needs version change");
 }
 
 /// [`CompiledContractCache`] which simulates failures in the underlying

--- a/runtime/near-vm-runner/src/wasmer2_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer2_runner.rs
@@ -335,13 +335,25 @@ impl Wasmer2VM {
                     .map_err(|err| {
                         use wasmer_engine::InstantiationError::{self, *};
                         match err.downcast_ref::<InstantiationError>() {
-                            Some(Start(err)) => translate_runtime_error(err.clone(), import.vmlogic),
-                            Some(Link(e)) => VMError::FunctionCallError(FunctionCallError::LinkError { msg: e.to_string() }),
-                            Some(CreateInstance(e)) => VMError::FunctionCallError(FunctionCallError::LinkError { msg: e.to_string() }),
-                            Some(CpuFeature(e)) => {
-                                panic!("host does not support the CPU features required to run contracts: {}", e)
+                            Some(Start(err)) => {
+                                translate_runtime_error(err.clone(), import.vmlogic)
                             }
-                            None => VMError::FunctionCallError(FunctionCallError::LinkError { msg: err.to_string() })
+                            Some(Link(e)) => {
+                                VMError::FunctionCallError(FunctionCallError::LinkError {
+                                    msg: e.to_string(),
+                                })
+                            }
+                            Some(CreateInstance(e)) => {
+                                VMError::FunctionCallError(FunctionCallError::LinkError {
+                                    msg: e.to_string(),
+                                })
+                            }
+                            Some(CpuFeature(e)) => panic!(
+                                "host doesn't support the CPU features needed to run contracts: {}",
+                                e
+                            ),
+                            // TODO: make this a static invariant.
+                            None => panic!("this ought to be unreachable"),
                         }
                     })?;
                 // SAFETY: being called immediately after instantiation.


### PR DESCRIPTION
This makes the changes necessary on the nearcore side to start
experimenting with – and testing – the branch of runtime implementing
0-copy deserialization.


@Ekleog I wonder how difficult would it be to throw this at the fuzzing infrastructure?