### PR TITLE
pytest: extend get_all_heights to return hashes as well

### DIFF
--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -244,26 +244,16 @@ class BaseNode(object):
         return BlockId(height=sync_info['latest_block_height'],
                        hash=sync_info['latest_block_hash'])
 
-    def get_all_heights(self):
-        hash_ = self.get_latest_block().hash
-        heights = []
-
-        while True:
-            block = self.get_block(hash_)
-            if 'error' in block and 'data' in block[
-                    'error'] and 'DB Not Found Error: BLOCK:' in block['error'][
-                        'data']:
-                break
-            elif 'result' not in block:
-                logger.info(block)
-
-            height = block['result']['header']['height']
-            if height == 0:
-                break
-            heights.append(height)
-            hash_ = block['result']['header']['prev_hash']
-
-        return reversed(heights)
+    def get_all_blocks(self) -> typing.Sequence[BlockId]:
+        ids = []
+        block_hash = self.get_latest_block().hash
+        while block_hash != '11111111111111111111111111111111':
+            block = self.get_block(block_hash)
+            assert 'result' in block, block
+            header = block['result']['header']
+            ids.append(BlockId.from_header(header))
+            block_hash = header.get('prev_hash')
+        return reversed(ids)
 
     def get_validators(self):
         return self.json_rpc('validators', [None])

--- a/pytest/tests/sanity/state_sync.py
+++ b/pytest/tests/sanity/state_sync.py
@@ -89,7 +89,7 @@ for height, block_hash in utils.poll_blocks(boot_node,
         ctx.send_moar_txs(block_hash, 3, False)
         logger.info(f'Sending moar txs at height {boot_height}')
 
-boot_heights = boot_node.get_all_heights()
+boot_heights = [block_id.height for block_id in boot_node.get_all_blocks()]
 
 assert catch_up_height in boot_heights, "%s not in %s" % (catch_up_height,
                                                           boot_heights)

--- a/pytest/tests/sanity/state_sync_late.py
+++ b/pytest/tests/sanity/state_sync_late.py
@@ -78,7 +78,7 @@ for catch_up_height, hash_ in utils.poll_blocks(node2,
             ctx.send_moar_txs(hash_, 3, False)
             logger.info(f'Sending moar txs at height {boot_height}')
 
-boot_heights = boot_node.get_all_heights()
+boot_heights = [block_id.height for block_id in boot_node.get_all_blocks()]
 
 assert catch_up_height in boot_heights, "%s not in %s" % (catch_up_height,
                                                           boot_heights)

--- a/pytest/tests/sanity/state_sync_routed.py
+++ b/pytest/tests/sanity/state_sync_routed.py
@@ -129,7 +129,7 @@ for catch_up_height, hash_ in utils.poll_blocks(node4,
             logger.info(f"Sending moar txs at height {boot_height}")
     time.sleep(0.1)
 
-boot_heights = boot_node.get_all_heights()
+boot_heights = [block_id.height for block_id in boot_node.get_all_blocks()]
 
 assert catch_up_height in boot_heights, "%s not in %s" % (catch_up_height,
                                                           boot_heights)


### PR DESCRIPTION
Replace BaseNode.get_all_heights method with BaseNode.get_all_blocks which
returns hashes alongside heights of all the blocks known to a node.  This
feature will be used in future commit.

Issue: https://github.com/near/nearcore/issues/6242