### PR TITLE
chain: pass genesis hash to Rosetta and get rid of GetBlockHash request

### DIFF
--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -190,13 +190,6 @@ impl Message for GetBlock {
     type Result = Result<BlockView, GetBlockError>;
 }
 
-/// Actor message requesting block hash by id, hash or sync state.
-pub struct GetBlockHash(pub BlockReference);
-
-impl Message for GetBlockHash {
-    type Result = Result<CryptoHash, GetBlockError>;
-}
-
 /// Get block with the block merkle tree. Used for testing
 pub struct GetBlockWithMerkleTree(pub BlockReference);
 

--- a/chain/client/src/lib.rs
+++ b/chain/client/src/lib.rs
@@ -1,8 +1,8 @@
 pub use near_client_primitives::types::{
-    Error, GetBlock, GetBlockHash, GetBlockProof, GetBlockProofResponse, GetBlockWithMerkleTree,
-    GetChunk, GetExecutionOutcome, GetExecutionOutcomeResponse, GetExecutionOutcomesForBlock,
-    GetGasPrice, GetNetworkInfo, GetNextLightClientBlock, GetProtocolConfig, GetReceipt,
-    GetStateChanges, GetStateChangesInBlock, GetStateChangesWithCauseInBlock,
+    Error, GetBlock, GetBlockProof, GetBlockProofResponse, GetBlockWithMerkleTree, GetChunk,
+    GetExecutionOutcome, GetExecutionOutcomeResponse, GetExecutionOutcomesForBlock, GetGasPrice,
+    GetNetworkInfo, GetNextLightClientBlock, GetProtocolConfig, GetReceipt, GetStateChanges,
+    GetStateChangesInBlock, GetStateChangesWithCauseInBlock,
     GetStateChangesWithCauseInBlockForTrackedShards, GetValidatorInfo, GetValidatorOrdered, Query,
     QueryError, Status, StatusResponse, SyncStatus, TxStatus, TxStatusError,
 };

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -19,13 +19,12 @@ use near_chain::{
 };
 use near_chain_configs::{ClientConfig, ProtocolConfigView};
 use near_client_primitives::types::{
-    Error, GetBlock, GetBlockError, GetBlockHash, GetBlockProof, GetBlockProofError,
-    GetBlockProofResponse, GetBlockWithMerkleTree, GetChunkError, GetExecutionOutcome,
-    GetExecutionOutcomeError, GetExecutionOutcomesForBlock, GetGasPrice, GetGasPriceError,
-    GetNextLightClientBlockError, GetProtocolConfig, GetProtocolConfigError, GetReceipt,
-    GetReceiptError, GetStateChangesError, GetStateChangesWithCauseInBlock,
-    GetStateChangesWithCauseInBlockForTrackedShards, GetValidatorInfoError, Query, QueryError,
-    TxStatus, TxStatusError,
+    Error, GetBlock, GetBlockError, GetBlockProof, GetBlockProofError, GetBlockProofResponse,
+    GetBlockWithMerkleTree, GetChunkError, GetExecutionOutcome, GetExecutionOutcomeError,
+    GetExecutionOutcomesForBlock, GetGasPrice, GetGasPriceError, GetNextLightClientBlockError,
+    GetProtocolConfig, GetProtocolConfigError, GetReceipt, GetReceiptError, GetStateChangesError,
+    GetStateChangesWithCauseInBlock, GetStateChangesWithCauseInBlockForTrackedShards,
+    GetValidatorInfoError, Query, QueryError, TxStatus, TxStatusError,
 };
 use near_network::types::{NetworkRequests, PeerManagerAdapter, PeerManagerMessageRequest};
 #[cfg(feature = "test_features")]
