### PR TITLE
chore: remove impossible-to-trigger panic

### DIFF
--- a/core/primitives-core/src/account.rs
+++ b/core/primitives-core/src/account.rs
@@ -115,9 +115,6 @@ impl BorshDeserialize for Account {
         // This should only ever happen if we have pre-transition account serialized in state
         // See test_account_size
         let deserialized_account = LegacyAccount::deserialize(buf)?;
-        if buf.len() != 0 {
-            panic!("Tried deserializing a buffer that is not exactly the size of an account");
-        }
         Ok(Account {
             amount: deserialized_account.amount,
             locked: deserialized_account.locked,


### PR DESCRIPTION
This panic both never triggered and broke the API constraints of
BorshDeserialize. See the discussion at [1]

[1] https://github.com/near/nearcore/issues/6186

fixes #6186