### PR TITLE
network: avoid double Arc::clone in NetworkState

### DIFF
--- a/chain/network/src/peer_manager/network_state.rs
+++ b/chain/network/src/peer_manager/network_state.rs
@@ -113,7 +113,7 @@ impl NetworkState {
     /// It will fail (and log) if we have too many connections already,
     /// or if the peer drops the connection in the meantime.
     fn spawn_peer_actor(
-        self: &Arc<Self>,
+        self: Arc<Self>,
         clock: &time::Clock,
         stream: TcpStream,
         stream_cfg: StreamConfig,
@@ -123,7 +123,7 @@ impl NetworkState {
         };
     }
 
-    pub async fn spawn_inbound(self: &Arc<Self>, clock: &time::Clock, stream: TcpStream) {
+    pub async fn spawn_inbound(self: Arc<Self>, clock: &time::Clock, stream: TcpStream) {
         self.spawn_peer_actor(clock, stream, StreamConfig::Inbound);
     }
 

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -216,7 +216,7 @@ impl Actor for PeerManagerActor {
                             // we would like to exchange set of connected peers even without establishing
                             // a proper connection.
                             debug!(target: "network", from = ?client_addr, "got new connection");
-                            state.spawn_inbound(&clock, conn).await;
+                            state.clone().spawn_inbound(&clock, conn).await;
                         }
                     }
                 }


### PR DESCRIPTION
spawn_outbound takes self as `Arc<Self>` but then calls
spawn_peer_actor passing it as `&Arc<Self>`.  The latter then clones
the Arc.  Meanwhile, Arc owned by spawn_outbound gets dropped.  Fix by
changing all the methods to take an Arc and moving cloning to the call
sites.
