### PR TITLE
Remove left over references to lazy_static dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2871,7 +2871,6 @@ dependencies = [
  "awc",
  "base64 0.13.0",
  "bs58",
- "lazy_static",
  "libfuzzer-sys",
  "near-jsonrpc",
  "near-jsonrpc-tests",
@@ -2937,7 +2936,6 @@ dependencies = [
 name = "near-metrics"
 version = "0.0.0"
 dependencies = [
- "lazy_static",
  "prometheus",
  "tracing",
 ]
@@ -3114,7 +3112,6 @@ dependencies = [
  "futures",
  "hex",
  "insta",
- "lazy_static",
  "near-account-id",
  "near-chain-configs",
  "near-client",

--- a/chain/jsonrpc/fuzz/Cargo.toml
+++ b/chain/jsonrpc/fuzz/Cargo.toml
@@ -15,7 +15,6 @@ awc = "3.0.0-beta.5"
 actix = "0.13.0"
 arbitrary = { version = "1", features = ["derive"] }
 base64 = "0.13"
-lazy_static = "1.4"
 libfuzzer-sys = { version = "0.4", features = ["arbitrary-derive"] }
 once_cell = "1.5.2"
 bs58 = "0.4"

--- a/chain/rosetta-rpc/Cargo.toml
+++ b/chain/rosetta-rpc/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2021"
 [dependencies]
 derive_more = "0.99.9"
 hex = "0.4"
-lazy_static = "1.4"
 strum = { version = "0.20", features = ["derive"] }
 
 awc = "3.0.0-beta.5"

--- a/core/metrics/Cargo.toml
+++ b/core/metrics/Cargo.toml
@@ -11,6 +11,5 @@ repository = "https://github.com/near/nearcore"
 description = "A fork of the lighthouse_metrics crate used to implement prometheus"
 
 [dependencies]
-lazy_static = "1.4"
 prometheus = "0.11"
 tracing = "0.1.13"


### PR DESCRIPTION
We’re no longer using lazy_static anywhere.  Remove unused
dependencies from Cargo.toml files.

Issue: https://github.com/near/nearcore/pull/5321