### PR TITLE
feat: new estimator variance check

### DIFF
--- a/runtime/runtime-params-estimator/src/gas_cost.rs
+++ b/runtime/runtime-params-estimator/src/gas_cost.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
 use std::panic::Location;
 use std::time::{Duration, Instant};
-use std::{fmt, ops};
+use std::{fmt, iter, ops};
 
 use near_primitives::types::Gas;
 use num_rational::Ratio;
@@ -438,6 +438,16 @@ impl ops::Add for GasCost {
 impl ops::AddAssign for GasCost {
     fn add_assign(&mut self, rhs: GasCost) {
         *self = self.clone() + rhs;
+    }
+}
+
+impl iter::Sum for GasCost {
+    fn sum<I: Iterator<Item = Self>>(mut iter: I) -> Self {
+        let mut accum = iter.next().unwrap_or(GasCost::zero(GasMetric::Time));
+        for gas in iter {
+            accum += gas;
+        }
+        accum
     }
 }
 

--- a/runtime/runtime-params-estimator/src/utils.rs
+++ b/runtime/runtime-params-estimator/src/utils.rs
@@ -312,10 +312,10 @@ pub(crate) fn aggregate_per_block_measurements(
     (gas_cost, total_ext_costs)
 }
 
-pub(crate) fn average_cost(config: &Config, measurements: &[GasCost]) -> GasCost {
-    let total = measurements.iter().fold(GasCost::zero(config.metric), |acc, x| acc + x.clone());
-    let mut avg = total / measurements.len() as u64;
+pub(crate) fn average_cost(measurements: Vec<GasCost>) -> GasCost {
     let scalar_costs = measurements.iter().map(|cost| cost.to_gas() as f64).collect::<Vec<_>>();
+    let total: GasCost = measurements.into_iter().sum();
+    let mut avg = total / scalar_costs.len() as u64;
     if is_high_variance(&scalar_costs) {
         avg.set_uncertain("HIGH-VARIANCE");
     }
@@ -323,23 +323,21 @@ pub(crate) fn average_cost(config: &Config, measurements: &[GasCost]) -> GasCost
 }
 
 /// We expect our cost computations to be fairly reproducible, and just flag
-/// "high-variance" measurements as suspicious. To make results easily
-/// explainable, we just require that all the samples don't deviate from the
-/// mean by more than 15%, where the number 15 is somewhat arbitrary.
+/// "high-variance" measurements as suspicious. We require that standard
+/// deviation is no more than 10% of the mean.
 ///
 /// Note that this looks at block processing times, and each block contains
 /// multiples of things we are actually measuring. As low block variance doesn't
 /// guarantee low within-block variance, this is necessary an approximate sanity
 /// check.
 pub(crate) fn is_high_variance(samples: &[f64]) -> bool {
-    let threshold = 0.15;
+    let threshold = 0.1;
 
     let mean = samples.iter().copied().sum::<f64>() / (samples.len() as f64);
-
-    let all_below_threshold =
-        samples.iter().copied().all(|it| (mean - it).abs() < mean * threshold);
-
-    !all_below_threshold
+    let variance =
+        samples.iter().map(|value| (mean - *value).powi(2)).sum::<f64>() / samples.len() as f64;
+    let stddev = variance.sqrt();
+    stddev / mean > threshold
 }
 
 /// Returns several percentile values from the given vector of costs. For


### PR DESCRIPTION
The condition to check for high variance of measurements so far has been
that no single sample is further than 15% from the mean away. We often
missed that when running with 5 iterations and one warm-up iteration.
The counter-intuitive side of this check is that is becomes less likely
that variance is considered low enough, if more iterations are added.

The new condition computes actual variance and standard deviation.
Now we expect that standard deviation is lower than 10%.

Also add an outer loop to block overhead computation. Usually there
is a loop + a number of actions inside a block. But this estimation
has empty blocks and therefore each measurement so far was
just a single apply block call. Grouping 10 empty blocks together
for each measurement and adding an outer loop for `--iters` reduces 
the overall variance.