### PR TITLE
nearcore: use StoreOpener in recompress_storage

### DIFF
--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -46,7 +46,7 @@ pub mod migrations;
 pub mod test_utils;
 mod trie;
 
-pub use crate::config::{get_store_path, store_path_exists, StoreConfig, StoreOpener, STORE_PATH};
+pub use crate::config::{get_store_path, StoreConfig, StoreOpener};
 
 #[derive(Clone)]
 pub struct Store {

--- a/core/store/src/migrations.rs
+++ b/core/store/src/migrations.rs
@@ -6,17 +6,8 @@ use near_primitives::epoch_manager::epoch_info::{EpochInfo, EpochInfoV1};
 use near_primitives::hash::CryptoHash;
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::AccountId;
-use near_primitives::version::DbVersion;
 
-use crate::db::{DBError, RocksDB};
 use crate::{DBCol, Store, StoreOpener, StoreUpdate};
-use std::path::Path;
-
-// This is used by recompress_storage only.  TODO(#6857): Get rid of this
-// function in favour of StoreOpener::get_version_if_exists.
-pub fn get_store_version(path: &Path) -> Result<DbVersion, DBError> {
-    RocksDB::get_version(path)
-}
 
 fn set_store_version_inner(store_update: &mut StoreUpdate, db_version: u32) {
     store_update.set(
@@ -149,7 +140,6 @@ pub fn migrate_29_to_30(store_opener: &StoreOpener) {
     };
     use std::collections::BTreeMap;
 
-    // TODO(#6857): Don’t use .path().
     let store = store_opener.open();
 
     #[derive(BorshDeserialize)]


### PR DESCRIPTION
This allows removal of get_store_version (since the code is now using
StoreOpener::get_version_if_exists is used) and reduces uses of the
StoreOpener::path method.

Issue: https://github.com/near/nearcore/issues/6857