### PR TITLE
core: accept passing arguments by value in CryptoHash::hash_bytes

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2124,7 +2124,7 @@ impl Chain {
                     flat_storage_state.update_flat_head(&new_flat_head).unwrap_or_else(|err| {
                         match &err {
                             FlatStorageError::BlockNotSupported(_) => {
-                                // It's possible that new head is not a child of current flat head, e.g. when we have a 
+                                // It's possible that new head is not a child of current flat head, e.g. when we have a
                                 // fork:
                                 //
                                 //      (flat head)        /-------> 6
@@ -2725,7 +2725,7 @@ impl Chain {
             for receipt_proof in receipt_proofs.iter() {
                 let ReceiptProof(receipts, shard_proof) = receipt_proof;
                 let ShardProof { from_shard_id, to_shard_id: _, proof } = shard_proof;
-                let receipts_hash = CryptoHash::hash_borsh(&ReceiptList(shard_id, receipts));
+                let receipts_hash = CryptoHash::hash_borsh(ReceiptList(shard_id, receipts));
                 let from_shard_id = *from_shard_id as usize;
 
                 let root_proof = block.chunks()[from_shard_id].outgoing_receipts_root();
@@ -2967,7 +2967,7 @@ impl Chain {
                     _ => visited_shard_ids.insert(*from_shard_id),
                 };
                 let RootProof(root, block_proof) = &shard_state_header.root_proofs()[i][j];
-                let receipts_hash = CryptoHash::hash_borsh(&ReceiptList(shard_id, receipts));
+                let receipts_hash = CryptoHash::hash_borsh(ReceiptList(shard_id, receipts));
                 // 4e. Proving the set of receipts is the subset of outgoing_receipts of shard `shard_id`
                 if !verify_path(*root, proof, &receipts_hash) {
                     byzantine_assert!(false);
@@ -4396,7 +4396,7 @@ impl Chain {
         shard_layout: &ShardLayout,
     ) -> Vec<CryptoHash> {
         if shard_layout.num_shards() == 1 {
-            return vec![CryptoHash::hash_borsh(&ReceiptList(0, receipts))];
+            return vec![CryptoHash::hash_borsh(ReceiptList(0, receipts))];
         }
         let mut account_id_to_shard_id_map = HashMap::new();
         let mut shard_receipts: Vec<_> =

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -181,7 +181,7 @@ fn create_receipt_nonce(
     amount: Balance,
     nonce: Nonce,
 ) -> CryptoHash {
-    CryptoHash::hash_borsh(&ReceiptNonce { from, to, amount, nonce })
+    CryptoHash::hash_borsh(ReceiptNonce { from, to, amount, nonce })
 }
 
 impl KeyValueRuntime {
@@ -1583,7 +1583,7 @@ mod test {
                 })
                 .cloned()
                 .collect();
-            receipts_hashes.push(CryptoHash::hash_borsh(&ReceiptList(shard_id, &shard_receipts)));
+            receipts_hashes.push(CryptoHash::hash_borsh(ReceiptList(shard_id, &shard_receipts)));
         }
         receipts_hashes
     }

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -682,7 +682,7 @@ mod tests {
             0,
             100,
             1_000_000_000,
-            CryptoHash::hash_borsh(&genesis_bps),
+            CryptoHash::hash_borsh(genesis_bps),
         );
         let signer =
             InMemoryValidatorSigner::from_seed("other".parse().unwrap(), KeyType::ED25519, "other");

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -1655,7 +1655,7 @@ impl ShardsManager {
             // because prev_block_hash may not be ready
             let shard_id = proof.1.to_shard_id;
             let ReceiptProof(shard_receipts, receipt_proof) = proof;
-            let receipt_hash = CryptoHash::hash_borsh(&ReceiptList(shard_id, shard_receipts));
+            let receipt_hash = CryptoHash::hash_borsh(ReceiptList(shard_id, shard_receipts));
             if !verify_path(header.outgoing_receipts_root(), &receipt_proof.proof, &receipt_hash) {
                 byzantine_assert!(false);
                 return Err(Error::ChainError(near_chain::Error::InvalidReceiptsProof));

--- a/chain/network/src/network_protocol/edge.rs
+++ b/chain/network/src/network_protocol/edge.rs
@@ -108,7 +108,7 @@ impl Edge {
     /// It is important that peer0 < peer1 at this point.
     pub fn build_hash(peer0: &PeerId, peer1: &PeerId, nonce: u64) -> CryptoHash {
         let (peer0, peer1) = if peer0 < peer1 { (peer0, peer1) } else { (peer1, peer0) };
-        CryptoHash::hash_borsh(&(peer0, peer1, nonce))
+        CryptoHash::hash_borsh((peer0, peer1, nonce))
     }
 
     pub fn make_key(peer0: PeerId, peer1: PeerId) -> (PeerId, PeerId) {

--- a/chain/network/src/network_protocol/mod.rs
+++ b/chain/network/src/network_protocol/mod.rs
@@ -534,7 +534,7 @@ impl RoutedMessage {
         source: &PeerId,
         body: &RoutedMessageBody,
     ) -> CryptoHash {
-        CryptoHash::hash_borsh(&RoutedMessageNoSignature { target, author: source, body })
+        CryptoHash::hash_borsh(RoutedMessageNoSignature { target, author: source, body })
     }
 
     pub fn hash(&self) -> CryptoHash {

--- a/core/primitives-core/src/hash.rs
+++ b/core/primitives-core/src/hash.rs
@@ -29,9 +29,9 @@ impl CryptoHash {
     /// results.  For example, `CryptoHash::hash_borsh(&[1u32, 2, 3])` hashes
     /// a representation of a `[u32; 3]` array rather than a slice.  It may be
     /// cleaner to use [`Self::hash_borsh_iter`] instead.
-    pub fn hash_borsh<T: BorshSerialize>(value: &T) -> CryptoHash {
+    pub fn hash_borsh<T: BorshSerialize>(value: T) -> CryptoHash {
         let mut hasher = sha2::Sha256::default();
-        BorshSerialize::serialize(value, &mut hasher).unwrap();
+        value.serialize(&mut hasher).unwrap();
         CryptoHash(hasher.finalize().into())
     }
 

--- a/core/primitives/src/merkle.rs
+++ b/core/primitives/src/merkle.rs
@@ -19,7 +19,7 @@ pub enum Direction {
 }
 
 pub fn combine_hash(hash1: &MerkleHash, hash2: &MerkleHash) -> MerkleHash {
-    CryptoHash::hash_borsh(&(hash1, hash2))
+    CryptoHash::hash_borsh((hash1, hash2))
 }
 
 /// Merklize an array of items. If the array is empty, returns hash of 0
@@ -89,8 +89,8 @@ pub fn merklize<T: BorshSerialize>(arr: &[T]) -> (MerkleHash, Vec<MerklePath>) {
 }
 
 /// Verify merkle path for given item and corresponding path.
-pub fn verify_path<T: BorshSerialize>(root: MerkleHash, path: &MerklePath, item: &T) -> bool {
-    verify_hash(root, path, CryptoHash::hash_borsh(&item))
+pub fn verify_path<T: BorshSerialize>(root: MerkleHash, path: &MerklePath, item: T) -> bool {
+    verify_hash(root, path, CryptoHash::hash_borsh(item))
 }
 
 pub fn verify_hash(root: MerkleHash, path: &MerklePath, item_hash: MerkleHash) -> bool {
@@ -114,9 +114,9 @@ pub fn compute_root_from_path(path: &MerklePath, item_hash: MerkleHash) -> Merkl
 
 pub fn compute_root_from_path_and_item<T: BorshSerialize>(
     path: &MerklePath,
-    item: &T,
+    item: T,
 ) -> MerkleHash {
-    compute_root_from_path(path, CryptoHash::hash_borsh(&item))
+    compute_root_from_path(path, CryptoHash::hash_borsh(item))
 }
 
 /// Merkle tree that only maintains the path for the next leaf, i.e,
@@ -199,8 +199,8 @@ mod tests {
     fn test_incorrect_path() {
         let items = vec![111, 222, 333];
         let (root, paths) = merklize(&items);
-        for i in 0..items.len() {
-            assert!(!verify_path(root, &paths[(i + 1) % 3], &items[i]))
+        for (i, item) in items.iter().enumerate() {
+            assert!(!verify_path(root, &paths[(i + 1) % 3], item))
         }
     }
 

--- a/core/primitives/src/merkle.rs
+++ b/core/primitives/src/merkle.rs
@@ -199,8 +199,8 @@ mod tests {
     fn test_incorrect_path() {
         let items = vec![111, 222, 333];
         let (root, paths) = merklize(&items);
-        for (i, item) in items.iter().enumerate() {
-            assert!(!verify_path(root, &paths[(i + 1) % 3], item))
+        for i in 0..items.len() {
+            assert!(!verify_path(root, &paths[(i + 1) % 3], &items[i]))
         }
     }
 

--- a/core/primitives/src/network.rs
+++ b/core/primitives/src/network.rs
@@ -71,7 +71,7 @@ impl AnnounceAccount {
         peer_id: &PeerId,
         epoch_id: &EpochId,
     ) -> CryptoHash {
-        CryptoHash::hash_borsh(&(account_id, peer_id, epoch_id))
+        CryptoHash::hash_borsh((account_id, peer_id, epoch_id))
     }
 
     pub fn hash(&self) -> CryptoHash {

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -407,7 +407,7 @@ impl ExecutionOutcomeWithId {
     pub fn to_hashes(&self) -> Vec<CryptoHash> {
         let mut result = Vec::with_capacity(2 + self.outcome.logs.len());
         result.push(self.id);
-        result.push(CryptoHash::hash_borsh(&PartialExecutionOutcome::from(&self.outcome)));
+        result.push(CryptoHash::hash_borsh(PartialExecutionOutcome::from(&self.outcome)));
         result.extend(self.outcome.logs.iter().map(|log| hash(log.as_bytes())));
         result
     }

--- a/core/primitives/src/validator_signer.rs
+++ b/core/primitives/src/validator_signer.rs
@@ -109,7 +109,7 @@ impl ValidatorSigner for EmptyValidatorSigner {
     }
 
     fn sign_challenge(&self, challenge_body: &ChallengeBody) -> (CryptoHash, Signature) {
-        (CryptoHash::hash_borsh(&challenge_body), Signature::default())
+        (CryptoHash::hash_borsh(challenge_body), Signature::default())
     }
 
     fn sign_account_announce(
@@ -200,7 +200,7 @@ impl ValidatorSigner for InMemoryValidatorSigner {
     }
 
     fn sign_challenge(&self, challenge_body: &ChallengeBody) -> (CryptoHash, Signature) {
-        let hash = CryptoHash::hash_borsh(&challenge_body);
+        let hash = CryptoHash::hash_borsh(challenge_body);
         let signature = self.signer.sign(hash.as_ref());
         (hash, signature)
     }

--- a/integration-tests/src/tests/nearcore/rpc_nodes.rs
+++ b/integration-tests/src/tests/nearcore/rpc_nodes.rs
@@ -78,7 +78,7 @@ fn outcome_view_to_hashes(outcome: &ExecutionOutcomeView) -> Vec<CryptoHash> {
         ExecutionStatusView::Failure(_) => PartialExecutionStatus::Failure,
         ExecutionStatusView::SuccessReceiptId(id) => PartialExecutionStatus::SuccessReceiptId(*id),
     };
-    let mut result = vec![CryptoHash::hash_borsh(&(
+    let mut result = vec![CryptoHash::hash_borsh((
         outcome.receipt_ids.clone(),
         outcome.gas_burnt,
         outcome.tokens_burnt,

--- a/runtime/near-vm-runner/src/cache.rs
+++ b/runtime/near-vm-runner/src/cache.rs
@@ -57,7 +57,7 @@ pub fn get_contract_cache_key(
         vm_kind,
         vm_hash: vm_hash(vm_kind),
     };
-    CryptoHash::hash_borsh(&key)
+    CryptoHash::hash_borsh(key)
 }
 
 #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
This makes call sites simpler and there is no need to require that
argument to CryptoHash::hash_bytes is a reference.  There’s a blanket
implementation for references so caller still has that option if they
need it.
