### PR TITLE
pytest: don’t set rpc.metrics_addr

### DIFF
--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -398,7 +398,6 @@ class LocalNode(BaseNode):
             },
             'rpc': {
                 'addr': f'0.0.0.0:{rpc_port}',
-                'metrics_addr': f'0.0.0.0:{rpc_port + 1000}',
             },
             'consensus': {
                 'min_num_peers': int(not single_node)


### PR DESCRIPTION
The filed has been removed ages ago and currently results in warnings:

    WARN nearcore::config: .../config.json: encountered unrecognised fields: ["rpc.?.metrics_addr"]

Stop setting the value in tests.