### PR TITLE
fuzz: avoid runtime-tester false positives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4338,6 +4338,7 @@ name = "runtime-tester"
 version = "0.0.0"
 dependencies = [
  "byteorder",
+ "cpu-time",
  "libfuzzer-sys",
  "near-chain",
  "near-chain-configs",

--- a/test-utils/runtime-tester/Cargo.toml
+++ b/test-utils/runtime-tester/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 
 [dependencies]
 byteorder = "1.2"
+cpu-time = "1.0"
 libfuzzer-sys = { version = "0.4"}
 tracing = "0.1.13"
 serde = { version = "1", features = ["derive"] }

--- a/test-utils/runtime-tester/fuzz/fuzz_targets/runtime_fuzzer.rs
+++ b/test-utils/runtime-tester/fuzz/fuzz_targets/runtime_fuzzer.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 fn do_fuzz(scenario: &Scenario) -> Result<(), String> {
     let stats = scenario.run().result.map_err(|e| format!("{}", e))?;
     for block_stats in stats.blocks_stats {
-        if block_stats.block_production_time > Duration::from_secs(3) {
+        if block_stats.block_production_time > Duration::from_secs(2) {
             return Err(format!(
                 "block at height {} was produced in {:?}",
                 block_stats.height, block_stats.block_production_time

--- a/test-utils/runtime-tester/src/run_test.rs
+++ b/test-utils/runtime-tester/src/run_test.rs
@@ -1,7 +1,7 @@
 use std::io;
 use std::path::Path;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use near_chain::{Block, ChainGenesis, Provenance};
 use near_chain_configs::Genesis;
@@ -84,7 +84,7 @@ impl Scenario {
                 env.clients[0].process_tx(signed_tx, false, false);
             }
 
-            let start_time = Instant::now();
+            let start_time = cpu_time::ProcessTime::now();
 
             last_block = env.clients[0]
                 .produce_block(block.height)?


### PR DESCRIPTION
System time is a high-variability metric. CPU time consumed by the
process should be much less volatile, and so hopefully will lead to both
fewer false positives, but also to a lesser need for safety margins,
thus allowing the lowering of 3 seconds to 2 seconds when fuzzing.