### PR TITLE
json: remove deprecated old style path+data request format

### DIFF
--- a/chain/jsonrpc/src/api/query.rs
+++ b/chain/jsonrpc/src/api/query.rs
@@ -3,72 +3,13 @@ use serde_json::Value;
 use near_client_primitives::types::QueryError;
 use near_jsonrpc_primitives::errors::RpcParseError;
 use near_jsonrpc_primitives::types::query::{RpcQueryError, RpcQueryRequest, RpcQueryResponse};
-use near_primitives::serialize;
-use near_primitives::types::BlockReference;
-use near_primitives::views::{QueryRequest, QueryResponse};
+use near_primitives::views::QueryResponse;
 
 use super::{parse_params, RpcFrom, RpcRequest};
 
-/// Max size of the query path (soft-deprecated)
-const QUERY_DATA_MAX_SIZE: usize = 10 * 1024;
-
 impl RpcRequest for RpcQueryRequest {
     fn parse(value: Option<Value>) -> Result<Self, RpcParseError> {
-        let params = parse_params::<(String, String)>(value.clone());
-        let query_request = if let Ok((path, data)) = params {
-            // Handle a soft-deprecated version of the query API, which is based on
-            // positional arguments with a "path"-style first argument.
-            //
-            // This whole block can be removed one day, when the new API is 100% adopted.
-            let data =
-                serialize::from_base58(&data).map_err(|err| RpcParseError(err.to_string()))?;
-            let query_data_size = path.len() + data.len();
-            if query_data_size > QUERY_DATA_MAX_SIZE {
-                return Err(RpcParseError(format!(
-                    "Query data size {} is too large",
-                    query_data_size
-                )));
-            }
-
-            let mut path_parts = path.splitn(3, '/');
-            let make_err = || RpcParseError("Not enough query parameters provided".to_string());
-            let query_command = path_parts.next().ok_or_else(make_err)?;
-            let account_id = path_parts
-                .next()
-                .ok_or_else(make_err)?
-                .parse()
-                .map_err(|err| RpcParseError(format!("{}", err)))?;
-            let maybe_extra_arg = path_parts.next();
-
-            let request = match query_command {
-                "account" => QueryRequest::ViewAccount { account_id },
-                "access_key" => match maybe_extra_arg {
-                    None => QueryRequest::ViewAccessKeyList { account_id },
-                    Some(pk) => QueryRequest::ViewAccessKey {
-                        account_id,
-                        public_key: pk
-                            .parse()
-                            .map_err(|_| RpcParseError("Invalid public key".to_string()))?,
-                    },
-                },
-                "code" => QueryRequest::ViewCode { account_id },
-                "contract" => QueryRequest::ViewState { account_id, prefix: data.into() },
-                "call" => match maybe_extra_arg {
-                    Some(method_name) => QueryRequest::CallFunction {
-                        account_id,
-                        method_name: method_name.to_string(),
-                        args: data.into(),
-                    },
-                    None => return Err(RpcParseError("Method name is missing".to_string())),
-                },
-                _ => return Err(RpcParseError(format!("Unknown path {}", query_command))),
-            };
-            // Use Finality::None here to make backward compatibility tests work
-            Self { request, block_reference: BlockReference::latest() }
-        } else {
-            parse_params::<Self>(value)?
-        };
-        Ok(query_request)
+        Ok(parse_params::<Self>(value)?)
     }
 }
 

--- a/core/primitives-core/src/serialize.rs
+++ b/core/primitives-core/src/serialize.rs
@@ -2,10 +2,6 @@ pub fn to_base58<T: AsRef<[u8]>>(input: T) -> String {
     bs58::encode(input).into_string()
 }
 
-pub fn from_base58(s: &str) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
-    bs58::decode(s).into_vec().map_err(|err| err.into())
-}
-
 pub fn to_base64<T: AsRef<[u8]>>(input: T) -> String {
     base64::encode(&input)
 }


### PR DESCRIPTION
This has been deprecated at least since August 2020 (see #3237), isn’t
documented and it’s probably fair to say that anyone who cared
migrated to JSON RPC requests.

As a side effect, this allows us to get rid of from_base58 function.
