### PR TITLE
fix: do not block on prefetcher

### DIFF
--- a/core/store/src/trie/prefetching_trie_storage.rs
+++ b/core/store/src/trie/prefetching_trie_storage.rs
@@ -409,7 +409,7 @@ impl PrefetchApi {
         root: StateRoot,
         trie_key: TrieKey,
     ) -> Result<(), (StateRoot, TrieKey)> {
-        self.work_queue_tx.send((root, trie_key)).map_err(|e| e.0)
+        self.work_queue_tx.try_send((root, trie_key)).map_err(|e| e.into_inner())
     }
 
     pub fn start_io_thread(


### PR DESCRIPTION
The bounded queue was intended to drop new requests on the sender side
instead of blocking the main thread.

The prefetching requests we send today are at least 100 times fewer
than what fits in the channel, and only white listed accounts can even
trigger it. So this is not a concern in practice, yet.