### PR TITLE
recompress_storage: fix handling of rc columns

### DIFF
--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -607,7 +607,7 @@ pub fn recompress_storage(home_dir: &Path, opts: RecompressOpts) -> anyhow::Resu
         let mut total_written: u64 = 0;
         let mut batch_written: u64 = 0;
         let mut count_keys: u64 = 0;
-        for (key, value) in src_store.iter(column) {
+        for (key, value) in src_store.iter_without_rc_logic(column) {
             store_update.set(column, &key, &value);
             total_written += value.len() as u64;
             batch_written += value.len() as u64;


### PR DESCRIPTION
Store::iter strips reference count from reference counted columns and
writing returned value to a new database leads to corrupted data since
the count is no longer present.  The correct way to deal with raw
values saved in the database is to use Store::iter_without_rc_logic.
Switch recompress_storage to do that.

Issue: https://github.com/near/nearcore/issues/6119