### PR TITLE
feat: Adjust AltBn128 gas costs

### DIFF
--- a/core/primitives/res/runtime_configs/parameters.txt
+++ b/core/primitives/res/runtime_configs/parameters.txt
@@ -122,12 +122,12 @@ wasm_promise_and_per_promise: 5_452_176
 wasm_promise_return: 560_152_386
 wasm_validator_stake_base: 911_834_726_400
 wasm_validator_total_stake_base: 911_834_726_400
-wasm_alt_bn128_g1_multiexp_base: 713_006_929_500
-wasm_alt_bn128_g1_multiexp_element: 3_335_092_461
-wasm_alt_bn128_pairing_check_base: 9_685_508_901_000
-wasm_alt_bn128_pairing_check_element: 26_575_188_546
-wasm_alt_bn128_g1_sum_base: 3_175_314_375
-wasm_alt_bn128_g1_sum_element: 76_218_543
+wasm_alt_bn128_g1_multiexp_base: 713_000_000_000
+wasm_alt_bn128_g1_multiexp_element: 320_000_000_000
+wasm_alt_bn128_pairing_check_base: 9_686_000_000_000
+wasm_alt_bn128_pairing_check_element: 5_102_000_000_000
+wasm_alt_bn128_g1_sum_base: 3_000_000_000
+wasm_alt_bn128_g1_sum_element: 5_000_000_000
 
 # Smart contract limits
 max_gas_burnt: 200_000_000_000_000


### PR DESCRIPTION
Per element costs have still been on the per-byte values. To compensate,
multiply by factor equal to the size of the corresponding element.

- g1_multiexp: 96
- g1_sum: 65
- pairing_check: 192

Additionally, all AltBn128 parameters are now rounded to whole Ggas.