### PR TITLE
rosetta: refactor BlockIdentifier construction

### DIFF
--- a/chain/rosetta-rpc/src/lib.rs
+++ b/chain/rosetta-rpc/src/lib.rs
@@ -16,7 +16,6 @@ use strum::IntoEnumIterator;
 use near_chain_configs::Genesis;
 use near_client::{ClientActor, ViewClientActor};
 use near_primitives::borsh::BorshDeserialize;
-use near_primitives::serialize::BaseEncode;
 
 pub use config::RosettaRpcConfig;
 
@@ -116,21 +115,15 @@ async fn network_status(
     let network_info = network_info.map_err(errors::ErrorKind::InternalError)?;
     let genesis_hash =
         genesis_hash.map_err(|err| errors::ErrorKind::InternalInvariantError(err.to_string()))?;
-    let genesis_block_identifier = models::BlockIdentifier {
-        index: genesis_height.try_into().unwrap(),
-        hash: genesis_hash.to_base(),
-    };
+    let genesis_block_identifier = models::BlockIdentifier::new(genesis_height, &genesis_hash);
     let oldest_block_identifier: models::BlockIdentifier = earliest_block
         .ok()
-        .map(|block| (&block.header).into())
+        .map(|block| (&block).into())
         .unwrap_or_else(|| genesis_block_identifier.clone());
 
     let final_block = crate::utils::get_final_block(&view_client_addr).await?;
     Ok(Json(models::NetworkStatusResponse {
-        current_block_identifier: models::BlockIdentifier {
-            index: final_block.header.height.try_into().unwrap(),
-            hash: final_block.header.hash.to_base(),
-        },
+        current_block_identifier: (&final_block).into(),
         current_block_timestamp: i64::try_from(final_block.header.timestamp_nanosec / 1_000_000)
             .unwrap(),
         genesis_block_identifier,
@@ -219,7 +212,7 @@ async fn block_details(
         .await?
         .ok_or_else(|| errors::ErrorKind::NotFound("Block not found".into()))?;
 
-    let block_identifier: models::BlockIdentifier = (&block.header).into();
+    let block_identifier: models::BlockIdentifier = (&block).into();
 
     let parent_block_identifier = if block.header.prev_hash == Default::default() {
         // According to Rosetta API genesis block should have the parent block
@@ -232,11 +225,7 @@ async fn block_details(
             ))
             .await?
             .map_err(|err| errors::ErrorKind::InternalError(err.to_string()))?;
-
-        models::BlockIdentifier {
-            index: parent_block.header.height.try_into().unwrap(),
-            hash: parent_block.header.hash.to_base(),
-        }
+        (&parent_block).into()
     };
 
     let transactions = crate::adapters::collect_transactions(
@@ -397,10 +386,7 @@ async fn account_balance(
         None
     };
     Ok(Json(models::AccountBalanceResponse {
-        block_identifier: models::BlockIdentifier {
-            hash: block_hash.to_base(),
-            index: block_height.try_into().unwrap(),
-        },
+        block_identifier: models::BlockIdentifier::new(block_height, &block_hash),
         balances: vec![models::Amount::from_yoctonear(balance)],
         metadata: nonces,
     }))
@@ -549,7 +535,7 @@ async fn construction_metadata(
 
     Ok(Json(models::ConstructionMetadataResponse {
         metadata: models::ConstructionMetadata {
-            recent_block_hash: block_hash.to_base(),
+            recent_block_hash: block_hash.to_string(),
             signer_public_access_key_nonce: access_key.nonce.saturating_add(1),
         },
     }))

--- a/chain/rosetta-rpc/src/models.rs
+++ b/chain/rosetta-rpc/src/models.rs
@@ -1,6 +1,7 @@
 use paperclip::actix::{api_v2_errors, Apiv2Schema};
 
-use near_primitives::{serialize::BaseEncode, types::Nonce};
+use near_primitives::hash::CryptoHash;
+use near_primitives::types::{BlockHeight, Nonce};
 
 use crate::utils::{BlobInHexString, BorshInHexString};
 
@@ -174,19 +175,21 @@ pub(crate) struct Block {
 pub(crate) struct BlockIdentifier {
     /// This is also known as the block height.
     pub index: i64,
-
     pub hash: String,
 }
 
-impl From<&near_primitives::views::BlockHeaderView> for BlockIdentifier {
-    fn from(header: &near_primitives::views::BlockHeaderView) -> Self {
+impl BlockIdentifier {
+    pub fn new(height: BlockHeight, hash: &CryptoHash) -> Self {
         Self {
-            index: header
-                .height
-                .try_into()
-                .expect("Rosetta only supports block indecies up to i64::MAX"),
-            hash: header.hash.to_base(),
+            index: height.try_into().expect("Rosetta only supports block indecies up to i64::MAX"),
+            hash: hash.to_string(),
         }
+    }
+}
+
+impl From<&near_primitives::views::BlockView> for BlockIdentifier {
+    fn from(block: &near_primitives::views::BlockView) -> Self {
+        Self::new(block.header.height, &block.header.hash)
     }
 }
 
@@ -1060,7 +1063,7 @@ impl TransactionIdentifier {
         prefix: &'static str,
         hash: &near_primitives::hash::CryptoHash,
     ) -> Self {
-        Self { hash: format!("{}:{}", prefix, hash.to_base()) }
+        Self { hash: format!("{}:{}", prefix, hash) }
     }
 }
 


### PR DESCRIPTION
Firstly, replace From<BlockHeaderView> with From<BlockView>
implementation for BlockIdentifier.  The former is somewhat more
flexible but in practice we only ever used it when we had the full
block view at hand.

Secondly, introduce BlockIdentifier::new constructor to better
encapsulate creating the identifier from height and hash.  It reduces
code duplication.

Lastly, replace use of to_base method with use of to_string method.
They are equivalent for CryptoHash but the latter produces less syntax
noise since we don’t need to use our home grown BaseEncode trait.