### PR TITLE
feat: expose logs and receipt metadata from VMLogic

### DIFF
--- a/runtime/near-vm-logic/src/logic.rs
+++ b/runtime/near-vm-logic/src/logic.rs
@@ -147,6 +147,16 @@ impl<'a> VMLogic<'a> {
         }
     }
 
+    /// Returns reference to logs that have been created so far.
+    pub fn logs(&self) -> &[String] {
+        &self.logs
+    }
+
+    /// Returns receipt metadata for created receipts
+    pub fn action_receipts(&self) -> &[(AccountId, ReceiptMetadata)] {
+        &self.receipt_manager.action_receipts
+    }
+
     #[allow(dead_code)]
     #[cfg(test)]
     pub(crate) fn receipt_manager(&self) -> &ReceiptManager {


### PR DESCRIPTION
Needed to retain functionality for unit testing within the SDK

https://github.com/near/near-sdk-rs/pull/820 is the matching PR to the SDK (and other changes needed when updating for reference)