### PR TITLE
store: introduce StoreConfig::test_config constructor

### DIFF
--- a/chain/network/src/peer_manager/peer_store_test.rs
+++ b/chain/network/src/peer_manager/peer_store_test.rs
@@ -29,7 +29,7 @@ fn gen_peer_info(port: u16) -> PeerInfo {
 
 #[test]
 fn ban_store() {
-    let (_tmp_dir, opener) = Store::tmp_opener();
+    let (_tmp_dir, opener) = Store::test_opener();
     let peer_info_a = gen_peer_info(0);
     let peer_info_to_ban = gen_peer_info(1);
     let boot_nodes = vec![peer_info_a, peer_info_to_ban.clone()];
@@ -49,7 +49,7 @@ fn ban_store() {
 
 #[test]
 fn test_unconnected_peer() {
-    let (_tmp_dir, opener) = Store::tmp_opener();
+    let (_tmp_dir, opener) = Store::test_opener();
     let peer_info_a = gen_peer_info(0);
     let peer_info_to_ban = gen_peer_info(1);
     let boot_nodes = vec![peer_info_a, peer_info_to_ban];
@@ -283,7 +283,7 @@ fn check_ignore_blacklisted_peers() {
 
 #[test]
 fn remove_blacklisted_peers_from_store() {
-    let (_tmp_dir, opener) = Store::tmp_opener();
+    let (_tmp_dir, opener) = Store::test_opener();
     let (peer_ids, peer_infos): (Vec<_>, Vec<_>) = (0..3)
         .map(|i| {
             let id = get_peer_id(format!("node{}", i));
@@ -335,7 +335,7 @@ fn assert_peers_in_cache(
 
 #[test]
 fn test_delete_peers() {
-    let (_tmp_dir, opener) = Store::tmp_opener();
+    let (_tmp_dir, opener) = Store::test_opener();
     let (peer_ids, peer_infos): (Vec<_>, Vec<_>) = (0..3)
         .map(|i| {
             let id = get_peer_id(format!("node{}", i));

--- a/core/store/benches/store_bench.rs
+++ b/core/store/benches/store_bench.rs
@@ -16,8 +16,10 @@ fn benchmark_write_then_read_successful(
     max_value_size: usize,
     col: DBCol,
 ) {
-    let (_tmp_dir, opener) = Store::tmp_opener();
-    let store = opener.open();
+    let tmp_dir = tempfile::tempdir().unwrap();
+    // Use default StoreConfig rather than Store::test_opener so we’re using the
+    // same configuration as in production.
+    let store = Store::opener(tmp_dir.path(), &Default::default()).open();
     let keys = generate_keys(num_keys, key_size);
     write_to_db(&store, &keys, max_value_size, col);
 

--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -16,7 +16,7 @@ pub struct StoreConfig {
     pub enable_statistics: bool,
 
     /// Re-export storage layer statistics as prometheus metrics.
-    #[serde(default = "default_enable_statistics_export")]
+    #[serde(default = "StoreConfig::default_enable_statistics_export")]
     pub enable_statistics_export: bool,
 
     /// Maximum number of store files being opened simultaneously.
@@ -26,7 +26,7 @@ pub struct StoreConfig {
     /// needs.
     /// Increasing this value up to a value higher than 1024 also requires setting `ulimit -n` in
     /// Linux.
-    #[serde(default = "default_max_open_files")]
+    #[serde(default = "StoreConfig::default_max_open_files")]
     pub max_open_files: u32,
 
     /// Cache size for DBCol::State column.
@@ -34,61 +34,65 @@ pub struct StoreConfig {
     /// Increasing DBCol::State cache size helps making storage more efficient. On the other hand we
     /// don't want to increase hugely requirements for running a node so currently we use a small
     /// default value for it.
-    #[serde(default = "default_col_state_cache_size")]
+    #[serde(default = "StoreConfig::default_col_state_cache_size")]
     pub col_state_cache_size: bytesize::ByteSize,
 
     /// Block size used internally in RocksDB.
     /// Default value: 16KiB.
     /// We're still experimented with this parameter and it seems decreasing its value can improve
     /// the performance of the storage
-    #[serde(default = "default_block_size")]
+    #[serde(default = "StoreConfig::default_block_size")]
     pub block_size: bytesize::ByteSize,
 }
 
-fn default_enable_statistics_export() -> bool {
-    StoreConfig::DEFAULT.enable_statistics_export
-}
-
-fn default_max_open_files() -> u32 {
-    StoreConfig::DEFAULT.max_open_files
-}
-
-fn default_col_state_cache_size() -> bytesize::ByteSize {
-    StoreConfig::DEFAULT.col_state_cache_size
-}
-
-fn default_block_size() -> bytesize::ByteSize {
-    StoreConfig::DEFAULT.block_size
-}
-
 impl StoreConfig {
-    /// We've used a value of 512 for max_open_files since 3 Dec 2019. As it turned out we were
-    /// hitting that limit and store had to constantly close/reopen the same set of files.
-    /// Running state viewer on a dense set of 500 blocks did almost 200K file opens (having less
-    /// than 7K unique files opened, some files were opened 400+ times).
-    /// Using 10K limit for max_open_files led to performance improvement of ~11%.
-    const DEFAULT_MAX_OPEN_FILES: u32 = 10_000;
+    /// Returns the default value for the `max_open_files` database limite.
+    ///
+    /// We used to use value of 512 but we were hitting that limit often and
+    /// store had to constantly close and reopen the same set of files.  Running
+    /// state viewer on a dense set of 500 blocks did almost 200k file opens
+    /// (having less than 7K unique files opened, some files were opened 400+
+    /// times).  Using 10k limit for max_open_files led to performance
+    /// improvement of ~11%.
+    const fn default_max_open_files() -> u32 {
+        10_000
+    }
 
-    /// We used to have the same cache size for all columns 32MB. When some RocksDB
-    /// inefficiencies were found DBCol::State cache size was increased up to 512MB.
-    /// This was done Nov 13 2021 and we consider increasing the value.
-    /// Tests have shown that increase of col_state_cache_size up to 25GB (we've used this big
-    /// value to estimate performance improvement headroom) having max_open_files=10K improved
-    /// performance of state viewer by 60%.
-    const DEFAULT_COL_STATE_CACHE_SIZE: bytesize::ByteSize = bytesize::ByteSize::mib(512);
+    /// Returns the default [`DBCol::State`] cache size.
+    ///
+    /// We used to have the same cache size for all columns, 32 MiB.  When some
+    /// RocksDB inefficiencies were found [`DBCol::State`] cache size was
+    /// increased up to 512 MiB.  This was done on 13th of Nov 2021 and we
+    /// consider increasing the value.  Tests have shown that increase to 25 GiB
+    /// (we've used this big value to estimate performance improvement headroom)
+    /// having `max_open_files` at 10k improved performance of state viewer by
+    /// 60%.
+    const fn default_col_state_cache_size() -> bytesize::ByteSize {
+        bytesize::ByteSize::mib(512)
+    }
 
-    /// Earlier this value was taken from the openethereum default parameter and we use it since
-    /// then.
-    const DEFAULT_BLOCK_SIZE: bytesize::ByteSize = bytesize::ByteSize::kib(16);
+    /// Returns the default value for database block size.
+    ///
+    /// This value was taken from the Openethereum default parameter and we use
+    /// it since then.
+    const fn default_block_size() -> bytesize::ByteSize {
+        bytesize::ByteSize::kib(16)
+    }
 
-    pub const DEFAULT: Self = Self {
-        path: None,
-        enable_statistics: false,
-        enable_statistics_export: true,
-        max_open_files: Self::DEFAULT_MAX_OPEN_FILES,
-        col_state_cache_size: Self::DEFAULT_COL_STATE_CACHE_SIZE,
-        block_size: Self::DEFAULT_BLOCK_SIZE,
-    };
+    /// Returns the default for `enable_statistics_export` setting.
+    const fn default_enable_statistics_export() -> bool {
+        true
+    }
+
+    /// Returns configuration meant for tests.
+    ///
+    /// Since tests often operate with less data than real node, the test
+    /// configuration is adjusted to reduce resource use.  For example, default
+    /// `max_open_files` limit is 512 which helps in situations when tests are
+    /// run in isolated environments with tighter resource limits.
+    pub fn test_config() -> Self {
+        Self { max_open_files: 512, ..Self::default() }
+    }
 
     /// Returns cache size for given column.
     pub const fn col_cache_size(&self, col: crate::DBCol) -> bytesize::ByteSize {
@@ -101,7 +105,14 @@ impl StoreConfig {
 
 impl Default for StoreConfig {
     fn default() -> Self {
-        Self::DEFAULT
+        Self {
+            path: None,
+            enable_statistics: false,
+            enable_statistics_export: Self::default_enable_statistics_export(),
+            max_open_files: Self::default_max_open_files(),
+            col_state_cache_size: Self::default_col_state_cache_size(),
+            block_size: Self::default_block_size(),
+        }
     }
 }
 

--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -86,7 +86,7 @@ impl Default for StoreConfig {
 
             // This value was taken from the Openethereum default parameter and
             // we use it since then.
-            block_size: bytesize::ByteSize::kib(16)
+            block_size: bytesize::ByteSize::kib(16),
         }
     }
 }

--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -3,20 +3,18 @@ use near_primitives::version::DbVersion;
 const STORE_PATH: &str = "data";
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
 pub struct StoreConfig {
     /// Path to the database.  If relative, resolved relative to neard home
     /// directory.  This is useful if node runs with a separate disk holding the
     /// database.
-    #[serde(default)]
     pub path: Option<std::path::PathBuf>,
 
     /// Collect internal storage layer statistics.
     /// Minor performance impact is expected.
-    #[serde(default)]
     pub enable_statistics: bool,
 
     /// Re-export storage layer statistics as prometheus metrics.
-    #[serde(default = "StoreConfig::default_enable_statistics_export")]
     pub enable_statistics_export: bool,
 
     /// Maximum number of store files being opened simultaneously.
@@ -26,7 +24,6 @@ pub struct StoreConfig {
     /// needs.
     /// Increasing this value up to a value higher than 1024 also requires setting `ulimit -n` in
     /// Linux.
-    #[serde(default = "StoreConfig::default_max_open_files")]
     pub max_open_files: u32,
 
     /// Cache size for DBCol::State column.
@@ -34,56 +31,16 @@ pub struct StoreConfig {
     /// Increasing DBCol::State cache size helps making storage more efficient. On the other hand we
     /// don't want to increase hugely requirements for running a node so currently we use a small
     /// default value for it.
-    #[serde(default = "StoreConfig::default_col_state_cache_size")]
     pub col_state_cache_size: bytesize::ByteSize,
 
     /// Block size used internally in RocksDB.
     /// Default value: 16KiB.
     /// We're still experimented with this parameter and it seems decreasing its value can improve
     /// the performance of the storage
-    #[serde(default = "StoreConfig::default_block_size")]
     pub block_size: bytesize::ByteSize,
 }
 
 impl StoreConfig {
-    /// Returns the default value for the `max_open_files` database limite.
-    ///
-    /// We used to use value of 512 but we were hitting that limit often and
-    /// store had to constantly close and reopen the same set of files.  Running
-    /// state viewer on a dense set of 500 blocks did almost 200k file opens
-    /// (having less than 7K unique files opened, some files were opened 400+
-    /// times).  Using 10k limit for max_open_files led to performance
-    /// improvement of ~11%.
-    const fn default_max_open_files() -> u32 {
-        10_000
-    }
-
-    /// Returns the default [`DBCol::State`] cache size.
-    ///
-    /// We used to have the same cache size for all columns, 32 MiB.  When some
-    /// RocksDB inefficiencies were found [`DBCol::State`] cache size was
-    /// increased up to 512 MiB.  This was done on 13th of Nov 2021 and we
-    /// consider increasing the value.  Tests have shown that increase to 25 GiB
-    /// (we've used this big value to estimate performance improvement headroom)
-    /// having `max_open_files` at 10k improved performance of state viewer by
-    /// 60%.
-    const fn default_col_state_cache_size() -> bytesize::ByteSize {
-        bytesize::ByteSize::mib(512)
-    }
-
-    /// Returns the default value for database block size.
-    ///
-    /// This value was taken from the Openethereum default parameter and we use
-    /// it since then.
-    const fn default_block_size() -> bytesize::ByteSize {
-        bytesize::ByteSize::kib(16)
-    }
-
-    /// Returns the default for `enable_statistics_export` setting.
-    const fn default_enable_statistics_export() -> bool {
-        true
-    }
-
     /// Returns configuration meant for tests.
     ///
     /// Since tests often operate with less data than real node, the test
@@ -108,10 +65,28 @@ impl Default for StoreConfig {
         Self {
             path: None,
             enable_statistics: false,
-            enable_statistics_export: Self::default_enable_statistics_export(),
-            max_open_files: Self::default_max_open_files(),
-            col_state_cache_size: Self::default_col_state_cache_size(),
-            block_size: Self::default_block_size(),
+            enable_statistics_export: true,
+
+            // We used to use value of 512 but we were hitting that limit often
+            // and store had to constantly close and reopen the same set of
+            // files.  Running state viewer on a dense set of 500 blocks did
+            // almost 200k file opens (having less than 7K unique files opened,
+            // some files were opened 400+ times).  Using 10k limit for
+            // max_open_files led to performance improvement of ~11%.
+            max_open_files: 10_000,
+
+            // We used to have the same cache size for all columns, 32 MiB.
+            // When some RocksDB inefficiencies were found [`DBCol::State`]
+            // cache size was increased up to 512 MiB.  This was done on 13th of
+            // Nov 2021 and we consider increasing the value.  Tests have shown
+            // that increase to 25 GiB (we've used this big value to estimate
+            // performance improvement headroom) having `max_open_files` at 10k
+            // improved performance of state viewer by 60%.
+            col_state_cache_size: bytesize::ByteSize::mib(512),
+
+            // This value was taken from the Openethereum default parameter and
+            // we use it since then.
+            block_size: bytesize::ByteSize::kib(16)
         }
     }
 }

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -806,13 +806,13 @@ mod tests {
     #[test]
     fn test_prewrite_check() {
         let tmp_dir = tempfile::Builder::new().prefix("prewrite_check").tempdir().unwrap();
-        let store = RocksDB::open(tmp_dir.path(), &StoreConfig::DEFAULT, false).unwrap();
+        let store = RocksDB::open(tmp_dir.path(), &StoreConfig::test_config(), false).unwrap();
         store.pre_write_check().unwrap()
     }
 
     #[test]
     fn test_clear_column() {
-        let (_tmp_dir, opener) = Store::tmp_opener();
+        let (_tmp_dir, opener) = Store::test_opener();
         let store = opener.open();
         assert_eq!(store.get(DBCol::State, &[1]).unwrap(), None);
         {
@@ -833,7 +833,7 @@ mod tests {
 
     #[test]
     fn rocksdb_merge_sanity() {
-        let (_tmp_dir, opener) = Store::tmp_opener();
+        let (_tmp_dir, opener) = Store::test_opener();
         let store = opener.open();
         let ptr = (&*store.storage) as *const (dyn Database + 'static);
         let rocksdb = unsafe { &*(ptr as *const RocksDB) };

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -629,7 +629,7 @@ mod tests {
 
     #[test]
     fn rocksdb_iter_order() {
-        let (_tmp_dir, opener) = crate::Store::tmp_opener();
+        let (_tmp_dir, opener) = crate::Store::test_opener();
         test_iter_order_impl(opener.open(), 10_000);
     }
 

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -7,6 +7,7 @@ use std::{fmt, io};
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use once_cell::sync::Lazy;
 
 pub use columns::DBCol;
 pub use db::{
@@ -59,16 +60,18 @@ impl Store {
         StoreOpener::new(home_dir, config)
     }
 
-    /// Initialises a new opener for temporary store.
+    /// Initialises an opener for a new temporary test store.
     ///
-    /// This is meant for tests only.  It **panics** if a temporary directory
-    /// cannot be created.
+    /// As per the name, this is meant for tests only.  The created store will
+    /// use test configuration (which may differ slightly from default config).
+    /// The function **panics** if a temporary directory cannot be created.
     ///
-    /// Caller must hold the temporary directory returned as first element of
-    /// the tuple while the store is open.
-    pub fn tmp_opener() -> (tempfile::TempDir, StoreOpener<'static>) {
+    /// Note that the caller must hold the temporary directory returned as first
+    /// element of the tuple while the store is open.
+    pub fn test_opener() -> (tempfile::TempDir, StoreOpener<'static>) {
+        static CONFIG: Lazy<StoreConfig> = Lazy::new(StoreConfig::test_config);
         let dir = tempfile::tempdir().unwrap();
-        let opener = Self::opener(dir.path(), &StoreConfig::DEFAULT);
+        let opener = Self::opener(dir.path(), &CONFIG);
         (dir, opener)
     }
 

--- a/genesis-tools/genesis-populate/src/state_dump.rs
+++ b/genesis-tools/genesis-populate/src/state_dump.rs
@@ -17,8 +17,7 @@ pub struct StateDump {
 
 impl StateDump {
     pub fn from_dir(dir: &Path, store_home_dir: &Path) -> Self {
-        let store =
-            near_store::Store::opener(store_home_dir, &near_store::StoreConfig::DEFAULT).open();
+        let store = near_store::Store::opener(store_home_dir, &Default::default()).open();
         let state_file = dir.join(STATE_DUMP_FILE);
         store
             .load_from_file(DBCol::State, state_file.as_path())

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -2123,7 +2123,7 @@ mod test {
             has_reward: bool,
             minimum_stake_divisor: Option<u64>,
         ) -> Self {
-            let (dir, opener) = Store::tmp_opener();
+            let (dir, opener) = Store::test_opener();
             let store = opener.open();
             let all_validators = validators.iter().fold(BTreeSet::new(), |acc, x| {
                 acc.union(&x.iter().cloned().collect()).cloned().collect()

--- a/test-utils/runtime-tester/src/run_test.rs
+++ b/test-utils/runtime-tester/src/run_test.rs
@@ -47,7 +47,7 @@ impl Scenario {
         let (tempdir, store) = if self.use_in_memory_store {
             (None, create_test_store())
         } else {
-            let (tempdir, opener) = near_store::Store::tmp_opener();
+            let (tempdir, opener) = near_store::Store::test_opener();
             (Some(tempdir), opener.open())
         };
 


### PR DESCRIPTION
The problem some users encountered was that they were running tests in
an environment where resource limits (most notably hard NOFILE limit)
were too low for the default store configuration to work.  This lead
to the tests failing even though they could easily run without ever
approaching the limits.

This change introduces StoreConfig::test_config method which returns
test store configuration with max_open_files lowered to the old 512
default.

With that also rename Store::tmp_opener to test_opener (to indicate
it uses non-default configuration) and perform minor refactoring on
StoreConfig associated constants.
