### PR TITLE
fix: failing mock node test for flat state

### DIFF
--- a/tools/mock-node/src/lib.rs
+++ b/tools/mock-node/src/lib.rs
@@ -507,7 +507,7 @@ mod test {
             env.produce_block(0, i + 1);
         }
 
-        let chain = Chain::new(
+        let chain = Chain::new_for_view_client(
             runtimes[0].clone(),
             &chain_genesis,
             env.clients[0].chain.doomslug_threshold_mode,

--- a/tools/mock-node/src/lib.rs
+++ b/tools/mock-node/src/lib.rs
@@ -507,6 +507,7 @@ mod test {
             env.produce_block(0, i + 1);
         }
 
+        // Create view client chain to retrieve and check chain data in the test.
         let chain = Chain::new_for_view_client(
             runtimes[0].clone(),
             &chain_genesis,


### PR DESCRIPTION
`test_chain_history_access` fails because `setup_mock` creates two `Chain`s, each of them tries to create flat storage, and the latter one fails because the object already exists.

Looks like that `Chain::new_for_view_client` is a nice fix, because it is allowed to have both regular and view clients accessing the same shard.

## Testing

Existing tests.