### PR TITLE
peer_store: split add_direct_peer into two methods

### DIFF
--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -1,6 +1,6 @@
 use crate::peer::codec::Codec;
 use crate::peer::peer_actor::PeerActor;
-use crate::peer_manager::peer_store::{PeerStore, TrustLevel};
+use crate::peer_manager::peer_store::PeerStore;
 use crate::private_actix::{
     PeerRequestResult, PeersRequest, RegisterPeer, RegisterPeerResponse, SendMessage, StopMsg,
     Unregister, ValidateEdgeList,
@@ -2218,7 +2218,7 @@ impl PeerManagerActor {
                 PeerResponse::NoResponse
             }
             PeerRequest::UpdatePeerInfo(peer_info) => {
-                if let Err(err) = self.peer_store.add_trusted_peer(peer_info, TrustLevel::Direct) {
+                if let Err(err) = self.peer_store.add_direct_peer(peer_info) {
                     error!(target: "network", ?err, "Fail to update peer store");
                 }
                 PeerResponse::NoResponse


### PR DESCRIPTION
add_direct_peer method is called with a trust_level argument.  It is
supposed to be either TrustLevel::Direct or TrustLevel::Signed but
there’s nothing preventing the function being called incorrectly with
TrustLevel::Indirect value.

Split the method into two: add_direct_peer and add_signed_peer.

Furthermore, mark private add_peer method always inline so that match
present in the function gets resolved at compile time.

As it happens, the method is always called with a constant value for
the trust level