### PR TITLE
refactor: introduce EpochManagerHandle

### DIFF
--- a/chain/epoch_manager/src/lib.rs
+++ b/chain/epoch_manager/src/lib.rs
@@ -1,7 +1,7 @@
 use num_rational::Rational64;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use near_cache::SyncLruCache;
 use primitive_types::U256;
@@ -17,8 +17,8 @@ use near_primitives::errors::EpochError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{
-    AccountId, ApprovalStake, Balance, BlockChunkValidatorStats, BlockHeight, EpochId, ShardId,
-    ValidatorId, ValidatorKickoutReason, ValidatorStats,
+    AccountId, ApprovalStake, Balance, BlockChunkValidatorStats, BlockHeight, EpochId,
+    EpochInfoProvider, ShardId, ValidatorId, ValidatorKickoutReason, ValidatorStats,
 };
 use near_primitives::version::{ProtocolVersion, UPGRADABILITY_FIX_PROTOCOL_VERSION};
 use near_primitives::views::{
@@ -48,6 +48,64 @@ mod validator_selection;
 const EPOCH_CACHE_SIZE: usize = if cfg!(feature = "no_cache") { 1 } else { 50 };
 const BLOCK_CACHE_SIZE: usize = if cfg!(feature = "no_cache") { 5 } else { 1000 }; // TODO(#5080): fix this
 const AGGREGATOR_SAVE_PERIOD: u64 = 1000;
+
+/// In the current architecture, various components have access to the same
+/// shared mutable instance of [`EpochManager`]. This handle manages locking
+/// required for such access.
+///
+/// It's up to the caller to ensure that there are no logical races when using
+/// `.write` access.
+#[derive(Clone)]
+pub struct EpochManagerHandle {
+    inner: Arc<RwLock<EpochManager>>,
+}
+
+impl EpochManagerHandle {
+    pub fn write(&self) -> RwLockWriteGuard<EpochManager> {
+        self.inner.write().unwrap()
+    }
+
+    pub fn read(&self) -> RwLockReadGuard<EpochManager> {
+        self.inner.read().unwrap()
+    }
+}
+
+impl EpochInfoProvider for EpochManagerHandle {
+    fn validator_stake(
+        &self,
+        epoch_id: &EpochId,
+        last_block_hash: &CryptoHash,
+        account_id: &AccountId,
+    ) -> Result<Option<Balance>, EpochError> {
+        let epoch_manager = self.read();
+        let last_block_info = epoch_manager.get_block_info(last_block_hash)?;
+        if last_block_info.slashed().contains_key(account_id) {
+            return Ok(None);
+        }
+        let epoch_info = epoch_manager.get_epoch_info(epoch_id)?;
+        Ok(epoch_info.get_validator_id(account_id).map(|id| epoch_info.validator_stake(*id)))
+    }
+
+    fn validator_total_stake(
+        &self,
+        epoch_id: &EpochId,
+        last_block_hash: &CryptoHash,
+    ) -> Result<Balance, EpochError> {
+        let epoch_manager = self.read();
+        let last_block_info = epoch_manager.get_block_info(last_block_hash)?;
+        let epoch_info = epoch_manager.get_epoch_info(epoch_id)?;
+        Ok(epoch_info
+            .validators_iter()
+            .filter(|info| !last_block_info.slashed().contains_key(info.account_id()))
+            .map(|info| info.stake())
+            .sum())
+    }
+
+    fn minimum_stake(&self, prev_block_hash: &CryptoHash) -> Result<Balance, EpochError> {
+        let epoch_manager = self.read();
+        epoch_manager.minimum_stake(prev_block_hash)
+    }
+}
 
 /// Tracks epoch information across different forks, such as validators.
 /// Note: that even after garbage collection, the data about genesis epoch should be in the store.
@@ -164,6 +222,11 @@ impl EpochManager {
             store_update.commit()?;
         }
         Ok(epoch_manager)
+    }
+
+    pub fn into_handle(self) -> EpochManagerHandle {
+        let inner = Arc::new(RwLock::new(self));
+        EpochManagerHandle { inner }
     }
 
     /// Only used in mock node

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -14,7 +14,7 @@ use near_chain_configs::{
     MIN_GC_NUM_EPOCHS_TO_KEEP,
 };
 use near_crypto::{PublicKey, Signature};
