### PR TITLE
Add #[track_caller] annotation to assert functions

### DIFF
--- a/chain/network/src/peer_manager/peer_store_test.rs
+++ b/chain/network/src/peer_manager/peer_store_test.rs
@@ -237,6 +237,7 @@ fn check_add_peers_overriding() {
 fn check_ignore_blacklisted_peers() {
     let clock = time::FakeClock::default();
 
+    #[track_caller]
     fn assert_peers(peer_store: &PeerStore, expected: &[&PeerId]) {
         let expected: HashSet<&PeerId> = HashSet::from_iter(expected.iter().cloned());
         let got = HashSet::from_iter(peer_store.peer_states.keys());
@@ -327,6 +328,7 @@ fn remove_blacklisted_peers_from_store() {
     assert_peers_in_store(&opener, &peer_ids[0..2]);
 }
 
+#[track_caller]
 fn assert_peers_in_store(opener: &StoreOpener, want: &[PeerId]) {
     let store = store::Store::from(opener.open());
     let got: HashSet<PeerId> = store.list_peer_states().unwrap().into_iter().map(|x| x.0).collect();
@@ -334,6 +336,7 @@ fn assert_peers_in_store(opener: &StoreOpener, want: &[PeerId]) {
     assert_eq!(got, want);
 }
 
+#[track_caller]
 fn assert_peers_in_cache(
     peer_store: &PeerStore,
     expected_peers: &[PeerId],

--- a/core/primitives/src/rand.rs
+++ b/core/primitives/src/rand.rs
@@ -172,6 +172,7 @@ mod test {
     }
 
     /// Assert y is within 0.5% of x.
+    #[track_caller]
     fn assert_relative_closeness(x: i32, y: i32) {
         let diff = (y - x).abs();
         let relative_diff = f64::from(diff) / f64::from(x);

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -683,6 +683,7 @@ mod tests {
     }
 
     /// Asserts that elements in the vector are sorted.
+    #[track_caller]
     fn assert_sorted(want_count: usize, keys: Vec<Box<[u8]>>) {
         assert_eq!(want_count, keys.len());
         for (pos, pair) in keys.windows(2).enumerate() {

--- a/integration-tests/src/tests/standard_cases/mod.rs
+++ b/integration-tests/src/tests/standard_cases/mod.rs
@@ -851,6 +851,7 @@ pub fn test_delete_key_last(node: impl Node) {
     assert!(node_user.get_access_key(account_id, &node.signer().public_key()).is_err());
 }
 
+#[track_caller]
 fn assert_access_key(
     access_key: &AccessKey,
     access_key_view: AccessKeyView,

--- a/runtime/near-vm-logic/src/tests/helpers.rs
+++ b/runtime/near-vm-logic/src/tests/helpers.rs
@@ -114,6 +114,7 @@ pub fn reset_costs_counter() {
     with_ext_cost_counter(|cc| cc.clear())
 }
 
+#[track_caller]
 pub fn assert_costs(expected: HashMap<ExtCosts, u64>) {
     with_ext_cost_counter(|cc| assert_eq!(*cc, expected));
     reset_costs_counter();

--- a/runtime/near-vm-runner/src/tests/rs_contract.rs
+++ b/runtime/near-vm-runner/src/tests/rs_contract.rs
@@ -21,6 +21,7 @@ fn test_contract() -> ContractCode {
     ContractCode::new(code.to_vec(), None)
 }
 
+#[track_caller]
 fn assert_run_result(result: VMResult, expected_value: u64) {
     if let Some(_) = result.error() {
         panic!("Failed execution");


### PR DESCRIPTION
Adding #[track_caller] annotation to assert functions makes it so
that if the assertion fails when running the test, the output will
include location where the assertion was called rather than location
of the assert! macro inside of the assert function.