### PR TITLE
chain: set the gc_fork_clean_step default to 100

### DIFF
--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -33,7 +33,7 @@ pub struct GCConfig {
 
 impl Default for GCConfig {
     fn default() -> Self {
-        Self { gc_blocks_limit: 2, gc_fork_clean_step: 1000 }
+        Self { gc_blocks_limit: 2, gc_fork_clean_step: 100 }
     }
 }
 

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -1775,7 +1775,7 @@ fn test_config_from_file() {
         let want_gc = if has_gc {
             GCConfig { gc_blocks_limit: 42, gc_fork_clean_step: 420 }
         } else {
-            GCConfig { gc_blocks_limit: 2, gc_fork_clean_step: 1000 }
+            GCConfig { gc_blocks_limit: 2, gc_fork_clean_step: 100 }
         };
         assert_eq!(want_gc, config.gc);
 


### PR DESCRIPTION
The current default has shown itself to be quite expensive at times,
sometimes taking ~half a second to go through all 1000. Drop the default to
100 to try and mitigate this.

Note that since most people won't have set this new config option manually,
this will be a real change for most.