### PR TITLE
debug: forward debug flag to loading estimation

### DIFF
--- a/runtime/runtime-params-estimator/src/function_call.rs
+++ b/runtime/runtime-params-estimator/src/function_call.rs
@@ -32,7 +32,7 @@ pub(crate) fn contract_loading_cost(config: &Config) -> (GasCost, GasCost) {
     }
 
     let tolerance = LeastSquaresTolerance::default();
-    GasCost::least_squares_method_gas_cost(&xs, &ys, &tolerance, false)
+    GasCost::least_squares_method_gas_cost(&xs, &ys, &tolerance, config.debug)
 }
 
 fn make_many_methods_contract(method_count: i32) -> ContractCode {


### PR DESCRIPTION
--debug flag on estimator is used to show intermediate results and other
useful information. The contract loading estimation did not respect this
flag so far because the code predates the debug flag.