### PR TITLE
refactor: Simplify estimator debug flags

### DIFF
--- a/runtime/runtime-params-estimator/src/config.rs
+++ b/runtime/runtime-params-estimator/src/config.rs
@@ -32,10 +32,10 @@ pub struct Config {
     pub costs_to_measure: Option<Vec<String>>,
     /// Configuration specific to raw RocksDB tests. Does NOT affect normal tests that use RocksDB through the nearcore interface.
     pub rocksdb_test_config: RocksDBTestConfig,
-    /// Print extra details on least-squares computation
-    pub debug_least_squares: bool,
+    /// Print extra details on estimations.
+    pub debug: bool,
     /// Print JSON output for estimation results.
     pub json_output: bool,
-    /// Clear all OS caches between measured blocks
+    /// Clear all OS caches between measured blocks.
     pub drop_os_cache: bool,
 }

--- a/runtime/runtime-params-estimator/src/gas_metering.rs
+++ b/runtime/runtime-params-estimator/src/gas_metering.rs
@@ -35,9 +35,9 @@ pub(crate) fn gas_metering_cost(config: &Config) -> (GasCost, GasCost) {
 
     let tolerance = LeastSquaresTolerance::default().factor_rel_nn_tolerance(0.001);
     let (cost1_base, cost1_op) =
-        GasCost::least_squares_method_gas_cost(&xs1, &ys1, &tolerance, config.debug_least_squares);
+        GasCost::least_squares_method_gas_cost(&xs1, &ys1, &tolerance, config.debug);
     let (cost2_base, cost2_op) =
-        GasCost::least_squares_method_gas_cost(&xs2, &ys2, &tolerance, config.debug_least_squares);
+        GasCost::least_squares_method_gas_cost(&xs2, &ys2, &tolerance, config.debug);
 
     let cost_base = std::cmp::max(cost1_base, cost2_base);
     let cost_op = std::cmp::max(cost1_op, cost2_op);

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -526,7 +526,7 @@ fn action_deploy_contract_per_byte(ctx: &mut EstimatorContext) -> GasCost {
         &LeastSquaresTolerance::default()
             .base_abs_nn_tolerance(negative_base_tolerance)
             .factor_rel_nn_tolerance(rel_factor_tolerance),
-        ctx.config.debug_least_squares,
+        ctx.config.debug,
     );
     per_byte
 }
@@ -584,7 +584,7 @@ fn compilation_cost_base_per_byte(ctx: &mut EstimatorContext) -> (GasCost, GasCo
         return base_byte_cost;
     }
 
-    let verbose = ctx.config.debug_least_squares;
+    let verbose = ctx.config.debug;
     let base_byte_cost = compute_compile_cost_vm(ctx.config.metric, ctx.config.vm_kind, verbose);
 
     ctx.cached.compile_cost_base_per_byte = Some(base_byte_cost.clone());

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -72,9 +72,9 @@ struct CliArgs {
     /// Drop OS cache before measurements for better IO accuracy. Requires sudo.
     #[clap(long)]
     drop_os_cache: bool,
-    /// Print extra debug information
-    #[clap(long, multiple_occurrences = true, possible_values=&["io", "rocksdb", "least-squares"])]
-    debug: Vec<String>,
+    /// Print extra debug information.
+    #[clap(long)]
+    debug: bool,
     /// Print detailed estimation results in JSON format. One line with one JSON
     /// object per estimation.
     #[clap(long)]
@@ -160,15 +160,13 @@ fn main() -> anyhow::Result<()> {
         .unwrap();
     }
 
-    let debug_options: Vec<_> = cli_args.debug.iter().map(String::as_str).collect();
-
     if cli_args.docker {
         return main_docker(
             &state_dump_path,
             cli_args.full,
             cli_args.docker_shell,
             cli_args.json_output,
-            debug_options.contains(&"io"),
+            cli_args.debug,
         );
     }
 
@@ -206,7 +204,7 @@ fn main() -> anyhow::Result<()> {
 
     let warmup_iters_per_block = cli_args.warmup_iters;
     let mut rocksdb_test_config = cli_args.db_test_config;
-    rocksdb_test_config.debug_rocksdb = debug_options.contains(&"rocksdb");
+    rocksdb_test_config.debug_rocksdb = cli_args.debug;
     rocksdb_test_config.drop_os_cache = cli_args.drop_os_cache;
     let iter_per_block = cli_args.iters;
     let active_accounts = cli_args.accounts_num;
@@ -234,7 +232,7 @@ fn main() -> anyhow::Result<()> {
         vm_kind,
         costs_to_measure,
         rocksdb_test_config,
-        debug_least_squares: debug_options.contains(&"least-squares"),
+        debug: cli_args.debug,
         json_output: cli_args.json_output,
         drop_os_cache: cli_args.drop_os_cache,
     };
@@ -264,7 +262,7 @@ fn main_docker(
     full: bool,
     debug_shell: bool,
     json_output: bool,
-    debug_io_log: bool,
+    debug: bool,
 ) -> anyhow::Result<()> {
     exec("docker --version").context("please install `docker`")?;
 
@@ -301,7 +299,7 @@ cargo build --manifest-path /host/nearcore/Cargo.toml \
 
         let mut qemu_cmd_builder = QemuCommandBuilder::default();
 
-        if debug_io_log {
+        if debug {
             qemu_cmd_builder = qemu_cmd_builder.plugin_log(true).print_on_every_close(true);
         }
         let mut qemu_cmd =


### PR DESCRIPTION
Use a single debug flag rather than a list of debug options.