### PR TITLE
chore: remove backtrace dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3306,7 +3306,6 @@ version = "0.0.0"
 dependencies = [
  "actix",
  "atty",
- "backtrace",
  "bencher",
  "clap 3.1.18",
  "itoa 1.0.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,6 @@ async-recursion = "0.3.2"
 async-trait = "0.1.58"
 atty = "0.2"
 awc = { version = "3", features = ["openssl"] }
-backtrace = "0.3.64"
 base64 = "0.13"
 bencher = "0.1.5"
 bitflags = "1.2"

--- a/core/o11y/Cargo.toml
+++ b/core/o11y/Cargo.toml
@@ -16,7 +16,6 @@ near-primitives-core = { path = "../../core/primitives-core" }
 
 actix.workspace = true
 atty.workspace = true
-backtrace.workspace = true
 clap.workspace = true
 once_cell.workspace = true
 opentelemetry.workspace = true

--- a/core/o11y/src/lib.rs
+++ b/core/o11y/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 
-pub use {backtrace, tracing, tracing_appender, tracing_subscriber};
+pub use {tracing, tracing_appender, tracing_subscriber};
 
 use clap::Parser;
 pub use context::*;
@@ -562,7 +562,7 @@ impl<'a> EnvFilterBuilder<'a> {
 ///
 /// This is intended as a printf-debugging aid.
 pub fn print_backtrace() {
-    let bt = backtrace::Backtrace::new();
+    let bt = std::backtrace::Backtrace::force_capture();
     eprintln!("{bt:?}")
 }
 


### PR DESCRIPTION
the standard library now supports capturing backtraces