### PR TITLE
Upgrade rust to 1.59.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,6 +2,6 @@
 # This specifies the version of Rust we use to build.
 # Individual crates in the workspace may support a lower version, as indicated by `rust-version` field in each crate's `Cargo.toml`.
 # The version specified below, should be at least as high as the maximum `rust-version` within the workspace.
-channel = "1.58.1"
+channel = "1.59.0"
 components = [ "rustfmt" ]
 targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
Rust 1.59.0. has been announced: https://blog.rust-lang.org/2022/02/24/Rust-1.59.0.html

One of the most useful changes is `Destructuring assignments`

It's possible to write now
```rust
let (a, b, c, d, e);

(a, b) = (1, 2);
[c, .., d, _] = [1, 2, 3, 4, 5];
Struct { e, .. } = Struct { e: 5, f: 3 };

assert_eq!([1, 2, 1, 4, 5], [a, b, c, d, e]);
```