### PR TITLE
fix: remove mistaken write-once assert from CompiledContractCache

### DIFF
--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -641,7 +641,11 @@ impl StoreCompiledContractCache {
 impl CompiledContractCache for StoreCompiledContractCache {
     fn put(&self, key: &CryptoHash, value: Vec<u8>) -> io::Result<()> {
         let mut update = crate::db::DBTransaction::new();
-        update.insert(DBCol::CachedContractCode, key.as_ref().to_vec(), value);
+        // We intentionally use `.set` here, rather than `.insert`. We don't yet
+        // guarantee deterministic compilation, so, if we happen to compile the
+        // same contract concurrently on two threads, the `value`s might differ,
+        // but this doesn't matter.
+        update.set(DBCol::CachedContractCode, key.as_ref().to_vec(), value);
         self.db.write(update)
     }
 


### PR DESCRIPTION
This `.insert` was causing some test failures on CI, like the following one: 

https://buildkite.com/nearprotocol/nearcore/builds/18816#01828244-167b-42e9-aae2-2884f8daa9f1/94-831

