### PR TITLE
chain: map blacklisted IPv4 to IPv6

### DIFF
--- a/chain/network-primitives/src/blacklist.rs
+++ b/chain/network-primitives/src/blacklist.rs
@@ -1,7 +1,13 @@
 /// A blacklist for socket addresses.  Supports adding individual IP:port tuples
 /// to the blacklist or entire IPs.
 #[derive(Debug, Default, Clone)]
-pub struct Blacklist(std::collections::HashMap<std::net::IpAddr, PortsSet>);
+pub struct Blacklist(
+    /// Only IPv6 addresses are stored.  IPv4 addresses are mapped to IPv6 before being added.
+    ///
+    /// Without the mapping, we could blacklist an IPv4 and still interact with that address if
+    /// it is presented as IPv6.
+    std::collections::HashMap<std::net::Ipv6Addr, PortsSet>,
+);
 
 // TODO(CP-34): merge Blacklist with whitelist functionality and replace them with sth
 // like AuthorizationConfig.
@@ -31,7 +37,7 @@ impl Blacklist {
             }
             PatternAddr::IpPort(addr) => {
                 self.0
-                    .entry(addr.ip())
+                    .entry(*addr.ip())
                     .and_modify(|ports| ports.add_port(addr.port()))
                     .or_insert_with(|| PortsSet::new(addr.port()));
             }
@@ -41,7 +47,11 @@ impl Blacklist {
 
     /// Returns whether given address is on the blacklist.
     pub fn contains(&self, addr: &std::net::SocketAddr) -> bool {
-        match self.0.get(&addr.ip()) {
+        let ip = match addr.ip() {
+            std::net::IpAddr::V4(ip) => ip.to_ipv6_mapped(),
+            std::net::IpAddr::V6(ip) => ip,
+        };
+        match self.0.get(&ip) {
             None => false,
             Some(ports) => ports.contains(addr.port()),
         }
@@ -51,18 +61,31 @@ impl Blacklist {
 /// Used to match a socket addr by IP:Port or only by IP
 #[cfg_attr(test, derive(Debug, PartialEq))]
 enum PatternAddr {
-    Ip(std::net::IpAddr),
-    IpPort(std::net::SocketAddr),
+    Ip(std::net::Ipv6Addr),
+    IpPort(std::net::SocketAddrV6),
 }
 
 impl std::str::FromStr for PatternAddr {
     type Err = std::net::AddrParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if let Ok(pattern) = s.parse() {
-            return Ok(PatternAddr::Ip(pattern));
+        if let Ok(ip_addr) = s.parse::<std::net::IpAddr>() {
+            let ip_addr_v6 = match ip_addr {
+                std::net::IpAddr::V4(ip) => ip.to_ipv6_mapped(),
+                std::net::IpAddr::V6(ip) => ip,
+            };
+            return Ok(PatternAddr::Ip(ip_addr_v6));
         }
-        s.parse().map(PatternAddr::IpPort)
+        let socket_addr_v6 = match s.parse::<std::net::SocketAddr>()? {
+            std::net::SocketAddr::V4(socket_addr) => std::net::SocketAddrV6::new(
+                socket_addr.ip().to_ipv6_mapped(),
+                socket_addr.port(),
+                0,
+                0,
+            ),
+            std::net::SocketAddr::V6(socket_addr) => socket_addr,
+        };
+        Ok(PatternAddr::IpPort(socket_addr_v6))
     }
 }
 
@@ -114,9 +137,9 @@ mod test {
         assert_eq!("err", parse("192.0.2.4.5"));
         assert_eq!("err", parse("192.0.2.4:424242"));
 
-        assert_eq!("192.0.2.4", parse("192.0.2.4"));
-        assert_eq!("192.0.2.4:0", parse("192.0.2.4:0"));
-        assert_eq!("192.0.2.4:42", parse("192.0.2.4:42"));
+        assert_eq!("::ffff:192.0.2.4", parse("192.0.2.4"));
+        assert_eq!("[::ffff:192.0.2.4]:0", parse("192.0.2.4:0"));
+        assert_eq!("[::ffff:192.0.2.4]:42", parse("192.0.2.4:42"));
 
         assert_eq!("::1", parse("::1"));
         assert_eq!("[::1]:42", parse("[::1]:42"));
@@ -147,7 +170,8 @@ mod test {
         let ip = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 4));
         let lo4 = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
         let lo6 = IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));
-        let mapped = IpAddr::V6("::ffff:127.0.0.1".parse().unwrap());
+        let mapped_ip = IpAddr::V6("::ffff:192.0.2.4".parse().unwrap());
+        let mapped_lo4 = IpAddr::V6("::ffff:127.0.0.1".parse().unwrap());
 
         let blacklist = super::Blacklist::from_iter(vec![
             "127.0.0.1".to_string(),
@@ -161,7 +185,9 @@ mod test {
         assert!(!blacklist.contains(&SocketAddr::new(ip, 8080)));
         assert!(blacklist.contains(&SocketAddr::new(lo6, 42)));
         assert!(!blacklist.contains(&SocketAddr::new(lo6, 8080)));
-        assert!(!blacklist.contains(&SocketAddr::new(mapped, 42)));
-        assert!(!blacklist.contains(&SocketAddr::new(mapped, 8080)));
+        assert!(blacklist.contains(&SocketAddr::new(mapped_lo4, 42)));
+        assert!(blacklist.contains(&SocketAddr::new(mapped_lo4, 8080)));
+        assert!(blacklist.contains(&SocketAddr::new(mapped_ip, 42)));
+        assert!(!blacklist.contains(&SocketAddr::new(mapped_ip, 8080)));
     }
 }


### PR DESCRIPTION
Prevent interacting with a blacklisted IPv4 if it is presented as IPv6, see #6521. To this end, `Blacklist` is modified to store `std::net::Ipv6Addr` (instead of `IpAddr`). When adding or querying an IPv4 address, it is [mapped to IPv6](https://doc.rust-lang.org/std/net/struct.Ipv4Addr.html#method.to_ipv6_mapped).

The public interface of `Blacklist` remains unchanged, but `contains()` may return a different value.

```rust
use std::net::*;

let blacklist = Blacklist::from_iter(vec![
    "127.0.0.1".to_string(),
    "192.0.2.4:42".to_string(),
])

// Previously those would have returned false.
let ip_a = IpAddr::V6("::ffff:127.0.0.1".parse().unwrap());
let ip_b = IpAddr::V6("::ffff:192.0.2.4".parse().unwrap());
assert!(blacklist.contains(&SocketAddr::new(ip_a, 8080)));
assert!(blacklist.contains(&SocketAddr::new(ip_b, 42)));

// When querying an IPv4 the mapping happens implicitly.
let ip_v4 = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
assert!(blacklist.contains(&SocketAddr::new(ip_v4, 8080)));
```

Issue #6521

**Test plan:** Covered by existing tests.