### PR TITLE
also respect storage config when checking rocksdb version

### DIFF
--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -163,7 +163,7 @@ impl<'a> StoreOpener<'a> {
     /// Returns version of the database; or `None` if it does not exist.
     pub fn get_version_if_exists(&self) -> std::io::Result<Option<DbVersion>> {
         if self.check_if_exists() {
-            Some(crate::RocksDB::get_version(&self.path)).transpose()
+            Some(crate::RocksDB::get_version(&self.path, &self.config)).transpose()
         } else {
             Ok(None)
         }

--- a/core/store/src/db/rocksdb.rs
+++ b/core/store/src/db/rocksdb.rs
@@ -465,8 +465,8 @@ impl RocksDB {
     }
 
     /// Returns version of the database state on disk.
-    pub fn get_version(path: &Path) -> io::Result<DbVersion> {
-        let value = RocksDB::open(path, &StoreConfig::default(), Mode::ReadOnly)?
+    pub(crate) fn get_version(path: &Path, config: &StoreConfig) -> io::Result<DbVersion> {
+        let value = RocksDB::open(path, config, Mode::ReadOnly)?
             .get_raw_bytes(DBCol::DbVersion, crate::db::VERSION_KEY)?
             .ok_or_else(|| {
                 other_error(


### PR DESCRIPTION
In our case it's the number of file descriptors that is not respected.