### PR TITLE
fix: a quickfix to make demux tolerant to stopping tokio::Runtime

### DIFF
--- a/chain/network/src/concurrency/demux.rs
+++ b/chain/network/src/concurrency/demux.rs
@@ -106,18 +106,22 @@ type Stream<Arg, Res> = mpsc::UnboundedSender<Call<Arg, Res>>;
 #[derive(Clone)]
 pub struct Demux<Arg, Res>(Stream<Arg, Res>);
 
+#[derive(thiserror::Error,Debug)]
+#[error("tokio::Runtime running the demux service has been stopped")]
+pub struct ServiceStoppedError;
+
 impl<Arg: 'static + Send, Res: 'static + Send> Demux<Arg, Res> {
     pub fn call(
         &self,
         arg: Arg,
         f: impl AsyncFn<Vec<Arg>, Vec<Res>>,
-    ) -> impl std::future::Future<Output = Res> {
+    ) -> impl std::future::Future<Output = Result<Res,ServiceStoppedError>> {
         let stream = self.0.clone();
         async move {
             let (send, recv) = oneshot::channel();
             // ok().unwrap(), because DemuxCall doesn't implement Debug.
-            stream.send(Call { arg, out: send, handler: f.wrap() }).ok().unwrap();
-            recv.await.unwrap()
+            stream.send(Call { arg, out: send, handler: f.wrap() }).map_err(|_|ServiceStoppedError)?;
+            recv.await.map_err(|_|ServiceStoppedError)
         }
     }
 
@@ -126,6 +130,9 @@ impl<Arg: 'static + Send, Res: 'static + Send> Demux<Arg, Res> {
     pub fn new(rl: RateLimit) -> Demux<Arg, Res> {
         rl.validate().unwrap();
         let (send, mut recv): (Stream<Arg, Res>, _) = mpsc::unbounded_channel();
+        // TODO(gprusak): this task should be running as long as Demux object exists.
+        // "Current" runtime can have a totally different lifespan, so we shouldn't spawn on it.
+        // Find a way to express "runtime lifetime > Demux lifetime".
         tokio::spawn(async move {
             let mut calls = vec![];
             let mut closed = false;
@@ -161,6 +168,7 @@ impl<Arg: 'static + Send, Res: 'static + Send> Demux<Arg, Res> {
                     // cancellation. Once we add cancellation support, this task could accept a context sum:
                     // the sum is valid iff any context is valid.
                     let calls = std::mem::take(&mut calls);
+                    // TODO(gprusak): don't spawn on the "current" runtime. See one of the previous TODOs.
                     tokio::spawn(async move {
                         let mut args = vec![];
                         let mut outs = vec![];

--- a/chain/network/src/concurrency/tests.rs
+++ b/chain/network/src/concurrency/tests.rs
@@ -10,7 +10,7 @@ async fn test_demux() {
             handles.push(tokio::spawn(async move {
                 let j = demux
                     .call(i, |is: Vec<u64>| async { is.into_iter().map(|i| i + 1).collect() })
-                    .await;
+                    .await.unwrap();
                 assert_eq!(i + 1, j);
             }));
         }

--- a/chain/network/src/concurrency/tests.rs
+++ b/chain/network/src/concurrency/tests.rs
@@ -10,7 +10,8 @@ async fn test_demux() {
             handles.push(tokio::spawn(async move {
                 let j = demux
                     .call(i, |is: Vec<u64>| async { is.into_iter().map(|i| i + 1).collect() })
-                    .await.unwrap();
+                    .await
+                    .unwrap();
                 assert_eq!(i + 1, j);
             }));
         }

--- a/chain/network/src/peer_manager/connected_peers.rs
+++ b/chain/network/src/peer_manager/connected_peers.rs
@@ -128,34 +128,40 @@ impl ConnectedPeer {
     ) -> impl Future<Output = ()> {
         let this = self.clone();
         async move {
-            let res = this.send_accounts_data_demux.call(data, {
-                let this = this.clone();
-                |ds: Vec<Vec<Arc<SignedAccountData>>>| async move {
-                    let res = ds.iter().map(|_| ()).collect();
-                    let mut sum = HashMap::<_, Arc<SignedAccountData>>::new();
-                    for d in ds.into_iter().flatten() {
-                        match sum.entry((d.epoch_id.clone(), d.account_id.clone())) {
-                            Entry::Occupied(mut x) => {
-                                if x.get().timestamp < d.timestamp {
+            let res = this
+                .send_accounts_data_demux
+                .call(data, {
+                    let this = this.clone();
+                    |ds: Vec<Vec<Arc<SignedAccountData>>>| async move {
+                        let res = ds.iter().map(|_| ()).collect();
+                        let mut sum = HashMap::<_, Arc<SignedAccountData>>::new();
+                        for d in ds.into_iter().flatten() {
+                            match sum.entry((d.epoch_id.clone(), d.account_id.clone())) {
+                                Entry::Occupied(mut x) => {
+                                    if x.get().timestamp < d.timestamp {
+                                        x.insert(d);
+                                    }
+                                }
+                                Entry::Vacant(x) => {
                                     x.insert(d);
                                 }
                             }
-                            Entry::Vacant(x) => {
-                                x.insert(d);
-                            }
                         }
+                        let msg = Arc::new(PeerMessage::SyncAccountsData(SyncAccountsData {
+                            incremental: true,
+                            requesting_full_sync: false,
+                            accounts_data: sum.into_values().collect(),
+                        }));
+                        this.send_message(msg);
+                        res
                     }
-                    let msg = Arc::new(PeerMessage::SyncAccountsData(SyncAccountsData {
-                        incremental: true,
-                        requesting_full_sync: false,
-                        accounts_data: sum.into_values().collect(),
-                    }));
-                    this.send_message(msg);
-                    res
-                }
-            }).await;
+                })
+                .await;
             if res.is_err() {
-                tracing::info!("peer {} disconnected, while sencing SyncAccountsData",this.peer_info.id);
+                tracing::info!(
+                    "peer {} disconnected, while sencing SyncAccountsData",
+                    this.peer_info.id
+                );
             }
         }
     }

--- a/chain/network/src/peer_manager/connected_peers.rs
+++ b/chain/network/src/peer_manager/connected_peers.rs
@@ -127,32 +127,37 @@ impl ConnectedPeer {
         data: Vec<Arc<SignedAccountData>>,
     ) -> impl Future<Output = ()> {
         let this = self.clone();
-        self.send_accounts_data_demux.call(
-            data,
-            |ds: Vec<Vec<Arc<SignedAccountData>>>| async move {
-                let res = ds.iter().map(|_| ()).collect();
-                let mut sum = HashMap::<_, Arc<SignedAccountData>>::new();
-                for d in ds.into_iter().flatten() {
-                    match sum.entry((d.epoch_id.clone(), d.account_id.clone())) {
-                        Entry::Occupied(mut x) => {
-                            if x.get().timestamp < d.timestamp {
+        async move {
+            let res = this.send_accounts_data_demux.call(data, {
+                let this = this.clone();
+                |ds: Vec<Vec<Arc<SignedAccountData>>>| async move {
+                    let res = ds.iter().map(|_| ()).collect();
+                    let mut sum = HashMap::<_, Arc<SignedAccountData>>::new();
+                    for d in ds.into_iter().flatten() {
+                        match sum.entry((d.epoch_id.clone(), d.account_id.clone())) {
+                            Entry::Occupied(mut x) => {
+                                if x.get().timestamp < d.timestamp {
+                                    x.insert(d);
+                                }
+                            }
+                            Entry::Vacant(x) => {
                                 x.insert(d);
                             }
                         }
-                        Entry::Vacant(x) => {
-                            x.insert(d);
-                        }
                     }
+                    let msg = Arc::new(PeerMessage::SyncAccountsData(SyncAccountsData {
+                        incremental: true,
+                        requesting_full_sync: false,
+                        accounts_data: sum.into_values().collect(),
+                    }));
+                    this.send_message(msg);
+                    res
                 }
-                let msg = Arc::new(PeerMessage::SyncAccountsData(SyncAccountsData {
-                    incremental: true,
-                    requesting_full_sync: false,
-                    accounts_data: sum.into_values().collect(),
-                }));
-                this.send_message(msg);
-                res
-            },
-        )
+            }).await;
+            if res.is_err() {
+                tracing::info!("peer {} disconnected, while sencing SyncAccountsData",this.peer_info.id);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Spawning tasks on runtime of unknown lifecycle is scary :/. I need to think this through again.
