### PR TITLE
store: replace StoreOpener::create with Mode::Create

### DIFF
--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -76,7 +76,7 @@ pub enum MigrationSnapshot {
 }
 
 /// Mode in which to open the storage.
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy)]
 pub enum Mode {
     /// Open an existing database in read-only mode.  Fail if it doesn’t exist.
     ReadOnly,
@@ -84,6 +84,23 @@ pub enum Mode {
     ReadWriteExisting,
     /// Open a database in read-write mode.  create if it doesn’t exist.
     ReadWrite,
+    /// Creates a new database in read-write mode.  Fails if it exists.
+    Create,
+}
+
+impl Mode {
+    pub const fn read_only(self) -> bool {
+        matches!(self, Mode::ReadOnly)
+    }
+    pub const fn read_write(self) -> bool {
+        !self.read_only()
+    }
+    pub const fn can_create(self) -> bool {
+        matches!(self, Mode::ReadWrite | Mode::Create)
+    }
+    pub const fn must_create(self) -> bool {
+        matches!(self, Mode::Create)
+    }
 }
 
 impl StoreConfig {

--- a/core/store/src/db/rocksdb/snapshot.rs
+++ b/core/store/src/db/rocksdb/snapshot.rs
@@ -66,7 +66,7 @@ impl Snapshot {
             return Err(SnapshotError::AlreadyExists(snapshot_path));
         }
 
-        let db = super::RocksDB::open(db_path, config, crate::Mode::ReadWrite)?;
+        let db = super::RocksDB::open(db_path, config, crate::Mode::ReadWriteExisting)?;
         let cp = Checkpoint::new(&db.db).map_err(super::into_other)?;
         cp.create_checkpoint(&snapshot_path)?;
 

--- a/core/store/src/opener.rs
+++ b/core/store/src/opener.rs
@@ -20,9 +20,6 @@ pub struct StoreOpener<'a> {
 
     /// Configuration as provided by the user.
     config: &'a StoreConfig,
-
-    /// Which mode to open storeg in.
-    mode: Mode,
 }
 
 impl<'a> StoreOpener<'a> {
@@ -30,13 +27,7 @@ impl<'a> StoreOpener<'a> {
     pub(crate) fn new(home_dir: &std::path::Path, config: &'a StoreConfig) -> Self {
         let path =
             home_dir.join(config.path.as_deref().unwrap_or(std::path::Path::new(STORE_PATH)));
-        Self { path, config, mode: Mode::ReadWrite }
-    }
-
-    /// Configure which mode the database should be opened in.
-    pub fn mode(mut self, mode: Mode) -> Self {
-        self.mode = mode;
-        self
+        Self { path, config }
     }
 
     /// Returns path to the underlying RocksDB database.
@@ -56,33 +47,30 @@ impl<'a> StoreOpener<'a> {
         crate::RocksDB::get_version(&self.path, &self.config)
     }
 
+    /// Opens the storage in read-write mode.
+    ///
+    /// Creates the database if missing.
+    pub fn open(&self) -> std::io::Result<crate::NodeStorage> {
+        self.open_in_mode(Mode::ReadWrite)
+    }
+
     /// Opens the RocksDB database.
     ///
     /// When opening in read-only mode, verifies that the database version is
     /// what the node expects and fails if it isn’t.  If database doesn’t exist,
-    /// creates a new one unless mode is [`Mode::ReadWriteExisting`].
-    pub fn open(&self) -> std::io::Result<crate::NodeStorage> {
-        self.open_impl(false)
-    }
-
-    /// Creates a new RocksDB database.
-    ///
-    /// Works like `open` except that it fails if the database already exists.
-    /// Note that this is a best-effort check and the creation is not atomic.
-    pub fn create(&self) -> std::io::Result<crate::NodeStorage> {
-        self.open_impl(true)
-    }
-
-    fn open_impl(&self, create: bool) -> std::io::Result<crate::NodeStorage> {
+    /// creates a new one unless mode is [`Mode::ReadWriteExisting`].  On the
+    /// other hand, if mode is [`Mode::Create`], fails if the database already
+    /// exists.
+    pub fn open_in_mode(&self, mode: Mode) -> std::io::Result<crate::NodeStorage> {
         let db_version = crate::RocksDB::get_version(&self.path, self.config)?;
         let exists = if let Some(db_version) = db_version {
-            if create {
+            if mode.must_create() {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::Other,
                     "Cannot create already existing database",
                 ));
             }
-            if self.mode == Mode::ReadOnly && db_version != crate::version::DB_VERSION {
+            if mode.read_only() && db_version != crate::version::DB_VERSION {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::Other,
                     format!(
@@ -93,10 +81,10 @@ impl<'a> StoreOpener<'a> {
                 ));
             }
             true
-        } else if self.mode == Mode::ReadOnly {
+        } else if !mode.can_create() {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::Other,
-                "Cannot open non-existent database for reading",
+                "Cannot open non-existent database",
             ));
         } else {
             false
@@ -104,8 +92,7 @@ impl<'a> StoreOpener<'a> {
         tracing::info!(target: "near", path=%self.path.display(),
                        "{} RocksDB database",
                        if exists { "Opening" } else { "Creating a new" });
-        let storage =
-            std::sync::Arc::new(crate::RocksDB::open(&self.path, &self.config, self.mode)?);
+        let storage = std::sync::Arc::new(crate::RocksDB::open(&self.path, &self.config, mode)?);
         if !exists && version::get_db_version(storage.as_ref())?.is_none() {
             // Initialise newly created database by setting it’s version.
             let store = crate::Store { storage };

--- a/nearcore/benches/store.rs
+++ b/nearcore/benches/store.rs
@@ -29,8 +29,7 @@ fn read_trie_items(bench: &mut Bencher, shard_id: usize, mode: Mode) {
     bench.iter(move || {
         tracing::info!(target: "neard", "{:?}", home_dir);
         let store = near_store::NodeStorage::opener(&home_dir, &near_config.config.store)
-            .mode(mode)
-            .open()
+            .open_in_mode(mode)
             .unwrap()
             .get_store(Temperature::Hot);
 

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -352,7 +352,7 @@ pub fn recompress_storage(home_dir: &Path, opts: RecompressOpts) -> anyhow::Resu
         skip_columns.push(DBCol::TrieChanges);
     }
 
-    let src_opener = NodeStorage::opener(home_dir, &config.store).mode(Mode::ReadOnly);
+    let src_opener = NodeStorage::opener(home_dir, &config.store);
     let src_path = src_opener.path();
 
     let mut dst_config = config.store.clone();
@@ -368,7 +368,7 @@ pub fn recompress_storage(home_dir: &Path, opts: RecompressOpts) -> anyhow::Resu
           "Recompressing database");
 
     let src_store = src_opener
-        .open()
+        .open_in_mode(Mode::ReadOnly)
         .with_context(|| format!("Opening database at {}", src_opener.path().display()))?
         .get_store(Temperature::Hot);
 
@@ -387,8 +387,8 @@ pub fn recompress_storage(home_dir: &Path, opts: RecompressOpts) -> anyhow::Resu
     };
 
     let dst_store = dst_opener
-        .create()
-        .with_context(|| format!("Creating database at {}", dst_opener.path().display()))?
+        .open_in_mode(Mode::Create)
+        .with_context(|| format!("Creating database at {}", dst_path.display()))?
         .get_store(Temperature::Hot);
 
     const BATCH_SIZE_BYTES: u64 = 150_000_000;

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -76,9 +76,8 @@ impl StateViewerSubCommand {
     pub fn run(self, home_dir: &Path, genesis_validation: GenesisValidationMode, mode: Mode) {
         let near_config = load_config(home_dir, genesis_validation)
             .unwrap_or_else(|e| panic!("Error loading config: {:#}", e));
-        let store_opener =
-            near_store::NodeStorage::opener(home_dir, &near_config.config.store).mode(mode);
-        let store = store_opener.open().unwrap();
+        let store_opener = near_store::NodeStorage::opener(home_dir, &near_config.config.store);
+        let store = store_opener.open_in_mode(mode).unwrap();
         let hot = store.get_store(near_store::Temperature::Hot);
         match self {
             StateViewerSubCommand::Peers => peers(store),
@@ -95,7 +94,7 @@ impl StateViewerSubCommand {
             StateViewerSubCommand::DumpCode(cmd) => cmd.run(home_dir, near_config, hot),
             StateViewerSubCommand::DumpAccountStorage(cmd) => cmd.run(home_dir, near_config, hot),
             StateViewerSubCommand::EpochInfo(cmd) => cmd.run(home_dir, near_config, hot),
-            StateViewerSubCommand::RocksDBStats(cmd) => cmd.run(&store_opener.path()),
+            StateViewerSubCommand::RocksDBStats(cmd) => cmd.run(store_opener.path()),
             StateViewerSubCommand::Receipts(cmd) => cmd.run(near_config, hot),
             StateViewerSubCommand::Chunks(cmd) => cmd.run(near_config, hot),
             StateViewerSubCommand::PartialChunks(cmd) => cmd.run(near_config, hot),


### PR DESCRIPTION
Introduce new mode for opening the storage, Mode::Create, and use it
instead of StoreOpener::create method.  This is removes some
nonsensical combinations where one might set mode to ReadOnly or
ReadWriteExisting and then call create method.

Furthermore, get rid of StoreOpener::mode method and instead add
StoreOpener::open_in_mode which takes the mode at the moment when
database is opened.  I’d say it ends up being more readable as the
mode is always specified at the exact same location where function to
open the storage is called.
