### PR TITLE
chore: update `awc` to stable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2404,6 +2404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
 dependencies = [
  "scopeguard",
+ "serde",
 ]
 
 [[package]]
@@ -2414,7 +2415,6 @@ checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
 dependencies = [
  "autocfg 1.1.0",
  "scopeguard",
- "serde",
 ]
 
 [[package]]
@@ -3845,7 +3845,7 @@ dependencies = [
  "paperclip-actix",
  "paperclip-core",
  "paperclip-macros",
- "parking_lot 0.12.0",
+ "parking_lot 0.10.2",
  "semver 0.9.0",
  "serde",
  "serde_derive",
@@ -3867,7 +3867,7 @@ dependencies = [
  "once_cell",
  "paperclip-core",
  "paperclip-macros",
- "parking_lot 0.12.0",
+ "parking_lot 0.10.2",
  "serde_json",
 ]
 
@@ -3881,7 +3881,7 @@ dependencies = [
  "mime",
  "once_cell",
  "paperclip-macros",
- "parking_lot 0.12.0",
+ "parking_lot 0.10.2",
  "pin-project",
  "regex",
  "serde",

--- a/chain/jsonrpc/client/Cargo.toml
+++ b/chain/jsonrpc/client/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.60.0"
 edition = "2021"
 
 [dependencies]
-awc = "3.0.0-beta.5"
+awc = "3.0.0"
 actix-http = "3.0.4"
 futures = "0.3"
 serde = { version = "1", features = ["derive"] }

--- a/chain/jsonrpc/fuzz/Cargo.toml
+++ b/chain/jsonrpc/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
-awc = "3.0.0-beta.5"
+awc = "3.0.0"
 actix = "0.13.0"
 arbitrary = { version = "1", features = ["derive"] }
 base64 = "0.13"

--- a/chain/jsonrpc/jsonrpc-tests/Cargo.toml
+++ b/chain/jsonrpc/jsonrpc-tests/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 
 [dependencies]
 actix = "0.13.0"
-awc = "3.0.0-beta.5"
+awc = "3.0.0"
 once_cell = "1.5.2"
 futures = "0.3"
 borsh = "0.9"

--- a/chain/rosetta-rpc/Cargo.toml
+++ b/chain/rosetta-rpc/Cargo.toml
@@ -14,7 +14,7 @@ derive_more = "0.99.9"
 hex = "0.4"
 strum = { version = "0.24", features = ["derive"] }
 
-awc = "3.0.0-beta.5"
+awc = "3.0.0"
 actix = "0.13.0"
 actix-web = "4.0.1"
 actix-http = "3.0.4"

--- a/chain/telemetry/Cargo.toml
+++ b/chain/telemetry/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 
 [dependencies]
 openssl = { version = "0.10", features = ["vendored"] }
-awc = "3.0.0-beta.5"
+awc = "3.0.0"
 actix-web = { version = "4.0.1", features = [ "openssl" ] }
 futures = "0.3"
 actix = "0.13.0"

--- a/nearcore/Cargo.toml
+++ b/nearcore/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.51"
-awc = "3.0.0-beta.5"
+awc = "3.0.0"
 actix = "0.13.0"
 actix-web = "4.0.1"
 actix-rt = "2"


### PR DESCRIPTION
Following https://github.com/near/nearcore/issues/6694