### PR TITLE
fix a bug in send_network_chain_info

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -2175,7 +2175,7 @@ impl Client {
         }
         let info = self
             .runtime_adapter
-            .get_validator_info(ValidatorInfoIdentifier::EpochId(tip.epoch_id.clone()))?;
+            .get_validator_info(ValidatorInfoIdentifier::BlockHash(tip.last_block_hash))?;
         let mut accounts = HashMap::new();
         accounts.extend(
             info.current_validators


### PR DESCRIPTION
The get_validator_info function doesn't work with the current epoch id, see comments in ValidatorIdentifier.