### PR TITLE
feat: allow passing `--home` and `--verbose` with every subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
-## [unreleased]
+## unreleased
+
+### Protocol Changes
+
+*
+
+### Non-protocol Changes
+
+* `neard` now accepts `--home` and `--verbose` anywhere in the command line: `neard run --home ./near`.
+
+
+## 1.29.0 []
 
 ### Protocol Changes
 

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -123,10 +123,10 @@ pub(super) struct StateViewerCommand {
 struct NeardOpts {
     /// Sets verbose logging for the given target, or for all targets if no
     /// target is given.
-    #[clap(long, name = "target")]
+    #[clap(long, global(true), name = "target")]
     verbose: Option<Option<String>>,
     /// Directory for config and data.
-    #[clap(long, parse(from_os_str), default_value_os = crate::DEFAULT_HOME.as_os_str())]
+    #[clap(long, global(true), parse(from_os_str), default_value_os = crate::DEFAULT_HOME.as_os_str())]
     home: PathBuf,
     /// Skips consistency checks of the 'genesis.json' file upon startup.
     /// Let's you start `neard` slightly faster.


### PR DESCRIPTION
Before, `neard run --home ./near` gave an error, now both of these work:

```
$ neard run --home ./near
$ neard --home ./near run
```