### PR TITLE
chore: upgrade rust-version to 1.65.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,4 +238,4 @@ opt-level = 3
 [workspace.package]
 edition = "2021"
 authors = ["Near Inc <hello@nearprotocol.com>"]
-rust-version = "1.64.0"
+rust-version = "1.65.0"

--- a/runtime/near-test-contracts/Cargo.toml
+++ b/runtime/near-test-contracts/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 publish = false
 authors = ["Near Inc <hello@nearprotocol.com>"]
 # Please update rust-toolchain.toml as well when changing version here:
-rust-version = "1.64.0"
+rust-version = "1.65.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/runtime/near-test-contracts/contract-for-fuzzing-rs/Cargo.toml
+++ b/runtime/near-test-contracts/contract-for-fuzzing-rs/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 publish = false
 # Please update rust-toolchain.toml as well when changing version here:
-rust-version = "1.64.0"
+rust-version = "1.65.0"
 edition = "2018"
 
 [lib]

--- a/runtime/near-test-contracts/estimator-contract/Cargo.toml
+++ b/runtime/near-test-contracts/estimator-contract/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 publish = false
 # Please update rust-toolchain.toml as well when changing version here:
-rust-version = "1.64.0"
+rust-version = "1.65.0"
 edition = "2021"
 
 [lib]

--- a/runtime/near-test-contracts/test-contract-rs/Cargo.toml
+++ b/runtime/near-test-contracts/test-contract-rs/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 publish = false
 # Please update rust-toolchain.toml as well when changing version here:
-rust-version = "1.64.0"
+rust-version = "1.65.0"
 edition = "2021"
 
 [lib]

--- a/runtime/runtime-params-estimator/emu-cost/Dockerfile
+++ b/runtime/runtime-params-estimator/emu-cost/Dockerfile
@@ -1,5 +1,5 @@
 # our local base image
-FROM rust:1.64.0
+FROM rust:1.65.0
 
 LABEL description="Container for builds"
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,6 +2,6 @@
 # This specifies the version of Rust we use to build.
 # Individual crates in the workspace may support a lower version, as indicated by `rust-version` field in each crate's `Cargo.toml`.
 # The version specified below, should be at least as high as the maximum `rust-version` within the workspace.
-channel = "1.64.0"
+channel = "1.65.0"
 components = [ "rustfmt" ]
 targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
- GATs are finally here! I'd be surprised if we cannot make use of it.
- stabilized `std::backtrace::Backtrace`, we should see if we can remove
the `backtrace` dependency
- let else statements are now a thing