### PR TITLE
refactor: cleanup nightly alt_bn128 API 

### DIFF
--- a/core/primitives-core/src/config.rs
+++ b/core/primitives-core/src/config.rs
@@ -621,17 +621,15 @@ pub enum ExtCosts {
     #[cfg(feature = "protocol_feature_alt_bn128")]
     alt_bn128_g1_multiexp_base,
     #[cfg(feature = "protocol_feature_alt_bn128")]
-    alt_bn128_g1_multiexp_byte,
-    #[cfg(feature = "protocol_feature_alt_bn128")]
-    alt_bn128_g1_multiexp_sublinear,
+    alt_bn128_g1_multiexp_element,
     #[cfg(feature = "protocol_feature_alt_bn128")]
     alt_bn128_pairing_check_base,
     #[cfg(feature = "protocol_feature_alt_bn128")]
-    alt_bn128_pairing_check_byte,
+    alt_bn128_pairing_check_element,
     #[cfg(feature = "protocol_feature_alt_bn128")]
     alt_bn128_g1_sum_base,
     #[cfg(feature = "protocol_feature_alt_bn128")]
-    alt_bn128_g1_sum_byte,
+    alt_bn128_g1_sum_element,
 }
 
 // Type of an action, used in fees logic.
@@ -711,17 +709,15 @@ impl ExtCosts {
             #[cfg(feature = "protocol_feature_alt_bn128")]
             alt_bn128_g1_multiexp_base => config.alt_bn128_g1_multiexp_base,
             #[cfg(feature = "protocol_feature_alt_bn128")]
-            alt_bn128_g1_multiexp_byte => config.alt_bn128_g1_multiexp_byte,
-            #[cfg(feature = "protocol_feature_alt_bn128")]
-            alt_bn128_g1_multiexp_sublinear => config.alt_bn128_g1_multiexp_sublinear,
+            alt_bn128_g1_multiexp_element => config.alt_bn128_g1_multiexp_byte,
             #[cfg(feature = "protocol_feature_alt_bn128")]
             alt_bn128_pairing_check_base => config.alt_bn128_pairing_check_base,
             #[cfg(feature = "protocol_feature_alt_bn128")]
-            alt_bn128_pairing_check_byte => config.alt_bn128_pairing_check_byte,
+            alt_bn128_pairing_check_element => config.alt_bn128_pairing_check_byte,
             #[cfg(feature = "protocol_feature_alt_bn128")]
             alt_bn128_g1_sum_base => config.alt_bn128_g1_sum_base,
             #[cfg(feature = "protocol_feature_alt_bn128")]
-            alt_bn128_g1_sum_byte => config.alt_bn128_g1_sum_byte,
+            alt_bn128_g1_sum_element => config.alt_bn128_g1_sum_byte,
         }
     }
 }

--- a/core/primitives-core/src/profile.rs
+++ b/core/primitives-core/src/profile.rs
@@ -250,17 +250,15 @@ impl Cost {
         #[cfg(feature = "protocol_feature_alt_bn128")]
         Cost::ExtCost { ext_cost_kind: ExtCosts::alt_bn128_g1_multiexp_base },
         #[cfg(feature = "protocol_feature_alt_bn128")]
-        Cost::ExtCost { ext_cost_kind: ExtCosts::alt_bn128_g1_multiexp_byte },
-        #[cfg(feature = "protocol_feature_alt_bn128")]
-        Cost::ExtCost { ext_cost_kind: ExtCosts::alt_bn128_g1_multiexp_sublinear },
+        Cost::ExtCost { ext_cost_kind: ExtCosts::alt_bn128_g1_multiexp_element },
         #[cfg(feature = "protocol_feature_alt_bn128")]
         Cost::ExtCost { ext_cost_kind: ExtCosts::alt_bn128_pairing_check_base },
         #[cfg(feature = "protocol_feature_alt_bn128")]
-        Cost::ExtCost { ext_cost_kind: ExtCosts::alt_bn128_pairing_check_byte },
+        Cost::ExtCost { ext_cost_kind: ExtCosts::alt_bn128_pairing_check_element },
         #[cfg(feature = "protocol_feature_alt_bn128")]
         Cost::ExtCost { ext_cost_kind: ExtCosts::alt_bn128_g1_sum_base },
         #[cfg(feature = "protocol_feature_alt_bn128")]
-        Cost::ExtCost { ext_cost_kind: ExtCosts::alt_bn128_g1_sum_byte },
+        Cost::ExtCost { ext_cost_kind: ExtCosts::alt_bn128_g1_sum_element },
     ];
 
     pub fn index(self) -> usize {
@@ -333,17 +331,15 @@ impl Cost {
             #[cfg(feature = "protocol_feature_alt_bn128")]
             Cost::ExtCost { ext_cost_kind: ExtCosts::alt_bn128_g1_multiexp_base } => 64,
             #[cfg(feature = "protocol_feature_alt_bn128")]
-            Cost::ExtCost { ext_cost_kind: ExtCosts::alt_bn128_g1_multiexp_byte } => 65,
+            Cost::ExtCost { ext_cost_kind: ExtCosts::alt_bn128_g1_multiexp_element } => 65,
             #[cfg(feature = "protocol_feature_alt_bn128")]
-            Cost::ExtCost { ext_cost_kind: ExtCosts::alt_bn128_g1_multiexp_sublinear } => 66,
+            Cost::ExtCost { ext_cost_kind: ExtCosts::alt_bn128_pairing_check_base } => 66,
             #[cfg(feature = "protocol_feature_alt_bn128")]
-            Cost::ExtCost { ext_cost_kind: ExtCosts::alt_bn128_pairing_check_base } => 67,
+            Cost::ExtCost { ext_cost_kind: ExtCosts::alt_bn128_pairing_check_element } => 67,
             #[cfg(feature = "protocol_feature_alt_bn128")]
-            Cost::ExtCost { ext_cost_kind: ExtCosts::alt_bn128_pairing_check_byte } => 68,
+            Cost::ExtCost { ext_cost_kind: ExtCosts::alt_bn128_g1_sum_base } => 68,
             #[cfg(feature = "protocol_feature_alt_bn128")]
-            Cost::ExtCost { ext_cost_kind: ExtCosts::alt_bn128_g1_sum_base } => 69,
-            #[cfg(feature = "protocol_feature_alt_bn128")]
-            Cost::ExtCost { ext_cost_kind: ExtCosts::alt_bn128_g1_sum_byte } => 70,
+            Cost::ExtCost { ext_cost_kind: ExtCosts::alt_bn128_g1_sum_element } => 69,
         }
     }
 }

--- a/runtime/near-test-contracts/test-contract-rs/src/lib.rs
+++ b/runtime/near-test-contracts/test-contract-rs/src/lib.rs
@@ -239,31 +239,6 @@ pub unsafe fn ext_used_gas() {
     value_return(result.len() as u64, result.as_ptr() as *const u64 as u64);
 }
 
-#[cfg(feature = "protocol_feature_alt_bn128")]
-#[no_mangle]
-pub unsafe fn ext_alt_bn128_g1_multiexp() {
-    input(0);
-    alt_bn128_g1_multiexp(u64::MAX, 0, 1);
-    value_return(u64::MAX, 1);
-}
-
-#[cfg(feature = "protocol_feature_alt_bn128")]
-#[no_mangle]
-pub unsafe fn ext_alt_bn128_g1_sum() {
-    input(0);
-    alt_bn128_g1_sum(u64::MAX, 0, 1);
-    value_return(u64::MAX, 1);
-}
-
-#[cfg(feature = "protocol_feature_alt_bn128")]
-#[no_mangle]
-pub unsafe fn ext_alt_bn128_pairing_check() {
-    input(0);
-    let res = alt_bn128_pairing_check(u64::MAX, 0);
-    let byte = [res as u8; 1];
-    value_return(1, byte.as_ptr() as _);
-}
-
 #[no_mangle]
 pub unsafe fn ext_validator_stake() {
     input(0);

--- a/runtime/near-vm-errors/src/lib.rs
+++ b/runtime/near-vm-errors/src/lib.rs
@@ -219,15 +219,10 @@ pub enum HostError {
     Deprecated { method_name: String },
     /// General errors for ECDSA recover.
     ECRecoverError { msg: String },
-    /// Deserialization error for alt_bn128 functions
+    /// Invalid input to alt_bn128 familiy of functions (e.g., point which isn't
+    /// on the curve).
     #[cfg(feature = "protocol_feature_alt_bn128")]
-    AltBn128DeserializationError { msg: String },
-    /// Serialization error for alt_bn128 functions
-    #[cfg(feature = "protocol_feature_alt_bn128")]
-    AltBn128SerializationError { msg: String },
-    /// Items limit error for alt_bn128_g1_multiexp
-    #[cfg(feature = "protocol_feature_alt_bn128")]
-    AltBn128MaxNumberOfItemsExceeded,
+    AltBn128InvalidInput { msg: String },
 }
 
 #[derive(Debug, PartialEq)]
@@ -425,11 +420,7 @@ impl std::fmt::Display for HostError {
             ContractSizeExceeded { size, limit } => write!(f, "The size of a contract code in DeployContract action {} exceeds the limit {}", size, limit),
             Deprecated {method_name}=> write!(f, "Attempted to call deprecated host function {}", method_name),
             #[cfg(feature = "protocol_feature_alt_bn128")]
-            AltBn128DeserializationError { msg } => write!(f, "AltBn128 deserialization error: {}", msg),
-            #[cfg(feature = "protocol_feature_alt_bn128")]
-            AltBn128SerializationError { msg } => write!(f, "AltBn128 serialization error: {}", msg),
-            #[cfg(feature = "protocol_feature_alt_bn128")]
-            AltBn128MaxNumberOfItemsExceeded => write!(f, "AltBn128 multi exp max items exceeded."),
+            AltBn128InvalidInput { msg } => write!(f, "AltBn128 invalid input: {}", msg),
             ECRecoverError { msg } => write!(f, "ECDSA recover error: {}", msg),
         }
     }

--- a/runtime/near-vm-logic/src/alt_bn128.rs
+++ b/runtime/near-vm-logic/src/alt_bn128.rs
@@ -27,8 +27,11 @@ impl From<InvalidInput> for VMLogicError {
 pub(crate) fn split_elements<const ELEMENT_SIZE: usize>(
     data: &[u8],
 ) -> Result<ArrayChunks<'_, ELEMENT_SIZE>, InvalidInput> {
-    ArrayChunks::new(data)
-        .map_err(|leftover| InvalidInput { msg: format!("{} leftover bytes", leftover.len()) })
+    ArrayChunks::new(data).map_err(|leftover| {
+        let msg =
+            format!("invalid array, byte length {}, element size {}", data.len(), ELEMENT_SIZE);
+        InvalidInput { msg }
+    })
 }
 
 const G1_MULTIEXP_ELEMENT_SIZE: usize = POINT_SIZE + SCALAR_SIZE;

--- a/runtime/near-vm-logic/src/alt_bn128.rs
+++ b/runtime/near-vm-logic/src/alt_bn128.rs
@@ -1,348 +1,169 @@
-use bn::arith::U256;
-use bn::{pairing_batch, AffineG1, AffineG2, Fq, Fq2, Fr, Group, GroupError, Gt, G1, G2};
-use borsh::{BorshDeserialize, BorshSerialize};
-use near_vm_errors::VMLogicError;
-use std::io::{self, Error, ErrorKind, Write};
+use crate::array_utils::{join_array, split_array, ArrayChunks};
+use bn::Group;
+use near_vm_errors::{HostError, VMLogicError};
 
-use crate::HostError;
+const BOOL_SIZE: usize = 1;
+const U128_SIZE: usize = 128 / 8;
+const SCALAR_SIZE: usize = U128_SIZE * 2;
+const POINT_SIZE: usize = SCALAR_SIZE * 2;
 
