### PR TITLE
start-mock-network: limit the number of worker threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2112,6 +2112,7 @@ dependencies = [
  "portpicker",
  "primitive-types",
  "rand 0.7.3",
+ "rayon",
  "regex",
  "serde",
  "serde_json",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -26,6 +26,7 @@ once_cell = "1.5"
 parking_lot = "0.11.2"
 primitive-types = "0.10.1"
 rand = "0.7"
+rayon = "1.5"
 regex = "1"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }

--- a/integration-tests/src/mock_network/setup.rs
+++ b/integration-tests/src/mock_network/setup.rs
@@ -249,7 +249,9 @@ pub fn setup_mock_network(
                             &state_root,
                             PartId::new(part_id, num_parts),
                         )
-                        .with_context(|| format!("Obtaining state part {} in shard {}", part_id, shard_id))?;
+                        .with_context(|| {
+                            format!("Obtaining state part {} in shard {}", part_id, shard_id)
+                        })?;
                     client_runtime
                         .apply_state_part(
                             shard_id,
@@ -258,7 +260,9 @@ pub fn setup_mock_network(
                             &state_part,
                             &mock_network_runtime.get_epoch_id_from_prev_block(&hash)?,
                         )
-                        .with_context(|| format!("Applying state part {} in shard {}", part_id, shard_id))?;
+                        .with_context(|| {
+                            format!("Applying state part {} in shard {}", part_id, shard_id)
+                        })?;
                     finished_parts_count.fetch_add(1, Ordering::SeqCst);
                     info!(
                         target: "mock_network",

--- a/integration-tests/src/mock_network/setup.rs
+++ b/integration-tests/src/mock_network/setup.rs
@@ -1,5 +1,6 @@
 use crate::mock_network::MockPeerManagerActor;
 use actix::{Actor, Addr, Arbiter, Recipient};
+use anyhow::Context;
 #[cfg(feature = "mock_network")]
 use near_chain::ChainStoreUpdate;
 use near_chain::{
@@ -21,15 +22,15 @@ use near_store::create_store;
 use near_store::test_utils::create_test_store;
 use near_telemetry::TelemetryActor;
 use nearcore::{get_store_path, NearConfig, NightshadeRuntime};
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use regex::Regex;
 use std::cmp::min;
-use std::collections::HashMap;
+use std::io;
 use std::path::Path;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
-use std::{io, thread};
 use tracing::info;
 
 fn setup_runtime(
@@ -236,54 +237,39 @@ pub fn setup_mock_network(
             let state_root_node =
                 mock_network_runtime.get_state_root_node(shard_id, &hash, &state_root).unwrap();
             let num_parts = get_num_state_parts(state_root_node.memory_usage);
-            let mut handlers = HashMap::new();
             let finished_parts_count = Arc::new(AtomicUsize::new(0));
-            for part_id in 0..num_parts {
-                let mock_network_runtime1 = mock_network_runtime.clone();
-                let client_runtime1 = client_runtime.clone();
-                let finished_parts_count1 = finished_parts_count.clone();
-                let hash1 = hash.clone();
-                let state_root1 = state_root.clone();
-                let next_hash1 = next_hash.clone();
-                handlers.insert(
-                    part_id,
-                    thread::spawn(move || {
-                        let state_part = mock_network_runtime1
-                            .obtain_state_part(
-                                shard_id,
-                                &next_hash1,
-                                &state_root1,
-                                PartId::new(part_id, num_parts),
-                            )
-                            .unwrap();
-                        client_runtime1
-                            .apply_state_part(
-                                shard_id,
-                                &state_root1,
-                                PartId::new(part_id, num_parts),
-                                &state_part,
-                                &mock_network_runtime1
-                                    .get_epoch_id_from_prev_block(&hash1)
-                                    .unwrap(),
-                            )
-                            .unwrap();
-                        finished_parts_count1.fetch_add(1, Ordering::SeqCst);
-                        info!(
-                            target: "mock_network",
-                            "Done {}/{} parts for shard {}",
-                            finished_parts_count1.load(Ordering::SeqCst) + 1,
-                            num_parts,
+
+            (0..num_parts)
+                .into_par_iter()
+                .try_for_each(|part_id| -> anyhow::Result<()> {
+                    let state_part = mock_network_runtime
+                        .obtain_state_part(
                             shard_id,
-                        );
-                    }),
-                );
-            }
-            for (part_id, handler) in handlers {
-                handler.join().expect(&format!(
-                    "Problem in copying state parts {} in shard {}",
-                    part_id, shard_id,
-                ));
-            }
+                            &next_hash,
+                            &state_root,
+                            PartId::new(part_id, num_parts),
+                        )
+                        .with_context(|| format!("Obtaining state part {} in shard {}", part_id, shard_id))?;
+                    client_runtime
+                        .apply_state_part(
+                            shard_id,
+                            &state_root,
+                            PartId::new(part_id, num_parts),
+                            &state_part,
+                            &mock_network_runtime.get_epoch_id_from_prev_block(&hash)?,
+                        )
+                        .with_context(|| format!("Applying state part {} in shard {}", part_id, shard_id))?;
+                    finished_parts_count.fetch_add(1, Ordering::SeqCst);
+                    info!(
+                        target: "mock_network",
+                        "Done {}/{} parts for shard {}",
+                        finished_parts_count.load(Ordering::SeqCst) + 1,
+                        num_parts,
+                        shard_id,
+                    );
+                    Ok(())
+                })
+                .unwrap();
         }
     }
 


### PR DESCRIPTION
setup_mock_network() can start up a very large number of threads if
get_num_state_parts() returns a big number, which makes it difficult
to run the tool successfully with mainnet data. Fix it by using rayon
to split the work among threads in a pool.