### PR TITLE
Fixed network integration tests which were succeeding even though nodes were crashing in the middle.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2075,6 +2075,7 @@ version = "0.0.0"
 dependencies = [
  "actix",
  "actix-rt",
+ "anyhow",
  "assert_matches",
  "base64 0.11.0",
  "borsh",
@@ -2107,6 +2108,7 @@ dependencies = [
  "nearcore",
  "node-runtime",
  "once_cell",
+ "parking_lot 0.11.2",
  "portpicker",
  "primitive-types",
  "rand 0.7.3",

--- a/chain/network/src/routing/edge_validator_actor.rs
+++ b/chain/network/src/routing/edge_validator_actor.rs
@@ -1,5 +1,5 @@
 use crate::private_actix::{StopMsg, ValidateEdgeList};
-use actix::{Actor, Handler, SyncContext, System};
+use actix::{Actor, Handler, SyncContext, ActorContext};
 use conqueue::{QueueReceiver, QueueSender};
 use near_network_primitives::types::Edge;
 use near_performance_metrics_macros::perf;
@@ -22,8 +22,8 @@ impl Actor for EdgeValidatorActor {
 
 impl Handler<StopMsg> for EdgeValidatorActor {
     type Result = ();
-    fn handle(&mut self, _: StopMsg, _ctx: &mut Self::Context) -> Self::Result {
-        System::current().stop();
+    fn handle(&mut self, _: StopMsg, ctx: &mut Self::Context) -> Self::Result {
+        ctx.stop();
     }
 }
 

--- a/chain/network/src/routing/edge_validator_actor.rs
+++ b/chain/network/src/routing/edge_validator_actor.rs
@@ -1,5 +1,5 @@
 use crate::private_actix::{StopMsg, ValidateEdgeList};
-use actix::{Actor, Handler, SyncContext, ActorContext};
+use actix::{Actor, ActorContext, Handler, SyncContext};
 use conqueue::{QueueReceiver, QueueSender};
 use near_network_primitives::types::Edge;
 use near_performance_metrics_macros::perf;

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -4,8 +4,7 @@ use crate::routing::graph::Graph;
 use crate::routing::routing_table_view::SAVE_PEERS_MAX_TIME;
 use crate::stats::metrics;
 use actix::{
-    Actor, ActorFutureExt, Addr, Context, ContextFutureSpawner, Handler, Running, SyncArbiter,
-    System, WrapFuture,
+    Actor, ActorFutureExt, Addr, Context, ContextFutureSpawner, Handler, Running, SyncArbiter, WrapFuture, ActorContext,
 };
 use near_network_primitives::types::{Edge, EdgeState};
 use near_performance_metrics_macros::perf;
@@ -411,9 +410,9 @@ impl Actor for RoutingTableActor {
 
 impl Handler<StopMsg> for RoutingTableActor {
     type Result = ();
-    fn handle(&mut self, _: StopMsg, _ctx: &mut Self::Context) -> Self::Result {
+    fn handle(&mut self, _: StopMsg, ctx: &mut Self::Context) -> Self::Result {
         self.edge_validator_pool.do_send(StopMsg {});
-        System::current().stop();
+        ctx.stop();
     }
 }
 

--- a/chain/network/src/routing/routing_table_actor.rs
+++ b/chain/network/src/routing/routing_table_actor.rs
@@ -4,7 +4,8 @@ use crate::routing::graph::Graph;
 use crate::routing::routing_table_view::SAVE_PEERS_MAX_TIME;
 use crate::stats::metrics;
 use actix::{
-    Actor, ActorFutureExt, Addr, Context, ContextFutureSpawner, Handler, Running, SyncArbiter, WrapFuture, ActorContext,
+    Actor, ActorContext, ActorFutureExt, Addr, Context, ContextFutureSpawner, Handler, Running,
+    SyncArbiter, WrapFuture,
 };
 use near_network_primitives::types::{Edge, EdgeState};
 use near_performance_metrics_macros::perf;

--- a/chain/network/src/test_utils.rs
+++ b/chain/network/src/test_utils.rs
@@ -411,7 +411,6 @@ impl PeerManagerAdapter for NetworkRecipient {
 
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
 #[derive(Message, Clone, Debug)]
-#[cfg(feature = "test_features")]
 #[rtype(result = "()")]
 pub struct SetAdvOptions {
     pub disable_edge_signature_verification: Option<bool>,

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -14,6 +14,7 @@ name = "start_mock_network"
 [dependencies]
 actix = "0.13.0"
 actix-rt = "2"
+anyhow = "1.0.55"
 base64 = "0.11"
 borsh = "0.9"
 chrono = { version = "0.4.4", features = ["serde"] }
@@ -22,6 +23,7 @@ futures = "0.3"
 hex = "0.4"
 hyper = { version = "0.14", features = ["full"] }
 once_cell = "1.5"
+parking_lot = "0.11.2"
 primitive-types = "0.10.1"
 rand = "0.7"
 regex = "1"

--- a/integration-tests/src/tests/network/ban_peers.rs
+++ b/integration-tests/src/tests/network/ban_peers.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 /// Check we don't try to connect to a banned peer and we don't accept
 /// incoming connection from it.
 #[test]
-fn dont_connect_to_banned_peer() {
+fn dont_connect_to_banned_peer() -> anyhow::Result<()> {
     let mut runner = Runner::new(2, 2)
         .enable_outbound()
         .use_boot_nodes(vec![0, 1])
@@ -15,17 +15,17 @@ fn dont_connect_to_banned_peer() {
 
     runner.push_action(ban_peer(0, 1));
     // It needs to wait a large timeout so we are sure both peer don't establish a connection.
-    runner.push(Action::Wait(1000));
+    runner.push(Action::Wait(Duration::from_millis(1000)));
 
     runner.push(Action::CheckRoutingTable(0, vec![]));
     runner.push(Action::CheckRoutingTable(1, vec![]));
 
-    start_test(runner);
+    start_test(runner)
 }
 
 /// Check two peers are able to connect again after one peers is banned and unbanned.
 #[test]
-fn connect_to_unbanned_peer() {
+fn connect_to_unbanned_peer() -> anyhow::Result<()> {
     let mut runner = Runner::new(2, 2)
         .enable_outbound()
         .use_boot_nodes(vec![0, 1])
@@ -38,7 +38,7 @@ fn connect_to_unbanned_peer() {
     // Ban peer 1
     runner.push_action(ban_peer(0, 1));
 
-    runner.push(Action::Wait(1000));
+    runner.push(Action::Wait(Duration::from_millis(1000)));
     // During two seconds peer is banned so no connection is possible.
     runner.push(Action::CheckRoutingTable(0, vec![]));
     runner.push(Action::CheckRoutingTable(1, vec![]));
@@ -47,5 +47,5 @@ fn connect_to_unbanned_peer() {
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1])]));
     runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0])]));
 
-    start_test(runner);
+    start_test(runner)
 }

--- a/integration-tests/src/tests/network/churn_attack.rs
+++ b/integration-tests/src/tests/network/churn_attack.rs
@@ -5,13 +5,13 @@ pub use crate::tests::network::runner::*;
 /// Turn off two non adjacent nodes, and check other two nodes create
 /// a connection among them.
 #[test]
-fn churn_attack() {
+fn churn_attack() -> anyhow::Result<()> {
     let mut runner = Runner::new(4, 4).enable_outbound().max_num_peers(2);
 
-    runner.push(Action::AddEdge(0, 1));
-    runner.push(Action::AddEdge(2, 3));
-    runner.push(Action::AddEdge(3, 0));
-    runner.push(Action::AddEdge(1, 2));
+    runner.push(Action::AddEdge(0, 1, true));
+    runner.push(Action::AddEdge(2, 3, true));
+    runner.push(Action::AddEdge(3, 0, true));
+    runner.push(Action::AddEdge(1, 2, true));
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (3, vec![3]), (2, vec![1, 3])]));
     runner.push(Action::CheckRoutingTable(2, vec![(1, vec![1]), (3, vec![3]), (0, vec![1, 3])]));
     runner.push(Action::Stop(1));
@@ -19,5 +19,5 @@ fn churn_attack() {
     runner.push(Action::CheckRoutingTable(0, vec![(2, vec![2])]));
     runner.push(Action::CheckRoutingTable(2, vec![(0, vec![0])]));
 
-    start_test(runner);
+    start_test(runner)
 }

--- a/integration-tests/src/tests/network/churn_attack.rs
+++ b/integration-tests/src/tests/network/churn_attack.rs
@@ -8,10 +8,10 @@ pub use crate::tests::network::runner::*;
 fn churn_attack() -> anyhow::Result<()> {
     let mut runner = Runner::new(4, 4).enable_outbound().max_num_peers(2);
 
-    runner.push(Action::AddEdge(0, 1, true));
-    runner.push(Action::AddEdge(2, 3, true));
-    runner.push(Action::AddEdge(3, 0, true));
-    runner.push(Action::AddEdge(1, 2, true));
+    runner.push(Action::AddEdge { from: 0, to: 1, force: true });
+    runner.push(Action::AddEdge { from: 2, to: 3, force: true });
+    runner.push(Action::AddEdge { from: 3, to: 0, force: true });
+    runner.push(Action::AddEdge { from: 1, to: 2, force: true });
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (3, vec![3]), (2, vec![1, 3])]));
     runner.push(Action::CheckRoutingTable(2, vec![(1, vec![1]), (3, vec![3]), (0, vec![1, 3])]));
     runner.push(Action::Stop(1));

