### PR TITLE
Simplify DBCol’s Display implementation and prefer it over Debug

### DIFF
--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -3315,7 +3315,7 @@ mod tests {
             DBCol::ChunkExtra,
         ];
         for col in DBCol::iter() {
-            println!("current column is {:?}", col);
+            println!("current column is {col}");
             if gced_cols.contains(&col) {
                 // only genesis block includes new chunk.
                 let count = if col == DBCol::OutcomeIds { Some(1) } else { Some(8) };

--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -119,10 +119,7 @@ impl StoreValidator {
         for col in DBCol::iter() {
             if col.is_gc() && self.inner.gc_count[col] == 0 {
                 if col.is_gc_optional() {
-                    res.push((
-                        format!("{col} (skipping is acceptable)"),
-                        self.inner.gc_count[col],
-                    ))
+                    res.push((format!("{col} (skipping is acceptable)"), self.inner.gc_count[col]))
                 } else {
                     res.push((col.to_string(), self.inner.gc_count[col]))
                 }

--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -30,11 +30,6 @@ use near_primitives::time::Clock;
 
 mod validate;
 
-fn to_string<T: std::fmt::Debug>(v: &T) -> String {
-    format!("{:?}", v)
-}
-
-#[derive(Debug)]
 pub struct StoreValidatorCache {
     head: BlockHeight,
     header_head: BlockHeight,
@@ -125,11 +120,11 @@ impl StoreValidator {
             if col.is_gc() && self.inner.gc_count[col] == 0 {
                 if col.is_gc_optional() {
                     res.push((
-                        to_string(&col) + " (skipping is acceptable)",
+                        format!("{col} (skipping is acceptable)"),
                         self.inner.gc_count[col],
                     ))
                 } else {
-                    res.push((to_string(&col), self.inner.gc_count[col]))
+                    res.push((col.to_string(), self.inner.gc_count[col]))
                 }
             }
         }
@@ -143,7 +138,7 @@ impl StoreValidator {
         self.tests
     }
     fn process_error<K: std::fmt::Debug>(&mut self, err: StoreValidatorError, key: K, col: DBCol) {
-        self.errors.push(ErrorMessage { key: to_string(&key), col: to_string(&col), err })
+        self.errors.push(ErrorMessage { key: format!("{key:?}"), col: col.to_string(), err })
     }
     fn validate_col(&mut self, col: DBCol) -> Result<(), StoreValidatorError> {
         for item in self.store.clone().iter_raw_bytes(col) {

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -5,9 +5,9 @@ use std::fmt;
 /// You can think about our storage as 2-dimensional table (with key and column as indexes/coordinates).
 #[derive(
     PartialEq,
-    Debug,
     Copy,
     Clone,
+    Debug,
     Hash,
     Eq,
     BorshDeserialize,
@@ -359,62 +359,8 @@ impl DBCol {
 }
 
 impl fmt::Display for DBCol {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let desc = match self {
-            Self::DbVersion => "db version",
-            Self::BlockMisc => "miscellaneous block data",
-            Self::Block => "block data",
-            Self::BlockHeader => "block header data",
-            Self::BlockHeight => "block height",
-            Self::State => "blockchain state",
-            Self::ChunkExtra => "extra information of trunk",
-            Self::TransactionResult => "transaction results",
-            Self::OutgoingReceipts => "outgoing receipts",
-            Self::IncomingReceipts => "incoming receipts",
-            Self::Peers => "peer information",
-            Self::EpochInfo => "epoch information",
-            Self::BlockInfo => "block information",
-            Self::Chunks => "chunks",
-            Self::PartialChunks => "partial chunks",
-            Self::BlocksToCatchup => "blocks need to apply chunks",
-            Self::StateDlInfos => "blocks downloading",
-            Self::ChallengedBlocks => "challenged blocks",
-            Self::StateHeaders => "state headers",
-            Self::InvalidChunks => "invalid chunks",
-            Self::BlockExtra => "extra block information",
-            Self::BlockPerHeight => "hash of block per height",
-            Self::StateParts => "state parts",
-            Self::EpochStart => "epoch start",
-            Self::AccountAnnouncements => "account announcements",
-            Self::NextBlockHashes => "next block hash",
-            Self::EpochLightClientBlocks => "epoch light client block",
-            Self::ReceiptIdToShardId => "receipt id to shard id",
-            Self::_NextBlockWithNewChunk => "next block with new chunk (deprecated)",
-            Self::_LastBlockWithNewChunk => "last block with new chunk (deprecated)",
-            Self::PeerComponent => "peer components",
-            Self::ComponentEdges => "component edges",
-            Self::LastComponentNonce => "last component nonce",
-            Self::Transactions => "transactions",
-            Self::ChunkPerHeightShard => "hash of chunk per height and shard_id",
-            Self::StateChanges => "key value changes",
-            Self::BlockRefCount => "refcount per block",
-            Self::TrieChanges => "trie changes",
-            Self::BlockMerkleTree => "block merkle tree",
-            Self::ChunkHashesByHeight => "chunk hashes indexed by height_created",
-            Self::BlockOrdinal => "block ordinal",
-            Self::GCCount => "gc count",
-            Self::OutcomeIds => "outcome ids",
-            Self::_TransactionRefCount => "refcount per transaction (deprecated)",
-            Self::ProcessedBlockHeights => "processed block heights",
-            Self::Receipts => "receipts",
-            Self::CachedContractCode => "cached code",
-            Self::EpochValidatorInfo => "epoch validator info",
-            Self::HeaderHashesByHeight => "header hashes indexed by their height",
-            Self::StateChangesForSplitStates => "state changes indexed by block hash and shard id",
-            #[cfg(feature = "protocol_feature_flat_state")]
-            Self::FlatState => "flat state",
-        };
-        write!(f, "{}", desc)
+    fn fmt(&self, fmtr: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmtr.write_str(<&str>::from(self))
     }
 }
 

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -359,8 +359,8 @@ impl DBCol {
 }
 
 impl fmt::Display for DBCol {
-    fn fmt(&self, fmtr: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmtr.write_str(<&str>::from(self))
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
     }
 }
 

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -144,7 +144,7 @@ key: {key:?}
     )
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum StatsValue {
     Count(i64),
     Sum(i64),

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -144,7 +144,7 @@ new value: {value:?}
     )
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum StatsValue {
     Count(i64),
     Sum(i64),

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -89,7 +89,7 @@ impl Store {
         tracing::trace!(
             target: "store",
             db_op = "get",
-            col = ?column,
+            col = %column,
             key = %to_base(key),
             size = value.as_ref().map(Vec::len)
         );
@@ -215,7 +215,7 @@ impl StoreUpdate {
     /// It is a programming error if `insert` overwrites an existing, different
     /// value. Use it for insert-only columns.
     pub fn insert(&mut self, column: DBCol, key: &[u8], value: &[u8]) {
-        assert!(column.is_insert_only(), "can't insert: {column:?}");
+        assert!(column.is_insert_only(), "can't insert: {column}");
         self.transaction.insert(column, key.to_vec(), value.to_vec())
     }
 
@@ -225,7 +225,7 @@ impl StoreUpdate {
         key: &[u8],
         value: &T,
     ) -> io::Result<()> {
-        assert!(column.is_insert_only(), "can't insert_ser: {column:?}");
+        assert!(column.is_insert_only(), "can't insert_ser: {column}");
         let data = value.try_to_vec()?;
         self.insert(column, key, &data);
         Ok(())
@@ -247,7 +247,7 @@ impl StoreUpdate {
         data: &[u8],
         increase: std::num::NonZeroU32,
     ) {
-        assert!(column.is_rc(), "can't update refcount: {column:?}");
+        assert!(column.is_rc(), "can't update refcount: {column}");
         let value = refcount::add_positive_refcount(data, increase);
         self.transaction.update_refcount(column, key.to_vec(), value);
     }
@@ -270,7 +270,7 @@ impl StoreUpdate {
         key: &[u8],
         decrease: std::num::NonZeroU32,
     ) {
-        assert!(column.is_rc(), "can't update refcount: {column:?}");
+        assert!(column.is_rc(), "can't update refcount: {column}");
         let value = refcount::encode_negative_refcount(decrease);
         self.transaction.update_refcount(column, key.to_vec(), value)
     }
@@ -289,7 +289,7 @@ impl StoreUpdate {
     /// Must not be used for reference-counted columns; use
     /// ['Self::increment_refcount'] or [`Self::decrement_refcount`] instead.
     pub fn set(&mut self, column: DBCol, key: &[u8], value: &[u8]) {
-        assert!(!(column.is_rc() || column.is_insert_only()), "can't set: {column:?}");
+        assert!(!(column.is_rc() || column.is_insert_only()), "can't set: {column}");
         self.transaction.set(column, key.to_vec(), value.to_vec())
     }
 
@@ -303,7 +303,7 @@ impl StoreUpdate {
         key: &[u8],
         value: &T,
     ) -> io::Result<()> {
-        assert!(!(column.is_rc() || column.is_insert_only()), "can't set_ser: {column:?}");
+        assert!(!(column.is_rc() || column.is_insert_only()), "can't set_ser: {column}");
         let data = value.try_to_vec()?;
         self.set(column, key, &data);
         Ok(())
@@ -324,7 +324,7 @@ impl StoreUpdate {
     /// Must not be used for reference-counted columns; use
     /// ['Self::increment_refcount'] or [`Self::decrement_refcount`] instead.
     pub fn delete(&mut self, column: DBCol, key: &[u8]) {
-        assert!(!column.is_rc(), "can't delete: {column:?}");
+        assert!(!column.is_rc(), "can't delete: {column}");
         self.transaction.delete(column, key.to_vec());
     }
 
@@ -387,19 +387,19 @@ impl StoreUpdate {
         for op in &self.transaction.ops {
             match op {
                 DBOp::Insert { col, key, value } => {
-                    tracing::trace!(target: "store", db_op = "insert", col = ?col, key =  %to_base(key), size = value.len())
+                    tracing::trace!(target: "store", db_op = "insert", col = %col, key =  %to_base(key), size = value.len())
                 }
                 DBOp::Set { col, key, value } => {
-                    tracing::trace!(target: "store", db_op = "set", col = ?col, key =  %to_base(key), size = value.len())
+                    tracing::trace!(target: "store", db_op = "set", col = %col, key =  %to_base(key), size = value.len())
                 }
                 DBOp::UpdateRefcount { col, key, value } => {
-                    tracing::trace!(target: "store", db_op = "update_rc", col = ?col, key =  %to_base(key), size = value.len())
+                    tracing::trace!(target: "store", db_op = "update_rc", col = %col, key =  %to_base(key), size = value.len())
                 }
                 DBOp::Delete { col, key } => {
-                    tracing::trace!(target: "store", db_op = "delete", col = ?col, key =  %to_base(key))
+                    tracing::trace!(target: "store", db_op = "delete", col = %col, key =  %to_base(key))
                 }
                 DBOp::DeleteAll { col } => {
-                    tracing::trace!(target: "store", db_op = "delete_all", col = ?col)
+                    tracing::trace!(target: "store", db_op = "delete_all", col = %col)
                 }
             }
         }
@@ -412,13 +412,13 @@ impl fmt::Debug for StoreUpdate {
         writeln!(f, "Store Update {{")?;
         for op in self.transaction.ops.iter() {
             match op {
-                DBOp::Insert { col, key, .. } => writeln!(f, "  + {:?} {}", col, to_base(key))?,
-                DBOp::Set { col, key, .. } => writeln!(f, "  * {:?} {}", col, to_base(key))?,
+                DBOp::Insert { col, key, .. } => writeln!(f, "  + {col} {}", to_base(key))?,
+                DBOp::Set { col, key, .. } => writeln!(f, "  = {col} {}", to_base(key))?,
                 DBOp::UpdateRefcount { col, key, .. } => {
-                    writeln!(f, "  +- {:?} {}", col, to_base(key))?
+                    writeln!(f, "  ± {col} {}", to_base(key))?
                 }
-                DBOp::Delete { col, key } => writeln!(f, "  - {:?} {}", col, to_base(key))?,
-                DBOp::DeleteAll { col } => writeln!(f, "  delete all {:?}", col)?,
+                DBOp::Delete { col, key } => writeln!(f, "  - {col} {}", to_base(key))?,
+                DBOp::DeleteAll { col } => writeln!(f, "  - {col} (all)")?,
             }
         }
         writeln!(f, "}}")

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -414,9 +414,7 @@ impl fmt::Debug for StoreUpdate {
             match op {
                 DBOp::Insert { col, key, .. } => writeln!(f, "  + {col} {}", to_base(key))?,
                 DBOp::Set { col, key, .. } => writeln!(f, "  = {col} {}", to_base(key))?,
-                DBOp::UpdateRefcount { col, key, .. } => {
-                    writeln!(f, "  ± {col} {}", to_base(key))?
-                }
+                DBOp::UpdateRefcount { col, key, .. } => writeln!(f, "  ± {col} {}", to_base(key))?,
                 DBOp::Delete { col, key } => writeln!(f, "  - {col} {}", to_base(key))?,
                 DBOp::DeleteAll { col } => writeln!(f, "  - {col} (all)")?,
             }

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -445,7 +445,7 @@ pub fn recompress_storage(home_dir: &Path, opts: RecompressOpts) -> anyhow::Resu
         let mut batch_written: u64 = 0;
         let mut count_keys: u64 = 0;
         for item in src_store.iter_raw_bytes(column) {
-            let (key, value) = item.with_context(|| format!("scanning column {column:?}"))?;
+            let (key, value) = item.with_context(|| format!("scanning column {column}"))?;
             store_update.set_raw_bytes(column, &key, &value);
             total_written += value.len() as u64;
             batch_written += value.len() as u64;


### PR DESCRIPTION
I’d argue that the current DBCol’s Display implementation offers no
value.  I cannot think of a situation in which we’d rather see the
description of the column provided by the implementation rather than
the variant name.

If one sees the name of the column in logs or some other places, it’s
trivial to start grepping the source code for uses of that column.
When the description is shown it first need to be transformed back
into the variant name to actually be useful.

And it’s not like the description explains anything.  For example,
‘epoch information’ is no more clear than EpochInfo.  In a few cases,
things like ‘hash of chunk per height and shard_id’ are easier to read
than ChunkPerHeightShard but I’d still question if this is enough to
justify existence of this custom implementation.

In this change I suggest 1) replacing Display implementation by one
which simply outputs the variant name and 2) converting existing code
to prefer using Display rather than Debug formatting for columns.

With that we get rid of 50 lines of code, will never again need to
look at the Display implementation (e.g. when adding or removing
columns) and make it simpler to format columns with plain `{col}`.

Note that the Debug derive needs to remain as it is (indirectly) used
in a couple of asserts and tests.
