### PR TITLE
feat(network): Added ability to resolve DNS records for peers instead of only IP addresses

### DIFF
--- a/chain/network-primitives/src/config_json.rs
+++ b/chain/network-primitives/src/config_json.rs
@@ -51,12 +51,16 @@ pub struct Config {
     /// If empty, will use the same port as the addr, and will introspect on the listener.
     pub external_address: String,
     /// Comma separated list of nodes to connect to.
+    /// Examples:
+    ///   ed25519:86EtEy7epneKyrcJwSWP7zsisTkfDRH5CFVszt4qiQYw@31.192.22.209:24567
+    ///   ed25519:86EtEy7epneKyrcJwSWP7zsisTkfDRH5CFVszt4qiQYw@nearnode.com:24567
     pub boot_nodes: String,
     /// Comma separated list of whitelisted nodes. Inbound connections from the nodes on
     /// the whitelist are accepted even if the limit of the inbound connection has been reached.
-    /// For each whitelisted node specifying both PeerId and IP:port is required:
-    /// Example:
+    /// For each whitelisted node specifying both PeerId and one of IP:port or Host:port is required:
+    /// Examples:
     ///   ed25519:86EtEy7epneKyrcJwSWP7zsisTkfDRH5CFVszt4qiQYw@31.192.22.209:24567
+    ///   ed25519:86EtEy7epneKyrcJwSWP7zsisTkfDRH5CFVszt4qiQYw@nearnode.com:24567
     #[serde(default)]
     pub whitelist_nodes: String,
     /// Maximum number of active peers. Hard limit.

--- a/chain/network-primitives/src/network_protocol/mod.rs
+++ b/chain/network-primitives/src/network_protocol/mod.rs
@@ -20,7 +20,7 @@ use near_primitives::views::{FinalExecutionOutcomeView, QueryRequest, QueryRespo
 use std::collections::HashSet;
 use std::fmt;
 use std::fmt::{Debug, Error, Formatter};
-use std::net::SocketAddr;
+use std::net::{SocketAddr, ToSocketAddrs};
 use std::str::FromStr;
 
 pub(crate) mod edge;
@@ -71,30 +71,50 @@ impl fmt::Display for PeerInfo {
 
 impl FromStr for PeerInfo {
     type Err = Box<dyn std::error::Error>;
-
+    /// Returns a PeerInfo from string
+    ///
+    /// Valid format examples:
+    ///     ed25519:C6HLP37VJN1Wj2irxxZPsVsSya92Rnx12tqK3us5erKV
+    ///     ed25519:C6HLP37VJN1Wj2irxxZPsVsSya92Rnx12tqK3us5erKV@127.0.0.1:24567
+    ///     ed25519:C6HLP37VJN1Wj2irxxZPsVsSya92Rnx12tqK3us5erKV@test.near
+    ///     ed25519:C6HLP37VJN1Wj2irxxZPsVsSya92Rnx12tqK3us5erKV@127.0.0.1:24567@test.near
+    ///
+    /// Hostname can be used instead of IP address, if node trusts DNS server it connects to, for example:
+    ///     ed25519:C6HLP37VJN1Wj2irxxZPsVsSya92Rnx12tqK3us5erKV@localhost:24567@test.near
+    ///     ed25519:C6HLP37VJN1Wj2irxxZPsVsSya92Rnx12tqK3us5erKV@my.own.node.test:24567@test.near
+    ///
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let chunks: Vec<&str> = s.split('@').collect();
         let addr;
         let account_id;
+
+        let invalid_peer_error_factory = || -> Self::Err {
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("Invalid PeerInfo format: {:?}", chunks),
+            ))
+        };
+
         if chunks.len() == 1 {
             addr = None;
             account_id = None;
         } else if chunks.len() == 2 {
-            if let Ok(x) = chunks[1].parse::<SocketAddr>() {
-                addr = Some(x);
+            if let Ok(mut x) = chunks[1].to_socket_addrs() {
+                addr = x.next();
                 account_id = None;
             } else {
                 addr = None;
                 account_id = Some(chunks[1].parse().unwrap());
             }
         } else if chunks.len() == 3 {
-            addr = Some(chunks[1].parse::<SocketAddr>()?);
-            account_id = Some(chunks[2].parse().unwrap());
+            if let Ok(mut x) = chunks[1].to_socket_addrs() {
+                addr = x.next();
+                account_id = Some(chunks[2].parse().unwrap());
+            } else {
+                return Err(invalid_peer_error_factory());
+            }
         } else {
-            return Err(Box::new(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!("Invalid PeerInfo format: {:?}", chunks),
-            )));
+            return Err(invalid_peer_error_factory());
         }
         Ok(PeerInfo { id: PeerId::new(chunks[0].parse()?), addr, account_id })
     }
@@ -452,5 +472,46 @@ impl StateResponseInfo {
             Self::V1(info) => ShardStateSyncResponse::V1(info.state_response),
             Self::V2(info) => info.state_response,
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::net::IpAddr;
+    use std::net::SocketAddr;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    #[test]
+    /// TODO this test might require an improvement (probably by mocking the DNS resolution)
+    fn test_from_str() {
+        use crate::types::PeerInfo;
+        use std::str::FromStr;
+
+        let socket_v4 = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 1337);
+        let socket_v6 = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 1337);
+
+        let mut peer_test = PeerInfo::from_str(
+            "ed25519:C6HLP37VJN1Wj2irxxZPsVsSya92Rnx12tqK3us5erKV@localhost:1337@account.near",
+        )
+        .unwrap();
+        assert!(peer_test.addr.unwrap() == socket_v4 || peer_test.addr.unwrap() == socket_v6);
+
+        peer_test = PeerInfo::from_str(
+            "ed25519:C6HLP37VJN1Wj2irxxZPsVsSya92Rnx12tqK3us5erKV@localhost:1337",
+        )
+        .unwrap();
+        assert!(peer_test.addr.unwrap() == socket_v4 || peer_test.addr.unwrap() == socket_v6);
+
+        peer_test = PeerInfo::from_str(
+            "ed25519:C6HLP37VJN1Wj2irxxZPsVsSya92Rnx12tqK3us5erKV@127.0.0.1:1337@account.near",
+        )
+        .unwrap();
+        assert!(peer_test.addr.unwrap() == socket_v4 || peer_test.addr.unwrap() == socket_v6);
+
+        peer_test = PeerInfo::from_str(
+            "ed25519:C6HLP37VJN1Wj2irxxZPsVsSya92Rnx12tqK3us5erKV@127.0.0.1:1337",
+        )
+        .unwrap();
+        assert!(peer_test.addr.unwrap() == socket_v4 || peer_test.addr.unwrap() == socket_v6);
     }
 }


### PR DESCRIPTION
We use kuberenetes for spinning up networks now with custom genesis using DNs instead of IPs and we have a problem that nodes can't resolve DNS records which are assigned to services. This fixes the issue.