### PR TITLE
fuzz: go back to the default 2G of ram for each fuzzer

### DIFF
--- a/nightly/fuzz.toml
+++ b/nightly/fuzz.toml
@@ -14,22 +14,22 @@ weight = 10
 crate = "runtime/near-vm-runner/fuzz"
 runner = "runner"
 weight = 10
-flags = ["-len_control=0", "-prefer_small=0", "-max_len=4000000", "-rss_limit_mb=1024"]
+flags = ["-len_control=0", "-prefer_small=0", "-max_len=4000000"]
 
 [[target]]
 crate = "test-utils/runtime-tester/fuzz"
 runner = "runtime_fuzzer"
 weight = 10
-flags = ["-len_control=0", "-prefer_small=0", "-max_len=4000000", "-rss_limit_mb=1024"]
+flags = ["-len_control=0", "-prefer_small=0", "-max_len=4000000"]
 
 [[target]]
 crate = "core/account-id/fuzz"
 runner = "borsh"
 weight = 1
-flags = ["-len_control=0", "-prefer_small=0", "-max_len=4000000", "-rss_limit_mb=1024"]
+flags = ["-len_control=0", "-prefer_small=0", "-max_len=4000000"]
 
 [[target]]
 crate = "core/account-id/fuzz"
 runner = "serde"
 weight = 1
-flags = ["-len_control=0", "-prefer_small=0", "-max_len=4000000", "-rss_limit_mb=1024"]
+flags = ["-len_control=0", "-prefer_small=0", "-max_len=4000000"]


### PR DESCRIPTION
Spurious OOMs, maybe related to
https://github.com/rust-fuzz/cargo-fuzz/issues/270, seem to have started
appearing — they are very hard to reproduce locally, so let's increase a
bit the memory limit