### PR TITLE
network: update to rand 0.7 and switch from PCG to xorshift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1791,12 +1791,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "futures"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3211,8 +3205,8 @@ dependencies = [
  "pretty_assertions",
  "protobuf 3.0.2",
  "protobuf-codegen",
- "rand 0.6.5",
- "rand_pcg",
+ "rand 0.7.3",
+ "rand_xorshift 0.2.0",
  "rayon",
  "serde",
  "smart-default",
@@ -4418,7 +4412,6 @@ dependencies = [
  "rand_hc 0.1.0",
  "rand_isaac",
  "rand_jitter",
- "rand_os",
  "rand_pcg",
  "rand_xorshift 0.1.1",
  "winapi",
@@ -4550,20 +4543,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_os"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
-dependencies = [
- "cloudabi",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.4.2",
- "rdrand",
- "winapi",
-]
-
-[[package]]
 name = "rand_pcg"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4622,15 +4601,6 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils 0.8.8",
  "num_cpus",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -35,8 +35,8 @@ thiserror = "1"
 near-rust-allocator-proxy = { version = "0.4", optional = true }
 once_cell = "1.12.0"
 opentelemetry = { version = "0.17", features = ["trace"] }
-rand = "0.6"
-rand_pcg = "0.1"
+rand = "0.7"
+rand_xorshift = "0.2"
 serde = { version = "1", features = ["alloc", "derive", "rc"] }
 strum = { version = "0.24", features = ["derive"] }
 tokio-stream = { version = "0.1.2", features = ["net"] }

--- a/chain/network/src/testonly/mod.rs
+++ b/chain/network/src/testonly/mod.rs
@@ -8,10 +8,10 @@ pub mod actix;
 pub mod fake_client;
 pub mod stream;
 
-pub type Rng = rand_pcg::Pcg32;
+pub type Rng = rand_xorshift::XorShiftRng;
 
 pub fn make_rng(seed: u64) -> Rng {
-    Rng::new(seed, 0xa02bdbf7bb3c0a7)
+    rand::SeedableRng::seed_from_u64(seed)
 }
 
 pub trait AsSet<'a, T> {

--- a/deny.toml
+++ b/deny.toml
@@ -26,12 +26,16 @@ skip = [
     # criterion uses clap=2.34.0 which relies on an older textwrap
     { name = "textwrap", version = "=0.11.0" },
 
-    # near-epoch-manager fixed the rand version to ensure protocol stability
+    # near-epoch-manager fixed the rand version to ensure protocol
+    # stability.  This pulls in other ancient crates.
     { name = "rand", version = "=0.6.5" },
+    { name = "rand_xorshift", version = "=0.1.1" },
     # rand 0.6.5 uses two versions of rand_core due to weird dependencies mismatch with rand_chacha
     { name = "rand_core", version = "=0.3.1" },
     { name = "rand_chacha", version = "=0.1.1" },
+
     { name = "autocfg", version = "=0.1.8" },
+
     # wasmer 0.17 and wasmtime 0.17 use conflicting versions of those
     { name = "wasmparser", version = "=0.51.4" },
     { name = "rand_core", version = "=0.4.2" },
@@ -56,7 +60,6 @@ skip = [
     { name = "parity-wasm", version = "=0.41.0" },
 
     # param estimator uses newer imports, but it's not part of neard
-    { name = "rand_xorshift", version = "=0.2.0" },
     { name = "wasmparser", version = "=0.59.0" },
 
     # wasmer and wasmtime


### PR DESCRIPTION
Firstly, update rand dependency to 0.7 to put the crate more in line
with the rest of the repository.

Furthermore, switch from rand_pcg to rand_xorshift.  The latter is
already used in a couple places while near-network was the only user
of the former so it’s best to converge on a single crate.