### PR TITLE
pytest: fix state_sync_fail.py

### DIFF
--- a/pytest/tests/sanity/state_sync_fail.py
+++ b/pytest/tests/sanity/state_sync_fail.py
@@ -63,5 +63,5 @@ time.sleep(3)
 try:
     status = node2.get_status()
     sys.exit("node 2 successfully started while it should fail")
-except requests.exceptions.HTTPError:
+except requests.exceptions.ConnectionError:
     pass


### PR DESCRIPTION
this started failing after https://github.com/near/nearcore/pull/6326 because
that PR made it so that the process actually dies when the client actor panics.
Before that change, the node stays up but gives HTTP errors when trying to ask
for stuff that the client actor has to provide. Now that the node will actually exit,
we'll get a ConnectionError instead of an HTTPError