### PR TITLE
client: add {node,validator}_public_key field to /status response; deprecated node_key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@
   deprecated.  If they are set in `config.json` the node will fail if migration
   needs to be performed.  Use `store.migration_snapshot` instead to configure
   the behaviour [#7486](https://github.com/near/nearcore/pull/7486)
+* Confusingly, `node_key` field in `/status` response used to contain
+  *validator* key.  It now contains node key.  Validator key is now in a new
+  `validator_key` field.  If you were reading validator key you need to read the
+  new field.  If you used `node_key` for id to list in public address or boot
+  nodes list, you may continue to do so.
 * Added `near_peer_message_sent_by_type_bytes` and
   `near_peer_message_sent_by_type_total` Prometheus metrics measuring
   size and number of messages sent to peers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,9 @@
   deprecated.  If they are set in `config.json` the node will fail if migration
   needs to be performed.  Use `store.migration_snapshot` instead to configure
   the behaviour [#7486](https://github.com/near/nearcore/pull/7486)
-* Confusingly, `node_key` field in `/status` response used to contain
-  *validator* key.  It now contains node key.  Validator key is now in a new
-  `validator_key` field.  If you were reading validator key you need to read the
-  new field.  If you used `node_key` for id to list in public address or boot
-  nodes list, you may continue to do so.
+* `/status` response has now two more fields: `node_public_key` and
+  `validator_public_key`.  The `node_key` field is now deprecated and should not
+  be used since it confusingly holds validator key.
 * Added `near_peer_message_sent_by_type_bytes` and
   `near_peer_message_sent_by_type_total` Prometheus metrics measuring
   size and number of messages sent to peers.

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -720,8 +720,12 @@ impl Handler<Status> for ClientActor {
         let protocol_version =
             self.client.runtime_adapter.get_epoch_protocol_version(&head.epoch_id)?;
 
-        let validator_and_key =
-            self.client.validator_signer.as_ref().map(|vs| (vs.validator_id(), vs.public_key()));
+        let node_public_key = self.node_id.public_key().clone();
+        let (validator_account_id, validator_public_key) = match &self.client.validator_signer {
+            Some(vs) => (Some(vs.validator_id().clone()), Some(vs.public_key().clone())),
+            None => (None, None),
+        };
+        let node_key = validator_public_key.clone();
 
         let mut earliest_block_hash = None;
         let mut earliest_block_height = None;
@@ -778,9 +782,10 @@ impl Handler<Status> for ClientActor {
                 epoch_id: Some(head.epoch_id),
                 epoch_start_height,
             },
-            validator_account_id: validator_and_key.as_ref().map(|v| v.0.clone()),
-            validator_key: validator_and_key.as_ref().map(|v| v.1.clone()),
-            node_key: self.node_id.public_key().clone(),
+            validator_account_id,
+            validator_public_key,
+            node_public_key,
+            node_key,
             uptime_sec,
             detailed_debug_status,
         })

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -779,7 +779,8 @@ impl Handler<Status> for ClientActor {
                 epoch_start_height,
             },
             validator_account_id: validator_and_key.as_ref().map(|v| v.0.clone()),
-            node_key: validator_and_key.as_ref().map(|v| v.1.clone()),
+            validator_key: validator_and_key.as_ref().map(|v| v.1.clone()),
+            node_key: self.node_id.public_key().clone(),
             uptime_sec,
             detailed_debug_status,
         })

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -532,8 +532,10 @@ pub struct StatusResponse {
     pub sync_info: StatusSyncInfo,
     /// Validator id of the node
     pub validator_account_id: Option<AccountId>,
+    /// Public key of the validator.
+    pub validator_key: Option<PublicKey>,
     /// Public key of the node.
-    pub node_key: Option<PublicKey>,
+    pub node_key: PublicKey,
     /// Uptime of the node.
     pub uptime_sec: i64,
     /// Information about last blocks, network, epoch and chain & chunk info.

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -533,9 +533,11 @@ pub struct StatusResponse {
     /// Validator id of the node
     pub validator_account_id: Option<AccountId>,
     /// Public key of the validator.
-    pub validator_key: Option<PublicKey>,
+    pub validator_public_key: Option<PublicKey>,
     /// Public key of the node.
-    pub node_key: PublicKey,
+    pub node_public_key: PublicKey,
+    /// Deprecated; same as `validator_public_key` which you should use instead.
+    pub node_key: Option<PublicKey>,
     /// Uptime of the node.
     pub uptime_sec: i64,
     /// Information about last blocks, network, epoch and chain & chunk info.


### PR DESCRIPTION
Currently, response to the /status request returns a `node_key`
field. However, the field does not include node key but rather
validator key.  Deprecated it in favour of two new fields:
`node_public_key` and `validator_public_key`.

Fixes: https://github.com/near/nearcore/issues/7672
