### PR TITLE
fix/Add Empty enum to OperationStatusKind

### DIFF
--- a/chain/rosetta-rpc/src/models.rs
+++ b/chain/rosetta-rpc/src/models.rs
@@ -719,15 +719,18 @@ pub(crate) enum OperationType {
     Apiv2Schema,
     strum::EnumIter,
 )]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub(crate) enum OperationStatusKind {
+    #[serde(rename = "SCREAMING_SNAKE_CASE")]
     Success,
+    #[serde(rename = "")]
+    Empty,
 }
 
 impl OperationStatusKind {
     pub(crate) fn is_successful(&self) -> bool {
         match self {
             Self::Success => true,
+            Self::Empty => false,
         }
     }
 }


### PR DESCRIPTION
According to the Rosetta Spec,  `operations provided during transaction construction (often times called "intent" in the documentation) MUST NOT have a populated status field (operations yet to be included on-chain have not yet succeeded or failed).` This also must include empty strings according to the authors of Rosetta Spec for the testing to continue on their side. 