### PR TITLE
1.26.0: Count function imports towards the function limit

### DIFF
--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -3363,7 +3363,12 @@ fn verify_contract_limits_upgrade(
         deploy_test_contract(
             &mut env,
             "test0".parse().unwrap(),
-            &near_test_contracts::large_contract(function_limit + 1, local_limit + 1),
+            &near_test_contracts::LargeContract {
+                functions: function_limit + 1,
+                locals_per_function: local_limit + 1,
+                ..Default::default()
+            }
+            .make(),
             epoch_length,
             1,
         );

--- a/runtime/near-vm-runner/src/tests/compile_errors.rs
+++ b/runtime/near-vm-runner/src/tests/compile_errors.rs
@@ -159,7 +159,11 @@ fn test_limit_contract_functions_number() {
         let functions_number_limit: u32 = 10_000;
         let method_name = "main";
 
-        let code = near_test_contracts::large_contract(functions_number_limit + 1, 0);
+        let code = near_test_contracts::LargeContract {
+            functions: functions_number_limit + 1,
+            ..Default::default()
+        }
+        .make();
         let (_, err) = make_simple_contract_call_with_protocol_version_vm(
             &code,
             method_name,
@@ -168,7 +172,11 @@ fn test_limit_contract_functions_number() {
         );
         assert_eq!(err, None);
 
-        let code = near_test_contracts::large_contract(functions_number_limit, 0);
+        let code = near_test_contracts::LargeContract {
+            functions: functions_number_limit,
+            ..Default::default()
+        }
+        .make();
         let (_, err) = make_simple_contract_call_with_protocol_version_vm(
             &code,
             method_name,
@@ -177,7 +185,49 @@ fn test_limit_contract_functions_number() {
         );
         assert_eq!(err, None);
 
-        let code = near_test_contracts::large_contract(functions_number_limit + 1, 0);
+        let code = near_test_contracts::LargeContract {
+            functions: functions_number_limit + 1,
+            ..Default::default()
+        }
+        .make();
+        let (_, err) = make_simple_contract_call_with_protocol_version_vm(
+            &code,
+            method_name,
+            new_protocol_version,
+            vm_kind,
+        );
+        assert_matches!(
+            err,
+            Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
+                CompilationError::PrepareError(PrepareError::TooManyFunctions)
+            )))
+        );
+
+        let code = near_test_contracts::LargeContract {
+            functions: functions_number_limit / 2,
+            panic_imports: functions_number_limit / 2 + 1,
+            ..Default::default()
+        }
+        .make();
+        let (_, err) = make_simple_contract_call_with_protocol_version_vm(
+            &code,
+            method_name,
+            new_protocol_version,
+            vm_kind,
+        );
+        assert_matches!(
+            err,
+            Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
+                CompilationError::PrepareError(PrepareError::TooManyFunctions)
+            )))
+        );
+
+        let code = near_test_contracts::LargeContract {
+            functions: functions_number_limit,
+            panic_imports: 1,
+            ..Default::default()
+        }
+        .make();
         let (_, err) = make_simple_contract_call_with_protocol_version_vm(
             &code,
             method_name,
@@ -203,7 +253,12 @@ fn test_limit_locals() {
             VMKind::Wasmtime => return,
         }
 
-        let wasm_err = near_test_contracts::large_contract(1, 50_001);
+        let wasm_err = near_test_contracts::LargeContract {
+            functions: 1,
+            locals_per_function: 50_001,
+            ..Default::default()
+        }
+        .make();
         let res = make_simple_contract_call_vm(&wasm_err, "main", vm_kind);
         gas_and_error_match(
             res,
@@ -213,7 +268,12 @@ fn test_limit_locals() {
             ))),
         );
 
-        let wasm_ok = near_test_contracts::large_contract(1, 50_000);
+        let wasm_ok = near_test_contracts::LargeContract {
+            functions: 1,
+            locals_per_function: 50_000,
+            ..Default::default()
+        }
+        .make();
         let res = make_simple_contract_call_vm(&wasm_ok, "main", vm_kind);
         gas_and_error_match(
             res,
@@ -228,7 +288,12 @@ fn test_limit_locals_global() {
     with_vm_variants(|vm_kind| {
         let new_protocol_version = ProtocolFeature::LimitContractLocals.protocol_version();
         let old_protocol_version = new_protocol_version - 1;
-        let code_1000001_locals = near_test_contracts::large_contract(101, 9901);
+        let code_1000001_locals = near_test_contracts::LargeContract {
+            functions: 101,
+            locals_per_function: 9901,
+            ..Default::default()
+        }
+        .make();
         match vm_kind {
             VMKind::Wasmer0 | VMKind::Wasmer2 => {}
             // All contracts leading to hardware traps can not run concurrently on Wasmtime and Wasmer,
@@ -258,7 +323,12 @@ fn test_limit_locals_global() {
         assert_eq!(err, None);
 
         let (_, err) = make_simple_contract_call_with_protocol_version_vm(
-            &near_test_contracts::large_contract(64, 15625),
+            &near_test_contracts::LargeContract {
+                functions: 64,
+                locals_per_function: 15625,
+                ..Default::default()
+            }
+            .make(),
             "main",
             new_protocol_version,
             vm_kind,


### PR DESCRIPTION
Fixes a regression introduced in
7f1672f89f1700eb3601f742759ac2742f7007aa

This is a backport of #6698 to the 1.26.0 release.