### PR TITLE
fix: race in NetworkRecepient 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,7 +2424,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
 dependencies = [
  "scopeguard",
- "serde",
 ]
 
 [[package]]
@@ -2435,6 +2434,7 @@ checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
 dependencies = [
  "autocfg 1.1.0",
  "scopeguard",
+ "serde",
 ]
 
 [[package]]
@@ -3711,9 +3711,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
 
 [[package]]
 name = "oorandom"
@@ -3864,7 +3864,7 @@ dependencies = [
  "paperclip-actix",
  "paperclip-core",
  "paperclip-macros",
- "parking_lot 0.10.2",
+ "parking_lot 0.12.0",
  "semver 0.9.0",
  "serde",
  "serde_derive",
@@ -3886,7 +3886,7 @@ dependencies = [
  "once_cell",
  "paperclip-core",
  "paperclip-macros",
- "parking_lot 0.10.2",
+ "parking_lot 0.12.0",
  "serde_json",
 ]
 
@@ -3900,7 +3900,7 @@ dependencies = [
  "mime",
  "once_cell",
  "paperclip-macros",
- "parking_lot 0.10.2",
+ "parking_lot 0.12.0",
  "pin-project",
  "regex",
  "serde",

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -28,7 +28,7 @@ itertools = "0.10.3"
 lru = "0.7.2"
 thiserror = "1"
 near-rust-allocator-proxy = { version = "0.4", optional = true }
-once_cell = "1.5.2"
+once_cell = "1.12.0"
 rand = "0.6"
 rand_pcg = "0.1"
 serde = { version = "1", features = ["alloc", "derive", "rc"], optional = true }


### PR DESCRIPTION
closes https://github.com/near/nearcore/issues/6826

We have circular depedencies between PeerManager and Client, which we
break via `dyn PeerManagerAdapter`. As this is a real cycle, we close it
at runtime by calling `set_recipient`. But today nothing prevents client
from sending message to network before that, and indeed that happens if
we are unlucky with timing.

This commit fixes the issue by making `PeerManagerAdapter` APIs block
until the loop is closed.

<hr/>

After finishing the implementation, I realized that this might not be the ideal solution. It seems that actix has the API ([Actor::create](https://docs.rs/actix/latest/actix/prelude/trait.Actor.html#method.create)) for tying such loop nicely, where you can get actor's address before creating the actor. We use it, for example, here: 

https://github.com/near/nearcore/blob/d18f345a7f773131134e3f5ec877b3074fec05ad/integration-tests/src/tests/network/runner.rs#L64-L70

So, in theory, we can just `impl PeerManagerAdapter for Recipient<PeerManagerMessageRequest>` and then rewrite all call-sites to use `create` and friends. 

Upon closer examination, it seems that that is possible, but not trivial, as create API is not orthogonal enough.

* we use `Actor::start_in_arbiter` and `Actor::mock`, which don't have create-like alternatives. We can open-code them, but that's adding more to the framework
* `::create` itself can't return something else, so that means we'd have to use `.unwrap`s

So I think it's better to maybe do just what this PR is doing and just fix the current code. 

Test Plan
---------

Verify that, after applying the following "unfortunate timing" diff

```diff
diff --git a/tools/mock_node/src/setup.rs b/tools/mock_node/src/setup.rs
index 30940262b..9e7493cad 100644
--- a/tools/mock_node/src/setup.rs
+++ b/tools/mock_node/src/setup.rs
@@ -322,6 +322,7 @@ pub fn setup_mock_node(
                 !archival,
             )
         });
+    std::thread::sleep_ms(300);
     network_adapter.set_recipient(mock_network_actor.clone().recipient());
 
     // for some reason, with "test_features", start_http requires PeerManagerActor,
```

The following test

```
$ cargo test --package mock_node --lib -- setup::test::test_mock_node_basic --exact --nocapture
```

fails on master and passes with this PR applied