### PR TITLE
store: refactor StoreUpdate

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2652,7 +2652,7 @@ impl Chain {
 
         // Saving the header data
         let mut store_update = self.store.store().store_update();
-        store_update.set_ser(DBCol::StateHeaders, &key, &shard_state_header)?;
+        store_update.set_ser(DBCol::StateHeaders, key, &shard_state_header)?;
         store_update.commit()?;
 
         Ok(shard_state_header)
@@ -2713,7 +2713,7 @@ impl Chain {
 
         // Saving the part data
         let mut store_update = self.store.store().store_update();
-        store_update.set(DBCol::StateParts, &key, &state_part);
+        store_update.set(DBCol::StateParts, key, state_part.clone());
         store_update.commit()?;
 
         Ok(state_part)
@@ -2868,7 +2868,7 @@ impl Chain {
         // Saving the header data.
         let mut store_update = self.store.store().store_update();
         let key = StateHeaderKey(shard_id, sync_hash).try_to_vec()?;
-        store_update.set_ser(DBCol::StateHeaders, &key, &shard_state_header)?;
+        store_update.set_ser(DBCol::StateHeaders, key, &shard_state_header)?;
         store_update.commit()?;
 
         Ok(())
@@ -2900,7 +2900,7 @@ impl Chain {
         // Saving the part data.
         let mut store_update = self.store.store().store_update();
         let key = StatePartKey(sync_hash, shard_id, part_id.idx).try_to_vec()?;
-        store_update.set(DBCol::StateParts, &key, data);
+        store_update.set(DBCol::StateParts, key, data.clone());
         store_update.commit()?;
         Ok(())
     }

--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -450,8 +450,8 @@ mod tests {
         // simulating IO error.
         store_update.set_raw_bytes(
             DBCol::Block,
-            chain.get_block_by_height(0).unwrap().hash().as_ref(),
-            &vec![123],
+            chain.get_block_by_height(0).unwrap().hash().into(),
+            vec![123],
         );
         store_update.commit().unwrap();
         match sv.validate_col(DBCol::Block) {
@@ -465,7 +465,7 @@ mod tests {
         let (chain, mut sv) = init();
         let mut store_update = chain.store().store().store_update();
         assert!(sv.validate_col(DBCol::TrieChanges).is_ok());
-        store_update.set_ser::<Vec<u8>>(DBCol::TrieChanges, "567".as_ref(), &vec![123]).unwrap();
+        store_update.set_ser(DBCol::TrieChanges, *b"567", &vec![123u8]).unwrap();
         store_update.commit().unwrap();
         match sv.validate_col(DBCol::TrieChanges) {
             Err(StoreValidatorError::DBCorruption(_)) => {}

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -52,6 +52,12 @@ impl From<ChunkHash> for Vec<u8> {
     }
 }
 
+impl From<&ChunkHash> for Vec<u8> {
+    fn from(chunk_hash: &ChunkHash) -> Self {
+        chunk_hash.0.into()
+    }
+}
+
 impl From<CryptoHash> for ChunkHash {
     fn from(crypto_hash: CryptoHash) -> Self {
         Self(crypto_hash)

--- a/core/store/src/db/refcount.rs
+++ b/core/store/src/db/refcount.rs
@@ -63,6 +63,8 @@ pub(crate) fn encode_negative_refcount(rc: std::num::NonZeroU32) -> Vec<u8> {
     (-i64::from(rc.get())).to_le_bytes().to_vec()
 }
 
+pub(crate) static MINUS_ONE_REFCOUNT: [u8; 8] = (-1i64).to_le_bytes();
+
 /// Merge reference counted values together.
 ///
 /// Extracts reference count from all provided value and sums them together and

--- a/core/store/src/migrations.rs
+++ b/core/store/src/migrations.rs
@@ -13,7 +13,11 @@ pub fn set_store_version(store: &Store, db_version: u32) {
     let mut store_update = store.store_update();
     // Contrary to other integers, we’re using textual representation for
     // storing DbVersion in VERSION_KEY thus to_string rather than to_le_bytes.
-    store_update.set(DBCol::DbVersion, crate::db::VERSION_KEY, db_version.to_string().as_bytes());
+    store_update.set(
+        DBCol::DbVersion,
+        crate::db::VERSION_KEY.to_vec(),
+        db_version.to_string().into_bytes(),
+    );
     store_update.commit().expect("Failed to write version to database");
 }
 

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -302,8 +302,8 @@ impl WrappedTrieChanges {
                 KeyForStateChanges::from_trie_key(&self.block_hash, &change_with_trie_key.trie_key);
             store_update.set(
                 DBCol::StateChanges,
-                storage_key.as_ref(),
-                &change_with_trie_key.try_to_vec().expect("Borsh serialize cannot fail"),
+                Vec::from(storage_key),
+                change_with_trie_key.try_to_vec().expect("Borsh serialize cannot fail"),
             );
         }
     }
@@ -311,7 +311,7 @@ impl WrappedTrieChanges {
     pub fn trie_changes_into(&mut self, store_update: &mut StoreUpdate) -> io::Result<()> {
         store_update.set_ser(
             DBCol::TrieChanges,
-            &shard_layout::get_block_shard_uid(&self.block_hash, &self.shard_uid),
+            shard_layout::get_block_shard_uid(&self.block_hash, &self.shard_uid),
             &self.trie_changes,
         )
     }

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -220,7 +220,7 @@ fn init_and_migrate_store(home_dir: &Path, near_config: &NearConfig) -> anyhow::
     );
     if !store_is_archive && client_is_archive {
         let mut update = store.store_update();
-        update.set_ser(DBCol::BlockMisc, near_store::db::IS_ARCHIVE_KEY, &true)?;
+        update.set_ser(DBCol::BlockMisc, near_store::db::IS_ARCHIVE_KEY.to_vec(), &true)?;
         update.commit()?;
     }
 
@@ -441,9 +441,9 @@ pub fn recompress_storage(home_dir: &Path, opts: RecompressOpts) -> anyhow::Resu
         let mut count_keys: u64 = 0;
         for item in src_store.iter_raw_bytes(column) {
             let (key, value) = item.with_context(|| format!("scanning column {column:?}"))?;
-            store_update.set_raw_bytes(column, &key, &value);
             total_written += value.len() as u64;
             batch_written += value.len() as u64;
+            store_update.set_raw_bytes(column, key.into_vec(), value.into_vec());
             count_keys += 1;
             if batch_written >= BATCH_SIZE_BYTES {
                 store_update.commit()?;
@@ -476,7 +476,7 @@ pub fn recompress_storage(home_dir: &Path, opts: RecompressOpts) -> anyhow::Resu
         let chunk_tail = final_head_height.unwrap();
         info!(target: "recompress", %chunk_tail, "Setting chunk tail");
         let mut store_update = dst_store.store_update();
-        store_update.set_ser(DBCol::BlockMisc, near_store::CHUNK_TAIL_KEY, &chunk_tail)?;
+        store_update.set_ser(DBCol::BlockMisc, near_store::CHUNK_TAIL_KEY.to_vec(), &chunk_tail)?;
         store_update.commit()?;
     }
 


### PR DESCRIPTION
Use Deref magic to move all methods which queue new operations out of
StoreUpdate to DBTransaction and use generic arguments so that borrowed
slices as well as owned vector are accepted as arguments.  This avoids
owned vector from being cloned unnecessarily.