### PR TITLE
crypto: add ‘private_key’ alias for ‘secret_key’ field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,13 @@
   RocksDB configurable via `config.json` file (at `store.path` path)
   rather than being hard-coded to `data` directory in neard home
   directory [#6938](https://github.com/near/nearcore/pull/6938)
-* Removed `testnet` alias for `localnet` command; the alias has been
-  deprecated since 1.24 [#7033](https://github.com/near/nearcore/pull/7033)
+* Removed `testnet` alias for `localnet` command; it’s been deprecated
+  since 1.24 [#7033](https://github.com/near/nearcore/pull/7033)
 * Removed undocumented `unsafe_reset_all` and `unsafe_reset_data`
-  commands.  They were deprecated since 1.25
+  commands; they were deprecated since 1.25
+* Key files can use `private_key` field instead of `secret_key` now;
+  this improves interoperability with near cli which uses the former
+  name [#7030](https://github.com/near/nearcore/issues/7030)
 
 ## 1.26.0 [2022-05-18]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2857,6 +2857,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.2",
  "subtle",
+ "tempfile",
  "thiserror",
 ]
 

--- a/core/crypto/Cargo.toml
+++ b/core/crypto/Cargo.toml
@@ -34,6 +34,7 @@ deepsize = { version = "0.2.0", optional = true }
 [dev-dependencies]
 hex-literal = "0.2"
 sha2 = ">=0.8,<=0.10"
+tempfile = "3.3"
 
 [features]
 deepsize_feature = [

--- a/core/crypto/src/key_file.rs
+++ b/core/crypto/src/key_file.rs
@@ -13,6 +13,10 @@ use near_account_id::AccountId;
 pub struct KeyFile {
     pub account_id: AccountId,
     pub public_key: PublicKey,
+    // Credential files generated which near cli works with have private_key
+    // rather than secret_key field.  To make it possible to read those from
+    // neard add private_key as an alias to this field so either will work.
+    #[serde(alias = "private_key")]
     pub secret_key: SecretKey,
 }
 
@@ -34,4 +38,37 @@ impl KeyFile {
         let content = std::fs::read_to_string(path)?;
         Ok(serde_json::from_str(&content)?)
     }
+}
+
+#[test]
+fn test_from_file() {
+    fn load(contents: &[u8]) -> io::Result<KeyFile> {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.as_file().write_all(contents).unwrap();
+        let result = KeyFile::from_file(tmp.path());
+        tmp.close().unwrap();
+        result
+    }
+
+    load(br#"{
+        "account_id": "example",
+        "public_key": "ed25519:6DSjZ8mvsRZDvFqFxo8tCKePG96omXW7eVYVSySmDk8e",
+        "secret_key": "ed25519:3D4YudUahN1nawWogh8pAKSj92sUNMdbZGjn7kERKzYoTy8tnFQuwoGUC51DowKqorvkr2pytJSnwuSbsNVfqygr"
+    }"#).unwrap();
+
+    load(br#"{
+        "account_id": "example",
+        "public_key": "ed25519:6DSjZ8mvsRZDvFqFxo8tCKePG96omXW7eVYVSySmDk8e",
+        "private_key": "ed25519:3D4YudUahN1nawWogh8pAKSj92sUNMdbZGjn7kERKzYoTy8tnFQuwoGUC51DowKqorvkr2pytJSnwuSbsNVfqygr"
+    }"#).unwrap();
+
+    let err = load(br#"{
+        "account_id": "example",
+        "public_key": "ed25519:6DSjZ8mvsRZDvFqFxo8tCKePG96omXW7eVYVSySmDk8e",
+        "secret_key": "ed25519:3D4YudUahN1nawWogh8pAKSj92sUNMdbZGjn7kERKzYoTy8tnFQuwoGUC51DowKqorvkr2pytJSnwuSbsNVfqygr",
+        "private_key": "ed25519:3D4YudUahN1nawWogh8pAKSj92sUNMdbZGjn7kERKzYoTy8tnFQuwoGUC51DowKqorvkr2pytJSnwuSbsNVfqygr"
+    }"#).map(|key| key.account_id).unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    let inner_msg = err.into_inner().unwrap().to_string();
+    assert!(inner_msg.contains("duplicate field"));
 }


### PR DESCRIPTION
To make it easier to use credential files that near cli tool works
with, introduce ‘private_key’ alias for the ‘secret_key’ field in
KeyFile struct.  This way, the JSON file can have either of those
fields set and it’ll be read correctly.

Fixes: https://github.com/near/nearcore/issues/7030