--- a/integration-tests/src/tests/network/full_network.rs
+++ b/integration-tests/src/tests/network/full_network.rs
@@ -14,7 +14,7 @@ pub fn connect_at_max_capacity(
     max_num_peers: u32,
     expected_connections: usize,
     extra_nodes: usize,
-) {
+) -> anyhow::Result<()> {
     // Use at most 4 boot nodes
     let total_boot_nodes = min(num_node, 4);
 
@@ -50,25 +50,25 @@ pub fn connect_at_max_capacity(
         runner.push_action(check_expected_connections(node_id, Some(expected_connections), None));
     }
 
-    start_test(runner);
+    start_test(runner)
 }
 
 /// Check that two nodes are able to connect if they only know themselves from boot list.
 #[test]
-fn simple_network() {
-    connect_at_max_capacity(2, 1, 1, 1, 1, 0);
+fn simple_network() -> anyhow::Result<()> {
+    connect_at_max_capacity(2, 1, 1, 1, 1, 0)
 }
 
 /// Start 4 nodes and connect them all with each other.
 /// Create new node, it should be able to connect since max allowed peers is 4.
 #[test]
-fn connect_on_almost_full_network() {
-    connect_at_max_capacity(4, 1, 3, 4, 1, 1);
+fn connect_on_almost_full_network() -> anyhow::Result<()> {
+    connect_at_max_capacity(4, 1, 3, 4, 1, 1)
 }
 
 /// Start 4 nodes and connect them all with each other.
 /// Create new node, it should be able to connect even if max allowed peers is 3.
 #[test]
-fn connect_on_full_network() {
-    connect_at_max_capacity(5, 2, 3, 4, 2, 1);
+fn connect_on_full_network() -> anyhow::Result<()> {
+    connect_at_max_capacity(5, 2, 3, 4, 2, 1)
 }

--- a/integration-tests/src/tests/network/peer_handshake.rs
+++ b/integration-tests/src/tests/network/peer_handshake.rs
@@ -212,12 +212,12 @@ fn peer_recover() {
 /// B knows nothing about A (since store is wiped) and A knows old information from B.
 /// A should learn new information from B and connect with it.
 #[test]
-fn check_connection_with_new_identity() {
+fn check_connection_with_new_identity() -> anyhow::Result<()> {
     let mut runner = Runner::new(2, 2).enable_outbound();
 
     // This is needed, because even if outbound is enabled, there is no booting nodes,
     // so A and B doesn't know each other yet.
-    runner.push(Action::AddEdge(0, 1));
+    runner.push(Action::AddEdge(0, 1, true));
 
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1])]));
     runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0])]));
