### PR TITLE
store: add documentation to Database trait and refactor it a little

### DIFF
--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -830,35 +830,6 @@ mod tests {
         store.pre_write_check().unwrap()
     }
 
-    fn do_test_clear_column(store: Store) {
-        assert_eq!(store.get(DBCol::State, &[1]).unwrap(), None);
-        {
-            let mut store_update = store.store_update();
-            store_update.increment_refcount(DBCol::State, &[1], &[1]);
-            store_update.increment_refcount(DBCol::State, &[2], &[2]);
-            store_update.increment_refcount(DBCol::State, &[3], &[3]);
-            store_update.commit().unwrap();
-        }
-        assert_eq!(store.get(DBCol::State, &[1]).unwrap(), Some(vec![1]));
-        {
-            let mut store_update = store.store_update();
-            store_update.delete_all(DBCol::State);
-            store_update.commit().unwrap();
-        }
-        assert_eq!(store.get(DBCol::State, &[1]).unwrap(), None);
-    }
-
-    #[test]
-    fn test_clear_column_rocksdb() {
-        let (_tmp_dir, opener) = Store::test_opener();
-        do_test_clear_column(opener.open());
-    }
-
-    #[test]
-    fn test_clear_column_testdb() {
-        do_test_clear_column(crate::test_utils::create_test_store());
-    }
-
     #[test]
     fn rocksdb_merge_sanity() {
         let (_tmp_dir, opener) = Store::test_opener();

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -79,7 +79,9 @@ impl Store {
     }
 
     pub fn get(&self, column: DBCol, key: &[u8]) -> io::Result<Option<Vec<u8>>> {
-        self.storage.get(column, key)
+        self.storage
+            .get_raw_bytes(column, key)
+            .map(|result| refcount::get_with_rc_logic(column, result))
     }
 
     pub fn get_ser<T: BorshDeserialize>(&self, column: DBCol, key: &[u8]) -> io::Result<Option<T>> {


### PR DESCRIPTION
Firstly, remove transaction function from the Database trait in favour
of callers simply creating DBTransaction object themselves.

Secondly, replace Database::get by get_raw_bytes method which,
similarly to iter_raw_bytes, doesn’t perform refcount decoding.  RC
handling is now done at Store::get level which means that it’s now
common code regardless of Database implementation.  This new method
can be further used in tests which so far were using their own code.

And lastly, while doing all that, add more documentation to functions
within Database trait.
