### PR TITLE
chain: standardise on ‘get_block_header’ naming

### DIFF
--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -162,7 +162,7 @@ pub trait ChainStoreAccess {
         Ok(None)
     }
     /// Returns block header from the current chain for given height if present.
-    fn get_header_by_height(&self, height: BlockHeight) -> Result<BlockHeader, Error> {
+    fn get_block_header_by_height(&self, height: BlockHeight) -> Result<BlockHeader, Error> {
         let hash = self.get_block_hash_by_height(height)?;
         self.get_block_header(&hash)
     }
@@ -180,7 +180,7 @@ pub trait ChainStoreAccess {
         shard_id: ShardId,
     ) -> Result<ChunkHash, Error>;
     /// Returns block header from the current chain defined by `sync_hash` for given height if present.
-    fn get_header_on_chain_by_height(
+    fn get_block_header_on_chain_by_height(
         &self,
         sync_hash: &CryptoHash,
         height: BlockHeight,
@@ -557,7 +557,7 @@ impl ChainStore {
             }
         } else {
             let header = self
-                .get_header_on_chain_by_height(prev_block_header.hash(), base_height)
+                .get_block_header_on_chain_by_height(prev_block_header.hash(), base_height)
                 .map_err(|_| InvalidTxError::InvalidChain)?;
             if header.hash() == base_block_hash {
                 Ok(())
@@ -1670,7 +1670,7 @@ impl<'a> ChainStoreUpdate<'a> {
 
     #[cfg(feature = "test_features")]
     pub fn adv_save_latest_known(&mut self, height: BlockHeight) -> Result<(), Error> {
-        let header = self.get_header_by_height(height)?;
+        let header = self.get_block_header_by_height(height)?;
         let tip = Tip::from_header(&header);
         self.chain_store
             .save_latest_known(LatestKnown { height, seen: to_timestamp(Utc::now()) })?;

--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -487,7 +487,7 @@ mod tests {
     #[test]
     fn test_discrepancy() {
         let (chain, mut sv) = init();
-        let block_header = chain.get_header_by_height(0).unwrap();
+        let block_header = chain.get_block_header_by_height(0).unwrap();
         assert!(validate::block_header_hash_validity(&mut sv, block_header.hash(), &block_header)
             .is_ok());
         match validate::block_header_hash_validity(&mut sv, &CryptoHash::default(), &block_header) {

--- a/chain/chain/src/tests/challenges.rs
+++ b/chain/chain/src/tests/challenges.rs
@@ -40,9 +40,9 @@ fn challenges_new_head_prev() {
 
     assert_eq!(chain.head_header().unwrap().hash(), &hashes[2]);
 
-    assert_eq!(chain.get_header_by_height(2).unwrap().hash(), &hashes[1]);
-    assert_eq!(chain.get_header_by_height(3).unwrap().hash(), &hashes[2]);
-    assert!(chain.get_header_by_height(4).is_err());
+    assert_eq!(chain.get_block_header_by_height(2).unwrap().hash(), &hashes[1]);
+    assert_eq!(chain.get_block_header_by_height(3).unwrap().hash(), &hashes[2]);
+    assert!(chain.get_block_header_by_height(4).is_err());
 
     // Try to add a block on top of the fifth block.
     if let Err(e) = chain.preprocess_block(

--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -151,8 +151,8 @@ fn build_chain_with_skips_and_forks() {
     assert!(chain.process_block_test(&None, b3).is_ok());
     assert!(chain.process_block_test(&None, b4).is_ok());
     assert!(chain.process_block_test(&None, b5).is_ok());
-    assert!(chain.get_header_by_height(1).is_err());
-    assert_eq!(chain.get_header_by_height(5).unwrap().height(), 5);
+    assert!(chain.get_block_header_by_height(1).is_err());
+    assert_eq!(chain.get_block_header_by_height(5).unwrap().height(), 5);
 }
 
 /// Verifies that the block at height are updated correctly when blocks from different forks are
@@ -199,9 +199,9 @@ fn blocks_at_height() {
     chain.process_block_test(&None, b_3).unwrap();
     assert_eq!(chain.header_head().unwrap().height, 3);
 
-    assert_eq!(chain.get_header_by_height(1).unwrap().hash(), &b_1_hash);
-    assert_eq!(chain.get_header_by_height(2).unwrap().hash(), &b_2_hash);
-    assert_eq!(chain.get_header_by_height(3).unwrap().hash(), &b_3_hash);
+    assert_eq!(chain.get_block_header_by_height(1).unwrap().hash(), &b_1_hash);
+    assert_eq!(chain.get_block_header_by_height(2).unwrap().hash(), &b_2_hash);
+    assert_eq!(chain.get_block_header_by_height(3).unwrap().hash(), &b_3_hash);
 
     chain.process_block_test(&None, c_1).unwrap();
     chain.process_block_test(&None, c_3).unwrap();
@@ -209,31 +209,31 @@ fn blocks_at_height() {
     chain.process_block_test(&None, c_5).unwrap();
     assert_eq!(chain.header_head().unwrap().height, 5);
 
-    assert_eq!(chain.get_header_by_height(1).unwrap().hash(), &c_1_hash);
-    assert!(chain.get_header_by_height(2).is_err());
-    assert_eq!(chain.get_header_by_height(3).unwrap().hash(), &c_3_hash);
-    assert_eq!(chain.get_header_by_height(4).unwrap().hash(), &c_4_hash);
-    assert_eq!(chain.get_header_by_height(5).unwrap().hash(), &c_5_hash);
+    assert_eq!(chain.get_block_header_by_height(1).unwrap().hash(), &c_1_hash);
+    assert!(chain.get_block_header_by_height(2).is_err());
+    assert_eq!(chain.get_block_header_by_height(3).unwrap().hash(), &c_3_hash);
+    assert_eq!(chain.get_block_header_by_height(4).unwrap().hash(), &c_4_hash);
+    assert_eq!(chain.get_block_header_by_height(5).unwrap().hash(), &c_5_hash);
 
     chain.process_block_test(&None, d_3).unwrap();
     chain.process_block_test(&None, d_4).unwrap();
     chain.process_block_test(&None, d_6).unwrap();
     assert_eq!(chain.header_head().unwrap().height, 6);
 
-    assert_eq!(chain.get_header_by_height(1).unwrap().hash(), &b_1_hash);
-    assert_eq!(chain.get_header_by_height(2).unwrap().hash(), &b_2_hash);
-    assert_eq!(chain.get_header_by_height(3).unwrap().hash(), &d_3_hash);
-    assert_eq!(chain.get_header_by_height(4).unwrap().hash(), &d_4_hash);
-    assert!(chain.get_header_by_height(5).is_err());
-    assert_eq!(chain.get_header_by_height(6).unwrap().hash(), &d_6_hash);
+    assert_eq!(chain.get_block_header_by_height(1).unwrap().hash(), &b_1_hash);
+    assert_eq!(chain.get_block_header_by_height(2).unwrap().hash(), &b_2_hash);
+    assert_eq!(chain.get_block_header_by_height(3).unwrap().hash(), &d_3_hash);
+    assert_eq!(chain.get_block_header_by_height(4).unwrap().hash(), &d_4_hash);
+    assert!(chain.get_block_header_by_height(5).is_err());
+    assert_eq!(chain.get_block_header_by_height(6).unwrap().hash(), &d_6_hash);
 
     chain.process_block_test(&None, e_7).unwrap();
 
-    assert_eq!(chain.get_header_by_height(1).unwrap().hash(), &b_1_hash);
+    assert_eq!(chain.get_block_header_by_height(1).unwrap().hash(), &b_1_hash);
     for h in 2..=5 {
-        assert!(chain.get_header_by_height(h).is_err());
+        assert!(chain.get_block_header_by_height(h).is_err());
     }
-    assert_eq!(chain.get_header_by_height(7).unwrap().hash(), &e_7_hash);
+    assert_eq!(chain.get_block_header_by_height(7).unwrap().hash(), &e_7_hash);
 }
 
 #[test]

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1492,7 +1492,7 @@ impl Client {
         let parent_hash = match inner {
             ApprovalInner::Endorsement(parent_hash) => *parent_hash,
             ApprovalInner::Skip(parent_height) => {
-                match self.chain.get_header_by_height(*parent_height) {
+                match self.chain.get_block_header_by_height(*parent_height) {
                     Ok(header) => *header.hash(),
                     Err(e) => {
                         self.handle_process_approval_error(approval, approval_type, true, e);

--- a/chain/client/src/debug.rs
+++ b/chain/client/src/debug.rs
@@ -488,7 +488,7 @@ impl ClientActor {
                 let mut production = ProductionAtHeight::default();
 
                 // The block may be in the last epoch from head, we need to account for that.
-                if let Ok(header) = self.client.chain.get_header_by_height(height) {
+                if let Ok(header) = self.client.chain.get_block_header_by_height(height) {
                     epoch_id = header.epoch_id().clone();
                 }
 

--- a/chain/client/src/sync.rs
+++ b/chain/client/src/sync.rs
@@ -344,7 +344,7 @@ impl HeaderSync {
             } else {
                 // Walk backwards to find last known hash.
                 let last_loc = *locator.last().unwrap();
-                if let Ok(header) = chain.get_header_by_height(h) {
+                if let Ok(header) = chain.get_block_header_by_height(h) {
                     if header.height() != last_loc.0 {
                         locator.push((header.height(), *header.hash()));
                     }
@@ -506,7 +506,7 @@ impl BlockSync {
             let mut candidate = (header.height(), *header.hash(), *header.prev_hash());
 
             // First go back until we find the common block
-            while match chain.get_header_by_height(candidate.0) {
+            while match chain.get_block_header_by_height(candidate.0) {
                 Ok(header) => header.hash() != &candidate.1,
                 Err(e) => match e {
                     near_chain::Error::DBNotFoundErr(_) => true,

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -148,7 +148,7 @@ impl ViewClientActor {
                 let block_hash = self.chain.head()?.last_block_hash;
                 self.chain.get_block_header(&block_hash)
             }
-            Some(BlockId::Height(height)) => self.chain.get_header_by_height(height),
+            Some(BlockId::Height(height)) => self.chain.get_block_header_by_height(height),
             Some(BlockId::Hash(block_hash)) => self.chain.get_block_header(&block_hash),
         }
     }
@@ -192,7 +192,7 @@ impl ViewClientActor {
     fn handle_query(&mut self, msg: Query) -> Result<QueryResponse, QueryError> {
         let header = match msg.block_reference {
             BlockReference::BlockId(BlockId::Height(block_height)) => {
-                self.chain.get_header_by_height(block_height)
+                self.chain.get_block_header_by_height(block_height)
             }
             BlockReference::BlockId(BlockId::Hash(block_hash)) => {
                 self.chain.get_block_header(&block_hash)
@@ -644,7 +644,7 @@ impl Handler<GetValidatorInfo> for ViewClientActor {
             EpochReference::BlockId(block_id) => {
                 let block_header = match block_id {
                     BlockId::Hash(h) => self.chain.get_block_header(&h)?,
-                    BlockId::Height(h) => self.chain.get_header_by_height(h)?,
+                    BlockId::Height(h) => self.chain.get_block_header_by_height(h)?,
                 };
                 let next_block_hash =
                     self.chain.store().get_next_block_hash(block_header.hash())?;
@@ -953,7 +953,7 @@ impl Handler<GetProtocolConfig> for ViewClientActor {
                 self.chain.get_block_header(&block_hash)
             }
             BlockReference::BlockId(BlockId::Height(height)) => {
-                self.chain.get_header_by_height(height)
+                self.chain.get_block_header_by_height(height)
             }
             BlockReference::BlockId(BlockId::Hash(hash)) => self.chain.get_block_header(&hash),
             BlockReference::SyncCheckpoint(sync_checkpoint) => {

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -2029,7 +2029,7 @@ fn test_sync_hash_validity() {
         env.produce_block(0, i);
     }
     for i in 0..19 {
-        let block_hash = *env.clients[0].chain.get_header_by_height(i).unwrap().hash();
+        let block_hash = *env.clients[0].chain.get_block_header_by_height(i).unwrap().hash();
         let res = env.clients[0].chain.check_sync_hash_validity(&block_hash);
         println!("height {:?} -> {:?}", i, res);
         if i == 11 || i == 16 {


### PR DESCRIPTION
Some of the functions returning BlockHeader are named get_header while
others are called get_block_header.  Remove that inconsistency by
renaming the former function to follow the format of the latter.

While I would honestly prefer ‘get_header’, doing the renaming in the
other direction results in a larger diff so I’ve settled on more
verbose ‘get_block_header’:

     14 files changed, 139 insertions(+), 155 deletions(-)

This was done with:

    sed -i s/get_header/get_block_header/g -- $(git grep -l get_header)