### PR TITLE
store: introduce CompiledContractCache::has to avoid data cloning

### DIFF
--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -910,8 +910,11 @@ pub enum TransactionOrReceiptId {
 
 /// Cache for compiled modules
 pub trait CompiledContractCache: Send + Sync {
-    fn put(&self, key: &CryptoHash, value: Vec<u8>) -> Result<(), std::io::Error>;
-    fn get(&self, key: &CryptoHash) -> Result<Option<Vec<u8>>, std::io::Error>;
+    fn put(&self, key: &CryptoHash, value: Vec<u8>) -> std::io::Result<()>;
+    fn get(&self, key: &CryptoHash) -> std::io::Result<Option<Vec<u8>>>;
+    fn has(&self, key: &CryptoHash) -> std::io::Result<bool> {
+        self.get(key).map(|entry| entry.is_some())
+    }
 }
 
 /// Provides information about current epoch validators.

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -778,6 +778,10 @@ impl CompiledContractCache for StoreCompiledContractCache {
     fn get(&self, key: &CryptoHash) -> io::Result<Option<Vec<u8>>> {
         Ok(self.db.get_raw_bytes(DBCol::CachedContractCode, key.as_ref())?.map(Vec::from))
     }
+
+    fn has(&self, key: &CryptoHash) -> io::Result<bool> {
+        self.db.get_raw_bytes(DBCol::CachedContractCode, key.as_ref()).map(|entry| entry.is_some())
+    }
 }
 
 #[cfg(test)]

--- a/runtime/near-vm-runner/src/cache.rs
+++ b/runtime/near-vm-runner/src/cache.rs
@@ -372,11 +372,9 @@ pub fn precompile_contract_vm(
     };
     let key = get_contract_cache_key(wasm_code, vm_kind, config);
     // Check if we already cached with such a key.
-    match cache.get(&key).map_err(|_io_error| CacheError::ReadError)? {
-        // If so - do not override.
-        Some(_) => return Ok(Ok(ContractPrecompilatonResult::ContractAlreadyInCache)),
-        None => {}
-    };
+    if cache.has(&key).map_err(|_io_error| CacheError::ReadError)? {
+        return Ok(Ok(ContractPrecompilatonResult::ContractAlreadyInCache));
+    }
     match vm_kind {
         #[cfg(all(feature = "wasmer0_vm", target_arch = "x86_64"))]
         VMKind::Wasmer0 => {


### PR DESCRIPTION
precompile_contract_vm function is not interested in the actual
compiled contract code, it only cares whether the cache contains it.
However, at the moment it uses CompiledContractCache::get method which
clones the data read from the database.  Introduce a has method which
only checks whether the value exists or not.
