### PR TITLE
refactor: add EpochManagerAdapter infra 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2871,6 +2871,7 @@ dependencies = [
  "near-chain-primitives",
  "near-client-primitives",
  "near-crypto",
+ "near-epoch-manager",
  "near-o11y",
  "near-pool",
  "near-primitives",

--- a/chain/chain/Cargo.toml
+++ b/chain/chain/Cargo.toml
@@ -34,6 +34,7 @@ near-primitives = { path = "../../core/primitives" }
 near-store = { path = "../../core/store" }
 near-cache = { path = "../../utils/near-cache" }
 near-client-primitives = { path = "../client-primitives"}
+near-epoch-manager = { path = "../epoch-manager" }
 
 [dev-dependencies]
 insta = "1"

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, RwLock};
 
 use borsh::{BorshDeserialize, BorshSerialize};
 
+use near_epoch_manager::EpochManagerAdapter;
 use near_primitives::sandbox::state_patch::SandboxStatePatch;
 use near_primitives::state_part::PartId;
 use num_rational::Ratio;
@@ -405,6 +406,8 @@ impl KeyValueRuntime {
         Ok(chunk_producers.iter().filter(|it| !block_producers.contains(it)).collect())
     }
 }
+
+impl EpochManagerAdapter for KeyValueRuntime {}
 
 impl RuntimeAdapter for KeyValueRuntime {
     fn genesis_state(&self) -> (Store, Vec<StateRoot>) {

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -407,7 +407,11 @@ impl KeyValueRuntime {
     }
 }
 
-impl EpochManagerAdapter for KeyValueRuntime {}
+impl EpochManagerAdapter for KeyValueRuntime {
+    fn epoch_exists(&self, epoch_id: &EpochId) -> bool {
+        self.hash_to_valset.write().unwrap().contains_key(epoch_id)
+    }
+}
 
 impl RuntimeAdapter for KeyValueRuntime {
     fn genesis_state(&self) -> (Store, Vec<StateRoot>) {
@@ -1163,10 +1167,6 @@ impl RuntimeAdapter for KeyValueRuntime {
         } else {
             0
         }
-    }
-
-    fn epoch_exists(&self, epoch_id: &EpochId) -> bool {
-        self.hash_to_valset.write().unwrap().contains_key(epoch_id)
     }
 
     fn get_epoch_minted_amount(&self, _epoch_id: &EpochId) -> Result<Balance, Error> {

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use chrono::DateTime;
+use near_epoch_manager::EpochManagerAdapter;
 use near_primitives::sandbox::state_patch::SandboxStatePatch;
 use near_primitives::time::Utc;
 use num_rational::Rational32;
@@ -261,7 +262,7 @@ impl ChainGenesis {
 /// Bridge between the chain and the runtime.
 /// Main function is to update state given transactions.
 /// Additionally handles validators.
-pub trait RuntimeAdapter: Send + Sync {
+pub trait RuntimeAdapter: EpochManagerAdapter + Send + Sync {
     /// Get store and genesis state roots
     fn genesis_state(&self) -> (Store, Vec<StateRoot>);
 

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -556,9 +556,6 @@ pub trait RuntimeAdapter: EpochManagerAdapter + Send + Sync {
     /// Get the block height for which garbage collection should not go over
     fn get_gc_stop_height(&self, block_hash: &CryptoHash) -> BlockHeight;
 
-    /// Check if epoch exists.
-    fn epoch_exists(&self, epoch_id: &EpochId) -> bool;
-
     /// Amount of tokens minted in given epoch.
     fn get_epoch_minted_amount(&self, epoch_id: &EpochId) -> Result<Balance, Error>;
 

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -1,0 +1,33 @@
+use crate::{EpochManager, EpochManagerHandle};
+use std::sync::{RwLockReadGuard, RwLockWriteGuard};
+
+/// A trait that abstracts the interface of the EpochManager.
+///
+/// It is intended to be an intermediate state in a refactor: we want to remove
+/// epoch manager stuff from RuntimeAdapter's interface, and, as a first step,
+/// we move it to a new trait. The end goal is for the code to use the concrete
+/// epoch manager type directly. Though, we might want to still keep this trait
+/// in, to allow for easy overriding of epoch manager in tests.
+pub trait EpochManagerAdapter: Send + Sync {}
+
+/// A technical plumbing trait to conveniently implement [`EpochManagerAdapter`]
+/// for `NightshadeRuntime` without too much copy-paste.
+///
+/// Once we remove `RuntimeAdapter: EpochManagerAdapter` bound, we could get rid
+/// of this trait and instead add inherent methods directly to
+/// `EpochManagerHandle`.
+pub trait HasEpochMangerHandle {
+    fn write(&self) -> RwLockWriteGuard<EpochManager>;
+    fn read(&self) -> RwLockReadGuard<EpochManager>;
+}
+
+impl HasEpochMangerHandle for EpochManagerHandle {
+    fn write(&self) -> RwLockWriteGuard<EpochManager> {
+        self.write()
+    }
+    fn read(&self) -> RwLockReadGuard<EpochManager> {
+        self.read()
+    }
+}
+
+impl<T: HasEpochMangerHandle + Send + Sync> EpochManagerAdapter for T {}

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -1,3 +1,5 @@
+use near_primitives::types::EpochId;
+
 use crate::{EpochManager, EpochManagerHandle};
 use std::sync::{RwLockReadGuard, RwLockWriteGuard};
 
@@ -8,7 +10,10 @@ use std::sync::{RwLockReadGuard, RwLockWriteGuard};
 /// we move it to a new trait. The end goal is for the code to use the concrete
 /// epoch manager type directly. Though, we might want to still keep this trait
 /// in, to allow for easy overriding of epoch manager in tests.
-pub trait EpochManagerAdapter: Send + Sync {}
+pub trait EpochManagerAdapter: Send + Sync {
+    /// Check if epoch exists.
+    fn epoch_exists(&self, epoch_id: &EpochId) -> bool;
+}
 
 /// A technical plumbing trait to conveniently implement [`EpochManagerAdapter`]
 /// for `NightshadeRuntime` without too much copy-paste.
@@ -30,4 +35,9 @@ impl HasEpochMangerHandle for EpochManagerHandle {
     }
 }
 
-impl<T: HasEpochMangerHandle + Send + Sync> EpochManagerAdapter for T {}
+impl<T: HasEpochMangerHandle + Send + Sync> EpochManagerAdapter for T {
+    fn epoch_exists(&self, epoch_id: &EpochId) -> bool {
+        let epoch_manager = self.read();
+        epoch_manager.get_epoch_info(epoch_id).is_ok()
+    }
+}

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -29,10 +29,12 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use tracing::{debug, warn};
 
+pub use crate::adapter::{EpochManagerAdapter, HasEpochMangerHandle};
 pub use crate::reward_calculator::RewardCalculator;
 pub use crate::reward_calculator::NUM_SECONDS_IN_A_YEAR;
 pub use crate::types::RngSeed;
 
+mod adapter;
 mod proposals;
 mod reward_calculator;
 mod shard_assignment;

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -68,7 +68,7 @@ use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, RwLockReadGuard, RwLockWriteGuard};
 use std::time::Instant;
 use tracing::{debug, error, info, warn};
 
@@ -655,6 +655,16 @@ fn apply_delayed_receipts<'a>(
 
 pub fn state_record_to_shard_id(state_record: &StateRecord, shard_layout: &ShardLayout) -> ShardId {
     account_id_to_shard_id(state_record_to_account_id(state_record), shard_layout)
+}
+
+impl near_epoch_manager::HasEpochMangerHandle for NightshadeRuntime {
+    fn write(&self) -> RwLockWriteGuard<EpochManager> {
+        self.epoch_manager.write()
+    }
+
+    fn read(&self) -> RwLockReadGuard<EpochManager> {
+        self.epoch_manager.read()
+    }
 }
 
 impl RuntimeAdapter for NightshadeRuntime {

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -1239,11 +1239,6 @@ impl RuntimeAdapter for NightshadeRuntime {
         .unwrap_or(self.genesis_config.genesis_height)
     }
 
-    fn epoch_exists(&self, epoch_id: &EpochId) -> bool {
-        let epoch_manager = self.epoch_manager.read();
-        epoch_manager.get_epoch_info(epoch_id).is_ok()
-    }
-
     fn get_epoch_minted_amount(&self, epoch_id: &EpochId) -> Result<Balance, Error> {
         let epoch_manager = self.epoch_manager.read();
         Ok(epoch_manager.get_epoch_info(epoch_id)?.minted_amount())


### PR DESCRIPTION
Part of https://github.com/near/nearcore/issues/6910

The grand plan is to separate EpochManager out of NightshadeRuntime. As
a first step, I want to separate the *types* of runtime and epoch
manager, while keeping them in the same object. I want to do this via
the following series of steps:

```
trait RuntimeAdapter {}
```

```
trait EpochManagerAdapter {}

trait RuntimeAdapter: EpochManagerAdapter {}
```

```
trait EpochManagerAdapter {}

trait RuntimeAdapter {}
```

This PR introduces the EpochManagerAdapter infra.

You can see the rough idea of the plan in https://github.com/near/nearcore/pull/7606