### PR TITLE
types: turn DbVersion into a strong type

### DIFF
--- a/chain/client/src/metrics.rs
+++ b/chain/client/src/metrics.rs
@@ -309,8 +309,8 @@ pub static PRODUCE_AND_DISTRIBUTE_CHUNK_TIME: Lazy<near_metrics::HistogramVec> =
 /// database version and build information.  The latter is taken from
 /// `neard_version` argument.
 pub(crate) fn export_version(neard_version: &near_primitives::version::Version) {
-    NODE_PROTOCOL_VERSION.set(near_primitives::version::PROTOCOL_VERSION as i64);
-    NODE_DB_VERSION.set(near_primitives::version::DB_VERSION as i64);
+    NODE_PROTOCOL_VERSION.set(near_primitives::version::PROTOCOL_VERSION.into());
+    NODE_DB_VERSION.set(near_primitives::version::DB_VERSION.into());
     NODE_BUILD_INFO.reset();
     NODE_BUILD_INFO
         .with_label_values(&[

--- a/core/primitives/src/db_version.rs
+++ b/core/primitives/src/db_version.rs
@@ -1,0 +1,52 @@
+/// Database version.
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+pub struct DbVersion(pub u32);
+
+/// Current version of the database.
+pub const DB_VERSION: DbVersion = DbVersion(31);
+
+impl DbVersion {
+    /// Returns binary serialisation of the version.
+    pub fn serialise(self) -> Vec<u8> {
+        self.0.to_string().into_bytes()
+    }
+
+    /// Deserialises database version from binary data.
+    ///
+    /// This is an inverse of [`DbVersion::serialise`].
+    pub fn deserialise(bytes: &[u8]) -> Result<Self, String> {
+        let value = std::str::from_utf8(bytes)
+            .map_err(|err| format!("invalid DbVersion (‘{bytes:x?}’): {err}"))?;
+        let ver = u32::from_str_radix(value, 10)
+            .map_err(|err| format!("invalid DbVersion (‘{value}’): {err}"))?;
+        Ok(Self(ver))
+    }
+}
+
+impl std::fmt::Debug for DbVersion {
+    #[inline]
+    fn fmt(&self, fmtr: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(&self.0, fmtr)
+    }
+}
+
+impl std::fmt::Display for DbVersion {
+    #[inline]
+    fn fmt(&self, fmtr: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.0, fmtr)
+    }
+}
+
+impl From<u32> for DbVersion {
+    #[inline]
+    fn from(ver: u32) -> Self {
+        Self(ver)
+    }
+}
+
+impl From<DbVersion> for i64 {
+    #[inline]
+    fn from(ver: DbVersion) -> Self {
+        i64::from(ver.0)
+    }
+}

--- a/core/primitives/src/lib.rs
+++ b/core/primitives/src/lib.rs
@@ -11,6 +11,7 @@ pub use near_primitives_core::serialize;
 pub mod block;
 pub mod block_header;
 pub mod challenge;
+mod db_version;
 pub mod epoch_manager;
 pub mod errors;
 pub mod merkle;

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -16,11 +16,7 @@ pub struct Version {
     pub rustc_version: String,
 }
 
-/// Database version.
-pub type DbVersion = u32;
-
-/// Current version of the database.
-pub const DB_VERSION: DbVersion = 31;
+pub use crate::db_version::{DbVersion, DB_VERSION};
 
 use crate::upgrade_schedule::{get_protocol_version_internal, ProtocolUpgradeVotingSchedule};
 /// Protocol version type.

--- a/core/store/src/db/rocksdb.rs
+++ b/core/store/src/db/rocksdb.rs
@@ -446,9 +446,9 @@ impl RocksDB {
                         .into(),
                 )
             })?;