@@ -230,13 +230,13 @@ fn check_connection_with_new_identity() {
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1])]));
     runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0])]));
 
-    runner.push(Action::Wait(2000));
+    runner.push(Action::Wait(Duration::from_millis(2000)));
 
     // Check the no node tried to connect to itself in this process.
     #[cfg(feature = "test_features")]
     runner.push_action(wait_for(|| near_network::RECEIVED_INFO_ABOUT_ITSELF.get() == 0));
 
-    start_test(runner);
+    start_test(runner)
 }
 
 #[test]

--- a/integration-tests/src/tests/network/peer_handshake.rs
+++ b/integration-tests/src/tests/network/peer_handshake.rs
@@ -217,7 +217,7 @@ fn check_connection_with_new_identity() -> anyhow::Result<()> {
 
     // This is needed, because even if outbound is enabled, there is no booting nodes,
     // so A and B doesn't know each other yet.
-    runner.push(Action::AddEdge(0, 1, true));
+    runner.push(Action::AddEdge { from: 0, to: 1, force: true });
 
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1])]));
     runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0])]));

--- a/integration-tests/src/tests/network/routing.rs
+++ b/integration-tests/src/tests/network/routing.rs
@@ -5,7 +5,7 @@ use tokio::time::Duration;
 fn simple() -> anyhow::Result<()> {
     let mut runner = Runner::new(2, 1);
 
-    runner.push(Action::AddEdge(0, 1, true));
+    runner.push(Action::AddEdge { from: 0, to: 1, force: true });
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1])]));
     runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0])]));
 
@@ -26,8 +26,8 @@ fn from_boot_nodes() -> anyhow::Result<()> {
 fn three_nodes_path() -> anyhow::Result<()> {
     let mut runner = Runner::new(3, 2);
 
-    runner.push(Action::AddEdge(0, 1, true));
-    runner.push(Action::AddEdge(1, 2, true));
+    runner.push(Action::AddEdge { from: 0, to: 1, force: true });
+    runner.push(Action::AddEdge { from: 1, to: 2, force: true });
     runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0]), (2, vec![2])]));
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![1])]));
     runner.push(Action::CheckRoutingTable(2, vec![(1, vec![1]), (0, vec![1])]));
@@ -39,12 +39,12 @@ fn three_nodes_path() -> anyhow::Result<()> {
 fn three_nodes_star() -> anyhow::Result<()> {
     let mut runner = Runner::new(3, 2);
 
-    runner.push(Action::AddEdge(0, 1, true));
-    runner.push(Action::AddEdge(1, 2, true));
+    runner.push(Action::AddEdge { from: 0, to: 1, force: true });
+    runner.push(Action::AddEdge { from: 1, to: 2, force: true });
     runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0]), (2, vec![2])]));
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![1])]));
     runner.push(Action::CheckRoutingTable(2, vec![(1, vec![1]), (0, vec![1])]));
-    runner.push(Action::AddEdge(0, 2, true));
+    runner.push(Action::AddEdge { from: 0, to: 2, force: true });
     runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0]), (2, vec![2])]));
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![2])]));
     runner.push(Action::CheckRoutingTable(2, vec![(1, vec![1]), (0, vec![0])]));
@@ -56,14 +56,14 @@ fn three_nodes_star() -> anyhow::Result<()> {
 fn join_components() -> anyhow::Result<()> {
     let mut runner = Runner::new(4, 4);
 
-    runner.push(Action::AddEdge(0, 1, true));
-    runner.push(Action::AddEdge(2, 3, true));
+    runner.push(Action::AddEdge { from: 0, to: 1, force: true });
+    runner.push(Action::AddEdge { from: 2, to: 3, force: true });
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1])]));
     runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0])]));
     runner.push(Action::CheckRoutingTable(2, vec![(3, vec![3])]));
     runner.push(Action::CheckRoutingTable(3, vec![(2, vec![2])]));
-    runner.push(Action::AddEdge(0, 2, true));
-    runner.push(Action::AddEdge(3, 1, true));
+    runner.push(Action::AddEdge { from: 0, to: 2, force: true });
+    runner.push(Action::AddEdge { from: 3, to: 1, force: true });
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![2]), (3, vec![1, 2])]));
     runner.push(Action::CheckRoutingTable(3, vec![(1, vec![1]), (2, vec![2]), (0, vec![1, 2])]));
     runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0]), (3, vec![3]), (2, vec![0, 3])]));
