### PR TITLE
validator number cap for state dump tool

### DIFF
--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -119,11 +119,17 @@ pub struct DumpStateCmd {
     /// This is a directory if --stream is set, and a file otherwise.
     #[clap(long, parse(from_os_str))]
     file: Option<PathBuf>,
-    /// List of account IDs to dump.
-    /// Note: validators will always be dumped.
+    /// List of only account IDs to dump.
+    /// If set, account IDs not listed will not be dumped.
     /// If not set, all account IDs will be dumped.
+    /// Note: validators aren't subject to this param. They always get dumped unless a restriction
+    /// of validator cap applies.
     #[clap(long)]
     account_ids: Option<Vec<AccountId>>,
+    /// Maximum number of validators in the genesis file output.
+    /// If set, only the first X (as set) validators will appear in the final genesis.
+    #[clap(long)]
+    validator_cap: Option<usize>,
 }
 
 impl DumpStateCmd {
@@ -136,6 +142,7 @@ impl DumpStateCmd {
             near_config,
             store,
             self.account_ids.as_ref(),
+            self.validator_cap,
         );
     }
 }

--- a/tools/state-viewer/src/state_dump.rs
+++ b/tools/state-viewer/src/state_dump.rs
@@ -29,6 +29,7 @@ pub fn state_dump(
     near_config: &NearConfig,
     records_path: Option<&Path>,
     select_account_ids: Option<&Vec<AccountId>>,
+    validator_cap: Option<usize>,
 ) -> NearConfig {
     println!(
         "Generating genesis from state data of #{} / {}",
@@ -65,6 +66,9 @@ pub fn state_dump(
         })
         .collect();
     genesis_config.validators.sort_by_key(|account_info| account_info.account_id.clone());
+    if let Some(n) = validator_cap {
+        genesis_config.validators.truncate(n);
+    }
     // Record the protocol version of the latest block. Otherwise, the state
     // dump ignores the fact that the nodes can be running a newer protocol
     // version than the protocol version of the genesis.
@@ -374,6 +378,7 @@ mod test {
             &near_config,
             Some(&records_file.path().to_path_buf()),
             None,
+            None,
         );
         let new_genesis = new_near_config.genesis;
         assert_eq!(new_genesis.config.validators.len(), 2);
@@ -447,6 +452,7 @@ mod test {
             &near_config,
             None,
             Some(&select_account_ids),
+            None,
         );
         let new_genesis = new_near_config.genesis;
         let mut expected_accounts: HashSet<AccountId> =
@@ -503,6 +509,7 @@ mod test {
             &near_config,
             None,
             None,
+            None,
         );
         let new_genesis = new_near_config.genesis;
         assert_eq!(new_genesis.config.validators.len(), 2);
@@ -542,6 +549,7 @@ mod test {
             last_block.header().clone(),
             &near_config,
             Some(&records_file.path().to_path_buf()),
+            None,
             None,
         );
         let new_genesis = new_near_config.genesis;
@@ -586,6 +594,7 @@ mod test {
             last_block.header().clone(),
             &near_config,
             Some(&records_file.path().to_path_buf()),
+            None,
             None,
         );
         let new_genesis = new_near_config.genesis;
@@ -669,6 +678,7 @@ mod test {
             &near_config,
             Some(&records_file.path().to_path_buf()),
             None,
+            None,
         );
     }
 
@@ -737,6 +747,7 @@ mod test {
             last_block.header().clone(),
             &near_config,
             Some(&records_file.path().to_path_buf()),
+            None,
             None,
         );
         let new_genesis = new_near_config.genesis;


### PR DESCRIPTION
Add a parameter to specify the cap for the number of validators included in the output genesis file of state dumper. Adding a validator number cap can significantly reduce the size of the genesis output.


### First round reviewers
 - @mm-near 
 - @mzhangmzz 