### PR TITLE
added ignoring unparseable messages

### DIFF
--- a/pytest/lib/peer.py
+++ b/pytest/lib/peer.py
@@ -43,9 +43,14 @@ class Connection:
             # Connection was closed on the other side
             if response_raw is None:
                 return None
-
-            response = BinarySerializer(schema).deserialize(
-                response_raw, PeerMessage)
+            # TODO(CP-85): when removing borsh support, fix this to use protobufs,
+            # (or preferably reimplement the test in rust).
+            try:
+                response = BinarySerializer(schema).deserialize(
+                    response_raw, PeerMessage)
+            except IndexError:
+                # unparsable message, ignore.
+                continue
 
             if expected is None or response.enum == expected or (
                     callable(expected) and expected(response)):

--- a/pytest/lib/proxy.py
+++ b/pytest/lib/proxy.py
@@ -86,8 +86,14 @@ class ProxyHandler:
         sender_ordinal = port_holder_to_node_ord(sender_port_holder)
         receiver_ordinal = port_holder_to_node_ord(receiver_port_holder)
         try:
-            message = BinarySerializer(schema).deserialize(
-                raw_message, PeerMessage)
+            # TODO(CP-85): when removing borsh support, fix this to use protobufs,
+            # (or preferably reimplement the test in rust).
+            try:
+                message = BinarySerializer(schema).deserialize(
+                    raw_message, PeerMessage)
+            except IndexError:
+                # unparsable message, ignore.
+                return
             assert BinarySerializer(schema).serialize(message) == raw_message
 
             if message.enum == 'Handshake':


### PR DESCRIPTION
This fixes the python tests which were broken by https://github.com/near/nearcore/commit/0d879ac
nayduck run: https://nayduck.near.org/#/run/2491
There are 8 tests that are still failing, but they started failing even before my PR was merged.