### PR TITLE
crypto: remove unnecessary use of arrayref dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3012,7 +3012,6 @@ dependencies = [
 name = "near-crypto"
 version = "0.0.0"
 dependencies = [
- "arrayref",
  "blake2",
  "borsh",
  "bs58",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,6 @@ ansi_term = "0.12"
 anyhow = "1.0.62"
 arbitrary = { version = "1", features = ["derive"] }
 arc-swap = "1.5"
-arrayref = "0.3"
 assert_matches = "1.5.0"
 async-recursion = "0.3.2"
 async-trait = "0.1.58"

--- a/core/crypto/Cargo.toml
+++ b/core/crypto/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/near/nearcore"
 description = "This is an internal crate for common cryptographic types"
 
 [dependencies]
-arrayref.workspace = true
 blake2.workspace = true
 borsh.workspace = true
 bs58.workspace = true

--- a/core/crypto/src/hash.rs
+++ b/core/crypto/src/hash.rs
@@ -1,5 +1,4 @@
 use crate::util::{Packable, Point, Scalar};
-use arrayref::array_ref;
 use blake2::digest::generic_array::{typenum::U32, GenericArray};
 use blake2::digest::{BlockInput, FixedOutput, Reset, Update, VariableOutput};
 use blake2::VarBlake2b;
@@ -112,7 +111,7 @@ macro_rules! hash_s {
 
 pub fn _prs_result(digest: Hash512) -> Scalar {
     let res = digest.finalize_fixed();
-    Scalar::from_bytes_mod_order_wide(array_ref!(res, 0, 64))
+    Scalar::from_bytes_mod_order_wide((&res[0..64]).try_into().unwrap())
 }
 
 macro_rules! prs {

--- a/core/crypto/src/key_conversion.rs
+++ b/core/crypto/src/key_conversion.rs
@@ -1,5 +1,4 @@
 use crate::{signature, vrf, PublicKey};
-use arrayref::array_ref;
 use curve25519_dalek::edwards::{CompressedEdwardsY, EdwardsPoint};
 use curve25519_dalek::ristretto::RistrettoPoint;
 use curve25519_dalek::scalar::Scalar;
@@ -29,7 +28,7 @@ pub fn convert_secret_key(key: &signature::ED25519SecretKey) -> vrf::SecretKey {
         &ed25519_dalek::SecretKey::from_bytes(&key.0[..32]).unwrap(),
     )
     .to_bytes();
-    vrf::SecretKey::from_scalar(Scalar::from_bytes_mod_order(*array_ref!(&b, 0, 32)))
+    vrf::SecretKey::from_scalar(Scalar::from_bytes_mod_order(b[0..32].try_into().unwrap()))
 }
 
 #[cfg(test)]

--- a/core/crypto/src/util.rs
+++ b/core/crypto/src/util.rs
@@ -1,4 +1,3 @@
-use arrayref::{array_refs, mut_array_refs};
 use curve25519_dalek::ristretto::CompressedRistretto;
 use curve25519_dalek::traits::VartimeMultiscalarMul;
 
@@ -59,15 +58,17 @@ impl<T1: Packable<Packed = [u8; 32]>, T2: Packable<Packed = [u8; 32]>> Packable 
     type Packed = [u8; 64];
 
     fn unpack(data: &[u8; 64]) -> Option<Self> {
-        let (d1, d2) = array_refs!(data, 32, 32);
-        Some((unpack(d1)?, unpack(d2)?))
+        // TODO(mina86): Use split_array_ref once stabilised.
+        let d1 = unpack((&data[..32]).try_into().unwrap())?;
+        let d2 = unpack((&data[32..]).try_into().unwrap())?;
+        Some((d1, d2))
     }
 
     fn pack(&self) -> [u8; 64] {
         let mut res = [0; 64];
-        let (d1, d2) = mut_array_refs!(&mut res, 32, 32);
-        *d1 = self.0.pack();
-        *d2 = self.1.pack();
+        // TODO(mina86): Use split_array_mut once stabilised.
+        *<&mut [u8; 32]>::try_from(&mut res[..32]).unwrap() = self.0.pack();
+        *<&mut [u8; 32]>::try_from(&mut res[32..]).unwrap() = self.1.pack();
         res
     }
 }
@@ -81,16 +82,19 @@ impl<
     type Packed = [u8; 96];
 
     fn unpack(data: &[u8; 96]) -> Option<Self> {
-        let (d1, d2, d3) = array_refs!(data, 32, 32, 32);
-        Some((unpack(d1)?, unpack(d2)?, unpack(d3)?))
+        // TODO(mina86): Use split_array_ref once stabilised.
+        let d1 = unpack((&data[..32]).try_into().unwrap())?;
+        let d2 = unpack((&data[32..64]).try_into().unwrap())?;
+        let d3 = unpack((&data[64..]).try_into().unwrap())?;
+        Some((d1, d2, d3))
     }
 
     fn pack(&self) -> [u8; 96] {
         let mut res = [0; 96];
-        let (d1, d2, d3) = mut_array_refs!(&mut res, 32, 32, 32);
-        *d1 = self.0.pack();
-        *d2 = self.1.pack();
-        *d3 = self.2.pack();
+        // TODO(mina86): Use split_array_mut once stabilised.
+        *<&mut [u8; 32]>::try_from(&mut res[..32]).unwrap() = self.0.pack();
+        *<&mut [u8; 32]>::try_from(&mut res[32..64]).unwrap() = self.1.pack();
+        *<&mut [u8; 32]>::try_from(&mut res[64..]).unwrap() = self.2.pack();
         res
     }
 }


### PR DESCRIPTION
All of the uses can be replaced by TryFrom/TryInto especially now that
const generics are a thing.  In the future, the code may be further
improved by using split_array_ref which will eliminate the need to try
convert and unwrap as size checking will be done at compile time.
