### PR TITLE
Chunk delay metric: report delay per shard

### DIFF
--- a/chain/client/src/metrics.rs
+++ b/chain/client/src/metrics.rs
@@ -74,26 +74,16 @@ pub static TGAS_USAGE_HIST: Lazy<HistogramVec> = Lazy::new(|| {
     )
     .unwrap()
 });
-pub static CHUNKS_RECEIVING_DELAY_US: Lazy<IntGauge> = Lazy::new(|| {
-    try_create_int_gauge(
-        "near_chunks_receiving_delay_us",
-        "Max delay between receiving a block and its chunks for several most recent blocks",
-    )
-    .unwrap()
-});
-pub static CHUNKS_RECEIVING_DELAY: Lazy<Histogram> = Lazy::new(|| {
+pub static BLOCK_CHUNKS_DELAY: Lazy<Histogram> = Lazy::new(|| {
     try_create_histogram(
-        "near_chunks_receiving_delay",
-        "Delay between receiving a block and its chunks",
+        "near_block_chunks_delay",
+        "Delay between receiving a block and all its chunks",
     )
     .unwrap()
 });
-pub static BLOCKS_AHEAD_OF_HEAD: Lazy<IntGauge> = Lazy::new(|| {
-    try_create_int_gauge(
-        "near_blocks_ahead_of_head",
-        "Height difference between the current head and the newest block or chunk received",
-    )
-    .unwrap()
+pub static CHUNK_DELAY: Lazy<Histogram> = Lazy::new(|| {
+    try_create_histogram("near_chunk_delay", "Delay between requesting and receving a chunk")
+        .unwrap()
 });
 pub static VALIDATORS_CHUNKS_PRODUCED: Lazy<IntGaugeVec> = Lazy::new(|| {
     near_metrics::try_create_int_gauge_vec(

--- a/chain/client/src/metrics.rs
+++ b/chain/client/src/metrics.rs
@@ -81,6 +81,13 @@ pub static CHUNKS_RECEIVING_DELAY_US: Lazy<IntGauge> = Lazy::new(|| {
     )
     .unwrap()
 });
+pub static CHUNKS_RECEIVING_DELAY: Lazy<Histogram> = Lazy::new(|| {
+    try_create_histogram(
+        "near_chunks_receiving_delay",
+        "Delay between receiving a block and its chunks",
+    )
+    .unwrap()
+});
 pub static BLOCKS_AHEAD_OF_HEAD: Lazy<IntGauge> = Lazy::new(|| {
     try_create_int_gauge(
         "near_blocks_ahead_of_head",


### PR DESCRIPTION
Adds a new metric by tracking the event of requesting a chunk.

Changes how the timestamps are stored. Instead of triggering metric update at every opportunity, wait for the block to be processed and then update the metrics. Makes things a lot simpler.


Updates the existing chunks delay metric to report a histogram:
* Time between learning about a block and receiving the last of its chunks

Metric "blocks ahead of head" is removed as redundant, as it is mostly the same as the number of orphan blocks.