-use near_epoch_manager::EpochManager;
+use near_epoch_manager::{EpochManager, EpochManagerHandle};
 use near_pool::types::PoolIterator;
 use near_primitives::account::{AccessKey, Account};
 use near_primitives::block::{Approval, ApprovalInner};
@@ -67,65 +67,14 @@ use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::Path;
-use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::sync::Arc;
 use std::time::Instant;
 use tracing::{debug, error, info, warn};
 
 pub mod errors;
 
-const POISONED_LOCK_ERR: &str = "The lock was poisoned.";
 const STATE_DUMP_FILE: &str = "state_dump";
 const GENESIS_ROOTS_FILE: &str = "genesis_roots";
-
-/// Wrapper type for epoch manager to get avoid implementing trait for foreign types.
-pub struct SafeEpochManager(pub Arc<RwLock<EpochManager>>);
-
-impl SafeEpochManager {
-    fn write(&self) -> RwLockWriteGuard<EpochManager> {
-        self.0.write().expect(POISONED_LOCK_ERR)
-    }
-
-    fn read(&self) -> RwLockReadGuard<EpochManager> {
-        self.0.read().expect(POISONED_LOCK_ERR)
-    }
-}
-
-impl EpochInfoProvider for SafeEpochManager {
-    fn validator_stake(
-        &self,
-        epoch_id: &EpochId,
-        last_block_hash: &CryptoHash,
-        account_id: &AccountId,
-    ) -> Result<Option<Balance>, EpochError> {
-        let epoch_manager = self.read();
-        let last_block_info = epoch_manager.get_block_info(last_block_hash)?;
-        if last_block_info.slashed().contains_key(account_id) {
-            return Ok(None);
-        }
-        let epoch_info = epoch_manager.get_epoch_info(epoch_id)?;
-        Ok(epoch_info.get_validator_id(account_id).map(|id| epoch_info.validator_stake(*id)))
-    }
-
-    fn validator_total_stake(
-        &self,
-        epoch_id: &EpochId,
-        last_block_hash: &CryptoHash,
-    ) -> Result<Balance, EpochError> {
-        let epoch_manager = self.read();
-        let last_block_info = epoch_manager.get_block_info(last_block_hash)?;
-        let epoch_info = epoch_manager.get_epoch_info(epoch_id)?;
-        Ok(epoch_info
-            .validators_iter()
-            .filter(|info| !last_block_info.slashed().contains_key(info.account_id()))
-            .map(|info| info.stake())
-            .sum())
-    }
-
-    fn minimum_stake(&self, prev_block_hash: &CryptoHash) -> Result<Balance, EpochError> {
-        let epoch_manager = self.read();
-        epoch_manager.minimum_stake(prev_block_hash)
-    }
-}
 
 /// Defines Nightshade state transition and validator rotation.
 /// TODO: this possibly should be merged with the runtime cargo or at least reconciled on the interfaces.
