### PR TITLE
store: adding StateChanges to cold columns

### DIFF
--- a/core/store/src/cold_storage.rs
+++ b/core/store/src/cold_storage.rs
@@ -179,7 +179,11 @@ fn get_keys_from_store(
                     store.iter_prefix_with_callback(
                         DBCol::StateChanges,
                         &block_hash_key,
-                        |full_key| keys.push(full_key[block_hash_key.len()..].to_vec()),
+                        |full_key| {
+                            let mut full_key = Vec::from(full_key);
+                            full_key.drain(..block_hash_key.len());
+                            keys.push(full_key);
+                        },
                     )?;
                     keys
                 }
@@ -257,7 +261,7 @@ impl StoreWithCache<'_> {
     ) -> io::Result<()> {
         for iter_result in self.store.iter_prefix(col, key_prefix) {
             let (key, value) = iter_result?;
-            self.cache.insert((col.clone(), key.to_vec()), Some(value.to_vec()));
+            self.cache.insert((col, key.to_vec()), Some(value.into()));
             callback(key);
         }
         Ok(())

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -368,7 +368,7 @@ impl DBCol {
     /// Whether this column should be copied to the cold storage.
     pub const fn is_cold(&self) -> bool {
         match self {
-            DBCol::Block | DBCol::State => true,
+            DBCol::Block | DBCol::State | DBCol::StateChanges => true,
             _ => false,
         }
     }

--- a/integration-tests/src/tests/client/cold_storage.rs
+++ b/integration-tests/src/tests/client/cold_storage.rs
@@ -60,6 +60,7 @@ fn test_storage_after_commit_of_cold_update() {
     test_cold_genesis_update(&*cold_db, &env.clients[0].runtime_adapter.store()).unwrap();
 
     let state_reads = test_get_store_reads(DBCol::State);
+    let state_changes_reads = test_get_store_reads(DBCol::StateChanges);
 
     for h in 1..max_height {
         let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
@@ -128,6 +129,8 @@ fn test_storage_after_commit_of_cold_update() {
 
     // assert that we don't read State from db, but from TrieChanges
     assert_eq!(state_reads, test_get_store_reads(DBCol::State));
+    // assert that we don't read StateChanges from db again after iter_prefix
+    assert_eq!(state_changes_reads, test_get_store_reads(DBCol::StateChanges));
 
     let cold_store = NodeStorage::new(cold_db).get_store(Temperature::Hot);
 


### PR DESCRIPTION
This is the second column that breaks 'get keys -> combine keys -> read -> write' pipeline, but it is also the last one. Other columns don't require special magic with cache. Also, as mentioned before, this column shouldn't either, it should write values directly to colddb, not cache. This change for State and StateChanges will come in the future and it probably will not impact code all that much. 