### PR TITLE
feat: added feature flag to core crypto to support wasm build

### DIFF
--- a/core/crypto/Cargo.toml
+++ b/core/crypto/Cargo.toml
@@ -22,7 +22,6 @@ ed25519-dalek = "1"
 primitive-types = "0.10"
 once_cell = "1.5.2"
 libc = "0.2"
-parity-secp256k1 = "0.7"
 rand = "0.7"
 rand_core = "0.5"
 serde = { version = "1", features = [ "derive" ] }
@@ -32,11 +31,19 @@ thiserror = "1"
 near-account-id = { path = "../account-id" }
 deepsize = { version = "0.2.0", optional = true }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", features=["js"]}
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+parity-secp256k1 = "0.7"
+
 [dev-dependencies]
 hex-literal = "0.2"
 sha2 = ">=0.8,<0.10"
 
 [features]
+default = ["secp256k1"]
+secp256k1 = []
 deepsize_feature = [
   "deepsize",
   "near-account-id/deepsize_feature",

--- a/core/crypto/Cargo.toml
+++ b/core/crypto/Cargo.toml
@@ -43,7 +43,6 @@ sha2 = ">=0.8,<0.10"
 
 [features]
 secp256k1 = []
-wasm_feature = []
 deepsize_feature = [
   "deepsize",
   "near-account-id/deepsize_feature",

--- a/core/crypto/Cargo.toml
+++ b/core/crypto/Cargo.toml
@@ -42,8 +42,8 @@ hex-literal = "0.2"
 sha2 = ">=0.8,<0.10"
 
 [features]
-default = ["secp256k1"]
 secp256k1 = []
+wasm_feature = []
 deepsize_feature = [
   "deepsize",
   "near-account-id/deepsize_feature",

--- a/core/crypto/src/test_utils.rs
+++ b/core/crypto/src/test_utils.rs
@@ -1,9 +1,11 @@
 use ed25519_dalek::ed25519::signature::Signature as _;
+#[cfg(feature = "secp256k1")]
 use rand::rngs::StdRng;
 
-use crate::signature::{
-    ED25519PublicKey, ED25519SecretKey, KeyType, PublicKey, SecretKey, SECP256K1,
-};
+#[cfg(feature = "secp256k1")]
+use crate::signature::SECP256K1;
+use crate::signature::{ED25519PublicKey, ED25519SecretKey, KeyType, PublicKey, SecretKey};
+
 use crate::{InMemorySigner, Signature};
 use near_account_id::AccountId;
 
@@ -16,7 +18,7 @@ fn ed25519_key_pair_from_seed(seed: &str) -> ed25519_dalek::Keypair {
     let public = ed25519_dalek::PublicKey::from(&secret);
     ed25519_dalek::Keypair { secret, public }
 }
-
+#[cfg(feature = "secp256k1")]
 fn secp256k1_secret_key_from_seed(seed: &str) -> secp256k1::key::SecretKey {
     let seed_bytes = seed.as_bytes();
     let len = std::cmp::min(32, seed_bytes.len());
@@ -45,7 +47,10 @@ impl SecretKey {
                 let keypair = ed25519_key_pair_from_seed(seed);
                 SecretKey::ED25519(ED25519SecretKey(keypair.to_bytes()))
             }
+            #[cfg(feature = "secp256k1")]
             _ => SecretKey::SECP256K1(secp256k1_secret_key_from_seed(seed)),
+            #[cfg(not(feature = "secp256k1"))]
+            _ => unimplemented!(),
         }
     }
 }


### PR DESCRIPTION
### Background:
There is not a good package to support `secp256k1` in WASM build.  Therefore, we should add a feature flag to disable `secp256k1` to allow developer to build without `secp256k1`.

### Changes:
- added feature flag `secp256k1`
- added `secp256k1` as default feature

### How to test:
- Run `cargo build`, it should build successfully
- Run `cargo build --no-default-features --target wasm32-unknown-unknown`, it should build successfully