@@ -76,9 +76,9 @@ fn join_components() -> anyhow::Result<()> {
 fn account_propagation() -> anyhow::Result<()> {
     let mut runner = Runner::new(3, 2);
 
-    runner.push(Action::AddEdge(0, 1, true));
+    runner.push(Action::AddEdge { from: 0, to: 1, force: true });
     runner.push(Action::CheckAccountId(1, vec![0, 1]));
-    runner.push(Action::AddEdge(0, 2, true));
+    runner.push(Action::AddEdge { from: 0, to: 2, force: true });
     runner.push(Action::CheckAccountId(2, vec![0, 1]));
 
     start_test(runner)
@@ -88,7 +88,7 @@ fn account_propagation() -> anyhow::Result<()> {
 fn ping_simple() -> anyhow::Result<()> {
     let mut runner = Runner::new(2, 2);
 
-    runner.push(Action::AddEdge(0, 1, true));
+    runner.push(Action::AddEdge { from: 0, to: 1, force: true });
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1])]));
     runner.push(Action::PingTo(0, 0, 1));
     runner.push(Action::CheckPingPong(1, vec![(0, 0, None)], vec![]));
@@ -103,8 +103,8 @@ fn ping_jump() -> anyhow::Result<()> {
     let mut runner = Runner::new(3, 2);
 
     // Add edges
-    runner.push(Action::AddEdge(0, 1, true));
-    runner.push(Action::AddEdge(1, 2, true));
+    runner.push(Action::AddEdge { from: 0, to: 1, force: true });
+    runner.push(Action::AddEdge { from: 1, to: 2, force: true });
     // Check routing tables and wait for `PeerManager` to update it's routing table
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![1])]));
     runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0]), (2, vec![2])]));
@@ -132,8 +132,8 @@ fn ping_jump() -> anyhow::Result<()> {
 fn test_dont_drop_after_ttl() -> anyhow::Result<()> {
     let mut runner = Runner::new(3, 1).routed_message_ttl(2);
 
-    runner.push(Action::AddEdge(0, 1, true));
-    runner.push(Action::AddEdge(1, 2, true));
+    runner.push(Action::AddEdge { from: 0, to: 1, force: true });
+    runner.push(Action::AddEdge { from: 1, to: 2, force: true });
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![1])]));
     runner.push(Action::PingTo(0, 0, 2));
     runner.push(Action::CheckPingPong(2, vec![(0, 0, None)], vec![]));
@@ -154,8 +154,8 @@ fn test_dont_drop_after_ttl() -> anyhow::Result<()> {
 fn test_drop_after_ttl() -> anyhow::Result<()> {
     let mut runner = Runner::new(3, 1).routed_message_ttl(1);
 
-    runner.push(Action::AddEdge(0, 1, true));
-    runner.push(Action::AddEdge(1, 2, true));
+    runner.push(Action::AddEdge { from: 0, to: 1, force: true });
+    runner.push(Action::AddEdge { from: 1, to: 2, force: true });
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![1])]));
     runner.push(Action::PingTo(0, 0, 2));
     runner.push(Action::Wait(Duration::from_millis(100)));
@@ -169,8 +169,8 @@ fn test_drop_after_ttl() -> anyhow::Result<()> {
 fn simple_remove() -> anyhow::Result<()> {
     let mut runner = Runner::new(3, 3);
 
-    runner.push(Action::AddEdge(0, 1, true));
-    runner.push(Action::AddEdge(1, 2, true));
+    runner.push(Action::AddEdge { from: 0, to: 1, force: true });
+    runner.push(Action::AddEdge { from: 1, to: 2, force: true });
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![1])]));
     runner.push(Action::CheckRoutingTable(2, vec![(1, vec![1]), (0, vec![1])]));
     runner.push(Action::Stop(1));
@@ -184,10 +184,10 @@ fn simple_remove() -> anyhow::Result<()> {
 fn square() -> anyhow::Result<()> {
     let mut runner = Runner::new(4, 4);
 
-    runner.push(Action::AddEdge(0, 1, true));
-    runner.push(Action::AddEdge(1, 2, true));
-    runner.push(Action::AddEdge(2, 3, true));
-    runner.push(Action::AddEdge(3, 0, true));
+    runner.push(Action::AddEdge { from: 0, to: 1, force: true });
+    runner.push(Action::AddEdge { from: 1, to: 2, force: true });
+    runner.push(Action::AddEdge { from: 2, to: 3, force: true });
+    runner.push(Action::AddEdge { from: 3, to: 0, force: true });
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (3, vec![3]), (2, vec![1, 3])]));
     runner.push(Action::Stop(1));
     runner.push(Action::CheckRoutingTable(0, vec![(3, vec![3]), (2, vec![3])]));
@@ -236,12 +236,12 @@ fn blacklist_all() -> anyhow::Result<()> {
 fn max_num_peers_limit() -> anyhow::Result<()> {
     let mut runner = Runner::new(4, 4).max_num_peers(2).enable_outbound();
 
-    runner.push(Action::AddEdge(0, 1, true));
-    runner.push(Action::AddEdge(1, 2, true));
+    runner.push(Action::AddEdge { from: 0, to: 1, force: true });
+    runner.push(Action::AddEdge { from: 1, to: 2, force: true });
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![2])]));
     runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0]), (2, vec![2])]));
     runner.push(Action::CheckRoutingTable(2, vec![(1, vec![1]), (0, vec![0])]));
