### PR TITLE
jsonrpc: check base58 length limit before the whole buffer is decoded

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3054,6 +3054,7 @@ dependencies = [
  "actix",
  "actix-cors",
  "actix-web",
+ "bs58",
  "easy-ext",
  "futures",
  "near-chain-configs",

--- a/chain/jsonrpc/Cargo.toml
+++ b/chain/jsonrpc/Cargo.toml
@@ -11,6 +11,7 @@ edition.workspace = true
 actix-cors.workspace = true
 actix-web.workspace = true
 actix.workspace = true
+bs58.workspace = true
 easy-ext.workspace = true
 futures.workspace = true
 once_cell.workspace = true

--- a/chain/jsonrpc/src/api/query.rs
+++ b/chain/jsonrpc/src/api/query.rs
@@ -49,7 +49,7 @@ impl RpcRequest for RpcQueryRequest {
                 .next()
                 .ok_or_else(make_err)?
                 .parse()
-                .map_err(|err| RpcParseError(err.to_string()))?;
+                .map_err(|err| RpcParseError(format!("{}", err)))?;
             let maybe_extra_arg = path_parts.next();
 
             let request = match query_command {

--- a/chain/jsonrpc/src/api/query.rs
+++ b/chain/jsonrpc/src/api/query.rs
@@ -3,7 +3,6 @@ use serde_json::Value;
 use near_client_primitives::types::QueryError;
 use near_jsonrpc_primitives::errors::RpcParseError;
 use near_jsonrpc_primitives::types::query::{RpcQueryError, RpcQueryRequest, RpcQueryResponse};
-use near_primitives::serialize;
 use near_primitives::types::BlockReference;
 use near_primitives::views::{QueryRequest, QueryResponse};
 
@@ -12,23 +11,36 @@ use super::{parse_params, RpcFrom, RpcRequest};
 /// Max size of the query path (soft-deprecated)
 const QUERY_DATA_MAX_SIZE: usize = 10 * 1024;
 
+/// Parses base58-encoded data from legacy path+data request format.
+fn parse_bs58_data(max_len: usize, encoded: String) -> Result<Vec<u8>, RpcParseError> {
+    // N-byte encoded base58 string decodes to at most N bytes so there’s no
+    // need to allocate full max_len output buffer if encoded length is shorter.
+    let mut data = vec![0u8; max_len.min(encoded.len())];
+    match bs58::decode(encoded.as_bytes()).into(data.as_mut_slice()) {
+        Ok(len) => {
+            data.truncate(len);
+            Ok(data)
+        }
+        Err(bs58::decode::Error::BufferTooSmall) => {
+            Err(RpcParseError("Query data size is too large".to_string()))
+        }
+        Err(err) => Err(RpcParseError(err.to_string())),
+    }
+}
+
 impl RpcRequest for RpcQueryRequest {
     fn parse(value: Option<Value>) -> Result<Self, RpcParseError> {
         let params = parse_params::<(String, String)>(value.clone());
-        let query_request = if let Ok((path, data)) = params {
+        let query_request = if let Ok((path, encoded)) = params {
             // Handle a soft-deprecated version of the query API, which is based on
             // positional arguments with a "path"-style first argument.
             //
             // This whole block can be removed one day, when the new API is 100% adopted.
-            let data =
-                serialize::from_base58(&data).map_err(|err| RpcParseError(err.to_string()))?;
-            let query_data_size = path.len() + data.len();
-            if query_data_size > QUERY_DATA_MAX_SIZE {
-                return Err(RpcParseError(format!(
-                    "Query data size {} is too large",
-                    query_data_size
-                )));
-            }
+
+            let parse_data = || {
+                let max_len = QUERY_DATA_MAX_SIZE.saturating_sub(path.len());
+                parse_bs58_data(max_len, encoded)
+            };
 
             let mut path_parts = path.splitn(3, '/');
             let make_err = || RpcParseError("Not enough query parameters provided".to_string());
@@ -37,7 +49,7 @@ impl RpcRequest for RpcQueryRequest {
                 .next()
                 .ok_or_else(make_err)?
                 .parse()
-                .map_err(|err| RpcParseError(format!("{}", err)))?;
+                .map_err(|err| RpcParseError(err.to_string()))?;
             let maybe_extra_arg = path_parts.next();
 
             let request = match query_command {
@@ -54,14 +66,14 @@ impl RpcRequest for RpcQueryRequest {
                 "code" => QueryRequest::ViewCode { account_id },
                 "contract" => QueryRequest::ViewState {
                     account_id,
-                    prefix: data.into(),
+                    prefix: parse_data()?.into(),
                     include_proof: false,
                 },
                 "call" => match maybe_extra_arg {
                     Some(method_name) => QueryRequest::CallFunction {
                         account_id,
                         method_name: method_name.to_string(),
-                        args: data.into(),
+                        args: parse_data()?.into(),
                     },
                     None => return Err(RpcParseError("Method name is missing".to_string())),
                 },

--- a/chain/jsonrpc/src/api/query.rs
+++ b/chain/jsonrpc/src/api/query.rs
@@ -31,7 +31,7 @@ fn parse_bs58_data(max_len: usize, encoded: String) -> Result<Vec<u8>, RpcParseE
 impl RpcRequest for RpcQueryRequest {
     fn parse(value: Option<Value>) -> Result<Self, RpcParseError> {
         let params = parse_params::<(String, String)>(value.clone());
-        let query_request = if let Ok((path, encoded)) = params {
+        let query_request = if let Ok((path, data)) = params {
             // Handle a soft-deprecated version of the query API, which is based on
             // positional arguments with a "path"-style first argument.
             //
@@ -39,7 +39,7 @@ impl RpcRequest for RpcQueryRequest {
 
             let parse_data = || {
                 let max_len = QUERY_DATA_MAX_SIZE.saturating_sub(path.len());
-                parse_bs58_data(max_len, encoded)
+                parse_bs58_data(max_len, data)
             };
 
             let mut path_parts = path.splitn(3, '/');

--- a/core/primitives-core/src/serialize.rs
+++ b/core/primitives-core/src/serialize.rs
@@ -2,13 +2,6 @@ pub fn to_base58<T: AsRef<[u8]>>(input: T) -> String {
     bs58::encode(input).into_string()
 }
 
-/// Deprecated.  If you want to decode a CryptoHash, use CryptoHash::from_str.
-/// For anything else, don’t use base58.  This is still here because of
-/// deprecated RPC query format in RpcQueryRequest::parse.
-pub fn from_base58(s: &str) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
-    bs58::decode(s).into_vec().map_err(|err| err.into())
-}
-
 pub fn to_base64<T: AsRef<[u8]>>(input: T) -> String {
     base64::encode(&input)
 }


### PR DESCRIPTION
Currently, when RpcRequest::parse handles legacy path+data query
format, it first decodes the data and only later checks its size.
This means that the server will dutifully decode any oversized buffer
only to discard the result later reporting an error.  Problem with
that is that base58 is an atrocious format and decoding is O(n²)
operation.  Because of that, it’s desired to stop decoding as soon as
its known that the data is too long.  Change the implementation so
that this happens.

Note that for simplicity this commit doesn’t implement a short-circuit
taking advantage of the fact that the length of the decoded string can
be estimated based on the length of the source.  The path+data query
format is legacy and should be deleted at some point so I essentially
implemented the minimum required for the code to be somewhat sane.
