### PR TITLE
feat: tracing logs in estimator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4819,6 +4819,7 @@ dependencies = [
  "sha256",
  "tempfile",
  "tracing-span-tree",
+ "tracing-subscriber",
  "walrus",
  "wat",
 ]

--- a/runtime/runtime-params-estimator/Cargo.toml
+++ b/runtime/runtime-params-estimator/Cargo.toml
@@ -25,6 +25,7 @@ chrono = "0.4"
 sha256 = "1.0.2"
 bytesize = "1.1"
 tracing-span-tree = "0.1"
+tracing-subscriber = "0.3.11"
 
 
 genesis-populate = { path = "../../genesis-tools/genesis-populate"}

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -197,6 +197,14 @@ fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
+    if cli_args.debug {
+        use tracing_subscriber::prelude::__tracing_subscriber_SubscriberExt;
+        use tracing_subscriber::util::SubscriberInitExt;
+        tracing_subscriber::registry()
+            .with(tracing_subscriber::fmt::layer())
+            .with(tracing_subscriber::EnvFilter::from_default_env())
+            .init();
+    }
     if cli_args.tracing_span_tree {
         tracing_span_tree::span_tree().enable();
     }

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -197,16 +197,15 @@ fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    if cli_args.debug {
+    if cli_args.tracing_span_tree {
+        tracing_span_tree::span_tree().enable();
+    } else {
         use tracing_subscriber::prelude::__tracing_subscriber_SubscriberExt;
         use tracing_subscriber::util::SubscriberInitExt;
         tracing_subscriber::registry()
             .with(tracing_subscriber::fmt::layer())
             .with(tracing_subscriber::EnvFilter::from_default_env())
             .init();
-    }
-    if cli_args.tracing_span_tree {
-        tracing_span_tree::span_tree().enable();
     }
 
     let warmup_iters_per_block = cli_args.warmup_iters;


### PR DESCRIPTION
Allow to select tracing levels and targets with the `RUST_LOG` environment variable when the estimator is running without the `--tracing-span-tree` flag.