### PR TITLE
First attempt at refactoring store

### DIFF
--- a/chain/epoch_manager/src/test_utils.rs
+++ b/chain/epoch_manager/src/test_utils.rs
@@ -277,7 +277,7 @@ pub fn record_block_with_final_block_hash(
     height: BlockHeight,
     proposals: Vec<ValidatorStake>,
 ) {
-    epoch_manager
+    let update = epoch_manager
         .record_block_info(
             BlockInfo::new(
                 cur_h,
@@ -294,9 +294,8 @@ pub fn record_block_with_final_block_hash(
             ),
             [0; 32],
         )
-        .unwrap()
-        .commit()
         .unwrap();
+    epoch_manager.col_store.commit(update).unwrap();
 }
 
 pub fn record_block_with_slashes(
@@ -307,7 +306,7 @@ pub fn record_block_with_slashes(
     proposals: Vec<ValidatorStake>,
     slashed: Vec<SlashedValidator>,
 ) {
-    epoch_manager
+    let update = epoch_manager
         .record_block_info(
             BlockInfo::new(
                 cur_h,
@@ -324,9 +323,8 @@ pub fn record_block_with_slashes(
             ),
             [0; 32],
         )
-        .unwrap()
-        .commit()
         .unwrap();
+    epoch_manager.col_store.commit(update).unwrap();
 }
 
 pub fn record_block(
@@ -367,5 +365,6 @@ pub fn block_info(
 }
 
 pub fn record_with_block_info(epoch_manager: &mut EpochManager, block_info: BlockInfo) {
-    epoch_manager.record_block_info(block_info, [0; 32]).unwrap().commit().unwrap();
+    let update = epoch_manager.record_block_info(block_info, [0; 32]).unwrap();
+    epoch_manager.col_store.commit(update).unwrap();
 }

--- a/chain/network/src/tests/cache_edges.rs
+++ b/chain/network/src/tests/cache_edges.rs
@@ -8,7 +8,7 @@ use near_crypto::Signature;
 use near_network_primitives::types::{Edge, EdgeState};
 use near_primitives::network::PeerId;
 use near_primitives::time::Clock;
-use near_store::test_utils::create_test_store;
+use near_store::test_utils::{create_test_store, reopen_test_store};
 use near_store::{ColComponentEdges, ColPeerComponent, Store};
 use std::collections::{HashMap, HashSet};
 use std::time::Instant;
@@ -240,7 +240,8 @@ fn load_component_nonce_on_start() {
     test.add_edge(0, 1, 2);
     test.set_times(vec![(1, 2)]);
     test.update_routing_table();
-    let routing_table = RoutingTableActor::new(random_peer_id(), test.store.clone());
+    let store = reopen_test_store(&test.store);
+    let routing_table = RoutingTableActor::new(random_peer_id(), store);
     assert_eq!(routing_table.next_available_component_nonce, 2);
 
     System::current().stop();
@@ -262,7 +263,8 @@ fn load_component_nonce_2_on_start() {
         vec![(0, vec![(0, 1, false)]), (1, vec![(0, 2, false)])],
         vec![(1, 0), (2, 1)],
     );
-    let routing_table = RoutingTableActor::new(random_peer_id(), test.store.clone());
+    let store = reopen_test_store(&test.store);
+    let routing_table = RoutingTableActor::new(random_peer_id(), store);
     assert_eq!(routing_table.next_available_component_nonce, 3);
 
     System::current().stop();

--- a/core/store/src/column_store.rs
+++ b/core/store/src/column_store.rs
@@ -116,8 +116,9 @@ macro_rules! define_column_set {
     ($set:ident { $($col:ident),* $(,)?}) => {
         pub enum $set {}
         impl $crate::column_store::ColumnSet for $set {
-            const COLUMNS: $crate::column_store::ColBitSet =
-                $crate::column_store::ColBitSet::new(&[$($col::RAW),*]);
+            const COLUMNS: $crate::column_store::ColBitSet = $crate::column_store::ColBitSet::new(&[
+                $(<$col as $crate::column_store::Column>::RAW),*
+            ]);
         }
     };
 }

--- a/core/store/src/column_store.rs
+++ b/core/store/src/column_store.rs
@@ -55,7 +55,7 @@ impl<CS: ColumnSet> ColumnStore<CS> {
         C: Column,
     {
         let () = AssertHasColumn::<CS, C>::OK;
-        self.raw.get(C::RAW, key)
+        self.raw.get_unchecked(C::RAW, key)
     }
 
     pub fn update(&self) -> ColumnStoreUpdate<CS> {
@@ -158,6 +158,11 @@ impl Default for AtomicColBitSet {
 }
 
 impl AtomicColBitSet {
+    pub(crate) fn contains(&self, col: DBCol) -> bool {
+        let mask = ColBitSet::mask(col);
+        self.repr.load(Ordering::SeqCst) & mask == mask
+    }
+
     pub(crate) fn claim(&self, other: ColBitSet) -> Result<(), ()> {
         loop {
             let repr = self.repr.load(Ordering::SeqCst);

--- a/core/store/src/column_store.rs
+++ b/core/store/src/column_store.rs
@@ -1,0 +1,177 @@
+use std::io;
+use std::marker::PhantomData;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use borsh::{BorshDeserialize, BorshSerialize};
+
+use crate::db::DBTransaction;
+use crate::{DBCol, Store};
+
+pub trait Column {
+    const RAW: DBCol;
+    type Val: BorshSerialize + BorshDeserialize;
+}
+
+pub struct ColumnStore<CS> {
+    raw: Store,
+    _ghost: PhantomData<CS>,
+}
+
+// Note: ColumnStore is intentionally !Clone. We use Rust's ownership rule to
+// mediate access to the state and avoid db-level data races.
+//
+// impl<CS> !Clone for ColumnStore<CS> {}
+
+pub struct ColumnStoreUpdate<CS> {
+    transaction: DBTransaction,
+    _ghost: PhantomData<CS>,
+}
+
+pub trait ColumnSet {
+    const COLUMNS: ColBitSet;
+}
+
+impl<CS: ColumnSet> ColumnStore<CS> {
+    pub fn split(raw: &Store) -> Self {
+        if raw.unclaimed_cols.claim(CS::COLUMNS).is_err() {
+            panic!("failed to claim columns")
+        }
+        let raw = raw.clone();
+        Self { raw, _ghost: PhantomData }
+    }
+
+    pub fn get<C>(&self, key: &[u8]) -> io::Result<Option<C::Val>>
+    where
+        C: Column,
+    {
+        match self.get_bytes::<C>(key)? {
+            None => Ok(None),
+            Some(bytes) => Ok(Some(BorshDeserialize::try_from_slice(&bytes)?)),
+        }
+    }
+    pub fn get_bytes<C>(&self, key: &[u8]) -> io::Result<Option<Vec<u8>>>
+    where
+        C: Column,
+    {
+        let () = AssertHasColumn::<CS, C>::OK;
+        self.raw.get(C::RAW, key)
+    }
+
+    pub fn update(&self) -> ColumnStoreUpdate<CS> {
+        ColumnStoreUpdate { transaction: DBTransaction::default(), _ghost: PhantomData }
+    }
+
+    pub fn commit(&mut self, update: ColumnStoreUpdate<CS>) -> io::Result<()> {
+        self.raw.storage.write(update.transaction)?;
+        Ok(())
+    }
+}
+
+impl<CS: ColumnSet> ColumnStoreUpdate<CS> {
+    pub fn set<C>(&mut self, key: &[u8], value: &C::Val)
+    where
+        C: Column,
+    {
+        let buf = value
+            .try_to_vec()
+            .unwrap_or_else(|err| panic!("failed to borsh-serialize a DB object: {err}"));
+        self.set_bytes::<C>(key, buf)
+    }
+    pub fn set_bytes<C>(&mut self, key: &[u8], value: Vec<u8>)
+    where
+        C: Column,
+    {
+        let () = AssertHasColumn::<CS, C>::OK;
+        self.transaction.insert(C::RAW, key.to_vec(), value)
+    }
+    pub fn delete<C>(&mut self, key: &[u8])
+    where
+        C: Column,
+    {
+        let () = AssertHasColumn::<CS, C>::OK;
+        self.transaction.delete(C::RAW, key.to_vec())
+    }
+}
+
+struct AssertHasColumn<CS: ColumnSet, C: Column>(CS, C);
+
+impl<CS: ColumnSet, C: Column> AssertHasColumn<CS, C> {
+    const OK: () = [()][!CS::COLUMNS.contains(C::RAW) as usize];
+}
+
+#[macro_export]
+macro_rules! define_columns {
+    ($($col:ident: $val_ty:ty),*$(,)?) => {$(
+        pub enum $col {}
+        impl $crate::column_store::Column for $col {
+            const RAW: $crate::DBCol = $crate::DBCol::$col;
+            type Val = $val_ty;
+        }
+    )*};
+}
+
+#[macro_export]
+macro_rules! define_column_set {
+    ($set:ident { $($col:ident),* $(,)?}) => {
+        pub enum $set {}
+        impl $crate::column_store::ColumnSet for $set {
+            const COLUMNS: $crate::column_store::ColBitSet =
+                $crate::column_store::ColBitSet::new(&[$($col::RAW),*]);
+        }
+    };
+}
+
+#[derive(Clone, Copy)]
+pub struct ColBitSet {
+    repr: u64,
+}
+
+impl ColBitSet {
+    pub const fn new(cols: &[DBCol]) -> ColBitSet {
+        let mut repr = 0;
+        let mut i = 0;
+        while i < cols.len() {
+            repr |= ColBitSet::mask(cols[i]);
+            i += 1;
+        }
+        ColBitSet { repr }
+    }
+    pub const fn contains(&self, col: DBCol) -> bool {
+        let mask = ColBitSet::mask(col);
+        self.repr & mask == mask
+    }
+    const fn mask(col: DBCol) -> u64 {
+        1 << (col as u64)
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct AtomicColBitSet {
+    repr: Arc<AtomicU64>,
+}
+
+impl Default for AtomicColBitSet {
+    fn default() -> Self {
+        Self { repr: Arc::new(AtomicU64::new(!0)) }
+    }
+}
+
+impl AtomicColBitSet {
+    pub(crate) fn claim(&self, other: ColBitSet) -> Result<(), ()> {
+        loop {
+            let repr = self.repr.load(Ordering::SeqCst);
+            if repr & other.repr != other.repr {
+                return Err(());
+            }
+            let new_repr = repr & !other.repr;
+            if self
+                .repr
+                .compare_exchange(repr, new_repr, Ordering::SeqCst, Ordering::SeqCst)
+                .is_ok()
+            {
+                return Ok(());
+            }
+        }
+    }
+}

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -55,6 +55,7 @@ pub const VERSION_KEY: &[u8; 7] = b"VERSION";
 pub const GENESIS_JSON_HASH_KEY: &[u8; 17] = b"GENESIS_JSON_HASH";
 pub const GENESIS_STATE_ROOTS_KEY: &[u8; 19] = b"GENESIS_STATE_ROOTS";
 
+#[derive(Default)]
 pub(crate) struct DBTransaction {
     pub(crate) ops: Vec<DBOp>,
 }

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -1,3 +1,4 @@
+use column_store::AtomicColBitSet;
 use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Read, Write};
@@ -38,6 +39,7 @@ pub use crate::trie::{
     TrieChanges, WrappedTrieChanges,
 };
 
+pub mod column_store;
 mod columns;
 pub mod db;
 pub mod migrations;
@@ -47,11 +49,13 @@ mod trie;
 #[derive(Clone)]
 pub struct Store {
     storage: Arc<dyn Database>,
+    unclaimed_cols: AtomicColBitSet,
 }
 
 impl Store {
     pub(crate) fn new(storage: Arc<dyn Database>) -> Store {
-        Store { storage }
+        let unclaimed_cols = AtomicColBitSet::default();
+        Store { storage, unclaimed_cols }
     }
 
     pub fn get(&self, column: DBCol, key: &[u8]) -> io::Result<Option<Vec<u8>>> {

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -59,6 +59,10 @@ impl Store {
     }
 
     pub fn get(&self, column: DBCol, key: &[u8]) -> io::Result<Option<Vec<u8>>> {
+        assert!(self.unclaimed_cols.contains(column));
+        self.get_unchecked(column, key)
+    }
+    fn get_unchecked(&self, column: DBCol, key: &[u8]) -> io::Result<Option<Vec<u8>>> {
         self.storage.get(column, key).map_err(io::Error::from)
     }
 

--- a/core/store/src/test_utils.rs
+++ b/core/store/src/test_utils.rs
@@ -19,6 +19,11 @@ pub fn create_test_store() -> Store {
     Store::new(db)
 }
 
+pub fn reopen_test_store(store: &Store) -> Store {
+    let db = Arc::clone(&store.storage);
+    Store::new(db)
+}
+
 /// Creates a Trie using an in-memory database.
 pub fn create_tries() -> ShardTries {
     create_tries_complex(0, 1)


### PR DESCRIPTION
The goal here was to make it clear which parts of the codebase mutate which parts of the database, to make it easier to see what can be run independently. 

The idea was to slice our Store into disjoint set of columns and hand subset of store to various subsystems. 

It worked perfectly for RoutingTableActor, which stores some auxilary info in the db, which is not touched by anything else. 

It failed completely for the EpochManager. While it's true that the EpochManager "owns" some subset of columns, it doesn't actually mutate them. Rather, it sends up StoreUpdate to the chain, and that's where the mutation actually takes place. So, we can't just "give" some columns to epoch manager, as the ultimate owner of data is the chain. 

This is probably a dead end, but still might be interesting to look at. 