### PR TITLE
Update rocksdb to 0.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.0.4"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5885cb81a0d4d0d322864bea1bb6c2a8144626b4fdc625d4c51eba197e7797a"
+checksum = "6f9ffb6db08c1c3a1f4aef540f1a63193adc73c4fbd40b75a95fc8c5258f6e51"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -85,13 +85,13 @@ dependencies = [
  "itoa 1.0.2",
  "language-tags",
  "local-channel",
- "log",
  "mime",
  "percent-encoding",
  "pin-project-lite",
  "rand 0.8.5",
- "sha-1",
+ "sha1 0.10.1",
  "smallvec",
+ "tracing",
  "zstd",
 ]
 
@@ -470,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.59.2"
+version = "0.60.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
+checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -2449,9 +2449,9 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.6.1+6.28.2"
+version = "0.8.0+7.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bc587013734dadb7cf23468e531aa120788b87243648be42e2d3a072186291"
+checksum = "611804e4666a25136fcc5f8cf425ab4d26c7f74ea245ffe92ea23b85b6420b5d"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -4642,7 +4642,7 @@ dependencies = [
  "dtoa",
  "itoa 0.4.8",
  "percent-encoding",
- "sha1",
+ "sha1 0.6.1",
  "url",
 ]
 
@@ -4856,9 +4856,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "620f4129485ff1a7128d184bc687470c21c7951b64779ebc9cfdad3dcd920290"
+checksum = "7e9562ea1d70c0cc63a34a22d977753b50cca91cc6b6527750463bd5dd8697bc"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -5197,23 +5197,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
-dependencies = [
- "cfg-if 1.0.0",
- "cpufeatures",
- "digest 0.10.3",
-]
-
-[[package]]
 name = "sha1"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
 dependencies = [
  "sha1_smol",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77f4e7f65455545c2153c1253d25056825e77ee2533f0e41deb65a93a34852f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -6784,18 +6784,18 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.10.2+zstd.1.5.2"
+version = "0.11.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4a6bd64f22b5e3e94b4e238669ff9f10815c27a5180108b849d24174a83847"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "4.1.6+zstd.1.5.2"
+version = "5.0.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b61c51bb270702d6167b8ce67340d2754b088d0c091b06e593aa772c3ee9bb"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -6803,9 +6803,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "1.6.3+zstd.1.5.2"
+version = "2.0.1+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc49afa5c8d634e75761feda8c592051e7eeb4683ba827211eb0d731d3402ea8"
+checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
 dependencies = [
  "cc",
  "libc",

--- a/chain/indexer/Cargo.toml
+++ b/chain/indexer/Cargo.toml
@@ -13,7 +13,7 @@ anyhow = "1.0.51"
 async-recursion = "0.3.2"
 tracing = "0.1.13"
 futures = "0.3.5"
-rocksdb = { version = "0.18.0", default-features = false, features = ["snappy", "lz4", "zstd", "zlib"] }
+rocksdb = { version = "0.19.0", default-features = false, features = ["snappy", "lz4", "zstd", "zlib"] }
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1.0.55"
 tokio = { version = "1.1", features = ["time", "sync"] }

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -14,7 +14,7 @@ bytesize = { version = "1.1", features = ["serde"] }
 derive_more = "0.99.3"
 elastic-array = "0.11"
 enum-map = "2.1.0"
-rocksdb = { version = "0.18.0", default-features = false, features = ["snappy", "lz4", "zstd", "zlib"] }
+rocksdb = { version = "0.19.0", default-features = false, features = ["snappy", "lz4", "zstd", "zlib"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"

--- a/core/store/src/db/rocksdb.rs
+++ b/core/store/src/db/rocksdb.rs
@@ -485,9 +485,6 @@ impl RocksDB {
     /// Gets every int property in CF_PROPERTY_NAMES for every column in DBCol.
     fn get_cf_statistics(&self, result: &mut StoreStatistics) {
         for prop_name in CF_PROPERTY_NAMES {
-            // TODO(mina86): Once const_str_from_utf8 is stabilised we can
-            // convert this run-time UTF8 validation into compile-time one.
-            let stat_name = std::str::from_utf8(prop_name.to_bytes()).unwrap();
             let mut values = vec![];
             for col in DBCol::iter() {
                 let size = self.db.property_int_value_cf(self.cf_handle(col), prop_name);
@@ -496,6 +493,9 @@ impl RocksDB {
                 }
             }
             if !values.is_empty() {
+                // TODO(mina86): Once const_str_from_utf8 is stabilised we might
+                // be able convert this runtime UTF-8 validation into const.
+                let stat_name = prop_name.to_str().unwrap();
                 result.data.push((stat_name.to_string(), values));
             }
         }

--- a/core/store/src/db/rocksdb.rs
+++ b/core/store/src/db/rocksdb.rs
@@ -205,7 +205,7 @@ impl RocksDB {
             (start, end)
         };
         match range {
-            (Some(start), Some(end)) => Ok(Some(start.0..end.0)),
+            (Some(start), Some(end)) => Ok(Some(start.0..=end.0)),
             (None, None) => Ok(None),
             _ => unreachable!(),
         }
@@ -269,9 +269,9 @@ impl Database for RocksDB {
                     let cf_handle = self.cf_handle(col);
                     let range = self.get_cf_key_range(cf_handle).map_err(into_other)?;
                     if let Some(range) = range {
-                        batch.delete_range_cf(cf_handle, &range.start, &range.end);
+                        batch.delete_range_cf(cf_handle, range.start(), range.end());
                         // delete_range_cf deletes ["begin_key", "end_key"), so need one more delete
-                        batch.delete_cf(cf_handle, range.end)
+                        batch.delete_cf(cf_handle, range.end())
                     }
                 }
             }

--- a/core/store/src/db/rocksdb.rs
+++ b/core/store/src/db/rocksdb.rs
@@ -196,7 +196,7 @@ impl RocksDB {
     fn get_cf_key_range(
         &self,
         cf_handle: &ColumnFamily,
-    ) -> Result<Option<std::ops::Range<Box<[u8]>>>, ::rocksdb::Error> {
+    ) -> Result<Option<std::ops::RangeInclusive<Box<[u8]>>>, ::rocksdb::Error> {
         let range = {
             let mut iter = self.db.iterator_cf(cf_handle, IteratorMode::Start);
             let start = iter.next().transpose()?;

--- a/core/store/src/db/rocksdb.rs
+++ b/core/store/src/db/rocksdb.rs
@@ -20,7 +20,7 @@ use crate::{metrics, DBCol, StoreConfig, StoreStatistics};
 /// List of integer RocskDB properties we’re reading when collecting statistics.
 ///
 /// In the end, they are exported as Prometheus metrics.
-pub const CF_PROPERTY_NAMES: [&'static std::ffi::CStr; 1] =
+const CF_PROPERTY_NAMES: [&'static std::ffi::CStr; 1] =
     [::rocksdb::properties::LIVE_SST_FILES_SIZE];
 
 pub struct RocksDB {
@@ -485,9 +485,9 @@ impl RocksDB {
     /// Gets every int property in CF_PROPERTY_NAMES for every column in DBCol.
     fn get_cf_statistics(&self, result: &mut StoreStatistics) {
         for prop_name in CF_PROPERTY_NAMES {
-            let stat_name = prop_name.to_bytes();
-            // SAFETY: RocksDB property names are always entirely ASCII.
-            let stat_name = unsafe { std::str::from_utf8_unchecked(stat_name) };
+            // TODO(mina86): Once const_str_from_utf8 is stabilised we can
+            // convert this run-time UTF8 validation into compile-time one.
+            let stat_name = std::str::from_utf8(prop_name.to_bytes()).unwrap();
             let mut values = vec![];
             for col in DBCol::iter() {
                 let size = self.db.property_int_value_cf(self.cf_handle(col), prop_name);

--- a/deny.toml
+++ b/deny.toml
@@ -108,4 +108,7 @@ skip = [
 
     # prometheus depends on an old version of protobuf
     { name = "protobuf", version = "=2.27.1" },
+
+    # redis we’re using uses ancient sha
+    { name = "sha1", version = "=0.6.1" },
 ]

--- a/runtime/runtime-params-estimator/Cargo.toml
+++ b/runtime/runtime-params-estimator/Cargo.toml
@@ -39,7 +39,7 @@ near-primitives = { path = "../../core/primitives" }
 near-o11y = { path = "../../core/o11y" }
 
 nearcore = { path = "../../nearcore" }
-rocksdb = { version = "0.18.0", default-features = false, features = ["snappy", "lz4", "zstd", "zlib"] }
+rocksdb = { version = "0.19.0", default-features = false, features = ["snappy", "lz4", "zstd", "zlib"] }
 walrus = "0.18.0"
 hex = "0.4"
 cfg-if = "1"


### PR DESCRIPTION
This brings a few changes which allow our code to be simplified:

* Iterators now return Result<Item, Error> rather than forcing users
  to check for errors with separate status method call.  We can remove
  our wrapping code;

* rocksdb::PrefixRange allows setting a prefix range which is what we
  used to do ourselves.  This lets us get rid of next_prefix function;

* property_value method et al. accept CStr arguments and properties
  defined in rocksdb::properties are now defined as CStrs.  This is
  an optimisation as previously each call to property_int_value_cf
  resulted in str→CStr conversion which requires memory allocation.

Notably, with this update Cargo (after issuing a build command) also
decided that updating actix-http from 3.0.4 to 3.2.1 is in order.
