### PR TITLE
Fix get_validator_info function to return error instead of taking a long time if the function is called on the wrong block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2984,6 +2984,7 @@ dependencies = [
 name = "near-epoch-manager"
 version = "0.0.0"
 dependencies = [
+ "assert_matches",
  "borsh",
  "chrono",
  "near-cache",

--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -300,6 +300,9 @@ impl From<EpochError> for Error {
         match error {
             EpochError::EpochOutOfBounds(epoch_id) => Error::EpochOutOfBounds(epoch_id),
             EpochError::MissingBlock(h) => Error::DBNotFoundErr(to_base(&h)),
+            EpochError::BlockOutOfBounds(h) => {
+                Error::Other(format!("get_validator_info used invalid block hash {:?}", h))
+            }
             err => Error::ValidatorError(err.to_string()),
         }
     }

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -699,7 +699,12 @@ pub trait RuntimeAdapter: Send + Sync {
         request: &QueryRequest,
     ) -> Result<QueryResponse, near_chain_primitives::error::QueryError>;
 
-    /// WARNING: this call may be expensive.
+    /// Get detailed information for validators in current epoch and next epoch.
+    /// Note: this function is only implemented for RPC purposes. For regular chain code,
+    /// please use other functions.
+    /// Also note: the ValidatorInfoIdentifier here must be either epoch id of a previous epoch
+    /// or the latest block hash (chain header head instead of head). Otherwise, the function will
+    /// return error.
     fn get_validator_info(
         &self,
         epoch_id: ValidatorInfoIdentifier,
@@ -797,10 +802,10 @@ pub struct LatestKnown {
 }
 
 /// Either an epoch id or latest block hash.  When `EpochId` variant is used it
-/// must be an identifier of a past epoch.  When `BlockHeight` is used it must
-/// be hash of the latest block in the current epoch.  Using current epoch id
-/// with `EpochId` or arbitrary block hash in past or present epochs will result
-/// in errors.
+/// must be an identifier of a past epoch.  When `BlockHash` is used it must
+/// be hash of the latest block in the current epoch, i.e., header head.  
+/// Using current epoch id with `EpochId` or arbitrary block hash in past or present epochs
+/// will result in errors.
 #[derive(Debug)]
 pub enum ValidatorInfoIdentifier {
     EpochId(EpochId),

--- a/chain/epoch_manager/Cargo.toml
+++ b/chain/epoch_manager/Cargo.toml
@@ -27,6 +27,9 @@ near-store = { path = "../../core/store" }
 near-chain-configs = { path = "../../core/chain-configs" }
 near-cache = { path = "../../utils/near-cache" }
 
+[dev-dependencies]
+assert_matches = "1.5.0"
+
 [features]
 expensive_tests = []
 protocol_feature_fix_staking_threshold = ["near-primitives/protocol_feature_fix_staking_threshold"]

--- a/chain/epoch_manager/src/lib.rs
+++ b/chain/epoch_manager/src/lib.rs
@@ -1519,9 +1519,8 @@ impl EpochManager {
     ///
     /// The block hash passed as argument should be a final block so that the
     /// method can perform efficient incremental updates.  Calling this method
-    /// on a block which has not been finalised yet is likely to result in
-    /// performance issues since handling forks will force it to traverse the
-    /// entire epoch from scratch.
+    /// on a block which has not been finalised will cause this function to return
+    /// errors or future calls of this function return errors.
     ///
     /// The result of the aggregation is stored in `self.epoch_info_aggregator`.
     ///
@@ -1557,9 +1556,8 @@ impl EpochManager {
     /// Returns epoch info aggregate with state up to `last_block_hash`.
     ///
     /// The block hash passed as argument should be the latest block belonging
-    /// to current epoch.  Calling this method on any other block is likely to
-    /// result in performance issues since handling something which is not past
-    /// the final block will force it to traverse the entire epoch from scratch.
+    /// to current epoch.  Calling this method on any other block will cause this function
+    /// to return error.
     ///
     /// This method does not change `self.epoch_info_aggregator`.
     pub fn get_epoch_info_aggregator_upto_last(
@@ -1585,9 +1583,8 @@ impl EpochManager {
     /// start of epoch `block_hash` belongs to.
     ///
     /// The block hash passed as argument should be a latest final block or
-    /// a descendant of a latest final block. Calling this method on any other
-    /// block is likely to result in performance issues since handling forks
-    /// will force it to traverse the entire epoch from scratch.
+    /// a descendant of a latest final block. The function will return error
+    /// if calling this method on any other block
     ///
     /// If `block_hash` equals `self.epoch_info_aggregator.last_block_hash`
     /// returns None.  Otherwise returns `Some((aggregator, full_info))` tuple.
@@ -1623,8 +1620,8 @@ impl EpochManager {
             // current block, but then drop it so that we can call
             // get_block_info for previous block.
             let block_info = self.get_block_info(&cur_hash)?;
-            // We've reached before where the current aggregator is updated to, keep going backwards
-            // will
+            // We've reached before where the current aggregator is updated to, stop going backwards
+            // because we will risk going until epoch start and this function will take too long
             if block_info.height() < agg_height {
                 return Err(EpochError::BlockOutOfBounds(*block_hash));
             }

--- a/chain/epoch_manager/src/test_utils.rs
+++ b/chain/epoch_manager/src/test_utils.rs
@@ -292,6 +292,37 @@ pub fn record_block_with_final_block_hash(
         .unwrap();
 }
 
+pub fn record_block_with_last_final_block(
+    epoch_manager: &mut EpochManager,
+    prev_h: CryptoHash,
+    cur_h: CryptoHash,
+    height: BlockHeight,
+    last_final_block_hash: CryptoHash,
+    last_final_block_height: BlockHeight,
+    proposals: Vec<ValidatorStake>,
+) {
+    epoch_manager
+        .record_block_info(
+            BlockInfo::new(
+                cur_h,
+                height,
+                last_final_block_height,
+                last_final_block_hash,
+                prev_h,
+                proposals,
+                vec![],
+                vec![],
+                DEFAULT_TOTAL_SUPPLY,
+                PROTOCOL_VERSION,
+                height * NUM_NS_IN_SECOND,
+            ),
+            [0; 32],
+        )
+        .unwrap()
+        .commit()
+        .unwrap();
+}
+
 pub fn record_block_with_slashes(
     epoch_manager: &mut EpochManager,
     prev_h: CryptoHash,

--- a/core/primitives/src/errors.rs
+++ b/core/primitives/src/errors.rs
@@ -765,6 +765,9 @@ pub enum EpochError {
     },
     /// Requesting validators for an epoch that wasn't computed yet.
     EpochOutOfBounds(EpochId),
+    /// Requesting validator info for an invalid block. A valid block must be children of the last
+    /// final block
+    BlockOutOfBounds(CryptoHash),
     /// Missing block hash in the storage (means there is some structural issue).
     MissingBlock(CryptoHash),
     /// Error due to IO (DB read/write, serialization, etc.).
@@ -801,6 +804,9 @@ impl Display for EpochError {
             EpochError::NotEnoughValidators { num_shards, num_validators } => {
                 write!(f, "There were not enough validator proposals to fill all shards. num_proposals: {}, num_shards: {}", num_validators, num_shards)
             }
+            EpochError::BlockOutOfBounds(hash) => {
+                write!(f, "get_validator_info used invalid block hash {:?}", hash)
+            }
         }
     }
 }
@@ -820,6 +826,9 @@ impl Debug for EpochError {
             EpochError::ShardingError(err) => write!(f, "ShardingError({})", err),
             EpochError::NotEnoughValidators { num_shards, num_validators } => {
                 write!(f, "NotEnoughValidators({}, {})", num_validators, num_shards)
+            }
+            EpochError::BlockOutOfBounds(hash) => {
+                write!(f, "BlockOutOfBounds({:?})", hash)
             }
         }
     }

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -1638,8 +1638,12 @@ impl RuntimeAdapter for NightshadeRuntime {
         }
     }
 
-    /// WARNING: this function calls EpochManager::get_epoch_info_aggregator_upto_last
-    /// underneath which can be very expensive.
+    /// Get detailed information for validators in current epoch and next epoch.
+    /// Note: this function is only implemented for RPC purposes. For regular chain code,
+    /// please use other functions.
+    /// Also note: the ValidatorInfoIdentifier here must be either epoch id of a previous epoch
+    /// or the latest block hash (chain header head instead of head). Otherwise, the function will
+    /// return error.
     fn get_validator_info(
         &self,
         epoch_id: ValidatorInfoIdentifier,


### PR DESCRIPTION
Previously, we've had issues with `get_validator_info` function a few times when the function can take a long time if it is called on a block that's not the descendant of the latest final block. This PR fixes that by making the function return errors instead of silently taking a long time.