### PR TITLE
integration-tests: fix hashing of a list of elements

### DIFF
--- a/core/primitives-core/src/hash.rs
+++ b/core/primitives-core/src/hash.rs
@@ -18,14 +18,29 @@ impl CryptoHash {
         Self([0; 32])
     }
 
+    /// Calculates hash of given bytes.
     pub fn hash_bytes(bytes: &[u8]) -> CryptoHash {
         CryptoHash(sha2::Sha256::digest(bytes).into())
     }
 
+    /// Calculates hash of borsh-serialised representation of an object.
+    ///
+    /// Note that if you have a slice of objects to serialise, you might
+    /// prefer using [`Self::hash_borsh_slice`] instead.
     pub fn hash_borsh<T: BorshSerialize>(value: &T) -> CryptoHash {
         let mut hasher = sha2::Sha256::default();
         BorshSerialize::serialize(value, &mut hasher).unwrap();
         CryptoHash(hasher.finalize().into())
+    }
+
+    /// Calculates hash of borsh-serialised representation of vector of objects.
+    ///
+    /// This does pretty much the same thing as [`Self::hash_borsh`] except
+    /// that it’s less error prone.  For example, `CryptoHash::hash_borsh(&[1u32,
+    ///  2, 3])` hashes a representation of a `[u32; 3]` array rather than
+    /// a slice.
+    pub fn hash_borsh_slice<T: BorshSerialize>(slice: &[T]) -> CryptoHash {
+        Self::hash_borsh(&slice)
     }
 
     pub const fn as_bytes(&self) -> &[u8; 32] {

--- a/integration-tests/src/tests/nearcore/sync_nodes.rs
+++ b/integration-tests/src/tests/nearcore/sync_nodes.rs
@@ -51,7 +51,7 @@ fn add_blocks(
         let next_epoch_id = EpochId(
             *blocks[(((prev.header().height()) / epoch_length) * epoch_length) as usize].hash(),
         );
-        let next_bp_hash = CryptoHash::hash_borsh(&[ValidatorStake::new(
+        let next_bp_hash = CryptoHash::hash_borsh_slice(&[ValidatorStake::new(
             "other".parse().unwrap(),
             signer.public_key(),
             TESTING_INIT_STAKE,


### PR DESCRIPTION
Turns out `CryptoHash::hash_borsh(&[foo])` doesn’t quite do what one
might expect.  Rather than hashing one-element slice (which is
serialised as length of one plus serialisation of the element) it
hashes one-element array (which is serialised as just the element).

Introduce `CryptoHash::hash_borsh_slice` to provide less error-prone
method and fix tests which fell victim of the confusion.  The tests
were broken by commit d5f650ab: ‘Prefer CryptoHash::hash_borsh to
try_to_vec+hash combo’.