### PR TITLE
metrics: refactor NetworkMetrics and remove bunch of dead functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2938,6 +2938,7 @@ name = "near-metrics"
 version = "0.0.0"
 dependencies = [
  "lazy_static",
+ "once_cell",
  "prometheus",
  "tracing",
 ]

--- a/core/metrics/Cargo.toml
+++ b/core/metrics/Cargo.toml
@@ -14,3 +14,6 @@ description = "A fork of the lighthouse_metrics crate used to implement promethe
 lazy_static = "1.4"
 prometheus = "0.11"
 tracing = "0.1.13"
+
+[dev-dependencies]
+once_cell = "1.5.2"

--- a/core/metrics/src/lib.rs
+++ b/core/metrics/src/lib.rs
@@ -33,21 +33,21 @@
 //!         "Total number of runs",
 //!     )
 //!     .unwrap()
-//! };
+//! });
 //! pub static CURRENT_VALUE: Lazy<IntGauge> = Lazy::new(|| {
 //!     try_create_int_gauge(
 //!         "current_value",
 //!         "The current value",
 //!     )
 //!     .unwrap()
-//! };
+//! });
 //! pub static RUN_TIME: Lazy<Histogram> = Lazy::new(|| {
 //!     try_create_histogram(
 //!         "run_seconds",
 //!         "Time taken (measured to high precision)",
 //!     )
 //!     .unwrap()
-//! };
+//! });
 //!
 //! fn main() {
 //!     for i in 0..100 {

--- a/core/metrics/src/lib.rs
+++ b/core/metrics/src/lib.rs
@@ -54,11 +54,16 @@
 //!         RUN_COUNT.inc();
 //!         let timer = RUN_TIME.start_timer();
 //!         for j in 0..10 {
-//!             current_value.set(j);
+//!             CURRENT_VALUE.set(j);
 //!             println!("Howdy partner");
 //!         }
 //!         timer.observe_duration();
 //!     }
+//!
+//!     assert_eq!(100, RUN_COUNT.get());
+//!     assert_eq!(9, CURRENT_VALUE.get());
+//!     assert_eq!(100, RUN_TIME.get_sample_count());
+//!     assert!(0.0 < RUN_TIME.get_sample_sum());
 //! }
 //! ```
 

--- a/core/metrics/src/lib.rs
+++ b/core/metrics/src/lib.rs
@@ -27,21 +27,21 @@
 //! use near_metrics::*;
 //!
 //! // These metrics are "magically" linked to the global registry defined in `lighthouse_metrics`.
-//! pub static ref RUN_COUNT: Lazy<IntCounter> = Lazy::new(|| {
+//! pub static RUN_COUNT: Lazy<IntCounter> = Lazy::new(|| {
 //!     try_create_int_counter(
 //!         "runs_total",
 //!         "Total number of runs",
 //!     )
 //!     .unwrap()
 //! };
-//! pub static ref CURRENT_VALUE: Lazy<IntGauge> = Lazy::new(|| {
+//! pub static CURRENT_VALUE: Lazy<IntGauge> = Lazy::new(|| {
 //!     try_create_int_gauge(
 //!         "current_value",
 //!         "The current value",
 //!     )
 //!     .unwrap()
 //! };
-//! pub static ref RUN_TIME: Lazy<Histogram> = Lazy::new(|| {
+//! pub static RUN_TIME: Lazy<Histogram> = Lazy::new(|| {
 //!     try_create_histogram(
 //!         "run_seconds",
 //!         "Time taken (measured to high precision)",
@@ -57,7 +57,7 @@
 //!             current_value.set(j);
 //!             println!("Howdy partner");
 //!         }
-//!         timer.obsorve_duration();
+//!         timer.observe_duration();
 //!     }
 //! }
 //! ```

--- a/core/metrics/src/lib.rs
+++ b/core/metrics/src/lib.rs
@@ -4,11 +4,12 @@
 //! and functions to add and use the following components (more info at
 //! [Prometheus docs](https://prometheus.io/docs/concepts/metric_types/)):
 //!
