### PR TITLE
Add protocol config changes for chunk only producers

### DIFF
--- a/chain/epoch_manager/src/lib.rs
+++ b/chain/epoch_manager/src/lib.rs
@@ -535,7 +535,7 @@ impl EpochManager {
         let config = self.config.for_protocol_version(epoch_info.protocol_version());
         // Compute kick outs for validators who are offline.
         let (kickout, validator_block_chunk_stats) = Self::compute_kickout_info(
-            config,
+            &config,
             &epoch_info,
             &block_validator_tracker,
             &chunk_validator_tracker,

--- a/chain/epoch_manager/src/lib.rs
+++ b/chain/epoch_manager/src/lib.rs
@@ -141,7 +141,7 @@ impl EpochManager {
             let genesis_epoch_config =
                 epoch_manager.config.for_protocol_version(genesis_protocol_version);
             let epoch_info = proposals_to_epoch_info(
-                genesis_epoch_config,
+                &genesis_epoch_config,
                 [0; 32],
                 &EpochInfo::default(),
                 validators,
@@ -601,7 +601,7 @@ impl EpochManager {
         };
         let next_next_epoch_config = self.config.for_protocol_version(next_version);
         let next_next_epoch_info = match proposals_to_epoch_info(
-            next_next_epoch_config,
+            &next_next_epoch_config,
             rng_seed,
             &next_epoch_info,
             all_proposals,
@@ -627,11 +627,12 @@ impl EpochManager {
             Err(err) => return Err(err),
         };
         let next_next_epoch_id = EpochId(*last_block_hash);
-        debug!(target: "epoch_manager", "next next epoch height: {}, id: {:?}, protocol version: {} shard layout: {:?}",
+        debug!(target: "epoch_manager", "next next epoch height: {}, id: {:?}, protocol version: {} shard layout: {:?} config: {:?}",
                next_next_epoch_info.epoch_height(),
                &next_next_epoch_id,
                next_next_epoch_info.protocol_version(),
-               self.config.for_protocol_version(next_next_epoch_info.protocol_version()).shard_layout);
+               self.config.for_protocol_version(next_next_epoch_info.protocol_version()).shard_layout,
+            self.config.for_protocol_version(next_next_epoch_info.protocol_version()));
         // This epoch info is computed for the epoch after next (T+2),
         // where epoch_id of it is the hash of last block in this epoch (T).
         self.save_epoch_info(store_update, &next_next_epoch_id, Arc::new(next_next_epoch_info))?;
@@ -1403,14 +1404,14 @@ impl EpochManager {
         Ok(ShardConfig::new(epoch_config))
     }
 
-    pub fn get_epoch_config(&self, epoch_id: &EpochId) -> Result<&EpochConfig, EpochError> {
+    pub fn get_epoch_config(&self, epoch_id: &EpochId) -> Result<EpochConfig, EpochError> {
         let protocol_version = self.get_epoch_info(epoch_id)?.protocol_version();
         Ok(self.config.for_protocol_version(protocol_version))
     }
 
-    pub fn get_shard_layout(&self, epoch_id: &EpochId) -> Result<&ShardLayout, EpochError> {
+    pub fn get_shard_layout(&self, epoch_id: &EpochId) -> Result<ShardLayout, EpochError> {
         let protocol_version = self.get_epoch_info(epoch_id)?.protocol_version();
-        let shard_layout = &self.config.for_protocol_version(protocol_version).shard_layout;
+        let shard_layout = self.config.for_protocol_version(protocol_version).shard_layout;
         Ok(shard_layout)
     }
 

--- a/chain/epoch_manager/src/test_utils.rs
+++ b/chain/epoch_manager/src/test_utils.rs
@@ -154,7 +154,7 @@ pub fn epoch_config(
         #[cfg(feature = "protocol_feature_max_kickout_stake")]
         validator_max_kickout_stake_perc: 100,
     };
-    AllEpochConfig::new(epoch_config, simple_nightshade_shard_config)
+    AllEpochConfig::new(false, epoch_config, simple_nightshade_shard_config)
 }
 
 pub fn stake(account_id: AccountId, amount: Balance) -> ValidatorStake {

--- a/chain/epoch_manager/src/tests/mod.rs
+++ b/chain/epoch_manager/src/tests/mod.rs
@@ -2180,15 +2180,12 @@ fn test_protocol_version_switch_with_shard_layout_change() {
         epoch_manager.get_epoch_info(&epochs[1]).unwrap().protocol_version(),
         new_protocol_version - 1
     );
-    assert_eq!(
-        *epoch_manager.get_shard_layout(&epochs[1]).unwrap(),
-        ShardLayout::v0_single_shard(),
-    );
+    assert_eq!(epoch_manager.get_shard_layout(&epochs[1]).unwrap(), ShardLayout::v0_single_shard(),);
     assert_eq!(
         epoch_manager.get_epoch_info(&epochs[2]).unwrap().protocol_version(),
         new_protocol_version
     );
-    assert_eq!(*epoch_manager.get_shard_layout(&epochs[2]).unwrap(), shard_layout);
+    assert_eq!(epoch_manager.get_shard_layout(&epochs[2]).unwrap(), shard_layout);
 
     // Check split shards
     // h[5] is the first block of epoch epochs[1] and shard layout will change at epochs[2]
@@ -2233,7 +2230,7 @@ fn test_protocol_version_switch_with_many_seats() {
         #[cfg(feature = "protocol_feature_max_kickout_stake")]
         validator_max_kickout_stake_perc: 100,
     };
-    let config = AllEpochConfig::new(epoch_config, None);
+    let config = AllEpochConfig::new(false, epoch_config, None);
     let amount_staked = 1_000_000;
     let validators = vec![
         stake("test1".parse().unwrap(), amount_staked),

--- a/chain/jsonrpc/jsonrpc-tests/res/genesis_config.json
+++ b/chain/jsonrpc/jsonrpc-tests/res/genesis_config.json
@@ -66,5 +66,6 @@
     1,
     6250
   ],
+  "use_production_config": false,
   "records": []
 }

--- a/core/chain-configs/src/genesis_config.rs
+++ b/core/chain-configs/src/genesis_config.rs
@@ -272,10 +272,6 @@ impl From<&GenesisConfig> for AllEpochConfig {
             initial_epoch_config.clone(),
             shard_config,
         );
-        assert_eq!(
-            initial_epoch_config,
-            epoch_config.for_protocol_version(genesis_config.protocol_version).clone()
-        );
         epoch_config
     }
 }

--- a/core/chain-configs/src/genesis_config.rs
+++ b/core/chain-configs/src/genesis_config.rs
@@ -69,7 +69,7 @@ fn default_minimum_validators_per_shard() -> u64 {
 
 #[cfg(feature = "protocol_feature_chunk_only_producers")]
 fn default_num_chunk_only_producer_seats() -> u64 {
-    200
+    300
 }
 
 fn default_use_production_config() -> bool {
@@ -179,7 +179,7 @@ pub struct GenesisConfig {
     pub simple_nightshade_shard_layout: Option<ShardLayout>,
     #[cfg(feature = "protocol_feature_chunk_only_producers")]
     #[serde(default = "default_num_chunk_only_producer_seats")]
-    #[default(200)]
+    #[default(300)]
     pub num_chunk_only_producer_seats: NumSeats,
     /// The minimum number of validators each shard must have
     #[cfg(feature = "protocol_feature_chunk_only_producers")]
@@ -197,6 +197,9 @@ pub struct GenesisConfig {
     pub minimum_stake_ratio: Rational32,
     #[serde(default = "default_use_production_config")]
     #[default(false)]
+    /// This is only for test purposes. We hard code some configs for mainnet and testnet
+    /// in AllEpochConfig, and we want to have a way to test that code path. This flag is for that.
+    /// If set to true, the node will use the same config override path as mainnet and testnet.
     pub use_production_config: bool,
 }
 

--- a/core/chain-configs/src/genesis_config.rs
+++ b/core/chain-configs/src/genesis_config.rs
@@ -78,7 +78,7 @@ fn default_use_production_config() -> bool {
 
 #[cfg(feature = "protocol_feature_max_kickout_stake")]
 fn default_max_kickout_stake_threshold() -> u8 {
-    30
+    100
 }
 
 fn default_simple_nightshade_shard_layout() -> Option<ShardLayout> {
@@ -188,7 +188,8 @@ pub struct GenesisConfig {
     pub minimum_validators_per_shard: NumSeats,
     #[cfg(feature = "protocol_feature_max_kickout_stake")]
     #[serde(default = "default_max_kickout_stake_threshold")]
-    #[default(30)]
+    #[default(100)]
+    /// Max stake percentage of the validators we will kick out.
     pub max_kickout_stake_perc: u8,
     /// The lowest ratio s/s_total any block producer can have.
     /// See https://github.com/near/NEPs/pull/167 for details

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -137,6 +137,15 @@ impl AllEpochConfig {
                 config.chunk_producer_kickout_threshold = 80;
                 config.validator_selection_config.num_chunk_only_producer_seats = 200;
             }
+
+            #[cfg(feature = "protocol_feature_max_kickout_stake")]
+            if checked_feature!(
+                "protocol_feature_max_kickout_stake",
+                ChunkOnlyProducers,
+                protocol_version
+            ) {
+                config.validator_max_kickout_stake_perc = 30;
+            }
         }
         config
     }

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -127,6 +127,8 @@ impl AllEpochConfig {
                 ChunkOnlyProducers,
                 protocol_version
             ) {
+                // On testnet, genesis config set num_block_producer_seats to 200
+                // This is to bring it back to 100 to be the same as on mainnet
                 config.num_block_producer_seats = 100;
                 // Technically, after ChunkOnlyProducers is enabled, this field is no longer used
                 // We still set it here just in case

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -121,7 +121,6 @@ impl AllEpochConfig {
             }
         }
         if self.use_production_config {
-            // If chunk only producers
             #[cfg(feature = "protocol_feature_chunk_only_producers")]
             if checked_feature!(
                 "protocol_feature_chunk_only_producers",
@@ -141,7 +140,7 @@ impl AllEpochConfig {
             #[cfg(feature = "protocol_feature_max_kickout_stake")]
             if checked_feature!(
                 "protocol_feature_max_kickout_stake",
-                ChunkOnlyProducers,
+                MaxKickoutStake,
                 protocol_version
             ) {
                 config.validator_max_kickout_stake_perc = 30;

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -418,8 +418,8 @@ impl NightshadeRuntime {
     ) -> Result<ShardUId, Error> {
         let epoch_manager = self.epoch_manager.read();
         let shard_layout = epoch_manager.get_shard_layout(epoch_id).map_err(Error::from)?;
-        let shard_id = account_id_to_shard_id(account_id, shard_layout);
-        Ok(ShardUId::from_shard_id_and_layout(shard_id, shard_layout))
+        let shard_id = account_id_to_shard_id(account_id, &shard_layout);
+        Ok(ShardUId::from_shard_id_and_layout(shard_id, &shard_layout))
     }
 
     /// Processes state update.
@@ -1133,7 +1133,7 @@ impl RuntimeAdapter for NightshadeRuntime {
     fn get_shard_config(&self, epoch_id: &EpochId) -> Result<ShardConfig, Error> {
         let epoch_manager = self.epoch_manager.read();
         let epoch_config = epoch_manager.get_epoch_config(epoch_id).map_err(Error::from)?;
-        Ok(ShardConfig::new(&epoch_config))
+        Ok(ShardConfig::new(epoch_config))
     }
 
     fn get_prev_shard_ids(
@@ -1174,7 +1174,7 @@ impl RuntimeAdapter for NightshadeRuntime {
     fn shard_id_to_uid(&self, shard_id: ShardId, epoch_id: &EpochId) -> Result<ShardUId, Error> {
         let epoch_manager = self.epoch_manager.read();
         let shard_layout = epoch_manager.get_shard_layout(epoch_id).map_err(Error::from)?;
-        Ok(ShardUId::from_shard_id_and_layout(shard_id, shard_layout))
+        Ok(ShardUId::from_shard_id_and_layout(shard_id, &shard_layout))
     }
 
     fn num_total_parts(&self) -> usize {
@@ -1202,7 +1202,7 @@ impl RuntimeAdapter for NightshadeRuntime {
     ) -> Result<ShardId, Error> {
         let epoch_manager = self.epoch_manager.read();
         let shard_layout = epoch_manager.get_shard_layout(epoch_id).map_err(Error::from)?;
-        Ok(account_id_to_shard_id(account_id, shard_layout))
+        Ok(account_id_to_shard_id(account_id, &shard_layout))
     }
 
     fn get_part_owner(&self, epoch_id: &EpochId, part_id: u64) -> Result<AccountId, Error> {

--- a/nearcore/src/shard_tracker.rs
+++ b/nearcore/src/shard_tracker.rs
@@ -196,7 +196,7 @@ mod tests {
         };
         EpochManager::new(
             store,
-            AllEpochConfig::new(initial_epoch_config, simple_nightshade_shard_config),
+            AllEpochConfig::new(false, initial_epoch_config, simple_nightshade_shard_config),
             genesis_protocol_version,
             reward_calculator,
             vec![ValidatorStake::new(
@@ -367,7 +367,7 @@ mod tests {
                 let epoch_id = epoch_manager.get_epoch_id_from_prev_block(&h[i - 1]).unwrap();
                 let shard_layout = epoch_manager.get_shard_layout(&epoch_id).unwrap();
                 for account_id in tracked_accounts.iter() {
-                    total_tracked_shards.insert(account_id_to_shard_id(account_id, shard_layout));
+                    total_tracked_shards.insert(account_id_to_shard_id(account_id, &shard_layout));
                 }
                 shard_layout.num_shards()
             };

--- a/nearcore/src/shard_tracker.rs
+++ b/nearcore/src/shard_tracker.rs
@@ -60,7 +60,7 @@ impl ShardTracker {
                 let tracking_mask = self.tracking_shards.get_or_insert(epoch_id, || {
                     let mut tracking_mask = vec![false; shard_layout.num_shards() as usize];
                     for account_id in tracked_accounts {
-                        let shard_id = account_id_to_shard_id(account_id, shard_layout);
+                        let shard_id = account_id_to_shard_id(account_id, &shard_layout);
                         *tracking_mask.get_mut(shard_id as usize).unwrap() = true;
                     }
                     tracking_mask

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -552,7 +552,7 @@ pub(crate) fn view_chain(
     let mut chunks = vec![];
     for (i, chunk_header) in block.chunks().iter().enumerate() {
         if chunk_header.height_included() == block.header().height() {
-            let shard_uid = ShardUId::from_shard_id_and_layout(i as ShardId, shard_layout);
+            let shard_uid = ShardUId::from_shard_id_and_layout(i as ShardId, &shard_layout);
             chunk_extras
                 .push((i, chain_store.get_chunk_extra(block.hash(), &shard_uid).unwrap().clone()));
             chunks.push((i, chain_store.get_chunk(&chunk_header.chunk_hash()).unwrap().clone()));
@@ -564,7 +564,7 @@ pub(crate) fn view_chain(
         .enumerate()
         .filter_map(|(i, chunk_header)| {
             if chunk_header.height_included() == block.header().height() {
-                let shard_uid = ShardUId::from_shard_id_and_layout(i as ShardId, shard_layout);
+                let shard_uid = ShardUId::from_shard_id_and_layout(i as ShardId, &shard_layout);
                 Some((i, chain_store.get_chunk_extra(block.hash(), &shard_uid).unwrap()))
             } else {
                 None


### PR DESCRIPTION
This sets a few changes for ChunkOnlyProducers:
- set number of block producers to 100 (for testnet)
- change number of chunk only producers to 200
- decrease the kick off limit for both block and chunk producers to 80

Test plan:
- start a localnet with use_production_config set to true and test that it runs and check from the debug log that the epoch config is set correctly 
- thinking about other ways to test it programmatically