### PR TITLE
test: simplify mocking in setup_mock_all_validators

### DIFF
--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -12,6 +12,7 @@ use chrono::DateTime;
 use futures::{future, FutureExt};
 use near_primitives::time::Utc;
 use num_rational::Ratio;
+use once_cell::sync::OnceCell;
 use rand::{thread_rng, Rng};
 
 use near_chain::test_utils::{
@@ -483,7 +484,7 @@ impl BlockStats {
 }
 
 fn send_chunks<T, I, F>(
-    connectors: Arc<RwLock<Vec<(Addr<ClientActor>, Addr<ViewClientActor>)>>>,
+    connectors: &[(Addr<ClientActor>, Addr<ViewClientActor>)],
     recipients: I,
     target: T,
     drop_chunks: bool,
@@ -496,7 +497,7 @@ fn send_chunks<T, I, F>(
     for (i, name) in recipients {
         if name == target {
             if !drop_chunks || !sample_binary(1, 10) {
-                connectors.read().unwrap()[i].0.do_send(create_msg());
+                connectors[i].0.do_send(create_msg());
             }
         }
     }
@@ -565,12 +566,8 @@ pub fn setup_mock_all_validators(
     let genesis_time = Clock::utc();
     let mut ret = vec![];
 
-    let connectors: Arc<RwLock<Vec<(Addr<ClientActor>, Addr<ViewClientActor>)>>> =
-        Arc::new(RwLock::new(vec![]));
-
-    // Lock the connectors so that none of the threads spawned below access them until we overwrite
-    //    them at the end of this function
-    let mut locked_connectors = connectors.write().unwrap();
+    let connectors: Arc<OnceCell<Vec<(Addr<ClientActor>, Addr<ViewClientActor>)>>> =
+        Default::default();
 
     let announced_accounts = Arc::new(RwLock::new(HashSet::new()));
     let genesis_block = Arc::new(RwLock::new(None));
@@ -591,7 +588,6 @@ pub fn setup_mock_all_validators(
         let key_pairs1 = key_pairs.clone();
         let addresses = addresses.clone();
         let connectors1 = connectors.clone();
-        let connectors2 = connectors.clone();
         let network_mock1 = peer_manager_mock.clone();
         let announced_accounts1 = announced_accounts.clone();
         let last_height1 = last_height.clone();
@@ -605,6 +601,8 @@ pub fn setup_mock_all_validators(
             let client_addr = ctx.address();
             let _account_id = account_id.clone();
             let pm = PeerManagerMock::mock(Box::new(move |msg, _ctx| {
+                // Note: this `.wait` will block until all `ClientActors` are created.
+                let connectors1 = connectors1.wait();
                 let msg = msg.downcast_ref::<PeerManagerMessageRequest>().unwrap();
 
                 let mut guard = network_mock1.write().unwrap();
@@ -620,7 +618,7 @@ pub fn setup_mock_all_validators(
                         let last_height2 = last_height2.read().unwrap();
                         let peers: Vec<_> = key_pairs1
                             .iter()
-                            .take(connectors2.read().unwrap().len())
+                            .take(connectors1.len())
                             .enumerate()
                             .map(|(i, peer_info)| FullPeerInfo {
                                 peer_info: peer_info.clone(),
@@ -658,7 +656,7 @@ pub fn setup_mock_all_validators(
                                 block_stats2.check_stats(false);
                             }
 
-                            for (client, _) in connectors1.read().unwrap().iter() {
+                            for (client, _) in connectors1 {
                                 client.do_send(NetworkClientMessages::Block(
                                     block.clone(),
                                     PeerInfo::random().id,
@@ -685,7 +683,7 @@ pub fn setup_mock_all_validators(
                                 )
                             };
                             send_chunks(
-                                Arc::clone(&connectors1),
+                                connectors1,
                                 validators_clone2.iter().flatten().map(|s| Some(s.clone())).enumerate(),
                                 target.account_id.as_ref().map(|s| s.clone()),
                                 drop_chunks,
@@ -697,7 +695,7 @@ pub fn setup_mock_all_validators(
                                 NetworkClientMessages::PartialEncodedChunkResponse(response.clone(), Clock::instant())
                             };
                             send_chunks(
-                                Arc::clone(&connectors1),
+                                connectors1,
                                 addresses.iter().enumerate(),
                                 route_back,
                                 drop_chunks,
@@ -714,7 +712,7 @@ pub fn setup_mock_all_validators(
                                 )
                             };
                             send_chunks(
-                                Arc::clone(&connectors1),
+                                connectors1,
                                 validators_clone2.iter().flatten().cloned().enumerate(),
                                 account_id.clone(),
                                 drop_chunks,
@@ -726,7 +724,7 @@ pub fn setup_mock_all_validators(
                                 NetworkClientMessages::PartialEncodedChunkForward(forward.clone())
                             };
                             send_chunks(
-                                Arc::clone(&connectors1),
+                                connectors1,
                                 validators_clone2.iter().flatten().cloned().enumerate(),
                                 account_id.clone(),
                                 drop_chunks,
@@ -737,20 +735,16 @@ pub fn setup_mock_all_validators(
                             for (i, peer_info) in key_pairs.iter().enumerate() {
                                 let peer_id = peer_id.clone();
                                 if peer_info.id == peer_id {
-                                    let connectors2 = connectors1.clone();
+                                    let me = connectors1[my_ord].0.clone();
                                     actix::spawn(
-                                        connectors1.read().unwrap()[i]
+                                        connectors1[i]
                                             .1
                                             .send(NetworkViewClientMessages::BlockRequest(*hash))
                                             .then(move |response| {
                                                 let response = response.unwrap();
                                                 match response {
                                                     NetworkViewClientResponses::Block(block) => {
-                                                        connectors2.read().unwrap()[my_ord]
-                                                            .0
-                                                            .do_send(NetworkClientMessages::Block(
-                                                                *block, peer_id, true,
-                                                            ));
+                                                        me.do_send(NetworkClientMessages::Block(*block, peer_id, true));
                                                     }
                                                     NetworkViewClientResponses::NoResponse => {}
                                                     _ => assert!(false),
@@ -765,9 +759,9 @@ pub fn setup_mock_all_validators(
                             for (i, peer_info) in key_pairs.iter().enumerate() {
                                 let peer_id = peer_id.clone();
                                 if peer_info.id == peer_id {
-                                    let connectors2 = connectors1.clone();
+                                    let me = connectors1[my_ord].0.clone();
                                     actix::spawn(
-                                        connectors1.read().unwrap()[i]
+                                        connectors1[i]
                                             .1
                                             .send(NetworkViewClientMessages::EpochSyncRequest{
                                                 epoch_id: epoch_id.clone(),
@@ -776,11 +770,7 @@ pub fn setup_mock_all_validators(
                                                 let response = response.unwrap();
                                                 match response {
                                                     NetworkViewClientResponses::EpochSyncResponse(response) => {
-                                                        connectors2.read().unwrap()[my_ord]
-                                                            .0
-                                                            .do_send(NetworkClientMessages::EpochSyncResponse(
-                                                                peer_id, response
-                                                            ));
+                                                        me.do_send(NetworkClientMessages::EpochSyncResponse(peer_id, response));
                                                     }
                                                     NetworkViewClientResponses::NoResponse => {}
                                                     _ => assert!(false),
@@ -795,9 +785,9 @@ pub fn setup_mock_all_validators(
                             for (i, peer_info) in key_pairs.iter().enumerate() {
                                 let peer_id = peer_id.clone();
                                 if peer_info.id == peer_id {
-                                    let connectors2 = connectors1.clone();
+                                    let me = connectors1[my_ord].0.clone();
                                     actix::spawn(
-                                        connectors1.read().unwrap()[i]
+                                        connectors1[i]
                                             .1
                                             .send(NetworkViewClientMessages::EpochSyncFinalizationRequest{
                                                 epoch_id: epoch_id.clone(),
@@ -806,11 +796,7 @@ pub fn setup_mock_all_validators(
                                                 let response = response.unwrap();
                                                 match response {
                                                     NetworkViewClientResponses::EpochSyncFinalizationResponse(response) => {
-                                                        connectors2.read().unwrap()[my_ord]
-                                                            .0
-                                                            .do_send(NetworkClientMessages::EpochSyncFinalizationResponse(
-                                                                peer_id, response
-                                                            ));
+                                                        me.do_send(NetworkClientMessages::EpochSyncFinalizationResponse(peer_id, response));
                                                     }
                                                     NetworkViewClientResponses::NoResponse => {}
                                                     _ => assert!(false),
@@ -825,9 +811,9 @@ pub fn setup_mock_all_validators(
                             for (i, peer_info) in key_pairs.iter().enumerate() {
                                 let peer_id = peer_id.clone();
                                 if peer_info.id == peer_id {
-                                    let connectors2 = connectors1.clone();
+                                    let me = connectors1[my_ord].0.clone();
                                     actix::spawn(
-                                        connectors1.read().unwrap()[i]
+                                        connectors1[i]
                                             .1
                                             .send(NetworkViewClientMessages::BlockHeadersRequest(
                                                 hashes.clone(),
@@ -838,13 +824,7 @@ pub fn setup_mock_all_validators(
                                                     NetworkViewClientResponses::BlockHeaders(
                                                         headers,
                                                     ) => {
-                                                        connectors2.read().unwrap()[my_ord]
-                                                            .0
-                                                            .do_send(
-                                                                NetworkClientMessages::BlockHeaders(
-                                                                    headers, peer_id,
-                                                                ),
-                                                            );
+                                                        me.do_send(NetworkClientMessages::BlockHeaders(headers, peer_id));
                                                     }
                                                     NetworkViewClientResponses::NoResponse => {}
                                                     _ => assert!(false),
@@ -866,9 +846,9 @@ pub fn setup_mock_all_validators(
                             };
                             for (i, name) in validators_clone2.iter().flatten().enumerate() {
                                 if name == target_account_id {
-                                    let connectors2 = connectors1.clone();
+                                    let me = connectors1[my_ord].0.clone();
                                     actix::spawn(
-                                        connectors1.read().unwrap()[i]
+                                        connectors1[i]
                                             .1
                                             .send(NetworkViewClientMessages::StateRequestHeader {
                                                 shard_id: *shard_id,
@@ -880,13 +860,7 @@ pub fn setup_mock_all_validators(
                                                     NetworkViewClientResponses::StateResponse(
                                                         response,
                                                     ) => {
-                                                        connectors2.read().unwrap()[my_ord]
-                                                            .0
-                                                            .do_send(
-                                                            NetworkClientMessages::StateResponse(
-                                                                *response,
-                                                            ),
-                                                        );
+                                                        me.do_send(NetworkClientMessages::StateResponse(*response));
                                                     }
                                                     NetworkViewClientResponses::NoResponse => {}
                                                     _ => assert!(false),
@@ -909,9 +883,9 @@ pub fn setup_mock_all_validators(
                             };
                             for (i, name) in validators_clone2.iter().flatten().enumerate() {
                                 if name == target_account_id {
-                                    let connectors2 = connectors1.clone();
+                                    let me = connectors1[my_ord].0.clone();
                                     actix::spawn(
-                                        connectors1.read().unwrap()[i]
+                                        connectors1[i]
                                             .1
                                             .send(NetworkViewClientMessages::StateRequestPart {
                                                 shard_id: *shard_id,
@@ -924,13 +898,7 @@ pub fn setup_mock_all_validators(
                                                     NetworkViewClientResponses::StateResponse(
                                                         response,
                                                     ) => {
-                                                        connectors2.read().unwrap()[my_ord]
-                                                            .0
-                                                            .do_send(
-                                                            NetworkClientMessages::StateResponse(
-                                                                *response,
-                                                            ),
-                                                        );
+                                                        me.do_send(NetworkClientMessages::StateResponse(*response));
                                                     }
                                                     NetworkViewClientResponses::NoResponse => {}
                                                     _ => assert!(false),
@@ -944,7 +912,7 @@ pub fn setup_mock_all_validators(
                         NetworkRequests::StateResponse { route_back, response } => {
                             for (i, address) in addresses.iter().enumerate() {
                                 if route_back == address {
-                                    connectors1.read().unwrap()[i].0.do_send(
+                                    connectors1[i].0.do_send(
                                         NetworkClientMessages::StateResponse(response.clone()),
                                     );
                                 }
@@ -958,7 +926,7 @@ pub fn setup_mock_all_validators(
                             );
                             if aa.get(&key).is_none() {
                                 aa.insert(key);
-                                for (_, view_client) in connectors1.read().unwrap().iter() {
+                                for (_, view_client) in connectors1 {
                                     view_client.do_send(NetworkViewClientMessages::AnnounceAccount(
                                         vec![(announce_account.clone(), None)],
                                     ))
@@ -986,7 +954,7 @@ pub fn setup_mock_all_validators(
                             if do_propagate {
                                 for (i, name) in validators_clone2.iter().flatten().enumerate() {
                                     if name == &approval_message.target {
-                                        connectors1.read().unwrap()[i].0.do_send(
+                                        connectors1[i].0.do_send(
                                             NetworkClientMessages::BlockApproval(
                                                 approval.clone(),
                                                 my_key_pair.id.clone(),
@@ -1070,7 +1038,7 @@ pub fn setup_mock_all_validators(
         .write()
         .unwrap()
         .insert(*genesis_block.read().unwrap().as_ref().unwrap().header().clone().hash(), 0);
-    *locked_connectors = ret.clone();
+    connectors.set(ret.clone()).unwrap();
     let value = genesis_block.read().unwrap();
     (value.clone().unwrap(), ret, block_stats)
 }

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -552,6 +552,7 @@ pub fn setup_mock_all_validators(
         RwLock<
             Box<
                 dyn FnMut(
+                    &[(Addr<ClientActor>, Addr<ViewClientActor>)],
                     AccountId,
                     &PeerManagerMessageRequest,
                 ) -> (PeerManagerMessageResponse, bool),
@@ -606,7 +607,7 @@ pub fn setup_mock_all_validators(
                 let msg = msg.downcast_ref::<PeerManagerMessageRequest>().unwrap();
 
                 let mut guard = network_mock1.write().unwrap();
-                let (resp, perform_default) = guard.deref_mut()(account_id.clone(), msg);
+                let (resp, perform_default) = guard.deref_mut()(connectors1.as_slice(), account_id.clone(), msg);
                 drop(guard);
 
                 if perform_default {

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -548,18 +548,15 @@ pub fn setup_mock_all_validators(
     archive: Vec<bool>,
     epoch_sync_enabled: Vec<bool>,
     check_block_stats: bool,
-    peer_manager_mock: Arc<
-        RwLock<
-            Box<
-                dyn FnMut(
-                    &[(Addr<ClientActor>, Addr<ViewClientActor>)],
-                    AccountId,
-                    &PeerManagerMessageRequest,
-                ) -> (PeerManagerMessageResponse, bool),
-            >,
-        >,
+    peer_manager_mock: Box<
+        dyn FnMut(
+            &[(Addr<ClientActor>, Addr<ViewClientActor>)],
+            AccountId,
+            &PeerManagerMessageRequest,
+        ) -> (PeerManagerMessageResponse, bool),
     >,
 ) -> (Block, Vec<(Addr<ClientActor>, Addr<ViewClientActor>)>, Arc<RwLock<BlockStats>>) {
+    let peer_manager_mock = Arc::new(RwLock::new(peer_manager_mock));
     let validators_clone = validators.clone();
     let key_pairs = key_pairs;
 

--- a/chain/client/src/tests/bug_repros.rs
+++ b/chain/client/src/tests/bug_repros.rs
@@ -23,7 +23,6 @@ use near_network::types::{
 use near_network_primitives::types::PeerInfo;
 use near_primitives::block::Block;
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::AccountId;
 
 #[test]
 fn repro_1183() {
@@ -63,94 +62,91 @@ fn repro_1183() {
             vec![false; validators.iter().map(|x| x.len()).sum()],
             vec![true; validators.iter().map(|x| x.len()).sum()],
             false,
-            Arc::new(RwLock::new(Box::new(
-                move |_, _account_id: _, msg: &PeerManagerMessageRequest| {
-                    if let NetworkRequests::Block { block } = msg.as_network_requests_ref() {
-                        let mut last_block = last_block.write().unwrap();
-                        let mut delayed_one_parts = delayed_one_parts.write().unwrap();
+            Box::new(move |_, _account_id: _, msg: &PeerManagerMessageRequest| {
+                if let NetworkRequests::Block { block } = msg.as_network_requests_ref() {
+                    let mut last_block = last_block.write().unwrap();
+                    let mut delayed_one_parts = delayed_one_parts.write().unwrap();
 
-                        if let Some(last_block) = last_block.clone() {
-                            for (client, _) in connectors1.write().unwrap().iter() {
-                                client.do_send(NetworkClientMessages::Block(
-                                    last_block.clone(),
-                                    PeerInfo::random().id,
-                                    false,
-                                ))
-                            }
+                    if let Some(last_block) = last_block.clone() {
+                        for (client, _) in connectors1.write().unwrap().iter() {
+                            client.do_send(NetworkClientMessages::Block(
+                                last_block.clone(),
+                                PeerInfo::random().id,
+                                false,
+                            ))
                         }
-                        for delayed_message in delayed_one_parts.iter() {
-                            if let PartialEncodedChunkMessage {
-                                account_id,
-                                partial_encoded_chunk,
-                                ..
-                            } = delayed_message
-                            {
-                                for (i, name) in validators2.iter().flatten().enumerate() {
-                                    if name == account_id {
-                                        connectors1.write().unwrap()[i].0.do_send(
-                                            NetworkClientMessages::PartialEncodedChunk(
-                                                partial_encoded_chunk.clone().into(),
-                                            ),
-                                        );
-                                    }
-                                }
-                            } else {
-                                assert!(false);
-                            }
-                        }
-
-                        let mut nonce_delta = 0;
-                        for from in ["test1", "test2", "test3", "test4"].iter() {
-                            for to in ["test1", "test2", "test3", "test4"].iter() {
-                                let (from, to) = (from.parse().unwrap(), to.parse().unwrap());
-                                connectors1.write().unwrap()
-                                    [account_id_to_shard_id(&from, 4) as usize]
-                                    .0
-                                    .do_send(NetworkClientMessages::Transaction {
-                                        transaction: SignedTransaction::send_money(
-                                            block.header().height() * 16 + nonce_delta,
-                                            from.clone(),
-                                            to,
-                                            &InMemorySigner::from_seed(
-                                                from.clone(),
-                                                KeyType::ED25519,
-                                                from.as_ref(),
-                                            ),
-                                            1,
-                                            *block.header().prev_hash(),
-                                        ),
-                                        is_forwarded: false,
-                                        check_only: false,
-                                    });
-                                nonce_delta += 1
-                            }
-                        }
-
-                        *last_block = Some(block.clone());
-                        *delayed_one_parts = vec![];
-
-                        if block.header().height() >= 25 {
-                            System::current().stop();
-                        }
-                        (NetworkResponses::NoResponse.into(), false)
-                    } else if let NetworkRequests::PartialEncodedChunkMessage { .. } =
-                        msg.as_network_requests_ref()
-                    {
-                        if thread_rng().gen_bool(0.5) {
-                            (NetworkResponses::NoResponse.into(), true)
-                        } else {
-                            let msg2 = msg.clone();
-                            delayed_one_parts
-                                .write()
-                                .unwrap()
-                                .push(msg2.as_network_requests_ref().clone());
-                            (NetworkResponses::NoResponse.into(), false)
-                        }
-                    } else {
-                        (NetworkResponses::NoResponse.into(), true)
                     }
-                },
-            ))),
+                    for delayed_message in delayed_one_parts.iter() {
+                        if let PartialEncodedChunkMessage {
+                            account_id,
+                            partial_encoded_chunk,
+                            ..
+                        } = delayed_message
+                        {
+                            for (i, name) in validators2.iter().flatten().enumerate() {
+                                if name == account_id {
+                                    connectors1.write().unwrap()[i].0.do_send(
+                                        NetworkClientMessages::PartialEncodedChunk(
+                                            partial_encoded_chunk.clone().into(),
+                                        ),
+                                    );
+                                }
+                            }
+                        } else {
+                            assert!(false);
+                        }
+                    }
+
+                    let mut nonce_delta = 0;
+                    for from in ["test1", "test2", "test3", "test4"].iter() {
+                        for to in ["test1", "test2", "test3", "test4"].iter() {
+                            let (from, to) = (from.parse().unwrap(), to.parse().unwrap());
+                            connectors1.write().unwrap()[account_id_to_shard_id(&from, 4) as usize]
+                                .0
+                                .do_send(NetworkClientMessages::Transaction {
+                                    transaction: SignedTransaction::send_money(
+                                        block.header().height() * 16 + nonce_delta,
+                                        from.clone(),
+                                        to,
+                                        &InMemorySigner::from_seed(
+                                            from.clone(),
+                                            KeyType::ED25519,
+                                            from.as_ref(),
+                                        ),
+                                        1,
+                                        *block.header().prev_hash(),
+                                    ),
+                                    is_forwarded: false,
+                                    check_only: false,
+                                });
+                            nonce_delta += 1
+                        }
+                    }
+
+                    *last_block = Some(block.clone());
+                    *delayed_one_parts = vec![];
+
+                    if block.header().height() >= 25 {
+                        System::current().stop();
+                    }
+                    (NetworkResponses::NoResponse.into(), false)
+                } else if let NetworkRequests::PartialEncodedChunkMessage { .. } =
+                    msg.as_network_requests_ref()
+                {
+                    if thread_rng().gen_bool(0.5) {
+                        (NetworkResponses::NoResponse.into(), true)
+                    } else {
+                        let msg2 = msg.clone();
+                        delayed_one_parts
+                            .write()
+                            .unwrap()
+                            .push(msg2.as_network_requests_ref().clone());
+                        (NetworkResponses::NoResponse.into(), false)
+                    }
+                } else {
+                    (NetworkResponses::NoResponse.into(), true)
+                }
+            }),
         );
         *connectors.write().unwrap() = conn;
 
@@ -174,19 +170,7 @@ fn test_sync_from_achival_node() {
     let epoch_length = 4;
 
     run_actix(async move {
-        let network_mock: Arc<
-            RwLock<
-                Box<
-                    dyn FnMut(
-                        &[(Addr<ClientActor>, Addr<ViewClientActor>)],
-                        AccountId,
-                        &PeerManagerMessageRequest,
-                    ) -> (PeerManagerMessageResponse, bool),
-                >,
-            >,
-        > = Arc::new(RwLock::new(Box::new(|_, _, _: &PeerManagerMessageRequest| {
-            (NetworkResponses::NoResponse.into(), true)
-        })));
+        let mut block_counter = 0;
         setup_mock_all_validators(
             validators.clone(),
             key_pairs,
@@ -200,76 +184,73 @@ fn test_sync_from_achival_node() {
             vec![true, false, false, false],
             vec![false, true, true, true],
             false,
-            network_mock.clone(),
-        );
-        let mut block_counter = 0;
-        *network_mock.write().unwrap() = Box::new(
-            move |conns,
-                  _,
-                  msg: &PeerManagerMessageRequest|
-                  -> (PeerManagerMessageResponse, bool) {
-                let msg = msg.as_network_requests_ref();
-                if let NetworkRequests::Block { block } = msg {
-                    let mut largest_height = largest_height.write().unwrap();
-                    *largest_height = max(block.header().height(), *largest_height);
-                }
-                if *largest_height.read().unwrap() >= 50 {
-                    System::current().stop();
-                }
-                if *largest_height.read().unwrap() <= 30 {
-                    match msg {
-                        NetworkRequests::Block { block } => {
-                            for (i, (client, _)) in conns.iter().enumerate() {
-                                if i != 3 {
-                                    client.do_send(NetworkClientMessages::Block(
-                                        block.clone(),
-                                        PeerInfo::random().id,
-                                        false,
-                                    ))
+            Box::new(
+                move |conns,
+                      _,
+                      msg: &PeerManagerMessageRequest|
+                      -> (PeerManagerMessageResponse, bool) {
+                    let msg = msg.as_network_requests_ref();
+                    if let NetworkRequests::Block { block } = msg {
+                        let mut largest_height = largest_height.write().unwrap();
+                        *largest_height = max(block.header().height(), *largest_height);
+                    }
+                    if *largest_height.read().unwrap() >= 50 {
+                        System::current().stop();
+                    }
+                    if *largest_height.read().unwrap() <= 30 {
+                        match msg {
+                            NetworkRequests::Block { block } => {
+                                for (i, (client, _)) in conns.iter().enumerate() {
+                                    if i != 3 {
+                                        client.do_send(NetworkClientMessages::Block(
+                                            block.clone(),
+                                            PeerInfo::random().id,
+                                            false,
+                                        ))
+                                    }
                                 }
-                            }
-                            if block.header().height() <= 10 {
-                                blocks.write().unwrap().insert(*block.hash(), block.clone());
-                            }
-                            (NetworkResponses::NoResponse.into(), false)
-                        }
-                        NetworkRequests::Approval { approval_message } => {
-                            for (i, (client, _)) in conns.clone().into_iter().enumerate() {
-                                if i != 3 {
-                                    client.do_send(NetworkClientMessages::BlockApproval(
-                                        approval_message.approval.clone(),
-                                        PeerInfo::random().id,
-                                    ))
+                                if block.header().height() <= 10 {
+                                    blocks.write().unwrap().insert(*block.hash(), block.clone());
                                 }
+                                (NetworkResponses::NoResponse.into(), false)
                             }
-                            (NetworkResponses::NoResponse.into(), false)
-                        }
-                        _ => (NetworkResponses::NoResponse.into(), true),
-                    }
-                } else {
-                    if block_counter > 10 {
-                        panic!("incorrect rebroadcasting of blocks");
-                    }
-                    for (_, block) in blocks.write().unwrap().drain() {
-                        conns[3].0.do_send(NetworkClientMessages::Block(
-                            block,
-                            PeerInfo::random().id,
-                            false,
-                        ));
-                    }
-                    match msg {
-                        NetworkRequests::Block { block } => {
-                            if block.header().height() <= 10 {
-                                block_counter += 1;
+                            NetworkRequests::Approval { approval_message } => {
+                                for (i, (client, _)) in conns.clone().into_iter().enumerate() {
+                                    if i != 3 {
+                                        client.do_send(NetworkClientMessages::BlockApproval(
+                                            approval_message.approval.clone(),
+                                            PeerInfo::random().id,
+                                        ))
+                                    }
+                                }
+                                (NetworkResponses::NoResponse.into(), false)
                             }
-                            (NetworkResponses::NoResponse.into(), true)
+                            _ => (NetworkResponses::NoResponse.into(), true),
                         }
-                        _ => (NetworkResponses::NoResponse.into(), true),
+                    } else {
+                        if block_counter > 10 {
+                            panic!("incorrect rebroadcasting of blocks");
+                        }
+                        for (_, block) in blocks.write().unwrap().drain() {
+                            conns[3].0.do_send(NetworkClientMessages::Block(
+                                block,
+                                PeerInfo::random().id,
+                                false,
+                            ));
+                        }
+                        match msg {
+                            NetworkRequests::Block { block } => {
+                                if block.header().height() <= 10 {
+                                    block_counter += 1;
+                                }
+                                (NetworkResponses::NoResponse.into(), true)
+                            }
+                            _ => (NetworkResponses::NoResponse.into(), true),
+                        }
                     }
-                }
-            },
+                },
+            ),
         );
-
         near_network::test_utils::wait_or_panic(20000);
     });
 }
@@ -283,19 +264,6 @@ fn test_long_gap_between_blocks() {
     let target_height = 600;
 
     run_actix(async move {
-        let network_mock: Arc<
-            RwLock<
-                Box<
-                    dyn FnMut(
-                        &[(Addr<ClientActor>, Addr<ViewClientActor>)],
-                        AccountId,
-                        &PeerManagerMessageRequest,
-                    ) -> (PeerManagerMessageResponse, bool),
-                >,
-            >,
-        > = Arc::new(RwLock::new(Box::new(|_, _, _: &PeerManagerMessageRequest| {
-            (NetworkResponses::NoResponse.into(), true)
-        })));
         setup_mock_all_validators(
             validators.clone(),
             key_pairs,
@@ -309,35 +277,34 @@ fn test_long_gap_between_blocks() {
             vec![false, false],
             vec![true, true],
             false,
-            network_mock.clone(),
-        );
-        *network_mock.write().unwrap() = Box::new(
-            move |conns,
-                  _,
-                  msg: &PeerManagerMessageRequest|
-                  -> (PeerManagerMessageResponse, bool) {
-                match msg.as_network_requests_ref() {
-                    NetworkRequests::Approval { approval_message } => {
-                        actix::spawn(conns[1].1.send(GetBlock::latest()).then(move |res| {
-                            let res = res.unwrap().unwrap();
-                            if res.header.height > target_height {
-                                System::current().stop();
-                            }
-                            futures::future::ready(())
-                        }));
-                        if approval_message.approval.target_height < target_height {
-                            (NetworkResponses::NoResponse.into(), false)
-                        } else {
-                            if approval_message.target.as_ref() == "test1" {
-                                (NetworkResponses::NoResponse.into(), true)
-                            } else {
+            Box::new(
+                move |conns,
+                      _,
+                      msg: &PeerManagerMessageRequest|
+                      -> (PeerManagerMessageResponse, bool) {
+                    match msg.as_network_requests_ref() {
+                        NetworkRequests::Approval { approval_message } => {
+                            actix::spawn(conns[1].1.send(GetBlock::latest()).then(move |res| {
+                                let res = res.unwrap().unwrap();
+                                if res.header.height > target_height {
+                                    System::current().stop();
+                                }
+                                futures::future::ready(())
+                            }));
+                            if approval_message.approval.target_height < target_height {
                                 (NetworkResponses::NoResponse.into(), false)
+                            } else {
+                                if approval_message.target.as_ref() == "test1" {
+                                    (NetworkResponses::NoResponse.into(), true)
+                                } else {
+                                    (NetworkResponses::NoResponse.into(), false)
+                                }
                             }
                         }
+                        _ => (NetworkResponses::NoResponse.into(), true),
                     }
-                    _ => (NetworkResponses::NoResponse.into(), true),
-                }
-            },
+                },
+            ),
         );
 
         near_network::test_utils::wait_or_panic(60000);

--- a/chain/client/src/tests/catching_up.rs
+++ b/chain/client/src/tests/catching_up.rs
@@ -159,7 +159,7 @@ fn test_catchup_receipts_sync_common(wait_till: u64, send: u64, sync_hold: bool)
             vec![false; validators.iter().map(|x| x.len()).sum()],
             false,
             Arc::new(RwLock::new(Box::new(
-                move |_account_id: _, msg: &PeerManagerMessageRequest| {
+                move |_, _account_id: _, msg: &PeerManagerMessageRequest| {
                     let msg = msg.as_network_requests_ref();
                     let account_from = "test3.3".parse().unwrap();
                     let account_to = "test1.1".parse().unwrap();
@@ -460,7 +460,7 @@ fn test_catchup_random_single_part_sync_common(skip_15: bool, non_zero: bool, he
             vec![true; validators.iter().map(|x| x.len()).sum()],
             false,
             Arc::new(RwLock::new(Box::new(
-                move |_account_id: _, msg: &PeerManagerMessageRequest| {
+                move |_, _account_id: _, msg: &PeerManagerMessageRequest| {
                     let msg = msg.as_network_requests_ref();
                     let mut seen_heights_same_block = seen_heights_same_block.write().unwrap();
                     let mut phase = phase.write().unwrap();
@@ -657,7 +657,7 @@ fn test_catchup_sanity_blocks_produced() {
             vec![true; validators.iter().map(|x| x.len()).sum()],
             false,
             Arc::new(RwLock::new(Box::new(
-                move |_account_id: _, msg: &PeerManagerMessageRequest| {
+                move |_, _account_id: _, msg: &PeerManagerMessageRequest| {
                     let msg = msg.as_network_requests_ref();
                     let propagate = if let NetworkRequests::Block { block } = msg {
                         check_height(*block.hash(), block.header().height());
@@ -728,7 +728,7 @@ fn test_chunk_grieving() {
             vec![true; validators.iter().map(|x| x.len()).sum()],
             false,
             Arc::new(RwLock::new(Box::new(
-                move |sender_account_id: AccountId, msg: &PeerManagerMessageRequest| {
+                move |_, sender_account_id: AccountId, msg: &PeerManagerMessageRequest| {
                     let msg = msg.as_network_requests_ref();
                     let mut grieving_chunk_hash = grieving_chunk_hash.write().unwrap();
                     let mut unaccepted_block_hash = unaccepted_block_hash.write().unwrap();
@@ -895,7 +895,7 @@ fn test_all_chunks_accepted_common(
             vec![true; validators.iter().map(|x| x.len()).sum()],
             false,
             Arc::new(RwLock::new(Box::new(
-                move |sender_account_id: AccountId, msg: &PeerManagerMessageRequest| {
+                move |_, sender_account_id: AccountId, msg: &PeerManagerMessageRequest| {
                     let msg = msg.as_network_requests_ref();
                     let mut seen_chunk_same_sender = seen_chunk_same_sender.write().unwrap();
                     let mut requested = requested.write().unwrap();

--- a/chain/client/src/tests/catching_up.rs
+++ b/chain/client/src/tests/catching_up.rs
@@ -158,202 +158,196 @@ fn test_catchup_receipts_sync_common(wait_till: u64, send: u64, sync_hold: bool)
             vec![true; validators.iter().map(|x| x.len()).sum()],
             vec![false; validators.iter().map(|x| x.len()).sum()],
             false,
-            Arc::new(RwLock::new(Box::new(
-                move |_, _account_id: _, msg: &PeerManagerMessageRequest| {
-                    let msg = msg.as_network_requests_ref();
-                    let account_from = "test3.3".parse().unwrap();
-                    let account_to = "test1.1".parse().unwrap();
-                    let source_shard_id = account_id_to_shard_id(&account_from, 4);
-                    let destination_shard_id = account_id_to_shard_id(&account_to, 4);
+            Box::new(move |_, _account_id: _, msg: &PeerManagerMessageRequest| {
+                let msg = msg.as_network_requests_ref();
+                let account_from = "test3.3".parse().unwrap();
+                let account_to = "test1.1".parse().unwrap();
+                let source_shard_id = account_id_to_shard_id(&account_from, 4);
+                let destination_shard_id = account_id_to_shard_id(&account_to, 4);
 
-                    let mut phase = phase.write().unwrap();
-                    let mut seen_heights_with_receipts =
-                        seen_heights_with_receipts.write().unwrap();
-                    let mut seen_hashes_with_state = seen_hashes_with_state.write().unwrap();
-                    match *phase {
-                        ReceiptsSyncPhases::WaitingForFirstBlock => {
-                            if let NetworkRequests::Block { block } = msg {
-                                assert!(block.header().height() <= send);
-                                // This tx is rather fragile, specifically it's important that
-                                //   1. the `from` and `to` account are not in the same shard;
-                                //   2. ideally the producer of the chunk at height 3 for the shard
-                                //      in which `from` resides should not also be a block producer
-                                //      at height 3
-                                //   3. The `from` shard should also not match the block producer
-                                //      for height 1, because such block producer will produce
-                                //      the chunk for height 2 right away, before we manage to send
-                                //      the transaction.
-                                if block.header().height() == send {
-                                    println!(
-                                        "From shard: {}, to shard: {}",
-                                        source_shard_id, destination_shard_id,
-                                    );
-                                    for i in 0..16 {
-                                        send_tx(
-                                            &connectors1.write().unwrap()[i].0,
-                                            account_from.clone(),
-                                            account_to.clone(),
-                                            111,
-                                            1,
-                                            *block.header().prev_hash(),
-                                        );
-                                    }
-                                    *phase = ReceiptsSyncPhases::WaitingForSecondBlock;
-                                }
-                            }
-                        }
-                        ReceiptsSyncPhases::WaitingForSecondBlock => {
-                            // This block now contains a chunk with the transaction sent above.
-                            if let NetworkRequests::Block { block } = msg {
-                                assert!(block.header().height() <= send + 1);
-                                if block.header().height() == send + 1 {
-                                    *phase = ReceiptsSyncPhases::WaitingForDistantEpoch;
-                                }
-                            }
-                        }
-                        ReceiptsSyncPhases::WaitingForDistantEpoch => {
-                            // This block now contains a chunk with the transaction sent above.
-                            if let NetworkRequests::Block { block } = msg {
-                                assert!(block.header().height() >= send + 1);
-                                assert!(block.header().height() <= wait_till);
-                                if block.header().height() == wait_till {
-                                    *phase = ReceiptsSyncPhases::VerifyingOutgoingReceipts;
-                                }
-                            }
-                            if let NetworkRequests::PartialEncodedChunkMessage {
-                                partial_encoded_chunk,
-                                ..
-                            } = msg
-                            {
-                                // The chunk producers in all epochs before `distant` need to be trying to
-                                //     include the receipt. The `distant` epoch is the first one that
-                                //     will get the receipt through the state sync.
-                                let receipts: Vec<Receipt> = partial_encoded_chunk
-                                    .receipts
-                                    .iter()
-                                    .map(|x| x.0.clone())
-                                    .flatten()
-                                    .collect();
-                                if receipts.len() > 0 {
-                                    assert_eq!(
-                                        partial_encoded_chunk.header.shard_id(),
-                                        source_shard_id
-                                    );
-                                    seen_heights_with_receipts
-                                        .insert(partial_encoded_chunk.header.height_created());
-                                } else {
-                                    assert_ne!(
-                                        partial_encoded_chunk.header.shard_id(),
-                                        source_shard_id
-                                    );
-                                }
-                                // Do not propagate any one parts, this will prevent any chunk from
-                                //    being included in the block
-                                return (NetworkResponses::NoResponse.into(), false);
-                            }
-                            if let NetworkRequests::StateRequestHeader {
-                                shard_id,
-                                sync_hash,
-                                target,
-                            } = msg
-                            {
-                                if sync_hold {
-                                    let srs = StateRequestStruct {
-                                        shard_id: *shard_id,
-                                        sync_hash: *sync_hash,
-                                        part_id: None,
-                                        target: target.clone(),
-                                    };
-                                    if !seen_hashes_with_state
-                                        .contains(&hash_func(&srs.try_to_vec().unwrap()))
-                                    {
-                                        seen_hashes_with_state
-                                            .insert(hash_func(&srs.try_to_vec().unwrap()));
-                                        return (NetworkResponses::NoResponse.into(), false);
-                                    }
-                                }
-                            }
-                            if let NetworkRequests::StateRequestPart {
-                                shard_id,
-                                sync_hash,
-                                part_id,
-                                target,
-                            } = msg
-                            {
-                                if sync_hold {
-                                    let srs = StateRequestStruct {
-                                        shard_id: *shard_id,
-                                        sync_hash: *sync_hash,
-                                        part_id: Some(*part_id),
-                                        target: target.clone(),
-                                    };
-                                    if !seen_hashes_with_state
-                                        .contains(&hash_func(&srs.try_to_vec().unwrap()))
-                                    {
-                                        seen_hashes_with_state
-                                            .insert(hash_func(&srs.try_to_vec().unwrap()));
-                                        return (NetworkResponses::NoResponse.into(), false);
-                                    }
-                                }
-                            }
-                        }
-                        ReceiptsSyncPhases::VerifyingOutgoingReceipts => {
-                            for height in send + 2..=wait_till {
+                let mut phase = phase.write().unwrap();
+                let mut seen_heights_with_receipts = seen_heights_with_receipts.write().unwrap();
+                let mut seen_hashes_with_state = seen_hashes_with_state.write().unwrap();
+                match *phase {
+                    ReceiptsSyncPhases::WaitingForFirstBlock => {
+                        if let NetworkRequests::Block { block } = msg {
+                            assert!(block.header().height() <= send);
+                            // This tx is rather fragile, specifically it's important that
+                            //   1. the `from` and `to` account are not in the same shard;
+                            //   2. ideally the producer of the chunk at height 3 for the shard
+                            //      in which `from` resides should not also be a block producer
+                            //      at height 3
+                            //   3. The `from` shard should also not match the block producer
+                            //      for height 1, because such block producer will produce
+                            //      the chunk for height 2 right away, before we manage to send
+                            //      the transaction.
+                            if block.header().height() == send {
                                 println!(
-                                    "checking height {:?} out of {:?}, result = {:?}",
-                                    height,
-                                    wait_till,
-                                    seen_heights_with_receipts.contains(&height)
+                                    "From shard: {}, to shard: {}",
+                                    source_shard_id, destination_shard_id,
                                 );
-                                if !sync_hold {
-                                    // If we don't delay the state, all heights should contain the same receipts
-                                    assert!(seen_heights_with_receipts.contains(&height));
+                                for i in 0..16 {
+                                    send_tx(
+                                        &connectors1.write().unwrap()[i].0,
+                                        account_from.clone(),
+                                        account_to.clone(),
+                                        111,
+                                        1,
+                                        *block.header().prev_hash(),
+                                    );
+                                }
+                                *phase = ReceiptsSyncPhases::WaitingForSecondBlock;
+                            }
+                        }
+                    }
+                    ReceiptsSyncPhases::WaitingForSecondBlock => {
+                        // This block now contains a chunk with the transaction sent above.
+                        if let NetworkRequests::Block { block } = msg {
+                            assert!(block.header().height() <= send + 1);
+                            if block.header().height() == send + 1 {
+                                *phase = ReceiptsSyncPhases::WaitingForDistantEpoch;
+                            }
+                        }
+                    }
+                    ReceiptsSyncPhases::WaitingForDistantEpoch => {
+                        // This block now contains a chunk with the transaction sent above.
+                        if let NetworkRequests::Block { block } = msg {
+                            assert!(block.header().height() >= send + 1);
+                            assert!(block.header().height() <= wait_till);
+                            if block.header().height() == wait_till {
+                                *phase = ReceiptsSyncPhases::VerifyingOutgoingReceipts;
+                            }
+                        }
+                        if let NetworkRequests::PartialEncodedChunkMessage {
+                            partial_encoded_chunk,
+                            ..
+                        } = msg
+                        {
+                            // The chunk producers in all epochs before `distant` need to be trying to
+                            //     include the receipt. The `distant` epoch is the first one that
+                            //     will get the receipt through the state sync.
+                            let receipts: Vec<Receipt> = partial_encoded_chunk
+                                .receipts
+                                .iter()
+                                .map(|x| x.0.clone())
+                                .flatten()
+                                .collect();
+                            if receipts.len() > 0 {
+                                assert_eq!(
+                                    partial_encoded_chunk.header.shard_id(),
+                                    source_shard_id
+                                );
+                                seen_heights_with_receipts
+                                    .insert(partial_encoded_chunk.header.height_created());
+                            } else {
+                                assert_ne!(
+                                    partial_encoded_chunk.header.shard_id(),
+                                    source_shard_id
+                                );
+                            }
+                            // Do not propagate any one parts, this will prevent any chunk from
+                            //    being included in the block
+                            return (NetworkResponses::NoResponse.into(), false);
+                        }
+                        if let NetworkRequests::StateRequestHeader { shard_id, sync_hash, target } =
+                            msg
+                        {
+                            if sync_hold {
+                                let srs = StateRequestStruct {
+                                    shard_id: *shard_id,
+                                    sync_hash: *sync_hash,
+                                    part_id: None,
+                                    target: target.clone(),
+                                };
+                                if !seen_hashes_with_state
+                                    .contains(&hash_func(&srs.try_to_vec().unwrap()))
+                                {
+                                    seen_hashes_with_state
+                                        .insert(hash_func(&srs.try_to_vec().unwrap()));
+                                    return (NetworkResponses::NoResponse.into(), false);
                                 }
                             }
-                            *phase = ReceiptsSyncPhases::WaitingForValidate;
                         }
-                        ReceiptsSyncPhases::WaitingForValidate => {
-                            // This block now contains a chunk with the transaction sent above.
-                            if let NetworkRequests::Block { block } = msg {
-                                assert!(block.header().height() >= wait_till);
-                                assert!(block.header().height() <= wait_till + 20);
-                                if block.header().height() == wait_till + 20 {
-                                    System::current().stop();
+                        if let NetworkRequests::StateRequestPart {
+                            shard_id,
+                            sync_hash,
+                            part_id,
+                            target,
+                        } = msg
+                        {
+                            if sync_hold {
+                                let srs = StateRequestStruct {
+                                    shard_id: *shard_id,
+                                    sync_hash: *sync_hash,
+                                    part_id: Some(*part_id),
+                                    target: target.clone(),
+                                };
+                                if !seen_hashes_with_state
+                                    .contains(&hash_func(&srs.try_to_vec().unwrap()))
+                                {
+                                    seen_hashes_with_state
+                                        .insert(hash_func(&srs.try_to_vec().unwrap()));
+                                    return (NetworkResponses::NoResponse.into(), false);
                                 }
-                                if block.header().height() == wait_till + 10 {
-                                    for i in 0..16 {
-                                        actix::spawn(
-                                            connectors1.write().unwrap()[i]
-                                                .1
-                                                .send(Query::new(
-                                                    BlockReference::latest(),
-                                                    QueryRequest::ViewAccount {
-                                                        account_id: account_to.clone(),
-                                                    },
-                                                ))
-                                                .then(move |res| {
-                                                    let res_inner = res.unwrap();
-                                                    if let Ok(query_response) = res_inner {
-                                                        if let ViewAccount(view_account_result) =
-                                                            query_response.kind
-                                                        {
-                                                            assert_eq!(
-                                                                view_account_result.amount,
-                                                                1111
-                                                            );
-                                                        }
+                            }
+                        }
+                    }
+                    ReceiptsSyncPhases::VerifyingOutgoingReceipts => {
+                        for height in send + 2..=wait_till {
+                            println!(
+                                "checking height {:?} out of {:?}, result = {:?}",
+                                height,
+                                wait_till,
+                                seen_heights_with_receipts.contains(&height)
+                            );
+                            if !sync_hold {
+                                // If we don't delay the state, all heights should contain the same receipts
+                                assert!(seen_heights_with_receipts.contains(&height));
+                            }
+                        }
+                        *phase = ReceiptsSyncPhases::WaitingForValidate;
+                    }
+                    ReceiptsSyncPhases::WaitingForValidate => {
+                        // This block now contains a chunk with the transaction sent above.
+                        if let NetworkRequests::Block { block } = msg {
+                            assert!(block.header().height() >= wait_till);
+                            assert!(block.header().height() <= wait_till + 20);
+                            if block.header().height() == wait_till + 20 {
+                                System::current().stop();
+                            }
+                            if block.header().height() == wait_till + 10 {
+                                for i in 0..16 {
+                                    actix::spawn(
+                                        connectors1.write().unwrap()[i]
+                                            .1
+                                            .send(Query::new(
+                                                BlockReference::latest(),
+                                                QueryRequest::ViewAccount {
+                                                    account_id: account_to.clone(),
+                                                },
+                                            ))
+                                            .then(move |res| {
+                                                let res_inner = res.unwrap();
+                                                if let Ok(query_response) = res_inner {
+                                                    if let ViewAccount(view_account_result) =
+                                                        query_response.kind
+                                                    {
+                                                        assert_eq!(
+                                                            view_account_result.amount,
+                                                            1111
+                                                        );
                                                     }
-                                                    future::ready(())
-                                                }),
-                                        );
-                                    }
+                                                }
+                                                future::ready(())
+                                            }),
+                                    );
                                 }
                             }
                         }
-                    };
-                    (NetworkResponses::NoResponse.into(), true)
-                },
-            ))),
+                    }
+                };
+                (NetworkResponses::NoResponse.into(), true)
+            }),
         );
         *connectors.write().unwrap() = conn;
         let mut max_wait_ms = 240000;
@@ -459,154 +453,144 @@ fn test_catchup_random_single_part_sync_common(skip_15: bool, non_zero: bool, he
             vec![false; validators.iter().map(|x| x.len()).sum()],
             vec![true; validators.iter().map(|x| x.len()).sum()],
             false,
-            Arc::new(RwLock::new(Box::new(
-                move |_, _account_id: _, msg: &PeerManagerMessageRequest| {
-                    let msg = msg.as_network_requests_ref();
-                    let mut seen_heights_same_block = seen_heights_same_block.write().unwrap();
-                    let mut phase = phase.write().unwrap();
-                    match *phase {
-                        RandomSinglePartPhases::WaitingForFirstBlock => {
-                            if let NetworkRequests::Block { block } = msg {
-                                assert_eq!(block.header().height(), 1);
-                                *phase = RandomSinglePartPhases::WaitingForThirdEpoch;
+            Box::new(move |_, _account_id: _, msg: &PeerManagerMessageRequest| {
+                let msg = msg.as_network_requests_ref();
+                let mut seen_heights_same_block = seen_heights_same_block.write().unwrap();
+                let mut phase = phase.write().unwrap();
+                match *phase {
+                    RandomSinglePartPhases::WaitingForFirstBlock => {
+                        if let NetworkRequests::Block { block } = msg {
+                            assert_eq!(block.header().height(), 1);
+                            *phase = RandomSinglePartPhases::WaitingForThirdEpoch;
+                        }
+                    }
+                    RandomSinglePartPhases::WaitingForThirdEpoch => {
+                        if let NetworkRequests::Block { block } = msg {
+                            if block.header().height() == 1 {
+                                return (NetworkResponses::NoResponse.into(), false);
+                            }
+                            assert!(block.header().height() >= 2);
+                            assert!(block.header().height() <= height);
+                            let mut tx_count = 0;
+                            if block.header().height() == height && block.header().height() >= 2 {
+                                for (i, validator1) in flat_validators.iter().enumerate() {
+                                    for (j, validator2) in flat_validators.iter().enumerate() {
+                                        let mut amount = (((i + j + 17) * 701) % 42 + 1) as u128;
+                                        if non_zero {
+                                            if i > j {
+                                                amount = 2;
+                                            } else {
+                                                amount = 1;
+                                            }
+                                        }
+                                        println!(
+                                            "VALUES {:?} {:?} {:?}",
+                                            validator1.to_string(),
+                                            validator2.to_string(),
+                                            amount
+                                        );
+                                        for conn in 0..flat_validators.len() {
+                                            send_tx(
+                                                &connectors1.write().unwrap()[conn].0,
+                                                validator1.clone(),
+                                                validator2.clone(),
+                                                amount,
+                                                (12345 + tx_count) as u64,
+                                                *block.header().prev_hash(),
+                                            );
+                                        }
+                                        tx_count += 1;
+                                    }
+                                }
+                                *phase = RandomSinglePartPhases::WaitingForSixEpoch;
+                                assert_eq!(tx_count, 16 * 16);
                             }
                         }
-                        RandomSinglePartPhases::WaitingForThirdEpoch => {
-                            if let NetworkRequests::Block { block } = msg {
-                                if block.header().height() == 1 {
+                    }
+                    RandomSinglePartPhases::WaitingForSixEpoch => {
+                        if let NetworkRequests::Block { block } = msg {
+                            assert!(block.header().height() >= height);
+                            assert!(block.header().height() <= 32);
+                            let check_height = if skip_15 { 28 } else { 26 };
+                            if block.header().height() >= check_height {
+                                println!("BLOCK HEIGHT {:?}", block.header().height());
+                                for i in 0..16 {
+                                    for j in 0..16 {
+                                        let amounts1 = amounts.clone();
+                                        let validator = flat_validators[j].clone();
+                                        actix::spawn(
+                                            connectors1.write().unwrap()[i]
+                                                .1
+                                                .send(Query::new(
+                                                    BlockReference::latest(),
+                                                    QueryRequest::ViewAccount {
+                                                        account_id: flat_validators[j].clone(),
+                                                    },
+                                                ))
+                                                .then(move |res| {
+                                                    let res_inner = res.unwrap();
+                                                    if let Ok(query_response) = res_inner {
+                                                        if let ViewAccount(view_account_result) =
+                                                            query_response.kind
+                                                        {
+                                                            check_amount(
+                                                                amounts1,
+                                                                validator,
+                                                                view_account_result.amount,
+                                                            );
+                                                        }
+                                                    }
+                                                    future::ready(())
+                                                }),
+                                        );
+                                    }
+                                }
+                            }
+                            if block.header().height() == 32 {
+                                println!(
+                                    "SEEN HEIGHTS SAME BLOCK {:?}",
+                                    seen_heights_same_block.len()
+                                );
+                                assert_eq!(seen_heights_same_block.len(), 1);
+                                let amounts1 = amounts.clone();
+                                for flat_validator in &flat_validators {
+                                    match amounts1.write().unwrap().entry(flat_validator.clone()) {
+                                        Entry::Occupied(_) => {
+                                            continue;
+                                        }
+                                        Entry::Vacant(entry) => {
+                                            println!(
+                                                "VALIDATOR = {:?}, ENTRY = {:?}",
+                                                flat_validator, entry
+                                            );
+                                            assert!(false);
+                                        }
+                                    };
+                                }
+                                System::current().stop();
+                            }
+                        }
+                        if let NetworkRequests::PartialEncodedChunkMessage {
+                            partial_encoded_chunk,
+                            ..
+                        } = msg
+                        {
+                            if partial_encoded_chunk.header.height_created() == 22 {
+                                seen_heights_same_block
+                                    .insert(partial_encoded_chunk.header.prev_block_hash().clone());
+                            }
+                            if skip_15 {
+                                if partial_encoded_chunk.header.height_created() == 14
+                                    || partial_encoded_chunk.header.height_created() == 15
+                                {
                                     return (NetworkResponses::NoResponse.into(), false);
                                 }
-                                assert!(block.header().height() >= 2);
-                                assert!(block.header().height() <= height);
-                                let mut tx_count = 0;
-                                if block.header().height() == height && block.header().height() >= 2
-                                {
-                                    for (i, validator1) in flat_validators.iter().enumerate() {
-                                        for (j, validator2) in flat_validators.iter().enumerate() {
-                                            let mut amount =
-                                                (((i + j + 17) * 701) % 42 + 1) as u128;
-                                            if non_zero {
-                                                if i > j {
-                                                    amount = 2;
-                                                } else {
-                                                    amount = 1;
-                                                }
-                                            }
-                                            println!(
-                                                "VALUES {:?} {:?} {:?}",
-                                                validator1.to_string(),
-                                                validator2.to_string(),
-                                                amount
-                                            );
-                                            for conn in 0..flat_validators.len() {
-                                                send_tx(
-                                                    &connectors1.write().unwrap()[conn].0,
-                                                    validator1.clone(),
-                                                    validator2.clone(),
-                                                    amount,
-                                                    (12345 + tx_count) as u64,
-                                                    *block.header().prev_hash(),
-                                                );
-                                            }
-                                            tx_count += 1;
-                                        }
-                                    }
-                                    *phase = RandomSinglePartPhases::WaitingForSixEpoch;
-                                    assert_eq!(tx_count, 16 * 16);
-                                }
                             }
                         }
-                        RandomSinglePartPhases::WaitingForSixEpoch => {
-                            if let NetworkRequests::Block { block } = msg {
-                                assert!(block.header().height() >= height);
-                                assert!(block.header().height() <= 32);
-                                let check_height = if skip_15 { 28 } else { 26 };
-                                if block.header().height() >= check_height {
-                                    println!("BLOCK HEIGHT {:?}", block.header().height());
-                                    for i in 0..16 {
-                                        for j in 0..16 {
-                                            let amounts1 = amounts.clone();
-                                            let validator = flat_validators[j].clone();
-                                            actix::spawn(
-                                                connectors1.write().unwrap()[i]
-                                                    .1
-                                                    .send(Query::new(
-                                                        BlockReference::latest(),
-                                                        QueryRequest::ViewAccount {
-                                                            account_id: flat_validators[j].clone(),
-                                                        },
-                                                    ))
-                                                    .then(move |res| {
-                                                        let res_inner = res.unwrap();
-                                                        if let Ok(query_response) = res_inner {
-                                                            if let ViewAccount(
-                                                                view_account_result,
-                                                            ) = query_response.kind
-                                                            {
-                                                                check_amount(
-                                                                    amounts1,
-                                                                    validator,
-                                                                    view_account_result.amount,
-                                                                );
-                                                            }
-                                                        }
-                                                        future::ready(())
-                                                    }),
-                                            );
-                                        }
-                                    }
-                                }
-                                if block.header().height() == 32 {
-                                    println!(
-                                        "SEEN HEIGHTS SAME BLOCK {:?}",
-                                        seen_heights_same_block.len()
-                                    );
-                                    assert_eq!(seen_heights_same_block.len(), 1);
-                                    let amounts1 = amounts.clone();
-                                    for flat_validator in &flat_validators {
-                                        match amounts1
-                                            .write()
-                                            .unwrap()
-                                            .entry(flat_validator.clone())
-                                        {
-                                            Entry::Occupied(_) => {
-                                                continue;
-                                            }
-                                            Entry::Vacant(entry) => {
-                                                println!(
-                                                    "VALIDATOR = {:?}, ENTRY = {:?}",
-                                                    flat_validator, entry
-                                                );
-                                                assert!(false);
-                                            }
-                                        };
-                                    }
-                                    System::current().stop();
-                                }
-                            }
-                            if let NetworkRequests::PartialEncodedChunkMessage {
-                                partial_encoded_chunk,
-                                ..
-                            } = msg
-                            {
-                                if partial_encoded_chunk.header.height_created() == 22 {
-                                    seen_heights_same_block.insert(
-                                        partial_encoded_chunk.header.prev_block_hash().clone(),
-                                    );
-                                }
-                                if skip_15 {
-                                    if partial_encoded_chunk.header.height_created() == 14
-                                        || partial_encoded_chunk.header.height_created() == 15
-                                    {
-                                        return (NetworkResponses::NoResponse.into(), false);
-                                    }
-                                }
-                            }
-                        }
-                    };
-                    (NetworkResponses::NoResponse.into(), true)
-                },
-            ))),
+                    }
+                };
+                (NetworkResponses::NoResponse.into(), true)
+            }),
         );
         *connectors.write().unwrap() = conn;
 
@@ -656,31 +640,29 @@ fn test_catchup_sanity_blocks_produced() {
             vec![false; validators.iter().map(|x| x.len()).sum()],
             vec![true; validators.iter().map(|x| x.len()).sum()],
             false,
-            Arc::new(RwLock::new(Box::new(
-                move |_, _account_id: _, msg: &PeerManagerMessageRequest| {
-                    let msg = msg.as_network_requests_ref();
-                    let propagate = if let NetworkRequests::Block { block } = msg {
-                        check_height(*block.hash(), block.header().height());
+            Box::new(move |_, _account_id: _, msg: &PeerManagerMessageRequest| {
+                let msg = msg.as_network_requests_ref();
+                let propagate = if let NetworkRequests::Block { block } = msg {
+                    check_height(*block.hash(), block.header().height());
 
-                        if block.header().height() % 10 == 5 {
-                            check_height(*block.header().prev_hash(), block.header().height() - 2);
-                        } else {
-                            check_height(*block.header().prev_hash(), block.header().height() - 1);
-                        }
-
-                        if block.header().height() >= 25 {
-                            System::current().stop();
-                        }
-
-                        // Do not propagate blocks at heights %10=4
-                        block.header().height() % 10 != 4
+                    if block.header().height() % 10 == 5 {
+                        check_height(*block.header().prev_hash(), block.header().height() - 2);
                     } else {
-                        true
-                    };
+                        check_height(*block.header().prev_hash(), block.header().height() - 1);
+                    }
 
-                    (NetworkResponses::NoResponse.into(), propagate)
-                },
-            ))),
+                    if block.header().height() >= 25 {
+                        System::current().stop();
+                    }
+
+                    // Do not propagate blocks at heights %10=4
+                    block.header().height() % 10 != 4
+                } else {
+                    true
+                };
+
+                (NetworkResponses::NoResponse.into(), propagate)
+            }),
         );
         *connectors.write().unwrap() = conn;
 
@@ -727,115 +709,111 @@ fn test_chunk_grieving() {
             vec![false; validators.iter().map(|x| x.len()).sum()],
             vec![true; validators.iter().map(|x| x.len()).sum()],
             false,
-            Arc::new(RwLock::new(Box::new(
-                move |_, sender_account_id: AccountId, msg: &PeerManagerMessageRequest| {
-                    let msg = msg.as_network_requests_ref();
-                    let mut grieving_chunk_hash = grieving_chunk_hash.write().unwrap();
-                    let mut unaccepted_block_hash = unaccepted_block_hash.write().unwrap();
-                    let mut phase = phase.write().unwrap();
-                    match *phase {
-                        ChunkGrievingPhases::FirstAttack => {
-                            if let NetworkRequests::PartialEncodedChunkMessage {
-                                partial_encoded_chunk,
-                                account_id,
-                            } = msg
-                            {
-                                let height = partial_encoded_chunk.header.height_created();
-                                let shard_id = partial_encoded_chunk.header.shard_id();
-                                if height == 12 && shard_id == 0 {
-                                    // "test3.6" is the chunk producer on height 12, shard_id 0
-                                    assert_eq!(sender_account_id, malicious_node);
-                                    println!(
-                                        "ACCOUNT {:?} PARTS {:?} CHUNK {:?}",
-                                        account_id,
-                                        partial_encoded_chunk.parts.len(),
-                                        partial_encoded_chunk
-                                    );
-                                    if account_id == &victim_node {
-                                        // "test3.5" is a block producer of block on height 12, sending to it
-                                        *grieving_chunk_hash =
-                                            partial_encoded_chunk.header.chunk_hash();
-                                    } else {
-                                        return (NetworkResponses::NoResponse.into(), false);
-                                    }
-                                }
-                            }
-                            if let NetworkRequests::Block { block } = msg {
-                                if block.header().height() == 12 {
-                                    println!("BLOCK {:?}", block);
-                                    *unaccepted_block_hash = *block.header().hash();
-                                    assert_eq!(4, block.header().chunks_included());
-                                    *phase = ChunkGrievingPhases::SecondAttack;
+            Box::new(move |_, sender_account_id: AccountId, msg: &PeerManagerMessageRequest| {
+                let msg = msg.as_network_requests_ref();
+                let mut grieving_chunk_hash = grieving_chunk_hash.write().unwrap();
+                let mut unaccepted_block_hash = unaccepted_block_hash.write().unwrap();
+                let mut phase = phase.write().unwrap();
+                match *phase {
+                    ChunkGrievingPhases::FirstAttack => {
+                        if let NetworkRequests::PartialEncodedChunkMessage {
+                            partial_encoded_chunk,
+                            account_id,
+                        } = msg
+                        {
+                            let height = partial_encoded_chunk.header.height_created();
+                            let shard_id = partial_encoded_chunk.header.shard_id();
+                            if height == 12 && shard_id == 0 {
+                                // "test3.6" is the chunk producer on height 12, shard_id 0
+                                assert_eq!(sender_account_id, malicious_node);
+                                println!(
+                                    "ACCOUNT {:?} PARTS {:?} CHUNK {:?}",
+                                    account_id,
+                                    partial_encoded_chunk.parts.len(),
+                                    partial_encoded_chunk
+                                );
+                                if account_id == &victim_node {
+                                    // "test3.5" is a block producer of block on height 12, sending to it
+                                    *grieving_chunk_hash =
+                                        partial_encoded_chunk.header.chunk_hash();
+                                } else {
+                                    return (NetworkResponses::NoResponse.into(), false);
                                 }
                             }
                         }
-                        ChunkGrievingPhases::SecondAttack => {
-                            if let NetworkRequests::PartialEncodedChunkRequest {
-                                request,
-                                target:
-                                    AccountIdOrPeerTrackingShard {
-                                        account_id: Some(account_id), ..
-                                    },
-                                ..
-                            } = msg
-                            {
-                                if request.chunk_hash == *grieving_chunk_hash {
-                                    if account_id == &malicious_node {
-                                        // holding grieving_chunk_hash by malicious node
-                                        return (NetworkResponses::NoResponse.into(), false);
-                                    }
-                                }
-                            } else if let NetworkRequests::PartialEncodedChunkRequest { .. } = msg {
-                                // this test was written before the feature that allows
-                                // sending requests directly to the peer. The test likely never
-                                // triggers this path, but if this assert triggers, the above
-                                // `if let` needs to be extended to block messages sent to the
-                                // malicious node directly via the peer id
-                                assert!(false);
-                            }
-                            if let NetworkRequests::PartialEncodedChunkResponse {
-                                route_back: _,
-                                response,
-                            } = msg
-                            {
-                                if response.chunk_hash == *grieving_chunk_hash {
-                                    // Only victim_node knows some parts of grieving_chunk_hash
-                                    // It's not enough to restore the chunk completely
-                                    assert_eq!(sender_account_id, victim_node);
-                                }
-                            }
-                            if let NetworkRequests::PartialEncodedChunkMessage {
-                                partial_encoded_chunk,
-                                account_id,
-                            } = msg
-                            {
-                                let height = partial_encoded_chunk.header.height_created();
-                                let shard_id = partial_encoded_chunk.header.shard_id();
-                                if height == 42 && shard_id == 2 {
-                                    // "test3.6" is the chunk producer on height 42, shard_id 2
-                                    assert_eq!(sender_account_id, malicious_node);
-                                    println!(
-                                        "ACCOUNT {:?} PARTS {:?} CHUNK {:?}",
-                                        account_id,
-                                        partial_encoded_chunk.parts.len(),
-                                        partial_encoded_chunk
-                                    );
-                                }
-                            }
-                            if let NetworkRequests::Block { block } = msg {
-                                if block.header().height() == 42 {
-                                    println!("BLOCK {:?}", block,);
-                                    // This is the main assert of the test
-                                    // Chunk from malicious node shouldn't be accepted at all
-                                    assert_eq!(3, block.header().chunks_included());
-                                    System::current().stop();
-                                }
+                        if let NetworkRequests::Block { block } = msg {
+                            if block.header().height() == 12 {
+                                println!("BLOCK {:?}", block);
+                                *unaccepted_block_hash = *block.header().hash();
+                                assert_eq!(4, block.header().chunks_included());
+                                *phase = ChunkGrievingPhases::SecondAttack;
                             }
                         }
-                    };
-                    (NetworkResponses::NoResponse.into(), true)
-                },
-            ))),
+                    }
+                    ChunkGrievingPhases::SecondAttack => {
+                        if let NetworkRequests::PartialEncodedChunkRequest {
+                            request,
+                            target:
+                                AccountIdOrPeerTrackingShard { account_id: Some(account_id), .. },
+                            ..
+                        } = msg
+                        {
+                            if request.chunk_hash == *grieving_chunk_hash {
+                                if account_id == &malicious_node {
+                                    // holding grieving_chunk_hash by malicious node
+                                    return (NetworkResponses::NoResponse.into(), false);
+                                }
+                            }
+                        } else if let NetworkRequests::PartialEncodedChunkRequest { .. } = msg {
+                            // this test was written before the feature that allows
+                            // sending requests directly to the peer. The test likely never
+                            // triggers this path, but if this assert triggers, the above
+                            // `if let` needs to be extended to block messages sent to the
+                            // malicious node directly via the peer id
+                            assert!(false);
+                        }
+                        if let NetworkRequests::PartialEncodedChunkResponse {
+                            route_back: _,
+                            response,
+                        } = msg
+                        {
+                            if response.chunk_hash == *grieving_chunk_hash {
+                                // Only victim_node knows some parts of grieving_chunk_hash
+                                // It's not enough to restore the chunk completely
+                                assert_eq!(sender_account_id, victim_node);
+                            }
+                        }
+                        if let NetworkRequests::PartialEncodedChunkMessage {
+                            partial_encoded_chunk,
+                            account_id,
+                        } = msg
+                        {
+                            let height = partial_encoded_chunk.header.height_created();
+                            let shard_id = partial_encoded_chunk.header.shard_id();
+                            if height == 42 && shard_id == 2 {
+                                // "test3.6" is the chunk producer on height 42, shard_id 2
+                                assert_eq!(sender_account_id, malicious_node);
+                                println!(
+                                    "ACCOUNT {:?} PARTS {:?} CHUNK {:?}",
+                                    account_id,
+                                    partial_encoded_chunk.parts.len(),
+                                    partial_encoded_chunk
+                                );
+                            }
+                        }
+                        if let NetworkRequests::Block { block } = msg {
+                            if block.header().height() == 42 {
+                                println!("BLOCK {:?}", block,);
+                                // This is the main assert of the test
+                                // Chunk from malicious node shouldn't be accepted at all
+                                assert_eq!(3, block.header().chunks_included());
+                                System::current().stop();
+                            }
+                        }
+                    }
+                };
+                (NetworkResponses::NoResponse.into(), true)
+            }),
         );
         *connectors.write().unwrap() = conn;
         let max_wait_ms = 240000;
@@ -894,87 +872,83 @@ fn test_all_chunks_accepted_common(
             vec![false; validators.iter().map(|x| x.len()).sum()],
             vec![true; validators.iter().map(|x| x.len()).sum()],
             false,
-            Arc::new(RwLock::new(Box::new(
-                move |_, sender_account_id: AccountId, msg: &PeerManagerMessageRequest| {
-                    let msg = msg.as_network_requests_ref();
-                    let mut seen_chunk_same_sender = seen_chunk_same_sender.write().unwrap();
-                    let mut requested = requested.write().unwrap();
-                    let mut responded = responded.write().unwrap();
-                    if let NetworkRequests::PartialEncodedChunkMessage {
-                        account_id,
-                        partial_encoded_chunk,
-                    } = msg
-                    {
-                        let header = &partial_encoded_chunk.header;
-                        if seen_chunk_same_sender.contains(&(
-                            account_id.clone(),
-                            header.height_created(),
-                            header.shard_id(),
+            Box::new(move |_, sender_account_id: AccountId, msg: &PeerManagerMessageRequest| {
+                let msg = msg.as_network_requests_ref();
+                let mut seen_chunk_same_sender = seen_chunk_same_sender.write().unwrap();
+                let mut requested = requested.write().unwrap();
+                let mut responded = responded.write().unwrap();
+                if let NetworkRequests::PartialEncodedChunkMessage {
+                    account_id,
+                    partial_encoded_chunk,
+                } = msg
+                {
+                    let header = &partial_encoded_chunk.header;
+                    if seen_chunk_same_sender.contains(&(
+                        account_id.clone(),
+                        header.height_created(),
+                        header.shard_id(),
+                    )) {
+                        println!("=== SAME CHUNK AGAIN!");
+                        assert!(false);
+                    };
+                    seen_chunk_same_sender.insert((
+                        account_id.clone(),
+                        header.height_created(),
+                        header.shard_id(),
+                    ));
+                }
+                if let NetworkRequests::PartialEncodedChunkRequest { request, .. } = msg {
+                    if verbose {
+                        if requested.contains(&(
+                            sender_account_id.clone(),
+                            request.part_ords.clone(),
+                            request.chunk_hash.clone(),
                         )) {
-                            println!("=== SAME CHUNK AGAIN!");
-                            assert!(false);
+                            println!("=== SAME REQUEST AGAIN!");
                         };
-                        seen_chunk_same_sender.insert((
-                            account_id.clone(),
-                            header.height_created(),
-                            header.shard_id(),
+                        requested.insert((
+                            sender_account_id,
+                            request.part_ords.clone(),
+                            request.chunk_hash.clone(),
                         ));
                     }
-                    if let NetworkRequests::PartialEncodedChunkRequest { request, .. } = msg {
-                        if verbose {
-                            if requested.contains(&(
-                                sender_account_id.clone(),
-                                request.part_ords.clone(),
-                                request.chunk_hash.clone(),
-                            )) {
-                                println!("=== SAME REQUEST AGAIN!");
-                            };
-                            requested.insert((
-                                sender_account_id,
-                                request.part_ords.clone(),
-                                request.chunk_hash.clone(),
-                            ));
+                }
+                if let NetworkRequests::PartialEncodedChunkResponse { route_back, response } = msg {
+                    if verbose {
+                        if responded.contains(&(
+                            route_back.clone(),
+                            response.parts.iter().map(|x| x.part_ord).collect(),
+                            response.chunk_hash.clone(),
+                        )) {
+                            println!("=== SAME RESPONSE AGAIN!");
                         }
+                        responded.insert((
+                            route_back.clone(),
+                            response.parts.iter().map(|x| x.part_ord).collect(),
+                            response.chunk_hash.clone(),
+                        ));
                     }
-                    if let NetworkRequests::PartialEncodedChunkResponse { route_back, response } =
-                        msg
-                    {
-                        if verbose {
-                            if responded.contains(&(
-                                route_back.clone(),
-                                response.parts.iter().map(|x| x.part_ord).collect(),
-                                response.chunk_hash.clone(),
-                            )) {
-                                println!("=== SAME RESPONSE AGAIN!");
-                            }
-                            responded.insert((
-                                route_back.clone(),
-                                response.parts.iter().map(|x| x.part_ord).collect(),
-                                response.chunk_hash.clone(),
-                            ));
-                        }
-                    }
-                    if let NetworkRequests::Block { block } = msg {
-                        // There is no chunks at height 1
-                        if block.header().height() > 1 {
-                            if block.header().height() % epoch_length != 1 {
-                                if block.header().chunks_included() != 4 {
-                                    println!(
-                                        "BLOCK WITH {:?} CHUNKS, {:?}",
-                                        block.header().chunks_included(),
-                                        block
-                                    );
-                                    assert!(false);
-                                }
-                            }
-                            if block.header().height() == last_height {
-                                System::current().stop();
+                }
+                if let NetworkRequests::Block { block } = msg {
+                    // There is no chunks at height 1
+                    if block.header().height() > 1 {
+                        if block.header().height() % epoch_length != 1 {
+                            if block.header().chunks_included() != 4 {
+                                println!(
+                                    "BLOCK WITH {:?} CHUNKS, {:?}",
+                                    block.header().chunks_included(),
+                                    block
+                                );
+                                assert!(false);
                             }
                         }
+                        if block.header().height() == last_height {
+                            System::current().stop();
+                        }
                     }
-                    (NetworkResponses::NoResponse.into(), true)
-                },
-            ))),
+                }
+                (NetworkResponses::NoResponse.into(), true)
+            }),
         );
         *connectors.write().unwrap() = conn;
         let max_wait_ms = block_prod_time * last_height / 10 * 18 + 20000;

--- a/chain/client/src/tests/consensus.rs
+++ b/chain/client/src/tests/consensus.rs
@@ -77,208 +77,202 @@ fn test_consensus_with_epoch_switches() {
             vec![true; validators.iter().map(|x| x.len()).sum()],
             vec![false; validators.iter().map(|x| x.len()).sum()],
             false,
-            Arc::new(RwLock::new(Box::new(
-                move |_, from_whom: AccountId, msg: &PeerManagerMessageRequest| {
-                    let mut all_blocks: RwLockWriteGuard<BTreeMap<BlockHeight, Block>> =
-                        all_blocks.write().unwrap();
-                    let mut final_block_heights = final_block_heights.write().unwrap();
-                    let mut block_to_height = block_to_height.write().unwrap();
-                    let mut block_to_prev_block = block_to_prev_block.write().unwrap();
-                    let mut largest_target_height = largest_target_height.write().unwrap();
-                    let mut skips_per_height = skips_per_height.write().unwrap();
-                    let mut largest_block_height = largest_block_height.write().unwrap();
+            Box::new(move |_, from_whom: AccountId, msg: &PeerManagerMessageRequest| {
+                let mut all_blocks: RwLockWriteGuard<BTreeMap<BlockHeight, Block>> =
+                    all_blocks.write().unwrap();
+                let mut final_block_heights = final_block_heights.write().unwrap();
+                let mut block_to_height = block_to_height.write().unwrap();
+                let mut block_to_prev_block = block_to_prev_block.write().unwrap();
+                let mut largest_target_height = largest_target_height.write().unwrap();
+                let mut skips_per_height = skips_per_height.write().unwrap();
+                let mut largest_block_height = largest_block_height.write().unwrap();
 
-                    let mut delayed_blocks = delayed_blocks.write().unwrap();
+                let mut delayed_blocks = delayed_blocks.write().unwrap();
 
-                    match msg.as_network_requests_ref() {
-                        NetworkRequests::Block { block } => {
-                            if !all_blocks.contains_key(&block.header().height()) {
-                                println!(
-                                    "BLOCK @{} EPOCH: {:?}, APPROVALS: {:?}",
-                                    block.header().height(),
-                                    block.header().epoch_id(),
-                                    block
-                                        .header()
-                                        .approvals()
-                                        .iter()
-                                        .map(|x| if x.is_some() { 1 } else { 0 })
-                                        .collect::<Vec<_>>()
-                                );
-                            }
-                            all_blocks.insert(block.header().height(), block.clone());
-                            block_to_prev_block.insert(*block.hash(), *block.header().prev_hash());
-                            block_to_height.insert(*block.hash(), block.header().height());
+                match msg.as_network_requests_ref() {
+                    NetworkRequests::Block { block } => {
+                        if !all_blocks.contains_key(&block.header().height()) {
+                            println!(
+                                "BLOCK @{} EPOCH: {:?}, APPROVALS: {:?}",
+                                block.header().height(),
+                                block.header().epoch_id(),
+                                block
+                                    .header()
+                                    .approvals()
+                                    .iter()
+                                    .map(|x| if x.is_some() { 1 } else { 0 })
+                                    .collect::<Vec<_>>()
+                            );
+                        }
+                        all_blocks.insert(block.header().height(), block.clone());
+                        block_to_prev_block.insert(*block.hash(), *block.header().prev_hash());
+                        block_to_height.insert(*block.hash(), block.header().height());
 
-                            if *largest_block_height / 20 < block.header().height() / 20 {
-                                // Periodically verify the finality
-                                println!("VERIFYING FINALITY CONDITIONS");
-                                for block in all_blocks.values() {
-                                    if let Some(prev_hash) = block_to_prev_block.get(&block.hash())
-                                    {
-                                        if let Some(prev_height) = block_to_height.get(prev_hash) {
-                                            let cur_height = block.header().height();
-                                            for f in final_block_heights.iter() {
-                                                if f < &cur_height && f > prev_height {
-                                                    assert!(
-                                                        false,
-                                                        "{} < {} < {}",
-                                                        prev_height, f, cur_height
-                                                    );
-                                                }
+                        if *largest_block_height / 20 < block.header().height() / 20 {
+                            // Periodically verify the finality
+                            println!("VERIFYING FINALITY CONDITIONS");
+                            for block in all_blocks.values() {
+                                if let Some(prev_hash) = block_to_prev_block.get(&block.hash()) {
+                                    if let Some(prev_height) = block_to_height.get(prev_hash) {
+                                        let cur_height = block.header().height();
+                                        for f in final_block_heights.iter() {
+                                            if f < &cur_height && f > prev_height {
+                                                assert!(
+                                                    false,
+                                                    "{} < {} < {}",
+                                                    prev_height, f, cur_height
+                                                );
                                             }
                                         }
                                     }
                                 }
-
-                                if *largest_block_height >= HEIGHT_GOAL {
-                                    System::current().stop();
-                                }
                             }
 
-                            if block.header().height() > *largest_block_height + 3 {
-                                *largest_block_height = block.header().height();
-                                if delayed_blocks.len() < 2 {
-                                    delayed_blocks.push(block.clone());
-                                    return (NetworkResponses::NoResponse.into(), false);
-                                }
-                            }
-                            *largest_block_height =
-                                std::cmp::max(block.header().height(), *largest_block_height);
-
-                            let mut new_delayed_blocks = vec![];
-                            for delayed_block in delayed_blocks.iter() {
-                                if delayed_block.hash() == block.hash() {
-                                    return (NetworkResponses::NoResponse.into(), false);
-                                }
-                                if delayed_block.header().height() <= block.header().height() + 2 {
-                                    for target_ord in 0..24 {
-                                        connectors1.write().unwrap()[target_ord].0.do_send(
-                                            NetworkClientMessages::Block(
-                                                delayed_block.clone(),
-                                                key_pairs[0].clone().id,
-                                                true,
-                                            ),
-                                        );
-                                    }
-                                } else {
-                                    new_delayed_blocks.push(delayed_block.clone())
-                                }
-                            }
-                            *delayed_blocks = new_delayed_blocks;
-
-                            let mut heights = vec![];
-                            let mut cur_hash = *block.hash();
-                            while let Some(height) = block_to_height.get(&cur_hash) {
-                                heights.push(height);
-                                cur_hash = block_to_prev_block.get(&cur_hash).unwrap().clone();
-                                if heights.len() > 10 {
-                                    break;
-                                }
-                            }
-                            // Use Doomslug finality, since without duplicate blocks at the same height
-                            // it also provides safety under 1/3 faults
-                            let is_final = heights.len() > 1 && heights[1] + 1 == *heights[0];
-                            println!(
-                                "IS_FINAL: {} DELAYED: ({:?}) BLOCK: {} HISTORY: {:?}",
-                                is_final,
-                                delayed_blocks
-                                    .iter()
-                                    .map(|x| x.header().height())
-                                    .collect::<Vec<_>>(),
-                                block.hash(),
-                                heights,
-                            );
-
-                            if is_final {
-                                final_block_heights.insert(*heights[1]);
+                            if *largest_block_height >= HEIGHT_GOAL {
+                                System::current().stop();
                             }
                         }
-                        NetworkRequests::Approval { approval_message } => {
-                            // Identify who we are, and whom we are sending this message to
-                            let mut epoch_id = 100;
-                            let mut destination_ord = 100;
-                            let mut my_ord = 100;
 
-                            for i in 0..validators.len() {
-                                for j in 0..validators[i].len() {
-                                    if validators[i][j] == approval_message.target {
-                                        epoch_id = i;
-                                        destination_ord = j;
-                                    }
-                                    if validators[i][j] == from_whom {
-                                        my_ord = i * 8 + j;
-                                    }
+                        if block.header().height() > *largest_block_height + 3 {
+                            *largest_block_height = block.header().height();
+                            if delayed_blocks.len() < 2 {
+                                delayed_blocks.push(block.clone());
+                                return (NetworkResponses::NoResponse.into(), false);
+                            }
+                        }
+                        *largest_block_height =
+                            std::cmp::max(block.header().height(), *largest_block_height);
+
+                        let mut new_delayed_blocks = vec![];
+                        for delayed_block in delayed_blocks.iter() {
+                            if delayed_block.hash() == block.hash() {
+                                return (NetworkResponses::NoResponse.into(), false);
+                            }
+                            if delayed_block.header().height() <= block.header().height() + 2 {
+                                for target_ord in 0..24 {
+                                    connectors1.write().unwrap()[target_ord].0.do_send(
+                                        NetworkClientMessages::Block(
+                                            delayed_block.clone(),
+                                            key_pairs[0].clone().id,
+                                            true,
+                                        ),
+                                    );
+                                }
+                            } else {
+                                new_delayed_blocks.push(delayed_block.clone())
+                            }
+                        }
+                        *delayed_blocks = new_delayed_blocks;
+
+                        let mut heights = vec![];
+                        let mut cur_hash = *block.hash();
+                        while let Some(height) = block_to_height.get(&cur_hash) {
+                            heights.push(height);
+                            cur_hash = block_to_prev_block.get(&cur_hash).unwrap().clone();
+                            if heights.len() > 10 {
+                                break;
+                            }
+                        }
+                        // Use Doomslug finality, since without duplicate blocks at the same height
+                        // it also provides safety under 1/3 faults
+                        let is_final = heights.len() > 1 && heights[1] + 1 == *heights[0];
+                        println!(
+                            "IS_FINAL: {} DELAYED: ({:?}) BLOCK: {} HISTORY: {:?}",
+                            is_final,
+                            delayed_blocks.iter().map(|x| x.header().height()).collect::<Vec<_>>(),
+                            block.hash(),
+                            heights,
+                        );
+
+                        if is_final {
+                            final_block_heights.insert(*heights[1]);
+                        }
+                    }
+                    NetworkRequests::Approval { approval_message } => {
+                        // Identify who we are, and whom we are sending this message to
+                        let mut epoch_id = 100;
+                        let mut destination_ord = 100;
+                        let mut my_ord = 100;
+
+                        for i in 0..validators.len() {
+                            for j in 0..validators[i].len() {
+                                if validators[i][j] == approval_message.target {
+                                    epoch_id = i;
+                                    destination_ord = j;
+                                }
+                                if validators[i][j] == from_whom {
+                                    my_ord = i * 8 + j;
                                 }
                             }
-                            assert_ne!(epoch_id, 100);
-                            assert_ne!(my_ord, 100);
+                        }
+                        assert_ne!(epoch_id, 100);
+                        assert_ne!(my_ord, 100);
 
-                            // For each height we define `skips_per_height`, and each block producer sends
-                            // skips that far into the future from that source height.
-                            let source_height = match approval_message.approval.inner {
-                                ApprovalInner::Endorsement(_) => {
-                                    if largest_target_height[my_ord]
-                                        >= approval_message.approval.target_height
-                                        && my_ord % 8 >= 2
-                                    {
-                                        // We already manually sent a skip conflicting with this endorsement
-                                        // my_ord % 8 < 2 are two malicious actors in every epoch and they
-                                        // continue sending endorsements
-                                        return (NetworkResponses::NoResponse.into(), false);
-                                    }
-
-                                    approval_message.approval.target_height - 1
+                        // For each height we define `skips_per_height`, and each block producer sends
+                        // skips that far into the future from that source height.
+                        let source_height = match approval_message.approval.inner {
+                            ApprovalInner::Endorsement(_) => {
+                                if largest_target_height[my_ord]
+                                    >= approval_message.approval.target_height
+                                    && my_ord % 8 >= 2
+                                {
+                                    // We already manually sent a skip conflicting with this endorsement
+                                    // my_ord % 8 < 2 are two malicious actors in every epoch and they
+                                    // continue sending endorsements
+                                    return (NetworkResponses::NoResponse.into(), false);
                                 }
-                                ApprovalInner::Skip(source_height) => source_height,
+
+                                approval_message.approval.target_height - 1
+                            }
+                            ApprovalInner::Skip(source_height) => source_height,
+                        };
+
+                        while source_height as usize >= skips_per_height.len() {
+                            skips_per_height.push(if thread_rng().gen_bool(0.8) {
+                                0
+                            } else {
+                                thread_rng().gen_range(2, 9)
+                            });
+                        }
+                        if skips_per_height[source_height as usize] > 0
+                            && approval_message.approval.target_height - source_height == 1
+                        {
+                            let delta = skips_per_height[source_height as usize];
+                            let approval = Approval {
+                                target_height: approval_message.approval.target_height
+                                    + delta as u64,
+                                inner: ApprovalInner::Skip(source_height),
+                                ..approval_message.approval.clone()
                             };
-
-                            while source_height as usize >= skips_per_height.len() {
-                                skips_per_height.push(if thread_rng().gen_bool(0.8) {
-                                    0
-                                } else {
-                                    thread_rng().gen_range(2, 9)
-                                });
-                            }
-                            if skips_per_height[source_height as usize] > 0
-                                && approval_message.approval.target_height - source_height == 1
-                            {
-                                let delta = skips_per_height[source_height as usize];
-                                let approval = Approval {
-                                    target_height: approval_message.approval.target_height
-                                        + delta as u64,
-                                    inner: ApprovalInner::Skip(source_height),
-                                    ..approval_message.approval.clone()
-                                };
-                                largest_target_height[my_ord] = std::cmp::max(
-                                    largest_target_height[my_ord],
-                                    approval.target_height as u64,
-                                );
-                                connectors1.write().unwrap()
-                                    [epoch_id * 8 + (destination_ord + delta) % 8]
-                                    .0
-                                    .do_send(NetworkClientMessages::BlockApproval(
-                                        approval,
-                                        key_pairs[my_ord].id.clone(),
-                                    ));
-                                // Do not send the endorsement for couple block producers in each epoch
-                                // This is needed because otherwise the block with enough endorsements
-                                // sometimes comes faster than the sufficient number of skips is created,
-                                // (because the block producer themselves doesn't send the endorsement
-                                // over the network, they have one more approval ready to produce their
-                                // block than the block producer that will be at the later height). If
-                                // such a block is indeed produced faster than all the skips are created,
-                                // the paritcipants who haven't sent their endorsements to be converted
-                                // to skips change their head.
-                                if my_ord % 8 < 2 {
-                                    return (NetworkResponses::NoResponse.into(), false);
-                                }
+                            largest_target_height[my_ord] = std::cmp::max(
+                                largest_target_height[my_ord],
+                                approval.target_height as u64,
+                            );
+                            connectors1.write().unwrap()
+                                [epoch_id * 8 + (destination_ord + delta) % 8]
+                                .0
+                                .do_send(NetworkClientMessages::BlockApproval(
+                                    approval,
+                                    key_pairs[my_ord].id.clone(),
+                                ));
+                            // Do not send the endorsement for couple block producers in each epoch
+                            // This is needed because otherwise the block with enough endorsements
+                            // sometimes comes faster than the sufficient number of skips is created,
+                            // (because the block producer themselves doesn't send the endorsement
+                            // over the network, they have one more approval ready to produce their
+                            // block than the block producer that will be at the later height). If
+                            // such a block is indeed produced faster than all the skips are created,
+                            // the paritcipants who haven't sent their endorsements to be converted
+                            // to skips change their head.
+                            if my_ord % 8 < 2 {
+                                return (NetworkResponses::NoResponse.into(), false);
                             }
                         }
-                        _ => {}
-                    };
-                    (NetworkResponses::NoResponse.into(), true)
-                },
-            ))),
+                    }
+                    _ => {}
+                };
+                (NetworkResponses::NoResponse.into(), true)
+            }),
         );
         *connectors.write().unwrap() = conn;
 

--- a/chain/client/src/tests/consensus.rs
+++ b/chain/client/src/tests/consensus.rs
@@ -78,7 +78,7 @@ fn test_consensus_with_epoch_switches() {
             vec![false; validators.iter().map(|x| x.len()).sum()],
             false,
             Arc::new(RwLock::new(Box::new(
-                move |from_whom: AccountId, msg: &PeerManagerMessageRequest| {
+                move |_, from_whom: AccountId, msg: &PeerManagerMessageRequest| {
                     let mut all_blocks: RwLockWriteGuard<BTreeMap<BlockHeight, Block>> =
                         all_blocks.write().unwrap();
                     let mut final_block_heights = final_block_heights.write().unwrap();

--- a/chain/client/src/tests/cross_shard_tx.rs
+++ b/chain/client/src/tests/cross_shard_tx.rs
@@ -58,7 +58,7 @@ fn test_keyvalue_runtime_balances() {
             vec![true; validators.iter().map(|x| x.len()).sum()],
             false,
             Arc::new(RwLock::new(Box::new(
-                move |_account_id: _, _msg: &PeerManagerMessageRequest| {
+                move |_, _account_id: _, _msg: &PeerManagerMessageRequest| {
                     (NetworkResponses::NoResponse.into(), true)
                 },
             ))),
@@ -437,7 +437,7 @@ fn test_cross_shard_tx_common(
             vec![false; validators.iter().map(|x| x.len()).sum()],
             true,
             Arc::new(RwLock::new(Box::new(
-                move |_account_id: _, _msg: &PeerManagerMessageRequest| {
+                move |_, _account_id: _, _msg: &PeerManagerMessageRequest| {
                     (
                         PeerManagerMessageResponse::NetworkResponses(NetworkResponses::NoResponse),
                         true,

--- a/chain/client/src/tests/cross_shard_tx.rs
+++ b/chain/client/src/tests/cross_shard_tx.rs
@@ -57,11 +57,9 @@ fn test_keyvalue_runtime_balances() {
             vec![false; validators.iter().map(|x| x.len()).sum()],
             vec![true; validators.iter().map(|x| x.len()).sum()],
             false,
-            Arc::new(RwLock::new(Box::new(
-                move |_, _account_id: _, _msg: &PeerManagerMessageRequest| {
-                    (NetworkResponses::NoResponse.into(), true)
-                },
-            ))),
+            Box::new(move |_, _account_id: _, _msg: &PeerManagerMessageRequest| {
+                (NetworkResponses::NoResponse.into(), true)
+            }),
         );
         *connectors.write().unwrap() = conn;
 
@@ -436,14 +434,9 @@ fn test_cross_shard_tx_common(
             vec![true; validators.iter().map(|x| x.len()).sum()],
             vec![false; validators.iter().map(|x| x.len()).sum()],
             true,
-            Arc::new(RwLock::new(Box::new(
-                move |_, _account_id: _, _msg: &PeerManagerMessageRequest| {
-                    (
-                        PeerManagerMessageResponse::NetworkResponses(NetworkResponses::NoResponse),
-                        true,
-                    )
-                },
-            ))),
+            Box::new(move |_, _account_id: _, _msg: &PeerManagerMessageRequest| {
+                (PeerManagerMessageResponse::NetworkResponses(NetworkResponses::NoResponse), true)
+            }),
         );
         *connectors.write().unwrap() = conn;
         let block_hash = *genesis_block.hash();

--- a/chain/client/src/tests/query_client.rs
+++ b/chain/client/src/tests/query_client.rs
@@ -1,13 +1,13 @@
-use actix::{Addr, System};
+use actix::System;
 use futures::{future, FutureExt};
 use near_primitives::merkle::PartialMerkleTree;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::time::Duration;
 
 use crate::test_utils::{setup_mock_all_validators, setup_no_network, setup_only_view};
 use crate::{
-    ClientActor, GetBlock, GetBlockWithMerkleTree, GetExecutionOutcomesForBlock, Query, QueryError,
-    Status, TxStatus, ViewClientActor,
+    GetBlock, GetBlockWithMerkleTree, GetExecutionOutcomesForBlock, Query, QueryError, Status,
+    TxStatus,
 };
 use near_actix_test_utils::run_actix;
 use near_chain_configs::DEFAULT_GC_NUM_EPOCHS_TO_KEEP;
@@ -24,7 +24,7 @@ use near_network_primitives::types::{
 use near_primitives::block::{Block, BlockHeader};
 use near_primitives::time::Utc;
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::{AccountId, BlockId, BlockReference, EpochId};
+use near_primitives::types::{BlockId, BlockReference, EpochId};
 use near_primitives::utils::to_timestamp;
 use near_primitives::validator_signer::InMemoryValidatorSigner;
 use near_primitives::version::PROTOCOL_VERSION;
@@ -255,19 +255,6 @@ fn test_garbage_collection() {
         let block_prod_time = 100;
         let epoch_length = 5;
         let target_height = epoch_length * (DEFAULT_GC_NUM_EPOCHS_TO_KEEP + 1);
-        let network_mock: Arc<
-            RwLock<
-                Box<
-                    dyn FnMut(
-                        &[(Addr<ClientActor>, Addr<ViewClientActor>)],
-                        AccountId,
-                        &PeerManagerMessageRequest,
-                    ) -> (PeerManagerMessageResponse, bool),
-                >,
-            >,
-        > = Arc::new(RwLock::new(Box::new(|_, _, _: &PeerManagerMessageRequest| {
-            (NetworkResponses::NoResponse.into(), true)
-        })));
 
         setup_mock_all_validators(
             vec![vec!["test1".parse().unwrap(), "test2".parse().unwrap()]],
@@ -282,27 +269,66 @@ fn test_garbage_collection() {
             vec![false, true], // first validator non-archival, second archival
             vec![true, true],
             true,
-            network_mock.clone(),
-        );
+            Box::new(
+                move |conns,
+                      _,
+                      msg: &PeerManagerMessageRequest|
+                      -> (PeerManagerMessageResponse, bool) {
+                    if let NetworkRequests::Block { block } = msg.as_network_requests_ref() {
+                        if block.header().height() > target_height {
+                            let view_client_non_archival = &conns[0].1;
+                            let view_client_archival = &conns[1].1;
+                            let mut tests = vec![];
 
-        *network_mock.write().unwrap() = Box::new(
-            move |conns,
-                  _,
-                  msg: &PeerManagerMessageRequest|
-                  -> (PeerManagerMessageResponse, bool) {
-                if let NetworkRequests::Block { block } = msg.as_network_requests_ref() {
-                    if block.header().height() > target_height {
-                        let view_client_non_archival = &conns[0].1;
-                        let view_client_archival = &conns[1].1;
-                        let mut tests = vec![];
+                            // Recent data is present on all nodes (archival or not).
+                            let prev_height = block.header().prev_height().unwrap();
+                            for (_, view_client) in conns.iter() {
+                                tests.push(actix::spawn(
+                                    view_client
+                                        .send(Query::new(
+                                            BlockReference::BlockId(BlockId::Height(prev_height)),
+                                            QueryRequest::ViewAccount {
+                                                account_id: "test1".parse().unwrap(),
+                                            },
+                                        ))
+                                        .then(move |res| {
+                                            let res = res.unwrap().unwrap();
+                                            match res.kind {
+                                                QueryResponseKind::ViewAccount(_) => (),
+                                                _ => panic!("Invalid response"),
+                                            }
+                                            futures::future::ready(())
+                                        }),
+                                ));
+                            }
 
-                        // Recent data is present on all nodes (archival or not).
-                        let prev_height = block.header().prev_height().unwrap();
-                        for (_, view_client) in conns.iter() {
+                            // On non-archival node old data is garbage collected.
                             tests.push(actix::spawn(
-                                view_client
+                                view_client_non_archival
                                     .send(Query::new(
-                                        BlockReference::BlockId(BlockId::Height(prev_height)),
+                                        BlockReference::BlockId(BlockId::Height(1)),
+                                        QueryRequest::ViewAccount {
+                                            account_id: "test1".parse().unwrap(),
+                                        },
+                                    ))
+                                    .then(move |res| {
+                                        let res = res.unwrap();
+                                        match res {
+                                            Err(err) => assert!(matches!(
+                                                err,
+                                                QueryError::GarbageCollectedBlock { .. }
+                                            )),
+                                            Ok(_) => panic!("Unexpected Ok variant"),
+                                        }
+                                        futures::future::ready(())
+                                    }),
+                            ));
+
+                            // On archival node old data is _not_ garbage collected.
+                            tests.push(actix::spawn(
+                                view_client_archival
+                                    .send(Query::new(
+                                        BlockReference::BlockId(BlockId::Height(1)),
                                         QueryRequest::ViewAccount {
                                             account_id: "test1".parse().unwrap(),
                                         },
@@ -316,58 +342,18 @@ fn test_garbage_collection() {
                                         futures::future::ready(())
                                     }),
                             ));
+
+                            actix::spawn(futures::future::join_all(tests).then(|_| {
+                                System::current().stop();
+                                futures::future::ready(())
+                            }));
                         }
-
-                        // On non-archival node old data is garbage collected.
-                        tests.push(actix::spawn(
-                            view_client_non_archival
-                                .send(Query::new(
-                                    BlockReference::BlockId(BlockId::Height(1)),
-                                    QueryRequest::ViewAccount {
-                                        account_id: "test1".parse().unwrap(),
-                                    },
-                                ))
-                                .then(move |res| {
-                                    let res = res.unwrap();
-                                    match res {
-                                        Err(err) => assert!(matches!(
-                                            err,
-                                            QueryError::GarbageCollectedBlock { .. }
-                                        )),
-                                        Ok(_) => panic!("Unexpected Ok variant"),
-                                    }
-                                    futures::future::ready(())
-                                }),
-                        ));
-
-                        // On archival node old data is _not_ garbage collected.
-                        tests.push(actix::spawn(
-                            view_client_archival
-                                .send(Query::new(
-                                    BlockReference::BlockId(BlockId::Height(1)),
-                                    QueryRequest::ViewAccount {
-                                        account_id: "test1".parse().unwrap(),
-                                    },
-                                ))
-                                .then(move |res| {
-                                    let res = res.unwrap().unwrap();
-                                    match res.kind {
-                                        QueryResponseKind::ViewAccount(_) => (),
-                                        _ => panic!("Invalid response"),
-                                    }
-                                    futures::future::ready(())
-                                }),
-                        ));
-
-                        actix::spawn(futures::future::join_all(tests).then(|_| {
-                            System::current().stop();
-                            futures::future::ready(())
-                        }));
                     }
-                }
-                (NetworkResponses::NoResponse.into(), true)
-            },
+                    (NetworkResponses::NoResponse.into(), true)
+                },
+            ),
         );
+
         near_network::test_utils::wait_or_panic(block_prod_time * target_height * 2 + 2000);
     })
 }

--- a/chain/client/src/tests/query_client.rs
+++ b/chain/client/src/tests/query_client.rs
@@ -269,7 +269,7 @@ fn test_garbage_collection() {
             (NetworkResponses::NoResponse.into(), true)
         })));
 
-        let (_, conns, _) = setup_mock_all_validators(
+        setup_mock_all_validators(
             vec![vec!["test1".parse().unwrap(), "test2".parse().unwrap()]],
             vec![PeerInfo::random(), PeerInfo::random()],
             1,
@@ -286,7 +286,10 @@ fn test_garbage_collection() {
         );
 
         *network_mock.write().unwrap() = Box::new(
-            move |_, _, msg: &PeerManagerMessageRequest| -> (PeerManagerMessageResponse, bool) {
+            move |conns,
+                  _,
+                  msg: &PeerManagerMessageRequest|
+                  -> (PeerManagerMessageResponse, bool) {
                 if let NetworkRequests::Block { block } = msg.as_network_requests_ref() {
                     if block.header().height() > target_height {
                         let view_client_non_archival = &conns[0].1;

--- a/integration-tests/src/tests/client/chunks_management.rs
+++ b/integration-tests/src/tests/client/chunks_management.rs
@@ -83,7 +83,7 @@ fn chunks_produced_and_distributed_common(
         vec![true; validators.iter().map(|x| x.len()).sum()],
         false,
         Arc::new(RwLock::new(Box::new(
-            move |from_whom: AccountId, msg: &PeerManagerMessageRequest| {
+            move |_, from_whom: AccountId, msg: &PeerManagerMessageRequest| {
                 let msg = msg.as_network_requests_ref();
                 match msg {
                     NetworkRequests::Block { block } => {

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 
-use actix::{Addr, System};
+use actix::System;
 use assert_matches::assert_matches;
 use futures::{future, FutureExt};
 use near_primitives::config::VMConfig;
@@ -23,7 +23,7 @@ use near_chunks::{ChunkStatus, ShardsManager};
 use near_client::test_utils::{
     create_chunk_on_height, setup_client, setup_mock, setup_mock_all_validators, TestEnv,
 };
-use near_client::{Client, ClientActor, GetBlock, GetBlockWithMerkleTree, ViewClientActor};
+use near_client::{Client, GetBlock, GetBlockWithMerkleTree};
 use near_crypto::{InMemorySigner, KeyType, PublicKey, Signature, Signer};
 use near_logger_utils::{init_integration_logger, init_test_logger};
 use near_network::test_utils::{wait_or_panic, MockPeerManagerAdapter};
@@ -506,19 +506,6 @@ fn produce_block_with_approvals_arrived_early() {
     let block_holder: Arc<RwLock<Option<Block>>> = Arc::new(RwLock::new(None));
     run_actix(async move {
         let mut approval_counter = 0;
-        let network_mock: Arc<
-            RwLock<
-                Box<
-                    dyn FnMut(
-                        &[(Addr<ClientActor>, Addr<ViewClientActor>)],
-                        AccountId,
-                        &PeerManagerMessageRequest,
-                    ) -> (PeerManagerMessageResponse, bool),
-                >,
-            >,
-        > = Arc::new(RwLock::new(Box::new(|_, _, _: &PeerManagerMessageRequest| {
-            (PeerManagerMessageResponse::NetworkResponses(NetworkResponses::NoResponse), true)
-        })));
         setup_mock_all_validators(
             validators.clone(),
             key_pairs,
@@ -532,52 +519,51 @@ fn produce_block_with_approvals_arrived_early() {
             vec![false; validators.iter().map(|x| x.len()).sum()],
             vec![true; validators.iter().map(|x| x.len()).sum()],
             false,
-            network_mock.clone(),
-        );
-        *network_mock.write().unwrap() = Box::new(
-            move |conns,
-                  _,
-                  msg: &PeerManagerMessageRequest|
-                  -> (PeerManagerMessageResponse, bool) {
-                let msg = msg.as_network_requests_ref();
-                match msg {
-                    NetworkRequests::Block { block } => {
-                        if block.header().height() == 3 {
-                            for (i, (client, _)) in conns.iter().enumerate() {
-                                if i > 0 {
-                                    client.do_send(NetworkClientMessages::Block(
-                                        block.clone(),
-                                        PeerInfo::random().id,
-                                        false,
-                                    ))
+            Box::new(
+                move |conns,
+                      _,
+                      msg: &PeerManagerMessageRequest|
+                      -> (PeerManagerMessageResponse, bool) {
+                    let msg = msg.as_network_requests_ref();
+                    match msg {
+                        NetworkRequests::Block { block } => {
+                            if block.header().height() == 3 {
+                                for (i, (client, _)) in conns.iter().enumerate() {
+                                    if i > 0 {
+                                        client.do_send(NetworkClientMessages::Block(
+                                            block.clone(),
+                                            PeerInfo::random().id,
+                                            false,
+                                        ))
+                                    }
                                 }
+                                *block_holder.write().unwrap() = Some(block.clone());
+                                return (NetworkResponses::NoResponse.into(), false);
+                            } else if block.header().height() == 4 {
+                                System::current().stop();
                             }
-                            *block_holder.write().unwrap() = Some(block.clone());
-                            return (NetworkResponses::NoResponse.into(), false);
-                        } else if block.header().height() == 4 {
-                            System::current().stop();
+                            (NetworkResponses::NoResponse.into(), true)
                         }
-                        (NetworkResponses::NoResponse.into(), true)
+                        NetworkRequests::Approval { approval_message } => {
+                            if approval_message.target.as_ref() == "test1"
+                                && approval_message.approval.target_height == 4
+                            {
+                                approval_counter += 1;
+                            }
+                            if approval_counter == 3 {
+                                let block = block_holder.read().unwrap().clone().unwrap();
+                                conns[0].0.do_send(NetworkClientMessages::Block(
+                                    block,
+                                    PeerInfo::random().id,
+                                    false,
+                                ));
+                            }
+                            (NetworkResponses::NoResponse.into(), true)
+                        }
+                        _ => (NetworkResponses::NoResponse.into(), true),
                     }
-                    NetworkRequests::Approval { approval_message } => {
-                        if approval_message.target.as_ref() == "test1"
-                            && approval_message.approval.target_height == 4
-                        {
-                            approval_counter += 1;
-                        }
-                        if approval_counter == 3 {
-                            let block = block_holder.read().unwrap().clone().unwrap();
-                            conns[0].0.do_send(NetworkClientMessages::Block(
-                                block,
-                                PeerInfo::random().id,
-                                false,
-                            ));
-                        }
-                        (NetworkResponses::NoResponse.into(), true)
-                    }
-                    _ => (NetworkResponses::NoResponse.into(), true),
-                }
-            },
+                },
+            ),
         );
 
         near_network::test_utils::wait_or_panic(10000);
@@ -743,20 +729,7 @@ fn ban_peer_for_invalid_block_common(mode: InvalidBlockMode) {
         vec![PeerInfo::random(), PeerInfo::random(), PeerInfo::random(), PeerInfo::random()];
     run_actix(async move {
         let mut ban_counter = 0;
-        let peer_manager_mock: Arc<
-            RwLock<
-                Box<
-                    dyn FnMut(
-                        &[(Addr<ClientActor>, Addr<ViewClientActor>)],
-                        AccountId,
-                        &PeerManagerMessageRequest,
-                    ) -> (PeerManagerMessageResponse, bool),
-                >,
-            >,
-        > = Arc::new(RwLock::new(Box::new(|_, _, _: &PeerManagerMessageRequest| {
-            (PeerManagerMessageResponse::NetworkResponses(NetworkResponses::NoResponse), true)
-        })));
-
+        let mut sent_bad_blocks = false;
         setup_mock_all_validators(
             validators.clone(),
             key_pairs,
@@ -770,99 +743,84 @@ fn ban_peer_for_invalid_block_common(mode: InvalidBlockMode) {
             vec![false; validators.iter().map(|x| x.len()).sum()],
             vec![true; validators.iter().map(|x| x.len()).sum()],
             false,
-            peer_manager_mock.clone(),
-        );
-        let mut sent_bad_blocks = false;
-        *peer_manager_mock.write().unwrap() = Box::new(
-            move |conns,
-                  _,
-                  msg: &PeerManagerMessageRequest|
-                  -> (PeerManagerMessageResponse, bool) {
-                match msg.as_network_requests_ref() {
-                    NetworkRequests::Block { block } => {
-                        if block.header().height() >= 4 && !sent_bad_blocks {
-                            let block_producer_idx =
-                                block.header().height() as usize % validators[0].len();
-                            let block_producer = &validators[0][block_producer_idx];
-                            let validator_signer1 = InMemoryValidatorSigner::from_seed(
-                                block_producer.clone(),
-                                KeyType::ED25519,
-                                block_producer.as_ref(),
-                            );
-                            sent_bad_blocks = true;
-                            let mut block_mut = block.clone();
-                            match mode {
-                                InvalidBlockMode::InvalidHeader => {
-                                    // produce an invalid block with invalid header.
-                                    block_mut.mut_header().get_mut().inner_rest.chunk_mask = vec![];
-                                    block_mut.mut_header().resign(&validator_signer1);
-                                }
-                                InvalidBlockMode::IllFormed => {
-                                    // produce an ill-formed block
-                                    block_mut
-                                        .mut_header()
-                                        .get_mut()
-                                        .inner_rest
-                                        .chunk_headers_root = hash(&[1]);
-                                    block_mut.mut_header().resign(&validator_signer1);
-                                }
-                                InvalidBlockMode::InvalidBlock => {
-                                    // produce an invalid block whose invalidity cannot be verified by just
-                                    // having its header.
-                                    let proposals = vec![ValidatorStake::new(
-                                        "test1".parse().unwrap(),
-                                        PublicKey::empty(KeyType::ED25519),
-                                        0,
-                                    )];
+            Box::new(
+                move |conns,
+                      _,
+                      msg: &PeerManagerMessageRequest|
+                      -> (PeerManagerMessageResponse, bool) {
+                    match msg.as_network_requests_ref() {
+                        NetworkRequests::Block { block } => {
+                            if block.header().height() >= 4 && !sent_bad_blocks {
+                                let block_producer_idx =
+                                    block.header().height() as usize % validators[0].len();
+                                let block_producer = &validators[0][block_producer_idx];
+                                let validator_signer1 = InMemoryValidatorSigner::from_seed(
+                                    block_producer.clone(),
+                                    KeyType::ED25519,
+                                    block_producer.as_ref(),
+                                );
+                                sent_bad_blocks = true;
+                                let mut block_mut = block.clone();
+                                match mode {
+                                    InvalidBlockMode::InvalidHeader => {
+                                        // produce an invalid block with invalid header.
+                                        block_mut.mut_header().get_mut().inner_rest.chunk_mask =
+                                            vec![];
+                                        block_mut.mut_header().resign(&validator_signer1);
+                                    }
+                                    InvalidBlockMode::IllFormed => {
+                                        // produce an ill-formed block
+                                        block_mut
+                                            .mut_header()
+                                            .get_mut()
+                                            .inner_rest
+                                            .chunk_headers_root = hash(&[1]);
+                                        block_mut.mut_header().resign(&validator_signer1);
+                                    }
+                                    InvalidBlockMode::InvalidBlock => {
+                                        // produce an invalid block whose invalidity cannot be verified by just
+                                        // having its header.
+                                        let proposals = vec![ValidatorStake::new(
+                                            "test1".parse().unwrap(),
+                                            PublicKey::empty(KeyType::ED25519),
+                                            0,
+                                        )];
 
-                                    block_mut
-                                        .mut_header()
-                                        .get_mut()
-                                        .inner_rest
-                                        .validator_proposals = proposals;
-                                    block_mut.mut_header().resign(&validator_signer1);
+                                        block_mut
+                                            .mut_header()
+                                            .get_mut()
+                                            .inner_rest
+                                            .validator_proposals = proposals;
+                                        block_mut.mut_header().resign(&validator_signer1);
+                                    }
                                 }
-                            }
 
-                            for (i, (client, _)) in conns.clone().into_iter().enumerate() {
-                                if i != block_producer_idx {
-                                    client.do_send(NetworkClientMessages::Block(
-                                        block_mut.clone(),
-                                        PeerInfo::random().id,
-                                        false,
-                                    ))
+                                for (i, (client, _)) in conns.clone().into_iter().enumerate() {
+                                    if i != block_producer_idx {
+                                        client.do_send(NetworkClientMessages::Block(
+                                            block_mut.clone(),
+                                            PeerInfo::random().id,
+                                            false,
+                                        ))
+                                    }
                                 }
-                            }
 
-                            return (
-                                PeerManagerMessageResponse::NetworkResponses(
-                                    NetworkResponses::NoResponse,
-                                ),
-                                false,
-                            );
-                        }
-                        if block.header().height() > 20 {
-                            match mode {
-                                InvalidBlockMode::InvalidHeader | InvalidBlockMode::IllFormed => {
-                                    assert_eq!(ban_counter, 3);
-                                }
-                                _ => {}
+                                return (
+                                    PeerManagerMessageResponse::NetworkResponses(
+                                        NetworkResponses::NoResponse,
+                                    ),
+                                    false,
+                                );
                             }
-                            System::current().stop();
-                        }
-                        (
-                            PeerManagerMessageResponse::NetworkResponses(
-                                NetworkResponses::NoResponse,
-                            ),
-                            true,
-                        )
-                    }
-                    NetworkRequests::BanPeer { peer_id, ban_reason } => match mode {
-                        InvalidBlockMode::InvalidHeader | InvalidBlockMode::IllFormed => {
-                            assert_eq!(ban_reason, &ReasonForBan::BadBlockHeader);
-                            ban_counter += 1;
-                            if ban_counter > 3 {
-                                panic!("more bans than expected");
+                            if block.header().height() > 20 {
+                                match mode {
+                                    InvalidBlockMode::InvalidHeader
+                                    | InvalidBlockMode::IllFormed => {
+                                        assert_eq!(ban_counter, 3);
+                                    }
+                                    _ => {}
+                                }
+                                System::current().stop();
                             }
                             (
                                 PeerManagerMessageResponse::NetworkResponses(
@@ -871,18 +829,37 @@ fn ban_peer_for_invalid_block_common(mode: InvalidBlockMode) {
                                 true,
                             )
                         }
-                        InvalidBlockMode::InvalidBlock => {
-                            panic!("banning peer {:?} unexpectedly for {:?}", peer_id, ban_reason);
-                        }
-                    },
-                    _ => (
-                        PeerManagerMessageResponse::NetworkResponses(NetworkResponses::NoResponse),
-                        true,
-                    ),
-                }
-            },
+                        NetworkRequests::BanPeer { peer_id, ban_reason } => match mode {
+                            InvalidBlockMode::InvalidHeader | InvalidBlockMode::IllFormed => {
+                                assert_eq!(ban_reason, &ReasonForBan::BadBlockHeader);
+                                ban_counter += 1;
+                                if ban_counter > 3 {
+                                    panic!("more bans than expected");
+                                }
+                                (
+                                    PeerManagerMessageResponse::NetworkResponses(
+                                        NetworkResponses::NoResponse,
+                                    ),
+                                    true,
+                                )
+                            }
+                            InvalidBlockMode::InvalidBlock => {
+                                panic!(
+                                    "banning peer {:?} unexpectedly for {:?}",
+                                    peer_id, ban_reason
+                                );
+                            }
+                        },
+                        _ => (
+                            PeerManagerMessageResponse::NetworkResponses(
+                                NetworkResponses::NoResponse,
+                            ),
+                            true,
+                        ),
+                    }
+                },
+            ),
         );
-
         near_network::test_utils::wait_or_panic(20000);
     });
 }


### PR DESCRIPTION
There are many lovable aspects to `setup_mock_all_validators`! What this PR deals with is "tying the knot" infra. `setup_mock_validator` is based on creating `n` validators and setting up the mock network between them. To create a mock network, you need all `n` validators, and to create a validator, you need a mock network. The cycle is broken at runtime, in three different ways: 

* inside `setup_mock_all_validators`, we have `locked_connectors` 
* at some call-sites, we overwrite the whole `peer_manager_mock`
* yet at other call-sites, we essentially create a copy of `locked_connectors`

This PR unifies that to a single infra: 

* there's a single `Arc<OnceCell<Vec<Addr<Client>>>>` inside `setup_mock_all_validators`
* `OnceCell::wait` is used as a barrier 
* The `&[Addr<CLient>]` are passed in as an argument to `peer_manager_mock`, so that it doesn't have to re-invent a way to get a hold of those

This changes the signature of the function, so the diff is pretty large. It is designed to be reviewed per-commit. 