### PR TITLE
store: propagate error when deleting the snapshot

### DIFF
--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -181,7 +181,17 @@ fn apply_store_migrations_if_exists(
 
     // DB migration was successful, remove the snapshot to avoid it taking up
     // precious disk space.
-    snapshot.remove();
+    if let Err(err) = snapshot.remove() {
+        anyhow::bail!(
+            "The DB migration has succeeded but deleting of the snapshot at {} \
+             has failed: {}\n
+             Try renaming the snapshot directory to temporary name (e.g. by \
+             adding tilde to its name) and starting the node.  If that works, \
+             the snapshot can be deleted.",
+            err.path.display(),
+            err.error
+        )
+    }
 
     Ok(())
 }


### PR DESCRIPTION
If Snapshot::remove failed to delete the snapshot it would log the
error but wouldn’t propagate it letting the node continue to work. The
reasoning was that the database has migrated so there’s no harm just
going on.

However, it’s possible that operator won’t notice errors in the log
and leave the snapshot around.  This will waste space but also cause
next migration to fail.  What’s worse, that failure will recommend
rolling back to the existing snapshot.  This may result in database
being rolled back to state from weeks or months ago.

Change this behaviour by making Snapshot::remove propagate the error
and opening of the database failing if the removal fails.
