### PR TITLE
fix(shardnet): don't ignore errors in restake.py

### DIFF
--- a/pytest/tests/shardnet/restake.py
+++ b/pytest/tests/shardnet/restake.py
@@ -2,6 +2,7 @@ import argparse
 import shlex
 import random
 import sys
+from retrying import retry, RetryError
 from rc import pmap
 import pathlib
 
@@ -9,7 +10,11 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
 import mocknet
 from configured_logger import logger
 
+def retry_if_nonzero(result):
+    return result != 0
 
+
+@retry(retry_on_result=retry_if_nonzero, wait_fixed=2000, stop_max_attempt_number=3)
 def create_account(node, near_pk, near_sk):
     node.machine.upload('tests/shardnet/scripts/create_account.sh',
                         '/home/ubuntu',
@@ -18,14 +23,21 @@ def create_account(node, near_pk, near_sk):
         bash /home/ubuntu/create_account.sh {near_pk} {near_sk} 1>/home/ubuntu/create_account.out 2>/home/ubuntu/create_account.err
     '''.format(near_pk=shlex.quote(near_pk), near_sk=shlex.quote(near_sk))
     logger.info(f'Creating an account on {node.instance_name}: {s}')
-    node.machine.run('bash', input=s)
+    result = node.machine.run('bash', input=s)
+    if result.returncode != 0:
+        logger.error(f'error running create_account.sh on {node.instance_name}')
+    return result.returncode
 
 
 def restart_restaked(node, restaked_url, delay_sec, near_pk, near_sk,
                      need_create_accounts):
     if need_create_accounts and not node.instance_name.startswith(
             'shardnet-boot'):
-        create_account(node, near_pk, near_sk)
+        try:
+            create_account(node, near_pk, near_sk)
+        except RetryError:
+            logger.error(f'Skipping stake step after errors running create_account.sh on {node.instance_name}')
+            return
 
     node.machine.upload('tests/shardnet/scripts/restaked.sh',
                         '/home/ubuntu',

--- a/pytest/tests/shardnet/restake.py
+++ b/pytest/tests/shardnet/restake.py
@@ -11,13 +11,7 @@ import mocknet
 from configured_logger import logger
 
 
-def retry_if_nonzero(result):
-    return result != 0
-
-
-@retry(retry_on_result=retry_if_nonzero,
-       wait_fixed=2000,
-       stop_max_attempt_number=3)
+@retry(retry_on_result=bool, wait_fixed=2000, stop_max_attempt_number=3)
 def create_account(node, near_pk, near_sk):
     node.machine.upload('tests/shardnet/scripts/create_account.sh',
                         '/home/ubuntu',

--- a/pytest/tests/shardnet/restake.py
+++ b/pytest/tests/shardnet/restake.py
@@ -10,11 +10,14 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
 import mocknet
 from configured_logger import logger
 
+
 def retry_if_nonzero(result):
     return result != 0
 
 
-@retry(retry_on_result=retry_if_nonzero, wait_fixed=2000, stop_max_attempt_number=3)
+@retry(retry_on_result=retry_if_nonzero,
+       wait_fixed=2000,
+       stop_max_attempt_number=3)
 def create_account(node, near_pk, near_sk):
     node.machine.upload('tests/shardnet/scripts/create_account.sh',
                         '/home/ubuntu',
@@ -36,7 +39,9 @@ def restart_restaked(node, restaked_url, delay_sec, near_pk, near_sk,
         try:
             create_account(node, near_pk, near_sk)
         except RetryError:
-            logger.error(f'Skipping stake step after errors running create_account.sh on {node.instance_name}')
+            logger.error(
+                f'Skipping stake step after errors running create_account.sh on {node.instance_name}'
+            )
             return
 
     node.machine.upload('tests/shardnet/scripts/restaked.sh',


### PR DESCRIPTION
when running create_account.sh fails, we'll continue with the staking
part but it will silently fail because the account doesn't exist. This
actually happens for transient reasons in practice, so retry the
command a few times and dont continue if it fails.