### PR TITLE
show output file path after dumping tx

### DIFF
--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -137,6 +137,7 @@ pub(crate) fn dump_tx(
         Some(path) => PathBuf::from(path),
         None => PathBuf::from(&home_dir).join("tx.json"),
     };
+    println!("Saving tx (height {} to {}) into {}", start_height, end_height, json_path.display(),);
     fs::write(json_path, json!(txs).to_string())
         .expect("Error writing the results to a json file.");
     return Ok(());


### PR DESCRIPTION
This PR adds a line of output at the end of `dump_state`, for convenience. 

### Test steps
 - `make neard`
 - `/target/release/neard --home $NEAR_HOME_PATH view-state dump_tx --start-height $X --end-height $Y`
 - expect to see a line of output in the end that shows 

### Reviewers
 - @mzhangmzz 
 - @mm-near 