### PR TITLE
test: Fix chunks_recovered_from_full_timeout_too_short.

### DIFF
--- a/integration-tests/src/tests/client/chunks_management.rs
+++ b/integration-tests/src/tests/client/chunks_management.rs
@@ -309,7 +309,12 @@ fn chunks_produced_and_distributed_one_val_per_shard_should_succeed_even_without
 fn chunks_recovered_from_others() {
     heavy_test(|| {
         run_actix(async {
-            chunks_produced_and_distributed_common(2, true, true, 4 * CHUNK_REQUEST_SWITCH_TO_OTHERS_MS);
+            chunks_produced_and_distributed_common(
+                2,
+                true,
+                true,
+                4 * CHUNK_REQUEST_SWITCH_TO_OTHERS_MS,
+            );
         });
     });
 }
@@ -324,7 +329,12 @@ fn chunks_recovered_from_others() {
 fn chunks_recovered_from_full_timeout_too_short() {
     heavy_test(|| {
         run_actix(async {
-            chunks_produced_and_distributed_common(4, true, true, 2 * CHUNK_REQUEST_SWITCH_TO_OTHERS_MS);
+            chunks_produced_and_distributed_common(
+                4,
+                true,
+                true,
+                2 * CHUNK_REQUEST_SWITCH_TO_OTHERS_MS,
+            );
         });
     });
 }

--- a/integration-tests/src/tests/client/chunks_management.rs
+++ b/integration-tests/src/tests/client/chunks_management.rs
@@ -29,6 +29,7 @@ use near_primitives::types::AccountId;
 fn chunks_produced_and_distributed_common(
     validator_groups: u64,
     drop_from_1_to_4: bool,
+    drop_all_chunk_forward_msgs: bool,
     block_timeout: u64,
 ) {
     init_test_logger();
@@ -174,6 +175,10 @@ fn chunks_produced_and_distributed_common(
                     }
                 }
                 NetworkRequests::PartialEncodedChunkForward { account_id: to_whom, .. } => {
+                    if drop_all_chunk_forward_msgs {
+                        println!("Dropping Partial Encoded Chunk Forward Message");
+                        return (NetworkResponses::NoResponse.into(), false);
+                    }
                     if drop_from_1_to_4
                         && from_whom.as_ref() == "test1"
                         && to_whom.as_ref() == "test4"
@@ -240,7 +245,7 @@ fn chunks_produced_and_distributed_common(
 fn chunks_produced_and_distributed_all_in_all_shards() {
     heavy_test(|| {
         run_actix(async {
-            chunks_produced_and_distributed_common(1, false, 15 * CHUNK_REQUEST_RETRY_MS);
+            chunks_produced_and_distributed_common(1, false, false, 15 * CHUNK_REQUEST_RETRY_MS);
         });
     });
 }
@@ -249,7 +254,7 @@ fn chunks_produced_and_distributed_all_in_all_shards() {
 fn chunks_produced_and_distributed_2_vals_per_shard() {
     heavy_test(|| {
         run_actix(async {
-            chunks_produced_and_distributed_common(2, false, 15 * CHUNK_REQUEST_RETRY_MS);
+            chunks_produced_and_distributed_common(2, false, false, 15 * CHUNK_REQUEST_RETRY_MS);
         });
     });
 }
@@ -258,7 +263,34 @@ fn chunks_produced_and_distributed_2_vals_per_shard() {
 fn chunks_produced_and_distributed_one_val_per_shard() {
     heavy_test(|| {
         run_actix(async {
-            chunks_produced_and_distributed_common(4, false, 15 * CHUNK_REQUEST_RETRY_MS);
+            chunks_produced_and_distributed_common(4, false, false, 15 * CHUNK_REQUEST_RETRY_MS);
+        });
+    });
+}
+
+#[test]
+fn chunks_produced_and_distributed_all_in_all_shards_should_succeed_even_without_forwarding() {
+    heavy_test(|| {
+        run_actix(async {
+            chunks_produced_and_distributed_common(1, false, false, 15 * CHUNK_REQUEST_RETRY_MS);
+        });
+    });
+}
+
+#[test]
+fn chunks_produced_and_distributed_2_vals_per_shard_should_succeed_even_without_forwarding() {
+    heavy_test(|| {
+        run_actix(async {
+            chunks_produced_and_distributed_common(2, false, false, 15 * CHUNK_REQUEST_RETRY_MS);
+        });
+    });
+}
+
+#[test]
+fn chunks_produced_and_distributed_one_val_per_shard_should_succeed_even_without_forwarding() {
+    heavy_test(|| {
+        run_actix(async {
+            chunks_produced_and_distributed_common(4, false, false, 15 * CHUNK_REQUEST_RETRY_MS);
         });
     });
 }
@@ -268,12 +300,16 @@ fn chunks_produced_and_distributed_one_val_per_shard() {
 /// We block all the communication from test1 to test4, and expect that in 1.5 seconds test4 will
 /// give up on getting the part from test1 and will get it from test2 (who will have it because
 /// `validator_groups=2`)
+///
+/// Note that due to #7385 (which sends chunk forwarding messages irrespective of shard assignment),
+/// we disable chunk forwarding messages for the following tests, so we can focus on chunk
+/// requesting behavior.
 #[test]
 #[cfg_attr(not(feature = "expensive_tests"), ignore)]
 fn chunks_recovered_from_others() {
     heavy_test(|| {
         run_actix(async {
-            chunks_produced_and_distributed_common(2, true, 4 * CHUNK_REQUEST_SWITCH_TO_OTHERS_MS);
+            chunks_produced_and_distributed_common(2, true, true, 4 * CHUNK_REQUEST_SWITCH_TO_OTHERS_MS);
         });
     });
 }
@@ -288,7 +324,7 @@ fn chunks_recovered_from_others() {
 fn chunks_recovered_from_full_timeout_too_short() {
     heavy_test(|| {
         run_actix(async {
-            chunks_produced_and_distributed_common(4, true, 2 * CHUNK_REQUEST_SWITCH_TO_OTHERS_MS);
+            chunks_produced_and_distributed_common(4, true, true, 2 * CHUNK_REQUEST_SWITCH_TO_OTHERS_MS);
         });
     });
 }
@@ -302,6 +338,7 @@ fn chunks_recovered_from_full() {
         run_actix(async {
             chunks_produced_and_distributed_common(
                 4,
+                true,
                 true,
                 2 * CHUNK_REQUEST_SWITCH_TO_FULL_FETCH_MS,
             );


### PR DESCRIPTION
#7385 made chunk forward messages sent to all chunk producers irrespective of shard assignment. This test suite was assuming the previous behavior that forward messages only went to the chunk producers that care about the specific shard. It's still a useful test suite though because it was testing the chunk fetching timeout behavior. So this PR conditionally drops all chunk forward messages so we can focus on testing the chunk fetching behavior.