### PR TITLE
feat: introduce StoreUpdate::set_raw escape hatch

### DIFF
--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -138,7 +138,7 @@ impl StoreValidator {
         self.errors.push(ErrorMessage { key: to_string(&key), col: to_string(&col), err })
     }
     fn validate_col(&mut self, col: DBCol) -> Result<(), StoreValidatorError> {
-        for (key, value) in self.store.clone().iter_without_rc_logic(col) {
+        for (key, value) in self.store.clone().iter_raw_bytes(col) {
             let key_ref = key.as_ref();
             let value_ref = value.as_ref();
             match col {

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -386,7 +386,6 @@ impl Database for RocksDB {
                     batch.put_cf(&*self.cfs[col as usize], key, value);
                 },
                 DBOp::UpdateRefcount { col, key, value } => unsafe {
-                    assert!(col.is_rc());
                     batch.merge_cf(&*self.cfs[col as usize], key, value);
                 },
                 DBOp::Delete { col, key } => unsafe {

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -299,7 +299,7 @@ pub(crate) trait Database: Sync + Send {
     }
     fn get(&self, col: DBCol, key: &[u8]) -> Result<Option<Vec<u8>>, DBError>;
     fn iter<'a>(&'a self, column: DBCol) -> Box<dyn Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a>;
-    fn iter_without_rc_logic<'a>(
+    fn iter_raw_bytes<'a>(
         &'a self,
         column: DBCol,
     ) -> Box<dyn Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a>;
@@ -324,7 +324,7 @@ impl Database for RocksDB {
         Ok(RocksDB::get_with_rc_logic(col, result))
     }
 
-    fn iter_without_rc_logic<'a>(
+    fn iter_raw_bytes<'a>(
         &'a self,
         col: DBCol,
     ) -> Box<dyn Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a> {
@@ -434,11 +434,11 @@ impl Database for TestDB {
     }
 
     fn iter<'a>(&'a self, col: DBCol) -> Box<dyn Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a> {
-        let iterator = self.iter_without_rc_logic(col);
+        let iterator = self.iter_raw_bytes(col);
         RocksDB::iter_with_rc_logic(col, iterator)
     }
 
-    fn iter_without_rc_logic<'a>(
+    fn iter_raw_bytes<'a>(
         &'a self,
         col: DBCol,
     ) -> Box<dyn Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a> {

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -176,12 +176,13 @@ impl StoreUpdate {
     }
 
     pub fn update_refcount(&mut self, column: DBCol, key: &[u8], value: &[u8], rc_delta: i64) {
-        log_assert!(column.is_rc());
+        assert!(column.is_rc());
         let value = encode_value_with_rc(value, rc_delta);
         self.transaction.update_refcount(column, key.to_vec(), value)
     }
 
     pub fn set(&mut self, column: DBCol, key: &[u8], value: &[u8]) {
+        assert!(!column.is_rc());
         self.transaction.insert(column, key.to_vec(), value.to_vec())
     }
 
@@ -191,7 +192,6 @@ impl StoreUpdate {
         key: &[u8],
         value: &T,
     ) -> io::Result<()> {
-        log_assert!(!column.is_rc());
         let data = value.try_to_vec()?;
         self.set(column, key, &data);
         Ok(())

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -454,8 +454,8 @@ pub fn recompress_storage(home_dir: &Path, opts: RecompressOpts) -> anyhow::Resu
         let mut total_written: u64 = 0;
         let mut batch_written: u64 = 0;
         let mut count_keys: u64 = 0;
-        for (key, value) in src_store.iter_without_rc_logic(column) {
-            store_update.set(column, &key, &value);
+        for (key, value) in src_store.iter_raw_bytes(column) {
+            store_update.set_raw_bytes(column, &key, &value);
             total_written += value.len() as u64;
             batch_written += value.len() as u64;
             count_keys += 1;


### PR DESCRIPTION
This method is an deliberate escape hatch, and shouldn't be used outside of auxilary code like migrations which wants to hack on the database directly.

Note: this also tightens some asserts a bit, it *should* be fine but I wouldn't be surprised if some tests fail...