### PR TITLE
fix debug page crash when there is no block available

### DIFF
--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -807,24 +807,20 @@ impl Handler<Status> for ClientActor {
                     .chain
                     .blocks_with_missing_chunks
                     .list_blocks_by_height(),
-                epoch_info: EpochInfoView {
-                    epoch_id: head.epoch_id.0,
-                    height: epoch_start_height,
-                    first_block_hash: self
-                        .client
-                        .chain
-                        .get_block_by_height(epoch_start_height)?
-                        .header()
-                        .hash()
-                        .clone(),
-                    start_time: self
-                        .client
-                        .chain
-                        .get_block_by_height(epoch_start_height)?
-                        .header()
-                        .timestamp()
-                        .to_rfc3339(),
-                    validators: validators.to_vec(),
+                epoch_info: {
+                    EpochInfoView {
+                        epoch_id: head.epoch_id.0,
+                        height: epoch_start_height,
+                        first_block: self
+                            .client
+                            .chain
+                            .get_block_by_height(epoch_start_height)
+                            .ok()
+                            .map(|block| {
+                                (block.header().hash().clone(), block.header().timestamp())
+                            }),
+                        validators: validators.to_vec(),
+                    }
                 },
             })
         } else {

--- a/chain/jsonrpc/res/epoch_info.html
+++ b/chain/jsonrpc/res/epoch_info.html
@@ -40,8 +40,13 @@
                     let epoch_info = data.detailed_debug_status.epoch_info;
                     $('.js-epoch-id').text(epoch_info.epoch_id);
                     $('.js-epoch-height').text(epoch_info.height);
-                    $('.js-epoch-first-block-hash').text(epoch_info.first_block_hash);
-                    $('.js-epoch-start-time').text(epoch_info.start_time);
+                    if (epoch_info.first_block === null) {
+                        $('.js-epoch-first-block-hash').text("Not yet available");
+                        $('.js-epoch-start-time').text("Not yet available");
+                    } else {
+                        $('.js-epoch-first-block-hash').text(epoch_info.first_block[0]);
+                        $('.js-epoch-start-time').text(epoch_info.first_block[1]);
+                    }
                     epoch_info.validators.forEach((validator, index) =>
                         $('.js-tbody-validators').append($('<tr>')
                             .append($('<td>').append(validator.account_id))
@@ -68,12 +73,8 @@
             <span class="js-epoch-id"></span>
         </p>
         <p>
-            First block hash:
+            First block (height at <span class="js-epoch-height"></span>) hash:
             <span class="js-epoch-first-block-hash"></span>
-        </p>
-        <p>
-            Height at:
-            <span class="js-epoch-height"></span>
         </p>
         <p>
             Started at:

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -389,8 +389,7 @@ impl From<Tip> for BlockStatusView {
 pub struct EpochInfoView {
     pub epoch_id: CryptoHash,
     pub height: BlockHeight,
-    pub first_block_hash: CryptoHash,
-    pub start_time: String,
+    pub first_block: Option<(CryptoHash, DateTime<chrono::Utc>)>,
     pub validators: Vec<ValidatorInfo>,
 }
 


### PR DESCRIPTION
### Description
In `HeaderSync`, there is no block available. Debug page actually crashes in this mode by trying to access block 0. This PR fixes this issue.

### JIRA Issue
[CP-60](https://nearinc.atlassian.net/browse/CP-60)

### Test plan (on testnet)
 - Build with `make neard`
 - Under `nearcore` directory, launch testnet using command `nearup stop && nearup run testnet --binary-path ./target/release`
 - Open your browser and go to http://[host_address]:3030/debug/epoch_info
 - Expect to see a webpage that looks similar to the one below
 - Verify that the page works in `HeaderSync` mode, too (You can clear all files under `~/.near/testnet` to force `HeaderSync`, but remember to set`"enable_debug_rpc": true`, under `rpc`, in `~/.near/testnet/config.json`)

### Screenshot on testnet
<img width="863" alt="Screen Shot 2022-04-28 at 6 04 23 PM" src="https://user-images.githubusercontent.com/98097537/165870856-430474f1-266d-469b-b43d-380ca881f30d.png">

### Test plan (on localnet)
 - Build with `make neard`
 - Under `nearcore` directory, launch localnet using command `nearup stop && nearup run localnet --binary-path ./target/release`
 - Open your browser and go to http://[host_address]:3030/debug/epoch_info
 - Expect to see a webpage that looks similar to the one below

### Screenshot on localnet
<img width="1018" alt="Screen Shot 2022-04-28 at 6 04 17 PM" src="https://user-images.githubusercontent.com/98097537/165870864-d657150c-1f12-4c79-b860-a5856e20af47.png">


### First round reviewer
 - @mzhangmzz 
 - @mm-near 
