### PR TITLE
feat: add runtime checks for "immutable" columns

### DIFF
--- a/chain/epoch_manager/src/lib.rs
+++ b/chain/epoch_manager/src/lib.rs
@@ -1369,7 +1369,7 @@ impl EpochManager {
     ) -> Result<(), EpochError> {
         let block_hash = *block_info.hash();
         store_update
-            .set_ser(DBCol::BlockInfo, block_hash.as_ref(), &block_info)
+            .insert_ser(DBCol::BlockInfo, block_hash.as_ref(), &block_info)
             .map_err(EpochError::from)?;
         self.blocks_info.put(block_hash, block_info);
         Ok(())

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -236,6 +236,23 @@ pub enum DBCol {
 }
 
 impl DBCol {
+    /// Whether data in this column is effectively immutable.
+    ///
+    /// Data in such columns is never overwriten, though it can be deleted by gc
+    /// eventually. Specifically, for a given key:
+    ///
+    /// * It's OK to insert a new value.
+    /// * It's also OK to insert a value which is equal to the one already
+    ///   stored.
+    /// * Inserting a different value would crash the node in debug, but not in
+    ///   release.
+    /// * GC (and only GC) is allowed to remove any value.
+    ///
+    /// In some sence, insert-only column acts as an rc-column, where rc is
+    /// always one.
+    pub fn is_insert_only(&self) -> bool {
+        INSERT_ONLY_COLUMNS[*self as usize]
+    }
     /// Whethere this column is reference-counted.
     /// This means, that we're storing additional 8 bytes at the end of the payload with the current RC value.
     /// For such columns you must not use set, set_ser or delete, but 'update_refcount' instead.
@@ -305,6 +322,8 @@ const OPTIONAL_GC_COLUMNS: [bool; DBCol::COUNT] = col_set(&[
 const RC_COLUMNS: [bool; DBCol::COUNT] =
     col_set(&[DBCol::State, DBCol::Transactions, DBCol::Receipts, DBCol::ReceiptIdToShardId]);
 
+const INSERT_ONLY_COLUMNS: [bool; DBCol::COUNT] = col_set(&[DBCol::BlockInfo]);
+
 const fn col_set(cols: &[DBCol]) -> [bool; DBCol::COUNT] {
     let mut res = [false; DBCol::COUNT];
     let mut i = 0;
@@ -370,5 +389,16 @@ impl fmt::Display for DBCol {
             Self::StateChangesForSplitStates => "state changes indexed by block hash and shard id",
         };
         write!(f, "{}", desc)
+    }
+}
+
+#[test]
+fn column_props_sanity() {
+    for col in DBCol::iter() {
+        if col.is_gc_optional() {
+            assert!(col.is_gc())
+        }
+        // Check that rc and write_once are mutually exclusive.
+        assert!((col.is_rc() as u32) + (col.is_insert_only() as u32) <= 1, "{col}")
     }
 }

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -141,7 +141,7 @@ impl Store {
             let mut value = vec![0; value_len];
             file.read_exact(&mut value)?;
 
-            transaction.insert(column, key, value);
+            transaction.set(column, key, value);
         }
         self.storage.write(transaction).map_err(io::Error::from)
     }
@@ -175,17 +175,44 @@ impl StoreUpdate {
         StoreUpdate { storage, transaction, tries: Some(tries) }
     }
 
+    /// Inserts a new value into the database.
+    ///
+    /// It is a programming error if `insert` overwrites an existing, different
+    /// value. Use it for insert-only columns.
+    pub fn insert(&mut self, column: DBCol, key: &[u8], value: &[u8]) {
+        assert!(column.is_insert_only());
+        self.transaction.insert(column, key.to_vec(), value.to_vec())
+    }
+
+    pub fn insert_ser<T: BorshSerialize>(
+        &mut self,
+        column: DBCol,
+        key: &[u8],
+        value: &T,
+    ) -> io::Result<()> {
+        let data = value.try_to_vec()?;
+        self.insert(column, key, &data);
+        Ok(())
+    }
+
+    /// Inserts a new reference-counted value into the database, or adjusts its
+    /// reference count if it is already there.
+    ///
+    /// It is a programming error if `update_refcount` supplies a different
+    /// value than the one stored in te database. Use it for rc columns.
     pub fn update_refcount(&mut self, column: DBCol, key: &[u8], value: &[u8], rc_delta: i64) {
         assert!(column.is_rc());
         let value = encode_value_with_rc(value, rc_delta);
         self.transaction.update_refcount(column, key.to_vec(), value)
     }
 
-    /// Saves a given value.
-    /// Must not be used for RC columns - please use 'update_refcount' instead.
+    /// Modifies a value in the database.
+    ///
+    /// Unlike `insert` or `update_refcount`, arbitrary modifications are
+    /// allowed, and extra care must be taken to aviod consistency anomalies.
     pub fn set(&mut self, column: DBCol, key: &[u8], value: &[u8]) {
-        assert!(!column.is_rc());
-        self.transaction.insert(column, key.to_vec(), value.to_vec())
+        assert!(!(column.is_rc() || column.is_insert_only()));
+        self.transaction.set(column, key.to_vec(), value.to_vec())
     }
 
     /// Saves a BorshSerialized value.
@@ -242,9 +269,9 @@ impl StoreUpdate {
                     .ops
                     .iter()
                     .filter_map(|op| match op {
-                        DBOp::Insert { col, key, .. } | DBOp::Delete { col, key } => {
-                            Some((*col as u8, key))
-                        }
+                        DBOp::Set { col, key, .. }
+                        | DBOp::Insert { col, key, .. }
+                        | DBOp::Delete { col, key } => Some((*col as u8, key)),
                         DBOp::UpdateRefcount { .. } | DBOp::DeleteAll { .. } => None,
                     })
                     .collect::<Vec<_>>();
@@ -271,6 +298,7 @@ impl fmt::Debug for StoreUpdate {
         for op in self.transaction.ops.iter() {
             match op {
                 DBOp::Insert { col, key, .. } => writeln!(f, "  + {:?} {}", col, to_base(key))?,
+                DBOp::Set { col, key, .. } => writeln!(f, "  * {:?} {}", col, to_base(key))?,
                 DBOp::UpdateRefcount { col, key, .. } => {
                     writeln!(f, "  +- {:?} {}", col, to_base(key))?
                 }

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -89,7 +89,7 @@ impl ShardTries {
                         TrieCachingStorage::get_shard_uid_and_hash_from_key(key)?;
                     shards.entry(shard_uid).or_insert(vec![]).push((hash, Some(value)));
                 }
-                DBOp::Insert { col, .. } if *col == DBCol::State => unreachable!(),
+                DBOp::Set { col, .. } if *col == DBCol::State => unreachable!(),
                 DBOp::Delete { col, .. } if *col == DBCol::State => unreachable!(),
                 DBOp::DeleteAll { col } if *col == DBCol::State => {
                     // Delete is possible in reset_data_pre_state_sync


### PR DESCRIPTION
We have three classes of columns in the DB:

* read-write columns which are modified arbitrary
* insert only columns, where each value is written once and exists
  unchanged until GCed. You can call such columns immutable.
* RC columns, which are also immutable, but allow repated writes which
  bump rc.

Today, we use the same operations for working with both read-write
and write-once columns. In this PR, I want to seprate that into two
semantically distinct operations (which would allow us to have better
runtime and compile-time checks):

* `set` for read-write columns
* `insert` for insert-only columns

The main motivation is to make reasoning about the code easier -- if a
bit of code only does inserts and no sets, it can be reorderd relatively
easily.