### PR TITLE
store: delete contents of GCCount when doing 31→32 database migration

### DIFF
--- a/core/store/src/migrations.rs
+++ b/core/store/src/migrations.rs
@@ -175,9 +175,14 @@ pub fn migrate_29_to_30(storage: &crate::NodeStorage) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Migrates database from version 31 to 32.
+///
+/// This involves deleting contents of ChunkPerHeightShard and GCCount columns
+/// which are now deprecated and no longer used.
 pub fn migrate_31_to_32(storage: &crate::NodeStorage) -> anyhow::Result<()> {
     let mut update = storage.get_store(crate::Temperature::Hot).store_update();
     update.delete_all(DBCol::_ChunkPerHeightShard);
+    update.delete_all(DBCol::_GCCount);
     update.commit()?;
     Ok(())
 }


### PR DESCRIPTION
GCCount column has been deprecated in commit bb978a459.