-    runner.push(Action::AddEdge(3, 0, false));
+    runner.push(Action::AddEdge { from: 3, to: 0, force: false });
     runner.push(Action::Wait(Duration::from_millis(100)));
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![2])]));
     runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0]), (2, vec![2])]));
@@ -266,25 +266,25 @@ fn archival_node() -> anyhow::Result<()> {
         .set_as_archival(0)
         .set_as_archival(1);
 
-    runner.push(Action::AddEdge(2, 0, true));
+    runner.push(Action::AddEdge { from: 2, to: 0, force: true });
     runner.push(Action::Wait(Duration::from_millis(50)));
-    runner.push(Action::AddEdge(3, 0, true));
+    runner.push(Action::AddEdge { from: 3, to: 0, force: true });
     runner.push(Action::Wait(Duration::from_millis(50)));
-    runner.push(Action::AddEdge(4, 0, true));
+    runner.push(Action::AddEdge { from: 4, to: 0, force: true });
     runner.push(Action::Wait(Duration::from_millis(50)));
     runner.push_action(check_expected_connections(0, Some(2), Some(2)));
 
-    runner.push(Action::AddEdge(1, 0, true));
+    runner.push(Action::AddEdge { from: 1, to: 0, force: true });
     runner.push(Action::Wait(Duration::from_millis(50)));
     runner.push_action(check_expected_connections(0, Some(2), Some(2)));
     runner.push_action(check_direct_connection(0, 1));
 
     for _step in 0..4 {
-        runner.push(Action::AddEdge(2, 0, true));
+        runner.push(Action::AddEdge { from: 2, to: 0, force: true });
         runner.push(Action::Wait(Duration::from_millis(50)));
-        runner.push(Action::AddEdge(3, 0, true));
+        runner.push(Action::AddEdge { from: 3, to: 0, force: true });
         runner.push(Action::Wait(Duration::from_millis(50)));
-        runner.push(Action::AddEdge(4, 0, true));
+        runner.push(Action::AddEdge { from: 4, to: 0, force: true });
         runner.push(Action::Wait(Duration::from_millis(50)));
         runner.push_action(check_expected_connections(0, Some(2), Some(2)));
         runner.push_action(check_direct_connection(0, 1));
@@ -302,27 +302,27 @@ fn test_dropping_routing_messages() -> anyhow::Result<()> {
     runner.push(Action::SetOptions { target: 0, max_num_peers: Some(1) });
     runner.push(Action::SetOptions { target: 1, max_num_peers: Some(2) });
     runner.push(Action::SetOptions { target: 2, max_num_peers: Some(1) });
-    runner.push(Action::AddEdge(0, 1, true));
-    runner.push(Action::AddEdge(1, 2, true));
+    runner.push(Action::AddEdge { from: 0, to: 1, force: true });
+    runner.push(Action::AddEdge { from: 1, to: 2, force: true });
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1])]));
     runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0]), (2, vec![2])]));
     runner.push(Action::CheckRoutingTable(2, vec![(1, vec![1])]));
     // Wait for routing table calculation
-    runner.push(Action::Wait(2000));
+    runner.push(Action::Wait(Duration::from_millis(2000)));
 
     // Send two pings, one will be dropped, because the delay between them was less than 100ms.
     runner.push(Action::PingTo(0, 0, 2));
     runner.push(Action::PingTo(0, 0, 2));
-    runner.push(Action::Wait(100));
+    runner.push(Action::Wait(Duration::from_millis(100)));
     runner.push(Action::CheckPingPong(2, vec![(0, 0, Some(1))], vec![]));
     runner.push(Action::CheckPingPong(0, vec![], vec![(0, 2, Some(1))]));
 
     // Send two pings, one will be dropped, the delay is 150ms, so they don't get dropped.
-    runner.push(Action::Wait(300));
+    runner.push(Action::Wait(Duration::from_millis(300)));
     runner.push(Action::PingTo(0, 0, 2));
-    runner.push(Action::Wait(300));
+    runner.push(Action::Wait(Duration::from_millis(300)));
     runner.push(Action::PingTo(0, 0, 2));
-    runner.push(Action::Wait(300));
+    runner.push(Action::Wait(Duration::from_millis(300)));
     runner.push(Action::CheckPingPong(2, vec![(0, 0, Some(3))], vec![]));
     runner.push(Action::CheckPingPong(0, vec![], vec![(0, 2, Some(3))]));
 

--- a/integration-tests/src/tests/network/routing.rs
+++ b/integration-tests/src/tests/network/routing.rs
@@ -1,109 +1,110 @@
 use crate::tests::network::runner::*;
+use tokio::time::Duration;
 
 #[test]
-fn simple() {
+fn simple() -> anyhow::Result<()> {
     let mut runner = Runner::new(2, 1);
 
-    runner.push(Action::AddEdge(0, 1));
+    runner.push(Action::AddEdge(0, 1, true));
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1])]));
     runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0])]));
 
-    start_test(runner);
+    start_test(runner)
 }
 
 #[test]
-fn from_boot_nodes() {
+fn from_boot_nodes() -> anyhow::Result<()> {
     let mut runner = Runner::new(2, 1).use_boot_nodes(vec![0]).enable_outbound();
 
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1])]));
     runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0])]));
 
-    start_test(runner);
+    start_test(runner)
 }
 
 #[test]
