### PR TITLE
[chunks] Move chain_head maintenance into ShardsManager

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2157,7 +2157,8 @@ impl Chain {
         );
 
         // Determine the block status of this block (whether it is a side fork and updates the chain head)
-        // Block status is needed in Client::on_block_accepted to decide to how to update the tx pool.
+        // Block status is needed in Client::on_block_accepted_with_optional_chunk_produce to
+        // decide to how to update the tx pool.
         let block_status = self.determine_status(new_head, prev_head);
         Ok(AcceptedBlock { hash: *block.hash(), status: block_status, provenance })
     }

--- a/chain/chunks/src/client.rs
+++ b/chain/chunks/src/client.rs
@@ -1,6 +1,14 @@
+use std::collections::HashMap;
+
 use actix::Message;
 use near_network::types::MsgRecipient;
-use near_primitives::sharding::{EncodedShardChunk, PartialEncodedChunk, ShardChunk};
+use near_pool::{PoolIteratorWrapper, TransactionPool};
+use near_primitives::{
+    epoch_manager::RngSeed,
+    sharding::{EncodedShardChunk, PartialEncodedChunk, ShardChunk},
+    transaction::SignedTransaction,
+    types::ShardId,
+};
 
 pub trait ClientAdapterForShardsManager {
     fn did_complete_chunk(
@@ -28,5 +36,88 @@ impl<A: MsgRecipient<ShardsManagerResponse>> ClientAdapterForShardsManager for A
     }
     fn saw_invalid_chunk(&self, chunk: EncodedShardChunk) {
         self.do_send(ShardsManagerResponse::InvalidChunk(chunk));
+    }
+}
+
+pub struct ShardedTransactionPool {
+    tx_pools: HashMap<ShardId, TransactionPool>,
+
+    /// Useful to make tests deterministic and reproducible,
+    /// while keeping the security of randomization of transactions in pool
+    rng_seed: RngSeed,
+}
+
+impl ShardedTransactionPool {
+    pub fn new(rng_seed: RngSeed) -> Self {
+        TransactionPool::init_metrics();
+        Self { tx_pools: HashMap::new(), rng_seed }
+    }
+
+    pub fn get_pool_iterator(&mut self, shard_id: ShardId) -> Option<PoolIteratorWrapper<'_>> {
+        self.tx_pools.get_mut(&shard_id).map(|pool| pool.pool_iterator())
+    }
+
+    /// Returns true if transaction is not in the pool before call
+    pub fn insert_transaction(&mut self, shard_id: ShardId, tx: SignedTransaction) -> bool {
+        self.pool_for_shard(shard_id).insert_transaction(tx)
+    }
+
+    pub fn remove_transactions(&mut self, shard_id: ShardId, transactions: &[SignedTransaction]) {
+        if let Some(pool) = self.tx_pools.get_mut(&shard_id) {
+            pool.remove_transactions(transactions)
+        }
+    }
+
+    /// Computes a deterministic random seed for given `shard_id`.
+    /// This seed is used to randomize the transaction pool.
+    /// For better security we want the seed to different in each shard.
+    /// For testing purposes we want it to be the reproducible and derived from the `self.rng_seed` and `shard_id`
+    fn random_seed(base_seed: &RngSeed, shard_id: ShardId) -> RngSeed {
+        let mut res = *base_seed;
+        res[0] = shard_id as u8;
+        res[1] = (shard_id / 256) as u8;
+        res
+    }
+
+    fn pool_for_shard(&mut self, shard_id: ShardId) -> &mut TransactionPool {
+        self.tx_pools
+            .entry(shard_id)
+            .or_insert_with(|| TransactionPool::new(Self::random_seed(&self.rng_seed, shard_id)))
+    }
+
+    pub fn reintroduce_transactions(
+        &mut self,
+        shard_id: ShardId,
+        transactions: &[SignedTransaction],
+    ) {
+        self.pool_for_shard(shard_id).reintroduce_transactions(transactions.to_vec());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use near_primitives::epoch_manager::RngSeed;
+
+    use crate::client::ShardedTransactionPool;
+
+    const TEST_SEED: RngSeed = [3; 32];
+
+    #[test]
+    fn test_random_seed_with_shard_id() {
+        let seed0 = ShardedTransactionPool::random_seed(&TEST_SEED, 0);
+        let seed10 = ShardedTransactionPool::random_seed(&TEST_SEED, 10);
+        let seed256 = ShardedTransactionPool::random_seed(&TEST_SEED, 256);
+        let seed1000 = ShardedTransactionPool::random_seed(&TEST_SEED, 1000);
+        let seed1000000 = ShardedTransactionPool::random_seed(&TEST_SEED, 1_000_000);
+        assert_ne!(seed0, seed10);
+        assert_ne!(seed0, seed256);
+        assert_ne!(seed0, seed1000);
+        assert_ne!(seed0, seed1000000);
+        assert_ne!(seed10, seed256);
+        assert_ne!(seed10, seed1000);
+        assert_ne!(seed10, seed1000000);
+        assert_ne!(seed256, seed1000);
+        assert_ne!(seed256, seed1000000);
+        assert_ne!(seed1000, seed1000000);
     }
 }

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -481,6 +481,7 @@ pub struct ShardsManager {
     encoded_chunks: EncodedChunksCache,
     requested_partial_encoded_chunks: RequestPool,
     chunk_forwards_cache: lru::LruCache<ChunkHash, HashMap<u64, PartialEncodedChunkPart>>,
+    chain_head: Option<Tip>,
 
     seals_mgr: SealsManager,
 }
