### PR TITLE
refactor: simplify `split_method_names` in vm Logic

### DIFF
--- a/runtime/near-vm-logic/src/utils.rs
+++ b/runtime/near-vm-logic/src/utils.rs
@@ -1,26 +1,16 @@
-use near_vm_errors::{HostError, VMLogicError};
-
-type Result<T> = ::std::result::Result<T, VMLogicError>;
+use near_vm_errors::HostError;
 
 /// Uses `,` separator to split `method_names` into a vector of method names.
 /// Returns an empty vec if the empty slice is given.
 /// Throws `HostError::EmptyMethodName` in case there is an empty method name inside.
-pub(crate) fn split_method_names(method_names: &[u8]) -> Result<Vec<Vec<u8>>> {
+pub(crate) fn split_method_names(method_names: &[u8]) -> Result<Vec<Vec<u8>>, HostError> {
     if method_names.is_empty() {
         Ok(vec![])
     } else {
         method_names
             .split(|c| *c == b',')
-            .map(
-                |v| {
-                    if v.is_empty() {
-                        Err(HostError::EmptyMethodName.into())
-                    } else {
-                        Ok(v.to_vec())
-                    }
-                },
-            )
-            .collect::<Result<Vec<_>>>()
+            .map(|v| if v.is_empty() { Err(HostError::EmptyMethodName) } else { Ok(v.to_vec()) })
+            .collect()
     }
 }
 
@@ -48,33 +38,21 @@ mod tests {
 
     #[test]
     fn test_split_empty_method_name_inside() {
-        assert_eq!(
-            split_method_names(b"hello,,world"),
-            Err(VMLogicError::HostError(HostError::EmptyMethodName))
-        );
+        assert_eq!(split_method_names(b"hello,,world"), Err(HostError::EmptyMethodName));
     }
 
     #[test]
     fn test_split_empty_method_name_front() {
-        assert_eq!(
-            split_method_names(b",world"),
-            Err(VMLogicError::HostError(HostError::EmptyMethodName))
-        );
+        assert_eq!(split_method_names(b",world"), Err(HostError::EmptyMethodName));
     }
 
     #[test]
     fn test_split_empty_method_name_back() {
-        assert_eq!(
-            split_method_names(b"world,"),
-            Err(VMLogicError::HostError(HostError::EmptyMethodName))
-        );
+        assert_eq!(split_method_names(b"world,"), Err(HostError::EmptyMethodName));
     }
 
     #[test]
     fn test_split_empty_method_name_comma_only() {
-        assert_eq!(
-            split_method_names(b","),
-            Err(VMLogicError::HostError(HostError::EmptyMethodName))
-        );
+        assert_eq!(split_method_names(b","), Err(HostError::EmptyMethodName));
     }
 }


### PR DESCRIPTION
This also makes us to rely less on VMLogicError: Eq