### PR TITLE
[chunks] Move chunk completion out of ShardsManager

### DIFF
--- a/chain/chunks/src/client.rs
+++ b/chain/chunks/src/client.rs
@@ -1,0 +1,13 @@
+use actix::Message;
+use near_network::types::MsgRecipient;
+use near_primitives::sharding::ShardChunkHeader;
+
+#[derive(Message)]
+#[rtype(result = "()")]
+pub enum ShardsManagerResponse {
+    ChunkCompleted(ShardChunkHeader),
+}
+
+pub trait ClientAdapterForShardsManager: MsgRecipient<ShardsManagerResponse> {}
+
+impl<A: MsgRecipient<ShardsManagerResponse>> ClientAdapterForShardsManager for A {}

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -85,6 +85,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use chrono::DateTime;
+use client::{ClientAdapterForShardsManager, ShardsManagerResponse};
 use near_primitives::time::Utc;
 use rand::seq::IteratorRandom;
 use rand::seq::SliceRandom;
@@ -127,6 +128,7 @@ use near_primitives::epoch_manager::RngSeed;
 use rand::Rng;
 
 mod chunk_cache;
+pub mod client;
 mod metrics;
 pub mod test_utils;
 
@@ -473,6 +475,8 @@ pub struct ShardsManager {
 
     runtime_adapter: Arc<dyn RuntimeAdapter>,
     peer_manager_adapter: Arc<dyn PeerManagerAdapter>,
+    client_adapter: Arc<dyn ClientAdapterForShardsManager>,
+    rs: ReedSolomonWrapper,
 
     encoded_chunks: EncodedChunksCache,
     requested_partial_encoded_chunks: RequestPool,
@@ -489,6 +493,7 @@ impl ShardsManager {
         me: Option<AccountId>,
         runtime_adapter: Arc<dyn RuntimeAdapter>,
         network_adapter: Arc<dyn PeerManagerAdapter>,
+        client_adapter: Arc<dyn ClientAdapterForShardsManager>,
         rng_seed: RngSeed,
     ) -> Self {
         TransactionPool::init_metrics();
@@ -497,6 +502,11 @@ impl ShardsManager {
             tx_pools: HashMap::new(),
             runtime_adapter: runtime_adapter.clone(),
             peer_manager_adapter: network_adapter,
+            client_adapter,
+            rs: ReedSolomonWrapper::new(
+                runtime_adapter.num_data_parts(),
+                runtime_adapter.num_total_parts() - runtime_adapter.num_data_parts(),
+            ),
             encoded_chunks: EncodedChunksCache::new(),
             requested_partial_encoded_chunks: RequestPool::new(
                 Duration::from_millis(CHUNK_REQUEST_RETRY_MS),
@@ -1024,7 +1034,6 @@ impl ShardsManager {
         request: PartialEncodedChunkRequestMsg,
         route_back: CryptoHash,
         chain_store: &mut ChainStore,
-        rs: &mut ReedSolomonWrapper,
     ) {
         let _span = tracing::debug_span!(
             target: "chunks",
@@ -1038,7 +1047,7 @@ impl ShardsManager {
             account = ?self.me);
 
         let (started, key, response) =
-            self.prepare_partial_encoded_chunk_response(request, chain_store, rs);
+            self.prepare_partial_encoded_chunk_response(request, chain_store);
 
         let elapsed = started.elapsed().as_secs_f64();
         let labels = [key, if response.is_some() { "ok" } else { "failed" }];
@@ -1057,7 +1066,6 @@ impl ShardsManager {
         &mut self,
         request: PartialEncodedChunkRequestMsg,
         chain_store: &mut ChainStore,
-        rs: &mut ReedSolomonWrapper,
     ) -> (std::time::Instant, &'static str, Option<PartialEncodedChunkResponseMsg>) {
         // Try getting data from in-memory cache.
         let started = Instant::now();
@@ -1082,8 +1090,7 @@ impl ShardsManager {
         if let Ok(chunk) = chain_store.get_chunk(&request.chunk_hash) {
             // TODO(#6242): This is currently not implemented and effectively
             // this is dead code.
-            let response =
-                self.prepare_partial_encoded_chunk_response_from_chunk(request, rs, &chunk);
+            let response = self.prepare_partial_encoded_chunk_response_from_chunk(request, &chunk);
             return (started, "chunk", response);
         }
 
@@ -1193,14 +1200,13 @@ impl ShardsManager {
     pub fn prepare_partial_encoded_chunk_response_from_chunk(
         &mut self,
         request: PartialEncodedChunkRequestMsg,
-        rs: &mut ReedSolomonWrapper,
         chunk: &ShardChunk,
     ) -> Option<PartialEncodedChunkResponseMsg> {
         let total_parts = self.runtime_adapter.num_total_parts();
         // rs is created with self.runtime_adapter.num_total_parts() so this
         // assert should always hold true.  If it doesn’t than something strange
         // is going on.
-        assert_eq!(total_parts, rs.total_shard_count());
+        assert_eq!(total_parts, self.rs.total_shard_count());
         for &ord in request.part_ords.iter() {
             let ord: usize = ord.try_into().unwrap();
             if ord >= total_parts {
@@ -1232,7 +1238,7 @@ impl ShardsManager {
         // need parity parts, instruct the constructor to calculate them as
         // well.  Otherwise we won’t bother.
         let (parts, encoded_length) = EncodedShardChunk::encode_transaction_receipts(
-            rs,
+            &mut self.rs,
             chunk.transactions().to_vec(),
             &outgoing_receipts).map_err(|err| {
                 warn!(target: "chunks", "Not sending {}, failed to encode transaction receipts: {}", request.chunk_hash.0, err);
@@ -1245,7 +1251,7 @@ impl ShardsManager {
         }
 
         let mut content = EncodedShardChunkBody { parts };
-        if let Err(err) = content.reconstruct(rs) {
+        if let Err(err) = content.reconstruct(&mut self.rs) {
             warn!(target: "chunks",
                    "Not sending {}, failed to reconstruct RS parity parts: {}",
                    request.chunk_hash.0, err);
@@ -1357,13 +1363,12 @@ impl ShardsManager {
         }
     }
 
-    pub fn decode_and_persist_encoded_chunk_if_complete(
+    fn decode_and_persist_encoded_chunk_if_complete(
         &mut self,
         mut encoded_chunk: EncodedShardChunk,
         chain_store: &mut ChainStore,
-        rs: &mut ReedSolomonWrapper,
     ) -> Result<bool, Error> {
-        match ShardsManager::check_chunk_complete(&mut encoded_chunk, rs) {
+        match ShardsManager::check_chunk_complete(&mut encoded_chunk, &mut self.rs) {
             ChunkStatus::Complete(merkle_paths) => {
                 self.decode_and_persist_encoded_chunk(encoded_chunk, chain_store, merkle_paths)?;
                 Ok(true)
@@ -1377,7 +1382,7 @@ impl ShardsManager {
         }
     }
 
-    pub fn validate_partial_encoded_chunk_forward(
+    fn validate_partial_encoded_chunk_forward(
         &mut self,
         forward: &PartialEncodedChunkForwardMsg,
     ) -> Result<(), Error> {
@@ -1463,6 +1468,52 @@ impl ShardsManager {
                 }
             }
         }
+    }
+
+    pub fn process_partial_encoded_chunk_forward(
+        &mut self,
+        forward: PartialEncodedChunkForwardMsg,
+        chain_head: Option<&Tip>,
+        chain_store: &mut ChainStore,
+    ) -> Result<ProcessPartialEncodedChunkResult, Error> {
+        let maybe_header = self
+            .validate_partial_encoded_chunk_forward(&forward)
+            .and_then(|_| self.get_partial_encoded_chunk_header(&forward.chunk_hash));
+
+        let header = match maybe_header {
+            Ok(header) => Ok(header),
+            Err(Error::UnknownChunk) => {
+                // We don't know this chunk yet; cache the forwarded part
+                // to be used after we get the header.
+                self.insert_forwarded_chunk(forward);
+                return Err(Error::UnknownChunk);
+            }
+            Err(Error::ChainError(chain_error)) => {
+                match chain_error {
+                    near_chain::Error::DBNotFoundErr(_) => {
+                        // We can't check if this chunk came from a valid chunk producer because
+                        // we don't know `prev_block`, however the signature is checked when
+                        // forwarded parts are later processed as partial encoded chunks, so we
+                        // can mark it as unknown for now.
+                        self.insert_forwarded_chunk(forward);
+                        return Err(Error::UnknownChunk);
+                    }
+                    // Some other error occurred, we don't know how to handle it
+                    _ => Err(Error::ChainError(chain_error)),
+                }
+            }
+            Err(err) => Err(err),
+        }?;
+        let partial_chunk = PartialEncodedChunk::V2(PartialEncodedChunkV2 {
+            header,
+            parts: forward.parts,
+            receipts: Vec::new(),
+        });
+        self.process_partial_encoded_chunk(
+            MaybeValidated::from_validated(partial_chunk),
+            chain_head,
+            chain_store,
+        )
     }
 
     /// Get a list of incomplete chunks whose previous block hash is `prev_block_hash`
@@ -1622,11 +1673,12 @@ impl ShardsManager {
     ///    receipts in the chunk are received and the chunk has been processed.
     pub fn process_partial_encoded_chunk(
         &mut self,
-        partial_encoded_chunk: MaybeValidated<&PartialEncodedChunkV2>,
+        partial_encoded_chunk: MaybeValidated<PartialEncodedChunk>,
         chain_head: Option<&Tip>,
         chain_store: &mut ChainStore,
-        rs: &mut ReedSolomonWrapper,
     ) -> Result<ProcessPartialEncodedChunkResult, Error> {
+        let partial_encoded_chunk =
+            partial_encoded_chunk.map(|chunk| PartialEncodedChunkV2::from(chunk));
         let header = &partial_encoded_chunk.header;
         let chunk_hash = header.chunk_hash();
         debug!(target: "chunks", ?chunk_hash, height=header.height_created(), shard_id=header.shard_id(), "Process partial encoded chunk:  parts {}",
@@ -1637,9 +1689,9 @@ impl ShardsManager {
             if entry.complete {
                 return Ok(ProcessPartialEncodedChunkResult::Known);
             }
-            debug!(target: "chunks", "{} parts in cache, total needed: {}", entry.parts.len(), rs.data_shard_count());
+            debug!(target: "chunks", "{} parts in cache, total needed: {}", entry.parts.len(), self.rs.data_shard_count());
         } else {
-            debug!(target: "chunks", "0 parts in cache, total needed: {}", rs.data_shard_count());
+            debug!(target: "chunks", "0 parts in cache, total needed: {}", self.rs.data_shard_count());
         }
 
         // 1.b Checking chunk height
@@ -1676,7 +1728,7 @@ impl ShardsManager {
             Err(err) => return Err(err),
             Ok(_) => (),
         }
-        let partial_encoded_chunk = partial_encoded_chunk.into_inner();
+        let partial_encoded_chunk = partial_encoded_chunk.as_ref().into_inner();
 
         // 1.d Checking part_ords' validity
         let num_total_parts = self.runtime_adapter.num_total_parts();
@@ -1747,7 +1799,7 @@ impl ShardsManager {
         self.insert_header_if_not_exists_and_process_cached_chunk_forwards(header);
 
         // 5. Check if the chunk is complete; requesting more if not.
-        let result = self.try_process_chunk_parts_and_receipts(header, chain_store, rs)?;
+        let result = self.try_process_chunk_parts_and_receipts(header, chain_store)?;
         match result {
             ProcessPartialEncodedChunkResult::NeedMorePartsOrReceipts => {
                 // This may be the first time we see this chunk, so mark it in the request pool.
@@ -1768,7 +1820,6 @@ impl ShardsManager {
         &mut self,
         header: &ShardChunkHeader,
         chain_store: &mut ChainStore,
-        rs: &mut ReedSolomonWrapper,
     ) -> Result<ProcessPartialEncodedChunkResult, Error> {
         // The logic from now on requires previous block is processed because
         // calculating owner parts requires that, so we first check
@@ -1880,7 +1931,7 @@ impl ShardsManager {
             }
 
             let successfully_decoded =
-                self.decode_and_persist_encoded_chunk_if_complete(encoded_chunk, chain_store, rs)?;
+                self.decode_and_persist_encoded_chunk_if_complete(encoded_chunk, chain_store)?;
 
             assert!(successfully_decoded);
 
@@ -1894,9 +1945,12 @@ impl ShardsManager {
 
     /// A helper function to be called after a chunk is considered complete
     fn complete_chunk(&mut self, chunk_hash: &ChunkHash) {
+        let header = self.encoded_chunks.get(chunk_hash).unwrap().header.clone();
         self.encoded_chunks.mark_entry_complete(chunk_hash);
         self.encoded_chunks.remove_from_cache_if_outside_horizon(chunk_hash);
         self.requested_partial_encoded_chunks.remove(chunk_hash);
+        debug!(target: "chunks", "Completed chunk {:?}", chunk_hash);
+        self.client_adapter.do_send(ShardsManagerResponse::ChunkCompleted(header));
     }
 
     /// Send the parts of the partial_encoded_chunk that are owned by `self.me` to the
@@ -2312,10 +2366,12 @@ mod test {
     fn test_request_partial_encoded_chunk_from_self() {
         let runtime_adapter = Arc::new(KeyValueRuntime::new(create_test_store(), 5));
         let network_adapter = Arc::new(MockPeerManagerAdapter::default());
+        let client_adapter = Arc::new(MockClientAdapterForShardsManager::default());
         let mut shards_manager = ShardsManager::new(
             Some("test".parse().unwrap()),
             runtime_adapter,
             network_adapter.clone(),
+            client_adapter,
             TEST_SEED,
         );
         let added = Clock::instant();
@@ -2364,11 +2420,13 @@ mod test {
         let runtime_adapter =
             Arc::new(KeyValueRuntime::new_with_validators(create_test_store(), vs, 5));
         let network_adapter = Arc::new(MockPeerManagerAdapter::default());
+        let client_adapter = Arc::new(MockClientAdapterForShardsManager::default());
         let mut chain_store = ChainStore::new(create_test_store(), 0, true);
         let mut shards_manager = ShardsManager::new(
             Some("test".parse().unwrap()),
             runtime_adapter.clone(),
             network_adapter,
+            client_adapter,
             TEST_SEED,
         );
         let signer =
@@ -2424,13 +2482,11 @@ mod test {
             encoded_chunk.create_partial_encoded_chunk(vec![2, 3, 4], vec![], &proof);
         std::thread::sleep(Duration::from_millis(crate::ACCEPTING_SEAL_PERIOD_MS as u64 + 100));
         for partial_encoded_chunk in vec![partial_encoded_chunk1, partial_encoded_chunk2] {
-            let pec_v2 = partial_encoded_chunk.into();
             shards_manager
                 .process_partial_encoded_chunk(
-                    MaybeValidated::from(&pec_v2),
+                    MaybeValidated::from(partial_encoded_chunk),
                     None,
                     &mut chain_store,
-                    &mut rs,
                 )
                 .unwrap();
         }
@@ -2536,16 +2592,16 @@ mod test {
             Some(fixture.mock_shard_tracker.clone()),
             fixture.mock_runtime.clone(),
             fixture.mock_network.clone(),
+            fixture.mock_client_adapter.clone(),
             TEST_SEED,
         );
         // process chunk part 0
         let partial_encoded_chunk = fixture.make_partial_encoded_chunk(&[0]);
         let result = shards_manager
             .process_partial_encoded_chunk(
-                MaybeValidated::from(&partial_encoded_chunk),
+                MaybeValidated::from(partial_encoded_chunk),
                 Some(&fixture.mock_chain_head),
                 &mut fixture.chain_store,
-                &mut fixture.rs,
             )
             .unwrap();
         assert_matches!(result, ProcessPartialEncodedChunkResult::NeedBlock);
@@ -2577,10 +2633,9 @@ mod test {
         let partial_encoded_chunk = fixture.make_partial_encoded_chunk(&[1]);
         let result = shards_manager
             .process_partial_encoded_chunk(
-                MaybeValidated::from(&partial_encoded_chunk),
+                MaybeValidated::from(partial_encoded_chunk),
                 Some(&fixture.mock_chain_head),
                 &mut fixture.chain_store,
-                &mut fixture.rs,
             )
             .unwrap();
         assert_matches!(result, ProcessPartialEncodedChunkResult::NeedBlock);
@@ -2607,17 +2662,19 @@ mod test {
             Some(fixture.mock_shard_tracker.clone()),
             fixture.mock_runtime.clone(),
             fixture.mock_network.clone(),
+            fixture.mock_client_adapter.clone(),
             TEST_SEED,
         );
 
         // part id > num parts
         let mut partial_encoded_chunk = fixture.make_partial_encoded_chunk(&[0]);
-        partial_encoded_chunk.parts[0].part_ord = fixture.mock_chunk_parts.len() as u64;
+        if let PartialEncodedChunk::V2(ref mut chunk) = partial_encoded_chunk {
+            chunk.parts[0].part_ord = fixture.mock_chunk_parts.len() as u64;
+        }
         let result = shards_manager.process_partial_encoded_chunk(
-            MaybeValidated::from(&partial_encoded_chunk),
+            MaybeValidated::from(partial_encoded_chunk),
             Some(&fixture.mock_chain_head),
             &mut fixture.chain_store,
-            &mut fixture.rs,
         );
         assert_matches!(result, Err(Error::InvalidChunkPartId));
 
@@ -2633,15 +2690,15 @@ mod test {
             Some(fixture.mock_chunk_part_owner.clone()),
             fixture.mock_runtime.clone(),
             fixture.mock_network.clone(),
+            fixture.mock_client_adapter.clone(),
             TEST_SEED,
         );
         let partial_encoded_chunk = fixture.make_partial_encoded_chunk(&fixture.mock_part_ords);
         let result = shards_manager
             .process_partial_encoded_chunk(
-                MaybeValidated::from(&partial_encoded_chunk),
+                MaybeValidated::from(partial_encoded_chunk),
                 None,
                 &mut fixture.chain_store,
-                &mut fixture.rs,
             )
             .unwrap();
         match result {
@@ -2693,6 +2750,7 @@ mod test {
             Some(fixture.mock_chunk_part_owner.clone()),
             fixture.mock_runtime.clone(),
             fixture.mock_network.clone(),
+            fixture.mock_client_adapter.clone(),
             TEST_SEED,
         );
         let count_num_forward_msgs = |fixture: &ChunkTestFixture| {
@@ -2713,7 +2771,7 @@ mod test {
             .collect();
         // Received 3 partial encoded chunks; the owned part is received 3 times, but should
         // only forward the part on receiving it the first time.
-        let partial_encoded_chunks = [
+        let mut partial_encoded_chunks = vec![
             fixture
                 .make_partial_encoded_chunk(&[non_owned_part_ords[0], fixture.mock_part_ords[0]]),
             fixture
@@ -2723,28 +2781,25 @@ mod test {
         ];
         shards_manager
             .process_partial_encoded_chunk(
-                MaybeValidated::from(&partial_encoded_chunks[0]),
+                MaybeValidated::from(partial_encoded_chunks.remove(0)),
                 None,
                 &mut fixture.chain_store,
-                &mut fixture.rs,
             )
             .unwrap();
         let num_forward_msgs_after_first_receiving = count_num_forward_msgs(&fixture);
         assert!(num_forward_msgs_after_first_receiving > 0);
         shards_manager
             .process_partial_encoded_chunk(
-                MaybeValidated::from(&partial_encoded_chunks[1]),
+                MaybeValidated::from(partial_encoded_chunks.remove(0)),
                 None,
                 &mut fixture.chain_store,
-                &mut fixture.rs,
             )
             .unwrap();
         shards_manager
             .process_partial_encoded_chunk(
-                MaybeValidated::from(&partial_encoded_chunks[2]),
+                MaybeValidated::from(partial_encoded_chunks.remove(0)),
                 None,
                 &mut fixture.chain_store,
-                &mut fixture.rs,
             )
             .unwrap();
         let num_forward_msgs_after_receiving_duplicates = count_num_forward_msgs(&fixture);
@@ -2777,6 +2832,7 @@ mod test {
             account_id,
             fixture.mock_runtime.clone(),
             fixture.mock_network.clone(),
+            fixture.mock_client_adapter.clone(),
             TEST_SEED,
         );
         shards_manager.insert_header_if_not_exists_and_process_cached_chunk_forwards(
@@ -2859,15 +2915,15 @@ mod test {
             Some(fixture.mock_chunk_part_owner.clone()),
             fixture.mock_runtime.clone(),
             fixture.mock_network.clone(),
+            fixture.mock_client_adapter.clone(),
             TEST_SEED,
         );
         let partial_encoded_chunk = fixture.make_partial_encoded_chunk(&fixture.mock_part_ords);
         let _ = shards_manager
             .process_partial_encoded_chunk(
-                MaybeValidated::from(&partial_encoded_chunk),
+                MaybeValidated::from(partial_encoded_chunk),
                 None,
                 &mut fixture.chain_store,
-                &mut fixture.rs,
             )
             .unwrap();
         let chunk_only_producers: Vec<_> = fixture
@@ -2944,6 +3000,7 @@ mod test {
             Some(fixture.mock_shard_tracker.clone()),
             fixture.mock_runtime.clone(),
             fixture.mock_network.clone(),
+            fixture.mock_client_adapter.clone(),
             TEST_SEED,
         );
         let (most_parts, other_parts) = {
@@ -2958,18 +3015,17 @@ mod test {
         );
         // The validator receives the chunk forward
         shards_manager.insert_forwarded_chunk(forward);
-        let partial_encoded_chunk = PartialEncodedChunkV2 {
+        let partial_encoded_chunk = PartialEncodedChunk::V2(PartialEncodedChunkV2 {
             header: fixture.mock_chunk_header.clone(),
             parts: other_parts,
             receipts: Vec::new(),
-        };
+        });
         // The validator receives a chunk header with the rest of the parts it needed
         let result = shards_manager
             .process_partial_encoded_chunk(
-                MaybeValidated::from(&partial_encoded_chunk),
+                MaybeValidated::from(partial_encoded_chunk),
                 Some(&fixture.mock_chain_head),
                 &mut fixture.chain_store,
-                &mut fixture.rs,
             )
             .unwrap();
 
@@ -3013,6 +3069,7 @@ mod test {
             Some(fixture.mock_shard_tracker.clone()),
             fixture.mock_runtime.clone(),
             fixture.mock_network.clone(),
+            fixture.mock_client_adapter.clone(),
             TEST_SEED,
         );
         let forward = PartialEncodedChunkForwardMsg::from_header_and_parts(
@@ -3031,7 +3088,6 @@ mod test {
             .try_process_chunk_parts_and_receipts(
                 &fixture.mock_chunk_header,
                 &mut fixture.chain_store,
-                &mut fixture.rs,
             )
             .unwrap();
         match process_result {

--- a/chain/chunks/src/test_utils.rs
+++ b/chain/chunks/src/test_utils.rs
@@ -1,5 +1,10 @@
-use std::sync::Arc;
+use std::collections::VecDeque;
+use std::sync::{Arc, RwLock};
 
+use actix::MailboxError;
+use futures::future::BoxFuture;
+use futures::FutureExt;
+use near_network::types::MsgRecipient;
 use near_primitives::time::Clock;
 
 use near_chain::test_utils::{KeyValueRuntime, ValidatorSchedule};
@@ -11,7 +16,8 @@ use near_primitives::block::BlockHeader;
 use near_primitives::hash::{self, CryptoHash};
 use near_primitives::merkle;
 use near_primitives::sharding::{
-    ChunkHash, PartialEncodedChunkPart, PartialEncodedChunkV2, ReedSolomonWrapper, ShardChunkHeader,
+    ChunkHash, PartialEncodedChunk, PartialEncodedChunkPart, PartialEncodedChunkV2,
+    ReedSolomonWrapper, ShardChunkHeader,
 };
 use near_primitives::types::NumShards;
 use near_primitives::types::{AccountId, EpochId, ShardId};
@@ -20,6 +26,7 @@ use near_primitives::validator_signer::InMemoryValidatorSigner;
 use near_primitives::version::PROTOCOL_VERSION;
 use near_store::Store;
 
+use crate::client::ShardsManagerResponse;
 use crate::{
     Seal, SealsManager, ShardsManager, ACCEPTING_SEAL_PERIOD_MS, PAST_SEAL_HEIGHT_HORIZON,
 };
@@ -132,6 +139,7 @@ impl SealsManagerTestFixture {
 pub struct ChunkTestFixture {
     pub mock_runtime: Arc<KeyValueRuntime>,
     pub mock_network: Arc<MockPeerManagerAdapter>,
+    pub mock_client_adapter: Arc<MockClientAdapterForShardsManager>,
     pub chain_store: ChainStore,
     pub mock_part_ords: Vec<u64>,
     pub mock_chunk_part_owner: AccountId,
@@ -173,6 +181,7 @@ impl ChunkTestFixture {
 
     pub fn new_with_runtime(orphan_chunk: bool, mock_runtime: Arc<KeyValueRuntime>) -> Self {
         let mock_network = Arc::new(MockPeerManagerAdapter::default());
+        let mock_client_adapter = Arc::new(MockClientAdapterForShardsManager::default());
 
         let data_parts = mock_runtime.num_data_parts();
         let parity_parts = mock_runtime.num_total_parts() - data_parts;
@@ -265,6 +274,7 @@ impl ChunkTestFixture {
         ChunkTestFixture {
             mock_runtime,
             mock_network,
+            mock_client_adapter,
             chain_store,
             mock_part_ords,
             mock_chunk_part_owner,
@@ -282,18 +292,18 @@ impl ChunkTestFixture {
         }
     }
 
-    pub fn make_partial_encoded_chunk(&self, part_ords: &[u64]) -> PartialEncodedChunkV2 {
+    pub fn make_partial_encoded_chunk(&self, part_ords: &[u64]) -> PartialEncodedChunk {
         let parts = part_ords
             .iter()
             .copied()
             .flat_map(|ord| self.mock_chunk_parts.iter().find(|part| part.part_ord == ord))
             .cloned()
             .collect();
-        PartialEncodedChunkV2 {
+        PartialEncodedChunk::V2(PartialEncodedChunkV2 {
             header: self.mock_chunk_header.clone(),
             parts,
             receipts: Vec::new(),
-        }
+        })
     }
 }
 
@@ -327,4 +337,29 @@ fn default_runtime() -> KeyValueRuntime {
     // 12 validators, 3 shards, 4 validators per shard
     let vs = make_validators(12, 0, 3);
     KeyValueRuntime::new_with_validators(store.clone(), vs, 5)
+}
+// Mocked `PeerManager` adapter, has a queue of `PeerManagerMessageRequest` messages.
+#[derive(Default)]
+pub struct MockClientAdapterForShardsManager {
+    pub requests: Arc<RwLock<VecDeque<ShardsManagerResponse>>>,
+}
+
+impl MsgRecipient<ShardsManagerResponse> for MockClientAdapterForShardsManager {
+    fn send(&self, msg: ShardsManagerResponse) -> BoxFuture<'static, Result<(), MailboxError>> {
+        self.do_send(msg);
+        futures::future::ok(()).boxed()
+    }
+
+    fn do_send(&self, msg: ShardsManagerResponse) {
+        self.requests.write().unwrap().push_back(msg);
+    }
+}
+
+impl MockClientAdapterForShardsManager {
+    pub fn pop(&self) -> Option<ShardsManagerResponse> {
+        self.requests.write().unwrap().pop_front()
+    }
+    pub fn pop_most_recent(&self) -> Option<ShardsManagerResponse> {
+        self.requests.write().unwrap().pop_back()
+    }
 }

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -22,6 +22,7 @@ use near_chain::{
     ChainGenesis, DoneApplyChunkCallback, Provenance, RuntimeAdapter,
 };
 use near_chain_configs::ClientConfig;
+use near_chunks::client::ShardsManagerResponse;
 use near_client_primitives::types::{
     Error, GetNetworkInfo, NetworkInfoResponse, ShardSyncDownload, ShardSyncStatus, Status,
     StatusError, StatusSyncInfo, SyncStatus,
@@ -146,11 +147,12 @@ impl ClientActor {
     ) -> Result<Self, Error> {
         let state_parts_arbiter = Arbiter::new();
         let self_addr = ctx.address();
+        let self_addr_clone = self_addr.clone();
         let sync_jobs_actor_addr = SyncJobsActor::start_in_arbiter(
             &state_parts_arbiter.handle(),
             move |ctx: &mut Context<SyncJobsActor>| -> SyncJobsActor {
                 ctx.set_mailbox_capacity(SyncJobsActor::MAILBOX_CAPACITY);
-                SyncJobsActor { client_addr: self_addr }
+                SyncJobsActor { client_addr: self_addr_clone }
             },
         );
         wait_until_genesis(&chain_genesis.time);
@@ -163,6 +165,7 @@ impl ClientActor {
             chain_genesis,
             runtime_adapter,
             network_adapter.clone(),
+            Arc::new(self_addr.clone()),
             validator_signer,
             enable_doomslug,
             rng_seed,
@@ -569,16 +572,12 @@ impl ClientActor {
                     part_request_msg,
                     route_back,
                     self.client.chain.mut_store(),
-                    &mut self.client.rs,
                 );
                 NetworkClientResponses::NoResponse
             }
             NetworkClientMessages::PartialEncodedChunkResponse(response, time) => {
                 PARTIAL_ENCODED_CHUNK_RESPONSE_DELAY.observe(time.elapsed().as_secs_f64());
-                let _ = self.client.process_partial_encoded_chunk_response(
-                    response,
-                    self.get_apply_chunks_done_callback(),
-                );
+                let _ = self.client.process_partial_encoded_chunk_response(response);
                 NetworkClientResponses::NoResponse
             }
             NetworkClientMessages::PartialEncodedChunk(partial_encoded_chunk) => {
@@ -586,17 +585,11 @@ impl ClientActor {
                     partial_encoded_chunk.height_created(),
                     partial_encoded_chunk.shard_id(),
                 );
-                let _ = self.client.process_partial_encoded_chunk(
-                    MaybeValidated::from(partial_encoded_chunk),
-                    self.get_apply_chunks_done_callback(),
-                );
+                let _ = self.client.process_partial_encoded_chunk(partial_encoded_chunk);
                 NetworkClientResponses::NoResponse
             }
             NetworkClientMessages::PartialEncodedChunkForward(forward) => {
-                match self.client.process_partial_encoded_chunk_forward(
-                    forward,
-                    self.get_apply_chunks_done_callback(),
-                ) {
+                match self.client.process_partial_encoded_chunk_forward(forward) {
                     Ok(()) => {}
                     // Unknown chunk is normal if we get parts before the header
                     Err(Error::Chunk(near_chunks::Error::UnknownChunk)) => (),
@@ -1732,10 +1725,7 @@ impl ClientActor {
                             self.get_apply_chunks_done_callback(),
                         ));
 
-                        self.client.process_block_processing_artifact(
-                            block_processing_artifacts,
-                            self.get_apply_chunks_done_callback(),
-                        );
+                        self.client.process_block_processing_artifact(block_processing_artifacts);
 
                         self.client.sync_status = SyncStatus::BodySync {
                             start_height: 0,
@@ -1963,6 +1953,22 @@ impl Handler<StateSplitResponse> for ClientActor {
             sync.set_split_result(msg.shard_id, msg.new_state_roots);
         } else {
             self.client.state_sync.set_split_result(msg.shard_id, msg.new_state_roots);
+        }
+    }
+}
+
+impl Handler<ShardsManagerResponse> for ClientActor {
+    type Result = ();
+
+    fn handle(&mut self, msg: ShardsManagerResponse, _: &mut Self::Context) -> Self::Result {
+        let _span =
+            tracing::debug_span!(target: "client", "handle", handler = "ShardsManagerResponse")
+                .entered();
+        match msg {
+            ShardsManagerResponse::ChunkCompleted(chunk_header) => {
+                self.client
+                    .on_chunk_completed(&chunk_header, self.get_apply_chunks_done_callback());
+            }
         }
     }
 }

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -1,6 +1,8 @@
 use actix::{Actor, Addr, AsyncContext, Context};
 use chrono::DateTime;
 use futures::{future, FutureExt};
+use near_chunks::client::{ClientAdapterForShardsManager, ShardsManagerResponse};
+use near_chunks::test_utils::MockClientAdapterForShardsManager;
 use near_o11y::testonly::TracingCapture;
 use near_primitives::time::Utc;
 use num_rational::Ratio;
@@ -34,7 +36,7 @@ use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::merkle::{merklize, MerklePath, PartialMerkleTree};
 use near_primitives::receipt::Receipt;
 use near_primitives::shard_layout::ShardUId;
-use near_primitives::sharding::{EncodedShardChunk, PartialEncodedChunk, ReedSolomonWrapper};
+use near_primitives::sharding::{EncodedShardChunk, ReedSolomonWrapper};
 use near_primitives::transaction::{Action, FunctionCallAction, SignedTransaction};
 use near_primitives::types::{
     AccountId, Balance, BlockHeight, BlockHeightDelta, EpochId, NumBlocks, NumSeats, ShardId,
@@ -1090,6 +1092,7 @@ pub fn setup_client_with_runtime(
     account_id: Option<AccountId>,
     enable_doomslug: bool,
     network_adapter: Arc<dyn PeerManagerAdapter>,
+    client_adapter: Arc<dyn ClientAdapterForShardsManager>,
     chain_genesis: ChainGenesis,
     runtime_adapter: Arc<dyn RuntimeAdapter>,
     rng_seed: RngSeed,
@@ -1105,6 +1108,7 @@ pub fn setup_client_with_runtime(
         chain_genesis,
         runtime_adapter,
         network_adapter,
+        client_adapter,
         validator_signer,
         enable_doomslug,
         rng_seed,
@@ -1120,6 +1124,7 @@ pub fn setup_client(
     account_id: Option<AccountId>,
     enable_doomslug: bool,
     network_adapter: Arc<dyn PeerManagerAdapter>,
+    client_adapter: Arc<dyn ClientAdapterForShardsManager>,
     chain_genesis: ChainGenesis,
     rng_seed: RngSeed,
 ) -> Client {
@@ -1131,6 +1136,7 @@ pub fn setup_client(
         account_id,
         enable_doomslug,
         network_adapter,
+        client_adapter,
         chain_genesis,
         runtime_adapter,
         rng_seed,
@@ -1143,6 +1149,7 @@ pub struct TestEnv {
     pub chain_genesis: ChainGenesis,
     pub validators: Vec<AccountId>,
     pub network_adapters: Vec<Arc<MockPeerManagerAdapter>>,
+    pub client_adapters: Vec<Arc<MockClientAdapterForShardsManager>>,
     pub clients: Vec<Client>,
     account_to_client_index: HashMap<AccountId, usize>,
     paused_blocks: Arc<Mutex<HashMap<CryptoHash, Arc<OnceCell<()>>>>>,
@@ -1258,12 +1265,16 @@ impl TestEnvBuilder {
         let network_adapters = self
             .network_adapters
             .unwrap_or_else(|| (0..num_clients).map(|_| Arc::new(Default::default())).collect());
+        let client_adapters = (0..num_clients)
+            .map(|_| Arc::new(MockClientAdapterForShardsManager::default()))
+            .collect::<Vec<_>>();
         assert_eq!(clients.len(), network_adapters.len());
         let clients = match self.runtime_adapters {
             None => clients
                 .into_iter()
                 .zip(network_adapters.iter())
-                .map(|(account_id, network_adapter)| {
+                .zip(client_adapters.iter())
+                .map(|((account_id, network_adapter), client_adapter)| {
                     let rng_seed = match seeds.get(&account_id) {
                         Some(seed) => *seed,
                         None => TEST_SEED,
@@ -1276,6 +1287,7 @@ impl TestEnvBuilder {
                         Some(account_id),
                         false,
                         network_adapter.clone(),
+                        client_adapter.clone(),
                         chain_genesis.clone(),
                         rng_seed,
                     )
@@ -1286,8 +1298,8 @@ impl TestEnvBuilder {
                 clients
                     .into_iter()
                     .zip((&network_adapters).iter())
-                    .zip(runtime_adapters.into_iter())
-                    .map(|((account_id, network_adapter), runtime_adapter)| {
+                    .zip(runtime_adapters.into_iter().zip(client_adapters.iter()))
+                    .map(|((account_id, network_adapter), (runtime_adapter, client_adapter))| {
                         let rng_seed = match seeds.get(&account_id) {
                             Some(seed) => *seed,
                             None => TEST_SEED,
@@ -1297,6 +1309,7 @@ impl TestEnvBuilder {
                             Some(account_id),
                             false,
                             network_adapter.clone(),
+                            client_adapter.clone(),
                             chain_genesis.clone(),
                             runtime_adapter,
                             rng_seed,
@@ -1310,6 +1323,7 @@ impl TestEnvBuilder {
             chain_genesis,
             validators,
             network_adapters,
+            client_adapters,
             clients,
             account_to_client_index: self
                 .clients
@@ -1398,10 +1412,7 @@ impl TestEnv {
                 ) = request
                 {
                     self.client(&account_id)
-                        .process_partial_encoded_chunk(
-                            MaybeValidated::from(PartialEncodedChunk::from(partial_encoded_chunk)),
-                            Arc::new(|_| {}),
-                        )
+                        .process_partial_encoded_chunk(partial_encoded_chunk.into())
                         .unwrap();
                 }
             }
@@ -1428,9 +1439,7 @@ impl TestEnv {
         {
             let target_id = self.account_to_client_index[&target.account_id.unwrap()];
             let response = self.get_partial_encoded_chunk_response(target_id, request);
-            self.clients[id]
-                .process_partial_encoded_chunk_response(response, Arc::new(|_| {}))
-                .unwrap();
+            self.clients[id].process_partial_encoded_chunk_response(response).unwrap();
         } else {
             panic!("The request is not a PartialEncodedChunk request {:?}", request);
         }
@@ -1446,7 +1455,6 @@ impl TestEnv {
             request,
             CryptoHash::default(),
             client.chain.mut_store(),
-            &mut client.rs,
         );
         let response = self.network_adapters[id].pop_most_recent().unwrap();
         if let PeerManagerMessageRequest::NetworkRequests(
@@ -1459,6 +1467,25 @@ impl TestEnv {
                 "did not find PartialEncodedChunkResponse from the network queue {:?}",
                 response
             );
+        }
+    }
+
+    pub fn process_shards_manager_responses(&mut self, id: usize) {
+        while let Some(msg) = self.client_adapters[id].pop() {
+            match msg {
+                ShardsManagerResponse::ChunkCompleted(chunk_header) => {
+                    self.clients[id].on_chunk_completed(&chunk_header, Arc::new(|_| {}));
+                }
+            }
+        }
+    }
+
+    pub fn process_shards_manager_responses_and_finish_processing_blocks(&mut self, idx: usize) {
+        loop {
+            self.process_shards_manager_responses(idx);
+            if self.clients[idx].finish_blocks_in_processing().is_empty() {
+                return;
+            }
         }
     }
 
@@ -1577,6 +1604,7 @@ impl TestEnv {
             Some(self.get_client_id(idx).clone()),
             false,
             self.network_adapters[idx].clone(),
+            self.client_adapters[idx].clone(),
             self.chain_genesis.clone(),
             rng_seed,
         )

--- a/chain/client/src/tests/chunks_management.rs
+++ b/chain/client/src/tests/chunks_management.rs
@@ -6,7 +6,6 @@ use near_network::types::NetworkRequests;
 use near_network_primitives::types::PartialEncodedChunkRequestMsg;
 use near_o11y::testonly::init_integration_logger;
 use near_primitives::hash::CryptoHash;
-use near_primitives::sharding::ReedSolomonWrapper;
 
 #[test]
 fn test_request_chunk_restart() {
@@ -23,14 +22,10 @@ fn test_request_chunk_restart() {
         tracking_shards: HashSet::default(),
     };
     let client = &mut env.clients[0];
-    let num_total_parts = client.runtime_adapter.num_total_parts();
-    let num_data_parts = client.runtime_adapter.num_data_parts();
-    let mut rs = ReedSolomonWrapper::new(num_data_parts, num_total_parts - num_data_parts);
     client.shards_mgr.process_partial_encoded_chunk_request(
         request.clone(),
         CryptoHash::default(),
         client.chain.mut_store(),
-        &mut rs,
     );
     assert!(env.network_adapters[0].pop().is_some());
 
@@ -40,7 +35,6 @@ fn test_request_chunk_restart() {
         request,
         CryptoHash::default(),
         client.chain.mut_store(),
-        &mut rs,
     );
     let response = env.network_adapters[0].pop().unwrap().as_network_requests();
 

--- a/integration-tests/src/tests/client/challenges.rs
+++ b/integration-tests/src/tests/client/challenges.rs
@@ -24,7 +24,6 @@ use near_primitives::sharding::{EncodedShardChunk, ReedSolomonWrapper};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{AccountId, EpochId};
-use near_primitives::utils::MaybeValidated;
 use near_primitives::validator_signer::InMemoryValidatorSigner;
 use near_primitives::version::PROTOCOL_VERSION;
 use near_store::test_utils::create_test_store;
@@ -539,12 +538,7 @@ fn test_receive_invalid_chunk_as_chunk_producer() {
         one_part_receipt_proofs,
         &vec![merkle_paths[0].clone()],
     );
-    assert!(env.clients[1]
-        .process_partial_encoded_chunk(
-            MaybeValidated::from(partial_encoded_chunk),
-            Arc::new(|_| {})
-        )
-        .is_ok());
+    assert!(env.clients[1].process_partial_encoded_chunk(partial_encoded_chunk).is_ok());
     env.process_block(1, block, Provenance::NONE);
 
     // At this point we should create a challenge and send it out.

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -8,6 +8,7 @@ use actix::System;
 use assert_matches::assert_matches;
 use futures::{future, FutureExt};
 use near_chain::test_utils::ValidatorSchedule;
+use near_chunks::test_utils::MockClientAdapterForShardsManager;
 use near_primitives::num_rational::{Ratio, Rational32};
 
 use near_actix_test_utils::run_actix;
@@ -1064,6 +1065,7 @@ fn test_time_attack() {
     init_test_logger();
     let store = create_test_store();
     let network_adapter = Arc::new(MockPeerManagerAdapter::default());
+    let client_adapter = Arc::new(MockClientAdapterForShardsManager::default());
     let chain_genesis = ChainGenesis::test();
     let vs =
         ValidatorSchedule::new().block_producers_per_epoch(vec![vec!["test1".parse().unwrap()]]);
@@ -1073,6 +1075,7 @@ fn test_time_attack() {
         Some("test1".parse().unwrap()),
         false,
         network_adapter,
+        client_adapter,
         chain_genesis,
         TEST_SEED,
     );
@@ -1097,6 +1100,7 @@ fn test_invalid_approvals() {
     init_test_logger();
     let store = create_test_store();
     let network_adapter = Arc::new(MockPeerManagerAdapter::default());
+    let client_adapter = Arc::new(MockClientAdapterForShardsManager::default());
     let chain_genesis = ChainGenesis::test();
     let vs =
         ValidatorSchedule::new().block_producers_per_epoch(vec![vec!["test1".parse().unwrap()]]);
@@ -1106,6 +1110,7 @@ fn test_invalid_approvals() {
         Some("test1".parse().unwrap()),
         false,
         network_adapter,
+        client_adapter,
         chain_genesis,
         TEST_SEED,
     );
@@ -1145,6 +1150,7 @@ fn test_invalid_gas_price() {
     init_test_logger();
     let store = create_test_store();
     let network_adapter = Arc::new(MockPeerManagerAdapter::default());
+    let client_adapter = Arc::new(MockClientAdapterForShardsManager::default());
     let mut chain_genesis = ChainGenesis::test();
     chain_genesis.min_gas_price = 100;
     let vs =
@@ -1155,6 +1161,7 @@ fn test_invalid_gas_price() {
         Some("test1".parse().unwrap()),
         false,
         network_adapter,
+        client_adapter,
         chain_genesis,
         TEST_SEED,
     );
@@ -1314,6 +1321,7 @@ fn test_bad_chunk_mask() {
                 Some(account_id.clone()),
                 false,
                 Arc::new(MockPeerManagerAdapter::default()),
+                Arc::new(MockClientAdapterForShardsManager::default()),
                 chain_genesis.clone(),
                 TEST_SEED,
             )
@@ -1920,6 +1928,7 @@ fn test_incorrect_validator_key_produce_block() {
         chain_genesis,
         runtime_adapter,
         Arc::new(MockPeerManagerAdapter::default()),
+        Arc::new(MockClientAdapterForShardsManager::default()),
         Some(signer),
         false,
         TEST_SEED,

--- a/integration-tests/src/tests/client/runtimes.rs
+++ b/integration-tests/src/tests/client/runtimes.rs
@@ -120,50 +120,51 @@ fn test_process_partial_encoded_chunk_with_missing_block() {
     let client = &mut env.clients[0];
     let chunk_producer = ChunkTestFixture::default();
     let mut mock_chunk = chunk_producer.make_partial_encoded_chunk(&[0]);
-    // change the prev_block to some unknown block
-    match &mut mock_chunk.header {
-        ShardChunkHeader::V1(ref mut header) => {
-            header.inner.prev_block_hash = hash(b"some_prev_block");
-            header.init();
-        }
-        ShardChunkHeader::V2(ref mut header) => {
-            header.inner.prev_block_hash = hash(b"some_prev_block");
-            header.init();
-        }
-        ShardChunkHeader::V3(header) => {
-            match &mut header.inner {
-                ShardChunkHeaderInner::V1(inner) => {
-                    inner.prev_block_hash = hash(b"some_prev_block")
+    match &mut mock_chunk {
+        PartialEncodedChunk::V2(mock_chunk) => {
+            // change the prev_block to some unknown block
+            match &mut mock_chunk.header {
+                ShardChunkHeader::V1(ref mut header) => {
+                    header.inner.prev_block_hash = hash(b"some_prev_block");
+                    header.init();
                 }
-                ShardChunkHeaderInner::V2(inner) => {
-                    inner.prev_block_hash = hash(b"some_prev_block")
+                ShardChunkHeader::V2(ref mut header) => {
+                    header.inner.prev_block_hash = hash(b"some_prev_block");
+                    header.init();
+                }
+                ShardChunkHeader::V3(header) => {
+                    match &mut header.inner {
+                        ShardChunkHeaderInner::V1(inner) => {
+                            inner.prev_block_hash = hash(b"some_prev_block")
+                        }
+                        ShardChunkHeaderInner::V2(inner) => {
+                            inner.prev_block_hash = hash(b"some_prev_block")
+                        }
+                    }
+                    header.init();
                 }
             }
-            header.init();
         }
+        _ => unreachable!(),
     }
 
     let mock_forward = PartialEncodedChunkForwardMsg::from_header_and_parts(
-        &mock_chunk.header,
-        mock_chunk.parts.clone(),
+        &mock_chunk.cloned_header(),
+        mock_chunk.parts().to_vec(),
     );
 
     // process_partial_encoded_chunk should return Ok(NeedBlock) if the chunk is
     // based on a missing block.
     let result = client.shards_mgr.process_partial_encoded_chunk(
-        MaybeValidated::from(&mock_chunk),
+        MaybeValidated::from(mock_chunk.clone()),
         None,
         client.chain.mut_store(),
-        &mut client.rs,
     );
     assert_matches!(result, Ok(ProcessPartialEncodedChunkResult::NeedBlock));
 
     // Client::process_partial_encoded_chunk should not return an error
     // if the chunk is based on a missing block.
-    let result = client.process_partial_encoded_chunk(
-        MaybeValidated::from(PartialEncodedChunk::V2(mock_chunk)),
-        Arc::new(|_| {}),
-    );
+    let result = client.process_partial_encoded_chunk(mock_chunk);
     match result {
         Ok(()) => {
             let accepted_blocks = client.finish_blocks_in_processing();
@@ -174,7 +175,7 @@ fn test_process_partial_encoded_chunk_with_missing_block() {
 
     // process_partial_encoded_chunk_forward should return UnknownChunk if it is based on a
     // a missing block.
-    let result = client.process_partial_encoded_chunk_forward(mock_forward, Arc::new(|_| {}));
+    let result = client.process_partial_encoded_chunk_forward(mock_forward);
     assert_matches!(
         result.unwrap_err(),
         near_client_primitives::types::Error::Chunk(near_chunks::Error::UnknownChunk)

--- a/integration-tests/src/tests/client/shards_manager.rs
+++ b/integration-tests/src/tests/client/shards_manager.rs
@@ -35,7 +35,7 @@ fn test_prepare_partial_encoded_chunk_response() {
     // will be served from an in-memory cache.
     let request = PartialEncodedChunkRequestMsg {
         chunk_hash: chunk_hash.clone(),
-        part_ords: (0..(env.clients[0].rs.total_shard_count() as u64)).collect(),
+        part_ords: (0..env.clients[0].runtime_adapter.num_total_parts() as u64).collect(),
         tracking_shards: Some(0u64).into_iter().collect(),
     };
     let res = Some(env.get_partial_encoded_chunk_response(0, request.clone()));
@@ -52,11 +52,9 @@ fn test_prepare_partial_encoded_chunk_response() {
     // response from ShardChunk object.
     let chunk = env.clients[0].chain.mut_store().get_chunk(&chunk_hash).unwrap();
     let client = &mut env.clients[0];
-    let res_from_chunk = client.shards_mgr.prepare_partial_encoded_chunk_response_from_chunk(
-        request.clone(),
-        &mut client.rs,
-        &chunk,
-    );
+    let res_from_chunk = client
+        .shards_mgr
+        .prepare_partial_encoded_chunk_response_from_chunk(request.clone(), &chunk);
 
     assert_eq!(res, res_from_partial);
     assert_eq!(res, res_from_chunk);


### PR DESCRIPTION
* Move handling of chunk completion to a ClientActor message (ShardsManagerResponse), because this will eventually be async. So no more passing DoneApplyingChunksCallback. Add support of this message to TestEnv; tests that rely on chunk part messaging now need to manually handle such messages (because the TestEnv doesn't have real actors). Fixed tests that need this.
* Move ReedSolomonWrapper inside ShardsManager. However Client still has a copy because it actually needs to encode the parts to produce a chunk - at least the merkle root is needed.
* Does not touch ChainStore yet. Leaving that till later.
* Minor refactoring to push chunk part processing logic from Client into ShardsManager (otherwise Client needs to fetch header and stuff).