### PR TITLE
integration-tests: fix verify_contract_limits_upgrade() protocol upgrading

### DIFF
--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -3342,9 +3342,9 @@ fn verify_contract_limits_upgrade(
     let old_protocol_version = feature.protocol_version() - 1;
     let new_protocol_version = feature.protocol_version();
 
+    let epoch_length = 5;
     // Prepare TestEnv with a contract at the old protocol version.
     let mut env = {
-        let epoch_length = 5;
         let mut genesis =
             Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
         genesis.config.epoch_length = epoch_length;
@@ -3402,16 +3402,22 @@ fn verify_contract_limits_upgrade(
     // Move to the new protocol version.
     {
         let tip = env.clients[0].chain.head().unwrap();
-        let epoch_id = env.clients[0]
-            .runtime_adapter
-            .get_epoch_id_from_prev_block(&tip.last_block_hash)
-            .unwrap();
-        let block_producer =
-            env.clients[0].runtime_adapter.get_block_producer(&epoch_id, tip.height).unwrap();
-        let mut block = env.clients[0].produce_block(tip.height + 1).unwrap().unwrap();
-        set_block_protocol_version(&mut block, block_producer, new_protocol_version);
-        let (_, res) = env.clients[0].process_block(block.clone().into(), Provenance::NONE);
-        assert!(res.is_ok());
+        let mut last_block_hash = tip.last_block_hash;
+        for i in 0..2 * epoch_length {
+            let height = tip.height + i + 1;
+            let mut block = env.clients[0].produce_block(height).unwrap().unwrap();
+
+            let epoch_id = env.clients[0]
+                .runtime_adapter
+                .get_epoch_id_from_prev_block(&last_block_hash)
+                .unwrap();
+            let block_producer =
+                env.clients[0].runtime_adapter.get_block_producer(&epoch_id, height).unwrap();
+            set_block_protocol_version(&mut block, block_producer, new_protocol_version);
+
+            last_block_hash = *block.header().hash();
+            env.process_block(0, block, Provenance::PRODUCED);
+        }
     }
 
     // Re-run the transaction & get tx outcome.


### PR DESCRIPTION
See https://github.com/near/nearcore/pull/6649, as the changes here
are basically copy-pasted from there. This test does the same protocol
upgrading, and also currently fails when the new upgrade schedule is
set to a time in the future.