### PR TITLE
Makefile: classify perf-release as release build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ debug: neard-debug
 	$(MAKE) sandbox
 
 
+perf-release: NEAR_RELEASE_BUILD=release
 perf-release:
 	CARGO_PROFILE_RELEASE_DEBUG=true cargo build -p neard --release --features performance_stats,memory_stats
 	cargo build -p store-validator --release --features nearcore/performance_stats,nearcore/memory_stats


### PR DESCRIPTION
We’re running canary nodes with executable build using perf-release
target.  Since that target does not set NEAR_RELEASE_BUILD environment
variable when canary starts it prints warning about unsupported node
being run:

    neard: Running a neard executable which wasn’t built with `make release` command isn’t supported on mainnet.
    neard: Note that `cargo build --release` builds lack optimisations which may be needed to run properly on mainnet

Fix that by setting the environment variable in perf-release target
(just like it’s done in release target) so that neard executable
knows it’s a supported build.