### PR TITLE
refactor: make blocks and headers cheaply clonable

### DIFF
--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -1,4 +1,5 @@
 use std::cmp::max;
+use std::sync::Arc;
 
 use crate::time::{Clock, Utc};
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -75,8 +76,8 @@ pub struct BlockV2 {
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone, Eq, PartialEq)]
 pub enum Block {
-    BlockV1(Box<BlockV1>),
-    BlockV2(Box<BlockV2>),
+    BlockV1(Arc<BlockV1>),
+    BlockV2(Arc<BlockV2>),
 }
 
 pub fn genesis_chunks(
@@ -140,7 +141,7 @@ impl Block {
                 })
                 .collect();
 
-            Block::BlockV1(Box::new(BlockV1 {
+            Block::BlockV1(Arc::new(BlockV1 {
                 header,
                 chunks: legacy_chunks,
                 challenges,
@@ -148,7 +149,7 @@ impl Block {
                 vrf_proof,
             }))
         } else {
-            Block::BlockV2(Box::new(BlockV2 { header, chunks, challenges, vrf_value, vrf_proof }))
+            Block::BlockV2(Arc::new(BlockV2 { header, chunks, challenges, vrf_value, vrf_proof }))
         }
     }
 

--- a/core/primitives/src/block_header.rs
+++ b/core/primitives/src/block_header.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::time::Utc;
 use borsh::{BorshDeserialize, BorshSerialize};
 use chrono::DateTime;
@@ -323,9 +325,9 @@ impl BlockHeaderV3 {
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Debug, Clone, Eq, PartialEq)]
 pub enum BlockHeader {
-    BlockHeaderV1(Box<BlockHeaderV1>),
-    BlockHeaderV2(Box<BlockHeaderV2>),
-    BlockHeaderV3(Box<BlockHeaderV3>),
+    BlockHeaderV1(Arc<BlockHeaderV1>),
+    BlockHeaderV2(Arc<BlockHeaderV2>),
+    BlockHeaderV3(Arc<BlockHeaderV3>),
 }
 
 impl BlockHeader {
@@ -409,7 +411,7 @@ impl BlockHeader {
                 &inner_lite.try_to_vec().expect("Failed to serialize"),
                 &inner_rest.try_to_vec().expect("Failed to serialize"),
             );
-            Self::BlockHeaderV1(Box::new(BlockHeaderV1 {
+            Self::BlockHeaderV1(Arc::new(BlockHeaderV1 {
                 prev_hash,
                 inner_lite,
                 inner_rest,
@@ -438,7 +440,7 @@ impl BlockHeader {
                 &inner_lite.try_to_vec().expect("Failed to serialize"),
                 &inner_rest.try_to_vec().expect("Failed to serialize"),
             );
-            Self::BlockHeaderV2(Box::new(BlockHeaderV2 {
+            Self::BlockHeaderV2(Arc::new(BlockHeaderV2 {
                 prev_hash,
                 inner_lite,
                 inner_rest,
@@ -470,7 +472,7 @@ impl BlockHeader {
                 &inner_lite.try_to_vec().expect("Failed to serialize"),
                 &inner_rest.try_to_vec().expect("Failed to serialize"),
             );
-            Self::BlockHeaderV3(Box::new(BlockHeaderV3 {
+            Self::BlockHeaderV3(Arc::new(BlockHeaderV3 {
                 prev_hash,
                 inner_lite,
                 inner_rest,
@@ -530,7 +532,7 @@ impl BlockHeader {
                 &inner_lite.try_to_vec().expect("Failed to serialize"),
                 &inner_rest.try_to_vec().expect("Failed to serialize"),
             );
-            Self::BlockHeaderV1(Box::new(BlockHeaderV1 {
+            Self::BlockHeaderV1(Arc::new(BlockHeaderV1 {
                 prev_hash: CryptoHash::default(),
                 inner_lite,
                 inner_rest,
@@ -559,7 +561,7 @@ impl BlockHeader {
                 &inner_lite.try_to_vec().expect("Failed to serialize"),
                 &inner_rest.try_to_vec().expect("Failed to serialize"),
             );
-            Self::BlockHeaderV2(Box::new(BlockHeaderV2 {
+            Self::BlockHeaderV2(Arc::new(BlockHeaderV2 {
                 prev_hash: CryptoHash::default(),
                 inner_lite,
                 inner_rest,
@@ -591,7 +593,7 @@ impl BlockHeader {
                 &inner_lite.try_to_vec().expect("Failed to serialize"),
                 &inner_rest.try_to_vec().expect("Failed to serialize"),
             );
-            Self::BlockHeaderV3(Box::new(BlockHeaderV3 {
+            Self::BlockHeaderV3(Arc::new(BlockHeaderV3 {
                 prev_hash: CryptoHash::default(),
                 inner_lite,
                 inner_rest,

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use num_rational::Rational;
 
@@ -261,19 +262,22 @@ impl BlockHeader {
             BlockHeader::BlockHeaderV1(_) | BlockHeader::BlockHeaderV2(_) => {
                 panic!("old header should not appear in tests")
             }
-            BlockHeader::BlockHeaderV3(header) => header,
+            BlockHeader::BlockHeaderV3(header) => Arc::make_mut(header),
         }
     }
 
     pub fn set_lastest_protocol_version(&mut self, latest_protocol_version: ProtocolVersion) {
         match self {
             BlockHeader::BlockHeaderV1(header) => {
+                let header = Arc::make_mut(header);
                 header.inner_rest.latest_protocol_version = latest_protocol_version;
             }
             BlockHeader::BlockHeaderV2(header) => {
+                let header = Arc::make_mut(header);
                 header.inner_rest.latest_protocol_version = latest_protocol_version;
             }
             BlockHeader::BlockHeaderV3(header) => {
+                let header = Arc::make_mut(header);
                 header.inner_rest.latest_protocol_version = latest_protocol_version;
             }
         }
@@ -287,14 +291,17 @@ impl BlockHeader {
         );
         match self {
             BlockHeader::BlockHeaderV1(header) => {
+                let header = Arc::make_mut(header);
                 header.hash = hash;
                 header.signature = signature;
             }
             BlockHeader::BlockHeaderV2(header) => {
+                let header = Arc::make_mut(header);
                 header.hash = hash;
                 header.signature = signature;
             }
             BlockHeader::BlockHeaderV3(header) => {
+                let header = Arc::make_mut(header);
                 header.hash = hash;
                 header.signature = signature;
             }
@@ -305,14 +312,21 @@ impl BlockHeader {
 impl Block {
     pub fn mut_header(&mut self) -> &mut BlockHeader {
         match self {
-            Block::BlockV1(block) => &mut block.header,
-            Block::BlockV2(block) => &mut block.header,
+            Block::BlockV1(block) => {
+                let block = Arc::make_mut(block);
+                &mut block.header
+            }
+            Block::BlockV2(block) => {
+                let block = Arc::make_mut(block);
+                &mut block.header
+            }
         }
     }
 
     pub fn set_chunks(&mut self, chunks: Vec<ShardChunkHeader>) {
         match self {
             Block::BlockV1(block) => {
+                let block = Arc::make_mut(block);
                 let legacy_chunks = chunks
                     .into_iter()
                     .map(|chunk| match chunk {
@@ -325,10 +339,11 @@ impl Block {
                         }
                     })
                     .collect();
-                block.as_mut().chunks = legacy_chunks;
+                block.chunks = legacy_chunks;
             }
             Block::BlockV2(block) => {
-                block.as_mut().chunks = chunks;
+                let block = Arc::make_mut(block);
+                block.chunks = chunks;
             }
         }
     }

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -609,7 +609,7 @@ impl From<BlockHeaderView> for BlockHeader {
                 hash: CryptoHash::default(),
             };
             header.init();
-            BlockHeader::BlockHeaderV1(Box::new(header))
+            BlockHeader::BlockHeaderV1(Arc::new(header))
         } else if last_header_v2_version.is_none()
             || view.latest_protocol_version <= last_header_v2_version.unwrap()
         {
@@ -641,7 +641,7 @@ impl From<BlockHeaderView> for BlockHeader {
                 hash: CryptoHash::default(),
             };
             header.init();
-            BlockHeader::BlockHeaderV2(Box::new(header))
+            BlockHeader::BlockHeaderV2(Arc::new(header))
         } else {
             let mut header = BlockHeaderV3 {
                 prev_hash: view.prev_hash,
@@ -673,7 +673,7 @@ impl From<BlockHeaderView> for BlockHeader {
                 hash: CryptoHash::default(),
             };
             header.init();
-            BlockHeader::BlockHeaderV3(Box::new(header))
+            BlockHeader::BlockHeaderV3(Arc::new(header))
         }
     }
 }

--- a/integration-tests/src/tests/client/challenges.rs
+++ b/integration-tests/src/tests/client/challenges.rs
@@ -47,7 +47,7 @@ fn test_block_with_challenges() {
     {
         let body = match &mut block {
             Block::BlockV1(_) => unreachable!(),
-            Block::BlockV2(body) => body.as_mut(),
+            Block::BlockV2(body) => Arc::make_mut(body),
         };
         let challenge_body = ChallengeBody::BlockDoubleSign(BlockDoubleSign {
             left_block_header: genesis.header().try_to_vec().unwrap(),

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -1240,7 +1240,7 @@ fn test_bad_orphan() {
             // Change the chunk in any way, chunk_headers_root won't match
             let body = match &mut block {
                 Block::BlockV1(_) => unreachable!(),
-                Block::BlockV2(body) => body.as_mut(),
+                Block::BlockV2(body) => Arc::make_mut(body),
             };
             let chunk = match &mut body.chunks[0] {
                 ShardChunkHeader::V1(_) => unreachable!(),
@@ -1276,7 +1276,7 @@ fn test_bad_orphan() {
         {
             let body = match &mut block {
                 Block::BlockV1(_) => unreachable!(),
-                Block::BlockV2(body) => body.as_mut(),
+                Block::BlockV2(body) => Arc::make_mut(body),
             };
             let chunk = match &mut body.chunks[0] {
                 ShardChunkHeader::V1(_) => unreachable!(),
@@ -3137,8 +3137,9 @@ fn test_header_version_downgrade() {
         let mut header = header_view.into();
 
         // BlockHeaderV1, but protocol version is newest
-        match header {
-            BlockHeader::BlockHeaderV1(ref mut header) => {
+        match &mut header {
+            BlockHeader::BlockHeaderV1(header) => {
+                let header = Arc::make_mut(header);
                 header.inner_rest.latest_protocol_version = PROTOCOL_VERSION;
                 let (hash, signature) = validator_signer.sign_block_header_parts(
                     header.prev_hash,

--- a/test-utils/testlib/src/process_blocks.rs
+++ b/test-utils/testlib/src/process_blocks.rs
@@ -1,12 +1,14 @@
 use near_chain::{Block, BlockHeader};
 use near_crypto::KeyType;
 use near_primitives::validator_signer::InMemoryValidatorSigner;
+use std::sync::Arc;
 
 pub fn set_no_chunk_in_block(block: &mut Block, prev_block: &Block) {
     let chunk_headers = vec![prev_block.chunks()[0].clone()];
     block.set_chunks(chunk_headers.clone());
     match block.mut_header() {
         BlockHeader::BlockHeaderV1(header) => {
+            let header = Arc::make_mut(header);
             header.inner_rest.chunk_headers_root =
                 Block::compute_chunk_headers_root(&chunk_headers).0;
             header.inner_rest.chunk_tx_root = Block::compute_chunk_tx_root(&chunk_headers);
@@ -17,6 +19,7 @@ pub fn set_no_chunk_in_block(block: &mut Block, prev_block: &Block) {
             header.inner_rest.gas_price = prev_block.header().gas_price();
         }
         BlockHeader::BlockHeaderV2(header) => {
+            let header = Arc::make_mut(header);
             header.inner_rest.chunk_headers_root =
                 Block::compute_chunk_headers_root(&chunk_headers).0;
             header.inner_rest.chunk_tx_root = Block::compute_chunk_tx_root(&chunk_headers);
@@ -27,6 +30,7 @@ pub fn set_no_chunk_in_block(block: &mut Block, prev_block: &Block) {
             header.inner_rest.gas_price = prev_block.header().gas_price();
         }
         BlockHeader::BlockHeaderV3(header) => {
+            let header = Arc::make_mut(header);
             header.inner_rest.chunk_headers_root =
                 Block::compute_chunk_headers_root(&chunk_headers).0;
             header.inner_rest.chunk_tx_root = Block::compute_chunk_tx_root(&chunk_headers);


### PR DESCRIPTION
Prep work for #6811

This is a somewhat large change of the internal model, as now this types
are mostly immutable. This seems reasonable -- I can imagine us doing
things like fetching a block on the database thread, putting it into the
cache and handling a reference to it to HTTP server.

It seems that blocks are immutable in practice -- the only exception are
some testing utilities, but `Arc::make_mut` deals with those cases.