### PR TITLE
pytest: fix Rosetta test after addition of transfer_fee_type

### DIFF
--- a/pytest/tests/sanity/rosetta.py
+++ b/pytest/tests/sanity/rosetta.py
@@ -634,7 +634,8 @@ class RosettaTestCase(unittest.TestCase):
                 'metadata': {
                     'predecessor_id': {
                         'address': 'test0'
-                    }
+                    },
+                    'transfer_fee_type': 'GAS_PREPAYMENT'
                 }
             }],
             'related_transactions': [{
@@ -730,7 +731,8 @@ class RosettaTestCase(unittest.TestCase):
                     'metadata': {
                         'predecessor_id': {
                             'address': 'system'
-                        }
+                        },
+                        'transfer_fee_type': 'GAS_REFUND'
                     }
                 }],
                 'transaction_identifier': related.identifier
@@ -866,7 +868,8 @@ class RosettaTestCase(unittest.TestCase):
                     'metadata': {
                         'predecessor_id': {
                             'address': "system"
-                        }
+                        },
+                        'transfer_fee_type': 'GAS_REFUND'
                     }
                 }],
                 'transaction_identifier': receipt_id_2


### PR DESCRIPTION
The transfer_fee_type metadata field has been introduced in 7a663fce2
without updating the test.  Do it now.

Issue: https://github.com/near/nearcore/issues/7654
