### PR TITLE
Fix the shardnet feature for the indexer

### DIFF
--- a/chain/client/Cargo.toml
+++ b/chain/client/Cargo.toml
@@ -77,4 +77,4 @@ sandbox = [
   "near-chain/sandbox",
 ]
 # Shardnet is the experimental network that we deploy for chunk-only producer testing.
-shardnet = ["near-primitives/shardnet"]
+shardnet = ["protocol_feature_chunk_only_producers"]

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -55,7 +55,7 @@ nightly_protocol = []
 
 
 # Shardnet is the experimental network that we deploy for chunk-only producer testing.
-shardnet = []
+shardnet = ["protocol_feature_chunk_only_producers"]
 
 deepsize_feature = [
   "deepsize",

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -71,7 +71,6 @@ nightly_protocol = ["nearcore/nightly_protocol"]
 
 # Shardnet is the experimental network that we deploy for chunk-only producer testing.
 shardnet = [
-  "near-primitives/shardnet",
   "protocol_feature_chunk_only_producers"
 ]
 


### PR DESCRIPTION
Before this PR, the `shardnet` compilation feature didn't enable `protocol_feature_chunk_only_producers` in all needed place.