### PR TITLE
fix(network): PeerStore's cache gets out of sync

### DIFF
--- a/chain/network/src/peer_manager/peer_store.rs
+++ b/chain/network/src/peer_manager/peer_store.rs
@@ -220,7 +220,12 @@ impl PeerStore {
     fn delete_peers(&mut self, peer_ids: &[PeerId]) -> Result<(), Box<dyn std::error::Error>> {
         let mut store_update = self.store.store_update();
         for peer_id in peer_ids {
-            self.peer_states.remove(peer_id);
+            if let Some(peer_state) = self.peer_states.remove(peer_id) {
+                if let Some(addr) = peer_state.peer_info.addr {
+                    self.addr_peers.remove(&addr);
+                }
+            }
+
             store_update.delete(DBCol::Peers, &peer_id.try_to_vec()?);
         }
         store_update.commit().map_err(Into::into)
@@ -754,17 +759,6 @@ mod test {
 
     #[test]
     fn remove_blacklisted_peers_from_store() {
-        fn assert_peers(store_path: &std::path::Path, expected: &[PeerId]) {
-            let store = create_store(store_path);
-            let stored_peers: HashSet<PeerId> = HashSet::from_iter(
-                store
-                    .iter(DBCol::Peers)
-                    .map(|(key, _)| PeerId::try_from_slice(key.as_ref()).unwrap()),
-            );
-            let expected: HashSet<PeerId> = HashSet::from_iter(expected.iter().cloned());
-            assert_eq!(stored_peers, expected);
-        }
-
         let tmp_dir = tempfile::Builder::new()
             .prefix("_remove_blacklisted_peers_from_store")
             .tempdir()
@@ -783,7 +777,7 @@ mod test {
             let mut peer_store = PeerStore::new(store.clone(), &[], Default::default()).unwrap();
             peer_store.add_indirect_peers(peer_infos.clone().into_iter()).unwrap();
         }
-        assert_peers(tmp_dir.path(), &peer_ids);
+        assert_peers_in_store(tmp_dir.path(), &peer_ids);
 
         // Blacklisted peers are removed from the store.
         {
@@ -792,6 +786,60 @@ mod test {
                 Blacklist::from_iter([format!("{}", peer_infos[2].addr.unwrap())].into_iter());
             let _peer_store = PeerStore::new(store.clone(), &[], blacklist).unwrap();
         }
-        assert_peers(tmp_dir.path(), &peer_ids[0..2]);
+        assert_peers_in_store(tmp_dir.path(), &peer_ids[0..2]);
+    }
+
+    fn assert_peers_in_store(store_path: &std::path::Path, expected: &[PeerId]) {
+        let store = create_store(store_path);
+        let stored_peers: HashSet<PeerId> = HashSet::from_iter(
+            store.iter(DBCol::Peers).map(|(key, _)| PeerId::try_from_slice(key.as_ref()).unwrap()),
+        );
+        let expected: HashSet<PeerId> = HashSet::from_iter(expected.iter().cloned());
+        assert_eq!(stored_peers, expected);
+    }
+
+    fn assert_peers_in_cache(
+        peer_store: &PeerStore,
+        expected_peers: &[PeerId],
+        expected_addresses: &[SocketAddr],
+    ) {
+        let expected_peers: HashSet<&PeerId> = HashSet::from_iter(expected_peers.iter());
+        let cached_peers = HashSet::from_iter(peer_store.peer_states.keys());
+        assert_eq!(expected_peers, cached_peers);
+
+        let expected_addresses: HashSet<&SocketAddr> =
+            HashSet::from_iter(expected_addresses.iter());
+        let cached_addresses = HashSet::from_iter(peer_store.addr_peers.keys());
+        assert_eq!(expected_addresses, cached_addresses);
+    }
+
+    #[test]
+    fn test_delete_peers() {
+        let tmp_dir = tempfile::Builder::new().prefix("_test_delete_peers").tempdir().unwrap();
+        let (peer_ids, peer_infos): (Vec<_>, Vec<_>) = (0..3)
+            .map(|i| {
+                let id = get_peer_id(format!("node{}", i));
+                let info = get_peer_info(id.clone(), Some(get_addr(i)));
+                (id, info)
+            })
+            .unzip();
+        let peer_addresses =
+            peer_infos.iter().map(|info| info.addr.unwrap().clone()).collect::<Vec<_>>();
+
+        {
+            let store = create_store(tmp_dir.path());
+            let mut peer_store = PeerStore::new(store.clone(), &[], Default::default()).unwrap();
+            peer_store.add_indirect_peers(peer_infos.clone().into_iter()).unwrap();
+        }
+        assert_peers_in_store(tmp_dir.path(), &peer_ids);
+
+        {
+            let store = create_store(tmp_dir.path());
+            let mut peer_store = PeerStore::new(store.clone(), &[], Default::default()).unwrap();
+            assert_peers_in_cache(&peer_store, &peer_ids, &peer_addresses);
+            peer_store.delete_peers(&peer_ids).unwrap();
+            assert_peers_in_cache(&peer_store, &[], &[]);
+        }
+        assert_peers_in_store(tmp_dir.path(), &[]);
     }
 }

--- a/chain/network/src/peer_manager/peer_store.rs
+++ b/chain/network/src/peer_manager/peer_store.rs
@@ -803,12 +803,11 @@ mod test {
         expected_peers: &[PeerId],
         expected_addresses: &[SocketAddr],
     ) {
-        let expected_peers: HashSet<&PeerId> = HashSet::from_iter(expected_peers.iter());
+        let expected_peers: HashSet<&PeerId> = HashSet::from_iter(expected_peers);
         let cached_peers = HashSet::from_iter(peer_store.peer_states.keys());
         assert_eq!(expected_peers, cached_peers);
 
-        let expected_addresses: HashSet<&SocketAddr> =
-            HashSet::from_iter(expected_addresses.iter());
+        let expected_addresses: HashSet<&SocketAddr> = HashSet::from_iter(expected_addresses);
         let cached_addresses = HashSet::from_iter(peer_store.addr_peers.keys());
         assert_eq!(expected_addresses, cached_addresses);
     }


### PR DESCRIPTION
`PeerStore` maintains its internal cache in two maps:
https://github.com/near/nearcore/blob/dddbb6a9691d0be59bef59cf50bbf096e1b617c8/chain/network/src/peer_manager/peer_store.rs#L47-L51

In [`remove_expired`](https://github.com/near/nearcore/blob/dddbb6a9691d0be59bef59cf50bbf096e1b617c8/chain/network/src/peer_manager/peer_store.rs#L282-L299) peers are deleted (via `delete_peers`) *only* from `peer_states`
but not from `addr_peers`.

Assume a peer with address `x` was deleted via `remove_expired`. When learning
about a new indirect peer which has the same address `x`, that information is
not stored due to `x` still being in `addr_peers`:
https://github.com/near/nearcore/blob/dddbb6a9691d0be59bef59cf50bbf096e1b617c8/chain/network/src/peer_manager/peer_store.rs#L381-L389

This PR updates `delete_peers` to remove addresses from `addr_peers` and
adds `test_delete_peers`.

There's only one other call site of `delete_peers`: `PeerStore::new`. Its
behavior is not changed by this PR. The peers it deletes aren't added to the
internal cache.
