### PR TITLE
runtime-params-estimator: remove unused walrus dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2218,12 +2218,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4830,7 +4824,6 @@ dependencies = [
  "tracing",
  "tracing-span-tree",
  "tracing-subscriber",
- "walrus",
  "wat",
 ]
 
@@ -6116,32 +6109,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "walrus"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d470d0583e65f4cab21a1ff3c1ba3dd23ae49e68f516f0afceaeb001b32af39"
-dependencies = [
- "anyhow",
- "id-arena",
- "leb128",
- "log",
- "walrus-macro",
- "wasmparser 0.59.0",
-]
-
-[[package]]
-name = "walrus-macro"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c2bb690b44cb1b0fdcc54d4998d21f8bdaf706b93775425e440b174f39ad16"
-dependencies = [
- "heck 0.3.3",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6431,12 +6398,6 @@ name = "wasmparser"
 version = "0.51.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aeb1956b19469d1c5e63e459d29e7b5aa0f558d9f16fcef09736f8a265e6c10a"
-
-[[package]]
-name = "wasmparser"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a950e6a618f62147fd514ff445b2a0b53120d382751960797f85f058c7eda9b9"
 
 [[package]]
 name = "wasmparser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,6 @@ tracing-opentelemetry = "0.17.0"
 tracing-span-tree = "0.1"
 tracing-subscriber = { version = "0.3.15", features = ["env-filter", "fmt", "registry", "std"] }
 validator = "0.12"
-walrus = "0.18.0"
 wasm-encoder = "0.11.0"
 wasm-smith = "0.10"
 wasmparser = "0.78"

--- a/deny.toml
+++ b/deny.toml
@@ -48,9 +48,6 @@ skip = [
     { name = "pwasm-utils", version = "=0.12.0" },
     { name = "parity-wasm", version = "=0.41.0" },
 
-    # param estimator uses newer imports, but it's not part of neard
-    { name = "wasmparser", version = "=0.59.0" },
-
     # wasmer and wasmtime
     { name = "target-lexicon", version = "=0.10.0" },
 

--- a/runtime/runtime-params-estimator/Cargo.toml
+++ b/runtime/runtime-params-estimator/Cargo.toml
@@ -31,7 +31,6 @@ tempfile.workspace = true
 tracing-span-tree.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true
-walrus.workspace = true
 wat.workspace = true
 
 genesis-populate = { path = "../../genesis-tools/genesis-populate"}

--- a/runtime/runtime-params-estimator/src/vm_estimator.rs
+++ b/runtime/runtime-params-estimator/src/vm_estimator.rs
@@ -10,7 +10,6 @@ use near_store::StoreCompiledContractCache;
 use near_vm_logic::VMContext;
 use near_vm_runner::internal::VMKind;
 use near_vm_runner::precompile_contract_vm;
-use walrus::Result;
 
 const CURRENT_ACCOUNT_ID: &str = "alice";
 const SIGNER_ACCOUNT_ID: &str = "bob";


### PR DESCRIPTION
The only thing for which walrus was used was `walrus::Result`.  The
fun fact is that this is literally just `Result` if both generic
arguments are specified.  Remove the unnecessary dependency on walrus.
