### PR TITLE
test: fix flaky test

### DIFF
--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -158,7 +158,7 @@ impl Client {
     /// This function finishes processing block with hash `hash`, if the procesing of that block
     /// has started.
     pub fn finish_block_in_processing(&mut self, hash: &CryptoHash) -> Vec<CryptoHash> {
-        if let Ok(_) = wait_for_block_in_processing(&mut self.chain, hash) {
+        if let Ok(()) = wait_for_block_in_processing(&mut self.chain, hash) {
             let (accepted_blocks, errors) = self.postprocess_ready_blocks(Arc::new(|_| {}), true);
             assert!(errors.is_empty());
             return accepted_blocks;

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -2085,6 +2085,8 @@ fn test_block_height_processed_orphan() {
 
 #[test]
 fn test_validate_chunk_extra() {
+    let mut capture = near_logger_utils::TracingCapture::enable();
+
     let epoch_length = 5;
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
@@ -2168,7 +2170,25 @@ fn test_validate_chunk_extra() {
         assert_matches!(res.unwrap_err(), near_chain::Error::ChunksMissing(_));
     }
 
-    // Process the previously unavailable chunk. This causes two blocks to be accepted.
+    // Process the previously unavailable chunk. This causes two blocks to be
+    // accepted. Technically, the blocks are accepted concurrently, so we can
+    // observe either `block1 -> block2` reorg or `block2, block1` fork. We want
+    // to try to produce chunks on top of block1, so we force the reorg case
+    // using `capture`
+
+    let barrier = Arc::new(std::sync::Barrier::new(2));
+    capture.set_callback({
+        let block2_hash = *block2.hash();
+        let barrier = Arc::clone(&barrier);
+        move |msg| {
+            if msg.starts_with("do_apply_chunks")
+                && msg.contains(&format!("block_hash={block2_hash}"))
+            {
+                barrier.wait();
+            }
+        }
+    });
+
     let mut chain_store =
         ChainStore::new(env.clients[0].chain.store().store().clone(), genesis_height, true);
     let chunk_header = encoded_chunk.cloned_header();
@@ -2178,8 +2198,11 @@ fn test_validate_chunk_extra() {
         .unwrap();
     env.clients[0].chain.blocks_with_missing_chunks.accept_chunk(&chunk_header.chunk_hash());
     env.clients[0].process_blocks_with_missing_chunks(Arc::new(|_| {}));
-    let accepted_blocks = env.clients[0].finish_blocks_in_processing();
-    assert_eq!(accepted_blocks.len(), 2);
+    let accepted_blocks = env.clients[0].finish_block_in_processing(block1.hash());
+    assert_eq!(accepted_blocks.len(), 1);
+    barrier.wait();
+    let accepted_blocks = env.clients[0].finish_block_in_processing(block2.hash());
+    assert_eq!(accepted_blocks.len(), 1);
 
     // About to produce a block on top of block1. Validate that this chunk is legit.
     let chunks = env.clients[0].shards_mgr.prepare_chunks(block1.hash());

--- a/test-utils/logger/src/tracing_capture.rs
+++ b/test-utils/logger/src/tracing_capture.rs
@@ -2,33 +2,49 @@ use std::fmt::Write;
 use std::mem;
 use std::sync::{Arc, Mutex};
 
-/// Captures logs into a `Vec<String>`.
+/// Intercepts `tracing` logs.
 ///
-/// You can use this in tests to verify that the code hits a particular code
-/// path.
+/// The intended use-case is for tests which want to probe inner workings of the
+/// system which are not observable through public APIs only.
 pub struct TracingCapture {
     captured: Arc<Mutex<Captured>>,
     _guard: tracing::subscriber::DefaultGuard,
 }
 
-#[derive(Default)]
 struct Captured {
+    on_log: Arc<dyn Fn(&str) + Send + Sync>,
     logs: Vec<String>,
 }
 
-#[derive(Default)]
 struct Subscriber(Arc<Mutex<Captured>>);
 
 impl TracingCapture {
+    /// Sets `TracingCapture` as the "default subscriber".
+    ///
+    /// "default subscriber" is essentially a thread-local, so some care must be
+    /// taken to properly propagate this across threads for multi-threaded
+    /// tests.
     pub fn enable() -> TracingCapture {
-        let subscriber = Subscriber::default();
-        let captured = subscriber.0.clone();
+        let captured =
+            Arc::new(Mutex::new(Captured { on_log: Arc::new(|_| ()), logs: Vec::new() }));
+        let subscriber = Subscriber(Arc::clone(&captured));
         let _guard = tracing::subscriber::set_default(subscriber);
         TracingCapture { captured, _guard }
     }
+    /// Get all the logs so-far.
+    ///
+    /// Useful to verify that some particular code-path was hit by a test.
     pub fn drain(&mut self) -> Vec<String> {
         let mut guard = self.captured.lock().unwrap();
         mem::take(&mut guard.logs)
+    }
+    /// Sets the callback to execute on every log line emitted.
+    ///
+    /// The intended use-case is for testing multithreaded code: by *blocking*
+    /// in the `on_log` for specific log-lines, the test can maneuver the
+    /// threads into particularly interesting interleavings.
+    pub fn set_callback(&mut self, on_log: impl Fn(&str) + Send + Sync + 'static) {
+        self.captured.lock().unwrap().on_log = Arc::new(on_log)
     }
 }
 
@@ -45,6 +61,11 @@ impl tracing::Subscriber for Subscriber {
             span.record(&mut visitor);
             visitor.0
         };
+
+        // Tricky: as `on_log` is expected to block, we take care to call it
+        // *without* holding any mutexes.
+        let on_log = Arc::clone(&self.0.lock().unwrap().on_log);
+        on_log(&buf);
 
         let mut guard = self.0.lock().unwrap();
         guard.logs.push(buf);


### PR DESCRIPTION
test_validate_chunk_extra was failing from time to time. The way to
observe it is to run

```
$ cargo t -q -r --features nightly,test_features -p 'integration-tests' -- tests::client::process_blocks::test_validate_chunk_extra
```

while under heavy CPU load.

The reason for failure is that this test processes two blocks from
different forks concurrently, and depending on block processing times,
could see the head change as a Next -> Reorg or as Next -> Fork. And the
test really wants to see a reorg here.

We didn't hit this before because we didn't have concurrent processing
of blocks implemented, and the single-threaded impl just happened to
process blocks in the natural order.

I didn't find any nice way to force block1 to be processed before
block2, so I extended the TracingCapture infrastructure with generic
mechanism to force particular thread schedulings.

closes #7368