### PR TITLE
feat(state-viewer): simple gas counter extraction 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5356,6 +5356,7 @@ dependencies = [
  "anyhow",
  "borsh",
  "clap 3.1.18",
+ "insta",
  "near-chain",
  "near-chain-configs",
  "near-client",

--- a/core/primitives-core/src/parameter.rs
+++ b/core/primitives-core/src/parameter.rs
@@ -240,7 +240,9 @@ impl Parameter {
             Parameter::WasmRipemd160Base,
             Parameter::WasmRipemd160Block,
             Parameter::WasmEcrecoverBase,
+            #[cfg(feature = "protocol_feature_ed25519_verify")]
             Parameter::WasmEd25519VerifyBase,
+            #[cfg(feature = "protocol_feature_ed25519_verify")]
             Parameter::WasmEd25519VerifyByte,
             Parameter::WasmLogBase,
             Parameter::WasmLogByte,

--- a/core/primitives-core/src/parameter.rs
+++ b/core/primitives-core/src/parameter.rs
@@ -110,9 +110,7 @@ pub enum Parameter {
     WasmRipemd160Base,
     WasmRipemd160Block,
     WasmEcrecoverBase,
-    #[cfg(feature = "protocol_feature_ed25519_verify")]
     WasmEd25519VerifyBase,
-    #[cfg(feature = "protocol_feature_ed25519_verify")]
     WasmEd25519VerifyByte,
     WasmLogBase,
     WasmLogByte,
@@ -242,9 +240,7 @@ impl Parameter {
             Parameter::WasmRipemd160Base,
             Parameter::WasmRipemd160Block,
             Parameter::WasmEcrecoverBase,
-            #[cfg(feature = "protocol_feature_ed25519_verify")]
             Parameter::WasmEd25519VerifyBase,
-            #[cfg(feature = "protocol_feature_ed25519_verify")]
             Parameter::WasmEd25519VerifyByte,
             Parameter::WasmLogBase,
             Parameter::WasmLogByte,
@@ -402,6 +398,8 @@ impl Parameter {
             Parameter::WasmEd25519VerifyByte => {
                 Some(Cost::ExtCost { ext_cost_kind: ExtCosts::ed25519_verify_byte })
             }
+            #[cfg(not(feature = "protocol_feature_ed25519_verify"))]
+            Parameter::WasmEd25519VerifyBase | Parameter::WasmEd25519VerifyByte => None,
             Parameter::WasmLogBase => Some(Cost::ExtCost { ext_cost_kind: ExtCosts::log_base }),
             Parameter::WasmLogByte => Some(Cost::ExtCost { ext_cost_kind: ExtCosts::log_byte }),
             Parameter::WasmStorageWriteBase => {

--- a/core/primitives-core/src/parameter.rs
+++ b/core/primitives-core/src/parameter.rs
@@ -1,3 +1,5 @@
+use crate::config::{ActionCosts, ExtCosts};
+use crate::profile::Cost;
 use std::slice;
 
 /// Protocol configuration parameter which may change between protocol versions.
@@ -108,7 +110,9 @@ pub enum Parameter {
     WasmRipemd160Base,
     WasmRipemd160Block,
     WasmEcrecoverBase,
+    #[cfg(feature = "protocol_feature_ed25519_verify")]
     WasmEd25519VerifyBase,
+    #[cfg(feature = "protocol_feature_ed25519_verify")]
     WasmEd25519VerifyByte,
     WasmLogBase,
     WasmLogByte,
@@ -238,7 +242,9 @@ impl Parameter {
             Parameter::WasmRipemd160Base,
             Parameter::WasmRipemd160Block,
             Parameter::WasmEcrecoverBase,
+            #[cfg(feature = "protocol_feature_ed25519_verify")]
             Parameter::WasmEd25519VerifyBase,
+            #[cfg(feature = "protocol_feature_ed25519_verify")]
             Parameter::WasmEd25519VerifyByte,
             Parameter::WasmLogBase,
             Parameter::WasmLogByte,
@@ -311,5 +317,369 @@ impl Parameter {
             Parameter::AccountIdValidityRulesVersion,
         ]
         .iter()
+    }
+
+    pub fn cost(self) -> Option<Cost> {
+        match self {
+            // wasm op
+            Parameter::WasmRegularOpCost => Some(Cost::WasmInstruction),
+            // wasm execution ext costs
+            Parameter::WasmBase => Some(Cost::ExtCost { ext_cost_kind: ExtCosts::base }),
+            Parameter::WasmContractLoadingBase => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::contract_loading_base })
+            }
+            Parameter::WasmContractLoadingBytes => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::contract_loading_bytes })
+            }
+            Parameter::WasmReadMemoryBase => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::read_memory_base })
+            }
+            Parameter::WasmReadMemoryByte => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::read_memory_byte })
+            }
+            Parameter::WasmWriteMemoryBase => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::write_memory_base })
+            }
+            Parameter::WasmWriteMemoryByte => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::write_memory_byte })
+            }
+            Parameter::WasmReadRegisterBase => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::read_register_base })
+            }
+            Parameter::WasmReadRegisterByte => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::read_register_byte })
+            }
+            Parameter::WasmWriteRegisterBase => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::write_register_base })
+            }
+            Parameter::WasmWriteRegisterByte => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::write_register_byte })
+            }
+            Parameter::WasmUtf8DecodingBase => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::utf8_decoding_base })
+            }
+            Parameter::WasmUtf8DecodingByte => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::utf8_decoding_byte })
+            }
+            Parameter::WasmUtf16DecodingBase => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::utf16_decoding_base })
+            }
+            Parameter::WasmUtf16DecodingByte => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::utf16_decoding_byte })
+            }
+            Parameter::WasmSha256Base => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::sha256_base })
+            }
+            Parameter::WasmSha256Byte => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::sha256_byte })
+            }
+            Parameter::WasmKeccak256Base => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::keccak256_base })
+            }
+            Parameter::WasmKeccak256Byte => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::keccak256_byte })
+            }
+            Parameter::WasmKeccak512Base => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::keccak512_base })
+            }
+            Parameter::WasmKeccak512Byte => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::keccak512_byte })
+            }
+            Parameter::WasmRipemd160Base => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::ripemd160_base })
+            }
+            Parameter::WasmRipemd160Block => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::ripemd160_block })
+            }
+            Parameter::WasmEcrecoverBase => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::ecrecover_base })
+            }
+            #[cfg(feature = "protocol_feature_ed25519_verify")]
+            Parameter::WasmEd25519VerifyBase => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::ed25519_verify_base })
+            }
+            #[cfg(feature = "protocol_feature_ed25519_verify")]
+            Parameter::WasmEd25519VerifyByte => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::ed25519_verify_byte })
+            }
+            Parameter::WasmLogBase => Some(Cost::ExtCost { ext_cost_kind: ExtCosts::log_base }),
+            Parameter::WasmLogByte => Some(Cost::ExtCost { ext_cost_kind: ExtCosts::log_byte }),
+            Parameter::WasmStorageWriteBase => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::storage_write_base })
+            }
+            Parameter::WasmStorageWriteKeyByte => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::storage_write_key_byte })
+            }
+            Parameter::WasmStorageWriteValueByte => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::storage_write_value_byte })
+            }
+            Parameter::WasmStorageWriteEvictedByte => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::storage_write_evicted_byte })
+            }
+            Parameter::WasmStorageReadBase => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::storage_read_base })
+            }
+            Parameter::WasmStorageReadKeyByte => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::storage_read_key_byte })
+            }
+            Parameter::WasmStorageReadValueByte => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::storage_read_value_byte })
+            }
+            Parameter::WasmStorageRemoveBase => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::storage_remove_base })
+            }
+            Parameter::WasmStorageRemoveKeyByte => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::storage_remove_key_byte })
+            }
+            Parameter::WasmStorageRemoveRetValueByte => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::storage_remove_ret_value_byte })
+            }
+            Parameter::WasmStorageHasKeyBase => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::storage_has_key_base })
+            }
+            Parameter::WasmStorageHasKeyByte => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::storage_has_key_byte })
+            }
+            Parameter::WasmStorageIterCreatePrefixBase => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::storage_iter_create_prefix_base })
+            }
+            Parameter::WasmStorageIterCreatePrefixByte => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::storage_iter_create_prefix_byte })
+            }
+            Parameter::WasmStorageIterCreateRangeBase => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::storage_iter_create_range_base })
+            }
+            Parameter::WasmStorageIterCreateFromByte => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::storage_iter_create_from_byte })
+            }
+            Parameter::WasmStorageIterCreateToByte => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::storage_iter_create_to_byte })
+            }
+            Parameter::WasmStorageIterNextBase => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::storage_iter_next_base })
+            }
+            Parameter::WasmStorageIterNextKeyByte => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::storage_iter_next_key_byte })
+            }
+            Parameter::WasmStorageIterNextValueByte => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::storage_iter_next_value_byte })
+            }
+            Parameter::WasmTouchingTrieNode => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::touching_trie_node })
+            }
+            Parameter::WasmReadCachedTrieNode => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::read_cached_trie_node })
+            }
+            Parameter::WasmPromiseAndBase => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::promise_and_base })
+            }
+            Parameter::WasmPromiseAndPerPromise => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::promise_and_per_promise })
+            }
+            Parameter::WasmPromiseReturn => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::promise_return })
+            }
+            Parameter::WasmValidatorStakeBase => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::validator_stake_base })
+            }
+            Parameter::WasmValidatorTotalStakeBase => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::validator_total_stake_base })
+            }
+            Parameter::WasmAltBn128G1MultiexpBase => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::alt_bn128_g1_multiexp_base })
+            }
+            Parameter::WasmAltBn128G1MultiexpElement => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::alt_bn128_g1_multiexp_element })
+            }
+            Parameter::WasmAltBn128PairingCheckBase => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::alt_bn128_pairing_check_base })
+            }
+            Parameter::WasmAltBn128PairingCheckElement => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::alt_bn128_pairing_check_element })
+            }
+            Parameter::WasmAltBn128G1SumBase => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::alt_bn128_g1_sum_base })
+            }
+            Parameter::WasmAltBn128G1SumElement => {
+                Some(Cost::ExtCost { ext_cost_kind: ExtCosts::alt_bn128_g1_sum_element })
+            }
+
+            Parameter::WasmGrowMemCost => todo!(),
+
+            // actions
+            Parameter::ActionCreateAccountSendSir => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::create_account })
+            }
+            Parameter::ActionCreateAccountSendNotSir => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::create_account })
+            }
+            Parameter::ActionCreateAccountExecution => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::create_account })
+            }
+            Parameter::ActionDeleteAccountSendSir => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::delete_account })
+            }
+            Parameter::ActionDeleteAccountSendNotSir => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::delete_account })
+            }
+            Parameter::ActionDeleteAccountExecution => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::delete_account })
+            }
+            Parameter::ActionDeployContractSendSir => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::deploy_contract })
+            }
+            Parameter::ActionDeployContractSendNotSir => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::deploy_contract })
+            }
+            Parameter::ActionDeployContractExecution => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::deploy_contract })
+            }
+            Parameter::ActionDeployContractPerByteSendSir => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::deploy_contract })
+            }
+            Parameter::ActionDeployContractPerByteSendNotSir => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::deploy_contract })
+            }
+            Parameter::ActionDeployContractPerByteExecution => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::deploy_contract })
+            }
+            Parameter::ActionFunctionCallSendSir => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::function_call })
+            }
+            Parameter::ActionFunctionCallSendNotSir => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::function_call })
+            }
+            Parameter::ActionFunctionCallExecution => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::function_call })
+            }
+            Parameter::ActionFunctionCallPerByteSendSir => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::function_call })
+            }
+            Parameter::ActionFunctionCallPerByteSendNotSir => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::function_call })
+            }
+            Parameter::ActionFunctionCallPerByteExecution => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::function_call })
+            }
+            Parameter::ActionTransferSendSir => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::transfer })
+            }
+            Parameter::ActionTransferSendNotSir => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::transfer })
+            }
+            Parameter::ActionTransferExecution => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::transfer })
+            }
+            Parameter::ActionStakeSendSir => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::stake })
+            }
+            Parameter::ActionStakeSendNotSir => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::stake })
+            }
+            Parameter::ActionStakeExecution => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::stake })
+            }
+            Parameter::ActionAddFullAccessKeySendSir => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::add_key })
+            }
+            Parameter::ActionAddFullAccessKeySendNotSir => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::add_key })
+            }
+            Parameter::ActionAddFullAccessKeyExecution => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::add_key })
+            }
+            Parameter::ActionAddFunctionCallKeySendSir => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::add_key })
+            }
+            Parameter::ActionAddFunctionCallKeySendNotSir => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::add_key })
+            }
+            Parameter::ActionAddFunctionCallKeyExecution => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::add_key })
+            }
+            Parameter::ActionAddFunctionCallKeyPerByteSendSir => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::add_key })
+            }
+            Parameter::ActionAddFunctionCallKeyPerByteSendNotSir => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::add_key })
+            }
+            Parameter::ActionAddFunctionCallKeyPerByteExecution => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::add_key })
+            }
+            Parameter::ActionDeleteKeySendSir => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::delete_key })
+            }
+            Parameter::ActionDeleteKeySendNotSir => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::delete_key })
+            }
+            Parameter::ActionDeleteKeyExecution => {
+                Some(Cost::ActionCost { action_cost_kind: ActionCosts::delete_key })
+            }
+
+            // vm limits
+            Parameter::MaxGasBurnt
+            | Parameter::MaxStackHeight
+            | Parameter::StackLimiterVersion
+            | Parameter::InitialMemoryPages
+            | Parameter::MaxMemoryPages
+            | Parameter::RegistersMemoryLimit
+            | Parameter::MaxRegisterSize
+            | Parameter::MaxNumberRegisters
+            | Parameter::MaxNumberLogs
+            | Parameter::MaxTotalLogLength
+            | Parameter::MaxTotalPrepaidGas
+            | Parameter::MaxActionsPerReceipt
+            | Parameter::MaxNumberBytesMethodNames
+            | Parameter::MaxLengthMethodName
+            | Parameter::MaxArgumentsLength
+            | Parameter::MaxLengthReturnedData
+            | Parameter::MaxContractSize
+            | Parameter::MaxTransactionSize
+            | Parameter::MaxLengthStorageKey
+            | Parameter::MaxLengthStorageValue
+            | Parameter::MaxPromisesPerFunctionCallAction
+            | Parameter::MaxNumberInputDataDependencies
+            | Parameter::MaxFunctionsNumberPerContract
+            | Parameter::Wasmer2StackLimit
+            | Parameter::MaxLocalsPerContract
+            | Parameter::AccountIdValidityRulesVersion => None,
+
+            // other
+            Parameter::BurntGasRewardNumerator
+            | Parameter::BurntGasRewardDenominator
+            | Parameter::PessimisticGasPriceInflationNumerator
+            | Parameter::PessimisticGasPriceInflationDenominator
+            | Parameter::MinAllowedTopLevelAccountLength
+            | Parameter::RegistrarAccountId
+            | Parameter::StorageAmountPerByte
+            | Parameter::StorageNumBytesAccount
+            | Parameter::StorageNumExtraBytesRecord
+            | Parameter::ActionReceiptCreationSendSir
+            | Parameter::ActionReceiptCreationSendNotSir
+            | Parameter::ActionReceiptCreationExecution
+            | Parameter::DataReceiptCreationBaseSendSir
+            | Parameter::DataReceiptCreationBaseSendNotSir
+            | Parameter::DataReceiptCreationBaseExecution
+            | Parameter::DataReceiptCreationPerByteSendSir
+            | Parameter::DataReceiptCreationPerByteSendNotSir
+            | Parameter::DataReceiptCreationPerByteExecution
+            | Parameter::MaxGasBurntView => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Parameter;
+
+    #[test]
+    fn test_parameter_to_cost() {
+        for param in Parameter::ext_costs() {
+            assert!(param.cost().is_some());
+        }
+
+        for param in Parameter::vm_limits() {
+            assert!(param.cost().is_none());
+        }
     }
 }

