### PR TITLE
store: move database migration snapshot handling to near-store

### DIFF
--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -193,6 +193,14 @@ impl<'a> StoreOpener<'a> {
             .map(|db| crate::Store::new(std::sync::Arc::new(db)))
     }
 
+    /// Creates a new snapshot which can be used to recover the database state.
+    ///
+    /// The snapshot is used during database migration to allow users to roll
+    /// back failed migrations.
+    ///
+    /// Note that due to RocksDB being weird, this will create an empty database
+    /// if it does not already exist.  This might not be what you want so make
+    /// sure the database already exists.
     pub fn new_migration_snapshot(
         &self,
         snapshot_path: std::path::PathBuf,

--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -162,6 +162,11 @@ impl<'a> StoreOpener<'a> {
         &self.path
     }
 
+    #[cfg(test)]
+    pub(crate) fn config(&self) -> &StoreConfig {
+        self.config
+    }
+
     /// Returns version of the database; or `None` if it does not exist.
     pub fn get_version_if_exists(&self) -> io::Result<Option<DbVersion>> {
         if self.check_if_exists() {

--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -187,4 +187,11 @@ impl<'a> StoreOpener<'a> {
         crate::RocksDB::open(&self.path, &self.config, self.mode)
             .map(|db| crate::Store::new(std::sync::Arc::new(db)))
     }
+
+    pub fn new_migration_snapshot(
+        &self,
+        snapshot_path: std::path::PathBuf,
+    ) -> Result<crate::Snapshot, crate::SnapshotError> {
+        crate::Snapshot::new(&self.path, self.config, snapshot_path)
+    }
 }

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -3,7 +3,7 @@ use std::io;
 use crate::DBCol;
 
 pub mod refcount;
-mod rocksdb;
+pub(crate) mod rocksdb;
 mod testdb;
 
 pub use self::rocksdb::RocksDB;

--- a/core/store/src/db/rocksdb.rs
+++ b/core/store/src/db/rocksdb.rs
@@ -3,7 +3,6 @@ use std::path::Path;
 use std::sync::atomic::Ordering;
 use std::sync::{Condvar, Mutex};
 
-use ::rocksdb::checkpoint::Checkpoint;
 use ::rocksdb::{
     BlockBasedOptions, Cache, ColumnFamily, Direction, Env, IteratorMode, Options, ReadOptions,
     WriteBatch, DB,
@@ -17,6 +16,8 @@ use near_primitives::version::DbVersion;
 use crate::config::Mode;
 use crate::db::{refcount, DBIterator, DBOp, DBTransaction, Database, StatsValue};
 use crate::{metrics, DBCol, StoreConfig, StoreStatistics};
+
+pub(crate) mod snapshot;
 
 /// List of integer RocskDB properties we’re reading when collecting statistics.
 ///
@@ -504,11 +505,6 @@ impl RocksDB {
         } else {
             Ok(())
         }
-    }
-
-    /// Creates a Checkpoint object that can be used to actually create a checkpoint on disk.
-    pub fn checkpoint(&self) -> io::Result<Checkpoint> {
-        Checkpoint::new(&self.db).map_err(into_other)
     }
 
     /// Gets every int property in CF_STAT_NAMES for every column in DBCol.

--- a/core/store/src/db/rocksdb/snapshot.rs
+++ b/core/store/src/db/rocksdb/snapshot.rs
@@ -1,0 +1,142 @@
+use std::io;
+
+use ::rocksdb::checkpoint::Checkpoint;
+
+/// Representation of a RocksDB checkpoint.
+///
+/// Serves as kind of RAII type which logs information about the checkpoint when
+/// object is dropped if the checkpoint hasn’t been removed beforehand by
+/// [`Snapshot::remove`] method.
+///
+/// The usage of the type is to create a checkpoint before a risky database
+/// operation and then [`Snapshot::remove`] it when the operation finishes
+/// successfully.  In that scenario, the checkpoint will be gracefully deleted
+/// from the file system.  On the other hand, if the operation fails an the
+/// checkpoint is not deleted, this type’s Drop implementation will log
+/// informational messages pointing where the snapshot resides and how to
+/// recover data from it.
+#[repr(transparent)]
+#[derive(Debug)]
+pub struct Snapshot(std::path::PathBuf);
+
+/// Possible errors when creating a checkpoint.
+#[derive(Debug)]
+pub enum SnapshotError {
+    /// Snapshot at requested location already exists.
+    ///
+    /// More specifically, the specified path exists (since the code does only
+    /// rudimentary check whether the path is a checkpoint or not).
+    AlreadyExists(std::path::PathBuf),
+
+    /// Error while creating a snapshot.
+    IOError(io::Error),
+}
+
+impl std::convert::From<io::Error> for SnapshotError {
+    fn from(err: io::Error) -> Self {
+        Self::IOError(err)
+    }
+}
+
+impl std::convert::From<::rocksdb::Error> for SnapshotError {
+    fn from(err: ::rocksdb::Error) -> Self {
+        super::into_other(err).into()
+    }
+}
+
+impl Snapshot {
+    /// Creates a new snapshot for given database.
+    ///
+    /// If the snapshot already exists, returns [`SnapshotError::AlreadyExists`]
+    /// error.  (More specifically, if the `snapshot_path` already exists since
+    /// the method does not make any more sophisticated checks whether the path
+    /// contains a snapshot or not).
+    pub(crate) fn new(
+        db_path: &std::path::Path,
+        config: &crate::StoreConfig,
+        snapshot_path: std::path::PathBuf,
+    ) -> Result<Self, SnapshotError> {
+        tracing::info!(target: "db", snapshot_path=%snapshot_path.display(),
+                       "Creating database snapshot");
+        if snapshot_path.exists() {
+            return Err(SnapshotError::AlreadyExists(snapshot_path));
+        }
+
+        let db = super::RocksDB::open(db_path, config, crate::Mode::ReadOnly)?;
+        let cp = Checkpoint::new(&db.db).map_err(super::into_other)?;
+        cp.create_checkpoint(&snapshot_path)?;
+
+        Ok(Self(snapshot_path))
+    }
+
+    /// Deletes the checkpoint from the file system.
+    ///
+    /// If the deletion fails, error is logged but the function does not fail.
+    pub fn remove(self) {
+        // SAFETY: Self is a repr(transparent) containing PathBuf so this
+        // transmute is guaranteed to be safe.  We’re doing this to avoid
+        // Snapshot::drop call.
+        let path: std::path::PathBuf = unsafe { core::mem::transmute(self) };
+
+        tracing::info!(target: "db", snapshot_path=%path.display(),
+                       "Deleting the database snapshot");
+        if let Err(err) = std::fs::remove_dir_all(&path) {
+            tracing::error!(target: "db", snapshot_path=%path.display(), ?err,
+                            "Failed to delete the database snapshot");
+            tracing::error!(target: "db", snapshot_path=%path.display(),
+                            "Please delete the snapshot manually before");
+        }
+    }
+}
+
+impl std::ops::Drop for Snapshot {
+    /// If the checkpoint hasn’t been deleted, log information about it.
+    ///
+    /// If the checkpoint hasn’t been deleted with [`Self::remove`] method, this
+    /// will log information about where the checkpoint resides in the file
+    /// system and how to recover data from it.
+    fn drop(&mut self) {
+        tracing::info!(target: "db", snapshot_path=%self.0.display(),
+                       "In case of issues, the database can be recovered \
+                        from the database snapshot");
+        tracing::info!(target: "db", snapshot_path=%self.0.display(),
+                       "To recover from the snapshot, delete files in the \
+                        database directory and replace them with contents \
+                        of the snapshot directory");
+    }
+}
+
+#[test]
+fn test_snapshot() {
+    use assert_matches::assert_matches;
+
+    let (tmpdir, opener) = crate::Store::test_opener();
+    let path = tmpdir.path().join("cp");
+
+    // Database doesn’t exist so cannot create a snapshot.
+    assert_matches!(opener.new_migration_snapshot(path.clone()), Err(SnapshotError::IOError(_)));
+
+    // Create the database
+    core::mem::drop(opener.open());
+
+    // Creating snapshot should work now.
+    let snapshot = opener.new_migration_snapshot(path.clone()).unwrap();
+
+    // Snapshot already exists so cannot create a new one.
+    assert_matches!(
+        opener.new_migration_snapshot(path.clone()),
+        Err(SnapshotError::AlreadyExists(_))
+    );
+
+    snapshot.remove();
+
+    // This should work correctly again since the snapshot has been removed.
+    opener.new_migration_snapshot(path.clone()).unwrap();
+
+    // And this again should fail.  We don’t remove the snapshot in
+    // Snapshot::drop.
+    assert_matches!(
+        opener.new_migration_snapshot(path.clone()),
+        Err(SnapshotError::AlreadyExists(_))
+    );
+}

--- a/core/store/src/db/rocksdb/snapshot.rs
+++ b/core/store/src/db/rocksdb/snapshot.rs
@@ -107,14 +107,11 @@ impl std::ops::Drop for Snapshot {
 }
 
 #[test]
-fn test_snapshot() {
+fn test_snapshot_creation() {
     use assert_matches::assert_matches;
 
     let (tmpdir, opener) = crate::Store::test_opener();
     let path = tmpdir.path().join("cp");
-
-    // Database doesn’t exist so cannot create a snapshot.
-    assert_matches!(opener.new_migration_snapshot(path.clone()), Err(SnapshotError::IOError(_)));
 
     // Create the database
     core::mem::drop(opener.open());

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -46,6 +46,7 @@ pub mod test_utils;
 mod trie;
 
 pub use crate::config::{Mode, StoreConfig, StoreOpener};
+pub use crate::db::rocksdb::snapshot::{Snapshot, SnapshotError};
 
 #[derive(Clone)]
 pub struct Store {

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -133,9 +133,9 @@ fn apply_store_migrations_if_exists(
     // the migration fails, the snapshot can be used to restore the database to
     // its original state.
     let snapshot = if near_config.config.use_db_migration_snapshot {
-        Some(create_db_checkpoint(store_opener, near_config)?)
+        create_db_checkpoint(store_opener, near_config)?
     } else {
-        None
+        near_store::Snapshot::no_snapshot()
     };
 
     // Add migrations here based on `db_version`.
@@ -182,7 +182,7 @@ fn apply_store_migrations_if_exists(
 
     // DB migration was successful, remove the snapshot to avoid it taking up
     // precious disk space.
-    snapshot.map(near_store::Snapshot::remove);
+    snapshot.remove();
 
     Ok(true)
 }


### PR DESCRIPTION
Move code which creates and deletes database migration snapshot to
near-store crate from nearcore.  This is done by introducing
a near_store::Snapshot struct which creates the snapshot and allows
to delete it once the migration finishes.

While at it, implement Drop for Snapshot which logs the location of
the snapshot.  With it, if migration is interrupted and the snapshot
is not removed, the location will be printed near the end of the log
pointing user at it.

My overall goal here is to move use_db_migration_snapshot and
db_migration_snapshot_path options from node Config into StoreConfig.
In the future, once we have cold storage, this will allow configuring
different locations for snapshots of hot and cold databases.