### PR TITLE
Use non-blocking log writer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2349,15 +2349,6 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
-dependencies = [
- "regex-automata",
-]
-
-[[package]]
-name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
@@ -2943,7 +2934,7 @@ version = "0.1.0"
 dependencies = [
  "tracing",
  "tracing-appender",
- "tracing-subscriber 0.3.9",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -5388,7 +5379,7 @@ checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
 dependencies = [
  "crossbeam-channel",
  "time 0.3.7",
- "tracing-subscriber 0.3.9",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -5424,45 +5415,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-span-tree"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877726b1570d7764022ef20cc61479b5bcfc1118b90521ce61f6cc9e4f5ffbd8"
+checksum = "c3809cda0328d505548af1ca24fac329f41c0c213d0a1e78908922d0b43e5c43"
 dependencies = [
  "tracing",
- "tracing-subscriber 0.2.25",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
-dependencies = [
- "ansi_term",
- "chrono",
- "lazy_static",
- "matchers 0.0.1",
- "regex",
- "serde",
- "serde_json",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-log",
- "tracing-serde",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -5473,7 +5432,7 @@ checksum = "9e0ab7bdc962035a87fba73f3acca9b8a8d0034c2e6f60b84aeaaddddc155dce"
 dependencies = [
  "ansi_term 0.12.1",
  "lazy_static",
- "matchers 0.1.0",
+ "matchers",
  "regex",
  "sharded-slab",
  "smallvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "tracing",
  "tracing-appender",
@@ -5430,7 +5430,7 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e0ab7bdc962035a87fba73f3acca9b8a8d0034c2e6f60b84aeaaddddc155dce"
 dependencies = [
- "ansi_term 0.12.1",
+ "ansi_term",
  "lazy_static",
  "matchers",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
  "h2",
  "http",
  "httparse",
- "itoa",
+ "itoa 0.4.8",
  "language-tags",
  "local-channel",
  "log",
@@ -213,7 +213,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "itoa",
+ "itoa 0.4.8",
  "language-tags",
  "log",
  "mime",
@@ -397,7 +397,7 @@ dependencies = [
  "cookie",
  "derive_more",
  "futures-core",
- "itoa",
+ "itoa 0.4.8",
  "log",
  "mime",
  "percent-encoding",
@@ -783,6 +783,7 @@ dependencies = [
  "near-crypto",
  "near-network",
  "near-network-primitives",
+ "near-o11y",
  "near-primitives",
  "near-store",
  "nearcore",
@@ -790,8 +791,7 @@ dependencies = [
  "parking_lot 0.11.2",
  "rand 0.8.4",
  "tokio",
- "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.9",
 ]
 
 [[package]]
@@ -1184,7 +1184,7 @@ checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
 dependencies = [
  "bstr",
  "csv-core",
- "itoa",
+ "itoa 0.4.8",
  "ryu",
  "serde",
 ]
@@ -1854,7 +1854,7 @@ checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
 dependencies = [
  "bytes",
  "fnv",
- "itoa",
+ "itoa 0.4.8",
 ]
 
 [[package]]
@@ -1895,7 +1895,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 0.4.8",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1968,11 +1968,12 @@ dependencies = [
  "anyhow",
  "clap 3.1.6",
  "near-indexer",
+ "near-o11y",
  "openssl-probe",
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.2.25",
 ]
 
 [[package]]
@@ -2097,6 +2098,12 @@ name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "jobserver"
@@ -2347,6 +2354,15 @@ name = "matchers"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata",
 ]
@@ -2858,7 +2874,7 @@ name = "near-logger-utils"
 version = "0.0.0"
 dependencies = [
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.2.25",
 ]
 
 [[package]]
@@ -2921,6 +2937,15 @@ dependencies = [
  "serde",
  "strum",
  "tokio",
+]
+
+[[package]]
+name = "near-o11y"
+version = "0.1.0"
+dependencies = [
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber 0.3.9",
 ]
 
 [[package]]
@@ -3304,6 +3329,7 @@ dependencies = [
  "clap 3.1.6",
  "futures",
  "near-chain-configs",
+ "near-o11y",
  "near-performance-metrics",
  "near-primitives",
  "near-rust-allocator-proxy",
@@ -3317,7 +3343,7 @@ dependencies = [
  "tikv-jemallocator",
  "tokio",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.2.25",
 ]
 
 [[package]]
@@ -3436,6 +3462,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aba1801fb138d8e85e11d0fc70baf4fe1cdfffda7c6cd34a854905df588e5ed0"
+dependencies = [
  "libc",
 ]
 
@@ -4182,7 +4217,7 @@ dependencies = [
  "async-trait",
  "combine",
  "dtoa",
- "itoa",
+ "itoa 0.4.8",
  "percent-encoding",
  "sha1",
  "url",
@@ -4309,10 +4344,10 @@ dependencies = [
  "integration-tests",
  "near-crypto",
  "near-jsonrpc-client",
+ "near-o11y",
  "near-primitives",
  "nearcore",
- "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.9",
 ]
 
 [[package]]
@@ -4648,7 +4683,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
 dependencies = [
  "indexmap",
- "itoa",
+ "itoa 0.4.8",
  "ryu",
  "serde",
 ]
@@ -4660,7 +4695,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
 dependencies = [
  "form_urlencoded",
- "itoa",
+ "itoa 0.4.8",
  "ryu",
  "serde",
 ]
@@ -4918,11 +4953,12 @@ name = "storage-usage-delta-calculator"
 version = "0.0.0"
 dependencies = [
  "near-chain-configs",
+ "near-o11y",
  "near-primitives",
  "node-runtime",
  "serde_json",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.2.25",
 ]
 
 [[package]]
@@ -5124,9 +5160,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
 ]
@@ -5184,6 +5220,17 @@ dependencies = [
  "time-macros",
  "version_check",
  "winapi",
+]
+
+[[package]]
+name = "time"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
+dependencies = [
+ "itoa 1.0.1",
+ "libc",
+ "num_threads",
 ]
 
 [[package]]
@@ -5339,6 +5386,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
+dependencies = [
+ "crossbeam-channel",
+ "time 0.3.7",
+ "tracing-subscriber 0.3.9",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5351,11 +5409,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.21"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+checksum = "aa31669fa42c09c34d94d8165dd2012e8ff3c66aca50f3bb226b68f216f2706c"
 dependencies = [
  "lazy_static",
+ "valuable",
 ]
 
 [[package]]
@@ -5386,7 +5445,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877726b1570d7764022ef20cc61479b5bcfc1118b90521ce61f6cc9e4f5ffbd8"
 dependencies = [
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.2.25",
 ]
 
 [[package]]
@@ -5398,7 +5457,7 @@ dependencies = [
  "ansi_term",
  "chrono",
  "lazy_static",
- "matchers",
+ "matchers 0.0.1",
  "regex",
  "serde",
  "serde_json",
@@ -5409,6 +5468,24 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e0ab7bdc962035a87fba73f3acca9b8a8d0034c2e6f60b84aeaaddddc155dce"
+dependencies = [
+ "ansi_term 0.12.1",
+ "lazy_static",
+ "matchers 0.1.0",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -5510,6 +5587,12 @@ name = "validator_types"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad9680608df133af2c1ddd5eaf1ddce91d60d61b6bc51494ef326458365a470a"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,7 +791,6 @@ dependencies = [
  "parking_lot 0.11.2",
  "rand 0.8.4",
  "tokio",
- "tracing-subscriber 0.3.9",
 ]
 
 [[package]]
@@ -1973,7 +1972,6 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber 0.2.25",
 ]
 
 [[package]]
@@ -2873,8 +2871,8 @@ dependencies = [
 name = "near-logger-utils"
 version = "0.0.0"
 dependencies = [
+ "near-o11y",
  "tracing",
- "tracing-subscriber 0.2.25",
 ]
 
 [[package]]
@@ -3343,7 +3341,6 @@ dependencies = [
  "tikv-jemallocator",
  "tokio",
  "tracing",
- "tracing-subscriber 0.2.25",
 ]
 
 [[package]]
@@ -4347,7 +4344,6 @@ dependencies = [
  "near-o11y",
  "near-primitives",
  "nearcore",
- "tracing-subscriber 0.3.9",
 ]
 
 [[package]]
@@ -4958,7 +4954,6 @@ dependencies = [
  "node-runtime",
  "serde_json",
  "tracing",
- "tracing-subscriber 0.2.25",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "core/primitives-core",
     "core/store",
     "core/metrics",
+    "core/o11y",
     "runtime/near-vm-logic",
     "runtime/near-vm-runner",
     "runtime/near-vm-runner/fuzz",

--- a/core/o11y/Cargo.toml
+++ b/core/o11y/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "near-o11y"
+description = "Observability helpers for the near codebase"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+tracing = { version = "0.1.13", features = ["std"] }
+tracing-subscriber = { version = "0.3.9", features = ["fmt", "env-filter", "std"] }
+tracing-appender = "0.2.2"

--- a/core/o11y/Cargo.toml
+++ b/core/o11y/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "near-o11y"
+version = "0.0.0"
+authors = ["Near Inc <hello@nearprotocol.com>"]
 description = "Observability helpers for the near codebase"
-readme = "README.md"
-version = "0.1.0"
 edition = "2021"
 publish = false
+readme = "README.md"
+rust-version = "1.56.0"
 
 [dependencies]
 tracing = { version = "0.1.13", features = ["std"] }

--- a/core/o11y/Cargo.toml
+++ b/core/o11y/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "near-o11y"
 description = "Observability helpers for the near codebase"
+readme = "README.md"
 version = "0.1.0"
 edition = "2021"
 publish = false

--- a/core/o11y/README.md
+++ b/core/o11y/README.md
@@ -1,0 +1,9 @@
+Observability (o11y) helpers for the NEAR codebase.
+
+This crate contains all sorts of utilities to enable a more convenient observability implementation
+in the NEAR codebase. Of particular interest to most will be standardized tracing subscriber setup
+available via the [`default_subscriber`] function.
+
+Among other things you should expect to find here eventually are utilities to work with prometheus
+metrics (wrappers for additional metric types, a server publishing these metrics, etc.) as well as
+NEAR-specific event and span subscriber implementations, etc.

--- a/core/o11y/src/lib.rs
+++ b/core/o11y/src/lib.rs
@@ -1,3 +1,9 @@
+#![doc = include_str!("../README.md")]
+
+pub use {tracing, tracing_appender, tracing_subscriber};
+
+use std::borrow::Cow;
+
 use tracing_subscriber::EnvFilter;
 
 /// The default value for the `RUST_LOG` environment variable if one isn't specified otherwise.
@@ -10,15 +16,41 @@ pub const DEFAULT_RUST_LOG: &'static str = "tokio_reactor=info,\
      near-rust-allocator-proxy=info,\
      warn";
 
+/// The resource representing a registered subscriber.
+///
+/// Once dropped, the subscriber is unregistered, and the output is flushed. Any messages output
+/// after this value is dropped will be delivered to a previously active subscriber, if any.
+#[allow(dead_code)] // Fields are never read
+pub struct DefaultSubcriberGuard {
+    // NB: the field order matters here. I would've used `ManuallyDrop` to indicate this
+    // particularity, but somebody decided at some point that doing so is unconventional Rust and
+    // that implicit is better than explicit.
+    //
+    // We must first drop the `subscriber_guard` so that no new messages are delivered to this
+    // subscriber while we take care of flushing the messages already in queue. If dropped the
+    // other way around, the events/spans generated while the subscriber drop guard runs would be
+    // lost.
+    subscriber_guard: tracing::subscriber::DefaultGuard,
+    writer_guard: tracing_appender::non_blocking::WorkerGuard,
+}
+
 /// Run the code with a default subscriber set to the option appropriate for the NEAR code.
-pub fn with_default_subscriber<R, F>(log_filter: EnvFilter, run: F) -> R
-where
-    F: FnOnce() -> R,
-{
+///
+/// This will override any subscribers set until now, and will be in effect until the value
+/// returned by this function goes out of scope.
+///
+/// # Example
+///
+/// ```rust
+/// let filter = near_o11y::EnvFilterBuilder::from_env().finish();
+/// let _subscriber = near_o11y::default_subscriber(filter);
+/// near_o11y::tracing::info!(message = "Still a lot of work remains to make it proper o11y");
+/// ```
+pub fn default_subscriber(log_filter: EnvFilter) -> DefaultSubcriberGuard {
     // Do not lock the `stderr` here to allow for things like `dbg!()` work during development.
     let stderr = std::io::stderr();
     let lined_stderr = std::io::LineWriter::new(stderr);
-    let (writer, _writer_guard) = tracing_appender::non_blocking(lined_stderr);
+    let (writer, writer_guard) = tracing_appender::non_blocking(lined_stderr);
     let subscriber = tracing_subscriber::FmtSubscriber::builder()
         .with_span_events(
             tracing_subscriber::fmt::format::FmtSpan::ENTER
@@ -27,5 +59,58 @@ where
         .with_env_filter(log_filter)
         .with_writer(writer)
         .finish();
-    tracing::subscriber::with_default(subscriber, run)
+    DefaultSubcriberGuard {
+        subscriber_guard: tracing::subscriber::set_default(subscriber),
+        writer_guard,
+    }
+}
+
+pub struct EnvFilterBuilder<'a> {
+    rust_log: Cow<'a, str>,
+    verbose: Option<Cow<'a, str>>,
+}
+
+impl<'a> EnvFilterBuilder<'a> {
+    /// Create the `EnvFilter` from the environment variable or the [`DEFAULT_RUST_LOG`] value if
+    /// the environment is not set.
+    pub fn from_env() -> Self {
+        Self::new(
+            std::env::var("RUST_LOG").map(Cow::Owned).unwrap_or(Cow::Borrowed(DEFAULT_RUST_LOG)),
+        )
+    }
+
+    /// Specify an exact `RUST_LOG` value to use.
+    ///
+    /// This method will not inspect the environment variable.
+    pub fn new<S: Into<Cow<'a, str>>>(rust_log: S) -> Self {
+        Self { rust_log: rust_log.into(), verbose: None }
+    }
+
+    /// Make the produced [`EnvFilter`] verbose.
+    ///
+    /// If the `module` string is empty, all targets will log debug output. Otherwise only the
+    /// specified target will log the debug output.
+    pub fn verbose<S: Into<Cow<'a, str>>>(&mut self, target: Option<S>) -> &mut Self {
+        self.verbose = target.map(Into::into);
+        self
+    }
+
+    /// Construct an [`EnvFilter`] as configured.
+    pub fn finish(self) -> EnvFilter {
+        let mut env_filter = EnvFilter::new(self.rust_log);
+        if let Some(module) = self.verbose {
+            env_filter = env_filter
+                .add_directive("cranelift_codegen=warn".parse().expect("parse directive"))
+                .add_directive("h2=warn".parse().expect("parse directive"))
+                .add_directive("trust_dns_resolver=warn".parse().expect("parse_directive"))
+                .add_directive("trust_dns_proto=warn".parse().expect("parse_directive"));
+            env_filter = if module.is_empty() {
+                env_filter.add_directive(tracing::Level::DEBUG.into())
+            } else {
+                let directive = format!("{}=debug", module).parse().expect("parse directive");
+                env_filter.add_directive(directive)
+            };
+        }
+        env_filter
+    }
 }

--- a/core/o11y/src/lib.rs
+++ b/core/o11y/src/lib.rs
@@ -90,7 +90,7 @@ impl<'a> EnvFilterBuilder<'a> {
     ///
     /// If the `module` string is empty, all targets will log debug output. Otherwise only the
     /// specified target will log the debug output.
-    pub fn verbose<S: Into<Cow<'a, str>>>(&mut self, target: Option<S>) -> &mut Self {
+    pub fn verbose<S: Into<Cow<'a, str>>>(mut self, target: Option<S>) -> Self {
         self.verbose = target.map(Into::into);
         self
     }

--- a/core/o11y/src/lib.rs
+++ b/core/o11y/src/lib.rs
@@ -1,0 +1,31 @@
+use tracing_subscriber::EnvFilter;
+
+/// The default value for the `RUST_LOG` environment variable if one isn't specified otherwise.
+pub const DEFAULT_RUST_LOG: &'static str = "tokio_reactor=info,\
+     near=info,\
+     stats=info,\
+     telemetry=info,\
+     delay_detector=info,\
+     near-performance-metrics=info,\
+     near-rust-allocator-proxy=info,\
+     warn";
+
+/// Run the code with a default subscriber set to the option appropriate for the NEAR code.
+pub fn with_default_subscriber<R, F>(log_filter: EnvFilter, run: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    // Do not lock the `stderr` here to allow for things like `dbg!()` work during development.
+    let stderr = std::io::stderr();
+    let lined_stderr = std::io::LineWriter::new(stderr);
+    let (writer, _writer_guard) = tracing_appender::non_blocking(lined_stderr);
+    let subscriber = tracing_subscriber::FmtSubscriber::builder()
+        .with_span_events(
+            tracing_subscriber::fmt::format::FmtSpan::ENTER
+                | tracing_subscriber::fmt::format::FmtSpan::CLOSE,
+        )
+        .with_env_filter(log_filter)
+        .with_writer(writer)
+        .finish();
+    tracing::subscriber::with_default(subscriber, run)
+}

--- a/deny.toml
+++ b/deny.toml
@@ -96,5 +96,10 @@ skip = [
     { name = "rustc_version", version = "=0.2.3" },
 
     # paperclip-macros, strum_macros, walrus-macro depend on this while clap3.1.6 uses heck=0.4.0
-    { name = "heck", version = "=0.3.3" }
+    { name = "heck", version = "=0.3.3" },
+
+    # actix-http depends on an old version
+    { name = "itoa", version = "=0.4.8" },
+    { name = "time", version = "=0.2.27" },
+
 ]

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -31,6 +31,7 @@ near-primitives = { path = "../core/primitives" }
 near-performance-metrics = { path = "../utils/near-performance-metrics" }
 near-state-viewer = { path = "../tools/state-viewer", package = "state-viewer" }
 near-store = { path = "../core/store" }
+near-o11y = { path = "../core/o11y" }
 
 [build-dependencies]
 anyhow = "1.0.51"

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -16,7 +16,6 @@ name = "neard"
 clap = { version = "3.1.6", features = ["derive"] }
 actix = "=0.11.0-beta.2"
 tracing = "0.1.13"
-tracing-subscriber = "0.2.4"
 openssl-probe = "0.1.2"
 near-rust-allocator-proxy = { version = "0.4", optional = true }
 once_cell = "1.5.2"

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -6,9 +6,9 @@ use near_primitives::types::{Gas, NumSeats, NumShards};
 use near_state_viewer::StateViewerSubCommand;
 use near_store::db::RocksDB;
 use nearcore::get_store_path;
+use std::fs;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
-use std::{env, fs, io};
 use tokio::sync::oneshot;
 use tracing::{debug, error, info, warn};
 
@@ -31,7 +31,7 @@ impl NeardCmd {
         // Sandbox node can log to sandbox logging target via sandbox_debug_log host function.
         // This is hidden by default so we enable it for sandbox node.
         let env_filter = if cfg!(feature = "sandbox") {
-            env_filter = env_filter.add_directive("sandbox=debug".parse().unwrap());
+            env_filter.add_directive("sandbox=debug".parse().unwrap())
         } else {
             env_filter
         };

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -47,7 +47,7 @@ impl NeardCmd {
         #[cfg(feature = "test_features")]
         {
             error!("THIS IS A NODE COMPILED WITH ADVERSARIAL BEHAVIORS. DO NOT USE IN PRODUCTION.");
-            if env::var("ADVERSARY_CONSENT").unwrap_or_default() != "1" {
+            if std::env::var("ADVERSARY_CONSENT").unwrap_or_default() != "1" {
                 error!(
                     "To run a node with adversarial behavior enabled give your consent \
                             by setting an environment variable:"

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -27,54 +27,96 @@ pub(super) struct NeardCmd {
 impl NeardCmd {
     pub(super) fn parse_and_run() {
         let neard_cmd = Self::parse();
-        neard_cmd.opts.init();
-        info!(target: "neard", "Version: {}, Build: {}, Latest Protocol: {}", crate::NEARD_VERSION, crate::NEARD_BUILD, near_primitives::version::PROTOCOL_VERSION);
+        let verbose = neard_cmd.opts.verbose.as_deref();
 
-        #[cfg(feature = "test_features")]
-        {
-            error!("THIS IS A NODE COMPILED WITH ADVERSARIAL BEHAVIORS. DO NOT USE IN PRODUCTION.");
+        let rust_log = env::var("RUST_LOG");
+        let rust_log = rust_log.as_ref().map(String::as_str).unwrap_or(near_o11y::DEFAULT_RUST_LOG);
+        let mut env_filter = EnvFilter::new(rust_log);
+        if let Some(module) = verbose {
+            env_filter = env_filter
+                .add_directive("cranelift_codegen=warn".parse().unwrap())
+                .add_directive("h2=warn".parse().unwrap())
+                .add_directive("trust_dns_resolver=warn".parse().unwrap())
+                .add_directive("trust_dns_proto=warn".parse().unwrap());
 
-            if env::var("ADVERSARY_CONSENT").unwrap_or_default() != "1" {
-                error!("To run a node with adversarial behavior enabled give your consent by setting variable:");
-                error!("ADVERSARY_CONSENT=1");
-                std::process::exit(1);
+            if module.is_empty() {
+                env_filter = env_filter.add_directive(LevelFilter::DEBUG.into());
+            } else {
+                env_filter = env_filter.add_directive(format!("{}=debug", module).parse().unwrap());
             }
         }
-
-        let home_dir = neard_cmd.opts.home;
-        let genesis_validation = if neard_cmd.opts.unsafe_fast_startup {
-            GenesisValidationMode::UnsafeFast
-        } else {
-            GenesisValidationMode::Full
-        };
-
-        match neard_cmd.subcmd {
-            NeardSubCommand::Init(cmd) => cmd.run(&home_dir),
-            NeardSubCommand::Localnet(cmd) => cmd.run(&home_dir),
-            NeardSubCommand::Testnet(cmd) => {
-                warn!("The 'testnet' command has been renamed to 'localnet' and will be removed in the future");
-                cmd.run(&home_dir);
-            }
-            NeardSubCommand::Run(cmd) => cmd.run(&home_dir, genesis_validation),
-
-            // TODO(mina86): Remove the command in Q3 2022.
-            NeardSubCommand::UnsafeResetData => {
-                let store_path = get_store_path(&home_dir);
-                unsafe_reset("unsafe_reset_data", &store_path, "data", "<near-home-dir>/data");
-            }
-            // TODO(mina86): Remove the command in Q3 2022.
-            NeardSubCommand::UnsafeResetAll => {
-                unsafe_reset("unsafe_reset_all", &home_dir, "data and config", "<near-home-dir>");
-            }
-
-            NeardSubCommand::StateViewer(cmd) => {
-                cmd.run(&home_dir, genesis_validation);
-            }
-
-            NeardSubCommand::RecompressStorage(cmd) => {
-                cmd.run(&home_dir);
-            }
+        if cfg!(feature = "sandbox") {
+            // Sandbox node can log to sandbox logging target via sandbox_debug_log host function.
+            // This is hidden by default so we enable it for sandbox node.
+            env_filter = env_filter.add_directive("sandbox=debug".parse().unwrap());
         }
+
+        near_o11y::with_default_subscriber(env_filter, || {
+            info!(
+                target: "neard",
+                version = crate::NEARD_VERSION,
+                build = crate::NEARD_BUILD,
+                latest_protocol = near_primitives::version::PROTOCOL_VERSION
+            );
+
+            #[cfg(feature = "test_features")]
+            {
+                error!(
+                    "THIS IS A NODE COMPILED WITH ADVERSARIAL BEHAVIORS. DO NOT USE IN PRODUCTION."
+                );
+                if env::var("ADVERSARY_CONSENT").unwrap_or_default() != "1" {
+                    error!(
+                        "To run a node with adversarial behavior enabled give your consent \
+                            by setting an environment variable:"
+                    );
+                    error!("ADVERSARY_CONSENT=1");
+                    std::process::exit(1);
+                }
+            }
+
+            let home_dir = neard_cmd.opts.home;
+            let genesis_validation = if neard_cmd.opts.unsafe_fast_startup {
+                GenesisValidationMode::UnsafeFast
+            } else {
+                GenesisValidationMode::Full
+            };
+
+            match neard_cmd.subcmd {
+                NeardSubCommand::Init(cmd) => cmd.run(&home_dir),
+                NeardSubCommand::Localnet(cmd) => cmd.run(&home_dir),
+                NeardSubCommand::Testnet(cmd) => {
+                    warn!(
+                        "The 'testnet' command has been renamed to 'localnet' \
+                           and will be removed in the future"
+                    );
+                    cmd.run(&home_dir);
+                }
+                NeardSubCommand::Run(cmd) => cmd.run(&home_dir, genesis_validation),
+
+                // TODO(mina86): Remove the command in Q3 2022.
+                NeardSubCommand::UnsafeResetData => {
+                    let store_path = get_store_path(&home_dir);
+                    unsafe_reset("unsafe_reset_data", &store_path, "data", "<near-home-dir>/data");
+                }
+                // TODO(mina86): Remove the command in Q3 2022.
+                NeardSubCommand::UnsafeResetAll => {
+                    unsafe_reset(
+                        "unsafe_reset_all",
+                        &home_dir,
+                        "data and config",
+                        "<near-home-dir>",
+                    );
+                }
+
+                NeardSubCommand::StateViewer(cmd) => {
+                    cmd.run(&home_dir, genesis_validation);
+                }
+
+                NeardSubCommand::RecompressStorage(cmd) => {
+                    cmd.run(&home_dir);
+                }
+            }
+        });
     }
 }
 
@@ -100,12 +142,6 @@ struct NeardOpts {
     /// Let's you start `neard` slightly faster.
     #[clap(long)]
     pub unsafe_fast_startup: bool,
-}
-
-impl NeardOpts {
-    fn init(&self) {
-        init_logging(self.verbose.as_deref());
-    }
 }
 
 #[derive(Parser)]
@@ -444,47 +480,6 @@ impl LocalnetCmd {
             false,
         );
     }
-}
-
-fn init_logging(verbose: Option<&str>) {
-    const DEFAULT_RUST_LOG: &'static str =
-        "tokio_reactor=info,near=info,stats=info,telemetry=info,\
-         delay_detector=info,near-performance-metrics=info,\
-         near-rust-allocator-proxy=info,warn";
-
-    let rust_log = env::var("RUST_LOG");
-    let rust_log = rust_log.as_ref().map(String::as_str).unwrap_or(DEFAULT_RUST_LOG);
-    let mut env_filter = EnvFilter::new(rust_log);
-
-    if let Some(module) = verbose {
-        env_filter = env_filter
-            .add_directive("cranelift_codegen=warn".parse().unwrap())
-            .add_directive("cranelift_codegen=warn".parse().unwrap())
-            .add_directive("h2=warn".parse().unwrap())
-            .add_directive("trust_dns_resolver=warn".parse().unwrap())
-            .add_directive("trust_dns_proto=warn".parse().unwrap());
-
-        if module.is_empty() {
-            env_filter = env_filter.add_directive(LevelFilter::DEBUG.into());
-        } else {
-            env_filter = env_filter.add_directive(format!("{}=debug", module).parse().unwrap());
-        }
-    }
-
-    if cfg!(feature = "sandbox") {
-        // Sandbox node can log to sandbox logging target via sandbox_debug_log host function.
-        // This is hidden by default so we enable it for sandbox node.
-        env_filter = env_filter.add_directive("sandbox=debug".parse().unwrap());
-    }
-
-    tracing_subscriber::fmt::Subscriber::builder()
-        .with_span_events(
-            tracing_subscriber::fmt::format::FmtSpan::ENTER
-                | tracing_subscriber::fmt::format::FmtSpan::CLOSE,
-        )
-        .with_env_filter(env_filter)
-        .with_writer(io::stderr)
-        .init();
 }
 
 #[derive(Args)]

--- a/test-utils/logger/Cargo.toml
+++ b/test-utils/logger/Cargo.toml
@@ -9,4 +9,4 @@ edition = "2021"
 
 [dependencies]
 tracing = "0.1.13"
-tracing-subscriber = "0.2.4"
+near-o11y = { path = "../../core/o11y" }

--- a/test-utils/logger/src/lib.rs
+++ b/test-utils/logger/src/lib.rs
@@ -1,6 +1,6 @@
 mod tracing_capture;
 
-use tracing_subscriber::EnvFilter;
+use near_o11y::tracing_subscriber::{fmt as subscriber_fmt, EnvFilter};
 
 pub use tracing_capture::TracingCapture;
 
@@ -17,10 +17,10 @@ fn setup_subscriber_from_filter(mut env_filter: EnvFilter) {
         }
     }
 
-    let _ = tracing_subscriber::fmt::Subscriber::builder()
-        .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
+    let _ = subscriber_fmt::Subscriber::builder()
+        .with_span_events(subscriber_fmt::format::FmtSpan::CLOSE)
         .with_env_filter(env_filter)
-        .with_writer(tracing_subscriber::fmt::TestWriter::new())
+        .with_writer(subscriber_fmt::TestWriter::new())
         .try_init();
 }
 

--- a/tools/chainsync-loadtest/Cargo.toml
+++ b/tools/chainsync-loadtest/Cargo.toml
@@ -16,8 +16,7 @@ name = "chainsync-loadtest"
 clap = { version = "3.1.6", features = ["derive"] }
 actix = "=0.11.0-beta.2"
 parking_lot = "0.11.2"
-tracing = "0.1.13"
-tracing-subscriber = "0.2.4"
+tracing-subscriber = "0.3.9"
 openssl-probe = "0.1.4"
 futures = "0.3"
 anyhow = "1.0.55"
@@ -33,6 +32,7 @@ near-store = { path = "../../core/store" }
 nearcore = { path = "../../nearcore" }
 near-network = { path = "../../chain/network" }
 near-network-primitives = { path = "../../chain/network-primitives" }
+near-o11y = { path = "../../core/o11y" }
 
 [features]
 [package.metadata.workspaces]

--- a/tools/chainsync-loadtest/Cargo.toml
+++ b/tools/chainsync-loadtest/Cargo.toml
@@ -16,7 +16,6 @@ name = "chainsync-loadtest"
 clap = { version = "3.1.6", features = ["derive"] }
 actix = "=0.11.0-beta.2"
 parking_lot = "0.11.2"
-tracing-subscriber = "0.3.9"
 openssl-probe = "0.1.4"
 futures = "0.3"
 anyhow = "1.0.55"

--- a/tools/chainsync-loadtest/src/main.rs
+++ b/tools/chainsync-loadtest/src/main.rs
@@ -2,7 +2,6 @@ mod concurrency;
 mod fetch_chain;
 mod network;
 
-use std::io;
 use std::sync::Arc;
 
 use actix::{Actor, Arbiter};
@@ -131,8 +130,9 @@ impl Cmd {
 }
 
 fn main() {
-    let env_filter =
-        near_o11y::EnvFilterBuilder::from_env().finish().add_directive(LevelFilter::INFO.into());
+    let env_filter = near_o11y::EnvFilterBuilder::from_env()
+        .finish()
+        .add_directive(near_o11y::tracing::Level::INFO.into());
     let _subscriber = near_o11y::default_subscriber(env_filter);
     let orig_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |panic_info| {

--- a/tools/indexer/example/Cargo.toml
+++ b/tools/indexer/example/Cargo.toml
@@ -14,7 +14,6 @@ openssl-probe = "0.1.2"
 serde_json = "1.0.55"
 tokio = { version = "1.1", features = ["sync"] }
 tracing = "0.1.13"
-tracing-subscriber = "0.2.4"
 anyhow = "1.0"
 
 near-indexer = { path = "../../../chain/indexer" }

--- a/tools/indexer/example/Cargo.toml
+++ b/tools/indexer/example/Cargo.toml
@@ -18,3 +18,4 @@ tracing-subscriber = "0.2.4"
 anyhow = "1.0"
 
 near-indexer = { path = "../../../chain/indexer" }
+near-o11y = { path = "../../../core/o11y" }

--- a/tools/indexer/example/src/configs.rs
+++ b/tools/indexer/example/src/configs.rs
@@ -2,8 +2,6 @@ use clap::Parser;
 
 use near_indexer::near_primitives::types::Gas;
 
-use tracing_subscriber::EnvFilter;
-
 /// NEAR Indexer Example
 /// Watches for stream of blocks from the chain
 #[derive(Parser, Debug)]

--- a/tools/indexer/example/src/configs.rs
+++ b/tools/indexer/example/src/configs.rs
@@ -64,16 +64,6 @@ pub(crate) struct InitConfigArgs {
     pub max_gas_burnt_view: Option<Gas>,
 }
 
-pub(crate) fn init_logging() {
-    let env_filter = EnvFilter::new(
-        "nearcore=info,indexer_example=info,tokio_reactor=info,near=info,stats=info,telemetry=info,indexer=info,near-performance-metrics=info",
-    );
-    tracing_subscriber::fmt::Subscriber::builder()
-        .with_env_filter(env_filter)
-        .with_writer(std::io::stderr)
-        .init();
-}
-
 impl From<InitConfigArgs> for near_indexer::InitConfigArgs {
     fn from(config_args: InitConfigArgs) -> Self {
         Self {

--- a/tools/indexer/example/src/main.rs
+++ b/tools/indexer/example/src/main.rs
@@ -260,7 +260,7 @@ fn main() -> Result<()> {
     // We use it to automatically search the for root certificates to perform HTTPS calls
     // (sending telemetry and downloading genesis)
     openssl_probe::init_ssl_cert_env_vars();
-    let env_filter = EnvFilter::new(
+    let env_filter = near_o11y::tracing_subscriber::EnvFilter::new(
         "nearcore=info,indexer_example=info,tokio_reactor=info,near=info,\
          stats=info,telemetry=info,indexer=info,near-performance-metrics=info",
     );

--- a/tools/restaked/Cargo.toml
+++ b/tools/restaked/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "3.1.6", features = ["derive"] }
-clap = "2.33.0"
 
 near-crypto = { path = "../../core/crypto" }
 near-primitives = { path = "../../core/primitives" }

--- a/tools/restaked/Cargo.toml
+++ b/tools/restaked/Cargo.toml
@@ -9,13 +9,14 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "3.1.6", features = ["derive"] }
-tracing = "0.1.13"
-tracing-subscriber = "0.2.4"
+clap = "2.33.0"
+tracing-subscriber = "0.3.9"
 
 near-crypto = { path = "../../core/crypto" }
 near-primitives = { path = "../../core/primitives" }
 near-jsonrpc-client = { path = "../../chain/jsonrpc/client" }
 nearcore = { path = "../../nearcore" }
+near-o11y = { path = "../../core/o11y" }
 
 integration-tests = { path = "../../integration-tests" }
 

--- a/tools/restaked/Cargo.toml
+++ b/tools/restaked/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2021"
 [dependencies]
 clap = { version = "3.1.6", features = ["derive"] }
 clap = "2.33.0"
-tracing-subscriber = "0.3.9"
 
 near-crypto = { path = "../../core/crypto" }
 near-primitives = { path = "../../core/primitives" }

--- a/tools/restaked/src/main.rs
+++ b/tools/restaked/src/main.rs
@@ -3,11 +3,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use clap::{Arg, Command};
-use tracing::metadata::LevelFilter;
-use tracing::{error, info};
-use tracing_subscriber::EnvFilter;
 
 use near_crypto::{InMemorySigner, KeyFile};
+use near_o11y::tracing::{error, info};
 use near_primitives::views::CurrentEpochValidatorInfo;
 use nearcore::config::{Config, BLOCK_PRODUCER_KICKOUT_THRESHOLD, CONFIG_FILENAME};
 use nearcore::get_default_home;
@@ -24,10 +22,10 @@ fn maybe_kicked_out(validator_info: &CurrentEpochValidatorInfo) -> bool {
 }
 
 fn main() {
-    let env_filter = EnvFilter::default().add_directive(LevelFilter::DEBUG.into());
-    near_o11y::with_default_subscriber(env_filter, || {
-        let default_home = get_default_home();
-        let matches = Command::new("Key-pairs generator")
+    let filter = near_o11y::EnvFilterBuilder::from_env().verbose(Some("")).finish();
+    let _subscriber = near_o11y::default_subscriber(filter);
+    let default_home = get_default_home();
+    let matches = Command::new("Key-pairs generator")
         .about(
             "Continuously checking the node and executes staking transaction if node is kicked out",
         )
@@ -61,73 +59,69 @@ fn main() {
         )
         .get_matches();
 
-        let home_dir = matches.value_of("home").map(Path::new).unwrap();
-        let wait_period = matches
-            .value_of("wait-period")
-            .map(|s| s.parse().expect("Wait period must be a number"))
-            .unwrap();
-        let rpc_url = matches.value_of("rpc-url").unwrap();
-        let stake_amount = matches
-            .value_of("stake-amount")
-            .map(|s| s.parse().expect("Stake amount must be a number"))
-            .unwrap();
+    let home_dir = matches.value_of("home").map(Path::new).unwrap();
+    let wait_period = matches
+        .value_of("wait-period")
+        .map(|s| s.parse().expect("Wait period must be a number"))
+        .unwrap();
+    let rpc_url = matches.value_of("rpc-url").unwrap();
+    let stake_amount = matches
+        .value_of("stake-amount")
+        .map(|s| s.parse().expect("Stake amount must be a number"))
+        .unwrap();
 
-        let config = Config::from_file(&home_dir.join(CONFIG_FILENAME)).expect("can't load config");
-        let key_file = KeyFile::from_file(&home_dir.join(&config.validator_key_file));
-        // Support configuring if there is another key.
-        let signer = InMemorySigner::from_file(&home_dir.join(&config.validator_key_file));
-        let account_id = signer.account_id.clone();
-        let mut last_stake_amount = stake_amount;
+    let config = Config::from_file(&home_dir.join(CONFIG_FILENAME)).expect("can't load config");
+    let key_file = KeyFile::from_file(&home_dir.join(&config.validator_key_file));
+    // Support configuring if there is another key.
+    let signer = InMemorySigner::from_file(&home_dir.join(&config.validator_key_file));
+    let account_id = signer.account_id.clone();
+    let mut last_stake_amount = stake_amount;
 
-        assert_eq!(
-            signer.account_id, key_file.account_id,
-            "Only can stake for the same account as given signer key"
-        );
+    assert_eq!(
+        signer.account_id, key_file.account_id,
+        "Only can stake for the same account as given signer key"
+    );
 
-        let user = RpcUser::new(rpc_url, account_id.clone(), Arc::new(signer));
-        loop {
-            let validators = user.validators(None).unwrap();
-            // Check:
-            //  - don't already have a proposal
-            //  - too many missing blocks in current validators
-            //  - missing in next validators
-            if validators
-                .current_proposals
-                .iter()
-                .any(|proposal| proposal.account_id() == &account_id)
-            {
-                continue;
-            }
-            let mut restake = false;
-            validators
-                .current_validators
-                .iter()
-                .filter(|validator_info| validator_info.account_id == account_id)
-                .last()
-                .map(|validator_info| {
-                    last_stake_amount = validator_info.stake;
-                    if maybe_kicked_out(validator_info) {
-                        restake = true;
-                    }
-                });
-            restake |= !validators
-                .next_validators
-                .iter()
-                .any(|validator_info| validator_info.account_id == account_id);
-            if restake {
-                // Already kicked out or getting kicked out.
-                let amount = if stake_amount == 0 { last_stake_amount } else { stake_amount };
-                info!(
-                    target: "restaked",
-                    "Sending staking transaction {} -> {}", key_file.account_id, amount
-                );
-                if let Err(err) =
-                    user.stake(key_file.account_id.clone(), key_file.public_key.clone(), amount)
-                {
-                    error!(target: "restaked", "Failed to send staking transaction: {}", err);
-                }
-            }
-            std::thread::sleep(Duration::from_secs(wait_period));
+    let user = RpcUser::new(rpc_url, account_id.clone(), Arc::new(signer));
+    loop {
+        let validators = user.validators(None).unwrap();
+        // Check:
+        //  - don't already have a proposal
+        //  - too many missing blocks in current validators
+        //  - missing in next validators
+        if validators.current_proposals.iter().any(|proposal| proposal.account_id() == &account_id)
+        {
+            continue;
         }
-    });
+        let mut restake = false;
+        validators
+            .current_validators
+            .iter()
+            .filter(|validator_info| validator_info.account_id == account_id)
+            .last()
+            .map(|validator_info| {
+                last_stake_amount = validator_info.stake;
+                if maybe_kicked_out(validator_info) {
+                    restake = true;
+                }
+            });
+        restake |= !validators
+            .next_validators
+            .iter()
+            .any(|validator_info| validator_info.account_id == account_id);
+        if restake {
+            // Already kicked out or getting kicked out.
+            let amount = if stake_amount == 0 { last_stake_amount } else { stake_amount };
+            info!(
+                target: "restaked",
+                "Sending staking transaction {} -> {}", key_file.account_id, amount
+            );
+            if let Err(err) =
+                user.stake(key_file.account_id.clone(), key_file.public_key.clone(), amount)
+            {
+                error!(target: "restaked", "Failed to send staking transaction: {}", err);
+            }
+        }
+        std::thread::sleep(Duration::from_secs(wait_period));
+    }
 }

--- a/tools/restaked/src/main.rs
+++ b/tools/restaked/src/main.rs
@@ -24,13 +24,10 @@ fn maybe_kicked_out(validator_info: &CurrentEpochValidatorInfo) -> bool {
 }
 
 fn main() {
-    tracing_subscriber::fmt::Subscriber::builder()
-        .with_env_filter(EnvFilter::default().add_directive(LevelFilter::DEBUG.into()))
-        .with_writer(std::io::stderr)
-        .init();
-
-    let default_home = get_default_home();
-    let matches = Command::new("Key-pairs generator")
+    let env_filter = EnvFilter::default().add_directive(LevelFilter::DEBUG.into());
+    near_o11y::with_default_subscriber(env_filter, || {
+        let default_home = get_default_home();
+        let matches = Command::new("Key-pairs generator")
         .about(
             "Continuously checking the node and executes staking transaction if node is kicked out",
         )
@@ -64,66 +61,73 @@ fn main() {
         )
         .get_matches();
 
-    let home_dir = matches.value_of("home").map(Path::new).unwrap();
-    let wait_period = matches
-        .value_of("wait-period")
-        .map(|s| s.parse().expect("Wait period must be a number"))
-        .unwrap();
-    let rpc_url = matches.value_of("rpc-url").unwrap();
-    let stake_amount = matches
-        .value_of("stake-amount")
-        .map(|s| s.parse().expect("Stake amount must be a number"))
-        .unwrap();
+        let home_dir = matches.value_of("home").map(Path::new).unwrap();
+        let wait_period = matches
+            .value_of("wait-period")
+            .map(|s| s.parse().expect("Wait period must be a number"))
+            .unwrap();
+        let rpc_url = matches.value_of("rpc-url").unwrap();
+        let stake_amount = matches
+            .value_of("stake-amount")
+            .map(|s| s.parse().expect("Stake amount must be a number"))
+            .unwrap();
 
-    let config = Config::from_file(&home_dir.join(CONFIG_FILENAME)).expect("can't load config");
-    let key_file = KeyFile::from_file(&home_dir.join(&config.validator_key_file));
-    // Support configuring if there is another key.
-    let signer = InMemorySigner::from_file(&home_dir.join(&config.validator_key_file));
-    let account_id = signer.account_id.clone();
-    let mut last_stake_amount = stake_amount;
+        let config = Config::from_file(&home_dir.join(CONFIG_FILENAME)).expect("can't load config");
+        let key_file = KeyFile::from_file(&home_dir.join(&config.validator_key_file));
+        // Support configuring if there is another key.
+        let signer = InMemorySigner::from_file(&home_dir.join(&config.validator_key_file));
+        let account_id = signer.account_id.clone();
+        let mut last_stake_amount = stake_amount;
 
-    assert_eq!(
-        signer.account_id, key_file.account_id,
-        "Only can stake for the same account as given signer key"
-    );
+        assert_eq!(
+            signer.account_id, key_file.account_id,
+            "Only can stake for the same account as given signer key"
+        );
 
-    let user = RpcUser::new(rpc_url, account_id.clone(), Arc::new(signer));
-    loop {
-        let validators = user.validators(None).unwrap();
-        // Check:
-        //  - don't already have a proposal
-        //  - too many missing blocks in current validators
-        //  - missing in next validators
-        if validators.current_proposals.iter().any(|proposal| proposal.account_id() == &account_id)
-        {
-            continue;
-        }
-        let mut restake = false;
-        validators
-            .current_validators
-            .iter()
-            .filter(|validator_info| validator_info.account_id == account_id)
-            .last()
-            .map(|validator_info| {
-                last_stake_amount = validator_info.stake;
-                if maybe_kicked_out(validator_info) {
-                    restake = true;
-                }
-            });
-        restake |= !validators
-            .next_validators
-            .iter()
-            .any(|validator_info| validator_info.account_id == account_id);
-        if restake {
-            // Already kicked out or getting kicked out.
-            let amount = if stake_amount == 0 { last_stake_amount } else { stake_amount };
-            info!(target: "restaked", "Sending staking transaction {} -> {}", key_file.account_id, amount);
-            if let Err(err) =
-                user.stake(key_file.account_id.clone(), key_file.public_key.clone(), amount)
+        let user = RpcUser::new(rpc_url, account_id.clone(), Arc::new(signer));
+        loop {
+            let validators = user.validators(None).unwrap();
+            // Check:
+            //  - don't already have a proposal
+            //  - too many missing blocks in current validators
+            //  - missing in next validators
+            if validators
+                .current_proposals
+                .iter()
+                .any(|proposal| proposal.account_id() == &account_id)
             {
-                error!(target: "restaked", "Failed to send staking transaction: {}", err);
+                continue;
             }
+            let mut restake = false;
+            validators
+                .current_validators
+                .iter()
+                .filter(|validator_info| validator_info.account_id == account_id)
+                .last()
+                .map(|validator_info| {
+                    last_stake_amount = validator_info.stake;
+                    if maybe_kicked_out(validator_info) {
+                        restake = true;
+                    }
+                });
+            restake |= !validators
+                .next_validators
+                .iter()
+                .any(|validator_info| validator_info.account_id == account_id);
+            if restake {
+                // Already kicked out or getting kicked out.
+                let amount = if stake_amount == 0 { last_stake_amount } else { stake_amount };
+                info!(
+                    target: "restaked",
+                    "Sending staking transaction {} -> {}", key_file.account_id, amount
+                );
+                if let Err(err) =
+                    user.stake(key_file.account_id.clone(), key_file.public_key.clone(), amount)
+                {
+                    error!(target: "restaked", "Failed to send staking transaction: {}", err);
+                }
+            }
+            std::thread::sleep(Duration::from_secs(wait_period));
         }
-        std::thread::sleep(Duration::from_secs(wait_period));
-    }
+    });
 }

--- a/tools/storage-usage-delta-calculator/Cargo.toml
+++ b/tools/storage-usage-delta-calculator/Cargo.toml
@@ -17,3 +17,4 @@ tracing-subscriber = "0.2.4"
 near-chain-configs = { path = "../../core/chain-configs" }
 near-primitives = { path = "../../core/primitives" }
 node-runtime = { path = "../../runtime/runtime" }
+near-o11y = { path = "../../core/o11y" }

--- a/tools/storage-usage-delta-calculator/Cargo.toml
+++ b/tools/storage-usage-delta-calculator/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2021"
 [dependencies]
 serde_json = "1.0"
 tracing = "0.1.13"
-tracing-subscriber = "0.2.4"
 
 near-chain-configs = { path = "../../core/chain-configs" }
 near-primitives = { path = "../../core/primitives" }

--- a/tools/storage-usage-delta-calculator/src/main.rs
+++ b/tools/storage-usage-delta-calculator/src/main.rs
@@ -11,7 +11,7 @@ use tracing::debug;
 /// run 'neard --home ~/.near/mainnet/ view_state dump_state'
 /// to get it
 fn main() -> std::io::Result<()> {
-    let env_filter = EnvFilterBuilder::from_env().verbose(Some("")).finish();
+    let env_filter = near_o11y::EnvFilterBuilder::from_env().verbose(Some("")).finish();
     let _subscriber = near_o11y::default_subscriber(env_filter);
     debug!(target: "storage-calculator", "Start");
 

--- a/tools/storage-usage-delta-calculator/src/main.rs
+++ b/tools/storage-usage-delta-calculator/src/main.rs
@@ -5,39 +5,36 @@ use near_primitives::version::PROTOCOL_VERSION;
 use node_runtime::Runtime;
 use std::fs::File;
 use tracing::debug;
-use tracing::metadata::LevelFilter;
-use tracing_subscriber::EnvFilter;
 
 /// Calculates delta between actual storage usage and one saved in state
 /// output.json should contain dump of current state,
 /// run 'neard --home ~/.near/mainnet/ view_state dump_state'
 /// to get it
 fn main() -> std::io::Result<()> {
-    let env_filter = EnvFilter::default().add_directive(LevelFilter::DEBUG.into());
-    near_o11y::with_default_subscriber(env_filter, || {
-        debug!(target: "storage-calculator", "Start");
+    let env_filter = EnvFilterBuilder::from_env().verbose(Some("")).finish();
+    let _subscriber = near_o11y::default_subscriber(env_filter);
+    debug!(target: "storage-calculator", "Start");
 
-        let genesis = Genesis::from_file("output.json", GenesisValidationMode::Full);
-        debug!(target: "storage-calculator", "Genesis read");
+    let genesis = Genesis::from_file("output.json", GenesisValidationMode::Full);
+    debug!(target: "storage-calculator", "Genesis read");
 
-        let config_store = RuntimeConfigStore::new(None);
-        let config = config_store.get_config(PROTOCOL_VERSION);
-        let storage_usage = Runtime::new().compute_storage_usage(&genesis.records.0[..], config);
-        debug!(target: "storage-calculator", "Storage usage calculated");
+    let config_store = RuntimeConfigStore::new(None);
+    let config = config_store.get_config(PROTOCOL_VERSION);
+    let storage_usage = Runtime::new().compute_storage_usage(&genesis.records.0[..], config);
+    debug!(target: "storage-calculator", "Storage usage calculated");
 
-        let mut result = Vec::new();
-        for record in genesis.records.0 {
-            if let StateRecord::Account { account_id, account } = record {
-                let actual_storage_usage = storage_usage.get(&account_id).unwrap();
-                let saved_storage_usage = account.storage_usage();
-                let delta = actual_storage_usage - saved_storage_usage;
-                if delta != 0 {
-                    debug!("{},{}", account_id, delta);
-                    result.push((account_id.clone(), delta));
-                }
+    let mut result = Vec::new();
+    for record in genesis.records.0 {
+        if let StateRecord::Account { account_id, account } = record {
+            let actual_storage_usage = storage_usage.get(&account_id).unwrap();
+            let saved_storage_usage = account.storage_usage();
+            let delta = actual_storage_usage - saved_storage_usage;
+            if delta != 0 {
+                debug!("{},{}", account_id, delta);
+                result.push((account_id.clone(), delta));
             }
         }
-        serde_json::to_writer_pretty(&File::create("storage_usage_delta.json")?, &result)?;
-        Ok(())
-    })
+    }
+    serde_json::to_writer_pretty(&File::create("storage_usage_delta.json")?, &result)?;
+    Ok(())
 }

--- a/tools/storage-usage-delta-calculator/src/main.rs
+++ b/tools/storage-usage-delta-calculator/src/main.rs
@@ -13,33 +13,31 @@ use tracing_subscriber::EnvFilter;
 /// run 'neard --home ~/.near/mainnet/ view_state dump_state'
 /// to get it
 fn main() -> std::io::Result<()> {
-    tracing_subscriber::fmt::Subscriber::builder()
-        .with_env_filter(EnvFilter::default().add_directive(LevelFilter::DEBUG.into()))
-        .with_writer(std::io::stderr)
-        .init();
+    let env_filter = EnvFilter::default().add_directive(LevelFilter::DEBUG.into());
+    near_o11y::with_default_subscriber(env_filter, || {
+        debug!(target: "storage-calculator", "Start");
 
-    debug!(target: "storage-calculator", "Start");
+        let genesis = Genesis::from_file("output.json", GenesisValidationMode::Full);
+        debug!(target: "storage-calculator", "Genesis read");
 
-    let genesis = Genesis::from_file("output.json", GenesisValidationMode::Full);
-    debug!(target: "storage-calculator", "Genesis read");
+        let config_store = RuntimeConfigStore::new(None);
+        let config = config_store.get_config(PROTOCOL_VERSION);
+        let storage_usage = Runtime::new().compute_storage_usage(&genesis.records.0[..], config);
+        debug!(target: "storage-calculator", "Storage usage calculated");
 
-    let config_store = RuntimeConfigStore::new(None);
-    let config = config_store.get_config(PROTOCOL_VERSION);
-    let storage_usage = Runtime::new().compute_storage_usage(&genesis.records.0[..], config);
-    debug!(target: "storage-calculator", "Storage usage calculated");
-
-    let mut result = Vec::new();
-    for record in genesis.records.0 {
-        if let StateRecord::Account { account_id, account } = record {
-            let actual_storage_usage = storage_usage.get(&account_id).unwrap();
-            let saved_storage_usage = account.storage_usage();
-            let delta = actual_storage_usage - saved_storage_usage;
-            if delta != 0 {
-                debug!("{},{}", account_id, delta);
-                result.push((account_id.clone(), delta));
+        let mut result = Vec::new();
+        for record in genesis.records.0 {
+            if let StateRecord::Account { account_id, account } = record {
+                let actual_storage_usage = storage_usage.get(&account_id).unwrap();
+                let saved_storage_usage = account.storage_usage();
+                let delta = actual_storage_usage - saved_storage_usage;
+                if delta != 0 {
+                    debug!("{},{}", account_id, delta);
+                    result.push((account_id.clone(), delta));
+                }
             }
         }
-    }
-    serde_json::to_writer_pretty(&File::create("storage_usage_delta.json")?, &result)?;
-    Ok(())
+        serde_json::to_writer_pretty(&File::create("storage_usage_delta.json")?, &result)?;
+        Ok(())
+    })
 }


### PR DESCRIPTION
This will utilize a separate thread to write out the spans and events
without while letting the main computation to proceed with its business.
Additionally, we are buffering the output by lines, thus reducing the
frequency of syscalls that can occur when the subscriber is writing out
parts of the message.

This should mitigate concerns of enabling debug logging as its impact on
performance should now be minimal (putting an event structure onto a
MPSC queue.) There are still costs associated with logging everything
however. Most notably formatting and construction of the
`tracing_core::ValueSet`s still occur on the caller side, so if
constructing those is expensive, the logging might remain expensive.
An example of code sketchy like that (although silly) could be:

```
debug!(message = { std::time::sleep(Duration::from_secs(1)); "hello" })
```

or for a less silly example:

```
debug!("{}", my_vector.iter().map(|...| {
  do_expensive_stuff()
}).collect::<String>())
```

These should be considered a bug (alas one that `tracing` does not have
any tooling to detect, sadly.)

I opted adding a new crate dedicated to observability utilities. From my
experience using things like prometheus will eventually result in a
variety of utilities being written, so this crate eventually would
likely expand in scope...

Fixes https://github.com/near/nearcore/issues/6072 (though I haven't made any actual measurements as to what the improvement really is)