### PR TITLE
store: deprecate GCCount column

### DIFF
--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -18,7 +18,7 @@ use near_primitives::sharding::{ChunkHash, ShardChunk, StateSyncInfo};
 use near_primitives::syncing::{ShardStateSyncResponseHeader, StateHeaderKey, StatePartKey};
 use near_primitives::transaction::ExecutionOutcomeWithIdAndProof;
 use near_primitives::types::chunk_extra::ChunkExtra;
-use near_primitives::types::{AccountId, BlockHeight, EpochId, GCCount};
+use near_primitives::types::{AccountId, BlockHeight, EpochId};
 use near_primitives::utils::get_block_shard_id_rev;
 use near_store::db::refcount;
 use near_store::{DBCol, Store, TrieChanges};
@@ -37,12 +37,6 @@ pub struct StoreValidatorCache {
     chunk_tail: BlockHeight,
     block_heights_less_tail: Vec<CryptoHash>,
 
-    /// For each database column, count of how many times that colum was garbage
-    /// collected.  The map is updated by [`validate::gc_col_count`] function
-    /// called from [`StoreValidator::validate_col`] method and final validation
-    /// on it is performed by [`validate::gc_col_count_final`] function.
-    gc_count: enum_map::EnumMap<DBCol, u64>,
-
     tx_refcount: HashMap<CryptoHash, u64>,
     receipt_refcount: HashMap<CryptoHash, u64>,
     block_refcount: HashMap<CryptoHash, u64>,
@@ -57,7 +51,6 @@ impl StoreValidatorCache {
             tail: 0,
             chunk_tail: 0,
             block_heights_less_tail: vec![],
-            gc_count: Default::default(),
             tx_refcount: HashMap::new(),
             receipt_refcount: HashMap::new(),
             block_refcount: HashMap::new(),
@@ -113,20 +106,6 @@ impl StoreValidator {
     }
     pub fn is_failed(&self) -> bool {
         self.tests == 0 || self.errors.len() > 0
-    }
-    pub fn get_gc_counters(&self) -> Vec<(String, u64)> {
-        let mut res = vec![];
-        for col in DBCol::iter() {
-            if col.is_gc() && self.inner.gc_count[col] == 0 {
-                if col.is_gc_optional() {
-                    res.push((format!("{col} (skipping is acceptable)"), self.inner.gc_count[col]))
-                } else {
-                    res.push((col.to_string(), self.inner.gc_count[col]))
-                }
-            }
-        }
-        res.sort();
-        res
     }
     pub fn num_failed(&self) -> u64 {
         self.errors.len() as u64
@@ -301,11 +280,6 @@ impl StoreValidator {
                         self.check(&validate::epoch_validity, &epoch_id, &epoch_info, col);
                     }
                 }
-                DBCol::GCCount => {
-                    let col = DBCol::try_from_slice(key_ref)?;
-                    let count = GCCount::try_from_slice(value_ref)?;
-                    self.check(&validate::gc_col_count, &col, &count, col);
-                }
                 DBCol::Transactions => {
                     let (_value, rc) = refcount::decode_value_with_rc(value_ref);
                     let tx_hash = CryptoHash::try_from(key_ref)?;
@@ -374,10 +348,6 @@ impl StoreValidator {
         // There is no more than one Block which Height is lower than Tail and not equal to Genesis
         if let Err(e) = validate::block_height_cmp_tail_final(self) {
             self.process_error(e, "TAIL", DBCol::BlockMisc)
-        }
-        // Check GC counters
-        if let Err(_) = validate::gc_col_count_final(self) {
-            // TODO #2861
         }
         // Check that all refs are counted
         if let Err(e) = validate::tx_refcount_final(self) {

--- a/chain/chain/src/store_validator/validate.rs
+++ b/chain/chain/src/store_validator/validate.rs
@@ -1,7 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
 use borsh::BorshSerialize;
-use strum::IntoEnumIterator;
 use thiserror::Error;
 
 use near_primitives::block::{Block, BlockHeader, Tip};
@@ -787,22 +786,6 @@ pub(crate) fn epoch_validity(
     Ok(())
 }
 
-/// Validates values in [`DBCol::GCCount`] and updates [`StoreValidator`]’s copy
-/// of it.  Returns an error if a non-zero value is encountered for a column
-/// which is not gc.
-pub(crate) fn gc_col_count(
-    sv: &mut StoreValidator,
-    col: &DBCol,
-    count: &u64,
-) -> Result<(), StoreValidatorError> {
-    if col.is_gc() {
-        sv.inner.gc_count[*col] = *count;
-    } else if *count > 0 {
-        err!("DBCol is cleared by mistake")
-    }
-    Ok(())
-}
-
 pub(crate) fn tx_refcount(
     sv: &mut StoreValidator,
     tx_hash: &CryptoHash,
@@ -903,26 +886,6 @@ pub(crate) fn block_height_cmp_tail_final(
         err!("Found {:?} Blocks with height lower than Tail, {:?}", len, blocks)
     }
     Ok(())
-}
-
-/// Performs final validation on values in [`DBCol::GCCount`] values.  Returns
-/// error if some but not all gc columns have been garbage collected.  That is,
-/// valid state is if either no columns are garbage collected or all gc columns
-/// are garbage collected.
-pub(crate) fn gc_col_count_final(sv: &mut StoreValidator) -> Result<(), StoreValidatorError> {
-    // Number of columns which have had at least one garbage collection.
-    let gced_count = sv.inner.gc_count.values().filter(|n| **n != 0).count();
-    // Number of GC columns.
-    let gc_colum_count = DBCol::iter().filter(DBCol::is_gc).count();
-    // Either no columns were GCed or all GC columns were GCed.
-    if gced_count == 0 || gced_count == gc_colum_count {
-        return Ok(());
-    }
-    // TODO #2861 build a graph of dependencies or make it better in another way
-    err!(
-        "Suspicious {gced_count} columns were GCed but {gc_colum_count} \
-         columns are GC columns, look into GC values manually"
-    )
 }
 
 pub(crate) fn tx_refcount_final(sv: &mut StoreValidator) -> Result<(), StoreValidatorError> {

--- a/core/primitives-core/src/types.rs
+++ b/core/primitives-core/src/types.rs
@@ -50,8 +50,6 @@ pub type NumSeats = u64;
 /// Block height delta that measures the difference between `BlockHeight`s.
 pub type BlockHeightDelta = u64;
 
-pub type GCCount = u64;
-
 pub type ReceiptIndex = usize;
 pub type PromiseId = Vec<ReceiptIndex>;
 

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -1,4 +1,3 @@
-use borsh::{BorshDeserialize, BorshSerialize};
 use std::fmt;
 
 /// This enum holds the information about the columns that we use within the
@@ -17,17 +16,7 @@ use std::fmt;
 /// deprecation.  Make sure to add `#[strum(serialize = "OriginalName")]`
 /// attribute in front of the variant when you deprecate a column.
 #[derive(
-    PartialEq,
-    Copy,
-    Clone,
-    Debug,
-    Hash,
-    Eq,
-    BorshDeserialize,
-    BorshSerialize,
-    enum_map::Enum,
-    strum::EnumIter,
-    strum::IntoStaticStr,
+    PartialEq, Copy, Clone, Debug, Hash, Eq, enum_map::Enum, strum::EnumIter, strum::IntoStaticStr,
 )]
 pub enum DBCol {
     /// Column to indicate which version of database this is.
@@ -214,10 +203,9 @@ pub enum DBCol {
     /// - *Rows*: ordinal (u64)
     /// - *Column type*: BlockHash (CryptoHash)
     BlockOrdinal,
-    /// GC Count for each column - number of times we did the GarbageCollection on the column.
-    /// - *Rows*: column id (byte)
-    /// - *Column type*: u64
-    GCCount,
+    /// Deprecated.
+    #[strum(serialize = "GCCount")]
+    _GCCount,
     /// All Outcome ids by block hash and shard id. For each shard it is ordered by execution order.
     /// TODO: seems that it has only 'transaction ids' there (not sure if intentional)
     /// - *Rows*: BlockShardId (BlockHash || ShardId) - 40 bytes
@@ -340,42 +328,6 @@ impl DBCol {
             _ => false,
         }
     }
-
-    /// Whether this column is garbage collected.
-    pub const fn is_gc(&self) -> bool {
-        match self {
-            DBCol::DbVersion  // DB version is unrelated to GC
-            | DBCol::BlockMisc
-            // TODO #3488 remove
-            | DBCol::BlockHeader  // header sync needs headers
-            | DBCol::GCCount      // GC count it self isn't GCed
-            | DBCol::BlockHeight  // block sync needs it + genesis should be accessible
-            | DBCol::Peers        // Peers is unrelated to GC
-            | DBCol::BlockMerkleTree
-            | DBCol::AccountAnnouncements
-            | DBCol::EpochLightClientBlocks
-            | DBCol::PeerComponent  // Peer related info doesn't GC
-            | DBCol::LastComponentNonce
-            | DBCol::ComponentEdges
-            | DBCol::BlockOrdinal
-            | DBCol::EpochInfo           // https://github.com/nearprotocol/nearcore/pull/2952
-            | DBCol::EpochValidatorInfo  // https://github.com/nearprotocol/nearcore/pull/2952
-            | DBCol::EpochStart          // https://github.com/nearprotocol/nearcore/pull/2952
-            | DBCol::CachedContractCode => false,
-            _ => true,
-        }
-    }
-
-    /// Whether GC for this column is possible, but optional.
-    pub const fn is_gc_optional(&self) -> bool {
-        match self {
-            // A node may never restarted
-            DBCol::StateHeaders |
-            // True until #2515
-            DBCol::StateParts => true,
-            _ => false,
-        }
-    }
 }
 
 impl fmt::Display for DBCol {
@@ -389,9 +341,6 @@ fn column_props_sanity() {
     use strum::IntoEnumIterator;
 
     for col in DBCol::iter() {
-        if col.is_gc_optional() {
-            assert!(col.is_gc(), "{col}")
-        }
         // Check that rc and write_once are mutually exclusive.
         assert!((col.is_rc() as u32) + (col.is_insert_only() as u32) <= 1, "{col}")
     }

--- a/core/store/src/db/rocksdb.rs
+++ b/core/store/src/db/rocksdb.rs
@@ -644,7 +644,7 @@ fn col_name(col: DBCol) -> &'static str {
         DBCol::BlockMerkleTree => "col38",
         DBCol::ChunkHashesByHeight => "col39",
         DBCol::BlockOrdinal => "col40",
-        DBCol::GCCount => "col41",
+        DBCol::_GCCount => "col41",
         DBCol::OutcomeIds => "col42",
         DBCol::_TransactionRefCount => "col43",
         DBCol::ProcessedBlockHeights => "col44",

--- a/test-utils/store-validator/src/main.rs
+++ b/test-utils/store-validator/src/main.rs
@@ -69,8 +69,4 @@ fn main() {
     } else {
         println!("{}", Green.bold().paint("No errors found"));
     }
-    let gc_counters = store_validator.get_gc_counters();
-    for (col, count) in gc_counters {
-        println!("{} {}", White.bold().paint(col), count);
-    }
 }


### PR DESCRIPTION
We’re writing to the GCCount column but never read from it in
production. It’s only ever used in store validator but even there zero
values in garbage-collected columns results in the column being
printed at the end of the validation rather than any kind of failure.
So really, I’d argue the column doesn’t serve any purpose.

Removing the column not only simplifies the code but also allows us to
get rid of borsh serialisation of the DBCol enum.  This in turn means
that now the variants in the enum can be rearranged or deleted without
breaking things.

Note that I’m not clearing out this column in this commit.  I’m
planning to introduce an unrelated database migration soon and will do
the clearing then.
