### PR TITLE
mock network first iteration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2004,6 +2004,7 @@ dependencies = [
  "base64 0.11.0",
  "borsh",
  "chrono",
+ "clap 3.0.0-beta.2",
  "futures",
  "hex",
  "hyper",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2020,6 +2020,7 @@ dependencies = [
  "near-logger-utils",
  "near-network",
  "near-network-primitives",
+ "near-performance-metrics",
  "near-primitives",
  "near-store",
  "near-telemetry",

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3018,6 +3018,10 @@ impl Chain {
             .ok_or_else(|| ErrorKind::DBNotFoundErr(format!("EXECUTION OUTCOME: {}", id)).into())
     }
 
+    /// Retrieve the up to `max_headers_returned` headers on the main chain
+    /// `hashes`: a list of block "locators". This function will find the first block in `hashes`
+    ///           that is on the main chain and returns the blocks after this block. If none of the
+    ///           blocks in `hashes` are on the main chain, the function returns an empty vector.
     pub fn retrieve_headers(
         &mut self,
         hashes: Vec<CryptoHash>,

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3019,7 +3019,8 @@ impl Chain {
     }
 
     /// Retrieve the up to `max_headers_returned` headers on the main chain
-    /// `hashes`: a list of block "locators". This function will find the first block in `hashes`
+    /// `hashes`: a list of block "locators". `hashes` should be ordered from older blocks to
+    ///           more recent blocks. This function will find the first block in `hashes`
     ///           that is on the main chain and returns the blocks after this block. If none of the
     ///           blocks in `hashes` are on the main chain, the function returns an empty vector.
     pub fn retrieve_headers(

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3026,6 +3026,7 @@ impl Chain {
         &mut self,
         hashes: Vec<CryptoHash>,
         max_headers_returned: u64,
+        max_height: Option<BlockHeight>,
     ) -> Result<Vec<BlockHeader>, Error> {
         let header = match self.find_common_header(&hashes) {
             Some(header) => header,
@@ -3033,7 +3034,8 @@ impl Chain {
         };
 
         let mut headers = vec![];
-        let max_height = self.header_head()?.height;
+        let header_head_height = self.header_head()?.height;
+        let max_height = max_height.unwrap_or(header_head_height);
         // TODO: this may be inefficient if there are a lot of skipped blocks.
         for h in header.height() + 1..=max_height {
             if let Ok(header) = self.get_header_by_height(h) {

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -2128,26 +2128,25 @@ mod test {
             InMemoryValidatorSigner::from_seed("test".parse().unwrap(), KeyType::ED25519, "test");
         let mut rs = ReedSolomonWrapper::new(4, 10);
         let shard_layout = runtime_adapter.get_shard_layout(&EpochId::default()).unwrap();
-        let (encoded_chunk, proof) = shards_manager
-            .create_encoded_shard_chunk(
-                CryptoHash::default(),
-                CryptoHash::default(),
-                CryptoHash::default(),
-                1,
-                0,
-                0,
-                0,
-                0,
-                vec![],
-                vec![],
-                &vec![],
-                merklize(&Chain::build_receipts_hashes(&vec![], &shard_layout)).0,
-                CryptoHash::default(),
-                &signer,
-                &mut rs,
-                PROTOCOL_VERSION,
-            )
-            .unwrap();
+        let (encoded_chunk, proof) = ShardsManager::create_encoded_shard_chunk(
+            CryptoHash::default(),
+            CryptoHash::default(),
+            CryptoHash::default(),
+            1,
+            0,
+            0,
+            0,
+            0,
+            vec![],
+            vec![],
+            &vec![],
+            merklize(&Chain::build_receipts_hashes(&vec![], &shard_layout)).0,
+            CryptoHash::default(),
+            &signer,
+            &mut rs,
+            PROTOCOL_VERSION,
+        )
+        .unwrap();
         let header = encoded_chunk.cloned_header();
         shards_manager.requested_partial_encoded_chunks.insert(
             header.chunk_hash(),

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -1748,7 +1748,6 @@ impl ShardsManager {
     }
 
     pub fn create_encoded_shard_chunk(
-        &mut self,
         prev_block_hash: CryptoHash,
         prev_state_root: StateRoot,
         outcome_root: CryptoHash,

--- a/chain/chunks/src/test_utils.rs
+++ b/chain/chunks/src/test_utils.rs
@@ -8,7 +8,6 @@ use near_chain::{Chain, ChainStore};
 use near_crypto::KeyType;
 use near_network::test_utils::MockPeerManagerAdapter;
 use near_primitives::block::BlockHeader;
-use near_primitives::epoch_manager::RngSeed;
 use near_primitives::hash::{self, CryptoHash};
 use near_primitives::merkle;
 use near_primitives::sharding::{
@@ -209,37 +208,29 @@ impl ChunkTestFixture {
             .find(|v| v != &mock_chunk_producer && v != &mock_shard_tracker)
             .unwrap();
 
-        const TEST_SEED: RngSeed = [3; 32];
-        let mut producer_shard_manager = ShardsManager::new(
-            Some(mock_chunk_producer),
-            mock_runtime.clone(),
-            mock_network.clone(),
-            TEST_SEED,
-        );
         let receipts = Vec::new();
         let shard_layout = mock_runtime.get_shard_layout(&EpochId::default()).unwrap();
         let receipts_hashes = Chain::build_receipts_hashes(&receipts, &shard_layout);
         let (receipts_root, _) = merkle::merklize(&receipts_hashes);
-        let (mock_chunk, mock_merkles) = producer_shard_manager
-            .create_encoded_shard_chunk(
-                mock_parent_hash,
-                Default::default(),
-                Default::default(),
-                mock_height,
-                mock_shard_id,
-                0,
-                1000,
-                0,
-                Vec::new(),
-                Vec::new(),
-                &receipts,
-                receipts_root,
-                MerkleHash::default(),
-                &signer,
-                &mut rs,
-                PROTOCOL_VERSION,
-            )
-            .unwrap();
+        let (mock_chunk, mock_merkles) = ShardsManager::create_encoded_shard_chunk(
+            mock_parent_hash,
+            Default::default(),
+            Default::default(),
+            mock_height,
+            mock_shard_id,
+            0,
+            1000,
+            0,
+            Vec::new(),
+            Vec::new(),
+            &receipts,
+            receipts_root,
+            MerkleHash::default(),
+            &signer,
+            &mut rs,
+            PROTOCOL_VERSION,
+        )
+        .unwrap();
 
         let all_part_ords: Vec<u64> =
             (0..mock_chunk.content().parts.len()).map(|p| p as u64).collect();

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -603,7 +603,7 @@ impl Client {
         let (outgoing_receipts_root, _) = merklize(&outgoing_receipts_hashes);
 
         let protocol_version = self.runtime_adapter.get_epoch_protocol_version(epoch_id)?;
-        let (encoded_chunk, merkle_paths) = self.shards_mgr.create_encoded_shard_chunk(
+        let (encoded_chunk, merkle_paths) = ShardsManager::create_encoded_shard_chunk(
             prev_block_hash,
             *chunk_extra.state_root(),
             *chunk_extra.outcome_root(),

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -459,7 +459,7 @@ impl ViewClientActor {
         &mut self,
         hashes: Vec<CryptoHash>,
     ) -> Result<Vec<BlockHeader>, near_chain::Error> {
-        self.chain.retrieve_headers(hashes, sync::MAX_BLOCK_HEADERS)
+        self.chain.retrieve_headers(hashes, sync::MAX_BLOCK_HEADERS, None)
     }
 
     fn check_signature_account_announce(

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -459,23 +459,7 @@ impl ViewClientActor {
         &mut self,
         hashes: Vec<CryptoHash>,
     ) -> Result<Vec<BlockHeader>, near_chain::Error> {
-        let header = match self.chain.find_common_header(&hashes) {
-            Some(header) => header,
-            None => return Ok(vec![]),
-        };
-
-        let mut headers = vec![];
-        let max_height = self.chain.header_head()?.height;
-        // TODO: this may be inefficient if there are a lot of skipped blocks.
-        for h in header.height() + 1..=max_height {
-            if let Ok(header) = self.chain.get_header_by_height(h) {
-                headers.push(header.clone());
-                if headers.len() >= sync::MAX_BLOCK_HEADERS as usize {
-                    break;
-                }
-            }
-        }
-        Ok(headers)
+        self.chain.retrieve_headers(hashes, sync::MAX_BLOCK_HEADERS)
     }
 
     fn check_signature_account_announce(

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -327,7 +327,7 @@ pub struct FullPeerInfo {
     pub partial_edge_info: PartialEdgeInfo,
 }
 
-#[derive(Debug, actix::MessageResponse)]
+#[derive(Debug, Clone, actix::MessageResponse)]
 pub struct NetworkInfo {
     pub connected_peers: Vec<FullPeerInfo>,
     pub num_connected_peers: usize,

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -42,6 +42,7 @@ near-primitives = { path = "../core/primitives" }
 near-store = { path = "../core/store" }
 near-telemetry = { path = "../chain/telemetry" }
 near-test-contracts = { path = "../runtime/near-test-contracts" }
+near-performance-metrics = { path = "../utils/near-performance-metrics" }
 near-vm-errors = { path = "../runtime/near-vm-errors" }
 near-vm-runner = { path = "../runtime/near-vm-runner" }
 nearcore = { path = "../nearcore" }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -7,12 +7,17 @@ publish = false
 rust-version = "1.56.0"
 edition = "2021"
 
+[[bin]]
+path = "src/bin/start_mock_network.rs"
+name = "start_mock_network"
+
 [dependencies]
 actix = "=0.11.0-beta.2"
 actix-rt = "2"
 base64 = "0.11"
 borsh = "0.9"
 chrono = { version = "0.4.4", features = ["serde"] }
+clap = "=3.0.0-beta.2"
 futures = "0.3"
 hex = "0.4"
 hyper = { version = "0.14", features = ["full"] }
@@ -48,6 +53,7 @@ near-vm-runner = { path = "../runtime/near-vm-runner" }
 nearcore = { path = "../nearcore" }
 node-runtime = { path = "../runtime/runtime" }
 testlib = { path = "../test-utils/testlib" }
+near-logger-utils = { path = "../test-utils/logger" }
 
 [dev-dependencies]
 assert_matches = "1.3"

--- a/integration-tests/src/bin/start_mock_network.rs
+++ b/integration-tests/src/bin/start_mock_network.rs
@@ -6,13 +6,15 @@ use futures::{future, FutureExt};
 use std::path::Path;
 
 use integration_tests::mock_network::setup::{setup_mock_network, SyncMode};
-use integration_tests::mock_network::GetChainHistoryFinalBlockHeight;
+use integration_tests::mock_network::GetChainTargetBlockHeight;
 use near_actix_test_utils::run_actix;
 use near_chain_configs::GenesisValidationMode;
 use near_client::GetBlock;
 use near_crypto::{InMemorySigner, KeyType};
 use near_logger_utils::init_integration_logger;
 use near_network::test_utils::WaitOrTimeoutActor;
+use near_primitives::types::BlockHeight;
+use std::time::Duration;
 
 /// Program to start a testing environment for one client and a mock network environment
 /// The mock network simulates the entire network by reading a pre-generated chain history
@@ -25,10 +27,17 @@ struct Cli {
     /// Home dir for the new client that will be started. If not specified, the binary will
     /// generate a temporary directory
     client_home_dir: Option<String>,
+    /// Simulated network delay (in ms)
+    #[clap(short = 'd', long, default_value = "100")]
+    network_delay: u64,
     /// If true, the mock network simulates the client in syncing mode, otherwise,
     /// the client and its simulated peers will all start from the genesis block
-    #[clap(short, long)]
+    #[clap(short = 'S', long)]
     sync: bool,
+    /// Target height that the client should sync to before stopping. If not specified,
+    /// use the height of the last block in chain history
+    #[clap(short = 'h', long)]
+    target_height: Option<BlockHeight>,
 }
 
 fn main() {
@@ -42,21 +51,30 @@ fn main() {
         InMemorySigner::from_random("mock_network_node".parse().unwrap(), KeyType::ED25519);
     near_config.network_config.public_key = signer.public_key;
     near_config.network_config.secret_key = signer.secret_key;
+    near_config.client_config.tracked_shards =
+        (0..near_config.genesis.config.shard_layout.num_shards()).collect();
 
     let tempdir = tempfile::Builder::new().prefix("mock_network_node").tempdir().unwrap();
     let client_home_dir =
         args.client_home_dir.unwrap_or(String::from(tempdir.path().to_str().unwrap()));
     let sync_mode = if args.sync { SyncMode::Sync } else { SyncMode::NoSync };
+    let network_delay = Duration::from_millis(args.network_delay);
     run_actix(async move {
-        let (mock_network, _client, view_client) =
-            setup_mock_network(Path::new(&client_home_dir), home_dir, &near_config, sync_mode);
-        let chain_height =
-            async { mock_network.send(GetChainHistoryFinalBlockHeight).await }.await.unwrap();
+        let (mock_network, _client, view_client) = setup_mock_network(
+            Path::new(&client_home_dir),
+            home_dir,
+            &near_config,
+            sync_mode,
+            network_delay,
+            args.target_height,
+        );
+        let target_height =
+            async { mock_network.send(GetChainTargetBlockHeight).await }.await.unwrap();
         WaitOrTimeoutActor::new(
             Box::new(move |_ctx| {
                 actix::spawn(view_client.send(GetBlock::latest()).then(move |res| {
                     if let Ok(Ok(block)) = res {
-                        if block.header.height >= chain_height {
+                        if block.header.height >= target_height {
                             System::current().stop()
                         }
                     }
@@ -64,7 +82,7 @@ fn main() {
                 }));
             }),
             100,
-            60000,
+            target_height * 1000,
         )
         .start();
     })

--- a/integration-tests/src/bin/start_mock_network.rs
+++ b/integration-tests/src/bin/start_mock_network.rs
@@ -70,6 +70,7 @@ fn main() {
         );
         let target_height =
             async { mock_network.send(GetChainTargetBlockHeight).await }.await.unwrap();
+        // wait until the client reach target_height
         WaitOrTimeoutActor::new(
             Box::new(move |_ctx| {
                 actix::spawn(view_client.send(GetBlock::latest()).then(move |res| {

--- a/integration-tests/src/bin/start_mock_network.rs
+++ b/integration-tests/src/bin/start_mock_network.rs
@@ -19,6 +19,15 @@ use std::time::Duration;
 /// Program to start a testing environment for one client and a mock network environment
 /// The mock network simulates the entire network by reading a pre-generated chain history
 /// on storage and responds to the client's network requests.
+/// The binary runs in two modes, Sync and NoSync, determined by flag `sync`.
+///
+/// In Sync mode, the client and mock network start from different height and client is trying
+/// to catch up. The client starts from genesis height, and the mock network starts from
+/// target height (see args.target_height) and no new blocks are produced.
+///
+/// In NoSync mode, the client and mock network start at the same height and new blocks will
+/// be produced. They both start from genesis height and the mock network will produce
+/// blocks until target height.
 #[derive(Clap)]
 struct Cli {
     /// Existing home dir for the pre-generated chain history. For example, you can use
@@ -30,8 +39,7 @@ struct Cli {
     /// Simulated network delay (in ms)
     #[clap(short = 'd', long, default_value = "100")]
     network_delay: u64,
-    /// If true, the mock network simulates the client in syncing mode, otherwise,
-    /// the client and its simulated peers will all start from the genesis block
+    /// Sync mode of the binary
     #[clap(short = 'S', long)]
     sync: bool,
     /// Target height that the client should sync to before stopping. If not specified,

--- a/integration-tests/src/bin/start_mock_network.rs
+++ b/integration-tests/src/bin/start_mock_network.rs
@@ -1,0 +1,58 @@
+extern crate integration_tests;
+
+use actix::{Actor, System};
+use clap::Clap;
+use futures::{future, FutureExt};
+use std::path::Path;
+
+use futures::executor::block_on;
+use integration_tests::mock_network::setup::setup_mock_network;
+use integration_tests::mock_network::GetChainHistoryFinalBlockHeight;
+use near_actix_test_utils::run_actix;
+use near_chain_configs::GenesisValidationMode;
+use near_client::GetBlock;
+use near_crypto::{InMemorySigner, KeyType};
+use near_logger_utils::init_integration_logger;
+use near_network::test_utils::WaitOrTimeoutActor;
+
+#[derive(Clap)]
+struct Cli {
+    chain_history_home_dir: String,
+}
+
+fn main() {
+    init_integration_logger();
+    let args = Cli::parse();
+    let home_dir = Path::new(&args.chain_history_home_dir);
+    let mut near_config = nearcore::config::load_config(home_dir, GenesisValidationMode::Full);
+    near_config.validator_signer = None;
+    near_config.client_config.min_num_peers = 1;
+    let signer =
+        InMemorySigner::from_random("mock_network_node".parse().unwrap(), KeyType::ED25519);
+    near_config.network_config.public_key = signer.public_key;
+    near_config.network_config.secret_key = signer.secret_key;
+
+    let dir1 = tempfile::Builder::new().prefix("mock_network_node").tempdir().unwrap();
+    run_actix(async move {
+        let (mock_network, _client, view_client) =
+            setup_mock_network(dir1.path().clone(), home_dir, &near_config);
+        let chain_height =
+            async { mock_network.send(GetChainHistoryFinalBlockHeight).await }.await.unwrap();
+        println!("chain height {:?}", chain_height);
+        WaitOrTimeoutActor::new(
+            Box::new(move |_ctx| {
+                actix::spawn(view_client.send(GetBlock::latest()).then(|res| {
+                    if let Ok(Ok(block)) = res {
+                        if block.header.height >= 20 {
+                            System::current().stop()
+                        }
+                    }
+                    future::ready(())
+                }));
+            }),
+            100,
+            60000,
+        )
+        .start();
+    })
+}

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod genesis_helpers;
+pub mod mock_network;
 pub mod node;
 pub mod runtime_utils;
 pub mod test_helpers;

--- a/integration-tests/src/mock_network/README.md
+++ b/integration-tests/src/mock_network/README.md
@@ -1,7 +1,7 @@
 # mock-network
 This crate hosts libraries to start a test env for a single node by replacing the network module with a mock network environment. 
 The mock network environment simulates the interaction that the client will usually have with other nodes by 
-responding to the client's network messages and broadcasts new blocks. The mock network reads a pre-generated chain 
+responding to the client's network messages and broadcasting new blocks. The mock network reads a pre-generated chain 
 history from storage.
 
 The crate has two files and another binary sits in ../bin/start_mock_network

--- a/integration-tests/src/mock_network/README.md
+++ b/integration-tests/src/mock_network/README.md
@@ -1,0 +1,15 @@
+# mock-network
+This crate hosts libraries to start a test env for a single node by replacing the network module with a mock network environment. 
+The mock network environment simulates the interaction that the client will usually have with other nodes by 
+responding to the client's network messages and broadcasts new blocks. The mock network reads a pre-generated chain 
+history from storage.
+
+The crate has two files and another binary sits in ../bin/start_mock_network
+
+## mod.rs
+Implements `ChainHistoryAccess` and `MockPeerManagerActor`, which is the main 
+components of the mock network.
+## setup.rs
+Provides functions for setting up a mock network from configs and home dirs.
+## start_mock_network.rs
+A binary that starts a mock network from the home dir of an existing node

--- a/integration-tests/src/mock_network/mod.rs
+++ b/integration-tests/src/mock_network/mod.rs
@@ -14,7 +14,6 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::types::{BlockHeight, ShardId};
 use std::collections::HashMap;
 use std::time::Duration;
-use tracing::info;
 
 mod setup;
 

--- a/integration-tests/src/mock_network/mod.rs
+++ b/integration-tests/src/mock_network/mod.rs
@@ -19,7 +19,7 @@ mod setup;
 
 /// MockPeerManagerActor mocks PeerManagerActor and responds to messages from ClientActor.
 /// Instead of sending these messages out to other peers, it simulates a network and reads
-/// the needed block and chunk content from the storage.
+/// the needed block and chunk content from storage.
 /// MockPeerManagerActor has the following responsibilities
 /// - Responds to BlockRequest, BlockHeadersRequest and PartialEncodedChunkRequest
 /// - Sends NetworkInfo to ClientActor periodically

--- a/integration-tests/src/mock_network/mod.rs
+++ b/integration-tests/src/mock_network/mod.rs
@@ -249,20 +249,20 @@ mod test {
     }
 
     #[test]
-    fn test_mock_network_impl() {
+    fn test_chain_history_access() {
         init_test_logger();
-        let (mut mock_network, mut env) = setup_mock();
+        let (mut chain_history_access, mut env) = setup_mock();
         let blocks: Vec<_> =
             (1..21).map(|h| env.clients[0].chain.get_block_by_height(h).unwrap().clone()).collect();
 
         for block in blocks.iter() {
-            assert_eq!(&mock_network.retrieve_block(block.hash()).unwrap(), block);
+            assert_eq!(&chain_history_access.retrieve_block(block.hash()).unwrap(), block);
         }
 
         for block in blocks.iter() {
             for chunk in block.chunks().iter() {
                 if chunk.height_included() == block.header().height() {
-                    let _partial_encoded_chunk_response = mock_network
+                    let _partial_encoded_chunk_response = chain_history_access
                         .retrieve_partial_encoded_chunk(&PartialEncodedChunkRequestMsg {
                             chunk_hash: chunk.chunk_hash(),
                             part_ords: (0..env.clients[0].runtime_adapter.num_total_parts() as u64)
@@ -281,7 +281,7 @@ mod test {
         for block in blocks.iter() {
             // check the retrieve block headers work. We don't check the results here since
             // it is simply a wrapper around Chain::retrieve_block_headers
-            mock_network.retrieve_block_headers(vec![*block.hash()]).unwrap();
+            chain_history_access.retrieve_block_headers(vec![*block.hash()]).unwrap();
         }
     }
 }

--- a/integration-tests/src/mock_network/mod.rs
+++ b/integration-tests/src/mock_network/mod.rs
@@ -15,7 +15,7 @@ use near_primitives::types::{BlockHeight, ShardId};
 use std::collections::HashMap;
 use std::time::Duration;
 
-mod setup;
+pub mod setup;
 
 /// MockPeerManagerActor mocks PeerManagerActor and responds to messages from ClientActor.
 /// Instead of sending these messages out to other peers, it simulates a network and reads
@@ -24,7 +24,7 @@ mod setup;
 /// - Responds to BlockRequest, BlockHeadersRequest and PartialEncodedChunkRequest
 /// - Sends NetworkInfo to ClientActor periodically
 /// - Simulates block production and sends the most "recent" block to ClientActor
-struct MockPeerManagerActor {
+pub struct MockPeerManagerActor {
     /// Client address for the node that we are testing
     client_addr: Recipient<NetworkClientMessages>,
     /// Access a pre-generated chain history from storage
@@ -150,6 +150,22 @@ impl Handler<PeerManagerMessageRequest> for MockPeerManagerActor {
             }
         }
         PeerManagerMessageResponse::NetworkResponses(NetworkResponses::NoResponse)
+    }
+}
+
+#[derive(actix::Message, Debug)]
+#[rtype(result = "u64")]
+pub struct GetChainHistoryFinalBlockHeight;
+
+impl Handler<GetChainHistoryFinalBlockHeight> for MockPeerManagerActor {
+    type Result = u64;
+
+    fn handle(
+        &mut self,
+        msg: GetChainHistoryFinalBlockHeight,
+        _ctx: &mut Self::Context,
+    ) -> Self::Result {
+        self.chain_history_access.chain.head().unwrap().height
     }
 }
 

--- a/integration-tests/src/mock_network/mod.rs
+++ b/integration-tests/src/mock_network/mod.rs
@@ -21,7 +21,8 @@ pub mod setup;
 /// Instead of sending these messages out to other peers, it simulates a network and reads
 /// the needed block and chunk content from storage.
 /// MockPeerManagerActor has the following responsibilities
-/// - Responds to BlockRequest, BlockHeadersRequest and PartialEncodedChunkRequest
+/// - Responds to the requests sent from ClientActor, including
+///     BlockRequest, BlockHeadersRequest and PartialEncodedChunkRequest
 /// - Sends NetworkInfo to ClientActor periodically
 /// - Simulates block production and sends the most "recent" block to ClientActor
 pub struct MockPeerManagerActor {
@@ -78,7 +79,7 @@ impl MockPeerManagerActor {
 
     /// This function gets called periodically
     /// When it is called, it increments peer heights by 1 and sends the block at that height
-    /// to ClientActor. In a way, it simulates peers that get upgraded and broadcast blocks
+    /// to ClientActor. In a way, it simulates peers that broadcast new blocks
     fn update_peers(&mut self, ctx: &mut Context<MockPeerManagerActor>) {
         let _response =
             self.client_addr.do_send(NetworkClientMessages::NetworkInfo(self.network_info.clone()));
@@ -162,7 +163,7 @@ impl Handler<GetChainHistoryFinalBlockHeight> for MockPeerManagerActor {
 
     fn handle(
         &mut self,
-        msg: GetChainHistoryFinalBlockHeight,
+        _msg: GetChainHistoryFinalBlockHeight,
         _ctx: &mut Self::Context,
     ) -> Self::Result {
         self.chain_history_access.chain.head().unwrap().height

--- a/integration-tests/src/mock_network/setup.rs
+++ b/integration-tests/src/mock_network/setup.rs
@@ -15,7 +15,6 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
-#[allow(dead_code)]
 fn setup_runtime(home_dir: &Path, config: &NearConfig) -> Arc<NightshadeRuntime> {
     let path = get_store_path(home_dir);
     let store = create_store(&path);
@@ -29,7 +28,6 @@ fn setup_runtime(home_dir: &Path, config: &NearConfig) -> Arc<NightshadeRuntime>
     ))
 }
 
-#[allow(dead_code)]
 fn setup_mock_peer_manager_actor(
     runtime: Arc<NightshadeRuntime>,
     client_addr: Recipient<NetworkClientMessages>,
@@ -43,8 +41,7 @@ fn setup_mock_peer_manager_actor(
     MockPeerManagerActor::new(client_addr, genesis_config, chain, 0, block_production_delay)
 }
 
-#[allow(dead_code)]
-fn setup_mock_network(
+pub fn setup_mock_network(
     client_home_dir: &Path,
     network_home_dir: &Path,
     config: &NearConfig,

--- a/integration-tests/src/mock_network/setup.rs
+++ b/integration-tests/src/mock_network/setup.rs
@@ -15,6 +15,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
+#[allow(dead_code)]
 fn setup_runtime(home_dir: &Path, config: &NearConfig) -> Arc<NightshadeRuntime> {
     let path = get_store_path(home_dir);
     let store = create_store(&path);
@@ -28,6 +29,7 @@ fn setup_runtime(home_dir: &Path, config: &NearConfig) -> Arc<NightshadeRuntime>
     ))
 }
 
+#[allow(dead_code)]
 fn setup_mock_peer_manager_actor(
     runtime: Arc<NightshadeRuntime>,
     client_addr: Recipient<NetworkClientMessages>,
@@ -41,6 +43,7 @@ fn setup_mock_peer_manager_actor(
     MockPeerManagerActor::new(client_addr, genesis_config, chain, 0, block_production_delay)
 }
 
+#[allow(dead_code)]
 fn setup_mock_network(
     client_home_dir: &Path,
     network_home_dir: &Path,

--- a/integration-tests/src/mock_network/setup.rs
+++ b/integration-tests/src/mock_network/setup.rs
@@ -115,7 +115,9 @@ mod test {
 
     // Just a test to test that the basic mocknet setup works
     // This test first starts a localnet with one validator node that generates 20 blocks
-    // then start a mock network with one non-validator node trying to catch up these 20 blocks
+    // to generate a chain history
+    // then start a mock network with this chain history and test that
+    // the client in the mock network can catch up these 20 blocks
     #[test]
     fn test_mocknet_basic() {
         init_integration_logger();

--- a/integration-tests/src/mock_network/setup.rs
+++ b/integration-tests/src/mock_network/setup.rs
@@ -1,0 +1,170 @@
+use crate::mock_network::MockPeerManagerActor;
+use actix::{Actor, Addr, Arbiter, Recipient};
+use near_chain::{Chain, ChainGenesis, DoomslugThresholdMode};
+use near_chain_configs::GenesisConfig;
+#[cfg(feature = "test_features")]
+use near_client::AdversarialControls;
+use near_client::{start_client, start_view_client, ClientActor, ViewClientActor};
+use near_network::test_utils::NetworkRecipient;
+use near_network::types::NetworkClientMessages;
+use near_primitives::network::PeerId;
+use near_store::create_store;
+use near_telemetry::TelemetryActor;
+use nearcore::{get_store_path, NearConfig, NightshadeRuntime};
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+fn setup_runtime(home_dir: &Path, config: &NearConfig) -> Arc<NightshadeRuntime> {
+    let path = get_store_path(home_dir);
+    let store = create_store(&path);
+
+    Arc::new(NightshadeRuntime::with_config(
+        home_dir,
+        store.clone(),
+        config,
+        config.client_config.trie_viewer_state_size_limit,
+        config.client_config.max_gas_burnt_view,
+    ))
+}
+
+fn setup_mock_peer_manager_actor(
+    runtime: Arc<NightshadeRuntime>,
+    client_addr: Recipient<NetworkClientMessages>,
+    genesis_config: &GenesisConfig,
+    chain_genesis: &ChainGenesis,
+    block_production_delay: Duration,
+) -> MockPeerManagerActor {
+    let chain =
+        Chain::new_for_view_client(runtime, chain_genesis, DoomslugThresholdMode::NoApprovals)
+            .unwrap();
+    MockPeerManagerActor::new(client_addr, genesis_config, chain, 0, block_production_delay)
+}
+
+fn setup_mock_network(
+    client_home_dir: &Path,
+    network_home_dir: &Path,
+    config: &NearConfig,
+) -> (Addr<MockPeerManagerActor>, Addr<ClientActor>, Addr<ViewClientActor>) {
+    let client_runtime = setup_runtime(client_home_dir, &config);
+    let mock_network_runtime = setup_runtime(network_home_dir, &config);
+
+    let telemetry = TelemetryActor::new(config.telemetry_config.clone()).start();
+    let chain_genesis = ChainGenesis::from(&config.genesis);
+
+    let node_id = PeerId::new(config.network_config.public_key.clone().into());
+    let network_adapter = Arc::new(NetworkRecipient::default());
+    #[cfg(feature = "test_features")]
+    let adv = Arc::new(std::sync::RwLock::new(AdversarialControls::default()));
+
+    let block_production_delay = config.client_config.min_block_production_delay;
+    let (client_actor, _) = start_client(
+        config.client_config.clone(),
+        chain_genesis.clone(),
+        client_runtime.clone(),
+        node_id,
+        network_adapter.clone(),
+        config.validator_signer.clone(),
+        telemetry,
+        #[cfg(feature = "test_features")]
+        adv.clone(),
+    );
+
+    let view_client = start_view_client(
+        None,
+        chain_genesis.clone(),
+        client_runtime.clone(),
+        network_adapter.clone(),
+        config.client_config.clone(),
+        #[cfg(feature = "test_features")]
+        adv.clone(),
+    );
+
+    let arbiter = Arbiter::new();
+    let client_actor1 = client_actor.clone();
+    let genesis_config = config.genesis.config.clone();
+    let mock_network_actor =
+        MockPeerManagerActor::start_in_arbiter(&arbiter.handle(), move |_ctx| {
+            setup_mock_peer_manager_actor(
+                mock_network_runtime,
+                client_actor1.recipient(),
+                &genesis_config,
+                &chain_genesis,
+                block_production_delay,
+            )
+        });
+    network_adapter.set_recipient(mock_network_actor.clone().recipient());
+    (mock_network_actor, client_actor, view_client)
+}
+
+#[cfg(test)]
+mod test {
+    use crate::mock_network::setup::setup_mock_network;
+    use actix::{Actor, System};
+    use futures::{future, FutureExt};
+    use near_actix_test_utils::run_actix;
+    use near_chain_configs::Genesis;
+    use near_client::GetBlock;
+    use near_logger_utils::init_integration_logger;
+    use near_network::test_utils::{open_port, WaitOrTimeoutActor};
+    use nearcore::config::GenesisExt;
+    use nearcore::{load_test_config, start_with_config};
+
+    // just a test to test that the basic mocknet setup works
+    #[test]
+    fn test_mocknet_basic() {
+        init_integration_logger();
+
+        // first set up a network with only one validator and generate some blocks
+        let genesis = Genesis::test(vec!["test0".parse().unwrap()], 1);
+        let mut near_config = load_test_config("test0", open_port(), genesis.clone());
+        near_config.client_config.min_num_peers = 0;
+
+        let dir = tempfile::Builder::new().prefix("test0").tempdir().unwrap();
+        let path1 = dir.path().clone();
+        run_actix(async move {
+            let nearcore::NearNode { view_client, .. } =
+                start_with_config(path1, near_config).expect("start_with_config");
+
+            WaitOrTimeoutActor::new(
+                Box::new(move |_ctx| {
+                    actix::spawn(view_client.send(GetBlock::latest()).then(|res| {
+                        let latest_height =
+                            if let Ok(Ok(block)) = res { block.header.height } else { 0 };
+                        if latest_height >= 20 {
+                            System::current().stop()
+                        }
+                        future::ready(())
+                    }));
+                }),
+                100,
+                60000,
+            )
+            .start();
+        });
+
+        // start the mock network to simulate a new node "test1" to sync up
+        let dir1 = tempfile::Builder::new().prefix("test1").tempdir().unwrap();
+        let mut near_config1 = load_test_config("test1", open_port(), genesis);
+        near_config1.client_config.min_num_peers = 1;
+        run_actix(async move {
+            let (_mock_network, _client, view_client) =
+                setup_mock_network(dir1.path().clone(), dir.path().clone(), &near_config1);
+            WaitOrTimeoutActor::new(
+                Box::new(move |_ctx| {
+                    actix::spawn(view_client.send(GetBlock::latest()).then(|res| {
+                        if let Ok(Ok(block)) = res {
+                            if block.header.height >= 20 {
+                                System::current().stop()
+                            }
+                        }
+                        future::ready(())
+                    }));
+                }),
+                100,
+                60000,
+            )
+            .start();
+        })
+    }
+}

--- a/integration-tests/src/mock_network/setup.rs
+++ b/integration-tests/src/mock_network/setup.rs
@@ -113,7 +113,9 @@ mod test {
     use nearcore::config::GenesisExt;
     use nearcore::{load_test_config, start_with_config};
 
-    // just a test to test that the basic mocknet setup works
+    // Just a test to test that the basic mocknet setup works
+    // This test first starts a localnet with one validator node that generates 20 blocks
+    // then start a mock network with one non-validator node trying to catch up these 20 blocks
     #[test]
     fn test_mocknet_basic() {
         init_integration_logger();

--- a/integration-tests/src/tests/client/challenges.rs
+++ b/integration-tests/src/tests/client/challenges.rs
@@ -11,6 +11,7 @@ use near_chain::{
     Provenance,
 };
 use near_chain_configs::Genesis;
+use near_chunks::ShardsManager;
 use near_client::test_utils::{create_chunk, create_chunk_with_transactions, run_catchup, TestEnv};
 use near_client::Client;
 use near_crypto::{InMemorySigner, KeyType, Signer};
@@ -304,27 +305,25 @@ fn test_verify_chunk_invalid_state_challenge() {
     let data_parts = env.clients[0].runtime_adapter.num_data_parts();
     let parity_parts = total_parts - data_parts;
     let mut rs = ReedSolomonWrapper::new(data_parts, parity_parts);
-    let (mut invalid_chunk, merkle_paths) = env.clients[0]
-        .shards_mgr
-        .create_encoded_shard_chunk(
-            *last_block.hash(),
-            StateRoot::default(),
-            CryptoHash::default(),
-            last_block.header().height() + 1,
-            0,
-            0,
-            1_000,
-            0,
-            vec![],
-            vec![],
-            &vec![],
-            last_block.chunks()[0].outgoing_receipts_root(),
-            CryptoHash::default(),
-            &validator_signer,
-            &mut rs,
-            PROTOCOL_VERSION,
-        )
-        .unwrap();
+    let (mut invalid_chunk, merkle_paths) = ShardsManager::create_encoded_shard_chunk(
+        *last_block.hash(),
+        StateRoot::default(),
+        CryptoHash::default(),
+        last_block.header().height() + 1,
+        0,
+        0,
+        1_000,
+        0,
+        vec![],
+        vec![],
+        &vec![],
+        last_block.chunks()[0].outgoing_receipts_root(),
+        CryptoHash::default(),
+        &validator_signer,
+        &mut rs,
+        PROTOCOL_VERSION,
+    )
+    .unwrap();
 
     let client = &mut env.clients[0];
 

--- a/tools/restaked/Cargo.toml
+++ b/tools/restaked/Cargo.toml
@@ -18,3 +18,6 @@ near-jsonrpc-client = { path = "../../chain/jsonrpc/client" }
 nearcore = { path = "../../nearcore" }
 
 integration-tests = { path = "../../integration-tests" }
+
+[features]
+test_features = ["integration-tests/test_features"]


### PR DESCRIPTION
First iteration of mock network (different from Nikolay's mocknet, better name suggestion welcomed)
A mock network simulates a test environment for ClientActor by replacing PeerManagerActor, instead of sending network messages out to other peers, it simulates a network and reads the needed block and chunk content from storage.

In this first iteration, the mock network only simulates one peer and all messages get instant response from the mock network. I will add more complicated peer logic in future iteration. 
