### PR TITLE
runtime-params-estimator: use in-memory store

### DIFF
--- a/runtime/runtime-params-estimator/src/function_call.rs
+++ b/runtime/runtime-params-estimator/src/function_call.rs
@@ -70,8 +70,7 @@ fn compute_function_call_cost(
     warmup_repeats: u64,
     contract: &ContractCode,
 ) -> GasCost {
-    let workdir = tempfile::Builder::new().prefix("runtime_testbed").tempdir().unwrap();
-    let store = near_store::StoreOpener::with_default_config(workdir.path()).open();
+    let store = near_store::test_utils::create_test_store();
     let cache_store = Arc::new(StoreCompiledContractCache { store });
     let cache: Option<&dyn CompiledContractCache> = Some(cache_store.as_ref());
     let protocol_version = ProtocolVersion::MAX;

--- a/runtime/runtime-params-estimator/src/gas_metering.rs
+++ b/runtime/runtime-params-estimator/src/gas_metering.rs
@@ -128,8 +128,7 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     let vm_kind = config.vm_kind;
     let warmup_repeats = config.warmup_iters_per_block;
 
-    let workdir = tempfile::Builder::new().prefix("runtime_testbed").tempdir().unwrap();
-    let store = near_store::StoreOpener::with_default_config(workdir.path()).open();
+    let store = near_store::test_utils::create_test_store();
     let cache_store = Arc::new(StoreCompiledContractCache { store });
     let cache: Option<&dyn CompiledContractCache> = Some(cache_store.as_ref());
     let config_store = RuntimeConfigStore::new(None);

--- a/runtime/runtime-params-estimator/src/vm_estimator.rs
+++ b/runtime/runtime-params-estimator/src/vm_estimator.rs
@@ -81,10 +81,9 @@ fn precompilation_cost(
     let cache_store1: Arc<StoreCompiledContractCache>;
     let cache_store2: Arc<MockCompiledContractCache>;
     let cache: Option<&dyn CompiledContractCache>;
-    let use_file_store = true;
-    if use_file_store {
-        let workdir = tempfile::Builder::new().prefix("runtime_testbed").tempdir().unwrap();
-        let store = near_store::StoreOpener::with_default_config(workdir.path()).open();
+    let use_store = true;
+    if use_store {
+        let store = near_store::test_utils::create_test_store();
         cache_store1 = Arc::new(StoreCompiledContractCache { store });
         cache = Some(cache_store1.as_ref());
     } else {
@@ -155,8 +154,7 @@ pub(crate) fn compile_single_contract_cost(
 ) -> GasCost {
     let contract = ContractCode::new(contract_bytes.to_vec(), None);
 
-    let workdir = tempfile::Builder::new().prefix("runtime_testbed").tempdir().unwrap();
-    let store = near_store::StoreOpener::with_default_config(workdir.path()).open();
+    let store = near_store::test_utils::create_test_store();
     let cache = Arc::new(StoreCompiledContractCache { store });
 
     measure_contract(vm_kind, metric, &contract, Some(cache.as_ref()))


### PR DESCRIPTION
Rather than creating a temporary directory with a RocksDB database,
use a test store which is a simple in-memory store.