### PR TITLE
store: introduce TrieAccess and make getter functions use it

### DIFF
--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -32,7 +32,7 @@ pub use crate::trie::iterator::TrieIterator;
 pub use crate::trie::update::{TrieUpdate, TrieUpdateIterator, TrieUpdateValuePtr};
 pub use crate::trie::{
     estimator, split_state, ApplyStatePartResult, KeyForStateChanges, PartialStorage, ShardTries,
-    Trie, TrieCache, TrieCacheFactory, TrieCachingStorage, TrieChanges, TrieStorage,
+    Trie, TrieCache, TrieCacheFactory, TrieCachingStorage, TrieChanges, TrieReader, TrieStorage,
     WrappedTrieChanges,
 };
 
@@ -428,11 +428,11 @@ impl fmt::Debug for StoreUpdate {
 /// Reads an object from Trie.
 /// # Errors
 /// see StorageError
-pub fn get<T: BorshDeserialize>(
-    state_update: &TrieUpdate,
+pub fn get<T: BorshDeserialize, R: TrieReader>(
+    trie: &R,
     key: &TrieKey,
 ) -> Result<Option<T>, StorageError> {
-    match state_update.get(key)? {
+    match trie.get(&key.to_vec())? {
         None => Ok(None),
         Some(data) => match T::try_from_slice(&data) {
             Err(_err) => {
@@ -453,11 +453,11 @@ pub fn set_account(state_update: &mut TrieUpdate, account_id: AccountId, account
     set(state_update, TrieKey::Account { account_id }, account)
 }
 
-pub fn get_account(
-    state_update: &TrieUpdate,
+pub fn get_account<R: TrieReader>(
+    trie: &R,
     account_id: &AccountId,
 ) -> Result<Option<Account>, StorageError> {
-    get(state_update, &TrieKey::Account { account_id: account_id.clone() })
+    get(trie, &TrieKey::Account { account_id: account_id.clone() })
 }
 
 pub fn set_received_data(
@@ -469,12 +469,12 @@ pub fn set_received_data(
     set(state_update, TrieKey::ReceivedData { receiver_id, data_id }, data);
 }
 
-pub fn get_received_data(
-    state_update: &TrieUpdate,
+pub fn get_received_data<R: TrieReader>(
+    trie: &R,
     receiver_id: &AccountId,
     data_id: CryptoHash,
 ) -> Result<Option<ReceivedData>, StorageError> {
-    get(state_update, &TrieKey::ReceivedData { receiver_id: receiver_id.clone(), data_id })
+    get(trie, &TrieKey::ReceivedData { receiver_id: receiver_id.clone(), data_id })
 }
 
 pub fn set_postponed_receipt(state_update: &mut TrieUpdate, receipt: &Receipt) {
@@ -493,18 +493,18 @@ pub fn remove_postponed_receipt(
     state_update.remove(TrieKey::PostponedReceipt { receiver_id: receiver_id.clone(), receipt_id });
 }
 
-pub fn get_postponed_receipt(
-    state_update: &TrieUpdate,
+pub fn get_postponed_receipt<R: TrieReader>(
+    trie: &R,
     receiver_id: &AccountId,
     receipt_id: CryptoHash,
 ) -> Result<Option<Receipt>, StorageError> {
-    get(state_update, &TrieKey::PostponedReceipt { receiver_id: receiver_id.clone(), receipt_id })
+    get(trie, &TrieKey::PostponedReceipt { receiver_id: receiver_id.clone(), receipt_id })
 }
 
-pub fn get_delayed_receipt_indices(
-    state_update: &TrieUpdate,
+pub fn get_delayed_receipt_indices<R: TrieReader>(
+    trie: &R,
 ) -> Result<DelayedReceiptIndices, StorageError> {
-    Ok(get(state_update, &TrieKey::DelayedReceiptIndices)?.unwrap_or_default())
+    Ok(get(trie, &TrieKey::DelayedReceiptIndices)?.unwrap_or_default())
 }
 
 pub fn set_access_key(
@@ -524,23 +524,23 @@ pub fn remove_access_key(
     state_update.remove(TrieKey::AccessKey { account_id, public_key });
 }
 
-pub fn get_access_key(
-    state_update: &TrieUpdate,
+pub fn get_access_key<R: TrieReader>(
+    trie: &R,
     account_id: &AccountId,
     public_key: &PublicKey,
 ) -> Result<Option<AccessKey>, StorageError> {
     get(
-        state_update,
+        trie,
         &TrieKey::AccessKey { account_id: account_id.clone(), public_key: public_key.clone() },
     )
 }
 
-pub fn get_access_key_raw(
-    state_update: &TrieUpdate,
+pub fn get_access_key_raw<R: TrieReader>(
+    trie: &R,
     raw_key: &[u8],
 ) -> Result<Option<AccessKey>, StorageError> {
     get(
-        state_update,
+        trie,
         &trie_key_parsers::parse_trie_key_access_key_from_raw_key(raw_key)
             .expect("access key in the state should be correct"),
     )
@@ -550,13 +550,14 @@ pub fn set_code(state_update: &mut TrieUpdate, account_id: AccountId, code: &Con
     state_update.set(TrieKey::ContractCode { account_id }, code.code().to_vec());
 }
 
-pub fn get_code(
-    state_update: &TrieUpdate,
+pub fn get_code<R: TrieReader>(
+    trie: &R,
     account_id: &AccountId,
     code_hash: Option<CryptoHash>,
 ) -> Result<Option<ContractCode>, StorageError> {
-    state_update
-        .get(&TrieKey::ContractCode { account_id: account_id.clone() })
+    let key = TrieKey::ContractCode { account_id: account_id.clone() };
+    trie
+        .get(&key.to_vec())
         .map(|opt| opt.map(|code| ContractCode::new(code, code_hash)))
 }
 

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -556,9 +556,7 @@ pub fn get_code<R: TrieReader>(
     code_hash: Option<CryptoHash>,
 ) -> Result<Option<ContractCode>, StorageError> {
     let key = TrieKey::ContractCode { account_id: account_id.clone() };
-    trie
-        .get(&key.to_vec())
-        .map(|opt| opt.map(|code| ContractCode::new(code, code_hash)))
+    trie.get(&key.to_vec()).map(|opt| opt.map(|code| ContractCode::new(code, code_hash)))
 }
 
 /// Removes account, code and all access keys associated to it.

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -416,9 +416,9 @@ pub struct Trie {
 pub trait TrieAccess {
     /// Retrieves value with given key from the trie.
     ///
-    /// In principle, this does not allow reads data from different chunks (be
-    /// it from different shards or different blocks).  In practice it might be
-    /// possible to retrieve nodes which don’t belong to a trie this reader is
+    /// In principle, this doesn’t allow reads data from different chunks (be it
+    /// from different shards or different blocks).  In practice it might be
+    /// possible to retrieve values which don’t belong to a trie this reader is
     /// meant for, but this must not be relied upon.
     fn get(&self, key: &TrieKey) -> Result<Option<Vec<u8>>, StorageError>;
 }

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -411,7 +411,14 @@ pub struct Trie {
     pub flat_state: Option<FlatState>,
 }
 
+/// Trait for reading data from a trie.
 pub trait TrieReader {
+    /// Retrieves node with given key from the trie.
+    ///
+    /// In principle, this does not allow reads data from different chunks (be
+    /// it from different shards or different blocks).  In practice it might be
+    /// possible to retrieve nodes which don’t belong to a trie this reader is
+    /// meant for, but this must not be relied upon.
     fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, StorageError>;
 }
 

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -11,6 +11,7 @@ use near_primitives::hash::{hash, CryptoHash};
 pub use near_primitives::shard_layout::ShardUId;
 use near_primitives::state::ValueRef;
 use near_primitives::state_record::is_delayed_receipt_key;
+use near_primitives::trie_key::TrieKey;
 use near_primitives::types::{StateRoot, StateRootNode};
 
 use crate::flat_state::FlatState;
@@ -412,14 +413,14 @@ pub struct Trie {
 }
 
 /// Trait for reading data from a trie.
-pub trait TrieReader {
+pub trait TrieAccess {
     /// Retrieves value with given key from the trie.
     ///
     /// In principle, this does not allow reads data from different chunks (be
     /// it from different shards or different blocks).  In practice it might be
     /// possible to retrieve nodes which don’t belong to a trie this reader is
     /// meant for, but this must not be relied upon.
-    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, StorageError>;
+    fn get(&self, key: &TrieKey) -> Result<Option<Vec<u8>>, StorageError>;
 }
 
 /// Stores reference count change for some key-value pair in DB.
@@ -755,9 +756,9 @@ impl Trie {
     }
 }
 
-impl TrieReader for Trie {
-    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, StorageError> {
-        Trie::get(self, key)
+impl TrieAccess for Trie {
+    fn get(&self, key: &TrieKey) -> Result<Option<Vec<u8>>, StorageError> {
+        Trie::get(self, &key.to_vec())
     }
 }
 

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -413,7 +413,7 @@ pub struct Trie {
 
 /// Trait for reading data from a trie.
 pub trait TrieReader {
-    /// Retrieves node with given key from the trie.
+    /// Retrieves value with given key from the trie.
     ///
     /// In principle, this does not allow reads data from different chunks (be
     /// it from different shards or different blocks).  In practice it might be

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -411,6 +411,10 @@ pub struct Trie {
     pub flat_state: Option<FlatState>,
 }
 
+pub trait TrieReader {
+    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, StorageError>;
+}
+
 /// Stores reference count change for some key-value pair in DB.
 #[derive(BorshSerialize, BorshDeserialize, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct TrieRefcountChange {
@@ -741,6 +745,12 @@ impl Trie {
 
     pub fn get_trie_nodes_count(&self) -> TrieNodesCount {
         self.storage.get_trie_nodes_count()
+    }
+}
+
+impl TrieReader for Trie {
+    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, StorageError> {
+        Trie::get(self, key)
     }
 }
 

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -416,10 +416,10 @@ pub struct Trie {
 pub trait TrieAccess {
     /// Retrieves value with given key from the trie.
     ///
-    /// In principle, this doesn’t allow reads data from different chunks (be it
-    /// from different shards or different blocks).  In practice it might be
-    /// possible to retrieve values which don’t belong to a trie this reader is
-    /// meant for, but this must not be relied upon.
+    /// This doesn’t allow to read data from different chunks (be it from
+    /// different shards or different blocks).  That is, the shard and state
+    /// root are already known by the object rather than being passed as
+    /// argument.
     fn get(&self, key: &TrieKey) -> Result<Option<Vec<u8>>, StorageError>;
 }
 

--- a/core/store/src/trie/split_state.rs
+++ b/core/store/src/trie/split_state.rs
@@ -262,7 +262,7 @@ fn apply_delayed_receipts_to_split_states_impl(
         let trie_update = trie_updates.get_mut(&new_shard_uid).unwrap();
         let trie_key = TrieKey::DelayedReceipt { index: delayed_receipts_indices.first_index };
 
-        let stored_receipt = get::<Receipt>(trie_update, &trie_key)?
+        let stored_receipt = get::<Receipt, _>(trie_update, &trie_key)?
             .expect("removed receipt does not exist in new state");
         // check that the receipt to remove is at the first of delayed receipt queue
         assert_eq!(&stored_receipt, receipt);
@@ -740,7 +740,7 @@ mod tests {
             let mut removed_receipts = vec![];
             for index in delayed_receipt_indices.first_index..next_first_index {
                 let trie_key = TrieKey::DelayedReceipt { index };
-                removed_receipts.push(get::<Receipt>(&trie_update, &trie_key).unwrap().unwrap());
+                removed_receipts.push(get::<Receipt, _>(&trie_update, &trie_key).unwrap().unwrap());
                 trie_update.remove(trie_key);
             }
             delayed_receipt_indices.first_index = next_first_index;

--- a/core/store/src/trie/split_state.rs
+++ b/core/store/src/trie/split_state.rs
@@ -262,7 +262,7 @@ fn apply_delayed_receipts_to_split_states_impl(
         let trie_update = trie_updates.get_mut(&new_shard_uid).unwrap();
         let trie_key = TrieKey::DelayedReceipt { index: delayed_receipts_indices.first_index };
 
-        let stored_receipt = get::<Receipt, _>(trie_update, &trie_key)?
+        let stored_receipt = get::<Receipt>(trie_update, &trie_key)?
             .expect("removed receipt does not exist in new state");
         // check that the receipt to remove is at the first of delayed receipt queue
         assert_eq!(&stored_receipt, receipt);
@@ -740,7 +740,7 @@ mod tests {
             let mut removed_receipts = vec![];
             for index in delayed_receipt_indices.first_index..next_first_index {
                 let trie_key = TrieKey::DelayedReceipt { index };
-                removed_receipts.push(get::<Receipt, _>(&trie_update, &trie_key).unwrap().unwrap());
+                removed_receipts.push(get::<Receipt>(&trie_update, &trie_key).unwrap().unwrap());
                 trie_update.remove(trie_key);
             }
             delayed_receipt_indices.first_index = next_first_index;

--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -82,18 +82,15 @@ impl TrieUpdate {
     }
 
     pub fn get(&self, key: &TrieKey) -> Result<Option<Vec<u8>>, StorageError> {
-        self.get_impl(&key.to_vec())
-    }
-
-    fn get_impl(&self, key: &[u8]) -> Result<Option<Vec<u8>>, StorageError> {
-        if let Some(key_value) = self.prospective.get(key) {
+        let key = key.to_vec();
+        if let Some(key_value) = self.prospective.get(&key) {
             return Ok(key_value.value.as_ref().map(<Vec<u8>>::clone));
-        } else if let Some(changes_with_trie_key) = self.committed.get(key) {
+        } else if let Some(changes_with_trie_key) = self.committed.get(&key) {
             if let Some(RawStateChange { data, .. }) = changes_with_trie_key.changes.last() {
                 return Ok(data.as_ref().map(<Vec<u8>>::clone));
             }
         }
-        self.trie.get(key)
+        self.trie.get(&key)
     }
 
     pub fn set(&mut self, trie_key: TrieKey, value: Vec<u8>) {
@@ -166,9 +163,9 @@ impl TrieUpdate {
     }
 }
 
-impl crate::TrieReader for TrieUpdate {
-    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, StorageError> {
-        TrieUpdate::get_impl(self, key)
+impl crate::TrieAccess for TrieUpdate {
+    fn get(&self, key: &TrieKey) -> Result<Option<Vec<u8>>, StorageError> {
+        TrieUpdate::get(self, key)
     }
 }
 

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -2464,8 +2464,8 @@ fn test_refund_receipts_processing() {
             .runtime_adapter
             .get_tries()
             .new_trie_update(test_shard_uid, *chunk_extra.state_root());
-        let delayed_indices =
-            get::<DelayedReceiptIndices>(&state_update, &TrieKey::DelayedReceiptIndices).unwrap();
+        let delayed_indices: Option<DelayedReceiptIndices> =
+            get(&state_update, &TrieKey::DelayedReceiptIndices).unwrap();
         let finished_all_delayed_receipts = match delayed_indices {
             None => false,
             Some(delayed_indices) => {
@@ -3140,10 +3140,8 @@ fn test_congestion_receipt_execution() {
         .runtime_adapter
         .get_tries()
         .new_trie_update(ShardUId::single_shard(), *chunk_extra.state_root());
-    let delayed_indices =
-        get::<DelayedReceiptIndices>(&state_update, &TrieKey::DelayedReceiptIndices)
-            .unwrap()
-            .unwrap();
+    let delayed_indices: DelayedReceiptIndices =
+        get(&state_update, &TrieKey::DelayedReceiptIndices).unwrap().unwrap();
     assert!(delayed_indices.next_available_index > 0);
     let mut block = env.clients[0].produce_block(height + 1).unwrap().unwrap();
     testlib::process_blocks::set_no_chunk_in_block(&mut block, &prev_block);

--- a/runtime/runtime/src/balance_checker.rs
+++ b/runtime/runtime/src/balance_checker.rs
@@ -317,8 +317,8 @@ mod tests {
     }
 
     fn prepare_state_change(
-        initial_state: impl FnOnce(&mut TrieUpdate),
-        final_state: impl FnOnce(&mut TrieUpdate),
+        set_initial_state: impl FnOnce(&mut TrieUpdate),
+        set_final_state: impl FnOnce(&mut TrieUpdate),
     ) -> TrieUpdate {
         let tries = create_tries();
         let shard_uid = ShardUId::single_shard();
@@ -326,7 +326,7 @@ mod tests {
         // Commit initial state
         let root = {
             let mut trie_update = tries.new_trie_update(shard_uid, Trie::EMPTY_ROOT);
-            initial_state(&mut trie_update);
+            set_initial_state(&mut trie_update);
             trie_update.commit(StateChangeCause::NotWritableToDisk);
             let trie_changes = trie_update.finalize().unwrap().0;
             let (store_update, root) = tries.apply_all(&trie_changes, shard_uid);
@@ -337,7 +337,7 @@ mod tests {
         // Prepare final state
         {
             let mut trie_update = tries.new_trie_update(ShardUId::single_shard(), root);
-            final_state(&mut trie_update);
+            set_final_state(&mut trie_update);
             trie_update.commit(StateChangeCause::NotWritableToDisk);
             trie_update
         }

--- a/runtime/runtime/src/balance_checker.rs
+++ b/runtime/runtime/src/balance_checker.rs
@@ -14,12 +14,12 @@ use near_primitives::transaction::SignedTransaction;
 use near_primitives::trie_key::TrieKey;
 use near_primitives::types::{AccountId, Balance};
 use near_primitives::version::ProtocolVersion;
-use near_store::{get, get_account, get_postponed_receipt, TrieReader, TrieUpdate};
+use near_store::{get, get_account, get_postponed_receipt, TrieAccess, TrieUpdate};
 use std::collections::HashSet;
 
 /// Returns delayed receipts with given range of indices.
 fn get_delayed_receipts(
-    state: &impl TrieReader,
+    state: &dyn TrieAccess,
     indexes: std::ops::Range<u64>,
 ) -> Result<Vec<Receipt>, StorageError> {
     indexes
@@ -77,7 +77,7 @@ fn total_receipts_cost(
 
 /// Returns total account balance of all accounts with given ids.
 fn total_accounts_balance(
-    state: &impl TrieReader,
+    state: &dyn TrieAccess,
     accounts_ids: &HashSet<AccountId>,
 ) -> Result<Balance, RuntimeError> {
     accounts_ids.iter().try_fold(0u128, |accumulator, account_id| {
@@ -91,7 +91,7 @@ fn total_accounts_balance(
 
 /// Calculates and returns total costs of all the postponed receipts.
 fn total_postponed_receipts_cost(
-    state: &impl TrieReader,
+    state: &dyn TrieAccess,
     transaction_costs: &RuntimeFeesConfig,
     current_protocol_version: ProtocolVersion,
     receipt_ids: &HashSet<(AccountId, crate::CryptoHash)>,

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1165,7 +1165,6 @@ impl Runtime {
         .entered();
 
         let trie = Rc::new(trie);
-        let initial_state = TrieUpdate::new(trie.clone());
         let mut state_update = TrieUpdate::new(trie.clone());
 
         let mut stats = ApplyStats::default();
@@ -1339,7 +1338,6 @@ impl Runtime {
 
         check_balance(
             &apply_state.config.transaction_costs,
-            &initial_state,
             &state_update,
             validator_accounts_update,
             incoming_receipts,

--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -288,8 +288,8 @@ fn apply_block_from_range(
 
     let state_update =
         runtime_adapter.get_tries().new_trie_update(shard_uid, *chunk_extra.state_root());
-    let delayed_indices =
-        get::<DelayedReceiptIndices>(&state_update, &TrieKey::DelayedReceiptIndices).unwrap();
+    let delayed_indices: Option<DelayedReceiptIndices> =
+        get(&state_update, &TrieKey::DelayedReceiptIndices).unwrap();
 
     match existing_chunk_extra {
         Some(existing_chunk_extra) => {


### PR DESCRIPTION
Define a TrieAccess trait with a single get method whose purpose is
reading data from given trie.  That is, a trie rooted at one specific
root.

Implement this for Trie and TrieUpdate and with that, change helper
getter functions which previously require `state_update: &TrieUpdate`.

This allows runtime’s check_balance function to work without the need
for explicit `initial_state: &TrieUpdate` to be specified.  The
function can assume that initial state is the one in the Trie
underlying the final state and then read data directly from that
Trie when fetching initial balances etc.

There may be other places where use of &TrieUpdate to read data is now
not necessary.  This commit doesn’t go into changing all of them.  In
fact, I haven’t looked for other such places.

Issue: https://github.com/near/nearcore/issues/6308