### PR TITLE
store: check RocksDB iterator’s status for errors when done

### DIFF
--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -146,7 +146,8 @@ impl StoreValidator {
         self.errors.push(ErrorMessage { key: to_string(&key), col: to_string(&col), err })
     }
     fn validate_col(&mut self, col: DBCol) -> Result<(), StoreValidatorError> {
-        for (key, value) in self.store.clone().iter_raw_bytes(col) {
+        for item in self.store.clone().iter_raw_bytes(col) {
+            let (key, value) = item?;
             let key_ref = key.as_ref();
             let value_ref = value.as_ref();
             match col {

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -1330,7 +1330,7 @@ pub fn display_chain(me: &Option<AccountId>, chain: &mut Chain, tail: bool) {
         head.last_block_hash
     );
     let mut headers = vec![];
-    for (key, _) in chain_store.store().clone().iter(DBCol::BlockHeader) {
+    for (key, _) in chain_store.store().clone().iter(DBCol::BlockHeader).map(Result::unwrap) {
         let header = chain_store
             .get_block_header(&CryptoHash::try_from(key.as_ref()).unwrap())
             .unwrap()

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1770,7 +1770,7 @@ impl Client {
         state_split_scheduler: &dyn Fn(StateSplitRequest),
     ) -> Result<Vec<AcceptedBlock>, Error> {
         let me = &self.validator_signer.as_ref().map(|x| x.validator_id().clone());
-        for (sync_hash, state_sync_info) in self.chain.store().iterate_state_sync_infos() {
+        for (sync_hash, state_sync_info) in self.chain.store().iterate_state_sync_infos()? {
             assert_eq!(sync_hash, state_sync_info.epoch_tail_hash);
             let network_adapter1 = self.network_adapter.clone();
 

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -1686,7 +1686,7 @@ pub fn run_catchup(
         state_split_inside_messages.write().unwrap().push(msg);
     };
     let rt = client.runtime_adapter.clone();
-    while !client.chain.store().iterate_state_sync_infos().is_empty() {
+    while !client.chain.store().iterate_state_sync_infos().unwrap().is_empty() {
         let call = client.run_catchup(highest_height_peers, &f, &block_catch_up, &state_split)?;
         for msg in block_messages.write().unwrap().drain(..) {
             let results = do_apply_chunks(msg.work);

--- a/chain/network/src/store/schema/mod.rs
+++ b/chain/network/src/store/schema/mod.rs
@@ -274,7 +274,9 @@ impl Store {
         &self,
     ) -> impl Iterator<Item = Result<(<C::Key as Format>::T, <C::Value as Format>::T), Error>> + '_
     {
-        self.0.iter(C::COL).map(|(k, v)| Ok((C::Key::decode(&k)?, C::Value::decode(&v)?)))
+        self.0
+            .iter(C::COL)
+            .map(|item| item.and_then(|(k, v)| Ok((C::Key::decode(&k)?, C::Value::decode(&v)?))))
     }
     pub fn get<C: Column>(
         &self,

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -246,6 +246,8 @@ pub struct TestDB {
     db: RwLock<enum_map::EnumMap<DBCol, BTreeMap<Vec<u8>, Vec<u8>>>>,
 }
 
+pub(crate) type DBIterator<'a> = Box<dyn Iterator<Item = io::Result<(Box<[u8]>, Box<[u8]>)>> + 'a>;
+
 pub(crate) trait Database: Sync + Send {
     /// Returns raw bytes for given `key` ignoring any reference count decoding
     /// if any.
@@ -266,18 +268,14 @@ pub(crate) trait Database: Sync + Send {
     /// count will be treated as non-existing (i.e. they’re going to be
     /// skipped).  For all other columns, the value is returned directly from
     /// the database.
-    fn iter<'a>(&'a self, column: DBCol) -> Box<dyn Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a>;
+    fn iter<'a>(&'a self, column: DBCol) -> DBIterator<'a>;
 
     /// Iterate over items in given column whose keys start with given prefix.
     ///
     /// This is morally equivalent to [`Self::iter`] with a filter discarding
     /// keys which do not start with given `key_prefix` (but faster).  The items
     /// are returned in lexicographical order sorted by the key.
-    fn iter_prefix<'a>(
-        &'a self,
-        col: DBCol,
-        key_prefix: &'a [u8],
-    ) -> Box<dyn Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a>;
+    fn iter_prefix<'a>(&'a self, col: DBCol, key_prefix: &'a [u8]) -> DBIterator<'a>;
 
     /// Iterate over items in given column bypassing reference count decoding if
     /// any.
@@ -290,10 +288,7 @@ pub(crate) trait Database: Sync + Send {
     /// If in doubt, use [`Self::iter`] instead.  Unless you’re doing something
     /// low-level with the database (e.g. doing a migration), you probably don’t
     /// want this method.
-    fn iter_raw_bytes<'a>(
-        &'a self,
-        column: DBCol,
-    ) -> Box<dyn Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a>;
+    fn iter_raw_bytes<'a>(&'a self, column: DBCol) -> DBIterator<'a>;
 
     /// Atomically apply all operations in given batch at once.
     fn write(&self, batch: DBTransaction) -> io::Result<()>;
@@ -307,6 +302,60 @@ pub(crate) trait Database: Sync + Send {
     fn get_store_statistics(&self) -> Option<StoreStatistics>;
 }
 
+impl RocksDB {
+    fn iter_raw_bytes_impl<'a>(
+        &'a self,
+        col: DBCol,
+        prefix: Option<&'a [u8]>,
+    ) -> RocksDBIterator<'a> {
+        let cf_handle = self.cf_handle(col);
+        let mut read_options = rocksdb_read_options();
+        let mode = if let Some(prefix) = prefix {
+            // prefix_same_as_start doesn’t do anything for us.  It takes effect
+            // only if prefix extractor is configured for the column family
+            // which is something we’re not doing.  Setting this option is
+            // therefore pointless.
+            //     read_options.set_prefix_same_as_start(true);
+
+            // We’re running the iterator in From mode so there’s no need to set
+            // the lower bound.
+            //    read_options.set_iterate_lower_bound(key_prefix);
+
+            // Upper bound is exclusive so if we set it to the next prefix
+            // iterator will stop once keys no longer start with our desired
+            // prefix.
+            if let Some(upper) = next_prefix(prefix) {
+                read_options.set_iterate_upper_bound(upper);
+            }
+
+            IteratorMode::From(prefix, Direction::Forward)
+        } else {
+            IteratorMode::Start
+        };
+        let iter = self.db.iterator_cf_opt(cf_handle, read_options, mode);
+        RocksDBIterator(Some(iter))
+    }
+}
+
+struct RocksDBIterator<'a>(Option<rocksdb::DBIteratorWithThreadMode<'a, DB>>);
+
+impl<'a> Iterator for RocksDBIterator<'a> {
+    type Item = io::Result<(Box<[u8]>, Box<[u8]>)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let iter = self.0.as_mut()?;
+        if let Some(item) = iter.next() {
+            Some(Ok(item))
+        } else {
+            let status = iter.status();
+            self.0 = None;
+            status.err().map(into_other).map(Result::Err)
+        }
+    }
+}
+
+impl<'a> std::iter::FusedIterator for RocksDBIterator<'a> {}
+
 impl Database for RocksDB {
     fn get_raw_bytes(&self, col: DBCol, key: &[u8]) -> io::Result<Option<Vec<u8>>> {
         let timer =
@@ -318,51 +367,17 @@ impl Database for RocksDB {
         Ok(result)
     }
 
-    fn iter_raw_bytes<'a>(
-        &'a self,
-        col: DBCol,
-    ) -> Box<dyn Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a> {
-        let read_options = rocksdb_read_options();
-        let cf_handle = self.cf_handle(col);
-        let iterator = self.db.iterator_cf_opt(cf_handle, read_options, IteratorMode::Start);
-        Box::new(iterator)
+    fn iter_raw_bytes<'a>(&'a self, col: DBCol) -> DBIterator<'a> {
+        Box::new(self.iter_raw_bytes_impl(col, None))
     }
 
-    fn iter<'a>(&'a self, col: DBCol) -> Box<dyn Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a> {
-        let read_options = rocksdb_read_options();
-        let cf_handle = self.cf_handle(col);
-        let iterator = self.db.iterator_cf_opt(cf_handle, read_options, IteratorMode::Start);
-        refcount::iter_with_rc_logic(col, iterator)
+    fn iter<'a>(&'a self, col: DBCol) -> DBIterator<'a> {
+        refcount::iter_with_rc_logic(col, self.iter_raw_bytes_impl(col, None))
     }
 
-    fn iter_prefix<'a>(
-        &'a self,
-        col: DBCol,
-        key_prefix: &'a [u8],
-    ) -> Box<dyn Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a> {
-        let mut read_options = rocksdb_read_options();
-
-        // prefix_same_as_start doesn’t do anything for us.  It takes effect
-        // only if prefix extractor is configured for the column family which is
-        // something we’re not doing.  Setting this option is thus pointless.
-        //     read_options.set_prefix_same_as_start(true);
-
-        // We’re running the iterator in From mode so there’s no need to set the
-        // lower bound.
-        //    read_options.set_iterate_lower_bound(key_prefix);
-
-        // Upper bound is exclusive so if we set it to the next prefix iterator
-        // will stop once keys no longer start with our desired prefix.
-        if let Some(upper) = next_prefix(key_prefix) {
-            read_options.set_iterate_upper_bound(upper);
-        }
-
-        let iterator = self.db.iterator_cf_opt(
-            self.cf_handle(col),
-            read_options,
-            IteratorMode::From(key_prefix, Direction::Forward),
-        );
-        refcount::iter_with_rc_logic(col, iterator)
+    fn iter_prefix<'a>(&'a self, col: DBCol, key_prefix: &'a [u8]) -> DBIterator<'a> {
+        let iter = self.iter_raw_bytes_impl(col, Some(key_prefix));
+        refcount::iter_with_rc_logic(col, iter)
     }
 
     fn write(&self, transaction: DBTransaction) -> io::Result<()> {
@@ -460,32 +475,25 @@ impl Database for TestDB {
         Ok(self.db.read().unwrap()[col].get(key).cloned())
     }
 
-    fn iter<'a>(&'a self, col: DBCol) -> Box<dyn Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a> {
+    fn iter<'a>(&'a self, col: DBCol) -> DBIterator<'a> {
         let iterator = self.iter_raw_bytes(col);
         refcount::iter_with_rc_logic(col, iterator)
     }
 
-    fn iter_raw_bytes<'a>(
-        &'a self,
-        col: DBCol,
-    ) -> Box<dyn Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a> {
+    fn iter_raw_bytes<'a>(&'a self, col: DBCol) -> DBIterator<'a> {
         let iterator = self.db.read().unwrap()[col]
             .clone()
             .into_iter()
-            .map(|(k, v)| (k.into_boxed_slice(), v.into_boxed_slice()));
+            .map(|(k, v)| Ok((k.into_boxed_slice(), v.into_boxed_slice())));
         Box::new(iterator)
     }
 
-    fn iter_prefix<'a>(
-        &'a self,
-        col: DBCol,
-        key_prefix: &'a [u8],
-    ) -> Box<dyn Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a> {
+    fn iter_prefix<'a>(&'a self, col: DBCol, key_prefix: &'a [u8]) -> DBIterator<'a> {
         let iterator = self.db.read().unwrap()[col]
             .range(key_prefix.to_vec()..)
             .take_while(move |(k, _)| k.starts_with(&key_prefix))
-            .map(|(k, v)| (k.clone().into_boxed_slice(), v.clone().into_boxed_slice()))
-            .collect::<Vec<_>>();
+            .map(|(k, v)| Ok((k.clone().into_boxed_slice(), v.clone().into_boxed_slice())))
+            .collect::<Vec<io::Result<_>>>();
         refcount::iter_with_rc_logic(col, iterator.into_iter())
     }
 

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -26,8 +26,8 @@ use near_primitives::trie_key::{trie_key_parsers, TrieKey};
 use near_primitives::types::{AccountId, CompiledContractCache, StateRoot};
 
 use crate::db::{
-    refcount, DBOp, DBTransaction, Database, RocksDB, StoreStatistics, GENESIS_JSON_HASH_KEY,
-    GENESIS_STATE_ROOTS_KEY,
+    refcount, DBIterator, DBOp, DBTransaction, Database, RocksDB, StoreStatistics,
+    GENESIS_JSON_HASH_KEY, GENESIS_STATE_ROOTS_KEY,
 };
 pub use crate::trie::iterator::TrieIterator;
 pub use crate::trie::update::{TrieUpdate, TrieUpdateIterator, TrieUpdateValuePtr};
@@ -98,10 +98,7 @@ impl Store {
         StoreUpdate::new(Arc::clone(&self.storage))
     }
 
-    pub fn iter<'a>(
-        &'a self,
-        column: DBCol,
-    ) -> Box<dyn Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a> {
+    pub fn iter<'a>(&'a self, column: DBCol) -> DBIterator<'a> {
         self.storage.iter(column)
     }
 
