### PR TITLE
chain: remove TxStatusError::InvalidTx variant

### DIFF
--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -8,7 +8,6 @@ use chrono::DateTime;
 use near_primitives::time::Utc;
 
 use near_chain_configs::ProtocolConfigView;
-use near_primitives::errors::InvalidTxError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{MerklePath, PartialMerkleTree};
 use near_primitives::network::PeerId;
@@ -595,7 +594,6 @@ pub struct TxStatus {
 pub enum TxStatusError {
     ChainError(near_chain_primitives::Error),
     MissingTransaction(CryptoHash),
-    InvalidTx(InvalidTxError),
     InternalError(String),
     TimeoutError,
 }

--- a/chain/jsonrpc/src/api/transactions.rs
+++ b/chain/jsonrpc/src/api/transactions.rs
@@ -47,7 +47,6 @@ impl RpcFrom<TxStatusError> for RpcTransactionError {
             TxStatusError::MissingTransaction(requested_transaction_hash) => {
                 Self::UnknownTransaction { requested_transaction_hash }
             }
-            TxStatusError::InvalidTx(context) => Self::InvalidTransaction { context },
             TxStatusError::InternalError(debug_info) => Self::InternalError { debug_info },
             TxStatusError::TimeoutError => Self::TimeoutError,
         }

--- a/chain/rosetta-rpc/src/errors.rs
+++ b/chain/rosetta-rpc/src/errors.rs
@@ -35,10 +35,6 @@ impl From<near_client::TxStatusError> for ErrorKind {
             near_client::TxStatusError::MissingTransaction(err) => {
                 Self::NotFound(format!("Transaction is missing: {:?}", err))
             }
-            near_client::TxStatusError::InvalidTx(err) => Self::NotFound(format!(
-                "Transaction is invalid, so it will never be included to the chain: {:?}",
-                err
-            )),
             near_client::TxStatusError::InternalError(_)
             | near_client::TxStatusError::TimeoutError => {
                 // TODO: remove the statuses from TxStatusError since they are


### PR DESCRIPTION
The TxStatusError::InvalidTx variant is never constructed
so get rid of it.