@@ -546,31 +545,6 @@ impl Handler<GetBlock> for ViewClientActor {
             .get_block_producer(block.header().epoch_id(), block.header().height())?;
 
         Ok(BlockView::from_author_block(block_author, block))
-    }
-}
-
-/// Handles retrieving block header from the chain.
-impl Handler<GetBlockHash> for ViewClientActor {
-    type Result = Result<CryptoHash, GetBlockError>;
-
-    #[perf]
-    fn handle(&mut self, msg: GetBlockHash, _: &mut Self::Context) -> Self::Result {
-        match msg.0 {
-            BlockReference::Finality(finality) => self.get_block_hash_by_finality(&finality),
-            BlockReference::BlockId(BlockId::Height(height)) => {
-                self.chain.get_block_hash_by_height(height)
-            }
-            BlockReference::BlockId(BlockId::Hash(hash)) => {
-                // Fetch block header to confirm that the block exists.  This is
-                // only done so that we can get an error if the hash does not
-                // correspond to a known block.
-                self.chain.get_block_header(&hash).map(|_| hash)
-            }
-            BlockReference::SyncCheckpoint(sync_checkpoint) => Ok(self
-                .get_block_hash_by_sync_checkpoint(&sync_checkpoint)?
-                .ok_or(GetBlockError::NotSyncedYet)?),
-        }
-        .map_err(std::convert::Into::into)
     }
 }
 

--- a/chain/rosetta-rpc/src/adapters/mod.rs
+++ b/chain/rosetta-rpc/src/adapters/mod.rs
@@ -1,8 +1,5 @@
-use std::sync::Arc;
-
 use actix::Addr;
 
-use near_chain_configs::Genesis;
 use near_client::ViewClientActor;
 
 use validated_operations::ValidatedOperation;
