### PR TITLE
scripts: actually look at ‘scripts’ directory when ‘formatting’

### DIFF
--- a/scripts/formatting
+++ b/scripts/formatting
@@ -41,7 +41,7 @@ def run_tools(*, check: bool) -> str:
         has_yapf = run((sys.executable, '-m', 'pip', 'install', 'yapf'))
 
     flag = '-pdr' if check else '-pir'
-    args = ('pytest', 'script', SELF_FILE)
+    args = ('pytest', 'scripts', SELF_FILE)
     if not has_yapf or not run((sys.executable, '-m', 'yapf', flag) + args):
         langs.append('Python')
 


### PR DESCRIPTION
Due to a typo, the scripts/formatting script did not look at Python
files located in scripts directory when checking or fixing the
formatting.  Fix that issue.