### PR TITLE
support state_viewer:tx_dump for a range of blocks

### DIFF
--- a/tools/state-viewer/README.md
+++ b/tools/state-viewer/README.md
@@ -92,11 +92,13 @@ Flags:
 
 ### `dump_tx`
 
-Saves all transactions of a block to a file.
+Saves all transactions of a range of blocks [start, end] to a file.
 
 Flags:
 
-* `--height` specifies the block by its height.
+* `--start-height` specifies the start block by its height, inclusive.
+
+* `--end-height` specifies the end block by its height, inclusive.
 
 * `--account-ids` specifies the accounts as receivers of the transactions that need to be dumped. By default, all transactions will be dumped if this parameter is not set.
 

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -155,9 +155,12 @@ impl DumpStateRedisCmd {
 
 #[derive(Parser)]
 pub struct DumpTxCmd {
-    /// Specify which block to dump transactions for.
+    /// Specify the start block by height to begin dumping transactions from, inclusive.
     #[clap(long)]
-    height: BlockHeight,
+    start_height: BlockHeight,
+    /// Specify the end block by height to stop dumping transactions at, inclusive.
+    #[clap(long)]
+    end_height: BlockHeight,
     /// List of account IDs to dump.
     /// If not set, all account IDs will be dumped.
     #[clap(long)]
@@ -170,7 +173,8 @@ pub struct DumpTxCmd {
 impl DumpTxCmd {
     pub fn run(self, home_dir: &Path, near_config: NearConfig, store: Store) {
         dump_tx(
-            self.height,
+            self.start_height,
+            self.end_height,
             home_dir,
             near_config,
             store,

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -1,7 +1,7 @@
 use crate::apply_chain_range::apply_chain_range;
 use crate::state_dump::state_dump;
 use crate::state_dump::state_dump_redis;
-use crate::tx_dump::tx_dump;
+use crate::tx_dump::dump_tx_from_block;
 use crate::{apply_chunk, epoch_info};
 use ansi_term::Color::Red;
 use near_chain::chain::collect_receipts_from_response;
@@ -112,7 +112,8 @@ pub(crate) fn dump_state_redis(
 }
 
 pub(crate) fn dump_tx(
-    height: BlockHeight,
+    start_height: BlockHeight,
+    end_height: BlockHeight,
     home_dir: &Path,
     near_config: NearConfig,
     store: Store,
@@ -124,9 +125,12 @@ pub(crate) fn dump_tx(
         near_config.genesis.config.genesis_height,
         !near_config.client_config.archive,
     );
-    let hash = chain_store.get_block_hash_by_height(height)?;
-    let block = chain_store.get_block(&hash)?;
-    let txs = tx_dump(&mut chain_store, &block, select_account_ids);
+    let mut txs = vec![];
+    for height in start_height..=end_height {
+        let hash = chain_store.get_block_hash_by_height(height)?;
+        let block = chain_store.get_block(&hash)?;
+        txs.extend(dump_tx_from_block(&mut chain_store, &block, select_account_ids));
+    }
     let json_path = match output_path {
         Some(path) => PathBuf::from(path),
         None => PathBuf::from(&home_dir).join("tx.json"),

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -120,16 +120,18 @@ pub(crate) fn dump_tx(
     select_account_ids: Option<&Vec<AccountId>>,
     output_path: Option<String>,
 ) -> Result<(), Error> {
-    let mut chain_store = ChainStore::new(
+    let chain_store = ChainStore::new(
         store.clone(),
         near_config.genesis.config.genesis_height,
         !near_config.client_config.archive,
     );
     let mut txs = vec![];
     for height in start_height..=end_height {
-        let hash = chain_store.get_block_hash_by_height(height)?;
-        let block = chain_store.get_block(&hash)?;
-        txs.extend(dump_tx_from_block(&mut chain_store, &block, select_account_ids));
+        let hash_result = chain_store.get_block_hash_by_height(height);
+        if let Ok(hash) = hash_result {
+            let block = chain_store.get_block(&hash)?;
+            txs.extend(dump_tx_from_block(&chain_store, &block, select_account_ids));
+        }
     }
     let json_path = match output_path {
         Some(path) => PathBuf::from(path),

--- a/tools/state-viewer/src/tx_dump.rs
+++ b/tools/state-viewer/src/tx_dump.rs
@@ -5,7 +5,7 @@ use near_primitives::block::Block;
 use near_primitives::transaction::SignedTransaction;
 
 /// Returns a list of transactions found in the block.
-pub fn tx_dump(
+pub fn dump_tx_from_block(
     chain_store: &ChainStore,
     block: &Block,
     select_account_ids: Option<&Vec<AccountId>>,


### PR DESCRIPTION
This PR enables transactions to be dumped from a range of blocks on `dump_tx` command.

See changes in README on how to use the new tx dumper with the new parameters.

### Test steps
 - Prepare a home directory that contains transactions in the db
 - Compile the code using `make neard`
 - Run `./target/release/neard --home $HOME_PATH view_state dump_tx --start-height XXX --end-height YYY` (replace XXX and YYY with heights, and `$HOME_PATH` with the actual home directory location)

### Reviewers
 - @mzhangmzz 
 - @mm-near 