### PR TITLE
core: get rid of SharedChunkHeader::prev_block_hash_ref

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3872,7 +3872,7 @@ impl<'a> ChainUpdate<'a> {
                     let gas_price = prev_block.header().gas_price();
                     let random_seed = *block.header().random_value();
                     let height = chunk_header.height_included();
-                    let prev_block_hash = chunk_header.prev_block_hash();
+                    let prev_block_hash = chunk_header.prev_block_hash().clone();
                     #[cfg(feature = "sandbox")]
                     let states_to_patch = self.states_to_patch.take();
 
@@ -4307,7 +4307,7 @@ impl<'a> ChainUpdate<'a> {
             block.chunks().iter().zip(prev_chunk_headers.iter())
         {
             if chunk_header.height_included() == block.header().height() {
-                if &chunk_header.prev_block_hash() != block.header().prev_hash() {
+                if chunk_header.prev_block_hash() != block.header().prev_hash() {
                     return Err(Error::InvalidChunk.into());
                 }
             } else {

--- a/chain/chain/src/validate.rs
+++ b/chain/chain/src/validate.rs
@@ -69,10 +69,10 @@ pub fn validate_chunk_proofs(
     } else {
         let shard_layout = {
             let prev_block_hash = match chunk {
-                ShardChunk::V1(chunk) => chunk.header.inner.prev_block_hash,
+                ShardChunk::V1(chunk) => &chunk.header.inner.prev_block_hash,
                 ShardChunk::V2(chunk) => chunk.header.prev_block_hash(),
             };
-            runtime_adapter.get_shard_layout_from_prev_block(&prev_block_hash)?
+            runtime_adapter.get_shard_layout_from_prev_block(prev_block_hash)?
         };
         let outgoing_receipts_hashes = Chain::build_receipts_hashes(receipts, &shard_layout);
         let (receipts_root, _) = merklize(&outgoing_receipts_hashes);

--- a/chain/chunks/src/chunk_cache.rs
+++ b/chain/chunks/src/chunk_cache.rs
@@ -115,7 +115,7 @@ impl EncodedChunksCache {
     pub fn mark_entry_complete(&mut self, chunk_hash: &ChunkHash) {
         if let Some(entry) = self.encoded_chunks.get_mut(chunk_hash) {
             entry.complete = true;
-            let previous_block_hash = entry.header.prev_block_hash();
+            let previous_block_hash = &entry.header.prev_block_hash().clone();
             self.remove_chunk_from_incomplete_chunks(previous_block_hash, chunk_hash);
         } else {
             warn!(target:"chunks", "cannot mark non-existent entry as complete {:?}", chunk_hash);
@@ -151,10 +151,10 @@ impl EncodedChunksCache {
     // Use `mark_entry_complete` instead for outside calls
     fn remove_chunk_from_incomplete_chunks(
         &mut self,
-        prev_block_hash: CryptoHash,
+        prev_block_hash: &CryptoHash,
         chunk_hash: &ChunkHash,
     ) {
-        if let Occupied(mut entry) = self.incomplete_chunks.entry(prev_block_hash) {
+        if let Occupied(mut entry) = self.incomplete_chunks.entry(prev_block_hash.clone()) {
             entry.get_mut().remove(chunk_hash);
             if entry.get().is_empty() {
                 entry.remove();
@@ -180,7 +180,7 @@ impl EncodedChunksCache {
                 .or_default()
                 .insert(chunk_hash.clone());
             self.incomplete_chunks
-                .entry(chunk_header.prev_block_hash())
+                .entry(chunk_header.prev_block_hash().clone())
                 .or_default()
                 .insert(chunk_hash.clone());
             EncodedChunksCacheEntry::from_chunk_header(chunk_header.clone())
@@ -245,7 +245,7 @@ impl EncodedChunksCache {
         if height >= self.largest_seen_height.saturating_sub(CHUNK_HEADER_HEIGHT_HORIZON)
             && height <= self.largest_seen_height + MAX_HEIGHTS_AHEAD
         {
-            let prev_block_hash = header.prev_block_hash();
+            let prev_block_hash = header.prev_block_hash().clone();
             let mut block_hash_to_chunk_headers = self
                 .block_hash_to_chunk_headers
                 .pop(&prev_block_hash)

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -740,7 +740,7 @@ impl ShardsManager {
     /// Only marks this chunk as being requested
     /// Note no requests are actually sent at this point.
     fn request_chunk_single_mark_only(&mut self, chunk_header: &ShardChunkHeader) {
-        self.request_chunk_single(chunk_header, chunk_header.prev_block_hash(), None, false)
+        self.request_chunk_single(chunk_header, chunk_header.prev_block_hash().clone(), None, false)
     }
 
     /// send partial chunk requests for one chunk
@@ -770,7 +770,7 @@ impl ShardsManager {
 
         self.encoded_chunks.try_insert(&chunk_header);
 
-        let prev_block_hash = chunk_header.prev_block_hash();
+        let prev_block_hash = chunk_header.prev_block_hash().clone();
         self.requested_partial_encoded_chunks.insert(
             chunk_hash.clone(),
             ChunkRequestInfo {
@@ -1153,7 +1153,7 @@ impl ShardsManager {
         let shard_id = chunk_header.shard_id();
         let shard_layout = self
             .runtime_adapter
-            .get_shard_layout_from_prev_block(chunk_header.prev_block_hash_ref())?;
+            .get_shard_layout_from_prev_block(chunk_header.prev_block_hash())?;
 
         let hashes = Chain::build_receipts_hashes(&outgoing_receipts, &shard_layout);
         let (root, proofs) = merklize(&hashes);
@@ -1505,7 +1505,7 @@ impl ShardsManager {
         //    And if the validation fails in this case, we actually can't say if the chunk is actually
         //    invalid. So we must return chain_error instead of return error
         let (ancestor_hash, epoch_id, epoch_id_confirmed) = {
-            let prev_block_hash = header.prev_block_hash();
+            let prev_block_hash = header.prev_block_hash().clone();
             let epoch_id = self.runtime_adapter.get_epoch_id_from_prev_block(&prev_block_hash);
             if let Ok(epoch_id) = epoch_id {
                 (prev_block_hash, epoch_id, true)
@@ -2317,12 +2317,13 @@ mod test {
         )
         .unwrap();
         let header = encoded_chunk.cloned_header();
+        let prev_block_hash = header.prev_block_hash();
         shards_manager.requested_partial_encoded_chunks.insert(
             header.chunk_hash(),
             ChunkRequestInfo {
                 height: header.height_created(),
-                ancestor_hash: header.prev_block_hash(),
-                prev_block_hash: header.prev_block_hash(),
+                ancestor_hash: prev_block_hash.clone(),
+                prev_block_hash: prev_block_hash.clone(),
                 shard_id: header.shard_id(),
                 last_requested: Clock::instant(),
                 added: Clock::instant(),
@@ -2629,7 +2630,7 @@ mod test {
         };
         shards_manager.request_chunks(
             vec![fixture.mock_chunk_header.clone()],
-            fixture.mock_chunk_header.prev_block_hash(),
+            fixture.mock_chunk_header.prev_block_hash().clone(),
             &header_head,
         );
         assert!(shards_manager
@@ -2650,7 +2651,7 @@ mod test {
         );
         shards_manager.request_chunks(
             vec![fixture.mock_chunk_header.clone()],
-            fixture.mock_chunk_header.prev_block_hash(),
+            fixture.mock_chunk_header.prev_block_hash().clone(),
             &header_head,
         );
         assert!(shards_manager
@@ -2671,7 +2672,7 @@ mod test {
         );
         shards_manager.request_chunks(
             vec![fixture.mock_chunk_header.clone()],
-            fixture.mock_chunk_header.prev_block_hash(),
+            fixture.mock_chunk_header.prev_block_hash().clone(),
             &header_head,
         );
         assert!(shards_manager

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -1615,7 +1615,7 @@ pub fn create_chunk(
         let signer = client.validator_signer.as_ref().unwrap().clone();
         let header = chunk.cloned_header();
         let (mut encoded_chunk, mut new_merkle_paths) = EncodedShardChunk::new(
-            header.prev_block_hash(),
+            header.prev_block_hash().clone(),
             header.prev_state_root(),
             header.outcome_root(),
             header.height_created(),

--- a/chain/client/src/tests/catching_up.rs
+++ b/chain/client/src/tests/catching_up.rs
@@ -590,8 +590,9 @@ fn test_catchup_random_single_part_sync_common(skip_15: bool, non_zero: bool, he
                             } = msg
                             {
                                 if partial_encoded_chunk.header.height_created() == 22 {
-                                    seen_heights_same_block
-                                        .insert(partial_encoded_chunk.header.prev_block_hash());
+                                    seen_heights_same_block.insert(
+                                        partial_encoded_chunk.header.prev_block_hash().clone(),
+                                    );
                                 }
                                 if skip_15 {
                                     if partial_encoded_chunk.header.height_created() == 14

--- a/chain/network-primitives/src/network_protocol/mod.rs
+++ b/chain/network-primitives/src/network_protocol/mod.rs
@@ -380,7 +380,7 @@ impl PartialEncodedChunkForwardMsg {
             inner_header_hash: header.inner_header_hash(),
             merkle_root: header.encoded_merkle_root(),
             signature: header.signature().clone(),
-            prev_block_hash: header.prev_block_hash(),
+            prev_block_hash: header.prev_block_hash().clone(),
             height_created: header.height_created(),
             shard_id: header.shard_id(),
             parts,

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -295,18 +295,7 @@ impl ShardChunkHeader {
     }
 
     #[inline]
-    pub fn prev_block_hash(&self) -> CryptoHash {
-        match self {
-            Self::V1(header) => header.inner.prev_block_hash,
-            Self::V2(header) => header.inner.prev_block_hash,
-            Self::V3(header) => *header.inner.prev_block_hash(),
-        }
-    }
-
-    // TODO(mina86): Change return type of prev_block_hash to &CryptoHash and
-    // then this method can be deleted.
-    #[inline]
-    pub fn prev_block_hash_ref(&self) -> &CryptoHash {
+    pub fn prev_block_hash(&self) -> &CryptoHash {
         match self {
             Self::V1(header) => &header.inner.prev_block_hash,
             Self::V2(header) => &header.inner.prev_block_hash,
@@ -538,7 +527,7 @@ impl PartialEncodedChunk {
     pub fn prev_block(&self) -> &CryptoHash {
         match &self {
             PartialEncodedChunk::V1(chunk) => &chunk.header.inner.prev_block_hash,
-            PartialEncodedChunk::V2(chunk) => chunk.header.prev_block_hash_ref(),
+            PartialEncodedChunk::V2(chunk) => chunk.header.prev_block_hash(),
         }
     }
 
@@ -711,7 +700,7 @@ impl ShardChunk {
     pub fn prev_block(&self) -> &CryptoHash {
         match &self {
             ShardChunk::V1(chunk) => &chunk.header.inner.prev_block_hash,
-            ShardChunk::V2(chunk) => chunk.header.prev_block_hash_ref(),
+            ShardChunk::V2(chunk) => chunk.header.prev_block_hash(),
         }
     }
 


### PR DESCRIPTION
Change SharedChunkHeader::prev_block_hash method to return a reference
(rather than cloning the hash) so that prev_block_hash_ref method
becomes unnecessary and can be deleted.

Convert all users of all those methods as required.  In a few plasecs
that allowed us to avoid cloning but in others we had to clone either
because we wanted a clone or to satisfy borrow checker.