### PR TITLE
refactor: compress send&react to response pattern

### DIFF
--- a/chain/network/src/lib.rs
+++ b/chain/network/src/lib.rs
@@ -10,6 +10,7 @@ pub use crate::stats::metrics::RECEIVED_INFO_ABOUT_ITSELF;
 mod network_protocol;
 mod peer;
 mod peer_manager;
+mod view_client_adapter;
 #[cfg(feature = "test_features")]
 pub mod private_actix;
 #[cfg(not(feature = "test_features"))]

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -1,4 +1,5 @@
 use crate::network_protocol::{Encoding, ParsePeerMessageError};
+use crate::view_client_adapter::ViewClientAdapter;
 use crate::peer::codec::Codec;
 use crate::peer::tracker::Tracker;
 use crate::private_actix::{
@@ -88,7 +89,7 @@ pub(crate) struct PeerActor {
     /// Addr for client to send messages related to the chain.
     client_addr: Recipient<NetworkClientMessages>,
     /// Addr for view client to send messages related to the chain.
-    view_client_addr: Recipient<NetworkViewClientMessages>,
+    view_client_addr: ViewClientAdapter,
     /// Tracker for requests and responses.
     tracker: Tracker,
     /// This node genesis id.
@@ -142,7 +143,7 @@ impl PeerActor {
         peer_manager_addr: Recipient<PeerManagerMessageRequest>,
         peer_manager_wrapper_addr: Recipient<ActixMessageWrapper<PeerManagerMessageRequest>>,
         client_addr: Recipient<NetworkClientMessages>,
-        view_client_addr: Recipient<NetworkViewClientMessages>,
+        view_client_addr: ViewClientAdapter,
         partial_edge_info: Option<PartialEdgeInfo>,
         txns_since_last_block: Arc<AtomicUsize>,
         peer_counter: Arc<AtomicUsize>,

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -1,4 +1,5 @@
 use crate::network_protocol::Encoding;
+use crate::view_client_adapter::ViewClientAdapter;
 use crate::peer::codec::Codec;
 use crate::peer::peer_actor::PeerActor;
 use crate::peer_manager::peer_store::PeerStore;
@@ -180,7 +181,7 @@ pub struct PeerManagerActor {
     /// Address of the client actor.
     client_addr: Recipient<NetworkClientMessages>,
     /// Address of the view client actor.
-    view_client_addr: Recipient<NetworkViewClientMessages>,
+    view_client_addr: ViewClientAdapter,
     /// Peer store that provides read/write access to peers.
     peer_store: PeerStore,
     /// Set of outbound connections that were not consolidated yet.
@@ -302,7 +303,7 @@ impl PeerManagerActor {
         store: Store,
         config: NetworkConfig,
         client_addr: Recipient<NetworkClientMessages>,
-        view_client_addr: Recipient<NetworkViewClientMessages>,
+        view_client_addr: ViewClientAdapter,
         routing_table_addr: Addr<RoutingTableActor>,
     ) -> anyhow::Result<Self> {
         let peer_store =

--- a/chain/network/src/tests/peer_actor.rs
+++ b/chain/network/src/tests/peer_actor.rs
@@ -290,7 +290,7 @@ impl PeerHandle {
                     fa.clone().recipient(),
                     fa.clone().recipient(),
                     fa.clone().recipient(),
-                    fa.clone().recipient(),
+                    fa.clone().recipient().into(),
                     cfg.start_handshake_with.as_ref().map(|id| cfg.partial_edge_info(id, 1)),
                     Arc::new(AtomicUsize::new(0)),
                     Arc::new(AtomicUsize::new(0)),

--- a/chain/network/src/view_client_adapter.rs
+++ b/chain/network/src/view_client_adapter.rs
@@ -1,0 +1,79 @@
+use futures::future::BoxFuture;
+use futures::Future;
+use near_network_primitives::types::{NetworkViewClientMessages, NetworkViewClientResponses};
+use std::fmt;
+use std::sync::Arc;
+
+/// [`ViewClientAdapter`] defines the subset of view client's interface which is
+/// needed by the network.
+///
+/// It exists primarily to break inter-crate dependencies -- network should not
+/// know the specific type of the client.
+///
+/// [`ViewClientAdapter`] is a [`Clone`] handle to some concurrent object
+/// running in a different thread or task, so [`ViewClientAdapter::send`] is
+/// `async`.
+///
+/// In theory, sending can fail if the other side has already shut down. At the
+/// moment, we don't impose any lifetimes constraints here, and generally just
+/// ignore this case.
+///
+/// Implementation wise, this is a struct which holds a `dyn Trait` inside. As
+/// we only need to customize a single method (sending a message), a
+/// [`ViewClientAdapter`] can be constructed from arbitrary closure.
+#[derive(Clone)]
+pub struct ViewClientAdapter {
+    inner: Arc<
+        dyn Fn(
+                NetworkViewClientMessages,
+            )
+                -> BoxFuture<'static, Result<NetworkViewClientResponses, ViewClientIsDeadError>>
+            + Send
+            + Sync,
+    >,
+}
+
+impl ViewClientAdapter {
+    pub fn new<F, Fut>(send_msg: F) -> ViewClientAdapter
+    where
+        F: Fn(NetworkViewClientMessages) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<NetworkViewClientResponses, ViewClientIsDeadError>>
+            + Send
+            + 'static,
+    {
+        let inner = Arc::new(move |msg| Box::pin(send_msg(msg)) as BoxFuture<_>);
+        ViewClientAdapter { inner }
+    }
+
+    pub fn send(
+        &self,
+        msg: NetworkViewClientMessages,
+    ) -> impl Future<Output = Result<NetworkViewClientResponses, ViewClientIsDeadError>> {
+        (self.inner)(msg)
+    }
+}
+
+pub struct ViewClientIsDeadError;
+impl fmt::Display for ViewClientIsDeadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("ViewClient is dead")
+    }
+}
+
+impl From<actix::Recipient<NetworkViewClientMessages>> for ViewClientAdapter {
+    fn from(recipient: actix::Recipient<NetworkViewClientMessages>) -> Self {
+        Self::new(move |msg| {
+            let fut = recipient.send(msg);
+            async move {
+                let res = fut.await;
+                match res {
+                    Ok(it) => Ok(it),
+                    Err(actix::MailboxError::Closed) => Err(ViewClientIsDeadError),
+                    Err(actix::MailboxError::Timeout) => {
+                        unreachable!("don't actually call `send().timeout()`")
+                    }
+                }
+            }
+        })
+    }
+}

--- a/chain/network/src/view_client_adapter.rs
+++ b/chain/network/src/view_client_adapter.rs
@@ -45,7 +45,7 @@ impl ViewClientAdapter {
         ViewClientAdapter { inner }
     }
 
-    pub fn send(
+    pub(crate) fn send(
         &self,
         msg: NetworkViewClientMessages,
     ) -> impl Future<Output = Result<NetworkViewClientResponses, ViewClientIsDeadError>> {

--- a/integration-tests/src/tests/network/infinite_loop.rs
+++ b/integration-tests/src/tests/network/infinite_loop.rs
@@ -74,7 +74,7 @@ pub fn make_peer_manager(
             store,
             config,
             client_addr.recipient(),
-            view_client_addr.recipient(),
+            view_client_addr.recipient().into(),
             routing_table_addr,
         )
         .unwrap(),

--- a/integration-tests/src/tests/network/peer_handshake.rs
+++ b/integration-tests/src/tests/network/peer_handshake.rs
@@ -65,7 +65,7 @@ fn make_peer_manager(
         store,
         config,
         client_addr.recipient(),
-        view_client_addr.recipient(),
+        view_client_addr.recipient().into(),
         routing_table_addr,
     )
     .unwrap()

--- a/integration-tests/src/tests/network/runner.rs
+++ b/integration-tests/src/tests/network/runner.rs
@@ -113,7 +113,7 @@ fn setup_network_node(
             store.clone(),
             config,
             client_actor.recipient(),
-            view_client_actor.recipient(),
+            view_client_actor.recipient().into(),
             routing_table_addr,
         )
         .unwrap()

--- a/integration-tests/src/tests/network/stress_network.rs
+++ b/integration-tests/src/tests/network/stress_network.rs
@@ -55,7 +55,7 @@ fn make_peer_manager(seed: &str, port: u16, boot_nodes: Vec<(&str, u16)>) -> Pee
         store,
         config,
         client_addr.recipient(),
-        view_client_addr.recipient(),
+        view_client_addr.recipient().into(),
         routing_table_addr,
     )
     .unwrap()

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -292,7 +292,7 @@ pub fn start_with_config_and_synchronization(
             store,
             network_config,
             client_actor1,
-            view_client1,
+            view_client1.into(),
             routing_table_addr,
         )
         .unwrap()

--- a/tools/chainsync-loadtest/src/main.rs
+++ b/tools/chainsync-loadtest/src/main.rs
@@ -40,7 +40,7 @@ pub fn start_with_config(config: NearConfig, qps_limit: u32) -> anyhow::Result<A
             store,
             config.network_config,
             client_actor.clone().recipient(),
-            client_actor.clone().recipient(),
+            client_actor.clone().recipient().into(),
             routing_table_addr,
         )
         .unwrap()


### PR DESCRIPTION
Optional follow up to https://github.com/near/nearcore/pull/7040 (see the last commit). 

Now that we have `ViewClientAdapter` type, we can add convenince fns to it