### PR TITLE
fix: avoid infinite loop in estimator

### DIFF
--- a/runtime/runtime-params-estimator/src/transaction_builder.rs
+++ b/runtime/runtime-params-estimator/src/transaction_builder.rs
@@ -95,6 +95,9 @@ impl TransactionBuilder {
         self.accounts[account_index].clone()
     }
     pub(crate) fn random_unused_account(&mut self) -> AccountId {
+        if self.used_accounts.len() == self.accounts.len() {
+            panic!("All accounts used. Try running with a higher value for the parameter `--accounts-num <NUM>`.")
+        }
         loop {
             let account = self.random_account();
             if self.used_accounts.insert(account.clone()) {


### PR DESCRIPTION
When all accounts have been used and an estimation requests
an unsued account, the estimator panics instead of hanging in an
infinite loop.

Example error:

```
thread 'main' panicked at 'All accounts used. Try running with a higher value for the parameter `--accounts-num <NUM>`.', runtime/runtime-params-estimator/src/transaction_builder.rs:99:13
```

resolves #7448