### PR TITLE
Remove usage of strum::AsStaticStr in favour of strum:IntoStaticStr

### DIFF
--- a/chain/network-primitives/src/types.rs
+++ b/chain/network-primitives/src/types.rs
@@ -288,7 +288,7 @@ pub enum SandboxResponse {
     SandboxFastForwardFailed(String),
 }
 
-#[derive(actix::Message, strum::AsStaticStr)]
+#[derive(actix::Message, strum::IntoStaticStr)]
 #[rtype(result = "NetworkViewClientResponses")]
 pub enum NetworkViewClientMessages {
     #[cfg(feature = "test_features")]

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -390,7 +390,7 @@ pub enum NetworkResponses {
     RouteNotFound,
 }
 
-#[derive(actix::Message, Debug, strum::AsRefStr, strum::AsStaticStr)]
+#[derive(actix::Message, Debug, strum::AsRefStr, strum::IntoStaticStr)]
 // TODO(#1313): Use Box
 #[allow(clippy::large_enum_variant)]
 #[rtype(result = "NetworkClientResponses")]

--- a/utils/near-performance-metrics/src/stats_disabled.rs
+++ b/utils/near-performance-metrics/src/stats_disabled.rs
@@ -18,7 +18,7 @@ pub fn measure_performance_with_debug<F, Message, Result>(
 ) -> Result
 where
     F: FnOnce(Message) -> Result,
-    Message: strum::AsStaticRef<str>,
+    Message: Into<&'static str>,
 {
     f(msg)
 }

--- a/utils/near-performance-metrics/src/stats_enabled.rs
+++ b/utils/near-performance-metrics/src/stats_enabled.rs
@@ -13,7 +13,6 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::{Arc, Mutex};
 use std::task::Poll;
 use std::time::{Duration, Instant};
-use strum::AsStaticRef;
 use tracing::{info, warn};
 
 static MEMORY_LIMIT: u64 = 512 * bytesize::MIB;
@@ -298,10 +297,9 @@ pub fn measure_performance_with_debug<F, Message, Result>(
 ) -> Result
 where
     F: FnOnce(Message) -> Result,
-    Message: AsStaticRef<str>,
+    Message: Into<&'static str>,
 {
-    let msg_text: &'static str = msg.as_static();
-    measure_performance_internal(class_name, msg, f, Some(msg_text))
+    measure_performance_internal(class_name, msg, f, Some(msg.into()))
 }
 
 pub fn measure_performance_internal<F, Message, Result>(


### PR DESCRIPTION
Convert remaining usage of strum::AsStaticStr (which is deprecated
in never strum versions) with strum:IntoStaticStr which provides
the same feature without the need for a custom trait.

Uses of strum::AsRefStr could also be replaced but they are left as
is for now because conversion is a bit messy.  `msg.as_ref()` would
need to be replaced by `(&msg).into()` and this added borrow is wee
bit ugly.  We may do it in the future commit.