### PR TITLE
fix(chain): revert the gc_blocks_limit default to 2

### DIFF
--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -45,7 +45,7 @@ pub struct GCConfig {
 impl Default for GCConfig {
     fn default() -> Self {
         Self {
-            gc_blocks_limit: 5,
+            gc_blocks_limit: 2,
             gc_fork_clean_step: 100,
             gc_num_epochs_to_keep: DEFAULT_GC_NUM_EPOCHS_TO_KEEP,
         }

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -1510,7 +1510,7 @@ fn test_config_from_file() {
         let want_gc = if has_gc {
             GCConfig { gc_blocks_limit: 42, gc_fork_clean_step: 420, gc_num_epochs_to_keep: 24 }
         } else {
-            GCConfig { gc_blocks_limit: 5, gc_fork_clean_step: 100, gc_num_epochs_to_keep: 5 }
+            GCConfig { gc_blocks_limit: 2, gc_fork_clean_step: 100, gc_num_epochs_to_keep: 5 }
         };
         assert_eq!(want_gc, config.gc);
 


### PR DESCRIPTION
this was inadvertently changed to 5 in https://github.com/near/nearcore/pull/6604