### PR TITLE
RFC: introduce unified testing infrastructure for contract runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,6 +1384,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dissimilar"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c97b9233581d84b8e1e689cdd3a47b6f69770084fc246e86a7f78b0d9c1d4a5"
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1557,6 +1563,16 @@ dependencies = [
  "serde_json",
  "tempfile",
  "xshell",
+]
+
+[[package]]
+name = "expect-test"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dced95c9dcd4e3241f95841aad395f9c8d7933a3b0b524bdeb2440885c72a271"
+dependencies = [
+ "dissimilar",
+ "once_cell",
 ]
 
 [[package]]
@@ -3396,6 +3412,7 @@ dependencies = [
  "assert_matches",
  "base64 0.13.0",
  "borsh",
+ "expect-test",
  "loupe",
  "memoffset",
  "near-cache",

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -64,6 +64,7 @@ wasm-smith = "0.10"
 assert_matches = "1.3"
 wat = "1.0.40"
 base64 = "0.13"
+expect-test = "1.3.0"
 
 [features]
 # all vms enabled for now

--- a/runtime/near-vm-runner/src/tests/compile_errors.rs
+++ b/runtime/near-vm-runner/src/tests/compile_errors.rs
@@ -1,61 +1,63 @@
+use super::test_builder::test_builder;
+use expect_test::expect;
 use near_primitives::version::ProtocolFeature;
-use near_vm_errors::{CompilationError, FunctionCallError, PrepareError, VMError, WasmTrap};
-
-use assert_matches::assert_matches;
-
-use crate::tests::{
-    gas_and_error_match, make_simple_contract_call_vm,
-    make_simple_contract_call_with_protocol_version_vm, with_vm_variants,
-};
-use crate::vm_kind::VMKind;
-
-fn initializer_wrong_signature_contract() -> Vec<u8> {
-    wat::parse_str(
-        r#"
-            (module
-              (type (;0;) (func (param i32)))
-              (func (;0;) (type 0))
-              (start 0)
-              (export "hello" (func 0))
-            )"#,
-    )
-    .unwrap()
-}
 
 #[test]
 fn test_initializer_wrong_signature_contract() {
-    with_vm_variants(|vm_kind: VMKind| {
-        assert_eq!(
-            make_simple_contract_call_vm(&initializer_wrong_signature_contract(), "hello", vm_kind)
-                .1,
-            (Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
-                CompilationError::PrepareError(PrepareError::Deserialization)
-            ))))
-        );
-    });
-}
-
-fn function_not_defined_contract() -> Vec<u8> {
-    wat::parse_str(
-        r#"
-            (module
-              (export "hello" (func 0))
-            )"#,
-    )
-    .unwrap()
+    test_builder()
+        .wat(
+            r#"
+(module
+  (type (;0;) (func (param i32)))
+  (func (;0;) (type 0))
+  (start 0)
+  (export "hello" (func 0))
+)"#,
+        )
+        .method("hello")
+        .protocol_features(&[
+            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+            ProtocolFeature::FixContractLoadingCost,
+        ])
+        .expects(&[
+            expect![[r#"
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
+                Err: PrepareError: Error happened while deserializing the module.
+            "#]],
+            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+            expect![[r#"
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 43899213 used gas 43899213
+                Err: PrepareError: Error happened while deserializing the module.
+            "#]],
+        ]);
 }
 
 #[test]
 /// StackHeightInstrumentation is weird but it's what we return for now
 fn test_function_not_defined_contract() {
-    with_vm_variants(|vm_kind: VMKind| {
-        assert_eq!(
-            make_simple_contract_call_vm(&function_not_defined_contract(), "hello", vm_kind).1,
-            (Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
-                CompilationError::PrepareError(PrepareError::Deserialization)
-            ))))
-        );
-    });
+    test_builder()
+        .wat(
+            r#"
+(module
+  (export "hello" (func 0))
+)"#,
+        )
+        .method("hello")
+        .protocol_features(&[
+            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+            ProtocolFeature::FixContractLoadingCost,
+        ])
+        .expects(&[
+            expect![[r#"
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
+                Err: PrepareError: Error happened while deserializing the module.
+            "#]],
+            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+            expect![[r#"
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 39564213 used gas 39564213
+                Err: PrepareError: Error happened while deserializing the module.
+            "#]],
+        ]);
 }
 
 fn function_type_not_defined_contract(bad_type: u64) -> Vec<u8> {
@@ -72,300 +74,313 @@ fn function_type_not_defined_contract(bad_type: u64) -> Vec<u8> {
 
 #[test]
 fn test_function_type_not_defined_contract_1() {
-    with_vm_variants(|vm_kind: VMKind| {
-        assert_eq!(
-            make_simple_contract_call_vm(&function_type_not_defined_contract(1), "hello", vm_kind)
-                .1,
-            (Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
-                CompilationError::PrepareError(PrepareError::Deserialization)
-            ))))
-        );
-    });
+    test_builder()
+        .wasm(&function_type_not_defined_contract(1))
+        .method("hello")
+        .protocol_features(&[
+            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+            ProtocolFeature::FixContractLoadingCost,
+        ])
+        .expects(&[
+            expect![[r#"
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
+                Err: PrepareError: Error happened while deserializing the module.
+            "#]],
+            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+            expect![[r#"
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 41731713 used gas 41731713
+                Err: PrepareError: Error happened while deserializing the module.
+            "#]],
+        ]);
 }
 
 #[test]
 // Weird case. It's not valid wasm (wat2wasm validate will fail), but wasmer allows it.
 fn test_function_type_not_defined_contract_2() {
-    with_vm_variants(|vm_kind: VMKind| {
-        assert_eq!(
-            make_simple_contract_call_vm(&function_type_not_defined_contract(0), "hello", vm_kind)
-                .1,
-            (Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
-                CompilationError::PrepareError(PrepareError::Deserialization)
-            ))))
-        );
-    });
+    test_builder()
+        .wasm(&function_type_not_defined_contract(0))
+        .method("hello")
+        .protocol_features(&[
+            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+            ProtocolFeature::FixContractLoadingCost,
+        ])
+        .expects(&[
+            expect![[r#"
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
+                Err: PrepareError: Error happened while deserializing the module.
+            "#]],
+            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+            expect![[r#"
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 41731713 used gas 41731713
+                Err: PrepareError: Error happened while deserializing the module.
+            "#]],
+        ]);
 }
 
 #[test]
 fn test_garbage_contract() {
-    with_vm_variants(|vm_kind: VMKind| {
-        assert_eq!(
-            make_simple_contract_call_vm(&[], "hello", vm_kind).1,
-            (Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
-                CompilationError::PrepareError(PrepareError::Deserialization)
-            ))))
-        );
-    });
+    test_builder()
+        .wasm(&[])
+        .protocol_features(&[
+            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+            ProtocolFeature::FixContractLoadingCost,
+        ])
+        .expects(&[
+            expect![[r#"
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
+                Err: PrepareError: Error happened while deserializing the module.
+            "#]],
+            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+            expect![[r#"
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 35445963 used gas 35445963
+                Err: PrepareError: Error happened while deserializing the module.
+            "#]],
+        ]);
 }
 
-fn evil_function_index() -> Vec<u8> {
-    wat::parse_str(
-        r#"
+#[test]
+fn test_evil_function_index() {
+    test_builder()
+        .wat(
+            r#"
           (module
             (type (;0;) (func))
             (func (;0;) (type 0)
               call 4294967295)
             (export "abort_with_zero" (func 0))
           )"#,
-    )
-    .unwrap()
-}
-
-#[test]
-fn test_evil_function_index() {
-    with_vm_variants(|vm_kind: VMKind| {
-        assert_eq!(
-            make_simple_contract_call_vm(&evil_function_index(), "abort_with_zero", vm_kind).1,
-            (Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
-                CompilationError::PrepareError(PrepareError::Deserialization)
-            ))))
-        );
-    });
+        )
+        .method("abort_with_zero")
+        .protocol_features(&[
+            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+            ProtocolFeature::FixContractLoadingCost,
+        ])
+        .expects(&[
+            expect![[r#"
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
+                Err: PrepareError: Error happened while deserializing the module.
+            "#]],
+            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+            expect![[r#"
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 46500213 used gas 46500213
+                Err: PrepareError: Error happened while deserializing the module.
+            "#]],
+        ]);
 }
 
 #[test]
 fn test_limit_contract_functions_number() {
-    with_vm_variants(|vm_kind: VMKind| {
-        let old_protocol_version =
-            ProtocolFeature::LimitContractFunctionsNumber.protocol_version() - 1;
-        let new_protocol_version = old_protocol_version + 1;
+    let functions_number_limit: u32 = 10_000;
 
-        let functions_number_limit: u32 = 10_000;
-        let method_name = "main";
-
-        let code = near_test_contracts::LargeContract {
-            functions: functions_number_limit + 1,
-            ..Default::default()
-        }
-        .make();
-        let (_, err) = make_simple_contract_call_with_protocol_version_vm(
-            &code,
-            method_name,
-            old_protocol_version,
-            vm_kind,
-        );
-        assert_eq!(err, None);
-
-        let code = near_test_contracts::LargeContract {
+    test_builder().wasm(
+        &near_test_contracts::LargeContract {
             functions: functions_number_limit,
             ..Default::default()
         }
-        .make();
-        let (_, err) = make_simple_contract_call_with_protocol_version_vm(
-            &code,
-            method_name,
-            new_protocol_version,
-            vm_kind,
-        );
-        assert_eq!(err, None);
+        .make(),
+    )
+    .protocol_features(&[
+        ProtocolFeature::LimitContractFunctionsNumber,
+        #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+        ProtocolFeature::FixContractLoadingCost,
+    ])
+    .expects(&[
+        expect![[r#"
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 13048032213 used gas 13048032213
+        "#]],
+        expect![[r#"
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 13048032213 used gas 13048032213
+        "#]],
+        #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+        expect![[r#"
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 13048032213 used gas 13048032213
+        "#]],
+    ]);
 
-        let code = near_test_contracts::LargeContract {
+    test_builder().wasm(
+        &near_test_contracts::LargeContract {
             functions: functions_number_limit + 1,
             ..Default::default()
         }
-        .make();
-        let (_, err) = make_simple_contract_call_with_protocol_version_vm(
-            &code,
-            method_name,
-            new_protocol_version,
-            vm_kind,
-        );
-        assert_matches!(
-            err,
-            Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
-                CompilationError::PrepareError(PrepareError::TooManyFunctions)
-            )))
-        );
+        .make(),
+    )
+    .protocol_features(&[
+        ProtocolFeature::LimitContractFunctionsNumber,
+        #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+        ProtocolFeature::FixContractLoadingCost,
+    ])
+    .expects(&[
+        expect![[r#"
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 13049332713 used gas 13049332713
+        "#]],
+        expect![[r#"
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
+            Err: PrepareError: Too many functions in contract.
+        "#]],
+        #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+        expect![[r#"
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 13049332713 used gas 13049332713
+            Err: PrepareError: Too many functions in contract.
+        "#]],
+    ]);
 
-        let code = near_test_contracts::LargeContract {
-            functions: functions_number_limit / 2,
-            panic_imports: functions_number_limit / 2 + 1,
-            ..Default::default()
-        }
-        .make();
-        let (_, err) = make_simple_contract_call_with_protocol_version_vm(
-            &code,
-            method_name,
-            new_protocol_version,
-            vm_kind,
-        );
-        assert_matches!(
-            err,
-            Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
-                CompilationError::PrepareError(PrepareError::TooManyFunctions)
-            )))
-        );
+    test_builder()
+        .wasm(
+            &near_test_contracts::LargeContract {
+                functions: functions_number_limit / 2,
+                panic_imports: functions_number_limit / 2 + 1,
+                ..Default::default()
+            }
+            .make(),
+        )
+        .protocol_features(&[
+            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+            ProtocolFeature::FixContractLoadingCost,
+        ])
+        .expects(&[
+            expect![[r#"
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
+                Err: PrepareError: Too many functions in contract.
+            "#]],
+            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+            expect![[r#"
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 19554433713 used gas 19554433713
+                Err: PrepareError: Too many functions in contract.
+            "#]],
+        ]);
 
-        let code = near_test_contracts::LargeContract {
-            functions: functions_number_limit,
-            panic_imports: 1,
-            ..Default::default()
-        }
-        .make();
-        let (_, err) = make_simple_contract_call_with_protocol_version_vm(
-            &code,
-            method_name,
-            new_protocol_version,
-            vm_kind,
-        );
-        assert_matches!(
-            err,
-            Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
-                CompilationError::PrepareError(PrepareError::TooManyFunctions)
-            )))
-        );
-    });
+    test_builder()
+        .wasm(
+            &near_test_contracts::LargeContract {
+                functions: functions_number_limit,
+                panic_imports: 1,
+                ..Default::default()
+            }
+            .make(),
+        )
+        .protocol_features(&[
+            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+            ProtocolFeature::FixContractLoadingCost,
+        ])
+        .expects(&[
+            expect![[r#"
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
+                Err: PrepareError: Too many functions in contract.
+            "#]],
+            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+            expect![[r#"
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 13051283463 used gas 13051283463
+                Err: PrepareError: Too many functions in contract.
+            "#]],
+        ]);
 }
 
 #[test]
 fn test_limit_locals() {
-    with_vm_variants(|vm_kind| {
-        match vm_kind {
-            VMKind::Wasmer0 | VMKind::Wasmer2 => {}
-            // All contracts leading to hardware traps can not run concurrently on Wasmtime and Wasmer,
-            // Restore, once get rid of Wasmer 0.x.
-            VMKind::Wasmtime => return,
-        }
+    test_builder()
+        .wasm(
+            &near_test_contracts::LargeContract {
+                functions: 1,
+                locals_per_function: 50_001,
+                ..Default::default()
+            }
+            .make(),
+        )
+        .protocol_features(&[
+            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+            ProtocolFeature::FixContractLoadingCost,
+        ])
+        .expects(&[
+            expect![[r#"
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
+                Err: PrepareError: Error happened while deserializing the module.
+            "#]],
+            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+            expect![[r#"
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 43682463 used gas 43682463
+                Err: PrepareError: Error happened while deserializing the module.
+            "#]],
+        ]);
 
-        let wasm_err = near_test_contracts::LargeContract {
-            functions: 1,
-            locals_per_function: 50_001,
-            ..Default::default()
-        }
-        .make();
-        let res = make_simple_contract_call_vm(&wasm_err, "main", vm_kind);
-        let expected_gas = super::prepaid_loading_gas(wasm_err.len());
-        gas_and_error_match(
-            res,
-            expected_gas,
-            Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
-                CompilationError::PrepareError(PrepareError::Deserialization),
-            ))),
-        );
-
-        let wasm_ok = near_test_contracts::LargeContract {
-            functions: 1,
-            locals_per_function: 50_000,
-            ..Default::default()
-        }
-        .make();
-        let res = make_simple_contract_call_vm(&wasm_ok, "main", vm_kind);
-        gas_and_error_match(
-            res,
-            43682463,
-            Some(VMError::FunctionCallError(FunctionCallError::WasmTrap(WasmTrap::Unreachable))),
-        );
-    })
+    test_builder()
+        .wasm(
+            &near_test_contracts::LargeContract {
+                functions: 1,
+                locals_per_function: 50_000,
+                ..Default::default()
+            }
+            .make(),
+        )
+        .skip_wasmtime()
+        .expect(expect![[r#"
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 43682463 used gas 43682463
+            Err: WebAssembly trap: An `unreachable` opcode was executed.
+        "#]]);
 }
 
 #[test]
 fn test_limit_locals_global() {
-    with_vm_variants(|vm_kind| {
-        let new_protocol_version = ProtocolFeature::LimitContractLocals.protocol_version();
-        let old_protocol_version = new_protocol_version - 1;
-        let code_1000001_locals = near_test_contracts::LargeContract {
-            functions: 101,
-            locals_per_function: 9901,
-            ..Default::default()
-        }
-        .make();
-        match vm_kind {
-            VMKind::Wasmer0 | VMKind::Wasmer2 => {}
-            // All contracts leading to hardware traps can not run concurrently on Wasmtime and Wasmer,
-            // Restore, once get rid of Wasmer 0.x.
-            VMKind::Wasmtime => return,
-        }
+    test_builder().wasm(&near_test_contracts::LargeContract {
+        functions: 101,
+        locals_per_function: 9901,
+        ..Default::default()
+    }
+    .make())
+    .protocol_features(&[
+        ProtocolFeature::LimitContractLocals,
+        #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+        ProtocolFeature::FixContractLoadingCost,
+    ])
+    .expects(&[
+        expect![[r#"
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 195407463 used gas 195407463
+        "#]],
+        expect![[r#"
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
+            Err: PrepareError: Too many locals declared in the contract.
+        "#]],
+        #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+        expect![[r#"
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 195407463 used gas 195407463
+            Err: PrepareError: Too many locals declared in the contract.
+        "#]],
+    ]);
 
-        let (_, err) = make_simple_contract_call_with_protocol_version_vm(
-            &code_1000001_locals,
-            "main",
-            new_protocol_version,
-            vm_kind,
-        );
-        assert_eq!(
-            err,
-            Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
-                CompilationError::PrepareError(PrepareError::TooManyLocals),
-            ))),
-        );
-
-        let (_, err) = make_simple_contract_call_with_protocol_version_vm(
-            &code_1000001_locals,
-            "main",
-            old_protocol_version,
-            vm_kind,
-        );
-        assert_eq!(err, None);
-
-        let (_, err) = make_simple_contract_call_with_protocol_version_vm(
+    test_builder()
+        .wasm(
             &near_test_contracts::LargeContract {
                 functions: 64,
                 locals_per_function: 15625,
                 ..Default::default()
             }
             .make(),
-            "main",
-            new_protocol_version,
-            vm_kind,
-        );
-        assert_eq!(err, None);
-    })
+        )
+        .expect(expect![[r#"
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 139269213 used gas 139269213
+        "#]]);
 }
 
-fn call_sandbox_debug_log() -> Vec<u8> {
-    wat::parse_str(
-        r#"
-            (module
-                (import "env" "sandbox_debug_log" (func (;0;) (param i64 i64)))
-                (func $main (export "main")
-                    (call 0 (i64.const 0) (i64.const 1)))
-            )"#,
-    )
-    .unwrap()
-}
-
-#[cfg(not(feature = "sandbox"))]
 #[test]
 fn test_sandbox_only_function() {
-    with_vm_variants(|vm_kind| {
-        let wasm = call_sandbox_debug_log();
-        let res = make_simple_contract_call_vm(&wasm, "main", vm_kind);
-        let error_msg = match vm_kind {
-            VMKind::Wasmer0 => {
-                "link error: Import not found, namespace: env, name: sandbox_debug_log"
-            }
-            VMKind::Wasmer2 => {
-                "Error while importing \"env\".\"sandbox_debug_log\": unknown import. Expected Function(FunctionType { params: [I64, I64], results: [] })"
-            }
-            VMKind::Wasmtime => "\"unknown import: `env::sandbox_debug_log` has not been defined\"",
-        };
-        gas_and_error_match(
-            res,
-            54519963,
-            Some(VMError::FunctionCallError(FunctionCallError::LinkError {
-                msg: error_msg.to_string(),
-            })),
-        );
-    })
-}
+    let tb = test_builder()
+        .wat(
+            r#"
+(module
+    (import "env" "sandbox_debug_log" (func (;0;) (param i64 i64)))
+    (func $main (export "main")
+        (call 0 (i64.const 0) (i64.const 1)))
+)"#,
+        )
+        .opaque_error();
 
-#[cfg(feature = "sandbox")]
-#[test]
-fn test_sandbox_only_function_when_sandbox_feature() {
-    with_vm_variants(|vm_kind| {
-        let wasm = call_sandbox_debug_log();
-        let res = make_simple_contract_call_vm(&wasm, "main", vm_kind);
-        gas_and_error_match(res, 66089076, None);
-    })
+    #[cfg(feature = "sandbox")]
+    tb.expect(expect![[r#"
+        VMOutcome: balance 4 storage_usage 12 return data None burnt gas 56988231 used gas 56988231
+    "#]]);
+
+    #[cfg(not(feature = "sandbox"))]
+    tb.expect(expect![[r#"
+        VMOutcome: balance 4 storage_usage 12 return data None burnt gas 54519963 used gas 54519963
+        Err: ...
+    "#]]);
 }

--- a/runtime/near-vm-runner/src/tests/runtime_errors.rs
+++ b/runtime/near-vm-runner/src/tests/runtime_errors.rs
@@ -694,8 +694,8 @@ fn test_gas_exceed_loading() {
 // overflow
 #[test]
 fn gas_overflow_direct_call() {
-    with_vm_variants(|vm_kind: VMKind| {
-        let direct_call = wat::parse_str(
+    test_builder()
+        .wat(
             r#"
 (module
   (import "env" "gas" (func $gas (param i32)))
@@ -703,25 +703,18 @@ fn gas_overflow_direct_call() {
     (call $gas (i32.const 0xffff_ffff)))
 )"#,
         )
-        .unwrap();
-
-        let actual = make_simple_contract_call_vm(&direct_call, "main", vm_kind);
-        gas_and_error_match(
-            actual,
-            100000000000000,
-            Some(VMError::FunctionCallError(FunctionCallError::HostError(
-                HostError::GasLimitExceeded,
-            ))),
-        );
-    });
+        .expect(expect![[r#"
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 100000000000000 used gas 100000000000000
+            Err: Exceeded the maximum amount of gas allowed to burn per contract.
+        "#]]);
 }
 
 // Call the "gas" host function indirectly with unreasonably large values,
 // trying to force overflow.
 #[test]
 fn gas_overflow_indirect_call() {
-    with_vm_variants(|vm_kind: VMKind| {
-        let indirect_call = wat::parse_str(
+    test_builder()
+        .wat(
             r#"
 (module
   (import "env" "gas" (func $gas (param i32)))
@@ -737,17 +730,10 @@ fn gas_overflow_indirect_call() {
       (i32.const 0)))
 )"#,
         )
-        .unwrap();
-
-        let actual = make_simple_contract_call_vm(&indirect_call, "main", vm_kind);
-        gas_and_error_match(
-            actual,
-            100000000000000,
-            Some(VMError::FunctionCallError(FunctionCallError::HostError(
-                HostError::GasLimitExceeded,
-            ))),
-        );
-    });
+        .expect(expect![[r#"
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 100000000000000 used gas 100000000000000
+            Err: Exceeded the maximum amount of gas allowed to burn per contract.
+        "#]]);
 }
 
 #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]

--- a/runtime/near-vm-runner/src/tests/runtime_errors.rs
+++ b/runtime/near-vm-runner/src/tests/runtime_errors.rs
@@ -682,10 +682,12 @@ fn test_nan_sign() {
 // even load a contract.
 #[test]
 fn test_gas_exceed_loading() {
-    test_builder().wat(SIMPLE_CONTRACT).method("non_empty_non_existing").gas(1).expect(expect![[r#"
-        VMOutcome: balance 4 storage_usage 12 return data None burnt gas 1 used gas 1
-        Err: Exceeded the prepaid gas.
-    "#]]);
+    test_builder().wat(SIMPLE_CONTRACT).method("non_empty_non_existing").gas(1).expect(expect![[
+        r#"
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 1 used gas 1
+            Err: Exceeded the prepaid gas.
+        "#
+    ]]);
 }
 
 // Call the "gas" host function with unreasonably large values, trying to force

--- a/runtime/near-vm-runner/src/tests/runtime_errors.rs
+++ b/runtime/near-vm-runner/src/tests/runtime_errors.rs
@@ -1,574 +1,433 @@
-use crate::tests::{
-    gas_and_error_match, make_simple_contract_call_vm, make_simple_contract_call_with_gas_vm,
-    make_simple_contract_call_with_protocol_version_vm, prepaid_loading_gas, with_vm_variants,
-};
-use crate::vm_kind::VMKind;
+use super::test_builder::test_builder;
+use expect_test::expect;
 use near_primitives::version::ProtocolFeature;
-use near_vm_errors::{
-    CompilationError, FunctionCallError, HostError, MethodResolveError, PrepareError, VMError,
-    WasmTrap,
-};
 
-fn infinite_initializer_contract() -> Vec<u8> {
-    wat::parse_str(
-        r#"
-            (module
-              (type (;0;) (func))
-              (func (;0;) (type 0) (loop (br 0)))
-              (func (;1;) (type 0))
-              (start 0)
-              (export "hello" (func 1))
-            )"#,
-    )
-    .unwrap()
-}
+static INFINITE_INITIALIZER_CONTRACT: &str = r#"
+(module
+  (type (;0;) (func))
+  (func (;0;) (type 0) (loop (br 0)))
+  (func (;1;) (type 0))
+  (start 0)
+  (export "hello" (func 1))
+)"#;
 
 #[test]
 fn test_infinite_initializer() {
-    with_vm_variants(|vm_kind: VMKind| {
-        gas_and_error_match(
-            make_simple_contract_call_vm(&infinite_initializer_contract(), "hello", vm_kind),
-            100000000000000,
-            Some(VMError::FunctionCallError(FunctionCallError::HostError(HostError::GasExceeded))),
-        );
-    });
+    test_builder()
+        .wat(INFINITE_INITIALIZER_CONTRACT)
+        .method("hello")
+        .expect(expect![[r#"
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 100000000000000 used gas 100000000000000
+            Err: Exceeded the prepaid gas.
+        "#]]);
 }
 
 #[test]
 fn test_infinite_initializer_export_not_found() {
-    with_vm_variants(|vm_kind: VMKind| {
-        let code = infinite_initializer_contract();
-        gas_and_error_match(
-            make_simple_contract_call_vm(&code, "hello2", vm_kind),
-            prepaid_loading_gas(code.len()),
-            Some(VMError::FunctionCallError(FunctionCallError::MethodResolveError(
-                MethodResolveError::MethodNotFound,
-            ))),
-        );
-    });
+    test_builder()
+        .wat(INFINITE_INITIALIZER_CONTRACT)
+        .method("hello2")
+        .protocol_features(&[
+            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+            ProtocolFeature::FixContractLoadingCost,
+        ]).expects(&[
+            expect![[r#"
+                VMOutcome: balance 0 storage_usage 0 return data None burnt gas 0 used gas 0
+                Err: MethodNotFound
+            "#]],
+            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+            expect![[r#"
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 45633213 used gas 45633213
+                Err: MethodNotFound
+            "#]],
+        ]);
 }
 
-fn simple_contract() -> Vec<u8> {
-    wat::parse_str(
-        r#"
-            (module
-              (type (;0;) (func))
-              (func (;0;) (type 0))
-              (export "hello" (func 0))
-            )"#,
-    )
-    .unwrap()
-}
+static SIMPLE_CONTRACT: &str = r#"
+(module
+  (type (;0;) (func))
+  (func (;0;) (type 0))
+  (export "hello" (func 0))
+)"#;
 
 #[test]
 fn test_simple_contract() {
-    with_vm_variants(|vm_kind: VMKind| {
-        gas_and_error_match(
-            make_simple_contract_call_vm(&simple_contract(), "hello", vm_kind),
-            43032213,
-            None,
-        );
-    });
-}
-
-fn multi_memories_contract() -> Vec<u8> {
-    vec![
-        0, 97, 115, 109, 1, 0, 0, 0, 2, 12, 1, 3, 101, 110, 118, 0, 2, 1, 239, 1, 248, 1, 4, 6, 1,
-        112, 0, 143, 129, 32, 7, 12, 1, 8, 0, 17, 17, 17, 17, 17, 17, 2, 2, 0,
-    ]
+    test_builder().wat(SIMPLE_CONTRACT).method("hello").expect(expect![[r#"
+        VMOutcome: balance 4 storage_usage 12 return data None burnt gas 43032213 used gas 43032213
+    "#]]);
 }
 
 #[test]
 fn test_multiple_memories() {
-    with_vm_variants(|vm_kind: VMKind| {
-        let code = multi_memories_contract();
-        let (result, error) = make_simple_contract_call_vm(&code, "hello", vm_kind);
-        let expected_gas = prepaid_loading_gas(code.len());
-        assert_eq!(result.used_gas, expected_gas);
-        match error {
-            Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
-                CompilationError::WasmerCompileError { .. },
-            ))) => match vm_kind {
-                VMKind::Wasmer0 | VMKind::Wasmer2 => {}
-                VMKind::Wasmtime => {
-                    panic!("Unexpected")
-                }
-            },
-            Some(VMError::FunctionCallError(FunctionCallError::LinkError { .. })) => {
-                // Wasmtime classifies this error as link error at the moment.
-                match vm_kind {
-                    VMKind::Wasmer0 | VMKind::Wasmer2 => {
-                        panic!("Unexpected")
-                    }
-                    VMKind::Wasmtime => {}
-                }
-            }
-            _ => {
-                panic!("Unexpected error: {:?}", error)
-            }
-        }
-    });
+    test_builder()
+        .wasm(&[
+            0, 97, 115, 109, 1, 0, 0, 0, 2, 12, 1, 3, 101, 110, 118, 0, 2, 1, 239, 1, 248, 1, 4, 6,
+            1, 112, 0, 143, 129, 32, 7, 12, 1, 8, 0, 17, 17, 17, 17, 17, 17, 2, 2, 0,
+        ])
+        .method("hello")
+        // Wasmtime classifies this error as link error at the moment.
+        .opaque_error()
+        .protocol_features(&[
+            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+            ProtocolFeature::FixContractLoadingCost,
+        ])
+        .expects(&[
+            expect![[r#"
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
+                Err: ...
+            "#]],
+            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+            expect![[r#"
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 44982963 used gas 44982963
+                Err: ...
+            "#]],
+        ]);
 }
 
 #[test]
 fn test_export_not_found() {
-    with_vm_variants(|vm_kind: VMKind| {
-        let code = simple_contract();
-        gas_and_error_match(
-            make_simple_contract_call_vm(&code, "hello2", vm_kind),
-            prepaid_loading_gas(code.len()),
-            Some(VMError::FunctionCallError(FunctionCallError::MethodResolveError(
-                MethodResolveError::MethodNotFound,
-            ))),
-        );
-    });
+    test_builder().wat(SIMPLE_CONTRACT)
+        .method("hello2")
+        .protocol_features(&[
+            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+            ProtocolFeature::FixContractLoadingCost,
+        ]).expects(&[
+            expect![[r#"
+                VMOutcome: balance 0 storage_usage 0 return data None burnt gas 0 used gas 0
+                Err: MethodNotFound
+            "#]],
+            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+            expect![[r#"
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 43032213 used gas 43032213
+                Err: MethodNotFound
+            "#]],
+        ]);
 }
 
 #[test]
 fn test_empty_method() {
-    with_vm_variants(|vm_kind: VMKind| {
-        // Empty method should be checked before anything that require gas.
-        // Running this test without prepaid gas to check that.
-        let code = simple_contract();
-        gas_and_error_match(
-            make_simple_contract_call_with_gas_vm(&code, "", 0, vm_kind),
-            0,
-            Some(VMError::FunctionCallError(FunctionCallError::MethodResolveError(
-                MethodResolveError::MethodEmptyName,
-            ))),
-        );
-    });
-}
-
-fn trap_contract() -> Vec<u8> {
-    wat::parse_str(
-        r#"
-            (module
-              (type (;0;) (func))
-              (func (;0;) (type 0) (unreachable))
-              (export "hello" (func 0))
-            )"#,
-    )
-    .unwrap()
+    test_builder().wat(SIMPLE_CONTRACT).method("").expect(expect![[r#"
+        VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
+        Err: MethodEmptyName
+    "#]]);
 }
 
 #[test]
 fn test_trap_contract() {
-    with_vm_variants(|vm_kind: VMKind| {
-        match vm_kind {
-            VMKind::Wasmer0 | VMKind::Wasmer2 => {}
-            // All contracts leading to hardware traps can not run concurrently on Wasmtime and Wasmer,
-            // Restore, once get rid of Wasmer 0.x.
-            VMKind::Wasmtime => return,
-        }
-        gas_and_error_match(
-            make_simple_contract_call_vm(&trap_contract(), "hello", vm_kind),
-            47105334,
-            Some(VMError::FunctionCallError(FunctionCallError::WasmTrap(WasmTrap::Unreachable))),
+    test_builder()
+        .wat(
+            r#"
+(module
+  (type (;0;) (func))
+  (func (;0;) (type 0) (unreachable))
+  (export "hello" (func 0))
+)"#,
         )
-    })
-}
-
-fn trap_initializer() -> Vec<u8> {
-    wat::parse_str(
-        r#"
-            (module
-              (type (;0;) (func))
-              (func (;0;) (type 0) (unreachable))
-              (start 0)
-              (export "hello" (func 0))
-            )"#,
-    )
-    .unwrap()
+        .method("hello")
+        .skip_wasmtime()
+        .expect(expect![[r#"
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 44071719 used gas 44071719
+            Err: WebAssembly trap: An `unreachable` opcode was executed.
+        "#]]);
 }
 
 #[test]
 fn test_trap_initializer() {
-    // See the comment is test_stack_overflow.
-    with_vm_variants(|vm_kind: VMKind| {
-        match vm_kind {
-            VMKind::Wasmer0 | VMKind::Wasmer2 => {}
-            // All contracts leading to hardware traps can not run concurrently on Wasmtime and Wasmer,
-            // Check if can restore, once get rid of Wasmer 0.x.
-            VMKind::Wasmtime => return,
-        }
-        gas_and_error_match(
-            make_simple_contract_call_vm(&trap_initializer(), "hello", vm_kind),
-            47755584,
-            Some(VMError::FunctionCallError(FunctionCallError::WasmTrap(WasmTrap::Unreachable))),
-        );
-    });
-}
-
-fn div_by_zero_contract() -> Vec<u8> {
-    wat::parse_str(
-        r#"
-            (module
-              (type (;0;) (func))
-              (func (;0;) (type 0)
-                i32.const 1
-                i32.const 0
-                i32.div_s
-                return
-              )
-              (export "hello" (func 0))
-            )"#,
-    )
-    .unwrap()
+    test_builder()
+        .wat(
+            r#"
+(module
+  (type (;0;) (func))
+  (func (;0;) (type 0) (unreachable))
+  (start 0)
+  (export "hello" (func 0))
+)"#,
+        )
+        .method("hello")
+        .skip_wasmtime()
+        .expect(expect![[r#"
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 44721969 used gas 44721969
+            Err: WebAssembly trap: An `unreachable` opcode was executed.
+        "#]]);
 }
 
 #[test]
 fn test_div_by_zero_contract() {
-    with_vm_variants(|vm_kind: VMKind| {
-        match vm_kind {
-            VMKind::Wasmer0 | VMKind::Wasmer2 => {}
-            // All contracts leading to hardware traps can not run concurrently on Wasmtime and Wasmer,
-            // Check if can restore, once get rid of Wasmer 0.x.
-            VMKind::Wasmtime => return,
-        }
-        gas_and_error_match(
-            make_simple_contract_call_vm(&div_by_zero_contract(), "hello", vm_kind),
-            59758197,
-            Some(VMError::FunctionCallError(FunctionCallError::WasmTrap(
-                WasmTrap::IllegalArithmetic,
-            ))),
+    test_builder()
+        .wat(
+            r#"
+(module
+  (type (;0;) (func))
+  (func (;0;) (type 0)
+    i32.const 1
+    i32.const 0
+    i32.div_s
+    return
+  )
+  (export "hello" (func 0))
+)"#,
         )
-    })
-}
-
-fn float_to_int_contract(index: usize) -> Vec<u8> {
-    let ops = ["i32.trunc_f64_s", "i32.trunc_f64_u", "i64.trunc_f64_s", "i64.trunc_f64_u"];
-    let code = format!(
-        r#"
-            (module
-              (type (;0;) (func))
-              (func (;0;) (type 0)
-                f64.const 0x1p+1023
-                {}
-                return
-              )
-              (export "hello" (func 0))
-            )"#,
-        ops[index]
-    );
-    wat::parse_str(&code).unwrap()
+        .method("hello")
+        .skip_wasmtime()
+        .expect(expect![[r#"
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 47623737 used gas 47623737
+            Err: WebAssembly trap: An arithmetic exception, e.g. divided by zero.
+        "#]]);
 }
 
 #[test]
 fn test_float_to_int_contract() {
-    with_vm_variants(|vm_kind: VMKind| {
-        match vm_kind {
-            VMKind::Wasmer0 | VMKind::Wasmer2 => {}
-            // All contracts leading to hardware traps can not run concurrently on Wasmtime and Wasmer,
-            // Check if can restore, once get rid of Wasmer 0.x.
-            VMKind::Wasmtime => return,
-        }
-        for index in 0..=3 {
-            gas_and_error_match(
-                make_simple_contract_call_vm(&float_to_int_contract(index), "hello", vm_kind),
-                56985576,
-                Some(VMError::FunctionCallError(FunctionCallError::WasmTrap(
-                    WasmTrap::IllegalArithmetic,
-                ))),
-            )
-        }
-    })
-}
-
-fn indirect_call_to_null_contract() -> Vec<u8> {
-    wat::parse_str(
-        r#"
-            (module
-              (type (;0;) (func))
-              (table (;0;) 2 funcref)
-              (func (;0;) (type 0)
-                i32.const 1
-                call_indirect (type 0)
-                return
-              )
-              (export "hello" (func 0))
-            )"#,
-    )
-    .unwrap()
+    for op in ["i32.trunc_f64_s", "i32.trunc_f64_u", "i64.trunc_f64_s", "i64.trunc_f64_u"] {
+        test_builder()
+            .wat(&format!(
+                r#"
+(module
+  (type (;0;) (func))
+  (func (;0;) (type 0)
+    f64.const 0x1p+1023
+    {op}
+    return
+  )
+  (export "hello" (func 0))
+)"#,
+            ))
+            .method("hello")
+            .skip_wasmtime()
+            .expect(expect![[r#"
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 47884731 used gas 47884731
+                Err: WebAssembly trap: An arithmetic exception, e.g. divided by zero.
+            "#]]);
+    }
 }
 
 #[test]
 fn test_indirect_call_to_null_contract() {
-    with_vm_variants(|vm_kind: VMKind| {
-        match vm_kind {
-            VMKind::Wasmer2 => {}
-            // Wasmer 0.x cannot distinguish indirect calls to null and calls with incorrect signature.
-            VMKind::Wasmer0 => return,
-            // All contracts leading to hardware traps can not run concurrently on Wasmtime and Wasmer,
-            // Check if can restore, once get rid of Wasmer 0.x.
-            VMKind::Wasmtime => return,
-        }
-        gas_and_error_match(
-            make_simple_contract_call_vm(&indirect_call_to_null_contract(), "hello", vm_kind),
-            57202326,
-            Some(VMError::FunctionCallError(FunctionCallError::WasmTrap(
-                WasmTrap::IndirectCallToNull,
-            ))),
+    test_builder()
+        .wat(
+            r#"
+(module
+  (type (;0;) (func))
+  (table (;0;) 2 funcref)
+  (func (;0;) (type 0)
+    i32.const 1
+    call_indirect (type 0)
+    return
+  )
+  (export "hello" (func 0))
+)"#,
         )
-    })
-}
-
-fn indirect_call_to_wrong_signature_contract() -> Vec<u8> {
-    wat::parse_str(
-        r#"
-            (module
-              (type (;0;) (func))
-              (type (;1;) (func (result i32)))
-              (func (;0;) (type 0)
-                i32.const 1
-                call_indirect (type 1)
-                return
-              )
-              (func (;1;) (type 1)
-                i32.const 0
-                return
-              )
-              (table (;0;) 3 3 funcref)
-              (elem (;0;) (i32.const 1) 0 1)
-              (export "hello" (func 0))
-            )"#,
-    )
-    .unwrap()
+        .method("hello")
+        .opaque_error()
+        .skip_wasmtime()
+        .expect(expect![[r#"
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 48101481 used gas 48101481
+            Err: ...
+        "#]])
 }
 
 #[test]
 fn test_indirect_call_to_wrong_signature_contract() {
-    with_vm_variants(|vm_kind: VMKind| {
-        match vm_kind {
-            VMKind::Wasmer0 | VMKind::Wasmer2 => {}
-            // All contracts leading to hardware traps can not run concurrently on Wasmtime and Wasmer,
-            // Check if can restore, once get rid of Wasmer 0.x.
-            VMKind::Wasmtime => return,
-        }
-        gas_and_error_match(
-            make_simple_contract_call_vm(
-                &indirect_call_to_wrong_signature_contract(),
-                "hello",
-                vm_kind,
-            ),
-            61970826,
-            Some(VMError::FunctionCallError(FunctionCallError::WasmTrap(
-                WasmTrap::IncorrectCallIndirectSignature,
-            ))),
+    test_builder()
+        .wat(
+            r#"
+(module
+  (type (;0;) (func))
+  (type (;1;) (func (result i32)))
+  (func (;0;) (type 0)
+    i32.const 1
+    call_indirect (type 1)
+    return
+  )
+  (func (;1;) (type 1)
+    i32.const 0
+    return
+  )
+  (table (;0;) 3 3 funcref)
+  (elem (;0;) (i32.const 1) 0 1)
+  (export "hello" (func 0))
+)"#,
         )
-    })
-}
-
-fn wrong_signature_contract() -> Vec<u8> {
-    wat::parse_str(
-        r#"
-            (module
-              (type (;0;) (func (param i32)))
-              (func (;0;) (type 0))
-              (export "hello" (func 0))
-            )"#,
-    )
-    .unwrap()
+        .method("hello")
+        .skip_wasmtime()
+        .expect(expect![[r#"
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 52869981 used gas 52869981
+            Err: WebAssembly trap: Call indirect incorrect signature trap.
+        "#]])
 }
 
 #[test]
 fn test_wrong_signature_contract() {
-    with_vm_variants(|vm_kind: VMKind| {
-        let code = wrong_signature_contract();
-        let expected_gas = prepaid_loading_gas(code.len());
-        gas_and_error_match(
-            make_simple_contract_call_vm(&code, "hello", vm_kind),
-            expected_gas,
-            Some(VMError::FunctionCallError(FunctionCallError::MethodResolveError(
-                MethodResolveError::MethodInvalidSignature,
-            ))),
-        );
-    });
-}
-
-fn export_wrong_type() -> Vec<u8> {
-    wat::parse_str(
-        r#"
-            (module
-              (global (;0;) i32 (i32.const 123))
-              (export "hello" (global 0))
-            )"#,
-    )
-    .unwrap()
+    test_builder()
+        .wat(
+            r#"
+(module
+  (type (;0;) (func (param i32)))
+  (func (;0;) (type 0))
+  (export "hello" (func 0))
+)"#,
+        )
+        .method("hello")
+        .protocol_features(&[
+            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+            ProtocolFeature::FixContractLoadingCost,
+        ])
+        .expects(&[
+            expect![[r#"
+                VMOutcome: balance 0 storage_usage 0 return data None burnt gas 0 used gas 0
+                Err: MethodInvalidSignature
+            "#]],
+            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+            expect![[r#"
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 43248963 used gas 43248963
+                Err: MethodInvalidSignature
+            "#]],
+        ]);
 }
 
 #[test]
 fn test_export_wrong_type() {
-    with_vm_variants(|vm_kind: VMKind| {
-        let code = export_wrong_type();
-        gas_and_error_match(
-            make_simple_contract_call_vm(&code, "hello", vm_kind),
-            prepaid_loading_gas(code.len()),
-            Some(VMError::FunctionCallError(FunctionCallError::MethodResolveError(
-                MethodResolveError::MethodNotFound,
-            ))),
-        );
-    });
-}
-
-fn guest_panic() -> Vec<u8> {
-    wat::parse_str(
-        r#"
-            (module
-              (type (;0;) (func))
-              (import "env" "panic" (func (;0;) (type 0)))
-              (func (;1;) (type 0) (call 0))
-              (export "hello" (func 1))
-            )"#,
-    )
-    .unwrap()
+    test_builder()
+        .wat(
+            r#"
+(module
+  (global (;0;) i32 (i32.const 123))
+  (export "hello" (global 0))
+)"#,
+        )
+        .method("hello")
+        .protocol_features(&[
+            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+            ProtocolFeature::FixContractLoadingCost,
+        ])
+        .expects(&[
+            expect![[r#"
+                VMOutcome: balance 0 storage_usage 0 return data None burnt gas 0 used gas 0
+                Err: MethodNotFound
+            "#]],
+            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+            expect![[r#"
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 41514963 used gas 41514963
+                Err: MethodNotFound
+            "#]],
+        ]);
 }
 
 #[test]
 fn test_guest_panic() {
-    with_vm_variants(|vm_kind: VMKind| {
-        gas_and_error_match(
-            make_simple_contract_call_vm(&guest_panic(), "hello", vm_kind),
-            315341445,
-            Some(VMError::FunctionCallError(FunctionCallError::HostError(HostError::GuestPanic {
-                panic_msg: "explicit guest panic".to_string(),
-            }))),
-        );
-    });
-}
-
-fn stack_overflow() -> Vec<u8> {
-    wat::parse_str(
-        r#"
-            (module
-              (type (;0;) (func))
-              (func (;0;) (type 0) (call 0))
-              (export "hello" (func 0))
-            )"#,
-    )
-    .unwrap()
+    test_builder()
+        .wat(
+            r#"
+(module
+  (type (;0;) (func))
+  (import "env" "panic" (func (;0;) (type 0)))
+  (func (;1;) (type 0) (call 0))
+  (export "hello" (func 1))
+)"#,
+        )
+        .method("hello")
+        .expect(expect![[r#"
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 312307830 used gas 312307830
+            Err: Smart contract panicked: explicit guest panic
+        "#]]);
 }
 
 #[test]
 fn test_stack_overflow() {
-    with_vm_variants(|vm_kind: VMKind| {
-        // We only test trapping tests on Wasmer, as of version 0.17, when tests executed in parallel,
-        // Wasmer signal handlers may catch signals thrown from the Wasmtime, and produce fake failing tests.
-        match vm_kind {
-            VMKind::Wasmer0 | VMKind::Wasmer2 => gas_and_error_match(
-                make_simple_contract_call_vm(&stack_overflow(), "hello", vm_kind),
-                63226248177,
-                Some(VMError::FunctionCallError(FunctionCallError::WasmTrap(
-                    WasmTrap::Unreachable,
-                ))),
-            ),
-            VMKind::Wasmtime => {}
-        }
-    });
-}
-
-fn stack_overflow_many_locals() -> Vec<u8> {
-    wat::parse_str(
-        r#"
-            (module
-              (func $f1 (export "f1")
-                (local i32)
-                (call $f1))
-              (func $f2 (export "f2")
-                (local i32 i32 i32 i32)
-                (call $f2))
-            )"#,
-    )
-    .unwrap()
+    test_builder()
+        .wat(
+            r#"
+(module
+  (type (;0;) (func))
+  (func (;0;) (type 0) (call 0))
+  (export "hello" (func 0))
+)"#,
+        )
+        .method("hello")
+        .skip_wasmtime()
+        .expect(expect![[r#"
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 13523500017 used gas 13523500017
+            Err: WebAssembly trap: An `unreachable` opcode was executed.
+        "#]]);
 }
 
 #[test]
 fn test_stack_instrumentation_protocol_upgrade() {
-    with_vm_variants(|vm_kind: VMKind| {
-        match vm_kind {
-            VMKind::Wasmer0 | VMKind::Wasmer2 => {}
-            // All contracts leading to hardware traps can not run concurrently on Wasmtime and Wasmer,
-            // Restore, once get rid of Wasmer 0.x.
-            VMKind::Wasmtime => return,
-        }
-        let code = stack_overflow_many_locals();
+    test_builder()
+        .wat(
+            r#"
+(module
+  (func $f1 (export "f1")
+    (local i32)
+    (call $f1))
+  (func $f2 (export "f2")
+    (local i32 i32 i32 i32)
+    (call $f2))
+)"#,
+        )
+        .method("f1")
+        .protocol_features(&[ProtocolFeature::CorrectStackLimit])
+        .skip_wasmtime()
+        .expects(&[
+            expect![[r#"
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 6789985365 used gas 6789985365
+                Err: WebAssembly trap: An `unreachable` opcode was executed.
+            "#]],
+            expect![[r#"
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 6789985365 used gas 6789985365
+                Err: WebAssembly trap: An `unreachable` opcode was executed.
+            "#]],
+        ]);
 
-        let res = make_simple_contract_call_with_protocol_version_vm(
-            &code,
-            "f1",
-            ProtocolFeature::CorrectStackLimit.protocol_version() - 1,
-            vm_kind,
-        );
-        gas_and_error_match(
-            res,
-            6789985365,
-            Some(VMError::FunctionCallError(FunctionCallError::WasmTrap(WasmTrap::Unreachable))),
-        );
-        let res = make_simple_contract_call_with_protocol_version_vm(
-            &code,
-            "f2",
-            ProtocolFeature::CorrectStackLimit.protocol_version() - 1,
-            vm_kind,
-        );
-        gas_and_error_match(
-            res,
-            6789985365,
-            Some(VMError::FunctionCallError(FunctionCallError::WasmTrap(WasmTrap::Unreachable))),
-        );
-
-        let res = make_simple_contract_call_with_protocol_version_vm(
-            &code,
-            "f1",
-            ProtocolFeature::CorrectStackLimit.protocol_version(),
-            vm_kind,
-        );
-        gas_and_error_match(
-            res,
-            6789985365,
-            Some(VMError::FunctionCallError(FunctionCallError::WasmTrap(WasmTrap::Unreachable))),
-        );
-        let res = make_simple_contract_call_with_protocol_version_vm(
-            &code,
-            "f2",
-            ProtocolFeature::CorrectStackLimit.protocol_version(),
-            vm_kind,
-        );
-        gas_and_error_match(
-            res,
-            2745316869,
-            Some(VMError::FunctionCallError(FunctionCallError::WasmTrap(WasmTrap::Unreachable))),
-        );
-    });
-}
-
-fn memory_grow() -> Vec<u8> {
-    wat::parse_str(
-        r#"
-            (module
-              (type (;0;) (func))
-              (func (;0;) (type 0)
-                (loop
-                  (memory.grow (i32.const 1))
-                  drop
-                  br 0
-                )
-              )
-              (memory (;0;) 17 32)
-              (export "hello" (func 0))
-            )"#,
-    )
-    .unwrap()
+    test_builder()
+        .wat(
+            r#"
+(module
+  (func $f1 (export "f1")
+    (local i32)
+    (call $f1))
+  (func $f2 (export "f2")
+    (local i32 i32 i32 i32)
+    (call $f2))
+)"#,
+        )
+        .method("f2")
+        .protocol_features(&[ProtocolFeature::CorrectStackLimit])
+        .skip_wasmtime()
+        .expects(&[
+            expect![[r#"
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 6789985365 used gas 6789985365
+                Err: WebAssembly trap: An `unreachable` opcode was executed.
+            "#]],
+            expect![[r#"
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 2745316869 used gas 2745316869
+                Err: WebAssembly trap: An `unreachable` opcode was executed.
+            "#]],
+        ]);
 }
 
 #[test]
 fn test_memory_grow() {
-    with_vm_variants(|vm_kind: VMKind| {
-        gas_and_error_match(
-            make_simple_contract_call_vm(&memory_grow(), "hello", vm_kind),
-            100000000000000,
-            Some(VMError::FunctionCallError(FunctionCallError::HostError(HostError::GasExceeded))),
-        );
-    });
+    test_builder()
+        .wat(
+            r#"
+(module
+  (type (;0;) (func))
+  (func (;0;) (type 0)
+    (loop
+      (memory.grow (i32.const 1))
+      drop
+      br 0
+    )
+  )
+  (memory (;0;) 17 32)
+  (export "hello" (func 0))
+)"#,
+        )
+        .method("hello")
+        .expect(expect![[r#"
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 100000000000000 used gas 100000000000000
+            Err: Exceeded the prepaid gas.
+        "#]]);
 }
 
 fn bad_import_global(env: &str) -> Vec<u8> {
@@ -604,95 +463,90 @@ fn bad_import_func(env: &str) -> Vec<u8> {
 // Invalid import not from "env" -> PrepareError::Instantiate
 // Invalid import from "env" -> LinkError
 fn test_bad_import_1() {
-    with_vm_variants(|vm_kind: VMKind| {
-        let code = bad_import_global("wtf");
-        gas_and_error_match(
-            make_simple_contract_call_vm(&code, "hello", vm_kind),
-            prepaid_loading_gas(code.len()),
-            Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
-                CompilationError::PrepareError(PrepareError::Instantiate),
-            ))),
-        )
-    });
+    test_builder()
+        .wasm(&bad_import_global("wtf"))
+        .method("hello")
+        .protocol_features(&[
+            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+            ProtocolFeature::FixContractLoadingCost,
+        ])
+        .expects(&[
+            expect![[r#"
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
+                Err: PrepareError: Error happened during instantiation.
+            "#]],
+            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+            expect![[r#"
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 46500213 used gas 46500213
+                Err: PrepareError: Error happened during instantiation.
+            "#]],
+        ]);
 }
 
 #[test]
 fn test_bad_import_2() {
-    with_vm_variants(|vm_kind: VMKind| {
-        let code = bad_import_func("wtf");
-        gas_and_error_match(
-            make_simple_contract_call_vm(&code, "hello", vm_kind),
-            prepaid_loading_gas(code.len()),
-            Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
-                CompilationError::PrepareError(PrepareError::Instantiate),
-            ))),
-        );
-    });
+    test_builder()
+        .wasm(&bad_import_func("wtf"))
+        .method("hello")
+        .protocol_features(&[
+            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+            ProtocolFeature::FixContractLoadingCost,
+        ])
+        .expects(&[
+            expect![[r#"
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
+                Err: PrepareError: Error happened during instantiation.
+            "#]],
+            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
+            expect![[r#"
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 45849963 used gas 45849963
+                Err: PrepareError: Error happened during instantiation.
+            "#]],
+        ]);
 }
 
 #[test]
 fn test_bad_import_3() {
-    with_vm_variants(|vm_kind: VMKind| {
-        let msg = match vm_kind {
-            VMKind::Wasmer0 => "link error: Incorrect import type, namespace: env, name: input, expected type: global, found type: function",
-            VMKind::Wasmtime => "\"expected global, but found func\"",
-            VMKind::Wasmer2 => "Error while importing \"env\".\"input\": incompatible import type. Expected Global(GlobalType { ty: I32, mutability: Const }) but received Function(FunctionType { params: [I64], results: [] })",
-        }.to_string();
-        gas_and_error_match(
-            make_simple_contract_call_vm(&bad_import_global("env"), "hello", vm_kind),
-            46500213,
-            Some(VMError::FunctionCallError(FunctionCallError::LinkError { msg })),
-        );
-    });
+    test_builder().wasm(&bad_import_global("env")).method("hello").opaque_error().expect(expect![
+        [r#"
+        VMOutcome: balance 4 storage_usage 12 return data None burnt gas 46500213 used gas 46500213
+        Err: ...
+    "#]
+    ]);
 }
 
 #[test]
 fn test_bad_import_4() {
-    with_vm_variants(|vm_kind: VMKind| {
-        let msg = match vm_kind {
-            VMKind::Wasmer0 => "link error: Import not found, namespace: env, name: wtf",
-            VMKind::Wasmtime => "\"unknown import: `env::wtf` has not been defined\"",
-            VMKind::Wasmer2 => "Error while importing \"env\".\"wtf\": unknown import. Expected Function(FunctionType { params: [], results: [] })",
-        }
-        .to_string();
-        gas_and_error_match(
-            make_simple_contract_call_vm(&bad_import_func("env"), "hello", vm_kind),
-            45849963,
-            Some(VMError::FunctionCallError(FunctionCallError::LinkError { msg })),
-        );
-    });
-}
-
-fn some_initializer_contract() -> Vec<u8> {
-    wat::parse_str(
+    test_builder().wasm(&bad_import_func("env")).method("hello").opaque_error().expect(expect![[
         r#"
-            (module
-              (type (;0;) (func))
-              (func (;0;) (type 0) nop)
-              (start 0)
-              (export "hello" (func 0))
-            )"#,
-    )
-    .unwrap()
+        VMOutcome: balance 4 storage_usage 12 return data None burnt gas 45849963 used gas 45849963
+        Err: ...
+    "#
+    ]]);
 }
 
 #[test]
 fn test_initializer_no_gas() {
-    with_vm_variants(|vm_kind: VMKind| {
-        gas_and_error_match(
-            make_simple_contract_call_with_gas_vm(
-                &some_initializer_contract(),
-                "hello",
-                0,
-                vm_kind,
-            ),
-            0,
-            Some(VMError::FunctionCallError(FunctionCallError::HostError(HostError::GasExceeded))),
-        );
-    });
+    test_builder()
+        .wat(
+            r#"
+(module
+  (type (;0;) (func))
+  (func (;0;) (type 0) nop)
+  (start 0)
+  (export "hello" (func 0))
+)"#,
+        )
+        .method("hello")
+        .gas(0)
+        .expect(expect![[r#"
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
+            Err: Exceeded the prepaid gas.
+        "#]]);
 }
 
-fn bad_many_imports() -> Vec<u8> {
+#[test]
+fn test_bad_many_imports() {
     let mut imports = String::new();
     for i in 0..100 {
         imports.push_str(&format!(
@@ -702,137 +556,107 @@ fn bad_many_imports() -> Vec<u8> {
             i, i
         ));
     }
-    wat::parse_str(format!(
-        r#"
-            (module
-              (type (;0;) (func))
-              {}
-              (export "hello" (func 0))
-            )"#,
-        imports
-    ))
-    .unwrap()
+
+    test_builder()
+        .wat(&format!(
+            r#"
+                (module
+                  (type (;0;) (func))
+                  {}
+                  (export "hello" (func 0))
+                )"#,
+            imports
+        ))
+        .method("hello")
+        .opaque_error()
+        .expect(expect![[r#"
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 299664213 used gas 299664213
+            Err: ...
+        "#]])
 }
 
-#[test]
-fn test_bad_many_imports() {
-    with_vm_variants(|vm_kind: VMKind| {
-        let (outcome, error) = make_simple_contract_call_vm(&bad_many_imports(), "hello", vm_kind);
-        assert_eq!(outcome.used_gas, 299664213);
-        assert_eq!(outcome.burnt_gas, 299664213);
-        if let Some(VMError::FunctionCallError(FunctionCallError::LinkError { msg })) = error {
-            eprintln!("{}", msg);
-            assert!(msg.len() < 1000, "Huge error message: {}", msg.len());
-        } else {
-            panic!("{:?}", error);
-        }
-    });
-}
-
-fn external_call_contract() -> Vec<u8> {
-    wat::parse_str(
-        r#"
-            (module
-              (import "env" "prepaid_gas" (func (;0;) (result i64)))
-              (export "hello" (func 1))
-              (func (;1;)
-                  (drop (call 0))
-                  )
-            )"#,
-    )
-    .unwrap()
-}
+static EXTERNAL_CALL_CONTRACT: &str = r#"
+(module
+  (import "env" "prepaid_gas" (func (;0;) (result i64)))
+  (export "hello" (func 1))
+  (func (;1;)
+      (drop (call 0))
+      )
+)"#;
 
 #[test]
 fn test_external_call_ok() {
-    with_vm_variants(|vm_kind: VMKind| {
-        gas_and_error_match(
-            make_simple_contract_call_vm(&external_call_contract(), "hello", vm_kind),
-            321582066,
-            None,
-        );
-    });
+    test_builder().wat(EXTERNAL_CALL_CONTRACT).method("hello").expect(expect![[r#"
+        VMOutcome: balance 4 storage_usage 12 return data None burnt gas 315514836 used gas 315514836
+    "#]]);
 }
 
 #[test]
 fn test_external_call_error() {
-    with_vm_variants(|vm_kind: VMKind| {
-        gas_and_error_match(
-            make_simple_contract_call_with_gas_vm(&external_call_contract(), "hello", 100, vm_kind),
-            100,
-            Some(VMError::FunctionCallError(FunctionCallError::HostError(HostError::GasExceeded))),
-        );
-    });
+    test_builder().wat(EXTERNAL_CALL_CONTRACT).method("hello").gas(100).expect(expect![[r#"
+        VMOutcome: balance 4 storage_usage 12 return data None burnt gas 100 used gas 100
+        Err: Exceeded the prepaid gas.
+    "#]]);
 }
 
-fn external_indirect_call_contract() -> Vec<u8> {
-    wat::parse_str(
-        r#"
-            (module
-              (import "env" "prepaid_gas" (func $lol (result i64)))
-              (type $lol_t (func (result i64)))
+static EXTERNAL_INDIRECT_CALL_CONTRACT: &str = r#"
+(module
+  (import "env" "prepaid_gas" (func $lol (result i64)))
+  (type $lol_t (func (result i64)))
 
-              (table 1 funcref)
-              (elem (i32.const 0) $lol)
+  (table 1 funcref)
+  (elem (i32.const 0) $lol)
 
-              (func (export "main")
-                (call_indirect (type $lol_t) (i32.const 0))
-                drop
-              )
-            )"#,
-    )
-    .unwrap()
-}
+  (func (export "main")
+    (call_indirect (type $lol_t) (i32.const 0))
+    drop
+  )
+)"#;
 
 #[test]
 fn test_external_call_indirect() {
-    with_vm_variants(|vm_kind: VMKind| {
-        let (outcome, err) =
-            make_simple_contract_call_vm(&external_indirect_call_contract(), "main", vm_kind);
-        gas_and_error_match((outcome, err), 334541937, None);
-    });
+    test_builder().wat(EXTERNAL_INDIRECT_CALL_CONTRACT).expect(expect![[r#"
+        VMOutcome: balance 4 storage_usage 12 return data None burnt gas 325441092 used gas 325441092
+    "#]]);
 }
+
+const ADDRESS_OVERFLOW: &str = r#"
+(module
+  (memory 1)
+  (func (export "main")
+    i32.const 1
+    i64.load32_u offset=4294967295 (;2^32 - 1;) align=1
+    drop
+  )
+)"#;
 
 /// Load from address so far out of bounds that it causes integer overflow.
-fn address_overflow() -> Vec<u8> {
-    wat::parse_str(
-        r#"
-        (module
-          (memory 1)
-          (func (export "main")
-            i32.const 1
-            i64.load32_u offset=4294967295 (;2^32 - 1;) align=1
-            drop
-          )
-        )"#,
-    )
-    .unwrap()
-}
-
 #[test]
 fn test_address_overflow() {
-    with_vm_variants(|vm_kind: VMKind| {
-        match vm_kind {
-            VMKind::Wasmer0 | VMKind::Wasmer2 => {}
-            // All contracts leading to hardware traps can not run concurrently on Wasmtime and Wasmer,
-            // Restore, once get rid of Wasmer 0.x.
-            VMKind::Wasmtime => return,
-        }
+    test_builder().wat(ADDRESS_OVERFLOW).skip_wasmtime().skip_wasmer0().expect(expect![[r#"
+        VMOutcome: balance 4 storage_usage 12 return data None burnt gas 48534981 used gas 48534981
+        Err: WebAssembly trap: Memory out of bounds trap.
+    "#]]);
 
-        let actual = make_simple_contract_call_vm(&address_overflow(), "main", vm_kind);
-        match vm_kind {
-            VMKind::Wasmer2 | VMKind::Wasmtime => gas_and_error_match(
-                actual,
-                57635826,
-                Some(VMError::FunctionCallError(FunctionCallError::WasmTrap(
-                    WasmTrap::MemoryOutOfBounds,
-                ))),
-            ),
-            // wasmer0 incorrectly doesn't catch overflow during address calculation
-            VMKind::Wasmer0 => gas_and_error_match(actual, 57635826, None),
-        };
-    });
+    // wasmer0 incorrectly doesn't catch overflow during address calculation
+    test_builder().wat(ADDRESS_OVERFLOW).skip_wasmtime().skip_wasmer2().expect(expect![[r#"
+        VMOutcome: balance 4 storage_usage 12 return data None burnt gas 48534981 used gas 48534981
+    "#]]);
 }
+
+const NAN_SIGN: &str = r#"
+(module
+  (func (export "main")
+    (i32.div_u
+      (i32.const 0)
+      (f32.gt
+        (f32.copysign
+          (f32.const 1.0)
+          (f32.sqrt (f32.const -1.0)))
+        (f32.const 0)))
+    drop
+  )
+)"#;
 
 /// Uses `f32.copysign` to observe a sign of `NaN`.
 ///
@@ -841,67 +665,27 @@ fn test_address_overflow() {
 ///   https://github.com/WebAssembly/design/blob/main/Nondeterminism.md
 ///
 /// We solve this problem by canonicalizing NaNs.
-fn nan_sign() -> Vec<u8> {
-    wat::parse_str(
-        r#"
-        (module
-          (func (export "main")
-            (i32.div_u
-              (i32.const 0)
-              (f32.gt
-                (f32.copysign
-                  (f32.const 1.0)
-                  (f32.sqrt (f32.const -1.0)))
-                (f32.const 0)))
-            drop
-          )
-        )"#,
-    )
-    .unwrap()
-}
-
 #[test]
 fn test_nan_sign() {
-    with_vm_variants(|vm_kind: VMKind| {
-        match vm_kind {
-            VMKind::Wasmer0 | VMKind::Wasmer2 => {}
-            // All contracts leading to hardware traps can not run concurrently on Wasmtime and Wasmer,
-            // Restore, once get rid of Wasmer 0.x.
-            VMKind::Wasmtime => return,
-        }
+    test_builder().wat(NAN_SIGN).skip_wasmtime().skip_wasmer0().expect(expect![[r#"
+        VMOutcome: balance 4 storage_usage 12 return data None burnt gas 54988767 used gas 54988767
+    "#]]);
 
-        let actual = make_simple_contract_call_vm(&nan_sign(), "main", vm_kind);
-        match vm_kind {
-            VMKind::Wasmer2 => gas_and_error_match(actual, 82291302, None),
-            VMKind::Wasmtime | VMKind::Wasmer0 => gas_and_error_match(
-                actual,
-                82291302,
-                Some(VMError::FunctionCallError(FunctionCallError::WasmTrap(
-                    WasmTrap::IllegalArithmetic,
-                ))),
-            ),
-        }
-    });
+    // wasmer0 doesn't canonicalize NaNs
+    test_builder().wat(NAN_SIGN).skip_wasmtime().skip_wasmer2().expect(expect![[r#"
+        VMOutcome: balance 4 storage_usage 12 return data None burnt gas 54988767 used gas 54988767
+        Err: WebAssembly trap: An arithmetic exception, e.g. divided by zero.
+    "#]]);
 }
 
 // Check that a `GasExceeded` error is returned when there is not enough gas to
 // even load a contract.
 #[test]
 fn test_gas_exceed_loading() {
-    with_vm_variants(|vm_kind: VMKind| {
-        // Loading is the first thing that happens on the VM entrypoint that
-        // requires gas, thus attaching only 1 gas triggers the desired
-        // behavior.
-        let gas = 1;
-        let method_name = "non_empty_non_existing";
-        let actual =
-            make_simple_contract_call_with_gas_vm(&simple_contract(), method_name, gas, vm_kind);
-        gas_and_error_match(
-            actual,
-            gas, //< It is import to be non-zero gas here.
-            Some(VMError::FunctionCallError(FunctionCallError::HostError(HostError::GasExceeded))),
-        );
-    });
+    test_builder().wat(SIMPLE_CONTRACT).method("non_empty_non_existing").gas(1).expect(expect![[r#"
+        VMOutcome: balance 4 storage_usage 12 return data None burnt gas 1 used gas 1
+        Err: Exceeded the prepaid gas.
+    "#]]);
 }
 
 // Call the "gas" host function with unreasonably large values, trying to force
@@ -967,130 +751,71 @@ fn gas_overflow_indirect_call() {
 #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
 mod fix_contract_loading_cost_protocol_upgrade {
     use super::*;
-    use crate::tests::make_simple_contract_call_ex;
 
-    /// Simple contract that uses non-zero gas to execute main.
-    #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
-    fn almost_trivial_contract_and_exec_gas() -> (Vec<u8>, u64) {
-        let code = wat::parse_str(
-            r#"
-            (module
-                (func (export "main")
-                  i32.const 1
-                  i32.const 1
-                  i32.div_s
-                  return
-                )
-            )"#,
-        )
-        .unwrap();
-        (code, 3_291_024)
-    }
+    static ALMOST_TRIVIAL_CONTRACT: &str = r#"
+(module
+    (func (export "main")
+      i32.const 1
+      i32.const 1
+      i32.div_s
+      return
+    )
+)"#;
 
     // Normal execution should be unchanged before and after.
     #[test]
     fn test_fn_loading_gas_protocol_upgrade() {
-        with_vm_variants(|vm_kind: VMKind| {
-            let (code, exec_gas) = almost_trivial_contract_and_exec_gas();
-            let loading_gas = prepaid_loading_gas(code.len());
-            let total_gas = exec_gas + loading_gas;
-
-            let res = make_simple_contract_call_ex(
-                &code,
-                "main",
-                vm_kind,
-                Some(ProtocolFeature::FixContractLoadingCost.protocol_version() - 1),
-                total_gas + 1,
-            );
-            gas_and_error_match(res, total_gas, None);
-            let res = make_simple_contract_call_ex(
-                &code,
-                "main",
-                vm_kind,
-                Some(ProtocolFeature::FixContractLoadingCost.protocol_version()),
-                total_gas + 1,
-            );
-            gas_and_error_match(res, total_gas, None);
-        });
+        test_builder()
+            .wat(ALMOST_TRIVIAL_CONTRACT)
+            .protocol_features(&[ProtocolFeature::FixContractLoadingCost])
+            .expects(&[
+                expect![[r#"
+                    VMOutcome: balance 4 storage_usage 12 return data None burnt gas 47406987 used gas 47406987
+                "#]],
+                expect![[r#"
+                    VMOutcome: balance 4 storage_usage 12 return data None burnt gas 47406987 used gas 47406987
+                "#]],
+            ]);
     }
 
     // Executing with just enough gas to load the contract will fail before and
     // after. Both charge the same amount of gas.
     #[test]
     fn test_fn_loading_gas_protocol_upgrade_exceed_loading() {
-        with_vm_variants(|vm_kind: VMKind| {
-            let (code, _exec_gas) = almost_trivial_contract_and_exec_gas();
-            let loading_gas = prepaid_loading_gas(code.len());
-
-            let res = make_simple_contract_call_ex(
-                &code,
-                "main",
-                vm_kind,
-                Some(ProtocolFeature::FixContractLoadingCost.protocol_version() - 1),
-                loading_gas,
-            );
-            gas_and_error_match(
-                res,
-                loading_gas,
-                Some(VMError::FunctionCallError(FunctionCallError::HostError(
-                    HostError::GasExceeded,
-                ))),
-            );
-            let res = make_simple_contract_call_ex(
-                &code,
-                "main",
-                vm_kind,
-                Some(ProtocolFeature::FixContractLoadingCost.protocol_version()),
-                loading_gas,
-            );
-            gas_and_error_match(
-                res,
-                loading_gas,
-                Some(VMError::FunctionCallError(FunctionCallError::HostError(
-                    HostError::GasExceeded,
-                ))),
-            );
-        });
+        test_builder()
+            .wat(ALMOST_TRIVIAL_CONTRACT)
+            .gas(44115963)
+            .protocol_features(&[ProtocolFeature::FixContractLoadingCost])
+            .expects(&[
+                expect![[r#"
+                    VMOutcome: balance 4 storage_usage 12 return data None burnt gas 44115963 used gas 44115963
+                    Err: Exceeded the prepaid gas.
+                "#]],
+                expect![[r#"
+                    VMOutcome: balance 4 storage_usage 12 return data None burnt gas 44115963 used gas 44115963
+                    Err: Exceeded the prepaid gas.
+                "#]],
+            ]);
     }
 
     /// Executing with enough gas to finish loading but not to execute the full
     /// contract should have the same outcome before and after.
     #[test]
     fn test_fn_loading_gas_protocol_upgrade_exceed_executing() {
-        with_vm_variants(|vm_kind: VMKind| {
-            let (code, exec_gas) = almost_trivial_contract_and_exec_gas();
-            let loading_gas = prepaid_loading_gas(code.len());
-            let total_gas = exec_gas + loading_gas;
-
-            let res = make_simple_contract_call_ex(
-                &code,
-                "main",
-                vm_kind,
-                Some(ProtocolFeature::FixContractLoadingCost.protocol_version() - 1),
-                total_gas - 1,
-            );
-            gas_and_error_match(
-                res,
-                total_gas - 1,
-                Some(VMError::FunctionCallError(FunctionCallError::HostError(
-                    HostError::GasExceeded,
-                ))),
-            );
-            let res = make_simple_contract_call_ex(
-                &code,
-                "main",
-                vm_kind,
-                Some(ProtocolFeature::FixContractLoadingCost.protocol_version()),
-                total_gas - 1,
-            );
-            gas_and_error_match(
-                res,
-                total_gas - 1,
-                Some(VMError::FunctionCallError(FunctionCallError::HostError(
-                    HostError::GasExceeded,
-                ))),
-            );
-        });
+        test_builder()
+            .wat(ALMOST_TRIVIAL_CONTRACT)
+            .gas(47406986)
+            .protocol_features(&[ProtocolFeature::FixContractLoadingCost])
+            .expects(&[
+                expect![[r#"
+                    VMOutcome: balance 4 storage_usage 12 return data None burnt gas 47406986 used gas 47406986
+                    Err: Exceeded the prepaid gas.
+                "#]],
+                expect![[r#"
+                    VMOutcome: balance 4 storage_usage 12 return data None burnt gas 47406986 used gas 47406986
+                    Err: Exceeded the prepaid gas.
+                "#]],
+            ]);
     }
 
     fn function_not_defined_contract() -> Vec<u8> {
@@ -1103,135 +828,96 @@ mod fix_contract_loading_cost_protocol_upgrade {
         .unwrap()
     }
 
-    #[track_caller]
-    fn check_failed_compilation(vm_kind: VMKind, code: &[u8], expected_error: CompilationError) {
-        let new_version = ProtocolFeature::FixContractLoadingCost.protocol_version();
-        let old_version = new_version - 1;
-        {
-            let res = make_simple_contract_call_with_protocol_version_vm(
-                &code,
-                "main",
-                old_version,
-                vm_kind,
-            );
-            // This is the first property the tests check: Gas cost before
-            // compilation errors must remain zero for old versions.
-            let expected_gas = 0;
-            gas_and_error_match(
-                res,
-                expected_gas,
-                Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
-                    expected_error.clone(),
-                ))),
-            );
-        }
-
-        {
-            let res = make_simple_contract_call_with_protocol_version_vm(
-                &code,
-                "main",
-                new_version,
-                vm_kind,
-            );
-
-            // This is the second property the tests check: Gas costs
-            // for loading gas are charged when failing during
-            // compilation.
-            let expected_gas = prepaid_loading_gas(code.len());
-            gas_and_error_match(
-                res,
-                expected_gas,
-                Some(VMError::FunctionCallError(FunctionCallError::CompilationError(
-                    expected_error,
-                ))),
-            );
-        }
-    }
-
     /// Failure during preparation must remain free of gas charges for old versions
     /// but new versions must charge the loading gas.
     #[test]
     fn test_fn_loading_gas_protocol_upgrade_fail_preparing() {
-        with_vm_variants(|vm_kind: VMKind| {
-            // This list covers all control flows that are expected to change
-            // with the protocol feature.
-            // Having a test for every possible preparation error would be even
-            // better, to ensure triggering any of them will always remain
-            // compatible with versions before this upgrade. Unfortunately, we
-            // currently do not have tests ready to trigger each error.
-            check_failed_compilation(
-                vm_kind,
-                &function_not_defined_contract(),
-                CompilationError::PrepareError(PrepareError::Deserialization),
-            );
-            check_failed_compilation(
-                vm_kind,
-                &bad_import_global("wtf"),
-                CompilationError::PrepareError(PrepareError::Instantiate),
-            );
-            check_failed_compilation(
-                vm_kind,
-                &bad_import_func("wtf"),
-                CompilationError::PrepareError(PrepareError::Instantiate),
-            );
-            check_failed_compilation(
-                vm_kind,
-                &near_test_contracts::LargeContract {
-                    functions: 101,
-                    locals_per_function: 9901,
-                    ..Default::default()
-                }
-                .make(),
-                CompilationError::PrepareError(PrepareError::TooManyLocals),
-            );
-            let functions_number_limit: u32 = 10_000;
-            check_failed_compilation(
-                vm_kind,
-                &near_test_contracts::LargeContract {
-                    functions: functions_number_limit / 2,
-                    panic_imports: functions_number_limit / 2 + 1,
-                    ..Default::default()
-                }
-                .make(),
-                CompilationError::PrepareError(PrepareError::TooManyFunctions),
-            );
-        });
-    }
+        // This list covers all control flows that are expected to change
+        // with the protocol feature.
+        // Having a test for every possible preparation error would be even
+        // better, to ensure triggering any of them will always remain
+        // compatible with versions before this upgrade. Unfortunately, we
+        // currently do not have tests ready to trigger each error.
 
-    /// For compilation tests other than checked in `test_fn_loading_gas_protocol_upgrade_fail_preparing`.
-    #[test]
-    fn test_fn_loading_gas_protocol_upgrade_fail_compiling() {
-        with_vm_variants(|vm_kind: VMKind| {
-            // This triggers `WasmerCompileError` or, for wasmtime, `LinkerError`.
-            let code = multi_memories_contract();
-            let new_version = ProtocolFeature::FixContractLoadingCost.protocol_version();
-            let old_version = new_version - 1;
-            let old_error = {
-                let (outcome, error) = make_simple_contract_call_with_protocol_version_vm(
-                    &code,
-                    "main",
-                    old_version,
-                    vm_kind,
-                );
-                assert_eq!(0, outcome.used_gas);
-                assert_eq!(0, outcome.burnt_gas);
-                error
-            };
+        test_builder()
+            .wasm(&function_not_defined_contract())
+            .protocol_features(&[ProtocolFeature::FixContractLoadingCost])
+            .expects(&[
+                expect![[r#"
+                    VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
+                    Err: PrepareError: Error happened while deserializing the module.
+                "#]],
+                expect![[r#"
+                    VMOutcome: balance 4 storage_usage 12 return data None burnt gas 39564213 used gas 39564213
+                    Err: PrepareError: Error happened while deserializing the module.
+                "#]],
+            ]);
 
-            let new_error = {
-                let (outcome, error) = make_simple_contract_call_with_protocol_version_vm(
-                    &code,
-                    "main",
-                    new_version,
-                    vm_kind,
-                );
-                let expected_gas = prepaid_loading_gas(code.len());
-                assert_eq!(expected_gas, outcome.used_gas);
-                assert_eq!(expected_gas, outcome.burnt_gas);
-                error
-            };
+        test_builder()
+            .wasm(&bad_import_global("wtf"))
+            .protocol_features(&[ProtocolFeature::FixContractLoadingCost])
+            .expects(&[
+                expect![[r#"
+                    VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
+                    Err: PrepareError: Error happened during instantiation.
+                "#]],
+                expect![[r#"
+                    VMOutcome: balance 4 storage_usage 12 return data None burnt gas 46500213 used gas 46500213
+                    Err: PrepareError: Error happened during instantiation.
+                "#]],
+            ]);
 
-            assert_eq!(old_error, new_error);
-        });
+        test_builder()
+            .wasm(&bad_import_func("wtf"))
+            .protocol_features(&[ProtocolFeature::FixContractLoadingCost])
+            .expects(&[
+                expect![[r#"
+                    VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
+                    Err: PrepareError: Error happened during instantiation.
+                "#]],
+                expect![[r#"
+                    VMOutcome: balance 4 storage_usage 12 return data None burnt gas 45849963 used gas 45849963
+                    Err: PrepareError: Error happened during instantiation.
+                "#]],
+            ]);
+
+        test_builder()
+            .wasm(&near_test_contracts::LargeContract {
+                functions: 101,
+                locals_per_function: 9901,
+                ..Default::default()
+            }
+            .make())
+            .protocol_features(&[ProtocolFeature::FixContractLoadingCost])
+            .expects(&[
+                expect![[r#"
+                    VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
+                    Err: PrepareError: Too many locals declared in the contract.
+                "#]],
+                expect![[r#"
+                    VMOutcome: balance 4 storage_usage 12 return data None burnt gas 195407463 used gas 195407463
+                    Err: PrepareError: Too many locals declared in the contract.
+                "#]],
+            ]);
+
+        let functions_number_limit: u32 = 10_000;
+        test_builder()
+            .wasm(&near_test_contracts::LargeContract {
+                functions: functions_number_limit / 2,
+                panic_imports: functions_number_limit / 2 + 1,
+                ..Default::default()
+            }
+            .make())
+            .protocol_features(&[ProtocolFeature::FixContractLoadingCost])
+            .expects(&[
+                expect![[r#"
+                    VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
+                    Err: PrepareError: Too many functions in contract.
+                "#]],
+                expect![[r#"
+                    VMOutcome: balance 4 storage_usage 12 return data None burnt gas 19554433713 used gas 19554433713
+                    Err: PrepareError: Too many functions in contract.
+                "#]],
+            ]);
     }
 }

--- a/runtime/near-vm-runner/src/tests/test_builder.rs
+++ b/runtime/near-vm-runner/src/tests/test_builder.rs
@@ -62,6 +62,7 @@ impl TestBuilder {
         self
     }
 
+    #[allow(dead_code)]
     pub(crate) fn get_wasm(&self) -> &[u8] {
         self.code.code()
     }

--- a/runtime/near-vm-runner/src/tests/test_builder.rs
+++ b/runtime/near-vm-runner/src/tests/test_builder.rs
@@ -179,7 +179,7 @@ impl TestBuilder {
                 };
                 if let Some(err) = res.error() {
                     let mut err = err.to_string();
-                    assert!(err.len() < 1000, "errors should be bounded in size");
+                    assert!(err.len() < 1000, "errors should be bounded in size to prevent abuse via exhausting the storage space");
                     if self.opaque_error {
                         err = "...".to_string();
                     }

--- a/runtime/near-vm-runner/src/tests/test_builder.rs
+++ b/runtime/near-vm-runner/src/tests/test_builder.rs
@@ -1,0 +1,188 @@
+use crate::internal::VMKind;
+use near_primitives::{
+    contract::ContractCode,
+    runtime::{config_store::RuntimeConfigStore, fees::RuntimeFeesConfig},
+    types::Gas,
+    version::{ProtocolFeature, PROTOCOL_VERSION},
+};
+use near_vm_logic::{mocks::mock_external::MockedExternal, VMContext};
+use std::collections::HashSet;
+use std::fmt::Write;
+
+pub(crate) fn test_builder() -> TestBuilder {
+    let context = VMContext {
+        current_account_id: "alice".parse().unwrap(),
+        signer_account_id: "bob".parse().unwrap(),
+        signer_account_pk: vec![0, 1, 2],
+        predecessor_account_id: "carol".parse().unwrap(),
+        input: Vec::new(),
+        block_index: 10,
+        block_timestamp: 42,
+        epoch_height: 1,
+        account_balance: 2u128,
+        account_locked_balance: 0,
+        storage_usage: 12,
+        attached_deposit: 2u128,
+        prepaid_gas: 10_u64.pow(14),
+        random_seed: vec![0, 1, 2],
+        view_config: None,
+        output_data_receivers: vec![],
+    };
+    TestBuilder {
+        code: ContractCode::new(Vec::new(), None),
+        context,
+        method: "main".to_string(),
+        protocol_features: &[],
+        skip: HashSet::new(),
+        opaque_error: false,
+        opaque_outcome: false,
+    }
+}
+
+pub(crate) struct TestBuilder {
+    code: ContractCode,
+    context: VMContext,
+    protocol_features: &'static [ProtocolFeature],
+    method: String,
+    skip: HashSet<VMKind>,
+    opaque_error: bool,
+    opaque_outcome: bool,
+}
+
+impl TestBuilder {
+    pub(crate) fn wat(mut self, wat: &str) -> Self {
+        let wasm = wat::parse_str(wat)
+            .unwrap_or_else(|err| panic!("failed to parse input wasm: {err}\n{wat}"));
+        self.code = ContractCode::new(wasm, None);
+        self
+    }
+
+    pub(crate) fn wasm(mut self, wasm: &[u8]) -> Self {
+        self.code = ContractCode::new(wasm.to_vec(), None);
+        self
+    }
+
+    pub(crate) fn method(mut self, method: &str) -> Self {
+        self.method = method.to_string();
+        self
+    }
+
+    pub(crate) fn gas(mut self, gas: Gas) -> Self {
+        self.context.prepaid_gas = gas;
+        self
+    }
+
+    pub(crate) fn opaque_error(mut self) -> Self {
+        self.opaque_error = true;
+        self
+    }
+
+    pub(crate) fn opaque_outcome(mut self) -> Self {
+        self.opaque_outcome = true;
+        self
+    }
+
+    // We only test trapping tests on Wasmer, as of version 0.17, when tests executed in parallel,
+    // Wasmer signal handlers may catch signals thrown from the Wasmtime, and produce fake failing tests.
+    pub(crate) fn skip_wasmtime(mut self) -> Self {
+        self.skip.insert(VMKind::Wasmtime);
+        self
+    }
+
+    pub(crate) fn skip_wasmer0(mut self) -> Self {
+        self.skip.insert(VMKind::Wasmer0);
+        self
+    }
+
+    pub(crate) fn skip_wasmer2(mut self) -> Self {
+        self.skip.insert(VMKind::Wasmer2);
+        self
+    }
+
+    pub(crate) fn protocol_features(
+        mut self,
+        protocol_features: &'static [ProtocolFeature],
+    ) -> Self {
+        self.protocol_features = protocol_features;
+        self
+    }
+
+    pub(crate) fn expect(self, want: expect_test::Expect) {
+        self.expects(&[want])
+    }
+
+    pub(crate) fn expects(self, wants: &[expect_test::Expect]) {
+        let runtime_config_store = RuntimeConfigStore::new(None);
+
+        let mut protocol_versions = Vec::new();
+        for feat in self.protocol_features {
+            protocol_versions.push(feat.protocol_version() - 1)
+        }
+        protocol_versions.push(PROTOCOL_VERSION);
+        assert_eq!(
+            wants.len(),
+            protocol_versions.len(),
+            "specified {} features but only {} expectation ({} + 1 needed)",
+            self.protocol_features.len(),
+            wants.len(),
+            self.protocol_features.len()
+        );
+
+        for (want, &protocol_version) in wants.iter().zip(&protocol_versions) {
+            let mut results = vec![];
+            for vm_kind in [VMKind::Wasmer2, VMKind::Wasmer0, VMKind::Wasmtime] {
+                if self.skip.contains(&vm_kind) {
+                    continue;
+                }
+                let runtime_config = runtime_config_store.get_config(protocol_version);
+
+                let mut fake_external = MockedExternal::new();
+                let config = runtime_config.wasm_config.clone();
+                let fees = RuntimeFeesConfig::test();
+                let context = self.context.clone();
+
+                let promise_results = vec![];
+
+                let runtime = vm_kind.runtime(config).expect("runtime has not been compiled");
+                let res = runtime.run(
+                    &self.code,
+                    &self.method,
+                    &mut fake_external,
+                    context,
+                    &fees,
+                    &promise_results,
+                    protocol_version,
+                    None,
+                );
+
+                let mut got = if self.opaque_outcome {
+                    String::new()
+                } else {
+                    format!("{:?}\n", res.outcome())
+                };
+                if let Some(err) = res.error() {
+                    let mut err = err.to_string();
+                    assert!(err.len() < 1000, "errors should be bounded in size");
+                    if self.opaque_error {
+                        err = "...".to_string();
+                    }
+                    writeln!(got, "Err: {err}").unwrap();
+                }
+
+                results.push((vm_kind, got));
+            }
+
+            if !results.is_empty() {
+                want.assert_eq(&results[0].1);
+                for i in 1..results.len() {
+                    if results[i].1 != results[0].1 {
+                        panic!(
+                            "Inconsistent VM Output:\n{:?}:\n{}\n\n{:?}:\n{}",
+                            results[0].0, results[0].1, results[i].0, results[i].1
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/runtime/near-vm-runner/src/tests/wasm_validation.rs
+++ b/runtime/near-vm-runner/src/tests/wasm_validation.rs
@@ -1,5 +1,6 @@
+use super::test_builder::test_builder;
 use crate::prepare::prepare_contract;
-use crate::vm_kind::VMKind;
+use expect_test::expect;
 use near_vm_logic::VMConfig;
 
 static SIMD: &str = r#"
@@ -110,13 +111,9 @@ fn ensure_fails_verification() {
 
 #[test]
 fn ensure_fails_execution() {
-    crate::tests::with_vm_variants(|vm_kind: VMKind| {
-        for (feature_name, wat) in EXPECTED_UNSUPPORTED {
-            let wasm = wat::parse_str(wat).expect("parsing test wat should succeed");
-            let (_, err) = crate::tests::make_simple_contract_call_vm(&wasm, "entry", vm_kind);
-            if err.is_none() {
-                panic!("wasm containing use of {} feature did not fail to prepare", feature_name);
-            }
-        }
-    });
+    for (_feature_name, wat) in EXPECTED_UNSUPPORTED {
+        test_builder().wat(wat).opaque_error().opaque_outcome().expect(expect![[r#"
+            Err: ...
+        "#]]);
+    }
 }

--- a/runtime/near-vm-runner/src/vm_kind.rs
+++ b/runtime/near-vm-runner/src/vm_kind.rs
@@ -3,7 +3,7 @@ use near_primitives::checked_feature;
 use near_vm_logic::ProtocolVersion;
 use std::hash::Hash;
 
-#[derive(Clone, Copy, Debug, Hash, BorshSerialize)]
+#[derive(Clone, Copy, Debug, Hash, BorshSerialize, PartialEq, Eq)]
 // Note, that VMKind is part of serialization protocol, so we cannor remove entries
 // from this list if particular VM reached publically visible networks.
 //


### PR DESCRIPTION
RFC solution for https://github.com/near/nearcore/issues/6921

Vision:

* remove `make_simple_call` family of functions completely in favor of unified `test_builde()`
* use snapshot/expect testing rather than relying on `Error: Eq`. I'd love to use `insta` as that's what we are using elsewhere, but I don't think insta can do what I want here (packaging "snapshot" as a value), so I plugged my `expect_test`. 
* pull the `with_vm_kinds` loop inside