### PR TITLE
add include validators option to state dump

### DIFF
--- a/core/chain-configs/src/genesis_config.rs
+++ b/core/chain-configs/src/genesis_config.rs
@@ -3,6 +3,7 @@
 //! NOTE: chain-configs is not the best place for `GenesisConfig` since it
 //! contains `RuntimeConfig`, but we keep it here for now until we figure
 //! out the better place.
+use std::collections::HashSet;
 use std::fs::File;
 use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
@@ -565,6 +566,31 @@ impl Genesis {
                 callback(record);
             }
         }
+    }
+}
+
+/// Config for changes applied to state dump.
+#[derive(Debug, Default)]
+pub struct GenesisChangeConfig {
+    pub select_account_ids: Option<Vec<AccountId>>,
+    pub whitelist_validators: Option<HashSet<AccountId>>,
+}
+
+impl GenesisChangeConfig {
+    pub fn with_select_account_ids(mut self, select_account_ids: Option<Vec<AccountId>>) -> Self {
+        self.select_account_ids = select_account_ids;
+        self
+    }
+
+    pub fn with_whitelist_validators(
+        mut self,
+        whitelist_validators: Option<Vec<AccountId>>,
+    ) -> Self {
+        self.whitelist_validators = match whitelist_validators {
+            None => None,
+            Some(whitelist) => Some(whitelist.into_iter().collect::<HashSet<AccountId>>()),
+        };
+        self
     }
 }
 

--- a/core/chain-configs/src/lib.rs
+++ b/core/chain-configs/src/lib.rs
@@ -7,6 +7,6 @@ pub use client_config::{
     MIN_GC_NUM_EPOCHS_TO_KEEP, TEST_STATE_SYNC_TIMEOUT,
 };
 pub use genesis_config::{
-    get_initial_supply, Genesis, GenesisConfig, GenesisRecords, GenesisValidationMode,
-    ProtocolConfig, ProtocolConfigView,
+    get_initial_supply, Genesis, GenesisChangeConfig, GenesisConfig, GenesisRecords,
+    GenesisValidationMode, ProtocolConfig, ProtocolConfigView,
 };

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -2,7 +2,7 @@ use crate::commands::*;
 use crate::epoch_info;
 use crate::rocksdb_stats::get_rocksdb_stats;
 use clap::{Args, Parser, Subcommand};
-use near_chain_configs::GenesisValidationMode;
+use near_chain_configs::{GenesisChangeConfig, GenesisValidationMode};
 use near_primitives::account::id::AccountId;
 use near_primitives::hash::CryptoHash;
 use near_primitives::sharding::ChunkHash;
@@ -123,6 +123,11 @@ pub struct DumpStateCmd {
     /// If not set, all account IDs will be dumped.
     #[clap(long)]
     account_ids: Option<Vec<AccountId>>,
+    /// List of validators to remain validators.
+    /// All other validators will be kicked, but still dumped.
+    /// Their stake will be returned to balance.
+    #[clap(long)]
+    include_validators: Option<Vec<AccountId>>,
 }
 
 impl DumpStateCmd {
@@ -134,7 +139,9 @@ impl DumpStateCmd {
             home_dir,
             near_config,
             store,
-            self.account_ids.as_ref(),
+            &GenesisChangeConfig::default()
+                .with_select_account_ids(self.account_ids)
+                .with_whitelist_validators(self.include_validators),
         );
     }
 }

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -9,6 +9,7 @@ use near_chain::migrations::check_if_block_is_first_with_chunk_of_version;
 use near_chain::types::{ApplyTransactionResult, BlockHeaderInfo};
 use near_chain::Error;
 use near_chain::{ChainStore, ChainStoreAccess, ChainStoreUpdate, RuntimeAdapter};
+use near_chain_configs::GenesisChangeConfig;
 use near_epoch_manager::EpochManager;
 use near_network::iter_peers_from_store;
 use near_primitives::account::id::AccountId;
