### PR TITLE
network: introduce Blacklist type 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2926,6 +2926,7 @@ dependencies = [
  "serde",
  "strum",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/chain/network-primitives/Cargo.toml
+++ b/chain/network-primitives/Cargo.toml
@@ -20,6 +20,7 @@ deepsize = { version = "0.2.0", optional = true }
 serde = { version = "1", features = ["alloc", "derive", "rc"], optional = true }
 strum = { version = "0.20", features = ["derive"] }
 tokio = { version = "1.1", features = ["net", "rt-multi-thread"] }
+tracing = "0.1.13"
 
 near-crypto = { path = "../../core/crypto" }
 near-primitives = { path = "../../core/primitives" }

--- a/chain/network-primitives/src/blacklist.rs
+++ b/chain/network-primitives/src/blacklist.rs
@@ -1,0 +1,170 @@
+/// A blacklist for socket addresses.  Supports adding individual IP:port tuples
+/// to the blacklist or entire IPs.
+#[derive(Debug, Clone)]
+pub struct Blacklist(std::collections::HashMap<std::net::IpAddr, PortsSet>);
+
+impl Default for Blacklist {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+impl Blacklist {
+    /// Construct a blacklist from list of addresses.
+    ///
+    /// Arguments:
+    /// - `blacklist` - list of strings in one of the following format:
+    ///    - "IP" - for example 127.0.0.1 - if only IP is provided we will block all ports
+    ///    - "IP:PORT - for example 127.0.0.1:2134
+    pub fn from_iter(blacklist: impl IntoIterator<Item = String>) -> Self {
+        let mut result = Self::default();
+        for addr in blacklist {
+            if result.add(&addr).is_err() {
+                tracing::warn!(target: "network", "{}: invalid blacklist pattern, ignoring", addr);
+            }
+        }
+        result
+    }
+
+    fn add(&mut self, addr: &str) -> Result<(), std::net::AddrParseError> {
+        match addr.parse::<PatternAddr>()? {
+            PatternAddr::Ip(ip) => {
+                self.0.entry(ip).and_modify(|ports| ports.add_all()).or_insert(PortsSet::All);
+            }
+            PatternAddr::IpPort(addr) => {
+                self.0
+                    .entry(addr.ip())
+                    .and_modify(|ports| ports.add_port(addr.port()))
+                    .or_insert_with(|| PortsSet::new(addr.port()));
+            }
+        }
+        Ok(())
+    }
+
+    /// Returns whether given address is on the blacklist.
+    pub fn contains(&self, addr: &std::net::SocketAddr) -> bool {
+        match self.0.get(&addr.ip()) {
+            None => false,
+            Some(ports) => ports.contains(addr.port()),
+        }
+    }
+}
+
+/// Used to match a socket addr by IP:Port or only by IP
+#[cfg_attr(test, derive(Debug, PartialEq))]
+enum PatternAddr {
+    Ip(std::net::IpAddr),
+    IpPort(std::net::SocketAddr),
+}
+
+impl std::str::FromStr for PatternAddr {
+    type Err = std::net::AddrParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(pattern) = s.parse() {
+            return Ok(PatternAddr::Ip(pattern));
+        }
+        s.parse().map(PatternAddr::IpPort)
+    }
+}
+
+/// Set of TCP ports with special case for ‘all ports’.
+#[derive(Debug, Clone)]
+enum PortsSet {
+    All,
+    Some(std::collections::HashSet<u16>),
+}
+
+impl PortsSet {
+    fn new(port: u16) -> Self {
+        Self::Some(std::collections::HashSet::from_iter(Some(port).into_iter()))
+    }
+
+    fn add_all(&mut self) {
+        *self = Self::All
+    }
+
+    fn add_port(&mut self, port: u16) {
+        if let Self::Some(ports) = self {
+            ports.insert(port);
+        }
+    }
+
+    fn contains(&self, port: u16) -> bool {
+        match self {
+            Self::All => true,
+            Self::Some(ports) => ports.contains(&port),
+        }
+    }
+}
+
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test_pattern_addr() {
+        fn parse(value: &str) -> String {
+            match value.parse() {
+                Ok(super::PatternAddr::Ip(ip)) => ip.to_string(),
+                Ok(super::PatternAddr::IpPort(addr)) => addr.to_string(),
+                Err(_) => "err".to_string(),
+            }
+        }
+
+        assert_eq!("err", parse("foo"));
+        assert_eq!("err", parse("1.2.3.*"));
+        assert_eq!("err", parse("1.2.3.0/24"));
+        assert_eq!("err", parse("1.2.3.4.5"));
+        assert_eq!("err", parse("1.2.3.4:424242"));
+
+        assert_eq!("1.2.3.4", parse("1.2.3.4"));
+        assert_eq!("1.2.3.4:0", parse("1.2.3.4:0"));
+        assert_eq!("1.2.3.4:42", parse("1.2.3.4:42"));
+
+        assert_eq!("::1", parse("::1"));
+        assert_eq!("[::1]:42", parse("[::1]:42"));
+
+        assert_eq!("::ffff:127.0.0.1", parse("::ffff:127.0.0.1"));
+        assert_eq!("[::ffff:127.0.0.1]:42", parse("[::ffff:127.0.0.1]:42"));
+    }
+
+    #[test]
+    fn test_ports_set() {
+        let mut ports = super::PortsSet::new(42);
+        assert!(ports.contains(42));
+        assert!(!ports.contains(24));
+        ports.add_port(24);
+        assert!(ports.contains(42));
+        assert!(ports.contains(24));
+        assert!(!ports.contains(12));
+        ports.add_all();
+        assert!(ports.contains(42));
+        assert!(ports.contains(24));
+        assert!(ports.contains(12));
+    }
+
+    #[test]
+    fn test_blacklist() {
+        use std::net::*;
+
+        let lo4 = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+        let ip1234 = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
+        let lo6 = IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));
+        let lo4mappend = IpAddr::V6("::ffff:127.0.0.1".parse().unwrap());
+
+        let blacklist = super::Blacklist::from_iter(vec![
+            "127.0.0.1".to_string(),
+            "1.2.3.4:42".to_string(),
+            "[::1]:42".to_string(),
+        ]);
+
+        assert!(blacklist.contains(&SocketAddr::new(lo4, 42)));
+        assert!(blacklist.contains(&SocketAddr::new(lo4, 8080)));
+        assert!(blacklist.contains(&SocketAddr::new(ip1234, 42)));
+        assert!(!blacklist.contains(&SocketAddr::new(ip1234, 8080)));
+        assert!(blacklist.contains(&SocketAddr::new(lo6, 42)));
+        assert!(!blacklist.contains(&SocketAddr::new(lo6, 8080)));
+        assert!(!blacklist.contains(&SocketAddr::new(lo4mappend, 42)));
+        assert!(!blacklist.contains(&SocketAddr::new(lo4mappend, 8080)));
+    }
+}

