### PR TITLE
Chain debug page: head & header head info

### DIFF
--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -798,6 +798,8 @@ impl Handler<Status> for ClientActor {
                         self.client.chain.genesis_block().header().height(),
                     ),
                 ),
+                current_head_status: self.client.chain.head()?.clone().into(),
+                current_header_head_status:  self.client.chain.header_head()?.clone().into(),
             })
         } else {
             None

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -799,7 +799,7 @@ impl Handler<Status> for ClientActor {
                     ),
                 ),
                 current_head_status: self.client.chain.head()?.clone().into(),
-                current_header_head_status:  self.client.chain.header_head()?.clone().into(),
+                current_header_head_status: self.client.chain.header_head()?.clone().into(),
             })
         } else {
             None

--- a/chain/jsonrpc/res/chain_info.html
+++ b/chain/jsonrpc/res/chain_info.html
@@ -45,7 +45,7 @@
                     $('.js-current-header-head-height').text(header_head.height);
                 },
                 dataType: "json",
-                error: function (errMsg, textStatus, errorThrown) {
+                error: (errMsg, textStatus, errorThrown) => {
                     alert("Failed: " + textStatus + " :" + errorThrown);
                 },
                 contentType: "application/json; charset=utf-8",

--- a/chain/jsonrpc/res/chain_info.html
+++ b/chain/jsonrpc/res/chain_info.html
@@ -1,0 +1,103 @@
+<html>
+<head>
+    <style>
+        table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+
+        table,
+        th,
+        td {
+            border: 1px solid black;
+        }
+
+        td {
+            text-align: left;
+            vertical-align: top;
+            padding: 8px;
+        }
+
+        th {
+            text-align: center;
+            vertical-align: center;
+            padding: 8px;
+            background-color: lightgrey;
+        }
+
+        tr.active {
+            background-color: #eff8bf;
+        }
+    </style>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+    <script>
+        $(document).ready(() => {
+            $('span').text("Loading...");
+            $.ajax({
+                type: "GET",
+                url: "/debug/api/chain_info",
+                success: data => {
+                    let head = data.detailed_debug_status.current_head_status;
+                    let header_head = data.detailed_debug_status.current_header_head_status;
+                    $('.js-current-head-hash').text(head.hash);
+                    $('.js-current-head-height').text(head.height);
+                    $('.js-current-header-head-hash').text(header_head.hash);
+                    $('.js-current-header-head-height').text(header_head.height);
+                },
+                dataType: "json",
+                error: function (errMsg, textStatus, errorThrown) {
+                    alert("Failed: " + textStatus + " :" + errorThrown);
+                },
+                contentType: "application/json; charset=utf-8",
+            })
+
+        });
+    </script>
+</head>
+<body>
+    <h1>
+        Welcome to the Chain page!
+    </h1>
+    <h3>
+        <p>
+            Current head:
+            <span class="js-current-head-hash"></span>
+            @
+            <span class="js-current-head-height"></span>
+        </p>
+        <p>
+            Current header head:
+            <span class="js-current-header-head-hash"></span>
+            @
+            <span class="js-current-header-head-height"></span>
+        </p>
+    </h3>
+    <h2>
+        <p>
+            Orphan Pool (Under construction)
+        </p>
+    </h2>
+    <table>
+        <thead><tr>
+            <th>Hash</th>
+            <th>Height</th>
+        </tr></thead>
+        <tbody class="js-tbody-orphan-pool">
+        </tbody>
+    </table>
+    <h2>
+        <p>
+            Missing Chunks Pool (Under construction)
+        </p>
+    </h2>
+    <table>
+        <thead><tr>
+            <th>Hash</th>
+            <th>Height</th>
+        </tr></thead>
+        <tbody class="js-tbody-missing-chunks-pool">
+        </tbody>
+    </table>
+</body>
+
+</html>

--- a/chain/jsonrpc/res/chain_info.html
+++ b/chain/jsonrpc/res/chain_info.html
@@ -35,7 +35,7 @@
             $('span').text("Loading...");
             $.ajax({
                 type: "GET",
-                url: "/debug/api/chain_info",
+                url: "/debug/api/status",
                 success: data => {
                     let head = data.detailed_debug_status.current_head_status;
                     let header_head = data.detailed_debug_status.current_header_head_status;

--- a/chain/jsonrpc/res/debug.html
+++ b/chain/jsonrpc/res/debug.html
@@ -3,6 +3,7 @@
 <body>
     <h1><a href="/debug/last_blocks">Last blocks</a></h1>
     <h1><a href="/debug/sync_info">Sync info</a></h1>
+    <h1><a href="/debug/chain_info">Chain info</a></h1>
 </body>
 
 </html>

--- a/chain/jsonrpc/res/last_blocks.html
+++ b/chain/jsonrpc/res/last_blocks.html
@@ -58,7 +58,7 @@
             root.html("Loading...");
             $.ajax({
                 type: "GET",
-                url: "/debug/api/last_blocks",
+                url: "/debug/api/status",
                 success: function (data) {
                     var root = $("#blocks_table_tbody");
                     root.html("");

--- a/chain/jsonrpc/res/sync_info.html
+++ b/chain/jsonrpc/res/sync_info.html
@@ -35,7 +35,7 @@
             $('span').text("Loading...");
             $.ajax({
                 type: "GET",
-                url: "/debug/api/sync_info",
+                url: "/debug/api/status",
                 success: data => {
                     let sync_status = data.detailed_debug_status.sync_status;
                     let network_info = data.detailed_debug_status.network_info;

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -1534,7 +1534,9 @@ pub fn start_http(
             .service(last_blocks_html)
             .service(web::resource("/debug/api/sync_info").route(web::get().to(sync_info_handler)))
             .service(sync_info_html)
-            .service(web::resource("/debug/api/chain_info").route(web::get().to(chain_info_handler)))
+            .service(
+                web::resource("/debug/api/chain_info").route(web::get().to(chain_info_handler)),
+            )
             .service(chain_info_html)
     })
     .bind(addr)

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -1422,6 +1422,13 @@ async fn sync_info_handler(handler: web::Data<JsonRpcHandler>) -> Result<HttpRes
     }
 }
 
+async fn chain_info_handler(handler: web::Data<JsonRpcHandler>) -> Result<HttpResponse, HttpError> {
+    match handler.debug().await {
+        Ok(value) => Ok(HttpResponse::Ok().json(&value)),
+        Err(_) => Ok(HttpResponse::ServiceUnavailable().finish()),
+    }
+}
+
 fn get_cors(cors_allowed_origins: &[String]) -> Cors {
     let mut cors = Cors::permissive();
     if cors_allowed_origins != ["*".to_string()] {
@@ -1439,6 +1446,7 @@ lazy_static_include::lazy_static_include_str! {
     LAST_BLOCKS_HTML => "res/last_blocks.html",
     DEBUG_HTML => "res/debug.html",
     SYNC_INFO_HTML => "res/sync_info.html",
+    CHAIN_INFO_HTML => "res/chain_info.html",
 }
 
 #[get("/debug")]
@@ -1454,6 +1462,11 @@ async fn last_blocks_html() -> actix_web::Result<impl actix_web::Responder> {
 #[get("/debug/sync_info")]
 async fn sync_info_html() -> actix_web::Result<impl actix_web::Responder> {
     Ok(HttpResponse::Ok().body(*SYNC_INFO_HTML))
+}
+
+#[get("/debug/chain_info")]
+async fn chain_info_html() -> actix_web::Result<impl actix_web::Responder> {
+    Ok(HttpResponse::Ok().body(*CHAIN_INFO_HTML))
 }
 
 /// Starts HTTP server(s) listening for RPC requests.
@@ -1521,6 +1534,8 @@ pub fn start_http(
             .service(last_blocks_html)
             .service(web::resource("/debug/api/sync_info").route(web::get().to(sync_info_handler)))
             .service(sync_info_html)
+            .service(web::resource("/debug/api/chain_info").route(web::get().to(chain_info_handler)))
+            .service(chain_info_html)
     })
     .bind(addr)
     .unwrap()

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -1415,20 +1415,6 @@ pub async fn prometheus_handler() -> Result<HttpResponse, HttpError> {
     }
 }
 
-async fn sync_info_handler(handler: web::Data<JsonRpcHandler>) -> Result<HttpResponse, HttpError> {
-    match handler.debug().await {
-        Ok(value) => Ok(HttpResponse::Ok().json(&value)),
-        Err(_) => Ok(HttpResponse::ServiceUnavailable().finish()),
-    }
-}
-
-async fn chain_info_handler(handler: web::Data<JsonRpcHandler>) -> Result<HttpResponse, HttpError> {
-    match handler.debug().await {
-        Ok(value) => Ok(HttpResponse::Ok().json(&value)),
-        Err(_) => Ok(HttpResponse::ServiceUnavailable().finish()),
-    }
-}
-
 fn get_cors(cors_allowed_origins: &[String]) -> Cors {
     let mut cors = Cors::permissive();
     if cors_allowed_origins != ["*".to_string()] {
@@ -1529,14 +1515,10 @@ pub fn start_http(
             )
             .service(web::resource("/network_info").route(web::get().to(network_info_handler)))
             .service(web::resource("/metrics").route(web::get().to(prometheus_handler)))
-            .service(web::resource("/debug/api/last_blocks").route(web::get().to(debug_handler)))
+            .service(web::resource("/debug/api/status").route(web::get().to(debug_handler)))
             .service(debug_html)
             .service(last_blocks_html)
-            .service(web::resource("/debug/api/sync_info").route(web::get().to(sync_info_handler)))
             .service(sync_info_html)
-            .service(
-                web::resource("/debug/api/chain_info").route(web::get().to(chain_info_handler)),
-            )
             .service(chain_info_html)
     })
     .bind(addr)

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use near_crypto::{PublicKey, Signature};
 
 use crate::account::{AccessKey, AccessKeyPermission, Account, FunctionCallPermission};
-use crate::block::{Block, BlockHeader};
+use crate::block::{Block, BlockHeader, Tip};
 use crate::block_header::{
     BlockHeaderInnerLite, BlockHeaderInnerRest, BlockHeaderInnerRestV2, BlockHeaderInnerRestV3,
     BlockHeaderV1, BlockHeaderV2, BlockHeaderV3,
@@ -366,11 +366,29 @@ pub struct NetworkInfoView {
 }
 
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct BlockStatusView {
+    pub height: BlockHeight,
+    pub hash: CryptoHash,
+}
+
+impl From<Tip> for BlockStatusView {
+    fn from(tip: Tip) -> Self {
+        Self {
+            height: tip.height,
+            hash: tip.last_block_hash,
+        }
+    }
+}
+
+#[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DetailedDebugStatus {
     pub last_blocks: Vec<DebugBlockStatus>,
     pub network_info: NetworkInfoView,
     pub sync_status: String,
+    pub current_head_status: BlockStatusView,
+    pub current_header_head_status: BlockStatusView,
 }
 
 // TODO: add more information to status.
@@ -394,7 +412,7 @@ pub struct StatusResponse {
     pub sync_info: StatusSyncInfo,
     /// Validator id of the node
     pub validator_account_id: Option<AccountId>,
-    /// Information about last blocks and sync info.
+    /// Information about last blocks, sync info and chain info.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub detailed_debug_status: Option<DetailedDebugStatus>,
 }

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -374,10 +374,7 @@ pub struct BlockStatusView {
 
 impl From<Tip> for BlockStatusView {
     fn from(tip: Tip) -> Self {
-        Self {
-            height: tip.height,
-            hash: tip.last_block_hash,
-        }
+        Self { height: tip.height, hash: tip.last_block_hash }
     }
 }
 


### PR DESCRIPTION
### Description
This PR adds the skeleton of the chain info debug page , and fills in the heights & hashes of the current head & header head.

### JIRA Issue
[CP-18](https://nearinc.atlassian.net/browse/CP-18)

### Test plan

 - Build with make neard
 - Under `nearcore` directory, launch localnet using command `nearup stop && nearup run localnet --binary-path ./target/release`
 - Open your browser and go to http://[host_address]:3030/debug/
 - Expect to see the link "Chain Info"
 - Click the link "Chain Info"
 - Expect to see a webpage that looks similar to the one below
 - Go back to http://[host_address]:3030/debug/
 - Make sure other links aren't broken, either

### Screenshot on localnet
<img width="1512" alt="Screen Shot 2022-03-25 at 1 19 29 PM" src="https://user-images.githubusercontent.com/98097537/160195292-1de980d5-c034-4db0-a6ee-7d327dfe4950.png">


### First round reviewer
 - @mzhangmzz 
 - @mm-near 