### PR TITLE
chain: normalise ‘_by_hash’ and ‘_by_height’ naming

### DIFF
--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1387,7 +1387,7 @@ impl ClientActor {
             Err(e) => match e {
                 near_chain::Error::Orphan => {
                     if !self.client.chain.is_orphan(&prev_hash) {
-                        self.request_block_by_hash(prev_hash, peer_id)
+                        self.request_block(prev_hash, peer_id)
                     }
                 }
                 // missing chunks are already handled in self.client.process_block()
@@ -1419,7 +1419,7 @@ impl ClientActor {
         }
     }
 
-    fn request_block_by_hash(&mut self, hash: CryptoHash, peer_id: PeerId) {
+    fn request_block(&mut self, hash: CryptoHash, peer_id: PeerId) {
         match self.client.chain.block_exists(&hash) {
             Ok(false) => {
                 self.network_adapter.do_send(PeerManagerMessageRequest::NetworkRequests(
@@ -1708,7 +1708,7 @@ impl ClientActor {
                                     for hash in
                                         vec![*header.prev_hash(), *header.hash()].into_iter()
                                     {
-                                        self.request_block_by_hash(hash, id.clone());
+                                        self.request_block(hash, id.clone());
                                     }
                                 }
                             }

--- a/chain/indexer/src/streamer/fetchers.rs
+++ b/chain/indexer/src/streamer/fetchers.rs
@@ -47,7 +47,7 @@ pub(crate) async fn fetch_block_by_height(
 }
 
 /// Fetches specific block by it's hash
-pub(crate) async fn fetch_block_by_hash(
+pub(crate) async fn fetch_block(
     client: &Addr<near_client::ViewClientActor>,
     hash: CryptoHash,
 ) -> Result<views::BlockView, FailedToFetchData> {

--- a/chain/indexer/src/streamer/mod.rs
+++ b/chain/indexer/src/streamer/mod.rs
@@ -19,8 +19,8 @@ use crate::{AwaitForNodeSyncedEnum, IndexerConfig};
 
 use self::errors::FailedToFetchData;
 use self::fetchers::{
-    fetch_block_by_hash, fetch_block_by_height, fetch_block_chunks, fetch_latest_block,
-    fetch_outcomes, fetch_state_changes, fetch_status,
+    fetch_block, fetch_block_by_height, fetch_block_chunks, fetch_latest_block, fetch_outcomes,
+    fetch_state_changes, fetch_status,
 };
 use self::utils::convert_transactions_sir_into_local_receipts;
 use crate::streamer::fetchers::fetch_protocol_config;
@@ -155,7 +155,7 @@ async fn build_streamer_message(
                     if prev_block_tried > 1000 {
                         panic!("Failed to find local receipt in 1000 prev blocks");
                     }
-                    let prev_block = match fetch_block_by_hash(&client, prev_block_hash).await {
+                    let prev_block = match fetch_block(&client, prev_block_hash).await {
                         Ok(block) => block,
                         Err(err) => panic!("Unable to get previous block: {:?}", err),
                     };

--- a/chain/indexer/src/streamer/utils.rs
+++ b/chain/indexer/src/streamer/utils.rs
@@ -5,7 +5,7 @@ use near_primitives::views;
 use node_runtime::config::tx_cost;
 
 use super::errors::FailedToFetchData;
-use super::fetchers::fetch_block_by_hash;
+use super::fetchers::fetch_block;
 
 pub(crate) async fn convert_transactions_sir_into_local_receipts(
     client: &Addr<near_client::ViewClientActor>,
@@ -16,7 +16,7 @@ pub(crate) async fn convert_transactions_sir_into_local_receipts(
     if txs.is_empty() {
         return Ok(vec![]);
     }
-    let prev_block = fetch_block_by_hash(&client, block.header.prev_hash).await?;
+    let prev_block = fetch_block(&client, block.header.prev_hash).await?;
     let prev_block_gas_price = prev_block.header.gas_price;
 
     let local_receipts: Vec<views::ReceiptView> =

--- a/integration-tests/src/tests/standard_cases/mod.rs
+++ b/integration-tests/src/tests/standard_cases/mod.rs
@@ -855,7 +855,7 @@ fn assert_access_key(
     user: &dyn User,
 ) {
     let mut key = access_key.clone();
-    let block = user.get_block_by_hash(result.transaction_outcome.block_hash);
+    let block = user.get_block(result.transaction_outcome.block_hash);
     if let Some(b) = block {
         key.nonce = (b.header.height - 1) * AccessKey::ACCESS_KEY_NONCE_RANGE_MULTIPLIER;
     }

--- a/integration-tests/src/tests/test_tps_regression.rs
+++ b/integration-tests/src/tests/test_tps_regression.rs
@@ -109,7 +109,7 @@ fn run_multiple_nodes(
                 if let Some(new_ind) = node.read().unwrap().user().get_best_height() {
                     if new_ind > prev_ind {
                         let blocks = ((prev_ind + 1)..=new_ind)
-                            .filter_map(|idx| node.read().unwrap().user().get_block(idx))
+                            .filter_map(|idx| node.read().unwrap().user().get_block_by_height(idx))
                             .collect::<Vec<_>>();
                         for b in &blocks {
                             let tx_num = b.chunks.iter().fold(0, |acc, chunk| {
@@ -118,7 +118,7 @@ fn run_multiple_nodes(
                                         .read()
                                         .unwrap()
                                         .user()
-                                        .get_chunk(b.header.height, chunk.shard_id)
+                                        .get_chunk_by_height(b.header.height, chunk.shard_id)
                                         .unwrap();
                                     acc + chunk.transactions.len()
                                 } else {

--- a/integration-tests/src/user/mod.rs
+++ b/integration-tests/src/user/mod.rs
@@ -61,11 +61,11 @@ pub trait User {
 
     fn get_best_block_hash(&self) -> Option<CryptoHash>;
 
-    fn get_block(&self, height: BlockHeight) -> Option<BlockView>;
+    fn get_block_by_height(&self, height: BlockHeight) -> Option<BlockView>;
 
-    fn get_block_by_hash(&self, block_hash: CryptoHash) -> Option<BlockView>;
+    fn get_block(&self, block_hash: CryptoHash) -> Option<BlockView>;
 
-    fn get_chunk(&self, height: BlockHeight, shard_id: ShardId) -> Option<ChunkView>;
+    fn get_chunk_by_height(&self, height: BlockHeight, shard_id: ShardId) -> Option<ChunkView>;
 
     fn get_transaction_result(&self, hash: &CryptoHash) -> ExecutionOutcomeView;
 

--- a/integration-tests/src/user/rpc_user.rs
+++ b/integration-tests/src/user/rpc_user.rs
@@ -149,17 +149,17 @@ impl User for RpcUser {
         self.get_status().map(|status| status.sync_info.latest_block_hash)
     }
 
-    fn get_block(&self, height: BlockHeight) -> Option<BlockView> {
+    fn get_block_by_height(&self, height: BlockHeight) -> Option<BlockView> {
         self.actix(move |client| client.block(BlockReference::BlockId(BlockId::Height(height))))
             .ok()
     }
 
-    fn get_block_by_hash(&self, block_hash: CryptoHash) -> Option<BlockView> {
+    fn get_block(&self, block_hash: CryptoHash) -> Option<BlockView> {
         self.actix(move |client| client.block(BlockReference::BlockId(BlockId::Hash(block_hash))))
             .ok()
     }
 
-    fn get_chunk(&self, height: BlockHeight, shard_id: ShardId) -> Option<ChunkView> {
+    fn get_chunk_by_height(&self, height: BlockHeight, shard_id: ShardId) -> Option<ChunkView> {
         self.actix(move |client| {
             client.chunk(ChunkId::BlockShardId(BlockId::Height(height), shard_id))
         })

--- a/integration-tests/src/user/runtime_user.rs
+++ b/integration-tests/src/user/runtime_user.rs
@@ -300,15 +300,15 @@ impl User for RuntimeUser {
         Some(CryptoHash::default())
     }
 
-    fn get_block(&self, _height: u64) -> Option<BlockView> {
+    fn get_block_by_height(&self, _height: u64) -> Option<BlockView> {
         unimplemented!("get_block should not be implemented for RuntimeUser");
     }
 
-    fn get_block_by_hash(&self, _block_hash: CryptoHash) -> Option<BlockView> {
+    fn get_block(&self, _block_hash: CryptoHash) -> Option<BlockView> {
         None
     }
 
-    fn get_chunk(&self, _height: u64, _shard_id: u64) -> Option<ChunkView> {
+    fn get_chunk_by_height(&self, _height: u64, _shard_id: u64) -> Option<ChunkView> {
         unimplemented!("get_chunk should not be implemented for RuntimeUser");
     }
 


### PR DESCRIPTION
The code base isn’t fully consistent in how functions getting data by
their hash or height are named.  For example, in different strucs and
traits we have examples of ‘get_block’ (some taking hash while others
taking height argument), ‘get_block_by_hash’ and ‘get_block_by_height’
methods.

Normalise the naming such that functions fetching data by hash don’t
have a suffix (e.g. ‘get_block’ or ‘get_chunk’) while functions
fetching data by height have it (e.g. ‘get_block_by_height’).

This was made with just a little bit of grepping and sedding.
It’s possible that there still remain functions which don’t follow
convention suggested here.