### PR TITLE
stabilize feature protocol_feature_reject_blocks_with_outdated_protocol_version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,15 @@
 ## [unreleased]
 
 ### Protocol Changes
-
 * Stabilize `account_id_in_function_call_permission` feature: enforcing validity
   of account ids in function call permission.
 * Enable TIER1 peer discovery. Validator nodes are now exchanging the [public addresses
   set in config](https://github.com/near/nearcore/blob/301fb493ea4f6d9b75d7dac7f2b52d00a1b2b709/chain/network/src/config_json.rs#L162).
   The TIER1 connections support (direct connections between validators) based on
   this discovery mechanism will be added soon.
-
+* Stabilize `protocol_feature_reject_blocks_with_outdated_protocol_version`: consider blocks
+   created with old protocol versions invalid.
+  
 ### Non-protocol Changes
 
 * `use_db_migration_snapshot` and `db_migration_snapshot_path` options are now

--- a/chain/chain/Cargo.toml
+++ b/chain/chain/Cargo.toml
@@ -49,9 +49,8 @@ test_features = []
 delay_detector = ["delay-detector/delay_detector"]
 no_cache = ["near-store/no_cache"]
 protocol_feature_flat_state = ["near-store/protocol_feature_flat_state"]
-protocol_feature_reject_blocks_with_outdated_protocol_version = ["near-primitives/protocol_feature_reject_blocks_with_outdated_protocol_version"]
 
-shardnet = ["protocol_feature_reject_blocks_with_outdated_protocol_version"]
+shardnet = []
 
 nightly = [
   "nightly_protocol",
@@ -59,7 +58,6 @@ nightly = [
 nightly_protocol = [
   "near-store/nightly_protocol",
   "near-primitives/nightly_protocol",
-  "protocol_feature_reject_blocks_with_outdated_protocol_version"
 ]
 mock_node = []
 sandbox = ["near-primitives/sandbox"]

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1193,12 +1193,11 @@ impl Chain {
             }
         }
 
-        #[cfg(feature = "protocol_feature_reject_blocks_with_outdated_protocol_version")]
         if let Ok(epoch_protocol_version) =
             self.runtime_adapter.get_epoch_protocol_version(header.epoch_id())
         {
             if checked_feature!(
-                "protocol_feature_reject_blocks_with_outdated_protocol_version",
+                "stable",
                 RejectBlocksWithOutdatedProtocolVersions,
                 epoch_protocol_version
             ) {

--- a/chain/chain/src/tests/.simple_chain.rs.pending-snap
+++ b/chain/chain/src/tests/.simple_chain.rs.pending-snap
@@ -1,0 +1,5 @@
+{"run_id":"1666124319-656355000","line":47,"new":{"module_name":"near_chain__tests__simple_chain","snapshot_name":"build_chain","metadata":{"source":"chain/chain/src/tests/simple_chain.rs","assertion_line":47,"expression":"hash"},"snapshot":"7r5VSLXhkxHHEeiAAPQbKPGv3rr877obehGYwPbKZMA7"},"old":{"module_name":"near_chain__tests__simple_chain","metadata":{},"snapshot":"2iGtRFjF6BcqPF6tDcfLLojRaNax2PKDLxRqRc3RxRn7"}}
+{"run_id":"1666124486-940911000","line":47,"new":null,"old":null}
+{"run_id":"1666124486-940911000","line":79,"new":{"module_name":"near_chain__tests__simple_chain","snapshot_name":"build_chain-2","metadata":{"source":"chain/chain/src/tests/simple_chain.rs","assertion_line":79,"expression":"hash"},"snapshot":"9772sSKzm1eGPV3pRi17YaZkotrcN6dAkJUn226CopTm"},"old":{"module_name":"near_chain__tests__simple_chain","metadata":{},"snapshot":"7BkghFM7ZA8piYHAWYu4vTY6vE1pkTwy14bqQnS138qE"}}
+{"run_id":"1666124516-580365000","line":47,"new":null,"old":null}
+{"run_id":"1666124516-580365000","line":79,"new":null,"old":null}

--- a/chain/chain/src/tests/.simple_chain.rs.pending-snap
+++ b/chain/chain/src/tests/.simple_chain.rs.pending-snap
@@ -1,5 +1,0 @@
-{"run_id":"1666124319-656355000","line":47,"new":{"module_name":"near_chain__tests__simple_chain","snapshot_name":"build_chain","metadata":{"source":"chain/chain/src/tests/simple_chain.rs","assertion_line":47,"expression":"hash"},"snapshot":"7r5VSLXhkxHHEeiAAPQbKPGv3rr877obehGYwPbKZMA7"},"old":{"module_name":"near_chain__tests__simple_chain","metadata":{},"snapshot":"2iGtRFjF6BcqPF6tDcfLLojRaNax2PKDLxRqRc3RxRn7"}}
-{"run_id":"1666124486-940911000","line":47,"new":null,"old":null}
-{"run_id":"1666124486-940911000","line":79,"new":{"module_name":"near_chain__tests__simple_chain","snapshot_name":"build_chain-2","metadata":{"source":"chain/chain/src/tests/simple_chain.rs","assertion_line":79,"expression":"hash"},"snapshot":"9772sSKzm1eGPV3pRi17YaZkotrcN6dAkJUn226CopTm"},"old":{"module_name":"near_chain__tests__simple_chain","metadata":{},"snapshot":"7BkghFM7ZA8piYHAWYu4vTY6vE1pkTwy14bqQnS138qE"}}
-{"run_id":"1666124516-580365000","line":47,"new":null,"old":null}
-{"run_id":"1666124516-580365000","line":79,"new":null,"old":null}

--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -44,7 +44,7 @@ fn build_chain() {
     if cfg!(feature = "nightly") {
         insta::assert_display_snapshot!(hash, @"HTpETHnBkxcX1h3eD87uC5YP5nV66E6UYPrJGnQHuRqt");
     } else {
-        insta::assert_display_snapshot!(hash, @"2iGtRFjF6BcqPF6tDcfLLojRaNax2PKDLxRqRc3RxRn7");
+        insta::assert_display_snapshot!(hash, @"7r5VSLXhkxHHEeiAAPQbKPGv3rr877obehGYwPbKZMA7");
     }
 
     for i in 1..5 {
@@ -76,7 +76,7 @@ fn build_chain() {
     if cfg!(feature = "nightly") {
         insta::assert_display_snapshot!(hash, @"HyDYbjs5tgeEDf1N1XB4m312VdCeKjHqeGQ7dc7Lqwv8");
     } else {
-        insta::assert_display_snapshot!(hash, @"7BkghFM7ZA8piYHAWYu4vTY6vE1pkTwy14bqQnS138qE");
+        insta::assert_display_snapshot!(hash, @"9772sSKzm1eGPV3pRi17YaZkotrcN6dAkJUn226CopTm");
     }
 }
 

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -42,7 +42,6 @@ sandbox = []
 dump_errors_schema = ["near-rpc-error-macro/dump_errors_schema"]
 protocol_feature_fix_staking_threshold = []
 protocol_feature_fix_contract_loading_cost = []
-protocol_feature_reject_blocks_with_outdated_protocol_version = []
 protocol_feature_ed25519_verify = [
   "near-primitives-core/protocol_feature_ed25519_verify"
 ]
@@ -50,7 +49,6 @@ nightly = [
   "nightly_protocol",
   "protocol_feature_fix_staking_threshold",
   "protocol_feature_fix_contract_loading_cost",
-  "protocol_feature_reject_blocks_with_outdated_protocol_version",
   "protocol_feature_ed25519_verify",
 ]
 
@@ -58,7 +56,7 @@ nightly_protocol = []
 
 
 # Shardnet is the experimental network that we deploy for chunk-only producer testing.
-shardnet = ["protocol_feature_reject_blocks_with_outdated_protocol_version"]
+shardnet = []
 
 [dev-dependencies]
 assert_matches.workspace = true

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -136,6 +136,8 @@ pub enum ProtocolFeature {
     MaxKickoutStake,
     /// Validate account id for function call access keys.
     AccountIdInFunctionCallPermission,
+    /// Blocks created with outdated protocol version will be considered as invalid
+    RejectBlocksWithOutdatedProtocolVersions,
 
     /// In case not all validator seats are occupied our algorithm provide incorrect minimal seat
     /// price - it reports as alpha * sum_stake instead of alpha * sum_stake / (1 - alpha), where
@@ -147,8 +149,6 @@ pub enum ProtocolFeature {
     FixContractLoadingCost,
     #[cfg(feature = "protocol_feature_ed25519_verify")]
     Ed25519Verify,
-    #[cfg(feature = "protocol_feature_reject_blocks_with_outdated_protocol_version")]
-    RejectBlocksWithOutdatedProtocolVersions,
     #[cfg(feature = "shardnet")]
     ShardnetShardLayoutUpgrade,
 }
@@ -161,7 +161,7 @@ pub const PEER_MIN_ALLOWED_PROTOCOL_VERSION: ProtocolVersion =
 /// Current protocol version used on the mainnet.
 /// Some features (e. g. FixStorageUsage) require that there is at least one epoch with exactly
 /// the corresponding version
-const STABLE_PROTOCOL_VERSION: ProtocolVersion = 57;
+const STABLE_PROTOCOL_VERSION: ProtocolVersion = 58;
 
 /// Largest protocol version supported by the current binary.
 pub const PROTOCOL_VERSION: ProtocolVersion = if cfg!(feature = "nightly_protocol") {
@@ -231,6 +231,7 @@ impl ProtocolFeature {
             ProtocolFeature::AltBn128 => 55,
             ProtocolFeature::ChunkOnlyProducers | ProtocolFeature::MaxKickoutStake => 56,
             ProtocolFeature::AccountIdInFunctionCallPermission => 57,
+            ProtocolFeature::RejectBlocksWithOutdatedProtocolVersions => 58,
 
             // Nightly & shardnet features, this is to make feature MaxKickoutStake not enabled on
             // shardnet
@@ -240,14 +241,6 @@ impl ProtocolFeature {
             ProtocolFeature::FixContractLoadingCost => 129,
             #[cfg(feature = "protocol_feature_ed25519_verify")]
             ProtocolFeature::Ed25519Verify => 131,
-            #[cfg(feature = "protocol_feature_reject_blocks_with_outdated_protocol_version")]
-            ProtocolFeature::RejectBlocksWithOutdatedProtocolVersions => {
-                if cfg!(feature = "shardnet") {
-                    102
-                } else {
-                    132
-                }
-            }
             #[cfg(feature = "shardnet")]
             ProtocolFeature::ShardnetShardLayoutUpgrade => 102,
         }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -67,16 +67,11 @@ test_features = ["nearcore/test_features"]
 protocol_feature_fix_contract_loading_cost = [
   "nearcore/protocol_feature_fix_contract_loading_cost",
 ]
-protocol_feature_reject_blocks_with_outdated_protocol_version = [
-  "near-primitives/protocol_feature_reject_blocks_with_outdated_protocol_version",
-  "near-chain/protocol_feature_reject_blocks_with_outdated_protocol_version"
-]
 protocol_feature_flat_state = ["nearcore/protocol_feature_flat_state"]
 nightly = [
   "nightly_protocol",
   "nearcore/nightly",
   "protocol_feature_fix_contract_loading_cost",
-  "protocol_feature_reject_blocks_with_outdated_protocol_version"
 ]
 nightly_protocol = ["nearcore/nightly_protocol"]
 sandbox = [

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -617,34 +617,15 @@ fn invalid_blocks_common(is_requested: bool) {
                         } else {
                             assert_eq!(block.header().height(), 1);
                             assert_eq!(block.header().chunk_mask().len(), 1);
-                            #[cfg(not(
-                                feature = "protocol_feature_reject_blocks_with_outdated_protocol_version"
-                            ))]
-                            assert_eq!(ban_counter, 2);
-                            #[cfg(
-                                feature = "protocol_feature_reject_blocks_with_outdated_protocol_version"
-                            )]
-                            {
-                                assert_eq!(
-                                    block.header().latest_protocol_version(),
-                                    PROTOCOL_VERSION
-                                );
-                                assert_eq!(ban_counter, 3);
-                            }
+                            assert_eq!(block.header().latest_protocol_version(), PROTOCOL_VERSION);
+                            assert_eq!(ban_counter, 3);
                             System::current().stop();
                         }
                     }
                     NetworkRequests::BanPeer { ban_reason, .. } => {
                         assert_eq!(ban_reason, &ReasonForBan::BadBlockHeader);
                         ban_counter += 1;
-                        #[cfg(
-                            feature = "protocol_feature_reject_blocks_with_outdated_protocol_version"
-                        )]
                         let expected_ban_counter = 4;
-                        #[cfg(not(
-                            feature = "protocol_feature_reject_blocks_with_outdated_protocol_version"
-                        ))]
-                        let expected_ban_counter = 3;
                         if ban_counter == expected_ban_counter && is_requested {
                             System::current().stop();
                         }
