### PR TITLE
fuzz: fight fuzzer false positives by attempting to reduce the allowed memory

### DIFF
--- a/nightly/fuzz.toml
+++ b/nightly/fuzz.toml
@@ -2,34 +2,34 @@
 name = "master"
 weight = 10
 
-[[branch]]
-name = "1.25.0"
-weight = 10
-
-[[branch]]
-name = "1.24.0"
-weight = 10
+#[[branch]]
+#name = "1.25.0"
+#weight = 10
+#
+#[[branch]]
+#name = "1.24.0"
+#weight = 10
 
 [[target]]
 crate = "runtime/near-vm-runner/fuzz"
 runner = "runner"
 weight = 10
-flags = ["-len_control=0", "-prefer_small=0", "-max_len=4000000", "-rss_limit_mb=10240"]
+flags = ["-len_control=0", "-prefer_small=0", "-max_len=4000000", "-rss_limit_mb=1024"]
 
 [[target]]
 crate = "test-utils/runtime-tester/fuzz"
 runner = "runtime_fuzzer"
 weight = 10
-flags = ["-len_control=0", "-prefer_small=0", "-max_len=4000000", "-rss_limit_mb=10240"]
+flags = ["-len_control=0", "-prefer_small=0", "-max_len=4000000", "-rss_limit_mb=1024"]
 
 [[target]]
 crate = "core/account-id/fuzz"
 runner = "borsh"
 weight = 1
-flags = ["-len_control=0", "-prefer_small=0", "-max_len=4000000", "-rss_limit_mb=10240"]
+flags = ["-len_control=0", "-prefer_small=0", "-max_len=4000000", "-rss_limit_mb=1024"]
 
 [[target]]
 crate = "core/account-id/fuzz"
 runner = "serde"
 weight = 1
-flags = ["-len_control=0", "-prefer_small=0", "-max_len=4000000", "-rss_limit_mb=10240"]
+flags = ["-len_control=0", "-prefer_small=0", "-max_len=4000000", "-rss_limit_mb=1024"]


### PR DESCRIPTION
Context: grafana for at least two of the last spurious crashes since switching to measuring CPU time shows a memory peak of ~4G just around the time of the crash report.

I'm thinking if one iteration of one of these fuzzers takes more than 1G there's probably something wrong, so might as well lower the limit.

I'm also seeing to integrate the cAdvisor exporter in order to get cgroup-specific metrics, which should help identify the root cause of the memory peak in case it was not actually one fuzzer causing the issues.