### PR TITLE
chain: don’t clone Store in RuntimeAdapter::get_store

### DIFF
--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -696,8 +696,8 @@ impl RuntimeAdapter for KeyValueRuntime {
         (self.store.clone(), ((0..self.num_shards).map(|_| Trie::EMPTY_ROOT).collect()))
     }
 
-    fn get_store(&self) -> Store {
-        self.store.clone()
+    fn store(&self) -> &Store {
+        &self.store
     }
 
     fn get_tries(&self) -> ShardTries {

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -266,7 +266,7 @@ pub trait RuntimeAdapter: EpochManagerAdapter + Send + Sync {
 
     fn get_tries(&self) -> ShardTries;
 
-    fn get_store(&self) -> Store;
+    fn store(&self) -> &Store;
 
     /// Returns trie. Since shard layout may change from epoch to epoch, `shard_id` itself is
     /// not enough to identify the trie. `prev_hash` is used to identify the epoch the given

--- a/chain/chunks/src/test_utils.rs
+++ b/chain/chunks/src/test_utils.rs
@@ -277,7 +277,7 @@ impl ChunkTestFixture {
             Vec::new(),
             &mock_merkle_paths,
         );
-        let chain_store = ChainStore::new(mock_runtime.get_store(), 0, true);
+        let chain_store = ChainStore::new(mock_runtime.store().clone(), 0, true);
 
         ChunkTestFixture {
             mock_runtime,

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1879,7 +1879,7 @@ impl SyncJobsActor {
         msg: &ApplyStatePartsRequest,
     ) -> Result<(), near_chain_primitives::error::Error> {
         let _span = tracing::debug_span!(target: "client", "apply_parts").entered();
-        let store = msg.runtime.get_store();
+        let store = msg.runtime.store();
 
         for part_id in 0..msg.num_parts {
             let key = StatePartKey(msg.sync_hash, msg.shard_id, part_id).try_to_vec()?;

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -2384,7 +2384,7 @@ fn test_catchup_gas_price_change() {
     let rt = Arc::clone(&env.clients[1].runtime_adapter);
     let f = move |msg: ApplyStatePartsRequest| {
         use borsh::BorshSerialize;
-        let store = rt.get_store();
+        let store = rt.store();
 
         for part_id in 0..msg.num_parts {
             let key = StatePartKey(msg.sync_hash, msg.shard_id, part_id).try_to_vec().unwrap();

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -669,8 +669,8 @@ impl RuntimeAdapter for NightshadeRuntime {
         (self.store.clone(), self.genesis_state_roots.clone())
     }
 
-    fn get_store(&self) -> Store {
-        self.store.clone()
+    fn store(&self) -> &Store {
+        &self.store
     }
 
     fn get_tries(&self) -> ShardTries {

--- a/tools/mock-node/src/setup.rs
+++ b/tools/mock-node/src/setup.rs
@@ -119,12 +119,12 @@ pub fn setup_mock_node(
     if client_start_height > 0 {
         tracing::info!(target: "mock_node", "Preparing client data dir to be able to start at the specified start height {}", client_start_height);
         let mut chain_store = ChainStore::new(
-            client_runtime.get_store(),
+            client_runtime.store().clone(),
             config.genesis.config.genesis_height,
             !config.client_config.archive,
         );
         let mut network_chain_store = ChainStore::new(
-            mock_network_runtime.get_store(),
+            mock_network_runtime.store().clone(),
             config.genesis.config.genesis_height,
             !config.client_config.archive,
         );
@@ -166,12 +166,12 @@ pub fn setup_mock_node(
 
         // copy epoch info
         let mut epoch_manager = EpochManager::new_from_genesis_config(
-            client_runtime.get_store(),
+            client_runtime.store().clone(),
             &config.genesis.config,
         )
         .unwrap();
         let mock_epoch_manager = EpochManager::new_from_genesis_config(
-            mock_network_runtime.get_store(),
+            mock_network_runtime.store().clone(),
             &config.genesis.config,
         )
         .unwrap();


### PR DESCRIPTION
Replace RuntimeAdapter::get_store with RuntimeAdapter::store method
which returns reference to a Store rather than cloning it.  This
avoids some instances where the Store is cloned unnecessarily.
