### PR TITLE
chore: remove dead code

### DIFF
--- a/core/metrics/src/lib.rs
+++ b/core/metrics/src/lib.rs
@@ -109,24 +109,6 @@ pub fn try_create_counter(name: &str, help: &str) -> Result<Counter> {
     Ok(counter)
 }
 
-/// Creates 'IntCounterVec' - if it has trouble registering to Prometheus
-/// it will keep appending a number until the name is unique.
-pub fn do_create_int_counter_vec(name: &str, help: &str, labels: &[&str]) -> IntCounterVec {
-    if let Ok(value) = try_create_int_counter_vec(name, help, labels) {
-        return value;
-    }
-    let mut suffix = 0;
-
-    loop {
-        if let Ok(value) =
-            try_create_int_counter_vec(format!("{}_{}", name, suffix).as_str(), help, labels)
-        {
-            return value;
-        }
-        suffix += 1;
-    }
-}
-
 /// Attempts to crate an `IntGauge`, returning `Err` if the registry does not accept the gauge
 /// (potentially due to naming conflict).
 pub fn try_create_int_gauge(name: &str, help: &str) -> Result<IntGauge> {


### PR DESCRIPTION
This ... is somewhat questionable API, let's remove it if we are not
using it.

Was added and removed in

* 061161bd7b8566bea541537d6d98177ee6246827
* 1198ec789abcdf71fecbe37b3be81ad00417146d