### PR TITLE
refactor: use consistent field name for error

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1089,13 +1089,13 @@ impl Chain {
                     match chain_update.mark_block_as_challenged(&block_hash, None) {
                         Ok(()) => {}
                         Err(err) => {
-                            warn!(target: "chain", %block_hash, error = ?err, "Error saving block as challenged");
+                            warn!(target: "chain", %block_hash, ?err, "Error saving block as challenged");
                         }
                     }
                 }
             }
             Err(err) => {
-                warn!(target: "chain", error = ?err, "Invalid challenge: {:#?}", challenge);
+                warn!(target: "chain", ?err, "Invalid challenge: {:#?}", challenge);
             }
         }
         unwrap_or_return!(chain_update.commit());

--- a/neard/src/log_config_watcher.rs
+++ b/neard/src/log_config_watcher.rs
@@ -51,7 +51,7 @@ impl LogConfigWatcher {
             Err(err) => match err.kind() {
                 ErrorKind::NotFound => {
                     if let UpdateBehavior::UpdateOrReset = update_behavior {
-                        info!(target: "neard", logging_config_path=%self.watched_path.display(), err=?err, "Reset the logging config because the logging config file doesn't exist.");
+                        info!(target: "neard", logging_config_path=%self.watched_path.display(), ?err, "Reset the logging config because the logging config file doesn't exist.");
                         return reload_env_filter(None, None).map_err(LogConfigError::Reload);
                     }
                     Ok(())
@@ -63,7 +63,7 @@ impl LogConfigWatcher {
 
     pub fn update(&self, update_behavior: UpdateBehavior) {
         if let Err(err) = self.do_update(update_behavior) {
-            error!(target: "neard", err=?err, "Failed to update the logging config.");
+            error!(target: "neard", ?err, "Failed to update the logging config.");
         }
     }
 }


### PR DESCRIPTION
Most of the code uses `?err`, rather than `error`, so let's use it here
as well, to make jqing for field easier.