### PR TITLE
refactor: DBTransaction

### DIFF
--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -404,7 +404,7 @@ pub enum DBOp {
 }
 
 impl DBTransaction {
-    pub fn put(&mut self, col: DBCol, key: Vec<u8>, value: Vec<u8>) {
+    pub fn insert(&mut self, col: DBCol, key: Vec<u8>, value: Vec<u8>) {
         self.ops.push(DBOp::Insert { col, key, value });
     }
 

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -404,29 +404,16 @@ pub enum DBOp {
 }
 
 impl DBTransaction {
-    pub fn put<K: AsRef<[u8]>, V: AsRef<[u8]>>(&mut self, col: DBCol, key: K, value: V) {
-        self.ops.push(DBOp::Insert {
-            col,
-            key: key.as_ref().to_owned(),
-            value: value.as_ref().to_owned(),
-        });
+    pub fn put(&mut self, col: DBCol, key: Vec<u8>, value: Vec<u8>) {
+        self.ops.push(DBOp::Insert { col, key, value });
     }
 
-    pub fn update_refcount<K: AsRef<[u8]>, V: AsRef<[u8]>>(
-        &mut self,
-        col: DBCol,
-        key: K,
-        value: V,
-    ) {
-        self.ops.push(DBOp::UpdateRefcount {
-            col,
-            key: key.as_ref().to_owned(),
-            value: value.as_ref().to_owned(),
-        });
+    pub fn update_refcount(&mut self, col: DBCol, key: Vec<u8>, value: Vec<u8>) {
+        self.ops.push(DBOp::UpdateRefcount { col, key, value });
     }
 
-    pub fn delete<K: AsRef<[u8]>>(&mut self, col: DBCol, key: K) {
-        self.ops.push(DBOp::Delete { col, key: key.as_ref().to_owned() });
+    pub fn delete(&mut self, col: DBCol, key: Vec<u8>) {
+        self.ops.push(DBOp::Delete { col, key });
     }
 
     pub fn delete_all(&mut self, col: DBCol) {

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -392,11 +392,11 @@ pub const VERSION_KEY: &[u8; 7] = b"VERSION";
 pub const GENESIS_JSON_HASH_KEY: &[u8; 17] = b"GENESIS_JSON_HASH";
 pub const GENESIS_STATE_ROOTS_KEY: &[u8; 19] = b"GENESIS_STATE_ROOTS";
 
-pub struct DBTransaction {
-    pub ops: Vec<DBOp>,
+pub(crate) struct DBTransaction {
+    pub(crate) ops: Vec<DBOp>,
 }
 
-pub enum DBOp {
+pub(crate) enum DBOp {
     Insert { col: DBCol, key: Vec<u8>, value: Vec<u8> },
     UpdateRefcount { col: DBCol, key: Vec<u8>, value: Vec<u8> },
     Delete { col: DBCol, key: Vec<u8> },
@@ -404,19 +404,19 @@ pub enum DBOp {
 }
 
 impl DBTransaction {
-    pub fn insert(&mut self, col: DBCol, key: Vec<u8>, value: Vec<u8>) {
+    pub(crate) fn insert(&mut self, col: DBCol, key: Vec<u8>, value: Vec<u8>) {
         self.ops.push(DBOp::Insert { col, key, value });
     }
 
-    pub fn update_refcount(&mut self, col: DBCol, key: Vec<u8>, value: Vec<u8>) {
+    pub(crate) fn update_refcount(&mut self, col: DBCol, key: Vec<u8>, value: Vec<u8>) {
         self.ops.push(DBOp::UpdateRefcount { col, key, value });
     }
 
-    pub fn delete(&mut self, col: DBCol, key: Vec<u8>) {
+    pub(crate) fn delete(&mut self, col: DBCol, key: Vec<u8>) {
         self.ops.push(DBOp::Delete { col, key });
     }
 
-    pub fn delete_all(&mut self, col: DBCol) {
+    pub(crate) fn delete_all(&mut self, col: DBCol) {
         self.ops.push(DBOp::DeleteAll { col });
     }
 }
@@ -583,7 +583,7 @@ pub struct TestDB {
     db: RwLock<Vec<HashMap<Vec<u8>, Vec<u8>>>>,
 }
 
-pub trait Database: Sync + Send {
+pub(crate) trait Database: Sync + Send {
     fn transaction(&self) -> DBTransaction {
         DBTransaction { ops: Vec::new() }
     }

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -48,7 +48,7 @@ pub struct Store {
 }
 
 impl Store {
-    pub fn new(storage: Arc<dyn Database>) -> Store {
+    pub(crate) fn new(storage: Arc<dyn Database>) -> Store {
         Store { storage }
     }
 
@@ -155,7 +155,7 @@ pub struct StoreUpdate {
 }
 
 impl StoreUpdate {
-    pub fn new(storage: Arc<dyn Database>) -> Self {
+    pub(crate) fn new(storage: Arc<dyn Database>) -> Self {
         let transaction = storage.transaction();
         StoreUpdate { storage, transaction, tries: None }
     }

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -132,7 +132,7 @@ impl Store {
             let mut value = vec![0; value_len];
             file.read_exact(&mut value)?;
 
-            transaction.put(column, key, value);
+            transaction.insert(column, key, value);
         }
         self.storage.write(transaction).map_err(io::Error::from)
     }
@@ -173,7 +173,7 @@ impl StoreUpdate {
     }
 
     pub fn set(&mut self, column: DBCol, key: &[u8], value: &[u8]) {
-        self.transaction.put(column, key.to_vec(), value.to_vec())
+        self.transaction.insert(column, key.to_vec(), value.to_vec())
     }
 
     pub fn set_ser<T: BorshSerialize>(
@@ -211,7 +211,7 @@ impl StoreUpdate {
     fn merge_transaction(&mut self, transaction: DBTransaction) {
         for op in transaction.ops {
             match op {
-                DBOp::Insert { col, key, value } => self.transaction.put(col, key, value),
+                DBOp::Insert { col, key, value } => self.transaction.insert(col, key, value),
                 DBOp::Delete { col, key } => self.transaction.delete(col, key),
                 DBOp::UpdateRefcount { col, key, value } => {
                     self.transaction.update_refcount(col, key, value)

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -79,7 +79,7 @@ impl ShardTries {
         self.0.store.clone()
     }
 
-    pub fn update_cache(&self, transaction: &DBTransaction) -> std::io::Result<()> {
+    pub(crate) fn update_cache(&self, transaction: &DBTransaction) -> std::io::Result<()> {
         let mut caches = self.0.caches.write().expect(POISONED_LOCK_ERR);
         let mut shards = HashMap::new();
         for op in &transaction.ops {

--- a/integration-tests/src/mock_network/setup.rs
+++ b/integration-tests/src/mock_network/setup.rs
@@ -17,8 +17,8 @@ use near_primitives::network::PeerId;
 use near_primitives::state_part::PartId;
 use near_primitives::syncing::get_num_state_parts;
 use near_primitives::types::BlockHeight;
-use near_store::db::TestDB;
-use near_store::{create_store, Store};
+use near_store::create_store;
+use near_store::test_utils::create_test_store;
 use near_telemetry::TelemetryActor;
 use nearcore::{get_store_path, NearConfig, NightshadeRuntime};
 use regex::Regex;
@@ -38,7 +38,7 @@ fn setup_runtime(
     in_memory_storage: bool,
 ) -> Arc<NightshadeRuntime> {
     let store = if in_memory_storage {
-        Store::new(Arc::new(TestDB::new()))
+        create_test_store()
     } else {
         let path = get_store_path(home_dir);
         create_store(&path)

--- a/tools/chainsync-loadtest/src/main.rs
+++ b/tools/chainsync-loadtest/src/main.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use actix::{Actor, Arbiter};
 use anyhow::{anyhow, Context};
 use clap::Parser;
+use near_store::test_utils::create_test_store;
 use openssl_probe;
 
 use concurrency::{Ctx, Scope};
@@ -19,14 +20,13 @@ use near_network::PeerManagerActor;
 use near_o11y::tracing::{error, info};
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
-use near_store::{db, Store};
 use nearcore::config;
 use nearcore::config::NearConfig;
 
 pub fn start_with_config(config: NearConfig, qps_limit: u32) -> anyhow::Result<Arc<Network>> {
     config.network_config.verify().context("start_with_config")?;
     let node_id = PeerId::new(config.network_config.public_key.clone());
-    let store = Store::new(Arc::new(db::TestDB::new()));
+    let store = create_test_store();
 
     let network_adapter = Arc::new(NetworkRecipient::default());
     let network = Network::new(&config, network_adapter.clone(), qps_limit);


### PR DESCRIPTION
Two related tangentially-related changes here:

* Remove extra clones from DBTrasaction by make its API more natural in terms of ownership
* And then make it and related things private to near_store, and not world-visible