### PR TITLE
create epoch info debug page to show validators

### DIFF
--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -801,10 +801,16 @@ impl Handler<Status> for ClientActor {
                 current_head_status: head.clone().into(),
                 current_header_head_status: self.client.chain.header_head()?.clone().into(),
                 orphans: self.client.chain.orphans().list_orphans_by_height(),
-                epoch_info: EpochInfoView { 
+                epoch_info: EpochInfoView {
                     epoch_id: head.epoch_id.0,
-                    start_time: self.client.chain.get_block_by_height(epoch_start_height)?.header().timestamp().to_rfc3339(),
-                    validators: validators.to_vec()
+                    start_time: self
+                        .client
+                        .chain
+                        .get_block_by_height(epoch_start_height)?
+                        .header()
+                        .timestamp()
+                        .to_rfc3339(),
+                    validators: validators.to_vec(),
                 },
             })
         } else {

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -798,10 +798,14 @@ impl Handler<Status> for ClientActor {
                         self.client.chain.genesis_block().header().height(),
                     ),
                 ),
-                current_head_status: self.client.chain.head()?.clone().into(),
+                current_head_status: head.clone().into(),
                 current_header_head_status: self.client.chain.header_head()?.clone().into(),
                 orphans: self.client.chain.orphans().list_orphans_by_height(),
