### PR TITLE
refactor: minor sync cleanups

### DIFF
--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1645,7 +1645,7 @@ impl ClientActor {
                 {
                     unwrap_or_run_later!(self.client.block_sync.run(
                         &mut self.client.sync_status,
-                        &mut self.client.chain,
+                        &self.client.chain,
                         highest_height,
                         &self.network_info.highest_height_peers
                     ))

--- a/chain/client/src/sync.rs
+++ b/chain/client/src/sync.rs
@@ -479,7 +479,7 @@ impl BlockSync {
 
     /// Returns true if state download is required (last known block is too far).
     /// Otherwise request recent blocks from peers round robin.
-    pub fn block_sync(
+    fn block_sync(
         &mut self,
         chain: &Chain,
         highest_height_peers: &[FullPeerInfo],


### PR DESCRIPTION
Notably, use `&Chain` rather than `&mut Chain` where we can.

Backstory: debugging https://github.com/near/nearcore/issues/7371