### PR TITLE
Add more debug metrics

### DIFF
--- a/chain/client/src/metrics.rs
+++ b/chain/client/src/metrics.rs
@@ -176,3 +176,19 @@ pub static CLIENT_MESSAGES_PROCESSING_TIME: Lazy<HistogramVec> = Lazy::new(|| {
     )
     .unwrap()
 });
+pub static CHECK_TRIGGERS_TIME: Lazy<Histogram> = Lazy::new(|| {
+    try_create_histogram(
+        "near_client_triggers_time",
+        "Processing time of the check_triggers function in client",
+    )
+    .unwrap()
+});
+pub static CLIENT_TRIGGER_TIME_BY_TYPE: Lazy<HistogramVec> = Lazy::new(|| {
+    try_create_histogram_vec(
+        "near_client_triggers_time_by_type",
+        "Time spent on the different triggers in client",
+        &["trigger"],
+        Some(prometheus::exponential_buckets(0.0001, 1.6, 20).unwrap()),
+    )
+    .unwrap()
+});

--- a/chain/network-primitives/src/network_protocol/mod.rs
+++ b/chain/network-primitives/src/network_protocol/mod.rs
@@ -171,6 +171,7 @@ pub struct Pong {
     PartialEq,
     Eq,
     Clone,
+    strum::AsRefStr,
     strum::AsStaticStr,
     strum::EnumVariantNames,
 )]

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -1005,12 +1005,7 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for PeerActor {
                         .then(move |res, act, ctx| {
                             if res.map(|f| f.into_inner().as_routed_message_from()).unwrap_or(false)
                             {
-                                metrics::PEER_ROUTED_MESSAGE_RECEIVED_BY_TYPE_TOTAL
-                                    .with_label_values(&[routed_message.body.as_ref(), "true"]);
                                 act.receive_message(ctx, PeerMessage::Routed(routed_message));
-                            } else {
-                                metrics::PEER_ROUTED_MESSAGE_RECEIVED_BY_TYPE_TOTAL
-                                    .with_label_values(&[routed_message.body.as_ref(), "false"]);
                             }
                             actix::fut::ready(())
                         })

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -391,14 +391,18 @@ impl PeerActor {
         // Wrap peer message into what client expects.
         let network_client_msg = match msg {
             PeerMessage::Block(block) => {
-                metrics::PEER_BLOCK_RECEIVED_TOTAL.inc();
+                metrics::PEER_CLIENT_MESSAGE_RECEIVED_BY_TYPE_TOTAL
+                    .with_label_values(&["block"])
+                    .inc();
                 let block_hash = *block.hash();
                 self.tracker.push_received(block_hash);
                 self.chain_info.height = max(self.chain_info.height, block.header().height());
                 NetworkClientMessages::Block(block, peer_id, self.tracker.has_request(&block_hash))
             }
             PeerMessage::Transaction(transaction) => {
-                metrics::PEER_TRANSACTION_RECEIVED_TOTAL.inc();
+                metrics::PEER_CLIENT_MESSAGE_RECEIVED_BY_TYPE_TOTAL
+                    .with_label_values(&["transaction"])
+                    .inc();
                 NetworkClientMessages::Transaction {
                     transaction,
                     is_forwarded: false,
@@ -406,12 +410,18 @@ impl PeerActor {
                 }
             }
             PeerMessage::BlockHeaders(headers) => {
+                metrics::PEER_CLIENT_MESSAGE_RECEIVED_BY_TYPE_TOTAL
+                    .with_label_values(&["blockheaders"])
+                    .inc();
                 NetworkClientMessages::BlockHeaders(headers, peer_id)
             }
             // All Routed messages received at this point are for us.
             PeerMessage::Routed(routed_message) => {
                 let msg_hash = routed_message.hash();
 
+                metrics::PEER_CLIENT_MESSAGE_RECEIVED_BY_TYPE_TOTAL
+                    .with_label_values(&[routed_message.body.as_ref()])
+                    .inc();
                 match routed_message.body {
                     RoutedMessageBody::BlockApproval(approval) => {
                         NetworkClientMessages::BlockApproval(approval, peer_id)

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -711,6 +711,7 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for PeerActor {
             NetworkMetrics::peer_message_bytes_rx(peer_msg.msg_variant()).as_ref(),
             msg.len() as u64,
         );
+
         metrics::PEER_MESSAGE_RECEIVED_BY_TYPE_TOTAL
             .with_label_values(&[peer_msg.msg_variant()])
             .inc();

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -1494,6 +1494,7 @@ impl PeerManagerActor {
         let _d = delay_detector::DelayDetector::new(|| {
             format!("network request {}", msg.as_ref()).into()
         });
+        metrics::REQUEST_COUNT_BY_TYPE_TOTAL.with_label_values(&[msg.as_ref()]).inc();
         match msg {
             NetworkRequests::Block { block } => {
                 Self::broadcast_message(

--- a/chain/network/src/stats/metrics.rs
+++ b/chain/network/src/stats/metrics.rs
@@ -23,6 +23,22 @@ pub static PEER_MESSAGE_RECEIVED_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
     )
     .unwrap()
 });
+pub static PEER_MESSAGE_RECEIVED_BY_TYPE_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
+    try_create_int_counter_vec(
+        "near_peer_message_received_by_type_total",
+        "Number of messages received from peers, by message types",
+        &["type"],
+    )
+    .unwrap()
+});
+pub static PEER_ROUTED_MESSAGE_RECEIVED_BY_TYPE_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
+    try_create_int_counter_vec(
+        "near_peer_routed_message_received_by_type_total",
+        "Number of routed messages received from peers, by message types and whether the messages are for this node",
+        &["type", "for_me"],
+    )
+    .unwrap()
+});
 pub static PEER_CLIENT_MESSAGE_RECEIVED_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
     try_create_int_counter(
         "near_peer_client_message_received_total",

--- a/chain/network/src/stats/metrics.rs
+++ b/chain/network/src/stats/metrics.rs
@@ -1,7 +1,8 @@
 use crate::types::PeerMessage;
 use near_metrics::{
     inc_counter_by_opt, inc_counter_opt, try_create_histogram, try_create_int_counter,
-    try_create_int_gauge, Histogram, IntCounter, IntGauge,
+    try_create_int_counter_vec, try_create_int_gauge, Histogram, IntCounter, IntCounterVec,
+    IntGauge,
 };
 use near_network_primitives::types::RoutedMessageBody;
 use once_cell::sync::Lazy;
@@ -29,14 +30,11 @@ pub static PEER_CLIENT_MESSAGE_RECEIVED_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
     )
     .unwrap()
 });
-pub static PEER_BLOCK_RECEIVED_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
-    try_create_int_counter("near_peer_block_received_total", "Number of blocks received by peers")
-        .unwrap()
-});
-pub static PEER_TRANSACTION_RECEIVED_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
-    try_create_int_counter(
-        "near_peer_transaction_received_total",
-        "Number of transactions received by peers",
+pub static PEER_CLIENT_MESSAGE_RECEIVED_BY_TYPE_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
+    try_create_int_counter_vec(
+        "near_peer_client_message_received_by_type_total",
+        "Number of messages for client received from peers, by message types",
+        &["type"],
     )
     .unwrap()
 });

