### PR TITLE
fix: don't type convert errors to strings unnecessary

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3925,7 +3925,7 @@ impl<'a> ChainUpdate<'a> {
                                     apply_split_result_or_state_changes,
                                 }))
                             }
-                            Err(err) => Err(Error::Other(err.to_string()).into()),
+                            Err(err) => Err(err),
                         }
                     }));
                 } else {
@@ -3994,7 +3994,7 @@ impl<'a> ChainUpdate<'a> {
                                     apply_split_result_or_state_changes,
                                 }))
                             }
-                            Err(err) => Err(Error::Other(err.to_string()).into()),
+                            Err(err) => Err(err),
                         }
                     }));
                 }


### PR DESCRIPTION
I *think* the old code caused the following flaky failure for me from
time to time:

thread 'tests::client::process_blocks::access_key_nonce_range_tests::test_chunk_transaction_validity' panicked at \
  'assertion failed: `Other("Invalid Transactions")` does not match `Error::InvalidTransactions`', \
  integration-tests/src/tests/client/process_blocks.rs:3811:9

failures:
    tests::client::process_blocks::access_key_nonce_range_tests::test_chunk_transaction_validity

Note that this might be a behavior-changing change. I don't know the
surrounding code well enough to judge whether this is problematic. But
the current code does look very much like a bug.