### PR TITLE
add a debug page with sync and network info

### DIFF
--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -758,7 +758,11 @@ impl Handler<Status> for ClientActor {
                 last_block_height = block.header().height();
             }
 
-            Some(DetailedDebugStatus { last_blocks: blocks_debug })
+            Some(DetailedDebugStatus {
+                last_blocks: blocks_debug,
+                network_info: self.network_info.clone().into(),
+                sync_status: self.client.sync_status.as_variant_name().to_string(),
+            })
         } else {
             None
         };

--- a/chain/jsonrpc/res/debug.html
+++ b/chain/jsonrpc/res/debug.html
@@ -2,6 +2,7 @@
 
 <body>
     <h1><a href="/debug/last_blocks">Last blocks</a></h1>
+    <h1><a href="/debug/sync_info">Sync info</a></h1>
 </body>
 
 </html>

--- a/chain/jsonrpc/res/sync_info.html
+++ b/chain/jsonrpc/res/sync_info.html
@@ -31,12 +31,12 @@
     </style>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
     <script>
-        $(document).ready(function () {
+        $(document).ready(() => {
             $('span').text("Loading...");
             $.ajax({
                 type: "GET",
                 url: "/debug/api/sync_info",
-                success: function (data) {
+                success: data => {
                     let sync_status = data.detailed_debug_status.sync_status;
                     let network_info = data.detailed_debug_status.network_info;
                     $('.js-sync-status').text(sync_status);

--- a/chain/jsonrpc/res/sync_info.html
+++ b/chain/jsonrpc/res/sync_info.html
@@ -1,0 +1,93 @@
+<html>
+<head>
+    <style>
+        table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+
+        table,
+        th,
+        td {
+            border: 1px solid black;
+        }
+
+        td {
+            text-align: left;
+            vertical-align: top;
+            padding: 8px;
+        }
+
+        th {
+            text-align: center;
+            vertical-align: center;
+            padding: 8px;
+            background-color: lightgrey;
+        }
+
+        tr.active {
+            background-color: #eff8bf;
+        }
+    </style>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+    <script>
+        $(document).ready(function () {
+            $('span').text("Loading...");
+            $.ajax({
+                type: "GET",
+                url: "/debug/api/sync_info",
+                success: function (data) {
+                    let sync_status = data.detailed_debug_status.sync_status;
+                    let network_info = data.detailed_debug_status.network_info;
+                    $('.js-sync-status').text(sync_status);
+                    $('.js-max-peers').text(network_info.peer_max_count);
+                    $('.js-num-peers').text(network_info.num_connected_peers);
+                    network_info.connected_peers.forEach(function(peer, index) {
+                        $('.js-tbody-peers').append($('<tr>')
+                            .append($('<td>').append(peer.addr))
+                            .append($('<td>').append(JSON.stringify(peer.account_id)))
+                            .append($('<td>').append(JSON.stringify(peer.height)))
+                            .append($('<td>').append(JSON.stringify(peer.tracked_shards)))
+                            .append($('<td>').append(JSON.stringify(peer.archival)))
+                        )
+                    });
+                    return;
+                },
+                dataType: "json",
+                error: function (errMsg, textStatus, errorThrown) {
+                    alert("Failed: " + textStatus + " :" + errorThrown);
+                },
+                contentType: "application/json; charset=utf-8",
+            })
+
+        });
+    </script>
+</head>
+<body>
+    <h1>
+        Welcome to the Sync Status page!
+    </h1>
+    <h2>
+        <p>
+            Current Sync Status:
+            <span class="js-sync-status"></span>
+        </p>
+        <p>
+            Number of peers: <span class="js-num-peers"></span>/<span class="js-max-peers"></span>
+        </p>
+    </h2>
+
+    <table>
+        <thead><tr>
+            <th>Address</th>
+            <th>Account ID</th>
+            <th>Height</th>
+            <th>Tracked Shards</th>
+            <th>Archival</th>
+        </tr></thead>
+        <tbody class="js-tbody-peers">
+        </tbody>
+    </table>
+</body>
+
+</html>

--- a/chain/jsonrpc/res/sync_info.html
+++ b/chain/jsonrpc/res/sync_info.html
@@ -51,7 +51,6 @@
                             .append($('<td>').append(JSON.stringify(peer.archival)))
                         )
                     });
-                    return;
                 },
                 dataType: "json",
                 error: function (errMsg, textStatus, errorThrown) {

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -904,19 +904,6 @@ impl JsonRpcHandler {
         }
     }
 
-    pub async fn sync_info(
-        &self,
-    ) -> Result<
-        near_jsonrpc_primitives::types::status::RpcStatusResponse,
-        near_jsonrpc_primitives::types::status::RpcStatusError,
-    > {
-        Ok(self
-            .client_addr
-            .send(Status { is_health_check: false, detailed: true })
-            .await??
-            .into())
-    }
-
     /// Expose Genesis Config (with internal Runtime Config) without state records to keep the
     /// output at a reasonable size.
     ///
@@ -1397,7 +1384,7 @@ pub async fn prometheus_handler() -> Result<HttpResponse, HttpError> {
 }
 
 async fn sync_info_handler(handler: web::Data<JsonRpcHandler>) -> Result<HttpResponse, HttpError> {
-    match handler.sync_info().await {
+    match handler.debug().await {
         Ok(value) => Ok(HttpResponse::Ok().json(&value)),
         Err(_) => Ok(HttpResponse::ServiceUnavailable().finish()),
     }

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -904,6 +904,19 @@ impl JsonRpcHandler {
         }
     }
 
+    pub async fn sync_info(
+        &self,
+    ) -> Result<
+        near_jsonrpc_primitives::types::status::RpcStatusResponse,
+        near_jsonrpc_primitives::types::status::RpcStatusError,
+    > {
+        Ok(self
+            .client_addr
+            .send(Status { is_health_check: false, detailed: true })
+            .await??
+            .into())
+    }
+
     /// Expose Genesis Config (with internal Runtime Config) without state records to keep the
     /// output at a reasonable size.
     ///
@@ -1383,6 +1396,13 @@ pub async fn prometheus_handler() -> Result<HttpResponse, HttpError> {
     }
 }
 
+async fn sync_info_handler(handler: web::Data<JsonRpcHandler>) -> Result<HttpResponse, HttpError> {
+    match handler.sync_info().await {
+        Ok(value) => Ok(HttpResponse::Ok().json(&value)),
+        Err(_) => Ok(HttpResponse::ServiceUnavailable().finish()),
+    }
+}
+
 fn get_cors(cors_allowed_origins: &[String]) -> Cors {
     let mut cors = Cors::permissive();
     if cors_allowed_origins != ["*".to_string()] {
@@ -1399,6 +1419,7 @@ fn get_cors(cors_allowed_origins: &[String]) -> Cors {
 lazy_static_include::lazy_static_include_str! {
     LAST_BLOCKS_HTML => "res/last_blocks.html",
     DEBUG_HTML => "res/debug.html",
+    SYNC_INFO_HTML => "res/sync_info.html",
 }
 
 #[get("/debug")]
@@ -1409,6 +1430,11 @@ async fn debug_html() -> actix_web::Result<impl actix_web::Responder> {
 #[get("/debug/last_blocks")]
 async fn last_blocks_html() -> actix_web::Result<impl actix_web::Responder> {
     Ok(HttpResponse::Ok().body(*LAST_BLOCKS_HTML))
+}
+
+#[get("/debug/sync_info")]
+async fn sync_info_html() -> actix_web::Result<impl actix_web::Responder> {
+    Ok(HttpResponse::Ok().body(*SYNC_INFO_HTML))
 }
 
 /// Starts HTTP server(s) listening for RPC requests.
@@ -1474,6 +1500,8 @@ pub fn start_http(
             .service(web::resource("/debug/api/last_blocks").route(web::get().to(debug_handler)))
             .service(debug_html)
             .service(last_blocks_html)
+            .service(web::resource("/debug/api/sync_info").route(web::get().to(sync_info_handler)))
+            .service(sync_info_html)
     })
     .bind(addr)
     .unwrap()

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -26,7 +26,7 @@ use near_primitives::syncing::{EpochSyncFinalizationResponse, EpochSyncResponse}
 use near_primitives::time::Instant;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{AccountId, BlockReference, EpochId, ShardId};
-use near_primitives::views::QueryRequest;
+use near_primitives::views::{NetworkInfoView, PeerInfoView, QueryRequest};
 use std::collections::HashMap;
 use std::fmt::Debug;
 use strum::AsStaticStr;
@@ -339,6 +339,18 @@ pub struct FullPeerInfo {
     pub partial_edge_info: PartialEdgeInfo,
 }
 
+impl From<&FullPeerInfo> for PeerInfoView {
+    fn from(full_peer_info: &FullPeerInfo) -> Self {
+        PeerInfoView {
+            addr: full_peer_info.peer_info.addr,
+            account_id: full_peer_info.peer_info.account_id.clone(),
+            height: full_peer_info.chain_info.height,
+            tracked_shards: full_peer_info.chain_info.tracked_shards.clone(),
+            archival: full_peer_info.chain_info.archival,
+        }
+    }
+}
+
 #[derive(Debug, Clone, actix::MessageResponse)]
 pub struct NetworkInfo {
     pub connected_peers: Vec<FullPeerInfo>,
@@ -350,6 +362,21 @@ pub struct NetworkInfo {
     /// Accounts of known block and chunk producers from routing table.
     pub known_producers: Vec<KnownProducer>,
     pub peer_counter: usize,
+}
+
+impl From<NetworkInfo> for NetworkInfoView {
+    fn from(network_info: NetworkInfo) -> Self {
+        NetworkInfoView {
+            peer_max_count: network_info.peer_max_count,
+            num_connected_peers: network_info.num_connected_peers,
+            connected_peers: network_info.connected_peers.iter().map(|full_peer_info|
+                full_peer_info.into()
+            ).collect::<Vec<_>>(),
+            sent_bytes_per_sec: network_info.sent_bytes_per_sec,
+            received_bytes_per_sec: network_info.received_bytes_per_sec,
+            peer_counter: network_info.peer_counter,
+        }
+    }
 }
 
 #[derive(Debug, actix::MessageResponse)]

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -342,7 +342,10 @@ pub struct FullPeerInfo {
 impl From<&FullPeerInfo> for PeerInfoView {
     fn from(full_peer_info: &FullPeerInfo) -> Self {
         PeerInfoView {
-            addr: full_peer_info.peer_info.addr,
+            addr: match full_peer_info.peer_info.addr {
+                Some(socket_addr) => socket_addr.to_string(),
+                None => "N/A".to_string(),
+            },
             account_id: full_peer_info.peer_info.account_id.clone(),
             height: full_peer_info.chain_info.height,
             tracked_shards: full_peer_info.chain_info.tracked_shards.clone(),

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -372,9 +372,11 @@ impl From<NetworkInfo> for NetworkInfoView {
         NetworkInfoView {
             peer_max_count: network_info.peer_max_count,
             num_connected_peers: network_info.num_connected_peers,
-            connected_peers: network_info.connected_peers.iter().map(|full_peer_info|
-                full_peer_info.into()
-            ).collect::<Vec<_>>(),
+            connected_peers: network_info
+                .connected_peers
+                .iter()
+                .map(|full_peer_info| full_peer_info.into())
+                .collect::<Vec<_>>(),
             sent_bytes_per_sec: network_info.sent_bytes_per_sec,
             received_bytes_per_sec: network_info.received_bytes_per_sec,
             peer_counter: network_info.peer_counter,

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -342,10 +342,7 @@ pub struct FullPeerInfo {
 impl From<&FullPeerInfo> for PeerInfoView {
     fn from(full_peer_info: &FullPeerInfo) -> Self {
         PeerInfoView {
-            addr: match full_peer_info.peer_info.addr {
-                Some(socket_addr) => socket_addr.to_string(),
-                None => "N/A".to_string(),
-            },
+            addr: full_peer_info.peer_info.addr,
             account_id: full_peer_info.peer_info.account_id.clone(),
             height: full_peer_info.chain_info.height,
             tracked_shards: full_peer_info.chain_info.tracked_shards.clone(),
@@ -377,9 +374,6 @@ impl From<NetworkInfo> for NetworkInfoView {
                 .iter()
                 .map(|full_peer_info| full_peer_info.into())
                 .collect::<Vec<_>>(),
-            sent_bytes_per_sec: network_info.sent_bytes_per_sec,
-            received_bytes_per_sec: network_info.received_bytes_per_sec,
-            peer_counter: network_info.peer_counter,
         }
     }
 }

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -4,6 +4,7 @@
 //! type gets changed, the view should preserve the old shape and only re-map the necessary bits
 //! from the source structure in the relevant `From<SourceStruct>` impl.
 use std::fmt;
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -348,9 +349,32 @@ pub struct DebugBlockStatus {
 }
 
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct PeerInfoView {
+    pub addr: Option<SocketAddr>,
+    pub account_id: Option<AccountId>,
+    pub height: BlockHeight,
+    pub tracked_shards: Vec<ShardId>,
+    pub archival: bool,
+}
+
+#[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct NetworkInfoView {
+    pub peer_max_count: u32,
+    pub num_connected_peers: usize,
+    pub connected_peers: Vec<PeerInfoView>,
+    pub sent_bytes_per_sec: u64,
+    pub received_bytes_per_sec: u64,
+    pub peer_counter: usize,
+}
+
+#[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DetailedDebugStatus {
     pub last_blocks: Vec<DebugBlockStatus>,
+    pub network_info: NetworkInfoView,
+    pub sync_status: String,
 }
 
 // TODO: add more information to status.
@@ -374,7 +398,7 @@ pub struct StatusResponse {
     pub sync_info: StatusSyncInfo,
     /// Validator id of the node
     pub validator_account_id: Option<AccountId>,
-    /// Information about last blocks.
+    /// Information about last blocks and sync info.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub detailed_debug_status: Option<DetailedDebugStatus>,
 }

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -4,6 +4,7 @@
 //! type gets changed, the view should preserve the old shape and only re-map the necessary bits
 //! from the source structure in the relevant `From<SourceStruct>` impl.
 use std::fmt;
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -347,25 +348,20 @@ pub struct DebugBlockStatus {
     pub timestamp_delta: u64,
 }
 
-#[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct PeerInfoView {
-    pub addr: String,
+    pub addr: Option<SocketAddr>,
     pub account_id: Option<AccountId>,
     pub height: BlockHeight,
     pub tracked_shards: Vec<ShardId>,
     pub archival: bool,
 }
 
-#[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct NetworkInfoView {
     pub peer_max_count: u32,
     pub num_connected_peers: usize,
     pub connected_peers: Vec<PeerInfoView>,
-    pub sent_bytes_per_sec: u64,
-    pub received_bytes_per_sec: u64,
-    pub peer_counter: usize,
 }
 
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -4,7 +4,6 @@
 //! type gets changed, the view should preserve the old shape and only re-map the necessary bits
 //! from the source structure in the relevant `From<SourceStruct>` impl.
 use std::fmt;
-use std::net::SocketAddr;
 use std::sync::Arc;
 
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -348,15 +347,17 @@ pub struct DebugBlockStatus {
     pub timestamp_delta: u64,
 }
 
+#[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct PeerInfoView {
-    pub addr: Option<SocketAddr>,
+    pub addr: String,
     pub account_id: Option<AccountId>,
     pub height: BlockHeight,
     pub tracked_shards: Vec<ShardId>,
     pub archival: bool,
 }
 
+#[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct NetworkInfoView {
     pub peer_max_count: u32,

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -4,7 +4,6 @@
 //! type gets changed, the view should preserve the old shape and only re-map the necessary bits
 //! from the source structure in the relevant `From<SourceStruct>` impl.
 use std::fmt;
-use std::net::SocketAddr;
 use std::sync::Arc;
 
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -351,7 +350,7 @@ pub struct DebugBlockStatus {
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct PeerInfoView {
-    pub addr: Option<SocketAddr>,
+    pub addr: String,
     pub account_id: Option<AccountId>,
     pub height: BlockHeight,
     pub tracked_shards: Vec<ShardId>,


### PR DESCRIPTION
This PR is to add a debugging page that reflects the sync status in a browser window.

JIRA Issue: [CP-10](https://nearinc.atlassian.net/browse/CP-10)

Test plan
 - Build with `make neard`
 - Launch using command `nearup stop && nearup run localnet --binary-path ./target/release`
 - Open your browser and go to http://[host_address[:3030/debug/
 - Expect to see the link "Sync Info"
 - Click the link "Sync Info"
 - Expect to see a webpage that looks similar to the one below
 
 Screenshot

(on localnet)
<img width="900" alt="Screen Shot 2022-03-09 at 1 19 22 PM" src="https://user-images.githubusercontent.com/98097537/157538171-390357d3-2ae3-4a7a-b0dc-0eb625dfd07b.png">

(on testnet)
<img width="1506" alt="Screen Shot 2022-03-15 at 4 50 54 PM" src="https://user-images.githubusercontent.com/98097537/158491078-06999a07-d64b-4ac0-9245-a0980169c5da.png">


First-round Reviewers
 - @mm-near 
 - @mzhangmzz 