### PR TITLE
fix: don't set rustflags for WASM

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,7 @@
 [build]
 # We compile with `panic=abort`, so we need `-Cforce-unwind-tables=y`
 # to get a useful backtrace on panic.
-rustflags = ["-Ctarget-feature=+sse4.1,+sse4.2", "-Cforce-unwind-tables=y"]
+rustflags = ["-Cforce-unwind-tables=y"]
+
+[target.'cfg(target_arch = "x86_64")']
+rustflags = ["-Ctarget-feature=+sse4.1,+sse4.2"]


### PR DESCRIPTION
For various tests, we compile a bunch of code in this repo to WASM, and
that emits a tone of warnings about sse not making sense here. Let's
scope it to just x86_64 cpu arch