### PR TITLE
primitives: keep data as Arc<[u8]> in StateRootNode

### DIFF
--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -1055,18 +1055,18 @@ impl RuntimeAdapter for KeyValueRuntime {
         _block_hash: &CryptoHash,
         state_root: &StateRoot,
     ) -> Result<StateRootNode, Error> {
-        Ok(StateRootNode {
-            data: self
-                .state
-                .read()
-                .unwrap()
-                .get(state_root)
-                .unwrap()
-                .clone()
-                .try_to_vec()
-                .expect("should never fall"),
-            memory_usage: *self.state_size.read().unwrap().get(state_root).unwrap(),
-        })
+        let data = self
+            .state
+            .read()
+            .unwrap()
+            .get(state_root)
+            .unwrap()
+            .clone()
+            .try_to_vec()
+            .expect("should never fall")
+            .into();
+        let memory_usage = *self.state_size.read().unwrap().get(state_root).unwrap();
+        Ok(StateRootNode { data: Some(data), memory_usage })
     }
 
     fn validate_state_root_node(

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -1066,7 +1066,7 @@ impl RuntimeAdapter for KeyValueRuntime {
             .expect("should never fall")
             .into();
         let memory_usage = *self.state_size.read().unwrap().get(state_root).unwrap();
-        Ok(StateRootNode { data: Some(data), memory_usage })
+        Ok(StateRootNode { data, memory_usage })
     }
 
     fn validate_state_root_node(

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -1,7 +1,10 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use derive_more::{AsRef as DeriveAsRef, From as DeriveFrom};
+use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
+
 use std::ops;
+use std::sync::Arc;
 
 use near_crypto::PublicKey;
 
@@ -423,19 +426,19 @@ impl StateChanges {
 pub struct StateRootNode {
     /// In Nightshade, data is the serialized TrieNodeWithSize.
     ///
-    /// Empty nodes are not encoded and are represented by `None` here.
-    pub data: Option<std::sync::Arc<[u8]>>,
+    /// Beware that hash of an empty state root (i.e. once who’s data is an
+    /// empty byte string) **does not** equal hash of an empty byte string.
+    /// Instead, an all-zero hash indicates an empty node.
+    pub data: Arc<[u8]>,
+
     /// In Nightshade, memory_usage is a field of TrieNodeWithSize.
     pub memory_usage: u64,
 }
 
 impl StateRootNode {
     pub fn empty() -> Self {
-        StateRootNode { data: None, memory_usage: 0 }
-    }
-
-    pub fn data(&self) -> &[u8] {
-        self.data.as_deref().unwrap_or(&[])
+        static EMPTY: Lazy<Arc<[u8]>> = Lazy::new(|| Arc::new([]));
+        StateRootNode { data: EMPTY.clone(), memory_usage: 0 }
     }
 }
 

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -421,15 +421,21 @@ impl StateChanges {
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
 #[derive(PartialEq, Eq, Clone, Debug, BorshSerialize, BorshDeserialize, Serialize)]
 pub struct StateRootNode {
-    /// in Nightshade, data is the serialized TrieNodeWithSize
-    pub data: Vec<u8>,
-    /// in Nightshade, memory_usage is a field of TrieNodeWithSize
+    /// In Nightshade, data is the serialized TrieNodeWithSize.
+    ///
+    /// Empty nodes are not encoded and are represented by `None` here.
+    pub data: Option<std::sync::Arc<[u8]>>,
+    /// In Nightshade, memory_usage is a field of TrieNodeWithSize.
     pub memory_usage: u64,
 }
 
 impl StateRootNode {
     pub fn empty() -> Self {
-        StateRootNode { data: vec![], memory_usage: 0 }
+        StateRootNode { data: None, memory_usage: 0 }
+    }
+
+    pub fn data(&self) -> &[u8] {
+        self.data.as_deref().unwrap_or(&[])
     }
 }
 

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -626,7 +626,7 @@ impl Trie {
         match self.retrieve_raw_node(&self.root)? {
             None => Ok(StateRootNode::empty()),
             Some((bytes, node)) => {
-                Ok(StateRootNode { data: bytes.to_vec(), memory_usage: node.memory_usage })
+                Ok(StateRootNode { data: Some(bytes), memory_usage: node.memory_usage })
             }
         }
     }

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -626,7 +626,7 @@ impl Trie {
         match self.retrieve_raw_node(&self.root)? {
             None => Ok(StateRootNode::empty()),
             Some((bytes, node)) => {
-                Ok(StateRootNode { data: Some(bytes), memory_usage: node.memory_usage })
+                Ok(StateRootNode { data: bytes, memory_usage: node.memory_usage })
             }
         }
     }

--- a/core/store/src/trie/state_parts.rs
+++ b/core/store/src/trie/state_parts.rs
@@ -238,7 +238,7 @@ impl Trie {
             .expect("apply_state_part is guaranteed to succeed when each part is valid")
     }
 
-    pub fn get_memory_usage_from_serialized(bytes: &Vec<u8>) -> Result<u64, StorageError> {
+    pub fn get_memory_usage_from_serialized(bytes: &[u8]) -> Result<u64, StorageError> {
         RawTrieNodeWithSize::decode(bytes).map(|raw_node| raw_node.memory_usage).map_err(|err| {
             StorageError::StorageInconsistentState(format!("Failed to decode node: {err}"))
         })

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -1748,20 +1748,12 @@ impl RuntimeAdapter for NightshadeRuntime {
         if state_root == &Trie::EMPTY_ROOT {
             return state_root_node == &StateRootNode::empty();
         }
-        if hash(&state_root_node.data) != *state_root {
-            false
-        } else {
-            match Trie::get_memory_usage_from_serialized(&state_root_node.data) {
-                Ok(memory_usage) => {
-                    if memory_usage != state_root_node.memory_usage {
-                        // Invalid value of memory_usage
-                        false
-                    } else {
-                        true
-                    }
-                }
-                Err(_) => false, // Invalid state_root_node
-            }
+        if hash(state_root_node.data()) != *state_root {
+            return false;
+        }
+        match Trie::get_memory_usage_from_serialized(state_root_node.data()) {
+            Ok(memory_usage) => memory_usage == state_root_node.memory_usage,
+            Err(_) => false, // Invalid state_root_node
         }
     }
 
@@ -2670,7 +2662,7 @@ mod test {
         let mut root_node_wrong = root_node;
         root_node_wrong.memory_usage += 1;
         assert!(!new_env.runtime.validate_state_root_node(&root_node_wrong, &env.state_roots[0]));
-        root_node_wrong.data = vec![123];
+        root_node_wrong.data = Some(std::sync::Arc::new([123]));
         assert!(!new_env.runtime.validate_state_root_node(&root_node_wrong, &env.state_roots[0]));
         assert!(!new_env.runtime.validate_state_part(
             &Trie::EMPTY_ROOT,

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -1748,10 +1748,10 @@ impl RuntimeAdapter for NightshadeRuntime {
         if state_root == &Trie::EMPTY_ROOT {
             return state_root_node == &StateRootNode::empty();
         }
-        if hash(state_root_node.data()) != *state_root {
+        if hash(&state_root_node.data) != *state_root {
             return false;
         }
-        match Trie::get_memory_usage_from_serialized(state_root_node.data()) {
+        match Trie::get_memory_usage_from_serialized(&state_root_node.data) {
             Ok(memory_usage) => memory_usage == state_root_node.memory_usage,
             Err(_) => false, // Invalid state_root_node
         }
@@ -2662,7 +2662,7 @@ mod test {
         let mut root_node_wrong = root_node;
         root_node_wrong.memory_usage += 1;
         assert!(!new_env.runtime.validate_state_root_node(&root_node_wrong, &env.state_roots[0]));
-        root_node_wrong.data = Some(std::sync::Arc::new([123]));
+        root_node_wrong.data = std::sync::Arc::new([123]);
         assert!(!new_env.runtime.validate_state_root_node(&root_node_wrong, &env.state_roots[0]));
         assert!(!new_env.runtime.validate_state_part(
             &Trie::EMPTY_ROOT,


### PR DESCRIPTION
When a node is retrieved its raw bytes end up in an `Arc<[u8]>`.  This
is because it’s how the value is stored in cache.  StateRootNode, on
the other hand, keeps the data as a vector which means that a new
object needs to be allocated from the shared slice.

Replace the `data` in StateRootNode to keep an Arc such that this
conversion is no longer necessary.