-fn three_nodes_path() {
+fn three_nodes_path() -> anyhow::Result<()> {
     let mut runner = Runner::new(3, 2);
 
-    runner.push(Action::AddEdge(0, 1));
-    runner.push(Action::AddEdge(1, 2));
+    runner.push(Action::AddEdge(0, 1, true));
+    runner.push(Action::AddEdge(1, 2, true));
     runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0]), (2, vec![2])]));
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![1])]));
     runner.push(Action::CheckRoutingTable(2, vec![(1, vec![1]), (0, vec![1])]));
 
-    start_test(runner);
+    start_test(runner)
 }
 
 #[test]
-fn three_nodes_star() {
+fn three_nodes_star() -> anyhow::Result<()> {
     let mut runner = Runner::new(3, 2);
 
-    runner.push(Action::AddEdge(0, 1));
-    runner.push(Action::AddEdge(1, 2));
+    runner.push(Action::AddEdge(0, 1, true));
+    runner.push(Action::AddEdge(1, 2, true));
     runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0]), (2, vec![2])]));
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![1])]));
     runner.push(Action::CheckRoutingTable(2, vec![(1, vec![1]), (0, vec![1])]));
-    runner.push(Action::AddEdge(0, 2));
+    runner.push(Action::AddEdge(0, 2, true));
     runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0]), (2, vec![2])]));
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![2])]));
     runner.push(Action::CheckRoutingTable(2, vec![(1, vec![1]), (0, vec![0])]));
 
-    start_test(runner);
+    start_test(runner)
 }
 
 #[test]
-fn join_components() {
+fn join_components() -> anyhow::Result<()> {
     let mut runner = Runner::new(4, 4);
 
-    runner.push(Action::AddEdge(0, 1));
-    runner.push(Action::AddEdge(2, 3));
+    runner.push(Action::AddEdge(0, 1, true));
+    runner.push(Action::AddEdge(2, 3, true));
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1])]));
     runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0])]));
     runner.push(Action::CheckRoutingTable(2, vec![(3, vec![3])]));
     runner.push(Action::CheckRoutingTable(3, vec![(2, vec![2])]));
-    runner.push(Action::AddEdge(0, 2));
-    runner.push(Action::AddEdge(3, 1));
+    runner.push(Action::AddEdge(0, 2, true));
+    runner.push(Action::AddEdge(3, 1, true));
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![2]), (3, vec![1, 2])]));
     runner.push(Action::CheckRoutingTable(3, vec![(1, vec![1]), (2, vec![2]), (0, vec![1, 2])]));
     runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0]), (3, vec![3]), (2, vec![0, 3])]));
     runner.push(Action::CheckRoutingTable(2, vec![(0, vec![0]), (3, vec![3]), (1, vec![0, 3])]));
 
-    start_test(runner);
+    start_test(runner)
 }
 
 #[test]
-fn account_propagation() {
+fn account_propagation() -> anyhow::Result<()> {
     let mut runner = Runner::new(3, 2);
 
-    runner.push(Action::AddEdge(0, 1));
+    runner.push(Action::AddEdge(0, 1, true));
     runner.push(Action::CheckAccountId(1, vec![0, 1]));
-    runner.push(Action::AddEdge(0, 2));
+    runner.push(Action::AddEdge(0, 2, true));
     runner.push(Action::CheckAccountId(2, vec![0, 1]));
 
-    start_test(runner);
+    start_test(runner)
 }
 
 #[test]
-fn ping_simple() {
+fn ping_simple() -> anyhow::Result<()> {
     let mut runner = Runner::new(2, 2);
 
-    runner.push(Action::AddEdge(0, 1));
+    runner.push(Action::AddEdge(0, 1, true));
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1])]));
     runner.push(Action::PingTo(0, 0, 1));
     runner.push(Action::CheckPingPong(1, vec![(0, 0, None)], vec![]));
     runner.push(Action::CheckPingPong(0, vec![], vec![(0, 1, None)]));
 
-    start_test(runner);
+    start_test(runner)
 }
 
 #[test]
 /// Crate 3 nodes connected in a line and try to use Ping.
-fn ping_jump() {
+fn ping_jump() -> anyhow::Result<()> {
     let mut runner = Runner::new(3, 2);
 
     // Add edges
-    runner.push(Action::AddEdge(0, 1));
-    runner.push(Action::AddEdge(1, 2));
+    runner.push(Action::AddEdge(0, 1, true));
+    runner.push(Action::AddEdge(1, 2, true));
     // Check routing tables and wait for `PeerManager` to update it's routing table
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![1])]));
     runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0]), (2, vec![2])]));
@@ -116,7 +117,7 @@ fn ping_jump() {
     // Check whenever Node 0 got reply from 2.
     runner.push(Action::CheckPingPong(0, vec![], vec![(0, 2, None)]));
 
-    start_test(runner);
+    start_test(runner)
 }
 
 /// Test routed messages are not dropped if have enough TTL.
@@ -128,17 +129,17 @@ fn ping_jump() {
 /// Send Ping from 0 to 2. It should arrive since there are only 2 edges from 0 to 2.
 /// Check Ping arrive at node 2 and later Pong arrive at node 0.
 #[test]
-fn test_dont_drop_after_ttl() {
+fn test_dont_drop_after_ttl() -> anyhow::Result<()> {
     let mut runner = Runner::new(3, 1).routed_message_ttl(2);
 
-    runner.push(Action::AddEdge(0, 1));
-    runner.push(Action::AddEdge(1, 2));
+    runner.push(Action::AddEdge(0, 1, true));
+    runner.push(Action::AddEdge(1, 2, true));
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![1])]));
     runner.push(Action::PingTo(0, 0, 2));
     runner.push(Action::CheckPingPong(2, vec![(0, 0, None)], vec![]));
     runner.push(Action::CheckPingPong(0, vec![], vec![(0, 2, None)]));
 
