### PR TITLE
fuzz: disable runtime-tester for now as it's got lots of intermittent failures anyway

### DIFF
--- a/nightly/fuzz.toml
+++ b/nightly/fuzz.toml
@@ -17,9 +17,11 @@ weight = 10
 flags = ["-len_control=0", "-prefer_small=0", "-max_len=4000000"]
 
 [[target]]
+# Disabled for now because of the frequent intermittent failures,
+# should re-enable once they've been investigated
 crate = "test-utils/runtime-tester/fuzz"
 runner = "runtime_fuzzer"
-weight = 10
+weight = 0
 flags = ["-len_control=0", "-prefer_small=0", "-max_len=4000000"]
 
 [[target]]


### PR DESCRIPTION
This way we can scale up the fuzzing infrastructure for the other fuzz targets without getting overwhelmed by this fuzzer's intermittent failures that look mostly independent from its inputs.