### PR TITLE
DRAFT: Preload contract on boot

### DIFF
--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -793,6 +793,15 @@ impl From<near_chain_primitives::Error> for GetProtocolConfigError {
     }
 }
 
+/// Load all state of an account's contract into trie cache.
+pub struct PreloadAccountData {
+    pub account_id: AccountId,
+}
+
+impl Message for PreloadAccountData {
+    type Result = Result<(), Error>;
+}
+
 #[cfg(feature = "sandbox")]
 #[derive(Debug)]
 pub enum SandboxMessage {

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1986,6 +1986,8 @@ impl Handler<PreloadAccountData> for ClientActor {
             ));
         }
 
+        info!(target: "store", "Preloading cache with trie nodes for account {account_id}...");
+
         let prefix = near_primitives::trie_key::trie_key_parsers::get_raw_prefix_for_contract_data(
             account_id,
             &[],

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -2009,9 +2009,10 @@ fn preload_account_state(
         &[],
     );
 
-    let min_num_subtries = 128;
-    let root_node = trie.retrieve_root_node()?;
-    let sub_trie_size = root_node.memory_usage / min_num_subtries;
+    // let min_num_subtries = 128;
+    // let root_node = trie.retrieve_root_node();
+    // let sub_trie_size = root_node.memory_usage / min_num_subtries;
+    let sub_trie_size = 10_000_000;
 
     let mut state_iter = trie.iter()?;
     state_iter.seek(prefix)?;

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -2028,6 +2028,7 @@ fn preload_account_state(
         let root = trie.get_root().clone();
         let handle = tokio::spawn(async move {
             trace!(target: "store", "Preload subtrie at {root}");
+            tokio::task::yield_now().await;
             let trie = Trie::new(Box::new(storage), root, None);
             let n = TrieIterator { trie: &trie, trail, key_nibbles }.count();
             trace!(target: "store", "Preload subtrie at {root} done");

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -2009,10 +2009,9 @@ fn preload_account_state(
         &[],
     );
 
-    // less than 10MB per thread should make it fairly quick.
-    // TODO: limit number of threads to something sensible.
-    // let sub_trie_size = 10_000_000;
-    let sub_trie_size = 100_000;
+    // less than 1MB per thread should make it fairly quick.
+    // even smaller numbers will run into problems because too many threads are created.
+    let sub_trie_size = 1_000_000;
     let max_threads = 128;
     let thread_slots = Arc::new(std::sync::atomic::AtomicU32::new(max_threads));
 

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -2011,8 +2011,8 @@ fn preload_account_state(
 
     // less than 10MB per thread should make it fairly quick.
     // TODO: limit number of threads to something sensible.
-    // let sub_trie_size = 10_000_000;
-    let sub_trie_size = 100_000;
+    let sub_trie_size = 10_000_000;
+    // let sub_trie_size = 100_000;
 
     let mut state_iter = trie.iter()?;
     state_iter.seek(prefix)?;

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -2009,9 +2009,8 @@ fn preload_account_state(
         &[],
     );
 
-    // let min_num_subtries = 128;
-    // let root_node = trie.retrieve_root_node();
-    // let sub_trie_size = root_node.memory_usage / min_num_subtries;
+    // less than 10MB per thread should make it fairly quick.
+    // TODO: limit number of threads to something sensible.
     let sub_trie_size = 10_000_000;
 
     let mut state_iter = trie.iter()?;

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -156,6 +156,8 @@ pub struct ClientConfig {
     pub max_gas_burnt_view: Option<Gas>,
     /// Re-export storage layer statistics as prometheus metrics.
     pub enable_statistics_export: bool,
+    /// Load data of accounts' contracts into cache after booting.
+    pub preload_contract_data: Vec<String>,
 }
 
 impl ClientConfig {
@@ -215,6 +217,7 @@ impl ClientConfig {
             trie_viewer_state_size_limit: None,
             max_gas_burnt_view: None,
             enable_statistics_export: true,
+            preload_contract_data: vec![],
         }
     }
 }

--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -71,6 +71,10 @@ pub struct StoreConfig {
     /// be copied between the databases.
     #[serde(skip_serializing_if = "MigrationSnapshot::is_default")]
     pub migration_snapshot: MigrationSnapshot,
+
+    /// Load data of accounts' contracts into cache after booting.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub preload_contract_data: Vec<String>,
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -142,6 +146,7 @@ impl Default for StoreConfig {
             trie_cache_capacities: vec![(ShardUId { version: 1, shard_id: 3 }, 45_000_000)],
 
             migration_snapshot: Default::default(),
+            preload_contract_data: vec![],
         }
     }
 }

--- a/core/store/src/trie/iterator.rs
+++ b/core/store/src/trie/iterator.rs
@@ -356,10 +356,11 @@ impl<'a> HeavySubTrieIterator<'a> {
         Ok(HeavySubTrieIterator { target_size_bytes, trie_iterator })
     }
 
+    // TODO: Instead return `SendTrieIterator` that contains only Send fields and has an into_iter() -> TrieIterator method.
     fn spawn_sub_trie_iter(&mut self) -> TrieIterator<'a> {
         let key_nibbles = self.trie_iterator.key_nibbles.clone();
-        self.trie_iterator.trail.pop();
-        return TrieIterator { trie: self.trie_iterator.trie, trail: vec![], key_nibbles };
+        let node = self.trie_iterator.trail.pop().unwrap();
+        return TrieIterator { trie: self.trie_iterator.trie, trail: vec![node], key_nibbles };
     }
 }
 

--- a/core/store/src/trie/iterator.rs
+++ b/core/store/src/trie/iterator.rs
@@ -5,7 +5,7 @@ use crate::trie::{TrieNode, TrieNodeWithSize, ValueHandle};
 use crate::{StorageError, Trie};
 
 #[derive(Debug)]
-struct Crumb {
+pub struct Crumb {
     node: TrieNodeWithSize,
     status: CrumbStatus,
 }
@@ -33,9 +33,17 @@ impl Crumb {
 }
 
 pub struct TrieIterator<'a> {
-    trie: &'a Trie,
-    trail: Vec<Crumb>,
-    pub(crate) key_nibbles: Vec<u8>,
+    pub trie: &'a Trie,
+    pub trail: Vec<Crumb>,
+    pub key_nibbles: Vec<u8>,
+}
+
+/// Divides the sub trie at the given iterator into the smallest set of subtries that each has a memory usage below the threshold.
+///
+/// Note that the nodes between the root and the subtrie nodes are not contained in the result.
+pub struct HeavySubTrieIterator<'a> {
+    trie_iterator: TrieIterator<'a>,
+    target_size_bytes: u64,
 }
 
 pub type TrieItem = (Vec<u8>, Vec<u8>);
