### PR TITLE
perf: avoid locks in epoch manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2759,7 +2759,7 @@ version = "0.0.0"
 dependencies = [
  "borsh",
  "chrono",
- "lru",
+ "near-cache",
  "near-chain",
  "near-chain-configs",
  "near-crypto",

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -1079,15 +1079,18 @@ impl RuntimeAdapter for KeyValueRuntime {
         _prev_epoch_last_block_hash: &CryptoHash,
         _epoch_id: &EpochId,
         _next_epoch_id: &EpochId,
-    ) -> Result<(BlockInfo, BlockInfo, BlockInfo, EpochInfo, EpochInfo, EpochInfo), Error> {
-        Ok((
-            BlockInfo::default(),
-            BlockInfo::default(),
-            BlockInfo::default(),
-            EpochInfo::default(),
-            EpochInfo::default(),
-            EpochInfo::default(),
-        ))
+    ) -> Result<
+        (
+            Arc<BlockInfo>,
+            Arc<BlockInfo>,
+            Arc<BlockInfo>,
+            Arc<EpochInfo>,
+            Arc<EpochInfo>,
+            Arc<EpochInfo>,
+        ),
+        Error,
+    > {
+        Ok(Default::default())
     }
 
     fn get_epoch_sync_data_hash(

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -1,5 +1,6 @@
 use std::cmp::Ordering;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use chrono::DateTime;
@@ -545,7 +546,17 @@ pub trait RuntimeAdapter: Send + Sync {
         prev_epoch_last_block_hash: &CryptoHash,
         epoch_id: &EpochId,
         next_epoch_id: &EpochId,
-    ) -> Result<(BlockInfo, BlockInfo, BlockInfo, EpochInfo, EpochInfo, EpochInfo), Error>;
+    ) -> Result<
+        (
+            Arc<BlockInfo>,
+            Arc<BlockInfo>,
+            Arc<BlockInfo>,
+            Arc<EpochInfo>,
+            Arc<EpochInfo>,
+            Arc<EpochInfo>,
+        ),
+        Error,
+    >;
 
     // TODO #3488 this likely to be updated
     /// Hash that is necessary for prove Epochs in Epoch Sync.

--- a/chain/epoch_manager/Cargo.toml
+++ b/chain/epoch_manager/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2021"
 # Changing this version will lead to change to the protocol, as will change how validators get shuffled.
 protocol_defining_rand = { package = "rand", version = "0.6.5", default-features = false }
 tracing = "0.1.13"
-lru = "0.7.2"
 borsh = "0.9"
 rand = "0.7"
 serde_json = "1"
@@ -26,6 +25,7 @@ near-primitives = { path = "../../core/primitives" }
 near-chain = { path = "../chain" }
 near-store = { path = "../../core/store" }
 near-chain-configs = { path = "../../core/chain-configs" }
+near-cache = { path = "../../utils/near-cache" }
 
 [features]
 expensive_tests = []

--- a/chain/epoch_manager/src/lib.rs
+++ b/chain/epoch_manager/src/lib.rs
@@ -1580,28 +1580,25 @@ impl EpochManager {
 
 #[cfg(test)]
 mod tests2 {
-    use num_rational::Rational;
-
-    use near_primitives::challenge::SlashedValidator;
-    use near_primitives::hash::hash;
-    use near_primitives::types::ValidatorKickoutReason::NotEnoughBlocks;
-    use near_primitives::version::PROTOCOL_VERSION;
-    use near_store::test_utils::create_test_store;
-
+    use super::*;
+    use crate::reward_calculator::NUM_NS_IN_SECOND;
     use crate::test_utils::{
         block_info, change_stake, default_reward_calculator, epoch_config,
         epoch_info_with_num_seats, hash_range, record_block, record_block_with_final_block_hash,
         record_block_with_slashes, record_with_block_info, reward, setup_default_epoch_manager,
         setup_epoch_manager, stake, DEFAULT_TOTAL_SUPPLY,
     };
-
-    use super::*;
-    use crate::reward_calculator::NUM_NS_IN_SECOND;
+    use near_primitives::challenge::SlashedValidator;
     use near_primitives::epoch_manager::EpochConfig;
     use near_primitives::epoch_manager::ShardConfig;
+    use near_primitives::hash::hash;
     use near_primitives::shard_layout::ShardLayout;
+    use near_primitives::types::ValidatorKickoutReason::NotEnoughBlocks;
     use near_primitives::utils::get_num_seats_per_shard;
     use near_primitives::version::ProtocolFeature::SimpleNightshade;
+    use near_primitives::version::PROTOCOL_VERSION;
+    use near_store::test_utils::create_test_store;
+    use num_rational::Rational;
 
     impl EpochManager {
         /// Returns number of produced and expected blocks by given validator.

--- a/chain/epoch_manager/src/lib.rs
+++ b/chain/epoch_manager/src/lib.rs
@@ -1,6 +1,8 @@
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::Arc;
 
+use near_cache::SyncLruCache;
 use primitive_types::U256;
 use tracing::{debug, warn};
 
@@ -58,15 +60,15 @@ pub struct EpochManager {
     genesis_protocol_version: ProtocolVersion,
 
     /// Cache of epoch information.
-    epochs_info: lru::LruCache<EpochId, EpochInfo>,
+    epochs_info: SyncLruCache<EpochId, Arc<EpochInfo>>,
     /// Cache of block information.
-    blocks_info: lru::LruCache<CryptoHash, BlockInfo>,
+    blocks_info: SyncLruCache<CryptoHash, Arc<BlockInfo>>,
     /// Cache of epoch id to epoch start height
-    epoch_id_to_start: lru::LruCache<EpochId, BlockHeight>,
+    epoch_id_to_start: SyncLruCache<EpochId, BlockHeight>,
     /// Epoch validators ordered by `block_producer_settlement`.
-    epoch_validators_ordered: lru::LruCache<EpochId, Vec<(ValidatorStake, bool)>>,
+    epoch_validators_ordered: SyncLruCache<EpochId, Arc<[(ValidatorStake, bool)]>>,
     /// Unique validators ordered by `block_producer_settlement`.
-    epoch_validators_ordered_unique: lru::LruCache<EpochId, Vec<(ValidatorStake, bool)>>,
+    epoch_validators_ordered_unique: SyncLruCache<EpochId, Arc<[(ValidatorStake, bool)]>>,
     /// Aggregator that keeps statistics about the current epoch.  It’s data are
     /// synced up to the last final block.  The information are updated by
     /// [`update_epoch_info_aggregator_upto_final`] method.  To get statistics
@@ -78,7 +80,7 @@ pub struct EpochManager {
     /// Counts loop iterations inside of aggregate_epoch_info_upto method.
     /// Used for tests as a bit of white-box testing.
     #[cfg(test)]
-    epoch_info_aggregator_loop_counter: usize,
+    epoch_info_aggregator_loop_counter: std::sync::atomic::AtomicUsize,
 }
 
 impl EpochManager {
@@ -115,14 +117,14 @@ impl EpochManager {
             config,
             reward_calculator,
             genesis_protocol_version,
-            epochs_info: lru::LruCache::new(EPOCH_CACHE_SIZE),
-            blocks_info: lru::LruCache::new(BLOCK_CACHE_SIZE),
-            epoch_id_to_start: lru::LruCache::new(EPOCH_CACHE_SIZE),
-            epoch_validators_ordered: lru::LruCache::new(EPOCH_CACHE_SIZE),
-            epoch_validators_ordered_unique: lru::LruCache::new(EPOCH_CACHE_SIZE),
+            epochs_info: SyncLruCache::new(EPOCH_CACHE_SIZE),
+            blocks_info: SyncLruCache::new(BLOCK_CACHE_SIZE),
+            epoch_id_to_start: SyncLruCache::new(EPOCH_CACHE_SIZE),
+            epoch_validators_ordered: SyncLruCache::new(EPOCH_CACHE_SIZE),
+            epoch_validators_ordered_unique: SyncLruCache::new(EPOCH_CACHE_SIZE),
             epoch_info_aggregator,
             #[cfg(test)]
-            epoch_info_aggregator_loop_counter: 0,
+            epoch_info_aggregator_loop_counter: Default::default(),
             largest_final_height: 0,
         };
         let genesis_epoch_id = EpochId::default();
@@ -146,9 +148,13 @@ impl EpochManager {
             // parent of genesis block that points to itself.
             // If we view it as block in epoch -1 and height -1, it naturally extends the
             // EpochId formula using T-2 for T=1, and height field is unused.
-            let block_info = BlockInfo::default();
+            let block_info = Arc::new(BlockInfo::default());
             let mut store_update = epoch_manager.store.store_update();
-            epoch_manager.save_epoch_info(&mut store_update, &genesis_epoch_id, epoch_info)?;
+            epoch_manager.save_epoch_info(
+                &mut store_update,
+                &genesis_epoch_id,
+                Arc::new(epoch_info),
+            )?;
             epoch_manager.save_block_info(&mut store_update, block_info)?;
             store_update.commit()?;
         }
@@ -167,7 +173,7 @@ impl EpochManager {
         block_hash: &CryptoHash,
         source_epoch_manager: &mut EpochManager,
     ) -> Result<(), EpochError> {
-        let block_info = source_epoch_manager.get_block_info(block_hash)?.clone();
+        let block_info = source_epoch_manager.get_block_info(block_hash)?;
         let prev_hash = block_info.prev_hash();
         let epoch_id = &source_epoch_manager.get_epoch_id_from_prev_block(prev_hash)?;
         let next_epoch_id = &source_epoch_manager.get_next_epoch_id_from_prev_block(prev_hash)?;
@@ -198,7 +204,7 @@ impl EpochManager {
         let epoch_first_block = block_info.epoch_first_block();
         self.save_block_info(
             &mut store_update,
-            source_epoch_manager.get_block_info(epoch_first_block)?.clone(),
+            source_epoch_manager.get_block_info(epoch_first_block)?,
         )?;
 
         self.save_block_info(&mut store_update, block_info)?;
@@ -226,12 +232,12 @@ impl EpochManager {
         next_epoch_info: EpochInfo,
     ) -> Result<StoreUpdate, EpochError> {
         let mut store_update = self.store.store_update();
-        self.save_block_info(&mut store_update, prev_epoch_first_block_info)?;
-        self.save_block_info(&mut store_update, prev_epoch_prev_last_block_info)?;
-        self.save_block_info(&mut store_update, prev_epoch_last_block_info)?;
-        self.save_epoch_info(&mut store_update, prev_epoch_id, prev_epoch_info)?;
-        self.save_epoch_info(&mut store_update, epoch_id, epoch_info)?;
-        self.save_epoch_info(&mut store_update, next_epoch_id, next_epoch_info)?;
+        self.save_block_info(&mut store_update, Arc::new(prev_epoch_first_block_info))?;
+        self.save_block_info(&mut store_update, Arc::new(prev_epoch_prev_last_block_info))?;
+        self.save_block_info(&mut store_update, Arc::new(prev_epoch_last_block_info))?;
+        self.save_epoch_info(&mut store_update, prev_epoch_id, Arc::new(prev_epoch_info))?;
+        self.save_epoch_info(&mut store_update, epoch_id, Arc::new(epoch_info))?;
+        self.save_epoch_info(&mut store_update, next_epoch_id, Arc::new(next_epoch_info))?;
         // TODO #3488
         // put unreachable! here to avoid warnings
         unreachable!();
@@ -497,13 +503,13 @@ impl EpochManager {
             Ok(next_next_epoch_info) => next_next_epoch_info,
             Err(EpochError::ThresholdError { stake_sum, num_seats }) => {
                 warn!(target: "epoch_manager", "Not enough stake for required number of seats (all validators tried to unstake?): amount = {} for {}", stake_sum, num_seats);
-                let mut epoch_info = next_epoch_info.clone();
+                let mut epoch_info = (*next_epoch_info).clone();
                 *epoch_info.epoch_height_mut() += 1;
                 epoch_info
             }
             Err(EpochError::NotEnoughValidators { num_validators, num_shards }) => {
                 warn!(target: "epoch_manager", "Not enough validators for required number of shards (all validators tried to unstake?): num_validators={} num_shards={}", num_validators, num_shards);
-                let mut epoch_info = next_epoch_info.clone();
+                let mut epoch_info = (*next_epoch_info).clone();
                 *epoch_info.epoch_height_mut() += 1;
                 epoch_info
             }
@@ -517,7 +523,7 @@ impl EpochManager {
                self.config.for_protocol_version(next_next_epoch_info.protocol_version()).shard_layout);
         // This epoch info is computed for the epoch after next (T+2),
         // where epoch_id of it is the hash of last block in this epoch (T).
-        self.save_epoch_info(store_update, &next_next_epoch_id, next_next_epoch_info)?;
+        self.save_epoch_info(store_update, &next_next_epoch_id, Arc::new(next_next_epoch_info))?;
         Ok(())
     }
 
@@ -535,14 +541,14 @@ impl EpochManager {
                 assert_eq!(block_info.proposals_iter().len(), 0);
                 let pre_genesis_epoch_id = EpochId::default();
                 let genesis_epoch_info = self.get_epoch_info(&pre_genesis_epoch_id)?.clone();
-                self.save_block_info(&mut store_update, block_info)?;
+                self.save_block_info(&mut store_update, Arc::new(block_info))?;
                 self.save_epoch_info(
                     &mut store_update,
                     &EpochId(current_hash),
                     genesis_epoch_info,
                 )?;
             } else {
-                let prev_block_info = self.get_block_info(block_info.prev_hash())?.clone();
+                let prev_block_info = self.get_block_info(block_info.prev_hash())?;
 
                 let mut is_epoch_start = false;
                 if prev_block_info.prev_hash() == &CryptoHash::default() {
@@ -566,7 +572,7 @@ impl EpochManager {
                 // Keep `slashed` from previous block if they are still in the epoch info stake change
                 // (e.g. we need to keep track that they are still slashed, because when we compute
                 // returned stake we are skipping account ids that are slashed in `stake_change`).
-                for (account_id, slash_state) in prev_block_info.slashed().iter() {
+                for (account_id, slash_state) in prev_block_info.slashed() {
                     if is_epoch_start {
                         if slash_state == &SlashState::DoubleSign
                             || slash_state == &SlashState::Other
@@ -602,8 +608,9 @@ impl EpochManager {
                     )?;
                 }
 
+                let block_info = Arc::new(block_info);
                 // Save current block info.
-                self.save_block_info(&mut store_update, block_info.clone())?;
+                self.save_block_info(&mut store_update, Arc::clone(&block_info))?;
                 if block_info.last_finalized_height() > &self.largest_final_height {
                     self.largest_final_height = *block_info.last_finalized_height();
 
@@ -629,63 +636,66 @@ impl EpochManager {
     /// Given epoch id and height, returns validator information that suppose to produce
     /// the block at that height. We don't require caller to know about EpochIds.
     pub fn get_block_producer_info(
-        &mut self,
+        &self,
         epoch_id: &EpochId,
         height: BlockHeight,
     ) -> Result<ValidatorStake, EpochError> {
-        let epoch_info = self.get_epoch_info(epoch_id)?.clone();
+        let epoch_info = self.get_epoch_info(epoch_id)?;
         let validator_id = Self::block_producer_from_info(&epoch_info, height);
         Ok(epoch_info.get_validator(validator_id))
     }
 
     /// Returns settlement of all block producers in current epoch, with indicator on whether they are slashed or not.
     pub fn get_all_block_producers_settlement(
-        &mut self,
+        &self,
         epoch_id: &EpochId,
         last_known_block_hash: &CryptoHash,
-    ) -> Result<&[(ValidatorStake, bool)], EpochError> {
+    ) -> Result<Arc<[(ValidatorStake, bool)]>, EpochError> {
         // TODO(3674): Revisit this when we enable slashing
-        if self.epoch_validators_ordered.get(epoch_id).is_none() {
-            let slashed = self.get_slashed_validators(last_known_block_hash)?.clone();
+        self.epoch_validators_ordered.get_or_try_put(epoch_id.clone(), |epoch_id| {
+            let block_info = self.get_block_info(last_known_block_hash)?;
             let epoch_info = self.get_epoch_info(epoch_id)?;
-            let mut settlement = Vec::with_capacity(epoch_info.block_producers_settlement().len());
-            for validator_id in epoch_info.block_producers_settlement().into_iter() {
-                let validator_stake = epoch_info.get_validator(*validator_id);
-                let is_slashed = slashed.contains_key(validator_stake.account_id());
-                settlement.push((validator_stake, is_slashed));
-            }
-            self.epoch_validators_ordered.put(epoch_id.clone(), settlement);
-        }
-        Ok(self.epoch_validators_ordered.get(epoch_id).unwrap())
+            let result = epoch_info
+                .block_producers_settlement()
+                .iter()
+                .map(|&validator_id| {
+                    let validator_stake = epoch_info.get_validator(validator_id);
+                    let is_slashed =
+                        block_info.slashed().contains_key(validator_stake.account_id());
+                    (validator_stake, is_slashed)
+                })
+                .collect();
+            Ok(result)
+        })
     }
 
     /// Returns all unique block producers in current epoch sorted by account_id, with indicator on whether they are slashed or not.
     pub fn get_all_block_producers_ordered(
-        &mut self,
+        &self,
         epoch_id: &EpochId,
         last_known_block_hash: &CryptoHash,
-    ) -> Result<&[(ValidatorStake, bool)], EpochError> {
-        if self.epoch_validators_ordered_unique.get(epoch_id).is_none() {
+    ) -> Result<Arc<[(ValidatorStake, bool)]>, EpochError> {
+        self.epoch_validators_ordered_unique.get_or_try_put(epoch_id.clone(), |epoch_id| {
             let settlement =
                 self.get_all_block_producers_settlement(epoch_id, last_known_block_hash)?;
-            let mut result = vec![];
             let mut validators: HashSet<AccountId> = HashSet::default();
-            for (validator_stake, is_slashed) in settlement {
-                let account_id = validator_stake.account_id();
-                if validators.insert(account_id.clone()) {
-                    result.push((validator_stake.clone(), *is_slashed));
-                }
-            }
-            self.epoch_validators_ordered_unique.put(epoch_id.clone(), result);
-        }
-        Ok(self.epoch_validators_ordered_unique.get(epoch_id).unwrap())
+            let result = settlement
+                .iter()
+                .filter(|(validator_stake, _is_slashed)| {
+                    let account_id = validator_stake.account_id();
+                    validators.insert(account_id.clone())
+                })
+                .cloned()
+                .collect();
+            Ok(result)
+        })
     }
 
     /// get_heuristic_block_approvers_ordered: block producers for epoch
     /// get_all_block_producers_ordered: block producers for epoch, slashing info
     /// get_all_block_approvers_ordered: block producers for epoch, slashing info, sometimes block producers for next epoch
     pub fn get_heuristic_block_approvers_ordered(
-        &mut self,
+        &self,
         epoch_id: &EpochId,
     ) -> Result<Vec<ApprovalStake>, EpochError> {
         let epoch_info = self.get_epoch_info(epoch_id)?;
@@ -703,7 +713,7 @@ impl EpochManager {
     }
 
     pub fn get_all_block_approvers_ordered(
-        &mut self,
+        &self,
         parent_hash: &CryptoHash,
     ) -> Result<Vec<(ApprovalStake, bool)>, EpochError> {
         let current_epoch_id = self.get_epoch_id_from_prev_block(parent_hash)?;
@@ -714,7 +724,7 @@ impl EpochManager {
 
         let settlement_epoch_boundary = settlement.len();
 
-        let block_info = self.get_block_info(parent_hash)?.clone();
+        let block_info = self.get_block_info(parent_hash)?;
         if self.next_block_need_approvals_from_next_epoch(&block_info)? {
             settlement.extend(
                 self.get_all_block_producers_settlement(&next_epoch_id, parent_hash)?
@@ -747,7 +757,7 @@ impl EpochManager {
 
     /// For given epoch_id, height and shard_id returns validator that is chunk producer.
     pub fn get_chunk_producer_info(
-        &mut self,
+        &self,
         epoch_id: &EpochId,
         height: BlockHeight,
         shard_id: ShardId,
@@ -760,7 +770,7 @@ impl EpochManager {
     /// Returns validator for given account id for given epoch.
     /// We don't require caller to know about EpochIds. Doesn't account for slashing.
     pub fn get_validator_by_account_id(
-        &mut self,
+        &self,
         epoch_id: &EpochId,
         account_id: &AccountId,
     ) -> Result<Option<ValidatorStake>, EpochError> {
@@ -770,7 +780,7 @@ impl EpochManager {
 
     /// Returns fisherman for given account id for given epoch.
     pub fn get_fisherman_by_account_id(
-        &mut self,
+        &self,
         epoch_id: &EpochId,
         account_id: &AccountId,
     ) -> Result<Option<ValidatorStake>, EpochError> {
@@ -778,38 +788,31 @@ impl EpochManager {
         Ok(epoch_info.get_fisherman_by_account(account_id))
     }
 
-    pub fn get_slashed_validators(
-        &mut self,
-        block_hash: &CryptoHash,
-    ) -> Result<&HashMap<AccountId, SlashState>, EpochError> {
-        Ok(self.get_block_info(block_hash)?.slashed())
-    }
-
-    pub fn get_epoch_id(&mut self, block_hash: &CryptoHash) -> Result<EpochId, EpochError> {
+    pub fn get_epoch_id(&self, block_hash: &CryptoHash) -> Result<EpochId, EpochError> {
         Ok(self.get_block_info(block_hash)?.epoch_id().clone())
     }
 
-    pub fn get_next_epoch_id(&mut self, block_hash: &CryptoHash) -> Result<EpochId, EpochError> {
-        let block_info = self.get_block_info(block_hash)?.clone();
+    pub fn get_next_epoch_id(&self, block_hash: &CryptoHash) -> Result<EpochId, EpochError> {
+        let block_info = self.get_block_info(block_hash)?;
         self.get_next_epoch_id_from_info(&block_info)
     }
 
-    pub fn get_prev_epoch_id(&mut self, block_hash: &CryptoHash) -> Result<EpochId, EpochError> {
+    pub fn get_prev_epoch_id(&self, block_hash: &CryptoHash) -> Result<EpochId, EpochError> {
         let epoch_first_block = *self.get_block_info(block_hash)?.epoch_first_block();
         let prev_epoch_last_hash = *self.get_block_info(&epoch_first_block)?.prev_hash();
         self.get_epoch_id(&prev_epoch_last_hash)
     }
 
     pub fn get_epoch_info_from_hash(
-        &mut self,
+        &self,
         block_hash: &CryptoHash,
-    ) -> Result<&EpochInfo, EpochError> {
+    ) -> Result<Arc<EpochInfo>, EpochError> {
         let epoch_id = self.get_epoch_id(block_hash)?;
         self.get_epoch_info(&epoch_id)
     }
 
     pub fn cares_about_shard_from_prev_block(
-        &mut self,
+        &self,
         parent_hash: &CryptoHash,
         account_id: &AccountId,
         shard_id: ShardId,
@@ -822,7 +825,7 @@ impl EpochManager {
     // If shard layout will change next epoch, returns true if it cares about any shard
     // that `shard_id` will split to
     pub fn cares_about_shard_next_epoch_from_prev_block(
-        &mut self,
+        &self,
         parent_hash: &CryptoHash,
         account_id: &AccountId,
         shard_id: ShardId,
@@ -850,16 +853,13 @@ impl EpochManager {
 
     /// Returns true if next block after given block hash is in the new epoch.
     #[allow(clippy::wrong_self_convention)]
-    pub fn is_next_block_epoch_start(
-        &mut self,
-        parent_hash: &CryptoHash,
-    ) -> Result<bool, EpochError> {
-        let block_info = self.get_block_info(parent_hash)?.clone();
+    pub fn is_next_block_epoch_start(&self, parent_hash: &CryptoHash) -> Result<bool, EpochError> {
+        let block_info = self.get_block_info(parent_hash)?;
         self.is_next_block_in_next_epoch(&block_info)
     }
 
     pub fn get_epoch_id_from_prev_block(
-        &mut self,
+        &self,
         parent_hash: &CryptoHash,
     ) -> Result<EpochId, EpochError> {
         if self.is_next_block_epoch_start(parent_hash)? {
@@ -870,7 +870,7 @@ impl EpochManager {
     }
 
     pub fn get_next_epoch_id_from_prev_block(
-        &mut self,
+        &self,
         parent_hash: &CryptoHash,
     ) -> Result<EpochId, EpochError> {
         if self.is_next_block_epoch_start(parent_hash)? {
@@ -882,7 +882,7 @@ impl EpochManager {
     }
 
     pub fn get_epoch_start_height(
-        &mut self,
+        &self,
         block_hash: &CryptoHash,
     ) -> Result<BlockHeight, EpochError> {
         let epoch_first_block = *self.get_block_info(block_hash)?.epoch_first_block();
@@ -897,7 +897,7 @@ impl EpochManager {
     /// If successful, a triple of (hashmap of account id to max of stakes in the past three epochs,
     /// validator rewards in the last epoch, double sign slashing for the past epoch).
     pub fn compute_stake_return_info(
-        &mut self,
+        &self,
         last_block_hash: &CryptoHash,
     ) -> Result<
         (HashMap<AccountId, Balance>, HashMap<AccountId, Balance>, HashMap<AccountId, Balance>),
@@ -913,18 +913,18 @@ impl EpochManager {
             next_next_epoch_id, next_epoch_id, epoch_id
         );
         // Fetch last block info to get the slashed accounts.
-        let last_block_info = self.get_block_info(last_block_hash)?.clone();
+        let last_block_info = self.get_block_info(last_block_hash)?;
         // Since stake changes for epoch T are stored in epoch info for T+2, the one stored by epoch_id
         // is the prev_prev_stake_change.
         let prev_prev_stake_change = self.get_epoch_info(&epoch_id)?.stake_change().clone();
         let prev_stake_change = self.get_epoch_info(&next_epoch_id)?.stake_change().clone();
-        let stake_change = self.get_epoch_info(&next_next_epoch_id)?.stake_change();
+        let stake_change = self.get_epoch_info(&next_next_epoch_id)?.stake_change().clone();
         debug!(target: "epoch_manager",
             "prev_prev_stake_change: {:?}, prev_stake_change: {:?}, stake_change: {:?}, slashed: {:?}",
             prev_prev_stake_change, prev_stake_change, stake_change, last_block_info.slashed()
         );
         let all_stake_changes =
-            prev_prev_stake_change.iter().chain(&prev_stake_change).chain(stake_change);
+            prev_prev_stake_change.iter().chain(&prev_stake_change).chain(&stake_change);
         let all_keys: HashSet<&AccountId> = all_stake_changes.map(|(key, _)| key).collect();
 
         let mut stake_info = HashMap::new();
@@ -955,14 +955,15 @@ impl EpochManager {
     /// Compute slashing information. Returns a hashmap of account id to slashed amount for double sign
     /// slashing.
     fn compute_double_sign_slashing_info(
-        &mut self,
+        &self,
         last_block_hash: &CryptoHash,
     ) -> Result<HashMap<AccountId, Balance>, EpochError> {
-        let slashed = self.get_slashed_validators(last_block_hash)?.clone();
+        let last_block_info = self.get_block_info(last_block_hash)?;
         let epoch_id = self.get_epoch_id(last_block_hash)?;
         let epoch_info = self.get_epoch_info(&epoch_id)?;
         let total_stake: Balance = epoch_info.validators_iter().map(|v| v.stake()).sum();
-        let total_slashed_stake: Balance = slashed
+        let total_slashed_stake: Balance = last_block_info
+            .slashed()
             .iter()
             .filter_map(|(account_id, slashed)| match slashed {
                 SlashState::DoubleSign => Some(
@@ -975,9 +976,9 @@ impl EpochManager {
             .sum();
         let is_totally_slashed = total_slashed_stake * 3 >= total_stake;
         let mut res = HashMap::default();
-        for (account_id, slash_state) in slashed {
+        for (account_id, slash_state) in last_block_info.slashed() {
             if let SlashState::DoubleSign = slash_state {
-                if let Some(&idx) = epoch_info.get_validator_id(&account_id) {
+                if let Some(&idx) = epoch_info.get_validator_id(account_id) {
                     let stake = epoch_info.validator_stake(idx);
                     let slashed_stake = if is_totally_slashed {
                         stake
@@ -988,7 +989,7 @@ impl EpochManager {
                             / U256::from(total_stake))
                         .as_u128()
                     };
-                    res.insert(account_id, slashed_stake);
+                    res.insert(account_id.clone(), slashed_stake);
                 }
             }
         }
@@ -997,12 +998,12 @@ impl EpochManager {
 
     /// Get validators for current epoch and next epoch.
     pub fn get_validator_info(
-        &mut self,
+        &self,
         epoch_identifier: ValidatorInfoIdentifier,
     ) -> Result<EpochValidatorInfo, EpochError> {
         let epoch_id = match epoch_identifier {
             ValidatorInfoIdentifier::EpochId(ref id) => id.clone(),
-            ValidatorInfoIdentifier::BlockHash(ref b) => self.get_block_info(b)?.epoch_id().clone(),
+            ValidatorInfoIdentifier::BlockHash(ref b) => self.get_epoch_id(b)?,
         };
         let cur_epoch_info = self.get_epoch_info(&epoch_id)?.clone();
         let epoch_height = cur_epoch_info.epoch_height();
@@ -1155,7 +1156,7 @@ impl EpochManager {
     /// Compare two epoch ids based on their start height. This works because finality gadget
     /// guarantees that we cannot have two different epochs on two forks
     pub fn compare_epoch_id(
-        &mut self,
+        &self,
         epoch_id: &EpochId,
         other_epoch_id: &EpochId,
     ) -> Result<Ordering, EpochError> {
@@ -1175,7 +1176,7 @@ impl EpochManager {
 
     /// Get minimum stake allowed at current block. Attempts to stake with a lower stake will be
     /// rejected.
-    pub fn minimum_stake(&mut self, prev_block_hash: &CryptoHash) -> Result<Balance, EpochError> {
+    pub fn minimum_stake(&self, prev_block_hash: &CryptoHash) -> Result<Balance, EpochError> {
         let next_epoch_id = self.get_next_epoch_id_from_prev_block(prev_block_hash)?;
         let (protocol_version, seat_price) = {
             let epoch_info = self.get_epoch_info(&next_epoch_id)?;
@@ -1194,10 +1195,10 @@ impl EpochManager {
         block_header_info: &BlockHeaderInfo,
         store_update: &mut StoreUpdate,
     ) -> Result<(), EpochError> {
-        let block_info = self.get_block_info(&block_header_info.hash)?.clone();
+        let last_block_info = self.get_block_info(&block_header_info.hash)?;
         self.finalize_epoch(
             store_update,
-            &block_info,
+            &last_block_info,
             &block_header_info.hash,
             block_header_info.random_value.into(),
         )?;
@@ -1208,7 +1209,7 @@ impl EpochManager {
 /// Private utilities for EpochManager.
 impl EpochManager {
     fn cares_about_shard_in_epoch(
-        &mut self,
+        &self,
         epoch_id: EpochId,
         account_id: &AccountId,
         shard_id: ShardId,
@@ -1241,8 +1242,7 @@ impl EpochManager {
     }
 
     /// Returns true, if given current block info, next block supposed to be in the next epoch.
-    #[allow(clippy::wrong_self_convention)]
-    fn is_next_block_in_next_epoch(&mut self, block_info: &BlockInfo) -> Result<bool, EpochError> {
+    fn is_next_block_in_next_epoch(&self, block_info: &BlockInfo) -> Result<bool, EpochError> {
         if block_info.prev_hash() == &CryptoHash::default() {
             return Ok(true);
         }
@@ -1263,7 +1263,7 @@ impl EpochManager {
     /// Returns true, if given current block info, next block must include the approvals from the next
     /// epoch (in addition to the approvals from the current epoch)
     fn next_block_need_approvals_from_next_epoch(
-        &mut self,
+        &self,
         block_info: &BlockInfo,
     ) -> Result<bool, EpochError> {
         if self.is_next_block_in_next_epoch(block_info)? {
@@ -1282,35 +1282,29 @@ impl EpochManager {
     }
 
     /// Returns epoch id for the next epoch (T+1), given an block info in current epoch (T).
-    fn get_next_epoch_id_from_info(
-        &mut self,
-        block_info: &BlockInfo,
-    ) -> Result<EpochId, EpochError> {
+    fn get_next_epoch_id_from_info(&self, block_info: &BlockInfo) -> Result<EpochId, EpochError> {
         let first_block_info = self.get_block_info(block_info.epoch_first_block())?;
         Ok(EpochId(*first_block_info.prev_hash()))
     }
 
-    pub fn get_shard_config(&mut self, epoch_id: &EpochId) -> Result<ShardConfig, EpochError> {
+    pub fn get_shard_config(&self, epoch_id: &EpochId) -> Result<ShardConfig, EpochError> {
         let protocol_version = self.get_epoch_info(epoch_id)?.protocol_version();
         let epoch_config = self.config.for_protocol_version(protocol_version);
         Ok(ShardConfig::new(epoch_config))
     }
 
-    pub fn get_epoch_config(&mut self, epoch_id: &EpochId) -> Result<&EpochConfig, EpochError> {
+    pub fn get_epoch_config(&self, epoch_id: &EpochId) -> Result<&EpochConfig, EpochError> {
         let protocol_version = self.get_epoch_info(epoch_id)?.protocol_version();
         Ok(self.config.for_protocol_version(protocol_version))
     }
 
-    pub fn get_shard_layout(&mut self, epoch_id: &EpochId) -> Result<&ShardLayout, EpochError> {
+    pub fn get_shard_layout(&self, epoch_id: &EpochId) -> Result<&ShardLayout, EpochError> {
         let protocol_version = self.get_epoch_info(epoch_id)?.protocol_version();
         let shard_layout = &self.config.for_protocol_version(protocol_version).shard_layout;
         Ok(shard_layout)
     }
 
-    pub fn will_shard_layout_change(
-        &mut self,
-        parent_hash: &CryptoHash,
-    ) -> Result<bool, EpochError> {
+    pub fn will_shard_layout_change(&self, parent_hash: &CryptoHash) -> Result<bool, EpochError> {
         let epoch_id = self.get_epoch_id_from_prev_block(parent_hash)?;
         let next_epoch_id = self.get_next_epoch_id_from_prev_block(parent_hash)?;
         let shard_layout = self.get_shard_layout(&epoch_id)?.clone();
@@ -1318,21 +1312,15 @@ impl EpochManager {
         Ok(shard_layout != next_shard_layout)
     }
 
-    pub fn get_epoch_info(&mut self, epoch_id: &EpochId) -> Result<&EpochInfo, EpochError> {
-        if !self.epochs_info.get(epoch_id).is_some() {
-            let epoch_info = self
-                .store
-                .get_ser(ColEpochInfo, epoch_id.as_ref())
-                .map_err(|err| err.into())
-                .and_then(|value| {
-                    value.ok_or_else(|| EpochError::EpochOutOfBounds(epoch_id.clone()))
-                })?;
-            self.epochs_info.put(epoch_id.clone(), epoch_info);
-        }
-        self.epochs_info.get(epoch_id).ok_or(EpochError::EpochOutOfBounds(epoch_id.clone()))
+    pub fn get_epoch_info(&self, epoch_id: &EpochId) -> Result<Arc<EpochInfo>, EpochError> {
+        self.epochs_info.get_or_try_put(epoch_id.clone(), |epoch_id| {
+            self.store
+                .get_ser(ColEpochInfo, epoch_id.as_ref())?
+                .ok_or_else(|| EpochError::EpochOutOfBounds(epoch_id.clone()))
+        })
     }
 
-    fn has_epoch_info(&mut self, epoch_id: &EpochId) -> Result<bool, EpochError> {
+    fn has_epoch_info(&self, epoch_id: &EpochId) -> Result<bool, EpochError> {
         match self.get_epoch_info(epoch_id) {
             Ok(_) => Ok(true),
             Err(EpochError::EpochOutOfBounds(_)) => Ok(false),
@@ -1344,26 +1332,22 @@ impl EpochManager {
         &mut self,
         store_update: &mut StoreUpdate,
         epoch_id: &EpochId,
-        epoch_info: EpochInfo,
+        epoch_info: Arc<EpochInfo>,
     ) -> Result<(), EpochError> {
-        store_update
-            .set_ser(ColEpochInfo, epoch_id.as_ref(), &epoch_info)
-            .map_err(EpochError::from)?;
+        store_update.set_ser(ColEpochInfo, epoch_id.as_ref(), &epoch_info)?;
         self.epochs_info.put(epoch_id.clone(), epoch_info);
         Ok(())
     }
 
-    pub fn get_epoch_validator_info(
-        &mut self,
-        epoch_id: &EpochId,
-    ) -> Result<EpochSummary, EpochError> {
+    pub fn get_epoch_validator_info(&self, epoch_id: &EpochId) -> Result<EpochSummary, EpochError> {
         // We don't use cache here since this query happens rarely and only for rpc.
         self.store
-            .get_ser(ColEpochValidatorInfo, epoch_id.as_ref())
-            .map_err(|err| err.into())
-            .and_then(|value| value.ok_or_else(|| EpochError::EpochOutOfBounds(epoch_id.clone())))
+            .get_ser(ColEpochValidatorInfo, epoch_id.as_ref())?
+            .ok_or_else(|| EpochError::EpochOutOfBounds(epoch_id.clone()))
     }
 
+    // NOTE: beware, after calling `save_epoch_validator_info`,
+    // `get_epoch_validator_info` will return stale results.
     fn save_epoch_validator_info(
         &self,
         store_update: &mut StoreUpdate,
@@ -1375,7 +1359,7 @@ impl EpochManager {
             .map_err(EpochError::from)
     }
 
-    fn has_block_info(&mut self, hash: &CryptoHash) -> Result<bool, EpochError> {
+    fn has_block_info(&self, hash: &CryptoHash) -> Result<bool, EpochError> {
         match self.get_block_info(hash) {
             Ok(_) => Ok(true),
             Err(EpochError::MissingBlock(_)) => Ok(false),
@@ -1387,22 +1371,19 @@ impl EpochManager {
     /// # Errors
     /// EpochError::IOErr if storage returned an error
     /// EpochError::MissingBlock if block is not in storage
-    pub fn get_block_info(&mut self, hash: &CryptoHash) -> Result<&BlockInfo, EpochError> {
-        if self.blocks_info.get(hash).is_none() {
-            let block_info = self
-                .store
-                .get_ser(ColBlockInfo, hash.as_ref())
-                .map_err(EpochError::from)
-                .and_then(|value| value.ok_or_else(|| EpochError::MissingBlock(*hash)))?;
-            self.blocks_info.put(*hash, block_info);
-        }
-        self.blocks_info.get(hash).ok_or(EpochError::MissingBlock(*hash))
+    pub fn get_block_info(&self, hash: &CryptoHash) -> Result<Arc<BlockInfo>, EpochError> {
+        self.blocks_info.get_or_try_put(*hash, |hash| {
+            self.store
+                .get_ser(ColBlockInfo, hash.as_ref())?
+                .ok_or_else(|| EpochError::MissingBlock(*hash))
+                .map(Arc::new)
+        })
     }
 
     fn save_block_info(
         &mut self,
         store_update: &mut StoreUpdate,
-        block_info: BlockInfo,
+        block_info: Arc<BlockInfo>,
     ) -> Result<(), EpochError> {
         let block_hash = *block_info.hash();
         store_update
@@ -1425,21 +1406,12 @@ impl EpochManager {
         Ok(())
     }
 
-    fn get_epoch_start_from_epoch_id(
-        &mut self,
-        epoch_id: &EpochId,
-    ) -> Result<BlockHeight, EpochError> {
-        if self.epoch_id_to_start.get(epoch_id).is_none() {
-            let epoch_start = self
-                .store
-                .get_ser(ColEpochStart, epoch_id.as_ref())
-                .map_err(EpochError::from)
-                .and_then(|value| {
-                    value.ok_or_else(|| EpochError::EpochOutOfBounds(epoch_id.clone()))
-                })?;
-            self.epoch_id_to_start.put(epoch_id.clone(), epoch_start);
-        }
-        Ok(*self.epoch_id_to_start.get(epoch_id).unwrap())
+    fn get_epoch_start_from_epoch_id(&self, epoch_id: &EpochId) -> Result<BlockHeight, EpochError> {
+        self.epoch_id_to_start.get_or_try_put(epoch_id.clone(), |epoch_id| {
+            self.store
+                .get_ser(ColEpochStart, epoch_id.as_ref())?
+                .ok_or_else(|| EpochError::EpochOutOfBounds(epoch_id.clone()))
+        })
     }
 
     /// Updates epoch info aggregator to state as of `last_final_block_hash`
@@ -1487,7 +1459,7 @@ impl EpochManager {
     ///
     /// This method does not change `self.epoch_info_aggregator`.
     pub fn get_epoch_info_aggregator_upto_last(
-        &mut self,
+        &self,
         last_block_hash: &CryptoHash,
     ) -> Result<EpochInfoAggregator, EpochError> {
         if let Some((mut aggregator, replace)) = self.aggregate_epoch_info_upto(last_block_hash)? {
@@ -1521,7 +1493,7 @@ impl EpochManager {
     /// `self.epoch_info_aggregator`).  That happens if the method reaches epoch
     /// boundary.
     fn aggregate_epoch_info_upto(
-        &mut self,
+        &self,
         block_hash: &CryptoHash,
     ) -> Result<Option<(EpochInfoAggregator, bool)>, EpochError> {
         if block_hash == &self.epoch_info_aggregator.last_block_hash {
@@ -1546,7 +1518,8 @@ impl EpochManager {
         Ok(Some(loop {
             #[cfg(test)]
             {
-                self.epoch_info_aggregator_loop_counter += 1;
+                self.epoch_info_aggregator_loop_counter
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             }
 
             // To avoid cloning BlockInfo we need to first get reference to the
@@ -1571,7 +1544,7 @@ impl EpochManager {
             let prev_epoch = prev_info.epoch_id().clone();
 
             let block_info = self.get_block_info(&cur_hash)?;
-            aggregator.update(block_info, &epoch_info, prev_height);
+            aggregator.update(&block_info, &epoch_info, prev_height);
 
             if prev_hash == self.epoch_info_aggregator.last_block_hash {
                 // We’ve reached sync point of the old aggregator.  If old
@@ -1585,14 +1558,14 @@ impl EpochManager {
     }
 
     pub fn get_protocol_upgrade_block_height(
-        &mut self,
+        &self,
         block_hash: CryptoHash,
     ) -> Result<Option<BlockHeight>, EpochError> {
         let cur_epoch_info = self.get_epoch_info_from_hash(&block_hash)?.clone();
         let next_epoch_id = self.get_next_epoch_id(&block_hash)?;
-        let next_epoch_info = self.get_epoch_info(&next_epoch_id)?.clone();
+        let next_epoch_info = self.get_epoch_info(&next_epoch_id)?;
         if cur_epoch_info.protocol_version() != next_epoch_info.protocol_version() {
-            let block_info = self.get_block_info(&block_hash)?.clone();
+            let block_info = self.get_block_info(&block_hash)?;
             let epoch_length =
                 self.config.for_protocol_version(cur_epoch_info.protocol_version()).epoch_length;
             let estimated_next_epoch_start =
@@ -1681,7 +1654,7 @@ mod tests2 {
                 && a.validator_reward() == b.validator_reward()
         };
         let epoch0 = epoch_manager.get_epoch_id(&h[0]).unwrap();
-        assert!(compare_epoch_infos(epoch_manager.get_epoch_info(&epoch0).unwrap(), &expected0));
+        assert!(compare_epoch_infos(&epoch_manager.get_epoch_info(&epoch0).unwrap(), &expected0));
 
         record_block(
             &mut epoch_manager,
@@ -1691,13 +1664,13 @@ mod tests2 {
             vec![stake("test2".parse().unwrap(), amount_staked)],
         );
         let epoch1 = epoch_manager.get_epoch_id(&h[1]).unwrap();
-        assert!(compare_epoch_infos(epoch_manager.get_epoch_info(&epoch1).unwrap(), &expected0));
+        assert!(compare_epoch_infos(&epoch_manager.get_epoch_info(&epoch1).unwrap(), &expected0));
         assert_eq!(epoch_manager.get_epoch_id(&h[2]), Err(EpochError::MissingBlock(h[2])));
 
         record_block(&mut epoch_manager, h[1], h[2], 2, vec![]);
         // test2 staked in epoch 1 and therefore should be included in epoch 3.
         let epoch2 = epoch_manager.get_epoch_id(&h[2]).unwrap();
-        assert!(compare_epoch_infos(epoch_manager.get_epoch_info(&epoch2).unwrap(), &expected0));
+        assert!(compare_epoch_infos(&epoch_manager.get_epoch_info(&epoch2).unwrap(), &expected0));
 
         record_block(&mut epoch_manager, h[2], h[3], 3, vec![]);
 
@@ -1723,10 +1696,10 @@ mod tests2 {
         );
         // no validator change in the last epoch
         let epoch3 = epoch_manager.get_epoch_id(&h[3]).unwrap();
-        assert!(compare_epoch_infos(epoch_manager.get_epoch_info(&epoch3).unwrap(), &expected3));
+        assert!(compare_epoch_infos(&epoch_manager.get_epoch_info(&epoch3).unwrap(), &expected3));
 
         // Start another epoch manager from the same store to check that it saved the state.
-        let mut epoch_manager2 = EpochManager::new(
+        let epoch_manager2 = EpochManager::new(
             epoch_manager.store.clone(),
             epoch_manager.config.clone(),
             PROTOCOL_VERSION,
@@ -1737,7 +1710,7 @@ mod tests2 {
                 .collect(),
         )
         .unwrap();
-        assert!(compare_epoch_infos(epoch_manager2.get_epoch_info(&epoch3).unwrap(), &expected3));
+        assert!(compare_epoch_infos(&epoch_manager2.get_epoch_info(&epoch3).unwrap(), &expected3));
     }
 
     #[test]
@@ -1768,14 +1741,14 @@ mod tests2 {
         record_block(&mut epoch_manager, h[2], h[3], 3, vec![]);
         let epoch_id = epoch_manager.get_next_epoch_id(&h[3]).unwrap();
         let epoch_info = epoch_manager.get_epoch_info(&epoch_id).unwrap();
-        check_validators(epoch_info, &[("test2", amount_staked)]);
-        check_fishermen(epoch_info, &[]);
+        check_validators(&epoch_info, &[("test2", amount_staked)]);
+        check_fishermen(&epoch_info, &[]);
         check_stake_change(
-            epoch_info,
+            &epoch_info,
             vec![("test1".parse().unwrap(), 0), ("test2".parse().unwrap(), amount_staked)],
         );
         check_reward(
-            epoch_info,
+            &epoch_info,
             vec![
                 ("test1".parse().unwrap(), 0),
                 ("test2".parse().unwrap(), 0),
@@ -1927,10 +1900,10 @@ mod tests2 {
         record_block(&mut epoch_manager, h[4], h[5], 5, vec![]);
         let epoch_id = epoch_manager.get_next_epoch_id(&h[5]).unwrap();
         let epoch_info = epoch_manager.get_epoch_info(&epoch_id).unwrap();
-        check_validators(epoch_info, &[("test1", amount_staked)]);
-        check_fishermen(epoch_info, &[]);
-        check_kickout(epoch_info, &[]);
-        check_stake_change(epoch_info, vec![("test1".parse().unwrap(), amount_staked)]);
+        check_validators(&epoch_info, &[("test1", amount_staked)]);
+        check_fishermen(&epoch_info, &[]);
+        check_kickout(&epoch_info, &[]);
+        check_stake_change(&epoch_info, vec![("test1".parse().unwrap(), amount_staked)]);
     }
 
     /// When computing validator kickout, we should not kickout validators such that the union
@@ -1966,10 +1939,8 @@ mod tests2 {
                 prev_block = *curr_block;
             }
         }
-        let epoch_infos: Vec<_> = h
-            .iter()
-            .filter_map(|x| epoch_manager.get_epoch_info(&EpochId(*x)).ok().cloned())
-            .collect();
+        let epoch_infos: Vec<_> =
+            h.iter().filter_map(|x| epoch_manager.get_epoch_info(&EpochId(*x)).ok()).collect();
         check_kickout(
             &epoch_infos[1],
             &[(
@@ -2014,15 +1985,15 @@ mod tests2 {
 
         let epoch_id = epoch_manager.get_next_epoch_id(&h[3]).unwrap();
         let epoch_info = epoch_manager.get_epoch_info(&epoch_id).unwrap();
-        check_validators(epoch_info, &[("test2", amount_staked)]);
-        check_fishermen(epoch_info, &[]);
+        check_validators(&epoch_info, &[("test2", amount_staked)]);
+        check_fishermen(&epoch_info, &[]);
         check_stake_change(
-            epoch_info,
+            &epoch_info,
             vec![("test1".parse().unwrap(), 0), ("test2".parse().unwrap(), amount_staked)],
         );
-        check_kickout(epoch_info, &[("test1", ValidatorKickoutReason::Unstaked)]);
+        check_kickout(&epoch_info, &[("test1", ValidatorKickoutReason::Unstaked)]);
         check_reward(
-            epoch_info,
+            &epoch_info,
             vec![
                 ("test1".parse().unwrap(), 0),
                 ("test2".parse().unwrap(), 0),
@@ -2034,12 +2005,12 @@ mod tests2 {
         record_block(&mut epoch_manager, h[4], h[5], 5, vec![]);
         let epoch_id = epoch_manager.get_next_epoch_id(&h[5]).unwrap();
         let epoch_info = epoch_manager.get_epoch_info(&epoch_id).unwrap();
-        check_validators(epoch_info, &[("test2", amount_staked)]);
-        check_fishermen(epoch_info, &[]);
-        check_stake_change(epoch_info, vec![("test2".parse().unwrap(), amount_staked)]);
-        check_kickout(epoch_info, &[]);
+        check_validators(&epoch_info, &[("test2", amount_staked)]);
+        check_fishermen(&epoch_info, &[]);
+        check_stake_change(&epoch_info, vec![("test2".parse().unwrap(), amount_staked)]);
+        check_kickout(&epoch_info, &[]);
         check_reward(
-            epoch_info,
+            &epoch_info,
             vec![
                 ("test1".parse().unwrap(), 0),
                 ("test2".parse().unwrap(), 0),
@@ -2051,11 +2022,14 @@ mod tests2 {
         record_block(&mut epoch_manager, h[6], h[7], 7, vec![]);
         let epoch_id = epoch_manager.get_next_epoch_id(&h[7]).unwrap();
         let epoch_info = epoch_manager.get_epoch_info(&epoch_id).unwrap();
-        check_validators(epoch_info, &[("test2", amount_staked)]);
-        check_fishermen(epoch_info, &[]);
-        check_stake_change(epoch_info, vec![("test2".parse().unwrap(), amount_staked)]);
-        check_kickout(epoch_info, &[]);
-        check_reward(epoch_info, vec![("test2".parse().unwrap(), 0), ("near".parse().unwrap(), 0)]);
+        check_validators(&epoch_info, &[("test2", amount_staked)]);
+        check_fishermen(&epoch_info, &[]);
+        check_stake_change(&epoch_info, vec![("test2".parse().unwrap(), amount_staked)]);
+        check_kickout(&epoch_info, &[]);
+        check_reward(
+            &epoch_info,
+            vec![("test2".parse().unwrap(), 0), ("near".parse().unwrap(), 0)],
+        );
     }
 
     #[test]
@@ -2110,20 +2084,20 @@ mod tests2 {
         let epoch_id = epoch_manager.get_epoch_id(&h[5]).unwrap();
         assert_eq!(epoch_id.0, h[2]);
         let epoch_info = epoch_manager.get_epoch_info(&epoch_id).unwrap();
-        check_validators(epoch_info, &[("test2", amount_staked)]);
-        check_fishermen(epoch_info, &[]);
+        check_validators(&epoch_info, &[("test2", amount_staked)]);
+        check_fishermen(&epoch_info, &[]);
         check_stake_change(
-            epoch_info,
+            &epoch_info,
             vec![("test1".parse().unwrap(), 0), ("test2".parse().unwrap(), amount_staked)],
         );
-        check_kickout(epoch_info, &[("test1", ValidatorKickoutReason::Slashed)]);
+        check_kickout(&epoch_info, &[("test1", ValidatorKickoutReason::Slashed)]);
 
         let slashed1: Vec<_> =
-            epoch_manager.get_slashed_validators(&h[2]).unwrap().clone().into_iter().collect();
+            epoch_manager.get_block_info(&h[2]).unwrap().slashed().clone().into_iter().collect();
         let slashed2: Vec<_> =
-            epoch_manager.get_slashed_validators(&h[3]).unwrap().clone().into_iter().collect();
+            epoch_manager.get_block_info(&h[3]).unwrap().slashed().clone().into_iter().collect();
         let slashed3: Vec<_> =
-            epoch_manager.get_slashed_validators(&h[5]).unwrap().clone().into_iter().collect();
+            epoch_manager.get_block_info(&h[5]).unwrap().slashed().clone().into_iter().collect();
         assert_eq!(slashed1, vec![("test1".parse().unwrap(), SlashState::Other)]);
         assert_eq!(slashed2, vec![("test1".parse().unwrap(), SlashState::AlreadySlashed)]);
         assert_eq!(slashed3, vec![("test1".parse().unwrap(), SlashState::AlreadySlashed)]);
@@ -2162,14 +2136,13 @@ mod tests2 {
                 SlashedValidator::new("test1".parse().unwrap(), false),
             ],
         );
-
         let slashed: Vec<_> =
-            epoch_manager.get_slashed_validators(&h[2]).unwrap().clone().into_iter().collect();
+            epoch_manager.get_block_info(&h[2]).unwrap().slashed().clone().into_iter().collect();
         assert_eq!(slashed, vec![("test1".parse().unwrap(), SlashState::Other)]);
         record_block(&mut epoch_manager, h[2], h[3], 3, vec![]);
         // new epoch
         let slashed: Vec<_> =
-            epoch_manager.get_slashed_validators(&h[3]).unwrap().clone().into_iter().collect();
+            epoch_manager.get_block_info(&h[3]).unwrap().slashed().clone().into_iter().collect();
         assert_eq!(slashed, vec![("test1".parse().unwrap(), SlashState::AlreadySlashed)]);
         // slash test1 for double sign
         record_block_with_slashes(
@@ -2207,7 +2180,7 @@ mod tests2 {
         );
 
         let slashed: Vec<_> =
-            epoch_manager.get_slashed_validators(&h[5]).unwrap().clone().into_iter().collect();
+            epoch_manager.get_block_info(&h[5]).unwrap().slashed().clone().into_iter().collect();
         assert_eq!(slashed, vec![("test1".parse().unwrap(), SlashState::AlreadySlashed)]);
     }
 
@@ -2233,12 +2206,12 @@ mod tests2 {
         );
 
         let slashed: Vec<_> =
-            epoch_manager.get_slashed_validators(&h[1]).unwrap().clone().into_iter().collect();
+            epoch_manager.get_block_info(&h[1]).unwrap().slashed().clone().into_iter().collect();
         assert_eq!(slashed, vec![("test1".parse().unwrap(), SlashState::DoubleSign)]);
 
         record_block(&mut epoch_manager, h[1], h[2], 2, vec![]);
         let slashed: Vec<_> =
-            epoch_manager.get_slashed_validators(&h[2]).unwrap().clone().into_iter().collect();
+            epoch_manager.get_block_info(&h[2]).unwrap().slashed().clone().into_iter().collect();
         assert_eq!(slashed, vec![("test1".parse().unwrap(), SlashState::DoubleSign)]);
         // new epoch
         record_block_with_slashes(
@@ -2250,7 +2223,7 @@ mod tests2 {
             vec![SlashedValidator::new("test1".parse().unwrap(), true)],
         );
         let slashed: Vec<_> =
-            epoch_manager.get_slashed_validators(&h[3]).unwrap().clone().into_iter().collect();
+            epoch_manager.get_block_info(&h[3]).unwrap().slashed().clone().into_iter().collect();
         assert_eq!(slashed, vec![("test1".parse().unwrap(), SlashState::DoubleSign)]);
     }
 
@@ -2377,18 +2350,18 @@ mod tests2 {
         let protocol_reward = *validator_reward.get("near").unwrap();
 
         let epoch_info = epoch_manager.get_epoch_info(&EpochId(h[2])).unwrap();
-        check_validators(epoch_info, &[("test2", stake_amount + test2_reward)]);
-        check_fishermen(epoch_info, &[("test1", test1_stake_amount)]);
+        check_validators(&epoch_info, &[("test2", stake_amount + test2_reward)]);
+        check_fishermen(&epoch_info, &[("test1", test1_stake_amount)]);
         check_stake_change(
-            epoch_info,
+            &epoch_info,
             vec![
                 ("test1".parse().unwrap(), test1_stake_amount),
                 ("test2".parse().unwrap(), stake_amount + test2_reward),
             ],
         );
-        check_kickout(epoch_info, &[]);
+        check_kickout(&epoch_info, &[]);
         check_reward(
-            epoch_info,
+            &epoch_info,
             vec![
                 ("test2".parse().unwrap(), test2_reward),
                 ("near".parse().unwrap(), protocol_reward),
@@ -2483,20 +2456,20 @@ mod tests2 {
 
         let epoch_info = epoch_manager.get_epoch_info(&EpochId(h[2])).unwrap();
         check_validators(
-            epoch_info,
+            &epoch_info,
             &[("test1", stake_amount1 + test1_reward), ("test2", stake_amount2 + test2_reward)],
         );
-        check_fishermen(epoch_info, &[]);
+        check_fishermen(&epoch_info, &[]);
         check_stake_change(
-            epoch_info,
+            &epoch_info,
             vec![
                 ("test1".parse().unwrap(), stake_amount1 + test1_reward),
                 ("test2".parse().unwrap(), stake_amount2 + test2_reward),
             ],
         );
-        check_kickout(epoch_info, &[]);
+        check_kickout(&epoch_info, &[]);
         check_reward(
-            epoch_info,
+            &epoch_info,
             vec![
                 ("test1".parse().unwrap(), test1_reward),
                 ("test2".parse().unwrap(), test2_reward),
@@ -2607,10 +2580,8 @@ mod tests2 {
         );
         let test2_reward = *validator_reward.get("test2").unwrap();
         let protocol_reward = *validator_reward.get("near").unwrap();
-        let epoch_infos: Vec<_> = h
-            .iter()
-            .filter_map(|x| epoch_manager.get_epoch_info(&EpochId(*x)).ok().cloned())
-            .collect();
+        let epoch_infos: Vec<_> =
+            h.iter().filter_map(|x| epoch_manager.get_epoch_info(&EpochId(*x)).ok()).collect();
         let epoch_info = &epoch_infos[1];
         check_validators(epoch_info, &[("test2", stake_amount + test2_reward)]);
         check_fishermen(epoch_info, &[]);
@@ -2661,18 +2632,18 @@ mod tests2 {
         let epoch_id = epoch_manager.get_next_epoch_id(&h[3]).unwrap();
         assert_eq!(epoch_id, EpochId(h[2]));
         let epoch_info = epoch_manager.get_epoch_info(&epoch_id).unwrap();
-        check_validators(epoch_info, &[("test1", amount_staked), ("test2", amount_staked)]);
-        check_fishermen(epoch_info, &[]);
+        check_validators(&epoch_info, &[("test1", amount_staked), ("test2", amount_staked)]);
+        check_fishermen(&epoch_info, &[]);
         check_stake_change(
-            epoch_info,
+            &epoch_info,
             vec![
                 ("test1".parse().unwrap(), amount_staked),
                 ("test2".parse().unwrap(), amount_staked),
             ],
         );
-        check_kickout(epoch_info, &[]);
+        check_kickout(&epoch_info, &[]);
         check_reward(
-            epoch_info,
+            &epoch_info,
             vec![
                 ("test1".parse().unwrap(), 0),
                 ("test2".parse().unwrap(), 0),
@@ -2744,7 +2715,7 @@ mod tests2 {
         }
         let epoch_info = hashes
             .iter()
-            .filter_map(|x| epoch_manager.get_epoch_info(&EpochId(*x)).ok().cloned())
+            .filter_map(|x| epoch_manager.get_epoch_info(&EpochId(*x)).ok())
             .last()
             .unwrap();
         assert_eq!(
@@ -2825,7 +2796,7 @@ mod tests2 {
         }
         let epoch_info = hashes
             .iter()
-            .filter_map(|x| epoch_manager.get_epoch_info(&EpochId(*x)).ok().cloned())
+            .filter_map(|x| epoch_manager.get_epoch_info(&EpochId(*x)).ok())
             .last()
             .unwrap();
         assert_eq!(
@@ -3217,7 +3188,7 @@ mod tests2 {
         }
 
         let last_epoch_info =
-            hashes.iter().filter_map(|x| em.get_epoch_info(&EpochId(*x)).ok().cloned()).last();
+            hashes.iter().filter_map(|x| em.get_epoch_info(&EpochId(*x)).ok()).last();
         assert_eq!(
             last_epoch_info.unwrap().validator_kickout(),
             &vec![(
@@ -3271,7 +3242,7 @@ mod tests2 {
             ("test4".parse().unwrap(), fishermen_threshold / 2),
         ];
         let epoch_length = 4;
-        let mut em = setup_epoch_manager(
+        let em = setup_epoch_manager(
             validators,
             epoch_length,
             1,
@@ -3283,10 +3254,10 @@ mod tests2 {
             default_reward_calculator(),
         );
         let epoch_info = em.get_epoch_info(&EpochId::default()).unwrap();
-        check_validators(epoch_info, &[("test1", stake_amount), ("test2", stake_amount)]);
-        check_fishermen(epoch_info, &[("test3", fishermen_threshold)]);
+        check_validators(&epoch_info, &[("test1", stake_amount), ("test2", stake_amount)]);
+        check_fishermen(&epoch_info, &[("test3", fishermen_threshold)]);
         check_stake_change(
-            epoch_info,
+            &epoch_info,
             vec![
                 ("test1".parse().unwrap(), stake_amount),
                 ("test2".parse().unwrap(), stake_amount),
@@ -3294,7 +3265,7 @@ mod tests2 {
                 ("test4".parse().unwrap(), 0),
             ],
         );
-        check_kickout(epoch_info, &[]);
+        check_kickout(&epoch_info, &[]);
     }
 
     #[test]
@@ -3324,10 +3295,10 @@ mod tests2 {
         record_block(&mut em, h[1], h[2], 2, vec![stake("test3".parse().unwrap(), 1)]);
 
         let epoch_info = em.get_epoch_info(&EpochId(h[2])).unwrap();
-        check_validators(epoch_info, &[("test1", stake_amount)]);
-        check_fishermen(epoch_info, &[]);
+        check_validators(&epoch_info, &[("test1", stake_amount)]);
+        check_fishermen(&epoch_info, &[]);
         check_stake_change(
-            epoch_info,
+            &epoch_info,
             vec![
                 ("test1".parse().unwrap(), stake_amount),
                 ("test2".parse().unwrap(), 0),
@@ -3398,7 +3369,9 @@ mod tests2 {
         );
         assert_eq!(
             BLOCK_CACHE_SIZE + 2,
-            epoch_manager.epoch_info_aggregator_loop_counter,
+            epoch_manager
+                .epoch_info_aggregator_loop_counter
+                .load(std::sync::atomic::Ordering::SeqCst),
             "Expected every block to be visited exactly once"
         );
     }
@@ -3446,11 +3419,11 @@ mod tests2 {
         );
         record_block(&mut epoch_manager, h[3], h[4], 4, vec![]);
         let epoch_info = epoch_manager.get_epoch_info(&EpochId(h[4])).unwrap();
-        check_validators(epoch_info, &[("test1", stake_amount), ("test2", stake_amount)]);
-        check_fishermen(epoch_info, &[("test3", 10)]);
-        check_kickout(epoch_info, &[]);
+        check_validators(&epoch_info, &[("test1", stake_amount), ("test2", stake_amount)]);
+        check_fishermen(&epoch_info, &[("test3", 10)]);
+        check_kickout(&epoch_info, &[]);
         check_stake_change(
-            epoch_info,
+            &epoch_info,
             vec![
                 ("test1".parse().unwrap(), stake_amount),
                 ("test2".parse().unwrap(), stake_amount),
@@ -3725,10 +3698,8 @@ mod tests2 {
             }
         }
 
-        let last_epoch_info = hashes
-            .iter()
-            .filter_map(|x| epoch_manager.get_epoch_info(&EpochId(*x)).ok().cloned())
-            .last();
+        let last_epoch_info =
+            hashes.iter().filter_map(|x| epoch_manager.get_epoch_info(&EpochId(*x)).ok()).last();
         assert_eq!(last_epoch_info.unwrap().validator_kickout(), &HashMap::default());
     }
 
@@ -4024,8 +3995,8 @@ mod tests2 {
             epoch_manager.record_block_info(block_info, [0; 32]).unwrap();
         }
 
-        let get_epoch_infos = |em: &mut EpochManager| -> Vec<EpochInfo> {
-            h.iter().filter_map(|x| em.get_epoch_info(&EpochId(*x)).ok().cloned()).collect()
+        let get_epoch_infos = |em: &mut EpochManager| -> Vec<Arc<EpochInfo>> {
+            h.iter().filter_map(|x| em.get_epoch_info(&EpochId(*x)).ok()).collect()
         };
 
         let epoch_infos = get_epoch_infos(&mut epoch_manager);
@@ -4119,13 +4090,13 @@ mod tests2 {
         assert_eq!(epoch_manager.epoch_validators_ordered.len(), 1);
         let epoch_validators_in_cache =
             epoch_manager.epoch_validators_ordered.get(&epoch_id).unwrap().clone();
-        assert_eq!(epoch_validators, epoch_validators_in_cache);
+        assert_eq!(*epoch_validators, *epoch_validators_in_cache);
 
         assert_eq!(epoch_manager.epoch_validators_ordered_unique.len(), 0);
         let epoch_validators_unique =
             epoch_manager.get_all_block_producers_ordered(&epoch_id, &h[3]).unwrap().to_vec();
         let epoch_validators_unique_in_cache =
             epoch_manager.epoch_validators_ordered_unique.get(&epoch_id).unwrap().clone();
-        assert_eq!(epoch_validators_unique, epoch_validators_unique_in_cache);
+        assert_eq!(*epoch_validators_unique, *epoch_validators_unique_in_cache);
     }
 }

--- a/chain/epoch_manager/src/lib.rs
+++ b/chain/epoch_manager/src/lib.rs
@@ -503,13 +503,13 @@ impl EpochManager {
             Ok(next_next_epoch_info) => next_next_epoch_info,
             Err(EpochError::ThresholdError { stake_sum, num_seats }) => {
                 warn!(target: "epoch_manager", "Not enough stake for required number of seats (all validators tried to unstake?): amount = {} for {}", stake_sum, num_seats);
-                let mut epoch_info = (*next_epoch_info).clone();
+                let mut epoch_info = EpochInfo::clone(&next_epoch_info);
                 *epoch_info.epoch_height_mut() += 1;
                 epoch_info
             }
             Err(EpochError::NotEnoughValidators { num_validators, num_shards }) => {
                 warn!(target: "epoch_manager", "Not enough validators for required number of shards (all validators tried to unstake?): num_validators={} num_shards={}", num_validators, num_shards);
-                let mut epoch_info = (*next_epoch_info).clone();
+                let mut epoch_info = EpochInfo::clone(&next_epoch_info);
                 *epoch_info.epoch_height_mut() += 1;
                 epoch_info
             }
@@ -1346,7 +1346,7 @@ impl EpochManager {
             .ok_or_else(|| EpochError::EpochOutOfBounds(epoch_id.clone()))
     }
 
-    // NOTE: beware, after calling `save_epoch_validator_info`,
+    // Note(#6572): beware, after calling `save_epoch_validator_info`,
     // `get_epoch_validator_info` will return stale results.
     fn save_epoch_validator_info(
         &self,

--- a/chain/epoch_manager/src/tests/random_epochs.rs
+++ b/chain/epoch_manager/src/tests/random_epochs.rs
@@ -1,6 +1,7 @@
 use rand::prelude::StdRng;
 use rand::{Rng, SeedableRng};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::sync::Arc;
 
 use crate::test_utils::{
     hash_range, record_block_with_slashes, setup_default_epoch_manager, stake,
@@ -133,12 +134,12 @@ fn validate(
         .collect::<Vec<_>>();
     assert_eq!(
         &epoch_infos[0],
-        epoch_manager.get_epoch_info(&EpochId(CryptoHash::default())).unwrap(),
+        &epoch_manager.get_epoch_info(&EpochId(CryptoHash::default())).unwrap(),
         "first two epoch are the same, even epoch_height"
     );
     let block_infos = block_hashes
         .iter()
-        .map(|&hash| epoch_manager.get_block_info(&hash).unwrap().clone())
+        .map(|&hash| epoch_manager.get_block_info(&hash).unwrap())
         .collect::<Vec<_>>();
     if DEBUG_PRINT {
         println!("Block heights: {:?}", heights);
@@ -165,7 +166,7 @@ fn validate(
     verify_epochs(&epoch_infos);
 }
 
-fn verify_epochs(epoch_infos: &Vec<EpochInfo>) {
+fn verify_epochs(epoch_infos: &Vec<Arc<EpochInfo>>) {
     for i in 1..epoch_infos.len() {
         let epoch_info = &epoch_infos[i];
         let prev_epoch_info = &epoch_infos[i - 1];
@@ -223,7 +224,7 @@ fn verify_epochs(epoch_infos: &Vec<EpochInfo>) {
     }
 }
 
-fn verify_proposals(epoch_manager: &mut EpochManager, block_infos: &Vec<BlockInfo>) {
+fn verify_proposals(epoch_manager: &mut EpochManager, block_infos: &Vec<Arc<BlockInfo>>) {
     let mut proposals = BTreeMap::default();
     for i in 1..block_infos.len() {
         let prev_block_info = &block_infos[i - 1];
@@ -255,7 +256,7 @@ fn verify_proposals(epoch_manager: &mut EpochManager, block_infos: &Vec<BlockInf
 
 fn verify_slashes(
     epoch_manager: &mut EpochManager,
-    block_infos: &Vec<BlockInfo>,
+    block_infos: &Vec<Arc<BlockInfo>>,
     slashes_per_block: &Vec<Vec<SlashedValidator>>,
 ) {
     for i in 1..block_infos.len() {
@@ -313,7 +314,7 @@ fn verify_slashes(
 fn verify_block_stats(
     epoch_manager: &mut EpochManager,
     heights: Vec<u64>,
-    block_infos: &Vec<BlockInfo>,
+    block_infos: &Vec<Arc<BlockInfo>>,
     block_hashes: &[CryptoHash],
 ) {
     for i in 1..block_infos.len() {

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::Path;
-use std::sync::{Arc, RwLock, RwLockWriteGuard};
+use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::time::Instant;
 
 use borsh::ser::BorshSerialize;
@@ -84,6 +84,10 @@ impl SafeEpochManager {
     fn write(&self) -> RwLockWriteGuard<EpochManager> {
         self.0.write().expect(POISONED_LOCK_ERR)
     }
+
+    fn read(&self) -> RwLockReadGuard<EpochManager> {
+        self.0.read().expect(POISONED_LOCK_ERR)
+    }
 }
 
 impl EpochInfoProvider for SafeEpochManager {
@@ -93,9 +97,9 @@ impl EpochInfoProvider for SafeEpochManager {
         last_block_hash: &CryptoHash,
         account_id: &AccountId,
     ) -> Result<Option<Balance>, EpochError> {
-        let mut epoch_manager = self.write();
-        let slashed = epoch_manager.get_slashed_validators(last_block_hash)?;
-        if slashed.contains_key(account_id) {
+        let epoch_manager = self.read();
+        let last_block_info = epoch_manager.get_block_info(last_block_hash)?;
+        if last_block_info.slashed().contains_key(account_id) {
             return Ok(None);
         }
         let epoch_info = epoch_manager.get_epoch_info(epoch_id)?;
@@ -107,23 +111,18 @@ impl EpochInfoProvider for SafeEpochManager {
         epoch_id: &EpochId,
         last_block_hash: &CryptoHash,
     ) -> Result<Balance, EpochError> {
-        let mut epoch_manager = self.write();
-        let slashed = epoch_manager.get_slashed_validators(last_block_hash)?.clone();
+        let epoch_manager = self.read();
+        let last_block_info = epoch_manager.get_block_info(last_block_hash)?;
         let epoch_info = epoch_manager.get_epoch_info(epoch_id)?;
         Ok(epoch_info
             .validators_iter()
-            .filter_map(|info| {
-                if slashed.contains_key(info.account_id()) {
-                    None
-                } else {
-                    Some(info.stake())
-                }
-            })
+            .filter(|info| !last_block_info.slashed().contains_key(info.account_id()))
+            .map(|info| info.stake())
             .sum())
     }
 
     fn minimum_stake(&self, prev_block_hash: &CryptoHash) -> Result<Balance, EpochError> {
-        let mut epoch_manager = self.write();
+        let epoch_manager = self.read();
         epoch_manager.minimum_stake(prev_block_hash)
     }
 }
@@ -234,7 +233,7 @@ impl NightshadeRuntime {
     }
 
     pub fn get_epoch_id(&self, hash: &CryptoHash) -> Result<EpochId, Error> {
-        let mut epoch_manager = self.epoch_manager.write();
+        let epoch_manager = self.epoch_manager.read();
         epoch_manager.get_epoch_id(hash).map_err(Error::from)
     }
 
@@ -376,7 +375,7 @@ impl NightshadeRuntime {
         shard_id: ShardId,
         prev_hash: &CryptoHash,
     ) -> Result<ShardUId, Error> {
-        let mut epoch_manager = self.epoch_manager.write();
+        let epoch_manager = self.epoch_manager.read();
         let epoch_id =
             epoch_manager.get_epoch_id_from_prev_block(prev_hash).map_err(Error::from)?;
         let shard_version =
@@ -389,7 +388,7 @@ impl NightshadeRuntime {
         shard_id: ShardId,
         epoch_id: &EpochId,
     ) -> Result<ShardUId, Error> {
-        let mut epoch_manager = self.epoch_manager.write();
+        let epoch_manager = self.epoch_manager.read();
         let shard_version =
             epoch_manager.get_shard_layout(epoch_id).map_err(Error::from)?.version();
         Ok(ShardUId { version: shard_version, shard_id: shard_id as u32 })
@@ -400,7 +399,7 @@ impl NightshadeRuntime {
         account_id: &AccountId,
         epoch_id: &EpochId,
     ) -> Result<ShardUId, Error> {
-        let mut epoch_manager = self.epoch_manager.write();
+        let epoch_manager = self.epoch_manager.read();
         let shard_layout = epoch_manager.get_shard_layout(epoch_id).map_err(Error::from)?;
         let shard_id = account_id_to_shard_id(account_id, shard_layout);
         Ok(ShardUId::from_shard_id_and_layout(shard_id, shard_layout))
@@ -430,7 +429,7 @@ impl NightshadeRuntime {
         let _span = tracing::debug_span!(target: "runtime", "process_state_update").entered();
         let epoch_id = self.get_epoch_id_from_prev_block(prev_block_hash)?;
         let validator_accounts_update = {
-            let mut epoch_manager = self.epoch_manager.write();
+            let epoch_manager = self.epoch_manager.read();
             let shard_layout = epoch_manager.get_shard_layout(&epoch_id)?.clone();
             debug!(target: "runtime",
                    "block height: {}, is next_block_epoch_start {}",
@@ -710,7 +709,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         vrf_value: &near_crypto::vrf::Value,
         vrf_proof: &near_crypto::vrf::Proof,
     ) -> Result<(), Error> {
-        let mut epoch_manager = self.epoch_manager.write();
+        let epoch_manager = self.epoch_manager.read();
         let validator = epoch_manager.get_block_producer_info(epoch_id, block_height)?;
         let public_key = near_crypto::key_conversion::convert_public_key(
             validator.public_key().unwrap_as_ed25519(),
@@ -890,17 +889,18 @@ impl RuntimeAdapter for NightshadeRuntime {
     }
 
     fn verify_header_signature(&self, header: &BlockHeader) -> Result<bool, Error> {
-        let mut epoch_manager = self.epoch_manager.write();
+        let epoch_manager = self.epoch_manager.read();
         let block_producer =
             epoch_manager.get_block_producer_info(header.epoch_id(), header.height())?;
-        let slashed = match epoch_manager.get_slashed_validators(header.prev_hash()) {
-            Ok(slashed) => slashed,
+        match epoch_manager.get_block_info(header.prev_hash()) {
+            Ok(block_info) => {
+                if block_info.slashed().contains_key(block_producer.account_id()) {
+                    return Ok(false);
+                }
+                Ok(header.signature().verify(header.hash().as_ref(), block_producer.public_key()))
+            }
             Err(_) => return Err(EpochError::MissingBlock(*header.prev_hash()).into()),
-        };
-        if slashed.contains_key(block_producer.account_id()) {
-            return Ok(false);
         }
-        Ok(header.signature().verify(header.hash().as_ref(), block_producer.public_key()))
     }
 
     fn verify_chunk_signature_with_header_parts(
@@ -912,12 +912,12 @@ impl RuntimeAdapter for NightshadeRuntime {
         height_created: BlockHeight,
         shard_id: ShardId,
     ) -> Result<bool, Error> {
-        let mut epoch_manager = self.epoch_manager.write();
+        let epoch_manager = self.epoch_manager.read();
         if let Ok(chunk_producer) =
             epoch_manager.get_chunk_producer_info(epoch_id, height_created, shard_id)
         {
-            let slashed = epoch_manager.get_slashed_validators(last_known_hash)?;
-            if slashed.contains_key(chunk_producer.account_id()) {
+            let block_info = epoch_manager.get_block_info(last_known_hash)?;
+            if block_info.slashed().contains_key(chunk_producer.account_id()) {
                 return Ok(false);
             }
             Ok(signature.verify(chunk_hash.as_ref(), chunk_producer.public_key()))
@@ -936,7 +936,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         approvals: &[Option<Signature>],
     ) -> Result<(), Error> {
         let info = {
-            let mut epoch_manager = self.epoch_manager.write();
+            let epoch_manager = self.epoch_manager.read();
             epoch_manager.get_heuristic_block_approvers_ordered(epoch_id).map_err(Error::from)?
         };
 
@@ -975,7 +975,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         approvals: &[Option<Signature>],
     ) -> Result<bool, Error> {
         let info = {
-            let mut epoch_manager = self.epoch_manager.write();
+            let epoch_manager = self.epoch_manager.read();
             epoch_manager.get_all_block_approvers_ordered(prev_block_hash).map_err(Error::from)?
         };
         if approvals.len() > info.len() {
@@ -1007,7 +1007,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         epoch_id: &EpochId,
         last_known_block_hash: &CryptoHash,
     ) -> Result<Vec<(ValidatorStake, bool)>, Error> {
-        let mut epoch_manager = self.epoch_manager.write();
+        let epoch_manager = self.epoch_manager.read();
         Ok(epoch_manager.get_all_block_producers_ordered(epoch_id, last_known_block_hash)?.to_vec())
     }
 
@@ -1015,7 +1015,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         &self,
         parent_hash: &CryptoHash,
     ) -> Result<Vec<(ApprovalStake, bool)>, Error> {
-        let mut epoch_manager = self.epoch_manager.write();
+        let epoch_manager = self.epoch_manager.read();
         epoch_manager.get_all_block_approvers_ordered(parent_hash).map_err(Error::from)
     }
 
@@ -1024,7 +1024,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         epoch_id: &EpochId,
         height: BlockHeight,
     ) -> Result<AccountId, Error> {
-        let mut epoch_manager = self.epoch_manager.write();
+        let epoch_manager = self.epoch_manager.read();
         Ok(epoch_manager.get_block_producer_info(epoch_id, height)?.take_account_id())
     }
 
@@ -1034,7 +1034,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         height: BlockHeight,
         shard_id: ShardId,
     ) -> Result<AccountId, Error> {
-        let mut epoch_manager = self.epoch_manager.write();
+        let epoch_manager = self.epoch_manager.read();
         Ok(epoch_manager.get_chunk_producer_info(epoch_id, height, shard_id)?.take_account_id())
     }
 
@@ -1044,11 +1044,11 @@ impl RuntimeAdapter for NightshadeRuntime {
         last_known_block_hash: &CryptoHash,
         account_id: &AccountId,
     ) -> Result<(ValidatorStake, bool), Error> {
-        let mut epoch_manager = self.epoch_manager.write();
+        let epoch_manager = self.epoch_manager.read();
         match epoch_manager.get_validator_by_account_id(epoch_id, account_id) {
             Ok(Some(validator)) => {
-                let slashed = epoch_manager.get_slashed_validators(last_known_block_hash)?;
-                Ok((validator, slashed.contains_key(account_id)))
+                let block_info = epoch_manager.get_block_info(last_known_block_hash)?;
+                Ok((validator, block_info.slashed().contains_key(account_id)))
             }
             Ok(None) => Err(ErrorKind::NotAValidator.into()),
             Err(e) => Err(e.into()),
@@ -1061,11 +1061,11 @@ impl RuntimeAdapter for NightshadeRuntime {
         last_known_block_hash: &CryptoHash,
         account_id: &AccountId,
     ) -> Result<(ValidatorStake, bool), Error> {
-        let mut epoch_manager = self.epoch_manager.write();
+        let epoch_manager = self.epoch_manager.read();
         match epoch_manager.get_fisherman_by_account_id(epoch_id, account_id) {
             Ok(Some(fisherman)) => {
-                let slashed = epoch_manager.get_slashed_validators(last_known_block_hash)?;
-                Ok((fisherman, slashed.contains_key(account_id)))
+                let block_info = epoch_manager.get_block_info(last_known_block_hash)?;
+                Ok((fisherman, block_info.slashed().contains_key(account_id)))
             }
             Ok(None) => Err(ErrorKind::NotAValidator.into()),
             Err(e) => Err(e.into()),
@@ -1073,17 +1073,17 @@ impl RuntimeAdapter for NightshadeRuntime {
     }
 
     fn num_shards(&self, epoch_id: &EpochId) -> Result<NumShards, Error> {
-        let mut epoch_manager = self.epoch_manager.write();
+        let epoch_manager = self.epoch_manager.read();
         Ok(epoch_manager.get_shard_layout(epoch_id).map_err(Error::from)?.num_shards())
     }
 
     fn get_shard_layout(&self, epoch_id: &EpochId) -> Result<ShardLayout, Error> {
-        let mut epoch_manager = self.epoch_manager.write();
+        let epoch_manager = self.epoch_manager.read();
         Ok(epoch_manager.get_shard_layout(epoch_id).map_err(Error::from)?.clone())
     }
 
     fn get_shard_config(&self, epoch_id: &EpochId) -> Result<ShardConfig, Error> {
-        let mut epoch_manager = self.epoch_manager.write();
+        let epoch_manager = self.epoch_manager.read();
         let epoch_config = epoch_manager.get_epoch_config(epoch_id).map_err(Error::from)?;
         Ok(ShardConfig::new(&epoch_config))
     }
@@ -1124,7 +1124,7 @@ impl RuntimeAdapter for NightshadeRuntime {
     }
 
     fn shard_id_to_uid(&self, shard_id: ShardId, epoch_id: &EpochId) -> Result<ShardUId, Error> {
-        let mut epoch_manager = self.epoch_manager.write();
+        let epoch_manager = self.epoch_manager.read();
         let shard_layout = epoch_manager.get_shard_layout(epoch_id).map_err(Error::from)?;
         Ok(ShardUId::from_shard_id_and_layout(shard_id, shard_layout))
     }
@@ -1152,13 +1152,13 @@ impl RuntimeAdapter for NightshadeRuntime {
         account_id: &AccountId,
         epoch_id: &EpochId,
     ) -> Result<ShardId, Error> {
-        let mut epoch_manager = self.epoch_manager.write();
+        let epoch_manager = self.epoch_manager.read();
         let shard_layout = epoch_manager.get_shard_layout(epoch_id).map_err(Error::from)?;
         Ok(account_id_to_shard_id(account_id, shard_layout))
     }
 
     fn get_part_owner(&self, parent_hash: &CryptoHash, part_id: u64) -> Result<AccountId, Error> {
-        let mut epoch_manager = self.epoch_manager.write();
+        let epoch_manager = self.epoch_manager.read();
         let epoch_id = epoch_manager.get_epoch_id_from_prev_block(parent_hash)?;
         let settlement =
             epoch_manager.get_all_block_producers_settlement(&epoch_id, parent_hash)?;
@@ -1186,12 +1186,12 @@ impl RuntimeAdapter for NightshadeRuntime {
     }
 
     fn is_next_block_epoch_start(&self, parent_hash: &CryptoHash) -> Result<bool, Error> {
-        let mut epoch_manager = self.epoch_manager.write();
+        let epoch_manager = self.epoch_manager.read();
         epoch_manager.is_next_block_epoch_start(parent_hash).map_err(Error::from)
     }
 
     fn get_epoch_id_from_prev_block(&self, parent_hash: &CryptoHash) -> Result<EpochId, Error> {
-        let mut epoch_manager = self.epoch_manager.write();
+        let epoch_manager = self.epoch_manager.read();
         epoch_manager.get_epoch_id_from_prev_block(parent_hash).map_err(Error::from)
     }
 
@@ -1199,18 +1199,18 @@ impl RuntimeAdapter for NightshadeRuntime {
         &self,
         parent_hash: &CryptoHash,
     ) -> Result<EpochId, Error> {
-        let mut epoch_manager = self.epoch_manager.write();
+        let epoch_manager = self.epoch_manager.read();
         epoch_manager.get_next_epoch_id_from_prev_block(parent_hash).map_err(Error::from)
     }
 
     fn get_epoch_start_height(&self, block_hash: &CryptoHash) -> Result<BlockHeight, Error> {
-        let mut epoch_manager = self.epoch_manager.write();
+        let epoch_manager = self.epoch_manager.read();
         epoch_manager.get_epoch_start_height(block_hash).map_err(Error::from)
     }
 
     fn get_gc_stop_height(&self, block_hash: &CryptoHash) -> BlockHeight {
         (|| -> Result<BlockHeight, Error> {
-            let mut epoch_manager = self.epoch_manager.write();
+            let epoch_manager = self.epoch_manager.read();
             // an epoch must have a first block.
             let epoch_first_block = *epoch_manager.get_block_info(block_hash)?.epoch_first_block();
             let epoch_first_block_info = epoch_manager.get_block_info(&epoch_first_block)?;
@@ -1230,12 +1230,12 @@ impl RuntimeAdapter for NightshadeRuntime {
     }
 
     fn epoch_exists(&self, epoch_id: &EpochId) -> bool {
-        let mut epoch_manager = self.epoch_manager.write();
+        let epoch_manager = self.epoch_manager.read();
         epoch_manager.get_epoch_info(epoch_id).is_ok()
     }
 
     fn get_epoch_minted_amount(&self, epoch_id: &EpochId) -> Result<Balance, Error> {
-        let mut epoch_manager = self.epoch_manager.write();
+        let epoch_manager = self.epoch_manager.read();
         Ok(epoch_manager.get_epoch_info(epoch_id)?.minted_amount())
     }
 
@@ -1269,22 +1269,32 @@ impl RuntimeAdapter for NightshadeRuntime {
         prev_epoch_last_block_hash: &CryptoHash,
         epoch_id: &EpochId,
         next_epoch_id: &EpochId,
-    ) -> Result<(BlockInfo, BlockInfo, BlockInfo, EpochInfo, EpochInfo, EpochInfo), Error> {
-        let mut epoch_manager = self.epoch_manager.write();
+    ) -> Result<
+        (
+            Arc<BlockInfo>,
+            Arc<BlockInfo>,
+            Arc<BlockInfo>,
+            Arc<EpochInfo>,
+            Arc<EpochInfo>,
+            Arc<EpochInfo>,
+        ),
+        Error,
+    > {
+        let epoch_manager = self.epoch_manager.read();
         let last_block_info = epoch_manager.get_block_info(prev_epoch_last_block_hash)?.clone();
         let prev_epoch_id = last_block_info.epoch_id().clone();
         Ok((
-            epoch_manager.get_block_info(last_block_info.epoch_first_block())?.clone(),
-            epoch_manager.get_block_info(last_block_info.prev_hash())?.clone(),
+            epoch_manager.get_block_info(last_block_info.epoch_first_block())?,
+            epoch_manager.get_block_info(last_block_info.prev_hash())?,
             last_block_info,
-            epoch_manager.get_epoch_info(&prev_epoch_id)?.clone(),
-            epoch_manager.get_epoch_info(epoch_id)?.clone(),
-            epoch_manager.get_epoch_info(next_epoch_id)?.clone(),
+            epoch_manager.get_epoch_info(&prev_epoch_id)?,
+            epoch_manager.get_epoch_info(epoch_id)?,
+            epoch_manager.get_epoch_info(next_epoch_id)?,
         ))
     }
 
     fn get_epoch_protocol_version(&self, epoch_id: &EpochId) -> Result<ProtocolVersion, Error> {
-        let mut epoch_manager = self.epoch_manager.write();
+        let epoch_manager = self.epoch_manager.read();
         Ok(epoch_manager.get_epoch_info(epoch_id)?.protocol_version())
     }
 
@@ -1480,7 +1490,7 @@ impl RuntimeAdapter for NightshadeRuntime {
             QueryRequest::CallFunction { account_id, method_name, args } => {
                 let mut logs = vec![];
                 let (epoch_height, current_protocol_version) = {
-                    let mut epoch_manager = self.epoch_manager.write();
+                    let epoch_manager = self.epoch_manager.read();
                     let epoch_info = epoch_manager.get_epoch_info(epoch_id).map_err(|err| {
                         near_chain::near_chain_primitives::error::QueryError::from_epoch_error(
                             err,
@@ -1580,7 +1590,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         &self,
         epoch_id: ValidatorInfoIdentifier,
     ) -> Result<EpochValidatorInfo, Error> {
-        let mut epoch_manager = self.epoch_manager.write();
+        let epoch_manager = self.epoch_manager.read();
         epoch_manager.get_validator_info(epoch_id).map_err(|e| e.into())
     }
 
@@ -1772,7 +1782,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         epoch_id: &EpochId,
         other_epoch_id: &EpochId,
     ) -> Result<Ordering, Error> {
-        let mut epoch_manager = self.epoch_manager.write();
+        let epoch_manager = self.epoch_manager.read();
         epoch_manager.compare_epoch_id(epoch_id, other_epoch_id).map_err(|e| e.into())
     }
 
@@ -1781,7 +1791,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         chunk_prev_block_hash: &CryptoHash,
         header_head: &CryptoHash,
     ) -> Result<bool, Error> {
-        let mut epoch_manager = self.epoch_manager.write();
+        let epoch_manager = self.epoch_manager.read();
         let head_epoch_id = epoch_manager.get_epoch_id(header_head)?;
         let head_next_epoch_id = epoch_manager.get_next_epoch_id(header_head)?;
         let chunk_epoch_id = epoch_manager.get_epoch_id_from_prev_block(chunk_prev_block_hash)?;
@@ -1804,7 +1814,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         let mut genesis_config = self.genesis_config.clone();
         genesis_config.protocol_version = protocol_version;
         let shard_config = {
-            let mut epoch_manager = self.epoch_manager.write();
+            let epoch_manager = self.epoch_manager.read();
             epoch_manager.get_shard_config(epoch_id)?
         };
         genesis_config.num_block_producer_seats_per_shard =
@@ -1821,7 +1831,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         &self,
         prev_block_hash: &CryptoHash,
     ) -> Result<EpochId, Error> {
-        let mut epoch_manager = self.epoch_manager.write();
+        let epoch_manager = self.epoch_manager.read();
         if epoch_manager.is_next_block_epoch_start(prev_block_hash)? {
             epoch_manager.get_epoch_id(prev_block_hash).map_err(Error::from)
         } else {
@@ -1830,7 +1840,7 @@ impl RuntimeAdapter for NightshadeRuntime {
     }
 
     fn will_shard_layout_change_next_epoch(&self, parent_hash: &CryptoHash) -> Result<bool, Error> {
-        let mut epoch_manager = self.epoch_manager.write();
+        let epoch_manager = self.epoch_manager.read();
         Ok(epoch_manager.will_shard_layout_change(parent_hash)?)
     }
 
@@ -1838,7 +1848,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         &self,
         prev_block_hash: &CryptoHash,
     ) -> Result<EpochHeight, Error> {
-        let mut epoch_manager = self.epoch_manager.write();
+        let epoch_manager = self.epoch_manager.read();
         let epoch_id = epoch_manager.get_epoch_id_from_prev_block(prev_block_hash)?;
         epoch_manager.get_epoch_info(&epoch_id).map(|info| info.epoch_height()).map_err(Error::from)
     }
@@ -1847,7 +1857,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         &self,
         block_hash: CryptoHash,
     ) -> Result<Option<BlockHeight>, EpochError> {
-        let mut epoch_manager = self.epoch_manager.write();
+        let epoch_manager = self.epoch_manager.read();
         epoch_manager.get_protocol_upgrade_block_height(block_hash)
     }
 }
@@ -2748,7 +2758,7 @@ mod test {
             |env: &mut TestEnv, expected_blocks: &mut [u64], expected_chunks: &mut [u64]| {
                 let epoch_id = env.head.epoch_id.clone();
                 let height = env.head.height;
-                let mut em = env.runtime.epoch_manager.0.write().unwrap();
+                let em = env.runtime.epoch_manager.0.read().unwrap();
                 let bp = em.get_block_producer_info(&epoch_id, height).unwrap();
                 let cp = em.get_chunk_producer_info(&epoch_id, height, 0).unwrap();
 

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -516,7 +516,7 @@ pub(crate) fn view_chain(
             }
         }
     };
-    let mut epoch_manager =
+    let epoch_manager =
         EpochManager::new_from_genesis_config(store.clone(), &near_config.genesis.config)
             .expect("Failed to start Epoch Manager");
     let shard_layout = epoch_manager.get_shard_layout(block.header().epoch_id()).unwrap();

--- a/tools/state-viewer/src/epoch_info.rs
+++ b/tools/state-viewer/src/epoch_info.rs
@@ -85,10 +85,10 @@ fn get_block_height_range(
             cur_block_info,
             epoch_info.epoch_height()
         );
-        let prev_epoch_last_block_hash =
-            *epoch_manager.get_block_info(cur_block_info.epoch_first_block()).unwrap().prev_hash();
+        let epoch_first_block_info =
+            epoch_manager.get_block_info(cur_block_info.epoch_first_block()).unwrap();
         let prev_epoch_last_block_info =
-            epoch_manager.get_block_info(&prev_epoch_last_block_hash).unwrap();
+            epoch_manager.get_block_info(epoch_first_block_info.prev_hash()).unwrap();
         if cur_epoch_height == epoch_info.epoch_height() {
             return epoch_manager.get_epoch_start_height(cur_block_info.hash()).unwrap()
                 ..(cur_block_info.height() + 1);

--- a/tools/state-viewer/src/epoch_info.rs
+++ b/tools/state-viewer/src/epoch_info.rs
@@ -41,14 +41,12 @@ pub(crate) fn print_epoch_info(
     let epoch_ids = get_epoch_ids(epoch_selection, store, chain_store, epoch_manager);
 
     let head_block_info =
-        epoch_manager.get_block_info(&chain_store.head().unwrap().last_block_hash).unwrap().clone();
+        epoch_manager.get_block_info(&chain_store.head().unwrap().last_block_hash).unwrap();
     let head_epoch_height =
         epoch_manager.get_epoch_info(head_block_info.epoch_id()).unwrap().epoch_height();
-    let mut epoch_infos: Vec<(EpochId, EpochInfo)> = epoch_ids
+    let mut epoch_infos: Vec<(EpochId, Arc<EpochInfo>)> = epoch_ids
         .iter()
-        .map(|epoch_id| {
-            (epoch_id.clone(), epoch_manager.get_epoch_info(&epoch_id).unwrap().clone())
-        })
+        .map(|epoch_id| (epoch_id.clone(), epoch_manager.get_epoch_info(&epoch_id).unwrap()))
         .collect();
     // Sorted output is much easier to follow.
     epoch_infos.sort_by_key(|(_, epoch_info)| epoch_info.epoch_height());
@@ -77,7 +75,7 @@ fn get_block_height_range(
     epoch_manager: &mut EpochManager,
 ) -> Range<BlockHeight> {
     let head = chain_store.head().unwrap();
-    let mut cur_block_info = epoch_manager.get_block_info(&head.last_block_hash).unwrap().clone();
+    let mut cur_block_info = epoch_manager.get_block_info(&head.last_block_hash).unwrap();
     loop {
         let cur_epoch_info = epoch_manager.get_epoch_info(cur_block_info.epoch_id()).unwrap();
         let cur_epoch_height = cur_epoch_info.epoch_height();
@@ -87,13 +85,10 @@ fn get_block_height_range(
             cur_block_info,
             epoch_info.epoch_height()
         );
-        let prev_epoch_last_block_hash = epoch_manager
-            .get_block_info(cur_block_info.epoch_first_block())
-            .unwrap()
-            .prev_hash()
-            .clone();
+        let prev_epoch_last_block_hash =
+            *epoch_manager.get_block_info(cur_block_info.epoch_first_block()).unwrap().prev_hash();
         let prev_epoch_last_block_info =
-            epoch_manager.get_block_info(&prev_epoch_last_block_hash).unwrap().clone();
+            epoch_manager.get_block_info(&prev_epoch_last_block_hash).unwrap();
         if cur_epoch_height == epoch_info.epoch_height() {
             return epoch_manager.get_epoch_start_height(cur_block_info.hash()).unwrap()
                 ..(cur_block_info.height() + 1);
@@ -112,11 +107,8 @@ fn get_epoch_ids(
     match epoch_selection {
         EpochSelection::All => iterate_and_filter(store, |_| true),
         EpochSelection::Current => {
-            let epoch_id = epoch_manager
-                .get_block_info(&chain_store.head().unwrap().last_block_hash)
-                .unwrap()
-                .epoch_id()
-                .clone();
+            let epoch_id =
+                epoch_manager.get_epoch_id(&chain_store.head().unwrap().last_block_hash).unwrap();
             vec![epoch_id]
         }
         EpochSelection::EpochId { epoch_id } => {
@@ -131,12 +123,12 @@ fn get_epoch_ids(
         }
         EpochSelection::BlockHash { block_hash } => {
             let block_hash = CryptoHash::from_str(&block_hash).unwrap();
-            vec![epoch_manager.get_block_info(&block_hash).unwrap().epoch_id().clone()]
+            vec![epoch_manager.get_epoch_id(&block_hash).unwrap()]
         }
         EpochSelection::BlockHeight { block_height } => {
             // Fetch an epoch containing the given block height.
             let block_hash = chain_store.get_block_hash_by_height(block_height).unwrap();
-            vec![epoch_manager.get_block_info(&block_hash).unwrap().epoch_id().clone()]
+            vec![epoch_manager.get_epoch_id(&block_hash).unwrap()]
         }
         EpochSelection::ProtocolVersion { protocol_version } => {
             // Fetch the first epoch of the given protocol version.

--- a/utils/near-cache/src/lib.rs
+++ b/utils/near-cache/src/lib.rs
@@ -19,6 +19,11 @@ where
         Self { inner: Mutex::new(LruCache::<K, V>::new(cap)) }
     }
 
+    /// Returns the number of key-value pairs that are currently in the the cache.
+    pub fn len(&self) -> usize {
+        self.inner.lock().unwrap().len()
+    }
+
     /// Return the value of they key in the cache otherwise computes the value and inserts it into
     /// the cache. If the key is already in the cache, they gets gets moved to the head of
     /// the LRU list.


### PR DESCRIPTION
This replaces `lru::LruCache` with `near_cache::SyncLruCache` in the implementation of the EpochManager, which in turn allows to make all the getters to use `&self`, which in turns allows the callers of EpochManager to actually take advantage of RwLock. 