### PR TITLE
client: introduce `near_build_info` metric with node’s release info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Use kebab-case names for neard subcommands to make them consistent with flag names.  snake_case names are still valid for existing subcommands but kebab-case will be used for new commands.
 * Added `near_peer_message_received_by_type_bytes` metric [#6661](https://github.com/near/nearcore/pull/6661)
 * Removed `near_<msg-type>_{total,bytes}` metrics in favour of `near_peer_message_received_by_type_{total,bytes}` metrics [#6661](https://github.com/near/nearcore/pull/6661)
+* Added `near_build_info` metric which exports neard’s build information [#6680](https://github.com/near/nearcore/pull/6680)
 
 ## 1.25.0 [2022-03-16]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2701,6 +2701,7 @@ dependencies = [
  "near-metrics",
  "near-network",
  "near-network-primitives",
+ "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",

--- a/chain/client/Cargo.toml
+++ b/chain/client/Cargo.toml
@@ -40,6 +40,7 @@ near-network = { path = "../network" }
 near-pool = { path = "../pool" }
 near-chunks = { path = "../chunks" }
 near-telemetry = { path = "../telemetry" }
+near-o11y = { path = "../../core/o11y" }
 near-performance-metrics = { path = "../../utils/near-performance-metrics" }
 near-performance-metrics-macros = { path = "../../utils/near-performance-metrics-macros" }
 delay-detector = { path = "../../tools/delay_detector" }

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -12,7 +12,7 @@ use near_primitives::telemetry::{
 use near_primitives::time::{Clock, Instant};
 use near_primitives::types::{AccountId, BlockHeight, EpochHeight, Gas, NumBlocks, ShardId};
 use near_primitives::validator_signer::ValidatorSigner;
-use near_primitives::version::{Version, DB_VERSION, PROTOCOL_VERSION};
+use near_primitives::version::Version;
 use near_primitives::views::{CurrentEpochValidatorInfo, EpochValidatorInfo, ValidatorKickoutView};
 use near_store::db::StoreStatistics;
 use near_telemetry::{telemetry, TelemetryActor};
@@ -60,6 +60,7 @@ impl InfoHelper {
         validator_signer: Option<Arc<dyn ValidatorSigner>>,
     ) -> Self {
         set_open_files_limit(0);
+        metrics::export_version(&client_config.version);
         InfoHelper {
             nearcore_version: client_config.version.clone(),
             sys: System::new(),
@@ -179,8 +180,6 @@ impl InfoHelper {
         (metrics::AVG_TGAS_USAGE.set((avg_gas_used as f64 / TERAGAS).round() as i64));
         (metrics::EPOCH_HEIGHT.set(epoch_height as i64));
         (metrics::PROTOCOL_UPGRADE_BLOCK_HEIGHT.set(protocol_upgrade_block_height as i64));
-        (metrics::NODE_PROTOCOL_VERSION.set(PROTOCOL_VERSION as i64));
-        (metrics::NODE_DB_VERSION.set(DB_VERSION as i64));
 
         // In case we can't get the list of validators for the current and the previous epoch,
         // skip updating the per-validator metrics.

--- a/chain/client/src/metrics.rs
+++ b/chain/client/src/metrics.rs
@@ -194,6 +194,7 @@ static NODE_BUILD_INFO: Lazy<IntCounterVec> = Lazy::new(|| {
 pub fn export_version(neard_version: &near_primitives::version::Version) {
     NODE_PROTOCOL_VERSION.set(near_primitives::version::PROTOCOL_VERSION as i64);
     NODE_DB_VERSION.set(near_primitives::version::DB_VERSION as i64);
+    NODE_BUILD_INFO.reset();
     NODE_BUILD_INFO
         .with_label_values(&[
             &neard_version.version,

--- a/chain/client/src/metrics.rs
+++ b/chain/client/src/metrics.rs
@@ -119,7 +119,6 @@ pub static PROTOCOL_UPGRADE_BLOCK_HEIGHT: Lazy<IntGauge> = Lazy::new(|| {
     )
     .unwrap()
 });
-
 pub static CHUNK_SKIPPED_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
     try_create_int_counter_vec(
         "near_chunk_skipped_total",
@@ -169,6 +168,23 @@ pub static CLIENT_TRIGGER_TIME_BY_TYPE: Lazy<HistogramVec> = Lazy::new(|| {
     .unwrap()
 });
 
+static NODE_PROTOCOL_VERSION: Lazy<IntGauge> = Lazy::new(|| {
+    try_create_int_gauge("near_node_protocol_version", "Max protocol version supported by the node")
+        .unwrap()
+});
+static NODE_DB_VERSION: Lazy<IntGauge> = Lazy::new(|| {
+    try_create_int_gauge("near_node_db_version", "DB version used by the node").unwrap()
+});
+static NODE_BUILD_INFO: Lazy<IntCounterVec> = Lazy::new(|| {
+    try_create_int_counter_vec(
+        "near_build_info",
+        "Metric whose labels indicate node’s version; see \
+             <https://www.robustperception.io/exposing-the-software-version-to-prometheus>.",
+        &["release", "build", "rustc_version"],
+    )
+    .unwrap()
+});
+
 /// Exports neard, protocol and database versions via Prometheus metrics.
 ///
 /// Defines and sets metrics which export node’s max supported protocol version,
@@ -176,36 +192,13 @@ pub static CLIENT_TRIGGER_TIME_BY_TYPE: Lazy<HistogramVec> = Lazy::new(|| {
 /// `neard_version` argument.  This should be called only once at startup.
 /// Subsequent calls don’t change exported values.
 pub fn export_version(neard_version: &near_primitives::version::Version) {
-    fn set<T, F: FnOnce(T)>(name: &str, result: near_metrics::Result<T>, callback: F) {
-        match result {
-            Ok(metric) => callback(metric),
-            Err(err) => near_o11y::log_assert!(false, "Error creating {} metric: {}", name, err),
-        };
-    }
-
-    let result = try_create_int_gauge(
-        "near_node_protocol_version",
-        "Max protocol version supported by the node",
-    );
-    set("near_node_protocol_version", result, |m| {
-        m.set(near_primitives::version::PROTOCOL_VERSION as i64)
-    });
-
-    let result = try_create_int_gauge("near_node_db_version", "Database version used by the node");
-    set("near_node_db_version", result, |m| m.set(near_primitives::version::DB_VERSION as i64));
-
-    let result = try_create_int_counter_vec(
-        "near_build_info",
-        "Metric whose labels indicate node’s version; see \
-         <https://www.robustperception.io/exposing-the-software-version-to-prometheus>.",
-        &["release", "build", "rustc_version"],
-    );
-    set("near_build_info", result, |m| {
-        m.with_label_values(&[
+    NODE_PROTOCOL_VERSION.set(near_primitives::version::PROTOCOL_VERSION as i64);
+    NODE_DB_VERSION.set(near_primitives::version::DB_VERSION as i64);
+    NODE_BUILD_INFO
+        .with_label_values(&[
             &neard_version.version,
             &neard_version.build,
             &neard_version.rustc_version,
         ])
-        .inc()
-    });
+        .inc();
 }


### PR DESCRIPTION
Introduce near_build_info with a constant value 1 which exports
node’s build information as labels.  Specifically, release, build and
rust version are exported.  See [1] for description how this metric
can be used.

[1] https://www.robustperception.io/exposing-the-software-version-to-prometheus

While at it, set near_node_protocol_version and near_node_db_version
only once (since they are always set to the same value) rather than
doing so each time statistics are printed.  Added bonus of this is
that those metrics are now set immediately when node starts rather
than the first time the stats info line is printed in the log.

Issue: https://github.com/near/nearcore/issues/5979