### PR TITLE
Fix wrong command in README of pytest

### DIFF
--- a/pytest/tests/loadtest/README.md
+++ b/pytest/tests/loadtest/README.md
@@ -6,7 +6,7 @@ This test consists of two parts:
 Init your own localnet:
 
 ```shell
-./target/debug/neard --home ~/.near_tmp init --chain-id localnet --num-shards=5
+./target/releas/neard --home ~/.near_tmp init --chain-id localnet --num-shards=5
 ```
 
 

--- a/pytest/tests/loadtest/README.md
+++ b/pytest/tests/loadtest/README.md
@@ -1,22 +1,24 @@
 # Loadtest 
 
-This test consists of two parts:
+This test requires a few steps.  Firstly, build the binary:
 
+```shell
+make neard-release
+```
 
-Init your own localnet:
+Secondly, initialise your own localnet:
 
 ```shell
 ./target/release/neard --home ~/.near_tmp init --chain-id localnet --num-shards=5
 ```
 
-
-Create accounts and deploy the contract:
+Thurdly, create accounts and deploy the contract:
 
 ```shell
 python3 pytest/tests/loadtest/setup.py --home=~/.near_tmp --num_accounts=5
 ```
 
-Run the test:
+And lastly, run the test:
 
 ```shell
 python3 pytest/tests/loadtest/loadtest.py --home=~/.near_tmp --num_accounts=5 --num_requests=1000

--- a/pytest/tests/loadtest/README.md
+++ b/pytest/tests/loadtest/README.md
@@ -6,7 +6,7 @@ This test consists of two parts:
 Init your own localnet:
 
 ```shell
-./target/releas/neard --home ~/.near_tmp init --chain-id localnet --num-shards=5
+./target/release/neard --home ~/.near_tmp init --chain-id localnet --num-shards=5
 ```
 
 


### PR DESCRIPTION
`neard` lives really under `release` but not `debug`.