### PR TITLE
test: unignore wasmer2 upgrade test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2650,6 +2650,7 @@ dependencies = [
  "near-crypto",
  "near-logger-utils",
  "near-metrics",
+ "near-o11y",
  "near-pool",
  "near-primitives",
  "near-store",

--- a/chain/chain/Cargo.toml
+++ b/chain/chain/Cargo.toml
@@ -28,6 +28,7 @@ near-chain-configs = { path = "../../core/chain-configs" }
 near-chain-primitives = { path = "../chain-primitives" }
 near-crypto = { path = "../../core/crypto" }
 near-metrics = { path = "../../core/metrics" }
+near-o11y = { path = "../../core/o11y" }
 near-pool = { path = "../pool" }
 near-primitives = { path = "../../core/primitives" }
 near-store = { path = "../../core/store" }

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -2534,7 +2534,6 @@ fn test_refund_receipts_processing() {
 }
 
 #[test]
-#[ignore]
 fn test_wasmer2_upgrade() {
     let mut capture = near_logger_utils::TracingCapture::enable();
 


### PR DESCRIPTION
It was temporarilty ignored to ship async block processing.

The reason why this test fails after the change is because, in the test,
we inspect the logs, and, now that the work happens in a different
threads, tracing loses its thread-local context and we fail to capture
the span.

In the ideal world, tracing&rayon would just magically work this out
between themselves, but today it seems that the best option is for us to
help them.

See also discussion at

https://discord.com/channels/500028886025895936/627649734592561152