### PR TITLE
Increase the secondary stack cleck limit

### DIFF
--- a/core/primitives-core/src/config.rs
+++ b/core/primitives-core/src/config.rs
@@ -84,6 +84,15 @@ pub struct VMLimitConfig {
     /// If present, stores max number of functions in one contract
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_functions_number_per_contract: Option<u64>,
+    /// If present, stores the secondary stack limit as implemented by wasmer2.
+    ///
+    /// This limit should never be hit normally.
+    #[serde(default="wasmer2_stack_limit_default")]
+    pub wasmer2_stack_limit: i32,
+}
+
+fn wasmer2_stack_limit_default() -> i32 {
+    100 * 1024
 }
 
 /// Our original code for limiting WASM stack was buggy. We fixed that, but we
@@ -216,6 +225,7 @@ impl VMLimitConfig {
             // Unlikely to hit it for normal development.
             max_number_input_data_dependencies: 128,
             max_functions_number_per_contract: None,
+            wasmer2_stack_limit: 200 * 1024,
         }
     }
 }

--- a/core/primitives-core/src/config.rs
+++ b/core/primitives-core/src/config.rs
@@ -87,7 +87,7 @@ pub struct VMLimitConfig {
     /// If present, stores the secondary stack limit as implemented by wasmer2.
     ///
     /// This limit should never be hit normally.
-    #[serde(default="wasmer2_stack_limit_default")]
+    #[serde(default = "wasmer2_stack_limit_default")]
     pub wasmer2_stack_limit: i32,
 }
 

--- a/core/primitives/res/runtime_configs/53.json
+++ b/core/primitives/res/runtime_configs/53.json
@@ -183,7 +183,8 @@
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
       "max_number_input_data_dependencies": 128,
-      "max_functions_number_per_contract": 10000
+      "max_functions_number_per_contract": 10000,
+      "wasmer2_stack_limit": 204800
     }
   },
   "account_creation_config": {

--- a/core/primitives/src/runtime/config_store.rs
+++ b/core/primitives/src/runtime/config_store.rs
@@ -22,6 +22,7 @@ static CONFIGS: &[(ProtocolVersion, &[u8])] = &[
     (50, include_config!("50.json")),
     // max_gas_burnt increased to 300 TGas
     (52, include_config!("52.json")),
+    // Increased deployment costs, increased wasmer2 stack_limit
     (53, include_config!("53.json")),
 ];
 
@@ -123,7 +124,7 @@ mod tests {
             "2cuq2HvuHT7Z27LUbgEtMxP2ejqrHK34J2V1GL1joiMn",
             "HFetcNKaC5s8Mj7bQz7jGMF7Rsvtuc3kjZRevWQ334n4",
             "EP9bv2znwbuBuimUgrSQm48ymHqwbHyUArZcWavSbPce",
-            "Gs3KXwHmXYGghRZvcVNGXVpbJxVF5SDRNMB3f32DiXUF",
+            "3i1T4Gg7JR8SgBDBQxeRUQ4FCgtjKvthC9LQ685zk7Qa",
         ];
         let actual_hashes = CONFIGS
             .iter()

--- a/runtime/near-vm-runner/src/wasmer2_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer2_runner.rs
@@ -374,7 +374,9 @@ impl Wasmer2VM {
                         // expected layout. `gas` remains dereferenceable throughout this function
                         // by the virtue of it being contained within `import` which lives for the
                         // entirety of this function.
-                        InstanceConfig::default().with_counter(gas),
+                        InstanceConfig::default()
+                            .with_counter(gas)
+                            .with_stack_limit(self.config.limit_config.wasmer2_stack_limit),
                     )
                     .map_err(|err| translate_instantiation_error(err, import.vmlogic))?;
                 // SAFETY: being called immediately after instantiation.


### PR DESCRIPTION
200*1024 is still just under 2MiB, which we can definitely afford, given a default stack size on glibc systems is 8MiB.