### PR TITLE
pytest: explicitly check synced blocks in block_sync_archival.py test

### DIFF
--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -134,6 +134,10 @@ class BlockId(typing.NamedTuple):
     def __str__(self) -> str:
         return f'#{self.height} {self.hash}'
 
+    def __eq__(self, rhs) -> bool:
+        return (isinstance(rhs, BlockId) and self.height == rhs.height and
+                self.hash == rhs.hash)
+
 
 class BaseNode(object):
 

--- a/pytest/tests/sanity/block_sync_archival.py
+++ b/pytest/tests/sanity/block_sync_archival.py
@@ -1,40 +1,92 @@
 #!/usr/bin/env python3
-# Spins up one validating node and one non-validating node that is archival. Let the validating node run
-# for a while and make sure that the archival node will sync all blocks.
+"""Tests that archival node can sync up history from another archival node.
 
-import sys, time
+Initialises a cluster with two archival nodes: one validator and one observer.
+Starts the validator and waits until several epochs worth of blocks are
+generated.  Then, starts the observer node and makes sure that it properly
+synchronises the full history.
+"""
+
 import pathlib
+import sys
+import typing
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
 
-from cluster import start_cluster
+import cluster
+from configured_logger import logger
 import utils
 
-TARGET_HEIGHT = 100
-TIMEOUT = 120
+EPOCH_LENGTH = 5
+TARGET_HEIGHT = 20 * EPOCH_LENGTH
 
-client_config0 = {"archive": True}
-client_config1 = {
-    "archive": True,
-    "tracked_shards": [0],
-}
 
-nodes = start_cluster(
-    1, 1, 1, None,
-    [["epoch_length", 10], ["block_producer_kickout_threshold", 80]], {
-        0: client_config0,
-        1: client_config1
-    })
+class Cluster:
 
-nodes[1].kill()
+    def __init__(self):
+        node_config = {
+            'archive': True,
+            'tracked_shards': [0],
+        }
+        self._config = cluster.load_config()
+        self._near_root, self._node_dirs = cluster.init_cluster(
+            1, 1, 1, self._config, [['epoch_length', EPOCH_LENGTH],
+                                    ['block_producer_kickout_threshold', 80]], {
+                                        0: node_config,
+                                        1: node_config,
+                                    })
+        self._nodes = [None] * 2
 
-utils.wait_for_blocks(nodes[0], target=TARGET_HEIGHT, timeout=TIMEOUT)
+    def start(self, ordinal: int) -> cluster.BaseNode:
+        assert self._nodes[ordinal] is None
+        self._nodes[ordinal] = node = cluster.spin_up_node(
+            self._config,
+            self._near_root,
+            self._node_dirs[ordinal],
+            ordinal,
+            boot_node=self._nodes[0],
+            single_node=not ordinal)
+        return node
 
-nodes[1].start(boot_node=nodes[1])
-time.sleep(2)
+    def __enter__(self):
+        return self
 
-utils.wait_for_blocks(nodes[1], target=TARGET_HEIGHT, timeout=TIMEOUT)
+    def __exit__(self, *_):
+        for node in self._nodes:
+            if node:
+                node.cleanup()
 
-for i in range(TARGET_HEIGHT):
-    block = nodes[1].json_rpc('block', [i], timeout=15)
-    assert 'error' not in block, block
+
+def get_all_blocks(node: cluster.BaseNode, *,
+                   head: cluster.BlockId) -> typing.Sequence[cluster.BlockId]:
+    """Returns all blocks from given head down to genesis block."""
+    ids = []
+    block_hash = head.hash
+    while block_hash != '11111111111111111111111111111111':
+        block = node.get_block(block_hash)
+        assert 'result' in block, block
+        header = block['result']['header']
+        ids.append(cluster.BlockId.from_header(header))
+        block_hash = header.get('prev_hash')
+    return list(reversed(ids))
+
+
+with Cluster() as nodes:
+    # Start the validator and wait for a few epoch’s worth of blocks to be
+    # generated.
+    boot = nodes.start(0)
+    latest = utils.wait_for_blocks(boot, target=TARGET_HEIGHT)
+
+    # Start the observer node and wait for it to catch up with the chain state.
+    fred = nodes.start(1)
+    utils.wait_for_blocks(fred, target=TARGET_HEIGHT)
+
+    # Verify that observer got all the blocks.  Note that get_all_blocks
+    # verifies that the node has full chain from head to genesis block.
+    boot_blocks = get_all_blocks(boot, head=latest)
+    fred_blocks = get_all_blocks(fred, head=latest)
+    if boot_blocks != fred_blocks:
+        for a, b in zip(boot_blocks, fred_blocks):
+            if a != b:
+                logger.error(f'{a} != {b}')
+        assert False

--- a/pytest/tests/sanity/block_sync_archival.py
+++ b/pytest/tests/sanity/block_sync_archival.py
@@ -37,7 +37,7 @@ class Cluster:
                                     })
         self._nodes = [None] * 2
 
-    def start(self, ordinal: int) -> cluster.BaseNode:
+    def start_node(self, ordinal: int) -> cluster.BaseNode:
         assert self._nodes[ordinal] is None
         self._nodes[ordinal] = node = cluster.spin_up_node(
             self._config,
@@ -74,11 +74,11 @@ def get_all_blocks(node: cluster.BaseNode, *,
 with Cluster() as nodes:
     # Start the validator and wait for a few epoch’s worth of blocks to be
     # generated.
-    boot = nodes.start(0)
+    boot = nodes.start_node(0)
     latest = utils.wait_for_blocks(boot, target=TARGET_HEIGHT)
 
     # Start the observer node and wait for it to catch up with the chain state.
-    fred = nodes.start(1)
+    fred = nodes.start_node(1)
     utils.wait_for_blocks(fred, target=TARGET_HEIGHT)
 
     # Verify that observer got all the blocks.  Note that get_all_blocks


### PR DESCRIPTION
Extend sanity/block_sync_archival.py test documentation describing in
more detail what it’s doing and mentioning that both nodes are
archival.  Furthermore, avoid starting the observer node at the
beginning just to kill it immediately; it’s now started only once the
validator generates the blocks.  Finally, add explicit comparison of
all the blocks in the validator and observer nodes.

Issue: https://github.com/near/nearcore/issues/6242
