### PR TITLE
DRAFT: simple flat storage migration

### DIFF
--- a/chain/chain/Cargo.toml
+++ b/chain/chain/Cargo.toml
@@ -50,6 +50,7 @@ delay_detector = ["delay-detector/delay_detector"]
 no_cache = ["near-store/no_cache"]
 protocol_feature_flat_state = ["near-store/protocol_feature_flat_state"]
 protocol_feature_reject_blocks_with_outdated_protocol_version = ["near-primitives/protocol_feature_reject_blocks_with_outdated_protocol_version"]
+protocol_feature_flat_state_migration = ["near-store/protocol_feature_flat_state_migration"]
 
 shardnet = ["protocol_feature_reject_blocks_with_outdated_protocol_version"]
 

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -2411,10 +2411,11 @@ impl<'a> ChainStoreUpdate<'a> {
             | DBCol::CachedContractCode => {
                 unreachable!();
             }
-            #[cfg(feature = "protocol_feature_flat_state")]
-            DBCol::FlatState | DBCol::FlatStateDeltas | DBCol::FlatStateMisc => {
-                unreachable!();
-            }
+            #[cfg(any(
+                feature = "protocol_feature_flat_state",
+                feature = "protocol_feature_flat_state_migration"
+            ))]
+            DBCol::FlatState | DBCol::FlatStateDeltas | DBCol::FlatStateMisc => { unreachable!(); }
         }
         self.merge(store_update);
     }

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -57,6 +57,7 @@ no_cache = []
 single_thread_rocksdb = [] # Deactivate RocksDB IO background threads
 test_features = []
 protocol_feature_flat_state = []
+protocol_feature_flat_state_migration = []
 
 nightly_protocol = []
 nightly = [

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -243,18 +243,27 @@ pub enum DBCol {
     /// Flat state contents. Used to get `ValueRef` by trie key faster than doing a trie lookup.
     /// - *Rows*: trie key (Vec<u8>)
     /// - *Column type*: ValueRef
-    #[cfg(feature = "protocol_feature_flat_state")]
+    #[cfg(any(
+        feature = "protocol_feature_flat_state",
+        feature = "protocol_feature_flat_state_migration"
+    ))]
     FlatState,
     /// Deltas for flat state. Stores how flat state should be updated for the given shard and block.
     /// - *Rows*: `KeyForFlatStateDelta { shard_id, block_hash }`
     /// - *Column type*: `FlatStateDelta`
-    #[cfg(feature = "protocol_feature_flat_state")]
+    #[cfg(any(
+        feature = "protocol_feature_flat_state",
+        feature = "protocol_feature_flat_state_migration"
+    ))]
     FlatStateDeltas,
     /// Miscellaneous data for flat state. Currently stores flat state head for each shard.
     /// - *Rows*: shard id
     /// - *Column type*: block hash (CryptoHash)
     // TODO (#7327): use only during testing, come up with proper format.
-    #[cfg(feature = "protocol_feature_flat_state")]
+    #[cfg(any(
+        feature = "protocol_feature_flat_state",
+        feature = "protocol_feature_flat_state_migration"
+    ))]
     FlatStateMisc,
 }
 

--- a/core/store/src/flat_state.rs
+++ b/core/store/src/flat_state.rs
@@ -444,7 +444,10 @@ struct FlatStorageStateInner {
     deltas: HashMap<CryptoHash, Arc<FlatStateDelta>>,
 }
 
-#[cfg(feature = "protocol_feature_flat_state")]
+#[cfg(any(
+    feature = "protocol_feature_flat_state",
+    feature = "protocol_feature_flat_state_migration"
+))]
 pub mod store_helper {
     use crate::flat_state::{FlatStorageError, KeyForFlatStateDelta};
     use crate::{FlatStateDelta, Store, StoreUpdate};
@@ -674,6 +677,8 @@ impl FlatStorageState {
         // Update flat state on disk.
         guard.flat_head = *new_head;
         let mut store_update = StoreUpdate::new(guard.store.storage.clone());
+        let shard_id = guard.shard_id;
+        tracing::info!(target: "chain", %shard_id, %new_head, "Moving FS head");
         store_helper::set_flat_head(&mut store_update, guard.shard_id, new_head);
         merged_delta.apply_to_flat_state(&mut store_update);
 

--- a/core/store/src/version.rs
+++ b/core/store/src/version.rs
@@ -2,7 +2,10 @@
 pub type DbVersion = u32;
 
 /// Current version of the database.
+#[cfg(not(feature = "protocol_feature_flat_state"))]
 pub const DB_VERSION: DbVersion = 33;
+#[cfg(feature = "protocol_feature_flat_state")]
+pub const DB_VERSION: DbVersion = 34;
 
 /// Deserialises database version from data read from database.
 ///

--- a/nearcore/Cargo.toml
+++ b/nearcore/Cargo.toml
@@ -110,6 +110,7 @@ protocol_feature_fix_contract_loading_cost = [
   "near-vm-runner/protocol_feature_fix_contract_loading_cost",
 ]
 protocol_feature_flat_state = ["near-store/protocol_feature_flat_state", "near-chain/protocol_feature_flat_state", "node-runtime/protocol_feature_flat_state"]
+protocol_feature_flat_state_migration = ["near-chain/protocol_feature_flat_state_migration"]
 
 nightly = [
   "nightly_protocol",

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -55,6 +55,7 @@ rosetta_rpc = ["nearcore/rosetta_rpc"]
 json_rpc = ["nearcore/json_rpc"]
 protocol_feature_fix_staking_threshold = ["nearcore/protocol_feature_fix_staking_threshold"]
 protocol_feature_flat_state = ["nearcore/protocol_feature_flat_state"]
+protocol_feature_flat_state_migration = ["nearcore/protocol_feature_flat_state_migration"]
 
 nightly = [
   "nightly_protocol",


### PR DESCRIPTION
This is a simple flat storage migration for localnet.
It iterates over all nodes sequentially, which is viable for small states but doesn't work for testnet/mainnet.

```
# Build and run a node without flat storage for a while.
cargo build -p neard --release && cp ./target/release/neard ~/neard-trie/
nearup run localnet --binary-path ~/neard-trie/ --num-nodes 1 --num-shards 4 --fix-accounts --override --verbose
nearup stop

# Build and run a node which adds deltas to DB for ~20 blocks so that after new final head all deltas will be saved.
cargo build -p neard --release --features protocol_feature_flat_state_migration && cp ./target/release/neard ~/neard-flat-migration/
nearup run localnet --binary-path ~/neard-flat-migration/ --num-nodes 1 --num-shards 4 --fix-accounts --verbose
nearup stop

# Build and run a node with flat storage, which also fully migrates DB if needed.
cargo build -p neard --release --features protocol_feature_flat_state && cp ./target/release/neard ~/neard-flat/
nearup run localnet --binary-path ~/neard-flat/ --num-nodes 1 --num-shards 4 --fix-accounts --verbose
```