### PR TITLE
fix: CpuBenchmarkSha256 encoding in assertion

### DIFF
--- a/runtime/runtime-params-estimator/src/estimator_params.rs
+++ b/runtime/runtime-params-estimator/src/estimator_params.rs
@@ -35,11 +35,8 @@ fn exec_sha256(repeats: u64) -> i64 {
     for index in 0..repeats {
         let input = "what should I do but tend upon the hours, and times of your desire";
         let val = CryptoHash::hash_bytes(input.as_bytes());
-        assert_eq!(
-            val.to_string(),
-            "9b4d38fd42c985baec11564a84366de0cbd26d3425ec4ce1266e26b7b951ac08"
-        );
-        result += val.as_bytes()[(index % 64) as usize] as i64;
+        assert_eq!(val.to_string(), "BTEVNkcDtaui6SJC19Efnrf7A3dCKT9v8y24NiC3S7RR");
+        result += val.as_bytes()[(index % 32) as usize] as i64;
     }
     result
 }


### PR DESCRIPTION
regression from #7154

Previously, the string was converted to hex, while the `CryptoHash`
uses bs58 encoding. Let's just go with bs58 to keep it simple.

This changes the output of the function. Which is completely irrelevant.
We only care that the hash gets computed and no compiler can remove it.