### PR TITLE
feat: separate counter for chunk nodes cache

### DIFF
--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -14,6 +14,7 @@ use crate::trie_key::TrieKey;
 use crate::receipt::Receipt;
 /// Reexport primitive types
 pub use near_primitives_core::types::*;
+use std::ops::Sub;
 
 /// Hash used by to store state root.
 pub type StateRoot = CryptoHash;
@@ -989,4 +990,24 @@ pub enum TrieCacheMode {
     /// only once during a single chunk processing. Such nodes remain in cache until the chunk processing is finished,
     /// and thus users (potentially different) are not required to pay twice for retrieval of the same node.
     CachingChunk,
+}
+
+/// Counts accessed trie nodes during tx/receipt execution for proper storage costs charging.
+#[derive(Debug)]
+pub struct TrieNodesCount {
+    /// Number of nodes read from storage or shard cache.
+    pub touches: u64,
+    /// Number of nodes read from the chunk cache.
+    pub chunk_cache_reads: u64,
+}
+
+impl Sub for TrieNodesCount {
+    type Output = Self;
+
+    fn sub(self, other: Self) -> Self::Output {
+        Self {
+            touches: self.touches - other.touches,
+            chunk_cache_reads: self.chunk_cache_reads - other.chunk_cache_reads,
+        }
+    }
 }

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -20,6 +20,7 @@ pub use crate::trie::shard_tries::{KeyForStateChanges, ShardTries, WrappedTrieCh
 pub(crate) use crate::trie::trie_storage::{TrieCache, TrieCachingStorage};
 use crate::trie::trie_storage::{TrieMemoryPartialStorage, TrieRecordingStorage, TrieStorage};
 use crate::StorageError;
+pub use near_primitives::types::TrieNodesCount;
 
 mod insert_delete;
 pub mod iterator;
@@ -751,8 +752,8 @@ impl Trie {
         TrieIterator::new(self, root)
     }
 
-    pub fn get_touched_nodes_count(&self) -> u64 {
-        self.storage.get_touched_nodes_count()
+    pub fn get_trie_nodes_count(&self) -> TrieNodesCount {
+        self.storage.get_trie_nodes_count()
     }
 }
 

--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -172,7 +172,8 @@ pub struct TrieCachingStorage {
     pub(crate) chunk_cache: RefCell<HashMap<CryptoHash, Arc<[u8]>>>,
     pub(crate) cache_mode: Cell<TrieCacheMode>,
 
-    /// Counts trie nodes retrieved from storage or shard cache.
+    /// Counts potentially expensive trie node reads which are served from disk in the worst case. Here we count reads
+    /// from DB or shard cache.
     pub(crate) db_read_nodes: Cell<u64>,
     /// Counts trie nodes retrieved from the chunk cache.
     pub(crate) mem_read_nodes: Cell<u64>,

--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -9,7 +9,7 @@ use crate::trie::POISONED_LOCK_ERR;
 use crate::{ColState, StorageError, Store};
 use lru::LruCache;
 use near_primitives::shard_layout::ShardUId;
-use near_primitives::types::TrieCacheMode;
+use near_primitives::types::{TrieCacheMode, TrieNodesCount};
 use std::cell::{Cell, RefCell};
 use std::io::ErrorKind;
 
@@ -76,7 +76,7 @@ pub trait TrieStorage {
         None
     }
 
-    fn get_touched_nodes_count(&self) -> u64;
+    fn get_trie_nodes_count(&self) -> TrieNodesCount;
 }
 
 /// Records every value read by retrieve_raw_bytes.
@@ -110,7 +110,7 @@ impl TrieStorage for TrieRecordingStorage {
         Some(self)
     }
 
-    fn get_touched_nodes_count(&self) -> u64 {
+    fn get_trie_nodes_count(&self) -> TrieNodesCount {
         unimplemented!();
     }
 }
@@ -138,7 +138,7 @@ impl TrieStorage for TrieMemoryPartialStorage {
         Some(self)
     }
 
-    fn get_touched_nodes_count(&self) -> u64 {
+    fn get_trie_nodes_count(&self) -> TrieNodesCount {
         unimplemented!();
     }
 }
@@ -172,8 +172,10 @@ pub struct TrieCachingStorage {
     pub(crate) chunk_cache: RefCell<HashMap<CryptoHash, Arc<[u8]>>>,
     pub(crate) cache_mode: Cell<TrieCacheMode>,
 
-    /// Counts retrieved trie nodes. Used to compute gas cost for touching trie nodes.
-    pub(crate) counter: Cell<u64>,
+    /// Counts trie nodes retrieved from storage or shard cache.
+    pub(crate) touched_nodes: Cell<u64>,
+    /// Counts trie nodes retrieved from the chunk cache.
+    pub(crate) chunk_cache_reads: Cell<u64>,
 }
 
 impl TrieCachingStorage {
@@ -184,7 +186,8 @@ impl TrieCachingStorage {
             shard_cache,
             cache_mode: Cell::new(TrieCacheMode::CachingShard),
             chunk_cache: RefCell::new(Default::default()),
-            counter: Cell::new(0u64),
+            touched_nodes: Cell::new(0),
+            chunk_cache_reads: Cell::new(0),
         }
     }
 
@@ -209,8 +212,12 @@ impl TrieCachingStorage {
         key
     }
 
-    fn inc_counter(&self) {
-        self.counter.set(self.counter.get() + 1);
+    fn inc_touched_nodes(&self) {
+        self.touched_nodes.set(self.touched_nodes.get() + 1);
+    }
+
+    fn inc_chunk_cache_reads(&self) {
+        self.chunk_cache_reads.set(self.chunk_cache_reads.get() + 1);
     }
 
     /// Set cache mode.
@@ -223,6 +230,7 @@ impl TrieStorage for TrieCachingStorage {
     fn retrieve_raw_bytes(&self, hash: &CryptoHash) -> Result<Arc<[u8]>, StorageError> {
         // Try to get value from chunk cache containing free of charge nodes.
         if let Some(val) = self.chunk_cache.borrow_mut().get(hash) {
+            self.inc_chunk_cache_reads();
             return Ok(val.clone());
         }
 
@@ -264,7 +272,7 @@ impl TrieStorage for TrieCachingStorage {
         // - - size of trie keys and values is limited by receipt gas limit / lowest per byte fee
         // (`storage_read_value_byte`) ~= (500 * 10**12 / 5611005) / 2**20 ~= 85 MB.
         // All values are given as of 16/03/2022. We may consider more precise limit for the chunk cache as well.
-        self.inc_counter();
+        self.inc_touched_nodes();
         if let TrieCacheMode::CachingChunk = self.cache_mode.borrow().get() {
             self.chunk_cache.borrow_mut().insert(*hash, val.clone());
         };
@@ -276,7 +284,10 @@ impl TrieStorage for TrieCachingStorage {
         Some(self)
     }
 
-    fn get_touched_nodes_count(&self) -> u64 {
-        self.counter.get()
+    fn get_trie_nodes_count(&self) -> TrieNodesCount {
+        TrieNodesCount {
+            touches: self.touched_nodes.get(),
+            chunk_cache_reads: self.chunk_cache_reads.get(),
+        }
     }
 }

--- a/core/store/src/trie/trie_tests.rs
+++ b/core/store/src/trie/trie_tests.rs
@@ -163,10 +163,10 @@ mod nodes_counter_tests {
         items
             .iter()
             .map(|(key, value)| {
-                let initial_count = trie.get_trie_nodes_count().touches;
+                let initial_count = trie.get_trie_nodes_count().db_reads;
                 let got_value = trie.get(&state_root, key).unwrap();
                 assert_eq!(*value, got_value);
-                trie.get_trie_nodes_count().touches - initial_count
+                trie.get_trie_nodes_count().db_reads - initial_count
             })
             .collect()
     }
@@ -251,8 +251,8 @@ mod caching_storage_tests {
             let result = trie_caching_storage.retrieve_raw_bytes(&key);
             let count_delta = trie_caching_storage.get_trie_nodes_count() - count_before;
             assert_eq!(result.unwrap().as_ref(), value);
-            assert_eq!(count_delta.touches, 1);
-            assert_eq!(count_delta.chunk_cache_reads, 0);
+            assert_eq!(count_delta.db_reads, 1);
+            assert_eq!(count_delta.mem_reads, 0);
             assert_eq!(trie_cache.get(&key).unwrap().as_ref(), value);
         }
     }
@@ -289,8 +289,8 @@ mod caching_storage_tests {
         let count_delta = trie_caching_storage.get_trie_nodes_count() - count_before;
         assert_eq!(trie_cache.get(&key), None);
         assert_eq!(result.unwrap().as_ref(), value);
-        assert_eq!(count_delta.touches, 0);
-        assert_eq!(count_delta.chunk_cache_reads, 1);
+        assert_eq!(count_delta.db_reads, 0);
+        assert_eq!(count_delta.mem_reads, 1);
     }
 
     /// Check that positions of item and costs of its retrieval are returned correctly.
@@ -318,16 +318,16 @@ mod caching_storage_tests {
         let result = trie_caching_storage.retrieve_raw_bytes(&key);
         let count_delta = trie_caching_storage.get_trie_nodes_count() - count_before;
         assert_eq!(result.unwrap().as_ref(), value);
-        assert_eq!(count_delta.touches, 1);
-        assert_eq!(count_delta.chunk_cache_reads, 0);
+        assert_eq!(count_delta.db_reads, 1);
+        assert_eq!(count_delta.mem_reads, 0);
 
         // After previous retrieval, item must be copied to chunk cache. Retrieval shouldn't increment the counter.
         let count_before = trie_caching_storage.get_trie_nodes_count();
         let result = trie_caching_storage.retrieve_raw_bytes(&key);
         let count_delta = trie_caching_storage.get_trie_nodes_count() - count_before;
         assert_eq!(result.unwrap().as_ref(), value);
-        assert_eq!(count_delta.touches, 0);
-        assert_eq!(count_delta.chunk_cache_reads, 1);
+        assert_eq!(count_delta.db_reads, 0);
+        assert_eq!(count_delta.mem_reads, 1);
 
         // Even if we switch to caching shard, retrieval shouldn't increment the counter. Chunk cache only grows and is
         // dropped only when trie caching storage is dropped.
@@ -336,8 +336,8 @@ mod caching_storage_tests {
         let result = trie_caching_storage.retrieve_raw_bytes(&key);
         let count_delta = trie_caching_storage.get_trie_nodes_count() - count_before;
         assert_eq!(result.unwrap().as_ref(), value);
-        assert_eq!(count_delta.touches, 0);
-        assert_eq!(count_delta.chunk_cache_reads, 1);
+        assert_eq!(count_delta.db_reads, 0);
+        assert_eq!(count_delta.mem_reads, 1);
     }
 
     /// Check that if an item present in chunk cache gets evicted from the shard cache, it stays in the chunk cache.
@@ -369,7 +369,7 @@ mod caching_storage_tests {
         let result = trie_caching_storage.retrieve_raw_bytes(&key);
         let count_delta = trie_caching_storage.get_trie_nodes_count() - count_before;
         assert_eq!(result.unwrap().as_ref(), value);
-        assert_eq!(count_delta.touches, 0);
-        assert_eq!(count_delta.chunk_cache_reads, 1);
+        assert_eq!(count_delta.db_reads, 0);
+        assert_eq!(count_delta.mem_reads, 1);
     }
 }

--- a/core/store/src/trie/trie_tests.rs
+++ b/core/store/src/trie/trie_tests.rs
@@ -4,6 +4,7 @@ use crate::{PartialStorage, Trie, TrieUpdate};
 use near_primitives::errors::StorageError;
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::shard_layout::ShardUId;
+use near_primitives::types::TrieNodesCount;
 use rand::seq::SliceRandom;
 use rand::Rng;
 use std::cell::RefCell;
@@ -54,7 +55,7 @@ impl TrieStorage for IncompletePartialStorage {
         unimplemented!()
     }
 
-    fn get_touched_nodes_count(&self) -> u64 {
+    fn get_trie_nodes_count(&self) -> TrieNodesCount {
         unimplemented!();
     }
 }
@@ -162,10 +163,10 @@ mod nodes_counter_tests {
         items
             .iter()
             .map(|(key, value)| {
-                let initial_counter = trie.get_touched_nodes_count();
+                let initial_count = trie.get_trie_nodes_count().touches;
                 let got_value = trie.get(&state_root, key).unwrap();
                 assert_eq!(*value, got_value);
-                trie.get_touched_nodes_count() - initial_counter
+                trie.get_trie_nodes_count().touches - initial_count
             })
             .collect()
     }
@@ -246,11 +247,12 @@ mod caching_storage_tests {
         assert_eq!(trie_cache.get(&key), None);
 
         for _ in 0..2 {
-            let count_before = trie_caching_storage.get_touched_nodes_count();
+            let count_before = trie_caching_storage.get_trie_nodes_count();
             let result = trie_caching_storage.retrieve_raw_bytes(&key);
-            let count_after = trie_caching_storage.get_touched_nodes_count();
+            let count_delta = trie_caching_storage.get_trie_nodes_count() - count_before;
             assert_eq!(result.unwrap().as_ref(), value);
-            assert_eq!(count_before + 1, count_after);
+            assert_eq!(count_delta.touches, 1);
+            assert_eq!(count_delta.chunk_cache_reads, 0);
             assert_eq!(trie_cache.get(&key).unwrap().as_ref(), value);
         }
     }
@@ -282,12 +284,13 @@ mod caching_storage_tests {
         trie_caching_storage.set_mode(TrieCacheMode::CachingChunk);
         let _ = trie_caching_storage.retrieve_raw_bytes(&key);
 
-        let count_before = trie_caching_storage.get_touched_nodes_count();
+        let count_before = trie_caching_storage.get_trie_nodes_count();
         let result = trie_caching_storage.retrieve_raw_bytes(&key);
-        let count_after = trie_caching_storage.get_touched_nodes_count();
+        let count_delta = trie_caching_storage.get_trie_nodes_count() - count_before;
         assert_eq!(trie_cache.get(&key), None);
         assert_eq!(result.unwrap().as_ref(), value);
-        assert_eq!(count_before, count_after);
+        assert_eq!(count_delta.touches, 0);
+        assert_eq!(count_delta.chunk_cache_reads, 1);
     }
 
     /// Check that positions of item and costs of its retrieval are returned correctly.
@@ -311,27 +314,30 @@ mod caching_storage_tests {
         // Move to CachingChunk mode. Retrieval should increment the counter, because it is the first time we accessed
         // item while caching chunk.
         trie_caching_storage.set_mode(TrieCacheMode::CachingChunk);
-        let count_before = trie_caching_storage.get_touched_nodes_count();
+        let count_before = trie_caching_storage.get_trie_nodes_count();
         let result = trie_caching_storage.retrieve_raw_bytes(&key);
-        let count_after = trie_caching_storage.get_touched_nodes_count();
+        let count_delta = trie_caching_storage.get_trie_nodes_count() - count_before;
         assert_eq!(result.unwrap().as_ref(), value);
-        assert_eq!(count_before + 1, count_after);
+        assert_eq!(count_delta.touches, 1);
+        assert_eq!(count_delta.chunk_cache_reads, 0);
 
         // After previous retrieval, item must be copied to chunk cache. Retrieval shouldn't increment the counter.
-        let count_before = trie_caching_storage.get_touched_nodes_count();
+        let count_before = trie_caching_storage.get_trie_nodes_count();
         let result = trie_caching_storage.retrieve_raw_bytes(&key);
-        let count_after = trie_caching_storage.get_touched_nodes_count();
+        let count_delta = trie_caching_storage.get_trie_nodes_count() - count_before;
         assert_eq!(result.unwrap().as_ref(), value);
-        assert_eq!(count_before, count_after);
+        assert_eq!(count_delta.touches, 0);
+        assert_eq!(count_delta.chunk_cache_reads, 1);
 
         // Even if we switch to caching shard, retrieval shouldn't increment the counter. Chunk cache only grows and is
         // dropped only when trie caching storage is dropped.
         trie_caching_storage.set_mode(TrieCacheMode::CachingShard);
-        let count_before = trie_caching_storage.get_touched_nodes_count();
+        let count_before = trie_caching_storage.get_trie_nodes_count();
         let result = trie_caching_storage.retrieve_raw_bytes(&key);
-        let count_after = trie_caching_storage.get_touched_nodes_count();
+        let count_delta = trie_caching_storage.get_trie_nodes_count() - count_before;
         assert_eq!(result.unwrap().as_ref(), value);
-        assert_eq!(count_before, count_after);
+        assert_eq!(count_delta.touches, 0);
+        assert_eq!(count_delta.chunk_cache_reads, 1);
     }
 
     /// Check that if an item present in chunk cache gets evicted from the shard cache, it stays in the chunk cache.
@@ -359,10 +365,11 @@ mod caching_storage_tests {
 
         // Check that the first element gets evicted, but the counter is not incremented.
         assert_eq!(trie_cache.get(&key), None);
-        let count_before = trie_caching_storage.get_touched_nodes_count();
+        let count_before = trie_caching_storage.get_trie_nodes_count();
         let result = trie_caching_storage.retrieve_raw_bytes(&key);
-        let count_after = trie_caching_storage.get_touched_nodes_count();
+        let count_delta = trie_caching_storage.get_trie_nodes_count() - count_before;
         assert_eq!(result.unwrap().as_ref(), value);
-        assert_eq!(count_before, count_after);
+        assert_eq!(count_delta.touches, 0);
+        assert_eq!(count_delta.chunk_cache_reads, 1);
     }
 }

--- a/runtime/near-vm-logic/src/dependencies.rs
+++ b/runtime/near-vm-logic/src/dependencies.rs
@@ -1,6 +1,7 @@
 //! External dependencies of the near-vm-logic.
 
 use near_primitives::hash::CryptoHash;
+use near_primitives::types::TrieNodesCount;
 use near_primitives_core::types::{AccountId, Balance};
 use near_vm_errors::VMLogicError;
 
@@ -165,7 +166,7 @@ pub trait External {
     fn generate_data_id(&mut self) -> CryptoHash;
 
     /// Returns amount of touched trie nodes by storage operations
-    fn get_touched_nodes_count(&self) -> u64;
+    fn get_trie_nodes_count(&self) -> TrieNodesCount;
 
     /// Returns the validator stake for given account in the current epoch.
     /// If the account is not a validator, returns `None`.

--- a/runtime/near-vm-logic/src/logic.rs
+++ b/runtime/near-vm-logic/src/logic.rs
@@ -2340,7 +2340,7 @@ impl<'a> VMLogic<'a> {
         let evicted =
             Self::deref_value(&mut self.gas_counter, storage_write_evicted_byte, evicted_ptr)?;
         let nodes_delta = self.ext.get_trie_nodes_count() - nodes_before;
-        self.gas_counter.pay_per(touching_trie_node, nodes_delta.touches)?;
+        self.gas_counter.pay_per(touching_trie_node, nodes_delta.db_reads)?;
         self.ext.storage_set(&key, &value)?;
         let storage_config = &self.fees_config.storage_usage_config;
         match evicted {
@@ -2419,7 +2419,7 @@ impl<'a> VMLogic<'a> {
         let nodes_before = self.ext.get_trie_nodes_count();
         let read = self.ext.storage_get(&key);
         let nodes_delta = self.ext.get_trie_nodes_count() - nodes_before;
-        self.gas_counter.pay_per(touching_trie_node, nodes_delta.touches)?;
+        self.gas_counter.pay_per(touching_trie_node, nodes_delta.db_reads)?;
         let read = Self::deref_value(&mut self.gas_counter, storage_read_value_byte, read?)?;
         match read {
             Some(value) => {
@@ -2473,7 +2473,7 @@ impl<'a> VMLogic<'a> {
 
         self.ext.storage_remove(&key)?;
         let nodes_delta = self.ext.get_trie_nodes_count() - nodes_before;
-        self.gas_counter.pay_per(touching_trie_node, nodes_delta.touches)?;
+        self.gas_counter.pay_per(touching_trie_node, nodes_delta.db_reads)?;
         let storage_config = &self.fees_config.storage_usage_config;
         match removed {
             Some(value) => {
@@ -2520,7 +2520,7 @@ impl<'a> VMLogic<'a> {
         let nodes_before = self.ext.get_trie_nodes_count();
         let res = self.ext.storage_has_key(&key);
         let nodes_delta = self.ext.get_trie_nodes_count() - nodes_before;
-        self.gas_counter.pay_per(touching_trie_node, nodes_delta.touches)?;
+        self.gas_counter.pay_per(touching_trie_node, nodes_delta.db_reads)?;
         Ok(res? as u64)
     }
 

--- a/runtime/near-vm-logic/src/logic.rs
+++ b/runtime/near-vm-logic/src/logic.rs
@@ -2335,12 +2335,12 @@ impl<'a> VMLogic<'a> {
         }
         self.gas_counter.pay_per(storage_write_key_byte, key.len() as u64)?;
         self.gas_counter.pay_per(storage_write_value_byte, value.len() as u64)?;
-        let nodes_before = self.ext.get_touched_nodes_count();
+        let nodes_before = self.ext.get_trie_nodes_count();
         let evicted_ptr = self.ext.storage_get(&key)?;
         let evicted =
             Self::deref_value(&mut self.gas_counter, storage_write_evicted_byte, evicted_ptr)?;
-        self.gas_counter
-            .pay_per(touching_trie_node, self.ext.get_touched_nodes_count() - nodes_before)?;
+        let nodes_delta = self.ext.get_trie_nodes_count() - nodes_before;
+        self.gas_counter.pay_per(touching_trie_node, nodes_delta.touches)?;
         self.ext.storage_set(&key, &value)?;
         let storage_config = &self.fees_config.storage_usage_config;
         match evicted {
@@ -2416,10 +2416,10 @@ impl<'a> VMLogic<'a> {
             .into());
         }
         self.gas_counter.pay_per(storage_read_key_byte, key.len() as u64)?;
-        let nodes_before = self.ext.get_touched_nodes_count();
+        let nodes_before = self.ext.get_trie_nodes_count();
         let read = self.ext.storage_get(&key);
-        self.gas_counter
-            .pay_per(touching_trie_node, self.ext.get_touched_nodes_count() - nodes_before)?;
+        let nodes_delta = self.ext.get_trie_nodes_count() - nodes_before;
+        self.gas_counter.pay_per(touching_trie_node, nodes_delta.touches)?;
         let read = Self::deref_value(&mut self.gas_counter, storage_read_value_byte, read?)?;
         match read {
             Some(value) => {
@@ -2466,14 +2466,14 @@ impl<'a> VMLogic<'a> {
             .into());
         }
         self.gas_counter.pay_per(storage_remove_key_byte, key.len() as u64)?;
-        let nodes_before = self.ext.get_touched_nodes_count();
+        let nodes_before = self.ext.get_trie_nodes_count();
         let removed_ptr = self.ext.storage_get(&key)?;
         let removed =
             Self::deref_value(&mut self.gas_counter, storage_remove_ret_value_byte, removed_ptr)?;
 
         self.ext.storage_remove(&key)?;
-        self.gas_counter
-            .pay_per(touching_trie_node, self.ext.get_touched_nodes_count() - nodes_before)?;
+        let nodes_delta = self.ext.get_trie_nodes_count() - nodes_before;
+        self.gas_counter.pay_per(touching_trie_node, nodes_delta.touches)?;
         let storage_config = &self.fees_config.storage_usage_config;
         match removed {
             Some(value) => {
@@ -2517,10 +2517,10 @@ impl<'a> VMLogic<'a> {
             .into());
         }
         self.gas_counter.pay_per(storage_has_key_byte, key.len() as u64)?;
-        let nodes_before = self.ext.get_touched_nodes_count();
+        let nodes_before = self.ext.get_trie_nodes_count();
         let res = self.ext.storage_has_key(&key);
-        self.gas_counter
-            .pay_per(touching_trie_node, self.ext.get_touched_nodes_count() - nodes_before)?;
+        let nodes_delta = self.ext.get_trie_nodes_count() - nodes_before;
+        self.gas_counter.pay_per(touching_trie_node, nodes_delta.touches)?;
         Ok(res? as u64)
     }
 

--- a/runtime/near-vm-logic/src/mocks/mock_external.rs
+++ b/runtime/near-vm-logic/src/mocks/mock_external.rs
@@ -1,5 +1,6 @@
 use crate::{External, ValuePtr};
 use near_primitives::hash::{hash, CryptoHash};
+use near_primitives::types::TrieNodesCount;
 use near_primitives_core::types::{AccountId, Balance, Gas};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -79,8 +80,8 @@ impl External for MockedExternal {
         data_id
     }
 
-    fn get_touched_nodes_count(&self) -> u64 {
-        0
+    fn get_trie_nodes_count(&self) -> TrieNodesCount {
+        TrieNodesCount { touches: 0, chunk_cache_reads: 0 }
     }
 
     fn validator_stake(&self, account_id: &AccountId) -> Result<Option<Balance>> {

--- a/runtime/near-vm-logic/src/mocks/mock_external.rs
+++ b/runtime/near-vm-logic/src/mocks/mock_external.rs
@@ -81,7 +81,7 @@ impl External for MockedExternal {
     }
 
     fn get_trie_nodes_count(&self) -> TrieNodesCount {
-        TrieNodesCount { touches: 0, chunk_cache_reads: 0 }
+        TrieNodesCount { db_reads: 0, mem_reads: 0 }
     }
 
     fn validator_stake(&self, account_id: &AccountId) -> Result<Option<Balance>> {

--- a/runtime/runtime/src/ext.rs
+++ b/runtime/runtime/src/ext.rs
@@ -6,7 +6,9 @@ use near_primitives::contract::ContractCode;
 use near_primitives::errors::{EpochError, StorageError};
 use near_primitives::hash::CryptoHash;
 use near_primitives::trie_key::{trie_key_parsers, TrieKey};
-use near_primitives::types::{AccountId, Balance, EpochId, EpochInfoProvider, TrieCacheMode};
+use near_primitives::types::{
+    AccountId, Balance, EpochId, EpochInfoProvider, TrieCacheMode, TrieNodesCount,
+};
 use near_primitives::utils::create_data_id;
 use near_primitives::version::ProtocolVersion;
 use near_store::{get_code, TrieUpdate, TrieUpdateValuePtr};
@@ -172,8 +174,8 @@ impl<'a> External for RuntimeExt<'a> {
         data_id
     }
 
-    fn get_touched_nodes_count(&self) -> u64 {
-        self.trie_update.trie.get_touched_nodes_count()
+    fn get_trie_nodes_count(&self) -> TrieNodesCount {
+        self.trie_update.trie.get_trie_nodes_count()
     }
 
     fn validator_stake(&self, account_id: &AccountId) -> ExtResult<Option<Balance>> {

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1268,7 +1268,7 @@ impl Runtime {
                                    state_update: &mut TrieUpdate,
                                    total_gas_burnt: &mut Gas|
          -> Result<_, RuntimeError> {
-            let _span = tracing::debug_span!(target: "runtime", "Runtime::process_receipt", receipt_id = %receipt.receipt_id, node_counter = state_update.trie.get_touched_nodes_count()).entered();
+            let _span = tracing::debug_span!(target: "runtime", "Runtime::process_receipt", receipt_id = %receipt.receipt_id, node_counter = ?state_update.trie.get_trie_nodes_count()).entered();
             let result = self.process_receipt(
                 state_update,
                 apply_state,
@@ -1278,7 +1278,7 @@ impl Runtime {
                 &mut stats,
                 epoch_info_provider,
             );
-            tracing::debug!(target: "runtime", node_counter = state_update.trie.get_touched_nodes_count());
+            tracing::debug!(target: "runtime", node_counter = ?state_update.trie.get_trie_nodes_count());
             result?.into_iter().try_for_each(
                 |outcome_with_id: ExecutionOutcomeWithId| -> Result<(), RuntimeError> {
                     *total_gas_burnt =


### PR DESCRIPTION
Recent experiments show that cost for reading kv pair from the chunk cache should be somewhere between 37 and 200 Mgas. Given that we use a safety multiplier 3 and that we could build an example where ~1M nodes are read from the chunk cache, we have to add the new cost to the runtime config.

The first step is adding a separate counter for that, and updating trie storage tests appropriately. This PR shouldn't affect the protocol in any way.

Next steps will be:
* add new cost to runtime config with an estimation function
* return to https://github.com/near/nearcore/pull/6450 and charge this cost there

## Testing

* Updating trie storage tests.
