### PR TITLE
Verify that crates and rust-toolchain.toml specify same version

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -75,6 +75,7 @@ steps:
       cargo build -p neard --bin neard
       python3 scripts/state/update_res.py check
 
+      python3 scripts/check_rust-version.py
       python3 scripts/check_nightly.py
       python3 scripts/check_pytests.py
       python3 scripts/check_fuzzing.py

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,6 @@
 [toolchain]
-# This specifies the version of Rust we use to build.
-# Individual crates in the workspace may support a lower version, as indicated by `rust-version` field in each crate's `Cargo.toml`.
-# The version specified below, should be at least as high as the maximum `rust-version` within the workspace.
+# This specifies the version of Rust we use to build.  Must equal
+# workspace.package.rust-version value in Cargo.toml.
 channel = "1.64.0"
 components = [ "rustfmt" ]
 targets = [ "wasm32-unknown-unknown" ]

--- a/scripts/check_rust-version.py
+++ b/scripts/check_rust-version.py
@@ -1,0 +1,96 @@
+"""Checks that we specify the same Rust version requirements everywhere."""
+import collections
+import os
+import subprocess
+import sys
+import typing
+
+import toml
+
+# List of crates which can have a different package.rust-version
+WHITELIST = [
+    'core/account-id',
+]
+
+
+def get(toml_value, *names):
+    """Returns nested field from given TOML object"""
+    for name in names:
+        if not isinstance(toml_value, dict):
+            return None
+        toml_value = toml_value.get(name, None)
+    return toml_value
+
+
+def get_rust_toolchain_channel() -> str:
+    """Returns ‘toolchain.channel’ value from rust-toolchain.toml file.
+
+    If the channel is not specified, raises SytemExit exception.
+    """
+    path = 'rust-toolchain.toml'
+    with open(path) as rd:
+        data = toml.load(rd)
+    channel = get(data, 'toolchain', 'channel')
+    if not channel:
+        sys.exit(f'{path}: ‘toolchain.channel’ not set')
+    return str(channel)
+
+
+def get_rust_version(path: str) -> typing.Optional[str]:
+    """Returns package.rust-version value from given Cargo.toml file.
+
+    If the rust-version is specified as inherited from workspace, returns
+    `None`.  If the value is not specified but workspace.package.rust-version
+    is, reads that value.  If neither values are provided, raises SytemExit
+    exception.
+    """
+    with open(path) as rd:
+        data = toml.load(rd)
+    version = get(data, 'package', 'rust-version')
+    if version:
+        if get(version, 'workspace'):
+            return None
+        return str(version)
+    version = get(data, 'workspace', 'package', 'rust-version')
+    if not version:
+        sys.exit(f'{path}: ‘package.rust-version’ not set')
+    return str(version)
+
+
+def get_all_versions() -> typing.Dict[str, typing.Sequence[str]]:
+    """Reads all rust versions specified throughout the repository"""
+    versions = collections.defaultdict(list)
+    versions[get_rust_toolchain_channel()].append('rust-toolchain.toml')
+
+    whitelist = {os.path.join(crate, 'Cargo.toml') for crate in WHITELIST}
+
+    out = subprocess.check_output(('git', 'ls-tree', '-zr', '--name-only', '@'),
+                                  text=True)
+    for name in out.split('\0'):
+        if (not name.startswith('pytest/') and
+            not name in whitelist and
+            (name == 'Cargo.toml' or name.endswith('/Cargo.toml'))):
+            version = get_rust_version(name)
+            if version:
+                versions[version].append(name)
+
+    return versions
+
+
+def main() -> int:
+    versions = get_all_versions()
+    if len(versions) == 1:
+        return 0
+
+    print('Found different Rust version strings', file=sys.stderr)
+    for version in sorted(versions):
+        files = versions[version]
+        files.sort()
+        print(f'[version {version}]', file=sys.stderr)
+        for name in files:
+            print(f'- {name}', file=sys.stderr)
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Add check_rust-version.py script and CI step which verifies that all
crates specify the same Rust version which is also the same given in
rust-toolchain.toml.  This makes sure that if we upgrade a version in
one place it’s updated everywhere else.

Fixes: https://github.com/near/nearcore/issues/6124
