### PR TITLE
[Debug UI] Show github link for version on debug page

### DIFF
--- a/chain/jsonrpc/res/debug.html
+++ b/chain/jsonrpc/res/debug.html
@@ -24,12 +24,19 @@
                 type: "GET",
                 url: "/status",
                 success: data => {
-                    let binaryText = $('<span>')
-                        .text(`version "${data.version.version}" built with rustc "${data.version.rustc_version}" at `);
-                    binaryText.append(
-                        $('<a>')
-                            .text(data.version.build)
-                            .attr('href', `https://github.com/near/nearcore/tree/${data.version.build}`));
+                    let binaryText = $('<span>');
+                    let version = data.version;
+                    let githubLink = $('<a>')
+                        .text(version.build)
+                        .attr('href', `https://github.com/near/nearcore/tree/${data.version.build}`);
+                    if (version.version == 'trunk') {
+                        binaryText.append('Nightly build ').append(githubLink);
+                    } else if (version.version == version.build) {
+                        binaryText.append('Release ').append(githubLink);
+                    } else {
+                        binaryText.append(`Release ${version.version} (build `).append(githubLink).append(')');
+                    }
+                    binaryText.append(` compiled with rustc ${version.rustc_version}`);
                     $('.js-chain').text(data.chain_id);
                     $('.js-protocol').text(data.protocol_version);
                     $('.js-binary').children().remove();

--- a/chain/jsonrpc/res/debug.html
+++ b/chain/jsonrpc/res/debug.html
@@ -24,9 +24,16 @@
                 type: "GET",
                 url: "/status",
                 success: data => {
+                    let binaryText = $('<span>')
+                        .text(`version "${data.version.version}" built with rustc "${data.version.rustc_version}" at `);
+                    binaryText.append(
+                        $('<a>')
+                            .text(data.version.build)
+                            .attr('href', `https://github.com/near/nearcore/tree/${data.version.build}`));
                     $('.js-chain').text(data.chain_id);
                     $('.js-protocol').text(data.protocol_version);
-                    $('.js-binary').text(JSON.stringify(data.version));
+                    $('.js-binary').children().remove();
+                    $('.js-binary').append(binaryText);
                     $('.js-uptime').text(convertTime(data.uptime_sec));
                 },
                 dataType: "json",


### PR DESCRIPTION
<img width="643" alt="image" src="https://user-images.githubusercontent.com/111538878/196556640-560aca51-d1a7-4c9c-8d14-678901666fa9.png">

The example link leads to https://github.com/near/nearcore/tree/1.1.0-2956-g93b66337a

(Yes, that is a tag that github understands, apparently.)

#7861