### PR TITLE
fix: 'chunk_id' is not defined in request_chain_info.py

### DIFF
--- a/debug_scripts/request_chain_info.py
+++ b/debug_scripts/request_chain_info.py
@@ -49,7 +49,7 @@ if __name__ == '__main__':
                 'block_id': get_block_id(args.block_id)
             }
         elif args.chunk_id is not None:
-            params = {'chunk_id': chunk_id}
+            params = {'chunk_id': args.chunk_id}
     else:
         assert False
 


### PR DESCRIPTION
small fix: resolve undefined variable `chunk_id` by referencing `args`