@@ -61,7 +62,7 @@ pub(crate) fn dump_state(
     home_dir: &Path,
     near_config: NearConfig,
     store: Store,
-    account_ids: Option<&Vec<AccountId>>,
+    change_config: &GenesisChangeConfig,
 ) {
     let mode = match height {
         Some(h) => LoadTrieMode::LastFinalFromHeight(h),
@@ -81,13 +82,13 @@ pub(crate) fn dump_state(
             header,
             &near_config,
             Some(&records_path),
-            account_ids,
+            change_config,
         );
         println!("Saving state at {:?} @ {} into {}", state_roots, height, output_dir.display(),);
         new_near_config.save_to_dir(&output_dir);
     } else {
         let new_near_config =
-            state_dump(runtime, &state_roots, header, &near_config, None, account_ids);
+            state_dump(runtime, &state_roots, header, &near_config, None, change_config);
         let output_file = file.unwrap_or(home_dir.join("output.json"));
         println!("Saving state at {:?} @ {} into {}", state_roots, height, output_file.display(),);
         new_near_config.genesis.to_file(&output_file);

--- a/tools/state-viewer/src/state_dump.rs
+++ b/tools/state-viewer/src/state_dump.rs
@@ -1,6 +1,6 @@
 use borsh::BorshSerialize;
 use near_chain::RuntimeAdapter;
-use near_chain_configs::Genesis;
+use near_chain_configs::{Genesis, GenesisChangeConfig, GenesisConfig};
 use near_crypto::PublicKey;
 use near_primitives::account::id::AccountId;
 use near_primitives::block::BlockHeader;
@@ -28,7 +28,7 @@ pub fn state_dump(
     last_block_header: BlockHeader,
     near_config: &NearConfig,
     records_path: Option<&Path>,
-    select_account_ids: Option<&Vec<AccountId>>,
+    change_config: &GenesisChangeConfig,
 ) -> NearConfig {
     println!(
         "Generating genesis from state data of #{} / {}",
@@ -94,12 +94,13 @@ pub fn state_dump(
                 &validators,
                 &genesis_config.protocol_treasury_account,
                 &mut |sr| seq.serialize_element(&sr).unwrap(),
-                select_account_ids,
+                change_config,
             );
             seq.end().unwrap();
             // `total_supply` is expected to change due to the natural processes of burning tokens and
             // minting tokens every epoch.
             genesis_config.total_supply = total_supply;
+            change_genesis_config(&mut genesis_config, change_config);
             near_config.genesis =
                 Genesis::new_with_path(genesis_config, records_path.to_path_buf());
             near_config.config.genesis_records_file =
@@ -114,11 +115,12 @@ pub fn state_dump(
                 &validators,
                 &genesis_config.protocol_treasury_account,
                 &mut |sr| records.push(sr),
-                select_account_ids,
+                change_config,
             );
             // `total_supply` is expected to change due to the natural processes of burning tokens and
             // minting tokens every epoch.
             genesis_config.total_supply = total_supply;
+            change_genesis_config(&mut genesis_config, change_config);
             near_config.genesis = Genesis::new(genesis_config, records.into());
         }
     }
@@ -216,9 +218,9 @@ fn iterate_over_records(
     validators: &HashMap<AccountId, (PublicKey, Balance)>,
     protocol_treasury_account: &AccountId,
     mut callback: impl FnMut(StateRecord),
-    select_account_ids: Option<&Vec<AccountId>>,
+    change_config: &GenesisChangeConfig,
 ) -> Balance {
-    let account_allowlist = match select_account_ids {
+    let account_allowlist = match &change_config.select_account_ids {
         None => None,
         Some(select_account_id_list) => {
             let mut result = validators.keys().collect::<HashSet<&AccountId>>();
@@ -246,6 +248,7 @@ fn iterate_over_records(
                         account.set_locked(stake);
                     }
                 }
+                change_state_record(&mut sr, change_config);
                 callback(sr);
             }
         }
@@ -253,22 +256,54 @@ fn iterate_over_records(
     total_supply
 }
 
+/// Change record according to genesis_change_config.
+/// 1. Remove stake from non-whitelisted validators;
+pub fn change_state_record(record: &mut StateRecord, genesis_change_config: &GenesisChangeConfig) {
+    {
+        // Kick validators outside of whitelist
+        if let Some(whitelist) = &genesis_change_config.whitelist_validators {
+            if let StateRecord::Account { account_id, account } = record {
+                if !whitelist.contains(account_id) {
+                    account.set_amount(account.amount() + account.locked());
+                    account.set_locked(0);
+                }
+            }
+        }
+    };
+}
+
+/// Change genesis_config according to genesis_change_config.
+/// 1. Kick all the non-whitelisted validators;
+pub fn change_genesis_config(
+    genesis_config: &mut GenesisConfig,
+    genesis_change_config: &GenesisChangeConfig,
+) {
+    {
+        // Kick validators outside of whitelist
+        if let Some(whitelist) = &genesis_change_config.whitelist_validators {
+            genesis_config.validators.retain(|v| whitelist.contains(&v.account_id));
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
     use std::path::Path;
     use std::sync::Arc;
 
     use near_chain::{ChainGenesis, Provenance};
     use near_chain_configs::genesis_validate::validate_genesis;
-    use near_chain_configs::Genesis;
+    use near_chain_configs::{Genesis, GenesisChangeConfig};
     use near_client::test_utils::{run_catchup, TestEnv};
     use near_crypto::{InMemorySigner, KeyFile, KeyType, PublicKey, SecretKey};
     use near_primitives::account::id::AccountId;
     use near_primitives::shard_layout::ShardLayout;
     use near_primitives::state_record::StateRecord;
     use near_primitives::transaction::{Action, DeployContractAction, SignedTransaction};
-    use near_primitives::types::{BlockHeight, BlockHeightDelta, NumBlocks, ProtocolVersion};
+    use near_primitives::types::{
+        Balance, BlockHeight, BlockHeightDelta, NumBlocks, ProtocolVersion,
+    };
     use near_primitives::version::ProtocolFeature::SimpleNightshade;
     use near_primitives::version::PROTOCOL_VERSION;
     use near_store::test_utils::create_test_store;
@@ -383,7 +418,7 @@ mod test {
             last_block.header().clone(),
             &near_config,
             Some(&records_file.path().to_path_buf()),
-            None,
+            &GenesisChangeConfig::default(),
         );
         let new_genesis = new_near_config.genesis;
         assert_eq!(new_genesis.config.validators.len(), 2);
@@ -456,7 +491,8 @@ mod test {
             last_block.header().clone(),
             &near_config,
             None,
-            Some(&select_account_ids),
+            &GenesisChangeConfig::default()
+                .with_select_account_ids(Some(select_account_ids.clone())),
         );
         let new_genesis = new_near_config.genesis;
         let mut expected_accounts: HashSet<AccountId> =
@@ -513,7 +549,7 @@ mod test {
             last_block.header().clone(),
             &near_config,
             None,
-            None,
+            &GenesisChangeConfig::default(),
         );
         let new_genesis = new_near_config.genesis;
         assert_eq!(new_genesis.config.validators.len(), 2);
@@ -553,7 +589,7 @@ mod test {
             last_block.header().clone(),
             &near_config,
             Some(&records_file.path().to_path_buf()),
-            None,
+            &GenesisChangeConfig::default(),
         );
         let new_genesis = new_near_config.genesis;
         assert_eq!(
@@ -598,7 +634,7 @@ mod test {
             last_block.header().clone(),
             &near_config,
             Some(&records_file.path().to_path_buf()),
-            None,
+            &GenesisChangeConfig::default(),
         );
         let new_genesis = new_near_config.genesis;
 
@@ -680,7 +716,7 @@ mod test {
             last_block.header().clone(),
             &near_config,
             Some(&records_file.path().to_path_buf()),
-            None,
+            &GenesisChangeConfig::default(),
         );
     }
 
@@ -749,11 +785,87 @@ mod test {
             last_block.header().clone(),
             &near_config,
             Some(&records_file.path().to_path_buf()),
-            None,
+            &GenesisChangeConfig::default(),
         );
         let new_genesis = new_near_config.genesis;
 
         assert_eq!(new_genesis.config.validators.len(), 2);
+        validate_genesis(&new_genesis);
+    }
+
+    #[test]
+    fn test_dump_state_respect_select_whitelist_validators() {
+        let epoch_length = 4;
+        let (store, genesis, mut env, near_config) = setup(epoch_length, PROTOCOL_VERSION, None);
+
+        let genesis_hash = *env.clients[0].chain.genesis().hash();
+        let signer = InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1");
+        let tx = SignedTransaction::stake(
+            1,
+            "test1".parse().unwrap(),
+            &signer,
+            TESTING_INIT_STAKE,
+            signer.public_key.clone(),
+            genesis_hash,
+        );
+        env.clients[0].process_tx(tx, false, false);
+
+        safe_produce_blocks(&mut env, 1, epoch_length * 2 + 1);
+
+        let head = env.clients[0].chain.head().unwrap();
+        let last_block_hash = head.last_block_hash;
+        let cur_epoch_id = head.epoch_id;
+        let block_producers = env.clients[0]
+            .runtime_adapter
+            .get_epoch_block_producers_ordered(&cur_epoch_id, &last_block_hash)
+            .unwrap();
+        assert_eq!(
+            block_producers.into_iter().map(|(r, _)| r.take_account_id()).collect::<HashSet<_>>(),
+            HashSet::from_iter(vec!["test0".parse().unwrap(), "test1".parse().unwrap()]),
+        );
+
+        let whitelist_validators =
+            vec!["test1".parse().unwrap(), "non_validator_account".parse().unwrap()];
+
+        let last_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap();
+        let state_roots: Vec<CryptoHash> =
+            last_block.chunks().iter().map(|chunk| chunk.prev_state_root()).collect();
+        let runtime = NightshadeRuntime::test(Path::new("."), store, &genesis);
+        let new_near_config = state_dump(
+            runtime,
+            &state_roots,
+            last_block.header().clone(),
+            &near_config,
+            None,
+            &GenesisChangeConfig::default().with_whitelist_validators(Some(whitelist_validators)),
+        );
+        let new_genesis = new_near_config.genesis;
+
+        assert_eq!(
+            new_genesis
+                .config
+                .validators
+                .iter()
+                .map(|x| x.account_id.clone())
+                .collect::<Vec<AccountId>>(),
+            vec!["test1".parse().unwrap()]
+        );
+
+        let stake: HashMap<AccountId, Balance> = new_genesis
+            .records
+            .0
+            .iter()
+            .filter_map(|x| {
+                if let StateRecord::Account { account_id, account } = x {
+                    Some((account_id.clone(), account.locked()))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        assert_eq!(stake.get("test0").unwrap_or(&(0 as Balance)), &(0 as Balance));
+
         validate_genesis(&new_genesis);
     }
 }


### PR DESCRIPTION
Adding option to state dump to kick non-whitelisted validators. This is needed for shardnet hardforks. 

As there are some other things we do with genesis file for shardnet after dumping, introducing change_state_record and change_genesis_config to accumulate the code for future possible alterations. 
Also introducing GenesisChangeConfig, which includes previously separate individual field select_account_ids along with new field whitelist_validators. 

Unit test:
- setup with one validator test0
- staking test1
- waiting 2 epochs
- dumping state with test1 and non_validator_account whitelisted
- checking that only test1 is in validators list in genesis config
- checking that test0 has 0 stake
- checking that genesis is valid