### PR TITLE
store: refactor StoreOpener; add Store::opener and related changes

### DIFF
--- a/chain/indexer/src/streamer/mod.rs
+++ b/chain/indexer/src/streamer/mod.rs
@@ -287,9 +287,9 @@ pub(crate) async fn start(
     blocks_sink: mpsc::Sender<StreamerMessage>,
 ) {
     info!(target: INDEXER, "Starting Streamer...");
-    let mut indexer_db_path =
-        near_store::StoreOpener::new(&indexer_config.home_dir, &store_config).get_path();
-    indexer_db_path.push("indexer");
+    let indexer_db_path = near_store::Store::opener(&indexer_config.home_dir, &store_config)
+        .get_path()
+        .join("indexer");
 
     // TODO: implement proper error handling
     let db = DB::open_default(indexer_db_path).unwrap();

--- a/chain/network/src/peer_manager/peer_store_test.rs
+++ b/chain/network/src/peer_manager/peer_store_test.rs
@@ -1,7 +1,7 @@
 use near_crypto::{KeyType, SecretKey};
 use near_network_primitives::types::{Blacklist, BlacklistEntry};
 use near_store::test_utils::create_test_store;
-use near_store::StoreOpener;
+use near_store::{Store, StoreOpener};
 use std::collections::HashSet;
 use std::net::{Ipv4Addr, SocketAddrV4};
 
@@ -29,19 +29,19 @@ fn gen_peer_info(port: u16) -> PeerInfo {
 
 #[test]
 fn ban_store() {
-    let tmp_dir = tempfile::Builder::new().prefix("_test_store_ban").tempdir().unwrap();
+    let (_tmp_dir, opener) = Store::tmp_opener();
     let peer_info_a = gen_peer_info(0);
     let peer_info_to_ban = gen_peer_info(1);
     let boot_nodes = vec![peer_info_a, peer_info_to_ban.clone()];
     {
-        let store = StoreOpener::with_default_config(tmp_dir.path()).open();
+        let store = opener.open();
         let mut peer_store = PeerStore::new(store, &boot_nodes, Default::default()).unwrap();
         assert_eq!(peer_store.healthy_peers(3).len(), 2);
         peer_store.peer_ban(&peer_info_to_ban.id, ReasonForBan::Abusive).unwrap();
         assert_eq!(peer_store.healthy_peers(3).len(), 1);
     }
     {
-        let store_new = StoreOpener::with_default_config(tmp_dir.path()).open();
+        let store_new = opener.open();
         let peer_store_new = PeerStore::new(store_new, &boot_nodes, Default::default()).unwrap();
         assert_eq!(peer_store_new.healthy_peers(3).len(), 1);
     }
@@ -49,12 +49,12 @@ fn ban_store() {
 
 #[test]
 fn test_unconnected_peer() {
-    let tmp_dir = tempfile::Builder::new().prefix("_test_store_ban").tempdir().unwrap();
+    let (_tmp_dir, opener) = Store::tmp_opener();
     let peer_info_a = gen_peer_info(0);
     let peer_info_to_ban = gen_peer_info(1);
     let boot_nodes = vec![peer_info_a, peer_info_to_ban];
     {
-        let store = StoreOpener::with_default_config(tmp_dir.path()).open();
+        let store = opener.open();
         let peer_store = PeerStore::new(store, &boot_nodes, Default::default()).unwrap();
         assert!(peer_store.unconnected_peer(|_| false).is_some());
         assert!(peer_store.unconnected_peer(|_| true).is_none());
@@ -283,8 +283,7 @@ fn check_ignore_blacklisted_peers() {
 
 #[test]
 fn remove_blacklisted_peers_from_store() {
-    let tmp_dir =
-        tempfile::Builder::new().prefix("_remove_blacklisted_peers_from_store").tempdir().unwrap();
+    let (_tmp_dir, opener) = Store::tmp_opener();
     let (peer_ids, peer_infos): (Vec<_>, Vec<_>) = (0..3)
         .map(|i| {
             let id = get_peer_id(format!("node{}", i));
@@ -295,24 +294,24 @@ fn remove_blacklisted_peers_from_store() {
 
     // Add three peers.
     {
-        let store = StoreOpener::with_default_config(tmp_dir.path()).open();
+        let store = opener.open();
         let mut peer_store = PeerStore::new(store, &[], Default::default()).unwrap();
         peer_store.add_indirect_peers(peer_infos.clone().into_iter()).unwrap();
     }
-    assert_peers_in_store(tmp_dir.path(), &peer_ids);
+    assert_peers_in_store(&opener, &peer_ids);
 
     // Blacklisted peers are removed from the store.
     {
-        let store = StoreOpener::with_default_config(tmp_dir.path()).open();
+        let store = opener.open();
         let blacklist: Blacklist =
             [BlacklistEntry::from_addr(peer_infos[2].addr.unwrap())].into_iter().collect();
         let _peer_store = PeerStore::new(store, &[], blacklist).unwrap();
     }
-    assert_peers_in_store(tmp_dir.path(), &peer_ids[0..2]);
+    assert_peers_in_store(&opener, &peer_ids[0..2]);
 }
 
-fn assert_peers_in_store(store_path: &std::path::Path, expected: &[PeerId]) {
-    let store = StoreOpener::with_default_config(store_path).open();
+fn assert_peers_in_store(opener: &StoreOpener, expected: &[PeerId]) {
+    let store = opener.open();
     let stored_peers: HashSet<PeerId> = HashSet::from_iter(
         store.iter(DBCol::Peers).map(|(key, _)| PeerId::try_from_slice(key.as_ref()).unwrap()),
     );
@@ -336,7 +335,7 @@ fn assert_peers_in_cache(
 
 #[test]
 fn test_delete_peers() {
-    let tmp_dir = tempfile::Builder::new().prefix("_test_delete_peers").tempdir().unwrap();
+    let (_tmp_dir, opener) = Store::tmp_opener();
     let (peer_ids, peer_infos): (Vec<_>, Vec<_>) = (0..3)
         .map(|i| {
             let id = get_peer_id(format!("node{}", i));
@@ -348,18 +347,18 @@ fn test_delete_peers() {
         peer_infos.iter().map(|info| info.addr.unwrap().clone()).collect::<Vec<_>>();
 
     {
-        let store = StoreOpener::with_default_config(tmp_dir.path()).open();
+        let store = opener.open();
         let mut peer_store = PeerStore::new(store, &[], Default::default()).unwrap();
         peer_store.add_indirect_peers(peer_infos.into_iter()).unwrap();
     }
-    assert_peers_in_store(tmp_dir.path(), &peer_ids);
+    assert_peers_in_store(&opener, &peer_ids);
 
     {
-        let store = StoreOpener::with_default_config(tmp_dir.path()).open();
+        let store = opener.open();
         let mut peer_store = PeerStore::new(store, &[], Default::default()).unwrap();
         assert_peers_in_cache(&peer_store, &peer_ids, &peer_addresses);
         peer_store.delete_peers(&peer_ids).unwrap();
         assert_peers_in_cache(&peer_store, &[], &[]);
     }
-    assert_peers_in_store(tmp_dir.path(), &[]);
+    assert_peers_in_store(&opener, &[]);
 }

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -17,6 +17,7 @@ enum-map = "2.1.0"
 rocksdb = { version = "0.18.0", default-features = false, features = ["snappy", "lz4", "zstd", "zlib"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tempfile = "3"
 num_cpus = "1.11"
 rand = "0.7"
 strum = { version = "0.24", features = ["derive"] }
@@ -36,7 +37,6 @@ near-cache = { path = "../../utils/near-cache" }
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-tempfile = "3"
 bencher = "0.1.5"
 rand = "0.7"
 

--- a/core/store/benches/store_bench.rs
+++ b/core/store/benches/store_bench.rs
@@ -3,7 +3,7 @@ extern crate bencher;
 
 use bencher::{black_box, Bencher};
 use near_primitives::errors::StorageError;
-use near_store::{DBCol, Store, StoreOpener};
+use near_store::{DBCol, Store};
 use std::time::{Duration, Instant};
 
 /// Run a benchmark to generate `num_keys` keys, each of size `key_size`, then write then
@@ -16,8 +16,8 @@ fn benchmark_write_then_read_successful(
     max_value_size: usize,
     col: DBCol,
 ) {
-    let tmp_dir = tempfile::Builder::new().tempdir().unwrap();
-    let store = StoreOpener::with_default_config(tmp_dir.path()).open();
+    let (_tmp_dir, opener) = Store::tmp_opener();
+    let store = opener.open();
     let keys = generate_keys(num_keys, key_size);
     write_to_db(&store, &keys, max_value_size, col);
 

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -54,6 +54,24 @@ pub struct Store {
 }
 
 impl Store {
+    /// Initialises a new opener with given home directory and store config.
+    pub fn opener<'a>(home_dir: &std::path::Path, config: &'a StoreConfig) -> StoreOpener<'a> {
+        StoreOpener::new(home_dir, config)
+    }
+
+    /// Initialises a new opener for temporary store.
+    ///
+    /// This is meant for tests only.  It **panics** if a temporary directory
+    /// cannot be created.
+    ///
+    /// Caller must hold the temporary directory returned as first element of
+    /// the tuple while the store is open.
+    pub fn tmp_opener() -> (tempfile::TempDir, StoreOpener<'static>) {
+        let dir = tempfile::tempdir().unwrap();
+        let opener = Self::opener(dir.path(), &StoreConfig::DEFAULT);
+        (dir, opener)
+    }
+
     pub(crate) fn new(storage: Arc<dyn Database>) -> Store {
         Store { storage }
     }

--- a/genesis-tools/genesis-populate/src/main.rs
+++ b/genesis-tools/genesis-populate/src/main.rs
@@ -29,7 +29,7 @@ fn main() {
     let near_config = load_config(home_dir, GenesisValidationMode::Full)
         .unwrap_or_else(|e| panic!("Error loading config: {:#}", e));
 
-    let store = near_store::StoreOpener::new(home_dir, &near_config.config.store).open();
+    let store = near_store::Store::opener(home_dir, &near_config.config.store).open();
     GenesisBuilder::from_config_and_store(home_dir, Arc::new(near_config.genesis), store)
         .add_additional_accounts(additional_accounts_num)
         .add_additional_accounts_contract(near_test_contracts::trivial_contract().to_vec())

--- a/genesis-tools/genesis-populate/src/state_dump.rs
+++ b/genesis-tools/genesis-populate/src/state_dump.rs
@@ -17,7 +17,8 @@ pub struct StateDump {
 
 impl StateDump {
     pub fn from_dir(dir: &Path, store_home_dir: &Path) -> Self {
-        let store = near_store::StoreOpener::with_default_config(store_home_dir).open();
+        let store =
+            near_store::Store::opener(store_home_dir, &near_store::StoreConfig::DEFAULT).open();
         let state_file = dir.join(STATE_DUMP_FILE);
         store
             .load_from_file(DBCol::State, state_file.as_path())

--- a/nearcore/benches/store.rs
+++ b/nearcore/benches/store.rs
@@ -28,7 +28,7 @@ fn read_trie_items(bench: &mut Bencher, shard_id: usize, read_only: bool) {
 
     bench.iter(move || {
         tracing::info!(target: "neard", "{:?}", home_dir);
-        let store = near_store::StoreOpener::new(&home_dir, &near_config.config.store)
+        let store = near_store::Store::opener(&home_dir, &near_config.config.store)
             .read_only(read_only)
             .open();
 

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -202,7 +202,7 @@ fn apply_store_migrations_if_exists(
 }
 
 fn init_and_migrate_store(home_dir: &Path, near_config: &NearConfig) -> anyhow::Result<Store> {
-    let opener = StoreOpener::new(home_dir, &near_config.config.store);
+    let opener = Store::opener(home_dir, &near_config.config.store);
     let exists = apply_store_migrations_if_exists(&opener, near_config)?;
     let store = opener.open();
     if !exists {
@@ -379,7 +379,7 @@ pub fn recompress_storage(home_dir: &Path, opts: RecompressOpts) -> anyhow::Resu
             .map_err(|err| anyhow::anyhow!("setrlimit: NOFILE: {}", err))?;
     }
 
-    let src_opener = StoreOpener::new(home_dir, &config.store).read_only(true);
+    let src_opener = Store::opener(home_dir, &config.store).read_only(true);
     let src_path = src_opener.get_path();
     if let Some(db_version) = src_opener.get_version_if_exists()? {
         anyhow::ensure!(
@@ -398,7 +398,7 @@ pub fn recompress_storage(home_dir: &Path, opts: RecompressOpts) -> anyhow::Resu
     // Note: opts.dest_dir is resolved relative to current working directory
     // (since it’s a command line option) which is why we set home to cwd.
     let cwd = std::env::current_dir()?;
-    let dst_opener = StoreOpener::new(&cwd, &dst_config);
+    let dst_opener = Store::opener(&cwd, &dst_config);
     let dst_path = dst_opener.get_path();
     anyhow::ensure!(
         !dst_opener.check_if_exists(),

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -143,8 +143,7 @@ fn main() -> anyhow::Result<()> {
 
         let near_config = nearcore::load_config(&state_dump_path, GenesisValidationMode::Full)
             .context("Error loading config")?;
-        let store =
-            near_store::StoreOpener::new(&state_dump_path, &near_config.config.store).open();
+        let store = near_store::Store::opener(&state_dump_path, &near_config.config.store).open();
         GenesisBuilder::from_config_and_store(
             &state_dump_path,
             Arc::new(near_config.genesis),

--- a/test-utils/runtime-tester/src/run_test.rs
+++ b/test-utils/runtime-tester/src/run_test.rs
@@ -47,10 +47,8 @@ impl Scenario {
         let (tempdir, store) = if self.use_in_memory_store {
             (None, create_test_store())
         } else {
-            let tempdir = tempfile::tempdir()
-                .unwrap_or_else(|err| panic!("failed to create temporary directory: {}", err));
-            let store = near_store::StoreOpener::with_default_config(tempdir.path()).open();
-            (Some(tempdir), store)
+            let (tempdir, opener) = near_store::Store::tmp_opener();
+            (Some(tempdir), opener.open())
         };
 
         let mut env = TestEnv::builder(ChainGenesis::from(&genesis))

--- a/test-utils/store-validator/src/main.rs
+++ b/test-utils/store-validator/src/main.rs
@@ -30,7 +30,7 @@ fn main() {
     let near_config = load_config(home_dir, GenesisValidationMode::Full)
         .unwrap_or_else(|e| panic!("Error loading config: {:#}", e));
 
-    let store = near_store::StoreOpener::new(home_dir, &near_config.config.store).open();
+    let store = near_store::Store::opener(home_dir, &near_config.config.store).open();
 
     let runtime_adapter: Arc<dyn RuntimeAdapter> =
         Arc::new(nearcore::NightshadeRuntime::from_config(home_dir, store.clone(), &near_config));

--- a/tools/mock_node/src/setup.rs
+++ b/tools/mock_node/src/setup.rs
@@ -33,7 +33,7 @@ fn setup_runtime(
     let store = if in_memory_storage {
         create_test_store()
     } else {
-        near_store::StoreOpener::new(home_dir, &config.config.store).open()
+        near_store::Store::opener(home_dir, &config.config.store).open()
     };
 
     Arc::new(NightshadeRuntime::from_config(home_dir, store, config))

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -70,7 +70,7 @@ impl StateViewerSubCommand {
     pub fn run(self, home_dir: &Path, genesis_validation: GenesisValidationMode, readwrite: bool) {
         let near_config = load_config(home_dir, genesis_validation)
             .unwrap_or_else(|e| panic!("Error loading config: {:#}", e));
-        let store = near_store::StoreOpener::new(home_dir, &near_config.config.store)
+        let store = near_store::Store::opener(home_dir, &near_config.config.store)
             .read_only(!readwrite)
             .open();
         match self {


### PR DESCRIPTION
Firstly, replace StoreOpener constructors with static methods on
the Store struct.  Specifically, add Store::opener (which acts just
like StoreOpener::new which is now private) and Store::tmp_opener
(which replaces StoreOpener::with_default_config).

Secondly, incorporate creation of the temporary directory into
the Store::tmp_opener method.  Previously, test code would create
a temporary directory and use StoreOpener::with_default_config.
Now, this is all rolled into single Store::tmp_opener method.

The motivation for that is to make it painfully obvious that
Store::tmp_opener is meant for tests only.  Anything that operates
on a non-temporary storage will have to use Store::opener and
provide it with a StoreConfig.

Lastly, change StoreOpener to resolve the path to the storage during
construction.  This replaces `home_dir` that the struct was holding
with a `path: PathBuf`.  This means that StoreOpener::get_path will
no longer resolve the path on each call and have its return value
ready to go.

Issue: https://github.com/near/nearcore/issues/6857