### PR TITLE
core: small KeyForStateChanges refactor

### DIFF
--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -655,7 +655,7 @@ impl ChainStore {
         // 2. Extract the original Trie key out of the keys returned by RocksDB
         // 3. Try extracting `account_id` from the key using KeyFor* implementations
 
-        let storage_key = KeyForStateChanges::get_prefix(block_hash);
+        let storage_key = KeyForStateChanges::for_block(block_hash);
 
         let mut block_changes = storage_key.find_iter(&self.store);
 
@@ -666,7 +666,7 @@ impl ChainStore {
         &self,
         block_hash: &CryptoHash,
     ) -> Result<StateChanges, Error> {
-        let storage_key = KeyForStateChanges::get_prefix(block_hash);
+        let storage_key = KeyForStateChanges::for_block(block_hash);
 
         let mut block_changes = storage_key.find_iter(&self.store);
 
@@ -709,8 +709,8 @@ impl ChainStore {
             StateChangesRequest::AccountChanges { account_ids } => {
                 let mut changes = StateChanges::new();
                 for account_id in account_ids {
-                    let data_key = TrieKey::Account { account_id: account_id.clone() }.to_vec();
-                    let storage_key = KeyForStateChanges::new(block_hash, data_key.as_ref());
+                    let data_key = TrieKey::Account { account_id: account_id.clone() };
+                    let storage_key = KeyForStateChanges::from_trie_key(block_hash, &data_key);
                     let changes_per_key = storage_key.find_exact_iter(&self.store);
                     changes.extend(StateChanges::from_account_changes(changes_per_key)?);
                 }
@@ -722,9 +722,8 @@ impl ChainStore {
                     let data_key = TrieKey::AccessKey {
                         account_id: key.account_id.clone(),
                         public_key: key.public_key.clone(),
-                    }
-                    .to_vec();
-                    let storage_key = KeyForStateChanges::new(block_hash, data_key.as_ref());
+                    };
+                    let storage_key = KeyForStateChanges::from_trie_key(block_hash, &data_key);
                     let changes_per_key = storage_key.find_exact_iter(&self.store);
                     changes.extend(StateChanges::from_access_key_changes(changes_per_key)?);
                 }
@@ -734,7 +733,7 @@ impl ChainStore {
                 let mut changes = StateChanges::new();
                 for account_id in account_ids {
                     let data_key = trie_key_parsers::get_raw_prefix_for_access_keys(account_id);
-                    let storage_key = KeyForStateChanges::new(block_hash, data_key.as_ref());
+                    let storage_key = KeyForStateChanges::from_raw_key(block_hash, &data_key);
                     let changes_per_key_prefix = storage_key.find_iter(&self.store);
                     changes.extend(StateChanges::from_access_key_changes(changes_per_key_prefix)?);
                 }
@@ -743,9 +742,8 @@ impl ChainStore {
             StateChangesRequest::ContractCodeChanges { account_ids } => {
                 let mut changes = StateChanges::new();
                 for account_id in account_ids {
-                    let data_key =
-                        TrieKey::ContractCode { account_id: account_id.clone() }.to_vec();
-                    let storage_key = KeyForStateChanges::new(block_hash, data_key.as_ref());
+                    let data_key = TrieKey::ContractCode { account_id: account_id.clone() };
+                    let storage_key = KeyForStateChanges::from_trie_key(block_hash, &data_key);
                     let changes_per_key = storage_key.find_exact_iter(&self.store);
                     changes.extend(StateChanges::from_contract_code_changes(changes_per_key)?);
                 }
@@ -758,7 +756,7 @@ impl ChainStore {
                         account_id,
                         key_prefix.as_ref(),
                     );
-                    let storage_key = KeyForStateChanges::new(block_hash, data_key.as_ref());
+                    let storage_key = KeyForStateChanges::from_raw_key(block_hash, &data_key);
                     let changes_per_key_prefix = storage_key.find_iter(&self.store);
                     changes.extend(StateChanges::from_data_changes(changes_per_key_prefix)?);
                 }
@@ -2170,7 +2168,7 @@ impl<'a> ChainStoreUpdate<'a> {
         self.gc_col(ColNextBlockHashes, &block_hash_vec);
         self.gc_col(ColChallengedBlocks, &block_hash_vec);
         self.gc_col(ColBlocksToCatchup, &block_hash_vec);
-        let storage_key = KeyForStateChanges::get_prefix(&block_hash);
+        let storage_key = KeyForStateChanges::for_block(&block_hash);
         let stored_state_changes: Vec<Vec<u8>> = self
             .chain_store
             .store()

--- a/core/primitives/src/trie_key.rs
+++ b/core/primitives/src/trie_key.rs
@@ -128,9 +128,8 @@ impl TrieKey {
         }
     }
 
-    pub fn to_vec(&self) -> Vec<u8> {
-        let expected_len = self.len();
-        let mut res = Vec::with_capacity(expected_len);
+    pub fn append_into(&self, res: &mut Vec<u8>) {
+        res.reserve(self.len());
         match self {
             TrieKey::Account { account_id } => {
                 res.extend(col::ACCOUNT);
@@ -184,6 +183,12 @@ impl TrieKey {
                 res.extend(key);
             }
         };
+    }
+
+    pub fn to_vec(&self) -> Vec<u8> {
+        let expected_len = self.len();
+        let mut res = Vec::with_capacity(expected_len);
+        self.append_into(&mut res);
         debug_assert_eq!(res.len(), expected_len);
         res
     }

--- a/core/primitives/src/trie_key.rs
+++ b/core/primitives/src/trie_key.rs
@@ -128,69 +128,70 @@ impl TrieKey {
         }
     }
 
-    pub fn append_into(&self, res: &mut Vec<u8>) {
-        res.reserve(self.len());
+    pub fn append_into(&self, buf: &mut Vec<u8>) {
+        let expected_len = self.len();
+        let start_len = buf.len();
+        buf.reserve(self.len());
         match self {
             TrieKey::Account { account_id } => {
-                res.extend(col::ACCOUNT);
-                res.extend(account_id.as_ref().as_bytes());
+                buf.extend(col::ACCOUNT);
+                buf.extend(account_id.as_ref().as_bytes());
             }
             TrieKey::ContractCode { account_id } => {
-                res.extend(col::CONTRACT_CODE);
-                res.extend(account_id.as_ref().as_bytes());
+                buf.extend(col::CONTRACT_CODE);
+                buf.extend(account_id.as_ref().as_bytes());
             }
             TrieKey::AccessKey { account_id, public_key } => {
-                res.extend(col::ACCESS_KEY);
-                res.extend(account_id.as_ref().as_bytes());
-                res.extend(col::ACCESS_KEY);
-                res.extend(public_key.try_to_vec().unwrap());
+                buf.extend(col::ACCESS_KEY);
+                buf.extend(account_id.as_ref().as_bytes());
+                buf.extend(col::ACCESS_KEY);
+                buf.extend(public_key.try_to_vec().unwrap());
             }
             TrieKey::ReceivedData { receiver_id, data_id } => {
-                res.extend(col::RECEIVED_DATA);
-                res.extend(receiver_id.as_ref().as_bytes());
-                res.extend(ACCOUNT_DATA_SEPARATOR);
-                res.extend(data_id.as_ref());
+                buf.extend(col::RECEIVED_DATA);
+                buf.extend(receiver_id.as_ref().as_bytes());
+                buf.extend(ACCOUNT_DATA_SEPARATOR);
+                buf.extend(data_id.as_ref());
             }
             TrieKey::PostponedReceiptId { receiver_id, data_id } => {
-                res.extend(col::POSTPONED_RECEIPT_ID);
-                res.extend(receiver_id.as_ref().as_bytes());
-                res.extend(ACCOUNT_DATA_SEPARATOR);
-                res.extend(data_id.as_ref());
+                buf.extend(col::POSTPONED_RECEIPT_ID);
+                buf.extend(receiver_id.as_ref().as_bytes());
+                buf.extend(ACCOUNT_DATA_SEPARATOR);
+                buf.extend(data_id.as_ref());
             }
             TrieKey::PendingDataCount { receiver_id, receipt_id } => {
-                res.extend(col::PENDING_DATA_COUNT);
-                res.extend(receiver_id.as_ref().as_bytes());
-                res.extend(ACCOUNT_DATA_SEPARATOR);
-                res.extend(receipt_id.as_ref());
+                buf.extend(col::PENDING_DATA_COUNT);
+                buf.extend(receiver_id.as_ref().as_bytes());
+                buf.extend(ACCOUNT_DATA_SEPARATOR);
+                buf.extend(receipt_id.as_ref());
             }
             TrieKey::PostponedReceipt { receiver_id, receipt_id } => {
-                res.extend(col::POSTPONED_RECEIPT);
-                res.extend(receiver_id.as_ref().as_bytes());
-                res.extend(ACCOUNT_DATA_SEPARATOR);
-                res.extend(receipt_id.as_ref());
+                buf.extend(col::POSTPONED_RECEIPT);
+                buf.extend(receiver_id.as_ref().as_bytes());
+                buf.extend(ACCOUNT_DATA_SEPARATOR);
+                buf.extend(receipt_id.as_ref());
             }
             TrieKey::DelayedReceiptIndices => {
-                res.extend(col::DELAYED_RECEIPT_INDICES);
+                buf.extend(col::DELAYED_RECEIPT_INDICES);
             }
             TrieKey::DelayedReceipt { index } => {
-                res.extend(col::DELAYED_RECEIPT_INDICES);
-                res.extend(&index.to_le_bytes());
+                buf.extend(col::DELAYED_RECEIPT_INDICES);
+                buf.extend(&index.to_le_bytes());
             }
             TrieKey::ContractData { account_id, key } => {
-                res.extend(col::CONTRACT_DATA);
-                res.extend(account_id.as_ref().as_bytes());
-                res.extend(ACCOUNT_DATA_SEPARATOR);
-                res.extend(key);
+                buf.extend(col::CONTRACT_DATA);
+                buf.extend(account_id.as_ref().as_bytes());
+                buf.extend(ACCOUNT_DATA_SEPARATOR);
+                buf.extend(key);
             }
         };
+        debug_assert_eq!(expected_len, buf.len() - start_len);
     }
 
     pub fn to_vec(&self) -> Vec<u8> {
-        let expected_len = self.len();
-        let mut res = Vec::with_capacity(expected_len);
-        self.append_into(&mut res);
-        debug_assert_eq!(res.len(), expected_len);
-        res
+        let mut buf = Vec::with_capacity(self.len());
+        self.append_into(&mut buf);
+        buf
     }
 }
 

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -314,10 +314,8 @@ impl WrappedTrieChanges {
                 | TrieKey::ContractData { .. } => {}
                 _ => continue,
             };
-            let storage_key = KeyForStateChanges::new_from_trie_key(
-                &self.block_hash,
-                &change_with_trie_key.trie_key,
-            );
+            let storage_key =
+                KeyForStateChanges::from_trie_key(&self.block_hash, &change_with_trie_key.trie_key);
             store_update.set(
                 DBCol::ColStateChanges,
                 storage_key.as_ref(),
@@ -349,26 +347,26 @@ impl KeyForStateChanges {
         std::mem::size_of::<CryptoHash>()
     }
 
-    fn get_prefix_with_capacity(block_hash: &CryptoHash, reserve_capacity: usize) -> Self {
+    fn new(block_hash: &CryptoHash, reserve_capacity: usize) -> Self {
         let mut key_prefix = Vec::with_capacity(Self::estimate_prefix_len() + reserve_capacity);
         key_prefix.extend(block_hash.as_ref());
         debug_assert_eq!(key_prefix.len(), Self::estimate_prefix_len());
         Self(key_prefix)
     }
 
-    pub fn get_prefix(block_hash: &CryptoHash) -> Self {
-        Self::get_prefix_with_capacity(block_hash, 0)
+    pub fn for_block(block_hash: &CryptoHash) -> Self {
+        Self::new(block_hash, 0)
     }
 
-    pub fn new(block_hash: &CryptoHash, raw_key: &[u8]) -> Self {
-        let mut key = Self::get_prefix_with_capacity(block_hash, raw_key.len());
+    pub fn from_raw_key(block_hash: &CryptoHash, raw_key: &[u8]) -> Self {
+        let mut key = Self::new(block_hash, raw_key.len());
         key.0.extend(raw_key);
         key
     }
 
-    pub fn new_from_trie_key(block_hash: &CryptoHash, trie_key: &TrieKey) -> Self {
-        let mut key = Self::get_prefix_with_capacity(block_hash, trie_key.len());
-        key.0.extend(trie_key.to_vec());
+    pub fn from_trie_key(block_hash: &CryptoHash, trie_key: &TrieKey) -> Self {
+        let mut key = Self::new(block_hash, trie_key.len());
+        trie_key.append_into(&mut key.0);
         key
     }
 


### PR DESCRIPTION
Firstly, rename KeyForStateChanges constructor methods.  Maybe it’s
just me, but get_prefix just doesn’t sound like a good name for
a constructer,  Use for_block, from_raw_key and from_trie_key names
instead which are shorter and at the same time more descriptive.

Secondly, add TrieKey::append_into method which rather than
allocating a new vector appends the data into existing vector.

Lastly, use that in KeyForStateChanges::from_trie_key method to
get rid of vector allocation.