### PR TITLE
strum: reduce usage of deprecated strum::AsStaticStr

### DIFF
--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -120,7 +120,7 @@ pub struct ShardSyncDownload {
 }
 
 /// Various status sync can be in, whether it's fast sync or archival.
-#[derive(Clone, Debug, strum::AsStaticStr)]
+#[derive(Clone, Debug, strum::AsRefStr)]
 pub enum SyncStatus {
     /// Initial state. Not enough peers to do anything yet.
     AwaitingPeers,
@@ -142,8 +142,8 @@ pub enum SyncStatus {
 
 impl SyncStatus {
     /// Get a string representation of the status variant
-    pub fn as_variant_name(&self) -> &'static str {
-        strum::AsStaticRef::as_static(self)
+    pub fn as_variant_name(&self) -> &str {
+        self.as_ref()
     }
 
     /// True if currently engaged in syncing the chain.

--- a/chain/network-primitives/src/network_protocol/mod.rs
+++ b/chain/network-primitives/src/network_protocol/mod.rs
@@ -165,9 +165,7 @@ pub struct Pong {
 
 // TODO(#1313): Use Box
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
-#[derive(
-    BorshSerialize, BorshDeserialize, PartialEq, Eq, Clone, strum::AsRefStr, strum::AsStaticStr,
-)]
+#[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Clone, strum::AsRefStr)]
 #[allow(clippy::large_enum_variant)]
 pub enum RoutedMessageBody {
     BlockApproval(Approval),

--- a/chain/network-primitives/src/types.rs
+++ b/chain/network-primitives/src/types.rs
@@ -25,7 +25,6 @@ use std::fmt::Debug;
 use std::hash::Hash;
 use std::net::SocketAddr;
 use std::time::Duration;
-use strum::AsStaticStr;
 use tokio::net::TcpStream;
 
 /// Exported types, which are part of network protocol.
@@ -289,7 +288,7 @@ pub enum SandboxResponse {
     SandboxFastForwardFailed(String),
 }
 
-#[derive(actix::Message, AsStaticStr)]
+#[derive(actix::Message, strum::AsStaticStr)]
 #[rtype(result = "NetworkViewClientResponses")]
 pub enum NetworkViewClientMessages {
     #[cfg(feature = "test_features")]

--- a/chain/network/src/network_protocol.rs
+++ b/chain/network/src/network_protocol.rs
@@ -170,7 +170,7 @@ impl std::error::Error for HandshakeFailureReason {}
 /// DO NOT MOVE, REORDER, DELETE items from the list. Only add new items to the end.
 /// If need to remove old items - replace with `None`.
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
-#[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Clone, Debug, strum::AsStaticStr)]
+#[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Clone, Debug, strum::AsRefStr)]
 // TODO(#1313): Use Box
 #[allow(clippy::large_enum_variant)]
 pub enum PeerMessage {
@@ -256,11 +256,10 @@ impl fmt::Display for PeerMessage {
 
 impl PeerMessage {
     pub(crate) fn msg_variant(&self) -> &str {
-        match self {
-            PeerMessage::Routed(routed_message) => {
-                strum::AsStaticRef::as_static(&routed_message.body)
-            }
-            _ => strum::AsStaticRef::as_static(self),
+        if let PeerMessage::Routed(routed_message) = self {
+            routed_message.body.as_ref()
+        } else {
+            self.as_ref()
         }
     }
 

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -172,12 +172,7 @@ impl PeerActor {
                     let tid = near_rust_allocator_proxy::get_tid();
                     #[cfg(not(feature = "performance_stats"))]
                     let tid = 0;
-                    error!(
-                        "{} Failed to send message {} of size {}",
-                        tid,
-                        strum::AsStaticRef::as_static(msg),
-                        bytes_len,
-                    )
+                    error!("{} Failed to send message {} of size {}", tid, msg.as_ref(), bytes_len,)
                 }
             }
             Err(err) => error!(target: "network", "Error converting message to bytes: {}", err),

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -2267,7 +2267,7 @@ impl PeerManagerActor {
     /// Otherwise try to route this message to the final receiver and return false.
     fn handle_msg_routed_from(&mut self, msg: RoutedMessageFrom) -> bool {
         let _d = delay_detector::DelayDetector::new(|| {
-            format!("routed message from {}", strum::AsStaticRef::as_static(&msg.msg.body)).into()
+            format!("routed message from {}", msg.msg.body.as_ref()).into()
         });
         let RoutedMessageFrom { mut msg, from } = msg;
 

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -29,7 +29,6 @@ use near_primitives::types::{AccountId, BlockReference, EpochId, ShardId};
 use near_primitives::views::{NetworkInfoView, PeerInfoView, QueryRequest};
 use std::collections::HashMap;
 use std::fmt::Debug;
-use strum::AsStaticStr;
 
 /// Message from peer to peer manager
 #[derive(actix::Message, strum::AsRefStr, Clone, Debug)]
@@ -391,7 +390,7 @@ pub enum NetworkResponses {
     RouteNotFound,
 }
 
-#[derive(actix::Message, Debug, strum::AsRefStr, AsStaticStr)]
+#[derive(actix::Message, Debug, strum::AsRefStr, strum::AsStaticStr)]
 // TODO(#1313): Use Box
 #[allow(clippy::large_enum_variant)]
 #[rtype(result = "NetworkClientResponses")]

--- a/utils/near-performance-metrics-macros/src/lib.rs
+++ b/utils/near-performance-metrics-macros/src/lib.rs
@@ -49,13 +49,11 @@ pub fn perf(_attr: TokenStream, item: TokenStream) -> TokenStream {
 /// This function assumes it wraps around a method with `&mut self, msg: NetworkClientMessages,
 /// ctx: &mut Self::Context<Self>` as arguments. There is currently a requirement that the second
 /// argument is called msg. There is an assumption that the argument called `msg` is an enum, which
-/// has `#[derive(AsStaticStr)]`.
+/// has `#[derive(AsRefStr)]`.
 ///
 /// # Examples
 /// ```ignore
-/// use strum::AsStaticStr;
-///
-/// #[derive(AsStaticStr)]
+/// #[derive(strum::AsRefStr)]
 /// pub enum MyMessage {
 ///      ExampleMessage()
 /// }

--- a/utils/near-performance-metrics/src/stats_disabled.rs
+++ b/utils/near-performance-metrics/src/stats_disabled.rs
@@ -18,7 +18,7 @@ pub fn measure_performance_with_debug<F, Message, Result>(
 ) -> Result
 where
     F: FnOnce(Message) -> Result,
-    Message: AsRef<str>,
+    Message: strum::AsStaticRef<str>,
 {
     f(msg)
 }

--- a/utils/near-performance-metrics/src/stats_disabled.rs
+++ b/utils/near-performance-metrics/src/stats_disabled.rs
@@ -1,5 +1,4 @@
 use std::time::Duration;
-use strum::AsStaticRef;
 
 pub fn measure_performance<F, Message, Result>(
     _class_name: &'static str,
@@ -19,7 +18,7 @@ pub fn measure_performance_with_debug<F, Message, Result>(
 ) -> Result
 where
     F: FnOnce(Message) -> Result,
-    Message: AsStaticRef<str>,
+    Message: AsRef<str>,
 {
     f(msg)
 }


### PR DESCRIPTION
strum::AsStaticStr derive and trait are deprecated.  Replace most uses
of them by strum::AsRefStr derive which serves very similar purpose.

Unfortunately there is a difference where the latter returns a reference
with lifetime same as ‘self’.  utils/near-performance-metrics currently
depends on NetworkClientMessages and NetworkViewClientMessages implementing
the former and being convertible to `&'static str`.  Because of that, those
two still use strum::AsStatirStr.
