### PR TITLE
refactor: introduce log_assert to be used instead of missused debug_asserts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3177,6 +3177,7 @@ dependencies = [
  "fs2",
  "lru",
  "near-crypto",
+ "near-o11y",
  "near-primitives",
  "num_cpus",
  "once_cell",

--- a/core/o11y/src/lib.rs
+++ b/core/o11y/src/lib.rs
@@ -147,3 +147,54 @@ impl<'a> EnvFilterBuilder<'a> {
         env_filter
     }
 }
+
+/// Asserts that the condition is true, logging an error otherwise.
+///
+/// This macro complements `assert!` and `debug_assert`. All three macros should
+/// only be used for conditions, whose violation signifise a programming error.
+/// All three macros are no-ops if the condition is true.
+///
+/// The behavior when the condition is false (i.e. when the assert fails) is
+/// different, and informs different usage patterns.
+///
+/// `assert!` panics. Use it for sanity-checking invariants, whose violation can
+/// compromise correctness of the protocol. For example, it's better to shut a
+/// node down via a panic than to admit potentially non-deterministic behavior.
+///
+/// `debug_assert!` panics if `cfg(debug_assertions)` is true, that is, only
+/// during development. In production, `debug_assert!` is compiled away (that
+/// is, the condition is not evaluated at all). Use `debug_assert!` if
+/// evaluating the condition is too slow. In other words, `debug_assert!` is a
+/// performance optimization.
+///
+/// Finally, `log_assert!` panics in debug mode, while in release mode it emits
+/// a `tracing::error!` log line. Use it for sanity-checking non-essential
+/// invariants, whose violation signals a bug in the code, where we'd rather
+/// avoid shutting the whole node down.
+///
+/// For example, `log_assert` is a great choice to use in some auxilary code
+/// paths -- would be a shame if a bug in, eg, metrics collection code brought
+/// the whole network down.
+///
+/// Another use case is adding new asserts to the old code -- if you are only
+/// 99% sure that the assert is correct, and there's evidance that the old code
+/// is working fine in practice, `log_assert!` is the right choice!
+///
+/// References:
+///   * <https://www.sqlite.org/assert.html>
+#[macro_export]
+macro_rules! log_assert {
+    ($cond:expr) => {
+        $crate::log_assert!($cond, "assertion failed: {}", stringify!($cond))
+    };
+
+    ($cond:expr, $fmt:literal $($arg:tt)*) => {
+        if cfg!(debug_assertions) {
+            assert!($cond, $fmt $($arg)*);
+        } else {
+            if !$cond {
+                $crate::tracing::error!($fmt $($arg)*);
+            }
+        }
+    };
+}

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -28,6 +28,7 @@ once_cell = "1.5.2"
 rlimit = "0.7"
 
 near-crypto = { path = "../crypto" }
+near-o11y = { path = "../o11y" }
 near-primitives = { path = "../primitives" }
 
 [dev-dependencies]

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -15,6 +15,7 @@ pub use db::{
     LARGEST_TARGET_HEIGHT_KEY, LATEST_KNOWN_KEY, TAIL_KEY,
 };
 use near_crypto::PublicKey;
+use near_o11y::log_assert;
 use near_primitives::account::{AccessKey, Account};
 use near_primitives::contract::ContractCode;
 pub use near_primitives::errors::StorageError;
@@ -169,7 +170,7 @@ impl StoreUpdate {
     }
 
     pub fn update_refcount(&mut self, column: DBCol, key: &[u8], value: &[u8], rc_delta: i64) {
-        debug_assert!(column.is_rc());
+        log_assert!(column.is_rc());
         let value = encode_value_with_rc(value, rc_delta);
         self.transaction.update_refcount(column, key.to_vec(), value)
     }
@@ -184,7 +185,7 @@ impl StoreUpdate {
         key: &[u8],
         value: &T,
     ) -> io::Result<()> {
-        debug_assert!(!column.is_rc());
+        log_assert!(!column.is_rc());
         let data = value.try_to_vec()?;
         self.set(column, key, &data);
         Ok(())
@@ -203,7 +204,7 @@ impl StoreUpdate {
         match (&self.tries, other.tries) {
             (_, None) => (),
             (None, Some(tries)) => self.tries = Some(tries),
-            (Some(t1), Some(t2)) => debug_assert!(t1.is_same(&t2)),
+            (Some(t1), Some(t2)) => log_assert!(t1.is_same(&t2)),
         }
 
         self.merge_transaction(other.transaction);


### PR DESCRIPTION
debug_assert is for cases where assert condition is too costly to evaluate.

If the reason for using debug_assert is to avoid the node crashing in prod, than
log_assert is strinctly better: it crashes the node in debug, but logs in
release.