@@ -492,6 +493,7 @@ impl ShardsManager {
         network_adapter: Arc<dyn PeerManagerAdapter>,
         client_adapter: Arc<dyn ClientAdapterForShardsManager>,
         store: ReadOnlyChunksStore,
+        initial_chain_head: Option<Tip>,
     ) -> Self {
         Self {
             me: me.clone(),
@@ -511,15 +513,17 @@ impl ShardsManager {
                 Duration::from_millis(CHUNK_REQUEST_RETRY_MAX_MS),
             ),
             chunk_forwards_cache: lru::LruCache::new(CHUNK_FORWARD_CACHE_SIZE),
+            chain_head: initial_chain_head,
             seals_mgr: SealsManager::new(me, runtime_adapter),
         }
     }
 
-    pub fn update_largest_seen_height(&mut self, new_height: BlockHeight) {
+    pub fn update_chain_head(&mut self, tip: Tip) {
         self.encoded_chunks.update_largest_seen_height(
-            new_height,
+            tip.height,
             &self.requested_partial_encoded_chunks.requests,
         );
+        self.chain_head = Some(tip);
     }
 
     fn request_partial_encoded_chunk(
@@ -952,7 +956,6 @@ impl ShardsManager {
     }
 
     pub fn receipts_recipient_filter<T>(
-        &self,
         from_shard_id: ShardId,
         tracking_shards: T,
         receipts_by_shard: &HashMap<ShardId, Vec<Receipt>>,
@@ -1237,6 +1240,7 @@ impl ShardsManager {
         Some(PartialEncodedChunkResponseMsg { chunk_hash, parts, receipts })
     }
 
+    // pub for testing
     pub fn check_chunk_complete(
         chunk: &mut EncodedShardChunk,
         rs: &mut ReedSolomonWrapper,
@@ -1343,7 +1347,7 @@ impl ShardsManager {
     /// Gets the header associated with the chunk hash from the `encoded_chunks` cache.
     /// An error is returned if the chunk is not present or the hash in the associated
     /// header does not match the given hash.
-    pub fn get_partial_encoded_chunk_header(
+    fn get_partial_encoded_chunk_header(
         &self,
         chunk_hash: &ChunkHash,
     ) -> Result<ShardChunkHeader, Error> {
@@ -1362,7 +1366,7 @@ impl ShardsManager {
         Ok(header)
     }
 
-    pub fn insert_forwarded_chunk(&mut self, forward: PartialEncodedChunkForwardMsg) {
+    fn insert_forwarded_chunk(&mut self, forward: PartialEncodedChunkForwardMsg) {
         let chunk_hash = forward.chunk_hash.clone();
         let num_total_parts = self.rs.total_shard_count() as u64;
         match self.chunk_forwards_cache.get_mut(&chunk_hash) {
@@ -1396,8 +1400,7 @@ impl ShardsManager {
     pub fn process_partial_encoded_chunk_forward(
         &mut self,
         forward: PartialEncodedChunkForwardMsg,
-        chain_head: Option<&Tip>,
-    ) -> Result<ProcessPartialEncodedChunkResult, Error> {
+    ) -> Result<(), Error> {
         let maybe_header = self
             .validate_partial_encoded_chunk_forward(&forward)
             .and_then(|_| self.get_partial_encoded_chunk_header(&forward.chunk_hash));
@@ -1431,24 +1434,8 @@ impl ShardsManager {
             parts: forward.parts,
             receipts: Vec::new(),
         });
-        self.process_partial_encoded_chunk(
-            MaybeValidated::from_validated(partial_chunk),
-            chain_head,
-        )
-    }
-
-    /// Get a list of incomplete chunks whose previous block hash is `prev_block_hash`
-    pub fn get_incomplete_chunks(&self, prev_block_hash: &CryptoHash) -> Vec<ShardChunkHeader> {
-        if let Some(chunk_hashes) = self.encoded_chunks.get_incomplete_chunks(prev_block_hash) {
-            chunk_hashes
-                .iter()
-                .flat_map(|chunk_hash| {
-                    self.encoded_chunks.get(chunk_hash).map(|e| e.header.clone())
-                })
-                .collect()
-        } else {
-            vec![]
-        }
+        self.process_partial_encoded_chunk(MaybeValidated::from_validated(partial_chunk))?;
+        Ok(())
     }
 
     /// Validate a chunk header
@@ -1466,7 +1453,7 @@ impl ShardsManager {
     // To achieve full validation, this function is called twice for each chunk entry
     // first when the chunk entry is inserted in `encoded_chunks`
     // then in `process_partial_encoded_chunk` after checking the previous block is ready
-    pub fn validate_chunk_header(
+    fn validate_chunk_header(
         &self,
         chain_head: Option<&Tip>,
         header: &ShardChunkHeader,
@@ -1542,7 +1529,7 @@ impl ShardsManager {
     /// Inserts the header if it is not already known, and process the forwarded chunk parts cached
     /// for this chunk, if any. Returns true if the header was newly inserted or forwarded parts
     /// were newly processed.
-    pub fn insert_header_if_not_exists_and_process_cached_chunk_forwards(
+    fn insert_header_if_not_exists_and_process_cached_chunk_forwards(
         &mut self,
         header: &ShardChunkHeader,
     ) -> bool {
@@ -1581,7 +1568,6 @@ impl ShardsManager {
     /// Params
     /// `partial_encoded_chunk`: the partial encoded chunk needs to be processed. `MaybeValidated`
     ///                          denotes whether the chunk header has been validated or not
-    /// `chain_head`: current chain head, used for validating chunk header
     ///
     /// Returns
     ///  ProcessPartialEncodedChunkResult::Known: if all information in
@@ -1595,7 +1581,6 @@ impl ShardsManager {
     pub fn process_partial_encoded_chunk(
         &mut self,
         partial_encoded_chunk: MaybeValidated<PartialEncodedChunk>,
-        chain_head: Option<&Tip>,
     ) -> Result<ProcessPartialEncodedChunkResult, Error> {
         let partial_encoded_chunk =
             partial_encoded_chunk.map(|chunk| PartialEncodedChunkV2::from(chunk));
@@ -1634,7 +1619,7 @@ impl ShardsManager {
 
         // 1.c checking header validity
         match partial_encoded_chunk.validate_with(|pec| {
-            self.validate_chunk_header(chain_head.clone(), &pec.header).map(|()| true)
+            self.validate_chunk_header(self.chain_head.as_ref(), &pec.header).map(|()| true)
         }) {
             Err(Error::ChainError(chain_error)) => match chain_error {
                 // validate_chunk_header returns DBNotFoundError if the previous block is not ready
@@ -1696,14 +1681,14 @@ impl ShardsManager {
                 &epoch_id,
                 &partial_encoded_chunk.header.prev_block_hash(),
             )?;
-        } else if let Some(chain_head) = chain_head {
+        } else if let Some(chain_head) = &self.chain_head {
             let epoch_id =
                 self.runtime_adapter.get_epoch_id_from_prev_block(&chain_head.last_block_hash)?;
             self.send_partial_encoded_chunk_to_chunk_trackers(
                 partial_encoded_chunk,
                 new_part_ords,
                 &epoch_id,
-                &chain_head.last_block_hash,
+                &chain_head.last_block_hash.clone(),
             )?;
         };
 
@@ -1724,11 +1709,35 @@ impl ShardsManager {
         Ok(result)
     }
 
+    pub fn process_partial_encoded_chunk_response(
+        &mut self,
+        response: PartialEncodedChunkResponseMsg,
+    ) -> Result<(), Error> {
+        let header = self.get_partial_encoded_chunk_header(&response.chunk_hash)?;
+        let partial_chunk = PartialEncodedChunk::new(header, response.parts, response.receipts);
+        // We already know the header signature is valid because we read it from the
+        // shard manager.
+        self.process_partial_encoded_chunk(MaybeValidated::from_validated(partial_chunk))?;
+        Ok(())
+    }
+
+    /// Let the ShardsManager know about the chunk header, when encountering that chunk header
+    /// from the block and the chunk is possibly not yet known to the ShardsManager.
+    pub fn process_chunk_header_from_block(
+        &mut self,
+        header: &ShardChunkHeader,
+    ) -> Result<(), Error> {
+        if self.insert_header_if_not_exists_and_process_cached_chunk_forwards(header) {
+            self.try_process_chunk_parts_and_receipts(header)?;
+        }
+        Ok(())
+    }
+
     /// Checks if the chunk has all parts and receipts, if so and if the node cares about the shard,
     /// decodes and persists the full chunk
     /// `header`: header of the chunk. It must be known by `ShardsManager`, either
     ///           by previous call to `process_partial_encoded_chunk` or `request_partial_encoded_chunk`
-    pub fn try_process_chunk_parts_and_receipts(
+    fn try_process_chunk_parts_and_receipts(
         &mut self,
         header: &ShardChunkHeader,
     ) -> Result<ProcessPartialEncodedChunkResult, Error> {
@@ -1872,9 +1881,31 @@ impl ShardsManager {
         self.client_adapter.did_complete_chunk(partial_chunk, shard_chunk);
     }
 
+    /// Try to process chunks in the chunk cache whose previous block hash is `prev_block_hash` and
+    /// who are not marked as complete yet
+    /// This function is needed because chunks in chunk cache will only be marked as complete after
+    /// the previous block is accepted. So we need to check if there are any chunks can be marked as
+    /// complete when a new block is accepted.
+    pub fn check_incomplete_chunks(&mut self, prev_block_hash: &CryptoHash) {
+        let mut chunks_to_process = vec![];
+        for chunk_hashes in self.encoded_chunks.get_incomplete_chunks(prev_block_hash) {
+            for chunk_hash in chunk_hashes {
+                if let Some(entry) = self.encoded_chunks.get(chunk_hash) {
+                    chunks_to_process.push(entry.header.clone());
+                }
+            }
+        }
+        for header in chunks_to_process {
+            debug!(target:"chunks", "try to process incomplete chunk {:?}, prev_block: {:?}", header.chunk_hash(), prev_block_hash);
+            if let Err(err) = self.try_process_chunk_parts_and_receipts(&header) {
+                error!(target:"chunks", "unexpected error processing orphan chunk {:?}", err)
+            }
+        }
+    }
+
     /// Send the parts of the partial_encoded_chunk that are owned by `self.me` to the
     /// other validators that are tracking the shard.
-    pub fn send_partial_encoded_chunk_to_chunk_trackers(
+    fn send_partial_encoded_chunk_to_chunk_trackers(
         &mut self,
         partial_encoded_chunk: &PartialEncodedChunkV2,
         part_ords: HashSet<u64>,
@@ -2161,6 +2192,7 @@ mod test {
             network_adapter.clone(),
             client_adapter,
             ReadOnlyChunksStore::new(store),
+            None,
         );
         let added = Clock::instant();
         shards_manager.requested_partial_encoded_chunks.insert(
@@ -2216,6 +2248,7 @@ mod test {
             network_adapter,
             client_adapter,
             chain_store.new_read_only_chunks_store(),
+            None,
         );
         let signer =
             InMemoryValidatorSigner::from_seed("test".parse().unwrap(), KeyType::ED25519, "test");
@@ -2271,7 +2304,7 @@ mod test {
         std::thread::sleep(Duration::from_millis(crate::ACCEPTING_SEAL_PERIOD_MS as u64 + 100));
         for partial_encoded_chunk in vec![partial_encoded_chunk1, partial_encoded_chunk2] {
             shards_manager
-                .process_partial_encoded_chunk(MaybeValidated::from(partial_encoded_chunk), None)
+                .process_partial_encoded_chunk(MaybeValidated::from(partial_encoded_chunk))
                 .unwrap();
         }
     }
@@ -2378,14 +2411,12 @@ mod test {
             fixture.mock_network.clone(),
             fixture.mock_client_adapter.clone(),
             fixture.chain_store.new_read_only_chunks_store(),
+            Some(fixture.mock_chain_head.clone()),
         );
         // process chunk part 0
         let partial_encoded_chunk = fixture.make_partial_encoded_chunk(&[0]);
         let result = shards_manager
-            .process_partial_encoded_chunk(
-                MaybeValidated::from(partial_encoded_chunk),
-                Some(&fixture.mock_chain_head),
-            )
+            .process_partial_encoded_chunk(MaybeValidated::from(partial_encoded_chunk))
             .unwrap();
         assert_matches!(result, ProcessPartialEncodedChunkResult::NeedBlock);
 
@@ -2415,10 +2446,7 @@ mod test {
         // process chunk part 1
         let partial_encoded_chunk = fixture.make_partial_encoded_chunk(&[1]);
         let result = shards_manager
-            .process_partial_encoded_chunk(
-                MaybeValidated::from(partial_encoded_chunk),
-                Some(&fixture.mock_chain_head),
-            )
+            .process_partial_encoded_chunk(MaybeValidated::from(partial_encoded_chunk))
             .unwrap();
         assert_matches!(result, ProcessPartialEncodedChunkResult::NeedBlock);
 
@@ -2446,6 +2474,7 @@ mod test {
             fixture.mock_network.clone(),
             fixture.mock_client_adapter.clone(),
             fixture.chain_store.new_read_only_chunks_store(),
+            None,
         );
 
         // part id > num parts
@@ -2453,10 +2482,8 @@ mod test {
         if let PartialEncodedChunk::V2(ref mut chunk) = partial_encoded_chunk {
             chunk.parts[0].part_ord = fixture.mock_chunk_parts.len() as u64;
         }
-        let result = shards_manager.process_partial_encoded_chunk(
-            MaybeValidated::from(partial_encoded_chunk),
-            Some(&fixture.mock_chain_head),
-        );
+        let result = shards_manager
+            .process_partial_encoded_chunk(MaybeValidated::from(partial_encoded_chunk));
         assert_matches!(result, Err(Error::InvalidChunkPartId));
 
         // TODO: add more test cases
@@ -2473,10 +2500,11 @@ mod test {
             fixture.mock_network.clone(),
             fixture.mock_client_adapter.clone(),
             fixture.chain_store.new_read_only_chunks_store(),
+            None,
         );
         let partial_encoded_chunk = fixture.make_partial_encoded_chunk(&fixture.mock_part_ords);
         let result = shards_manager
-            .process_partial_encoded_chunk(MaybeValidated::from(partial_encoded_chunk), None)
+            .process_partial_encoded_chunk(MaybeValidated::from(partial_encoded_chunk))
             .unwrap();
         match result {
             ProcessPartialEncodedChunkResult::NeedMorePartsOrReceipts => {}
@@ -2529,6 +2557,7 @@ mod test {
             fixture.mock_network.clone(),
             fixture.mock_client_adapter.clone(),
             fixture.chain_store.new_read_only_chunks_store(),
+            None,
         );
         let count_num_forward_msgs = |fixture: &ChunkTestFixture| {
             fixture
@@ -2557,24 +2586,15 @@ mod test {
                 .make_partial_encoded_chunk(&[non_owned_part_ords[2], fixture.mock_part_ords[0]]),
         ];
         shards_manager
-            .process_partial_encoded_chunk(
-                MaybeValidated::from(partial_encoded_chunks.remove(0)),
-                None,
-            )
+            .process_partial_encoded_chunk(MaybeValidated::from(partial_encoded_chunks.remove(0)))
             .unwrap();
         let num_forward_msgs_after_first_receiving = count_num_forward_msgs(&fixture);
         assert!(num_forward_msgs_after_first_receiving > 0);
         shards_manager
-            .process_partial_encoded_chunk(
-                MaybeValidated::from(partial_encoded_chunks.remove(0)),
-                None,
-            )
+            .process_partial_encoded_chunk(MaybeValidated::from(partial_encoded_chunks.remove(0)))
             .unwrap();
         shards_manager
-            .process_partial_encoded_chunk(
-                MaybeValidated::from(partial_encoded_chunks.remove(0)),
-                None,
-            )
+            .process_partial_encoded_chunk(MaybeValidated::from(partial_encoded_chunks.remove(0)))
             .unwrap();
         let num_forward_msgs_after_receiving_duplicates = count_num_forward_msgs(&fixture);
         assert_eq!(
@@ -2608,6 +2628,7 @@ mod test {
             fixture.mock_network.clone(),
             fixture.mock_client_adapter.clone(),
             fixture.chain_store.new_read_only_chunks_store(),
+            None,
         );
         shards_manager.insert_header_if_not_exists_and_process_cached_chunk_forwards(
             &fixture.mock_chunk_header,
@@ -2691,10 +2712,11 @@ mod test {
             fixture.mock_network.clone(),
             fixture.mock_client_adapter.clone(),
             fixture.chain_store.new_read_only_chunks_store(),
+            None,
         );
         let partial_encoded_chunk = fixture.make_partial_encoded_chunk(&fixture.mock_part_ords);
         let _ = shards_manager
-            .process_partial_encoded_chunk(MaybeValidated::from(partial_encoded_chunk), None)
+            .process_partial_encoded_chunk(MaybeValidated::from(partial_encoded_chunk))
             .unwrap();
         let chunk_only_producers: Vec<_> = fixture
             .mock_runtime
@@ -2772,6 +2794,7 @@ mod test {
             fixture.mock_network.clone(),
             fixture.mock_client_adapter.clone(),
             fixture.chain_store.new_read_only_chunks_store(),
+            None,
         );
         let (most_parts, other_parts) = {
             let mut most_parts = fixture.mock_chunk_parts.clone();
@@ -2784,7 +2807,10 @@ mod test {
             most_parts,
         );
         // The validator receives the chunk forward
-        shards_manager.insert_forwarded_chunk(forward);
+        assert_matches!(
+            shards_manager.process_partial_encoded_chunk_forward(forward),
+            Err(Error::UnknownChunk)
+        );
         let partial_encoded_chunk = PartialEncodedChunk::V2(PartialEncodedChunkV2 {
             header: fixture.mock_chunk_header.clone(),
             parts: other_parts,
@@ -2792,10 +2818,7 @@ mod test {
         });
         // The validator receives a chunk header with the rest of the parts it needed
         let result = shards_manager
-            .process_partial_encoded_chunk(
-                MaybeValidated::from(partial_encoded_chunk),
-                Some(&fixture.mock_chain_head),
-            )
+            .process_partial_encoded_chunk(MaybeValidated::from(partial_encoded_chunk))
             .unwrap();
 
         match result {
@@ -2840,13 +2863,17 @@ mod test {
             fixture.mock_network.clone(),
             fixture.mock_client_adapter.clone(),
             fixture.chain_store.new_read_only_chunks_store(),
+            None,
         );
         let forward = PartialEncodedChunkForwardMsg::from_header_and_parts(
             &fixture.mock_chunk_header,
             fixture.mock_chunk_parts.clone(),
         );
         // The validator receives the chunk forward
-        shards_manager.insert_forwarded_chunk(forward);
+        assert_matches!(
+            shards_manager.process_partial_encoded_chunk_forward(forward),
+            Err(Error::UnknownChunk)
+        );
         // The validator then receives the block, which is missing chunks; it notifies the
         // ShardsManager of the chunk header, and ShardsManager is able to complete the chunk
         // because of the forwarded parts.shards_manager

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -27,8 +27,7 @@ use near_chain::{
 use near_chain_configs::ClientConfig;
 use near_chunks::ShardsManager;
 use near_network::types::{
-    FullPeerInfo, NetworkClientResponses, NetworkRequests, PartialEncodedChunkForwardMsg,
-    PartialEncodedChunkResponseMsg, PeerManagerAdapter,
+    FullPeerInfo, NetworkClientResponses, NetworkRequests, PeerManagerAdapter,
 };
 use near_primitives::block::{Approval, ApprovalInner, ApprovalMessage, Block, BlockHeader, Tip};
 use near_primitives::challenge::{Challenge, ChallengeBody};
@@ -185,6 +184,7 @@ impl Client {
             network_adapter.clone(),
             client_adapter.clone(),
             chain.store().new_read_only_chunks_store(),
+            chain.head().ok(),
         );
         let sharded_tx_pool = ShardedTransactionPool::new(rng_seed);
         let sync_status = SyncStatus::AwaitingPeers;
@@ -928,7 +928,7 @@ impl Client {
             .flat_map(|block| block.missing_chunks.iter())
             .chain(orphans_missing_chunks.iter().flat_map(|block| block.missing_chunks.iter()));
         for chunk in missing_chunks {
-            match self.process_chunk_header_from_block_for_shards_manager(chunk) {
+            match self.shards_mgr.process_chunk_header_from_block(chunk) {
                 Ok(_) => {}
                 Err(err) => {
                     warn!(target: "client", "Failed to process missing chunk from block: {:?}", err)
@@ -945,55 +945,6 @@ impl Client {
                 NetworkRequests::Block { block: block.clone() },
             ));
             self.rebroadcasted_blocks.put(*block.hash(), ());
-        }
-    }
-
-    pub fn process_partial_encoded_chunk(
-        &mut self,
-        partial_chunk: PartialEncodedChunk,
-    ) -> Result<(), Error> {
-        self.shards_mgr.process_partial_encoded_chunk(
-            MaybeValidated::from(partial_chunk),
-            self.chain.head().ok().as_ref(),
-        )?;
-        Ok(())
-    }
-
-    pub fn process_partial_encoded_chunk_response(
-        &mut self,
-        response: PartialEncodedChunkResponseMsg,
-    ) -> Result<(), Error> {
-        let header = self.shards_mgr.get_partial_encoded_chunk_header(&response.chunk_hash)?;
-        let partial_chunk = PartialEncodedChunk::new(header, response.parts, response.receipts);
-        // We already know the header signature is valid because we read it from the
-        // shard manager.
-        self.shards_mgr.process_partial_encoded_chunk(
-            MaybeValidated::from_validated(partial_chunk),
-            self.chain.head().ok().as_ref(),
-        )?;
-        Ok(())
-    }
-
-    pub fn process_partial_encoded_chunk_forward(
-        &mut self,
-        forward: PartialEncodedChunkForwardMsg,
-    ) -> Result<(), Error> {
-        self.shards_mgr
-            .process_partial_encoded_chunk_forward(forward, self.chain.head().ok().as_ref())?;
-        Ok(())
-    }
-
-    /// Try to process chunks in the chunk cache whose previous block hash is `prev_block_hash` and
-    /// who are not marked as complete yet
-    /// This function is needed because chunks in chunk cache will only be marked as complete after
-    /// the previous block is accepted. So we need to check if there are any chunks can be marked as
-    /// complete when a new block is accepted.
-    pub fn check_incomplete_chunks(&mut self, prev_block_hash: &CryptoHash) {
-        for chunk_header in self.shards_mgr.get_incomplete_chunks(prev_block_hash) {
-            debug!(target:"client", "try to process incomplete chunks {:?}, prev_block: {:?}", chunk_header.chunk_hash(), prev_block_hash);
-            if let Err(err) = self.shards_mgr.try_process_chunk_parts_and_receipts(&chunk_header) {
-                error!(target:"client", "unexpected error processing orphan chunk {:?}", err)
-            }
         }
     }
 
@@ -1022,18 +973,6 @@ impl Client {
         if let Err(err) = update.commit() {
             error!(target: "client", "Error saving invalid chunk: {:?}", err);
         }
-    }
-
-    /// Let the ShardsManager know about the chunk header, when encountering that chunk header
-    /// from the block and the chunk is possibly not yet known to the ShardsManager.
-    pub fn process_chunk_header_from_block_for_shards_manager(
-        &mut self,
-        header: &ShardChunkHeader,
-    ) -> Result<(), Error> {
-        if self.shards_mgr.insert_header_if_not_exists_and_process_cached_chunk_forwards(header) {
-            self.shards_mgr.try_process_chunk_parts_and_receipts(header)?;
-        }
-        Ok(())
     }
 
     pub fn sync_block_headers(
@@ -1163,7 +1102,7 @@ impl Client {
         }
 
         if status.is_new_head() {
-            self.shards_mgr.update_largest_seen_height(block.header().height());
+            self.shards_mgr.update_chain_head(Tip::from_header(&block.header()));
             let last_final_block = block.header().last_final_block();
             let last_finalized_height = if last_final_block == &CryptoHash::default() {
                 self.chain.genesis().height()
@@ -1317,7 +1256,7 @@ impl Client {
                 }
             }
         }
-        self.check_incomplete_chunks(block.hash());
+        self.shards_mgr.check_incomplete_chunks(block.hash());
     }
 
     pub fn persist_and_distribute_encoded_chunk(

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -6,7 +6,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use near_chunks::client::ClientAdapterForShardsManager;
+use near_chunks::client::{ClientAdapterForShardsManager, ShardedTransactionPool};
 use near_chunks::logic::{
     cares_about_shard_this_or_next_epoch, decode_encoded_chunk, persist_chunk,
 };
@@ -27,7 +27,8 @@ use near_chain::{
 use near_chain_configs::ClientConfig;
 use near_chunks::ShardsManager;
 use near_network::types::{
-    FullPeerInfo, NetworkClientResponses, NetworkRequests, PeerManagerAdapter,
+    FullPeerInfo, NetworkClientResponses, NetworkRequests, PartialEncodedChunkForwardMsg,
+    PartialEncodedChunkResponseMsg, PeerManagerAdapter,
 };
 use near_primitives::block::{Approval, ApprovalInner, ApprovalMessage, Block, BlockHeader, Tip};
 use near_primitives::challenge::{Challenge, ChallengeBody};
@@ -51,7 +52,6 @@ use crate::sync::{BlockSync, EpochSync, HeaderSync, StateSync, StateSyncResult};
 use crate::{metrics, SyncStatus};
 use near_client_primitives::types::{Error, ShardSyncDownload, ShardSyncStatus};
 use near_network::types::{AccountKeys, ChainInfo, PeerManagerMessageRequest, SetChainInfo};
-use near_network::types::{PartialEncodedChunkForwardMsg, PartialEncodedChunkResponseMsg};
 use near_o11y::log_assert;
 use near_primitives::block_header::ApprovalType;
 use near_primitives::epoch_manager::RngSeed;
@@ -91,6 +91,7 @@ pub struct Client {
     pub runtime_adapter: Arc<dyn RuntimeAdapter>,
     pub shards_mgr: ShardsManager,
     me: Option<AccountId>,
+    pub sharded_tx_pool: ShardedTransactionPool,
     /// Network adapter.
     network_adapter: Arc<dyn PeerManagerAdapter>,
     /// Signer for block producer (if present).
@@ -184,8 +185,8 @@ impl Client {
             network_adapter.clone(),
             client_adapter.clone(),
             chain.store().new_read_only_chunks_store(),
-            rng_seed,
         );
+        let sharded_tx_pool = ShardedTransactionPool::new(rng_seed);
         let sync_status = SyncStatus::AwaitingPeers;
         let genesis_block = chain.genesis_block();
         let epoch_sync = EpochSync::new(
@@ -242,6 +243,7 @@ impl Client {
             runtime_adapter,
             shards_mgr,
             me,
+            sharded_tx_pool,
             network_adapter,
             validator_signer,
             pending_approvals: lru::LruCache::new(num_block_producer_seats),
@@ -286,7 +288,7 @@ impl Client {
                     true,
                     self.runtime_adapter.as_ref(),
                 ) {
-                    self.shards_mgr.remove_transactions(
+                    self.sharded_tx_pool.remove_transactions(
                         shard_id,
                         // By now the chunk must be in store, otherwise the block would have been orphaned
                         self.chain.get_chunk(&chunk_header.chunk_hash()).unwrap().transactions(),
@@ -310,7 +312,7 @@ impl Client {
                     false,
                     self.runtime_adapter.as_ref(),
                 ) {
-                    self.shards_mgr.reintroduce_transactions(
+                    self.sharded_tx_pool.reintroduce_transactions(
                         shard_id,
                         // By now the chunk must be in store, otherwise the block would have been orphaned
                         self.chain.get_chunk(&chunk_header.chunk_hash()).unwrap().transactions(),
@@ -749,13 +751,13 @@ impl Client {
         chunk_extra: &ChunkExtra,
         prev_block_header: &BlockHeader,
     ) -> Result<Vec<SignedTransaction>, Error> {
-        let Self { chain, shards_mgr, runtime_adapter, .. } = self;
+        let Self { chain, sharded_tx_pool, runtime_adapter, .. } = self;
 
         let next_epoch_id =
             runtime_adapter.get_epoch_id_from_prev_block(prev_block_header.hash())?;
         let protocol_version = runtime_adapter.get_epoch_protocol_version(&next_epoch_id)?;
 
-        let transactions = if let Some(mut iter) = shards_mgr.get_pool_iterator(shard_id) {
+        let transactions = if let Some(mut iter) = sharded_tx_pool.get_pool_iterator(shard_id) {
             let transaction_validity_period = chain.transaction_validity_period;
             runtime_adapter.prepare_transactions(
                 prev_block_header.gas_price(),
@@ -785,7 +787,7 @@ impl Client {
         };
         // Reintroduce valid transactions back to the pool. They will be removed when the chunk is
         // included into the block.
-        shards_mgr.reintroduce_transactions(shard_id, &transactions);
+        sharded_tx_pool.reintroduce_transactions(shard_id, &transactions);
         Ok(transactions)
     }
 
@@ -1122,28 +1124,7 @@ impl Client {
     }
 
     /// Gets called when block got accepted.
-    /// Send updates over network, update tx pool and notify ourselves if it's time to produce next block.
-    /// Blocks are passed in no particular order.
-    pub fn on_block_accepted(
-        &mut self,
-        block_hash: CryptoHash,
-        status: BlockStatus,
-        provenance: Provenance,
-    ) {
-        let _span = tracing::debug_span!(
-            target: "client",
-            "on_block_accepted",
-            ?block_hash,
-            ?status,
-            ?provenance)
-        .entered();
-        self.on_block_accepted_with_optional_chunk_produce(block_hash, status, provenance, false);
-    }
-
-    /// Gets called when block got accepted.
-    /// Only produce chunk if `skip_produce_chunk` is false
-    /// Note that this function should only be directly called from tests, production code
-    /// should always use `on_block_accepted`
+    /// Only produce chunk if `skip_produce_chunk` is false.
     /// `skip_produce_chunk` is set to true to simulate when there are missing chunks in a block
     pub fn on_block_accepted_with_optional_chunk_produce(
         &mut self,
@@ -1738,7 +1719,7 @@ impl Client {
                 // TODO #6713: Transactions don't need to be recorded if the node is not a validator
                 // for the shard.
                 // If I'm not an active validator I should forward tx to next validators.
-                self.shards_mgr.insert_transaction(shard_id, tx.clone());
+                self.sharded_tx_pool.insert_transaction(shard_id, tx.clone());
                 trace!(target: "client", shard_id, "Recorded a transaction.");
 
                 // Active validator:

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -583,7 +583,7 @@ impl ClientActor {
             }
             NetworkClientMessages::PartialEncodedChunkResponse(response, time) => {
                 PARTIAL_ENCODED_CHUNK_RESPONSE_DELAY.observe(time.elapsed().as_secs_f64());
-                let _ = self.client.process_partial_encoded_chunk_response(response);
+                let _ = self.client.shards_mgr.process_partial_encoded_chunk_response(response);
                 NetworkClientResponses::NoResponse
             }
             NetworkClientMessages::PartialEncodedChunk(partial_encoded_chunk) => {
@@ -591,14 +591,17 @@ impl ClientActor {
                     partial_encoded_chunk.height_created(),
                     partial_encoded_chunk.shard_id(),
                 );
-                let _ = self.client.process_partial_encoded_chunk(partial_encoded_chunk);
+                let _ = self
+                    .client
+                    .shards_mgr
+                    .process_partial_encoded_chunk(partial_encoded_chunk.into());
                 NetworkClientResponses::NoResponse
             }
             NetworkClientMessages::PartialEncodedChunkForward(forward) => {
-                match self.client.process_partial_encoded_chunk_forward(forward) {
-                    Ok(()) => {}
+                match self.client.shards_mgr.process_partial_encoded_chunk_forward(forward) {
+                    Ok(_) => {}
                     // Unknown chunk is normal if we get parts before the header
-                    Err(Error::Chunk(near_chunks::Error::UnknownChunk)) => (),
+                    Err(near_chunks::Error::UnknownChunk) => (),
                     Err(err) => {
                         error!(target: "client", "Error processing forwarded chunk: {}", err)
                     }

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -36,7 +36,7 @@ use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::merkle::{merklize, MerklePath, PartialMerkleTree};
 use near_primitives::receipt::Receipt;
 use near_primitives::shard_layout::ShardUId;
-use near_primitives::sharding::{EncodedShardChunk, ReedSolomonWrapper};
+use near_primitives::sharding::{EncodedShardChunk, PartialEncodedChunk, ReedSolomonWrapper};
 use near_primitives::transaction::{Action, FunctionCallAction, SignedTransaction};
 use near_primitives::types::{
     AccountId, Balance, BlockHeight, BlockHeightDelta, EpochId, NumBlocks, NumSeats, ShardId,
@@ -1419,7 +1419,10 @@ impl TestEnv {
                 ) = request
                 {
                     self.client(&account_id)
-                        .process_partial_encoded_chunk(partial_encoded_chunk.into())
+                        .shards_mgr
+                        .process_partial_encoded_chunk(
+                            PartialEncodedChunk::from(partial_encoded_chunk).into(),
+                        )
                         .unwrap();
                 }
             }
@@ -1446,7 +1449,7 @@ impl TestEnv {
         {
             let target_id = self.account_to_client_index[&target.account_id.unwrap()];
             let response = self.get_partial_encoded_chunk_response(target_id, request);
-            self.clients[id].process_partial_encoded_chunk_response(response).unwrap();
+            self.clients[id].shards_mgr.process_partial_encoded_chunk_response(response).unwrap();
         } else {
             panic!("The request is not a PartialEncodedChunk request {:?}", request);
         }

--- a/integration-tests/src/tests/client/challenges.rs
+++ b/integration-tests/src/tests/client/challenges.rs
@@ -512,7 +512,7 @@ fn test_receive_invalid_chunk_as_chunk_producer() {
     let receipts_hashes = Chain::build_receipts_hashes(&receipts, &shard_layout);
     let (_receipts_root, receipts_proofs) = merklize(&receipts_hashes);
     let receipts_by_shard = Chain::group_receipts_by_shard(receipts, &shard_layout);
-    let one_part_receipt_proofs = env.clients[0].shards_mgr.receipts_recipient_filter(
+    let one_part_receipt_proofs = ShardsManager::receipts_recipient_filter(
         0,
         Vec::default(),
         &receipts_by_shard,
@@ -524,7 +524,10 @@ fn test_receive_invalid_chunk_as_chunk_producer() {
         one_part_receipt_proofs,
         &[merkle_paths[0].clone()],
     );
-    assert!(env.clients[1].process_partial_encoded_chunk(partial_encoded_chunk).is_ok());
+    assert!(env.clients[1]
+        .shards_mgr
+        .process_partial_encoded_chunk(partial_encoded_chunk.into())
+        .is_ok());
     env.process_block(1, block, Provenance::NONE);
 
     // At this point we should create a challenge and send it out.

--- a/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
+++ b/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
@@ -652,6 +652,7 @@ impl ChunkForwardingOptimizationTestData {
                     partial_encoded_chunk.parts.len();
                 self.env
                     .client(&account_id)
+                    .shards_mgr
                     .process_partial_encoded_chunk(
                         PartialEncodedChunk::from(partial_encoded_chunk).into(),
                     )
@@ -674,9 +675,14 @@ impl ChunkForwardingOptimizationTestData {
                     ));
                 }
                 self.num_part_ords_forwarded += forward.parts.len();
-                match self.env.client(&account_id).process_partial_encoded_chunk_forward(forward) {
+                match self
+                    .env
+                    .client(&account_id)
+                    .shards_mgr
+                    .process_partial_encoded_chunk_forward(forward)
+                {
                     Ok(_) => {}
-                    Err(near_client::Error::Chunk(near_chunks::Error::UnknownChunk)) => {
+                    Err(near_chunks::Error::UnknownChunk) => {
                         self.num_forwards_with_missing_chunk_header += 1;
                     }
                     Err(e) => {

--- a/integration-tests/src/tests/client/runtimes.rs
+++ b/integration-tests/src/tests/client/runtimes.rs
@@ -155,27 +155,14 @@ fn test_process_partial_encoded_chunk_with_missing_block() {
 
     // process_partial_encoded_chunk should return Ok(NeedBlock) if the chunk is
     // based on a missing block.
-    let result = client
-        .shards_mgr
-        .process_partial_encoded_chunk(MaybeValidated::from(mock_chunk.clone()), None);
+    let result =
+        client.shards_mgr.process_partial_encoded_chunk(MaybeValidated::from(mock_chunk.clone()));
     assert_matches!(result, Ok(ProcessPartialEncodedChunkResult::NeedBlock));
-
-    // Client::process_partial_encoded_chunk should not return an error
-    // if the chunk is based on a missing block.
-    let result = client.process_partial_encoded_chunk(mock_chunk);
-    match result {
-        Ok(()) => {
-            let accepted_blocks = client.finish_blocks_in_processing();
-            assert!(accepted_blocks.is_empty());
-        }
-        Err(e) => panic!("Client::process_partial_encoded_chunk failed with {:?}", e),
-    }
+    let accepted_blocks = client.finish_blocks_in_processing();
+    assert!(accepted_blocks.is_empty());
 
     // process_partial_encoded_chunk_forward should return UnknownChunk if it is based on a
     // a missing block.
-    let result = client.process_partial_encoded_chunk_forward(mock_forward);
-    assert_matches!(
-        result.unwrap_err(),
-        near_client_primitives::types::Error::Chunk(near_chunks::Error::UnknownChunk)
-    );
+    let result = client.shards_mgr.process_partial_encoded_chunk_forward(mock_forward);
+    assert_matches!(result.unwrap_err(), near_chunks::Error::UnknownChunk);
 }


### PR DESCRIPTION
* chain_head, which used to be passed into the ShardsManager with the process_partial_encoded_* calls, is now kept by the ShardsManager, which is required to send chunk management network messages directly to the ShardsManager. Whenever the chain_head is updated, the Client will provide the new chain_head to the ShardsManager. This makes chain_head updating asynchronous, but that is OK, because this is only used to opportunistically validate orphan chunk headers, and the accuracy of the chain_head does not affect correctness.
* Note that "header_head", which is different from chain_head (i.e. it only waits for a valid block header but not the entire valid block), is still passed in; this is used for the chunk requesting path. This is not a problem, because the request path is initiated by the Client (upon receiving a block with missing chunks), except that we also pass in a header_head when resending requests; the use of header_head for this context does not require an accurate header_head, and this will be handled in a later PR to read from the store directly.
* This PR also moves response handling, forward handling, and incomplete chunks checking to the ShardsManager, bypassing the Client completely. It also makes some functions no longer pub.