### PR TITLE
chain: rename RoutedMessageBody::Unused to _UnusedReceiptOutcomeResponse

### DIFF
--- a/chain/network-primitives/src/network_protocol/mod.rs
+++ b/chain/network-primitives/src/network_protocol/mod.rs
@@ -193,14 +193,15 @@ pub enum RoutedMessageBody {
     TxStatusRequest(AccountId, CryptoHash),
     TxStatusResponse(FinalExecutionOutcomeView),
 
-    // Kept for backwards borsh compatibility.
+    /// Not used, but needed for borsh backward compatibility.
     _UnusedQueryRequest,
-    // Kept for backwards borsh compatibility.
+    /// Not used, but needed for borsh backward compatibility.
     _UnusedQueryResponse,
 
     ReceiptOutcomeRequest(CryptoHash),
-    /// Not used, but needed to preserve backward compatibility.
-    Unused,
+    /// Not used, but needed for borsh backward compatibility.
+    _UnusedReceiptOutcomeResponse,
+
     StateRequestHeader(ShardId, CryptoHash),
     StateRequestPart(ShardId, CryptoHash, u64),
     StateResponse(StateResponseInfoV1),
@@ -259,9 +260,10 @@ impl Debug for RoutedMessageBody {
             RoutedMessageBody::TxStatusResponse(response) => {
                 write!(f, "TxStatusResponse({})", response.transaction.hash)
             }
-            RoutedMessageBody::_UnusedQueryRequest { .. } => write!(f, "QueryRequest"),
-            RoutedMessageBody::_UnusedQueryResponse { .. } => write!(f, "QueryResponse"),
+            RoutedMessageBody::_UnusedQueryRequest => write!(f, "QueryRequest"),
+            RoutedMessageBody::_UnusedQueryResponse => write!(f, "QueryResponse"),
             RoutedMessageBody::ReceiptOutcomeRequest(hash) => write!(f, "ReceiptRequest({})", hash),
+            RoutedMessageBody::_UnusedReceiptOutcomeResponse => write!(f, "ReceiptOutcomeResponse"),
             RoutedMessageBody::StateRequestHeader(shard_id, sync_hash) => {
                 write!(f, "StateRequestHeader({}, {})", shard_id, sync_hash)
             }
@@ -300,7 +302,6 @@ impl Debug for RoutedMessageBody {
             ),
             RoutedMessageBody::Ping(_) => write!(f, "Ping"),
             RoutedMessageBody::Pong(_) => write!(f, "Pong"),
-            RoutedMessageBody::Unused => write!(f, "Unused"),
         }
     }
 }

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -519,12 +519,12 @@ impl PeerActor {
                     | RoutedMessageBody::Pong(_)
                     | RoutedMessageBody::TxStatusRequest(_, _)
                     | RoutedMessageBody::TxStatusResponse(_)
-                    | RoutedMessageBody::_UnusedQueryRequest { .. }
-                    | RoutedMessageBody::_UnusedQueryResponse { .. }
+                    | RoutedMessageBody::_UnusedQueryRequest
+                    | RoutedMessageBody::_UnusedQueryResponse
                     | RoutedMessageBody::ReceiptOutcomeRequest(_)
+                    | RoutedMessageBody::_UnusedReceiptOutcomeResponse
                     | RoutedMessageBody::StateRequestHeader(_, _)
-                    | RoutedMessageBody::StateRequestPart(_, _, _)
-                    | RoutedMessageBody::Unused => {
+                    | RoutedMessageBody::StateRequestPart(_, _, _) => {
                         error!(target: "network", "Peer receive_client_message received unexpected type: {:?}", routed_message);
                         return;
                     }


### PR DESCRIPTION
We keep adding more and more unused variants to RoutedMessageBody
enum making name the name Unused overburdened.  Rename existing
Unused variant to _UnusedReceiptOutcomeResponse so that it stays
consistent with other two unused variants.  With three of them now
hopefully this will establish the pattern.

While at it, harmonise how all three of the variants are handled.