### PR TITLE
adjusted log message

### DIFF
--- a/pytest/tests/sanity/state_sync_routed.py
+++ b/pytest/tests/sanity/state_sync_routed.py
@@ -145,7 +145,7 @@ while True:
     assert time.time(
     ) - started < TIMEOUT, "Waiting for node 4 to connect to two peers"
     tracker4.reset()
-    if tracker4.count("Consolidated connection full_peer_info") == 2:
+    if tracker4.count("Consolidated connection") == 2:
         break
     time.sleep(0.1)
 


### PR DESCRIPTION
because the test relies on the string in a log.
Passing nayduck run: https://nayduck.near.org/#/test/358900