### PR TITLE
store: separate StoreUpdate::update_refcount into increase and decrease

### DIFF
--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -2271,7 +2271,7 @@ impl<'a> ChainStoreUpdate<'a> {
             Ok(receipt_ids) => {
                 for receipt_id in receipt_ids {
                     let key: Vec<u8> = receipt_id.into();
-                    store_update.decrease_refcount(DBCol::ReceiptIdToShardId, &key);
+                    store_update.decrement_refcount(DBCol::ReceiptIdToShardId, &key);
                     self.chain_store.receipt_id_to_shard_id.pop(&key);
                     self.inc_gc(DBCol::ReceiptIdToShardId);
                 }
@@ -2377,11 +2377,11 @@ impl<'a> ChainStoreUpdate<'a> {
                 panic!("Must use gc_outgoing_receipts");
             }
             DBCol::Transactions => {
-                store_update.decrease_refcount(col, key);
+                store_update.decrement_refcount(col, key);
                 self.chain_store.transactions.pop(key);
             }
             DBCol::Receipts => {
-                store_update.decrease_refcount(col, key);
+                store_update.decrement_refcount(col, key);
                 self.chain_store.receipts.pop(key);
             }
             DBCol::Chunks => {
@@ -2692,13 +2692,13 @@ impl<'a> ChainStoreUpdate<'a> {
             // Increase transaction refcounts for all included txs
             for tx in chunk.transactions().iter() {
                 let bytes = tx.try_to_vec().expect("Borsh cannot fail");
-                store_update.increase_refcount(DBCol::Transactions, tx.get_hash().as_ref(), &bytes);
+                store_update.increment_refcount(DBCol::Transactions, tx.get_hash().as_ref(), &bytes);
             }
 
             // Increase receipt refcounts for all included receipts
             for receipt in chunk.receipts().iter() {
                 let bytes = receipt.try_to_vec().expect("Borsh cannot fail");
-                store_update.increase_refcount(
+                store_update.increment_refcount(
                     DBCol::Receipts,
                     receipt.get_hash().as_ref(),
                     &bytes,
@@ -2764,7 +2764,7 @@ impl<'a> ChainStoreUpdate<'a> {
         }
         for (receipt_id, shard_id) in self.chain_store_cache_update.receipt_id_to_shard_id.iter() {
             let data = shard_id.try_to_vec()?;
-            store_update.increase_refcount(DBCol::ReceiptIdToShardId, receipt_id.as_ref(), &data);
+            store_update.increment_refcount(DBCol::ReceiptIdToShardId, receipt_id.as_ref(), &data);
         }
         for (block_hash, refcount) in self.chain_store_cache_update.block_refcounts.iter() {
             store_update.set_ser(DBCol::BlockRefCount, block_hash.as_ref(), refcount)?;

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -2271,7 +2271,7 @@ impl<'a> ChainStoreUpdate<'a> {
             Ok(receipt_ids) => {
                 for receipt_id in receipt_ids {
                     let key: Vec<u8> = receipt_id.into();
-                    store_update.update_refcount(DBCol::ReceiptIdToShardId, &key, &[], -1);
+                    store_update.decrease_refcount(DBCol::ReceiptIdToShardId, &key);
                     self.chain_store.receipt_id_to_shard_id.pop(&key);
                     self.inc_gc(DBCol::ReceiptIdToShardId);
                 }
@@ -2377,11 +2377,11 @@ impl<'a> ChainStoreUpdate<'a> {
                 panic!("Must use gc_outgoing_receipts");
             }
             DBCol::Transactions => {
-                store_update.update_refcount(col, key, &[], -1);
+                store_update.decrease_refcount(col, key);
                 self.chain_store.transactions.pop(key);
             }
             DBCol::Receipts => {
-                store_update.update_refcount(col, key, &[], -1);
+                store_update.decrease_refcount(col, key);
                 self.chain_store.receipts.pop(key);
             }
             DBCol::Chunks => {
@@ -2692,22 +2692,16 @@ impl<'a> ChainStoreUpdate<'a> {
             // Increase transaction refcounts for all included txs
             for tx in chunk.transactions().iter() {
                 let bytes = tx.try_to_vec().expect("Borsh cannot fail");
-                store_update.update_refcount(
-                    DBCol::Transactions,
-                    tx.get_hash().as_ref(),
-                    &bytes,
-                    1,
-                );
+                store_update.increase_refcount(DBCol::Transactions, tx.get_hash().as_ref(), &bytes);
             }
 
             // Increase receipt refcounts for all included receipts
             for receipt in chunk.receipts().iter() {
                 let bytes = receipt.try_to_vec().expect("Borsh cannot fail");
-                store_update.update_refcount(
+                store_update.increase_refcount(
                     DBCol::Receipts,
                     receipt.get_hash().as_ref(),
                     &bytes,
-                    1,
                 );
             }
 
@@ -2770,7 +2764,7 @@ impl<'a> ChainStoreUpdate<'a> {
         }
         for (receipt_id, shard_id) in self.chain_store_cache_update.receipt_id_to_shard_id.iter() {
             let data = shard_id.try_to_vec()?;
-            store_update.update_refcount(DBCol::ReceiptIdToShardId, receipt_id.as_ref(), &data, 1);
+            store_update.increase_refcount(DBCol::ReceiptIdToShardId, receipt_id.as_ref(), &data);
         }
         for (block_hash, refcount) in self.chain_store_cache_update.block_refcounts.iter() {
             store_update.set_ser(DBCol::BlockRefCount, block_hash.as_ref(), refcount)?;

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -2692,7 +2692,11 @@ impl<'a> ChainStoreUpdate<'a> {
             // Increase transaction refcounts for all included txs
             for tx in chunk.transactions().iter() {
                 let bytes = tx.try_to_vec().expect("Borsh cannot fail");
-                store_update.increment_refcount(DBCol::Transactions, tx.get_hash().as_ref(), &bytes);
+                store_update.increment_refcount(
+                    DBCol::Transactions,
+                    tx.get_hash().as_ref(),
+                    &bytes,
+                );
             }
 
             // Increase receipt refcounts for all included receipts

--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -180,7 +180,7 @@ impl StoreValidator {
                     // EpochInfo for current Epoch id of Block exists
                     self.check(&validate::block_epoch_exists, &block_hash, &block, col);
                     // Increase Block Refcount
-                    self.check(&validate::block_increase_refcount, &block_hash, &block, col);
+                    self.check(&validate::block_increment_refcount, &block_hash, &block, col);
                 }
                 DBCol::BlockHeight => {
                     let height = BlockHeight::try_from_slice(key_ref)?;

--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -20,7 +20,8 @@ use near_primitives::transaction::ExecutionOutcomeWithIdAndProof;
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{AccountId, BlockHeight, EpochId, GCCount};
 use near_primitives::utils::get_block_shard_id_rev;
-use near_store::{decode_value_with_rc, DBCol, Store, TrieChanges};
+use near_store::db::refcount;
+use near_store::{DBCol, Store, TrieChanges};
 use validate::StoreValidatorError;
 
 use crate::RuntimeAdapter;
@@ -313,12 +314,12 @@ impl StoreValidator {
                     self.check(&validate::gc_col_count, &col, &count, col);
                 }
                 DBCol::Transactions => {
-                    let (_value, rc) = decode_value_with_rc(value_ref);
+                    let (_value, rc) = refcount::decode_value_with_rc(value_ref);
                     let tx_hash = CryptoHash::try_from(key_ref)?;
                     self.check(&validate::tx_refcount, &tx_hash, &(rc as u64), col);
                 }
                 DBCol::Receipts => {
-                    let (_value, rc) = decode_value_with_rc(value_ref);
+                    let (_value, rc) = refcount::decode_value_with_rc(value_ref);
                     let receipt_id = CryptoHash::try_from(key_ref)?;
                     self.check(&validate::receipt_refcount, &receipt_id, &(rc as u64), col);
                 }

--- a/chain/chain/src/store_validator/validate.rs
+++ b/chain/chain/src/store_validator/validate.rs
@@ -454,7 +454,7 @@ pub(crate) fn block_epoch_exists(
     Ok(())
 }
 
-pub(crate) fn block_increase_refcount(
+pub(crate) fn block_increment_refcount(
     sv: &mut StoreValidator,
     _block_hash: &CryptoHash,
     block: &Block,

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -268,7 +268,7 @@ impl DBCol {
     /// A reference-counted column is one where we store additional 8-byte value
     /// at the end of the payload with the current reference counter value.  For
     /// such columns you must not use `set`, `set_ser` or `delete` operations,
-    /// but 'increase_refcount' and `decrease_refcount` instead.
+    /// but 'increment_refcount' and `decrement_refcount` instead.
     ///
     /// Under the hood, we’re using custom merge operator (`refcount_merge`) to
     /// properly ‘join’ the refcounted cells.  This means that the 'value' for
@@ -277,13 +277,13 @@ impl DBCol {
     /// Example:
     ///
     /// ```ignore
-    /// increase_refcount("foo", "bar");
+    /// increment_refcount("foo", "bar");
     /// // good - after this call, the RC will be equal to 3.
-    /// increase_refcount_by("foo", "bar", 2);
+    /// increment_refcount_by("foo", "bar", 2);
     /// // bad - the value is still 'bar'.
-    /// increase_refcount("foo", "baz");
+    /// increment_refcount("foo", "baz");
     /// // ok - the value will be removed now. (as rc == 0)
-    /// decrease_refcount_by("foo", "", 3)
+    /// decrement_refcount_by("foo", "", 3)
     /// ```
     ///
     /// Quick note on negative refcounts: if we have a key that ends up having
@@ -293,8 +293,8 @@ impl DBCol {
     /// Example:
     ///
     /// ```ignore
-    /// increase_refcount("a", "b");
-    /// decrease_refcount_by("a", 3);
+    /// increment_refcount("a", "b");
+    /// decrement_refcount_by("a", 3);
     /// // Now we have the entry in the database with key "a", empty payload and
     /// // refcount value of -2,
     /// ```

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -805,9 +805,9 @@ mod tests {
         assert_eq!(store.get(DBCol::State, &[1]).unwrap(), None);
         {
             let mut store_update = store.store_update();
-            store_update.increase_refcount(DBCol::State, &[1], &[1]);
-            store_update.increase_refcount(DBCol::State, &[2], &[2]);
-            store_update.increase_refcount(DBCol::State, &[3], &[3]);
+            store_update.increment_refcount(DBCol::State, &[1], &[1]);
+            store_update.increment_refcount(DBCol::State, &[2], &[2]);
+            store_update.increment_refcount(DBCol::State, &[3], &[3]);
             store_update.commit().unwrap();
         }
         assert_eq!(store.get(DBCol::State, &[1]).unwrap(), Some(vec![1]));
@@ -828,12 +828,12 @@ mod tests {
         assert_eq!(store.get(DBCol::State, &[1]).unwrap(), None);
         {
             let mut store_update = store.store_update();
-            store_update.increase_refcount(DBCol::State, &[1], &[1]);
+            store_update.increment_refcount(DBCol::State, &[1], &[1]);
             store_update.commit().unwrap();
         }
         {
             let mut store_update = store.store_update();
-            store_update.increase_refcount(DBCol::State, &[1], &[1]);
+            store_update.increment_refcount(DBCol::State, &[1], &[1]);
             store_update.commit().unwrap();
         }
         assert_eq!(store.get(DBCol::State, &[1]).unwrap(), Some(vec![1]));
@@ -843,7 +843,7 @@ mod tests {
         );
         {
             let mut store_update = store.store_update();
-            store_update.decrease_refcount(DBCol::State, &[1]);
+            store_update.decrement_refcount(DBCol::State, &[1]);
             store_update.commit().unwrap();
         }
         assert_eq!(store.get(DBCol::State, &[1]).unwrap(), Some(vec![1]));
@@ -853,7 +853,7 @@ mod tests {
         );
         {
             let mut store_update = store.store_update();
-            store_update.decrease_refcount(DBCol::State, &[1]);
+            store_update.decrement_refcount(DBCol::State, &[1]);
             store_update.commit().unwrap();
         }
         // Refcount goes to 0 -> get() returns None

--- a/core/store/src/db/refcount.rs
+++ b/core/store/src/db/refcount.rs
@@ -87,7 +87,7 @@ pub fn decode_value_with_rc(bytes: &[u8]) -> (Option<&[u8]>, i64) {
 
 /// Encode a positive reference count into the value.
 pub(crate) fn add_positive_refcount(data: &[u8], rc: std::num::NonZeroU32) -> Vec<u8> {
-    let rc = std::num::NonZeroI64::from(rc).get();
+    let rc = i64::from(rc.get());
     let mut value = Vec::with_capacity(data.len() + 8);
     value.extend_from_slice(data);
     value.extend_from_slice(&rc.to_le_bytes());
@@ -98,7 +98,8 @@ pub(crate) fn add_positive_refcount(data: &[u8], rc: std::num::NonZeroU32) -> Ve
 ///
 /// `rc` gives the absolute value of the reference count.
 pub(crate) fn encode_negative_refcount(rc: std::num::NonZeroU32) -> Vec<u8> {
-    (-(rc.get() as i64)).to_le_bytes().to_vec()
+    let rc = -i64::from(rc.get());
+    rc.to_le_bytes().to_vec()
 }
 
 /// Merge reference counted values together.

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -155,19 +155,16 @@ impl ShardTries {
         store_update: &mut StoreUpdate,
     ) {
         store_update.tries = Some(tries);
-        for TrieRefcountChange { trie_node_or_value_hash, trie_node_or_value, rc } in
-            deletions.iter()
-        {
+        for TrieRefcountChange { trie_node_or_value_hash, rc, .. } in deletions.iter() {
+            let rc = match std::num::NonZeroU32::new(*rc) {
+                None => continue,
+                Some(rc) => rc,
+            };
             let key = TrieCachingStorage::get_key_from_shard_uid_and_hash(
                 shard_uid,
                 trie_node_or_value_hash,
             );
-            store_update.update_refcount(
-                DBCol::State,
-                key.as_ref(),
-                trie_node_or_value,
-                -(*rc as i64),
-            );
+            store_update.decrease_refcount_by(DBCol::State, key.as_ref(), rc);
         }
     }
 
@@ -181,16 +178,15 @@ impl ShardTries {
         for TrieRefcountChange { trie_node_or_value_hash, trie_node_or_value, rc } in
             insertions.iter()
         {
+            let rc = match std::num::NonZeroU32::new(*rc) {
+                None => continue,
+                Some(rc) => rc,
+            };
             let key = TrieCachingStorage::get_key_from_shard_uid_and_hash(
                 shard_uid,
                 trie_node_or_value_hash,
             );
-            store_update.update_refcount(
-                DBCol::State,
-                key.as_ref(),
-                trie_node_or_value,
-                *rc as i64,
-            );
+            store_update.increase_refcount_by(DBCol::State, key.as_ref(), trie_node_or_value, rc);
         }
     }
 
@@ -281,16 +277,15 @@ impl ShardTries {
         for TrieRefcountChange { trie_node_or_value_hash, trie_node_or_value, rc } in
             trie_changes.insertions.into_iter()
         {
+            let rc = match std::num::NonZeroU32::new(rc) {
+                None => continue,
+                Some(rc) => rc,
+            };
             let key = TrieCachingStorage::get_key_from_shard_uid_and_hash(
                 shard_uid,
                 &trie_node_or_value_hash,
             );
-            store_update.update_refcount(
-                DBCol::State,
-                key.as_ref(),
-                &trie_node_or_value,
-                rc as i64,
-            );
+            store_update.increase_refcount_by(DBCol::State, key.as_ref(), &trie_node_or_value, rc);
         }
         (store_update, trie_changes.new_root)
     }

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -164,7 +164,7 @@ impl ShardTries {
                 shard_uid,
                 trie_node_or_value_hash,
             );
-            store_update.decrease_refcount_by(DBCol::State, key.as_ref(), rc);
+            store_update.decrement_refcount_by(DBCol::State, key.as_ref(), rc);
         }
     }
 
@@ -186,7 +186,7 @@ impl ShardTries {
                 shard_uid,
                 trie_node_or_value_hash,
             );
-            store_update.increase_refcount_by(DBCol::State, key.as_ref(), trie_node_or_value, rc);
+            store_update.increment_refcount_by(DBCol::State, key.as_ref(), trie_node_or_value, rc);
         }
     }
 
@@ -285,7 +285,7 @@ impl ShardTries {
                 shard_uid,
                 &trie_node_or_value_hash,
             );
-            store_update.increase_refcount_by(DBCol::State, key.as_ref(), &trie_node_or_value, rc);
+            store_update.increment_refcount_by(DBCol::State, key.as_ref(), &trie_node_or_value, rc);
         }
         (store_update, trie_changes.new_root)
     }


### PR DESCRIPTION
Every time StoreUpdate::update_refcount is used it’s called with
a positive or a negative value.  I.e. each caller knows whether they
are increasing or decreasing the value.  This makes it trivial to
split the method into increase_refcount and decrease_refcount methods.
The two methods are now simpler since they don’t have to check sign of
the delta argument.