### PR TITLE
fix: enable backtraces on x86

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,4 +4,4 @@
 rustflags = ["-Cforce-unwind-tables=y"]
 
 [target.'cfg(target_arch = "x86_64")']
-rustflags = ["-Ctarget-feature=+sse4.1,+sse4.2"]
+rustflags = ["-Ctarget-feature=+sse4.1,+sse4.2", "-Cforce-unwind-tables=y"]


### PR DESCRIPTION
Turns out `rustflags` here are not additive!