### PR TITLE
simplified the round robin in RoutingTableView

### DIFF
--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -301,7 +301,7 @@ impl PeerManagerActor {
         let network_graph = Arc::new(RwLock::new(routing::GraphWithCache::new(my_peer_id.clone())));
         let routing_table_addr =
             routing::Actor::new(clock.clone(), store.clone(), network_graph.clone()).start();
-        let routing_table_view = RoutingTableView::new(store);
+        let routing_table_view = RoutingTableView::new(store, my_peer_id.clone());
 
         let txns_since_last_block = Arc::new(AtomicUsize::new(0));
 
@@ -356,8 +356,10 @@ impl PeerManagerActor {
                     routing_table,
                     peers_to_ban,
                 }) => {
-                    act.routing_table_view.remove_local_edges(local_edges_to_remove.iter());
-                    act.routing_table_view.peer_forwarding = routing_table.clone();
+                    for peer_id in &local_edges_to_remove {
+                        act.routing_table_view.remove_local_edge(peer_id);
+                    }
+                    act.routing_table_view.set_routing_table(routing_table.clone());
                     for peer in peers_to_ban {
                         act.ban_peer(&peer, ReasonForBan::InvalidEdge);
                     }
@@ -372,24 +374,11 @@ impl PeerManagerActor {
         if edges.is_empty() {
             return;
         }
-        Self::add_local_edges(&mut self.routing_table_view, &edges, &self.my_peer_id);
 
-        self.routing_table_addr.do_send(routing::actor::Message::AddVerifiedEdges { edges });
-    }
-
-    fn add_local_edges(
-        routing_table_view: &mut RoutingTableView,
-        edges: &Vec<Edge>,
-        my_peer_id: &PeerId,
-    ) {
-        for edge in edges.iter() {
-            if let Some(other_peer) = edge.other(my_peer_id) {
-                if !routing_table_view.is_local_edge_newer(other_peer, edge.nonce()) {
-                    continue;
-                }
-                routing_table_view.local_edges_info.insert(other_peer.clone(), edge.clone());
-            }
+        for edge in &edges {
+            self.routing_table_view.add_local_edge(edge.clone());
         }
+        self.routing_table_addr.do_send(routing::actor::Message::AddVerifiedEdges { edges });
     }
 
     fn broadcast_accounts(&mut self, mut accounts: Vec<AnnounceAccount>) {
@@ -510,9 +499,7 @@ impl PeerManagerActor {
                         // from routing table
                         Self::wait_peer_or_remove(ctx, edge.clone(), self.network_metrics.clone());
                     }
-                    self.routing_table_view
-                        .local_edges_info
-                        .insert(other_peer.clone(), edge.clone());
+                    self.routing_table_view.add_local_edge(edge.clone());
                 }
             }
             let network_metrics = self.network_metrics.clone();
@@ -1349,7 +1336,7 @@ impl PeerManagerActor {
                       account_id = ?self.config.validator.as_ref().map(|v|v.account_id()),
                       to = ?msg.msg.target,
                       reason = ?find_route_error,
-                      known_peers = ?self.routing_table_view.peer_forwarding.len(),
+                      known_peers = ?self.routing_table_view.routing_table_len(),
                       msg = ?msg.msg.body,
                     "Drop signed message"
                 );

--- a/chain/network/src/routing/mod.rs
+++ b/chain/network/src/routing/mod.rs
@@ -6,7 +6,7 @@ pub mod actor;
 mod graph;
 mod graph_with_cache;
 pub(crate) use actor::Actor;
-pub(crate) use graph_with_cache::RoutingTable;
+pub(crate) use graph_with_cache::NextHopTable;
 // for benchmark only
 pub use graph::Graph;
 pub use graph_with_cache::GraphWithCache;

--- a/chain/network/src/routing/tests/cache.rs
+++ b/chain/network/src/routing/tests/cache.rs
@@ -13,7 +13,7 @@ fn announcement_same_epoch() {
     let peer_id1 = random_peer_id();
     let epoch_id0 = random_epoch_id();
 
-    let mut routing_table = RoutingTableView::new(store);
+    let mut routing_table = RoutingTableView::new(store, random_peer_id());
 
     let announce0 = AnnounceAccount {
         account_id: "near0".parse().unwrap(),
@@ -49,7 +49,7 @@ fn dont_load_on_build() {
     let epoch_id0 = random_epoch_id();
     let epoch_id1 = random_epoch_id();
 
-    let mut routing_table = RoutingTableView::new(store.clone());
+    let mut routing_table = RoutingTableView::new(store.clone(), random_peer_id());
 
     let announce0 = AnnounceAccount {
         account_id: "near0".parse().unwrap(),
@@ -72,7 +72,7 @@ fn dont_load_on_build() {
     assert!(vec![announce0, announce1].iter().all(|announce| { accounts.contains(&announce) }));
     assert_eq!(accounts.len(), 2);
 
-    let routing_table1 = RoutingTableView::new(store);
+    let routing_table1 = RoutingTableView::new(store, random_peer_id());
     assert_eq!(routing_table1.get_announce_accounts().count(), 0);
 }
 
@@ -83,8 +83,8 @@ fn load_from_disk() {
     let peer_id0 = random_peer_id();
     let epoch_id0 = random_epoch_id();
 
-    let mut routing_table = RoutingTableView::new(store.clone());
-    let mut routing_table1 = RoutingTableView::new(store);
+    let mut routing_table = RoutingTableView::new(store.clone(), random_peer_id());
+    let mut routing_table1 = RoutingTableView::new(store, random_peer_id());
 
     let announce0 = AnnounceAccount {
         account_id: "near0".parse().unwrap(),

--- a/chain/network/src/routing/tests/mod.rs
+++ b/chain/network/src/routing/tests/mod.rs
@@ -1,2 +1,3 @@
 mod cache;
 mod cache_edges;
+mod routing_table_view;

--- a/chain/network/src/routing/tests/routing_table_view.rs
+++ b/chain/network/src/routing/tests/routing_table_view.rs
@@ -1,0 +1,36 @@
+use crate::network_protocol::testonly as data;
+use crate::routing;
+use crate::routing::routing_table_view::*;
+use crate::store;
+use crate::testonly::make_rng;
+use near_network_primitives::time;
+use near_network_primitives::types::PeerIdOrHash;
+use near_store::test_utils::create_test_store;
+use rand::seq::SliceRandom;
+use std::sync::Arc;
+
+#[test]
+fn find_route() {
+    let mut rng = make_rng(385305732);
+    let clock = time::FakeClock::default();
+    let rng = &mut rng;
+    let store = create_test_store();
+    let store = store::Store::from(&store);
+
+    // Create a sample NextHopTable.
+    let peers: Vec<_> = (0..10).map(|_| data::make_peer_id(rng)).collect();
+    let mut next_hops = routing::NextHopTable::new();
+    for p in &peers {
+        next_hops.insert(p.clone(), (0..3).map(|_| peers.choose(rng).cloned().unwrap()).collect());
+    }
+    let next_hops = Arc::new(next_hops);
+
+    // Check that RoutingTableView always selects a valid next hop.
+    let mut rtv = RoutingTableView::new(store, data::make_peer_id(rng));
+    rtv.set_next_hops(next_hops.clone());
+    for _ in 0..1000 {
+        let p = peers.choose(rng).unwrap();
+        let got = rtv.find_route(&clock.clock(), &PeerIdOrHash::PeerId(p.clone())).unwrap();
+        assert!(next_hops.get(p).unwrap().contains(&got));
+    }
+}

--- a/integration-tests/src/tests/network/runner.rs
+++ b/integration-tests/src/tests/network/runner.rs
@@ -169,7 +169,7 @@ async fn check_routing_table(
         PeerManagerMessageResponse::FetchRoutingTable(rt) => rt,
         _ => bail!("bad response"),
     };
-    if expected_routing_tables(&rt.routing_table, &want_rt) {
+    if expected_routing_tables(&rt.next_hops, &want_rt) {
         return Ok(ControlFlow::Break(()));
     }
     Ok(ControlFlow::Continue(()))
@@ -717,7 +717,7 @@ async fn check_direct_connection_inner(
         PeerManagerMessageResponse::FetchRoutingTable(rt) => rt,
         _ => bail!("bad response"),
     };
-    let routes = if let Some(routes) = rt.routing_table.get(&target_peer_id) {
+    let routes = if let Some(routes) = rt.next_hops.get(&target_peer_id) {
         routes
     } else {
         debug!(target: "network", ?target_peer_id, node_id, target_id,

--- a/integration-tests/src/tests/network/runner.rs
+++ b/integration-tests/src/tests/network/runner.rs
@@ -169,7 +169,7 @@ async fn check_routing_table(
         PeerManagerMessageResponse::FetchRoutingTable(rt) => rt,
         _ => bail!("bad response"),
     };
-    if expected_routing_tables(&rt.peer_forwarding, &want_rt) {
+    if expected_routing_tables(&rt.routing_table, &want_rt) {
         return Ok(ControlFlow::Break(()));
     }
     Ok(ControlFlow::Continue(()))
@@ -717,7 +717,7 @@ async fn check_direct_connection_inner(
         PeerManagerMessageResponse::FetchRoutingTable(rt) => rt,
         _ => bail!("bad response"),
     };
-    let routes = if let Some(routes) = rt.peer_forwarding.get(&target_peer_id) {
+    let routes = if let Some(routes) = rt.routing_table.get(&target_peer_id) {
         routes
     } else {
         debug!(target: "network", ?target_peer_id, node_id, target_id,


### PR DESCRIPTION
also hidden some implementation details, which were exposed to PeerManagerActor.

The previous implementation of next hop selection was slightly favoring sending messages to newly connected peers for unknown reasons. The current one aims at uniform utilization of all connected peers and is way simpler. The expected impact on the actual performance is negligible.