### PR TITLE
fix(pytests): fix gc_after_sync.py failure

### DIFF
--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -269,8 +269,12 @@ class BaseNode(object):
 
         return reversed(heights)
 
-    def get_validators(self):
-        return self.json_rpc('validators', [None])
+    def get_validators(self, epoch_id=None):
+        if epoch_id is None:
+            args = [None]
+        else:
+            args = {'epoch_id': epoch_id}
+        return self.json_rpc('validators', args)
 
     def get_account(self, acc, finality='optimistic', do_assert=True):
         res = self.json_rpc('query', {

--- a/pytest/tests/sanity/gc_after_sync.py
+++ b/pytest/tests/sanity/gc_after_sync.py
@@ -68,12 +68,15 @@ node1_height, _ = utils.wait_for_blocks(nodes[1],
                                         target=node0_height,
                                         verbose=True)
 
-epoch_id = nodes[1].json_rpc('block', [node1_height], timeout=15)['result']['header']['epoch_id']
-epoch_start_height = nodes[1].get_validators(epoch_id=epoch_id)['result']['epoch_start_height']
+epoch_id = nodes[1].json_rpc('block', [node1_height],
+                             timeout=15)['result']['header']['epoch_id']
+epoch_start_height = nodes[1].get_validators(
+    epoch_id=epoch_id)['result']['epoch_start_height']
 
 # all fresh data should be synced
 blocks_count = 0
-for height in range(max(node1_height - 10, epoch_start_height), node1_height+1):
+for height in range(max(node1_height - 10, epoch_start_height),
+                    node1_height + 1):
     block0 = nodes[0].json_rpc('block', [height], timeout=15)
     block1 = nodes[1].json_rpc('block', [height], timeout=15)
     assert block0 == block1, (block0, block1)

--- a/pytest/tests/sanity/gc_after_sync.py
+++ b/pytest/tests/sanity/gc_after_sync.py
@@ -68,12 +68,15 @@ node1_height, _ = utils.wait_for_blocks(nodes[1],
                                         target=node0_height,
                                         verbose=True)
 
+epoch_id = nodes[1].json_rpc('block', [node1_height], timeout=15)['result']['header']['epoch_id']
+epoch_start_height = nodes[1].get_validators(epoch_id=epoch_id)['result']['epoch_start_height']
+
 # all fresh data should be synced
 blocks_count = 0
-for height in range(node1_height - 10, node1_height):
+for height in range(max(node1_height - 10, epoch_start_height), node1_height+1):
     block0 = nodes[0].json_rpc('block', [height], timeout=15)
     block1 = nodes[1].json_rpc('block', [height], timeout=15)
-    assert block0 == block1
+    assert block0 == block1, (block0, block1)
     if 'result' in block0:
         blocks_count += 1
 assert blocks_count > 0
@@ -84,7 +87,7 @@ blocks_count = 0
 for height in range(1, 60):
     block0 = nodes[0].json_rpc('block', [height], timeout=15)
     block1 = nodes[1].json_rpc('block', [height], timeout=15)
-    assert block0 == block1
+    assert block0 == block1, (block0, block1)
     if 'result' in block0:
         blocks_count += 1
 assert blocks_count == 0


### PR DESCRIPTION
e.g.: https://nayduck.near.org/#/test/322670

After waiting for the node that's been restarted to sync, the block at
height HEAD-10 might not be stored since state sync will start at the
beginning of the epoch, which may be after that point. So start checking
blocks at max(HEAD-10, epoch_start) instead