### PR TITLE
Extracted client API in near_network.

### DIFF
--- a/chain/network/src/client.rs
+++ b/chain/network/src/client.rs
@@ -1,0 +1,368 @@
+use crate::network_protocol::{
+    PartialEncodedChunkForwardMsg, PartialEncodedChunkRequestMsg, PartialEncodedChunkResponseMsg,
+    StateResponseInfo,
+};
+use crate::types::{
+    NetworkClientMessages, NetworkClientResponses, NetworkInfo, NetworkViewClientMessages,
+    NetworkViewClientResponses, ReasonForBan,
+};
+use near_o11y::{WithSpanContext, WithSpanContextExt};
+use near_primitives::block::{Approval, Block, BlockHeader};
+use near_primitives::challenge::Challenge;
+use near_primitives::hash::CryptoHash;
+use near_primitives::network::{AnnounceAccount, PeerId};
+use near_primitives::sharding::PartialEncodedChunk;
+use near_primitives::transaction::SignedTransaction;
+use near_primitives::types::{AccountId, EpochId, ShardId};
+use near_primitives::views::FinalExecutionOutcomeView;
+
+pub struct Client {
+    /// Address of the client actor.
+    pub client_addr: actix::Recipient<WithSpanContext<NetworkClientMessages>>,
+    /// Address of the view client actor.
+    pub view_client_addr: actix::Recipient<NetworkViewClientMessages>,
+}
+
+pub type Result<T> = std::result::Result<T, ReasonForBan>;
+
+impl Client {
+    pub async fn tx_status_request(
+        &self,
+        account_id: AccountId,
+        tx_hash: CryptoHash,
+    ) -> Result<Option<FinalExecutionOutcomeView>> {
+        match self
+            .view_client_addr
+            .send(NetworkViewClientMessages::TxStatus {
+                tx_hash: tx_hash,
+                signer_account_id: account_id,
+            })
+            .await
+        {
+            Ok(NetworkViewClientResponses::TxStatus(tx_result)) => Ok(Some(*tx_result)),
+            Ok(NetworkViewClientResponses::Ban { ban_reason }) => Err(ban_reason),
+            Ok(resp) => panic!("unexpected ViewClientResponse: {resp:?}"),
+            Err(err) => {
+                tracing::error!("mailbox error: {err}");
+                Ok(None)
+            }
+        }
+    }
+
+    pub async fn tx_status_response(&self, tx_result: FinalExecutionOutcomeView) -> Result<()> {
+        match self
+            .view_client_addr
+            .send(NetworkViewClientMessages::TxStatusResponse(Box::new(tx_result.clone())))
+            .await
+        {
+            Ok(NetworkViewClientResponses::NoResponse) => Ok(()),
+            Ok(NetworkViewClientResponses::Ban { ban_reason }) => Err(ban_reason),
+            Ok(resp) => panic!("unexpected ViewClientResponse: {resp:?}"),
+            Err(err) => {
+                tracing::error!("mailbox error: {err}");
+                Ok(())
+            }
+        }
+    }
+
+    pub async fn state_request_header(
+        &self,
+        shard_id: ShardId,
+        sync_hash: CryptoHash,
+    ) -> Result<Option<StateResponseInfo>> {
+        match self
+            .view_client_addr
+            .send(NetworkViewClientMessages::StateRequestHeader {
+                shard_id: shard_id,
+                sync_hash: sync_hash,
+            })
+            .await
+        {
+            Ok(NetworkViewClientResponses::StateResponse(resp)) => Ok(Some(*resp)),
+            Ok(NetworkViewClientResponses::NoResponse) => Ok(None),
+            Ok(NetworkViewClientResponses::Ban { ban_reason }) => Err(ban_reason),
+            Ok(resp) => panic!("unexpected ViewClientResponse: {resp:?}"),
+            Err(err) => {
+                tracing::error!("mailbox error: {err}");
+                Ok(None)
+            }
+        }
+    }
+
+    pub async fn state_request_part(
+        &self,
+        shard_id: ShardId,
+        sync_hash: CryptoHash,
+        part_id: u64,
+    ) -> Result<Option<StateResponseInfo>> {
+        match self
+            .view_client_addr
+            .send(NetworkViewClientMessages::StateRequestPart {
+                shard_id: shard_id,
+                sync_hash: sync_hash,
+                part_id: part_id,
+            })
+            .await
+        {
+            Ok(NetworkViewClientResponses::StateResponse(resp)) => Ok(Some(*resp)),
+            Ok(NetworkViewClientResponses::NoResponse) => Ok(None),
+            Ok(NetworkViewClientResponses::Ban { ban_reason }) => Err(ban_reason),
+            Ok(resp) => panic!("unexpected ViewClientResponse: {resp:?}"),
+            Err(err) => {
+                tracing::error!("mailbox error: {err}");
+                Ok(None)
+            }
+        }
+    }
+
+    pub async fn state_response(&self, info: StateResponseInfo) -> Result<()> {
+        match self
+            .client_addr
+            .send(NetworkClientMessages::StateResponse(info).with_span_context())
+            .await
+        {
+            Ok(NetworkClientResponses::NoResponse) => Ok(()),
+            Ok(NetworkClientResponses::Ban { ban_reason }) => Err(ban_reason),
+            Ok(resp) => panic!("unexpected ClientResponse: {resp:?}"),
+            Err(err) => {
+                tracing::error!("mailbox error: {err}");
+                Ok(())
+            }
+        }
+    }
+
+    pub async fn block_approval(&self, approval: Approval, peer_id: PeerId) -> Result<()> {
+        match self
+            .client_addr
+            .send(NetworkClientMessages::BlockApproval(approval, peer_id).with_span_context())
+            .await
+        {
+            Ok(NetworkClientResponses::NoResponse) => Ok(()),
+            Ok(NetworkClientResponses::Ban { ban_reason }) => Err(ban_reason),
+            Ok(resp) => panic!("unexpected ClientResponse: {resp:?}"),
+            Err(err) => {
+                tracing::error!("mailbox error: {err}");
+                Ok(())
+            }
+        }
+    }
+
+    pub async fn transaction(
+        &self,
+        transaction: SignedTransaction,
+        is_forwarded: bool,
+    ) -> Result<()> {
+        match self
+            .client_addr
+            .send(
+                NetworkClientMessages::Transaction { transaction, is_forwarded, check_only: false }
+                    .with_span_context(),
+            )
+            .await
+        {
+            Ok(NetworkClientResponses::ValidTx) => Ok(()),
+            Ok(NetworkClientResponses::InvalidTx(err)) => {
+                tracing::warn!(target: "network", ?err, "Received invalid tx");
+                // TODO: count as malicious behavior?
+                Ok(())
+            }
+            Ok(NetworkClientResponses::Ban { ban_reason }) => Err(ban_reason),
+            Ok(resp) => panic!("unexpected ClientResponse: {resp:?}"),
+            Err(err) => {
+                tracing::error!("mailbox error: {err}");
+                Ok(())
+            }
+        }
+    }
+
+    pub async fn partial_encoded_chunk_request(
+        &self,
+        req: PartialEncodedChunkRequestMsg,
+        msg_hash: CryptoHash,
+    ) -> Result<()> {
+        match self
+            .client_addr
+            .send(
+                NetworkClientMessages::PartialEncodedChunkRequest(req, msg_hash)
+                    .with_span_context(),
+            )
+            .await
+        {
+            Ok(NetworkClientResponses::NoResponse) => Ok(()),
+            Ok(NetworkClientResponses::Ban { ban_reason }) => Err(ban_reason),
+            Ok(resp) => panic!("unexpected ClientResponse: {resp:?}"),
+            Err(err) => {
+                tracing::error!("mailbox error: {err}");
+                Ok(())
+            }
+        }
+    }
+
+    pub async fn partial_encoded_chunk_response(
+        &self,
+        resp: PartialEncodedChunkResponseMsg,
+        timestamp: time::Instant,
+    ) -> Result<()> {
+        match self
+            .client_addr
+            .send(
+                NetworkClientMessages::PartialEncodedChunkResponse(resp, timestamp.into())
+                    .with_span_context(),
+            )
+            .await
+        {
+            Ok(NetworkClientResponses::NoResponse) => Ok(()),
+            Ok(NetworkClientResponses::Ban { ban_reason }) => Err(ban_reason),
+            Ok(resp) => panic!("unexpected ClientResponse: {resp:?}"),
+            Err(err) => {
+                tracing::error!("mailbox error: {err}");
+                Ok(())
+            }
+        }
+    }
+
+    pub async fn partial_encoded_chunk(&self, chunk: PartialEncodedChunk) -> Result<()> {
+        match self
+            .client_addr
+            .send(NetworkClientMessages::PartialEncodedChunk(chunk).with_span_context())
+            .await
+        {
+            Ok(NetworkClientResponses::NoResponse) => Ok(()),
+            Ok(NetworkClientResponses::Ban { ban_reason }) => Err(ban_reason),
+            Ok(resp) => panic!("unexpected ClientResponse: {resp:?}"),
+            Err(err) => {
+                tracing::error!("mailbox error: {err}");
+                Ok(())
+            }
+        }
+    }
+
+    pub async fn partial_encoded_chunk_forward(
+        &self,
+        msg: PartialEncodedChunkForwardMsg,
+    ) -> Result<()> {
+        match self
+            .client_addr
+            .send(NetworkClientMessages::PartialEncodedChunkForward(msg).with_span_context())
+            .await
+        {
+            Ok(NetworkClientResponses::NoResponse) => Ok(()),
+            Ok(NetworkClientResponses::Ban { ban_reason }) => Err(ban_reason),
+            Ok(resp) => panic!("unexpected ClientResponse: {resp:?}"),
+            Err(err) => {
+                tracing::error!("mailbox error: {err}");
+                Ok(())
+            }
+        }
+    }
+
+    pub async fn block_request(&self, hash: CryptoHash) -> Result<Option<Block>> {
+        match self.view_client_addr.send(NetworkViewClientMessages::BlockRequest(hash)).await {
+            Ok(NetworkViewClientResponses::Block(block)) => Ok(Some(*block)),
+            Ok(NetworkViewClientResponses::NoResponse) => Ok(None),
+            Ok(NetworkViewClientResponses::Ban { ban_reason }) => Err(ban_reason),
+            Ok(resp) => panic!("unexpected ViewClientResponse: {resp:?}"),
+            Err(err) => {
+                tracing::error!("mailbox error: {err}");
+                Ok(None)
+            }
+        }
+    }
+
+    pub async fn block_headers_request(
+        &self,
+        hashes: Vec<CryptoHash>,
+    ) -> Result<Option<Vec<BlockHeader>>> {
+        match self
+            .view_client_addr
+            .send(NetworkViewClientMessages::BlockHeadersRequest(hashes))
+            .await
+        {
+            Ok(NetworkViewClientResponses::BlockHeaders(block_headers)) => Ok(Some(block_headers)),
+            Ok(NetworkViewClientResponses::NoResponse) => Ok(None),
+            Ok(NetworkViewClientResponses::Ban { ban_reason }) => Err(ban_reason),
+            Ok(resp) => panic!("unexpected ViewClientResponse: {resp:?}"),
+            Err(err) => {
+                tracing::error!("mailbox error: {err}");
+                Ok(None)
+            }
+        }
+    }
+
+    pub async fn block(&self, block: Block, peer_id: PeerId, was_requested: bool) -> Result<()> {
+        match self
+            .client_addr
+            .send(NetworkClientMessages::Block(block, peer_id, was_requested).with_span_context())
+            .await
+        {
+            Ok(NetworkClientResponses::NoResponse) => Ok(()),
+            Ok(NetworkClientResponses::Ban { ban_reason }) => Err(ban_reason),
+            Ok(resp) => panic!("unexpected ClientResponse: {resp:?}"),
+            Err(err) => {
+                tracing::error!("mailbox error: {err}");
+                Ok(())
+            }
+        }
+    }
+
+    pub async fn block_headers(&self, headers: Vec<BlockHeader>, peer_id: PeerId) -> Result<()> {
+        match self
+            .client_addr
+            .send(NetworkClientMessages::BlockHeaders(headers, peer_id).with_span_context())
+            .await
+        {
+            Ok(NetworkClientResponses::NoResponse) => Ok(()),
+            Ok(NetworkClientResponses::Ban { ban_reason }) => Err(ban_reason),
+            Ok(resp) => panic!("unexpected ClientResponse: {resp:?}"),
+            Err(err) => {
+                tracing::error!("mailbox error: {err}");
+                Ok(())
+            }
+        }
+    }
+
+    pub async fn challenge(&self, challenge: Challenge) -> Result<()> {
+        match self
+            .client_addr
+            .send(NetworkClientMessages::Challenge(challenge).with_span_context())
+            .await
+        {
+            Ok(NetworkClientResponses::NoResponse) => Ok(()),
+            Ok(NetworkClientResponses::Ban { ban_reason }) => Err(ban_reason),
+            Ok(resp) => panic!("unexpected ClientResponse: {resp:?}"),
+            Err(err) => {
+                tracing::error!("mailbox error: {err}");
+                Ok(())
+            }
+        }
+    }
+
+    pub async fn network_info(&self, info: NetworkInfo) {
+        match self
+            .client_addr
+            .send(NetworkClientMessages::NetworkInfo(info).with_span_context())
+            .await
+        {
+            Ok(NetworkClientResponses::NoResponse) => {}
+            Ok(resp) => panic!("unexpected ClientResponse: {resp:?}"),
+            Err(err) => tracing::error!("mailbox error: {err}"),
+        }
+    }
+
+    pub async fn announce_account(
+        &self,
+        accounts: Vec<(AnnounceAccount, Option<EpochId>)>,
+    ) -> Result<Vec<AnnounceAccount>> {
+        match self.view_client_addr.send(NetworkViewClientMessages::AnnounceAccount(accounts)).await
+        {
+            Ok(NetworkViewClientResponses::AnnounceAccount(accounts)) => Ok(accounts),
+            Ok(NetworkViewClientResponses::NoResponse) => Ok(vec![]),
+            Ok(NetworkViewClientResponses::Ban { ban_reason }) => Err(ban_reason),
+            Ok(resp) => panic!("unexpected ClientResponse: {resp:?}"),
+            Err(err) => {
+                tracing::error!("mailbox error: {err}");
+                Ok(vec![])
+            }
+        }
+    }
+}

