### PR TITLE
chain: cleanup ReceiptOutcomeRequest et al.

### DIFF
--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -1012,8 +1012,7 @@ pub fn setup_mock_all_validators(
                         NetworkRequests::ForwardTx(_, _)
                         | NetworkRequests::BanPeer { .. }
                         | NetworkRequests::TxStatus(_, _, _)
-                        | NetworkRequests::Challenge(_)
-                        | NetworkRequests::ReceiptOutComeRequest(_, _) => {}
+                        | NetworkRequests::Challenge(_) => {}
                     };
                 }
                 resp

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -44,15 +44,14 @@ use near_primitives::syncing::{
     ShardStateSyncResponseV2,
 };
 use near_primitives::types::{
-    AccountId, BlockId, BlockReference, EpochId, EpochReference, Finality, MaybeBlockId, ShardId,
+    AccountId, BlockId, BlockReference, EpochReference, Finality, MaybeBlockId, ShardId,
     TransactionOrReceiptId,
 };
 use near_primitives::views::validator_stake_view::ValidatorStakeView;
 use near_primitives::views::{
     BlockView, ChunkView, EpochValidatorInfo, ExecutionOutcomeWithIdView,
-    FinalExecutionOutcomeView, FinalExecutionOutcomeViewEnum, FinalExecutionStatus, GasPriceView,
-    LightClientBlockView, QueryRequest, QueryResponse, ReceiptView, StateChangesKindsView,
-    StateChangesView,
+    FinalExecutionOutcomeView, FinalExecutionOutcomeViewEnum, GasPriceView, LightClientBlockView,
+    QueryRequest, QueryResponse, ReceiptView, StateChangesKindsView, StateChangesView,
 };
 
 use crate::{
@@ -330,34 +329,6 @@ impl ViewClientActor {
         }
     }
 
-    fn request_receipt_outcome(
-        &mut self,
-        receipt_id: CryptoHash,
-        epoch_id: &EpochId,
-        last_block_hash: &CryptoHash,
-    ) -> Result<(), TxStatusError> {
-        if let Ok(dst_shard_id) = self.chain.get_shard_id_for_receipt_id(&receipt_id) {
-            let shard_uid = self
-                .runtime_adapter
-                .shard_id_to_uid(dst_shard_id, epoch_id)
-                .map_err(|err| TxStatusError::InternalError(err.to_string()))?;
-            if self.chain.get_chunk_extra(last_block_hash, &shard_uid).is_err() {
-                let mut request_manager = self.request_manager.write().expect(POISONED_LOCK_ERR);
-                if Self::need_request(receipt_id, &mut request_manager.receipt_outcome_requests) {
-                    let validator = self
-                        .chain
-                        .find_validator_for_forwarding(dst_shard_id)
-                        .map_err(|e| TxStatusError::ChainError(e))?;
-                    self.network_adapter.do_send(PeerManagerMessageRequest::NetworkRequests(
-                        NetworkRequests::ReceiptOutComeRequest(validator, receipt_id),
-                    ));
-                }
-            }
-        }
-
-        Ok(())
-    }
-
     fn get_tx_status(
         &mut self,
         tx_hash: CryptoHash,
@@ -386,55 +357,30 @@ impl ViewClientActor {
         ) {
             match self.chain.get_final_transaction_result(&tx_hash) {
                 Ok(tx_result) => {
-                    match &tx_result.status {
-                        FinalExecutionStatus::NotStarted | FinalExecutionStatus::Started => {
-                            for receipt_view in tx_result.receipts_outcome.iter() {
-                                self.request_receipt_outcome(
-                                    receipt_view.id,
-                                    &head.epoch_id,
-                                    &head.last_block_hash,
-                                )?;
-                            }
-                        }
-                        FinalExecutionStatus::SuccessValue(_)
-                        | FinalExecutionStatus::Failure(_) => {}
-                    }
-                    if fetch_receipt {
+                    let res = if fetch_receipt {
                         let final_result = self
                             .chain
                             .get_final_transaction_result_with_receipt(tx_result)
                             .map_err(|e| TxStatusError::ChainError(e))?;
-                        return Ok(Some(
-                            FinalExecutionOutcomeViewEnum::FinalExecutionOutcomeWithReceipt(
-                                final_result,
-                            ),
-                        ));
-                    }
-                    return Ok(Some(FinalExecutionOutcomeViewEnum::FinalExecutionOutcome(
-                        tx_result,
-                    )));
+                        FinalExecutionOutcomeViewEnum::FinalExecutionOutcomeWithReceipt(
+                            final_result,
+                        )
+                    } else {
+                        FinalExecutionOutcomeViewEnum::FinalExecutionOutcome(tx_result)
+                    };
+                    Ok(Some(res))
                 }
-                Err(e) => match e {
-                    near_chain::Error::DBNotFoundErr(_) => {
-                        if let Ok(execution_outcome) = self.chain.get_execution_outcome(&tx_hash) {
-                            for receipt_id in execution_outcome.outcome_with_id.outcome.receipt_ids
-                            {
-                                self.request_receipt_outcome(
-                                    receipt_id,
-                                    &head.epoch_id,
-                                    &head.last_block_hash,
-                                )?;
-                            }
-                            return Ok(None);
-                        } else {
-                            return Err(TxStatusError::MissingTransaction(tx_hash));
-                        }
+                Err(near_chain::Error::DBNotFoundErr(_)) => {
+                    if self.chain.get_execution_outcome(&tx_hash).is_ok() {
+                        Ok(None)
+                    } else {
+                        Err(TxStatusError::MissingTransaction(tx_hash))
                     }
-                    _ => {
-                        warn!(target: "client", "Error trying to get transaction result: {}", e.to_string());
-                        return Err(TxStatusError::ChainError(e));
-                    }
-                },
+                }
+                Err(err) => {
+                    warn!(target: "client", "Error trying to get transaction result: {err}");
+                    Err(TxStatusError::ChainError(err))
+                }
             }
         } else {
             let mut request_manager = self.request_manager.write().expect(POISONED_LOCK_ERR);
@@ -454,8 +400,8 @@ impl ViewClientActor {
                     NetworkRequests::TxStatus(validator, signer_account_id, tx_hash),
                 ));
             }
+            Ok(None)
         }
