### PR TITLE
[chunks] Move ChainStore use out of ShardsManager and into the Client

### DIFF
--- a/chain/chain/src/chunks_store.rs
+++ b/chain/chain/src/chunks_store.rs
@@ -1,0 +1,60 @@
+use std::sync::Arc;
+
+use borsh::BorshDeserialize;
+use near_cache::CellLruCache;
+use near_chain_primitives::Error;
+use near_primitives::sharding::{ChunkHash, PartialEncodedChunk, ShardChunk};
+use near_store::{DBCol, Store};
+
+#[cfg(not(feature = "no_cache"))]
+const CHUNK_CACHE_SIZE: usize = 1024;
+#[cfg(feature = "no_cache")]
+const CHUNK_CACHE_SIZE: usize = 1;
+
+pub struct ReadOnlyChunksStore {
+    store: Store,
+    partial_chunks: CellLruCache<Vec<u8>, Arc<PartialEncodedChunk>>,
+    chunks: CellLruCache<Vec<u8>, Arc<ShardChunk>>,
+}
+
+impl ReadOnlyChunksStore {
+    pub fn new(store: Store) -> Self {
+        Self {
+            store,
+            partial_chunks: CellLruCache::new(CHUNK_CACHE_SIZE),
+            chunks: CellLruCache::new(CHUNK_CACHE_SIZE),
+        }
+    }
+
+    fn read_with_cache<'a, T: BorshDeserialize + Clone + 'a>(
+        &self,
+        col: DBCol,
+        cache: &'a CellLruCache<Vec<u8>, T>,
+        key: &[u8],
+    ) -> std::io::Result<Option<T>> {
+        if let Some(value) = cache.get(key) {
+            return Ok(Some(value));
+        }
+        if let Some(result) = self.store.get_ser::<T>(col, key)? {
+            cache.put(key.to_vec(), result.clone());
+            return Ok(Some(result));
+        }
+        Ok(None)
+    }
+    pub fn get_partial_chunk(
+        &self,
+        chunk_hash: &ChunkHash,
+    ) -> Result<Arc<PartialEncodedChunk>, Error> {
+        match self.read_with_cache(DBCol::PartialChunks, &self.partial_chunks, chunk_hash.as_ref())
+        {
+            Ok(Some(shard_chunk)) => Ok(shard_chunk),
+            _ => Err(Error::ChunkMissing(chunk_hash.clone())),
+        }
+    }
+    pub fn get_chunk(&self, chunk_hash: &ChunkHash) -> Result<Arc<ShardChunk>, Error> {
+        match self.read_with_cache(DBCol::Chunks, &self.chunks, chunk_hash.as_ref()) {
+            Ok(Some(shard_chunk)) => Ok(shard_chunk),
+            _ => Err(Error::ChunkMissing(chunk_hash.clone())),
+        }
+    }
+}

--- a/chain/chain/src/lib.rs
+++ b/chain/chain/src/lib.rs
@@ -11,6 +11,7 @@ pub use types::{Block, BlockHeader, BlockStatus, ChainGenesis, Provenance, Runti
 mod block_processing_utils;
 pub mod blocks_delay_tracker;
 pub mod chain;
+pub mod chunks_store;
 pub mod crypto_hash_timer;
 mod doomslug;
 mod lightclient;

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -39,6 +39,7 @@ use near_store::{
     LATEST_KNOWN_KEY, TAIL_KEY,
 };
 
+use crate::chunks_store::ReadOnlyChunksStore;
 use crate::types::{Block, BlockHeader, LatestKnown};
 use crate::{byzantine_assert, RuntimeAdapter};
 use near_store::db::StoreStatistics;
@@ -397,6 +398,10 @@ impl ChainStore {
             processed_block_heights: CellLruCache::new(CACHE_SIZE),
             save_trie_changes,
         }
+    }
+
+    pub fn new_read_only_chunks_store(&self) -> ReadOnlyChunksStore {
+        ReadOnlyChunksStore::new(self.store.clone())
     }
 
     pub fn store_update(&mut self) -> ChainStoreUpdate<'_> {

--- a/chain/chunks/src/client.rs
+++ b/chain/chunks/src/client.rs
@@ -1,13 +1,32 @@
 use actix::Message;
 use near_network::types::MsgRecipient;
-use near_primitives::sharding::ShardChunkHeader;
+use near_primitives::sharding::{EncodedShardChunk, PartialEncodedChunk, ShardChunk};
+
+pub trait ClientAdapterForShardsManager {
+    fn did_complete_chunk(
+        &self,
+        partial_chunk: PartialEncodedChunk,
+        shard_chunk: Option<ShardChunk>,
+    );
+    fn saw_invalid_chunk(&self, chunk: EncodedShardChunk);
+}
 
 #[derive(Message)]
 #[rtype(result = "()")]
 pub enum ShardsManagerResponse {
-    ChunkCompleted(ShardChunkHeader),
+    ChunkCompleted { partial_chunk: PartialEncodedChunk, shard_chunk: Option<ShardChunk> },
+    InvalidChunk(EncodedShardChunk),
 }
 
-pub trait ClientAdapterForShardsManager: MsgRecipient<ShardsManagerResponse> {}
-
-impl<A: MsgRecipient<ShardsManagerResponse>> ClientAdapterForShardsManager for A {}
+impl<A: MsgRecipient<ShardsManagerResponse>> ClientAdapterForShardsManager for A {
+    fn did_complete_chunk(
+        &self,
+        partial_chunk: PartialEncodedChunk,
+        shard_chunk: Option<ShardChunk>,
+    ) {
+        self.do_send(ShardsManagerResponse::ChunkCompleted { partial_chunk, shard_chunk });
+    }
+    fn saw_invalid_chunk(&self, chunk: EncodedShardChunk) {
+        self.do_send(ShardsManagerResponse::InvalidChunk(chunk));
+    }
+}

