### PR TITLE
add blocks with missing chunks on chain page

### DIFF
--- a/chain/chain/src/missing_chunks.rs
+++ b/chain/chain/src/missing_chunks.rs
@@ -1,6 +1,7 @@
 use near_primitives::hash::CryptoHash;
 use near_primitives::sharding::ChunkHash;
 use near_primitives::types::BlockHeight;
+use near_primitives::views::BlockStatusView;
 use std::cmp::Ordering;
 use std::collections::{
     btree_map::{self, BTreeMap},
@@ -142,6 +143,19 @@ impl<Block: BlockLike> MissingChunksPool<Block> {
                 }
             }
         }
+    }
+
+    pub fn list_blocks_by_height(&self) -> Vec<BlockStatusView> {
+        let mut rtn = Vec::new();
+        for (height, blocks_with_missing_chunks) in &self.height_idx {
+            rtn.push(
+                blocks_with_missing_chunks
+                    .iter()
+                    .map(|block| BlockStatusView::new(&height, &block))
+                    .collect::<Vec<_>>(),
+            );
+        }
+        rtn.into_iter().flatten().collect()
     }
 
     fn mark_block_as_ready(&mut self, block_hash: &BlockHash) {

--- a/chain/chain/src/missing_chunks.rs
+++ b/chain/chain/src/missing_chunks.rs
@@ -146,16 +146,15 @@ impl<Block: BlockLike> MissingChunksPool<Block> {
     }
 
     pub fn list_blocks_by_height(&self) -> Vec<BlockStatusView> {
-        let mut rtn = Vec::new();
+        let mut result = Vec::new();
         for (height, blocks_with_missing_chunks) in &self.height_idx {
-            rtn.push(
+            result.extend(
                 blocks_with_missing_chunks
                     .iter()
                     .map(|block| BlockStatusView::new(&height, &block))
-                    .collect::<Vec<_>>(),
             );
         }
-        rtn.into_iter().flatten().collect()
+        result
     }
 
     fn mark_block_as_ready(&mut self, block_hash: &BlockHash) {

--- a/chain/chain/src/missing_chunks.rs
+++ b/chain/chain/src/missing_chunks.rs
@@ -151,7 +151,7 @@ impl<Block: BlockLike> MissingChunksPool<Block> {
             result.extend(
                 blocks_with_missing_chunks
                     .iter()
-                    .map(|block| BlockStatusView::new(&height, &block))
+                    .map(|block| BlockStatusView::new(&height, &block)),
             );
         }
         result

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -802,7 +802,11 @@ impl Handler<Status> for ClientActor {
                 current_head_status: head.clone().into(),
                 current_header_head_status: self.client.chain.header_head()?.clone().into(),
                 orphans: self.client.chain.orphans().list_orphans_by_height(),
-                blocks_with_missing_chunks: self.client.chain.blocks_with_missing_chunks.list_blocks_by_height(),
+                blocks_with_missing_chunks: self
+                    .client
+                    .chain
+                    .blocks_with_missing_chunks
+                    .list_blocks_by_height(),
                 epoch_info: EpochInfoView {
                     epoch_id: head.epoch_id.0,
                     height: epoch_start_height,

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -802,6 +802,7 @@ impl Handler<Status> for ClientActor {
                 current_head_status: head.clone().into(),
                 current_header_head_status: self.client.chain.header_head()?.clone().into(),
                 orphans: self.client.chain.orphans().list_orphans_by_height(),
+                missing_chunks: self.client.chain.blocks_with_missing_chunks.list_blocks_by_height(),
                 epoch_info: EpochInfoView {
                     epoch_id: head.epoch_id.0,
                     height: epoch_start_height,

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -802,7 +802,7 @@ impl Handler<Status> for ClientActor {
                 current_head_status: head.clone().into(),
                 current_header_head_status: self.client.chain.header_head()?.clone().into(),
                 orphans: self.client.chain.orphans().list_orphans_by_height(),
-                missing_chunks: self.client.chain.blocks_with_missing_chunks.list_blocks_by_height(),
+                blocks_with_missing_chunks: self.client.chain.blocks_with_missing_chunks.list_blocks_by_height(),
                 epoch_info: EpochInfoView {
                     epoch_id: head.epoch_id.0,
                     height: epoch_start_height,

--- a/chain/jsonrpc/res/chain_info.html
+++ b/chain/jsonrpc/res/chain_info.html
@@ -57,6 +57,20 @@
                             .append($('<td colspan="2">').append("(None)"))
                         )
                     }
+
+                    let missing_chunks = data.detailed_debug_status.missing_chunks;
+                    if (missing_chunks.length > 0) {
+                        missing_chunks.forEach((orphan, index) => {
+                            $('.js-tbody-missing-chunks').append($('<tr>')
+                                .append($('<td>').append(orphan.hash))
+                                .append($('<td>').append(orphan.height))
+                            )
+                        });
+                    } else {
+                        $('.js-tbody-missing-chunks').append($('<tr>')
+                            .append($('<td colspan="2">').append("(None)"))
+                        )
+                    }
                 },
                 dataType: "json",
                 error: (errMsg, textStatus, errorThrown) => {
@@ -101,7 +115,7 @@
     </table>
     <h2>
         <p>
-            Missing Chunks Pool (Under construction)
+            Missing Chunks Pool
         </p>
     </h2>
     <table>
@@ -109,7 +123,7 @@
             <th>Hash</th>
             <th>Height</th>
         </tr></thead>
-        <tbody class="js-tbody-missing-chunks-pool">
+        <tbody class="js-tbody-missing-chunks">
         </tbody>
     </table>
 </body>

--- a/chain/jsonrpc/res/chain_info.html
+++ b/chain/jsonrpc/res/chain_info.html
@@ -58,16 +58,16 @@
                         )
                     }
 
-                    let missing_chunks = data.detailed_debug_status.missing_chunks;
-                    if (missing_chunks.length > 0) {
-                        missing_chunks.forEach((orphan, index) => {
-                            $('.js-tbody-missing-chunks').append($('<tr>')
+                    let blocks_with_missing_chunks = data.detailed_debug_status.blocks_with_missing_chunks;
+                    if (blocks_with_missing_chunks.length > 0) {
+                        blocks_with_missing_chunks.forEach((orphan, index) => {
+                            $('.js-tbody-blocks-with-missing-chunks').append($('<tr>')
                                 .append($('<td>').append(orphan.hash))
                                 .append($('<td>').append(orphan.height))
                             )
                         });
                     } else {
-                        $('.js-tbody-missing-chunks').append($('<tr>')
+                        $('.js-tbody-blocks-with-missing-chunks').append($('<tr>')
                             .append($('<td colspan="2">').append("(None)"))
                         )
                     }
@@ -123,7 +123,7 @@
             <th>Hash</th>
             <th>Height</th>
         </tr></thead>
-        <tbody class="js-tbody-missing-chunks">
+        <tbody class="js-tbody-blocks-with-missing-chunks">
         </tbody>
     </table>
 </body>

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -403,6 +403,7 @@ pub struct DetailedDebugStatus {
     pub current_head_status: BlockStatusView,
     pub current_header_head_status: BlockStatusView,
     pub orphans: Vec<BlockStatusView>,
+    pub missing_chunks: Vec<BlockStatusView>,
     pub epoch_info: EpochInfoView,
 }
 

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -403,7 +403,7 @@ pub struct DetailedDebugStatus {
     pub current_head_status: BlockStatusView,
     pub current_header_head_status: BlockStatusView,
     pub orphans: Vec<BlockStatusView>,
-    pub missing_chunks: Vec<BlockStatusView>,
+    pub blocks_with_missing_chunks: Vec<BlockStatusView>,
     pub epoch_info: EpochInfoView,
 }
 


### PR DESCRIPTION
### Description
This PR adds a section for blocks with missing chunks to the chain info debug page that displays hash and height info of those blocks.

### JIRA Issue
[CP-24](https://nearinc.atlassian.net/browse/CP-24)

### Test plan

 - Build with make neard
 - Under `nearcore` directory, launch localnet using command `nearup stop && nearup run localnet --binary-path ./target/release`
 - Open your browser and go to http://[host_address]:3030/debug/chain_info
 - Expect to see a webpage that looks similar to the one below
(Positive case TBD)

### Screenshot on localnet
<img width="1510" alt="Screen Shot 2022-04-11 at 9 24 55 AM" src="https://user-images.githubusercontent.com/98097537/162786684-4a456308-c2db-42a8-a17c-791c29720a7a.png">


### First round reviewer
 - @mm-near 