### PR TITLE
fix: revert default value for trie cache capacity

### DIFF
--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -97,7 +97,7 @@ impl Default for StoreConfig {
             // we use it since then.
             block_size: bytesize::ByteSize::kib(16),
 
-            trie_cache_capacities: vec![(ShardUId { version: 1, shard_id: 3 }, 2_000_000)],
+            trie_cache_capacities: Default::default(),
         }
     }
 }


### PR DESCRIPTION
Revert default value (to 50K) because after https://github.com/near/nearcore/pull/7022 we got more evidence that it doesn't help to speed up storage ops.

## Testing

Existing tests.