### PR TITLE
store: make StoreOpener::open return Result rather than panicking

### DIFF
--- a/chain/indexer/src/streamer/mod.rs
+++ b/chain/indexer/src/streamer/mod.rs
@@ -287,9 +287,8 @@ pub(crate) async fn start(
     blocks_sink: mpsc::Sender<StreamerMessage>,
 ) {
     info!(target: INDEXER, "Starting Streamer...");
-    let indexer_db_path = near_store::Store::opener(&indexer_config.home_dir, &store_config)
-        .get_path()
-        .join("indexer");
+    let indexer_db_path =
+        near_store::Store::opener(&indexer_config.home_dir, &store_config).path().join("indexer");
 
     // TODO: implement proper error handling
     let db = DB::open_default(indexer_db_path).unwrap();

--- a/chain/network/src/peer_manager/peer_store_test.rs
+++ b/chain/network/src/peer_manager/peer_store_test.rs
@@ -35,7 +35,7 @@ fn ban_store() {
     let peer_info_to_ban = gen_peer_info(1);
     let boot_nodes = vec![peer_info_a, peer_info_to_ban.clone()];
     {
-        let store = store::Store::from(opener.open());
+        let store = store::Store::from(opener.open().unwrap());
         let mut peer_store =
             PeerStore::new(&clock.clock(), store, &boot_nodes, Default::default(), false).unwrap();
         assert_eq!(peer_store.healthy_peers(3).len(), 2);
@@ -43,7 +43,7 @@ fn ban_store() {
         assert_eq!(peer_store.healthy_peers(3).len(), 1);
     }
     {
-        let store_new = store::Store::from(opener.open());
+        let store_new = store::Store::from(opener.open().unwrap());
         let peer_store_new =
             PeerStore::new(&clock.clock(), store_new, &boot_nodes, Default::default(), false)
                 .unwrap();
@@ -59,7 +59,7 @@ fn test_unconnected_peer() {
     let peer_info_to_ban = gen_peer_info(1);
     let boot_nodes = vec![peer_info_a, peer_info_to_ban];
     {
-        let store = store::Store::from(opener.open());
+        let store = store::Store::from(opener.open().unwrap());
         let peer_store =
             PeerStore::new(&clock.clock(), store, &boot_nodes, Default::default(), false).unwrap();
         assert!(peer_store.unconnected_peer(|_| false).is_some());
@@ -79,7 +79,7 @@ fn test_unconnected_peer_only_boot_nodes() {
     // we should connect to peer_in_store
     {
         let (_tmp_dir, opener) = Store::test_opener();
-        let store = store::Store::from(opener.open());
+        let store = store::Store::from(opener.open().unwrap());
         let mut peer_store =
             PeerStore::new(&clock.clock(), store, &boot_nodes, Default::default(), false).unwrap();
         peer_store.add_peer(&clock.clock(), peer_in_store.clone(), TrustLevel::Direct).unwrap();
@@ -92,7 +92,7 @@ fn test_unconnected_peer_only_boot_nodes() {
     // connect to only boot nodes is enabled - we should not find any peer to connect to.
     {
         let (_tmp_dir, opener) = Store::test_opener();
-        let store = store::Store::from(opener.open());
+        let store = store::Store::from(opener.open().unwrap());
         let mut peer_store =
             PeerStore::new(&clock.clock(), store, &boot_nodes, Default::default(), true).unwrap();
         peer_store.add_peer(&clock.clock(), peer_in_store.clone(), TrustLevel::Direct).unwrap();
@@ -104,7 +104,7 @@ fn test_unconnected_peer_only_boot_nodes() {
     // we should connect to it - no matter what the setting is.
     for connect_to_boot_nodes in [true, false] {
         let (_tmp_dir, opener) = Store::test_opener();
-        let store = store::Store::from(opener.open());
+        let store = store::Store::from(opener.open().unwrap());
         let mut peer_store = PeerStore::new(
             &clock.clock(),
             store,
@@ -366,7 +366,7 @@ fn remove_blacklisted_peers_from_store() {
 
     // Add three peers.
     {
-        let store = store::Store::from(opener.open());
+        let store = store::Store::from(opener.open().unwrap());
         let mut peer_store =
             PeerStore::new(&clock.clock(), store, &[], Default::default(), false).unwrap();
         peer_store.add_indirect_peers(&clock.clock(), peer_infos.clone().into_iter()).unwrap();
@@ -375,7 +375,7 @@ fn remove_blacklisted_peers_from_store() {
 
     // Blacklisted peers are removed from the store.
     {
-        let store = store::Store::from(opener.open());
+        let store = store::Store::from(opener.open().unwrap());
         let blacklist: Blacklist =
             [BlacklistEntry::from_addr(peer_infos[2].addr.unwrap())].into_iter().collect();
         let _peer_store = PeerStore::new(&clock.clock(), store, &[], blacklist, false).unwrap();
@@ -385,7 +385,7 @@ fn remove_blacklisted_peers_from_store() {
 
 #[track_caller]
 fn assert_peers_in_store(opener: &StoreOpener, want: &[PeerId]) {
-    let store = store::Store::from(opener.open());
+    let store = store::Store::from(opener.open().unwrap());
     let got: HashSet<PeerId> = store.list_peer_states().unwrap().into_iter().map(|x| x.0).collect();
     let want: HashSet<PeerId> = want.iter().cloned().collect();
     assert_eq!(got, want);
@@ -421,7 +421,7 @@ fn test_delete_peers() {
         peer_infos.iter().map(|info| info.addr.unwrap().clone()).collect::<Vec<_>>();
 
     {
-        let store = store::Store::from(opener.open());
+        let store = store::Store::from(opener.open().unwrap());
         let mut peer_store =
             PeerStore::new(&clock.clock(), store, &[], Default::default(), false).unwrap();
         peer_store.add_indirect_peers(&clock.clock(), peer_infos.into_iter()).unwrap();
@@ -429,7 +429,7 @@ fn test_delete_peers() {
     assert_peers_in_store(&opener, &peer_ids);
 
     {
-        let store = store::Store::from(opener.open());
+        let store = store::Store::from(opener.open().unwrap());
         let mut peer_store =
             PeerStore::new(&clock.clock(), store, &[], Default::default(), false).unwrap();
         assert_peers_in_cache(&peer_store, &peer_ids, &peer_addresses);

--- a/core/store/benches/store_bench.rs
+++ b/core/store/benches/store_bench.rs
@@ -19,7 +19,7 @@ fn benchmark_write_then_read_successful(
     let tmp_dir = tempfile::tempdir().unwrap();
     // Use default StoreConfig rather than Store::test_opener so we’re using the
     // same configuration as in production.
-    let store = Store::opener(tmp_dir.path(), &Default::default()).open();
+    let store = Store::opener(tmp_dir.path(), &Default::default()).open().unwrap();
     let keys = generate_keys(num_keys, key_size);
     write_to_db(&store, &keys, max_value_size, col);
 

--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -1,3 +1,5 @@
+use std::io;
+
 use near_primitives::shard_layout::ShardUId;
 use near_primitives::version::DbVersion;
 
@@ -161,7 +163,7 @@ impl<'a> StoreOpener<'a> {
     }
 
     /// Returns version of the database; or `None` if it does not exist.
-    pub fn get_version_if_exists(&self) -> std::io::Result<Option<DbVersion>> {
+    pub fn get_version_if_exists(&self) -> io::Result<Option<DbVersion>> {
         if self.check_if_exists() {
             Some(crate::RocksDB::get_version(&self.path, &self.config)).transpose()
         } else {
@@ -170,11 +172,11 @@ impl<'a> StoreOpener<'a> {
     }
 
     /// Opens the RocksDB database.
-    pub fn open(&self) -> std::io::Result<crate::Store> {
+    pub fn open(&self) -> io::Result<crate::Store> {
         let exists = self.check_if_exists();
         if !exists && matches!(self.mode, Mode::ReadOnly) {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
                 "Cannot open non-existent database for reading",
             ));
         }

--- a/core/store/src/db/rocksdb.rs
+++ b/core/store/src/db/rocksdb.rs
@@ -654,7 +654,7 @@ mod tests {
     #[test]
     fn rocksdb_merge_sanity() {
         let (_tmp_dir, opener) = Store::test_opener();
-        let store = opener.open();
+        let store = opener.open().unwrap();
         let ptr = (&*store.storage) as *const (dyn Database + 'static);
         let rocksdb = unsafe { &*(ptr as *const RocksDB) };
         assert_eq!(store.get(DBCol::State, &[1]).unwrap(), None);

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -684,7 +684,7 @@ mod tests {
     #[test]
     fn clear_column_rocksdb() {
         let (_tmp_dir, opener) = Store::test_opener();
-        test_clear_column(opener.open());
+        test_clear_column(opener.open().unwrap());
     }
 
     #[test]
@@ -755,7 +755,7 @@ mod tests {
 
     #[test]
     fn rocksdb_iter_order() {
-        test_iter_order_impl(Store::test_opener().1.open());
+        test_iter_order_impl(Store::test_opener().1.open().unwrap());
     }
 
     #[test]

--- a/core/store/src/migrations.rs
+++ b/core/store/src/migrations.rs
@@ -78,7 +78,7 @@ where
 }
 
 pub fn migrate_28_to_29(store_opener: &StoreOpener) {
-    let store = store_opener.open();
+    let store = store_opener.open().unwrap();
     let mut store_update = store.store_update();
     store_update.delete_all(DBCol::_NextBlockWithNewChunk);
     store_update.delete_all(DBCol::_LastBlockWithNewChunk);
@@ -99,7 +99,7 @@ pub fn migrate_29_to_30(store_opener: &StoreOpener) {
     };
     use std::collections::BTreeMap;
 
-    let store = store_opener.open();
+    let store = store_opener.open().unwrap();
 
     #[derive(BorshDeserialize)]
     pub struct OldEpochSummary {

--- a/genesis-tools/genesis-populate/src/main.rs
+++ b/genesis-tools/genesis-populate/src/main.rs
@@ -25,7 +25,7 @@ fn main() {
     let near_config = load_config(home_dir, GenesisValidationMode::Full)
         .unwrap_or_else(|e| panic!("Error loading config: {:#}", e));
 
-    let store = near_store::Store::opener(home_dir, &near_config.config.store).open();
+    let store = near_store::Store::opener(home_dir, &near_config.config.store).open().unwrap();
     GenesisBuilder::from_config_and_store(home_dir, near_config, store)
         .add_additional_accounts(additional_accounts_num)
         .add_additional_accounts_contract(near_test_contracts::trivial_contract().to_vec())

--- a/genesis-tools/genesis-populate/src/state_dump.rs
+++ b/genesis-tools/genesis-populate/src/state_dump.rs
@@ -16,7 +16,7 @@ pub struct StateDump {
 
 impl StateDump {
     pub fn from_dir(dir: &Path, store_home_dir: &Path) -> Self {
-        let store = near_store::Store::opener(store_home_dir, &Default::default()).open();
+        let store = near_store::Store::opener(store_home_dir, &Default::default()).open().unwrap();
         let state_file = dir.join(STATE_DUMP_FILE);
         store
             .load_from_file(DBCol::State, state_file.as_path())

--- a/nearcore/benches/store.rs
+++ b/nearcore/benches/store.rs
@@ -28,8 +28,10 @@ fn read_trie_items(bench: &mut Bencher, shard_id: usize, mode: Mode) {
 
     bench.iter(move || {
         tracing::info!(target: "neard", "{:?}", home_dir);
-        let store =
-            near_store::Store::opener(&home_dir, &near_config.config.store).mode(mode).open();
+        let store = near_store::Store::opener(&home_dir, &near_config.config.store)
+            .mode(mode)
+            .open()
+            .unwrap();
 
         let chain_store =
             ChainStore::new(store.clone(), near_config.genesis.config.genesis_height, true);

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -9,7 +9,7 @@ use near_store::DBCol;
 /// Fix an issue with block ordinal (#5761)
 // This migration takes at least 3 hours to complete on mainnet
 pub fn migrate_30_to_31(store_opener: &near_store::StoreOpener, near_config: &crate::NearConfig) {
-    let store = store_opener.open();
+    let store = store_opener.open().unwrap();
     if near_config.client_config.archive && &near_config.genesis.config.chain_id == "mainnet" {
         let genesis_height = near_config.genesis.config.genesis_height;
         let chain_store = ChainStore::new(store.clone(), genesis_height, false);

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -2106,7 +2106,7 @@ mod test {
             minimum_stake_divisor: Option<u64>,
         ) -> Self {
             let (dir, opener) = Store::test_opener();
-            let store = opener.open();
+            let store = opener.open().unwrap();
             let all_validators = validators.iter().fold(BTreeSet::new(), |acc, x| {
                 acc.union(&x.iter().cloned().collect()).cloned().collect()
             });

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -131,7 +131,8 @@ fn main() -> anyhow::Result<()> {
 
         let near_config = nearcore::load_config(&state_dump_path, GenesisValidationMode::Full)
             .context("Error loading config")?;
-        let store = near_store::Store::opener(&state_dump_path, &near_config.config.store).open();
+        let store =
+            near_store::Store::opener(&state_dump_path, &near_config.config.store).open().unwrap();
         GenesisBuilder::from_config_and_store(&state_dump_path, near_config, store)
             .add_additional_accounts(cli_args.additional_accounts_num)
             .add_additional_accounts_contract(contract_code.to_vec())

--- a/test-utils/runtime-tester/src/run_test.rs
+++ b/test-utils/runtime-tester/src/run_test.rs
@@ -48,7 +48,7 @@ impl Scenario {
             (None, create_test_store())
         } else {
             let (tempdir, opener) = near_store::Store::test_opener();
-            (Some(tempdir), opener.open())
+            (Some(tempdir), opener.open().unwrap())
         };
 
         let mut env = TestEnv::builder(ChainGenesis::new(&genesis))

--- a/test-utils/store-validator/src/main.rs
+++ b/test-utils/store-validator/src/main.rs
@@ -30,7 +30,7 @@ fn main() {
     let near_config = load_config(home_dir, GenesisValidationMode::Full)
         .unwrap_or_else(|e| panic!("Error loading config: {:#}", e));
 
-    let store = near_store::Store::opener(home_dir, &near_config.config.store).open();
+    let store = near_store::Store::opener(home_dir, &near_config.config.store).open().unwrap();
 
     let runtime_adapter: Arc<dyn RuntimeAdapter> =
         Arc::new(nearcore::NightshadeRuntime::from_config(home_dir, store.clone(), &near_config));

--- a/tools/mock-node/src/setup.rs
+++ b/tools/mock-node/src/setup.rs
@@ -33,7 +33,7 @@ fn setup_runtime(
     let store = if in_memory_storage {
         create_test_store()
     } else {
-        near_store::Store::opener(home_dir, &config.config.store).open()
+        near_store::Store::opener(home_dir, &config.config.store).open().unwrap()
     };
 
     Arc::new(NightshadeRuntime::from_config(home_dir, store, config))

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -75,7 +75,7 @@ impl StateViewerSubCommand {
             .unwrap_or_else(|e| panic!("Error loading config: {:#}", e));
         let store_opener =
             near_store::Store::opener(home_dir, &near_config.config.store).mode(mode);
-        let store = store_opener.open();
+        let store = store_opener.open().unwrap();
         match self {
             StateViewerSubCommand::Peers => peers(store),
             StateViewerSubCommand::State => state(home_dir, near_config, store),
@@ -91,7 +91,7 @@ impl StateViewerSubCommand {
             StateViewerSubCommand::DumpCode(cmd) => cmd.run(home_dir, near_config, store),
             StateViewerSubCommand::DumpAccountStorage(cmd) => cmd.run(home_dir, near_config, store),
             StateViewerSubCommand::EpochInfo(cmd) => cmd.run(home_dir, near_config, store),
-            StateViewerSubCommand::RocksDBStats(cmd) => cmd.run(&store_opener.get_path()),
+            StateViewerSubCommand::RocksDBStats(cmd) => cmd.run(&store_opener.path()),
             StateViewerSubCommand::Receipts(cmd) => cmd.run(near_config, store),
             StateViewerSubCommand::Chunks(cmd) => cmd.run(near_config, store),
             StateViewerSubCommand::PartialChunks(cmd) => cmd.run(near_config, store),


### PR DESCRIPTION
Having a Result allows for the error to be propagated to the user in
nicer form than in a panic message.  This will also help in the future
expansion of the StoreOpener::open method to return different kinds of
failures which may be handled by the caller in different ways.