### PR TITLE
Fix(jsonrpc): QueryError is a possible QueryResponseKind

### DIFF
--- a/chain/jsonrpc-primitives/src/types/query.rs
+++ b/chain/jsonrpc-primitives/src/types/query.rs
@@ -87,6 +87,9 @@ pub enum QueryResponseKind {
     CallResult(near_primitives::views::CallResult),
     AccessKey(near_primitives::views::AccessKeyView),
     AccessKeyList(near_primitives::views::AccessKeyList),
+    /// This can be returned due to the post-processing code:
+    /// https://github.com/near/nearcore/blob/2d7e7f141b387c15cde9a60ed90d64fd0a517c07/chain/jsonrpc/src/lib.rs#L140
+    LegacyError(near_primitives::views::QueryError),
 }
 
 impl RpcQueryRequest {


### PR DESCRIPTION
I got a deserialization error from `serde_json` when using the [near-jsonrpc-client](https://github.com/near/near-jsonrpc-client-rs). The error happened because the contract I was doing a view call on panicked during its execution, causing the response to contain an `error` field, but this was not expected by the enums/structs serde was trying to construct from the response. This PR fixes the issue by including the `QueryError` variant in `QueryResponseKind`.

Now, this fixes the problem I was having, but I am unsure if it is the right fix. The reason the `error` field appears is because of some [custom post-processing](https://github.com/near/nearcore/blob/2d7e7f141b387c15cde9a60ed90d64fd0a517c07/chain/jsonrpc/src/lib.rs#L152-L161) of the strongly-typed error that arises from the nearcore internals. However, the function doing this post-processing has a comment `Should be refactored once structured errors fully shipped`, so this makes me wonder if that refactoring should be done instead of adding the new kind variant as I have done here.

Any insight nearcore devs can offer would be appreciated here, thanks!