### PR TITLE
pytest: remove requirement of specific scipy version

### DIFF
--- a/pytest/requirements.txt
+++ b/pytest/requirements.txt
@@ -11,9 +11,7 @@ python-rc==0.3.9
 requests
 retrying
 scikit-learn
-# TODO(mina86): scipy 1.7.2 breaks buildkite so for the time being pin
-# to an older version.  Remove the pin once issue is fixed properly.
-scipy==1.7.1
+scipy
 semver
 toml
 tqdm


### PR DESCRIPTION
We had some issues with scipy 1.7.2 on buildkite (which I can no
longer recall if I’m to be honest) but now requiring 1.7.1 poses its
own problems.  It is incompatible with Python 3.10 and also causes
issues on M1.  Both of those are solved by unpinning the version and
allowing latest scipy release.
