### PR TITLE
add num_epoch_to_store to gc_config

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -106,9 +106,6 @@ pub const TX_ROUTING_HEIGHT_HORIZON: BlockHeightDelta = 4;
 /// Private constant for 1 NEAR (copy from near/config.rs) used for reporting.
 const NEAR_BASE: Balance = 1_000_000_000_000_000_000_000_000;
 
-/// Number of epochs for which we keep store data
-pub const NUM_EPOCHS_TO_KEEP_STORE_DATA: u64 = 5;
-
 /// apply_chunks may be called in two code paths, through process_block or through catchup_blocks
 /// When it is called through process_block, it is possible that the shard state for the next epoch
 /// has not been caught up yet, thus the two modes IsCaughtUp and NotCaughtUp.

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -8,7 +8,7 @@ use near_primitives::state_part::PartId;
 use num_rational::Rational;
 use tracing::debug;
 
-use near_chain_configs::{MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA, ProtocolConfig};
+use near_chain_configs::{DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA, ProtocolConfig};
 use near_chain_primitives::{Error, ErrorKind};
 use near_crypto::{KeyType, PublicKey, SecretKey, Signature};
 use near_pool::types::PoolIterator;
@@ -1043,12 +1043,12 @@ impl RuntimeAdapter for KeyValueRuntime {
                 .unwrap_or_default()
                 .map(|h| h.height())
                 .unwrap_or_default();
-            block_height.saturating_sub(MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA * self.epoch_length)
+            block_height.saturating_sub(DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA * self.epoch_length)
         /*  // TODO: use this version of the code instead - after we fix the block creation
             // issue in multiple tests.
-        // We have to return the first block of the epoch T-MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA.
+        // We have to return the first block of the epoch T-DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA.
         let mut current_header = self.get_block_header(block_hash).unwrap().unwrap();
-        for _ in 0..MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA {
+        for _ in 0..DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA {
             let last_block_of_prev_epoch = current_header.next_epoch_id();
             current_header =
                 self.get_block_header(&last_block_of_prev_epoch.0).unwrap().unwrap();

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -8,7 +8,7 @@ use near_primitives::state_part::PartId;
 use num_rational::Rational;
 use tracing::debug;
 
-use near_chain_configs::{ProtocolConfig, DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA};
+use near_chain_configs::{ProtocolConfig, DEFAULT_GC_NUM_EPOCHS_TO_KEEP};
 use near_chain_primitives::{Error, ErrorKind};
 use near_crypto::{KeyType, PublicKey, SecretKey, Signature};
 use near_pool::types::PoolIterator;
@@ -1043,12 +1043,12 @@ impl RuntimeAdapter for KeyValueRuntime {
                 .unwrap_or_default()
                 .map(|h| h.height())
                 .unwrap_or_default();
-            block_height.saturating_sub(DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA * self.epoch_length)
+            block_height.saturating_sub(DEFAULT_GC_NUM_EPOCHS_TO_KEEP * self.epoch_length)
         /*  // TODO: use this version of the code instead - after we fix the block creation
             // issue in multiple tests.
-        // We have to return the first block of the epoch T-DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA.
+        // We have to return the first block of the epoch T-DEFAULT_GC_NUM_EPOCHS_TO_KEEP.
         let mut current_header = self.get_block_header(block_hash).unwrap().unwrap();
-        for _ in 0..DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA {
+        for _ in 0..DEFAULT_GC_NUM_EPOCHS_TO_KEEP {
             let last_block_of_prev_epoch = current_header.next_epoch_id();
             current_header =
                 self.get_block_header(&last_block_of_prev_epoch.0).unwrap().unwrap();

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -8,8 +8,7 @@ use near_primitives::state_part::PartId;
 use num_rational::Rational;
 use tracing::debug;
 
-use near_chain_configs::ProtocolConfig;
-use near_chain_configs::MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA;
+use near_chain_configs::{MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA, ProtocolConfig};
 use near_chain_primitives::{Error, ErrorKind};
 use near_crypto::{KeyType, PublicKey, SecretKey, Signature};
 use near_pool::types::PoolIterator;

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -9,6 +9,7 @@ use num_rational::Rational;
 use tracing::debug;
 
 use near_chain_configs::ProtocolConfig;
+use near_chain_configs::MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA;
 use near_chain_primitives::{Error, ErrorKind};
 use near_crypto::{KeyType, PublicKey, SecretKey, Signature};
 use near_pool::types::PoolIterator;
@@ -46,7 +47,7 @@ use near_store::{
     WrappedTrieChanges,
 };
 
-use crate::chain::{Chain, NUM_EPOCHS_TO_KEEP_STORE_DATA};
+use crate::chain::Chain;
 use crate::store::ChainStoreAccess;
 use crate::types::{
     ApplySplitStateResult, ApplyTransactionResult, BlockHeaderInfo, ChainGenesis,
@@ -1043,12 +1044,12 @@ impl RuntimeAdapter for KeyValueRuntime {
                 .unwrap_or_default()
                 .map(|h| h.height())
                 .unwrap_or_default();
-            block_height.saturating_sub(NUM_EPOCHS_TO_KEEP_STORE_DATA * self.epoch_length)
+            block_height.saturating_sub(MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA * self.epoch_length)
         /*  // TODO: use this version of the code instead - after we fix the block creation
             // issue in multiple tests.
-        // We have to return the first block of the epoch T-NUM_EPOCHS_TO_KEEP_STORE_DATA.
+        // We have to return the first block of the epoch T-MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA.
         let mut current_header = self.get_block_header(block_hash).unwrap().unwrap();
-        for _ in 0..NUM_EPOCHS_TO_KEEP_STORE_DATA {
+        for _ in 0..MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA {
             let last_block_of_prev_epoch = current_header.next_epoch_id();
             current_header =
                 self.get_block_header(&last_block_of_prev_epoch.0).unwrap().unwrap();

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -8,7 +8,7 @@ use near_primitives::state_part::PartId;
 use num_rational::Rational;
 use tracing::debug;
 
-use near_chain_configs::{DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA, ProtocolConfig};
+use near_chain_configs::{ProtocolConfig, DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA};
 use near_chain_primitives::{Error, ErrorKind};
 use near_crypto::{KeyType, PublicKey, SecretKey, Signature};
 use near_pool::types::PoolIterator;

--- a/chain/chain/src/tests/gc.rs
+++ b/chain/chain/src/tests/gc.rs
@@ -664,7 +664,11 @@ fn test_fork_far_away_from_epoch_end() {
     chain1
         .clear_data(
             tries1.clone(),
-            &GCConfig { gc_blocks_limit: 100, gc_fork_clean_step: fork_clean_step },
+            &GCConfig {
+                gc_blocks_limit: 100,
+                gc_fork_clean_step: fork_clean_step,
+                ..GCConfig::default()
+            },
         )
         .expect("Clear data failed");
 

--- a/chain/client/src/tests/query_client.rs
+++ b/chain/client/src/tests/query_client.rs
@@ -9,7 +9,7 @@ use crate::{
     TxStatus,
 };
 use near_actix_test_utils::run_actix;
-use near_chain_configs::DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA;
+use near_chain_configs::DEFAULT_GC_NUM_EPOCHS_TO_KEEP;
 use near_crypto::{InMemorySigner, KeyType};
 use near_logger_utils::init_test_logger;
 use near_network::test_utils::MockPeerManagerAdapter;
@@ -252,7 +252,7 @@ fn test_garbage_collection() {
     run_actix(async {
         let block_prod_time = 100;
         let epoch_length = 5;
-        let target_height = epoch_length * (DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA + 1);
+        let target_height = epoch_length * (DEFAULT_GC_NUM_EPOCHS_TO_KEEP + 1);
         let network_mock: Arc<
             RwLock<
                 Box<

--- a/chain/client/src/tests/query_client.rs
+++ b/chain/client/src/tests/query_client.rs
@@ -9,7 +9,7 @@ use crate::{
     TxStatus,
 };
 use near_actix_test_utils::run_actix;
-use near_chain::chain::NUM_EPOCHS_TO_KEEP_STORE_DATA;
+use near_chain_configs::MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA;
 use near_crypto::{InMemorySigner, KeyType};
 use near_logger_utils::init_test_logger;
 use near_network::test_utils::MockPeerManagerAdapter;
@@ -252,7 +252,7 @@ fn test_garbage_collection() {
     run_actix(async {
         let block_prod_time = 100;
         let epoch_length = 5;
-        let target_height = epoch_length * (NUM_EPOCHS_TO_KEEP_STORE_DATA + 1);
+        let target_height = epoch_length * (MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA + 1);
         let network_mock: Arc<
             RwLock<
                 Box<

--- a/chain/client/src/tests/query_client.rs
+++ b/chain/client/src/tests/query_client.rs
@@ -9,7 +9,7 @@ use crate::{
     TxStatus,
 };
 use near_actix_test_utils::run_actix;
-use near_chain_configs::MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA;
+use near_chain_configs::DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA;
 use near_crypto::{InMemorySigner, KeyType};
 use near_logger_utils::init_test_logger;
 use near_network::test_utils::MockPeerManagerAdapter;
@@ -252,7 +252,7 @@ fn test_garbage_collection() {
     run_actix(async {
         let block_prod_time = 100;
         let epoch_length = 5;
-        let target_height = epoch_length * (MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA + 1);
+        let target_height = epoch_length * (DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA + 1);
         let network_mock: Arc<
             RwLock<
                 Box<

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -1,4 +1,5 @@
 //! Chain Client Configuration
+use std::cmp::max;
 use std::cmp::min;
 use std::time::Duration;
 
@@ -17,6 +18,9 @@ pub enum LogSummaryStyle {
     Colored,
 }
 
+/// Minimum Number of epochs for which we keep store data
+pub const MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA: u64 = 3;
+
 /// Configuration for garbage collection.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct GCConfig {
@@ -29,11 +33,19 @@ pub struct GCConfig {
     /// when cleaning forks during garbage collection.
     #[serde(default = "default_gc_fork_clean_step")]
     pub gc_fork_clean_step: u64,
+
+    /// Number of epochs for which we keep store data.
+    #[serde(default = "default_num_epochs_to_keep_store_data")]
+    num_epochs_to_keep_store_data: u64,
 }
 
 impl Default for GCConfig {
     fn default() -> Self {
-        Self { gc_blocks_limit: 2, gc_fork_clean_step: 1000 }
+        Self {
+            gc_blocks_limit: 2,
+            gc_fork_clean_step: 1000,
+            num_epochs_to_keep_store_data: MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA,
+        }
     }
 }
 
@@ -43,6 +55,16 @@ fn default_gc_blocks_limit() -> NumBlocks {
 
 fn default_gc_fork_clean_step() -> u64 {
     GCConfig::default().gc_fork_clean_step
+}
+
+fn default_num_epochs_to_keep_store_data() -> u64 {
+    GCConfig::default().num_epochs_to_keep_store_data()
+}
+
+impl GCConfig {
+    pub fn num_epochs_to_keep_store_data(&self) -> u64 {
+        max(MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA, self.num_epochs_to_keep_store_data)
+    }
 }
 
 #[derive(Clone, Serialize, Deserialize)]

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -47,7 +47,7 @@ impl Default for GCConfig {
         Self {
             gc_blocks_limit: 5,
             gc_fork_clean_step: 1000,
-            num_epochs_to_keep_store_data: MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA,
+            num_epochs_to_keep_store_data: DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA,
         }
     }
 }

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -18,8 +18,11 @@ pub enum LogSummaryStyle {
     Colored,
 }
 
-/// Minimum Number of epochs for which we keep store data
+/// Minimum number of epochs for which we keep store data
 pub const MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA: u64 = 3;
+
+/// Default number of epochs for which we keep store data
+pub const DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA: u64 = 5;
 
 /// Configuration for garbage collection.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -42,7 +45,7 @@ pub struct GCConfig {
 impl Default for GCConfig {
     fn default() -> Self {
         Self {
-            gc_blocks_limit: 2,
+            gc_blocks_limit: 5,
             gc_fork_clean_step: 1000,
             num_epochs_to_keep_store_data: MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA,
         }

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -19,10 +19,10 @@ pub enum LogSummaryStyle {
 }
 
 /// Minimum number of epochs for which we keep store data
-pub const MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA: u64 = 3;
+pub const MIN_GC_NUM_EPOCHS_TO_KEEP: u64 = 3;
 
 /// Default number of epochs for which we keep store data
-pub const DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA: u64 = 5;
+pub const DEFAULT_GC_NUM_EPOCHS_TO_KEEP: u64 = 5;
 
 /// Configuration for garbage collection.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -38,8 +38,8 @@ pub struct GCConfig {
     pub gc_fork_clean_step: u64,
 
     /// Number of epochs for which we keep store data.
-    #[serde(default = "default_num_epochs_to_keep_store_data")]
-    pub num_epochs_to_keep_store_data: u64,
+    #[serde(default = "default_gc_num_epochs_to_keep")]
+    pub gc_num_epochs_to_keep: u64,
 }
 
 impl Default for GCConfig {
@@ -47,7 +47,7 @@ impl Default for GCConfig {
         Self {
             gc_blocks_limit: 5,
             gc_fork_clean_step: 1000,
-            num_epochs_to_keep_store_data: DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA,
+            gc_num_epochs_to_keep: DEFAULT_GC_NUM_EPOCHS_TO_KEEP,
         }
     }
 }
@@ -60,13 +60,13 @@ fn default_gc_fork_clean_step() -> u64 {
     GCConfig::default().gc_fork_clean_step
 }
 
-fn default_num_epochs_to_keep_store_data() -> u64 {
-    GCConfig::default().num_epochs_to_keep_store_data()
+fn default_gc_num_epochs_to_keep() -> u64 {
+    GCConfig::default().gc_num_epochs_to_keep()
 }
 
 impl GCConfig {
-    pub fn num_epochs_to_keep_store_data(&self) -> u64 {
-        max(MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA, self.num_epochs_to_keep_store_data)
+    pub fn gc_num_epochs_to_keep(&self) -> u64 {
+        max(MIN_GC_NUM_EPOCHS_TO_KEEP, self.gc_num_epochs_to_keep)
     }
 }
 

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -39,7 +39,7 @@ pub struct GCConfig {
 
     /// Number of epochs for which we keep store data.
     #[serde(default = "default_num_epochs_to_keep_store_data")]
-    num_epochs_to_keep_store_data: u64,
+    pub num_epochs_to_keep_store_data: u64,
 }
 
 impl Default for GCConfig {

--- a/core/chain-configs/src/lib.rs
+++ b/core/chain-configs/src/lib.rs
@@ -2,7 +2,7 @@ mod client_config;
 mod genesis_config;
 pub mod genesis_validate;
 
-pub use client_config::{ClientConfig, GCConfig, LogSummaryStyle, TEST_STATE_SYNC_TIMEOUT};
+pub use client_config::{ClientConfig, GCConfig, LogSummaryStyle, MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA, TEST_STATE_SYNC_TIMEOUT};
 pub use genesis_config::{
     get_initial_supply, Genesis, GenesisConfig, GenesisRecords, GenesisValidationMode,
     ProtocolConfig, ProtocolConfigView,

--- a/core/chain-configs/src/lib.rs
+++ b/core/chain-configs/src/lib.rs
@@ -3,8 +3,8 @@ mod genesis_config;
 pub mod genesis_validate;
 
 pub use client_config::{
-    ClientConfig, GCConfig, LogSummaryStyle, DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA,
-    MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA, TEST_STATE_SYNC_TIMEOUT,
+    ClientConfig, GCConfig, LogSummaryStyle, DEFAULT_GC_NUM_EPOCHS_TO_KEEP,
+    MIN_GC_NUM_EPOCHS_TO_KEEP, TEST_STATE_SYNC_TIMEOUT,
 };
 pub use genesis_config::{
     get_initial_supply, Genesis, GenesisConfig, GenesisRecords, GenesisValidationMode,

--- a/core/chain-configs/src/lib.rs
+++ b/core/chain-configs/src/lib.rs
@@ -3,8 +3,8 @@ mod genesis_config;
 pub mod genesis_validate;
 
 pub use client_config::{
-    ClientConfig, DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA, GCConfig, LogSummaryStyle,
-    MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA, TEST_STATE_SYNC_TIMEOUT
+    ClientConfig, GCConfig, LogSummaryStyle, DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA,
+    MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA, TEST_STATE_SYNC_TIMEOUT,
 };
 pub use genesis_config::{
     get_initial_supply, Genesis, GenesisConfig, GenesisRecords, GenesisValidationMode,

--- a/core/chain-configs/src/lib.rs
+++ b/core/chain-configs/src/lib.rs
@@ -2,7 +2,10 @@ mod client_config;
 mod genesis_config;
 pub mod genesis_validate;
 
-pub use client_config::{ClientConfig, GCConfig, LogSummaryStyle, MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA, TEST_STATE_SYNC_TIMEOUT};
+pub use client_config::{
+    ClientConfig, DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA, GCConfig, LogSummaryStyle,
+    MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA, TEST_STATE_SYNC_TIMEOUT
+};
 pub use genesis_config::{
     get_initial_supply, Genesis, GenesisConfig, GenesisRecords, GenesisValidationMode,
     ProtocolConfig, ProtocolConfigView,

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -65,6 +65,7 @@ impl GenesisBuilder {
             None,
             None,
             None,
+            None,
         );
         Self {
             home_dir: home_dir.to_path_buf(),

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -11,7 +11,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 use crate::state_dump::StateDump;
 use near_chain::types::BlockHeaderInfo;
 use near_chain::{Block, Chain, ChainStore, RuntimeAdapter};
-use near_chain_configs::Genesis;
+use near_chain_configs::{DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA, Genesis};
 use near_crypto::{InMemorySigner, KeyType};
 use near_primitives::account::{AccessKey, Account};
 use near_primitives::block::{genesis_chunks, Tip};
@@ -65,7 +65,7 @@ impl GenesisBuilder {
             None,
             None,
             None,
-            5,
+            DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA,
         );
         Self {
             home_dir: home_dir.to_path_buf(),

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -65,7 +65,7 @@ impl GenesisBuilder {
             None,
             None,
             None,
-            None,
+            5,
         );
         Self {
             home_dir: home_dir.to_path_buf(),

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -11,7 +11,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 use crate::state_dump::StateDump;
 use near_chain::types::BlockHeaderInfo;
 use near_chain::{Block, Chain, ChainStore, RuntimeAdapter};
-use near_chain_configs::{DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA, Genesis};
+use near_chain_configs::{Genesis, DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA};
 use near_crypto::{InMemorySigner, KeyType};
 use near_primitives::account::{AccessKey, Account};
 use near_primitives::block::{genesis_chunks, Tip};

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -11,7 +11,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 use crate::state_dump::StateDump;
 use near_chain::types::BlockHeaderInfo;
 use near_chain::{Block, Chain, ChainStore, RuntimeAdapter};
-use near_chain_configs::{Genesis, DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA};
+use near_chain_configs::{Genesis, DEFAULT_GC_NUM_EPOCHS_TO_KEEP};
 use near_crypto::{InMemorySigner, KeyType};
 use near_primitives::account::{AccessKey, Account};
 use near_primitives::block::{genesis_chunks, Tip};
@@ -65,7 +65,7 @@ impl GenesisBuilder {
             None,
             None,
             None,
-            DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA,
+            DEFAULT_GC_NUM_EPOCHS_TO_KEEP,
         );
         Self {
             home_dir: home_dir.to_path_buf(),

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -10,13 +10,13 @@ use futures::{future, FutureExt};
 use near_primitives::num_rational::Rational;
 
 use near_actix_test_utils::run_actix;
-use near_chain::chain::{ApplyStatePartsRequest, NUM_EPOCHS_TO_KEEP_STORE_DATA};
+use near_chain::chain::ApplyStatePartsRequest;
 use near_chain::types::LatestKnown;
 use near_chain::validate::validate_chunk_with_chunk_extra;
 use near_chain::{
     Block, ChainGenesis, ChainStore, ChainStoreAccess, ErrorKind, Provenance, RuntimeAdapter,
 };
-use near_chain_configs::{ClientConfig, Genesis};
+use near_chain_configs::{ClientConfig, Genesis, MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA};
 use near_chunks::{ChunkStatus, ShardsManager};
 use near_client::test_utils::{
     create_chunk_on_height, run_catchup, setup_client, setup_mock, setup_mock_all_validators,
@@ -1402,7 +1402,7 @@ fn test_gc_with_epoch_length_common(epoch_length: NumBlocks) {
     let mut blocks = vec![];
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap().clone();
     blocks.push(genesis_block);
-    for i in 1..=epoch_length * (NUM_EPOCHS_TO_KEEP_STORE_DATA + 1) {
+    for i in 1..=epoch_length * (MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA + 1) {
         let block = env.clients[0].produce_block(i).unwrap().unwrap();
         env.process_block(0, block.clone(), Provenance::PRODUCED);
         assert!(
@@ -1412,7 +1412,7 @@ fn test_gc_with_epoch_length_common(epoch_length: NumBlocks) {
 
         blocks.push(block);
     }
-    for i in 0..=epoch_length * (NUM_EPOCHS_TO_KEEP_STORE_DATA + 1) {
+    for i in 0..=epoch_length * (MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA + 1) {
         println!("height = {}", i);
         if i < epoch_length {
             let block_hash = *blocks[i as usize].hash();
@@ -1630,7 +1630,7 @@ fn test_gc_fork_tail() {
         let block = env.clients[0].produce_block(i).unwrap().unwrap();
         env.process_block(1, block, Provenance::NONE);
     }
-    for i in 102..epoch_length * NUM_EPOCHS_TO_KEEP_STORE_DATA + 5 {
+    for i in 102..epoch_length * MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA + 5 {
         let block = env.clients[0].produce_block(i).unwrap().unwrap();
         for j in 0..2 {
             env.process_block(j, block.clone(), Provenance::NONE);
@@ -1739,7 +1739,7 @@ fn test_not_resync_old_blocks() {
         .runtime_adapters(create_nightshade_runtimes(&genesis, 1))
         .build();
     let mut blocks = vec![];
-    for i in 1..=epoch_length * (NUM_EPOCHS_TO_KEEP_STORE_DATA + 1) {
+    for i in 1..=epoch_length * (MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA + 1) {
         let block = env.clients[0].produce_block(i).unwrap().unwrap();
         env.process_block(0, block.clone(), Provenance::PRODUCED);
         blocks.push(block);
@@ -1765,7 +1765,7 @@ fn test_gc_tail_update() {
         .runtime_adapters(create_nightshade_runtimes(&genesis, 2))
         .build();
     let mut blocks = vec![];
-    for i in 1..=epoch_length * (NUM_EPOCHS_TO_KEEP_STORE_DATA + 1) {
+    for i in 1..=epoch_length * (MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA + 1) {
         let block = env.clients[0].produce_block(i).unwrap().unwrap();
         env.process_block(0, block.clone(), Provenance::PRODUCED);
         blocks.push(block);
@@ -3357,6 +3357,7 @@ fn verify_contract_limits_upgrade(
                 &genesis,
                 TrackedConfig::new_empty(),
                 RuntimeConfigStore::new(None),
+                None,
             ))];
         let mut env = TestEnv::builder(chain_genesis).runtime_adapters(runtimes).build();
 
@@ -3512,6 +3513,7 @@ fn test_deploy_cost_increased() {
                 &genesis,
                 TrackedConfig::new_empty(),
                 RuntimeConfigStore::new(None),
+                None,
             ))];
         TestEnv::builder(chain_genesis).runtime_adapters(runtimes).build()
     };
@@ -3875,6 +3877,7 @@ mod access_key_nonce_range_tests {
                     &genesis,
                     TrackedConfig::AllShards,
                     RuntimeConfigStore::test(),
+                    None,
                 )) as Arc<dyn RuntimeAdapter>
             })
             .collect();
@@ -4021,6 +4024,7 @@ mod access_key_nonce_range_tests {
                     &genesis,
                     TrackedConfig::AllShards,
                     RuntimeConfigStore::test(),
+                    None,
                 )) as Arc<dyn RuntimeAdapter>
             })
             .collect();

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -4757,6 +4757,7 @@ mod chunk_nodes_cache_test {
                 &genesis,
                 TrackedConfig::new_empty(),
                 RuntimeConfigStore::new(None),
+                None,
             ))];
         let mut env = TestEnv::builder(chain_genesis).runtime_adapters(runtimes).build();
 

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -16,7 +16,7 @@ use near_chain::validate::validate_chunk_with_chunk_extra;
 use near_chain::{
     Block, ChainGenesis, ChainStore, ChainStoreAccess, ErrorKind, Provenance, RuntimeAdapter,
 };
-use near_chain_configs::{ClientConfig, Genesis, MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA};
+use near_chain_configs::{ClientConfig, DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA, Genesis};
 use near_chunks::{ChunkStatus, ShardsManager};
 use near_client::test_utils::{
     create_chunk_on_height, run_catchup, setup_client, setup_mock, setup_mock_all_validators,
@@ -1402,7 +1402,7 @@ fn test_gc_with_epoch_length_common(epoch_length: NumBlocks) {
     let mut blocks = vec![];
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap().clone();
     blocks.push(genesis_block);
-    for i in 1..=epoch_length * (MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA + 1) {
+    for i in 1..=epoch_length * (DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA + 1) {
         let block = env.clients[0].produce_block(i).unwrap().unwrap();
         env.process_block(0, block.clone(), Provenance::PRODUCED);
         assert!(
@@ -1412,7 +1412,7 @@ fn test_gc_with_epoch_length_common(epoch_length: NumBlocks) {
 
         blocks.push(block);
     }
-    for i in 0..=epoch_length * (MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA + 1) {
+    for i in 0..=epoch_length * (DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA + 1) {
         println!("height = {}", i);
         if i < epoch_length {
             let block_hash = *blocks[i as usize].hash();
@@ -1630,7 +1630,7 @@ fn test_gc_fork_tail() {
         let block = env.clients[0].produce_block(i).unwrap().unwrap();
         env.process_block(1, block, Provenance::NONE);
     }
-    for i in 102..epoch_length * MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA + 5 {
+    for i in 102..epoch_length * DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA + 5 {
         let block = env.clients[0].produce_block(i).unwrap().unwrap();
         for j in 0..2 {
             env.process_block(j, block.clone(), Provenance::NONE);
@@ -1739,7 +1739,7 @@ fn test_not_resync_old_blocks() {
         .runtime_adapters(create_nightshade_runtimes(&genesis, 1))
         .build();
     let mut blocks = vec![];
-    for i in 1..=epoch_length * (MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA + 1) {
+    for i in 1..=epoch_length * (DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA + 1) {
         let block = env.clients[0].produce_block(i).unwrap().unwrap();
         env.process_block(0, block.clone(), Provenance::PRODUCED);
         blocks.push(block);
@@ -1765,7 +1765,7 @@ fn test_gc_tail_update() {
         .runtime_adapters(create_nightshade_runtimes(&genesis, 2))
         .build();
     let mut blocks = vec![];
-    for i in 1..=epoch_length * (MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA + 1) {
+    for i in 1..=epoch_length * (DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA + 1) {
         let block = env.clients[0].produce_block(i).unwrap().unwrap();
         env.process_block(0, block.clone(), Provenance::PRODUCED);
         blocks.push(block);

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -16,7 +16,7 @@ use near_chain::validate::validate_chunk_with_chunk_extra;
 use near_chain::{
     Block, ChainGenesis, ChainStore, ChainStoreAccess, ErrorKind, Provenance, RuntimeAdapter,
 };
-use near_chain_configs::{ClientConfig, DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA, Genesis};
+use near_chain_configs::{ClientConfig, Genesis, DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA};
 use near_chunks::{ChunkStatus, ShardsManager};
 use near_client::test_utils::{
     create_chunk_on_height, run_catchup, setup_client, setup_mock, setup_mock_all_validators,

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -4851,6 +4851,7 @@ mod lower_storage_key_limit_test {
                     &genesis,
                     TrackedConfig::AllShards,
                     RuntimeConfigStore::new(None),
+                    None,
                 )) as Arc<dyn RuntimeAdapter>];
             let mut env = TestEnv::builder(chain_genesis).runtime_adapters(runtimes).build();
 

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -16,7 +16,7 @@ use near_chain::validate::validate_chunk_with_chunk_extra;
 use near_chain::{
     Block, ChainGenesis, ChainStore, ChainStoreAccess, ErrorKind, Provenance, RuntimeAdapter,
 };
-use near_chain_configs::{ClientConfig, Genesis, DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA};
+use near_chain_configs::{ClientConfig, Genesis, DEFAULT_GC_NUM_EPOCHS_TO_KEEP};
 use near_chunks::{ChunkStatus, ShardsManager};
 use near_client::test_utils::{
     create_chunk_on_height, run_catchup, setup_client, setup_mock, setup_mock_all_validators,
@@ -1402,7 +1402,7 @@ fn test_gc_with_epoch_length_common(epoch_length: NumBlocks) {
     let mut blocks = vec![];
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap().clone();
     blocks.push(genesis_block);
-    for i in 1..=epoch_length * (DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA + 1) {
+    for i in 1..=epoch_length * (DEFAULT_GC_NUM_EPOCHS_TO_KEEP + 1) {
         let block = env.clients[0].produce_block(i).unwrap().unwrap();
         env.process_block(0, block.clone(), Provenance::PRODUCED);
         assert!(
@@ -1412,7 +1412,7 @@ fn test_gc_with_epoch_length_common(epoch_length: NumBlocks) {
 
         blocks.push(block);
     }
-    for i in 0..=epoch_length * (DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA + 1) {
+    for i in 0..=epoch_length * (DEFAULT_GC_NUM_EPOCHS_TO_KEEP + 1) {
         println!("height = {}", i);
         if i < epoch_length {
             let block_hash = *blocks[i as usize].hash();
@@ -1630,7 +1630,7 @@ fn test_gc_fork_tail() {
         let block = env.clients[0].produce_block(i).unwrap().unwrap();
         env.process_block(1, block, Provenance::NONE);
     }
-    for i in 102..epoch_length * DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA + 5 {
+    for i in 102..epoch_length * DEFAULT_GC_NUM_EPOCHS_TO_KEEP + 5 {
         let block = env.clients[0].produce_block(i).unwrap().unwrap();
         for j in 0..2 {
             env.process_block(j, block.clone(), Provenance::NONE);
@@ -1739,7 +1739,7 @@ fn test_not_resync_old_blocks() {
         .runtime_adapters(create_nightshade_runtimes(&genesis, 1))
         .build();
     let mut blocks = vec![];
-    for i in 1..=epoch_length * (DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA + 1) {
+    for i in 1..=epoch_length * (DEFAULT_GC_NUM_EPOCHS_TO_KEEP + 1) {
         let block = env.clients[0].produce_block(i).unwrap().unwrap();
         env.process_block(0, block.clone(), Provenance::PRODUCED);
         blocks.push(block);
@@ -1765,7 +1765,7 @@ fn test_gc_tail_update() {
         .runtime_adapters(create_nightshade_runtimes(&genesis, 2))
         .build();
     let mut blocks = vec![];
-    for i in 1..=epoch_length * (DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA + 1) {
+    for i in 1..=epoch_length * (DEFAULT_GC_NUM_EPOCHS_TO_KEEP + 1) {
         let block = env.clients[0].produce_block(i).unwrap().unwrap();
         env.process_block(0, block.clone(), Provenance::PRODUCED);
         blocks.push(block);

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -1455,11 +1455,15 @@ fn test_config_from_file() {
         // we want to ensure that they happen.
         let want_gc = if has_gc {
             GCConfig {
-                gc_blocks_limit: 42, gc_fork_clean_step: 420, num_epochs_to_keep_store_data: 5
+                gc_blocks_limit: 42,
+                gc_fork_clean_step: 420,
+                num_epochs_to_keep_store_data: 5,
             }
         } else {
             GCConfig {
-                gc_blocks_limit: 2, gc_fork_clean_step: 1000, num_epochs_to_keep_store_data: 5
+                gc_blocks_limit: 2,
+                gc_fork_clean_step: 1000,
+                num_epochs_to_keep_store_data: 5,
             }
         };
         assert_eq!(want_gc, config.gc);

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -1454,9 +1454,13 @@ fn test_config_from_file() {
         // values is probably not worth it but there may be some other defaults
         // we want to ensure that they happen.
         let want_gc = if has_gc {
-            GCConfig { gc_blocks_limit: 42, gc_fork_clean_step: 420 }
+            GCConfig {
+                gc_blocks_limit: 42, gc_fork_clean_step: 420, num_epochs_to_keep_store_data: 5
+            }
         } else {
-            GCConfig { gc_blocks_limit: 2, gc_fork_clean_step: 1000 }
+            GCConfig {
+                gc_blocks_limit: 2, gc_fork_clean_step: 1000, num_epochs_to_keep_store_data: 5
+            }
         };
         assert_eq!(want_gc, config.gc);
 

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -1454,9 +1454,9 @@ fn test_config_from_file() {
         // values is probably not worth it but there may be some other defaults
         // we want to ensure that they happen.
         let want_gc = if has_gc {
-            GCConfig { gc_blocks_limit: 42, gc_fork_clean_step: 420, gc_num_epochs_to_keep: 5 }
+            GCConfig { gc_blocks_limit: 42, gc_fork_clean_step: 420, gc_num_epochs_to_keep: 24 }
         } else {
-            GCConfig { gc_blocks_limit: 2, gc_fork_clean_step: 1000, gc_num_epochs_to_keep: 5 }
+            GCConfig { gc_blocks_limit: 5, gc_fork_clean_step: 1000, gc_num_epochs_to_keep: 5 }
         };
         assert_eq!(want_gc, config.gc);
 

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -1454,17 +1454,9 @@ fn test_config_from_file() {
         // values is probably not worth it but there may be some other defaults
         // we want to ensure that they happen.
         let want_gc = if has_gc {
-            GCConfig {
-                gc_blocks_limit: 42,
-                gc_fork_clean_step: 420,
-                gc_num_epochs_to_keep: 5,
-            }
+            GCConfig { gc_blocks_limit: 42, gc_fork_clean_step: 420, gc_num_epochs_to_keep: 5 }
         } else {
-            GCConfig {
-                gc_blocks_limit: 2,
-                gc_fork_clean_step: 1000,
-                gc_num_epochs_to_keep: 5,
-            }
+            GCConfig { gc_blocks_limit: 2, gc_fork_clean_step: 1000, gc_num_epochs_to_keep: 5 }
         };
         assert_eq!(want_gc, config.gc);
 

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -1457,13 +1457,13 @@ fn test_config_from_file() {
             GCConfig {
                 gc_blocks_limit: 42,
                 gc_fork_clean_step: 420,
-                num_epochs_to_keep_store_data: 5,
+                gc_num_epochs_to_keep: 5,
             }
         } else {
             GCConfig {
                 gc_blocks_limit: 2,
                 gc_fork_clean_step: 1000,
-                num_epochs_to_keep_store_data: 5,
+                gc_num_epochs_to_keep: 5,
             }
         };
         assert_eq!(want_gc, config.gc);

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -211,7 +211,9 @@ impl NightshadeRuntime {
             shard_tracker,
             genesis_state_roots: state_roots,
             migration_data: Arc::new(load_migration_data(&genesis.config.chain_id)),
-            num_epochs_to_keep_store_data,
+            num_epochs_to_keep_store_data: num_epochs_to_keep_store_data.max(
+                MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA,
+            ),
         }
     }
 

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -1975,6 +1975,7 @@ mod test {
 
     use num_rational::Rational;
 
+    use near_chain_configs::DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA;
     use near_crypto::{InMemorySigner, KeyType, Signer};
     use near_logger_utils::init_test_logger;
     use near_primitives::block::Tip;
@@ -2154,6 +2155,7 @@ mod test {
                 None,
                 None,
                 Some(RuntimeConfigStore::free()),
+                DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA,
             );
             let (_store, state_roots) = runtime.genesis_state();
             let genesis_hash = hash(&vec![0]);

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -13,7 +13,10 @@ use near_chain::types::{
     ApplySplitStateResult, ApplyTransactionResult, BlockHeaderInfo, ValidatorInfoIdentifier,
 };
 use near_chain::{BlockHeader, Doomslug, DoomslugThresholdMode, Error, ErrorKind, RuntimeAdapter};
-use near_chain_configs::{Genesis, GenesisConfig, ProtocolConfig, MIN_GC_NUM_EPOCHS_TO_KEEP};
+use near_chain_configs::{
+    Genesis, GenesisConfig, ProtocolConfig, DEFAULT_GC_NUM_EPOCHS_TO_KEEP,
+    MIN_GC_NUM_EPOCHS_TO_KEEP,
+};
 use near_crypto::{PublicKey, Signature};
 use near_epoch_manager::EpochManager;
 use near_pool::types::PoolIterator;
@@ -231,7 +234,7 @@ impl NightshadeRuntime {
             None,
             None,
             Some(runtime_config_store),
-            gc_num_epochs_to_keep.unwrap_or(MIN_GC_NUM_EPOCHS_TO_KEEP),
+            gc_num_epochs_to_keep.unwrap_or(DEFAULT_GC_NUM_EPOCHS_TO_KEEP),
         )
     }
 

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -211,8 +211,7 @@ impl NightshadeRuntime {
             shard_tracker,
             genesis_state_roots: state_roots,
             migration_data: Arc::new(load_migration_data(&genesis.config.chain_id)),
-            gc_num_epochs_to_keep: gc_num_epochs_to_keep
-                .max(MIN_GC_NUM_EPOCHS_TO_KEEP),
+            gc_num_epochs_to_keep: gc_num_epochs_to_keep.max(MIN_GC_NUM_EPOCHS_TO_KEEP),
         }
     }
 

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -13,7 +13,7 @@ use near_chain::types::{
     ApplySplitStateResult, ApplyTransactionResult, BlockHeaderInfo, ValidatorInfoIdentifier,
 };
 use near_chain::{BlockHeader, Doomslug, DoomslugThresholdMode, Error, ErrorKind, RuntimeAdapter};
-use near_chain_configs::{Genesis, GenesisConfig, MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA, ProtocolConfig};
+use near_chain_configs::{Genesis, GenesisConfig, ProtocolConfig, MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA};
 use near_crypto::{PublicKey, Signature};
 use near_epoch_manager::EpochManager;
 use near_pool::types::PoolIterator;
@@ -211,9 +211,8 @@ impl NightshadeRuntime {
             shard_tracker,
             genesis_state_roots: state_roots,
             migration_data: Arc::new(load_migration_data(&genesis.config.chain_id)),
-            num_epochs_to_keep_store_data: num_epochs_to_keep_store_data.max(
-                MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA,
-            ),
+            num_epochs_to_keep_store_data: num_epochs_to_keep_store_data
+                .max(MIN_NUM_EPOCHS_TO_KEEP_STORE_DATA),
         }
     }
 

--- a/test-utils/runtime-tester/src/run_test.rs
+++ b/test-utils/runtime-tester/src/run_test.rs
@@ -63,6 +63,7 @@ impl Scenario {
                 &genesis,
                 TrackedConfig::new_empty(),
                 runtime_config_store,
+                None,
             ))])
             .build();
 

--- a/test-utils/store-validator/src/main.rs
+++ b/test-utils/store-validator/src/main.rs
@@ -7,7 +7,7 @@ use clap::{Arg, Command};
 
 use near_chain::store_validator::StoreValidator;
 use near_chain::RuntimeAdapter;
-use near_chain_configs::{DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA, GenesisValidationMode};
+use near_chain_configs::{GenesisValidationMode, DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA};
 use near_logger_utils::init_integration_logger;
 use near_store::create_store;
 use nearcore::{get_default_home, get_store_path, load_config, TrackedConfig};

--- a/test-utils/store-validator/src/main.rs
+++ b/test-utils/store-validator/src/main.rs
@@ -7,7 +7,7 @@ use clap::{Arg, Command};
 
 use near_chain::store_validator::StoreValidator;
 use near_chain::RuntimeAdapter;
-use near_chain_configs::{GenesisValidationMode, DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA};
+use near_chain_configs::{GenesisValidationMode, DEFAULT_GC_NUM_EPOCHS_TO_KEEP};
 use near_logger_utils::init_integration_logger;
 use near_store::create_store;
 use nearcore::{get_default_home, get_store_path, load_config, TrackedConfig};
@@ -41,7 +41,7 @@ fn main() {
         None,
         None,
         None,
-        DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA,
+        DEFAULT_GC_NUM_EPOCHS_TO_KEEP,
     ));
 
     let mut store_validator = StoreValidator::new(

--- a/test-utils/store-validator/src/main.rs
+++ b/test-utils/store-validator/src/main.rs
@@ -41,6 +41,7 @@ fn main() {
         None,
         None,
         None,
+        None,
     ));
 
     let mut store_validator = StoreValidator::new(

--- a/test-utils/store-validator/src/main.rs
+++ b/test-utils/store-validator/src/main.rs
@@ -7,7 +7,7 @@ use clap::{Arg, Command};
 
 use near_chain::store_validator::StoreValidator;
 use near_chain::RuntimeAdapter;
-use near_chain_configs::GenesisValidationMode;
+use near_chain_configs::{DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA, GenesisValidationMode};
 use near_logger_utils::init_integration_logger;
 use near_store::create_store;
 use nearcore::{get_default_home, get_store_path, load_config, TrackedConfig};
@@ -41,7 +41,7 @@ fn main() {
         None,
         None,
         None,
-        None,
+        DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA,
     ));
 
     let mut store_validator = StoreValidator::new(

--- a/testdata/example-config-gc.json
+++ b/testdata/example-config-gc.json
@@ -128,6 +128,6 @@
     "archive": false,
     "gc_blocks_limit": 42,
     "gc_fork_clean_step": 420,
-    "num_epochs_to_keep_store_data": 5,
+    "gc_num_epochs_to_keep": 24,
     "view_client_threads": 4
 }

--- a/testdata/example-config-gc.json
+++ b/testdata/example-config-gc.json
@@ -128,5 +128,6 @@
     "archive": false,
     "gc_blocks_limit": 42,
     "gc_fork_clean_step": 420,
+    "num_epochs_to_keep_store_data": 5,
     "view_client_threads": 4
 }

--- a/tools/restored-receipts-verifier/src/main.rs
+++ b/tools/restored-receipts-verifier/src/main.rs
@@ -1,6 +1,6 @@
 use clap::{Arg, Command};
 use near_chain::{ChainStore, ChainStoreAccess, RuntimeAdapter};
-use near_chain_configs::GenesisValidationMode;
+use near_chain_configs::{DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA, GenesisValidationMode};
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::Receipt;
 use near_store::create_store;
@@ -60,7 +60,7 @@ fn main() -> Result<()> {
         None,
         near_config.client_config.max_gas_burnt_view,
         None,
-        None,
+        DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA,
     );
 
     let mut receipts_missing = Vec::<Receipt>::new();

--- a/tools/restored-receipts-verifier/src/main.rs
+++ b/tools/restored-receipts-verifier/src/main.rs
@@ -1,6 +1,6 @@
 use clap::{Arg, Command};
 use near_chain::{ChainStore, ChainStoreAccess, RuntimeAdapter};
-use near_chain_configs::{DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA, GenesisValidationMode};
+use near_chain_configs::{GenesisValidationMode, DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA};
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::Receipt;
 use near_store::create_store;

--- a/tools/restored-receipts-verifier/src/main.rs
+++ b/tools/restored-receipts-verifier/src/main.rs
@@ -60,6 +60,7 @@ fn main() -> Result<()> {
         None,
         near_config.client_config.max_gas_burnt_view,
         None,
+        None,
     );
 
     let mut receipts_missing = Vec::<Receipt>::new();

--- a/tools/restored-receipts-verifier/src/main.rs
+++ b/tools/restored-receipts-verifier/src/main.rs
@@ -1,6 +1,6 @@
 use clap::{Arg, Command};
 use near_chain::{ChainStore, ChainStoreAccess, RuntimeAdapter};
-use near_chain_configs::{GenesisValidationMode, DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA};
+use near_chain_configs::{GenesisValidationMode, DEFAULT_GC_NUM_EPOCHS_TO_KEEP};
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::Receipt;
 use near_store::create_store;
@@ -60,7 +60,7 @@ fn main() -> Result<()> {
         None,
         near_config.client_config.max_gas_burnt_view,
         None,
-        DEFAULT_NUM_EPOCHS_TO_KEEP_STORE_DATA,
+        DEFAULT_GC_NUM_EPOCHS_TO_KEEP,
     );
 
     let mut receipts_missing = Vec::<Receipt>::new();

--- a/tools/state-viewer/src/apply_chunk.rs
+++ b/tools/state-viewer/src/apply_chunk.rs
@@ -460,6 +460,7 @@ mod test {
             &genesis,
             TrackedConfig::AllShards,
             RuntimeConfigStore::test(),
+            None,
         ));
         let chain_genesis = ChainGenesis::test();
 
@@ -537,6 +538,7 @@ mod test {
             &genesis,
             TrackedConfig::AllShards,
             RuntimeConfigStore::test(),
+            None,
         ));
         let mut chain_genesis = ChainGenesis::test();
         // receipts get delayed with the small ChainGenesis::test() limit


### PR DESCRIPTION
Adds `num_epochs_to_store_data` option to `config.json` file.  This
configures how many epochs back from the current epoch a non-archival
node will keep.  This used to be hard coded to five but can now be
configured.  Note that values below three are mapped to three, that
is, node will always keep data for at least three last epochs.
