### PR TITLE
fix(script): Fix params-estimator init in CI

### DIFF
--- a/runtime/runtime-params-estimator/emu-cost/ci.sh
+++ b/runtime/runtime-params-estimator/emu-cost/ci.sh
@@ -15,10 +15,9 @@ docker run \
 set -ex
 cd /host/${srcdir}/runtime/runtime-params-estimator
 pushd test-contract; ./build.sh; popd
-cargo run --release --package neard --bin neard -- --home /tmp/data init --test-seed=alice.near --account-id=test.near --fast
-cargo run --release --package genesis-populate --bin genesis-populate -- --additional-accounts-num=200000 --home /tmp/data
+mkdir /tmp/data
 cargo build --release --package runtime-params-estimator --features required
-./emu-cost/counter_plugin/qemu-x86_64 -cpu Westmere-v1 -plugin file=./emu-cost/counter_plugin/libcounter.so ../../target/release/runtime-params-estimator --home /tmp/data --accounts-num 20000 --iters 1 --warmup-iters 1
+./emu-cost/counter_plugin/qemu-x86_64 -cpu Westmere-v1 -plugin file=./emu-cost/counter_plugin/libcounter.so ../../target/release/runtime-params-estimator --home /tmp/data --additional-accounts-num=200000 --accounts-num 20000 --iters 1 --warmup-iters 1
 
 cp /tmp/data/runtime_config.json /host/${srcdir}
 "


### PR DESCRIPTION
The old way of initializing a neard home does not install the test
contract on all accounts, which leads to estimations failing.
Giving an empty directory to the estimator as home will cause it to
initialize it properly.