### PR TITLE
fix chainsync workspace grouping

### DIFF
--- a/tools/chainsync-loadtest/Cargo.toml
+++ b/tools/chainsync-loadtest/Cargo.toml
@@ -32,7 +32,3 @@ nearcore = { path = "../../nearcore" }
 near-network = { path = "../../chain/network" }
 near-network-primitives = { path = "../../chain/network-primitives" }
 near-o11y = { path = "../../core/o11y" }
-
-[features]
-[package.metadata.workspaces]
-independent = true


### PR DESCRIPTION
https://github.com/near/nearcore/issues/6380 introduced the private crate – `chainsync-loadtest` as an “independent” crate, using that directive, `cargo-workspaces` defaulted to interactive input during CI run, querying for a version. This patch makes `chainsync-loadtest` part of the larger workspace group, fixing the issue.