### PR TITLE
chain: add RpcQueryError::GarbageCollectedBlock

### DIFF
--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -346,6 +346,13 @@ pub enum QueryError {
     },
     #[error("The node reached its limits. Try again later. More details: {error_message}")]
     InternalError { error_message: String },
+    #[error(
+        "The data for block #{block_height} is garbage collected on this node, use an archival node to fetch historical data"
+    )]
+    GarbageCollectedBlock {
+        block_height: near_primitives::types::BlockHeight,
+        block_hash: near_primitives::hash::CryptoHash,
+    },
     #[error("Block either has never been observed on the node or has been garbage collected: {block_reference:?}")]
     UnknownBlock { block_reference: near_primitives::types::BlockReference },
     // NOTE: Currently, the underlying errors are too broad, and while we tried to handle

--- a/chain/client/src/tests/query_client.rs
+++ b/chain/client/src/tests/query_client.rs
@@ -1,29 +1,34 @@
 use actix::System;
 use futures::{future, FutureExt};
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
 
-use crate::test_utils::{setup_no_network, setup_only_view};
+use crate::test_utils::{setup_mock_all_validators, setup_no_network, setup_only_view};
 use crate::{
-    GetBlock, GetBlockWithMerkleTree, GetExecutionOutcomesForBlock, Query, Status, TxStatus,
+    GetBlock, GetBlockWithMerkleTree, GetExecutionOutcomesForBlock, Query, QueryError, Status,
+    TxStatus,
 };
 use near_actix_test_utils::run_actix;
+use near_chain::chain::NUM_EPOCHS_TO_KEEP_STORE_DATA;
 use near_crypto::{InMemorySigner, KeyType};
 use near_logger_utils::init_test_logger;
 use near_network::test_utils::MockPeerManagerAdapter;
-use near_network::types::{NetworkClientMessages, NetworkClientResponses};
+use near_network::types::{
+    NetworkClientMessages, NetworkClientResponses, NetworkRequests, NetworkResponses,
+    PeerManagerMessageRequest, PeerManagerMessageResponse,
+};
 use near_network_primitives::types::{
     NetworkViewClientMessages, NetworkViewClientResponses, PeerInfo,
 };
 use near_primitives::block::{Block, BlockHeader};
 use near_primitives::time::Utc;
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::{BlockId, BlockReference, EpochId};
+use near_primitives::types::{AccountId, BlockId, BlockReference, EpochId};
 use near_primitives::utils::to_timestamp;
 use near_primitives::validator_signer::InMemoryValidatorSigner;
 use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives::views::{FinalExecutionOutcomeViewEnum, QueryRequest, QueryResponseKind};
 use num_rational::Rational;
-use std::sync::Arc;
-use std::time::Duration;
 
 /// Query account from view client
 #[test]
@@ -234,4 +239,126 @@ fn test_state_request() {
         });
         near_network::test_utils::wait_or_panic(50000);
     });
+}
+
+#[test]
+/// When querying data which was garbage collected on a node it returns
+/// `QueryError::GarbageCollectedBlock`.
+fn test_garbage_collection() {
+    init_test_logger();
+    run_actix(async {
+        let block_prod_time = 100;
+        let epoch_length = 5;
+        let target_height = epoch_length * (NUM_EPOCHS_TO_KEEP_STORE_DATA + 1);
+        let network_mock: Arc<
+            RwLock<
+                Box<
+                    dyn FnMut(
+                        AccountId,
+                        &PeerManagerMessageRequest,
+                    ) -> (PeerManagerMessageResponse, bool),
+                >,
+            >,
+        > = Arc::new(RwLock::new(Box::new(|_: _, _: &PeerManagerMessageRequest| {
+            (NetworkResponses::NoResponse.into(), true)
+        })));
+
+        let (_, conns, _) = setup_mock_all_validators(
+            vec![vec!["test1".parse().unwrap(), "test2".parse().unwrap()]],
+            vec![PeerInfo::random(), PeerInfo::random()],
+            1,
+            true,
+            block_prod_time,
+            false,
+            false,
+            epoch_length,
+            true,
+            vec![false, true], // first validator non-archival, second archival
+            vec![true, true],
+            true,
+            network_mock.clone(),
+        );
+
+        *network_mock.write().unwrap() = Box::new(
+            move |_: _, msg: &PeerManagerMessageRequest| -> (PeerManagerMessageResponse, bool) {
+                if let NetworkRequests::Block { block } = msg.as_network_requests_ref() {
+                    if block.header().height() > target_height {
+                        let view_client_non_archival = &conns[0].1;
+                        let view_client_archival = &conns[1].1;
+                        let mut tests = vec![];
+
+                        // Recent data is present on all nodes (archival or not).
+                        let prev_height = block.header().prev_height().unwrap();
+                        for (_, view_client) in conns.iter() {
+                            tests.push(actix::spawn(
+                                view_client
+                                    .send(Query::new(
+                                        BlockReference::BlockId(BlockId::Height(prev_height)),
+                                        QueryRequest::ViewAccount {
+                                            account_id: "test1".parse().unwrap(),
+                                        },
+                                    ))
+                                    .then(move |res| {
+                                        let res = res.unwrap().unwrap();
+                                        match res.kind {
+                                            QueryResponseKind::ViewAccount(_) => (),
+                                            _ => panic!("Invalid response"),
+                                        }
+                                        futures::future::ready(())
+                                    }),
+                            ));
+                        }
+
+                        // On non-archival node old data is garbage collected.
+                        tests.push(actix::spawn(
+                            view_client_non_archival
+                                .send(Query::new(
+                                    BlockReference::BlockId(BlockId::Height(1)),
+                                    QueryRequest::ViewAccount {
+                                        account_id: "test1".parse().unwrap(),
+                                    },
+                                ))
+                                .then(move |res| {
+                                    let res = res.unwrap();
+                                    match res {
+                                        Err(err) => assert!(matches!(
+                                            err,
+                                            QueryError::GarbageCollectedBlock { .. }
+                                        )),
+                                        Ok(_) => panic!("Unexpected Ok variant"),
+                                    }
+                                    futures::future::ready(())
+                                }),
+                        ));
+
+                        // On archival node old data is _not_ garbage collected.
+                        tests.push(actix::spawn(
+                            view_client_archival
+                                .send(Query::new(
+                                    BlockReference::BlockId(BlockId::Height(1)),
+                                    QueryRequest::ViewAccount {
+                                        account_id: "test1".parse().unwrap(),
+                                    },
+                                ))
+                                .then(move |res| {
+                                    let res = res.unwrap().unwrap();
+                                    match res.kind {
+                                        QueryResponseKind::ViewAccount(_) => (),
+                                        _ => panic!("Invalid response"),
+                                    }
+                                    futures::future::ready(())
+                                }),
+                        ));
+
+                        actix::spawn(futures::future::join_all(tests).then(|_| {
+                            System::current().stop();
+                            futures::future::ready(())
+                        }));
+                    }
+                }
+                (NetworkResponses::NoResponse.into(), true)
+            },
+        );
+        near_network::test_utils::wait_or_panic(block_prod_time * target_height * 2 + 2000);
+    })
 }

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -195,6 +195,15 @@ impl ViewClientActor {
         }
     }
 
