### PR TITLE
view_client: introduce get_block_*_by_reference methods

### DIFF
--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -45,7 +45,7 @@ use near_primitives::syncing::{
 };
 use near_primitives::types::{
     AccountId, BlockId, BlockReference, EpochId, EpochReference, Finality, MaybeBlockId, ShardId,
-    TransactionOrReceiptId,
+    SyncCheckpoint, TransactionOrReceiptId,
 };
 use near_primitives::views::validator_stake_view::ValidatorStakeView;
 use near_primitives::views::{
@@ -176,59 +176,87 @@ impl ViewClientActor {
         }
     }
 
-    fn get_block_hash_by_sync_checkpoint(
-        &mut self,
-        synchronization_checkpoint: &near_primitives::types::SyncCheckpoint,
-    ) -> Result<Option<CryptoHash>, near_chain::Error> {
-        use near_primitives::types::SyncCheckpoint;
+    /// Returns block header by reference.
+    ///
+    /// Returns `None` if the reference is a `SyncCheckpoint::EarliestAvailable`
+    /// reference and no such block exists yet.  This is typically translated by
+    /// the caller into some form of ‘no sync block’ higher-level error.
+    fn get_block_header_by_reference(
+        &self,
+        reference: &BlockReference,
+    ) -> Result<Option<BlockHeader>, near_chain::Error> {
+        match reference {
+            BlockReference::BlockId(BlockId::Height(block_height)) => {
+                self.chain.get_block_header_by_height(*block_height).map(Some)
+            }
+            BlockReference::BlockId(BlockId::Hash(block_hash)) => {
+                self.chain.get_block_header(block_hash).map(Some)
+            }
+            BlockReference::Finality(finality) => self
+                .get_block_hash_by_finality(finality)
+                .and_then(|block_hash| self.chain.get_block_header(&block_hash))
+                .map(Some),
+            BlockReference::SyncCheckpoint(SyncCheckpoint::Genesis) => {
+                Ok(Some(self.chain.genesis().clone()))
+            }
+            BlockReference::SyncCheckpoint(SyncCheckpoint::EarliestAvailable) => {
+                let block_hash = match self.chain.get_earliest_block_hash() {
+                    Ok(Some(block_hash)) => block_hash,
+                    Ok(None) => return Ok(None),
+                    Err(err) => return Err(err),
+                };
+                self.chain.get_block_header(&block_hash).map(Some)
+            }
+        }
+    }
 
-        match synchronization_checkpoint {
-            SyncCheckpoint::Genesis => Ok(Some(self.chain.genesis().hash().clone())),
-            SyncCheckpoint::EarliestAvailable => self.chain.get_earliest_block_hash(),
+    /// Returns block by reference.
+    ///
+    /// Returns `None` if the reference is a `SyncCheckpoint::EarliestAvailable`
+    /// reference and no such block exists yet.  This is typically translated by
+    /// the caller into some form of ‘no sync block’ higher-level error.
+    fn get_block_by_reference(
+        &self,
+        reference: &BlockReference,
+    ) -> Result<Option<Block>, near_chain::Error> {
+        match reference {
+            BlockReference::BlockId(BlockId::Height(block_height)) => {
+                self.chain.get_block_by_height(*block_height).map(Some)
+            }
+            BlockReference::BlockId(BlockId::Hash(block_hash)) => {
+                self.chain.get_block(block_hash).map(Some)
+            }
+            BlockReference::Finality(finality) => self
+                .get_block_hash_by_finality(finality)
+                .and_then(|block_hash| self.chain.get_block(&block_hash))
+                .map(Some),
+            BlockReference::SyncCheckpoint(SyncCheckpoint::Genesis) => {
+                Ok(Some(self.chain.genesis_block().clone()))
+            }
+            BlockReference::SyncCheckpoint(SyncCheckpoint::EarliestAvailable) => {
+                let block_hash = match self.chain.get_earliest_block_hash() {
+                    Ok(Some(block_hash)) => block_hash,
+                    Ok(None) => return Ok(None),
+                    Err(err) => return Err(err),
+                };
+                self.chain.get_block(&block_hash).map(Some)
+            }
         }
     }
 
     fn handle_query(&mut self, msg: Query) -> Result<QueryResponse, QueryError> {
-        let header = match msg.block_reference {
-            BlockReference::BlockId(BlockId::Height(block_height)) => {
-                self.chain.get_block_header_by_height(block_height)
+        let header = self.get_block_header_by_reference(&msg.block_reference);
+        let header = match header {
+            Ok(Some(header)) => Ok(header),
+            Ok(None) => Err(QueryError::NoSyncedBlocks),
+            Err(near_chain::near_chain_primitives::Error::DBNotFoundErr(_)) => {
+                Err(QueryError::UnknownBlock { block_reference: msg.block_reference })
             }
-            BlockReference::BlockId(BlockId::Hash(block_hash)) => {
-                self.chain.get_block_header(&block_hash)
+            Err(near_chain::near_chain_primitives::Error::IOErr(err)) => {
+                Err(QueryError::InternalError { error_message: err.to_string() })
             }
-            BlockReference::Finality(ref finality) => self
-                .get_block_hash_by_finality(finality)
-                .and_then(|block_hash| self.chain.get_block_header(&block_hash)),
-            BlockReference::SyncCheckpoint(ref synchronization_checkpoint) => {
-                if let Some(block_hash) = self
-                    .get_block_hash_by_sync_checkpoint(synchronization_checkpoint)
-                    .map_err(|err| match err {
-                        near_chain::near_chain_primitives::Error::DBNotFoundErr(_) => {
-                            QueryError::UnknownBlock {
-                                block_reference: msg.block_reference.clone(),
-                            }
-                        }
-                        near_chain::near_chain_primitives::Error::IOErr(error) => {
-                            QueryError::InternalError { error_message: error.to_string() }
-                        }
-                        _ => QueryError::Unreachable { error_message: err.to_string() },
-                    })?
-                {
-                    self.chain.get_block_header(&block_hash)
-                } else {
-                    return Err(QueryError::NoSyncedBlocks);
-                }
-            }
-        };
-        let header = header.map_err(|err| match err {
-            near_chain::near_chain_primitives::Error::DBNotFoundErr(_) => {
-                QueryError::UnknownBlock { block_reference: msg.block_reference.clone() }
-            }
-            near_chain::near_chain_primitives::Error::IOErr(error) => {
-                QueryError::InternalError { error_message: error.to_string() }
-            }
-            _ => QueryError::Unreachable { error_message: err.to_string() },
-        })?;
+            Err(err) => Err(QueryError::Unreachable { error_message: err.to_string() }),
+        }?;
 
         let account_id = match &msg.request {
             QueryRequest::ViewAccount { account_id, .. } => account_id,
@@ -519,30 +547,13 @@ impl Handler<GetBlock> for ViewClientActor {
 
     #[perf]
     fn handle(&mut self, msg: GetBlock, _: &mut Self::Context) -> Self::Result {
-        let block = match msg.0 {
-            BlockReference::Finality(finality) => {
-                let block_hash = self.get_block_hash_by_finality(&finality)?;
-                self.chain.get_block(&block_hash)
-            }
-            BlockReference::BlockId(BlockId::Height(height)) => {
-                self.chain.get_block_by_height(height)
-            }
-            BlockReference::BlockId(BlockId::Hash(hash)) => self.chain.get_block(&hash),
-            BlockReference::SyncCheckpoint(sync_checkpoint) => {
-                if let Some(block_hash) =
-                    self.get_block_hash_by_sync_checkpoint(&sync_checkpoint)?
-                {
-                    self.chain.get_block(&block_hash)
-                } else {
-                    return Err(GetBlockError::NotSyncedYet);
-                }
-            }
-        }?;
-
+        let block = match self.get_block_by_reference(&msg.0)? {
+            None => return Err(GetBlockError::NotSyncedYet),
+            Some(block) => block,
+        };
         let block_author = self
             .runtime_adapter
             .get_block_producer(block.header().epoch_id(), block.header().height())?;
-
         Ok(BlockView::from_author_block(block_author, block))
     }
 }
@@ -946,29 +957,13 @@ impl Handler<GetProtocolConfig> for ViewClientActor {
 
     #[perf]
     fn handle(&mut self, msg: GetProtocolConfig, _: &mut Self::Context) -> Self::Result {
-        let block_header = match msg.0 {
-            BlockReference::Finality(finality) => {
-                let block_hash = self.get_block_hash_by_finality(&finality)?;
-                self.chain.get_block_header(&block_hash)
+        let header = match self.get_block_header_by_reference(&msg.0)? {
+            None => {
+                return Err(GetProtocolConfigError::UnknownBlock("EarliestAvailable".to_string()))
             }
-            BlockReference::BlockId(BlockId::Height(height)) => {
-                self.chain.get_block_header_by_height(height)
-            }
-            BlockReference::BlockId(BlockId::Hash(hash)) => self.chain.get_block_header(&hash),
-            BlockReference::SyncCheckpoint(sync_checkpoint) => {
-                if let Some(block_hash) =
-                    self.get_block_hash_by_sync_checkpoint(&sync_checkpoint)?
-                {
-                    self.chain.get_block_header(&block_hash)
-                } else {
-                    return Err(GetProtocolConfigError::UnknownBlock(format!(
-                        "{:?}",
-                        sync_checkpoint
-                    )));
-                }
-            }
-        }?;
-        let config = self.runtime_adapter.get_protocol_config(block_header.epoch_id())?;
+            Some(header) => header,
+        };
+        let config = self.runtime_adapter.get_protocol_config(header.epoch_id())?;
         Ok(config.into())
     }
 }


### PR DESCRIPTION
Add ViewClientActor::get_block_header_by_reference and
ViewClientActor::get_block_by_reference methods which take
BlockReference as argument and return corresponding block or
header.

This refactoring does two things.  Firstly, both handle_query and code
for GetProtocolConfig needed to get block header by reference and used
nearly the same code to do it.  Adding get_block_header_by_reference
reduces code duplication.

Secondly, code for getting block and header by reference look almost
identical.  Putting those two new methods together makes it more
apparent and helps keep the code in sync.

While doing that, get rid of get_block_hash_by_sync_checkpoint method
and inline it instead.  This has a minor side effect of not having to
fetch genesis from storage but copy from Chain can be used instead.
