### PR TITLE
feat(params-estimator): Clear IO caches

### DIFF
--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -878,6 +878,11 @@ impl RocksDB {
     pub fn checkpoint(&self) -> Result<Checkpoint, DBError> {
         Checkpoint::new(&self.db).map_err(|err| DBError(err))
     }
+
+    /// Synchronously flush all Memtables to SST files on disk
+    pub fn flush(&self) -> Result<(), DBError> {
+        self.db.flush().map_err(DBError::from)
+    }
 }
 
 fn available_space<P: AsRef<Path> + std::fmt::Debug>(

--- a/runtime/runtime-params-estimator/src/config.rs
+++ b/runtime/runtime-params-estimator/src/config.rs
@@ -34,4 +34,6 @@ pub struct Config {
     pub rocksdb_test_config: RocksDBTestConfig,
     /// Print extra details on least-squares computation
     pub debug_least_squares: bool,
+    /// Clear all OS caches between measured blocks
+    pub drop_os_cache: bool,
 }

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -101,9 +101,12 @@ impl<'c> Testbed<'c> {
         // - only required in time based measurements, since ICount looks at syscalls directly.
         // - requires sudo, therefore this is executed optionally
         if self.config.metric == GasMetric::Time && self.config.drop_os_cache {
+            #[cfg(target_os = "linux")]
             clear_linux_page_cache().expect(
                 "Failed to drop OS caches. Are you root and is /proc mounted with write access?",
             );
+            #[cfg(not(target_os = "linux"))]
+            panic!("Cannot drop OS caches on non-linux systems.");
         }
     }
 }

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -69,6 +69,9 @@ struct CliArgs {
     /// Works only with enabled docker, because precise computations without it doesn't make sense.
     #[clap(long)]
     full: bool,
+    /// Drop OS cache before measurements for better IO accuracy. Requires sudo.
+    #[clap(long)]
+    drop_os_cache: bool,
     /// Print extra debug information
     #[clap(long, multiple(true), possible_values=&["io", "rocksdb", "least-squares"])]
     debug: Vec<String>,
@@ -192,6 +195,7 @@ fn main() -> anyhow::Result<()> {
     let warmup_iters_per_block = cli_args.warmup_iters;
     let mut rocksdb_test_config = cli_args.db_test_config;
     rocksdb_test_config.debug_rocksdb = debug_options.contains(&"rocksdb");
+    rocksdb_test_config.drop_os_cache = cli_args.drop_os_cache;
     let iter_per_block = cli_args.iters;
     let active_accounts = cli_args.accounts_num;
     let metric = match cli_args.metric.as_str() {
@@ -219,6 +223,7 @@ fn main() -> anyhow::Result<()> {
         costs_to_measure,
         rocksdb_test_config,
         debug_least_squares: debug_options.contains(&"least-squares"),
+        drop_os_cache: cli_args.drop_os_cache,
     };
     let cost_table = runtime_params_estimator::run(config);
 

--- a/runtime/runtime-params-estimator/src/rocksdb.rs
+++ b/runtime/runtime-params-estimator/src/rocksdb.rs
@@ -289,8 +289,11 @@ fn new_test_db(
         db_config.force_compaction,
         true, // always force-flush in setup
     );
-    clear_linux_page_cache()
-        .expect("Failed to drop OS caches. Are you root and is /proc mounted with write access?");
+    if db_config.drop_os_cache {
+        clear_linux_page_cache().expect(
+            "Failed to drop OS caches. Are you root and is /proc mounted with write access?",
+        );
+    }
 
     db
 }

--- a/runtime/runtime-params-estimator/src/rocksdb.rs
+++ b/runtime/runtime-params-estimator/src/rocksdb.rs
@@ -5,7 +5,7 @@ use rand::{prelude::SliceRandom, Rng};
 use rand_xorshift::XorShiftRng;
 use rocksdb::DB;
 
-use crate::{config::Config, gas_cost::GasCost};
+use crate::{config::Config, gas_cost::GasCost, utils::clear_linux_page_cache};
 
 #[derive(Debug, Clone, Clap)]
 pub struct RocksDBTestConfig {
@@ -50,6 +50,9 @@ pub struct RocksDBTestConfig {
     /// (`RocksDb*` estimations only)
     #[clap(long, name = "rdb-input-data-path", long)]
     pub input_data_path: Option<PathBuf>,
+    /// Drop OS cache before measurements for better IO accuracy.
+    #[clap(skip)]
+    pub drop_os_cache: bool,
 }
 
 // These tests make use of reproducible pseud-randomness.
@@ -286,6 +289,8 @@ fn new_test_db(
         db_config.force_compaction,
         true, // always force-flush in setup
     );
+    clear_linux_page_cache()
+        .expect("Failed to drop OS caches. Are you root and is /proc mounted with write access?");
 
     db
 }

--- a/runtime/runtime-params-estimator/src/testbed.rs
+++ b/runtime/runtime-params-estimator/src/testbed.rs
@@ -137,4 +137,11 @@ impl RuntimeTestbed {
             self.process_block(&[], allow_failures);
         }
     }
+
+    /// Flushes RocksDB memtable
+    pub fn flush_db_write_buffer(&mut self) {
+        let store = self.tries.get_store();
+        let rocksdb = store.get_rocksdb().unwrap();
+        rocksdb.flush().unwrap();
+    }
 }

