### PR TITLE
fix!(vm-logic): Remove error from attached deposit for view calls

### DIFF
--- a/runtime/near-vm-logic/src/logic.rs
+++ b/runtime/near-vm-logic/src/logic.rs
@@ -745,12 +745,6 @@ impl<'a> VMLogic<'a> {
     pub fn attached_deposit(&mut self, balance_ptr: u64) -> Result<()> {
         self.gas_counter.pay_base(base)?;
 
-        if self.context.is_view() {
-            return Err(HostError::ProhibitedInView {
-                method_name: "attached_deposit".to_string(),
-            }
-            .into());
-        }
         self.memory_set_u128(balance_ptr, self.context.attached_deposit)
     }
 

--- a/runtime/near-vm-logic/src/tests/context.rs
+++ b/runtime/near-vm-logic/src/tests/context.rs
@@ -1,7 +1,6 @@
-use near_primitives::config::{VMLimitConfig, ViewConfig};
-
 use crate::tests::vm_logic_builder::VMLogicBuilder;
 use crate::VMContext;
+use near_primitives::config::{VMLimitConfig, ViewConfig};
 
 pub fn create_context() -> VMContext {
     VMContext {

--- a/runtime/near-vm-logic/src/tests/view_method.rs
+++ b/runtime/near-vm-logic/src/tests/view_method.rs
@@ -17,7 +17,6 @@ fn test_prohibited_view_methods() {
     test_prohibited!(signer_account_id, 0);
     test_prohibited!(signer_account_pk, 0);
     test_prohibited!(predecessor_account_id, 0);
-    test_prohibited!(attached_deposit, 0);
     test_prohibited!(prepaid_gas);
     test_prohibited!(used_gas);
     test_prohibited!(promise_create, 0, 0, 0, 0, 0, 0, 0, 0);


### PR DESCRIPTION
Accompanying PR for https://github.com/near/NEPs/pull/418

It's very simple, so I figured I'd just open.

I'm generally uncomfortable with how certain context is redundant for view context, and it wasn't clear whether or not this check should be kept and just return 0 for attached deposit for view contexts. Seems like the only logic which uses the view logic [sets the deposit to 0](https://github.com/near/nearcore/blob/d13f66bcdf71ff6a6fdf9f31edad1182283a7523/runtime/runtime/src/state_viewer/mod.rs#L224), but I'm not sure if it will ever be wanted to be able to configure context for view calls in the future.