### PR TITLE
store: refactor flat_state.rs to reduce amount of annotations

### DIFF
--- a/core/store/src/flat_state.rs
+++ b/core/store/src/flat_state.rs
@@ -84,7 +84,7 @@ mod imp {
 
     impl FlatState {
         pub fn get_ref(&self, _root: &CryptoHash, _key: &[u8]) -> ! {
-            match self {}
+            match *self {}
         }
     }
 

--- a/core/store/src/flat_state.rs
+++ b/core/store/src/flat_state.rs
@@ -77,6 +77,8 @@ mod imp {
     use crate::Store;
 
     /// Since this has no variants it can never be instantiated.
+    ///
+    /// To use flat state enable `protocol_feature_flat_state` cargo feature.
     #[derive(Clone)]
     pub enum FlatState {}
 
@@ -86,6 +88,8 @@ mod imp {
         }
     }
 
+    /// Always returns `None`; to use of flat state enable
+    /// `protocol_feature_flat_state` cargo feature.
     #[inline]
     pub fn maybe_new(_use_flat_state: bool, _store: &Store) -> Option<FlatState> {
         None

--- a/core/store/src/flat_state.rs
+++ b/core/store/src/flat_state.rs
@@ -7,58 +7,89 @@
 //! To optimize this, we want to use flat state: alongside the trie, we store a mapping from keys to value
 //! references so that, if you don't need a proof, you can do a db lookup in just two db accesses - one to get value
 //! reference, one to get value itself.
-/// TODO (#7327): consider inlining small values, so we could use only one db access.
+// TODO (#7327): consider inlining small values, so we could use only one db access.
 
 #[cfg(feature = "protocol_feature_flat_state")]
-use crate::DBCol;
-use crate::Store;
-use near_primitives::errors::StorageError;
-use near_primitives::hash::CryptoHash;
-use near_primitives::state::ValueRef;
+mod imp {
+    use near_primitives::errors::StorageError;
+    use near_primitives::hash::CryptoHash;
+    use near_primitives::state::ValueRef;
 
-/// Struct for getting value references from the flat storage.
-/// Used to speed up `get` and `get_ref` trie methods.
-/// It should store all trie keys for state on top of chain head, except delayed receipt keys, because they are the
-/// same for each shard and they are requested only once during applying chunk.
-/// TODO (#7327): implement flat state deltas to support forks
-/// TODO (#7327): store on top of final head (or earlier) so updates will only go forward
-#[derive(Clone)]
-pub struct FlatState {
-    #[allow(dead_code)]
-    store: Store,
-}
+    use crate::Store;
 
-impl FlatState {
-    #[cfg(feature = "protocol_feature_flat_state")]
-    pub fn new(store: Store) -> Self {
-        Self { store }
+    /// Struct for getting value references from the flat storage.
+    ///
+    /// Used to speed up `get` and `get_ref` trie methods.  It should store all
+    /// trie keys for state on top of chain head, except delayed receipt keys,
+    /// because they are the same for each shard and they are requested only
+    /// once during applying chunk.
+    // TODO (#7327): implement flat state deltas to support forks.
+    // TODO (#7327): store on top of final head (or earlier) so updates will
+    // only go forward.
+    #[derive(Clone)]
+    pub struct FlatState {
+        store: Store,
     }
 
-    #[allow(unused_variables)]
-    fn get_raw_ref(&self, key: &[u8]) -> Result<Option<Vec<u8>>, StorageError> {
-        #[cfg(feature = "protocol_feature_flat_state")]
-        return self
-            .store
-            .get(DBCol::FlatState, key)
-            .map_err(|_| StorageError::StorageInternalError);
-        #[cfg(not(feature = "protocol_feature_flat_state"))]
-        unreachable!();
-    }
+    impl FlatState {
+        fn get_raw_ref(&self, key: &[u8]) -> Result<Option<Vec<u8>>, StorageError> {
+            return self
+                .store
+                .get(crate::DBCol::FlatState, key)
+                .map_err(|_| StorageError::StorageInternalError);
+        }
 
-    /// Get value reference using raw trie key and state root. We assume that flat state contains data for this root.
-    /// To avoid duplication, we don't store values themselves in flat state, they are stored in `DBCol::State`. Also
-    /// the separation is done so we could charge users for the value length before loading the value.
-    /// TODO (#7327): support different roots (or block hashes).
-    pub fn get_ref(
-        &self,
-        _root: &CryptoHash,
-        key: &[u8],
-    ) -> Result<Option<ValueRef>, StorageError> {
-        match self.get_raw_ref(key)? {
-            Some(bytes) => {
-                ValueRef::decode(&bytes).map(Some).map_err(|_| StorageError::StorageInternalError)
+        /// Returns value reference using raw trie key and state root.
+        ///
+        /// We assume that flat state contains data for this root.  To avoid
+        /// duplication, we don't store values themselves in flat state, they
+        /// are stored in `DBCol::State`. Also the separation is done so we
+        /// could charge users for the value length before loading the value.
+        // TODO (#7327): support different roots (or block hashes).
+        pub fn get_ref(
+            &self,
+            _root: &CryptoHash,
+            key: &[u8],
+        ) -> Result<Option<ValueRef>, StorageError> {
+            match self.get_raw_ref(key)? {
+                Some(bytes) => ValueRef::decode(&bytes)
+                    .map(Some)
+                    .map_err(|_| StorageError::StorageInternalError),
+                None => Ok(None),
             }
-            None => Ok(None),
         }
     }
+
+    /// Possibly creates a new [`FlateState`] object backed by given storage.
+    ///
+    /// Always returns `None` if the `protocol_feature_flat_state` Cargo feature is
+    /// not enabled.  Otherwise, returns a new [`FlatState`] object backed by
+    /// specified storage if `use_flat_state` argument is true.
+    pub fn maybe_new(use_flat_state: bool, store: &Store) -> Option<FlatState> {
+        use_flat_state.then(|| FlatState { store: store.clone() })
+    }
 }
+
+#[cfg(not(feature = "protocol_feature_flat_state"))]
+mod imp {
+    use near_primitives::hash::CryptoHash;
+
+    use crate::Store;
+
+    /// Since this has no variants it can never be instantiated.
+    #[derive(Clone)]
+    pub enum FlatState {}
+
+    impl FlatState {
+        pub fn get_ref(&self, _root: &CryptoHash, _key: &[u8]) -> ! {
+            unreachable!()
+        }
+    }
+
+    #[inline]
+    pub fn maybe_new(_use_flat_state: bool, _store: &Store) -> Option<FlatState> {
+        None
+    }
+}
+
+pub use imp::{maybe_new, FlatState};

--- a/core/store/src/flat_state.rs
+++ b/core/store/src/flat_state.rs
@@ -82,7 +82,7 @@ mod imp {
 
     impl FlatState {
         pub fn get_ref(&self, _root: &CryptoHash, _key: &[u8]) -> ! {
-            unreachable!()
+            match self {}
         }
     }
 


### PR DESCRIPTION
Add flat_state::maybe_new function which creates FlatState object when
requested and the feature is enabled.  This removes bunch of
annotations and noise from shard_tries.rs.

Furthermore, split definition of FlateState to one when the feature is
enabled and another when it’s disabled.  This further removes bunch of
annotations this time at definition place.

Furthermore, by making the latter impossible to instantiate (by using
an enum with no variants) this encodes in the type system that the
flat state won’t be created if the feature is not enabled and its
method won’t be called.  This also makes `Option<FlatState>` a ZST.