--- a/tools/state-viewer/Cargo.toml
+++ b/tools/state-viewer/Cargo.toml
@@ -34,6 +34,7 @@ nearcore = { path = "../../nearcore" }
 node-runtime = { path = "../../runtime/runtime" }
 
 [dev-dependencies]
+insta.workspace = true
 near-client = { path = "../../chain/client" }
 testlib = { path = "../../test-utils/testlib" }
 

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -16,6 +16,7 @@ use near_network::iter_peers_from_store;
 use near_primitives::account::id::AccountId;
 use near_primitives::block::{Block, BlockHeader};
 use near_primitives::hash::CryptoHash;
+use near_primitives::runtime::config_store::RuntimeConfigStore;
 use near_primitives::shard_layout::ShardUId;
 use near_primitives::sharding::ChunkHash;
 use near_primitives::state_record::StateRecord;
@@ -32,7 +33,6 @@ use near_store::TrieConfig;
 use near_store::{NodeStorage, Store};
 use nearcore::{NearConfig, NightshadeRuntime};
 use node_runtime::adapter::ViewRuntimeAdapter;
-use node_runtime::near_primitives::runtime::config_store::RuntimeConfigStore;
 use serde_json::json;
 use std::collections::HashMap;
 use std::fs::{self, File};
@@ -832,14 +832,13 @@ pub(crate) fn gas_profile(
         near_config.genesis.config.genesis_height,
         !near_config.client_config.archive,
     );
