### PR TITLE
feat: trie storage for parallel reads

### DIFF
--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -647,6 +647,7 @@ pub struct TrieDBStorage {
 }
 
 impl TrieDBStorage {
+    #[allow(unused)]
     pub fn new(store: Store, shard_uid: ShardUId) -> Self {
         Self { store, shard_uid }
     }

--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -640,7 +640,10 @@ impl TrieCachingStorage {
     }
 }
 
-/// Storage for reading State nodes and values from DB.
+/// Storage for reading State nodes and values directly from DB.
+///
+/// This `TrieStorage` implementation has no caches, it just goes to DB.
+/// It is useful for background tasks that should not affect chunk processing and block each other.
 pub struct TrieDBStorage {
     pub(crate) store: Store,
     pub(crate) shard_uid: ShardUId,

--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -366,6 +366,7 @@ impl TrieStorage for TrieMemoryPartialStorage {
     }
 }
 
+/// Storage for reading State nodes and values from DB which caches reads.
 pub struct TrieCachingStorage {
     pub(crate) store: Store,
     pub(crate) shard_uid: ShardUId,
@@ -639,18 +640,19 @@ impl TrieCachingStorage {
     }
 }
 
-pub struct TrieDiskStorage {
+/// Storage for reading State nodes and values from DB.
+pub struct TrieDBStorage {
     pub(crate) store: Store,
     pub(crate) shard_uid: ShardUId,
 }
 
-impl TrieDiskStorage {
+impl TrieDBStorage {
     pub fn new(store: Store, shard_uid: ShardUId) -> Self {
         Self { store, shard_uid }
     }
 }
 
-impl TrieStorage for TrieDiskStorage {
+impl TrieStorage for TrieDBStorage {
     fn retrieve_raw_bytes(&self, hash: &CryptoHash) -> Result<Arc<[u8]>, StorageError> {
         read_node_from_db(&self.store, self.shard_uid, hash)
     }

--- a/core/store/src/trie/trie_tests.rs
+++ b/core/store/src/trie/trie_tests.rs
@@ -201,7 +201,7 @@ mod nodes_counter_tests {
 mod trie_storage_tests {
     use super::*;
     use crate::test_utils::{create_test_store, create_tries};
-    use crate::trie::trie_storage::{TrieCache, TrieCachingStorage, TrieDiskStorage};
+    use crate::trie::trie_storage::{TrieCache, TrieCachingStorage, TrieDBStorage};
     use crate::trie::TrieRefcountChange;
     use crate::{Store, TrieChanges, TrieConfig};
     use assert_matches::assert_matches;
@@ -227,16 +227,16 @@ mod trie_storage_tests {
 
     /// Put item into storage. Check that it is retrieved correctly.
     #[test]
-    fn test_retrieve_disk() {
+    fn test_retrieve_db() {
         let value = vec![1u8];
         let values = vec![value.clone()];
         let shard_uid = ShardUId::single_shard();
         let store = create_store_with_values(&values, shard_uid);
-        let trie_disk_storage = TrieDiskStorage::new(store, shard_uid);
+        let trie_db_storage = TrieDBStorage::new(store, shard_uid);
         let key = hash(&value);
-        assert_eq!(trie_disk_storage.retrieve_raw_bytes(&key).unwrap().as_ref(), value);
+        assert_eq!(trie_db_storage.retrieve_raw_bytes(&key).unwrap().as_ref(), value);
         let wrong_key = hash(&vec![2]);
-        assert_matches!(trie_disk_storage.retrieve_raw_bytes(&wrong_key), Err(_));
+        assert_matches!(trie_db_storage.retrieve_raw_bytes(&wrong_key), Err(_));
     }
 
     /// Put item into storage. Check that getting it from cache returns the correct value.


### PR DESCRIPTION
To create flat storage, we will need to do many parallel unique reads from disk. We don't want to reuse `TrieCachingStorage` there because it uses shared trie cache, which is bad due to two reasons:
* it would affect chunk processing, which must remain on the same speed
* parallel threads may block each other, while having the same cache is useless for them. 

Instead, we implement simple `TrieDBStorage` for reading state data from DB directly.

It will be used in the following PR.

## Testing

* `test_retrieve_db`