### PR TITLE
Fix a flaky test `test_query_rpc_account_view_account_doesnt_exist_must_return_error`

### DIFF
--- a/integration-tests/src/tests/nearcore/rpc_nodes.rs
+++ b/integration-tests/src/tests/nearcore/rpc_nodes.rs
@@ -323,18 +323,28 @@ fn test_query_rpc_account_view_account_doesnt_exist_must_return_error() {
 
     cluster.exec_until_stop(|_, rpc_addrs, _| async move {
         let client = new_client(&format!("http://{}", rpc_addrs[0]));
-        let query_response = client
-            .query(near_jsonrpc_primitives::types::query::RpcQueryRequest {
-                block_reference: near_primitives::types::BlockReference::Finality(Finality::Final),
-                request: near_primitives::views::QueryRequest::ViewAccount {
-                    account_id: "accountdoesntexist.0".parse().unwrap(),
-                },
-            })
-            .await;
+        let error_message = loop {
+            let query_response = client
+                .query(near_jsonrpc_primitives::types::query::RpcQueryRequest {
+                    block_reference: near_primitives::types::BlockReference::Finality(Finality::Final),
+                    request: near_primitives::views::QueryRequest::ViewAccount {
+                        account_id: "accountdoesntexist.0".parse().unwrap(),
+                    },
+                })
+                .await;
 
-        let error_message = match query_response {
-            Ok(result) => panic!("expected error but received Ok: {:?}", result.kind),
-            Err(err) => err.data.unwrap(),
+            break match query_response {
+                Ok(result) => panic!("expected error but received Ok: {:?}", result.kind),
+                Err(err) => {
+                    let value = err.data.unwrap();
+                    if value == serde_json::to_value("Block either has never been observed on the node or has been garbage collected: Finality(Final)").unwrap() {
+                                println!("No blocks are produced yet, retry.");
+                                sleep(std::time::Duration::from_millis(100)).await;
+                                continue;
+                    }
+                    value
+                }
+            };
         };
 
         assert!(


### PR DESCRIPTION
by retrying the request is the finality cannot be resolved to a block due to no blocks being produced.