### PR TITLE
refactor: remove redundant clones

### DIFF
--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -2060,8 +2060,7 @@ impl<'a> ChainStoreUpdate<'a> {
         runtime_adapter: &dyn RuntimeAdapter,
         block_hash: &CryptoHash,
     ) -> Vec<ShardUId> {
-        let block_header =
-            self.get_block_header(block_hash).expect("block header must exist").clone();
+        let block_header = self.get_block_header(block_hash).expect("block header must exist");
         let shard_layout = runtime_adapter
             .get_shard_layout(block_header.epoch_id())
             .expect("epoch info must exist");
@@ -2143,10 +2142,8 @@ impl<'a> ChainStoreUpdate<'a> {
             }
         }
 
-        let block = self
-            .get_block(&block_hash)
-            .expect("block data is not expected to be already cleaned")
-            .clone();
+        let block =
+            self.get_block(&block_hash).expect("block data is not expected to be already cleaned");
         let height = block.header().height();
 
         // 2. Delete shard_id-indexed data (Receipts, State Headers and Parts, etc.)
@@ -2508,7 +2505,7 @@ impl<'a> ChainStoreUpdate<'a> {
         source_store: &mut ChainStore,
     ) -> Result<ChainStoreUpdate<'a>, Error> {
         let mut chain_store_update = ChainStoreUpdate::new(chain_store);
