### PR TITLE
refactor: Remove unnecessary lifetimes when storing configs

### DIFF
--- a/chain/indexer/src/streamer/mod.rs
+++ b/chain/indexer/src/streamer/mod.rs
@@ -287,7 +287,7 @@ pub(crate) async fn start(
     blocks_sink: mpsc::Sender<StreamerMessage>,
 ) {
     info!(target: INDEXER, "Starting Streamer...");
-    let indexer_db_path = near_store::Store::opener(&indexer_config.home_dir, &store_config)
+    let indexer_db_path = near_store::Store::opener(&indexer_config.home_dir, store_config.clone())
         .get_path()
         .join("indexer");
 

--- a/core/store/benches/store_bench.rs
+++ b/core/store/benches/store_bench.rs
@@ -19,7 +19,7 @@ fn benchmark_write_then_read_successful(
     let tmp_dir = tempfile::tempdir().unwrap();
     // Use default StoreConfig rather than Store::test_opener so we’re using the
     // same configuration as in production.
-    let store = Store::opener(tmp_dir.path(), &Default::default()).open();
+    let store = Store::opener(tmp_dir.path(), Default::default()).open();
     let keys = generate_keys(num_keys, key_size);
     write_to_db(&store, &keys, max_value_size, col);
 

--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -111,7 +111,7 @@ impl Default for StoreConfig {
 ///     .home(neard_home_dir)
 ///     .open();
 /// ```
-pub struct StoreOpener<'a> {
+pub struct StoreOpener {
     /// Path to the database.
     ///
     /// This is resolved from nearcore home directory and store configuration
@@ -119,15 +119,15 @@ pub struct StoreOpener<'a> {
     path: std::path::PathBuf,
 
     /// Configuration as provided by the user.
-    config: &'a StoreConfig,
+    config: StoreConfig,
 
     /// Which mode to open storeg in.
     mode: Mode,
 }
 
-impl<'a> StoreOpener<'a> {
+impl StoreOpener {
     /// Initialises a new opener with given home directory and store config.
-    pub(crate) fn new(home_dir: &std::path::Path, config: &'a StoreConfig) -> Self {
+    pub(crate) fn new(home_dir: &std::path::Path, config: StoreConfig) -> Self {
         let path =
             home_dir.join(config.path.as_deref().unwrap_or(std::path::Path::new(STORE_PATH)));
         Self { path, config, mode: Mode::ReadWrite }

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -53,7 +53,7 @@ pub struct Store {
 
 impl Store {
     /// Initialises a new opener with given home directory and store config.
-    pub fn opener<'a>(home_dir: &std::path::Path, config: &'a StoreConfig) -> StoreOpener<'a> {
+    pub fn opener(home_dir: &std::path::Path, config: StoreConfig) -> StoreOpener {
         StoreOpener::new(home_dir, config)
     }
 
@@ -65,10 +65,10 @@ impl Store {
     ///
     /// Note that the caller must hold the temporary directory returned as first
     /// element of the tuple while the store is open.
-    pub fn test_opener() -> (tempfile::TempDir, StoreOpener<'static>) {
+    pub fn test_opener() -> (tempfile::TempDir, StoreOpener) {
         static CONFIG: Lazy<StoreConfig> = Lazy::new(StoreConfig::test_config);
         let dir = tempfile::tempdir().unwrap();
-        let opener = Self::opener(dir.path(), &CONFIG);
+        let opener = Self::opener(dir.path(), CONFIG.clone());
         (dir, opener)
     }
 

--- a/genesis-tools/genesis-populate/src/main.rs
+++ b/genesis-tools/genesis-populate/src/main.rs
@@ -25,7 +25,7 @@ fn main() {
     let near_config = load_config(home_dir, GenesisValidationMode::Full)
         .unwrap_or_else(|e| panic!("Error loading config: {:#}", e));
 
-    let store = near_store::Store::opener(home_dir, &near_config.config.store).open();
+    let store = near_store::Store::opener(home_dir, near_config.config.store.clone()).open();
     GenesisBuilder::from_config_and_store(home_dir, near_config, store)
         .add_additional_accounts(additional_accounts_num)
         .add_additional_accounts_contract(near_test_contracts::trivial_contract().to_vec())

--- a/genesis-tools/genesis-populate/src/state_dump.rs
+++ b/genesis-tools/genesis-populate/src/state_dump.rs
@@ -16,7 +16,7 @@ pub struct StateDump {
 
 impl StateDump {
     pub fn from_dir(dir: &Path, store_home_dir: &Path) -> Self {
-        let store = near_store::Store::opener(store_home_dir, &Default::default()).open();
+        let store = near_store::Store::opener(store_home_dir, Default::default()).open();
         let state_file = dir.join(STATE_DUMP_FILE);
         store
             .load_from_file(DBCol::State, state_file.as_path())

--- a/nearcore/benches/store.rs
+++ b/nearcore/benches/store.rs
@@ -28,8 +28,9 @@ fn read_trie_items(bench: &mut Bencher, shard_id: usize, mode: Mode) {
 
     bench.iter(move || {
         tracing::info!(target: "neard", "{:?}", home_dir);
-        let store =
-            near_store::Store::opener(&home_dir, &near_config.config.store).mode(mode).open();
+        let store = near_store::Store::opener(&home_dir, near_config.config.store.clone())
+            .mode(mode)
+            .open();
 
         let chain_store =
             ChainStore::new(store.clone(), near_config.genesis.config.genesis_height, true);

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -201,7 +201,7 @@ fn apply_store_migrations_if_exists(
 }
 
 fn init_and_migrate_store(home_dir: &Path, near_config: &NearConfig) -> anyhow::Result<Store> {
-    let opener = Store::opener(home_dir, &near_config.config.store);
+    let opener = Store::opener(home_dir, near_config.config.store.clone());
     let exists = apply_store_migrations_if_exists(&opener, near_config)?;
     let store = opener.open();
     if !exists {
@@ -371,7 +371,7 @@ pub fn recompress_storage(home_dir: &Path, opts: RecompressOpts) -> anyhow::Resu
             .map_err(|err| anyhow::anyhow!("setrlimit: NOFILE: {}", err))?;
     }
 
-    let src_opener = Store::opener(home_dir, &config.store).mode(Mode::ReadOnly);
+    let src_opener = Store::opener(home_dir, config.store.clone()).mode(Mode::ReadOnly);
     let src_path = src_opener.get_path();
     if let Some(db_version) = src_opener.get_version_if_exists()? {
         anyhow::ensure!(
@@ -390,7 +390,7 @@ pub fn recompress_storage(home_dir: &Path, opts: RecompressOpts) -> anyhow::Resu
     // Note: opts.dest_dir is resolved relative to current working directory
     // (since it’s a command line option) which is why we set home to cwd.
     let cwd = std::env::current_dir()?;
-    let dst_opener = Store::opener(&cwd, &dst_config);
+    let dst_opener = Store::opener(&cwd, dst_config);
     let dst_path = dst_opener.get_path();
     anyhow::ensure!(
         !dst_opener.check_if_exists(),

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -131,7 +131,8 @@ fn main() -> anyhow::Result<()> {
 
         let near_config = nearcore::load_config(&state_dump_path, GenesisValidationMode::Full)
             .context("Error loading config")?;
-        let store = near_store::Store::opener(&state_dump_path, &near_config.config.store).open();
+        let store =
+            near_store::Store::opener(&state_dump_path, near_config.config.store.clone()).open();
         GenesisBuilder::from_config_and_store(&state_dump_path, near_config, store)
             .add_additional_accounts(cli_args.additional_accounts_num)
             .add_additional_accounts_contract(contract_code.to_vec())

--- a/test-utils/store-validator/src/main.rs
+++ b/test-utils/store-validator/src/main.rs
@@ -30,7 +30,7 @@ fn main() {
     let near_config = load_config(home_dir, GenesisValidationMode::Full)
         .unwrap_or_else(|e| panic!("Error loading config: {:#}", e));
 
-    let store = near_store::Store::opener(home_dir, &near_config.config.store).open();
+    let store = near_store::Store::opener(home_dir, near_config.config.store.clone()).open();
 
     let runtime_adapter: Arc<dyn RuntimeAdapter> =
         Arc::new(nearcore::NightshadeRuntime::from_config(home_dir, store.clone(), &near_config));

--- a/tools/mock_node/src/setup.rs
+++ b/tools/mock_node/src/setup.rs
@@ -33,7 +33,7 @@ fn setup_runtime(
     let store = if in_memory_storage {
         create_test_store()
     } else {
-        near_store::Store::opener(home_dir, &config.config.store).open()
+        near_store::Store::opener(home_dir, config.config.store.clone()).open()
     };
 
     Arc::new(NightshadeRuntime::from_config(home_dir, store, config))

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -75,7 +75,7 @@ impl StateViewerSubCommand {
         let near_config = load_config(home_dir, genesis_validation)
             .unwrap_or_else(|e| panic!("Error loading config: {:#}", e));
         let store_opener =
-            near_store::Store::opener(home_dir, &near_config.config.store).mode(mode);
+            near_store::Store::opener(home_dir, near_config.config.store.clone()).mode(mode);
         let store = store_opener.open();
         match self {
             StateViewerSubCommand::Peers => peers(store),


### PR DESCRIPTION
Storing data with reference (and having to use lifetimes) is useful when the data being referenced it too expensive to be copied or when we need to maintain a single shared copy of the data.  In the case of initial configuration, I would argue that we can just store copies of the configs and remove the related lifetimes.  

Test plan
------------
Existing tests