### PR TITLE
refeactor: split get_and_update_epoch_info_aggregator into get and up…

### DIFF
--- a/chain/epoch_manager/src/tests/random_epochs.rs
+++ b/chain/epoch_manager/src/tests/random_epochs.rs
@@ -242,11 +242,7 @@ fn verify_proposals(epoch_manager: &mut EpochManager, block_infos: &Vec<BlockInf
                 assert_ne!(prev_block_info.epoch_id(), block_info.epoch_id(), "epoch id changes");
             }
             let aggregator = epoch_manager
-                .get_and_update_epoch_info_aggregator(
-                    prev_block_info.epoch_id(),
-                    block_info.prev_hash(),
-                    true,
-                )
+                .get_epoch_info_aggregator(prev_block_info.epoch_id(), block_info.prev_hash())
                 .unwrap();
             assert_eq!(aggregator.all_proposals, proposals, "Proposals do not match");
             proposals = BTreeMap::from_iter(
@@ -330,11 +326,7 @@ fn verify_block_stats(
         let blocks_in_epoch_expected = heights[i] - prev_epoch_end_height;
         {
             let aggregator = epoch_manager
-                .get_and_update_epoch_info_aggregator(
-                    block_infos[i].epoch_id(),
-                    &block_hashes[i],
-                    true,
-                )
+                .get_epoch_info_aggregator(block_infos[i].epoch_id(), &block_hashes[i])
                 .unwrap();
             let epoch_info = epoch_manager.get_epoch_info(block_infos[i].epoch_id()).unwrap();
             for key in aggregator.block_tracker.keys().copied() {


### PR DESCRIPTION
…date.

Standard refactor -- split a function with a boolean param into two
differently named functions. This doesn't bring substantail benefit
right now, but in the future refactor, the `get` version would take
`&self`, while the `take` version would use `&mut self`.

Realized that this is needed for #6549