### PR TITLE
refactored NetworkRecipient interface

### DIFF
--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -6,7 +6,6 @@ use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use tracing::info;
 
-use actix::actors::mocker::Mocker;
 use actix::{Actor, Addr, AsyncContext, Context};
 use chrono::DateTime;
 use futures::{future, FutureExt};
@@ -23,12 +22,11 @@ use near_chain::{
 };
 use near_chain_configs::ClientConfig;
 use near_crypto::{InMemorySigner, KeyType, PublicKey};
-use near_network::test_utils::{MockPeerManagerAdapter, NetworkRecipient};
+use near_network::test_utils::MockPeerManagerAdapter;
 use near_network::types::{
-    FullPeerInfo, NetworkClientMessages, NetworkClientResponses, NetworkRequests, NetworkResponses,
-    PeerManagerAdapter,
+    FullPeerInfo, NetworkClientMessages, NetworkClientResponses, NetworkRecipient, NetworkRequests,
+    NetworkResponses, PeerManagerAdapter,
 };
-use near_network::PeerManagerActor;
 use near_network_primitives::types::PartialEdgeInfo;
 use near_primitives::block::{ApprovalInner, Block, GenesisId};
 use near_primitives::hash::{hash, CryptoHash};
@@ -64,7 +62,25 @@ use near_primitives::runtime::config::RuntimeConfig;
 use near_primitives::time::{Clock, Instant};
 use near_primitives::utils::MaybeValidated;
 
-pub type PeerManagerMock = Mocker<PeerManagerActor>;
+pub struct PeerManagerMock {
+    handle: Box<
+        dyn FnMut(
+            PeerManagerMessageRequest,
+            &mut actix::Context<Self>,
+        ) -> PeerManagerMessageResponse,
+    >,
+}
+
+impl actix::Actor for PeerManagerMock {
+    type Context = actix::Context<Self>;
+}
+
+impl actix::Handler<PeerManagerMessageRequest> for PeerManagerMock {
+    type Result = PeerManagerMessageResponse;
+    fn handle(&mut self, msg: PeerManagerMessageRequest, ctx: &mut Self::Context) -> Self::Result {
+        (self.handle)(msg, ctx)
+    }
+}
 
 /// min block production time in milliseconds
 pub const MIN_BLOCK_PROD_TIME: Duration = Duration::from_millis(100);
@@ -362,14 +378,12 @@ pub fn setup_mock_with_validity_period_and_no_epoch_sync(
     });
     let client_addr1 = client_addr.clone();
 
-    let network_actor = PeerManagerMock::mock(Box::new(move |msg, ctx| {
-        let msg = msg.downcast_ref::<PeerManagerMessageRequest>().unwrap();
-        let resp = peermanager_mock(msg, ctx, client_addr1.clone());
-        Box::new(Some(resp))
-    }))
+    let network_actor = PeerManagerMock {
+        handle: Box::new(move |msg, ctx| peermanager_mock(&msg, ctx, client_addr1.clone())),
+    }
     .start();
 
-    network_adapter.set_recipient(network_actor.recipient());
+    network_adapter.set_recipient(network_actor);
 
     (client_addr, vca.unwrap())
 }
