### PR TITLE
refactor: cleanup contract runtime entry point

### DIFF
--- a/runtime/near-vm-runner/src/wasmer2_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer2_runner.rs
@@ -40,18 +40,18 @@ const WASMER_FEATURES: Features = Features {
 pub struct Wasmer2Memory(Arc<LinearMemory>);
 
 impl Wasmer2Memory {
-    pub(crate) fn new(initial_memory_pages: u32, max_memory_pages: u32) -> Result<Self, VMError> {
+    pub(crate) fn new(
+        initial_memory_pages: u32,
+        max_memory_pages: u32,
+    ) -> Result<Self, wasmer_vm::MemoryError> {
         let max_pages = Pages(max_memory_pages);
-        Ok(Wasmer2Memory(Arc::new(
-            LinearMemory::new(
-                &MemoryType::new(Pages(initial_memory_pages), Some(max_pages), false),
-                &MemoryStyle::Static {
-                    bound: max_pages,
-                    offset_guard_size: wasmer_types::WASM_PAGE_SIZE as u64,
-                },
-            )
-            .expect("creating memory must not fail"),
-        )))
+        Ok(Wasmer2Memory(Arc::new(LinearMemory::new(
+            &MemoryType::new(Pages(initial_memory_pages), Some(max_pages), false),
+            &MemoryStyle::Static {
+                bound: max_pages,
+                offset_guard_size: wasmer_types::WASM_PAGE_SIZE as u64,
+            },
+        )?)))
     }
 
     // Returns the pointer to memory at the specified offset and the size of the buffer starting at

--- a/runtime/near-vm-runner/src/wasmer2_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer2_runner.rs
@@ -40,7 +40,7 @@ const WASMER_FEATURES: Features = Features {
 pub struct Wasmer2Memory(Arc<LinearMemory>);
 
 impl Wasmer2Memory {
-    pub(crate) fn new(
+    fn new(
         initial_memory_pages: u32,
         max_memory_pages: u32,
     ) -> Result<Self, wasmer_vm::MemoryError> {

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -1,8 +1,11 @@
+use crate::config::{safe_add_gas, RuntimeConfig};
+use crate::ext::{ExternalError, RuntimeExt};
+use crate::{ActionResult, ApplyState};
 use borsh::{BorshDeserialize, BorshSerialize};
-
 use near_crypto::PublicKey;
 use near_primitives::account::{AccessKey, AccessKeyPermission, Account};
 use near_primitives::checked_feature;
+use near_primitives::config::ViewConfig;
 use near_primitives::contract::ContractCode;
 use near_primitives::errors::{ActionError, ActionErrorKind, ContractCallError, RuntimeError};
 use near_primitives::hash::CryptoHash;
@@ -29,11 +32,6 @@ use near_vm_errors::{
 };
 use near_vm_logic::types::PromiseResult;
 use near_vm_logic::VMContext;
-
-use crate::config::{safe_add_gas, RuntimeConfig};
-use crate::ext::{ExternalError, RuntimeExt};
-use crate::{ActionResult, ApplyState};
-use near_primitives::config::ViewConfig;
 use near_vm_runner::{precompile_contract, VMResult};
 
 /// Runs given function call with given context / apply state.

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -40,7 +40,7 @@ use near_vm_runner::{precompile_contract, VMResult};
 pub(crate) fn execute_function_call(
     apply_state: &ApplyState,
     runtime_ext: &mut RuntimeExt,
-    account: &mut Account,
+    account: &Account,
     predecessor_id: &AccountId,
     action_receipt: &ActionReceipt,
     promise_results: &[PromiseResult],


### PR DESCRIPTION
Just minor cleanups:

* remove needles `&mut`
* flatten the entry point a bit
* collapse two unwraps into one