### PR TITLE
feat: add print_backtrace function for easier debugging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2999,6 +2999,7 @@ dependencies = [
 name = "near-o11y"
 version = "0.0.0"
 dependencies = [
+ "backtrace",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",

--- a/core/o11y/Cargo.toml
+++ b/core/o11y/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 rust-version = "1.60.0"
 
 [dependencies]
+backtrace = "0.3.64"
 tracing = { version = "0.1.13", features = ["std"] }
 tracing-subscriber = { version = "0.3.9", features = ["fmt", "env-filter", "std"] }
 tracing-appender = "0.2.2"

--- a/core/o11y/src/lib.rs
+++ b/core/o11y/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 
-pub use {tracing, tracing_appender, tracing_subscriber};
+pub use {backtrace, tracing, tracing_appender, tracing_subscriber};
 
 use std::borrow::Cow;
 
@@ -146,6 +146,14 @@ impl<'a> EnvFilterBuilder<'a> {
         }
         env_filter
     }
+}
+
+/// Prints backtrace to stderr.
+///
+/// This is intended as a printf-debugging aid.
+pub fn print_backtrace() {
+    let bt = backtrace::Backtrace::new();
+    eprintln!("{bt:?}")
 }
 
 /// Asserts that the condition is true, logging an error otherwise.


### PR DESCRIPTION
This little utility is quite useful during ad-hoc debugging sessions.
Having it accessible in the ubiquitious o11y crate would be convenient.