### PR TITLE
test: more helpful assertion messages

### DIFF
--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -126,7 +126,7 @@ fn check_tx_processing(
     env.clients[0].process_tx(tx, false, false);
     let next_height = produce_blocks_from_height(env, blocks_number, height);
     let final_outcome = env.clients[0].chain.get_final_transaction_result(&tx_hash).unwrap();
-    assert!(matches!(final_outcome.status, FinalExecutionStatus::SuccessValue(_)));
+    assert_matches!(final_outcome.status, FinalExecutionStatus::SuccessValue(_));
     next_height
 }
 
@@ -1184,7 +1184,7 @@ fn test_invalid_height_too_large() {
         InMemoryValidatorSigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
     let b2 = Block::empty_with_height(&b1, u64::MAX, &signer);
     let (_, res) = env.clients[0].process_block(b2.into(), Provenance::NONE);
-    assert!(matches!(res.unwrap_err(), Error::InvalidBlockHeight(_)));
+    assert_matches!(res.unwrap_err(), Error::InvalidBlockHeight(_));
 }
 
 #[test]
@@ -1198,7 +1198,7 @@ fn test_invalid_height_too_old() {
         env.produce_block(0, i);
     }
     let (_, res) = env.clients[0].process_block(block.into(), Provenance::NONE);
-    assert!(matches!(res.unwrap_err(), Error::InvalidBlockHeight(_)));
+    assert_matches!(res.unwrap_err(), Error::InvalidBlockHeight(_));
 }
 
 #[test]
@@ -1298,7 +1298,7 @@ fn test_bad_orphan() {
         block.mut_header().get_mut().inner_lite.height += 2000;
         block.mut_header().resign(&*signer);
         let (_, res) = env.clients[0].process_block(block.into(), Provenance::NONE);
-        assert!(matches!(res.unwrap_err(), Error::InvalidBlockHeight(_)));
+        assert_matches!(res.unwrap_err(), Error::InvalidBlockHeight(_));
     }
     let (_, res) = env.clients[0].process_block(block.into(), Provenance::NONE);
     assert!(res.is_ok());
