### PR TITLE
fix!: adjust gas distribution formula for NEP264

### DIFF
--- a/runtime/near-vm-logic/src/tests/gas_counter.rs
+++ b/runtime/near-vm-logic/src/tests/gas_counter.rs
@@ -197,8 +197,12 @@ fn function_call_weight_basic_cases_test() {
     // Weight over u64 bounds
     function_call_weight_check(&[(0, u64::MAX, 9_999_999_999), (0, 1000, 1)]);
 
-    // Weight over u64 bounds with three values
-    function_call_weight_check(&[(0, u64::MAX, 9_999_999_999), (0, 1, 0), (0, 1000, 1)]);
+    // Weight gas limit with three function calls
+    function_call_weight_check(&[
+        (0, 10_000_000_000, 4_999_999_999),
+        (0, 1, 0),
+        (0, 10_000_000_000, 5_000_000_001),
+    ]);
 
     // Weights with one zero and one non-zero
     function_call_weight_check(&[(0, 0, 0), (0, 1, 10_000_000_000)])

--- a/runtime/near-vm-logic/src/tests/gas_counter.rs
+++ b/runtime/near-vm-logic/src/tests/gas_counter.rs
@@ -197,7 +197,7 @@ fn function_call_weight_basic_cases_test() {
     // Weight over u64 bounds
     function_call_weight_check(&[(0, u64::MAX, 9_999_999_999), (0, 1000, 1)]);
 
-    // Weight gas limit with three function calls
+    // Weight over gas limit with three function calls
     function_call_weight_check(&[
         (0, 10_000_000_000, 4_999_999_999),
         (0, 1, 0),

--- a/runtime/near-vm-logic/src/tests/gas_counter.rs
+++ b/runtime/near-vm-logic/src/tests/gas_counter.rs
@@ -195,7 +195,10 @@ fn function_call_weight_basic_cases_test() {
     ]);
 
     // Weight over u64 bounds
-    function_call_weight_check(&[(0, u64::MAX, 0), (0, 1000, 10_000_000_000)]);
+    function_call_weight_check(&[(0, u64::MAX, 9_999_999_999), (0, 1000, 1)]);
+
+    // Weight over u64 bounds with three values
+    function_call_weight_check(&[(0, u64::MAX, 9_999_999_999), (0, 1, 0), (0, 1000, 1)]);
 
     // Weights with one zero and one non-zero
     function_call_weight_check(&[(0, 0, 0), (0, 1, 10_000_000_000)])


### PR DESCRIPTION
Adjusting formula based on @matklad suggestion. It more closely represents distributing gas based on weights if the sum of weights is greater than the amount of gas remaining at the cost of performing slightly more arithmetic.

I think this makes more sense, but hard to think about the exact implications without some benchmark of the two.