### PR TITLE
Run mocknet nodes on port 3030

### DIFF
--- a/pytest/lib/mocknet.py
+++ b/pytest/lib/mocknet.py
@@ -766,6 +766,7 @@ def update_config_file(config_filename_in, config_filename_out, all_node_pks,
     config_json['archive'] = True
     config_json['archival_peer_connections_lower_bound'] = 1
     config_json['network']['boot_nodes'] = ','.join(node_addresses)
+    config_json['rpc']['addr'] = '0.0.0.0:3030'
 
     with open(config_filename_out, 'w') as f:
         json.dump(config_json, f, indent=2)


### PR DESCRIPTION
Mocknet scripts assume the nodes run on port 3030, for example here https://github.com/near/nearcore/blob/master/pytest/lib/mocknet_helpers.py#L10, but it's not the only reference to port 3030.
After a recent infrastructure change the nodes run on port 4040 by default.

This PR sets a port that works well with mocknet. An alternative would be to update mocknet scripts to use a different port, but that requires more maintenance.