### PR TITLE
implemented accounts data cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3169,6 +3169,7 @@ dependencies = [
  "near-logger-utils",
  "near-metrics",
  "near-network-primitives",
+ "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,6 +1319,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1417,6 +1427,12 @@ dependencies = [
  "rustc_version 0.4.0",
  "syn",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -3163,6 +3179,7 @@ dependencies = [
  "once_cell",
  "opentelemetry",
  "parking_lot 0.12.1",
+ "pretty_assertions",
  "protobuf 3.0.2",
  "protobuf-codegen",
  "rand 0.6.5",
@@ -3907,6 +3924,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "029d8d0b2f198229de29dca79676f2738ff952edf3fde542eb8bf94d8c21b435"
 
 [[package]]
+name = "output_vt100"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "page_size"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4157,6 +4183,18 @@ name = "pretty-hex"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5c99d529f0d30937f6f4b8a86d988047327bb88d04d2c4afc356de74722131"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89f989ac94207d048d92db058e4f6ec7342b0971fc58d1271ca148b799b3563"
+dependencies = [
+ "ansi_term",
+ "ctor",
+ "diff",
+ "output_vt100",
+]
 
 [[package]]
 name = "primitive-types"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3184,6 +3184,7 @@ dependencies = [
  "protobuf-codegen",
  "rand 0.6.5",
  "rand_pcg",
+ "rayon",
  "serde",
  "smart-default",
  "strum",

--- a/chain/network-primitives/src/types.rs
+++ b/chain/network-primitives/src/types.rs
@@ -23,7 +23,7 @@ use near_primitives::views::{FinalExecutionOutcomeView, QueryResponse};
 use serde::Serialize;
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::Debug;
-use std::hash::{Hash, Hasher};
+use std::hash::Hash;
 use std::net::SocketAddr;
 use tokio::net::TcpStream;
 
@@ -321,48 +321,9 @@ pub enum NetworkViewClientMessages {
     AnnounceAccount(Vec<(AnnounceAccount, Option<EpochId>)>),
 }
 
-#[derive(Debug)]
-pub struct WithHash<T> {
-    inner: T,
-    hash: u64,
-}
-
-impl<T: Hash> Hash for WithHash<T> {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        state.write_u64(self.hash);
-    }
-}
-
-impl<T: Hash + Default> Default for WithHash<T> {
-    fn default() -> Self {
-        WithHash::new(T::default())
-    }
-}
-
-impl<T> std::cmp::PartialEq for WithHash<T> {
-    fn eq(&self, other: &Self) -> bool {
-        self.hash == other.hash
-    }
-}
-
-impl<T> std::ops::Deref for WithHash<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.inner
-    }
-}
-
-impl<T: Hash> WithHash<T> {
-    pub fn new(inner: T) -> Self {
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        inner.hash(&mut hasher);
-        Self { inner, hash: hasher.finish() }
-    }
-}
-
 /// Set of account keys with a cached hash.
 /// BTreeMap implements Hash (while HashMap doesn't).
-pub type AccountKeys = WithHash<BTreeMap<(EpochId, AccountId), PublicKey>>;
+pub type AccountKeys = BTreeMap<(EpochId, AccountId), PublicKey>;
 
 // Network-relevant data about the epoch.
 #[derive(Debug, Clone)]

--- a/chain/network-primitives/src/types.rs
+++ b/chain/network-primitives/src/types.rs
@@ -11,6 +11,7 @@ use crate::time;
 /// - We also export publicly types from `crate::network_protocol`
 use actix::Message;
 use borsh::{BorshDeserialize, BorshSerialize};
+use near_crypto::PublicKey;
 use near_crypto::SecretKey;
 use near_primitives::block::{Block, BlockHeader, GenesisId};
 use near_primitives::hash::CryptoHash;
@@ -20,6 +21,7 @@ use near_primitives::transaction::ExecutionOutcomeWithIdAndProof;
 use near_primitives::types::{AccountId, BlockHeight, EpochId, ShardId};
 use near_primitives::views::{FinalExecutionOutcomeView, QueryResponse};
 use serde::Serialize;
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::net::SocketAddr;
@@ -317,6 +319,18 @@ pub enum NetworkViewClientMessages {
     /// They are paired with last epoch id known to this announcement, in order to accept only
     /// newer announcements.
     AnnounceAccount(Vec<(AnnounceAccount, Option<EpochId>)>),
+}
+
+// Network-relevant data about the epoch.
+#[derive(Debug, Clone)]
+pub struct NetworkEpochInfo {
+    pub id: EpochId,
+    // Public keys of accounts participating in the BFT consensus.
+    // It currently includes "block producers", "chunk producers" and "approvers".
+    // They are collectively known as "validators".
+    // Peers acting on behalf of these accounts have a higher
+    // priority on the NEAR network than other peers.
+    pub priority_accounts: HashMap<AccountId, PublicKey>,
 }
 
 #[derive(Debug, actix::MessageResponse)]

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -57,6 +57,7 @@ near-logger-utils = { path = "../../test-utils/logger" }
 [dev-dependencies]
 criterion = { version = "0.3.5", default_features = false, features = ["html_reports", "cargo_bench_support"] }
 tempfile = "3"
