### PR TITLE
Revert "Fix/rosetta rpc predecessor"

### DIFF
--- a/chain/rosetta-rpc/src/adapters/mod.rs
+++ b/chain/rosetta-rpc/src/adapters/mod.rs
@@ -321,7 +321,6 @@ impl From<NearActions> for Vec<crate::models::Operation> {
                         validated_operations::TransferOperation {
                             account: sender_account_identifier.clone(),
                             amount: -transfer_amount.clone(),
-                            predecessor_id: sender_account_identifier.clone(),
                         }
                         .into_operation(sender_transfer_operation_id.clone()),
                     );
@@ -330,7 +329,6 @@ impl From<NearActions> for Vec<crate::models::Operation> {
                         validated_operations::TransferOperation {
                             account: receiver_account_identifier.clone(),
                             amount: transfer_amount,
-                            predecessor_id: sender_account_identifier.clone(),
                         }
                         .into_related_operation(
                             crate::models::OperationIdentifier::new(&operations),
@@ -383,7 +381,6 @@ impl From<NearActions> for Vec<crate::models::Operation> {
                             validated_operations::TransferOperation {
                                 account: sender_account_identifier.clone(),
                                 amount: -attached_amount.clone(),
-                                predecessor_id: sender_account_identifier.clone(),
                             }
                             .into_operation(fund_transfer_operation_id.clone()),
                         );

--- a/chain/rosetta-rpc/src/adapters/validated_operations/transfer.rs
+++ b/chain/rosetta-rpc/src/adapters/validated_operations/transfer.rs
@@ -3,7 +3,6 @@ use super::ValidatedOperation;
 pub(crate) struct TransferOperation {
     pub(crate) account: crate::models::AccountIdentifier,
     pub(crate) amount: crate::models::Amount,
-    pub(crate) predecessor_id: crate::models::AccountIdentifier,
 }
 
 impl ValidatedOperation for TransferOperation {
@@ -18,10 +17,7 @@ impl ValidatedOperation for TransferOperation {
 
             account: self.account,
             amount: Some(self.amount),
-            metadata: Some(crate::models::OperationMetadata {
-                predecessor_id: Some(self.predecessor_id),
-                ..Default::default()
-            }),
+            metadata: None,
 
             related_operations: None,
             type_: Self::OPERATION_TYPE,
@@ -42,8 +38,7 @@ impl TryFrom<crate::models::Operation> for TransferOperation {
     fn try_from(operation: crate::models::Operation) -> Result<Self, Self::Error> {
         Self::validate_operation_type(operation.type_)?;
         let amount = operation.amount.ok_or_else(required_fields_error)?;
-        let metadata = operation.metadata.ok_or_else(required_fields_error)?;
-        let predecessor_id = metadata.predecessor_id.ok_or_else(required_fields_error)?;
-        Ok(Self { account: operation.account, amount, predecessor_id })
+
+        Ok(Self { account: operation.account, amount })
     }
 }

--- a/chain/rosetta-rpc/src/models.rs
+++ b/chain/rosetta-rpc/src/models.rs
@@ -770,9 +770,6 @@ pub(crate) struct OperationMetadata {
     /// Has to be specified for FUNCTION_CALL operation
     #[serde(skip_serializing_if = "Option::is_none")]
     pub attached_gas: Option<crate::utils::SignedDiff<near_primitives::types::Gas>>,
-    /// Has to be specified for TRANSFER operation
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub predecessor_id: Option<AccountIdentifier>,
 }
 
 /// Operations contain all balance-changing information within a transaction.


### PR DESCRIPTION
That commit broke sanity/rosetta.py pytest.

This reverts commit add1390034763834648e7f3180c90f6b58f55ecf.