--- a/chain/network/src/lib.rs
+++ b/chain/network/src/lib.rs
@@ -12,10 +12,10 @@ mod store;
 
 pub mod actix;
 pub mod blacklist;
+pub mod client;
 pub mod config;
 pub mod config_json;
 pub mod routing;
-
 pub mod tcp;
 pub mod test_utils;
 pub mod time;

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -3,7 +3,7 @@ use crate::concurrency::atomic_cell::AtomicCell;
 use crate::concurrency::demux;
 use crate::network_protocol::{
     Edge, EdgeState, Encoding, ParsePeerMessageError, PartialEdgeInfo, PeerChainInfoV2, PeerInfo,
-    RoutedMessageBody, SyncAccountsData, RoutingTableUpdate,
+    RoutedMessageBody, RoutingTableUpdate, SyncAccountsData,
 };
 use crate::peer::stream;
 use crate::peer::tracker::Tracker;
@@ -19,9 +19,7 @@ use crate::stats::metrics;
 use crate::tcp;
 use crate::time;
 use crate::types::{
-    Ban, Handshake, HandshakeFailureReason,
-    PeerIdOrHash, PeerMessage, PeerType,
-    ReasonForBan,
+    Ban, Handshake, HandshakeFailureReason, PeerIdOrHash, PeerMessage, PeerType, ReasonForBan,
 };
 use actix::fut::future::wrap_future;
 use actix::{Actor, ActorContext, ActorFutureExt, AsyncContext, Context, Handler, Running};
