### PR TITLE
move receipt_id_to_shard_id to be saved after apply_chunks

### DIFF
--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -128,7 +128,7 @@ pub enum DBCol {
     /// - *Rows*: EpochId (CryptoHash)
     /// - *Content type*: LightClientBlockView
     EpochLightClientBlocks = 26,
-    /// Mapping from Receipt id to Shard id
+    /// Mapping from Receipt id to destination Shard Id, i.e, the shard that this receipt is sent to.
     /// - *Rows*: ReceiptId (CryptoHash)
     /// - *Content type*: Shard Id || ref_count (u64 || u64)
     ReceiptIdToShardId = 27,


### PR DESCRIPTION
This PR is also part of the initiative to refactor process_block so there are no writes to ChainStore before apply_chunks.
It also simplifies the implementation of receipt_id_to_shard_id by saving it as outgoing receipts instead of as incoming receipts. We can do that because receipt_id_to_shard_id is used for tx_status rpc calls to track the receipts a transaction generates, to fetch the receipts that are executed in other shards. Therefore, we need to store a mapping from receipt id to the destination shard ids for all outgoing receipts. 