### PR TITLE
chore: bump version to 0.13.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ members = [
 ]
 
 [workspace.metadata.workspaces]
-version = "0.12.0"
+version = "0.13.0"
 exclude = [ "neard" ]
 
 [patch.crates-io]


### PR DESCRIPTION
Tagged: https://github.com/near/nearcore/releases/tag/crates-0.13.0

Check here for a full changelog: https://github.com/near/nearcore/compare/crates-0.12.0...crates-0.13.0

Tested `cargo package` on each public crate locally, they all compile independently of the workspace. We should be good to go.