### PR TITLE
store: remove DBCol::variant_name

### DIFF
--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -358,7 +358,7 @@ impl StoreValidator {
             }
             if let Some(timeout) = self.timeout {
                 if self.start_time.elapsed() > Duration::from_millis(timeout) {
-                    warn!(target: "adversary", "Store validator hit timeout at {} ({}/{})", col.variant_name(), col.into_usize(), DBCol::LENGTH);
+                    warn!(target: "adversary", "Store validator hit timeout at {col} ({}/{})", col.into_usize(), DBCol::LENGTH);
                     return;
                 }
             }

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -348,14 +348,6 @@ impl DBCol {
             _ => false,
         }
     }
-
-    /// Returns variant’s name as a static string.
-    ///
-    /// This is equivalent to [`Into::into`] but often makes the call site
-    /// simpler since there is no need to ascribe the type.
-    pub fn variant_name(&self) -> &'static str {
-        self.into()
-    }
 }
 
 impl fmt::Display for DBCol {

--- a/core/store/src/db/rocksdb.rs
+++ b/core/store/src/db/rocksdb.rs
@@ -148,7 +148,7 @@ impl RocksDB {
         }
         cf_handles.map(|col, ptr| {
             ptr.unwrap_or_else(|| {
-                panic!("Missing cf handle for {}", col.variant_name());
+                panic!("Missing cf handle for {col}");
             })
         })
     }


### PR DESCRIPTION
DBCol::variant_name method is redundant considering it can be easily
replaced by the features of the Display trait in all places where it
is currently used.