### PR TITLE
refactor: Make the near-client-primitives optional dependency in near-jsonrpc-primitives

### DIFF
--- a/chain/jsonrpc-primitives/Cargo.toml
+++ b/chain/jsonrpc-primitives/Cargo.toml
@@ -22,7 +22,9 @@ near-crypto = { path = "../../core/crypto" }
 near-primitives = { path = "../../core/primitives" }
 near-chain-configs = { path = "../../core/chain-configs" }
 near-rpc-error-macro = { path = "../../tools/rpctypegen/macro" }
-near-client-primitives = { path = "../client-primitives" }
+near-client-primitives = { path = "../client-primitives", optional = true }
 
 [features]
+full = ["debug_types"]
+debug_types = ["near-client-primitives"]
 test_features = []

--- a/chain/jsonrpc-primitives/src/types/status.rs
+++ b/chain/jsonrpc-primitives/src/types/status.rs
@@ -6,6 +6,7 @@ pub struct RpcStatusResponse {
     pub status_response: near_primitives::views::StatusResponse,
 }
 
+#[cfg(feature = "debug_types")]
 #[derive(Debug, Serialize)]
 pub struct RpcDebugStatusResponse {
     pub status_response: near_client_primitives::debug::DebugStatusResponse,

--- a/chain/jsonrpc/Cargo.toml
+++ b/chain/jsonrpc/Cargo.toml
@@ -28,7 +28,7 @@ near-client = { path = "../client" }
 near-network = { path = "../network" }
 near-o11y = { path = "../../core/o11y" }
 near-jsonrpc-client = { path = "client" }
-near-jsonrpc-primitives = { path = "../jsonrpc-primitives" }
+near-jsonrpc-primitives = { path = "../jsonrpc-primitives", features = ["full"] }
 near-jsonrpc-adversarial-primitives = { path = "../jsonrpc-adversarial-primitives", optional = true }
 near-rpc-error-macro = { path = "../../tools/rpctypegen/macro" }
 near-network-primitives = { path = "../network-primitives" }


### PR DESCRIPTION
This cuts the number of dependencies pulled in by `near-jsonrpc-primitives` from 211 down to 145. I am especially happy to see `actix` and `tokio` gone! This will help `near-jsonrpc-client` to be a bit slimmer.