### PR TITLE
network: remove PeerManagerActor::config field

### DIFF
--- a/chain/network/src/peer/testonly.rs
+++ b/chain/network/src/peer/testonly.rs
@@ -125,7 +125,7 @@ impl PeerHandle {
                 store.clone(),
                 peer_store::PeerStore::new(&clock, network_cfg.peer_store.clone(), store.clone())
                     .unwrap(),
-                Arc::new(network_cfg.verify().unwrap()),
+                network_cfg.verify().unwrap(),
                 cfg.chain.genesis_id.clone(),
                 fc,
                 vec![],

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -106,7 +106,7 @@ pub(crate) struct NetworkState {
     /// DO NOT spawn actors from a task on this runtime.
     runtime: Runtime,
     /// PeerManager config.
-    pub config: Arc<config::VerifiedConfig>,
+    pub config: config::VerifiedConfig,
     /// When network state has been constructed.
     pub created_at: time::Instant,
     /// GenesisId of the chain.
@@ -155,7 +155,7 @@ impl NetworkState {
         clock: &time::Clock,
         store: store::Store,
         peer_store: peer_store::PeerStore,
-        config: Arc<config::VerifiedConfig>,
+        config: config::VerifiedConfig,
         genesis_id: GenesisId,
         client: Arc<dyn client::Client>,
         whitelist_nodes: Vec<WhitelistNode>,

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -81,10 +81,6 @@ const PREFER_PREVIOUSLY_CONNECTED_PEER: f64 = 0.6;
 /// Actor that manages peers connections.
 pub struct PeerManagerActor {
     pub(crate) clock: time::Clock,
-    /// Networking configuration.
-    /// TODO(gprusak): this field is duplicated with
-    /// NetworkState.config. Remove it from here.
-    config: Arc<config::VerifiedConfig>,
     /// Peer information for this node.
     my_peer_id: PeerId,
     /// Flag that track whether we started attempts to establish outbound connections.
@@ -133,7 +129,7 @@ impl Actor for PeerManagerActor {
 
     fn started(&mut self, ctx: &mut Self::Context) {
         // Start server if address provided.
-        if let Some(server_addr) = self.config.node_addr {
+        if let Some(server_addr) = self.state.config.node_addr {
             debug!(target: "network", at = ?server_addr, "starting public server");
             let clock = self.clock.clone();
             let state = self.state.clone();
@@ -164,14 +160,16 @@ impl Actor for PeerManagerActor {
         }
 
         // Periodically push network information to client.
-        self.push_network_info_trigger(ctx, self.config.push_info_period);
+        self.push_network_info_trigger(ctx, self.state.config.push_info_period);
 
         // Periodically starts peer monitoring.
-        debug!(target: "network", max_period=?self.config.monitor_peers_max_period, "monitor_peers_trigger");
+        debug!(target: "network",
+               max_period=?self.state.config.monitor_peers_max_period,
+               "monitor_peers_trigger");
         self.monitor_peers_trigger(
             ctx,
             MONITOR_PEERS_INITIAL_DURATION,
-            (MONITOR_PEERS_INITIAL_DURATION, self.config.monitor_peers_max_period),
+            (MONITOR_PEERS_INITIAL_DURATION, self.state.config.monitor_peers_max_period),
         );
 
         let state = self.state.clone();
@@ -250,21 +248,18 @@ impl PeerManagerActor {
             }
             v
         };
-        let config = Arc::new(config);
         let arbiter = actix::Arbiter::new().handle();
-        let clock = clock.clone();
         let state = Arc::new(NetworkState::new(
             &clock,
             store.clone(),
             peer_store,
-            config.clone(),
+            config,
             genesis_id,
             client,
             whitelist_nodes,
         ));
         Ok(Self::start_in_arbiter(&arbiter, move |_ctx| Self {
             my_peer_id: my_peer_id.clone(),
-            config: config.clone(),
             started_connect_attempts: false,
             state,
             clock,
@@ -321,10 +316,11 @@ impl PeerManagerActor {
             tier2.ready.values().filter(|peer| peer.peer_type == PeerType::Outbound).count()
                 + tier2.outbound_handshakes.len();
 
-        (total_connections < self.config.ideal_connections_lo as usize
+        (total_connections < self.state.config.ideal_connections_lo as usize
             || (total_connections < self.state.max_num_peers.load(Ordering::Relaxed) as usize
-                && potential_outbound_connections < self.config.minimum_outbound_peers as usize))
-            && !self.config.outbound_disabled
+                && potential_outbound_connections
+                    < self.state.config.minimum_outbound_peers as usize))
+            && !self.state.config.outbound_disabled
     }
 
     /// Returns peers close to the highest height
@@ -341,7 +337,8 @@ impl PeerManagerActor {
         infos
             .into_iter()
             .filter(|i| {
-                i.chain_info.height.saturating_add(self.config.highest_peer_horizon) >= max_height
+                i.chain_info.height.saturating_add(self.state.config.highest_peer_horizon)
+                    >= max_height
             })
             .collect()
     }
@@ -394,22 +391,24 @@ impl PeerManagerActor {
         safe_set.extend(whitelisted_peers);
 
         // If there is not enough non-whitelisted peers, return without disconnecting anyone.
-        if tier2.ready.len() - safe_set.len() <= self.config.ideal_connections_hi as usize {
+        if tier2.ready.len() - safe_set.len() <= self.state.config.ideal_connections_hi as usize {
             return;
         }
 
         // If there is not enough outbound peers, add them to the safe set.
         let outbound_peers = filter_peers(&|p| p.peer_type == PeerType::Outbound);
         if outbound_peers.len() + tier2.outbound_handshakes.len()
-            <= self.config.minimum_outbound_peers as usize
+            <= self.state.config.minimum_outbound_peers as usize
         {
             safe_set.extend(outbound_peers);
         }
 
         // If there is not enough archival peers, add them to the safe set.
-        if self.config.archive {
+        if self.state.config.archive {
             let archival_peers = filter_peers(&|p| p.initial_chain_info.archival);
-            if archival_peers.len() <= self.config.archival_peer_connections_lower_bound as usize {
+            if archival_peers.len()
+                <= self.state.config.archival_peer_connections_lower_bound as usize
+            {
                 safe_set.extend(archival_peers);
             }
         }
@@ -420,7 +419,8 @@ impl PeerManagerActor {
             .ready
             .values()
             .filter(|p| {
-                now - p.last_time_received_message.load() < self.config.peer_recent_time_window
+                now - p.last_time_received_message.load()
+                    < self.state.config.peer_recent_time_window
             })
             .cloned()
             .collect();
@@ -428,7 +428,7 @@ impl PeerManagerActor {
         // Sort by established time.
         active_peers.sort_by_key(|p| p.connection_established_time);
         // Saturate safe set with recently active peers.
-        let set_limit = self.config.safe_set_size as usize;
+        let set_limit = self.state.config.safe_set_size as usize;
         for p in active_peers {
             if safe_set.len() >= set_limit {
                 break;
@@ -441,7 +441,7 @@ impl PeerManagerActor {
         if let Some(p) = candidates.choose(&mut rand::thread_rng()) {
             debug!(target: "network", id = ?p.peer_info.id,
                 tier2_len = tier2.ready.len(),
-                ideal_connections_hi = self.config.ideal_connections_hi,
+                ideal_connections_hi = self.state.config.ideal_connections_hi,
                 "Stop active connection"
             );
             p.stop(None);
@@ -484,7 +484,7 @@ impl PeerManagerActor {
                 |peer_state| {
                     // Ignore connecting to ourself
                     self.my_peer_id == peer_state.peer_info.id
-                    || self.config.node_addr == peer_state.peer_info.addr
+                    || self.state.config.node_addr == peer_state.peer_info.addr
                     // Or to peers we are currently trying to connect to
                     || tier2.outbound_handshakes.contains(&peer_state.peer_info.id)
                 },


### PR DESCRIPTION
PeerManagerActor has access to config via NetworkState so there’s no
reason for the NetworkState::config field.

Once that field is removed, the config doesn’t need to be cloned any
longer which means that it doesn’t need to be wrapped in an Arc when
saved in NetworkState.
