### PR TITLE
Moving log_summary into check_triggers

### DIFF
--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1480,8 +1480,7 @@ impl ClientActor {
 
     /// Print current summary.
     fn log_summary(&mut self) {
-        #[cfg(feature = "delay_detector")]
-        let _d = delay_detector::DelayDetector::new("client log summary".into());
+        let _d = delay_detector::DelayDetector::new(|| "client log summary".into());
         let is_syncing = self.client.sync_status.is_syncing();
         let head = unwrap_or_return!(self.client.chain.head());
         let validator_info = if !is_syncing {

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -79,6 +79,10 @@ pub struct ClientActor {
 
     /// Last time handle_block_production method was called
     block_production_next_attempt: DateTime<Utc>,
+
+    // Last time when log_summary method was called.
+    log_summary_timer_next_attempt: DateTime<Utc>,
+
     block_production_started: bool,
     doomslug_timer_next_attempt: DateTime<Utc>,
     chunk_request_retry_next_attempt: DateTime<Utc>,
@@ -170,6 +174,7 @@ impl ClientActor {
             last_validator_announce_time: None,
             info_helper,
             block_production_next_attempt: now,
+            log_summary_timer_next_attempt: now,
             block_production_started: false,
             doomslug_timer_next_attempt: now,
             chunk_request_retry_next_attempt: now,
@@ -228,9 +233,6 @@ impl Actor for ClientActor {
 
         // Start catchup job.
         self.catchup(ctx);
-
-        // Start periodic logging of current state of the client.
-        self.log_summary(ctx);
     }
 }
 
@@ -880,6 +882,21 @@ impl ClientActor {
                     .unwrap_or(delay),
             )
         }
+
+        self.log_summary_timer_next_attempt = self.run_timer(
+            self.client.config.log_summary_period,
+            self.log_summary_timer_next_attempt,
+            ctx,
+            |act, ctx| act.log_summary(),
+        );
+        delay = core::cmp::min(
+            delay,
+            self.log_summary_timer_next_attempt
+                .signed_duration_since(now)
+                .to_std()
+                .unwrap_or(delay),
+        );
+
         self.chunk_request_retry_next_attempt = self.run_timer(
             self.client.config.chunk_request_retry_period,
             self.chunk_request_retry_next_attempt,
@@ -1462,71 +1479,60 @@ impl ClientActor {
         });
     }
 
-    /// Periodically log summary.
-    fn log_summary(&self, ctx: &mut Context<Self>) {
-        near_performance_metrics::actix::run_later(
-            ctx,
-            self.client.config.log_summary_period,
-            move |act, ctx| {
-                #[cfg(feature = "delay_detector")]
-                let _d = delay_detector::DelayDetector::new("client log summary".into());
-                let is_syncing = act.client.sync_status.is_syncing();
-                let head = unwrap_or_return!(act.client.chain.head(), act.log_summary(ctx));
-                let validator_info = if !is_syncing {
-                    let validators = unwrap_or_return!(
-                        act.client.runtime_adapter.get_epoch_block_producers_ordered(
-                            &head.epoch_id,
-                            &head.last_block_hash
-                        ),
-                        act.log_summary(ctx)
-                    );
-                    let num_validators = validators.len();
-                    let account_id = act.client.validator_signer.as_ref().map(|x| x.validator_id());
-                    let is_validator = if let Some(account_id) = account_id {
-                        match act.client.runtime_adapter.get_validator_by_account_id(
-                            &head.epoch_id,
-                            &head.last_block_hash,
-                            account_id,
-                        ) {
-                            Ok((_, is_slashed)) => !is_slashed,
-                            Err(_) => false,
-                        }
-                    } else {
-                        false
-                    };
-                    Some(ValidatorInfoHelper { is_validator, num_validators })
-                } else {
-                    None
-                };
+    /// Print current summary.
+    fn log_summary(&mut self) {
+        #[cfg(feature = "delay_detector")]
+        let _d = delay_detector::DelayDetector::new("client log summary".into());
+        let is_syncing = self.client.sync_status.is_syncing();
+        let head = unwrap_or_return!(self.client.chain.head());
+        let validator_info = if !is_syncing {
+            let validators = unwrap_or_return!(self
+                .client
+                .runtime_adapter
+                .get_epoch_block_producers_ordered(&head.epoch_id, &head.last_block_hash));
+            let num_validators = validators.len();
+            let account_id = self.client.validator_signer.as_ref().map(|x| x.validator_id());
+            let is_validator = if let Some(account_id) = account_id {
+                match self.client.runtime_adapter.get_validator_by_account_id(
+                    &head.epoch_id,
+                    &head.last_block_hash,
+                    account_id,
+                ) {
+                    Ok((_, is_slashed)) => !is_slashed,
+                    Err(_) => false,
+                }
+            } else {
+                false
+            };
+            Some(ValidatorInfoHelper { is_validator, num_validators })
+        } else {
+            None
+        };
 
-                let epoch_identifier = ValidatorInfoIdentifier::BlockHash(head.last_block_hash);
-                let validator_epoch_stats = act
-                    .client
-                    .runtime_adapter
-                    .get_validator_info(epoch_identifier)
-                    .map(get_validator_epoch_stats)
-                    .unwrap_or_default();
-                act.info_helper.info(
-                    act.client.chain.store().get_genesis_height(),
-                    &head,
-                    &act.client.sync_status,
-                    &act.node_id,
-                    &act.network_info,
-                    validator_info,
-                    validator_epoch_stats,
-                    act.client
-                        .runtime_adapter
-                        .get_epoch_height_from_prev_block(&head.prev_block_hash)
-                        .unwrap_or(0),
-                    act.client
-                        .runtime_adapter
-                        .get_protocol_upgrade_block_height(head.last_block_hash)
-                        .unwrap_or(None)
-                        .unwrap_or(0),
-                );
-
-                act.log_summary(ctx);
-            },
+        let epoch_identifier = ValidatorInfoIdentifier::BlockHash(head.last_block_hash);
+        let validator_epoch_stats = self
+            .client
+            .runtime_adapter
+            .get_validator_info(epoch_identifier)
+            .map(get_validator_epoch_stats)
+            .unwrap_or_default();
+        self.info_helper.info(
+            self.client.chain.store().get_genesis_height(),
+            &head,
+            &self.client.sync_status,
+            &self.node_id,
+            &self.network_info,
+            validator_info,
+            validator_epoch_stats,
+            self.client
+                .runtime_adapter
+                .get_epoch_height_from_prev_block(&head.prev_block_hash)
+                .unwrap_or(0),
+            self.client
+                .runtime_adapter
+                .get_protocol_upgrade_block_height(head.last_block_hash)
+                .unwrap_or(None)
+                .unwrap_or(0),
         );
     }
 }

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -888,7 +888,7 @@ impl ClientActor {
             self.client.config.log_summary_period,
             self.log_summary_timer_next_attempt,
             ctx,
-            |act, ctx| act.log_summary(),
+            |act, _ctx| act.log_summary(),
         );
         delay = core::cmp::min(
             delay,


### PR DESCRIPTION
Currently log_summary was executed periodically via 'run_later'. Unfortunately, Actix can sometimes 'starve' these threads when system is overloaded.

Moved the code to run from check_triggers, which will not starve.

Tested:
Run loadtest to verify the behaviour under load.