@@ -815,10 +813,7 @@ impl PeerActor {
             }
             PeerMessage::SyncRoutingTable(rtu) => {
                 self.handle_sync_routing_table(ctx, conn, rtu);
-                self.network_state
-                    .config
-                    .event_sink
-                    .push(Event::MessageProcessed(peer_msg));
+                self.network_state.config.event_sink.push(Event::MessageProcessed(peer_msg));
             }
             PeerMessage::SyncAccountsData(msg) => {
                 let peer_id = conn.peer_info.id.clone();

--- a/chain/network/src/peer/testonly.rs
+++ b/chain/network/src/peer/testonly.rs
@@ -4,7 +4,7 @@ use crate::config::NetworkConfig;
 use crate::network_protocol::testonly as data;
 use crate::network_protocol::{
     Edge, PartialEdgeInfo, PeerInfo, PeerMessage, RawRoutedMessage, RoutedMessageBody,
-    RoutedMessageV2, RoutingTableUpdate,
+    RoutedMessageV2,
 };
 use crate::peer::peer_actor::{ClosingReason, PeerActor};
 use crate::peer_manager::network_state::NetworkState;
@@ -57,7 +57,6 @@ impl PeerConfig {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum Event {
-    RoutingTable(RoutingTableUpdate),
     Client(fake_client::Event),
     Network(peer_manager_actor::Event),
 }

--- a/chain/network/src/peer/testonly.rs
+++ b/chain/network/src/peer/testonly.rs
@@ -1,4 +1,5 @@
 use crate::broadcast;
+use crate::client;
 use crate::config::NetworkConfig;
 use crate::network_protocol::testonly as data;
 use crate::network_protocol::{
@@ -185,8 +186,10 @@ impl PeerHandle {
             let network_state = Arc::new(NetworkState::new(
                 Arc::new(network_cfg.verify().unwrap()),
                 cfg.chain.genesis_id.clone(),
-                fc.clone().recipient(),
-                fc.clone().recipient(),
+                client::Client {
+                    client_addr: fc.clone().recipient(),
+                    view_client_addr: fc.clone().recipient(),
+                },
                 fpm.recipient(),
                 routing_table_addr,
                 routing_table_view,

--- a/chain/network/src/peer/tests/communication.rs
+++ b/chain/network/src/peer/tests/communication.rs
@@ -4,7 +4,6 @@ use crate::network_protocol::{Handshake, HandshakeFailureReason, PeerMessage, Ro
 use crate::peer::testonly::{Event, PeerConfig, PeerHandle};
 use crate::peer_manager::peer_manager_actor::Event as PME;
 use crate::tcp;
-use crate::testonly::fake_client::Event as CE;
 use crate::testonly::make_rng;
 use crate::testonly::stream::Stream;
 use crate::time;
@@ -12,8 +11,6 @@ use crate::types::{PartialEncodedChunkRequestMsg, PartialEncodedChunkResponseMsg
 use anyhow::Context as _;
 use assert_matches::assert_matches;
 use near_o11y::testonly::init_test_logger;
-use near_primitives::syncing::EpochSyncResponse;
-use near_primitives::types::EpochId;
 use near_primitives::version::{PEER_MIN_ALLOWED_PROTOCOL_VERSION, PROTOCOL_VERSION};
 use std::sync::Arc;
 
@@ -47,27 +44,18 @@ async fn test_peer_communication(
     outbound.complete_handshake().await;
     inbound.complete_handshake().await;
 
-    // TODO(gprusak): In proto encoding SyncAccountsData exchange is part of the handshake.
-    // As a workaround, in borsh encoding an empty RoutingTableUpdate is sent.
-    // Once borsh support is removed, the initial SyncAccountsData should be consumed in
-    // complete_handshake.
-    let filter = |ev| match ev {
-        Event::Network(PME::MessageProcessed(PeerMessage::SyncAccountsData(_))) => None,
-        Event::RoutingTable(_) => None,
-        ev => Some(ev),
-    };
-
-    let message_processed = |ev| match ev {
-        Event::Network(PME::MessageProcessed(PeerMessage::SyncAccountsData(_))) => None,
-        Event::Network(PME::MessageProcessed(msg)) => Some(msg),
-        _ => None,
+    let message_processed = |want| {
+        move |ev| match ev {
+            Event::Network(PME::MessageProcessed(got)) if got == want => Some(()),
+            _ => None,
+        }
     };
 
     // RequestUpdateNonce
     let mut events = inbound.events.from_now();
     let want = PeerMessage::RequestUpdateNonce(data::make_partial_edge(&mut rng));
     outbound.send(want.clone()).await;
-    assert_eq!(want, events.recv_until(message_processed).await);
+    events.recv_until(message_processed(want)).await;
 
     // ReponseUpdateNonce
     let mut events = inbound.events.from_now();
@@ -75,48 +63,49 @@ async fn test_peer_communication(
     let b = data::make_signer(&mut rng);
     let want = PeerMessage::ResponseUpdateNonce(data::make_edge(&a, &b));
     outbound.send(want.clone()).await;
-    assert_eq!(want, events.recv_until(message_processed).await);
+    events.recv_until(message_processed(want)).await;
 
     // PeersRequest -> PeersResponse
     // This test is different from the rest, because we cannot skip sending the response back.
     let mut events = outbound.events.from_now();
     let want = PeerMessage::PeersResponse(inbound.cfg.peers.clone());
     outbound.send(PeerMessage::PeersRequest).await;
-    assert_eq!(want, events.recv_until(message_processed).await);
+    events.recv_until(message_processed(want)).await;
 
     // BlockRequest
     let mut events = inbound.events.from_now();
-    let want = chain.blocks[5].hash().clone();
-    outbound.send(PeerMessage::BlockRequest(want.clone())).await;
-    assert_eq!(Event::Client(CE::BlockRequest(want)), events.recv_until(filter).await);
+    let want = PeerMessage::BlockRequest(chain.blocks[5].hash().clone());
+    outbound.send(want.clone()).await;
+    events.recv_until(message_processed(want)).await;
 
     // Block
     let mut events = inbound.events.from_now();
     let want = PeerMessage::Block(chain.blocks[5].clone());
     outbound.send(want.clone()).await;
-    assert_eq!(want, events.recv_until(message_processed).await);
+    events.recv_until(message_processed(want)).await;
 
     // BlockHeadersRequest
     let mut events = inbound.events.from_now();
-    let want: Vec<_> = chain.blocks.iter().map(|b| b.hash().clone()).collect();
-    outbound.send(PeerMessage::BlockHeadersRequest(want.clone())).await;
-    assert_eq!(Event::Client(CE::BlockHeadersRequest(want)), events.recv_until(filter).await);
+    let want =
+        PeerMessage::BlockHeadersRequest(chain.blocks.iter().map(|b| b.hash().clone()).collect());
+    outbound.send(want.clone()).await;
+    events.recv_until(message_processed(want)).await;
 
     // BlockHeaders
     let mut events = inbound.events.from_now();
     let want = PeerMessage::BlockHeaders(chain.get_block_headers());
     outbound.send(want.clone()).await;
-    assert_eq!(want, events.recv_until(message_processed).await);
+    events.recv_until(message_processed(want)).await;
 
     // SyncRoutingTable
     let mut events = inbound.events.from_now();
-    let want = data::make_routing_table(&mut rng);
-    outbound.send(PeerMessage::SyncRoutingTable(want.clone())).await;
-    assert_eq!(Event::RoutingTable(want), events.recv().await);
+    let want = PeerMessage::SyncRoutingTable(data::make_routing_table(&mut rng));
+    outbound.send(want.clone()).await;
+    events.recv_until(message_processed(want)).await;
 
     // PartialEncodedChunkRequest
     let mut events = inbound.events.from_now();
-    let want = Box::new(outbound.routed_message(
+    let want = PeerMessage::Routed(Box::new(outbound.routed_message(
         RoutedMessageBody::PartialEncodedChunkRequest(PartialEncodedChunkRequestMsg {
             chunk_hash: chain.blocks[5].chunks()[2].chunk_hash(),
             part_ords: vec![],
@@ -125,10 +114,9 @@ async fn test_peer_communication(
         inbound.cfg.id(),
         1,    // ttl
         None, // TODO(gprusak): this should be clock.now_utc(), once borsh support is dropped.
-    ));
-    let want = PeerMessage::Routed(want);
+    )));
     outbound.send(want.clone()).await;
-    assert_eq!(want, events.recv_until(message_processed).await);
+    events.recv_until(message_processed(want)).await;
 
     // PartialEncodedChunkResponse
     let mut events = inbound.events.from_now();
@@ -145,46 +133,24 @@ async fn test_peer_communication(
         None, // TODO(gprusak): this should be clock.now_utc(), once borsh support is dropped.
     )));
     outbound.send(want.clone()).await;
-    assert_eq!(want, events.recv_until(message_processed).await);
+    events.recv_until(message_processed(want)).await;
 
     // Transaction
     let mut events = inbound.events.from_now();
     let want = data::make_signed_transaction(&mut rng);
     let want = PeerMessage::Transaction(want);
     outbound.send(want.clone()).await;
-    assert_eq!(want, events.recv_until(message_processed).await);
+    events.recv_until(message_processed(want)).await;
 
     // Challenge
     let mut events = inbound.events.from_now();
     let want = PeerMessage::Challenge(data::make_challenge(&mut rng));
     outbound.send(want.clone()).await;
-    assert_eq!(want, events.recv_until(message_processed).await);
-
-    // EpochSyncRequest
-    let mut events = inbound.events.from_now();
-    let want = EpochId(chain.blocks[1].hash().clone());
-    outbound.send(PeerMessage::EpochSyncRequest(want.clone())).await;
-    assert_eq!(Event::Client(CE::EpochSyncRequest(want)), events.recv_until(filter).await);
-
-    // EpochSyncResponse
-    let mut events = inbound.events.from_now();
-    let want = PeerMessage::EpochSyncResponse(Box::new(EpochSyncResponse::UpToDate));
-    outbound.send(want.clone()).await;
-    assert_eq!(want, events.recv_until(message_processed).await);
-
-    // EpochSyncFinalizationRequest
-    let mut events = inbound.events.from_now();
-    let want = EpochId(chain.blocks[1].hash().clone());
-    outbound.send(PeerMessage::EpochSyncFinalizationRequest(want.clone())).await;
-    assert_eq!(
-        Event::Client(CE::EpochSyncFinalizationRequest(want)),
-        events.recv_until(filter).await
-    );
+    events.recv_until(message_processed(want)).await;
 
     // TODO:
     // LastEdge, HandshakeFailure, Disconnect - affect the state of the PeerActor and are
     // observable only under specific conditions.
-    // ExpochSyncFinalizationResponse - unused.
     Ok(())
 }
 

--- a/chain/network/src/peer_manager/testonly.rs
+++ b/chain/network/src/peer_manager/testonly.rs
@@ -1,4 +1,5 @@
 use crate::broadcast;
+use crate::client;
 use crate::config;
 use crate::network_protocol::testonly as data;
 use crate::network_protocol::{
@@ -287,8 +288,10 @@ pub(crate) async fn start(
                 clock,
                 store,
                 cfg,
-                fc.clone().recipient(),
-                fc.clone().recipient(),
+                client::Client {
+                    client_addr: fc.clone().recipient(),
+                    view_client_addr: fc.clone().recipient(),
+                },
                 genesis_id,
             )
             .unwrap()

--- a/chain/network/src/private_actix.rs
+++ b/chain/network/src/private_actix.rs
@@ -1,9 +1,8 @@
 /// This file is contains all types used for communication between `Actors` within this crate.
 /// They are not meant to be used outside.
-use crate::network_protocol::{Edge, PartialEdgeInfo, PeerInfo, PeerMessage, RoutingTableUpdate};
+use crate::network_protocol::{Edge, PartialEdgeInfo, PeerInfo, PeerMessage};
 use crate::peer_manager::connection;
 use crate::types::{Ban, ReasonForBan};
-use conqueue::QueueSender;
 use near_primitives::network::PeerId;
 use std::collections::HashMap;
 use std::fmt;
@@ -26,12 +25,6 @@ pub(crate) enum PeerToManagerMsg {
     Ban(Ban),
     RequestUpdateNonce(PeerId, PartialEdgeInfo),
     ResponseUpdateNonce(Edge),
-    /// Data to sync routing table from active peer.
-    SyncRoutingTable {
-        peer_id: PeerId,
-        routing_table_update: RoutingTableUpdate,
-    },
-
     // PeerRequest
     UpdatePeerInfo(PeerInfo),
 }
@@ -124,7 +117,7 @@ pub(crate) struct ValidateEdgeList {
     /// `PeerManagetActor`, and then send to `RoutingTableActor`. And then `RoutingTableActor`
     /// will add them.
     /// TODO(#5254): Simplify this process.
-    pub sender: QueueSender<Edge>,
+    pub sender: crossbeam_channel::Sender<Edge>,
 }
 
 impl PeerToManagerMsgResp {

--- a/chain/network/src/routing/actor.rs
+++ b/chain/network/src/routing/actor.rs
@@ -267,7 +267,7 @@ pub enum Response {
     RoutingTableUpdateResponse {
         /// PeerManager maintains list of local edges. We will notify `PeerManager`
         /// to remove those edges.
-        local_edges_to_remove: Vec<PeerId>,
+        pruned_edges: Vec<Edge>,
         /// Active PeerId that are part of the shortest path to each PeerId.
         next_hops: Arc<routing::NextHopTable>,
         /// List of peers to ban for sending invalid edges.
@@ -309,11 +309,7 @@ impl actix::Handler<Message> for Actor {
                 let (next_hops, pruned_edges) =
                     self.update_routing_table(prune_unreachable_since, prune_edges_older_than);
                 Response::RoutingTableUpdateResponse {
-                    local_edges_to_remove: pruned_edges
-                        .iter()
-                        .filter_map(|e| e.other(&self.my_peer_id))
-                        .cloned()
-                        .collect(),
+                    pruned_edges,
                     next_hops,
                     peers_to_ban: std::mem::take(&mut self.peers_to_ban),
                 }

--- a/chain/network/src/stats/metrics.rs
+++ b/chain/network/src/stats/metrics.rs
@@ -199,24 +199,6 @@ pub(crate) static PEER_MESSAGE_SENT_BY_TYPE_TOTAL: Lazy<IntCounterVec> = Lazy::n
     )
     .unwrap()
 });
-pub(crate) static PEER_CLIENT_MESSAGE_RECEIVED_BY_TYPE_TOTAL: Lazy<IntCounterVec> =
-    Lazy::new(|| {
-        try_create_int_counter_vec(
-            "near_peer_client_message_received_by_type_total",
-            "Number of messages for client received from peers, by message types",
-            &["type"],
-        )
-        .unwrap()
-    });
-pub(crate) static PEER_VIEW_CLIENT_MESSAGE_RECEIVED_BY_TYPE_TOTAL: Lazy<IntCounterVec> =
-    Lazy::new(|| {
-        try_create_int_counter_vec(
-            "near_peer_view_client_message_received_by_type_total",
-            "Number of messages for view client received from peers, by message types",
-            &["type"],
-        )
-        .unwrap()
-    });
 pub(crate) static REQUEST_COUNT_BY_TYPE_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
     try_create_int_counter_vec(
         "near_requests_count_by_type_total",

--- a/chain/network/src/test_utils.rs
+++ b/chain/network/src/test_utils.rs
@@ -308,6 +308,7 @@ impl MockPeerManagerAdapter {
 }
 
 pub mod test_features {
+    use crate::client;
     use crate::config;
     use crate::test_utils::convert_boot_nodes;
     use crate::time;
@@ -360,8 +361,10 @@ pub mod test_features {
             time::Clock::real(),
             store,
             config,
-            client_addr.recipient(),
-            view_client_addr.recipient(),
+            client::Client {
+                client_addr: client_addr.recipient(),
+                view_client_addr: view_client_addr.recipient(),
+            },
             GenesisId::default(),
         )
         .unwrap()

--- a/integration-tests/src/tests/network/peer_handshake.rs
+++ b/integration-tests/src/tests/network/peer_handshake.rs
@@ -49,8 +49,10 @@ fn make_peer_manager(
         time::Clock::real(),
         near_store::db::TestDB::new(),
         config,
-        client_addr.recipient(),
-        view_client_addr.recipient(),
+        near_network::client::Client {
+            client_addr: client_addr.recipient(),
+            view_client_addr: view_client_addr.recipient(),
+        },
         GenesisId::default(),
     )
     .unwrap()

--- a/integration-tests/src/tests/network/runner.rs
+++ b/integration-tests/src/tests/network/runner.rs
@@ -99,8 +99,10 @@ fn setup_network_node(
         time::Clock::real(),
         db.clone(),
         config,
-        client_actor.recipient(),
-        view_client_actor.recipient(),
+        near_network::client::Client {
+            client_addr: client_actor.recipient(),
+            view_client_addr: view_client_actor.recipient(),
+        },
         genesis_id,
     )
     .unwrap();

--- a/integration-tests/src/tests/network/stress_network.rs
+++ b/integration-tests/src/tests/network/stress_network.rs
@@ -43,8 +43,10 @@ fn make_peer_manager(
         time::Clock::real(),
         near_store::db::TestDB::new(),
         config,
-        client_addr.recipient(),
-        view_client_addr.recipient(),
+        near_network::client::Client {
+            client_addr: client_addr.recipient(),
+            view_client_addr: view_client_addr.recipient(),
+        },
         GenesisId::default(),
     )
     .unwrap()

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -193,8 +193,10 @@ pub fn start_with_config_and_synchronization(
         time::Clock::real(),
         store.into_inner(near_store::Temperature::Hot),
         config.network_config,
-        client_actor.clone().recipient(),
-        view_client.clone().recipient(),
+        near_network::client::Client {
+            client_addr: client_actor.clone().recipient(),
+            view_client_addr: view_client.clone().recipient(),
+        },
         genesis_id,
     )
     .context("PeerManager::spawn()")?;

--- a/tools/chainsync-loadtest/src/main.rs
+++ b/tools/chainsync-loadtest/src/main.rs
@@ -47,8 +47,10 @@ pub fn start_with_config(config: NearConfig, qps_limit: u32) -> anyhow::Result<A
         time::Clock::real(),
         near_store::db::TestDB::new(),
         config.network_config,
-        client_actor.clone().recipient(),
-        client_actor.clone().recipient(),
+        near_network::client::Client {
+            client_addr: client_actor.clone().recipient(),
+            view_client_addr: client_actor.clone().recipient(),
+        },
         GenesisId {
             chain_id: config.client_config.chain_id.clone(),
             hash: genesis_hash(&config.client_config.chain_id),


### PR DESCRIPTION
This way the client actors are abstracted out from the network crate.
Also moved the multiplexing PeerMessage -> (View)ClientActor API, from PeerActor to NetworkState.
Improved tests which started failing (this PR doesn't introduce semantic changes, therefore those tests were apparently too fragile).