### PR TITLE
relax ulimit check for nix sandbox build

### DIFF
--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -149,13 +149,15 @@ fn ensure_max_open_files_limit(max_open_files: i32) -> () {
     let (soft, hard) = rlimit::Resource::NOFILE.get().unwrap();
     let required = max_open_files as u64 + 1025;
     if soft < required {
-        assert!(
-            hard >= required,
-            "Can't run near binary since hard limit for the number \
-                of opened files is too small: {} required: {}",
-            hard,
-            required
-        );
+        if hard < required {
+            warn!(
+                "Cannot increase hard limit limit for the number \
+                 of opened files current: {} required: {}",
+                hard,
+                required
+            );
+            return;
+        }
         rlimit::Resource::NOFILE.set(required, hard).unwrap();
     }
 }


### PR DESCRIPTION
On nixos the nix-daemon limits files to 4096 by default...
In our tests we probably don't need more than that...