### PR TITLE
refactor: don't type-erase IO errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2646,6 +2646,7 @@ name = "near-chain"
 version = "0.0.0"
 dependencies = [
  "actix",
+ "assert_matches",
  "borsh",
  "chrono",
  "delay-detector",

--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -59,7 +59,7 @@ pub enum QueryError {
     },
 }
 
-#[derive(Eq, PartialEq, Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// The block is already known
     #[error("Block is known: {0}")]
@@ -198,7 +198,7 @@ pub enum Error {
     ChallengedBlockOnChain,
     /// IO Error.
     #[error("IO Error: {0}")]
-    IOErr(String),
+    IOErr(#[from] io::Error),
     /// Not found record in the DB.
     #[error("DB Not Found Error: {0}")]
     DBNotFoundErr(String),
@@ -289,12 +289,6 @@ impl Error {
             Error::IOErr(_) | Error::Other(_) | Error::DBNotFoundErr(_) => true,
             _ => false,
         }
-    }
-}
-
-impl From<io::Error> for Error {
-    fn from(error: io::Error) -> Self {
-        Error::IOErr(error.to_string())
     }
 }
 

--- a/chain/chain/Cargo.toml
+++ b/chain/chain/Cargo.toml
@@ -33,6 +33,7 @@ near-store = { path = "../../core/store" }
 
 [dev-dependencies]
 insta = "1"
+assert_matches = "1.5.0"
 
 near-logger-utils = {path = "../../test-utils/logger"}
 

--- a/chain/chain/src/tests/challenges.rs
+++ b/chain/chain/src/tests/challenges.rs
@@ -1,5 +1,6 @@
 use crate::test_utils::setup;
 use crate::{Block, Error};
+use assert_matches::assert_matches;
 use near_logger_utils::init_test_logger;
 
 #[test]
