### PR TITLE
pytest: fix db_migration.py after changes to migration config options

### DIFF
--- a/pytest/tests/sanity/db_migration.py
+++ b/pytest/tests/sanity/db_migration.py
@@ -5,6 +5,7 @@ Shutdowns the node and restarts with the same data folder with the new binary.
 Makes sure that the node can still produce blocks.
 """
 
+import json
 import logging
 import os
 import sys
@@ -64,6 +65,16 @@ def main():
         "init",
         "--fast",
     ))
+
+    # Adjust changes required since #7486.  This is needed because current
+    # stable release populates the deprecated migration configuration options.
+    # TODO(mina86): Remove this once we get stable release which doesn’t
+    # populate those fields by default.
+    config_path = node_root / 'config.json'
+    data = json.loads(config_path.read_text(encoding='utf-8'))
+    data.pop('db_migration_snapshot_path', None)
+    data.pop('use_db_migration_snapshot', None)
+    config_path.write_text(json.dumps(data), encoding='utf-8')
 
     # Run stable node for few blocks.
     logging.info("Starting the stable node...")


### PR DESCRIPTION
Since db_migration.py uses the stable neard to initialise the node, it
results with config.json with use_db_migration_snapshot field
set. This makes the new binary complain when it tries to run
migration.

Note that this shouldn’t be a major issue in production since config
files offered on S3 don’t have that field set.