-//! - `Histogram`: used with `start_timer(..)` and `stop_timer(..)` to record durations (e.g.,
-//! block processing time).
-//! - `IncCounter`: used to represent an ideally ever-growing, never-shrinking integer (e.g.,
-//! number of block processing requests).
-//! - `IntGauge`: used to represent an varying integer (e.g., number of attestations per block).
+//! - `Histogram`: used with `start_timer()` and `observe_duration()` or
+//!     `observe()` method to record durations (e.g., block processing time).
+//! - `IncCounter`: used to represent an ideally ever-growing, never-shrinking
+//!     integer (e.g., number of block processing requests).
+//! - `IntGauge`: used to represent an varying integer (e.g., number of
+//!     attestations per block).
 //!
 //! ## Important
 //!
@@ -21,39 +22,42 @@
 //! ## Example
 //!
 //! ```rust
-//! #[macro_use]
-//! extern crate lazy_static;
+//! use once_cell::sync::Lazy;
+//!
 //! use near_metrics::*;
 //!
 //! // These metrics are "magically" linked to the global registry defined in `lighthouse_metrics`.
-//! lazy_static! {
-//!     pub static ref RUN_COUNT: Result<IntCounter> = try_create_int_counter(
+//! pub static ref RUN_COUNT: Lazy<IntCounter> = Lazy::new(|| {
+//!     try_create_int_counter(
 //!         "runs_total",
-//!         "Total number of runs"
-//!     );
-//!     pub static ref CURRENT_VALUE: Result<IntGauge> = try_create_int_gauge(
+//!         "Total number of runs",
+//!     )
+//!     .unwrap()
+//! };
+//! pub static ref CURRENT_VALUE: Lazy<IntGauge> = Lazy::new(|| {
+//!     try_create_int_gauge(
 //!         "current_value",
-//!         "The current value"
-//!     );
-//!     pub static ref RUN_TIME: Result<Histogram> =
-//!         try_create_histogram("run_seconds", "Time taken (measured to high precision)");
-//! }
-//!
+//!         "The current value",
+//!     )
+//!     .unwrap()
+//! };
+//! pub static ref RUN_TIME: Lazy<Histogram> = Lazy::new(|| {
+//!     try_create_histogram(
+//!         "run_seconds",
+//!         "Time taken (measured to high precision)",
+//!     )
+//!     .unwrap()
+//! };
 //!
 //! fn main() {
-//!     let run_count: Result<IntCounter> = try_create_int_counter(&"RUN_COUNT", &"RUN_COUNT");
-//!     let run_time: Result<Histogram>  = try_create_histogram("RUN_TIME", &"RUN_TIME");
-//!     let current_value: Result<IntGauge>  = try_create_int_gauge("CURRENT_VALUE", "RUN_COUNT");
 //!     for i in 0..100 {
-//!         inc_counter(&run_count);
-//!         let timer = start_timer(&run_time);
-//!
+//!         RUN_COUNT.inc();
+//!         let timer = RUN_TIME.start_timer();
 //!         for j in 0..10 {
-//!             set_gauge(&current_value, j);
+//!             current_value.set(j);
 //!             println!("Howdy partner");
 //!         }
-//!
-//!         stop_timer(timer);
+//!         timer.obsorve_duration();
 //!     }
 //! }
 //! ```
@@ -62,9 +66,7 @@ pub use prometheus::{
     Encoder, Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Result,
     TextEncoder,
 };
