### PR TITLE
chore: remove per component code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # CODEOWNERS: https://help.github.com/articles/about-codeowners/
 
-. @nearcore-codeowners
+. @near/nearcore-codeowners
 /.buildkite/ @rtsai123 @mhalambek

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,36 +1,4 @@
 # CODEOWNERS: https://help.github.com/articles/about-codeowners/
 
-/chain/ @bowenwang1996 @mzhangmzz @mm-near
-/chain/client/src/view_client.rs @khorolets @rtsai123
-/chain/client-primitives/ @mina86 @nikurt
-/chain/network/ @mm-near @bowenwang1996
-/chain/network-primitives/ @mm-near
-/chain/jsonrpc/ @mina86 @nikurt
-/chain/jsonrpc-primitives/ @mina86 @nikurt
-/chain/indexer/ @khorolets @mm-near
-/chain/indexer-primitives/ @khorolets @mm-near
-/chain/rosetta-rpc/ @frol @mina86
-/utils  @mm-near
-
-/runtime/ @bowenwang1996 @EgorKulikov @mzhangmzz @mm-near
-/runtime/runtime-params-estimator/ @matklad @jakmeier
-/runtime/near-test-contracts/ @matklad @Longarithm
-/runtime/near-vm-runner-standalone/ @matklad @nagisa
-/runtime/near-vm-runner/  @matklad @nagisa
-
-/genesis-tools/ @nikurt
-/tools/indexer/ @khorolets
-/tools/themis/ @miraclx
-
-/core/  @bowenwang1996 @matklad @mm-near
-/core/store/src/trie @mzhangmzz @longarithm
-/neard/ @bowenwang1996 @mm-near
-/nearcore/ @bowenwang1996 @mm-near
-/test-utils/state-viewer @nikurt
-/test-utils/runtime-tester @posvyatokum @matklad
-
+. @nearcore-codeowners
 /.buildkite/ @rtsai123 @mhalambek
-/scripts/ @rtsai123 @mhalambek @mina86 @nikurt
-
-/docs/ @bowenwang1996 @matklad @mm-near
-/pytest/ @mm-near @mina86

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,8 +48,10 @@ The `test plan` should describe in detail what tests are presented, and what cas
 ### After the PR is submitted
 
 1. We have a CI process configured to run all the sanity tests on each PR. If the CI fails on your PR, you need to fix it before it will be reviewed.
-2. Once the CI passes, you should expect the first feedback to appear within 48 hours.
-   The reviewers will first review your tests, and make sure that they can convince themselves the test coverage is adequate before they even look into the change, so make sure you tested all the corner cases.
+2. Once the CI passes, you should expect the first feedback to appear within one business day. 
+   One code owner (chosen in a round robin order for the codeowner list) will first review your pull request.
+   They may re-assign the pull request to another person if they feel that they don't have sufficient expertise to review the pull request.
+   The reviewers will review your tests, and make sure that they can convince themselves the test coverage is adequate before they even look into the change, so make sure you tested all the corner cases.
    If you would like to request review from a specific review, feel free to do so [through the github UI](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review).
 3. Once you address all the comments, and your PR is accepted, we will take care of merging it.
 4. If your PR introduces a new protocol feature, please document it in [CHANGELOG.md](CHANGELOG.md) under `unreleased`.


### PR DESCRIPTION
Today the nearcore code review process is substandard. When a PR is submitted, code owners’ reviews are automatically requested. Given that some components have a few code owners, often a PR automatically requests review from many people. At the same time, a PR needs approvals from at least one code owner of every component. As a result, the code review process may take several days and sometimes people ignore those review requests thinking that other code owners would review them instead.

After some discussion with @mm-near and @matklad, we decide to experiment with the following solution: there will be a single team of codeowners and once a pull request is submitted, one of the codeowners' review will be requested. The chosen codeowner can re-assign to another person for review if they feel they don't have sufficient expertise to review the PR. This should increase the turnaround time for a PR to get merged. Let's see how it goes and we can adjust the process as we go.