### PR TITLE
refactor: imporve performance of random unused account selection

### DIFF
--- a/runtime/runtime-params-estimator/src/transaction_builder.rs
+++ b/runtime/runtime-params-estimator/src/transaction_builder.rs
@@ -103,7 +103,7 @@ impl TransactionBuilder {
         self.accounts[account_index].clone()
     }
     pub(crate) fn random_unused_account(&mut self) -> AccountId {
-        if self.unused_index == self.accounts.len() {
+        if self.unused_index >= self.unused_accounts.len() {
             panic!("All accounts used. Try running with a higher value for the parameter `--accounts-num <NUM>`.")
         }
         let tmp = self.unused_index;

--- a/runtime/runtime-params-estimator/src/transaction_builder.rs
+++ b/runtime/runtime-params-estimator/src/transaction_builder.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use genesis_populate::get_account_id;
 use near_crypto::{InMemorySigner, KeyType};
@@ -6,6 +6,7 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::transaction::{Action, FunctionCallAction, SignedTransaction};
 use near_primitives::types::AccountId;
 use rand::prelude::ThreadRng;
+use rand::seq::SliceRandom;
 use rand::Rng;
 
 /// A helper to create transaction for processing by a `TestBed`.
@@ -13,12 +14,19 @@ use rand::Rng;
 pub(crate) struct TransactionBuilder {
     accounts: Vec<AccountId>,
     nonces: HashMap<AccountId, u64>,
-    used_accounts: HashSet<AccountId>,
+    unused_accounts: Vec<usize>,
+    unused_index: usize,
 }
 
 impl TransactionBuilder {
     pub(crate) fn new(accounts: Vec<AccountId>) -> TransactionBuilder {
-        TransactionBuilder { accounts, nonces: HashMap::new(), used_accounts: HashSet::new() }
+        let n = accounts.len();
+        let mut rng = rand::thread_rng();
+        let mut unused_accounts: Vec<usize> = Vec::from_iter(0..n);
+        unused_accounts.shuffle(&mut rng);
+        let unused_index: usize = 0;
+
+        TransactionBuilder { accounts, nonces: HashMap::new(), unused_accounts, unused_index }
     }
 
     pub(crate) fn transaction_from_actions(
@@ -95,15 +103,12 @@ impl TransactionBuilder {
         self.accounts[account_index].clone()
     }
     pub(crate) fn random_unused_account(&mut self) -> AccountId {
-        if self.used_accounts.len() == self.accounts.len() {
+        if self.unused_index == self.accounts.len() {
             panic!("All accounts used. Try running with a higher value for the parameter `--accounts-num <NUM>`.")
         }
-        loop {
-            let account = self.random_account();
-            if self.used_accounts.insert(account.clone()) {
-                return account;
-            }
-        }
+        let tmp = self.unused_index;
+        self.unused_index += 1;
+        return self.accounts[self.unused_accounts[tmp]].clone();
     }
     pub(crate) fn random_account_pair(&mut self) -> (AccountId, AccountId) {
         let first = self.random_account();


### PR DESCRIPTION
Improve the performance of selecting random unused account in https://github.com/near/nearcore/blob/master/runtime/runtime-params-estimator/src/transaction_builder.rs. See #7450 for more details.


