### PR TITLE
fix: use new database version for flat state

### DIFF
--- a/core/store/src/metadata.rs
+++ b/core/store/src/metadata.rs
@@ -4,7 +4,8 @@ use crate::{DBCol, NodeStorage, Temperature};
 pub type DbVersion = u32;
 
 /// Current version of the database.
-pub const DB_VERSION: DbVersion = 34;
+pub const DB_VERSION: DbVersion =
+    if cfg!(feature = "protocol_feature_flat_state") { 35 } else { 34 };
 
 /// Database version at which point DbKind was introduced.
 const DB_VERSION_WITH_KIND: DbVersion = 34;

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -157,6 +157,10 @@ impl<'a> near_store::StoreMigrator for Migrator<'a> {
             33 => {
                 near_store::migrations::migrate_33_to_34(storage, self.config.client_config.archive)
             }
+            #[cfg(feature = "protocol_feature_flat_state")]
+            34 => {
+                panic!("Trying to use a DB that has no been migrated to flat state. This binary does not support migrating.")
+            }
             DB_VERSION.. => unreachable!(),
         }
     }


### PR DESCRIPTION
When flat state is used, the database should be upgraded.

The migration code is not stable enough, yet to merge but
we already want to run the master code on migrated databases.