### PR TITLE
nightly: switch to fuzzing 1.28.1 and 1.29.0

### DIFF
--- a/nightly/fuzz.toml
+++ b/nightly/fuzz.toml
@@ -3,11 +3,11 @@ name = "master"
 weight = 10
 
 [[branch]]
-name = "1.28.0"
+name = "1.29.0"
 weight = 10
 
 [[branch]]
-name = "1.27.0"
+name = "1.28.1"
 weight = 10
 
 [[target]]


### PR DESCRIPTION
Firstly, 1.29 release cycle has started so start fuzzing 1.29.0.

Secondly, 1.28.1 has been released so switch to fuzzing that rather
than 1.28.0.

And lastly, with all that don’t waste time fuzzing 1.27 any longer.