-        Ok(None)
     }
 
     fn retrieve_headers(
@@ -1031,51 +977,6 @@ impl Handler<NetworkViewClientMessages> for ViewClientActor {
                 if request_manager.tx_status_requests.pop(&tx_hash).is_some() {
                     request_manager.tx_status_response.put(tx_hash, *tx_result);
                 }
-                NetworkViewClientResponses::NoResponse
-            }
-            NetworkViewClientMessages::ReceiptOutcomeRequest(receipt_id) => {
-                if let Ok(outcome_with_proof) = self.chain.get_execution_outcome(&receipt_id) {
-                    NetworkViewClientResponses::ReceiptOutcomeResponse(Box::new(outcome_with_proof))
-                } else {
-                    NetworkViewClientResponses::NoResponse
-                }
-            }
-            NetworkViewClientMessages::ReceiptOutcomeResponse(_response) => {
-                // TODO: remove rpc routing in (#3204)
-                //                let have_request = {
-                //                    let mut request_manager =
-                //                        self.request_manager.write().expect(POISONED_LOCK_ERR);
-                //                    request_manager.receipt_outcome_requests.cache_remove(response.id()).is_some()
-                //                };
-                //
-                //                if have_request {
-                //                    if let Ok(&shard_id) = self.chain.get_shard_id_for_receipt_id(response.id()) {
-                //                        let block_hash = response.block_hash;
-                //                        if let Ok(Some(&next_block_hash)) =
-                //                            self.chain.get_next_block_hash_with_new_chunk(&block_hash, shard_id)
-                //                        {
-                //                            if let Ok(block) = self.chain.get_block(&next_block_hash) {
-                //                                if shard_id < block.chunks().len() as u64 {
-                //                                    if verify_path(
-                //                                        block.chunks()[shard_id as usize].outcome_root(),
-                //                                        &response.proof,
-                //                                        &response.outcome_with_id.to_hashes(),
-                //                                    ) {
-                //                                        let mut chain_store_update =
-                //                                            self.chain.mut_store().store_update();
-                //                                        chain_store_update.save_outcome_with_proof(
-                //                                            response.outcome_with_id.id,
-                //                                            *response,
-                //                                        );
-                //                                        if let Err(e) = chain_store_update.commit() {
-                //                                            error!(target: "view_client", "Error committing to chain store: {}", e);
-                //                                        }
-                //                                    }
-                //                                }
-                //                            }
-                //                        }
-                //                    }
-                //                }
                 NetworkViewClientResponses::NoResponse
             }
             NetworkViewClientMessages::BlockRequest(hash) => {

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -406,7 +406,7 @@ impl ViewClientActor {
                     }
                 }
                 Err(err) => {
-                    warn!(target: "client", "Error trying to get transaction result: {err}");
+                    warn!(target: "client", ?err, "Error trying to get transaction result");
                     Err(TxStatusError::ChainError(err))
                 }
             }

