### PR TITLE
store: change static ShardTries methods into regular ones

### DIFF
--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -334,11 +334,11 @@ impl StoreUpdate {
     /// Set shard_tries to given object.
     ///
     /// Panics if shard_tries are already set to a different object.
-    fn set_shard_tries(&mut self, tries: ShardTries) {
+    fn set_shard_tries(&mut self, tries: &ShardTries) {
         if let Some(our) = &self.shard_tries {
             assert!(tries.is_same(our));
         } else {
-            self.shard_tries = Some(tries);
+            self.shard_tries = Some(tries.clone());
         }
     }
 
@@ -347,8 +347,10 @@ impl StoreUpdate {
     /// Panics if `self` and `other` both have shard_tries set to different
     /// objects.
     pub fn merge(&mut self, other: StoreUpdate) {
-        if let Some(tries) = other.shard_tries {
-            self.set_shard_tries(tries);
+        match (&self.shard_tries, other.shard_tries) {
+            (Some(our), Some(other)) => assert!(our.is_same(&other)),
+            (None, other) => self.shard_tries = other,
+            _ => (),
         }
         self.transaction.merge(other.transaction)
     }

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -149,12 +149,12 @@ impl ShardTries {
     }
 
     fn apply_deletions_inner(
+        &self,
         deletions: &Vec<TrieRefcountChange>,
-        tries: ShardTries,
         shard_uid: ShardUId,
         store_update: &mut StoreUpdate,
     ) {
-        store_update.set_shard_tries(tries);
+        store_update.set_shard_tries(self);
         for TrieRefcountChange { trie_node_or_value_hash, rc, .. } in deletions.iter() {
             let rc = match std::num::NonZeroU32::new(*rc) {
                 None => continue,
@@ -169,12 +169,12 @@ impl ShardTries {
     }
 
     fn apply_insertions_inner(
+        &self,
         insertions: &Vec<TrieRefcountChange>,
-        tries: ShardTries,
         shard_uid: ShardUId,
         store_update: &mut StoreUpdate,
     ) {
-        store_update.set_shard_tries(tries);
+        store_update.set_shard_tries(self);
         for TrieRefcountChange { trie_node_or_value_hash, trie_node_or_value, rc } in
             insertions.iter()
         {
@@ -191,25 +191,15 @@ impl ShardTries {
     }
 
     fn apply_all_inner(
+        &self,
         trie_changes: &TrieChanges,
-        tries: ShardTries,
         shard_uid: ShardUId,
         apply_deletions: bool,
     ) -> (StoreUpdate, StateRoot) {
-        let mut store_update = StoreUpdate::new_with_tries(tries.clone());
-        ShardTries::apply_insertions_inner(
-            &trie_changes.insertions,
-            tries.clone(),
-            shard_uid,
-            &mut store_update,
-        );
+        let mut store_update = StoreUpdate::new_with_tries(self.clone());
+        self.apply_insertions_inner(&trie_changes.insertions, shard_uid, &mut store_update);
         if apply_deletions {
-            ShardTries::apply_deletions_inner(
-                &trie_changes.deletions,
-                tries,
-                shard_uid,
-                &mut store_update,
-            );
+            self.apply_deletions_inner(&trie_changes.deletions, shard_uid, &mut store_update);
         }
         (store_update, trie_changes.new_root)
     }
@@ -220,12 +210,7 @@ impl ShardTries {
         shard_uid: ShardUId,
         store_update: &mut StoreUpdate,
     ) {
-        ShardTries::apply_insertions_inner(
-            &trie_changes.insertions,
-            self.clone(),
-            shard_uid,
-            store_update,
-        )
+        self.apply_insertions_inner(&trie_changes.insertions, shard_uid, store_update)
     }
 
     pub fn apply_deletions(
@@ -234,12 +219,7 @@ impl ShardTries {
         shard_uid: ShardUId,
         store_update: &mut StoreUpdate,
     ) {
-        ShardTries::apply_deletions_inner(
-            &trie_changes.deletions,
-            self.clone(),
-            shard_uid,
-            store_update,
-        )
+        self.apply_deletions_inner(&trie_changes.deletions, shard_uid, store_update)
     }
 
     pub fn revert_insertions(
@@ -248,12 +228,7 @@ impl ShardTries {
         shard_uid: ShardUId,
         store_update: &mut StoreUpdate,
     ) {
-        ShardTries::apply_deletions_inner(
-            &trie_changes.insertions,
-            self.clone(),
-            shard_uid,
-            store_update,
-        )
+        self.apply_deletions_inner(&trie_changes.insertions, shard_uid, store_update)
     }
 
     pub fn apply_all(
@@ -261,7 +236,7 @@ impl ShardTries {
         trie_changes: &TrieChanges,
         shard_uid: ShardUId,
     ) -> (StoreUpdate, StateRoot) {
-        ShardTries::apply_all_inner(trie_changes, self.clone(), shard_uid, true)
+        self.apply_all_inner(trie_changes, shard_uid, true)
     }
 
     // apply_all with less memory overhead


### PR DESCRIPTION
Convert static methods of ShardTries which effectively take self as
argument into regular non-static methods.  This makes code more
idiomatic.