+pretty_assertions = "1.2"
 
 [features]
 deepsize_feature = [

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = "1.0.55"
 protobuf-codegen = "3.0.1"
 
 [dependencies]
+rayon = "1.5"
 smart-default = "0.6"
 protobuf = "3.0.1"
 actix = "0.13.0"

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -44,6 +44,7 @@ tracing-opentelemetry = { version = "0.17" }
 assert_matches = "1.3"
 
 delay-detector = { path = "../../tools/delay_detector" }
+near-o11y = { path = "../../core/o11y" }
 near-crypto = { path = "../../core/crypto" }
 near-metrics = { path = "../../core/metrics" }
 near-network-primitives = { path = "../network-primitives" }

--- a/chain/network/src/accounts_data/mod.rs
+++ b/chain/network/src/accounts_data/mod.rs
@@ -1,0 +1,240 @@
+//! Cache of Cache for a small number of epochs. (probably just current and next epoch).
+//! Assumptions:
+//! - verifying signatures is expensive, we need a dedicated threadpool for handling that.
+//!   TODO(gprusak): it would be nice to have a benchmark for that
+//! - a bad peer may attack by sending a lot of invalid signatures
+//! - we can afford verifying all valid signatures (for the given epochs) that we have never seen before.
+//! - we can afford verifying a few invalid signatures per PeerMessage.
+//!
+//! Strategy:
+//! - handling of SyncAccountDataResponses should be throttled by PeerActor/PeerManagerActor.
+//! - synchronously select interesting Cache (i.e. those with never timestamp than any
+//!   previously seen for the given (account_id,epoch_id) pair.
+//! - asynchronously verify signatures, until an invalid signature is encountered.
+//! - if any signature is invalid, drop validation of the remaining signature and ban the peer
+//! - all valid signatures verified, so far should be inserted, since otherwise we are open to the
+//!   following attack:
+//!     - a bad peer may spam us with <N valid AccountData> + <1 invalid AccountData>
+//!     - we would validate everything every time, realizing that the last one is invalid, then
+//!       discarding the progress
+//!     - banning a peer wouldn't help since peers are anonymous, so a single attacker can act as a
+//!       lot of peers
+use crate::network_protocol;
+use crate::network_protocol::SignedAccountData;
+use near_crypto::PublicKey;
+use near_network_primitives::time;
+use near_network_primitives::types::NetworkEpochInfo;
+use near_primitives::types::{AccountId, EpochId};
+use parking_lot::RwLock;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+#[cfg(test)]
+mod tests;
+
+/// Current state of knowledge about an account.
+/// key is the public key of the account in the given epoch.
+/// It will be used to verify new incoming versions of SignedAccountData
+/// for this account.
+struct Account {
+    key: PublicKey,
+    data: Option<SignedAccountData>,
+}
+
+impl Account {
+    fn is_new(&self, t: time::Utc) -> bool {
+        match &self.data {
+            Some(old) if old.timestamp >= t => false,
+            _ => true,
+        }
+    }
+}
+
+struct Epoch(HashMap<AccountId, Account>);
+
+impl Epoch {
+    fn new(keys: &HashMap<AccountId, PublicKey>) -> Self {
+        Self(
+            keys.iter()
+                .map(|(id, key)| (id.clone(), Account { key: key.clone(), data: None }))
+                .collect(),
+        )
+    }
+}
+
+#[derive(thiserror::Error, Debug, PartialEq, Eq)]
+pub(crate) enum Error {
+    #[error("found an invalid signature")]
+    InvalidSignature,
+    #[error("found too large payload")]
+    DataTooLarge,
+    #[error("found multiple entries for the same (epoch_id,account_id)")]
+    SingleAccountMultipleData,
+    #[error("found account data not relevant for the given epoch")]
+    InvalidAccount,
+}
+
+/// Current state of per-epoch knowledge about accounts.
+/// It is a small map: it is expected to just contain current epoch and next epoch.
+struct Epochs(HashMap<EpochId, Epoch>);
+
+impl Epochs {
+    fn try_insert(&mut self, d: SignedAccountData) -> Option<SignedAccountData> {
+        let mut a = self.0.get_mut(&d.epoch_id)?.0.get_mut(&d.account_id)?;
+        if !a.is_new(d.timestamp) {
+            return None;
+        }
+        a.data = Some(d.clone());
+        Some(d)
+    }
+}
+
+// TODO(gprusak): replace Option with ManuallyDrop?
+struct Runtime(Option<tokio::runtime::Runtime>);
+
+impl std::ops::Deref for Runtime {
+    type Target = tokio::runtime::Runtime;
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref().unwrap()
+    }
+}
+
+impl Drop for Runtime {
+    fn drop(&mut self) {
+        self.0.take().unwrap().shutdown_background()
+    }
+}
+
+impl Runtime {
+    fn new() -> Self {
+        Self(Some(tokio::runtime::Runtime::new().unwrap()))
+    }
+}
+
+pub(crate) struct Cache {
+    epochs: RwLock<Epochs>,
+    runtime: Runtime,
+}
+
+// TODO(gprusak): Cache will be used in the next PR.
+#[allow(dead_code)]
+impl Cache {
+    pub fn new() -> Self {
+        Self { epochs: RwLock::new(Epochs(HashMap::new())), runtime: Runtime::new() }
+    }
+
+    /// Sets new_epochs as active and copies over the keys
+    /// for accounts which were not active before.
+    /// The set of accounts per epoch is expected to be deterministic,
+    /// So it is not possible to update the set of accounts for an already
+    /// active epoch - such an update will be ignored silently.
+    /// This code is more general than needed: active epochs are expected
+    /// to be just {this_epoch,next_epoch} and set_epochs should be called
+    /// every time chain advances to the next epoch. set_epoch is idempotent
+    /// and is very cheap in case it is called with the same argument multiple
+    /// times.
+    /// TODO(gprusak): note that the current implementation just checks that
+    /// epoch_id didn't change, then ignoring content.
+    /// It would be more strict (while still being cheap) to
+    /// accept NetworkEpochInfo with a cached hash, and compare hashes instead of epoch_id.
+    pub fn set_epochs(&self, new_epochs: Vec<&NetworkEpochInfo>) -> bool {
+        let mut epochs = self.epochs.write();
+        epochs.0.retain(|id, _| new_epochs.iter().any(|e| &e.id == id));
+        let mut has_new = false;
+        for e in new_epochs {
+            epochs.0.entry(e.id.clone()).or_insert_with(|| {
+                has_new = true;
+                Epoch::new(&e.priority_accounts)
+            });
+        }
+        has_new
+    }
+
+    /// Selects new data and verifies the signatures.
+    /// Returns the verified new data and an optional error.
+    /// Note that even if error has been returned the partially validated output is returned
+    /// anyway.
+    fn verify(&self, data: Vec<SignedAccountData>) -> (Vec<SignedAccountData>, Option<Error>) {
+        // Filter out non-interesting data, so that we never check signatures for valid non-interesting data.
+        // Bad peers may force us to check signatures for fake data anyway, but we will ban them after first invalid signature.
+        // It locks epochs for reading for a short period.
+        let mut found = HashSet::new();
+        let mut data_and_keys = vec![];
+        let epochs = self.epochs.read();
+        for d in data {
+            // We want the communication needed for broadcasting per-account data to be minimal.
+            // Therefore broadcasting multiple datasets per account is considered malicious
+            // behavior, since all but one are obviously outdated.
+            let data_id = (d.epoch_id.clone(), d.account_id.clone());
+            if found.contains(&data_id) {
+                return (vec![], Some(Error::SingleAccountMultipleData));
+            }
+            found.insert(data_id);
+            // There is a limit on the amount of RAM occupied by per-account datasets.
+            // Broadcasting larger datasets is considered malicious behavior.
+            if d.payload().len() > network_protocol::MAX_ACCOUNT_DATA_SIZE_BYTES {
+                return (vec![], Some(Error::DataTooLarge));
+            }
+            // It is fine to broadcast account data for epochs that we don't care about.
+            let epoch = match epochs.0.get(&d.epoch_id) {
+                Some(e) => e,
+                None => continue,
+            };
+            // It is NOT fine to broadcast account data which is not relevant to the given epoch.
+            let account = match epoch.0.get(&d.account_id) {
+                Some(a) => a,
+                None => return (vec![], Some(Error::InvalidAccount)),
+            };
+            // It is fine to broadcast data we already know about.
+            if !account.is_new(d.timestamp) {
+                continue;
+            }
+            data_and_keys.push((d, account.key.clone()));
+        }
+        drop(epochs);
+
+        // We verify signatures synchronously for now.
+        // To verify signatures in parallel, we should have a way to stop verification at the first invalid one.
+        let mut data = vec![];
+        for (d, key) in data_and_keys {
+            if !d.payload().verify(&key) {
+                return (data, Some(Error::InvalidSignature));
+            }
+            data.push(d);
+        }
+        return (data, None);
+    }
+
+    /// Verifies the signatures and inserts verified data to the cache.
+    /// Returns the data inserted and optionally a verification error.
+    /// WriteLock is acquired only for the final update (after verification).
+    pub async fn insert(
+        self: Arc<Self>,
+        data: Vec<SignedAccountData>,
+    ) -> (Vec<SignedAccountData>, Option<Error>) {
+        let x = self.clone();
+        // Execute insertion in a dedicated runtime.
+        self.runtime
+            .spawn(async move {
+                let (data, err) = x.verify(data);
+                // Insert the successfully verified data, even if an error has been encountered.
+                let mut epochs = x.epochs.write();
+                // Return the inserted data.
+                (data.into_iter().filter_map(|d| epochs.try_insert(d)).collect(), err)
+            })
+            .await
+            .unwrap()
+    }
+
+    /// Copies and returns all the AccountData in the cache.
+    pub fn dump(&self) -> Vec<SignedAccountData> {
+        self.epochs
+            .read()
+            .0
+            .values()
+            .map(|e| &e.0)
+            .flatten()
+            .filter_map(|(_, a)| a.data.clone())
+            .collect()
+    }
+}

