### PR TITLE
refactor: simplify synchronization for next hops table

### DIFF
--- a/chain/network/src/routing/graph_with_cache.rs
+++ b/chain/network/src/routing/graph_with_cache.rs
@@ -3,7 +3,7 @@ use crate::routing;
 use crate::stats::metrics;
 use crate::time;
 use near_primitives::network::PeerId;
-use parking_lot::Mutex;
+use once_cell::sync::OnceCell;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tracing::trace;
@@ -22,7 +22,7 @@ pub struct GraphWithCache {
     edges: HashMap<EdgeKey, Edge>,
     /// Peers of this node, which are on any shortest path to the given node.
     /// Derived from graph.
-    cached_next_hops: Mutex<Option<Arc<NextHopTable>>>,
+    cached_next_hops: OnceCell<Arc<NextHopTable>>,
     // Don't allow edges that are before this time (if set)
     prune_edges_before: Option<time::Utc>,
 }
@@ -32,7 +32,7 @@ impl GraphWithCache {
         Self {
             graph: routing::Graph::new(my_peer_id),
             edges: Default::default(),
-            cached_next_hops: Default::default(),
+            cached_next_hops: OnceCell::new(),
             prune_edges_before: None,
         }
     }
@@ -55,7 +55,7 @@ impl GraphWithCache {
     pub fn set_unreliable_peers(&mut self, unreliable_peers: HashSet<PeerId>) {
         self.graph.set_unreliable_peers(unreliable_peers);
         // Invalidate cache.
-        *self.cached_next_hops.lock() = None;
+        self.cached_next_hops = OnceCell::new();
     }
 
     /// Adds an edge without validating the signatures. O(1).
@@ -79,7 +79,7 @@ impl GraphWithCache {
         }
         self.edges.insert(key.clone(), edge);
         // Invalidate cache.
-        *self.cached_next_hops.lock() = None;
+        self.cached_next_hops = OnceCell::new();
         true
     }
 
@@ -104,14 +104,14 @@ impl GraphWithCache {
             }
         }
         if removed {
-            *self.cached_next_hops.lock() = None;
+            self.cached_next_hops = OnceCell::new();
         }
     }
 
     /// Computes the next hops table, based on the graph. O(|Graph|).
     pub fn next_hops(&self) -> Arc<NextHopTable> {
-        if let Some(rt) = self.cached_next_hops.lock().clone() {
-            return rt;
+        if let Some(rt) = self.cached_next_hops.get() {
+            return Arc::clone(rt);
         }
         let _d = delay_detector::DelayDetector::new(|| "routing table update".into());
         let _next_hops_recalculation = metrics::ROUTING_TABLE_RECALCULATION_HISTOGRAM.start_timer();
@@ -119,7 +119,7 @@ impl GraphWithCache {
         let rt = Arc::new(self.graph.calculate_distance());
         metrics::ROUTING_TABLE_RECALCULATIONS.inc();
         metrics::PEER_REACHABLE.set(rt.len() as i64);
-        *self.cached_next_hops.lock() = Some(rt.clone());
+        self.cached_next_hops.set(rt.clone());
         rt
     }
 


### PR DESCRIPTION
The primary goal here was to get rid of `.lock()` on code paths where we
had `&mut` already. But I've noticed that we can simplify
synchronization here in general? We don't need a mutex, once cell is
enough.

In the old code, if two threads race to compute the table, they'll both
burn CPU to do that. With this patch, only one thread will be doing
computation, while the others would sleep.

In other words, if we get a thundering herd on `cached_next_hop`, only
one thread will do the work.
