### PR TITLE
feat: return error if building test contract fails

### DIFF
--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 
-use anyhow::{Context, Error};
+use anyhow::Context;
 use clap::Parser;
 use genesis_populate::GenesisBuilder;
 use near_chain_configs::GenesisValidationMode;
@@ -103,13 +103,11 @@ fn main() -> anyhow::Result<()> {
             .output()
             .context("could not build test contract")?;
         if !result.status.success() {
-            return Err(Error::from(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!(
-                    "Failed to build test contract: {}",
-                    String::from_utf8_lossy(&result.stderr)
-                ),
-            )));
+            anyhow::bail!(
+                "Failed to build test contract, {}, stderr: {}",
+                result.status,
+                String::from_utf8_lossy(&result.stderr)
+            );
         }
     }
 

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -19,7 +19,6 @@ use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
-use std::str;
 use std::sync::Arc;
 use std::time;
 
@@ -108,7 +107,7 @@ fn main() -> anyhow::Result<()> {
                 std::io::ErrorKind::InvalidData,
                 format!(
                     "Failed to build test contract: {}",
-                    str::from_utf8(&result.stderr).unwrap()
+                    String::from_utf8_lossy(&result.stderr)
                 ),
             )));
         }


### PR DESCRIPTION
I realized that if building test contract fails, we don't notice it, because it just results in non-zero status.

The PR should fix it.