### PR TITLE
Revert "Update rocksdb to 0.19 (#7357)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.2.1"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f9ffb6db08c1c3a1f4aef540f1a63193adc73c4fbd40b75a95fc8c5258f6e51"
+checksum = "a5885cb81a0d4d0d322864bea1bb6c2a8144626b4fdc625d4c51eba197e7797a"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -85,13 +85,13 @@ dependencies = [
  "itoa 1.0.2",
  "language-tags",
  "local-channel",
+ "log",
  "mime",
  "percent-encoding",
  "pin-project-lite",
  "rand 0.8.5",
- "sha1 0.10.1",
+ "sha-1",
  "smallvec",
- "tracing",
  "zstd",
 ]
 
@@ -470,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.60.1"
+version = "0.59.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
+checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -2449,9 +2449,9 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.8.0+7.4.4"
+version = "0.6.1+6.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611804e4666a25136fcc5f8cf425ab4d26c7f74ea245ffe92ea23b85b6420b5d"
+checksum = "81bc587013734dadb7cf23468e531aa120788b87243648be42e2d3a072186291"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -4642,7 +4642,7 @@ dependencies = [
  "dtoa",
  "itoa 0.4.8",
  "percent-encoding",
- "sha1 0.6.1",
+ "sha1",
  "url",
 ]
 
