### PR TITLE
test: fix non-determinisit tests

### DIFF
--- a/integration-tests/src/tests/runtime/sanity_checks.rs
+++ b/integration-tests/src/tests/runtime/sanity_checks.rs
@@ -101,19 +101,26 @@ fn test_cost_sanity() {
         near_test_contracts::rs_contract()
     };
     let node = setup_runtime_node_with_contract(test_contract);
-    let data = serde_json::json!({
-        "contract_code": to_base64(near_test_contracts::trivial_contract()),
-        "method_name": "main",
-        "method_args": to_base64(&[]),
-        "validator_id": bob_account().as_str(),
-    });
+
+    let args = format!(
+        r#"{{
+            "contract_code": {:?},
+            "method_name": "main",
+            "method_args": "",
+            "validator_id": {:?}
+        }}"#,
+        to_base64(near_test_contracts::trivial_contract()),
+        bob_account().as_str()
+    );
+    eprintln!("{args}");
+
     let res = node
         .user()
         .function_call(
             alice_account(),
             test_contract_account(),
             "sanity_check",
-            serde_json::to_vec(&data).unwrap(),
+            args.into_bytes(),
             MAX_GAS,
             0,
         )

--- a/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_gas_profile.snap
+++ b/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_gas_profile.snap
@@ -1,7 +1,6 @@
 ---
 source: integration-tests/src/tests/runtime/sanity_checks.rs
 expression: receipts_gas_profile
-
 ---
 [
     [
@@ -113,7 +112,7 @@ expression: receipts_gas_profile
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
             cost: "READ_REGISTER_BYTE",
-            gas_used: 18628218,
+            gas_used: 25034748,
         },
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
@@ -233,7 +232,7 @@ expression: receipts_gas_profile
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
             cost: "WASM_INSTRUCTION",
-            gas_used: 24159407184,
+            gas_used: 27893896668,
         },
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
@@ -243,7 +242,7 @@ expression: receipts_gas_profile
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
             cost: "WRITE_MEMORY_BYTE",
-            gas_used: 689114316,
+            gas_used: 866159496,
         },
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
@@ -253,7 +252,7 @@ expression: receipts_gas_profile
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
             cost: "WRITE_REGISTER_BYTE",
-            gas_used: 1170881712,
+            gas_used: 1417983372,
         },
     ],
     [

--- a/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_gas_profile_nightly.snap
+++ b/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_gas_profile_nightly.snap
@@ -142,7 +142,7 @@ expression: receipts_gas_profile
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
             cost: "READ_REGISTER_BYTE",
-            gas_used: 18628218,
+            gas_used: 25034748,
         },
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
@@ -262,7 +262,7 @@ expression: receipts_gas_profile
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
             cost: "WASM_INSTRUCTION",
-            gas_used: 24286111608,
+            gas_used: 28020601092,
         },
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
@@ -272,7 +272,7 @@ expression: receipts_gas_profile
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
             cost: "WRITE_MEMORY_BYTE",
-            gas_used: 689114316,
+            gas_used: 866159496,
         },
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
@@ -282,7 +282,7 @@ expression: receipts_gas_profile
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
             cost: "WRITE_REGISTER_BYTE",
-            gas_used: 1657481904,
+            gas_used: 1904583564,
         },
     ],
     [


### PR DESCRIPTION
The test might pass or fail depending on whether you `cargo t` or `cargo
t -p integration-tests`.

The reason for that is that `preserve_order` feature of serde_json
differs depending on which cargo command you invoke. That in turn leads
to different input to the contract.

There's two ways we can fix this:

* enableing preserve_order feature for integration tests crate
* formatting the JSON manually

I went with the second option as it seems simpler and more robust.