### PR TITLE
nightly: disable tests broken due to changes to transaction pool handling

### DIFF
--- a/nightly/expensive.txt
+++ b/nightly/expensive.txt
@@ -1,16 +1,18 @@
 # catchup tests
 expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_receipts_sync_third_epoch
 expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_receipts_sync_third_epoch --features nightly
-expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_receipts_sync_last_block
-expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_receipts_sync_last_block --features nightly
+# TODO(#3284): Known issue.  Fix is incoming.
+#expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_receipts_sync_last_block
+#expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_receipts_sync_last_block --features nightly
 expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_receipts_sync_distant_epoch
 expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_receipts_sync_distant_epoch --features nightly
 expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_random_single_part_sync
 expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_random_single_part_sync --features nightly
 expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_random_single_part_sync_skip_15
 expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_random_single_part_sync_skip_15 --features nightly
-expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_random_single_part_sync_send_15
-expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_random_single_part_sync_send_15 --features nightly
+# TODO(#3284): Known issue.  Fix is incoming.
+#expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_random_single_part_sync_send_15
+#expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_random_single_part_sync_send_15 --features nightly
 expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_random_single_part_sync_non_zero_amounts
 expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_random_single_part_sync_non_zero_amounts --features nightly
 expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_random_single_part_sync_height_6

--- a/nightly/pytest-sanity.txt
+++ b/nightly/pytest-sanity.txt
@@ -48,11 +48,14 @@ pytest --timeout=3600 sanity/state_sync_massive_validator.py --features nightly
 pytest sanity/sync_chunks_from_archival.py
 pytest sanity/sync_chunks_from_archival.py --features nightly
 
-pytest sanity/rpc_tx_forwarding.py
+# TODO(#3284): Known issue.  Fix is incoming.
+#pytest sanity/rpc_tx_forwarding.py
 pytest sanity/rpc_tx_forwarding.py --features nightly
-pytest --timeout=240 sanity/skip_epoch.py
+# TODO(#3284): Known issue.  Fix is incoming.
+#pytest --timeout=240 sanity/skip_epoch.py
 pytest --timeout=240 sanity/skip_epoch.py --features nightly
-pytest --timeout=240 sanity/one_val.py
+# TODO(#3284): Known issue.  Fix is incoming.
+#pytest --timeout=240 sanity/one_val.py
 pytest --timeout=240 sanity/one_val.py nightly --features nightly
 pytest --timeout=240 sanity/lightclnt.py
 pytest --timeout=240 sanity/lightclnt.py --features nightly
@@ -86,7 +89,8 @@ pytest --timeout=300 sanity/large_messages.py
 pytest --timeout=300 sanity/large_messages.py --features nightly
 pytest --timeout=120 sanity/handshake_tie_resolution.py
 pytest --timeout=120 sanity/handshake_tie_resolution.py --features nightly
-pytest sanity/repro_2916.py
+# TODO(#3284): Known issue.  Fix is incoming.
+#pytest sanity/repro_2916.py
 pytest sanity/repro_2916.py --features nightly
 pytest --timeout=240 sanity/switch_node_key.py
 pytest --timeout=240 sanity/switch_node_key.py --features nightly


### PR DESCRIPTION
Commit a361b25e: ‘Don’t add transactions to a pool in non-validator
nodes’ broke a few nightly tests.  This is a known issue at the
moment.  Disable the tests while fix is being worked on.

Issue: https://github.com/near/nearcore/issues/3284