### PR TITLE
Add missing ‘chain/telemetry’ to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "chain/network",
     "chain/pool",
     "chain/rosetta-rpc",
+    "chain/telemetry",
     "core/account-id",
     "core/account-id/fuzz",
     "core/chain-configs",


### PR DESCRIPTION
Fixes: https://github.com/near/nearcore/issues/4541