### PR TITLE
fix: fix account deserialization on arm64 while keeping the behavior of panicking if deserializing too big a slice

### DIFF
--- a/core/primitives-core/src/account.rs
+++ b/core/primitives-core/src/account.rs
@@ -112,20 +112,19 @@ struct LegacyAccount {
 
 impl BorshDeserialize for Account {
     fn deserialize(buf: &mut &[u8]) -> Result<Self, io::Error> {
-        if buf.len() == std::mem::size_of::<LegacyAccount>() {
-            // This should only ever happen if we have pre-transition account serialized in state
-            // See test_account_size
-            let deserialized_account = LegacyAccount::deserialize(buf)?;
-            Ok(Account {
-                amount: deserialized_account.amount,
-                locked: deserialized_account.locked,
-                code_hash: deserialized_account.code_hash,
-                storage_usage: deserialized_account.storage_usage,
-                version: AccountVersion::V1,
-            })
-        } else {
-            unreachable!();
+        // This should only ever happen if we have pre-transition account serialized in state
+        // See test_account_size
+        let deserialized_account = LegacyAccount::deserialize(buf)?;
+        if buf.len() != 0 {
+            panic!("Tried deserializing a buffer that is not exactly the size of an account");
         }
+        Ok(Account {
+            amount: deserialized_account.amount,
+            locked: deserialized_account.locked,
+            code_hash: deserialized_account.code_hash,
+            storage_usage: deserialized_account.storage_usage,
+            version: AccountVersion::V1,
+        })
     }
 }
 


### PR DESCRIPTION
Fixes #6293 

Note I'm not sure why we were panicking upon invalid buffer length before: it looks to me like something that was left over from an experiment of adding a second version of account serialization and no longer makes sense, but I'm keeping it for now until @EgorKulikov comments about its use.

I tried building and running the two neard command lines listed in #6293 on both arm64 and amd64 and they succeeded properly.

cc @frol @EgorKulikov @bowenwang1996 @mm-near 