### PR TITLE
add chunk info debug page

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -2014,21 +2014,16 @@ impl Client {
     }
 
     pub fn detailed_upcoming_blocks_info_as_web(&self) -> ChunkInfoView {
-        let height_status_map = match self.detailed_upcoming_blocks_info() {
-            Ok(m) => m,
-            Err(_) => HashMap::new(),
-        };
-
+        let height_status_map = self.detailed_upcoming_blocks_info().unwrap_or_default();
         let next_blocks_log = height_status_map
             .keys()
             .sorted()
             .map(|height| {
                 let val = height_status_map.get(height).unwrap();
 
-                let block_debug = val
+                let mut block_debug = val
                     .iter()
-                    .map(|entry| {
-                        let block_info = entry.1;
+                    .map(|(block_hash, block_info)| {
                         let chunk_status = block_info
                             .chunk_hashes
                             .iter()
@@ -2056,11 +2051,9 @@ impl Client {
 
                         format!(
                             "{} {} {} Chunks:({}))",
-                            entry.0, in_progress_str, in_orphan_str, chunk_status.join(""),
+                            block_hash, in_progress_str, in_orphan_str, chunk_status.join(""),
                         )
-                    })
-                    .collect::<Vec<String>>();
-
+                    });
                 format!("{} {}", height, block_debug.join("\n"))
             })
             .collect::<Vec<String>>();

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1880,8 +1880,9 @@ impl Client {
     }
 
     // Helper function to prepare the debug info about detailed upcoming blocks.
-    fn detailed_upcoming_blocks_info(&self)
-        -> Result<HashMap<BlockHeight, HashMap<CryptoHash, UpcomingBlockDebugStatus>>, Error> {
+    fn detailed_upcoming_blocks_info(
+        &self,
+    ) -> Result<HashMap<BlockHeight, HashMap<CryptoHash, UpcomingBlockDebugStatus>>, Error> {
         let now = Instant::now();
         let mut height_status_map: HashMap<
             BlockHeight,
@@ -2020,40 +2021,38 @@ impl Client {
             .sorted()
             .map(|height| {
                 let val = height_status_map.get(height).unwrap();
-
-                let mut block_debug = val
-                    .iter()
-                    .map(|(block_hash, block_info)| {
-                        let chunk_status = block_info
-                            .chunk_hashes
-                            .iter()
-                            .map(|it| {
-                                if block_info.chunks_completed.contains(it) {
-                                    "(done)"
-                                } else if block_info.chunks_received.contains(it) {
-                                    "(received)"
-                                } else if block_info.chunks_requested.contains(it) {
-                                    "(requested)"
-                                } else {
-                                    "."
-                                }
-                            })
-                            .collect::<Vec<&str>>();
-
-                        let in_progress_str = match block_info.in_progress_for {
-                            Some(duration) => format!("in progress for: {:?}", duration),
-                            None => "".to_string(),
-                        };
-                        let in_orphan_str = match block_info.in_orphan_for {
-                            Some(duration) => format!("orphan for {:?}", duration),
-                            None => "".to_string(),
-                        };
-
-                        format!(
-                            "{} {} {} Chunks:({}))",
-                            block_hash, in_progress_str, in_orphan_str, chunk_status.join(""),
-                        )
-                    });
+                let mut block_debug = val.iter().map(|(block_hash, block_info)| {
+                    let chunk_status = block_info
+                        .chunk_hashes
+                        .iter()
+                        .map(|it| {
+                            if block_info.chunks_completed.contains(it) {
+                                "(done)"
+                            } else if block_info.chunks_received.contains(it) {
+                                "(received)"
+                            } else if block_info.chunks_requested.contains(it) {
+                                "(requested)"
+                            } else {
+                                "."
+                            }
+                        })
+                        .collect::<Vec<&str>>();
+                    let in_progress_str = match block_info.in_progress_for {
+                        Some(duration) => format!("in progress for: {:?}", duration),
+                        None => "".to_string(),
+                    };
+                    let in_orphan_str = match block_info.in_orphan_for {
+                        Some(duration) => format!("orphan for {:?}", duration),
+                        None => "".to_string(),
+                    };
+                    format!(
+                        "{} {} {} Chunks:({}))",
+                        block_hash,
+                        in_progress_str,
+                        in_orphan_str,
+                        chunk_status.join(""),
+                    )
+                });
                 format!("{} {}", height, block_debug.join("\n"))
             })
             .collect::<Vec<String>>();

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -2039,7 +2039,7 @@ impl Client {
                             })
                             .collect::<Vec<&str>>();
                         let in_progress_str = match block_info.in_progress_for {
-                            Some(duration) => format!("in progress for: {:?}", duration),
+                            Some(duration) => format!("in progress for {:?}", duration),
                             None => "".to_string(),
                         };
                         let in_orphan_str = match block_info.in_orphan_for {

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -38,6 +38,7 @@ use near_primitives::types::{AccountId, ApprovalStake, BlockHeight, EpochId, Num
 use near_primitives::unwrap_or_return;
 use near_primitives::utils::MaybeValidated;
 use near_primitives::validator_signer::ValidatorSigner;
+use near_primitives::views::ChunkInfoView;
 
 use crate::sync::{BlockSync, EpochSync, HeaderSync, StateSync, StateSyncResult};
 use crate::{metrics, SyncStatus};
@@ -1878,8 +1879,9 @@ impl Client {
         Ok(())
     }
 
-    // Returns detailed information about the upcoming blocks.
-    pub fn detailed_upcoming_blocks_info(&self) -> Result<String, Error> {
+    // Helper function to prepare the debug info about detailed upcoming blocks.
+    fn detailed_upcoming_blocks_info(&self)
+        -> Result<HashMap<BlockHeight, HashMap<CryptoHash, UpcomingBlockDebugStatus>>, Error> {
         let now = Instant::now();
         let mut height_status_map: HashMap<
             BlockHeight,
@@ -1933,6 +1935,12 @@ impl Client {
                 }
             }
         }
+        Ok(height_status_map)
+    }
+
+    // Returns detailed information about the upcoming blocks in the form of printables.
+    pub fn detailed_upcoming_blocks_info_as_printable(&self) -> Result<String, Error> {
+        let height_status_map = self.detailed_upcoming_blocks_info()?;
         let use_colour = matches!(self.config.log_summary_style, LogSummaryStyle::Colored);
         let paint = |colour: ansi_term::Colour, text: Option<String>| match text {
             None => ansi_term::Style::default().paint(""),
@@ -2003,5 +2011,64 @@ impl Client {
             if next_blocks_log.len() > 0 { "\n" } else { "" },
             next_blocks_log.join("\n")
         ))
+    }
+
+    pub fn detailed_upcoming_blocks_info_as_web(&self) -> ChunkInfoView {
+        let height_status_map = match self.detailed_upcoming_blocks_info() {
+            Ok(m) => m,
+            Err(_) => HashMap::new(),
+        };
+
+        let next_blocks_log = height_status_map
+            .keys()
+            .sorted()
+            .map(|height| {
+                let val = height_status_map.get(height).unwrap();
+
+                let block_debug = val
+                    .iter()
+                    .map(|entry| {
+                        let block_info = entry.1;
+                        let chunk_status = block_info
+                            .chunk_hashes
+                            .iter()
+                            .map(|it| {
+                                if block_info.chunks_completed.contains(it) {
+                                    "(done)"
+                                } else if block_info.chunks_received.contains(it) {
+                                    "(received)"
+                                } else if block_info.chunks_requested.contains(it) {
+                                    "(requested)"
+                                } else {
+                                    "."
+                                }
+                            })
+                            .collect::<Vec<&str>>();
+
+                        let in_progress_str = match block_info.in_progress_for {
+                            Some(duration) => format!("in progress for: {:?}", duration),
+                            None => "".to_string(),
+                        };
+                        let in_orphan_str = match block_info.in_orphan_for {
+                            Some(duration) => format!("orphan for {:?}", duration),
+                            None => "".to_string(),
+                        };
+
+                        format!(
+                            "{} {} {} Chunks:({}))",
+                            entry.0, in_progress_str, in_orphan_str, chunk_status.join(""),
+                        )
+                    })
+                    .collect::<Vec<String>>();
+
+                format!("{} {}", height, block_debug.join("\n"))
+            })
+            .collect::<Vec<String>>();
+        ChunkInfoView {
+            num_of_blocks_in_progress: self.chain.blocks_delay_tracker.blocks_in_progress.len(),
+            num_of_chunks_in_progress: self.chain.blocks_delay_tracker.chunks_in_progress.len(),
+            num_of_orphans: self.chain.orphans().len(),
+            next_blocks_log,
+        }
     }
 }

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -38,9 +38,7 @@ use near_primitives::types::{AccountId, ApprovalStake, BlockHeight, EpochId, Num
 use near_primitives::unwrap_or_return;
 use near_primitives::utils::MaybeValidated;
 use near_primitives::validator_signer::ValidatorSigner;
-use near_primitives::views::{
-    BlockByChunksView, ChunkInfoView,
-};
+use near_primitives::views::{BlockByChunksView, ChunkInfoView};
 
 use crate::sync::{BlockSync, EpochSync, HeaderSync, StateSync, StateSyncResult};
 use crate::{metrics, SyncStatus};
@@ -2023,37 +2021,39 @@ impl Client {
             .sorted()
             .map(|height| {
                 let val = height_status_map.get(height).unwrap();
-                val.iter().map(|(block_hash, block_info)| {
-                    let chunk_status = block_info
-                        .chunk_hashes
-                        .iter()
-                        .map(|it| {
-                            if block_info.chunks_completed.contains(it) {
-                                "(OK)"
-                            } else if block_info.chunks_received.contains(it) {
-                                "(\\/)"
-                            } else if block_info.chunks_requested.contains(it) {
-                                "(/\\)"
-                            } else {
-                                "(..)"
-                            }
-                        })
-                        .collect::<Vec<&str>>();
-                    let in_progress_str = match block_info.in_progress_for {
-                        Some(duration) => format!("in progress for: {:?}", duration),
-                        None => "".to_string(),
-                    };
-                    let in_orphan_str = match block_info.in_orphan_for {
-                        Some(duration) => format!("orphan for {:?}", duration),
-                        None => "".to_string(),
-                    };
-                    BlockByChunksView {
-                        height: height.clone(),
-                        hash: block_hash.clone(),
-                        block_status: format!("{} {}", in_progress_str, in_orphan_str),
-                        chunk_status: chunk_status.join(""),
-                    }
-                }).collect::<Vec<BlockByChunksView>>()
+                val.iter()
+                    .map(|(block_hash, block_info)| {
+                        let chunk_status = block_info
+                            .chunk_hashes
+                            .iter()
+                            .map(|it| {
+                                if block_info.chunks_completed.contains(it) {
+                                    "(OK)"
+                                } else if block_info.chunks_received.contains(it) {
+                                    "(\\/)"
+                                } else if block_info.chunks_requested.contains(it) {
+                                    "(/\\)"
+                                } else {
+                                    "(..)"
+                                }
+                            })
+                            .collect::<Vec<&str>>();
+                        let in_progress_str = match block_info.in_progress_for {
+                            Some(duration) => format!("in progress for: {:?}", duration),
+                            None => "".to_string(),
+                        };
+                        let in_orphan_str = match block_info.in_orphan_for {
+                            Some(duration) => format!("orphan for {:?}", duration),
+                            None => "".to_string(),
+                        };
+                        BlockByChunksView {
+                            height: height.clone(),
+                            hash: block_hash.clone(),
+                            block_status: format!("{} {}", in_progress_str, in_orphan_str),
+                            chunk_status: chunk_status.join(""),
+                        }
+                    })
+                    .collect::<Vec<BlockByChunksView>>()
             })
             .flatten()
             .collect::<Vec<BlockByChunksView>>();

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -904,7 +904,6 @@ impl Handler<Status> for ClientActor {
                     .config
                     .min_block_production_delay
                     .as_millis() as u64,
-                },
                 chunk_info: self.client.detailed_upcoming_blocks_info_as_web(),
             })
         } else {

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -904,6 +904,8 @@ impl Handler<Status> for ClientActor {
                     .config
                     .min_block_production_delay
                     .as_millis() as u64,
+                },
+                chunk_info: self.client.detailed_upcoming_blocks_info_as_web(),
             })
         } else {
             None
@@ -1881,7 +1883,7 @@ impl ClientActor {
                 .unwrap_or(0),
             statistics,
         );
-        debug!(target: "stats", "{}", self.client.detailed_upcoming_blocks_info().unwrap_or(String::from("Upcoming block info failed.")));
+        debug!(target: "stats", "{}", self.client.detailed_upcoming_blocks_info_as_printable().unwrap_or(String::from("Upcoming block info failed.")));
     }
 }
 

