### PR TITLE
refactor: Align gas metering estimation

### DIFF
--- a/runtime/runtime-params-estimator/src/function_call.rs
+++ b/runtime/runtime-params-estimator/src/function_call.rs
@@ -20,7 +20,6 @@ pub(crate) fn test_function_call(metric: GasMetric, vm_kind: VMKind) -> (Ratio<i
     for method_count in vec![5, 20, 30, 50, 100, 200, 1000] {
         let contract = make_many_methods_contract(method_count);
         let cost = compute_function_call_cost(metric, vm_kind, REPEATS, &contract);
-        println!("{:?} {:?} {} {}", vm_kind, metric, method_count, cost / REPEATS);
         xs.push(contract.code().len() as u64);
         ys.push(cost / REPEATS);
     }
@@ -31,10 +30,6 @@ pub(crate) fn test_function_call(metric: GasMetric, vm_kind: VMKind) -> (Ratio<i
     }
 
     let (cost_base, cost_byte, _) = least_squares_method(&xs, &ys);
-    println!(
-        "{:?} {:?} function call base {} gas, per byte {} gas",
-        vm_kind, metric, cost_base, cost_byte,
-    );
     (cost_base, cost_byte)
 }
 

--- a/runtime/runtime-params-estimator/src/gas_metering.rs
+++ b/runtime/runtime-params-estimator/src/gas_metering.rs
@@ -1,56 +1,47 @@
-use crate::config::GasMetric;
-use crate::gas_cost::GasCost;
-use crate::least_squares::least_squares_method;
+use crate::config::Config;
+use crate::gas_cost::{GasCost, LeastSquaresTolerance};
 use crate::vm_estimator::create_context;
 use near_primitives::config::VMConfig;
 use near_primitives::contract::ContractCode;
 use near_primitives::runtime::config_store::RuntimeConfigStore;
-use near_primitives::types::{CompiledContractCache, Gas};
+use near_primitives::types::CompiledContractCache;
 use near_primitives::version::PROTOCOL_VERSION;
 use near_store::{create_store, StoreCompiledContractCache};
 use near_vm_logic::mocks::mock_external::MockedExternal;
-use near_vm_runner::internal::VMKind;
 use nearcore::get_store_path;
+use num_traits::{CheckedSub, SaturatingSub};
 use std::fmt::Write;
 use std::sync::Arc;
 
