### PR TITLE
fix: broken pytest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,6 @@ loupe = "0.1"
 lru = "0.7.2"
 memoffset = "0.6"
 near-rust-allocator-proxy = "0.4"
-near-sdk = "3.1.0"
 nix = "0.15.0"
 num-bigint = "0.3"
 num-rational = { version = "0.3.1", features = ["serde"] }

--- a/pytest/tests/loadtest/contract/Cargo.toml
+++ b/pytest/tests/loadtest/contract/Cargo.toml
@@ -12,7 +12,7 @@ members = []
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-near-sdk.workspace = true
+near-sdk = "3.1.0"
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
loadest isn't part of our top-level workspace. We also shouldn't be
using `near-sdk` here ideally, but that's a different story.

https://near.zulipchat.com/#narrow/stream/295558-pagoda.2Fcore/topic/pytest.2Floadtest.20broken.3F
