### PR TITLE
Estimator speed

### DIFF
--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -812,28 +812,27 @@ fn utf8_decoding_base(ctx: &mut EstimatorContext) -> GasCost {
     fn_cost(ctx, "utf8_log_10b_10k", ExtCosts::utf8_decoding_base, 10_000)
 }
 fn utf8_decoding_byte(ctx: &mut EstimatorContext) -> GasCost {
-    let no_nul =
-        fn_cost(ctx, "utf8_log_10kib_10k", ExtCosts::utf8_decoding_byte, 10 * 1024 * 10_000);
+    let no_nul = fn_cost(ctx, "utf8_log_10kib_1k", ExtCosts::utf8_decoding_byte, 10 * 1024 * 1_000);
     let nul = fn_cost(
         ctx,
-        "nul_utf8_log_10kib_10k",
+        "nul_utf8_log_10kib_1k",
         ExtCosts::utf8_decoding_byte,
-        (10 * 1024 - 1) * 10_000,
+        (10 * 1024 - 1) * 1_000,
     );
     nul.max(no_nul)
 }
 
 fn utf16_decoding_base(ctx: &mut EstimatorContext) -> GasCost {
-    fn_cost(ctx, "utf16_log_10b_10k", ExtCosts::utf16_decoding_base, 10_000)
+    fn_cost(ctx, "utf16_log_10b_10k", ExtCosts::utf16_decoding_base, 1_000)
 }
 fn utf16_decoding_byte(ctx: &mut EstimatorContext) -> GasCost {
     let no_nul =
-        fn_cost(ctx, "utf16_log_10kib_10k", ExtCosts::utf16_decoding_byte, 10 * 1024 * 10_000);
+        fn_cost(ctx, "utf16_log_10kib_1k", ExtCosts::utf16_decoding_byte, 10 * 1024 * 1_000);
     let nul = fn_cost(
         ctx,
-        "nul_utf16_log_10kib_10k",
+        "nul_utf16_log_10kib_1k",
         ExtCosts::utf16_decoding_byte,
-        (10 * 1024 - 2) * 10_000,
+        (10 * 1024 - 2) * 1_000,
     );
     nul.max(no_nul)
 }

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -96,7 +96,7 @@ use rand::Rng;
 use utils::{
     aggregate_per_block_measurements, fn_cost, fn_cost_count, fn_cost_with_setup,
     generate_data_only_contract, generate_fn_name, noop_function_call_cost, read_resource,
-    transaction_cost,
+    transaction_cost, transaction_cost_ext,
 };
 use vm_estimator::{compile_single_contract_cost, compute_compile_cost_vm};
 
@@ -569,7 +569,9 @@ fn deploy_contract_cost(
         let actions = vec![Action::DeployContract(DeployContractAction { code: code_factory() })];
         tb.transaction_from_actions(sender, receiver, actions)
     };
