### PR TITLE
[fix] protobuf backward compatibility test

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@ env:
 steps:
   - label: "protobuf backward compatibility"
     command: |
-      buf breaking --against ".git#ref=`git merge-base --fork-point master`"
+      buf breaking --against ".git#ref=`git merge-base master HEAD`"
 
     timeout: 30
     agents:


### PR DESCRIPTION
"git merge-base --fork-point master" is unreliable and sometimes returns no response (I don't know why).
"git merge-base master HEAD" works in the case we discovered, so switching to that.