### PR TITLE
feat: icount estimations without RocksDB

### DIFF
--- a/core/store/src/db/testdb.rs
+++ b/core/store/src/db/testdb.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, RwLock};
 use crate::db::{refcount, DBIterator, DBOp, DBSlice, DBTransaction, Database};
 use crate::{DBCol, StoreStatistics};
 
-/// An in-memory database intended for tests.
+/// An in-memory database intended for tests and IO-agnostic estimations.
 #[derive(Default)]
 pub struct TestDB {
     // In order to ensure determinism when iterating over column's results

--- a/genesis-tools/genesis-populate/src/state_dump.rs
+++ b/genesis-tools/genesis-populate/src/state_dump.rs
@@ -1,5 +1,6 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_primitives::types::StateRoot;
+use near_store::db::TestDB;
 use near_store::{DBCol, Store, Temperature};
 use std::fs::File;
 use std::io::{Read, Write};
@@ -14,11 +15,14 @@ pub struct StateDump {
 }
 
 impl StateDump {
-    pub fn from_dir(dir: &Path, store_home_dir: &Path) -> Self {
-        let store = near_store::NodeStorage::opener(store_home_dir, &Default::default())
-            .open()
-            .unwrap()
-            .get_store(Temperature::Hot);
+    pub fn from_dir(dir: &Path, store_home_dir: &Path, in_memory_db: bool) -> Self {
+        let node_storage = if in_memory_db {
+            let storage = TestDB::new();
+            near_store::NodeStorage::new(storage)
+        } else {
+            near_store::NodeStorage::opener(store_home_dir, &Default::default()).open().unwrap()
+        };
+        let store = node_storage.get_store(Temperature::Hot);
         let state_file = dir.join(STATE_DUMP_FILE);
         store
             .load_from_file(DBCol::State, state_file.as_path())

--- a/runtime/runtime-params-estimator/src/config.rs
+++ b/runtime/runtime-params-estimator/src/config.rs
@@ -38,4 +38,6 @@ pub struct Config {
     pub json_output: bool,
     /// Clear all OS caches between measured blocks.
     pub drop_os_cache: bool,
+    /// Use in-memory test DB, useful to avoid variance caused by DB.
+    pub in_memory_db: bool,
 }

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -42,7 +42,8 @@ impl<'c> EstimatorContext<'c> {
     }
 
     pub(crate) fn testbed(&mut self) -> Testbed<'_> {
-        let inner = RuntimeTestbed::from_state_dump(&self.config.state_dump_path);
+        let inner =
+            RuntimeTestbed::from_state_dump(&self.config.state_dump_path, self.config.in_memory_db);
         Testbed {
             config: self.config,
             inner,

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -276,7 +276,7 @@ fn main() -> anyhow::Result<()> {
 }
 
 /// Spawns another instance of this binary but inside docker.
-/// 
+///
 /// Most command line args are passed through but `--docker` is removed.
 /// We are now also running with an in-memory database to increase turn-around
 /// time and make the results more consistent. Note that this means qemu based

--- a/runtime/runtime-params-estimator/src/testbed.rs
+++ b/runtime/runtime-params-estimator/src/testbed.rs
@@ -25,9 +25,10 @@ pub struct RuntimeTestbed {
 
 impl RuntimeTestbed {
     /// Copies dump from another directory and loads the state from it.
-    pub fn from_state_dump(dump_dir: &Path) -> Self {
+    pub fn from_state_dump(dump_dir: &Path, in_memory_db: bool) -> Self {
         let workdir = tempfile::Builder::new().prefix("runtime_testbed").tempdir().unwrap();
-        let StateDump { store, roots } = StateDump::from_dir(dump_dir, workdir.path());
+        let StateDump { store, roots } =
+            StateDump::from_dir(dump_dir, workdir.path(), in_memory_db);
         // Ensure decent RocksDB SST file layout.
         store.compact().expect("compaction failed");
         let tries = ShardTries::test(store, 1);


### PR DESCRIPTION
Do not use RocksDB for qemu based estimations, it is very slow and has
very high variance. It also doesn't measure anything useful, the IO
bytes that we count are not a good approximation for IO costs at all.
See #6445 for a detailed explanation why this is the case.

Resolves #7526.