### PR TITLE
bug: combine checks in themis and replace warning with bug

### DIFF
--- a/tools/themis/src/main.rs
+++ b/tools/themis/src/main.rs
@@ -12,7 +12,6 @@ fn main() -> anyhow::Result<()> {
         rules::is_unversioned,
         rules::has_publish_spec,
         rules::has_rust_version,
-        rules::has_debuggable_rust_version,
         rules::has_unified_rust_edition,
         rules::author_is_near,
         rules::publishable_has_license,

--- a/tools/themis/src/rules.rs
+++ b/tools/themis/src/rules.rs
@@ -1,9 +1,7 @@
-use std::collections::HashMap;
-
-use anyhow::{bail, Context};
-
 use super::types::{ComplianceError, Expected, Outlier, Workspace};
 use super::{style, utils};
+use anyhow::{bail, Context};
+use std::collections::HashMap;
 
 /// Ensure all crates have the `publish = <true/false>` specification
 pub fn has_publish_spec(workspace: &Workspace) -> anyhow::Result<()> {
@@ -25,21 +23,58 @@ pub fn has_publish_spec(workspace: &Workspace) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Ensure all crates specify a MSRV
+/// Ensure all crates specify a MSRV and that it is <= to the version in the
+/// rust-toolchain.toml file.
 pub fn has_rust_version(workspace: &Workspace) -> anyhow::Result<()> {
-    let outliers: Vec<_> = workspace
-        .members
-        .iter()
-        .filter(|pkg| pkg.parsed.rust_version.is_none())
-        .map(|pkg| Outlier { path: pkg.parsed.manifest_path.clone(), found: None })
-        .collect();
+    let rust_toolchain =
+        utils::parse_toml::<toml::Value>(&workspace.root.join("rust-toolchain.toml"))
+            .context("Failed to read rust-toolchain file")?;
+    let rust_toolchain = rust_toolchain["toolchain"]["channel"].as_str().unwrap().to_owned();
+    let rust_toolchain = match semver::Version::parse(&rust_toolchain) {
+        Ok(rust_toolchain) => rust_toolchain,
+        Err(err) => {
+            bail!(
+                "semver: unable to parse rustup channel from {}: {}",
+                style::highlight("rust-toolchain.toml"),
+                err
+            );
+        }
+    };
 
-    if !outliers.is_empty() {
+    let mut no_rust_version = vec![];
+    let mut wrong_rust_version = vec![];
+
+    for pkg in &workspace.members {
+        match &pkg.parsed.rust_version {
+            Some(rust_version) => {
+                if !rust_version.matches(&rust_toolchain) {
+                    wrong_rust_version.push(Outlier {
+                        path: pkg.parsed.manifest_path.clone(),
+                        found: Some(format!("{}", rust_version)),
+                    });
+                }
+            }
+            None => no_rust_version
+                .push(Outlier { path: pkg.parsed.manifest_path.clone(), found: None }),
+        }
+    }
+
+    if !no_rust_version.is_empty() {
         bail!(ComplianceError {
             msg: "These packages should specify a Minimum Supported Rust Version (MSRV)"
                 .to_string(),
             expected: None,
-            outliers,
+            outliers: no_rust_version,
+        });
+    }
+    if !wrong_rust_version.is_empty() {
+        bail!(ComplianceError {
+            msg: "These packages have an incompatible `rust-version`".to_string(),
+            expected: Some(Expected {
+                value: format!("<={}", rust_toolchain),
+                reason: Some("as defined in the `rust-toolchain`".to_string()),
+            }),
+            outliers: wrong_rust_version,
         });
     }
 
@@ -65,59 +100,6 @@ pub fn is_unversioned(workspace: &Workspace) -> anyhow::Result<()> {
         bail!(ComplianceError {
             msg: "These packages shouldn't be versioned".to_string(),
             expected: Some(Expected { value: "0.0.0".to_string(), reason: None }),
-            outliers,
-        });
-    }
-
-    Ok(())
-}
-
-/// Ensures all crates have a rust-version spec less than
-/// or equal to the version defined in rust-toolchain.toml
-pub fn has_debuggable_rust_version(workspace: &Workspace) -> anyhow::Result<()> {
-    let rust_toolchain =
-        utils::parse_toml::<toml::Value>(&workspace.root.join("rust-toolchain.toml"))
-            .context("Failed to read rust-toolchain file")?;
-    let rust_toolchain = rust_toolchain["toolchain"]["channel"].as_str().unwrap().to_owned();
-
-    let rust_toolchain = match semver::Version::parse(&rust_toolchain) {
-        Ok(rust_toolchain) => rust_toolchain,
-        Err(err) => {
-            utils::warn!(
-                "semver: unable to parse rustup channel from {}: {}",
-                style::highlight("rust-toolchain.toml"),
-                err
-            );
-
-            return Ok(());
-        }
-    };
-
-    let mut outliers = vec![];
-    for pkg in &workspace.members {
-        match &pkg.parsed.rust_version {
-            Some(rust_version) => {
-                if !rust_version.matches(&rust_toolchain) {
-                    outliers.push(Outlier {
-                        path: pkg.parsed.manifest_path.clone(),
-                        found: Some(format!("{}", rust_version)),
-                    });
-                }
-            }
-            None => {
-                // we can skip, since we have has_rust_version check
-                continue;
-            }
-        }
-    }
-
-    if !outliers.is_empty() {
-        bail!(ComplianceError {
-            msg: "These packages have an incompatible `rust-version`".to_string(),
-            expected: Some(Expected {
-                value: format!("<={}", rust_toolchain),
-                reason: Some("as defined in the `rust-toolchain`".to_string()),
-            }),
             outliers,
         });
     }

--- a/tools/themis/src/utils.rs
+++ b/tools/themis/src/utils.rs
@@ -12,8 +12,6 @@ macro_rules! _warn {
     }
 }
 
-pub(crate) use _warn as warn;
-
 pub fn parse_toml<T: DeserializeOwned>(path: &Utf8PathBuf) -> anyhow::Result<T> {
     Ok(toml::from_slice(&fs::read(path)?)?)
 }


### PR DESCRIPTION
themis has two functions that perform similar checks:
- `has_rust_version`: which ensures that each crate specifies a MSRV
- `has_debuggable_rust_version`: which is incorrectly named and ensures that the MSRV is <= than the version than the version in rust-toolchain.toml.

This PR does the following:
- combines the logic of the above two functions into `has_rust_version`.
- replaces a warning with error if rust-toolchain.toml cannot be properly parsed.  This is to ensure that failures are properly caught in CI.