### PR TITLE
moved outgoing_peers inside connection::Pool

### DIFF
--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -1077,7 +1077,8 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for PeerActor {
                     if new_data.len() > 0 {
                         let handles: Vec<_> = pms
                             .tier2
-                            .read()
+                            .load()
+                            .ready
                             .values()
                             // Do not send the data back.
                             .filter(|p| peer_id != p.peer_info.id)

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -634,10 +634,10 @@ impl Actor for PeerActor {
                     // peer store. This avoids a situation in which both peers are connecting to
                     // each other, and after resolving the tie, a peer tries to remove the other
                     // peer from the active connection if it was added in the parallel connection.
-                    remove_from_peer_store: match &self.peer_status {
-                        PeerStatus::Connecting { .. } => false,
-                        _ => true,
-                    },
+                    remove_from_peer_store: !matches!(
+                        &self.peer_status,
+                        PeerStatus::Connecting { .. }
+                    ),
                 }));
             }
         }

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -1190,6 +1190,18 @@ pub(crate) enum ConnectingStatus {
     Outbound(connection::OutboundHandshakePermit),
 }
 
+/// State machine of the PeerActor.
+/// The transition graph for inbound connection is:
+/// Connecting(Inbound) -> Ready -> Banned
+/// for outbound connection is:
+/// Connecting(Outbound) -> Ready -> Banned
+///
+/// From every state the PeerActor can be immediately shut down.
+/// In the Connecting state only Handshake-related messages are allowed.
+/// All the other messages can be exchanged only in the Ready state.
+///
+/// For the exact process of establishing a connection between peers,
+/// see PoolSnapshot in chain/network/src/peer_manager/connection.rs.
 #[derive(Debug)]
 enum PeerStatus {
     /// Handshake in progress.

--- a/chain/network/src/peer_manager/connection.rs
+++ b/chain/network/src/peer_manager/connection.rs
@@ -1,3 +1,4 @@
+use crate::concurrency::arc_mutex::ArcMutex;
 use crate::concurrency::atomic_cell::AtomicCell;
 use crate::concurrency::demux;
 use crate::network_protocol::PeerMessage;
@@ -6,7 +7,6 @@ use crate::peer::peer_actor::PeerActor;
 use crate::private_actix::SendMessage;
 use crate::stats::metrics;
 use crate::types::FullPeerInfo;
-use arc_swap::ArcSwap;
 use near_network_primitives::time;
 use near_network_primitives::types::{
     PartialEdgeInfo, PeerChainInfoV2, PeerInfo, PeerManagerRequest, PeerManagerRequestWithContext,
@@ -21,14 +21,6 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tracing::Span;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
-
-fn update<T: Clone>(p: &ArcSwap<T>, mut f: impl FnMut(&mut T)) {
-    p.rcu(|v| {
-        let mut v = (**v).clone();
-        f(&mut v);
-        Arc::new(v)
-    });
-}
 
 #[derive(Clone)]
 pub(crate) struct Stats {
@@ -155,48 +147,116 @@ impl Connection {
     }
 }
 
-#[derive(Default)]
-pub(crate) struct Pool(ArcSwap<im::HashMap<PeerId, Arc<Connection>>>);
+#[derive(Clone)]
+pub(crate) struct PoolSnapshot {
+    pub me: PeerId,
+    pub ready: im::HashMap<PeerId, Arc<Connection>>,
+    /// Set of started outbound connections, which are not ready yet.
+    pub outbound_handshakes: im::HashSet<PeerId>,
+}
+
+pub(crate) struct OutboundHandshakePermit(PeerId, Pool);
+
+impl OutboundHandshakePermit {
+    pub fn peer_id(&self) -> &PeerId {
+        &self.0
+    }
+}
+
+impl fmt::Debug for OutboundHandshakePermit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        self.peer_id().fmt(f)
+    }
+}
+
+impl Drop for OutboundHandshakePermit {
+    fn drop(&mut self) {
+        self.1 .0.update(|pool| {
+            pool.outbound_handshakes.remove(&self.0);
+        });
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct Pool(Arc<ArcMutex<PoolSnapshot>>);
+
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum PoolError {
+    #[error("already connected to this peer")]
+    AlreadyConnected,
+    #[error("already started another outbound connection to this peer")]
+    AlreadyStartedConnecting,
+}
 
 impl Pool {
-    pub fn read(&self) -> Arc<im::HashMap<PeerId, Arc<Connection>>> {
-        self.0.load_full()
+    pub fn new(me: PeerId) -> Pool {
+        Self(Arc::new(ArcMutex::new(PoolSnapshot {
+            me,
+            ready: im::HashMap::new(),
+            outbound_handshakes: im::HashSet::new(),
+        })))
     }
 
-    pub fn insert(&self, peer: Arc<Connection>) {
-        let id = peer.peer_info.id.clone();
-        update(&self.0, |peers| {
-            peers.insert(id.clone(), peer.clone());
-        });
+    pub fn load(&self) -> Arc<PoolSnapshot> {
+        self.0.load()
+    }
+
+    pub fn insert_ready(&self, peer: Arc<Connection>) -> Result<(), PoolError> {
+        self.0.update(move |pool| {
+            let id = &peer.peer_info.id;
+            if pool.ready.contains_key(id) {
+                return Err(PoolError::AlreadyConnected);
+            }
+            if peer.peer_type == PeerType::Inbound {
+                if pool.outbound_handshakes.contains(id) && id < &pool.me {
+                    return Err(PoolError::AlreadyStartedConnecting);
+                }
+            }
+            pool.ready.insert(id.clone(), peer);
+            Ok(())
+        })
+    }
+
+    pub fn start_outbound(&self, peer_id: PeerId) -> Result<OutboundHandshakePermit, PoolError> {
+        self.0.update(move |pool| {
+            if pool.ready.contains_key(&peer_id) {
+                return Err(PoolError::AlreadyConnected);
+            }
+            if pool.outbound_handshakes.contains(&peer_id) {
+                return Err(PoolError::AlreadyStartedConnecting);
+            }
+            pool.outbound_handshakes.insert(peer_id.clone());
+            Ok(OutboundHandshakePermit(peer_id, self.clone()))
+        })
     }
 
     pub fn remove(&self, peer_id: &PeerId) {
-        update(&self.0, |peers| {
-            peers.remove(peer_id);
+        self.0.update(|pool| {
+            pool.ready.remove(peer_id);
         });
     }
 
-    /// Send message to peer that belong to our active set
+    /// Send message to peer that belongs to our active set
     /// Return whether the message is sent or not.
     pub fn send_message(&self, peer_id: PeerId, msg: Arc<PeerMessage>) -> bool {
-        let connected_peers = self.read();
-        if let Some(peer) = connected_peers.get(&peer_id) {
+        let pool = self.load();
+        if let Some(peer) = pool.ready.get(&peer_id) {
             peer.send_message(msg);
             return true;
         }
         tracing::debug!(target: "network",
            to = ?peer_id,
-           num_connected_peers = connected_peers.len(),
+           num_connected_peers = pool.ready.len(),
            ?msg,
            "Failed sending message: peer not connected"
         );
         false
     }
 
-    /// Broadcast message to all active peers.
+    /// Broadcast message to all ready peers.
     pub fn broadcast_message(&self, msg: Arc<PeerMessage>) {
         metrics::BROADCAST_MESSAGES.with_label_values(&[msg.msg_variant()]).inc();
-        for peer in self.read().values() {
+        for peer in self.load().ready.values() {
             peer.send_message(msg.clone());
         }
     }

--- a/chain/network/src/peer_manager/connection.rs
+++ b/chain/network/src/peer_manager/connection.rs
@@ -181,6 +181,8 @@ pub(crate) struct PoolSnapshot {
     /// b. Peer A executes 1 and then attempts 2.
     /// In this scenario A will fail to obtain a permit, because it has already accepted a
     /// connection from B.
+    ///
+    /// TODO(gprusak): cover it with tests.
     pub outbound_handshakes: im::HashSet<PeerId>,
 }
 
@@ -200,13 +202,11 @@ impl fmt::Debug for OutboundHandshakePermit {
 
 impl Drop for OutboundHandshakePermit {
     fn drop(&mut self) {
-        let pool = match self.1.upgrade() {
-            Some(pool) => pool,
-            None => return,
-        };
-        pool.update(|pool| {
-            pool.outbound_handshakes.remove(&self.0);
-        });
+        if let Some(pool) = self.1.upgrade() {
+            pool.update(|pool| {
+                pool.outbound_handshakes.remove(&self.0);
+            });
+        }
     }
 }
 


### PR DESCRIPTION
outgoing_peers is an additional piece of state which prevents a race condition when 2 peers are trying to connect to each other at the same time. We will need that duplicated for the TIER1 connection pool, so I moved this functionality inside of connection::Pool. Also, I applied RAII pattern to make sure that the elements of outgoing_peers (aka outbound_handshakes) are eventually removed.