--- a/runtime/runtime-params-estimator/src/utils.rs
+++ b/runtime/runtime-params-estimator/src/utils.rs
@@ -24,7 +24,8 @@ pub fn read_resource(path: &str) -> Vec<u8> {
 /// Attempts to clear OS page cache on Linux based system. Will fail on
 /// other systems. Requires write access to /proc/sys/vm/drop_caches
 pub fn clear_linux_page_cache() -> io::Result<()> {
-    Command::new("sync").output().expect("sync failed");
+    let out = Command::new("sync").output().expect("sync failed");
+    assert!(out.status.success());
     fs::write("/proc/sys/vm/drop_caches", b"1")
 }
 

--- a/runtime/runtime-params-estimator/src/utils.rs
+++ b/runtime/runtime-params-estimator/src/utils.rs
@@ -4,7 +4,6 @@ use crate::gas_cost::GasCost;
 use crate::transaction_builder::TransactionBuilder;
 
 use std::collections::HashMap;
-use std::process::Command;
 use std::{fs, io};
 
 use near_primitives::transaction::SignedTransaction;
@@ -23,9 +22,11 @@ pub fn read_resource(path: &str) -> Vec<u8> {
 
 /// Attempts to clear OS page cache on Linux based system. Will fail on
 /// other systems. Requires write access to /proc/sys/vm/drop_caches
+#[cfg(target_os = "linux")]
 pub fn clear_linux_page_cache() -> io::Result<()> {
-    let out = Command::new("sync").output().expect("sync failed");
-    assert!(out.status.success());
+    unsafe {
+        libc::sync();
+    }
     fs::write("/proc/sys/vm/drop_caches", b"1")
 }
 

--- a/runtime/runtime-params-estimator/src/utils.rs
+++ b/runtime/runtime-params-estimator/src/utils.rs
@@ -4,6 +4,8 @@ use crate::gas_cost::GasCost;
 use crate::transaction_builder::TransactionBuilder;
 
 use std::collections::HashMap;
+use std::process::Command;
+use std::{fs, io};
 
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::AccountId;
@@ -17,6 +19,13 @@ pub fn read_resource(path: &str) -> Vec<u8> {
     let path = std::path::Path::new(dir).join(path);
     std::fs::read(&path)
         .unwrap_or_else(|err| panic!("failed to load test resource: {}, {}", path.display(), err))
+}
+
+/// Attempts to clear OS page cache on Linux based system. Will fail on
+/// other systems. Requires write access to /proc/sys/vm/drop_caches
+pub fn clear_linux_page_cache() -> io::Result<()> {
+    Command::new("sync").output().expect("sync failed");
+    fs::write("/proc/sys/vm/drop_caches", b"1")
 }
 
 pub(crate) fn transaction_cost(


### PR DESCRIPTION
Setting up state for estimating benchmarks leads to warm chaches.
But the goal is to measure the times used when caches are cold.
Flushing write buffers and clearing the OS cache helps here.