### PR TITLE
store: avoid prefix checks in TrieUpdateIterator by using proper bounds

### DIFF
--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -191,9 +191,26 @@ impl<'a> Iterator for MergeIter<'a> {
 }
 
 pub struct TrieUpdateIterator<'a> {
-    prefix: Vec<u8>,
     trie_iter: Peekable<TrieIterator<'a>>,
     overlay_iter: Peekable<MergeIter<'a>>,
+}
+
+/// Returns an end bound for a range which corresponds to all values with
+/// a given prefix.
+///
+/// In other words, the smallest value larger than the `prefix` which does not
+/// start with the `prefix`.  If no such value exists, returns `None`.
+fn make_prefix_range_end_bound(prefix: &[u8]) -> Option<Vec<u8>> {
+    let ffs = prefix.iter().rev().take_while(|&&byte| byte == u8::MAX).count();
+    let next = &prefix[..(prefix.len() - ffs)];
+    if next.is_empty() {
+        // Prefix consisted of \xff bytes.  There is no key that follows it.
+        None
+    } else {
+        let mut next = next.to_vec();
+        *next.last_mut().unwrap() += 1;
+        Some(next)
+    }
 }
 
 impl<'a> TrieUpdateIterator<'a> {
@@ -201,7 +218,15 @@ impl<'a> TrieUpdateIterator<'a> {
     pub fn new(state_update: &'a TrieUpdate, prefix: &[u8]) -> Result<Self, StorageError> {
         let mut trie_iter = state_update.trie.iter()?;
         trie_iter.seek_prefix(prefix)?;
-        let range = (Bound::Included(prefix), Bound::Unbounded);
+
+        let end_bound = make_prefix_range_end_bound(prefix);
+        let end_bound = if let Some(end_bound) = &end_bound {
+            Bound::Excluded(end_bound.as_slice())
+        } else {
+            Bound::Unbounded
+        };
+        let range = (Bound::Included(prefix), end_bound);
+
         let committed_iter = state_update.committed.range::<[u8], _>(range).map(
             |(raw_key, changes_with_trie_key)| {
                 let key = raw_key.as_slice();
@@ -224,11 +249,7 @@ impl<'a> TrieUpdateIterator<'a> {
             right: (Box::new(prospective_iter) as Box<dyn Iterator<Item = _>>).peekable(),
         }
         .peekable();
-        Ok(TrieUpdateIterator {
-            prefix: prefix.to_vec(),
-            trie_iter: trie_iter.peekable(),
-            overlay_iter,
-        })
+        Ok(TrieUpdateIterator { trie_iter: trie_iter.peekable(), overlay_iter })
     }
 }
 
@@ -236,10 +257,7 @@ impl<'a> Iterator for TrieUpdateIterator<'a> {
     type Item = Result<Vec<u8>, StorageError>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let stop_cond = |key: &[u8], prefix: &[u8]| {
-            // TODO(mina86): Figure out if starts_with check is still necessary.
-            !key.starts_with(prefix)
-        };
+        #[derive(Eq, PartialEq)]
         enum Ordering {
             Trie,
             Overlay,
@@ -247,63 +265,43 @@ impl<'a> Iterator for TrieUpdateIterator<'a> {
         }
         // Usually one iteration, unless need to skip None values in prospective / committed.
         loop {
-            let res = {
-                match (self.trie_iter.peek(), self.overlay_iter.peek()) {
-                    (Some(&Ok((ref left_key, _))), Some(&(ref right_key, _))) => {
-                        match (
-                            stop_cond(left_key, &self.prefix),
-                            stop_cond(*right_key, &self.prefix),
-                        ) {
-                            (false, false) => match left_key.as_slice().cmp(right_key) {
-                                std::cmp::Ordering::Less => Ordering::Trie,
-                                std::cmp::Ordering::Equal => Ordering::Both,
-                                std::cmp::Ordering::Greater => Ordering::Overlay,
-                            },
-                            (false, true) => Ordering::Trie,
-                            (true, false) => Ordering::Overlay,
-                            (true, true) => {
-                                return None;
-                            }
-                        }
-                    }
-                    (Some(&Ok((ref left_key, _))), None) => {
-                        if stop_cond(left_key, &self.prefix) {
-                            return None;
-                        }
-                        Ordering::Trie
-                    }
-                    (None, Some(&(right_key, _))) => {
-                        if stop_cond(right_key, &self.prefix) {
-                            return None;
-                        }
-                        Ordering::Overlay
-                    }
-                    (None, None) => return None,
-                    (Some(&Err(ref e)), _) => return Some(Err(e.clone())),
+            let res = match (self.trie_iter.peek(), self.overlay_iter.peek()) {
+                (Some(Err(err)), _) => {
+                    // TODO(mina86): We’re not advancing the iterator which
+                    // means that it’ll continue to return errors.  On the
+                    // other hand, we don’t want to just advance it because
+                    // we don’t want the iterator to continue returning
+                    // values after an error.
+                    return Some(Err(err.clone()));
                 }
+
+                (Some(Ok((left_key, _))), Some((right_key, _))) => {
+                    match left_key.as_slice().cmp(right_key) {
+                        std::cmp::Ordering::Less => Ordering::Trie,
+                        std::cmp::Ordering::Equal => Ordering::Both,
+                        std::cmp::Ordering::Greater => Ordering::Overlay,
+                    }
+                }
+                (Some(_), None) => Ordering::Trie,
+                (None, Some(_)) => Ordering::Overlay,
+                (None, None) => return None,
             };
 
-            // Check which elements comes first and only advance the corresponding iterator.
-            // If two keys are equal, take the value from `right`.
-            return match res {
-                Ordering::Trie => match self.trie_iter.next() {
-                    Some(Ok((key, _value))) => Some(Ok(key)),
-                    _ => None,
-                },
-                Ordering::Overlay => match self.overlay_iter.next() {
-                    Some((key, Some(_))) => Some(Ok(key.to_vec())),
-                    Some((_, None)) => continue,
-                    None => None,
-                },
-                Ordering::Both => {
-                    self.trie_iter.next();
-                    match self.overlay_iter.next() {
-                        Some((key, Some(_))) => Some(Ok(key.to_vec())),
-                        Some((_, None)) => continue,
-                        None => None,
-                    }
+            // Check which element comes first and advance the corresponding
+            // iterator only.  If both keys are equal, check if overlay doesn’t
+            // delete the value.
+            if res == Ordering::Trie {
+                if let Some(Ok((key, _))) = self.trie_iter.next() {
+                    return Some(Ok(key));
                 }
-            };
+            } else {
+                if res == Ordering::Both {
+                    self.trie_iter.next();
+                }
+                if let Some((key, Some(_))) = self.overlay_iter.next() {
+                    return Some(Ok(key.to_vec()));
+                }
+            }
         }
     }
 }
@@ -452,5 +450,18 @@ mod tests {
                 test_key(b"dog3".to_vec()).to_vec()
             ]
         );
+    }
+
+    #[test]
+    fn test_make_prefix_range_end_bound() {
+        fn test(want: Option<&[u8]>, prefix: &[u8]) {
+            assert_eq!(want, make_prefix_range_end_bound(prefix).as_deref());
+        }
+
+        test(None, b"");
+        test(None, b"\xff");
+        test(None, b"\xff\xff\xff\xff");
+        test(Some(b"b"), b"a");
+        test(Some(b"b"), b"a\xff\xff\xff");
     }
 }


### PR DESCRIPTION
By replacing a BTreeMap range iterator from open-ended into one whose
end depends on the prefix it’s possible to guarantee that only keys
with specified prefix are returned.  With that guaranteed, it’s no
longer necessary to manually check if key has the prefix. This
simplifies the code quite a bit by removing the stop condition.
