### PR TITLE
feat: Lower min gas price on nightly

### DIFF
--- a/chain/chain/Cargo.toml
+++ b/chain/chain/Cargo.toml
@@ -50,10 +50,12 @@ protocol_feature_chunk_only_producers = [
 ]
 
 protocol_feature_routing_exchange_algorithm = []
+protocol_feature_lower_min_gas_price = []
 nightly = [
   "nightly_protocol",
   "protocol_feature_chunk_only_producers",
   "protocol_feature_routing_exchange_algorithm",
+  "protocol_feature_lower_min_gas_price",
 ]
 nightly_protocol = [
   "near-store/nightly_protocol",

--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -39,7 +39,7 @@ fn build_chain() {
     //     cargo insta test --accept -p near-chain --features nightly -- tests::simple_chain::build_chain
     let hash = chain.head().unwrap().last_block_hash;
     if cfg!(feature = "nightly") {
-        insta::assert_display_snapshot!(hash, @"8F4vXPPNevoQXVGdwKAZQfzzxhSyqWp3xJiik4RMUKSk");
+        insta::assert_display_snapshot!(hash, @"7Db9S56zVuTKvYGnHXvsJYH6CvQBBEm2TC7Y3S85SZps");
     } else {
         insta::assert_display_snapshot!(hash, @"sFAi6Xq5jWcbRetAkMQ3A44GvfLHSLMnb8SqaRsmWmo");
     }
@@ -68,7 +68,7 @@ fn build_chain() {
 
     let hash = chain.head().unwrap().last_block_hash;
     if cfg!(feature = "nightly") {
-        insta::assert_display_snapshot!(hash, @"DrW7MsRaFhEdjQcxjqrTXvNmQ1eptgURQ7RUTeZnrBXC");
+        insta::assert_display_snapshot!(hash, @"HbPMs5o1Twqb7ZqrrhaCGawwZbYJVaPHZ7tfoihcnYxc");
     } else {
         insta::assert_display_snapshot!(hash, @"F5srbRRkG5KBzvDzEpDiiJp257SCVUaeFhNeXAddbHGZ");
     }

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -30,7 +30,7 @@ use near_primitives::types::{
 };
 use near_primitives::version::{
     ProtocolVersion, MIN_GAS_PRICE_NEP_92, MIN_GAS_PRICE_NEP_92_FIX, MIN_PROTOCOL_VERSION_NEP_92,
-    MIN_PROTOCOL_VERSION_NEP_92_FIX,
+    MIN_PROTOCOL_VERSION_NEP_92_FIX, REDUCED_MIN_GAS_PRICE
 };
 use near_primitives::views::{EpochValidatorInfo, QueryRequest, QueryResponse};
 use near_store::{PartialStorage, ShardTries, Store, StoreUpdate, Trie, WrappedTrieChanges};
@@ -171,7 +171,9 @@ impl BlockEconomicsConfig {
     const MAX_GAS_MULTIPLIER: u128 = 20;
     /// Compute min gas price according to protocol version and genesis protocol version.
     pub fn min_gas_price(&self, protocol_version: ProtocolVersion) -> Balance {
-        if self.genesis_protocol_version < MIN_PROTOCOL_VERSION_NEP_92 {
+        if cfg!(feature = "protocol_feature_lower_min_gas_price") {
+           REDUCED_MIN_GAS_PRICE
+        } else if self.genesis_protocol_version < MIN_PROTOCOL_VERSION_NEP_92 {
             if protocol_version >= MIN_PROTOCOL_VERSION_NEP_92_FIX {
                 MIN_GAS_PRICE_NEP_92_FIX
             } else if protocol_version >= MIN_PROTOCOL_VERSION_NEP_92 {

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -30,7 +30,7 @@ use near_primitives::types::{
 };
 use near_primitives::version::{
     ProtocolVersion, MIN_GAS_PRICE_NEP_92, MIN_GAS_PRICE_NEP_92_FIX, MIN_PROTOCOL_VERSION_NEP_92,
-    MIN_PROTOCOL_VERSION_NEP_92_FIX, REDUCED_MIN_GAS_PRICE
+    MIN_PROTOCOL_VERSION_NEP_92_FIX, REDUCED_MIN_GAS_PRICE,
 };
 use near_primitives::views::{EpochValidatorInfo, QueryRequest, QueryResponse};
 use near_store::{PartialStorage, ShardTries, Store, StoreUpdate, Trie, WrappedTrieChanges};
@@ -172,7 +172,7 @@ impl BlockEconomicsConfig {
     /// Compute min gas price according to protocol version and genesis protocol version.
     pub fn min_gas_price(&self, protocol_version: ProtocolVersion) -> Balance {
         if cfg!(feature = "protocol_feature_lower_min_gas_price") {
-           REDUCED_MIN_GAS_PRICE
+            REDUCED_MIN_GAS_PRICE
         } else if self.genesis_protocol_version < MIN_PROTOCOL_VERSION_NEP_92 {
             if protocol_version >= MIN_PROTOCOL_VERSION_NEP_92_FIX {
                 MIN_GAS_PRICE_NEP_92_FIX

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -31,6 +31,8 @@ pub const MIN_PROTOCOL_VERSION_NEP_92: ProtocolVersion = 31;
 pub const MIN_GAS_PRICE_NEP_92_FIX: Balance = 100_000_000;
 pub const MIN_PROTOCOL_VERSION_NEP_92_FIX: ProtocolVersion = 32;
 
+pub const REDUCED_MIN_GAS_PRICE: Balance = 10_000_000;
+
 pub const CORRECT_RANDOM_VALUE_PROTOCOL_VERSION: ProtocolVersion = 33;
 
 /// See [NEP 71](https://github.com/nearprotocol/NEPs/pull/71)
@@ -162,6 +164,9 @@ pub enum ProtocolFeature {
     /// alpha is min stake ratio
     #[cfg(feature = "protocol_feature_fix_staking_threshold")]
     FixStakingThreshold,
+
+    #[cfg(feature = "protocol_feature_lower_min_gas_price")]
+    LowerMinGasPrice,
 }
 
 /// Both, outgoing and incoming tcp connections to peers, will be rejected if `peer's`
@@ -178,7 +183,7 @@ const STABLE_PROTOCOL_VERSION: ProtocolVersion = 54;
 pub const PROTOCOL_VERSION: ProtocolVersion = STABLE_PROTOCOL_VERSION;
 /// Current latest nightly version of the protocol.
 #[cfg(feature = "nightly_protocol")]
-pub const PROTOCOL_VERSION: ProtocolVersion = 128;
+pub const PROTOCOL_VERSION: ProtocolVersion = 129;
 
 /// The points in time after which the voting for the protocol version should start.
 #[allow(dead_code)]
@@ -243,6 +248,8 @@ impl ProtocolFeature {
             ProtocolFeature::RoutingExchangeAlgorithm => 117,
             #[cfg(feature = "protocol_feature_fix_staking_threshold")]
             ProtocolFeature::FixStakingThreshold => 126,
+            #[cfg(feature = "protocol_feature_lower_min_gas_price")]
+            ProtocolFeature::LowerMinGasPrice => 129,
         }
     }
 }


### PR DESCRIPTION
This is an implementation of the community proposal to [lower the gas floor price](https://gov.near.org/t/proposal-reduce-the-gas-floor-price-on-the-near-network/20980/6) from 0.0001 N/TGas to 0.00001 N/TGas. This should be tested via a feature flag on nightly first.

Test plan: `cargo test --features nightly`

This is my first contribution to nearcore, please let me know if I'm missing something big here :)