### PR TITLE
Revert "add config check that validators track all shards (#7383)"

### DIFF
--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -847,8 +847,6 @@ pub fn init_configs(
     if max_gas_burnt_view.is_some() {
         config.max_gas_burnt_view = max_gas_burnt_view;
     }
-    // https://github.com/near/nearcore/issues/7388
-    config.tracked_shards = vec![0];
 
     match chain_id.as_ref() {
         "mainnet" => {
@@ -1065,8 +1063,6 @@ pub fn create_testnet_configs_from_seeds(
             };
             config.network.skip_sync_wait = num_validator_seats == 1;
         }
-        // https://github.com/near/nearcore/issues/7388
-        config.tracked_shards = vec![0];
         config.archive = archive;
         config.consensus.min_num_peers =
             std::cmp::min(num_validator_seats as usize - 1, config.consensus.min_num_peers);
@@ -1229,7 +1225,6 @@ pub fn load_config(
         let signer = InMemoryValidatorSigner::from_file(&validator_file).with_context(|| {
             format!("Failed initializing validator signer from {}", validator_file.display())
         })?;
-        anyhow::ensure!(!config.tracked_shards.is_empty(), "Validator must track all shards. Please change `tracked_shards` field in config.json to be any non-empty vector");
         Some(Arc::new(signer) as Arc<dyn ValidatorSigner>)
     } else {
         None

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -406,10 +406,6 @@ class LocalNode(BaseNode):
             'consensus': {
                 'min_num_peers': int(not single_node)
             },
-            # We won't need this after #7383 is released to mainnet, but for now,
-            # we need it, otherwise, the check added in #7383 will complain the
-            # nodes don't track any shard
-            'tracked_shards': [0],
         })
 
         atexit.register(atexit_cleanup, self)


### PR DESCRIPTION
The commit breaks ‘sanity/repro_2916.py’ and ‘sanity/gc_sync_after_sync.py
swap_nodes’ python tests.

This reverts commit 9d71da60266dd90667ef15ad035250f5dde73814.