@@ -137,7 +86,7 @@ pub struct NightshadeRuntime {
     tries: ShardTries,
     trie_viewer: TrieViewer,
     pub runtime: Runtime,
-    epoch_manager: SafeEpochManager,
+    epoch_manager: EpochManagerHandle,
     shard_tracker: ShardTracker,
     genesis_state_roots: Vec<StateRoot>,
     migration_data: Arc<MigrationData>,
@@ -193,10 +142,9 @@ impl NightshadeRuntime {
             genesis.config.num_block_producer_seats_per_shard.len() as NumShards,
         );
         let tries = ShardTries::new(store.clone(), trie_cache_factory);
-        let epoch_manager = Arc::new(RwLock::new(
-            EpochManager::new_from_genesis_config(store.clone(), &genesis_config)
-                .expect("Failed to start Epoch Manager"),
-        ));
+        let epoch_manager = EpochManager::new_from_genesis_config(store.clone(), &genesis_config)
+            .expect("Failed to start Epoch Manager")
+            .into_handle();
         let shard_tracker = ShardTracker::new(tracked_config, epoch_manager.clone());
         NightshadeRuntime {
             genesis_config,
@@ -205,7 +153,7 @@ impl NightshadeRuntime {
             tries,
             runtime,
             trie_viewer,
-            epoch_manager: SafeEpochManager(epoch_manager),
+            epoch_manager,
             shard_tracker,
             genesis_state_roots: state_roots,
             migration_data: Arc::new(load_migration_data(&genesis.config.chain_id)),
@@ -2784,7 +2732,7 @@ mod test {
             |env: &mut TestEnv, expected_blocks: &mut [u64], expected_chunks: &mut [u64]| {
                 let epoch_id = env.head.epoch_id.clone();
                 let height = env.head.height;
-                let em = env.runtime.epoch_manager.0.read().unwrap();
+                let em = env.runtime.epoch_manager.read();
                 let bp = em.get_block_producer_info(&epoch_id, height).unwrap();
                 let cp = em.get_chunk_producer_info(&epoch_id, height, 0).unwrap();
 

--- a/nearcore/src/shard_tracker.rs
+++ b/nearcore/src/shard_tracker.rs
@@ -131,25 +131,23 @@ impl ShardTracker {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
-
+    use super::{account_id_to_shard_id, ShardTracker};
+    use crate::shard_tracker::TrackedConfig;
     use near_crypto::{KeyType, PublicKey};
+    use near_epoch_manager::test_utils::hash_range;
     use near_epoch_manager::{EpochManager, EpochManagerHandle, RewardCalculator};
     use near_primitives::epoch_manager::block_info::BlockInfo;
     use near_primitives::epoch_manager::{AllEpochConfig, EpochConfig, ShardConfig};
     use near_primitives::hash::CryptoHash;
+    use near_primitives::shard_layout::ShardLayout;
     use near_primitives::types::validator_stake::ValidatorStake;
     use near_primitives::types::{BlockHeight, EpochId, NumShards, ProtocolVersion, ShardId};
-    use near_store::test_utils::create_test_store;
-    use super::{account_id_to_shard_id, ShardTracker};
-    use near_primitives::shard_layout::ShardLayout;
-
-    use crate::shard_tracker::TrackedConfig;
-    use near_epoch_manager::test_utils::hash_range;
     use near_primitives::utils::get_num_seats_per_shard;
     use near_primitives::version::ProtocolFeature::SimpleNightshade;
     use near_primitives::version::PROTOCOL_VERSION;
+    use near_store::test_utils::create_test_store;
     use num_rational::Ratio;
+    use std::collections::HashSet;
 
     const DEFAULT_TOTAL_SUPPLY: u128 = 1_000_000_000_000;
 

--- a/nearcore/src/shard_tracker.rs
+++ b/nearcore/src/shard_tracker.rs
@@ -1,14 +1,10 @@
-use std::sync::{Arc, RwLock};
-
 use crate::append_only_map::AppendOnlyMap;
 use near_chain_configs::ClientConfig;
-use near_epoch_manager::EpochManager;
+use near_epoch_manager::EpochManagerHandle;
 use near_primitives::errors::EpochError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::account_id_to_shard_id;
 use near_primitives::types::{AccountId, EpochId, ShardId};
-
-const POISONED_LOCK_ERR: &str = "The lock was poisoned.";
 
 pub enum TrackedConfig {
     Accounts(Vec<AccountId>),
@@ -40,11 +36,11 @@ pub struct ShardTracker {
     /// Stores shard tracking information by epoch, only useful if TrackedState == Accounts
     tracking_shards: AppendOnlyMap<EpochId, BitMask>,
     /// Epoch manager that for given block hash computes the epoch id.
-    epoch_manager: Arc<RwLock<EpochManager>>,
+    epoch_manager: EpochManagerHandle,
 }
 
 impl ShardTracker {
-    pub fn new(tracked_config: TrackedConfig, epoch_manager: Arc<RwLock<EpochManager>>) -> Self {
+    pub fn new(tracked_config: TrackedConfig, epoch_manager: EpochManagerHandle) -> Self {
         ShardTracker { tracked_config, tracking_shards: AppendOnlyMap::new(), epoch_manager }
     }
 
@@ -55,7 +51,7 @@ impl ShardTracker {
     ) -> Result<bool, EpochError> {
         match &self.tracked_config {
             TrackedConfig::Accounts(tracked_accounts) => {
-                let epoch_manager = self.epoch_manager.read().expect(POISONED_LOCK_ERR);
+                let epoch_manager = self.epoch_manager.read();
                 let shard_layout = epoch_manager.get_shard_layout(epoch_id)?;
                 let tracking_mask = self.tracking_shards.get_or_insert(epoch_id, || {
                     let mut tracking_mask = vec![false; shard_layout.num_shards() as usize];
@@ -73,7 +69,7 @@ impl ShardTracker {
 
     fn tracks_shard(&self, shard_id: ShardId, prev_hash: &CryptoHash) -> Result<bool, EpochError> {
         let epoch_id = {
-            let epoch_manager = self.epoch_manager.read().expect(POISONED_LOCK_ERR);
+            let epoch_manager = self.epoch_manager.read();
             epoch_manager.get_epoch_id_from_prev_block(prev_hash)?
         };
         self.tracks_shard_at_epoch(shard_id, &epoch_id)
@@ -90,7 +86,7 @@ impl ShardTracker {
         // https://github.com/near/nearcore/issues/4936
         if let Some(account_id) = account_id {
             let account_cares_about_shard = {
-                let epoch_manager = self.epoch_manager.read().expect(POISONED_LOCK_ERR);
+                let epoch_manager = self.epoch_manager.read();
                 epoch_manager
                     .cares_about_shard_from_prev_block(parent_hash, account_id, shard_id)
                     .unwrap_or(false)
@@ -117,7 +113,7 @@ impl ShardTracker {
     ) -> bool {
         if let Some(account_id) = account_id {
             let account_cares_about_shard = {
-                let epoch_manager = self.epoch_manager.read().expect(POISONED_LOCK_ERR);
+                let epoch_manager = self.epoch_manager.read();
                 epoch_manager
                     .cares_about_shard_next_epoch_from_prev_block(parent_hash, account_id, shard_id)
                     .unwrap_or(false)
@@ -136,22 +132,19 @@ impl ShardTracker {
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
-    use std::sync::{Arc, RwLock};
 
     use near_crypto::{KeyType, PublicKey};
-    use near_epoch_manager::{EpochManager, RewardCalculator};
+    use near_epoch_manager::{EpochManager, EpochManagerHandle, RewardCalculator};
     use near_primitives::epoch_manager::block_info::BlockInfo;
     use near_primitives::epoch_manager::{AllEpochConfig, EpochConfig, ShardConfig};
     use near_primitives::hash::CryptoHash;
     use near_primitives::types::validator_stake::ValidatorStake;
     use near_primitives::types::{BlockHeight, EpochId, NumShards, ProtocolVersion, ShardId};
     use near_store::test_utils::create_test_store;
-
     use super::{account_id_to_shard_id, ShardTracker};
     use near_primitives::shard_layout::ShardLayout;
 
     use crate::shard_tracker::TrackedConfig;
-    use crate::shard_tracker::POISONED_LOCK_ERR;
     use near_epoch_manager::test_utils::hash_range;
     use near_primitives::utils::get_num_seats_per_shard;
     use near_primitives::version::ProtocolFeature::SimpleNightshade;
@@ -164,7 +157,7 @@ mod tests {
         genesis_protocol_version: ProtocolVersion,
         num_shards: NumShards,
         simple_nightshade_shard_config: Option<ShardConfig>,
-    ) -> EpochManager {
+    ) -> EpochManagerHandle {
         let store = create_test_store();
         let initial_epoch_config = EpochConfig {
             epoch_length: 1,
@@ -205,6 +198,7 @@ mod tests {
             )],
         )
         .unwrap()
+        .into_handle()
     }
 
     #[allow(unused)]
@@ -262,12 +256,10 @@ mod tests {
     fn test_track_accounts() {
         let num_shards = 4;
         let epoch_manager = get_epoch_manager(PROTOCOL_VERSION, num_shards, None);
-        let shard_layout = epoch_manager.get_shard_layout(&EpochId::default()).unwrap().clone();
+        let shard_layout =
+            epoch_manager.read().get_shard_layout(&EpochId::default()).unwrap().clone();
         let tracked_accounts = vec!["test1".parse().unwrap(), "test2".parse().unwrap()];
-        let tracker = ShardTracker::new(
-            TrackedConfig::Accounts(tracked_accounts),
-            Arc::new(RwLock::new(epoch_manager)),
-        );
+        let tracker = ShardTracker::new(TrackedConfig::Accounts(tracked_accounts), epoch_manager);
         let mut total_tracked_shards = HashSet::new();
         total_tracked_shards
             .insert(account_id_to_shard_id(&"test1".parse().unwrap(), &shard_layout));
@@ -288,8 +280,7 @@ mod tests {
     fn test_track_all_shards() {
         let num_shards = 4;
         let epoch_manager = get_epoch_manager(PROTOCOL_VERSION, num_shards, None);
-        let tracker =
-            ShardTracker::new(TrackedConfig::AllShards, Arc::new(RwLock::new(epoch_manager)));
+        let tracker = ShardTracker::new(TrackedConfig::AllShards, epoch_manager);
         let total_tracked_shards: HashSet<_> = (0..num_shards).collect();
 
         assert_eq!(
@@ -316,11 +307,7 @@ mod tests {
             avg_hidden_validator_seats_per_shard: get_num_seats_per_shard(4, 0),
             shard_layout: shard_layout,
         };
-        let epoch_manager = Arc::new(RwLock::new(get_epoch_manager(
-            simple_nightshade_version - 1,
-            1,
-            Some(shard_config),
-        )));
+        let epoch_manager = get_epoch_manager(simple_nightshade_version - 1, 1, Some(shard_config));
         let tracked_accounts = vec!["near".parse().unwrap(), "zoo".parse().unwrap()];
         let tracker = ShardTracker::new(
             TrackedConfig::Accounts(tracked_accounts.clone()),
@@ -329,7 +316,7 @@ mod tests {
 
         let h = hash_range(8);
         {
-            let mut epoch_manager = epoch_manager.write().expect(POISONED_LOCK_ERR);
+            let mut epoch_manager = epoch_manager.write();
             record_block(
                 &mut epoch_manager,
                 CryptoHash::default(),
@@ -362,7 +349,7 @@ mod tests {
         for i in 1..8 {
             let mut total_tracked_shards = HashSet::new();
             let num_shards = {
-                let epoch_manager = epoch_manager.read().expect(POISONED_LOCK_ERR);
+                let epoch_manager = epoch_manager.read();
                 let epoch_id = epoch_manager.get_epoch_id_from_prev_block(&h[i - 1]).unwrap();
                 let shard_layout = epoch_manager.get_shard_layout(&epoch_id).unwrap();
                 for account_id in tracked_accounts.iter() {


### PR DESCRIPTION
The mechanical change here is rather small: rename SafeEpochManager to
EpochManagerHandle, and move it from nearcore to epoch_manager crate.

The architectural implications are rather large in contrast. What I aim
to do eventually is to remove EpochManager from RuntimeAdapter trait and
instead force everyone who needs em to hold EpochManagerHandle, rather
than dyn RuntimeAdapter. That way, the RuntimeAdapter would become
essentially stateless, and the shared mutable state of epoch manager
would be explicitly accounted for.

work towards #6910