### PR TITLE
crypto: remove direct dependency on rand_core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2972,7 +2972,6 @@ dependencies = [
  "parity-secp256k1",
  "primitive-types",
  "rand 0.7.3",
- "rand_core 0.5.1",
  "serde",
  "serde_json",
  "sha2 0.10.2",

--- a/core/crypto/Cargo.toml
+++ b/core/crypto/Cargo.toml
@@ -23,7 +23,6 @@ primitive-types = { version = "0.10", default-features = false }
 once_cell = "1.5.2"
 parity-secp256k1 = "0.7"
 rand = "0.7"
-rand_core = "0.5"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 subtle = "2.2"

--- a/core/crypto/src/signature.rs
+++ b/core/crypto/src/signature.rs
@@ -9,7 +9,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use ed25519_dalek::ed25519::signature::{Signer, Verifier};
 use once_cell::sync::Lazy;
 use primitive_types::U256;
-use rand_core::OsRng;
+use rand::rngs::OsRng;
 use secp256k1::Message;
 use serde::{Deserialize, Serialize};
 

--- a/core/crypto/src/vrf.rs
+++ b/core/crypto/src/vrf.rs
@@ -3,7 +3,7 @@ use bs58;
 use curve25519_dalek::constants::{
     RISTRETTO_BASEPOINT_POINT as G, RISTRETTO_BASEPOINT_TABLE as GT,
 };
-use rand_core::OsRng;
+use rand::rngs::OsRng;
 use std::borrow::Borrow;
 use subtle::{ConditionallySelectable, ConstantTimeEq};
 


### PR DESCRIPTION
Everything we need from rand_core is re-exported by rand crate which
we’re already depending on.  There’s no need to depend on rand_core
directly.