### PR TITLE
network: replace strum::AsStrRef derives with strum::IntoStaticStr

### DIFF
--- a/chain/network-primitives/src/network_protocol/mod.rs
+++ b/chain/network-primitives/src/network_protocol/mod.rs
@@ -165,7 +165,7 @@ pub struct Pong {
 
 // TODO(#1313): Use Box
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
-#[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Clone, strum::AsRefStr)]
+#[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Clone, strum::IntoStaticStr)]
 #[allow(clippy::large_enum_variant)]
 pub enum RoutedMessageBody {
     BlockApproval(Approval),
@@ -340,6 +340,10 @@ impl RoutedMessage {
     pub fn decrease_ttl(&mut self) -> bool {
         self.ttl = self.ttl.saturating_sub(1);
         self.ttl > 0
+    }
+
+    pub fn body_variant(&self) -> &'static str {
+        (&self.body).into()
     }
 }
 

--- a/chain/network/src/network_protocol/mod.rs
+++ b/chain/network/src/network_protocol/mod.rs
@@ -76,7 +76,7 @@ pub enum HandshakeFailureReason {
     InvalidTarget,
 }
 
-#[derive(PartialEq, Eq, Clone, Debug, strum::AsRefStr, strum::EnumVariantNames)]
+#[derive(PartialEq, Eq, Clone, Debug, strum::IntoStaticStr, strum::EnumVariantNames)]
 #[allow(clippy::large_enum_variant)]
 pub enum PeerMessage {
     Handshake(Handshake),
@@ -159,10 +159,10 @@ impl PeerMessage {
         })
     }
 
-    pub(crate) fn msg_variant(&self) -> &str {
+    pub(crate) fn msg_variant(&self) -> &'static str {
         match self {
-            PeerMessage::Routed(routed_message) => routed_message.body.as_ref(),
-            _ => self.as_ref(),
+            PeerMessage::Routed(routed_msg) => routed_msg.body_variant(),
+            _ => self.into(),
         }
     }
 

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -246,11 +246,8 @@ impl PeerActor {
             let tid = near_rust_allocator_proxy::get_tid();
             #[cfg(not(feature = "performance_stats"))]
             let tid = 0;
-            return Err(IOError::Send {
-                tid,
-                message_type: msg.as_ref().to_string(),
-                size: bytes_len,
-            });
+            let msg_type: &str = msg.into();
+            return Err(IOError::Send { tid, message_type: msg_type.to_string(), size: bytes_len });
         }
         Ok(())
     }

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -2273,7 +2273,7 @@ impl PeerManagerActor {
     /// Otherwise try to route this message to the final receiver and return false.
     fn handle_msg_routed_from(&mut self, msg: RoutedMessageFrom) -> bool {
         let _d = delay_detector::DelayDetector::new(|| {
-            format!("routed message from {}", msg.msg.body.as_ref()).into()
+            format!("routed message from {}", msg.msg.body_variant()).into()
         });
         let RoutedMessageFrom { mut msg, from } = msg;
 

--- a/chain/network/src/stats/metrics.rs
+++ b/chain/network/src/stats/metrics.rs
@@ -121,7 +121,7 @@ pub(crate) enum MessageDropped {
 
 impl MessageDropped {
     pub fn inc(self, msg: &RoutedMessageBody) {
-        self.inc_msg_type(msg.as_ref())
+        self.inc_msg_type(msg.into())
     }
 
     pub fn inc_unknown_msg(self) {


### PR DESCRIPTION
The advantage of strum::IntoStaticStr derive is that provided into
method returns a static reference rather than a one with self’s
lifetime which also creates a borrow on self.

Issue: https://github.com/near/nearcore/issues/6704
