### PR TITLE
test: simplify cops support in KeyValue runtime

### DIFF
--- a/chain/chunks/src/test_utils.rs
+++ b/chain/chunks/src/test_utils.rs
@@ -162,15 +162,17 @@ impl ChunkTestFixture {
         // 3 block producer. 1 block producer + 2 chunk only producer per shard
         // This setup ensures that the chunk producer
         let (block_producers, chunk_producers) = make_validators(6, 2, 3);
-        let mock_runtime = Arc::new(KeyValueRuntime::new_with_validators_and_no_gc(
-            store.clone(),
-            block_producers,
-            chunk_producers,
-            3,
-            3,
-            5,
-            false,
-        ));
+        let mock_runtime = Arc::new(
+            KeyValueRuntime::new_with_validators_and_no_gc(
+                store.clone(),
+                block_producers,
+                3,
+                3,
+                5,
+                false,
+            )
+            .with_chunk_only_producers(chunk_producers),
+        );
         Self::new_with_runtime(false, mock_runtime)
     }
 

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -152,13 +152,9 @@ pub fn setup(
 ) -> (Block, ClientActor, Addr<ViewClientActor>) {
     let store = create_test_store();
     let num_validator_seats = validators.iter().map(|x| x.len()).sum::<usize>() as NumSeats;
-    #[cfg(feature = "protocol_feature_chunk_only_producers")]
-    let valset_num = validators.len();
     let runtime = Arc::new(KeyValueRuntime::new_with_validators_and_no_gc(
         store,
         validators,
-        #[cfg(feature = "protocol_feature_chunk_only_producers")]
-        vec![vec![vec![]; num_shards as usize]; valset_num],
         validator_groups,
         num_shards,
         epoch_length,
@@ -251,8 +247,6 @@ pub fn setup_only_view(
     let runtime = Arc::new(KeyValueRuntime::new_with_validators_and_no_gc(
         store,
         validators,
-        #[cfg(feature = "protocol_feature_chunk_only_producers")]
-        vec![vec![vec![]; num_shards as usize]],
         validator_groups,
         num_shards,
         epoch_length,


### PR DESCRIPTION
* eagarly compute assignemt of validators to blocks & chunks, which I find a bit easier to wrap my head around (you can print `EpochValidatorSet`s and just see the result)
* compress the code by centralizing cfg handling