### PR TITLE
store: add StateRoot into Trie struct

### DIFF
--- a/chain/chain/src/store_validator/validate.rs
+++ b/chain/chain/src/store_validator/validate.rs
@@ -559,9 +559,9 @@ pub(crate) fn trie_changes_chunk_extra_exists(
         );
     }
     // 4) Trie should exist for `shard_uid` and the root
-    let trie = sv.runtime_adapter.get_tries().get_trie_for_shard(*shard_uid);
+    let trie = sv.runtime_adapter.get_tries().get_trie_for_shard(*shard_uid, new_root.clone());
     let trie_iterator = unwrap_or_err!(
-        trie.iter(&new_root),
+        trie.iter(),
         "Trie Node Missing for shard {:?} root {:?}",
         shard_uid,
         new_root

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -418,16 +418,23 @@ impl RuntimeAdapter for KeyValueRuntime {
         &self,
         shard_id: ShardId,
         _block_hash: &CryptoHash,
+        state_root: StateRoot,
     ) -> Result<Trie, Error> {
-        Ok(self.tries.get_trie_for_shard(ShardUId { version: 0, shard_id: shard_id as u32 }))
+        Ok(self
+            .tries
+            .get_trie_for_shard(ShardUId { version: 0, shard_id: shard_id as u32 }, state_root))
     }
 
     fn get_view_trie_for_shard(
         &self,
         shard_id: ShardId,
         _block_hash: &CryptoHash,
+        state_root: StateRoot,
     ) -> Result<Trie, Error> {
-        Ok(self.tries.get_view_trie_for_shard(ShardUId { version: 0, shard_id: shard_id as u32 }))
+        Ok(self.tries.get_view_trie_for_shard(
+            ShardUId { version: 0, shard_id: shard_id as u32 },
+            state_root,
+        ))
     }
 
     fn verify_block_vrf(

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -263,13 +263,19 @@ pub trait RuntimeAdapter: Send + Sync {
     /// Returns trie. Since shard layout may change from epoch to epoch, `shard_id` itself is
     /// not enough to identify the trie. `prev_hash` is used to identify the epoch the given
     /// `shard_id` is at.
-    fn get_trie_for_shard(&self, shard_id: ShardId, prev_hash: &CryptoHash) -> Result<Trie, Error>;
+    fn get_trie_for_shard(
+        &self,
+        shard_id: ShardId,
+        prev_hash: &CryptoHash,
+        state_root: StateRoot,
+    ) -> Result<Trie, Error>;
 
     /// Returns trie with view cache
     fn get_view_trie_for_shard(
         &self,
         shard_id: ShardId,
         prev_hash: &CryptoHash,
+        state_root: StateRoot,
     ) -> Result<Trie, Error>;
 
     fn verify_block_vrf(

--- a/core/store/benches/trie_bench.rs
+++ b/core/store/benches/trie_bench.rs
@@ -14,21 +14,21 @@ fn rand_bytes() -> Vec<u8> {
 
 fn trie_lookup(bench: &mut Bencher) {
     let tries = create_tries();
-    let trie = tries.get_trie_for_shard(ShardUId::single_shard());
-    let root = Trie::EMPTY_ROOT;
+    let mut trie = tries.get_trie_for_shard(ShardUId::single_shard(), Trie::EMPTY_ROOT);
     let mut changes = vec![];
     for _ in 0..100 {
         changes.push((rand_bytes(), Some(rand_bytes())));
     }
     let other_changes = changes.clone();
-    let trie_changes = trie.update(&root, changes.drain(..)).unwrap();
+    let trie_changes = trie.update(changes.drain(..)).unwrap();
     let (state_update, root) = tries.apply_all(&trie_changes, ShardUId::single_shard());
     state_update.commit().expect("Failed to commit");
+    trie.set_root(root);
 
     bench.iter(|| {
         for _ in 0..1 {
             for (key, _) in other_changes.iter() {
-                trie.get(&root, key).unwrap();
+                trie.get(key).unwrap();
             }
         }
     });
@@ -36,8 +36,7 @@ fn trie_lookup(bench: &mut Bencher) {
 
 fn trie_update(bench: &mut Bencher) {
     let tries = create_tries();
-    let trie = tries.get_trie_for_shard(ShardUId::single_shard());
-    let root = Trie::EMPTY_ROOT;
+    let trie = tries.get_trie_for_shard(ShardUId::single_shard(), Trie::EMPTY_ROOT);
     let mut changes = vec![];
     for _ in 0..100 {
         changes.push((rand_bytes(), Some(rand_bytes())));
@@ -45,7 +44,7 @@ fn trie_update(bench: &mut Bencher) {
 
     bench.iter(|| {
         let mut this_changes = changes.clone();
-        let _ = trie.update(&root, this_changes.drain(..));
+        let _ = trie.update(this_changes.drain(..));
     });
 }
 

--- a/core/store/src/test_utils.rs
+++ b/core/store/src/test_utils.rs
@@ -36,13 +36,13 @@ pub fn test_populate_trie(
     shard_uid: ShardUId,
     changes: Vec<(Vec<u8>, Option<Vec<u8>>)>,
 ) -> CryptoHash {
-    let mut trie = tries.get_trie_for_shard(shard_uid, root.clone());
+    let trie = tries.get_trie_for_shard(shard_uid, root.clone());
     assert_eq!(trie.storage.as_caching_storage().unwrap().shard_uid.shard_id, 0);
     let trie_changes = trie.update(changes.iter().cloned()).unwrap();
     let (store_update, root) = tries.apply_all(&trie_changes, shard_uid);
     store_update.commit().unwrap();
     let deduped = simplify_changes(&changes);
-    trie.set_root(root);
+    let trie = tries.get_trie_for_shard(shard_uid, root.clone());
     for (key, value) in deduped {
         assert_eq!(trie.get(&key), Ok(value));
     }

--- a/core/store/src/test_utils.rs
+++ b/core/store/src/test_utils.rs
@@ -36,14 +36,15 @@ pub fn test_populate_trie(
     shard_uid: ShardUId,
     changes: Vec<(Vec<u8>, Option<Vec<u8>>)>,
 ) -> CryptoHash {
-    let trie = tries.get_trie_for_shard(shard_uid);
+    let mut trie = tries.get_trie_for_shard(shard_uid, root.clone());
     assert_eq!(trie.storage.as_caching_storage().unwrap().shard_uid.shard_id, 0);
-    let trie_changes = trie.update(root, changes.iter().cloned()).unwrap();
+    let trie_changes = trie.update(changes.iter().cloned()).unwrap();
     let (store_update, root) = tries.apply_all(&trie_changes, shard_uid);
     store_update.commit().unwrap();
     let deduped = simplify_changes(&changes);
+    trie.set_root(root);
     for (key, value) in deduped {
-        assert_eq!(trie.get(&root, &key), Ok(value));
+        assert_eq!(trie.get(&key), Ok(value));
     }
     root
 }

--- a/core/store/src/trie/iterator.rs
+++ b/core/store/src/trie/iterator.rs
@@ -36,7 +36,6 @@ pub struct TrieIterator<'a> {
     trie: &'a Trie,
     trail: Vec<Crumb>,
     pub(crate) key_nibbles: Vec<u8>,
-    root: CryptoHash,
 }
 
 pub type TrieItem = (Vec<u8>, Vec<u8>);
@@ -52,14 +51,13 @@ pub struct TrieTraversalItem {
 impl<'a> TrieIterator<'a> {
     #![allow(clippy::new_ret_no_self)]
     /// Create a new iterator.
-    pub(super) fn new(trie: &'a Trie, root: &CryptoHash) -> Result<Self, StorageError> {
+    pub(super) fn new(trie: &'a Trie) -> Result<Self, StorageError> {
         let mut r = TrieIterator {
             trie,
             trail: Vec::with_capacity(8),
             key_nibbles: Vec::with_capacity(64),
-            root: *root,
         };
-        let node = trie.retrieve_node(root)?;
+        let node = trie.retrieve_node(&trie.root)?;
         r.descend_into_node(node);
         Ok(r)
     }
@@ -76,7 +74,7 @@ impl<'a> TrieIterator<'a> {
     ) -> Result<CryptoHash, StorageError> {
         self.trail.clear();
         self.key_nibbles.clear();
-        let mut hash = self.root;
+        let mut hash = self.trie.root;
         loop {
             let node = self.trie.retrieve_node(&hash)?;
             self.trail.push(Crumb { status: CrumbStatus::Entering, node });
@@ -339,8 +337,6 @@ mod tests {
     use rand::seq::SliceRandom;
     use rand::Rng;
 
-    use near_primitives::hash::CryptoHash;
-
     use crate::test_utils::{
         create_tries, create_tries_complex, gen_changes, simplify_changes, test_populate_trie,
     };
@@ -355,7 +351,6 @@ mod tests {
         for _ in 0..100 {
             let tries = create_tries_complex(1, 2);
             let shard_uid = ShardUId { version: 1, shard_id: 0 };
-            let trie = tries.get_trie_for_shard(shard_uid);
             let trie_changes = gen_changes(&mut rng, 10);
             let trie_changes = simplify_changes(&trie_changes);
 
@@ -367,36 +362,37 @@ mod tests {
             }
             let state_root =
                 test_populate_trie(&tries, &Trie::EMPTY_ROOT, shard_uid, trie_changes.clone());
+            let trie = tries.get_trie_for_shard(shard_uid, state_root);
 
             {
-                let result1: Vec<_> = trie.iter(&state_root).unwrap().map(Result::unwrap).collect();
+                let result1: Vec<_> = trie.iter().unwrap().map(Result::unwrap).collect();
                 let result2: Vec<_> = map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
                 assert_eq!(result1, result2);
             }
-            test_seek(&trie, &map, &state_root, &[]);
+            test_seek(&trie, &map, &[]);
 
             let empty_vec = vec![];
             let max_key = map.keys().max().unwrap_or(&empty_vec);
             let min_key = map.keys().min().unwrap_or(&empty_vec);
-            test_get_trie_items(&trie, &map, &state_root, &[], &[]);
-            test_get_trie_items(&trie, &map, &state_root, min_key, max_key);
+            test_get_trie_items(&trie, &map, &[], &[]);
+            test_get_trie_items(&trie, &map, min_key, max_key);
             for (seek_key, _) in trie_changes.iter() {
-                test_seek(&trie, &map, &state_root, seek_key);
-                test_get_trie_items(&trie, &map, &state_root, min_key, seek_key);
-                test_get_trie_items(&trie, &map, &state_root, seek_key, max_key);
+                test_seek(&trie, &map, seek_key);
+                test_get_trie_items(&trie, &map, min_key, seek_key);
+                test_get_trie_items(&trie, &map, seek_key, max_key);
             }
             for _ in 0..20 {
                 let alphabet = &b"abcdefgh"[0..rng.gen_range(2, 8)];
                 let key_length = rng.gen_range(1, 8);
                 let seek_key: Vec<u8> =
                     (0..key_length).map(|_| *alphabet.choose(&mut rng).unwrap()).collect();
-                test_seek(&trie, &map, &state_root, &seek_key);
+                test_seek(&trie, &map, &seek_key);
 
                 let seek_key2: Vec<u8> =
                     (0..key_length).map(|_| *alphabet.choose(&mut rng).unwrap()).collect();
                 let path_begin = seek_key.clone().min(seek_key2.clone());
                 let path_end = seek_key.clone().max(seek_key2.clone());
-                test_get_trie_items(&trie, &map, &state_root, &path_begin, &path_end);
+                test_get_trie_items(&trie, &map, &path_begin, &path_end);
             }
         }
     }
@@ -404,17 +400,13 @@ mod tests {
     fn test_get_trie_items(
         trie: &Trie,
         map: &BTreeMap<Vec<u8>, Vec<u8>>,
-        state_root: &CryptoHash,
         path_begin: &[u8],
         path_end: &[u8],
     ) {
         let path_begin_nibbles: Vec<_> = NibbleSlice::new(path_begin).iter().collect();
         let path_end_nibbles: Vec<_> = NibbleSlice::new(path_end).iter().collect();
-        let result1 = trie
-            .iter(state_root)
-            .unwrap()
-            .get_trie_items(&path_begin_nibbles, &path_end_nibbles)
-            .unwrap();
+        let result1 =
+            trie.iter().unwrap().get_trie_items(&path_begin_nibbles, &path_end_nibbles).unwrap();
         let result2: Vec<_> = map
             .range(path_begin.to_vec()..path_end.to_vec())
             .map(|(k, v)| (k.clone(), v.clone()))
@@ -422,20 +414,14 @@ mod tests {
         assert_eq!(result1, result2);
 
         // test when path_end ends in [16]
-        let result1 =
-            trie.iter(state_root).unwrap().get_trie_items(&path_begin_nibbles, &[16u8]).unwrap();
+        let result1 = trie.iter().unwrap().get_trie_items(&path_begin_nibbles, &[16u8]).unwrap();
         let result2: Vec<_> =
             map.range(path_begin.to_vec()..).map(|(k, v)| (k.clone(), v.clone())).collect();
         assert_eq!(result1, result2);
     }
 
-    fn test_seek(
-        trie: &Trie,
-        map: &BTreeMap<Vec<u8>, Vec<u8>>,
-        state_root: &CryptoHash,
-        seek_key: &[u8],
-    ) {
-        let mut iterator = trie.iter(state_root).unwrap();
+    fn test_seek(trie: &Trie, map: &BTreeMap<Vec<u8>, Vec<u8>>, seek_key: &[u8]) {
+        let mut iterator = trie.iter().unwrap();
         iterator.seek(&seek_key).unwrap();
         let result1: Vec<_> = iterator.map(Result::unwrap).take(5).collect();
         let result2: Vec<_> =
@@ -448,7 +434,6 @@ mod tests {
         let mut rng = rand::thread_rng();
         for _ in 0..100 {
             let tries = create_tries();
-            let trie = tries.get_trie_for_shard(ShardUId::single_shard());
             let trie_changes = gen_changes(&mut rng, 10);
             let trie_changes = simplify_changes(&trie_changes);
             let state_root = test_populate_trie(
@@ -457,7 +442,8 @@ mod tests {
                 ShardUId::single_shard(),
                 trie_changes.clone(),
             );
-            let mut iterator = trie.iter(&state_root).unwrap();
+            let trie = tries.get_trie_for_shard(ShardUId::single_shard(), state_root);
+            let mut iterator = trie.iter().unwrap();
             loop {
                 let iter_step = match iterator.iter_step() {
                     Some(iter_step) => iter_step,

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -407,6 +407,7 @@ impl RawTrieNodeWithSize {
 
 pub struct Trie {
     pub storage: Box<dyn TrieStorage>,
+    root: StateRoot,
     pub flat_state: Option<FlatState>,
 }
 
@@ -472,8 +473,12 @@ pub struct ApplyStatePartResult {
 impl Trie {
     pub const EMPTY_ROOT: StateRoot = StateRoot::new();
 
-    pub fn new(storage: Box<dyn TrieStorage>, flat_state: Option<FlatState>) -> Self {
-        Trie { storage, flat_state }
+    pub fn new(
+        storage: Box<dyn TrieStorage>,
+        root: StateRoot,
+        flat_state: Option<FlatState>,
+    ) -> Self {
+        Trie { storage, root, flat_state }
     }
 
     pub fn recording_reads(&self) -> Self {
@@ -484,7 +489,7 @@ impl Trie {
             shard_uid: storage.shard_uid,
             recorded: RefCell::new(Default::default()),
         };
-        Trie { storage: Box::new(storage), flat_state: None }
+        Trie { storage: Box::new(storage), root: self.root.clone(), flat_state: None }
     }
 
     pub fn recorded_storage(&self) -> Option<PartialStorage> {
@@ -495,16 +500,24 @@ impl Trie {
         Some(PartialStorage { nodes: PartialState(nodes) })
     }
 
-    pub fn from_recorded_storage(partial_storage: PartialStorage) -> Self {
+    pub fn from_recorded_storage(partial_storage: PartialStorage, root: StateRoot) -> Self {
         let recorded_storage =
             partial_storage.nodes.0.into_iter().map(|value| (hash(&value), value)).collect();
-        Trie {
-            storage: Box::new(TrieMemoryPartialStorage {
-                recorded_storage,
-                visited_nodes: Default::default(),
-            }),
-            flat_state: None,
-        }
+        let storage = Box::new(TrieMemoryPartialStorage {
+            recorded_storage,
+            visited_nodes: Default::default(),
+        });
+        Self::new(storage, root, None)
+    }
+
+    pub fn get_root(&self) -> &StateRoot {
+        &self.root
+    }
+
+    /// Sets state root of current Trie to given value.  Used only in tests.
+    #[doc(hidden)]
+    pub fn set_root(&mut self, root: StateRoot) {
+        self.root = root;
     }
 
     #[cfg(test)]
@@ -603,8 +616,8 @@ impl Trie {
         }
     }
 
-    pub fn retrieve_root_node(&self, root: &StateRoot) -> Result<StateRootNode, StorageError> {
-        match self.retrieve_raw_node(root)? {
+    pub fn retrieve_root_node(&self) -> Result<StateRootNode, StorageError> {
+        match self.retrieve_raw_node(&self.root)? {
             None => Ok(StateRootNode::empty()),
             Some((bytes, node)) => Ok(StateRootNode {
                 data: bytes.to_vec(),
@@ -613,12 +626,8 @@ impl Trie {
         }
     }
 
-    fn lookup(
-        &self,
-        root: &CryptoHash,
-        mut key: NibbleSlice<'_>,
-    ) -> Result<Option<ValueRef>, StorageError> {
-        let mut hash = *root;
+    fn lookup(&self, mut key: NibbleSlice<'_>) -> Result<Option<ValueRef>, StorageError> {
+        let mut hash = self.root.clone();
         loop {
             let node = match self.retrieve_raw_node(&hash)? {
                 None => return Ok(None),
@@ -666,19 +675,19 @@ impl Trie {
         }
     }
 
-    pub fn get_ref(&self, root: &CryptoHash, key: &[u8]) -> Result<Option<ValueRef>, StorageError> {
+    pub fn get_ref(&self, key: &[u8]) -> Result<Option<ValueRef>, StorageError> {
         let is_delayed = is_delayed_receipt_key(key);
         match &self.flat_state {
-            Some(flat_state) if !is_delayed => flat_state.get_ref(root, &key),
+            Some(flat_state) if !is_delayed => flat_state.get_ref(&self.root, &key),
             _ => {
                 let key = NibbleSlice::new(key);
-                self.lookup(root, key)
+                self.lookup(key)
             }
         }
     }
 
-    pub fn get(&self, root: &CryptoHash, key: &[u8]) -> Result<Option<Vec<u8>>, StorageError> {
-        match self.get_ref(root, key)? {
+    pub fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, StorageError> {
+        match self.get_ref(key)? {
             Some(ValueRef { hash, .. }) => {
                 self.storage.retrieve_raw_bytes(&hash).map(|bytes| Some(bytes.to_vec()))
             }
@@ -712,33 +721,29 @@ impl Trie {
         (insertions, deletions)
     }
 
-    pub fn update<I>(&self, root: &CryptoHash, changes: I) -> Result<TrieChanges, StorageError>
+    pub fn update<I>(&self, changes: I) -> Result<TrieChanges, StorageError>
     where
         I: Iterator<Item = (Vec<u8>, Option<Vec<u8>>)>,
     {
         let mut memory = NodesStorage::new();
-        let mut root_node = self.move_node_to_mutable(&mut memory, root)?;
+        let mut root_node = self.move_node_to_mutable(&mut memory, &self.root)?;
         for (key, value) in changes {
             let key = NibbleSlice::new(&key);
-            match value {
-                Some(arr) => {
-                    root_node = self.insert(&mut memory, root_node, key, arr)?;
-                }
-                None => {
-                    root_node = self.delete(&mut memory, root_node, key)?;
-                }
-            }
+            root_node = match value {
+                Some(arr) => self.insert(&mut memory, root_node, key, arr),
+                None => self.delete(&mut memory, root_node, key),
+            }?;
         }
 
         #[cfg(test)]
         {
             self.memory_usage_verify(&memory, NodeHandle::InMemory(root_node));
         }
-        Trie::flatten_nodes(root, memory, root_node)
+        Trie::flatten_nodes(&self.root, memory, root_node)
     }
 
-    pub fn iter<'a>(&'a self, root: &CryptoHash) -> Result<TrieIterator<'a>, StorageError> {
-        TrieIterator::new(self, root)
+    pub fn iter<'a>(&'a self) -> Result<TrieIterator<'a>, StorageError> {
+        TrieIterator::new(self)
     }
 
     pub fn get_trie_nodes_count(&self) -> TrieNodesCount {
@@ -793,15 +798,16 @@ mod tests {
         shard_uid: ShardUId,
         changes: TrieChanges,
     ) -> CryptoHash {
-        let trie = tries.get_trie_for_shard(shard_uid);
+        let mut trie = tries.get_trie_for_shard(shard_uid, root.clone());
         let delete_changes: TrieChanges =
             changes.iter().map(|(key, _)| (key.clone(), None)).collect();
         let mut other_delete_changes = delete_changes.clone();
-        let trie_changes = trie.update(root, other_delete_changes.drain(..)).unwrap();
+        let trie_changes = trie.update(other_delete_changes.drain(..)).unwrap();
         let (store_update, root) = tries.apply_all(&trie_changes, shard_uid);
+        trie.set_root(root.clone());
         store_update.commit().unwrap();
         for (key, _) in delete_changes {
-            assert_eq!(trie.get(&root, &key), Ok(None));
+            assert_eq!(trie.get(&key), Ok(None));
         }
         root
     }
@@ -834,9 +840,8 @@ mod tests {
         // test trie version > 0
         let tries = create_tries_complex(SHARD_VERSION, 2);
         let shard_uid = ShardUId { version: SHARD_VERSION, shard_id: 0 };
-        let trie = tries.get_trie_for_shard(shard_uid);
-        let empty_root = Trie::EMPTY_ROOT;
-        assert_eq!(trie.get(&empty_root, &[122]), Ok(None));
+        let trie = tries.get_trie_for_shard(shard_uid, Trie::EMPTY_ROOT);
+        assert_eq!(trie.get(&[122]), Ok(None));
         let changes = vec![
             (b"doge".to_vec(), Some(b"coin".to_vec())),
             (b"docu".to_vec(), Some(b"value".to_vec())),
@@ -845,17 +850,16 @@ mod tests {
             (b"dog".to_vec(), Some(b"puppy".to_vec())),
             (b"h".to_vec(), Some(b"value".to_vec())),
         ];
-        let root = test_populate_trie(&tries, &empty_root, shard_uid, changes.clone());
+        let root = test_populate_trie(&tries, &Trie::EMPTY_ROOT, shard_uid, changes.clone());
         let new_root = test_clear_trie(&tries, &root, shard_uid, changes);
-        assert_eq!(new_root, empty_root);
-        assert_eq!(trie.iter(&new_root).unwrap().fold(0, |acc, _| acc + 1), 0);
+        assert_eq!(new_root, Trie::EMPTY_ROOT);
+        assert_eq!(trie.iter().unwrap().fold(0, |acc, _| acc + 1), 0);
     }
 
     #[test]
     fn test_trie_iter() {
         let tries = create_tries_complex(SHARD_VERSION, 2);
         let shard_uid = ShardUId { version: SHARD_VERSION, shard_id: 0 };
-        let trie = tries.get_trie_for_shard(shard_uid);
         let pairs = vec![
             (b"a".to_vec(), Some(b"111".to_vec())),
             (b"b".to_vec(), Some(b"222".to_vec())),
@@ -863,14 +867,15 @@ mod tests {
             (b"y".to_vec(), Some(b"444".to_vec())),
         ];
         let root = test_populate_trie(&tries, &Trie::EMPTY_ROOT, shard_uid, pairs.clone());
+        let trie = tries.get_trie_for_shard(shard_uid, root.clone());
         let mut iter_pairs = vec![];
-        for pair in trie.iter(&root).unwrap() {
+        for pair in trie.iter().unwrap() {
             let (key, value) = pair.unwrap();
             iter_pairs.push((key, Some(value.to_vec())));
         }
         assert_eq!(pairs, iter_pairs);
 
-        let mut other_iter = trie.iter(&root).unwrap();
+        let mut other_iter = trie.iter().unwrap();
         other_iter.seek(b"r").unwrap();
         assert_eq!(other_iter.next().unwrap().unwrap().0, b"x".to_vec());
     }
@@ -903,7 +908,6 @@ mod tests {
     #[test]
     fn test_trie_iter_seek_stop_at_extension() {
         let tries = create_tries();
-        let trie = tries.get_trie_for_shard(ShardUId::single_shard());
         let changes = vec![
             (vec![0, 116, 101, 115, 116], Some(vec![0])),
             (vec![2, 116, 101, 115, 116], Some(vec![0])),
@@ -923,7 +927,8 @@ mod tests {
             ),
         ];
         let root = test_populate_trie(&tries, &Trie::EMPTY_ROOT, ShardUId::single_shard(), changes);
-        let mut iter = trie.iter(&root).unwrap();
+        let trie = tries.get_trie_for_shard(ShardUId::single_shard(), root.clone());
+        let mut iter = trie.iter().unwrap();
         iter.seek(&vec![0, 116, 101, 115, 116, 44]).unwrap();
         let mut pairs = vec![];
         for pair in iter {
@@ -947,7 +952,6 @@ mod tests {
     #[test]
     fn test_trie_remove_non_existent_key() {
         let tries = create_tries();
-        let trie = tries.get_trie_for_shard(ShardUId::single_shard());
         let initial = vec![
             (vec![99, 44, 100, 58, 58, 49], Some(vec![1])),
             (vec![99, 44, 100, 58, 58, 50], Some(vec![1])),
@@ -960,28 +964,30 @@ mod tests {
             (vec![99, 44, 100, 58, 58, 50, 52], None),
         ];
         let root = test_populate_trie(&tries, &root, ShardUId::single_shard(), changes);
-        for r in trie.iter(&root).unwrap() {
+        let trie = tries.get_trie_for_shard(ShardUId::single_shard(), root);
+        for r in trie.iter().unwrap() {
             r.unwrap();
         }
     }
 
     #[test]
     fn test_equal_leafs() {
-        let tries = create_tries();
-        let trie = tries.get_trie_for_shard(ShardUId::single_shard());
         let initial = vec![
             (vec![1, 2, 3], Some(vec![1])),
             (vec![2, 2, 3], Some(vec![1])),
             (vec![3, 2, 3], Some(vec![1])),
         ];
+        let tries = create_tries();
         let root = test_populate_trie(&tries, &Trie::EMPTY_ROOT, ShardUId::single_shard(), initial);
-        for r in trie.iter(&root).unwrap() {
+        let mut trie = tries.get_trie_for_shard(ShardUId::single_shard(), root.clone());
+        for r in trie.iter().unwrap() {
             r.unwrap();
         }
 
         let changes = vec![(vec![1, 2, 3], None)];
         let root = test_populate_trie(&tries, &root, ShardUId::single_shard(), changes);
-        for r in trie.iter(&root).unwrap() {
+        trie.set_root(root);
+        for r in trie.iter().unwrap() {
             r.unwrap();
         }
     }
@@ -991,14 +997,12 @@ mod tests {
         let mut rng = rand::thread_rng();
         for _ in 0..100 {
             let tries = create_tries();
-            let trie = tries.get_trie_for_shard(ShardUId::single_shard());
+            let trie = tries.get_trie_for_shard(ShardUId::single_shard(), Trie::EMPTY_ROOT);
             let trie_changes = gen_changes(&mut rng, 20);
             let simplified_changes = simplify_changes(&trie_changes);
 
-            let trie_changes1 =
-                trie.update(&Trie::EMPTY_ROOT, trie_changes.iter().cloned()).unwrap();
-            let trie_changes2 =
-                trie.update(&Trie::EMPTY_ROOT, simplified_changes.iter().cloned()).unwrap();
+            let trie_changes1 = trie.update(trie_changes.iter().cloned()).unwrap();
+            let trie_changes2 = trie.update(simplified_changes.iter().cloned()).unwrap();
             if trie_changes1.new_root != trie_changes2.new_root {
                 eprintln!("{:?}", trie_changes);
                 eprintln!("{:?}", simplified_changes);
@@ -1015,18 +1019,17 @@ mod tests {
         let mut rng = rand::thread_rng();
         for _test_run in 0..10 {
             let tries = create_tries();
-            let trie = tries.get_trie_for_shard(ShardUId::single_shard());
             let trie_changes = gen_changes(&mut rng, 500);
-
             let state_root = test_populate_trie(
                 &tries,
                 &Trie::EMPTY_ROOT,
                 ShardUId::single_shard(),
                 trie_changes.clone(),
             );
+            let trie = tries.get_trie_for_shard(ShardUId::single_shard(), state_root.clone());
             let queries = gen_changes(&mut rng, 500).into_iter().map(|(key, _)| key);
             for query in queries {
-                let mut iterator = trie.iter(&state_root).unwrap();
+                let mut iterator = trie.iter().unwrap();
                 iterator.seek(&query).unwrap();
                 if let Some(Ok((key, _))) = iterator.next() {
                     assert!(key >= query);
@@ -1041,41 +1044,38 @@ mod tests {
         for _test_run in 0..10 {
             let num_iterations = rng.gen_range(1, 20);
             let tries = create_tries();
-            let trie = tries.get_trie_for_shard(ShardUId::single_shard());
             let mut state_root = Trie::EMPTY_ROOT;
+            let mut trie = tries.get_trie_for_shard(ShardUId::single_shard(), state_root.clone());
             for _ in 0..num_iterations {
                 let trie_changes = gen_changes(&mut rng, 20);
                 state_root =
                     test_populate_trie(&tries, &state_root, ShardUId::single_shard(), trie_changes);
-                println!(
-                    "New memory_usage: {}",
-                    trie.retrieve_root_node(&state_root).unwrap().memory_usage
-                );
+                trie.set_root(state_root.clone());
+                println!("New memory_usage: {}", trie.retrieve_root_node().unwrap().memory_usage);
             }
-            {
-                let trie_changes = trie
-                    .iter(&state_root)
+
+            let trie_changes = trie
+                .iter()
+                .unwrap()
+                .map(|item| {
+                    let (key, _) = item.unwrap();
+                    (key, None)
+                })
+                .collect::<Vec<_>>();
+            state_root =
+                test_populate_trie(&tries, &state_root, ShardUId::single_shard(), trie_changes);
+            assert_eq!(state_root, Trie::EMPTY_ROOT, "Trie must be empty");
+            assert!(
+                trie.storage
+                    .as_caching_storage()
                     .unwrap()
-                    .map(|item| {
-                        let (key, _) = item.unwrap();
-                        (key, None)
-                    })
-                    .collect::<Vec<_>>();
-                state_root =
-                    test_populate_trie(&tries, &state_root, ShardUId::single_shard(), trie_changes);
-                assert_eq!(state_root, Trie::EMPTY_ROOT, "Trie must be empty");
-                assert!(
-                    trie.storage
-                        .as_caching_storage()
-                        .unwrap()
-                        .store
-                        .iter(DBCol::State)
-                        .peekable()
-                        .peek()
-                        .is_none(),
-                    "Storage must be empty"
-                );
-            }
+                    .store
+                    .iter(DBCol::State)
+                    .peekable()
+                    .peek()
+                    .is_none(),
+                "Storage must be empty"
+            );
         }
     }
 
@@ -1095,8 +1095,8 @@ mod tests {
         let root = test_populate_trie(&tries, &empty_root, ShardUId::single_shard(), changes);
 
         let tries2 = ShardTries::test(store, 1);
-        let trie2 = tries2.get_trie_for_shard(ShardUId::single_shard());
-        assert_eq!(trie2.get(&root, b"doge"), Ok(Some(b"coin".to_vec())));
+        let trie2 = tries2.get_trie_for_shard(ShardUId::single_shard(), root.clone());
+        assert_eq!(trie2.get(b"doge"), Ok(Some(b"coin".to_vec())));
     }
 
     // TODO: somehow also test that we don't record unnecessary nodes
@@ -1115,16 +1115,17 @@ mod tests {
         ];
         let root = test_populate_trie(&tries, &empty_root, ShardUId::single_shard(), changes);
 
-        let trie2 = tries.get_trie_for_shard(ShardUId::single_shard()).recording_reads();
-        trie2.get(&root, b"dog").unwrap();
-        trie2.get(&root, b"horse").unwrap();
+        let trie2 =
+            tries.get_trie_for_shard(ShardUId::single_shard(), root.clone()).recording_reads();
+        trie2.get(b"dog").unwrap();
+        trie2.get(b"horse").unwrap();
         let partial_storage = trie2.recorded_storage();
 
-        let trie3 = Trie::from_recorded_storage(partial_storage.unwrap());
+        let trie3 = Trie::from_recorded_storage(partial_storage.unwrap(), root.clone());
 
-        assert_eq!(trie3.get(&root, b"dog"), Ok(Some(b"puppy".to_vec())));
-        assert_eq!(trie3.get(&root, b"horse"), Ok(Some(b"stallion".to_vec())));
-        assert_eq!(trie3.get(&root, b"doge"), Err(StorageError::TrieNodeMissing));
+        assert_eq!(trie3.get(b"dog"), Ok(Some(b"puppy".to_vec())));
+        assert_eq!(trie3.get(b"horse"), Ok(Some(b"stallion".to_vec())));
+        assert_eq!(trie3.get(b"doge"), Err(StorageError::TrieNodeMissing));
     }
 
     #[test]
@@ -1139,24 +1140,27 @@ mod tests {
         let root = test_populate_trie(&tries, &empty_root, ShardUId::single_shard(), changes);
         // Trie: extension -> branch -> 2 leaves
         {
-            let trie2 = tries.get_trie_for_shard(ShardUId::single_shard()).recording_reads();
-            trie2.get(&root, b"doge").unwrap();
+            let trie2 =
+                tries.get_trie_for_shard(ShardUId::single_shard(), root.clone()).recording_reads();
+            trie2.get(b"doge").unwrap();
             // record extension, branch and one leaf with value, but not the other
             assert_eq!(trie2.recorded_storage().unwrap().nodes.0.len(), 4);
         }
 
         {
-            let trie2 = tries.get_trie_for_shard(ShardUId::single_shard()).recording_reads();
+            let trie2 =
+                tries.get_trie_for_shard(ShardUId::single_shard(), root.clone()).recording_reads();
             let updates = vec![(b"doge".to_vec(), None)];
-            trie2.update(&root, updates.into_iter()).unwrap();
+            trie2.update(updates.into_iter()).unwrap();
             // record extension, branch and both leaves (one with value)
             assert_eq!(trie2.recorded_storage().unwrap().nodes.0.len(), 5);
         }
 
         {
-            let trie2 = tries.get_trie_for_shard(ShardUId::single_shard()).recording_reads();
+            let trie2 =
+                tries.get_trie_for_shard(ShardUId::single_shard(), root.clone()).recording_reads();
             let updates = vec![(b"dodo".to_vec(), Some(b"asdf".to_vec()))];
-            trie2.update(&root, updates.into_iter()).unwrap();
+            trie2.update(updates.into_iter()).unwrap();
             // record extension and branch, but not leaves
             assert_eq!(trie2.recorded_storage().unwrap().nodes.0.len(), 2);
         }
@@ -1177,7 +1181,7 @@ mod tests {
         let store2 = create_test_store();
         store2.load_from_file(DBCol::State, &dir.path().join("test.bin")).unwrap();
         let tries2 = ShardTries::test(store2, 1);
-        let trie2 = tries2.get_trie_for_shard(ShardUId::single_shard());
-        assert_eq!(trie2.get(&root, b"doge").unwrap().unwrap(), b"coin");
+        let trie2 = tries2.get_trie_for_shard(ShardUId::single_shard(), root.clone());
+        assert_eq!(trie2.get(b"doge").unwrap().unwrap(), b"coin");
     }
 }

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -1,5 +1,4 @@
 use std::io;
-use std::rc::Rc;
 use std::sync::{Arc, RwLock};
 
 use borsh::BorshSerialize;
@@ -91,18 +90,19 @@ impl ShardTries {
         Arc::ptr_eq(&self.0, &other.0)
     }
 
-    pub fn new_trie_update(&self, shard_uid: ShardUId, state_root: CryptoHash) -> TrieUpdate {
-        TrieUpdate::new(Rc::new(self.get_trie_for_shard(shard_uid)), state_root)
+    pub fn new_trie_update(&self, shard_uid: ShardUId, state_root: StateRoot) -> TrieUpdate {
+        TrieUpdate::new(std::rc::Rc::new(self.get_trie_for_shard(shard_uid, state_root)))
     }
 
-    pub fn new_trie_update_view(&self, shard_uid: ShardUId, state_root: CryptoHash) -> TrieUpdate {
-        TrieUpdate::new(Rc::new(self.get_view_trie_for_shard(shard_uid)), state_root)
+    pub fn new_trie_update_view(&self, shard_uid: ShardUId, state_root: StateRoot) -> TrieUpdate {
+        TrieUpdate::new(std::rc::Rc::new(self.get_view_trie_for_shard(shard_uid, state_root)))
     }
 
     #[allow(unused_variables)]
     fn get_trie_for_shard_internal(
         &self,
         shard_uid: ShardUId,
+        state_root: StateRoot,
         is_view: bool,
         use_flat_state: bool,
     ) -> Trie {
@@ -125,19 +125,23 @@ impl ShardTries {
             #[cfg(not(feature = "protocol_feature_flat_state"))]
             None
         };
-        Trie::new(storage, flat_state)
+        Trie::new(storage, state_root, flat_state)
     }
 
-    pub fn get_trie_for_shard(&self, shard_uid: ShardUId) -> Trie {
-        self.get_trie_for_shard_internal(shard_uid, false, false)
+    pub fn get_trie_for_shard(&self, shard_uid: ShardUId, state_root: StateRoot) -> Trie {
+        self.get_trie_for_shard_internal(shard_uid, state_root, false, false)
     }
 
-    pub fn get_trie_with_flat_state_for_shard(&self, shard_uid: ShardUId) -> Trie {
-        self.get_trie_for_shard_internal(shard_uid, false, true)
+    pub fn get_trie_with_flat_state_for_shard(
+        &self,
+        shard_uid: ShardUId,
+        state_root: StateRoot,
+    ) -> Trie {
+        self.get_trie_for_shard_internal(shard_uid, state_root, false, true)
     }
 
-    pub fn get_view_trie_for_shard(&self, shard_uid: ShardUId) -> Trie {
-        self.get_trie_for_shard_internal(shard_uid, true, false)
+    pub fn get_view_trie_for_shard(&self, shard_uid: ShardUId, state_root: StateRoot) -> Trie {
+        self.get_trie_for_shard_internal(shard_uid, state_root, true, false)
     }
 
     pub fn get_store(&self) -> Store {

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -1,4 +1,5 @@
 use std::io;
+use std::rc::Rc;
 use std::sync::{Arc, RwLock};
 
 use borsh::BorshSerialize;
@@ -91,11 +92,11 @@ impl ShardTries {
     }
 
     pub fn new_trie_update(&self, shard_uid: ShardUId, state_root: StateRoot) -> TrieUpdate {
-        TrieUpdate::new(std::rc::Rc::new(self.get_trie_for_shard(shard_uid, state_root)))
+        TrieUpdate::new(Rc::new(self.get_trie_for_shard(shard_uid, state_root)))
     }
 
     pub fn new_trie_update_view(&self, shard_uid: ShardUId, state_root: StateRoot) -> TrieUpdate {
-        TrieUpdate::new(std::rc::Rc::new(self.get_view_trie_for_shard(shard_uid, state_root)))
+        TrieUpdate::new(Rc::new(self.get_view_trie_for_shard(shard_uid, state_root)))
     }
 
     #[allow(unused_variables)]

--- a/core/store/src/trie/split_state.rs
+++ b/core/store/src/trie/split_state.rs
@@ -25,18 +25,12 @@ impl Trie {
     ///
     /// # Errors
     /// StorageError if the storage is corrupted
-    pub fn get_trie_items_for_part(
-        &self,
-        part_id: PartId,
-        state_root: &StateRoot,
-    ) -> Result<Vec<TrieItem>, StorageError> {
+    pub fn get_trie_items_for_part(&self, part_id: PartId) -> Result<Vec<TrieItem>, StorageError> {
         assert!(self.storage.as_caching_storage().is_some());
 
-        let path_begin =
-            self.find_path_for_part_boundary(state_root, part_id.idx, part_id.total)?;
-        let path_end =
-            self.find_path_for_part_boundary(state_root, part_id.idx + 1, part_id.total)?;
-        self.iter(state_root)?.get_trie_items(&path_begin, &path_end)
+        let path_begin = self.find_path_for_part_boundary(part_id.idx, part_id.total)?;
+        let path_end = self.find_path_for_part_boundary(part_id.idx + 1, part_id.total)?;
+        self.iter()?.get_trie_items(&path_begin, &path_end)
     }
 }
 
@@ -157,9 +151,10 @@ impl ShardTries {
         let mut new_state_roots = state_roots.clone();
         let mut store_update = StoreUpdate::new_with_tries(self.clone());
         for (shard_uid, changes) in changes_by_shard {
-            let trie = self.get_trie_for_shard(shard_uid);
-            // Here we assume that state_roots contains shard_uid, the caller of this method will guarantee that
-            let trie_changes = trie.update(&state_roots[&shard_uid], changes.into_iter())?;
+            // Here we assume that state_roots contains shard_uid, the caller of this method will guarantee that.
+            let trie_changes = self
+                .get_trie_for_shard(shard_uid, state_roots[&shard_uid])
+                .update(changes.into_iter())?;
             let (update, state_root) = self.apply_all(&trie_changes, shard_uid);
             new_state_roots.insert(shard_uid, state_root);
             store_update.merge(update);
@@ -373,8 +368,9 @@ mod tests {
         shard_uid: &ShardUId,
         state_root: &StateRoot,
     ) -> Vec<(Vec<u8>, Vec<u8>)> {
-        let trie = tries.get_trie_for_shard(*shard_uid);
-        trie.iter(state_root)
+        tries
+            .get_trie_for_shard(*shard_uid, state_root.clone())
+            .iter()
             .unwrap()
             .map(Result::unwrap)
             .filter(|(key, _)| parse_account_id_from_raw_key(key).unwrap().is_some())
@@ -441,15 +437,13 @@ mod tests {
             changes.into_iter().map(|(key, value)| (key, value.unwrap())).collect();
         expected_trie_items.sort();
 
-        let trie = tries.get_trie_for_shard(ShardUId::single_shard());
-        let total_trie_items =
-            trie.get_trie_items_for_part(PartId::new(0, 1), &state_root).unwrap();
+        let trie = tries.get_trie_for_shard(ShardUId::single_shard(), state_root);
+        let total_trie_items = trie.get_trie_items_for_part(PartId::new(0, 1)).unwrap();
         assert_eq!(expected_trie_items, total_trie_items);
 
         let mut combined_trie_items = vec![];
         for part_id in 0..num_parts {
-            let trie_items =
-                trie.get_trie_items_for_part(PartId::new(part_id, num_parts), &state_root).unwrap();
+            let trie_items = trie.get_trie_items_for_part(PartId::new(part_id, num_parts)).unwrap();
             combined_trie_items.extend_from_slice(&trie_items);
             // check that items are split relatively evenly across all parts
             assert!(
@@ -479,7 +473,6 @@ mod tests {
                 .map(|x| (ShardUId { version: 1, shard_id: x as u32 }, Trie::EMPTY_ROOT))
                 .collect();
             for _ in 0..10 {
-                let trie = tries.get_trie_for_shard(ShardUId::single_shard());
                 let changes = gen_changes(&mut rng, 100);
                 state_root = test_populate_trie(
                     &tries,
@@ -500,12 +493,12 @@ mod tests {
                 state_roots = new_state_roots;
 
                 // check that the 4 tries combined to the orig trie
-                let trie_items: HashMap<_, _> =
-                    trie.iter(&state_root).unwrap().map(Result::unwrap).collect();
+                let trie = tries.get_trie_for_shard(ShardUId::single_shard(), state_root);
+                let trie_items: HashMap<_, _> = trie.iter().unwrap().map(Result::unwrap).collect();
                 let mut combined_trie_items: HashMap<Vec<u8>, Vec<u8>> = HashMap::new();
                 for (shard_uid, state_root) in state_roots.iter() {
-                    let trie = tries.get_view_trie_for_shard(*shard_uid);
-                    combined_trie_items.extend(trie.iter(state_root).unwrap().map(Result::unwrap));
+                    let trie = tries.get_view_trie_for_shard(*shard_uid, *state_root);
+                    combined_trie_items.extend(trie.iter().unwrap().map(Result::unwrap));
                 }
                 assert_eq!(trie_items, combined_trie_items);
             }
@@ -681,8 +674,8 @@ mod tests {
         // add accounts and receipts to the split shards
         let mut split_state_roots = {
             let trie_items = tries
-                .get_view_trie_for_shard(ShardUId::single_shard())
-                .get_trie_items_for_part(PartId::new(0, 1), &state_root)
+                .get_view_trie_for_shard(ShardUId::single_shard(), state_root.clone())
+                .get_trie_items_for_part(PartId::new(0, 1))
                 .unwrap();
             let split_state_roots: HashMap<_, _> = (0..num_shards)
                 .map(|shard_id| {

--- a/core/store/src/trie/state_parts.rs
+++ b/core/store/src/trie/state_parts.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 
 use near_primitives::challenge::PartialState;
-use near_primitives::hash::CryptoHash;
 use near_primitives::state_part::PartId;
 use near_primitives::types::StateRoot;
 use tracing::error;
@@ -24,15 +23,11 @@ impl Trie {
     ///
     /// # Errors
     /// StorageError if the storage is corrupted
-    pub fn get_trie_nodes_for_part(
-        &self,
-        part_id: PartId,
-        state_root: &StateRoot,
-    ) -> Result<PartialState, StorageError> {
+    pub fn get_trie_nodes_for_part(&self, part_id: PartId) -> Result<PartialState, StorageError> {
         assert!(self.storage.as_caching_storage().is_some());
 
         let with_recording = self.recording_reads();
-        with_recording.visit_nodes_for_state_part(state_root, part_id)?;
+        with_recording.visit_nodes_for_state_part(part_id)?;
         let recorded = with_recording.recorded_storage().unwrap();
 
         let trie_nodes = recorded.nodes;
@@ -46,20 +41,15 @@ impl Trie {
     ///
     /// Creating a StatePart takes all these nodes, validating a StatePart checks that it has the
     /// right set of nodes.
-    fn visit_nodes_for_state_part(
-        &self,
-        root_hash: &CryptoHash,
-        part_id: PartId,
-    ) -> Result<(), StorageError> {
-        let path_begin = self.find_path_for_part_boundary(root_hash, part_id.idx, part_id.total)?;
-        let path_end =
-            self.find_path_for_part_boundary(root_hash, part_id.idx + 1, part_id.total)?;
-        let mut iterator = self.iter(root_hash)?;
+    fn visit_nodes_for_state_part(&self, part_id: PartId) -> Result<(), StorageError> {
+        let path_begin = self.find_path_for_part_boundary(part_id.idx, part_id.total)?;
+        let path_end = self.find_path_for_part_boundary(part_id.idx + 1, part_id.total)?;
+        let mut iterator = self.iter()?;
         iterator.visit_nodes_interval(&path_begin, &path_end)?;
 
         // Extra nodes for compatibility with the previous version of computing state parts
         if part_id.idx + 1 != part_id.total {
-            let mut iterator = self.iter(root_hash)?;
+            let mut iterator = self.iter()?;
             let path_end_encoded = NibbleSlice::encode_nibbles(&path_end, false);
             iterator.seek_nibble_slice(NibbleSlice::from_encoded(&path_end_encoded[..]).0)?;
             if let Some(item) = iterator.next() {
@@ -74,7 +64,6 @@ impl Trie {
     /// path is returned as nibbles, last path is vec![16], previous paths end in nodes
     pub(crate) fn find_path_for_part_boundary(
         &self,
-        state_root: &StateRoot,
         part_id: u64,
         num_parts: u64,
     ) -> Result<Vec<u8>, StorageError> {
@@ -82,7 +71,7 @@ impl Trie {
         if part_id == num_parts {
             return Ok(vec![16]);
         }
-        let root_node = self.retrieve_node(state_root)?;
+        let root_node = self.retrieve_node(&self.root)?;
         let total_size = root_node.memory_usage;
         let size_start = (total_size + num_parts - 1) / num_parts * part_id;
         self.find_path(&root_node, size_start)
@@ -182,9 +171,10 @@ impl Trie {
         trie_nodes: PartialState,
     ) -> Result<(), StorageError> {
         let num_nodes = trie_nodes.0.len();
-        let trie = Trie::from_recorded_storage(PartialStorage { nodes: trie_nodes });
+        let trie =
+            Trie::from_recorded_storage(PartialStorage { nodes: trie_nodes }, state_root.clone());
 
-        trie.visit_nodes_for_state_part(state_root, part_id)?;
+        trie.visit_nodes_for_state_part(part_id)?;
         let storage = trie.storage.as_partial_storage().unwrap();
 
         if storage.visited_nodes.borrow().len() != num_nodes {
@@ -206,12 +196,13 @@ impl Trie {
                 contract_codes: vec![],
             });
         }
-        let trie = Trie::from_recorded_storage(PartialStorage { nodes: PartialState(part) });
-        let path_begin =
-            trie.find_path_for_part_boundary(state_root, part_id.idx, part_id.total)?;
-        let path_end =
-            trie.find_path_for_part_boundary(state_root, part_id.idx + 1, part_id.total)?;
-        let mut iterator = trie.iter(state_root)?;
+        let trie = Trie::from_recorded_storage(
+            PartialStorage { nodes: PartialState(part) },
+            state_root.clone(),
+        );
+        let path_begin = trie.find_path_for_part_boundary(part_id.idx, part_id.total)?;
+        let path_end = trie.find_path_for_part_boundary(part_id.idx + 1, part_id.total)?;
+        let mut iterator = trie.iter()?;
         let trie_traversal_items = iterator.visit_nodes_interval(&path_begin, &path_end)?;
         let mut map = HashMap::new();
         let mut contract_codes = Vec::new();
@@ -291,9 +282,12 @@ mod tests {
                 .flatten()
                 .map(|data| data.to_vec())
                 .collect::<Vec<_>>();
-            let trie = Trie::from_recorded_storage(PartialStorage { nodes: PartialState(nodes) });
+            let trie = Trie::from_recorded_storage(
+                PartialStorage { nodes: PartialState(nodes) },
+                state_root.clone(),
+            );
             let mut insertions = <HashMap<CryptoHash, (Vec<u8>, u32)>>::new();
-            trie.traverse_all_nodes(state_root, |hash| {
+            trie.traverse_all_nodes(|hash| {
                 if let Some((_bytes, rc)) = insertions.get_mut(hash) {
                     *rc += 1;
                 } else {
@@ -322,15 +316,14 @@ mod tests {
         /// on_enter is applied for nodes as well as values
         fn traverse_all_nodes<F: FnMut(&CryptoHash) -> Result<(), StorageError>>(
             &self,
-            root: &CryptoHash,
             mut on_enter: F,
         ) -> Result<(), StorageError> {
-            if root == &Trie::EMPTY_ROOT {
+            if self.root == Trie::EMPTY_ROOT {
                 return Ok(());
             }
             let mut stack: Vec<(CryptoHash, TrieNodeWithSize, CrumbStatus)> = Vec::new();
-            let root_node = self.retrieve_node(root)?;
-            stack.push((*root, root_node, CrumbStatus::Entering));
+            let root_node = self.retrieve_node(&self.root)?;
+            stack.push((self.root.clone(), root_node, CrumbStatus::Entering));
             while let Some((hash, node, position)) = stack.pop() {
                 if let CrumbStatus::Entering = position {
                     on_enter(&hash)?;
@@ -408,15 +401,14 @@ mod tests {
 
         fn visit_nodes_for_size_range_old(
             &self,
-            root_hash: &CryptoHash,
             size_start: u64,
             size_end: u64,
         ) -> Result<(), StorageError> {
-            let root_node = self.retrieve_node(root_hash)?;
+            let root_node = self.retrieve_node(&self.root)?;
             let path_begin = self.find_path(&root_node, size_start)?;
             let path_end = self.find_path(&root_node, size_end)?;
 
-            let mut iterator = self.iter(root_hash)?;
+            let mut iterator = self.iter()?;
             let path_begin_encoded = NibbleSlice::encode_nibbles(&path_begin, false);
             iterator.seek_nibble_slice(NibbleSlice::from_encoded(&path_begin_encoded[..]).0)?;
             loop {
@@ -440,10 +432,9 @@ mod tests {
         pub fn get_trie_nodes_for_part_old(
             &self,
             part_id: PartId,
-            state_root: &StateRoot,
         ) -> Result<PartialState, StorageError> {
             assert!(self.storage.as_caching_storage().is_some());
-            let root_node = self.retrieve_node(state_root)?;
+            let root_node = self.retrieve_node(&self.root)?;
             let total_size = root_node.memory_usage;
             let size_start = (total_size + part_id.total - 1) / part_id.total * part_id.idx;
             let size_end = std::cmp::min(
@@ -452,7 +443,7 @@ mod tests {
             );
 
             let with_recording = self.recording_reads();
-            with_recording.visit_nodes_for_size_range_old(state_root, size_start, size_end)?;
+            with_recording.visit_nodes_for_size_range_old(size_start, size_end)?;
             let recorded = with_recording.recorded_storage().unwrap();
 
             let trie_nodes = recorded.nodes;
@@ -550,18 +541,16 @@ mod tests {
         let trie_changes = gen_trie_changes(&mut rng, max_key_length, big_value_length);
         println!("Number of nodes: {}", trie_changes.len());
         let tries = create_tries();
-        let trie = tries.get_trie_for_shard(ShardUId::single_shard());
         let state_root =
             test_populate_trie(&tries, &Trie::EMPTY_ROOT, ShardUId::single_shard(), trie_changes);
-        let memory_size = trie.retrieve_root_node(&state_root).unwrap().memory_usage;
+        let trie = tries.get_trie_for_shard(ShardUId::single_shard(), state_root);
+        let memory_size = trie.retrieve_root_node().unwrap().memory_usage;
         println!("Total memory size: {}", memory_size);
         for num_parts in [2, 3, 5, 10, 50].iter().cloned() {
             let approximate_size_per_part = memory_size / num_parts;
             let parts = (0..num_parts)
                 .map(|part_id| {
-                    trie.get_trie_nodes_for_part(PartId::new(part_id, num_parts), &state_root)
-                        .unwrap()
-                        .0
+                    trie.get_trie_nodes_for_part(PartId::new(part_id, num_parts)).unwrap().0
                 })
                 .collect::<Vec<_>>();
             let part_nodecounts_vec = parts.iter().map(|nodes| nodes.len()).collect::<Vec<_>>();
@@ -619,7 +608,6 @@ mod tests {
         let mut rng = rand::thread_rng();
         for _ in 0..2000 {
             let tries = create_tries();
-            let trie = tries.get_trie_for_shard(ShardUId::single_shard());
             let trie_changes = gen_changes(&mut rng, 20);
             let state_root = test_populate_trie(
                 &tries,
@@ -627,20 +615,19 @@ mod tests {
                 ShardUId::single_shard(),
                 trie_changes.clone(),
             );
-            let root_memory_usage = trie.retrieve_root_node(&state_root).unwrap().memory_usage;
+            let trie = tries.get_trie_for_shard(ShardUId::single_shard(), state_root);
+            let root_memory_usage = trie.retrieve_root_node().unwrap().memory_usage;
 
             {
                 // Test that combining all parts gets all nodes
                 let num_parts = rng.gen_range(2, 10);
                 let parts = (0..num_parts)
                     .map(|part_id| {
-                        trie.get_trie_nodes_for_part(PartId::new(part_id, num_parts), &state_root)
-                            .unwrap()
-                            .0
+                        trie.get_trie_nodes_for_part(PartId::new(part_id, num_parts)).unwrap().0
                     })
                     .collect::<Vec<_>>();
 
-                let trie_changes = check_combine_state_parts(&state_root, num_parts, &parts);
+                let trie_changes = check_combine_state_parts(trie.get_root(), num_parts, &parts);
 
                 let mut nodes = <HashMap<CryptoHash, Vec<u8>>>::new();
                 let sizes_vec = parts
@@ -658,7 +645,7 @@ mod tests {
                 let size_of_all = all_nodes.iter().map(|node| node.len()).sum::<usize>();
                 let num_nodes = all_nodes.len();
                 Trie::validate_trie_nodes_for_part(
-                    &state_root,
+                    trie.get_root(),
                     PartId::new(0, 1),
                     PartialState(all_nodes),
                 )
@@ -708,7 +695,6 @@ mod tests {
         let mut rng = rand::thread_rng();
         for _ in 0..20 {
             let tries = create_tries();
-            let trie = tries.get_trie_for_shard(ShardUId::single_shard());
             let trie_changes = gen_changes(&mut rng, 10);
 
             let state_root = test_populate_trie(
@@ -717,19 +703,19 @@ mod tests {
                 ShardUId::single_shard(),
                 trie_changes.clone(),
             );
+            let trie = tries.get_trie_for_shard(ShardUId::single_shard(), state_root);
+
             for _ in 0..10 {
                 // Test that creating and validating are consistent
                 let num_parts: u64 = rng.gen_range(1, 10);
                 let part_id = rng.gen_range(0, num_parts);
-                let trie_nodes = trie
-                    .get_trie_nodes_for_part(PartId::new(part_id, num_parts), &state_root)
-                    .unwrap();
-                let trie_nodes2 = trie
-                    .get_trie_nodes_for_part_old(PartId::new(part_id, num_parts), &state_root)
-                    .unwrap();
+                let trie_nodes =
+                    trie.get_trie_nodes_for_part(PartId::new(part_id, num_parts)).unwrap();
+                let trie_nodes2 =
+                    trie.get_trie_nodes_for_part_old(PartId::new(part_id, num_parts)).unwrap();
                 assert_eq!(trie_nodes, trie_nodes2);
                 Trie::validate_trie_nodes_for_part(
-                    &state_root,
+                    trie.get_root(),
                     PartId::new(part_id, num_parts),
                     trie_nodes,
                 )

--- a/core/store/src/trie/trie_tests.rs
+++ b/core/store/src/trie/trie_tests.rs
@@ -80,10 +80,11 @@ where
     print!("Test touches {} nodes, expected result {:?}...", size, expected);
     for i in 0..(size + 1) {
         let storage = IncompletePartialStorage::new(storage.clone(), i);
-        let trie = Trie { storage: Box::new(storage), root: Trie::EMPTY_ROOT, flat_state: None };
+        let new_trie =
+            Trie { storage: Box::new(storage), root: trie.get_root().clone(), flat_state: None };
         let expected_result =
             if i < size { Err(&StorageError::TrieNodeMissing) } else { Ok(&expected) };
-        assert_eq!(test(Rc::new(trie)).as_ref(), expected_result);
+        assert_eq!(test(Rc::new(new_trie)).as_ref(), expected_result);
     }
     println!("Success");
 }

--- a/core/store/src/trie/trie_tests.rs
+++ b/core/store/src/trie/trie_tests.rs
@@ -80,7 +80,7 @@ where
     print!("Test touches {} nodes, expected result {:?}...", size, expected);
     for i in 0..(size + 1) {
         let storage = IncompletePartialStorage::new(storage.clone(), i);
-        let trie = Trie { storage: Box::new(storage), flat_state: None };
+        let trie = Trie { storage: Box::new(storage), root: Trie::EMPTY_ROOT, flat_state: None };
         let expected_result =
             if i < size { Err(&StorageError::TrieNodeMissing) } else { Ok(&expected) };
         assert_eq!(test(Rc::new(trie)).as_ref(), expected_result);
@@ -94,27 +94,25 @@ fn test_reads_with_incomplete_storage() {
     for _ in 0..50 {
         let tries = create_tries_complex(1, 2);
         let shard_uid = ShardUId { version: 1, shard_id: 0 };
-        let trie = tries.get_trie_for_shard(shard_uid);
-        let trie = Rc::new(trie);
-        let mut state_root = Trie::EMPTY_ROOT;
         let trie_changes = gen_changes(&mut rng, 20);
         let trie_changes = simplify_changes(&trie_changes);
         if trie_changes.is_empty() {
             continue;
         }
-        state_root = test_populate_trie(&tries, &state_root, shard_uid, trie_changes.clone());
+        let state_root =
+            test_populate_trie(&tries, &Trie::EMPTY_ROOT, shard_uid, trie_changes.clone());
+        let trie = Rc::new(tries.get_trie_for_shard(shard_uid, state_root));
 
         {
             let (key, _) = trie_changes.choose(&mut rng).unwrap();
             println!("Testing lookup {:?}", key);
-            let lookup_test =
-                |trie: Rc<Trie>| -> Result<_, StorageError> { trie.get(&state_root, key) };
+            let lookup_test = |trie: Rc<Trie>| -> Result<_, StorageError> { trie.get(key) };
             test_incomplete_storage(Rc::clone(&trie), lookup_test);
         }
         {
             println!("Testing TrieIterator over whole trie");
             let trie_records = |trie: Rc<Trie>| -> Result<_, StorageError> {
-                let iterator = trie.iter(&state_root)?;
+                let iterator = trie.iter()?;
                 iterator.collect::<Result<Vec<_>, _>>()
             };
             test_incomplete_storage(Rc::clone(&trie), trie_records);
@@ -124,7 +122,7 @@ fn test_reads_with_incomplete_storage() {
             let key_prefix = &key[0..rng.gen_range(0, key.len() + 1)];
             println!("Testing TrieUpdateIterator over prefix {:?}", key_prefix);
             let trie_update_keys = |trie: Rc<Trie>| -> Result<_, StorageError> {
-                let trie_update = TrieUpdate::new(trie, state_root);
+                let trie_update = TrieUpdate::new(trie);
                 let keys = trie_update.iter(key_prefix)?.collect::<Result<Vec<_>, _>>()?;
                 Ok(keys)
             };
@@ -143,28 +141,22 @@ mod nodes_counter_tests {
         NibbleSlice::encode_nibbles(&nibbles, false).into_vec()
     }
 
-    fn create_trie(items: &[(Vec<u8>, Option<Vec<u8>>)]) -> (Rc<Trie>, CryptoHash) {
+    fn create_trie(items: &[(Vec<u8>, Option<Vec<u8>>)]) -> Rc<Trie> {
         let tries = create_tries();
         let shard_uid = ShardUId { version: 1, shard_id: 0 };
-        let trie = tries.get_trie_for_shard(shard_uid);
-        let trie = Rc::new(trie);
-        let state_root = Trie::EMPTY_ROOT;
         let trie_changes = simplify_changes(&items);
-        let state_root = test_populate_trie(&tries, &state_root, shard_uid, trie_changes);
-        (trie, state_root)
+        let state_root = test_populate_trie(&tries, &Trie::EMPTY_ROOT, shard_uid, trie_changes);
+        let trie = tries.get_trie_for_shard(shard_uid, state_root);
+        Rc::new(trie)
     }
 
     // Get values corresponding to keys one by one, returning vector of numbers of touched nodes for each `get`.
-    fn get_touched_nodes_numbers(
-        trie: Rc<Trie>,
-        state_root: CryptoHash,
-        items: &[(Vec<u8>, Option<Vec<u8>>)],
-    ) -> Vec<u64> {
+    fn get_touched_nodes_numbers(trie: Rc<Trie>, items: &[(Vec<u8>, Option<Vec<u8>>)]) -> Vec<u64> {
         items
             .iter()
             .map(|(key, value)| {
                 let initial_count = trie.get_trie_nodes_count().db_reads;
-                let got_value = trie.get(&state_root, key).unwrap();
+                let got_value = trie.get(key).unwrap();
                 assert_eq!(*value, got_value);
                 trie.get_trie_nodes_count().db_reads - initial_count
             })
@@ -182,8 +174,8 @@ mod nodes_counter_tests {
             (create_trie_key(&vec![0, 1, 1]), Some(vec![1])),
             (create_trie_key(&vec![1, 0, 0]), Some(vec![2])),
         ];
-        let (trie, state_root) = create_trie(&trie_items);
-        assert_eq!(get_touched_nodes_numbers(trie.clone(), state_root, &trie_items), vec![5, 5, 4]);
+        let trie = create_trie(&trie_items);
+        assert_eq!(get_touched_nodes_numbers(trie.clone(), &trie_items), vec![5, 5, 4]);
 
         let storage = trie.storage.as_caching_storage().unwrap();
         assert_eq!(storage.shard_cache.len(), 9);
@@ -199,8 +191,8 @@ mod nodes_counter_tests {
             (create_trie_key(&vec![0, 0]), Some(vec![1])),
             (create_trie_key(&vec![1, 1]), Some(vec![1])),
         ];
-        let (trie, state_root) = create_trie(&trie_items);
-        assert_eq!(get_touched_nodes_numbers(trie.clone(), state_root, &trie_items), vec![4, 4]);
+        let trie = create_trie(&trie_items);
+        assert_eq!(get_touched_nodes_numbers(trie.clone(), &trie_items), vec![4, 4]);
 
         let storage = trie.storage.as_caching_storage().unwrap();
         assert_eq!(storage.shard_cache.len(), 5);

--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -3,7 +3,8 @@ use std::iter::Peekable;
 
 use near_primitives::hash::CryptoHash;
 use near_primitives::types::{
-    RawStateChange, RawStateChanges, RawStateChangesWithTrieKey, StateChangeCause, TrieCacheMode,
+    RawStateChange, RawStateChanges, RawStateChangesWithTrieKey, StateChangeCause, StateRoot,
+    TrieCacheMode,
 };
 
 use crate::trie::TrieChanges;

--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -169,7 +169,7 @@ impl TrieUpdate {
         TrieUpdateIterator::new(self, prefix, start, Some(end))
     }
 
-    pub fn get_root(&self) -> &CryptoHash {
+    pub fn get_root(&self) -> &StateRoot {
         self.trie.get_root()
     }
 

--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -73,6 +73,7 @@ impl TrieUpdate {
                 return Ok(data.as_ref().map(TrieUpdateValuePtr::MemoryRef));
             }
         }
+
         self.trie.get_ref(&key).map(|option| {
             option.map(|ValueRef { length, hash }| {
                 TrieUpdateValuePtr::HashAndSize(&self.trie, length, hash)
@@ -81,18 +82,15 @@ impl TrieUpdate {
     }
 
     pub fn get(&self, key: &TrieKey) -> Result<Option<Vec<u8>>, StorageError> {
-        self.get_impl(&key.to_vec())
-    }
-
-    fn get_impl(&self, key: &[u8]) -> Result<Option<Vec<u8>>, StorageError> {
-        if let Some(key_value) = self.prospective.get(key) {
+        let key = key.to_vec();
+        if let Some(key_value) = self.prospective.get(&key) {
             return Ok(key_value.value.as_ref().map(<Vec<u8>>::clone));
-        } else if let Some(changes_with_trie_key) = self.committed.get(key) {
+        } else if let Some(changes_with_trie_key) = self.committed.get(&key) {
             if let Some(RawStateChange { data, .. }) = changes_with_trie_key.changes.last() {
                 return Ok(data.as_ref().map(<Vec<u8>>::clone));
             }
         }
-        self.trie.get(key)
+        self.trie.get(&key)
     }
 
     pub fn set(&mut self, trie_key: TrieKey, value: Vec<u8>) {
@@ -138,22 +136,6 @@ impl TrieUpdate {
                 (k, data)
             }))?;
         Ok((trie_changes, state_changes))
-    }
-
-    pub fn finalize_genesis(self) -> Result<TrieChanges, StorageError> {
-        assert!(self.prospective.is_empty(), "Finalize cannot be called with uncommitted changes.");
-        let TrieUpdate { trie, committed, .. } = self;
-        let trie_changes =
-            trie.update(committed.into_iter().map(|(k, changes_with_trie_key)| {
-                let data = changes_with_trie_key
-                    .changes
-                    .into_iter()
-                    .last()
-                    .expect("Committed entry should have at least one change")
-                    .data;
-                (k, data)
-            }))?;
-        Ok(trie_changes)
     }
 
     /// Returns Error if the underlying storage fails

--- a/integration-tests/src/tests/client/features/fix_storage_usage.rs
+++ b/integration-tests/src/tests/client/features/fix_storage_usage.rs
@@ -46,10 +46,10 @@ fn process_blocks_with_storage_usage_fix(
         let trie = Rc::new(
             env.clients[0]
                 .runtime_adapter
-                .get_trie_for_shard(0, block.header().prev_hash())
+                .get_trie_for_shard(0, block.header().prev_hash(), root)
                 .unwrap(),
         );
-        let state_update = TrieUpdate::new(trie.clone(), root);
+        let state_update = TrieUpdate::new(trie.clone());
         use near_primitives::account::Account;
         let mut account_test1_raw = state_update
             .get(&TrieKey::Account { account_id: "test1".parse().unwrap() })

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -4107,10 +4107,10 @@ mod contract_precompilation_tests {
         let trie = Rc::new(
             env.clients[1]
                 .runtime_adapter
-                .get_trie_for_shard(0, block.header().prev_hash())
+                .get_trie_for_shard(0, block.header().prev_hash(), state_root)
                 .unwrap(),
         );
-        let state_update = TrieUpdate::new(trie, state_root);
+        let state_update = TrieUpdate::new(trie);
 
         let mut logs = vec![];
         let view_state = ViewApplyState {

--- a/integration-tests/src/user/runtime_user.rs
+++ b/integration-tests/src/user/runtime_user.rs
@@ -91,8 +91,9 @@ impl RuntimeUser {
             let apply_result = client
                 .runtime
                 .apply(
-                    client.tries.get_trie_for_shard(ShardUId::single_shard()),
-                    client.state_root,
+                    client
+                        .tries
+                        .get_trie_for_shard(ShardUId::single_shard(), client.state_root.clone()),
                     &None,
                     &apply_state,
                     &receipts,

--- a/nearcore/benches/store.rs
+++ b/nearcore/benches/store.rs
@@ -41,12 +41,13 @@ fn read_trie_items(bench: &mut Bencher, shard_id: usize, mode: Mode) {
             last_block.chunks().iter().map(|chunk| chunk.prev_state_root()).collect();
         let header = last_block.header();
 
-        let state_root = state_roots[shard_id];
-        let trie = runtime.get_trie_for_shard(shard_id as u64, header.prev_hash()).unwrap();
-        let trie = trie.iter(&state_root).unwrap();
-
+        let trie = runtime
+            .get_trie_for_shard(shard_id as u64, header.prev_hash(), state_roots[shard_id])
+            .unwrap();
         let start = Instant::now();
         let num_items_read = trie
+            .iter()
+            .unwrap()
             .enumerate()
             .map(|(i, _)| {
                 if i % 500 == 0 {

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -426,7 +426,6 @@ impl NightshadeRuntime {
     fn process_state_update(
         &self,
         trie: Trie,
-        state_root: CryptoHash,
         shard_id: ShardId,
         block_height: BlockHeight,
         block_hash: &CryptoHash,
@@ -556,7 +555,6 @@ impl NightshadeRuntime {
             .runtime
             .apply(
                 trie,
-                state_root,
                 &validator_accounts_update,
                 &apply_state,
                 receipts,
@@ -718,18 +716,24 @@ impl RuntimeAdapter for NightshadeRuntime {
 
     // TODO (#7327): Make usage of flat state conditional on prev_hash and call `get_trie_for_shard` if this is not the
     // case. Current implementation never creates flat state if `protocol_feature_flat_state` is not enabled.
-    fn get_trie_for_shard(&self, shard_id: ShardId, prev_hash: &CryptoHash) -> Result<Trie, Error> {
+    fn get_trie_for_shard(
+        &self,
+        shard_id: ShardId,
+        prev_hash: &CryptoHash,
+        state_root: StateRoot,
+    ) -> Result<Trie, Error> {
         let shard_uid = self.get_shard_uid_from_prev_hash(shard_id, prev_hash)?;
-        Ok(self.tries.get_trie_with_flat_state_for_shard(shard_uid))
+        Ok(self.tries.get_trie_for_shard(shard_uid, state_root))
     }
 
     fn get_view_trie_for_shard(
         &self,
         shard_id: ShardId,
         prev_hash: &CryptoHash,
+        state_root: StateRoot,
     ) -> Result<Trie, Error> {
         let shard_uid = self.get_shard_uid_from_prev_hash(shard_id, prev_hash)?;
-        Ok(self.tries.get_view_trie_for_shard(shard_uid))
+        Ok(self.tries.get_view_trie_for_shard(shard_uid, state_root))
     }
 
     fn verify_block_vrf(
@@ -1424,7 +1428,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         is_first_block_with_chunk_of_version: bool,
         states_to_patch: Option<SandboxStatePatch>,
     ) -> Result<ApplyTransactionResult, Error> {
-        let trie = self.get_trie_for_shard(shard_id, prev_block_hash)?;
+        let trie = self.get_trie_for_shard(shard_id, prev_block_hash, state_root.clone())?;
 
         // TODO (#6316): support chunk nodes caching for TrieRecordingStorage
         if generate_storage_proof {
@@ -1433,7 +1437,6 @@ impl RuntimeAdapter for NightshadeRuntime {
         // let trie = if generate_storage_proof { trie.recording_reads() } else { trie };
         match self.process_state_update(
             trie,
-            *state_root,
             shard_id,
             height,
             block_hash,
@@ -1477,10 +1480,9 @@ impl RuntimeAdapter for NightshadeRuntime {
         is_new_chunk: bool,
         is_first_block_with_chunk_of_version: bool,
     ) -> Result<ApplyTransactionResult, Error> {
-        let trie = Trie::from_recorded_storage(partial_storage);
+        let trie = Trie::from_recorded_storage(partial_storage, state_root.clone());
         self.process_state_update(
             trie,
-            *state_root,
             shard_id,
             height,
             block_hash,
@@ -1656,8 +1658,8 @@ impl RuntimeAdapter for NightshadeRuntime {
     ) -> Result<Vec<u8>, Error> {
         let epoch_id = self.get_epoch_id(block_hash)?;
         let shard_uid = self.get_shard_uid_from_epoch_id(shard_id, &epoch_id)?;
-        let trie = self.tries.get_view_trie_for_shard(shard_uid);
-        let result = match trie.get_trie_nodes_for_part(part_id, state_root) {
+        let trie = self.tries.get_view_trie_for_shard(shard_uid, state_root.clone());
+        let result = match trie.get_trie_nodes_for_part(part_id) {
             Ok(partial_state) => partial_state,
             Err(e) => {
                 error!(target: "runtime",
@@ -1721,7 +1723,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         state_root: &StateRoot,
         next_epoch_shard_layout: &ShardLayout,
     ) -> Result<HashMap<ShardUId, StateRoot>, Error> {
-        let trie = self.tries.get_view_trie_for_shard(shard_uid);
+        let trie = self.tries.get_view_trie_for_shard(shard_uid, state_root.clone());
         let shard_id = shard_uid.shard_id();
         let new_shards = next_epoch_shard_layout
             .get_split_shard_uids(shard_id)
@@ -1743,12 +1745,11 @@ impl RuntimeAdapter for NightshadeRuntime {
             new_shard_uid
         };
 
-        let state_root_node = trie.retrieve_root_node(state_root)?;
+        let state_root_node = trie.retrieve_root_node()?;
         let num_parts = get_num_state_parts(state_root_node.memory_usage);
         debug!(target: "runtime", "splitting state for shard {} to {} parts to build new states", shard_id, num_parts);
         for part_id in 0..num_parts {
-            let trie_items =
-                trie.get_trie_items_for_part(PartId::new(part_id, num_parts), state_root)?;
+            let trie_items = trie.get_trie_items_for_part(PartId::new(part_id, num_parts))?;
             let (store_update, new_state_roots) = self.tries.add_values_to_split_states(
                 &state_roots,
                 trie_items.into_iter().map(|(key, value)| (key, Some(value))).collect(),
@@ -1796,8 +1797,8 @@ impl RuntimeAdapter for NightshadeRuntime {
         let epoch_id = self.get_epoch_id(block_hash)?;
         let shard_uid = self.get_shard_uid_from_epoch_id(shard_id, &epoch_id)?;
         self.tries
-            .get_view_trie_for_shard(shard_uid)
-            .retrieve_root_node(state_root)
+            .get_view_trie_for_shard(shard_uid, state_root.clone())
+            .retrieve_root_node()
             .map_err(Into::into)
     }
 
@@ -3492,10 +3493,14 @@ mod test {
     #[test]
     fn test_flat_state_usage() {
         let env = TestEnv::new(vec![vec!["test1".parse().unwrap()]], 4, false);
-        let trie = env.runtime.get_trie_for_shard(0, &env.head.prev_block_hash).unwrap();
+        let trie =
+            env.runtime.get_trie_for_shard(0, &env.head.prev_block_hash, Trie::EMPTY_ROOT).unwrap();
         assert_eq!(trie.flat_state.is_some(), cfg!(feature = "protocol_feature_flat_state"));
 
-        let trie = env.runtime.get_view_trie_for_shard(0, &env.head.prev_block_hash).unwrap();
+        let trie = env
+            .runtime
+            .get_view_trie_for_shard(0, &env.head.prev_block_hash, Trie::EMPTY_ROOT)
+            .unwrap();
         assert!(trie.flat_state.is_none());
     }
 
@@ -3531,16 +3536,17 @@ mod test {
         // - using view state, which should never use flat state
         let head_prev_block_hash = env.head.prev_block_hash;
         let state_root = env.state_roots[0];
-        let state = env.runtime.get_trie_for_shard(0, &head_prev_block_hash).unwrap();
-        let view_state = env.runtime.get_trie_for_shard(0, &head_prev_block_hash).unwrap();
+        let state = env.runtime.get_trie_for_shard(0, &head_prev_block_hash, state_root).unwrap();
+        let view_state =
+            env.runtime.get_trie_for_shard(0, &head_prev_block_hash, state_root).unwrap();
         let trie_key = TrieKey::Account { account_id: validators[1].clone() };
         let key = trie_key.to_vec();
 
-        let state_value = state.get(&state_root, &key).unwrap().unwrap();
+        let state_value = state.get(&key).unwrap().unwrap();
         let account = Account::try_from_slice(&state_value).unwrap();
         assert_eq!(account.amount(), TESTING_INIT_BALANCE - TESTING_INIT_STAKE + 10);
 
-        let view_state_value = view_state.get(&state_root, &key).unwrap().unwrap();
+        let view_state_value = view_state.get(&key).unwrap().unwrap();
         assert_eq!(state_value, view_state_value);
     }
 }

--- a/runtime/runtime-params-estimator/src/testbed.rs
+++ b/runtime/runtime-params-estimator/src/testbed.rs
@@ -97,8 +97,7 @@ impl RuntimeTestbed {
         let apply_result = self
             .runtime
             .apply(
-                self.tries.get_trie_for_shard(ShardUId::single_shard()),
-                self.root,
+                self.tries.get_trie_for_shard(ShardUId::single_shard(), self.root.clone()),
                 &None,
                 &self.apply_state,
                 &self.prev_receipts,

--- a/runtime/runtime/src/ext.rs
+++ b/runtime/runtime/src/ext.rs
@@ -175,7 +175,7 @@ impl<'a> External for RuntimeExt<'a> {
     }
 
     fn get_trie_nodes_count(&self) -> TrieNodesCount {
-        self.trie_update.trie.get_trie_nodes_count()
+        self.trie_update.trie().get_trie_nodes_count()
     }
 
     fn validator_stake(&self, account_id: &AccountId) -> ExtResult<Option<Balance>> {

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -142,7 +142,7 @@ impl TrieViewer {
         let mut values = vec![];
         let query = trie_key_parsers::get_raw_prefix_for_contract_data(account_id, prefix);
         let acc_sep_len = query.len() - prefix.len();
-        let mut iter = state_update.trie.iter(&state_update.get_root())?;
+        let mut iter = state_update.trie().iter()?;
         iter.seek(&query)?;
         for item in iter {
             let (key, value) = item?;
@@ -170,7 +170,7 @@ impl TrieViewer {
         epoch_info_provider: &dyn EpochInfoProvider,
     ) -> Result<Vec<u8>, errors::CallFunctionError> {
         let now = Instant::now();
-        let root = state_update.get_root();
+        let root = state_update.get_root().clone();
         let mut account = get_account(&state_update, contract_id)?.ok_or_else(|| {
             errors::CallFunctionError::AccountDoesNotExist {
                 requested_account_id: contract_id.clone(),

--- a/runtime/runtime/tests/runtime_group_tools/mod.rs
+++ b/runtime/runtime/tests/runtime_group_tools/mod.rs
@@ -117,8 +117,7 @@ impl StandaloneRuntime {
         let apply_result = self
             .runtime
             .apply(
-                self.tries.get_trie_for_shard(ShardUId::single_shard()),
-                self.root,
+                self.tries.get_trie_for_shard(ShardUId::single_shard(), self.root.clone()),
                 &None,
                 &self.apply_state,
                 receipts,

--- a/tools/state-viewer/src/state_dump.rs
+++ b/tools/state-viewer/src/state_dump.rs
@@ -140,10 +140,10 @@ pub fn state_dump_redis(
     let block_hash = last_block_header.hash();
 
     for (shard_id, state_root) in state_roots.iter().enumerate() {
-        let trie =
-            runtime.get_trie_for_shard(shard_id as u64, last_block_header.prev_hash()).unwrap();
-        let trie = trie.iter(&state_root).unwrap();
-        for item in trie {
+        let trie = runtime
+            .get_trie_for_shard(shard_id as u64, last_block_header.prev_hash(), state_root.clone())
+            .unwrap();
+        for item in trie.iter().unwrap() {
             let (key, value) = item.unwrap();
             if let Some(sr) = StateRecord::from_raw_key_value(key, value) {
                 if let StateRecord::Account { account_id, account } = &sr {
@@ -231,10 +231,10 @@ fn iterate_over_records(
     };
     let mut total_supply = 0;
     for (shard_id, state_root) in state_roots.iter().enumerate() {
-        let trie =
-            runtime.get_trie_for_shard(shard_id as u64, last_block_header.prev_hash()).unwrap();
-        let trie = trie.iter(state_root).unwrap();
-        for item in trie {
+        let trie = runtime
+            .get_trie_for_shard(shard_id as u64, last_block_header.prev_hash(), state_root.clone())
+            .unwrap();
+        for item in trie.iter().unwrap() {
             let (key, value) = item.unwrap();
             if let Some(mut sr) = StateRecord::from_raw_key_value(key, value) {
                 if !should_include_record(&sr, &account_allowlist) {


### PR DESCRIPTION
Introduce a new `root: StateRoot` field into Trie structure.  With that,
methods reading the state no longer need a state root argument (so remove
it).  This also makes state root redundant in TrieUpdate struct (so remove
it as well).

The overarching goal here is to make Trie and TrieUpdate interface the
same.  With that, it’s going to be possible to create a common trait
for accessing state from Trie and TrieUpdate.

Issue: https://github.com/near/nearcore/issues/6308
Fixes: https://github.com/near/nearcore/issues/7362