### PR TITLE
client: don’t update validators produced counters when syncing

### DIFF
--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1757,13 +1757,16 @@ impl ClientActor {
             None
         };
 
-        let epoch_identifier = ValidatorInfoIdentifier::BlockHash(head.last_block_hash);
-        let validator_epoch_stats = self
-            .client
-            .runtime_adapter
-            .get_validator_info(epoch_identifier)
-            .map(get_validator_epoch_stats)
-            .unwrap_or_default();
+        let validator_epoch_stats = if is_syncing {
+            Default::default()
+        } else {
+            let epoch_identifier = ValidatorInfoIdentifier::BlockHash(head.last_block_hash);
+            self.client
+                .runtime_adapter
+                .get_validator_info(epoch_identifier)
+                .map(get_validator_epoch_stats)
+                .unwrap_or_default()
+        };
         let statistics = if self.client.config.enable_statistics_export {
             self.client.chain.store().get_store_statistics()
         } else {

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1758,6 +1758,14 @@ impl ClientActor {
         };
 
         let validator_epoch_stats = if is_syncing {
+            // EpochManager::get_validator_info method (which is what runtime
+            // adapter calls) is expensive when node is syncing so we’re simply
+            // not collecting the statistics.  The statistics are used to update
+            // a few Prometheus metrics only so we prefer to leave the metrics
+            // unset until node finishes synchronising.  TODO(#6763): If we
+            // manage to get get_validator_info fasts again (or return an error
+            // if computation would be too slow), remove the ‘if is_syncing’
+            // check.
             Default::default()
         } else {
             let epoch_identifier = ValidatorInfoIdentifier::BlockHash(head.last_block_hash);


### PR DESCRIPTION
EpochManager::get_validator_info call querying information by block
hash turns out to be quite expensive while node is synchronising.

Normally, EpochManager maintains validator information up to the
latest final block.  With that, calling get_validator_info with
a block hash usually needs to iterate over only a handful of blocks
until it hits the latest final block and then can read the already
aggregated data.

However, while node is syncing, the aggregated data is not maintained.
This means that getting validator info for a given block requires
iteration over all blocks until start of the epoch.  This is an
expensive operation.

EpochManager::get_validator_info is called each time stats line is
generated.  When synchronising this ends up taking a up all of the
processing time to the point that node doesn’t respond to /status
queries.

Stop getting the validator information when node is synchronising to
avoid this problem.  The observable effect is that

- near_validators_blocks_expected,
- near_validators_blocks_produced,
- near_validators_chunks_expected and
- near_validators_chunks_produced

metrics are not updated.

Issue: https://github.com/near/nearcore/issues/6763
