### PR TITLE
test: fix wrong_sync_info.py

### DIFF
--- a/chain/client/src/adversarial.rs
+++ b/chain/client/src/adversarial.rs
@@ -1,15 +1,11 @@
 #[cfg(feature = "test_features")]
 mod adv {
-    use std::sync::atomic::{AtomicI64, Ordering};
+    use std::sync::atomic::Ordering;
 
     #[derive(Default)]
     struct Inner {
         disable_header_sync: std::sync::atomic::AtomicBool,
         disable_doomslug: std::sync::atomic::AtomicBool,
-        // Negative values mean None, non-negative values mean Some(sync_height
-        // as u64).  This is only for testig so we can live with not supporting
-        // values over i64::MAX.
-        sync_height: AtomicI64,
         is_archival: bool,
     }
 
@@ -18,11 +14,7 @@ mod adv {
 
     impl Controls {
         pub fn new(is_archival: bool) -> Self {
-            Self(std::sync::Arc::new(Inner {
-                is_archival,
-                sync_height: AtomicI64::from(-1),
-                ..Inner::default()
-            }))
+            Self(std::sync::Arc::new(Inner { is_archival, ..Inner::default() }))
         }
 
         pub fn disable_header_sync(&self) -> bool {
@@ -39,20 +31,6 @@ mod adv {
 
         pub fn set_disable_doomslug(&self, value: bool) {
             self.0.disable_doomslug.store(value, Ordering::SeqCst);
-        }
-
-        pub fn sync_height(&self) -> Option<u64> {
-            let value = self.0.sync_height.load(Ordering::SeqCst);
-            if value < 0 {
-                None
-            } else {
-                Some(value as u64)
-            }
-        }
-
-        pub fn set_sync_height(&self, height: u64) {
-            let value: i64 = height.try_into().unwrap();
-            self.0.sync_height.store(value, Ordering::SeqCst);
         }
 
         pub fn is_archival(&self) -> bool {
@@ -77,10 +55,6 @@ mod adv {
 
         pub const fn disable_doomslug(&self) -> bool {
             false
-        }
-
-        pub const fn sync_height(&self) -> Option<u64> {
-            None
         }
     }
 }

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -2049,10 +2049,9 @@ impl Client {
             (0..num_shards).collect()
         };
         let tier1_accounts = self.get_tier1_accounts(&tip)?;
-        #[cfg(not(feature = "test_features"))]
         let height = tip.height;
         #[cfg(feature = "test_features")]
-        let height = self.adv_sync_height.unwrap_or(tip.height);
+        let height = self.adv_sync_height.unwrap_or(height);
         self.network_adapter.do_send(SetChainInfo(ChainInfo {
             height,
             tracked_shards,

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -73,6 +73,9 @@ pub struct Client {
     pub adv_produce_blocks: bool,
     #[cfg(feature = "test_features")]
     pub adv_produce_blocks_only_valid: bool,
+    /// Controls the height which is broadcasted to other peers.
+    #[cfg(feature = "test_features")]
+    pub adv_sync_height: Option<BlockHeight>,
 
     /// Fast Forward accrued delta height used to calculate fast forwarded timestamps for each block.
     #[cfg(feature = "sandbox")]
@@ -220,6 +223,8 @@ impl Client {
             adv_produce_blocks: false,
             #[cfg(feature = "test_features")]
             adv_produce_blocks_only_valid: false,
+            #[cfg(feature = "test_features")]
+            adv_sync_height: None,
             #[cfg(feature = "sandbox")]
             accrued_fastforward_delta: 0,
             config,
@@ -2044,8 +2049,12 @@ impl Client {
             (0..num_shards).collect()
         };
         let tier1_accounts = self.get_tier1_accounts(&tip)?;
+        #[cfg(not(feature = "test_features"))]
+        let height = tip.height;
+        #[cfg(feature = "test_features")]
+        let height = self.adv_sync_height.unwrap_or(tip.height);
         self.network_adapter.do_send(SetChainInfo(ChainInfo {
-            height: tip.height,
+            height,
             tracked_shards,
             tier1_accounts,
         }));

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -341,6 +341,12 @@ impl ClientActor {
                         chain_store_update.commit().expect("adv method should not fail");
                         NetworkClientResponses::NoResponse
                     }
+                    near_network_primitives::types::NetworkAdversarialMessage::AdvSetSyncInfo(height) => {
+                        info!(target: "adversary", %height, "AdvSetSyncInfo");
+                        self.client.adv_sync_height = Some(height);
+                        self.client.send_network_chain_info().expect("adv method should not fail");
+                        NetworkClientResponses::NoResponse
+                    }
                     near_network_primitives::types::NetworkAdversarialMessage::AdvGetSavedBlocks => {
                         info!(target: "adversary", "Requested number of saved blocks");
                         let store = self.client.chain.store().store();
@@ -372,7 +378,6 @@ impl ClientActor {
                             NetworkClientResponses::AdvResult(store_validator.tests_done())
                         }
                     }
-                    _ => panic!("invalid adversary message"),
                 };
             }
             NetworkClientMessages::Transaction { transaction, is_forwarded, check_only } => {

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -927,11 +927,6 @@ impl Handler<NetworkViewClientMessages> for ViewClientActor {
                         self.chain.adv_disable_doomslug();
                         NetworkViewClientResponses::NoResponse
                     }
-                    NetworkAdversarialMessage::AdvSetSyncInfo(height) => {
-                        info!(target: "adversary", "Setting adversarial sync height: {}", height);
-                        self.adv.set_sync_height(height);
-                        NetworkViewClientResponses::NoResponse
-                    }
                     NetworkAdversarialMessage::AdvDisableHeaderSync => {
                         info!(target: "adversary", "Blocking header sync");
                         self.adv.set_disable_header_sync(true);

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -1068,8 +1068,8 @@ impl JsonRpcHandler {
     async fn adv_set_sync_info(&self, params: Option<Value>) -> Result<Value, RpcError> {
         let height = crate::api::parse_params::<u64>(params)?;
         actix::spawn(
-            self.view_client_addr
-                .send(near_network_primitives::types::NetworkViewClientMessages::Adversarial(
+            self.client_addr
+                .send(near_network::types::NetworkClientMessages::Adversarial(
                     near_network_primitives::types::NetworkAdversarialMessage::AdvSetSyncInfo(
                         height,
                     ),


### PR DESCRIPTION
We accidentally made the whole `SetSyncInfo` infra dead code in
https://github.com/near/nearcore/pull/7171

The main change in that PR was the switch from "network pulls data from
client" to "client pushes data to network" model, so we effectively move
this adv control over to client here.

Perhaps it would be cleaner to scope this to just `PeerManager`,
without going through client, but perhaps not -- client has much more
extensive infra for adversarial patching.
