### PR TITLE
test: use base contract for upgradability tests

### DIFF
--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -4849,7 +4849,7 @@ mod lower_storage_key_limit_test {
             deploy_test_contract(
                 &mut env,
                 "test0".parse().unwrap(),
-                near_test_contracts::rs_contract(),
+                near_test_contracts::base_rs_contract(),
                 epoch_length.clone(),
                 1,
             );


### PR DESCRIPTION
The `rs_contract()` uses all the latest protocol features (ie, it
changes over time). This is something you want most of the time, (as we
test against the latest protocol), *but* for upgradability tests
specifically this is wrong -- for those tests, we want to guarantee that
only the base protocol is being used.