### PR TITLE
Removed custom tag from protobuf presubmit agent

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,7 +8,7 @@ steps:
       buf breaking --against '.git#branch=master'
     timeout: 30
     agents:
-    - "rust=1.61.0"
+    - "distro=amazonlinux"
 
   - label: "cargo test integration-tests*"
     command: |


### PR DESCRIPTION
buf is now installed on the default agent.