--- a/chain/jsonrpc/res/chunk_info.html
+++ b/chain/jsonrpc/res/chunk_info.html
@@ -41,9 +41,12 @@
                     $('.js-block-count').text(chunk_info.num_of_blocks_in_progress);
                     $('.js-chunk-count').text(chunk_info.num_of_chunks_in_progress);
                     $('.js-orphan-count').text(chunk_info.num_of_orphans);
-                    chunk_info.next_blocks_log.forEach((log, index) =>
+                    chunk_info.next_blocks_by_chunks.forEach((line, index) =>
                         $('.js-tbody-log').append($('<tr>')
-                            .append($('<td>').append(log))
+                            .append($('<td>').append(line.height))
+                            .append($('<td>').append(line.hash))
+                            .append($('<td>').append(line.block_status))
+                            .append($('<td>').append($('<pre>').append(line.chunk_status)))
                         )
                     );
                 },
@@ -75,13 +78,16 @@
             <span class="js-orphan-count"></span>
         </p>
         <p>
-            Blocks log:
+            Upcoming Blocks
         </p>
     </h2>
 
     <table>
         <thead><tr>
-            <th>Blocks</th>
+            <th>Height</th>
+            <th>Hash</th>
+            <th>Block Status</th>
+            <th>Chunk Status</th>
         </tr></thead>
         <tbody class="js-tbody-log">
         </tbody>

