### PR TITLE
core: views: prefer base64_format to manual base64 conversions

### DIFF
--- a/chain/jsonrpc/jsonrpc-tests/tests/rpc_transactions.rs
+++ b/chain/jsonrpc/jsonrpc-tests/tests/rpc_transactions.rs
@@ -93,7 +93,7 @@ fn test_send_tx_commit() {
         );
         let bytes = tx.try_to_vec().unwrap();
         let result = client.broadcast_tx_commit(to_base64(&bytes)).await.unwrap();
-        assert_eq!(result.status, FinalExecutionStatus::SuccessValue(to_base64(&[])));
+        assert_eq!(result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
     });
 }
 

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -7,11 +7,10 @@ use near_primitives_core::types::ProtocolVersion;
 use crate::account::{AccessKey, AccessKeyPermission, Account};
 use crate::block::Block;
 use crate::block_header::{BlockHeader, BlockHeaderV3};
-use crate::errors::{EpochError, TxExecutionError};
+use crate::errors::EpochError;
 use crate::hash::CryptoHash;
 use crate::merkle::PartialMerkleTree;
 use crate::num_rational::Ratio;
-use crate::serialize::from_base64;
 use crate::sharding::ShardChunkHeader;
 use crate::transaction::{
     Action, AddKeyAction, CreateAccountAction, DeleteAccountAction, DeleteKeyAction,
@@ -21,7 +20,6 @@ use crate::transaction::{
 use crate::types::{AccountId, Balance, BlockHeight, EpochId, EpochInfoProvider, Gas, Nonce};
 use crate::validator_signer::ValidatorSigner;
 use crate::version::PROTOCOL_VERSION;
-use crate::views::FinalExecutionStatus;
 
 pub fn account_new(amount: Balance, code_hash: CryptoHash) -> Account {
     Account::new(amount, 0, code_hash, std::mem::size_of::<Account>() as u64)
@@ -488,26 +486,6 @@ impl EpochInfoProvider for MockEpochInfoProvider {
 
     fn minimum_stake(&self, _prev_block_hash: &CryptoHash) -> Result<Balance, EpochError> {
         Ok(0)
-    }
-}
-
-impl FinalExecutionStatus {
-    pub fn as_success(self) -> Option<String> {
-        match self {
-            FinalExecutionStatus::SuccessValue(value) => Some(value),
-            _ => None,
-        }
-    }
-
-    pub fn as_failure(self) -> Option<TxExecutionError> {
-        match self {
-            FinalExecutionStatus::Failure(failure) => Some(failure),
-            _ => None,
-        }
-    }
-
-    pub fn as_success_decoded(self) -> Option<Vec<u8>> {
-        self.as_success().and_then(|value| from_base64(&value).ok())
     }
 }
 

--- a/integration-tests/src/tests/client/sandbox.rs
+++ b/integration-tests/src/tests/client/sandbox.rs
@@ -7,7 +7,6 @@ use near_client::test_utils::TestEnv;
 use near_crypto::{InMemorySigner, KeyType};
 use near_primitives::account::Account;
 use near_primitives::sandbox_state_patch::SandboxStatePatch;
-use near_primitives::serialize::{from_base64, to_base64};
 use near_primitives::state_record::StateRecord;
 use near_primitives::transaction::{
     Action, DeployContractAction, FunctionCallAction, SignedTransaction,
@@ -81,17 +80,17 @@ fn send_tx(
 fn test_patch_state() {
     let (mut env, _signer) = test_setup();
 
-    let state = env.query_state("test0".parse().unwrap());
+    let state_item = env.query_state("test0".parse().unwrap()).swap_remove(0);
     env.clients[0].chain.patch_state(SandboxStatePatch::new(vec![StateRecord::Data {
         account_id: "test0".parse().unwrap(),
-        data_key: from_base64(&state[0].key).unwrap(),
+        data_key: state_item.key,
         value: b"world".to_vec(),
     }]));
 
     do_blocks(&mut env, 9, 20);
-    let state2 = env.query_state("test0".parse().unwrap());
-    assert_eq!(state2.len(), 1);
-    assert_eq!(state2[0].value, to_base64(b"world"));
+    let state = env.query_state("test0".parse().unwrap());
+    assert_eq!(state.len(), 1);
+    assert_eq!(state[0].value, b"world");
 }
 
 #[test]

--- a/integration-tests/src/tests/nearcore/rpc_nodes.rs
+++ b/integration-tests/src/tests/nearcore/rpc_nodes.rs
@@ -15,7 +15,7 @@ use near_network::test_utils::WaitOrTimeoutActor;
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::merkle::{compute_root_from_path_and_item, verify_path};
 use near_primitives::runtime::config_store::RuntimeConfigStore;
-use near_primitives::serialize::{from_base64, to_base64};
+use near_primitives::serialize::to_base64;
 use near_primitives::transaction::{PartialExecutionStatus, SignedTransaction};
 use near_primitives::types::{
     BlockId, BlockReference, EpochId, EpochReference, Finality, TransactionOrReceiptId,
@@ -74,9 +74,7 @@ fn test_get_validator_info_rpc() {
 fn outcome_view_to_hashes(outcome: &ExecutionOutcomeView) -> Vec<CryptoHash> {
     let status = match &outcome.status {
         ExecutionStatusView::Unknown => PartialExecutionStatus::Unknown,
-        ExecutionStatusView::SuccessValue(s) => {
-            PartialExecutionStatus::SuccessValue(from_base64(s).unwrap())
-        }
+        ExecutionStatusView::SuccessValue(s) => PartialExecutionStatus::SuccessValue(s.clone()),
         ExecutionStatusView::Failure(_) => PartialExecutionStatus::Failure,
         ExecutionStatusView::SuccessReceiptId(id) => PartialExecutionStatus::SuccessReceiptId(*id),
     };

--- a/integration-tests/src/tests/runtime/deployment.rs
+++ b/integration-tests/src/tests/runtime/deployment.rs
@@ -1,12 +1,10 @@
 use crate::node::{Node, RuntimeNode};
 use near_chain_configs::Genesis;
 use near_primitives::runtime::config_store::RuntimeConfigStore;
-use near_primitives::transaction::{Action, DeployContractAction};
+use near_primitives::transaction::{Action, DeployContractAction, SignedTransaction};
 use near_primitives::types::AccountId;
 use near_primitives::version::PROTOCOL_VERSION;
-use near_primitives::{
-    serialize::to_base64, transaction::SignedTransaction, views::FinalExecutionStatus,
-};
+use near_primitives::views::FinalExecutionStatus;
 use nearcore::config::GenesisExt;
 
 const ONE_NEAR: u128 = 10u128.pow(24);
@@ -52,7 +50,7 @@ fn test_deploy_max_size_contract() {
             token_balance,
         )
         .unwrap();
-    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(to_base64(&[])));
+    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
     assert_eq!(transaction_result.receipts_outcome.len(), 2);
 
     // Deploy contract
@@ -61,7 +59,7 @@ fn test_deploy_max_size_contract() {
     near_vm_runner::prepare::prepare_contract(&wasm_binary, &config.wasm_config).unwrap();
     let transaction_result =
         node_user.deploy_contract(test_contract_id, wasm_binary.to_vec()).unwrap();
-    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(to_base64(&[])));
+    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
     assert_eq!(transaction_result.receipts_outcome.len(), 1);
 
     // Check total TX gas is in limit

--- a/integration-tests/src/tests/runtime/sanity_checks.rs
+++ b/integration-tests/src/tests/runtime/sanity_checks.rs
@@ -2,7 +2,7 @@ use crate::node::{Node, RuntimeNode};
 use near_chain_configs::Genesis;
 use near_primitives::runtime::config::RuntimeConfig;
 use near_primitives::runtime::config_store::RuntimeConfigStore;
-use near_primitives::serialize::{from_base64, to_base64};
+use near_primitives::serialize::to_base64;
 use near_primitives::types::AccountId;
 use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives::views::{
@@ -61,12 +61,12 @@ fn setup_runtime_node_with_contract(wasm_binary: &[u8]) -> RuntimeNode {
             TESTING_INIT_BALANCE / 2,
         )
         .unwrap();
-    assert_eq!(tx_result.status, FinalExecutionStatus::SuccessValue(to_base64(&[])));
+    assert_eq!(tx_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
     assert_eq!(tx_result.receipts_outcome.len(), 2);
 
     let tx_result =
         node_user.deploy_contract(test_contract_account(), wasm_binary.to_vec()).unwrap();
-    assert_eq!(tx_result.status, FinalExecutionStatus::SuccessValue(to_base64(&[])));
+    assert_eq!(tx_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
     assert_eq!(tx_result.receipts_outcome.len(), 1);
 
     node
@@ -125,7 +125,7 @@ fn test_cost_sanity() {
             0,
         )
         .unwrap();
-    assert_eq!(res.status, FinalExecutionStatus::SuccessValue(to_base64(&[])));
+    assert_eq!(res.status, FinalExecutionStatus::SuccessValue(Vec::new()));
     assert_eq!(res.transaction_outcome.outcome.metadata.gas_profile, None);
 
     let receipts_status = get_receipts_status_with_clear_hash(&res.receipts_outcome);
@@ -176,7 +176,7 @@ fn test_cost_sanity_nondeterministic() {
         .user()
         .function_call(alice_account(), test_contract_account(), "main", vec![], MAX_GAS, 0)
         .unwrap();
-    assert_eq!(res.status, FinalExecutionStatus::SuccessValue(to_base64(&[])));
+    assert_eq!(res.status, FinalExecutionStatus::SuccessValue(Vec::new()));
     assert_eq!(res.transaction_outcome.outcome.metadata.gas_profile, None);
 
     let receipts_status = get_receipts_status_with_clear_hash(&res.receipts_outcome);
@@ -219,7 +219,7 @@ fn test_sanity_used_gas() {
 
     let num_return_values = 4;
     let returned_bytes = match res.status {
-        FinalExecutionStatus::SuccessValue(v) => from_base64(&v).unwrap(),
+        FinalExecutionStatus::SuccessValue(v) => v,
         _ => panic!("Unexpected status: {:?}", res.status),
     };
     assert_eq!(returned_bytes.len(), num_return_values * size_of::<u64>());

--- a/integration-tests/src/tests/runtime/state_viewer.rs
+++ b/integration-tests/src/tests/runtime/state_viewer.rs
@@ -136,8 +136,8 @@ fn test_view_state() {
     assert_eq!(
         result.values,
         [
-            StateItem { key: "dGVzdDEyMw==".to_string(), value: "MTIz".to_string(), proof: vec![] },
-            StateItem { key: "dGVzdDMyMQ==".to_string(), value: "MzIx".to_string(), proof: vec![] }
+            StateItem { key: b"test123".to_vec(), value: b"123".to_vec(), proof: vec![] },
+            StateItem { key: b"test321".to_vec(), value: b"321".to_vec(), proof: vec![] }
         ]
     );
     let result = trie_viewer.view_state(&state_update, &alice_account(), b"xyz").unwrap();
@@ -145,7 +145,7 @@ fn test_view_state() {
     let result = trie_viewer.view_state(&state_update, &alice_account(), b"test123").unwrap();
     assert_eq!(
         result.values,
-        [StateItem { key: "dGVzdDEyMw==".to_string(), value: "MTIz".to_string(), proof: vec![] }]
+        [StateItem { key: b"test123".to_vec(), value: b"123".to_vec(), proof: vec![] }]
     );
 }
 

--- a/integration-tests/src/tests/runtime/test_evil_contracts.rs
+++ b/integration-tests/src/tests/runtime/test_evil_contracts.rs
@@ -1,6 +1,5 @@
 use crate::node::{Node, RuntimeNode};
 use near_primitives::errors::{ActionError, ActionErrorKind, ContractCallError};
-use near_primitives::serialize::to_base64;
 use near_primitives::views::FinalExecutionStatus;
 use std::mem::size_of;
 
@@ -27,12 +26,12 @@ fn setup_test_contract(wasm_binary: &[u8]) -> RuntimeNode {
             TESTING_INIT_BALANCE / 2,
         )
         .unwrap();
-    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(to_base64(&[])));
+    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
     assert_eq!(transaction_result.receipts_outcome.len(), 2);
 
     let transaction_result =
         node_user.deploy_contract("test_contract".parse().unwrap(), wasm_binary.to_vec()).unwrap();
-    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(to_base64(&[])));
+    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
     assert_eq!(transaction_result.receipts_outcome.len(), 1);
 
     node
@@ -60,7 +59,7 @@ fn test_evil_deep_trie() {
             )
             .unwrap();
         println!("Gas burnt: {}", res.receipts_outcome[0].outcome.gas_burnt);
-        assert_eq!(res.status, FinalExecutionStatus::SuccessValue(to_base64(&[])), "{:?}", res);
+        assert_eq!(res.status, FinalExecutionStatus::SuccessValue(Vec::new()), "{:?}", res);
     });
     (0..50).rev().for_each(|i| {
         println!("deleteStrings #{}", i);
@@ -81,7 +80,7 @@ fn test_evil_deep_trie() {
             )
             .unwrap();
         println!("Gas burnt: {}", res.receipts_outcome[0].outcome.gas_burnt);
-        assert_eq!(res.status, FinalExecutionStatus::SuccessValue(to_base64(&[])), "{:?}", res);
+        assert_eq!(res.status, FinalExecutionStatus::SuccessValue(Vec::new()), "{:?}", res);
     });
 }
 
@@ -104,12 +103,7 @@ fn test_evil_deep_recursion() {
             )
             .unwrap();
         if n <= 1000 {
-            assert_eq!(
-                res.status,
-                FinalExecutionStatus::SuccessValue(to_base64(&n_bytes)),
-                "{:?}",
-                res
-            );
+            assert_eq!(res.status, FinalExecutionStatus::SuccessValue(n_bytes), "{:?}", res);
         } else {
             assert_matches!(res.status, FinalExecutionStatus::Failure(_), "{:?}", res);
         }

--- a/integration-tests/src/tests/standard_cases/mod.rs
+++ b/integration-tests/src/tests/standard_cases/mod.rs
@@ -13,7 +13,6 @@ use near_primitives::errors::{
     TxExecutionError,
 };
 use near_primitives::hash::{hash, CryptoHash};
-use near_primitives::serialize::to_base64;
 use near_primitives::types::{AccountId, Balance, TrieNodesCount};
 use near_primitives::views::{
     AccessKeyView, AccountView, ExecutionMetadataView, FinalExecutionOutcomeView,
@@ -52,7 +51,7 @@ fn add_access_key(
     let transaction_result = node_user
         .add_key(account_id.clone(), signer2.public_key.clone(), access_key.clone())
         .unwrap();
-    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(String::new()));
+    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
     assert_eq!(transaction_result.receipts_outcome.len(), 1);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
@@ -67,7 +66,7 @@ pub fn test_smart_contract_simple(node: impl Node) {
         .unwrap();
     assert_eq!(
         transaction_result.status,
-        FinalExecutionStatus::SuccessValue(to_base64(&10i32.to_le_bytes()))
+        FinalExecutionStatus::SuccessValue(10i32.to_le_bytes().to_vec())
     );
     assert_eq!(transaction_result.receipts_outcome.len(), 2);
     let new_root = node_user.get_state_root();
@@ -113,7 +112,7 @@ pub fn test_smart_contract_self_call(node: impl Node) {
         .unwrap();
     assert_eq!(
         transaction_result.status,
-        FinalExecutionStatus::SuccessValue(to_base64(&10i32.to_le_bytes()))
+        FinalExecutionStatus::SuccessValue(10i32.to_le_bytes().to_vec())
     );
     assert_eq!(transaction_result.receipts_outcome.len(), 2);
     let new_root = node_user.get_state_root();
@@ -211,7 +210,7 @@ pub fn test_smart_contract_with_args(node: impl Node) {
         .unwrap();
     assert_eq!(
         transaction_result.status,
-        FinalExecutionStatus::SuccessValue(to_base64(&5u64.to_le_bytes()))
+        FinalExecutionStatus::SuccessValue(5u64.to_le_bytes().to_vec())
     );
     assert_eq!(transaction_result.receipts_outcome.len(), 2);
     let new_root = node_user.get_state_root();
@@ -225,7 +224,7 @@ pub fn test_async_call_with_logs(node: impl Node) {
     let transaction_result = node_user
         .function_call(account_id.clone(), bob_account(), "log_something", vec![], 10u64.pow(14), 0)
         .unwrap();
-    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(String::new()));
+    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
     assert_eq!(transaction_result.receipts_outcome.len(), 2);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
@@ -239,7 +238,7 @@ pub fn test_nonce_update_when_deploying_contract(node: impl Node) {
     let root = node_user.get_state_root();
     let transaction_result =
         node_user.deploy_contract(account_id.clone(), wasm_binary.to_vec()).unwrap();
-    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(String::new()));
+    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
     assert_eq!(transaction_result.receipts_outcome.len(), 1);
     assert_eq!(node_user.get_access_key_nonce_for_signer(account_id).unwrap(), 1);
     let new_root = node_user.get_state_root();
@@ -268,7 +267,7 @@ pub fn test_upload_contract(node: impl Node) {
             TESTING_INIT_BALANCE / 2,
         )
         .unwrap();
-    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(String::new()));
+    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
     assert_eq!(transaction_result.receipts_outcome.len(), 2);
 
     node_user.view_contract_code(&eve_dot_alice_account()).expect_err(
@@ -279,7 +278,7 @@ pub fn test_upload_contract(node: impl Node) {
     let wasm_binary = b"test_binary";
     let transaction_result =
         node_user.deploy_contract(eve_dot_alice_account(), wasm_binary.to_vec()).unwrap();
-    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(String::new()));
+    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
     assert_eq!(transaction_result.receipts_outcome.len(), 1);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
@@ -297,7 +296,7 @@ pub fn test_redeploy_contract(node: impl Node) {
     let test_binary = b"test_binary";
     let transaction_result =
         node_user.deploy_contract(account_id.clone(), test_binary.to_vec()).unwrap();
-    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(String::new()));
+    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
     assert_eq!(transaction_result.receipts_outcome.len(), 1);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
@@ -314,7 +313,7 @@ pub fn test_send_money(node: impl Node) {
     let transfer_cost = fee_helper.transfer_cost();
     let transaction_result =
         node_user.send_money(account_id.clone(), bob_account(), money_used).unwrap();
-    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(String::new()));
+    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
     assert_eq!(transaction_result.receipts_outcome.len(), 2);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
@@ -347,7 +346,7 @@ pub fn transfer_tokens_implicit_account(node: impl Node) {
     let receiver_id = AccountId::try_from(hex::encode(&raw_public_key)).unwrap();
     let transaction_result =
         node_user.send_money(account_id.clone(), receiver_id.clone(), tokens_used).unwrap();
-    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(String::new()));
+    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
     assert_eq!(transaction_result.receipts_outcome.len(), 2);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
@@ -371,7 +370,7 @@ pub fn transfer_tokens_implicit_account(node: impl Node) {
     let transaction_result =
         node_user.send_money(account_id.clone(), receiver_id.clone(), tokens_used).unwrap();
 
-    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(String::new()));
+    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
     assert_eq!(transaction_result.receipts_outcome.len(), 2);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
@@ -458,7 +457,7 @@ pub fn test_smart_contract_reward(node: impl Node) {
         .unwrap();
     assert_eq!(
         transaction_result.status,
-        FinalExecutionStatus::SuccessValue(to_base64(&10i32.to_le_bytes()))
+        FinalExecutionStatus::SuccessValue(10i32.to_le_bytes().to_vec())
     );
     assert_eq!(transaction_result.receipts_outcome.len(), 2);
     let new_root = node_user.get_state_root();
@@ -544,7 +543,7 @@ pub fn test_create_account(node: impl Node) {
     let fee_helper = fee_helper(&node);
     let create_account_cost = fee_helper.create_account_transfer_full_key_cost();
 
-    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(String::new()));
+    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
     assert_eq!(transaction_result.receipts_outcome.len(), 2);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
@@ -577,7 +576,7 @@ pub fn test_create_account_again(node: impl Node) {
         )
         .unwrap();
 
-    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(String::new()));
+    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
     assert_eq!(transaction_result.receipts_outcome.len(), 2);
     let fee_helper = fee_helper(&node);
     let create_account_cost = fee_helper.create_account_transfer_full_key_cost();
@@ -708,7 +707,7 @@ pub fn test_swap_key(node: impl Node) {
             AccessKey::full_access(),
         )
         .unwrap();
-    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(String::new()));
+    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
     assert_eq!(transaction_result.receipts_outcome.len(), 1);
     let new_root1 = node_user.get_state_root();
     assert_ne!(new_root, new_root1);
@@ -769,7 +768,7 @@ pub fn test_delete_key(node: impl Node) {
     let root = node_user.get_state_root();
     let transaction_result =
         node_user.delete_key(account_id.clone(), node.signer().public_key()).unwrap();
-    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(String::new()));
+    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
     assert_eq!(transaction_result.receipts_outcome.len(), 1);
     let new_root = node_user.get_state_root();
     assert_ne!(new_root, root);
@@ -820,10 +819,7 @@ pub fn test_delete_key_last(node: impl Node) {
 
     match transaction_result {
         Ok(transaction_result) => {
-            assert_eq!(
-                transaction_result.status,
-                FinalExecutionStatus::SuccessValue(String::new())
-            );
+            assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
             assert_eq!(transaction_result.receipts_outcome.len(), 1);
         }
         Err(err) => {
@@ -906,7 +902,7 @@ pub fn test_delete_access_key(node: impl Node) {
     let root = node_user.get_state_root();
     let transaction_result =
         node_user.delete_key(account_id.clone(), signer2.public_key.clone()).unwrap();
-    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(String::new()));
+    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
     assert_eq!(transaction_result.receipts_outcome.len(), 1);
     let new_root = node_user.get_state_root();
     assert_ne!(new_root, root);
@@ -966,7 +962,7 @@ pub fn test_delete_access_key_with_allowance(node: impl Node) {
     let delete_access_key_cost = fee_helper.delete_key_cost();
     let transaction_result =
         node_user.delete_key(account_id.clone(), signer2.public_key.clone()).unwrap();
-    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(String::new()));
+    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
     assert_eq!(transaction_result.receipts_outcome.len(), 1);
     let new_root = node_user.get_state_root();
     assert_ne!(new_root, root);
@@ -1005,7 +1001,7 @@ pub fn test_access_key_smart_contract(node: impl Node) {
         .unwrap();
     assert_eq!(
         transaction_result.status,
-        FinalExecutionStatus::SuccessValue(to_base64(&10i32.to_le_bytes()))
+        FinalExecutionStatus::SuccessValue(10i32.to_le_bytes().to_vec())
     );
     let gas_refund = fee_helper.gas_to_balance(
         prepaid_gas + exec_gas - transaction_result.receipts_outcome[0].outcome.gas_burnt,
@@ -1129,7 +1125,7 @@ pub fn test_increase_stake(node: impl Node) {
     let transaction_result = node_user
         .stake(account_id.clone(), node.block_signer().public_key(), amount_staked)
         .unwrap();
-    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(String::new()));
+    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
     assert_eq!(transaction_result.receipts_outcome.len(), 1);
     let node_user = node.user();
     let new_root = node_user.get_state_root();
@@ -1150,7 +1146,7 @@ pub fn test_decrease_stake(node: impl Node) {
         .unwrap();
     let fee_helper = fee_helper(&node);
     let stake_cost = fee_helper.stake_cost();
-    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(String::new()));
+    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
     assert_eq!(transaction_result.receipts_outcome.len(), 1);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
@@ -1170,7 +1166,7 @@ pub fn test_unstake_while_not_staked(node: impl Node) {
             TESTING_INIT_BALANCE / 2,
         )
         .unwrap();
-    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(String::new()));
+    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
     assert_eq!(transaction_result.receipts_outcome.len(), 2);
     let transaction_result =
         node_user.stake(eve_dot_alice_account(), node.block_signer().public_key(), 0).unwrap();
@@ -1211,7 +1207,7 @@ pub fn test_delete_account_ok(node: impl Node) {
     );
     let transaction_result =
         node_user.delete_account(eve_dot_alice_account(), eve_dot_alice_account()).unwrap();
-    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(String::new()));
+    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
     assert!(node.user().view_account(&eve_dot_alice_account()).is_err());
 }
 
@@ -1313,7 +1309,7 @@ pub fn test_delete_account_while_staking(node: impl Node) {
             money_used - stake_fee - delete_account_fee,
         )
         .unwrap();
-    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(String::new()));
+    assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
     assert_eq!(transaction_result.receipts_outcome.len(), 1);
     let transaction_result =
         node_user.delete_account(eve_dot_alice_account(), eve_dot_alice_account()).unwrap();
@@ -1339,7 +1335,7 @@ pub fn test_smart_contract_free(node: impl Node) {
         .unwrap();
     assert_eq!(
         transaction_result.status,
-        FinalExecutionStatus::SuccessValue(to_base64(&10i32.to_le_bytes()))
+        FinalExecutionStatus::SuccessValue(10i32.to_le_bytes().to_vec())
     );
     assert_eq!(transaction_result.receipts_outcome.len(), 1);
 

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -12,7 +12,6 @@ use near_primitives::{
         apply_state::ApplyState,
         migration_data::{MigrationData, MigrationFlags},
     },
-    serialize::to_base64,
     transaction::FunctionCallAction,
     trie_key::trie_key_parsers,
     types::{AccountId, EpochInfoProvider, Gas},
@@ -151,8 +150,8 @@ impl TrieViewer {
                 break;
             }
             values.push(StateItem {
-                key: to_base64(&key[acc_sep_len..]),
-                value: to_base64(&value),
+                key: key[acc_sep_len..].to_vec(),
+                value: value,
                 proof: vec![],
             });
         }


### PR DESCRIPTION
Rather than declaring a field String and having all the users do
base64 conversion manually, declare it Vec<u8> with base64_format
serialisation scheme.  This way, only the serialisation code needs to
worry how the data looks on the wire.  This also means that users
reading the data don’t need to worry about decoding errors.

Fixes: https://github.com/near/nearcore/issues/7232