### PR TITLE
refactor: more useful error message

### DIFF
--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -302,7 +302,7 @@ impl From<EpochError> for Error {
     fn from(error: EpochError) -> Self {
         match error {
             EpochError::EpochOutOfBounds(epoch_id) => Error::EpochOutOfBounds(epoch_id),
-            EpochError::MissingBlock(h) => Error::DBNotFoundErr(h.to_string()),
+            EpochError::MissingBlock(h) => Error::DBNotFoundErr(format!("epoch block: {h}")),
             EpochError::NotAValidator(_account_id, _epoch_id) => Error::NotAValidator,
             err => Error::ValidatorError(err.to_string()),
         }


### PR DESCRIPTION
Make it clear what kind of thing is missing from the DB. Ideally, we'd
add a db_col field to the error, but that's going to be a much larger
change.
