### PR TITLE
fix: make TestDB iterator deterministic

### DIFF
--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -259,6 +259,9 @@ impl RocksDB {
 }
 
 pub struct TestDB {
+    // In order to ensure determinism when iterating over column's results
+    // a BTreeMap is used since it is an ordered map. Using a HashMap would
+    // not yield this guarantee, and therefore is discarded.
     db: RwLock<enum_map::EnumMap<DBCol, BTreeMap<Vec<u8>, Vec<u8>>>>,
 }
 

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -434,7 +434,7 @@ impl Database for TestDB {
             .take_while(move |(k, _)| k.starts_with(&key_prefix))
             .map(|(k, v)| (k.clone().into_boxed_slice(), v.clone().into_boxed_slice()))
             .collect::<Vec<_>>();
-        RocksDB::iter_with_rc_logic(col, Box::new(iterator.into_iter()))
+        RocksDB::iter_with_rc_logic(col, iterator.into_iter())
     }
 
     fn write(&self, transaction: DBTransaction) -> Result<(), DBError> {

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -8,7 +8,7 @@ use rocksdb::{
     BlockBasedOptions, Cache, ColumnFamily, ColumnFamilyDescriptor, Direction, Env, IteratorMode,
     Options, ReadOptions, WriteBatch, DB,
 };
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::io;
 use std::path::Path;
 use std::sync::atomic::Ordering;
@@ -259,7 +259,7 @@ impl RocksDB {
 }
 
 pub struct TestDB {
-    db: RwLock<enum_map::EnumMap<DBCol, HashMap<Vec<u8>, Vec<u8>>>>,
+    db: RwLock<enum_map::EnumMap<DBCol, BTreeMap<Vec<u8>, Vec<u8>>>>,
 }
 
 pub(crate) trait Database: Sync + Send {

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -260,8 +260,8 @@ impl RocksDB {
 
 pub struct TestDB {
     // In order to ensure determinism when iterating over column's results
-    // a BTreeMap is used since it is an ordered map. Using a HashMap would
-    // not yield this guarantee, and therefore is discarded.
+    // a BTreeMap is used since it is an ordered map. A HashMap would
+    // give the aforementioned guarantee, and therefore is discarded.
     db: RwLock<enum_map::EnumMap<DBCol, BTreeMap<Vec<u8>, Vec<u8>>>>,
 }
 

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -575,4 +575,63 @@ mod tests {
         #[cfg(feature = "no_cache")]
         panic!("no cache is enabled");
     }
+
+    /// Asserts that elements in the vector are sorted.
+    fn assert_sorted(want_count: usize, keys: Vec<Box<[u8]>>) {
+        assert_eq!(want_count, keys.len());
+        for (pos, pair) in keys.windows(2).enumerate() {
+            let (fst, snd) = (&pair[0], &pair[1]);
+            assert!(fst <= snd, "{fst:?} > {snd:?} at {pos}");
+        }
+    }
+
+    /// Checks that keys are sorted when iterating.
+    fn test_iter_order_impl(store: crate::Store, count: usize) {
+        use rand::Rng;
+
+        // An arbitrary non-rc non-insert-only column we can write data into.
+        const COLUMN: crate::DBCol = crate::DBCol::Peers;
+        assert!(!COLUMN.is_rc());
+        assert!(!COLUMN.is_insert_only());
+
+        // Fill column with random keys.  We're inserting three sets of keys.
+        // One set prefixed by "foo", second by "bar" and last by "baz".  Each
+        // set is `count` keys (for total of `3*count` keys).
+        let mut rng: rand::rngs::StdRng = rand::SeedableRng::seed_from_u64(0x3243f6a8885a308d);
+        let mut update = store.store_update();
+        let mut buf = [0u8; 20];
+        for prefix in [b"foo", b"bar", b"baz"] {
+            buf[..prefix.len()].clone_from_slice(prefix);
+            for _ in 0..count {
+                rng.fill(&mut buf[prefix.len()..]);
+                update.set(COLUMN, &buf, &buf);
+            }
+        }
+        update.commit().unwrap();
+
+        // Check that full scan produces keys in proper order.
+        let keys: Vec<Box<[u8]>> = store.iter(COLUMN).map(|(key, _)| key).collect();
+        assert_sorted(3 * count, keys);
+
+        let keys: Vec<Box<[u8]>> = store.iter_raw_bytes(COLUMN).map(|(key, _)| key).collect();
+        assert_sorted(3 * count, keys);
+
+        // Check that prefix scan produces keys in proper order.
+        let keys: Vec<Box<[u8]>> = store.iter_prefix(COLUMN, b"baz").map(|(key, _)| key).collect();
+        for (pos, key) in keys.iter().enumerate() {
+            assert_eq!(b"baz", &key[0..3], "Expected ‘baz’ prefix but got {key:?} at {pos}");
+        }
+        assert_sorted(count, keys);
+    }
+
+    #[test]
+    fn rocksdb_iter_order() {
+        let (_tmp_dir, opener) = crate::Store::tmp_opener();
+        test_iter_order_impl(opener.open(), 10_000);
+    }
+
+    #[test]
+    fn testdb_iter_order() {
+        test_iter_order_impl(crate::test_utils::create_test_store(), 10_000);
+    }
 }


### PR DESCRIPTION
Fixes: #7024

Test plan
---------
I did not find a test that could be updated/enhanced to validate that the iteration would remain deterministic.
Not sure whether this extra step is needed. But if it is, I'd appreciate some guidance.

Edit:

Added two tests: `rocksdb_iter_order` and `testdb_iter_order`. These two tests that there is determinism
when calling the `iter` functions.