### PR TITLE
pytest: remove Docker container once sanity/docker.py test finishes

### DIFF
--- a/pytest/tests/sanity/docker.py
+++ b/pytest/tests/sanity/docker.py
@@ -235,7 +235,7 @@ def main():
         cids = tuple(filter(None, (node._container_id for node in nodes)))
         if cids:
             logger.info('Stopping containers')
-            run(('docker', 'stop') + cids)
+            run(('docker', 'rm', '-f') + cids)
         for node in nodes:
             node._container_id = None
 


### PR DESCRIPTION
‘docker stop’ stops a container but leaves it still accessible.  Use
‘docker rm -f’ to stop and remove any data regarding the container.