### PR TITLE
bumped PROTOCOL_VERSION for shardnet

### DIFF
--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -172,7 +172,12 @@ pub enum ProtocolFeature {
 
 /// Both, outgoing and incoming tcp connections to peers, will be rejected if `peer's`
 /// protocol version is lower than this.
-pub const PEER_MIN_ALLOWED_PROTOCOL_VERSION: ProtocolVersion = STABLE_PROTOCOL_VERSION - 2;
+pub const PEER_MIN_ALLOWED_PROTOCOL_VERSION: ProtocolVersion = if cfg!(feature = "shardnet") {
+    // For shardnet, enable `ChunkOnlyProducers` but nothing else.
+    PROTOCOL_VERSION - 1
+} else {
+    STABLE_PROTOCOL_VERSION - 2
+};
 
 /// Current protocol version used on the mainnet.
 /// Some features (e. g. FixStorageUsage) require that there is at least one epoch with exactly
@@ -185,7 +190,7 @@ pub const PROTOCOL_VERSION: ProtocolVersion = if cfg!(feature = "nightly_protoco
     131
 } else if cfg!(feature = "shardnet") {
     // For shardnet, enable `ChunkOnlyProducers` but nothing else.
-    100
+    101
 } else {
     // Enable all stable features.
     STABLE_PROTOCOL_VERSION


### PR DESCRIPTION
also set the PEER_MIN_ALLOWED_PROTOCOL_VERSION to PROTOCOL_VERSION-1, so that we can reject old binaries from the network in 2 releases.