### PR TITLE
Add check in preprocess_block to check no challenged block on chain

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1360,9 +1360,9 @@ impl Chain {
         Ok(())
     }
 
-    /// Check if the block is one a chain that has challenged blocks. Returns Ok if the chain
+    /// Check if the chain leading to the given block has challenged blocks on it. Returns Ok if the chain
     /// does not have challenged blocks, otherwise error ChallengedBlockOnChain.
-    fn check_if_block_path_challenged(&self, block_header: &BlockHeader) -> Result<(), Error> {
+    fn check_if_challenged_block_on_chain(&self, block_header: &BlockHeader) -> Result<(), Error> {
         let mut hash = *block_header.hash();
         let mut height = block_header.height();
         let mut prev_hash = *block_header.prev_hash();
@@ -1986,7 +1986,7 @@ impl Chain {
     /// Preprocess a block before applying chunks, verify that we have the necessary information
     /// to process the block an the block is valid.
     //  Note that this function does NOT introduce any changes to chain state.
-    fn preprocess_block(
+    pub(crate) fn preprocess_block(
         &self,
         me: &Option<AccountId>,
         block: &MaybeValidated<Block>,
@@ -2083,7 +2083,7 @@ impl Chain {
                 (self.prev_block_is_caught_up(&prev_prev_hash, &prev_hash)?, None)
             };
 
-        self.check_if_block_path_challenged(block.header())?;
+        self.check_if_challenged_block_on_chain(block.header())?;
 
         debug!(target: "chain", "{:?} Process block {}, is_caught_up: {}", me, block.hash(), is_caught_up);
 

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -1574,6 +1574,8 @@ impl<'a> ChainStoreUpdate<'a> {
         Ok(())
     }
 
+    /// This function checks that the block is not on a chain with challenged blocks and updates
+    /// fields in ChainStore that stores information of the canonical chain
     fn update_height_if_not_challenged(
         &mut self,
         height: BlockHeight,
@@ -1599,9 +1601,6 @@ impl<'a> ChainStoreUpdate<'a> {
                     return Ok(());
                 }
                 _ => {
-                    if self.is_block_challenged(&header_hash)? {
-                        return Err(Error::ChallengedBlockOnChain);
-                    }
                     self.chain_store_cache_update
                         .height_to_hashes
                         .insert(header_height, Some(header_hash));

--- a/chain/chain/src/tests/challenges.rs
+++ b/chain/chain/src/tests/challenges.rs
@@ -2,6 +2,7 @@ use crate::test_utils::setup;
 use crate::{Block, Error};
 use assert_matches::assert_matches;
 use near_logger_utils::init_test_logger;
+use near_primitives::utils::MaybeValidated;
 
 #[test]
 fn challenges_new_head_prev() {
@@ -44,7 +45,13 @@ fn challenges_new_head_prev() {
 
     // Try to add a block on top of the fifth block.
 
-    if let Err(e) = chain.process_block_test(&None, last_block) {
+    if let Err(e) = chain.preprocess_block(
+        &None,
+        &MaybeValidated::from(last_block),
+        Provenance::None,
+        &mut vec![],
+        None,
+    ) {
         assert_matches!(e, Error::ChallengedBlockOnChain)
     } else {
         assert!(false);


### PR DESCRIPTION
In postprocess_block, when it updated tip, it checks that no challenged block is on chain. This check should be performed in preprocess_block instead of postprocess_block. After this change, postprocess_block shouldn't return errors other than database errors. This change will make the error handling of of postprocess_block #6968 easier. 