### PR TITLE
Handle opentelemetry errors

### DIFF
--- a/core/o11y/src/lib.rs
+++ b/core/o11y/src/lib.rs
@@ -241,15 +241,15 @@ fn opentelemetry_error_handler(error: opentelemetry::global::Error) {
     match error.into() {
         opentelemetry::global::Error::Trace(err) => tracing::warn!(
             target: "opentelemetry",
-            err = ?err,
+            ?err,
             "OpenTelemetry trace error"),
         opentelemetry::global::Error::Other(err) => tracing::warn!(
             target: "opentelemetry",
-            err = ?err,
+            ?err,
             "OpenTelemetry error"),
         err => tracing::warn!(
             target: "opentelemetry",
-            err = ?err,
+            ?err,
             "Unknown OpenTelemetry error"),
     }
 }

--- a/core/o11y/src/lib.rs
+++ b/core/o11y/src/lib.rs
@@ -242,7 +242,7 @@ fn opentelemetry_error_handler(error: opentelemetry::global::Error) {
         opentelemetry::global::Error::Trace(err) => tracing::warn!(
             target: "opentelemetry",
             err = ?err,
-        "OpenTelemetry trace error"),
+            "OpenTelemetry trace error"),
         opentelemetry::global::Error::Other(err) => tracing::warn!(
             target: "opentelemetry",
             err = ?err,


### PR DESCRIPTION
Without this PR the errors get reported using `eprintln!()`, which can be noisy and can't be controlled with `RUST_LOG`.
cc: @marcelo-gonzalez 