### PR TITLE
feat: stabilize precharged contract loading gas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Protocol Changes
 
+* Charge the gas cost for loading an smart contract even when it fails.
+
 ### Non-protocol Changes
 
 

--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -41,7 +41,7 @@ fn build_chain() {
     if cfg!(feature = "nightly") {
         insta::assert_display_snapshot!(hash, @"FxxmGH4peXwKR5C9YiSKjX7nWVg3zBuvjp9k5bTF1yDs");
     } else {
-        insta::assert_display_snapshot!(hash, @"6sAno2uEwwQ5yiDscePWY8HWmRJLpGNv39uoff3BCpxT");
+        insta::assert_display_snapshot!(hash, @"H9xDK5MNxmDuS9P5i8P2ZLCLbdJRXpsXhUzwe6BeD75J");
     }
 
     for i in 1..5 {
@@ -70,7 +70,7 @@ fn build_chain() {
     if cfg!(feature = "nightly") {
         insta::assert_display_snapshot!(hash, @"43q5wcc9rdsocY2Htbk7vT88x6zkka5Vr17CQJUTkT9n");
     } else {
-        insta::assert_display_snapshot!(hash, @"Fn9MgjUx6VXhPYNqqDtf2C9kBVveY2vuSLXNLZUNJCqK");
+        insta::assert_display_snapshot!(hash, @"DisE1kbb7RTcJVgjoNYQCuM9TYus6fEG8AJY3cL9LmDz");
     }
 }
 

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -44,13 +44,11 @@ sandbox = []
 dump_errors_schema = ["near-rpc-error-macro/dump_errors_schema"]
 protocol_feature_chunk_only_producers = []
 protocol_feature_fix_staking_threshold = []
-protocol_feature_fix_contract_loading_cost = []
 protocol_feature_account_id_in_function_call_permission = []
 nightly = [
   "nightly_protocol",
   "protocol_feature_chunk_only_producers",
   "protocol_feature_fix_staking_threshold",
-  "protocol_feature_fix_contract_loading_cost",
   "protocol_feature_account_id_in_function_call_permission",
 ]
 nightly_protocol = []

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -154,6 +154,8 @@ pub enum ProtocolFeature {
     LowerStorageKeyLimit,
     // alt_bn128_g1_multiexp, alt_bn128_g1_sum, alt_bn128_pairing_check host functions
     AltBn128,
+    /// Charge for contract loading before it happens.
+    FixContractLoadingCost,
 
     #[cfg(feature = "protocol_feature_chunk_only_producers")]
     ChunkOnlyProducers,
@@ -162,10 +164,7 @@ pub enum ProtocolFeature {
     /// alpha is min stake ratio
     #[cfg(feature = "protocol_feature_fix_staking_threshold")]
     FixStakingThreshold,
-    /// Charge for contract loading before it happens.
-    #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
-    FixContractLoadingCost,
-    /// Charge for contract loading before it happens.
+    /// Validate account id for function call access keys.
     #[cfg(feature = "protocol_feature_account_id_in_function_call_permission")]
     AccountIdInFunctionCallPermission,
 }
@@ -177,7 +176,7 @@ pub const PEER_MIN_ALLOWED_PROTOCOL_VERSION: ProtocolVersion = STABLE_PROTOCOL_V
 /// Current protocol version used on the mainnet.
 /// Some features (e. g. FixStorageUsage) require that there is at least one epoch with exactly
 /// the corresponding version
-const STABLE_PROTOCOL_VERSION: ProtocolVersion = 55;
+const STABLE_PROTOCOL_VERSION: ProtocolVersion = 56;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "nightly_protocol")] {
@@ -246,14 +245,13 @@ impl ProtocolFeature {
             | ProtocolFeature::ChunkNodesCache
             | ProtocolFeature::LowerStorageKeyLimit => 53,
             ProtocolFeature::AltBn128 => 55,
+            ProtocolFeature::FixContractLoadingCost => 56,
 
             // Nightly & shardnet features
             #[cfg(feature = "protocol_feature_chunk_only_producers")]
             ProtocolFeature::ChunkOnlyProducers => 100,
             #[cfg(feature = "protocol_feature_fix_staking_threshold")]
             ProtocolFeature::FixStakingThreshold => 126,
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
-            ProtocolFeature::FixContractLoadingCost => 129,
             #[cfg(feature = "protocol_feature_account_id_in_function_call_permission")]
             ProtocolFeature::AccountIdInFunctionCallPermission => 130,
         }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -74,15 +74,11 @@ protocol_feature_chunk_only_producers = [
 protocol_feature_account_id_in_function_call_permission = [
   "near-primitives/protocol_feature_account_id_in_function_call_permission"
 ]
-protocol_feature_fix_contract_loading_cost = [
-  "nearcore/protocol_feature_fix_contract_loading_cost",
-]
 nightly = [
   "nightly_protocol",
   "nearcore/nightly",
   "protocol_feature_chunk_only_producers",
   "protocol_feature_account_id_in_function_call_permission",
-  "protocol_feature_fix_contract_loading_cost",
 ]
 nightly_protocol = ["nearcore/nightly_protocol"]
 sandbox = [

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -4980,7 +4980,6 @@ mod lower_storage_key_limit_test {
     }
 }
 
-#[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
 mod new_contract_loading_cost {
     use super::*;
     use near_primitives::views::FinalExecutionOutcomeView;

--- a/nearcore/Cargo.toml
+++ b/nearcore/Cargo.toml
@@ -117,9 +117,6 @@ protocol_feature_fix_staking_threshold = [
   "near-primitives/protocol_feature_fix_staking_threshold",
   "near-epoch-manager/protocol_feature_fix_staking_threshold",
 ]
-protocol_feature_fix_contract_loading_cost = [
-  "near-vm-runner/protocol_feature_fix_contract_loading_cost",
-]
 nightly = [
   "nightly_protocol",
   "near-primitives/nightly",
@@ -128,7 +125,6 @@ nightly = [
   "near-store/nightly",
   "protocol_feature_chunk_only_producers",
   "protocol_feature_fix_staking_threshold",
-  "protocol_feature_fix_contract_loading_cost",
 ]
 nightly_protocol = [
   "near-primitives/nightly_protocol",

--- a/runtime/near-vm-logic/Cargo.toml
+++ b/runtime/near-vm-logic/Cargo.toml
@@ -40,9 +40,6 @@ serde_json = { version = "1", features = ["preserve_order"] }
 
 [features]
 default = []
-protocol_feature_fix_contract_loading_cost = [
-    "near-primitives/protocol_feature_fix_contract_loading_cost",
-]
 io_trace = ["tracing"]
 
 # Use this feature to enable counting of fees and costs applied.

--- a/runtime/near-vm-logic/src/logic.rs
+++ b/runtime/near-vm-logic/src/logic.rs
@@ -2749,11 +2749,7 @@ impl<'a> VMLogic<'a> {
                 ));
             return Err(error);
         }
-        if checked_feature!(
-            "protocol_feature_fix_contract_loading_cost",
-            FixContractLoadingCost,
-            current_protocol_version
-        ) {
+        if checked_feature!("stable", FixContractLoadingCost, current_protocol_version) {
             if self.add_contract_loading_fee(wasm_code_bytes as u64).is_err() {
                 let error =
                     VMError::FunctionCallError(near_vm_errors::FunctionCallError::HostError(
@@ -2771,11 +2767,7 @@ impl<'a> VMLogic<'a> {
         current_protocol_version: u32,
         wasm_code_bytes: usize,
     ) -> std::result::Result<(), VMError> {
-        if !checked_feature!(
-            "protocol_feature_fix_contract_loading_cost",
-            FixContractLoadingCost,
-            current_protocol_version
-        ) {
+        if !checked_feature!("stable", FixContractLoadingCost, current_protocol_version) {
             if self.add_contract_loading_fee(wasm_code_bytes as u64).is_err() {
                 return Err(VMError::FunctionCallError(
                     near_vm_errors::FunctionCallError::HostError(

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -92,14 +92,8 @@ no_cpu_compatibility_checks = []
 
 no_cache = []
 
-protocol_feature_fix_contract_loading_cost = [
-    "near-primitives/protocol_feature_fix_contract_loading_cost",
-    "near-vm-logic/protocol_feature_fix_contract_loading_cost",
-]
-
 nightly = [
     "near-primitives/nightly",
-    "protocol_feature_fix_contract_loading_cost",
 ]
 sandbox = ["near-vm-logic/sandbox"]
 io_trace = ["near-vm-logic/io_trace"]

--- a/runtime/near-vm-runner/src/runner.rs
+++ b/runtime/near-vm-runner/src/runner.rs
@@ -175,11 +175,7 @@ impl VMResult {
         error: VMError,
         current_protocol_version: u32,
     ) -> VMResult {
-        if checked_feature!(
-            "protocol_feature_fix_contract_loading_cost",
-            FixContractLoadingCost,
-            current_protocol_version
-        ) {
+        if checked_feature!("stable", FixContractLoadingCost, current_protocol_version) {
             VMResult::abort(logic, error)
         } else {
             VMResult::nop_outcome(error)

--- a/runtime/near-vm-runner/src/tests.rs
+++ b/runtime/near-vm-runner/src/tests.rs
@@ -55,9 +55,5 @@ fn create_context(input: Vec<u8>) -> VMContext {
 /// `wasm_contract_loading_base` and `wasm_contract_loading_bytes` which would
 /// have to be updated if they change in the future.
 fn prepaid_loading_gas(bytes: usize) -> u64 {
-    if cfg!(feature = "protocol_feature_fix_contract_loading_cost") {
-        35_445_963 + bytes as u64 * 21_6750
-    } else {
-        0
-    }
+    35_445_963 + bytes as u64 * 21_6750
 }

--- a/runtime/near-vm-runner/src/tests/compile_errors.rs
+++ b/runtime/near-vm-runner/src/tests/compile_errors.rs
@@ -14,7 +14,6 @@ fn test_initializer_wrong_signature_contract() {
 )"#,
         )
         .protocol_features(&[
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             ProtocolFeature::FixContractLoadingCost,
         ])
         .expects(&[
@@ -22,7 +21,6 @@ fn test_initializer_wrong_signature_contract() {
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
                 Err: PrepareError: Error happened while deserializing the module.
             "#]],
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 48017463 used gas 48017463
                 Err: PrepareError: Error happened while deserializing the module.
@@ -37,7 +35,6 @@ fn test_function_not_defined_contract() {
         .wat(r#"(module (export "hello" (func 0)))"#)
         .method("hello")
         .protocol_features(&[
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             ProtocolFeature::FixContractLoadingCost,
         ])
         .expects(&[
@@ -45,7 +42,6 @@ fn test_function_not_defined_contract() {
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
                 Err: PrepareError: Error happened while deserializing the module.
             "#]],
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 39564213 used gas 39564213
                 Err: PrepareError: Error happened while deserializing the module.
@@ -69,7 +65,6 @@ fn test_function_type_not_defined_contract_1() {
     test_builder()
         .wasm(&function_type_not_defined_contract(1))
         .protocol_features(&[
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             ProtocolFeature::FixContractLoadingCost,
         ])
         .expects(&[
@@ -77,7 +72,6 @@ fn test_function_type_not_defined_contract_1() {
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
                 Err: PrepareError: Error happened while deserializing the module.
             "#]],
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 44982963 used gas 44982963
                 Err: PrepareError: Error happened while deserializing the module.
@@ -91,7 +85,6 @@ fn test_function_type_not_defined_contract_2() {
     test_builder()
         .wasm(&function_type_not_defined_contract(0))
         .protocol_features(&[
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             ProtocolFeature::FixContractLoadingCost,
         ])
         .expects(&[
@@ -99,7 +92,6 @@ fn test_function_type_not_defined_contract_2() {
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
                 Err: PrepareError: Error happened while deserializing the module.
             "#]],
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 44982963 used gas 44982963
                 Err: PrepareError: Error happened while deserializing the module.
@@ -112,7 +104,6 @@ fn test_garbage_contract() {
     test_builder()
         .wasm(&[])
         .protocol_features(&[
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             ProtocolFeature::FixContractLoadingCost,
         ])
         .expects(&[
@@ -120,7 +111,6 @@ fn test_garbage_contract() {
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
                 Err: PrepareError: Error happened while deserializing the module.
             "#]],
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 35445963 used gas 35445963
                 Err: PrepareError: Error happened while deserializing the module.
@@ -134,7 +124,6 @@ fn test_evil_function_index() {
         .wat(r#"(module (func (export "main") call 4294967295))"#)
         .method("abort_with_zero")
         .protocol_features(&[
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             ProtocolFeature::FixContractLoadingCost,
         ])
         .expects(&[
@@ -142,7 +131,6 @@ fn test_evil_function_index() {
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
                 Err: PrepareError: Error happened while deserializing the module.
             "#]],
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 44115963 used gas 44115963
                 Err: PrepareError: Error happened while deserializing the module.
@@ -163,7 +151,6 @@ fn test_limit_contract_functions_number() {
     )
     .protocol_features(&[
         ProtocolFeature::LimitContractFunctionsNumber,
-        #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
         ProtocolFeature::FixContractLoadingCost,
     ])
     .expects(&[
@@ -173,7 +160,6 @@ fn test_limit_contract_functions_number() {
         expect![[r#"
             VMOutcome: balance 4 storage_usage 12 return data None burnt gas 13048032213 used gas 13048032213
         "#]],
-        #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
         expect![[r#"
             VMOutcome: balance 4 storage_usage 12 return data None burnt gas 13048032213 used gas 13048032213
         "#]],
@@ -188,7 +174,6 @@ fn test_limit_contract_functions_number() {
     )
     .protocol_features(&[
         ProtocolFeature::LimitContractFunctionsNumber,
-        #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
         ProtocolFeature::FixContractLoadingCost,
     ])
     .expects(&[
@@ -199,7 +184,6 @@ fn test_limit_contract_functions_number() {
             VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
             Err: PrepareError: Too many functions in contract.
         "#]],
-        #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
         expect![[r#"
             VMOutcome: balance 4 storage_usage 12 return data None burnt gas 13049332713 used gas 13049332713
             Err: PrepareError: Too many functions in contract.
@@ -216,7 +200,6 @@ fn test_limit_contract_functions_number() {
             .make(),
         )
         .protocol_features(&[
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             ProtocolFeature::FixContractLoadingCost,
         ])
         .expects(&[
@@ -224,7 +207,6 @@ fn test_limit_contract_functions_number() {
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
                 Err: PrepareError: Too many functions in contract.
             "#]],
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 19554433713 used gas 19554433713
                 Err: PrepareError: Too many functions in contract.
@@ -241,7 +223,6 @@ fn test_limit_contract_functions_number() {
             .make(),
         )
         .protocol_features(&[
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             ProtocolFeature::FixContractLoadingCost,
         ])
         .expects(&[
@@ -249,7 +230,6 @@ fn test_limit_contract_functions_number() {
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
                 Err: PrepareError: Too many functions in contract.
             "#]],
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 13051283463 used gas 13051283463
                 Err: PrepareError: Too many functions in contract.
@@ -269,7 +249,6 @@ fn test_limit_locals() {
             .make(),
         )
         .protocol_features(&[
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             ProtocolFeature::FixContractLoadingCost,
         ])
         .expects(&[
@@ -277,7 +256,6 @@ fn test_limit_locals() {
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
                 Err: PrepareError: Error happened while deserializing the module.
             "#]],
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 43682463 used gas 43682463
                 Err: PrepareError: Error happened while deserializing the module.
@@ -310,7 +288,6 @@ fn test_limit_locals_global() {
     .make())
     .protocol_features(&[
         ProtocolFeature::LimitContractLocals,
-        #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
         ProtocolFeature::FixContractLoadingCost,
     ])
     .expects(&[
@@ -321,7 +298,6 @@ fn test_limit_locals_global() {
             VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
             Err: PrepareError: Too many locals declared in the contract.
         "#]],
-        #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
         expect![[r#"
             VMOutcome: balance 4 storage_usage 12 return data None burnt gas 195407463 used gas 195407463
             Err: PrepareError: Too many locals declared in the contract.

--- a/runtime/near-vm-runner/src/tests/runtime_errors.rs
+++ b/runtime/near-vm-runner/src/tests/runtime_errors.rs
@@ -27,14 +27,12 @@ fn test_infinite_initializer_export_not_found() {
         .wat(INFINITE_INITIALIZER_CONTRACT)
         .method("no-such-method")
         .protocol_features(&[
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             ProtocolFeature::FixContractLoadingCost,
         ]).expects(&[
             expect![[r#"
                 VMOutcome: balance 0 storage_usage 0 return data None burnt gas 0 used gas 0
                 Err: MethodNotFound
             "#]],
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 49101213 used gas 49101213
                 Err: MethodNotFound
@@ -61,7 +59,6 @@ fn test_multiple_memories() {
         // Wasmtime classifies this error as link error at the moment.
         .opaque_error()
         .protocol_features(&[
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             ProtocolFeature::FixContractLoadingCost,
         ])
         .expects(&[
@@ -69,7 +66,6 @@ fn test_multiple_memories() {
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
                 Err: ...
             "#]],
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 44982963 used gas 44982963
                 Err: ...
@@ -82,14 +78,12 @@ fn test_export_not_found() {
     test_builder().wat(SIMPLE_CONTRACT)
         .method("no-such-method")
         .protocol_features(&[
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             ProtocolFeature::FixContractLoadingCost,
         ]).expects(&[
             expect![[r#"
                 VMOutcome: balance 0 storage_usage 0 return data None burnt gas 0 used gas 0
                 Err: MethodNotFound
             "#]],
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 42815463 used gas 42815463
                 Err: MethodNotFound
@@ -230,7 +224,6 @@ fn test_wrong_signature_contract() {
     test_builder()
         .wat(r#"(module (func (export "main") (param i32)))"#)
         .protocol_features(&[
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             ProtocolFeature::FixContractLoadingCost,
         ])
         .expects(&[
@@ -238,7 +231,6 @@ fn test_wrong_signature_contract() {
                 VMOutcome: balance 0 storage_usage 0 return data None burnt gas 0 used gas 0
                 Err: MethodInvalidSignature
             "#]],
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 43032213 used gas 43032213
                 Err: MethodInvalidSignature
@@ -251,7 +243,6 @@ fn test_export_wrong_type() {
     test_builder()
         .wat(r#"(module (global (export "main") i32 (i32.const 123)))"#)
         .protocol_features(&[
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             ProtocolFeature::FixContractLoadingCost,
         ])
         .expects(&[
@@ -259,7 +250,6 @@ fn test_export_wrong_type() {
                 VMOutcome: balance 0 storage_usage 0 return data None burnt gas 0 used gas 0
                 Err: MethodNotFound
             "#]],
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 41298213 used gas 41298213
                 Err: MethodNotFound
@@ -418,7 +408,6 @@ fn test_bad_import_1() {
     test_builder()
         .wasm(&bad_import_global("no-such-module"))
         .protocol_features(&[
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             ProtocolFeature::FixContractLoadingCost,
         ])
         .expects(&[
@@ -426,7 +415,6 @@ fn test_bad_import_1() {
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
                 Err: PrepareError: Error happened during instantiation.
             "#]],
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 50618463 used gas 50618463
                 Err: PrepareError: Error happened during instantiation.
@@ -439,7 +427,6 @@ fn test_bad_import_2() {
     test_builder()
         .wasm(&bad_import_func("no-such-module"))
         .protocol_features(&[
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             ProtocolFeature::FixContractLoadingCost,
         ])
         .expects(&[
@@ -447,7 +434,6 @@ fn test_bad_import_2() {
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
                 Err: PrepareError: Error happened during instantiation.
             "#]],
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 50184963 used gas 50184963
                 Err: PrepareError: Error happened during instantiation.
@@ -669,7 +655,6 @@ fn gas_overflow_indirect_call() {
         "#]]);
 }
 
-#[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
 mod fix_contract_loading_cost_protocol_upgrade {
     use super::*;
     use crate::tests::prepaid_loading_gas;


### PR DESCRIPTION
# Feature to stabilize
The gas cost for loading a contract executable used to be charged afterwards. However, the general rule for gas charges is that they should be charged before the cost occurs. This is only noticable when the execution fails during that step. But it is nevertheless important, as an attacker could potentially abuse this to fill up block space without being charged for it.

Note that "loading" in this context is a technical term for preparing and populating all memory regions for an executable. Reading the data from the database is NOT included in this.

On a side note, the actual gas parameter values have not been updated, yet. We know that `wasm_contract_loading_bytes` in particular is too low. But it is counter balanced by `action_function_call` which is higher than it needs to be. Stabilizing this feature paves the floor to adjust those parameters.

Main implementation PR: #6772
Main issue: #5962

# Testing and QA
## Tests
The original PR (#6772) includes tests on the VM level that ensure old versions are unaffeceted while new versions charge the cost correctly.
Integration tests in #7169 checks the same again but on the apply-block level.

## Impact on existing smart contracts
This change does not affect anything except for function calls that fail during preparation. Since those were already failing, it should not impact anyone. Only the error type and amount of gas charged changes.

# Checklist
- [ ] TODO Link to nightly nayduck run (`./scripts/nayduck.py`, [docs](https://github.com/near/nearcore/blob/master/nightly/README.md#scheduling-a-run)):  https://nayduck.near.org/
- [x] Update CHANGELOG.md to include this protocol feature in the `Unreleased` section.