### PR TITLE
refactor(mock-node): remove GetChainTargetBlockHeight

### DIFF
--- a/tools/mock_node/benches/sync.rs
+++ b/tools/mock_node/benches/sync.rs
@@ -5,7 +5,7 @@ use actix::System;
 use anyhow::anyhow;
 use criterion::Criterion;
 use flate2::read::GzDecoder;
-use mock_node::setup::setup_mock_node;
+use mock_node::setup::{setup_mock_node, MockNode};
 use mock_node::MockNetworkConfig;
 use near_actix_test_utils::{block_on_interruptible, setup_actix};
 use near_chain_configs::GenesisValidationMode;
@@ -102,7 +102,7 @@ fn do_bench(c: &mut Criterion, home_archive: &str, target_height: Option<BlockHe
             let tempdir = tempfile::Builder::new().prefix("mock_node").tempdir().unwrap();
             let network_config = MockNetworkConfig::with_delay(Duration::from_millis(100));
             let servers = block_on_interruptible(&sys, async move {
-                let (_client, view_client, servers, target_height) = setup_mock_node(
+                let MockNode {view_client, servers, target_height, ..} = setup_mock_node(
                     tempdir.path(),
                     home.as_path(),
                     near_config,

--- a/tools/mock_node/benches/sync.rs
+++ b/tools/mock_node/benches/sync.rs
@@ -6,7 +6,7 @@ use anyhow::anyhow;
 use criterion::Criterion;
 use flate2::read::GzDecoder;
 use mock_node::setup::setup_mock_node;
-use mock_node::{GetChainTargetBlockHeight, MockNetworkConfig};
+use mock_node::MockNetworkConfig;
 use near_actix_test_utils::{block_on_interruptible, setup_actix};
 use near_chain_configs::GenesisValidationMode;
 use near_client::GetBlock;
@@ -102,7 +102,7 @@ fn do_bench(c: &mut Criterion, home_archive: &str, target_height: Option<BlockHe
             let tempdir = tempfile::Builder::new().prefix("mock_node").tempdir().unwrap();
             let network_config = MockNetworkConfig::with_delay(Duration::from_millis(100));
             let servers = block_on_interruptible(&sys, async move {
-                let (mock_network, _client, view_client, servers) = setup_mock_node(
+                let (_client, view_client, servers, target_height) = setup_mock_node(
                     tempdir.path(),
                     home.as_path(),
                     near_config,
@@ -112,8 +112,6 @@ fn do_bench(c: &mut Criterion, home_archive: &str, target_height: Option<BlockHe
                     target_height,
                     false,
                 );
-                let target_height =
-                    mock_network.send(GetChainTargetBlockHeight).await.unwrap();
 
                 let started = Instant::now();
                 loop {

--- a/tools/mock_node/src/lib.rs
+++ b/tools/mock_node/src/lib.rs
@@ -392,22 +392,6 @@ impl Handler<PeerManagerMessageRequest> for MockPeerManagerActor {
     }
 }
 
-#[derive(actix::Message, Debug)]
-#[rtype(result = "u64")]
-pub struct GetChainTargetBlockHeight;
-
-impl Handler<GetChainTargetBlockHeight> for MockPeerManagerActor {
-    type Result = u64;
-
-    fn handle(
-        &mut self,
-        _msg: GetChainTargetBlockHeight,
-        _ctx: &mut Self::Context,
-    ) -> Self::Result {
-        self.target_height
-    }
-}
-
 /// This class provides access a pre-generated chain history
 struct ChainHistoryAccess {
     chain: Chain,

--- a/tools/mock_node/src/main.rs
+++ b/tools/mock_node/src/main.rs
@@ -6,7 +6,7 @@
 use actix::System;
 use anyhow::Context;
 use clap::Parser;
-use mock_node::setup::setup_mock_node;
+use mock_node::setup::{setup_mock_node, MockNode};
 use mock_node::MockNetworkConfig;
 use near_actix_test_utils::run_actix;
 use near_chain_configs::GenesisValidationMode;
@@ -120,7 +120,7 @@ fn main() -> anyhow::Result<()> {
     let client_height = args.start_height.unwrap_or(args.client_height);
     let network_height = args.start_height.or(args.network_height);
     run_actix(async move {
-        let (client, view_client, _, target_height) = setup_mock_node(
+        let MockNode { client, view_client, target_height, .. } = setup_mock_node(
             Path::new(&client_home_dir),
             home_dir,
             near_config,

--- a/tools/mock_node/src/main.rs
+++ b/tools/mock_node/src/main.rs
@@ -7,7 +7,7 @@ use actix::System;
 use anyhow::Context;
 use clap::Parser;
 use mock_node::setup::setup_mock_node;
-use mock_node::{GetChainTargetBlockHeight, MockNetworkConfig};
+use mock_node::MockNetworkConfig;
 use near_actix_test_utils::run_actix;
 use near_chain_configs::GenesisValidationMode;
 use near_client::{GetBlock, Status};
@@ -120,7 +120,7 @@ fn main() -> anyhow::Result<()> {
     let client_height = args.start_height.unwrap_or(args.client_height);
     let network_height = args.start_height.or(args.network_height);
     run_actix(async move {
-        let (mock_network, client, view_client, _) = setup_mock_node(
+        let (client, view_client, _, target_height) = setup_mock_node(
             Path::new(&client_home_dir),
             home_dir,
             near_config,
@@ -147,8 +147,6 @@ fn main() -> anyhow::Result<()> {
                 }
             }
         });
-
-        let target_height = mock_network.send(GetChainTargetBlockHeight).await.unwrap();
 
         // Wait until the client reach target_height.
         wait_or_timeout(

--- a/tools/mock_node/src/setup.rs
+++ b/tools/mock_node/src/setup.rs
@@ -40,27 +40,15 @@ fn setup_runtime(
 }
 
 fn setup_mock_peer_manager_actor(
-    runtime: Arc<NightshadeRuntime>,
+    chain: Chain,
     client_addr: Recipient<NetworkClientMessages>,
     genesis_config: &GenesisConfig,
-    chain_genesis: &ChainGenesis,
     block_production_delay: Duration,
     client_start_height: BlockHeight,
     network_start_height: Option<BlockHeight>,
     network_config: &MockNetworkConfig,
-    target_height: Option<BlockHeight>,
-    save_trie_changes: bool,
+    target_height: BlockHeight,
 ) -> MockPeerManagerActor {
-    let chain = Chain::new_for_view_client(
-        runtime,
-        chain_genesis,
-        DoomslugThresholdMode::NoApprovals,
-        save_trie_changes,
-    )
-    .unwrap();
-    let chain_height = chain.head().unwrap().height;
-    let target_height = min(target_height.unwrap_or(chain_height), chain_height);
-
     let network_start_height = match network_start_height {
         None => target_height,
         Some(0) => chain.genesis_block().header().height(),
@@ -91,8 +79,8 @@ fn setup_mock_peer_manager_actor(
 ///                  use the height from the chain head in storage
 /// `in_memory_storage`: if true, make client use in memory storage instead of rocksdb
 ///
-/// Returns an actix::Addr handle to each of the actors spawned, plus a Vec of Servers representing
-/// the ports that the mock node is currently listening on.
+/// Returns a Vec of Servers representing the ports that the mock node is currently listening on,
+/// and the target height actually available to sync to in the chain history database.
 pub fn setup_mock_node(
     client_home_dir: &Path,
     network_home_dir: &Path,
@@ -103,10 +91,10 @@ pub fn setup_mock_node(
     target_height: Option<BlockHeight>,
     in_memory_storage: bool,
 ) -> (
-    Addr<MockPeerManagerActor>,
     Addr<ClientActor>,
     Addr<ViewClientActor>,
     Option<Vec<(&'static str, actix_web::dev::ServerHandle)>>,
+    BlockHeight,
 ) {
     let parent_span = tracing::debug_span!(target: "mock_node", "setup_mock_node").entered();
     let client_runtime = setup_runtime(client_home_dir, &config, in_memory_storage);
@@ -267,22 +255,31 @@ pub fn setup_mock_node(
     let genesis_config = config.genesis.config.clone();
     let archival = config.client_config.archive;
     let network_config = network_config.clone();
+
+    let chain = Chain::new_for_view_client(
+        mock_network_runtime,
+        &chain_genesis,
+        DoomslugThresholdMode::NoApprovals,
+        !archival,
+    )
+    .unwrap();
+    let chain_height = chain.head().unwrap().height;
+    let target_height = min(target_height.unwrap_or(chain_height), chain_height);
+
     let mock_network_actor =
         MockPeerManagerActor::start_in_arbiter(&arbiter.handle(), move |_ctx| {
             setup_mock_peer_manager_actor(
-                mock_network_runtime,
+                chain,
                 client_actor1.recipient(),
                 &genesis_config,
-                &chain_genesis,
                 block_production_delay,
                 client_start_height,
                 network_start_height,
                 &network_config,
                 target_height,
-                !archival,
             )
         });
-    network_adapter.set_recipient(mock_network_actor.clone().recipient());
+    network_adapter.set_recipient(mock_network_actor.recipient());
 
     // for some reason, with "test_features", start_http requires PeerManagerActor,
     // we are not going to run start_mock_network with test_features, so let's disable that for now
@@ -298,7 +295,7 @@ pub fn setup_mock_node(
     #[cfg(feature = "test_features")]
     let server = None;
 
-    (mock_network_actor, client_actor, view_client, server)
+    (client_actor, view_client, server, target_height)
 }
 
 #[cfg(test)]
@@ -417,7 +414,7 @@ mod tests {
             (0..near_config1.genesis.config.shard_layout.num_shards()).collect();
         let network_config = MockNetworkConfig::with_delay(Duration::from_millis(10));
         run_actix(async move {
-            let (_mock_network, _client, view_client, _) = setup_mock_node(
+            let (_client, view_client, _, _) = setup_mock_node(
                 dir1.path().clone(),
                 dir.path().clone(),
                 near_config1,

--- a/tools/mock_node/src/setup.rs
+++ b/tools/mock_node/src/setup.rs
@@ -66,6 +66,17 @@ fn setup_mock_peer_manager_actor(
     )
 }
 
+pub struct MockNode {
+    // client under test
+    pub client: Addr<ClientActor>,
+    // view client under test
+    pub view_client: Addr<ViewClientActor>,
+    // RPC servers started by the client
+    pub servers: Option<Vec<(&'static str, actix_web::dev::ServerHandle)>>,
+    // target height actually available to sync to in the chain history database
+    pub target_height: BlockHeight,
+}
+
 /// Setup up a mock node, including setting up
 /// a MockPeerManagerActor and a ClientActor and a ViewClientActor
 /// `client_home_dir`: home dir for the new client
@@ -79,8 +90,7 @@ fn setup_mock_peer_manager_actor(
 ///                  use the height from the chain head in storage
 /// `in_memory_storage`: if true, make client use in memory storage instead of rocksdb
 ///
-/// Returns a Vec of Servers representing the ports that the mock node is currently listening on,
-/// and the target height actually available to sync to in the chain history database.
+/// Returns a struct representing the node under test
 pub fn setup_mock_node(
     client_home_dir: &Path,
     network_home_dir: &Path,
@@ -90,12 +100,7 @@ pub fn setup_mock_node(
     network_start_height: Option<BlockHeight>,
     target_height: Option<BlockHeight>,
     in_memory_storage: bool,
-) -> (
-    Addr<ClientActor>,
-    Addr<ViewClientActor>,
-    Option<Vec<(&'static str, actix_web::dev::ServerHandle)>>,
-    BlockHeight,
-) {
+) -> MockNode {
     let parent_span = tracing::debug_span!(target: "mock_node", "setup_mock_node").entered();
     let client_runtime = setup_runtime(client_home_dir, &config, in_memory_storage);
     let mock_network_runtime = setup_runtime(network_home_dir, &config, false);
@@ -229,7 +234,7 @@ pub fn setup_mock_node(
     }
 
     let block_production_delay = config.client_config.min_block_production_delay;
-    let (client_actor, _) = start_client(
+    let (client, _) = start_client(
         config.client_config.clone(),
         chain_genesis.clone(),
         client_runtime.clone(),
@@ -251,7 +256,7 @@ pub fn setup_mock_node(
     );
 
     let arbiter = Arbiter::new();
-    let client_actor1 = client_actor.clone();
+    let client1 = client.clone();
     let genesis_config = config.genesis.config.clone();
     let archival = config.client_config.archive;
     let network_config = network_config.clone();
@@ -270,7 +275,7 @@ pub fn setup_mock_node(
         MockPeerManagerActor::start_in_arbiter(&arbiter.handle(), move |_ctx| {
             setup_mock_peer_manager_actor(
                 chain,
-                client_actor1.recipient(),
+                client1.recipient(),
                 &genesis_config,
                 block_production_delay,
                 client_start_height,
@@ -284,23 +289,23 @@ pub fn setup_mock_node(
     // for some reason, with "test_features", start_http requires PeerManagerActor,
     // we are not going to run start_mock_network with test_features, so let's disable that for now
     #[cfg(not(feature = "test_features"))]
-    let server = config.rpc_config.map(|rpc_config| {
+    let servers = config.rpc_config.map(|rpc_config| {
         near_jsonrpc::start_http(
             rpc_config,
             config.genesis.config,
-            client_actor.clone(),
+            client.clone(),
             view_client.clone(),
         )
     });
     #[cfg(feature = "test_features")]
-    let server = None;
+    let servers = None;
 
-    (client_actor, view_client, server, target_height)
+    MockNode { client, view_client, servers, target_height }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::setup::setup_mock_node;
+    use crate::setup::{setup_mock_node, MockNode};
     use crate::MockNetworkConfig;
     use actix::{Actor, System};
     use futures::{future, FutureExt};
@@ -414,7 +419,7 @@ mod tests {
             (0..near_config1.genesis.config.shard_layout.num_shards()).collect();
         let network_config = MockNetworkConfig::with_delay(Duration::from_millis(10));
         run_actix(async move {
-            let (_client, view_client, _, _) = setup_mock_node(
+            let MockNode { view_client, .. } = setup_mock_node(
                 dir1.path().clone(),
                 dir.path().clone(),
                 near_config1,


### PR DESCRIPTION
we don't have to wait for the peer manager to start to find out what
the the target height is, so getting rid of this simplifies the code a
bit. But more importantly, it removes an explicit dependency on actix
stuff in the mock main.rs file, which will make it easier to refactor
the mock code to not talk to the client via actix