--- a/chain/network/src/stats/metrics.rs
+++ b/chain/network/src/stats/metrics.rs
@@ -54,6 +54,14 @@ pub static PEER_CLIENT_MESSAGE_RECEIVED_BY_TYPE_TOTAL: Lazy<IntCounterVec> = Laz
     )
     .unwrap()
 });
+pub static REQUEST_COUNT_BY_TYPE_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
+    try_create_int_counter_vec(
+        "near_requests_count_by_type_total",
+        "Number of network requests we send out, by message types",
+        &["type"],
+    )
+    .unwrap()
+});
 
 // Routing table metrics
 pub static ROUTING_TABLE_RECALCULATIONS: Lazy<IntCounter> = Lazy::new(|| {

--- a/chain/network/src/stats/metrics.rs
+++ b/chain/network/src/stats/metrics.rs
@@ -31,14 +31,6 @@ pub static PEER_MESSAGE_RECEIVED_BY_TYPE_TOTAL: Lazy<IntCounterVec> = Lazy::new(
     )
     .unwrap()
 });
-pub static PEER_ROUTED_MESSAGE_RECEIVED_BY_TYPE_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
-    try_create_int_counter_vec(
-        "near_peer_routed_message_received_by_type_total",
-        "Number of routed messages received from peers, by message types and whether the messages are for this node",
-        &["type", "for_me"],
-    )
-    .unwrap()
-});
 pub static PEER_CLIENT_MESSAGE_RECEIVED_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
     try_create_int_counter(
         "near_peer_client_message_received_total",


### PR DESCRIPTION
Added metrics to track how much time client actor spends on each check_trigger and add more detailed network messages counting by type.
Metrics:

<img width="860" alt="Screen Shot 2022-03-29 at 6 34 46 PM" src="https://user-images.githubusercontent.com/34969888/160717964-8652b0bf-c06c-4655-8b36-ecc75b79d8fb.png">
<img width="860" alt="Screen Shot 2022-03-29 at 6 35 43 PM" src="https://user-images.githubusercontent.com/34969888/160718019-65a144a8-4986-4fbe-8183-d1546d40659c.png">

