### PR TITLE
peer_manager: include information about number of banned known peers

### DIFF
--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -290,7 +290,11 @@ impl PeerManagerActor {
         let peer_store =
             PeerStore::new(&clock, store.clone(), &config.boot_nodes, config.blacklist.clone())
                 .map_err(|e| anyhow::Error::msg(e.to_string()))?;
-        debug!(target: "network", len = peer_store.len(), boot_nodes = config.boot_nodes.len(), "Found known peers");
+        debug!(target: "network",
+               len = peer_store.len(),
+               boot_nodes = config.boot_nodes.len(),
+               banned = peer_store.count_banned(),
+               "Found known peers");
         debug!(target: "network", blacklist = ?config.blacklist, "Blacklist");
 
         let my_peer_id = config.node_id();

--- a/chain/network/src/peer_manager/peer_store.rs
+++ b/chain/network/src/peer_manager/peer_store.rs
@@ -161,6 +161,10 @@ impl PeerStore {
             .map_or(false, |known_peer_state| known_peer_state.status.is_banned())
     }
 
+    pub(crate) fn count_banned(&self) -> usize {
+        self.peer_states.values().filter(|st| st.status.is_banned()).count()
+    }
+
     pub(crate) fn peer_connected(
         &mut self,
         clock: &time::Clock,


### PR DESCRIPTION
When reading peers from the database, some of them may be banned.
Knowing how many peers were read does not give complete information.
Include number of banned peers so that it’s clear from logs how many
usable known peers there are.