### PR TITLE
feat: gc deltas and block infos from flat storage

### DIFF
--- a/core/store/src/flat_state.rs
+++ b/core/store/src/flat_state.rs
@@ -690,10 +690,12 @@ impl FlatStorageState {
             .cloned()
             .collect();
         for hash in hashes_to_remove {
+            // Note that we have to remove delta for new head but we still need to keep block info, e.g. for knowing
+            // height of the head.
+            guard.deltas.remove(&hash);
             if &hash != new_head {
                 guard.blocks.remove(&hash);
             }
-            guard.deltas.remove(&hash);
             store_helper::remove_delta(&mut store_update, guard.shard_id, hash);
         }
 

--- a/core/store/src/flat_state.rs
+++ b/core/store/src/flat_state.rs
@@ -666,7 +666,6 @@ impl FlatStorageState {
     pub fn update_flat_head(&self, new_head: &CryptoHash) -> Result<(), FlatStorageError> {
         let mut guard = self.0.write().expect(POISONED_LOCK_ERR);
         let deltas = guard.get_deltas_between_blocks(new_head)?;
-        tracing::debug!(target: "client", "blocks: {}, deltas: {}", guard.blocks.len(), guard.deltas.len());
         let mut merged_delta = FlatStateDelta::default();
         for delta in deltas.into_iter().rev() {
             merged_delta.merge(delta.as_ref());

--- a/core/store/src/flat_state.rs
+++ b/core/store/src/flat_state.rs
@@ -478,6 +478,11 @@ pub mod store_helper {
             .map_err(|_| FlatStorageError::StorageInternalError)
     }
 
+    pub fn remove_delta(store_update: &mut StoreUpdate, shard_id: ShardId, block_hash: CryptoHash) {
+        let key = KeyForFlatStateDelta { shard_id, block_hash };
+        store_update.delete(crate::DBCol::FlatStateDeltas, &key.try_to_vec().unwrap());
+    }
+
     pub(crate) fn get_flat_head(store: &Store, shard_id: ShardId) -> CryptoHash {
         store
             .get_ser(crate::DBCol::FlatStateMisc, &shard_id.try_to_vec().unwrap())
@@ -661,15 +666,37 @@ impl FlatStorageState {
     pub fn update_flat_head(&self, new_head: &CryptoHash) -> Result<(), FlatStorageError> {
         let mut guard = self.0.write().expect(POISONED_LOCK_ERR);
         let deltas = guard.get_deltas_between_blocks(new_head)?;
+        tracing::debug!(target: "client", "blocks: {}, deltas: {}", guard.blocks.len(), guard.deltas.len());
         let mut merged_delta = FlatStateDelta::default();
         for delta in deltas.into_iter().rev() {
             merged_delta.merge(delta.as_ref());
         }
 
+        // Update flat state on disk.
         guard.flat_head = *new_head;
         let mut store_update = StoreUpdate::new(guard.store.storage.clone());
         store_helper::set_flat_head(&mut store_update, guard.shard_id, new_head);
         merged_delta.apply_to_flat_state(&mut store_update);
+
+        // Remove old deltas and blocks info from memory and disk.
+        // TODO (#7327): in case of long forks it can take a while and delay processing of some chunk. Consider
+        // avoid iterating over all blocks and making removals lazy.
+        let flat_head_height = guard.blocks.get(&guard.flat_head).unwrap().height;
+        let hashes_to_remove: Vec<_> = guard
+            .blocks
+            .iter()
+            .filter(|(_, block_info)| block_info.height <= flat_head_height)
+            .map(|(block_hash, _)| block_hash)
+            .cloned()
+            .collect();
+        for hash in hashes_to_remove {
+            if &hash != new_head {
+                guard.blocks.remove(&hash);
+            }
+            guard.deltas.remove(&hash);
+            store_helper::remove_delta(&mut store_update, guard.shard_id, hash);
+        }
+
         store_update.commit().expect(BORSH_ERR);
         Ok(())
     }
@@ -959,6 +986,14 @@ mod tests {
         assert_eq!(flat_state0.get_ref(&[2]).unwrap(), Some(ValueRef::new(&[1])));
         assert_eq!(flat_state1.get_ref(&[1]).unwrap(), Some(ValueRef::new(&[4])));
         assert_eq!(flat_state1.get_ref(&[2]).unwrap(), None);
+        assert_matches!(
+            store_helper::get_delta(&store, 0, chain.get_block_hash(5)).unwrap(),
+            Some(_)
+        );
+        assert_matches!(
+            store_helper::get_delta(&store, 0, chain.get_block_hash(10)).unwrap(),
+            Some(_)
+        );
 
         // 5. Move the flat head to block 5, verify that flat_state0 still returns the same values
         // and flat_state1 returns an error. Also check that DBCol::FlatState is updated correctly
@@ -970,6 +1005,11 @@ mod tests {
         assert_eq!(flat_state0.get_ref(&[1]).unwrap(), None);
         assert_eq!(flat_state0.get_ref(&[2]).unwrap(), Some(ValueRef::new(&[1])));
         assert_matches!(flat_state1.get_ref(&[1]), Err(StorageError::FlatStorageError(_)));
+        assert_matches!(store_helper::get_delta(&store, 0, chain.get_block_hash(5)).unwrap(), None);
+        assert_matches!(
+            store_helper::get_delta(&store, 0, chain.get_block_hash(10)).unwrap(),
+            Some(_)
+        );
 
         // 6. Move the flat head to block 10, verify that flat_state0 still returns the same values
         //    Also checks that DBCol::FlatState is updated correctly.
@@ -981,5 +1021,9 @@ mod tests {
         assert_eq!(store_helper::get_ref(&store, &[2]).unwrap(), Some(ValueRef::new(&[1])));
         assert_eq!(flat_state0.get_ref(&[1]).unwrap(), None);
         assert_eq!(flat_state0.get_ref(&[2]).unwrap(), Some(ValueRef::new(&[1])));
+        assert_matches!(
+            store_helper::get_delta(&store, 0, chain.get_block_hash(10)).unwrap(),
+            None
+        );
     }
 }


### PR DESCRIPTION
If we move flat storage head, all deltas with heights not exceeding new head height become obsolete and have to be removed. Storing them in both memory and disk is a big concern because theoretical boundary on their sizes has an order of 100 MBs and we can't afford more than tens of blocks here.

Currently we just iterate over all available blocks in memory to find data to be removed, but we can consider more optimal versions in the future.

The implementation is safe because head update, applying deltas and removing old deltas happen in a single DB transaction. If node crashes in the middle, during restart new flat storage is created which takes all blocks and deltas from disk again.

## Testing

* Updating `flat_storage_state_sanity` test
* Checking logs of localnet node. It is expected that number of deltas is lower by one because we don't have delta for flat head:
```
2258:2022-10-04T22:04:40.842443Z DEBUG postprocess_block{height=12}: client: blocks: 4, deltas: 3
2259:2022-10-04T22:04:40.842482Z DEBUG postprocess_block{height=12}: client: blocks: 4, deltas: 3
2260:2022-10-04T22:04:40.842496Z DEBUG postprocess_block{height=12}: client: blocks: 4, deltas: 3
2261:2022-10-04T22:04:40.842508Z DEBUG postprocess_block{height=12}: client: blocks: 4, deltas: 3
```