### PR TITLE
feat: estimate fn call action without loading cost

### DIFF
--- a/runtime/runtime-params-estimator/src/cost.rs
+++ b/runtime/runtime-params-estimator/src/cost.rs
@@ -84,11 +84,11 @@ pub enum Cost {
     /// for all costs of calling a function that are already known on the caller
     /// side.
     ///
-    /// Estimation: Measure the cost to execute a transaction with a call to the
-    /// method "". This is a hack to abort measurement before loading the
-    /// executable, which is a cost measured and charged separately. Subtract
-    /// the receipt creating cost from that, as that is already charged
-    /// separately.
+    /// Estimation: Measure the cost to execute a NOP function on a tiny
+    /// contract. To filter out block and general receipt processing overhead,
+    /// the difference between calling it N +1 times and calling it once in a
+    /// transaction is divided by N. Executable loading cost is also subtracted
+    /// from the final result because this is charged separately.
     ActionFunctionCallBase,
     /// Estimates `action_creation_config.function_call_cost_per_byte`, which is
     /// the incremental cost for each byte of the method name and method

--- a/runtime/runtime-params-estimator/src/cost.rs
+++ b/runtime/runtime-params-estimator/src/cost.rs
@@ -84,9 +84,11 @@ pub enum Cost {
     /// for all costs of calling a function that are already known on the caller
     /// side.
     ///
-    /// Estimation: Measure the cost to execute a transaction with an empty
-    /// function with no arguments. Subtract the receipt creating cost from
-    /// that, as that is already charged separately.
+    /// Estimation: Measure the cost to execute a transaction with a call to the
+    /// method "". This is a hack to abort measurement before loading the
+    /// executable, which is a cost measured and charged separately. Subtract
+    /// the receipt creating cost from that, as that is already charged
+    /// separately.
     ActionFunctionCallBase,
     /// Estimates `action_creation_config.function_call_cost_per_byte`, which is
     /// the incremental cost for each byte of the method name and method

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -81,8 +81,9 @@ impl<'c> Testbed<'c> {
         &'a mut self,
         blocks: Vec<Vec<SignedTransaction>>,
         block_latency: usize,
-        allow_failures: bool,
     ) -> Vec<(GasCost, HashMap<ExtCosts, u64>)> {
+        let allow_failures = false;
+
         let mut res = Vec::with_capacity(blocks.len());
 
         for block in blocks {
@@ -127,7 +128,7 @@ impl<'c> Testbed<'c> {
         caching_storage
     }
 
-    fn clear_caches(&mut self) {
+    pub(crate) fn clear_caches(&mut self) {
         // Flush out writes hanging in memtable
         self.inner.flush_db_write_buffer();
 

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -81,9 +81,8 @@ impl<'c> Testbed<'c> {
         &'a mut self,
         blocks: Vec<Vec<SignedTransaction>>,
         block_latency: usize,
+        allow_failures: bool,
     ) -> Vec<(GasCost, HashMap<ExtCosts, u64>)> {
-        let allow_failures = false;
-
         let mut res = Vec::with_capacity(blocks.len());
 
         for block in blocks {

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -266,7 +266,7 @@ fn action_receipt_creation(ctx: &mut EstimatorContext) -> GasCost {
     let block_size = 100;
     // Sender != Receiver means this will be executed over two blocks.
     let block_latency = 1;
-    let cost = transaction_cost_ext(ctx, block_size, &mut make_transaction, block_latency).0;
+    let cost = transaction_cost_ext(ctx, block_size, &mut make_transaction, block_latency, false).0;
 
     ctx.cached.action_receipt_creation = Some(cost.clone());
     cost
@@ -303,7 +303,7 @@ fn action_transfer(ctx: &mut EstimatorContext) -> GasCost {
         let block_size = 100;
         // Transferring from one account to another may touch two shards, thus executes over two blocks.
         let block_latency = 1;
-        transaction_cost_ext(ctx, block_size, &mut make_transaction, block_latency).0
+        transaction_cost_ext(ctx, block_size, &mut make_transaction, block_latency, false).0
     };
 
     let base_cost = action_receipt_creation(ctx);
@@ -327,7 +327,7 @@ fn action_create_account(ctx: &mut EstimatorContext) -> GasCost {
         let block_size = 100;
         // Creating a new account is initiated by an account that potentially is on a different shard. Thus, it executes over two blocks.
         let block_latency = 1;
-        transaction_cost_ext(ctx, block_size, &mut make_transaction, block_latency).0
+        transaction_cost_ext(ctx, block_size, &mut make_transaction, block_latency, false).0
     };
 
     let base_cost = action_receipt_creation(ctx);
@@ -348,7 +348,7 @@ fn action_delete_account(ctx: &mut EstimatorContext) -> GasCost {
         let block_size = 100;
         // Deleting an account is initiated by an account that potentially is on a different shard. Thus, it executes over two blocks.
         let block_latency = 1;
-        transaction_cost_ext(ctx, block_size, &mut make_transaction, block_latency).0
+        transaction_cost_ext(ctx, block_size, &mut make_transaction, block_latency, false).0
     };
 
     let base_cost = action_sir_receipt_creation(ctx);
@@ -592,7 +592,7 @@ fn deploy_contract_cost(
     };
     // Use a small block size since deployments are gas heavy.
     let block_size = 5;
-    let (total_cost, _ext) = transaction_cost_ext(ctx, block_size, &mut make_transaction, 0);
+    let (total_cost, _ext) = transaction_cost_ext(ctx, block_size, &mut make_transaction, 0, false);
     let base_cost = action_sir_receipt_creation(ctx);
 
     total_cost.saturating_sub(&base_cost, &NonNegativeTolerance::PER_MILLE)
@@ -660,8 +660,21 @@ fn pure_deploy_bytes(ctx: &mut EstimatorContext) -> GasCost {
     (cost_4mb - cost_empty) / (large_code_len - small_code_len) as u64
 }
 
+/// Base cost for a fn call action, without receipt creation or contract loading.
+///
+/// Measure the cost of executing the method with empty name, which aborts even
+/// before loading the executable. Then subtract receipt creation cost.
 fn action_function_call_base(ctx: &mut EstimatorContext) -> GasCost {
-    let total_cost = noop_function_call_cost(ctx);
+    let mut make_transaction = |tb: &mut TransactionBuilder| -> SignedTransaction {
+        let sender = tb.random_unused_account();
+        // Call empty method.
+        tb.transaction_from_function_call(sender, "", Vec::new())
+    };
+    let block_size = 10;
+    // Failure is expected since calling the empty method is not valid.
+    let allow_failures = true;
+    let (total_cost, _ext_costs) =
+        transaction_cost_ext(ctx, block_size, &mut make_transaction, 0, allow_failures);
     let base_cost = action_sir_receipt_creation(ctx);
 
     total_cost.saturating_sub(&base_cost, &NonNegativeTolerance::PER_MILLE)
@@ -693,7 +706,7 @@ fn inner_action_function_call_per_byte(ctx: &mut EstimatorContext, arg_len: usiz
     };
     let block_size = 5;
     let block_latency = 0;
-    transaction_cost_ext(ctx, block_size, &mut make_transaction, block_latency).0
+    transaction_cost_ext(ctx, block_size, &mut make_transaction, block_latency, false).0
 }
 
 fn contract_loading_base(ctx: &mut EstimatorContext) -> GasCost {
@@ -1107,7 +1120,7 @@ fn apply_block_cost(ctx: &mut EstimatorContext) -> GasCost {
     let n_blocks = testbed.config.warmup_iters_per_block + testbed.config.iter_per_block;
     let blocks = vec![vec![]; n_blocks];
 
-    let measurements = testbed.measure_blocks(blocks, 0);
+    let measurements = testbed.measure_blocks(blocks, 0, false);
     let measurements =
         measurements.into_iter().skip(testbed.config.warmup_iters_per_block).collect::<Vec<_>>();
     let (gas_cost, _ext_costs) =

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -659,10 +659,10 @@ fn pure_deploy_bytes(ctx: &mut EstimatorContext) -> GasCost {
 
 /// Base cost for a fn call action, without receipt creation or contract loading.
 fn action_function_call_base(ctx: &mut EstimatorContext) -> GasCost {
-    let inner_iterations = 100;
+    let n_actions = 100;
     let code = generate_data_only_contract(0, &VMConfig::test());
     // This returns a cost without block/transaction/receipt overhead.
-    let base_cost = fn_cost_in_contract(ctx, "main", &code, inner_iterations);
+    let base_cost = fn_cost_in_contract(ctx, "main", &code, n_actions);
     // Executable loading is a separately charged step, so it must be subtracted on the action cost.
     let executable_loading_cost = contract_loading_base(ctx);
     base_cost.saturating_sub(&executable_loading_cost, &NonNegativeTolerance::PER_MILLE)
@@ -716,13 +716,13 @@ fn contract_loading_base_per_byte(ctx: &mut EstimatorContext) -> (GasCost, GasCo
 }
 fn function_call_per_storage_byte(ctx: &mut EstimatorContext) -> GasCost {
     let vm_config = VMConfig::test();
-    let inner_iterations = 5;
+    let n_actions = 5;
 
     let small_code = generate_data_only_contract(0, &vm_config);
-    let small_cost = fn_cost_in_contract(ctx, "main", &small_code, inner_iterations);
+    let small_cost = fn_cost_in_contract(ctx, "main", &small_code, n_actions);
 
     let large_code = generate_data_only_contract(4_000_000, &vm_config);
-    let large_cost = fn_cost_in_contract(ctx, "main", &large_code, inner_iterations);
+    let large_cost = fn_cost_in_contract(ctx, "main", &large_code, n_actions);
 
     large_cost.saturating_sub(&small_cost, &NonNegativeTolerance::PER_MILLE)
         / (large_code.len() - small_code.len()) as u64

--- a/runtime/runtime-params-estimator/src/trie.rs
+++ b/runtime/runtime-params-estimator/src/trie.rs
@@ -45,7 +45,7 @@ pub(crate) fn write_node(
             .map(|value| vec![tb.account_insert_key(signer.clone(), key.as_bytes(), *value)])
             .take(measured_iters + warmup_iters),
     );
-    let results = &testbed.measure_blocks(blocks, block_latency, false)[1..];
+    let results = &testbed.measure_blocks(blocks, block_latency)[1..];
     let (short_key_results, long_key_results) = results.split_at(measured_iters + warmup_iters);
     let (cost_short_key, ext_cost_short_key) = aggregate_per_block_measurements(
         testbed.config,
@@ -100,7 +100,7 @@ pub(crate) fn read_node_from_db(
         iter::repeat_with(|| vec![tb.account_has_key(signer.clone(), &key)])
             .take(measured_iters + warmup_iters),
     );
-    let results = &testbed.measure_blocks(blocks, block_latency, false)[1..];
+    let results = &testbed.measure_blocks(blocks, block_latency)[1..];
     let (short_key_results, long_key_results) = results.split_at(measured_iters + warmup_iters);
     let (cost_short_key, ext_cost_short_key) = aggregate_per_block_measurements(
         testbed.config,

--- a/runtime/runtime-params-estimator/src/trie.rs
+++ b/runtime/runtime-params-estimator/src/trie.rs
@@ -45,7 +45,7 @@ pub(crate) fn write_node(
             .map(|value| vec![tb.account_insert_key(signer.clone(), key.as_bytes(), *value)])
             .take(measured_iters + warmup_iters),
     );
-    let results = &testbed.measure_blocks(blocks, block_latency)[1..];
+    let results = &testbed.measure_blocks(blocks, block_latency, false)[1..];
     let (short_key_results, long_key_results) = results.split_at(measured_iters + warmup_iters);
     let (cost_short_key, ext_cost_short_key) = aggregate_per_block_measurements(
         testbed.config,
@@ -100,7 +100,7 @@ pub(crate) fn read_node_from_db(
         iter::repeat_with(|| vec![tb.account_has_key(signer.clone(), &key)])
             .take(measured_iters + warmup_iters),
     );
-    let results = &testbed.measure_blocks(blocks, block_latency)[1..];
+    let results = &testbed.measure_blocks(blocks, block_latency, false)[1..];
     let (short_key_results, long_key_results) = results.split_at(measured_iters + warmup_iters);
     let (cost_short_key, ext_cost_short_key) = aggregate_per_block_measurements(
         testbed.config,

--- a/runtime/runtime-params-estimator/src/utils.rs
+++ b/runtime/runtime-params-estimator/src/utils.rs
@@ -35,7 +35,7 @@ pub(crate) fn transaction_cost(
     make_transaction: &mut dyn FnMut(&mut TransactionBuilder) -> SignedTransaction,
 ) -> GasCost {
     let block_size = 100;
-    let (gas_cost, _ext_costs) = transaction_cost_ext(ctx, block_size, make_transaction, 0, false);
+    let (gas_cost, _ext_costs) = transaction_cost_ext(ctx, block_size, make_transaction, 0);
     gas_cost
 }
 
@@ -45,7 +45,6 @@ pub(crate) fn transaction_cost_ext(
     block_size: usize,
     make_transaction: &mut dyn FnMut(&mut TransactionBuilder) -> SignedTransaction,
     block_latency: usize,
-    allow_failures: bool,
 ) -> (GasCost, HashMap<ExtCosts, u64>) {
     let measurement_overhead = overhead_per_measured_block(ctx, block_latency);
 
@@ -64,8 +63,8 @@ pub(crate) fn transaction_cost_ext(
         blocks
     };
 
-    let measurements = testbed.measure_blocks(blocks, block_latency, allow_failures);
-    let mut measurements =
+    let measurements = testbed.measure_blocks(blocks, block_latency);
+    let measurements =
         measurements.into_iter().skip(testbed.config.warmup_iters_per_block).collect::<Vec<_>>();
 
     aggregate_per_block_measurements(
@@ -117,7 +116,7 @@ pub(crate) fn fn_cost_count(
         tb.transaction_from_function_call(sender, method, Vec::new())
     };
     let (gas_cost, ext_costs) =
-        transaction_cost_ext(ctx, block_size, &mut make_transaction, block_latency, false);
+        transaction_cost_ext(ctx, block_size, &mut make_transaction, block_latency);
     let ext_cost = ext_costs[&ext_cost];
     (gas_cost, ext_cost)
 }
@@ -182,7 +181,7 @@ pub(crate) fn fn_cost_with_setup(
             blocks
         };
 
-        let measurements = testbed.measure_blocks(blocks, 0, false);
+        let measurements = testbed.measure_blocks(blocks, 0);
         // Filter out setup blocks.
         let measurements: Vec<_> = measurements
             .into_iter()
@@ -225,6 +224,7 @@ pub(crate) fn fn_cost_in_contract(
         let tb = testbed.transaction_builder();
         std::iter::repeat_with(|| tb.random_unused_account()).take(n_blocks).collect::<Vec<_>>()
     };
+    testbed.clear_caches();
 
     for account in &chosen_accounts {
         let tb = testbed.transaction_builder();
@@ -248,7 +248,7 @@ pub(crate) fn fn_cost_in_contract(
         blocks
     };
 
-    let mut measurements = testbed.measure_blocks(blocks, 0, false);
+    let mut measurements = testbed.measure_blocks(blocks, 0);
     measurements.drain(0..ctx.config.warmup_iters_per_block);
 
     let (gas_cost, _ext_costs) =

--- a/runtime/runtime-params-estimator/src/utils.rs
+++ b/runtime/runtime-params-estimator/src/utils.rs
@@ -208,21 +208,24 @@ pub(crate) fn fn_cost_with_setup(
 /// this causes the contract to be deployed once in every iteration. Therefore,
 /// whenever possible, prefer to add a method to the generic test contract.
 ///
-/// The no-op function call cost is NOT subtracted.
+/// The measured cost is the pure cost of executing a function call action. The
+/// overhead of block, transaction, and receipt processing is already subtracted
+/// in the returned result. It does so by executing the method n+1 times in a
+/// single transaction, and subtract the cost of a transaction that calls the
+/// method once, before dividing by n.
 pub(crate) fn fn_cost_in_contract(
     ctx: &mut EstimatorContext,
     method: &str,
     code: &[u8],
-    block_size: usize,
+    n_actions: usize,
 ) -> GasCost {
-    let block_latency = 0;
-    let overhead = overhead_per_measured_block(ctx, block_latency);
-    let n_blocks = ctx.config.warmup_iters_per_block + ctx.config.iter_per_block;
+    let n_warmup_blocks = ctx.config.warmup_iters_per_block;
+    let n_blocks = n_warmup_blocks + ctx.config.iter_per_block;
     let mut testbed = ctx.testbed();
 
-    let chosen_accounts = {
+    let mut chosen_accounts = {
         let tb = testbed.transaction_builder();
-        std::iter::repeat_with(|| tb.random_unused_account()).take(n_blocks).collect::<Vec<_>>()
+        std::iter::repeat_with(|| tb.random_unused_account()).take(n_blocks + 1).collect::<Vec<_>>()
     };
     testbed.clear_caches();
 
@@ -234,26 +237,47 @@ pub(crate) fn fn_cost_in_contract(
         testbed.process_block(vec![setup_tx], 0);
     }
 
-    let blocks = {
-        let mut blocks = Vec::with_capacity(n_blocks);
-        for account in chosen_accounts {
-            let tb = testbed.transaction_builder();
-            let mut block = Vec::new();
-            for _ in 0..block_size {
-                let tx = tb.transaction_from_function_call(account.clone(), method, Vec::new());
-                block.push(tx);
-            }
-            blocks.push(block);
-        }
-        blocks
-    };
+    let mut blocks = Vec::with_capacity(n_blocks);
+    // Measurement blocks with single tx with many actions.
+    for account in chosen_accounts.drain(..n_blocks) {
+        let actions = std::iter::repeat_with(|| function_call_action(method.to_string()))
+            .take(n_actions)
+            .collect();
+        let tx = testbed.transaction_builder().transaction_from_actions(
+            account.clone(),
+            account,
+            actions,
+        );
+        blocks.push(vec![tx]);
+    }
+    // Base with single tx with single action. Insert it after warm-up blocks.
+    let final_account = chosen_accounts.pop().unwrap();
+    let base_tx = testbed.transaction_builder().transaction_from_actions(
+        final_account.clone(),
+        final_account,
+        vec![function_call_action(method.to_string())],
+    );
+    blocks.insert(n_warmup_blocks, vec![base_tx]);
 
     let mut measurements = testbed.measure_blocks(blocks, 0);
-    measurements.drain(0..ctx.config.warmup_iters_per_block);
+    measurements.drain(0..n_warmup_blocks);
 
+    let (base_gas_cost, _base_ext_costs) = measurements.remove(0);
+    // Do not subtract block overhead because we already subtract the base.
+    let overhead = None;
+    let block_size = 1;
     let (gas_cost, _ext_costs) =
-        aggregate_per_block_measurements(ctx.config, block_size, measurements, Some(overhead));
-    gas_cost
+        aggregate_per_block_measurements(ctx.config, block_size, measurements, overhead);
+    gas_cost.saturating_sub(&base_gas_cost, &NonNegativeTolerance::Strict) / (n_actions - 1) as u64
+}
+
+fn function_call_action(method_name: String) -> Action {
+    Action::FunctionCall(near_primitives::transaction::FunctionCallAction {
+        method_name,
+        args: Vec::new(),
+        gas: 10u64.pow(15),
+        deposit: 0,
+    })
 }
 
 pub(crate) fn aggregate_per_block_measurements(


### PR DESCRIPTION
`action_function_call_*` costs are currently used to also cover contract
loading. But we want to give `wasm_contract_loading_*` costs meaningful
values and consequently reduce `action_function_call_*`.

This adjusts the `ActionFunctionCallBase` estimation to not include
contract loading costs. The difference is rather singificant since the
test contract used before was almost 100kB in size.

This change also introduces an approach of subtracting receipt overhead
completely, by executing multiple actions into one receipt.