--- a/chain/chunks/src/logic.rs
+++ b/chain/chunks/src/logic.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use near_chain::{validate::validate_chunk_proofs, Chain, ChainStore, RuntimeAdapter};
 use near_chunks_primitives::Error;
 use near_primitives::{
@@ -14,182 +12,184 @@ use near_primitives::{
 };
 use tracing::log::{debug, error};
 
-#[derive(Clone)]
-pub struct ChunksLogic {
-    pub me: Option<AccountId>,
-    pub runtime_adapter: Arc<dyn RuntimeAdapter>,
+pub fn need_receipt(
+    prev_block_hash: &CryptoHash,
+    shard_id: ShardId,
+    me: Option<&AccountId>,
+    runtime_adapter: &dyn RuntimeAdapter,
+) -> bool {
+    cares_about_shard_this_or_next_epoch(me, prev_block_hash, shard_id, true, runtime_adapter)
 }
 
-impl ChunksLogic {
-    pub fn new(me: Option<AccountId>, runtime_adapter: Arc<dyn RuntimeAdapter>) -> Self {
-        Self { me, runtime_adapter }
+/// Returns true if we need this part to sign the block.
+pub fn need_part(
+    prev_block_hash: &CryptoHash,
+    part_ord: u64,
+    me: Option<&AccountId>,
+    runtime_adapter: &dyn RuntimeAdapter,
+) -> Result<bool, Error> {
+    let epoch_id = runtime_adapter.get_epoch_id_from_prev_block(prev_block_hash)?;
+    Ok(Some(&runtime_adapter.get_part_owner(&epoch_id, part_ord)?) == me)
+}
+
+pub fn cares_about_shard_this_or_next_epoch(
+    account_id: Option<&AccountId>,
+    parent_hash: &CryptoHash,
+    shard_id: ShardId,
+    is_me: bool,
+    runtime_adapter: &dyn RuntimeAdapter,
+) -> bool {
+    runtime_adapter.cares_about_shard(account_id, parent_hash, shard_id, is_me)
+        || runtime_adapter.will_care_about_shard(account_id, parent_hash, shard_id, is_me)
+}
+
+/// Constructs receipt proofs for specified chunk and returns them in an
+/// iterator.
+pub fn make_outgoing_receipts_proofs(
+    chunk_header: &ShardChunkHeader,
+    outgoing_receipts: &[Receipt],
+    runtime_adapter: &dyn RuntimeAdapter,
+) -> Result<impl Iterator<Item = ReceiptProof>, near_chunks_primitives::Error> {
+    let shard_id = chunk_header.shard_id();
+    let shard_layout =
+        runtime_adapter.get_shard_layout_from_prev_block(chunk_header.prev_block_hash())?;
+
+    let hashes = Chain::build_receipts_hashes(&outgoing_receipts, &shard_layout);
+    let (root, proofs) = merklize(&hashes);
+    assert_eq!(chunk_header.outgoing_receipts_root(), root);
+
+    let mut receipts_by_shard =
+        Chain::group_receipts_by_shard(outgoing_receipts.to_vec(), &shard_layout);
+    let it = proofs.into_iter().enumerate().map(move |(proof_shard_id, proof)| {
+        let proof_shard_id = proof_shard_id as u64;
+        let receipts = receipts_by_shard.remove(&proof_shard_id).unwrap_or_else(Vec::new);
+        let shard_proof =
+            ShardProof { from_shard_id: shard_id, to_shard_id: proof_shard_id, proof: proof };
+        ReceiptProof(receipts, shard_proof)
+    });
+    Ok(it)
+}
+
+pub fn make_partial_encoded_chunk_from_owned_parts_and_needed_receipts<'a>(
+    header: &'a ShardChunkHeader,
+    parts: impl Iterator<Item = &'a PartialEncodedChunkPart>,
+    receipts: impl Iterator<Item = &'a ReceiptProof>,
+    me: Option<&AccountId>,
+    runtime_adapter: &dyn RuntimeAdapter,
+) -> PartialEncodedChunk {
+    let prev_block_hash = header.prev_block_hash();
+    let cares_about_shard = cares_about_shard_this_or_next_epoch(
+        me,
+        prev_block_hash,
+        header.shard_id(),
+        true,
+        runtime_adapter,
+    );
+    let parts = parts
+        .filter(|entry| {
+            cares_about_shard
+                || need_part(prev_block_hash, entry.part_ord, me, runtime_adapter).unwrap_or(false)
+        })
+        .cloned()
+        .collect();
+    let receipts = receipts
+        .filter(|receipt| {
+            cares_about_shard
+                || need_receipt(prev_block_hash, receipt.1.to_shard_id, me, runtime_adapter)
+        })
+        .cloned()
+        .collect();
+    match header.clone() {
+        ShardChunkHeader::V1(header) => {
+            PartialEncodedChunk::V1(PartialEncodedChunkV1 { header, parts, receipts })
+        }
+        header => PartialEncodedChunk::V2(PartialEncodedChunkV2 { header, parts, receipts }),
     }
+}
 
-    pub fn me(&self) -> Option<&AccountId> {
-        self.me.as_ref()
-    }
+pub fn decode_encoded_chunk(
+    encoded_chunk: &EncodedShardChunk,
+    merkle_paths: Vec<MerklePath>,
+    me: Option<&AccountId>,
+    runtime_adapter: &dyn RuntimeAdapter,
+) -> Result<(ShardChunk, PartialEncodedChunk), Error> {
+    let chunk_hash = encoded_chunk.chunk_hash();
 
-    pub fn need_receipt(&self, prev_block_hash: &CryptoHash, shard_id: ShardId) -> bool {
-        self.cares_about_shard_this_or_next_epoch(self.me.as_ref(), prev_block_hash, shard_id, true)
-    }
-
-    /// Returns true if we need this part to sign the block.
-    pub fn need_part(&self, prev_block_hash: &CryptoHash, part_ord: u64) -> Result<bool, Error> {
-        let epoch_id = self.runtime_adapter.get_epoch_id_from_prev_block(prev_block_hash)?;
-        Ok(Some(self.runtime_adapter.get_part_owner(&epoch_id, part_ord)?) == self.me)
-    }
-
-    pub fn cares_about_shard_this_or_next_epoch(
-        &self,
-        account_id: Option<&AccountId>,
-        parent_hash: &CryptoHash,
-        shard_id: ShardId,
-        is_me: bool,
-    ) -> bool {
-        self.runtime_adapter.cares_about_shard(account_id, parent_hash, shard_id, is_me)
-            || self.runtime_adapter.will_care_about_shard(account_id, parent_hash, shard_id, is_me)
-    }
-
-    /// Constructs receipt proofs for specified chunk and returns them in an
-    /// iterator.
-    pub fn make_outgoing_receipts_proofs(
-        &self,
-        chunk_header: &ShardChunkHeader,
-        outgoing_receipts: &[Receipt],
-    ) -> Result<impl Iterator<Item = ReceiptProof>, near_chunks_primitives::Error> {
-        let shard_id = chunk_header.shard_id();
-        let shard_layout = self
-            .runtime_adapter
-            .get_shard_layout_from_prev_block(chunk_header.prev_block_hash())?;
-
-        let hashes = Chain::build_receipts_hashes(&outgoing_receipts, &shard_layout);
-        let (root, proofs) = merklize(&hashes);
-        assert_eq!(chunk_header.outgoing_receipts_root(), root);
-
-        let mut receipts_by_shard =
-            Chain::group_receipts_by_shard(outgoing_receipts.to_vec(), &shard_layout);
-        let it = proofs.into_iter().enumerate().map(move |(proof_shard_id, proof)| {
-            let proof_shard_id = proof_shard_id as u64;
-            let receipts = receipts_by_shard.remove(&proof_shard_id).unwrap_or_else(Vec::new);
-            let shard_proof =
-                ShardProof { from_shard_id: shard_id, to_shard_id: proof_shard_id, proof: proof };
-            ReceiptProof(receipts, shard_proof)
-        });
-        Ok(it)
-    }
-
-    pub fn make_partial_encoded_chunk_from_owned_parts_and_needed_receipts<'a>(
-        &'a self,
-        header: &'a ShardChunkHeader,
-        parts: impl Iterator<Item = &'a PartialEncodedChunkPart>,
-        receipts: impl Iterator<Item = &'a ReceiptProof>,
-    ) -> PartialEncodedChunk {
-        let prev_block_hash = header.prev_block_hash();
-        let cares_about_shard = self.cares_about_shard_this_or_next_epoch(
-            self.me.as_ref(),
-            prev_block_hash,
-            header.shard_id(),
-            true,
-        );
-        let parts = parts
-            .filter(|entry| {
-                cares_about_shard
-                    || self.need_part(prev_block_hash, entry.part_ord).unwrap_or(false)
-            })
-            .cloned()
-            .collect();
-        let receipts = receipts
-            .filter(|receipt| {
-                cares_about_shard || self.need_receipt(prev_block_hash, receipt.1.to_shard_id)
-            })
-            .cloned()
-            .collect();
-        match header.clone() {
-            ShardChunkHeader::V1(header) => {
-                PartialEncodedChunk::V1(PartialEncodedChunkV1 { header, parts, receipts })
+    if let Ok(shard_chunk) = encoded_chunk
+        .decode_chunk(runtime_adapter.num_data_parts())
+        .map_err(|err| Error::from(err))
+        .and_then(|shard_chunk| {
+            if !validate_chunk_proofs(&shard_chunk, runtime_adapter)? {
+                return Err(Error::InvalidChunk);
             }
-            header => PartialEncodedChunk::V2(PartialEncodedChunkV2 { header, parts, receipts }),
-        }
+            Ok(shard_chunk)
+        })
+    {
+        debug!(target: "chunks", "Reconstructed and decoded chunk {}, encoded length was {}, num txs: {}, I'm {:?}", chunk_hash.0, encoded_chunk.encoded_length(), shard_chunk.transactions().len(), me);
+
+        let partial_chunk = create_partial_chunk(
+            encoded_chunk,
+            merkle_paths,
+            shard_chunk.receipts().to_vec(),
+            me,
+            runtime_adapter,
+        )?;
+
+        return Ok((shard_chunk, partial_chunk));
+    } else {
+        // Can't decode chunk or has invalid proofs, ignore it
+        error!(target: "chunks", "Reconstructed, but failed to decoded chunk {}, I'm {:?}", chunk_hash.0, me);
+        return Err(Error::InvalidChunk);
     }
+}
 
-    pub fn decode_encoded_chunk(
-        &mut self,
-        encoded_chunk: &EncodedShardChunk,
-        merkle_paths: Vec<MerklePath>,
-    ) -> Result<(ShardChunk, PartialEncodedChunk), Error> {
-        let chunk_hash = encoded_chunk.chunk_hash();
-
-        if let Ok(shard_chunk) = encoded_chunk
-            .decode_chunk(self.runtime_adapter.num_data_parts())
-            .map_err(|err| Error::from(err))
-            .and_then(|shard_chunk| {
-                if !validate_chunk_proofs(&shard_chunk, &*self.runtime_adapter)? {
-                    return Err(Error::InvalidChunk);
-                }
-                Ok(shard_chunk)
+fn create_partial_chunk(
+    encoded_chunk: &EncodedShardChunk,
+    merkle_paths: Vec<MerklePath>,
+    outgoing_receipts: Vec<Receipt>,
+    me: Option<&AccountId>,
+    runtime_adapter: &dyn RuntimeAdapter,
+) -> Result<PartialEncodedChunk, Error> {
+    let header = encoded_chunk.cloned_header();
+    let receipts =
+        make_outgoing_receipts_proofs(&header, &outgoing_receipts, runtime_adapter)?.collect();
+    let partial_chunk = PartialEncodedChunkV2 {
+        header,
+        parts: encoded_chunk
+            .content()
+            .parts
+            .clone()
+            .into_iter()
+            .zip(merkle_paths)
+            .enumerate()
+            .map(|(part_ord, (part, merkle_proof))| {
+                let part_ord = part_ord as u64;
+                let part = part.unwrap();
+                PartialEncodedChunkPart { part_ord, part, merkle_proof }
             })
-        {
-            debug!(target: "chunks", "Reconstructed and decoded chunk {}, encoded length was {}, num txs: {}, I'm {:?}", chunk_hash.0, encoded_chunk.encoded_length(), shard_chunk.transactions().len(), self.me);
+            .collect(),
+        receipts,
+    };
 
-            let partial_chunk = self.create_partial_chunk(
-                encoded_chunk,
-                merkle_paths,
-                shard_chunk.receipts().to_vec(),
-            )?;
+    Ok(make_partial_encoded_chunk_from_owned_parts_and_needed_receipts(
+        &partial_chunk.header,
+        partial_chunk.parts.iter(),
+        partial_chunk.receipts.iter(),
+        me,
+        runtime_adapter,
+    ))
+}
 
-            return Ok((shard_chunk, partial_chunk));
-        } else {
-            // Can't decode chunk or has invalid proofs, ignore it
-            error!(target: "chunks", "Reconstructed, but failed to decoded chunk {}, I'm {:?}", chunk_hash.0, self.me);
-            return Err(Error::InvalidChunk);
-        }
+pub fn persist_chunk(
+    partial_chunk: PartialEncodedChunk,
+    shard_chunk: Option<ShardChunk>,
+    store: &mut ChainStore,
+) -> Result<(), Error> {
+    let mut update = store.store_update();
+    update.save_partial_chunk(partial_chunk);
+    if let Some(shard_chunk) = shard_chunk {
+        update.save_chunk(shard_chunk);
     }
-
-    fn create_partial_chunk(
-        &self,
-        encoded_chunk: &EncodedShardChunk,
-        merkle_paths: Vec<MerklePath>,
-        outgoing_receipts: Vec<Receipt>,
-    ) -> Result<PartialEncodedChunk, Error> {
-        let header = encoded_chunk.cloned_header();
-        let receipts = self.make_outgoing_receipts_proofs(&header, &outgoing_receipts)?.collect();
-        let partial_chunk = PartialEncodedChunkV2 {
-            header,
-            parts: encoded_chunk
-                .content()
-                .parts
-                .clone()
-                .into_iter()
-                .zip(merkle_paths)
-                .enumerate()
-                .map(|(part_ord, (part, merkle_proof))| {
-                    let part_ord = part_ord as u64;
-                    let part = part.unwrap();
-                    PartialEncodedChunkPart { part_ord, part, merkle_proof }
-                })
-                .collect(),
-            receipts,
-        };
-
-        Ok(self.make_partial_encoded_chunk_from_owned_parts_and_needed_receipts(
-            &partial_chunk.header,
-            partial_chunk.parts.iter(),
-            partial_chunk.receipts.iter(),
-        ))
-    }
-
-    pub fn persist_chunk(
-        &self,
-        partial_chunk: PartialEncodedChunk,
-        shard_chunk: Option<ShardChunk>,
-        store: &mut ChainStore,
-    ) -> Result<(), Error> {
-        let mut update = store.store_update();
-        update.save_partial_chunk(partial_chunk);
-        if let Some(shard_chunk) = shard_chunk {
-            update.save_chunk(shard_chunk);
-        }
-        update.commit()?;
-        Ok(())
-    }
+    update.commit()?;
+    Ok(())
 }

--- a/chain/chunks/src/logic.rs
+++ b/chain/chunks/src/logic.rs
@@ -1,0 +1,195 @@
+use std::sync::Arc;
+
+use near_chain::{validate::validate_chunk_proofs, Chain, ChainStore, RuntimeAdapter};
+use near_chunks_primitives::Error;
+use near_primitives::{
+    hash::CryptoHash,
+    merkle::{merklize, MerklePath},
+    receipt::Receipt,
+    sharding::{
+        EncodedShardChunk, PartialEncodedChunk, PartialEncodedChunkPart, PartialEncodedChunkV1,
+        PartialEncodedChunkV2, ReceiptProof, ShardChunk, ShardChunkHeader, ShardProof,
+    },
+    types::{AccountId, ShardId},
+};
+use tracing::log::{debug, error};
+
+#[derive(Clone)]
+pub struct ChunksLogic {
+    pub me: Option<AccountId>,
+    pub runtime_adapter: Arc<dyn RuntimeAdapter>,
+}
+
+impl ChunksLogic {
+    pub fn new(me: Option<AccountId>, runtime_adapter: Arc<dyn RuntimeAdapter>) -> Self {
+        Self { me, runtime_adapter }
+    }
+
+    pub fn me(&self) -> Option<&AccountId> {
+        self.me.as_ref()
+    }
+
+    pub fn need_receipt(&self, prev_block_hash: &CryptoHash, shard_id: ShardId) -> bool {
+        self.cares_about_shard_this_or_next_epoch(self.me.as_ref(), prev_block_hash, shard_id, true)
+    }
+
+    /// Returns true if we need this part to sign the block.
+    pub fn need_part(&self, prev_block_hash: &CryptoHash, part_ord: u64) -> Result<bool, Error> {
+        let epoch_id = self.runtime_adapter.get_epoch_id_from_prev_block(prev_block_hash)?;
+        Ok(Some(self.runtime_adapter.get_part_owner(&epoch_id, part_ord)?) == self.me)
+    }
+
+    pub fn cares_about_shard_this_or_next_epoch(
+        &self,
+        account_id: Option<&AccountId>,
+        parent_hash: &CryptoHash,
+        shard_id: ShardId,
+        is_me: bool,
+    ) -> bool {
+        self.runtime_adapter.cares_about_shard(account_id, parent_hash, shard_id, is_me)
+            || self.runtime_adapter.will_care_about_shard(account_id, parent_hash, shard_id, is_me)
+    }
+
+    /// Constructs receipt proofs for specified chunk and returns them in an
+    /// iterator.
+    pub fn make_outgoing_receipts_proofs(
+        &self,
+        chunk_header: &ShardChunkHeader,
+        outgoing_receipts: &[Receipt],
+    ) -> Result<impl Iterator<Item = ReceiptProof>, near_chunks_primitives::Error> {
+        let shard_id = chunk_header.shard_id();
+        let shard_layout = self
+            .runtime_adapter
+            .get_shard_layout_from_prev_block(chunk_header.prev_block_hash())?;
+
+        let hashes = Chain::build_receipts_hashes(&outgoing_receipts, &shard_layout);
+        let (root, proofs) = merklize(&hashes);
+        assert_eq!(chunk_header.outgoing_receipts_root(), root);
+
+        let mut receipts_by_shard =
+            Chain::group_receipts_by_shard(outgoing_receipts.to_vec(), &shard_layout);
+        let it = proofs.into_iter().enumerate().map(move |(proof_shard_id, proof)| {
+            let proof_shard_id = proof_shard_id as u64;
+            let receipts = receipts_by_shard.remove(&proof_shard_id).unwrap_or_else(Vec::new);
+            let shard_proof =
+                ShardProof { from_shard_id: shard_id, to_shard_id: proof_shard_id, proof: proof };
+            ReceiptProof(receipts, shard_proof)
+        });
+        Ok(it)
+    }
+
+    pub fn make_partial_encoded_chunk_from_owned_parts_and_needed_receipts<'a>(
+        &'a self,
+        header: &'a ShardChunkHeader,
+        parts: impl Iterator<Item = &'a PartialEncodedChunkPart>,
+        receipts: impl Iterator<Item = &'a ReceiptProof>,
+    ) -> PartialEncodedChunk {
+        let prev_block_hash = header.prev_block_hash();
+        let cares_about_shard = self.cares_about_shard_this_or_next_epoch(
+            self.me.as_ref(),
+            prev_block_hash,
+            header.shard_id(),
+            true,
+        );
+        let parts = parts
+            .filter(|entry| {
+                cares_about_shard
+                    || self.need_part(prev_block_hash, entry.part_ord).unwrap_or(false)
+            })
+            .cloned()
+            .collect();
+        let receipts = receipts
+            .filter(|receipt| {
+                cares_about_shard || self.need_receipt(prev_block_hash, receipt.1.to_shard_id)
+            })
+            .cloned()
+            .collect();
+        match header.clone() {
+            ShardChunkHeader::V1(header) => {
+                PartialEncodedChunk::V1(PartialEncodedChunkV1 { header, parts, receipts })
+            }
+            header => PartialEncodedChunk::V2(PartialEncodedChunkV2 { header, parts, receipts }),
+        }
+    }
+
+    pub fn decode_encoded_chunk(
+        &mut self,
+        encoded_chunk: &EncodedShardChunk,
+        merkle_paths: Vec<MerklePath>,
+    ) -> Result<(ShardChunk, PartialEncodedChunk), Error> {
+        let chunk_hash = encoded_chunk.chunk_hash();
+
+        if let Ok(shard_chunk) = encoded_chunk
+            .decode_chunk(self.runtime_adapter.num_data_parts())
+            .map_err(|err| Error::from(err))
+            .and_then(|shard_chunk| {
+                if !validate_chunk_proofs(&shard_chunk, &*self.runtime_adapter)? {
+                    return Err(Error::InvalidChunk);
+                }
+                Ok(shard_chunk)
+            })
+        {
+            debug!(target: "chunks", "Reconstructed and decoded chunk {}, encoded length was {}, num txs: {}, I'm {:?}", chunk_hash.0, encoded_chunk.encoded_length(), shard_chunk.transactions().len(), self.me);
+
+            let partial_chunk = self.create_partial_chunk(
+                encoded_chunk,
+                merkle_paths,
+                shard_chunk.receipts().to_vec(),
+            )?;
+
+            return Ok((shard_chunk, partial_chunk));
+        } else {
+            // Can't decode chunk or has invalid proofs, ignore it
+            error!(target: "chunks", "Reconstructed, but failed to decoded chunk {}, I'm {:?}", chunk_hash.0, self.me);
+            return Err(Error::InvalidChunk);
+        }
+    }
+
+    fn create_partial_chunk(
+        &self,
+        encoded_chunk: &EncodedShardChunk,
+        merkle_paths: Vec<MerklePath>,
+        outgoing_receipts: Vec<Receipt>,
+    ) -> Result<PartialEncodedChunk, Error> {
+        let header = encoded_chunk.cloned_header();
+        let receipts = self.make_outgoing_receipts_proofs(&header, &outgoing_receipts)?.collect();
+        let partial_chunk = PartialEncodedChunkV2 {
+            header,
+            parts: encoded_chunk
+                .content()
+                .parts
+                .clone()
+                .into_iter()
+                .zip(merkle_paths)
+                .enumerate()
+                .map(|(part_ord, (part, merkle_proof))| {
+                    let part_ord = part_ord as u64;
+                    let part = part.unwrap();
+                    PartialEncodedChunkPart { part_ord, part, merkle_proof }
+                })
+                .collect(),
+            receipts,
+        };
+
+        Ok(self.make_partial_encoded_chunk_from_owned_parts_and_needed_receipts(
+            &partial_chunk.header,
+            partial_chunk.parts.iter(),
+            partial_chunk.receipts.iter(),
+        ))
+    }
+
+    pub fn persist_chunk(
+        &self,
+        partial_chunk: PartialEncodedChunk,
+        shard_chunk: Option<ShardChunk>,
+        store: &mut ChainStore,
+    ) -> Result<(), Error> {
+        let mut update = store.store_update();
+        update.save_partial_chunk(partial_chunk);
+        if let Some(shard_chunk) = shard_chunk {
+            update.save_chunk(shard_chunk);
+        }
+        update.commit()?;
+        Ok(())
+    }
+}

--- a/chain/chunks/src/test_utils.rs
+++ b/chain/chunks/src/test_utils.rs
@@ -27,7 +27,6 @@ use near_primitives::version::PROTOCOL_VERSION;
 use near_store::Store;
 
 use crate::client::ShardsManagerResponse;
-use crate::logic::ChunksLogic;
 use crate::{
     Seal, SealsManager, ShardsManager, ACCEPTING_SEAL_PERIOD_MS, PAST_SEAL_HEIGHT_HORIZON,
 };
@@ -104,7 +103,7 @@ impl SealsManagerTestFixture {
     }
 
     pub fn create_seals_manager(&self) -> SealsManager {
-        SealsManager::new(ChunksLogic::new(self.mock_me.clone(), self.mock_runtime.clone()))
+        SealsManager::new(self.mock_me.clone(), self.mock_runtime.clone())
     }
 
     pub fn create_seal(&self, seals_manager: &mut SealsManager) {

--- a/chain/chunks/src/test_utils.rs
+++ b/chain/chunks/src/test_utils.rs
@@ -27,6 +27,7 @@ use near_primitives::version::PROTOCOL_VERSION;
 use near_store::Store;
 
 use crate::client::ShardsManagerResponse;
+use crate::logic::ChunksLogic;
 use crate::{
     Seal, SealsManager, ShardsManager, ACCEPTING_SEAL_PERIOD_MS, PAST_SEAL_HEIGHT_HORIZON,
 };
@@ -103,7 +104,7 @@ impl SealsManagerTestFixture {
     }
 
     pub fn create_seals_manager(&self) -> SealsManager {
-        SealsManager::new(self.mock_me.clone(), self.mock_runtime.clone())
+        SealsManager::new(ChunksLogic::new(self.mock_me.clone(), self.mock_runtime.clone()))
     }
 
     pub fn create_seal(&self, seals_manager: &mut SealsManager) {

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use near_chunks::client::ClientAdapterForShardsManager;
+use near_chunks::logic::ChunksLogic;
 use near_client_primitives::debug::ChunkProduction;
 use near_primitives::time::Clock;
 use tracing::{debug, error, info, trace, warn};
@@ -32,8 +33,8 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{merklize, MerklePath, PartialMerkleTree};
 use near_primitives::receipt::Receipt;
 use near_primitives::sharding::{
-    ChunkHash, EncodedShardChunk, PartialEncodedChunk, ReedSolomonWrapper, ShardChunkHeader,
-    ShardInfo,
+    ChunkHash, EncodedShardChunk, PartialEncodedChunk, ReedSolomonWrapper, ShardChunk,
+    ShardChunkHeader, ShardInfo,
 };
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::chunk_extra::ChunkExtra;
@@ -87,6 +88,7 @@ pub struct Client {
     pub doomslug: Doomslug,
     pub runtime_adapter: Arc<dyn RuntimeAdapter>,
     pub shards_mgr: ShardsManager,
+    pub chunks_logic: ChunksLogic,
     /// Network adapter.
     network_adapter: Arc<dyn PeerManagerAdapter>,
     /// Signer for block producer (if present).
@@ -173,11 +175,13 @@ impl Client {
             doomslug_threshold_mode,
             !config.archive,
         )?;
+        let me = validator_signer.as_ref().map(|x| x.validator_id().clone());
+        let chunks_logic = ChunksLogic::new(me, runtime_adapter.clone());
         let shards_mgr = ShardsManager::new(
-            validator_signer.as_ref().map(|x| x.validator_id().clone()),
-            runtime_adapter.clone(),
+            chunks_logic.clone(),
             network_adapter.clone(),
             client_adapter.clone(),
+            chain.store().new_read_only_chunks_store(),
             rng_seed,
         );
         let sync_status = SyncStatus::AwaitingPeers;
@@ -235,6 +239,7 @@ impl Client {
             doomslug,
             runtime_adapter,
             shards_mgr,
+            chunks_logic,
             network_adapter,
             validator_signer,
             pending_approvals: lru::LruCache::new(num_block_producer_seats),
@@ -272,7 +277,7 @@ impl Client {
         for (shard_id, chunk_header) in block.chunks().iter().enumerate() {
             let shard_id = shard_id as ShardId;
             if block.header().height() == chunk_header.height_included() {
-                if self.shards_mgr.cares_about_shard_this_or_next_epoch(
+                if self.chunks_logic.cares_about_shard_this_or_next_epoch(
                     Some(&me),
                     block.header().prev_hash(),
                     shard_id,
@@ -295,7 +300,7 @@ impl Client {
         for (shard_id, chunk_header) in block.chunks().iter().enumerate() {
             let shard_id = shard_id as ShardId;
             if block.header().height() == chunk_header.height_included() {
-                if self.shards_mgr.cares_about_shard_this_or_next_epoch(
+                if self.chunks_logic.cares_about_shard_this_or_next_epoch(
                     Some(&me),
                     block.header().prev_hash(),
                     shard_id,
@@ -944,7 +949,6 @@ impl Client {
         self.shards_mgr.process_partial_encoded_chunk(
             MaybeValidated::from(partial_chunk),
             self.chain.head().ok().as_ref(),
-            self.chain.mut_store(),
         )?;
         Ok(())
     }
@@ -960,7 +964,6 @@ impl Client {
         self.shards_mgr.process_partial_encoded_chunk(
             MaybeValidated::from_validated(partial_chunk),
             self.chain.head().ok().as_ref(),
-            self.chain.mut_store(),
         )?;
         Ok(())
     }
@@ -969,11 +972,8 @@ impl Client {
         &mut self,
         forward: PartialEncodedChunkForwardMsg,
     ) -> Result<(), Error> {
-        self.shards_mgr.process_partial_encoded_chunk_forward(
-            forward,
-            self.chain.head().ok().as_ref(),
-            self.chain.mut_store(),
-        )?;
+        self.shards_mgr
+            .process_partial_encoded_chunk_forward(forward, self.chain.head().ok().as_ref())?;
         Ok(())
     }
 
@@ -985,25 +985,38 @@ impl Client {
     pub fn check_incomplete_chunks(&mut self, prev_block_hash: &CryptoHash) {
         for chunk_header in self.shards_mgr.get_incomplete_chunks(prev_block_hash) {
             debug!(target:"client", "try to process incomplete chunks {:?}, prev_block: {:?}", chunk_header.chunk_hash(), prev_block_hash);
-            if let Err(err) = self
-                .shards_mgr
-                .try_process_chunk_parts_and_receipts(&chunk_header, self.chain.mut_store())
-            {
+            if let Err(err) = self.shards_mgr.try_process_chunk_parts_and_receipts(&chunk_header) {
                 error!(target:"client", "unexpected error processing orphan chunk {:?}", err)
             }
         }
     }
 
+    /// Called asynchronously when the ShardsManager finishes processing a chunk.
     pub fn on_chunk_completed(
         &mut self,
-        chunk_header: &ShardChunkHeader,
+        partial_chunk: PartialEncodedChunk,
+        shard_chunk: Option<ShardChunk>,
         apply_chunks_done_callback: DoneApplyChunkCallback,
     ) {
-        self.chain.blocks_delay_tracker.mark_chunk_completed(chunk_header, Clock::utc());
+        let chunk_header = partial_chunk.cloned_header();
+        self.chunks_logic
+            .persist_chunk(partial_chunk, shard_chunk, self.chain.mut_store())
+            .expect("Could not persist chunk");
+        self.chain.blocks_delay_tracker.mark_chunk_completed(&chunk_header, Clock::utc());
         // We're marking chunk as accepted.
         self.chain.blocks_with_missing_chunks.accept_chunk(&chunk_header.chunk_hash());
         // If this was the last chunk that was missing for a block, it will be processed now.
         self.process_blocks_with_missing_chunks(apply_chunks_done_callback)
+    }
+
+    /// Called asynchronously when the ShardsManager finishes processing a chunk but the chunk
+    /// is invalid.
+    pub fn on_invalid_chunk(&mut self, encoded_chunk: EncodedShardChunk) {
+        let mut update = self.chain.mut_store().store_update();
+        update.save_invalid_chunk(encoded_chunk);
+        if let Err(err) = update.commit() {
+            error!(target: "client", "Error saving invalid chunk: {:?}", err);
+        }
     }
 
     /// Let the ShardsManager know about the chunk header, when encountering that chunk header
@@ -1013,7 +1026,7 @@ impl Client {
         header: &ShardChunkHeader,
     ) -> Result<(), Error> {
         if self.shards_mgr.insert_header_if_not_exists_and_process_cached_chunk_forwards(header) {
-            self.shards_mgr.try_process_chunk_parts_and_receipts(header, self.chain.mut_store())?;
+            self.shards_mgr.try_process_chunk_parts_and_receipts(header)?;
         }
         Ok(())
     }
@@ -1303,16 +1316,14 @@ impl Client {
                             block.header().height() + 1,
                             shard_id,
                         ) {
-                            Ok(Some((encoded_chunk, merkle_paths, receipts))) => self
-                                .shards_mgr
-                                .distribute_encoded_chunk(
+                            Ok(Some((encoded_chunk, merkle_paths, receipts))) => {
+                                self.persist_and_distribute_encoded_chunk(
                                     encoded_chunk,
                                     merkle_paths,
                                     receipts,
-                                    self.chain.mut_store(),
-                                    shard_id,
                                 )
-                                .expect("Failed to process produced chunk"),
+                                .expect("Failed to process produced chunk");
+                            }
                             Ok(None) => {}
                             Err(err) => {
                                 error!(target: "client", "Error producing chunk {:?}", err);
@@ -1323,6 +1334,23 @@ impl Client {
             }
         }
         self.check_incomplete_chunks(block.hash());
+    }
+
+    pub fn persist_and_distribute_encoded_chunk(
+        &mut self,
+        encoded_chunk: EncodedShardChunk,
+        merkle_paths: Vec<MerklePath>,
+        receipts: Vec<Receipt>,
+    ) -> Result<(), Error> {
+        let (shard_chunk, partial_chunk) =
+            self.chunks_logic.decode_encoded_chunk(&encoded_chunk, merkle_paths.clone())?;
+        self.chunks_logic.persist_chunk(
+            partial_chunk,
+            Some(shard_chunk),
+            self.chain.mut_store(),
+        )?;
+        self.shards_mgr.distribute_encoded_chunk(encoded_chunk, &merkle_paths, receipts)?;
+        Ok(())
     }
 
     pub fn request_missing_chunks(

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -7,7 +7,9 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use near_chunks::client::ClientAdapterForShardsManager;
-use near_chunks::logic::{cares_about_shard_this_or_next_epoch, persist_chunk, decode_encoded_chunk};
+use near_chunks::logic::{
+    cares_about_shard_this_or_next_epoch, decode_encoded_chunk, persist_chunk,
+};
 use near_client_primitives::debug::ChunkProduction;
 use near_primitives::time::Clock;
 use tracing::{debug, error, info, trace, warn};
@@ -1343,13 +1345,13 @@ impl Client {
         merkle_paths: Vec<MerklePath>,
         receipts: Vec<Receipt>,
     ) -> Result<(), Error> {
-        let (shard_chunk, partial_chunk) =
-            decode_encoded_chunk(&encoded_chunk, merkle_paths.clone(), self.me.as_ref(), self.runtime_adapter.as_ref())?;
-        persist_chunk(
-            partial_chunk,
-            Some(shard_chunk),
-            self.chain.mut_store(),
+        let (shard_chunk, partial_chunk) = decode_encoded_chunk(
+            &encoded_chunk,
+            merkle_paths.clone(),
+            self.me.as_ref(),
+            self.runtime_adapter.as_ref(),
         )?;
+        persist_chunk(partial_chunk, Some(shard_chunk), self.chain.mut_store())?;
         self.shards_mgr.distribute_encoded_chunk(encoded_chunk, &merkle_paths, receipts)?;
         Ok(())
     }

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -23,6 +23,7 @@ use near_chain::{
 };
 use near_chain_configs::ClientConfig;
 use near_chunks::client::ShardsManagerResponse;
+use near_chunks::logic::cares_about_shard_this_or_next_epoch;
 use near_client_primitives::types::{
     Error, GetNetworkInfo, NetworkInfoResponse, ShardSyncDownload, ShardSyncStatus, Status,
     StatusError, StatusSyncInfo, SyncStatus,
@@ -1701,11 +1702,12 @@ impl ClientActor {
                 let shards_to_sync =
                     (0..self.client.runtime_adapter.num_shards(&epoch_id).unwrap())
                         .filter(|x| {
-                            self.client.chunks_logic.cares_about_shard_this_or_next_epoch(
+                            cares_about_shard_this_or_next_epoch(
                                 me.as_ref(),
                                 &prev_hash,
                                 *x,
                                 true,
+                                self.client.runtime_adapter.as_ref(),
                             )
                         })
                         .collect();

--- a/chain/client/src/tests/chunks_management.rs
+++ b/chain/client/src/tests/chunks_management.rs
@@ -22,20 +22,12 @@ fn test_request_chunk_restart() {
         tracking_shards: HashSet::default(),
     };
     let client = &mut env.clients[0];
-    client.shards_mgr.process_partial_encoded_chunk_request(
-        request.clone(),
-        CryptoHash::default(),
-        client.chain.mut_store(),
-    );
+    client.shards_mgr.process_partial_encoded_chunk_request(request.clone(), CryptoHash::default());
     assert!(env.network_adapters[0].pop().is_some());
 
     env.restart(0);
     let client = &mut env.clients[0];
-    client.shards_mgr.process_partial_encoded_chunk_request(
-        request,
-        CryptoHash::default(),
-        client.chain.mut_store(),
-    );
+    client.shards_mgr.process_partial_encoded_chunk_request(request, CryptoHash::default());
     let response = env.network_adapters[0].pop().unwrap().as_network_requests();
 
     if let NetworkRequests::PartialEncodedChunkResponse { response: response_body, .. } = response {

--- a/integration-tests/src/tests/client/challenges.rs
+++ b/integration-tests/src/tests/client/challenges.rs
@@ -382,14 +382,7 @@ fn test_verify_chunk_invalid_state_challenge() {
 
     // Receive invalid chunk to the validator.
     client
-        .shards_mgr
-        .distribute_encoded_chunk(
-            invalid_chunk.clone(),
-            merkle_paths,
-            vec![],
-            client.chain.mut_store(),
-            0,
-        )
+        .persist_and_distribute_encoded_chunk(invalid_chunk.clone(), merkle_paths, vec![])
         .unwrap();
 
     match &mut invalid_chunk {
@@ -507,14 +500,7 @@ fn test_receive_invalid_chunk_as_chunk_producer() {
     let (chunk, merkle_paths, receipts, block) = create_invalid_proofs_chunk(&mut env.clients[0]);
     let client = &mut env.clients[0];
     assert!(client
-        .shards_mgr
-        .distribute_encoded_chunk(
-            chunk.clone(),
-            merkle_paths.clone(),
-            receipts.clone(),
-            client.chain.mut_store(),
-            0,
-        )
+        .persist_and_distribute_encoded_chunk(chunk.clone(), merkle_paths.clone(), receipts.clone())
         .is_err());
     let result = client.process_block_test(block.clone().into(), Provenance::NONE);
     // We have declined block with invalid chunk.

--- a/integration-tests/src/tests/client/runtimes.rs
+++ b/integration-tests/src/tests/client/runtimes.rs
@@ -155,11 +155,9 @@ fn test_process_partial_encoded_chunk_with_missing_block() {
 
     // process_partial_encoded_chunk should return Ok(NeedBlock) if the chunk is
     // based on a missing block.
-    let result = client.shards_mgr.process_partial_encoded_chunk(
-        MaybeValidated::from(mock_chunk.clone()),
-        None,
-        client.chain.mut_store(),
-    );
+    let result = client
+        .shards_mgr
+        .process_partial_encoded_chunk(MaybeValidated::from(mock_chunk.clone()), None);
     assert_matches!(result, Ok(ProcessPartialEncodedChunkResult::NeedBlock));
 
     // Client::process_partial_encoded_chunk should not return an error

--- a/integration-tests/src/tests/client/sharding_upgrade.rs
+++ b/integration-tests/src/tests/client/sharding_upgrade.rs
@@ -182,6 +182,9 @@ impl TestShardUpgradeEnv {
         );
 
         env.process_partial_encoded_chunks();
+        for j in 0..self.num_clients {
+            env.process_shards_manager_responses_and_finish_processing_blocks(j);
+        }
 
         // after state split, check chunk extra exists and the states are correct
         for account_id in self.initial_accounts.iter() {


### PR DESCRIPTION
ShardsManager currently needs mutable access to ChainStore for persisting PartialEncodedChunk (for parts and receipts that the node tracks), ShardChunk (if the chunk is Reed-Solomon reconstructible), and EncodedShardChunk for chunks that were invalid. This PR moves all these writes out from the ShardsManager, into the Client. They are persisted in three ways:

When on_chunk_completed(partial_chunk: PartialEncodedChunk, shard_chunk: Option<ShardChunk>) is called (which is invoked by the ClientActor upon receiving a ChunkCompleted message sent by ShardsManager), we persist the partial chunk and optionally the shard chunk.
Similar case as above, but for on_invalid_chunk(encoded_chunk: EncodedShardChunk).
When we are a chunk producer and produces a chunk; we immediately persist the PartialEncodedChunk and ShardChunk (before handing over the chunk to the ShardsManager for distribution).
Some logic is refactored out from the ShardsManager into ChunksLogic. This is because the Client also needs some of this logic (for case #3 above). The ChunksLogic code is mostly identical to the original code from ShardsManager except that whenever the old code would persist the chunks, the new code would return them and have the caller handle the next steps.

The ShardsManager still needs read-only access to chunks; for that, a simple ReadOnlyChunksStore is introduced which contains caching for the partial chunks and shard chunks columns. Caching here is fine because these columns are never mutated once written.