### PR TITLE
Fix/num validators in neard log summary including chunk producers

### DIFF
--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1782,16 +1782,11 @@ impl ClientActor {
         let is_syncing = self.client.sync_status.is_syncing();
         let head = unwrap_or_return!(self.client.chain.head());
         let validator_info = if !is_syncing {
-            let block_producing_validators = unwrap_or_return!(self
-                .client
-                .runtime_adapter
-                .get_epoch_block_producers_ordered(&head.epoch_id, &head.last_block_hash));
-            let chunk_only_validators = unwrap_or_return!(self
+            let chunk_validators = unwrap_or_return!(self
                 .client
                 .runtime_adapter
                 .get_epoch_chunk_producers(&head.epoch_id));
-            // after 1.29.0: num_validators = chunk only producers + block producers
-            let num_validators = block_producing_validators.len() + chunk_only_validators.len();
+            let num_validators = chunk_validators.len();
             let account_id = self.client.validator_signer.as_ref().map(|x| x.validator_id());
             let is_validator = if let Some(account_id) = account_id {
                 match self.client.runtime_adapter.get_validator_by_account_id(

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1782,11 +1782,16 @@ impl ClientActor {
         let is_syncing = self.client.sync_status.is_syncing();
         let head = unwrap_or_return!(self.client.chain.head());
         let validator_info = if !is_syncing {
-            let validators = unwrap_or_return!(self
+            let block_producing_validators = unwrap_or_return!(self
                 .client
                 .runtime_adapter
                 .get_epoch_block_producers_ordered(&head.epoch_id, &head.last_block_hash));
-            let num_validators = validators.len();
+            let chunk_only_validators = unwrap_or_return!(self
+                .client
+                .runtime_adapter
+                .get_epoch_chunk_producers(&head.epoch_id));
+            // after 1.29.0: num_validators = chunk only producers + block producers
+            let num_validators = block_producing_validators.len() + chunk_only_validators.len();
             let account_id = self.client.validator_signer.as_ref().map(|x| x.validator_id());
             let is_validator = if let Some(account_id) = account_id {
                 match self.client.runtime_adapter.get_validator_by_account_id(


### PR DESCRIPTION
Fix for issue: https://github.com/near/nearcore/issues/7780

For epoch id: `EXfPTSH3cQwj9S8G696kvQZThfntj59UeNjdN8T3Aphv`
From go/mainnet-debug (screenshot below):
Num Validators (117) = chunk only producing validators (17) + block producing validators (100) (which also produce chunks)
In code: 
num_validators = chunk_validators.len() (since both chunk only and block producing validators produce chunks)

Validated fix on local node (see node output screenshot).

<img width="859" alt="Screen Shot 2022-10-06 at 1 20 20 PM" src="https://user-images.githubusercontent.com/113615218/194418913-c0598143-490d-49e4-84c0-9a3752a5569a.png">

![Screenshot from 2022-10-06 13-21-24](https://user-images.githubusercontent.com/113615218/194419005-61d877d1-902e-44a3-b823-7cb4008d3962.png)
