### PR TITLE
Option to disable colored log output.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3061,7 +3061,9 @@ dependencies = [
 name = "near-o11y"
 version = "0.0.0"
 dependencies = [
+ "atty",
  "backtrace",
+ "clap 3.1.6",
  "once_cell",
  "opentelemetry",
  "opentelemetry-jaeger",

--- a/core/o11y/Cargo.toml
+++ b/core/o11y/Cargo.toml
@@ -9,7 +9,9 @@ readme = "README.md"
 rust-version = "1.60.0"
 
 [dependencies]
+atty = "0.2"
 backtrace = "0.3.64"
+clap = { version = "3", features = ["derive"] }
 once_cell = "1.5.2"
 opentelemetry = { version = "0.17", default-features = false, features = ["trace"] }
 opentelemetry-jaeger = "0.16"

--- a/core/o11y/src/lib.rs
+++ b/core/o11y/src/lib.rs
@@ -77,8 +77,8 @@ impl<S: tracing::Subscriber + Send + Sync> DefaultSubcriberGuard<S> {
 }
 
 /// Whether to use colored log format.
-/// Option `Auto` enables color output if the logging is done to a terminal, and disables color
-/// output if logging is done to a non-terminal, such as a file or input of another process.
+/// Option `Auto` enables color output only if the logging is done to a terminal and
+/// `NO_COLOR` environment variable is not set.
 #[derive(clap::ArgEnum, Debug, Clone)]
 pub enum ColorOutput {
     Always,
@@ -115,7 +115,7 @@ pub fn default_subscriber(
     let ansi = match color_output {
         ColorOutput::Always => true,
         ColorOutput::Never => false,
-        ColorOutput::Auto => is_terminal(),
+        ColorOutput::Auto => std::env::var_os("NO_COLOR").is_none() && is_terminal(),
     };
 
     let subscriber_builder = tracing_subscriber::FmtSubscriber::builder()

--- a/core/o11y/src/lib.rs
+++ b/core/o11y/src/lib.rs
@@ -100,7 +100,7 @@ fn is_terminal() -> bool {
 ///
 /// ```rust
 /// let filter = near_o11y::EnvFilterBuilder::from_env().finish().unwrap();
-/// let _subscriber = near_o11y::default_subscriber(filter, ColorOutput::Color);
+/// let _subscriber = near_o11y::default_subscriber(filter, ColorOutput::Auto);
 /// near_o11y::tracing::info!(message = "Still a lot of work remains to make it proper o11y");
 /// ```
 pub fn default_subscriber(

--- a/core/o11y/src/lib.rs
+++ b/core/o11y/src/lib.rs
@@ -100,7 +100,7 @@ fn is_terminal() -> bool {
 ///
 /// ```rust
 /// let filter = near_o11y::EnvFilterBuilder::from_env().finish().unwrap();
-/// let _subscriber = near_o11y::default_subscriber(filter, ColorOutput::Auto);
+/// let _subscriber = near_o11y::default_subscriber(filter, near_o11y::ColorOutput::Auto);
 /// near_o11y::tracing::info!(message = "Still a lot of work remains to make it proper o11y");
 /// ```
 pub fn default_subscriber(

--- a/core/o11y/src/lib.rs
+++ b/core/o11y/src/lib.rs
@@ -76,6 +76,21 @@ impl<S: tracing::Subscriber + Send + Sync> DefaultSubcriberGuard<S> {
     }
 }
 
+/// Whether to use colored log format.
+/// Option `Auto` enables color output if the logging is done to a terminal, and disables color
+/// output if logging is done to a non-terminal, such as a file or input of another process.
+#[derive(clap::ArgEnum, Debug, Clone)]
+pub enum ColorOutput {
+    Always,
+    Never,
+    Auto,
+}
+
+fn is_terminal() -> bool {
+    // Crate `atty` provides a platform-independent way of checking whether the output is a tty.
+    atty::is(atty::Stream::Stderr)
+}
+
 /// Run the code with a default subscriber set to the option appropriate for the NEAR code.
 ///
 /// This will override any subscribers set until now, and will be in effect until the value
@@ -85,18 +100,26 @@ impl<S: tracing::Subscriber + Send + Sync> DefaultSubcriberGuard<S> {
 ///
 /// ```rust
 /// let filter = near_o11y::EnvFilterBuilder::from_env().finish().unwrap();
-/// let _subscriber = near_o11y::default_subscriber(filter);
+/// let _subscriber = near_o11y::default_subscriber(filter, ColorOutput::Color);
 /// near_o11y::tracing::info!(message = "Still a lot of work remains to make it proper o11y");
 /// ```
 pub fn default_subscriber(
     log_filter: EnvFilter,
+    color_output: ColorOutput,
 ) -> DefaultSubcriberGuard<impl tracing::Subscriber + Send + Sync> {
     // Do not lock the `stderr` here to allow for things like `dbg!()` work during development.
     let stderr = std::io::stderr();
     let lined_stderr = std::io::LineWriter::new(stderr);
     let (writer, writer_guard) = tracing_appender::non_blocking(lined_stderr);
 
+    let ansi = match color_output {
+        ColorOutput::Always => true,
+        ColorOutput::Never => false,
+        ColorOutput::Auto => is_terminal(),
+    };
+
     let subscriber_builder = tracing_subscriber::FmtSubscriber::builder()
+        .with_ansi(ansi)
         .with_span_events(
             tracing_subscriber::fmt::format::FmtSpan::ENTER
                 | tracing_subscriber::fmt::format::FmtSpan::CLOSE,

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -1,7 +1,7 @@
 use crate::log_config_watcher::{LogConfigWatcher, UpdateBehavior};
 use clap::{Args, Parser};
 use near_chain_configs::GenesisValidationMode;
-use near_o11y::{default_subscriber, BuildEnvFilterError, EnvFilterBuilder};
+use near_o11y::{default_subscriber, BuildEnvFilterError, ColorOutput, EnvFilterBuilder};
 use near_primitives::types::{Gas, NumSeats, NumShards};
 use near_state_viewer::StateViewerSubCommand;
 use near_store::db::RocksDB;
@@ -37,7 +37,7 @@ impl NeardCmd {
         } else {
             env_filter
         };
-        let _subscriber = default_subscriber(env_filter).global();
+        let _subscriber = default_subscriber(env_filter, neard_cmd.opts.color).global();
 
         info!(
             target: "neard",
@@ -141,6 +141,9 @@ struct NeardOpts {
     /// Let's you start `neard` slightly faster.
     #[clap(long)]
     pub unsafe_fast_startup: bool,
+    /// Whether the log needs to be colored.
+    #[clap(long, arg_enum, default_value = "auto")]
+    pub color: ColorOutput,
 }
 
 #[derive(Parser)]

--- a/tools/chainsync-loadtest/src/main.rs
+++ b/tools/chainsync-loadtest/src/main.rs
@@ -18,6 +18,7 @@ use near_network::routing::start_routing_table_actor;
 use near_network::test_utils::NetworkRecipient;
 use near_network::PeerManagerActor;
 use near_o11y::tracing::{error, info};
+use near_o11y::ColorOutput;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
 use nearcore::config;
@@ -134,7 +135,7 @@ fn main() {
         .finish()
         .unwrap()
         .add_directive(near_o11y::tracing::Level::INFO.into());
-    let _subscriber = near_o11y::default_subscriber(env_filter).global();
+    let _subscriber = near_o11y::default_subscriber(env_filter, ColorOutput::Auto).global();
     let orig_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |panic_info| {
         orig_hook(panic_info);

--- a/tools/indexer/example/src/main.rs
+++ b/tools/indexer/example/src/main.rs
@@ -7,6 +7,7 @@ use tracing::info;
 
 use configs::{Opts, SubCommand};
 use near_indexer;
+use near_o11y::ColorOutput;
 
 mod configs;
 
@@ -264,7 +265,7 @@ fn main() -> Result<()> {
         "nearcore=info,indexer_example=info,tokio_reactor=info,near=info,\
          stats=info,telemetry=info,indexer=info,near-performance-metrics=info",
     );
-    let _susbcriber = near_o11y::default_subscriber(env_filter).global();
+    let _susbcriber = near_o11y::default_subscriber(env_filter, ColorOutput::Auto).global();
     let opts: Opts = Opts::parse();
 
     let home_dir =

--- a/tools/restaked/src/main.rs
+++ b/tools/restaked/src/main.rs
@@ -1,16 +1,15 @@
-use std::path::Path;
-use std::sync::Arc;
-use std::time::Duration;
-
 use clap::{Arg, Command};
-
 use near_crypto::{InMemorySigner, KeyFile};
 use near_o11y::tracing::{error, info};
 use near_primitives::views::CurrentEpochValidatorInfo;
 use nearcore::config::{Config, BLOCK_PRODUCER_KICKOUT_THRESHOLD, CONFIG_FILENAME};
 use nearcore::get_default_home;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
 // TODO(1905): Move out RPC interface for transacting into separate production crate.
 use integration_tests::user::{rpc_user::RpcUser, User};
+use near_o11y::ColorOutput;
 
 const DEFAULT_WAIT_PERIOD_SEC: &str = "60";
 const DEFAULT_RPC_URL: &str = "http://localhost:3030";

--- a/tools/restaked/src/main.rs
+++ b/tools/restaked/src/main.rs
@@ -23,7 +23,7 @@ fn maybe_kicked_out(validator_info: &CurrentEpochValidatorInfo) -> bool {
 
 fn main() {
     let filter = near_o11y::EnvFilterBuilder::from_env().verbose(Some("")).finish().unwrap();
-    let _subscriber = near_o11y::default_subscriber(filter).global();
+    let _subscriber = near_o11y::default_subscriber(filter, ColorOutput::Auto).global();
     let default_home = get_default_home();
     let matches = Command::new("Key-pairs generator")
         .about(

--- a/tools/storage-usage-delta-calculator/src/main.rs
+++ b/tools/storage-usage-delta-calculator/src/main.rs
@@ -1,4 +1,5 @@
 use near_chain_configs::{Genesis, GenesisValidationMode};
+use near_o11y::ColorOutput;
 use near_primitives::runtime::config_store::RuntimeConfigStore;
 use near_primitives::state_record::StateRecord;
 use near_primitives::version::PROTOCOL_VERSION;
@@ -12,7 +13,7 @@ use tracing::debug;
 /// to get it
 fn main() -> std::io::Result<()> {
     let env_filter = near_o11y::EnvFilterBuilder::from_env().verbose(Some("")).finish().unwrap();
-    let _subscriber = near_o11y::default_subscriber(env_filter).global();
+    let _subscriber = near_o11y::default_subscriber(env_filter, ColorOutput::Auto).global();
     debug!(target: "storage-calculator", "Start");
 
     let genesis = Genesis::from_file("output.json", GenesisValidationMode::Full);


### PR DESCRIPTION
Tested by running a betanet node for 5 minutes. Both runs generated ~3.6M log lines, but file sizes differ 1.5x.
--color=always - 1.5GB
--color=never - 1.0GB

Fix #6548