--- a/chain/jsonrpc/res/chunk_info.html
+++ b/chain/jsonrpc/res/chunk_info.html
@@ -42,7 +42,7 @@
                     $('.js-chunk-count').text(chunk_info.num_of_chunks_in_progress);
                     $('.js-orphan-count').text(chunk_info.num_of_orphans);
                     chunk_info.next_blocks_log.forEach((log, index) =>
-                        $('.js-tbody-validators').append($('<tr>')
+                        $('.js-tbody-log').append($('<tr>')
                             .append($('<td>').append(log))
                         )
                     );

--- a/chain/jsonrpc/res/chunk_info.html
+++ b/chain/jsonrpc/res/chunk_info.html
@@ -1,0 +1,91 @@
+<html>
+<head>
+    <style>
+        table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+
+        table,
+        th,
+        td {
+            border: 1px solid black;
+        }
+
+        td {
+            text-align: left;
+            vertical-align: top;
+            padding: 8px;
+        }
+
+        th {
+            text-align: center;
+            vertical-align: center;
+            padding: 8px;
+            background-color: lightgrey;
+        }
+
+        tr.active {
+            background-color: #eff8bf;
+        }
+    </style>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+    <script>
+        $(document).ready(() => {
+            $('span').text("Loading...");
+            $.ajax({
+                type: "GET",
+                url: "/debug/api/status",
+                success: data => {
+                    let chunk_info = data.detailed_debug_status.chunk_info;
+                    $('.js-block-count').text(chunk_info.num_of_blocks_in_progress);
+                    $('.js-chunk-count').text(chunk_info.num_of_chunks_in_progress);
+                    $('.js-orphan-count').text(chunk_info.num_of_orphans);
+                    chunk_info.next_blocks_log.forEach((log, index) =>
+                        $('.js-tbody-validators').append($('<tr>')
+                            .append($('<td>').append(log))
+                        )
+                    );
+                },
+                dataType: "json",
+                error: function (errMsg, textStatus, errorThrown) {
+                    alert("Failed: " + textStatus + " :" + errorThrown);
+                },
+                contentType: "application/json; charset=utf-8",
+            })
+
+        });
+    </script>
+</head>
+<body>
+    <h1>
+        Welcome to the Chunk Status page!
+    </h1>
+    <h2>
+        <p>
+            Number of blocks in progress:
+            <span class="js-block-count"></span>
+        </p>
+        <p>
+            Number of chunks in progress:
+            <span class="js-chunk-count"></span>
+        </p>
+        <p>
+            Number of orphans:
+            <span class="js-orphan-count"></span>
+        </p>
+        <p>
+            Blocks log:
+        </p>
+    </h2>
+
+    <table>
+        <thead><tr>
+            <th>Blocks</th>
+        </tr></thead>
+        <tbody class="js-tbody-log">
+        </tbody>
+    </table>
+</body>
+
+</html>

--- a/chain/jsonrpc/res/debug.html
+++ b/chain/jsonrpc/res/debug.html
@@ -5,6 +5,7 @@
     <h1><a href="/debug/sync_info">Sync info</a></h1>
     <h1><a href="/debug/chain_info">Chain info</a></h1>
     <h1><a href="/debug/epoch_info">Epoch info</a></h1>
+    <h1><a href="/debug/chunk_info">Chunk info</a></h1>
 </body>
 
 </html>

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -1434,6 +1434,7 @@ lazy_static_include::lazy_static_include_str! {
     SYNC_INFO_HTML => "res/sync_info.html",
     CHAIN_INFO_HTML => "res/chain_info.html",
     EPOCH_INFO_HTML => "res/epoch_info.html",
+    CHUNK_INFO_HTML => "res/chunk_info.html",
 }
 
 #[get("/debug")]
@@ -1459,6 +1460,11 @@ async fn chain_info_html() -> actix_web::Result<impl actix_web::Responder> {
 #[get("/debug/epoch_info")]
 async fn epoch_info_html() -> actix_web::Result<impl actix_web::Responder> {
     Ok(HttpResponse::Ok().body(*EPOCH_INFO_HTML))
+}
+
+#[get("/debug/chunk_info")]
+async fn chunk_info_html() -> actix_web::Result<impl actix_web::Responder> {
+    Ok(HttpResponse::Ok().body(*CHUNK_INFO_HTML))
 }
 
 /// Starts HTTP server(s) listening for RPC requests.
@@ -1527,6 +1533,7 @@ pub fn start_http(
             .service(sync_info_html)
             .service(chain_info_html)
             .service(epoch_info_html)
+            .service(chunk_info_html)
     })
     .bind(addr)
     .unwrap()

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -409,11 +409,20 @@ pub struct EpochInfoView {
 
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
 #[derive(Serialize, Deserialize, Debug)]
+pub struct BlockByChunksView {
+    pub height: BlockHeight,
+    pub hash: CryptoHash,
+    pub block_status: String,
+    pub chunk_status: String,
+}
+
+#[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct ChunkInfoView {
     pub num_of_blocks_in_progress: usize,
     pub num_of_chunks_in_progress: usize,
     pub num_of_orphans: usize,
-    pub next_blocks_log: Vec<String>,
+    pub next_blocks_by_chunks: Vec<BlockByChunksView>,
 }
 
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -409,6 +409,15 @@ pub struct EpochInfoView {
 
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
 #[derive(Serialize, Deserialize, Debug)]
+pub struct ChunkInfoView {
+    pub num_of_blocks_in_progress: usize,
+    pub num_of_chunks_in_progress: usize,
+    pub num_of_orphans: usize,
+    pub next_blocks_log: Vec<String>,
+}
+
+#[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct DetailedDebugStatus {
     pub last_blocks: Vec<DebugBlockStatus>,
     pub network_info: NetworkInfoView,
@@ -420,6 +429,7 @@ pub struct DetailedDebugStatus {
     // List of epochs - in descending order (next epoch is first).
     pub epochs_info: Vec<EpochInfoView>,
     pub block_production_delay_millis: u64,
+    pub chunk_info: ChunkInfoView,
 }
 
 // TODO: add more information to status.
@@ -443,7 +453,7 @@ pub struct StatusResponse {
     pub sync_info: StatusSyncInfo,
     /// Validator id of the node
     pub validator_account_id: Option<AccountId>,
-    /// Information about last blocks, sync, epoch and chain info.
+    /// Information about last blocks, sync, epoch, chunk and chain info.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub detailed_debug_status: Option<DetailedDebugStatus>,
 }


### PR DESCRIPTION
### Description
This PR adds the skeleton of the chunk info debug page.

### JIRA Issue
[CP-83](https://nearinc.atlassian.net/browse/CP-83)

### Test plan

 - Build with make neard
 - Under `nearcore` directory, launch localnet using command `nearup stop && nearup run localnet --binary-path ./target/release`
 - Open your browser and go to http://[host_address]:3030/debug/
 - Expect to see the link "Chunk Info"
 - Click the link "Chunk Info"
 - Expect to see a webpage that looks similar to the one below

### Screenshot on testnet
<img width="958" alt="Screen Shot 2022-05-09 at 4 16 50 PM" src="https://user-images.githubusercontent.com/98097537/167513851-8cc7ee97-cab0-49d7-81f8-3f9334bec2cf.png">



### First round reviewer
 - @mzhangmzz 
 - @mm-near 