### PR TITLE
refactor: remove `is_chunk_only` field from ValidatorStake

### DIFF
--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -180,8 +180,6 @@ impl KeyValueRuntime {
                                 SecretKey::from_seed(KeyType::ED25519, account_id.as_ref())
                                     .public_key(),
                                 1_000_000,
-                                #[cfg(feature = "protocol_feature_chunk_only_producers")]
-                                false,
                             )
                         })
                         .collect()

--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -39,7 +39,7 @@ fn build_chain() {
     //     cargo insta test --accept -p near-chain --features nightly -- tests::simple_chain::build_chain
     let hash = chain.head().unwrap().last_block_hash;
     if cfg!(feature = "nightly") {
-        insta::assert_display_snapshot!(hash, @"7Db9S56zVuTKvYGnHXvsJYH6CvQBBEm2TC7Y3S85SZps");
+        insta::assert_display_snapshot!(hash, @"AzXEGtscMJaA5td3Nxdrmv2eC3SaYD2spydh3WDbRjAh");
     } else {
         insta::assert_display_snapshot!(hash, @"6sAno2uEwwQ5yiDscePWY8HWmRJLpGNv39uoff3BCpxT");
     }
@@ -68,7 +68,7 @@ fn build_chain() {
 
     let hash = chain.head().unwrap().last_block_hash;
     if cfg!(feature = "nightly") {
-        insta::assert_display_snapshot!(hash, @"HbPMs5o1Twqb7ZqrrhaCGawwZbYJVaPHZ7tfoihcnYxc");
+        insta::assert_display_snapshot!(hash, @"BkaWorGLVNsKyzS1HXXur1sNYDhSCssNvAnbP1TtW2az");
     } else {
         insta::assert_display_snapshot!(hash, @"Fn9MgjUx6VXhPYNqqDtf2C9kBVveY2vuSLXNLZUNJCqK");
     }

--- a/chain/epoch_manager/src/test_utils.rs
+++ b/chain/epoch_manager/src/test_utils.rs
@@ -98,8 +98,6 @@ pub fn epoch_info_with_num_seats(
                     account_id.clone(),
                     SecretKey::from_seed(KeyType::ED25519, account_id.as_ref()).public_key(),
                     stake,
-                    #[cfg(feature = "protocol_feature_chunk_only_producers")]
-                    false,
                 )
             })
             .collect()
