### PR TITLE
nightly: increase timeout for contracts/gibberish.py test

### DIFF
--- a/nightly/pytest-contracts.txt
+++ b/nightly/pytest-contracts.txt
@@ -1,7 +1,7 @@
 # python tests for smart contract deployment and invocation
 pytest contracts/deploy_call_smart_contract.py
 pytest contracts/deploy_call_smart_contract.py --features nightly_protocol,nightly_protocol_features
-pytest --timeout=300 contracts/gibberish.py
-pytest --timeout=300 contracts/gibberish.py --features nightly_protocol,nightly_protocol_features
+pytest --timeout=10m contracts/gibberish.py
+pytest --timeout=10m contracts/gibberish.py --features nightly_protocol,nightly_protocol_features
 pytest --timeout=400 contracts/infinite_loops.py
 pytest --timeout=400 contracts/infinite_loops.py --features nightly_protocol,nightly_protocol_features


### PR DESCRIPTION
The cuts close to five minutes run time it’s allotted which sometimes
makes it miss the deadline and fail making the test flaky.  Increase
the timeout.