-pub(crate) fn gas_metering_cost(metric: GasMetric, vm_kind: VMKind) -> (Gas, Gas) {
-    const REPEATS: i32 = 1000;
+pub(crate) fn gas_metering_cost(config: &Config) -> (GasCost, GasCost) {
     let mut xs1 = vec![];
     let mut ys1 = vec![];
     let mut xs2 = vec![];
     let mut ys2 = vec![];
     for depth in vec![1, 10, 20, 30, 50, 100, 200, 1000] {
-        if true {
+        {
             // Here we test gas metering costs for forward branch cases.
             let nested_contract = make_deeply_nested_blocks_contact(depth);
-            let cost = compute_gas_metering_cost(metric, vm_kind, REPEATS, &nested_contract);
+            let cost = compute_gas_metering_cost(config, &nested_contract);
             xs1.push(depth as u64);
             ys1.push(cost);
         }
-        if true {
+        {
             let loop_contract = make_simple_loop_contact(depth);
-            let cost = compute_gas_metering_cost(metric, vm_kind, REPEATS, &loop_contract);
+            let cost = compute_gas_metering_cost(config, &loop_contract);
             xs2.push(depth as u64);
             ys2.push(cost);
         }
     }
 
-    // Regression analysis only makes sense for additive metrics.
-    if metric == GasMetric::Time {
-        return (0, 0);
-    }
+    let tolerance = LeastSquaresTolerance::default().factor_rel_nn_tolerance(0.001);
+    let (cost1_base, cost1_op) =
+        GasCost::least_squares_method_gas_cost(&xs1, &ys1, &tolerance, config.debug_least_squares);
+    let (cost2_base, cost2_op) =
+        GasCost::least_squares_method_gas_cost(&xs2, &ys2, &tolerance, config.debug_least_squares);
 
-    let (cost1_base, cost1_op, _) = least_squares_method(&xs1, &ys1);
-    let (cost2_base, cost2_op, _) = least_squares_method(&xs2, &ys2);
-
-    #[cfg(test)]
-    println!("forward branches: {} gas base {} gas per op", cost1_base, cost1_op,);
-    #[cfg(test)]
-    println!("backward branches: {} gas base {} gas per op", cost2_base, cost2_op,);
-
-    let cost_base = std::cmp::max(cost1_base, cost2_base).round().to_integer() as u64;
-    let cost_op = std::cmp::max(cost1_op, cost2_op).round().to_integer() as u64;
+    let cost_base = std::cmp::max(cost1_base, cost2_base);
+    let cost_op = std::cmp::max(cost1_op, cost2_op);
     (cost_base, cost_op)
 }
 
@@ -133,12 +124,12 @@ fn make_simple_loop_contact(depth: i32) -> ContractCode {
  * running contracts with and without gas metering and comparing the difference induced by gas
  * metering.
  */
-pub fn compute_gas_metering_cost(
-    gas_metric: GasMetric,
-    vm_kind: VMKind,
-    repeats: i32,
-    contract: &ContractCode,
-) -> u64 {
+pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode) -> GasCost {
+    let gas_metric = config.metric;
+    let repeats = config.iter_per_block as u64;
+    let vm_kind = config.vm_kind;
+    let warmup_repeats = config.warmup_iters_per_block;
+
     let workdir = tempfile::Builder::new().prefix("runtime_testbed").tempdir().unwrap();
     let store = create_store(&get_store_path(workdir.path()));
     let cache_store = Arc::new(StoreCompiledContractCache { store });
@@ -147,27 +138,30 @@ pub fn compute_gas_metering_cost(
     let runtime_config = config_store.get_config(PROTOCOL_VERSION).as_ref();
     let vm_config_gas = runtime_config.wasm_config.clone();
     let runtime = vm_kind.runtime(vm_config_gas).expect("runtime has not been enabled");
+    let runtime_free_gas = vm_kind.runtime(VMConfig::free()).expect("runtime has not been enabled");
     let fees = runtime_config.transaction_costs.clone();
     let mut fake_external = MockedExternal::new();
     let fake_context = create_context(vec![]);
     let promise_results = vec![];
 
-    // Warmup.
-    let result = runtime.run(
-        contract,
-        "hello",
-        &mut fake_external,
-        fake_context.clone(),
-        &fees,
-        &promise_results,
-        PROTOCOL_VERSION,
-        cache,
-    );
-    if result.1.is_some() {
-        let err = result.1.as_ref().unwrap();
-        eprintln!("error: {}", err);
+    // Warmup with gas metering
+    for _ in 0..warmup_repeats {
+        let result = runtime.run(
+            contract,
+            "hello",
+            &mut fake_external,
+            fake_context.clone(),
+            &fees,
+            &promise_results,
+            PROTOCOL_VERSION,
+            cache,
+        );
+        if result.1.is_some() {
+            let err = result.1.as_ref().unwrap();
+            eprintln!("error: {}", err);
+        }
+        assert!(result.1.is_none());
     }
-    assert!(result.1.is_none());
 
     // Run with gas metering.
     let start = GasCost::measure(gas_metric);
@@ -184,24 +178,11 @@ pub fn compute_gas_metering_cost(
         );
         assert!(result.1.is_none());
     }
-    let total_raw_with_gas = start.elapsed().to_gas();
+    let total_raw_with_gas = start.elapsed();
 
-    let vm_config_no_gas = VMConfig::free();
-    let runtime = vm_kind.runtime(vm_config_no_gas).expect("runtime has not been enabled");
-    let result = runtime.run(
-        contract,
-        "hello",
-        &mut fake_external,
-        fake_context.clone(),
-        &fees,
-        &promise_results,
-        PROTOCOL_VERSION,
-        cache,
-    );
-    assert!(result.1.is_none());
-    let start = GasCost::measure(gas_metric);
-    for _ in 0..repeats {
-        let result = runtime.run(
+    // Warmup without gas metering
+    for _ in 0..warmup_repeats {
+        let result = runtime_free_gas.run(
             contract,
             "hello",
             &mut fake_external,
@@ -213,16 +194,40 @@ pub fn compute_gas_metering_cost(
         );
         assert!(result.1.is_none());
     }
-    let total_raw_no_gas = start.elapsed().to_gas();
 
-    // TODO: This seems to fail almost always but has some non-determinism to it.
-    assert!(
-        total_raw_with_gas > total_raw_no_gas,
-        "Cost with gas metering should be higher than without. Metric: {:?}. Estimated with gas metering: {}, without: {}",
-        gas_metric,
-        total_raw_with_gas,
-        total_raw_no_gas
-    );
+    // Run without gas metering.
+    let start = GasCost::measure(gas_metric);
+    for _ in 0..repeats {
+        let result = runtime_free_gas.run(
+            contract,
+            "hello",
+            &mut fake_external,
+            fake_context.clone(),
+            &fees,
+            &promise_results,
+            PROTOCOL_VERSION,
+            cache,
+        );
+        assert!(result.1.is_none());
+    }
+    let total_raw_no_gas = start.elapsed();
 
-    total_raw_with_gas - total_raw_no_gas
+    if total_raw_with_gas < total_raw_no_gas {
+        // This might happen due to experimental error, especially when running
+        // without warmup or too few iterations.
+        let mut null_cost = GasCost::zero(gas_metric);
+        null_cost.set_uncertain(true);
+        return null_cost;
+    }
+
+    let cost_diff = match total_raw_with_gas.checked_sub(&total_raw_no_gas) {
+        Some(cost) => cost,
+        None => {
+            let mut cost = total_raw_with_gas.saturating_sub(&total_raw_no_gas);
+            cost.set_uncertain(true);
+            cost
+        }
+    };
+
+    cost_diff / repeats
 }

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -521,7 +521,7 @@ fn action_deploy_contract_per_byte(ctx: &mut EstimatorContext) -> GasCost {
     let (_base, per_byte) = GasCost::least_squares_method_gas_cost(
         &xs,
         &ys,
-        LeastSquaresTolerance::default()
+        &LeastSquaresTolerance::default()
             .base_abs_nn_tolerance(negative_base_tolerance)
             .factor_rel_nn_tolerance(rel_factor_tolerance),
         ctx.config.debug_least_squares,
@@ -1091,9 +1091,7 @@ fn gas_metering(ctx: &mut EstimatorContext) -> (GasCost, GasCost) {
     if let Some(cached) = ctx.cached.gas_metering_cost_base_per_op.clone() {
         return cached;
     }
-    let (base, byte) = gas_metering_cost(ctx.config.metric, ctx.config.vm_kind);
-    let base = GasCost::from_gas(base.into(), ctx.config.metric);
-    let byte = GasCost::from_gas(byte.into(), ctx.config.metric);
+    let (base, byte) = gas_metering_cost(&ctx.config);
     ctx.cached.gas_metering_cost_base_per_op = Some((base.clone(), byte.clone()));
     (base, byte)
 }

--- a/runtime/runtime-params-estimator/src/vm_estimator.rs
+++ b/runtime/runtime-params-estimator/src/vm_estimator.rs
@@ -108,7 +108,7 @@ fn precompilation_cost(
     let (a, b) = GasCost::least_squares_method_gas_cost(
         &xs,
         &ys,
-        LeastSquaresTolerance::default()
+        &LeastSquaresTolerance::default()
             .base_abs_nn_tolerance(negative_base_tolerance)
             .factor_rel_nn_tolerance(rel_factor_tolerance),
         verbose,


### PR DESCRIPTION
Gas metering estimation now also respects CLI parameters
(`--iters` and --`warmups-iters`)

Also avoid runtime panic in case of unstable measurements