--- a/chain/network/src/accounts_data/mod.rs
+++ b/chain/network/src/accounts_data/mod.rs
@@ -1,14 +1,19 @@
-//! Cache of Cache for a small number of epochs. (probably just current and next epoch).
+//! Cache of AccountData. It keeps AccountData for important accounts for the current epoch.
+//! The set of important accounts for the given epoch is expected to never change (should be
+//! deterministic). Note that "important accounts for the current epoch" is not limited to
+//! "validators of the current epoch", but rather may include for example "validators of the next
+//! epoch" so that AccountData of future validators is broadcasted in advance.
+//!
 //! Assumptions:
 //! - verifying signatures is expensive, we need a dedicated threadpool for handling that.
 //!   TODO(gprusak): it would be nice to have a benchmark for that
 //! - a bad peer may attack by sending a lot of invalid signatures
-//! - we can afford verifying all valid signatures (for the given epochs) that we have never seen before.
-//! - we can afford verifying a few invalid signatures per PeerMessage.
+//! - we can afford verifying each valid signature of the current epoch once.
+//! - we can afford verifying a few invalid signatures per SyncAccountsData message.
 //!
 //! Strategy:
-//! - handling of SyncAccountDataResponses should be throttled by PeerActor/PeerManagerActor.
-//! - synchronously select interesting Cache (i.e. those with never timestamp than any
+//! - handling of SyncAccountsData should be throttled by PeerActor/PeerManagerActor.
+//! - synchronously select interesting AccountData (i.e. those with never timestamp than any
 //!   previously seen for the given (account_id,epoch_id) pair.
 //! - asynchronously verify signatures, until an invalid signature is encountered.
 //! - if any signature is invalid, drop validation of the remaining signature and ban the peer
@@ -21,74 +26,17 @@
 //!       lot of peers
 use crate::network_protocol;
 use crate::network_protocol::SignedAccountData;
-use near_crypto::PublicKey;
-use near_network_primitives::time;
-use near_network_primitives::types::NetworkEpochInfo;
+use near_network_primitives::types::{AccountKeys, WithHash};
 use near_primitives::types::{AccountId, EpochId};
 use parking_lot::RwLock;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 #[cfg(test)]
 mod tests;
 
-/// Current state of knowledge about an account.
-/// key is the public key of the account in the given epoch.
-/// It will be used to verify new incoming versions of SignedAccountData
-/// for this account.
-struct Account {
-    key: PublicKey,
-    data: Option<SignedAccountData>,
-}
-
-impl Account {
-    fn is_new(&self, t: time::Utc) -> bool {
-        match &self.data {
-            Some(old) if old.timestamp >= t => false,
-            _ => true,
-        }
-    }
-}
-
-struct Epoch(HashMap<AccountId, Account>);
-
-impl Epoch {
-    fn new(keys: &HashMap<AccountId, PublicKey>) -> Self {
-        Self(
-            keys.iter()
-                .map(|(id, key)| (id.clone(), Account { key: key.clone(), data: None }))
-                .collect(),
-        )
-    }
-}
-
-#[derive(thiserror::Error, Debug, PartialEq, Eq)]
-pub(crate) enum Error {
-    #[error("found an invalid signature")]
-    InvalidSignature,
-    #[error("found too large payload")]
-    DataTooLarge,
-    #[error("found multiple entries for the same (epoch_id,account_id)")]
-    SingleAccountMultipleData,
-    #[error("found account data not relevant for the given epoch")]
-    InvalidAccount,
-}
-
-/// Current state of per-epoch knowledge about accounts.
-/// It is a small map: it is expected to just contain current epoch and next epoch.
-struct Epochs(HashMap<EpochId, Epoch>);
-
-impl Epochs {
-    fn try_insert(&mut self, d: SignedAccountData) -> Option<SignedAccountData> {
-        let mut a = self.0.get_mut(&d.epoch_id)?.0.get_mut(&d.account_id)?;
-        if !a.is_new(d.timestamp) {
-            return None;
-        }
-        a.data = Some(d.clone());
-        Some(d)
-    }
-}
-
+/// Runtime is a wrapper of tokio::runtime::Runtime
+/// which starts rutime shutdown when dropped.
 // TODO(gprusak): replace Option with ManuallyDrop?
 struct Runtime(Option<tokio::runtime::Runtime>);
 
@@ -111,8 +59,46 @@ impl Runtime {
     }
 }
 
+#[derive(thiserror::Error, Debug, PartialEq, Eq)]
+pub(crate) enum Error {
+    #[error("found an invalid signature")]
+    InvalidSignature,
+    #[error("found too large payload")]
+    DataTooLarge,
+    #[error("found multiple entries for the same (epoch_id,account_id)")]
+    SingleAccountMultipleData,
+}
+
+struct CacheInner {
+    keys: Arc<AccountKeys>,
+    /// Current state of knowledge about an account.
+    /// key is the public key of the account in the given epoch.
+    /// It will be used to verify new incoming versions of SignedAccountData
+    /// for this account.
+    data: HashMap<(EpochId, AccountId), SignedAccountData>,
+}
+
+impl CacheInner {
+    fn is_new(&self, d: &SignedAccountData) -> bool {
+        let id = (d.epoch_id.clone(), d.account_id.clone());
+        self.keys.contains_key(&id)
+            && match self.data.get(&id) {
+                Some(old) if old.timestamp >= d.timestamp => false,
+                _ => true,
+            }
+    }
+    fn try_insert(&mut self, d: SignedAccountData) -> Option<SignedAccountData> {
+        if !self.is_new(&d) {
+            return None;
+        }
+        let id = (d.epoch_id.clone(), d.account_id.clone());
+        self.data.insert(id, d.clone());
+        Some(d)
+    }
+}
+
 pub(crate) struct Cache {
-    epochs: RwLock<Epochs>,
+    inner: RwLock<CacheInner>,
     runtime: Runtime,
 }
 
