### PR TITLE
store: prefer enum_map::EnumMap to strum’s count and iterator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1440,6 +1440,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-map"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348b2a57c82f98b9dbd8098b1abb2416f221823d3e50cbe24eaebdd16896826"
+dependencies = [
+ "enum-map-derive",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a63b7a0ddec6f38dcec5e36257750b7a8fcaf4227e12ceb306e341d63634da05"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "enumset"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3267,6 +3287,7 @@ dependencies = [
  "bytesize",
  "derive_more",
  "elastic-array",
+ "enum-map",
  "fs2",
  "lru",
  "near-crypto",

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -13,6 +13,7 @@ byteorder = "1.2"
 bytesize = { version = "1.1", features = ["serde"] }
 derive_more = "0.99.3"
 elastic-array = "0.11"
+enum-map = "2.1.0"
 rocksdb = { version = "0.18.0", default-features = false, features = ["snappy", "lz4", "zstd", "zlib"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -13,6 +13,7 @@ use strum::{EnumCount, IntoEnumIterator};
     Eq,
     BorshDeserialize,
     BorshSerialize,
+    enum_map::Enum,
     strum::EnumCount,
     strum::EnumIter,
     strum::IntoStaticStr,

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -108,8 +108,9 @@ pub struct RocksDB {
 
     /// Map from [`DBCol`] to a column family handler in the RocksDB.
     ///
-    /// Rather than reading values from it directly, use [`RocksDB::cf_handle`]
-    /// method instead which gives `&ColumnFamily` which is what you want.
+    /// Rather than accessing this field directly, use [`RocksDB::cf_handle`]
+    /// method instead.  It returns `&ColumnFamily` which is what you usually
+    /// want.
     cf_handles: enum_map::EnumMap<DBCol, std::ptr::NonNull<ColumnFamily>>,
 
     check_free_space_counter: std::sync::atomic::AtomicU16,

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -14,7 +14,6 @@ use std::path::Path;
 use std::sync::atomic::Ordering;
 use std::sync::{Condvar, Mutex, RwLock};
 use std::{cmp, fmt};
-use strum::EnumCount;
 use tracing::{error, info, warn};
 
 pub(crate) mod refcount;
@@ -106,7 +105,17 @@ impl DBTransaction {
 pub struct RocksDB {
     db: DB,
     db_opt: Options,
-    cfs: Vec<*const ColumnFamily>,
+
+    /// Map from [`DBCol`] to a column family handler in the RocksDB.
+    ///
+    /// Rather than reading values from it directly, use [`RocksDB::cf_handle`]
+    /// method instead which gives `&ColumnFamily` which is what you want.
+    ///
+    /// We’re storing `*const ColumnFamily` rather than `&ColumnFamily` because
+    /// the latter requires dealing with internal references (i.e. lifetime of
+    /// the references is the same as lifetime of `db`) and Rust doesn’t like
+    /// that.  All the pointers are guaranteed to be non-null.
+    cfs: enum_map::EnumMap<DBCol, *const ColumnFamily>,
 
     check_free_space_counter: std::sync::atomic::AtomicU16,
     check_free_space_interval: u16,
@@ -180,9 +189,13 @@ impl RocksDB {
             Self::open_read_write(path.as_ref(), store_config)
         }?;
 
-        let cfs = DBCol::iter()
-            .map(|col| db.cf_handle(&col_name(col)).unwrap() as *const ColumnFamily)
-            .collect();
+        let mut cfs = enum_map::enum_map! { _ => std::ptr::null() };
+        for col in DBCol::iter() {
+            let handle = db.cf_handle(&col_name(col));
+            let name: &str = (&col).into();
+            assert!(handle.is_some(), "Missing cf handle for {name}");
+            cfs[col] = handle.unwrap() as *const ColumnFamily;
+        }
         Ok(Self {
             db,
             db_opt,
@@ -231,10 +244,17 @@ impl RocksDB {
         }
         Ok((db, options))
     }
+
+    fn cf_handle(&self, col: DBCol) -> &ColumnFamily {
+        let ptr = self.cfs[col];
+        debug_assert!(!ptr.is_null(), "{col}");
+        // SAFETY: RocksDB::open() guarantees that all the values are non-null.
+        unsafe { &*ptr }
+    }
 }
 
 pub struct TestDB {
-    db: RwLock<Vec<HashMap<Vec<u8>, Vec<u8>>>>,
+    db: RwLock<enum_map::EnumMap<DBCol, HashMap<Vec<u8>, Vec<u8>>>>,
 }
 
 pub(crate) trait Database: Sync + Send {
@@ -267,7 +287,7 @@ impl Database for RocksDB {
             metrics::DATABASE_OP_LATENCY_HIST.with_label_values(&["get", col.into()]).start_timer();
 
         let read_options = rocksdb_read_options();
-        let result = self.db.get_cf_opt(unsafe { &*self.cfs[col as usize] }, key, &read_options)?;
+        let result = self.db.get_cf_opt(self.cf_handle(col), key, &read_options)?;
         let result = Ok(RocksDB::get_with_rc_logic(col, result));
 
         timer.observe_duration();
@@ -279,20 +299,16 @@ impl Database for RocksDB {
         col: DBCol,
     ) -> Box<dyn Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a> {
         let read_options = rocksdb_read_options();
-        unsafe {
-            let cf_handle = &*self.cfs[col as usize];
-            let iterator = self.db.iterator_cf_opt(cf_handle, read_options, IteratorMode::Start);
-            Box::new(iterator)
-        }
+        let cf_handle = self.cf_handle(col);
+        let iterator = self.db.iterator_cf_opt(cf_handle, read_options, IteratorMode::Start);
+        Box::new(iterator)
     }
 
     fn iter<'a>(&'a self, col: DBCol) -> Box<dyn Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a> {
         let read_options = rocksdb_read_options();
-        unsafe {
-            let cf_handle = &*self.cfs[col as usize];
-            let iterator = self.db.iterator_cf_opt(cf_handle, read_options, IteratorMode::Start);
-            RocksDB::iter_with_rc_logic(col, iterator)
-        }
+        let cf_handle = self.cf_handle(col);
+        let iterator = self.db.iterator_cf_opt(cf_handle, read_options, IteratorMode::Start);
+        RocksDB::iter_with_rc_logic(col, iterator)
     }
 
     fn iter_prefix<'a>(
@@ -304,20 +320,18 @@ impl Database for RocksDB {
         // `self.read_options` here.
         let mut read_options = rocksdb_read_options();
         read_options.set_prefix_same_as_start(true);
-        unsafe {
-            let cf_handle = &*self.cfs[col as usize];
-            // This implementation is copied from RocksDB implementation of `prefix_iterator_cf` since
-            // there is no `prefix_iterator_cf_opt` method.
-            let iterator = self
-                .db
-                .iterator_cf_opt(
-                    cf_handle,
-                    read_options,
-                    IteratorMode::From(key_prefix, Direction::Forward),
-                )
-                .take_while(move |(key, _value)| key.starts_with(key_prefix));
-            RocksDB::iter_with_rc_logic(col, iterator)
-        }
+        let cf_handle = self.cf_handle(col);
+        // This implementation is copied from RocksDB implementation of `prefix_iterator_cf` since
+        // there is no `prefix_iterator_cf_opt` method.
+        let iterator = self
+            .db
+            .iterator_cf_opt(
+                cf_handle,
+                read_options,
+                IteratorMode::From(key_prefix, Direction::Forward),
+            )
+            .take_while(move |(key, _value)| key.starts_with(key_prefix));
+        RocksDB::iter_with_rc_logic(col, iterator)
     }
 
     fn write(&self, transaction: DBTransaction) -> Result<(), DBError> {
@@ -332,25 +346,25 @@ impl Database for RocksDB {
         let mut batch = WriteBatch::default();
         for op in transaction.ops {
             match op {
-                DBOp::Set { col, key, value } => unsafe {
-                    batch.put_cf(&*self.cfs[col as usize], key, value);
-                },
+                DBOp::Set { col, key, value } => {
+                    batch.put_cf(self.cf_handle(col), key, value);
+                }
                 DBOp::Insert { col, key, value } => {
                     if cfg!(debug_assertions) {
                         if let Ok(Some(old_value)) = self.get(col, &key) {
                             assert_no_ovewrite(col, &key, &value, &*old_value)
                         }
                     }
-                    batch.put_cf(unsafe { &*self.cfs[col as usize] }, key, value);
+                    batch.put_cf(self.cf_handle(col), key, value);
                 }
-                DBOp::UpdateRefcount { col, key, value } => unsafe {
-                    batch.merge_cf(&*self.cfs[col as usize], key, value);
-                },
-                DBOp::Delete { col, key } => unsafe {
-                    batch.delete_cf(&*self.cfs[col as usize], key);
-                },
+                DBOp::UpdateRefcount { col, key, value } => {
+                    batch.merge_cf(self.cf_handle(col), key, value);
+                }
+                DBOp::Delete { col, key } => {
+                    batch.delete_cf(self.cf_handle(col), key);
+                }
                 DBOp::DeleteAll { col } => {
-                    let cf_handle = unsafe { &*self.cfs[col as usize] };
+                    let cf_handle = self.cf_handle(col);
                     let opt_first = self.db.iterator_cf(cf_handle, IteratorMode::Start).next();
                     let opt_last = self.db.iterator_cf(cf_handle, IteratorMode::End).next();
                     assert_eq!(opt_first.is_some(), opt_last.is_some());
@@ -386,7 +400,7 @@ impl Database for RocksDB {
 
 impl Database for TestDB {
     fn get(&self, col: DBCol, key: &[u8]) -> Result<Option<Vec<u8>>, DBError> {
-        let result = self.db.read().unwrap()[col as usize].get(key).cloned();
+        let result = self.db.read().unwrap()[col].get(key).cloned();
         Ok(RocksDB::get_with_rc_logic(col, result))
     }
 
@@ -399,7 +413,7 @@ impl Database for TestDB {
         &'a self,
         col: DBCol,
     ) -> Box<dyn Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a> {
-        let iterator = self.db.read().unwrap()[col as usize]
+        let iterator = self.db.read().unwrap()[col]
             .clone()
             .into_iter()
             .map(|(k, v)| (k.into_boxed_slice(), v.into_boxed_slice()));
@@ -422,29 +436,29 @@ impl Database for TestDB {
         for op in transaction.ops {
             match op {
                 DBOp::Set { col, key, value } => {
-                    db[col as usize].insert(key, value);
+                    db[col].insert(key, value);
                 }
                 DBOp::Insert { col, key, value } => {
                     if cfg!(debug_assertions) {
-                        if let Some(old_value) = db[col as usize].get(&key) {
+                        if let Some(old_value) = db[col].get(&key) {
                             assert_no_ovewrite(col, &key, &value, &*old_value)
                         }
                     }
-                    db[col as usize].insert(key, value);
+                    db[col].insert(key, value);
                 }
                 DBOp::UpdateRefcount { col, key, value } => {
-                    let mut val = db[col as usize].get(&key).cloned().unwrap_or_default();
+                    let mut val = db[col].get(&key).cloned().unwrap_or_default();
                     merge_refcounted_records(&mut val, &value);
                     if !val.is_empty() {
-                        db[col as usize].insert(key, val);
+                        db[col].insert(key, val);
                     } else {
-                        db[col as usize].remove(&key);
+                        db[col].remove(&key);
                     }
                 }
                 DBOp::Delete { col, key } => {
-                    db[col as usize].remove(&key);
+                    db[col].remove(&key);
                 }
-                DBOp::DeleteAll { col } => db[col as usize].clear(),
+                DBOp::DeleteAll { col } => db[col].clear(),
             };
         }
         Ok(())
@@ -712,8 +726,7 @@ impl Drop for InstanceCounter {
 
 impl TestDB {
     pub fn new() -> Self {
-        let db: Vec<_> = (0..DBCol::COUNT).map(|_| HashMap::new()).collect();
-        Self { db: RwLock::new(db) }
+        Self { db: Default::default() }
     }
 }
 
@@ -769,7 +782,7 @@ mod tests {
         #[cfg(not(feature = "single_thread_rocksdb"))]
         fn compact(&self, col: DBCol) {
             self.db.compact_range_cf(
-                unsafe { &*self.cfs[col as usize] },
+                self.cf_handle(col),
                 Option::<&[u8]>::None,
                 Option::<&[u8]>::None,
             );
@@ -781,8 +794,7 @@ mod tests {
             key: &[u8],
         ) -> Result<Option<Vec<u8>>, DBError> {
             let read_options = rocksdb_read_options();
-            let result =
-                self.db.get_cf_opt(unsafe { &*self.cfs[col as usize] }, key, &read_options)?;
+            let result = self.db.get_cf_opt(self.cf_handle(col), key, &read_options)?;
             Ok(result)
         }
     }


### PR DESCRIPTION
RocksDB and TestDB both create vectors which are meant to map from
column to some value.  The issue is that the way they are created
assumes that variants in DBCol are all listed in order of their
values, the values are all unique and there are no holes.  In other
words, removing or rearranging variants of DBCol causes things to
break.

Solve that by using enum_map::EnumMap which creates fixed-size
constant-access arrays (same as a Vec approach) but allow the map to
be indexed by the enum value itself which avoids all of the above
issues.

Furthermore, introduce RocksDB::cf_handle method which consolidates
all bunch of unsafe blocks into a single unsafe block in that method.
Having a single unsafe block makes it easier to reason about the
safety guarantees.