@@ -44,7 +45,7 @@ fn challenges_new_head_prev() {
     // Try to add a block on top of the fifth block.
 
     if let Err(e) = chain.process_block_test(&None, last_block) {
-        assert_eq!(e, Error::ChallengedBlockOnChain)
+        assert_matches!(e, Error::ChallengedBlockOnChain)
     } else {
         assert!(false);
     }

--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -1,6 +1,7 @@
 use crate::near_chain_primitives::error::BlockKnownError;
 use crate::test_utils::setup;
 use crate::{Block, ChainStoreAccess, Error};
+use assert_matches::assert_matches;
 use chrono;
 use chrono::TimeZone;
 use near_logger_utils::init_test_logger;
@@ -105,12 +106,18 @@ fn build_chain_with_orhpans() {
         CryptoHash::default(),
         None,
     );
-    assert_eq!(chain.process_block_test(&None, block).unwrap_err(), Error::Orphan);
-    assert_eq!(chain.process_block_test(&None, blocks.pop().unwrap()).unwrap_err(), Error::Orphan);
-    assert_eq!(chain.process_block_test(&None, blocks.pop().unwrap()).unwrap_err(), Error::Orphan);
+    assert_matches!(chain.process_block_test(&None, block).unwrap_err(), Error::Orphan);
+    assert_matches!(
+        chain.process_block_test(&None, blocks.pop().unwrap()).unwrap_err(),
+        Error::Orphan
+    );
+    assert_matches!(
+        chain.process_block_test(&None, blocks.pop().unwrap()).unwrap_err(),
+        Error::Orphan
+    );
     let res = chain.process_block_test(&None, blocks.pop().unwrap());
     assert_eq!(res.unwrap().unwrap().height, 10);
-    assert_eq!(
+    assert_matches!(
         chain.process_block_test(&None, blocks.pop().unwrap(),).unwrap_err(),
         Error::BlockKnown(BlockKnownError::KnownInStore)
     );

--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -183,7 +183,9 @@ pub enum GetBlockError {
 impl From<near_chain_primitives::Error> for GetBlockError {
     fn from(error: near_chain_primitives::Error) -> Self {
         match error {
-            near_chain_primitives::Error::IOErr(error_message) => Self::IOError { error_message },
+            near_chain_primitives::Error::IOErr(error) => {
+                Self::IOError { error_message: error.to_string() }
+            }
             near_chain_primitives::Error::DBNotFoundErr(error_message) => {
                 Self::UnknownBlock { error_message }
             }
@@ -254,7 +256,9 @@ pub enum GetChunkError {
 impl From<near_chain_primitives::Error> for GetChunkError {
     fn from(error: near_chain_primitives::Error) -> Self {
         match error {
-            near_chain_primitives::Error::IOErr(error_message) => Self::IOError { error_message },
+            near_chain_primitives::Error::IOErr(error) => {
+                Self::IOError { error_message: error.to_string() }
+            }
             near_chain_primitives::Error::DBNotFoundErr(error_message) => {
                 Self::UnknownBlock { error_message }
             }
@@ -379,8 +383,10 @@ pub enum StatusError {
 impl From<near_chain_primitives::error::Error> for StatusError {
     fn from(error: near_chain_primitives::error::Error) -> Self {
         match error {
+            near_chain_primitives::error::Error::IOErr(error) => {
+                Self::InternalError { error_message: error.to_string() }
+            }
             near_chain_primitives::error::Error::DBNotFoundErr(error_message)
-            | near_chain_primitives::error::Error::IOErr(error_message)
             | near_chain_primitives::error::Error::ValidatorError(error_message) => {
                 Self::InternalError { error_message }
             }
@@ -422,8 +428,8 @@ impl From<near_chain_primitives::error::Error> for GetNextLightClientBlockError 
             near_chain_primitives::error::Error::DBNotFoundErr(error_message) => {
                 Self::UnknownBlock { error_message }
             }
-            near_chain_primitives::error::Error::IOErr(error_message) => {
-                Self::InternalError { error_message }
+            near_chain_primitives::error::Error::IOErr(error) => {
+                Self::InternalError { error_message: error.to_string() }
             }
             near_chain_primitives::error::Error::EpochOutOfBounds(epoch_id) => {
                 Self::EpochOutOfBounds { epoch_id }
@@ -468,8 +474,8 @@ pub enum GetGasPriceError {
 impl From<near_chain_primitives::Error> for GetGasPriceError {
     fn from(error: near_chain_primitives::Error) -> Self {
         match error {
-            near_chain_primitives::Error::IOErr(error_message) => {
-                Self::InternalError { error_message }
+            near_chain_primitives::Error::IOErr(error) => {
+                Self::InternalError { error_message: error.to_string() }
             }
             near_chain_primitives::Error::DBNotFoundErr(error_message) => {
                 Self::UnknownBlock { error_message }
@@ -555,7 +561,7 @@ impl From<near_chain_primitives::Error> for GetValidatorInfoError {
         match error {
             near_chain_primitives::Error::DBNotFoundErr(_)
             | near_chain_primitives::Error::EpochOutOfBounds(_) => Self::UnknownEpoch,
-            near_chain_primitives::Error::IOErr(s) => Self::IOError(s),
+            near_chain_primitives::Error::IOErr(s) => Self::IOError(s.to_string()),
             _ => Self::Unreachable(error.to_string()),
         }
     }
@@ -593,7 +599,9 @@ pub enum GetStateChangesError {
 impl From<near_chain_primitives::Error> for GetStateChangesError {
     fn from(error: near_chain_primitives::Error) -> Self {
         match error {
-            near_chain_primitives::Error::IOErr(error_message) => Self::IOError { error_message },
+            near_chain_primitives::Error::IOErr(error) => {
+                Self::IOError { error_message: error.to_string() }
+            }
             near_chain_primitives::Error::DBNotFoundErr(error_message) => {
                 Self::UnknownBlock { error_message }
             }
@@ -677,8 +685,8 @@ impl From<TxStatusError> for GetExecutionOutcomeError {
 impl From<near_chain_primitives::error::Error> for GetExecutionOutcomeError {
     fn from(error: near_chain_primitives::error::Error) -> Self {
         match error {
-            near_chain_primitives::Error::IOErr(error_message) => {
-                Self::InternalError { error_message }
+            near_chain_primitives::Error::IOErr(error) => {
+                Self::InternalError { error_message: error.to_string() }
             }
             near_chain_primitives::Error::DBNotFoundErr(error_message) => {
                 Self::UnknownBlock { error_message }
@@ -768,7 +776,7 @@ pub enum GetReceiptError {
 impl From<near_chain_primitives::Error> for GetReceiptError {
     fn from(error: near_chain_primitives::Error) -> Self {
         match error {
-            near_chain_primitives::Error::IOErr(s) => Self::IOError(s),
+            near_chain_primitives::Error::IOErr(error) => Self::IOError(error.to_string()),
             _ => Self::Unreachable(error.to_string()),
         }
     }
@@ -801,7 +809,7 @@ pub enum GetProtocolConfigError {
 impl From<near_chain_primitives::Error> for GetProtocolConfigError {
     fn from(error: near_chain_primitives::Error) -> Self {
         match error {
-            near_chain_primitives::Error::IOErr(s) => Self::IOError(s),
+            near_chain_primitives::Error::IOErr(error) => Self::IOError(error.to_string()),
             near_chain_primitives::Error::DBNotFoundErr(s) => Self::UnknownBlock(s),
             _ => Self::Unreachable(error.to_string()),
         }

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1447,7 +1447,7 @@ impl Client {
                 account_id,
             ) {
                 Ok(_) => next_block_epoch_id.clone(),
-                Err(e) if e == near_chain::Error::NotAValidator => {
+                Err(near_chain::Error::NotAValidator) => {
                     match self.runtime_adapter.get_next_epoch_id_from_prev_block(&parent_hash) {
                         Ok(next_block_next_epoch_id) => next_block_next_epoch_id,
                         Err(_) => return,

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -224,8 +224,8 @@ impl ViewClientActor {
                                 block_reference: msg.block_reference.clone(),
                             }
                         }
-                        near_chain::near_chain_primitives::Error::IOErr(error_message) => {
-                            QueryError::InternalError { error_message }
+                        near_chain::near_chain_primitives::Error::IOErr(error) => {
+                            QueryError::InternalError { error_message: error.to_string() }
                         }
                         _ => QueryError::Unreachable { error_message: err.to_string() },
                     })?
@@ -241,8 +241,8 @@ impl ViewClientActor {
                 near_chain::near_chain_primitives::Error::DBNotFoundErr(_) => {
                     QueryError::UnknownBlock { block_reference: msg.block_reference.clone() }
                 }
-                near_chain::near_chain_primitives::Error::IOErr(error_message) => {
-                    QueryError::InternalError { error_message }
+                near_chain::near_chain_primitives::Error::IOErr(error) => {
+                    QueryError::InternalError { error_message: error.to_string() }
                 }
                 _ => QueryError::Unreachable { error_message: err.to_string() },
             })?
@@ -283,8 +283,8 @@ impl ViewClientActor {
                     }
                     Err(err) => QueryError::InternalError { error_message: err.to_string() },
                 },
-                near_chain::near_chain_primitives::Error::IOErr(error_message) => {
-                    QueryError::InternalError { error_message }
+                near_chain::near_chain_primitives::Error::IOErr(error) => {
+                    QueryError::InternalError { error_message: error.to_string() }
                 }
                 _ => QueryError::Unreachable { error_message: err.to_string() },
             })?;

--- a/integration-tests/src/tests/client/challenges.rs
+++ b/integration-tests/src/tests/client/challenges.rs
@@ -1,8 +1,5 @@
-use std::path::Path;
-use std::sync::Arc;
-
+use assert_matches::assert_matches;
 use borsh::BorshSerialize;
-
 use near_chain::missing_chunks::MissingChunksPool;
 use near_chain::types::BlockEconomicsConfig;
 use near_chain::validate::validate_challenge;
@@ -34,6 +31,8 @@ use near_primitives::version::PROTOCOL_VERSION;
 use near_store::test_utils::create_test_store;
 use nearcore::config::{GenesisExt, FISHERMEN_THRESHOLD};
 use nearcore::NightshadeRuntime;
+use std::path::Path;
+use std::sync::Arc;
 
 /// Check that block containing a challenge is rejected.
 /// TODO (#2445): Enable challenges when they are working correctly.
@@ -62,7 +61,7 @@ fn test_block_with_challenges() {
     }
 
     let (_, result) = env.clients[0].process_block(block.into(), Provenance::NONE);
-    assert_eq!(result.unwrap_err(), Error::InvalidChallengeRoot);
+    assert_matches!(result.unwrap_err(), Error::InvalidChallengeRoot);
 }
 
 #[test]
@@ -197,7 +196,7 @@ fn test_verify_chunk_proofs_malicious_challenge_no_changes() {
     let shard_id = chunk.shard_id();
     let challenge_result =
         challenge(env, shard_id as usize, MaybeEncodedShardChunk::Encoded(chunk), &block);
-    assert_eq!(challenge_result.unwrap_err(), Error::MaliciousChallenge);
+    assert_matches!(challenge_result.unwrap_err(), Error::MaliciousChallenge);
 }
 
 #[test]
@@ -233,7 +232,7 @@ fn test_verify_chunk_proofs_malicious_challenge_valid_order_transactions() {
     let shard_id = chunk.shard_id();
     let challenge_result =
         challenge(env, shard_id as usize, MaybeEncodedShardChunk::Encoded(chunk), &block);
-    assert_eq!(challenge_result.unwrap_err(), Error::MaliciousChallenge);
+    assert_matches!(challenge_result.unwrap_err(), Error::MaliciousChallenge);
 }
 
 #[test]
@@ -457,7 +456,7 @@ fn test_verify_chunk_invalid_state_challenge() {
     let runtime_adapter = client.chain.runtime_adapter.clone();
     // Invalidate chunk state challenges because they are not supported yet.
     // TODO (#2445): Enable challenges when they are working correctly.
-    assert_eq!(
+    assert_matches!(
         validate_challenge(
             &*runtime_adapter,
             block.header().epoch_id(),


### PR DESCRIPTION
This changes from `IOErr(String)` to `IOErr(io::Error)`, so we don't
lose specific error. The consequence here is that Error is no longer Eq,
so the tests are adjusted accordingly.

In general, errors should be neither Eq nor Clone, they are not values.

Often times, when an error feels like a value, it means that the error
type wants to be split in two, from `Result<T, Error>` into
`Result<Result<T, InvalidTx>, io::Error>` where the outer Error captures
real errors/exceptions (such as the database having a bad day), and
internal error is just a normal outcome of a request processing.