@@ -159,13 +157,7 @@ pub fn epoch_config(
 
 pub fn stake(account_id: AccountId, amount: Balance) -> ValidatorStake {
     let public_key = SecretKey::from_seed(KeyType::ED25519, account_id.as_ref()).public_key();
-    ValidatorStake::new(
-        account_id,
-        public_key,
-        amount,
-        #[cfg(feature = "protocol_feature_chunk_only_producers")]
-        false,
-    )
+    ValidatorStake::new(account_id, public_key, amount)
 }
 
 /// No-op reward calculator. Will produce no reward

--- a/chain/epoch_manager/src/validator_selection.rs
+++ b/chain/epoch_manager/src/validator_selection.rs
@@ -48,8 +48,7 @@ pub fn proposals_to_epoch_info(
         &mut stake_change,
         &mut fishermen,
     );
-    let mut block_producer_proposals =
-        order_proposals(proposals.values().filter(|p| !p.is_chunk_only()).cloned());
+    let mut block_producer_proposals = order_proposals(proposals.values().cloned());
     let (block_producers, bp_stake_threshold) = select_block_producers(
         &mut block_producer_proposals,
         max_bp_selected,
@@ -78,7 +77,7 @@ pub fn proposals_to_epoch_info(
 
     // since block producer proposals could become chunk producers, their actual stake threshold
     // is the smaller of the two thresholds
-    let bp_stake_threshold = cmp::min(bp_stake_threshold, cp_stake_threshold);
+    let threshold = cmp::min(bp_stake_threshold, cp_stake_threshold);
 
     // process remaining chunk_producer_proposals that were not selected for either role
     for OrderedValidatorStake(p) in chunk_producer_proposals {
@@ -91,8 +90,6 @@ pub fn proposals_to_epoch_info(
             if prev_epoch_info.account_is_validator(account_id)
                 || prev_epoch_info.account_is_fisherman(account_id)
             {
-                let threshold =
-                    if p.is_chunk_only() { cp_stake_threshold } else { bp_stake_threshold };
                 debug_assert!(stake < threshold);
                 let account_id = p.take_account_id();
                 validator_kickout.insert(
@@ -202,7 +199,7 @@ pub fn proposals_to_epoch_info(
         validator_reward,
         validator_kickout,
         minted_amount,
-        bp_stake_threshold,
+        threshold,
         next_version,
         rng_seed,
     ))
@@ -480,13 +477,6 @@ mod tests {
         .unwrap();
 
         assert_eq!(epoch_info.epoch_height(), prev_epoch_height + 1);
-
-        // no block producers are chunk-only
-        epoch_info
-            .block_producers_settlement()
-            .into_iter()
-            .map(|id| epoch_info.get_validator(*id))
-            .for_each(|v| assert!(!v.is_chunk_only()));
 
         // the top stakes are the chosen block producers
         let mut sorted_proposals = proposals;
@@ -907,69 +897,33 @@ mod tests {
 
     impl IntoValidatorStake for &str {
         fn into_validator_stake(self) -> ValidatorStake {
-            ValidatorStake::new(
-                self.parse().unwrap(),
-                PublicKey::empty(KeyType::ED25519),
-                100,
-                #[cfg(feature = "protocol_feature_chunk_only_producers")]
-                false,
-            )
+            ValidatorStake::new(self.parse().unwrap(), PublicKey::empty(KeyType::ED25519), 100)
         }
     }
 
     impl IntoValidatorStake for (&str, Balance) {
         fn into_validator_stake(self) -> ValidatorStake {
-            ValidatorStake::new(
-                self.0.parse().unwrap(),
-                PublicKey::empty(KeyType::ED25519),
-                self.1,
-                #[cfg(feature = "protocol_feature_chunk_only_producers")]
-                false,
-            )
+            ValidatorStake::new(self.0.parse().unwrap(), PublicKey::empty(KeyType::ED25519), self.1)
         }
     }
 
     impl IntoValidatorStake for (String, Balance) {
         fn into_validator_stake(self) -> ValidatorStake {
-            ValidatorStake::new(
-                self.0.parse().unwrap(),
-                PublicKey::empty(KeyType::ED25519),
-                self.1,
-                #[cfg(feature = "protocol_feature_chunk_only_producers")]
-                false,
-            )
+            ValidatorStake::new(self.0.parse().unwrap(), PublicKey::empty(KeyType::ED25519), self.1)
         }
     }
 
     #[cfg(feature = "protocol_feature_chunk_only_producers")]
     impl IntoValidatorStake for (&str, Balance, Proposal) {
         fn into_validator_stake(self) -> ValidatorStake {
-            let is_chunk_only = match self.2 {
-                Proposal::BlockProducer => false,
-                Proposal::ChunkOnlyProducer => true,
-            };
-            ValidatorStake::new(
-                self.0.parse().unwrap(),
-                PublicKey::empty(KeyType::ED25519),
-                self.1,
-                is_chunk_only,
-            )
+            ValidatorStake::new(self.0.parse().unwrap(), PublicKey::empty(KeyType::ED25519), self.1)
         }
     }
 
     #[cfg(feature = "protocol_feature_chunk_only_producers")]
     impl IntoValidatorStake for (String, Balance, Proposal) {
         fn into_validator_stake(self) -> ValidatorStake {
-            let is_chunk_only = match self.2 {
-                Proposal::BlockProducer => false,
-                Proposal::ChunkOnlyProducer => true,
-            };
-            ValidatorStake::new(
-                self.0.parse().unwrap(),
-                PublicKey::empty(KeyType::ED25519),
-                self.1,
-                is_chunk_only,
-            )
+            ValidatorStake::new(self.0.parse().unwrap(), PublicKey::empty(KeyType::ED25519), self.1)
         }
     }
 

--- a/core/chain-configs/src/genesis_config.rs
+++ b/core/chain-configs/src/genesis_config.rs
@@ -318,8 +318,6 @@ impl GenesisConfig {
                     account_info.account_id.clone(),
                     account_info.public_key.clone(),
                     account_info.amount,
-                    #[cfg(feature = "protocol_feature_chunk_only_producers")]
-                    false,
                 )
             })
             .collect()

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -484,23 +484,6 @@ pub mod validator_stake {
     #[serde(tag = "validator_stake_struct_version")]
     pub enum ValidatorStake {
         V1(ValidatorStakeV1),
-        #[cfg(feature = "protocol_feature_chunk_only_producers")]
-        V2(ValidatorStakeV2),
-    }
-
-    #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
-    #[cfg(feature = "protocol_feature_chunk_only_producers")]
-    #[derive(BorshSerialize, BorshDeserialize, Serialize, Debug, Clone, PartialEq, Eq)]
-    pub struct ValidatorStakeV2 {
-        /// Account that stakes money.
-        pub account_id: AccountId,
-        /// Public key of the proposed validator.
-        pub public_key: PublicKey,
-        /// Stake / weight of the validator.
-        pub stake: Balance,
-        /// Flag indicating if this validator proposed to be a chunk-only producer
-        /// (i.e. cannot become a block producer).
-        pub is_chunk_only: bool,
     }
 
     pub struct ValidatorStakeIter<'a> {
@@ -564,44 +547,13 @@ pub mod validator_stake {
             Self::V1(ValidatorStakeV1 { account_id, public_key, stake })
         }
 
-        #[cfg(not(feature = "protocol_feature_chunk_only_producers"))]
         pub fn new(account_id: AccountId, public_key: PublicKey, stake: Balance) -> Self {
             Self::new_v1(account_id, public_key, stake)
-        }
-
-        #[cfg(feature = "protocol_feature_chunk_only_producers")]
-        pub fn new(
-            account_id: AccountId,
-            public_key: PublicKey,
-            stake: Balance,
-            is_chunk_only: bool,
-        ) -> Self {
-            Self::V2(ValidatorStakeV2 { account_id, public_key, stake, is_chunk_only })
         }
 
         pub fn into_v1(self) -> ValidatorStakeV1 {
             match self {
                 Self::V1(v1) => v1,
-                #[cfg(feature = "protocol_feature_chunk_only_producers")]
-                Self::V2(v2) => {
-                    // This function is called on V2 variant if
-                    // protocol_feature_chunk_only_producers is enabled, but current protocol
-                    // version is lower than required for block headers v3.
-                    ValidatorStakeV1 {
-                        account_id: v2.account_id,
-                        public_key: v2.public_key,
-                        stake: v2.stake,
-                    }
-                }
-            }
-        }
-
-        #[inline]
-        pub fn is_chunk_only(&self) -> bool {
-            match self {
-                Self::V1(_) => false,
-                #[cfg(feature = "protocol_feature_chunk_only_producers")]
-                Self::V2(v2) => v2.is_chunk_only,
             }
         }
 
@@ -609,8 +561,6 @@ pub mod validator_stake {
         pub fn account_and_stake(self) -> (AccountId, Balance) {
             match self {
                 Self::V1(v1) => (v1.account_id, v1.stake),
-                #[cfg(feature = "protocol_feature_chunk_only_producers")]
-                Self::V2(v2) => (v2.account_id, v2.stake),
             }
         }
 
@@ -618,8 +568,6 @@ pub mod validator_stake {
         pub fn destructure(self) -> (AccountId, PublicKey, Balance) {
             match self {
                 Self::V1(v1) => (v1.account_id, v1.public_key, v1.stake),
-                #[cfg(feature = "protocol_feature_chunk_only_producers")]
-                Self::V2(v2) => (v2.account_id, v2.public_key, v2.stake),
             }
         }
 
@@ -627,8 +575,6 @@ pub mod validator_stake {
         pub fn take_account_id(self) -> AccountId {
             match self {
                 Self::V1(v1) => v1.account_id,
-                #[cfg(feature = "protocol_feature_chunk_only_producers")]
-                Self::V2(v2) => v2.account_id,
             }
         }
 
@@ -636,8 +582,6 @@ pub mod validator_stake {
         pub fn account_id(&self) -> &AccountId {
             match self {
                 Self::V1(v1) => &v1.account_id,
-                #[cfg(feature = "protocol_feature_chunk_only_producers")]
-                Self::V2(v2) => &v2.account_id,
             }
         }
 
@@ -645,8 +589,6 @@ pub mod validator_stake {
         pub fn take_public_key(self) -> PublicKey {
             match self {
                 Self::V1(v1) => v1.public_key,
-                #[cfg(feature = "protocol_feature_chunk_only_producers")]
-                Self::V2(v2) => v2.public_key,
             }
         }
 
@@ -654,8 +596,6 @@ pub mod validator_stake {
         pub fn public_key(&self) -> &PublicKey {
             match self {
                 Self::V1(v1) => &v1.public_key,
-                #[cfg(feature = "protocol_feature_chunk_only_producers")]
-                Self::V2(v2) => &v2.public_key,
             }
         }
 
@@ -663,8 +603,6 @@ pub mod validator_stake {
         pub fn stake(&self) -> Balance {
             match self {
                 Self::V1(v1) => v1.stake,
-                #[cfg(feature = "protocol_feature_chunk_only_producers")]
-                Self::V2(v2) => v2.stake,
             }
         }
 
@@ -672,8 +610,6 @@ pub mod validator_stake {
         pub fn stake_mut(&mut self) -> &mut Balance {
             match self {
                 Self::V1(v1) => &mut v1.stake,
-                #[cfg(feature = "protocol_feature_chunk_only_producers")]
-                Self::V2(v2) => &mut v2.stake,
             }
         }
 

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -1296,8 +1296,6 @@ pub mod validator_stake_view {
     #[serde(tag = "validator_stake_struct_version")]
     pub enum ValidatorStakeView {
         V1(ValidatorStakeViewV1),
-        #[cfg(feature = "protocol_feature_chunk_only_producers")]
-        V2(ValidatorStakeViewV2),
     }
 
     impl ValidatorStakeView {
@@ -1309,8 +1307,6 @@ pub mod validator_stake_view {
         pub fn take_account_id(self) -> AccountId {
             match self {
                 Self::V1(v1) => v1.account_id,
-                #[cfg(feature = "protocol_feature_chunk_only_producers")]
-                Self::V2(v2) => v2.account_id,
             }
         }
 
@@ -1318,8 +1314,6 @@ pub mod validator_stake_view {
         pub fn account_id(&self) -> &AccountId {
             match self {
                 Self::V1(v1) => &v1.account_id,
-                #[cfg(feature = "protocol_feature_chunk_only_producers")]
-                Self::V2(v2) => &v2.account_id,
             }
         }
     }
@@ -1345,13 +1339,6 @@ pub mod validator_stake_view {
                     public_key: v1.public_key,
                     stake: v1.stake,
                 }),
-                #[cfg(feature = "protocol_feature_chunk_only_producers")]
-                ValidatorStake::V2(v2) => Self::V2(ValidatorStakeViewV2 {
-                    account_id: v2.account_id,
-                    public_key: v2.public_key,
-                    stake: v2.stake,
-                    is_chunk_only: v2.is_chunk_only,
-                }),
             }
         }
     }
@@ -1360,10 +1347,6 @@ pub mod validator_stake_view {
         fn from(view: ValidatorStakeView) -> Self {
             match view {
                 ValidatorStakeView::V1(v1) => Self::new_v1(v1.account_id, v1.public_key, v1.stake),
-                #[cfg(feature = "protocol_feature_chunk_only_producers")]
-                ValidatorStakeView::V2(v2) => {
-                    Self::new(v2.account_id, v2.public_key, v2.stake, v2.is_chunk_only)
-                }
             }
         }
     }

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -802,14 +802,6 @@ fn ban_peer_for_invalid_block_common(mode: InvalidBlockMode) {
                                 InvalidBlockMode::InvalidBlock => {
                                     // produce an invalid block whose invalidity cannot be verified by just
                                     // having its header.
-                                    #[cfg(feature = "protocol_feature_chunk_only_producers")]
-                                    let proposals = vec![ValidatorStake::new(
-                                        "test1".parse().unwrap(),
-                                        PublicKey::empty(KeyType::ED25519),
-                                        0,
-                                        false,
-                                    )];
-                                    #[cfg(not(feature = "protocol_feature_chunk_only_producers"))]
                                     let proposals = vec![ValidatorStake::new(
                                         "test1".parse().unwrap(),
                                         PublicKey::empty(KeyType::ED25519),
@@ -2113,14 +2105,6 @@ fn test_not_process_height_twice() {
     env.process_block(0, block, Provenance::PRODUCED);
     let validator_signer =
         InMemoryValidatorSigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
-    #[cfg(feature = "protocol_feature_chunk_only_producers")]
-    let proposals = vec![ValidatorStake::new(
-        "test1".parse().unwrap(),
-        PublicKey::empty(KeyType::ED25519),
-        0,
-        false,
-    )];
-    #[cfg(not(feature = "protocol_feature_chunk_only_producers"))]
     let proposals =
         vec![ValidatorStake::new("test1".parse().unwrap(), PublicKey::empty(KeyType::ED25519), 0)];
     invalid_block.mut_header().get_mut().inner_rest.validator_proposals = proposals;

--- a/integration-tests/src/tests/nearcore/sync_nodes.rs
+++ b/integration-tests/src/tests/nearcore/sync_nodes.rs
@@ -50,15 +50,6 @@ fn add_blocks(
         let next_epoch_id = EpochId(
             *blocks[(((prev.header().height()) / epoch_length) * epoch_length) as usize].hash(),
         );
-        #[cfg(feature = "protocol_feature_chunk_only_producers")]
-        let next_bp_hash = Chain::compute_collection_hash(vec![ValidatorStake::new(
-            "other".parse().unwrap(),
-            signer.public_key(),
-            TESTING_INIT_STAKE,
-            false,
-        )])
-        .unwrap();
-        #[cfg(not(feature = "protocol_feature_chunk_only_producers"))]
         let next_bp_hash = Chain::compute_collection_hash(vec![ValidatorStake::new(
             "other".parse().unwrap(),
             signer.public_key(),

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -2688,8 +2688,6 @@ mod test {
                     block_producers[0].validator_id().clone(),
                     block_producers[0].public_key(),
                     TESTING_INIT_STAKE + 1,
-                    #[cfg(feature = "protocol_feature_chunk_only_producers")]
-                    false,
                 )]
             } else {
                 vec![]
@@ -2850,8 +2848,6 @@ mod test {
                     "test1".parse().unwrap(),
                     block_producers[0].public_key(),
                     0,
-                    #[cfg(feature = "protocol_feature_chunk_only_producers")]
-                    false,
                 )
                 .into()],
                 prev_epoch_kickout: Default::default(),

--- a/nearcore/src/shard_tracker.rs
+++ b/nearcore/src/shard_tracker.rs
@@ -201,8 +201,6 @@ mod tests {
                 "test".parse().unwrap(),
                 PublicKey::empty(KeyType::ED25519),
                 100,
-                #[cfg(feature = "protocol_feature_chunk_only_producers")]
-                false,
             )],
         )
         .unwrap()

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -306,8 +306,6 @@ pub(crate) fn action_stake(
             account_id.clone(),
             stake.public_key.clone(),
             stake.stake,
-            #[cfg(feature = "protocol_feature_chunk_only_producers")]
-            false,
         ));
         if stake.stake > account.locked() {
             // We've checked above `account.amount >= increment`


### PR DESCRIPTION
We figured out that we don't actually need it. And, indeed, today the
code is unused.

The code still preserves versions for stakes, just in case we need it
later.

closes https://nearinc.atlassian.net/browse/CPR-83