### PR TITLE
store: introduce StoreOpener; get rid of StoreConfig::read_only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2901,6 +2901,7 @@ dependencies = [
  "near-crypto",
  "near-indexer-primitives",
  "near-primitives",
+ "near-store",
  "nearcore",
  "node-runtime",
  "rocksdb",

--- a/chain/indexer/Cargo.toml
+++ b/chain/indexer/Cargo.toml
@@ -24,4 +24,5 @@ near-chain-configs = { path = "../../core/chain-configs" }
 near-crypto = { path = "../../core/crypto" }
 near-indexer-primitives = { path = "../indexer-primitives" }
 near-primitives = { path = "../../core/primitives" }
+near-store = { path = "../../core/store" }
 node-runtime = { path = "../../runtime/runtime" }

--- a/chain/indexer/src/streamer/mod.rs
+++ b/chain/indexer/src/streamer/mod.rs
@@ -286,7 +286,7 @@ pub(crate) async fn start(
     blocks_sink: mpsc::Sender<StreamerMessage>,
 ) {
     info!(target: INDEXER, "Starting Streamer...");
-    let mut indexer_db_path = nearcore::get_store_path(&indexer_config.home_dir);
+    let mut indexer_db_path = near_store::get_store_path(&indexer_config.home_dir);
     indexer_db_path.push("indexer");
 
     // TODO: implement proper error handling

--- a/chain/network/src/peer_manager/peer_store.rs
+++ b/chain/network/src/peer_manager/peer_store.rs
@@ -474,8 +474,8 @@ where
 #[cfg(test)]
 mod test {
     use near_crypto::{KeyType, SecretKey};
-    use near_store::create_store;
     use near_store::test_utils::create_test_store;
+    use near_store::StoreOpener;
     use std::collections::HashSet;
     use std::net::{Ipv4Addr, SocketAddrV4};
 
@@ -508,14 +508,14 @@ mod test {
         let peer_info_to_ban = gen_peer_info(1);
         let boot_nodes = vec![peer_info_a, peer_info_to_ban.clone()];
         {
-            let store = create_store(tmp_dir.path());
+            let store = StoreOpener::with_default_config().home(tmp_dir.path()).open();
             let mut peer_store = PeerStore::new(store, &boot_nodes, Default::default()).unwrap();
             assert_eq!(peer_store.healthy_peers(3).len(), 2);
             peer_store.peer_ban(&peer_info_to_ban.id, ReasonForBan::Abusive).unwrap();
             assert_eq!(peer_store.healthy_peers(3).len(), 1);
         }
         {
-            let store_new = create_store(tmp_dir.path());
+            let store_new = StoreOpener::with_default_config().home(tmp_dir.path()).open();
             let peer_store_new =
                 PeerStore::new(store_new, &boot_nodes, Default::default()).unwrap();
             assert_eq!(peer_store_new.healthy_peers(3).len(), 1);
@@ -529,7 +529,7 @@ mod test {
         let peer_info_to_ban = gen_peer_info(1);
         let boot_nodes = vec![peer_info_a, peer_info_to_ban];
         {
-            let store = create_store(tmp_dir.path());
+            let store = StoreOpener::with_default_config().home(tmp_dir.path()).open();
             let peer_store = PeerStore::new(store, &boot_nodes, Default::default()).unwrap();
             assert!(peer_store.unconnected_peer(|_| false).is_some());
             assert!(peer_store.unconnected_peer(|_| true).is_none());
@@ -773,7 +773,7 @@ mod test {
 
         // Add three peers.
         {
-            let store = create_store(tmp_dir.path());
+            let store = StoreOpener::with_default_config().home(tmp_dir.path()).open();
             let mut peer_store = PeerStore::new(store.clone(), &[], Default::default()).unwrap();
             peer_store.add_indirect_peers(peer_infos.clone().into_iter()).unwrap();
         }
@@ -781,7 +781,7 @@ mod test {
 
         // Blacklisted peers are removed from the store.
         {
-            let store = create_store(tmp_dir.path());
+            let store = StoreOpener::with_default_config().home(tmp_dir.path()).open();
             let blacklist =
                 Blacklist::from_iter([format!("{}", peer_infos[2].addr.unwrap())].into_iter());
             let _peer_store = PeerStore::new(store.clone(), &[], blacklist).unwrap();
@@ -790,7 +790,7 @@ mod test {
     }
 
     fn assert_peers_in_store(store_path: &std::path::Path, expected: &[PeerId]) {
-        let store = create_store(store_path);
+        let store = StoreOpener::with_default_config().home(store_path).open();
         let stored_peers: HashSet<PeerId> = HashSet::from_iter(
             store.iter(DBCol::Peers).map(|(key, _)| PeerId::try_from_slice(key.as_ref()).unwrap()),
         );
@@ -826,14 +826,14 @@ mod test {
             peer_infos.iter().map(|info| info.addr.unwrap().clone()).collect::<Vec<_>>();
 
         {
-            let store = create_store(tmp_dir.path());
+            let store = StoreOpener::with_default_config().home(tmp_dir.path()).open();
             let mut peer_store = PeerStore::new(store.clone(), &[], Default::default()).unwrap();
             peer_store.add_indirect_peers(peer_infos.clone().into_iter()).unwrap();
         }
         assert_peers_in_store(tmp_dir.path(), &peer_ids);
 
         {
-            let store = create_store(tmp_dir.path());
+            let store = StoreOpener::with_default_config().home(tmp_dir.path()).open();
             let mut peer_store = PeerStore::new(store.clone(), &[], Default::default()).unwrap();
             assert_peers_in_cache(&peer_store, &peer_ids, &peer_addresses);
             peer_store.delete_peers(&peer_ids).unwrap();

--- a/core/store/benches/store_bench.rs
+++ b/core/store/benches/store_bench.rs
@@ -3,7 +3,7 @@ extern crate bencher;
 
 use bencher::{black_box, Bencher};
 use near_primitives::errors::StorageError;
-use near_store::{create_store, DBCol, Store};
+use near_store::{DBCol, Store, StoreOpener};
 use std::time::{Duration, Instant};
 
 /// Run a benchmark to generate `num_keys` keys, each of size `key_size`, then write then
@@ -16,7 +16,8 @@ fn benchmark_write_then_read_successful(
     max_value_size: usize,
     col: DBCol,
 ) {
-    let store = create_store_in_random_folder();
+    let tmp_dir = tempfile::Builder::new().tempdir().unwrap();
+    let store = StoreOpener::with_default_config().home(tmp_dir.path()).open();
     let keys = generate_keys(num_keys, key_size);
     write_to_db(&store, &keys, max_value_size, col);
 
@@ -33,13 +34,6 @@ fn benchmark_write_then_read_successful(
             keys.len()
         );
     });
-}
-
-/// Create `Store` in a random folder.
-fn create_store_in_random_folder() -> Store {
-    let tmp_dir = tempfile::Builder::new().prefix("_test_clear_column").tempdir().unwrap();
-    let store = create_store(tmp_dir.path());
-    store
 }
 
 /// Generate `count` keys of `key_size` length.

--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -1,9 +1,9 @@
+// TODO(mina86): This is pub only because recompress-storage needs this value.
+// Refactor code so that this can be private.
+pub const STORE_PATH: &str = "data";
+
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct StoreConfig {
-    /// Attempted writes to the DB will fail. Doesn't require a `LOCK` file.
-    #[serde(skip)]
-    pub read_only: bool,
-
     /// Collect internal storage layer statistics.
     /// Minor performance impact is expected.
     #[serde(default)]
@@ -77,7 +77,6 @@ impl StoreConfig {
 
     const fn const_default() -> Self {
         Self {
-            read_only: false,
             enable_statistics: false,
             enable_statistics_export: true,
             max_open_files: Self::DEFAULT_MAX_OPEN_FILES,
@@ -86,24 +85,118 @@ impl StoreConfig {
         }
     }
 
-    pub const fn read_only() -> StoreConfig {
-        StoreConfig::const_default().with_read_only(true)
-    }
-
-    pub const fn read_write() -> StoreConfig {
-        Self::const_default()
-    }
-
-    pub const fn with_read_only(mut self, read_only: bool) -> Self {
-        self.read_only = read_only;
-        self
-    }
-
     /// Returns cache size for given column.
     pub const fn col_cache_size(&self, col: crate::DBCol) -> bytesize::ByteSize {
         match col {
             crate::DBCol::State => self.col_state_cache_size,
             _ => bytesize::ByteSize::mib(32),
         }
+    }
+}
+
+impl Default for StoreConfig {
+    fn default() -> Self {
+        Self::const_default()
+    }
+}
+
+// TODO(#6857): Make this method in StoreOpener.  This way caller won’t need to
+// resolve path to the storage.
+pub fn store_path_exists<P: AsRef<std::path::Path>>(path: P) -> bool {
+    std::fs::canonicalize(path).is_ok()
+}
+
+// TODO(#6857): Get rid of this function.  Clients of this method should not
+// care about path of the storage instead letting StoreOpener figure that one
+// out.
+pub fn get_store_path(base_path: &std::path::Path) -> std::path::PathBuf {
+    base_path.join(STORE_PATH)
+}
+
+/// Builder for opening a RocksDB database.
+///
+/// Typical usage:
+///
+/// ```ignore
+/// let store = StoreOpener::new(&near_config.config.store)
+///     .home(neard_home_dir)
+///     .open();
+/// ```
+pub struct StoreOpener<'a> {
+    path: Option<&'a std::path::Path>,
+    home: Option<&'a std::path::Path>,
+    config: &'a StoreConfig,
+    read_only: bool,
+}
+
+impl<'a> StoreOpener<'a> {
+    /// Initialises a new opener with given store configuration.
+    pub fn new(config: &'a StoreConfig) -> Self {
+        Self { path: None, home: None, config: config, read_only: false }
+    }
+
+    /// Initialises a new opener using default store configuration.
+    ///
+    /// This is meant for tests only.  Production code should always read store
+    /// configuration from a config file and use [`Self::new`] instead.
+    pub fn with_default_config() -> Self {
+        static CONFIG: StoreConfig = StoreConfig::const_default();
+        Self::new(&CONFIG)
+    }
+
+    /// Configure whether the database should be opened in read-only mode.
+    pub fn read_only(mut self, read_only: bool) -> Self {
+        self.read_only = read_only;
+        self
+    }
+
+    /// Specifies neard home directory.
+    ///
+    /// By default, the database lives in a `data` directory inside of the home
+    /// directory.
+    pub fn home(mut self, home: &'a std::path::Path) -> Self {
+        self.home = Some(home);
+        self
+    }
+
+    /// Specifies path to the database.
+    ///
+    /// You should avoid using this method instead setting [`Self::home`] on
+    /// relying on the opener resolving path to the storage relative to the near
+    /// home direcotry.
+    ///
+    /// If the path is absolute, it simply points at the database.  Otherwise,
+    /// it is resolved relative to home dir (which is set via [`Self::home`]
+    /// method.
+    ///
+    /// TODO(#6857): Get rid of this method.
+    pub fn path(mut self, path: &'a std::path::Path) -> Self {
+        self.path = Some(path);
+        self
+    }
+
+    /// Opens the RocksDB database.
+    ///
+    /// Panics on failure.
+    // TODO(mina86): Change it to return Result.
+    pub fn open(&self) -> crate::Store {
+        tracing::warn!(target: "near", "self.path={:?}; self.home={:?}", self.path, self.home);
+        let path = self.path.unwrap_or(std::path::Path::new(STORE_PATH));
+        tracing::warn!(target: "near", "path={path:?}");
+        let path = self.home.map_or(std::borrow::Cow::Borrowed(path), |home| {
+            std::borrow::Cow::Owned(home.join(path))
+        });
+        tracing::warn!(target: "near", "path={path:?}");
+        if std::fs::canonicalize(&path).is_ok() {
+            tracing::info!(target: "near", path=%path.display(), "Opening RocksDB database");
+        } else if self.read_only {
+            tracing::error!(target: "near", path=%path.display(), "Database does not exist");
+            panic!("Failed to open non-existent the database");
+        } else {
+            tracing::info!(target: "near", path=%path.display(), "Creating new RocksDB database");
+        }
+        let db = crate::RocksDB::open(&path, &self.config, self.read_only)
+            .expect("Failed to open the database");
+        crate::Store::new(std::sync::Arc::new(db))
     }
 }

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -174,15 +174,19 @@ fn ensure_max_open_files_limit(max_open_files: u32) -> Result<(), DBError> {
 impl RocksDB {
     /// Opens the database either in read only or in read/write mode depending
     /// on the read_only parameter specified in the store_config.
-    pub fn open(path: impl AsRef<Path>, store_config: &StoreConfig) -> Result<RocksDB, DBError> {
+    pub fn open(
+        path: &Path,
+        store_config: &StoreConfig,
+        read_only: bool,
+    ) -> Result<RocksDB, DBError> {
         use strum::IntoEnumIterator;
 
         ensure_max_open_files_limit(store_config.max_open_files)?;
 
-        let (db, db_opt) = if store_config.read_only {
-            Self::open_read_only(path.as_ref(), store_config)
+        let (db, db_opt) = if read_only {
+            Self::open_read_only(path, store_config)
         } else {
-            Self::open_read_write(path.as_ref(), store_config)
+            Self::open_read_write(path, store_config)
         }?;
 
         let mut cf_handles = enum_map::EnumMap::default();
@@ -614,7 +618,7 @@ impl RocksDB {
 
     /// Returns version of the database state on disk.
     pub fn get_version(path: &Path) -> Result<DbVersion, DBError> {
-        let value = RocksDB::open(path, &StoreConfig::read_only())?
+        let value = RocksDB::open(path, &StoreConfig::default(), true)?
             .get(DBCol::DbVersion, VERSION_KEY)?
             .ok_or_else(|| {
                 DBError(
@@ -778,7 +782,7 @@ fn parse_statistics(statistics: &str) -> Result<StoreStatistics, Box<dyn std::er
 mod tests {
     use crate::db::StatsValue::{Count, Percentile, Sum};
     use crate::db::{parse_statistics, rocksdb_read_options, DBError, Database, RocksDB};
-    use crate::{create_store, DBCol, StoreConfig, StoreStatistics};
+    use crate::{DBCol, StoreConfig, StoreOpener, StoreStatistics};
 
     impl RocksDB {
         #[cfg(not(feature = "single_thread_rocksdb"))]
@@ -804,14 +808,14 @@ mod tests {
     #[test]
     fn test_prewrite_check() {
         let tmp_dir = tempfile::Builder::new().prefix("_test_prewrite_check").tempdir().unwrap();
-        let store = RocksDB::open(tmp_dir.path(), &StoreConfig::read_write()).unwrap();
+        let store = RocksDB::open(tmp_dir.path(), &StoreConfig::default(), false).unwrap();
         store.pre_write_check().unwrap()
     }
 
     #[test]
     fn test_clear_column() {
         let tmp_dir = tempfile::Builder::new().prefix("_test_clear_column").tempdir().unwrap();
-        let store = create_store(tmp_dir.path());
+        let store = StoreOpener::with_default_config().home(tmp_dir.path()).open();
         assert_eq!(store.get(DBCol::State, &[1]).unwrap(), None);
         {
             let mut store_update = store.store_update();
@@ -832,7 +836,7 @@ mod tests {
     #[test]
     fn rocksdb_merge_sanity() {
         let tmp_dir = tempfile::Builder::new().prefix("_test_snapshot_sanity").tempdir().unwrap();
-        let store = create_store(tmp_dir.path());
+        let store = StoreOpener::with_default_config().home(tmp_dir.path()).open();
         let ptr = (&*store.storage) as *const (dyn Database + 'static);
         let rocksdb = unsafe { &*(ptr as *const RocksDB) };
         assert_eq!(store.get(DBCol::State, &[1]).unwrap(), None);

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -46,7 +46,7 @@ pub mod migrations;
 pub mod test_utils;
 mod trie;
 
-pub use crate::config::StoreConfig;
+pub use crate::config::{get_store_path, store_path_exists, StoreConfig, StoreOpener, STORE_PATH};
 
 #[derive(Clone)]
 pub struct Store {
@@ -330,15 +330,6 @@ pub fn read_with_cache<'a, T: BorshDeserialize + 'a>(
         return Ok(cache.get(key));
     }
     Ok(None)
-}
-
-pub fn create_store(path: &Path) -> Store {
-    create_store_with_config(path, &StoreConfig::read_write())
-}
-
-pub fn create_store_with_config(path: &Path, store_config: &StoreConfig) -> Store {
-    let db = RocksDB::open(path, &store_config).expect("Failed to open the database");
-    Store::new(Arc::new(db))
 }
 
 /// Reads an object from Trie.

--- a/core/store/src/migrations.rs
+++ b/core/store/src/migrations.rs
@@ -9,7 +9,7 @@ use near_primitives::types::AccountId;
 use near_primitives::version::DbVersion;
 
 use crate::db::{DBError, RocksDB};
-use crate::{create_store, DBCol, Store, StoreUpdate};
+use crate::{DBCol, Store, StoreConfig, StoreOpener, StoreUpdate};
 use std::path::Path;
 
 pub fn get_store_version(path: &Path) -> Result<DbVersion, DBError> {
@@ -125,8 +125,9 @@ where
     Ok(())
 }
 
-pub fn migrate_28_to_29(path: &Path) {
-    let store = create_store(path);
+pub fn migrate_28_to_29(path: &Path, store_config: &StoreConfig) {
+    // TODO(#6857): Don’t use .path().
+    let store = StoreOpener::new(store_config).path(path).open();
     let mut store_update = store.store_update();
     store_update.delete_all(DBCol::_NextBlockWithNewChunk);
     store_update.delete_all(DBCol::_LastBlockWithNewChunk);
@@ -135,7 +136,7 @@ pub fn migrate_28_to_29(path: &Path) {
     set_store_version(&store, 29);
 }
 
-pub fn migrate_29_to_30(path: &Path) {
+pub fn migrate_29_to_30(path: &Path, store_config: &StoreConfig) {
     use near_primitives::epoch_manager::block_info::BlockInfo;
     use near_primitives::epoch_manager::epoch_info::EpochSummary;
     use near_primitives::epoch_manager::AGGREGATOR_KEY;
@@ -147,7 +148,8 @@ pub fn migrate_29_to_30(path: &Path) {
     };
     use std::collections::BTreeMap;
 
-    let store = create_store(path);
+    // TODO(#6857): Don’t use .path().
+    let store = StoreOpener::new(store_config).path(path).open();
 
     #[derive(BorshDeserialize)]
     pub struct OldEpochSummary {

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -21,10 +21,8 @@ use near_primitives::shard_layout::{account_id_to_shard_id, ShardUId};
 use near_primitives::state_record::StateRecord;
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{AccountId, Balance, EpochId, ShardId, StateChangeCause, StateRoot};
-use near_store::{
-    create_store, get_account, set_access_key, set_account, set_code, Store, TrieUpdate,
-};
-use nearcore::{get_store_path, NightshadeRuntime, TrackedConfig};
+use near_store::{get_account, set_access_key, set_account, set_code, Store, TrieUpdate};
+use nearcore::{NightshadeRuntime, TrackedConfig};
 
 fn get_account_id(account_index: u64) -> AccountId {
     AccountId::try_from(format!("near_{}_{}", account_index, account_index)).unwrap()
@@ -81,11 +79,6 @@ impl GenesisBuilder {
             additional_accounts_code_hash: CryptoHash::default(),
             print_progress: false,
         }
-    }
-
-    pub fn from_config(home_dir: &Path, genesis: Arc<Genesis>) -> Self {
-        let store = create_store(&get_store_path(home_dir));
-        Self::from_config_and_store(home_dir, genesis, store)
     }
 
     pub fn print_progress(mut self) -> Self {

--- a/genesis-tools/genesis-populate/src/main.rs
+++ b/genesis-tools/genesis-populate/src/main.rs
@@ -3,8 +3,7 @@ use std::sync::Arc;
 
 use clap::{Arg, Command};
 
-use near_store::create_store;
-use nearcore::{get_default_home, get_store_path, load_config};
+use nearcore::{get_default_home, load_config};
 
 use genesis_populate::GenesisBuilder;
 use near_chain_configs::GenesisValidationMode;
@@ -30,7 +29,7 @@ fn main() {
     let near_config = load_config(home_dir, GenesisValidationMode::Full)
         .unwrap_or_else(|e| panic!("Error loading config: {:#}", e));
 
-    let store = create_store(&get_store_path(home_dir));
+    let store = near_store::StoreOpener::with_default_config().home(home_dir).open();
     GenesisBuilder::from_config_and_store(home_dir, Arc::new(near_config.genesis), store)
         .add_additional_accounts(additional_accounts_num)
         .add_additional_accounts_contract(near_test_contracts::trivial_contract().to_vec())

--- a/genesis-tools/genesis-populate/src/state_dump.rs
+++ b/genesis-tools/genesis-populate/src/state_dump.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use near_primitives::types::StateRoot;
 use near_store::DBCol;
-use near_store::{create_store, Store};
+use near_store::Store;
 
 const STATE_DUMP_FILE: &str = "state_dump";
 const GENESIS_ROOTS_FILE: &str = "genesis_roots";
@@ -17,7 +17,8 @@ pub struct StateDump {
 
 impl StateDump {
     pub fn from_dir(dir: &Path, target_store_path: &Path) -> Self {
-        let store = create_store(target_store_path);
+        // TODO(#6857): Don’t use .path().
+        let store = near_store::StoreOpener::with_default_config().path(target_store_path).open();
         let state_file = dir.join(STATE_DUMP_FILE);
         store
             .load_from_file(DBCol::State, state_file.as_path())

--- a/nearcore/benches/store.rs
+++ b/nearcore/benches/store.rs
@@ -6,8 +6,8 @@ use near_chain::{ChainStore, ChainStoreAccess, RuntimeAdapter};
 use near_chain_configs::GenesisValidationMode;
 use near_logger_utils::init_integration_logger;
 use near_primitives::types::StateRoot;
-use near_store::{StoreConfig, TrieIterator};
-use nearcore::{get_default_home, get_store_path, load_config, NightshadeRuntime};
+use near_store::TrieIterator;
+use nearcore::{get_default_home, load_config, NightshadeRuntime};
 use std::time::{Duration, Instant};
 
 /// Read `TrieItem`s - nodes containing values - using Trie iterator, stop when 10k items were read.

--- a/nearcore/benches/store.rs
+++ b/nearcore/benches/store.rs
@@ -28,10 +28,9 @@ fn read_trie_items(bench: &mut Bencher, shard_id: usize, read_only: bool) {
 
     bench.iter(move || {
         tracing::info!(target: "neard", "{:?}", home_dir);
-        let store_config = StoreConfig::read_write().with_read_only(read_only);
         let store = near_store::StoreOpener::with_default_config()
             .read_only(read_only)
-            .home(home_dir)
+            .home(&home_dir)
             .open();
 
         let mut chain_store =

--- a/nearcore/benches/store.rs
+++ b/nearcore/benches/store.rs
@@ -6,7 +6,7 @@ use near_chain::{ChainStore, ChainStoreAccess, RuntimeAdapter};
 use near_chain_configs::GenesisValidationMode;
 use near_logger_utils::init_integration_logger;
 use near_primitives::types::StateRoot;
-use near_store::{create_store_with_config, StoreConfig, TrieIterator};
+use near_store::{StoreConfig, TrieIterator};
 use nearcore::{get_default_home, get_store_path, load_config, NightshadeRuntime};
 use std::time::{Duration, Instant};
 
@@ -29,7 +29,10 @@ fn read_trie_items(bench: &mut Bencher, shard_id: usize, read_only: bool) {
     bench.iter(move || {
         tracing::info!(target: "neard", "{:?}", home_dir);
         let store_config = StoreConfig::read_write().with_read_only(read_only);
-        let store = create_store_with_config(&get_store_path(&home_dir), &store_config);
+        let store = near_store::StoreOpener::with_default_config()
+            .read_only(read_only)
+            .home(home_dir)
+            .open();
 
         let mut chain_store =
             ChainStore::new(store.clone(), near_config.genesis.config.genesis_height, true);

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -486,7 +486,7 @@ impl Default for Config {
             max_gas_burnt_view: None,
             db_migration_snapshot_path: None,
             use_db_migration_snapshot: true,
-            store: near_store::StoreConfig::read_write(),
+            store: near_store::StoreConfig::default(),
         }
     }
 }

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -21,9 +21,8 @@ use near_store::db::RocksDB;
 use near_store::migrations::{
     get_store_version, migrate_28_to_29, migrate_29_to_30, set_store_version,
 };
-use near_store::{create_store, create_store_with_config, DBCol, Store};
+use near_store::{DBCol, Store, StoreOpener};
 use near_telemetry::TelemetryActor;
-use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::oneshot;
@@ -36,23 +35,6 @@ mod metrics;
 pub mod migrations;
 mod runtime;
 mod shard_tracker;
-
-const STORE_PATH: &str = "data";
-
-pub fn store_path_exists<P: AsRef<Path>>(path: P) -> bool {
-    fs::canonicalize(path).is_ok()
-}
-
-pub fn get_store_path(base_path: &Path) -> PathBuf {
-    let mut store_path = base_path.to_owned();
-    store_path.push(STORE_PATH);
-    if store_path_exists(&store_path) {
-        info!(target: "near", "Opening store database at {:?}", store_path);
-    } else {
-        info!(target: "near", "Did not find {:?} path, will be creating new store database", store_path);
-    }
-    store_path
-}
 
 pub fn get_default_home() -> PathBuf {
     if let Ok(near_home) = std::env::var("NEAR_HOME") {
@@ -96,7 +78,7 @@ fn create_db_checkpoint(path: &Path, near_config: &NearConfig) -> anyhow::Result
                     checkpoint_path.display(),
                     path.display());
 
-    let db = RocksDB::open(path, &near_config.config.store)?;
+    let db = RocksDB::open(path, &near_config.config.store, false)?;
     let checkpoint = db.checkpoint()?;
     info!(target: "near", "Creating a database migration snapshot in '{}'", checkpoint_path.display());
     checkpoint.create_checkpoint(&checkpoint_path)?;
@@ -156,21 +138,20 @@ fn apply_store_migrations(path: &Path, near_config: &NearConfig) -> anyhow::Resu
     }
     if db_version <= 27 {
         // version 27 => 28: add DBCol::StateChangesForSplitStates
-        // Does not need to do anything since open db with option `create_missing_column_families`
-        // Nevertheless need to bump db version, because db_version 27 binary can't open db_version 28 db
-        info!(target: "near", "Migrate DB from version 27 to 28");
-        let store = create_store(path);
-        set_store_version(&store, 28);
+        // Does not need to do anything since open db with option
+        // `create_missing_column_families`.  Nevertheless need to bump db
+        // version, because db_version 27 binary can't open db_version 28 db.
+        // Combine it with migration from 28 to 29; don’t do anything here.
     }
     if db_version <= 28 {
         // version 28 => 29: delete ColNextBlockWithNewChunk, ColLastBlockWithNewChunk
         info!(target: "near", "Migrate DB from version 28 to 29");
-        migrate_28_to_29(path);
+        migrate_28_to_29(path, &near_config.config.store);
     }
     if db_version <= 29 {
         // version 29 => 30: migrate all structures that use ValidatorStake to versionized version
         info!(target: "near", "Migrate DB from version 29 to 30");
-        migrate_29_to_30(path);
+        migrate_29_to_30(path, &near_config.config.store);
     }
     if db_version <= 30 {
         // version 30 => 31: recompute block ordinal due to a bug fixed in #5761
@@ -179,11 +160,12 @@ fn apply_store_migrations(path: &Path, near_config: &NearConfig) -> anyhow::Resu
     }
 
     if cfg!(feature = "nightly") || cfg!(feature = "nightly_protocol") {
-        let store = create_store(&path);
+        // TODO(#6857): Don’t use .path().
+        let store = StoreOpener::new(&near_config.config.store).path(path).open();
         // set some dummy value to avoid conflict with other migrations from nightly features
         set_store_version(&store, 10000);
     } else {
-        let db_version = get_store_version(&path)?;
+        let db_version = get_store_version(path)?;
         debug_assert_eq!(db_version, near_primitives::version::DB_VERSION);
     }
 
@@ -211,13 +193,13 @@ fn apply_store_migrations(path: &Path, near_config: &NearConfig) -> anyhow::Resu
 }
 
 fn init_and_migrate_store(home_dir: &Path, near_config: &NearConfig) -> anyhow::Result<Store> {
-    let path = get_store_path(home_dir);
-    let store_exists = store_path_exists(&path);
+    let path = near_store::get_store_path(home_dir);
+    let store_exists = near_store::store_path_exists(&path);
     if store_exists {
         apply_store_migrations(&path, near_config)?;
     }
-    let store =
-        create_store_with_config(&path, &near_config.config.store.clone().with_read_only(false));
+    // TODO(#6857): Don’t use .path().
+    let store = StoreOpener::new(&near_config.config.store).path(&path).open();
     if !store_exists {
         set_store_version(&store, near_primitives::version::DB_VERSION);
     }
@@ -399,9 +381,9 @@ pub fn recompress_storage(home_dir: &Path, opts: RecompressOpts) -> anyhow::Resu
             .map_err(|err| anyhow::anyhow!("setrlimit: NOFILE: {}", err))?;
     }
 
-    let src_dir = home_dir.join(STORE_PATH);
+    let src_dir = home_dir.join(near_store::STORE_PATH);
     anyhow::ensure!(
-        store_path_exists(&src_dir),
+        near_store::store_path_exists(&src_dir),
         "{}: source storage doesn’t exist",
         src_dir.display()
     );
@@ -415,13 +397,14 @@ pub fn recompress_storage(home_dir: &Path, opts: RecompressOpts) -> anyhow::Resu
     );
 
     anyhow::ensure!(
-        !store_path_exists(&opts.dest_dir),
+        !near_store::store_path_exists(&opts.dest_dir),
         "{}: directory already exists",
         opts.dest_dir.display()
     );
 
     info!(target: "recompress", src = %src_dir.display(), dest = %opts.dest_dir.display(), "Recompressing database");
-    let src_store = create_store_with_config(&src_dir, &config.store.clone().with_read_only(true));
+    // TODO(#6857): Don’t use .path().
+    let src_store = StoreOpener::new(&config.store).read_only(true).path(&src_dir).open();
 
     let final_head_height = if skip_columns.contains(&DBCol::PartialChunks) {
         let tip: Option<near_primitives::block::Tip> =
@@ -437,7 +420,8 @@ pub fn recompress_storage(home_dir: &Path, opts: RecompressOpts) -> anyhow::Resu
         None
     };
 
-    let dst_store = create_store_with_config(&opts.dest_dir, &config.store);
+    // TODO(#6857): Don’t use .path().
+    let dst_store = StoreOpener::new(&config.store).path(&opts.dest_dir).open();
 
     const BATCH_SIZE_BYTES: u64 = 150_000_000;
 

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -4,7 +4,7 @@ use near_primitives::runtime::migration_data::MigrationData;
 use near_primitives::types::Gas;
 use near_primitives::utils::index_to_bytes;
 use near_store::migrations::{set_store_version, BatchedStoreUpdate};
-use near_store::{create_store, DBCol};
+use near_store::DBCol;
 use std::path::Path;
 
 lazy_static_include::lazy_static_include_bytes! {
@@ -17,7 +17,8 @@ lazy_static_include::lazy_static_include_bytes! {
 /// Fix an issue with block ordinal (#5761)
 // This migration takes at least 3 hours to complete on mainnet
 pub fn migrate_30_to_31(path: &Path, near_config: &crate::NearConfig) {
-    let store = create_store(path);
+    // TODO(#6857): Don’t use .path().
+    let store = near_store::StoreOpener::new(&near_config.config.store).path(path).open();
     if near_config.client_config.archive && &near_config.genesis.config.chain_id == "mainnet" {
         let genesis_height = near_config.genesis.config.genesis_height;
         let mut chain_store = ChainStore::new(store.clone(), genesis_height, false);

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -2001,10 +2001,8 @@ mod test {
     use near_primitives::views::{
         AccountView, CurrentEpochValidatorInfo, NextEpochValidatorInfo, ValidatorKickoutView,
     };
-    use near_store::create_store;
 
     use crate::config::{GenesisExt, TESTING_INIT_BALANCE, TESTING_INIT_STAKE};
-    use crate::get_store_path;
 
     use super::*;
 
@@ -2140,7 +2138,7 @@ mod test {
             minimum_stake_divisor: Option<u64>,
         ) -> Self {
             let dir = tempfile::Builder::new().prefix(prefix).tempdir().unwrap();
-            let store = create_store(&get_store_path(dir.path()));
+            let store = near_store::StoreOpener::with_default_config().home(dir.path()).open();
             let all_validators = validators.iter().fold(BTreeSet::new(), |acc, x| {
                 acc.union(&x.iter().cloned().collect()).cloned().collect()
             });

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -8,7 +8,6 @@ use near_o11y::{
 use near_primitives::types::{Gas, NumSeats, NumShards};
 use near_state_viewer::StateViewerSubCommand;
 use near_store::db::RocksDB;
-use nearcore::get_store_path;
 use std::cell::Cell;
 use std::fs;
 use std::net::SocketAddr;
@@ -80,7 +79,7 @@ impl NeardCmd {
 
             // TODO(mina86): Remove the command in Q3 2022.
             NeardSubCommand::UnsafeResetData => {
-                let store_path = get_store_path(&home_dir);
+                let store_path = near_store::get_store_path(&home_dir);
                 unsafe_reset("unsafe_reset_data", &store_path, "data", "<near-home-dir>/data");
             }
             // TODO(mina86): Remove the command in Q3 2022.

--- a/runtime/runtime-params-estimator/src/function_call.rs
+++ b/runtime/runtime-params-estimator/src/function_call.rs
@@ -5,10 +5,9 @@ use crate::vm_estimator::create_context;
 use near_primitives::contract::ContractCode;
 use near_primitives::runtime::config_store::RuntimeConfigStore;
 use near_primitives::types::{CompiledContractCache, Gas, ProtocolVersion};
-use near_store::{create_store, StoreCompiledContractCache};
+use near_store::StoreCompiledContractCache;
 use near_vm_logic::mocks::mock_external::MockedExternal;
 use near_vm_runner::internal::VMKind;
-use nearcore::get_store_path;
 use num_rational::Ratio;
 use std::fmt::Write;
 use std::sync::Arc;
@@ -68,7 +67,7 @@ pub fn compute_function_call_cost(
     contract: &ContractCode,
 ) -> Gas {
     let workdir = tempfile::Builder::new().prefix("runtime_testbed").tempdir().unwrap();
-    let store = create_store(&get_store_path(workdir.path()));
+    let store = near_store::StoreOpener::with_default_config().home(workdir.path()).open();
     let cache_store = Arc::new(StoreCompiledContractCache { store });
     let cache: Option<&dyn CompiledContractCache> = Some(cache_store.as_ref());
     let protocol_version = ProtocolVersion::MAX;

--- a/runtime/runtime-params-estimator/src/gas_metering.rs
+++ b/runtime/runtime-params-estimator/src/gas_metering.rs
@@ -6,9 +6,8 @@ use near_primitives::contract::ContractCode;
 use near_primitives::runtime::config_store::RuntimeConfigStore;
 use near_primitives::types::CompiledContractCache;
 use near_primitives::version::PROTOCOL_VERSION;
-use near_store::{create_store, StoreCompiledContractCache};
+use near_store::StoreCompiledContractCache;
 use near_vm_logic::mocks::mock_external::MockedExternal;
-use nearcore::get_store_path;
 use std::fmt::Write;
 use std::sync::Arc;
 
@@ -130,7 +129,7 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     let warmup_repeats = config.warmup_iters_per_block;
 
     let workdir = tempfile::Builder::new().prefix("runtime_testbed").tempdir().unwrap();
-    let store = create_store(&get_store_path(workdir.path()));
+    let store = near_store::StoreOpener::with_default_config().home(workdir.path()).open();
     let cache_store = Arc::new(StoreCompiledContractCache { store });
     let cache: Option<&dyn CompiledContractCache> = Some(cache_store.as_ref());
     let config_store = RuntimeConfigStore::new(None);

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -5,9 +5,7 @@ use clap::Parser;
 use genesis_populate::GenesisBuilder;
 use near_chain_configs::GenesisValidationMode;
 use near_primitives::version::PROTOCOL_VERSION;
-use near_store::create_store;
 use near_vm_runner::internal::VMKind;
-use nearcore::{get_store_path, load_config};
 use runtime_params_estimator::config::{Config, GasMetric};
 use runtime_params_estimator::utils::read_resource;
 use runtime_params_estimator::{
@@ -143,9 +141,10 @@ fn main() -> anyhow::Result<()> {
         )
         .expect("failed to init config");
 
-        let near_config = load_config(&state_dump_path, GenesisValidationMode::Full)
+        let near_config = nearcore::load_config(&state_dump_path, GenesisValidationMode::Full)
             .context("Error loading config")?;
-        let store = create_store(&get_store_path(&state_dump_path));
+        let store =
+            near_store::StoreOpener::new(&near_config.config.store).home(&state_dump_path).open();
         GenesisBuilder::from_config_and_store(
             &state_dump_path,
             Arc::new(near_config.genesis),

--- a/runtime/runtime-params-estimator/src/testbed.rs
+++ b/runtime/runtime-params-estimator/src/testbed.rs
@@ -8,7 +8,6 @@ use near_primitives::types::{Gas, MerkleHash};
 use near_primitives::version::PROTOCOL_VERSION;
 use near_store::{ShardTries, ShardUId, Store, StoreCompiledContractCache};
 use near_vm_logic::VMLimitConfig;
-use nearcore::get_store_path;
 use node_runtime::{ApplyState, Runtime};
 use std::path::Path;
 use std::sync::Arc;
@@ -28,7 +27,7 @@ impl RuntimeTestbed {
     /// Copies dump from another directory and loads the state from it.
     pub fn from_state_dump(dump_dir: &Path) -> Self {
         let workdir = tempfile::Builder::new().prefix("runtime_testbed").tempdir().unwrap();
-        let store_path = get_store_path(workdir.path());
+        let store_path = near_store::get_store_path(workdir.path());
         let StateDump { store, roots } = StateDump::from_dir(dump_dir, &store_path);
         let tries = ShardTries::new(store.clone(), 0, 1);
 

--- a/runtime/runtime-params-estimator/src/vm_estimator.rs
+++ b/runtime/runtime-params-estimator/src/vm_estimator.rs
@@ -5,11 +5,10 @@ use near_primitives::contract::ContractCode;
 use near_primitives::runtime::config_store::RuntimeConfigStore;
 use near_primitives::types::CompiledContractCache;
 use near_primitives::version::PROTOCOL_VERSION;
-use near_store::{create_store, StoreCompiledContractCache};
+use near_store::StoreCompiledContractCache;
 use near_vm_logic::VMContext;
 use near_vm_runner::internal::VMKind;
 use near_vm_runner::precompile_contract_vm;
-use nearcore::get_store_path;
 use std::sync::Arc;
 use walrus::Result;
 
@@ -85,7 +84,7 @@ fn precompilation_cost(
     let use_file_store = true;
     if use_file_store {
         let workdir = tempfile::Builder::new().prefix("runtime_testbed").tempdir().unwrap();
-        let store = create_store(&get_store_path(workdir.path()));
+        let store = near_store::StoreOpener::with_default_config().home(workdir.path()).open();
         cache_store1 = Arc::new(StoreCompiledContractCache { store });
         cache = Some(cache_store1.as_ref());
     } else {
@@ -157,7 +156,7 @@ pub(crate) fn compile_single_contract_cost(
     let contract = ContractCode::new(contract_bytes.to_vec(), None);
 
     let workdir = tempfile::Builder::new().prefix("runtime_testbed").tempdir().unwrap();
-    let store = create_store(&get_store_path(workdir.path()));
+    let store = near_store::StoreOpener::with_default_config().home(workdir.path()).open();
     let cache = Arc::new(StoreCompiledContractCache { store });
 
     measure_contract(vm_kind, metric, &contract, Some(cache.as_ref()))

--- a/test-utils/runtime-tester/src/run_test.rs
+++ b/test-utils/runtime-tester/src/run_test.rs
@@ -11,7 +11,6 @@ use near_crypto::InMemorySigner;
 use near_primitives::hash::CryptoHash;
 use near_primitives::transaction::{Action, SignedTransaction};
 use near_primitives::types::{AccountId, BlockHeight, BlockHeightDelta, Gas, Nonce};
-use near_store::create_store;
 use near_store::test_utils::create_test_store;
 use nearcore::TrackedConfig;
 use nearcore::{config::GenesisExt, NightshadeRuntime};
@@ -50,7 +49,7 @@ impl Scenario {
         } else {
             let tempdir = tempfile::tempdir()
                 .unwrap_or_else(|err| panic!("failed to create temporary directory: {}", err));
-            let store = create_store(&nearcore::get_store_path(tempdir.path()));
+            let store = near_store::StoreOpener::with_default_config().home(tempdir.path()).open();
             (Some(tempdir), store)
         };
 

--- a/test-utils/store-validator/src/main.rs
+++ b/test-utils/store-validator/src/main.rs
@@ -9,8 +9,7 @@ use near_chain::store_validator::StoreValidator;
 use near_chain::RuntimeAdapter;
 use near_chain_configs::{GenesisValidationMode, DEFAULT_GC_NUM_EPOCHS_TO_KEEP};
 use near_logger_utils::init_integration_logger;
-use near_store::create_store;
-use nearcore::{get_default_home, get_store_path, load_config, TrackedConfig};
+use nearcore::{get_default_home, load_config, TrackedConfig};
 
 fn main() {
     init_integration_logger();
@@ -31,7 +30,7 @@ fn main() {
     let near_config = load_config(home_dir, GenesisValidationMode::Full)
         .unwrap_or_else(|e| panic!("Error loading config: {:#}", e));
 
-    let store = create_store(&get_store_path(home_dir));
+    let store = near_store::StoreOpener::with_default_config().home(home_dir).open();
 
     let runtime_adapter: Arc<dyn RuntimeAdapter> = Arc::new(nearcore::NightshadeRuntime::new(
         home_dir,

--- a/tools/mock_node/src/setup.rs
+++ b/tools/mock_node/src/setup.rs
@@ -14,10 +14,9 @@ use near_primitives::network::PeerId;
 use near_primitives::state_part::PartId;
 use near_primitives::syncing::get_num_state_parts;
 use near_primitives::types::BlockHeight;
-use near_store::create_store;
 use near_store::test_utils::create_test_store;
 use near_telemetry::TelemetryActor;
-use nearcore::{get_store_path, NearConfig, NightshadeRuntime};
+use nearcore::{NearConfig, NightshadeRuntime};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use regex::Regex;
 use std::cmp::min;
@@ -37,8 +36,7 @@ fn setup_runtime(
     let store = if in_memory_storage {
         create_test_store()
     } else {
-        let path = get_store_path(home_dir);
-        create_store(&path)
+        near_store::StoreOpener::new(&config.config.store).home(home_dir).open()
     };
 
     Arc::new(NightshadeRuntime::with_config(

--- a/tools/restored-receipts-verifier/src/main.rs
+++ b/tools/restored-receipts-verifier/src/main.rs
@@ -3,9 +3,8 @@ use near_chain::{ChainStore, ChainStoreAccess, RuntimeAdapter};
 use near_chain_configs::{GenesisValidationMode, DEFAULT_GC_NUM_EPOCHS_TO_KEEP};
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::Receipt;
-use near_store::create_store;
 use nearcore::migrations::load_migration_data;
-use nearcore::{get_default_home, get_store_path, load_config, NightshadeRuntime, TrackedConfig};
+use nearcore::{get_default_home, load_config, NightshadeRuntime, TrackedConfig};
 use std::collections::HashSet;
 use std::io::Result;
 use std::path::Path;
@@ -46,7 +45,7 @@ fn main() -> Result<()> {
     let near_config = load_config(home_dir, GenesisValidationMode::Full)
         .unwrap_or_else(|e| panic!("Error loading config: {:#}", e));
 
-    let store = create_store(&get_store_path(home_dir));
+    let store = near_store::StoreOpener::new(&near_config.config.store).home(home_dir).open();
     let mut chain_store = ChainStore::new(
         store.clone(),
         near_config.genesis.config.genesis_height,

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -7,8 +7,8 @@ use near_primitives::account::id::AccountId;
 use near_primitives::hash::CryptoHash;
 use near_primitives::sharding::ChunkHash;
 use near_primitives::types::{BlockHeight, ShardId};
-use near_store::{create_store_with_config, Store};
-use nearcore::{get_store_path, load_config, NearConfig};
+use near_store::Store;
+use nearcore::{load_config, NearConfig};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
@@ -70,9 +70,10 @@ impl StateViewerSubCommand {
     pub fn run(self, home_dir: &Path, genesis_validation: GenesisValidationMode, readwrite: bool) {
         let near_config = load_config(home_dir, genesis_validation)
             .unwrap_or_else(|e| panic!("Error loading config: {:#}", e));
-        let store_path = get_store_path(home_dir);
-        let store_config = &near_config.config.store.clone().with_read_only(!readwrite);
-        let store = create_store_with_config(&store_path, store_config);
+        let store = near_store::StoreOpener::new(&near_config.config.store)
+            .read_only(!readwrite)
+            .home(home_dir)
+            .open();
         match self {
             StateViewerSubCommand::Peers => peers(store),
             StateViewerSubCommand::State => state(home_dir, near_config, store),

--- a/tools/state-viewer/src/rocksdb_stats.rs
+++ b/tools/state-viewer/src/rocksdb_stats.rs
@@ -1,4 +1,3 @@
-use nearcore::get_store_path;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -73,7 +72,7 @@ impl Data {
 }
 
 pub fn get_rocksdb_stats(home_dir: &Path, file: Option<PathBuf>) -> anyhow::Result<()> {
-    let store_dir = get_store_path(&home_dir);
+    let store_dir = near_store::get_store_path(&home_dir);
     let mut cmd = Command::new("sst_dump");
     cmd.arg(format!("--file={}", store_dir.to_str().unwrap()))
         .arg("--show_properties")


### PR DESCRIPTION
Introduce near_store::StoreOpener as a new interface for opening
storage.  This gets rid of create_store and create_store_with_config
functions and converts all users of those into users of StoreOpener.

While doing that, convert a few uses of create_store (i.e. calls which
ignore StoreConfig) into ones where the configuration is taken into
consideration.

Issue: https://github.com/near/nearcore/issues/6857