### PR TITLE
store: propagate errors from migration functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3436,6 +3436,7 @@ version = "0.0.0"
 name = "near-store"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
  "assert_matches",
  "bencher",
  "borsh",

--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -214,16 +214,6 @@ pub enum Error {
     Other(String),
 }
 
-impl std::convert::From<Error> for io::Error {
-    fn from(err: Error) -> io::Error {
-        match err {
-            Error::IOErr(err) => err,
-            Error::Other(msg) => io::Error::new(io::ErrorKind::Other, msg),
-            err => io::Error::new(io::ErrorKind::Other, err),
-        }
-    }
-}
-
 /// For now StorageError can happen at any time from ViewClient because of
 /// the used isolation level + running ViewClient in a separate thread.
 pub trait LogTransientStorageError {

--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -214,6 +214,16 @@ pub enum Error {
     Other(String),
 }
 
+impl std::convert::From<Error> for io::Error {
+    fn from(err: Error) -> io::Error {
+        match err {
+            Error::IOErr(err) => err,
+            Error::Other(msg) => io::Error::new(io::ErrorKind::Other, msg),
+            err => io::Error::new(io::ErrorKind::Other, err),
+        }
+    }
+}
+
 /// For now StorageError can happen at any time from ViewClient because of
 /// the used isolation level + running ViewClient in a separate thread.
 pub trait LogTransientStorageError {

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -9,6 +9,7 @@ rust-version = "1.63.0"
 edition = "2021"
 
 [dependencies]
+anyhow = "1.0.62"
 byteorder = "1.2"
 bytesize = { version = "1.1", features = ["serde"] }
 derive_more = "0.99.3"

--- a/core/store/src/migrations.rs
+++ b/core/store/src/migrations.rs
@@ -78,17 +78,18 @@ where
     store_update.finish()
 }
 
-pub fn migrate_28_to_29(store_opener: &StoreOpener) -> std::io::Result<()> {
+pub fn migrate_28_to_29(store_opener: &StoreOpener) -> anyhow::Result<()> {
     let store = store_opener.open()?;
     let mut store_update = store.store_update();
     store_update.delete_all(DBCol::_NextBlockWithNewChunk);
     store_update.delete_all(DBCol::_LastBlockWithNewChunk);
     store_update.commit()?;
 
-    set_store_version(&store, 29)
+    set_store_version(&store, 29)?;
+    Ok(())
 }
 
-pub fn migrate_29_to_30(store_opener: &StoreOpener) -> std::io::Result<()> {
+pub fn migrate_29_to_30(store_opener: &StoreOpener) -> anyhow::Result<()> {
     use near_primitives::epoch_manager::block_info::BlockInfo;
     use near_primitives::epoch_manager::epoch_info::EpochSummary;
     use near_primitives::epoch_manager::AGGREGATOR_KEY;
@@ -176,5 +177,6 @@ pub fn migrate_29_to_30(store_opener: &StoreOpener) -> std::io::Result<()> {
 
     store_update.finish()?;
 
-    set_store_version(&store, 30)
+    set_store_version(&store, 30)?;
+    Ok(())
 }

--- a/core/store/src/migrations.rs
+++ b/core/store/src/migrations.rs
@@ -9,12 +9,12 @@ use near_primitives::types::AccountId;
 
 use crate::{DBCol, Store, StoreOpener, StoreUpdate};
 
-pub fn set_store_version(store: &Store, db_version: u32) {
+pub fn set_store_version(store: &Store, db_version: u32) -> std::io::Result<()> {
     let mut store_update = store.store_update();
     // Contrary to other integers, we’re using textual representation for
     // storing DbVersion in VERSION_KEY thus to_string rather than to_le_bytes.
     store_update.set(DBCol::DbVersion, crate::db::VERSION_KEY, db_version.to_string().as_bytes());
-    store_update.commit().expect("Failed to write version to database");
+    store_update.commit()
 }
 
 pub struct BatchedStoreUpdate<'a> {
@@ -70,24 +70,25 @@ where
     F: Fn(T) -> U,
 {
     let mut store_update = BatchedStoreUpdate::new(store, 10_000_000);
-    for (key, value) in store.iter(col).map(Result::unwrap) {
+    for pair in store.iter(col) {
+        let (key, value) = pair?;
         let new_value = f(T::try_from_slice(&value).unwrap());
         store_update.set_ser(col, &key, &new_value)?;
     }
     store_update.finish()
 }
 
-pub fn migrate_28_to_29(store_opener: &StoreOpener) {
-    let store = store_opener.open().unwrap();
+pub fn migrate_28_to_29(store_opener: &StoreOpener) -> std::io::Result<()> {
+    let store = store_opener.open()?;
     let mut store_update = store.store_update();
     store_update.delete_all(DBCol::_NextBlockWithNewChunk);
     store_update.delete_all(DBCol::_LastBlockWithNewChunk);
-    store_update.commit().unwrap();
+    store_update.commit()?;
 
-    set_store_version(&store, 29);
+    set_store_version(&store, 29)
 }
 
-pub fn migrate_29_to_30(store_opener: &StoreOpener) {
+pub fn migrate_29_to_30(store_opener: &StoreOpener) -> std::io::Result<()> {
     use near_primitives::epoch_manager::block_info::BlockInfo;
     use near_primitives::epoch_manager::epoch_info::EpochSummary;
     use near_primitives::epoch_manager::AGGREGATOR_KEY;
@@ -99,7 +100,7 @@ pub fn migrate_29_to_30(store_opener: &StoreOpener) {
     };
     use std::collections::BTreeMap;
 
-    let store = store_opener.open().unwrap();
+    let store = store_opener.open()?;
 
     #[derive(BorshDeserialize)]
     pub struct OldEpochSummary {
@@ -129,9 +130,9 @@ pub fn migrate_29_to_30(store_opener: &StoreOpener) {
         pub last_block_hash: CryptoHash,
     }
 
-    map_col(&store, DBCol::ChunkExtra, ChunkExtra::V1).unwrap();
+    map_col(&store, DBCol::ChunkExtra, ChunkExtra::V1)?;
 
-    map_col(&store, DBCol::BlockInfo, BlockInfo::V1).unwrap();
+    map_col(&store, DBCol::BlockInfo, BlockInfo::V1)?;
 
     map_col(&store, DBCol::EpochValidatorInfo, |info: OldEpochSummary| EpochSummary {
         prev_epoch_last_block_hash: info.prev_epoch_last_block_hash,
@@ -139,14 +140,16 @@ pub fn migrate_29_to_30(store_opener: &StoreOpener) {
         validator_kickout: info.validator_kickout,
         validator_block_chunk_stats: info.validator_block_chunk_stats,
         next_version: info.next_version,
-    })
-    .unwrap();
+    })?;
 
     // DBCol::EpochInfo has a special key which contains a different type than all other
     // values (EpochInfoAggregator), so we cannot use `map_col` on it. We need to handle
     // the AGGREGATOR_KEY differently from all others.
     let col = DBCol::EpochInfo;
-    let keys: Vec<_> = store.iter(col).map(Result::unwrap).map(|(key, _)| key).collect();
+    let keys = store
+        .iter(col)
+        .map(|item| item.map(|(key, _)| key))
+        .collect::<std::io::Result<Vec<_>>>()?;
     let mut store_update = BatchedStoreUpdate::new(&store, 10_000_000);
     for key in keys {
         if key.as_ref() == AGGREGATOR_KEY {
@@ -163,15 +166,15 @@ pub fn migrate_29_to_30(store_opener: &StoreOpener) {
                     .map(|(account, stake)| (account, ValidatorStake::V1(stake)))
                     .collect(),
             };
-            store_update.set_ser(col, key.as_ref(), &new_value).unwrap();
+            store_update.set_ser(col, key.as_ref(), &new_value)?;
         } else {
             let value: EpochInfoV1 = store.get_ser(col, key.as_ref()).unwrap().unwrap();
             let new_value = EpochInfo::V1(value);
-            store_update.set_ser(col, key.as_ref(), &new_value).unwrap();
+            store_update.set_ser(col, key.as_ref(), &new_value)?;
         }
     }
 
-    store_update.finish().unwrap();
+    store_update.finish()?;
 
-    set_store_version(&store, 30);
+    set_store_version(&store, 30)
 }

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -152,17 +152,17 @@ fn apply_store_migrations_if_exists(
     if db_version <= 28 {
         // version 28 => 29: delete ColNextBlockWithNewChunk, ColLastBlockWithNewChunk
         info!(target: "near", "Migrate DB from version 28 to 29");
-        migrate_28_to_29(store_opener);
+        migrate_28_to_29(store_opener)?;
     }
     if db_version <= 29 {
         // version 29 => 30: migrate all structures that use ValidatorStake to versionized version
         info!(target: "near", "Migrate DB from version 29 to 30");
-        migrate_29_to_30(store_opener);
+        migrate_29_to_30(store_opener)?;
     }
     if db_version <= 30 {
         // version 30 => 31: recompute block ordinal due to a bug fixed in #5761
         info!(target: "near", "Migrate DB from version 30 to 31");
-        migrate_30_to_31(store_opener, &near_config);
+        migrate_30_to_31(store_opener, &near_config)?;
     }
 
     if cfg!(feature = "nightly") || cfg!(feature = "nightly_protocol") {
@@ -170,7 +170,7 @@ fn apply_store_migrations_if_exists(
             .open()
             .with_context(|| format!("Opening database at {}", store_opener.path().display()))?;
         // set some dummy value to avoid conflict with other migrations from nightly features
-        set_store_version(&store, 10000);
+        set_store_version(&store, 10000)?;
     } else {
         debug_assert_eq!(
             Some(near_primitives::version::DB_VERSION),
@@ -208,7 +208,8 @@ fn init_and_migrate_store(home_dir: &Path, near_config: &NearConfig) -> anyhow::
         .open()
         .with_context(|| format!("Opening database at {}", opener.path().display()))?;
     if !exists {
-        set_store_version(&store, near_primitives::version::DB_VERSION);
+        set_store_version(&store, near_primitives::version::DB_VERSION)
+            .with_context(|| format!("Initialising database at {}", opener.path().display()))?;
     }
 
     // Check if the storage is an archive and if it is make sure we are too.

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -11,18 +11,19 @@ use near_store::DBCol;
 pub fn migrate_30_to_31(
     store_opener: &near_store::StoreOpener,
     near_config: &crate::NearConfig,
-) -> std::io::Result<()> {
+) -> anyhow::Result<()> {
     let store = store_opener.open()?;
     if near_config.client_config.archive && &near_config.genesis.config.chain_id == "mainnet" {
         do_migrate_30_to_31(&store, &near_config.genesis.config)?;
     }
-    set_store_version(&store, 31)
+    set_store_version(&store, 31)?;
+    Ok(())
 }
 
 pub fn do_migrate_30_to_31(
     store: &near_store::Store,
     genesis_config: &near_chain_configs::GenesisConfig,
-) -> std::io::Result<()> {
+) -> anyhow::Result<()> {
     let genesis_height = genesis_config.genesis_height;
     let chain_store = ChainStore::new(store.clone(), genesis_height, false);
     let head = chain_store.head()?;
@@ -47,7 +48,8 @@ pub fn do_migrate_30_to_31(
         }
     }
     println!("total inconsistency count: {}", count);
-    store_update.finish()
+    store_update.finish()?;
+    Ok(())
 }
 
 /// In test runs reads and writes here used 442 TGas, but in test on live net migration take

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -8,33 +8,46 @@ use near_store::DBCol;
 
 /// Fix an issue with block ordinal (#5761)
 // This migration takes at least 3 hours to complete on mainnet
-pub fn migrate_30_to_31(store_opener: &near_store::StoreOpener, near_config: &crate::NearConfig) {
-    let store = store_opener.open().unwrap();
+pub fn migrate_30_to_31(
+    store_opener: &near_store::StoreOpener,
+    near_config: &crate::NearConfig,
+) -> std::io::Result<()> {
+    let store = store_opener.open()?;
     if near_config.client_config.archive && &near_config.genesis.config.chain_id == "mainnet" {
-        let genesis_height = near_config.genesis.config.genesis_height;
-        let chain_store = ChainStore::new(store.clone(), genesis_height, false);
-        let head = chain_store.head().unwrap();
-        let mut store_update = BatchedStoreUpdate::new(&store, 10_000_000);
-        let mut count = 0;
-        // we manually checked mainnet archival data and the first block where the discrepancy happened is `47443088`.
-        for height in 47443088..=head.height {
-            if let Ok(block_hash) = chain_store.get_block_hash_by_height(height) {
-                let block_ordinal = chain_store.get_block_merkle_tree(&block_hash).unwrap().size();
-                let block_hash_from_block_ordinal =
-                    chain_store.get_block_hash_from_ordinal(block_ordinal).unwrap();
-                if block_hash_from_block_ordinal != block_hash {
-                    println!("Inconsistency in block ordinal to block hash mapping found at block height {}", height);
-                    count += 1;
-                    store_update
-                        .set_ser(DBCol::BlockOrdinal, &index_to_bytes(block_ordinal), &block_hash)
-                        .expect("BorshSerialize should not fail");
-                }
+        do_migrate_30_to_31(&store, &near_config.genesis.config)?;
+    }
+    set_store_version(&store, 31)
+}
+
+pub fn do_migrate_30_to_31(
+    store: &near_store::Store,
+    genesis_config: &near_chain_configs::GenesisConfig,
+) -> std::io::Result<()> {
+    let genesis_height = genesis_config.genesis_height;
+    let chain_store = ChainStore::new(store.clone(), genesis_height, false);
+    let head = chain_store.head()?;
+    let mut store_update = BatchedStoreUpdate::new(&store, 10_000_000);
+    let mut count = 0;
+    // we manually checked mainnet archival data and the first block where the discrepancy happened is `47443088`.
+    for height in 47443088..=head.height {
+        if let Ok(block_hash) = chain_store.get_block_hash_by_height(height) {
+            let block_ordinal = chain_store.get_block_merkle_tree(&block_hash)?.size();
+            let block_hash_from_block_ordinal =
+                chain_store.get_block_hash_from_ordinal(block_ordinal)?;
+            if block_hash_from_block_ordinal != block_hash {
+                println!(
+                    "Inconsistency in block ordinal to block hash mapping found at block height {}",
+                    height
+                );
+                count += 1;
+                store_update
+                    .set_ser(DBCol::BlockOrdinal, &index_to_bytes(block_ordinal), &block_hash)
+                    .expect("BorshSerialize should not fail");
             }
         }
-        println!("total inconsistency count: {}", count);
-        store_update.finish().expect("Failed to migrate");
     }
-    set_store_version(&store, 31);
+    println!("total inconsistency count: {}", count);
+    store_update.finish()
 }
 
 /// In test runs reads and writes here used 442 TGas, but in test on live net migration take


### PR DESCRIPTION
Rather than panicking which gives a somewhat dry and very technical
error message to the user, propagate errors when migrating up the
stack.
