### PR TITLE
refactor: Clean up VMResult::NotRun

### DIFF
--- a/runtime/near-vm-runner-standalone/src/main.rs
+++ b/runtime/near-vm-runner-standalone/src/main.rs
@@ -168,7 +168,6 @@ fn main() {
     let maybe_error = last_result.error();
 
     match &last_result {
-        VMResult::NotRun(_) => {}
         VMResult::Aborted(outcome, _) | VMResult::Ok(outcome) => {
             println!(
                 "{:#?}",

--- a/runtime/near-vm-runner-standalone/src/script.rs
+++ b/runtime/near-vm-runner-standalone/src/script.rs
@@ -216,10 +216,10 @@ fn vm_script_smoke_test() {
 
     assert_eq!(res.outcomes.len(), 4);
 
-    let logs = &res.outcomes[0].outcome().unwrap().logs;
+    let logs = &res.outcomes[0].outcome().logs;
     assert_eq!(logs, &vec!["hello".to_string()]);
 
-    let ret = res.outcomes.last().unwrap().outcome().unwrap().return_data.clone();
+    let ret = res.outcomes.last().unwrap().outcome().return_data.clone();
 
     let expected = ReturnData::Value(4950u64.to_le_bytes().to_vec());
     assert_eq!(ret, expected);
@@ -238,12 +238,11 @@ fn profile_data_is_per_outcome() {
     let res = script.run();
     assert_eq!(res.outcomes.len(), 4);
     assert_eq!(
-        res.outcomes[1].outcome().unwrap().profile.host_gas(),
-        res.outcomes[2].outcome().unwrap().profile.host_gas()
+        res.outcomes[1].outcome().profile.host_gas(),
+        res.outcomes[2].outcome().profile.host_gas()
     );
     assert!(
-        res.outcomes[1].outcome().unwrap().profile.host_gas()
-            > res.outcomes[3].outcome().unwrap().profile.host_gas()
+        res.outcomes[1].outcome().profile.host_gas() > res.outcomes[3].outcome().profile.host_gas()
     );
 }
 

--- a/runtime/near-vm-runner/src/preload.rs
+++ b/runtime/near-vm-runner/src/preload.rs
@@ -131,7 +131,7 @@ impl ContractCaller {
             Some(call) => {
                 let call_data = call.rx.recv().unwrap();
                 match call_data.result {
-                    Err(err) => VMResult::NotRun(err),
+                    Err(err) => VMResult::nop_outcome(err),
                     Ok(module) => match (&module, &mut self.vm_data_private) {
                         #[cfg(feature = "wasmer0_vm")]
                         (VMModule::Wasmer0(module), VMDataPrivate::Wasmer0(memory)) => {

--- a/runtime/near-vm-runner/src/runner.rs
+++ b/runtime/near-vm-runner/src/runner.rs
@@ -1,12 +1,13 @@
 use near_primitives::config::VMConfig;
 use near_primitives::contract::ContractCode;
 use near_primitives::hash::CryptoHash;
+use near_primitives::profile::ProfileData;
 use near_primitives::runtime::fees::RuntimeFeesConfig;
 use near_primitives::types::CompiledContractCache;
 use near_primitives::version::ProtocolVersion;
 use near_vm_errors::VMError;
 use near_vm_logic::types::PromiseResult;
-use near_vm_logic::{External, VMContext, VMLogic, VMOutcome};
+use near_vm_logic::{External, ReturnData, VMContext, VMLogic, VMOutcome};
 
 use crate::vm_kind::VMKind;
 
@@ -113,10 +114,6 @@ impl VMKind {
 /// function inside.
 #[derive(Debug, PartialEq)]
 pub enum VMResult {
-    /// Execution was not able to start because preconditions were not met.
-    /// TODO: Remove this with more refactoring or present a good reason why it
-    /// is needed.
-    NotRun(VMError),
     /// Execution started but hit an error.
     Aborted(VMOutcome, VMError),
     /// Execution finished without error.
@@ -138,19 +135,35 @@ impl VMResult {
         VMResult::Ok(outcome)
     }
 
+    /// Creates an outcome with a no-op outcome.
+    pub fn nop_outcome(error: VMError) -> VMResult {
+        let outcome = VMOutcome {
+            // Note: Balance and storage fields are ignored on a failed outcome.
+            balance: 0,
+            storage_usage: 0,
+            // Note: Fields below are added or merged when processing the
+            // outcome. With 0 or the empty set, those are no-ops.
+            return_data: ReturnData::None,
+            burnt_gas: 0,
+            used_gas: 0,
+            logs: Vec::new(),
+            profile: ProfileData::default(),
+            action_receipts: Vec::new(),
+        };
+        VMResult::Aborted(outcome, error)
+    }
+
     /// Borrow the internal outcome, if there is one.
-    pub fn outcome(&self) -> Option<&VMOutcome> {
+    pub fn outcome(&self) -> &VMOutcome {
         match self {
-            VMResult::NotRun(_err) => None,
-            VMResult::Aborted(outcome, _err) => Some(outcome),
-            VMResult::Ok(outcome) => Some(outcome),
+            VMResult::Aborted(outcome, _err) => outcome,
+            VMResult::Ok(outcome) => outcome,
         }
     }
 
     /// Borrow the internal error, if there is one.
     pub fn error(&self) -> Option<&VMError> {
         match self {
-            VMResult::NotRun(err) => Some(err),
             VMResult::Aborted(_outcome, err) => Some(err),
             VMResult::Ok(_outcome) => None,
         }
@@ -158,11 +171,10 @@ impl VMResult {
 
     /// Unpack the internal outcome and error. This method mostly exists for
     /// easy compatibility with code that was written before `VMResult` existed.
-    pub fn outcome_error(self) -> (Option<VMOutcome>, Option<VMError>) {
+    pub fn outcome_error(self) -> (VMOutcome, Option<VMError>) {
         match self {
-            VMResult::NotRun(err) => (None, Some(err)),
-            VMResult::Aborted(outcome, err) => (Some(outcome), Some(err)),
-            VMResult::Ok(outcome) => (Some(outcome), None),
+            VMResult::Aborted(outcome, err) => (outcome, Some(err)),
+            VMResult::Ok(outcome) => (outcome, None),
         }
     }
 }

--- a/runtime/near-vm-runner/src/tests.rs
+++ b/runtime/near-vm-runner/src/tests.rs
@@ -60,7 +60,7 @@ fn make_simple_contract_call_with_gas_vm(
     method_name: &str,
     prepaid_gas: u64,
     vm_kind: VMKind,
-) -> (Option<VMOutcome>, Option<VMError>) {
+) -> (VMOutcome, Option<VMError>) {
     let mut fake_external = MockedExternal::new();
     let mut context = create_context(vec![]);
     context.prepaid_gas = prepaid_gas;
@@ -90,7 +90,7 @@ fn make_simple_contract_call_with_protocol_version_vm(
     method_name: &str,
     protocol_version: ProtocolVersion,
     vm_kind: VMKind,
-) -> (Option<VMOutcome>, Option<VMError>) {
+) -> (VMOutcome, Option<VMError>) {
     let mut fake_external = MockedExternal::new();
     let context = create_context(vec![]);
     let runtime_config_store = RuntimeConfigStore::new(None);
@@ -119,23 +119,26 @@ fn make_simple_contract_call_vm(
     code: &[u8],
     method_name: &str,
     vm_kind: VMKind,
-) -> (Option<VMOutcome>, Option<VMError>) {
+) -> (VMOutcome, Option<VMError>) {
     make_simple_contract_call_with_gas_vm(code, method_name, 10u64.pow(14), vm_kind)
 }
 
 #[track_caller]
 fn gas_and_error_match(
-    outcome_and_error: (Option<VMOutcome>, Option<VMError>),
+    outcome_and_error: (VMOutcome, Option<VMError>),
     expected_gas: Option<u64>,
     expected_error: Option<VMError>,
 ) {
     match expected_gas {
         Some(gas) => {
-            let outcome = outcome_and_error.0.unwrap();
+            let outcome = outcome_and_error.0;
             assert_eq!(outcome.used_gas, gas, "used gas differs");
             assert_eq!(outcome.burnt_gas, gas, "burnt gas differs");
         }
-        None => assert!(outcome_and_error.0.is_none()),
+        None => {
+            assert_eq!(outcome_and_error.0.used_gas, 0);
+            assert_eq!(outcome_and_error.0.burnt_gas, 0);
+        }
     }
 
     assert_eq!(outcome_and_error.1, expected_error);

--- a/runtime/near-vm-runner/src/tests/cache.rs
+++ b/runtime/near-vm-runner/src/tests/cache.rs
@@ -53,7 +53,7 @@ fn test_does_not_cache_io_error() {
 
         cache.set_read_fault(true);
         let result = make_cached_contract_call_vm(&cache, &code, "main", prepaid_gas, vm_kind);
-        assert!(result.outcome().is_none());
+        assert_eq!(result.outcome().used_gas, 0);
         assert_matches!(
             result.error(),
             Some(&VMError::CacheError(near_vm_errors::CacheError::ReadError))
@@ -61,7 +61,7 @@ fn test_does_not_cache_io_error() {
 
         cache.set_write_fault(true);
         let result = make_cached_contract_call_vm(&cache, &code, "main", prepaid_gas, vm_kind);
-        assert!(result.outcome().is_none());
+        assert_eq!(result.outcome().used_gas, 0);
         assert_matches!(
             result.error(),
             Some(&VMError::CacheError(near_vm_errors::CacheError::WriteError))

--- a/runtime/near-vm-runner/src/tests/compile_errors.rs
+++ b/runtime/near-vm-runner/src/tests/compile_errors.rs
@@ -26,13 +26,11 @@ fn initializer_wrong_signature_contract() -> Vec<u8> {
 fn test_initializer_wrong_signature_contract() {
     with_vm_variants(|vm_kind: VMKind| {
         assert_eq!(
-            make_simple_contract_call_vm(&initializer_wrong_signature_contract(), "hello", vm_kind),
-            (
-                None,
-                Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
-                    CompilationError::PrepareError(PrepareError::Deserialization)
-                )))
-            )
+            make_simple_contract_call_vm(&initializer_wrong_signature_contract(), "hello", vm_kind)
+                .1,
+            (Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
+                CompilationError::PrepareError(PrepareError::Deserialization)
+            ))))
         );
     });
 }
@@ -52,13 +50,10 @@ fn function_not_defined_contract() -> Vec<u8> {
 fn test_function_not_defined_contract() {
     with_vm_variants(|vm_kind: VMKind| {
         assert_eq!(
-            make_simple_contract_call_vm(&function_not_defined_contract(), "hello", vm_kind),
-            (
-                None,
-                Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
-                    CompilationError::PrepareError(PrepareError::Deserialization)
-                )))
-            )
+            make_simple_contract_call_vm(&function_not_defined_contract(), "hello", vm_kind).1,
+            (Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
+                CompilationError::PrepareError(PrepareError::Deserialization)
+            ))))
         );
     });
 }
@@ -79,13 +74,11 @@ fn function_type_not_defined_contract(bad_type: u64) -> Vec<u8> {
 fn test_function_type_not_defined_contract_1() {
     with_vm_variants(|vm_kind: VMKind| {
         assert_eq!(
-            make_simple_contract_call_vm(&function_type_not_defined_contract(1), "hello", vm_kind),
-            (
-                None,
-                Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
-                    CompilationError::PrepareError(PrepareError::Deserialization)
-                )))
-            )
+            make_simple_contract_call_vm(&function_type_not_defined_contract(1), "hello", vm_kind)
+                .1,
+            (Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
+                CompilationError::PrepareError(PrepareError::Deserialization)
+            ))))
         );
     });
 }
@@ -95,13 +88,11 @@ fn test_function_type_not_defined_contract_1() {
 fn test_function_type_not_defined_contract_2() {
     with_vm_variants(|vm_kind: VMKind| {
         assert_eq!(
-            make_simple_contract_call_vm(&function_type_not_defined_contract(0), "hello", vm_kind),
-            (
-                None,
-                Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
-                    CompilationError::PrepareError(PrepareError::Deserialization)
-                )))
-            )
+            make_simple_contract_call_vm(&function_type_not_defined_contract(0), "hello", vm_kind)
+                .1,
+            (Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
+                CompilationError::PrepareError(PrepareError::Deserialization)
+            ))))
         );
     });
 }
@@ -110,13 +101,10 @@ fn test_function_type_not_defined_contract_2() {
 fn test_garbage_contract() {
     with_vm_variants(|vm_kind: VMKind| {
         assert_eq!(
-            make_simple_contract_call_vm(&[], "hello", vm_kind),
-            (
-                None,
-                Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
-                    CompilationError::PrepareError(PrepareError::Deserialization)
-                )))
-            )
+            make_simple_contract_call_vm(&[], "hello", vm_kind).1,
+            (Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
+                CompilationError::PrepareError(PrepareError::Deserialization)
+            ))))
         );
     });
 }
