### PR TITLE
feat: reduce block overhead effect on estimations

### DIFF
--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -19,11 +19,15 @@ use near_primitives::types::{AccountId, Balance, EpochId, ShardId, StateChangeCa
 use near_store::{get_account, set_access_key, set_account, set_code, Store, TrieUpdate};
 use nearcore::{NearConfig, NightshadeRuntime};
 use std::collections::BTreeMap;
+use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-fn get_account_id(account_index: u64) -> AccountId {
-    AccountId::try_from(format!("near_{}_{}", account_index, account_index)).unwrap()
+pub fn get_account_id(account_index: u64) -> AccountId {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    account_index.hash(&mut hasher);
+    let hash = hasher.finish();
+    AccountId::try_from(format!("{hash}_near_{account_index}_{account_index}")).unwrap()
 }
 
 pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -8,7 +8,7 @@ use near_vm_logic::ExtCosts;
 use crate::config::{Config, GasMetric};
 use crate::gas_cost::GasCost;
 use crate::testbed::RuntimeTestbed;
-use crate::utils::get_account_id;
+use genesis_populate::get_account_id;
 
 use super::transaction_builder::TransactionBuilder;
 
@@ -47,7 +47,9 @@ impl<'c> EstimatorContext<'c> {
             config: self.config,
             inner,
             transaction_builder: TransactionBuilder::new(
-                (0..self.config.active_accounts).map(get_account_id).collect(),
+                (0..self.config.active_accounts)
+                    .map(|index| get_account_id(index as u64))
+                    .collect(),
             ),
         }
     }

--- a/runtime/runtime-params-estimator/src/transaction_builder.rs
+++ b/runtime/runtime-params-estimator/src/transaction_builder.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
+use genesis_populate::get_account_id;
 use near_crypto::{InMemorySigner, KeyType};
 use near_primitives::hash::CryptoHash;
 use near_primitives::transaction::{Action, FunctionCallAction, SignedTransaction};
@@ -7,7 +8,6 @@ use near_primitives::types::AccountId;
 use rand::prelude::ThreadRng;
 use rand::Rng;
 
-use crate::utils::get_account_id;
 /// A helper to create transaction for processing by a `TestBed`.
 #[derive(Clone)]
 pub(crate) struct TransactionBuilder {
@@ -87,7 +87,7 @@ impl TransactionBuilder {
         rand::thread_rng()
     }
 
-    pub(crate) fn account(&mut self, account_index: usize) -> AccountId {
+    pub(crate) fn account(&mut self, account_index: u64) -> AccountId {
         get_account_id(account_index)
     }
     pub(crate) fn random_account(&mut self) -> AccountId {


### PR DESCRIPTION
1. Use account ids without a shared prefix.
2. Subtract block overhead instead of just checking it is insignificant.

resolves #7003