### PR TITLE
pytest: update tests to no longer used deleted ‘testnet’ command

### DIFF
--- a/pytest/tests/sanity/backward_compatible.py
+++ b/pytest/tests/sanity/backward_compatible.py
@@ -25,17 +25,8 @@ def main():
     executables = branches.prepare_ab_test()
 
     # Setup local network.
-    subprocess.check_call([
-        executables.stable.neard,
-        "--home=%s" % node_root,
-        # TODO(#4372): testnet subcommand deprecated since 1.24.  Replace with
-        # localnet after a couple of releases in 2022.
-        "testnet",
-        "--v",
-        "2",
-        "--prefix",
-        "test"
-    ])
+    subprocess.check_call((executables.stable.neard, f'--home={node_root}',
+                           'localnet', '-v', '2', '--prefix', 'test'))
 
     # Run both binaries at the same time.
     config = executables.stable.node_config()

--- a/pytest/tests/sanity/upgradable.py
+++ b/pytest/tests/sanity/upgradable.py
@@ -78,10 +78,8 @@ def test_upgrade() -> None:
     node_root = utils.get_near_tempdir('upgradable', clean=True)
 
     # Setup local network.
-    # TODO(#4372): testnet subcommand deprecated since 1.24.  Replace with
-    # localnet after a couple of releases in 2022.
-    cmd = (executables.stable.neard, "--home=%s" % node_root, "testnet", "--v",
-           "4", "--prefix", "test")
+    cmd = (executables.stable.neard, f'--home={node_root}', 'testnet', '-v',
+           '4', '--prefix', 'test')
     logger.info(' '.join(str(arg) for arg in cmd))
     subprocess.check_call(cmd)
     genesis_config_changes = [("epoch_length", 20),

--- a/pytest/tests/sanity/upgradable.py
+++ b/pytest/tests/sanity/upgradable.py
@@ -78,7 +78,7 @@ def test_upgrade() -> None:
     node_root = utils.get_near_tempdir('upgradable', clean=True)
 
     # Setup local network.
-    cmd = (executables.stable.neard, f'--home={node_root}', 'testnet', '-v',
+    cmd = (executables.stable.neard, f'--home={node_root}', 'localnet', '-v',
            '4', '--prefix', 'test')
     logger.info(' '.join(str(arg) for arg in cmd))
     subprocess.check_call(cmd)


### PR DESCRIPTION
Issue: https://github.com/near/nearcore/issues/4372