### PR TITLE
jsonrpc: refactor `process_request_internal`

### DIFF
--- a/chain/jsonrpc-primitives/src/errors.rs
+++ b/chain/jsonrpc-primitives/src/errors.rs
@@ -157,6 +157,12 @@ impl From<RpcParseError> for RpcError {
     }
 }
 
+impl From<std::convert::Infallible> for RpcError {
+    fn from(_: std::convert::Infallible) -> Self {
+        unsafe { core::hint::unreachable_unchecked() }
+    }
+}
+
 impl fmt::Display for ServerError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/chain/jsonrpc/src/api/mod.rs
+++ b/chain/jsonrpc/src/api/mod.rs
@@ -25,6 +25,12 @@ pub(crate) trait RpcRequest: Sized {
     fn parse(value: Option<Value>) -> Result<Self, RpcParseError>;
 }
 
+impl RpcRequest for () {
+    fn parse(_: Option<Value>) -> Result<Self, RpcParseError> {
+        Ok(())
+    }
+}
+
 pub trait RpcFrom<T> {
     fn rpc_from(_: T) -> Self;
 }
@@ -73,7 +79,7 @@ impl RpcFrom<near_primitives::errors::InvalidTxError> for ServerError {
     }
 }
 
-fn parse_params<T: DeserializeOwned>(value: Option<Value>) -> Result<T, RpcParseError> {
+pub(crate) fn parse_params<T: DeserializeOwned>(value: Option<Value>) -> Result<T, RpcParseError> {
     if let Some(value) = value {
         serde_json::from_value(value)
             .map_err(|err| RpcParseError(format!("Failed parsing args: {}", err)))


### PR DESCRIPTION
Refactor `JsonRpcHandler::process_request_internal` method which is
one of the longest methods in our code base by:
- extracting common code into a new `process_method_call` function,
- moving adversarial requests handling to a new
  `process_adversarial_request_internal` method and
- creating separate methods for each type of adversarial RPC request.

This removes around 100 lines of code and reduces length of the method
from 325 lines to mere 88.

The `process_method_call` function is generic on the argument and
result of an RPC request.  It not only handles bunch of duplicated
code but thanks to type inference it also reduces amount of times the
same type needs to be specified.  The function is actually quite tiny,
but thanks to all the inference and syntax reduction it handles
replaces a few lines each time.

Similarly, introduce `serialise_response` which wraps a common call to
the serde serialisation.  Again, it’s a tiny function but the code it
replaces is a bit noisy so hopefully having a single method makes the
code more readable.

Lastly, `parse_params` was just a duplicate of function of the same
name from `api` module so just use that rather than duplicating the
code.  And observe that `jsonify` has always been called with
`Ok(Ok(value))` argument which means that it can be simplified to the
point where it’s not necessary.