### PR TITLE
neard: remove ‘testnet’ command alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
   RocksDB configurable via `config.json` file (at `store.path` path)
   rather than being hard-coded to `data` directory in neard home
   directory [#6938](https://github.com/near/nearcore/pull/6938)
+* Removed `testnet` alias for `localnet` command; the alias has been
+  deprecated since 1.24
 
 ## 1.26.0 [2022-05-18]
 

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -68,13 +68,6 @@ impl NeardCmd {
         match neard_cmd.subcmd {
             NeardSubCommand::Init(cmd) => cmd.run(&home_dir),
             NeardSubCommand::Localnet(cmd) => cmd.run(&home_dir),
-            NeardSubCommand::Testnet(cmd) => {
-                warn!(
-                    "The 'testnet' command has been renamed to 'localnet' \
-                           and will be removed in the future"
-                );
-                cmd.run(&home_dir);
-            }
             NeardSubCommand::Run(cmd) => cmd.run(&home_dir, genesis_validation, runtime),
 
             // TODO(mina86): Remove the command in Q3 2022.
@@ -181,13 +174,6 @@ pub(super) enum NeardSubCommand {
     /// Sets up local configuration with all necessary files (validator key, node key, genesis and
     /// config)
     Localnet(LocalnetCmd),
-    /// DEPRECATED: this command has been renamed to 'localnet' and will be removed in a future
-    /// release.
-    // We’re not using clap(alias = "testnet") on Localnet because we want this
-    // to be a separate subcommand with a deprecation warning.  TODO(#4372):
-    // Deprecated since 1.24.  Delete it in a couple of releases in 2022.
-    #[clap(hide = true)]
-    Testnet(LocalnetCmd),
     /// (unsafe) Remove the entire NEAR home directory (which includes the
     /// configuration, genesis files, private keys and data).  This effectively
     /// removes all information about the network.


### PR DESCRIPTION
The ‘testnet’ command has been deprecated since 1.24 in favour of
‘localnet’.  Remove it.