### PR TITLE
store: propagate errors when reading db version rather than panicking

### DIFF
--- a/core/store/src/migrations.rs
+++ b/core/store/src/migrations.rs
@@ -26,7 +26,7 @@ use near_primitives::utils::{
 };
 use near_primitives::version::DbVersion;
 
-use crate::db::{RocksDB, GENESIS_JSON_HASH_KEY, VERSION_KEY};
+use crate::db::{DBError, RocksDB, GENESIS_JSON_HASH_KEY, VERSION_KEY};
 use crate::migrations::v6_to_v7::{
     col_state_refcount_8byte, migrate_col_transaction_refcount, migrate_receipts_refcount,
 };
@@ -44,8 +44,8 @@ use std::path::Path;
 pub mod v6_to_v7;
 pub mod v8_to_v9;
 
-pub fn get_store_version(path: &Path) -> DbVersion {
-    RocksDB::get_version(path).expect("Failed to open the database")
+pub fn get_store_version(path: &Path) -> Result<DbVersion, DBError> {
+    RocksDB::get_version(path)
 }
 
 fn set_store_version_inner(store_update: &mut StoreUpdate, db_version: u32) {

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -115,7 +115,7 @@ fn create_db_checkpoint(path: &Path, near_config: &NearConfig) -> anyhow::Result
 
 /// Function checks current version of the database and applies migrations to the database.
 fn apply_store_migrations(path: &Path, near_config: &NearConfig) -> anyhow::Result<()> {
-    let db_version = get_store_version(&path);
+    let db_version = get_store_version(&path)?;
     if db_version == near_primitives::version::DB_VERSION {
         return Ok(());
     }
@@ -332,7 +332,7 @@ fn apply_store_migrations(path: &Path, near_config: &NearConfig) -> anyhow::Resu
 
     #[cfg(not(feature = "nightly_protocol"))]
     {
-        let db_version = get_store_version(&path);
+        let db_version = get_store_version(&path)?;
         debug_assert_eq!(db_version, near_primitives::version::DB_VERSION);
     }
 
@@ -542,7 +542,7 @@ pub fn recompress_storage(home_dir: &Path, opts: RecompressOpts) -> anyhow::Resu
         "{}: source storage doesn’t exist",
         src_dir.display()
     );
-    let db_version = get_store_version(&src_dir);
+    let db_version = get_store_version(&src_dir)?;
     anyhow::ensure!(
         db_version == near_primitives::version::DB_VERSION,
         "{}: expected DB version {} but got {}",


### PR DESCRIPTION
All places which used RocksDB::get_version were already able to return
an error which makes propagating an error when reading the version
trivial.

Issue: https://github.com/near/nearcore/issues/6622