### PR TITLE
feat(params-estimator): Wasm Op estimation V2

### DIFF
--- a/runtime/runtime-params-estimator/src/config.rs
+++ b/runtime/runtime-params-estimator/src/config.rs
@@ -34,6 +34,8 @@ pub struct Config {
     pub rocksdb_test_config: RocksDBTestConfig,
     /// Print extra details on least-squares computation
     pub debug_least_squares: bool,
+    /// Print extra details on each wasm instruction measured
+    pub debug_wasm_op: bool,
     /// Clear all OS caches between measured blocks
     pub drop_os_cache: bool,
 }

--- a/runtime/runtime-params-estimator/src/cost.rs
+++ b/runtime/runtime-params-estimator/src/cost.rs
@@ -70,6 +70,7 @@ pub enum Cost {
 
     HostFunctionCall,
     WasmInstruction,
+    WasmInstructionV2,
     ReadMemoryBase,
     ReadMemoryByte,
     WriteMemoryBase,

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -73,7 +73,7 @@ struct CliArgs {
     #[clap(long)]
     drop_os_cache: bool,
     /// Print extra debug information
-    #[clap(long, multiple(true), possible_values=&["io", "rocksdb", "least-squares"])]
+    #[clap(long, multiple(true), possible_values=&["io", "rocksdb", "least-squares", "wasm-op"])]
     debug: Vec<String>,
     /// Prints hierarchical execution-timing information using the tracing-span-tree crate.
     #[clap(long)]
@@ -222,6 +222,7 @@ fn main() -> anyhow::Result<()> {
         costs_to_measure,
         rocksdb_test_config,
         debug_least_squares: debug_options.contains(&"least-squares"),
+        debug_wasm_op: debug_options.contains(&"wasm-op"),
         drop_os_cache: cli_args.drop_os_cache,
     };
     let cost_table = runtime_params_estimator::run(config);

--- a/runtime/runtime-params-estimator/src/wasm_instruction.rs
+++ b/runtime/runtime-params-estimator/src/wasm_instruction.rs
@@ -1,0 +1,90 @@
+use near_primitives::contract::ContractCode;
+
+use crate::gas_cost::GasCost;
+
+use crate::estimator_context::EstimatorRuntime;
+
+pub(crate) fn op_loop_cost(
+    runner: &EstimatorRuntime,
+    repeats: u64,
+    warmup_repeats: u64,
+    op: &str,
+    wasm_type: &str,
+    second_operand: &str,
+) -> GasCost {
+    // this number should be large enough to dwarf loop overhead
+    let loop_body_size = 1_000;
+    let op_iters = 100_000;
+
+    let local = match wasm_type {
+        "i64" => "$a",
+        "f64" => "$x",
+        _ => panic!("{wasm_type} not implemented in op_loop_cost"),
+    };
+
+
+    let contract = make_op_loop_contract(
+        &format!(
+            "
+    local.get {local}
+    {second_operand}
+    {op}
+    drop
+    "
+        ),
+        op_iters,
+        loop_body_size,
+    );
+
+    let total = function_call_cost(runner, repeats, warmup_repeats, &contract);
+    total / (op_iters * loop_body_size) as u64
+}
+
+pub(crate) fn make_op_loop_contract(op: &str, iters: usize, ops_per_iter: usize) -> ContractCode {
+    let body = op.repeat(ops_per_iter);
+    let code = format!(
+        "
+        (module
+        (export \"op_loop\" (func 0))
+            (func (;0;)
+                (local $i i32) (local $a i64) (local $x f64)
+                (loop $my_loop
+                    ;; add one to $i
+                    local.get $i
+                    i32.const 1
+                    i32.add
+                    local.set $i
+              
+                    ;; Execute the operation n times
+                    {body}
+              
+                    ;; branch loop on i < n
+                    local.get $i
+                    i32.const {iters}
+                    i32.lt_s
+                    br_if $my_loop
+                )
+                return
+            )
+        )
+        ",
+    );
+    ContractCode::new(wat::parse_str(code).unwrap(), None)
+}
+
+fn function_call_cost(
+    runner: &EstimatorRuntime,
+    repeats: u64,
+    warmup_repeats: u64,
+    contract: &ContractCode,
+) -> GasCost {
+    for _ in 0..warmup_repeats {
+        runner.run(contract, "op_loop");
+    }
+
+    let mut cost = runner.run(contract, "op_loop");
+    for _ in 1..repeats {
+        cost += runner.run(contract, "op_loop");
+    }
+    cost / repeats
+}


### PR DESCRIPTION
Introduce an alternative way to estimate Wasm instruction cost, that
executes a single type of instruction in a tight loop.
    
The current wasm instruction estimation only looks at memory load/store.
While this might be generally  the slowest operation, for Icount based
measurements this is not really relevant. We need to estimate the
operation that produces the most x86 ops.
Also, memory-prefetchers can often avoid memory latency, which might
introduce errors into the current time based measurements.