### PR TITLE
Changing remove_witness to get_witness in Doomslug

### DIFF
--- a/chain/chain/src/doomslug.rs
+++ b/chain/chain/src/doomslug.rs
@@ -454,19 +454,19 @@ impl Doomslug {
             && (approved_stake2 > threshold2 || threshold2 == 0)
     }
 
-    pub fn remove_witness(
-        &mut self,
+    pub fn get_witness(
+        &self,
         prev_hash: &CryptoHash,
         parent_height: BlockHeight,
         target_height: BlockHeight,
     ) -> HashMap<AccountId, Approval> {
         let hash_or_height = ApprovalInner::new(prev_hash, parent_height, target_height);
-        if let Some(approval_trackers_at_height) = self.approval_tracking.get_mut(&target_height) {
+        if let Some(approval_trackers_at_height) = self.approval_tracking.get(&target_height) {
             let approvals_tracker =
-                approval_trackers_at_height.approval_trackers.remove(&hash_or_height);
+                approval_trackers_at_height.approval_trackers.get(&hash_or_height);
             match approvals_tracker {
                 None => HashMap::new(),
-                Some(approvals_tracker) => approvals_tracker.witness,
+                Some(approvals_tracker) => approvals_tracker.witness.clone(),
             }
         } else {
             HashMap::new()

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -441,7 +441,7 @@ impl Client {
             return Ok(None);
         }
 
-        let mut approvals_map = self.doomslug.remove_witness(&prev_hash, prev_height, next_height);
+        let mut approvals_map = self.doomslug.get_witness(&prev_hash, prev_height, next_height);
 
         // At this point, the previous epoch hash must be available
         let epoch_id = self


### PR DESCRIPTION
The previous code was removing the witness at the moment of block creation - which makes debugging/reviewing history a lot harder (as the data is gone).

Now, the data is persisted, and it is removed when we GC all the trackers for a given height..