### PR TITLE
Register the subscriber globally

### DIFF
--- a/core/o11y/src/lib.rs
+++ b/core/o11y/src/lib.rs
@@ -20,18 +20,18 @@ pub const DEFAULT_RUST_LOG: &'static str = "tokio_reactor=info,\
 ///
 /// Once dropped, the subscriber is unregistered, and the output is flushed. Any messages output
 /// after this value is dropped will be delivered to a previously active subscriber, if any.
-#[allow(dead_code)] // Fields are never read
 pub struct DefaultSubcriberGuard<S> {
     // NB: the field order matters here. I would've used `ManuallyDrop` to indicate this
     // particularity, but somebody decided at some point that doing so is unconventional Rust and
     // that implicit is better than explicit.
     //
-    // We must first drop the `subscriber_guard` so that no new messages are delivered to this
-    // subscriber while we take care of flushing the messages already in queue. If dropped the
+    // We must first drop the `local_subscriber_guard` so that no new messages are delivered to
+    // this subscriber while we take care of flushing the messages already in queue. If dropped the
     // other way around, the events/spans generated while the subscriber drop guard runs would be
     // lost.
     subscriber: Option<S>,
     local_subscriber_guard: Option<tracing::subscriber::DefaultGuard>,
+    #[allow(dead_code)] // This field is never read, but has semantic purpose as a drop guard.
     writer_guard: tracing_appender::non_blocking::WorkerGuard,
 }
 

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -35,7 +35,7 @@ impl NeardCmd {
         } else {
             env_filter
         };
-        let _subscriber = default_subscriber(env_filter);
+        let _subscriber = default_subscriber(env_filter).global();
 
         info!(
             target: "neard",

--- a/tools/chainsync-loadtest/src/main.rs
+++ b/tools/chainsync-loadtest/src/main.rs
@@ -133,7 +133,7 @@ fn main() {
     let env_filter = near_o11y::EnvFilterBuilder::from_env()
         .finish()
         .add_directive(near_o11y::tracing::Level::INFO.into());
-    let _subscriber = near_o11y::default_subscriber(env_filter);
+    let _subscriber = near_o11y::default_subscriber(env_filter).global();
     let orig_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |panic_info| {
         orig_hook(panic_info);

--- a/tools/indexer/example/src/main.rs
+++ b/tools/indexer/example/src/main.rs
@@ -264,7 +264,7 @@ fn main() -> Result<()> {
         "nearcore=info,indexer_example=info,tokio_reactor=info,near=info,\
          stats=info,telemetry=info,indexer=info,near-performance-metrics=info",
     );
-    let _susbcriber = near_o11y::default_subscriber(env_filter);
+    let _susbcriber = near_o11y::default_subscriber(env_filter).global();
     let opts: Opts = Opts::parse();
 
     let home_dir =

--- a/tools/restaked/src/main.rs
+++ b/tools/restaked/src/main.rs
@@ -23,7 +23,7 @@ fn maybe_kicked_out(validator_info: &CurrentEpochValidatorInfo) -> bool {
 
 fn main() {
     let filter = near_o11y::EnvFilterBuilder::from_env().verbose(Some("")).finish();
-    let _subscriber = near_o11y::default_subscriber(filter);
+    let _subscriber = near_o11y::default_subscriber(filter).global();
     let default_home = get_default_home();
     let matches = Command::new("Key-pairs generator")
         .about(

--- a/tools/storage-usage-delta-calculator/src/main.rs
+++ b/tools/storage-usage-delta-calculator/src/main.rs
@@ -12,7 +12,7 @@ use tracing::debug;
 /// to get it
 fn main() -> std::io::Result<()> {
     let env_filter = near_o11y::EnvFilterBuilder::from_env().verbose(Some("")).finish();
-    let _subscriber = near_o11y::default_subscriber(env_filter);
+    let _subscriber = near_o11y::default_subscriber(env_filter).global();
     debug!(target: "storage-calculator", "Start");
 
     let genesis = Genesis::from_file("output.json", GenesisValidationMode::Full);


### PR DESCRIPTION
When the subscriber is registered globally, it transparently also
applies to any thread, unlike the subscribers that are registered using
`set_default`, which only apply to the current thread.

This is somewhat incompatible with the non-blocking writer, because now
it is possible that we drop the writer guard in the main thread, flush
the `stderr` and then threads log additional messages before the program
exits. This would then lead to some messages being lost.

I feel like we can afford this, though. The alternative would be to
somehow ensure we register the subscriber for every thread, but thread
creation is not necessarily have a full control over. Libraries could
spawn their own, etc.