### PR TITLE
Fix local build on mac

### DIFF
--- a/core/crypto/src/key_file.rs
+++ b/core/crypto/src/key_file.rs
@@ -22,7 +22,7 @@ impl KeyFile {
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            let perm = std::fs::Permissions::from_mode(libc::S_IWUSR | libc::S_IRUSR);
+            let perm = std::fs::Permissions::from_mode((libc::S_IWUSR | libc::S_IRUSR).into());
             file.set_permissions(perm)?;
         }
         let str = serde_json::to_string_pretty(self)?;


### PR DESCRIPTION
mode_t is u16 not u32 on apple os https://github.com/rust-lang/libc/blob/master/src/unix/bsd/apple/mod.rs#L11