### PR TITLE
refactor: use built-in option to strip compiled WASM

### DIFF
--- a/runtime/runtime-params-estimator/test-contract/Cargo.toml
+++ b/runtime/runtime-params-estimator/test-contract/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["cdylib"]
 codegen-units = 1
 # Tell `rustc` to optimize for small code size.
 opt-level = "z"
+strip = true
 lto = true
 debug = false
 panic = "abort"

--- a/runtime/runtime-params-estimator/test-contract/build.sh
+++ b/runtime/runtime-params-estimator/test-contract/build.sh
@@ -39,7 +39,7 @@ unset CARGO_TARGET_DIR;
 
 # First, measure the size of the file without payload.
 rm -rf target
-RUSTFLAGS='-C link-arg=-s' cargo build --target wasm32-unknown-unknown --release $features_with_arg
+cargo build --target wasm32-unknown-unknown --release $features_with_arg
 bare_wasm=$(filesize target/wasm32-unknown-unknown/release/test_contract.wasm)
 echo ${bare_wasm}
 
@@ -48,17 +48,17 @@ echo ${bare_wasm}
 
 # 10KiB
 dd if=/dev/urandom of=./res/payload bs=$(expr 10240 - ${bare_wasm}) count=1
-RUSTFLAGS='-C link-arg=-s' cargo build --target wasm32-unknown-unknown --release  --features "payload$features_with_comma"
+cargo build --target wasm32-unknown-unknown --release  --features "payload$features_with_comma"
 cp target/wasm32-unknown-unknown/release/test_contract.wasm ./res/stable_small_contract.wasm
 
 # 100KiB
 dd if=/dev/urandom of=./res/payload bs=$(expr 102400 - ${bare_wasm}) count=1
-RUSTFLAGS='-C link-arg=-s' cargo build --target wasm32-unknown-unknown --release  --features "payload$features_with_comma"
+cargo build --target wasm32-unknown-unknown --release  --features "payload$features_with_comma"
 cp target/wasm32-unknown-unknown/release/test_contract.wasm ./res/stable_medium_contract.wasm
 
 # 1MiB
 dd if=/dev/urandom of=./res/payload bs=$(expr 1048576 - ${bare_wasm}) count=1
-RUSTFLAGS='-C link-arg=-s' cargo build --target wasm32-unknown-unknown --release  --features "payload$features_with_comma"
+cargo build --target wasm32-unknown-unknown --release  --features "payload$features_with_comma"
 cp target/wasm32-unknown-unknown/release/test_contract.wasm ./res/stable_large_contract.wasm
 
 rm ./res/payload
@@ -66,7 +66,7 @@ rm ./res/payload
 # Compiling nightly
 
 rm -rf target
-RUSTFLAGS='-C link-arg=-s' cargo build --target wasm32-unknown-unknown --release --features "nightly$features_with_comma"
+cargo build --target wasm32-unknown-unknown --release --features "nightly$features_with_comma"
 bare_wasm=$(filesize target/wasm32-unknown-unknown/release/test_contract.wasm)
 echo ${bare_wasm}
 
@@ -76,17 +76,17 @@ echo ${bare_wasm}
 # Note the base is 16057 due to alt_bn128 hardcoded input.
 # 20KiB
 dd if=/dev/urandom of=./res/payload bs=$(expr 20480 - ${bare_wasm}) count=1
-RUSTFLAGS='-C link-arg=-s' cargo build --target wasm32-unknown-unknown --release  --features "payload,nightly$features_with_comma"
+cargo build --target wasm32-unknown-unknown --release  --features "payload,nightly$features_with_comma"
 cp target/wasm32-unknown-unknown/release/test_contract.wasm ./res/nightly_small_contract.wasm
 
 # 100KiB
 dd if=/dev/urandom of=./res/payload bs=$(expr 102400 - ${bare_wasm}) count=1
-RUSTFLAGS='-C link-arg=-s' cargo build --target wasm32-unknown-unknown --release  --features "payload,nightly$features_with_comma"
+cargo build --target wasm32-unknown-unknown --release  --features "payload,nightly$features_with_comma"
 cp target/wasm32-unknown-unknown/release/test_contract.wasm ./res/nightly_medium_contract.wasm
 
 # 1MiB
 dd if=/dev/urandom of=./res/payload bs=$(expr 1048576 - ${bare_wasm}) count=1
-RUSTFLAGS='-C link-arg=-s' cargo build --target wasm32-unknown-unknown --release  --features "payload,nightly$features_with_comma"
+cargo build --target wasm32-unknown-unknown --release  --features "payload,nightly$features_with_comma"
 cp target/wasm32-unknown-unknown/release/test_contract.wasm ./res/nightly_large_contract.wasm
 
 rm ./res/payload

--- a/runtime/runtime-params-estimator/test-contract/src/lib.rs
+++ b/runtime/runtime-params-estimator/test-contract/src/lib.rs
@@ -1,8 +1,6 @@
 #![no_std]
 #![allow(non_snake_case)]
 
