### PR TITLE
fix: protocol_feature handling for FunctionCallWeight

### DIFF
--- a/runtime/near-vm-logic/src/logic.rs
+++ b/runtime/near-vm-logic/src/logic.rs
@@ -1608,7 +1608,7 @@ impl<'a> VMLogic<'a> {
         arguments_ptr: u64,
         amount_ptr: u64,
         gas: Gas,
-        gas_weight: GasWeight,
+        gas_weight: u64,
     ) -> Result<()> {
         let append_action_fn = |vm: &mut Self, receipt_idx, method_name, arguments, amount, gas| {
             vm.receipt_manager.append_action_function_call_weight(
@@ -1617,7 +1617,7 @@ impl<'a> VMLogic<'a> {
                 arguments,
                 amount,
                 gas,
-                gas_weight,
+                GasWeight(gas_weight),
             )
         };
         self.internal_promise_batch_action_function_call(

--- a/runtime/near-vm-logic/src/tests/helpers.rs
+++ b/runtime/near-vm-logic/src/tests/helpers.rs
@@ -1,6 +1,4 @@
 use crate::{with_ext_cost_counter, VMLogic};
-#[cfg(feature = "protocol_feature_function_call_weight")]
-use near_primitives_core::types::GasWeight;
 use near_primitives_core::{config::ExtCosts, types::Gas};
 use near_vm_errors::VMLogicError;
 use std::collections::HashMap;
@@ -60,7 +58,7 @@ pub fn promise_batch_action_function_call_weight(
     promise_index: u64,
     amount: u128,
     gas: Gas,
-    ratio: GasWeight,
+    weight: u64,
 ) -> Result<()> {
     let method_id = b"promise_batch_action";
     let args = b"promise_batch_action_args";
@@ -73,7 +71,7 @@ pub fn promise_batch_action_function_call_weight(
         args.as_ptr() as _,
         amount.to_le_bytes().as_ptr() as _,
         gas,
-        ratio,
+        weight,
     )
 }
 

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -93,6 +93,9 @@ protocol_feature_alt_bn128 = [
     "near-primitives/protocol_feature_alt_bn128",
     "near-vm-errors/protocol_feature_alt_bn128"
 ]
+protocol_feature_function_call_weight = [
+    "near-vm-logic/protocol_feature_function_call_weight",
+]
 nightly_protocol = ["near-primitives/nightly_protocol"]
 sandbox = ["near-vm-logic/sandbox"]
 

--- a/runtime/near-vm-runner/src/imports.rs
+++ b/runtime/near-vm-runner/src/imports.rs
@@ -155,7 +155,7 @@ imports! {
         amount_ptr: u64,
         gas: u64
     ] -> []>,
-    #["protocol_feature_function_call_weight", FunctionCallRatio] promise_batch_action_function_call_weight<[
+    #["protocol_feature_function_call_weight", FunctionCallWeight] promise_batch_action_function_call_weight<[
         promise_index: u64,
         method_name_len: u64,
         method_name_ptr: u64,

--- a/runtime/runtime/Cargo.toml
+++ b/runtime/runtime/Cargo.toml
@@ -58,6 +58,7 @@ protocol_feature_alt_bn128 = [
 protocol_feature_function_call_weight = [
     "near-primitives/protocol_feature_function_call_weight",
     "near-vm-logic/protocol_feature_function_call_weight",
+    "near-vm-runner/protocol_feature_function_call_weight",
 ]
 sandbox = ["near-vm-logic/sandbox", "near-vm-runner/sandbox"]
 


### PR DESCRIPTION
This contains two fixes:

* We didn't actually add the relevat feature flag to Cargo.toml,
  so near-vm-runner side of implementation was effectively dead
* In the signature of the logic function, only u64/u32 are allowed (this
  is a signature directly exported into WASM)


Test Plan
---------

Run `cargo test --package near-vm-runner --lib --all-features` locally and check that it indeed adds the required host fn. 