+    fn block_maybe_garbage_collected(&self, block: &BlockHeader) -> Result<bool, Error> {
+        if self.config.archive {
+            return Ok(false);
+        }
+        let tip = self.chain.head()?;
+        let gc_stop_height = self.runtime_adapter.get_gc_stop_height(&tip.last_block_hash);
+        Ok(block.height() < gc_stop_height)
+    }
+
     fn handle_query(&mut self, msg: Query) -> Result<QueryResponse, QueryError> {
         let header = match msg.block_reference {
             BlockReference::BlockId(BlockId::Height(block_height)) => {
@@ -256,10 +265,18 @@ impl ViewClientActor {
             .shard_id_to_uid(shard_id, header.epoch_id())
             .map_err(|err| QueryError::InternalError { error_message: err.to_string() })?;
 
+        let block_maybe_gc = self.block_maybe_garbage_collected(&header);
         let chunk_extra = self.chain.get_chunk_extra(header.hash(), &shard_uid).map_err(|err| {
             match err.kind() {
                 near_chain::near_chain_primitives::ErrorKind::DBNotFoundErr(_) => {
-                    QueryError::UnavailableShard { requested_shard_id: shard_id }
+                    match block_maybe_gc {
+                        Ok(true) => QueryError::GarbageCollectedBlock {
+                            block_height: header.height(),
+                            block_hash: header.hash().clone(),
+                        },
+                        Ok(false) => QueryError::UnavailableShard { requested_shard_id: shard_id },
+                        Err(err) => QueryError::InternalError { error_message: err.to_string() },
+                    }
                 }
                 near_chain::near_chain_primitives::ErrorKind::IOErr(error_message) => {
                     QueryError::InternalError { error_message }

--- a/chain/jsonrpc-primitives/src/types/query.rs
+++ b/chain/jsonrpc-primitives/src/types/query.rs
@@ -19,6 +19,13 @@ pub enum RpcQueryError {
     NoSyncedBlocks,
     #[error("The node does not track the shard ID {requested_shard_id}")]
     UnavailableShard { requested_shard_id: near_primitives::types::ShardId },
+    #[error(
+        "The data for block #{block_height} is garbage collected on this node, use an archival node to fetch historical data"
+    )]
+    GarbageCollectedBlock {
+        block_height: near_primitives::types::BlockHeight,
+        block_hash: near_primitives::hash::CryptoHash,
+    },
     #[error("Block either has never been observed on the node or has been garbage collected: {block_reference:?}")]
     UnknownBlock { block_reference: near_primitives::types::BlockReference },
     #[error("Account ID {requested_account_id} is invalid")]
@@ -172,6 +179,10 @@ impl From<near_client_primitives::types::QueryError> for RpcQueryError {
             near_client_primitives::types::QueryError::UnknownBlock { block_reference } => {
                 Self::UnknownBlock { block_reference }
             }
+            near_client_primitives::types::QueryError::GarbageCollectedBlock {
+                block_height,
+                block_hash,
+            } => Self::GarbageCollectedBlock { block_height, block_hash },
             near_client_primitives::types::QueryError::InvalidAccount {
                 requested_account_id,
                 block_height,


### PR DESCRIPTION
Querying garbage collected historical data from a non-archival node yields `RpcQueryError::UnavailableShard`, see #4340.

#### Changes introduced by this PR
Before returning `RpcQueryError::UnavailableShard`, `ViewClientActor` checks in `handle_query` if the block might have been garbage collected. If yes, it returns `QueryError::GarbageCollectedBlock` (new error variant).

#### Testing
- Start two validator nodes: one non-archival, one archival.
- Let them produce blocks until garbage collection kicks in.
- Query data that might have been garbage collected and verify:
  - The non-archival node returns `QueryError::GarbageCollectedBlock`.
  - The archival node returns the data.