### PR TITLE
feat(params-estimator): Cleanup fn call estimation

### DIFF
--- a/runtime/runtime-params-estimator/src/cost.rs
+++ b/runtime/runtime-params-estimator/src/cost.rs
@@ -584,7 +584,7 @@ pub enum Cost {
     /// Estimates the executable loading part of `wasm_contract_loading_bytes`
     /// which is charged for each byte in a contract when it is loaded as an
     /// executable.
-    /// 
+    ///
     /// This cost also has to cover the reading of the code from the database.
     /// So technically, it covers code loading from database and also executable
     /// loading. But it is still charged right before executable loading because
@@ -594,9 +594,9 @@ pub enum Cost {
     /// Estimation: See `ContractLoadingBase`.
     ContractLoadingPerByte,
     /// Estimates the storage loading part of `wasm_contract_loading_bytes`.
-    /// 
+    ///
     /// See comment on `ContractLoadingPerByte` why these are combined.
-    /// 
+    ///
     /// Estimation: Measure the cost difference of two transactions calling a
     /// trivial smart contract method, where one contract has a large data
     /// section and the other contract is very small. Divide the difference in

--- a/runtime/runtime-params-estimator/src/cost.rs
+++ b/runtime/runtime-params-estimator/src/cost.rs
@@ -83,13 +83,10 @@ pub enum Cost {
     /// cost for adding a `FunctionCallAction` to a receipt. It aims to account
     /// for all costs of calling a function that are already known on the caller
     /// side.
-    /// 
+    ///
     /// Estimation: Measure the cost to execute a transaction with an empty
     /// function with no arguments. Subtract the receipt creating cost from
     /// that, as that is already charged separately.
-    /// 
-    /// TODO[jakmeier][#6353]: Today, the estimation falsely includes the
-    /// loading cost of the estimator test contract.
     ActionFunctionCallBase,
     /// Estimates `action_creation_config.function_call_cost_per_byte`, which is
     /// the incremental cost for each byte of the method name and method
@@ -573,26 +570,38 @@ pub enum Cost {
     /// around bytes that are not code. Divide this cost by the difference of
     /// bytes.
     DeployBytes,
-    /// Estimates `contract_compile_base` which is charged once per contract
+    /// Estimates `wasm_contract_loading_base` which is charged once per contract
     /// that is loaded from the database to execute a method on it.
-    /// (will be renamed to `contract_loading_base`, see
-    /// https://github.com/near/nearcore/issues/5962)
     ///
     /// Estimation: Measure the cost to execute an empty contract method
     /// directly on a runtime instance, using different sizes of contracts.
     /// Use least-squares to calculate base and per-byte cost.
     /// The contract size is scaled by adding more methods to it. This has been
-    /// identified as a particular expensive in terms of per-byte loading time.
+    /// identified as particular expensive in terms of per-byte loading time.
     /// This makes it a better scaling strategy than, for example, adding large
     /// constants in the data section.
     ContractLoadingBase,
-    /// Estimates `contract_compile_byte` which is charged for each byte in a
-    /// contract when it is loaded from the database to execute a method on it.
-    /// (will be renamed to `contract_loading_base`, see
-    /// https://github.com/near/nearcore/issues/5962)
+    /// Estimates the executable loading part of `wasm_contract_loading_bytes`
+    /// which is charged for each byte in a contract when it is loaded as an
+    /// executable.
+    /// 
+    /// This cost also has to cover the reading of the code from the database.
+    /// So technically, it covers code loading from database and also executable
+    /// loading. But it is still charged right before executable loading because
+    /// pre-charging for loading from the database is not possible without
+    /// knowing the code size.
     ///
     /// Estimation: See `ContractLoadingBase`.
     ContractLoadingPerByte,
+    /// Estimates the storage loading part of `wasm_contract_loading_bytes`.
+    /// 
+    /// See comment on `ContractLoadingPerByte` why these are combined.
+    /// 
+    /// Estimation: Measure the cost difference of two transactions calling a
+    /// trivial smart contract method, where one contract has a large data
+    /// section and the other contract is very small. Divide the difference in
+    /// size.
+    FunctionCallPerStorageByte,
     GasMeteringBase,
     GasMeteringOp,
     /// Cost of inserting a new value directly into a RocksDB instance.

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -26,7 +26,7 @@ pub(crate) struct CachedCosts {
     pub(crate) deploy_contract_base: Option<GasCost>,
     pub(crate) noop_function_call_cost: Option<GasCost>,
     pub(crate) storage_read_base: Option<GasCost>,
-    pub(crate) action_function_call_base_per_byte_v2: Option<(GasCost, GasCost)>,
+    pub(crate) contract_loading_base_per_byte: Option<(GasCost, GasCost)>,
     pub(crate) compile_cost_base_per_byte: Option<(GasCost, GasCost)>,
     pub(crate) compile_cost_base_per_byte_v2: Option<(GasCost, GasCost)>,
     pub(crate) gas_metering_cost_base_per_op: Option<(GasCost, GasCost)>,

--- a/runtime/runtime-params-estimator/src/function_call.rs
+++ b/runtime/runtime-params-estimator/src/function_call.rs
@@ -13,12 +13,12 @@ use std::sync::Arc;
 /// Estimates linear cost curve for a function call execution cost per byte of
 /// total contract code. The contract size is increased by adding more methods
 /// to it. This cost is pure VM cost, without the loading from storage.
-pub(crate) fn function_call_cost_per_code_byte(config: &Config) -> (GasCost, GasCost) {
+pub(crate) fn contract_loading_cost(config: &Config) -> (GasCost, GasCost) {
     let mut xs = vec![];
     let mut ys = vec![];
     let repeats = config.iter_per_block as u64;
     let warmup_repeats = config.warmup_iters_per_block as u64;
-    for method_count in vec![5, 20, 30, 50, 100, 200, 1000] {
+    for method_count in [5, 20, 30, 50, 100, 200, 1000] {
         let contract = make_many_methods_contract(method_count);
         let cost = compute_function_call_cost(
             config.metric,

--- a/runtime/runtime-params-estimator/src/function_call.rs
+++ b/runtime/runtime-params-estimator/src/function_call.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 /// Estimates linear cost curve for a function call execution cost per byte of
 /// total contract code. The contract size is increased by adding more methods
-/// to it.
+/// to it. This cost is pure VM cost, without the loading from storage.
 pub(crate) fn function_call_cost_per_code_byte(config: &Config) -> (GasCost, GasCost) {
     let mut xs = vec![];
     let mut ys = vec![];

--- a/runtime/runtime-params-estimator/src/function_call.rs
+++ b/runtime/runtime-params-estimator/src/function_call.rs
@@ -1,35 +1,38 @@
-use crate::config::GasMetric;
-use crate::gas_cost::GasCost;
-use crate::least_squares::least_squares_method;
+use crate::config::{Config, GasMetric};
+use crate::gas_cost::{GasCost, LeastSquaresTolerance};
 use crate::vm_estimator::create_context;
 use near_primitives::contract::ContractCode;
 use near_primitives::runtime::config_store::RuntimeConfigStore;
-use near_primitives::types::{CompiledContractCache, Gas, ProtocolVersion};
+use near_primitives::types::{CompiledContractCache, ProtocolVersion};
 use near_store::StoreCompiledContractCache;
 use near_vm_logic::mocks::mock_external::MockedExternal;
 use near_vm_runner::internal::VMKind;
-use num_rational::Ratio;
 use std::fmt::Write;
 use std::sync::Arc;
 
-pub(crate) fn test_function_call(metric: GasMetric, vm_kind: VMKind) -> (Ratio<i128>, Ratio<i128>) {
+/// Estimates linear cost curve for a function call execution cost per byte of
+/// total contract code. The contract size is increased by adding more methods
+/// to it.
+pub(crate) fn function_call_cost_per_code_byte(config: &Config) -> (GasCost, GasCost) {
     let mut xs = vec![];
     let mut ys = vec![];
-    const REPEATS: u64 = 50;
+    let repeats = config.iter_per_block as u64;
+    let warmup_repeats = config.warmup_iters_per_block as u64;
     for method_count in vec![5, 20, 30, 50, 100, 200, 1000] {
         let contract = make_many_methods_contract(method_count);
-        let cost = compute_function_call_cost(metric, vm_kind, REPEATS, &contract);
+        let cost = compute_function_call_cost(
+            config.metric,
+            config.vm_kind,
+            repeats,
+            warmup_repeats,
+            &contract,
+        );
         xs.push(contract.code().len() as u64);
-        ys.push(cost / REPEATS);
+        ys.push(cost / repeats);
     }
 
-    // Regression analysis only makes sense for additive metrics.
-    if metric == GasMetric::Time {
-        return (0.into(), 0.into());
-    }
-
-    let (cost_base, cost_byte, _) = least_squares_method(&xs, &ys);
-    (cost_base, cost_byte)
+    let tolerance = LeastSquaresTolerance::default();
+    GasCost::least_squares_method_gas_cost(&xs, &ys, &tolerance, false)
 }
 
 fn make_many_methods_contract(method_count: i32) -> ContractCode {
@@ -60,12 +63,13 @@ fn make_many_methods_contract(method_count: i32) -> ContractCode {
     ContractCode::new(wat::parse_str(code).unwrap(), None)
 }
 
-pub fn compute_function_call_cost(
+fn compute_function_call_cost(
     gas_metric: GasMetric,
     vm_kind: VMKind,
     repeats: u64,
+    warmup_repeats: u64,
     contract: &ContractCode,
-) -> Gas {
+) -> GasCost {
     let workdir = tempfile::Builder::new().prefix("runtime_testbed").tempdir().unwrap();
     let store = near_store::StoreOpener::with_default_config(workdir.path()).open();
     let cache_store = Arc::new(StoreCompiledContractCache { store });
@@ -81,7 +85,7 @@ pub fn compute_function_call_cost(
     let promise_results = vec![];
 
     // Warmup.
-    if repeats != 1 {
+    for _ in 0..warmup_repeats {
         let result = runtime.run(
             contract,
             "hello0",
@@ -109,5 +113,5 @@ pub fn compute_function_call_cost(
         );
         assert!(result.error().is_none());
     }
-    start.elapsed().to_gas()
+    start.elapsed()
 }

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -72,7 +72,7 @@ mod function_call;
 mod gas_metering;
 mod trie;
 
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryFrom;
 use std::time::Instant;
 
 use estimator_params::sha256_cost;
@@ -91,7 +91,6 @@ use near_primitives::version::PROTOCOL_VERSION;
 use near_vm_logic::mocks::mock_external::MockedExternal;
 use near_vm_logic::{ExtCosts, VMConfig};
 use near_vm_runner::MockCompiledContractCache;
-use num_rational::Ratio;
 use rand::Rng;
 use serde_json::json;
 use utils::{
@@ -130,8 +129,6 @@ static ALL_COSTS: &[(Cost, fn(&mut EstimatorContext) -> GasCost)] = &[
     (Cost::ActionDeployContractPerByte, action_deploy_contract_per_byte),
     (Cost::ActionFunctionCallBase, action_function_call_base),
     (Cost::ActionFunctionCallPerByte, action_function_call_per_byte),
-    (Cost::ActionFunctionCallBaseV2, action_function_call_base_v2),
-    (Cost::ActionFunctionCallPerByteV2, action_function_call_per_byte_v2),
     (Cost::HostFunctionCall, host_function_call),
     (Cost::WasmInstruction, wasm_instruction),
     (Cost::DataReceiptCreationBase, data_receipt_creation_base),
@@ -187,6 +184,8 @@ static ALL_COSTS: &[(Cost, fn(&mut EstimatorContext) -> GasCost)] = &[
     (Cost::ContractCompileBaseV2, contract_compile_base_v2),
     (Cost::ContractCompileBytesV2, contract_compile_bytes_v2),
     (Cost::DeployBytes, pure_deploy_bytes),
+    (Cost::ContractLoadingBase, contract_loading_base),
+    (Cost::ContractLoadingPerByte, contract_loading_per_byte),
     (Cost::GasMeteringBase, gas_metering_base),
     (Cost::GasMeteringOp, gas_metering_op),
     (Cost::RocksDbInsertValueByte, rocks_db_insert_value_byte),
@@ -683,31 +682,23 @@ fn action_function_call_per_byte(ctx: &mut EstimatorContext) -> GasCost {
     total_cost.saturating_sub(&base_cost, &NonNegativeTolerance::PER_MILLE) / bytes_per_transaction
 }
 
-fn action_function_call_base_v2(ctx: &mut EstimatorContext) -> GasCost {
-    let (base, _per_byte) = action_function_call_base_per_byte_v2(ctx);
+fn contract_loading_base(ctx: &mut EstimatorContext) -> GasCost {
+    let (base, _per_byte) = contract_loading_base_per_byte(ctx);
     base
 }
-fn action_function_call_per_byte_v2(ctx: &mut EstimatorContext) -> GasCost {
-    let (_base, per_byte) = action_function_call_base_per_byte_v2(ctx);
+fn contract_loading_per_byte(ctx: &mut EstimatorContext) -> GasCost {
+    let (_base, per_byte) = contract_loading_base_per_byte(ctx);
     per_byte
 }
-fn action_function_call_base_per_byte_v2(ctx: &mut EstimatorContext) -> (GasCost, GasCost) {
-    if let Some(base_byte_cost) = ctx.cached.action_function_call_base_per_byte_v2.clone() {
+fn contract_loading_base_per_byte(ctx: &mut EstimatorContext) -> (GasCost, GasCost) {
+    if let Some(base_byte_cost) = ctx.cached.contract_loading_base_per_byte.clone() {
         return base_byte_cost;
     }
 
-    let (base, byte) =
-        crate::function_call::test_function_call(ctx.config.metric, ctx.config.vm_kind);
-    let convert_ratio = |r: Ratio<i128>| -> Ratio<u64> {
-        Ratio::new((*r.numer()).try_into().unwrap(), (*r.denom()).try_into().unwrap())
-    };
-    let base_byte_cost = (
-        GasCost::from_gas(convert_ratio(base), ctx.config.metric),
-        GasCost::from_gas(convert_ratio(byte), ctx.config.metric),
-    );
-
-    ctx.cached.action_function_call_base_per_byte_v2 = Some(base_byte_cost.clone());
-    base_byte_cost
+    let (total_base, per_byte) = crate::function_call::function_call_cost_per_code_byte(ctx.config);
+    let base = total_base - action_function_call_base(ctx);
+    ctx.cached.contract_loading_base_per_byte = Some((base.clone(), per_byte.clone()));
+    (base, per_byte)
 }
 
 fn data_receipt_creation_base(ctx: &mut EstimatorContext) -> GasCost {

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -701,10 +701,12 @@ fn contract_loading_base_per_byte(ctx: &mut EstimatorContext) -> (GasCost, GasCo
     (base, per_byte)
 }
 fn function_call_per_storage_byte(ctx: &mut EstimatorContext) -> GasCost {
-    let small_code = generate_data_only_contract(0);
+    let vm_config = VMConfig::test();
+
+    let small_code = generate_data_only_contract(0, &vm_config);
     let small_cost = fn_cost_in_contract(ctx, "main", &small_code);
 
-    let large_code = generate_data_only_contract(4_000_000);
+    let large_code = generate_data_only_contract(4_000_000, &vm_config);
     let large_cost = fn_cost_in_contract(ctx, "main", &large_code);
 
     large_cost.saturating_sub(&small_cost, &NonNegativeTolerance::PER_MILLE)


### PR DESCRIPTION
Various changes around function call estimation.

1. Estimation for function call cost related to loading contract code from storage.
2. Change fn call estimations to use CLI arguments for iteration counts and reduce inner iterations to something that runs faster.
3. Add some documentation to estimations and rename a few things to make the code clearer.