@@ -18,15 +15,14 @@ mod validated_operations;
 /// `other_transactions` to deal with this: https://community.rosetta-api.org/t/how-to-return-data-without-being-able-to-paginate/98
 /// We choose to do a proper implementation for the genesis block later.
 async fn convert_genesis_records_to_transaction(
-    genesis: Arc<Genesis>,
+    genesis: &crate::GenesisWithIdentifier,
     view_client_addr: Addr<ViewClientActor>,
     block: &near_primitives::views::BlockView,
 ) -> crate::errors::Result<crate::models::Transaction> {
-    let genesis_account_ids = genesis.records.as_ref().iter().filter_map(|record| {
+    let mut genesis_account_ids = std::collections::HashSet::new();
+    genesis.for_each_record(|record| {
         if let near_primitives::state_record::StateRecord::Account { account_id, .. } = record {
-            Some(account_id)
-        } else {
-            None
+            genesis_account_ids.insert(account_id.clone());
         }
     });
     // Collect genesis accounts into a BTreeMap rather than a HashMap so that
@@ -35,7 +31,7 @@ async fn convert_genesis_records_to_transaction(
     // stay the same).
     let genesis_accounts: std::collections::BTreeMap<_, _> = crate::utils::query_accounts(
         &near_primitives::types::BlockId::Hash(block.header.hash).into(),
-        genesis_account_ids,
+        genesis_account_ids.iter(),
         &view_client_addr,
     )
     .await?;
@@ -175,7 +171,7 @@ pub(crate) async fn convert_block_to_transactions(
 }
 
 pub(crate) async fn collect_transactions(
-    genesis: Arc<Genesis>,
+    genesis: &crate::GenesisWithIdentifier,
     view_client_addr: Addr<ViewClientActor>,
     block: &near_primitives::views::BlockView,
 ) -> crate::errors::Result<Vec<crate::models::Transaction>> {

--- a/chain/rosetta-rpc/src/adapters/mod.rs
+++ b/chain/rosetta-rpc/src/adapters/mod.rs
@@ -20,7 +20,7 @@ async fn convert_genesis_records_to_transaction(
     block: &near_primitives::views::BlockView,
 ) -> crate::errors::Result<crate::models::Transaction> {
     let mut genesis_account_ids = std::collections::HashSet::new();
-    genesis.for_each_record(|record| {
+    genesis.genesis.for_each_record(|record| {
         if let near_primitives::state_record::StateRecord::Account { account_id, .. } = record {
             genesis_account_ids.insert(account_id.clone());
         }

--- a/chain/rosetta-rpc/src/adapters/mod.rs
+++ b/chain/rosetta-rpc/src/adapters/mod.rs
@@ -1,5 +1,6 @@
 use actix::Addr;
 
+use near_chain_configs::Genesis;
 use near_client::ViewClientActor;
 
 use validated_operations::ValidatedOperation;
@@ -15,12 +16,12 @@ mod validated_operations;
 /// `other_transactions` to deal with this: https://community.rosetta-api.org/t/how-to-return-data-without-being-able-to-paginate/98
 /// We choose to do a proper implementation for the genesis block later.
 async fn convert_genesis_records_to_transaction(
-    genesis: &crate::GenesisWithIdentifier,
+    genesis: &Genesis,
     view_client_addr: Addr<ViewClientActor>,
     block: &near_primitives::views::BlockView,
 ) -> crate::errors::Result<crate::models::Transaction> {
     let mut genesis_account_ids = std::collections::HashSet::new();
-    genesis.genesis.for_each_record(|record| {
+    genesis.for_each_record(|record| {
         if let near_primitives::state_record::StateRecord::Account { account_id, .. } = record {
             genesis_account_ids.insert(account_id.clone());
         }
@@ -171,7 +172,7 @@ pub(crate) async fn convert_block_to_transactions(
 }
 
 pub(crate) async fn collect_transactions(
-    genesis: &crate::GenesisWithIdentifier,
+    genesis: &Genesis,
     view_client_addr: Addr<ViewClientActor>,
     block: &near_primitives::views::BlockView,
 ) -> crate::errors::Result<Vec<crate::models::Transaction>> {

--- a/chain/rosetta-rpc/src/lib.rs
+++ b/chain/rosetta-rpc/src/lib.rs
@@ -16,7 +16,6 @@ use strum::IntoEnumIterator;
 use near_chain_configs::Genesis;
 use near_client::{ClientActor, ViewClientActor};
 use near_primitives::borsh::BorshDeserialize;
-use near_primitives::state_record::StateRecord;
 
 pub use config::RosettaRpcConfig;
 
@@ -35,12 +34,6 @@ pub const BLOCKCHAIN: &str = "nearprotocol";
 struct GenesisWithIdentifier {
     genesis: Genesis,
     block_id: models::BlockIdentifier,
-}
-
-impl GenesisWithIdentifier {
-    fn for_each_record(&self, callback: impl FnMut(&StateRecord)) {
-        self.genesis.for_each_record(callback)
-    }
 }
 
 /// Verifies that network identifier provided by the user is what we expect.

--- a/chain/rosetta-rpc/src/lib.rs
+++ b/chain/rosetta-rpc/src/lib.rs
@@ -229,7 +229,7 @@ async fn block_details(
     };
 
     let transactions = crate::adapters::collect_transactions(
-        genesis.as_ref(),
+        &genesis.genesis,
         Addr::clone(&view_client_addr),
         &block,
     )
@@ -288,7 +288,7 @@ async fn block_transaction_details(
         .ok_or_else(|| errors::ErrorKind::NotFound("Block not found".into()))?;
 
     let transaction = crate::adapters::collect_transactions(
-        genesis.as_ref(),
+        &genesis.genesis,
         Addr::clone(&view_client_addr),
         &block,
     )

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -317,7 +317,8 @@ pub fn start_with_config_and_synchronization(
             "Rosetta RPC",
             start_rosetta_rpc(
                 rosetta_rpc_config,
-                Arc::new(config.genesis.clone()),
+                config.genesis.clone(),
+                genesis_block.header().hash(),
                 client_actor.clone(),
                 view_client.clone(),
             ),

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -12,8 +12,6 @@ use near_network::types::NetworkRecipient;
 use near_network::PeerManagerActor;
 use near_primitives::block::GenesisId;
 use near_primitives::version::DbVersion;
-#[cfg(feature = "rosetta_rpc")]
-use near_rosetta_rpc::start_rosetta_rpc;
 #[cfg(feature = "performance_stats")]
 use near_rust_allocator_proxy::reset_memory_usage_max;
 use near_store::db::RocksDB;
@@ -315,9 +313,9 @@ pub fn start_with_config_and_synchronization(
     if let Some(rosetta_rpc_config) = config.rosetta_rpc_config {
         rpc_servers.push((
             "Rosetta RPC",
-            start_rosetta_rpc(
+            near_rosetta_rpc::start_rosetta_rpc(
                 rosetta_rpc_config,
-                config.genesis.clone(),
+                config.genesis,
                 genesis_block.header().hash(),
                 client_actor.clone(),
                 view_client.clone(),


### PR DESCRIPTION
Rosetta RPC is the only user of GetBlockHash message.  It uses it to
get the hash of the genesis block.  Instead, pass the hash of the
genesis block to Rosetta RPC server when it’s starting so that there
is no need to query the view client for it.  With that, GetBlockHash
becomes unused and can be deleted completely.