### PR TITLE
Add extra logging if chunk is missed

### DIFF
--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -161,7 +161,11 @@ fn apply_block_from_range(
             height
         );
         existing_chunk_extra = Some(res_existing_chunk_extra.unwrap());
-        let chunk = chain_store.get_chunk(&block.chunks()[shard_id as usize].chunk_hash()).unwrap();
+        let chunk_hash = block.chunks()[shard_id as usize].chunk_hash();
+        let chunk = chain_store.get_chunk(&chunk_hash).unwrap_or_else(|error| {
+            panic!("Can't get chunk on height: {} chunk_hash: {:?} error: {}", height, chunk_hash, error);
+        });
+
 
         let prev_block = match chain_store.get_block(block.header().prev_hash()) {
             Ok(prev_block) => prev_block,

--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -163,9 +163,11 @@ fn apply_block_from_range(
         existing_chunk_extra = Some(res_existing_chunk_extra.unwrap());
         let chunk_hash = block.chunks()[shard_id as usize].chunk_hash();
         let chunk = chain_store.get_chunk(&chunk_hash).unwrap_or_else(|error| {
-            panic!("Can't get chunk on height: {} chunk_hash: {:?} error: {}", height, chunk_hash, error);
+            panic!(
+                "Can't get chunk on height: {} chunk_hash: {:?} error: {}",
+                height, chunk_hash, error
+            );
         });
-
 
         let prev_block = match chain_store.get_block(block.header().prev_hash()) {
             Ok(prev_block) => prev_block,


### PR DESCRIPTION
I've faced errors like this a couple of times running state viewer (somewhere in the middle of a long range of blocks (66490923, 67354923)):
```
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: ChunkMissing(ChunkHash(`32r725HSviy7jJrZDRk18PCue1RQ2UNua5SJE8E7eeeP`))', tools/state-viewer/src/apply_chain_range.rs:168:92
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: ChunkMissing(ChunkHash(`Cxek8EevzbuVAQdrokwKwtU3waRaqscCPPwbpe72vCM`))', tools/state-viewer/src/apply_chain_range.rs:168:92
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: ChunkMissing(ChunkHash(`54X4azhsWaG823Ga4QzwrH5y4ZkBR7PP1HCJyAANL3Wh`))', tools/state-viewer/src/apply_chain_range.rs:168:92
```

It seems to not reproduce anymore but having extra logging with a height would be helpful if someone faces the same issue.