### PR TITLE
crypto: make signature module public

### DIFF
--- a/core/crypto/src/lib.rs
+++ b/core/crypto/src/lib.rs
@@ -17,7 +17,7 @@ mod errors;
 pub mod key_conversion;
 mod key_file;
 pub mod randomness;
-mod signature;
+pub mod signature;
 mod signer;
 mod test_utils;
 pub mod vrf;


### PR DESCRIPTION
Our internal application uses the indexer, and converts the received streamer message into our internal block representation.   In order to take decisions on how to process the signature, we need to have access to the structures and definitions in the crypto/signature module.