### PR TITLE
chain: refactor AdversarialControls to reduce conditional compilation

### DIFF
--- a/chain/client/src/adversarial.rs
+++ b/chain/client/src/adversarial.rs
@@ -1,0 +1,84 @@
+#[cfg(feature = "test_features")]
+mod adv {
+    use std::sync::atomic::Ordering;
+
+    #[derive(Default)]
+    struct Inner {
+        disable_header_sync: std::sync::atomic::AtomicBool,
+        disable_doomslug: std::sync::atomic::AtomicBool,
+        // Negative values mean None, non-negative values mean Some(sync_height
+        // as u64).  This is only for testig so we can live with not supporting
+        // values over i64::MAX.
+        sync_height: std::sync::atomic::AtomicI64,
+        is_archival: bool,
+    }
+
+    #[derive(Default, Clone)]
+    pub struct Controls(std::sync::Arc<Inner>);
+
+    impl Controls {
+        pub fn new(is_archival: bool) -> Self {
+            Self(std::sync::Arc::new(Inner { is_archival, ..Inner::default() }))
+        }
+
+        pub fn disable_header_sync(&self) -> bool {
+            self.0.disable_header_sync.load(Ordering::SeqCst)
+        }
+
+        pub fn set_disable_header_sync(&mut self, value: bool) {
+            self.0.disable_header_sync.store(value, Ordering::SeqCst);
+        }
+
+        pub fn disable_doomslug(&self) -> bool {
+            self.0.disable_doomslug.load(Ordering::SeqCst)
+        }
+
+        pub fn set_disable_doomslug(&self, value: bool) {
+            self.0.disable_doomslug.store(value, Ordering::SeqCst);
+        }
+
+        pub fn sync_height(&self) -> Option<u64> {
+            let value = self.0.sync_height.load(Ordering::SeqCst);
+            if value < 0 {
+                None
+            } else {
+                Some(value as u64)
+            }
+        }
+
+        pub fn set_sync_height(&self, height: u64) {
+            let value: i64 = height.try_into().unwrap();
+            self.0.sync_height.store(value, Ordering::SeqCst);
+        }
+
+        pub fn is_archival(&self) -> bool {
+            self.0.is_archival
+        }
+    }
+}
+
+#[cfg(not(feature = "test_features"))]
+mod adv {
+    #[derive(Default, Clone)]
+    pub struct Controls;
+
+    impl Controls {
+        pub const fn new(_is_archival: bool) -> Self {
+            Self
+        }
+
+        pub const fn disable_header_sync(&self) -> bool {
+            false
+        }
+
+        pub const fn disable_doomslug(&self) -> bool {
+            false
+        }
+
+        pub const fn sync_height(&self) -> Option<u64> {
+            None
+        }
+    }
+}
+
+pub use adv::Controls;

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -71,8 +71,7 @@ const HEAD_STALL_MULTIPLIER: u32 = 4;
 
 pub struct ClientActor {
     /// Adversarial controls
-    #[cfg(feature = "test_features")]
-    pub adv: Arc<std::sync::RwLock<crate::AdversarialControls>>,
+    pub adv: crate::adversarial::Controls,
 
     client: Client,
     network_adapter: Arc<dyn PeerManagerAdapter>,
@@ -141,7 +140,7 @@ impl ClientActor {
         rng_seed: RngSeed,
         ctx: &Context<ClientActor>,
         shutdown_signal: Option<oneshot::Sender<()>>,
-        #[cfg(feature = "test_features")] adv: Arc<std::sync::RwLock<crate::AdversarialControls>>,
+        adv: crate::adversarial::Controls,
     ) -> Result<Self, Error> {
         let state_parts_arbiter = Arbiter::new();
         let self_addr = ctx.address();
@@ -169,7 +168,6 @@ impl ClientActor {
 
         let now = Utc::now();
         Ok(ClientActor {
-            #[cfg(feature = "test_features")]
             adv,
             client,
             network_adapter,
@@ -283,14 +281,14 @@ impl ClientActor {
                 return match adversarial_msg {
                     near_network_primitives::types::NetworkAdversarialMessage::AdvDisableDoomslug => {
                         info!(target: "adversary", "Turning Doomslug off");
-                        self.adv.write().unwrap().adv_disable_doomslug = true;
+                        self.adv.set_disable_doomslug(true);
                         self.client.doomslug.adv_disable();
                         self.client.chain.adv_disable_doomslug();
                         NetworkClientResponses::NoResponse
                     }
                     near_network_primitives::types::NetworkAdversarialMessage::AdvDisableHeaderSync => {
                         info!(target: "adversary", "Blocking header sync");
-                        self.adv.write().unwrap().adv_disable_header_sync = true;
+                        self.adv.set_disable_header_sync(true);
                         NetworkClientResponses::NoResponse
                     }
                     near_network_primitives::types::NetworkAdversarialMessage::AdvProduceBlocks(num_blocks, only_valid) => {
@@ -361,7 +359,7 @@ impl ClientActor {
                             genesis,
                             self.client.runtime_adapter.clone(),
                             self.client.chain.store().store().clone(),
-                            self.adv.read().unwrap().is_archival,
+                            self.adv.is_archival(),
                         );
                         store_validator.set_timeout(timeout);
                         store_validator.validate();
@@ -1561,14 +1559,7 @@ impl ClientActor {
     }
 
     fn needs_syncing(&self, needs_syncing: bool) -> bool {
-        #[cfg(feature = "test_features")]
-        {
-            if self.adv.read().unwrap().adv_disable_header_sync {
-                return false;
-            }
-        }
-
-        needs_syncing
+        !self.adv.disable_header_sync() && needs_syncing
     }
 
     /// Starts syncing and then switches to either syncing or regular mode.
@@ -2084,7 +2075,7 @@ pub fn start_client(
     validator_signer: Option<Arc<dyn ValidatorSigner>>,
     telemetry_actor: Addr<TelemetryActor>,
     sender: Option<oneshot::Sender<()>>,
-    #[cfg(feature = "test_features")] adv: Arc<std::sync::RwLock<crate::AdversarialControls>>,
+    adv: crate::adversarial::Controls,
 ) -> (Addr<ClientActor>, ArbiterHandle) {
     let client_arbiter = Arbiter::new();
     let client_arbiter_handle = client_arbiter.handle();
@@ -2101,7 +2092,6 @@ pub fn start_client(
             random_seed_from_thread(),
             ctx,
             sender,
-            #[cfg(feature = "test_features")]
             adv,
         )
         .unwrap()

--- a/chain/client/src/lib.rs
+++ b/chain/client/src/lib.rs
@@ -9,10 +9,9 @@ pub use near_client_primitives::types::{
 
 pub use crate::client::Client;
 pub use crate::client_actor::{start_client, ClientActor};
-#[cfg(feature = "test_features")]
-pub use crate::view_client::AdversarialControls;
 pub use crate::view_client::{start_view_client, ViewClientActor};
 
+pub mod adversarial;
 mod client;
 mod client_actor;
 mod info;

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -47,8 +47,6 @@ use near_store::test_utils::create_test_store;
 use near_store::Store;
 use near_telemetry::TelemetryActor;
 
-#[cfg(feature = "test_features")]
-use crate::AdversarialControls;
 use crate::{start_view_client, Client, ClientActor, SyncStatus, ViewClientActor};
 use near_chain::chain::{do_apply_chunks, BlockCatchUpRequest, StateSplitRequest};
 use near_chain::types::AcceptedBlock;
@@ -136,8 +134,7 @@ pub fn setup(
         epoch_sync_enabled,
     );
 
-    #[cfg(feature = "test_features")]
-    let adv = Arc::new(RwLock::new(AdversarialControls::default()));
+    let adv = crate::adversarial::Controls::default();
 
     let view_client_addr = start_view_client(
         Some(signer.validator_id().clone()),
@@ -145,7 +142,6 @@ pub fn setup(
         runtime.clone(),
         network_adapter.clone(),
         config.clone(),
-        #[cfg(feature = "test_features")]
         adv.clone(),
     );
 
@@ -161,7 +157,6 @@ pub fn setup(
         TEST_SEED,
         ctx,
         None,
-        #[cfg(feature = "test_features")]
         adv,
     )
     .unwrap();
@@ -229,8 +224,7 @@ pub fn setup_only_view(
         epoch_sync_enabled,
     );
 
-    #[cfg(feature = "test_features")]
-    let adv = Arc::new(RwLock::new(AdversarialControls::default()));
+    let adv = crate::adversarial::Controls::default();
 
     start_view_client(
         Some(signer.validator_id().clone()),
@@ -238,8 +232,7 @@ pub fn setup_only_view(
         runtime,
         network_adapter.clone(),
         config,
-        #[cfg(feature = "test_features")]
-        adv.clone(),
+        adv,
     )
 }
 

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -81,26 +81,9 @@ pub struct ViewClientRequestManager {
     pub receipt_outcome_requests: lru::LruCache<CryptoHash, Instant>,
 }
 
-#[cfg(feature = "test_features")]
-#[derive(Default)]
-pub struct AdversarialControls {
-    pub adv_disable_header_sync: bool,
-    pub adv_disable_doomslug: bool,
-    pub adv_sync_height: Option<u64>,
-    pub is_archival: bool,
-}
-
-#[cfg(feature = "test_features")]
-impl AdversarialControls {
-    pub fn new(is_archival: bool) -> Self {
-        Self { is_archival, ..Self::default() }
-    }
-}
-
 /// View client provides currently committed (to the storage) view of the current chain and state.
 pub struct ViewClientActor {
-    #[cfg(feature = "test_features")]
-    pub adv: Arc<RwLock<AdversarialControls>>,
+    pub adv: crate::adversarial::Controls,
 
     /// Validator account (if present).
     validator_account_id: Option<AccountId>,
@@ -135,7 +118,7 @@ impl ViewClientActor {
         network_adapter: Arc<dyn PeerManagerAdapter>,
         config: ClientConfig,
         request_manager: Arc<RwLock<ViewClientRequestManager>>,
-        #[cfg(feature = "test_features")] adv: Arc<RwLock<AdversarialControls>>,
+        adv: crate::adversarial::Controls,
     ) -> Result<Self, Error> {
         // TODO: should we create shared ChainStore that is passed to both Client and ViewClient?
         let chain = Chain::new_for_view_client(
@@ -145,7 +128,6 @@ impl ViewClientActor {
             !config.archive,
         )?;
         Ok(ViewClientActor {
-            #[cfg(feature = "test_features")]
             adv,
             validator_account_id,
             chain,
@@ -502,14 +484,11 @@ impl ViewClientActor {
     }
 
     fn get_height(&self, head: &Tip) -> BlockHeight {
-        #[cfg(feature = "test_features")]
-        {
-            if let Some(height) = self.adv.read().unwrap().adv_sync_height {
-                return height;
-            }
+        if let Some(height) = self.adv.sync_height() {
+            height
+        } else {
+            head.height
         }
-
-        head.height
     }
 
     fn check_state_sync_request(&self) -> bool {
@@ -1043,18 +1022,18 @@ impl Handler<NetworkViewClientMessages> for ViewClientActor {
                 return match adversarial_msg {
                     NetworkAdversarialMessage::AdvDisableDoomslug => {
                         info!(target: "adversary", "Turning Doomslug off");
-                        self.adv.write().unwrap().adv_disable_doomslug = true;
+                        self.adv.set_disable_doomslug(true);
                         self.chain.adv_disable_doomslug();
                         NetworkViewClientResponses::NoResponse
                     }
                     NetworkAdversarialMessage::AdvSetSyncInfo(height) => {
                         info!(target: "adversary", "Setting adversarial sync height: {}", height);
-                        self.adv.write().unwrap().adv_sync_height = Some(height);
+                        self.adv.set_sync_height(height);
                         NetworkViewClientResponses::NoResponse
                     }
                     NetworkAdversarialMessage::AdvDisableHeaderSync => {
                         info!(target: "adversary", "Blocking header sync");
-                        self.adv.write().unwrap().adv_disable_header_sync = true;
+                        self.adv.set_disable_header_sync(true);
                         NetworkViewClientResponses::NoResponse
                     }
                     NetworkAdversarialMessage::AdvSwitchToHeight(height) => {
@@ -1147,14 +1126,9 @@ impl Handler<NetworkViewClientMessages> for ViewClientActor {
                 }
             }
             NetworkViewClientMessages::BlockHeadersRequest(hashes) => {
-                #[cfg(feature = "test_features")]
-                {
-                    if self.adv.read().unwrap().adv_disable_header_sync {
-                        return NetworkViewClientResponses::NoResponse;
-                    }
-                }
-
-                if let Ok(headers) = self.retrieve_headers(hashes) {
+                if self.adv.disable_header_sync() {
+                    NetworkViewClientResponses::NoResponse
+                } else if let Ok(headers) = self.retrieve_headers(hashes) {
                     NetworkViewClientResponses::BlockHeaders(headers)
                 } else {
                     NetworkViewClientResponses::NoResponse
@@ -1395,7 +1369,7 @@ pub fn start_view_client(
     runtime_adapter: Arc<dyn RuntimeAdapter>,
     network_adapter: Arc<dyn PeerManagerAdapter>,
     config: ClientConfig,
-    #[cfg(feature = "test_features")] adv: Arc<RwLock<AdversarialControls>>,
+    adv: crate::adversarial::Controls,
 ) -> Addr<ViewClientActor> {
     let request_manager = Arc::new(RwLock::new(ViewClientRequestManager::new()));
     SyncArbiter::start(config.view_client_threads, move || {
@@ -1412,7 +1386,6 @@ pub fn start_view_client(
             network_adapter1,
             config1,
             request_manager1,
-            #[cfg(feature = "test_features")]
             adv.clone(),
         )
         .unwrap()

--- a/integration-tests/src/tests/network/runner.rs
+++ b/integration-tests/src/tests/network/runner.rs
@@ -68,8 +68,7 @@ pub fn setup_network_node(
         let network_adapter = NetworkRecipient::default();
         network_adapter.set_recipient(ctx.address().recipient());
         let network_adapter = Arc::new(network_adapter);
-        #[cfg(feature = "test_features")]
-        let adv = Arc::new(RwLock::new(Default::default()));
+        let adv = near_client::adversarial::Controls::default();
 
         let client_actor = start_client(
             client_config.clone(),
@@ -80,7 +79,6 @@ pub fn setup_network_node(
             Some(signer),
             telemetry_actor,
             None,
-            #[cfg(feature = "test_features")]
             adv.clone(),
         )
         .0;
@@ -90,8 +88,7 @@ pub fn setup_network_node(
             runtime.clone(),
             network_adapter,
             client_config,
-            #[cfg(feature = "test_features")]
-            adv.clone(),
+            adv,
         );
 
         let routing_table_addr =

--- a/tools/mock_node/src/setup.rs
+++ b/tools/mock_node/src/setup.rs
@@ -6,8 +6,6 @@ use near_chain::{
     Chain, ChainGenesis, ChainStore, ChainStoreAccess, DoomslugThresholdMode, RuntimeAdapter,
 };
 use near_chain_configs::GenesisConfig;
-#[cfg(feature = "test_features")]
-use near_client::AdversarialControls;
 use near_client::{start_client, start_view_client, ClientActor, ViewClientActor};
 use near_epoch_manager::EpochManager;
 use near_network::test_utils::NetworkRecipient;
@@ -154,8 +152,7 @@ pub fn setup_mock_node(
 
     let node_id = PeerId::new(config.network_config.public_key.clone().into());
     let network_adapter = Arc::new(NetworkRecipient::default());
-    #[cfg(feature = "test_features")]
-    let adv = Arc::new(std::sync::RwLock::new(AdversarialControls::default()));
+    let adv = near_client::adversarial::Controls::default();
 
     // if no start height is provided for the mock network at ProduceNewBlocks mode, fall back to
     // client start height
@@ -295,7 +292,6 @@ pub fn setup_mock_node(
         config.validator_signer.clone(),
         telemetry,
         None,
-        #[cfg(feature = "test_features")]
         adv.clone(),
     );
 
@@ -305,8 +301,7 @@ pub fn setup_mock_node(
         client_runtime.clone(),
         network_adapter.clone(),
         config.client_config.clone(),
-        #[cfg(feature = "test_features")]
-        adv.clone(),
+        adv,
     );
 
     let arbiter = Arbiter::new();


### PR DESCRIPTION
Provide an ‘empty’ definition of AdversarialControls which is used
when test_features compilation feature is not enabled.  This empty
definition provides accessors to all adversarial controls always
returning non-adversarial values.

Based on the test_features flag either the empty definition (if it’s
missing) or definitinons where adversarial behaviour can be enabled
(if it’s present) is used.

With this refactoring most `#[cfg(feature = "test_features")]` guards
can be removed.  This simplifies the code by removing some of the
syntax noise.

While at it, also change the controls such that rather than using
RwLock all the options are stored in atomic values.  This further
simplifies the code slightly.