### PR TITLE
Add function preprocess_block

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -4193,6 +4193,8 @@ impl<'a> ChainUpdate<'a> {
         Ok(())
     }
 
+    /// Return a StateSyncInfo that includes the information needed for syncing state for shards needed
+    /// in the next epoch.
     fn get_state_dl_info(
         &mut self,
         me: &Option<AccountId>,
@@ -4284,6 +4286,9 @@ impl<'a> ChainUpdate<'a> {
         Ok(())
     }
 
+    /// Preprocess a block before applying chunks, verify that we have the necessary information
+    /// to process the block an the block is valid.
+    //  Note that this function does NOT introduce any changes to chain state.
     fn preprocess_block(
         &mut self,
         me: &Option<AccountId>,
@@ -4450,8 +4455,7 @@ impl<'a> ChainUpdate<'a> {
     }
 
     /// Runs the block processing, including validation and finding a place for the new block in the chain.
-    /// Returns new head if chain head updated, as well as a boolean indicating if we need to start
-    ///    fetching state for the next epoch.
+    /// Returns new head if chain head updated
     fn process_block(
         &mut self,
         me: &Option<AccountId>,

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -118,6 +118,12 @@ enum ApplyChunksMode {
     NotCaughtUp,
 }
 
+/// Contains information from preprocessing a block
+struct BlockPreprocessInfo {
+    state_dl_info: Option<StateSyncInfo>,
+    incoming_receipts: HashMap<ShardId, Vec<ReceiptProof>>,
+}
+
 /// Orphan is a block whose previous block is not accepted (in store) yet.
 /// Therefore, they are not ready to be processed yet.
 /// We save these blocks in an in-memory orphan pool to be processed later
@@ -4187,11 +4193,11 @@ impl<'a> ChainUpdate<'a> {
         Ok(())
     }
 
-    fn start_downloading_state(
+    fn get_state_dl_info(
         &mut self,
         me: &Option<AccountId>,
         block: &Block,
-    ) -> Result<bool, Error> {
+    ) -> Result<Option<StateSyncInfo>, Error> {
         let prev_hash = *block.header().prev_hash();
         let shards_to_dl =
             Chain::get_shards_to_dl_state(self.runtime_adapter.clone(), me, &prev_hash)?;
@@ -4215,7 +4221,7 @@ impl<'a> ChainUpdate<'a> {
             debug_assert!(false);
         }
         if shards_to_dl.is_empty() {
-            Ok(false)
+            Ok(None)
         } else {
             debug!(target: "chain", "Downloading state for {:?}, I'm {:?}", shards_to_dl, me);
 
@@ -4230,8 +4236,7 @@ impl<'a> ChainUpdate<'a> {
                     .collect(),
             };
 
-            self.chain_store_update.add_state_dl_info(state_dl_info);
-            Ok(true)
+            Ok(Some(state_dl_info))
         }
     }
 
@@ -4285,8 +4290,13 @@ impl<'a> ChainUpdate<'a> {
         block: &MaybeValidated<Block>,
         provenance: &Provenance,
         on_challenge: &mut dyn FnMut(ChallengeBody),
-    ) -> Result<Vec<Box<dyn FnOnce() -> Result<ApplyChunkResult, Error> + Send + 'static>>, Error>
-    {
+    ) -> Result<
+        (
+            Vec<Box<dyn FnOnce() -> Result<ApplyChunkResult, Error> + Send + 'static>>,
+            BlockPreprocessInfo,
+        ),
+        Error,
+    > {
         debug!(target: "chain", "Block {}, approvals: {}, me: {:?}", block.hash(), block.header().num_approvals(), me);
 
         // Check that we know the epoch of the block before we try to get the header
@@ -4350,22 +4360,23 @@ impl<'a> ChainUpdate<'a> {
             return Err(ErrorKind::InvalidBlockHeight(prev_height).into());
         }
 
-        let is_caught_up = if self.runtime_adapter.is_next_block_epoch_start(&prev_hash)? {
-            if !self.prev_block_is_caught_up(&prev_prev_hash, &prev_hash)? {
-                // The previous block is not caught up for the next epoch relative to the previous
-                // block, which is the current epoch for this block, so this block cannot be applied
-                // at all yet, needs to be orphaned
-                return Err(ErrorKind::Orphan.into());
-            }
+        let (is_caught_up, state_dl_info) =
+            if self.runtime_adapter.is_next_block_epoch_start(&prev_hash)? {
+                if !self.prev_block_is_caught_up(&prev_prev_hash, &prev_hash)? {
+                    // The previous block is not caught up for the next epoch relative to the previous
+                    // block, which is the current epoch for this block, so this block cannot be applied
+                    // at all yet, needs to be orphaned
+                    return Err(ErrorKind::Orphan.into());
+                }
 
-            // For the first block of the epoch we check if we need to start download states for
-            // shards that we will care about in the next epoch. If there is no state to be downloaded,
-            // we consider that we are caught up, otherwise not
-            let has_state_to_download = self.start_downloading_state(me, block)?;
-            !has_state_to_download
-        } else {
-            self.prev_block_is_caught_up(&prev_prev_hash, &prev_hash)?
-        };
+                // For the first block of the epoch we check if we need to start download states for
+                // shards that we will care about in the next epoch. If there is no state to be downloaded,
+                // we consider that we are caught up, otherwise not
+                let state_dl_info = self.get_state_dl_info(me, block)?;
+                (state_dl_info.is_none(), state_dl_info)
+            } else {
+                (self.prev_block_is_caught_up(&prev_prev_hash, &prev_hash)?, None)
+            };
 
         debug!(target: "chain", "{:?} Process block {}, is_caught_up: {}", me, block.hash(), is_caught_up);
 
@@ -4410,7 +4421,7 @@ impl<'a> ChainUpdate<'a> {
         self.validate_chunk_headers(&block, &prev_block)?;
 
         self.ping_missing_chunks(me, prev_hash, block)?;
-        let receipts_by_shard = self.collect_incoming_receipts_from_block(me, block)?;
+        let incoming_receipts = self.collect_incoming_receipts_from_block(me, block)?;
 
         // If we have the state for shards in the next epoch already downloaded, apply the state transition
         // for these states as well
@@ -4420,7 +4431,7 @@ impl<'a> ChainUpdate<'a> {
                 me,
                 block,
                 &prev_block,
-                &receipts_by_shard,
+                &incoming_receipts,
                 ApplyChunksMode::IsCaughtUp,
             )?
         } else {
@@ -4430,12 +4441,12 @@ impl<'a> ChainUpdate<'a> {
                 me,
                 block,
                 &prev_block,
-                &receipts_by_shard,
+                &incoming_receipts,
                 ApplyChunksMode::NotCaughtUp,
             )?
         };
 
-        Ok(apply_chunk_work)
+        Ok((apply_chunk_work, BlockPreprocessInfo { state_dl_info, incoming_receipts }))
     }
 
     /// Runs the block processing, including validation and finding a place for the new block in the chain.
@@ -4451,14 +4462,19 @@ impl<'a> ChainUpdate<'a> {
         let _span =
             tracing::debug_span!(target: "chain", "Process block", "#{}", block.header().height())
                 .entered();
-
-        let apply_chunk_work = self.preprocess_block(me, block, provenance, on_challenge)?;
         let prev_hash = block.header().prev_hash();
         let prev_block = self.chain_store_update.get_block(prev_hash)?.clone();
+
+        let (apply_chunk_work, BlockPreprocessInfo { state_dl_info, incoming_receipts }) =
+            self.preprocess_block(me, block, provenance, on_challenge)?;
+
         self.apply_chunks_and_process_results(block, &prev_block, apply_chunk_work)?;
 
-        for (shard_id, receipt_proofs) in receipts_by_shard {
+        for (shard_id, receipt_proofs) in incoming_receipts {
             self.chain_store_update.save_incoming_receipt(block.hash(), shard_id, receipt_proofs);
+        }
+        if let Some(state_dl_info) = state_dl_info {
+            self.chain_store_update.add_state_dl_info(state_dl_info);
         }
 
         self.chain_store_update.save_block_header(block.header().clone())?;

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -4462,12 +4462,12 @@ impl<'a> ChainUpdate<'a> {
         let _span =
             tracing::debug_span!(target: "chain", "Process block", "#{}", block.header().height())
                 .entered();
-        let prev_hash = block.header().prev_hash();
-        let prev_block = self.chain_store_update.get_block(prev_hash)?.clone();
 
         let (apply_chunk_work, BlockPreprocessInfo { state_dl_info, incoming_receipts }) =
             self.preprocess_block(me, block, provenance, on_challenge)?;
 
+        let prev_hash = block.header().prev_hash();
+        let prev_block = self.chain_store_update.get_block(prev_hash)?.clone();
         self.apply_chunks_and_process_results(block, &prev_block, apply_chunk_work)?;
 
         for (shard_id, receipt_proofs) in incoming_receipts {

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -122,6 +122,7 @@ enum ApplyChunksMode {
 struct BlockPreprocessInfo {
     state_dl_info: Option<StateSyncInfo>,
     incoming_receipts: HashMap<ShardId, Vec<ReceiptProof>>,
+    challenges_result: ChallengesResult,
 }
 
 /// Orphan is a block whose previous block is not accepted (in store) yet.
@@ -4451,7 +4452,10 @@ impl<'a> ChainUpdate<'a> {
             )?
         };
 
-        Ok((apply_chunk_work, BlockPreprocessInfo { state_dl_info, incoming_receipts }))
+        Ok((
+            apply_chunk_work,
+            BlockPreprocessInfo { state_dl_info, incoming_receipts, challenges_result },
+        ))
     }
 
     /// Runs the block processing, including validation and finding a place for the new block in the chain.
@@ -4467,8 +4471,10 @@ impl<'a> ChainUpdate<'a> {
             tracing::debug_span!(target: "chain", "Process block", "#{}", block.header().height())
                 .entered();
 
-        let (apply_chunk_work, BlockPreprocessInfo { state_dl_info, incoming_receipts }) =
-            self.preprocess_block(me, block, provenance, on_challenge)?;
+        let (
+            apply_chunk_work,
+            BlockPreprocessInfo { state_dl_info, incoming_receipts, challenges_result },
+        ) = self.preprocess_block(me, block, provenance, on_challenge)?;
 
         let prev_hash = block.header().prev_hash();
         let prev_block = self.chain_store_update.get_block(prev_hash)?.clone();

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -1731,7 +1731,6 @@ fn test_tx_forward_around_epoch_boundary() {
 /// Blocks that have already been gc'ed should not be accepted again.
 #[test]
 fn test_not_resync_old_blocks() {
-    init_integration_logger();
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     let epoch_length = 5;
     genesis.config.epoch_length = epoch_length;
@@ -1750,7 +1749,6 @@ fn test_not_resync_old_blocks() {
         let block = blocks[i as usize - 1].clone();
         assert!(env.clients[0].chain.get_block(block.hash()).is_err());
         let (_, res) = env.clients[0].process_block(block.into(), Provenance::NONE);
-        println!("{:?}", res);
         assert!(matches!(res, Err(x) if matches!(x.kind(), ErrorKind::Orphan)));
         assert_eq!(env.clients[0].chain.orphans_len(), 0);
     }

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -1731,6 +1731,7 @@ fn test_tx_forward_around_epoch_boundary() {
 /// Blocks that have already been gc'ed should not be accepted again.
 #[test]
 fn test_not_resync_old_blocks() {
+    init_integration_logger();
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     let epoch_length = 5;
     genesis.config.epoch_length = epoch_length;
@@ -1749,6 +1750,7 @@ fn test_not_resync_old_blocks() {
         let block = blocks[i as usize - 1].clone();
         assert!(env.clients[0].chain.get_block(block.hash()).is_err());
         let (_, res) = env.clients[0].process_block(block.into(), Provenance::NONE);
+        println!("{:?}", res);
         assert!(matches!(res, Err(x) if matches!(x.kind(), ErrorKind::Orphan)));
         assert_eq!(env.clients[0].chain.orphans_len(), 0);
     }


### PR DESCRIPTION
Refactoring ChainUpdate::process_block to move the processing before apply_chunks to a new function preprocess_block. Later, the preprocess_block function will be moved to Chain, because there should be no chain update in this function.