### PR TITLE
test: introduce ValidatorSchedule to specify COPs for KeyValue runtime conveniently

### DIFF
--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -3028,7 +3028,7 @@ mod tests {
 
     use crate::store::{ChainStoreAccess, GCMode};
     use crate::store_validator::StoreValidator;
-    use crate::test_utils::KeyValueRuntime;
+    use crate::test_utils::{KeyValueRuntime, ValidatorSchedule};
     use crate::{Chain, ChainGenesis, DoomslugThresholdMode, RuntimeAdapter};
 
     fn get_chain() -> Chain {
@@ -3038,19 +3038,10 @@ mod tests {
     fn get_chain_with_epoch_length(epoch_length: NumBlocks) -> Chain {
         let store = create_test_store();
         let chain_genesis = ChainGenesis::test();
-        let validators = vec![vec!["test1"]];
-        let runtime_adapter = Arc::new(KeyValueRuntime::new_with_validators(
-            store,
-            validators
-                .into_iter()
-                .map(|inner| {
-                    inner.into_iter().map(|account_id| account_id.parse().unwrap()).collect()
-                })
-                .collect(),
-            1,
-            1,
-            epoch_length,
-        ));
+        let vs = ValidatorSchedule::new()
+            .block_producers_per_epoch(vec![vec!["test1".parse().unwrap()]]);
+        let runtime_adapter =
+            Arc::new(KeyValueRuntime::new_with_validators(store, vs, epoch_length));
         Chain::new(runtime_adapter, &chain_genesis, DoomslugThresholdMode::NoApprovals, true)
             .unwrap()
     }

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -1,3 +1,5 @@
+mod validator_schedule;
+
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
@@ -58,6 +60,8 @@ use crate::{BlockProcessingArtifact, Doomslug, Provenance};
 use near_primitives::epoch_manager::ShardConfig;
 use near_primitives::time::Clock;
 use near_primitives::utils::MaybeValidated;
+
+pub use self::validator_schedule::ValidatorSchedule;
 
 /// Wait for all blocks that started processing to be ready for postprocessing
 /// Returns true if there are new blocks that are ready

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -1357,23 +1357,17 @@ pub fn setup_with_tx_validity_period(
 }
 
 pub fn setup_with_validators(
-    validators: Vec<AccountId>,
-    validator_groups: u64,
-    num_shards: NumShards,
+    vs: ValidatorSchedule,
     epoch_length: u64,
     tx_validity_period: NumBlocks,
 ) -> (Chain, Arc<KeyValueRuntime>, Vec<Arc<InMemoryValidatorSigner>>) {
     let store = create_test_store();
-    let signers = validators
-        .iter()
+    let signers = vs
+        .all_block_producers()
         .map(|x| {
             Arc::new(InMemoryValidatorSigner::from_seed(x.clone(), KeyType::ED25519, x.as_ref()))
         })
         .collect();
-    let vs = ValidatorSchedule::new()
-        .block_producers_per_epoch(vec![validators])
-        .num_shards(num_shards)
-        .validator_groups(validator_groups);
     let runtime = Arc::new(KeyValueRuntime::new_with_validators(store, vs, epoch_length));
     let chain = Chain::new(
         runtime.clone(),

--- a/chain/chain/src/test_utils/validator_schedule.rs
+++ b/chain/chain/src/test_utils/validator_schedule.rs
@@ -7,9 +7,9 @@ use near_primitives::types::{AccountId, NumShards};
 /// to select the validators. For for tests though, we just want to select them
 /// by fiat.
 pub struct ValidatorSchedule {
-    block_producers: Vec<Vec<AccountId>>,
-    validator_groups: u64,
-    num_shards: NumShards,
+    pub(super) block_producers: Vec<Vec<AccountId>>,
+    pub(super) validator_groups: u64,
+    pub(super) num_shards: NumShards,
 }
 
 impl ValidatorSchedule {

--- a/chain/chain/src/test_utils/validator_schedule.rs
+++ b/chain/chain/src/test_utils/validator_schedule.rs
@@ -10,19 +10,32 @@ use near_primitives::types::{AccountId, NumShards};
 /// Conventional short name for `ValidatorSchedule` is `vs`.
 pub struct ValidatorSchedule {
     pub(super) block_producers: Vec<Vec<AccountId>>,
+    #[cfg(feature = "protocol_feature_chunk_only_producers")]
+    pub(super) chunk_only_producers: Vec<Vec<Vec<AccountId>>>,
     pub(super) validator_groups: u64,
     pub(super) num_shards: NumShards,
 }
 
 impl ValidatorSchedule {
     pub fn new() -> Self {
-        Self { block_producers: Vec::new(), validator_groups: 1, num_shards: 1 }
+        Self {
+            block_producers: Vec::new(),
+            #[cfg(feature = "protocol_feature_chunk_only_producers")]
+            chunk_only_producers: Vec::new(),
+            validator_groups: 1,
+            num_shards: 1,
+        }
     }
-    pub fn block_producers_per_epoch(
-        mut self,
-        block_producers: Vec<Vec<AccountId>>,
-    ) -> ValidatorSchedule {
+    pub fn block_producers_per_epoch(mut self, block_producers: Vec<Vec<AccountId>>) -> Self {
         self.block_producers = block_producers;
+        self
+    }
+    pub fn chunk_only_producers_per_epoch_per_shard(
+        mut self,
+
+        chunk_only_producers: Vec<Vec<Vec<AccountId>>>,
+    ) -> Self {
+        self.chunk_only_producers = chunk_only_producers;
         self
     }
     pub fn validator_groups(mut self, validator_groups: u64) -> Self {

--- a/chain/chain/src/test_utils/validator_schedule.rs
+++ b/chain/chain/src/test_utils/validator_schedule.rs
@@ -33,4 +33,8 @@ impl ValidatorSchedule {
         self.num_shards = num_shards;
         self
     }
+
+    pub fn all_block_producers(&self) -> impl Iterator<Item = &AccountId> {
+        self.block_producers.iter().flatten()
+    }
 }

--- a/chain/chain/src/test_utils/validator_schedule.rs
+++ b/chain/chain/src/test_utils/validator_schedule.rs
@@ -1,3 +1,5 @@
+use near_primitives::types::{AccountId, NumShards};
+
 /// Validator schedule describes how block and chunk producers are selected by
 /// the KeyValue runtime.
 ///
@@ -5,5 +7,28 @@
 /// to select the validators. For for tests though, we just want to select them
 /// by fiat.
 pub struct ValidatorSchedule {
+    block_producers: Vec<Vec<AccountId>>,
+    validator_groups: u64,
+    num_shards: NumShards,
+}
 
+impl ValidatorSchedule {
+    pub fn new() -> Self {
+        Self { block_producers: Vec::new(), validator_groups: 1, num_shards: 1 }
+    }
+    pub fn block_producers_per_epoch(
+        mut self,
+        block_producers: Vec<Vec<AccountId>>,
+    ) -> ValidatorSchedule {
+        self.block_producers = block_producers;
+        self
+    }
+    pub fn validator_groups(mut self, validator_groups: u64) -> Self {
+        self.validator_groups = validator_groups;
+        self
+    }
+    pub fn num_shards(mut self, num_shards: NumShards) -> Self {
+        self.num_shards = num_shards;
+        self
+    }
 }

--- a/chain/chain/src/test_utils/validator_schedule.rs
+++ b/chain/chain/src/test_utils/validator_schedule.rs
@@ -26,22 +26,37 @@ impl ValidatorSchedule {
             num_shards: 1,
         }
     }
+    /// Specifies, for each epoch, the set of block produces for this epoch.
+    ///
+    /// Conceptually, this "loops around" when `epoch_id >= block_producers.len()`
     pub fn block_producers_per_epoch(mut self, block_producers: Vec<Vec<AccountId>>) -> Self {
         self.block_producers = block_producers;
         self
     }
+
+    /// Specifies, for each shard in each epoch, the set of chunk-only produces
+    /// for the shard.
+    ///
+    /// The full set of chunk-producers is composed from chunk_only producers
+    /// and some subset of block_producers (this is controlled by
+    /// `validator_groups`).
+    #[cfg(feature = "protocol_feature_chunk_only_producers")]
     pub fn chunk_only_producers_per_epoch_per_shard(
         mut self,
-
         chunk_only_producers: Vec<Vec<Vec<AccountId>>>,
     ) -> Self {
         self.chunk_only_producers = chunk_only_producers;
         self
     }
+
+    /// Controls how chunk_producers are selected from the block producers.
+    ///
+    /// See how `EpochValidatorSet` is constructed for details.
     pub fn validator_groups(mut self, validator_groups: u64) -> Self {
         self.validator_groups = validator_groups;
         self
     }
+
     pub fn num_shards(mut self, num_shards: NumShards) -> Self {
         self.num_shards = num_shards;
         self

--- a/chain/chain/src/test_utils/validator_schedule.rs
+++ b/chain/chain/src/test_utils/validator_schedule.rs
@@ -6,6 +6,8 @@ use near_primitives::types::{AccountId, NumShards};
 /// In the real runtime, we use complex algorithm based on randomness and stake
 /// to select the validators. For for tests though, we just want to select them
 /// by fiat.
+///
+/// Conventional short name for `ValidatorSchedule` is `vs`.
 pub struct ValidatorSchedule {
     pub(super) block_producers: Vec<Vec<AccountId>>,
     pub(super) validator_groups: u64,

--- a/chain/chain/src/test_utils/validator_schedule.rs
+++ b/chain/chain/src/test_utils/validator_schedule.rs
@@ -1,0 +1,9 @@
+/// Validator schedule describes how block and chunk producers are selected by
+/// the KeyValue runtime.
+///
+/// In the real runtime, we use complex algorithm based on randomness and stake
+/// to select the validators. For for tests though, we just want to select them
+/// by fiat.
+pub struct ValidatorSchedule {
+
+}

--- a/chain/chain/src/tests/gc.rs
+++ b/chain/chain/src/tests/gc.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::chain::Chain;
-use crate::test_utils::KeyValueRuntime;
+use crate::test_utils::{KeyValueRuntime, ValidatorSchedule};
 use crate::types::{ChainGenesis, Tip};
 use crate::DoomslugThresholdMode;
 
@@ -26,17 +26,10 @@ fn get_chain_with_epoch_length_and_num_shards(
 ) -> Chain {
     let store = create_test_store();
     let chain_genesis = ChainGenesis::test();
-    let validators = vec![vec!["test1"]];
-    let runtime_adapter = Arc::new(KeyValueRuntime::new_with_validators(
-        store,
-        validators
-            .into_iter()
-            .map(|inner| inner.into_iter().map(|account_id| account_id.parse().unwrap()).collect())
-            .collect(),
-        1,
-        num_shards,
-        epoch_length,
-    ));
+    let vs = ValidatorSchedule::new()
+        .block_producers_per_epoch(vec![vec!["test1".parse().unwrap()]])
+        .num_shards(num_shards);
+    let runtime_adapter = Arc::new(KeyValueRuntime::new_with_validators(store, vs, epoch_length));
     Chain::new(runtime_adapter, &chain_genesis, DoomslugThresholdMode::NoApprovals, true).unwrap()
 }
 

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -2247,7 +2247,7 @@ mod test {
     use std::sync::Arc;
     use std::time::Duration;
 
-    use near_chain::test_utils::KeyValueRuntime;
+    use near_chain::test_utils::{KeyValueRuntime, ValidatorSchedule};
     use near_chain::{ChainStore, RuntimeAdapter};
     use near_crypto::KeyType;
     use near_logger_utils::init_test_logger;
@@ -2315,18 +2315,14 @@ mod test {
     #[cfg_attr(not(feature = "expensive_tests"), ignore)]
     fn test_seal_removal() {
         init_test_logger();
-        let runtime_adapter = Arc::new(KeyValueRuntime::new_with_validators(
-            create_test_store(),
-            vec![vec![
-                "test".parse().unwrap(),
-                "test1".parse().unwrap(),
-                "test2".parse().unwrap(),
-                "test3".parse().unwrap(),
-            ]],
-            1,
-            1,
-            5,
-        ));
+        let vs = ValidatorSchedule::new().block_producers_per_epoch(vec![vec![
+            "test".parse().unwrap(),
+            "test1".parse().unwrap(),
+            "test2".parse().unwrap(),
+            "test3".parse().unwrap(),
+        ]]);
+        let runtime_adapter =
+            Arc::new(KeyValueRuntime::new_with_validators(create_test_store(), vs, 5));
         let network_adapter = Arc::new(MockPeerManagerAdapter::default());
         let mut chain_store = ChainStore::new(create_test_store(), 0, true);
         let mut shards_manager = ShardsManager::new(

--- a/chain/chunks/src/test_utils.rs
+++ b/chain/chunks/src/test_utils.rs
@@ -161,18 +161,9 @@ impl ChunkTestFixture {
         let store = near_store::test_utils::create_test_store();
         // 3 block producer. 1 block producer + 2 chunk only producer per shard
         // This setup ensures that the chunk producer
-        let (block_producers, chunk_producers) = make_validators(6, 2, 3);
-        let mock_runtime = Arc::new(
-            KeyValueRuntime::new_with_validators_and_no_gc(
-                store.clone(),
-                block_producers,
-                3,
-                3,
-                5,
-                false,
-            )
-            .with_chunk_only_producers(chunk_producers),
-        );
+        let vs = make_validators(6, 2, 3);
+        let mock_runtime =
+            Arc::new(KeyValueRuntime::new_with_validators_and_no_gc(store.clone(), vs, 5, false));
         Self::new_with_runtime(false, mock_runtime)
     }
 
@@ -335,8 +326,12 @@ fn make_validators(
         ('a'..='z').take(n).map(|c| AccountId::try_from(format!("test_{}", c)).unwrap()).collect();
 
     let bp = vec![accounts.drain(..num_bp).collect()];
-    let _cp = vec![(0..num_shards).map(|_| accounts.drain(..num_cp_per_shard).collect()).collect()];
-    ValidatorSchedule::new().num_shards(3).block_producers_per_epoch(bp).validator_groups(3)
+    let cp = vec![(0..num_shards).map(|_| accounts.drain(..num_cp_per_shard).collect()).collect()];
+    ValidatorSchedule::new()
+        .num_shards(3)
+        .block_producers_per_epoch(bp)
+        .validator_groups(3)
+        .chunk_only_producers_per_epoch_per_shard(cp)
 }
 
 // 12 validators, 3 shards, 4 validators per shard

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -458,7 +458,7 @@ pub fn get_validator_epoch_stats(
 mod tests {
     use super::*;
     use assert_matches::assert_matches;
-    use near_chain::test_utils::KeyValueRuntime;
+    use near_chain::test_utils::{KeyValueRuntime, ValidatorSchedule};
     use near_chain::{Chain, ChainGenesis, DoomslugThresholdMode};
     use near_network::test_utils::peer_id_from_seed;
     use near_primitives::version::PROTOCOL_VERSION;
@@ -490,14 +490,10 @@ mod tests {
         let info_helper = InfoHelper::new(None, &config, None);
 
         let store = near_store::test_utils::create_test_store();
-        let runtime = Arc::new(KeyValueRuntime::new_with_validators_and_no_gc(
-            store,
-            vec![vec!["test".parse().unwrap()]],
-            1,
-            2,
-            123,
-            false,
-        ));
+        let vs =
+            ValidatorSchedule::new().block_producers_per_epoch(vec![vec!["test".parse().unwrap()]]);
+        let runtime =
+            Arc::new(KeyValueRuntime::new_with_validators_and_no_gc(store, vs, 123, false));
         let chain_genesis = ChainGenesis {
             time: Clock::utc(),
             height: 0,

--- a/chain/client/src/sync.rs
+++ b/chain/client/src/sync.rs
@@ -1303,7 +1303,9 @@ mod test {
     use std::sync::Arc;
     use std::thread;
 
-    use near_chain::test_utils::{process_block_sync, setup, setup_with_validators};
+    use near_chain::test_utils::{
+        process_block_sync, setup, setup_with_validators, ValidatorSchedule,
+    };
     use near_chain::{BlockProcessingArtifact, ChainGenesis, Provenance};
     use near_crypto::{KeyType, PublicKey};
     use near_network::test_utils::MockPeerManagerAdapter;
@@ -1446,16 +1448,13 @@ mod test {
         };
         set_syncing_peer(&mut header_sync);
 
-        let (chain, _, signers) = setup_with_validators(
-            vec!["test0", "test1", "test2", "test3", "test4"]
-                .iter()
-                .map(|x| x.parse().unwrap())
-                .collect(),
-            1,
-            1,
-            1000,
-            100,
-        );
+        let vs = ValidatorSchedule::new().block_producers_per_epoch(vec![vec![
+            "test0", "test1", "test2", "test3", "test4",
+        ]
+        .iter()
+        .map(|x| x.parse().unwrap())
+        .collect()]);
+        let (chain, _, signers) = setup_with_validators(vs, 1000, 100);
         let genesis = chain.get_block(&chain.genesis().hash().clone()).unwrap();
 
         let mut last_block = &genesis;

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -163,9 +163,7 @@ impl Client {
 
 /// Sets up ClientActor and ViewClientActor viewing the same store/runtime.
 pub fn setup(
-    validators: Vec<Vec<AccountId>>,
-    validator_groups: u64,
-    num_shards: NumShards,
+    vs: ValidatorSchedule,
     epoch_length: BlockHeightDelta,
     account_id: AccountId,
     skip_sync_wait: bool,
@@ -180,11 +178,7 @@ pub fn setup(
     ctx: &Context<ClientActor>,
 ) -> (Block, ClientActor, Addr<ViewClientActor>) {
     let store = create_test_store();
-    let num_validator_seats = validators.iter().map(|x| x.len()).sum::<usize>() as NumSeats;
-    let vs = ValidatorSchedule::new()
-        .num_shards(num_shards)
-        .block_producers_per_epoch(validators)
-        .validator_groups(validator_groups);
+    let num_validator_seats = vs.all_block_producers().count() as NumSeats;
     let runtime =
         Arc::new(KeyValueRuntime::new_with_validators_and_no_gc(store, vs, epoch_length, archive));
     let chain_genesis = ChainGenesis {
@@ -254,9 +248,7 @@ pub fn setup(
 }
 
 pub fn setup_only_view(
-    validators: Vec<Vec<AccountId>>,
-    validator_groups: u64,
-    num_shards: NumShards,
+    vs: ValidatorSchedule,
     epoch_length: BlockHeightDelta,
     account_id: AccountId,
     skip_sync_wait: bool,
@@ -270,11 +262,7 @@ pub fn setup_only_view(
     genesis_time: DateTime<Utc>,
 ) -> Addr<ViewClientActor> {
     let store = create_test_store();
-    let num_validator_seats = validators.iter().map(|x| x.len()).sum::<usize>() as NumSeats;
-    let vs = ValidatorSchedule::new()
-        .num_shards(num_shards)
-        .block_producers_per_epoch(validators)
-        .validator_groups(validator_groups);
+    let num_validator_seats = vs.all_block_producers().count() as NumSeats;
     let runtime =
         Arc::new(KeyValueRuntime::new_with_validators_and_no_gc(store, vs, epoch_length, archive));
     let chain_genesis = ChainGenesis {
@@ -365,10 +353,9 @@ pub fn setup_mock_with_validity_period_and_no_epoch_sync(
     let network_adapter = Arc::new(NetworkRecipient::default());
     let mut vca: Option<Addr<ViewClientActor>> = None;
     let client_addr = ClientActor::create(|ctx: &mut Context<ClientActor>| {
+        let vs = ValidatorSchedule::new().block_producers_per_epoch(vec![validators]);
         let (_, client, view_client_addr) = setup(
-            vec![validators],
-            1,
-            1,
+            vs,
             5,
             account_id,
             skip_sync_wait,
@@ -1027,10 +1014,12 @@ pub fn setup_mock_all_validators(
             }).start();
             let network_adapter = NetworkRecipient::default();
             network_adapter.set_recipient(pm);
+            let vs = ValidatorSchedule::new()
+                .num_shards(num_shards)
+                .validator_groups(validator_groups)
+                .block_producers_per_epoch(validators_clone.clone());
             let (block, client, view_client_addr) = setup(
-                validators_clone.clone(),
-                validator_groups,
-                num_shards,
+                vs,
                 epoch_length,
                 _account_id,
                 skip_sync_wait,
@@ -1126,20 +1115,14 @@ pub fn setup_client_with_runtime(
 
 pub fn setup_client(
     store: Store,
-    validators: Vec<Vec<AccountId>>,
-    validator_groups: u64,
-    num_shards: NumShards,
+    vs: ValidatorSchedule,
     account_id: Option<AccountId>,
     enable_doomslug: bool,
     network_adapter: Arc<dyn PeerManagerAdapter>,
     chain_genesis: ChainGenesis,
     rng_seed: RngSeed,
 ) -> Client {
-    let num_validator_seats = validators.iter().map(|x| x.len()).sum::<usize>() as NumSeats;
-    let vs = ValidatorSchedule::new()
-        .num_shards(num_shards)
-        .block_producers_per_epoch(validators)
-        .validator_groups(validator_groups);
+    let num_validator_seats = vs.all_block_producers().count() as NumSeats;
     let runtime_adapter =
         Arc::new(KeyValueRuntime::new_with_validators(store, vs, chain_genesis.epoch_length));
     setup_client_with_runtime(
@@ -1283,11 +1266,11 @@ impl TestEnvBuilder {
                         Some(seed) => *seed,
                         None => TEST_SEED,
                     };
+                    let vs = ValidatorSchedule::new()
+                        .block_producers_per_epoch(vec![validators.clone()]);
                     setup_client(
                         create_test_store(),
-                        vec![validators.clone()],
-                        1,
-                        1,
+                        vs,
                         Some(account_id),
                         false,
                         network_adapter.clone(),
@@ -1544,11 +1527,10 @@ impl TestEnv {
             Some(seed) => *seed,
             None => TEST_SEED,
         };
+        let vs = ValidatorSchedule::new().block_producers_per_epoch(vec![self.validators.clone()]);
         self.clients[idx] = setup_client(
             store,
-            vec![self.validators.clone()],
-            1,
-            1,
+            vs,
             Some(self.get_client_id(idx).clone()),
             false,
             self.network_adapters[idx].clone(),

--- a/chain/client/src/tests/query_client.rs
+++ b/chain/client/src/tests/query_client.rs
@@ -1,5 +1,6 @@
 use actix::System;
 use futures::{future, FutureExt};
+use near_chain::test_utils::ValidatorSchedule;
 use near_primitives::merkle::PartialMerkleTree;
 use std::sync::Arc;
 use std::time::Duration;
@@ -186,10 +187,10 @@ fn test_execution_outcome_for_chunk() {
 #[test]
 fn test_state_request() {
     run_actix(async {
+        let vs =
+            ValidatorSchedule::new().block_producers_per_epoch(vec![vec!["test".parse().unwrap()]]);
         let view_client = setup_only_view(
-            vec![vec!["test".parse().unwrap()]],
-            1,
-            1,
+            vs,
             10000000,
             "test".parse().unwrap(),
             true,

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -7,6 +7,7 @@ use std::sync::{Arc, RwLock};
 use actix::System;
 use assert_matches::assert_matches;
 use futures::{future, FutureExt};
+use near_chain::test_utils::ValidatorSchedule;
 use near_primitives::config::VMConfig;
 use near_primitives::num_rational::{Ratio, Rational32};
 
@@ -1038,11 +1039,11 @@ fn test_time_attack() {
     let store = create_test_store();
     let network_adapter = Arc::new(MockPeerManagerAdapter::default());
     let chain_genesis = ChainGenesis::test();
+    let vs =
+        ValidatorSchedule::new().block_producers_per_epoch(vec![vec!["test1".parse().unwrap()]]);
     let mut client = setup_client(
         store,
-        vec![vec!["test1".parse().unwrap()]],
-        1,
-        1,
+        vs,
         Some("test1".parse().unwrap()),
         false,
         network_adapter,
@@ -1071,11 +1072,11 @@ fn test_invalid_approvals() {
     let store = create_test_store();
     let network_adapter = Arc::new(MockPeerManagerAdapter::default());
     let chain_genesis = ChainGenesis::test();
+    let vs =
+        ValidatorSchedule::new().block_producers_per_epoch(vec![vec!["test1".parse().unwrap()]]);
     let mut client = setup_client(
         store,
-        vec![vec!["test1".parse().unwrap()]],
-        1,
-        1,
+        vs,
         Some("test1".parse().unwrap()),
         false,
         network_adapter,
@@ -1120,11 +1121,11 @@ fn test_invalid_gas_price() {
     let network_adapter = Arc::new(MockPeerManagerAdapter::default());
     let mut chain_genesis = ChainGenesis::test();
     chain_genesis.min_gas_price = 100;
+    let vs =
+        ValidatorSchedule::new().block_producers_per_epoch(vec![vec!["test1".parse().unwrap()]]);
     let mut client = setup_client(
         store,
-        vec![vec!["test1".parse().unwrap()]],
-        1,
-        1,
+        vs,
         Some("test1".parse().unwrap()),
         false,
         network_adapter,
@@ -1278,11 +1279,12 @@ fn test_bad_chunk_mask() {
     let mut clients: Vec<Client> = validators
         .iter()
         .map(|account_id| {
+            let vs = ValidatorSchedule::new()
+                .num_shards(2)
+                .block_producers_per_epoch(vec![validators.clone()]);
             setup_client(
                 create_test_store(),
-                vec![validators.clone()],
-                1,
-                2,
+                vs,
                 Some(account_id.clone()),
                 false,
                 Arc::new(MockPeerManagerAdapter::default()),

--- a/integration-tests/src/tests/network/runner.rs
+++ b/integration-tests/src/tests/network/runner.rs
@@ -1,7 +1,7 @@
 use crate::tests::network::multiset::MultiSet;
 use actix::{Actor, Addr, AsyncContext};
 use anyhow::{anyhow, bail, Context};
-use near_chain::test_utils::KeyValueRuntime;
+use near_chain::test_utils::{KeyValueRuntime, ValidatorSchedule};
 use near_chain::ChainGenesis;
 use near_chain_configs::ClientConfig;
 use near_client::{start_client, start_view_client};
@@ -48,8 +48,8 @@ fn setup_network_node(
 
     let num_validators = validators.len() as ValidatorId;
 
-    let runtime =
-        Arc::new(KeyValueRuntime::new_with_validators(store.clone(), vec![validators], 1, 1, 5));
+    let vs = ValidatorSchedule::new().block_producers_per_epoch(vec![validators]);
+    let runtime = Arc::new(KeyValueRuntime::new_with_validators(store.clone(), vs, 5));
     let signer = Arc::new(InMemoryValidatorSigner::from_seed(
         account_id.clone(),
         KeyType::ED25519,


### PR DESCRIPTION
With cops, we now need to somehow configure `setup_mock_all_validators` to also specify cops. It *could* be done by adding just another argument, but I'd rather avoid that. Instead, what I suggest is bunching up all related configs into a single builder object, `ValidatorSchedule`, and use that as a universal tool to configure validators for KeyValueRuntime. 

Note that this PR doesn't change `setup_mock_all_validators` -- that's going to be a bigger diff, so I want to land that separately.

I might also merge this with `EpochValidatorSet`, the structs handle similar data, but, at this stage, `EpochValidatorSet` is implementation detail, while `ValidatorSchedule` is the API for authors of tests. 

Can be reviewed per commit.