-use prometheus::{GaugeVec, HistogramOpts, HistogramTimer, Opts};
-
-use tracing::error;
+use prometheus::{GaugeVec, HistogramOpts, Opts};
 
 /// Collect all the metrics for reporting.
 pub fn gather() -> Vec<prometheus::proto::MetricFamily> {
@@ -162,118 +164,4 @@ pub fn try_create_gauge_vec(name: &str, help: &str, labels: &[&str]) -> Result<G
     let gauge = GaugeVec::new(opts, labels)?;
     prometheus::register(Box::new(gauge.clone()))?;
     Ok(gauge)
-}
-
-/// Starts a timer for the given `Histogram`, stopping when it gets dropped or given to `stop_timer(..)`.
-pub fn start_timer(histogram: &Result<Histogram>) -> Option<HistogramTimer> {
-    if let Ok(histogram) = histogram {
-        Some(histogram.start_timer())
-    } else {
-        error!(target: "metrics", "Failed to fetch histogram");
-        None
-    }
-}
-
-/// Starts a timer for the given `HistogramVec` and labels, stopping when it gets dropped or given to `stop_timer(..)`.
-pub fn start_timer_vec(
-    histogram: &Result<HistogramVec>,
-    label_values: &[&str],
-) -> Option<HistogramTimer> {
-    if let Ok(histogram) = histogram {
-        Some(histogram.with_label_values(label_values).start_timer())
-    } else {
-        error!(target: "metrics", "Failed to fetch histogram");
-        None
-    }
-}
-
-/// Sets the value of a `Histogram` manually.
-pub fn observe(histogram: &Result<Histogram>, value: f64) {
-    if let Ok(histogram) = histogram {
-        histogram.observe(value);
-    } else {
-        error!(target: "metrics", "Failed to fetch histogram");
-    }
-}
-
-/// Stops a timer created with `start_timer(..)`.
-pub fn stop_timer(timer: Option<HistogramTimer>) {
-    if let Some(t) = timer {
-        t.observe_duration();
-    }
-}
-
-pub fn inc_counter(counter: &Result<IntCounter>) {
-    if let Ok(counter) = counter {
-        counter.inc();
-    } else {
-        error!(target: "metrics", "Failed to fetch counter");
-    }
-}
-
-pub fn inc_counter_vec(counter: &Result<IntCounterVec>, label_values: &[&str]) {
-    if let Ok(counter) = counter {
-        counter.with_label_values(label_values).inc();
-    } else {
-        error!(target: "metrics", "Failed to fetch counter");
-    }
-}
-
-pub fn inc_counter_opt(counter: Option<&IntCounter>) {
-    if let Some(counter) = counter {
-        counter.inc();
-    }
-}
-
-pub fn get_counter(counter: &Result<IntCounter>) -> std::result::Result<u64, String> {
-    if let Ok(counter) = counter {
-        Ok(counter.get())
-    } else {
-        Err("Failed to fetch counter".to_string())
-    }
-}
-
-pub fn inc_counter_by(counter: &Result<IntCounter>, value: u64) {
-    if let Ok(counter) = counter {
-        counter.inc_by(value);
-    } else {
-        error!(target: "metrics", "Failed to fetch histogram");
-    }
-}
-
-pub fn inc_counter_by_opt(counter: Option<&IntCounter>, value: u64) {
-    if let Some(counter) = counter {
-        counter.inc_by(value);
-    }
-}
-
-pub fn set_gauge(gauge: &Result<IntGauge>, value: i64) {
-    if let Ok(gauge) = gauge {
-        gauge.set(value);
-    } else {
-        error!(target: "metrics", "Failed to fetch gauge");
-    }
-}
-
-pub fn inc_gauge(gauge: &Result<IntGauge>) {
-    if let Ok(gauge) = gauge {
-        gauge.inc();
-    } else {
-        error!(target: "metrics", "Failed to fetch gauge");
-    }
-}
-
-pub fn dec_gauge(gauge: &Result<IntGauge>) {
-    if let Ok(gauge) = gauge {
-        gauge.dec();
-    } else {
-        error!(target: "metrics", "Failed to fetch gauge");
-    }
-}
-pub fn get_gauge(gauge: &Result<IntGauge>) -> std::result::Result<i64, String> {
-    if let Ok(gauge) = gauge {
-        Ok(gauge.get())
-    } else {
-        Err("Failed to fetch gauge".to_string())
-    }
 }


### PR DESCRIPTION
If creating a counter fails don’t store it in the peer_messages hash
in NetworkMetrics.  There is no point in keeping a None entry in the
hash.  This simplifies inc and inc_by methods which no longer have to
handle the case of None being stored in the hash map (only the case of
value missing from the hash which they were handling already).

With that, inc_counter_opt and inc_counter_by_opt functions are no
longer used.  Just like a whole slew of other functions which
manipulate metrics defined in near_metrics crate.  Delete all of them.