### PR TITLE
refactor: remove `ContractCallError`

### DIFF
--- a/chain/jsonrpc/res/rpc_errors_schema.json
+++ b/chain/jsonrpc/res/rpc_errors_schema.json
@@ -534,15 +534,6 @@
         "tx_burnt_amount": ""
       }
     },
-    "ContractCallError": {
-      "name": "ContractCallError",
-      "subtypes": [
-        "MethodResolveError",
-        "CompilationError",
-        "ExecutionError"
-      ],
-      "props": {}
-    },
     "CostOverflow": {
       "name": "CostOverflow",
       "subtypes": [],
@@ -596,13 +587,6 @@
       "name": "DepositWithFunctionCall",
       "subtypes": [],
       "props": {}
-    },
-    "ExecutionError": {
-      "name": "ExecutionError",
-      "subtypes": [],
-      "props": {
-        "msg": ""
-      }
     },
     "Expired": {
       "name": "Expired",

--- a/core/primitives/src/errors.rs
+++ b/core/primitives/src/errors.rs
@@ -7,7 +7,7 @@ use std::fmt::{Debug, Display};
 
 use crate::hash::CryptoHash;
 use near_rpc_error_macro::RpcError;
-use near_vm_errors::{CompilationError, FunctionCallErrorSer, MethodResolveError};
+use near_vm_errors::FunctionCallErrorSer;
 
 /// Error returned in the ExecutionOutcome in case of failure
 #[derive(
@@ -333,44 +333,6 @@ pub struct ActionError {
 }
 
 impl std::error::Error for ActionError {}
-
-#[derive(Debug, Clone, PartialEq, Eq, RpcError)]
-pub enum ContractCallError {
-    MethodResolveError(MethodResolveError),
-    CompilationError(CompilationError),
-    ExecutionError { msg: String },
-}
-
-impl From<ContractCallError> for FunctionCallErrorSer {
-    fn from(e: ContractCallError) -> Self {
-        match e {
-            ContractCallError::CompilationError(e) => FunctionCallErrorSer::CompilationError(e),
-            ContractCallError::MethodResolveError(e) => FunctionCallErrorSer::MethodResolveError(e),
-            ContractCallError::ExecutionError { msg } => FunctionCallErrorSer::ExecutionError(msg),
-        }
-    }
-}
-
-impl From<FunctionCallErrorSer> for ContractCallError {
-    fn from(e: FunctionCallErrorSer) -> Self {
-        match e {
-            FunctionCallErrorSer::CompilationError(e) => ContractCallError::CompilationError(e),
-            FunctionCallErrorSer::MethodResolveError(e) => ContractCallError::MethodResolveError(e),
-            FunctionCallErrorSer::ExecutionError(msg) => ContractCallError::ExecutionError { msg },
-            FunctionCallErrorSer::LinkError { msg } => ContractCallError::ExecutionError { msg },
-            FunctionCallErrorSer::WasmUnknownError => {
-                ContractCallError::ExecutionError { msg: "unknown error".to_string() }
-            }
-            FunctionCallErrorSer::_EVMError => unreachable!(),
-            FunctionCallErrorSer::WasmTrap(e) => {
-                ContractCallError::ExecutionError { msg: format!("WASM: {:?}", e) }
-            }
-            FunctionCallErrorSer::HostError(e) => {
-                ContractCallError::ExecutionError { msg: format!("Host: {:?}", e) }
-            }
-        }
-    }
-}
 
 #[derive(
     BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq, Deserialize, Serialize, RpcError,

--- a/integration-tests/src/tests/runtime/test_evil_contracts.rs
+++ b/integration-tests/src/tests/runtime/test_evil_contracts.rs
@@ -1,6 +1,7 @@
 use crate::node::{Node, RuntimeNode};
-use near_primitives::errors::{ActionError, ActionErrorKind, ContractCallError};
+use near_primitives::errors::{ActionError, ActionErrorKind};
 use near_primitives::views::FinalExecutionStatus;
+use near_vm_errors::FunctionCallErrorSer;
 use std::mem::size_of;
 
 use assert_matches::assert_matches;
@@ -128,12 +129,9 @@ fn test_evil_abort() {
         FinalExecutionStatus::Failure(
             ActionError {
                 index: Some(0),
-                kind: ActionErrorKind::FunctionCallError(
-                    ContractCallError::ExecutionError {
-                        msg: "String encoding is bad UTF-16 sequence.".to_string()
-                    }
-                    .into()
-                )
+                kind: ActionErrorKind::FunctionCallError(FunctionCallErrorSer::ExecutionError(
+                    "String encoding is bad UTF-16 sequence.".to_string()
+                ))
             }
             .into()
         ),

--- a/integration-tests/src/tests/standard_cases/mod.rs
+++ b/integration-tests/src/tests/standard_cases/mod.rs
@@ -8,8 +8,7 @@ use near_crypto::{InMemorySigner, KeyType};
 use near_jsonrpc_primitives::errors::ServerError;
 use near_primitives::account::{AccessKey, AccessKeyPermission, FunctionCallPermission};
 use near_primitives::errors::{
-    ActionError, ActionErrorKind, ContractCallError, InvalidAccessKeyError, InvalidTxError,
-    TxExecutionError,
+    ActionError, ActionErrorKind, InvalidAccessKeyError, InvalidTxError, TxExecutionError,
 };
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::types::{AccountId, Balance, TrieNodesCount};
@@ -17,7 +16,7 @@ use near_primitives::views::{
     AccessKeyView, AccountView, ExecutionMetadataView, FinalExecutionOutcomeView,
     FinalExecutionStatus,
 };
-use near_vm_errors::MethodResolveError;
+use near_vm_errors::{FunctionCallErrorSer, MethodResolveError};
 use nearcore::config::{NEAR_BASE, TESTING_INIT_BALANCE, TESTING_INIT_STAKE};
 
 use crate::node::Node;
@@ -89,12 +88,9 @@ pub fn test_smart_contract_panic(node: impl Node) {
         FinalExecutionStatus::Failure(
             ActionError {
                 index: Some(0),
-                kind: ActionErrorKind::FunctionCallError(
-                    ContractCallError::ExecutionError {
-                        msg: "Smart contract panicked: WAT?".to_string()
-                    }
-                    .into()
-                )
+                kind: ActionErrorKind::FunctionCallError(FunctionCallErrorSer::ExecutionError(
+                    "Smart contract panicked: WAT?".to_string()
+                ))
             }
             .into()
         )
@@ -130,10 +126,9 @@ pub fn test_smart_contract_bad_method_name(node: impl Node) {
         FinalExecutionStatus::Failure(
             ActionError {
                 index: Some(0),
-                kind: ActionErrorKind::FunctionCallError(
-                    ContractCallError::MethodResolveError(MethodResolveError::MethodNotFound)
-                        .into()
-                )
+                kind: ActionErrorKind::FunctionCallError(FunctionCallErrorSer::MethodResolveError(
+                    MethodResolveError::MethodNotFound
+                ))
             }
             .into()
         )
@@ -155,10 +150,9 @@ pub fn test_smart_contract_empty_method_name_with_no_tokens(node: impl Node) {
         FinalExecutionStatus::Failure(
             ActionError {
                 index: Some(0),
-                kind: ActionErrorKind::FunctionCallError(
-                    ContractCallError::MethodResolveError(MethodResolveError::MethodEmptyName)
-                        .into()
-                )
+                kind: ActionErrorKind::FunctionCallError(FunctionCallErrorSer::MethodResolveError(
+                    MethodResolveError::MethodEmptyName
+                ))
             }
             .into()
         )
@@ -180,10 +174,9 @@ pub fn test_smart_contract_empty_method_name_with_tokens(node: impl Node) {
         FinalExecutionStatus::Failure(
             ActionError {
                 index: Some(0),
-                kind: ActionErrorKind::FunctionCallError(
-                    ContractCallError::MethodResolveError(MethodResolveError::MethodEmptyName)
-                        .into()
-                )
+                kind: ActionErrorKind::FunctionCallError(FunctionCallErrorSer::MethodResolveError(
+                    MethodResolveError::MethodEmptyName
+                ))
             }
             .into()
         )

--- a/runtime/near-vm-errors/src/lib.rs
+++ b/runtime/near-vm-errors/src/lib.rs
@@ -59,8 +59,7 @@ pub enum FunctionCallError {
 }
 
 /// Serializable version of `FunctionCallError`. Must never reorder/remove elements, can only
-/// add new variants at the end (but do that very carefully). This type must be never used
-/// directly, and must be converted to `ContractCallError` instead using `into()` converter.
+/// add new variants at the end (but do that very carefully).
 /// It describes stable serialization format, and only used by serialization logic.
 #[derive(Debug, Clone, PartialEq, Eq, BorshDeserialize, BorshSerialize, Serialize, Deserialize)]
 pub enum FunctionCallErrorSer {
@@ -296,6 +295,27 @@ impl std::error::Error for VMLogicError {}
 pub enum InconsistentStateError {
     /// Math operation with a value from the state resulted in a integer overflow.
     IntegerOverflow,
+}
+
+impl From<FunctionCallError> for FunctionCallErrorSer {
+    fn from(outer_err: FunctionCallError) -> Self {
+        match outer_err {
+            FunctionCallError::CompilationError(e) => FunctionCallErrorSer::CompilationError(e),
+            FunctionCallError::MethodResolveError(e) => FunctionCallErrorSer::MethodResolveError(e),
+            // TODO: consider using FunctionCallErrorSer::HostError
+            FunctionCallError::HostError(ref _e) => {
+                FunctionCallErrorSer::ExecutionError(outer_err.to_string())
+            }
+            // TODO: consider using FunctionCallErrorSer::LinkError
+            FunctionCallError::LinkError { msg } => {
+                FunctionCallErrorSer::ExecutionError(format!("Link Error: {}", msg))
+            }
+            // TODO: consider using FunctionCallErrorSer::WasmTrap
+            FunctionCallError::WasmTrap(ref _e) => {
+                FunctionCallErrorSer::ExecutionError(outer_err.to_string())
+            }
+        }
+    }
 }
 
 impl From<HostError> for VMLogicError {

--- a/runtime/near-vm-errors/src/lib.rs
+++ b/runtime/near-vm-errors/src/lib.rs
@@ -66,14 +66,19 @@ pub enum FunctionCallErrorSer {
     /// Wasm compilation error
     CompilationError(CompilationError),
     /// Wasm binary env link error
+    ///
+    /// Note: this is only to deserialize old data, use execution error for new data
     LinkError {
         msg: String,
     },
     /// Import/export resolve error
     MethodResolveError(MethodResolveError),
     /// A trap happened during execution of a binary
+    ///
+    /// Note: this is only to deserialize old data, use execution error for new data
     WasmTrap(WasmTrap),
     WasmUnknownError,
+    /// Note: this is only to deserialize old data, use execution error for new data
     HostError(HostError),
     // Unused, can be reused by a future error but must be exactly one error to keep ExecutionError
     // error borsh serialized at correct index
@@ -302,15 +307,15 @@ impl From<FunctionCallError> for FunctionCallErrorSer {
         match outer_err {
             FunctionCallError::CompilationError(e) => FunctionCallErrorSer::CompilationError(e),
             FunctionCallError::MethodResolveError(e) => FunctionCallErrorSer::MethodResolveError(e),
-            // TODO: consider using FunctionCallErrorSer::HostError
+            // Note: We deliberately collapse all execution errors for
+            // serialization to make the DB representation less dependent
+            // on specific types in Rust code.
             FunctionCallError::HostError(ref _e) => {
                 FunctionCallErrorSer::ExecutionError(outer_err.to_string())
             }
-            // TODO: consider using FunctionCallErrorSer::LinkError
             FunctionCallError::LinkError { msg } => {
                 FunctionCallErrorSer::ExecutionError(format!("Link Error: {}", msg))
             }
-            // TODO: consider using FunctionCallErrorSer::WasmTrap
             FunctionCallError::WasmTrap(ref _e) => {
                 FunctionCallErrorSer::ExecutionError(outer_err.to_string())
             }

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -7,7 +7,7 @@ use near_primitives::account::{AccessKey, AccessKeyPermission, Account};
 use near_primitives::checked_feature;
 use near_primitives::config::ViewConfig;
 use near_primitives::contract::ContractCode;
-use near_primitives::errors::{ActionError, ActionErrorKind, ContractCallError, RuntimeError};
+use near_primitives::errors::{ActionError, ActionErrorKind, RuntimeError};
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::{ActionReceipt, Receipt, ReceiptEnum};
 use near_primitives::runtime::config::AccountCreationConfig;
@@ -27,7 +27,10 @@ use near_store::{
     get_access_key, get_code, remove_access_key, remove_account, set_access_key, set_code,
     StorageError, TrieUpdate,
 };
-use near_vm_errors::{CompilationError, FunctionCallError, InconsistentStateError, VMRunnerError};
+use near_vm_errors::{
+    CompilationError, FunctionCallError, FunctionCallErrorSer, InconsistentStateError,
+    VMRunnerError,
+};
 use near_vm_logic::types::PromiseResult;
 use near_vm_logic::{VMContext, VMOutcome};
 use near_vm_runner::precompile_contract;
@@ -204,65 +207,41 @@ pub(crate) fn action_function_call(
         }
     }
 
-    let execution_succeeded = match outcome.aborted {
-        Some(err) => {
-            metrics::FUNCTION_CALL_PROCESSED_FUNCTION_CALL_ERRORS
-                .with_label_values(&[(&err).into()])
-                .inc();
-            match err {
-                FunctionCallError::CompilationError(err) => {
-                    metrics::FUNCTION_CALL_PROCESSED_COMPILATION_ERRORS
-                        .with_label_values(&[(&err).into()])
-                        .inc();
-                    result.result = Err(ActionErrorKind::FunctionCallError(
-                        ContractCallError::CompilationError(err).into(),
-                    )
-                    .into());
-                    false
-                }
-                FunctionCallError::LinkError { msg } => {
-                    result.result = Err(ActionErrorKind::FunctionCallError(
-                        ContractCallError::ExecutionError { msg: format!("Link Error: {}", msg) }
-                            .into(),
-                    )
-                    .into());
-                    false
-                }
-                FunctionCallError::MethodResolveError(err) => {
-                    metrics::FUNCTION_CALL_PROCESSED_METHOD_RESOLVE_ERRORS
-                        .with_label_values(&[(&err).into()])
-                        .inc();
-                    result.result = Err(ActionErrorKind::FunctionCallError(
-                        ContractCallError::MethodResolveError(err).into(),
-                    )
-                    .into());
-                    false
-                }
-                FunctionCallError::WasmTrap(ref inner_err) => {
-                    metrics::FUNCTION_CALL_PROCESSED_WASM_TRAP_ERRORS
-                        .with_label_values(&[inner_err.into()])
-                        .inc();
-                    result.result = Err(ActionErrorKind::FunctionCallError(
-                        ContractCallError::ExecutionError { msg: err.to_string() }.into(),
-                    )
-                    .into());
-                    false
-                }
-                FunctionCallError::HostError(ref inner_err) => {
-                    metrics::FUNCTION_CALL_PROCESSED_HOST_ERRORS
-                        .with_label_values(&[inner_err.into()])
-                        .inc();
-                    result.result = Err(ActionErrorKind::FunctionCallError(
-                        ContractCallError::ExecutionError { msg: err.to_string() }.into(),
-                    )
-                    .into());
-                    false
-                }
+    let execution_succeeded = outcome.aborted.is_none();
+    if let Some(err) = outcome.aborted {
+        // collect metrics for failed function calls
+        metrics::FUNCTION_CALL_PROCESSED_FUNCTION_CALL_ERRORS
+            .with_label_values(&[(&err).into()])
+            .inc();
+        match &err {
+            FunctionCallError::CompilationError(err) => {
+                metrics::FUNCTION_CALL_PROCESSED_COMPILATION_ERRORS
+                    .with_label_values(&[err.into()])
+                    .inc();
+            }
+            FunctionCallError::LinkError { .. } => (),
+            FunctionCallError::MethodResolveError(err) => {
+                metrics::FUNCTION_CALL_PROCESSED_METHOD_RESOLVE_ERRORS
+                    .with_label_values(&[err.into()])
+                    .inc();
+            }
+            FunctionCallError::WasmTrap(ref inner_err) => {
+                metrics::FUNCTION_CALL_PROCESSED_WASM_TRAP_ERRORS
+                    .with_label_values(&[inner_err.into()])
+                    .inc();
+            }
+            FunctionCallError::HostError(ref inner_err) => {
+                metrics::FUNCTION_CALL_PROCESSED_HOST_ERRORS
+                    .with_label_values(&[inner_err.into()])
+                    .inc();
             }
         }
-        None => true,
-    };
-
+        // Update action result with the abort error converted to the
+        // transaction runtime's format of errors.
+        let ser: FunctionCallErrorSer = err.into();
+        let action_err: ActionError = ActionErrorKind::FunctionCallError(ser).into();
+        result.result = Err(action_err);
+    }
     result.gas_burnt = safe_add_gas(result.gas_burnt, outcome.burnt_gas)?;
     result.gas_burnt_for_function_call =
         safe_add_gas(result.gas_burnt_for_function_call, outcome.burnt_gas)?;


### PR DESCRIPTION
The indirection from `FunctionCallError` to `ContractCallError`
to `FunctionCallErrorSer` seems to be obsolete after the latest
rounds of refactoring. Let's remove it.