### PR TITLE
fix: state-viewer starting timestamp

### DIFF
--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -30,6 +30,7 @@ pub const TGAS: u64 = 1024 * 1024 * 1024 * 1024;
 
 struct ProgressReporter {
     cnt: AtomicU64,
+    // Timestamp to make relative measurements of block processing speed (in ms)
     ts: AtomicU64,
     all: u64,
     skipped: AtomicU64,

--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -22,11 +22,6 @@ use near_primitives::types::{BlockHeight, ShardId};
 use near_store::{get, DBCol, Store};
 use nearcore::NightshadeRuntime;
 
-fn timestamp() -> u64 {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs()
-}
-
 fn timestamp_ms() -> u64 {
     use std::time::{SystemTime, UNIX_EPOCH};
     SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64
@@ -364,7 +359,7 @@ pub fn apply_chain_range(
     let range = start_height..=end_height;
     let progress_reporter = ProgressReporter {
         cnt: AtomicU64::new(0),
-        ts: AtomicU64::new(timestamp()),
+        ts: AtomicU64::new(timestamp_ms()),
         all: end_height - start_height,
         skipped: AtomicU64::new(0),
         empty_blocks: AtomicU64::new(0),


### PR DESCRIPTION
Fix typo leading to big value in the first progress report:

```
Printing results including outcomes of applying receipts
Processed 50 blocks, 1653136875922 ms passed, 0.0000 blocks per second (0 skipped), 4992473365.28 secs remaining 3 empty blocks 204.21 avg gas per non-empty block
Processed 100 blocks, 97978 ms passed, 0.5103 blocks per second (0 skipped), 197.92 secs remaining 4 empty blocks 199.30 avg gas per non-empty block
```

## Testing
Manual run