-    start_test(runner);
+    start_test(runner)
 }
 
 /// Test routed messages are dropped if don't have enough TTL.
@@ -150,104 +151,104 @@ fn test_dont_drop_after_ttl() {
 /// Send Ping from 0 to 2. It should not arrive since there are 2 edges from 0 to 2.
 /// Check none of Ping and Pong arrived.
 #[test]
-fn test_drop_after_ttl() {
+fn test_drop_after_ttl() -> anyhow::Result<()> {
     let mut runner = Runner::new(3, 1).routed_message_ttl(1);
 
-    runner.push(Action::AddEdge(0, 1));
-    runner.push(Action::AddEdge(1, 2));
+    runner.push(Action::AddEdge(0, 1, true));
+    runner.push(Action::AddEdge(1, 2, true));
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![1])]));
     runner.push(Action::PingTo(0, 0, 2));
-    runner.push(Action::Wait(100));
+    runner.push(Action::Wait(Duration::from_millis(100)));
     runner.push(Action::CheckPingPong(2, vec![], vec![]));
     runner.push(Action::CheckPingPong(0, vec![], vec![]));
 
-    start_test(runner);
+    start_test(runner)
 }
 
 #[test]
-fn simple_remove() {
+fn simple_remove() -> anyhow::Result<()> {
     let mut runner = Runner::new(3, 3);
 
-    runner.push(Action::AddEdge(0, 1));
-    runner.push(Action::AddEdge(1, 2));
+    runner.push(Action::AddEdge(0, 1, true));
+    runner.push(Action::AddEdge(1, 2, true));
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![1])]));
     runner.push(Action::CheckRoutingTable(2, vec![(1, vec![1]), (0, vec![1])]));
     runner.push(Action::Stop(1));
     runner.push(Action::CheckRoutingTable(0, vec![]));
     runner.push(Action::CheckRoutingTable(2, vec![]));
 
-    start_test(runner);
+    start_test(runner)
 }
 
 #[test]
-fn square() {
+fn square() -> anyhow::Result<()> {
     let mut runner = Runner::new(4, 4);
 
-    runner.push(Action::AddEdge(0, 1));
-    runner.push(Action::AddEdge(1, 2));
-    runner.push(Action::AddEdge(2, 3));
-    runner.push(Action::AddEdge(3, 0));
+    runner.push(Action::AddEdge(0, 1, true));
+    runner.push(Action::AddEdge(1, 2, true));
+    runner.push(Action::AddEdge(2, 3, true));
+    runner.push(Action::AddEdge(3, 0, true));
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (3, vec![3]), (2, vec![1, 3])]));
     runner.push(Action::Stop(1));
     runner.push(Action::CheckRoutingTable(0, vec![(3, vec![3]), (2, vec![3])]));
     runner.push(Action::CheckRoutingTable(2, vec![(3, vec![3]), (0, vec![3])]));
     runner.push(Action::CheckRoutingTable(3, vec![(2, vec![2]), (0, vec![0])]));
 
-    start_test(runner);
+    start_test(runner)
 }
 
 #[test]
-fn blacklist_01() {
+fn blacklist_01() -> anyhow::Result<()> {
     let mut runner = Runner::new(2, 2).add_to_blacklist(0, Some(1)).use_boot_nodes(vec![0]);
 
-    runner.push(Action::Wait(100));
+    runner.push(Action::Wait(Duration::from_millis(100)));
     runner.push(Action::CheckRoutingTable(1, vec![]));
     runner.push(Action::CheckRoutingTable(0, vec![]));
 
-    start_test(runner);
+    start_test(runner)
 }
 
 #[test]
-fn blacklist_10() {
+fn blacklist_10() -> anyhow::Result<()> {
     let mut runner = Runner::new(2, 2).add_to_blacklist(1, Some(0)).use_boot_nodes(vec![0]);
 
-    runner.push(Action::Wait(100));
+    runner.push(Action::Wait(Duration::from_millis(100)));
     runner.push(Action::CheckRoutingTable(1, vec![]));
     runner.push(Action::CheckRoutingTable(0, vec![]));
 
-    start_test(runner);
+    start_test(runner)
 }
 
 #[test]
-fn blacklist_all() {
+fn blacklist_all() -> anyhow::Result<()> {
     let mut runner = Runner::new(2, 2).add_to_blacklist(0, None).use_boot_nodes(vec![0]);
 
-    runner.push(Action::Wait(100));
+    runner.push(Action::Wait(Duration::from_millis(100)));
     runner.push(Action::CheckRoutingTable(1, vec![]));
     runner.push(Action::CheckRoutingTable(0, vec![]));
 
-    start_test(runner);
+    start_test(runner)
 }
 
 /// Spawn 4 nodes with max peers required equal 2. Connect first three peers in a triangle.
 /// Try to connect peer3 to peer0 and see it fail since first three peer are at max capacity.
 #[test]
-fn max_num_peers_limit() {
+fn max_num_peers_limit() -> anyhow::Result<()> {
     let mut runner = Runner::new(4, 4).max_num_peers(2).enable_outbound();
 
-    runner.push(Action::AddEdge(0, 1));
-    runner.push(Action::AddEdge(1, 2));
+    runner.push(Action::AddEdge(0, 1, true));
+    runner.push(Action::AddEdge(1, 2, true));
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![2])]));
     runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0]), (2, vec![2])]));
     runner.push(Action::CheckRoutingTable(2, vec![(1, vec![1]), (0, vec![0])]));
