### PR TITLE
dump block transactions into a file

### DIFF
--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -19,7 +19,7 @@ use near_primitives_core::profile::ProfileData;
 pub type LogEntry = String;
 
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
-#[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone)]
+#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 pub struct Transaction {
     /// An account on which behalf transaction is signed
     pub signer_id: AccountId,
@@ -223,7 +223,7 @@ impl From<DeleteAccountAction> for Action {
 }
 
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
-#[derive(BorshSerialize, BorshDeserialize, Eq, Debug, Clone)]
+#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Eq, Debug, Clone)]
 #[borsh_init(init)]
 pub struct SignedTransaction {
     pub transaction: Transaction,

--- a/tools/state-viewer/README.md
+++ b/tools/state-viewer/README.md
@@ -90,6 +90,16 @@ Flags:
 
 * `--height` takes state from the genesis up to and including the given height. By default, dumps all available state.
 
+### `dump_tx`
+
+Saves all transactions of a block to a file.
+
+Flags:
+
+* `--height` specifies the block by its height.
+
+* `--account-ids` specifies the accounts as receivers of the transactions that need to be dumped. By default, all transactions will be dumped if this parameter is not set.
+
 ### `rocksdb_stats`
 
 Tool for measuring statistics of the store for each column:

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -161,14 +161,22 @@ pub struct DumpTxCmd {
     /// If not set, all account IDs will be dumped.
     #[clap(long)]
     account_ids: Option<Vec<AccountId>>,
+    /// Optionally, can specify the path of the output.
+    #[clap(long)]
+    output_path: Option<String>,
 }
 
 impl DumpTxCmd {
     pub fn run(self, home_dir: &Path, near_config: NearConfig, store: Store) {
-        match dump_tx(self.height, home_dir, near_config, store, self.account_ids.as_ref()) {
-            Ok(_) => (),
-            _ => panic!("error"),
-        }
+        dump_tx(
+            self.height,
+            home_dir,
+            near_config,
+            store,
+            self.account_ids.as_ref(),
+            self.output_path,
+        )
+        .expect("Failed to dump transaction...")
     }
 }
 

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -22,6 +22,9 @@ pub enum StateViewerSubCommand {
     DumpState(DumpStateCmd),
     #[clap(alias = "dump_state_redis")]
     DumpStateRedis(DumpStateRedisCmd),
+    /// Generate a file that contains all transactions from a block.
+    #[clap(alias = "dump_tx")]
+    DumpTx(DumpTxCmd),
     /// Print chain from start_index to end_index.
     Chain(ChainCmd),
     /// Replay headers from chain.
@@ -78,6 +81,7 @@ impl StateViewerSubCommand {
             StateViewerSubCommand::State => state(home_dir, near_config, store),
             StateViewerSubCommand::DumpState(cmd) => cmd.run(home_dir, near_config, store),
             StateViewerSubCommand::DumpStateRedis(cmd) => cmd.run(home_dir, near_config, store),
+            StateViewerSubCommand::DumpTx(cmd) => cmd.run(home_dir, near_config, store),
             StateViewerSubCommand::Chain(cmd) => cmd.run(home_dir, near_config, store),
             StateViewerSubCommand::Replay(cmd) => cmd.run(home_dir, near_config, store),
             StateViewerSubCommand::ApplyRange(cmd) => cmd.run(home_dir, near_config, store),
@@ -145,6 +149,26 @@ pub struct DumpStateRedisCmd {
 impl DumpStateRedisCmd {
     pub fn run(self, home_dir: &Path, near_config: NearConfig, store: Store) {
         dump_state_redis(self.height, home_dir, near_config, store);
+    }
+}
+
+#[derive(Parser)]
+pub struct DumpTxCmd {
+    /// Specify which block to dump transactions for.
+    #[clap(long)]
+    height: BlockHeight,
+    /// List of account IDs to dump.
+    /// If not set, all account IDs will be dumped.
+    #[clap(long)]
+    account_ids: Option<Vec<AccountId>>,
+}
+
+impl DumpTxCmd {
+    pub fn run(self, home_dir: &Path, near_config: NearConfig, store: Store) {
+        match dump_tx(self.height, home_dir, near_config, store, self.account_ids.as_ref()) {
+            Ok(_) => (),
+            _ => panic!("error"),
+        }
     }
 }
 

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -117,6 +117,7 @@ pub(crate) fn dump_tx(
     near_config: NearConfig,
     store: Store,
     select_account_ids: Option<&Vec<AccountId>>,
+    output_path: Option<String>,
 ) -> Result<(), Error> {
     let mut chain_store = ChainStore::new(
         store.clone(),
@@ -126,7 +127,11 @@ pub(crate) fn dump_tx(
     let hash = chain_store.get_block_hash_by_height(height)?;
     let block = chain_store.get_block(&hash)?;
     let txs = tx_dump(&mut chain_store, &block, select_account_ids);
-    fs::write(PathBuf::from(&home_dir).join("tx.json"), json!(txs).to_string())
+    let json_path = match output_path {
+        Some(path) => PathBuf::from(path),
+        None => PathBuf::from(&home_dir).join("tx.json"),
+    };
+    fs::write(json_path, json!(txs).to_string())
         .expect("Error writing the results to a json file.");
     return Ok(());
 }

--- a/tools/state-viewer/src/lib.rs
+++ b/tools/state-viewer/src/lib.rs
@@ -7,5 +7,6 @@ mod commands;
 mod epoch_info;
 mod rocksdb_stats;
 mod state_dump;
+mod tx_dump;
 
 pub use cli::StateViewerSubCommand;

--- a/tools/state-viewer/src/tx_dump.rs
+++ b/tools/state-viewer/src/tx_dump.rs
@@ -6,7 +6,7 @@ use near_primitives::transaction::SignedTransaction;
 
 /// Returns a list of transactions found in the block.
 pub fn tx_dump(
-    chain_store: &mut ChainStore,
+    chain_store: &ChainStore,
     block: &Block,
     select_account_ids: Option<&Vec<AccountId>>,
 ) -> Vec<SignedTransaction> {
@@ -38,11 +38,3 @@ fn should_include_signed_transaction(
         Some(specified_ids) => specified_ids.contains(&signed_transaction.transaction.receiver_id),
     }
 }
-
-// #[cfg(test)]
-// mod test {
-//     #[test]
-//     fn test_tx_dump() {
-//
-//     }
-// }

--- a/tools/state-viewer/src/tx_dump.rs
+++ b/tools/state-viewer/src/tx_dump.rs
@@ -1,0 +1,48 @@
+use near_chain::ChainStore;
+use near_chain::ChainStoreAccess;
+use near_primitives::account::id::AccountId;
+use near_primitives::block::Block;
+use near_primitives::transaction::SignedTransaction;
+
+/// Returns a list of transactions found in the block.
+pub fn tx_dump(
+    chain_store: &mut ChainStore,
+    block: &Block,
+    select_account_ids: Option<&Vec<AccountId>>,
+) -> Vec<SignedTransaction> {
+    let chunks = block.chunks();
+    let mut res = vec![];
+    for (_, chunk_header) in chunks.iter().enumerate() {
+        res.extend(
+            chain_store
+                .get_chunk(&chunk_header.chunk_hash())
+                .unwrap()
+                .transactions()
+                .into_iter()
+                .filter(|signed_transaction| {
+                    should_include_signed_transaction(signed_transaction, select_account_ids)
+                })
+                .map(|signed_transaction| signed_transaction.clone())
+                .collect::<Vec<_>>(),
+        );
+    }
+    return res;
+}
+
+fn should_include_signed_transaction(
+    signed_transaction: &SignedTransaction,
+    select_account_ids: Option<&Vec<AccountId>>,
+) -> bool {
+    match select_account_ids {
+        None => true,
+        Some(specified_ids) => specified_ids.contains(&signed_transaction.transaction.receiver_id),
+    }
+}
+
+// #[cfg(test)]
+// mod test {
+//     #[test]
+//     fn test_tx_dump() {
+//
+//     }
+// }


### PR DESCRIPTION
### Description
This PR adds a new command `dump_tx` to allow transactions in a certain block (specified by its height) to be dumped into a json file, while receiver accounts can be specified in the process, too.

### Test plan

  - Spin up a mainnet node (go/own-mainnet)
  - Clone this repo & branch and compile to get the binary
  - `./target/release/neard --home [YOUR_MAINNET_DIR, e.g.: /x/y/z] view_state dump_tx --height [YOUR_HEIGHT, e.g.: 33043] --account-ids [ACCOUNTS_OF_INTEREST]`


### First round reviewer
 - @mzhangmzz 
 - @mm-near 