### PR TITLE
chain: update build_chain test to use insta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2636,6 +2636,7 @@ dependencies = [
  "borsh",
  "chrono",
  "delay-detector",
+ "insta",
  "itertools",
  "lru",
  "near-chain-configs",

--- a/chain/chain/Cargo.toml
+++ b/chain/chain/Cargo.toml
@@ -32,6 +32,8 @@ near-primitives = { path = "../../core/primitives" }
 near-store = { path = "../../core/store" }
 
 [dev-dependencies]
+insta = "1"
+
 near-logger-utils = {path = "../../test-utils/logger"}
 
 [features]


### PR DESCRIPTION
With insta it’s much simpler to update the hashes when they change.

Furthermore, observe that empty_chain test doesn’t actually test
anything that build_chain doesn’t test already so remove it.