### PR TITLE
store: accept IntoIterator by Trie::update

### DIFF
--- a/core/store/benches/trie_bench.rs
+++ b/core/store/benches/trie_bench.rs
@@ -23,7 +23,7 @@ fn trie_lookup(bench: &mut Bencher) {
         }
         let changed_keys =
             changes.iter().map(|(key, _value)| key.clone()).collect::<Vec<Vec<u8>>>();
-        let trie_changes = trie.update(changes.into_iter()).unwrap();
+        let trie_changes = trie.update(changes).unwrap();
         let (state_update, root) = tries.apply_all(&trie_changes, ShardUId::single_shard());
         state_update.commit().expect("Failed to commit");
 
@@ -49,8 +49,7 @@ fn trie_update(bench: &mut Bencher) {
     }
 
     bench.iter(|| {
-        let mut this_changes = changes.clone();
-        let _ = trie.update(this_changes.drain(..));
+        let _ = trie.update(changes.iter().cloned());
     });
 }
 

--- a/core/store/src/trie/split_state.rs
+++ b/core/store/src/trie/split_state.rs
@@ -152,9 +152,8 @@ impl ShardTries {
         let mut store_update = StoreUpdate::new_with_tries(self.clone());
         for (shard_uid, changes) in changes_by_shard {
             // Here we assume that state_roots contains shard_uid, the caller of this method will guarantee that.
-            let trie_changes = self
-                .get_trie_for_shard(shard_uid, state_roots[&shard_uid])
-                .update(changes.into_iter())?;
+            let trie_changes =
+                self.get_trie_for_shard(shard_uid, state_roots[&shard_uid]).update(changes)?;
             let (update, state_root) = self.apply_all(&trie_changes, shard_uid);
             new_state_roots.insert(shard_uid, state_root);
             store_update.merge(update);


### PR DESCRIPTION
Change Trie::update to accept IntoIterator rather than Iterator.  This
simplifies a few call sites (by making explicit into_iter calls
unnecessary).  While at this, clean up some other uses of the update
method.