### PR TITLE
refactor: simplify error handling in main

### DIFF
--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -36,7 +36,7 @@ pub(super) struct NeardCmd {
 }
 
 impl NeardCmd {
-    pub(super) fn parse_and_run() -> Result<(), RunError> {
+    pub(super) fn parse_and_run() -> anyhow::Result<()> {
         let neard_cmd = Self::parse();
 
         // Enable logging of the current thread.
@@ -100,16 +100,6 @@ impl NeardCmd {
         };
         Ok(())
     }
-}
-
-#[derive(thiserror::Error, Debug)]
-pub(crate) enum RunError {
-    #[error("invalid logging directives provided")]
-    EnvFilter(#[source] BuildEnvFilterError),
-    #[error("could not install a rayon thread pool")]
-    RayonInstall(#[source] rayon::ThreadPoolBuildError),
-    #[error(transparent)]
-    Other(#[from] anyhow::Error),
 }
 
 #[derive(Parser)]
@@ -681,9 +671,8 @@ impl VerifyProofSubCommand {
     }
 }
 
-fn make_env_filter(verbose: Option<&str>) -> Result<EnvFilter, RunError> {
-    let env_filter =
-        EnvFilterBuilder::from_env().verbose(verbose).finish().map_err(RunError::EnvFilter)?;
+fn make_env_filter(verbose: Option<&str>) -> Result<EnvFilter, BuildEnvFilterError> {
+    let env_filter = EnvFilterBuilder::from_env().verbose(verbose).finish()?;
     // Sandbox node can log to sandbox logging target via sandbox_debug_log host function.
     // This is hidden by default so we enable it for sandbox node.
     let env_filter = if cfg!(feature = "sandbox") {

--- a/neard/src/main.rs
+++ b/neard/src/main.rs
@@ -2,7 +2,7 @@ mod cli;
 mod log_config_watcher;
 
 use self::cli::NeardCmd;
-use crate::cli::RunError;
+use anyhow::Context;
 use near_primitives::version::{Version, PROTOCOL_VERSION};
 use near_store::metadata::DB_VERSION;
 use nearcore::get_default_home;
@@ -41,7 +41,7 @@ static ALLOC: near_rust_allocator_proxy::ProxyAllocator<tikv_jemallocator::Jemal
 #[global_allocator]
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
-fn main() -> Result<(), RunError> {
+fn main() -> anyhow::Result<()> {
     if env::var("RUST_BACKTRACE").is_err() {
         // Enable backtraces on panics by default.
         env::set_var("RUST_BACKTRACE", "1");
@@ -50,7 +50,7 @@ fn main() -> Result<(), RunError> {
     rayon::ThreadPoolBuilder::new()
         .stack_size(8 * 1024 * 1024)
         .build_global()
-        .map_err(RunError::RayonInstall)?;
+        .context("failed to create the threadpool")?;
 
     #[cfg(feature = "memory_stats")]
     ALLOC.set_report_usage_interval(512 << 20).enable_stack_trace(true);


### PR DESCRIPTION
`anyhow` is the type to return from `main`, we dont' get any value here from preserving well-typed errors, and creatng more work down the line to add all future error variants: *surely* we can fail due to more than these two errors, right?