### PR TITLE
core: harmonise dec_format serialisation formats

### DIFF
--- a/core/chain-configs/src/genesis_config.rs
+++ b/core/chain-configs/src/genesis_config.rs
@@ -26,7 +26,7 @@ use near_primitives::version::ProtocolFeature;
 use near_primitives::{
     hash::CryptoHash,
     runtime::config::RuntimeConfig,
-    serialize::{u128_dec_format, u128_dec_format_compatible},
+    serialize::dec_format,
     state_record::StateRecord,
     types::{
         AccountId, AccountInfo, Balance, BlockHeight, BlockHeightDelta, EpochHeight, Gas,
@@ -116,9 +116,9 @@ pub struct GenesisConfig {
     /// Initial gas limit.
     pub gas_limit: Gas,
     /// Minimum gas price. It is also the initial gas price.
-    #[serde(with = "u128_dec_format_compatible")]
+    #[serde(with = "dec_format")]
     pub min_gas_price: Balance,
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     #[default(MAX_GAS_PRICE)]
     pub max_gas_price: Balance,
     /// Criterion for kicking out block producers (this is a number between 0 and 100)
@@ -147,7 +147,7 @@ pub struct GenesisConfig {
     #[default(Rational32::from_integer(0))]
     pub max_inflation_rate: Rational32,
     /// Total supply of tokens at genesis.
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     pub total_supply: Balance,
     /// Expected number of blocks per year
     pub num_blocks_per_year: NumBlocks,
@@ -155,7 +155,7 @@ pub struct GenesisConfig {
     #[default("near".parse().unwrap())]
     pub protocol_treasury_account: AccountId,
     /// Fishermen stake threshold.
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     pub fishermen_threshold: Balance,
     /// The minimum stake required for staking is last seat price divided by this number.
     #[serde(default = "default_minimum_stake_divisor")]
@@ -597,10 +597,10 @@ pub struct ProtocolConfigView {
     /// Initial gas limit.
     pub gas_limit: Gas,
     /// Minimum gas price. It is also the initial gas price.
-    #[serde(with = "u128_dec_format_compatible")]
+    #[serde(with = "dec_format")]
     pub min_gas_price: Balance,
     /// Maximum gas price.
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     pub max_gas_price: Balance,
     /// Criterion for kicking out block producers (this is a number between 0 and 100)
     pub block_producer_kickout_threshold: u8,
@@ -625,7 +625,7 @@ pub struct ProtocolConfigView {
     /// Protocol treasury account
     pub protocol_treasury_account: AccountId,
     /// Fishermen stake threshold.
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     pub fishermen_threshold: Balance,
     /// The minimum stake required for staking is last seat price divided by this number.
     pub minimum_stake_divisor: u64,

--- a/core/primitives-core/src/account.rs
+++ b/core/primitives-core/src/account.rs
@@ -5,7 +5,7 @@ use std::io;
 pub use near_account_id as id;
 
 use crate::hash::CryptoHash;
-use crate::serialize::{option_u128_dec_format, u128_dec_format_compatible};
+use crate::serialize::dec_format;
 use crate::types::{Balance, Nonce, StorageUsage};
 #[derive(
     BorshSerialize, BorshDeserialize, Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Copy,
@@ -24,10 +24,10 @@ impl Default for AccountVersion {
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 pub struct Account {
     /// The total not locked tokens.
-    #[serde(with = "u128_dec_format_compatible")]
+    #[serde(with = "dec_format")]
     amount: Balance,
     /// The amount locked due to staking.
-    #[serde(with = "u128_dec_format_compatible")]
+    #[serde(with = "dec_format")]
     locked: Balance,
     /// Hash of the code stored in the storage for this account.
     code_hash: CryptoHash,
@@ -194,7 +194,7 @@ pub struct FunctionCallPermission {
     /// `None` means unlimited allowance.
     /// NOTE: To change or increase the allowance, the old access key needs to be deleted and a new
     /// access key should be created.
-    #[serde(with = "option_u128_dec_format")]
+    #[serde(with = "dec_format")]
     pub allowance: Option<Balance>,
 
     // This isn't an AccountId because already existing records in testnet genesis have invalid

--- a/core/primitives-core/src/runtime/fees.rs
+++ b/core/primitives-core/src/runtime/fees.rs
@@ -301,27 +301,3 @@ pub fn transfer_send_fee(
         cfg.transfer_cost.send_fee(sender_is_receiver)
     }
 }
-
-/// Serde serializer for u128 to integer.
-/// This is copy from core/primitives/src/serialize.rs
-/// It is required as this module doesn't depend on primitives.
-/// TODO(3384): move basic primitives into a separate module and use in runtime.
-pub mod u128_dec_format {
-    use serde::de;
-    use serde::{Deserialize, Deserializer, Serializer};
-
-    pub fn serialize<S>(num: &u128, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(&format!("{}", num))
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<u128, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-        u128::from_str_radix(&s, 10).map_err(de::Error::custom)
-    }
-}

--- a/core/primitives-core/src/serialize.rs
+++ b/core/primitives-core/src/serialize.rs
@@ -206,7 +206,7 @@ pub mod dec_format {
             Self::from_str_radix(value, 10)
         }
         fn from_u64(value: u64) -> Self {
-            value as u128
+            value.into()
         }
     }
 

--- a/core/primitives-core/src/serialize.rs
+++ b/core/primitives-core/src/serialize.rs
@@ -158,23 +158,112 @@ fn test_base_bytes_format() {
     assert_de_error::<Test>("{\"field\":null}");
 }
 
-pub mod u64_dec_format {
+/// Serialises number as a string; deserialises either as a string or number.
+///
+/// This format works for `u64`, `u128`, `Option<u64>` and `Option<u128>` types.
+/// When serialising, numbers are serialised as decimal strings.  When
+/// deserialising, strings are parsed as decimal numbers while numbers are
+/// interpreted as is.
+pub mod dec_format {
     use serde::de;
-    use serde::{Deserialize, Deserializer, Serializer};
+    use serde::{Deserializer, Serializer};
 
-    pub fn serialize<S>(num: &u64, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(&format!("{}", num))
+    /// Abstraction between integers that we serialise.
+    pub trait DecType: Sized {
+        /// Formats number as a decimal string; passes `None` as is.
+        fn serialize(&self) -> Option<String>;
+
+        /// Constructs Self from a `null` value.  Returns error if this type
+        /// does not accept `null` values.
+        fn try_from_unit() -> Result<Self, ()> {
+            Err(())
+        }
+
+        /// Tries to parse decimal string as an integer.
+        fn try_from_str(value: &str) -> Result<Self, std::num::ParseIntError>;
+
+        /// Constructs Self from a 64-bit unsigned integer.
+        fn from_u64(value: u64) -> Self;
     }
 
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<u64, D::Error>
+    impl DecType for u64 {
+        fn serialize(&self) -> Option<String> {
+            Some(self.to_string())
+        }
+        fn try_from_str(value: &str) -> Result<Self, std::num::ParseIntError> {
+            Self::from_str_radix(value, 10)
+        }
+        fn from_u64(value: u64) -> Self {
+            value
+        }
+    }
+
+    impl DecType for u128 {
+        fn serialize(&self) -> Option<String> {
+            Some(self.to_string())
+        }
+        fn try_from_str(value: &str) -> Result<Self, std::num::ParseIntError> {
+            Self::from_str_radix(value, 10)
+        }
+        fn from_u64(value: u64) -> Self {
+            value as u128
+        }
+    }
+
+    impl<T: DecType> DecType for Option<T> {
+        fn serialize(&self) -> Option<String> {
+            self.as_ref().and_then(DecType::serialize)
+        }
+        fn try_from_unit() -> Result<Self, ()> {
+            Ok(None)
+        }
+        fn try_from_str(value: &str) -> Result<Self, std::num::ParseIntError> {
+            Some(T::try_from_str(value)).transpose()
+        }
+        fn from_u64(value: u64) -> Self {
+            Some(T::from_u64(value))
+        }
+    }
+
+    struct Visitor<T>(core::marker::PhantomData<T>);
+
+    impl<'de, T: DecType> de::Visitor<'de> for Visitor<T> {
+        type Value = T;
+
+        fn expecting(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+            fmt.write_str("a non-negative integer as a string")
+        }
+
+        fn visit_unit<E: de::Error>(self) -> Result<T, E> {
+            T::try_from_unit().map_err(|_| de::Error::invalid_type(de::Unexpected::Option, &self))
+        }
+
+        fn visit_u64<E: de::Error>(self, value: u64) -> Result<T, E> {
+            Ok(T::from_u64(value))
+        }
+
+        fn visit_str<E: de::Error>(self, value: &str) -> Result<T, E> {
+            T::try_from_str(value).map_err(de::Error::custom)
+        }
+    }
+
+    pub fn deserialize<'de, D, T>(deserializer: D) -> Result<T, D::Error>
     where
         D: Deserializer<'de>,
+        T: DecType,
     {
-        let s = String::deserialize(deserializer)?;
-        u64::from_str_radix(&s, 10).map_err(de::Error::custom)
+        deserializer.deserialize_any(Visitor(Default::default()))
+    }
+
+    pub fn serialize<S, T>(num: &T, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        T: DecType,
+    {
+        match num.serialize() {
+            Some(value) => serializer.serialize_str(&value),
+            None => serializer.serialize_none(),
+        }
     }
 }
 
@@ -182,85 +271,23 @@ pub mod u64_dec_format {
 fn test_u64_dec_format() {
     #[derive(PartialEq, Debug, serde::Deserialize, serde::Serialize)]
     struct Test {
-        #[serde(with = "u64_dec_format")]
+        #[serde(with = "dec_format")]
         field: u64,
     }
 
     assert_round_trip("{\"field\":\"42\"}", Test { field: 42 });
     assert_round_trip("{\"field\":\"18446744073709551615\"}", Test { field: u64::MAX });
+    assert_deserialise("{\"field\":42}", Test { field: 42 });
     assert_de_error::<Test>("{\"field\":18446744073709551616}");
     assert_de_error::<Test>("{\"field\":\"18446744073709551616\"}");
-    assert_de_error::<Test>("{\"field\":42}");
-}
-
-pub mod u128_dec_format {
-    use serde::de;
-    use serde::{Deserialize, Deserializer, Serializer};
-
-    pub fn serialize<S>(num: &u128, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(&format!("{}", num))
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<u128, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-        u128::from_str_radix(&s, 10).map_err(de::Error::custom)
-    }
+    assert_de_error::<Test>("{\"field\":42.0}");
 }
 
 #[test]
 fn test_u128_dec_format() {
     #[derive(PartialEq, Debug, serde::Deserialize, serde::Serialize)]
     struct Test {
-        #[serde(with = "u128_dec_format")]
-        field: u128,
-    }
-
-    assert_round_trip("{\"field\":\"42\"}", Test { field: 42 });
-    assert_round_trip("{\"field\":\"18446744073709551615\"}", Test { field: u64::MAX as u128 });
-    assert_round_trip("{\"field\":\"18446744073709551616\"}", Test { field: 18446744073709551616 });
-    assert_de_error::<Test>("{\"field\":42}");
-    assert_de_error::<Test>("{\"field\":null}");
-}
-
-pub mod u128_dec_format_compatible {
-    //! This in an extension to `u128_dec_format` that serves a compatibility layer role to
-    //! deserialize u128 from a "small" JSON number (u64).
-    //!
-    //! It is unfortunate that we cannot enable "arbitrary_precision" feature in
-    //! serde_json due to a bug: <https://github.com/serde-rs/json/issues/505>.
-    use serde::{de, Deserialize, Deserializer};
-
-    pub use super::u128_dec_format::serialize;
-
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum U128 {
-        Number(u64),
-        String(String),
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<u128, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        match U128::deserialize(deserializer)? {
-            U128::Number(value) => Ok(u128::from(value)),
-            U128::String(value) => u128::from_str_radix(&value, 10).map_err(de::Error::custom),
-        }
-    }
-}
-
-#[test]
-fn test_u128_dec_format_compatible() {
-    #[derive(PartialEq, Debug, serde::Deserialize, serde::Serialize)]
-    struct Test {
-        #[serde(with = "u128_dec_format_compatible")]
+        #[serde(with = "dec_format")]
         field: u128,
     }
 
@@ -269,41 +296,14 @@ fn test_u128_dec_format_compatible() {
     assert_round_trip("{\"field\":\"18446744073709551616\"}", Test { field: 18446744073709551616 });
     assert_deserialise("{\"field\":42}", Test { field: 42 });
     assert_de_error::<Test>("{\"field\":null}");
-}
-
-pub mod option_u128_dec_format {
-    use serde::de;
-    use serde::{Deserialize, Deserializer, Serializer};
-
-    pub fn serialize<S>(data: &Option<u128>, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        if let Some(ref num) = data {
-            serializer.serialize_str(&format!("{}", num))
-        } else {
-            serializer.serialize_none()
-        }
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<u128>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s: Option<String> = Option::deserialize(deserializer)?;
-        if let Some(s) = s {
-            Ok(Some(u128::from_str_radix(&s, 10).map_err(de::Error::custom)?))
-        } else {
-            Ok(None)
-        }
-    }
+    assert_de_error::<Test>("{\"field\":42.0}");
 }
 
 #[test]
 fn test_option_u128_dec_format() {
     #[derive(PartialEq, Debug, serde::Deserialize, serde::Serialize)]
     struct Test {
-        #[serde(with = "option_u128_dec_format")]
+        #[serde(with = "dec_format")]
         field: Option<u128>,
     }
 
@@ -317,7 +317,8 @@ fn test_option_u128_dec_format() {
         "{\"field\":\"18446744073709551616\"}",
         Test { field: Some(18446744073709551616) },
     );
-    assert_de_error::<Test>("{\"field\":42}");
+    assert_deserialise("{\"field\":42}", Test { field: Some(42) });
+    assert_de_error::<Test>("{\"field\":42.0}");
 }
 
 #[cfg(test)]

--- a/core/primitives-core/src/serialize.rs
+++ b/core/primitives-core/src/serialize.rs
@@ -235,7 +235,7 @@ pub mod dec_format {
         }
 
         fn visit_unit<E: de::Error>(self) -> Result<T, E> {
-            T::try_from_unit().map_err(|_| de::Error::invalid_type(de::Unexpected::Option, &self))
+            T::try_from_unit().map_err(|()| de::Error::invalid_type(de::Unexpected::Option, &self))
         }
 
         fn visit_u64<E: de::Error>(self, value: u64) -> Result<T, E> {

--- a/core/primitives/src/errors.rs
+++ b/core/primitives/src/errors.rs
@@ -1,4 +1,4 @@
-use crate::serialize::u128_dec_format;
+use crate::serialize::dec_format;
 use crate::types::{AccountId, Balance, EpochId, Gas, Nonce};
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_crypto::PublicKey;
@@ -117,9 +117,9 @@ pub enum InvalidTxError {
     /// Account does not have enough balance to cover TX cost
     NotEnoughBalance {
         signer_id: AccountId,
-        #[serde(with = "u128_dec_format")]
+        #[serde(with = "dec_format")]
         balance: Balance,
-        #[serde(with = "u128_dec_format")]
+        #[serde(with = "dec_format")]
         cost: Balance,
     },
     /// Signer account doesn't have enough balance after transaction.
@@ -127,7 +127,7 @@ pub enum InvalidTxError {
         /// An account which doesn't have enough balance to cover storage.
         signer_id: AccountId,
         /// Required balance to cover the state.
-        #[serde(with = "u128_dec_format")]
+        #[serde(with = "dec_format")]
         amount: Balance,
     },
     /// An integer overflow occurred during transaction cost estimation.
@@ -161,9 +161,9 @@ pub enum InvalidAccessKeyError {
     NotEnoughAllowance {
         account_id: AccountId,
         public_key: PublicKey,
-        #[serde(with = "u128_dec_format")]
+        #[serde(with = "dec_format")]
         allowance: Balance,
-        #[serde(with = "u128_dec_format")]
+        #[serde(with = "dec_format")]
         cost: Balance,
     },
     /// Having a deposit with a function call action is not allowed with a function call access key.
@@ -408,7 +408,7 @@ pub enum ActionErrorKind {
         /// An account which needs balance
         account_id: AccountId,
         /// Balance required to complete an action.
-        #[serde(with = "u128_dec_format")]
+        #[serde(with = "dec_format")]
         amount: Balance,
     },
     /// Account is not yet staked, but tries to unstake
@@ -416,18 +416,18 @@ pub enum ActionErrorKind {
     /// The account doesn't have enough balance to increase the stake.
     TriesToStake {
         account_id: AccountId,
-        #[serde(with = "u128_dec_format")]
+        #[serde(with = "dec_format")]
         stake: Balance,
-        #[serde(with = "u128_dec_format")]
+        #[serde(with = "dec_format")]
         locked: Balance,
-        #[serde(with = "u128_dec_format")]
+        #[serde(with = "dec_format")]
         balance: Balance,
     },
     InsufficientStake {
         account_id: AccountId,
-        #[serde(with = "u128_dec_format")]
+        #[serde(with = "dec_format")]
         stake: Balance,
-        #[serde(with = "u128_dec_format")]
+        #[serde(with = "dec_format")]
         minimum_stake: Balance,
     },
     /// An error occurred during a `FunctionCall` Action, parameter is debug message.
@@ -558,30 +558,30 @@ impl std::error::Error for InvalidAccessKeyError {}
 )]
 pub struct BalanceMismatchError {
     // Input balances
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     pub incoming_validator_rewards: Balance,
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     pub initial_accounts_balance: Balance,
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     pub incoming_receipts_balance: Balance,
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     pub processed_delayed_receipts_balance: Balance,
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     pub initial_postponed_receipts_balance: Balance,
     // Output balances
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     pub final_accounts_balance: Balance,
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     pub outgoing_receipts_balance: Balance,
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     pub new_delayed_receipts_balance: Balance,
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     pub final_postponed_receipts_balance: Balance,
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     pub tx_burnt_amount: Balance,
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     pub slashed_burnt_amount: Balance,
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     pub other_burnt_amount: Balance,
 }
 

--- a/core/primitives/src/receipt.rs
+++ b/core/primitives/src/receipt.rs
@@ -9,7 +9,7 @@ use near_crypto::{KeyType, PublicKey};
 use crate::borsh::maybestd::collections::HashMap;
 use crate::hash::CryptoHash;
 use crate::logging;
-use crate::serialize::{option_base64_format, u128_dec_format_compatible};
+use crate::serialize::{dec_format, option_base64_format};
 use crate::transaction::{Action, TransferAction};
 use crate::types::{AccountId, Balance, ShardId};
 
@@ -106,7 +106,7 @@ pub struct ActionReceipt {
     /// An access key which was used to sign the original transaction
     pub signer_public_key: PublicKey,
     /// A gas_price which has been used to buy gas in the original transaction
-    #[serde(with = "u128_dec_format_compatible")]
+    #[serde(with = "dec_format")]
     pub gas_price: Balance,
     /// If present, where to route the output data
     pub output_data_receivers: Vec<DataReceiver>,

--- a/core/primitives/src/runtime/config.rs
+++ b/core/primitives/src/runtime/config.rs
@@ -5,7 +5,7 @@ use crate::config::VMConfig;
 use crate::runtime::config_store::INITIAL_TESTNET_CONFIG;
 use crate::runtime::fees::RuntimeFeesConfig;
 use crate::runtime::parameter_table::ParameterTable;
-use crate::serialize::u128_dec_format;
+use crate::serialize::dec_format;
 use crate::types::{AccountId, Balance};
 
 use super::parameter_table::InvalidConfigError;
@@ -15,7 +15,7 @@ use super::parameter_table::InvalidConfigError;
 pub struct RuntimeConfig {
     /// Amount of yN per byte required to have on the account.  See
     /// <https://nomicon.io/Economics/README.html#state-stake> for details.
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     pub storage_amount_per_byte: Balance,
     /// Costs of different actions that need to be performed when sending and processing transaction
     /// and receipts.

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -12,7 +12,7 @@ use crate::errors::TxExecutionError;
 use crate::hash::{hash, CryptoHash};
 use crate::logging;
 use crate::merkle::MerklePath;
-use crate::serialize::{base64_format, u128_dec_format_compatible};
+use crate::serialize::{base64_format, dec_format};
 use crate::types::{AccountId, Balance, Gas, Nonce};
 use near_primitives_core::profile::ProfileData;
 
@@ -129,7 +129,7 @@ pub struct FunctionCallAction {
     #[serde(with = "base64_format")]
     pub args: Vec<u8>,
     pub gas: Gas,
-    #[serde(with = "u128_dec_format_compatible")]
+    #[serde(with = "dec_format")]
     pub deposit: Balance,
 }
 
@@ -153,7 +153,7 @@ impl fmt::Debug for FunctionCallAction {
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
 pub struct TransferAction {
-    #[serde(with = "u128_dec_format_compatible")]
+    #[serde(with = "dec_format")]
     pub deposit: Balance,
 }
 
@@ -168,7 +168,7 @@ impl From<TransferAction> for Action {
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
 pub struct StakeAction {
     /// Amount of tokens to stake.
-    #[serde(with = "u128_dec_format_compatible")]
+    #[serde(with = "dec_format")]
     pub stake: Balance,
     /// Validator key which will be used to sign transactions on behalf of singer_id
     pub public_key: PublicKey,

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -9,7 +9,7 @@ use crate::account::{AccessKey, Account};
 use crate::challenge::ChallengesResult;
 use crate::errors::EpochError;
 use crate::hash::CryptoHash;
-use crate::serialize::u128_dec_format;
+use crate::serialize::dec_format;
 use crate::trie_key::TrieKey;
 
 use crate::receipt::Receipt;
@@ -48,7 +48,7 @@ pub struct AccountWithPublicKey {
 pub struct AccountInfo {
     pub account_id: AccountId,
     pub public_key: PublicKey,
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     pub amount: Balance,
 }
 
@@ -871,9 +871,9 @@ pub enum ValidatorKickoutReason {
     Unstaked,
     /// Validator stake is now below threshold
     NotEnoughStake {
-        #[serde(with = "u128_dec_format", rename = "stake_u128")]
+        #[serde(with = "dec_format", rename = "stake_u128")]
         stake: Balance,
-        #[serde(with = "u128_dec_format", rename = "threshold_u128")]
+        #[serde(with = "dec_format", rename = "threshold_u128")]
         threshold: Balance,
     },
     /// Enough stake but is not chosen because of seat limits.

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -26,10 +26,7 @@ use crate::logging;
 use crate::merkle::MerklePath;
 use crate::profile::Cost;
 use crate::receipt::{ActionReceipt, DataReceipt, DataReceiver, Receipt, ReceiptEnum};
-use crate::serialize::{
-    base64_format, from_base64, option_base64_format, option_u128_dec_format, to_base64,
-    u128_dec_format, u64_dec_format,
-};
+use crate::serialize::{base64_format, dec_format, from_base64, option_base64_format, to_base64};
 use crate::sharding::{
     ChunkHash, ShardChunk, ShardChunkHeader, ShardChunkHeaderInner, ShardChunkHeaderInnerV2,
     ShardChunkHeaderV3,
@@ -52,9 +49,9 @@ use validator_stake_view::ValidatorStakeView;
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub struct AccountView {
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     pub amount: Balance,
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     pub locked: Balance,
     pub code_hash: CryptoHash,
     pub storage_usage: StorageUsage,
@@ -141,7 +138,7 @@ impl From<ContractCodeView> for ContractCode {
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub enum AccessKeyPermissionView {
     FunctionCall {
-        #[serde(with = "option_u128_dec_format")]
+        #[serde(with = "dec_format")]
         allowance: Option<Balance>,
         receiver_id: String,
         method_names: Vec<String>,
@@ -456,21 +453,21 @@ pub struct BlockHeaderView {
     pub challenges_root: CryptoHash,
     /// Legacy json number. Should not be used.
     pub timestamp: u64,
-    #[serde(with = "u64_dec_format")]
+    #[serde(with = "dec_format")]
     pub timestamp_nanosec: u64,
     pub random_value: CryptoHash,
     pub validator_proposals: Vec<ValidatorStakeView>,
     pub chunk_mask: Vec<bool>,
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     pub gas_price: Balance,
     pub block_ordinal: Option<NumBlocks>,
     /// TODO(2271): deprecated.
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     pub rent_paid: Balance,
     /// TODO(2271): deprecated.
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     pub validator_reward: Balance,
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     pub total_supply: Balance,
     pub challenges_result: ChallengesResult,
     pub last_final_block: CryptoHash,
@@ -649,7 +646,7 @@ pub struct BlockHeaderInnerLiteView {
     pub outcome_root: CryptoHash,
     /// Legacy json number. Should not be used.
     pub timestamp: u64,
-    #[serde(with = "u64_dec_format")]
+    #[serde(with = "dec_format")]
     pub timestamp_nanosec: u64,
     pub next_bp_hash: CryptoHash,
     pub block_merkle_root: CryptoHash,
@@ -724,12 +721,12 @@ pub struct ChunkHeaderView {
     pub gas_used: Gas,
     pub gas_limit: Gas,
     /// TODO(2271): deprecated.
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     pub rent_paid: Balance,
     /// TODO(2271): deprecated.
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     pub validator_reward: Balance,
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     pub balance_burnt: Balance,
     pub outgoing_receipts_root: CryptoHash,
     pub tx_root: CryptoHash,
@@ -848,15 +845,15 @@ pub enum ActionView {
         method_name: String,
         args: String,
         gas: Gas,
-        #[serde(with = "u128_dec_format")]
+        #[serde(with = "dec_format")]
         deposit: Balance,
     },
     Transfer {
-        #[serde(with = "u128_dec_format")]
+        #[serde(with = "dec_format")]
         deposit: Balance,
     },
     Stake {
-        #[serde(with = "u128_dec_format")]
+        #[serde(with = "dec_format")]
         stake: Balance,
         public_key: PublicKey,
     },
@@ -1056,7 +1053,7 @@ impl From<ExecutionStatus> for ExecutionStatusView {
 pub struct CostGasUsed {
     pub cost_category: String,
     pub cost: String,
-    #[serde(with = "u64_dec_format")]
+    #[serde(with = "dec_format")]
     pub gas_used: Gas,
 }
 
@@ -1130,7 +1127,7 @@ pub struct ExecutionOutcomeView {
     /// The amount of tokens burnt corresponding to the burnt gas amount.
     /// This value doesn't always equal to the `gas_burnt` multiplied by the gas price, because
     /// the prepaid gas price might be lower than the actual gas price and it creates a deficit.
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     pub tokens_burnt: Balance,
     /// The id of the account on which the execution happens. For transaction this is signer_id,
     /// for receipt this is receiver_id.
@@ -1236,7 +1233,7 @@ pub mod validator_stake_view {
     use serde::{Deserialize, Serialize};
 
     #[cfg(feature = "protocol_feature_chunk_only_producers")]
-    use crate::serialize::u128_dec_format;
+    use crate::serialize::dec_format;
     #[cfg(feature = "protocol_feature_chunk_only_producers")]
     use near_crypto::PublicKey;
     #[cfg(feature = "protocol_feature_chunk_only_producers")]
@@ -1281,7 +1278,7 @@ pub mod validator_stake_view {
     pub struct ValidatorStakeViewV2 {
         pub account_id: AccountId,
         pub public_key: PublicKey,
-        #[serde(with = "u128_dec_format")]
+        #[serde(with = "dec_format")]
         pub stake: Balance,
         pub is_chunk_only: bool,
     }
@@ -1312,7 +1309,7 @@ pub mod validator_stake_view {
 pub struct ValidatorStakeViewV1 {
     pub account_id: AccountId,
     pub public_key: PublicKey,
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     pub stake: Balance,
 }
 
@@ -1339,7 +1336,7 @@ pub enum ReceiptEnumView {
     Action {
         signer_id: AccountId,
         signer_public_key: PublicKey,
-        #[serde(with = "u128_dec_format")]
+        #[serde(with = "dec_format")]
         gas_price: Balance,
         output_data_receivers: Vec<DataReceiverView>,
         input_data_ids: Vec<CryptoHash>,
@@ -1462,7 +1459,7 @@ pub struct CurrentEpochValidatorInfo {
     pub account_id: AccountId,
     pub public_key: PublicKey,
     pub is_slashed: bool,
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     pub stake: Balance,
     pub shards: Vec<ShardId>,
     pub num_produced_blocks: NumBlocks,
@@ -1478,7 +1475,7 @@ pub struct CurrentEpochValidatorInfo {
 pub struct NextEpochValidatorInfo {
     pub account_id: AccountId,
     pub public_key: PublicKey,
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     pub stake: Balance,
     pub shards: Vec<ShardId>,
 }
@@ -1513,7 +1510,7 @@ impl From<BlockHeader> for LightClientBlockLiteView {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GasPriceView {
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     pub gas_price: Balance,
 }
 

--- a/runtime/near-vm-logic/src/context.rs
+++ b/runtime/near-vm-logic/src/context.rs
@@ -31,23 +31,23 @@ pub struct VMContext {
     // TODO #1903 rename to `block_height`
     pub block_index: BlockHeight,
     /// The current block timestamp (number of non-leap-nanoseconds since January 1, 1970 0:00:00 UTC).
-    #[serde(with = "serialize::u64_dec_format")]
+    #[serde(with = "serialize::dec_format")]
     pub block_timestamp: u64,
     /// The current epoch height.
     pub epoch_height: EpochHeight,
 
     /// The balance attached to the given account. Excludes the `attached_deposit` that was
     /// attached to the transaction.
-    #[serde(with = "serialize::u128_dec_format_compatible")]
+    #[serde(with = "serialize::dec_format")]
     pub account_balance: Balance,
     /// The balance of locked tokens on the given account.
-    #[serde(with = "serialize::u128_dec_format_compatible")]
+    #[serde(with = "serialize::dec_format")]
     pub account_locked_balance: Balance,
     /// The account's storage usage before the contract execution
     pub storage_usage: StorageUsage,
     /// The balance that was attached to the call that will be immediately deposited before the
     /// contract execution starts.
-    #[serde(with = "serialize::u128_dec_format_compatible")]
+    #[serde(with = "serialize::dec_format")]
     pub attached_deposit: Balance,
     /// The gas attached to the call that can be used to pay for the gas fees.
     pub prepaid_gas: Gas,


### PR DESCRIPTION
Replace all `{option_,}{u64,u128}_dec_format{,_compatible}` formats
with a single `dec_format` which automatically figures out the type
it’s serialising/deserialising.  This makes it somewhat easier to use
the formats since a simple `#[serde(with = "dec_format")]` now just
works without user having to think about the actual type of the field.

This brings one change in behaviour though.  Previously only some of
the fields used ‘compatible’ variant.  I.e. they would allow the field
to be either string or a number.  Most always expected a string.  With
this change, when deserialising u128 and u64 fields they can all be
gives as strings (the canonical format) or numbers.

Finally, remove one remaining unused instance of u128_dec_format which
was overlooked in previous commit.

Fixes: https://github.com/near/nearcore/issues/3384