### PR TITLE
Update mac_m1_binary.yml

### DIFF
--- a/.github/workflows/mac_m1_binary.yml
+++ b/.github/workflows/mac_m1_binary.yml
@@ -10,9 +10,6 @@ jobs:
     runs-on: macOS-m1
 
     steps:
-    - uses: hecrj/setup-rust-action@v1
-      with:
-        rust-version: nightly-2020-03-19
     - uses: actions/checkout@master
     - uses: isbang/setup-awscli@v0.1.0
     - run: scripts/mac-release.sh


### PR DESCRIPTION
removed rust actions as rustup is not supported on M1
see https://doc.rust-lang.org/nightly/rustc/platform-support.html