### PR TITLE
pytest: add default timeout to utils.wait_for_blocks

### DIFF
--- a/pytest/tests/adversarial/malicious_chain.py
+++ b/pytest/tests/adversarial/malicious_chain.py
@@ -12,7 +12,6 @@ valid_blocks_only = False  # creating invalid blocks, should be banned instantly
 if "valid_blocks_only" in sys.argv:
     valid_blocks_only = True  # creating valid blocks, should be fixed by doom slug
 
-TIMEOUT = 300
 BLOCKS = 25
 MALICIOUS_BLOCKS = 50
 
@@ -23,7 +22,7 @@ nodes = start_cluster(
 started = time.time()
 
 logger.info(f'Waiting for {BLOCKS} blocks...')
-height, _ = utils.wait_for_blocks(nodes[1], target=BLOCKS, timeout=TIMEOUT)
+height, _ = utils.wait_for_blocks(nodes[1], target=BLOCKS)
 logger.info(f'Got to {height} blocks, getting to fun stuff')
 
 nodes[1].get_status(verbose=True)

--- a/pytest/tests/adversarial/start_from_genesis.py
+++ b/pytest/tests/adversarial/start_from_genesis.py
@@ -16,7 +16,6 @@ doomslug = True
 if "doomslug_off" in sys.argv:
     doomslug = False  # turn off doomslug
 
-TIMEOUT = 300
 BLOCKS = 30
 
 # Low sync_check_period to sync from a new peer with greater height
@@ -43,7 +42,7 @@ started = time.time()
 
 time.sleep(2)
 logger.info(f'Waiting for {BLOCKS} blocks...')
-height, _ = utils.wait_for_blocks(nodes[0], target=BLOCKS, timeout=TIMEOUT)
+height, _ = utils.wait_for_blocks(nodes[0], target=BLOCKS)
 logger.info(f'Got to {height} blocks, getting to fun stuff')
 
 status = nodes[0].get_status()

--- a/pytest/tests/sanity/backward_compatible.py
+++ b/pytest/tests/sanity/backward_compatible.py
@@ -50,7 +50,6 @@ def main():
 
     # Check it all works.
     BLOCKS = 100
-    TIMEOUT = 150
     max_height = -1
     started = time.time()
 
@@ -122,7 +121,7 @@ def main():
     assert 'error' not in res, res
     assert 'Failure' not in res['result']['status'], res
 
-    utils.wait_for_blocks(current_node, target=BLOCKS, timeout=TIMEOUT)
+    utils.wait_for_blocks(current_node, target=BLOCKS)
 
 
 if __name__ == "__main__":

--- a/pytest/tests/sanity/block_sync.py
+++ b/pytest/tests/sanity/block_sync.py
@@ -13,7 +13,6 @@ from configured_logger import logger
 import utils
 
 BLOCKS = 10
-TIMEOUT = 25
 
 consensus_config0 = {
     "consensus": {
@@ -52,7 +51,7 @@ nodes = start_cluster(
      })
 time.sleep(3)
 
-utils.wait_for_blocks(nodes[0], target=BLOCKS, timeout=TIMEOUT)
+utils.wait_for_blocks(nodes[0], target=BLOCKS)
 
 logger.info("kill node 0")
 nodes[0].kill()
@@ -63,4 +62,4 @@ nodes[0].start(boot_node=nodes[0])
 time.sleep(3)
 
 node1_height = nodes[1].get_latest_block().height
-utils.wait_for_blocks(nodes[0], target=node1_height, timeout=TIMEOUT)
+utils.wait_for_blocks(nodes[0], target=node1_height)

--- a/pytest/tests/sanity/block_sync_archival.py
+++ b/pytest/tests/sanity/block_sync_archival.py
@@ -105,23 +105,18 @@ def main(argv: typing.Sequence[str]) -> None:
         min_delay = datetime.timedelta(milliseconds=1)
         target_height = LONG_TARGET_HEIGHT
 
-    timeout = target_height * 5
     with Cluster(min_block_production_delay=min_delay) as cluster:
         # Start the validator and wait for a few epoch’s worth of blocks to be
         # generated.
         boot = cluster.start_node(0)
         latest = utils.wait_for_blocks(boot,
                                        target=target_height,
-                                       poll_interval=1,
-                                       timeout=timeout)
+                                       poll_interval=1)
 
         # Start the observer node and wait for it to catch up with the chain
         # state.
         fred = cluster.start_node(1)
-        utils.wait_for_blocks(fred,
-                              target=target_height,
-                              poll_interval=1,
-                              timeout=timeout)
+        utils.wait_for_blocks(fred, target=target_height, poll_interval=1)
 
         # Verify that observer got all the blocks.  Note that get_all_blocks
         # verifies that the node has full chain from head to genesis block.

--- a/pytest/tests/sanity/garbage_collection.py
+++ b/pytest/tests/sanity/garbage_collection.py
@@ -13,7 +13,6 @@ from configured_logger import logger
 import utils
 
 TARGET_HEIGHT = 60
-TIMEOUT = 30
 
 consensus_config = {
     "consensus": {
@@ -62,4 +61,4 @@ time.sleep(3)
 
 start_time = time.time()
 
-utils.wait_for_blocks(nodes[1], target=node0_height, timeout=TIMEOUT)
+utils.wait_for_blocks(nodes[1], target=node0_height)

--- a/pytest/tests/sanity/garbage_collection1.py
+++ b/pytest/tests/sanity/garbage_collection1.py
@@ -68,4 +68,4 @@ nodes[2].start(boot_node=nodes[2])
 time.sleep(2)
 
 target = nodes[0].get_latest_block().height
-utils.wait_for_blocks(nodes[2], target=target, timeout=TIMEOUT)
+utils.wait_for_blocks(nodes[2], target=target)

--- a/pytest/tests/sanity/gc_after_sync1.py
+++ b/pytest/tests/sanity/gc_after_sync1.py
@@ -17,7 +17,6 @@ import utils
 TARGET_HEIGHT1 = 15
 TARGET_HEIGHT2 = 35
 TARGET_HEIGHT3 = 105
-TIMEOUT = 80
 
 node0_config = {"gc_blocks_limit": 10}
 
@@ -41,17 +40,17 @@ nodes = start_cluster(
 
 height = nodes[1].get_latest_block().height
 
-utils.wait_for_blocks(nodes[0], target=TARGET_HEIGHT1, timeout=TIMEOUT)
+utils.wait_for_blocks(nodes[0], target=TARGET_HEIGHT1)
 
 logger.info('Kill node 1')
 nodes[1].kill()
 
-utils.wait_for_blocks(nodes[0], target=TARGET_HEIGHT2, timeout=TIMEOUT)
+utils.wait_for_blocks(nodes[0], target=TARGET_HEIGHT2)
 
 logger.info('Restart node 1')
 nodes[1].start(boot_node=nodes[0])
 
-utils.wait_for_blocks(nodes[0], target=TARGET_HEIGHT3, timeout=TIMEOUT)
+utils.wait_for_blocks(nodes[0], target=TARGET_HEIGHT3)
 
 nodes[0].kill()
 

--- a/pytest/tests/sanity/gc_sync_after_sync.py
+++ b/pytest/tests/sanity/gc_sync_after_sync.py
@@ -19,7 +19,6 @@ import utils
 TARGET_HEIGHT1 = 60
 TARGET_HEIGHT2 = 170
 TARGET_HEIGHT3 = 250
-TIMEOUT = 300
 
 consensus_config = {
     "consensus": {
@@ -49,7 +48,6 @@ nodes[1].kill()
 
 node0_height, _ = utils.wait_for_blocks(nodes[0],
                                         target=TARGET_HEIGHT1,
-                                        timeout=TIMEOUT,
                                         verbose=True)
 
 logger.info('Restart node 1')
@@ -58,7 +56,6 @@ time.sleep(3)
 
 node1_height, _ = utils.wait_for_blocks(nodes[1],
                                         target=node0_height,
-                                        timeout=TIMEOUT,
                                         verbose=True)
 
 if swap_nodes:
@@ -70,7 +67,6 @@ nodes[1].kill()
 
 node0_height, _ = utils.wait_for_blocks(nodes[0],
                                         target=TARGET_HEIGHT2,
-                                        timeout=TIMEOUT,
                                         verbose=True)
 
 logger.info('Restart node 1')
@@ -79,7 +75,6 @@ time.sleep(3)
 
 node1_height, _ = utils.wait_for_blocks(nodes[1],
                                         target=node0_height,
-                                        timeout=TIMEOUT,
                                         verbose=True)
 
 # all fresh data should be synced
@@ -120,9 +115,6 @@ for height in range(130, 150):
 assert blocks_count == 0
 
 # check that node can GC normally after syncing
-utils.wait_for_blocks(nodes[1],
-                      target=TARGET_HEIGHT3,
-                      timeout=TIMEOUT,
-                      verbose=True)
+utils.wait_for_blocks(nodes[1], target=TARGET_HEIGHT3, verbose=True)
 
 logger.info('EPIC')

--- a/pytest/tests/sanity/handshake_tie_resolution.py
+++ b/pytest/tests/sanity/handshake_tie_resolution.py
@@ -12,11 +12,10 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
 import cluster
 import utils
 
-TIMEOUT = 150
 BLOCKS = 20
 
 nodes = cluster.start_cluster(4, 0, 4, None, [], {})
 trackers = [utils.LogTracker(node) for node in nodes]
-utils.wait_for_blocks(nodes[0], target=BLOCKS, timeout=TIMEOUT)
+utils.wait_for_blocks(nodes[0], target=BLOCKS)
 assert all(not tracker.check('Dropping handshake (Active Peer).')
            for tracker in trackers)

--- a/pytest/tests/sanity/proxy_restart.py
+++ b/pytest/tests/sanity/proxy_restart.py
@@ -12,7 +12,6 @@ from peer import *
 from proxy import ProxyHandler
 import utils
 
-TIMEOUT = 40
 TARGET_HEIGHT = 20
 
 nodes = start_cluster(2, 0, 1, None, [], {}, ProxyHandler)
@@ -20,4 +19,4 @@ nodes = start_cluster(2, 0, 1, None, [], {}, ProxyHandler)
 nodes[1].kill()
 nodes[1].start(boot_node=nodes[0])
 
-utils.wait_for_blocks(nodes[1], target=TARGET_HEIGHT, timeout=TIMEOUT)
+utils.wait_for_blocks(nodes[1], target=TARGET_HEIGHT)

--- a/pytest/tests/sanity/repro_2916.py
+++ b/pytest/tests/sanity/repro_2916.py
@@ -33,7 +33,7 @@ async def main():
     # start a cluster with two shards
     nodes = start_cluster(2, 0, 2, None, [], {})
 
-    height, hash_ = utils.wait_for_blocks(nodes[0], target=3, timeout=10)
+    height, hash_ = utils.wait_for_blocks(nodes[0], target=3)
     block = nodes[0].get_block(hash_)['result']
     chunk_hashes = [base58.b58decode(x['chunk_hash']) for x in block['chunks']]
     assert len(chunk_hashes) == 2

--- a/pytest/tests/sanity/spin_up_cluster.py
+++ b/pytest/tests/sanity/spin_up_cluster.py
@@ -19,7 +19,7 @@ def test_sanity_spin_up():
     See <https://github.com/near/nearcore/issues/4993>.
     """
     nodes = cluster.start_cluster(2, 0, 1, None, [], {})
-    utils.wait_for_blocks(nodes[0], target=4, timeout=10)
+    utils.wait_for_blocks(nodes[0], target=4)
 
 
 if __name__ == '__main__':

--- a/pytest/tests/sanity/state_sync2.py
+++ b/pytest/tests/sanity/state_sync2.py
@@ -16,7 +16,6 @@ import utils
 
 fcntl.fcntl(1, fcntl.F_SETFL, 0)  # no cache when execute from nightly runner
 
-TIMEOUT = 600
 BLOCKS = 105  # should be enough to trigger state sync for node 1 later, see comments there
 
 nightly = len(sys.argv) > 1
@@ -36,7 +35,7 @@ logger.info('cluster started')
 started = time.time()
 
 logger.info(f'Waiting for {BLOCKS} blocks...')
-height = utils.wait_for_blocks(nodes[1], target=BLOCKS, timeout=TIMEOUT)
+height = utils.wait_for_blocks(nodes[1], target=BLOCKS)
 logger.info(f'Got to {height} blocks, rebooting the first node')
 
 nodes[0].kill()
@@ -45,7 +44,7 @@ tracker = utils.LogTracker(nodes[0])
 nodes[0].start(boot_node=nodes[1])
 time.sleep(3)
 
-utils.wait_for_blocks(nodes[0], target=BLOCKS, timeout=TIMEOUT)
+utils.wait_for_blocks(nodes[0], target=BLOCKS)
 
 # make sure `nodes[0]` actually state synced
 assert tracker.check("transition to State Sync")

--- a/pytest/tests/sanity/state_sync3.py
+++ b/pytest/tests/sanity/state_sync3.py
@@ -45,7 +45,6 @@ logger.info("step 1")
 
 node0_height, _ = utils.wait_for_blocks(nodes[0],
                                         target=EPOCH_LENGTH * 2 + 1,
-                                        timeout=EPOCH_LENGTH * 10,
                                         poll_interval=5)
 
 nodes[1].start(boot_node=nodes[1])

--- a/pytest/tests/sanity/state_sync_fail.py
+++ b/pytest/tests/sanity/state_sync_fail.py
@@ -15,7 +15,6 @@ import requests
 import utils
 
 START_AT_BLOCK = 25
-TIMEOUT = 150 + START_AT_BLOCK * 10
 
 config = load_config()
 near_root, node_dirs = init_cluster(
@@ -55,9 +54,7 @@ node1 = spin_up_node(config, near_root, node_dirs[1], 1, boot_node=boot_node)
 
 ctx = utils.TxContext([0, 0], [boot_node, node1])
 
-sent_txs = False
-
-utils.wait_for_blocks(boot_node, target=START_AT_BLOCK, timeout=TIMEOUT)
+utils.wait_for_blocks(boot_node, target=START_AT_BLOCK)
 
 node2 = spin_up_node(config, near_root, node_dirs[2], 2, boot_node=boot_node)
 tracker = utils.LogTracker(node2)

--- a/pytest/tests/sanity/switch_node_key.py
+++ b/pytest/tests/sanity/switch_node_key.py
@@ -48,9 +48,7 @@ nodes[1].reset_node_key(node_key)
 nodes[1].start(boot_node=nodes[0])
 time.sleep(2)
 
-utils.wait_for_blocks(nodes[1],
-                      target=EPOCH_LENGTH * 2 + 5,
-                      timeout=TIMEOUT * 2)
+utils.wait_for_blocks(nodes[1], target=EPOCH_LENGTH * 2 + 5)
 
 validators = nodes[1].get_validators()
 assert len(

--- a/pytest/tests/sanity/sync_ban.py
+++ b/pytest/tests/sanity/sync_ban.py
@@ -82,7 +82,7 @@ nodes = start_cluster(1, 1, 1, None, [["epoch_length", EPOCH_LENGTH]], {
     1: node1_config
 }, Handler)
 
-utils.wait_for_blocks(nodes[0], target=110, timeout=TIMEOUT, poll_interval=2)
+utils.wait_for_blocks(nodes[0], target=110, poll_interval=2)
 
 should_sync.value = True
 

--- a/pytest/tests/sanity/sync_chunks_from_archival.py
+++ b/pytest/tests/sanity/sync_chunks_from_archival.py
@@ -94,19 +94,19 @@ class Handler(ProxyHandler):
 # TODO(mina86): Make it a utility class
 class Timeout:
 
-    def __init__(self, timeout: float) -> None:
-        if timeout <= 0:
-            raise ValueError('timeout must be positive')
+    def __init__(self, sesconds: float) -> None:
+        if sesconds <= 0:
+            raise ValueError('sesconds must be positive')
         self.__start = time.monotonic()
-        self.__end = self.__start + timeout
+        self.__end = self.__start + sesconds
 
     def check(self) -> bool:
         return time.monotonic() < self.__end
 
-    def elapsed(self) -> bool:
+    def elapsed_seconds(self) -> float:
         return time.monotonic() - self.__start
 
-    def left(self) -> bool:
+    def left_seconds(self) -> float:
         return self.__end - time.monotonic()
 
 
@@ -193,7 +193,7 @@ if __name__ == '__main__':
     logging.info(f'Getting to height {HEIGHTS_BEFORE_ROTATE}')
     utils.wait_for_blocks(boot_node,
                           target=HEIGHTS_BEFORE_ROTATE,
-                          timeout=timeout.left())
+                          timeout=timeout.left_seconds())
 
     node2 = spin_up_node(config,
                          near_root,
@@ -246,13 +246,13 @@ if __name__ == '__main__':
     logging.info(f'Getting to height {target}')
     height_to_sync_to, _ = utils.wait_for_blocks(node2,
                                                  target=target,
-                                                 timeout=timeout.left())
+                                                 timeout=timeout.left_seconds())
 
     logging.info("Spinning up one more node")
     node4 = spin_up_node(config, near_root, node_dirs[4], 4, boot_node=node2)
 
     logging.info('Waiting for the new node to sync.  '
-                 f'We are {timeout.elapsed()} seconds in')
+                 f'We are {timeout.elapsed_seconds()} seconds in')
     while True:
         assert timeout.check()
         sync_info = node4.get_status()['sync_info']
@@ -299,4 +299,4 @@ if __name__ == '__main__':
                     found = True
             assert found, f'Missing request for shard {shard} in block {height}'
 
-    logging.info(f'Done.  Took {timeout.elapsed()} seconds')
+    logging.info(f'Done.  Took {timeout.elapsed_seconds()} seconds')

--- a/pytest/tests/sanity/sync_chunks_from_archival.py
+++ b/pytest/tests/sanity/sync_chunks_from_archival.py
@@ -91,6 +91,25 @@ class Handler(ProxyHandler):
         return True
 
 
+# TODO(mina86): Make it a utility class
+class Timeout:
+
+    def __init__(self, timeout: float) -> None:
+        if timeout <= 0:
+            raise ValueError('timeout must be positive')
+        self.__start = time.monotonic()
+        self.__end = self.__start + timeout
+
+    def check(self) -> bool:
+        return time.monotonic() < self.__end
+
+    def elapsed(self) -> bool:
+        return time.monotonic() - self.__start
+
+    def left(self) -> bool:
+        return self.__end - time.monotonic()
+
+
 if __name__ == '__main__':
     manager = multiprocessing.Manager()
     hash_to_metadata = manager.dict()
@@ -103,7 +122,7 @@ if __name__ == '__main__':
                 requests=requests,
                 responses=responses))
 
-    started = time.time()
+    timeout = Timeout(TIMEOUT)
 
     logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
 
@@ -174,7 +193,7 @@ if __name__ == '__main__':
     logging.info(f'Getting to height {HEIGHTS_BEFORE_ROTATE}')
     utils.wait_for_blocks(boot_node,
                           target=HEIGHTS_BEFORE_ROTATE,
-                          timeout=TIMEOUT)
+                          timeout=timeout.left())
 
     node2 = spin_up_node(config,
                          near_root,
@@ -211,7 +230,7 @@ if __name__ == '__main__':
 
         logging.info("Waiting for rotation to occur")
         while True:
-            assert time.time() - started < TIMEOUT, get_validators(boot_node)
+            assert timeout.check(), get_validators(boot_node)
             if set(get_validators(boot_node)) == set(expected_vals):
                 break
             else:
@@ -227,15 +246,15 @@ if __name__ == '__main__':
     logging.info(f'Getting to height {target}')
     height_to_sync_to, _ = utils.wait_for_blocks(node2,
                                                  target=target,
-                                                 timeout=TIMEOUT)
+                                                 timeout=timeout.left())
 
     logging.info("Spinning up one more node")
     node4 = spin_up_node(config, near_root, node_dirs[4], 4, boot_node=node2)
 
-    logging.info("Waiting for the new node to sync. We are %s seconds in" %
-                 (time.time() - started))
+    logging.info('Waiting for the new node to sync.  '
+                 f'We are {timeout.elapsed()} seconds in')
     while True:
-        assert time.time() - started < TIMEOUT
+        assert timeout.check()
         sync_info = node4.get_status()['sync_info']
         if not sync_info['syncing']:
             new_height = sync_info['latest_block_height']
@@ -280,4 +299,4 @@ if __name__ == '__main__':
                     found = True
             assert found, f'Missing request for shard {shard} in block {height}'
 
-    logging.info("Done. Took %s seconds" % (time.time() - started))
+    logging.info(f'Done.  Took {timeout.elapsed()} seconds')

--- a/pytest/tests/sanity/transactions.py
+++ b/pytest/tests/sanity/transactions.py
@@ -81,10 +81,7 @@ last_balances = [x for x in ctx.expected_balances]
 step = 0
 sent_height = -1
 
-height, hash_ = utils.wait_for_blocks(nodes[4],
-                                      target=1,
-                                      timeout=TIMEOUT,
-                                      check_storage=False)
+height, hash_ = utils.wait_for_blocks(nodes[4], target=1, check_storage=False)
 tx = sign_payment_tx(nodes[0].signer_key, 'test1', 100, 1,
                      base58.b58decode(hash_.encode('utf8')))
 nodes[4].send_tx(tx)
@@ -95,7 +92,6 @@ sent_height = height
 
 height, hash_ = utils.wait_for_blocks(nodes[4],
                                       target=sent_height + 6,
-                                      timeout=TIMEOUT,
                                       check_storage=False)
 cur_balances = ctx.get_balances()
 assert cur_balances == ctx.expected_balances, "%s != %s" % (


### PR DESCRIPTION
Calculate default timeout to the utils.wait_for_blocks function.  The
timeout is based on number of blocks the function waits for.  Having
the default allows us to simplify tests which no longer need to
specify explicit timeout.