--- a/chain/network-primitives/src/network_protocol/mod.rs
+++ b/chain/network-primitives/src/network_protocol/mod.rs
@@ -193,14 +193,22 @@ pub enum RoutedMessageBody {
     TxStatusRequest(AccountId, CryptoHash),
     TxStatusResponse(FinalExecutionOutcomeView),
 
-    // Kept for backwards borsh compatibility.
+    /// Not used, but needed to borsh backward compatibility.
     _UnusedQueryRequest,
-    // Kept for backwards borsh compatibility.
+    /// Not used, but needed to borsh backward compatibility.
     _UnusedQueryResponse,
 
+    /// Not used any longer and ignored when received.
+    ///
+    /// We’ve been still sending those messages at protocol version 56 so we
+    /// need to wait until 59 before we can remove the variant completely.
+    /// Until then we need to be able to decode those messages (even though we
+    /// will ignore them).
     ReceiptOutcomeRequest(CryptoHash),
-    /// Not used, but needed to preserve backward compatibility.
-    Unused,
+
+    /// Not used, but needed to borsh backward compatibility.
+    _UnusedReceiptOutcomeResponse,
+
     StateRequestHeader(ShardId, CryptoHash),
     StateRequestPart(ShardId, CryptoHash, u64),
     StateResponse(StateResponseInfoV1),
@@ -262,6 +270,7 @@ impl Debug for RoutedMessageBody {
             RoutedMessageBody::_UnusedQueryRequest { .. } => write!(f, "QueryRequest"),
             RoutedMessageBody::_UnusedQueryResponse { .. } => write!(f, "QueryResponse"),
             RoutedMessageBody::ReceiptOutcomeRequest(hash) => write!(f, "ReceiptRequest({})", hash),
+            RoutedMessageBody::_UnusedReceiptOutcomeResponse => write!(f, "ReceiptResponse"),
             RoutedMessageBody::StateRequestHeader(shard_id, sync_hash) => {
                 write!(f, "StateRequestHeader({}, {})", shard_id, sync_hash)
             }
@@ -300,7 +309,6 @@ impl Debug for RoutedMessageBody {
             ),
             RoutedMessageBody::Ping(_) => write!(f, "Ping"),
             RoutedMessageBody::Pong(_) => write!(f, "Pong"),
-            RoutedMessageBody::Unused => write!(f, "Unused"),
         }
     }
 }

--- a/chain/network-primitives/src/types.rs
+++ b/chain/network-primitives/src/types.rs
@@ -16,7 +16,6 @@ use near_primitives::block::{Block, BlockHeader};
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::{AnnounceAccount, PeerId};
 use near_primitives::syncing::{EpochSyncFinalizationResponse, EpochSyncResponse};
-use near_primitives::transaction::ExecutionOutcomeWithIdAndProof;
 use near_primitives::types::{AccountId, BlockHeight, EpochId, ShardId};
 use near_primitives::views::FinalExecutionOutcomeView;
 use serde::Serialize;
