### PR TITLE
perf: avoid unnecessary allocations when merklizing stuff

### DIFF
--- a/core/primitives/src/merkle.rs
+++ b/core/primitives/src/merkle.rs
@@ -30,10 +30,7 @@ pub fn merklize<T: BorshSerialize>(arr: &[T]) -> (MerkleHash, Vec<MerklePath>) {
         return (MerkleHash::default(), vec![]);
     }
     let mut len = arr.len().next_power_of_two();
-    let mut hashes = arr
-        .iter()
-        .map(|elem| hash(&elem.try_to_vec().expect("Failed to serialize")))
-        .collect::<Vec<_>>();
+    let mut hashes = arr.iter().map(CryptoHash::hash_borsh).collect::<Vec<_>>();
 
     // degenerate case
     if len == 1 {

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -810,7 +810,9 @@ impl EncodedShardChunkBody {
     }
 
     pub fn get_merkle_hash_and_paths(&self) -> (MerkleHash, Vec<MerklePath>) {
-        merklize(&self.parts.iter().map(|x| x.as_ref().unwrap().clone()).collect::<Vec<_>>())
+        let parts: Vec<&[u8]> =
+            self.parts.iter().map(|x| x.as_deref().unwrap()).collect::<Vec<_>>();
+        merklize(&parts)
     }
 }
 


### PR DESCRIPTION
* CryptoHash::hash_borsh computes the hash in the streaming fashion,
  without allocating an intermediary vec
* EncodedShardChunkBody, we avoid cloning boxes, taking references
  instead.