### PR TITLE
fix: default genesis minimum gas price

### DIFF
--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -161,8 +161,8 @@ impl BlockHeaderInfo {
 /// Block economics config taken from genesis config
 pub struct BlockEconomicsConfig {
     gas_price_adjustment_rate: Rational32,
-    min_gas_price: Balance,
-    max_gas_price: Balance,
+    genesis_min_gas_price: Balance,
+    genesis_max_gas_price: Balance,
     genesis_protocol_version: ProtocolVersion,
 }
 
@@ -170,6 +170,12 @@ impl BlockEconomicsConfig {
     /// Set max gas price to be this multiplier * min_gas_price
     const MAX_GAS_MULTIPLIER: u128 = 20;
     /// Compute min gas price according to protocol version and genesis protocol version.
+    ///
+    /// This returns the effective minimum gas price for a block with the given
+    /// protocol version. The base value is defined in genesis.config but has
+    /// been overwritten at specific protocol versions. Chains with a genesis
+    /// version higher than those changes are not overwritten and will instead
+    /// respect the value defined in genesis.
     pub fn min_gas_price(&self, protocol_version: ProtocolVersion) -> Balance {
         if self.genesis_protocol_version < MIN_PROTOCOL_VERSION_NEP_92 {
             if protocol_version >= MIN_PROTOCOL_VERSION_NEP_92_FIX {
@@ -177,7 +183,7 @@ impl BlockEconomicsConfig {
             } else if protocol_version >= MIN_PROTOCOL_VERSION_NEP_92 {
                 MIN_GAS_PRICE_NEP_92
             } else {
-                self.min_gas_price
+                self.genesis_min_gas_price
             }
         } else if self.genesis_protocol_version < MIN_PROTOCOL_VERSION_NEP_92_FIX {
             if protocol_version >= MIN_PROTOCOL_VERSION_NEP_92_FIX {
@@ -186,18 +192,18 @@ impl BlockEconomicsConfig {
                 MIN_GAS_PRICE_NEP_92
             }
         } else {
-            self.min_gas_price
+            self.genesis_min_gas_price
         }
     }
 
     pub fn max_gas_price(&self, protocol_version: ProtocolVersion) -> Balance {
         if checked_feature!("stable", CapMaxGasPrice, protocol_version) {
             std::cmp::min(
-                self.max_gas_price,
+                self.genesis_max_gas_price,
                 Self::MAX_GAS_MULTIPLIER * self.min_gas_price(protocol_version),
             )
         } else {
-            self.max_gas_price
+            self.genesis_max_gas_price
         }
     }
 
@@ -210,8 +216,8 @@ impl From<&ChainGenesis> for BlockEconomicsConfig {
     fn from(chain_genesis: &ChainGenesis) -> Self {
         BlockEconomicsConfig {
             gas_price_adjustment_rate: chain_genesis.gas_price_adjustment_rate,
-            min_gas_price: chain_genesis.min_gas_price,
-            max_gas_price: chain_genesis.max_gas_price,
+            genesis_min_gas_price: chain_genesis.min_gas_price,
+            genesis_max_gas_price: chain_genesis.max_gas_price,
             genesis_protocol_version: chain_genesis.protocol_version,
         }
     }

--- a/chain/jsonrpc/jsonrpc-tests/res/genesis_config.json
+++ b/chain/jsonrpc/jsonrpc-tests/res/genesis_config.json
@@ -18,7 +18,7 @@
   "protocol_upgrade_num_epochs": 2,
   "epoch_length": 500,
   "gas_limit": 1000000000000000,
-  "min_gas_price": "1000000000",
+  "min_gas_price": "100000000",
   "max_gas_price": "10000000000000000000000",
   "block_producer_kickout_threshold": 90,
   "chunk_producer_kickout_threshold": 90,

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -107,8 +107,8 @@ pub const NUM_BLOCKS_PER_YEAR: u64 = 365 * 24 * 60 * 60;
 /// Initial gas limit.
 pub const INITIAL_GAS_LIMIT: Gas = 1_000_000_000_000_000;
 
-/// Initial gas price.
-pub const MIN_GAS_PRICE: Balance = 1_000_000_000;
+/// Initial and minimum gas price.
+pub const MIN_GAS_PRICE: Balance = 100_000_000;
 
 /// Protocol treasury account
 pub const PROTOCOL_TREASURY_ACCOUNT: &str = "near";


### PR DESCRIPTION
Update the default value for `min_gas_price` when creating a new chain
to the effective value we use in mainnet today. (10e9 ->10e8)

This changes the gas price for new chains, localnet and sandbox.

Also add some comments to `fn min_gas_price` to improve clarity.

Resolves #7466