### PR TITLE
fix(o11y): Add a missing `target` to a log message

### DIFF
--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -526,6 +526,7 @@ impl PeerManagerActor {
         }
 
         info!(
+            target: "bandwidth",
             total_bandwidth_used_by_all_peers,
             total_msg_received_count, max_max_record_num_messages_in_progress, "Bandwidth stats"
         );


### PR DESCRIPTION
Every other log message does specify `target`, and this inconsistency messes with logs ingestion into Grafana.