### PR TITLE
refactor: remove needless generics form GenesisConfig API 

### DIFF
--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -9,7 +9,7 @@ use near_primitives::time::Utc;
 use num_rational::Rational;
 
 use crate::DoomslugThresholdMode;
-use near_chain_configs::{GenesisConfig, ProtocolConfig};
+use near_chain_configs::{Genesis, ProtocolConfig};
 use near_chain_primitives::Error;
 use near_crypto::Signature;
 use near_pool::types::PoolIterator;
@@ -232,23 +232,19 @@ pub struct ChainGenesis {
     pub protocol_version: ProtocolVersion,
 }
 
-impl<T> From<T> for ChainGenesis
-where
-    T: AsRef<GenesisConfig>,
-{
-    fn from(genesis_config: T) -> Self {
-        let genesis_config = genesis_config.as_ref();
+impl ChainGenesis {
+    pub fn new(genesis: &Genesis) -> Self {
         Self {
-            time: genesis_config.genesis_time,
-            height: genesis_config.genesis_height,
-            gas_limit: genesis_config.gas_limit,
-            min_gas_price: genesis_config.min_gas_price,
-            max_gas_price: genesis_config.max_gas_price,
-            total_supply: genesis_config.total_supply,
-            gas_price_adjustment_rate: genesis_config.gas_price_adjustment_rate,
-            transaction_validity_period: genesis_config.transaction_validity_period,
-            epoch_length: genesis_config.epoch_length,
-            protocol_version: genesis_config.protocol_version,
+            time: genesis.config.genesis_time,
+            height: genesis.config.genesis_height,
+            gas_limit: genesis.config.gas_limit,
+            min_gas_price: genesis.config.min_gas_price,
+            max_gas_price: genesis.config.max_gas_price,
+            total_supply: genesis.config.total_supply,
+            gas_price_adjustment_rate: genesis.config.gas_price_adjustment_rate,
+            transaction_validity_period: genesis.config.transaction_validity_period,
+            epoch_length: genesis.config.epoch_length,
+            protocol_version: genesis.config.protocol_version,
         }
     }
 }

--- a/core/chain-configs/src/genesis_config.rs
+++ b/core/chain-configs/src/genesis_config.rs
@@ -280,12 +280,6 @@ pub struct Genesis {
     pub records_file: PathBuf,
 }
 
-impl AsRef<GenesisConfig> for &Genesis {
-    fn as_ref(&self) -> &GenesisConfig {
-        &self.config
-    }
-}
-
 impl GenesisConfig {
     /// Parses GenesisConfig from a JSON string.
     ///

--- a/integration-tests/src/genesis_helpers.rs
+++ b/integration-tests/src/genesis_helpers.rs
@@ -18,7 +18,7 @@ pub fn genesis_hash(genesis: &Genesis) -> CryptoHash {
 pub fn genesis_header(genesis: &Genesis) -> BlockHeader {
     let dir = tempdir().unwrap();
     let store = create_test_store();
-    let chain_genesis = ChainGenesis::from(genesis);
+    let chain_genesis = ChainGenesis::new(genesis);
     let runtime = Arc::new(NightshadeRuntime::test(dir.path(), store, genesis));
     let chain =
         Chain::new(runtime, &chain_genesis, DoomslugThresholdMode::TwoThirds, true).unwrap();
@@ -29,7 +29,7 @@ pub fn genesis_header(genesis: &Genesis) -> BlockHeader {
 pub fn genesis_block(genesis: &Genesis) -> Block {
     let dir = tempdir().unwrap();
     let store = create_test_store();
-    let chain_genesis = ChainGenesis::from(genesis);
+    let chain_genesis = ChainGenesis::new(genesis);
     let runtime = Arc::new(NightshadeRuntime::test(dir.path(), store, genesis));
     let chain =
         Chain::new(runtime, &chain_genesis, DoomslugThresholdMode::TwoThirds, true).unwrap();

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -170,7 +170,7 @@ fn prepare_env_with_congestion(
     if let Some(gas_price_adjustment_rate) = gas_price_adjustment_rate {
         genesis.config.gas_price_adjustment_rate = gas_price_adjustment_rate;
     }
-    let chain_genesis = ChainGenesis::from(&genesis);
+    let chain_genesis = ChainGenesis::new(&genesis);
     let mut env = TestEnv::builder(chain_genesis)
         .runtime_adapters(create_nightshade_runtimes(&genesis, 1))
         .build();
@@ -1823,7 +1823,7 @@ fn test_gas_price_change() {
     genesis.config.min_gas_price = min_gas_price;
     genesis.config.gas_limit = gas_limit;
     genesis.config.gas_price_adjustment_rate = gas_price_adjustment_rate;
-    let chain_genesis = ChainGenesis::from(&genesis);
+    let chain_genesis = ChainGenesis::new(&genesis);
     let mut env = TestEnv::builder(chain_genesis)
         .runtime_adapters(create_nightshade_runtimes(&genesis, 1))
         .build();
@@ -1870,7 +1870,7 @@ fn test_gas_price_overflow() {
     genesis.config.epoch_length = 43200;
     genesis.config.max_gas_price = max_gas_price;
 
-    let chain_genesis = ChainGenesis::from(&genesis);
+    let chain_genesis = ChainGenesis::new(&genesis);
     let mut env = TestEnv::builder(chain_genesis)
         .runtime_adapters(create_nightshade_runtimes(&genesis, 1))
         .build();
@@ -1914,7 +1914,7 @@ fn test_invalid_block_root() {
 #[test]
 fn test_incorrect_validator_key_produce_block() {
     let genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 2);
-    let chain_genesis = ChainGenesis::from(&genesis);
+    let chain_genesis = ChainGenesis::new(&genesis);
     let runtime_adapter: Arc<dyn RuntimeAdapter> = Arc::new(nearcore::NightshadeRuntime::test(
         Path::new("../../../.."),
         create_test_store(),
@@ -2280,7 +2280,7 @@ fn test_gas_price_change_no_chunk() {
     genesis.config.epoch_length = epoch_length;
     genesis.config.protocol_version = genesis_protocol_version;
     genesis.config.min_gas_price = min_gas_price;
-    let chain_genesis = ChainGenesis::from(&genesis);
+    let chain_genesis = ChainGenesis::new(&genesis);
     let mut env = TestEnv::builder(chain_genesis)
         .runtime_adapters(create_nightshade_runtimes(&genesis, 1))
         .build();
@@ -2310,7 +2310,7 @@ fn test_catchup_gas_price_change() {
     genesis.config.epoch_length = epoch_length;
     genesis.config.min_gas_price = min_gas_price;
     genesis.config.gas_limit = 1000000000000;
-    let chain_genesis = ChainGenesis::from(&genesis);
+    let chain_genesis = ChainGenesis::new(&genesis);
     let mut env = TestEnv::builder(chain_genesis)
         .clients_count(2)
         .runtime_adapters(create_nightshade_runtimes(&genesis, 2))
@@ -2410,7 +2410,7 @@ fn test_block_execution_outcomes() {
     genesis.config.epoch_length = epoch_length;
     genesis.config.min_gas_price = min_gas_price;
     genesis.config.gas_limit = 1000000000000;
-    let chain_genesis = ChainGenesis::from(&genesis);
+    let chain_genesis = ChainGenesis::new(&genesis);
     let mut env = TestEnv::builder(chain_genesis)
         .runtime_adapters(create_nightshade_runtimes(&genesis, 1))
         .build();
@@ -2496,7 +2496,7 @@ fn test_refund_receipts_processing() {
     genesis.config.min_gas_price = min_gas_price;
     // set gas limit to be small
     genesis.config.gas_limit = 1_000_000;
-    let chain_genesis = ChainGenesis::from(&genesis);
+    let chain_genesis = ChainGenesis::new(&genesis);
     let mut env = TestEnv::builder(chain_genesis)
         .runtime_adapters(create_nightshade_runtimes(&genesis, 1))
         .build();
@@ -2612,7 +2612,7 @@ fn test_wasmer2_upgrade() {
             Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
         genesis.config.epoch_length = epoch_length;
         genesis.config.protocol_version = old_protocol_version;
-        let chain_genesis = ChainGenesis::from(&genesis);
+        let chain_genesis = ChainGenesis::new(&genesis);
         let mut env = TestEnv::builder(chain_genesis)
             .runtime_adapters(create_nightshade_runtimes(&genesis, 1))
             .build();
@@ -2706,7 +2706,7 @@ fn test_execution_metadata() {
         let mut genesis =
             Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
         genesis.config.epoch_length = epoch_length;
-        let chain_genesis = ChainGenesis::from(&genesis);
+        let chain_genesis = ChainGenesis::new(&genesis);
         let mut env = TestEnv::builder(chain_genesis)
             .runtime_adapters(create_nightshade_runtimes(&genesis, 1))
             .build();
@@ -2804,7 +2804,7 @@ fn test_epoch_protocol_version_change() {
     genesis.config.epoch_length = epoch_length;
     genesis.config.protocol_version = PROTOCOL_VERSION;
     let genesis_height = genesis.config.genesis_height;
-    let chain_genesis = ChainGenesis::from(&genesis);
+    let chain_genesis = ChainGenesis::new(&genesis);
     let mut env = TestEnv::builder(chain_genesis)
         .clients_count(2)
         .validator_seats(2)
@@ -2874,7 +2874,7 @@ fn test_query_final_state() {
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
 
-    let chain_genesis = ChainGenesis::from(&genesis);
+    let chain_genesis = ChainGenesis::new(&genesis);
     let mut env = TestEnv::builder(chain_genesis)
         .runtime_adapters(create_nightshade_runtimes(&genesis, 1))
         .build();
@@ -3112,7 +3112,7 @@ fn test_header_version_downgrade() {
     use borsh::ser::BorshSerialize;
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = 5;
-    let chain_genesis = ChainGenesis::from(&genesis);
+    let chain_genesis = ChainGenesis::new(&genesis);
     let mut env = TestEnv::builder(chain_genesis)
         .runtime_adapters(create_nightshade_runtimes(&genesis, 1))
         .build();
@@ -3343,7 +3343,7 @@ fn verify_contract_limits_upgrade(
             Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
         genesis.config.epoch_length = epoch_length;
         genesis.config.protocol_version = old_protocol_version;
-        let chain_genesis = ChainGenesis::from(&genesis);
+        let chain_genesis = ChainGenesis::new(&genesis);
         let runtimes: Vec<Arc<dyn RuntimeAdapter>> =
             vec![Arc::new(nearcore::NightshadeRuntime::test_with_runtime_config_store(
                 Path::new("../../../.."),
@@ -3474,7 +3474,7 @@ fn test_catchup_no_sharding_change() {
     init_integration_logger();
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap()], 1);
     genesis.config.epoch_length = 5;
-    let chain_genesis = ChainGenesis::from(&genesis);
+    let chain_genesis = ChainGenesis::new(&genesis);
     let mut env = TestEnv::builder(chain_genesis)
         .clients_count(1)
         .validator_seats(1)
@@ -3511,7 +3511,7 @@ fn test_deploy_cost_increased() {
         let mut genesis = Genesis::test(vec!["test0".parse().unwrap()], 1);
         genesis.config.epoch_length = epoch_length;
         genesis.config.protocol_version = old_protocol_version;
-        let chain_genesis = ChainGenesis::from(&genesis);
+        let chain_genesis = ChainGenesis::new(&genesis);
         let runtimes: Vec<Arc<dyn RuntimeAdapter>> =
             vec![Arc::new(nearcore::NightshadeRuntime::test_with_runtime_config_store(
                 Path::new("../../../.."),
@@ -3879,7 +3879,7 @@ mod access_key_nonce_range_tests {
         genesis.config.shard_layout = ShardLayout::v1_test();
         genesis.config.num_block_producer_seats_per_shard =
             vec![num_validators, num_validators, num_validators, num_validators];
-        let chain_genesis = ChainGenesis::from(&genesis);
+        let chain_genesis = ChainGenesis::new(&genesis);
         let runtimes: Vec<Arc<dyn RuntimeAdapter>> = (0..2)
             .map(|_| {
                 Arc::new(nearcore::NightshadeRuntime::test_with_runtime_config_store(
@@ -4025,7 +4025,7 @@ mod access_key_nonce_range_tests {
         genesis.config.shard_layout = ShardLayout::v1_test();
         genesis.config.num_block_producer_seats_per_shard =
             vec![num_validators, num_validators, num_validators, num_validators];
-        let chain_genesis = ChainGenesis::from(&genesis);
+        let chain_genesis = ChainGenesis::new(&genesis);
         let runtimes: Vec<Arc<dyn RuntimeAdapter>> = (0..2)
             .map(|_| {
                 Arc::new(nearcore::NightshadeRuntime::test_with_runtime_config_store(
@@ -4113,7 +4113,7 @@ mod protocol_feature_restore_receipts_after_fix_tests {
         genesis.config.chain_id = String::from(chain_id);
         genesis.config.epoch_length = EPOCH_LENGTH;
         genesis.config.protocol_version = protocol_version;
-        let chain_genesis = ChainGenesis::from(&genesis);
+        let chain_genesis = ChainGenesis::new(&genesis);
         let runtime = nearcore::NightshadeRuntime::test(
             Path::new("../../../.."),
             create_test_store(),
@@ -4253,7 +4253,7 @@ mod storage_usage_fix_tests {
         genesis.config.chain_id = chain_id;
         genesis.config.epoch_length = epoch_length;
         genesis.config.protocol_version = ProtocolFeature::FixStorageUsage.protocol_version() - 1;
-        let chain_genesis = ChainGenesis::from(&genesis);
+        let chain_genesis = ChainGenesis::new(&genesis);
         let mut env = TestEnv::builder(chain_genesis)
             .runtime_adapters(create_nightshade_runtimes(&genesis, 1))
             .build();
@@ -4755,7 +4755,7 @@ mod chunk_nodes_cache_test {
         let old_protocol_version = ProtocolFeature::ChunkNodesCache.protocol_version() - 1;
         genesis.config.epoch_length = epoch_length;
         genesis.config.protocol_version = old_protocol_version;
-        let chain_genesis = ChainGenesis::from(&genesis);
+        let chain_genesis = ChainGenesis::new(&genesis);
         let runtimes: Vec<Arc<dyn RuntimeAdapter>> =
             vec![Arc::new(nearcore::NightshadeRuntime::test_with_runtime_config_store(
                 Path::new("../../../.."),
@@ -4848,7 +4848,7 @@ mod lower_storage_key_limit_test {
                 Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
             genesis.config.epoch_length = epoch_length;
             genesis.config.protocol_version = old_protocol_version;
-            let chain_genesis = ChainGenesis::from(&genesis);
+            let chain_genesis = ChainGenesis::new(&genesis);
             let runtimes: Vec<Arc<dyn RuntimeAdapter>> =
                 vec![Arc::new(nearcore::NightshadeRuntime::test_with_runtime_config_store(
                     Path::new("."),

--- a/integration-tests/src/tests/client/runtimes.rs
+++ b/integration-tests/src/tests/client/runtimes.rs
@@ -93,7 +93,7 @@ fn test_cap_max_gas_price() {
     genesis.config.max_gas_price = 1_000_000;
     genesis.config.protocol_version = ProtocolFeature::CapMaxGasPrice.protocol_version();
     genesis.config.epoch_length = epoch_length;
-    let chain_genesis = ChainGenesis::from(&genesis);
+    let chain_genesis = ChainGenesis::new(&genesis);
     let mut env = TestEnv::builder(chain_genesis)
         .runtime_adapters(create_nightshade_runtimes(&genesis, 1))
         .build();

--- a/integration-tests/src/tests/client/sharding_upgrade.rs
+++ b/integration-tests/src/tests/client/sharding_upgrade.rs
@@ -65,7 +65,7 @@ impl TestShardUpgradeEnv {
             [validators, gen_unique_accounts(&mut rng, num_init_accounts)].concat();
         let genesis =
             setup_genesis(epoch_length, num_validators as u64, initial_accounts.clone(), gas_limit);
-        let chain_genesis = ChainGenesis::from(&genesis);
+        let chain_genesis = ChainGenesis::new(&genesis);
         let env = TestEnv::builder(chain_genesis)
             .clients_count(num_clients)
             .validator_seats(num_validators)

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -250,7 +250,7 @@ pub fn start_with_config_and_synchronization(
     let runtime = Arc::new(NightshadeRuntime::from_config(home_dir, store.clone(), &config));
 
     let telemetry = TelemetryActor::new(config.telemetry_config.clone()).start();
-    let chain_genesis = ChainGenesis::from(&config.genesis);
+    let chain_genesis = ChainGenesis::new(&config.genesis);
 
     let node_id = config.network_config.node_id();
     let network_adapter = Arc::new(NetworkRecipient::default());

--- a/nearcore/tests/economics.rs
+++ b/nearcore/tests/economics.rs
@@ -32,7 +32,7 @@ fn build_genesis() -> Genesis {
 fn setup_env(genesis: &Genesis) -> TestEnv {
     init_integration_logger();
     let store1 = create_test_store();
-    TestEnv::builder(ChainGenesis::from(&genesis))
+    TestEnv::builder(ChainGenesis::new(&genesis))
         .runtime_adapters(vec![Arc::new(nearcore::NightshadeRuntime::test(
             Path::new("."),
             store1,

--- a/test-utils/runtime-tester/src/run_test.rs
+++ b/test-utils/runtime-tester/src/run_test.rs
@@ -51,7 +51,7 @@ impl Scenario {
             (Some(tempdir), opener.open())
         };
 
-        let mut env = TestEnv::builder(ChainGenesis::from(&genesis))
+        let mut env = TestEnv::builder(ChainGenesis::new(&genesis))
             .clients(clients.clone())
             .validators(clients)
             .runtime_adapters(vec![Arc::new(NightshadeRuntime::test_with_runtime_config_store(

--- a/tools/mock_node/src/lib.rs
+++ b/tools/mock_node/src/lib.rs
@@ -472,7 +472,7 @@ mod test {
     // build a TestEnv with one validator with 20 blocks of history, all empty
     fn setup_mock() -> (ChainHistoryAccess, TestEnv) {
         let genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
-        let chain_genesis = ChainGenesis::from(&genesis);
+        let chain_genesis = ChainGenesis::new(&genesis);
         let runtimes = vec![Arc::new(nearcore::NightshadeRuntime::test(
             Path::new("../../../.."),
             create_test_store(),

--- a/tools/mock_node/src/setup.rs
+++ b/tools/mock_node/src/setup.rs
@@ -106,7 +106,7 @@ pub fn setup_mock_node(
     let mock_network_runtime = setup_runtime(network_home_dir, &config, false);
 
     let telemetry = TelemetryActor::new(config.telemetry_config.clone()).start();
-    let chain_genesis = ChainGenesis::from(&config.genesis);
+    let chain_genesis = ChainGenesis::new(&config.genesis);
 
     let node_id = config.network_config.node_id();
     let network_adapter = Arc::new(NetworkRecipient::default());


### PR DESCRIPTION
We never actually use this stuff generically, cutting this out removes
indirection and makes it clear what's going on.

Can be reviewed per-commit