### PR TITLE
Revert "start client actor in a separate thread"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2501,7 +2501,6 @@ version = "0.0.0"
 dependencies = [
  "actix-rt",
  "futures",
- "near-store",
 ]
 
 [[package]]

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1745,8 +1745,7 @@ pub fn start_client(
     sender: Option<oneshot::Sender<()>>,
     #[cfg(feature = "test_features")] adv: Arc<std::sync::RwLock<crate::AdversarialControls>>,
 ) -> (Addr<ClientActor>, ArbiterHandle) {
-    let client_arbiter = Arbiter::new();
-    let client_arbiter_handle = client_arbiter.handle();
+    let client_arbiter_handle = Arbiter::current();
     let client_addr = ClientActor::start_in_arbiter(&client_arbiter_handle, move |ctx| {
         ClientActor::new(
             client_config,

--- a/test-utils/actix-test-utils/Cargo.toml
+++ b/test-utils/actix-test-utils/Cargo.toml
@@ -10,4 +10,3 @@ edition = "2021"
 [dependencies]
 actix-rt = "2"
 futures = "0.3"
-near-store = { path = "../../core/store" }

--- a/test-utils/actix-test-utils/src/lib.rs
+++ b/test-utils/actix-test-utils/src/lib.rs
@@ -101,5 +101,4 @@ pub fn run_actix<F: std::future::Future>(f: F) {
     let sys = actix_rt::System::new();
     sys.block_on(handle_interrupt!(f));
     sys.run().unwrap();
-    near_store::db::RocksDB::block_until_all_instances_are_dropped();
 }


### PR DESCRIPTION
This reverts commit f2bba0841ecc8c9917babe57757f14fed838fa3b.

The commit casuse ~30 timeouts in NayDuck tests.