### PR TITLE
enabled TIER1 peer discovery in all envs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Stabilize `account_id_in_function_call_permission` feature: enforcing validity
   of account ids in function call permission.
+* Enable TIER1 peer discovery. Validator nodes are now exchanging the [public addresses
+  set in config](https://github.com/near/nearcore/blob/301fb493ea4f6d9b75d7dac7f2b52d00a1b2b709/chain/network/src/config_json.rs#L162).
+  The TIER1 connections support (direct connections between validators) based on
+  this discovery mechanism will be added soon.
 
 ### Non-protocol Changes
 

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -593,13 +593,8 @@ impl NearConfig {
                 network_key_pair.secret_key,
                 validator_signer.clone(),
                 config.archive,
-                match genesis.config.chain_id.as_ref() {
-                    "mainnet" | "testnet" | "betanet" => {
-                        near_network::config::Features { enable_tier1: false }
-                    }
-                    // shardnet and all test setups.
-                    "shardnet" | _ => near_network::config::Features { enable_tier1: true },
-                },
+                // Enable tier1 (currently tier1 discovery only).
+                near_network::config::Features { enable_tier1: true },
             )?,
             telemetry_config: config.telemetry,
             #[cfg(feature = "json_rpc")]


### PR DESCRIPTION
Validators are already adding their public IPs to the configs (some correctly, some incorrectly) and this PR enables broadcasting this information to the network. It will allow us to monitor whether broadcasting works and check whether validators have correctly configured their public IPs. So far TIER1 peer discovery has been enabled in shardnet (while it still existed) and no regression has been observed.

The TIER1 connections are still not established, the relevant code will be merged in another PR (possibly protected with a separate feature flag, and this flag will be renamed accordingly). 