### PR TITLE
feat(params-estimator): nightly feature estimation

### DIFF
--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -289,13 +289,19 @@ fn main_docker(
         let mut buf = String::new();
         buf.push_str("set -ex;\n");
         buf.push_str("cd /host/nearcore;\n");
-        buf.push_str(
-            "\
-cargo build --manifest-path /host/nearcore/Cargo.toml \
-  --package runtime-params-estimator --bin runtime-params-estimator \
-  --features required --release;
-",
-        );
+        buf.push_str("cargo build --manifest-path /host/nearcore/Cargo.toml");
+        buf.push_str(" --package runtime-params-estimator --bin runtime-params-estimator");
+
+        // Feature "required" is always necessary for accurate measurements.
+        buf.push_str(" --features required");
+
+        // Also add nightly protocol features to docker build if they are enabled.
+        #[cfg(feature = "nightly_protocol_features")]
+        buf.push_str(",nightly_protocol_features");
+        #[cfg(feature = "nightly_protocol")]
+        buf.push_str(",nightly_protocol");
+
+        buf.push_str(" --release;");
 
         let mut qemu_cmd_builder = QemuCommandBuilder::default();
 


### PR DESCRIPTION
Add nightly feature flags to build inside docker, to allow icount
estimates of nightly features without hackery.