@@ -592,13 +606,11 @@ pub fn setup_mock_all_validators(
         let client_addr = ClientActor::create(|ctx| {
             let client_addr = ctx.address();
             let _account_id = account_id.clone();
-            let pm = PeerManagerMock::mock(Box::new(move |msg, _ctx| {
+            let pm = PeerManagerMock{handle:Box::new(move |msg, _ctx| {
                 // Note: this `.wait` will block until all `ClientActors` are created.
                 let connectors1 = connectors1.wait();
-                let msg = msg.downcast_ref::<PeerManagerMessageRequest>().unwrap();
-
                 let mut guard = network_mock1.write().unwrap();
-                let (resp, perform_default) = guard.deref_mut()(connectors1.as_slice(), account_id.clone(), msg);
+                let (resp, perform_default) = guard.deref_mut()(connectors1.as_slice(), account_id.clone(), &msg);
                 drop(guard);
 
                 if perform_default {
@@ -997,11 +1009,10 @@ pub fn setup_mock_all_validators(
                         | NetworkRequests::ReceiptOutComeRequest(_, _) => {}
                     };
                 }
-                Box::new(Some(resp))
-            }))
-            .start();
+                resp
+            })}.start();
             let network_adapter = NetworkRecipient::default();
-            network_adapter.set_recipient(pm.recipient());
+            network_adapter.set_recipient(pm);
             let (block, client, view_client_addr) = setup(
                 validators_clone.clone(),
                 validator_groups,

--- a/chain/network/src/test_utils.rs
+++ b/chain/network/src/test_utils.rs
@@ -1,9 +1,9 @@
 use crate::types::{
-    NetworkInfo, NetworkResponses, PeerManagerAdapter, PeerManagerMessageRequest,
+    MsgRecipient, NetworkInfo, NetworkResponses, PeerManagerMessageRequest,
     PeerManagerMessageResponse,
 };
 use crate::PeerManagerActor;
-use actix::{Actor, ActorContext, Context, Handler, MailboxError, Message, Recipient};
+use actix::{Actor, ActorContext, Context, Handler, MailboxError, Message};
 use futures::future::BoxFuture;
 use futures::{future, Future, FutureExt};
 use near_crypto::{KeyType, SecretKey};
@@ -12,7 +12,7 @@ use near_primitives::hash::hash;
 use near_primitives::network::PeerId;
 use near_primitives::types::EpochId;
 use near_primitives::utils::index_to_bytes;
-use once_cell::sync::{Lazy, OnceCell};
+use once_cell::sync::Lazy;
 use rand::{thread_rng, RngCore};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::net::TcpListener;
@@ -276,7 +276,7 @@ pub struct MockPeerManagerAdapter {
     pub requests: Arc<RwLock<VecDeque<PeerManagerMessageRequest>>>,
 }
 
-impl PeerManagerAdapter for MockPeerManagerAdapter {
+impl MsgRecipient<PeerManagerMessageRequest> for MockPeerManagerAdapter {
     fn send(
         &self,
         msg: PeerManagerMessageRequest,
@@ -357,32 +357,6 @@ pub mod test_features {
         .start();
         PeerManagerActor::new(store, config, client_addr.recipient(), view_client_addr.recipient())
             .unwrap()
-    }
-}
-
-#[derive(Default)]
-pub struct NetworkRecipient {
-    peer_manager_recipient: OnceCell<Recipient<PeerManagerMessageRequest>>,
-}
-
-impl NetworkRecipient {
-    pub fn set_recipient(&self, peer_manager_recipient: Recipient<PeerManagerMessageRequest>) {
-        self.peer_manager_recipient
-            .set(peer_manager_recipient)
-            .expect("can't `set_recipient` twice");
-    }
-}
-
-impl PeerManagerAdapter for NetworkRecipient {
-    fn send(
-        &self,
-        msg: PeerManagerMessageRequest,
-    ) -> BoxFuture<'static, Result<PeerManagerMessageResponse, MailboxError>> {
-        self.peer_manager_recipient.wait().send(msg).boxed()
-    }
-
-    fn do_send(&self, msg: PeerManagerMessageRequest) {
-        let _ = self.peer_manager_recipient.wait().do_send(msg);
     }
 }
 

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -28,7 +28,8 @@ use near_crypto::{InMemorySigner, KeyType, PublicKey, Signature, Signer};
 use near_logger_utils::{init_integration_logger, init_test_logger};
 use near_network::test_utils::{wait_or_panic, MockPeerManagerAdapter};
 use near_network::types::{
-    FullPeerInfo, NetworkClientMessages, NetworkClientResponses, NetworkRequests, NetworkResponses,
+    FullPeerInfo, MsgRecipient as _, NetworkClientMessages, NetworkClientResponses,
+    NetworkRequests, NetworkResponses,
 };
 use near_network::types::{NetworkInfo, PeerManagerMessageRequest, PeerManagerMessageResponse};
 use near_network_primitives::types::{PeerChainInfoV2, PeerInfo, ReasonForBan};
@@ -3473,7 +3474,6 @@ mod access_key_nonce_range_tests {
     use super::*;
     use near_chain::chain::NUM_ORPHAN_ANCESTORS_CHECK;
     use near_client::test_utils::create_chunk_with_transactions;
-    use near_network::types::PeerManagerAdapter;
     use near_primitives::account::AccessKey;
     use near_primitives::shard_layout::ShardLayout;
     use rand::seq::SliceRandom;

--- a/integration-tests/src/tests/network/runner.rs
+++ b/integration-tests/src/tests/network/runner.rs
@@ -9,7 +9,7 @@ use near_crypto::KeyType;
 use near_logger_utils::init_test_logger;
 use near_network::broadcast;
 use near_network::test_utils::{
-    expected_routing_tables, open_port, peer_id_from_seed, BanPeerSignal, GetInfo, NetworkRecipient,
+    expected_routing_tables, open_port, peer_id_from_seed, BanPeerSignal, GetInfo,
 };
 use near_network::types::{PeerManagerMessageRequest, PeerManagerMessageResponse};
 use near_network::{Event, PeerManagerActor};
@@ -61,9 +61,7 @@ fn setup_network_node(
         let mut client_config = ClientConfig::test(false, 100, 200, num_validators, false, true);
         client_config.archive = config.archive;
         client_config.ttl_account_id_router = config.ttl_account_id_router;
-        let network_adapter = NetworkRecipient::default();
-        network_adapter.set_recipient(ctx.address().recipient());
-        let network_adapter = Arc::new(network_adapter);
+        let network_adapter = Arc::new(ctx.address());
         let adv = near_client::adversarial::Controls::default();
 
         let client_actor = start_client(

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -8,7 +8,7 @@ use actix_web;
 use anyhow::Context;
 use near_chain::ChainGenesis;
 use near_client::{start_client, start_view_client, ClientActor, ViewClientActor};
-use near_network::test_utils::NetworkRecipient;
+use near_network::types::NetworkRecipient;
 use near_network::PeerManagerActor;
 use near_primitives::version::DbVersion;
 #[cfg(feature = "rosetta_rpc")]
@@ -293,7 +293,7 @@ pub fn start_with_config_and_synchronization(
             .unwrap()
         }
     });
-    network_adapter.set_recipient(network_actor.clone().recipient());
+    network_adapter.set_recipient(network_actor.clone());
 
     #[cfg(feature = "json_rpc")]
     if let Some(rpc_config) = config.rpc_config {

--- a/tools/chainsync-loadtest/src/main.rs
+++ b/tools/chainsync-loadtest/src/main.rs
@@ -14,7 +14,7 @@ use concurrency::{Ctx, Scope};
 use network::{FakeClientActor, Network};
 
 use near_chain_configs::Genesis;
-use near_network::test_utils::NetworkRecipient;
+use near_network::types::NetworkRecipient;
 use near_network::PeerManagerActor;
 use near_o11y::tracing::{error, info};
 use near_primitives::hash::CryptoHash;
@@ -40,8 +40,7 @@ pub fn start_with_config(config: NearConfig, qps_limit: u32) -> anyhow::Result<A
             client_actor.clone().recipient(),
         )
         .unwrap()
-    })
-    .recipient();
+    });
     network_adapter.set_recipient(network_actor);
     return Ok(network);
 }

--- a/tools/mock_node/src/setup.rs
+++ b/tools/mock_node/src/setup.rs
@@ -10,8 +10,8 @@ use near_chain::{
 use near_chain_configs::GenesisConfig;
 use near_client::{start_client, start_view_client, ClientActor, ViewClientActor};
 use near_epoch_manager::EpochManager;
-use near_network::test_utils::NetworkRecipient;
 use near_network::types::NetworkClientMessages;
+use near_network::types::NetworkRecipient;
 use near_primitives::state_part::PartId;
 use near_primitives::syncing::get_num_state_parts;
 use near_primitives::types::BlockHeight;
@@ -284,7 +284,7 @@ pub fn setup_mock_node(
                 target_height,
             )
         });
-    network_adapter.set_recipient(mock_network_actor.recipient());
+    network_adapter.set_recipient(mock_network_actor);
 
     // for some reason, with "test_features", start_http requires PeerManagerActor,
     // we are not going to run start_mock_network with test_features, so let's disable that for now


### PR DESCRIPTION
Refactored NetworkRecipient interface so that it supports multiple message types and easy mocking. Currently we have an enum for all-messages and an enum for all-responses, which requires an unwrap of right response variant at every call site.