-use core::mem;
-
 #[panic_handler]
 #[no_mangle]
 pub fn panic(_info: &::core::panic::PanicInfo) -> ! {
@@ -484,6 +482,7 @@ pub unsafe fn ecrecover_10k() {
 }
 
 #[repr(C)]
+#[cfg(feature = "protocol_feature_alt_bn128")]
 struct MultiexpElem([u8; 64], [u8; 32]);
 
 // Function to measure `alt_bn128_g1_multiexp_base` and `alt_bn128_g1_multiexp_sublinear`. Also measures `base`, `write_register_base`,
@@ -500,7 +499,7 @@ pub unsafe fn alt_bn128_g1_multiexp_1_10() {
     ];
     for _ in 0..10 {
         alt_bn128_g1_multiexp(
-            mem::size_of_val(&buffer) as u64,
+            core::mem::size_of_val(&buffer) as u64,
             buffer.as_ptr() as *const u64 as u64,
             0,
         );
@@ -538,7 +537,7 @@ pub unsafe fn alt_bn128_g1_multiexp_10_10() {
     ];
     for _ in 0..10 {
         alt_bn128_g1_multiexp(
-            mem::size_of_val(&buffer) as u64,
+            core::mem::size_of_val(&buffer) as u64,
             buffer.as_ptr() as *const u64 as u64,
             0,
         );
@@ -546,6 +545,7 @@ pub unsafe fn alt_bn128_g1_multiexp_10_10() {
 }
 
 #[repr(C)]
+#[cfg(feature = "protocol_feature_alt_bn128")]
 struct SumElem(u8, [u8; 64]);
 
 // Function to measure `alt_bn128_g1_sum_base` and `alt_bn128_g1_sum_element`. Also measures `base`, `write_register_base`,
@@ -560,7 +560,11 @@ pub unsafe fn alt_bn128_g1_sum_1_1k() {
         SumElem(0, [11, 49, 94, 29, 152, 111, 116, 138, 248, 2, 184, 8, 159, 80, 169, 45, 149, 48, 32, 49, 37, 6, 133, 105, 171, 194, 120, 44, 195, 17, 180, 35, 137, 154, 4, 192, 211, 244, 93, 200, 2, 44, 0, 64, 26, 108, 139, 147, 88, 235, 242, 23, 253, 52, 110, 236, 67, 99, 176, 2, 186, 198, 228, 25]),
     ];
     for _ in 0..1_000 {
-        alt_bn128_g1_sum(mem::size_of_val(&buffer) as u64, buffer.as_ptr() as *const u64 as u64, 0);
+        alt_bn128_g1_sum(
+            core::mem::size_of_val(&buffer) as u64,
+            buffer.as_ptr() as *const u64 as u64,
+            0,
+        );
     }
 }
 
@@ -585,11 +589,16 @@ pub unsafe fn alt_bn128_g1_sum_10_1k() {
         SumElem(1, [173, 37, 223, 11, 68, 227, 111, 46, 246, 210, 31, 181, 36, 149, 221, 113, 27, 34, 156, 35, 82, 144, 38, 34, 165, 43, 130, 70, 86, 34, 148, 30, 15, 207, 202, 218, 30, 22, 143, 20, 58, 60, 133, 67, 150, 255, 65, 29, 217, 94, 89, 182, 13, 160, 65, 173, 5, 232, 223, 65, 213, 210, 55, 25]),
     ];
     for _ in 0..1_000 {
-        alt_bn128_g1_sum(mem::size_of_val(&buffer) as u64, buffer.as_ptr() as *const u64 as u64, 0);
+        alt_bn128_g1_sum(
+            core::mem::size_of_val(&buffer) as u64,
+            buffer.as_ptr() as *const u64 as u64,
+            0,
+        );
     }
 }
 
 #[repr(C)]
+#[cfg(feature = "protocol_feature_alt_bn128")]
 struct PairingElem([u8; 64], [u8; 128]);
 
 // Function to measure `alt_bn128_pairing_check_base` and `alt_bn128_pairing_check_element`. Also measures `base`, `write_register_base`,
@@ -606,7 +615,7 @@ pub unsafe fn alt_bn128_pairing_check_1_10() {
     ];
     for _ in 0..10 {
         alt_bn128_pairing_check(
-            mem::size_of_val(&buffer) as u64,
+            core::mem::size_of_val(&buffer) as u64,
             buffer.as_ptr() as *const u64 as u64,
         );
     }
@@ -643,7 +652,7 @@ pub unsafe fn alt_bn128_pairing_check_10_10() {
     ];
     for _ in 0..10 {
         alt_bn128_pairing_check(
-            mem::size_of_val(&buffer) as u64,
+            core::mem::size_of_val(&buffer) as u64,
             buffer.as_ptr() as *const u64 as u64,
         );
     }


### PR DESCRIPTION
docs: https://doc.rust-lang.org/cargo/reference/profiles.html#strip