### PR TITLE
feat: Track requested state parts

### DIFF
--- a/chain/chain/src/lib.rs
+++ b/chain/chain/src/lib.rs
@@ -19,6 +19,7 @@ mod lightclient;
 mod metrics;
 pub mod migrations;
 pub mod missing_chunks;
+mod state_request_tracker;
 mod store;
 pub mod store_validator;
 pub mod test_utils;

--- a/chain/chain/src/state_request_tracker.rs
+++ b/chain/chain/src/state_request_tracker.rs
@@ -1,0 +1,62 @@
+use crate::Chain;
+use lru::LruCache;
+use near_primitives::{
+    hash::CryptoHash,
+    types::ShardId,
+    views::{PartElapsedTimeView, RequestedStatePartsView},
+};
+use std::collections::HashMap;
+
+const REQUESTED_STATE_PARTS_CACHE_SIZE: usize = 4;
+
+//Track the state parts that are already requested for debugging
+//This struct provides methods to save and retrieve the information
+//along with time elapsed to create state part.
+//See https://github.com/near/nearcore/issues/7991 for more details
+#[derive(Debug)]
+pub(crate) struct StateRequestTracker {
+    requested_state_parts: LruCache<CryptoHash, HashMap<ShardId, Vec<PartElapsedTimeView>>>,
+}
+
+impl StateRequestTracker {
+    pub(crate) fn new() -> Self {
+        StateRequestTracker {
+            requested_state_parts: LruCache::new(REQUESTED_STATE_PARTS_CACHE_SIZE),
+        }
+    }
+
+    pub(crate) fn save_state_part_elapsed(
+        &mut self,
+        crypto_hash: &CryptoHash,
+        shard_id: &ShardId,
+        part_id: &u64,
+        elapsed_ms: u128,
+    ) {
+        self.requested_state_parts.get_or_insert(crypto_hash.clone(), || HashMap::new());
+        let parts_per_shard = self.requested_state_parts.get_mut(crypto_hash).unwrap();
+        let elapsed = parts_per_shard.entry(shard_id.clone()).or_insert_with(|| vec![]);
+        elapsed.push(PartElapsedTimeView::new(part_id, elapsed_ms));
+    }
+}
+
+impl Chain {
+    pub fn get_requested_state_parts(&self) -> Vec<RequestedStatePartsView> {
+        let result: Vec<RequestedStatePartsView> = self
+            .requested_state_parts
+            .requested_state_parts
+            .iter()
+            .map(|(crypto_hash, parts_per_shard)| {
+                let parts_per_shard_copy: HashMap<ShardId, Vec<PartElapsedTimeView>> =
+                    parts_per_shard
+                        .iter()
+                        .map(|(shard_id, part_elapsed)| (shard_id.clone(), part_elapsed.clone()))
+                        .collect();
+                RequestedStatePartsView {
+                    block_hash: crypto_hash.clone(),
+                    shard_requested_parts: parts_per_shard_copy,
+                }
+            })
+            .collect();
+        return result;
+    }
+}

