### PR TITLE
pytest: fix block_sync_archival.py

### DIFF
--- a/pytest/tests/sanity/block_sync_archival.py
+++ b/pytest/tests/sanity/block_sync_archival.py
@@ -41,7 +41,6 @@ class Cluster:
                  max_block_production_delay: _DurationMaybe = None):
         node_config = {
             'archive': True,
-            'archive_gc_partial_chunks': True,
             'tracked_shards': [0],
         }
 


### PR DESCRIPTION
By mistake archive_gc_partial_chunks setting has been added to the
test in previous commit changing it.  The option is meant for future
commits and currently causes test failures.  Fix that.

Issue: https://github.com/near/nearcore/issues/6242