### PR TITLE
network: prefer strum::IntoStatiStr than strum::AsStaticStr

### DIFF
--- a/chain/network/src/tests/peer_actor.rs
+++ b/chain/network/src/tests/peer_actor.rs
@@ -163,7 +163,8 @@ impl Handler<NetworkClientMessages> for FakeActor {
 impl Handler<PeerManagerMessageRequest> for FakeActor {
     type Result = PeerManagerMessageResponse;
     fn handle(&mut self, msg: PeerManagerMessageRequest, _ctx: &mut Self::Context) -> Self::Result {
-        println!("{}: PeerManager message {}", self.cfg.id(), strum::AsStaticRef::as_static(&msg));
+        let msg_type: &str = (&msg).into();
+        println!("{}: PeerManager message {}", self.cfg.id(), msg_type);
         match msg {
             PeerManagerMessageRequest::RegisterPeer(msg) => {
                 self.responses.send(Response::HandshakeDone).unwrap();

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -82,7 +82,7 @@ pub struct PeersResponse {
 /// which contains reply for each message to `PeerManager`.
 /// There is 1 to 1 mapping between an entry in `PeerManagerMessageRequest` and `PeerManagerMessageResponse`.
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
-#[derive(actix::Message, Debug, strum::AsStaticStr)]
+#[derive(actix::Message, Debug, strum::IntoStaticStr)]
 #[rtype(result = "PeerManagerMessageResponse")]
 pub enum PeerManagerMessageRequest {
     RoutedMessageFrom(RoutedMessageFrom),


### PR DESCRIPTION
The latter is deprecated so use the former which has equivalent
behaviour.