### PR TITLE
chain: avoid fetching header in ViewClientActor::get_block_hash_by_finality

### DIFF
--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -169,11 +169,10 @@ impl ViewClientActor {
         &self,
         finality: &Finality,
     ) -> Result<CryptoHash, near_chain::Error> {
-        let head_header = self.chain.head_header()?;
         match finality {
-            Finality::None => Ok(*head_header.hash()),
-            Finality::DoomSlug => Ok(*head_header.last_ds_final_block()),
-            Finality::Final => self.chain.final_head().map(|t| t.last_block_hash),
+            Finality::None => Ok(self.chain.head()?.last_block_hash),
+            Finality::DoomSlug => Ok(*self.chain.head_header()?.last_ds_final_block()),
+            Finality::Final => Ok(self.chain.final_head()?.last_block_hash),
         }
     }
 


### PR DESCRIPTION
`chain.head_header()?.hash()` translates roughly into
`chain.get_block_header(chain.head()?.last_block_hash)?.hash()`
and that’s of course just a convoluted way of writing
`chain.head()?.last_block_hash`.

Change the Finality::None case so that fetching of the block header
does not happen.