@@ -294,10 +293,6 @@ pub enum NetworkViewClientMessages {
     TxStatus { tx_hash: CryptoHash, signer_account_id: AccountId },
     /// Transaction status response
     TxStatusResponse(Box<FinalExecutionOutcomeView>),
-    /// Request for receipt outcome
-    ReceiptOutcomeRequest(CryptoHash),
-    /// Receipt outcome response
-    ReceiptOutcomeResponse(Box<ExecutionOutcomeWithIdAndProof>),
     /// Request a block.
     BlockRequest(CryptoHash),
     /// Request headers.
@@ -320,8 +315,6 @@ pub enum NetworkViewClientMessages {
 pub enum NetworkViewClientResponses {
     /// Transaction execution outcome
     TxStatus(Box<FinalExecutionOutcomeView>),
-    /// Receipt outcome response
-    ReceiptOutcomeResponse(Box<ExecutionOutcomeWithIdAndProof>),
     /// Block response.
     Block(Box<Block>),
     /// Headers response.

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -353,8 +353,12 @@ impl PeerActor {
                     RoutedMessageBody::TxStatusResponse(tx_result) => {
                         NetworkViewClientMessages::TxStatusResponse(Box::new(tx_result))
                     }
-                    RoutedMessageBody::ReceiptOutcomeRequest(receipt_id) => {
-                        NetworkViewClientMessages::ReceiptOutcomeRequest(receipt_id)
+                    RoutedMessageBody::ReceiptOutcomeRequest(_receipt_id) => {
+                        // Silently ignore for the time being.  We’ve been still
+                        // sending those messages at protocol version 56 so we
+                        // need to wait until 59 before we can remove the
+                        // variant completely.
+                        return;
                     }
                     RoutedMessageBody::StateRequestHeader(shard_id, sync_hash) => {
                         NetworkViewClientMessages::StateRequestHeader { shard_id, sync_hash }
@@ -522,9 +526,9 @@ impl PeerActor {
                     | RoutedMessageBody::_UnusedQueryRequest { .. }
                     | RoutedMessageBody::_UnusedQueryResponse { .. }
                     | RoutedMessageBody::ReceiptOutcomeRequest(_)
+                    | RoutedMessageBody::_UnusedReceiptOutcomeResponse
                     | RoutedMessageBody::StateRequestHeader(_, _)
-                    | RoutedMessageBody::StateRequestPart(_, _, _)
-                    | RoutedMessageBody::Unused => {
+                    | RoutedMessageBody::StateRequestPart(_, _, _) => {
                         error!(target: "network", "Peer receive_client_message received unexpected type: {:?}", routed_message);
                         return;
                     }

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -1613,16 +1613,6 @@ impl PeerManagerActor {
                     NetworkResponses::RouteNotFound
                 }
             }
-            NetworkRequests::ReceiptOutComeRequest(account_id, receipt_id) => {
-                if self.send_message_to_account(
-                    &account_id,
-                    RoutedMessageBody::ReceiptOutcomeRequest(receipt_id),
-                ) {
-                    NetworkResponses::NoResponse
-                } else {
-                    NetworkResponses::RouteNotFound
-                }
-            }
             NetworkRequests::Challenge(challenge) => {
                 // TODO(illia): smarter routing?
                 self.state

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -206,8 +206,6 @@ pub enum NetworkRequests {
     ForwardTx(AccountId, SignedTransaction),
     /// Query transaction status
     TxStatus(AccountId, AccountId, CryptoHash),
-    /// Request for receipt execution outcome
-    ReceiptOutComeRequest(AccountId, CryptoHash),
     /// A challenge to invalidate a block.
     Challenge(Challenge),
 }

--- a/tools/chainsync-loadtest/src/network.rs
+++ b/tools/chainsync-loadtest/src/network.rs
@@ -297,8 +297,6 @@ impl Handler<NetworkViewClientMessages> for FakeClientActor {
         let name = match msg {
             NetworkViewClientMessages::TxStatus { .. } => "TxStatus",
             NetworkViewClientMessages::TxStatusResponse(_) => "TxStatusResponse",
-            NetworkViewClientMessages::ReceiptOutcomeRequest(_) => "ReceiptOutcomeRequest",
-            NetworkViewClientMessages::ReceiptOutcomeResponse(_) => "ReceiptOutputResponse",
             NetworkViewClientMessages::BlockRequest(_) => "BlockRequest",
             NetworkViewClientMessages::BlockHeadersRequest(_) => "BlockHeadersRequest",
             NetworkViewClientMessages::StateRequestHeader { .. } => "StateRequestHeader",


### PR DESCRIPTION
As far as I can tell, ReceiptOutcomeRequest does nothing useful.

- There’s ViewClientActor::request_receipt_outcome which generates
  NetworkRequests::ReceiptOutComeRequest messages.
- Those end up in PeerManagerActor::handle_msg_network_requests which
  sends it over network as RoutedMessageBody::ReceiptOutcomeRequest.
- That is handled by PeerActor::receive_view_client_message which
  repackages it into NetworkViewClientMessages::ReceiptOutcomeRequest
  and sends it to ViewClientActor.
- ViewClientActor gets the outcome and in response sends
  a NetworkViewClientResponses::ReceiptOutcomeResponse.
- This ends up back in PeerActor where the response is caught by
  a catch-all `_ => {}` case which ignores it.

Seems like, we can get rid of pretty much everything in that chain
starting from ViewClientActor::request_receipt_outcome method.  The
one complication is that because of borsh we need to keep
RoutedMessageBody::ReceiptOutcomeRequest for a while longer until we
upgrade protocol enough times that we know nodes never send that
message.

While at it, rename RoutedMessageBody::Unused to
_UnusedReceiptOutcomeResponse since the name ‘Unused’ is getting
crowded.  We already have three unused messages and the receipt
outcome request will become fourth.

Issue: https://github.com/near/nearcore/pull/3204
