### PR TITLE
adding store::get_or_err and store::get_ser_or_err

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3440,6 +3440,7 @@ dependencies = [
  "fs2",
  "insta",
  "lru",
+ "near-chain-primitives",
  "near-crypto",
  "near-metrics",
  "near-o11y",

--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -217,6 +217,17 @@ pub enum Error {
     Other(String),
 }
 
+pub fn option_to_not_found<T, F>(res: io::Result<Option<T>>, field_name: F) -> Result<T, Error>
+where
+    F: std::string::ToString,
+{
+    match res {
+        Ok(Some(o)) => Ok(o),
+        Ok(None) => Err(Error::DBNotFoundErr(field_name.to_string())),
+        Err(e) => Err(e.into()),
+    }
+}
+
 /// For now StorageError can happen at any time from ViewClient because of
 /// the used isolation level + running ViewClient in a separate thread.
 pub trait LogTransientStorageError {

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -6,7 +6,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use near_cache::CellLruCache;
 use near_primitives::time::Utc;
 
-use near_chain_primitives::error::Error;
+use near_chain_primitives::error::{option_to_not_found, Error};
 use near_primitives::block::Tip;
 use near_primitives::errors::InvalidTxError;
 use near_primitives::hash::CryptoHash;
@@ -367,17 +367,6 @@ pub struct ChainStore {
     processed_block_heights: CellLruCache<Vec<u8>, ()>,
     /// Is this a non-archival node that needs to store to DBCol::TrieChanges?
     save_trie_changes: bool,
-}
-
-fn option_to_not_found<T, F>(res: io::Result<Option<T>>, field_name: F) -> Result<T, Error>
-where
-    F: std::string::ToString,
-{
-    match res {
-        Ok(Some(o)) => Ok(o),
-        Ok(None) => Err(Error::DBNotFoundErr(field_name.to_string())),
-        Err(e) => Err(e.into()),
-    }
 }
 
 impl ChainStore {

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -30,6 +30,7 @@ lru = "0.7.2"
 once_cell = "1.5.2"
 rlimit = "0.7"
 
+near-chain-primitives = { path = "../../chain/chain-primitives" }
 near-crypto = { path = "../crypto" }
 near-o11y = { path = "../o11y" }
 near-primitives = { path = "../primitives" }


### PR DESCRIPTION
Don't know if it even should exist. I just needed to read value from database and convert None to DBNotFound Error in my code a bunch and wished it was a part of the Store interface. 
So I'm basically adding get functions which expect key to be present.
Please suggest better naming alternatives. Also, I don't know if adding a new dependancy to the store is a good idea (because I don't know anything about our guidelines for dependancies). 