-        serde_json::from_slice(&value).map_err(|_err| {
+        DbVersion::deserialise(&value).map_err(|err| {
             other_error(format!(
-                "Failed to parse database version: {value:?}; \
+                "Failed to parse database version: {err}; \
                  it’s not a neard database or database is corrupted."
             ))
         })

--- a/core/store/src/migrations.rs
+++ b/core/store/src/migrations.rs
@@ -6,14 +6,13 @@ use near_primitives::epoch_manager::epoch_info::{EpochInfo, EpochInfoV1};
 use near_primitives::hash::CryptoHash;
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::AccountId;
+use near_primitives::version::DbVersion;
 
 use crate::{DBCol, Store, StoreOpener, StoreUpdate};
 
-pub fn set_store_version(store: &Store, db_version: u32) -> std::io::Result<()> {
+pub fn set_store_version(store: &Store, db_version: DbVersion) -> std::io::Result<()> {
     let mut store_update = store.store_update();
-    // Contrary to other integers, we’re using textual representation for
-    // storing DbVersion in VERSION_KEY thus to_string rather than to_le_bytes.
-    store_update.set(DBCol::DbVersion, crate::db::VERSION_KEY, db_version.to_string().as_bytes());
+    store_update.set(DBCol::DbVersion, crate::db::VERSION_KEY, &db_version.serialise());
     store_update.commit()
 }
 
@@ -85,7 +84,7 @@ pub fn migrate_28_to_29(store_opener: &StoreOpener) -> anyhow::Result<()> {
     store_update.delete_all(DBCol::_LastBlockWithNewChunk);
     store_update.commit()?;
 
-    set_store_version(&store, 29)?;
+    set_store_version(&store, DbVersion(29))?;
     Ok(())
 }
 
@@ -177,6 +176,6 @@ pub fn migrate_29_to_30(store_opener: &StoreOpener) -> anyhow::Result<()> {
 
     store_update.finish()?;
 
-    set_store_version(&store, 30)?;
+    set_store_version(&store, DbVersion(30))?;
     Ok(())
 }

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -124,7 +124,7 @@ fn apply_store_migrations_if_exists(
     // For given db version, latest neard release which supported that version.
     // If you’re removing support for a database version from neard put an entry
     // here so that we can inform user which version they need.
-    const LATEST_DB_SUPPORTED: [(DbVersion, &'static str); 1] = [(26, "1.26")];
+    const LATEST_DB_SUPPORTED: [(DbVersion, &'static str); 1] = [(DbVersion(26), "1.26")];
     if let Some((_, release)) =
         LATEST_DB_SUPPORTED.iter().filter(|(ver, _)| db_version <= *ver).next()
     {
@@ -141,29 +141,29 @@ fn apply_store_migrations_if_exists(
     let snapshot = create_db_checkpoint(store_opener, near_config)?;
 
     // Add migrations here based on `db_version`.
-    if db_version <= 26 {
+    if db_version <= DbVersion(26) {
         // Unreachable since we should have bailed when checking
         // LATEST_DB_SUPPORTED above.
         unreachable!();
     }
-    if db_version <= 27 {
+    if db_version <= DbVersion(27) {
         // version 27 => 28: add DBCol::StateChangesForSplitStates
         // Does not need to do anything since open db with option
         // `create_missing_column_families`.  Nevertheless need to bump db
         // version, because db_version 27 binary can't open db_version 28 db.
         // Combine it with migration from 28 to 29; don’t do anything here.
     }
-    if db_version <= 28 {
+    if db_version <= DbVersion(28) {
         // version 28 => 29: delete ColNextBlockWithNewChunk, ColLastBlockWithNewChunk
         info!(target: "near", "Migrate DB from version 28 to 29");
         migrate_28_to_29(store_opener)?;
     }
-    if db_version <= 29 {
+    if db_version <= DbVersion(29) {
         // version 29 => 30: migrate all structures that use ValidatorStake to versionized version
         info!(target: "near", "Migrate DB from version 29 to 30");
         migrate_29_to_30(store_opener)?;
     }
-    if db_version <= 30 {
+    if db_version <= DbVersion(30) {
         // version 30 => 31: recompute block ordinal due to a bug fixed in #5761
         info!(target: "near", "Migrate DB from version 30 to 31");
         migrate_30_to_31(store_opener, &near_config)?;
@@ -175,7 +175,7 @@ fn apply_store_migrations_if_exists(
             .with_context(|| format!("Opening database at {}", store_opener.path().display()))?
             .get_store(Temperature::Hot);
         // set some dummy value to avoid conflict with other migrations from nightly features
-        set_store_version(&store, 10000)?;
+        set_store_version(&store, DbVersion(10000))?;
     } else {
         debug_assert_eq!(
             Some(near_primitives::version::DB_VERSION),

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -3,6 +3,7 @@ use near_primitives::receipt::ReceiptResult;
 use near_primitives::runtime::migration_data::MigrationData;
 use near_primitives::types::Gas;
 use near_primitives::utils::index_to_bytes;
+use near_primitives::version::DbVersion;
 use near_store::migrations::{set_store_version, BatchedStoreUpdate};
 use near_store::{DBCol, Temperature};
 
@@ -16,7 +17,7 @@ pub fn migrate_30_to_31(
     if near_config.client_config.archive && &near_config.genesis.config.chain_id == "mainnet" {
         do_migrate_30_to_31(&store, &near_config.genesis.config)?;
     }
-    set_store_version(&store, 31)?;
+    set_store_version(&store, DbVersion(31))?;
     Ok(())
 }
 


### PR DESCRIPTION
Honestly, the main motivation is addition of serialise and deserialise
methods which can now encapsulate how we store the version in the
database.