@@ -111,18 +108,11 @@ impl Store {
     /// This method is a deliberate escape hatch, and shouldn't be used outside
     /// of auxilary code like migrations which wants to hack on the database
     /// directly.
-    pub fn iter_raw_bytes<'a>(
-        &'a self,
-        column: DBCol,
-    ) -> Box<dyn Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a> {
+    pub fn iter_raw_bytes<'a>(&'a self, column: DBCol) -> DBIterator<'a> {
         self.storage.iter_raw_bytes(column)
     }
 
-    pub fn iter_prefix<'a>(
-        &'a self,
-        column: DBCol,
-        key_prefix: &'a [u8],
-    ) -> Box<dyn Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a> {
+    pub fn iter_prefix<'a>(&'a self, column: DBCol, key_prefix: &'a [u8]) -> DBIterator<'a> {
         self.storage.iter_prefix(column, key_prefix)
     }
 
@@ -133,13 +123,14 @@ impl Store {
     ) -> impl Iterator<Item = io::Result<(Box<[u8]>, T)>> + 'a {
         self.storage
             .iter_prefix(column, key_prefix)
-            .map(|(key, value)| Ok((key, T::try_from_slice(value.as_ref())?)))
+            .map(|item| item.and_then(|(key, value)| Ok((key, T::try_from_slice(value.as_ref())?))))
     }
 
     pub fn save_to_file(&self, column: DBCol, filename: &Path) -> io::Result<()> {
         let file = File::create(filename)?;
         let mut file = BufWriter::new(file);
-        for (key, value) in self.storage.iter_raw_bytes(column) {
+        for item in self.storage.iter_raw_bytes(column) {
+            let (key, value) = item?;
             file.write_u32::<LittleEndian>(key.len() as u32)?;
             file.write_all(&key)?;
             file.write_u32::<LittleEndian>(value.len() as u32)?;
@@ -683,8 +674,8 @@ mod tests {
         }
         update.commit().unwrap();
 
-        fn collect<'a>(iter: impl Iterator<Item = (Box<[u8]>, Box<[u8]>)>) -> Vec<Box<[u8]>> {
-            iter.map(|(key, _)| key).collect()
+        fn collect<'a>(iter: crate::db::DBIterator<'a>) -> Vec<Box<[u8]>> {
+            iter.map(Result::unwrap).map(|(key, _)| key).collect()
         }
 
         // Check that full scan produces keys in proper order.

--- a/core/store/src/migrations.rs
+++ b/core/store/src/migrations.rs
@@ -69,7 +69,7 @@ where
     U: BorshSerialize,
     F: Fn(T) -> U,
 {
-    let keys: Vec<_> = store.iter(col).map(|(key, _)| key).collect();
+    let keys: Vec<_> = store.iter(col).map(Result::unwrap).map(|(key, _)| key).collect();
     let mut store_update = BatchedStoreUpdate::new(store, 10_000_000);
 
     for key in keys {
@@ -92,7 +92,7 @@ where
     let mut store_update = store.store_update();
     let batch_size_limit = 10_000_000;
     let mut batch_size = 0;
-    for (key, _) in store.iter(col) {
+    for (key, _) in store.iter(col).map(Result::unwrap) {
         let new_value = f(&key);
         let new_bytes = new_value.try_to_vec()?;
         batch_size += key.as_ref().len() + new_bytes.len() + 8;
@@ -181,7 +181,7 @@ pub fn migrate_29_to_30(store_opener: &StoreOpener) {
     // values (EpochInfoAggregator), so we cannot use `map_col` on it. We need to handle
     // the AGGREGATOR_KEY differently from all others.
     let col = DBCol::EpochInfo;
-    let keys: Vec<_> = store.iter(col).map(|(key, _)| key).collect();
+    let keys: Vec<_> = store.iter(col).map(Result::unwrap).map(|(key, _)| key).collect();
     let mut store_update = BatchedStoreUpdate::new(&store, 10_000_000);
     for key in keys {
         if key.as_ref() == AGGREGATOR_KEY {

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -3470,7 +3470,7 @@ fn test_catchup_no_sharding_change() {
         let block = env.clients[0].produce_block(h).unwrap().unwrap();
         let (_, res) = env.clients[0].process_block(block.clone().into(), Provenance::PRODUCED);
         res.unwrap();
-        assert_eq!(env.clients[0].chain.store().iterate_state_sync_infos(), vec![]);
+        assert_eq!(env.clients[0].chain.store().iterate_state_sync_infos().unwrap(), vec![]);
         assert_eq!(
             env.clients[0].chain.store().get_blocks_to_catchup(block.header().prev_hash()).unwrap(),
             vec![]

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -279,7 +279,7 @@ pub fn start_with_config_and_synchronization(
     #[allow(unused_mut)]
     let mut rpc_servers = Vec::new();
     let arbiter = Arbiter::new();
-    config.network_config.verify().with_context(|| "start_with_config")?;
+    config.network_config.verify().context("start_with_config")?;
     let network_actor = PeerManagerActor::start_in_arbiter(&arbiter.handle(), {
         let client_actor = client_actor.clone();
         let view_client = view_client.clone();
@@ -441,7 +441,8 @@ pub fn recompress_storage(home_dir: &Path, opts: RecompressOpts) -> anyhow::Resu
         let mut total_written: u64 = 0;
         let mut batch_written: u64 = 0;
         let mut count_keys: u64 = 0;
-        for (key, value) in src_store.iter_raw_bytes(column) {
+        for item in src_store.iter_raw_bytes(column) {
+            let (key, value) = item.with_context(|| format!("scanning column {column:?}"))?;
             store_update.set_raw_bytes(column, &key, &value);
             total_written += value.len() as u64;
             batch_written += value.len() as u64;

--- a/tools/state-viewer/src/apply_chunk.rs
+++ b/tools/state-viewer/src/apply_chunk.rs
@@ -216,7 +216,8 @@ fn apply_tx_in_chunk(
     let head = chain_store.head()?.height;
     let mut chunk_hashes = vec![];
 
-    for (k, v) in store.iter(DBCol::ChunkHashesByHeight) {
+    for item in store.iter(DBCol::ChunkHashesByHeight) {
+        let (k, v) = item.context("scanning ChunkHashesByHeight column")?;
         let height = BlockHeight::from_le_bytes(k[..].try_into().unwrap());
         if height > head {
             let hashes = HashSet::<ChunkHash>::try_from_slice(&v).unwrap();
@@ -321,7 +322,8 @@ fn apply_receipt_in_chunk(
     let mut to_apply = HashSet::new();
     let mut non_applied_chunks = HashMap::new();
 
-    for (k, v) in store.iter(DBCol::ChunkHashesByHeight) {
+    for item in store.iter(DBCol::ChunkHashesByHeight) {
+        let (k, v) = item.context("scanning ChunkHashesByHeight column")?;
         let height = BlockHeight::from_le_bytes(k[..].try_into().unwrap());
         if height > head {
             let hashes = HashSet::<ChunkHash>::try_from_slice(&v).unwrap();

--- a/tools/state-viewer/src/epoch_info.rs
+++ b/tools/state-viewer/src/epoch_info.rs
@@ -144,6 +144,7 @@ fn get_epoch_ids(
 fn iterate_and_filter(store: Store, predicate: impl Fn(EpochInfo) -> bool) -> Vec<EpochId> {
     store
         .iter(DBCol::EpochInfo)
+        .map(Result::unwrap)
         .filter_map(|(key, value)| {
             if key.as_ref() == AGGREGATOR_KEY {
                 None


### PR DESCRIPTION
RocksDB’s iterator (created e.g. by iterator_cf method) returns items
until there’s no more data to return *or error occurs*.  It’s then
caller’s responsibility to check for error via status method.  We
haven’t been doing that which means that we’ve been silently ignoring
errors when iterating.

Change the Database and Store iterator interface to return io::Result
and wrap RocksDB iterator with code which checks for errors once
iteration finishes.

We don’t often iterate and read errors are uncommon so it’s unlikely
that this affected us in significant way.

Fixes: https://github.com/near/nearcore/issues/6583
