### PR TITLE
refactor: introduce ViewClientHandle

### DIFF
--- a/chain/client/src/lib.rs
+++ b/chain/client/src/lib.rs
@@ -11,6 +11,7 @@ pub use near_client_primitives::types::{
 pub use crate::client::Client;
 pub use crate::client_actor::{start_client, ClientActor};
 pub use crate::view_client::{start_view_client, ViewClientActor};
+pub use crate::view_client_handle::ViewClientHandle;
 
 pub mod adversarial;
 mod client;
@@ -23,3 +24,4 @@ pub mod test_utils;
 #[cfg(test)]
 mod tests;
 mod view_client;
+mod view_client_handle;

--- a/chain/client/src/tests/bug_repros.rs
+++ b/chain/client/src/tests/bug_repros.rs
@@ -10,7 +10,7 @@ use futures::FutureExt;
 use rand::{thread_rng, Rng};
 
 use crate::test_utils::setup_mock_all_validators;
-use crate::{ClientActor, GetBlock, ViewClientActor};
+use crate::{ClientActor, GetBlock, ViewClientHandle};
 use near_actix_test_utils::run_actix;
 use near_chain::test_utils::account_id_to_shard_id;
 use near_crypto::{InMemorySigner, KeyType};
@@ -30,7 +30,7 @@ fn repro_1183() {
     let validator_groups = 2;
     init_test_logger();
     run_actix(async {
-        let connectors: Arc<RwLock<Vec<(Addr<ClientActor>, Addr<ViewClientActor>)>>> =
+        let connectors: Arc<RwLock<Vec<(Addr<ClientActor>, ViewClientHandle)>>> =
             Arc::new(RwLock::new(vec![]));
 
         let validators = vec![vec![

--- a/chain/client/src/tests/catching_up.rs
+++ b/chain/client/src/tests/catching_up.rs
@@ -7,7 +7,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use futures::{future, FutureExt};
 
 use crate::test_utils::setup_mock_all_validators;
-use crate::{ClientActor, Query, ViewClientActor};
+use crate::{ClientActor, Query, ViewClientHandle};
 use near_actix_test_utils::run_actix;
 use near_chain::test_utils::account_id_to_shard_id;
 use near_chain_configs::TEST_STATE_SYNC_TIMEOUT;
@@ -131,7 +131,7 @@ fn test_catchup_receipts_sync_common(wait_till: u64, send: u64, sync_hold: bool)
     let validator_groups = 1;
     init_integration_logger();
     run_actix(async move {
-        let connectors: Arc<RwLock<Vec<(Addr<ClientActor>, Addr<ViewClientActor>)>>> =
+        let connectors: Arc<RwLock<Vec<(Addr<ClientActor>, ViewClientHandle)>>> =
             Arc::new(RwLock::new(vec![]));
 
         let (validators, key_pairs) = get_validators_and_key_pairs();
@@ -415,7 +415,7 @@ fn test_catchup_random_single_part_sync_common(skip_15: bool, non_zero: bool, he
     let validator_groups = 2;
     init_integration_logger();
     run_actix(async move {
-        let connectors: Arc<RwLock<Vec<(Addr<ClientActor>, Addr<ViewClientActor>)>>> =
+        let connectors: Arc<RwLock<Vec<(Addr<ClientActor>, ViewClientHandle)>>> =
             Arc::new(RwLock::new(vec![]));
 
         let (validators, key_pairs) = get_validators_and_key_pairs();
@@ -625,7 +625,7 @@ fn test_catchup_sanity_blocks_produced() {
     let validator_groups = 2;
     init_integration_logger();
     run_actix(async move {
-        let connectors: Arc<RwLock<Vec<(Addr<ClientActor>, Addr<ViewClientActor>)>>> =
+        let connectors: Arc<RwLock<Vec<(Addr<ClientActor>, ViewClientHandle)>>> =
             Arc::new(RwLock::new(vec![]));
 
         let heights = Arc::new(RwLock::new(HashMap::new()));
@@ -700,7 +700,7 @@ fn test_chunk_grieving() {
     let validator_groups = 1;
     init_integration_logger();
     run_actix(async move {
-        let connectors: Arc<RwLock<Vec<(Addr<ClientActor>, Addr<ViewClientActor>)>>> =
+        let connectors: Arc<RwLock<Vec<(Addr<ClientActor>, ViewClientHandle)>>> =
             Arc::new(RwLock::new(vec![]));
 
         let (validators, key_pairs) = get_validators_and_key_pairs();
@@ -870,7 +870,7 @@ fn test_all_chunks_accepted_common(
     let validator_groups = 1;
     init_integration_logger();
     run_actix(async move {
-        let connectors: Arc<RwLock<Vec<(Addr<ClientActor>, Addr<ViewClientActor>)>>> =
+        let connectors: Arc<RwLock<Vec<(Addr<ClientActor>, ViewClientHandle)>>> =
             Arc::new(RwLock::new(vec![]));
 
         let (validators, key_pairs) = get_validators_and_key_pairs();

--- a/chain/client/src/tests/consensus.rs
+++ b/chain/client/src/tests/consensus.rs
@@ -5,7 +5,7 @@ use actix::{Addr, System};
 use rand::{thread_rng, Rng};
 
 use crate::test_utils::setup_mock_all_validators;
-use crate::{ClientActor, ViewClientActor};
+use crate::{ClientActor, ViewClientHandle};
 use near_actix_test_utils::run_actix;
 use near_chain::Block;
 use near_logger_utils::init_integration_logger;
@@ -29,7 +29,7 @@ fn test_consensus_with_epoch_switches() {
     const HEIGHT_GOAL: u64 = 120;
 
     run_actix(async move {
-        let connectors: Arc<RwLock<Vec<(Addr<ClientActor>, Addr<ViewClientActor>)>>> =
+        let connectors: Arc<RwLock<Vec<(Addr<ClientActor>, ViewClientHandle)>>> =
             Arc::new(RwLock::new(vec![]));
         let connectors1 = connectors.clone();
 

--- a/chain/client/src/tests/cross_shard_tx.rs
+++ b/chain/client/src/tests/cross_shard_tx.rs
@@ -23,7 +23,7 @@ use near_primitives::views::QueryResponseKind::ViewAccount;
 use near_primitives::views::{QueryRequest, QueryResponse};
 
 use crate::test_utils::{setup_mock_all_validators, BlockStats};
-use crate::{ClientActor, Query, ViewClientActor};
+use crate::{ClientActor, Query, ViewClientActor, ViewClientHandle};
 
 /// Tests that the KeyValueRuntime properly sets balances in genesis and makes them queriable
 #[test]
@@ -32,7 +32,7 @@ fn test_keyvalue_runtime_balances() {
     let successful_queries = Arc::new(AtomicUsize::new(0));
     init_integration_logger();
     run_actix(async move {
-        let connectors: Arc<RwLock<Vec<(Addr<ClientActor>, Addr<ViewClientActor>)>>> =
+        let connectors: Arc<RwLock<Vec<(Addr<ClientActor>, ViewClientHandle)>>> =
             Arc::new(RwLock::new(vec![]));
 
         let validators = vec![vec![
@@ -98,7 +98,7 @@ fn test_keyvalue_runtime_balances() {
 
 fn send_tx(
     num_validators: usize,
-    connectors: Arc<RwLock<Vec<(Addr<ClientActor>, Addr<ViewClientActor>)>>>,
+    connectors: Arc<RwLock<Vec<(Addr<ClientActor>, ViewClientHandle)>>>,
     connector_ordinal: usize,
     from: AccountId,
     to: AccountId,
@@ -157,7 +157,7 @@ fn send_tx(
 fn test_cross_shard_tx_callback(
     res: Result<Result<QueryResponse, crate::QueryError>, MailboxError>,
     account_id: AccountId,
-    connectors: Arc<RwLock<Vec<(Addr<ClientActor>, Addr<ViewClientActor>)>>>,
+    connectors: Arc<RwLock<Vec<(Addr<ClientActor>, ViewClientHandle)>>>,
     iteration: Arc<AtomicUsize>,
     nonce: Arc<AtomicUsize>,
     validators: Vec<AccountId>,
@@ -383,7 +383,7 @@ fn test_cross_shard_tx_common(
     let validator_groups = 4;
     init_integration_logger();
     run_actix(async move {
-        let connectors: Arc<RwLock<Vec<(Addr<ClientActor>, Addr<ViewClientActor>)>>> =
+        let connectors: Arc<RwLock<Vec<(Addr<ClientActor>, ViewClientHandle)>>> =
             Arc::new(RwLock::new(vec![]));
 
         let validators: Vec<Vec<_>> = if rotate_validators {

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -9,7 +9,7 @@ use std::hash::Hash;
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
-use actix::{Actor, Addr, Handler, SyncArbiter, SyncContext};
+use actix::{Actor, Handler, SyncArbiter, SyncContext};
 use tracing::{debug, error, info, trace, warn};
 
 use near_chain::types::ValidatorInfoIdentifier;
@@ -58,7 +58,7 @@ use near_primitives::views::{
 
 use crate::{
     sync, GetChunk, GetExecutionOutcomeResponse, GetNextLightClientBlock, GetStateChanges,
-    GetStateChangesInBlock, GetValidatorInfo, GetValidatorOrdered,
+    GetStateChangesInBlock, GetValidatorInfo, GetValidatorOrdered, ViewClientHandle,
 };
 
 /// Max number of queries that we keep.
@@ -1365,7 +1365,7 @@ pub fn start_view_client(
     network_adapter: Arc<dyn PeerManagerAdapter>,
     config: ClientConfig,
     adv: crate::adversarial::Controls,
-) -> Addr<ViewClientActor> {
+) -> ViewClientHandle {
     let request_manager = Arc::new(RwLock::new(ViewClientRequestManager::new()));
     SyncArbiter::start(config.view_client_threads, move || {
         // ViewClientActor::start_in_arbiter(&Arbiter::current(), move |_ctx| {

--- a/chain/client/src/view_client_handle.rs
+++ b/chain/client/src/view_client_handle.rs
@@ -1,0 +1,20 @@
+use actix::Addr;
+
+use crate::ViewClientActor;
+
+/// ViewClientHandle is the public API for read-only queries to chain.
+///
+/// It is an asynchronous API: the chain generally exists on a different thread
+/// from `ViewClientHandle`, so its methods don't do computation directly, but
+/// rather just send messages to that other thread. That's why this is a
+/// "Handle", rather than just "View Client".
+///
+/// At the moment `ViewClientHandle` doesn't express any particular ownership
+/// over the chain: even if you have `ViewClientHandle`, the chain might already
+/// be dead. in such cases, methods here can return an error or panic.
+///
+/// Historically, we directly exposed underlying actix' actor here. Now we are
+/// moving away from actix, and, as a first step, trying to make sure that actix
+/// types do not leak outside. This isn't a one PR worth of work though, so you
+/// are witnessing an intermediate state here!
+pub type ViewClientHandle = Addr<ViewClientActor>;

--- a/chain/indexer/src/lib.rs
+++ b/chain/indexer/src/lib.rs
@@ -83,7 +83,7 @@ pub struct IndexerConfig {
 pub struct Indexer {
     indexer_config: IndexerConfig,
     near_config: nearcore::NearConfig,
-    view_client: actix::Addr<near_client::ViewClientActor>,
+    view_client: near_client::ViewClientHandle,
     client: actix::Addr<near_client::ClientActor>,
 }
 
@@ -134,7 +134,7 @@ impl Indexer {
     /// Internal client actors just in case. Use on your own risk, backward compatibility is not guaranteed
     pub fn client_actors(
         &self,
-    ) -> (actix::Addr<near_client::ViewClientActor>, actix::Addr<near_client::ClientActor>) {
+    ) -> (near_client::ViewClientHandle, actix::Addr<near_client::ClientActor>) {
         (self.view_client.clone(), self.client.clone())
     }
 }

--- a/chain/indexer/src/streamer/fetchers.rs
+++ b/chain/indexer/src/streamer/fetchers.rs
@@ -25,7 +25,7 @@ pub(crate) async fn fetch_status(
 /// Fetches the status to retrieve `latest_block_height` to determine if we need to fetch
 /// entire block or we already fetched this block.
 pub(crate) async fn fetch_latest_block(
-    client: &Addr<near_client::ViewClientActor>,
+    client: &near_client::ViewClientHandle,
 ) -> Result<views::BlockView, FailedToFetchData> {
     client
         .send(near_client::GetBlock(near_primitives::types::BlockReference::Finality(
@@ -37,7 +37,7 @@ pub(crate) async fn fetch_latest_block(
 
 /// Fetches specific block by it's height
 pub(crate) async fn fetch_block_by_height(
-    client: &Addr<near_client::ViewClientActor>,
+    client: &near_client::ViewClientHandle,
     height: u64,
 ) -> Result<views::BlockView, FailedToFetchData> {
     client
@@ -48,7 +48,7 @@ pub(crate) async fn fetch_block_by_height(
 
 /// Fetches specific block by it's hash
 pub(crate) async fn fetch_block_by_hash(
-    client: &Addr<near_client::ViewClientActor>,
+    client: &near_client::ViewClientHandle,
     hash: CryptoHash,
 ) -> Result<views::BlockView, FailedToFetchData> {
     client
@@ -58,7 +58,7 @@ pub(crate) async fn fetch_block_by_hash(
 }
 
 pub(crate) async fn fetch_state_changes(
-    client: &Addr<near_client::ViewClientActor>,
+    client: &near_client::ViewClientHandle,
     block_hash: CryptoHash,
     epoch_id: near_primitives::types::EpochId,
 ) -> Result<HashMap<near_primitives::types::ShardId, views::StateChangesView>, FailedToFetchData> {
@@ -71,7 +71,7 @@ pub(crate) async fn fetch_state_changes(
 /// Fetch all ExecutionOutcomeWithId for current block
 /// Returns a HashMap where the key is shard id IndexerExecutionOutcomeWithOptionalReceipt
 pub(crate) async fn fetch_outcomes(
-    client: &Addr<near_client::ViewClientActor>,
+    client: &near_client::ViewClientHandle,
     block_hash: CryptoHash,
 ) -> Result<
     HashMap<near_primitives::types::ShardId, Vec<IndexerExecutionOutcomeWithOptionalReceipt>>,
@@ -113,7 +113,7 @@ pub(crate) async fn fetch_outcomes(
 }
 
 async fn fetch_receipt_by_id(
-    client: &Addr<near_client::ViewClientActor>,
+    client: &near_client::ViewClientHandle,
     receipt_id: CryptoHash,
 ) -> Result<Option<views::ReceiptView>, FailedToFetchData> {
     client
@@ -125,7 +125,7 @@ async fn fetch_receipt_by_id(
 /// Fetches single chunk (as `near_primitives::views::ChunkView`) by provided
 /// chunk hash.
 async fn fetch_single_chunk(
-    client: &Addr<near_client::ViewClientActor>,
+    client: &near_client::ViewClientHandle,
     chunk_hash: near_primitives::hash::CryptoHash,
 ) -> Result<views::ChunkView, FailedToFetchData> {
     client
@@ -137,7 +137,7 @@ async fn fetch_single_chunk(
 /// Fetches all chunks belonging to given block.
 /// Includes transactions and receipts in custom struct (to provide more info).
 pub(crate) async fn fetch_block_chunks(
-    client: &Addr<near_client::ViewClientActor>,
+    client: &near_client::ViewClientHandle,
     block: &views::BlockView,
 ) -> Result<Vec<views::ChunkView>, FailedToFetchData> {
     let mut futures: futures::stream::FuturesUnordered<_> = block
@@ -154,7 +154,7 @@ pub(crate) async fn fetch_block_chunks(
 }
 
 pub(crate) async fn fetch_protocol_config(
-    client: &Addr<near_client::ViewClientActor>,
+    client: &near_client::ViewClientHandle,
     block_hash: near_primitives::hash::CryptoHash,
 ) -> Result<near_chain_configs::ProtocolConfigView, FailedToFetchData> {
     Ok(client

--- a/chain/indexer/src/streamer/mod.rs
+++ b/chain/indexer/src/streamer/mod.rs
@@ -66,7 +66,7 @@ fn test_problematic_blocks_hash() {
 /// and returns everything together in one struct
 #[async_recursion]
 async fn build_streamer_message(
-    client: &Addr<near_client::ViewClientActor>,
+    client: &near_client::ViewClientHandle,
     block: views::BlockView,
 ) -> Result<StreamerMessage, FailedToFetchData> {
     let chunks = fetch_block_chunks(&client, &block).await?;
@@ -233,7 +233,7 @@ async fn build_streamer_message(
 /// Function that tries to find specific local receipt by it's ID and returns it
 /// otherwise returns None
 async fn find_local_receipt_by_id_in_block(
-    client: &Addr<near_client::ViewClientActor>,
+    client: &near_client::ViewClientHandle,
     protocol_config_view: &near_chain_configs::ProtocolConfigView,
     block: views::BlockView,
     receipt_id: near_primitives::hash::CryptoHash,
@@ -278,9 +278,9 @@ async fn find_local_receipt_by_id_in_block(
 /// Function that starts Streamer's busy loop. Every half a seconds it fetches the status
 /// compares to already fetched block height and in case it differs fetches new block of given height.
 ///
-/// We have to pass `client: Addr<near_client::ClientActor>` and `view_client: Addr<near_client::ViewClientActor>`.
+/// We have to pass `client: Addr<near_client::ClientActor>` and `view_client: near_client::ViewClientHandle`.
 pub(crate) async fn start(
-    view_client: Addr<near_client::ViewClientActor>,
+    view_client: near_client::ViewClientHandle,
     client: Addr<near_client::ClientActor>,
     indexer_config: IndexerConfig,
     store_config: near_store::StoreConfig,

--- a/chain/indexer/src/streamer/utils.rs
+++ b/chain/indexer/src/streamer/utils.rs
@@ -1,5 +1,3 @@
-use actix::Addr;
-
 use near_indexer_primitives::IndexerTransactionWithOutcome;
 use near_primitives::views;
 use node_runtime::config::tx_cost;
@@ -8,7 +6,7 @@ use super::errors::FailedToFetchData;
 use super::fetchers::fetch_block_by_hash;
 
 pub(crate) async fn convert_transactions_sir_into_local_receipts(
-    client: &Addr<near_client::ViewClientActor>,
+    client: &near_client::ViewClientHandle,
     protocol_config: &near_chain_configs::ProtocolConfigView,
     txs: Vec<&IndexerTransactionWithOutcome>,
     block: &views::BlockView,

--- a/chain/jsonrpc/jsonrpc-tests/src/lib.rs
+++ b/chain/jsonrpc/jsonrpc-tests/src/lib.rs
@@ -1,11 +1,11 @@
-use actix::Addr;
 use futures::{future, future::LocalBoxFuture, FutureExt, TryFutureExt};
 use once_cell::sync::Lazy;
 use serde_json::json;
 
 use near_chain_configs::GenesisConfig;
-use near_client::test_utils::setup_no_network_with_validity_period_and_no_epoch_sync;
-use near_client::ViewClientActor;
+use near_client::{
+    test_utils::setup_no_network_with_validity_period_and_no_epoch_sync, ViewClientHandle,
+};
 use near_jsonrpc::{start_http, RpcConfig};
 use near_jsonrpc_primitives::message::{from_slice, Message};
 use near_network::test_utils::open_port;
@@ -21,7 +21,7 @@ pub enum NodeType {
     NonValidator,
 }
 
-pub fn start_all(node_type: NodeType) -> (Addr<ViewClientActor>, String) {
+pub fn start_all(node_type: NodeType) -> (ViewClientHandle, String) {
     start_all_with_validity_period_and_no_epoch_sync(node_type, 100, false)
 }
 
@@ -29,7 +29,7 @@ pub fn start_all_with_validity_period_and_no_epoch_sync(
     node_type: NodeType,
     transaction_validity_period: NumBlocks,
     enable_doomslug: bool,
-) -> (Addr<ViewClientActor>, String) {
+) -> (ViewClientHandle, String) {
     let (client_addr, view_client_addr) = setup_no_network_with_validity_period_and_no_epoch_sync(
         vec!["test1".parse().unwrap(), "test2".parse().unwrap()],
         if let NodeType::Validator = node_type {

--- a/chain/rosetta-rpc/src/adapters/mod.rs
+++ b/chain/rosetta-rpc/src/adapters/mod.rs
@@ -1,9 +1,7 @@
 use std::sync::Arc;
 
-use actix::Addr;
-
 use near_chain_configs::Genesis;
-use near_client::ViewClientActor;
+use near_client::ViewClientHandle;
 
 use validated_operations::ValidatedOperation;
 
@@ -19,7 +17,7 @@ mod validated_operations;
 /// We choose to do a proper implementation for the genesis block later.
 async fn convert_genesis_records_to_transaction(
     genesis: Arc<Genesis>,
-    view_client_addr: Addr<ViewClientActor>,
+    view_client_addr: ViewClientHandle,
     block: &near_primitives::views::BlockView,
 ) -> crate::errors::Result<crate::models::Transaction> {
     let genesis_account_ids = genesis.records.as_ref().iter().filter_map(|record| {
@@ -111,7 +109,7 @@ async fn convert_genesis_records_to_transaction(
 }
 
 pub(crate) async fn convert_block_to_transactions(
-    view_client_addr: Addr<ViewClientActor>,
+    view_client_addr: ViewClientHandle,
     block: &near_primitives::views::BlockView,
 ) -> crate::errors::Result<Vec<crate::models::Transaction>> {
     let state_changes = view_client_addr
@@ -173,7 +171,7 @@ pub(crate) async fn convert_block_to_transactions(
 
 pub(crate) async fn collect_transactions(
     genesis: Arc<Genesis>,
-    view_client_addr: Addr<ViewClientActor>,
+    view_client_addr: ViewClientHandle,
     block: &near_primitives::views::BlockView,
 ) -> crate::errors::Result<Vec<crate::models::Transaction>> {
     if block.header.prev_hash == Default::default() {

--- a/chain/rosetta-rpc/src/adapters/transactions.rs
+++ b/chain/rosetta-rpc/src/adapters/transactions.rs
@@ -1,8 +1,6 @@
 use std::collections::HashMap;
 use std::string::ToString;
 
-use actix::Addr;
-
 use near_primitives::hash::CryptoHash;
 use near_primitives::views::SignedTransactionView;
 
@@ -20,7 +18,7 @@ impl ExecutionToReceipts {
     /// transaction or receipt causing the execution to list of created
     /// receipts’ hashes.
     pub(crate) async fn for_block(
-        view_client_addr: Addr<near_client::ViewClientActor>,
+        view_client_addr: near_client::ViewClientHandle,
         block_hash: CryptoHash,
     ) -> crate::errors::Result<Self> {
         let block = view_client_addr

--- a/chain/rosetta-rpc/src/lib.rs
+++ b/chain/rosetta-rpc/src/lib.rs
@@ -14,7 +14,7 @@ use paperclip::actix::{
 use strum::IntoEnumIterator;
 
 use near_chain_configs::Genesis;
-use near_client::{ClientActor, ViewClientActor};
+use near_client::{ClientActor, ViewClientHandle};
 use near_primitives::borsh::BorshDeserialize;
 use near_primitives::serialize::BaseEncode;
 
@@ -94,7 +94,7 @@ async fn network_list(
 async fn network_status(
     genesis: web::Data<Genesis>,
     client_addr: web::Data<Addr<ClientActor>>,
-    view_client_addr: web::Data<Addr<ViewClientActor>>,
+    view_client_addr: web::Data<ViewClientHandle>,
     body: Json<models::NetworkRequest>,
 ) -> Result<Json<models::NetworkStatusResponse>, models::Error> {
     let Json(models::NetworkRequest { network_identifier }) = body;
@@ -207,7 +207,7 @@ async fn network_options(
 async fn block_details(
     genesis: web::Data<Genesis>,
     client_addr: web::Data<Addr<ClientActor>>,
-    view_client_addr: web::Data<Addr<ViewClientActor>>,
+    view_client_addr: web::Data<ViewClientHandle>,
     body: Json<models::BlockRequest>,
 ) -> Result<Json<models::BlockResponse>, models::Error> {
     let Json(models::BlockRequest { network_identifier, block_identifier }) = body;
@@ -281,7 +281,7 @@ async fn block_details(
 async fn block_transaction_details(
     genesis: web::Data<Genesis>,
     client_addr: web::Data<Addr<ClientActor>>,
-    view_client_addr: web::Data<Addr<ViewClientActor>>,
+    view_client_addr: web::Data<ViewClientHandle>,
     body: Json<models::BlockTransactionRequest>,
 ) -> Result<Json<models::BlockTransactionResponse>, models::Error> {
     let Json(models::BlockTransactionRequest {
@@ -330,7 +330,7 @@ async fn block_transaction_details(
 /// optional BlockIdentifier.
 async fn account_balance(
     client_addr: web::Data<Addr<ClientActor>>,
-    view_client_addr: web::Data<Addr<ViewClientActor>>,
+    view_client_addr: web::Data<ViewClientHandle>,
     body: Json<models::AccountBalanceRequest>,
 ) -> Result<Json<models::AccountBalanceResponse>, models::Error> {
     let Json(models::AccountBalanceRequest {
@@ -507,7 +507,7 @@ async fn construction_preprocess(
 /// because of the wide scope of metadata that could be required.
 async fn construction_metadata(
     client_addr: web::Data<Addr<ClientActor>>,
-    view_client_addr: web::Data<Addr<ViewClientActor>>,
+    view_client_addr: web::Data<ViewClientHandle>,
     body: Json<models::ConstructionMetadataRequest>,
 ) -> Result<Json<models::ConstructionMetadataResponse>, models::Error> {
     let Json(models::ConstructionMetadataRequest { network_identifier, options, public_keys }) =
@@ -786,7 +786,7 @@ pub fn start_rosetta_rpc(
     config: crate::config::RosettaRpcConfig,
     genesis: Arc<Genesis>,
     client_addr: Addr<ClientActor>,
-    view_client_addr: Addr<ViewClientActor>,
+    view_client_addr: ViewClientHandle,
 ) -> actix_web::dev::ServerHandle {
     let crate::config::RosettaRpcConfig { addr, cors_allowed_origins, limits } = config;
     let server = HttpServer::new(move || {

--- a/chain/rosetta-rpc/src/utils.rs
+++ b/chain/rosetta-rpc/src/utils.rs
@@ -1,8 +1,7 @@
-use actix::Addr;
 use futures::StreamExt;
 
 use near_chain_configs::ProtocolConfigView;
-use near_client::ViewClientActor;
+use near_client::ViewClientHandle;
 use near_primitives::borsh::{BorshDeserialize, BorshSerialize};
 
 use crate::{errors, models};
@@ -303,7 +302,7 @@ impl RosettaAccountBalances {
 pub(crate) async fn query_account(
     block_id: near_primitives::types::BlockReference,
     account_id: near_primitives::types::AccountId,
-    view_client_addr: &Addr<ViewClientActor>,
+    view_client_addr: &ViewClientHandle,
 ) -> Result<
     (
         near_primitives::hash::CryptoHash,
@@ -340,7 +339,7 @@ pub(crate) async fn query_account(
 pub(crate) async fn query_accounts<R>(
     block_id: &near_primitives::types::BlockReference,
     account_ids: impl Iterator<Item = &near_primitives::types::AccountId>,
-    view_client_addr: &Addr<ViewClientActor>,
+    view_client_addr: &ViewClientHandle,
 ) -> Result<R, crate::errors::ErrorKind>
 where
     R: std::iter::FromIterator<(
@@ -371,7 +370,7 @@ pub(crate) async fn query_access_key(
     block_id: near_primitives::types::BlockReference,
     account_id: near_primitives::types::AccountId,
     public_key: near_crypto::PublicKey,
-    view_client_addr: &Addr<ViewClientActor>,
+    view_client_addr: &ViewClientHandle,
 ) -> Result<
     (
         near_primitives::hash::CryptoHash,
@@ -411,7 +410,7 @@ pub(crate) async fn query_access_key(
 
 pub(crate) async fn query_protocol_config(
     block_hash: near_primitives::hash::CryptoHash,
-    view_client_addr: &Addr<ViewClientActor>,
+    view_client_addr: &ViewClientHandle,
 ) -> crate::errors::Result<ProtocolConfigView> {
     view_client_addr
         .send(near_client::GetProtocolConfig(near_primitives::types::BlockReference::from(
@@ -466,7 +465,7 @@ where
 /// Returns `Ok(None)` if the block does not exist or is not final.
 pub(crate) async fn get_block_if_final(
     block_id: &near_primitives::types::BlockReference,
-    view_client_addr: &Addr<ViewClientActor>,
+    view_client_addr: &ViewClientHandle,
 ) -> Result<Option<near_primitives::views::BlockView>, models::Error> {
     let final_block = get_final_block(view_client_addr).await?;
     let is_query_by_height = match block_id {
@@ -513,7 +512,7 @@ pub(crate) async fn get_block_if_final(
 }
 
 pub(crate) async fn get_final_block(
-    view_client_addr: &Addr<ViewClientActor>,
+    view_client_addr: &ViewClientHandle,
 ) -> Result<near_primitives::views::BlockView, errors::ErrorKind> {
     view_client_addr
         .send(near_client::GetBlock(near_primitives::types::BlockReference::Finality(

--- a/integration-tests/src/tests/client/chunks_management.rs
+++ b/integration-tests/src/tests/client/chunks_management.rs
@@ -13,7 +13,7 @@ use near_chunks::{
     CHUNK_REQUEST_SWITCH_TO_OTHERS_MS,
 };
 use near_client::test_utils::setup_mock_all_validators;
-use near_client::{ClientActor, GetBlock, ViewClientActor};
+use near_client::{ClientActor, GetBlock, ViewClientHandle};
 use near_logger_utils::init_test_logger;
 use near_network::types::PeerManagerMessageRequest;
 use near_network::types::{NetworkClientMessages, NetworkRequests, NetworkResponses};
@@ -32,7 +32,7 @@ fn chunks_produced_and_distributed_common(
 ) {
     init_test_logger();
 
-    let connectors: Arc<RwLock<Vec<(Addr<ClientActor>, Addr<ViewClientActor>)>>> =
+    let connectors: Arc<RwLock<Vec<(Addr<ClientActor>, ViewClientHandle)>>> =
         Arc::new(RwLock::new(vec![]));
     let heights = Arc::new(RwLock::new(HashMap::new()));
     let heights1 = heights;

--- a/integration-tests/src/tests/nearcore/node_cluster.rs
+++ b/integration-tests/src/tests/nearcore/node_cluster.rs
@@ -4,7 +4,7 @@ use actix_rt::ArbiterHandle;
 use futures::future;
 use near_actix_test_utils::{run_actix, spawn_interruptible};
 use near_chain_configs::Genesis;
-use near_client::{ClientActor, ViewClientActor};
+use near_client::{ClientActor, ViewClientHandle};
 use near_logger_utils::init_integration_logger;
 use near_network::test_utils::{convert_boot_nodes, open_port};
 use near_primitives::types::{BlockHeight, BlockHeightDelta, NumSeats, NumShards};
@@ -18,7 +18,7 @@ fn start_nodes(
     num_lightclient: NumSeats,
     epoch_length: BlockHeightDelta,
     genesis_height: BlockHeight,
-) -> (Genesis, Vec<String>, Vec<(Addr<ClientActor>, Addr<ViewClientActor>, Vec<ArbiterHandle>)>) {
+) -> (Genesis, Vec<String>, Vec<(Addr<ClientActor>, ViewClientHandle, Vec<ArbiterHandle>)>) {
     init_integration_logger();
 
     let num_tracking_nodes = num_nodes - num_lightclient;
@@ -113,11 +113,7 @@ impl NodeCluster {
         F: FnOnce(
             near_chain_configs::Genesis,
             Vec<String>,
-            Vec<(
-                actix::Addr<ClientActor>,
-                actix::Addr<ViewClientActor>,
-                Vec<actix_rt::ArbiterHandle>,
-            )>,
+            Vec<(actix::Addr<ClientActor>, ViewClientHandle, Vec<actix_rt::ArbiterHandle>)>,
         ) -> R,
     {
         let (num_shards, num_validator_seats, num_lightclient, epoch_length, genesis_height) = (

--- a/integration-tests/src/tests/nearcore/stake_nodes.rs
+++ b/integration-tests/src/tests/nearcore/stake_nodes.rs
@@ -11,7 +11,7 @@ use crate::genesis_helpers::genesis_hash;
 use crate::test_helpers::heavy_test;
 use near_actix_test_utils::run_actix;
 use near_chain_configs::Genesis;
-use near_client::{ClientActor, GetBlock, Query, Status, ViewClientActor};
+use near_client::{ClientActor, GetBlock, Query, Status, ViewClientHandle};
 use near_crypto::{InMemorySigner, KeyType};
 use near_logger_utils::init_integration_logger;
 use near_network::test_utils::{convert_boot_nodes, open_port, WaitOrTimeoutActor};
@@ -31,7 +31,7 @@ struct TestNode {
     signer: Arc<InMemorySigner>,
     config: NearConfig,
     client: Addr<ClientActor>,
-    view_client: Addr<ViewClientActor>,
+    view_client: ViewClientHandle,
     genesis_hash: CryptoHash,
 }
 

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -7,7 +7,7 @@ use actix_rt::ArbiterHandle;
 use actix_web;
 use anyhow::Context;
 use near_chain::ChainGenesis;
-use near_client::{start_client, start_view_client, ClientActor, ViewClientActor};
+use near_client::{start_client, start_view_client, ClientActor, ViewClientHandle};
 use near_network::routing::start_routing_table_actor;
 use near_network::test_utils::NetworkRecipient;
 use near_network::PeerManagerActor;
@@ -230,7 +230,7 @@ fn init_and_migrate_store(home_dir: &Path, near_config: &NearConfig) -> anyhow::
 
 pub struct NearNode {
     pub client: Addr<ClientActor>,
-    pub view_client: Addr<ViewClientActor>,
+    pub view_client: ViewClientHandle,
     pub arbiters: Vec<ArbiterHandle>,
     pub rpc_servers: Vec<(&'static str, actix_web::dev::ServerHandle)>,
 }

--- a/tools/mock_node/src/setup.rs
+++ b/tools/mock_node/src/setup.rs
@@ -8,7 +8,7 @@ use near_chain::{
     Chain, ChainGenesis, ChainStore, ChainStoreAccess, DoomslugThresholdMode, RuntimeAdapter,
 };
 use near_chain_configs::GenesisConfig;
-use near_client::{start_client, start_view_client, ClientActor, ViewClientActor};
+use near_client::{start_client, start_view_client, ClientActor, ViewClientHandle};
 use near_epoch_manager::EpochManager;
 use near_network::test_utils::NetworkRecipient;
 use near_network::types::NetworkClientMessages;
@@ -70,7 +70,7 @@ pub struct MockNode {
     // client under test
     pub client: Addr<ClientActor>,
     // view client under test
-    pub view_client: Addr<ViewClientActor>,
+    pub view_client: ViewClientHandle,
     // RPC servers started by the client
     pub servers: Option<Vec<(&'static str, actix_web::dev::ServerHandle)>>,
     // target height actually available to sync to in the chain history database


### PR DESCRIPTION
First step of https://github.com/near/nearcore/pull/7038

This PR introduces `ViewClientHandle` *name* and changes code to use that. At the moment its merely an alias, so no behavior changes here, just a shotgun diff. 