### PR TITLE
core: avoid Vec↔Arc conversions when reading trie nodes

### DIFF
--- a/core/primitives/src/challenge.rs
+++ b/core/primitives/src/challenge.rs
@@ -10,7 +10,7 @@ use crate::types::AccountId;
 use crate::validator_signer::ValidatorSigner;
 
 /// Serialized TrieNodeWithSize
-pub type StateItem = Vec<u8>;
+pub type StateItem = std::sync::Arc<[u8]>;
 
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Debug, Clone, Eq, PartialEq)]

--- a/core/store/src/trie/state_parts.rs
+++ b/core/store/src/trie/state_parts.rs
@@ -248,6 +248,7 @@ impl Trie {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::sync::Arc;
 
     use rand::prelude::ThreadRng;
     use rand::Rng;
@@ -618,7 +619,7 @@ mod tests {
 
                 let trie_changes = check_combine_state_parts(trie.get_root(), num_parts, &parts);
 
-                let mut nodes = <HashMap<CryptoHash, std::sync::Arc<[u8]>>>::new();
+                let mut nodes = <HashMap<CryptoHash, Arc<[u8]>>>::new();
                 let sizes_vec = parts
                     .iter()
                     .map(|nodes| nodes.iter().map(|node| node.len()).sum::<usize>())
@@ -658,7 +659,7 @@ mod tests {
     fn check_combine_state_parts(
         state_root: &CryptoHash,
         num_parts: u64,
-        parts: &Vec<Vec<std::sync::Arc<[u8]>>>,
+        parts: &Vec<Vec<Arc<[u8]>>>,
     ) -> TrieChanges {
         let trie_changes = Trie::combine_state_parts_naive(state_root, parts).unwrap();
 

--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -268,8 +268,8 @@ pub struct TrieRecordingStorage {
 
 impl TrieStorage for TrieRecordingStorage {
     fn retrieve_raw_bytes(&self, hash: &CryptoHash) -> Result<Arc<[u8]>, StorageError> {
-        if let Some(val) = self.recorded.borrow().get(hash) {
-            return Ok(val.clone());
+        if let Some(val) = self.recorded.borrow().get(hash).cloned() {
+            return Ok(val);
         }
         let key = TrieCachingStorage::get_key_from_shard_uid_and_hash(self.shard_uid, hash);
         let val = self
@@ -303,10 +303,7 @@ pub struct TrieMemoryPartialStorage {
 
 impl TrieStorage for TrieMemoryPartialStorage {
     fn retrieve_raw_bytes(&self, hash: &CryptoHash) -> Result<Arc<[u8]>, StorageError> {
-        let result = self
-            .recorded_storage
-            .get(hash)
-            .map_or(Err(StorageError::TrieNodeMissing), |val| Ok(val.clone()));
+        let result = self.recorded_storage.get(hash).cloned().ok_or(StorageError::TrieNodeMissing);
         if result.is_ok() {
             self.visited_nodes.borrow_mut().insert(*hash);
         }

--- a/core/store/src/trie/trie_tests.rs
+++ b/core/store/src/trie/trie_tests.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 /// TrieMemoryPartialStorage, but contains only the first n requested nodes.
 pub struct IncompletePartialStorage {
-    pub(crate) recorded_storage: HashMap<CryptoHash, Vec<u8>>,
+    pub(crate) recorded_storage: HashMap<CryptoHash, Arc<[u8]>>,
     pub(crate) visited_nodes: RefCell<HashSet<CryptoHash>>,
     pub node_count_to_fail_after: usize,
 }
@@ -37,7 +37,7 @@ impl TrieStorage for IncompletePartialStorage {
         let result = self
             .recorded_storage
             .get(hash)
-            .map_or_else(|| Err(StorageError::TrieNodeMissing), |val| Ok(val.as_slice().into()));
+            .map_or(Err(StorageError::TrieNodeMissing), |val| Ok(val.clone()));
 
         if result.is_ok() {
             self.visited_nodes.borrow_mut().insert(*hash);

--- a/core/store/src/trie/trie_tests.rs
+++ b/core/store/src/trie/trie_tests.rs
@@ -34,10 +34,7 @@ impl IncompletePartialStorage {
 
 impl TrieStorage for IncompletePartialStorage {
     fn retrieve_raw_bytes(&self, hash: &CryptoHash) -> Result<Arc<[u8]>, StorageError> {
-        let result = self
-            .recorded_storage
-            .get(hash)
-            .map_or(Err(StorageError::TrieNodeMissing), |val| Ok(val.clone()));
+        let result = self.recorded_storage.get(hash).cloned().ok_or(StorageError::TrieNodeMissing);
 
         if result.is_ok() {
             self.visited_nodes.borrow_mut().insert(*hash);


### PR DESCRIPTION
Replace all caching and recording fields in trie storage to keep the
raw node’s bytes as `Arc<[u8]>` rather than `Vec<u8>`.  This forced
changing of the challanges::PartialState to use an Arc as well.