### PR TITLE
Fix memory leak in ChunksDelayTracker

### DIFF
--- a/chain/client/src/chunks_delay_tracker.rs
+++ b/chain/client/src/chunks_delay_tracker.rs
@@ -60,6 +60,7 @@ impl ChunksDelayTracker {
         for chunk_hash in chunks {
             self.chunks_in_progress.remove(chunk_hash);
         }
+        println!("finish_block_processing {}",self.blocks_in_progress.len());
     }
 
     fn update_block_chunks_requested_metric(

--- a/chain/client/src/chunks_delay_tracker.rs
+++ b/chain/client/src/chunks_delay_tracker.rs
@@ -60,7 +60,6 @@ impl ChunksDelayTracker {
         for chunk_hash in chunks {
             self.chunks_in_progress.remove(chunk_hash);
         }
-        println!("finish_block_processing {}",self.blocks_in_progress.len());
     }
 
     fn update_block_chunks_requested_metric(

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -747,18 +747,9 @@ impl Client {
             )
         };
 
-        // Record a timestamp of processing a block, but only do it if the block isn't known yet.
-        let block_known_error = if let Err(ref e) = result {
-            match e.kind() {
-                ErrorKind::BlockKnown(_) => true,
-                _ => false,
-            }
-        } else {
-            false
-        };
-        if !block_known_error {
-            self.chunks_delay_tracker.received_block(&block_hash, processing_started);
-        }
+        // Record a timestamp of processing a block, but only do it if the block is valid and isn't
+        // processed yet.
+        self.chunks_delay_tracker.received_block(&block_hash, processing_started, &result);
 
         // Send out challenges that accumulated via on_challenge.
         self.send_challenges(challenges);

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -294,8 +294,7 @@ impl Handler<NetworkClientMessages> for ClientActor {
                                     NetworkRequests::Block { block: block.clone() },
                                 ),
                             );
-                            let (accepted_blocks, _) =
-                                self.client.process_block(block.into(), Provenance::PRODUCED);
+                            let (accepted_blocks, _) = self.client.process_block(block.into(), Provenance::PRODUCED);
                             for accepted_block in accepted_blocks {
                                 self.client.on_block_accepted(
                                     accepted_block.hash,

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -294,7 +294,8 @@ impl Handler<NetworkClientMessages> for ClientActor {
                                     NetworkRequests::Block { block: block.clone() },
                                 ),
                             );
-                            let (accepted_blocks, _) = self.client.process_block(block.into(), Provenance::PRODUCED);
+                            let (accepted_blocks, _) =
+                                self.client.process_block(block.into(), Provenance::PRODUCED);
                             for accepted_block in accepted_blocks {
                                 self.client.on_block_accepted(
                                     accepted_block.hash,
@@ -1160,8 +1161,7 @@ impl ClientActor {
                 }
             }
         }
-        let (accepted_blocks, result) =
-            self.client.process_block(block, provenance);
+        let (accepted_blocks, result) = self.client.process_block(block, provenance);
         self.process_accepted_blocks(accepted_blocks);
         result.map(|_| ())
     }

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1160,7 +1160,8 @@ impl ClientActor {
                 }
             }
         }
-        let (accepted_blocks, result) = self.client.process_block(block, provenance);
+        let (accepted_blocks, result) =
+            self.client.process_block(block, provenance);
         self.process_accepted_blocks(accepted_blocks);
         result.map(|_| ())
     }


### PR DESCRIPTION
The leak happens if an already processed block attempts to be processed again.