### PR TITLE
moved fixing local edges to a background task.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3280,6 +3280,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_xorshift",
  "rayon",
+ "rlimit",
  "serde",
  "smart-default",
  "strum",

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -12,7 +12,6 @@ anyhow.workspace = true
 protobuf-codegen.workspace = true
 
 [dependencies]
-rlimit.workspace = true
 async-trait.workspace = true
 actix.workspace = true
 anyhow.workspace = true
@@ -59,6 +58,7 @@ near-store = { path = "../../core/store" }
 criterion.workspace = true
 pretty_assertions.workspace = true
 tempfile.workspace = true
+rlimit.workspace = true
 
 [features]
 delay_detector = ["delay-detector/delay_detector"]

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -12,6 +12,7 @@ anyhow.workspace = true
 protobuf-codegen.workspace = true
 
 [dependencies]
+rlimit.workspace = true
 async-trait.workspace = true
 actix.workspace = true
 anyhow.workspace = true

--- a/chain/network/src/broadcast/mod.rs
+++ b/chain/network/src/broadcast/mod.rs
@@ -70,7 +70,7 @@ impl<T: Clone + Send> Receiver<T> {
         v
     }
 
-    pub async fn recv_until<U>(&mut self, pred: impl Fn(T) -> Option<U>) -> U {
+    pub async fn recv_until<U>(&mut self, mut pred: impl FnMut(T) -> Option<U>) -> U {
         loop {
             if let Some(u) = pred(self.recv().await) {
                 return u;

--- a/chain/network/src/network_protocol/testonly.rs
+++ b/chain/network/src/network_protocol/testonly.rs
@@ -129,21 +129,21 @@ pub fn make_partial_edge<R: Rng>(rng: &mut R) -> PartialEdgeInfo {
     )
 }
 
-pub fn make_edge(a: &InMemorySigner, b: &InMemorySigner) -> Edge {
-    let (a, b) = if a.public_key < b.public_key { (a, b) } else { (b, a) };
-    let ap = PeerId::new(a.public_key.clone());
-    let bp = PeerId::new(b.public_key.clone());
+pub fn make_edge(a: &SecretKey, b: &SecretKey) -> Edge {
+    let (a, b) = if a.public_key() < b.public_key() { (a, b) } else { (b, a) };
+    let ap = PeerId::new(a.public_key());
+    let bp = PeerId::new(b.public_key());
     let nonce = 1; // Make it an active edge.
     let hash = Edge::build_hash(&ap, &bp, nonce);
-    Edge::new(ap, bp, nonce, a.secret_key.sign(hash.as_ref()), b.secret_key.sign(hash.as_ref()))
+    Edge::new(ap, bp, nonce, a.sign(hash.as_ref()), b.sign(hash.as_ref()))
 }
 
-pub fn make_edge_tombstone(a: &InMemorySigner, b: &InMemorySigner) -> Edge {
-    make_edge(a, b).remove_edge(PeerId::new(a.public_key.clone()), &a.secret_key)
+pub fn make_edge_tombstone(a: &SecretKey, b: &SecretKey) -> Edge {
+    make_edge(a, b).remove_edge(PeerId::new(a.public_key()), &a)
 }
 
 pub fn make_routing_table<R: Rng>(rng: &mut R) -> RoutingTableUpdate {
-    let signers: Vec<_> = (0..7).map(|_| make_signer(rng)).collect();
+    let signers: Vec<_> = (0..7).map(|_| make_secret_key(rng)).collect();
     RoutingTableUpdate {
         accounts: (0..10).map(|_| make_announce_account(rng)).collect(),
         edges: {

--- a/chain/network/src/network_protocol/tests.rs
+++ b/chain/network/src/network_protocol/tests.rs
@@ -53,8 +53,8 @@ fn serialize_deserialize() -> anyhow::Result<()> {
     let mut clock = time::FakeClock::default();
 
     let chain = data::Chain::make(&mut clock, &mut rng, 12);
-    let a = data::make_signer(&mut rng);
-    let b = data::make_signer(&mut rng);
+    let a = data::make_secret_key(&mut rng);
+    let b = data::make_secret_key(&mut rng);
     let edge = data::make_edge(&a, &b);
 
     let chunk_hash = chain.blocks[3].chunks()[0].chunk_hash();

--- a/chain/network/src/peer/testonly.rs
+++ b/chain/network/src/peer/testonly.rs
@@ -18,7 +18,7 @@ use crate::testonly::fake_client;
 use crate::time;
 use crate::types::PeerIdOrHash;
 use actix::{Actor, Context, Handler};
-use near_crypto::{InMemorySigner, Signature};
+use near_crypto::Signature;
 use near_o11y::{handler_debug_span, OpenTelemetrySpanExt, WithSpanContext, WithSpanContextExt};
 use near_primitives::network::PeerId;
 use std::sync::Arc;
@@ -45,10 +45,6 @@ impl PeerConfig {
 
     pub fn partial_edge_info(&self, other: &PeerId, nonce: u64) -> PartialEdgeInfo {
         PartialEdgeInfo::new(&self.id(), other, nonce, &self.network.node_key)
-    }
-
-    pub fn signer(&self) -> InMemorySigner {
-        InMemorySigner::from_secret_key("node".parse().unwrap(), self.network.node_key.clone())
     }
 }
 
@@ -99,6 +95,7 @@ pub(crate) struct PeerHandle {
     pub cfg: Arc<PeerConfig>,
     actix: ActixSystem<PeerActor>,
     pub events: broadcast::Receiver<Event>,
+    pub edge: Option<Edge>,
 }
 
 impl PeerHandle {
@@ -110,16 +107,20 @@ impl PeerHandle {
             .unwrap();
     }
 
-    pub async fn complete_handshake(&mut self) -> Edge {
-        self.events
-            .recv_until(|ev| match ev {
-                Event::Network(peer_manager_actor::Event::HandshakeCompleted(ev)) => Some(ev.edge),
-                Event::Network(peer_manager_actor::Event::ConnectionClosed(ev)) => {
-                    panic!("handshake failed: {}", ev.reason)
-                }
-                _ => None,
-            })
-            .await
+    pub async fn complete_handshake(&mut self) {
+        self.edge = Some(
+            self.events
+                .recv_until(|ev| match ev {
+                    Event::Network(peer_manager_actor::Event::HandshakeCompleted(ev)) => {
+                        Some(ev.edge)
+                    }
+                    Event::Network(peer_manager_actor::Event::ConnectionClosed(ev)) => {
+                        panic!("handshake failed: {}", ev.reason)
+                    }
+                    _ => None,
+                })
+                .await,
+        );
     }
     pub async fn fail_handshake(&mut self) -> ClosingReason {
         self.events
@@ -186,6 +187,6 @@ impl PeerHandle {
             PeerActor::spawn(clock, stream, cfg.force_encoding, network_state).unwrap()
         })
         .await;
-        Self { actix, cfg: cfg_, events: recv }
+        Self { actix, cfg: cfg_, events: recv, edge: None }
     }
 }

--- a/chain/network/src/peer/tests/communication.rs
+++ b/chain/network/src/peer/tests/communication.rs
@@ -59,8 +59,8 @@ async fn test_peer_communication(
 
     tracing::info!(target:"test","ReponseUpdateNonce");
     let mut events = inbound.events.from_now();
-    let a = data::make_signer(&mut rng);
-    let b = data::make_signer(&mut rng);
+    let a = data::make_secret_key(&mut rng);
+    let b = data::make_secret_key(&mut rng);
     let want = PeerMessage::ResponseUpdateNonce(data::make_edge(&a, &b));
     outbound.send(want.clone()).await;
     events.recv_until(message_processed(want)).await;

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -67,7 +67,7 @@ impl Drop for Runtime {
         let thread = self.thread.take().unwrap();
         // Await for the thread to stop, unless it is the current thread
         // (i.e. nobody waits for it).
-        if std::thread::current().id()!=thread.thread().id() {
+        if std::thread::current().id() != thread.thread().id() {
             thread.join().unwrap();
         }
     }

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -450,6 +450,8 @@ impl NetworkState {
                 _ => {}
             }
         }
-        futures_util::future::join_all(tasks).await;
+        for t in tasks {
+            let _ = t.await;
+        }
     }
 }

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -167,7 +167,7 @@ impl NetworkState {
         if let Some(edge) = self.routing_table_view.get_local_edge(&peer_id) {
             if edge.edge_type() == EdgeState::Active {
                 let edge_update = edge.remove_edge(self.config.node_id(), &self.config.node_key);
-                self.add_verified_edges_to_routing_table(clock, vec![edge_update.clone()]); 
+                self.add_verified_edges_to_routing_table(clock, vec![edge_update.clone()]);
             }
         }
 
@@ -287,7 +287,11 @@ impl NetworkState {
         }
     }
 
-    pub fn add_verified_edges_to_routing_table(self: &Arc<Self>, clock: &time::Clock, edges: Vec<Edge>) { 
+    pub fn add_verified_edges_to_routing_table(
+        self: &Arc<Self>,
+        clock: &time::Clock,
+        edges: Vec<Edge>,
+    ) {
         if edges.is_empty() {
             return;
         }
@@ -295,10 +299,11 @@ impl NetworkState {
         let this = self.clone();
         let clock = clock.clone();
         self.arbiter.spawn(async move {
-            match this.routing_table_addr.send(
-                routing::actor::Message::AddVerifiedEdges { edges }
-                .with_span_context(),
-            ).await {
+            match this
+                .routing_table_addr
+                .send(routing::actor::Message::AddVerifiedEdges { edges }.with_span_context())
+                .await
+            {
                 Ok(routing::actor::Response::AddVerifiedEdgesResponse(mut edges)) => {
                     // Don't send tombstones during the initial time.
                     // Most of the network is created during this time, which results
@@ -399,7 +404,7 @@ impl NetworkState {
                         // Peer is still not connected after waiting a timeout.
                         let new_edge =
                             edge.remove_edge(this.config.node_id(), &this.config.node_key);
-                        this.add_verified_edges_to_routing_table(&clock, vec![new_edge.clone()]); 
+                        this.add_verified_edges_to_routing_table(&clock, vec![new_edge.clone()]);
                     });
                 }
                 // OK

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -64,7 +64,12 @@ impl Runtime {
 impl Drop for Runtime {
     fn drop(&mut self) {
         self.stop.notify_one();
-        self.thread.take().unwrap().join().unwrap();
+        let thread = self.thread.take().unwrap();
+        // Await for the thread to stop, unless it is the current thread
+        // (i.e. nobody waits for it).
+        if std::thread::current().id()!=thread.thread().id() {
+            thread.join().unwrap();
+        }
     }
 }
 

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -40,7 +40,7 @@ use rand::seq::IteratorRandom;
 use rand::thread_rng;
 use rand::Rng;
 use std::cmp::min;
-use std::collections::{HashSet};
+use std::collections::HashSet;
 use std::net::SocketAddr;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -227,10 +227,7 @@ impl Actor for PeerManagerActor {
         }));
 
         // Periodically reads valid edges from `EdgesVerifierActor` and broadcast.
-        self.broadcast_validated_edges_trigger(
-            ctx,
-            BROADCAST_VALIDATED_EDGES_INTERVAL,
-        );
+        self.broadcast_validated_edges_trigger(ctx, BROADCAST_VALIDATED_EDGES_INTERVAL);
 
         // Periodically updates routing table and prune edges that are no longer reachable.
         self.update_routing_table_trigger(ctx, UPDATE_ROUTING_TABLE_INTERVAL);
@@ -421,7 +418,7 @@ impl PeerManagerActor {
                 break;
             }
         }
-        self.state.add_verified_edges_to_routing_table(&self.clock,new_edges); 
+        self.state.add_verified_edges_to_routing_table(&self.clock, new_edges);
 
         near_performance_metrics::actix::run_later(
             ctx,
@@ -1150,7 +1147,8 @@ impl PeerManagerActor {
                         edge_info.signature,
                     );
 
-                    self.state.add_verified_edges_to_routing_table(&self.clock, vec![new_edge.clone()]);
+                    self.state
+                        .add_verified_edges_to_routing_table(&self.clock, vec![new_edge.clone()]);
                     PeerToManagerMsgResp::EdgeUpdate(Box::new(new_edge))
                 } else {
                     PeerToManagerMsgResp::BanPeer(ReasonForBan::InvalidEdge)
@@ -1159,7 +1157,8 @@ impl PeerManagerActor {
             PeerToManagerMsg::ResponseUpdateNonce(edge) => {
                 if edge.other(&self.my_peer_id).is_some() {
                     if edge.verify() {
-                        self.state.add_verified_edges_to_routing_table(&self.clock, vec![edge.clone()]);
+                        self.state
+                            .add_verified_edges_to_routing_table(&self.clock, vec![edge.clone()]);
                         PeerToManagerMsgResp::Empty
                     } else {
                         PeerToManagerMsgResp::BanPeer(ReasonForBan::InvalidEdge)

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -222,7 +222,7 @@ impl Actor for PeerManagerActor {
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             loop {
                 interval.tick().await;
-                state.fix_local_edges(&clock);
+                state.fix_local_edges(&clock).await;
             }
         }));
 

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -146,6 +146,7 @@ pub enum Event {
     ServerStarted,
     RoutedMessageDropped,
     RoutingTableUpdate { next_hops: Arc<routing::NextHopTable>, pruned_edges: Vec<Edge> },
+    EdgesVerified(Vec<Edge>),
     Ping(Ping),
     Pong(Pong),
     SetChainInfo,

--- a/chain/network/src/peer_manager/testonly.rs
+++ b/chain/network/src/peer_manager/testonly.rs
@@ -2,10 +2,11 @@ use crate::broadcast;
 use crate::config;
 use crate::network_protocol::testonly as data;
 use crate::network_protocol::{
-    Encoding, PeerAddr, PeerInfo, PeerMessage, SignedAccountData, SyncAccountsData,
+    EdgeState, Encoding, PeerAddr, PeerInfo, PeerMessage, SignedAccountData, SyncAccountsData,
 };
 use crate::peer;
 use crate::peer::peer_actor::ClosingReason;
+use crate::peer_manager::network_state::NetworkState;
 use crate::peer_manager::peer_manager_actor::Event as PME;
 use crate::tcp;
 use crate::test_utils;
@@ -17,38 +18,28 @@ use crate::types::{
     PeerManagerMessageResponse, SetChainInfo,
 };
 use crate::PeerManagerActor;
-use near_o11y::{WithSpanContext, WithSpanContextExt};
+use near_o11y::WithSpanContextExt;
 use near_primitives::network::PeerId;
 use near_primitives::types::{AccountId, EpochId};
 use std::collections::HashSet;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 
-#[derive(actix::Message, Debug)]
+#[derive(actix::Message)]
 #[rtype("()")]
-struct CheckConsistency;
+struct WithNetworkState(
+    Box<dyn Send + FnOnce(Arc<NetworkState>) -> Pin<Box<dyn Send + 'static + Future<Output = ()>>>>,
+);
 
-impl actix::Handler<WithSpanContext<CheckConsistency>> for PeerManagerActor {
+impl actix::Handler<WithNetworkState> for PeerManagerActor {
     type Result = ();
-    /// Checks internal consistency of the PeerManagerActor.
-    /// This is a partial implementation, add more invariant checks
-    /// if needed.
-    fn handle(&mut self, _: WithSpanContext<CheckConsistency>, _: &mut actix::Context<Self>) {
-        // Check that the set of ready connections matches the PeerStore state.
-        let tier2: HashSet<_> = self.state.tier2.load().ready.keys().cloned().collect();
-        let store: HashSet<_> = self
-            .state
-            .peer_store
-            .dump()
-            .into_iter()
-            .filter_map(|state| {
-                if state.status == KnownPeerStatus::Connected {
-                    Some(state.peer_info.id)
-                } else {
-                    None
-                }
-            })
-            .collect();
-        assert_eq!(tier2, store);
+    fn handle(
+        &mut self,
+        WithNetworkState(f): WithNetworkState,
+        _: &mut Self::Context,
+    ) -> Self::Result {
+        assert!(actix::Arbiter::current().spawn(f(self.state.clone())));
     }
 }
 
@@ -169,6 +160,21 @@ impl ActorHandler {
             .await;
     }
 
+    pub async fn with_state<R: 'static + Send, Fut: 'static + Send + Future<Output = R>>(
+        &self,
+        f: impl 'static + Send + FnOnce(Arc<NetworkState>) -> Fut,
+    ) -> R {
+        let (send, recv) = tokio::sync::oneshot::channel();
+        self.actix
+            .addr
+            .send(WithNetworkState(Box::new(|s| {
+                Box::pin(async { send.send(f(s).await).ok().unwrap() })
+            })))
+            .await
+            .unwrap();
+        recv.await.unwrap()
+    }
+
     pub async fn start_inbound(
         &self,
         chain: Arc<data::Chain>,
@@ -249,8 +255,46 @@ impl ActorHandler {
         conn
     }
 
+    /// Checks internal consistency of the PeerManagerActor.
+    /// This is a partial implementation, add more invariant checks
+    /// if needed.
     pub async fn check_consistency(&self) {
-        self.actix.addr.send(CheckConsistency.with_span_context()).await.unwrap();
+        self.with_state(|s| async move {
+            // Check that the set of ready connections matches the PeerStore state.
+            let tier2: HashSet<_> = s.tier2.load().ready.keys().cloned().collect();
+            let store: HashSet<_> = s
+                .peer_store
+                .dump()
+                .into_iter()
+                .filter_map(|state| {
+                    if state.status == KnownPeerStatus::Connected {
+                        Some(state.peer_info.id)
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            assert_eq!(tier2, store);
+
+            // Check that the local_edges of the graph match the TIER2 connection pool.
+            let node_id = s.config.node_id();
+            let local_edges: HashSet<_> = s
+                .routing_table_view
+                .get_local_edges()
+                .iter()
+                .filter_map(|e| match e.edge_type() {
+                    EdgeState::Active => Some(e.other(&node_id).unwrap().clone()),
+                    EdgeState::Removed => None,
+                })
+                .collect();
+            assert_eq!(tier2, local_edges);
+        })
+        .await
+    }
+
+    pub async fn fix_local_edges(&self, clock: &time::Clock) {
+        let clock = clock.clone();
+        self.with_state(|s| async move { s.fix_local_edges(&clock).await }).await
     }
 
     pub async fn set_chain_info(&mut self, chain_info: ChainInfo) {

--- a/chain/network/src/peer_manager/testonly.rs
+++ b/chain/network/src/peer_manager/testonly.rs
@@ -162,7 +162,7 @@ impl ActorHandler {
                     Some(())
                 }
                 Event::PeerManager(PME::ConnectionClosed(ev)) if ev.stream_id == stream_id => {
-                    panic!("PeerManager accepted the handshake")
+                    panic!("PeerManager rejected the handshake")
                 }
                 _ => None,
             })

--- a/chain/network/src/peer_manager/tests/accounts_data.rs
+++ b/chain/network/src/peer_manager/tests/accounts_data.rs
@@ -172,16 +172,15 @@ async fn accounts_data_gradual_epoch_change() {
 #[tokio::test(flavor = "multi_thread")]
 async fn accounts_data_rate_limiting() {
     init_test_logger();
-    /* Each actix arbiter (in fact, the underlying tokio runtime) creates 4 file descriptors:
-     * 1. eventfd2()
-     * 2. epoll_create1()
-     * 3. fcntl() duplicating one end of some globally shared socketpair()
-     * 4. fcntl() duplicating epoll socket created in (2)
-     * This gives 5 file descriptors per PeerActor (4 + 1 TCP socket).
-     * PeerManager (together with the whole ActixSystem) creates 13 file descriptors.
-     * The usual default soft limit on the number of file descriptors on linux is 1024.
-     * Here we adjust it appropriately to account for test requirements.
-     */
+    // Each actix arbiter (in fact, the underlying tokio runtime) creates 4 file descriptors:
+    // 1. eventfd2()
+    // 2. epoll_create1()
+    // 3. fcntl() duplicating one end of some globally shared socketpair()
+    // 4. fcntl() duplicating epoll socket created in (2)
+    // This gives 5 file descriptors per PeerActor (4 + 1 TCP socket).
+    // PeerManager (together with the whole ActixSystem) creates 13 file descriptors.
+    // The usual default soft limit on the number of file descriptors on linux is 1024.
+    // Here we adjust it appropriately to account for test requirements.
     let limit = rlimit::Resource::NOFILE.get().unwrap();
     rlimit::Resource::NOFILE.set(std::cmp::min(limit.1, 3000), limit.1).unwrap();
 

--- a/chain/network/src/peer_manager/tests/routing.rs
+++ b/chain/network/src/peer_manager/tests/routing.rs
@@ -170,8 +170,6 @@ async fn wait_for_edges(peer: &mut peer::testonly::PeerHandle, want: &HashSet<Ed
                 PeerMessage::SyncRoutingTable(msg),
             )) => {
                 got.extend(msg.edges);
-                tracing::debug!(target:"dupa", "got = {:?}",got.iter().map(|e|e.hash()).collect::<Vec<_>>());
-                tracing::debug!(target:"dupa", "want = {:?}",want.iter().map(|e|e.hash()).collect::<Vec<_>>());
                 assert!(want.is_superset(&got));
             }
             // Ignore other messages.

--- a/chain/network/src/routing/routing_table_view.rs
+++ b/chain/network/src/routing/routing_table_view.rs
@@ -57,12 +57,6 @@ impl Inner {
         self.route_back.remove(clock, &hash)
     }
 
-    /// Checks whenever edge is newer than the one we already have.
-    /// Works only for local edges.
-    fn is_local_edge_newer(&self, other_peer: &PeerId, nonce: u64) -> bool {
-        self.local_edges.get(other_peer).map_or(0, |x| x.nonce()) < nonce
-    }
-
     /// Get AnnounceAccount for the given AccountId.
     fn get_announce(&mut self, account_id: &AccountId) -> Option<AnnounceAccount> {
         if let Some(announce_account) = self.account_peers.get(account_id) {
@@ -110,12 +104,6 @@ impl RoutingTableView {
             }
         }
         inner.next_hops = next_hops;
-    }
-
-    /// Checks whenever edge is newer than the one we already have.
-    /// Works only for local edges.
-    pub(crate) fn is_local_edge_newer(&self, other_peer: &PeerId, nonce: u64) -> bool {
-        self.0.lock().is_local_edge_newer(other_peer, nonce)
     }
 
     pub(crate) fn reachable_peers(&self) -> usize {

--- a/chain/network/src/routing/routing_table_view.rs
+++ b/chain/network/src/routing/routing_table_view.rs
@@ -208,6 +208,10 @@ impl RoutingTableView {
         self.0.lock().local_edges.get(other_peer).cloned()
     }
 
+    pub(crate) fn get_local_edges(&self) -> Vec<Edge> {
+        self.0.lock().local_edges.values().cloned().collect()
+    }
+
     /// Returns the diff: new local edges added.
     pub(crate) fn add_local_edges(&self, edges: &[Edge]) -> Vec<Edge> {
         let mut inner = self.0.lock();

--- a/chain/network/src/store/schema/tests.rs
+++ b/chain/network/src/store/schema/tests.rs
@@ -6,8 +6,8 @@ use crate::testonly::make_rng;
 fn borsh_wrapper_is_transparent() {
     let mut rng = make_rng(423423);
     let rng = &mut rng;
-    let s1 = data::make_signer(rng);
-    let s2 = data::make_signer(rng);
+    let s1 = data::make_secret_key(rng);
+    let s2 = data::make_secret_key(rng);
     let e = data::make_edge(&s1, &s2);
     assert_eq!(Borsh(e.clone()).try_to_vec().unwrap(), e.try_to_vec().unwrap());
 }

--- a/chain/network/src/time.rs
+++ b/chain/network/src/time.rs
@@ -85,10 +85,19 @@ impl Clock {
         }
     }
 
+    /// Cancellable.
     pub async fn sleep_until(&self, t: Instant) {
         match &self.0 {
             ClockInner::Real => tokio::time::sleep_until(t.into_inner().into()).await,
             ClockInner::Fake(fake) => fake.advance_until(t),
+        }
+    }
+
+    /// Cancellable.
+    pub async fn sleep(&self, d: Duration) {
+        match &self.0 {
+            ClockInner::Real => tokio::time::sleep(d.try_into().unwrap()).await,
+            ClockInner::Fake(fake) => fake.advance(d),
         }
     }
 }


### PR DESCRIPTION
Instead of triggering a fixing call when the unexpected edge arrives, the consistency between the graph and actual connection set will be checked periodically. This way it is straightforward to see that we will always eventually arrive at a consistent state.