### PR TITLE
add detailed sync info on debug sync page

### DIFF
--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1,7 +1,9 @@
 //! Client actor orchestrates Client and facilitates network connection.
 
 use crate::client::Client;
-use crate::info::{display_sync_status, get_validator_epoch_stats, InfoHelper, ValidatorInfoHelper};
+use crate::info::{
+    display_sync_status, get_validator_epoch_stats, InfoHelper, ValidatorInfoHelper,
+};
 use crate::metrics::PARTIAL_ENCODED_CHUNK_RESPONSE_DELAY;
 use crate::sync::{StateSync, StateSyncResult};
 use crate::{metrics, StatusResponse};

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1,7 +1,7 @@
 //! Client actor orchestrates Client and facilitates network connection.
 
 use crate::client::Client;
-use crate::info::{get_validator_epoch_stats, InfoHelper, ValidatorInfoHelper};
+use crate::info::{display_sync_status, get_validator_epoch_stats, InfoHelper, ValidatorInfoHelper};
 use crate::metrics::PARTIAL_ENCODED_CHUNK_RESPONSE_DELAY;
 use crate::sync::{StateSync, StateSyncResult};
 use crate::{metrics, StatusResponse};
@@ -774,7 +774,15 @@ impl Handler<Status> for ClientActor {
             Some(DetailedDebugStatus {
                 last_blocks: blocks_debug,
                 network_info: self.network_info.clone().into(),
-                sync_status: self.client.sync_status.as_variant_name().to_string(),
+                sync_status: format!(
+                    "{} ({})",
+                    self.client.sync_status.as_variant_name().to_string(),
+                    display_sync_status(
+                        &self.client.sync_status,
+                        &self.client.chain.head()?,
+                        self.client.chain.genesis_block().header().height(),
+                    ),
+                ),
             })
         } else {
             None

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -238,7 +238,7 @@ impl InfoHelper {
     }
 }
 
-fn display_sync_status(
+pub fn display_sync_status(
     sync_status: &SyncStatus,
     head: &Tip,
     genesis_height: BlockHeight,


### PR DESCRIPTION
### Description
This PR adds more detailed info of sync on the debug page, utilizing the existing `display_sync_status` method.

### JIRA Issue
[CP-19](https://nearinc.atlassian.net/browse/CP-19?atlOrigin=eyJpIjoiZTlhZDkyZWJkZmNkNDJjMTgyOWI4MTdmMTFjZTNkNDQiLCJwIjoiaiJ9)

### Test plan
 - Build with make neard
 - Under nearcore directory, launch localnet using command `nearup stop && nearup run localnet --binary-path./target/release`
 - Open your browser and go to `http://[host_address]:3030/debug/`
 - Click the link "Sync Info"
 - Expect to see a webpage that displays detailed sync info, similar to the one below, with contents in the parentheses

### Screenshots
<img width="1511" alt="Screen Shot 2022-03-28 at 5 57 31 PM" src="https://user-images.githubusercontent.com/98097537/160511309-5e3cb6d0-7efc-41c9-b83e-8209d7e7724b.png">
(on localnet)

### First round reviewers
 - @mzhangmzz
 - @mm-near