### PR TITLE
store: introduce StoreOpener::create; deal with version in StoreOpener

### DIFF
--- a/core/store/src/opener.rs
+++ b/core/store/src/opener.rs
@@ -104,7 +104,8 @@ impl<'a> StoreOpener<'a> {
         tracing::info!(target: "near", path=%self.path.display(),
                        "{} RocksDB database",
                        if exists { "Opening" } else { "Creating a new" });
-        let storage = std::sync::Arc::new(crate::RocksDB::open(&self.path, &self.config, self.mode)?);
+        let storage =
+            std::sync::Arc::new(crate::RocksDB::open(&self.path, &self.config, self.mode)?);
         if !exists && version::get_db_version(storage.as_ref())?.is_none() {
             // Initialise newly created database by setting it’s version.
             let store = crate::Store { storage };


### PR DESCRIPTION
This does three relate things:

1. When opening the database in read-only mode, StoreOpener now checks
   whether database version is the one node is built for.  If it
   isn’t, opening fails.  This is because we cannot perform migrations
   in read-only mode so there’s nothing we can do with the database.

2. When creating the database, initialise it by setting its version to
   the one node was built for.  This moves the code from nearcore.

3. Introduce StoreOpener::create which refuses to open already
   existing database.  Motivation here is mostly to remove database
   existence check from recompress_storage and thus get rid of the
   check_if_exists method to shrink StoreOpener API.
