### PR TITLE
endtoend: make more resilient to exceptions and other minor improvements

### DIFF
--- a/pytest/endtoend/endtoend.py
+++ b/pytest/endtoend/endtoend.py
@@ -39,27 +39,33 @@ balance_gauge = prometheus_client.Gauge(
     ['account'])
 
 
+def do_ping(account, rpc_server):
+    account_id = account.key.account_id
+    base_block_hash = mocknet_helpers.get_latest_block_hash(addr=rpc_server[0],
+                                                            port=rpc_server[1])
+    balance = mocknet_helpers.retry_and_ignore_errors(
+        lambda: mocknet_helpers.get_amount_yoctonear(
+            account_id, addr=rpc_server[0], port=rpc_server[1]))
+    if balance is not None:
+        balance_gauge.labels(account=account_id).set(balance)
+    logger.info(f'Sending 0 tokens from {account_id} to itself')
+    tx_res = mocknet_helpers.retry_and_ignore_errors(
+        lambda: account.send_transfer_tx(
+            account_id, transfer_amount=0, base_block_hash=base_block_hash))
+    logger.info(
+        f'Sending 0 tokens from {account_id} to itself, tx result: {tx_res}')
+
+
 def pinger(account, interval, rpc_server):
     account_id = account.key.account_id
     logger.info(f'pinger {account_id}')
     time.sleep(random.random() * interval)
     logger.info(f'pinger {account_id} woke up')
     while True:
-        base_block_hash = mocknet_helpers.get_latest_block_hash(
-            addr=rpc_server[0], port=rpc_server[1])
-        balance = mocknet_helpers.retry_and_ignore_errors(
-            lambda: mocknet_helpers.get_amount_yoctonear(
-                account_id, addr=rpc_server[0], port=rpc_server[1]))
-        if balance is not None:
-            balance_gauge.labels(account=account_id).set(balance)
-        logger.info(f'Sending 0 tokens from {account_id} to itself')
-        tx_res = mocknet_helpers.retry_and_ignore_errors(
-            lambda: account.send_transfer_tx(
-                account_id, transfer_amount=0, base_block_hash=base_block_hash))
-        logger.info(
-            f'Sending 0 tokens from {account_id} to itself, tx result: {tx_res}'
-        )
-
+        try:
+            do_ping(account, rpc_server)
+        except Exception as ex:
+            logger.warning(f'Error pinging account {account_id}', exc_info=ex)
         time.sleep(interval)
 
 
@@ -78,8 +84,6 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    prometheus_client.start_http_server(args.metrics_port)
-
     assert args.ips
     ips = args.ips.split(',')
     assert args.accounts
@@ -96,18 +100,19 @@ if __name__ == '__main__':
     base_block_hash = mocknet_helpers.get_latest_block_hash(addr=rpc_server[0],
                                                             port=rpc_server[1])
     accounts = []
-    for i in range(len(keys)):
-        nonce = mocknet_helpers.get_nonce_for_pk(keys[i].account_id,
-                                                 keys[i].pk,
+    for ip, key in zip(ips, keys):
+        nonce = mocknet_helpers.get_nonce_for_pk(key.account_id,
+                                                 key.pk,
                                                  addr=rpc_server[0],
                                                  port=rpc_server[1])
         accounts.append(
-            account_mod.Account(keys[i],
+            account_mod.Account(key,
                                 nonce,
                                 base_block_hash,
-                                rpc_infos=[(ips[i], port)]))
+                                rpc_infos=[(ip, port)]))
+
+    prometheus_client.start_http_server(args.metrics_port)
 
     with ThreadPoolExecutor() as executor:
-        for i in range(len(accounts)):
-            executor.submit(
-                lambda: pinger(accounts[i], interval_sec, rpc_server))
+        for account in accounts:
+            executor.submit(pinger, account, interval_sec, rpc_server)


### PR DESCRIPTION
Most notably, wrap body of the pinger loop in a try-except block which
logs exception information if any exception happens.  This way, even if
something goes wrong during one iteration, the test will continue trying.

And while editing the file, replace `for _ in range(len(_))` loops by
iterating over elements of lists.  This is more idiomatic and removes the
need to explicitly index the lists.

Lastly, initialise Prometheus client only after all arguments are validated.