-    // let receipt = chain_store.get_receipt(&receipt_id)?.expect("receipt not found");
     let outcomes = chain_store.get_outcomes_by_id(&receipt_id)?;
     let config_store = RuntimeConfigStore::new(None);
     let runtime_config = config_store.get_config(protocol_version);
 
     for outcome in outcomes {
         let profile = crate::gas_profile::extract_gas_counters(
-            outcome.outcome_with_id.outcome,
+            &outcome.outcome_with_id.outcome,
             runtime_config,
         );
         let mut out = std::io::stdout().lock();

--- a/tools/state-viewer/src/gas_profile.rs
+++ b/tools/state-viewer/src/gas_profile.rs
@@ -28,7 +28,7 @@ pub(crate) fn extract_gas_counters(
                             let parameter_value =
                                 ext_cost_kind.value(&config.wasm_config.ext_costs);
                             let gas = meta_data.get_ext_cost(ext_cost_kind);
-                            if parameter_value != 0 {
+                            if parameter_value != 0 && gas != 0 {
                                 assert_eq!(
                                     0,
                                     gas % parameter_value,
@@ -58,7 +58,7 @@ pub(crate) fn extract_gas_counters(
 impl std::fmt::Display for GasFeeCounters {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for (param, counter) in self.counters.iter() {
-            writeln!(f, "{param}: {counter}")?;
+            writeln!(f, "{param:<48} {counter:>16}")?;
         }
         Ok(())
     }

--- a/tools/state-viewer/src/gas_profile.rs
+++ b/tools/state-viewer/src/gas_profile.rs
@@ -12,44 +12,54 @@ pub(crate) struct GasFeeCounters {
 }
 
 pub(crate) fn extract_gas_counters(
-    outcome: ExecutionOutcome,
-    config: &RuntimeConfig,
+    outcome: &ExecutionOutcome,
+    runtime_config: &RuntimeConfig,
 ) -> Option<GasFeeCounters> {
-    match outcome.metadata {
+    match &outcome.metadata {
         near_primitives::transaction::ExecutionMetadata::V1 => None,
         near_primitives::transaction::ExecutionMetadata::V2(meta_data) => {
             let mut counters = BTreeMap::new();
+
             for param in Parameter::ext_costs() {
-                if let Some(cost) = param.cost() {
-                    match cost {
-                        // this is tricky because ActionCosts is not 1-to-1 with parameters
-                        Cost::ActionCost { .. } => todo!(),
-                        Cost::ExtCost { ext_cost_kind } => {
-                            let parameter_value =
-                                ext_cost_kind.value(&config.wasm_config.ext_costs);
-                            let gas = meta_data.get_ext_cost(ext_cost_kind);
-                            if parameter_value != 0 && gas != 0 {
-                                assert_eq!(
-                                    0,
-                                    gas % parameter_value,
-                                    "invalid gas profile for given config"
-                                );
-                                let counter = gas / parameter_value;
-                                *counters.entry(*param).or_default() += counter;
-                            }
+                match param.cost().unwrap_or_else(|| panic!("ext cost {param} must have a cost")) {
+                    Cost::ExtCost { ext_cost_kind } => {
+                        let parameter_value =
+                            ext_cost_kind.value(&runtime_config.wasm_config.ext_costs);
+                        let gas = meta_data.get_ext_cost(ext_cost_kind);
+                        if parameter_value != 0 && gas != 0 {
+                            assert_eq!(
+                                0,
+                                gas % parameter_value,
+                                "invalid gas profile for given config"
+                            );
+                            let counter = gas / parameter_value;
+                            *counters.entry(*param).or_default() += counter;
                         }
-                        Cost::WasmInstruction => {
-                            // this is tricky because we have to figure out how much gas has been burnt for function call execution
-                            // let total_gas_burnt_for_fn_calls = ???;
-                            // let gas = meta_data.compute_wasm_instruction_cost(total_gas_burnt_for_fn_calls);
-                            // let counter = gas / config.wasm_config.regular_op_cost;
-                            // counters.insert(param, counter)
-                            todo!()
-                        }
-                    };
-                }
-                // for cost in Cost::ALL {
+                    }
+                    _ => unreachable!("{param} must be ExtCost"),
+                };
             }
+
+            let num_wasm_ops = meta_data[Cost::WasmInstruction]
+                / runtime_config.wasm_config.regular_op_cost as u64;
+            if num_wasm_ops != 0 {
+                *counters.entry(Parameter::WasmRegularOpCost).or_default() += num_wasm_ops;
+            }
+
+            // TODO: Action costs should also be included.
+            // This is tricky, however. From just the gas numbers in the profile
+            // we cannot know the cost is split to parameters. Because base and byte
+            // costs are all merged. Same for different type of access keys.
+            // The only viable way right now is go through each action separately and
+            // recompute the gas cost from scratch. For promises in function
+            // calls that includes looping through outgoing promises and again
+            // recomputing the gas costs.
+            // And of course one has to consider that some actions will be SIR
+            // and some will not be.
+            //
+            // For now it is not clear if implementing this is even worth it.
+            // Alternatively, we could also make the profile data more detailed.
+
             Some(GasFeeCounters { counters })
         }
     }
@@ -61,5 +71,76 @@ impl std::fmt::Display for GasFeeCounters {
             writeln!(f, "{param:<48} {counter:>16}")?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use near_primitives::profile::ProfileData;
+    use near_primitives::transaction::ExecutionMetadata;
+    use near_primitives::types::AccountId;
+    use node_runtime::config::RuntimeConfig;
+
+    #[test]
+    fn test_extract_gas_counters() {
+        let config = RuntimeConfig::test();
+        let costs = [
+            (Parameter::WasmStorageWriteBase, 137),
+            (Parameter::WasmStorageWriteKeyByte, 4629),
+            (Parameter::WasmStorageWriteValueByte, 2246),
+            // note: actions are not included in profile, yet
+            (Parameter::ActionDeployContractExecution, 2 * 184765750000),
+            (Parameter::ActionDeployContractSendSir, 2 * 184765750000),
+            (Parameter::ActionDeployContractPerByteSendSir, 1024 * 6812999),
+            (Parameter::ActionDeployContractPerByteExecution, 1024 * 64572944),
+            (Parameter::WasmRegularOpCost, 7000),
+        ];
+
+        let outcome = create_execution_outcome(&costs, &config);
+        let profile = extract_gas_counters(&outcome, &config).expect("no counters returned");
+
+        insta::assert_display_snapshot!(profile);
+    }
+
+    fn create_execution_outcome(
+        costs: &[(Parameter, u64)],
+        config: &RuntimeConfig,
+    ) -> ExecutionOutcome {
+        let mut gas_burnt = 0;
+        let mut profile_data = ProfileData::new();
+        for &(parameter, value) in costs {
+            match parameter.cost() {
+                Some(Cost::ExtCost { ext_cost_kind }) => {
+                    let gas = value * ext_cost_kind.value(&config.wasm_config.ext_costs);
+                    profile_data.add_ext_cost(ext_cost_kind, gas);
+                    gas_burnt += gas;
+                }
+                Some(Cost::WasmInstruction) => {
+                    let gas = value * config.wasm_config.regular_op_cost as u64;
+                    profile_data[Cost::WasmInstruction] += gas;
+                    gas_burnt += gas;
+                }
+                // Multiplying for actions isn't possible because costs can be
+                // split into multiple parameters. Caller has to specify exact
+                // values.
+                Some(Cost::ActionCost { action_cost_kind }) => {
+                    profile_data.add_action_cost(action_cost_kind, value);
+                    gas_burnt += value;
+                }
+                _ => unimplemented!(),
+            }
+        }
+        let metadata = ExecutionMetadata::V2(profile_data);
+        let account_id: AccountId = "alice.near".to_owned().try_into().unwrap();
+        ExecutionOutcome {
+            logs: vec![],
+            receipt_ids: vec![],
+            gas_burnt,
+            tokens_burnt: 0,
+            executor_id: account_id.clone(),
+            status: near_primitives::transaction::ExecutionStatus::SuccessValue(vec![]),
+            metadata,
+        }
     }
 }

--- a/tools/state-viewer/src/gas_profile.rs
+++ b/tools/state-viewer/src/gas_profile.rs
@@ -1,0 +1,63 @@
+//! State viewer functions to read gas profile information from execution
+//! outcomes stored in RocksDB.
+
+use near_primitives::profile::Cost;
+use near_primitives::transaction::ExecutionOutcome;
+use near_primitives_core::parameter::Parameter;
+use node_runtime::config::RuntimeConfig;
+use std::collections::BTreeMap;
+
+pub(crate) struct GasFeeCounters {
+    counters: BTreeMap<Parameter, u64>,
+}
+
+pub(crate) fn extract_gas_counters(
+    outcome: ExecutionOutcome,
+    config: &RuntimeConfig,
+) -> Option<GasFeeCounters> {
+    match outcome.metadata {
+        near_primitives::transaction::ExecutionMetadata::V1 => None,
+        near_primitives::transaction::ExecutionMetadata::V2(meta_data) => {
+            let mut counters = BTreeMap::new();
+            for param in Parameter::ext_costs() {
+                if let Some(cost) = param.cost() {
+                    match cost {
+                        // this is tricky because ActionCosts is not 1-to-1 with parameters
+                        Cost::ActionCost { .. } => todo!(),
+                        Cost::ExtCost { ext_cost_kind } => {
+                            let parameter_value =
+                                ext_cost_kind.value(&config.wasm_config.ext_costs);
+                            let gas = meta_data.get_ext_cost(ext_cost_kind);
+                            assert_eq!(
+                                0,
+                                gas % parameter_value,
+                                "invalid gas profile for given config"
+                            );
+                            let counter = gas / parameter_value;
+                            *counters.entry(*param).or_default() += counter;
+                        }
+                        Cost::WasmInstruction => {
+                            // this is tricky because we have to figure out how much gas has been burnt for function call execution
+                            // let total_gas_burnt_for_fn_calls = ???;
+                            // let gas = meta_data.compute_wasm_instruction_cost(total_gas_burnt_for_fn_calls);
+                            // let counter = gas / config.wasm_config.regular_op_cost;
+                            // counters.insert(param, counter)
+                            todo!()
+                        }
+                    };
+                }
+                // for cost in Cost::ALL {
+            }
+            Some(GasFeeCounters { counters })
+        }
+    }
+}
+
+impl std::fmt::Display for GasFeeCounters {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (param, counter) in self.counters.iter() {
+            writeln!(f, "{param}: {counter}")?;
+        }
+        Ok(())
+    }
+}

--- a/tools/state-viewer/src/gas_profile.rs
+++ b/tools/state-viewer/src/gas_profile.rs
@@ -28,13 +28,15 @@ pub(crate) fn extract_gas_counters(
                             let parameter_value =
                                 ext_cost_kind.value(&config.wasm_config.ext_costs);
                             let gas = meta_data.get_ext_cost(ext_cost_kind);
-                            assert_eq!(
-                                0,
-                                gas % parameter_value,
-                                "invalid gas profile for given config"
-                            );
-                            let counter = gas / parameter_value;
-                            *counters.entry(*param).or_default() += counter;
+                            if parameter_value != 0 {
+                                assert_eq!(
+                                    0,
+                                    gas % parameter_value,
+                                    "invalid gas profile for given config"
+                                );
+                                let counter = gas / parameter_value;
+                                *counters.entry(*param).or_default() += counter;
+                            }
                         }
                         Cost::WasmInstruction => {
                             // this is tricky because we have to figure out how much gas has been burnt for function call execution

--- a/tools/state-viewer/src/lib.rs
+++ b/tools/state-viewer/src/lib.rs
@@ -5,6 +5,7 @@ mod apply_chunk;
 pub mod cli;
 mod commands;
 mod epoch_info;
+mod gas_profile;
 mod rocksdb_stats;
 mod state_dump;
 mod tx_dump;

--- a/tools/state-viewer/src/snapshots/state_viewer__gas_profile__tests__extract_gas_counters.snap
+++ b/tools/state-viewer/src/snapshots/state_viewer__gas_profile__tests__extract_gas_counters.snap
@@ -1,0 +1,9 @@
+---
+source: tools/state-viewer/src/gas_profile.rs
+expression: profile
+---
+wasm_regular_op_cost                                         7000
+wasm_storage_write_base                                       137
+wasm_storage_write_key_byte                                  4629
+wasm_storage_write_value_byte                                2246
+


### PR DESCRIPTION
Reverse-engineer the charged gas counters for an executed function call
in the state viewer. This is useful to have in the state viewer because the
RPC request for tx-status only gives the total gas values per cost.

A next step building on top would be another state viewer command that
takes a set of parameter changes and a range of blocks. It could then
find receipts that are successful with the old config but would run out of
gas with the new parameters. This is useful to evaluate any sort of gas
increase.

So far, only the counters for WASM execution / host function calls
are supported. Adding action counters would be much more effort
and probably it makes more sense to include more details in the
gas profile first.