### PR TITLE
Separate collecting rocksdb statistics and re-exporting them to prometheus

### DIFF
--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1764,6 +1764,11 @@ impl ClientActor {
             .get_validator_info(epoch_identifier)
             .map(get_validator_epoch_stats)
             .unwrap_or_default();
+        let statistics = if self.client.config.enable_statistics_export {
+            self.client.chain.store().get_store_statistics()
+        } else {
+            None
+        };
         self.info_helper.info(
             self.client.chain.store().get_genesis_height(),
             &head,
@@ -1781,7 +1786,7 @@ impl ClientActor {
                 .get_protocol_upgrade_block_height(head.last_block_hash)
                 .unwrap_or(None)
                 .unwrap_or(0),
-            self.client.chain.store().get_store_statistics(),
+            statistics,
         );
         debug!(target: "stats", "{}", self.client.detailed_upcoming_blocks_info().unwrap_or(String::from("Upcoming block info failed.")));
     }

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -154,6 +154,8 @@ pub struct ClientConfig {
     /// genesis file.  The value only affects the RPCs without influencing the
     /// protocol thus changing it per-node doesn’t affect the blockchain.
     pub max_gas_burnt_view: Option<Gas>,
+    /// Re-export storage layer statistics as prometheus metrics.
+    pub enable_statistics_export: bool,
 }
 
 impl ClientConfig {
@@ -212,6 +214,7 @@ impl ClientConfig {
             view_client_throttle_period: Duration::from_secs(1),
             trie_viewer_state_size_limit: None,
             max_gas_burnt_view: None,
+            enable_statistics_export: true,
         }
     }
 }

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -336,10 +336,14 @@ pub struct StoreConfig {
     #[serde(skip)]
     pub read_only: bool,
 
-    /// Re-export storage layer statistics as prometheus metrics.
+    /// Collect internal storage layer statistics.
     /// Minor performance impact is expected.
     #[serde(default)]
     pub enable_statistics: bool,
+
+    /// Re-export storage layer statistics as prometheus metrics.
+    #[serde(default = "default_enable_statistics_export")]
+    pub enable_statistics_export: bool,
 
     /// Maximum number of store files being opened simultaneously.
     /// Default value: 512.
@@ -365,6 +369,10 @@ pub struct StoreConfig {
     /// the performance of the storage
     #[serde(default = "default_block_size")]
     pub block_size: usize,
+}
+
+fn default_enable_statistics_export() -> bool {
+    true
 }
 
 fn default_max_open_files() -> u32 {
@@ -407,6 +415,7 @@ impl StoreConfig {
         StoreConfig {
             read_only: false,
             enable_statistics: false,
+            enable_statistics_export: true,
             max_open_files: default_max_open_files(),
             col_state_cache_size: default_col_state_cache_size(),
             block_size: default_block_size(),

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -700,6 +700,7 @@ impl NearConfig {
                 view_client_throttle_period: config.view_client_throttle_period,
                 trie_viewer_state_size_limit: config.trie_viewer_state_size_limit,
                 max_gas_burnt_view: config.max_gas_burnt_view,
+                enable_statistics_export: config.store.enable_statistics_export,
             },
             network_config: NetworkConfig {
                 public_key: network_key_pair.public_key,


### PR DESCRIPTION
This PR lets us verify whether the performance impact is caused by RocksDB statistics or by nearcore re-exporting those metrics. If the latter, we can optimize the code to reduce the performance impact.