### PR TITLE
VersionedPartialEncodedChunk is important

### DIFF
--- a/chain/network-primitives/src/network_protocol/mod.rs
+++ b/chain/network-primitives/src/network_protocol/mod.rs
@@ -232,7 +232,8 @@ impl RoutedMessageBody {
             // Both BlockApproval and VersionedPartialEncodedChunk is essential for block production and
             // are only sent by the original node and if they are lost, the receiver node doesn't
             // know to request them.
-            RoutedMessageBody::BlockApproval(_) | RoutedMessageBody::VersionedPartialEncodedChunk(_) => true,
+            RoutedMessageBody::BlockApproval(_)
+            | RoutedMessageBody::VersionedPartialEncodedChunk(_) => true,
             _ => false,
         }
     }

--- a/chain/network-primitives/src/network_protocol/mod.rs
+++ b/chain/network-primitives/src/network_protocol/mod.rs
@@ -229,10 +229,10 @@ impl RoutedMessageBody {
     // lost
     pub fn is_important(&self) -> bool {
         match self {
-            // Both BlockApproval and PartialEncodedChunk is essential for block production and
+            // Both BlockApproval and VersionedPartialEncodedChunk is essential for block production and
             // are only sent by the original node and if they are lost, the receiver node doesn't
             // know to request them.
-            RoutedMessageBody::BlockApproval(_) | RoutedMessageBody::PartialEncodedChunk(_) => true,
+            RoutedMessageBody::BlockApproval(_) | RoutedMessageBody::VersionedPartialEncodedChunk(_) => true,
             _ => false,
         }
     }


### PR DESCRIPTION
PartialEncodedChunk is deprecated and effectively unused. It is VersionedPartialEncodedChunk which is sent by chunk producer to approvers and should be reliably delivered.