### PR TITLE
Rollback of #7130 - due to cargo issue

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,4 @@
 [build]
 # We compile with `panic=abort`, so we need `-Cforce-unwind-tables=y`
 # to get a useful backtrace on panic.
-rustflags = ["-Cforce-unwind-tables=y"]
-
-[target.'cfg(target_arch = "x86_64")']
 rustflags = ["-Ctarget-feature=+sse4.1,+sse4.2", "-Cforce-unwind-tables=y"]


### PR DESCRIPTION
Cargo's bug repro: https://github.com/rust-lang/cargo/pull/11114

This has caused the flag not to be passed into rocksdb -- therefore impacting node performance.