### PR TITLE
move the check for is_height_processed forward before process_block_header

### DIFF
--- a/chain/chain/src/block_processing_utils.rs
+++ b/chain/chain/src/block_processing_utils.rs
@@ -1,6 +1,6 @@
 use crate::chain::{BlockMissingChunks, OrphanMissingChunks};
 use crate::near_chain_primitives::error::BlockKnownError::KnownInProcessing;
-use crate::Provenance;
+use crate::{metrics, Provenance};
 use near_primitives::block::Block;
 use near_primitives::challenge::{ChallengeBody, ChallengesResult};
 use near_primitives::hash::CryptoHash;
@@ -116,6 +116,8 @@ impl BlocksInProcessing {
         // is likely never hit, unless there are many forks in the chain.
         // In this case, we will simply drop the block.
         if self.preprocessed_blocks.len() >= MAX_PROCESSING_BLOCKS {
+            tracing::info!(target:"chain", "Dropping block {block_hash} because we are already processing {} blocks", self.preprocessed_blocks.len());
+            metrics::BLOCKS_DROPPED_BECAUSE_POOL_IS_FULL.inc();
             Err(AddError::ExceedingPoolSize)
         } else if self.preprocessed_blocks.contains_key(block_hash) {
             Err(AddError::BlockAlreadyInPool)

--- a/chain/chain/src/metrics.rs
+++ b/chain/chain/src/metrics.rs
@@ -98,3 +98,10 @@ pub static BLOCK_MISSING_CHUNKS_DELAY: Lazy<Histogram> = Lazy::new(|| {
     )
     .unwrap()
 });
+pub static BLOCKS_DROPPED_BECAUSE_POOL_IS_FULL: Lazy<IntGauge> = Lazy::new(|| {
+    try_create_int_gauge(
+        "near_blocks_dropped_because_pool_is_full",
+        "Number of blocks dropped because ",
+    )
+    .unwrap()
+});

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -801,23 +801,6 @@ impl Client {
         provenance: Provenance,
         apply_chunks_done_callback: DoneApplyChunkCallback,
     ) -> Result<(), near_chain::Error> {
-        let is_requested = match provenance {
-            Provenance::PRODUCED | Provenance::SYNC => true,
-            Provenance::NONE => false,
-        };
-        // drop the block if a) it is not requested, b) we already processed this height, c) it is not building on top of current head
-        if !is_requested
-            && block.header().prev_hash()
-                != &self
-                    .chain
-                    .head()
-                    .map_or_else(|_| CryptoHash::default(), |tip| tip.last_block_hash)
-        {
-            if self.chain.store().is_height_processed(block.header().height())? {
-                return Ok(());
-            }
-        }
-
         let mut block_processing_artifacts = BlockProcessingArtifact::default();
 
         let result = {

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1370,6 +1370,20 @@ impl ClientActor {
             debug!(target: "client", tail_height = tail, "Dropping a block that is too far behind.");
             return;
         }
+        // drop the block if a) it is not requested, b) we already processed this height, c) it is not building on top of current head
+        if !was_requested
+            && block.header().prev_hash()
+                != &self
+                    .client
+                    .chain
+                    .head()
+                    .map_or_else(|_| CryptoHash::default(), |tip| tip.last_block_hash)
+        {
+            if self.client.chain.is_height_processed(block.header().height()).unwrap_or_default() {
+                debug!(target: "client", height = block.header().height(), "Dropping a block because we've seen this height before and we didn't request it");
+                return;
+            }
+        }
         let prev_hash = *block.header().prev_hash();
         let provenance =
             if was_requested { near_chain::Provenance::SYNC } else { near_chain::Provenance::NONE };


### PR DESCRIPTION
This PR actually includes two changes that should probably be separated into two PRs, for now, they are together since they are just going to 1.30.0
1) The important change is to move the check for is_height_processed before process_block_header. Previously, this check happens after, which means, the node will re-process the block header (which takes a few ms) and re-broadcast an invalid block before drops it. In the case when there are many invalid blocks circulating in the network, this can cause the node to be too busy, 
2) A less important change is around when the block processing pool is full. Previously, we drop the block if the block processing pool is full and saves the block height as processed. This change gets rid of that because we want to be able to process the block again. Note that the behavior before does not mean the node can't process the dropped block forever. The node will eventually fall behind and gets into sync mode and request for the block, and the is_height_processed check only applies for unrequested blocks. 

Both of these two changes can be merged to master as well. I'll do so later though. 