### PR TITLE
refactor: expose get_epoch_id as a method of EpochManagerAdapter 

### DIFF
--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -454,8 +454,13 @@ impl EpochManagerAdapter for KeyValueRuntime {
         Ok(self.get_epoch_and_valset(*parent_hash)?.2)
     }
 
+    fn get_epoch_id(&self, block_hash: &CryptoHash) -> Result<EpochId, Error> {
+        let (epoch_id, _, _) = self.get_epoch_and_valset(*block_hash)?;
+        Ok(epoch_id)
+    }
+
     fn get_epoch_start_height(&self, block_hash: &CryptoHash) -> Result<BlockHeight, Error> {
-        let epoch_id = self.get_epoch_and_valset(*block_hash)?.0;
+        let epoch_id = self.get_epoch_id(block_hash)?;
         match self.get_block_header(&epoch_id.0)? {
             Some(block_header) => Ok(block_header.height()),
             None => Ok(0),

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -50,7 +50,10 @@ pub trait EpochManagerAdapter: Send + Sync {
     fn get_next_epoch_id_from_prev_block(&self, parent_hash: &CryptoHash)
         -> Result<EpochId, Error>;
 
-    /// Get epoch start for given block hash.
+    /// Get [`EpochId`] from a block belonging to the epoch.
+    fn get_epoch_id(&self, block_hash: &CryptoHash) -> Result<EpochId, Error>;
+
+    /// Get epoch start from a block belonging to the epoch.
     fn get_epoch_start_height(&self, block_hash: &CryptoHash) -> Result<BlockHeight, Error>;
 
     /// Epoch block producers ordered by their order in the proposals.
@@ -256,6 +259,11 @@ impl<T: HasEpochMangerHandle + Send + Sync> EpochManagerAdapter for T {
     ) -> Result<EpochId, Error> {
         let epoch_manager = self.read();
         epoch_manager.get_next_epoch_id_from_prev_block(parent_hash).map_err(Error::from)
+    }
+
+    fn get_epoch_id(&self, block_hash: &CryptoHash) -> Result<EpochId, Error> {
+        let epoch_manager = self.read();
+        epoch_manager.get_epoch_id(block_hash).map_err(Error::from)
     }
 
     fn get_epoch_start_height(&self, block_hash: &CryptoHash) -> Result<BlockHeight, Error> {

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -195,11 +195,6 @@ impl NightshadeRuntime {
         )
     }
 
-    pub fn get_epoch_id(&self, hash: &CryptoHash) -> Result<EpochId, Error> {
-        let epoch_manager = self.epoch_manager.read();
-        epoch_manager.get_epoch_id(hash).map_err(Error::from)
-    }
-
     /// Create store of runtime configs for the given chain id.
     ///
     /// For mainnet and other chains except testnet we don't need to override runtime config for


### PR DESCRIPTION
Part of https://github.com/near/nearcore/issues/6910, depends on https://github.com/near/nearcore/pull/7665

Previously, this was only available on NightshadeRuntime, but seems fine
to expose everywhere.