### PR TITLE
neard: enable target:"recompress" info logs by default

### DIFF
--- a/core/o11y/src/lib.rs
+++ b/core/o11y/src/lib.rs
@@ -9,6 +9,7 @@ use tracing_subscriber::EnvFilter;
 /// The default value for the `RUST_LOG` environment variable if one isn't specified otherwise.
 pub const DEFAULT_RUST_LOG: &'static str = "tokio_reactor=info,\
      near=info,\
+     recompress=info,\
      stats=info,\
      telemetry=info,\
      delay_detector=info,\


### PR DESCRIPTION
The target is used by recompress_storage.  Initially the command used
no target but then target was added which caused the log lines to be
ignored by default.

Issue: https://github.com/near/nearcore/issues/6119