### PR TITLE
chore: Remove estimator contract size padding

### DIFF
--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -771,9 +771,9 @@ fn wasm_instruction(ctx: &mut EstimatorContext) -> GasCost {
     let vm_kind = ctx.config.vm_kind;
 
     let code = read_resource(if cfg!(feature = "nightly") {
-        "test-contract/res/nightly_large_contract.wasm"
+        "test-contract/res/nightly_contract.wasm"
     } else {
-        "test-contract/res/stable_large_contract.wasm"
+        "test-contract/res/stable_contract.wasm"
     });
 
     let n_iters = 10;

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -117,10 +117,19 @@ fn main() -> anyhow::Result<()> {
         }
     };
     if state_dump_path.read_dir()?.next().is_none() {
+        // Every created account gets this smart contract deployed, such that
+        // any account can be used to perform estimations that require this
+        // contract.
+        // Note: This contract no longer has a fixed size, which means that
+        // changes to the test contract might affect all kinds of estimations.
+        // (Larger code = more time spent on reading it from the database, for
+        // example.) But this is generally a sign of a badly designed
+        // estimation, therefore we make no effort to guarantee a fixed size.
+        // Also, continuous estimation should be able to pick up such changes.
         let contract_code = read_resource(if cfg!(feature = "nightly") {
-            "test-contract/res/nightly_small_contract.wasm"
+            "test-contract/res/nightly_contract.wasm"
         } else {
-            "test-contract/res/stable_small_contract.wasm"
+            "test-contract/res/stable_contract.wasm"
         });
 
         nearcore::init_configs(

--- a/runtime/runtime-params-estimator/test-contract/Cargo.toml
+++ b/runtime/runtime-params-estimator/test-contract/Cargo.toml
@@ -24,5 +24,3 @@ members = []
 
 [features]
 nightly = []
-
-payload = []

--- a/runtime/runtime-params-estimator/test-contract/build.sh
+++ b/runtime/runtime-params-estimator/test-contract/build.sh
@@ -13,83 +13,18 @@ if [[ ! -z "$1" ]]; then
   features_with_comma=",$1"
 fi
 
-function filesize
-{
-  local file=$1
-  size=`stat -c%s $file 2>/dev/null` # linux
-  if [ $? -eq 0 ]; then
-    echo $size
-    return 0
-  fi
-
-  size=`stat -f%z $file 2>/dev/null` # macos
-  if [ $? -eq 0 ]; then
-    echo $size
-    return 0
-  fi
-
-  exit 1
-}
-
 rustup target add wasm32-unknown-unknown
 
 # Some users have CARGO_TARGET_DIR pointing to a custom target directory. This
 # script assumes a local target directory.
 unset CARGO_TARGET_DIR;
 
-# First, measure the size of the file without payload.
+# Build stable_contract.wasm
 rm -rf target
 cargo build --target wasm32-unknown-unknown --release $features_with_arg
-bare_wasm=$(filesize target/wasm32-unknown-unknown/release/test_contract.wasm)
-echo ${bare_wasm}
+cp target/wasm32-unknown-unknown/release/test_contract.wasm ./res/stable_contract.wasm
 
-# Generate several files of various sizes. We will compile these files into the Wasm binary to
-# bloat its size to the given values.
-
-# FIXME(#6822): we should just remove the payload logic. 10Kib variant is
-# broken, because the baseline contract is >10KiB (data for alt_bn estimatons).
-
-# 10KiB
-dd if=/dev/urandom of=./res/payload bs=1 count=1
-cargo build --target wasm32-unknown-unknown --release  --features "payload$features_with_comma"
-cp target/wasm32-unknown-unknown/release/test_contract.wasm ./res/stable_small_contract.wasm
-
-# 100KiB
-dd if=/dev/urandom of=./res/payload bs=$(expr 102400 - ${bare_wasm}) count=1
-cargo build --target wasm32-unknown-unknown --release  --features "payload$features_with_comma"
-cp target/wasm32-unknown-unknown/release/test_contract.wasm ./res/stable_medium_contract.wasm
-
-# 1MiB
-dd if=/dev/urandom of=./res/payload bs=$(expr 1048576 - ${bare_wasm}) count=1
-cargo build --target wasm32-unknown-unknown --release  --features "payload$features_with_comma"
-cp target/wasm32-unknown-unknown/release/test_contract.wasm ./res/stable_large_contract.wasm
-
-rm ./res/payload
-
-# Compiling nightly
-
+# Build nightly_contract.wasm
 rm -rf target
 cargo build --target wasm32-unknown-unknown --release --features "nightly$features_with_comma"
-bare_wasm=$(filesize target/wasm32-unknown-unknown/release/test_contract.wasm)
-echo ${bare_wasm}
-
-# Generate several files of various sizes. We will compile these files into the Wasm binary to
-# bloat its size to the given values.
-
-# Note the base is 16057 due to alt_bn128 hardcoded input.
-# 20KiB
-dd if=/dev/urandom of=./res/payload bs=$(expr 20480 - ${bare_wasm}) count=1
-cargo build --target wasm32-unknown-unknown --release  --features "payload,nightly$features_with_comma"
-cp target/wasm32-unknown-unknown/release/test_contract.wasm ./res/nightly_small_contract.wasm
-
-# 100KiB
-dd if=/dev/urandom of=./res/payload bs=$(expr 102400 - ${bare_wasm}) count=1
-cargo build --target wasm32-unknown-unknown --release  --features "payload,nightly$features_with_comma"
-cp target/wasm32-unknown-unknown/release/test_contract.wasm ./res/nightly_medium_contract.wasm
-
-# 1MiB
-dd if=/dev/urandom of=./res/payload bs=$(expr 1048576 - ${bare_wasm}) count=1
-cargo build --target wasm32-unknown-unknown --release  --features "payload,nightly$features_with_comma"
-cp target/wasm32-unknown-unknown/release/test_contract.wasm ./res/nightly_large_contract.wasm
-
-rm ./res/payload
+cp target/wasm32-unknown-unknown/release/test_contract.wasm ./res/nightly_contract.wasm

--- a/runtime/runtime-params-estimator/test-contract/src/lib.rs
+++ b/runtime/runtime-params-estimator/test-contract/src/lib.rs
@@ -157,17 +157,6 @@ extern "C" {
     fn storage_has_key(key_len: u64, key_ptr: u64) -> u64;
 }
 
-// This function is not doing anything useful, it is just here to make sure the payload is getting
-// compiled into Wasm.
-#[cfg(feature = "payload")]
-#[no_mangle]
-pub fn payload() {
-    let payload = include_bytes!("../res/payload");
-    unsafe {
-        value_return(1, payload.as_ptr() as *const u64 as u64);
-    }
-}
-
 // Function that does not do anything at all.
 #[no_mangle]
 pub fn noop() {}


### PR DESCRIPTION
The test cotract used in the estimator does no longer have a good reason
to have a fixed size. Instead, let's use the contract's natural size.

Closes #6822