--- a/chain/client-primitives/src/debug.rs
+++ b/chain/client-primitives/src/debug.rs
@@ -7,7 +7,8 @@ use crate::types::StatusError;
 use actix::Message;
 use chrono::DateTime;
 use near_primitives::views::{
-    CatchupStatusView, ChainProcessingInfo, EpochValidatorInfo, SyncStatusView,
+    CatchupStatusView, ChainProcessingInfo, EpochValidatorInfo, RequestedStatePartsView,
+    SyncStatusView,
 };
 use near_primitives::{
     block_header::ApprovalInner,
@@ -182,6 +183,8 @@ pub enum DebugStatus {
     CatchupStatus,
     // Request for the current state of chain processing (blocks in progress etc).
     ChainProcessingStatus,
+    // The state parts already requested.
+    RequestedStateParts,
 }
 
 impl Message for DebugStatus {
@@ -201,4 +204,6 @@ pub enum DebugStatusResponse {
     ValidatorStatus(ValidatorStatus),
     // Detailed information about chain processing (blocks in progress etc).
     ChainProcessingStatus(ChainProcessingInfo),
+    // The state parts already requested.
+    RequestedStateParts(Vec<RequestedStatePartsView>),
 }

--- a/chain/client/src/debug.rs
+++ b/chain/client/src/debug.rs
@@ -172,6 +172,9 @@ impl Handler<WithSpanContext<DebugStatus>> for ClientActor {
             DebugStatus::CatchupStatus => {
                 Ok(DebugStatusResponse::CatchupStatus(self.client.get_catchup_status()?))
             }
+            DebugStatus::RequestedStateParts => Ok(DebugStatusResponse::RequestedStateParts(
+                self.client.chain.get_requested_state_parts(),
+            )),
             DebugStatus::ChainProcessingStatus => Ok(DebugStatusResponse::ChainProcessingStatus(
                 self.client.chain.get_chain_processing_info(),
             )),

--- a/chain/jsonrpc-primitives/src/types/status.rs
+++ b/chain/jsonrpc-primitives/src/types/status.rs
@@ -2,7 +2,7 @@ use near_client_primitives::debug::{
     DebugBlockStatusData, EpochInfoView, TrackedShardsView, ValidatorStatus,
 };
 use near_primitives::views::{
-    CatchupStatusView, ChainProcessingInfo, PeerStoreView, SyncStatusView,
+    CatchupStatusView, ChainProcessingInfo, PeerStoreView, RequestedStatePartsView, SyncStatusView,
 };
 use serde::{Deserialize, Serialize};
 
@@ -25,6 +25,8 @@ pub enum DebugStatusResponse {
     ValidatorStatus(ValidatorStatus),
     PeerStore(PeerStoreView),
     ChainProcessingStatus(ChainProcessingInfo),
+    // The state parts already requested.
+    RequestedStateParts(Vec<RequestedStatePartsView>),
 }
 
 #[cfg(feature = "debug_types")]

--- a/chain/jsonrpc/src/api/status.rs
+++ b/chain/jsonrpc/src/api/status.rs
@@ -29,6 +29,9 @@ impl RpcFrom<near_client_primitives::debug::DebugStatusResponse>
             near_client_primitives::debug::DebugStatusResponse::CatchupStatus(x) => {
                 near_jsonrpc_primitives::types::status::DebugStatusResponse::CatchupStatus(x)
             }
+            near_client_primitives::debug::DebugStatusResponse::RequestedStateParts(x) => {
+                near_jsonrpc_primitives::types::status::DebugStatusResponse::RequestedStateParts(x)
+            }
             near_client_primitives::debug::DebugStatusResponse::TrackedShards(x) => {
                 near_jsonrpc_primitives::types::status::DebugStatusResponse::TrackedShards(x)
             }

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -789,6 +789,9 @@ impl JsonRpcHandler {
                     "/debug/api/chain_processing_status" => {
                         self.client_send(DebugStatus::ChainProcessingStatus).await?.rpc_into()
                     }
+                    "/debug/api/requested_state_parts" => {
+                        self.client_send(DebugStatus::RequestedStateParts).await?.rpc_into()
+                    }
                     "/debug/api/peer_store" => self
                         .peer_manager_send(near_network::debug::GetDebugStatus::PeerStore)
                         .await?

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -415,6 +415,14 @@ pub struct CatchupStatusView {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct RequestedStatePartsView {
+    // This is the first block of the epoch that was requested
+    pub block_hash: CryptoHash,
+    // All the part ids of the shards that were requested
+    pub shard_requested_parts: HashMap<ShardId, Vec<PartElapsedTimeView>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct BlockStatusView {
     pub height: BlockHeight,
     pub hash: CryptoHash,
@@ -429,6 +437,18 @@ impl BlockStatusView {
 impl From<Tip> for BlockStatusView {
     fn from(tip: Tip) -> Self {
         Self { height: tip.height, hash: tip.last_block_hash }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub struct PartElapsedTimeView {
+    pub part_id: u64,
+    pub elapsed_ms: u128,
+}
+
+impl PartElapsedTimeView {
+    pub fn new(part_id: &u64, elapsed_ms: u128) -> PartElapsedTimeView {
+        Self { part_id: part_id.clone(), elapsed_ms }
     }
 }
 


### PR DESCRIPTION
This changes stores the State and parts that were already requested with the elapsed time to create the state part.
Closes #7991 