### PR TITLE
store: get rid of RocksDBOptions

### DIFF
--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -105,42 +105,6 @@ pub struct RocksDB {
 unsafe impl Send for RocksDB {}
 unsafe impl Sync for RocksDB {}
 
-/// Options for configuring [`RocksDB`](RocksDB).
-///
-/// ```rust
-/// use near_store::{db::RocksDBOptions, StoreConfig};
-///
-/// let rocksdb = RocksDBOptions::default()
-///     .check_free_space_interval(256)
-///     .free_disk_space_threshold(bytesize::ByteSize::mb(10))
-///     .open("/db/path", &StoreConfig::read_only());
-/// ```
-pub struct RocksDBOptions {
-    cf_names: Option<Vec<String>>,
-    cf_descriptors: Option<Vec<ColumnFamilyDescriptor>>,
-
-    rocksdb_options: Option<Options>,
-    check_free_space_interval: u16,
-    free_space_threshold: bytesize::ByteSize,
-    warn_treshold: bytesize::ByteSize,
-}
-
-/// Sets [`RocksDBOptions::check_free_space_interval`] to 256,
-/// [`RocksDBOptions::free_disk_space_threshold`] to 16 MB and
-/// [`RocksDBOptions::free_disk_space_warn_threshold`] to 256 MB.
-impl Default for RocksDBOptions {
-    fn default() -> Self {
-        RocksDBOptions {
-            cf_names: None,
-            cf_descriptors: None,
-            rocksdb_options: None,
-            check_free_space_interval: 256,
-            free_space_threshold: bytesize::ByteSize::mb(16),
-            warn_treshold: bytesize::ByteSize::mb(256),
-        }
-    }
-}
-
 fn col_name(col: DBCol) -> String {
     format!("col{}", col as usize)
 }
@@ -179,96 +143,59 @@ fn ensure_max_open_files_limit(max_open_files: u32) -> Result<(), DBError> {
     }
 }
 
