### PR TITLE
store: replace Store::get_rocksdb with Store::flush

### DIFF
--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -464,7 +464,7 @@ impl Database for TestDB {
         }
         Ok(())
     }
-    
+
     fn flush(&self) -> Result<(), DBError> {
         Ok(())
     }

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -278,12 +278,8 @@ pub(crate) trait Database: Sync + Send {
         key_prefix: &'a [u8],
     ) -> Box<dyn Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a>;
     fn write(&self, batch: DBTransaction) -> Result<(), DBError>;
-    fn flush(&self) -> Result<(), DBError> {
-        Ok(())
-    }
-    fn get_store_statistics(&self) -> Option<StoreStatistics> {
-        None
-    }
+    fn flush(&self) -> Result<(), DBError>;
+    fn get_store_statistics(&self) -> Option<StoreStatistics>;
 }
 
 impl Database for RocksDB {
@@ -467,6 +463,14 @@ impl Database for TestDB {
             };
         }
         Ok(())
+    }
+    
+    fn flush(&self) -> Result<(), DBError> {
+        Ok(())
+    }
+
+    fn get_store_statistics(&self) -> Option<StoreStatistics> {
+        None
     }
 }
 

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -149,8 +149,9 @@ impl Store {
         self.storage.write(transaction).map_err(io::Error::from)
     }
 
-    pub fn get_rocksdb(&self) -> Option<&RocksDB> {
-        self.storage.as_rocksdb()
+    /// If the storage is backed by disk, flushes any in-memory data to disk.
+    pub fn flush(&self) -> io::Result<()> {
+        self.storage.flush().map_err(io::Error::from)
     }
 
     pub fn get_store_statistics(&self) -> Option<StoreStatistics> {

--- a/runtime/runtime-params-estimator/src/testbed.rs
+++ b/runtime/runtime-params-estimator/src/testbed.rs
@@ -140,9 +140,7 @@ impl RuntimeTestbed {
 
     /// Flushes RocksDB memtable
     pub fn flush_db_write_buffer(&mut self) {
-        let store = self.tries.get_store();
-        let rocksdb = store.get_rocksdb().unwrap();
-        rocksdb.flush().unwrap();
+        self.tries.get_store().flush().unwrap();
     }
 
     pub fn store(&mut self) -> Store {


### PR DESCRIPTION
Store::get_rocksdb method turns Store into a leaky abstraction as it
exposes the wrapped RocksDB to the clients.  At the same time, it’s
used in RuntimeTestbed only to flush the database.  Therefore, it can
be trivially replaced by a flush method which leaves the abstraction
intact.