### PR TITLE
Move `--color` into `o11y::Options`

### DIFF
--- a/core/o11y/src/lib.rs
+++ b/core/o11y/src/lib.rs
@@ -139,8 +139,10 @@ where
     layer
 }
 
-// Constructs an OpenTelemetryConfig which sends span data to an external collector.
-// OpenTelemetryConfig is currently empty, but more configuration will be added to it later.
+/// Constructs an OpenTelemetryConfig which sends span data to an external collector.
+//
+// NB: this function is `async` because `install_batch(Tokio)` requires a tokio context to
+// register timers and channels and whatnot.
 async fn make_opentelemetry_layer<S>(
     config: &Options,
 ) -> Filtered<OpenTelemetryLayer<S, Tracer>, LevelFilter, S>

--- a/core/o11y/src/lib.rs
+++ b/core/o11y/src/lib.rs
@@ -61,10 +61,14 @@ pub struct DefaultSubscriberGuard<S> {
 /// Configures exporter of span and trace data.
 // Currently empty, but more fields will be added in the future.
 #[derive(Debug, Default, Parser)]
-pub struct OpenTelemetryConfig {
-    #[clap(long)]
+pub struct Options {
     /// Enables export of span data using opentelemetry exporters.
+    #[clap(long)]
     opentelemetry: bool,
+
+    /// Whether the log needs to be colored.
+    #[clap(long, arg_enum, default_value = "auto")]
+    color: ColorOutput,
 }
 
 impl<S: tracing::Subscriber + Send + Sync> DefaultSubscriberGuard<S> {
@@ -104,6 +108,12 @@ pub enum ColorOutput {
     Auto,
 }
 
+impl Default for ColorOutput {
+    fn default() -> Self {
+        ColorOutput::Auto
+    }
+}
+
 fn is_terminal() -> bool {
     // Crate `atty` provides a platform-independent way of checking whether the output is a tty.
     atty::is(atty::Stream::Stderr)
@@ -131,8 +141,8 @@ where
 
 // Constructs an OpenTelemetryConfig which sends span data to an external collector.
 // OpenTelemetryConfig is currently empty, but more configuration will be added to it later.
-fn make_opentelemetry_layer<S>(
-    config: &OpenTelemetryConfig,
+async fn make_opentelemetry_layer<S>(
+    config: &Options,
 ) -> Filtered<OpenTelemetryLayer<S, Tracer>, LevelFilter, S>
 where
     S: tracing::Subscriber + for<'span> LookupSpan<'span>,
@@ -166,19 +176,20 @@ where
 /// ```rust
 /// let runtime = tokio::runtime::Runtime::new().unwrap();
 /// let filter = near_o11y::EnvFilterBuilder::from_env().finish().unwrap();
-/// let _subscriber = runtime.block_on(async {near_o11y::default_subscriber(filter, &near_o11y::ColorOutput::Auto, &near_o11y::OpenTelemetryConfig::default()).await.global() });
+/// let _subscriber = runtime.block_on(async {
+///     near_o11y::default_subscriber(filter, &Default::default()).await.global()
+/// });
 /// ```
 pub async fn default_subscriber(
     env_filter: EnvFilter,
-    color_output: &ColorOutput,
-    opentelemetry_config: &OpenTelemetryConfig,
+    options: &Options,
 ) -> DefaultSubscriberGuard<impl tracing::Subscriber + Send + Sync> {
     // Do not lock the `stderr` here to allow for things like `dbg!()` work during development.
     let stderr = std::io::stderr();
     let lined_stderr = std::io::LineWriter::new(stderr);
     let (writer, writer_guard) = tracing_appender::non_blocking(lined_stderr);
 
-    let ansi = match color_output {
+    let ansi = match options.color {
         ColorOutput::Always => true,
         ColorOutput::Never => false,
         ColorOutput::Auto => std::env::var_os("NO_COLOR").is_none() && is_terminal(),
@@ -190,7 +201,7 @@ pub async fn default_subscriber(
 
     let subscriber = tracing_subscriber::registry();
     let subscriber = subscriber.with(log_layer);
-    let subscriber = subscriber.with(make_opentelemetry_layer(opentelemetry_config));
+    let subscriber = subscriber.with(make_opentelemetry_layer(options).await);
 
     DefaultSubscriberGuard {
         subscriber: Some(subscriber),

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -3,8 +3,7 @@ use actix::SystemRunner;
 use clap::{Args, Parser};
 use near_chain_configs::GenesisValidationMode;
 use near_o11y::{
-    default_subscriber, BuildEnvFilterError, ColorOutput, DefaultSubscriberGuard, EnvFilterBuilder,
-    OpenTelemetryConfig,
+    default_subscriber, BuildEnvFilterError, DefaultSubscriberGuard, EnvFilterBuilder,
 };
 use near_primitives::types::{Gas, NumSeats, NumShards};
 use near_state_viewer::StateViewerSubCommand;
@@ -113,8 +112,7 @@ async fn init_logging(
     } else {
         env_filter
     };
-    let subscriber =
-        default_subscriber(env_filter, &opts.color, &opts.opentelemetry).await.global();
+    let subscriber = default_subscriber(env_filter, &opts.o11y).await.global();
     Ok(subscriber)
 }
 
@@ -159,12 +157,9 @@ struct NeardOpts {
     /// Let's you start `neard` slightly faster.
     #[clap(long)]
     unsafe_fast_startup: bool,
-    /// Whether the log needs to be colored.
-    #[clap(long, arg_enum, default_value = "auto")]
-    color: ColorOutput,
     /// Enables export of span data using opentelemetry protocol.
     #[clap(flatten)]
-    opentelemetry: OpenTelemetryConfig,
+    o11y: near_o11y::Options,
 }
 
 impl NeardOpts {

--- a/tools/chainsync-loadtest/src/main.rs
+++ b/tools/chainsync-loadtest/src/main.rs
@@ -18,7 +18,6 @@ use near_network::routing::start_routing_table_actor;
 use near_network::test_utils::NetworkRecipient;
 use near_network::PeerManagerActor;
 use near_o11y::tracing::{error, info};
-use near_o11y::{ColorOutput, OpenTelemetryConfig};
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
 use nearcore::config;
@@ -137,13 +136,7 @@ fn main() {
         .add_directive(near_o11y::tracing::Level::INFO.into());
     let runtime = tokio::runtime::Runtime::new().unwrap();
     let _subscriber = runtime.block_on(async {
-        near_o11y::default_subscriber(
-            env_filter,
-            &ColorOutput::Auto,
-            &OpenTelemetryConfig::default(),
-        )
-        .await
-        .global();
+        near_o11y::default_subscriber(env_filter, &Default::default()).await.global();
     });
     let orig_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |panic_info| {

--- a/tools/indexer/example/src/main.rs
+++ b/tools/indexer/example/src/main.rs
@@ -7,7 +7,6 @@ use tracing::info;
 
 use configs::{Opts, SubCommand};
 use near_indexer;
-use near_o11y::{ColorOutput, OpenTelemetryConfig};
 
 mod configs;
 
@@ -267,13 +266,7 @@ fn main() -> Result<()> {
     );
     let runtime = tokio::runtime::Runtime::new().unwrap();
     let _subscriber = runtime.block_on(async {
-        near_o11y::default_subscriber(
-            env_filter,
-            &ColorOutput::Auto,
-            &OpenTelemetryConfig::default(),
-        )
-        .await
-        .global();
+        near_o11y::default_subscriber(env_filter, &Default::default()).await.global();
     });
     let opts: Opts = Opts::parse();
 

--- a/tools/restaked/src/main.rs
+++ b/tools/restaked/src/main.rs
@@ -9,7 +9,6 @@ use std::sync::Arc;
 use std::time::Duration;
 // TODO(1905): Move out RPC interface for transacting into separate production crate.
 use integration_tests::user::{rpc_user::RpcUser, User};
-use near_o11y::{ColorOutput, OpenTelemetryConfig};
 
 const DEFAULT_WAIT_PERIOD_SEC: &str = "60";
 const DEFAULT_RPC_URL: &str = "http://localhost:3030";
@@ -24,13 +23,7 @@ fn main() {
     let env_filter = near_o11y::EnvFilterBuilder::from_env().verbose(Some("")).finish().unwrap();
     let runtime = tokio::runtime::Runtime::new().unwrap();
     let _subscriber = runtime.block_on(async {
-        near_o11y::default_subscriber(
-            env_filter,
-            &ColorOutput::Auto,
-            &OpenTelemetryConfig::default(),
-        )
-        .await
-        .global();
+        near_o11y::default_subscriber(env_filter, &Default::default()).await.global();
     });
 
     let default_home = get_default_home();

--- a/tools/storage-usage-delta-calculator/src/main.rs
+++ b/tools/storage-usage-delta-calculator/src/main.rs
@@ -1,5 +1,4 @@
 use near_chain_configs::{Genesis, GenesisValidationMode};
-use near_o11y::{ColorOutput, OpenTelemetryConfig};
 use near_primitives::runtime::config_store::RuntimeConfigStore;
 use near_primitives::state_record::StateRecord;
 use near_primitives::version::PROTOCOL_VERSION;
@@ -14,13 +13,7 @@ use tracing::debug;
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
     let env_filter = near_o11y::EnvFilterBuilder::from_env().verbose(Some("")).finish().unwrap();
-    let _subscriber = near_o11y::default_subscriber(
-        env_filter,
-        &ColorOutput::Auto,
-        &OpenTelemetryConfig::default(),
-    )
-    .await
-    .global();
+    let _subscriber = near_o11y::default_subscriber(env_filter, &Default::default()).await.global();
     debug!(target: "storage-calculator", "Start");
 
     let genesis = Genesis::from_file("output.json", GenesisValidationMode::Full);


### PR DESCRIPTION
o11y is responsible for setting up console output and its options, so it
makes sense to keep that flag in `o11y` too.

cc @nikurt
cc @mina86 (this is very mildly related to the discussion in https://github.com/near/nearcore/issues/6888; basically, I feel like we could do pretty much the same thing to the EnvFilter and then users only ever need to think about dealing with including an `o11y::Options` in their structopt definition)