### PR TITLE
nearcore: download compressed betanet and testnet genesis.json file

### DIFF
--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -1242,7 +1242,7 @@ pub fn init_testnet_configs(
 
 pub fn get_genesis_url(chain_id: &str) -> String {
     format!(
-        "https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore-deploy/{}/genesis.json",
+        "https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore-deploy/{}/genesis.json.xz",
         chain_id,
     )
 }


### PR DESCRIPTION
Now that nearcore can download a compressed genesis.json file and we
are offering one for betanet and testnet start downloading that file.

Fixes: https://github.com/near/nearcore/issues/4951