### PR TITLE
feat: set ed25519 verification gas parameters

### DIFF
--- a/core/primitives/res/runtime_configs/parameters.txt
+++ b/core/primitives/res/runtime_configs/parameters.txt
@@ -94,9 +94,8 @@ wasm_keccak512_byte: 36_649_701
 wasm_ripemd160_base: 853_675_086
 wasm_ripemd160_block: 680_107_584
 wasm_ecrecover_base: 3_365_369_625_000
-# both ed25519_verify_base and ed25519_verify_byte have NON-FINAL numbers (needs fine tuning)
-wasm_ed25519_verify_base: 40_311_888_867
-wasm_ed25519_verify_byte: 423_978_605
+wasm_ed25519_verify_base: 210_000_000_000
+wasm_ed25519_verify_byte: 9_000_000
 wasm_log_base: 3_543_313_050
 wasm_log_byte: 13_198_791
 wasm_storage_write_base: 64_196_736_000

--- a/runtime/near-test-contracts/estimator-contract/src/lib.rs
+++ b/runtime/near-test-contracts/estimator-contract/src/lib.rs
@@ -481,7 +481,7 @@ pub unsafe fn ecrecover_10k() {
 /// we are okay overcharging it.
 #[no_mangle]
 #[cfg(feature = "protocol_feature_ed25519_verify")]
-pub unsafe fn ed25519_verify_32b_64() {
+pub unsafe fn ed25519_verify_32b_500() {
     // private key: OReNDSAXOnl-U6Wki95ut01ehQW_9wcAF_utjzRNreg
     // public key: M4QwJx4Sogjr0KcMI_gsvt-lEU6tgd9GWmgejE_JYlA
     let public_key: [u8; 32] = [
@@ -502,7 +502,7 @@ pub unsafe fn ed25519_verify_32b_64() {
         109, 64, 0, 13, 104, 6,
     ];
 
-    for _ in 0..64 {
+    for _ in 0..500 {
         let result = ed25519_verify(
             signature.len() as _,
             signature.as_ptr() as _,

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -932,17 +932,15 @@ fn ecrecover_base(ctx: &mut EstimatorContext) -> GasCost {
 }
 
 #[cfg(feature = "protocol_feature_ed25519_verify")]
-// TODO: gas estimation will be calculated later -> setting a placeholder for
 fn ed25519_verify_base(ctx: &mut EstimatorContext) -> GasCost {
     if ctx.cached.ed25519_verify_base.is_none() {
-        let cost = fn_cost(ctx, "ed25519_verify_32b_64", ExtCosts::ed25519_verify_base, 64);
+        let cost = fn_cost(ctx, "ed25519_verify_32b_500", ExtCosts::ed25519_verify_base, 500);
         ctx.cached.ed25519_verify_base = Some(cost);
     }
     ctx.cached.ed25519_verify_base.clone().unwrap()
 }
 
 #[cfg(feature = "protocol_feature_ed25519_verify")]
-// TODO: gas estimation will be calculated later -> setting a placeholder for now
 fn ed25519_verify_byte(ctx: &mut EstimatorContext) -> GasCost {
     let base = ed25519_verify_base(ctx);
     // inside the WASM function, there are 64 calls to `ed25519_verify`.

--- a/runtime/runtime-params-estimator/src/utils.rs
+++ b/runtime/runtime-params-estimator/src/utils.rs
@@ -120,7 +120,7 @@ pub(crate) fn fn_cost_count(
     ext_cost: ExtCosts,
     block_latency: usize,
 ) -> (GasCost, u64) {
-    let block_size = 2;
+    let block_size = 20;
     let mut make_transaction = |tb: &mut TransactionBuilder| -> SignedTransaction {
         let sender = tb.random_unused_account();
         tb.transaction_from_function_call(sender, method, Vec::new())


### PR DESCRIPTION
On gcloud (Xeon Cascade Lake CPUs) the variance was
too high, so to reduce it:

- changed default block size for `fn_cost_count`
- increased inner iterations for ed25519 base estimation

Still, I found gcloud results to have high variance on some days.
It could be due to noisy neighbors, such as sharing interger 
multiplication units with a foreign hyper thread.

In the following, the estimation results are taken from a day where
results were stable. Outliers on other days were up to 2 times slower
but when outliers are removed, the same speed is achieved as
reported below.

```python
# time results on Xeon(R) CPU @ 2.80GHz (Cascade Lake-W)
Ed25519VerifyBase    68_093_951_344 gas [68.094µs]
Ed25519VerifyByte    3_198_227 gas [3ns]

# icount
Ed25519VerifyBase    88_704_920_930 gas [709639.37i 0.00r 0.00w]
Ed25519VerifyByte    4_285_422 gas [34.28i 0.00r 0.00w]
```

Above shows `icount` about ~30% higher than `time`.
But `icount` estimations are just a sanity check, 30% off is ok.

Taking the time measurement with safety-factor of 3 and some rounding:
```rust
wasm_ed25519_verify_base: 210_000_000_000
wasm_ed25519_verify_byte: 9_000_000
```
The per-byte cost is much lower than originally proposed. This makes
sense because we previously didn't subtract the base cost.

What makes ed25519 validation expensive are the 2 elliptic-curve scalar
multiplications. Those are independent of the input bytes. The input
bytes are hashed using sha-512 and that's it. We should therefore expect
the same costs per bytes as `wasm_keccak512_byte: 36_649_701`. The
current number there is based on an estimation that does not subtract
the base cost, so it is higher than necessary today. But they are in the
same order of magnitude, which is good to check.

Another comparison, on AMD Ryzen 9 5950X the estimations are lower 
and have almost no variance (it's a local machine).
```python
# time results on Ryzen 9 5950X (2200MHz - 5000MHz)
Ed25519VerifyBase    40_032_632_561 gas [40.033µs]
Ed25519VerifyByte    1_434_641 gas [1ns]
```
The faster results are roughly in line with the higher boost clock.
Good to know that AMD and Intel hardware has similar IPC here.
But to stay in line with validator minimal requirements, we have to
stick with the Xeon estimations from above.

Another data point is [the benchmark from ed25519-dalek](https://github.com/dalek-cryptography/ed25519-dalek#benchmarks)
with 46us per verification on a Skylake i9-7900X @3.30 GHz. Or 33us
if AVX2 instructions are enabled.

We currently cannot use any SIMD instructions because the feature
`curve25519-dalek/simd_backend` requires rust nightly.
(See https://github.com/dalek-cryptography/curve25519-dalek#backends-and-features)