### PR TITLE
store: remove unused ChainStore::owned_store method

### DIFF
--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -413,10 +413,6 @@ impl ChainStore {
         }
     }
 
-    pub fn owned_store(&self) -> &Store {
-        &self.store
-    }
-
     pub fn store_update(&mut self) -> ChainStoreUpdate<'_> {
         ChainStoreUpdate::new(self)
     }


### PR DESCRIPTION
ChainStore::owned_store method is never used.  Everyone who cares
about getting the underlying Store uses ChainStore::store (which is
part of ChainStoreAccess trait).