### PR TITLE
keep original validator count in pytest-replay

### DIFF
--- a/pytest/tests/replay/replay.py
+++ b/pytest/tests/replay/replay.py
@@ -31,8 +31,8 @@ def save_genesis_with_new_key_pair(genesis_path, key_pair, output_path):
         genesis = json.load(fin)
 
     new_key = key_pair.pk.split(':')[1] if ':' in key_pair.pk else key_pair.pk
-    genesis['validators'] = genesis['validators'][:1]
-    genesis['validators'][0]['public_key'] = new_key
+    for i in range(len(genesis['validators'])):
+        genesis['validators'][i]['public_key'] = new_key
     for record in genesis['records']:
         if 'AccessKey' in record:
             record['AccessKey']['public_key'] = new_key


### PR DESCRIPTION
This PR changes `pytest`-`replay` to make sure the genesis file it generates always passes the checks enforced by `neard`, since the list of staked accounts found in tries will be compared against the list validators.

### Test steps
 - Follow https://github.com/near/nearcore/blob/master/pytest/tests/replay/README.md to test it on mainnet

### Reviewers
 - @mzhangmzz 
 - @mm-near 