### PR TITLE
shardnet compilation feature for near-indexer-for-explorer

### DIFF
--- a/chain/client/Cargo.toml
+++ b/chain/client/Cargo.toml
@@ -76,3 +76,5 @@ sandbox = [
   "near-client-primitives/sandbox",
   "near-chain/sandbox",
 ]
+# Shardnet is the experimental network that we deploy for chunk-only producer testing.
+shardnet = ["near-primitives/shardnet"]

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -842,7 +842,7 @@ pub fn init_configs(
             genesis.to_file(&dir.join(config.genesis_file));
             info!(target: "near", "Generated mainnet genesis file in {}", dir.display());
         }
-        "testnet" | "betanet" => {
+        "testnet" | "betanet" | "shardnet" => {
             if test_seed.is_some() {
                 bail!("Test seed is not supported for official testnet");
             }


### PR DESCRIPTION
The indexer doesn't depend on `neard` but depends on `near-client`