### PR TITLE
store: use Database directly in StoreCompiledContractCache

### DIFF
--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -890,8 +890,8 @@ pub enum TransactionOrReceiptId {
 
 /// Cache for compiled modules
 pub trait CompiledContractCache: Send + Sync {
-    fn put(&self, key: &[u8], value: &[u8]) -> Result<(), std::io::Error>;
-    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, std::io::Error>;
+    fn put(&self, key: &CryptoHash, value: Vec<u8>) -> Result<(), std::io::Error>;
+    fn get(&self, key: &CryptoHash) -> Result<Option<Vec<u8>>, std::io::Error>;
 }
 
 /// Provides information about current epoch validators.

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -651,6 +651,8 @@ impl CompiledContractCache for StoreCompiledContractCache {
 
 #[cfg(test)]
 mod tests {
+    use near_primitives::hash::CryptoHash;
+
     use super::{DBCol, Store};
 
     #[test]
@@ -757,5 +759,19 @@ mod tests {
     #[test]
     fn testdb_iter_order() {
         test_iter_order_impl(crate::test_utils::create_test_store());
+    }
+
+    /// Check StoreCompiledContractCache implementation.
+    #[test]
+    fn test_store_compiled_contract_cache() {
+        use std::str::FromStr;
+        use near_primitives::types::CompiledContractCache;
+
+        let store = crate::test_utils::create_test_store();
+        let cache = super::StoreCompiledContractCache::new(&store);
+        let key = CryptoHash::from_str("75pAU4CJcp8Z9eoXcL6pSU8sRK5vn3NEpgvUrzZwQtr3").unwrap();
+        assert_eq!(None, cache.get(&key).unwrap());
+        assert_eq!((), cache.put(&key, b"foo".to_vec()).unwrap());
+        assert_eq!(Some(&b"foo"[..]), cache.get(&key).unwrap().as_deref());
     }
 }

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -764,8 +764,8 @@ mod tests {
     /// Check StoreCompiledContractCache implementation.
     #[test]
     fn test_store_compiled_contract_cache() {
-        use std::str::FromStr;
         use near_primitives::types::CompiledContractCache;
+        use std::str::FromStr;
 
         let store = crate::test_utils::create_test_store();
         let cache = super::StoreCompiledContractCache::new(&store);

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -4409,10 +4409,8 @@ mod contract_precompilation_tests {
         state_sync_on_height(&mut env, height - 1);
 
         // Check existence of contract in both caches.
-        let caches: Vec<Arc<StoreCompiledContractCache>> = stores
-            .iter()
-            .map(|s| Arc::new(StoreCompiledContractCache { store: s.clone() }))
-            .collect();
+        let caches: Vec<Arc<StoreCompiledContractCache>> =
+            stores.iter().map(StoreCompiledContractCache::new).collect();
         let contract_code = ContractCode::new(wasm_code.clone(), None);
         let vm_kind = VMKind::for_protocol_version(PROTOCOL_VERSION);
         let epoch_id = env.clients[0]
@@ -4426,7 +4424,7 @@ mod contract_precompilation_tests {
         let key = get_contract_cache_key(&contract_code, vm_kind, &runtime_config.wasm_config);
         for i in 0..num_clients {
             caches[i]
-                .get(&key.0)
+                .get(&key)
                 .unwrap_or_else(|_| panic!("Failed to get cached result for client {}", i))
                 .unwrap_or_else(|| {
                     panic!("Compilation result should be non-empty for client {}", i)
@@ -4524,10 +4522,8 @@ mod contract_precompilation_tests {
         // Perform state sync for the second client on the last produced height.
         state_sync_on_height(&mut env, height - 1);
 
-        let caches: Vec<Arc<StoreCompiledContractCache>> = stores
-            .iter()
-            .map(|s| Arc::new(StoreCompiledContractCache { store: s.clone() }))
-            .collect();
+        let caches: Vec<Arc<StoreCompiledContractCache>> =
+            stores.iter().map(StoreCompiledContractCache::new).collect();
         let vm_kind = VMKind::for_protocol_version(PROTOCOL_VERSION);
         let epoch_id = env.clients[0]
             .chain
@@ -4549,12 +4545,12 @@ mod contract_precompilation_tests {
         );
 
         // Check that both deployed contracts are presented in cache for client 0.
-        assert!(caches[0].get(&tiny_contract_key.0).unwrap().is_some());
-        assert!(caches[0].get(&test_contract_key.0).unwrap().is_some());
+        assert!(caches[0].get(&tiny_contract_key).unwrap().is_some());
+        assert!(caches[0].get(&test_contract_key).unwrap().is_some());
 
         // Check that only last contract is presented in cache for client 1.
-        assert!(caches[1].get(&tiny_contract_key.0).unwrap().is_none());
-        assert!(caches[1].get(&test_contract_key.0).unwrap().is_some());
+        assert!(caches[1].get(&tiny_contract_key).unwrap().is_none());
+        assert!(caches[1].get(&test_contract_key).unwrap().is_some());
     }
 
     #[test]
@@ -4610,10 +4606,8 @@ mod contract_precompilation_tests {
         // Perform state sync for the second client.
         state_sync_on_height(&mut env, height - 1);
 
-        let caches: Vec<Arc<StoreCompiledContractCache>> = stores
-            .iter()
-            .map(|s| Arc::new(StoreCompiledContractCache { store: s.clone() }))
-            .collect();
+        let caches: Vec<Arc<StoreCompiledContractCache>> =
+            stores.iter().map(StoreCompiledContractCache::new).collect();
 
         let epoch_id = env.clients[0]
             .chain
@@ -4631,10 +4625,10 @@ mod contract_precompilation_tests {
         );
 
         // Check that contract is cached for client 0 despite account deletion.
-        assert!(caches[0].get(&contract_key.0).unwrap().is_some());
+        assert!(caches[0].get(&contract_key).unwrap().is_some());
 
         // Check that contract is not cached for client 1 because of late state sync.
-        assert!(caches[1].get(&contract_key.0).unwrap().is_none());
+        assert!(caches[1].get(&contract_key).unwrap().is_none());
     }
 }
 

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -542,7 +542,7 @@ impl NightshadeRuntime {
             random_seed,
             current_protocol_version,
             config: self.runtime_config_store.get_config(current_protocol_version).clone(),
-            cache: Some(Arc::new(StoreCompiledContractCache { store: self.store.clone() })),
+            cache: Some(StoreCompiledContractCache::new(&self.store)),
             is_new_chunk,
             migration_data: Arc::clone(&self.migration_data),
             migration_flags: MigrationFlags {
@@ -634,7 +634,7 @@ impl NightshadeRuntime {
         let protocol_version = self.get_epoch_protocol_version(epoch_id)?;
         let runtime_config = self.runtime_config_store.get_config(protocol_version);
         let compiled_contract_cache: Option<Arc<dyn CompiledContractCache>> =
-            Some(Arc::new(StoreCompiledContractCache { store: self.store.clone() }));
+            Some(StoreCompiledContractCache::new(&self.store));
         // Execute precompile_contract in parallel but prevent it from using more than half of all
         // threads so that node will still function normally.
         rayon::scope(|scope| {
@@ -1956,7 +1956,7 @@ impl node_runtime::adapter::ViewRuntimeAdapter for NightshadeRuntime {
             epoch_height,
             block_timestamp,
             current_protocol_version,
-            cache: Some(Arc::new(StoreCompiledContractCache { store: self.tries.get_store() })),
+            cache: Some(StoreCompiledContractCache::new(&self.tries.get_store())),
         };
         self.trie_viewer.call_function(
             state_update,

--- a/runtime/near-vm-runner/src/tests/cache.rs
+++ b/runtime/near-vm-runner/src/tests/cache.rs
@@ -8,6 +8,7 @@ use crate::wasmer2_runner::Wasmer2VM;
 use crate::{prepare, MockCompiledContractCache};
 use assert_matches::assert_matches;
 use near_primitives::contract::ContractCode;
+use near_primitives::hash::CryptoHash;
 use near_primitives::runtime::fees::RuntimeFeesConfig;
 use near_primitives::types::CompiledContractCache;
 use near_stable_hasher::StableHasher;
@@ -188,14 +189,14 @@ impl FaultingCompiledContractCache {
 }
 
 impl CompiledContractCache for FaultingCompiledContractCache {
-    fn put(&self, key: &[u8], value: &[u8]) -> Result<(), io::Error> {
+    fn put(&self, key: &CryptoHash, value: Vec<u8>) -> Result<(), io::Error> {
         if self.write_fault.swap(false, Ordering::Relaxed) {
             return Err(io::ErrorKind::Other.into());
         }
         self.inner.put(key, value)
     }
 
-    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, io::Error> {
+    fn get(&self, key: &CryptoHash) -> Result<Option<Vec<u8>>, io::Error> {
         if self.read_fault.swap(false, Ordering::Relaxed) {
             return Err(io::ErrorKind::Other.into());
         }

--- a/runtime/runtime-params-estimator/src/function_call.rs
+++ b/runtime/runtime-params-estimator/src/function_call.rs
@@ -8,7 +8,6 @@ use near_store::StoreCompiledContractCache;
 use near_vm_logic::mocks::mock_external::MockedExternal;
 use near_vm_runner::internal::VMKind;
 use std::fmt::Write;
-use std::sync::Arc;
 
 /// Estimates linear cost curve for a function call execution cost per byte of
 /// total contract code. The contract size is increased by adding more methods
@@ -71,7 +70,7 @@ fn compute_function_call_cost(
     contract: &ContractCode,
 ) -> GasCost {
     let store = near_store::test_utils::create_test_store();
-    let cache_store = Arc::new(StoreCompiledContractCache { store });
+    let cache_store = StoreCompiledContractCache::new(&store);
     let cache: Option<&dyn CompiledContractCache> = Some(cache_store.as_ref());
     let protocol_version = ProtocolVersion::MAX;
     let config_store = RuntimeConfigStore::new(None);

--- a/runtime/runtime-params-estimator/src/gas_metering.rs
+++ b/runtime/runtime-params-estimator/src/gas_metering.rs
@@ -9,7 +9,6 @@ use near_primitives::version::PROTOCOL_VERSION;
 use near_store::StoreCompiledContractCache;
 use near_vm_logic::mocks::mock_external::MockedExternal;
 use std::fmt::Write;
-use std::sync::Arc;
 
 pub(crate) fn gas_metering_cost(config: &Config) -> (GasCost, GasCost) {
     let mut xs1 = vec![];
@@ -129,7 +128,7 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     let warmup_repeats = config.warmup_iters_per_block;
 
     let store = near_store::test_utils::create_test_store();
-    let cache_store = Arc::new(StoreCompiledContractCache { store });
+    let cache_store = StoreCompiledContractCache::new(&store);
     let cache: Option<&dyn CompiledContractCache> = Some(cache_store.as_ref());
     let config_store = RuntimeConfigStore::new(None);
     let runtime_config = config_store.get_config(PROTOCOL_VERSION).as_ref();

--- a/runtime/runtime-params-estimator/src/testbed.rs
+++ b/runtime/runtime-params-estimator/src/testbed.rs
@@ -72,7 +72,7 @@ impl RuntimeTestbed {
             random_seed: Default::default(),
             current_protocol_version: PROTOCOL_VERSION,
             config: Arc::new(runtime_config),
-            cache: Some(Arc::new(StoreCompiledContractCache { store: tries.get_store() })),
+            cache: Some(StoreCompiledContractCache::new(&tries.get_store())),
             is_new_chunk: true,
             migration_data: Arc::new(MigrationData::default()),
             migration_flags: MigrationFlags::default(),

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1584,7 +1584,7 @@ mod tests {
             random_seed: Default::default(),
             current_protocol_version: PROTOCOL_VERSION,
             config: Arc::new(RuntimeConfig::test()),
-            cache: Some(Arc::new(StoreCompiledContractCache { store: tries.get_store() })),
+            cache: Some(StoreCompiledContractCache::new(&tries.get_store())),
             is_new_chunk: true,
             migration_data: Arc::new(MigrationData::default()),
             migration_flags: MigrationFlags::default(),
@@ -2392,7 +2392,7 @@ mod tests {
         apply_state
             .cache
             .unwrap()
-            .get(&key.0)
+            .get(&key)
             .expect("Compiled contract should be cached")
             .expect("Compilation result should be non-empty");
     }


### PR DESCRIPTION
The main motivation here isn’t obvious.  It’s to decouple the cache
from Store struct similarly how peer store is now talking to Database
directly.  Long-term plan is to have hot and cold storage;  it’s
beneficial if part of the code which only ever talk to hot storage
don’t need to go through Store interface.

As a side benefit, this reduces the number of clones when storing
contracts in the cache.