### PR TITLE
fix: flaky test

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -44,7 +44,7 @@ steps:
   - label: "cargo test nightly not integration-tests*"
     command: |
       source ~/.cargo/env && set -eux
-      cargo test --workspace --features nightly,test_features -p '*' --exclude 'integration-tests*'
+      cargo test --workspace --features nightly,test_features,mock_node -p '*' --exclude 'integration-tests*'
 
     timeout: 60
     agents:

--- a/tools/mock-node/src/setup.rs
+++ b/tools/mock-node/src/setup.rs
@@ -289,9 +289,6 @@ pub fn setup_mock_node(
         });
     network_adapter.set_recipient(mock_network_actor);
 
-    // for some reason, with "test_features", start_http requires PeerManagerActor,
-    // we are not going to run start_mock_network with test_features, so let's disable that for now
-    #[cfg(not(feature = "test_features"))]
     let servers = config.rpc_config.map(|rpc_config| {
         near_jsonrpc::start_http(
             rpc_config,
@@ -300,8 +297,6 @@ pub fn setup_mock_node(
             view_client.clone(),
         )
     });
-    #[cfg(feature = "test_features")]
-    let servers = None;
 
     MockNode { client, view_client, servers, target_height }
 }
@@ -333,6 +328,7 @@ mod tests {
     // to generate a chain history
     // then start a mock network with this chain history and test that
     // the client in the mock network can catch up these 20 blocks
+    #[cfg_attr(not(feature = "mock_node"), ignore)]
     #[test]
     fn test_mock_node_basic() {
         init_integration_logger();


### PR DESCRIPTION
This test actually requires `mock_node` feature to be enabled to work.

I am not sure what's the best way to run this test. The ideal solution
would be to add an extra CI job just for mock-node, but I would loath
to combinatorially inflate CI for every feature we have. Not that it
would be particularly problematic for mock-node, but it would seem
like a bad precedent. So instead I tacked mock_node to our nightly
tests. This is roughly how it worked anyway, while mock_node was
a default feature.

Of corse, in the ideal world we'd perhaps not use conditional
compilation here (or anywhere at all, really), but this isn't the
battle I am ready to fight yet.

closes https://github.com/near/nearcore/issues/7631
