### PR TITLE
fix: log_summary spamming and ignoring RUST_LOG

### DIFF
--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1822,7 +1822,12 @@ impl ClientActor {
             statistics,
             &self.client.config,
         );
-        debug!(target: "stats", "{}", self.client.chain.print_chain_processing_info_to_string(self.client.config.log_summary_style).unwrap_or(String::from("Upcoming block info failed.")));
+        let summary = self
+            .client
+            .chain
+            .print_chain_processing_info_to_string(self.client.config.log_summary_style)
+            .unwrap_or(String::from("Upcoming block info failed."));
+        debug!(target: "stats", "{}", summary);
     }
 }
 


### PR DESCRIPTION
The `log_summary()` logs aren't being suppressed when they're being explicitly turned off via `RUST_LOG`.  This is annoying to see when running tests on https://github.com/near/workspaces-rs/issues/200.

This PR should resolve this, but what's weird about this fix, is that the change is just moving the call `print_chain_processing_info_to_string` into its own separate statement away from the macro. The expanded code doesn't seem to show why this is the case either:
```diff
         use ::tracing::__macro_support::MacroCallsite;
         static META: ::tracing::Metadata<'static> = {
             ::tracing_core::metadata::Metadata::new(
-                "event chain/client/src/client_actor.rs:1849",
+                "event chain/client/src/client_actor.rs:1854",
                 "stats",
                 ::tracing::Level::DEBUG,
                 Some("chain/client/src/client_actor.rs"),
-                Some(1849u32),
+                Some(1854u32),
                 Some("near_client::client_actor"),
                 ::tracing_core::field::FieldSet::new(
                     &["message"],
@@ -72,15 +72,7 @@
                 &iter.next().expect("FieldSet corrupted (this is a bug)"),
                 Some(&::core::fmt::Arguments::new_v1(
                     &[""],
-                    &[::core::fmt::ArgumentV1::new_display(
-                        &self
-                            .client
-                            .chain
-                            .print_chain_processing_info_to_string(
-                                self.client.config.log_summary_style,
-                            )
-                            .unwrap_or(String::from("Upcoming block info failed.")),
-                    )],
+                    &[::core::fmt::ArgumentV1::new_display(&summary)],
                 ) as &Value),
             )])
         });
@@ -121,17 +113,7 @@
                                     Some(&::core::fmt::Arguments::new_v1(
                                         &[""],
                                         &[::core::fmt::ArgumentV1::new_display(
-                                            &self
-                                                .client
-                                                .chain
-                                                .print_chain_processing_info_to_string(
-                                                    self.client
-                                                        .config
-                                                        .log_summary_style,
-                                                )
-                                                .unwrap_or(String::from(
-                                                    "Upcoming block info failed.",
-                                                )),
+                                            &summary,
                                         )],
                                     )
                                         as &Value),

```

Does anyone know why this might be happening?