--- a/chain/network-primitives/src/lib.rs
+++ b/chain/network-primitives/src/lib.rs
@@ -1,3 +1,4 @@
+mod blacklist;
 pub(crate) mod config;
 mod network_protocol;
 pub mod types;

--- a/chain/network-primitives/src/types.rs
+++ b/chain/network-primitives/src/types.rs
@@ -35,7 +35,8 @@ pub use crate::network_protocol::{
     RoutedMessageBody, StateResponseInfo, StateResponseInfoV1, StateResponseInfoV2,
 };
 
-pub use crate::config::{blacklist_from_iter, BlockedPorts, NetworkConfig};
+pub use crate::blacklist::Blacklist;
+pub use crate::config::NetworkConfig;
 
 pub use crate::network_protocol::edge::{Edge, EdgeState, PartialEdgeInfo, SimpleEdge};
 

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -24,11 +24,11 @@ use actix::{
 #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
 use futures::FutureExt;
 use near_network_primitives::types::{
-    AccountOrPeerIdOrHash, Ban, BlockedPorts, Edge, InboundTcpConnect, KnownPeerStatus,
-    KnownProducer, NetworkConfig, NetworkViewClientMessages, NetworkViewClientResponses,
-    OutboundTcpConnect, PeerIdOrHash, PeerInfo, PeerManagerRequest, PeerType, Ping, Pong,
-    QueryPeerStats, RawRoutedMessage, ReasonForBan, RoutedMessage, RoutedMessageBody,
-    RoutedMessageFrom, StateResponseInfo,
+    AccountOrPeerIdOrHash, Ban, Edge, InboundTcpConnect, KnownPeerStatus, KnownProducer,
+    NetworkConfig, NetworkViewClientMessages, NetworkViewClientResponses, OutboundTcpConnect,
+    PeerIdOrHash, PeerInfo, PeerManagerRequest, PeerType, Ping, Pong, QueryPeerStats,
+    RawRoutedMessage, ReasonForBan, RoutedMessage, RoutedMessageBody, RoutedMessageFrom,
+    StateResponseInfo,
 };
 use near_network_primitives::types::{EdgeState, PartialEdgeInfo};
 use near_performance_metrics::framed_write::FramedWrite;
@@ -48,7 +48,6 @@ use rand::seq::IteratorRandom;
 use rand::thread_rng;
 use std::cmp::{max, min};
 use std::collections::{HashMap, HashSet};
-use std::net::SocketAddr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -483,16 +482,6 @@ impl PeerManagerActor {
         near_performance_metrics::actix::run_later(ctx, interval, move |act, ctx| {
             act.broadcast_validated_edges_trigger(ctx, interval);
         });
-    }
-
-    fn is_blacklisted(
-        blacklist: &HashMap<std::net::IpAddr, BlockedPorts>,
-        addr: &SocketAddr,
-    ) -> bool {
-        blacklist.get(&addr.ip()).map_or(false, |blocked_ports| match blocked_ports {
-            BlockedPorts::All => true,
-            BlockedPorts::Some(ports) => ports.contains(&addr.port()),
-        })
     }
 
     #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]
@@ -1988,9 +1977,7 @@ impl PeerManagerActor {
         let _d = delay_detector::DelayDetector::new(|| "consolidate".into());
 
         // Check if this is a blacklisted peer.
-        if (msg.peer_info.addr.as_ref())
-            .map_or(true, |addr| Self::is_blacklisted(&self.config.blacklist, addr))
-        {
+        if (msg.peer_info.addr.as_ref()).map_or(true, |addr| self.config.blacklist.contains(addr)) {
             debug!(target: "network", peer_info = ?msg.peer_info, "Dropping connection from blacklisted peer or unknown address");
             return RegisterPeerResponse::Reject;
         }

--- a/integration-tests/src/tests/network/runner.rs
+++ b/integration-tests/src/tests/network/runner.rs
@@ -28,9 +28,8 @@ use near_network::test_utils::SetAdvOptions;
 use near_network::types::{NetworkRequests, NetworkResponses};
 use near_network::types::{PeerManagerMessageRequest, PeerManagerMessageResponse};
 use near_network::PeerManagerActor;
-use near_network_primitives::types::blacklist_from_iter;
 use near_network_primitives::types::{
-    NetworkConfig, OutboundTcpConnect, PeerInfo, ROUTED_MESSAGE_TTL,
+    Blacklist, NetworkConfig, OutboundTcpConnect, PeerInfo, ROUTED_MESSAGE_TTL,
 };
 use near_primitives::network::PeerId;
 use near_primitives::types::{AccountId, ValidatorId};
@@ -628,7 +627,7 @@ impl Runner {
                 .collect(),
         );
 
-        let blacklist = blacklist_from_iter(test_config.blacklist.iter().map(|x| {
+        let blacklist = Blacklist::from_iter(test_config.blacklist.iter().map(|x| {
             if let Some(x) = x {
                 format!("127.0.0.1:{}", ports[*x])
             } else {

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -25,8 +25,7 @@ use near_crypto::{InMemorySigner, KeyFile, KeyType, PublicKey, Signer};
 #[cfg(feature = "json_rpc")]
 use near_jsonrpc::RpcConfig;
 use near_network::test_utils::open_port;
-use near_network_primitives::types::blacklist_from_iter;
-use near_network_primitives::types::{NetworkConfig, ROUTED_MESSAGE_TTL};
+use near_network_primitives::types::{Blacklist, NetworkConfig, ROUTED_MESSAGE_TTL};
 use near_primitives::account::{AccessKey, Account};
 use near_primitives::hash::CryptoHash;
 #[cfg(test)]
@@ -731,7 +730,7 @@ impl NearConfig {
                 max_routes_to_store: MAX_ROUTES_TO_STORE,
                 highest_peer_horizon: HIGHEST_PEER_HORIZON,
                 push_info_period: Duration::from_millis(100),
-                blacklist: blacklist_from_iter(config.network.blacklist),
+                blacklist: Blacklist::from_iter(config.network.blacklist),
                 outbound_disabled: false,
                 archive: config.archive,
             },


### PR DESCRIPTION
Refactor code by moving blacklist creation and matching code into
a new Blacklist type.  While at it, print warning whenever blacklist
address is not parsed correctly (rather than silently ignoring it as
it was done previously).
