### PR TITLE
neard: prefer kebab-case for subcommand names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [NEP205](https://github.com/near/NEPs/issues/205): Configurable start of protocol upgrade voting [#6309](https://github.com/near/nearcore/pull/6309)
 * Make max_open_files and col_state_cache_size parameters configurable [#6584](https://github.com/near/nearcore/pull/6584)
 * Increase default max_open_files RocksDB parameter from 512 to 10k [#6607](https://github.com/near/nearcore/pull/6607)
+* Use kebab-case names for neard subcommands to make them consistent with flag names.  snake_case names are still valid for existing subcommands but kebab-case will be used for new commands.
 
 ## `1.23.0` [13-12-2021]
 

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -135,31 +135,30 @@ struct NeardOpts {
 #[derive(Parser)]
 pub(super) enum NeardSubCommand {
     /// Initializes NEAR configuration
-    #[clap(name = "init")]
     Init(InitCmd),
     /// Runs NEAR node
-    #[clap(name = "run")]
     Run(RunCmd),
     /// Sets up local configuration with all necessary files (validator key, node key, genesis and
     /// config)
-    #[clap(name = "localnet")]
     Localnet(LocalnetCmd),
     /// DEPRECATED: this command has been renamed to 'localnet' and will be removed in a future
     /// release.
-    // TODO(#4372): Deprecated since 1.24.  Delete it in a couple of releases in 2022.
-    #[clap(name = "testnet", hide = true)]
+    // We’re not using clap(alias = "testnet") on Localnet because we want this
+    // to be a separate subcommand with a deprecation warning.  TODO(#4372):
+    // Deprecated since 1.24.  Delete it in a couple of releases in 2022.
+    #[clap(hide = true)]
     Testnet(LocalnetCmd),
     /// (unsafe) Remove the entire NEAR home directory (which includes the
     /// configuration, genesis files, private keys and data).  This effectively
     /// removes all information about the network.
-    #[clap(name = "unsafe_reset_all", hide = true)]
+    #[clap(alias = "unsafe_reset_all", hide = true)]
     UnsafeResetAll,
     /// (unsafe) Remove all the data, effectively resetting node to the genesis state (keeps genesis and
     /// config).
-    #[clap(name = "unsafe_reset_data", hide = true)]
+    #[clap(alias = "unsafe_reset_data", hide = true)]
     UnsafeResetData,
     /// View DB state.
-    #[clap(name = "view_state")]
+    #[clap(name = "view-state", alias = "view_state")]
     StateViewer(StateViewerCommand),
     /// Recompresses the entire storage.  This is a slow operation which reads
     /// all the data from the database and writes them down to a new copy of the
@@ -187,7 +186,7 @@ pub(super) enum NeardSubCommand {
     ///
     /// Finally, because this command is meant only as a temporary migration
     /// tool, it is planned to be removed by the end of 2022.
-    #[clap(name = "recompress_storage")]
+    #[clap(alias = "recompress_storage")]
     RecompressStorage(RecompressStorageSubCommand),
 }
 

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -15,61 +15,54 @@ use std::str::FromStr;
 #[derive(Subcommand)]
 #[clap(subcommand_required = true, arg_required_else_help = true)]
 pub enum StateViewerSubCommand {
-    #[clap(name = "peers")]
     Peers,
-    #[clap(name = "state")]
     State,
     /// Generate a genesis file from the current state of the DB.
-    #[clap(name = "dump_state")]
+    #[clap(alias = "dump_state")]
     DumpState(DumpStateCmd),
-    #[clap(name = "dump_state_redis")]
+    #[clap(alias = "dump_state_redis")]
     DumpStateRedis(DumpStateRedisCmd),
     /// Print chain from start_index to end_index.
-    #[clap(name = "chain")]
     Chain(ChainCmd),
     /// Replay headers from chain.
-    #[clap(name = "replay")]
     Replay(ReplayCmd),
     /// Apply blocks at a range of heights for a single shard.
-    #[clap(name = "apply_range")]
+    #[clap(alias = "apply_range")]
     ApplyRange(ApplyRangeCmd),
     /// Apply block at some height for shard.
-    #[clap(name = "apply")]
     Apply(ApplyCmd),
     /// View head of the storage.
-    #[clap(name = "view_chain")]
+    #[clap(alias = "view_chain")]
     ViewChain(ViewChainCmd),
     /// Check whether the node has all the blocks up to its head.
-    #[clap(name = "check_block")]
+    #[clap(alias = "check_block")]
     CheckBlock,
     /// Dump deployed contract code of given account to wasm file.
-    #[clap(name = "dump_code")]
+    #[clap(alias = "dump_code")]
     DumpCode(DumpCodeCmd),
     /// Dump contract data in storage of given account to binary file.
-    #[clap(name = "dump_account_storage")]
+    #[clap(alias = "dump_account_storage")]
     DumpAccountStorage(DumpAccountStorageCmd),
     /// Print `EpochInfo` of an epoch given by `--epoch_id` or by `--epoch_height`.
-    #[clap(name = "epoch_info")]
+    #[clap(alias = "epoch_info")]
     EpochInfo(EpochInfoCmd),
     /// Dump stats for the RocksDB storage.
-    #[clap(name = "rocksdb_stats")]
+    #[clap(alias = "rocksdb_stats")]
     RocksDBStats(RocksDBStatsCmd),
-    #[clap(name = "receipts")]
     Receipts(ReceiptsCmd),
-    #[clap(name = "chunks")]
     Chunks(ChunksCmd),
-    #[clap(name = "partial_chunks")]
+    #[clap(alias = "partial_chunks")]
     PartialChunks(PartialChunksCmd),
     /// Apply a chunk, even if it's not included in any block on disk
-    #[clap(name = "apply_chunk")]
+    #[clap(alias = "apply_chunk")]
     ApplyChunk(ApplyChunkCmd),
     /// Apply a transaction if it occurs in some chunk we know about,
     /// even if it's not included in any block on disk
-    #[clap(name = "apply_tx")]
+    #[clap(alias = "apply_tx")]
     ApplyTx(ApplyTxCmd),
     /// Apply a receipt if it occurs in some chunk we know about,
     /// even if it's not included in any block on disk
-    #[clap(name = "apply_receipt")]
+    #[clap(alias = "apply_receipt")]
     ApplyReceipt(ApplyReceiptCmd),
 }
 

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -47,7 +47,7 @@ pub enum StateViewerSubCommand {
     #[clap(alias = "epoch_info")]
     EpochInfo(EpochInfoCmd),
     /// Dump stats for the RocksDB storage.
-    #[clap(alias = "rocksdb_stats")]
+    #[clap(name = "rocksdb-stats", alias = "rocksdb_stats")]
     RocksDBStats(RocksDBStatsCmd),
     Receipts(ReceiptsCmd),
     Chunks(ChunksCmd),


### PR DESCRIPTION
We’re using kebab-case for command line options (e.g. --chain-id,
--num-shards, --csv-file etc) but for whatever reason use snake_case
for commands (e.g. view_state, check_block etc.).  This leads to user
confusion as one needs to use both types of naming.

Fix this inconsistency by using kebab-case for subcommands and, for
backwards compatibility, leaving snake_case names as aliases so they
continue to be valid.

Alias for recompress-storage is not kept because it’s a new command
and as such there is no backwards compatibility issues with dropping
recompress_storage.

While at it, remove a few redundant clap(name) directive.  Clap
automatically derives name of the subcommand from the variant name
usually there is no need to explicitly specify it.

The diff in help between the old and the new:

    $ diff -u <(./neard-old --help) <(./neard-new --help)
    --- /dev/fd/63	2022-04-15 00:59:22.992962110 +0200
    +++ /dev/fd/62	2022-04-15 00:59:22.992962110 +0200
    @@ -1,8 +1,8 @@
    -neard (release trunk) (build crates-0.12.0-239-g9fc9e3180) (rustc 1.60.0) (protocol 53) (db 31)
    +neard (release trunk) (build crates-0.12.0-240-g5a2c3737a) (rustc 1.60.0) (protocol 53) (db 31)
     NEAR Protocol Node

     USAGE:
    -    neard-old [OPTIONS] <SUBCOMMAND>
    +    neard-new [OPTIONS] <SUBCOMMAND>

     OPTIONS:
         -h, --help                   Print help information
    @@ -18,8 +18,8 @@
         init                  Initializes NEAR configuration
         localnet              Sets up local configuration with all necessary files (validator key,
                                   node key, genesis and config)
    -    recompress_storage    Recompresses the entire storage.  This is a slow operation which reads
    +    recompress-storage    Recompresses the entire storage.  This is a slow operation which reads
                                   all the data from the database and writes them down to a new copy of
                                   the database
         run                   Runs NEAR node
    -    view_state            View DB state
    +    view-state            View DB state
    $ diff -u <(./neard-old view_state --help) <(./neard-new view_state --help)
    --- /dev/fd/63	2022-04-15 00:59:43.857081893 +0200
    +++ /dev/fd/62	2022-04-15 00:59:43.861081916 +0200
    @@ -1,8 +1,8 @@
    -neard-old-view_state
    +neard-new-view-state
     View DB state

     USAGE:
    -    neard-old view_state [OPTIONS] <SUBCOMMAND>
    +    neard-new view-state [OPTIONS] <SUBCOMMAND>

     OPTIONS:
         -h, --help         Print help information
    @@ -13,26 +13,26 @@

     SUBCOMMANDS:
         apply                   Apply block at some height for shard
    -    apply_chunk             Apply a chunk, even if it's not included in any block on disk
    -    apply_range             Apply blocks at a range of heights for a single shard
    -    apply_receipt           Apply a receipt if it occurs in some chunk we know about, even if
    +    apply-chunk             Apply a chunk, even if it's not included in any block on disk
    +    apply-range             Apply blocks at a range of heights for a single shard
    +    apply-receipt           Apply a receipt if it occurs in some chunk we know about, even if
                                     it's not included in any block on disk
    -    apply_tx                Apply a transaction if it occurs in some chunk we know about, even
    +    apply-tx                Apply a transaction if it occurs in some chunk we know about, even
                                     if it's not included in any block on disk
         chain                   Print chain from start_index to end_index
    -    check_block             Check whether the node has all the blocks up to its head
    +    check-block             Check whether the node has all the blocks up to its head
         chunks
    -    dump_account_storage    Dump contract data in storage of given account to binary file
    -    dump_code               Dump deployed contract code of given account to wasm file
    -    dump_state              Generate a genesis file from the current state of the DB
    -    dump_state_redis
    -    epoch_info              Print `EpochInfo` of an epoch given by `--epoch_id` or by
    +    dump-account-storage    Dump contract data in storage of given account to binary file
    +    dump-code               Dump deployed contract code of given account to wasm file
    +    dump-state              Generate a genesis file from the current state of the DB
    +    dump-state-redis
    +    epoch-info              Print `EpochInfo` of an epoch given by `--epoch_id` or by
                                     `--epoch_height`
         help                    Print this message or the help of the given subcommand(s)
    -    partial_chunks
    +    partial-chunks
         peers
         receipts
         replay                  Replay headers from chain
    -    rocksdb_stats           Dump stats for the RocksDB storage
    +    rocksdb-stats           Dump stats for the RocksDB storage
         state
    -    view_chain              View head of the storage
    +    view-chain              View head of the storage