### PR TITLE
store: flatten TransactionResult column to remove need for RMW

### DIFF
--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -2258,7 +2258,7 @@ impl<'a> ChainStoreUpdate<'a> {
 
     pub fn gc_outcomes(&mut self, block: &Block) -> Result<(), Error> {
         let block_hash = block.hash();
-        let mut store_update = self.store().store_update();
+        let store_update = self.store().store_update();
         for chunk_header in
             block.chunks().iter().filter(|h| h.height_included() == block.header().height())
         {

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -2710,7 +2710,7 @@ impl<'a> ChainStoreUpdate<'a> {
         for ((outcome_id, block_hash), outcome_with_proof) in
             self.chain_store_cache_update.outcomes.iter()
         {
-            store_update.set_ser(
+            store_update.insert_ser(
                 DBCol::TransactionResultForBlock,
                 &get_outcome_id_block_hash(outcome_id, block_hash),
                 &outcome_with_proof,

--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -16,7 +16,7 @@ use near_primitives::epoch_manager::AGGREGATOR_KEY;
 use near_primitives::hash::CryptoHash;
 use near_primitives::sharding::{ChunkHash, ShardChunk, StateSyncInfo};
 use near_primitives::syncing::{ShardStateSyncResponseHeader, StateHeaderKey, StatePartKey};
-use near_primitives::transaction::{ExecutionOutcomeWithProof};
+use near_primitives::transaction::ExecutionOutcomeWithProof;
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{AccountId, BlockHeight, EpochId};
 use near_primitives::utils::{get_block_shard_id_rev, get_outcome_id_block_hash_rev};

--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -16,7 +16,7 @@ use near_primitives::epoch_manager::AGGREGATOR_KEY;
 use near_primitives::hash::CryptoHash;
 use near_primitives::sharding::{ChunkHash, ShardChunk, StateSyncInfo};
 use near_primitives::syncing::{ShardStateSyncResponseHeader, StateHeaderKey, StatePartKey};
-use near_primitives::transaction::{ExecutionOutcomeWithIdAndProof, ExecutionOutcomeWithProof};
+use near_primitives::transaction::{ExecutionOutcomeWithProof};
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{AccountId, BlockHeight, EpochId};
 use near_primitives::utils::{get_block_shard_id_rev, get_outcome_id_block_hash_rev};

--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -16,10 +16,10 @@ use near_primitives::epoch_manager::AGGREGATOR_KEY;
 use near_primitives::hash::CryptoHash;
 use near_primitives::sharding::{ChunkHash, ShardChunk, StateSyncInfo};
 use near_primitives::syncing::{ShardStateSyncResponseHeader, StateHeaderKey, StatePartKey};
-use near_primitives::transaction::ExecutionOutcomeWithIdAndProof;
+use near_primitives::transaction::{ExecutionOutcomeWithIdAndProof, ExecutionOutcomeWithProof};
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{AccountId, BlockHeight, EpochId};
-use near_primitives::utils::get_block_shard_id_rev;
+use near_primitives::utils::{get_block_shard_id_rev, get_outcome_id_block_hash_rev};
 use near_store::db::refcount;
 use near_store::{DBCol, Store, TrieChanges};
 use validate::StoreValidatorError;
@@ -231,15 +231,14 @@ impl StoreValidator {
                     // Block which can be indexed by Outcome block_hash exists
                     self.check(&validate::outcome_id_block_exists, &block_hash, &outcome_ids, col);
                 }
-                DBCol::TransactionResult => {
-                    let outcome_id = CryptoHash::try_from_slice(key_ref)?;
-                    let outcomes =
-                        <Vec<ExecutionOutcomeWithIdAndProof>>::try_from_slice(value_ref)?;
+                DBCol::TransactionResultForBlock => {
+                    let (outcome_id, block_hash) = get_outcome_id_block_hash_rev(key_ref)?;
+                    let outcome = <ExecutionOutcomeWithProof>::try_from_slice(value_ref)?;
                     // Outcome is reachable in ColOutcomesByBlockHash
                     self.check(
                         &validate::outcome_indexed_by_block_hash,
-                        &outcome_id,
-                        &outcomes,
+                        &(outcome_id, block_hash),
+                        &outcome,
                         col,
                     );
                 }

--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -221,7 +221,7 @@ impl StoreValidator {
                 DBCol::OutcomeIds => {
                     let (block_hash, _) = get_block_shard_id_rev(key_ref)?;
                     let outcome_ids = Vec::<CryptoHash>::try_from_slice(value_ref)?;
-                    // TransactionResult which can be indexed by Outcome id exists
+                    // TransactionResultForBlock should exist for outcome ID and block hash
                     self.check(
                         &validate::outcome_by_outcome_id_exists,
                         &block_hash,

--- a/chain/chain/src/store_validator/validate.rs
+++ b/chain/chain/src/store_validator/validate.rs
@@ -12,7 +12,7 @@ use near_primitives::syncing::{
     get_num_state_parts, ShardStateSyncResponseHeader, StateHeaderKey, StatePartKey,
 };
 use near_primitives::transaction::{
-    ExecutionOutcomeWithIdAndProof, ExecutionOutcomeWithProof, SignedTransaction,
+    ExecutionOutcomeWithProof, SignedTransaction,
 };
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{BlockHeight, EpochId};
@@ -659,7 +659,7 @@ pub(crate) fn outcome_by_outcome_id_exists(
     outcome_ids: &[CryptoHash],
 ) -> Result<(), StoreValidatorError> {
     for outcome_id in outcome_ids {
-        let outcome = unwrap_or_err_db!(
+        let _outcome = unwrap_or_err_db!(
             sv.store.get_ser::<ExecutionOutcomeWithProof>(
                 DBCol::TransactionResultForBlock,
                 &get_outcome_id_block_hash(outcome_id, block_hash)

--- a/chain/chain/src/store_validator/validate.rs
+++ b/chain/chain/src/store_validator/validate.rs
@@ -11,10 +11,12 @@ use near_primitives::sharding::{ChunkHash, ShardChunk, StateSyncInfo};
 use near_primitives::syncing::{
     get_num_state_parts, ShardStateSyncResponseHeader, StateHeaderKey, StatePartKey,
 };
-use near_primitives::transaction::{ExecutionOutcomeWithIdAndProof, SignedTransaction};
+use near_primitives::transaction::{
+    ExecutionOutcomeWithIdAndProof, ExecutionOutcomeWithProof, SignedTransaction,
+};
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{BlockHeight, EpochId};
-use near_primitives::utils::{get_block_shard_id, index_to_bytes};
+use near_primitives::utils::{get_block_shard_id, get_outcome_id_block_hash, index_to_bytes};
 use near_store::{
     DBCol, TrieChanges, CHUNK_TAIL_KEY, FORK_TAIL_KEY, HEADER_HEAD_KEY, HEAD_KEY, TAIL_KEY,
 };
@@ -657,17 +659,15 @@ pub(crate) fn outcome_by_outcome_id_exists(
     outcome_ids: &[CryptoHash],
 ) -> Result<(), StoreValidatorError> {
     for outcome_id in outcome_ids {
-        let outcomes = unwrap_or_err_db!(
-            sv.store.get_ser::<Vec<ExecutionOutcomeWithIdAndProof>>(
-                DBCol::TransactionResult,
-                outcome_id.as_ref()
+        let outcome = unwrap_or_err_db!(
+            sv.store.get_ser::<ExecutionOutcomeWithProof>(
+                DBCol::TransactionResultForBlock,
+                &get_outcome_id_block_hash(outcome_id, block_hash)
             ),
-            "Can't get TransactionResult from storage with Outcome id {:?}",
-            outcome_id
+            "Can't get TransactionResultForBlock from storage with Outcome id {:?} block hash {:?}",
+            outcome_id,
+            block_hash
         );
-        if outcomes.iter().find(|outcome| &outcome.block_hash == block_hash).is_none() {
-            panic!("Invalid TransactionResult {:?} stored", outcomes);
-        }
     }
     Ok(())
 }
@@ -686,37 +686,35 @@ pub(crate) fn outcome_id_block_exists(
 
 pub(crate) fn outcome_indexed_by_block_hash(
     sv: &mut StoreValidator,
-    outcome_id: &CryptoHash,
-    outcomes: &[ExecutionOutcomeWithIdAndProof],
+    (outcome_id, block_hash): &(CryptoHash, CryptoHash),
+    _outcome: &ExecutionOutcomeWithProof,
 ) -> Result<(), StoreValidatorError> {
-    for outcome in outcomes {
-        let block = unwrap_or_err_db!(
-            sv.store.get_ser::<Block>(DBCol::Block, outcome.block_hash.as_ref()),
-            "Can't get Block {} from DB",
-            outcome.block_hash
-        );
-        let mut outcome_ids = vec![];
-        for chunk_header in block.chunks().iter() {
-            if chunk_header.height_included() == block.header().height() {
-                let shard_uid = sv
-                    .runtime_adapter
-                    .shard_id_to_uid(chunk_header.shard_id(), block.header().epoch_id())
-                    .map_err(|err| StoreValidatorError::DBNotFound {
-                        func_name: "get_shard_layout",
-                        reason: err.to_string(),
-                    })?;
-                if let Ok(Some(_)) = sv.store.get_ser::<ChunkExtra>(
-                    DBCol::ChunkExtra,
-                    &get_block_shard_uid(block.hash(), &shard_uid),
-                ) {
-                    outcome_ids.extend(unwrap_or_err_db!(
-                        sv.store.get_ser::<Vec<CryptoHash>>(
-                            DBCol::OutcomeIds,
-                            &get_block_shard_id(block.hash(), chunk_header.shard_id())
-                        ),
-                        "Can't get Outcome ids by Block Hash"
-                    ));
-                }
+    let block = unwrap_or_err_db!(
+        sv.store.get_ser::<Block>(DBCol::Block, block_hash.as_ref()),
+        "Can't get Block {} from DB",
+        block_hash
+    );
+    let mut outcome_ids = vec![];
+    for chunk_header in block.chunks().iter() {
+        if chunk_header.height_included() == block.header().height() {
+            let shard_uid = sv
+                .runtime_adapter
+                .shard_id_to_uid(chunk_header.shard_id(), block.header().epoch_id())
+                .map_err(|err| StoreValidatorError::DBNotFound {
+                    func_name: "get_shard_layout",
+                    reason: err.to_string(),
+                })?;
+            if let Ok(Some(_)) = sv.store.get_ser::<ChunkExtra>(
+                DBCol::ChunkExtra,
+                &get_block_shard_uid(block.hash(), &shard_uid),
+            ) {
+                outcome_ids.extend(unwrap_or_err_db!(
+                    sv.store.get_ser::<Vec<CryptoHash>>(
+                        DBCol::OutcomeIds,
+                        &get_block_shard_id(block.hash(), chunk_header.shard_id())
+                    ),
+                    "Can't get Outcome ids by Block Hash"
+                ));
             }
         }
         if !outcome_ids.contains(outcome_id) {

--- a/chain/chain/src/store_validator/validate.rs
+++ b/chain/chain/src/store_validator/validate.rs
@@ -11,9 +11,7 @@ use near_primitives::sharding::{ChunkHash, ShardChunk, StateSyncInfo};
 use near_primitives::syncing::{
     get_num_state_parts, ShardStateSyncResponseHeader, StateHeaderKey, StatePartKey,
 };
-use near_primitives::transaction::{
-    ExecutionOutcomeWithProof, SignedTransaction,
-};
+use near_primitives::transaction::{ExecutionOutcomeWithProof, SignedTransaction};
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{BlockHeight, EpochId};
 use near_primitives::utils::{get_block_shard_id, get_outcome_id_block_hash, index_to_bytes};

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -437,6 +437,12 @@ pub fn verify_transaction_signature(
     public_keys.iter().any(|key| transaction.signature.verify(hash, key))
 }
 
+/// A more compact struct, just for storage.
+#[derive(Clone, BorshSerialize, BorshDeserialize)]
+pub struct ExecutionOutcomeWithProof {
+    pub proof: MerklePath,
+    pub outcome: ExecutionOutcome,
+}
 #[cfg(test)]
 mod tests {
     use borsh::BorshDeserialize;

--- a/core/primitives/src/utils.rs
+++ b/core/primitives/src/utils.rs
@@ -202,6 +202,22 @@ pub fn get_block_shard_id_rev(
     Ok((block_hash, shard_id))
 }
 
+pub fn get_outcome_id_block_hash(outcome_id: &CryptoHash, block_hash: &CryptoHash) -> Vec<u8> {
+    let mut res = Vec::with_capacity(64);
+    res.extend_from_slice(outcome_id.as_ref());
+    res.extend_from_slice(block_hash.as_ref());
+    res
+}
+
+pub fn get_outcome_id_block_hash_rev(key: &[u8]) -> std::io::Result<(CryptoHash, CryptoHash)> {
+    if key.len() != 64 {
+        return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "Invalid key length"));
+    }
+    let outcome_id = CryptoHash::try_from(&key[..32]).unwrap();
+    let block_hash = CryptoHash::try_from(&key[32..]).unwrap();
+    Ok((outcome_id, block_hash))
+}
+
 /// Creates a new Receipt ID from a given signed transaction and a block hash.
 /// This method is backward compatible, so it takes the current protocol version.
 pub fn create_receipt_id_from_transaction(

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -47,11 +47,9 @@ pub enum DBCol {
     /// - *Rows*: BlockChunk (block_hash, shard_uid)
     /// - *Content type*: [near_primitives::types::chunk_extra::ChunkExtra]
     ChunkExtra,
-    /// Mapping from transaction outcome id (CryptoHash) to list of outcome ids with proofs.
-    /// Multiple outcomes can arise due to forks.
-    /// - *Rows*: outcome id (CryptoHash)
-    /// - *Content type*: Vec of [near_primitives::transaction::ExecutionOutcomeWithIdAndProof]
-    TransactionResult,
+    /// Deprecated.
+    #[strum(serialize = "TransactionResult")]
+    _TransactionResult,
     /// Mapping from Block + Shard to list of outgoing receipts.
     /// - *Rows*: block + shard
     /// - *Content type*: Vec of [near_primitives::receipt::Receipt]
@@ -237,6 +235,11 @@ pub enum DBCol {
     /// - *Rows*: BlockShardId (BlockHash || ShardId) - 40 bytes
     /// - *Column type*: StateChangesForSplitStates
     StateChangesForSplitStates,
+    /// Transaction or receipt outcome, by outcome ID (transaction or receipt hash) and block
+    /// hash. Multiple outcomes may be stored for the same outcome ID in case of forks.
+    /// *Rows*: OutcomeId (CryptoHash) || BlockHash (CryptoHash)
+    /// *Column type*: ExecutionOutcomeWithProof
+    TransactionResultForBlock,
     /// Flat state contents. Used to get `ValueRef` by trie key faster than doing a trie lookup.
     /// - *Rows*: trie key (Vec<u8>)
     /// - *Column type*: ValueRef

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -281,7 +281,8 @@ impl DBCol {
             | DBCol::BlockInfo
             | DBCol::Chunks
             | DBCol::InvalidChunks
-            | DBCol::PartialChunks => true,
+            | DBCol::PartialChunks
+            | DBCol::TransactionResultForBlock => true,
             _ => false,
         }
     }

--- a/core/store/src/db/rocksdb.rs
+++ b/core/store/src/db/rocksdb.rs
@@ -584,7 +584,7 @@ fn col_name(col: DBCol) -> &'static str {
         DBCol::BlockHeight => "col4",
         DBCol::State => "col5",
         DBCol::ChunkExtra => "col6",
-        DBCol::TransactionResult => "col7",
+        DBCol::_TransactionResult => "col7",
         DBCol::OutgoingReceipts => "col8",
         DBCol::IncomingReceipts => "col9",
         DBCol::Peers => "col10",

--- a/core/store/src/migrations.rs
+++ b/core/store/src/migrations.rs
@@ -4,8 +4,10 @@ use borsh::{BorshDeserialize, BorshSerialize};
 
 use near_primitives::epoch_manager::epoch_info::{EpochInfo, EpochInfoV1};
 use near_primitives::hash::CryptoHash;
+use near_primitives::transaction::{ExecutionOutcomeWithIdAndProof, ExecutionOutcomeWithProof};
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::AccountId;
+use near_primitives::utils::get_outcome_id_block_hash;
 
 use crate::{DBCol, Store, StoreUpdate};
 
@@ -184,5 +186,66 @@ pub fn migrate_31_to_32(storage: &crate::NodeStorage) -> anyhow::Result<()> {
     update.delete_all(DBCol::_ChunkPerHeightShard);
     update.delete_all(DBCol::_GCCount);
     update.commit()?;
+    Ok(())
+}
+
+fn get_row_count(store: &Store, col_name: &str) -> Option<i64> {
+    let statistics = store.get_store_statistics()?;
+    let col_stats = statistics.data.into_iter().find(|(col, _)| col == col_name)?.1;
+    for stat in col_stats {
+        match stat {
+            crate::db::StatsValue::Count(count) => return Some(count),
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Migrates database from version 32 to 33.
+///
+/// This removes the TransactionResult column and moves it to TransactionResultForBlock.
+/// The new column removes the need for high-latency read-modify-write operations when committing
+/// new blocks.
+pub fn migrate_32_to_33(storage: &crate::NodeStorage) -> anyhow::Result<()> {
+    const BATCH_SIZE: usize = 100000;
+    let store = storage.get_store(crate::Temperature::Hot);
+    let mut migrated_overall = 0;
+    let num_rows = get_row_count(&store, "col7");
+    loop {
+        let mut update = store.store_update();
+        let mut rows_migrated = 0;
+        for row in store
+            .iter_prefix_ser::<Vec<ExecutionOutcomeWithIdAndProof>>(DBCol::_TransactionResult, &[])
+        {
+            let (key, outcomes) = row?;
+            update.delete(DBCol::_TransactionResult, &key);
+            for outcome in outcomes {
+                update.set_ser(
+                    DBCol::TransactionResultForBlock,
+                    &get_outcome_id_block_hash(outcome.id(), &outcome.block_hash),
+                    &ExecutionOutcomeWithProof {
+                        proof: outcome.proof,
+                        outcome: outcome.outcome_with_id.outcome,
+                    },
+                )?;
+            }
+
+            rows_migrated += 1;
+            if rows_migrated == BATCH_SIZE {
+                break;
+            }
+        }
+        if rows_migrated == 0 {
+            break;
+        } else {
+            migrated_overall += rows_migrated;
+            update.commit()?;
+        }
+        println!(
+            "Migrated {}/{} TransactionResult rows",
+            migrated_overall,
+            num_rows.map(|rows| format!("{}", rows)).unwrap_or("unknown".to_string())
+        );
+    }
     Ok(())
 }

--- a/core/store/src/version.rs
+++ b/core/store/src/version.rs
@@ -2,7 +2,7 @@
 pub type DbVersion = u32;
 
 /// Current version of the database.
-pub const DB_VERSION: DbVersion = 32;
+pub const DB_VERSION: DbVersion = 33;
 
 /// Deserialises database version from data read from database.
 ///

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -153,6 +153,7 @@ impl<'a> near_store::StoreMigrator for Migrator<'a> {
             29 => near_store::migrations::migrate_29_to_30(storage),
             30 => migrate_30_to_31(storage, &self.config),
             31 => near_store::migrations::migrate_31_to_32(storage),
+            32 => near_store::migrations::migrate_32_to_33(storage),
             DB_VERSION.. => unreachable!(),
         }
     }

--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -14,7 +14,7 @@ use near_primitives::borsh::maybestd::sync::Arc;
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::DelayedReceiptIndices;
 use near_primitives::transaction::{
-    Action, ExecutionOutcomeWithId, ExecutionOutcomeWithIdAndProof,
+    Action, ExecutionOutcomeWithId, ExecutionOutcomeWithProof,
 };
 use near_primitives::trie_key::TrieKey;
 use near_primitives::types::chunk_extra::ChunkExtra;
@@ -90,15 +90,17 @@ fn old_outcomes(
     new_outcomes
         .iter()
         .map(|outcome| {
-            store
-                .get_ser::<Vec<ExecutionOutcomeWithIdAndProof>>(
-                    DBCol::TransactionResult,
+            let old_outcome = store
+                .iter_prefix_ser::<ExecutionOutcomeWithProof>(
+                    DBCol::TransactionResultForBlock,
                     outcome.id.as_ref(),
                 )
+                .next()
                 .unwrap()
-                .unwrap()[0]
-                .outcome_with_id
-                .clone()
+                .unwrap()
+                .1
+                .outcome;
+            ExecutionOutcomeWithId { id: outcome.id, outcome: old_outcome }
         })
         .collect()
 }

--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -13,9 +13,7 @@ use near_chain_configs::Genesis;
 use near_primitives::borsh::maybestd::sync::Arc;
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::DelayedReceiptIndices;
-use near_primitives::transaction::{
-    Action, ExecutionOutcomeWithId, ExecutionOutcomeWithProof,
-};
+use near_primitives::transaction::{Action, ExecutionOutcomeWithId, ExecutionOutcomeWithProof};
 use near_primitives::trie_key::TrieKey;
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{BlockHeight, ShardId};

--- a/tools/state-viewer/src/apply_chunk.rs
+++ b/tools/state-viewer/src/apply_chunk.rs
@@ -197,7 +197,7 @@ fn apply_tx_in_block(
             }
         },
         None => {
-            Err(anyhow!("Could not find tx with hash {} in block {}, even though `DBCol::TransactionResult` says it should be there", tx_hash, block_hash))
+            Err(anyhow!("Could not find tx with hash {} in block {}, even though `DBCol::TransactionResultForBlock` says it should be there", tx_hash, block_hash))
         }
     }
 }


### PR DESCRIPTION
This migrates TransactionResult column, which mapped OutcomeId
(CryptoHash of transaction or receipt) to
`Vec<ExecutionOutcomeWithIdAndProof>` (outcome, outcome ID, proof,
block hash), to a new column TransactionResultForBlock, which maps
(OutcomeId, BlockHash) to singular ExecutionOutcomeWithProof (outcome,
proof).

Note that an execution of a transaction or receipt may have multiple
outcomes due to forks; that's why we store a list of them.  The old
implementation had to append to this list whenever it commits a new
block to the store, leading to a read-modify-write operation.  The new
implementation directly writes to an entry keyed by both the outcome
ID and block hash.

At RPC time, we will do a prefix scan using the OutcomeId to achieve
the equivalent querying capability as today.

A DB migration is included to move everything from the old column to
the new column.  In testing it took around two minutes on RPC nodes
and over two hours on archival nodes.
