### PR TITLE
fix: add missing continue to shard cache put

### DIFF
--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -184,7 +184,6 @@ impl TrieCacheInner {
                     }
                     None => {
                         self.metrics.shard_cache_pop_misses.inc();
-
                         None
                     }
                 },

--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -184,6 +184,7 @@ impl TrieCacheInner {
                     }
                     None => {
                         self.metrics.shard_cache_pop_misses.inc();
+
                         None
                     }
                 },

--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -118,6 +118,7 @@ impl TrieCacheInner {
                     }
                     None => {
                         metrics::SHARD_CACHE_POP_MISSES.with_label_values(&metrics_labels).inc();
+                        continue;
                     }
                 },
                 None => {}


### PR DESCRIPTION
If we are unable to remove element with hash taken from deletions queue, we remove LRU item from cache. This is not optimal - we should continue iterating over deletions queue until we don't exhaust it.

## Testing

Existing tests - but we will have to add more https://github.com/near/nearcore/issues/7498