### PR TITLE
feat(estimator): compact RocksDB in testbed setup

### DIFF
--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -137,6 +137,14 @@ pub trait Database: Sync + Send {
     /// This is a no-op for in-memory databases.
     fn flush(&self) -> io::Result<()>;
 
+    /// Compact database representation.
+    /// 
+    /// If the database supports it a form of compaction, calling this function
+    /// is blocking until compaction finishes. Otherwise, this is a no-op.
+    fn compact(&self) -> io::Result<()> {
+        Ok(())
+    }
+
     /// Returns statistics about the database if available.
     fn get_store_statistics(&self) -> Option<StoreStatistics>;
 }

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -138,7 +138,7 @@ pub trait Database: Sync + Send {
     fn flush(&self) -> io::Result<()>;
 
     /// Compact database representation.
-    /// 
+    ///
     /// If the database supports it a form of compaction, calling this function
     /// is blocking until compaction finishes. Otherwise, this is a no-op.
     fn compact(&self) -> io::Result<()> {

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -141,9 +141,7 @@ pub trait Database: Sync + Send {
     ///
     /// If the database supports it a form of compaction, calling this function
     /// is blocking until compaction finishes. Otherwise, this is a no-op.
-    fn compact(&self) -> io::Result<()> {
-        Ok(())
-    }
+    fn compact(&self) -> io::Result<()>;
 
     /// Returns statistics about the database if available.
     fn get_store_statistics(&self) -> Option<StoreStatistics>;

--- a/core/store/src/db/rocksdb.rs
+++ b/core/store/src/db/rocksdb.rs
@@ -247,6 +247,14 @@ impl Database for RocksDB {
         self.db.write(batch).map_err(into_other)
     }
 
+    fn compact(&self) -> io::Result<()> {
+        let none = Option::<&[u8]>::None;
+        for col in DBCol::iter() {
+            self.db.compact_range_cf(self.cf_handle(col), none, none);
+        }
+        Ok(())
+    }
+
     fn flush(&self) -> io::Result<()> {
         self.db.flush().map_err(into_other)
     }

--- a/core/store/src/db/testdb.rs
+++ b/core/store/src/db/testdb.rs
@@ -88,6 +88,10 @@ impl Database for TestDB {
         Ok(())
     }
 
+    fn compact(&self) -> io::Result<()> {
+        Ok(())
+    }
+
     fn get_store_statistics(&self) -> Option<StoreStatistics> {
         None
     }

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -181,6 +181,11 @@ impl Store {
         self.storage.flush()
     }
 
+    /// Blocking compaction request if supported by storage.
+    pub fn compact(&self) -> io::Result<()> {
+        self.storage.compact()
+    }
+
     pub fn get_store_statistics(&self) -> Option<StoreStatistics> {
         self.storage.get_store_statistics()
     }

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -42,10 +42,13 @@
 //! dump all records to a `StateDump` written to a file. Then for each
 //! iteration of a an estimation, we first load the records from this dump into
 //! a fresh database. Afterwards, it is crucial to run compaction on RocksDB
-//! before starting measrments. Otherwise the SST file layout can be very
-//! ineifficient, as there wass no time to restructure them. Also, compaction
-//! may start during the measurement and makes the results unstable.
-//! 
+//! before starting measurements. Otherwise, the SST file layout can be very
+//! inefficient, as there was no time to restructure them. We assume that in
+//! production, the inflow of new data is not as bulky and therefore it should
+//! always be reasonably compacted. Also, without forcing it before
+//! measurements start, compaction may start during the measurement and makes
+//! the results unstable.
+//!
 //! Notes on code architecture:
 //!
 //! To keep estimations comprehensible, each estimation has a simple function

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -38,6 +38,14 @@
 //! costs and don't want to just run everything in order (as that would be to
 //! slow), we have a very simple manual caching infrastructure in place.
 //!
+//! To run estimations on a non-empty DB with standardised content, we first
+//! dump all records to a `StateDump` written to a file. Then for each
+//! iteration of a an estimation, we first load the records from this dump into
+//! a fresh database. Afterwards, it is crucial to run compaction on RocksDB
+//! before starting measrments. Otherwise the SST file layout can be very
+//! ineifficient, as there wass no time to restructure them. Also, compaction
+//! may start during the measurement and makes the results unstable.
+//! 
 //! Notes on code architecture:
 //!
 //! To keep estimations comprehensible, each estimation has a simple function

--- a/runtime/runtime-params-estimator/src/testbed.rs
+++ b/runtime/runtime-params-estimator/src/testbed.rs
@@ -28,6 +28,7 @@ impl RuntimeTestbed {
     pub fn from_state_dump(dump_dir: &Path) -> Self {
         let workdir = tempfile::Builder::new().prefix("runtime_testbed").tempdir().unwrap();
         let StateDump { store, roots } = StateDump::from_dir(dump_dir, workdir.path());
+        // Ensure decent RocksDB SST file layout.
         store.compact().expect("compaction failed");
         let tries = ShardTries::test(store, 1);
 

--- a/runtime/runtime-params-estimator/src/testbed.rs
+++ b/runtime/runtime-params-estimator/src/testbed.rs
@@ -28,6 +28,7 @@ impl RuntimeTestbed {
     pub fn from_state_dump(dump_dir: &Path) -> Self {
         let workdir = tempfile::Builder::new().prefix("runtime_testbed").tempdir().unwrap();
         let StateDump { store, roots } = StateDump::from_dir(dump_dir, workdir.path());
+        store.compact().expect("compaction failed");
         let tries = ShardTries::test(store, 1);
 
         assert!(roots.len() <= 1, "Parameter estimation works with one shard only.");


### PR DESCRIPTION
Run compaction on the DB after inserting all records from the state
dump. This brings the layout of SST files to a more stable and optimal
layout. See #4771 for more details.

This is an estimator only change.