@@ -1412,14 +1412,14 @@ fn test_gc_with_epoch_length_common(epoch_length: NumBlocks) {
         println!("height = {}", i);
         if i < epoch_length {
             let block_hash = *blocks[i as usize].hash();
-            assert!(matches!(
+            assert_matches!(
                 env.clients[0].chain.get_block(&block_hash).unwrap_err(),
                 Error::DBNotFoundErr(missing_block_hash) if missing_block_hash == "BLOCK: ".to_owned() + &block_hash.to_string()
-            ));
-            assert!(matches!(
+            );
+            assert_matches!(
                 env.clients[0].chain.get_block_by_height(i).unwrap_err(),
                 Error::DBNotFoundErr(missing_block_hash) if missing_block_hash == "BLOCK: ".to_owned() + &block_hash.to_string()
-            ));
+            );
             assert!(env.clients[0]
                 .chain
                 .mut_store()
@@ -1751,7 +1751,7 @@ fn test_not_resync_old_blocks() {
         let block = blocks[i as usize - 1].clone();
         assert!(env.clients[0].chain.get_block(block.hash()).is_err());
         let (_, res) = env.clients[0].process_block(block.into(), Provenance::NONE);
-        assert!(matches!(res, Err(x) if matches!(x, Error::Orphan)));
+        assert_matches!(res, Err(x) if matches!(x, Error::Orphan));
         assert_eq!(env.clients[0].chain.orphans_len(), 0);
     }
 }
@@ -1936,7 +1936,7 @@ fn test_incorrect_validator_key_produce_block() {
     )
     .unwrap();
     let res = client.produce_block(1);
-    assert!(matches!(res, Ok(None)));
+    assert_matches!(res, Ok(None));
 }
 
 fn test_block_merkle_proof_with_len(n: NumBlocks, rng: &mut StdRng) {
@@ -2050,7 +2050,7 @@ fn test_data_reset_before_state_sync() {
             &QueryRequest::ViewAccount { account_id: "test_account".parse().unwrap() },
         )
         .unwrap();
-    assert!(matches!(response.kind, QueryResponseKind::ViewAccount(_)));
+    assert_matches!(response.kind, QueryResponseKind::ViewAccount(_));
     env.clients[0].chain.reset_data_pre_state_sync(*head_block.hash()).unwrap();
     // account should not exist after clearing state
     let response = env.clients[0].runtime_adapter.query(
@@ -2126,7 +2126,7 @@ fn test_not_process_height_twice() {
     let (accepted_blocks, res) =
         env.clients[0].process_block(invalid_block.into(), Provenance::NONE);
     assert!(accepted_blocks.is_empty());
-    assert!(matches!(res, Ok(None)));
+    assert_matches!(res, Ok(None));
 }
 
 #[test]
@@ -2140,7 +2140,7 @@ fn test_block_height_processed_orphan() {
     orphan_block.mut_header().resign(&validator_signer);
     let block_height = orphan_block.header().height();
     let (_, tip) = env.clients[0].process_block(orphan_block.into(), Provenance::NONE);
-    assert!(matches!(tip.unwrap_err(), Error::Orphan));
+    assert_matches!(tip.unwrap_err(), Error::Orphan);
     assert!(env.clients[0].chain.mut_store().is_height_processed(block_height).unwrap());
 }
 
@@ -2196,7 +2196,7 @@ fn test_validate_chunk_extra() {
         } else {
             let (_, res) =
                 env.clients[0].process_block(last_block.clone().into(), Provenance::NONE);
-            assert!(matches!(res, Ok(Some(_))));
+            assert_matches!(res, Ok(Some(_)));
         }
     }
 
@@ -2226,7 +2226,7 @@ fn test_validate_chunk_extra() {
         block.mut_header().get_mut().inner_rest.chunk_mask = vec![true];
         block.mut_header().resign(&validator_signer);
         let (_, res) = env.clients[0].process_block(block.clone().into(), Provenance::NONE);
-        assert!(matches!(res.unwrap_err(), near_chain::Error::ChunksMissing(_)));
+        assert_matches!(res.unwrap_err(), near_chain::Error::ChunksMissing(_));
     }
 
     // Process the previously unavailable chunk. This causes two blocks to be accepted.
@@ -2571,10 +2571,10 @@ fn test_refund_receipts_processing() {
         match execution_outcome.outcome_with_id.outcome.status {
             ExecutionStatus::SuccessReceiptId(id) => {
                 let receipt_outcome = env.clients[0].chain.get_execution_outcome(&id).unwrap();
-                assert!(matches!(
+                assert_matches!(
                     receipt_outcome.outcome_with_id.outcome.status,
                     ExecutionStatus::Failure(TxExecutionError::ActionError(_))
-                ));
+                );
                 receipt_outcome.outcome_with_id.outcome.receipt_ids.iter().for_each(|id| {
                     refund_receipt_ids.insert(*id);
                 });
@@ -3279,7 +3279,7 @@ fn test_congestion_receipt_execution() {
 
     for tx_hash in &tx_hashes {
         let final_outcome = env.clients[0].chain.get_final_transaction_result(tx_hash).unwrap();
-        assert!(matches!(final_outcome.status, FinalExecutionStatus::SuccessValue(_)));
+        assert_matches!(final_outcome.status, FinalExecutionStatus::SuccessValue(_));
 
         // Check that all receipt ids have corresponding execution outcomes. This means that all receipts generated are executed.
         let transaction_outcome = env.clients[0].chain.get_execution_outcome(tx_hash).unwrap();
@@ -3442,7 +3442,7 @@ fn verify_contract_limits_upgrade(
         env.clients[0].chain.get_final_transaction_result(&tx_hash).unwrap()
     };
 
-    assert!(matches!(old_outcome.status, FinalExecutionStatus::SuccessValue(_)));
+    assert_matches!(old_outcome.status, FinalExecutionStatus::SuccessValue(_));
     let e = match new_outcome.status {
         FinalExecutionStatus::Failure(TxExecutionError::ActionError(e)) => e,
         status => panic!("expected transaction to fail, got {:?}", status),
@@ -3580,8 +3580,8 @@ fn test_deploy_cost_increased() {
 
     let new_outcome = deploy_contract(&mut env, 11);
 
-    assert!(matches!(old_outcome.status, FinalExecutionStatus::SuccessValue(_)));
-    assert!(matches!(new_outcome.status, FinalExecutionStatus::SuccessValue(_)));
+    assert_matches!(old_outcome.status, FinalExecutionStatus::SuccessValue(_));
+    assert_matches!(new_outcome.status, FinalExecutionStatus::SuccessValue(_));
 
     let old_deploy_gas = old_outcome.receipts_outcome[0].outcome.gas_burnt;
     let new_deploy_gas = new_outcome.receipts_outcome[0].outcome.gas_burnt;
@@ -3649,13 +3649,13 @@ mod access_key_nonce_range_tests {
             *genesis_block.hash(),
         );
         let res = env.clients[0].process_tx(create_account_tx, false, false);
-        assert!(matches!(res, NetworkClientResponses::ValidTx));
+        assert_matches!(res, NetworkClientResponses::ValidTx);
         for i in 4..8 {
             env.produce_block(0, i);
         }
 
         let res = env.clients[0].process_tx(send_money_tx, false, false);
-        assert!(matches!(res, NetworkClientResponses::InvalidTx(_)));
+        assert_matches!(res, NetworkClientResponses::InvalidTx(_));
     }
 
     /// Helper for checking that duplicate transactions from implicit accounts are properly rejected.
@@ -3756,10 +3756,10 @@ mod access_key_nonce_range_tests {
     fn test_transaction_hash_collision_for_implicit_account_fail() {
         let protocol_version =
             ProtocolFeature::AccessKeyNonceForImplicitAccounts.protocol_version();
-        assert!(matches!(
+        assert_matches!(
             get_status_of_tx_hash_collision_for_implicit_account(protocol_version),
             NetworkClientResponses::InvalidTx(InvalidTxError::InvalidNonce { .. })
-        ));
+        );
     }
 
     /// Test that duplicate transactions from implicit accounts are not rejected until protocol upgrade.
@@ -3767,10 +3767,10 @@ mod access_key_nonce_range_tests {
     fn test_transaction_hash_collision_for_implicit_account_ok() {
         let protocol_version =
             ProtocolFeature::AccessKeyNonceForImplicitAccounts.protocol_version() - 1;
-        assert!(matches!(
+        assert_matches!(
             get_status_of_tx_hash_collision_for_implicit_account(protocol_version),
             NetworkClientResponses::ValidTx
-        ));
+        );
     }
 
     /// Test that chunks with transactions that have expired are considered invalid.
@@ -3808,7 +3808,7 @@ mod access_key_nonce_range_tests {
             .distribute_encoded_chunk(encoded_shard_chunk, merkle_path, receipts, &mut chain_store)
             .unwrap();
         let (_, res) = env.clients[0].process_block(block.into(), Provenance::NONE);
-        assert!(matches!(res.unwrap_err(), Error::InvalidTransactions));
+        assert_matches!(res.unwrap_err(), Error::InvalidTransactions);
     }
 
     #[test]
@@ -3832,10 +3832,10 @@ mod access_key_nonce_range_tests {
             *genesis_block.hash(),
         );
         let res = env.clients[0].process_tx(tx, false, false);
-        assert!(matches!(
+        assert_matches!(
             res,
             NetworkClientResponses::InvalidTx(InvalidTxError::InvalidAccessKeyError(_))
-        ));
+        );
     }
 
     #[test]
@@ -4802,7 +4802,7 @@ mod chunk_nodes_cache_test {
 
                 let final_result =
                     env.clients[0].chain.get_final_transaction_result(&tx_hash).unwrap();
-                assert!(matches!(final_result.status, FinalExecutionStatus::SuccessValue(_)));
+                assert_matches!(final_result.status, FinalExecutionStatus::SuccessValue(_));
                 let transaction_outcome =
                     env.clients[0].chain.get_execution_outcome(&tx_hash).unwrap();
                 let receipt_ids = transaction_outcome.outcome_with_id.outcome.receipt_ids;
@@ -4911,7 +4911,7 @@ mod lower_storage_key_limit_test {
                 env.process_block(0, block.clone(), Provenance::PRODUCED);
             }
             let final_result = env.clients[0].chain.get_final_transaction_result(&tx_hash).unwrap();
-            assert!(matches!(final_result.status, FinalExecutionStatus::SuccessValue(_)));
+            assert_matches!(final_result.status, FinalExecutionStatus::SuccessValue(_));
         }
 
         // Move to the new protocol version.
@@ -4951,10 +4951,10 @@ mod lower_storage_key_limit_test {
                 env.process_block(0, block.clone(), Provenance::PRODUCED);
             }
             let final_result = env.clients[0].chain.get_final_transaction_result(&tx_hash).unwrap();
-            assert!(matches!(
+            assert_matches!(
                 final_result.status,
                 FinalExecutionStatus::Failure(TxExecutionError::ActionError(_))
-            ));
+            );
         }
 
         // Run transaction where storage key exactly fits the new limit, check that execution succeeds.
@@ -4991,7 +4991,7 @@ mod lower_storage_key_limit_test {
                 env.process_block(0, block.clone(), Provenance::PRODUCED);
             }
             let final_result = env.clients[0].chain.get_final_transaction_result(&tx_hash).unwrap();
-            assert!(matches!(final_result.status, FinalExecutionStatus::SuccessValue(_)));
+            assert_matches!(final_result.status, FinalExecutionStatus::SuccessValue(_));
         }
     }
 }

--- a/integration-tests/src/tests/client/runtimes.rs
+++ b/integration-tests/src/tests/client/runtimes.rs
@@ -1,10 +1,7 @@
 //! Client is responsible for tracking the chain, chunks, and producing them when needed.
 //! This client works completely synchronously and must be operated by some async actor outside.
 
-use std::collections::HashMap;
-use std::path::Path;
-use std::sync::Arc;
-
+use assert_matches::assert_matches;
 use near_chain::{ChainGenesis, RuntimeAdapter};
 use near_chain_configs::Genesis;
 use near_chunks::test_utils::ChunkTestFixture;
@@ -23,6 +20,9 @@ use near_primitives::utils::MaybeValidated;
 use near_primitives::validator_signer::InMemoryValidatorSigner;
 use near_store::test_utils::create_test_store;
 use nearcore::config::GenesisExt;
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
 
 pub fn create_nightshade_runtimes(genesis: &Genesis, n: usize) -> Vec<Arc<dyn RuntimeAdapter>> {
     (0..n)
@@ -156,7 +156,7 @@ fn test_process_partial_encoded_chunk_with_missing_block() {
         client.chain.mut_store(),
         &mut client.rs,
     );
-    assert!(matches!(result, Ok(ProcessPartialEncodedChunkResult::NeedBlock)));
+    assert_matches!(result, Ok(ProcessPartialEncodedChunkResult::NeedBlock));
 
     // Client::process_partial_encoded_chunk should not return an error
     // if the chunk is based on a missing block.
@@ -170,8 +170,8 @@ fn test_process_partial_encoded_chunk_with_missing_block() {
     // process_partial_encoded_chunk_forward should return UnknownChunk if it is based on a
     // a missing block.
     let result = client.process_partial_encoded_chunk_forward(mock_forward);
-    assert!(matches!(
+    assert_matches!(
         result,
         Err(near_client_primitives::types::Error::Chunk(near_chunks::Error::UnknownChunk))
-    ));
+    );
 }

--- a/integration-tests/src/tests/nearcore/rpc_nodes.rs
+++ b/integration-tests/src/tests/nearcore/rpc_nodes.rs
@@ -1,12 +1,11 @@
-use std::time::Duration;
-
+use crate::genesis_helpers::genesis_block;
+use crate::tests::nearcore::node_cluster::NodeCluster;
 use actix::clock::sleep;
 use actix::{Actor, System};
+use assert_matches::assert_matches;
 use borsh::BorshSerialize;
 use futures::future::join_all;
 use futures::{future, FutureExt, TryFutureExt};
-
-use crate::genesis_helpers::genesis_block;
 use near_actix_test_utils::spawn_interruptible;
 use near_client::{GetBlock, GetExecutionOutcome, GetValidatorInfo};
 use near_crypto::{InMemorySigner, KeyType};
@@ -23,8 +22,7 @@ use near_primitives::types::{
 };
 use near_primitives::version::ProtocolVersion;
 use near_primitives::views::{ExecutionOutcomeView, ExecutionStatusView};
-
-use crate::tests::nearcore::node_cluster::NodeCluster;
+use std::time::Duration;
 
 #[test]
 #[cfg_attr(not(feature = "expensive_tests"), ignore)]
@@ -304,7 +302,7 @@ fn test_query_rpc_account_view_must_succeed() {
                     query_response.kind
                 );
             };
-        assert!(matches!(account, near_primitives::views::AccountView { .. }));
+        assert_matches!(account, near_primitives::views::AccountView { .. });
         System::current().stop();
     });
 }


### PR DESCRIPTION
assert_matches! should print the miss-matched variant on failure.
Specifically, I'd love to see why `test_chunk_transaction_validity`
fails for me locally from time to time.