### PR TITLE
Fix a flaky test by adding a retry for requesting blocks

### DIFF
--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -169,6 +169,7 @@ impl SyncStatus {
 }
 
 /// Actor message requesting block by id, hash or sync state.
+#[derive(Debug)]
 pub struct GetBlock(pub BlockReference);
 
 #[derive(thiserror::Error, Debug)]

--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -169,7 +169,6 @@ impl SyncStatus {
 }
 
 /// Actor message requesting block by id, hash or sync state.
-#[derive(Debug)]
 pub struct GetBlock(pub BlockReference);
 
 #[derive(thiserror::Error, Debug)]

--- a/integration-tests/src/tests/nearcore/rpc_nodes.rs
+++ b/integration-tests/src/tests/nearcore/rpc_nodes.rs
@@ -44,20 +44,29 @@ fn test_get_validator_info_rpc() {
                 let rpc_addrs_copy = rpc_addrs.clone();
                 let view_client = clients[0].1.clone();
                 spawn_interruptible(async move {
-                    let block_view = view_client.send(GetBlock::latest()).await.unwrap().unwrap();
-                    if block_view.header.height > 1 {
-                        let client = new_client(&format!("http://{}", rpc_addrs_copy[0]));
-                        let block_hash = block_view.header.hash;
-                        let invalid_res = client.validators(Some(BlockId::Hash(block_hash))).await;
-                        assert!(invalid_res.is_err());
-                        let res = client.validators(None).await.unwrap();
+                    loop {
+                        let block_view = view_client.send(GetBlock::latest()).await.unwrap();
+                        if let Err(err) = block_view {
+                            println!("Failed to get the latest block: {:?}", err);
+                            sleep(std::time::Duration::from_millis(500)).await;
+                            continue;
+                        }
+                        let block_view = block_view.unwrap();
+                        if block_view.header.height > 1 {
+                            let client = new_client(&format!("http://{}", rpc_addrs_copy[0]));
+                            let block_hash = block_view.header.hash;
+                            let invalid_res =
+                                client.validators(Some(BlockId::Hash(block_hash))).await;
+                            assert!(invalid_res.is_err());
+                            let res = client.validators(None).await.unwrap();
 
-                        assert_eq!(res.current_validators.len(), 1);
-                        assert!(res
-                            .current_validators
-                            .iter()
-                            .any(|r| r.account_id.as_ref() == "near.0"));
-                        System::current().stop();
+                            assert_eq!(res.current_validators.len(), 1);
+                            assert!(res
+                                .current_validators
+                                .iter()
+                                .any(|r| r.account_id.as_ref() == "near.0"));
+                            System::current().stop();
+                        }
                     }
                 });
             }),


### PR DESCRIPTION
For an unknown reason the test requests a block before any blocks are produced.