@@ -700,21 +681,13 @@ fn invalid_blocks_common(is_requested: bool) {
             );
 
             // Send blocks with invalid protocol version
-            #[cfg(feature = "protocol_feature_reject_blocks_with_outdated_protocol_version")]
-            {
-                let mut block = valid_block.clone();
-                block.mut_header().get_mut().inner_rest.latest_protocol_version =
-                    PROTOCOL_VERSION - 1;
-                block.mut_header().get_mut().init();
-                client.do_send(
-                    NetworkClientMessages::Block(
-                        block.clone(),
-                        PeerInfo::random().id,
-                        is_requested,
-                    )
+            let mut block = valid_block.clone();
+            block.mut_header().get_mut().inner_rest.latest_protocol_version = PROTOCOL_VERSION - 1;
+            block.mut_header().get_mut().init();
+            client.do_send(
+                NetworkClientMessages::Block(block.clone(), PeerInfo::random().id, is_requested)
                     .with_span_context(),
-                );
-            }
+            );
 
             // Send block with invalid chunk signature
             let mut block = valid_block.clone();


### PR DESCRIPTION
# Feature to stabilize
With this feature, blocks produced with protocol versions older than the current protocol version in the network will be considered invalid. This is to ban blocks produced by validators that haven't upgraded after a protocol upgrade. 

# Context
Validators on old protocol versions could cause issues in the network, since they run on a different behavior. This PR is to further ban the blocks they produce to reduce the impact from these un-upgraded validators.  

# Testing and QA
- Unit test
- The feature was enabled and tested in shardnet

# Checklist
- [x] Link to nightly nayduck run https://nayduck.near.org/#/run/2724
- [x] Update CHANGELOG.md to include this protocol feature in the `Unreleased` section.