### PR TITLE
buildkite: don’t start Redis when running tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,8 +23,6 @@ steps:
 
   - label: "cargo test not integration-tests*"
     command: |
-      docker rm -f $(docker ps --filter "publish=6379" -q) | true
-      docker run -d -p 6379:6379 -d redis
       source ~/.cargo/env && set -eux
       cargo test --locked --workspace -p '*' --exclude 'integration-tests*'
 
@@ -45,8 +43,6 @@ steps:
 
   - label: "cargo test nightly not integration-tests*"
     command: |
-      docker rm -f $(docker ps --filter "publish=6379" -q) | true
-      docker run -d -p 6379:6379 -d redis
       source ~/.cargo/env && set -eux
       cargo test --workspace --features nightly,test_features -p '*' --exclude 'integration-tests*'
 


### PR DESCRIPTION
We used to have a Redis test which required running instance of Redis
running on the machine.  However, the test has been removed in commit
83a08f5b02f090363dd21f8601f6b0165f651875 so it’s no longer necessary
to set the instance up on CI.
