### PR TITLE
nit(network): make ConnectError::IO transparent

### DIFF
--- a/chain/network/src/raw/connection.rs
+++ b/chain/network/src/raw/connection.rs
@@ -69,8 +69,8 @@ impl std::fmt::Debug for Connection {
 
 #[derive(thiserror::Error, Debug)]
 pub enum ConnectError {
-    #[error("IO")]
-    IO(#[source] std::io::Error),
+    #[error(transparent)]
+    IO(std::io::Error),
     #[error("handshake failed {0:?}")]
     HandshakeFailure(HandshakeFailureReason),
     #[error("received unexpected message before the handshake: {0:?}")]


### PR DESCRIPTION
it's not so helpful to see:

```
2022-11-10T19:23:28.325928Z  INFO neard: version="trunk" build="1.1.0-3079-g4692d28bd" latest_protocol=57
2022-11-10T19:23:28.326020Z  WARN ping: the ping command is not stable, and may be removed or changed arbitrarily at any time
Error: Error connecting to 127.0.0.1:24567: IO
```

much better is:

```
2022-11-10T19:21:46.750676Z  INFO neard: version="trunk" build="1.1.0-3079-g4692d28bd-modified" latest_protocol=57
2022-11-10T19:21:46.750781Z  WARN ping: the ping command is not stable, and may be removed or changed arbitrarily at any time
Error: Error connecting to 127.0.0.1:24567: Connection refused (os error 111)
```

and the underlying source() if any is still preserved anyway