### PR TITLE
Revert "Process forwarded parts upon receiving a chunk header from block"

### DIFF
--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -134,7 +134,6 @@ pub struct KeyValueRuntime {
     /// chunk producers
     validators: HashMap<AccountId, ValidatorStake>,
     num_shards: NumShards,
-    tracks_all_shards: bool,
     epoch_length: u64,
     no_gc: bool,
 
@@ -272,7 +271,6 @@ impl KeyValueRuntime {
             validators,
             validators_by_valset,
             num_shards: vs.num_shards,
-            tracks_all_shards: false,
             epoch_length,
             state: RwLock::new(state),
             state_size: RwLock::new(state_size),
@@ -284,10 +282,6 @@ impl KeyValueRuntime {
             epoch_start: RwLock::new(map_with_default_hash2),
             no_gc,
         }
-    }
-
-    pub fn set_tracks_all_shards(&mut self, tracks_all_shards: bool) {
-        self.tracks_all_shards = tracks_all_shards;
     }
 
     fn get_block_header(&self, hash: &CryptoHash) -> Result<Option<BlockHeader>, Error> {
@@ -653,9 +647,6 @@ impl RuntimeAdapter for KeyValueRuntime {
         shard_id: ShardId,
         _is_me: bool,
     ) -> bool {
-        if self.tracks_all_shards {
-            return true;
-        }
         // This `unwrap` here tests that in all code paths we check that the epoch exists before
         //    we check if we care about a shard. Please do not remove the unwrap, fix the logic of
         //    the calling function.
@@ -678,9 +669,6 @@ impl RuntimeAdapter for KeyValueRuntime {
         shard_id: ShardId,
         _is_me: bool,
     ) -> bool {
-        if self.tracks_all_shards {
-            return true;
-        }
         // This `unwrap` here tests that in all code paths we check that the epoch exists before
         //    we check if we care about a shard. Please do not remove the unwrap, fix the logic of
         //    the calling function.

--- a/chain/chunks/src/chunk_cache.rs
+++ b/chain/chunks/src/chunk_cache.rs
@@ -168,9 +168,14 @@ impl EncodedChunksCache {
         }
     }
 
+    /// Insert if entry does not exist already
+    pub fn try_insert(&mut self, header: &ShardChunkHeader) {
+        self.get_or_insert_from_header(header);
+    }
+
     // Create an empty entry from the header and insert it if there is no entry for the chunk already
     // Return a mutable reference to the entry
-    pub fn get_or_insert_from_header(
+    fn get_or_insert_from_header(
         &mut self,
         chunk_header: &ShardChunkHeader,
     ) -> &mut EncodedChunksCacheEntry {
@@ -335,7 +340,7 @@ mod tests {
         let mut cache = EncodedChunksCache::new();
         let header0 = create_chunk_header(1, 0);
         let header1 = create_chunk_header(1, 1);
-        cache.get_or_insert_from_header(&header0);
+        cache.try_insert(&header0);
         cache.merge_in_partial_encoded_chunk(&PartialEncodedChunkV2 {
             header: header1.clone(),
             parts: vec![],

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -792,13 +792,7 @@ impl ShardsManager {
 
         debug!(target: "chunks", height, shard_id, ?chunk_hash, "Requesting.");
 
-        if let Some(entry) = self.encoded_chunks.get(&chunk_header.chunk_hash()) {
-            if entry.complete {
-                return;
-            }
-        } else {
-            debug_assert!(false, "Requested chunk is missing cache entry");
-        }
+        self.encoded_chunks.try_insert(&chunk_header);
 
         let prev_block_hash = chunk_header.prev_block_hash().clone();
         self.requested_partial_encoded_chunks.insert(
@@ -1563,36 +1557,6 @@ impl ShardsManager {
         Ok(())
     }
 
-    /// Inserts the header if it is not already known, and process the forwarded chunk parts cached
-    /// for this chunk, if any. Returns true if the header was newly inserted or forwarded parts
-    /// were newly processed.
-    pub fn insert_header_if_not_exists_and_process_cached_chunk_forwards(
-        &mut self,
-        header: &ShardChunkHeader,
-    ) -> bool {
-        let header_known_before = self.encoded_chunks.get(&header.chunk_hash()).is_some();
-        if self.encoded_chunks.get_or_insert_from_header(header).complete {
-            return false;
-        }
-        if let Some(parts) = self.chunk_forwards_cache.pop(&header.chunk_hash()) {
-            // Note that we don't need any further validation for the forwarded part.
-            // The forwarded part was earlier validated via validate_partial_encoded_chunk_forward,
-            // which checks the part against the merkle root in the forward message, and the merkle
-            // root is checked against the chunk hash in the forward message, and that chunk hash
-            // is used to identify the chunk. Furthermore, it's OK to directly use the header if
-            // it is the first time we learn of the header here, because later when we call
-            // try_process_chunk_parts_and_receipts, we will perform a header validation if we
-            // didn't already.
-            self.encoded_chunks.merge_in_partial_encoded_chunk(&PartialEncodedChunkV2 {
-                header: header.clone(),
-                parts: parts.into_values().collect(),
-                receipts: vec![],
-            });
-            return true;
-        }
-        !header_known_before
-    }
-
     /// Processes a partial encoded chunk message, which means
     /// 1) Checks that the partial encoded chunk message is valid, including checking
     ///    header, parts and receipts
@@ -1739,21 +1703,28 @@ impl ShardsManager {
             )?;
         };
 
-        // 4. Process the forwarded parts in chunk_forwards_cache.
-        self.insert_header_if_not_exists_and_process_cached_chunk_forwards(header);
-
-        // 5. Check if the chunk is complete; requesting more if not.
-        let result = self.try_process_chunk_parts_and_receipts(header, chain_store, rs)?;
-        match result {
-            ProcessPartialEncodedChunkResult::NeedMorePartsOrReceipts => {
-                // This may be the first time we see this chunk, so mark it in the request pool.
-                // If it's not already requested for, next time we resend requests we would
-                // request the chunk.
-                self.request_chunk_single_mark_only(header);
-            }
-            _ => {}
+        // 4. Process the forwarded parts in chunk_forwards_cache
+        if let Some(forwarded_parts) = self.chunk_forwards_cache.pop(&chunk_hash) {
+            // We have the header now, and there were some parts we were forwarded earlier.
+            // Let's process those parts now.
+            let forwarded_chunk = PartialEncodedChunkV2 {
+                header: header.clone(),
+                parts: forwarded_parts.into_iter().map(|(_, part)| part).collect(),
+                receipts: Vec::new(),
+            };
+            // Call process_partial_encoded_chunk recursively, "simulating" as that forwarded
+            // part is just received from the network
+            return self.process_partial_encoded_chunk(
+                // We can assert the signature on the header is valid because
+                // it would have been checked in an earlier call to this function.
+                MaybeValidated::from_validated(&forwarded_chunk),
+                None,
+                chain_store,
+                rs,
+            );
         }
-        Ok(result)
+
+        self.try_process_chunk_parts_and_receipts(&partial_encoded_chunk.header, chain_store, rs)
     }
 
     /// Checks if the chunk has all parts and receipts, if so and if the node cares about the shard,
@@ -1885,6 +1856,9 @@ impl ShardsManager {
             self.complete_chunk(&chunk_hash);
             return Ok(ProcessPartialEncodedChunkResult::HaveAllPartsAndReceipts);
         }
+
+        // add the chunk to the request pool in case it is not there already
+        self.request_chunk_single_mark_only(header);
         Ok(ProcessPartialEncodedChunkResult::NeedMorePartsOrReceipts)
     }
 
@@ -2640,14 +2614,12 @@ mod test {
             )
             .unwrap();
         match result {
-            ProcessPartialEncodedChunkResult::NeedMorePartsOrReceipts => {}
+            ProcessPartialEncodedChunkResult::NeedMorePartsOrReceipts => {
+                shards_manager.request_chunk_single_mark_only(&fixture.mock_chunk_header)
+            }
+
             _ => panic!("Expected to need more parts!"),
         }
-        shards_manager.request_chunk_single(
-            &fixture.mock_chunk_header,
-            *fixture.mock_chunk_header.prev_block_hash(),
-            Some(&fixture.mock_chain_head),
-        );
         let count_forwards_and_requests = |fixture: &ChunkTestFixture| -> (usize, usize) {
             let mut forwards_count = 0;
             let mut requests_count = 0;
@@ -2749,18 +2721,11 @@ mod test {
         );
     }
 
-    #[derive(PartialEq, Eq, Debug)]
-    struct RequestChunksResult {
-        marked_as_requested: bool,
-        sent_request_message_immediately: bool,
-        sent_request_message_after_timeout: bool,
-    }
-
-    /// Make ShardsManager request a chunk when run as the given account ID.
-    fn run_request_chunks_with_account(
-        fixture: &mut ChunkTestFixture,
+    fn check_request_chunks(
+        fixture: &ChunkTestFixture,
         account_id: Option<AccountId>,
-    ) -> RequestChunksResult {
+        expect_to_wait: bool,
+    ) {
         let header_head = Tip {
             height: 0,
             last_block_hash: CryptoHash::default(),
@@ -2774,33 +2739,28 @@ mod test {
             fixture.mock_network.clone(),
             TEST_SEED,
         );
-        shards_manager.insert_header_if_not_exists_and_process_cached_chunk_forwards(
-            &fixture.mock_chunk_header,
-        );
         shards_manager.request_chunks(
             vec![fixture.mock_chunk_header.clone()],
             fixture.mock_chunk_header.prev_block_hash().clone(),
             &header_head,
         );
-        let marked_as_requested = shards_manager
+        assert!(shards_manager
             .requested_partial_encoded_chunks
-            .contains_key(&fixture.mock_chunk_header.chunk_hash());
+            .contains_key(&fixture.mock_chunk_header.chunk_hash()));
+        if expect_to_wait {
+            let msg = fixture.mock_network.pop();
+            if msg.is_some() {
+                panic!("{:?}", msg);
+            }
 
-        let mut sent_request_message_immediately = false;
-        while let Some(_) = fixture.mock_network.pop() {
-            sent_request_message_immediately = true;
+            std::thread::sleep(Duration::from_millis(2 * CHUNK_REQUEST_RETRY_MS));
         }
-        std::thread::sleep(Duration::from_millis(2 * CHUNK_REQUEST_RETRY_MS));
         shards_manager.resend_chunk_requests(&header_head);
-        let mut sent_request_message_after_timeout = false;
+        let mut requested = false;
         while let Some(_) = fixture.mock_network.pop() {
-            sent_request_message_after_timeout = true;
+            requested = true;
         }
-        RequestChunksResult {
-            marked_as_requested,
-            sent_request_message_immediately,
-            sent_request_message_after_timeout,
-        }
+        assert!(requested);
     }
 
     #[test]
@@ -2809,38 +2769,15 @@ mod test {
     // when a validator requests chunks, the request is recorded but not sent, because it
     // will wait for chunks being forwarded
     fn test_chunk_forward_non_validator() {
-        // A non-validator that tracks all shards should request immediately.
-        let mut fixture = ChunkTestFixture::new_with_all_shards_tracking();
-        assert_eq!(
-            run_request_chunks_with_account(&mut fixture, None),
-            RequestChunksResult {
-                marked_as_requested: true,
-                sent_request_message_immediately: true,
-                sent_request_message_after_timeout: true,
-            }
-        );
+        // When a non validator node requests chunks, the request should be send immediately
+        let fixture = ChunkTestFixture::default();
+        check_request_chunks(&fixture, None, false);
 
         // still a non-validator because the account id is not a validator account id
-        assert_eq!(
-            run_request_chunks_with_account(&mut fixture, None),
-            RequestChunksResult {
-                marked_as_requested: true,
-                sent_request_message_immediately: true,
-                sent_request_message_after_timeout: true,
-            }
-        );
+        check_request_chunks(&fixture, Some("none".parse().unwrap()), false);
 
-        // when a tracking chunk producer request chunks, the request should not be send
-        // immediately.
-        let account_id = Some(fixture.mock_shard_tracker.clone());
-        assert_eq!(
-            run_request_chunks_with_account(&mut fixture, account_id),
-            RequestChunksResult {
-                marked_as_requested: true,
-                sent_request_message_immediately: false,
-                sent_request_message_after_timeout: true,
-            }
-        );
+        // when a validator request chunks, the request should not be send immediately
+        check_request_chunks(&fixture, Some(fixture.mock_shard_tracker.clone()), true);
     }
 
     // Test that chunk parts are forwarded to chunk only producers iff they are the next chunk producer
@@ -2916,13 +2853,10 @@ mod test {
         // when a validator request chunks, the request should be send immediately
         for account_id in chunk_only_producers {
             println!("account {:?}, {:?}", account_id, next_chunk_producer);
-            assert_eq!(
-                run_request_chunks_with_account(&mut fixture, Some(account_id.clone())),
-                RequestChunksResult {
-                    marked_as_requested: true,
-                    sent_request_message_immediately: account_id != next_chunk_producer,
-                    sent_request_message_after_timeout: true,
-                }
+            check_request_chunks(
+                &fixture,
+                Some(account_id.clone()),
+                account_id == next_chunk_producer,
             )
         }
     }
@@ -2981,68 +2915,6 @@ mod test {
             CryptoHash::default(),
             &fixture.mock_chain_head,
         );
-        std::thread::sleep(Duration::from_millis(2 * CHUNK_REQUEST_RETRY_MS));
-        shards_manager.resend_chunk_requests(&fixture.mock_chain_head);
-        assert!(fixture
-            .mock_network
-            .requests
-            .read()
-            .unwrap()
-            .iter()
-            .find(|r| {
-                match r.as_network_requests_ref() {
-                    NetworkRequests::PartialEncodedChunkRequest { .. } => true,
-                    _ => false,
-                }
-            })
-            .is_none());
-    }
-
-    #[test]
-    // Test that when a validator receives a chunk forward before the chunk header, and that the
-    // chunk header first arrives as part of a block, it should store the the forward and use it
-    // when it receives the header.
-    fn test_receive_forward_before_chunk_header_from_block() {
-        let mut fixture = ChunkTestFixture::default();
-        let mut shards_manager = ShardsManager::new(
-            Some(fixture.mock_shard_tracker.clone()),
-            fixture.mock_runtime.clone(),
-            fixture.mock_network.clone(),
-            TEST_SEED,
-        );
-        let forward = PartialEncodedChunkForwardMsg::from_header_and_parts(
-            &fixture.mock_chunk_header,
-            fixture.mock_chunk_parts.clone(),
-        );
-        // The validator receives the chunk forward
-        shards_manager.insert_forwarded_chunk(forward);
-        // The validator then receives the block, which is missing chunks; it notifies the
-        // ShardsManager of the chunk header, and ShardsManager is able to complete the chunk
-        // because of the forwarded parts.shards_manager
-        shards_manager.insert_header_if_not_exists_and_process_cached_chunk_forwards(
-            &fixture.mock_chunk_header,
-        );
-        let process_result = shards_manager
-            .try_process_chunk_parts_and_receipts(
-                &fixture.mock_chunk_header,
-                &mut fixture.chain_store,
-                &mut fixture.rs,
-            )
-            .unwrap();
-        match process_result {
-            ProcessPartialEncodedChunkResult::HaveAllPartsAndReceipts => {}
-            _ => {
-                panic!("Unexpected process_result: {:?}", process_result);
-            }
-        }
-        // Requesting it again should not send any actual requests as the chunk is already
-        // complete. Sleeping and resending later should also not send any requests.
-        shards_manager.request_chunk_single(
-            &fixture.mock_chunk_header,
-            *fixture.mock_chunk_header.prev_block_hash(),
-            Some(&fixture.mock_chain_head),
-        );
-
         std::thread::sleep(Duration::from_millis(2 * CHUNK_REQUEST_RETRY_MS));
         shards_manager.resend_chunk_requests(&fixture.mock_chain_head);
         assert!(fixture

--- a/chain/chunks/src/test_utils.rs
+++ b/chain/chunks/src/test_utils.rs
@@ -154,12 +154,6 @@ impl ChunkTestFixture {
         Self::new_with_runtime(orphan_chunk, Arc::new(default_runtime()))
     }
 
-    pub fn new_with_all_shards_tracking() -> Self {
-        let mut runtime = default_runtime();
-        runtime.set_tracks_all_shards(true);
-        Self::new_with_runtime(false, Arc::new(runtime))
-    }
-
     // Create a ChunkTestFixture to test chunk only producers
     pub fn new_with_chunk_only_producers() -> Self {
         let store = near_store::test_utils::create_test_store();

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -830,14 +830,11 @@ impl Client {
                 block,
                 provenance,
                 &mut block_processing_artifacts,
-                apply_chunks_done_callback.clone(),
+                apply_chunks_done_callback,
             )
         };
 
-        self.process_block_processing_artifact(
-            block_processing_artifacts,
-            apply_chunks_done_callback,
-        );
+        self.process_block_processing_artifact(block_processing_artifacts);
 
         // Send out challenge if the block was found to be invalid.
         if let Some(validator_signer) = self.validator_signer.as_ref() {
@@ -884,10 +881,7 @@ impl Client {
             &mut block_processing_artifacts,
             apply_chunks_done_callback.clone(),
         );
-        self.process_block_processing_artifact(
-            block_processing_artifacts,
-            apply_chunks_done_callback.clone(),
-        );
+        self.process_block_processing_artifact(block_processing_artifacts);
         let accepted_blocks_hashes =
             accepted_blocks.iter().map(|accepted_block| accepted_block.hash.clone()).collect();
         for accepted_block in accepted_blocks {
@@ -911,30 +905,12 @@ impl Client {
     pub(crate) fn process_block_processing_artifact(
         &mut self,
         block_processing_artifacts: BlockProcessingArtifact,
-        apply_chunks_done_callback: DoneApplyChunkCallback,
     ) {
         let BlockProcessingArtifact { orphans_missing_chunks, blocks_missing_chunks, challenges } =
             block_processing_artifacts;
         // Send out challenges that accumulated via on_challenge.
         self.send_challenges(challenges);
-        // For any missing chunk, call the ShardsManager with it so that it may apply forwarded parts.
-        // This may end up completing the chunk.
-        let missing_chunks = blocks_missing_chunks
-            .iter()
-            .flat_map(|block| block.missing_chunks.iter())
-            .chain(orphans_missing_chunks.iter().flat_map(|block| block.missing_chunks.iter()));
-        for chunk in missing_chunks {
-            match self.process_chunk_header_from_block_for_shards_manager(
-                chunk,
-                apply_chunks_done_callback.clone(),
-            ) {
-                Ok(_) => {}
-                Err(err) => {
-                    warn!(target: "client", "Failed to process missing chunk from block: {:?}", err)
-                }
-            }
-        }
-        // Request any (still) missing chunks.
+        // Request any missing chunks
         self.request_missing_chunks(blocks_missing_chunks, orphans_missing_chunks);
     }
 
@@ -1028,7 +1004,7 @@ impl Client {
             );
             match res {
                 Ok(res) => self.process_process_partial_encoded_chunk_result(
-                    &chunk_header,
+                    chunk_header,
                     res,
                     apply_chunks_done_callback.clone(),
                 ),
@@ -1055,44 +1031,22 @@ impl Client {
         debug!(target:"client", "process partial encoded chunk {:?}, result: {:?}", chunk_hash, process_result);
 
         self.process_process_partial_encoded_chunk_result(
-            &pec_v2.into_inner().header,
+            pec_v2.into_inner().header,
             process_result,
             apply_chunks_done_callback,
         );
         Ok(())
     }
 
-    /// Let the ShardsManager know about the chunk header, when encountering that chunk header
-    /// from the block and the chunk is possibly not yet known to the ShardsManager.
-    pub fn process_chunk_header_from_block_for_shards_manager(
-        &mut self,
-        header: &ShardChunkHeader,
-        apply_chunks_done_callback: DoneApplyChunkCallback,
-    ) -> Result<(), Error> {
-        if self.shards_mgr.insert_header_if_not_exists_and_process_cached_chunk_forwards(header) {
-            let process_result = self.shards_mgr.try_process_chunk_parts_and_receipts(
-                header,
-                self.chain.mut_store(),
-                &mut self.rs,
-            )?;
-            self.process_process_partial_encoded_chunk_result(
-                header,
-                process_result,
-                apply_chunks_done_callback,
-            );
-        }
-        Ok(())
-    }
-
     fn process_process_partial_encoded_chunk_result(
         &mut self,
-        header: &ShardChunkHeader,
+        header: ShardChunkHeader,
         process_result: ProcessPartialEncodedChunkResult,
         apply_chunks_done_callback: DoneApplyChunkCallback,
     ) {
         match process_result {
             ProcessPartialEncodedChunkResult::HaveAllPartsAndReceipts => {
-                self.chain.blocks_delay_tracker.mark_chunk_completed(header, Clock::utc());
+                self.chain.blocks_delay_tracker.mark_chunk_completed(&header, Clock::utc());
                 // We're marking chunk as accepted.
                 self.chain.blocks_with_missing_chunks.accept_chunk(&header.chunk_hash());
                 // If this was the last chunk that was missing for a block, it will be processed now.
@@ -1466,12 +1420,9 @@ impl Client {
         self.chain.check_blocks_with_missing_chunks(
             &me.map(|x| x.clone()),
             &mut blocks_processing_artifacts,
-            apply_chunks_done_callback.clone(),
-        );
-        self.process_block_processing_artifact(
-            blocks_processing_artifacts,
             apply_chunks_done_callback,
         );
+        self.process_block_processing_artifact(blocks_processing_artifacts);
     }
 
     pub fn is_validator(&self, epoch_id: &EpochId, block_hash: &CryptoHash) -> bool {
@@ -1967,10 +1918,7 @@ impl Client {
                             &blocks_catch_up_state.done_blocks,
                         )?;
 
-                        self.process_block_processing_artifact(
-                            block_processing_artifacts,
-                            apply_chunks_done_callback.clone(),
-                        );
+                        self.process_block_processing_artifact(block_processing_artifacts);
                     }
                 }
             }

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1732,10 +1732,7 @@ impl ClientActor {
                             self.get_apply_chunks_done_callback(),
                         ));
 
-                        self.client.process_block_processing_artifact(
-                            block_processing_artifacts,
-                            self.get_apply_chunks_done_callback(),
-                        );
+                        self.client.process_block_processing_artifact(block_processing_artifacts);
 
                         self.client.sync_status = SyncStatus::BodySync {
                             start_height: 0,

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -1448,7 +1448,7 @@ impl TestEnv {
             client.chain.mut_store(),
             &mut client.rs,
         );
-        let response = self.network_adapters[id].pop_most_recent().unwrap();
+        let response = self.network_adapters[id].pop().unwrap();
         if let PeerManagerMessageRequest::NetworkRequests(
             NetworkRequests::PartialEncodedChunkResponse { route_back: _, response },
         ) = response

--- a/chain/network/src/test_utils.rs
+++ b/chain/network/src/test_utils.rs
@@ -301,9 +301,6 @@ impl MockPeerManagerAdapter {
     pub fn pop(&self) -> Option<PeerManagerMessageRequest> {
         self.requests.write().unwrap().pop_front()
     }
-    pub fn pop_most_recent(&self) -> Option<PeerManagerMessageRequest> {
-        self.requests.write().unwrap().pop_back()
-    }
 }
 
 pub mod test_features {

--- a/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
+++ b/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
@@ -7,15 +7,12 @@ use near_chain::{ChainGenesis, ChainStore, ChainStoreAccess, Error, Provenance, 
 use near_chain_configs::Genesis;
 use near_client::test_utils::{create_chunk_with_transactions, TestEnv};
 use near_crypto::{InMemorySigner, KeyType, Signer};
-use near_network::types::{
-    MsgRecipient, NetworkClientResponses, NetworkRequests, PeerManagerMessageRequest,
-};
+use near_network::types::{MsgRecipient, NetworkClientResponses};
 use near_o11y::testonly::init_test_logger;
 use near_primitives::account::AccessKey;
 use near_primitives::errors::InvalidTxError;
 use near_primitives::runtime::config_store::RuntimeConfigStore;
 use near_primitives::shard_layout::ShardLayout;
-use near_primitives::sharding::{ChunkHash, PartialEncodedChunk};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{AccountId, BlockHeight};
 use near_primitives::version::{ProtocolFeature, ProtocolVersion};
@@ -25,10 +22,8 @@ use nearcore::config::GenesisExt;
 use nearcore::{TrackedConfig, NEAR_BASE};
 use rand::seq::SliceRandom;
 use rand::{thread_rng, Rng};
-use std::collections::HashSet;
 use std::path::Path;
 use std::sync::Arc;
-use tracing::debug;
 
 /// Try to process tx in the next blocks, check that tx and all generated receipts succeed.
 /// Return height of the next block.
@@ -534,259 +529,6 @@ fn test_processing_chunks_sanity() {
     // Check each chunk is only requested once.
     // There are 21 blocks in total, but the first block has no chunks,
     assert_eq!(num_requests, 4 * 20);
-}
-
-struct ChunkForwardingOptimizationTestData {
-    num_validators: usize,
-    env: TestEnv,
-
-    num_part_ords_requested: usize,
-    num_part_ords_sent_as_partial_encoded_chunk: usize,
-    num_part_ords_forwarded: usize,
-    num_forwards_with_missing_chunk_header: usize,
-    chunk_parts_that_must_be_known: HashSet<(ChunkHash, u64, usize)>,
-}
-
-impl ChunkForwardingOptimizationTestData {
-    fn new() -> ChunkForwardingOptimizationTestData {
-        let num_clients = 4;
-        let num_validators = 4 as usize;
-        let num_block_producers = 1;
-        let epoch_length = 10;
-
-        let accounts: Vec<AccountId> =
-            (0..num_clients).map(|i| format!("test{}", i).parse().unwrap()).collect();
-        let mut genesis = Genesis::test(accounts, num_validators as u64);
-        {
-            let config = &mut genesis.config;
-            config.epoch_length = epoch_length;
-            config.shard_layout = ShardLayout::v1_test();
-            config.num_block_producer_seats_per_shard = vec![
-                num_block_producers as u64,
-                num_block_producers as u64,
-                num_block_producers as u64,
-                num_block_producers as u64,
-            ];
-            config.num_block_producer_seats = num_block_producers as u64;
-        }
-        let chain_genesis = ChainGenesis::new(&genesis);
-        let runtimes: Vec<Arc<dyn RuntimeAdapter>> = (0..num_clients)
-            .map(|_| {
-                Arc::new(nearcore::NightshadeRuntime::test_with_runtime_config_store(
-                    Path::new("."),
-                    create_test_store(),
-                    &genesis,
-                    TrackedConfig::AllShards,
-                    RuntimeConfigStore::test(),
-                )) as Arc<dyn RuntimeAdapter>
-            })
-            .collect();
-        let env = TestEnv::builder(chain_genesis)
-            .clients_count(num_clients)
-            .validator_seats(num_validators as usize)
-            .runtime_adapters(runtimes)
-            .build();
-
-        ChunkForwardingOptimizationTestData {
-            num_validators,
-            env,
-            num_part_ords_requested: 0,
-            num_part_ords_sent_as_partial_encoded_chunk: 0,
-            num_part_ords_forwarded: 0,
-            num_forwards_with_missing_chunk_header: 0,
-            chunk_parts_that_must_be_known: HashSet::new(),
-        }
-    }
-
-    fn process_one_peer_message(&mut self, client_id: usize, requests: NetworkRequests) {
-        match requests {
-            NetworkRequests::PartialEncodedChunkRequest { ref target, ref request, .. } => {
-                for part_ord in &request.part_ords {
-                    assert!(
-                        self.chunk_parts_that_must_be_known.insert((
-                            request.chunk_hash.clone(),
-                            *part_ord,
-                            client_id
-                        )),
-                        "chunk request from {} to {:?} for chunk {} with part_ords {:?}",
-                        client_id,
-                        target,
-                        hex::encode(&request.chunk_hash.as_bytes()[..4]),
-                        part_ord,
-                    );
-                }
-                debug!(
-                    target: "test",
-                    "chunk request from {} to {:?} for chunk {} with part_ords {:?}",
-                    client_id,
-                    target,
-                    hex::encode(&request.chunk_hash.as_bytes()[..4]),
-                    request.part_ords
-                );
-                self.num_part_ords_requested += request.part_ords.len();
-                self.env.process_partial_encoded_chunk_request(
-                    client_id,
-                    PeerManagerMessageRequest::NetworkRequests(requests),
-                );
-            }
-            NetworkRequests::PartialEncodedChunkMessage { account_id, partial_encoded_chunk } => {
-                debug!(
-                    target: "test",
-                    "chunk msg from {} to {} height {} hash {} shard {} parts {:?}",
-                    client_id,
-                    account_id,
-                    partial_encoded_chunk.header.height_created(),
-                    hex::encode(&partial_encoded_chunk.header.chunk_hash().as_bytes()[..4]),
-                    partial_encoded_chunk.header.shard_id(),
-                    partial_encoded_chunk.parts.iter().map(|p| p.part_ord).collect::<Vec<_>>()
-                );
-                for part in &partial_encoded_chunk.parts {
-                    self.chunk_parts_that_must_be_known.insert((
-                        partial_encoded_chunk.header.chunk_hash(),
-                        part.part_ord,
-                        client_id,
-                    ));
-                }
-                self.num_part_ords_sent_as_partial_encoded_chunk +=
-                    partial_encoded_chunk.parts.len();
-                self.env
-                    .client(&account_id)
-                    .process_partial_encoded_chunk(
-                        PartialEncodedChunk::from(partial_encoded_chunk).into(),
-                        Arc::new(|_| {}),
-                    )
-                    .unwrap();
-            }
-            NetworkRequests::PartialEncodedChunkForward { account_id, forward } => {
-                debug!(
-                    target: "test",
-                    "chunk forward from {} to {} hash {} parts {:?}",
-                    client_id,
-                    account_id,
-                    hex::encode(&forward.chunk_hash.as_bytes()[..4]),
-                    forward.parts.iter().map(|p| p.part_ord).collect::<Vec<_>>()
-                );
-                for part_ord in &forward.parts {
-                    self.chunk_parts_that_must_be_known.insert((
-                        forward.chunk_hash.clone(),
-                        part_ord.part_ord,
-                        client_id,
-                    ));
-                }
-                self.num_part_ords_forwarded += forward.parts.len();
-                match self
-                    .env
-                    .client(&account_id)
-                    .process_partial_encoded_chunk_forward(forward, Arc::new(|_| {}))
-                {
-                    Ok(_) => {}
-                    Err(near_client::Error::Chunk(near_chunks::Error::UnknownChunk)) => {
-                        self.num_forwards_with_missing_chunk_header += 1;
-                    }
-                    Err(e) => {
-                        panic!("Unexpected error from chunk forward: {:?}", e)
-                    }
-                }
-            }
-            _ => {
-                panic!("Unexpected network request: {:?}", requests);
-            }
-        }
-    }
-
-    fn process_network_messages(&mut self) {
-        loop {
-            let mut any_message_processed = false;
-            for i in 0..self.num_validators {
-                if let Some(msg) = self.env.network_adapters[i].pop() {
-                    any_message_processed = true;
-                    match msg {
-                        PeerManagerMessageRequest::NetworkRequests(requests) => {
-                            self.process_one_peer_message(i, requests);
-                        }
-                        _ => {
-                            panic!("Unexpected message: {:?}", msg);
-                        }
-                    }
-                }
-            }
-            if !any_message_processed {
-                break;
-            }
-        }
-    }
-}
-
-#[test]
-fn test_chunk_forwarding_optimization() {
-    // Tests that a node should fully take advantage of forwarded chunk parts to never request
-    // a part that was already forwarded to it. We simulate four validator nodes, with one
-    // block producer and four chunk producers.
-    init_test_logger();
-    let mut test = ChunkForwardingOptimizationTestData::new();
-    loop {
-        let height = test.env.clients[0].chain.head().unwrap().height;
-        if height >= 31 {
-            break;
-        }
-        debug!(target: "test", "======= Height {} ======", height + 1);
-        test.process_network_messages();
-
-        let block = test.env.clients[0].produce_block(height + 1).unwrap().unwrap();
-        if block.header().height() > 1 {
-            // For any block except the first, the previous block's application at each
-            // current chunk producer should have produced a chunk and distributed the chunk.
-            // Since we've processed all network messages just now, the block producer should
-            // have all chunks and able to create a block with all chunks. So we check the
-            // heights.
-            for i in 0..4 {
-                assert_eq!(block.chunks()[i].height_created(), block.header().height());
-            }
-        }
-        // The block producer of course has the complete block so we can process that.
-        debug!(target: "test", "Processing block {} as the block producer", block.header().height());
-        test.env.process_block(0, block.clone(), Provenance::PRODUCED);
-
-        for i in 1..test.num_validators {
-            debug!(target: "test", "Processing block {} as validator #{}", block.header().height(), i);
-            let _ = test.env.clients[i].start_process_block(
-                block.clone().into(),
-                Provenance::NONE,
-                Arc::new(|_| {}),
-            );
-            let mut accepted_blocks =
-                test.env.clients[i].finish_block_in_processing(block.header().hash());
-            // Process any chunk part requests that this client sent. Note that this would also
-            // process other network messages (such as production of the next chunk) which is OK.
-            test.process_network_messages();
-            accepted_blocks.extend(test.env.clients[i].finish_blocks_in_processing());
-            assert_eq!(
-                accepted_blocks.len(),
-                1,
-                "Processing of block {} failed at validator #{}",
-                block.header().height(),
-                i
-            );
-            assert_eq!(&accepted_blocks[0], block.header().hash());
-            assert_eq!(test.env.clients[i].chain.head().unwrap().height, block.header().height());
-        }
-    }
-
-    // With very high probability we should've encountered some cases where forwarded parts
-    // could not be applied because the chunk header is not available. Assert this did indeed
-    // happen.
-    assert!(test.num_forwards_with_missing_chunk_header > 0);
-    debug!(target: "test",
-        "Counters for debugging:
-                num_part_ords_requested: {}
-                num_part_ords_sent_as_partial_encoded_chunk: {}
-                num_part_ords_forwarded: {}
-                num_forwards_with_missing_chunk_header: {}",
-        test.num_part_ords_requested,
-        test.num_part_ords_sent_as_partial_encoded_chunk,
-        test.num_part_ords_forwarded,
-        test.num_forwards_with_missing_chunk_header
-    );
 }
 
 /// Test asynchronous block processing (start_process_block_async).


### PR DESCRIPTION
This reverts commit 43158e4e941b048a2e690de608935ef7e8151c0a
which breaks sync_state_nodes_multishard and adversarial/fork_sync.py
tests:

    cargo test -pintegration-tests --features test_features,expensive_tests \
        -- sync_state_nodes_multishard
    cargo build -pneard --features test_features &&
        python3 pytest/tests/adversarial/fork_sync.py
