### PR TITLE
chore: bump `actix` to `v0.12.0` stable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "actix"
-version = "0.11.0-beta.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb78f9871feb3519e06b947c2becbf2cc7f67ce786e510e6bd3f9a27da3dbf1"
+checksum = "3720d0064a0ce5c0de7bd93bdb0a6caebab2a9b5668746145d7b3b0c5da02914"
 dependencies = [
  "actix-rt",
  "actix_derive",
@@ -16,6 +16,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-task",
+ "futures-util",
  "log",
  "once_cell",
  "parking_lot 0.11.2",
@@ -242,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "actix_derive"
-version = "0.6.0-beta.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae749cf2582eb83efd288edd4e9704600fdce1bc4f69aa0c86ca1368a3e4c13f"
+checksum = "6d44b8fee1ced9671ba043476deddef739dd0959bf77030b26b738cc591737a7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2327,6 +2328,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
 dependencies = [
  "scopeguard",
+ "serde",
 ]
 
 [[package]]
@@ -2336,7 +2338,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
 dependencies = [
  "scopeguard",
- "serde",
 ]
 
 [[package]]
@@ -2864,7 +2865,6 @@ name = "near-jsonrpc-fuzz"
 version = "0.0.0"
 dependencies = [
  "actix",
- "actix_derive",
  "arbitrary",
  "awc",
  "base64 0.13.0",
@@ -2981,7 +2981,6 @@ name = "near-network-primitives"
 version = "0.0.0"
 dependencies = [
  "actix",
- "actix_derive",
  "anyhow",
  "borsh",
  "chrono",
@@ -3321,7 +3320,6 @@ dependencies = [
  "actix",
  "actix-rt",
  "actix-web",
- "actix_derive",
  "anyhow",
  "awc",
  "bencher",
@@ -3639,7 +3637,7 @@ dependencies = [
  "paperclip-actix",
  "paperclip-core",
  "paperclip-macros",
- "parking_lot 0.11.2",
+ "parking_lot 0.10.2",
  "semver 0.9.0",
  "serde",
  "serde_derive",
@@ -3660,7 +3658,7 @@ dependencies = [
  "once_cell",
  "paperclip-core",
  "paperclip-macros",
- "parking_lot 0.11.2",
+ "parking_lot 0.10.2",
  "serde_json",
 ]
 
@@ -3673,7 +3671,7 @@ dependencies = [
  "mime",
  "once_cell",
  "paperclip-macros",
- "parking_lot 0.11.2",
+ "parking_lot 0.10.2",
  "pin-project",
  "regex",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2328,7 +2328,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
 dependencies = [
  "scopeguard",
- "serde",
 ]
 
 [[package]]
@@ -2338,6 +2337,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
 dependencies = [
  "scopeguard",
+ "serde",
 ]
 
 [[package]]
@@ -3637,7 +3637,7 @@ dependencies = [
  "paperclip-actix",
  "paperclip-core",
  "paperclip-macros",
- "parking_lot 0.10.2",
+ "parking_lot 0.11.2",
  "semver 0.9.0",
  "serde",
  "serde_derive",
@@ -3658,7 +3658,7 @@ dependencies = [
  "once_cell",
  "paperclip-core",
  "paperclip-macros",
- "parking_lot 0.10.2",
+ "parking_lot 0.11.2",
  "serde_json",
 ]
 
@@ -3671,7 +3671,7 @@ dependencies = [
  "mime",
  "once_cell",
  "paperclip-macros",
- "parking_lot 0.10.2",
+ "parking_lot 0.11.2",
  "pin-project",
  "regex",
  "serde",

--- a/chain/chain/Cargo.toml
+++ b/chain/chain/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.60.0"
 edition = "2021"
 
 [dependencies]
-actix = "=0.11.0-beta.2"
+actix = "0.12.0"
 borsh = "0.9"
 chrono = { version = "0.4.4", features = ["serde"] }
 itertools = "0.10.0"

--- a/chain/chunks/Cargo.toml
+++ b/chain/chunks/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.60.0"
 edition = "2021"
 
 [dependencies]
-actix = "=0.11.0-beta.2"
+actix = "0.12.0"
 futures = "0.3"
 rand = "0.7"
 chrono = "0.4.6"

--- a/chain/client-primitives/Cargo.toml
+++ b/chain/client-primitives/Cargo.toml
@@ -13,7 +13,7 @@ description = "This crate hosts NEAR client-related error types"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix = "=0.11.0-beta.2"
+actix = "0.12.0"
 chrono = { version = "0.4.4", features = ["serde"] }
 strum = { version = "0.20", features = ["derive"] }
 thiserror = "1.0"

--- a/chain/client/Cargo.toml
+++ b/chain/client/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 
 [dependencies]
 ansi_term = "0.12"
-actix = "=0.11.0-beta.2"
+actix = "0.12.0"
 actix-rt = "2"
 futures = "0.3"
 chrono = { version = "0.4.4", features = ["serde"] }

--- a/chain/indexer/Cargo.toml
+++ b/chain/indexer/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.60.0"
 edition = "2021"
 
 [dependencies]
-actix = "=0.11.0-beta.2"
+actix = "0.12.0"
 anyhow = "1.0.51"
 async-recursion = "0.3.2"
 tracing = "0.1.13"

--- a/chain/jsonrpc-primitives/Cargo.toml
+++ b/chain/jsonrpc-primitives/Cargo.toml
@@ -13,7 +13,7 @@ description = "This crate hosts structures for the NEAR JSON RPC Requests, Respo
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix = "=0.11.0-beta.2"
+actix = "0.12.0"
 once_cell = "1.5.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/chain/jsonrpc/Cargo.toml
+++ b/chain/jsonrpc/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.60.0"
 edition = "2021"
 
 [dependencies]
-actix = "=0.11.0-beta.2"
+actix = "0.12.0"
 actix-web = "=4.0.0-beta.6"
 actix-cors = { git = "https://github.com/near/actix-extras.git", branch="actix-web-4-beta.6" }
 easy-ext = "0.2"

--- a/chain/jsonrpc/fuzz/Cargo.toml
+++ b/chain/jsonrpc/fuzz/Cargo.toml
@@ -1,4 +1,3 @@
-
 [package]
 name = "near-jsonrpc-fuzz"
 version = "0.0.0"
@@ -13,8 +12,7 @@ cargo-fuzz = true
 
 [dependencies]
 awc = "3.0.0-beta.5"
-actix = "=0.11.0-beta.2"
-actix_derive = "=0.6.0-beta.1" # Pinned dependency in addition to actix dependecy (remove this line once the pinning is not needed)
+actix = "0.12.0"
 arbitrary = { version = "1", features = ["derive"] }
 base64 = "0.13"
 lazy_static = "1.4"

--- a/chain/jsonrpc/jsonrpc-tests/Cargo.toml
+++ b/chain/jsonrpc/jsonrpc-tests/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.60.0"
 edition = "2021"
 
 [dependencies]
-actix = "=0.11.0-beta.2"
+actix = "0.12.0"
 awc = "3.0.0-beta.5"
 once_cell = "1.5.2"
 futures = "0.3"

--- a/chain/network-primitives/Cargo.toml
+++ b/chain/network-primitives/Cargo.toml
@@ -12,8 +12,7 @@ publish = true
 
 [dependencies]
 anyhow = "1.0.51"
-actix = "=0.11.0-beta.2"
-actix_derive = "=0.6.0-beta.1" # Pinned dependency in addition to actix dependecy (remove this line once the pinning is not needed)
+actix = "0.12.0"
 borsh = "0.9"
 chrono = { version = "0.4.4", features = ["serde"] }
 deepsize = { version = "0.2.0", optional = true }

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.60.0"
 publish = false
 
 [dependencies]
-actix = "=0.11.0-beta.2"
+actix = "0.12.0"
 borsh = { version = "0.9", features = ["rc"] }
 bytes = "1"
 bytesize = "1.1"

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -12,8 +12,8 @@ use crate::types::{
 };
 use crate::PeerManagerActor;
 use actix::{
-    Actor, ActorContext, ActorFuture, Addr, Arbiter, AsyncContext, Context, ContextFutureSpawner,
-    Handler, Recipient, Running, StreamHandler, WrapFuture,
+    Actor, ActorContext, ActorFutureExt, Addr, Arbiter, AsyncContext, Context,
+    ContextFutureSpawner, Handler, Recipient, Running, StreamHandler, WrapFuture,
 };
 use borsh::{BorshDeserialize, BorshSerialize};
 use lru::LruCache;
@@ -24,6 +24,7 @@ use near_network_primitives::types::{
     RoutedMessage, RoutedMessageBody, RoutedMessageFrom, StateResponseInfo,
     UPDATE_INTERVAL_LAST_TIME_RECEIVED_MESSAGE,
 };
+
 use near_network_primitives::types::{Edge, PartialEdgeInfo};
 use near_performance_metrics::framed_write::{FramedWrite, WriteHandler};
 use near_performance_metrics_macros::perf;

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -18,7 +18,7 @@ use crate::types::{
     PeersResponse, RoutingTableUpdate,
 };
 use actix::{
-    Actor, ActorFuture, Addr, Arbiter, AsyncContext, Context, ContextFutureSpawner, Handler,
+    Actor, ActorFutureExt, Addr, Arbiter, AsyncContext, Context, ContextFutureSpawner, Handler,
     Recipient, Running, StreamHandler, WrapFuture,
 };
 #[cfg(feature = "protocol_feature_routing_exchange_algorithm")]

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -4,8 +4,8 @@ use crate::routing::graph::Graph;
 use crate::routing::routing_table_view::SAVE_PEERS_MAX_TIME;
 use crate::stats::metrics;
 use actix::{
-    Actor, ActorFuture, Addr, Context, ContextFutureSpawner, Handler, Running, SyncArbiter, System,
-    WrapFuture,
+    Actor, ActorFutureExt, Addr, Context, ContextFutureSpawner, Handler, Running, SyncArbiter,
+    System, WrapFuture,
 };
 use near_network_primitives::types::{Edge, EdgeState};
 use near_performance_metrics_macros::perf;

--- a/chain/rosetta-rpc/Cargo.toml
+++ b/chain/rosetta-rpc/Cargo.toml
@@ -16,7 +16,7 @@ lazy_static = "1.4"
 strum = { version = "0.20", features = ["derive"] }
 
 awc = "3.0.0-beta.5"
-actix = "=0.11.0-beta.2"
+actix = "0.12.0"
 actix-web = "=4.0.0-beta.6"
 actix-http = "=3.0.0-beta.6"
 actix-cors = { git = "https://github.com/near/actix-extras.git", branch="actix-web-4-beta.6" }

--- a/chain/telemetry/Cargo.toml
+++ b/chain/telemetry/Cargo.toml
@@ -12,7 +12,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 awc = "3.0.0-beta.5"
 actix-web = { version = "=4.0.0-beta.6", features = [ "openssl" ] }
 futures = "0.3"
-actix = "=0.11.0-beta.2"
+actix = "0.12.0"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 tracing = "0.1.13"

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/bin/start_mock_network.rs"
 name = "start_mock_network"
 
 [dependencies]
-actix = "=0.11.0-beta.2"
+actix = "0.12.0"
 actix-rt = "2"
 base64 = "0.11"
 borsh = "0.9"

--- a/nearcore/Cargo.toml
+++ b/nearcore/Cargo.toml
@@ -10,8 +10,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.51"
 awc = "3.0.0-beta.5"
-actix = "=0.11.0-beta.2" # Pinned the version to avoid compilation errors
-actix_derive = "=0.6.0-beta.1" # Pinned dependency in addition to actix dependecy (remove this line once the pinning is not needed)
+actix = "0.12.0"
 actix-web = "=4.0.0-beta.6"
 actix-rt = "2"
 byteorder = "1.2"

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -14,7 +14,7 @@ name = "neard"
 
 [dependencies]
 clap = { version = "3.1.6", features = ["derive"] }
-actix = "=0.11.0-beta.2"
+actix = "0.12.0"
 tracing = "0.1.13"
 openssl-probe = "0.1.2"
 near-rust-allocator-proxy = { version = "0.4", optional = true }

--- a/tools/chainsync-loadtest/Cargo.toml
+++ b/tools/chainsync-loadtest/Cargo.toml
@@ -14,7 +14,7 @@ name = "chainsync-loadtest"
 
 [dependencies]
 clap = { version = "3.1.6", features = ["derive"] }
-actix = "=0.11.0-beta.2"
+actix = "0.12.0"
 parking_lot = "0.11.2"
 openssl-probe = "0.1.4"
 futures = "0.3"

--- a/tools/indexer/example/Cargo.toml
+++ b/tools/indexer/example/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.60.0"
 edition = "2021"
 
 [dependencies]
-actix = "=0.11.0-beta.2"
+actix = "0.12.0"
 clap = "3.1.6"
 openssl-probe = "0.1.2"
 serde_json = "1.0.55"

--- a/utils/near-performance-metrics/Cargo.toml
+++ b/utils/near-performance-metrics/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.60.0"
 publish = false
 
 [dependencies]
-actix = "=0.11.0-beta.2"
+actix = "0.12.0"
 bitflags = "1.2"
 bytes = "1"
 bytesize = { version = "1.1", optional = true }

--- a/utils/near-performance-metrics/src/framed_write.rs
+++ b/utils/near-performance-metrics/src/framed_write.rs
@@ -409,7 +409,8 @@ where
     inner: UnsafeWriter<T, E, K>,
 }
 
-impl<T: 'static, E: 'static, A, K: 'static + EncoderCallBack> ActorFuture for WriterFut<T, E, A, K>
+impl<T: 'static, E: 'static, A, K: 'static + EncoderCallBack> ActorFuture<A>
+    for WriterFut<T, E, A, K>
 where
     T: AsyncWrite + Unpin,
     E: From<io::Error>,
@@ -417,7 +418,6 @@ where
     A::Context: AsyncContext<A>,
 {
     type Output = ();
-    type Actor = A;
 
     fn poll(
         self: Pin<&mut Self>,
@@ -514,7 +514,7 @@ where
     inner: UnsafeWriter<T, E, K>,
 }
 
-impl<T, E, A, K> ActorFuture for WriterDrain<T, E, A, K>
+impl<T, E, A, K> ActorFuture<A> for WriterDrain<T, E, A, K>
 where
     T: AsyncWrite + Unpin,
     E: From<io::Error>,
@@ -523,7 +523,6 @@ where
     K: EncoderCallBack,
 {
     type Output = ();
-    type Actor = A;
 
     fn poll(
         self: Pin<&mut Self>,

--- a/utils/near-rate-limiter/Cargo.toml
+++ b/utils/near-rate-limiter/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.60.0"
 publish = false
 
 [dependencies]
-actix = "=0.11.0-beta.2"
+actix = "0.12.0"
 bytes = "1.0.0"
 futures-core = "0.3.0"
 pin-project-lite = "0.2.0"


### PR DESCRIPTION
Closes https://github.com/near/nearcore/issues/5537

Updates `actix` to `v0.12.0`, resolving the compilation issue that required us to manually pin `actix_derive` in our dependency tree. Or downstream dependents of nearcore, having to copy the `Cargo.lock` into their projects.

Related: https://github.com/near/nearcore/pull/6246