@@ -138,13 +126,10 @@ fn evil_function_index() -> Vec<u8> {
 fn test_evil_function_index() {
     with_vm_variants(|vm_kind: VMKind| {
         assert_eq!(
-            make_simple_contract_call_vm(&evil_function_index(), "abort_with_zero", vm_kind),
-            (
-                None,
-                Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
-                    CompilationError::PrepareError(PrepareError::Deserialization)
-                )))
-            )
+            make_simple_contract_call_vm(&evil_function_index(), "abort_with_zero", vm_kind).1,
+            (Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
+                CompilationError::PrepareError(PrepareError::Deserialization)
+            ))))
         );
     });
 }

--- a/runtime/near-vm-runner/src/tests/contract_preload.rs
+++ b/runtime/near-vm-runner/src/tests/contract_preload.rs
@@ -83,10 +83,11 @@ fn test_result(result: VMResult, check_gas: bool) -> (i32, i32) {
             }
             oks += 1;
         }
-        VMResult::NotRun(FunctionCallError(_)) => {
+        VMResult::Aborted(outcome, FunctionCallError(_)) => {
+            assert_eq!(outcome.used_gas, 0, "Empty outcome expected but was: {outcome:?}",);
             errs += 1;
         }
-        VMResult::NotRun(err) | VMResult::Aborted(_, err) => {
+        VMResult::Aborted(_, err) => {
             assert!(false, "Unexpected error: {:?}", err)
         }
     }

--- a/runtime/near-vm-runner/src/tests/runtime_errors.rs
+++ b/runtime/near-vm-runner/src/tests/runtime_errors.rs
@@ -83,7 +83,7 @@ fn test_multiple_memories() {
     with_vm_variants(|vm_kind: VMKind| {
         let (result, error) =
             make_simple_contract_call_vm(&multi_memories_contract(), "hello", vm_kind);
-        assert_eq!(result, None);
+        assert_eq!(result.used_gas, 0);
         match error {
             Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
                 CompilationError::WasmerCompileError { .. },
@@ -707,15 +707,14 @@ fn bad_many_imports() -> Vec<u8> {
 #[test]
 fn test_bad_many_imports() {
     with_vm_variants(|vm_kind: VMKind| {
-        let result = make_simple_contract_call_vm(&bad_many_imports(), "hello", vm_kind);
-        let outcome = result.0.unwrap();
+        let (outcome, error) = make_simple_contract_call_vm(&bad_many_imports(), "hello", vm_kind);
         assert_eq!(outcome.used_gas, 299664213);
         assert_eq!(outcome.burnt_gas, 299664213);
-        if let Some(VMError::FunctionCallError(FunctionCallError::LinkError { msg })) = result.1 {
+        if let Some(VMError::FunctionCallError(FunctionCallError::LinkError { msg })) = error {
             eprintln!("{}", msg);
             assert!(msg.len() < 1000, "Huge error message: {}", msg.len());
         } else {
-            panic!("{:?}", result.1);
+            panic!("{:?}", error);
         }
     });
 }

--- a/runtime/near-vm-runner/src/tests/ts_contract.rs
+++ b/runtime/near-vm-runner/src/tests/ts_contract.rs
@@ -72,7 +72,7 @@ pub fn test_ts_contract() {
             None,
         );
 
-        if let ReturnData::Value(value) = result.outcome().unwrap().return_data.clone() {
+        if let ReturnData::Value(value) = result.outcome().return_data.clone() {
             let value = String::from_utf8(value).unwrap();
             assert_eq!(value, "bar");
         } else {

--- a/runtime/near-vm-runner/src/wasmer2_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer2_runner.rs
@@ -442,7 +442,7 @@ impl Wasmer2VM {
             artifact.engine(),
         );
         if let Err(e) = get_entrypoint_index(&*artifact, method_name) {
-            return VMResult::NotRun(e);
+            return VMResult::nop_outcome(e);
         }
         let status = self.run_method(artifact, import, method_name);
         match status {
@@ -528,13 +528,13 @@ impl crate::runner::VM for Wasmer2VM {
             let error = VMError::FunctionCallError(FunctionCallError::MethodResolveError(
                 MethodResolveError::MethodEmptyName,
             ));
-            return VMResult::NotRun(error);
+            return VMResult::nop_outcome(error);
         }
         let artifact =
             cache::wasmer2_cache::compile_module_cached_wasmer2(code, &self.config, cache);
         let artifact = match into_vm_result(artifact) {
             Ok(it) => it,
-            Err(err) => return VMResult::NotRun(err),
+            Err(err) => return VMResult::nop_outcome(err),
         };
 
         let mut memory = Wasmer2Memory::new(
@@ -570,7 +570,7 @@ impl crate::runner::VM for Wasmer2VM {
         );
         if let Err(e) = get_entrypoint_index(&*artifact, method_name) {
             // TODO: This should return an outcome to account for loading cost
-            return VMResult::NotRun(e);
+            return VMResult::nop_outcome(e);
         }
         match self.run_method(&artifact, import, method_name) {
             Ok(()) => VMResult::ok(logic),

--- a/runtime/near-vm-runner/src/wasmer_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer_runner.rs
@@ -238,7 +238,7 @@ pub(crate) fn run_wasmer0_module<'a>(
         let err = VMError::FunctionCallError(FunctionCallError::MethodResolveError(
             MethodResolveError::MethodEmptyName,
         ));
-        return VMResult::NotRun(err);
+        return VMResult::nop_outcome(err);
     }
     // Note that we don't clone the actual backing memory, just increase the RC.
     let memory_copy = memory.clone();
@@ -256,7 +256,7 @@ pub(crate) fn run_wasmer0_module<'a>(
     let import_object = imports::wasmer::build(memory_copy, &mut logic, current_protocol_version);
 
     if let Err(e) = check_method(&module, method_name) {
-        return VMResult::NotRun(e);
+        return VMResult::nop_outcome(e);
     }
 
     match run_method(&module, &import_object, method_name) {
@@ -315,14 +315,14 @@ impl crate::runner::VM for Wasmer0VM {
             let err = VMError::FunctionCallError(FunctionCallError::MethodResolveError(
                 MethodResolveError::MethodEmptyName,
             ));
-            return VMResult::NotRun(err);
+            return VMResult::nop_outcome(err);
         }
 
         // TODO: consider using get_module() here, once we'll go via deployment path.
         let module = cache::wasmer0_cache::compile_module_cached_wasmer0(code, &self.config, cache);
         let module = match into_vm_result(module) {
             Ok(x) => x,
-            Err(err) => return VMResult::NotRun(err),
+            Err(err) => return VMResult::nop_outcome(err),
         };
         let mut memory = WasmerMemory::new(
             self.config.limit_config.initial_memory_pages,
@@ -355,7 +355,7 @@ impl crate::runner::VM for Wasmer0VM {
 
         if let Err(e) = check_method(&module, method_name) {
             // TODO: This should return an outcome to account for loading cost
-            return VMResult::NotRun(e);
+            return VMResult::nop_outcome(e);
         }
 
         match run_method(&module, &import_object, method_name) {

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -754,9 +754,8 @@ fn wasm_instruction(ctx: &mut EstimatorContext) -> GasCost {
             PROTOCOL_VERSION,
             Some(&cache),
         );
-        assert!(vm_result.outcome().is_some());
         assert!(vm_result.error().is_some());
-        vm_result.outcome().cloned().unwrap()
+        vm_result.outcome_error().0
     };
 
     let warmup_outcome = run();

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -57,10 +57,10 @@ pub(crate) fn execute_function_call(
             let error = FunctionCallError::CompilationError(CompilationError::CodeDoesNotExist {
                 account_id: account_id.clone(),
             });
-            return VMResult::NotRun(VMError::FunctionCallError(error));
+            return VMResult::nop_outcome(VMError::FunctionCallError(error));
         }
         Err(e) => {
-            return VMResult::NotRun(VMError::ExternalError(AnyError::new(
+            return VMResult::nop_outcome(VMError::ExternalError(AnyError::new(
                 ExternalError::StorageError(e),
             )));
         }
@@ -230,46 +230,44 @@ pub(crate) fn action_function_call(
         }
         None => true,
     };
-    if let Some(outcome) = outcome {
-        result.gas_burnt = safe_add_gas(result.gas_burnt, outcome.burnt_gas)?;
-        result.gas_burnt_for_function_call =
-            safe_add_gas(result.gas_burnt_for_function_call, outcome.burnt_gas)?;
-        // Runtime in `generate_refund_receipts` takes care of using proper value for refunds.
-        // It uses `gas_used` for success and `gas_burnt` for failures. So it's not an issue to
-        // return a real `gas_used` instead of the `gas_burnt` into `ActionResult` even for
-        // `FunctionCall`s error.
-        result.gas_used = safe_add_gas(result.gas_used, outcome.used_gas)?;
-        result.logs.extend(outcome.logs.into_iter());
-        result.profile.merge(&outcome.profile);
-        if execution_succeeded {
-            let new_receipts: Vec<_> = outcome
-                .action_receipts
-                .into_iter()
-                .map(|(receiver_id, receipt)| Receipt {
-                    predecessor_id: account_id.clone(),
-                    receiver_id,
-                    // Actual receipt ID is set in the Runtime.apply_action_receipt(...) in the
-                    // "Generating receipt IDs" section
-                    receipt_id: CryptoHash::default(),
-                    receipt: ReceiptEnum::Action(ActionReceipt {
-                        signer_id: action_receipt.signer_id.clone(),
-                        signer_public_key: action_receipt.signer_public_key.clone(),
-                        gas_price: action_receipt.gas_price,
-                        output_data_receivers: receipt.output_data_receivers,
-                        input_data_ids: receipt.input_data_ids,
-                        actions: receipt.actions,
-                    }),
-                })
-                .collect();
 
-            account.set_amount(outcome.balance);
-            account.set_storage_usage(outcome.storage_usage);
-            result.result = Ok(outcome.return_data);
-            result.new_receipts.extend(new_receipts);
-        }
-    } else {
-        assert!(!execution_succeeded, "Outcome should always be available if execution succeeded")
+    result.gas_burnt = safe_add_gas(result.gas_burnt, outcome.burnt_gas)?;
+    result.gas_burnt_for_function_call =
+        safe_add_gas(result.gas_burnt_for_function_call, outcome.burnt_gas)?;
+    // Runtime in `generate_refund_receipts` takes care of using proper value for refunds.
+    // It uses `gas_used` for success and `gas_burnt` for failures. So it's not an issue to
+    // return a real `gas_used` instead of the `gas_burnt` into `ActionResult` even for
+    // `FunctionCall`s error.
+    result.gas_used = safe_add_gas(result.gas_used, outcome.used_gas)?;
+    result.logs.extend(outcome.logs);
+    result.profile.merge(&outcome.profile);
+    if execution_succeeded {
+        let new_receipts: Vec<_> = outcome
+            .action_receipts
+            .into_iter()
+            .map(|(receiver_id, receipt)| Receipt {
+                predecessor_id: account_id.clone(),
+                receiver_id,
+                // Actual receipt ID is set in the Runtime.apply_action_receipt(...) in the
+                // "Generating receipt IDs" section
+                receipt_id: CryptoHash::default(),
+                receipt: ReceiptEnum::Action(ActionReceipt {
+                    signer_id: action_receipt.signer_id.clone(),
+                    signer_public_key: action_receipt.signer_public_key.clone(),
+                    gas_price: action_receipt.gas_price,
+                    output_data_receivers: receipt.output_data_receivers,
+                    input_data_ids: receipt.input_data_ids,
+                    actions: receipt.actions,
+                }),
+            })
+            .collect();
+
+        account.set_amount(outcome.balance);
+        account.set_storage_usage(outcome.storage_usage);
+        result.result = Ok(outcome.return_data);
+        result.new_receipts.extend(new_receipts);
     }
+
     Ok(())
 }
 

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -245,14 +245,11 @@ impl TrieViewer {
         let time_str = format!("{:.*}ms", 2, time_ms);
 
         if let Some(err) = err {
-            if let Some(outcome) = outcome {
-                logs.extend(outcome.logs);
-            }
+            logs.extend(outcome.logs);
             let message = format!("wasm execution failed with error: {:?}", err);
             debug!(target: "runtime", "(exec time {}) {}", time_str, message);
             Err(errors::CallFunctionError::VMError { error_message: message })
         } else {
-            let outcome = outcome.unwrap();
             debug!(target: "runtime", "(exec time {}) result of execution: {:?}", time_str, outcome);
             logs.extend(outcome.logs);
             let result = match outcome.return_data {


### PR DESCRIPTION
Replace results without outcome with no-op outcome results.

Note that `VMOutcome` itself cannot be no-op, it needs to be considered
in conjunction with the error. Therefore, the constructor is on the
`VMResult` and requires an error.
If we move the error to a field inside `VMOutcome`, this will also
become clearer.