### PR TITLE
nightly: stop fuzzing 1.27.0

### DIFF
--- a/nightly/fuzz.toml
+++ b/nightly/fuzz.toml
@@ -6,10 +6,6 @@ weight = 10
 name = "1.28.0"
 weight = 10
 
-[[branch]]
-name = "1.27.0"
-weight = 10
-
 [[target]]
 crate = "runtime/near-vm-runner/fuzz"
 runner = "runner"


### PR DESCRIPTION
Now that 1.28.0 is out, there’s no longer need to fuzz 1.27.0.  Better
to concentrate efforts on the current release.