-    let total_cost = transaction_cost(testbed, &mut make_transaction);
+    // Use a small block size since deployments are gas heavy
+    let block_size = 5;
+    let (total_cost, _ext) = transaction_cost_ext(testbed, block_size, &mut make_transaction);
     let base_cost = action_sir_receipt_creation(ctx) + apply_block_cost(ctx);
     total_cost - base_cost
 }

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -805,7 +805,7 @@ fn log_base(ctx: &mut EstimatorContext) -> GasCost {
 }
 fn log_byte(ctx: &mut EstimatorContext) -> GasCost {
     // NOTE: We are paying per *output* byte here, hence 3/2 multiplier.
-    fn_cost(ctx, "utf16_log_10kib_10k", ExtCosts::log_byte, (10 * 1024 * 3 / 2) * 10_000)
+    fn_cost(ctx, "utf16_log_10kib_1k", ExtCosts::log_byte, (10 * 1024 * 3 / 2) * 1_000)
 }
 
 fn utf8_decoding_base(ctx: &mut EstimatorContext) -> GasCost {

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -569,7 +569,7 @@ fn deploy_contract_cost(
         let actions = vec![Action::DeployContract(DeployContractAction { code: code_factory() })];
         tb.transaction_from_actions(sender, receiver, actions)
     };
-    // Use a small block size since deployments are gas heavy
+    // Use a small block size since deployments are gas heavy.
     let block_size = 5;
     let (total_cost, _ext) = transaction_cost_ext(testbed, block_size, &mut make_transaction);
     let base_cost = action_sir_receipt_creation(ctx) + apply_block_cost(ctx);

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -823,7 +823,7 @@ fn utf8_decoding_byte(ctx: &mut EstimatorContext) -> GasCost {
 }
 
 fn utf16_decoding_base(ctx: &mut EstimatorContext) -> GasCost {
-    fn_cost(ctx, "utf16_log_10b_10k", ExtCosts::utf16_decoding_base, 1_000)
+    fn_cost(ctx, "utf16_log_10b_10k", ExtCosts::utf16_decoding_base, 10_000)
 }
 fn utf16_decoding_byte(ctx: &mut EstimatorContext) -> GasCost {
     let no_nul =

--- a/runtime/runtime-params-estimator/test-contract/src/lib.rs
+++ b/runtime/runtime-params-estimator/test-contract/src/lib.rs
@@ -282,9 +282,9 @@ pub unsafe fn utf8_log_10b_10k() {
 // It actually measures them together with `read_memory_base` and `read_memory_byte`.
 // Write utf8 10kib 1k times into log.
 #[no_mangle]
-pub unsafe fn utf8_log_10kib_10k() {
+pub unsafe fn utf8_log_10kib_1k() {
     let buffer = [65u8; 10240];
-    for _ in 0..10_000 {
+    for _ in 0..1_000 {
         log_utf8(buffer.len() as u64, buffer.as_ptr() as *const u64 as u64);
     }
 }
@@ -307,10 +307,10 @@ pub unsafe fn nul_utf8_log_10b_10k() {
 // It actually measures them together with `read_memory_base` and `read_memory_byte`.
 // Write utf8 10kib 1k times into log.
 #[no_mangle]
-pub unsafe fn nul_utf8_log_10kib_10k() {
+pub unsafe fn nul_utf8_log_10kib_1k() {
     let mut buffer = [65u8; 10240];
     buffer[buffer.len() - 1] = 0;
-    for _ in 0..10_000 {
+    for _ in 0..1_000 {
         log_utf8(core::u64::MAX, buffer.as_ptr() as *const u64 as u64);
     }
 }
@@ -330,9 +330,9 @@ pub unsafe fn utf16_log_10b_10k() {
 // It actually measures them together with `read_memory_base` and `read_memory_byte`.
 // Write utf16 10kib 1k times into log.
 #[no_mangle]
-pub unsafe fn utf16_log_10kib_10k() {
+pub unsafe fn utf16_log_10kib_1k() {
     let buffer = [65u8; 10240];
-    for _ in 0..10_000 {
+    for _ in 0..1_000 {
         log_utf16(buffer.len() as u64, buffer.as_ptr() as *const u64 as u64);
     }
 }
@@ -356,11 +356,11 @@ pub unsafe fn nul_utf16_log_10b_10k() {
 // It actually measures them together with `read_memory_base` and `read_memory_byte`.
 // Write utf16 10kib 1k times into log.
 #[no_mangle]
-pub unsafe fn nul_utf16_log_10kib_10k() {
+pub unsafe fn nul_utf16_log_10kib_1k() {
     let mut buffer = [65u8; 10240];
     buffer[buffer.len() - 2] = 0;
     buffer[buffer.len() - 1] = 0;
-    for _ in 0..10_000 {
+    for _ in 0..1_000 {
         log_utf16(core::u64::MAX, buffer.as_ptr() as *const u64 as u64);
     }
 }
@@ -1071,7 +1071,7 @@ pub unsafe fn account_storage_has_key() {
     input(0);
     let input_data = [0u8; MAX_ARG_LEN as usize];
     read_register(0, input_data.as_ptr() as _);
-    
+
     let key_len = u64::from_le_bytes(input_data[..8].try_into().unwrap());
     assert!(key_len < MAX_ARG_LEN - 16);
     let key = &input_data[8..8 + key_len as usize];


### PR DESCRIPTION
Some estimations took >1h to finish in qemu.
This change speeds them up by reducing unreasonable repetitions per
iteration.
(Total repetitions = iters_per_block * block_size * inner_repetitions)

- Deployment per byte: 100 -> 5 block size
- UTF8 / UTF16 decoding per byte: 10k -> 1k inner repetitions
    
The new time is around 5min per block for all 3 collectively.