### PR TITLE
fix: platform-compatibility bug in key_file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2853,7 +2853,6 @@ dependencies = [
  "derive_more",
  "ed25519-dalek",
  "hex-literal",
- "libc",
  "near-account-id",
  "once_cell",
  "parity-secp256k1",

--- a/core/crypto/Cargo.toml
+++ b/core/crypto/Cargo.toml
@@ -21,7 +21,6 @@ derive_more = "0.99.9"
 ed25519-dalek = "1"
 primitive-types = "0.10"
 once_cell = "1.5.2"
-libc = "0.2"
 parity-secp256k1 = "0.7"
 rand = "0.7"
 rand_core = "0.5"
@@ -41,4 +40,3 @@ deepsize_feature = [
   "deepsize",
   "near-account-id/deepsize_feature",
 ]
-

--- a/core/crypto/src/key_file.rs
+++ b/core/crypto/src/key_file.rs
@@ -22,7 +22,8 @@ impl KeyFile {
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            let perm = std::fs::Permissions::from_mode((libc::S_IWUSR | libc::S_IRUSR).into());
+            // Only the owner can read or write the file.
+            let perm = std::fs::Permissions::from_mode(0o600);
             file.set_permissions(perm)?;
         }
         let str = serde_json::to_string_pretty(self)?;


### PR DESCRIPTION
Permissions::from_mode is portable across unixes and requires u32. But
libc::mode_t isn't guaranteed to be u32, so the current code might break
on non-Linux Unix.

Instead of relying on platform-specific libc, just specify mode directly
using traditional octals.