### PR TITLE
network: remove near_<msg-type>_{total,bytes} metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 * Make RocksDB block_size configurable [#6631](https://github.com/near/nearcore/pull/6631)
 * Increase default max_open_files RocksDB parameter from 512 to 10k [#6607](https://github.com/near/nearcore/pull/6607)
 * Use kebab-case names for neard subcommands to make them consistent with flag names.  snake_case names are still valid for existing subcommands but kebab-case will be used for new commands.
+* Added `near_peer_message_received_by_type_bytes` metric [#6661](https://github.com/near/nearcore/pull/6661)
+* Removed `near_<msg-type>_{total,bytes}` metrics in favour of `near_peer_message_received_by_type_{total,bytes}` metrics [#6661](https://github.com/near/nearcore/pull/6661)
 
 ## 1.25.0 [2022-03-16]
 

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -4,7 +4,7 @@ use crate::peer::utils;
 use crate::private_actix::{
     PeersRequest, RegisterPeer, RegisterPeerResponse, SendMessage, Unregister,
 };
-use crate::stats::metrics::{self, NetworkMetrics};
+use crate::stats::metrics;
 use crate::types::{
     Handshake, HandshakeFailureReason, NetworkClientMessages, NetworkClientResponses,
     NetworkRequests, NetworkResponses, PeerManagerMessageRequest, PeerMessage, PeerRequest,
@@ -96,8 +96,6 @@ pub(crate) struct PeerActor {
     partial_edge_info: Option<PartialEdgeInfo>,
     /// Last time an update of received message was sent to PeerManager
     last_time_received_message_update: Instant,
-    /// Dynamic Prometheus metrics
-    network_metrics: Arc<NetworkMetrics>,
     /// How many transactions we have received since the last block message
     /// Note: Shared between multiple Peers.
     txns_since_last_block: Arc<AtomicUsize>,
@@ -128,7 +126,6 @@ impl PeerActor {
         client_addr: Recipient<NetworkClientMessages>,
         view_client_addr: Recipient<NetworkViewClientMessages>,
         partial_edge_info: Option<PartialEdgeInfo>,
-        network_metrics: Arc<NetworkMetrics>,
         txns_since_last_block: Arc<AtomicUsize>,
         peer_counter: Arc<AtomicUsize>,
         throttle_controller: ThrottleController,
@@ -150,7 +147,6 @@ impl PeerActor {
             chain_info: Default::default(),
             partial_edge_info,
             last_time_received_message_update: Clock::instant(),
-            network_metrics,
             txns_since_last_block,
             peer_counter,
             routed_message_cache: LruCache::new(ROUTED_MESSAGE_CACHE_SIZE),
@@ -694,17 +690,13 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for PeerActor {
 
         self.on_receive_message();
 
-        self.network_metrics
-            .inc(NetworkMetrics::peer_message_total_rx(peer_msg.msg_variant()).as_ref());
-
-        self.network_metrics.inc_by(
-            NetworkMetrics::peer_message_bytes_rx(peer_msg.msg_variant()).as_ref(),
-            msg.len() as u64,
-        );
-
-        metrics::PEER_MESSAGE_RECEIVED_BY_TYPE_TOTAL
-            .with_label_values(&[peer_msg.msg_variant()])
-            .inc();
+        {
+            let labels = [peer_msg.msg_variant()];
+            metrics::PEER_MESSAGE_RECEIVED_BY_TYPE_TOTAL.with_label_values(&labels).inc();
+            metrics::PEER_MESSAGE_RECEIVED_BY_TYPE_BYTES
+                .with_label_values(&labels)
+                .inc_by(msg.len() as u64);
+        }
 
         match (self.peer_status, peer_msg) {
             (_, PeerMessage::HandshakeFailure(peer_info, reason)) => {

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -877,7 +877,6 @@ impl PeerManagerActor {
             }
         };
 
-        let network_metrics = self.network_metrics.clone();
         let txns_since_last_block = Arc::clone(&self.txns_since_last_block);
 
         // Start every peer actor on separate thread.
@@ -914,7 +913,6 @@ impl PeerManagerActor {
                 client_addr,
                 view_client_addr,
                 partial_edge_info,
-                network_metrics,
                 txns_since_last_block,
                 peer_counter,
                 rate_limiter,
@@ -1144,7 +1142,7 @@ impl PeerManagerActor {
     /// Check if the number of connections (excluding whitelisted ones) exceeds ideal_connections_hi.
     /// If so, constructs a safe set of peers and selects one random peer outside of that set
     /// and sends signal to stop connection to it gracefully.
-    ///     
+    ///
     /// Safe set contruction process:
     /// 1. Add all whitelisted peers to the safe set.
     /// 2. If the number of outbound connections is less or equal than minimum_outbound_connections,


### PR DESCRIPTION
Remove `near_<msg-type>_total` metrics.  Data in those metrics are
available in a `near_peer_message_received_by_type_total` metric with
a `type` label which is easier to deal with.

Similarly, `replace near_<msg-type>_bytes` metrics with a single new
`near_peer_message_received_by_type_bytes` metric using `type` label.

The `near_<msg-type>_dropped` metric is left as is for now but will be
dealt with in another change.
