### PR TITLE
doc: update some urls in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ Overall, *NEAR* provides a wide range of tools for developers to easily build ap
 [rust-sdk]: https://github.com/near/near-sdk-rs
 [as-sdk]: https://github.com/near/near-sdk-as
 [examples-url]: https://near.dev
-[docs-url]: http://docs.nearprotocol.com
-[tutorials-url]: https://docs.nearprotocol.com/docs/roles/developer/tutorials/introduction
-[api-docs-url]: https://docs.nearprotocol.com/docs/roles/developer/examples/nearlib/introduction
+[docs-url]: https://docs.near.org
+[tutorials-url]: https://docs.near.org/docs/tutorials/overview
+[api-docs-url]: https://docs.near.org/docs/api/overview
 
 ## Join the Network
 


### PR DESCRIPTION
The original urls of the tutorials and api docs will all redirect to [getting started](https://docs.near.org/docs/develop/basics/getting-started), this pr corrects them.