### PR TITLE
core: avoid allocations when formatting crypto hash as base58

### DIFF
--- a/core/primitives-core/src/hash.rs
+++ b/core/primitives-core/src/hash.rs
@@ -44,9 +44,7 @@ impl CryptoHash {
         // enough.
         let mut buffer = [0u8; 45];
         let len = bs58::encode(self).into(&mut buffer[..]).unwrap();
-        // SAFETY: buffer[0..len] is all ASCII characters from the base58
-        // alphabet.
-        let value = unsafe { std::str::from_utf8_unchecked(&buffer[..len]) };
+        let value = std::str::from_utf8(&buffer[..len]).unwrap();
         visitor(value)
     }
 }


### PR DESCRIPTION
In some cases, CryptoHash is converted into a String which gets passed
as &str to other parts of the code only for the String to be discarded
later.  Avoid that by doing the encoding onto the stack and using &str
pointing at the on-stack buffer.