### PR TITLE
store: make home directory required when constructing StoreOpener

### DIFF
--- a/chain/network/src/peer_manager/peer_store.rs
+++ b/chain/network/src/peer_manager/peer_store.rs
@@ -508,14 +508,14 @@ mod test {
         let peer_info_to_ban = gen_peer_info(1);
         let boot_nodes = vec![peer_info_a, peer_info_to_ban.clone()];
         {
-            let store = StoreOpener::with_default_config().home(tmp_dir.path()).open();
+            let store = StoreOpener::with_default_config(tmp_dir.path()).open();
             let mut peer_store = PeerStore::new(store, &boot_nodes, Default::default()).unwrap();
             assert_eq!(peer_store.healthy_peers(3).len(), 2);
             peer_store.peer_ban(&peer_info_to_ban.id, ReasonForBan::Abusive).unwrap();
             assert_eq!(peer_store.healthy_peers(3).len(), 1);
         }
         {
-            let store_new = StoreOpener::with_default_config().home(tmp_dir.path()).open();
+            let store_new = StoreOpener::with_default_config(tmp_dir.path()).open();
             let peer_store_new =
                 PeerStore::new(store_new, &boot_nodes, Default::default()).unwrap();
             assert_eq!(peer_store_new.healthy_peers(3).len(), 1);
@@ -529,7 +529,7 @@ mod test {
         let peer_info_to_ban = gen_peer_info(1);
         let boot_nodes = vec![peer_info_a, peer_info_to_ban];
         {
-            let store = StoreOpener::with_default_config().home(tmp_dir.path()).open();
+            let store = StoreOpener::with_default_config(tmp_dir.path()).open();
             let peer_store = PeerStore::new(store, &boot_nodes, Default::default()).unwrap();
             assert!(peer_store.unconnected_peer(|_| false).is_some());
             assert!(peer_store.unconnected_peer(|_| true).is_none());
@@ -773,7 +773,7 @@ mod test {
 
         // Add three peers.
         {
-            let store = StoreOpener::with_default_config().home(tmp_dir.path()).open();
+            let store = StoreOpener::with_default_config(tmp_dir.path()).open();
             let mut peer_store = PeerStore::new(store, &[], Default::default()).unwrap();
             peer_store.add_indirect_peers(peer_infos.clone().into_iter()).unwrap();
         }
@@ -781,7 +781,7 @@ mod test {
 
         // Blacklisted peers are removed from the store.
         {
-            let store = StoreOpener::with_default_config().home(tmp_dir.path()).open();
+            let store = StoreOpener::with_default_config(tmp_dir.path()).open();
             let blacklist =
                 Blacklist::from_iter([format!("{}", peer_infos[2].addr.unwrap())].into_iter());
             let _peer_store = PeerStore::new(store, &[], blacklist).unwrap();
@@ -790,7 +790,7 @@ mod test {
     }
 
     fn assert_peers_in_store(store_path: &std::path::Path, expected: &[PeerId]) {
-        let store = StoreOpener::with_default_config().home(store_path).open();
+        let store = StoreOpener::with_default_config(store_path).open();
         let stored_peers: HashSet<PeerId> = HashSet::from_iter(
             store.iter(DBCol::Peers).map(|(key, _)| PeerId::try_from_slice(key.as_ref()).unwrap()),
         );
@@ -826,14 +826,14 @@ mod test {
             peer_infos.iter().map(|info| info.addr.unwrap().clone()).collect::<Vec<_>>();
 
         {
-            let store = StoreOpener::with_default_config().home(tmp_dir.path()).open();
+            let store = StoreOpener::with_default_config(tmp_dir.path()).open();
             let mut peer_store = PeerStore::new(store, &[], Default::default()).unwrap();
             peer_store.add_indirect_peers(peer_infos.into_iter()).unwrap();
         }
         assert_peers_in_store(tmp_dir.path(), &peer_ids);
 
         {
-            let store = StoreOpener::with_default_config().home(tmp_dir.path()).open();
+            let store = StoreOpener::with_default_config(tmp_dir.path()).open();
             let mut peer_store = PeerStore::new(store, &[], Default::default()).unwrap();
             assert_peers_in_cache(&peer_store, &peer_ids, &peer_addresses);
             peer_store.delete_peers(&peer_ids).unwrap();

--- a/core/store/benches/store_bench.rs
+++ b/core/store/benches/store_bench.rs
@@ -17,7 +17,7 @@ fn benchmark_write_then_read_successful(
     col: DBCol,
 ) {
     let tmp_dir = tempfile::Builder::new().tempdir().unwrap();
-    let store = StoreOpener::with_default_config().home(tmp_dir.path()).open();
+    let store = StoreOpener::with_default_config(tmp_dir.path()).open();
     let keys = generate_keys(num_keys, key_size);
     write_to_db(&store, &keys, max_value_size, col);
 

--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -123,11 +123,9 @@ pub fn get_store_path(base_path: &std::path::Path) -> std::path::PathBuf {
 ///     .open();
 /// ```
 pub struct StoreOpener<'a> {
-    /// Near home directory.
-    ///
-    /// Path to the database is resolved relative to this directory.  If it’s
-    /// not given current working directory is assumed.
-    home: Option<&'a std::path::Path>,
+    /// Near home directory; path to the database is resolved relative to this
+    /// directory.
+    home_dir: &'a std::path::Path,
 
     /// Configuration as provided by the user.
     config: &'a StoreConfig,
@@ -138,31 +136,22 @@ pub struct StoreOpener<'a> {
 
 impl<'a> StoreOpener<'a> {
     /// Initialises a new opener with given store configuration.
-    pub fn new(config: &'a StoreConfig) -> Self {
-        Self { home: None, config: config, read_only: false }
+    pub fn new(home_dir: &'a std::path::Path, config: &'a StoreConfig) -> Self {
+        Self { home_dir, config, read_only: false }
     }
 
     /// Initialises a new opener using default store configuration.
     ///
     /// This is meant for tests only.  Production code should always read store
     /// configuration from a config file and use [`Self::new`] instead.
-    pub fn with_default_config() -> Self {
+    pub fn with_default_config(home_dir: &'a std::path::Path) -> Self {
         static CONFIG: StoreConfig = StoreConfig::const_default();
-        Self::new(&CONFIG)
+        Self::new(home_dir, &CONFIG)
     }
 
     /// Configure whether the database should be opened in read-only mode.
     pub fn read_only(mut self, read_only: bool) -> Self {
         self.read_only = read_only;
-        self
-    }
-
-    /// Specifies neard home directory.
-    ///
-    /// By default, the database lives in a `data` directory inside of the home
-    /// directory.
-    pub fn home(mut self, home: &'a std::path::Path) -> Self {
-        self.home = Some(home);
         self
     }
 
@@ -182,8 +171,7 @@ impl<'a> StoreOpener<'a> {
     /// Does not check whether the database actually exists.  It merely
     /// constructs the path where the database would be if it existed.
     pub fn get_path(&self) -> std::path::PathBuf {
-        let path = self.config.path.as_deref().unwrap_or(std::path::Path::new(STORE_PATH));
-        self.home.map_or_else(|| path.to_owned(), |home| home.join(path))
+        self.home_dir.join(self.config.path.as_deref().unwrap_or(std::path::Path::new(STORE_PATH)))
     }
 
     /// Returns version of the database; or `None` if it does not exist.

--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -135,12 +135,12 @@ pub struct StoreOpener<'a> {
 }
 
 impl<'a> StoreOpener<'a> {
-    /// Initialises a new opener with given store configuration.
+    /// Initialises a new opener with given home directory and store config.
     pub fn new(home_dir: &'a std::path::Path, config: &'a StoreConfig) -> Self {
         Self { home_dir, config, read_only: false }
     }
 
-    /// Initialises a new opener using default store configuration.
+    /// Initialises a new opener with given home directory and default config.
     ///
     /// This is meant for tests only.  Production code should always read store
     /// configuration from a config file and use [`Self::new`] instead.

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -814,7 +814,7 @@ mod tests {
     #[test]
     fn test_clear_column() {
         let tmp_dir = tempfile::Builder::new().prefix("_test_clear_column").tempdir().unwrap();
-        let store = StoreOpener::with_default_config().home(tmp_dir.path()).open();
+        let store = StoreOpener::with_default_config(tmp_dir.path()).open();
         assert_eq!(store.get(DBCol::State, &[1]).unwrap(), None);
         {
             let mut store_update = store.store_update();
@@ -835,7 +835,7 @@ mod tests {
     #[test]
     fn rocksdb_merge_sanity() {
         let tmp_dir = tempfile::Builder::new().prefix("_test_snapshot_sanity").tempdir().unwrap();
-        let store = StoreOpener::with_default_config().home(tmp_dir.path()).open();
+        let store = StoreOpener::with_default_config(tmp_dir.path()).open();
         let ptr = (&*store.storage) as *const (dyn Database + 'static);
         let rocksdb = unsafe { &*(ptr as *const RocksDB) };
         assert_eq!(store.get(DBCol::State, &[1]).unwrap(), None);

--- a/genesis-tools/genesis-populate/src/main.rs
+++ b/genesis-tools/genesis-populate/src/main.rs
@@ -29,7 +29,7 @@ fn main() {
     let near_config = load_config(home_dir, GenesisValidationMode::Full)
         .unwrap_or_else(|e| panic!("Error loading config: {:#}", e));
 
-    let store = near_store::StoreOpener::new(&near_config.config.store).home(home_dir).open();
+    let store = near_store::StoreOpener::new(home_dir, &near_config.config.store).open();
     GenesisBuilder::from_config_and_store(home_dir, Arc::new(near_config.genesis), store)
         .add_additional_accounts(additional_accounts_num)
         .add_additional_accounts_contract(near_test_contracts::trivial_contract().to_vec())

--- a/genesis-tools/genesis-populate/src/state_dump.rs
+++ b/genesis-tools/genesis-populate/src/state_dump.rs
@@ -17,7 +17,7 @@ pub struct StateDump {
 
 impl StateDump {
     pub fn from_dir(dir: &Path, store_home_dir: &Path) -> Self {
-        let store = near_store::StoreOpener::with_default_config().home(store_home_dir).open();
+        let store = near_store::StoreOpener::with_default_config(store_home_dir).open();
         let state_file = dir.join(STATE_DUMP_FILE);
         store
             .load_from_file(DBCol::State, state_file.as_path())

--- a/nearcore/benches/store.rs
+++ b/nearcore/benches/store.rs
@@ -28,9 +28,8 @@ fn read_trie_items(bench: &mut Bencher, shard_id: usize, read_only: bool) {
 
     bench.iter(move || {
         tracing::info!(target: "neard", "{:?}", home_dir);
-        let store = near_store::StoreOpener::with_default_config(&home_dir)
-            .read_only(read_only)
-            .open();
+        let store =
+            near_store::StoreOpener::with_default_config(&home_dir).read_only(read_only).open();
 
         let chain_store =
             ChainStore::new(store.clone(), near_config.genesis.config.genesis_height, true);

--- a/nearcore/benches/store.rs
+++ b/nearcore/benches/store.rs
@@ -28,9 +28,8 @@ fn read_trie_items(bench: &mut Bencher, shard_id: usize, read_only: bool) {
 
     bench.iter(move || {
         tracing::info!(target: "neard", "{:?}", home_dir);
-        let store = near_store::StoreOpener::with_default_config()
+        let store = near_store::StoreOpener::with_default_config(&home_dir)
             .read_only(read_only)
-            .home(&home_dir)
             .open();
 
         let chain_store =

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -203,7 +203,7 @@ fn apply_store_migrations_if_exists(
 }
 
 fn init_and_migrate_store(home_dir: &Path, near_config: &NearConfig) -> anyhow::Result<Store> {
-    let opener = StoreOpener::new(&near_config.config.store).home(home_dir);
+    let opener = StoreOpener::new(home_dir, &near_config.config.store);
     let exists = apply_store_migrations_if_exists(&opener, near_config)?;
     let store = opener.open();
     if !exists {
@@ -381,7 +381,7 @@ pub fn recompress_storage(home_dir: &Path, opts: RecompressOpts) -> anyhow::Resu
             .map_err(|err| anyhow::anyhow!("setrlimit: NOFILE: {}", err))?;
     }
 
-    let src_opener = StoreOpener::new(&config.store).home(home_dir).read_only(true);
+    let src_opener = StoreOpener::new(home_dir, &config.store).read_only(true);
     let src_path = src_opener.get_path();
     if let Some(db_version) = src_opener.get_version_if_exists()? {
         anyhow::ensure!(
@@ -400,7 +400,7 @@ pub fn recompress_storage(home_dir: &Path, opts: RecompressOpts) -> anyhow::Resu
     // Note: opts.dest_dir is resolved relative to current working directory
     // (since it’s a command line option) which is why we set home to cwd.
     let cwd = std::env::current_dir()?;
-    let dst_opener = StoreOpener::new(&dst_config).home(&cwd);
+    let dst_opener = StoreOpener::new(&cwd, &dst_config);
     let dst_path = dst_opener.get_path();
     anyhow::ensure!(
         !dst_opener.check_if_exists(),

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -2130,7 +2130,7 @@ mod test {
             minimum_stake_divisor: Option<u64>,
         ) -> Self {
             let dir = tempfile::Builder::new().prefix(prefix).tempdir().unwrap();
-            let store = near_store::StoreOpener::with_default_config().home(dir.path()).open();
+            let store = near_store::StoreOpener::with_default_config(dir.path()).open();
             let all_validators = validators.iter().fold(BTreeSet::new(), |acc, x| {
                 acc.union(&x.iter().cloned().collect()).cloned().collect()
             });

--- a/runtime/runtime-params-estimator/src/function_call.rs
+++ b/runtime/runtime-params-estimator/src/function_call.rs
@@ -67,7 +67,7 @@ pub fn compute_function_call_cost(
     contract: &ContractCode,
 ) -> Gas {
     let workdir = tempfile::Builder::new().prefix("runtime_testbed").tempdir().unwrap();
-    let store = near_store::StoreOpener::with_default_config().home(workdir.path()).open();
+    let store = near_store::StoreOpener::with_default_config(workdir.path()).open();
     let cache_store = Arc::new(StoreCompiledContractCache { store });
     let cache: Option<&dyn CompiledContractCache> = Some(cache_store.as_ref());
     let protocol_version = ProtocolVersion::MAX;

--- a/runtime/runtime-params-estimator/src/gas_metering.rs
+++ b/runtime/runtime-params-estimator/src/gas_metering.rs
@@ -129,7 +129,7 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     let warmup_repeats = config.warmup_iters_per_block;
 
     let workdir = tempfile::Builder::new().prefix("runtime_testbed").tempdir().unwrap();
-    let store = near_store::StoreOpener::with_default_config().home(workdir.path()).open();
+    let store = near_store::StoreOpener::with_default_config(workdir.path()).open();
     let cache_store = Arc::new(StoreCompiledContractCache { store });
     let cache: Option<&dyn CompiledContractCache> = Some(cache_store.as_ref());
     let config_store = RuntimeConfigStore::new(None);

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -144,7 +144,7 @@ fn main() -> anyhow::Result<()> {
         let near_config = nearcore::load_config(&state_dump_path, GenesisValidationMode::Full)
             .context("Error loading config")?;
         let store =
-            near_store::StoreOpener::new(&near_config.config.store).home(&state_dump_path).open();
+            near_store::StoreOpener::new(&state_dump_path, &near_config.config.store).open();
         GenesisBuilder::from_config_and_store(
             &state_dump_path,
             Arc::new(near_config.genesis),

--- a/runtime/runtime-params-estimator/src/vm_estimator.rs
+++ b/runtime/runtime-params-estimator/src/vm_estimator.rs
@@ -84,7 +84,7 @@ fn precompilation_cost(
     let use_file_store = true;
     if use_file_store {
         let workdir = tempfile::Builder::new().prefix("runtime_testbed").tempdir().unwrap();
-        let store = near_store::StoreOpener::with_default_config().home(workdir.path()).open();
+        let store = near_store::StoreOpener::with_default_config(workdir.path()).open();
         cache_store1 = Arc::new(StoreCompiledContractCache { store });
         cache = Some(cache_store1.as_ref());
     } else {
@@ -156,7 +156,7 @@ pub(crate) fn compile_single_contract_cost(
     let contract = ContractCode::new(contract_bytes.to_vec(), None);
 
     let workdir = tempfile::Builder::new().prefix("runtime_testbed").tempdir().unwrap();
-    let store = near_store::StoreOpener::with_default_config().home(workdir.path()).open();
+    let store = near_store::StoreOpener::with_default_config(workdir.path()).open();
     let cache = Arc::new(StoreCompiledContractCache { store });
 
     measure_contract(vm_kind, metric, &contract, Some(cache.as_ref()))

--- a/test-utils/runtime-tester/src/run_test.rs
+++ b/test-utils/runtime-tester/src/run_test.rs
@@ -49,7 +49,7 @@ impl Scenario {
         } else {
             let tempdir = tempfile::tempdir()
                 .unwrap_or_else(|err| panic!("failed to create temporary directory: {}", err));
-            let store = near_store::StoreOpener::with_default_config().home(tempdir.path()).open();
+            let store = near_store::StoreOpener::with_default_config(tempdir.path()).open();
             (Some(tempdir), store)
         };
 

--- a/test-utils/store-validator/src/main.rs
+++ b/test-utils/store-validator/src/main.rs
@@ -30,7 +30,7 @@ fn main() {
     let near_config = load_config(home_dir, GenesisValidationMode::Full)
         .unwrap_or_else(|e| panic!("Error loading config: {:#}", e));
 
-    let store = near_store::StoreOpener::new(&near_config.config.store).home(home_dir).open();
+    let store = near_store::StoreOpener::new(home_dir, &near_config.config.store).open();
 
     let runtime_adapter: Arc<dyn RuntimeAdapter> =
         Arc::new(nearcore::NightshadeRuntime::from_config(home_dir, store.clone(), &near_config));

--- a/tools/mock_node/src/setup.rs
+++ b/tools/mock_node/src/setup.rs
@@ -34,7 +34,7 @@ fn setup_runtime(
     let store = if in_memory_storage {
         create_test_store()
     } else {
-        near_store::StoreOpener::new(&config.config.store).home(home_dir).open()
+        near_store::StoreOpener::new(home_dir, &config.config.store).open()
     };
 
     Arc::new(NightshadeRuntime::from_config(home_dir, store, config))

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -70,9 +70,8 @@ impl StateViewerSubCommand {
     pub fn run(self, home_dir: &Path, genesis_validation: GenesisValidationMode, readwrite: bool) {
         let near_config = load_config(home_dir, genesis_validation)
             .unwrap_or_else(|e| panic!("Error loading config: {:#}", e));
-        let store = near_store::StoreOpener::new(&near_config.config.store)
+        let store = near_store::StoreOpener::new(home_dir, &near_config.config.store)
             .read_only(!readwrite)
-            .home(home_dir)
             .open();
         match self {
             StateViewerSubCommand::Peers => peers(store),


### PR DESCRIPTION
Add home_dir as argument to StoreOpener::new and with_default_config
methods.  All call sites allready pass the home directory so this is
a purely refactoring change.  With that the home method is no longer
necessary.

Issue: https://github.com/near/nearcore/issues/6857