### PR TITLE
fix: adjust behaviour of chunk nodes cache test

### DIFF
--- a/integration-tests/src/tests/client/features/chunk_nodes_cache.rs
+++ b/integration-tests/src/tests/client/features/chunk_nodes_cache.rs
@@ -149,8 +149,19 @@ fn compare_node_counts() {
         })
         .collect();
 
-    assert_eq!(tx_node_counts[0], TrieNodesCount { db_reads: 4, mem_reads: 0 });
-    assert_eq!(tx_node_counts[1], TrieNodesCount { db_reads: 12, mem_reads: 0 });
-    assert_eq!(tx_node_counts[2], TrieNodesCount { db_reads: 8, mem_reads: 4 });
-    assert_eq!(tx_node_counts[3], TrieNodesCount { db_reads: 8, mem_reads: 4 });
+    if cfg!(feature = "protocol_feature_flat_state") {
+        // If flat storage is enabled, we shouldn't observe any trie node reads during transaction processing.
+        // For the first pair of write calls there are no contract values in storage, thus we see zero db reads.
+        assert_eq!(tx_node_counts[0], TrieNodesCount { db_reads: 0, mem_reads: 0 });
+        // For all other write calls we read the value reference from flat storage and the value from state.
+        // The first read doesn't count, so we should observe only two DB reads each time.
+        (1..4).for_each(|i| {
+            assert_eq!(tx_node_counts[i], TrieNodesCount { db_reads: 2, mem_reads: 0 })
+        });
+    } else {
+        assert_eq!(tx_node_counts[0], TrieNodesCount { db_reads: 4, mem_reads: 0 });
+        assert_eq!(tx_node_counts[1], TrieNodesCount { db_reads: 12, mem_reads: 0 });
+        assert_eq!(tx_node_counts[2], TrieNodesCount { db_reads: 8, mem_reads: 4 });
+        assert_eq!(tx_node_counts[3], TrieNodesCount { db_reads: 8, mem_reads: 4 });
+    }
 }


### PR DESCRIPTION
When we add flat storage, it is expected that we should record less DB
and memory trie node accesses. Here we simply change and explain the
values in test.

Small note: tests like `test_chunk_nodes_cache_same_common_parent`
still pass, because for nodes created there flat storage is not used.

## Testing

https://buildkite.com/nearprotocol/nearcore-flat-state/builds/70#0183c218-7b2c-4eea-8cd6-32f80cec0441
Now all integration tests pass, if we unite this PR with
https://github.com/near/nearcore/pull/7789.
