### PR TITLE
add metrics for block ordinal for current chain head

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -638,6 +638,8 @@ impl Chain {
               block_head.height, block_head.last_block_hash,
               header_head.height, header_head.last_block_hash);
         metrics::BLOCK_HEIGHT_HEAD.set(block_head.height as i64);
+        let block_header = store.get_block_header(&block_head.last_block_hash)?;
+        metrics::BLOCK_ORDINAL_HEAD.set(block_header.block_ordinal() as i64);
         metrics::HEADER_HEAD_HEIGHT.set(header_head.height as i64);
 
         metrics::TAIL_HEIGHT.set(store.tail()? as i64);
@@ -4855,6 +4857,7 @@ impl<'a> ChainUpdate<'a> {
 
             self.chain_store_update.save_body_head(&tip)?;
             metrics::BLOCK_HEIGHT_HEAD.set(tip.height as i64);
+            metrics::BLOCK_ORDINAL_HEAD.set(header.block_ordinal() as i64);
             debug!(target: "chain", "Head updated to {} at {}", tip.last_block_hash, tip.height);
             Ok(Some(tip))
         } else {

--- a/chain/chain/src/metrics.rs
+++ b/chain/chain/src/metrics.rs
@@ -23,6 +23,10 @@ pub static BLOCK_HEIGHT_HEAD: Lazy<IntGauge> = Lazy::new(|| {
     try_create_int_gauge("near_block_height_head", "Height of the current head of the blockchain")
         .unwrap()
 });
+pub static BLOCK_ORDINAL_HEAD: Lazy<IntGauge> = Lazy::new(|| {
+    try_create_int_gauge("near_block_ordinal_head", "Ordinal of the current head of the blockchain")
+        .unwrap()
+});
 pub static VALIDATOR_AMOUNT_STAKED: Lazy<IntGauge> = Lazy::new(|| {
     try_create_int_gauge(
         "near_validators_stake_total",


### PR DESCRIPTION
This will be used to calculate number of skipped blocks. The current calculation of this metrics is problematic. 