### PR TITLE
refactor: move `UnsupportedCompiler` to errors

### DIFF
--- a/chain/jsonrpc/res/rpc_errors_schema.json
+++ b/chain/jsonrpc/res/rpc_errors_schema.json
@@ -49,8 +49,7 @@
       "subtypes": [
         "CodeDoesNotExist",
         "PrepareError",
-        "WasmerCompileError",
-        "UnsupportedCompiler"
+        "WasmerCompileError"
       ],
       "props": {}
     },
@@ -390,13 +389,6 @@
       "name": "Unreachable",
       "subtypes": [],
       "props": {}
-    },
-    "UnsupportedCompiler": {
-      "name": "UnsupportedCompiler",
-      "subtypes": [],
-      "props": {
-        "msg": ""
-      }
     },
     "ValueLengthExceeded": {
       "name": "ValueLengthExceeded",

--- a/runtime/near-vm-errors/src/lib.rs
+++ b/runtime/near-vm-errors/src/lib.rs
@@ -25,6 +25,9 @@ pub enum VMRunnerError {
     WasmUnknownError {
         debug_message: String,
     },
+    UnsupportedCompiler {
+        debug_message: String,
+    },
 }
 
 /// Permitted errors that cause a function call to fail gracefully.
@@ -152,7 +155,6 @@ pub enum CompilationError {
     CodeDoesNotExist { account_id: AccountId },
     PrepareError(PrepareError),
     WasmerCompileError { msg: String },
-    UnsupportedCompiler { msg: String },
 }
 
 #[derive(
@@ -395,9 +397,6 @@ impl fmt::Display for CompilationError {
             CompilationError::WasmerCompileError { msg } => {
                 write!(f, "Wasmer compilation error: {}", msg)
             }
-            CompilationError::UnsupportedCompiler { msg } => {
-                write!(f, "Unsupported compiler: {}", msg)
-            }
         }
     }
 }
@@ -419,6 +418,9 @@ impl fmt::Display for VMRunnerError {
             }
             VMRunnerError::Nondeterministic(msg) => {
                 write!(f, "Nondeterministic error during contract execution: {}", msg)
+            }
+            VMRunnerError::UnsupportedCompiler { debug_message } => {
+                write!(f, "Unsupported compiler: {debug_message}")
             }
         }
     }

--- a/runtime/near-vm-errors/src/lib.rs
+++ b/runtime/near-vm-errors/src/lib.rs
@@ -25,6 +25,10 @@ pub enum VMRunnerError {
     WasmUnknownError {
         debug_message: String,
     },
+    /// Error when requiring an unavailable feature of the WASM compiler.
+    ///
+    /// The only place this gets emitted today is when calling `precompile`
+    /// in wasmtime runner.
     UnsupportedCompiler {
         debug_message: String,
     },

--- a/runtime/near-vm-runner/src/wasmtime_runner.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner.rs
@@ -8,8 +8,7 @@ use near_primitives::runtime::fees::RuntimeFeesConfig;
 use near_primitives::types::CompiledContractCache;
 use near_primitives::version::ProtocolVersion;
 use near_vm_errors::{
-    CompilationError, FunctionCallError, MethodResolveError, PrepareError, VMLogicError,
-    VMRunnerError, WasmTrap,
+    FunctionCallError, MethodResolveError, PrepareError, VMLogicError, VMRunnerError, WasmTrap,
 };
 use near_vm_logic::types::PromiseResult;
 use near_vm_logic::{External, MemoryLike, VMContext, VMLogic, VMOutcome};
@@ -295,9 +294,9 @@ impl crate::runner::VM for WasmtimeVM {
         _code_hash: &CryptoHash,
         _cache: &dyn CompiledContractCache,
     ) -> Result<Option<near_vm_errors::FunctionCallError>, VMRunnerError> {
-        Ok(Some(FunctionCallError::CompilationError(CompilationError::UnsupportedCompiler {
-            msg: "Precompilation not supported in Wasmtime yet".to_string(),
-        })))
+        Err(VMRunnerError::UnsupportedCompiler {
+            debug_message: "Precompilation not supported in Wasmtime yet".to_string(),
+        })
     }
 
     fn check_compile(&self, code: &[u8]) -> bool {

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -152,6 +152,9 @@ pub(crate) fn execute_function_call(
         VMRunnerError::WasmUnknownError { debug_message } => {
             panic!("Wasmer returned unknown message: {}", debug_message)
         }
+        VMRunnerError::UnsupportedCompiler { debug_message } => {
+            panic!("Unsupported compiler error: {}", debug_message)
+        }
     })
 }
 


### PR DESCRIPTION
This is an actual error, not a user abort. It should be treated as such,
therefore it belongs to `VMRunnerError` and not `CompilationError`
which is part of the use abort type aka `FunctionCallError`.

`CompilationError` implements `BorshSerialize` and is used in
`FunctionCallErrorSer`. Removing `UnsupportedCompiler` is okay because:
1) The error only gets thrown from unused`precompile`. It is is dead
code in production.
2) It is the last variant in the enum and hence does not affect the
borsh serialization format of other variants.

cc #7818 