### PR TITLE
fix(script): Estimator CI

### DIFF
--- a/runtime/runtime-params-estimator/emu-cost/ci.sh
+++ b/runtime/runtime-params-estimator/emu-cost/ci.sh
@@ -18,6 +18,4 @@ pushd test-contract; ./build.sh; popd
 mkdir /tmp/data
 cargo build --release --package runtime-params-estimator --features required
 ./emu-cost/counter_plugin/qemu-x86_64 -cpu Westmere-v1 -plugin file=./emu-cost/counter_plugin/libcounter.so ../../target/release/runtime-params-estimator --home /tmp/data --additional-accounts-num=200000 --accounts-num 20000 --iters 1 --warmup-iters 1
-
-cp /tmp/data/runtime_config.json /host/${srcdir}
 "


### PR DESCRIPTION
Do not copy runtime_config.json after estimation.

The CI script wants to prepare runtime_configs.json as buildkite
artifact but this is no longer generated by default. Generating it
in an extra step also does not work right now as some estimations are
missing.

We do not need this artifact and this script is deprecated anyway.