### PR TITLE
runtime: make test_cost_sanity independent of receipt hash

### DIFF
--- a/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_status.snap
+++ b/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_status.snap
@@ -3,7 +3,7 @@ source: integration-tests/src/tests/runtime/sanity_checks.rs
 expression: receipts_status
 
 ---
-- SuccessReceiptId: BpQW8EXPmXvHqUcx6x1JYZudyaCVEuoQ9Kbj93Kx7g18
+- SuccessReceiptId: "11111111111111111111111111111111"
 - Failure:
     ActionError:
       index: 0
@@ -38,4 +38,3 @@ expression: receipts_status
 - SuccessValue: ""
 - SuccessValue: ""
 - SuccessValue: ""
-


### PR DESCRIPTION
Issue: https://github.com/near/nearcore/issues/4961