### PR TITLE
pytest: observe metrics in block_sync_archival.py test

### DIFF
--- a/pytest/tests/sanity/block_sync_archival.py
+++ b/pytest/tests/sanity/block_sync_archival.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Tests that archival node can sync up history from another archival node.
 
-Initialises a cluster with two archival nodes: one validator and one observer.
-Starts the validator and waits until several epochs worth of blocks are
-generated.  Then, starts the observer node and makes sure that it properly
+Initialises a cluster with three archival nodes: one validator and two observer.
+Starts the validator with one observer keeping in sync.  Once several epochs
+worth of blocks are generated kills the validator (so that no new blocks are
+generated) and starts the second observer making sure that it properly
 synchronises the full history.
 
 When called with --long-run the test will generate enough blocks so that entries
@@ -18,6 +19,9 @@ import datetime
 import pathlib
 import sys
 import typing
+
+import prometheus_client.parser
+import requests
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
 
@@ -57,21 +61,25 @@ class Cluster:
 
         self._config = cluster.load_config()
         self._near_root, self._node_dirs = cluster.init_cluster(
-            1, 1, 1, self._config, [['epoch_length', EPOCH_LENGTH],
+            1, 2, 1, self._config, [['epoch_length', EPOCH_LENGTH],
                                     ['block_producer_kickout_threshold', 80]], {
                                         0: node_config,
                                         1: node_config,
+                                        2: node_config,
                                     })
-        self._nodes = [None] * 2
+        self._nodes = [None] * len(self._node_dirs)
 
-    def start_node(self, ordinal: int) -> cluster.BaseNode:
+    def start_node(self,
+                   ordinal: int,
+                   *,
+                   boot_node: int = 0) -> cluster.BaseNode:
         assert self._nodes[ordinal] is None
         self._nodes[ordinal] = node = cluster.spin_up_node(
             self._config,
             self._near_root,
             self._node_dirs[ordinal],
             ordinal,
-            boot_node=self._nodes[0],
+            boot_node=self._nodes[boot_node],
             single_node=not ordinal)
         return node
 
@@ -113,27 +121,60 @@ def main(argv: typing.Sequence[str]) -> None:
 
     with Cluster(min_block_production_delay=min_delay,
                  max_block_production_delay=max_delay) as cluster:
-        # Start the validator and wait for a few epoch’s worth of blocks to be
-        # generated.
+        # Start the validator and the first observer.  Wait until the observer
+        # synchronises a few epoch’s worth of blocks to be generated and then
+        # kill validator so no more blocks are generated.
         boot = cluster.start_node(0)
-        latest = utils.wait_for_blocks(boot,
-                                       target=target_height,
-                                       poll_interval=1)
-
-        # Start the observer node and wait for it to catch up with the chain
-        # state.
         fred = cluster.start_node(1)
         utils.wait_for_blocks(fred, target=target_height, poll_interval=1)
+        boot.kill()
+        latest = fred.get_latest_block()
+
+        # Start the second observer node and wait for it to catch up with the
+        # first observer.
+        barney = cluster.start_node(2, boot_node=1)
+        utils.wait_for_blocks(barney, target=latest.height, poll_interval=1)
 
         # Verify that observer got all the blocks.  Note that get_all_blocks
         # verifies that the node has full chain from head to genesis block.
-        boot_blocks = get_all_blocks(boot, head=latest)
         fred_blocks = get_all_blocks(fred, head=latest)
-        if boot_blocks != fred_blocks:
-            for a, b in zip(boot_blocks, fred_blocks):
+        barney_blocks = get_all_blocks(barney, head=latest)
+        if barney_blocks != fred_blocks:
+            for a, b in zip(fred_blocks, barney_blocks):
                 if a != b:
                     logger.error(f'{a} != {b}')
             assert False
+
+        # Get near_partial_encoded_chunk_request_processing_time metric
+        response = requests.get('http://{}:{}/metrics'.format(*fred.rpc_addr()))
+        response.raise_for_status()
+        histogram = next(
+            metric for metric in prometheus_client.parser.
+            text_string_to_metric_families(response.content.decode('utf8')) if
+            metric.name == 'near_partial_encoded_chunk_request_processing_time')
+        counts = dict((sample.labels['method'] + '/' + sample.labels['success'],
+                       int(sample.value))
+                      for sample in histogram.samples
+                      if sample.name.endswith('_count'))
+        logger.info('Counters: ' + '; '.join(
+            f'{key}: {count}' for key, count in sorted(counts.items())))
+
+        # In ‘short’ run (i.e. without --long-run flag) we expect all requests
+        # to be served from in-memory cache.  In --long-run we expect chunks to
+        # be removed from in-memory cache causing some of the requests to be
+        # served from partial chunks.
+        if opts.long_run:
+            keys = ('cache/ok', 'partial/ok')
+        else:
+            keys = ('cache/ok',)
+        for key in keys:
+            counts.setdefault(key, 0)
+        for key, count in counts.items():
+            if key in keys:
+                assert count, f'Expected {key} counter to be non-zero'
+            else:
+                assert not count, (
+                    f'Expected {key} counter to be zero but got {count}')
 
 
 if __name__ == '__main__':

--- a/pytest/tests/sanity/block_sync_archival.py
+++ b/pytest/tests/sanity/block_sync_archival.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """Tests that archival node can sync up history from another archival node.
 
-Initialises a cluster with three archival nodes: one validator and two observer.
-Starts the validator with one observer keeping in sync.  Once several epochs
-worth of blocks are generated kills the validator (so that no new blocks are
-generated) and starts the second observer making sure that it properly
-synchronises the full history.
+Initialises a cluster with three archival nodes: one validator and two
+observers.  Starts the validator with one observer keeping in sync.  Once
+several epochs worth of blocks are generated kills the validator (so that no new
+blocks are generated) and starts the second observer making sure that it
+properly synchronises the full history.
 
 When called with --long-run the test will generate enough blocks so that entries
 in EncodedChunksCache start being evicted.  That it, it’ll generate more than
@@ -72,14 +72,14 @@ class Cluster:
     def start_node(self,
                    ordinal: int,
                    *,
-                   boot_node: int = 0) -> cluster.BaseNode:
+                   boot_node_index: int = 0) -> cluster.BaseNode:
         assert self._nodes[ordinal] is None
         self._nodes[ordinal] = node = cluster.spin_up_node(
             self._config,
             self._near_root,
             self._node_dirs[ordinal],
             ordinal,
-            boot_node=self._nodes[boot_node],
+            boot_node=self._nodes[boot_node_index],
             single_node=not ordinal)
         return node
 
@@ -132,7 +132,7 @@ def main(argv: typing.Sequence[str]) -> None:
 
         # Start the second observer node and wait for it to catch up with the
         # first observer.
-        barney = cluster.start_node(2, boot_node=1)
+        barney = cluster.start_node(2, boot_node_index=1)
         utils.wait_for_blocks(barney, target=latest.height, poll_interval=1)
 
         # Verify that observer got all the blocks.  Note that get_all_blocks

--- a/pytest/tests/sanity/block_sync_archival.py
+++ b/pytest/tests/sanity/block_sync_archival.py
@@ -61,12 +61,17 @@ class Cluster:
 
         self._config = cluster.load_config()
         self._near_root, self._node_dirs = cluster.init_cluster(
-            1, 2, 1, self._config, [['epoch_length', EPOCH_LENGTH],
-                                    ['block_producer_kickout_threshold', 80]], {
-                                        0: node_config,
-                                        1: node_config,
-                                        2: node_config,
-                                    })
+            num_nodes=1,
+            num_observers=2,
+            num_shards=1,
+            config=self._config,
+            genesis_config_changes=[['epoch_length', EPOCH_LENGTH],
+                                    ['block_producer_kickout_threshold', 80]],
+            client_config_changes={
+                0: node_config,
+                1: node_config,
+                2: node_config,
+            })
         self._nodes = [None] * len(self._node_dirs)
 
     def start_node(self,


### PR DESCRIPTION
Add code for observing the partial chunks request processing time metrics
to make sure that the expected code paths are executed when handling the
request.

Issue: https://github.com/near/nearcore/issues/6242