### PR TITLE
Prefer StoreOpener::new to StoreOpener::with_default_config

### DIFF
--- a/genesis-tools/genesis-populate/src/main.rs
+++ b/genesis-tools/genesis-populate/src/main.rs
@@ -29,7 +29,7 @@ fn main() {
     let near_config = load_config(home_dir, GenesisValidationMode::Full)
         .unwrap_or_else(|e| panic!("Error loading config: {:#}", e));
 
-    let store = near_store::StoreOpener::with_default_config().home(home_dir).open();
+    let store = near_store::StoreOpener::new(&near_config).home(home_dir).open();
     GenesisBuilder::from_config_and_store(home_dir, Arc::new(near_config.genesis), store)
         .add_additional_accounts(additional_accounts_num)
         .add_additional_accounts_contract(near_test_contracts::trivial_contract().to_vec())

--- a/test-utils/store-validator/src/main.rs
+++ b/test-utils/store-validator/src/main.rs
@@ -30,7 +30,7 @@ fn main() {
     let near_config = load_config(home_dir, GenesisValidationMode::Full)
         .unwrap_or_else(|e| panic!("Error loading config: {:#}", e));
 
-    let store = near_store::StoreOpener::with_default_config().home(home_dir).open();
+    let store = near_store::StoreOpener::new(&near_config).home(home_dir).open();
 
     let runtime_adapter: Arc<dyn RuntimeAdapter> = Arc::new(nearcore::NightshadeRuntime::new(
         home_dir,


### PR DESCRIPTION
Whenever NearConfig is available, use StoreConfig from it rather than
assuming default store configuration when creating StoreOpener (and
thus opening storage).  This will become important when path is added
to the configuration.

With this change, the only remaining uses of with_default_config are
in test code where we would use default store configuration anyway.

Issue: https://github.com/near/nearcore/issues/6857