### PR TITLE
network: deprecate near_peer_message_received_total

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 * Added `near_peer_message_sent_by_type_bytes` and
   `near_peer_message_sent_by_type_total` Prometheus metrics measuring
   size and number of messages sent to peers.
+* `near_peer_message_received_total` Prometheus metric is now deprecated.
+  Instead of it aggregate `near_peer_message_received_by_type_total` metric
+  instead.  For example, to get total rate of received messages use
+  `sum(rate(near_peer_message_received_by_type_total{...}[5m]))`.
 
 ## 1.28.0 [2022-07-27]
 

--- a/chain/network/src/stats/metrics.rs
+++ b/chain/network/src/stats/metrics.rs
@@ -102,10 +102,11 @@ pub(crate) static PEER_MESSAGE_RECEIVED_BY_TYPE_BYTES: Lazy<IntCounterVec> = Laz
     )
     .unwrap()
 });
+// TODO(mina86): This has been deprecated in 1.30.  Remove at 1.32 or so.
 pub(crate) static PEER_MESSAGE_RECEIVED_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
     try_create_int_counter(
         "near_peer_message_received_total",
-        "Number of messages received from peers",
+        "Deprecated; aggregate near_peer_message_received_by_type_total instead",
     )
     .unwrap()
 });


### PR DESCRIPTION
Deprecate near_peer_message_received_total Prometheus metric in favour
of aggregating near_peer_message_received_by_type_total metric instead.