### PR TITLE
Prefer CryptoHash::hash_borsh to try_to_vec+hash combo

### DIFF
--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -171,7 +171,7 @@ fn create_receipt_nonce(
     amount: Balance,
     nonce: Nonce,
 ) -> CryptoHash {
-    hash(&ReceiptNonce { from, to, amount, nonce }.try_to_vec().unwrap())
+    CryptoHash::hash_borsh(&ReceiptNonce { from, to, amount, nonce })
 }
 
 impl KeyValueRuntime {
@@ -1529,10 +1529,9 @@ impl ChainGenesis {
 mod test {
     use std::convert::TryFrom;
 
-    use borsh::BorshSerialize;
     use rand::Rng;
 
-    use near_primitives::hash::{hash, CryptoHash};
+    use near_primitives::hash::CryptoHash;
     use near_primitives::receipt::Receipt;
     use near_primitives::sharding::ReceiptList;
     use near_primitives::time::Clock;
@@ -1555,8 +1554,7 @@ mod test {
                 })
                 .cloned()
                 .collect();
-            receipts_hashes
-                .push(hash(&ReceiptList(shard_id, &shard_receipts).try_to_vec().unwrap()));
+            receipts_hashes.push(CryptoHash::hash_borsh(&ReceiptList(shard_id, &shard_receipts)));
         }
         receipts_hashes
     }

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -819,8 +819,6 @@ mod tests {
     use near_primitives::validator_signer::InMemoryValidatorSigner;
     use near_primitives::version::PROTOCOL_VERSION;
 
-    use crate::Chain;
-
     use super::*;
 
     #[test]
@@ -836,7 +834,7 @@ mod tests {
             0,
             100,
             1_000_000_000,
-            Chain::compute_collection_hash(genesis_bps).unwrap(),
+            CryptoHash::hash_borsh(&genesis_bps),
         );
         let signer =
             InMemoryValidatorSigner::from_seed("other".parse().unwrap(), KeyType::ED25519, "other");

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -82,7 +82,6 @@ use std::collections::{btree_map, hash_map, BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use borsh::BorshSerialize;
 use chrono::DateTime;
 use near_primitives::time::Utc;
 use rand::seq::IteratorRandom;
@@ -96,7 +95,7 @@ use near_chain::{
 use near_network::types::{NetworkRequests, PeerManagerAdapter, PeerManagerMessageRequest};
 use near_pool::{PoolIteratorWrapper, TransactionPool};
 use near_primitives::block::Tip;
-use near_primitives::hash::{hash, CryptoHash};
+use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{merklize, verify_path, MerklePath};
 use near_primitives::receipt::Receipt;
 use near_primitives::sharding::{
@@ -1694,7 +1693,7 @@ impl ShardsManager {
             // because prev_block_hash may not be ready
             let shard_id = proof.1.to_shard_id;
             let ReceiptProof(shard_receipts, receipt_proof) = proof;
-            let receipt_hash = hash(&ReceiptList(shard_id, shard_receipts).try_to_vec().unwrap());
+            let receipt_hash = CryptoHash::hash_borsh(&ReceiptList(shard_id, shard_receipts));
             if !verify_path(header.outgoing_receipts_root(), &receipt_proof.proof, &receipt_hash) {
                 byzantine_assert!(false);
                 return Err(Error::ChainError(near_chain::Error::InvalidReceiptsProof));

--- a/core/primitives/src/challenge.rs
+++ b/core/primitives/src/challenge.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use near_crypto::Signature;
 
-use crate::hash::{hash, CryptoHash};
+use crate::hash::CryptoHash;
 use crate::merkle::MerklePath;
 use crate::sharding::{EncodedShardChunk, ShardChunk, ShardChunkHeader};
 use crate::types::AccountId;
@@ -97,7 +97,7 @@ pub struct Challenge {
 
 impl Challenge {
     pub fn init(&mut self) {
-        self.hash = hash(&self.body.try_to_vec().expect("Failed to serialize"));
+        self.hash = CryptoHash::hash_borsh(&self.body);
     }
 
     pub fn produce(body: ChallengeBody, signer: &dyn ValidatorSigner) -> Self {

--- a/core/primitives/src/merkle.rs
+++ b/core/primitives/src/merkle.rs
@@ -1,7 +1,7 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 
-use crate::hash::{hash, CryptoHash};
+use crate::hash::CryptoHash;
 use crate::types::MerkleHash;
 
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
@@ -92,8 +92,7 @@ pub fn merklize<T: BorshSerialize>(arr: &[T]) -> (MerkleHash, Vec<MerklePath>) {
 
 /// Verify merkle path for given item and corresponding path.
 pub fn verify_path<T: BorshSerialize>(root: MerkleHash, path: &MerklePath, item: &T) -> bool {
-    let hash = hash(&item.try_to_vec().expect("Failed to serialize"));
-    verify_hash(root, path, hash)
+    verify_hash(root, path, CryptoHash::hash_borsh(&item))
 }
 
 pub fn verify_hash(root: MerkleHash, path: &MerklePath, item_hash: MerkleHash) -> bool {
@@ -119,8 +118,7 @@ pub fn compute_root_from_path_and_item<T: BorshSerialize>(
     path: &MerklePath,
     item: &T,
 ) -> MerkleHash {
-    let hash = hash(&item.try_to_vec().expect("Failed to serialize"));
-    compute_root_from_path(path, hash)
+    compute_root_from_path(path, CryptoHash::hash_borsh(&item))
 }
 
 /// Merkle tree that only maintains the path for the next leaf, i.e,
@@ -239,7 +237,7 @@ mod tests {
         let mut hashes = vec![];
         for i in 0..50 {
             assert_eq!(compute_root(&hashes), tree.root());
-            let cur_hash = hash(&[i]);
+            let cur_hash = CryptoHash::hash_bytes(&[i]);
             hashes.push(cur_hash);
             tree.insert(cur_hash);
         }

--- a/core/primitives/src/validator_signer.rs
+++ b/core/primitives/src/validator_signer.rs
@@ -1,13 +1,11 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use borsh::BorshSerialize;
-
 use near_crypto::{InMemorySigner, KeyType, PublicKey, Signature, Signer};
 
 use crate::block::{Approval, ApprovalInner, BlockHeader};
 use crate::challenge::ChallengeBody;
-use crate::hash::{hash, CryptoHash};
+use crate::hash::CryptoHash;
 use crate::network::{AnnounceAccount, PeerId};
 use crate::sharding::ChunkHash;
 use crate::telemetry::TelemetryInfo;
@@ -111,8 +109,7 @@ impl ValidatorSigner for EmptyValidatorSigner {
     }
 
     fn sign_challenge(&self, challenge_body: &ChallengeBody) -> (CryptoHash, Signature) {
-        let hash = hash(&challenge_body.try_to_vec().expect("Failed to serialize"));
-        (hash, Signature::default())
+        (CryptoHash::hash_borsh(&challenge_body), Signature::default())
     }
 
     fn sign_account_announce(
@@ -203,7 +200,7 @@ impl ValidatorSigner for InMemoryValidatorSigner {
     }
 
     fn sign_challenge(&self, challenge_body: &ChallengeBody) -> (CryptoHash, Signature) {
-        let hash = hash(&challenge_body.try_to_vec().expect("Failed to serialize"));
+        let hash = CryptoHash::hash_borsh(&challenge_body);
         let signature = self.signer.sign(hash.as_ref());
         (hash, signature)
     }

--- a/integration-tests/src/tests/nearcore/rpc_nodes.rs
+++ b/integration-tests/src/tests/nearcore/rpc_nodes.rs
@@ -78,17 +78,13 @@ fn outcome_view_to_hashes(outcome: &ExecutionOutcomeView) -> Vec<CryptoHash> {
         ExecutionStatusView::Failure(_) => PartialExecutionStatus::Failure,
         ExecutionStatusView::SuccessReceiptId(id) => PartialExecutionStatus::SuccessReceiptId(*id),
     };
-    let mut result = vec![hash(
-        &(
-            outcome.receipt_ids.clone(),
-            outcome.gas_burnt,
-            outcome.tokens_burnt,
-            outcome.executor_id.clone(),
-            status,
-        )
-            .try_to_vec()
-            .expect("Failed to serialize"),
-    )];
+    let mut result = vec![CryptoHash::hash_borsh(&(
+        outcome.receipt_ids.clone(),
+        outcome.gas_burnt,
+        outcome.tokens_burnt,
+        outcome.executor_id.clone(),
+        status,
+    ))];
     for log in outcome.logs.iter() {
         result.push(hash(log.as_bytes()));
     }

--- a/integration-tests/src/tests/nearcore/sync_nodes.rs
+++ b/integration-tests/src/tests/nearcore/sync_nodes.rs
@@ -8,7 +8,7 @@ use futures::{future, FutureExt};
 use crate::genesis_helpers::genesis_block;
 use crate::test_helpers::heavy_test;
 use near_actix_test_utils::run_actix;
-use near_chain::{Block, Chain};
+use near_chain::Block;
 use near_chain_configs::Genesis;
 use near_client::{ClientActor, GetBlock};
 use near_crypto::{InMemorySigner, KeyType};
@@ -17,6 +17,7 @@ use near_network::types::NetworkClientMessages;
 use near_network_primitives::types::PeerInfo;
 use near_o11y::testonly::init_integration_logger;
 use near_primitives::block::Approval;
+use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::PartialMerkleTree;
 use near_primitives::num_rational::Ratio;
 use near_primitives::transaction::SignedTransaction;
@@ -50,12 +51,11 @@ fn add_blocks(
         let next_epoch_id = EpochId(
             *blocks[(((prev.header().height()) / epoch_length) * epoch_length) as usize].hash(),
         );
-        let next_bp_hash = Chain::compute_collection_hash(vec![ValidatorStake::new(
+        let next_bp_hash = CryptoHash::hash_borsh(&[ValidatorStake::new(
             "other".parse().unwrap(),
             signer.public_key(),
             TESTING_INIT_STAKE,
-        )])
-        .unwrap();
+        )]);
         let block = Block::produce(
             PROTOCOL_VERSION,
             PROTOCOL_VERSION,

--- a/integration-tests/src/tests/standard_cases/mod.rs
+++ b/integration-tests/src/tests/standard_cases/mod.rs
@@ -4,7 +4,6 @@ mod rpc;
 mod runtime;
 
 use assert_matches::assert_matches;
-use borsh::BorshSerialize;
 use near_crypto::{InMemorySigner, KeyType};
 use near_jsonrpc_primitives::errors::ServerError;
 use near_primitives::account::{AccessKey, AccessKeyPermission, FunctionCallPermission};
@@ -1423,7 +1422,7 @@ fn make_receipt(node: &impl Node, actions: Vec<Action>, receiver_id: AccountId) 
     Receipt {
         predecessor_id: alice_account(),
         receiver_id,
-        receipt_id: hash(&receipt_enum.try_to_vec().unwrap()),
+        receipt_id: CryptoHash::hash_borsh(&receipt_enum),
         receipt: receipt_enum,
     }
 }

--- a/runtime/near-vm-runner/src/cache.rs
+++ b/runtime/near-vm-runner/src/cache.rs
@@ -63,7 +63,7 @@ pub fn get_contract_cache_key(
         vm_kind,
         vm_hash: vm_hash(vm_kind),
     };
-    near_primitives::hash::hash(&key.try_to_vec().unwrap())
+    CryptoHash::hash_borsh(&key)
 }
 
 #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
CryptoHash::hash_borsh doesn’t allocate a vector where the object is
serialised into instead calculating the hash directly as the data is
serialised.  This reduces amount of memory allocations and thus
optimises the code.

It is worth noting however that while try_to_vec may fail, hash_borsh
panics on failures.  In most cases we were unwrapping the result of
serialisation anyway, but it does change behaviour in chain which used
to propagate the error and now it’s panicking on failure.  However,
that code operates on values which in practice cannot fail
serialisation so the change should be fine.
