### PR TITLE
chain: get rid of Query’s query_id

### DIFF
--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -16,7 +16,6 @@ use near_primitives::types::{
     AccountId, BlockHeight, BlockReference, EpochId, EpochReference, MaybeBlockId, ShardId,
     TransactionOrReceiptId,
 };
-use near_primitives::utils::generate_random_string;
 use near_primitives::views::validator_stake_view::ValidatorStakeView;
 use near_primitives::views::{
     BlockView, ChunkView, EpochValidatorInfo, ExecutionOutcomeWithIdView,
@@ -255,14 +254,13 @@ impl From<near_chain_primitives::Error> for GetChunkError {
 /// Queries client for given path / data.
 #[derive(Clone, Debug)]
 pub struct Query {
-    pub query_id: String,
     pub block_reference: BlockReference,
     pub request: QueryRequest,
 }
 
 impl Query {
     pub fn new(block_reference: BlockReference, request: QueryRequest) -> Self {
-        Query { query_id: generate_random_string(10), block_reference, request }
+        Query { block_reference, request }
     }
 }
 


### PR DESCRIPTION
Query::query_id field is never used.  Get rid of it.