-    runner.push(Action::AddEdge(3, 0));
-    runner.push(Action::Wait(100));
+    runner.push(Action::AddEdge(3, 0, false));
+    runner.push(Action::Wait(Duration::from_millis(100)));
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![2])]));
     runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0]), (2, vec![2])]));
     runner.push(Action::CheckRoutingTable(2, vec![(1, vec![1]), (0, vec![0])]));
     runner.push(Action::CheckRoutingTable(3, vec![]));
 
-    start_test(runner);
+    start_test(runner)
 }
 
 /// Check that two archival nodes keep connected after network rebalance. Nodes 0 and 1 are archival nodes, others aren't.
@@ -257,7 +258,7 @@ fn max_num_peers_limit() {
 /// Do four rounds where 2, 3, 4 tries to connect to 0 and check that connection between 0 and 1 was never dropped.
 #[test]
 // TODO(#5389) fix this test, ignoring for now to unlock merging
-fn archival_node() {
+fn archival_node() -> anyhow::Result<()> {
     let mut runner = Runner::new(5, 5)
         .max_num_peers(3)
         .ideal_connections(2, 2)
@@ -265,44 +266,44 @@ fn archival_node() {
         .set_as_archival(0)
         .set_as_archival(1);
 
-    runner.push(Action::AddEdge(2, 0));
-    runner.push(Action::Wait(50));
-    runner.push(Action::AddEdge(3, 0));
-    runner.push(Action::Wait(50));
-    runner.push(Action::AddEdge(4, 0));
-    runner.push(Action::Wait(50));
+    runner.push(Action::AddEdge(2, 0, true));
+    runner.push(Action::Wait(Duration::from_millis(50)));
+    runner.push(Action::AddEdge(3, 0, true));
+    runner.push(Action::Wait(Duration::from_millis(50)));
+    runner.push(Action::AddEdge(4, 0, true));
+    runner.push(Action::Wait(Duration::from_millis(50)));
     runner.push_action(check_expected_connections(0, Some(2), Some(2)));
 
-    runner.push(Action::AddEdge(1, 0));
-    runner.push(Action::Wait(50));
+    runner.push(Action::AddEdge(1, 0, true));
+    runner.push(Action::Wait(Duration::from_millis(50)));
     runner.push_action(check_expected_connections(0, Some(2), Some(2)));
     runner.push_action(check_direct_connection(0, 1));
 
     for _step in 0..4 {
-        runner.push(Action::AddEdge(2, 0));
-        runner.push(Action::Wait(50));
-        runner.push(Action::AddEdge(3, 0));
-        runner.push(Action::Wait(50));
-        runner.push(Action::AddEdge(4, 0));
-        runner.push(Action::Wait(50));
+        runner.push(Action::AddEdge(2, 0, true));
+        runner.push(Action::Wait(Duration::from_millis(50)));
+        runner.push(Action::AddEdge(3, 0, true));
+        runner.push(Action::Wait(Duration::from_millis(50)));
+        runner.push(Action::AddEdge(4, 0, true));
+        runner.push(Action::Wait(Duration::from_millis(50)));
         runner.push_action(check_expected_connections(0, Some(2), Some(2)));
         runner.push_action(check_direct_connection(0, 1));
     }
 
-    start_test(runner);
+    start_test(runner)
 }
 
 /// Spawn 3 nodes, add edges to form 0---1---2 line. Then send 2 pings from 0 to 2, one should be dropped.
 #[test]
 #[cfg(feature = "test_features")]
-fn test_dropping_routing_messages() {
+fn test_dropping_routing_messages() -> anyhow::Result<()> {
     let mut runner = Runner::new(3, 3).max_num_peers(2).enable_outbound();
 
     runner.push(Action::SetOptions { target: 0, max_num_peers: Some(1) });
     runner.push(Action::SetOptions { target: 1, max_num_peers: Some(2) });
     runner.push(Action::SetOptions { target: 2, max_num_peers: Some(1) });
-    runner.push(Action::AddEdge(0, 1));
-    runner.push(Action::AddEdge(1, 2));
+    runner.push(Action::AddEdge(0, 1, true));
+    runner.push(Action::AddEdge(1, 2, true));
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1])]));
     runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0]), (2, vec![2])]));
     runner.push(Action::CheckRoutingTable(2, vec![(1, vec![1])]));
@@ -325,5 +326,5 @@ fn test_dropping_routing_messages() {
     runner.push(Action::CheckPingPong(2, vec![(0, 0, Some(3))], vec![]));
     runner.push(Action::CheckPingPong(0, vec![], vec![(0, 2, Some(3))]));
 
-    start_test(runner);
+    start_test(runner)
 }


### PR DESCRIPTION
Replaced System::stop with Context::stop.
Fixed the testing framework by making sure that all actions were completed.
Removed flakiness by retrying the AddEdge action until success.

After this refactor:
1. each node is spawned in a separate actix runtime (so that one node cannot stop another)
2. the framework is now executed as a tokio future, rather than an actor (to simplify the flow and isolate it from the nodes).