### PR TITLE
Refactor BlockInProgress to print more information of processed blocks and chunks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2805,6 +2805,7 @@ name = "near-chain"
 version = "0.0.0"
 dependencies = [
  "actix",
+ "ansi_term",
  "assert_matches",
  "borsh",
  "chrono",

--- a/chain/chain/Cargo.toml
+++ b/chain/chain/Cargo.toml
@@ -8,6 +8,7 @@ rust-version = "1.60.0"
 edition = "2021"
 
 [dependencies]
+ansi_term = "0.12"
 actix = "0.13.0"
 borsh = "0.9"
 chrono = { version = "0.4.4", features = ["serde"] }

--- a/chain/chain/src/block_processing_utils.rs
+++ b/chain/chain/src/block_processing_utils.rs
@@ -81,6 +81,10 @@ impl BlocksInProcessing {
         BlocksInProcessing { preprocessed_blocks: HashMap::new() }
     }
 
+    pub(crate) fn len(&self) -> usize {
+        self.preprocessed_blocks.len()
+    }
+
     /// Add a preprocessed block to the pool. Return Error::ExceedingPoolSize if the pool already
     /// reaches its max size.
     pub(crate) fn add(
@@ -92,6 +96,10 @@ impl BlocksInProcessing {
 
         self.preprocessed_blocks.insert(*block.hash(), (block, preprocess_info));
         Ok(())
+    }
+
+    pub(crate) fn contains(&self, block_hash: &CryptoHash) -> bool {
+        self.preprocessed_blocks.contains_key(block_hash)
     }
 
     pub(crate) fn remove(

--- a/chain/chain/src/blocks_delay_tracker.rs
+++ b/chain/chain/src/blocks_delay_tracker.rs
@@ -1,29 +1,46 @@
-use itertools::Itertools;
-use near_primitives::block::Block;
+use near_chain_configs::LogSummaryStyle;
+use near_chain_primitives::Error;
+use near_primitives::block::{Block, Tip};
+use near_primitives::borsh::maybestd::collections::hash_map::Entry;
 use near_primitives::hash::CryptoHash;
 use near_primitives::sharding::ChunkHash;
+use near_primitives::time::Clock;
 use near_primitives::types::{BlockHeight, ShardId};
-use std::collections::HashMap;
+use near_primitives::views::{
+    BlockProcessingInfo, BlockProcessingStatus, ChainProcessingInfo, ChunkProcessingInfo,
+    ChunkProcessingStatus,
+};
+use std::collections::{BTreeMap, HashMap};
+use std::mem;
 use std::time::Instant;
 use tracing::error;
 
-use crate::metrics;
+use crate::{metrics, Chain, ChainStoreAccess};
+
+const BLOCK_DELAY_TRACKING_COUNT: u64 = 50;
 
 /// Provides monitoring information about the important timestamps throughout the lifetime of
-/// blocks and chunks. It keeps information of all pending blocks and chunks that have not been fully processed yet.
-/// A block is added the first time it is received and removed when it finishes processing
-/// A chunk is added the first time it is requested and removed when the block it belongs finishes processing
+/// blocks and chunks. It keeps information of recent blocks (blocks with height > head height -
+/// BLOCK_DELAY_TRACKING_HORIZON).
+/// A block is added the first time when chain tries to process the block. Note that this means
+/// the block already passes a few checks in ClientActor and in Client before it enters the chain
+/// code. For example, client actor checks that the block must be within head_height + BLOCK_HORIZON (500),
+/// that's why we know tracker at most tracks 550 blocks.
 #[derive(Debug, Default)]
 pub struct BlocksDelayTracker {
-    /// Contains only blocks that are not yet processed.
-    pub blocks_in_progress: HashMap<CryptoHash, BlockInProgress>,
-    /// An entry gets created when a chunk gets requested for the first time.
-    /// Chunks get deleted when the block gets processed.
-    pub chunks_in_progress: HashMap<ChunkHash, ChunkInProgress>,
+    // A block is added at the first time it was received, and
+    // removed if it is too far from the chain head.
+    blocks: HashMap<CryptoHash, BlockTrackingStats>,
+    // Maps block height to block hash. Used for gc.
+    // Theoretically, each block height should only have one block, if our work works correctly.
+    blocks_height_map: BTreeMap<BlockHeight, Vec<CryptoHash>>, // Chunks that belong to the blocks in the tracker
+    chunks: HashMap<ChunkHash, ChunkTrackingStats>,
+    //floating_chunks: HashMap<ChunkHash>,
+    head_height: BlockHeight,
 }
 
-#[derive(Debug)]
-pub struct BlockInProgress {
+#[derive(Debug, Clone)]
+pub struct BlockTrackingStats {
     /// Timestamp when block was received.
     pub received_timestamp: Instant,
     /// Timestamp when block was put to the orphan pool, if it ever was
@@ -34,44 +51,75 @@ pub struct BlockInProgress {
     pub removed_from_orphan_timestamp: Option<Instant>,
     /// Timestamp when block was moved out of the missing chunks pool
     pub removed_from_missing_chunks_timestamp: Option<Instant>,
-    /// Height at which the block is going to be added.
-    pub height: BlockHeight,
-    /// Hashes of the chunks that belong to this block.
-    pub chunks: Vec<ChunkHash>,
+    /// Timestamp when block was done processing
+    pub processed_timestamp: Option<Instant>,
+    /// Only contains new chunks that belong to this block, if the block doesn't produce a new chunk
+    /// for a shard, the corresponding item will be None.
+    pub chunks: Vec<Option<ChunkHash>>,
 }
 
 /// Records timestamps of requesting and receiving a chunk. Assumes that each chunk is requested
 /// before it is received.
-#[derive(Debug)]
-pub struct ChunkInProgress {
-    /// Timestamp of requesting a missing chunk.
-    pub chunk_requested: Instant,
-    /// Timestamp of receiving a chunk.
-    /// If a chunk is received multiple times, only the earliest timestamp is recorded.
-    pub chunk_received: Option<Instant>,
-    /// Block hash this chunk belongs to.
-    pub block_hash: CryptoHash,
+#[derive(Debug, Clone, Default)]
+pub struct ChunkTrackingStats {
+    /// Timestamp of first time when we request for this chunk.
+    pub requested_timestamp: Option<Instant>,
+    /// Timestamp of when the node receives all information it needs for this chunk
+    pub completed_timestamp: Option<Instant>,
+    /// Blocks that include this chunk, note that a chunk could be included by multiple blocks
+    pub blocks: Vec<CryptoHash>,
+}
+
+impl ChunkTrackingStats {
+    fn to_chunk_processing_info(&self) -> ChunkProcessingInfo {
+        let status = if self.completed_timestamp.is_some() {
+            ChunkProcessingStatus::Completed
+        } else if self.requested_timestamp.is_some() {
+            ChunkProcessingStatus::Requested
+        } else {
+            ChunkProcessingStatus::NeedToRequest
+        };
+        ChunkProcessingInfo { status }
+    }
 }
 
 impl BlocksDelayTracker {
     pub fn mark_block_received(&mut self, block: &Block, timestamp: Instant) {
         let block_hash = block.header().hash();
         let height = block.header().height();
-        let chunks = block.chunks().iter().map(|it| it.chunk_hash()).collect_vec();
 
-        self.blocks_in_progress.entry(*block_hash).or_insert(BlockInProgress {
-            received_timestamp: timestamp,
-            orphaned_timestamp: None,
-            missing_chunks_timestamp: None,
-            removed_from_orphan_timestamp: None,
-            removed_from_missing_chunks_timestamp: None,
-            height,
-            chunks,
-        });
+        if let Entry::Vacant(entry) = self.blocks.entry(*block_hash) {
+            let chunks = block
+                .chunks()
+                .iter()
+                .map(|chunk| {
+                    if chunk.height_included() == height {
+                        let chunk_stats = self
+                            .chunks
+                            .entry(chunk.chunk_hash())
+                            .or_insert(ChunkTrackingStats::default());
+                        chunk_stats.blocks.push(*block_hash);
+                        Some(chunk.chunk_hash())
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            entry.insert(BlockTrackingStats {
+                received_timestamp: timestamp,
+                orphaned_timestamp: None,
+                missing_chunks_timestamp: None,
+                removed_from_orphan_timestamp: None,
+                removed_from_missing_chunks_timestamp: None,
+                processed_timestamp: None,
+                chunks,
+            });
+            self.blocks_height_map.entry(height).or_insert(vec![]).push(*block_hash);
+        }
     }
 
     pub fn mark_block_orphaned(&mut self, block_hash: &CryptoHash, timestamp: Instant) {
-        if let Some(block_entry) = self.blocks_in_progress.get_mut(block_hash) {
+        if let Some(block_entry) = self.blocks.get_mut(block_hash) {
             block_entry.orphaned_timestamp = Some(timestamp);
         } else {
             error!(target:"blocks_delay_tracker", "block {:?} was orphaned but was not marked received", block_hash);
@@ -79,7 +127,7 @@ impl BlocksDelayTracker {
     }
 
     pub fn mark_block_unorphaned(&mut self, block_hash: &CryptoHash, timestamp: Instant) {
-        if let Some(block_entry) = self.blocks_in_progress.get_mut(block_hash) {
+        if let Some(block_entry) = self.blocks.get_mut(block_hash) {
             block_entry.removed_from_orphan_timestamp = Some(timestamp);
         } else {
             error!(target:"blocks_delay_tracker", "block {:?} was unorphaned but was not marked received", block_hash);
@@ -87,7 +135,7 @@ impl BlocksDelayTracker {
     }
 
     pub fn mark_block_has_missing_chunks(&mut self, block_hash: &CryptoHash, timestamp: Instant) {
-        if let Some(block_entry) = self.blocks_in_progress.get_mut(block_hash) {
+        if let Some(block_entry) = self.blocks.get_mut(block_hash) {
             block_entry.missing_chunks_timestamp = Some(timestamp);
         } else {
             error!(target:"blocks_delay_tracker", "block {:?} was marked as having missing chunks but was not marked received", block_hash);
@@ -99,48 +147,75 @@ impl BlocksDelayTracker {
         block_hash: &CryptoHash,
         timestamp: Instant,
     ) {
-        if let Some(block_entry) = self.blocks_in_progress.get_mut(block_hash) {
+        if let Some(block_entry) = self.blocks.get_mut(block_hash) {
             block_entry.removed_from_missing_chunks_timestamp = Some(timestamp);
         } else {
             error!(target:"blocks_delay_tracker", "block {:?} was marked as having no missing chunks but was not marked received", block_hash);
         }
     }
 
-    pub fn mark_chunk_received(&mut self, chunk_hash: &ChunkHash, timestamp: Instant) {
-        self.chunks_in_progress
-            .get_mut(&chunk_hash)
-            .map(|chunk_in_progress| chunk_in_progress.chunk_received.get_or_insert(timestamp));
+    pub fn mark_chunk_completed(&mut self, chunk_hash: ChunkHash, timestamp: Instant) {
+        self.chunks
+            .entry(chunk_hash)
+            .or_insert(ChunkTrackingStats::default())
+            .completed_timestamp
+            .get_or_insert(timestamp);
     }
 
-    pub fn mark_chunk_requested(
-        &mut self,
-        chunk_hash: &ChunkHash,
-        timestamp: Instant,
-        requestor_block_hash: &CryptoHash,
-    ) {
-        self.chunks_in_progress.entry(chunk_hash.clone()).or_insert_with(|| ChunkInProgress {
-            chunk_requested: timestamp,
-            chunk_received: None,
-            block_hash: requestor_block_hash.clone(),
-        });
+    pub fn mark_chunk_requested(&mut self, chunk_hash: ChunkHash, timestamp: Instant) {
+        self.chunks
+            .entry(chunk_hash)
+            .or_insert(ChunkTrackingStats::default())
+            .requested_timestamp
+            .get_or_insert(timestamp);
     }
 
-    pub fn finish_block_processing(&mut self, block_hash: &CryptoHash, chunks: &[ChunkHash]) {
-        if let Some(processed_block) = self.blocks_in_progress.remove(&block_hash) {
-            self.update_block_metrics(&processed_block);
-            for (shard_id, chunk_hash) in chunks.iter().enumerate() {
-                if let Some(processed_chunk) = self.chunks_in_progress.remove(&chunk_hash) {
-                    self.update_chunk_metrics(
-                        &processed_block,
-                        &processed_chunk,
-                        shard_id as ShardId,
-                    );
+    fn update_head(&mut self, head_height: BlockHeight) {
+        if head_height != self.head_height {
+            self.head_height = head_height;
+            let mut blocks_to_remove = self
+                .blocks_height_map
+                .split_off(&(head_height.saturating_sub(BLOCK_DELAY_TRACKING_COUNT)));
+            mem::swap(&mut self.blocks_height_map, &mut blocks_to_remove);
+
+            for block_hash in blocks_to_remove.values().flatten() {
+                if let Some(block) = self.blocks.remove(&block_hash) {
+                    for chunk_hash in block.chunks {
+                        if let Some(chunk_hash) = chunk_hash {
+                            self.chunks.remove(&chunk_hash);
+                        }
+                    }
+                } else {
+                    debug_assert!(false);
+                    error!(target:"block_delay_tracker", "block {:?} in height map but no in blocks", block_hash);
                 }
             }
         }
     }
 
-    fn update_block_metrics(&mut self, block: &BlockInProgress) {
+    pub fn finish_block_processing(&mut self, block_hash: &CryptoHash, new_head: Option<Tip>) {
+        tracing::info!(target:"block_delay_tracker", "\n{:?}\n{:?}\n{:?}", self.blocks_height_map, self.blocks, self.chunks);
+        if let Some(processed_block) = self.blocks.get_mut(&block_hash) {
+            processed_block.processed_timestamp = Some(Clock::instant());
+        }
+        // To get around the rust reference scope check
+        if let Some(processed_block) = self.blocks.get(&block_hash) {
+            let chunks = processed_block.chunks.clone();
+            self.update_block_metrics(processed_block);
+            for (shard_id, chunk_hash) in chunks.into_iter().enumerate() {
+                if let Some(chunk_hash) = chunk_hash {
+                    if let Some(processed_chunk) = self.chunks.get(&chunk_hash) {
+                        self.update_chunk_metrics(processed_chunk, shard_id as ShardId);
+                    }
+                }
+            }
+        }
+        if let Some(head) = new_head {
+            self.update_head(head.height);
+        }
+    }
+
+    fn update_block_metrics(&self, block: &BlockTrackingStats) {
         if let Some(start) = block.orphaned_timestamp {
             if let Some(end) = block.removed_from_orphan_timestamp {
                 metrics::BLOCK_ORPHANED_DELAY
@@ -159,22 +234,193 @@ impl BlocksDelayTracker {
         }
     }
 
-    fn update_chunk_metrics(
-        &mut self,
-        block: &BlockInProgress,
-        chunk: &ChunkInProgress,
-        shard_id: ShardId,
-    ) {
-        let chunk_requested = chunk.chunk_requested;
-        metrics::BLOCK_CHUNKS_REQUESTED_DELAY.with_label_values(&[&shard_id.to_string()]).observe(
-            chunk_requested.saturating_duration_since(block.received_timestamp).as_secs_f64(),
-        );
-        // Theoretically chunk_received should have been set here because a block being processed
-        // requires all chunks to be received
-        if let Some(chunk_received) = chunk.chunk_received {
-            metrics::CHUNK_RECEIVED_DELAY
-                .with_label_values(&[&shard_id.to_string()])
-                .observe(chunk_received.saturating_duration_since(chunk_requested).as_secs_f64());
+    fn update_chunk_metrics(&self, chunk: &ChunkTrackingStats, shard_id: ShardId) {
+        if let Some(chunk_requested) = chunk.requested_timestamp {
+            // Theoretically chunk_received should have been set here because a block being processed
+            // requires all chunks to be received
+            if let Some(chunk_received) = chunk.completed_timestamp {
+                metrics::CHUNK_RECEIVED_DELAY.with_label_values(&[&shard_id.to_string()]).observe(
+                    chunk_received.saturating_duration_since(chunk_requested).as_secs_f64(),
+                );
+            }
         }
+    }
+
+    fn get_block_processing_info(
+        &self,
+        block_height: BlockHeight,
+        block_hash: &CryptoHash,
+        chain: &Chain,
+    ) -> Option<BlockProcessingInfo> {
+        self.blocks.get(block_hash).map(|block_stats| {
+            let chunks_info: Vec<_> = block_stats
+                .chunks
+                .iter()
+                .map(|chunk_hash| {
+                    if let Some(chunk_hash) = chunk_hash {
+                        self.chunks.get(chunk_hash).map(|x| x.to_chunk_processing_info())
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            let now = Clock::instant();
+            let block_status = chain.get_block_status(block_hash);
+            let in_progress_ms = block_stats
+                .processed_timestamp
+                .unwrap_or(now)
+                .checked_duration_since(block_stats.received_timestamp)
+                .map(|x| x.as_millis())
+                .unwrap_or_default();
+            let orphaned_ms = if let Some(orphaned_time) = block_stats.orphaned_timestamp {
+                block_stats
+                    .removed_from_orphan_timestamp
+                    .unwrap_or(now)
+                    .checked_duration_since(orphaned_time)
+                    .map(|x| x.as_millis())
+            } else {
+                None
+            };
+            let missing_chunks_ms =
+                if let Some(missing_chunks_time) = block_stats.missing_chunks_timestamp {
+                    block_stats
+                        .removed_from_missing_chunks_timestamp
+                        .unwrap_or(now)
+                        .checked_duration_since(missing_chunks_time)
+                        .map(|x| x.as_millis())
+                } else {
+                    None
+                };
+            BlockProcessingInfo {
+                height: block_height,
+                hash: *block_hash,
+                in_progress_ms,
+                orphaned_ms,
+                block_status,
+                missing_chunks_ms,
+                chunks_info,
+            }
+        })
+    }
+}
+
+impl Chain {
+    fn get_block_status(&self, block_hash: &CryptoHash) -> BlockProcessingStatus {
+        if self.is_orphan(block_hash) {
+            return BlockProcessingStatus::Orphan;
+        }
+        if self.is_chunk_orphan(block_hash) {
+            return BlockProcessingStatus::WaitingForChunks;
+        }
+        if self.is_in_processing(block_hash) {
+            return BlockProcessingStatus::InProcessing;
+        }
+        if self.store().block_exists(block_hash).unwrap_or_default() {
+            return BlockProcessingStatus::Processed;
+        }
+        return BlockProcessingStatus::Unknown;
+    }
+
+    pub fn get_chain_processing_info(&self) -> ChainProcessingInfo {
+        let blocks_info: Vec<_> = self
+            .blocks_delay_tracker
+            .blocks_height_map
+            .iter()
+            .flat_map(|(height, hashes)| {
+                hashes
+                    .iter()
+                    .flat_map(|hash| {
+                        self.blocks_delay_tracker.get_block_processing_info(*height, hash, self)
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        ChainProcessingInfo {
+            num_blocks_in_processing: self.blocks_in_processing_len(),
+            num_orphans: self.orphans_len(),
+            num_blocks_missing_chunks: self.blocks_with_missing_chunks_len(),
+            blocks_info,
+        }
+    }
+
+    pub fn print_chain_processing_info_to_string(
+        &self,
+        log_summary_style: LogSummaryStyle,
+    ) -> Result<String, Error> {
+        let chain_info = self.get_chain_processing_info();
+        let blocks_info = chain_info.blocks_info;
+        let use_colour = matches!(log_summary_style, LogSummaryStyle::Colored);
+        let paint = |colour: ansi_term::Colour, text: Option<String>| match text {
+            None => ansi_term::Style::default().paint(""),
+            Some(text) if use_colour => colour.bold().paint(text),
+            Some(text) => ansi_term::Style::default().paint(text),
+        };
+
+        // Returns a status line for each block - also prints what is happening to its chunks.
+        let next_blocks_log = blocks_info
+            .into_iter()
+            .flat_map(|block_info| {
+                let mut all_chunks_received = true;
+                let chunk_status_str = block_info
+                    .chunks_info
+                    .iter()
+                    .map(|chunk_info| {
+                        if let Some(chunk_info) = chunk_info {
+                            all_chunks_received &=
+                                matches!(chunk_info.status, ChunkProcessingStatus::Completed);
+                            match chunk_info.status {
+                                ChunkProcessingStatus::Completed => "✔",
+                                ChunkProcessingStatus::Requested => "⬇",
+                                ChunkProcessingStatus::NeedToRequest => ".",
+                            }
+                        } else {
+                            "X"
+                        }
+                    })
+                    .collect::<Vec<&str>>()
+                    .join("");
+
+                let chunk_status_color = if all_chunks_received {
+                    ansi_term::Colour::Green
+                } else {
+                    ansi_term::Colour::White
+                };
+
+                let chunk_status_str = paint(chunk_status_color, Some(chunk_status_str));
+
+                let in_progress_str = format!("in progress for {:?}ms", block_info.in_progress_ms);
+
+                let in_orphan_str = match block_info.orphaned_ms {
+                    Some(duration) => format!("orphan for {:?}ms", duration),
+                    None => "".to_string(),
+                };
+
+                let missing_chunks_str = match block_info.missing_chunks_ms {
+                    Some(duration) => format!("orphan for {:?}ms", duration),
+                    None => "".to_string(),
+                };
+
+                Some(format!(
+                    "{} {} {:?} {} {} {} Chunks:({}))",
+                    block_info.height,
+                    block_info.hash,
+                    block_info.block_status,
+                    in_progress_str,
+                    in_orphan_str,
+                    missing_chunks_str,
+                    chunk_status_str,
+                ))
+            })
+            .collect::<Vec<String>>();
+
+        Ok(format!(
+            "{:?} Orphans: {} With missing chunks: {} In processing {}{}{}",
+            self.head()?.epoch_id,
+            self.orphans_len(),
+            self.blocks_with_missing_chunks_len(),
+            self.blocks_in_processing_len(),
+            if next_blocks_log.len() > 0 { "\n" } else { "" },
+            next_blocks_log.join("\n")
+        ))
     }
 }

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -44,7 +44,7 @@ use near_primitives::types::{
 use near_primitives::unwrap_or_return;
 use near_primitives::utils::MaybeValidated;
 use near_primitives::views::{
-    BlockStatusView, ExecutionOutcomeWithIdView, ExecutionStatusView, FinalExecutionOutcomeView,
+    ExecutionOutcomeWithIdView, ExecutionStatusView, FinalExecutionOutcomeView,
     FinalExecutionOutcomeWithReceiptView, FinalExecutionStatus, LightClientBlockView,
     SignedTransactionView,
 };
@@ -313,19 +313,6 @@ impl OrphanBlockPool {
         res
     }
 
-    pub fn list_orphans_by_height(&self) -> Vec<BlockStatusView> {
-        let mut rtn = Vec::new();
-        for (height, orphans) in &self.height_idx {
-            rtn.push(
-                orphans
-                    .iter()
-                    .map(|orphan| BlockStatusView::new(&height, &orphan))
-                    .collect::<Vec<_>>(),
-            );
-        }
-        rtn.into_iter().flatten().collect()
-    }
-
     /// Returns true if the block has not been requested yet and the number of orphans
     /// for which we have requested missing chunks have not exceeded MAX_ORPHAN_MISSING_CHUNKS
     fn can_request_missing_chunks_for_orphan(&self, block_hash: &CryptoHash) -> bool {
@@ -343,7 +330,6 @@ pub struct BlockMissingChunks {
     /// previous block hash
     pub prev_hash: CryptoHash,
     pub missing_chunks: Vec<ShardChunkHeader>,
-    pub block_hash: CryptoHash,
 }
 
 /// Contains information needed to request chunks for orphans
@@ -356,8 +342,6 @@ pub struct OrphanMissingChunks {
     /// this is used as an argument for `request_chunks_for_orphan`
     /// see comments in `request_chunks_for_orphan` for what `ancestor_hash` is used for
     pub ancestor_hash: CryptoHash,
-    // Block hash that was requesting this chunk.
-    pub requestor_block_hash: CryptoHash,
 }
 
 /// Provides view on the current chain state
@@ -1929,7 +1913,6 @@ impl Chain {
                         block_processing_artifact.blocks_missing_chunks.push(BlockMissingChunks {
                             prev_hash: *block.header().prev_hash(),
                             missing_chunks: missing_chunks.clone(),
-                            block_hash,
                         });
                         let time = Clock::instant();
                         self.blocks_delay_tracker.mark_block_has_missing_chunks(block.hash(), time);
@@ -2075,6 +2058,8 @@ impl Chain {
                 .saturating_duration_since(block_start_processing_time.clone())
                 .as_secs_f64(),
         );
+        self.blocks_delay_tracker.finish_block_processing(&block_hash, new_head.clone());
+
         timer.observe_duration();
         let _timer = CryptoHashTimer::new_with_start(*block.hash(), block_start_processing_time);
 
@@ -2087,7 +2072,7 @@ impl Chain {
 
         // Determine the block status of this block (whether it is a side fork and updates the chain head)
         // Block status is needed in Client::on_block_accepted to decide to how to update the tx pool.
-        let block_status = self.determine_status(new_head.clone(), prev_head);
+        let block_status = self.determine_status(new_head, prev_head);
         Ok(AcceptedBlock { hash: *block.hash(), status: block_status, provenance })
     }
 
@@ -2321,7 +2306,6 @@ impl Chain {
                                         missing_chunks,
                                         epoch_id,
                                         ancestor_hash: block_hash,
-                                        requestor_block_hash: *orphan.header().hash(),
                                     })
                                 }
                                 _ => None,
@@ -4130,6 +4114,11 @@ impl Chain {
         self.blocks_with_missing_chunks.len()
     }
 
+    #[inline]
+    pub fn blocks_in_processing_len(&self) -> usize {
+        self.blocks_in_processing.len()
+    }
+
     /// Returns number of evicted orphans.
     #[inline]
     pub fn orphans_evicted_len(&self) -> usize {
@@ -4146,6 +4135,12 @@ impl Chain {
     #[inline]
     pub fn is_chunk_orphan(&self, hash: &CryptoHash) -> bool {
         self.blocks_with_missing_chunks.contains(hash)
+    }
+
+    /// Check if hash is for a block that is being processed
+    #[inline]
+    pub fn is_in_processing(&self, hash: &CryptoHash) -> bool {
+        self.blocks_in_processing.contains(hash)
     }
 
     /// Check if can sync with sync_hash

--- a/chain/chain/src/metrics.rs
+++ b/chain/chain/src/metrics.rs
@@ -71,15 +71,6 @@ pub static FORK_TAIL_HEIGHT: Lazy<IntGauge> =
     Lazy::new(|| try_create_int_gauge("near_fork_tail_height", "Height of fork tail").unwrap());
 pub static GC_STOP_HEIGHT: Lazy<IntGauge> =
     Lazy::new(|| try_create_int_gauge("near_gc_stop_height", "Target height of gc").unwrap());
-pub static BLOCK_CHUNKS_REQUESTED_DELAY: Lazy<HistogramVec> = Lazy::new(|| {
-    try_create_histogram_vec(
-        "near_block_chunks_request_delay_seconds",
-        "Delay between receiving a block and requesting its chunks",
-        &["shard_id"],
-        Some(exponential_buckets(0.001, 1.6, 20).unwrap()),
-    )
-    .unwrap()
-});
 pub static CHUNK_RECEIVED_DELAY: Lazy<HistogramVec> = Lazy::new(|| {
     try_create_histogram_vec(
         "near_chunk_receive_delay_seconds",

--- a/chain/chain/src/missing_chunks.rs
+++ b/chain/chain/src/missing_chunks.rs
@@ -1,7 +1,6 @@
 use near_primitives::hash::CryptoHash;
 use near_primitives::sharding::ChunkHash;
 use near_primitives::types::BlockHeight;
-use near_primitives::views::BlockStatusView;
 use std::cmp::Ordering;
 use std::collections::{
     btree_map::{self, BTreeMap},
@@ -147,18 +146,6 @@ impl<Block: BlockLike> MissingChunksPool<Block> {
                 }
             }
         }
-    }
-
-    pub fn list_blocks_by_height(&self) -> Vec<BlockStatusView> {
-        let mut result = Vec::new();
-        for (height, blocks_with_missing_chunks) in &self.height_idx {
-            result.extend(
-                blocks_with_missing_chunks
-                    .iter()
-                    .map(|block| BlockStatusView::new(&height, &block)),
-            );
-        }
-        result
     }
 
     fn mark_block_as_ready(&mut self, block_hash: &BlockHash) {

--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -57,6 +57,7 @@ fn build_chain() {
         mock_clock_guard.add_instant(Instant::now());
         mock_clock_guard.add_instant(Instant::now());
         mock_clock_guard.add_instant(Instant::now());
+        mock_clock_guard.add_instant(Instant::now());
 
         let prev_hash = *chain.head_header().unwrap().hash();
         let prev = chain.get_block(&prev_hash).unwrap();
@@ -66,7 +67,7 @@ fn build_chain() {
     }
 
     assert_eq!(mock_clock_guard.utc_call_count(), 9);
-    assert_eq!(mock_clock_guard.instant_call_count(), 17);
+    assert_eq!(mock_clock_guard.instant_call_count(), 21);
     assert_eq!(chain.head().unwrap().height, 4);
 
     let hash = chain.head().unwrap().last_block_hash;

--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -67,7 +67,6 @@ fn build_chain() {
         assert_eq!(chain.head().unwrap().height, i as u64);
     }
 
-
     assert_eq!(mock_clock_guard.utc_call_count(), 10);
     assert_eq!(mock_clock_guard.instant_call_count(), 21);
     assert_eq!(chain.head().unwrap().height, 4);

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -20,7 +20,7 @@ use near_chain::{
     BlockProcessingArtifact, BlockStatus, Chain, ChainGenesis, ChainStoreAccess,
     DoneApplyChunkCallback, Doomslug, DoomslugThresholdMode, Provenance, RuntimeAdapter,
 };
-use near_chain_configs::{ClientConfig, LogSummaryStyle};
+use near_chain_configs::ClientConfig;
 use near_chunks::{ProcessPartialEncodedChunkResult, ShardsManager};
 use near_network::types::{
     FullPeerInfo, NetworkClientResponses, NetworkRequests, PeerManagerAdapter,
@@ -40,12 +40,9 @@ use near_primitives::types::{AccountId, ApprovalStake, BlockHeight, EpochId, Num
 use near_primitives::unwrap_or_return;
 use near_primitives::utils::MaybeValidated;
 use near_primitives::validator_signer::ValidatorSigner;
-use near_primitives::views::{BlockByChunksView, ChunkInfoView};
 
 use crate::sync::{BlockSync, EpochSync, HeaderSync, StateSync, StateSyncResult};
 use crate::{metrics, SyncStatus};
-use itertools::Itertools;
-use near_chain::chain::ChainAccess;
 use near_chain::types::ValidatorInfoIdentifier;
 use near_client_primitives::types::{Error, ShardSyncDownload, ShardSyncStatus};
 use near_network::types::PeerManagerMessageRequest;
@@ -131,13 +128,11 @@ pub struct Client {
 
 // Debug information about the upcoming block.
 #[derive(Default)]
-pub struct UpcomingBlockDebugStatus {
+pub struct BlockDebugStatus {
     // How long is this block 'in progress' (time since we first saw it).
     pub in_progress_for: Option<Duration>,
     // How long is this block in orphan pool.
     pub in_orphan_for: Option<Duration>,
-    // Epoch id for the block.
-    pub epoch_id: EpochId,
     // List of chunk hashes that belong to this block.
     pub chunk_hashes: Vec<ChunkHash>,
 
@@ -1038,7 +1033,7 @@ impl Client {
             ProcessPartialEncodedChunkResult::HaveAllPartsAndReceipts => {
                 self.chain
                     .blocks_delay_tracker
-                    .mark_chunk_received(&header.chunk_hash(), Clock::instant());
+                    .mark_chunk_completed(header.chunk_hash(), Clock::instant());
                 // We're marking chunk as accepted.
                 self.chain.blocks_with_missing_chunks.accept_chunk(&header.chunk_hash());
                 // If this was the last chunk that was missing for a block, it will be processed now.
@@ -1369,10 +1364,6 @@ impl Client {
             }
         }
         self.check_incomplete_chunks(block.hash(), apply_chunks_done_callback);
-
-        let chunk_hashes: Vec<ChunkHash> =
-            block.chunks().iter().map(|chunk| chunk.chunk_hash()).collect();
-        self.chain.blocks_delay_tracker.finish_block_processing(&block_hash, &chunk_hashes);
     }
 
     pub fn request_missing_chunks(
@@ -1381,13 +1372,9 @@ impl Client {
         orphans_missing_chunks: Vec<OrphanMissingChunks>,
     ) {
         let now = Clock::instant();
-        for BlockMissingChunks { prev_hash, missing_chunks, block_hash } in blocks_missing_chunks {
+        for BlockMissingChunks { prev_hash, missing_chunks } in blocks_missing_chunks {
             for chunk in &missing_chunks {
-                self.chain.blocks_delay_tracker.mark_chunk_requested(
-                    &chunk.chunk_hash(),
-                    now,
-                    &block_hash,
-                );
+                self.chain.blocks_delay_tracker.mark_chunk_requested(chunk.chunk_hash(), now);
             }
             self.shards_mgr.request_chunks(
                 missing_chunks,
@@ -1399,15 +1386,11 @@ impl Client {
             );
         }
 
-        for OrphanMissingChunks { missing_chunks, epoch_id, ancestor_hash, requestor_block_hash } in
+        for OrphanMissingChunks { missing_chunks, epoch_id, ancestor_hash } in
             orphans_missing_chunks
         {
             for chunk in &missing_chunks {
-                self.chain.blocks_delay_tracker.mark_chunk_requested(
-                    &chunk.chunk_hash(),
-                    now,
-                    &requestor_block_hash,
-                );
+                self.chain.blocks_delay_tracker.mark_chunk_requested(chunk.chunk_hash(), now);
             }
             self.shards_mgr.request_chunks_for_orphan(
                 missing_chunks,
@@ -1964,192 +1947,6 @@ impl Client {
         //            self.challenges.insert(challenge.hash, challenge);
         //        }
         Ok(())
-    }
-
-    // Helper function to prepare the debug info about detailed upcoming blocks.
-    fn detailed_upcoming_blocks_info(
-        &self,
-    ) -> Result<HashMap<BlockHeight, HashMap<CryptoHash, UpcomingBlockDebugStatus>>, Error> {
-        let now = Instant::now();
-        let mut height_status_map: HashMap<
-            BlockHeight,
-            HashMap<CryptoHash, UpcomingBlockDebugStatus>,
-        > = HashMap::new();
-
-        // First - look at all the 'in progress' blocks.
-        for entry in self.chain.blocks_delay_tracker.blocks_in_progress.iter() {
-            if entry.1.height < self.chain.head()?.height {
-                // In case chunks delay tracker 'leaked' some old blocks - we don't want them to show up.
-                continue;
-            }
-            let height_status = height_status_map.entry(entry.1.height).or_default();
-            let mut block_status = height_status.entry(*entry.0).or_default();
-            block_status.in_progress_for = now.checked_duration_since(entry.1.received_timestamp);
-            block_status.chunk_hashes = entry.1.chunks.clone();
-        }
-
-        // And in-progress chunks.
-        // Here we can see which ones we sent requests for and which responses already came back.
-        for entry in self.chain.blocks_delay_tracker.chunks_in_progress.iter() {
-            for height_entry in height_status_map.iter_mut() {
-                if height_entry.1.contains_key(&entry.1.block_hash) {
-                    let block_status_entry = height_entry.1.get_mut(&entry.1.block_hash).unwrap();
-                    block_status_entry.chunks_requested.insert(entry.0.clone());
-                    if entry.1.chunk_received.is_some() {
-                        block_status_entry.chunks_received.insert(entry.0.clone());
-                    }
-                }
-            }
-        }
-
-        // Look also on the orphans queue - some of the blocks here might already be processed,
-        // but others will be just waiting for their turn.
-        self.chain.orphans().map(&mut |chunk_hash, block, added| {
-            let h = block.header().height();
-            let height_status = height_status_map.entry(h).or_default();
-            let mut block_status = height_status.entry(*chunk_hash).or_default();
-            block_status.in_orphan_for = now.checked_duration_since(*added);
-            block_status.chunk_hashes =
-                block.chunks().iter().map(|it| it.chunk_hash()).collect_vec();
-        });
-
-        // Fetch the status of the chunks.
-        for height_entry in height_status_map.iter_mut() {
-            for block_entry in height_entry.1.iter_mut() {
-                for chunk_hash in block_entry.1.chunk_hashes.iter() {
-                    if let Ok(true) = self.chain.chain_store().chunk_exists(&chunk_hash) {
-                        block_entry.1.chunks_completed.insert(chunk_hash.clone());
-                    }
-                }
-            }
-        }
-        Ok(height_status_map)
-    }
-
-    // Returns detailed information about the upcoming blocks in the form of printables.
-    pub fn detailed_upcoming_blocks_info_as_printable(&self) -> Result<String, Error> {
-        let height_status_map = self.detailed_upcoming_blocks_info()?;
-        let use_colour = matches!(self.config.log_summary_style, LogSummaryStyle::Colored);
-        let paint = |colour: ansi_term::Colour, text: Option<String>| match text {
-            None => ansi_term::Style::default().paint(""),
-            Some(text) if use_colour => colour.bold().paint(text),
-            Some(text) => ansi_term::Style::default().paint(text),
-        };
-
-        // Returns a status line for each block - also prints what is happening to its chunks.
-        let next_blocks_log = height_status_map
-            .keys()
-            .sorted()
-            .map(|height| {
-                let val = height_status_map.get(height).unwrap();
-
-                let block_debug = val
-                    .iter()
-                    .map(|entry| {
-                        let block_info = entry.1;
-                        let chunk_status = block_info
-                            .chunk_hashes
-                            .iter()
-                            .map(|it| {
-                                if block_info.chunks_completed.contains(it) {
-                                    "✔"
-                                } else if block_info.chunks_received.contains(it) {
-                                    "⬇"
-                                } else if block_info.chunks_requested.contains(it) {
-                                    "⬆"
-                                } else {
-                                    "."
-                                }
-                            })
-                            .collect::<Vec<&str>>();
-
-                        let chunk_status_color =
-                            if block_info.chunks_completed.len() == block_info.chunk_hashes.len() {
-                                paint(ansi_term::Colour::Green, Some(chunk_status.join("")))
-                            } else {
-                                paint(ansi_term::Colour::White, Some(chunk_status.join("")))
-                            };
-
-                        let in_progress_str = match block_info.in_progress_for {
-                            Some(duration) => format!("in progress for {:?}", duration),
-                            None => "".to_string(),
-                        };
-                        let in_orphan_str = match block_info.in_orphan_for {
-                            Some(duration) => format!("orphan for {:?}", duration),
-                            None => "".to_string(),
-                        };
-
-                        format!(
-                            "{} {} {} Chunks:({}))",
-                            entry.0, in_progress_str, in_orphan_str, chunk_status_color,
-                        )
-                    })
-                    .collect::<Vec<String>>();
-
-                format!("{} {}", height, block_debug.join("\n"))
-            })
-            .collect::<Vec<String>>();
-
-        Ok(format!(
-            "{:?} Blocks in progress: {} Chunks in progress: {} Orphans: {}{}{}",
-            self.chain.head()?.epoch_id,
-            self.chain.blocks_delay_tracker.blocks_in_progress.len(),
-            self.chain.blocks_delay_tracker.chunks_in_progress.len(),
-            self.chain.orphans().len(),
-            if next_blocks_log.len() > 0 { "\n" } else { "" },
-            next_blocks_log.join("\n")
-        ))
-    }
-
-    pub fn detailed_upcoming_blocks_info_as_web(&self) -> ChunkInfoView {
-        let height_status_map = self.detailed_upcoming_blocks_info().unwrap_or_default();
-        let next_blocks_by_chunks = height_status_map
-            .keys()
-            .sorted()
-            .map(|height| {
-                let val = height_status_map.get(height).unwrap();
-                val.iter()
-                    .map(|(block_hash, block_info)| {
-                        let chunk_status = block_info
-                            .chunk_hashes
-                            .iter()
-                            .map(|it| {
-                                if block_info.chunks_completed.contains(it) {
-                                    "(OK)"
-                                } else if block_info.chunks_received.contains(it) {
-                                    "(\\/)"
-                                } else if block_info.chunks_requested.contains(it) {
-                                    "(/\\)"
-                                } else {
-                                    "(..)"
-                                }
-                            })
-                            .collect::<Vec<&str>>();
-                        let in_progress_str = match block_info.in_progress_for {
-                            Some(duration) => format!("in progress for {:?}", duration),
-                            None => "".to_string(),
-                        };
-                        let in_orphan_str = match block_info.in_orphan_for {
-                            Some(duration) => format!("orphan for {:?}", duration),
-                            None => "".to_string(),
-                        };
-                        BlockByChunksView {
-                            height: height.clone(),
-                            hash: block_hash.clone(),
-                            block_status: format!("{} {}", in_progress_str, in_orphan_str),
-                            chunk_status: chunk_status.join(""),
-                        }
-                    })
-                    .collect::<Vec<BlockByChunksView>>()
-            })
-            .flatten()
-            .collect::<Vec<BlockByChunksView>>();
-        ChunkInfoView {
-            num_of_blocks_in_progress: self.chain.blocks_delay_tracker.blocks_in_progress.len(),
-            num_of_chunks_in_progress: self.chain.blocks_delay_tracker.chunks_in_progress.len(),
-            num_of_orphans: self.chain.orphans().len(),
-            next_blocks_by_chunks,
-        }
     }
 }
 

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1031,9 +1031,7 @@ impl Client {
     ) {
         match process_result {
             ProcessPartialEncodedChunkResult::HaveAllPartsAndReceipts => {
-                self.chain
-                    .blocks_delay_tracker
-                    .mark_chunk_completed(header.chunk_hash(), Clock::instant());
+                self.chain.blocks_delay_tracker.mark_chunk_completed(&header, Clock::instant());
                 // We're marking chunk as accepted.
                 self.chain.blocks_with_missing_chunks.accept_chunk(&header.chunk_hash());
                 // If this was the last chunk that was missing for a block, it will be processed now.
@@ -1374,7 +1372,7 @@ impl Client {
         let now = Clock::instant();
         for BlockMissingChunks { prev_hash, missing_chunks } in blocks_missing_chunks {
             for chunk in &missing_chunks {
-                self.chain.blocks_delay_tracker.mark_chunk_requested(chunk.chunk_hash(), now);
+                self.chain.blocks_delay_tracker.mark_chunk_requested(chunk, now);
             }
             self.shards_mgr.request_chunks(
                 missing_chunks,
@@ -1390,7 +1388,7 @@ impl Client {
             orphans_missing_chunks
         {
             for chunk in &missing_chunks {
-                self.chain.blocks_delay_tracker.mark_chunk_requested(chunk.chunk_hash(), now);
+                self.chain.blocks_delay_tracker.mark_chunk_requested(chunk, now);
             }
             self.shards_mgr.request_chunks_for_orphan(
                 missing_chunks,

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -14,7 +14,7 @@ use borsh::BorshSerialize;
 use chrono::DateTime;
 use near_chain::chain::{
     do_apply_chunks, ApplyStatePartsRequest, ApplyStatePartsResponse, BlockCatchUpRequest,
-    BlockCatchUpResponse, ChainAccess, StateSplitRequest, StateSplitResponse,
+    BlockCatchUpResponse, StateSplitRequest, StateSplitResponse,
 };
 use near_chain::test_utils::format_hash;
 use near_chain::types::ValidatorInfoIdentifier;
@@ -727,18 +727,12 @@ impl Handler<Status> for ClientActor {
                 ),
                 current_head_status: head.clone().into(),
                 current_header_head_status: self.client.chain.header_head()?.into(),
-                orphans: self.client.chain.orphans().list_orphans_by_height(),
-                blocks_with_missing_chunks: self
-                    .client
-                    .chain
-                    .blocks_with_missing_chunks
-                    .list_blocks_by_height(),
                 block_production_delay_millis: self
                     .client
                     .config
                     .min_block_production_delay
                     .as_millis() as u64,
-                chunk_info: self.client.detailed_upcoming_blocks_info_as_web(),
+                chain_processing_info: self.client.chain.get_chain_processing_info(),
             })
         } else {
             None
@@ -1793,7 +1787,7 @@ impl ClientActor {
             statistics,
             &self.client.config,
         );
-        debug!(target: "stats", "{}", self.client.detailed_upcoming_blocks_info_as_printable().unwrap_or(String::from("Upcoming block info failed.")));
+        debug!(target: "stats", "{}", self.client.chain.print_chain_processing_info_to_string(self.client.config.log_summary_style).unwrap_or(String::from("Upcoming block info failed.")));
     }
 }
 

--- a/chain/jsonrpc/res/chain_n_chunk_info.html
+++ b/chain/jsonrpc/res/chain_n_chunk_info.html
@@ -93,6 +93,16 @@
                         $('.js-blocks-tbody').append(row)
 
                     })
+
+                    chain_info.floating_chunks_info.forEach(chunk=> {
+                        let row = $('<tr>');
+                        row.append($('<td>').append(chunk.height_created));
+                        row.append($('<td>').append(chunk.shard_id));
+                        row.append($('<td>').append(chunk.chunk_hash));
+                        row.append($('<td>').append(chunk.created_by));
+                        row.append($('<td>').append(chunk.status));
+
+                    })
                 },
                 dataType: "json",
                 error: function (errMsg, textStatus, errorThrown) {
@@ -115,6 +125,23 @@
     <h3 class="js-chain-info-summary-missing-chunks"></h3>
     <h3 class="js-chain-info-summary-processing"></h3>
 
+    <h3>Floating chunks</h3>
+    <div>Floating chunks are the chunks for which we don't know the block they belong to yet.</div>
+    <table>
+        <thead>
+        <tr>
+            <th>Height</th>
+            <th>ShardId</th>
+            <th>Hash</th>
+            <th>Created by</th>
+            <th>Status</th>
+        </tr>
+        </thead>
+        <tbody class="js-floating-chunks-tbody">
+        </tbody>
+    </table>
+
+    <h3>Blocks</h3>
     <table>
         <thead>
         <tr>

--- a/chain/jsonrpc/res/chain_n_chunk_info.html
+++ b/chain/jsonrpc/res/chain_n_chunk_info.html
@@ -31,6 +31,38 @@
     </style>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
     <script>
+        function printTimeInMs(time) {
+            if (time == null) {
+                return "N/A"
+            } else {
+                return time + "ms"
+            }
+        }
+
+        function printChunkInfoSummary(chunks_info) {
+            let chunk_status = [];
+            chunks_info.forEach(chunk => {
+                if (chunk == null) {
+                    chunk_status.push("X");
+                } else {
+                    switch (chunk.status) {
+                        case "Completed":
+                            chunk_status.push("✔");
+                            break;
+                        case "Requested":
+                            chunk_status.push("⬇");
+                            break;
+                        case "NeedToRequest":
+                            chunk_status.push(".");
+                            break;
+                        default:
+                            break;
+                    }
+                }
+            });
+            return chunk_status.join("")
+        }
+
         $(document).ready(() => {
             $('span').text("Loading...");
             $.ajax({
@@ -39,42 +71,28 @@
                 success: data => {
                     let head = data.detailed_debug_status.current_head_status;
                     let header_head = data.detailed_debug_status.current_header_head_status;
-                    $('.js-current-head-hash').text(head.hash);
-                    $('.js-current-head-height').text(head.height);
-                    $('.js-current-header-head-hash').text(header_head.hash);
-                    $('.js-current-header-head-height').text(header_head.height);
+                    $('.js-chain-info-summary-head').append("Current head: " + head.hash + "@" + head.height + "\n");
+                    $('.js-chain-info-summary-header-head').append("Current header head: " + header_head.hash + "@" + header_head.height + "\n");
+                    let chain_info = data.detailed_debug_status.chain_processing_info;
+                    $('.js-chain-info-summary-orphans').append("Num blocks in orphan pool: " + chain_info.num_orphans + "\n");
+                    $('.js-chain-info-summary-missing-chunks').append("Num blocks in missing chunks pool: " + chain_info.num_blocks_missing_chunks + "\n");
+                    $('.js-chain-info-summary-processing').append("Num blocks in processing: " + chain_info.num_blocks_in_processing + "\n");
 
-                    let orphans = data.detailed_debug_status.orphans;
-                    if (orphans.length > 0) {
-                        orphans.forEach((orphan, index) => {
-                            $('.js-tbody-orphans').append($('<tr>')
-                                .append($('<td>').append(orphan.hash))
-                                .append($('<td>').append(orphan.height))
-                            )
-                        });
-                    } else {
-                        $('.js-tbody-orphans').append($('<tr>')
-                            .append($('<td colspan="2">').append("(None)"))
-                        );
-                    }
+                    chain_info.blocks_info.forEach(block => {
+                        if (block.hash == head.hash) {
+                            $('.js-blocks-tbody').append($("<tr><td colspan=10><b>HEAD</b></td></tr>"));
+                        }
+                        let row = $('<tr>');
+                        row.append($('<td>').append(block.height));
+                        row.append($('<td>').append(block.hash));
+                        row.append($('<td>').append(block.block_status));
+                        row.append($('<td>').append(printTimeInMs(block.in_progress_ms)));
+                        row.append($('<td>').append(printTimeInMs(block.orphaned_ms)));
+                        row.append($('<td>').append(printTimeInMs(block.missing_chunks_ms)));
+                        row.append($('<td>').append(printChunkInfoSummary(block.chunks_info)));
+                        $('.js-blocks-tbody').append(row)
 
-                    let chunk_info = data.detailed_debug_status.chunk_info;
-                    $('.js-block-count').text(chunk_info.num_of_blocks_in_progress);
-                    $('.js-chunk-count').text(chunk_info.num_of_chunks_in_progress);
-                    if (chunk_info.next_blocks_by_chunks.length > 0) {
-                        chunk_info.next_blocks_by_chunks.forEach((line, index) =>
-                            $('.js-tbody-upcoming-blocks').append($('<tr>')
-                                .append($('<td>').append(line.height))
-                                .append($('<td>').append(line.hash))
-                                .append($('<td>').append(line.block_status))
-                                .append($('<td>').append($('<pre>').append(line.chunk_status)))
-                            )
-                        );
-                    } else {
-                        $('.js-tbody-upcoming-blocks').append($('<tr>')
-                            .append($('<td colspan="4">').append("(None)"))
-                        );
-                    }
+                    })
                 },
                 dataType: "json",
                 error: function (errMsg, textStatus, errorThrown) {
@@ -90,52 +108,26 @@
     <h1>
         Welcome to the Chain & Chunk Status page!
     </h1>
-    <h2>
-        <p>
-            Current head:
-            <span class="js-current-head-hash"></span>
-            @
-            <span class="js-current-head-height"></span>
-        </p>
-        <p>
-            Current header head:
-            <span class="js-current-header-head-hash"></span>
-            @
-            <span class="js-current-header-head-height"></span>
-        </p>
-        <p>
-            Number of blocks in progress:
-            <span class="js-block-count"></span>
-        </p>
-        <p>
-            Number of chunks in progress:
-            <span class="js-chunk-count"></span>
-        </p>
-        <p>
-            Orphans
-        </p>
-    </h2>
+    <h2> Chain Info Summary </h2>
+    <h3 class="js-chain-info-summary-head"></h3>
+    <h3 class="js-chain-info-summary-header-head"></h3>
+    <h3 class="js-chain-info-summary-orphans"></h3>
+    <h3 class="js-chain-info-summary-missing-chunks"></h3>
+    <h3 class="js-chain-info-summary-processing"></h3>
+
     <table>
-        <thead><tr>
-            <th>Hash</th>
-            <th>Height</th>
-        </tr></thead>
-        <tbody class="js-tbody-orphans">
-        </tbody>
-    </table>
-    <h2>
-        <p>
-            Upcoming Blocks
-        </p>
-    </h2>
-    <table>
-        <thead><tr>
+        <thead>
+        <tr>
             <th>Height</th>
             <th>Hash</th>
-            <th>Block Status</th>
-            <th>Chunk Status</th>
-        </tr></thead>
-        <tbody class="js-tbody-upcoming-blocks">
+            <th>Status</th>
+            <th>In Progress for</th>
+            <th>In Orphan for</th>
+            <th>Missing Chunks for</th>
+            <th>Chunk status</th>
+        </tr>
+        </thead>
+        <tbody class="js-blocks-tbody">
         </tbody>
     </table>
 </body>

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -383,11 +383,64 @@ pub struct BlockByChunksView {
 
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
 #[derive(Serialize, Deserialize, Debug)]
-pub struct ChunkInfoView {
-    pub num_of_blocks_in_progress: usize,
-    pub num_of_chunks_in_progress: usize,
-    pub num_of_orphans: usize,
-    pub next_blocks_by_chunks: Vec<BlockByChunksView>,
+pub struct ChainProcessingInfo {
+    pub num_blocks_in_processing: usize,
+    pub num_orphans: usize,
+    pub num_blocks_missing_chunks: usize,
+    pub blocks_info: Vec<BlockProcessingInfo>,
+}
+
+#[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
+#[derive(Serialize, Deserialize, Debug)]
+pub struct BlockProcessingInfo {
+    pub height: BlockHeight,
+    pub hash: CryptoHash,
+    /// Timestamp when block was received.
+    //pub received_timestamp: DateTime<chrono::Utc>,
+    /// Time (in ms) between when the block was first received and when it was processed
+    pub in_progress_ms: u128,
+    /// Time (in ms) that the block spent in the orphan pool. If the block was never put in the
+    /// orphan pool, it is None. If the block is still in the orphan pool, it is since the time
+    /// it was put into the pool until the current time.
+    pub orphaned_ms: Option<u128>,
+    /// Time (in ms) that the block spent in the missing chunks pool. If the block was never put in the
+    /// missing chunks pool, it is None. If the block is still in the missing chunks pool, it is
+    /// since the time it was put into the pool until the current time.
+    pub missing_chunks_ms: Option<u128>,
+    pub block_status: BlockProcessingStatus,
+    /// Only contains new chunks that belong to this block, if the block doesn't produce a new chunk
+    /// for a shard, the corresponding item will be None.
+    pub chunks_info: Vec<Option<ChunkProcessingInfo>>,
+}
+
+#[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
+#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub enum BlockProcessingStatus {
+    Orphan,
+    WaitingForChunks,
+    InProcessing,
+    Processed,
+    Unknown,
+}
+
+#[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ChunkProcessingInfo {
+    pub status: ChunkProcessingStatus,
+    /*
+    /// Timestamp of first time when we request for this chunk.
+    pub requested_timestamp: Option<Instant>,
+    /// Time (in secs) that it takes between when the chunk is completed and when it is completed.
+    pub request_secs: Option<f64>,
+     */
+}
+
+#[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
+#[derive(Serialize, Deserialize, Debug)]
+pub enum ChunkProcessingStatus {
+    NeedToRequest,
+    Requested,
+    Completed,
 }
 
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
@@ -397,10 +450,8 @@ pub struct DetailedDebugStatus {
     pub sync_status: String,
     pub current_head_status: BlockStatusView,
     pub current_header_head_status: BlockStatusView,
-    pub orphans: Vec<BlockStatusView>,
-    pub blocks_with_missing_chunks: Vec<BlockStatusView>,
     pub block_production_delay_millis: u64,
-    pub chunk_info: ChunkInfoView,
+    pub chain_processing_info: ChainProcessingInfo,
 }
 
 // TODO: add more information to status.

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -387,6 +387,7 @@ pub struct ChainProcessingInfo {
     pub num_blocks_in_processing: usize,
     pub num_orphans: usize,
     pub num_blocks_missing_chunks: usize,
+    /// contains processing info of recent blocks, ordered by height high to low
     pub blocks_info: Vec<BlockProcessingInfo>,
 }
 

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -389,6 +389,8 @@ pub struct ChainProcessingInfo {
     pub num_blocks_missing_chunks: usize,
     /// contains processing info of recent blocks, ordered by height high to low
     pub blocks_info: Vec<BlockProcessingInfo>,
+    /// contains processing info of chunks that we don't know which block it belongs to yet
+    pub floating_chunks_info: Vec<ChunkProcessingInfo>,
 }
 
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
@@ -427,6 +429,11 @@ pub enum BlockProcessingStatus {
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ChunkProcessingInfo {
+    pub height_created: BlockHeight,
+    pub shard_id: ShardId,
+    pub prev_block_hash: CryptoHash,
+    /// Account id of the validator who created this chunk
+    pub created_by: Option<AccountId>,
     pub status: ChunkProcessingStatus,
     /*
     /// Timestamp of first time when we request for this chunk.

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -431,6 +431,7 @@ pub enum BlockProcessingStatus {
 pub struct ChunkProcessingInfo {
     pub height_created: BlockHeight,
     pub shard_id: ShardId,
+    pub chunk_hash: ChunkHash,
     pub prev_block_hash: CryptoHash,
     /// Account id of the validator who created this chunk
     pub created_by: Option<AccountId>,

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -434,6 +434,7 @@ pub struct ChunkProcessingInfo {
     pub chunk_hash: ChunkHash,
     pub prev_block_hash: CryptoHash,
     /// Account id of the validator who created this chunk
+    /// Theoretically this field should never be None unless there is some database corruption.
     pub created_by: Option<AccountId>,
     pub status: ChunkProcessingStatus,
     /*


### PR DESCRIPTION
This PR refactors BlockInProgress to keep information of recent blocks, not just blocks that are in progress and updates the debug page and debug stats print. 

The new implementation also fixed some small issues: 
- Implemented GC in BlockInProgress correctly. Previously, a block is only removed if it finished processing. This could leave blocks permanently left in the pool if it never finished processing, which could happen for blocks on some old forks.
- Now missing chunks are reflected with character "X"

In a following PR, I will add more detailed information regarding chunk processing (which parts/receipts are received/missing).

New debug page: 
<img width="1769" alt="Screen Shot 2022-07-29 at 4 34 34 PM" src="https://user-images.githubusercontent.com/34969888/181839291-5c444fee-674f-431a-8c59-59dcd45bdd0a.png">

New debug stats:
```
2022-07-29T19:00:06.422803Z DEBUG stats: EpochId(`AcpLCWttsHYuh7HNMoKaQxU63enpEJC31TXDZnFXDqVS`) Orphans: 0 With missing chunks: 0 In processing 0
1881 GdeK8aYv6JYmc2zriRZjYNxiPy3r5wBNzXpaN73d2cw7 Processed in progress for 16ms   Chunks:(✔✔✔✔))
1880 AeXssP35WTDmxLSRJBs7AP5KsBgbPWmLr5217JDSTCqy Processed in progress for 27ms   Chunks:(✔✔✔✔))
1879 Bj2eheEAoKeEUUM3mm6iHbc48cLfFSvnsGNsmmALzLyK Processed in progress for 11ms   Chunks:(✔✔✔✔))
1878 3qMZnZNSaWhRtCoBXkkFcVnwm1oLZcKPG2kfJ3HMtzhk Processed in progress for 19ms   Chunks:(✔✔✔✔))
1877 4pVuKs8PK3HTQXxh5iHHTnYphpVUyXyx135FJaTXwP71 Processed in progress for 9ms   Chunks:(✔✔✔✔))
1876 3QzRZHhb7dbWzbk3akLXzBppyuLtWTwVK9x9ytpXb9Mw Processed in progress for 15ms   Chunks:(✔✔✔✔))
1875 BS3vJJGwA9KDmknFMetMqdMnw8G5rUFurowdndjSjiBx Processed in progress for 16ms   Chunks:(✔✔✔✔))
1874 7uKcdBdzgUfdhQ7AADZa1ryPoTZXWhQJjFfSYuR9U3hP Processed in progress for 24ms   Chunks:(✔✔✔✔))
1873 9APUhnFMfcetU3ZGbjJLTfZhspj9fATJKUo19uNwvDRr Processed in progress for 17ms   Chunks:(✔✔✔✔))
1872 APvWDvtEb8dCJiniQHPRcpAXYngWCv1PnyVdGqfT63co Processed in progress for 17ms   Chunks:(✔✔✔✔))
1871 HZJUwENk3PFYY7z5bVM1c722thUMGN4UpPAkMuDDaK9P Processed in progress for 11ms   Chunks:(✔✔✔✔))
1870 9KMtaFBZLPyWrYxpR5zWVQXMw5WragYxkD9E8uryjvag Processed in progress for 14ms   Chunks:(✔✔✔✔))
1869 eoxu78RPr7fb64CynxAqWSHgR774bWivaFRX6ti8arg Processed in progress for 17ms   Chunks:(XXXX))
```
