### PR TITLE
chore(ci): Updated the error message that themis would display when publishable crates depend on private crates

### DIFF
--- a/tools/themis/src/rules.rs
+++ b/tools/themis/src/rules.rs
@@ -314,7 +314,7 @@ pub fn recursively_publishable(workspace: &Workspace) -> anyhow::Result<()> {
     }
     if !outliers.is_empty() {
         bail!(ComplianceError {
-            msg: "These private packages are depended on by publishable packages".to_string(),
+            msg: "These private crates break publishable crates. Either make these private crates publishable or avoid using them in the publishable crates".to_string(),
             expected: None,
             outliers: outliers
                 .into_iter()


### PR DESCRIPTION
The original message was hard to understand at a first glance.

https://github.com/near/nearcore/pull/7707#discussion_r982229651