### PR TITLE
core: make Genesis::records and records_file private

### DIFF
--- a/core/chain-configs/src/genesis_validate.rs
+++ b/core/chain-configs/src/genesis_validate.rs
@@ -150,74 +150,74 @@ mod test {
     #[test]
     #[should_panic(expected = "wrong total supply")]
     fn test_total_supply_not_match() {
-        let mut genesis = Genesis::default();
-        genesis.config.validators = vec![AccountInfo {
+        let mut config = GenesisConfig::default();
+        config.validators = vec![AccountInfo {
             account_id: "test".parse().unwrap(),
             public_key: VALID_ED25519_RISTRETTO_KEY.parse().unwrap(),
             amount: 10,
         }];
-        genesis.records = GenesisRecords(vec![StateRecord::Account {
+        let records = GenesisRecords(vec![StateRecord::Account {
             account_id: "test".parse().unwrap(),
             account: create_account(),
         }]);
-        validate_genesis(&genesis);
+        validate_genesis(&Genesis::new(config, records));
     }
 
     #[test]
     #[should_panic(expected = "validator staking key is not valid")]
     fn test_invalid_staking_key() {
-        let mut genesis = Genesis::default();
-        genesis.config.validators = vec![AccountInfo {
+        let mut config = GenesisConfig::default();
+        config.validators = vec![AccountInfo {
             account_id: "test".parse().unwrap(),
             public_key: PublicKey::empty(KeyType::ED25519),
             amount: 10,
         }];
-        genesis.records = GenesisRecords(vec![StateRecord::Account {
+        let records = GenesisRecords(vec![StateRecord::Account {
             account_id: "test".parse().unwrap(),
             account: create_account(),
         }]);
-        validate_genesis(&genesis);
+        validate_genesis(&Genesis::new(config, records));
     }
 
     #[test]
     #[should_panic(expected = "validator accounts do not match staked accounts")]
     fn test_validator_not_match() {
-        let mut genesis = Genesis::default();
-        genesis.config.validators = vec![AccountInfo {
+        let mut config = GenesisConfig::default();
+        config.validators = vec![AccountInfo {
             account_id: "test".parse().unwrap(),
             public_key: VALID_ED25519_RISTRETTO_KEY.parse().unwrap(),
             amount: 100,
         }];
-        genesis.config.total_supply = 110;
-        genesis.records = GenesisRecords(vec![StateRecord::Account {
+        config.total_supply = 110;
+        let records = GenesisRecords(vec![StateRecord::Account {
             account_id: "test".parse().unwrap(),
             account: create_account(),
         }]);
-        validate_genesis(&genesis);
+        validate_genesis(&Genesis::new(config, records));
     }
 
     #[test]
     #[should_panic(expected = "no validators in genesis")]
     fn test_empty_validator() {
-        let mut genesis = Genesis::default();
-        genesis.records = GenesisRecords(vec![StateRecord::Account {
+        let config = GenesisConfig::default();
+        let records = GenesisRecords(vec![StateRecord::Account {
             account_id: "test".parse().unwrap(),
             account: create_account(),
         }]);
-        validate_genesis(&genesis);
+        validate_genesis(&Genesis::new(config, records));
     }
 
     #[test]
     #[should_panic(expected = "access key account test1 does not exist")]
     fn test_access_key_with_nonexistent_account() {
-        let mut genesis = Genesis::default();
-        genesis.config.validators = vec![AccountInfo {
+        let mut config = GenesisConfig::default();
+        config.validators = vec![AccountInfo {
             account_id: "test".parse().unwrap(),
             public_key: VALID_ED25519_RISTRETTO_KEY.parse().unwrap(),
             amount: 10,
         }];
-        genesis.config.total_supply = 110;
-        genesis.records = GenesisRecords(vec![
+        config.total_supply = 110;
+        let records = GenesisRecords(vec![
             StateRecord::Account { account_id: "test".parse().unwrap(), account: create_account() },
             StateRecord::AccessKey {
                 account_id: "test1".parse().unwrap(),
@@ -225,20 +225,20 @@ mod test {
                 access_key: AccessKey::full_access(),
             },
         ]);
-        validate_genesis(&genesis);
+        validate_genesis(&Genesis::new(config, records));
     }
 
     #[test]
     #[should_panic(expected = "account test has more than one contract deployed")]
     fn test_more_than_one_contract() {
-        let mut genesis = Genesis::default();
-        genesis.config.validators = vec![AccountInfo {
+        let mut config = GenesisConfig::default();
+        config.validators = vec![AccountInfo {
             account_id: "test".parse().unwrap(),
             public_key: VALID_ED25519_RISTRETTO_KEY.parse().unwrap(),
             amount: 10,
         }];
-        genesis.config.total_supply = 110;
-        genesis.records = GenesisRecords(vec![
+        config.total_supply = 110;
+        let records = GenesisRecords(vec![
             StateRecord::Account { account_id: "test".parse().unwrap(), account: create_account() },
             StateRecord::Contract { account_id: "test".parse().unwrap(), code: [1, 2, 3].to_vec() },
             StateRecord::Contract {
@@ -246,6 +246,6 @@ mod test {
                 code: [1, 2, 3, 4].to_vec(),
             },
         ]);
-        validate_genesis(&genesis);
+        validate_genesis(&Genesis::new(config, records));
     }
 }

--- a/integration-tests/src/node/mod.rs
+++ b/integration-tests/src/node/mod.rs
@@ -156,7 +156,8 @@ pub fn create_nodes_from_seeds(seeds: Vec<String>) -> Vec<NodeConfig> {
     genesis.config.gas_price_adjustment_rate = Ratio::from_integer(0);
     for seed in seeds {
         let mut is_account_record_found = false;
-        for record in genesis.records.as_mut() {
+        let records = genesis.force_read_records().as_mut();
+        for record in records.iter_mut() {
             if let StateRecord::Account { account_id: record_account_id, ref mut account } = record
             {
                 if record_account_id.as_ref() == seed {
@@ -166,9 +167,7 @@ pub fn create_nodes_from_seeds(seeds: Vec<String>) -> Vec<NodeConfig> {
             }
         }
         assert!(is_account_record_found);
-        genesis
-            .records
-            .as_mut()
+        records
             .push(StateRecord::Contract { account_id: seed.parse().unwrap(), code: code.to_vec() });
     }
     near_configs_to_node_configs(configs, validator_signers, network_signers, genesis)

--- a/integration-tests/src/tests/standard_cases/runtime.rs
+++ b/integration-tests/src/tests/standard_cases/runtime.rs
@@ -20,13 +20,14 @@ fn create_runtime_with_expensive_storage() -> RuntimeNode {
     // Set expensive state requirements and add alice more money.
     let mut runtime_config = RuntimeConfig::test();
     runtime_config.storage_amount_per_byte = TESTING_INIT_BALANCE / 1000;
-    match &mut genesis.records.as_mut()[0] {
+    let records = genesis.force_read_records().as_mut();
+    match &mut records[0] {
         StateRecord::Account { account, .. } => account.set_amount(TESTING_INIT_BALANCE * 10000),
         _ => {
             panic!("the first record is expected to be alice account creation!");
         }
     }
-    genesis.records.as_mut().push(StateRecord::Data {
+    records.push(StateRecord::Data {
         account_id: bob_account(),
         data_key: b"test".to_vec(),
         value: b"123".to_vec(),

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1438,6 +1438,19 @@ impl Runtime {
         storage_computer.finalize()
     }
 
+    /// Compute the expected storage per account for genesis records.
+    pub fn compute_genesis_storage_usage(
+        &self,
+        genesis: &Genesis,
+        config: &RuntimeConfig,
+    ) -> HashMap<AccountId, u64> {
+        let mut storage_computer = StorageComputer::new(config);
+        genesis.for_each_record(|record| {
+            storage_computer.process_record(record);
+        });
+        storage_computer.finalize()
+    }
+
     /// Balances are account, publickey, initial_balance, initial_tx_stake
     pub fn apply_genesis_state(
         &self,

--- a/test-utils/testlib/src/runtime_utils.rs
+++ b/test-utils/testlib/src/runtime_utils.rs
@@ -26,7 +26,8 @@ static DEFAULT_TEST_CONTRACT_HASH: Lazy<CryptoHash> =
 
 pub fn add_test_contract(genesis: &mut Genesis, account_id: &AccountId) {
     let mut is_account_record_found = false;
-    for record in genesis.records.as_mut() {
+    let records = genesis.force_read_records().as_mut();
+    for record in records.iter_mut() {
         if let StateRecord::Account { account_id: record_account_id, ref mut account } = record {
             if record_account_id == account_id {
                 is_account_record_found = true;
@@ -35,12 +36,12 @@ pub fn add_test_contract(genesis: &mut Genesis, account_id: &AccountId) {
         }
     }
     if !is_account_record_found {
-        genesis.records.as_mut().push(StateRecord::Account {
+        records.push(StateRecord::Account {
             account_id: account_id.clone(),
             account: Account::new(0, 0, *DEFAULT_TEST_CONTRACT_HASH, 0),
         });
     }
-    genesis.records.as_mut().push(StateRecord::Contract {
+    records.push(StateRecord::Contract {
         account_id: account_id.clone(),
         code: near_test_contracts::rs_contract().to_vec(),
     });

--- a/tools/state-viewer/src/state_dump.rs
+++ b/tools/state-viewer/src/state_dump.rs
@@ -501,11 +501,11 @@ mod test {
         expected_accounts.extend(select_account_ids.clone());
         expected_accounts.insert(new_genesis.config.protocol_treasury_account.clone());
         let mut actual_accounts: HashSet<AccountId> = HashSet::new();
-        for record in new_genesis.records.0.iter() {
+        new_genesis.for_each_record(|record| {
             if let StateRecord::Account { account_id, .. } = record {
                 actual_accounts.insert(account_id.clone());
             }
-        }
+        });
         assert_eq!(expected_accounts, actual_accounts);
         validate_genesis(&new_genesis);
     }
@@ -854,18 +854,12 @@ mod test {
             vec!["test1".parse().unwrap()]
         );
 
-        let stake: HashMap<AccountId, Balance> = new_genesis
-            .records
-            .0
-            .iter()
-            .filter_map(|x| {
-                if let StateRecord::Account { account_id, account } = x {
-                    Some((account_id.clone(), account.locked()))
-                } else {
-                    None
-                }
-            })
-            .collect();
+        let mut stake = HashMap::<AccountId, Balance>::new();
+        new_genesis.for_each_record(|record| {
+            if let StateRecord::Account { account_id, account } = record {
+                stake.insert(account_id.clone(), account.locked());
+            }
+        });
 
         assert_eq!(stake.get("test0").unwrap_or(&(0 as Balance)), &(0 as Balance));
 

--- a/tools/storage-usage-delta-calculator/src/main.rs
+++ b/tools/storage-usage-delta-calculator/src/main.rs
@@ -21,13 +21,13 @@ async fn main() -> std::io::Result<()> {
 
     let config_store = RuntimeConfigStore::new(None);
     let config = config_store.get_config(PROTOCOL_VERSION);
-    let storage_usage = Runtime::new().compute_storage_usage(&genesis.records.0[..], config);
+    let storage_usage = Runtime::new().compute_genesis_storage_usage(&genesis, config);
     debug!(target: "storage-calculator", "Storage usage calculated");
 
     let mut result = Vec::new();
-    for record in genesis.records.0 {
+    genesis.for_each_record(|record| {
         if let StateRecord::Account { account_id, account } = record {
-            let actual_storage_usage = storage_usage.get(&account_id).unwrap();
+            let actual_storage_usage = storage_usage.get(account_id).unwrap();
             let saved_storage_usage = account.storage_usage();
             let delta = actual_storage_usage - saved_storage_usage;
             if delta != 0 {
@@ -35,7 +35,7 @@ async fn main() -> std::io::Result<()> {
                 result.push((account_id.clone(), delta));
             }
         }
-    }
+    });
     serde_json::to_writer_pretty(&File::create("storage_usage_delta.json")?, &result)?;
     Ok(())
 }


### PR DESCRIPTION
Genesis::records are not guaranteed to be set since the records may
reside in records file instead.  Code accessing that field directly
(without taking records_file field into consideration as well) is
technically incorrect and violates Genesis’ encapsulation.

Make the records an records_file private to force all users of the
class to uses provided methods rather than accessing the fields
directly.  To accommodate all usage, introduce records_len and
force_read_records methods.

Note that this isn’t the state we’d like the struct to be in.
Ideally, we’d have an enum which either holds the records in a vector
or path to the file with the records.  This commit is a step into that
direction.
