### PR TITLE
fix: data sections in test wat codes

### DIFF
--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -3502,7 +3502,7 @@ fn test_deploy_cost_increased() {
 
     let contract_size = 1024 * 1024;
     let test_contract = near_test_contracts::sized_contract(contract_size);
-    // Rune code through preparation for validation. (Deploying will succeed either way).
+    // Run code through preparation for validation. (Deploying will succeed either way).
     near_vm_runner::prepare::prepare_contract(&test_contract, &VMConfig::test()).unwrap();
 
     // Prepare TestEnv with a contract at the old protocol version.

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -7,6 +7,7 @@ use std::sync::{Arc, RwLock};
 use actix::System;
 use assert_matches::assert_matches;
 use futures::{future, FutureExt};
+use near_primitives::config::VMConfig;
 use near_primitives::num_rational::Rational;
 
 use near_actix_test_utils::run_actix;
@@ -3501,6 +3502,8 @@ fn test_deploy_cost_increased() {
 
     let contract_size = 1024 * 1024;
     let test_contract = near_test_contracts::sized_contract(contract_size);
+    // Rune code through preparation for validation. (Deploying will succeed either way).
+    near_vm_runner::prepare::prepare_contract(&test_contract, &VMConfig::test()).unwrap();
 
     // Prepare TestEnv with a contract at the old protocol version.
     let epoch_length = 5;

--- a/integration-tests/src/tests/runtime/deployment.rs
+++ b/integration-tests/src/tests/runtime/deployment.rs
@@ -57,6 +57,8 @@ fn test_deploy_max_size_contract() {
 
     // Deploy contract
     let wasm_binary = near_test_contracts::sized_contract(contract_size as usize);
+    // Rune code through preparation for validation. (Deploying will succeed either way).
+    near_vm_runner::prepare::prepare_contract(&wasm_binary, &config.wasm_config).unwrap();
     let transaction_result =
         node_user.deploy_contract(test_contract_id, wasm_binary.to_vec()).unwrap();
     assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(to_base64(&[])));

--- a/runtime/near-test-contracts/src/lib.rs
+++ b/runtime/near-test-contracts/src/lib.rs
@@ -20,8 +20,8 @@ pub fn trivial_contract() -> &'static [u8] {
 pub fn sized_contract(size: usize) -> Vec<u8> {
     let payload = "x".repeat(size);
     let base_size = wat_contract(&format!(
-        r#"(
-            module (memory 1)
+        r#"(module
+            (memory 1)
             (func (export "main"))
             (data (i32.const 0) "{payload}")
         )"#
@@ -30,8 +30,8 @@ pub fn sized_contract(size: usize) -> Vec<u8> {
     let adjusted_size = size as i64 - (base_size as i64 - size as i64);
     let payload = "x".repeat(adjusted_size as usize);
     let code = format!(
-        r#"(
-            module (memory 1)
+        r#"(module 
+            (memory 1)
             (func (export "main"))
             (data (i32.const 0) "{payload}")
         )"#

--- a/runtime/near-test-contracts/src/lib.rs
+++ b/runtime/near-test-contracts/src/lib.rs
@@ -19,11 +19,23 @@ pub fn trivial_contract() -> &'static [u8] {
 /// Contract with exact size in bytes.
 pub fn sized_contract(size: usize) -> Vec<u8> {
     let payload = "x".repeat(size);
-    let base_size =
-        wat_contract(&format!("(module (data \"{payload}\") (func (export \"main\")))")).len();
+    let base_size = wat_contract(&format!(
+        r#"(
+            module (memory 1)
+            (func (export "main"))
+            (data (i32.const 0) "{payload}")
+        )"#
+    ))
+    .len();
     let adjusted_size = size as i64 - (base_size as i64 - size as i64);
     let payload = "x".repeat(adjusted_size as usize);
-    let code = format!("(module (data \"{payload}\") (func (export \"main\")))");
+    let code = format!(
+        r#"(
+            module (memory 1)
+            (func (export "main"))
+            (data (i32.const 0) "{payload}")
+        )"#
+    );
     let contract = wat_contract(&code);
     assert_eq!(contract.len(), size);
     contract

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -650,8 +650,9 @@ fn contract_compile_base_per_byte_v2(ctx: &mut EstimatorContext) -> (GasCost, Ga
     costs
 }
 fn pure_deploy_bytes(ctx: &mut EstimatorContext) -> GasCost {
-    let small_code = generate_data_only_contract(0);
-    let large_code = generate_data_only_contract(bytesize::mb(4u64) as usize);
+    let vm_config = VMConfig::test();
+    let small_code = generate_data_only_contract(0, &vm_config);
+    let large_code = generate_data_only_contract(bytesize::mb(4u64) as usize, &vm_config);
     let small_code_len = small_code.len();
     let large_code_len = large_code.len();
     let cost_empty = deploy_contract_cost(ctx, small_code, Some(b"main"));

--- a/runtime/runtime-params-estimator/src/utils.rs
+++ b/runtime/runtime-params-estimator/src/utils.rs
@@ -265,8 +265,6 @@ pub(crate) fn percentiles(
         .into_iter()
         .map(move |p| (p * sample_size as f32).ceil() as usize - 1)
         .map(move |idx| costs[idx].clone())
-    // .collect::<Vec<_>>()
-    // .into_iter()
 }
 
 /// Get account id from its index.
@@ -291,7 +289,13 @@ pub(crate) fn generate_data_only_contract(data_size: usize) -> Vec<u8> {
     // Using pseudo-random stream with fixed seed to create deterministic, incompressable payload.
     let prng: XorShiftRng = rand::SeedableRng::seed_from_u64(0xdeadbeef);
     let payload = prng.sample_iter(&Alphanumeric).take(data_size).collect::<String>();
-    let wat_code = format!("(module (data \"{payload}\") (func (export \"main\")))");
+    let wat_code = format!(
+        r#"(module 
+            (memory 1)
+            (func (export "main"))
+            (data (i32.const 0) "{payload}")
+        )"#
+    );
     wat::parse_str(wat_code).unwrap()
 }
 


### PR DESCRIPTION
Contracts with a controlled data section size are generated ad-hoc for
tests and estimations. But they never actually worked, they hit
`PrepareError::Deserialization` instead.


Test plan
-----------------
Validate the generated wat codes using `prepare_contract`.