### PR TITLE
added a metric monitoring Proto/Borsh encoding for peer connections

### DIFF
--- a/chain/network-primitives/src/types.rs
+++ b/chain/network-primitives/src/types.rs
@@ -52,7 +52,7 @@ pub const MAX_NUM_PEERS: usize = 128;
 
 /// Peer type.
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, strum::IntoStaticStr)]
 pub enum PeerType {
     /// Inbound session
     Inbound,
@@ -355,26 +355,6 @@ pub enum NetworkViewClientResponses {
     NoResponse,
 }
 
-/// Peer stats query.
-#[derive(actix::Message)]
-#[rtype(result = "PeerStatsResult")]
-pub struct QueryPeerStats {}
-
-/// Peer stats result
-#[derive(Debug, actix::MessageResponse)]
-pub struct PeerStatsResult {
-    /// Chain info.
-    pub chain_info: PeerChainInfoV2,
-    /// Number of bytes we've received from the peer.
-    pub received_bytes_per_sec: u64,
-    /// Number of bytes we've sent to the peer.
-    pub sent_bytes_per_sec: u64,
-    /// Returns if this peer is abusive and should be banned.
-    pub is_abusive: bool,
-    /// Counts of incoming/outgoing messages from given peer.
-    pub message_counts: (usize, usize),
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -419,7 +399,6 @@ mod tests {
         assert_size!(OutboundTcpConnect);
         assert_size!(Ban);
         assert_size!(StateResponseInfoV1);
-        assert_size!(QueryPeerStats);
         assert_size!(PartialEncodedChunkRequestMsg);
     }
 

--- a/chain/network/src/network_protocol/mod.rs
+++ b/chain/network/src/network_protocol/mod.rs
@@ -117,7 +117,7 @@ impl fmt::Display for PeerMessage {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash, strum::IntoStaticStr)]
 pub enum Encoding {
     Borsh,
     Proto,

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -8,7 +8,7 @@ use crate::stats::metrics;
 use crate::types::{
     Handshake, HandshakeFailureReason, NetworkClientMessages, NetworkClientResponses,
     NetworkRequests, NetworkResponses, PeerManagerMessageRequest, PeerMessage, PeerRequest,
-    PeerResponse, PeersResponse,
+    PeerResponse, PeerStatsResult, PeersResponse, QueryPeerStats,
 };
 use actix::{
     Actor, ActorContext, ActorFutureExt, Arbiter, AsyncContext, Context, ContextFutureSpawner,
@@ -18,9 +18,8 @@ use lru::LruCache;
 use near_crypto::Signature;
 use near_network_primitives::types::{
     Ban, NetworkViewClientMessages, NetworkViewClientResponses, PeerChainInfoV2, PeerIdOrHash,
-    PeerInfo, PeerManagerRequest, PeerStatsResult, PeerType, QueryPeerStats, ReasonForBan,
-    RoutedMessage, RoutedMessageBody, RoutedMessageFrom, StateResponseInfo,
-    UPDATE_INTERVAL_LAST_TIME_RECEIVED_MESSAGE,
+    PeerInfo, PeerManagerRequest, PeerType, ReasonForBan, RoutedMessage, RoutedMessageBody,
+    RoutedMessageFrom, StateResponseInfo, UPDATE_INTERVAL_LAST_TIME_RECEIVED_MESSAGE,
 };
 
 use near_network_primitives::types::{Edge, PartialEdgeInfo};
@@ -175,32 +174,43 @@ impl PeerActor {
         }
     }
 
-    fn parse_message(&mut self, msg: &[u8]) -> Result<PeerMessage, ParsePeerMessageError> {
-        if let Some(e) = self.force_encoding {
-            return PeerMessage::deserialize(e, msg);
+    // Determines the encoding to use for communication with the peer.
+    // It can be None while Handshake with the peer has not been finished yet.
+    // In case it is None, both encodings are attempted for parsing, and each message
+    // is sent twice.
+    fn encoding(&self) -> Option<Encoding> {
+        if self.force_encoding.is_some() {
+            return self.force_encoding;
         }
         if self.peer_status == PeerStatus::Connecting {
-            if let Ok(msg) = PeerMessage::deserialize(Encoding::Proto, msg) {
-                self.protocol_buffers_supported = true;
-                return Ok(msg);
+            return None;
+        }
+        if self.protocol_buffers_supported {
+            return Some(Encoding::Proto);
+        }
+        return Some(Encoding::Borsh);
+    }
+
+    fn parse_message(&mut self, msg: &[u8]) -> Result<PeerMessage, ParsePeerMessageError> {
+        if let Some(e) = self.encoding() {
+            return PeerMessage::deserialize(e, msg);
+        }
+        if let Ok(msg) = PeerMessage::deserialize(Encoding::Proto, msg) {
+            self.protocol_buffers_supported = true;
+            return Ok(msg);
+        }
+        match PeerMessage::deserialize(Encoding::Borsh, msg) {
+            Ok(msg) => Ok(msg),
+            Err(err) => {
+                self.send_message_or_log(&PeerMessage::HandshakeFailure(
+                    self.my_node_info.clone(),
+                    HandshakeFailureReason::ProtocolVersionMismatch {
+                        version: PROTOCOL_VERSION,
+                        oldest_supported_version: PEER_MIN_ALLOWED_PROTOCOL_VERSION,
+                    },
+                ));
+                Err(err)
             }
-            match PeerMessage::deserialize(Encoding::Borsh, msg) {
-                Ok(msg) => Ok(msg),
-                Err(err) => {
-                    self.send_message_or_log(&PeerMessage::HandshakeFailure(
-                        self.my_node_info.clone(),
-                        HandshakeFailureReason::ProtocolVersionMismatch {
-                            version: PROTOCOL_VERSION,
-                            oldest_supported_version: PEER_MIN_ALLOWED_PROTOCOL_VERSION,
-                        },
-                    ));
-                    Err(err)
-                }
-            }
-        } else if self.protocol_buffers_supported {
-            PeerMessage::deserialize(Encoding::Proto, msg)
-        } else {
-            PeerMessage::deserialize(Encoding::Borsh, msg)
         }
     }
 
@@ -211,17 +221,11 @@ impl PeerActor {
     }
 
     fn send_message(&mut self, msg: &PeerMessage) -> Result<(), IOError> {
-        if let Some(enc) = self.force_encoding {
+        if let Some(enc) = self.encoding() {
             return self.send_message_with_encoding(msg, enc);
         }
-        if self.peer_status == PeerStatus::Connecting {
-            self.send_message_with_encoding(msg, Encoding::Proto)?;
-            self.send_message_with_encoding(msg, Encoding::Borsh)?;
-        } else if self.protocol_buffers_supported {
-            self.send_message_with_encoding(msg, Encoding::Proto)?;
-        } else {
-            self.send_message_with_encoding(msg, Encoding::Borsh)?;
-        }
+        self.send_message_with_encoding(msg, Encoding::Proto)?;
+        self.send_message_with_encoding(msg, Encoding::Borsh)?;
         Ok(())
     }
 
@@ -1100,6 +1104,7 @@ impl Handler<QueryPeerStats> for PeerActor {
             sent_bytes_per_sec: sent.bytes_per_min / 60,
             is_abusive,
             message_counts: (sent.count_per_min, received.count_per_min),
+            encoding: self.encoding(),
         }
     }
 }

--- a/chain/network/src/stats/metrics.rs
+++ b/chain/network/src/stats/metrics.rs
@@ -1,10 +1,29 @@
+use crate::network_protocol::Encoding;
 use near_metrics::{
     do_create_int_counter_vec, try_create_histogram, try_create_int_counter,
     try_create_int_counter_vec, try_create_int_gauge, Histogram, IntCounter, IntCounterVec,
-    IntGauge,
+    IntGauge, IntGaugeVec,
 };
-use near_network_primitives::types::RoutedMessageBody;
+use near_network_primitives::types::{PeerType, RoutedMessageBody};
 use once_cell::sync::Lazy;
+use std::collections::HashMap;
+
+static PEER_CONNECTIONS: Lazy<IntGaugeVec> = Lazy::new(|| {
+    near_metrics::try_create_int_gauge_vec(
+        "near_peer_connections",
+        "Number of connected peers",
+        &["peer_type", "encoding"],
+    )
+    .unwrap()
+});
+
+pub fn set_peer_connections(values: HashMap<(PeerType, Option<Encoding>), i64>) {
+    for ((pt, enc), v) in values {
+        PEER_CONNECTIONS
+            .with_label_values(&[pt.into(), enc.map(|e| e.into()).unwrap_or("unknown")])
+            .set(v);
+    }
+}
 
 pub static PEER_CONNECTIONS_TOTAL: Lazy<IntGauge> = Lazy::new(|| {
     try_create_int_gauge("near_peer_connections_total", "Number of connected peers").unwrap()

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -1,6 +1,6 @@
 /// Type that belong to the network protocol.
 pub use crate::network_protocol::{
-    Handshake, HandshakeFailureReason, PeerMessage, RoutingTableUpdate,
+    Encoding, Handshake, HandshakeFailureReason, PeerMessage, RoutingTableUpdate,
 };
 pub use crate::network_protocol::{PartialSync, RoutingState, RoutingSyncV2, RoutingVersion2};
 use crate::private_actix::{
@@ -28,6 +28,28 @@ use near_primitives::types::{AccountId, BlockReference, EpochId, ShardId};
 use near_primitives::views::{NetworkInfoView, PeerInfoView, QueryRequest};
 use std::collections::HashMap;
 use std::fmt::Debug;
+
+/// Peer stats query.
+#[derive(actix::Message)]
+#[rtype(result = "PeerStatsResult")]
+pub struct QueryPeerStats {}
+
+/// Peer stats result
+#[derive(Debug, actix::MessageResponse)]
+pub struct PeerStatsResult {
+    /// Chain info.
+    pub chain_info: PeerChainInfoV2,
+    /// Number of bytes we've received from the peer.
+    pub received_bytes_per_sec: u64,
+    /// Number of bytes we've sent to the peer.
+    pub sent_bytes_per_sec: u64,
+    /// Returns if this peer is abusive and should be banned.
+    pub is_abusive: bool,
+    /// Counts of incoming/outgoing messages from given peer.
+    pub message_counts: (usize, usize),
+    /// Encoding used for communication.
+    pub encoding: Option<Encoding>,
+}
 
 /// Message from peer to peer manager
 #[derive(actix::Message, strum::AsRefStr, Clone, Debug)]


### PR DESCRIPTION
We will disable borsh encoding once node all versions >= PEER_MIN_ALLOWED_PROTOCOL_VERSION support protobuf decoding. Nevertheless, this metric will allow us to observe whether protobuf is actually used (as borsh is still enabled as a fallback).