### PR TITLE
feat(params-estimator): Block overhead consistency

### DIFF
--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -70,13 +70,13 @@ impl<'c> Testbed<'c> {
     /// might trigger multiple blocks in execution. The returned results are
     /// exactly one per input block, regardless of how many blocks needed to be
     /// executed. To avoid surprises in how many blocks are actually executed,
-    /// `blocks_per_block` must be specified and the function will panic if it
-    /// is wrong.
+    /// `block_latency` must be specified and the function will panic if it is
+    /// wrong. A latency of 0 means everything is done within a single block.
     #[track_caller]
     pub(crate) fn measure_blocks<'a>(
         &'a mut self,
         blocks: Vec<Vec<SignedTransaction>>,
-        blocks_per_block: usize,
+        block_latency: usize,
     ) -> Vec<(GasCost, HashMap<ExtCosts, u64>)> {
         let allow_failures = false;
 
@@ -92,7 +92,7 @@ impl<'c> Testbed<'c> {
                 extra_blocks = self.inner.process_blocks_until_no_receipts(allow_failures);
                 start.elapsed()
             };
-            assert_eq!(blocks_per_block, 1 + extra_blocks);
+            assert_eq!(block_latency, extra_blocks);
 
             let mut ext_costs: HashMap<ExtCosts, u64> = HashMap::new();
             node_runtime::with_ext_cost_counter(|cc| {

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -258,22 +258,16 @@ fn action_receipt_creation(ctx: &mut EstimatorContext) -> GasCost {
         return cached;
     }
 
-    let testbed = ctx.testbed();
-
     let mut make_transaction = |tb: &mut TransactionBuilder| -> SignedTransaction {
         let (sender, receiver) = tb.random_account_pair();
 
         tb.transaction_from_actions(sender, receiver, vec![])
     };
-    let total_cost = transaction_cost(testbed, &mut make_transaction);
-
-    // Two blocks per action receipt will be processed in the measurement, so
-    // the overhead is subtracted here
-    // TODO: Move block overhead subtraction into `Testbed::measure_blocks` for
-    // all measurements to benefit from this
-    let block_overhead_cost = apply_block_cost(ctx);
+    let block_size = 100;
+    // Sender != Receiver means this will be executed over two blocks.
+    let blocks_per_measurement = 2;
     let cost =
-        total_cost.saturating_sub(&(block_overhead_cost * 2), &NonNegativeTolerance::PER_MILLE);
+        transaction_cost_ext(ctx, block_size, &mut make_transaction, blocks_per_measurement).0;
 
     ctx.cached.action_receipt_creation = Some(cost.clone());
     cost
@@ -284,15 +278,13 @@ fn action_sir_receipt_creation(ctx: &mut EstimatorContext) -> GasCost {
         return cached;
     }
 
-    let testbed = ctx.testbed();
-
     let mut make_transaction = |tb: &mut TransactionBuilder| -> SignedTransaction {
         let sender = tb.random_account();
         let receiver = sender.clone();
 
         tb.transaction_from_actions(sender, receiver, vec![])
     };
-    let total_cost = transaction_cost(testbed, &mut make_transaction);
+    let total_cost = transaction_cost(ctx, &mut make_transaction);
 
     let block_overhead_cost = apply_block_cost(ctx);
     let cost = total_cost.saturating_sub(&block_overhead_cost, &NonNegativeTolerance::PER_MILLE);
@@ -303,15 +295,16 @@ fn action_sir_receipt_creation(ctx: &mut EstimatorContext) -> GasCost {
 
 fn action_transfer(ctx: &mut EstimatorContext) -> GasCost {
     let total_cost = {
-        let testbed = ctx.testbed();
-
         let mut make_transaction = |tb: &mut TransactionBuilder| -> SignedTransaction {
             let (sender, receiver) = tb.random_account_pair();
 
             let actions = vec![Action::Transfer(TransferAction { deposit: 1 })];
             tb.transaction_from_actions(sender, receiver, actions)
         };
-        transaction_cost(testbed, &mut make_transaction)
+        let block_size = 100;
+        // Transferring from one account to another may touch two shards, thus executes over two blocks.
+        let blocks_per_measurement = 2;
+        transaction_cost_ext(ctx, block_size, &mut make_transaction, blocks_per_measurement).0
     };
 
     let base_cost = action_receipt_creation(ctx);
@@ -321,8 +314,6 @@ fn action_transfer(ctx: &mut EstimatorContext) -> GasCost {
 
 fn action_create_account(ctx: &mut EstimatorContext) -> GasCost {
     let total_cost = {
-        let testbed = ctx.testbed();
-
         let mut make_transaction = |tb: &mut TransactionBuilder| -> SignedTransaction {
             let sender = tb.random_account();
             let new_account =
@@ -334,7 +325,10 @@ fn action_create_account(ctx: &mut EstimatorContext) -> GasCost {
             ];
             tb.transaction_from_actions(sender, new_account, actions)
         };
-        transaction_cost(testbed, &mut make_transaction)
+        let block_size = 100;
+        // Creating a new account is initiated by an account that potentially is on a different shard. Thus, it executes over two blocks.
+        let blocks_per_measurement = 2;
+        transaction_cost_ext(ctx, block_size, &mut make_transaction, blocks_per_measurement).0
     };
 
     let base_cost = action_receipt_creation(ctx);
@@ -344,8 +338,6 @@ fn action_create_account(ctx: &mut EstimatorContext) -> GasCost {
 
 fn action_delete_account(ctx: &mut EstimatorContext) -> GasCost {
     let total_cost = {
-        let testbed = ctx.testbed();
-
         let mut make_transaction = |tb: &mut TransactionBuilder| -> SignedTransaction {
             let sender = tb.random_unused_account();
             let receiver = sender.clone();
@@ -354,7 +346,10 @@ fn action_delete_account(ctx: &mut EstimatorContext) -> GasCost {
             let actions = vec![Action::DeleteAccount(DeleteAccountAction { beneficiary_id })];
             tb.transaction_from_actions(sender, receiver, actions)
         };
-        transaction_cost(testbed, &mut make_transaction)
+        let block_size = 100;
+        // Deleting an account is initiated by an account that potentially is on a different shard. Thus, it executes over two blocks.
+        let blocks_per_measurement = 2;
+        transaction_cost_ext(ctx, block_size, &mut make_transaction, blocks_per_measurement).0
     };
 
     let base_cost = action_sir_receipt_creation(ctx);
@@ -364,14 +359,12 @@ fn action_delete_account(ctx: &mut EstimatorContext) -> GasCost {
 
 fn action_add_full_access_key(ctx: &mut EstimatorContext) -> GasCost {
     let total_cost = {
-        let testbed = ctx.testbed();
-
         let mut make_transaction = |tb: &mut TransactionBuilder| -> SignedTransaction {
             let sender = tb.random_unused_account();
 
             add_key_transaction(tb, sender, AccessKeyPermission::FullAccess)
         };
-        transaction_cost(testbed, &mut make_transaction)
+        transaction_cost(ctx, &mut make_transaction)
     };
 
     let base_cost = action_sir_receipt_creation(ctx);
@@ -385,8 +378,6 @@ fn action_add_function_access_key_base(ctx: &mut EstimatorContext) -> GasCost {
     }
 
     let total_cost = {
-        let testbed = ctx.testbed();
-
         let mut make_transaction = |tb: &mut TransactionBuilder| -> SignedTransaction {
             let sender = tb.random_unused_account();
             let receiver_id = tb.account(0).to_string();
@@ -398,7 +389,7 @@ fn action_add_function_access_key_base(ctx: &mut EstimatorContext) -> GasCost {
             });
             add_key_transaction(tb, sender, permission)
         };
-        transaction_cost(testbed, &mut make_transaction)
+        transaction_cost(ctx, &mut make_transaction)
     };
 
     let base_cost = action_sir_receipt_creation(ctx);
@@ -410,8 +401,6 @@ fn action_add_function_access_key_base(ctx: &mut EstimatorContext) -> GasCost {
 
 fn action_add_function_access_key_per_byte(ctx: &mut EstimatorContext) -> GasCost {
     let total_cost = {
-        let testbed = ctx.testbed();
-
         let many_methods: Vec<_> = (0..1000).map(|i| format!("a123456{:03}", i)).collect();
         let mut make_transaction = |tb: &mut TransactionBuilder| -> SignedTransaction {
             let sender = tb.random_unused_account();
@@ -424,7 +413,7 @@ fn action_add_function_access_key_per_byte(ctx: &mut EstimatorContext) -> GasCos
             });
             add_key_transaction(tb, sender, permission)
         };
-        transaction_cost(testbed, &mut make_transaction)
+        transaction_cost(ctx, &mut make_transaction)
     };
 
     let base_cost = action_add_function_access_key_base(ctx);
@@ -454,8 +443,6 @@ fn add_key_transaction(
 
 fn action_delete_key(ctx: &mut EstimatorContext) -> GasCost {
     let total_cost = {
-        let testbed = ctx.testbed();
-
         let mut make_transaction = |tb: &mut TransactionBuilder| -> SignedTransaction {
             let sender = tb.random_unused_account();
             let receiver = sender.clone();
@@ -465,7 +452,7 @@ fn action_delete_key(ctx: &mut EstimatorContext) -> GasCost {
             })];
             tb.transaction_from_actions(sender, receiver, actions)
         };
-        transaction_cost(testbed, &mut make_transaction)
+        transaction_cost(ctx, &mut make_transaction)
     };
 
     let base_cost = action_sir_receipt_creation(ctx);
@@ -475,8 +462,6 @@ fn action_delete_key(ctx: &mut EstimatorContext) -> GasCost {
 
 fn action_stake(ctx: &mut EstimatorContext) -> GasCost {
     let total_cost = {
-        let testbed = ctx.testbed();
-
         let mut make_transaction = |tb: &mut TransactionBuilder| -> SignedTransaction {
             let sender = tb.random_unused_account();
             let receiver = sender.clone();
@@ -487,7 +472,7 @@ fn action_stake(ctx: &mut EstimatorContext) -> GasCost {
             })];
             tb.transaction_from_actions(sender, receiver, actions)
         };
-        transaction_cost(testbed, &mut make_transaction)
+        transaction_cost(ctx, &mut make_transaction)
     };
 
     let base_cost = action_sir_receipt_creation(ctx);
@@ -560,8 +545,6 @@ fn deploy_contract_cost(
     code: Vec<u8>,
     pivot_fn_name: Option<&[u8]>,
 ) -> GasCost {
-    let testbed = ctx.testbed();
-
     let mut code_num = 0;
     let mut code_factory = || {
         let mut code = code.clone();
@@ -585,8 +568,8 @@ fn deploy_contract_cost(
     };
     // Use a small block size since deployments are gas heavy.
     let block_size = 5;
-    let (total_cost, _ext) = transaction_cost_ext(testbed, block_size, &mut make_transaction);
-    let base_cost = action_sir_receipt_creation(ctx) + apply_block_cost(ctx);
+    let (total_cost, _ext) = transaction_cost_ext(ctx, block_size, &mut make_transaction, 1);
+    let base_cost = action_sir_receipt_creation(ctx);
 
     total_cost.saturating_sub(&base_cost, &NonNegativeTolerance::PER_MILLE)
 }
@@ -661,13 +644,11 @@ fn action_function_call_base(ctx: &mut EstimatorContext) -> GasCost {
 }
 fn action_function_call_per_byte(ctx: &mut EstimatorContext) -> GasCost {
     let total_cost = {
-        let testbed = ctx.testbed();
-
         let mut make_transaction = |tb: &mut TransactionBuilder| -> SignedTransaction {
             let sender = tb.random_unused_account();
             tb.transaction_from_function_call(sender, "noop", vec![0; 1024 * 1024])
         };
-        transaction_cost(testbed, &mut make_transaction)
+        transaction_cost(ctx, &mut make_transaction)
     };
 
     let base_cost = noop_function_call_cost(ctx);
@@ -706,16 +687,28 @@ fn action_function_call_base_per_byte_v2(ctx: &mut EstimatorContext) -> (GasCost
 
 fn data_receipt_creation_base(ctx: &mut EstimatorContext) -> GasCost {
     // NB: there isn't `ExtCosts` for data receipt creation, so we ignore (`_`) the counts.
-    let (total_cost, _) = fn_cost_count(ctx, "data_receipt_10b_1000", ExtCosts::base);
-    let (base_cost, _) = fn_cost_count(ctx, "data_receipt_base_10b_1000", ExtCosts::base);
+    // The function returns a chain of two promises.
+    let blocks_to_execute = 3;
+    let (total_cost, _) =
+        fn_cost_count(ctx, "data_receipt_10b_1000", ExtCosts::base, blocks_to_execute);
+    // The function returns a promise.
+    let blocks_to_execute = 2;
+    let (base_cost, _) =
+        fn_cost_count(ctx, "data_receipt_base_10b_1000", ExtCosts::base, blocks_to_execute);
 
     total_cost.saturating_sub(&base_cost, &NonNegativeTolerance::PER_MILLE) / 1000
 }
 
 fn data_receipt_creation_per_byte(ctx: &mut EstimatorContext) -> GasCost {
     // NB: there isn't `ExtCosts` for data receipt creation, so we ignore (`_`) the counts.
-    let (total_cost, _) = fn_cost_count(ctx, "data_receipt_100kib_1000", ExtCosts::base);
-    let (base_cost, _) = fn_cost_count(ctx, "data_receipt_10b_1000", ExtCosts::base);
+    // The function returns a chain of two promises.
+    let blocks_to_execute = 3;
+    let (total_cost, _) =
+        fn_cost_count(ctx, "data_receipt_100kib_1000", ExtCosts::base, blocks_to_execute);
+    // The function returns a chain of two promises.
+    let blocks_to_execute = 3;
+    let (base_cost, _) =
+        fn_cost_count(ctx, "data_receipt_10b_1000", ExtCosts::base, blocks_to_execute);
 
     let bytes_per_transaction = 1000 * 100 * 1024;
 
@@ -723,7 +716,8 @@ fn data_receipt_creation_per_byte(ctx: &mut EstimatorContext) -> GasCost {
 }
 
 fn host_function_call(ctx: &mut EstimatorContext) -> GasCost {
-    let (total_cost, count) = fn_cost_count(ctx, "base_1M", ExtCosts::base);
+    let blocks_to_execute = 1;
+    let (total_cost, count) = fn_cost_count(ctx, "base_1M", ExtCosts::base, blocks_to_execute);
     assert_eq!(count, 1_000_000);
 
     let base_cost = noop_function_call_cost(ctx);
@@ -1100,7 +1094,7 @@ fn touching_trie_node_read(ctx: &mut EstimatorContext) -> GasCost {
             .take(measured_iters + warmup_iters),
     );
 
-    let results = &testbed.measure_blocks(blocks)[1..];
+    let results = &testbed.measure_blocks(blocks, 1)[1..];
     let (short_key_results, long_key_results) = results.split_at(measured_iters + warmup_iters);
 
     let (cost_short_key, ext_cost_short_key) = aggregate_per_block_measurements(
@@ -1166,7 +1160,7 @@ fn touching_trie_node_write(ctx: &mut EstimatorContext) -> GasCost {
             .take(measured_iters + warmup_iters),
     );
 
-    let results = &testbed.measure_blocks(blocks)[1..];
+    let results = &testbed.measure_blocks(blocks, 1)[1..];
     let (short_key_results, long_key_results) = results.split_at(measured_iters + warmup_iters);
 
     let (cost_short_key, ext_cost_short_key) = aggregate_per_block_measurements(
@@ -1201,7 +1195,7 @@ fn apply_block_cost(ctx: &mut EstimatorContext) -> GasCost {
     let n_blocks = testbed.config.warmup_iters_per_block + testbed.config.iter_per_block;
     let blocks = vec![vec![]; n_blocks];
 
-    let measurements = testbed.measure_blocks(blocks);
+    let measurements = testbed.measure_blocks(blocks, 1);
     let measurements =
         measurements.into_iter().skip(testbed.config.warmup_iters_per_block).collect::<Vec<_>>();
     let (gas_cost, _ext_costs) = aggregate_per_block_measurements(testbed.config, 1, measurements);

--- a/runtime/runtime-params-estimator/src/testbed.rs
+++ b/runtime/runtime-params-estimator/src/testbed.rs
@@ -131,10 +131,14 @@ impl RuntimeTestbed {
         total_burnt_gas
     }
 
-    pub fn process_blocks_until_no_receipts(&mut self, allow_failures: bool) {
+    /// Returns the number of blocks required to reach quiescence
+    pub fn process_blocks_until_no_receipts(&mut self, allow_failures: bool) -> usize {
+        let mut n = 0;
         while !self.prev_receipts.is_empty() {
             self.process_block(&[], allow_failures);
+            n += 1;
         }
+        n
     }
 
     /// Flushes RocksDB memtable

--- a/runtime/runtime-params-estimator/src/utils.rs
+++ b/runtime/runtime-params-estimator/src/utils.rs
@@ -1,5 +1,6 @@
+use crate::apply_block_cost;
 use crate::config::Config;
-use crate::estimator_context::{EstimatorContext, Testbed};
+use crate::estimator_context::EstimatorContext;
 use crate::gas_cost::{GasCost, NonNegativeTolerance};
 use crate::transaction_builder::TransactionBuilder;
 
@@ -29,20 +30,28 @@ pub fn clear_linux_page_cache() -> std::io::Result<()> {
     std::fs::write("/proc/sys/vm/drop_caches", b"1")
 }
 
+#[track_caller]
 pub(crate) fn transaction_cost(
-    testbed: Testbed,
+    ctx: &mut EstimatorContext,
     make_transaction: &mut dyn FnMut(&mut TransactionBuilder) -> SignedTransaction,
 ) -> GasCost {
     let block_size = 100;
-    let (gas_cost, _ext_costs) = transaction_cost_ext(testbed, block_size, make_transaction);
+    let (gas_cost, _ext_costs) = transaction_cost_ext(ctx, block_size, make_transaction, 1);
     gas_cost
 }
 
+#[track_caller]
 pub(crate) fn transaction_cost_ext(
-    mut testbed: Testbed,
+    ctx: &mut EstimatorContext,
     block_size: usize,
     make_transaction: &mut dyn FnMut(&mut TransactionBuilder) -> SignedTransaction,
+    blocks_to_complete_tx: usize,
 ) -> (GasCost, HashMap<ExtCosts, u64>) {
+    let per_block_overhead = apply_block_cost(ctx);
+    let measurement_overhead =
+        per_block_overhead * blocks_to_complete_tx as u64 / block_size as u64;
+
+    let mut testbed = ctx.testbed();
     let blocks = {
         let n_blocks = testbed.config.warmup_iters_per_block + testbed.config.iter_per_block;
         let mut blocks = Vec::with_capacity(n_blocks);
@@ -57,20 +66,32 @@ pub(crate) fn transaction_cost_ext(
         blocks
     };
 
-    let measurements = testbed.measure_blocks(blocks);
-    let measurements =
+    let measurements = testbed.measure_blocks(blocks, blocks_to_complete_tx);
+    let mut measurements =
         measurements.into_iter().skip(testbed.config.warmup_iters_per_block).collect::<Vec<_>>();
+
+    // The assumption is that the overhead in the measurement due to applying blocks
+    // is negligible (<1%) and can therefore be ignored. This code is here to verify .
+    for (cost, _ext) in &mut measurements {
+        if measurement_overhead.clone() * 100 >= *cost {
+            cost.set_uncertain("BLOCK-MEASUREMENT-OVERHEAD");
+        }
+    }
 
     aggregate_per_block_measurements(testbed.config, block_size, measurements)
 }
 
+#[track_caller]
 pub(crate) fn fn_cost(
     ctx: &mut EstimatorContext,
     method: &str,
     ext_cost: ExtCosts,
     count: u64,
 ) -> GasCost {
-    let (total_cost, measured_count) = fn_cost_count(ctx, method, ext_cost);
+    // Most functions finish execution in a single block. Other measurements
+    // should use `fn_cost_count`.
+    let blocks_to_execute = 1;
+    let (total_cost, measured_count) = fn_cost_count(ctx, method, ext_cost, blocks_to_execute);
     assert_eq!(measured_count, count);
 
     let base_cost = noop_function_call_cost(ctx);
@@ -78,18 +99,20 @@ pub(crate) fn fn_cost(
     total_cost.saturating_sub(&base_cost, &NonNegativeTolerance::PER_MILLE) / count
 }
 
+#[track_caller]
 pub(crate) fn fn_cost_count(
     ctx: &mut EstimatorContext,
     method: &str,
     ext_cost: ExtCosts,
+    blocks_to_execute: usize,
 ) -> (GasCost, u64) {
     let block_size = 2;
     let mut make_transaction = |tb: &mut TransactionBuilder| -> SignedTransaction {
         let sender = tb.random_unused_account();
         tb.transaction_from_function_call(sender, method, Vec::new())
     };
-    let testbed = ctx.testbed();
-    let (gas_cost, ext_costs) = transaction_cost_ext(testbed, block_size, &mut make_transaction);
+    let (gas_cost, ext_costs) =
+        transaction_cost_ext(ctx, block_size, &mut make_transaction, blocks_to_execute);
     let ext_cost = ext_costs[&ext_cost];
     (gas_cost, ext_cost)
 }
@@ -100,13 +123,11 @@ pub(crate) fn noop_function_call_cost(ctx: &mut EstimatorContext) -> GasCost {
     }
 
     let cost = {
-        let testbed = ctx.testbed();
-
         let mut make_transaction = |tb: &mut TransactionBuilder| -> SignedTransaction {
             let sender = tb.random_unused_account();
             tb.transaction_from_function_call(sender, "noop", Vec::new())
         };
-        transaction_cost(testbed, &mut make_transaction)
+        transaction_cost(ctx, &mut make_transaction)
     };
 
     ctx.cached.noop_function_call_cost = Some(cost.clone());
@@ -154,7 +175,7 @@ pub(crate) fn fn_cost_with_setup(
             blocks
         };
 
-        let measurements = testbed.measure_blocks(blocks);
+        let measurements = testbed.measure_blocks(blocks, 1);
         // Filter out setup blocks.
         let measurements: Vec<_> = measurements
             .into_iter()


### PR DESCRIPTION
Most estimations execute transactions. The measurment includes
as many blocks as necessary to execute all receipts.

This change does two things.
1. Mark as uncertain if overhead of applying blocks is significant.
2. Force estimation function to define over how many blocks it executes.