### PR TITLE
chain: maybe_block_id_to_block_hash → maybe_block_id_to_block_header

### DIFF
--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -141,7 +141,7 @@ impl ViewClientActor {
     }
 
     fn maybe_block_id_to_block_header(
-        &mut self,
+        &self,
         block_id: MaybeBlockId,
     ) -> Result<BlockHeader, near_chain::Error> {
         match block_id {


### PR DESCRIPTION
In all instances where ViewClientActor::maybe_block_id_to_block_hash
is called, the caller takes the hash and fetches block’s header.
However, in two out of three cases the method already fetches the
header of the block (to determine the hash) making it trivially
available to the caller.

Replace the method with one which returns the header directly.  This
means that in one case where the fetching did not occur inside of the
method, it is now happening there.