### PR TITLE
added panic=abort to the whole workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,11 +64,16 @@ exclude = [ "neard" ]
 
 [patch.crates-io]
 
+# Note that "bench" profile inherits from "release" profile and
+# "test" profile inherits from "dev" profile.
+# https://doc.rust-lang.org/cargo/reference/profiles.html#test
+
 [profile.release]
 overflow-checks = true
+panic = 'abort'
 
-[profile.bench]
-overflow-checks = true
+[profile.dev]
+panic = 'abort'
 
 [profile.dev.package.hex]
 opt-level = 3 # BLS library is too slow to use in debug


### PR DESCRIPTION
Given that our storage-related code is crash-safe, we should be able to set panic=abort so that no panic goes unnoticed.
AFAICT the test targets are ignoring this setting:
https://github.com/alexcrichton/cargo/blob/master/src/cargo/core/profiles.rs#L114
therefore our "should_panic" tests still work (at least on my workstation).