### PR TITLE
refactor: new ChainStore API

### DIFF
--- a/chain/chain/src/validate.rs
+++ b/chain/chain/src/validate.rs
@@ -16,8 +16,8 @@ use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{AccountId, BlockHeight, EpochId, Nonce};
 
-use crate::{byzantine_assert, Chain};
-use crate::{ChainStore, Error, RuntimeAdapter};
+use crate::{byzantine_assert, Chain, ChainStoreAccess};
+use crate::{Error, RuntimeAdapter};
 
 /// Gas limit cannot be adjusted for more than 0.1% at a time.
 const GAS_LIMIT_ADJUSTMENT_FACTOR: u64 = 1000;
@@ -119,7 +119,7 @@ pub fn validate_transactions_order(transactions: &[SignedTransaction]) -> bool {
 
 /// Validate that all next chunk information matches previous chunk extra.
 pub fn validate_chunk_with_chunk_extra(
-    chain_store: &mut ChainStore,
+    chain_store: &dyn ChainStoreAccess,
     runtime_adapter: &dyn RuntimeAdapter,
     prev_block_hash: &CryptoHash,
     prev_chunk_extra: &ChunkExtra,

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -1662,7 +1662,7 @@ impl ShardsManager {
             header.shard_id(),
             chunk_hash.clone(),
         );
-        store_update.commit()?;
+        store_update.into_diff().commit(chain_store)?;
 
         // Merge parts and receipts included in the partial encoded chunk into chunk cache
         self.encoded_chunks.merge_in_partial_encoded_chunk(partial_encoded_chunk);
@@ -1802,7 +1802,7 @@ impl ShardsManager {
             if !cares_about_shard {
                 let mut store_update = chain_store.store_update();
                 self.persist_partial_chunk_for_data_availability(entry, &mut store_update);
-                store_update.commit()?;
+                store_update.into_diff().commit(chain_store)?;
 
                 self.complete_chunk(&chunk_hash);
                 return Ok(ProcessPartialEncodedChunkResult::HaveAllPartsAndReceipts);
@@ -2071,7 +2071,7 @@ impl ShardsManager {
 
             // Decoded a valid chunk, store it in the permanent store
             store_update.save_chunk(shard_chunk);
-            store_update.commit()?;
+            store_update.into_diff().commit(chain_store)?;
 
             self.requested_partial_encoded_chunks.remove(&chunk_hash);
 
@@ -2080,7 +2080,7 @@ impl ShardsManager {
             // Can't decode chunk or has invalid proofs, ignore it
             error!(target: "chunks", "Reconstructed, but failed to decoded chunk {}, I'm {:?}", chunk_hash.0, self.me);
             store_update.save_invalid_chunk(encoded_chunk);
-            store_update.commit()?;
+            store_update.into_diff().commit(chain_store)?;
             self.encoded_chunks.remove(&chunk_hash);
             self.requested_partial_encoded_chunks.remove(&chunk_hash);
             return Err(Error::InvalidChunk);

--- a/chain/chunks/src/test_utils.rs
+++ b/chain/chunks/src/test_utils.rs
@@ -93,7 +93,7 @@ impl SealsManagerTestFixture {
         let mut chain_store = ChainStore::new(store, header.height(), true);
         let mut update = chain_store.store_update();
         update.save_block_header(header).unwrap();
-        update.commit().unwrap();
+        update.into_diff().commit(&mut chain_store).unwrap();
     }
 
     pub fn create_seals_manager(&self) -> SealsManager {

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1273,7 +1273,7 @@ impl ClientActor {
         chain_store_update
             .save_largest_target_height(self.client.doomslug.get_largest_target_height());
 
-        match chain_store_update.commit() {
+        match chain_store_update.into_diff().commit(self.client.chain.mut_store()) {
             Ok(_) => {
                 let head = unwrap_or_return!(self.client.chain.head());
                 if self.client.is_validator(&head.epoch_id, &head.last_block_hash)


### PR DESCRIPTION
So far, we are using the following shape of the API for stores:

```rust
// Actual DB with data
struct Store {

}

// DB in the process of being updated.
// StoreUpdate provides the same API as Store, but also takes prospective (not yet committed) changes into account.
// Crucially, it requires exclusive reference to Store.
struct StoreUpdate<'a> {
  store: &'a mut Store,
  foos: HashMap<CryptoHash, Foo>,
  bars: HashMap<CryptoHash, Bar>,
}

impl Store {
  fn store_update<'a>(&'a mut self) -> StoreUpdate<'a> {}
}

impl<'a> StoreUpdate<'a> {
  fn commit(self) -> Result<()>
}
```

The API is to be used like this:

```rust
let mut store = ...;
let mut update = store.store_update();
mutate(&mut update);
update.commit()?;
```

This PR proposes the following alternative shape, which I am going to argue is superior:

```rust
struct Store {

}

struct StoreUpdate<'a> {
  store: &'a Store, // NB: &, not &mut
  diff: StoreDiff,
}

struct StoreDiff {
    foos: HashMap<CryptoHash, Foo>,
    bars: HashMap<CryptoHash, Bar>,
}

impl Store {
  fn store_update<'a>(&'a self) -> StoreUpdate<'a> {}
  fn commit(&mut self, diff: StoreDiff) -> Result<()>
}

impl<'a> StoreUpdate<'a> {
  fn into_diff(self) -> StoreDiff
}
```

The new API is to be used like this:

```rust
let mut store = ...;
let update = prepare_update(&store); // NB: need only & to create update
let diff = update.into_diff();
store.commit(diff)?; // &mut is needed only for commit
```

That is, the change is that creating a store update now requires only a shared reference.
Exclusive reference is needed only when committing the changes. I think this API is better
for the following reasons:

* closer reflects what actually happens -- we are *not* mutating store when working with update.
* is friendlier to parallelism -- now you can be creating several store updates in parallel.
  No silver bullet though -- it's still up to you to sequence the application of updates and ensure
  they are not conflicting (insert-only/rc columns are helpful)
* is more restrictive: now that StoreUpdate doesn't have commit, we significantly reduce the volume
  of code which *could* be committing to the database. In particular, stuff like
  https://near.zulipchat.com/#narrow/stream/322379-pagoda.2Fcore.2Fconcurrent-client/topic/Is.20ChainStoreUpdate.3A.3Atry_save_latest_known.20correct.3F
  becomes impossible by construction