@@ -120,34 +106,26 @@ pub(crate) struct Cache {
 #[allow(dead_code)]
 impl Cache {
     pub fn new() -> Self {
-        Self { epochs: RwLock::new(Epochs(HashMap::new())), runtime: Runtime::new() }
+        Self {
+            inner: RwLock::new(CacheInner {
+                keys: Arc::new(WithHash::new(BTreeMap::new())),
+                data: HashMap::new(),
+            }),
+            runtime: Runtime::new(),
+        }
     }
 
-    /// Sets new_epochs as active and copies over the keys
-    /// for accounts which were not active before.
-    /// The set of accounts per epoch is expected to be deterministic,
-    /// So it is not possible to update the set of accounts for an already
-    /// active epoch - such an update will be ignored silently.
-    /// This code is more general than needed: active epochs are expected
-    /// to be just {this_epoch,next_epoch} and set_epochs should be called
-    /// every time chain advances to the next epoch. set_epoch is idempotent
-    /// and is very cheap in case it is called with the same argument multiple
-    /// times.
-    /// TODO(gprusak): note that the current implementation just checks that
-    /// epoch_id didn't change, then ignoring content.
-    /// It would be more strict (while still being cheap) to
-    /// accept NetworkEpochInfo with a cached hash, and compare hashes instead of epoch_id.
-    pub fn set_epochs(&self, new_epochs: Vec<&NetworkEpochInfo>) -> bool {
-        let mut epochs = self.epochs.write();
-        epochs.0.retain(|id, _| new_epochs.iter().any(|e| &e.id == id));
-        let mut has_new = false;
-        for e in new_epochs {
-            epochs.0.entry(e.id.clone()).or_insert_with(|| {
-                has_new = true;
-                Epoch::new(&e.priority_accounts)
-            });
+    /// Updates the set of important accounts and their public keys.
+    /// The AccountData which is no longer important is dropped.
+    /// Returns true iff the set of accounts actually changed.
+    pub fn set_keys(&self, keys: Arc<AccountKeys>) -> bool {
+        let mut inner = self.inner.write();
+        if keys == inner.keys {
+            return false;
         }
-        has_new
+        inner.data.retain(|k, _| keys.contains_key(k));
+        inner.keys = keys;
+        true
     }
 
     /// Selects new data and verifies the signatures.
@@ -158,51 +136,44 @@ impl Cache {
         // Filter out non-interesting data, so that we never check signatures for valid non-interesting data.
         // Bad peers may force us to check signatures for fake data anyway, but we will ban them after first invalid signature.
         // It locks epochs for reading for a short period.
-        let mut found = HashSet::new();
-        let mut data_and_keys = vec![];
-        let epochs = self.epochs.read();
+        let mut data_and_keys = HashMap::new();
+        let inner = self.inner.read();
         for d in data {
-            // We want the communication needed for broadcasting per-account data to be minimal.
-            // Therefore broadcasting multiple datasets per account is considered malicious
-            // behavior, since all but one are obviously outdated.
-            let data_id = (d.epoch_id.clone(), d.account_id.clone());
-            if found.contains(&data_id) {
-                return (vec![], Some(Error::SingleAccountMultipleData));
-            }
-            found.insert(data_id);
             // There is a limit on the amount of RAM occupied by per-account datasets.
             // Broadcasting larger datasets is considered malicious behavior.
             if d.payload().len() > network_protocol::MAX_ACCOUNT_DATA_SIZE_BYTES {
                 return (vec![], Some(Error::DataTooLarge));
             }
-            // It is fine to broadcast account data for epochs that we don't care about.
-            let epoch = match epochs.0.get(&d.epoch_id) {
-                Some(e) => e,
-                None => continue,
-            };
-            // It is NOT fine to broadcast account data which is not relevant to the given epoch.
-            let account = match epoch.0.get(&d.account_id) {
-                Some(a) => a,
-                None => return (vec![], Some(Error::InvalidAccount)),
-            };
+            let id = (d.epoch_id.clone(), d.account_id.clone());
+            // We want the communication needed for broadcasting per-account data to be minimal.
+            // Therefore broadcasting multiple datasets per account is considered malicious
+            // behavior, since all but one are obviously outdated.
+            if data_and_keys.contains_key(&id) {
+                return (vec![], Some(Error::SingleAccountMultipleData));
+            }
             // It is fine to broadcast data we already know about.
-            if !account.is_new(d.timestamp) {
+            if !inner.is_new(&d) {
                 continue;
             }
-            data_and_keys.push((d, account.key.clone()));
+            // It is fine to broadcast account data that we don't care about.
+            let key = match inner.keys.get(&id) {
+                Some(key) => key.clone(),
+                None => continue,
+            };
+            data_and_keys.insert(id, (d, key));
         }
-        drop(epochs);
+        drop(inner);
 
         // We verify signatures synchronously for now.
         // To verify signatures in parallel, we should have a way to stop verification at the first invalid one.
         let mut data = vec![];
-        for (d, key) in data_and_keys {
+        for (d, key) in data_and_keys.into_values() {
             if !d.payload().verify(&key) {
                 return (data, Some(Error::InvalidSignature));
             }
             data.push(d);
         }
-        return (data, None);
+        (data, None)
     }
 
     /// Verifies the signatures and inserts verified data to the cache.
@@ -218,9 +189,9 @@ impl Cache {
             .spawn(async move {
                 let (data, err) = x.verify(data);
                 // Insert the successfully verified data, even if an error has been encountered.
-                let mut epochs = x.epochs.write();
+                let mut inner = x.inner.write();
                 // Return the inserted data.
-                (data.into_iter().filter_map(|d| epochs.try_insert(d)).collect(), err)
+                (data.into_iter().filter_map(|d| inner.try_insert(d)).collect(), err)
             })
             .await
             .unwrap()
@@ -228,13 +199,6 @@ impl Cache {
 
     /// Copies and returns all the AccountData in the cache.
     pub fn dump(&self) -> Vec<SignedAccountData> {
-        self.epochs
-            .read()
-            .0
-            .values()
-            .map(|e| &e.0)
-            .flatten()
-            .filter_map(|(_, a)| a.data.clone())
-            .collect()
+        self.inner.read().data.values().cloned().collect()
     }
 }

--- a/chain/network/src/accounts_data/tests.rs
+++ b/chain/network/src/accounts_data/tests.rs
@@ -1,61 +1,27 @@
 use crate::accounts_data::*;
 use crate::network_protocol::testonly as data;
-use crate::network_protocol::{AccountData, SignedAccountData};
+use crate::network_protocol::SignedAccountData;
 use crate::testonly::{make_rng, AsSet as _, Rng};
-use near_crypto::{InMemorySigner, SecretKey};
 use near_network_primitives::time;
-use near_network_primitives::types::NetworkEpochInfo;
-use near_primitives::types::{AccountId, EpochId};
+use near_network_primitives::types::AccountKeys;
+use near_primitives::types::EpochId;
 use pretty_assertions::assert_eq;
-use std::collections::HashMap;
 use std::sync::Arc;
 
-#[derive(Default)]
-struct Signers {
-    keys: HashMap<(EpochId, AccountId), SecretKey>,
+struct Signer {
+    epoch_id: EpochId,
+    signer: near_crypto::InMemorySigner,
 }
 
-impl Signers {
-    fn key(&mut self, rng: &mut Rng, epoch_id: &EpochId, account_id: &AccountId) -> &SecretKey {
-        self.keys
-            .entry((epoch_id.clone(), account_id.clone()))
-            .or_insert_with(|| data::make_secret_key(rng))
-    }
-
-    fn make_epoch(&mut self, rng: &mut Rng, account_ids: &[&AccountId]) -> NetworkEpochInfo {
-        let epoch_id = data::make_epoch_id(rng);
-        NetworkEpochInfo {
-            id: epoch_id.clone(),
-            priority_accounts: account_ids
-                .iter()
-                .map(|aid| ((*aid).clone(), self.key(rng, &epoch_id, &aid).public_key()))
-                .collect(),
-        }
-    }
-
-    fn make_account_data(
-        &mut self,
-        rng: &mut Rng,
-        epoch_id: &EpochId,
-        account_id: &AccountId,
-        timestamp: time::Utc,
-    ) -> SignedAccountData {
-        let signer = InMemorySigner::from_secret_key(
-            account_id.clone(),
-            self.key(rng, epoch_id, account_id).clone(),
-        );
-        AccountData {
-            peers: (0..3)
-                .map(|_| {
-                    let ip = data::make_ipv6(rng);
-                    data::make_peer_addr(rng, ip)
-                })
-                .collect(),
-            account_id: account_id.clone(),
-            epoch_id: epoch_id.clone(),
+impl Signer {
+    fn make_account_data(&self, rng: &mut Rng, timestamp: time::Utc) -> SignedAccountData {
+        data::make_account_data(
+            rng,
             timestamp,
-        }
-        .sign(&signer)
+            self.epoch_id.clone(),
+            self.signer.account_id.clone(),
+        )
+        .sign(&self.signer)
         .unwrap()
     }
 }
@@ -69,6 +35,23 @@ fn unwrap<'a, T: std::hash::Hash + std::cmp::Eq, E: std::fmt::Debug>(
     &v.0
 }
 
+fn make_signers(rng: &mut Rng, n: usize) -> Vec<Signer> {
+    (0..n)
+        .map(|_| Signer { epoch_id: data::make_epoch_id(rng), signer: data::make_signer(rng) })
+        .collect()
+}
+
+fn make_account_keys(signers: &[Signer]) -> Arc<AccountKeys> {
+    Arc::new(WithHash::new(
+        signers
+            .iter()
+            .map(|s| {
+                ((s.epoch_id.clone(), s.signer.account_id.clone()), s.signer.public_key.clone())
+            })
+            .collect(),
+    ))
+}
+
 #[tokio::test]
 async fn happy_path() {
     let mut rng = make_rng(2947294234);
@@ -76,59 +59,56 @@ async fn happy_path() {
     let clock = time::FakeClock::default();
     let now = clock.now_utc();
 
-    let accounts: Vec<_> = (0..4).map(|_| data::make_account_id(rng)).collect();
-    let mut signers = Signers::default();
-    let e0 = signers.make_epoch(rng, &[&accounts[0], &accounts[1], &accounts[2]]);
-    let e1 = signers.make_epoch(rng, &[&accounts[0], &accounts[3]]);
-    let e2 = signers.make_epoch(rng, &[&accounts[1], &accounts[2]]);
+    let signers: Vec<_> = make_signers(rng, 7);
+    let e0 = make_account_keys(&signers[0..5]);
+    let e1 = make_account_keys(&signers[2..7]);
 
     let cache = Arc::new(Cache::new());
     assert_eq!(cache.dump(), vec![]); // initially empty
-    cache.set_epochs(vec![&e0, &e1]);
-    assert_eq!(cache.dump(), vec![]); // empty after initial set_epoch.
+    assert!(cache.set_keys(e0.clone()));
+    assert_eq!(cache.dump(), vec![]); // empty after initial set_keys.
 
     // initial insert
-    let e0a0 = signers.make_account_data(rng, &e0.id, &accounts[0], now);
-    let e0a1 = signers.make_account_data(rng, &e0.id, &accounts[1], now);
-    let res = cache.clone().insert(vec![e0a0.clone(), e0a1.clone()]).await;
-    assert_eq!([&e0a0, &e0a1].as_set(), unwrap(&res).as_set());
-    assert_eq!([&e0a0, &e0a1].as_set(), cache.dump().as_set());
+    let a0 = signers[0].make_account_data(rng, now);
+    let a1 = signers[1].make_account_data(rng, now);
+    let res = cache.clone().insert(vec![a0.clone(), a1.clone()]).await;
+    assert_eq!([&a0, &a1].as_set(), unwrap(&res).as_set());
+    assert_eq!([&a0, &a1].as_set(), cache.dump().as_set());
 
     // entries of various types
-    let e1a0 = signers.make_account_data(rng, &e1.id, &accounts[0], now);
-    let e0a0new =
-        signers.make_account_data(rng, &e0.id, &accounts[0], now + time::Duration::seconds(1));
-    let e0a1old =
-        signers.make_account_data(rng, &e0.id, &accounts[1], now - time::Duration::seconds(1));
-    let e2a1 = signers.make_account_data(rng, &e2.id, &accounts[1], now);
+    let a0new = signers[0].make_account_data(rng, now + time::Duration::seconds(1));
+    let a1old = signers[1].make_account_data(rng, now - time::Duration::seconds(1));
+    let a2 = signers[2].make_account_data(rng, now);
+    let a5 = signers[5].make_account_data(rng, now);
     let res = cache
         .clone()
         .insert(vec![
-            e1a0.clone(),    // initial value => insert
-            e0a0new.clone(), // with newer timestamp => insert,
-            e0a1old.clone(), // with older timestamp => filter out,
-            e2a1.clone(),    // from inactive epoch => filter out,
+            a2.clone(),    // initial value => insert
+            a0new.clone(), // with newer timestamp => insert,
+            a1old.clone(), // with older timestamp => filter out,
+            a5.clone(),    // not in e0 => filter out.
         ])
         .await;
-    assert_eq!([&e1a0, &e0a0new].as_set(), unwrap(&res).as_set());
-    assert_eq!([&e0a0new, &e0a1, &e1a0].as_set(), cache.dump().as_set());
+    assert_eq!([&a2, &a0new].as_set(), unwrap(&res).as_set());
+    assert_eq!([&a0new, &a1, &a2].as_set(), cache.dump().as_set());
 
-    // set_epoch again. Entries from inactive epochs should be dropped.
-    cache.set_epochs(vec![&e0, &e2]);
-    assert_eq!([&e0a0new, &e0a1].as_set(), cache.dump().as_set());
+    // try setting the same key set again, should be a noop.
+    assert!(!cache.set_keys(e0));
+    assert_eq!([&a0new, &a1, &a2].as_set(), cache.dump().as_set());
+
+    // set_keys again. Data for accounts which are not in the new set should be dropped.
+    assert!(cache.set_keys(e1));
+    assert_eq!([&a2].as_set(), cache.dump().as_set());
     // insert some entries again.
-    let e0a2 = signers.make_account_data(rng, &e0.id, &accounts[2], now);
-    let e1a3 = signers.make_account_data(rng, &e1.id, &accounts[3], now);
     let res = cache
         .clone()
         .insert(vec![
-            e0a2.clone(), // e0 is still active => insert,
-            e1a3.clone(), // e1 is not active any more => filter out,
-            e2a1.clone(), // e2 has become active => insert,
+            a0.clone(), // a0 is not in e1 => filter out
+            a5.clone(), // a5 is in e1 => insert,
         ])
         .await;
-    assert_eq!([&e0a2, &e2a1].as_set(), unwrap(&res).as_set());
-    assert_eq!([&e0a0new, &e0a1, &e0a2, &e2a1].as_set(), cache.dump().as_set());
+    assert_eq!([&a5].as_set(), unwrap(&res).as_set());
+    assert_eq!([&a2, &a5].as_set(), cache.dump().as_set());
 }
 
 #[tokio::test]
@@ -138,15 +118,14 @@ async fn data_too_large() {
     let clock = time::FakeClock::default();
     let now = clock.now_utc();
 
-    let accounts: Vec<_> = (0..3).map(|_| data::make_account_id(rng)).collect();
-    let mut signers = Signers::default();
-    let e = signers.make_epoch(rng, &[&accounts[0], &accounts[1], &accounts[2]]);
+    let signers = make_signers(rng, 3);
+    let e = make_account_keys(&signers);
 
     let cache = Arc::new(Cache::new());
-    cache.set_epochs(vec![&e]);
-    let a0 = signers.make_account_data(rng, &e.id, &accounts[0], now);
-    let a1 = signers.make_account_data(rng, &e.id, &accounts[1], now);
-    let mut a2_too_large = signers.make_account_data(rng, &e.id, &accounts[2], now);
+    cache.set_keys(e);
+    let a0 = signers[0].make_account_data(rng, now);
+    let a1 = signers[1].make_account_data(rng, now);
+    let mut a2_too_large = signers[2].make_account_data(rng, now);
     *a2_too_large.payload_mut() =
         (0..crate::network_protocol::MAX_ACCOUNT_DATA_SIZE_BYTES + 1).map(|_| 17).collect();
 
@@ -167,47 +146,20 @@ async fn data_too_large() {
 }
 
 #[tokio::test]
-async fn invalid_account() {
-    let mut rng = make_rng(2947294234);
-    let rng = &mut rng;
-    let clock = time::FakeClock::default();
-    let now = clock.now_utc();
-
-    let accounts: Vec<_> = (0..2).map(|_| data::make_account_id(rng)).collect();
-    let mut signers = Signers::default();
-    let e1 = signers.make_epoch(rng, &[&accounts[0]]);
-    let e2 = signers.make_epoch(rng, &[&accounts[1]]);
-
-    let cache = Arc::new(Cache::new());
-    cache.set_epochs(vec![&e1, &e2]);
-    let a0 = signers.make_account_data(rng, &e1.id, &accounts[0], now);
-    // Account 1 is active in epoch e2, not e1. It should cause InvalidAccount error.
-    let a1 = signers.make_account_data(rng, &e1.id, &accounts[1], now);
-
-    let res = cache.clone().insert(vec![a0.clone(), a1.clone()]).await;
-    assert_eq!(Some(Error::InvalidAccount), res.1);
-    // Partial update is allowed, in case an error is encountered.
-    assert!([&a0].as_set().is_superset(&res.0.as_set()));
-    // Partial update should match the state.
-    assert_eq!(res.0.as_set(), cache.dump().as_set());
-}
-
-#[tokio::test]
 async fn invalid_signature() {
     let mut rng = make_rng(2947294234);
     let rng = &mut rng;
     let clock = time::FakeClock::default();
     let now = clock.now_utc();
 
-    let accounts: Vec<_> = (0..3).map(|_| data::make_account_id(rng)).collect();
-    let mut signers = Signers::default();
-    let e = signers.make_epoch(rng, &[&accounts[0], &accounts[1], &accounts[2]]);
+    let signers = make_signers(rng, 3);
+    let e = make_account_keys(&signers);
 
     let cache = Arc::new(Cache::new());
-    cache.set_epochs(vec![&e]);
-    let a0 = signers.make_account_data(rng, &e.id, &accounts[0], now);
-    let mut a1 = signers.make_account_data(rng, &e.id, &accounts[1], now);
-    let mut a2_invalid_sig = signers.make_account_data(rng, &e.id, &accounts[2], now);
+    cache.set_keys(e);
+    let a0 = signers[0].make_account_data(rng, now);
+    let mut a1 = signers[1].make_account_data(rng, now);
+    let mut a2_invalid_sig = signers[2].make_account_data(rng, now);
     *a2_invalid_sig.signature_mut() = a1.signature_mut().clone();
 
     // invalid signature => InvalidSignature
@@ -233,17 +185,15 @@ async fn single_account_multiple_data() {
     let clock = time::FakeClock::default();
     let now = clock.now_utc();
 
-    let accounts: Vec<_> = (0..3).map(|_| data::make_account_id(rng)).collect();
-    let mut signers = Signers::default();
-    let e = signers.make_epoch(rng, &[&accounts[0], &accounts[1], &accounts[2]]);
+    let signers = make_signers(rng, 3);
+    let e = make_account_keys(&signers);
 
     let cache = Arc::new(Cache::new());
-    cache.set_epochs(vec![&e]);
-    let a0 = signers.make_account_data(rng, &e.id, &accounts[0], now);
-    let a1 = signers.make_account_data(rng, &e.id, &accounts[1], now);
-    let a2old = signers.make_account_data(rng, &e.id, &accounts[2], now);
-    let a2new =
-        signers.make_account_data(rng, &e.id, &accounts[2], now + time::Duration::seconds(1));
+    cache.set_keys(e);
+    let a0 = signers[0].make_account_data(rng, now);
+    let a1 = signers[1].make_account_data(rng, now);
+    let a2old = signers[2].make_account_data(rng, now);
+    let a2new = signers[2].make_account_data(rng, now + time::Duration::seconds(1));
 
     // 2 entries for the same (epoch_id,account_id) => SingleAccountMultipleData
     let res =

--- a/chain/network/src/accounts_data/tests.rs
+++ b/chain/network/src/accounts_data/tests.rs
@@ -8,6 +8,19 @@ use near_primitives::types::EpochId;
 use pretty_assertions::assert_eq;
 use std::sync::Arc;
 
+// run a trivial future until completion => OK
+#[tokio::test]
+async fn must_complete_ok() {
+    assert_eq!(5, must_complete(async move { 5 }).await);
+}
+
+// drop a trivial future without completion => panic (in debug mode at least).
+#[tokio::test]
+#[should_panic]
+async fn must_complete_should_panic() {
+    let _ = must_complete(async move { 6 });
+}
+
 struct Signer {
     epoch_id: EpochId,
     signer: near_crypto::InMemorySigner,

--- a/chain/network/src/accounts_data/tests.rs
+++ b/chain/network/src/accounts_data/tests.rs
@@ -1,0 +1,257 @@
+use crate::accounts_data::*;
+use crate::network_protocol::testonly as data;
+use crate::network_protocol::{AccountData, SignedAccountData};
+use crate::testonly::{make_rng, AsSet as _, Rng};
+use near_crypto::{InMemorySigner, SecretKey};
+use near_network_primitives::time;
+use near_network_primitives::types::NetworkEpochInfo;
+use near_primitives::types::{AccountId, EpochId};
+use pretty_assertions::assert_eq;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+#[derive(Default)]
+struct Signers {
+    keys: HashMap<(EpochId, AccountId), SecretKey>,
+}
+
+impl Signers {
+    fn key(&mut self, rng: &mut Rng, epoch_id: &EpochId, account_id: &AccountId) -> &SecretKey {
+        self.keys
+            .entry((epoch_id.clone(), account_id.clone()))
+            .or_insert_with(|| data::make_secret_key(rng))
+    }
+
+    fn make_epoch(&mut self, rng: &mut Rng, account_ids: &[&AccountId]) -> NetworkEpochInfo {
+        let epoch_id = data::make_epoch_id(rng);
+        NetworkEpochInfo {
+            id: epoch_id.clone(),
+            priority_accounts: account_ids
+                .iter()
+                .map(|aid| ((*aid).clone(), self.key(rng, &epoch_id, &aid).public_key()))
+                .collect(),
+        }
+    }
+
+    fn make_account_data(
+        &mut self,
+        rng: &mut Rng,
+        epoch_id: &EpochId,
+        account_id: &AccountId,
+        timestamp: time::Utc,
+    ) -> SignedAccountData {
+        let signer = InMemorySigner::from_secret_key(
+            account_id.clone(),
+            self.key(rng, epoch_id, account_id).clone(),
+        );
+        AccountData {
+            peers: (0..3)
+                .map(|_| {
+                    let ip = data::make_ipv6(rng);
+                    data::make_peer_addr(rng, ip)
+                })
+                .collect(),
+            account_id: account_id.clone(),
+            epoch_id: epoch_id.clone(),
+            timestamp,
+        }
+        .sign(&signer)
+        .unwrap()
+    }
+}
+
+fn unwrap<'a, T: std::hash::Hash + std::cmp::Eq, E: std::fmt::Debug>(
+    v: &'a (T, Option<E>),
+) -> &'a T {
+    if let Some(err) = &v.1 {
+        panic!("unexpected error: {err:?}");
+    }
+    &v.0
+}
+
+#[tokio::test]
+async fn happy_path() {
+    let mut rng = make_rng(2947294234);
+    let rng = &mut rng;
+    let clock = time::FakeClock::default();
+    let now = clock.now_utc();
+
+    let accounts: Vec<_> = (0..4).map(|_| data::make_account_id(rng)).collect();
+    let mut signers = Signers::default();
+    let e0 = signers.make_epoch(rng, &[&accounts[0], &accounts[1], &accounts[2]]);
+    let e1 = signers.make_epoch(rng, &[&accounts[0], &accounts[3]]);
+    let e2 = signers.make_epoch(rng, &[&accounts[1], &accounts[2]]);
+
+    let cache = Arc::new(Cache::new());
+    assert_eq!(cache.dump(), vec![]); // initially empty
+    cache.set_epochs(vec![&e0, &e1]);
+    assert_eq!(cache.dump(), vec![]); // empty after initial set_epoch.
+
+    // initial insert
+    let e0a0 = signers.make_account_data(rng, &e0.id, &accounts[0], now);
+    let e0a1 = signers.make_account_data(rng, &e0.id, &accounts[1], now);
+    let res = cache.clone().insert(vec![e0a0.clone(), e0a1.clone()]).await;
+    assert_eq!([&e0a0, &e0a1].as_set(), unwrap(&res).as_set());
+    assert_eq!([&e0a0, &e0a1].as_set(), cache.dump().as_set());
+
+    // entries of various types
+    let e1a0 = signers.make_account_data(rng, &e1.id, &accounts[0], now);
+    let e0a0new =
+        signers.make_account_data(rng, &e0.id, &accounts[0], now + time::Duration::seconds(1));
+    let e0a1old =
+        signers.make_account_data(rng, &e0.id, &accounts[1], now - time::Duration::seconds(1));
+    let e2a1 = signers.make_account_data(rng, &e2.id, &accounts[1], now);
+    let res = cache
+        .clone()
+        .insert(vec![
+            e1a0.clone(),    // initial value => insert
+            e0a0new.clone(), // with newer timestamp => insert,
+            e0a1old.clone(), // with older timestamp => filter out,
+            e2a1.clone(),    // from inactive epoch => filter out,
+        ])
+        .await;
+    assert_eq!([&e1a0, &e0a0new].as_set(), unwrap(&res).as_set());
+    assert_eq!([&e0a0new, &e0a1, &e1a0].as_set(), cache.dump().as_set());
+
+    // set_epoch again. Entries from inactive epochs should be dropped.
+    cache.set_epochs(vec![&e0, &e2]);
+    assert_eq!([&e0a0new, &e0a1].as_set(), cache.dump().as_set());
+    // insert some entries again.
+    let e0a2 = signers.make_account_data(rng, &e0.id, &accounts[2], now);
+    let e1a3 = signers.make_account_data(rng, &e1.id, &accounts[3], now);
+    let res = cache
+        .clone()
+        .insert(vec![
+            e0a2.clone(), // e0 is still active => insert,
+            e1a3.clone(), // e1 is not active any more => filter out,
+            e2a1.clone(), // e2 has become active => insert,
+        ])
+        .await;
+    assert_eq!([&e0a2, &e2a1].as_set(), unwrap(&res).as_set());
+    assert_eq!([&e0a0new, &e0a1, &e0a2, &e2a1].as_set(), cache.dump().as_set());
+}
+
+#[tokio::test]
+async fn data_too_large() {
+    let mut rng = make_rng(2947294234);
+    let rng = &mut rng;
+    let clock = time::FakeClock::default();
+    let now = clock.now_utc();
+
+    let accounts: Vec<_> = (0..3).map(|_| data::make_account_id(rng)).collect();
+    let mut signers = Signers::default();
+    let e = signers.make_epoch(rng, &[&accounts[0], &accounts[1], &accounts[2]]);
+
+    let cache = Arc::new(Cache::new());
+    cache.set_epochs(vec![&e]);
+    let a0 = signers.make_account_data(rng, &e.id, &accounts[0], now);
+    let a1 = signers.make_account_data(rng, &e.id, &accounts[1], now);
+    let mut a2_too_large = signers.make_account_data(rng, &e.id, &accounts[2], now);
+    *a2_too_large.payload_mut() =
+        (0..crate::network_protocol::MAX_ACCOUNT_DATA_SIZE_BYTES + 1).map(|_| 17).collect();
+
+    // too large payload => DataTooLarge
+    let res = cache
+        .clone()
+        .insert(vec![
+            a0.clone(),
+            a1.clone(),
+            a2_too_large.clone(), // invalid entry => DataTooLarge
+        ])
+        .await;
+    assert_eq!(Some(Error::DataTooLarge), res.1);
+    // Partial update is allowed, in case an error is encountered.
+    assert!([&a0, &a1].as_set().is_superset(&res.0.as_set()));
+    // Partial update should match the state.
+    assert_eq!(res.0.as_set(), cache.dump().as_set());
+}
+
+#[tokio::test]
+async fn invalid_account() {
+    let mut rng = make_rng(2947294234);
+    let rng = &mut rng;
+    let clock = time::FakeClock::default();
+    let now = clock.now_utc();
+
+    let accounts: Vec<_> = (0..2).map(|_| data::make_account_id(rng)).collect();
+    let mut signers = Signers::default();
+    let e1 = signers.make_epoch(rng, &[&accounts[0]]);
+    let e2 = signers.make_epoch(rng, &[&accounts[1]]);
+
+    let cache = Arc::new(Cache::new());
+    cache.set_epochs(vec![&e1, &e2]);
+    let a0 = signers.make_account_data(rng, &e1.id, &accounts[0], now);
+    // Account 1 is active in epoch e2, not e1. It should cause InvalidAccount error.
+    let a1 = signers.make_account_data(rng, &e1.id, &accounts[1], now);
+
+    let res = cache.clone().insert(vec![a0.clone(), a1.clone()]).await;
+    assert_eq!(Some(Error::InvalidAccount), res.1);
+    // Partial update is allowed, in case an error is encountered.
+    assert!([&a0].as_set().is_superset(&res.0.as_set()));
+    // Partial update should match the state.
+    assert_eq!(res.0.as_set(), cache.dump().as_set());
+}
+
+#[tokio::test]
+async fn invalid_signature() {
+    let mut rng = make_rng(2947294234);
+    let rng = &mut rng;
+    let clock = time::FakeClock::default();
+    let now = clock.now_utc();
+
+    let accounts: Vec<_> = (0..3).map(|_| data::make_account_id(rng)).collect();
+    let mut signers = Signers::default();
+    let e = signers.make_epoch(rng, &[&accounts[0], &accounts[1], &accounts[2]]);
+
+    let cache = Arc::new(Cache::new());
+    cache.set_epochs(vec![&e]);
+    let a0 = signers.make_account_data(rng, &e.id, &accounts[0], now);
+    let mut a1 = signers.make_account_data(rng, &e.id, &accounts[1], now);
+    let mut a2_invalid_sig = signers.make_account_data(rng, &e.id, &accounts[2], now);
+    *a2_invalid_sig.signature_mut() = a1.signature_mut().clone();
+
+    // invalid signature => InvalidSignature
+    let res = cache
+        .clone()
+        .insert(vec![
+            a0.clone(),
+            a1.clone(),
+            a2_invalid_sig.clone(), // invalid entry => DataTooLarge
+        ])
+        .await;
+    assert_eq!(Some(Error::InvalidSignature), res.1);
+    // Partial update is allowed, in case an error is encountered.
+    assert!([&a0, &a1].as_set().is_superset(&res.0.as_set()));
+    // Partial update should match the state.
+    assert_eq!(res.0.as_set(), cache.dump().as_set());
+}
+
+#[tokio::test]
+async fn single_account_multiple_data() {
+    let mut rng = make_rng(2947294234);
+    let rng = &mut rng;
+    let clock = time::FakeClock::default();
+    let now = clock.now_utc();
+
+    let accounts: Vec<_> = (0..3).map(|_| data::make_account_id(rng)).collect();
+    let mut signers = Signers::default();
+    let e = signers.make_epoch(rng, &[&accounts[0], &accounts[1], &accounts[2]]);
+
+    let cache = Arc::new(Cache::new());
+    cache.set_epochs(vec![&e]);
+    let a0 = signers.make_account_data(rng, &e.id, &accounts[0], now);
+    let a1 = signers.make_account_data(rng, &e.id, &accounts[1], now);
+    let a2old = signers.make_account_data(rng, &e.id, &accounts[2], now);
+    let a2new =
+        signers.make_account_data(rng, &e.id, &accounts[2], now + time::Duration::seconds(1));
+
+    // 2 entries for the same (epoch_id,account_id) => SingleAccountMultipleData
+    let res =
+        cache.clone().insert(vec![a0.clone(), a1.clone(), a2old.clone(), a2new.clone()]).await;
+    assert_eq!(Some(Error::SingleAccountMultipleData), res.1);
+    // Partial update is allowed, in case an error is encountered.
+    assert!([&a0, &a1, &a2old, &a2new].as_set().is_superset(&res.0.as_set()));
+    // Partial update should match the state, this also verifies that only 1 of the competing
+    // entries has been applied.
+    assert_eq!(res.0.as_set(), cache.dump().as_set());
+}

--- a/chain/network/src/lib.rs
+++ b/chain/network/src/lib.rs
@@ -3,9 +3,11 @@ pub use crate::peer_manager::peer_store::iter_peers_from_store;
 #[cfg(feature = "test_features")]
 pub use crate::stats::metrics::RECEIVED_INFO_ABOUT_ITSELF;
 
+mod accounts_data;
 mod network_protocol;
 mod peer;
 mod peer_manager;
+
 pub(crate) mod private_actix;
 pub mod routing;
 pub(crate) mod stats;

--- a/chain/network/src/network_protocol/testonly.rs
+++ b/chain/network/src/network_protocol/testonly.rs
@@ -87,7 +87,8 @@ pub fn make_signer<R: Rng>(rng: &mut R) -> InMemorySigner {
 
 pub fn make_validator_signer<R: Rng>(rng: &mut R) -> InMemoryValidatorSigner {
     let account_id = make_account_id(rng);
-    InMemoryValidatorSigner::from_seed(account_id.clone(), KeyType::ED25519, &account_id)
+    let seed = rng.gen::<u64>().to_string();
+    InMemoryValidatorSigner::from_seed(account_id, KeyType::ED25519, &seed)
 }
 
 pub fn make_peer_info<R: Rng>(rng: &mut R) -> PeerInfo {
@@ -314,7 +315,8 @@ pub fn make_peer_addr(rng: &mut impl Rng, ip: net::IpAddr) -> PeerAddr {
 
 pub fn make_account_data(
     rng: &mut impl Rng,
-    clock: &time::Clock,
+    timestamp: time::Utc,
+    epoch_id: EpochId,
     account_id: AccountId,
 ) -> AccountData {
     AccountData {
@@ -335,14 +337,17 @@ pub fn make_account_data(
             },
         ],
         account_id,
-        epoch_id: make_epoch_id(rng),
-        timestamp: clock.now_utc(),
+        epoch_id,
+        timestamp,
     }
 }
 
 pub fn make_signed_account_data(rng: &mut impl Rng, clock: &time::Clock) -> SignedAccountData {
     let signer = make_signer(rng);
-    make_account_data(rng, clock, signer.account_id.clone()).sign(&signer).unwrap()
+    let epoch_id = make_epoch_id(rng);
+    make_account_data(rng, clock.now_utc(), epoch_id, signer.account_id.clone())
+        .sign(&signer)
+        .unwrap()
 }
 
 // Accessors for creating malformed SignedAccountData

--- a/chain/network/src/network_protocol/testonly.rs
+++ b/chain/network/src/network_protocol/testonly.rs
@@ -226,6 +226,7 @@ impl ChunkSet {
 pub fn make_epoch_id<R: Rng>(rng: &mut R) -> EpochId {
     EpochId(CryptoHash::hash_bytes(&rng.gen::<[u8; 19]>()))
 }
+
 pub struct Chain {
     pub genesis_id: GenesisId,
     pub blocks: Vec<Block>,
@@ -342,4 +343,14 @@ pub fn make_account_data(
 pub fn make_signed_account_data(rng: &mut impl Rng, clock: &time::Clock) -> SignedAccountData {
     let signer = make_signer(rng);
     make_account_data(rng, clock, signer.account_id.clone()).sign(&signer).unwrap()
+}
+
+// Accessors for creating malformed SignedAccountData
+impl SignedAccountData {
+    pub(crate) fn payload_mut(&mut self) -> &mut Vec<u8> {
+        &mut self.payload.payload
+    }
+    pub(crate) fn signature_mut(&mut self) -> &mut near_crypto::Signature {
+        &mut self.payload.signature
+    }
 }

--- a/chain/network/src/testonly/mod.rs
+++ b/chain/network/src/testonly/mod.rs
@@ -1,3 +1,7 @@
+use std::cmp::Eq;
+use std::collections::HashSet;
+use std::hash::Hash;
+
 pub mod actix;
 pub mod fake_client;
 pub mod stream;
@@ -6,4 +10,20 @@ pub type Rng = rand_pcg::Pcg32;
 
 pub fn make_rng(seed: u64) -> Rng {
     Rng::new(seed, 0xa02bdbf7bb3c0a7)
+}
+
+pub trait AsSet<'a, T> {
+    fn as_set(&'a self) -> HashSet<&'a T>;
+}
+
+impl<'a, T: Hash + Eq> AsSet<'a, T> for Vec<T> {
+    fn as_set(&'a self) -> HashSet<&'a T> {
+        self.iter().collect()
+    }
+}
+
+impl<'a, T: Hash + Eq> AsSet<'a, T> for [&'a T] {
+    fn as_set(&'a self) -> HashSet<&'a T> {
+        self.iter().cloned().collect()
+    }
 }

--- a/chain/network/src/testonly/mod.rs
+++ b/chain/network/src/testonly/mod.rs
@@ -1,5 +1,7 @@
+use pretty_assertions::Comparison;
 use std::cmp::Eq;
 use std::collections::HashSet;
+use std::fmt::Debug;
 use std::hash::Hash;
 
 pub mod actix;
@@ -25,5 +27,12 @@ impl<'a, T: Hash + Eq> AsSet<'a, T> for Vec<T> {
 impl<'a, T: Hash + Eq> AsSet<'a, T> for [&'a T] {
     fn as_set(&'a self) -> HashSet<&'a T> {
         self.iter().cloned().collect()
+    }
+}
+
+#[track_caller]
+pub fn assert_is_superset<'a, T: Debug + Hash + Eq>(sup: &HashSet<&'a T>, sub: &HashSet<&'a T>) {
+    if !sup.is_superset(sub) {
+        panic!("expected a super set, got diff:\n{}", Comparison::new(sup, sub));
     }
 }

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -445,6 +445,7 @@ impl StateRootNode {
     Eq,
     PartialEq,
     PartialOrd,
+    Ord,
     DeriveAsRef,
     BorshSerialize,
     BorshDeserialize,


### PR DESCRIPTION
https://nearinc.atlassian.net/browse/CPR-94

accounts_data::Cache is the central component collecting the SignedAccountData (data about validator nodes broadcasted by the the validators themselves). It takes care of preventing DDOS attacks of various types: minimizes the amount of signature verifications (which is computationally expensive) and detects malicious data as early as possible. It will be plugged into the PeerManager logic in the next PR.