-const POINT_IS_NOT_ON_THE_CURVE: &str = "point is not on the curve";
-const POINT_IS_NOT_IN_THE_SUBGROUP: &str = "point is not in the subgroup";
-const NOT_IN_FIELD: &str = "integer is not less than modulus";
-
-#[inline]
-pub fn ilog2(n: u64) -> u64 {
-    assert!(n > 0);
-    63 - n.leading_zeros() as u64
+pub(crate) struct InvalidInput {
+    pub(crate) msg: String,
 }
 
-pub fn alt_bn128_g1_multiexp_sublinear_complexity_estimate(
-    n_bytes: u64,
-    discount: u64,
-) -> Result<u64, HostError> {
-    // details of computation alt_bn128 parameters are available at https://gist.github.com/snjax/90e8b3e7f5c16a983a5f6347d1d28bde
-    const A: u64 = 85158;
-    const B: u64 = 15119;
-    const C: u64 = 682573;
-    const MULTIEXP_ITEM_SIZE: u64 = std::mem::size_of::<(G1, Fr)>() as u64;
-
-    // A+C*n/(log2(n)+4) - B*n - discount
-    let n = (n_bytes)
-        .checked_add(MULTIEXP_ITEM_SIZE)
-        .ok_or(HostError::IntegerOverflow)?
-        .checked_add(MULTIEXP_ITEM_SIZE)
-        .ok_or(HostError::IntegerOverflow)?
-        / MULTIEXP_ITEM_SIZE;
-
-    let res = A;
-    if n != 0 {
-        let growth_factor = std::cmp::min(ilog2(n), 15);
-        res.checked_add(
-            n.checked_mul(growth_factor + 3)
-                .ok_or(HostError::IntegerOverflow)?
-                .checked_add(1 << (1 + growth_factor))
-                .ok_or(HostError::IntegerOverflow)?
-                .checked_mul(C)
-                .ok_or(HostError::IntegerOverflow)?
-                / ((growth_factor + 4) * (growth_factor + 5)),
-        )
-        .ok_or(HostError::IntegerOverflow)?;
-    }
-
-    Ok(res.saturating_sub(
-        B.checked_mul(n)
-            .ok_or(HostError::IntegerOverflow)?
-            .checked_add(discount)
-            .ok_or(HostError::IntegerOverflow)?,
-    ))
-}
-
-#[derive(Copy, Clone)]
-struct WrapU256(pub U256);
-
-#[derive(Copy, Clone)]
-struct WrapFr(pub Fr);
-
-#[derive(Copy, Clone)]
-struct WrapFq(pub Fq);
-
-#[derive(Copy, Clone)]
-struct WrapFq2(pub Fq2);
-
-#[derive(Copy, Clone)]
-struct WrapG1(pub G1);
-
-#[derive(Copy, Clone)]
-struct WrapG2(pub G2);
-
-impl BorshSerialize for WrapU256 {
-    fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
-        self.0 .0.serialize(writer)
+impl InvalidInput {
+    fn new(msg: &str, bad_value: &[u8]) -> InvalidInput {
+        let msg = format!("{msg}: {bad_value:X?}");
+        InvalidInput { msg }
     }
 }
 
-impl BorshDeserialize for WrapU256 {
-    fn deserialize(buf: &mut &[u8]) -> Result<Self, Error> {
-        let value = <[u128; 2]>::deserialize(buf)?;
-        Ok(WrapU256(U256(value)))
+impl From<InvalidInput> for VMLogicError {
+    fn from(err: InvalidInput) -> Self {
+        HostError::AltBn128InvalidInput { msg: err.msg }.into()
     }
 }
 
-impl BorshSerialize for WrapFr {
-    fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
-        WrapU256(self.0.into_u256()).serialize(writer)
+pub(crate) fn split_elements<const ELEMENT_SIZE: usize>(
+    data: &[u8],
+) -> Result<ArrayChunks<'_, ELEMENT_SIZE>, InvalidInput> {
+    ArrayChunks::new(data)
+        .map_err(|leftover| InvalidInput { msg: format!("{} leftover bytes", leftover.len()) })
+}
+
+const G1_MULTIEXP_ELEMENT_SIZE: usize = POINT_SIZE + SCALAR_SIZE;
+
+pub(crate) fn g1_multiexp(
+    elements: ArrayChunks<'_, G1_MULTIEXP_ELEMENT_SIZE>,
+) -> Result<[u8; POINT_SIZE], InvalidInput> {
+    let elements: Vec<(bn::G1, bn::Fr)> = elements
+        .map(|chunk| {
+            let (g1, fr) = split_array(chunk);
+            let g1 = decode_g1(g1)?;
+            let fr = decode_fr(fr)?;
+            Ok((g1, fr))
+        })
+        .collect::<Result<Vec<_>, InvalidInput>>()?;
+
+    let res = bn::G1::multiexp(&elements);
+
+    Ok(encode_g1(res))
+}
+
+const G1_SUM_ELEMENT_SIZE: usize = BOOL_SIZE + POINT_SIZE;
+
+pub(crate) fn g1_sum(
+    elements: ArrayChunks<'_, G1_SUM_ELEMENT_SIZE>,
+) -> Result<[u8; POINT_SIZE], InvalidInput> {
+    let elements: Vec<(bool, bn::G1)> = {
+        elements
+            .map(|chunk| {
+                let (sign, g1) = split_array(chunk);
+                let sign = decode_bool(sign)?;
+                let g1 = decode_g1(g1)?;
+                Ok((sign, g1))
+            })
+            .collect::<Result<Vec<_>, InvalidInput>>()?
+    };
+
+    let res = elements
+        .iter()
+        .fold(bn::G1::zero(), |acc, &(sign, x)| if sign { acc - x } else { acc + x });
+
+    Ok(encode_g1(res))
+}
+
+const PAIRING_CHECK_ELEMENT_SIZE: usize = POINT_SIZE + POINT_SIZE * 2;
+
+pub(crate) fn pairing_check(
+    elements: ArrayChunks<'_, PAIRING_CHECK_ELEMENT_SIZE>,
+) -> Result<bool, InvalidInput> {
+    let elements: Vec<(bn::G1, bn::G2)> = elements
+        .map(|chunk| {
+            let (g1, g2) = split_array(chunk);
+            let g1 = decode_g1(g1)?;
+            let g2 = decode_g2(g2)?;
+            Ok((g1, g2))
+        })
+        .collect::<Result<Vec<_>, InvalidInput>>()?;
+
+    let res = bn::pairing_batch(&elements) == bn::Gt::one();
+
+    Ok(res)
+}
+
+fn encode_g1(val: bn::G1) -> [u8; POINT_SIZE] {
+    let (x, y) = bn::AffineG1::from_jacobian(val)
+        .map(|p| (p.x(), p.y()))
+        .unwrap_or_else(|| (bn::Fq::zero(), bn::Fq::zero()));
+    let x = encode_fq(x);
+    let y = encode_fq(y);
+    join_array(x, y)
+}
+
+fn encode_fq(val: bn::Fq) -> [u8; SCALAR_SIZE] {
+    encode_u256(val.into_u256())
+}
+
+fn encode_u256(val: bn::arith::U256) -> [u8; SCALAR_SIZE] {
+    let [lo, hi] = val.0;
+    join_array(lo.to_le_bytes(), hi.to_le_bytes())
+}
+
+fn decode_g1(raw: &[u8; POINT_SIZE]) -> Result<bn::G1, InvalidInput> {
+    let (x, y) = split_array(raw);
+    let x = decode_fq(x)?;
+    let y = decode_fq(y)?;
+    if x.is_zero() && y.is_zero() {
+        Ok(bn::G1::zero())
+    } else {
+        bn::AffineG1::new(x, y)
+            .map_err(|_err| InvalidInput::new("invalid g1", raw))
+            .map(bn::G1::from)
     }
 }
 
-impl BorshDeserialize for WrapFr {
-    fn deserialize(buf: &mut &[u8]) -> Result<Self, Error> {
-        let num = WrapU256::deserialize(buf)?.0;
-        Fr::new(num)
-            .ok_or_else(|| Error::new(ErrorKind::InvalidData, NOT_IN_FIELD))
-            .map(|r| WrapFr(r))
+fn decode_fq(raw: &[u8; SCALAR_SIZE]) -> Result<bn::Fq, InvalidInput> {
+    let val = decode_u256(raw);
+    bn::Fq::from_u256(val).map_err(|_| InvalidInput::new("invalid fq", raw))
+}
+
+fn decode_g2(raw: &[u8; 2 * POINT_SIZE]) -> Result<bn::G2, InvalidInput> {
+    let (x, y) = split_array(raw);
+    let x = decode_fq2(x)?;
+    let y = decode_fq2(y)?;
+    if x.is_zero() && y.is_zero() {
+        Ok(bn::G2::zero())
+    } else {
+        bn::AffineG2::new(x, y)
+            .map_err(|_err| InvalidInput::new("invalid g2", raw))
+            .map(bn::G2::from)
     }
 }
 
-impl BorshSerialize for WrapFq {
-    fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
-        WrapU256(self.0.into_u256()).serialize(writer)
+fn decode_fq2(raw: &[u8; 2 * SCALAR_SIZE]) -> Result<bn::Fq2, InvalidInput> {
+    let (real, imaginary) = split_array(raw);
+    let real = decode_fq(real)?;
+    let imaginary = decode_fq(imaginary)?;
+    Ok(bn::Fq2::new(real, imaginary))
+}
+
+fn decode_fr(raw: &[u8; SCALAR_SIZE]) -> Result<bn::Fr, InvalidInput> {
+    let val = decode_u256(raw);
+    bn::Fr::new(val).ok_or_else(|| InvalidInput::new("invalid fr", raw))
+}
+
+fn decode_u256(raw: &[u8; SCALAR_SIZE]) -> bn::arith::U256 {
+    let (lo, hi) = split_array(raw);
+    let lo = u128::from_le_bytes(*lo);
+    let hi = u128::from_le_bytes(*hi);
+    bn::arith::U256([lo, hi])
+}
+
+fn decode_bool(raw: &[u8; BOOL_SIZE]) -> Result<bool, InvalidInput> {
+    match raw {
+        [0] => Ok(false),
+        [1] => Ok(true),
+        _ => Err(InvalidInput::new("invalid bool", raw)),
     }
-}
-
-impl BorshDeserialize for WrapFq {
-    fn deserialize(buf: &mut &[u8]) -> Result<Self, Error> {
-        let num = WrapU256::deserialize(buf)?.0;
-        Fq::from_u256(num)
-            .map_err(|_| Error::new(ErrorKind::InvalidData, NOT_IN_FIELD))
-            .map(|r| WrapFq(r))
-    }
-}
-
-impl BorshSerialize for WrapFq2 {
-    fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
-        WrapFq(self.0.real()).serialize(writer)?;
-        WrapFq(self.0.imaginary()).serialize(writer)
-    }
-}
-
-impl BorshDeserialize for WrapFq2 {
-    fn deserialize(buf: &mut &[u8]) -> Result<Self, Error> {
-        let re = WrapFq::deserialize(buf)?.0;
-        let im = WrapFq::deserialize(buf)?.0;
-
-        Ok(WrapFq2(Fq2::new(re, im)))
-    }
-}
-
-impl BorshSerialize for WrapG1 {
-    fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
-        match AffineG1::from_jacobian(self.0) {
-            Some(p) => {
-                WrapFq(p.x()).serialize(writer)?;
-                WrapFq(p.y()).serialize(writer)?;
-            }
-            None => {
-                WrapFq(Fq::zero()).serialize(writer)?;
-                WrapFq(Fq::zero()).serialize(writer)?;
-            }
-        }
-        Ok(())
-    }
-}
-
-impl BorshDeserialize for WrapG1 {
-    fn deserialize(buf: &mut &[u8]) -> Result<Self, io::Error> {
-        let x = WrapFq::deserialize(buf)?.0;
-        let y = WrapFq::deserialize(buf)?.0;
-        if x.is_zero() && y.is_zero() {
-            Ok(WrapG1(G1::zero()))
-        } else {
-            AffineG1::new(x, y)
-                .map_err(|e| match e {
-                    GroupError::NotOnCurve => {
-                        io::Error::new(ErrorKind::InvalidData, POINT_IS_NOT_ON_THE_CURVE)
-                    }
-                    GroupError::NotInSubgroup => {
-                        io::Error::new(ErrorKind::InvalidData, POINT_IS_NOT_IN_THE_SUBGROUP)
-                    }
-                })
-                .map(|p| WrapG1(p.into()))
-        }
-    }
-}
-
-impl BorshSerialize for WrapG2 {
-    fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
-        match AffineG2::from_jacobian(self.0) {
-            Some(p) => {
-                WrapFq2(p.x()).serialize(writer)?;
-                WrapFq2(p.y()).serialize(writer)?;
-            }
-            None => {
-                WrapFq2(Fq2::zero()).serialize(writer)?;
-                WrapFq2(Fq2::zero()).serialize(writer)?;
-            }
-        }
-        Ok(())
-    }
-}
-
-impl BorshDeserialize for WrapG2 {
-    fn deserialize(buf: &mut &[u8]) -> Result<Self, io::Error> {
-        let x = WrapFq2::deserialize(buf)?.0;
-        let y = WrapFq2::deserialize(buf)?.0;
-        if x.is_zero() && y.is_zero() {
-            Ok(WrapG2(G2::zero()))
-        } else {
-            AffineG2::new(x, y)
-                .map_err(|e| match e {
-                    GroupError::NotOnCurve => {
-                        io::Error::new(ErrorKind::InvalidData, POINT_IS_NOT_ON_THE_CURVE)
-                    }
-                    GroupError::NotInSubgroup => {
-                        io::Error::new(ErrorKind::InvalidData, POINT_IS_NOT_IN_THE_SUBGROUP)
-                    }
-                })
-                .map(|p| WrapG2(p.into()))
-        }
-    }
-}
-
-/// Computes multiexp on alt_bn128 curve using Pippenger's algorithm
-/// \sum_i mul_i g_{1 i} should be equal result.
-/// Allows at max 5000 items
-///
-/// # Arguments
-///
-/// * `data` - slice of (g1:G1, fr:Fr), where
-///     G1 is point (x:Fq, y:Fq) on alt_bn128,
-///     alt_bn128 is Y^2 = X^3 + 3 curve over Fq,
-///     Fq is LE-serialized u256 number lesser than 21888242871839275222246405745257275088696311157297823662689037894645226208583
-///     Fr is LE-serialized u256 number lesser than 21888242871839275222246405745257275088548364400416034343698204186575808495617
-///
-/// # Errors
-///
-/// If point coordinates are not on curve, point is not in the subgroup, scalar
-/// is not in the field or data are wrong serialized, for example,
-/// `data.len()%std::mem::sizeof::<(G1,Fr)>()!=0`, the function returns `AltBn128DeserializationError`.
-///
-/// If `borsh::BorshSerialize` returns error during serialization, the function
-/// returns `AltBn128SerializationError`.
-///
-/// # Example
-/// ```
-/// # use near_vm_logic::alt_bn128::alt_bn128_g1_multiexp;
-/// # use base64;
-///
-/// let multiexp_data = "AgAAAOzTRBYFMdAMNTUnUW2wNUYLmsNMgKQUC12+o1wVU7QSxF/il/WRT3I1bJqPaWKBbGqehkYu0QS7ct2nz52CRCn3EXSIf0p4ORYJ7mRmZLWtUyGrqlKl/4DNx2kHDEUrET+SS7pJZ4ql4b8tnwGv8W020cyHrmLCU15/Hp+LLCsD2H5fx6TkvPtG6iZSiHT1Ih1TDyGsHTrOzFWN3hx0FwAaB2tgYeH+WuEKReDHNFmxyi8v597Ji5NP4PU8bZXkGQ==";
-/// let multiexp_result_data = "qoK67D1yppH5iP0qhCrD8Ms+idcZtEry4EegUtSpIylhCyZNbRQ0xVdRe9hQBxZIovzCMwFRMAdcZ5FB+QA6Lg==";
-/// let multiexp = base64::decode(multiexp_data).unwrap();
-/// let multiexp_result = base64::decode(multiexp_result_data).unwrap();
-/// let result = alt_bn128_g1_multiexp(&multiexp).unwrap();
-/// assert_eq!(multiexp_result, result);
-///
-/// ```
-pub fn alt_bn128_g1_multiexp(data: &[u8]) -> crate::logic::Result<Vec<u8>> {
-    let items = <Vec<(WrapG1, WrapFr)>>::try_from_slice(data)
-        .map_err(|e| HostError::AltBn128DeserializationError { msg: format!("{}", e) })?
-        .into_iter()
-        .map(|e| (e.0 .0, e.1 .0))
-        .collect::<Vec<_>>();
-    // Upper bounded by 2^9 buckets
-    // Reference: https://github.com/zeropoolnetwork/bn/blob/b25e138cd5a7d98ad16c091c20b4fa273ca1f993/src/groups/mod.rs#L71
-    if items.len() > 5000 {
-        return Err(VMLogicError::HostError(HostError::AltBn128MaxNumberOfItemsExceeded));
-    }
-    let result = WrapG1(G1::multiexp(&items))
-        .try_to_vec()
-        .map_err(|e| HostError::AltBn128SerializationError { msg: format!("{}", e) })?;
-    Ok(result)
-}
-
-/// Computes sum for signed g1 group elements on alt_bn128 curve
-/// \sum_i (-1)^{sign_i} g_{1 i} should be equal result.
-///
-/// # Arguments
-///
-/// * `data` - slice of (is_negative_sign:bool, g1:G1), where
-///     bool is serialized as byte, 0 for false and 1 for true,
-///     G1 is point (x:Fq, y:Fq) on alt_bn128,
-///     alt_bn128 is Y^2 = X^3 + 3 curve over Fq,
-///     Fq is LE-serialized u256 number lesser than 21888242871839275222246405745257275088696311157297823662689037894645226208583
-///
-/// # Errors
-///
-/// If point coordinates are not on curve, point is not in the subgroup, scalar
-/// is not in the field or data are wrong serialized, for example,
-/// `data.len()%std::mem::sizeof::<(bool, G1)>()!=0`, the function returns `AltBn128DeserializationError`.
-///
-/// If `borsh::BorshSerialize` returns error during serialization, the function
-/// returns `AltBn128SerializationError`.///
-/// # Example
-/// ```
-/// # use near_vm_logic::alt_bn128::alt_bn128_g1_sum;
-/// # use base64;
-///
-/// let sum_data = "AgAAAADs00QWBTHQDDU1J1FtsDVGC5rDTICkFAtdvqNcFVO0EsRf4pf1kU9yNWyaj2ligWxqnoZGLtEEu3Ldp8+dgkQpAT+SS7pJZ4ql4b8tnwGv8W020cyHrmLCU15/Hp+LLCsDb34dEXKnY0BG4EoWCfaLdEAFcmAKKBbqXEqkAlbaTDA=";
-/// let sum_result_data = "6I9NGC6Ikzk7Xw/CIippAtOEsTx4TodcXRjzzu5TLh4EIPsrWPsfnQMtqKfMMF+SHgSphZseRKyej9jTVCT8Aw==";
-/// let sum = base64::decode(sum_data).unwrap();
-/// let sum_result = base64::decode(sum_result_data).unwrap();
-/// let result = alt_bn128_g1_sum(&sum).unwrap();
-/// assert_eq!(sum_result, result);
-///
-/// ```
-pub fn alt_bn128_g1_sum(data: &[u8]) -> crate::logic::Result<Vec<u8>> {
-    let items = <Vec<(bool, WrapG1)>>::try_from_slice(data)
-        .map_err(|e| HostError::AltBn128DeserializationError { msg: format!("{}", e) })?
-        .into_iter()
-        .map(|e| (e.0, e.1 .0))
-        .collect::<Vec<_>>();
-
-    let mut acc = G1::zero();
-    acc = items.iter().fold(acc, |acc, &(sign, e)| if sign { acc - e } else { acc + e });
-
-    let result = WrapG1(acc)
-        .try_to_vec()
-        .map_err(|e| HostError::AltBn128SerializationError { msg: format!("{}", e) })?;
-    Ok(result)
-}
-
-/// Computes pairing check on alt_bn128 curve.
-/// \sum_i e(g_{1 i}, g_{2 i}) should be equal to one (in additive notation), e(g1, g2) is Ate pairing
-///
-/// # Arguments
-///
-/// * `data` - slice of (g1:G1, g2:G2), where
-///     G2 is Fr-ordered subgroup point (x:Fq2, y:Fq2) on alt_bn128 twist,
-///     alt_bn128 twist is Y^2 = X^3 + 3/(i+9) curve over Fq2
-///     Fq2 is complex field element (re: Fq, im: Fq)
-///     G1 is point (x:Fq, y:Fq) on alt_bn128,
-///     alt_bn128 is Y^2 = X^3 + 3 curve over Fq
-///     Fq is LE-serialized u256 number lesser than 21888242871839275222246405745257275088696311157297823662689037894645226208583
-///     Fr is LE-serialized u256 number lesser than 21888242871839275222246405745257275088548364400416034343698204186575808495617
-///
-/// # Errors
-///
-/// If point coordinates are not on curve, point is not in the subgroup, scalar
-/// is not in the field or data are wrong serialized, for example,
-/// `data.len()%std::mem::sizeof::<(G1,G2)>()!=0`, the function returns `AltBn128DeserializationError`.
-///
-/// # Example
-/// ```
-/// # use near_vm_logic::alt_bn128::alt_bn128_pairing_check;
-/// # use base64;
-///
-/// let pairs_data = "AgAAAHUK2WNxTupDt1oaOshWw3squNVY4PgSyGwGtQYcEWMHJIY1c8C0A3FM466TMq5PSpfDrArT0hpcdfZB7ahoEAQBGgPbBg3Bc03mGw3y1sMJ1WOHDKDKcoevKnSsT+oaKdRvwIF8cDlrJvTm3vAkQe6FvBMrlDvNKKGzreRYqecdEUOjM6W7ZSz6GERlXIDLvjNVCSs6iES0XG65qGuBLR67FmQRS13YfRfUC7rHzAGMhQtSLEHeFBowGoTcGdVdGU+wBJWX8wuD/el5Jt4PdnXI1q/pgrXBp/+ZqfDP6xwfU0pFswaWSENKpoJTUnN7b9DdQCvt1brrBzj7s1/pnxdtrVVnCKXr4tpPSHis+xRTecmMYqr2edoTcyqHPO8eIDGqq8zExaCeqC8Xbot73t71Yn3QRiduupL+Qrl2A04gL7PFXU/wzE7shdWtdV4/mkRZ7IoA9/LU9SH5ACP26QB8VsaiyTYTGsRL/kdG7jMCF7mYi4ZBa4Fy9C/78FDBFw==";
-/// let pairs = base64::decode(pairs_data).unwrap();
-/// let pairs_result = alt_bn128_pairing_check(&pairs).unwrap();
-/// assert!(pairs_result);
-///
-/// ```
-pub fn alt_bn128_pairing_check(data: &[u8]) -> crate::logic::Result<bool> {
-    let items = <Vec<(WrapG1, WrapG2)>>::try_from_slice(data)
-        .map_err(|e| HostError::AltBn128DeserializationError { msg: format!("{}", e) })?
-        .into_iter()
-        .map(|e| (e.0 .0, e.1 .0))
-        .collect::<Vec<_>>();
-    Ok(pairing_batch(&items) == Gt::one())
 }

--- a/runtime/near-vm-logic/src/alt_bn128.rs
+++ b/runtime/near-vm-logic/src/alt_bn128.rs
@@ -3,8 +3,7 @@ use bn::Group;
 use near_vm_errors::{HostError, VMLogicError};
 
 const BOOL_SIZE: usize = 1;
-const U128_SIZE: usize = 128 / 8;
-const SCALAR_SIZE: usize = U128_SIZE * 2;
+const SCALAR_SIZE: usize = 256 / 8;
 const POINT_SIZE: usize = SCALAR_SIZE * 2;
 
 pub(crate) struct InvalidInput {
@@ -27,7 +26,7 @@ impl From<InvalidInput> for VMLogicError {
 pub(crate) fn split_elements<const ELEMENT_SIZE: usize>(
     data: &[u8],
 ) -> Result<ArrayChunks<'_, ELEMENT_SIZE>, InvalidInput> {
-    ArrayChunks::new(data).map_err(|leftover| {
+    ArrayChunks::new(data).map_err(|()| {
         let msg =
             format!("invalid array, byte length {}, element size {}", data.len(), ELEMENT_SIZE);
         InvalidInput { msg }

--- a/runtime/near-vm-logic/src/array_utils.rs
+++ b/runtime/near-vm-logic/src/array_utils.rs
@@ -33,10 +33,10 @@ pub(crate) struct ArrayChunks<'a, const N: usize> {
 }
 
 impl<'a, const N: usize> ArrayChunks<'a, N> {
-    pub(crate) fn new(bytes: &'a [u8]) -> Result<ArrayChunks<'a, N>, &'a [u8]> {
+    pub(crate) fn new(bytes: &'a [u8]) -> Result<ArrayChunks<'a, N>, ()> {
         let inner = bytes.chunks_exact(N);
         if !inner.remainder().is_empty() {
-            return Err(inner.remainder());
+            return Err(());
         }
         Ok(ArrayChunks { inner })
     }

--- a/runtime/near-vm-logic/src/array_utils.rs
+++ b/runtime/near-vm-logic/src/array_utils.rs
@@ -1,0 +1,63 @@
+//! Polyfils for missing const-generic array APIs in the std.
+
+use std::slice::ChunksExact;
+
+/// Splits `&[u8; A + B]` into `(&[u8; A], &[u8; B])`.
+pub(crate) fn split_array<const N: usize, const L: usize, const R: usize>(
+    xs: &[u8; N],
+) -> (&[u8; L], &[u8; R]) {
+    let () = AssertEqSum::<N, L, R>::OK;
+
+    let (left, right) = xs.split_at(L);
+    (left.try_into().unwrap(), right.try_into().unwrap())
+}
+
+/// Joins `[u8; A]` and `[u8; B]` into `[u8; A + B]`.
+pub(crate) fn join_array<const N: usize, const L: usize, const R: usize>(
+    left: [u8; L],
+    right: [u8; R],
+) -> [u8; N] {
+    let () = AssertEqSum::<N, L, R>::OK;
+
+    let mut res = [0; N];
+    let (l, r) = res.split_at_mut(L);
+    l.copy_from_slice(&left);
+    r.copy_from_slice(&right);
+    res
+}
+
+/// Converts an `&[u8]` slice of length `N * k` into iterator of `k` `[u8; N]`
+/// chunks.
+pub(crate) struct ArrayChunks<'a, const N: usize> {
+    inner: ChunksExact<'a, u8>,
+}
+
+impl<'a, const N: usize> ArrayChunks<'a, N> {
+    pub(crate) fn new(bytes: &'a [u8]) -> Result<ArrayChunks<'a, N>, &'a [u8]> {
+        let inner = bytes.chunks_exact(N);
+        if !inner.remainder().is_empty() {
+            return Err(inner.remainder());
+        }
+        Ok(ArrayChunks { inner })
+    }
+}
+
+impl<'a, const N: usize> Iterator for ArrayChunks<'a, N> {
+    type Item = &'a [u8; N];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|it| it.try_into().unwrap())
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+impl<'a, const N: usize> ExactSizeIterator for ArrayChunks<'a, N> {}
+
+/// Asserts, at compile time, that `S == A + B`.
+struct AssertEqSum<const S: usize, const A: usize, const B: usize>;
+impl<const S: usize, const A: usize, const B: usize> AssertEqSum<S, A, B> {
+    const OK: () = [()][A + B - S];
+}

--- a/runtime/near-vm-logic/src/lib.rs
+++ b/runtime/near-vm-logic/src/lib.rs
@@ -1,7 +1,9 @@
 #![doc = include_str!("../README.md")]
 
 #[cfg(feature = "protocol_feature_alt_bn128")]
-pub mod alt_bn128;
+mod alt_bn128;
+#[cfg(feature = "protocol_feature_alt_bn128")]
+mod array_utils;
 mod context;
 mod dependencies;
 pub mod gas_counter;

--- a/runtime/near-vm-logic/src/logic.rs
+++ b/runtime/near-vm-logic/src/logic.rs
@@ -781,22 +781,33 @@ impl<'a> VMLogic<'a> {
     // # Math API #
     // ############
 
-    /// Compute multiexp on alt_bn128 curve.
-    /// See more detailed description at `alt_bn128::alt_bn128_g1_multiexp`.
+    /// Computes multiexp on alt_bn128 curve using Pippenger's algorithm \sum_i
+    /// mul_i g_{1 i} should be equal result.
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - sequence of (g1:G1, fr:Fr), where
+    ///    G1 is point (x:Fq, y:Fq) on alt_bn128,
+    ///   alt_bn128 is Y^2 = X^3 + 3 curve over Fq.
+    ///
+    ///   `value` is encoded as packed, little-endian
+    ///   `[((u256, u256), u256)]` slice.
     ///
     /// # Errors
     ///
-    /// If `value_len + value_ptr` points outside the memory or the registers use more memory than
-    /// the limit with `MemoryAccessViolation`.
+    /// If `value_len + value_ptr` points outside the memory or the registers
+    /// use more memory than the limit, the function returns
+    /// `MemoryAccessViolation`.
     ///
-    /// AltBn128SerializationError, AltBn128DeserializationError
+    /// If point coordinates are not on curve, point is not in the subgroup,
+    /// scalar is not in the field or  `value.len()%96!=0`, the function returns
+    /// `AltBn128InvalidInput`.
     ///
     /// # Cost
     ///
-    /// `base + write_register_base + write_register_byte * num_bytes + alt_bn128_g1_multiexp_base +
-    /// alt_bn128_g1_multiexp_byte * num_bytes + alt_bn128_g1_multiexp_sublinear *
-    /// alt_bn128_g1_multiexp_sublinear_complexity_estimate(num_bytes, (alt_bn128_g1_multiexp_base *
-    /// alt_bn128_g1_multiexp_byte * num_bytes) / alt_bn128_g1_multiexp_sublinear)`
+    /// `base + write_register_base + write_register_byte * num_bytes +
+    ///  alt_bn128_g1_multiexp_base +
+    ///  alt_bn128_g1_multiexp_element * num_elements`
     #[cfg(feature = "protocol_feature_alt_bn128")]
     pub fn alt_bn128_g1_multiexp(
         &mut self,
@@ -805,40 +816,42 @@ impl<'a> VMLogic<'a> {
         register_id: u64,
     ) -> Result<()> {
         self.gas_counter.pay_base(alt_bn128_g1_multiexp_base)?;
-        let value_buf = self.get_vec_from_memory_or_register(value_ptr, value_len)?;
-        let len = value_buf.len() as u64;
-        self.gas_counter.pay_per(alt_bn128_g1_multiexp_byte, len)?;
+        let data = self.get_vec_from_memory_or_register(value_ptr, value_len)?;
 
-        let discount = ((alt_bn128_g1_multiexp_base as u64)
-            .checked_add(
-                (alt_bn128_g1_multiexp_byte as u64)
-                    .checked_mul(len)
-                    .ok_or(HostError::IntegerOverflow)?,
-            )
-            .ok_or(HostError::IntegerOverflow)?)
-            / alt_bn128_g1_multiexp_sublinear as u64;
-        let sublinear_complexity =
-            crate::alt_bn128::alt_bn128_g1_multiexp_sublinear_complexity_estimate(len, discount)?;
-        self.gas_counter.pay_per(alt_bn128_g1_multiexp_sublinear, sublinear_complexity)?;
+        let elements = crate::alt_bn128::split_elements(&data)?;
+        self.gas_counter.pay_per(alt_bn128_g1_multiexp_element, elements.len() as u64)?;
 
-        let res = crate::alt_bn128::alt_bn128_g1_multiexp(&value_buf)?;
+        let res = crate::alt_bn128::g1_multiexp(elements)?;
 
-        self.internal_write_register(register_id, res)
+        self.internal_write_register(register_id, res.into())
     }
 
-    /// Compute signed sum on alt_bn128 for g1 group.
-    /// See more detailed description at `alt_bn128::alt_bn128_g1_sum`.
+    /// Computes sum for signed g1 group elements on alt_bn128 curve \sum_i
+    /// (-1)^{sign_i} g_{1 i} should be equal result.
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - sequence of (sign:bool, g1:G1), where
+    ///    G1 is point (x:Fq, y:Fq) on alt_bn128,
+    ///    alt_bn128 is Y^2 = X^3 + 3 curve over Fq.
+    ///
+    ///   `value` is encoded as packed, little-endian
+    ///   `[(u8, (u256, u256))]` slice. `0u8` is postive sign,
+    ///   `1u8` -- negative.
     ///
     /// # Errors
     ///
-    /// If `value_len + value_ptr` points outside the memory or the registers use more memory than
-    /// the limit with `MemoryAccessViolation`.
+    /// If `value_len + value_ptr` points outside the memory or the registers
+    /// use more memory than the limit, the function returns `MemoryAccessViolation`.
     ///
-    /// AltBn128SerializationError, AltBn128DeserializationError
+    /// If point coordinates are not on curve, point is not in the subgroup,
+    /// scalar is not in the field, sign is not 0 or 1, or `value.len()%65!=0`,
+    /// the function returns `AltBn128InvalidInput`.
     ///
     /// # Cost
     ///
-    /// `base + write_register_base + write_register_byte * num_bytes + alt_bn128_g1_sum_base + alt_bn128_g1_sum_byte * num_bytes`
+    /// `base + write_register_base + write_register_byte * num_bytes +
+    /// alt_bn128_g1_sum_base + alt_bn128_g1_sum_element * num_elements`
     #[cfg(feature = "protocol_feature_alt_bn128")]
     pub fn alt_bn128_g1_sum(
         &mut self,
@@ -847,34 +860,54 @@ impl<'a> VMLogic<'a> {
         register_id: u64,
     ) -> Result<()> {
         self.gas_counter.pay_base(alt_bn128_g1_sum_base)?;
-        let value_buf = self.get_vec_from_memory_or_register(value_ptr, value_len)?;
-        self.gas_counter.pay_per(alt_bn128_g1_sum_byte, value_buf.len() as u64)?;
+        let data = self.get_vec_from_memory_or_register(value_ptr, value_len)?;
 
-        let res = crate::alt_bn128::alt_bn128_g1_sum(&value_buf)?;
+        let elements = crate::alt_bn128::split_elements(&data)?;
+        self.gas_counter.pay_per(alt_bn128_g1_sum_element, elements.len() as u64)?;
 
-        self.internal_write_register(register_id, res)
+        let res = crate::alt_bn128::g1_sum(elements)?;
+
+        self.internal_write_register(register_id, res.into())
     }
 
-    /// Compute pairing check on alt_bn128 curve.
-    /// See more detailed description at `alt_bn128::alt_bn128_pairing_check`.
+    /// Computes pairing check on alt_bn128 curve.
+    /// \sum_i e(g_{1 i}, g_{2 i}) should be equal one (in additive notation), e(g1, g2) is Ate pairing
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - sequence of (g1:G1, g2:G2), where
+    ///   G2 is Fr-ordered subgroup point (x:Fq2, y:Fq2) on alt_bn128 twist,
+    ///   alt_bn128 twist is Y^2 = X^3 + 3/(i+9) curve over Fq2
+    ///   Fq2 is complex field element (re: Fq, im: Fq)
+    ///   G1 is point (x:Fq, y:Fq) on alt_bn128,
+    ///   alt_bn128 is Y^2 = X^3 + 3 curve over Fq
+    ///
+    ///   `value` is encoded a as packed, little-endian
+    ///   `[((u256, u256), ((u256, u256), (u256, u256)))]` slice.
     ///
     /// # Errors
     ///
     /// If `value_len + value_ptr` points outside the memory or the registers use more memory than
-    /// the limit with `MemoryAccessViolation`.
+    /// the function returns `MemoryAccessViolation`.
     ///
-    /// AltBn128SerializationError, AltBn128DeserializationError
+    /// If point coordinates are not on curve, point is not in the subgroup, scalar
+    /// is not in the field or data are wrong serialized, for example,
+    /// `value.len()%192!=0`, the function returns `AltBn128InvalidInput`.
     ///
     /// # Cost
     ///
-    /// `base + write_register_base + write_register_byte * num_bytes + alt_bn128_pairing_base + alt_bn128_pairing_byte * num_bytes`
+    /// `base + write_register_base + write_register_byte * num_bytes + alt_bn128_pairing_base + alt_bn128_pairing_element * num_elements`
     #[cfg(feature = "protocol_feature_alt_bn128")]
     pub fn alt_bn128_pairing_check(&mut self, value_len: u64, value_ptr: u64) -> Result<u64> {
         self.gas_counter.pay_base(alt_bn128_pairing_check_base)?;
-        let value_buf = self.get_vec_from_memory_or_register(value_ptr, value_len)?;
-        self.gas_counter.pay_per(alt_bn128_pairing_check_byte, value_buf.len() as u64)?;
+        let data = self.get_vec_from_memory_or_register(value_ptr, value_len)?;
 
-        Ok(crate::alt_bn128::alt_bn128_pairing_check(&value_buf)? as u64)
+        let elements = crate::alt_bn128::split_elements(&data)?;
+        self.gas_counter.pay_per(alt_bn128_pairing_check_element, elements.len() as u64)?;
+
+        let res = crate::alt_bn128::pairing_check(elements)?;
+
+        Ok(res as u64)
     }
 
     /// Writes random seed into the register.

--- a/runtime/near-vm-logic/src/tests/alt_bn128.rs
+++ b/runtime/near-vm-logic/src/tests/alt_bn128.rs
@@ -1,6 +1,72 @@
-use near_vm_errors::{HostError, VMLogicError};
-
 use super::{fixtures::get_context, vm_logic_builder::VMLogicBuilder};
+use near_vm_errors::{HostError, VMLogicError};
+use std::fmt::Write;
+
+/// Converts a sequence of integers to a single little-endian encoded byte
+/// vector. `u8` literals like `0u8` are treated as u8, hex literals like
+/// `0xbeef` are treated as `u256`.
+///
+/// Comas (`,`) can be used for readability, but don't affect semantics
+macro_rules! le_bytes {
+    ($($lit:tt)*) => (
+        {
+            #[allow(unused_mut)]
+            let mut buf: Vec<u8> = Vec::new();
+            $(parse_le_bytes(stringify!($lit), &mut buf);)*
+            buf
+        }
+    )
+}
+
+fn parse_le_bytes(s: &str, buf: &mut Vec<u8>) {
+    if s == "," {
+        return;
+    }
+    if let Some(byte) = s.strip_suffix("u8") {
+        buf.push(byte.parse::<u8>().unwrap());
+        return;
+    }
+    assert!(s.starts_with("0x"));
+    let s = &s[2..];
+    let zeros = "0".repeat(64 - s.len());
+    let s = format!("{zeros}{s}");
+    let hi = u128::from_str_radix(&s[..32], 16).unwrap();
+    let lo = u128::from_str_radix(&s[32..], 16).unwrap();
+    buf.extend(lo.to_le_bytes());
+    buf.extend(hi.to_le_bytes());
+}
+
+/// Renders a slice of bytes representing a point on the curve (a pair of u256)
+/// as `[le_bytes!]` compatible representation.
+fn render_le_bytes(p: &[u8]) -> String {
+    assert_eq!(p.len(), 64);
+    let mut res = String::new();
+    res.push_str("[");
+    let mut first = true;
+    for c in [&p[..32], &p[32..]] {
+        if !first {
+            res.push(' ');
+        }
+        first = false;
+        res.push_str("0x");
+        for b in c.iter().rev() {
+            write!(res, "{:02x}", b).unwrap();
+        }
+    }
+    res.push_str("]");
+    res
+}
+
+#[track_caller]
+fn assert_eq_points(left: &[u8], right: &[u8]) {
+    assert_eq!(
+        left,
+        right,
+        "differet poits on the cureve\n  left: {}\n  right {}\n",
+        render_le_bytes(left),
+        render_le_bytes(right)
+    );
+}
 
 #[track_caller]
 fn check_result<T, U>(
@@ -22,10 +88,7 @@ fn check_result<T, U>(
 #[test]
 fn test_alt_bn128_g1_multiexp() {
     #[track_caller]
-    fn check(input: &str, expected: Result<&str, &str>) {
-        let input = base64::decode(input).unwrap();
-        let expected = expected.map(|it| base64::decode(it).unwrap());
-
+    fn check(input: &[u8], expected: Result<&[u8], &str>) {
         let mut logic_builder = VMLogicBuilder::default();
         let mut logic = logic_builder.build(get_context(vec![], false));
 
@@ -38,30 +101,32 @@ fn test_alt_bn128_g1_multiexp() {
         }
     }
     #[track_caller]
-    fn check_ok(input: &str, expcted: &str) {
+    fn check_ok(input: &[u8], expcted: &[u8]) {
         check(input, Ok(expcted))
     }
     #[track_caller]
-    fn check_err(input: &str, expected_err: &str) {
+    fn check_err(input: &[u8], expected_err: &str) {
         check(input, Err(expected_err))
     }
 
+    check_ok(&le_bytes![], &le_bytes![0x0 0x0]);
     check_ok(
-        "",
-        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
-    );
-    check_ok(
-        "7NNEFgUx0Aw1NSdRbbA1Rguaw0yApBQLXb6jXBVTtBLEX+KX9ZFPcjVsmo9pYoFsap6GRi7RBLty3afPnYJEKfcRdIh/Sng5FgnuZGZkta1TIauqUqX/gM3HaQcMRSsRP5JLuklniqXhvy2fAa/xbTbRzIeuYsJTXn8en4ssKwPYfl/HpOS8+0bqJlKIdPUiHVMPIawdOs7MVY3eHHQXABoHa2Bh4f5a4QpF4Mc0WbHKLy/n3smLk0/g9TxtleQZ",
-    "qoK67D1yppH5iP0qhCrD8Ms+idcZtEry4EegUtSpIylhCyZNbRQ0xVdRe9hQBxZIovzCMwFRMAdcZ5FB+QA6Lg==",
+        &le_bytes![
+            0x12b453155ca3be5d0b14a4804cc39a0b4635b06d512735350cd031051644d3ec 0x2944829dcfa7dd72bb04d12e46869e6a6c8162698f9a6c35724f91f597e25fc4  0x112b450c0769c7cd80ffa552aaab2153adb5646664ee091639784a7f887411f7,
+            0x032b2c8b9f1e7f5e53c262ae87ccd1366df1af019f2dbfe1a58a6749ba4b923f 0x0017741cde8d55ccce3a1dac210f531d22f574885226ea46fbbce4a4c75f7ed8  0x19e4956d3cf5e04f938bc9dee72f2fcab15934c7e0450ae15afee161606b071a,
+        ],
+        &le_bytes![0x2923a9d452a047e0f24ab419d7893ecbf0c32a842afd88f991a6723decba82aa 0x2e3a00f94191675c0730510133c2fca248160750d87b5157c534146d4d260b61],
     );
 
-    check_err("XXXX", "leftover bytes");
+    check_err(b"XXXX", "leftover bytes");
     check_err(
-        "XAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        &le_bytes![0x92  0x2944829dcfa7dd72bb04d12e46869e6a6c8162698f9a6c35724f91f597e25fc4 0x112b450c0769c7cd80ffa552aaab2153adb5646664ee091639784a7f887411f7],
         "invalid g1",
     );
     check_err(
-        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXXX",
+        &le_bytes![
+            0x12b453155ca3be5d0b14a4804cc39a0b4635b06d512735350cd031051644d3ec 0x2944829dcfa7dd72bb04d12e46869e6a6c8162698f9a6c35724f91f597e25fc4  0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+        ],
         "invalid fr",
     );
 }
@@ -69,46 +134,47 @@ fn test_alt_bn128_g1_multiexp() {
 #[test]
 fn test_alt_bn128_g1_sum() {
     #[track_caller]
-    fn check(input: &str, expected: Result<&str, &str>) {
-        let input = base64::decode(input).unwrap();
-        let expected = expected.map(|it| base64::decode(it).unwrap());
-
+    fn check(input: &[u8], expected: Result<&[u8], &str>) {
         let mut logic_builder = VMLogicBuilder::default();
         let mut logic = logic_builder.build(get_context(vec![], false));
 
         let res = logic.alt_bn128_g1_sum(input.len() as _, input.as_ptr() as _, 0);
         if let Some(((), expected)) = check_result(res, expected) {
             let len = logic.register_len(0).unwrap();
-            let mut res = vec![0; len as usize];
+            let mut res = vec![0u8; len as usize];
             logic.read_register(0, res.as_mut_ptr() as _).unwrap();
-            assert_eq!(res, expected)
+            assert_eq_points(&res, expected)
         }
     }
     #[track_caller]
-    fn check_ok(input: &str, expcted: &str) {
+    fn check_ok(input: &[u8], expcted: &[u8]) {
         check(input, Ok(expcted))
     }
     #[track_caller]
-    fn check_err(input: &str, expected_err: &str) {
+    fn check_err(input: &[u8], expected_err: &str) {
         check(input, Err(expected_err))
     }
 
+    check_ok(&le_bytes![], &le_bytes![0x0 0x0]);
     check_ok(
-        "",
-        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
-    );
-    check_ok(
-        "AOzTRBYFMdAMNTUnUW2wNUYLmsNMgKQUC12+o1wVU7QSxF/il/WRT3I1bJqPaWKBbGqehkYu0QS7ct2nz52CRCkBP5JLuklniqXhvy2fAa/xbTbRzIeuYsJTXn8en4ssKwNvfh0RcqdjQEbgShYJ9ot0QAVyYAooFupcSqQCVtpMMA==",
-        "6I9NGC6Ikzk7Xw/CIippAtOEsTx4TodcXRjzzu5TLh4EIPsrWPsfnQMtqKfMMF+SHgSphZseRKyej9jTVCT8Aw=="
+        &le_bytes![
+            0u8  0x12b453155ca3be5d0b14a4804cc39a0b4635b06d512735350cd031051644d3ec 0x2944829dcfa7dd72bb04d12e46869e6a6c8162698f9a6c35724f91f597e25fc4,
+            1u8  0x032b2c8b9f1e7f5e53c262ae87ccd1366df1af019f2dbfe1a58a6749ba4b923f 0x304cda5602a44a5cea16280a60720540748bf609164ae0464063a772111d7e6f,
+        ],
+        &le_bytes![
+            0x1e2e53eecef3185d5c874e783cb184d302692a22c20f5f3b3993882e184d8fe8 0x03fc2454d3d88f9eac441e9b85a9041e925f30cca7a82d039d1ffb582bfb2004
+        ],
     );
 
-    check_err("XXXX", "leftover bytes");
+    check_err(&[92], "leftover bytes");
     check_err(
-        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        &le_bytes![
+            0u8  0x111 0x222
+        ],
         "invalid g1",
     );
     check_err(
-        "XAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        &le_bytes![92u8  0x12b453155ca3be5d0b14a4804cc39a0b4635b06d512735350cd031051644d3ec 0x2944829dcfa7dd72bb04d12e46869e6a6c8162698f9a6c35724f91f597e25fc4],
         "invalid bool",
     );
 }
@@ -116,9 +182,7 @@ fn test_alt_bn128_g1_sum() {
 #[test]
 fn test_alt_bn128_pairing_check() {
     #[track_caller]
-    fn check(input: &str, expected: Result<u64, &str>) {
-        let input = base64::decode(input).unwrap();
-
+    fn check(input: &[u8], expected: Result<u64, &str>) {
         let mut logic_builder = VMLogicBuilder::default();
         let mut logic = logic_builder.build(get_context(vec![], false));
 
@@ -128,23 +192,31 @@ fn test_alt_bn128_pairing_check() {
         }
     }
     #[track_caller]
-    fn check_ok(input: &str, expcted: u64) {
+    fn check_ok(input: &[u8], expcted: u64) {
         check(input, Ok(expcted))
     }
     #[track_caller]
-    fn check_err(input: &str, expected_err: &str) {
+    fn check_err(input: &[u8], expected_err: &str) {
         check(input, Err(expected_err))
     }
 
-    check_ok("", 1);
+    check_ok(&[], 1);
     check_ok(
-        "dQrZY3FO6kO3Who6yFbDeyq41Vjg+BLIbAa1BhwRYwckhjVzwLQDcUzjrpMyrk9Kl8OsCtPSGlx19kHtqGgQBAEaA9sGDcFzTeYbDfLWwwnVY4cMoMpyh68qdKxP6hop1G/AgXxwOWsm9Obe8CRB7oW8EyuUO80oobOt5Fip5x0RQ6MzpbtlLPoYRGVcgMu+M1UJKzqIRLRcbrmoa4EtHrsWZBFLXdh9F9QLusfMAYyFC1IsQd4UGjAahNwZ1V0ZT7AElZfzC4P96Xkm3g92dcjWr+mCtcGn/5mp8M/rHB9TSkWzBpZIQ0qmglNSc3tv0N1AK+3VuusHOPuzX+mfF22tVWcIpevi2k9IeKz7FFN5yYxiqvZ52hNzKoc87x4gMaqrzMTFoJ6oLxdui3ve3vVifdBGJ266kv5CuXYDTiAvs8VdT/DMTuyF1a11Xj+aRFnsigD38tT1IfkAI/bpAHxWxqLJNhMaxEv+R0buMwIXuZiLhkFrgXL0L/vwUMEX",
+        &le_bytes![
+            0x0763111c06b5066cc812f8e058d5b82a7bc356c83a1a5ab743ea4e7163d90a75 0x041068a8ed41f6755c1ad2d30aacc3974a4fae3293aee34c7103b4c073358624
+
+            0x291aea4fac742aaf8772caa00c8763d509c3d6f20d1be64d73c10d06db031a01 0x1de7a958e4adb3a128cd3b942b13bc85ee4124f0dee6f4266b39707c81c06fd4
+            0x1e2d816ba8b96e5cb444883a2b095533becb805c654418fa2c65bba533a34311 0x195dd519dc841a301a14de412c520b858c01ccc7ba0bd4177dd85d4b116416bb,
+
+
+            0x1f1cebcff0a999ffa7c1b582e9afd6c875760fde2679e9fd830bf3979504b04f 0x179fe95fb3fb3807ebbad5ed2b40ddd06f7b73525382a64a43489606b3454a53
+
+            0x201eef3c872a7313da79f6aa628cc9795314fbac78484fdae2eba5086755ad6d 0x204e0376b942fe92ba6e2746d07d62f5dede7b8b6e172fa89ea0c5c4ccabaa31
+            0x00e9f62300f921f5d4f2f7008aec59449a3f5e75add585ec4eccf04f5dc5b32f 0x17c150f0fb2ff472816b41868b98b9170233ee4647fe4bc41a1336c9a2c6567c
+        ],
         1,
     );
 
-    check_err("XXXX", "leftover bytes");
-    check_err(
-        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-        "invalid g2",
-    );
+    check_err(b"XXXX", "leftover bytes");
+    check_err(&le_bytes![0x0 0x0  0x0 0x0 0x0 0x0, 0x0 0x0  0x0 0x0 0x0 0x111], "invalid g2");
 }

--- a/runtime/near-vm-logic/src/tests/alt_bn128.rs
+++ b/runtime/near-vm-logic/src/tests/alt_bn128.rs
@@ -117,7 +117,7 @@ fn test_alt_bn128_g1_multiexp() {
         &le_bytes![0x2923a9d452a047e0f24ab419d7893ecbf0c32a842afd88f991a6723decba82aa 0x2e3a00f94191675c0730510133c2fca248160750d87b5157c534146d4d260b61],
     );
 
-    check_err(b"XXXX", "leftover bytes");
+    check_err(b"XXXX", "invalid array, byte length 4, element size 96");
     check_err(
         &le_bytes![0x92  0x2944829dcfa7dd72bb04d12e46869e6a6c8162698f9a6c35724f91f597e25fc4 0x112b450c0769c7cd80ffa552aaab2153adb5646664ee091639784a7f887411f7],
         "invalid g1",
@@ -165,7 +165,7 @@ fn test_alt_bn128_g1_sum() {
         ],
     );
 
-    check_err(&[92], "leftover bytes");
+    check_err(&[92], "invalid array, byte length 1, element size 65");
     check_err(
         &le_bytes![
             0u8  0x111 0x222
@@ -216,6 +216,6 @@ fn test_alt_bn128_pairing_check() {
         1,
     );
 
-    check_err(b"XXXX", "leftover bytes");
+    check_err(b"XXXX", "invalid array, byte length 4, element size 192");
     check_err(&le_bytes![0x0 0x0  0x0 0x0 0x0 0x0, 0x0 0x0  0x0 0x0 0x0 0x111], "invalid g2");
 }

--- a/runtime/near-vm-logic/src/tests/alt_bn128.rs
+++ b/runtime/near-vm-logic/src/tests/alt_bn128.rs
@@ -26,8 +26,7 @@ fn parse_le_bytes(s: &str, buf: &mut Vec<u8>) {
         buf.push(byte.parse::<u8>().unwrap());
         return;
     }
-    assert!(s.starts_with("0x"));
-    let s = &s[2..];
+    let s = s.strip_prefix("0x").expect("0x prefix was expected");
     let zeros = "0".repeat(64 - s.len());
     let s = format!("{zeros}{s}");
     let hi = u128::from_str_radix(&s[..32], 16).unwrap();

--- a/runtime/near-vm-logic/src/tests/alt_bn128.rs
+++ b/runtime/near-vm-logic/src/tests/alt_bn128.rs
@@ -1,49 +1,150 @@
+use near_vm_errors::{HostError, VMLogicError};
+
 use super::{fixtures::get_context, vm_logic_builder::VMLogicBuilder};
 
-#[test]
-fn test_alt_bn128_g1_sum() {
-    let expected = base64::decode(
-        "6I9NGC6Ikzk7Xw/CIippAtOEsTx4TodcXRjzzu5TLh4EIPsrWPsfnQMtqKfMMF+SHgSphZseRKyej9jTVCT8Aw==",
-    )
-    .unwrap();
-    let input = base64::decode("AOzTRBYFMdAMNTUnUW2wNUYLmsNMgKQUC12+o1wVU7QSxF/il/WRT3I1bJqPaWKBbGqehkYu0QS7ct2nz52CRCkBP5JLuklniqXhvy2fAa/xbTbRzIeuYsJTXn8en4ssKwNvfh0RcqdjQEbgShYJ9ot0QAVyYAooFupcSqQCVtpMMA==").unwrap();
-
-    let mut logic_builder = VMLogicBuilder::default();
-    let mut logic = logic_builder.build(get_context(vec![], false));
-
-    logic.alt_bn128_g1_sum(input.len() as _, input.as_ptr() as _, 0).unwrap();
-    let len = logic.register_len(0).unwrap();
-    let mut res = vec![0; len as usize];
-    logic.read_register(0, res.as_mut_ptr() as _).unwrap();
-    assert_eq!(res, expected)
-}
-
-#[test]
-fn test_alt_bn128_pairing_check() {
-    let expected = 1;
-    let input = base64::decode("dQrZY3FO6kO3Who6yFbDeyq41Vjg+BLIbAa1BhwRYwckhjVzwLQDcUzjrpMyrk9Kl8OsCtPSGlx19kHtqGgQBAEaA9sGDcFzTeYbDfLWwwnVY4cMoMpyh68qdKxP6hop1G/AgXxwOWsm9Obe8CRB7oW8EyuUO80oobOt5Fip5x0RQ6MzpbtlLPoYRGVcgMu+M1UJKzqIRLRcbrmoa4EtHrsWZBFLXdh9F9QLusfMAYyFC1IsQd4UGjAahNwZ1V0ZT7AElZfzC4P96Xkm3g92dcjWr+mCtcGn/5mp8M/rHB9TSkWzBpZIQ0qmglNSc3tv0N1AK+3VuusHOPuzX+mfF22tVWcIpevi2k9IeKz7FFN5yYxiqvZ52hNzKoc87x4gMaqrzMTFoJ6oLxdui3ve3vVifdBGJ266kv5CuXYDTiAvs8VdT/DMTuyF1a11Xj+aRFnsigD38tT1IfkAI/bpAHxWxqLJNhMaxEv+R0buMwIXuZiLhkFrgXL0L/vwUMEX").unwrap();
-
-    let mut logic_builder = VMLogicBuilder::default();
-    let mut logic = logic_builder.build(get_context(vec![], false));
-
-    let res = logic.alt_bn128_pairing_check(input.len() as _, input.as_ptr() as _).unwrap();
-    assert_eq!(res, expected)
+#[track_caller]
+fn check_result<T, U>(
+    actual: Result<T, VMLogicError>,
+    expected: Result<U, &str>,
+) -> Option<(T, U)> {
+    match (actual, expected) {
+        (Ok(actual), Ok(expected)) => Some((actual, expected)),
+        (Err(VMLogicError::HostError(HostError::AltBn128InvalidInput { msg: err })), Err(msg)) => {
+            let err = err.to_string();
+            assert!(err.contains(msg), "expected `{msg}` error, got {err}");
+            None
+        }
+        (Ok(_), Err(msg)) => panic!("expected `{msg}` error"),
+        (Err(err), _) => panic!("unexpected eror: `{}`", err.to_string()),
+    }
 }
 
 #[test]
 fn test_alt_bn128_g1_multiexp() {
-    let expected = base64::decode(
-        "qoK67D1yppH5iP0qhCrD8Ms+idcZtEry4EegUtSpIylhCyZNbRQ0xVdRe9hQBxZIovzCMwFRMAdcZ5FB+QA6Lg==",
-    )
-    .unwrap();
-    let input = base64::decode("7NNEFgUx0Aw1NSdRbbA1Rguaw0yApBQLXb6jXBVTtBLEX+KX9ZFPcjVsmo9pYoFsap6GRi7RBLty3afPnYJEKfcRdIh/Sng5FgnuZGZkta1TIauqUqX/gM3HaQcMRSsRP5JLuklniqXhvy2fAa/xbTbRzIeuYsJTXn8en4ssKwPYfl/HpOS8+0bqJlKIdPUiHVMPIawdOs7MVY3eHHQXABoHa2Bh4f5a4QpF4Mc0WbHKLy/n3smLk0/g9TxtleQZ").unwrap();
+    #[track_caller]
+    fn check(input: &str, expected: Result<&str, &str>) {
+        let input = base64::decode(input).unwrap();
+        let expected = expected.map(|it| base64::decode(it).unwrap());
 
-    let mut logic_builder = VMLogicBuilder::default();
-    let mut logic = logic_builder.build(get_context(vec![], false));
+        let mut logic_builder = VMLogicBuilder::default();
+        let mut logic = logic_builder.build(get_context(vec![], false));
 
-    logic.alt_bn128_g1_multiexp(input.len() as _, input.as_ptr() as _, 0).unwrap();
-    let len = logic.register_len(0).unwrap();
-    let mut res = vec![0; len as usize];
-    logic.read_register(0, res.as_mut_ptr() as _).unwrap();
-    assert_eq!(res, expected)
+        let res = logic.alt_bn128_g1_multiexp(input.len() as _, input.as_ptr() as _, 0);
+        if let Some(((), expected)) = check_result(res, expected) {
+            let len = logic.register_len(0).unwrap();
+            let mut res = vec![0u8; len as usize];
+            logic.read_register(0, res.as_mut_ptr() as _).unwrap();
+            assert_eq!(res, expected)
+        }
+    }
+    #[track_caller]
+    fn check_ok(input: &str, expcted: &str) {
+        check(input, Ok(expcted))
+    }
+    #[track_caller]
+    fn check_err(input: &str, expected_err: &str) {
+        check(input, Err(expected_err))
+    }
+
+    check_ok(
+        "",
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+    );
+    check_ok(
+        "7NNEFgUx0Aw1NSdRbbA1Rguaw0yApBQLXb6jXBVTtBLEX+KX9ZFPcjVsmo9pYoFsap6GRi7RBLty3afPnYJEKfcRdIh/Sng5FgnuZGZkta1TIauqUqX/gM3HaQcMRSsRP5JLuklniqXhvy2fAa/xbTbRzIeuYsJTXn8en4ssKwPYfl/HpOS8+0bqJlKIdPUiHVMPIawdOs7MVY3eHHQXABoHa2Bh4f5a4QpF4Mc0WbHKLy/n3smLk0/g9TxtleQZ",
+    "qoK67D1yppH5iP0qhCrD8Ms+idcZtEry4EegUtSpIylhCyZNbRQ0xVdRe9hQBxZIovzCMwFRMAdcZ5FB+QA6Lg==",
+    );
+
+    check_err("XXXX", "leftover bytes");
+    check_err(
+        "XAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        "invalid g1",
+    );
+    check_err(
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXXX",
+        "invalid fr",
+    );
+}
+
+#[test]
+fn test_alt_bn128_g1_sum() {
+    #[track_caller]
+    fn check(input: &str, expected: Result<&str, &str>) {
+        let input = base64::decode(input).unwrap();
+        let expected = expected.map(|it| base64::decode(it).unwrap());
+
+        let mut logic_builder = VMLogicBuilder::default();
+        let mut logic = logic_builder.build(get_context(vec![], false));
+
+        let res = logic.alt_bn128_g1_sum(input.len() as _, input.as_ptr() as _, 0);
+        if let Some(((), expected)) = check_result(res, expected) {
+            let len = logic.register_len(0).unwrap();
+            let mut res = vec![0; len as usize];
+            logic.read_register(0, res.as_mut_ptr() as _).unwrap();
+            assert_eq!(res, expected)
+        }
+    }
+    #[track_caller]
+    fn check_ok(input: &str, expcted: &str) {
+        check(input, Ok(expcted))
+    }
+    #[track_caller]
+    fn check_err(input: &str, expected_err: &str) {
+        check(input, Err(expected_err))
+    }
+
+    check_ok(
+        "",
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+    );
+    check_ok(
+        "AOzTRBYFMdAMNTUnUW2wNUYLmsNMgKQUC12+o1wVU7QSxF/il/WRT3I1bJqPaWKBbGqehkYu0QS7ct2nz52CRCkBP5JLuklniqXhvy2fAa/xbTbRzIeuYsJTXn8en4ssKwNvfh0RcqdjQEbgShYJ9ot0QAVyYAooFupcSqQCVtpMMA==",
+        "6I9NGC6Ikzk7Xw/CIippAtOEsTx4TodcXRjzzu5TLh4EIPsrWPsfnQMtqKfMMF+SHgSphZseRKyej9jTVCT8Aw=="
+    );
+
+    check_err("XXXX", "leftover bytes");
+    check_err(
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "invalid g1",
+    );
+    check_err(
+        "XAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "invalid bool",
+    );
+}
+
+#[test]
+fn test_alt_bn128_pairing_check() {
+    #[track_caller]
+    fn check(input: &str, expected: Result<u64, &str>) {
+        let input = base64::decode(input).unwrap();
+
+        let mut logic_builder = VMLogicBuilder::default();
+        let mut logic = logic_builder.build(get_context(vec![], false));
+
+        let res = logic.alt_bn128_pairing_check(input.len() as _, input.as_ptr() as _);
+        if let Some((res, expected)) = check_result(res, expected) {
+            assert_eq!(res, expected)
+        }
+    }
+    #[track_caller]
+    fn check_ok(input: &str, expcted: u64) {
+        check(input, Ok(expcted))
+    }
+    #[track_caller]
+    fn check_err(input: &str, expected_err: &str) {
+        check(input, Err(expected_err))
+    }
+
+    check_ok("", 1);
+    check_ok(
+        "dQrZY3FO6kO3Who6yFbDeyq41Vjg+BLIbAa1BhwRYwckhjVzwLQDcUzjrpMyrk9Kl8OsCtPSGlx19kHtqGgQBAEaA9sGDcFzTeYbDfLWwwnVY4cMoMpyh68qdKxP6hop1G/AgXxwOWsm9Obe8CRB7oW8EyuUO80oobOt5Fip5x0RQ6MzpbtlLPoYRGVcgMu+M1UJKzqIRLRcbrmoa4EtHrsWZBFLXdh9F9QLusfMAYyFC1IsQd4UGjAahNwZ1V0ZT7AElZfzC4P96Xkm3g92dcjWr+mCtcGn/5mp8M/rHB9TSkWzBpZIQ0qmglNSc3tv0N1AK+3VuusHOPuzX+mfF22tVWcIpevi2k9IeKz7FFN5yYxiqvZ52hNzKoc87x4gMaqrzMTFoJ6oLxdui3ve3vVifdBGJ266kv5CuXYDTiAvs8VdT/DMTuyF1a11Xj+aRFnsigD38tT1IfkAI/bpAHxWxqLJNhMaxEv+R0buMwIXuZiLhkFrgXL0L/vwUMEX",
+        1,
+    );
+
+    check_err("XXXX", "leftover bytes");
+    check_err(
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        "invalid g2",
+    );
 }

--- a/runtime/near-vm-logic/src/tests/alt_bn128.rs
+++ b/runtime/near-vm-logic/src/tests/alt_bn128.rs
@@ -6,8 +6,7 @@ fn test_alt_bn128_g1_sum() {
         "6I9NGC6Ikzk7Xw/CIippAtOEsTx4TodcXRjzzu5TLh4EIPsrWPsfnQMtqKfMMF+SHgSphZseRKyej9jTVCT8Aw==",
     )
     .unwrap();
-    let input = base64::decode("AgAAAADs00QWBTHQDDU1J1FtsDVGC5rDTICkFAtdvqNcFVO0EsRf4pf1kU9yNWyaj2ligWxqnoZGLtEEu3Ldp8+dgkQpAT+SS7pJZ4ql4b8tnwGv8W020cyHrmLCU15/Hp+LLCsDb34dEXKnY0BG4EoWCfaLdEAFcmAKKBbqXEqkAlbaTDA=").unwrap();
-    let input = &input[4..];
+    let input = base64::decode("AOzTRBYFMdAMNTUnUW2wNUYLmsNMgKQUC12+o1wVU7QSxF/il/WRT3I1bJqPaWKBbGqehkYu0QS7ct2nz52CRCkBP5JLuklniqXhvy2fAa/xbTbRzIeuYsJTXn8en4ssKwNvfh0RcqdjQEbgShYJ9ot0QAVyYAooFupcSqQCVtpMMA==").unwrap();
 
     let mut logic_builder = VMLogicBuilder::default();
     let mut logic = logic_builder.build(get_context(vec![], false));
@@ -22,8 +21,7 @@ fn test_alt_bn128_g1_sum() {
 #[test]
 fn test_alt_bn128_pairing_check() {
     let expected = 1;
-    let input = base64::decode("AgAAAHUK2WNxTupDt1oaOshWw3squNVY4PgSyGwGtQYcEWMHJIY1c8C0A3FM466TMq5PSpfDrArT0hpcdfZB7ahoEAQBGgPbBg3Bc03mGw3y1sMJ1WOHDKDKcoevKnSsT+oaKdRvwIF8cDlrJvTm3vAkQe6FvBMrlDvNKKGzreRYqecdEUOjM6W7ZSz6GERlXIDLvjNVCSs6iES0XG65qGuBLR67FmQRS13YfRfUC7rHzAGMhQtSLEHeFBowGoTcGdVdGU+wBJWX8wuD/el5Jt4PdnXI1q/pgrXBp/+ZqfDP6xwfU0pFswaWSENKpoJTUnN7b9DdQCvt1brrBzj7s1/pnxdtrVVnCKXr4tpPSHis+xRTecmMYqr2edoTcyqHPO8eIDGqq8zExaCeqC8Xbot73t71Yn3QRiduupL+Qrl2A04gL7PFXU/wzE7shdWtdV4/mkRZ7IoA9/LU9SH5ACP26QB8VsaiyTYTGsRL/kdG7jMCF7mYi4ZBa4Fy9C/78FDBFw==").unwrap();
-    let input = &input[4..];
+    let input = base64::decode("dQrZY3FO6kO3Who6yFbDeyq41Vjg+BLIbAa1BhwRYwckhjVzwLQDcUzjrpMyrk9Kl8OsCtPSGlx19kHtqGgQBAEaA9sGDcFzTeYbDfLWwwnVY4cMoMpyh68qdKxP6hop1G/AgXxwOWsm9Obe8CRB7oW8EyuUO80oobOt5Fip5x0RQ6MzpbtlLPoYRGVcgMu+M1UJKzqIRLRcbrmoa4EtHrsWZBFLXdh9F9QLusfMAYyFC1IsQd4UGjAahNwZ1V0ZT7AElZfzC4P96Xkm3g92dcjWr+mCtcGn/5mp8M/rHB9TSkWzBpZIQ0qmglNSc3tv0N1AK+3VuusHOPuzX+mfF22tVWcIpevi2k9IeKz7FFN5yYxiqvZ52hNzKoc87x4gMaqrzMTFoJ6oLxdui3ve3vVifdBGJ266kv5CuXYDTiAvs8VdT/DMTuyF1a11Xj+aRFnsigD38tT1IfkAI/bpAHxWxqLJNhMaxEv+R0buMwIXuZiLhkFrgXL0L/vwUMEX").unwrap();
 
     let mut logic_builder = VMLogicBuilder::default();
     let mut logic = logic_builder.build(get_context(vec![], false));
@@ -38,8 +36,7 @@ fn test_alt_bn128_g1_multiexp() {
         "qoK67D1yppH5iP0qhCrD8Ms+idcZtEry4EegUtSpIylhCyZNbRQ0xVdRe9hQBxZIovzCMwFRMAdcZ5FB+QA6Lg==",
     )
     .unwrap();
-    let input = base64::decode("AgAAAOzTRBYFMdAMNTUnUW2wNUYLmsNMgKQUC12+o1wVU7QSxF/il/WRT3I1bJqPaWKBbGqehkYu0QS7ct2nz52CRCn3EXSIf0p4ORYJ7mRmZLWtUyGrqlKl/4DNx2kHDEUrET+SS7pJZ4ql4b8tnwGv8W020cyHrmLCU15/Hp+LLCsD2H5fx6TkvPtG6iZSiHT1Ih1TDyGsHTrOzFWN3hx0FwAaB2tgYeH+WuEKReDHNFmxyi8v597Ji5NP4PU8bZXkGQ==").unwrap();
-    let input = &input[4..];
+    let input = base64::decode("7NNEFgUx0Aw1NSdRbbA1Rguaw0yApBQLXb6jXBVTtBLEX+KX9ZFPcjVsmo9pYoFsap6GRi7RBLty3afPnYJEKfcRdIh/Sng5FgnuZGZkta1TIauqUqX/gM3HaQcMRSsRP5JLuklniqXhvy2fAa/xbTbRzIeuYsJTXn8en4ssKwPYfl/HpOS8+0bqJlKIdPUiHVMPIawdOs7MVY3eHHQXABoHa2Bh4f5a4QpF4Mc0WbHKLy/n3smLk0/g9TxtleQZ").unwrap();
 
     let mut logic_builder = VMLogicBuilder::default();
     let mut logic = logic_builder.build(get_context(vec![], false));

--- a/runtime/near-vm-logic/src/tests/alt_bn128.rs
+++ b/runtime/near-vm-logic/src/tests/alt_bn128.rs
@@ -1,0 +1,52 @@
+use super::{fixtures::get_context, vm_logic_builder::VMLogicBuilder};
+
+#[test]
+fn test_alt_bn128_g1_sum() {
+    let expected = base64::decode(
+        "6I9NGC6Ikzk7Xw/CIippAtOEsTx4TodcXRjzzu5TLh4EIPsrWPsfnQMtqKfMMF+SHgSphZseRKyej9jTVCT8Aw==",
+    )
+    .unwrap();
+    let input = base64::decode("AgAAAADs00QWBTHQDDU1J1FtsDVGC5rDTICkFAtdvqNcFVO0EsRf4pf1kU9yNWyaj2ligWxqnoZGLtEEu3Ldp8+dgkQpAT+SS7pJZ4ql4b8tnwGv8W020cyHrmLCU15/Hp+LLCsDb34dEXKnY0BG4EoWCfaLdEAFcmAKKBbqXEqkAlbaTDA=").unwrap();
+    let input = &input[4..];
+
+    let mut logic_builder = VMLogicBuilder::default();
+    let mut logic = logic_builder.build(get_context(vec![], false));
+
+    logic.alt_bn128_g1_sum(input.len() as _, input.as_ptr() as _, 0).unwrap();
+    let len = logic.register_len(0).unwrap();
+    let mut res = vec![0; len as usize];
+    logic.read_register(0, res.as_mut_ptr() as _).unwrap();
+    assert_eq!(res, expected)
+}
+
+#[test]
+fn test_alt_bn128_pairing_check() {
+    let expected = 1;
+    let input = base64::decode("AgAAAHUK2WNxTupDt1oaOshWw3squNVY4PgSyGwGtQYcEWMHJIY1c8C0A3FM466TMq5PSpfDrArT0hpcdfZB7ahoEAQBGgPbBg3Bc03mGw3y1sMJ1WOHDKDKcoevKnSsT+oaKdRvwIF8cDlrJvTm3vAkQe6FvBMrlDvNKKGzreRYqecdEUOjM6W7ZSz6GERlXIDLvjNVCSs6iES0XG65qGuBLR67FmQRS13YfRfUC7rHzAGMhQtSLEHeFBowGoTcGdVdGU+wBJWX8wuD/el5Jt4PdnXI1q/pgrXBp/+ZqfDP6xwfU0pFswaWSENKpoJTUnN7b9DdQCvt1brrBzj7s1/pnxdtrVVnCKXr4tpPSHis+xRTecmMYqr2edoTcyqHPO8eIDGqq8zExaCeqC8Xbot73t71Yn3QRiduupL+Qrl2A04gL7PFXU/wzE7shdWtdV4/mkRZ7IoA9/LU9SH5ACP26QB8VsaiyTYTGsRL/kdG7jMCF7mYi4ZBa4Fy9C/78FDBFw==").unwrap();
+    let input = &input[4..];
+
+    let mut logic_builder = VMLogicBuilder::default();
+    let mut logic = logic_builder.build(get_context(vec![], false));
+
+    let res = logic.alt_bn128_pairing_check(input.len() as _, input.as_ptr() as _).unwrap();
+    assert_eq!(res, expected)
+}
+
+#[test]
+fn test_alt_bn128_g1_multiexp() {
+    let expected = base64::decode(
+        "qoK67D1yppH5iP0qhCrD8Ms+idcZtEry4EegUtSpIylhCyZNbRQ0xVdRe9hQBxZIovzCMwFRMAdcZ5FB+QA6Lg==",
+    )
+    .unwrap();
+    let input = base64::decode("AgAAAOzTRBYFMdAMNTUnUW2wNUYLmsNMgKQUC12+o1wVU7QSxF/il/WRT3I1bJqPaWKBbGqehkYu0QS7ct2nz52CRCn3EXSIf0p4ORYJ7mRmZLWtUyGrqlKl/4DNx2kHDEUrET+SS7pJZ4ql4b8tnwGv8W020cyHrmLCU15/Hp+LLCsD2H5fx6TkvPtG6iZSiHT1Ih1TDyGsHTrOzFWN3hx0FwAaB2tgYeH+WuEKReDHNFmxyi8v597Ji5NP4PU8bZXkGQ==").unwrap();
+    let input = &input[4..];
+
+    let mut logic_builder = VMLogicBuilder::default();
+    let mut logic = logic_builder.build(get_context(vec![], false));
+
+    logic.alt_bn128_g1_multiexp(input.len() as _, input.as_ptr() as _, 0).unwrap();
+    let len = logic.register_len(0).unwrap();
+    let mut res = vec![0; len as usize];
+    logic.read_register(0, res.as_mut_ptr() as _).unwrap();
+    assert_eq!(res, expected)
+}

--- a/runtime/near-vm-logic/src/tests/mod.rs
+++ b/runtime/near-vm-logic/src/tests/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "protocol_feature_alt_bn128")]
+mod alt_bn128;
 mod context;
 mod fixtures;
 mod gas_counter;

--- a/runtime/near-vm-runner/src/tests/rs_contract.rs
+++ b/runtime/near-vm-runner/src/tests/rs_contract.rs
@@ -252,30 +252,6 @@ def_test_ext!(
     vec![("alice", 100), ("bob", 1)]
 );
 
-#[cfg(feature = "protocol_feature_alt_bn128")]
-def_test_ext!(
-    ext_alt_bn128_pairing_check,
-    "ext_alt_bn128_pairing_check",
-    &[1],
-    &base64::decode("AgAAAHUK2WNxTupDt1oaOshWw3squNVY4PgSyGwGtQYcEWMHJIY1c8C0A3FM466TMq5PSpfDrArT0hpcdfZB7ahoEAQBGgPbBg3Bc03mGw3y1sMJ1WOHDKDKcoevKnSsT+oaKdRvwIF8cDlrJvTm3vAkQe6FvBMrlDvNKKGzreRYqecdEUOjM6W7ZSz6GERlXIDLvjNVCSs6iES0XG65qGuBLR67FmQRS13YfRfUC7rHzAGMhQtSLEHeFBowGoTcGdVdGU+wBJWX8wuD/el5Jt4PdnXI1q/pgrXBp/+ZqfDP6xwfU0pFswaWSENKpoJTUnN7b9DdQCvt1brrBzj7s1/pnxdtrVVnCKXr4tpPSHis+xRTecmMYqr2edoTcyqHPO8eIDGqq8zExaCeqC8Xbot73t71Yn3QRiduupL+Qrl2A04gL7PFXU/wzE7shdWtdV4/mkRZ7IoA9/LU9SH5ACP26QB8VsaiyTYTGsRL/kdG7jMCF7mYi4ZBa4Fy9C/78FDBFw==").unwrap()
-);
-
-#[cfg(feature = "protocol_feature_alt_bn128")]
-def_test_ext!(
-    ext_alt_bn128_g1_sum,
-    "ext_alt_bn128_g1_sum",
-    &base64::decode("6I9NGC6Ikzk7Xw/CIippAtOEsTx4TodcXRjzzu5TLh4EIPsrWPsfnQMtqKfMMF+SHgSphZseRKyej9jTVCT8Aw==").unwrap(),
-    &base64::decode("AgAAAADs00QWBTHQDDU1J1FtsDVGC5rDTICkFAtdvqNcFVO0EsRf4pf1kU9yNWyaj2ligWxqnoZGLtEEu3Ldp8+dgkQpAT+SS7pJZ4ql4b8tnwGv8W020cyHrmLCU15/Hp+LLCsDb34dEXKnY0BG4EoWCfaLdEAFcmAKKBbqXEqkAlbaTDA=").unwrap()
-);
-
-#[cfg(feature = "protocol_feature_alt_bn128")]
-def_test_ext!(
-    ext_alt_bn128_g1_multiexp,
-    "ext_alt_bn128_g1_multiexp",
-    &base64::decode("qoK67D1yppH5iP0qhCrD8Ms+idcZtEry4EegUtSpIylhCyZNbRQ0xVdRe9hQBxZIovzCMwFRMAdcZ5FB+QA6Lg==").unwrap(),
-    &base64::decode("AgAAAOzTRBYFMdAMNTUnUW2wNUYLmsNMgKQUC12+o1wVU7QSxF/il/WRT3I1bJqPaWKBbGqehkYu0QS7ct2nz52CRCn3EXSIf0p4ORYJ7mRmZLWtUyGrqlKl/4DNx2kHDEUrET+SS7pJZ4ql4b8tnwGv8W020cyHrmLCU15/Hp+LLCsD2H5fx6TkvPtG6iZSiHT1Ih1TDyGsHTrOzFWN3hx0FwAaB2tgYeH+WuEKReDHNFmxyi8v597Ji5NP4PU8bZXkGQ==").unwrap()
-);
-
 #[test]
 pub fn test_out_of_memory() {
     with_vm_variants(|vm_kind: VMKind| {

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -162,7 +162,6 @@ static ALL_COSTS: &[(Cost, fn(&mut EstimatorContext) -> GasCost)] = &[
     (Cost::EcrecoverBase, ecrecover_base),
     (Cost::AltBn128G1MultiexpBase, alt_bn128g1_multiexp_base),
     (Cost::AltBn128G1MultiexpByte, alt_bn128g1_multiexp_byte),
-    (Cost::AltBn128G1MultiexpSublinear, alt_bn128g1_multiexp_sublinear),
     (Cost::AltBn128G1SumBase, alt_bn128g1_sum_base),
     (Cost::AltBn128G1SumByte, alt_bn128g1_sum_byte),
     (Cost::AltBn128PairingCheckBase, alt_bn128_pairing_check_base),
@@ -887,19 +886,8 @@ fn alt_bn128g1_multiexp_byte(ctx: &mut EstimatorContext) -> GasCost {
     return fn_cost(
         ctx,
         "alt_bn128_g1_multiexp_10_1k",
-        ExtCosts::alt_bn128_g1_multiexp_byte,
+        ExtCosts::alt_bn128_g1_multiexp_element,
         964 * 1000,
-    );
-    #[cfg(not(feature = "protocol_feature_alt_bn128"))]
-    return GasCost::zero(ctx.config.metric);
-}
-fn alt_bn128g1_multiexp_sublinear(ctx: &mut EstimatorContext) -> GasCost {
-    #[cfg(feature = "protocol_feature_alt_bn128")]
-    return fn_cost(
-        ctx,
-        "alt_bn128_g1_multiexp_10_1k",
-        ExtCosts::alt_bn128_g1_multiexp_sublinear,
-        743342 * 1000,
     );
     #[cfg(not(feature = "protocol_feature_alt_bn128"))]
     return GasCost::zero(ctx.config.metric);
@@ -913,7 +901,7 @@ fn alt_bn128g1_sum_base(ctx: &mut EstimatorContext) -> GasCost {
 }
 fn alt_bn128g1_sum_byte(ctx: &mut EstimatorContext) -> GasCost {
     #[cfg(feature = "protocol_feature_alt_bn128")]
-    return fn_cost(ctx, "alt_bn128_g1_sum_10_1k", ExtCosts::alt_bn128_g1_sum_byte, 654 * 1000);
+    return fn_cost(ctx, "alt_bn128_g1_sum_10_1k", ExtCosts::alt_bn128_g1_sum_element, 654 * 1000);
     #[cfg(not(feature = "protocol_feature_alt_bn128"))]
     return GasCost::zero(ctx.config.metric);
 }
@@ -934,7 +922,7 @@ fn alt_bn128_pairing_check_byte(ctx: &mut EstimatorContext) -> GasCost {
     return fn_cost(
         ctx,
         "alt_bn128_pairing_check_10_1k",
-        ExtCosts::alt_bn128_pairing_check_byte,
+        ExtCosts::alt_bn128_pairing_check_element,
         1924 * 1000,
     );
     #[cfg(not(feature = "protocol_feature_alt_bn128"))]


### PR DESCRIPTION
Semantic changes:

* The input now is a raw slice (no length in front)
* Costs are now computed in terms of number of elements to operate on,
  not in terms of number of bytes
* Sublinear component of the multiexp_cost is removed. Manual sanity checking shows that this is indeed can be upper-bounded by a linear function, in terms of time and memory usage. Our estimator should give us upper-bound. That is, we should calculate sublinear component if we want to make the cost *lower*, it's efficiency, not safety, concern.
* We no longer have a limit of 5_000 elements for multiexp. I believe that the reasoning that there's a potential memory exhaustion is flawed. The size of the internal buffer is exponential in the *logarithm* of input, that is, it is linear (sublinear, actually, it's 2^log_10 N). 

Internal changes:

* We no longer use borsh to decode input.
* As a result, no more borsh errors in API.
* Tests move from near-vm-runner to near-vm-logic.
* We have a bit more tests
* All alt_bn errors are grouped under one general variant. 
* Tests now specify the input as somewhat transparent u256 numbers, not as opaque base64

---

Missing things:

* I haven't yet updated the estimator, plan to do that in a follow up. 
* I don't feel good at all about test coverage here. For each function, we have only one test for the happy case

# Test Plan

* Existing tests are carefully refactored to make sure we are testing the same thing. 
* New tests are added for various invalid input conditions. 