### PR TITLE
Prefer `&[T]` to `&Vec<T>`

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1227,7 +1227,7 @@ impl Chain {
                 .get_epoch_block_approvers_ordered(header.prev_hash())?
                 .iter()
                 .map(|(x, is_slashed)| (x.stake_this_epoch, x.stake_next_epoch, *is_slashed))
-                .collect();
+                .collect::<Vec<_>>();
             if !Doomslug::can_approved_block_be_produced(
                 self.doomslug_threshold_mode,
                 header.approvals(),
@@ -1298,7 +1298,7 @@ impl Chain {
     /// upgrade.
     pub fn verify_challenges(
         &self,
-        challenges: &Vec<Challenge>,
+        challenges: &[Challenge],
         epoch_id: &EpochId,
         prev_block_hash: &CryptoHash,
     ) -> Result<(ChallengesResult, Vec<CryptoHash>), Error> {
@@ -2906,7 +2906,7 @@ impl Chain {
         shard_id: ShardId,
         sync_hash: CryptoHash,
         part_id: PartId,
-        data: &Vec<u8>,
+        data: &[u8],
     ) -> Result<(), Error> {
         let shard_state_header = self.get_state_header(shard_id, sync_hash)?;
         let chunk = shard_state_header.take_chunk();
@@ -3128,7 +3128,7 @@ impl Chain {
         epoch_first_block: &CryptoHash,
         block_processing_artifacts: &mut BlockProcessingArtifact,
         apply_chunks_done_callback: DoneApplyChunkCallback,
-        affected_blocks: &Vec<CryptoHash>,
+        affected_blocks: &[CryptoHash],
     ) -> Result<(), Error> {
         debug!(
             "Finishing catching up blocks after syncing pre {:?}, me: {:?}",

--- a/chain/chain/src/doomslug.rs
+++ b/chain/chain/src/doomslug.rs
@@ -258,7 +258,7 @@ impl DoomslugApprovalsTrackersAtHeight {
         &mut self,
         now: Instant,
         approval: &Approval,
-        stakes: &Vec<(ApprovalStake, bool)>,
+        stakes: &[(ApprovalStake, bool)],
         threshold_mode: DoomslugThresholdMode,
     ) -> DoomslugBlockProductionReadiness {
         if let Some(last_parent) = self.last_approval_per_account.get(&approval.account_id) {
@@ -512,7 +512,7 @@ impl Doomslug {
     pub fn can_approved_block_be_produced(
         mode: DoomslugThresholdMode,
         approvals: &[Option<Signature>],
-        stakes: &Vec<(Balance, Balance, bool)>,
+        stakes: &[(Balance, Balance, bool)],
     ) -> bool {
         if mode == DoomslugThresholdMode::NoApprovals {
             return true;
@@ -595,7 +595,7 @@ impl Doomslug {
         &mut self,
         now: Instant,
         approval: &Approval,
-        stakes: &Vec<(ApprovalStake, bool)>,
+        stakes: &[(ApprovalStake, bool)],
     ) -> DoomslugBlockProductionReadiness {
         let threshold_mode = self.threshold_mode;
         let ret = self
@@ -622,7 +622,7 @@ impl Doomslug {
         &mut self,
         now: Instant,
         approval: &Approval,
-        stakes: &Vec<(ApprovalStake, bool)>,
+        stakes: &[(ApprovalStake, bool)],
     ) {
         if approval.target_height < self.tip.height
             || approval.target_height > self.tip.height + MAX_HEIGHTS_AHEAD_TO_STORE_APPROVALS

--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -328,8 +328,7 @@ impl StoreValidator {
                 }
                 DBCol::StateParts => {
                     let key = StatePartKey::try_from_slice(key_ref)?;
-                    let part = value_ref.to_vec();
-                    self.check(&validate::state_part_header_exists, &key, &part, col);
+                    self.check(&validate::state_part_header_exists, &key, value_ref, col);
                 }
                 _ => {}
             }
@@ -393,7 +392,7 @@ impl StoreValidator {
         }
     }
 
-    fn check<K: std::fmt::Debug, V>(
+    fn check<K: std::fmt::Debug + ?Sized, V: ?Sized>(
         &mut self,
         f: &dyn Fn(&mut StoreValidator, &K, &V) -> Result<(), StoreValidatorError>,
         key: &K,

--- a/chain/chain/src/store_validator/validate.rs
+++ b/chain/chain/src/store_validator/validate.rs
@@ -652,7 +652,7 @@ pub(crate) fn header_hash_of_height_exists(
 pub(crate) fn outcome_by_outcome_id_exists(
     sv: &mut StoreValidator,
     block_hash: &CryptoHash,
-    outcome_ids: &Vec<CryptoHash>,
+    outcome_ids: &[CryptoHash],
 ) -> Result<(), StoreValidatorError> {
     for outcome_id in outcome_ids {
         let outcomes = unwrap_or_err_db!(
@@ -673,7 +673,7 @@ pub(crate) fn outcome_by_outcome_id_exists(
 pub(crate) fn outcome_id_block_exists(
     sv: &mut StoreValidator,
     block_hash: &CryptoHash,
-    _outcome_ids: &Vec<CryptoHash>,
+    _outcome_ids: &[CryptoHash],
 ) -> Result<(), StoreValidatorError> {
     unwrap_or_err_db!(
         sv.store.get_ser::<Block>(DBCol::Block, block_hash.as_ref()),
@@ -685,7 +685,7 @@ pub(crate) fn outcome_id_block_exists(
 pub(crate) fn outcome_indexed_by_block_hash(
     sv: &mut StoreValidator,
     outcome_id: &CryptoHash,
-    outcomes: &Vec<ExecutionOutcomeWithIdAndProof>,
+    outcomes: &[ExecutionOutcomeWithIdAndProof],
 ) -> Result<(), StoreValidatorError> {
     for outcome in outcomes {
         let block = unwrap_or_err_db!(
@@ -874,7 +874,7 @@ pub(crate) fn state_header_block_exists(
 pub(crate) fn state_part_header_exists(
     sv: &mut StoreValidator,
     key: &StatePartKey,
-    _part: &Vec<u8>,
+    _part: &[u8],
 ) -> Result<(), StoreValidatorError> {
     let StatePartKey(block_hash, shard_id, part_id) = *key;
     let state_header_key = unwrap_or_err!(

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -1021,12 +1021,7 @@ impl RuntimeAdapter for KeyValueRuntime {
         Ok(data)
     }
 
-    fn validate_state_part(
-        &self,
-        _state_root: &StateRoot,
-        _part_id: PartId,
-        _data: &Vec<u8>,
-    ) -> bool {
+    fn validate_state_part(&self, _state_root: &StateRoot, _part_id: PartId, _data: &[u8]) -> bool {
         // We do not care about deeper validation in test_utils
         true
     }

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -725,7 +725,7 @@ pub trait RuntimeAdapter: Send + Sync {
 
     /// Validate state part that expected to be given state root with provided data.
     /// Returns false if the resulting part doesn't match the expected one.
-    fn validate_state_part(&self, state_root: &StateRoot, part_id: PartId, data: &Vec<u8>) -> bool;
+    fn validate_state_part(&self, state_root: &StateRoot, part_id: PartId, data: &[u8]) -> bool;
 
     fn apply_update_to_split_states(
         &self,

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -952,11 +952,7 @@ impl ShardsManager {
         self.pool_for_shard(shard_id).insert_transaction(tx)
     }
 
-    pub fn remove_transactions(
-        &mut self,
-        shard_id: ShardId,
-        transactions: &Vec<SignedTransaction>,
-    ) {
+    pub fn remove_transactions(&mut self, shard_id: ShardId, transactions: &[SignedTransaction]) {
         if let Some(pool) = self.tx_pools.get_mut(&shard_id) {
             pool.remove_transactions(transactions)
         }
@@ -982,9 +978,9 @@ impl ShardsManager {
     pub fn reintroduce_transactions(
         &mut self,
         shard_id: ShardId,
-        transactions: &Vec<SignedTransaction>,
+        transactions: &[SignedTransaction],
     ) {
-        self.pool_for_shard(shard_id).reintroduce_transactions(transactions.clone());
+        self.pool_for_shard(shard_id).reintroduce_transactions(transactions.to_vec());
     }
 
     pub fn receipts_recipient_filter<T>(
@@ -992,7 +988,7 @@ impl ShardsManager {
         from_shard_id: ShardId,
         tracking_shards: T,
         receipts_by_shard: &HashMap<ShardId, Vec<Receipt>>,
-        proofs: &Vec<MerklePath>,
+        proofs: &[MerklePath],
     ) -> Vec<ReceiptProof>
     where
         T: IntoIterator<Item = ShardId>,
@@ -2018,7 +2014,7 @@ impl ShardsManager {
         balance_burnt: Balance,
         validator_proposals: Vec<ValidatorStake>,
         transactions: Vec<SignedTransaction>,
-        outgoing_receipts: &Vec<Receipt>,
+        outgoing_receipts: &[Receipt],
         outgoing_receipts_root: CryptoHash,
         tx_root: CryptoHash,
         signer: &dyn ValidatorSigner,
@@ -2115,7 +2111,7 @@ impl ShardsManager {
             self.create_and_persist_partial_chunk(
                 &encoded_chunk,
                 merkle_paths,
-                shard_chunk.receipts().clone(),
+                shard_chunk.receipts().to_vec(),
                 &mut store_update,
             )?;
 

--- a/chain/chunks/src/test_utils.rs
+++ b/chain/chunks/src/test_utils.rs
@@ -264,7 +264,7 @@ impl ChunkTestFixture {
             mock_chunk_part_owner,
             mock_shard_tracker,
             mock_chunk_header: encoded_chunk.cloned_header(),
-            mock_chunk_parts: encoded_chunk.parts().clone(),
+            mock_chunk_parts: encoded_chunk.parts().to_vec(),
             mock_chain_head: Tip {
                 height: 0,
                 last_block_hash: CryptoHash::default(),

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1820,7 +1820,7 @@ impl Client {
     /// Walks through all the ongoing state syncs for future epochs and processes them
     pub fn run_catchup(
         &mut self,
-        highest_height_peers: &Vec<FullPeerInfo>,
+        highest_height_peers: &[FullPeerInfo],
         state_parts_task_scheduler: &dyn Fn(ApplyStatePartsRequest),
         block_catch_up_task_scheduler: &dyn Fn(BlockCatchUpRequest),
         state_split_scheduler: &dyn Fn(StateSplitRequest),

--- a/chain/client/src/sync.rs
+++ b/chain/client/src/sync.rs
@@ -166,7 +166,7 @@ impl HeaderSync {
         sync_status: &mut SyncStatus,
         chain: &Chain,
         highest_height: BlockHeight,
-        highest_height_peers: &Vec<FullPeerInfo>,
+        highest_height_peers: &[FullPeerInfo],
     ) -> Result<(), near_chain::Error> {
         let _span = tracing::debug_span!(target: "sync", "run", sync = "HeaderSync").entered();
         let header_head = chain.header_head()?;
@@ -359,7 +359,7 @@ impl HeaderSync {
 }
 
 /// Check if there is a close enough value to provided height in the locator.
-fn close_enough(locator: &Vec<(u64, CryptoHash)>, height: u64) -> Option<(u64, CryptoHash)> {
+fn close_enough(locator: &[(u64, CryptoHash)], height: u64) -> Option<(u64, CryptoHash)> {
     if locator.len() == 0 {
         return None;
     }
@@ -696,7 +696,7 @@ impl StateSync {
         new_shard_sync: &mut HashMap<u64, ShardSyncDownload>,
         chain: &mut Chain,
         runtime_adapter: &Arc<dyn RuntimeAdapter>,
-        highest_height_peers: &Vec<FullPeerInfo>,
+        highest_height_peers: &[FullPeerInfo],
         tracking_shards: Vec<ShardId>,
         now: DateTime<Utc>,
         state_parts_task_scheduler: &dyn Fn(ApplyStatePartsRequest),
@@ -1039,7 +1039,7 @@ impl StateSync {
         chain: &Chain,
         runtime_adapter: &Arc<dyn RuntimeAdapter>,
         sync_hash: CryptoHash,
-        highest_height_peers: &Vec<FullPeerInfo>,
+        highest_height_peers: &[FullPeerInfo],
     ) -> Result<Vec<AccountOrPeerIdOrHash>, Error> {
         // Remove candidates from pending list if request expired due to timeout
         self.last_part_id_requested.retain(|_, request| !request.expired());
@@ -1089,7 +1089,7 @@ impl StateSync {
         runtime_adapter: &Arc<dyn RuntimeAdapter>,
         sync_hash: CryptoHash,
         shard_sync_download: ShardSyncDownload,
-        highest_height_peers: &Vec<FullPeerInfo>,
+        highest_height_peers: &[FullPeerInfo],
     ) -> Result<ShardSyncDownload, near_chain::Error> {
         let possible_targets = self.possible_targets(
             me,
@@ -1189,7 +1189,7 @@ impl StateSync {
         new_shard_sync: &mut HashMap<u64, ShardSyncDownload>,
         chain: &mut Chain,
         runtime_adapter: &Arc<dyn RuntimeAdapter>,
-        highest_height_peers: &Vec<FullPeerInfo>,
+        highest_height_peers: &[FullPeerInfo],
         tracking_shards: Vec<ShardId>,
         state_parts_task_scheduler: &dyn Fn(ApplyStatePartsRequest),
         state_split_scheduler: &dyn Fn(StateSplitRequest),

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -1785,7 +1785,7 @@ pub fn create_chunk(
 /// and the catchup process can't catch up on these blocks yet.
 pub fn run_catchup(
     client: &mut Client,
-    highest_height_peers: &Vec<FullPeerInfo>,
+    highest_height_peers: &[FullPeerInfo],
 ) -> Result<(), Error> {
     let f = |_| {};
     let block_messages = Arc::new(RwLock::new(vec![]));

--- a/chain/epoch-manager/src/tests/random_epochs.rs
+++ b/chain/epoch-manager/src/tests/random_epochs.rs
@@ -166,7 +166,7 @@ fn validate(
     verify_epochs(&epoch_infos);
 }
 
-fn verify_epochs(epoch_infos: &Vec<Arc<EpochInfo>>) {
+fn verify_epochs(epoch_infos: &[Arc<EpochInfo>]) {
     for i in 1..epoch_infos.len() {
         let epoch_info = &epoch_infos[i];
         let prev_epoch_info = &epoch_infos[i - 1];
@@ -224,7 +224,7 @@ fn verify_epochs(epoch_infos: &Vec<Arc<EpochInfo>>) {
     }
 }
 
-fn verify_proposals(epoch_manager: &mut EpochManager, block_infos: &Vec<Arc<BlockInfo>>) {
+fn verify_proposals(epoch_manager: &mut EpochManager, block_infos: &[Arc<BlockInfo>]) {
     let mut proposals = BTreeMap::default();
     for i in 1..block_infos.len() {
         let prev_block_info = &block_infos[i - 1];
@@ -256,8 +256,8 @@ fn verify_proposals(epoch_manager: &mut EpochManager, block_infos: &Vec<Arc<Bloc
 
 fn verify_slashes(
     epoch_manager: &mut EpochManager,
-    block_infos: &Vec<Arc<BlockInfo>>,
-    slashes_per_block: &Vec<Vec<SlashedValidator>>,
+    block_infos: &[Arc<BlockInfo>],
+    slashes_per_block: &[Vec<SlashedValidator>],
 ) {
     for i in 1..block_infos.len() {
         let prev_slashes_set = block_infos[i - 1].slashed();
@@ -314,7 +314,7 @@ fn verify_slashes(
 fn verify_block_stats(
     epoch_manager: &mut EpochManager,
     heights: Vec<u64>,
-    block_infos: &Vec<Arc<BlockInfo>>,
+    block_infos: &[Arc<BlockInfo>],
     block_hashes: &[CryptoHash],
 ) {
     for i in 1..block_infos.len() {

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -536,7 +536,7 @@ impl Block {
 
 pub enum ChunksCollection<'a> {
     V1(Vec<ShardChunkHeader>),
-    V2(&'a Vec<ShardChunkHeader>),
+    V2(&'a [ShardChunkHeader]),
 }
 
 pub struct VersionedChunksIter<'a> {

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -514,7 +514,7 @@ impl PartialEncodedChunk {
     }
 
     #[inline]
-    pub fn parts(&self) -> &Vec<PartialEncodedChunkPart> {
+    pub fn parts(&self) -> &[PartialEncodedChunkPart] {
         match self {
             Self::V1(chunk) => &chunk.parts,
             Self::V2(chunk) => &chunk.parts,
@@ -522,7 +522,7 @@ impl PartialEncodedChunk {
     }
 
     #[inline]
-    pub fn receipts(&self) -> &Vec<ReceiptProof> {
+    pub fn receipts(&self) -> &[ReceiptProof] {
         match self {
             Self::V1(chunk) => &chunk.receipts,
             Self::V2(chunk) => &chunk.receipts,
@@ -751,7 +751,7 @@ impl ShardChunk {
     }
 
     #[inline]
-    pub fn receipts(&self) -> &Vec<Receipt> {
+    pub fn receipts(&self) -> &[Receipt] {
         match self {
             Self::V1(chunk) => &chunk.receipts,
             Self::V2(chunk) => &chunk.receipts,
@@ -759,7 +759,7 @@ impl ShardChunk {
     }
 
     #[inline]
-    pub fn transactions(&self) -> &Vec<SignedTransaction> {
+    pub fn transactions(&self) -> &[SignedTransaction] {
         match self {
             Self::V1(chunk) => &chunk.transactions,
             Self::V2(chunk) => &chunk.transactions,

--- a/core/primitives/src/syncing.rs
+++ b/core/primitives/src/syncing.rs
@@ -118,7 +118,7 @@ impl ShardStateSyncResponseHeader {
     }
 
     #[inline]
-    pub fn incoming_receipts_proofs(&self) -> &Vec<ReceiptProofResponse> {
+    pub fn incoming_receipts_proofs(&self) -> &[ReceiptProofResponse] {
         match self {
             Self::V1(header) => &header.incoming_receipts_proofs,
             Self::V2(header) => &header.incoming_receipts_proofs,
@@ -126,7 +126,7 @@ impl ShardStateSyncResponseHeader {
     }
 
     #[inline]
-    pub fn root_proofs(&self) -> &Vec<Vec<RootProof>> {
+    pub fn root_proofs(&self) -> &[Vec<RootProof>] {
         match self {
             Self::V1(header) => &header.root_proofs,
             Self::V2(header) => &header.root_proofs,

--- a/core/store/benches/store_bench.rs
+++ b/core/store/benches/store_bench.rs
@@ -54,7 +54,7 @@ fn generate_keys(count: usize, key_size: usize) -> Vec<Vec<u8>> {
 
 /// Read from DB value for given `kyes` in random order for `col`.
 /// Works only for column configured without reference counting, that is `.is_rc() == false`.
-fn read_from_db(store: &Store, keys: &Vec<Vec<u8>>, col: DBCol) -> usize {
+fn read_from_db(store: &Store, keys: &[Vec<u8>], col: DBCol) -> usize {
     let mut read = 0;
     for _k in 0..keys.len() {
         let r = rand::random::<u32>() % (keys.len() as u32);

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -391,7 +391,7 @@ impl StoreUpdate {
     ///
     /// Must not be used for reference-counted columns; use
     /// ['Self::increment_refcount'] or [`Self::decrement_refcount`] instead.
-    pub fn set_ser<T: BorshSerialize>(
+    pub fn set_ser<T: BorshSerialize + ?Sized>(
         &mut self,
         column: DBCol,
         key: &[u8],
@@ -716,9 +716,9 @@ pub fn set_genesis_hash(store_update: &mut StoreUpdate, genesis_hash: &CryptoHas
         .expect("Borsh cannot fail");
 }
 
-pub fn set_genesis_state_roots(store_update: &mut StoreUpdate, genesis_roots: &Vec<StateRoot>) {
+pub fn set_genesis_state_roots(store_update: &mut StoreUpdate, genesis_roots: &[StateRoot]) {
     store_update
-        .set_ser::<Vec<StateRoot>>(DBCol::BlockMisc, GENESIS_STATE_ROOTS_KEY, genesis_roots)
+        .set_ser(DBCol::BlockMisc, GENESIS_STATE_ROOTS_KEY, genesis_roots)
         .expect("Borsh cannot fail");
 }
 

--- a/core/store/src/trie/insert_delete.rs
+++ b/core/store/src/trie/insert_delete.rs
@@ -57,7 +57,7 @@ impl NodesStorage {
         StorageValueHandle(self.values.len() - 1)
     }
 
-    pub(crate) fn value_ref(&self, handle: StorageValueHandle) -> &Vec<u8> {
+    pub(crate) fn value_ref(&self, handle: StorageValueHandle) -> &[u8] {
         self.values
             .get(handle.0)
             .expect(INVALID_STORAGE_HANDLE)
@@ -637,7 +637,7 @@ impl Trie {
     fn flatten_value(memory: &mut NodesStorage, value: ValueHandle) -> (u32, CryptoHash) {
         match value {
             ValueHandle::InMemory(value_handle) => {
-                let value = memory.value_ref(value_handle).clone();
+                let value = memory.value_ref(value_handle).to_vec();
                 let value_length = value.len() as u32;
                 let value_hash = hash(&value);
                 let (_value, rc) =

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -147,7 +147,10 @@ impl ShardTries {
                     if *col == DBCol::State {
                         let (shard_uid, hash) =
                             TrieCachingStorage::get_shard_uid_and_hash_from_key(key)?;
-                        shards.entry(shard_uid).or_insert(vec![]).push((hash, Some(value)));
+                        shards
+                            .entry(shard_uid)
+                            .or_insert(vec![])
+                            .push((hash, Some(value.as_slice())));
                     }
                 }
                 DBOp::DeleteAll { col } => {
@@ -175,7 +178,7 @@ impl ShardTries {
 
     fn apply_deletions_inner(
         &self,
-        deletions: &Vec<TrieRefcountChange>,
+        deletions: &[TrieRefcountChange],
         shard_uid: ShardUId,
         store_update: &mut StoreUpdate,
     ) {
@@ -191,7 +194,7 @@ impl ShardTries {
 
     fn apply_insertions_inner(
         &self,
-        insertions: &Vec<TrieRefcountChange>,
+        insertions: &[TrieRefcountChange],
         shard_uid: ShardUId,
         store_update: &mut StoreUpdate,
     ) {

--- a/core/store/src/trie/state_parts.rs
+++ b/core/store/src/trie/state_parts.rs
@@ -659,7 +659,7 @@ mod tests {
     fn check_combine_state_parts(
         state_root: &CryptoHash,
         num_parts: u64,
-        parts: &Vec<Vec<Arc<[u8]>>>,
+        parts: &[Vec<Arc<[u8]>>],
     ) -> TrieChanges {
         let trie_changes = Trie::combine_state_parts_naive(state_root, parts).unwrap();
 

--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -230,7 +230,7 @@ impl TrieCache {
         self.0.lock().expect(POISONED_LOCK_ERR).clear()
     }
 
-    pub fn update_cache(&self, ops: Vec<(CryptoHash, Option<&Vec<u8>>)>) {
+    pub fn update_cache(&self, ops: Vec<(CryptoHash, Option<&[u8]>)>) {
         let mut guard = self.0.lock().expect(POISONED_LOCK_ERR);
         for (hash, opt_value_rc) in ops {
             if let Some(value_rc) = opt_value_rc {

--- a/genesis-tools/genesis-csv-to-json/src/serde_with.rs
+++ b/genesis-tools/genesis-csv-to-json/src/serde_with.rs
@@ -32,7 +32,7 @@ pub mod pks_as_str {
     use near_crypto::PublicKey;
     use serde::{Deserialize, Deserializer, Serializer};
 
-    pub fn serialize<S>(peer_info: &Vec<PublicKey>, serializer: S) -> Result<S::Ok, S::Error>
+    pub fn serialize<S>(peer_info: &[PublicKey], serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -1612,7 +1612,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         Ok(result)
     }
 
-    fn validate_state_part(&self, state_root: &StateRoot, part_id: PartId, data: &Vec<u8>) -> bool {
+    fn validate_state_part(&self, state_root: &StateRoot, part_id: PartId, data: &[u8]) -> bool {
         match BorshDeserialize::try_from_slice(data) {
             Ok(trie_nodes) => {
                 match Trie::validate_trie_nodes_for_part(state_root, part_id, trie_nodes) {

--- a/runtime/near-vm-runner/src/runner.rs
+++ b/runtime/near-vm-runner/src/runner.rs
@@ -103,7 +103,7 @@ pub trait VM {
     /// Verify the `code` contract can be compiled with this [`Runtime`].
     ///
     /// This is intended primarily for testing purposes.
-    fn check_compile(&self, code: &Vec<u8>) -> bool;
+    fn check_compile(&self, code: &[u8]) -> bool;
 }
 
 impl VMKind {

--- a/runtime/near-vm-runner/src/wasmer2_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer2_runner.rs
@@ -540,7 +540,7 @@ impl crate::runner::VM for Wasmer2VM {
         into_vm_result(result).err()
     }
 
-    fn check_compile(&self, code: &Vec<u8>) -> bool {
+    fn check_compile(&self, code: &[u8]) -> bool {
         self.compile_uncached(code).is_ok()
     }
 }

--- a/runtime/near-vm-runner/src/wasmer_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer_runner.rs
@@ -340,7 +340,7 @@ impl crate::runner::VM for Wasmer0VM {
         into_vm_result(result).err()
     }
 
-    fn check_compile(&self, code: &Vec<u8>) -> bool {
+    fn check_compile(&self, code: &[u8]) -> bool {
         wasmer_runtime::compile_with_config(
             code,
             wasmer_runtime::CompilerConfig { features: WASMER_FEATURES, ..Default::default() },

--- a/runtime/near-vm-runner/src/wasmtime_runner.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner.rs
@@ -315,7 +315,7 @@ impl crate::runner::VM for WasmtimeVM {
         )))
     }
 
-    fn check_compile(&self, code: &Vec<u8>) -> bool {
+    fn check_compile(&self, code: &[u8]) -> bool {
         let mut config = default_config();
         let engine = get_engine(&mut config);
         Module::new(&engine, code).is_ok()

--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -85,7 +85,7 @@ impl ProgressReporter {
 
 fn old_outcomes(
     store: Store,
-    new_outcomes: &Vec<ExecutionOutcomeWithId>,
+    new_outcomes: &[ExecutionOutcomeWithId],
 ) -> Vec<ExecutionOutcomeWithId> {
     new_outcomes
         .iter()

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -185,7 +185,7 @@ impl DumpTxCmd {
             home_dir,
             near_config,
             store,
-            self.account_ids.as_ref(),
+            self.account_ids.as_deref(),
             self.output_path,
         )
         .expect("Failed to dump transaction...")

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -118,7 +118,7 @@ pub(crate) fn dump_tx(
     home_dir: &Path,
     near_config: NearConfig,
     store: Store,
-    select_account_ids: Option<&Vec<AccountId>>,
+    select_account_ids: Option<&[AccountId]>,
     output_path: Option<String>,
 ) -> Result<(), Error> {
     let chain_store = ChainStore::new(

--- a/tools/state-viewer/src/tx_dump.rs
+++ b/tools/state-viewer/src/tx_dump.rs
@@ -8,7 +8,7 @@ use near_primitives::transaction::SignedTransaction;
 pub fn dump_tx_from_block(
     chain_store: &ChainStore,
     block: &Block,
-    select_account_ids: Option<&Vec<AccountId>>,
+    select_account_ids: Option<&[AccountId]>,
 ) -> Vec<SignedTransaction> {
     let chunks = block.chunks();
     let mut res = vec![];
@@ -31,7 +31,7 @@ pub fn dump_tx_from_block(
 
 fn should_include_signed_transaction(
     signed_transaction: &SignedTransaction,
-    select_account_ids: Option<&Vec<AccountId>>,
+    select_account_ids: Option<&[AccountId]>,
 ) -> bool {
     match select_account_ids {
         None => true,


### PR DESCRIPTION
Taking slice as argument is more flexible than taking reference to
a vector since the caller does not need to have to own the data.
In addition, slices also work if caller owns a boxed slice which
would need to be converted into a vector if function required
reference to a vector.  Slices also allow to take sub-slices easily.

The only remaining place is Store::push_component in near-network crate.
This is needed because near-network’s schema’s StoreUpdate::set doesn’t
work with borrowed types.  More generic magic is needed to make it work.