@@ -4856,9 +4856,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.19.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9562ea1d70c0cc63a34a22d977753b50cca91cc6b6527750463bd5dd8697bc"
+checksum = "620f4129485ff1a7128d184bc687470c21c7951b64779ebc9cfdad3dcd920290"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -5197,23 +5197,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.3",
+]
+
+[[package]]
 name = "sha1"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
 dependencies = [
  "sha1_smol",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77f4e7f65455545c2153c1253d25056825e77ee2533f0e41deb65a93a34852f"
-dependencies = [
- "cfg-if 1.0.0",
- "cpufeatures",
- "digest 0.10.3",
 ]
 
 [[package]]
@@ -6784,18 +6784,18 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.11.2+zstd.1.5.2"
+version = "0.10.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+checksum = "5f4a6bd64f22b5e3e94b4e238669ff9f10815c27a5180108b849d24174a83847"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
+version = "4.1.6+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+checksum = "94b61c51bb270702d6167b8ce67340d2754b088d0c091b06e593aa772c3ee9bb"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -6803,9 +6803,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.1+zstd.1.5.2"
+version = "1.6.3+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
+checksum = "fc49afa5c8d634e75761feda8c592051e7eeb4683ba827211eb0d731d3402ea8"
 dependencies = [
  "cc",
  "libc",

--- a/chain/indexer/Cargo.toml
+++ b/chain/indexer/Cargo.toml
@@ -13,7 +13,7 @@ anyhow = "1.0.51"
 async-recursion = "0.3.2"
 tracing = "0.1.13"
 futures = "0.3.5"
-rocksdb = { version = "0.19.0", default-features = false, features = ["snappy", "lz4", "zstd", "zlib"] }
+rocksdb = { version = "0.18.0", default-features = false, features = ["snappy", "lz4", "zstd", "zlib"] }
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1.0.55"
 tokio = { version = "1.1", features = ["time", "sync"] }

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -14,7 +14,7 @@ bytesize = { version = "1.1", features = ["serde"] }
 derive_more = "0.99.3"
 elastic-array = "0.11"
 enum-map = "2.1.0"
-rocksdb = { version = "0.19.0", default-features = false, features = ["snappy", "lz4", "zstd", "zlib"] }
+rocksdb = { version = "0.18.0", default-features = false, features = ["snappy", "lz4", "zstd", "zlib"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"

--- a/core/store/src/db/rocksdb.rs
+++ b/core/store/src/db/rocksdb.rs
@@ -5,7 +5,8 @@ use std::sync::{Condvar, Mutex};
 
 use ::rocksdb::checkpoint::Checkpoint;
 use ::rocksdb::{
-    BlockBasedOptions, Cache, ColumnFamily, Env, IteratorMode, Options, ReadOptions, WriteBatch, DB,
+    BlockBasedOptions, Cache, ColumnFamily, Direction, Env, IteratorMode, Options, ReadOptions,
+    WriteBatch, DB,
 };
 use once_cell::sync::Lazy;
 use strum::IntoEnumIterator;
@@ -20,8 +21,7 @@ use crate::{metrics, DBCol, StoreConfig, StoreStatistics};
 /// List of integer RocskDB properties we’re reading when collecting statistics.
 ///
 /// In the end, they are exported as Prometheus metrics.
-const CF_PROPERTY_NAMES: [&'static std::ffi::CStr; 1] =
-    [::rocksdb::properties::LIVE_SST_FILES_SIZE];
+pub const CF_STAT_NAMES: [&'static str; 1] = [::rocksdb::properties::LIVE_SST_FILES_SIZE];
 
 pub struct RocksDB {
     db: DB,
@@ -167,50 +167,51 @@ impl RocksDB {
     ) -> RocksDBIterator<'a> {
         let cf_handle = self.cf_handle(col);
         let mut read_options = rocksdb_read_options();
-        if let Some(prefix) = prefix {
-            read_options.set_iterate_range(::rocksdb::PrefixRange(prefix));
-            // Note: prefix_same_as_start doesn’t do anything for us.  It takes
-            // effect only if prefix extractor is configured for the column
-            // family which is something we’re not doing.  Setting this option
-            // is therefore pointless.
+        let mode = if let Some(prefix) = prefix {
+            // prefix_same_as_start doesn’t do anything for us.  It takes effect
+            // only if prefix extractor is configured for the column family
+            // which is something we’re not doing.  Setting this option is
+            // therefore pointless.
             //     read_options.set_prefix_same_as_start(true);
-        }
-        let iter = self.db.iterator_cf_opt(cf_handle, read_options, IteratorMode::Start);
-        RocksDBIterator(iter)
+
+            // We’re running the iterator in From mode so there’s no need to set
+            // the lower bound.
+            //    read_options.set_iterate_lower_bound(key_prefix);
+
+            // Upper bound is exclusive so if we set it to the next prefix
+            // iterator will stop once keys no longer start with our desired
+            // prefix.
+            if let Some(upper) = next_prefix(prefix) {
+                read_options.set_iterate_upper_bound(upper);
+            }
+
+            IteratorMode::From(prefix, Direction::Forward)
+        } else {
+            IteratorMode::Start
+        };
+        let iter = self.db.iterator_cf_opt(cf_handle, read_options, mode);
+        RocksDBIterator(Some(iter))
     }
 }
 
-struct RocksDBIterator<'a>(rocksdb::DBIteratorWithThreadMode<'a, DB>);
+struct RocksDBIterator<'a>(Option<rocksdb::DBIteratorWithThreadMode<'a, DB>>);
 
 impl<'a> Iterator for RocksDBIterator<'a> {
     type Item = io::Result<(Box<[u8]>, Box<[u8]>)>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        Some(self.0.next()?.map_err(into_other))
+        let iter = self.0.as_mut()?;
+        if let Some(item) = iter.next() {
+            Some(Ok(item))
+        } else {
+            let status = iter.status();
+            self.0 = None;
+            status.err().map(into_other).map(Result::Err)
+        }
     }
 }
 
 impl<'a> std::iter::FusedIterator for RocksDBIterator<'a> {}
-
-impl RocksDB {
-    fn get_cf_key_range(
-        &self,
-        cf_handle: &ColumnFamily,
-    ) -> Result<Option<std::ops::RangeInclusive<Box<[u8]>>>, ::rocksdb::Error> {
-        let range = {
-            let mut iter = self.db.iterator_cf(cf_handle, IteratorMode::Start);
-            let start = iter.next().transpose()?;
-            iter.set_mode(IteratorMode::End);
-            let end = iter.next().transpose()?;
-            (start, end)
-        };
-        match range {
-            (Some(start), Some(end)) => Ok(Some(start.0..=end.0)),
-            (None, None) => Ok(None),
-            _ => unreachable!(),
-        }
-    }
-}
 
 impl Database for RocksDB {
     fn get_raw_bytes(&self, col: DBCol, key: &[u8]) -> io::Result<Option<Vec<u8>>> {
@@ -267,11 +268,13 @@ impl Database for RocksDB {
                 }
                 DBOp::DeleteAll { col } => {
                     let cf_handle = self.cf_handle(col);
-                    let range = self.get_cf_key_range(cf_handle).map_err(into_other)?;
-                    if let Some(range) = range {
-                        batch.delete_range_cf(cf_handle, range.start(), range.end());
+                    let opt_first = self.db.iterator_cf(cf_handle, IteratorMode::Start).next();
+                    let opt_last = self.db.iterator_cf(cf_handle, IteratorMode::End).next();
+                    assert_eq!(opt_first.is_some(), opt_last.is_some());
+                    if let (Some((min_key, _)), Some((max_key, _))) = (opt_first, opt_last) {
+                        batch.delete_range_cf(cf_handle, &min_key, &max_key);
                         // delete_range_cf deletes ["begin_key", "end_key"), so need one more delete
-                        batch.delete_cf(cf_handle, range.end())
+                        batch.delete_cf(cf_handle, max_key)
                     }
                 }
             }
@@ -299,6 +302,32 @@ impl Database for RocksDB {
         } else {
             Some(result)
         }
+    }
+}
+
+/// Returns lowest value following largest value with given prefix.
+///
+/// In other words, computes upper bound for a prefix scan over list of keys
+/// sorted in lexicographical order.  This means that a prefix scan can be
+/// expressed as range scan over a right-open `[prefix, next_prefix(prefix))`
+/// range.
+///
+/// For example, for prefix `foo` the function returns `fop`.
+///
+/// Returns `None` if there is no value which can follow value with given
+/// prefix.  This happens when prefix consists entirely of `'\xff'` bytes (or is
+/// empty).
+fn next_prefix(prefix: &[u8]) -> Option<Vec<u8>> {
+    let ffs = prefix.iter().rev().take_while(|&&byte| byte == u8::MAX).count();
+    let next = &prefix[..(prefix.len() - ffs)];
+    if next.is_empty() {
+        // Prefix consisted of \xff bytes.  There is no prefix that
+        // follows it.
+        None
+    } else {
+        let mut next = next.to_vec();
+        *next.last_mut().unwrap() += 1;
+        Some(next)
     }
 }
 
@@ -482,20 +511,17 @@ impl RocksDB {
         Checkpoint::new(&self.db).map_err(into_other)
     }
 
-    /// Gets every int property in CF_PROPERTY_NAMES for every column in DBCol.
+    /// Gets every int property in CF_STAT_NAMES for every column in DBCol.
     fn get_cf_statistics(&self, result: &mut StoreStatistics) {
-        for prop_name in CF_PROPERTY_NAMES {
+        for stat_name in CF_STAT_NAMES {
             let mut values = vec![];
             for col in DBCol::iter() {
-                let size = self.db.property_int_value_cf(self.cf_handle(col), prop_name);
+                let size = self.db.property_int_value_cf(self.cf_handle(col), stat_name);
                 if let Ok(Some(value)) = size {
                     values.push(StatsValue::ColumnValue(col, value as i64));
                 }
             }
             if !values.is_empty() {
-                // TODO(mina86): Once const_str_from_utf8 is stabilised we might
-                // be able convert this runtime UTF-8 validation into const.
-                let stat_name = prop_name.to_str().unwrap();
                 result.data.push((stat_name.to_string(), values));
             }
         }
@@ -713,5 +739,18 @@ mod tests {
                 ]
             }
         );
+    }
+
+    #[test]
+    fn next_prefix() {
+        fn test(want: Option<&[u8]>, arg: &[u8]) {
+            assert_eq!(want, super::next_prefix(arg).as_ref().map(Vec::as_ref));
+        }
+
+        test(None, b"");
+        test(None, b"\xff");
+        test(None, b"\xff\xff\xff\xff");
+        test(Some(b"b"), b"a");
+        test(Some(b"b"), b"a\xff\xff\xff");
     }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -108,7 +108,4 @@ skip = [
 
     # prometheus depends on an old version of protobuf
     { name = "protobuf", version = "=2.27.1" },
-
-    # redis we’re using uses ancient sha
-    { name = "sha1", version = "=0.6.1" },
 ]

--- a/runtime/runtime-params-estimator/Cargo.toml
+++ b/runtime/runtime-params-estimator/Cargo.toml
@@ -39,7 +39,7 @@ near-primitives = { path = "../../core/primitives" }
 near-o11y = { path = "../../core/o11y" }
 
 nearcore = { path = "../../nearcore" }
-rocksdb = { version = "0.19.0", default-features = false, features = ["snappy", "lz4", "zstd", "zlib"] }
+rocksdb = { version = "0.18.0", default-features = false, features = ["snappy", "lz4", "zstd", "zlib"] }
 walrus = "0.18.0"
 hex = "0.4"
 cfg-if = "1"


### PR DESCRIPTION
This reverts commit 7e7cac03c9c17fa0bf85a9fe02df7503b3e5d21d.

There's nothing obviously wrong with it that we've noticed, but
it's best not to change this before cutting 1.29.0. So for now let's
revert it and then revert the revert after cutting the next release.