@@ -295,6 +303,14 @@ impl<'a> TrieIterator<'a> {
         }
         Ok(nodes_list)
     }
+
+    /// Iterate over subtries with memory usage below a certain threshold.
+    pub fn heavy_sub_tries(
+        self,
+        max_memory_usage: u64,
+    ) -> Result<HeavySubTrieIterator<'a>, StorageError> {
+        HeavySubTrieIterator::new(self, max_memory_usage)
+    }
 }
 
 enum IterStep {
@@ -326,6 +342,59 @@ impl<'a> Iterator for TrieIterator<'a> {
                             .retrieve_raw_bytes(&hash)
                             .map(|value| (self.key(), value.to_vec())),
                     )
+                }
+            }
+        }
+    }
+}
+
+impl<'a> HeavySubTrieIterator<'a> {
+    pub(super) fn new(
+        trie_iterator: TrieIterator<'a>,
+        target_size_bytes: u64,
+    ) -> Result<Self, StorageError> {
+        Ok(HeavySubTrieIterator { target_size_bytes, trie_iterator })
+    }
+
+    fn spawn_sub_trie_iter(&mut self) -> TrieIterator<'a> {
+        let key_nibbles = self.trie_iterator.key_nibbles.clone();
+        self.trie_iterator.trail.pop();
+        return TrieIterator { trie: self.trie_iterator.trie, trail: vec![], key_nibbles };
+    }
+}
+
+impl<'a> Iterator for HeavySubTrieIterator<'a> {
+    type Item = Result<TrieIterator<'a>, StorageError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let iter_step = self.trie_iterator.iter_step()?;
+            match iter_step {
+                IterStep::PopTrail => {
+                    // Leaving a branch after its last child. At this point, all
+                    // sub tries have been included in a returned subtrie root.
+                    self.trie_iterator.trail.pop();
+                }
+                IterStep::Descend(hash) => match self.trie_iterator.descend_into_node(&hash) {
+                    Ok(()) => {
+                        if self.trie_iterator.trail.last().unwrap().node.memory_usage
+                            < self.target_size_bytes
+                        {
+                            return Some(Ok(self.spawn_sub_trie_iter()));
+                        }
+                    }
+                    Err(err) => return Some(Err(err)),
+                },
+                IterStep::Continue => {}
+                IterStep::Value(_hash) => {
+                    match &self.trie_iterator.trail.last().unwrap().node.node {
+                        TrieNode::Leaf(_, _) => {
+                            // Leaf alone is heavy enough to be its own subtrie.
+                            return Some(Ok(self.spawn_sub_trie_iter()));
+                        }
+                        // values in other places are ignored
+                        TrieNode::Empty | TrieNode::Branch(_, _) | TrieNode::Extension(_, _) => (),
+                    }
                 }
             }
         }

