### PR TITLE
Increase max open files parameters in rocksdb up to 10K

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 * Switch to LZ4+ZSTD compression from Snappy in RocksDB [#6365](https://github.com/near/nearcore/pull/6365)
 * Moved Client Actor to separate thread - should improve performance [#6333](https://github.com/near/nearcore/pull/6333)
+* Made max_open_files/col_state_cache_size paramaters configurable [#6607](https://github.com/near/nearcore/pull/6607)
+* Increased max_open_files RocksDB parameter from 512 up to 10K [#6607](https://github.com/near/nearcore/pull/6607)
 
 ## `1.23.0` [13-12-2021]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * Switch to LZ4+ZSTD compression from Snappy in RocksDB [#6365](https://github.com/near/nearcore/pull/6365)
 * Moved Client Actor to separate thread - should improve performance [#6333](https://github.com/near/nearcore/pull/6333)
 * [NEP205](https://github.com/near/NEPs/issues/205): Configurable start of protocol upgrade voting [#6309](https://github.com/near/nearcore/pull/6309)
-* Make max_open_files and col_state_cache_size parameters configurable [#6607](https://github.com/near/nearcore/pull/6607)
+* Make max_open_files and col_state_cache_size parameters configurable [#6584](https://github.com/near/nearcore/pull/6584)
 * Increase default max_open_files RocksDB parameter from 512 to 10k [#6607](https://github.com/near/nearcore/pull/6607)
 
 ## `1.23.0` [13-12-2021]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@
 
 * Switch to LZ4+ZSTD compression from Snappy in RocksDB [#6365](https://github.com/near/nearcore/pull/6365)
 * Moved Client Actor to separate thread - should improve performance [#6333](https://github.com/near/nearcore/pull/6333)
-* Make max_open_files/col_state_cache_size paramaters configurable [#6607](https://github.com/near/nearcore/pull/6607)
-* Increase max_open_files RocksDB parameter from 512 up to 10K [#6607](https://github.com/near/nearcore/pull/6607)
+* Make max_open_files and col_state_cache_size parameters configurable [#6607](https://github.com/near/nearcore/pull/6607)
+* Increase default max_open_files RocksDB parameter from 512 to 10k [#6607](https://github.com/near/nearcore/pull/6607)
 
 ## `1.23.0` [13-12-2021]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@
 
 * Switch to LZ4+ZSTD compression from Snappy in RocksDB [#6365](https://github.com/near/nearcore/pull/6365)
 * Moved Client Actor to separate thread - should improve performance [#6333](https://github.com/near/nearcore/pull/6333)
-* Made max_open_files/col_state_cache_size paramaters configurable [#6607](https://github.com/near/nearcore/pull/6607)
-* Increased max_open_files RocksDB parameter from 512 up to 10K [#6607](https://github.com/near/nearcore/pull/6607)
+* Make max_open_files/col_state_cache_size paramaters configurable [#6607](https://github.com/near/nearcore/pull/6607)
+* Increase max_open_files RocksDB parameter from 512 up to 10K [#6607](https://github.com/near/nearcore/pull/6607)
 
 ## `1.23.0` [13-12-2021]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3181,6 +3181,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "rand 0.7.3",
+ "rlimit",
  "rocksdb",
  "serde",
  "serde_json",

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -25,6 +25,7 @@ borsh = "0.9"
 thiserror = "1"
 lru = "0.7.2"
 once_cell = "1.5.2"
+rlimit = "0.7"
 
 near-crypto = { path = "../crypto" }
 near-primitives = { path = "../primitives" }

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -150,7 +150,7 @@ fn ensure_max_open_files_limit(max_open_files: i32) -> () {
     let required = max_open_files as u64 + 1025;
     if soft < required {
         assert!(hard >= required, "Can't run near binary since hard limit for the number \
-                of opened files is too small: {} required: {}", hard, 2 * max_open_files);
+                of opened files is too small: {} required: {}", hard, required);
         rlimit::Resource::NOFILE.set(required, hard).unwrap();
     }
 }

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -149,8 +149,13 @@ fn ensure_max_open_files_limit(max_open_files: i32) -> () {
     let (soft, hard) = rlimit::Resource::NOFILE.get().unwrap();
     let required = max_open_files as u64 + 1025;
     if soft < required {
-        assert!(hard >= required, "Can't run near binary since hard limit for the number \
-                of opened files is too small: {} required: {}", hard, required);
+        assert!(
+            hard >= required,
+            "Can't run near binary since hard limit for the number \
+                of opened files is too small: {} required: {}",
+            hard,
+            required
+        );
         rlimit::Resource::NOFILE.set(required, hard).unwrap();
     }
 }

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -473,6 +473,18 @@ fn set_compression_options(opts: &mut Options) {
     opts.set_bottommost_zstd_max_train_bytes(max_train_bytes, true);
 }
 
+fn ensure_max_open_files_limit(max_open_files: i32) -> () {
+    // We’re configuring each RocksDB to use max_open_files file descriptors. In top of that we can
+    // have some other file descriptors opened by neard process so we use the value of
+    // 2 * max_open_files to be sure that the binary can correctly run.
+    let (soft, hard) = rlimit::Resource::NOFILE.get().unwrap();
+    let required = 2 * max_open_files as u64;
+    if soft < required {
+        assert!(hard >= required, "Can't run near binary since hard limit for the number of opened files is too small: {} required: {}", hard, 2 * max_open_files);
+        rlimit::Resource::NOFILE.set(required, hard).unwrap();
+    }
+}
+
 /// DB level options
 fn rocksdb_options(store_config: &StoreConfig) -> Options {
     let mut opts = Options::default();
@@ -481,6 +493,7 @@ fn rocksdb_options(store_config: &StoreConfig) -> Options {
     opts.create_missing_column_families(true);
     opts.create_if_missing(true);
     opts.set_use_fsync(false);
+    ensure_max_open_files_limit(store_config.max_open_files);
     opts.set_max_open_files(store_config.max_open_files);
     opts.set_keep_log_file_num(1);
     opts.set_bytes_per_sync(bytesize::MIB);

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -145,12 +145,12 @@ fn col_name(col: DBCol) -> String {
 fn ensure_max_open_files_limit(max_open_files: i32) -> () {
     // We’re configuring each RocksDB to use max_open_files file descriptors. On top of that we can
     // have some other file descriptors opened by neard process so we use the value of
-    // 2 * max_open_files to be sure that the binary can correctly run.
+    // max_open_files + 1025 to be sure that the binary can correctly run.
     let (soft, hard) = rlimit::Resource::NOFILE.get().unwrap();
     let required = max_open_files as u64 + 1025;
     if soft < required {
-        assert!(hard >= required, concat!("Can't run near binary since hard limit for the number ",
-                "of opened files is too small: {} required: {}"), hard, 2 * max_open_files);
+        assert!(hard >= required, "Can't run near binary since hard limit for the number \
+                of opened files is too small: {} required: {}", hard, 2 * max_open_files);
         rlimit::Resource::NOFILE.set(required, hard).unwrap();
     }
 }

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -474,7 +474,7 @@ fn set_compression_options(opts: &mut Options) {
 }
 
 fn ensure_max_open_files_limit(max_open_files: i32) -> () {
-    // We’re configuring each RocksDB to use max_open_files file descriptors. In top of that we can
+    // We’re configuring each RocksDB to use max_open_files file descriptors. On top of that we can
     // have some other file descriptors opened by neard process so we use the value of
     // 2 * max_open_files to be sure that the binary can correctly run.
     let (soft, hard) = rlimit::Resource::NOFILE.get().unwrap();

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -145,7 +145,7 @@ fn col_name(col: DBCol) -> String {
 fn ensure_max_open_files_limit(max_open_files: i32) -> () {
     // We’re configuring each RocksDB to use max_open_files file descriptors. On top of that we can
     // have some other file descriptors opened by neard process so we use the value of
-    // max_open_files + 1025 to be sure that the binary can correctly run.
+    // max_open_files + some constant to be sure that the binary can correctly run.
     let (soft, hard) = rlimit::Resource::NOFILE.get().unwrap();
     let required = max_open_files as u64 + 1025;
     if soft < required {

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -147,7 +147,7 @@ fn ensure_max_open_files_limit(max_open_files: i32) -> () {
     // have some other file descriptors opened by neard process so we use the value of
     // 2 * max_open_files to be sure that the binary can correctly run.
     let (soft, hard) = rlimit::Resource::NOFILE.get().unwrap();
-    let required = 2 * max_open_files as u64;
+    let required = max_open_files as u64 + 1025;
     if soft < required {
         assert!(hard >= required, concat!("Can't run near binary since hard limit for the number ",
                 "of opened files is too small: {} required: {}"), hard, 2 * max_open_files);


### PR DESCRIPTION
Increase the default max_open_files from 512 up to 10k;
Set ulimit for the number of files from neard to 11025.