### PR TITLE
nearcore: take max_open_files into consideration in recompress_storage

### DIFF
--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -561,7 +561,7 @@ pub fn recompress_storage(home_dir: &Path, opts: RecompressOpts) -> anyhow::Resu
     );
 
     info!(target: "recompress", src = %src_dir.display(), dest = %opts.dest_dir.display(), "Recompressing database");
-    let src_store = create_store_with_config(&src_dir, &config.store.with_read_only(true));
+    let src_store = create_store_with_config(&src_dir, &config.store.clone().with_read_only(true));
 
     let final_head_height = if skip_columns.contains(&DBCol::ColPartialChunks) {
         let tip: Option<near_primitives::block::Tip> =


### PR DESCRIPTION
So far recompress_storage assumed that a single database will use 512
file descriptors at the most and thus set NOFILE limit to three times
that (so it can open two databases simultaneously and have whole bunch
of descriptors to spare).  However, this number is now configurable
and may be larger.  Change the command to take into consideration what
is the actual configured max_open_files number.