--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -367,6 +367,7 @@ const DEFAULT_SHARD_CACHE_DELETIONS_QUEUE_CAPACITY: usize = 1;
 /// Note that most of Trie inner nodes are smaller than this - e.g. branches use around 32 * 16 = 512 bytes.
 pub(crate) const TRIE_LIMIT_CACHED_VALUE_SIZE: usize = 1000;
 
+#[derive(Clone)]
 pub struct TrieCachingStorage {
     pub(crate) store: Store,
     pub(crate) shard_uid: ShardUId,
@@ -393,6 +394,7 @@ pub struct TrieCachingStorage {
     metrics: TrieCacheInnerMetrics,
 }
 
+#[derive(Clone)]
 struct TrieCacheInnerMetrics {
     chunk_cache_hits: GenericCounter<prometheus::core::AtomicU64>,
     chunk_cache_misses: GenericCounter<prometheus::core::AtomicU64>,

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -587,6 +587,7 @@ impl NearConfig {
                 trie_viewer_state_size_limit: config.trie_viewer_state_size_limit,
                 max_gas_burnt_view: config.max_gas_burnt_view,
                 enable_statistics_export: config.store.enable_statistics_export,
+                preload_contract_data: config.store.preload_contract_data,
             },
             network_config: NetworkConfig::new(
                 config.network,


### PR DESCRIPTION
This is a draft implementation for  #7570. Submitted as draft PR for collaborative debugging.

cc @Longarithm 

Right now, this implementation gives me 259 threads from what I can see in the logs. In `iotop` I see at least 100 IO threads actively reading from disk with various speeds between 0 and 1000KB/s. 100KB/s looks like a rough median value.

With that I would expect that the full 1.1GB in the test account is fetched in roughly 2 minutes. But it still hasn't finished a single thread in a full hour.

The number of DB requests I have in the log surpassed 2 millions after about 1.5h but still it is not done. But that means even though it has read at least several GBs from disk, it still has only read 2 millions trie nodes. The RocksDB overhead is much more than I expect. Since we expect something like 10 million accounts, it looks like my current implementation simply does not scale enough. Or hopefully there is just something buggy in the implementation. But I am running out of ideas.

## Implementation Overview
On boot, right after starting the client actors, we send a new message of type `PreloadAccountData` to the client actor. 

Then create a `TrieIterator` and seek the root of the state subtrie of the account. From there, create a `HeavySubTrieIterator` that iterates over the selected subtrie in DFS but stops as soon as a leftover subtrie is lighter than 10MB as declared by its `memory_usage` field. When it reaches such a position, it returns a `TrieIterator` that will go over every element of the subtrie and continue with the next sibling.

So the output of `HeavySubTrieIterator` is a series of `TrieIterator`, each of them sufficiently small that we should be able to traverse it in a matter of seconds. The final step is to spawn a new thread for each `TrieIterator` and traverse it.

Note that we simply read each value once and then disgard it. Each thread has its own `Trie` instance but they share the `Arc<Mutex<TrieCacheInner>>`. This will load everything into the same shard cache as a side-effect.

Also, I am using plain std threads. I also tried using tokio threads but it introduces new problems and solves none. There is nothing that could be made async, as RocksDB does not support it. But we can consider moving it tokio threads if we want, once it works as intended.

Threads spawning generally could be improved, among other things. But it is not worth fleshing out if the performance is not what we need.
