### PR TITLE
chore: Remove estimator from release build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ docker-nearcore-nightly:
 
 release: neard-release
 	cargo build -p store-validator --release
-	cargo build -p runtime-params-estimator --release
 	cargo build -p genesis-populate --release
 	$(MAKE) sandbox-release
 
@@ -42,7 +41,6 @@ neard-debug:
 debug: neard-debug
 	cargo build -p near-vm-runner-standalone
 	cargo build -p store-validator
-	cargo build -p runtime-params-estimator
 	cargo build -p genesis-populate
 	$(MAKE) sandbox
 
@@ -61,7 +59,6 @@ perf-debug:
 
 nightly-release: neard-nightly-release
 	cargo build -p store-validator --release --features nearcore/nightly_protocol,nearcore/nightly_protocol_features,nearcore/performance_stats,nearcore/memory_stats
-	cargo build -p runtime-params-estimator --release --features nightly_protocol,nightly_protocol_features,nearcore/nightly_protocol,nearcore/nightly_protocol_features,nearcore/performance_stats,nearcore/memory_stats
 	cargo build -p genesis-populate --release --features nearcore/nightly_protocol,nearcore/nightly_protocol_features,nearcore/performance_stats,nearcore/memory_stats
 
 neard-nightly-release:
@@ -72,7 +69,6 @@ nightly-debug:
 	cargo build -p neard --features nightly_protocol,nightly_protocol_features,performance_stats,memory_stats
 	cargo build -p near-vm-runner-standalone --features nightly_protocol,nightly_protocol_features
 	cargo build -p store-validator --features nearcore/nightly_protocol,nearcore/nightly_protocol_features,nearcore/performance_stats,nearcore/memory_stats
-	cargo build -p runtime-params-estimator --features nightly_protocol,nightly_protocol_features,nearcore/nightly_protocol,nearcore/nightly_protocol_features,nearcore/performance_stats,nearcore/memory_stats
 	cargo build -p genesis-populate --features nearcore/nightly_protocol,nearcore/nightly_protocol_features,nearcore/performance_stats,nearcore/memory_stats
 
 


### PR DESCRIPTION
The parameter estimator is not part of released binaries and only
slows down `make release` unnecessarily.

Users of the estimator are adivised to to build manually.
Or, when running a full estimation and collecting the data in the
warehouse using `cargo run -p estimator-warehouse -- estimate`,
then compilation is automatic.