-impl RocksDBOptions {
-    /// Once the disk space is below the `free_disk_space_warn_threshold`, RocksDB will emit an warning message every [`interval`](RocksDBOptions::check_free_space_interval) write.
-    pub fn free_disk_space_warn_threshold(mut self, warn_treshold: bytesize::ByteSize) -> Self {
-        self.warn_treshold = warn_treshold;
-        self
-    }
-
-    pub fn cf_names(mut self, cf_names: Vec<String>) -> Self {
-        self.cf_names = Some(cf_names);
-        self
-    }
-    pub fn cf_descriptors(mut self, cf_descriptors: Vec<ColumnFamilyDescriptor>) -> Self {
-        self.cf_descriptors = Some(cf_descriptors);
-        self
-    }
-
-    pub fn rocksdb_options(mut self, rocksdb_options: Options) -> Self {
-        self.rocksdb_options = Some(rocksdb_options);
-        self
-    }
-
-    /// After n writes, the free memory in the database's data directory is checked.
-    pub fn check_free_space_interval(mut self, interval: u16) -> Self {
-        self.check_free_space_interval = interval;
-        self
-    }
-
-    /// Free space threshold. If the directory has fewer available bytes left, writing will not be
-    /// allowed to ensure recoverability.
-    pub fn free_disk_space_threshold(mut self, threshold: bytesize::ByteSize) -> Self {
-        self.free_space_threshold = threshold;
-        self
-    }
-
-    /// Opens the database either in read only or in read/write mode depending on the read_only
-    /// parameter specified in the store_config.
-    pub fn open(
-        self,
-        path: impl AsRef<Path>,
-        store_config: &StoreConfig,
-    ) -> Result<RocksDB, DBError> {
-        ensure_max_open_files_limit(store_config.max_open_files)?;
-        if store_config.read_only {
-            self.read_only(path.as_ref(), store_config)
-        } else {
-            self.read_write(path.as_ref(), store_config)
-        }
-    }
-
-    /// Opens a read only database.
-    fn read_only(self, path: &Path, store_config: &StoreConfig) -> Result<RocksDB, DBError> {
+impl RocksDB {
+    /// Opens the database either in read only or in read/write mode depending
+    /// on the read_only parameter specified in the store_config.
+    pub fn open(path: impl AsRef<Path>, store_config: &StoreConfig) -> Result<RocksDB, DBError> {
         use strum::IntoEnumIterator;
-        let options = self.rocksdb_options.unwrap_or_else(|| rocksdb_options(store_config));
-        let cf_with_opts =
-            DBCol::iter().map(|col| (col_name(col), rocksdb_column_options(col, store_config)));
-        let db = DB::open_cf_with_opts_for_read_only(&options, path, cf_with_opts, false)?;
+
+        ensure_max_open_files_limit(store_config.max_open_files)?;
+
+        let (db, db_opt) = if store_config.read_only {
+            Self::open_read_only(path.as_ref(), store_config)
+        } else {
+            Self::open_read_write(path.as_ref(), store_config)
+        }?;
+
         let cfs = DBCol::iter()
             .map(|col| db.cf_handle(&col_name(col)).unwrap() as *const ColumnFamily)
             .collect();
-
-        Ok(RocksDB {
+        Ok(Self {
             db,
-            db_opt: options,
+            db_opt,
             cfs,
-            check_free_space_interval: self.check_free_space_interval,
+            check_free_space_interval: 256,
             check_free_space_counter: std::sync::atomic::AtomicU16::new(0),
-            free_space_threshold: self.free_space_threshold,
+            free_space_threshold: bytesize::ByteSize::mb(16),
             _instance_counter: InstanceCounter::new(),
         })
     }
 
-    /// Opens the database in read/write mode.
-    fn read_write(self, path: &Path, store_config: &StoreConfig) -> Result<RocksDB, DBError> {
+    /// Opens a read only database.
+    fn open_read_only(path: &Path, store_config: &StoreConfig) -> Result<(DB, Options), DBError> {
         use strum::IntoEnumIterator;
-        let mut options = self.rocksdb_options.unwrap_or_else(|| rocksdb_options(store_config));
+        let options = rocksdb_options(store_config);
+        let cf_with_opts =
+            DBCol::iter().map(|col| (col_name(col), rocksdb_column_options(col, store_config)));
+        let db = DB::open_cf_with_opts_for_read_only(&options, path, cf_with_opts, false)?;
+        Ok((db, options))
+    }
+
+    /// Opens the database in read/write mode.
+    fn open_read_write(path: &Path, store_config: &StoreConfig) -> Result<(DB, Options), DBError> {
+        use strum::IntoEnumIterator;
+        let mut options = rocksdb_options(store_config);
         if store_config.enable_statistics {
             options = enable_statistics(options);
         }
-        let cf_names =
-            self.cf_names.unwrap_or_else(|| DBCol::iter().map(|col| col_name(col)).collect());
-        let cf_descriptors = self.cf_descriptors.unwrap_or_else(|| {
-            DBCol::iter()
-                .map(|col| {
-                    ColumnFamilyDescriptor::new(
-                        col_name(col),
-                        rocksdb_column_options(col, store_config),
-                    )
-                })
-                .collect()
-        });
+        let cf_descriptors = DBCol::iter()
+            .map(|col| {
+                ColumnFamilyDescriptor::new(
+                    col_name(col),
+                    rocksdb_column_options(col, store_config),
+                )
+            })
+            .collect::<Vec<_>>();
         let db = DB::open_cf_descriptors(&options, path, cf_descriptors)?;
         if cfg!(feature = "single_thread_rocksdb") {
             // These have to be set after open db
@@ -279,17 +206,7 @@ impl RocksDBOptions {
             env.set_background_threads(0);
             println!("Disabled all background threads in rocksdb");
         }
-        let cfs =
-            cf_names.iter().map(|n| db.cf_handle(n).unwrap() as *const ColumnFamily).collect();
-        Ok(RocksDB {
-            db,
-            db_opt: options,
-            cfs,
-            check_free_space_interval: self.check_free_space_interval,
-            check_free_space_counter: std::sync::atomic::AtomicU16::new(0),
-            free_space_threshold: self.free_space_threshold,
-            _instance_counter: InstanceCounter::new(),
-        })
+        Ok((db, options))
     }
 }
 
@@ -626,7 +543,7 @@ impl RocksDB {
 
     /// Returns version of the database state on disk.
     pub fn get_version(path: &Path) -> Result<DbVersion, DBError> {
-        let value = RocksDB::new(path, &StoreConfig::read_only())?
+        let value = RocksDB::open(path, &StoreConfig::read_only())?
             .get(DBCol::DbVersion, VERSION_KEY)?
             .ok_or_else(|| {
                 DBError(
@@ -641,10 +558,6 @@ impl RocksDB {
                  it’s not a neard database or database is corrupted."
             ))
         })
-    }
-
-    pub fn new(path: &Path, store_config: &StoreConfig) -> Result<Self, DBError> {
-        RocksDBOptions::default().open(path, &store_config)
     }
 
     /// Checks if there is enough memory left to perform a write. Not having enough memory left can
@@ -822,7 +735,7 @@ mod tests {
     #[test]
     fn test_prewrite_check() {
         let tmp_dir = tempfile::Builder::new().prefix("_test_prewrite_check").tempdir().unwrap();
-        let store = RocksDB::new(tmp_dir.path(), &StoreConfig::read_write()).unwrap();
+        let store = RocksDB::open(tmp_dir.path(), &StoreConfig::read_write()).unwrap();
         store.pre_write_check().unwrap()
     }
 

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -29,7 +29,7 @@ use near_primitives::types::{AccountId, CompiledContractCache, StateRoot};
 pub use crate::db::refcount::decode_value_with_rc;
 use crate::db::refcount::encode_value_with_rc;
 use crate::db::{
-    DBOp, DBTransaction, Database, RocksDB, RocksDBOptions, StoreStatistics, GENESIS_JSON_HASH_KEY,
+    DBOp, DBTransaction, Database, RocksDB, StoreStatistics, GENESIS_JSON_HASH_KEY,
     GENESIS_STATE_ROOTS_KEY,
 };
 pub use crate::trie::iterator::TrieIterator;
@@ -386,8 +386,7 @@ pub fn create_store(path: &Path) -> Store {
 }
 
 pub fn create_store_with_config(path: &Path, store_config: &StoreConfig) -> Store {
-    let db =
-        RocksDBOptions::default().open(path, &store_config).expect("Failed to open the database");
+    let db = RocksDB::open(path, &store_config).expect("Failed to open the database");
     Store::new(Arc::new(db))
 }
 

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -98,7 +98,7 @@ fn create_db_checkpoint(path: &Path, near_config: &NearConfig) -> anyhow::Result
                     checkpoint_path.display(),
                     path.display());
 
-    let db = RocksDB::new(&path, &near_config.config.store)?;
+    let db = RocksDB::open(path, &near_config.config.store)?;
     let checkpoint = db.checkpoint()?;
     info!(target: "near", "Creating a database migration snapshot in '{}'", checkpoint_path.display());
     checkpoint.create_checkpoint(&checkpoint_path)?;


### PR DESCRIPTION
The setters in RocksDBOptions are never used and the object is only
ever created with it’s default values.  As such, the structure
provides no value.  Get rid of it.