-        let block = source_store.get_block(block_hash)?.clone();
+        let block = source_store.get_block(block_hash)?;
         let header = block.header().clone();
         let height = header.height();
         let tip = Tip {
@@ -2546,7 +2543,7 @@ impl<'a> ChainStoreUpdate<'a> {
         chain_store_update
             .chain_store_cache_update
             .block_extras
-            .insert(*block_hash, source_store.get_block_extra(block_hash)?.clone());
+            .insert(*block_hash, source_store.get_block_extra(block_hash)?);
         let shard_layout = source_runtime.get_shard_layout(&header.epoch_id())?;
         for shard_uid in shard_layout.get_shard_uids() {
             chain_store_update.chain_store_cache_update.chunk_extras.insert(
@@ -3166,7 +3163,7 @@ mod tests {
     fn test_tx_validity_long_fork() {
         let transaction_validity_period = 5;
         let mut chain = get_chain();
-        let genesis = chain.get_block_by_height(0).unwrap().clone();
+        let genesis = chain.get_block_by_height(0).unwrap();
         let signer = Arc::new(InMemoryValidatorSigner::from_seed(
             "test1".parse().unwrap(),
             KeyType::ED25519,
@@ -3224,7 +3221,7 @@ mod tests {
     fn test_tx_validity_normal_case() {
         let transaction_validity_period = 5;
         let mut chain = get_chain();
-        let genesis = chain.get_block_by_height(0).unwrap().clone();
+        let genesis = chain.get_block_by_height(0).unwrap();
         let signer = Arc::new(InMemoryValidatorSigner::from_seed(
             "test1".parse().unwrap(),
             KeyType::ED25519,
@@ -3278,7 +3275,7 @@ mod tests {
     fn test_tx_validity_off_by_one() {
         let transaction_validity_period = 5;
         let mut chain = get_chain();
-        let genesis = chain.get_block_by_height(0).unwrap().clone();
+        let genesis = chain.get_block_by_height(0).unwrap();
         let signer = Arc::new(InMemoryValidatorSigner::from_seed(
             "test1".parse().unwrap(),
             KeyType::ED25519,
@@ -3328,7 +3325,7 @@ mod tests {
     #[test]
     fn test_cache_invalidation() {
         let mut chain = get_chain();
-        let genesis = chain.get_block_by_height(0).unwrap().clone();
+        let genesis = chain.get_block_by_height(0).unwrap();
         let signer = Arc::new(InMemoryValidatorSigner::from_seed(
             "test1".parse().unwrap(),
             KeyType::ED25519,
@@ -3373,7 +3370,7 @@ mod tests {
     fn test_clear_old_data() {
         let mut chain = get_chain_with_epoch_length(1);
         let runtime_adapter = chain.runtime_adapter.clone();
-        let genesis = chain.get_block_by_height(0).unwrap().clone();
+        let genesis = chain.get_block_by_height(0).unwrap();
         let signer = Arc::new(InMemoryValidatorSigner::from_seed(
             "test1".parse().unwrap(),
             KeyType::ED25519,
@@ -3512,7 +3509,7 @@ mod tests {
     fn test_clear_old_data_fixed_height() {
         let mut chain = get_chain();
         let runtime_adapter = chain.runtime_adapter.clone();
-        let genesis = chain.get_block_by_height(0).unwrap().clone();
+        let genesis = chain.get_block_by_height(0).unwrap();
         let signer = Arc::new(InMemoryValidatorSigner::from_seed(
             "test1".parse().unwrap(),
             KeyType::ED25519,
@@ -3584,7 +3581,7 @@ mod tests {
 
     fn test_clear_old_data_too_many_heights_common(gc_blocks_limit: NumBlocks) {
         let mut chain = get_chain_with_epoch_length(1);
-        let genesis = chain.get_block_by_height(0).unwrap().clone();
+        let genesis = chain.get_block_by_height(0).unwrap();
         let signer = Arc::new(InMemoryValidatorSigner::from_seed(
             "test1".parse().unwrap(),
             KeyType::ED25519,
@@ -3669,7 +3666,7 @@ mod tests {
     fn test_fork_chunk_tail_updates() {
         let mut chain = get_chain();
         let runtime_adapter = chain.runtime_adapter.clone();
-        let genesis = chain.get_block_by_height(0).unwrap().clone();
+        let genesis = chain.get_block_by_height(0).unwrap();
         let signer = Arc::new(InMemoryValidatorSigner::from_seed(
             "test1".parse().unwrap(),
             KeyType::ED25519,

--- a/chain/chain/src/tests/challenges.rs
+++ b/chain/chain/src/tests/challenges.rs
@@ -52,7 +52,7 @@ fn challenges_new_head_prev() {
     assert_eq!(chain.head_header().unwrap().hash(), &hashes[2]);
 
     // Add two more blocks
-    let b3 = Block::empty(&chain.get_block(&hashes[2]).unwrap().clone(), &*signer);
+    let b3 = Block::empty(&chain.get_block(&hashes[2]).unwrap(), &*signer);
     let _ = chain.process_block_test(&None, b3.clone()).unwrap().unwrap();
 
     let b4 = Block::empty(&b3, &*signer);
@@ -61,7 +61,7 @@ fn challenges_new_head_prev() {
     assert_eq!(chain.head_header().unwrap().hash(), &new_head);
 
     // Add two more blocks on an alternative chain
-    let b3 = Block::empty(&chain.get_block(&hashes[2]).unwrap().clone(), &*signer);
+    let b3 = Block::empty(&chain.get_block(&hashes[2]).unwrap(), &*signer);
     let _ = chain.process_block_test(&None, b3.clone()).unwrap();
 
     let b4 = Block::empty(&b3, &*signer);

--- a/chain/chain/src/tests/gc.rs
+++ b/chain/chain/src/tests/gc.rs
@@ -178,7 +178,7 @@ fn gc_fork_common(simple_chains: Vec<SimpleChain>, max_changes: usize) {
     let shard_to_check_trie = rng.gen_range(0, num_shards);
     let shard_uid = ShardUId { version: 0, shard_id: shard_to_check_trie as u32 };
     let trie1 = tries1.get_trie_for_shard(shard_uid);
-    let genesis1 = chain1.get_block_by_height(0).unwrap().clone();
+    let genesis1 = chain1.get_block_by_height(0).unwrap();
     let mut states1 = vec![];
     states1.push((
         genesis1,
@@ -639,7 +639,7 @@ fn test_fork_far_away_from_epoch_end() {
     let num_shards = 1;
     let mut chain1 = get_chain_with_epoch_length_and_num_shards(epoch_length, num_shards);
     let tries1 = chain1.runtime_adapter.get_tries();
-    let genesis1 = chain1.get_block_by_height(0).unwrap().clone();
+    let genesis1 = chain1.get_block_by_height(0).unwrap();
     let mut states1 = vec![(
         genesis1,
         vec![Trie::empty_root(); num_shards as usize],
@@ -699,7 +699,7 @@ fn test_fork_far_away_from_epoch_end() {
     {
         let (source_block1, state_root1, _) = states1.last().unwrap().clone();
         do_fork(
-            source_block1.clone(),
+            source_block1,
             state_root1,
             tries1.clone(),
             &mut chain1,

--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -78,7 +78,7 @@ fn build_chain() {
 fn build_chain_with_orhpans() {
     init_test_logger();
     let (mut chain, _, signer) = setup();
-    let mut blocks = vec![chain.get_block(&chain.genesis().hash().clone()).unwrap().clone()];
+    let mut blocks = vec![chain.get_block(&chain.genesis().hash().clone()).unwrap()];
     for i in 1..4 {
         let block = Block::empty(&blocks[i - 1], &*signer);
         blocks.push(block);

--- a/chain/chain/src/tests/sync_chain.rs
+++ b/chain/chain/src/tests/sync_chain.rs
@@ -8,7 +8,7 @@ fn chain_sync_headers() {
     init_test_logger();
     let (mut chain, _, bls_signer) = setup();
     assert_eq!(chain.header_head().unwrap().height, 0);
-    let mut blocks = vec![chain.get_block(&chain.genesis().hash().clone()).unwrap().clone()];
+    let mut blocks = vec![chain.get_block(&chain.genesis().hash().clone()).unwrap()];
     let mut block_merkle_tree = PartialMerkleTree::default();
     for i in 0..4 {
         blocks.push(Block::empty_with_block_merkle_tree(

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -1532,8 +1532,7 @@ impl ShardsManager {
                     // we are not sure if we are using the correct epoch id for validation, so
                     // we can't be sure if the chunk header is actually invalid. Let's return
                     // DbNotFoundError for now, which means we don't have all needed information yet
-                    Err(DBNotFoundErr(format!("block {:?}", header.prev_block_hash()).to_string())
-                        .into())
+                    Err(DBNotFoundErr(format!("block {:?}", header.prev_block_hash())).into())
                 };
             }
             Ok(true) => (),
@@ -1548,8 +1547,7 @@ impl ShardsManager {
             return if epoch_id_confirmed {
                 Err(Error::InvalidChunkHeader)
             } else {
-                Err(DBNotFoundErr(format!("block {:?}", header.prev_block_hash()).to_string())
-                    .into())
+                Err(DBNotFoundErr(format!("block {:?}", header.prev_block_hash())).into())
             };
         }
         Ok(())
@@ -2286,7 +2284,7 @@ mod test {
         let mut shards_manager = ShardsManager::new(
             Some("test".parse().unwrap()),
             runtime_adapter.clone(),
-            network_adapter.clone(),
+            network_adapter,
             TEST_SEED,
         );
         let signer =

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -895,7 +895,7 @@ impl Handler<Status> for ClientActor {
                     ),
                 ),
                 current_head_status: head.clone().into(),
-                current_header_head_status: self.client.chain.header_head()?.clone().into(),
+                current_header_head_status: self.client.chain.header_head()?.into(),
                 orphans: self.client.chain.orphans().list_orphans_by_height(),
                 blocks_with_missing_chunks: self
                     .client

--- a/chain/client/src/sync.rs
+++ b/chain/client/src/sync.rs
@@ -1446,7 +1446,7 @@ mod test {
             1000,
             100,
         );
-        let genesis = chain.get_block(&chain.genesis().hash().clone()).unwrap().clone();
+        let genesis = chain.get_block(&chain.genesis().hash().clone()).unwrap();
 
         let mut last_block = &genesis;
         let mut all_blocks = vec![];

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -117,7 +117,7 @@ pub fn setup(
     };
     let mut chain =
         Chain::new(runtime.clone(), &chain_genesis, doomslug_threshold_mode, !archive).unwrap();
-    let genesis_block = chain.get_block(&chain.genesis().hash().clone()).unwrap().clone();
+    let genesis_block = chain.get_block(&chain.genesis().hash().clone()).unwrap();
 
     let signer = Arc::new(InMemoryValidatorSigner::from_seed(
         account_id.clone(),
@@ -1450,7 +1450,7 @@ impl TestEnv {
 
     pub fn query_account(&mut self, account_id: AccountId) -> AccountView {
         let head = self.clients[0].chain.head().unwrap();
-        let last_block = self.clients[0].chain.get_block(&head.last_block_hash).unwrap().clone();
+        let last_block = self.clients[0].chain.get_block(&head.last_block_hash).unwrap();
         let last_chunk_header = &last_block.chunks()[0];
         let response = self.clients[0]
             .runtime_adapter
@@ -1473,7 +1473,7 @@ impl TestEnv {
 
     pub fn query_state(&mut self, account_id: AccountId) -> Vec<StateItem> {
         let head = self.clients[0].chain.head().unwrap();
-        let last_block = self.clients[0].chain.get_block(&head.last_block_hash).unwrap().clone();
+        let last_block = self.clients[0].chain.get_block(&head.last_block_hash).unwrap();
         let last_chunk_header = &last_block.chunks()[0];
         let response = self.clients[0]
             .runtime_adapter
@@ -1549,7 +1549,7 @@ pub fn create_chunk_on_height_for_shard(
     shard_id: ShardId,
 ) -> (EncodedShardChunk, Vec<MerklePath>, Vec<Receipt>) {
     let last_block_hash = client.chain.head().unwrap().last_block_hash;
-    let last_block = client.chain.get_block(&last_block_hash).unwrap().clone();
+    let last_block = client.chain.get_block(&last_block_hash).unwrap();
     client
         .produce_chunk(
             last_block_hash,
@@ -1583,8 +1583,7 @@ pub fn create_chunk(
     replace_transactions: Option<Vec<SignedTransaction>>,
     replace_tx_root: Option<CryptoHash>,
 ) -> (EncodedShardChunk, Vec<MerklePath>, Vec<Receipt>, Block) {
-    let last_block =
-        client.chain.get_block_by_height(client.chain.head().unwrap().height).unwrap().clone();
+    let last_block = client.chain.get_block_by_height(client.chain.head().unwrap().height).unwrap();
     let next_height = last_block.header().height() + 1;
     let (mut chunk, mut merkle_paths, receipts) = client
         .produce_chunk(

--- a/chain/client/src/tests/catching_up.rs
+++ b/chain/client/src/tests/catching_up.rs
@@ -147,7 +147,7 @@ fn test_catchup_receipts_sync_common(wait_till: u64, send: u64, sync_hold: bool)
         }
         let (_, conn, _) = setup_mock_all_validators(
             validators.clone(),
-            key_pairs.clone(),
+            key_pairs,
             validator_groups,
             true,
             block_prod_time,
@@ -428,7 +428,7 @@ fn test_catchup_random_single_part_sync_common(skip_15: bool, non_zero: bool, he
 
         let check_amount =
             move |amounts: Arc<RwLock<HashMap<_, _, _>>>, account_id: AccountId, amount: u128| {
-                match amounts.write().unwrap().entry(account_id.clone()) {
+                match amounts.write().unwrap().entry(account_id) {
                     Entry::Occupied(entry) => {
                         println!("OCCUPIED {:?}", entry);
                         assert_eq!(*entry.get(), amount);
@@ -448,7 +448,7 @@ fn test_catchup_random_single_part_sync_common(skip_15: bool, non_zero: bool, he
         let connectors1 = connectors.clone();
         let (_, conn, _) = setup_mock_all_validators(
             validators.clone(),
-            key_pairs.clone(),
+            key_pairs,
             validator_groups,
             true,
             6000,
@@ -629,7 +629,7 @@ fn test_catchup_sanity_blocks_produced() {
             Arc::new(RwLock::new(vec![]));
 
         let heights = Arc::new(RwLock::new(HashMap::new()));
-        let heights1 = heights.clone();
+        let heights1 = heights;
 
         let check_height =
             move |hash: CryptoHash, height| match heights1.write().unwrap().entry(hash.clone()) {
@@ -645,7 +645,7 @@ fn test_catchup_sanity_blocks_produced() {
 
         let (_, conn, _) = setup_mock_all_validators(
             validators.clone(),
-            key_pairs.clone(),
+            key_pairs,
             validator_groups,
             true,
             2000,
@@ -716,7 +716,7 @@ fn test_chunk_grieving() {
         let block_prod_time: u64 = 3500;
         let (_, conn, _) = setup_mock_all_validators(
             validators.clone(),
-            key_pairs.clone(),
+            key_pairs,
             validator_groups,
             true,
             block_prod_time,
@@ -883,7 +883,7 @@ fn test_all_chunks_accepted_common(
 
         let (_, conn, _) = setup_mock_all_validators(
             validators.clone(),
-            key_pairs.clone(),
+            key_pairs,
             validator_groups,
             true,
             block_prod_time,

--- a/chain/client/src/tests/chunks_management.rs
+++ b/chain/client/src/tests/chunks_management.rs
@@ -16,7 +16,7 @@ fn test_request_chunk_restart() {
         env.produce_block(0, i);
         env.network_adapters[0].pop();
     }
-    let block1 = env.clients[0].chain.get_block_by_height(3).unwrap().clone();
+    let block1 = env.clients[0].chain.get_block_by_height(3).unwrap();
     let request = PartialEncodedChunkRequestMsg {
         chunk_hash: block1.chunks()[0].chunk_hash(),
         part_ords: vec![0],

--- a/chain/client/src/tests/cross_shard_tx.rs
+++ b/chain/client/src/tests/cross_shard_tx.rs
@@ -181,13 +181,13 @@ fn test_cross_shard_tx_callback(
             *presumable_epoch.write().unwrap() += 1;
             let connectors_ = connectors.write().unwrap();
             let connectors1 = connectors.clone();
-            let iteration1 = iteration.clone();
-            let nonce1 = nonce.clone();
-            let validators1 = validators.clone();
-            let successful_queries1 = successful_queries.clone();
-            let unsuccessful_queries1 = unsuccessful_queries.clone();
-            let balances1 = balances.clone();
-            let observed_balances1 = observed_balances.clone();
+            let iteration1 = iteration;
+            let nonce1 = nonce;
+            let validators1 = validators;
+            let successful_queries1 = successful_queries;
+            let unsuccessful_queries1 = unsuccessful_queries;
+            let balances1 = balances;
+            let observed_balances1 = observed_balances;
             let presumable_epoch1 = presumable_epoch.clone();
             actix::spawn(
                 connectors_[account_id_to_shard_id(&account_id, 8) as usize
@@ -235,7 +235,7 @@ fn test_cross_shard_tx_callback(
         if view_account_result.amount == expected {
             let mut successful_queries_local = successful_queries.write().unwrap();
             assert!(!successful_queries_local.contains(&account_id));
-            successful_queries_local.insert(account_id.clone());
+            successful_queries_local.insert(account_id);
             if successful_queries_local.len() == 8 {
                 println!("Finished iteration {}", iteration.load(Ordering::Relaxed));
 
@@ -425,7 +425,7 @@ fn test_cross_shard_tx_common(
 
         let (genesis_block, conn, block_stats) = setup_mock_all_validators(
             validators.clone(),
-            key_pairs.clone(),
+            key_pairs,
             validator_groups,
             true,
             block_production_time,

--- a/chain/epoch_manager/src/lib.rs
+++ b/chain/epoch_manager/src/lib.rs
@@ -181,13 +181,13 @@ impl EpochManager {
         self.save_epoch_info(
             &mut store_update,
             epoch_id,
-            source_epoch_manager.get_epoch_info(epoch_id)?.clone(),
+            source_epoch_manager.get_epoch_info(epoch_id)?,
         )?;
         // save next epoch info too
         self.save_epoch_info(
             &mut store_update,
             next_epoch_id,
-            source_epoch_manager.get_epoch_info(next_epoch_id)?.clone(),
+            source_epoch_manager.get_epoch_info(next_epoch_id)?,
         )?;
         // save next next epoch info if the block is the last block
         if source_epoch_manager.is_next_block_epoch_start(block_hash)? {
@@ -196,7 +196,7 @@ impl EpochManager {
             self.save_epoch_info(
                 &mut store_update,
                 &next_next_epoch_id,
-                source_epoch_manager.get_epoch_info(&next_next_epoch_id)?.clone(),
+                source_epoch_manager.get_epoch_info(&next_next_epoch_id)?,
             )?;
         }
 
@@ -345,9 +345,9 @@ impl EpochManager {
         last_block_info: &BlockInfo,
         last_block_hash: &CryptoHash,
     ) -> Result<EpochSummary, EpochError> {
-        let epoch_info = self.get_epoch_info(last_block_info.epoch_id())?.clone();
+        let epoch_info = self.get_epoch_info(last_block_info.epoch_id())?;
         let next_epoch_id = self.get_next_epoch_id(last_block_hash)?;
-        let next_epoch_info = self.get_epoch_info(&next_epoch_id)?.clone();
+        let next_epoch_info = self.get_epoch_info(&next_epoch_id)?;
 
         let EpochInfoAggregator {
             block_tracker: block_validator_tracker,
@@ -461,7 +461,7 @@ impl EpochManager {
         let validator_stake =
             epoch_info.validators_iter().map(|r| r.account_and_stake()).collect::<HashMap<_, _>>();
         let next_epoch_id = self.get_next_epoch_id_from_info(block_info)?;
-        let next_epoch_info = self.get_epoch_info(&next_epoch_id)?.clone();
+        let next_epoch_info = self.get_epoch_info(&next_epoch_id)?;
         self.save_epoch_validator_info(store_update, block_info.epoch_id(), &epoch_summary)?;
 
         let EpochSummary {
@@ -540,7 +540,7 @@ impl EpochManager {
                 // This is genesis block, we special case as new epoch.
                 assert_eq!(block_info.proposals_iter().len(), 0);
                 let pre_genesis_epoch_id = EpochId::default();
-                let genesis_epoch_info = self.get_epoch_info(&pre_genesis_epoch_id)?.clone();
+                let genesis_epoch_info = self.get_epoch_info(&pre_genesis_epoch_id)?;
                 self.save_block_info(&mut store_update, Arc::new(block_info))?;
                 self.save_epoch_info(
                     &mut store_update,
@@ -567,7 +567,7 @@ impl EpochManager {
                     *block_info.epoch_id_mut() = prev_block_info.epoch_id().clone();
                     *block_info.epoch_first_block_mut() = *prev_block_info.epoch_first_block();
                 }
-                let epoch_info = self.get_epoch_info(block_info.epoch_id())?.clone();
+                let epoch_info = self.get_epoch_info(block_info.epoch_id())?;
 
                 // Keep `slashed` from previous block if they are still in the epoch info stake change
                 // (e.g. we need to keep track that they are still slashed, because when we compute
@@ -762,7 +762,7 @@ impl EpochManager {
         height: BlockHeight,
         shard_id: ShardId,
     ) -> Result<ValidatorStake, EpochError> {
-        let epoch_info = self.get_epoch_info(epoch_id)?.clone();
+        let epoch_info = self.get_epoch_info(epoch_id)?;
         let validator_id = Self::chunk_producer_from_info(&epoch_info, height, shard_id);
         Ok(epoch_info.get_validator(validator_id))
     }
@@ -1005,7 +1005,7 @@ impl EpochManager {
             ValidatorInfoIdentifier::EpochId(ref id) => id.clone(),
             ValidatorInfoIdentifier::BlockHash(ref b) => self.get_epoch_id(b)?,
         };
-        let cur_epoch_info = self.get_epoch_info(&epoch_id)?.clone();
+        let cur_epoch_info = self.get_epoch_info(&epoch_id)?;
         let epoch_height = cur_epoch_info.epoch_height();
         let epoch_start_height = self.get_epoch_start_from_epoch_id(&epoch_id)?;
         let mut validator_to_shard = (0..cur_epoch_info.validators_len())
@@ -1497,7 +1497,7 @@ impl EpochManager {
         }
 
         let epoch_id = self.get_block_info(block_hash)?.epoch_id().clone();
-        let epoch_info = self.get_epoch_info(&epoch_id)?.clone();
+        let epoch_info = self.get_epoch_info(&epoch_id)?;
 
         let mut aggregator = EpochInfoAggregator::new(epoch_id.clone(), *block_hash);
         let mut cur_hash = *block_hash;
@@ -1547,7 +1547,7 @@ impl EpochManager {
         &self,
         block_hash: CryptoHash,
     ) -> Result<Option<BlockHeight>, EpochError> {
-        let cur_epoch_info = self.get_epoch_info_from_hash(&block_hash)?.clone();
+        let cur_epoch_info = self.get_epoch_info_from_hash(&block_hash)?;
         let next_epoch_id = self.get_next_epoch_id(&block_hash)?;
         let next_epoch_info = self.get_epoch_info(&next_epoch_id)?;
         if cur_epoch_info.protocol_version() != next_epoch_info.protocol_version() {

--- a/chain/epoch_manager/src/tests/mod.rs
+++ b/chain/epoch_manager/src/tests/mod.rs
@@ -544,7 +544,7 @@ fn test_double_sign_slashing1() {
     // Epoch 3 -> defined by proposals/slashes in h[1].
     record_block(&mut epoch_manager, h[4], h[5], 5, vec![]);
     let epoch_id = epoch_manager.get_epoch_id(&h[5]).unwrap();
-    let epoch_info = epoch_manager.get_epoch_info(&epoch_id).unwrap().clone();
+    let epoch_info = epoch_manager.get_epoch_info(&epoch_id).unwrap();
     assert_eq!(
         epoch_info
             .validators_iter()
@@ -1207,7 +1207,7 @@ fn test_epoch_info_aggregator() {
     record_block_with_final_block_hash(&mut em, h[1], h[3], h[0], 3, vec![]);
     assert_eq!(h[0], em.epoch_info_aggregator.last_block_hash);
     let epoch_id = em.get_epoch_id(&h[3]).unwrap();
-    let epoch_info = em.get_epoch_info(&epoch_id).unwrap().clone();
+    let epoch_info = em.get_epoch_info(&epoch_id).unwrap();
 
     let mut tracker = HashMap::new();
     update_tracker(&epoch_info, 1..4, &[1, 3], &mut tracker);
@@ -1255,7 +1255,7 @@ fn test_epoch_info_aggregator_data_loss() {
     record_block(&mut em, h[3], h[5], 5, vec![stake("test1".parse().unwrap(), stake_amount - 1)]);
     assert_eq!(h[3], em.epoch_info_aggregator.last_block_hash);
     let epoch_id = em.get_epoch_id(&h[5]).unwrap();
-    let epoch_info = em.get_epoch_info(&epoch_id).unwrap().clone();
+    let epoch_info = em.get_epoch_info(&epoch_id).unwrap();
     let mut tracker = HashMap::new();
     update_tracker(&epoch_info, 1..6, &[1, 3, 5], &mut tracker);
     let aggregator = em.get_epoch_info_aggregator_upto_last(&h[5]).unwrap();
@@ -1305,7 +1305,7 @@ fn test_epoch_info_aggregator_reorg_past_final_block() {
     record_block_with_final_block_hash(&mut em, h[3], h[4], h[3], 4, vec![]);
     record_block_with_final_block_hash(&mut em, h[2], h[5], h[1], 5, vec![]);
     let epoch_id = em.get_epoch_id(&h[5]).unwrap();
-    let epoch_info = em.get_epoch_info(&epoch_id).unwrap().clone();
+    let epoch_info = em.get_epoch_info(&epoch_id).unwrap();
     let mut tracker = HashMap::new();
     update_tracker(&epoch_info, 1..6, &[1, 2, 5], &mut tracker);
     let aggregator = em.get_epoch_info_aggregator_upto_last(&h[5]).unwrap();
@@ -1347,7 +1347,7 @@ fn test_epoch_info_aggregator_reorg_beginning_of_epoch() {
     // reorg
     record_block(&mut em, h[4], h[7], 7, vec![]);
     let epoch_id = em.get_epoch_id(&h[7]).unwrap();
-    let epoch_info = em.get_epoch_info(&epoch_id).unwrap().clone();
+    let epoch_info = em.get_epoch_info(&epoch_id).unwrap();
     let mut tracker = HashMap::new();
     update_tracker(&epoch_info, 5..8, &[7], &mut tracker);
     let aggregator = em.get_epoch_info_aggregator_upto_last(&h[7]).unwrap();
@@ -1752,8 +1752,8 @@ fn test_epoch_height_increase() {
     record_block(&mut epoch_manager, h[0], h[2], 2, vec![stake("test1".parse().unwrap(), 223)]);
     record_block(&mut epoch_manager, h[2], h[4], 4, vec![]);
 
-    let epoch_info2 = epoch_manager.get_epoch_info(&EpochId(h[2])).unwrap().clone();
-    let epoch_info3 = epoch_manager.get_epoch_info(&EpochId(h[4])).unwrap().clone();
+    let epoch_info2 = epoch_manager.get_epoch_info(&EpochId(h[2])).unwrap();
+    let epoch_info3 = epoch_manager.get_epoch_info(&EpochId(h[4])).unwrap();
     assert_ne!(epoch_info2.epoch_height(), epoch_info3.epoch_height());
 }
 
@@ -1787,10 +1787,10 @@ fn test_unstake_slash() {
         vec![stake("test1".parse().unwrap(), stake_amount)],
     );
 
-    let epoch_info1 = epoch_manager.get_epoch_info(&EpochId(h[1])).unwrap().clone();
-    let epoch_info2 = epoch_manager.get_epoch_info(&EpochId(h[2])).unwrap().clone();
-    let epoch_info3 = epoch_manager.get_epoch_info(&EpochId(h[3])).unwrap().clone();
-    let epoch_info4 = epoch_manager.get_epoch_info(&EpochId(h[4])).unwrap().clone();
+    let epoch_info1 = epoch_manager.get_epoch_info(&EpochId(h[1])).unwrap();
+    let epoch_info2 = epoch_manager.get_epoch_info(&EpochId(h[2])).unwrap();
+    let epoch_info3 = epoch_manager.get_epoch_info(&EpochId(h[3])).unwrap();
+    let epoch_info4 = epoch_manager.get_epoch_info(&EpochId(h[4])).unwrap();
     assert_eq!(
         epoch_info1.validator_kickout().get("test1"),
         Some(&ValidatorKickoutReason::Unstaked)
@@ -1837,10 +1837,10 @@ fn test_no_unstake_slash() {
         vec![stake("test1".parse().unwrap(), stake_amount)],
     );
 
-    let epoch_info1 = epoch_manager.get_epoch_info(&EpochId(h[1])).unwrap().clone();
-    let epoch_info2 = epoch_manager.get_epoch_info(&EpochId(h[2])).unwrap().clone();
-    let epoch_info3 = epoch_manager.get_epoch_info(&EpochId(h[3])).unwrap().clone();
-    let epoch_info4 = epoch_manager.get_epoch_info(&EpochId(h[4])).unwrap().clone();
+    let epoch_info1 = epoch_manager.get_epoch_info(&EpochId(h[1])).unwrap();
+    let epoch_info2 = epoch_manager.get_epoch_info(&EpochId(h[2])).unwrap();
+    let epoch_info3 = epoch_manager.get_epoch_info(&EpochId(h[3])).unwrap();
+    let epoch_info4 = epoch_manager.get_epoch_info(&EpochId(h[4])).unwrap();
     assert_eq!(
         epoch_info1.validator_kickout().get("test1"),
         Some(&ValidatorKickoutReason::Slashed)
@@ -1888,11 +1888,11 @@ fn test_slash_non_validator() {
         vec![stake("test1".parse().unwrap(), stake_amount)],
     );
 
-    let epoch_info1 = epoch_manager.get_epoch_info(&EpochId(h[1])).unwrap().clone(); // Unstaked
-    let epoch_info2 = epoch_manager.get_epoch_info(&EpochId(h[2])).unwrap().clone(); // -
-    let epoch_info3 = epoch_manager.get_epoch_info(&EpochId(h[3])).unwrap().clone(); // Slashed
-    let epoch_info4 = epoch_manager.get_epoch_info(&EpochId(h[4])).unwrap().clone(); // Slashed
-    let epoch_info5 = epoch_manager.get_epoch_info(&EpochId(h[5])).unwrap().clone(); // Ok
+    let epoch_info1 = epoch_manager.get_epoch_info(&EpochId(h[1])).unwrap(); // Unstaked
+    let epoch_info2 = epoch_manager.get_epoch_info(&EpochId(h[2])).unwrap(); // -
+    let epoch_info3 = epoch_manager.get_epoch_info(&EpochId(h[3])).unwrap(); // Slashed
+    let epoch_info4 = epoch_manager.get_epoch_info(&EpochId(h[4])).unwrap(); // Slashed
+    let epoch_info5 = epoch_manager.get_epoch_info(&EpochId(h[5])).unwrap(); // Ok
     assert_eq!(
         epoch_info1.validator_kickout().get("test1"),
         Some(&ValidatorKickoutReason::Unstaked)
@@ -1945,9 +1945,9 @@ fn test_slash_restake() {
         4,
         vec![stake("test1".parse().unwrap(), stake_amount)],
     );
-    let epoch_info2 = epoch_manager.get_epoch_info(&EpochId(h[2])).unwrap().clone();
+    let epoch_info2 = epoch_manager.get_epoch_info(&EpochId(h[2])).unwrap();
     assert!(epoch_info2.stake_change().get("test1").is_none());
-    let epoch_info4 = epoch_manager.get_epoch_info(&EpochId(h[4])).unwrap().clone();
+    let epoch_info4 = epoch_manager.get_epoch_info(&EpochId(h[4])).unwrap();
     assert!(epoch_info4.stake_change().get("test1").is_some());
 }
 
@@ -2060,7 +2060,7 @@ fn test_fisherman_kickout() {
     // - Finalize epoch T+1 => T+3 kicks test1 as fisherman without a record in stake_change
     record_block(&mut epoch_manager, h[1], h[3], 3, vec![]);
 
-    let epoch_info2 = epoch_manager.get_epoch_info(&EpochId(h[1])).unwrap().clone();
+    let epoch_info2 = epoch_manager.get_epoch_info(&EpochId(h[1])).unwrap();
     check_validators(&epoch_info2, &[("test2", stake_amount), ("test3", stake_amount)]);
     check_fishermen(&epoch_info2, &[("test1", 148)]);
     check_stake_change(
@@ -2073,7 +2073,7 @@ fn test_fisherman_kickout() {
     );
     check_kickout(&epoch_info2, &[]);
 
-    let epoch_info3 = epoch_manager.get_epoch_info(&EpochId(h[3])).unwrap().clone();
+    let epoch_info3 = epoch_manager.get_epoch_info(&EpochId(h[3])).unwrap();
     check_validators(&epoch_info3, &[("test2", stake_amount), ("test3", stake_amount)]);
     check_fishermen(&epoch_info3, &[]);
     check_stake_change(
@@ -2381,14 +2381,13 @@ fn test_epoch_validators_cache() {
     let epoch_validators =
         epoch_manager.get_all_block_producers_settlement(&epoch_id, &h[3]).unwrap().to_vec();
     assert_eq!(epoch_manager.epoch_validators_ordered.len(), 1);
-    let epoch_validators_in_cache =
-        epoch_manager.epoch_validators_ordered.get(&epoch_id).unwrap().clone();
+    let epoch_validators_in_cache = epoch_manager.epoch_validators_ordered.get(&epoch_id).unwrap();
     assert_eq!(*epoch_validators, *epoch_validators_in_cache);
 
     assert_eq!(epoch_manager.epoch_validators_ordered_unique.len(), 0);
     let epoch_validators_unique =
         epoch_manager.get_all_block_producers_ordered(&epoch_id, &h[3]).unwrap().to_vec();
     let epoch_validators_unique_in_cache =
-        epoch_manager.epoch_validators_ordered_unique.get(&epoch_id).unwrap().clone();
+        epoch_manager.epoch_validators_ordered_unique.get(&epoch_id).unwrap();
     assert_eq!(*epoch_validators_unique, *epoch_validators_unique_in_cache);
 }

--- a/chain/epoch_manager/src/tests/random_epochs.rs
+++ b/chain/epoch_manager/src/tests/random_epochs.rs
@@ -126,7 +126,7 @@ fn validate(
         .iter()
         .filter_map(|hash| {
             if epoch_manager.is_next_block_epoch_start(hash).unwrap() {
-                Some(epoch_manager.get_epoch_info(&EpochId(*hash)).unwrap().clone())
+                Some(epoch_manager.get_epoch_info(&EpochId(*hash)).unwrap())
             } else {
                 None
             }

--- a/chain/jsonrpc-primitives/src/errors.rs
+++ b/chain/jsonrpc-primitives/src/errors.rs
@@ -203,7 +203,7 @@ impl From<ServerError> for RpcError {
             ServerError::TxExecutionError(_) => {
                 RpcError::new_handler_error(Some(error_data.clone()), error_data)
             }
-            _ => RpcError::new_internal_error(Some(error_data.clone()), e.to_string()),
+            _ => RpcError::new_internal_error(Some(error_data), e.to_string()),
         }
     }
 }

--- a/chain/jsonrpc/jsonrpc-tests/src/lib.rs
+++ b/chain/jsonrpc/jsonrpc-tests/src/lib.rs
@@ -51,7 +51,7 @@ pub fn start_all_with_validity_period_and_no_epoch_sync(
     start_http(
         RpcConfig::new(&addr),
         TEST_GENESIS_CONFIG.clone(),
-        client_addr.clone(),
+        client_addr,
         view_client_addr.clone(),
         #[cfg(feature = "test_features")]
         peer_manager_addr,

--- a/chain/jsonrpc/jsonrpc-tests/tests/rpc_transactions.rs
+++ b/chain/jsonrpc/jsonrpc-tests/tests/rpc_transactions.rs
@@ -25,11 +25,11 @@ fn test_send_tx_async() {
     run_actix(async {
         let (_, addr) = test_utils::start_all(test_utils::NodeType::Validator);
 
-        let client = new_client(&format!("http://{}", addr.clone()));
+        let client = new_client(&format!("http://{}", addr));
 
         let tx_hash2 = Arc::new(Mutex::new(None));
         let tx_hash2_1 = tx_hash2.clone();
-        let tx_hash2_2 = tx_hash2.clone();
+        let tx_hash2_2 = tx_hash2;
         let signer_account_id = "test1".to_string();
 
         actix::spawn(client.block(BlockReference::latest()).then(move |res| {

--- a/chain/network/src/peer_manager/peer_store.rs
+++ b/chain/network/src/peer_manager/peer_store.rs
@@ -774,7 +774,7 @@ mod test {
         // Add three peers.
         {
             let store = StoreOpener::with_default_config().home(tmp_dir.path()).open();
-            let mut peer_store = PeerStore::new(store.clone(), &[], Default::default()).unwrap();
+            let mut peer_store = PeerStore::new(store, &[], Default::default()).unwrap();
             peer_store.add_indirect_peers(peer_infos.clone().into_iter()).unwrap();
         }
         assert_peers_in_store(tmp_dir.path(), &peer_ids);
@@ -784,7 +784,7 @@ mod test {
             let store = StoreOpener::with_default_config().home(tmp_dir.path()).open();
             let blacklist =
                 Blacklist::from_iter([format!("{}", peer_infos[2].addr.unwrap())].into_iter());
-            let _peer_store = PeerStore::new(store.clone(), &[], blacklist).unwrap();
+            let _peer_store = PeerStore::new(store, &[], blacklist).unwrap();
         }
         assert_peers_in_store(tmp_dir.path(), &peer_ids[0..2]);
     }
@@ -827,14 +827,14 @@ mod test {
 
         {
             let store = StoreOpener::with_default_config().home(tmp_dir.path()).open();
-            let mut peer_store = PeerStore::new(store.clone(), &[], Default::default()).unwrap();
-            peer_store.add_indirect_peers(peer_infos.clone().into_iter()).unwrap();
+            let mut peer_store = PeerStore::new(store, &[], Default::default()).unwrap();
+            peer_store.add_indirect_peers(peer_infos.into_iter()).unwrap();
         }
         assert_peers_in_store(tmp_dir.path(), &peer_ids);
 
         {
             let store = StoreOpener::with_default_config().home(tmp_dir.path()).open();
-            let mut peer_store = PeerStore::new(store.clone(), &[], Default::default()).unwrap();
+            let mut peer_store = PeerStore::new(store, &[], Default::default()).unwrap();
             assert_peers_in_cache(&peer_store, &peer_ids, &peer_addresses);
             peer_store.delete_peers(&peer_ids).unwrap();
             assert_peers_in_cache(&peer_store, &[], &[]);

--- a/chain/network/src/tests/network_protocol.rs
+++ b/chain/network/src/tests/network_protocol.rs
@@ -46,7 +46,7 @@ fn serialize_deserialize() -> anyhow::Result<()> {
         PeerMessage::LastEdge(edge.clone()),
         PeerMessage::SyncRoutingTable(data::make_routing_table(&mut rng)),
         PeerMessage::RequestUpdateNonce(data::make_partial_edge(&mut rng)),
-        PeerMessage::ResponseUpdateNonce(edge.clone()),
+        PeerMessage::ResponseUpdateNonce(edge),
         PeerMessage::PeersRequest,
         PeerMessage::PeersResponse((0..5).map(|_| data::make_peer_info(&mut rng)).collect()),
         PeerMessage::BlockHeadersRequest(chain.blocks.iter().map(|b| b.hash().clone()).collect()),
@@ -60,7 +60,7 @@ fn serialize_deserialize() -> anyhow::Result<()> {
         PeerMessage::Challenge(data::make_challenge(&mut rng)),
         PeerMessage::EpochSyncRequest(epoch_id.clone()),
         PeerMessage::EpochSyncResponse(Box::new(EpochSyncResponse::UpToDate)),
-        PeerMessage::EpochSyncFinalizationRequest(epoch_id.clone()),
+        PeerMessage::EpochSyncFinalizationRequest(epoch_id),
         // TODO: EpochSyncFinalizationResponse
         // TODO: RoutingTableSyncV2,
     ];

--- a/chain/rosetta-rpc/src/adapters/mod.rs
+++ b/chain/rosetta-rpc/src/adapters/mod.rs
@@ -994,8 +994,8 @@ mod tests {
                 type_: crate::models::OperationType::Transfer,
                 account: "receiver.near".parse().unwrap(),
                 amount: Some(crate::models::Amount::from_yoctonear(1)),
-                operation_identifier: receiver_transfer_operation_id.clone(),
-                related_operations: Some(vec![sender_transfer_operation_id.clone()]),
+                operation_identifier: receiver_transfer_operation_id,
+                related_operations: Some(vec![sender_transfer_operation_id]),
                 status: None,
                 metadata: None,
             },
@@ -1027,8 +1027,8 @@ mod tests {
                 type_: crate::models::OperationType::Transfer,
                 account: "receiver.near".parse().unwrap(),
                 amount: Some(crate::models::Amount::from_yoctonear(1)),
-                operation_identifier: receiver_transfer_operation_id.clone(),
-                related_operations: Some(vec![sender_transfer_operation_id.clone()]),
+                operation_identifier: receiver_transfer_operation_id,
+                related_operations: Some(vec![sender_transfer_operation_id]),
                 status: None,
                 metadata: None,
             },
@@ -1060,8 +1060,8 @@ mod tests {
                 type_: crate::models::OperationType::Transfer,
                 account: "receiver.near".parse().unwrap(),
                 amount: Some(crate::models::Amount::from_yoctonear(1)),
-                operation_identifier: receiver_transfer_operation_id.clone(),
-                related_operations: Some(vec![sender_transfer_operation_id.clone()]),
+                operation_identifier: receiver_transfer_operation_id,
+                related_operations: Some(vec![sender_transfer_operation_id]),
                 status: None,
                 metadata: None,
             },
@@ -1093,8 +1093,8 @@ mod tests {
                 type_: crate::models::OperationType::Transfer,
                 account: "receiver.near".parse().unwrap(),
                 amount: Some(crate::models::Amount::from_yoctonear(0)),
-                operation_identifier: receiver_transfer_operation_id.clone(),
-                related_operations: Some(vec![sender_transfer_operation_id.clone()]),
+                operation_identifier: receiver_transfer_operation_id,
+                related_operations: Some(vec![sender_transfer_operation_id]),
                 status: None,
                 metadata: None,
             },
@@ -1140,8 +1140,8 @@ mod tests {
                 amount: Some(crate::models::Amount::from_yoctonear(1)),
                 operation_identifier: function_call_operation_id,
                 related_operations: Some(vec![
-                    fund_transfer_function_call_operation_id.clone(),
-                    initiate_function_call_operation_id.clone(),
+                    fund_transfer_function_call_operation_id,
+                    initiate_function_call_operation_id,
                 ]),
                 status: None,
                 metadata: Some(crate::models::OperationMetadata {
@@ -1193,8 +1193,8 @@ mod tests {
                 amount: Some(crate::models::Amount::from_yoctonear(1)),
                 operation_identifier: function_call_operation_id,
                 related_operations: Some(vec![
-                    fund_transfer_function_call_operation_id.clone(),
-                    initiate_function_call_operation_id.clone(),
+                    fund_transfer_function_call_operation_id,
+                    initiate_function_call_operation_id,
                 ]),
                 status: None,
                 metadata: Some(crate::models::OperationMetadata {
@@ -1246,8 +1246,8 @@ mod tests {
                 amount: Some(crate::models::Amount::from_yoctonear(1)),
                 operation_identifier: function_call_operation_id,
                 related_operations: Some(vec![
-                    fund_transfer_function_call_operation_id.clone(),
-                    initiate_function_call_operation_id.clone(),
+                    fund_transfer_function_call_operation_id,
+                    initiate_function_call_operation_id,
                 ]),
                 status: None,
                 metadata: Some(crate::models::OperationMetadata {
@@ -1299,8 +1299,8 @@ mod tests {
                 amount: Some(crate::models::Amount::from_yoctonear(1)),
                 operation_identifier: function_call_operation_id,
                 related_operations: Some(vec![
-                    fund_transfer_function_call_operation_id.clone(),
-                    initiate_function_call_operation_id.clone(),
+                    fund_transfer_function_call_operation_id,
+                    initiate_function_call_operation_id,
                 ]),
                 status: None,
                 metadata: Some(crate::models::OperationMetadata {
@@ -1352,8 +1352,8 @@ mod tests {
                 amount: Some(-crate::models::Amount::from_yoctonear(1)),
                 operation_identifier: function_call_operation_id,
                 related_operations: Some(vec![
-                    fund_transfer_function_call_operation_id.clone(),
-                    initiate_function_call_operation_id.clone(),
+                    fund_transfer_function_call_operation_id,
+                    initiate_function_call_operation_id,
                 ]),
                 status: None,
                 metadata: Some(crate::models::OperationMetadata {

--- a/core/o11y/src/lib.rs
+++ b/core/o11y/src/lib.rs
@@ -240,10 +240,7 @@ impl<'a> EnvFilterBuilder<'a> {
                 env_filter.add_directive(tracing::Level::DEBUG.into())
             } else {
                 let directive = format!("{}=debug", module).parse().map_err(|err| {
-                    BuildEnvFilterError::CreateEnvFilter(
-                        err,
-                        format!("{}=debug", module).to_string(),
-                    )
+                    BuildEnvFilterError::CreateEnvFilter(err, format!("{}=debug", module))
                 })?;
                 env_filter.add_directive(directive)
             };

--- a/core/store/src/trie/trie_tests.rs
+++ b/core/store/src/trie/trie_tests.rs
@@ -150,7 +150,7 @@ mod nodes_counter_tests {
         let trie = Rc::new(trie);
         let state_root = Trie::empty_root();
         let trie_changes = simplify_changes(&items);
-        let state_root = test_populate_trie(&tries, &state_root, shard_uid, trie_changes.clone());
+        let state_root = test_populate_trie(&tries, &state_root, shard_uid, trie_changes);
         (trie, state_root)
     }
 

--- a/genesis-tools/genesis-populate/src/state_dump.rs
+++ b/genesis-tools/genesis-populate/src/state_dump.rs
@@ -37,7 +37,7 @@ impl StateDump {
         dump_path.push(STATE_DUMP_FILE);
         self.store.save_to_file(DBCol::State, dump_path.as_path())?;
         {
-            let mut roots_files = dir.clone();
+            let mut roots_files = dir;
             roots_files.push(GENESIS_ROOTS_FILE);
             let mut file = File::create(roots_files)?;
             let data = self.roots.try_to_vec()?;

--- a/integration-tests/src/genesis_helpers.rs
+++ b/integration-tests/src/genesis_helpers.rs
@@ -33,5 +33,5 @@ pub fn genesis_block(genesis: &Genesis) -> Block {
     let runtime = Arc::new(NightshadeRuntime::test(dir.path(), store, genesis));
     let mut chain =
         Chain::new(runtime, &chain_genesis, DoomslugThresholdMode::TwoThirds, true).unwrap();
-    chain.get_block(&chain.genesis().hash().clone()).unwrap().clone()
+    chain.get_block(&chain.genesis().hash().clone()).unwrap()
 }

--- a/integration-tests/src/tests/client/challenges.rs
+++ b/integration-tests/src/tests/client/challenges.rs
@@ -39,7 +39,7 @@ use std::sync::Arc;
 #[test]
 fn test_block_with_challenges() {
     let mut env = TestEnv::builder(ChainGenesis::test()).build();
-    let genesis = env.clients[0].chain.get_block_by_height(0).unwrap().clone();
+    let genesis = env.clients[0].chain.get_block_by_height(0).unwrap();
 
     let mut block = env.clients[0].produce_block(1).unwrap().unwrap();
     let signer = env.clients[0].validator_signer.as_ref().unwrap().clone();
@@ -68,7 +68,7 @@ fn test_block_with_challenges() {
 fn test_verify_block_double_sign_challenge() {
     let mut env = TestEnv::builder(ChainGenesis::test()).clients_count(2).build();
     env.produce_block(0, 1);
-    let genesis = env.clients[0].chain.get_block_by_height(0).unwrap().clone();
+    let genesis = env.clients[0].chain.get_block_by_height(0).unwrap();
     let b1 = env.clients[0].produce_block(2).unwrap().unwrap();
 
     env.process_block(0, b1.clone(), Provenance::NONE);
@@ -329,7 +329,7 @@ fn test_verify_chunk_invalid_state_challenge() {
 
     // Invalid chunk & block.
     let last_block_hash = env.clients[0].chain.head().unwrap().last_block_hash;
-    let last_block = env.clients[0].chain.get_block(&last_block_hash).unwrap().clone();
+    let last_block = env.clients[0].chain.get_block(&last_block_hash).unwrap();
     let total_parts = env.clients[0].runtime_adapter.num_total_parts();
     let data_parts = env.clients[0].runtime_adapter.num_data_parts();
     let parity_parts = total_parts - data_parts;
@@ -376,7 +376,7 @@ fn test_verify_chunk_invalid_state_challenge() {
         }
     }
     let block_merkle_tree =
-        client.chain.mut_store().get_block_merkle_tree(last_block.hash()).unwrap().clone();
+        client.chain.mut_store().get_block_merkle_tree(last_block.hash()).unwrap();
     let mut block_merkle_tree = PartialMerkleTree::clone(&block_merkle_tree);
     block_merkle_tree.insert(*last_block.hash());
     let block = Block::produce(
@@ -498,7 +498,7 @@ fn test_receive_invalid_chunk_as_chunk_producer() {
     init_test_logger();
     let mut env = TestEnv::builder(ChainGenesis::test()).clients_count(2).build();
     env.produce_block(0, 1);
-    let block1 = env.clients[0].chain.get_block_by_height(1).unwrap().clone();
+    let block1 = env.clients[0].chain.get_block_by_height(1).unwrap();
     env.process_block(1, block1, Provenance::NONE);
     let (chunk, merkle_paths, receipts, block) = create_invalid_proofs_chunk(&mut env.clients[0]);
     let client = &mut env.clients[0];

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -172,7 +172,7 @@ fn prepare_env_with_congestion(
     let mut env = TestEnv::builder(chain_genesis)
         .runtime_adapters(create_nightshade_runtimes(&genesis, 1))
         .build();
-    let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap().clone();
+    let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
 
     // Deploy contract to test0.
@@ -1404,7 +1404,7 @@ fn test_gc_with_epoch_length_common(epoch_length: NumBlocks) {
         .runtime_adapters(create_nightshade_runtimes(&genesis, 1))
         .build();
     let mut blocks = vec![];
-    let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap().clone();
+    let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     blocks.push(genesis_block);
     for i in 1..=epoch_length * (DEFAULT_GC_NUM_EPOCHS_TO_KEEP + 1) {
         let block = env.clients[0].produce_block(i).unwrap().unwrap();
@@ -1546,7 +1546,7 @@ fn test_gc_after_state_sync() {
         env.process_block(1, block, Provenance::NONE);
     }
     let sync_height = epoch_length * 4 + 1;
-    let sync_block = env.clients[0].chain.get_block_by_height(sync_height).unwrap().clone();
+    let sync_block = env.clients[0].chain.get_block_by_height(sync_height).unwrap();
     let sync_hash = *sync_block.hash();
     let prev_block_hash = *sync_block.header().prev_hash();
     // reset cache
@@ -1582,13 +1582,12 @@ fn test_process_block_after_state_sync() {
         env.produce_block(0, i);
     }
     let sync_height = epoch_length * 4 + 1;
-    let sync_block = env.clients[0].chain.get_block_by_height(sync_height).unwrap().clone();
+    let sync_block = env.clients[0].chain.get_block_by_height(sync_height).unwrap();
     let sync_hash = *sync_block.hash();
     let chunk_extra = env.clients[0]
         .chain
         .get_chunk_extra(&sync_hash, &ShardUId { version: 1, shard_id: 0 })
-        .unwrap()
-        .clone();
+        .unwrap();
     let state_part = env.clients[0]
         .runtime_adapter
         .obtain_state_part(0, &sync_hash, chunk_extra.state_root(), PartId::new(0, 1))
@@ -1944,7 +1943,7 @@ fn test_incorrect_validator_key_produce_block() {
 
 fn test_block_merkle_proof_with_len(n: NumBlocks, rng: &mut StdRng) {
     let mut env = TestEnv::builder(ChainGenesis::test()).build();
-    let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap().clone();
+    let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     let mut blocks = vec![genesis_block.clone()];
     let mut cur_height = genesis_block.header().height() + 1;
     while cur_height < n {
@@ -2007,7 +2006,7 @@ fn test_block_merkle_proof() {
 #[test]
 fn test_block_merkle_proof_same_hash() {
     let mut env = TestEnv::builder(ChainGenesis::test()).build();
-    let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap().clone();
+    let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     let proof =
         env.clients[0].chain.get_block_proof(genesis_block.hash(), genesis_block.hash()).unwrap();
     assert!(proof.is_empty());
@@ -2039,7 +2038,7 @@ fn test_data_reset_before_state_sync() {
     }
     // check that the new account exists
     let head = env.clients[0].chain.head().unwrap();
-    let head_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap().clone();
+    let head_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap();
     let response = env.clients[0]
         .runtime_adapter
         .query(
@@ -2155,7 +2154,7 @@ fn test_validate_chunk_extra() {
     let mut env = TestEnv::builder(ChainGenesis::test())
         .runtime_adapters(create_nightshade_runtimes(&genesis, 1))
         .build();
-    let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap().clone();
+    let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     let genesis_height = genesis_block.header().height();
 
     let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
@@ -2256,11 +2255,8 @@ fn test_validate_chunk_extra() {
 
     // About to produce a block on top of block1. Validate that this chunk is legit.
     let chunks = env.clients[0].shards_mgr.prepare_chunks(block1.hash());
-    let chunk_extra = env.clients[0]
-        .chain
-        .get_chunk_extra(block1.hash(), &ShardUId::single_shard())
-        .unwrap()
-        .clone();
+    let chunk_extra =
+        env.clients[0].chain.get_chunk_extra(block1.hash(), &ShardUId::single_shard()).unwrap();
     assert!(validate_chunk_with_chunk_extra(
         &mut chain_store,
         &*env.clients[0].runtime_adapter,
@@ -2319,7 +2315,7 @@ fn test_catchup_gas_price_change() {
         .clients_count(2)
         .runtime_adapters(create_nightshade_runtimes(&genesis, 2))
         .build();
-    let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap().clone();
+    let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     let mut blocks = vec![];
     for i in 1..3 {
         let block = env.clients[0].produce_block(i).unwrap().unwrap();
@@ -2398,16 +2394,10 @@ fn test_catchup_gas_price_change() {
     };
     env.clients[1].chain.schedule_apply_state_parts(0, sync_hash, num_parts, &f).unwrap();
     env.clients[1].chain.set_state_finalize(0, sync_hash, Ok(())).unwrap();
-    let chunk_extra_after_sync = env.clients[1]
-        .chain
-        .get_chunk_extra(blocks[4].hash(), &ShardUId::single_shard())
-        .unwrap()
-        .clone();
-    let expected_chunk_extra = env.clients[0]
-        .chain
-        .get_chunk_extra(blocks[4].hash(), &ShardUId::single_shard())
-        .unwrap()
-        .clone();
+    let chunk_extra_after_sync =
+        env.clients[1].chain.get_chunk_extra(blocks[4].hash(), &ShardUId::single_shard()).unwrap();
+    let expected_chunk_extra =
+        env.clients[0].chain.get_chunk_extra(blocks[4].hash(), &ShardUId::single_shard()).unwrap();
     // The chunk extra of the prev block of sync block should be the same as the node that it is syncing from
     assert_eq!(chunk_extra_after_sync, expected_chunk_extra);
 }
@@ -2424,7 +2414,7 @@ fn test_block_execution_outcomes() {
     let mut env = TestEnv::builder(chain_genesis)
         .runtime_adapters(create_nightshade_runtimes(&genesis, 1))
         .build();
-    let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap().clone();
+    let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
     let mut tx_hashes = vec![];
     for i in 0..3 {
@@ -2458,8 +2448,8 @@ fn test_block_execution_outcomes() {
             delayed_receipt_id.push(execution_outcome.outcome_with_id.outcome.receipt_ids[0])
         }
     }
-    let block = env.clients[0].chain.get_block_by_height(2).unwrap().clone();
-    let chunk = env.clients[0].chain.get_chunk(&block.chunks()[0].chunk_hash()).unwrap().clone();
+    let block = env.clients[0].chain.get_block_by_height(2).unwrap();
+    let chunk = env.clients[0].chain.get_chunk(&block.chunks()[0].chunk_hash()).unwrap();
     assert_eq!(chunk.transactions().len(), 3);
     let execution_outcomes_from_block = env.clients[0]
         .chain
@@ -2477,9 +2467,8 @@ fn test_block_execution_outcomes() {
     );
 
     // Make sure the chunk outcomes contain the outcome from the delayed receipt.
-    let next_block = env.clients[0].chain.get_block_by_height(3).unwrap().clone();
-    let next_chunk =
-        env.clients[0].chain.get_chunk(&next_block.chunks()[0].chunk_hash()).unwrap().clone();
+    let next_block = env.clients[0].chain.get_block_by_height(3).unwrap();
+    let next_chunk = env.clients[0].chain.get_chunk(&next_block.chunks()[0].chunk_hash()).unwrap();
     assert!(next_chunk.transactions().is_empty());
     assert!(next_chunk.receipts().is_empty());
     let execution_outcomes_from_block = env.clients[0]
@@ -2511,7 +2500,7 @@ fn test_refund_receipts_processing() {
     let mut env = TestEnv::builder(chain_genesis)
         .runtime_adapters(create_nightshade_runtimes(&genesis, 1))
         .build();
-    let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap().clone();
+    let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
     let mut tx_hashes = vec![];
     // send transactions to a non-existing account to generate refund
@@ -2865,7 +2854,7 @@ fn test_epoch_protocol_version_change() {
             run_catchup(&mut env.clients[j], &vec![]).unwrap();
         }
     }
-    let last_block = env.clients[0].chain.get_block_by_height(16).unwrap().clone();
+    let last_block = env.clients[0].chain.get_block_by_height(16).unwrap();
     let protocol_version = env.clients[0]
         .runtime_adapter
         .get_epoch_protocol_version(last_block.header().epoch_id())
@@ -2888,7 +2877,7 @@ fn test_query_final_state() {
     let mut env = TestEnv::builder(chain_genesis)
         .runtime_adapters(create_nightshade_runtimes(&genesis, 1))
         .build();
-    let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap().clone();
+    let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
 
     let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
     let tx = SignedTransaction::send_money(
@@ -2913,7 +2902,7 @@ fn test_query_final_state() {
                              runtime_adapter: Arc<dyn RuntimeAdapter>,
                              account_id: AccountId| {
         let final_head = chain.store().final_head().unwrap();
-        let last_final_block = chain.get_block(&final_head.last_block_hash).unwrap().clone();
+        let last_final_block = chain.get_block(&final_head.last_block_hash).unwrap();
         let response = runtime_adapter
             .query(
                 ShardUId::single_shard(),
@@ -3078,7 +3067,7 @@ fn prepare_env_with_transaction() -> (TestEnv, CryptoHash) {
     let mut env = TestEnv::builder(ChainGenesis::test())
         .runtime_adapters(create_nightshade_runtimes(&genesis, 1))
         .build();
-    let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap().clone();
+    let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
 
     let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
     let tx = SignedTransaction::send_money(
@@ -3191,7 +3180,7 @@ fn test_node_shutdown_with_old_protocol_version() {
 #[test]
 fn test_block_ordinal() {
     let mut env = TestEnv::builder(ChainGenesis::test()).build();
-    let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap().clone();
+    let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     assert_eq!(genesis_block.header().block_ordinal(), 1);
     let mut ordinal = 1;
 
@@ -3256,12 +3245,9 @@ fn test_congestion_receipt_execution() {
     env.produce_block(0, 3);
     let height = 4;
     env.produce_block(0, height);
-    let prev_block = env.clients[0].chain.get_block_by_height(height).unwrap().clone();
-    let chunk_extra = env.clients[0]
-        .chain
-        .get_chunk_extra(prev_block.hash(), &ShardUId::single_shard())
-        .unwrap()
-        .clone();
+    let prev_block = env.clients[0].chain.get_block_by_height(height).unwrap();
+    let chunk_extra =
+        env.clients[0].chain.get_chunk_extra(prev_block.hash(), &ShardUId::single_shard()).unwrap();
     assert!(chunk_extra.gas_used() >= chunk_extra.gas_limit());
     let state_update = env.clients[0]
         .runtime_adapter
@@ -3312,7 +3298,7 @@ fn test_validator_stake_host_function() {
     let mut env = TestEnv::builder(ChainGenesis::test())
         .runtime_adapters(create_nightshade_runtimes(&genesis, 1))
         .build();
-    let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap().clone();
+    let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     let block_height = deploy_test_contract(
         &mut env,
         "test0".parse().unwrap(),
@@ -3613,7 +3599,7 @@ mod access_key_nonce_range_tests {
         let mut env = TestEnv::builder(ChainGenesis::test())
             .runtime_adapters(create_nightshade_runtimes(&genesis, 1))
             .build();
-        let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap().clone();
+        let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
 
         let signer0 =
             InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
@@ -3677,7 +3663,7 @@ mod access_key_nonce_range_tests {
         let mut env = TestEnv::builder(ChainGenesis::test())
             .runtime_adapters(create_nightshade_runtimes(&genesis, 1))
             .build();
-        let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap().clone();
+        let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
 
         let signer1 =
             InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1");
@@ -3703,7 +3689,7 @@ mod access_key_nonce_range_tests {
             *genesis_block.hash(),
         );
         height = check_tx_processing(&mut env, send_money_tx, height, blocks_number);
-        let block = env.clients[0].chain.get_block_by_height(height - 1).unwrap().clone();
+        let block = env.clients[0].chain.get_block_by_height(height - 1).unwrap();
 
         // Delete implicit account.
         let delete_account_tx = SignedTransaction::delete_account(
@@ -3716,7 +3702,7 @@ mod access_key_nonce_range_tests {
             *block.hash(),
         );
         height = check_tx_processing(&mut env, delete_account_tx, height, blocks_number);
-        let block = env.clients[0].chain.get_block_by_height(height - 1).unwrap().clone();
+        let block = env.clients[0].chain.get_block_by_height(height - 1).unwrap();
 
         // Send money to implicit account again, invoking its second creation.
         let send_money_again_tx = SignedTransaction::send_money(
@@ -3728,7 +3714,7 @@ mod access_key_nonce_range_tests {
             *block.hash(),
         );
         height = check_tx_processing(&mut env, send_money_again_tx, height, blocks_number);
-        let block = env.clients[0].chain.get_block_by_height(height - 1).unwrap().clone();
+        let block = env.clients[0].chain.get_block_by_height(height - 1).unwrap();
 
         // Send money from implicit account with incorrect nonce.
         let send_money_from_implicit_account_tx = SignedTransaction::send_money(
@@ -3787,7 +3773,7 @@ mod access_key_nonce_range_tests {
         let mut env = TestEnv::builder(ChainGenesis::test())
             .runtime_adapters(create_nightshade_runtimes(&genesis, 1))
             .build();
-        let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap().clone();
+        let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
         let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
         let tx = SignedTransaction::send_money(
             1,
@@ -3824,7 +3810,7 @@ mod access_key_nonce_range_tests {
         let mut env = TestEnv::builder(ChainGenesis::test())
             .runtime_adapters(create_nightshade_runtimes(&genesis, 1))
             .build();
-        let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap().clone();
+        let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
         let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
         let large_nonce = AccessKey::ACCESS_KEY_NONCE_RANGE_MULTIPLIER + 1;
         let tx = SignedTransaction::send_money(
@@ -4026,7 +4012,7 @@ mod access_key_nonce_range_tests {
         let epoch_length = 10;
 
         let accounts: Vec<AccountId> =
-            (0..num_clients).map(|i| format!("test{}", i).to_string().parse().unwrap()).collect();
+            (0..num_clients).map(|i| format!("test{}", i).parse().unwrap()).collect();
         let mut genesis = Genesis::test(accounts, num_validators);
         genesis.config.epoch_length = epoch_length;
         // make the blockchain to 4 shards
@@ -4393,13 +4379,10 @@ mod contract_precompilation_tests {
     const EPOCH_LENGTH: u64 = 5;
 
     fn state_sync_on_height(env: &mut TestEnv, height: BlockHeight) {
-        let sync_block = env.clients[0].chain.get_block_by_height(height).unwrap().clone();
+        let sync_block = env.clients[0].chain.get_block_by_height(height).unwrap();
         let sync_hash = *sync_block.hash();
-        let chunk_extra = env.clients[0]
-            .chain
-            .get_chunk_extra(&sync_hash, &ShardUId::single_shard())
-            .unwrap()
-            .clone();
+        let chunk_extra =
+            env.clients[0].chain.get_chunk_extra(&sync_hash, &ShardUId::single_shard()).unwrap();
         let epoch_id =
             env.clients[0].chain.get_block_header(&sync_hash).unwrap().epoch_id().clone();
         let state_part = env.clients[0]
@@ -4483,7 +4466,7 @@ mod contract_precompilation_tests {
         // Check that contract function may be successfully called on the second client.
         // Note that we can't test that behaviour is the same on two clients, because
         // compile_module_cached_wasmer0 is cached by contract key via macro.
-        let block = env.clients[0].chain.get_block_by_height(EPOCH_LENGTH).unwrap().clone();
+        let block = env.clients[0].chain.get_block_by_height(EPOCH_LENGTH).unwrap();
         let chunk_extra =
             env.clients[0].chain.get_chunk_extra(block.hash(), &ShardUId::single_shard()).unwrap();
         let state_root = *chunk_extra.state_root();
@@ -4813,7 +4796,7 @@ mod chunk_nodes_cache_test {
                 assert_eq!(receipt_ids.len(), 1);
                 let receipt_execution_outcome =
                     env.clients[0].chain.get_execution_outcome(&receipt_ids[0]).unwrap();
-                let metadata = receipt_execution_outcome.outcome_with_id.outcome.metadata.clone();
+                let metadata = receipt_execution_outcome.outcome_with_id.outcome.metadata;
                 match metadata {
                     ExecutionMetadata::V1 => panic!("ExecutionMetadata cannot be empty"),
                     ExecutionMetadata::V2(profile_data) => TrieNodesCount {
@@ -4942,12 +4925,9 @@ mod lower_storage_key_limit_test {
         // Re-run the transaction, check that execution fails.
         {
             let tip = env.clients[0].chain.head().unwrap();
-            let signed_tx = Transaction {
-                nonce: tip.height + 1,
-                block_hash: tip.last_block_hash,
-                ..tx.clone()
-            }
-            .sign(&signer);
+            let signed_tx =
+                Transaction { nonce: tip.height + 1, block_hash: tip.last_block_hash, ..tx }
+                    .sign(&signer);
             let tx_hash = signed_tx.get_hash().clone();
             env.clients[0].process_tx(signed_tx, false, false);
             for i in 0..epoch_length {
@@ -4982,12 +4962,9 @@ mod lower_storage_key_limit_test {
                 block_hash: CryptoHash::default(),
             };
             let tip = env.clients[0].chain.head().unwrap();
-            let signed_tx = Transaction {
-                nonce: tip.height + 1,
-                block_hash: tip.last_block_hash,
-                ..tx.clone()
-            }
-            .sign(&signer);
+            let signed_tx =
+                Transaction { nonce: tip.height + 1, block_hash: tip.last_block_hash, ..tx }
+                    .sign(&signer);
             let tx_hash = signed_tx.get_hash().clone();
             env.clients[0].process_tx(signed_tx, false, false);
             for i in 0..epoch_length {

--- a/integration-tests/src/tests/client/runtimes.rs
+++ b/integration-tests/src/tests/client/runtimes.rs
@@ -103,7 +103,7 @@ fn test_cap_max_gas_price() {
         env.process_block(0, block, Provenance::PRODUCED);
     }
 
-    let last_block = env.clients[0].chain.get_block_by_height(epoch_length - 1).unwrap().clone();
+    let last_block = env.clients[0].chain.get_block_by_height(epoch_length - 1).unwrap();
     let protocol_version = env.clients[0]
         .runtime_adapter
         .get_epoch_protocol_version(last_block.header().epoch_id())

--- a/integration-tests/src/tests/client/sharding_upgrade.rs
+++ b/integration-tests/src/tests/client/sharding_upgrade.rs
@@ -174,7 +174,7 @@ impl TestShardUpgradeEnv {
     /// check that all accounts in `accounts` exist in the current state
     fn check_accounts(&mut self, accounts: Vec<&AccountId>) {
         let head = self.env.clients[0].chain.head().unwrap();
-        let block = self.env.clients[0].chain.get_block(&head.last_block_hash).unwrap().clone();
+        let block = self.env.clients[0].chain.get_block(&head.last_block_hash).unwrap();
         for account_id in accounts {
             check_account(&mut self.env, account_id, &block)
         }
@@ -193,7 +193,7 @@ impl TestShardUpgradeEnv {
     ///    - all blocks after the block at `height` in the current canonical chain do not have
     ///      new chunks for the corresponding shards
     fn check_next_block_with_new_chunk(&mut self, height: BlockHeight) {
-        let block = self.env.clients[0].chain.get_block_by_height(height).unwrap().clone();
+        let block = self.env.clients[0].chain.get_block_by_height(height).unwrap();
         let block_hash = block.hash();
         let num_shards = block.chunks().len();
         for shard_id in 0..num_shards {
@@ -257,7 +257,7 @@ impl TestShardUpgradeEnv {
     ) -> Vec<CryptoHash> {
         let env = &mut self.env;
         let head = env.clients[0].chain.head().unwrap();
-        let block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap().clone();
+        let block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap();
         // check execution outcomes
         let shard_layout = env.clients[0]
             .runtime_adapter
@@ -320,7 +320,7 @@ impl TestShardUpgradeEnv {
             .runtime_adapter
             .get_shard_layout_from_prev_block(&head.last_block_hash)
             .unwrap();
-        let block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap().clone();
+        let block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap();
         for (shard_id, chunk_header) in block.chunks().iter().enumerate() {
             if chunk_header.height_included() == block.header().height() {
                 let outgoing_receipts = env.clients[0]

--- a/integration-tests/src/tests/network/runner.rs
+++ b/integration-tests/src/tests/network/runner.rs
@@ -688,7 +688,7 @@ impl RunningInfo {
         Ok(())
     }
     fn change_account_id(&mut self, node_id: usize, account_id: AccountId) {
-        self.runner.test_config[node_id].account_id = account_id.clone();
+        self.runner.test_config[node_id].account_id = account_id;
     }
 }
 

--- a/integration-tests/src/tests/runtime/deployment.rs
+++ b/integration-tests/src/tests/runtime/deployment.rs
@@ -46,7 +46,7 @@ fn test_deploy_max_size_contract() {
     // Create test account
     let transaction_result = node_user
         .create_account(
-            account_id.clone(),
+            account_id,
             test_contract_id.clone(),
             node.signer().public_key(),
             token_balance,

--- a/nearcore/benches/store.rs
+++ b/nearcore/benches/store.rs
@@ -44,7 +44,7 @@ fn read_trie_items(bench: &mut Bencher, shard_id: usize, read_only: bool) {
             near_config.client_config.max_gas_burnt_view,
         );
         let head = chain_store.head().unwrap();
-        let last_block = chain_store.get_block(&head.last_block_hash).unwrap().clone();
+        let last_block = chain_store.get_block(&head.last_block_hash).unwrap();
         let state_roots: Vec<StateRoot> =
             last_block.chunks().iter().map(|chunk| chunk.prev_state_root()).collect();
         let header = last_block.header();

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -1152,7 +1152,7 @@ pub fn init_configs(
                 max_inflation_rate: MAX_INFLATION_RATE,
                 total_supply: get_initial_supply(&records),
                 num_blocks_per_year: NUM_BLOCKS_PER_YEAR,
-                protocol_treasury_account: signer.account_id.clone(),
+                protocol_treasury_account: signer.account_id,
                 fishermen_threshold: FISHERMEN_THRESHOLD,
                 shard_layout: shards,
                 min_gas_price: MIN_GAS_PRICE,

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -1304,7 +1304,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         Error,
     > {
         let epoch_manager = self.epoch_manager.read();
-        let last_block_info = epoch_manager.get_block_info(prev_epoch_last_block_hash)?.clone();
+        let last_block_info = epoch_manager.get_block_info(prev_epoch_last_block_hash)?;
         let prev_epoch_id = last_block_info.epoch_id().clone();
         Ok((
             epoch_manager.get_block_info(last_block_info.epoch_first_block())?,

--- a/nearcore/tests/economics.rs
+++ b/nearcore/tests/economics.rs
@@ -92,12 +92,12 @@ fn test_burn_mint() {
     }
 
     // Block 3: epoch ends, it gets it's 10% of total supply - transfer cost.
-    let block3 = env.clients[0].chain.get_block_by_height(3).unwrap().clone();
+    let block3 = env.clients[0].chain.get_block_by_height(3).unwrap();
     // We burn half of the cost when tx executed and the other half in the next block for the receipt processing.
     let half_transfer_cost = fee_helper.transfer_cost() / 2;
     let epoch_total_reward = {
-        let block0 = env.clients[0].chain.get_block_by_height(0).unwrap().clone();
-        let block2 = env.clients[0].chain.get_block_by_height(2).unwrap().clone();
+        let block0 = env.clients[0].chain.get_block_by_height(0).unwrap();
+        let block2 = env.clients[0].chain.get_block_by_height(2).unwrap();
         let duration = block2.header().raw_timestamp() - block0.header().raw_timestamp();
         (U256::from(initial_total_supply) * U256::from(duration)
             / U256::from(10u128.pow(9) * 24 * 60 * 60 * 365 * 10))
@@ -110,15 +110,15 @@ fn test_burn_mint() {
     );
     assert_eq!(block3.chunks()[0].balance_burnt(), half_transfer_cost);
     // Block 4: subtract 2nd part of transfer.
-    let block4 = env.clients[0].chain.get_block_by_height(4).unwrap().clone();
+    let block4 = env.clients[0].chain.get_block_by_height(4).unwrap();
     assert_eq!(block4.header().total_supply(), block3.header().total_supply() - half_transfer_cost);
     assert_eq!(block4.chunks()[0].balance_burnt(), half_transfer_cost);
     // Check that Protocol Treasury account got it's 1% as well.
     assert_eq!(env.query_balance("near".parse().unwrap()), near_balance + epoch_total_reward / 10);
     // Block 5: reward from previous block.
-    let block5 = env.clients[0].chain.get_block_by_height(5).unwrap().clone();
+    let block5 = env.clients[0].chain.get_block_by_height(5).unwrap();
     let prev_total_supply = block4.header().total_supply();
-    let block2 = env.clients[0].chain.get_block_by_height(2).unwrap().clone();
+    let block2 = env.clients[0].chain.get_block_by_height(2).unwrap();
     let epoch_total_reward = (U256::from(prev_total_supply)
         * U256::from(block4.header().raw_timestamp() - block2.header().raw_timestamp())
         / U256::from(10u128.pow(9) * 24 * 60 * 60 * 365 * 10))

--- a/runtime/near-vm-runner/src/tests/cache.rs
+++ b/runtime/near-vm-runner/src/tests/cache.rs
@@ -88,7 +88,7 @@ fn make_cached_contract_call_vm(
         &code,
         method_name,
         &mut fake_external,
-        context.clone(),
+        context,
         &fees,
         &promise_results,
         LATEST_PROTOCOL_VERSION,

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -226,7 +226,7 @@ fn main() -> anyhow::Result<()> {
         iter_per_block,
         active_accounts,
         block_sizes: vec![],
-        state_dump_path: state_dump_path.clone(),
+        state_dump_path: state_dump_path,
         metric,
         vm_kind,
         costs_to_measure,

--- a/runtime/runtime-params-estimator/src/testbed.rs
+++ b/runtime/runtime-params-estimator/src/testbed.rs
@@ -29,7 +29,7 @@ impl RuntimeTestbed {
         let workdir = tempfile::Builder::new().prefix("runtime_testbed").tempdir().unwrap();
         let store_path = near_store::get_store_path(workdir.path());
         let StateDump { store, roots } = StateDump::from_dir(dump_dir, &store_path);
-        let tries = ShardTries::new(store.clone(), 0, 1);
+        let tries = ShardTries::new(store, 0, 1);
 
         assert!(roots.len() <= 1, "Parameter estimation works with one shard only.");
         assert!(!roots.is_empty(), "No state roots found.");

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -213,7 +213,7 @@ impl TrieViewer {
         };
         let action_receipt = ActionReceipt {
             signer_id: originator_id.clone(),
-            signer_public_key: public_key.clone(),
+            signer_public_key: public_key,
             gas_price: 0,
             output_data_receivers: vec![],
             input_data_ids: vec![],

--- a/test-utils/runtime-tester/src/fuzzing.rs
+++ b/test-utils/runtime-tester/src/fuzzing.rs
@@ -110,7 +110,7 @@ impl TransactionConfig {
             Ok(TransactionConfig {
                 nonce: scope.nonce(),
                 signer_id: signer_account.id.clone(),
-                receiver_id: receiver_account.id.clone(),
+                receiver_id: receiver_account.id,
                 signer: scope.full_access_signer(u, &signer_account)?,
                 actions: vec![Action::Transfer(TransferAction { deposit: amount })],
             })
@@ -189,10 +189,10 @@ impl TransactionConfig {
                 Ok(TransactionConfig {
                     nonce: scope.nonce(),
                     signer_id: signer_account.id.clone(),
-                    receiver_id: receiver_account.id.clone(),
+                    receiver_id: receiver_account.id,
                     signer,
                     actions: vec![Action::DeleteAccount(DeleteAccountAction {
-                        beneficiary_id: beneficiary_id.id.clone(),
+                        beneficiary_id: beneficiary_id.id,
                     })],
                 })
             });
@@ -613,7 +613,7 @@ impl Scope {
     ) -> Result<PublicKey> {
         let account_idx = self.usize_id(account);
         let (nonce, key) = self.accounts[account_idx].random_key(u)?;
-        let public_key = key.signer.public_key.clone();
+        let public_key = key.signer.public_key;
         self.accounts[account_idx].keys.remove(&nonce);
         Ok(public_key)
     }

--- a/test-utils/runtime-tester/src/run_test.rs
+++ b/test-utils/runtime-tester/src/run_test.rs
@@ -71,7 +71,7 @@ impl Scenario {
     }
 
     fn process_blocks(&self, env: &mut TestEnv) -> Result<RuntimeStats, Error> {
-        let mut last_block = env.clients[0].chain.get_block_by_height(0).unwrap().clone();
+        let mut last_block = env.clients[0].chain.get_block_by_height(0).unwrap();
 
         let mut runtime_stats = RuntimeStats::default();
 

--- a/test-utils/runtime-tester/src/scenario_builder.rs
+++ b/test-utils/runtime-tester/src/scenario_builder.rs
@@ -124,8 +124,8 @@ impl ScenarioBuilder {
 
         (*block).transactions.push(TransactionConfig {
             nonce: self.nonce,
-            signer_id: signer_id.clone(),
-            receiver_id: receiver_id.clone(),
+            signer_id: signer_id,
+            receiver_id: receiver_id,
             signer,
             actions,
         });

--- a/tools/chainsync-loadtest/src/main.rs
+++ b/tools/chainsync-loadtest/src/main.rs
@@ -103,7 +103,7 @@ impl Cmd {
         // To avoid that, we create a runtime within the synchronous code and pass just an Arc
         // inside of it.
         let rt_ = Arc::new(tokio::runtime::Runtime::new()?);
-        let rt = rt_.clone();
+        let rt = rt_;
         return actix::System::new().block_on(async move {
             let network =
                 start_with_config(near_config, cmd.qps_limit).context("start_with_config")?;

--- a/tools/chainsync-loadtest/src/network.rs
+++ b/tools/chainsync-loadtest/src/network.rs
@@ -182,7 +182,7 @@ impl Network {
                 s.spawn_weak(|ctx| {
                     self_.keep_sending(&ctx, move |peer| NetworkRequests::BlockHeadersRequest {
                         hashes: vec![hash.clone()],
-                        peer_id: peer.peer_info.id.clone(),
+                        peer_id: peer.peer_info.id,
                     })
                 });
                 let res = ctx.wrap(recv.wait()).await;
@@ -208,7 +208,7 @@ impl Network {
                 s.spawn_weak(|ctx| {
                     self_.keep_sending(&ctx, move |peer| NetworkRequests::BlockRequest {
                         hash: hash.clone(),
-                        peer_id: peer.peer_info.id.clone(),
+                        peer_id: peer.peer_info.id,
                     })
                 });
                 let res = ctx.wrap(recv.wait()).await;

--- a/tools/mock_node/src/lib.rs
+++ b/tools/mock_node/src/lib.rs
@@ -217,11 +217,11 @@ impl ChainHistoryAccess {
     }
 
     fn retrieve_block_by_height(&mut self, block_height: BlockHeight) -> Result<Block, Error> {
-        self.chain.get_block_by_height(block_height).map(|b| b.clone())
+        self.chain.get_block_by_height(block_height).map(|b| b)
     }
 
     fn retrieve_block(&mut self, block_hash: &CryptoHash) -> Result<Block, Error> {
-        self.chain.get_block(block_hash).map(|b| b.clone())
+        self.chain.get_block(block_hash).map(|b| b)
     }
 
     fn retrieve_partial_encoded_chunk(
@@ -311,7 +311,7 @@ mod test {
         init_test_logger();
         let (mut chain_history_access, env) = setup_mock();
         let blocks: Vec<_> =
-            (1..21).map(|h| env.clients[0].chain.get_block_by_height(h).unwrap().clone()).collect();
+            (1..21).map(|h| env.clients[0].chain.get_block_by_height(h).unwrap()).collect();
 
         for block in blocks.iter() {
             assert_eq!(&chain_history_access.retrieve_block(block.hash()).unwrap(), block);

--- a/tools/mock_node/src/setup.rs
+++ b/tools/mock_node/src/setup.rs
@@ -296,7 +296,7 @@ pub fn setup_mock_node(
     let view_client = start_view_client(
         None,
         chain_genesis.clone(),
-        client_runtime.clone(),
+        client_runtime,
         network_adapter.clone(),
         config.client_config.clone(),
         adv,
@@ -384,7 +384,7 @@ mod test {
             let nearcore::NearNode { view_client, client, .. } =
                 start_with_config(path1, near_config).expect("start_with_config");
 
-            let view_client1 = view_client.clone();
+            let view_client1 = view_client;
             let nonce = Arc::new(RwLock::new(10));
             WaitOrTimeoutActor::new(
                 Box::new(move |_ctx| {

--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -137,7 +137,7 @@ fn apply_block_from_range(
             return;
         }
     };
-    let block = chain_store.get_block(&block_hash).unwrap().clone();
+    let block = chain_store.get_block(&block_hash).unwrap();
     let shard_uid = runtime_adapter.shard_id_to_uid(shard_id, block.header().epoch_id()).unwrap();
     assert!(block.chunks().len() > 0);
     let mut existing_chunk_extra = None;
@@ -164,12 +164,11 @@ fn apply_block_from_range(
             "Can't get existing chunk extra for block #{}",
             height
         );
-        existing_chunk_extra = Some(res_existing_chunk_extra.unwrap().clone());
-        let chunk =
-            chain_store.get_chunk(&block.chunks()[shard_id as usize].chunk_hash()).unwrap().clone();
+        existing_chunk_extra = Some(res_existing_chunk_extra.unwrap());
+        let chunk = chain_store.get_chunk(&block.chunks()[shard_id as usize].chunk_hash()).unwrap();
 
         let prev_block = match chain_store.get_block(block.header().prev_hash()) {
-            Ok(prev_block) => prev_block.clone(),
+            Ok(prev_block) => prev_block,
             Err(_) => {
                 if verbose_output {
                     println!("Skipping applying block #{} because the previous block is unavailable and I can't determine the gas_price to use.", height);
@@ -250,7 +249,7 @@ fn apply_block_from_range(
     } else {
         chunk_present = false;
         let chunk_extra =
-            chain_store.get_chunk_extra(block.header().prev_hash(), &shard_uid).unwrap().clone();
+            chain_store.get_chunk_extra(block.header().prev_hash(), &shard_uid).unwrap();
         prev_chunk_extra = Some(chunk_extra.clone());
 
         runtime_adapter

--- a/tools/state-viewer/src/apply_chunk.rs
+++ b/tools/state-viewer/src/apply_chunk.rs
@@ -45,7 +45,7 @@ fn get_incoming_receipts(
     }
 
     let mut chunks =
-        chunk_hashes.iter().map(|h| chain_store.get_chunk(h).unwrap().clone()).collect::<Vec<_>>();
+        chunk_hashes.iter().map(|h| chain_store.get_chunk(h).unwrap()).collect::<Vec<_>>();
     chunks.sort_by(|left, right| left.shard_id().cmp(&right.shard_id()));
 
     for chunk in chunks {

--- a/tools/state-viewer/src/epoch_info.rs
+++ b/tools/state-viewer/src/epoch_info.rs
@@ -208,7 +208,6 @@ fn display_validator_info(
 
         let shard_ids = 0..runtime_adapter.num_shards(epoch_id).unwrap();
         let cp_for_chunks: Vec<(BlockHeight, ShardId)> = block_height_range
-            .clone()
             .into_iter()
             .map(|block_height| {
                 shard_ids

--- a/tools/state-viewer/src/state_dump.rs
+++ b/tools/state-viewer/src/state_dump.rs
@@ -337,10 +337,10 @@ mod test {
             block_producers.into_iter().map(|(r, _)| r.take_account_id()).collect::<HashSet<_>>(),
             HashSet::from_iter(vec!["test0".parse().unwrap(), "test1".parse().unwrap()])
         );
-        let last_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap().clone();
+        let last_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap();
         let state_roots: Vec<CryptoHash> =
             last_block.chunks().iter().map(|chunk| chunk.prev_state_root()).collect();
-        let runtime = NightshadeRuntime::test(Path::new("."), store.clone(), &genesis);
+        let runtime = NightshadeRuntime::test(Path::new("."), store, &genesis);
         let records_file = tempfile::NamedTempFile::new().unwrap();
         let new_near_config = state_dump(
             runtime,
@@ -384,10 +384,10 @@ mod test {
             block_producers.into_iter().map(|(r, _)| r.take_account_id()).collect::<HashSet<_>>(),
             HashSet::from_iter(vec!["test0".parse().unwrap(), "test1".parse().unwrap()])
         );
-        let last_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap().clone();
+        let last_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap();
         let state_roots: Vec<CryptoHash> =
             last_block.chunks().iter().map(|chunk| chunk.prev_state_root()).collect();
-        let runtime = NightshadeRuntime::test(Path::new("."), store.clone(), &genesis);
+        let runtime = NightshadeRuntime::test(Path::new("."), store, &genesis);
         let new_near_config =
             state_dump(runtime, &state_roots, last_block.header().clone(), &near_config, None);
         let new_genesis = new_near_config.genesis;
@@ -416,10 +416,10 @@ mod test {
         }
 
         let head = env.clients[0].chain.head().unwrap();
-        let last_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap().clone();
+        let last_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap();
         let state_roots: Vec<CryptoHash> =
             last_block.chunks().iter().map(|chunk| chunk.prev_state_root()).collect();
-        let runtime = NightshadeRuntime::test(Path::new("."), store.clone(), &genesis);
+        let runtime = NightshadeRuntime::test(Path::new("."), store, &genesis);
 
         let records_file = tempfile::NamedTempFile::new().unwrap();
         let new_near_config = state_dump(
@@ -459,11 +459,11 @@ mod test {
             env.clients[0].runtime_adapter.get_shard_layout(&head.epoch_id).unwrap(),
             ShardLayout::v1_test()
         );
-        let last_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap().clone();
+        let last_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap();
 
         let state_roots: Vec<CryptoHash> =
             last_block.chunks().iter().map(|chunk| chunk.prev_state_root()).collect();
-        let runtime = NightshadeRuntime::test(Path::new("."), store.clone(), &genesis);
+        let runtime = NightshadeRuntime::test(Path::new("."), store, &genesis);
         let records_file = tempfile::NamedTempFile::new().unwrap();
         let new_near_config = state_dump(
             runtime,
@@ -500,7 +500,7 @@ mod test {
         let mut env = TestEnv::builder(chain_genesis)
             .clients_count(2)
             .runtime_adapters(vec![
-                Arc::new(create_runtime(store1.clone())),
+                Arc::new(create_runtime(store1)),
                 Arc::new(create_runtime(store2.clone())),
             ])
             .build();
@@ -609,10 +609,10 @@ mod test {
             block_producers.into_iter().map(|(r, _)| r.take_account_id()).collect::<HashSet<_>>(),
             HashSet::from_iter(vec!["test0".parse().unwrap(), "test1".parse().unwrap()])
         );
-        let last_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap().clone();
+        let last_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap();
         let state_roots: Vec<CryptoHash> =
             last_block.chunks().iter().map(|chunk| chunk.prev_state_root()).collect();
-        let runtime = NightshadeRuntime::test(Path::new("."), store.clone(), &genesis);
+        let runtime = NightshadeRuntime::test(Path::new("."), store, &genesis);
         let records_file = tempfile::NamedTempFile::new().unwrap();
         let new_near_config = state_dump(
             runtime,


### PR DESCRIPTION
Follow up for #6811 which made a lot of clones redundant.

The diff was generated using the following clippy command:

    cargo clippy --fix -- -A clippy::all -W clippy::redundant_clone