### PR TITLE
core: change PROTOCOL_UPGRADE_SCHEDULE into a single value

### DIFF
--- a/core/primitives/src/upgrade_schedule.rs
+++ b/core/primitives/src/upgrade_schedule.rs
@@ -1,6 +1,5 @@
 use chrono::{DateTime, NaiveDateTime, ParseError, Utc};
 use near_primitives_core::types::ProtocolVersion;
-use std::collections::HashMap;
 use std::str::FromStr;
 
 /// Defines the point in time after which validators are expected to vote on the new protocol version.
@@ -32,13 +31,14 @@ pub(crate) fn get_protocol_version_internal(
     next_epoch_protocol_version: ProtocolVersion,
     // Latest protocol version supported by this client.
     client_protocol_version: ProtocolVersion,
-    // Map of protocol versions to points in time when voting for that protocol version is expected to start.
-    // If None or missing, the client votes for the latest protocol version immediately.
-    schedule: &HashMap<ProtocolVersion, ProtocolUpgradeVotingSchedule>,
+    // Point in time when voting for client_protocol_version version is expected
+    // to start.  If None,, the client votes for the latest protocol version
+    // immediately.
+    schedule: &Option<ProtocolUpgradeVotingSchedule>,
 ) -> ProtocolVersion {
     if next_epoch_protocol_version >= client_protocol_version {
         client_protocol_version
-    } else if let Some(voting_start) = schedule.get(&client_protocol_version) {
+    } else if let Some(voting_start) = schedule {
         if voting_start.is_in_future() {
             // Don't announce support for the latest protocol version yet.
             next_epoch_protocol_version
@@ -71,23 +71,19 @@ mod tests {
             get_protocol_version_internal(
                 client_protocol_version - 2,
                 client_protocol_version,
-                &HashMap::new(),
+                &None,
             )
         );
         assert_eq!(
             client_protocol_version,
-            get_protocol_version_internal(
-                client_protocol_version,
-                client_protocol_version,
-                &HashMap::new()
-            )
+            get_protocol_version_internal(client_protocol_version, client_protocol_version, &None)
         );
         assert_eq!(
             client_protocol_version,
             get_protocol_version_internal(
                 client_protocol_version + 2,
                 client_protocol_version,
-                &HashMap::new(),
+                &None,
             )
         );
     }
@@ -97,30 +93,25 @@ mod tests {
         // As no protocol upgrade voting schedule is set, always return the version supported by the client.
 
         let client_protocol_version = 100;
-        let schedule = HashMap::new();
 
         assert_eq!(
             client_protocol_version,
             get_protocol_version_internal(
                 client_protocol_version - 2,
                 client_protocol_version,
-                &schedule,
+                &None,
             )
         );
         assert_eq!(
             client_protocol_version,
-            get_protocol_version_internal(
-                client_protocol_version,
-                client_protocol_version,
-                &schedule
-            )
+            get_protocol_version_internal(client_protocol_version, client_protocol_version, &None)
         );
         assert_eq!(
             client_protocol_version,
             get_protocol_version_internal(
                 client_protocol_version + 2,
                 client_protocol_version,
-                &schedule
+                &None
             )
         );
     }
@@ -128,11 +119,8 @@ mod tests {
     #[test]
     fn test_before_scheduled_time() {
         let client_protocol_version = 100;
-        let mut schedule = HashMap::new();
-        schedule.insert(
-            client_protocol_version,
-            ProtocolUpgradeVotingSchedule::from_str("2050-01-01 00:00:00").unwrap(),
-        );
+        let schedule =
+            Some(ProtocolUpgradeVotingSchedule::from_str("2050-01-01 00:00:00").unwrap());
 
         // The client supports a newer version than the version of the next epoch.
         // Upgrade voting will start in the far future, therefore don't announce the newest supported version.
@@ -172,11 +160,8 @@ mod tests {
     #[test]
     fn test_after_scheduled_time() {
         let client_protocol_version = 100;
-        let mut schedule = HashMap::new();
-        schedule.insert(
-            client_protocol_version,
-            ProtocolUpgradeVotingSchedule::from_str("1900-01-01 00:00:00").unwrap(),
-        );
+        let schedule =
+            Some(ProtocolUpgradeVotingSchedule::from_str("1900-01-01 00:00:00").unwrap());
 
         // Regardless of the protocol version of the next epoch, return the version supported by the client.
         assert_eq!(

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::str::FromStr;
 
 use once_cell::sync::Lazy;
@@ -175,22 +174,17 @@ pub const PROTOCOL_VERSION: ProtocolVersion = if cfg!(feature = "nightly_protoco
     STABLE_PROTOCOL_VERSION
 };
 
-/// The points in time after which the voting for the protocol version should start.
+/// The points in time after which the voting for the latest protocol version
+/// should start.
 #[allow(dead_code)]
-const PROTOCOL_UPGRADE_SCHEDULE: Lazy<HashMap<ProtocolVersion, ProtocolUpgradeVotingSchedule>> =
-    Lazy::new(|| {
-        let mut schedule = HashMap::new();
+const PROTOCOL_UPGRADE_SCHEDULE: Lazy<Option<ProtocolUpgradeVotingSchedule>> = Lazy::new(|| {
+    if cfg!(feature = "shardnet") {
+        Some(ProtocolUpgradeVotingSchedule::from_str("2022-09-05 15:00:00").unwrap())
+    } else {
         // Update to latest protocol version on release.
-        schedule
-            .insert(54, ProtocolUpgradeVotingSchedule::from_str("2022-06-27 15:00:00").unwrap());
-
-        /*
-        // Final shardnet release. Do not include it in testnet or mainnet releases.
-        schedule
-            .insert(102, ProtocolUpgradeVotingSchedule::from_str("2022-09-05 15:00:00").unwrap());
-         */
-        schedule
-    });
+        None
+    }
+});
 
 /// Gives new clients an option to upgrade without announcing that they support
 /// the new version.  This gives non-validator nodes time to upgrade.  See


### PR DESCRIPTION
In practice, PROTOCOL_UPGRADE_SCHEDULE always includes at most one
value for the client protocol version.  Change it from hash map to an
Option to simplify code.
