### PR TITLE
fuzz: bump near-vm-runner fuzzer to 3G max RAM

### DIFF
--- a/nightly/fuzz.toml
+++ b/nightly/fuzz.toml
@@ -14,7 +14,7 @@ weight = 10
 crate = "runtime/near-vm-runner/fuzz"
 runner = "runner"
 weight = 10
-flags = ["-len_control=0", "-prefer_small=0", "-max_len=4000000"]
+flags = ["-len_control=0", "-prefer_small=0", "-max_len=4000000", "-rss_limit_mb=3072"]
 
 [[target]]
 # Disabled for now because of the frequent intermittent failures,


### PR DESCRIPTION
Before that, the fuzzer would OOM in a way that could be reproduced
only with the sanitizers enabled.