### PR TITLE
contract preparation: actually replace all memories with a single memory import, including imported memories

### DIFF
--- a/runtime/near-vm-runner/src/tests/runtime_errors.rs
+++ b/runtime/near-vm-runner/src/tests/runtime_errors.rs
@@ -54,11 +54,7 @@ fn test_simple_contract() {
 #[test]
 fn test_multiple_memories() {
     test_builder()
-        .wasm(&[
-            0, 97, 115, 109, 1, 0, 0, 0, 2, 12, 1, 3, 101, 110, 118, 0, 2, 1, 239, 1, 248, 1, 4, 6,
-            1, 112, 0, 143, 129, 32, 7, 12, 1, 8, 0, 17, 17, 17, 17, 17, 17, 2, 2, 0,
-        ])
-        // Wasmtime classifies this error as link error at the moment.
+        .wasm(b"\x00\x61\x73\x6d\x01\x00\x00\x00\x05\x07\x02\x01\x01\x02\x01\x03\x04")
         .opaque_error()
         .protocol_features(&[
             #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]

--- a/runtime/near-vm-runner/src/tests/runtime_errors.rs
+++ b/runtime/near-vm-runner/src/tests/runtime_errors.rs
@@ -54,7 +54,13 @@ fn test_simple_contract() {
 #[test]
 fn test_multiple_memories() {
     test_builder()
-        .wasm(b"\x00\x61\x73\x6d\x01\x00\x00\x00\x05\x07\x02\x01\x01\x02\x01\x03\x04")
+        .wasm(concat_bytes!(
+            b"\x00\x61\x73\x6d", // wasm header
+            b"\x01\x00\x00\x00", // version 1
+            b"\x05\x07\x02", // memory section with 2 items totalling 7 bytes
+            b"\x01\x01\x02", // first item
+            b"\x01\x03\x04", // second item
+        ))
         .opaque_error()
         .protocol_features(&[
             #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]


### PR DESCRIPTION
Before this change, our behavior regarding memory items was erratic at best:
- If passed with exactly one module-local memory, we would correctly remove it and replace it with an import
- If passed with more than one module-local memory, we would fail deserialization due to multiple memories being defined, and then ensure_no_internal_memory would be pointless
- If passed with one or many memory imports, they would be left in the prepared code, resulting in two memories being in the output webassembly, that would then fail the second validation

With this change, memory items are just all ignored, and a single memory import with the parameters we defined is added.

The test_multiple_memories test is updated to actually be a (manually-crafted because no tools seem to accept doing it) wasm blob that defines two memories, instead of a wasm blob that defines a memory import and incidentally due to preparation bugs turns out having multiple memories after preparation.

-----

This is a draft PR because it will require a protocol upgrade. However, before doing this boilerplate work, I’d like to put that out here for other people to have a look and check they’d be ok with this in a finalized form.

Fixes #6042