### PR TITLE
refactor(telemetry): Dropped unnecessary direct dependency on actix-web from telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,7 +67,6 @@ dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
- "actix-tls",
  "actix-utils",
  "ahash",
  "base64 0.13.0",
@@ -202,7 +201,6 @@ dependencies = [
  "actix-rt",
  "actix-server",
  "actix-service",
- "actix-tls",
  "actix-utils",
  "actix-web-codegen",
  "ahash",
@@ -3336,7 +3334,6 @@ name = "near-telemetry"
 version = "0.0.0"
 dependencies = [
  "actix",
- "actix-web",
  "awc",
  "futures",
  "near-metrics",

--- a/chain/telemetry/Cargo.toml
+++ b/chain/telemetry/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 
 [dependencies]
 actix = "0.13.0"
-actix-web = { version = "4.0.1", features = [ "openssl" ] }
 awc = { version = "3.0.0", features = [ "openssl" ] }
 futures = "0.3"
 once_cell = "1.5.2"

--- a/chain/telemetry/src/lib.rs
+++ b/chain/telemetry/src/lib.rs
@@ -46,7 +46,7 @@ impl TelemetryActor {
 
         let client = Client::builder()
             .timeout(CONNECT_TIMEOUT)
-            .connector(Connector::new().max_http_version(actix_web::http::Version::HTTP_11))
+            .connector(Connector::new().max_http_version(awc::http::Version::HTTP_11))
             .finish();
         Self { config, client }
     }


### PR DESCRIPTION
It is a follow-up PR to #6925