### PR TITLE
removed deprecated RoutedMessageBody::PartialEncodedChunk

### DIFF
--- a/chain/network-primitives/src/network_protocol/mod.rs
+++ b/chain/network-primitives/src/network_protocol/mod.rs
@@ -11,8 +11,7 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::combine_hash;
 use near_primitives::network::PeerId;
 use near_primitives::sharding::{
-    ChunkHash, PartialEncodedChunk, PartialEncodedChunkPart, PartialEncodedChunkV1,
-    PartialEncodedChunkWithArcReceipts, ReceiptProof, ShardChunkHeader,
+    ChunkHash, PartialEncodedChunk, PartialEncodedChunkPart, ReceiptProof, ShardChunkHeader,
 };
 use near_primitives::syncing::{ShardStateSyncResponse, ShardStateSyncResponseV1};
 use near_primitives::transaction::SignedTransaction;
@@ -214,7 +213,7 @@ pub enum RoutedMessageBody {
     StateResponse(StateResponseInfoV1),
     PartialEncodedChunkRequest(PartialEncodedChunkRequestMsg),
     PartialEncodedChunkResponse(PartialEncodedChunkResponseMsg),
-    PartialEncodedChunk(PartialEncodedChunkV1),
+    _UnusedPartialEncodedChunk,
     /// Ping/Pong used for testing networking and routing.
     Ping(Ping),
     Pong(Pong),
@@ -232,22 +231,9 @@ impl RoutedMessageBody {
             // Both BlockApproval and PartialEncodedChunk is essential for block production and
             // are only sent by the original node and if they are lost, the receiver node doesn't
             // know to request them.
-            RoutedMessageBody::BlockApproval(_) | RoutedMessageBody::PartialEncodedChunk(_) => true,
+            RoutedMessageBody::BlockApproval(_)
+            | RoutedMessageBody::VersionedPartialEncodedChunk(_) => true,
             _ => false,
-        }
-    }
-}
-
-impl From<PartialEncodedChunkWithArcReceipts> for RoutedMessageBody {
-    fn from(pec: PartialEncodedChunkWithArcReceipts) -> Self {
-        if let ShardChunkHeader::V1(legacy_header) = pec.header {
-            Self::PartialEncodedChunk(PartialEncodedChunkV1 {
-                header: legacy_header,
-                parts: pec.parts,
-                receipts: pec.receipts.into_iter().map(|r| ReceiptProof::clone(&r)).collect(),
-            })
-        } else {
-            Self::VersionedPartialEncodedChunk(pec.into())
         }
     }
 }
@@ -289,11 +275,9 @@ impl Debug for RoutedMessageBody {
                 response.chunk_hash,
                 response.parts.iter().map(|p| p.part_ord).collect::<Vec<_>>()
             ),
-            RoutedMessageBody::PartialEncodedChunk(chunk) => {
-                write!(f, "PartialChunk({:?})", chunk.header.hash)
-            }
+            RoutedMessageBody::_UnusedPartialEncodedChunk => write!(f, "PartiaEncodedChunk"),
             RoutedMessageBody::VersionedPartialEncodedChunk(_) => {
-                write!(f, "VersionedPartialChunk(?)")
+                write!(f, "VersionedPartialEncodedChunk(?)")
             }
             RoutedMessageBody::VersionedStateResponse(response) => write!(
                 f,

--- a/chain/network/src/network_protocol/mod.rs
+++ b/chain/network/src/network_protocol/mod.rs
@@ -340,7 +340,6 @@ impl PeerMessage {
                 r.msg.body,
                 RoutedMessageBody::BlockApproval(_)
                     | RoutedMessageBody::ForwardTx(_)
-                    | RoutedMessageBody::PartialEncodedChunk(_)
                     | RoutedMessageBody::PartialEncodedChunkForward(_)
                     | RoutedMessageBody::PartialEncodedChunkRequest(_)
                     | RoutedMessageBody::PartialEncodedChunkResponse(_)

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -33,7 +33,6 @@ use near_network_primitives::types::{Edge, PartialEdgeInfo};
 use near_performance_metrics_macros::perf;
 use near_primitives::logging;
 use near_primitives::network::PeerId;
-use near_primitives::sharding::PartialEncodedChunk;
 use near_primitives::utils::DisplayOption;
 use near_primitives::version::{
     ProtocolVersion, PEER_MIN_ALLOWED_PROTOCOL_VERSION, PROTOCOL_VERSION,
@@ -524,11 +523,6 @@ impl PeerActor {
                             self.clock.now().into(),
                         )
                     }
-                    RoutedMessageBody::PartialEncodedChunk(partial_encoded_chunk) => {
-                        NetworkClientMessages::PartialEncodedChunk(PartialEncodedChunk::V1(
-                            partial_encoded_chunk.clone(),
-                        ))
-                    }
                     RoutedMessageBody::VersionedPartialEncodedChunk(chunk) => {
                         NetworkClientMessages::PartialEncodedChunk(chunk.clone())
                     }
@@ -541,6 +535,7 @@ impl PeerActor {
                     | RoutedMessageBody::TxStatusResponse(_)
                     | RoutedMessageBody::_UnusedQueryRequest
                     | RoutedMessageBody::_UnusedQueryResponse
+                    | RoutedMessageBody::_UnusedPartialEncodedChunk
                     | RoutedMessageBody::ReceiptOutcomeRequest(_)
                     | RoutedMessageBody::_UnusedReceiptOutcomeResponse
                     | RoutedMessageBody::StateRequestHeader(_, _)

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -1314,7 +1314,10 @@ impl PeerManagerActor {
                 }
             }
             NetworkRequests::PartialEncodedChunkMessage { account_id, partial_encoded_chunk } => {
-                if self.send_message_to_account(&account_id, partial_encoded_chunk.into()) {
+                if self.send_message_to_account(
+                    &account_id,
+                    RoutedMessageBody::VersionedPartialEncodedChunk(partial_encoded_chunk.into()),
+                ) {
                     NetworkResponses::NoResponse
                 } else {
                     NetworkResponses::RouteNotFound


### PR DESCRIPTION
PartialEncodedChunk was deprecated in favor of VersionedPartialEncodedChunk for 2 years now: https://github.com/near/nearcore/pull/3463
It is confusing, in particular we have configured PartialEncodedChunk to be sent out 3x (to make it delivered reliably) while
we should have done that for VersionedPartialEncodedChunk (which is still sent out just 1x).

There is a codepath which encodes V1 PartialEncodedChunk into this specific RoutedMessagebody variant, however while decoding this distinction is lost. Technically this PR should be split into 2 separate rollouts (first: stop using the deprecated variant to send messages; second: stop accepting the deprecated variant). The situation gets even more complicated, because network protocol is supposed to be backward compatible for 2 versions (so, 3 rollouts), and since this is a routed message you can imagine a sequence of nodes where node in version N sends a message to node in version N+4 via node in version N+2 (and theoretically no amount of rollouts helps then, because the intermediate nodes cannot translate the message to a newer format, because it is signed).

In spite of all of that AFAICT it is safe to merge this PR in one go, because VersionedPartialEncodedChunk is used only to send new chunks from chunk producer to approvers. Therefore it is used only with V2 PartialEncodedChunk for quite some time now.