### PR TITLE
pytest: fix one_val.py test

### DIFF
--- a/pytest/tests/sanity/one_val.py
+++ b/pytest/tests/sanity/one_val.py
@@ -43,7 +43,14 @@ nightly_genesis_change = [
 
 # give more stake to the bootnode so that it can produce the blocks alone
 nodes = start_cluster(2, 1, 8, None,
-                      nightly_genesis_change if nightly else genesis_change, {})
+                      nightly_genesis_change if nightly else genesis_change, {
+                          0: {
+                              "tracked_shards": [0]
+                          },
+                          1: {
+                              "tracked_shards": [0]
+                          }
+                      })
 time.sleep(3)
 nodes[1].kill()
 


### PR DESCRIPTION
The test broke after recent changes to tracked shards configuration
options.  Fix it.