### PR TITLE
refactor: VM::run returns an enum instead of tuple

### DIFF
--- a/runtime/near-vm-runner-standalone/src/main.rs
+++ b/runtime/near-vm-runner-standalone/src/main.rs
@@ -7,6 +7,7 @@ use clap::Parser;
 use near_vm_logic::ProtocolVersion;
 use near_vm_logic::VMOutcome;
 use near_vm_runner::internal::VMKind;
+use near_vm_runner::VMResult;
 use serde::{
     de::{MapAccess, Visitor},
     ser::SerializeMap,
@@ -105,7 +106,7 @@ struct CliArgs {
 #[allow(unused)]
 #[derive(Debug, Clone)]
 struct StandaloneOutput {
-    pub outcome: Option<VMOutcome>,
+    pub outcome: VMOutcome,
     pub err: Option<String>,
     pub state: State,
 }
@@ -163,28 +164,29 @@ fn main() {
     step.promise_results(promise_results);
 
     let mut results = script.run();
-    let (outcome, err) = results.outcomes.pop().unwrap();
+    let last_result = results.outcomes.pop().unwrap();
+    let maybe_error = match &last_result {
+        VMResult::NotRun(err) | VMResult::Aborted(_, err) => Some(err),
+        VMResult::Ok(_) => None,
+    };
 
-    println!(
-        "{:#?}",
-        StandaloneOutput {
-            outcome: outcome.clone(),
-            err: err.map(|it| it.to_string()),
-            state: State(results.state.fake_trie),
-        }
-    );
+    match &last_result {
+        VMResult::NotRun(_) => {}
+        VMResult::Aborted(outcome, _) | VMResult::Ok(outcome) => {
+            println!(
+                "{:#?}",
+                StandaloneOutput {
+                    outcome: outcome.clone(),
+                    err: maybe_error.map(|it| it.to_string()),
+                    state: State(results.state.fake_trie),
+                }
+            );
 
-    if let Some(outcome) = &outcome {
-        println!("\nLogs:");
-        for log in &outcome.logs {
-            println!("{}\n", log);
-        }
-    }
-
-    match &outcome {
-        Some(outcome) => {
+            println!("\nLogs:");
+            for log in &outcome.logs {
+                println!("{}\n", log);
+            }
             println!("{:#?}", outcome.profile);
         }
-        _ => {}
     }
 }

--- a/runtime/near-vm-runner-standalone/src/main.rs
+++ b/runtime/near-vm-runner-standalone/src/main.rs
@@ -165,10 +165,7 @@ fn main() {
 
     let mut results = script.run();
     let last_result = results.outcomes.pop().unwrap();
-    let maybe_error = match &last_result {
-        VMResult::NotRun(err) | VMResult::Aborted(_, err) => Some(err),
-        VMResult::Ok(_) => None,
-    };
+    let maybe_error = last_result.error();
 
     match &last_result {
         VMResult::NotRun(_) => {}

--- a/runtime/near-vm-runner-standalone/src/script.rs
+++ b/runtime/near-vm-runner-standalone/src/script.rs
@@ -7,9 +7,9 @@ use near_primitives::types::CompiledContractCache;
 use near_primitives::version::PROTOCOL_VERSION;
 use near_vm_logic::mocks::mock_external::MockedExternal;
 use near_vm_logic::types::PromiseResult;
-use near_vm_logic::{ProtocolVersion, VMConfig, VMContext, VMOutcome};
+use near_vm_logic::{ProtocolVersion, VMConfig, VMContext};
 use near_vm_runner::internal::VMKind;
-use near_vm_runner::{MockCompiledContractCache, VMError};
+use near_vm_runner::{MockCompiledContractCache, VMResult};
 
 use crate::State;
 
@@ -37,7 +37,7 @@ pub struct Step {
 }
 
 pub struct ScriptResults {
-    pub outcomes: Vec<(Option<VMOutcome>, Option<VMError>)>,
+    pub outcomes: Vec<VMResult>,
     pub state: MockedExternal,
 }
 
@@ -216,10 +216,10 @@ fn vm_script_smoke_test() {
 
     assert_eq!(res.outcomes.len(), 4);
 
-    let logs = &res.outcomes[0].0.as_ref().unwrap().logs;
+    let logs = &res.outcomes[0].outcome().unwrap().logs;
     assert_eq!(logs, &vec!["hello".to_string()]);
 
-    let ret = res.outcomes.last().unwrap().0.as_ref().unwrap().return_data.clone();
+    let ret = res.outcomes.last().unwrap().outcome().unwrap().return_data.clone();
 
     let expected = ReturnData::Value(4950u64.to_le_bytes().to_vec());
     assert_eq!(ret, expected);
@@ -238,12 +238,12 @@ fn profile_data_is_per_outcome() {
     let res = script.run();
     assert_eq!(res.outcomes.len(), 4);
     assert_eq!(
-        res.outcomes[1].0.as_ref().unwrap().profile.host_gas(),
-        res.outcomes[2].0.as_ref().unwrap().profile.host_gas()
+        res.outcomes[1].outcome().unwrap().profile.host_gas(),
+        res.outcomes[2].outcome().unwrap().profile.host_gas()
     );
     assert!(
-        res.outcomes[1].0.as_ref().unwrap().profile.host_gas()
-            > res.outcomes[3].0.as_ref().unwrap().profile.host_gas()
+        res.outcomes[1].outcome().unwrap().profile.host_gas()
+            > res.outcomes[3].outcome().unwrap().profile.host_gas()
     );
 }
 

--- a/runtime/near-vm-runner-standalone/src/script.rs
+++ b/runtime/near-vm-runner-standalone/src/script.rs
@@ -268,8 +268,8 @@ fn test_evm_slow_deserialize_repro() {
 
         script.step(contract, "deploy_code").input(input).repeat(3);
         let res = script.run();
-        assert_eq!(res.outcomes[0].1, None);
-        assert_eq!(res.outcomes[1].1, None);
+        assert_eq!(res.outcomes[0].error(), None);
+        assert_eq!(res.outcomes[1].error(), None);
     }
 
     evm_slow_deserialize_repro(VMKind::Wasmer0);

--- a/runtime/near-vm-runner/fuzz/fuzz_targets/runner.rs
+++ b/runtime/near-vm-runner/fuzz/fuzz_targets/runner.rs
@@ -6,17 +6,17 @@ use near_primitives::contract::ContractCode;
 use near_primitives::runtime::fees::RuntimeFeesConfig;
 use near_primitives::version::PROTOCOL_VERSION;
 use near_vm_logic::mocks::mock_external::MockedExternal;
-use near_vm_logic::{VMConfig, VMContext, VMOutcome};
+use near_vm_logic::{VMConfig, VMContext};
 use near_vm_runner::internal::wasmparser::{Export, ExternalKind, Parser, Payload, TypeDef};
 use near_vm_runner::internal::VMKind;
-use near_vm_runner::VMError;
+use near_vm_runner::VMResult;
 
 libfuzzer_sys::fuzz_target!(|module: ArbitraryModule| {
     let code = ContractCode::new(module.0.to_bytes(), None);
-    let (_outcome, _err) = run_fuzz(&code, VMKind::for_protocol_version(PROTOCOL_VERSION));
+    let _result = run_fuzz(&code, VMKind::for_protocol_version(PROTOCOL_VERSION));
 });
 
-fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> (Option<VMOutcome>, Option<VMError>) {
+fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMResult {
     let mut fake_external = MockedExternal::new();
     let mut context = create_context(vec![]);
     context.prepaid_gas = 10u64.pow(14);

--- a/runtime/near-vm-runner/src/lib.rs
+++ b/runtime/near-vm-runner/src/lib.rs
@@ -27,7 +27,7 @@ pub use cache::{
 };
 #[cfg(target_arch = "x86_64")]
 pub use preload::{ContractCallPrepareRequest, ContractCallPrepareResult, ContractCaller};
-pub use runner::{run, VM};
+pub use runner::{run, VMResult, VM};
 
 /// This is public for internal experimentation use only, and should otherwise be considered an
 /// implementation detail of `near-vm-runner`.

--- a/runtime/near-vm-runner/src/preload.rs
+++ b/runtime/near-vm-runner/src/preload.rs
@@ -131,7 +131,7 @@ impl ContractCaller {
             Some(call) => {
                 let call_data = call.rx.recv().unwrap();
                 match call_data.result {
-                    Err(err) => VMResult::not_run(err),
+                    Err(err) => VMResult::NotRun(err),
                     Ok(module) => match (&module, &mut self.vm_data_private) {
                         #[cfg(feature = "wasmer0_vm")]
                         (VMModule::Wasmer0(module), VMDataPrivate::Wasmer0(memory)) => {

--- a/runtime/near-vm-runner/src/preload.rs
+++ b/runtime/near-vm-runner/src/preload.rs
@@ -8,10 +8,11 @@ use near_primitives::runtime::fees::RuntimeFeesConfig;
 use near_primitives::types::CompiledContractCache;
 use near_vm_errors::VMError;
 use near_vm_logic::types::PromiseResult;
-use near_vm_logic::{External, ProtocolVersion, VMConfig, VMContext, VMOutcome};
+use near_vm_logic::{External, ProtocolVersion, VMConfig, VMContext};
 
 use crate::cache::{self, into_vm_result};
 use crate::vm_kind::VMKind;
+use crate::VMResult;
 
 const SHARE_MEMORY_INSTANCE: bool = false;
 
@@ -125,12 +126,12 @@ impl ContractCaller {
         fees_config: &'a RuntimeFeesConfig,
         promise_results: &'a [PromiseResult],
         current_protocol_version: ProtocolVersion,
-    ) -> (Option<VMOutcome>, Option<VMError>) {
+    ) -> VMResult {
         match self.preloaded.get(preloaded.handle) {
             Some(call) => {
                 let call_data = call.rx.recv().unwrap();
                 match call_data.result {
-                    Err(err) => (None, Some(err)),
+                    Err(err) => VMResult::not_run(err),
                     Ok(module) => match (&module, &mut self.vm_data_private) {
                         #[cfg(feature = "wasmer0_vm")]
                         (VMModule::Wasmer0(module), VMDataPrivate::Wasmer0(memory)) => {

--- a/runtime/near-vm-runner/src/runner.rs
+++ b/runtime/near-vm-runner/src/runner.rs
@@ -125,8 +125,7 @@ impl VMResult {
     pub fn not_run(error: VMError) -> VMResult {
         VMResult::NotRun(error)
     }
-    #[cfg_attr(not(feature = "protocol_feature_function_call_weight"), allow(unused_mut))]
-    pub fn abort(mut logic: VMLogic, error: VMError) -> VMResult {
+    pub fn abort(logic: VMLogic, error: VMError) -> VMResult {
         let outcome = logic.compute_outcome_and_distribute_gas();
         VMResult::aborted(outcome, error)
     }

--- a/runtime/near-vm-runner/src/runner.rs
+++ b/runtime/near-vm-runner/src/runner.rs
@@ -122,19 +122,21 @@ pub enum VMResult {
 }
 
 impl VMResult {
-    pub fn not_run(error: VMError) -> VMResult {
-        VMResult::NotRun(error)
-    }
+    /// Consumes the `VMLogic` object and computes the final outcome with the
+    /// given error that stopped execution from finishing successfully.
     pub fn abort(logic: VMLogic, error: VMError) -> VMResult {
         let outcome = logic.compute_outcome_and_distribute_gas();
-        VMResult::aborted(outcome, error)
-    }
-    pub fn aborted(outcome: VMOutcome, error: VMError) -> VMResult {
         VMResult::Aborted(outcome, error)
     }
-    pub fn ok(outcome: VMOutcome) -> VMResult {
+
+    /// Consumes the `VMLogic` object and computes the final outcome for a
+    /// successful execution.
+    pub fn ok(logic: VMLogic) -> VMResult {
+        let outcome = logic.compute_outcome_and_distribute_gas();
         VMResult::Ok(outcome)
     }
+
+    /// Borrow the internal outcome, if there is one.
     pub fn outcome(&self) -> Option<&VMOutcome> {
         match self {
             VMResult::NotRun(_err) => None,
@@ -142,6 +144,8 @@ impl VMResult {
             VMResult::Ok(outcome) => Some(outcome),
         }
     }
+
+    /// Borrow the internal error, if there is one.
     pub fn error(&self) -> Option<&VMError> {
         match self {
             VMResult::NotRun(err) => Some(err),
@@ -149,6 +153,9 @@ impl VMResult {
             VMResult::Ok(_outcome) => None,
         }
     }
+
+    /// Unpack the internal outcome and error. This method mostly exists for
+    /// easy compatibility with code that was written before `VMResult` existed.
     pub fn outcome_error(self) -> (Option<VMOutcome>, Option<VMError>) {
         match self {
             VMResult::NotRun(err) => (None, Some(err)),

--- a/runtime/near-vm-runner/src/runner.rs
+++ b/runtime/near-vm-runner/src/runner.rs
@@ -114,6 +114,8 @@ impl VMKind {
 #[derive(Debug, PartialEq)]
 pub enum VMResult {
     /// Execution was not able to start because preconditions were not met.
+    /// TODO: Remove this with more refactoring or present a good reason why it
+    /// is needed.
     NotRun(VMError),
     /// Execution started but hit an error.
     Aborted(VMOutcome, VMError),

--- a/runtime/near-vm-runner/src/tests.rs
+++ b/runtime/near-vm-runner/src/tests.rs
@@ -71,16 +71,18 @@ fn make_simple_contract_call_with_gas_vm(
 
     let code = ContractCode::new(code.to_vec(), None);
     let runtime = vm_kind.runtime(config).expect("runtime has not been compiled");
-    runtime.run(
-        &code,
-        method_name,
-        &mut fake_external,
-        context,
-        &fees,
-        &promise_results,
-        LATEST_PROTOCOL_VERSION,
-        None,
-    )
+    runtime
+        .run(
+            &code,
+            method_name,
+            &mut fake_external,
+            context,
+            &fees,
+            &promise_results,
+            LATEST_PROTOCOL_VERSION,
+            None,
+        )
+        .outcome_error()
 }
 
 fn make_simple_contract_call_with_protocol_version_vm(
@@ -99,16 +101,18 @@ fn make_simple_contract_call_with_protocol_version_vm(
 
     let promise_results = vec![];
     let code = ContractCode::new(code.to_vec(), None);
-    runtime.run(
-        &code,
-        method_name,
-        &mut fake_external,
-        context,
-        fees,
-        &promise_results,
-        protocol_version,
-        None,
-    )
+    runtime
+        .run(
+            &code,
+            method_name,
+            &mut fake_external,
+            context,
+            fees,
+            &promise_results,
+            protocol_version,
+            None,
+        )
+        .outcome_error()
 }
 
 fn make_simple_contract_call_vm(

--- a/runtime/near-vm-runner/src/tests/contract_preload.rs
+++ b/runtime/near-vm-runner/src/tests/contract_preload.rs
@@ -11,12 +11,12 @@ use near_primitives::runtime::fees::RuntimeFeesConfig;
 use near_primitives::types::CompiledContractCache;
 use near_vm_errors::VMError::FunctionCallError;
 use near_vm_logic::mocks::mock_external::MockedExternal;
-use near_vm_logic::{ProtocolVersion, VMConfig, VMContext, VMOutcome};
+use near_vm_logic::{ProtocolVersion, VMConfig, VMContext};
 
 use crate::cache::precompile_contract_vm;
 use crate::errors::ContractPrecompilatonResult;
 use crate::vm_kind::VMKind;
-use crate::{ContractCallPrepareRequest, ContractCaller, VMError};
+use crate::{ContractCallPrepareRequest, ContractCaller, VMResult};
 
 fn default_vm_context() -> VMContext {
     return VMContext {
@@ -72,26 +72,23 @@ impl CompiledContractCache for MockCompiledContractCache {
     }
 }
 
-fn test_result(result: (Option<VMOutcome>, Option<VMError>), check_gas: bool) -> (i32, i32) {
+fn test_result(result: VMResult, check_gas: bool) -> (i32, i32) {
     let mut oks = 0;
     let mut errs = 0;
-    match result.0 {
-        Some(outcome) => {
+
+    match result {
+        VMResult::Ok(outcome) => {
             if check_gas {
                 assert_eq!(outcome.burnt_gas, 11088051921);
             }
             oks += 1;
         }
-        None => {}
-    };
-    match result.1 {
-        Some(err) => match err {
-            FunctionCallError(_) => {
-                errs += 1;
-            }
-            _ => assert!(false, "Unexpected error: {:?}", err),
-        },
-        None => {}
+        VMResult::NotRun(FunctionCallError(_)) => {
+            errs += 1;
+        }
+        VMResult::NotRun(err) | VMResult::Aborted(_, err) => {
+            assert!(false, "Unexpected error: {:?}", err)
+        }
     }
     (oks, errs)
 }

--- a/runtime/near-vm-runner/src/tests/rs_contract.rs
+++ b/runtime/near-vm-runner/src/tests/rs_contract.rs
@@ -13,6 +13,7 @@ use crate::tests::{
     PREDECESSOR_ACCOUNT_ID, SIGNER_ACCOUNT_ID, SIGNER_ACCOUNT_PK,
 };
 use crate::vm_kind::VMKind;
+use crate::VMResult;
 
 fn test_contract() -> ContractCode {
     let code = if cfg!(feature = "protocol_feature_alt_bn128") {
@@ -23,12 +24,12 @@ fn test_contract() -> ContractCode {
     ContractCode::new(code.to_vec(), None)
 }
 
-fn assert_run_result((outcome, err): (Option<VMOutcome>, Option<VMError>), expected_value: u64) {
-    if let Some(_) = err {
+fn assert_run_result(result: VMResult, expected_value: u64) {
+    if let Some(_) = result.error() {
         panic!("Failed execution");
     }
 
-    if let Some(VMOutcome { return_data, .. }) = outcome {
+    if let Some(VMOutcome { return_data, .. }) = result.outcome() {
         if let ReturnData::Value(value) = return_data {
             let mut arr = [0u8; size_of::<u64>()];
             arr.copy_from_slice(&value);
@@ -111,7 +112,7 @@ pub fn test_stablized_host_function() {
             LATEST_PROTOCOL_VERSION,
             None,
         );
-        assert_eq!(result.1, None);
+        assert_eq!(result.error(), None);
 
         let result = runtime.run(
             &code,
@@ -123,8 +124,8 @@ pub fn test_stablized_host_function() {
             ProtocolFeature::MathExtension.protocol_version() - 1,
             None,
         );
-        match result.1 {
-            Some(VMError::FunctionCallError(FunctionCallError::LinkError { msg: _ })) => {}
+        match result.error() {
+            Some(&VMError::FunctionCallError(FunctionCallError::LinkError { msg: _ })) => {}
             _ => panic!("should return a link error due to missing import"),
         }
     });
@@ -173,16 +174,9 @@ fn run_test_ext(
     let context = create_context(input.to_vec());
     let runtime = vm_kind.runtime(config).expect("runtime has not been compiled");
 
-    let (outcome, err) = runtime.run(
-        &code,
-        method,
-        &mut fake_external,
-        context,
-        &fees,
-        &[],
-        LATEST_PROTOCOL_VERSION,
-        None,
-    );
+    let (outcome, err) = runtime
+        .run(&code, method, &mut fake_external, context, &fees, &[], LATEST_PROTOCOL_VERSION, None)
+        .outcome_error();
 
     if let Some(outcome) = &outcome {
         assert_eq!(outcome.profile.action_gas(), 0);
@@ -318,9 +312,9 @@ pub fn test_out_of_memory() {
             None,
         );
         assert_eq!(
-            result.1,
+            result.error(),
             match vm_kind {
-                VMKind::Wasmer0 | VMKind::Wasmer2 => Some(VMError::FunctionCallError(
+                VMKind::Wasmer0 | VMKind::Wasmer2 => Some(&VMError::FunctionCallError(
                     FunctionCallError::WasmTrap(WasmTrap::Unreachable)
                 )),
                 VMKind::Wasmtime => unreachable!(),

--- a/runtime/near-vm-runner/src/tests/ts_contract.rs
+++ b/runtime/near-vm-runner/src/tests/ts_contract.rs
@@ -32,27 +32,24 @@ pub fn test_ts_contract() {
             None,
         );
         assert_eq!(
-            result.1,
-            Some(VMError::FunctionCallError(FunctionCallError::HostError(HostError::GuestPanic {
-                panic_msg: "explicit guest panic".to_string()
-            })))
+            result.error(),
+            Some(&VMError::FunctionCallError(FunctionCallError::HostError(
+                HostError::GuestPanic { panic_msg: "explicit guest panic".to_string() }
+            )))
         );
 
         // Call method that writes something into storage.
         let context = create_context(b"foo bar".to_vec());
-        runtime
-            .run(
-                &code,
-                "try_storage_write",
-                &mut fake_external,
-                context,
-                &fees,
-                &promise_results,
-                LATEST_PROTOCOL_VERSION,
-                None,
-            )
-            .0
-            .unwrap();
+        runtime.run(
+            &code,
+            "try_storage_write",
+            &mut fake_external,
+            context,
+            &fees,
+            &promise_results,
+            LATEST_PROTOCOL_VERSION,
+            None,
+        );
         // Verify by looking directly into the storage of the host.
         {
             let res = fake_external.storage_get(b"foo");
@@ -75,7 +72,7 @@ pub fn test_ts_contract() {
             None,
         );
 
-        if let ReturnData::Value(value) = result.0.unwrap().return_data {
+        if let ReturnData::Value(value) = result.outcome().unwrap().return_data.clone() {
             let value = String::from_utf8(value).unwrap();
             assert_eq!(value, "bar");
         } else {

--- a/runtime/near-vm-runner/src/wasmer2_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer2_runner.rs
@@ -1,6 +1,7 @@
 use crate::cache::into_vm_result;
 use crate::imports::wasmer2::Wasmer2Imports;
 use crate::prepare::WASM_FEATURES;
+use crate::runner::VMResult;
 use crate::{cache, imports};
 use memoffset::offset_of;
 use near_primitives::contract::ContractCode;
@@ -10,7 +11,7 @@ use near_stable_hasher::StableHasher;
 use near_vm_errors::{CompilationError, FunctionCallError, MethodResolveError, VMError, WasmTrap};
 use near_vm_logic::gas_counter::FastGasCounter;
 use near_vm_logic::types::{PromiseResult, ProtocolVersion};
-use near_vm_logic::{External, MemoryLike, VMConfig, VMContext, VMLogic, VMOutcome};
+use near_vm_logic::{External, MemoryLike, VMConfig, VMContext, VMLogic};
 use std::hash::{Hash, Hasher};
 use std::mem::size_of;
 use std::sync::Arc;
@@ -433,7 +434,7 @@ impl Wasmer2VM {
         fees_config: &'a RuntimeFeesConfig,
         promise_results: &'a [PromiseResult],
         current_protocol_version: ProtocolVersion,
-    ) -> (Option<VMOutcome>, Option<VMError>) {
+    ) -> VMResult {
         let vmmemory = memory.vm();
         let mut logic = VMLogic::new_with_protocol_version(
             ext,
@@ -446,10 +447,14 @@ impl Wasmer2VM {
         );
         let import = imports::wasmer2::build(vmmemory, &mut logic, current_protocol_version);
         if let Err(e) = get_entrypoint_index(&*artifact.artifact, method_name) {
-            return (None, Some(e));
+            return VMResult::not_run(e);
         }
-        let err = self.run_method(artifact, import, method_name).err();
-        (Some(logic.compute_outcome_and_distribute_gas()), err)
+        let status = self.run_method(artifact, import, method_name);
+        let outcome = logic.compute_outcome_and_distribute_gas();
+        match status {
+            Ok(()) => VMResult::ok(outcome),
+            Err(err) => VMResult::aborted(outcome, err),
+        }
     }
 }
 
@@ -526,7 +531,7 @@ impl crate::runner::VM for Wasmer2VM {
         promise_results: &[PromiseResult],
         current_protocol_version: ProtocolVersion,
         cache: Option<&dyn CompiledContractCache>,
-    ) -> (Option<VMOutcome>, Option<VMError>) {
+    ) -> VMResult {
         let _span = tracing::debug_span!(
             target: "vm",
             "run_wasmer2",
@@ -536,18 +541,18 @@ impl crate::runner::VM for Wasmer2VM {
         .entered();
 
         if method_name.is_empty() {
-            return (
-                None,
-                Some(VMError::FunctionCallError(FunctionCallError::MethodResolveError(
-                    MethodResolveError::MethodEmptyName,
-                ))),
-            );
+            let error = VMError::FunctionCallError(FunctionCallError::MethodResolveError(
+                MethodResolveError::MethodEmptyName,
+            ));
+            return VMResult::not_run(error);
         }
         let artifact =
             cache::wasmer2_cache::compile_module_cached_wasmer2(code, &self.config, cache);
         let artifact = match into_vm_result(artifact) {
             Ok(it) => it,
-            Err(err) => return (None, Some(err)),
+            Err(err) => {
+                return VMResult::not_run(err);
+            }
         };
 
         let mut memory = Wasmer2Memory::new(
@@ -570,19 +575,20 @@ impl crate::runner::VM for Wasmer2VM {
         );
         // TODO: remove, as those costs are incorrectly computed, and we shall account it on deployment.
         if logic.add_contract_compile_fee(code.code().len() as u64).is_err() {
-            return (
-                Some(logic.compute_outcome_and_distribute_gas()),
-                Some(VMError::FunctionCallError(FunctionCallError::HostError(
-                    near_vm_errors::HostError::GasExceeded,
-                ))),
-            );
+            let error = VMError::FunctionCallError(FunctionCallError::HostError(
+                near_vm_errors::HostError::GasExceeded,
+            ));
+            return VMResult::abort(logic, error);
         }
         let import = imports::wasmer2::build(vmmemory, &mut logic, current_protocol_version);
         if let Err(e) = get_entrypoint_index(&*artifact.artifact, method_name) {
-            return (None, Some(e));
+            // TODO: This should return an outcome to account for loading cost
+            return VMResult::not_run(e);
         }
-        let err = self.run_method(&artifact, import, method_name).err();
-        (Some(logic.compute_outcome_and_distribute_gas()), err)
+        match self.run_method(&artifact, import, method_name) {
+            Ok(()) => VMResult::ok(logic.compute_outcome_and_distribute_gas()),
+            Err(err) => VMResult::aborted(logic.compute_outcome_and_distribute_gas(), err),
+        }
     }
 
     fn precompile(

--- a/runtime/near-vm-runner/src/wasmer2_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer2_runner.rs
@@ -549,9 +549,7 @@ impl crate::runner::VM for Wasmer2VM {
             cache::wasmer2_cache::compile_module_cached_wasmer2(code, &self.config, cache);
         let artifact = match into_vm_result(artifact) {
             Ok(it) => it,
-            Err(err) => {
-                return VMResult::NotRun(err);
-            }
+            Err(err) => return VMResult::NotRun(err),
         };
 
         let mut memory = Wasmer2Memory::new(

--- a/runtime/near-vm-runner/src/wasmer_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer_runner.rs
@@ -2,6 +2,7 @@ use crate::cache::into_vm_result;
 use crate::errors::IntoVMError;
 use crate::memory::WasmerMemory;
 use crate::prepare::WASM_FEATURES;
+use crate::runner::VMResult;
 use crate::{cache, imports};
 use near_primitives::config::VMConfig;
 use near_primitives::contract::ContractCode;
@@ -10,7 +11,7 @@ use near_primitives::types::CompiledContractCache;
 use near_primitives::version::ProtocolVersion;
 use near_vm_errors::{CompilationError, FunctionCallError, MethodResolveError, VMError, WasmTrap};
 use near_vm_logic::types::PromiseResult;
-use near_vm_logic::{External, VMContext, VMLogic, VMLogicError, VMOutcome};
+use near_vm_logic::{External, VMContext, VMLogic, VMLogicError};
 use wasmer_runtime::{ImportObject, Module};
 
 const WASMER_FEATURES: wasmer_runtime::Features =
@@ -232,14 +233,12 @@ pub(crate) fn run_wasmer0_module<'a>(
     fees_config: &'a RuntimeFeesConfig,
     promise_results: &'a [PromiseResult],
     current_protocol_version: ProtocolVersion,
-) -> (Option<VMOutcome>, Option<VMError>) {
+) -> VMResult {
     if method_name.is_empty() {
-        return (
-            None,
-            Some(VMError::FunctionCallError(FunctionCallError::MethodResolveError(
-                MethodResolveError::MethodEmptyName,
-            ))),
-        );
+        let err = VMError::FunctionCallError(FunctionCallError::MethodResolveError(
+            MethodResolveError::MethodEmptyName,
+        ));
+        return VMResult::not_run(err);
     }
     // Note that we don't clone the actual backing memory, just increase the RC.
     let memory_copy = memory.clone();
@@ -257,11 +256,13 @@ pub(crate) fn run_wasmer0_module<'a>(
     let import_object = imports::wasmer::build(memory_copy, &mut logic, current_protocol_version);
 
     if let Err(e) = check_method(&module, method_name) {
-        return (None, Some(e));
+        return VMResult::not_run(e);
     }
 
-    let err = run_method(&module, &import_object, method_name).err();
-    (Some(logic.compute_outcome_and_distribute_gas()), err)
+    match run_method(&module, &import_object, method_name) {
+        Ok(()) => VMResult::ok(logic.compute_outcome_and_distribute_gas()),
+        Err(err) => VMResult::aborted(logic.compute_outcome_and_distribute_gas(), err),
+    }
 }
 
 pub(crate) fn wasmer0_vm_hash() -> u64 {
@@ -290,7 +291,7 @@ impl crate::runner::VM for Wasmer0VM {
         promise_results: &[PromiseResult],
         current_protocol_version: ProtocolVersion,
         cache: Option<&dyn CompiledContractCache>,
-    ) -> (Option<VMOutcome>, Option<VMError>) {
+    ) -> VMResult {
         let _span = tracing::debug_span!(
             target: "vm",
             "run_wasmer0",
@@ -311,19 +312,17 @@ impl crate::runner::VM for Wasmer0VM {
             panic!("AVX support is required in order to run Wasmer VM Singlepass backend.");
         }
         if method_name.is_empty() {
-            return (
-                None,
-                Some(VMError::FunctionCallError(FunctionCallError::MethodResolveError(
-                    MethodResolveError::MethodEmptyName,
-                ))),
-            );
+            let err = VMError::FunctionCallError(FunctionCallError::MethodResolveError(
+                MethodResolveError::MethodEmptyName,
+            ));
+            return VMResult::not_run(err);
         }
 
         // TODO: consider using get_module() here, once we'll go via deployment path.
         let module = cache::wasmer0_cache::compile_module_cached_wasmer0(code, &self.config, cache);
         let module = match into_vm_result(module) {
             Ok(x) => x,
-            Err(err) => return (None, Some(err)),
+            Err(err) => return VMResult::not_run(err),
         };
         let mut memory = WasmerMemory::new(
             self.config.limit_config.initial_memory_pages,
@@ -345,23 +344,24 @@ impl crate::runner::VM for Wasmer0VM {
 
         // TODO: remove, as those costs are incorrectly computed, and we shall account it on deployment.
         if logic.add_contract_compile_fee(code.code().len() as u64).is_err() {
-            return (
-                Some(logic.compute_outcome_and_distribute_gas()),
-                Some(VMError::FunctionCallError(FunctionCallError::HostError(
-                    near_vm_errors::HostError::GasExceeded,
-                ))),
-            );
+            let err = VMError::FunctionCallError(FunctionCallError::HostError(
+                near_vm_errors::HostError::GasExceeded,
+            ));
+            return VMResult::abort(logic, err);
         }
 
         let import_object =
             imports::wasmer::build(memory_copy, &mut logic, current_protocol_version);
 
         if let Err(e) = check_method(&module, method_name) {
-            return (None, Some(e));
+            // TODO: This should return an outcome to account for loading cost
+            return VMResult::not_run(e);
         }
 
-        let err = run_method(&module, &import_object, method_name).err();
-        (Some(logic.compute_outcome_and_distribute_gas()), err)
+        match run_method(&module, &import_object, method_name) {
+            Ok(()) => VMResult::ok(logic.compute_outcome_and_distribute_gas()),
+            Err(err) => VMResult::aborted(logic.compute_outcome_and_distribute_gas(), err),
+        }
     }
 
     fn precompile(

--- a/runtime/near-vm-runner/src/wasmer_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer_runner.rs
@@ -238,7 +238,7 @@ pub(crate) fn run_wasmer0_module<'a>(
         let err = VMError::FunctionCallError(FunctionCallError::MethodResolveError(
             MethodResolveError::MethodEmptyName,
         ));
-        return VMResult::not_run(err);
+        return VMResult::NotRun(err);
     }
     // Note that we don't clone the actual backing memory, just increase the RC.
     let memory_copy = memory.clone();
@@ -256,12 +256,12 @@ pub(crate) fn run_wasmer0_module<'a>(
     let import_object = imports::wasmer::build(memory_copy, &mut logic, current_protocol_version);
 
     if let Err(e) = check_method(&module, method_name) {
-        return VMResult::not_run(e);
+        return VMResult::NotRun(e);
     }
 
     match run_method(&module, &import_object, method_name) {
-        Ok(()) => VMResult::ok(logic.compute_outcome_and_distribute_gas()),
-        Err(err) => VMResult::aborted(logic.compute_outcome_and_distribute_gas(), err),
+        Ok(()) => VMResult::ok(logic),
+        Err(err) => VMResult::abort(logic, err),
     }
 }
 
@@ -315,14 +315,14 @@ impl crate::runner::VM for Wasmer0VM {
             let err = VMError::FunctionCallError(FunctionCallError::MethodResolveError(
                 MethodResolveError::MethodEmptyName,
             ));
-            return VMResult::not_run(err);
+            return VMResult::NotRun(err);
         }
 
         // TODO: consider using get_module() here, once we'll go via deployment path.
         let module = cache::wasmer0_cache::compile_module_cached_wasmer0(code, &self.config, cache);
         let module = match into_vm_result(module) {
             Ok(x) => x,
-            Err(err) => return VMResult::not_run(err),
+            Err(err) => return VMResult::NotRun(err),
         };
         let mut memory = WasmerMemory::new(
             self.config.limit_config.initial_memory_pages,
@@ -355,12 +355,12 @@ impl crate::runner::VM for Wasmer0VM {
 
         if let Err(e) = check_method(&module, method_name) {
             // TODO: This should return an outcome to account for loading cost
-            return VMResult::not_run(e);
+            return VMResult::NotRun(e);
         }
 
         match run_method(&module, &import_object, method_name) {
-            Ok(()) => VMResult::ok(logic.compute_outcome_and_distribute_gas()),
-            Err(err) => VMResult::aborted(logic.compute_outcome_and_distribute_gas(), err),
+            Ok(()) => VMResult::ok(logic),
+            Err(err) => VMResult::abort(logic, err),
         }
     }
 

--- a/runtime/near-vm-runner/src/wasmtime_runner.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner.rs
@@ -1,5 +1,6 @@
 use crate::errors::IntoVMError;
 use crate::prepare::WASM_FEATURES;
+use crate::runner::VMResult;
 use crate::{imports, prepare};
 use near_primitives::config::VMConfig;
 use near_primitives::contract::ContractCode;
@@ -12,7 +13,7 @@ use near_vm_errors::{
     WasmTrap,
 };
 use near_vm_logic::types::PromiseResult;
-use near_vm_logic::{External, MemoryLike, VMContext, VMLogic, VMOutcome};
+use near_vm_logic::{External, MemoryLike, VMContext, VMLogic};
 use std::cell::RefCell;
 use std::ffi::c_void;
 use std::str;
@@ -187,7 +188,7 @@ impl crate::runner::VM for WasmtimeVM {
         promise_results: &[PromiseResult],
         current_protocol_version: ProtocolVersion,
         _cache: Option<&dyn CompiledContractCache>,
-    ) -> (Option<VMOutcome>, Option<VMError>) {
+    ) -> VMResult {
         let _span = tracing::debug_span!(
             target: "vm",
             "run_wasmtime",
@@ -206,11 +207,11 @@ impl crate::runner::VM for WasmtimeVM {
         .unwrap();
         let prepared_code = match prepare::prepare_contract(code.code(), &self.config) {
             Ok(code) => code,
-            Err(err) => return (None, Some(VMError::from(err))),
+            Err(err) => return VMResult::not_run(VMError::from(err)),
         };
         let module = match Module::new(&engine, prepared_code) {
             Ok(module) => module,
-            Err(err) => return (None, Some(err.into_vm_error())),
+            Err(err) => return VMResult::not_run(err.into_vm_error()),
         };
         let mut linker = Linker::new(&engine);
         let memory_copy = memory.0;
@@ -226,12 +227,10 @@ impl crate::runner::VM for WasmtimeVM {
 
         // TODO: remove, as those costs are incorrectly computed, and we shall account it on deployment.
         if logic.add_contract_compile_fee(code.code().len() as u64).is_err() {
-            return (
-                Some(logic.compute_outcome_and_distribute_gas()),
-                Some(VMError::FunctionCallError(FunctionCallError::HostError(
-                    near_vm_errors::HostError::GasExceeded,
-                ))),
-            );
+            let err = VMError::FunctionCallError(FunctionCallError::HostError(
+                near_vm_errors::HostError::GasExceeded,
+            ));
+            return VMResult::abort(logic, err);
         }
 
         // Unfortunately, due to the Wasmtime implementation we have to do tricks with the
@@ -239,70 +238,57 @@ impl crate::runner::VM for WasmtimeVM {
         let raw_logic = &mut logic as *mut _ as *mut c_void;
         imports::wasmtime::link(&mut linker, memory_copy, raw_logic, current_protocol_version);
         if method_name.is_empty() {
-            return (
-                None,
-                Some(VMError::FunctionCallError(FunctionCallError::MethodResolveError(
-                    MethodResolveError::MethodEmptyName,
-                ))),
-            );
+            let err = VMError::FunctionCallError(FunctionCallError::MethodResolveError(
+                MethodResolveError::MethodEmptyName,
+            ));
+            return VMResult::not_run(err);
         }
         match module.get_export(method_name) {
             Some(export) => match export {
                 Func(func_type) => {
                     if func_type.params().len() != 0 || func_type.results().len() != 0 {
-                        return (
-                            None,
-                            Some(VMError::FunctionCallError(
-                                FunctionCallError::MethodResolveError(
-                                    MethodResolveError::MethodInvalidSignature,
-                                ),
-                            )),
-                        );
+                        let err =
+                            VMError::FunctionCallError(FunctionCallError::MethodResolveError(
+                                MethodResolveError::MethodInvalidSignature,
+                            ));
+                        // TODO: This should return an outcome to account for loading cost
+                        return VMResult::not_run(err);
                     }
                 }
                 _ => {
-                    return (
-                        None,
-                        Some(VMError::FunctionCallError(FunctionCallError::MethodResolveError(
-                            MethodResolveError::MethodNotFound,
-                        ))),
-                    )
+                    let err = VMError::FunctionCallError(FunctionCallError::MethodResolveError(
+                        MethodResolveError::MethodNotFound,
+                    ));
+                    // TODO: This should return an outcome to account for loading cost
+                    return VMResult::not_run(err);
                 }
             },
             None => {
-                return (
-                    None,
-                    Some(VMError::FunctionCallError(FunctionCallError::MethodResolveError(
-                        MethodResolveError::MethodNotFound,
-                    ))),
-                )
+                let err = VMError::FunctionCallError(FunctionCallError::MethodResolveError(
+                    MethodResolveError::MethodNotFound,
+                ));
+                // TODO: This should return an outcome to account for loading cost
+                return VMResult::not_run(err);
             }
         }
         match linker.instantiate(&mut store, &module) {
             Ok(instance) => match instance.get_func(&mut store, method_name) {
                 Some(func) => match func.typed::<(), (), _>(&mut store) {
                     Ok(run) => match run.call(&mut store, ()) {
-                        Ok(_) => (Some(logic.compute_outcome_and_distribute_gas()), None),
-                        Err(err) => (
-                            Some(logic.compute_outcome_and_distribute_gas()),
-                            Some(err.into_vm_error()),
-                        ),
+                        Ok(_) => VMResult::ok(logic.compute_outcome_and_distribute_gas()),
+                        Err(err) => (VMResult::abort(logic, err.into_vm_error())),
                     },
-                    Err(err) => (
-                        Some(logic.compute_outcome_and_distribute_gas()),
-                        Some(err.into_vm_error()),
-                    ),
+                    Err(err) => VMResult::abort(logic, err.into_vm_error()),
                 },
-                None => (
-                    None,
-                    Some(VMError::FunctionCallError(FunctionCallError::MethodResolveError(
+                None => {
+                    let err = VMError::FunctionCallError(FunctionCallError::MethodResolveError(
                         MethodResolveError::MethodNotFound,
-                    ))),
-                ),
+                    ));
+                    // TODO: This should return an outcome to account for loading cost
+                    VMResult::not_run(err)
+                }
             },
-            Err(err) => {
-                (Some(logic.compute_outcome_and_distribute_gas()), Some(err.into_vm_error()))
-            }
+            Err(err) => VMResult::abort(logic, err.into_vm_error()),
         }
     }
 

--- a/runtime/runtime-params-estimator/src/function_call.rs
+++ b/runtime/runtime-params-estimator/src/function_call.rs
@@ -93,7 +93,7 @@ pub fn compute_function_call_cost(
             protocol_version,
             cache,
         );
-        assert!(result.1.is_none());
+        assert!(result.error().is_none());
     }
     // Run with gas metering.
     let start = GasCost::measure(gas_metric);
@@ -108,7 +108,7 @@ pub fn compute_function_call_cost(
             protocol_version,
             cache,
         );
-        assert!(result.1.is_none());
+        assert!(result.error().is_none());
     }
     start.elapsed().to_gas()
 }

--- a/runtime/runtime-params-estimator/src/gas_metering.rs
+++ b/runtime/runtime-params-estimator/src/gas_metering.rs
@@ -155,8 +155,7 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
             PROTOCOL_VERSION,
             cache,
         );
-        if result.error().is_some() {
-            let err = result.error().unwrap();
+        if let Some(err) = result.error() {
             eprintln!("error: {}", err);
         }
         assert!(result.error().is_none());

--- a/runtime/runtime-params-estimator/src/gas_metering.rs
+++ b/runtime/runtime-params-estimator/src/gas_metering.rs
@@ -155,11 +155,11 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
             PROTOCOL_VERSION,
             cache,
         );
-        if result.1.is_some() {
-            let err = result.1.as_ref().unwrap();
+        if result.error().is_some() {
+            let err = result.error().unwrap();
             eprintln!("error: {}", err);
         }
-        assert!(result.1.is_none());
+        assert!(result.error().is_none());
     }
 
     // Run with gas metering.
@@ -175,7 +175,7 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
             PROTOCOL_VERSION,
             cache,
         );
-        assert!(result.1.is_none());
+        assert!(result.error().is_none());
     }
     let total_raw_with_gas = start.elapsed();
 
@@ -191,7 +191,7 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
             PROTOCOL_VERSION,
             cache,
         );
-        assert!(result.1.is_none());
+        assert!(result.error().is_none());
     }
 
     // Run without gas metering.
@@ -207,7 +207,7 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
             PROTOCOL_VERSION,
             cache,
         );
-        assert!(result.1.is_none());
+        assert!(result.error().is_none());
     }
     let total_raw_no_gas = start.elapsed();
 

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -743,7 +743,7 @@ fn wasm_instruction(ctx: &mut EstimatorContext) -> GasCost {
 
     let mut run = || {
         let context = create_context(vec![]);
-        let (outcome, err) = vm_kind.runtime(config.clone()).unwrap().run(
+        let vm_result = vm_kind.runtime(config.clone()).unwrap().run(
             &code,
             "cpu_ram_soak_test",
             &mut fake_external,
@@ -753,10 +753,9 @@ fn wasm_instruction(ctx: &mut EstimatorContext) -> GasCost {
             PROTOCOL_VERSION,
             Some(&cache),
         );
-        match (outcome, err) {
-            (Some(it), Some(_)) => it,
-            _ => panic!(),
-        }
+        assert!(vm_result.outcome().is_some());
+        assert!(vm_result.error().is_some());
+        vm_result.outcome().cloned().unwrap()
     };
 
     let warmup_outcome = run();

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -57,10 +57,10 @@ pub(crate) fn execute_function_call(
             let error = FunctionCallError::CompilationError(CompilationError::CodeDoesNotExist {
                 account_id: account_id.clone(),
             });
-            return VMResult::not_run(VMError::FunctionCallError(error));
+            return VMResult::NotRun(VMError::FunctionCallError(error));
         }
         Err(e) => {
-            return VMResult::not_run(VMError::ExternalError(AnyError::new(
+            return VMResult::NotRun(VMError::ExternalError(AnyError::new(
                 ExternalError::StorageError(e),
             )));
         }

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -28,13 +28,13 @@ use near_vm_errors::{
     AnyError, CacheError, CompilationError, FunctionCallError, InconsistentStateError, VMError,
 };
 use near_vm_logic::types::PromiseResult;
-use near_vm_logic::{VMContext, VMOutcome};
+use near_vm_logic::VMContext;
 
 use crate::config::{safe_add_gas, RuntimeConfig};
 use crate::ext::{ExternalError, RuntimeExt};
 use crate::{ActionResult, ApplyState};
 use near_primitives::config::ViewConfig;
-use near_vm_runner::precompile_contract;
+use near_vm_runner::{precompile_contract, VMResult};
 
 /// Runs given function call with given context / apply state.
 pub(crate) fn execute_function_call(
@@ -49,7 +49,7 @@ pub(crate) fn execute_function_call(
     config: &RuntimeConfig,
     is_last_action: bool,
     view_config: Option<ViewConfig>,
-) -> (Option<VMOutcome>, Option<VMError>) {
+) -> VMResult {
     let account_id = runtime_ext.account_id();
     let code = match runtime_ext.get_code(account.code_hash()) {
         Ok(Some(code)) => code,
@@ -57,13 +57,12 @@ pub(crate) fn execute_function_call(
             let error = FunctionCallError::CompilationError(CompilationError::CodeDoesNotExist {
                 account_id: account_id.clone(),
             });
-            return (None, Some(VMError::FunctionCallError(error)));
+            return VMResult::not_run(VMError::FunctionCallError(error));
         }
         Err(e) => {
-            return (
-                None,
-                Some(VMError::ExternalError(AnyError::new(ExternalError::StorageError(e)))),
-            );
+            return VMResult::not_run(VMError::ExternalError(AnyError::new(
+                ExternalError::StorageError(e),
+            )));
         }
     };
     // Output data receipts are ignored if the function call is not the last action in the batch.
@@ -159,7 +158,8 @@ pub(crate) fn action_function_call(
         config,
         is_last_action,
         None,
-    );
+    )
+    .outcome_error();
     let execution_succeeded = match err {
         Some(VMError::FunctionCallError(err)) => match err {
             FunctionCallError::Nondeterministic(msg) => {

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -237,7 +237,8 @@ impl TrieViewer {
             config,
             true,
             Some(ViewConfig { max_gas_burnt: self.max_gas_burnt_view }),
-        );
+        )
+        .outcome_error();
         let elapsed = now.elapsed();
         let time_ms =
             (elapsed.as_secs() as f64 / 1_000.0) + f64::from(elapsed.subsec_nanos()) / 1_000_000.0;


### PR DESCRIPTION
This refactor primarily tries to make the `VM::run` signature clearer.
It is also a preparation step towards changing where contract loading
gas costs are charged.