### PR TITLE
removed UpdateEdge from PeerManagerActor

### DIFF
--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -964,20 +964,11 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for PeerActor {
                     return;
                 }
 
-                self.peer_manager_addr
-                    .send(PeerToManagerMsg::UpdateEdge((
-                        self.other_peer_id().unwrap().clone(),
-                        edge.next(),
-                    )))
-                    .into_actor(self)
-                    .then(|res, act, _ctx| {
-                        if let Ok(PeerToManagerMsgResp::UpdatedEdge(edge_info)) = res {
-                            act.partial_edge_info = Some(edge_info);
-                            act.send_handshake();
-                        }
-                        actix::fut::ready(())
-                    })
-                    .spawn(ctx);
+                let edge_info = self
+                    .network_state
+                    .propose_edge(self.other_peer_id().unwrap(), Some(edge.next()));
+                self.partial_edge_info = Some(edge_info);
+                self.send_handshake();
             }
             (PeerStatus::Ready, PeerMessage::Disconnect) => {
                 debug!(target: "network", "Disconnect signal. Me: {:?} Peer: {:?}", self.my_node_info.id, self.other_peer_id());

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -1848,9 +1848,6 @@ impl PeerManagerActor {
                 self.handle_msg_peers_response(msg);
                 PeerToManagerMsgResp::Empty
             }
-            PeerToManagerMsg::UpdateEdge((peer, nonce)) => {
-                PeerToManagerMsgResp::UpdatedEdge(self.state.propose_edge(&peer, Some(nonce)))
-            }
             PeerToManagerMsg::RouteBack(body, target) => {
                 trace!(target: "network", ?target, "Sending message to route back");
                 self.send_message_to_peer(RawRoutedMessage {

--- a/chain/network/src/private_actix.rs
+++ b/chain/network/src/private_actix.rs
@@ -40,14 +40,13 @@ pub(crate) enum PeerToManagerMsg {
     },
 
     // PeerRequest
-    UpdateEdge((PeerId, u64)),
     RouteBack(Box<RoutedMessageBody>, CryptoHash),
     UpdatePeerInfo(PeerInfo),
 }
 
 /// List of all replies to messages to `PeerManager`. See `PeerManagerMessageRequest` for more details.
 #[derive(actix::MessageResponse, Debug)]
-pub enum PeerToManagerMsgResp {
+pub(crate) enum PeerToManagerMsgResp {
     RoutedMessageFrom(bool),
     RegisterPeer(RegisterPeerResponse),
     PeersRequest(PeerRequestResult),
@@ -58,7 +57,6 @@ pub enum PeerToManagerMsgResp {
     BanPeer(ReasonForBan),
 
     // PeerResponse
-    UpdatedEdge(PartialEdgeInfo),
     Empty,
 }
 /// Actor message which asks `PeerManagerActor` to register peer.


### PR DESCRIPTION
Now that propose_edge is a method of NetworkState, PeerActor is able to call it directly.