### PR TITLE
core: replace ShardChunkHeader::version_range by valid_for

### DIFF
--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -1556,7 +1556,7 @@ impl ShardsManager {
 
         // 2. check protocol version
         let protocol_version = self.runtime_adapter.get_epoch_protocol_version(&epoch_id)?;
-        if !header.version_range().contains(protocol_version) {
+        if !header.version_range().contains(&protocol_version) {
             return if epoch_id_confirmed {
                 Err(Error::InvalidChunkHeader)
             } else {

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -1556,14 +1556,13 @@ impl ShardsManager {
 
         // 2. check protocol version
         let protocol_version = self.runtime_adapter.get_epoch_protocol_version(&epoch_id)?;
-        if !header.version_range().contains(&protocol_version) {
-            return if epoch_id_confirmed {
-                Err(Error::InvalidChunkHeader)
-            } else {
-                Err(DBNotFoundErr(format!("block {:?}", header.prev_block_hash())).into())
-            };
+        if header.valid_for(protocol_version) {
+            Ok(())
+        } else if epoch_id_confirmed {
+            Err(Error::InvalidChunkHeader)
+        } else {
+            Err(DBNotFoundErr(format!("block {:?}", header.prev_block_hash())).into())
         }
-        Ok(())
     }
 
     /// Inserts the header if it is not already known, and process the forwarded chunk parts cached

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -403,7 +403,9 @@ impl ShardChunkHeader {
             ProtocolFeature::BlockHeaderV3.protocol_version();
         match &self {
             ShardChunkHeader::V1(_) => version < SHARD_CHUNK_HEADER_UPGRADE_VERSION,
-            ShardChunkHeader::V2(_) => SHARD_CHUNK_HEADER_UPGRADE_VERSION <= version && version < BLOCK_HEADER_V3_VERSION,
+            ShardChunkHeader::V2(_) => {
+                SHARD_CHUNK_HEADER_UPGRADE_VERSION <= version && version < BLOCK_HEADER_V3_VERSION
+            }
             ShardChunkHeader::V3(_) => BLOCK_HEADER_V3_VERSION <= version,
         }
     }

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -397,16 +397,14 @@ impl ShardChunkHeader {
         }
     }
 
-    /// Returns the range of `ProtocolVersion`s where this variant of the
-    /// message is accepted.  For the newest variant the upper limit is the
-    /// maximum protocol version.
-    pub fn version_range(&self) -> std::ops::Range<ProtocolVersion> {
+    /// Returns whether the header is valid for given `ProtocolVersion`.
+    pub fn valid_for(&self, version: ProtocolVersion) -> bool {
         const BLOCK_HEADER_V3_VERSION: ProtocolVersion =
             ProtocolFeature::BlockHeaderV3.protocol_version();
         match &self {
-            ShardChunkHeader::V1(_) => 0..SHARD_CHUNK_HEADER_UPGRADE_VERSION,
-            ShardChunkHeader::V2(_) => SHARD_CHUNK_HEADER_UPGRADE_VERSION..BLOCK_HEADER_V3_VERSION,
-            ShardChunkHeader::V3(_) => BLOCK_HEADER_V3_VERSION..ProtocolVersion::MAX,
+            ShardChunkHeader::V1(_) => version <= SHARD_CHUNK_HEADER_UPGRADE_VERSION,
+            ShardChunkHeader::V2(_) => SHARD_CHUNK_HEADER_UPGRADE_VERSION <= version && version <= BLOCK_HEADER_V3_VERSION,
+            ShardChunkHeader::V3(_) => BLOCK_HEADER_V3_VERSION <= version,
         }
     }
 }
@@ -534,13 +532,11 @@ impl PartialEncodedChunk {
         }
     }
 
-    /// Returns the range of `ProtocolVersion`s where this variant of the
-    /// message is accepted.  For the newest variant the upper limit is the
-    /// maximum protocol version.
-    pub fn version_range(&self) -> std::ops::Range<ProtocolVersion> {
+    /// Returns whether the chenk is valid for given `ProtocolVersion`.
+    pub fn version_range(&self, version: ProtocolVersion) -> bool {
         match &self {
-            PartialEncodedChunk::V1(_) => 0..SHARD_CHUNK_HEADER_UPGRADE_VERSION,
-            PartialEncodedChunk::V2(_) => SHARD_CHUNK_HEADER_UPGRADE_VERSION..ProtocolVersion::MAX,
+            PartialEncodedChunk::V1(_) => version <= SHARD_CHUNK_HEADER_UPGRADE_VERSION,
+            PartialEncodedChunk::V2(_) => SHARD_CHUNK_HEADER_UPGRADE_VERSION <= version,
         }
     }
 

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -51,21 +51,6 @@ pub const SHARD_CHUNK_HEADER_UPGRADE_VERSION: ProtocolVersion = 41;
 /// Updates the way receipt ID is constructed to use current block hash instead of last block hash
 pub const CREATE_RECEIPT_ID_SWITCH_TO_CURRENT_BLOCK_VERSION: ProtocolVersion = 42;
 
-pub struct ProtocolVersionRange {
-    lower: ProtocolVersion,
-    upper: Option<ProtocolVersion>,
-}
-
-impl ProtocolVersionRange {
-    pub fn new(lower: ProtocolVersion, upper: Option<ProtocolVersion>) -> Self {
-        Self { lower, upper }
-    }
-
-    pub fn contains(&self, version: ProtocolVersion) -> bool {
-        self.lower <= version && self.upper.map_or(true, |upper| version < upper)
-    }
-}
-
 pub fn is_implicit_account_creation_enabled(protocol_version: ProtocolVersion) -> bool {
     protocol_version >= IMPLICIT_ACCOUNT_CREATION_PROTOCOL_VERSION
 }


### PR DESCRIPTION
Replace ShardChunkHeader::version_range and
PartialEncodedChunk::version_range methods with valid_for method which
is simpler interface for the call site and which allows us to get rid
of custom ProtocolVersionRange type.

Note that, yes, PartialEncodedChunk::valid_for is actually unused.
I’m leaving it in though.  Perhaps it’s worth keeping the record of
when each version of the PartialEncodedChunk was introduced?