-                epoch_info: EpochInfoView { validators: validators.to_vec() },
+                epoch_info: EpochInfoView { 
+                    epoch_id: head.epoch_id.0,
+                    start_time: self.client.chain.get_block_by_height(epoch_start_height)?.header().timestamp().to_rfc3339(),
+                    validators: validators.to_vec()
+                },
             })
         } else {
             None

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -803,6 +803,14 @@ impl Handler<Status> for ClientActor {
                 orphans: self.client.chain.orphans().list_orphans_by_height(),
                 epoch_info: EpochInfoView {
                     epoch_id: head.epoch_id.0,
+                    height: epoch_start_height,
+                    first_block_hash: self
+                        .client
+                        .chain
+                        .get_block_by_height(epoch_start_height)?
+                        .header()
+                        .hash()
+                        .clone(),
                     start_time: self
                         .client
                         .chain

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -48,7 +48,7 @@ use near_primitives::utils::{from_timestamp, MaybeValidated};
 use near_primitives::validator_signer::ValidatorSigner;
 use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives::views::{
-    DebugBlockStatus, DebugChunkStatus, DetailedDebugStatus, ValidatorInfo,
+    DebugBlockStatus, DebugChunkStatus, DetailedDebugStatus, EpochInfoView, ValidatorInfo,
 };
 use near_store::db::DBCol::ColStateParts;
 use near_telemetry::TelemetryActor;
@@ -673,7 +673,7 @@ impl Handler<Status> for ClientActor {
                 return Err(StatusError::NodeIsSyncing);
             }
         }
-        let validators = self
+        let validators: Vec<ValidatorInfo> = self
             .client
             .runtime_adapter
             .get_epoch_block_producers_ordered(&head.epoch_id, &head.last_block_hash)?
@@ -801,6 +801,7 @@ impl Handler<Status> for ClientActor {
                 current_head_status: self.client.chain.head()?.clone().into(),
                 current_header_head_status: self.client.chain.header_head()?.clone().into(),
                 orphans: self.client.chain.orphans().list_orphans_by_height(),
+                epoch_info: EpochInfoView { validators: validators.to_vec() },
             })
         } else {
             None

--- a/chain/jsonrpc/res/debug.html
+++ b/chain/jsonrpc/res/debug.html
@@ -4,6 +4,7 @@
     <h1><a href="/debug/last_blocks">Last blocks</a></h1>
     <h1><a href="/debug/sync_info">Sync info</a></h1>
     <h1><a href="/debug/chain_info">Chain info</a></h1>
+    <h1><a href="/debug/epoch_info">Epoch info</a></h1>
 </body>
 
 </html>

--- a/chain/jsonrpc/res/epoch_info.html
+++ b/chain/jsonrpc/res/epoch_info.html
@@ -38,6 +38,8 @@
                 url: "/debug/api/status",
                 success: data => {
                     let epoch_info = data.detailed_debug_status.epoch_info;
+                    $('.js-epoch-id').text(epoch_info.epoch_id);
+                    $('.js-epoch-start-time').text(epoch_info.start_time);
                     epoch_info.validators.forEach((validator, index) =>
                         $('.js-tbody-validators').append($('<tr>')
                             .append($('<td>').append(validator.account_id))
@@ -60,7 +62,15 @@
     </h1>
     <h2>
         <p>
-            Current Validators
+            Current Epoch ID:
+            <span class="js-epoch-id"></span>
+        </p>
+        <p>
+            First block started at:
+            <span class="js-epoch-start-time"></span>
+        </p>
+        <p>
+            Validators
         </p>
     </h2>
 

--- a/chain/jsonrpc/res/epoch_info.html
+++ b/chain/jsonrpc/res/epoch_info.html
@@ -1,0 +1,76 @@
+<html>
+<head>
+    <style>
+        table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+
+        table,
+        th,
+        td {
+            border: 1px solid black;
+        }
+
+        td {
+            text-align: left;
+            vertical-align: top;
+            padding: 8px;
+        }
+
+        th {
+            text-align: center;
+            vertical-align: center;
+            padding: 8px;
+            background-color: lightgrey;
+        }
+
+        tr.active {
+            background-color: #eff8bf;
+        }
+    </style>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+    <script>
+        $(document).ready(() => {
+            $('span').text("Loading...");
+            $.ajax({
+                type: "GET",
+                url: "/debug/api/status",
+                success: data => {
+                    let epoch_info = data.detailed_debug_status.epoch_info;
+                    epoch_info.validators.forEach((validator, index) =>
+                        $('.js-tbody-validators').append($('<tr>')
+                            .append($('<td>').append(validator.account_id))
+                        )
+                    );
+                },
+                dataType: "json",
+                error: function (errMsg, textStatus, errorThrown) {
+                    alert("Failed: " + textStatus + " :" + errorThrown);
+                },
+                contentType: "application/json; charset=utf-8",
+            })
+
+        });
+    </script>
+</head>
+<body>
+    <h1>
+        Welcome to the Epoch Status page!
+    </h1>
+    <h2>
+        <p>
+            Current Validators
+        </p>
+    </h2>
+
+    <table>
+        <thead><tr>
+            <th>Account ID</th>
+        </tr></thead>
+        <tbody class="js-tbody-validators">
+        </tbody>
+    </table>
+</body>
+
+</html>

--- a/chain/jsonrpc/res/epoch_info.html
+++ b/chain/jsonrpc/res/epoch_info.html
@@ -39,6 +39,8 @@
                 success: data => {
                     let epoch_info = data.detailed_debug_status.epoch_info;
                     $('.js-epoch-id').text(epoch_info.epoch_id);
+                    $('.js-epoch-height').text(epoch_info.height);
+                    $('.js-epoch-first-block-hash').text(epoch_info.first_block_hash);
                     $('.js-epoch-start-time').text(epoch_info.start_time);
                     epoch_info.validators.forEach((validator, index) =>
                         $('.js-tbody-validators').append($('<tr>')
@@ -66,7 +68,15 @@
             <span class="js-epoch-id"></span>
         </p>
         <p>
-            First block started at:
+            First block hash:
+            <span class="js-epoch-first-block-hash"></span>
+        </p>
+        <p>
+            Height at:
+            <span class="js-epoch-height"></span>
+        </p>
+        <p>
+            Started at:
             <span class="js-epoch-start-time"></span>
         </p>
         <p>

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -1433,6 +1433,7 @@ lazy_static_include::lazy_static_include_str! {
     DEBUG_HTML => "res/debug.html",
     SYNC_INFO_HTML => "res/sync_info.html",
     CHAIN_INFO_HTML => "res/chain_info.html",
+    EPOCH_INFO_HTML => "res/epoch_info.html",
 }
 
 #[get("/debug")]
@@ -1453,6 +1454,11 @@ async fn sync_info_html() -> actix_web::Result<impl actix_web::Responder> {
 #[get("/debug/chain_info")]
 async fn chain_info_html() -> actix_web::Result<impl actix_web::Responder> {
     Ok(HttpResponse::Ok().body(*CHAIN_INFO_HTML))
+}
+
+#[get("/debug/epoch_info")]
+async fn epoch_info_html() -> actix_web::Result<impl actix_web::Responder> {
+    Ok(HttpResponse::Ok().body(*EPOCH_INFO_HTML))
 }
 
 /// Starts HTTP server(s) listening for RPC requests.
@@ -1520,6 +1526,7 @@ pub fn start_http(
             .service(last_blocks_html)
             .service(sync_info_html)
             .service(chain_info_html)
+            .service(epoch_info_html)
     })
     .bind(addr)
     .unwrap()

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -316,7 +316,7 @@ pub struct StatusSyncInfo {
 
 // TODO: add more information to ValidatorInfo
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct ValidatorInfo {
     pub account_id: AccountId,
     pub is_slashed: bool,
@@ -386,6 +386,12 @@ impl From<Tip> for BlockStatusView {
 
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
 #[derive(Serialize, Deserialize, Debug)]
+pub struct EpochInfoView {
+    pub validators: Vec<ValidatorInfo>,
+}
+
+#[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct DetailedDebugStatus {
     pub last_blocks: Vec<DebugBlockStatus>,
     pub network_info: NetworkInfoView,
@@ -393,6 +399,7 @@ pub struct DetailedDebugStatus {
     pub current_head_status: BlockStatusView,
     pub current_header_head_status: BlockStatusView,
     pub orphans: Vec<BlockStatusView>,
+    pub epoch_info: EpochInfoView,
 }
 
 // TODO: add more information to status.
@@ -416,7 +423,7 @@ pub struct StatusResponse {
     pub sync_info: StatusSyncInfo,
     /// Validator id of the node
     pub validator_account_id: Option<AccountId>,
-    /// Information about last blocks, sync info and chain info.
+    /// Information about last blocks, sync, epoch and chain info.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub detailed_debug_status: Option<DetailedDebugStatus>,
 }

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -387,6 +387,8 @@ impl From<Tip> for BlockStatusView {
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct EpochInfoView {
+    pub epoch_id: CryptoHash,
+    pub start_time: String,
     pub validators: Vec<ValidatorInfo>,
 }
 

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -388,6 +388,8 @@ impl From<Tip> for BlockStatusView {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct EpochInfoView {
     pub epoch_id: CryptoHash,
+    pub height: BlockHeight,
+    pub first_block_hash: CryptoHash,
     pub start_time: String,
     pub validators: Vec<ValidatorInfo>,
 }


### PR DESCRIPTION
### Description
This PR adds the skeleton of the epoch info debug page , and fills in the information of account IDs of the validators, as the first step.

### JIRA Issue
[CP-20](https://nearinc.atlassian.net/browse/CP-20)

### Test plan

 - Build with make neard
 - Under `nearcore` directory, launch localnet using command `nearup stop && nearup run localnet --binary-path ./target/release`
 - Open your browser and go to http://[host_address]:3030/debug/
 - Expect to see the link "Epoch Info"
 - Click the link "Epoch Info"
 - Expect to see a webpage that looks similar to the one below
 - Go back to http://[host_address]:3030/debug/
 - Make sure other links aren't broken, either

### Screenshot on localnet
<img width="1512" alt="Screen Shot 2022-04-07 at 2 22 19 PM" src="https://user-images.githubusercontent.com/98097537/162317831-7e28d7f8-334c-4113-b155-b0c1a219a4d3.png">


### First round reviewer
 - @mzhangmzz 
 - @mm-near 