### PR TITLE
feat: add more scenarios to FlatStorageState unit tests

### DIFF
--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -1137,12 +1137,10 @@ impl ChainAccessForFlatStorage for ChainStore {
     }
 
     fn get_block_hashes_at_height(&self, height: BlockHeight) -> HashSet<CryptoHash> {
-        self.get_all_block_hashes_by_height(height)
-            .unwrap()
-            .values()
-            .flatten()
-            .copied()
-            .collect::<HashSet<_>>()
+        match self.get_all_block_hashes_by_height(height) {
+            Ok(hashes) => hashes.values().flatten().copied().collect::<HashSet<_>>(),
+            Err(_) => Default::default(),
+        }
     }
 }
 

--- a/core/store/src/flat_state.rs
+++ b/core/store/src/flat_state.rs
@@ -861,6 +861,7 @@ mod tests {
             hash(&height.try_to_vec().unwrap())
         }
 
+        /// Build a chain with given set of heights and a function mapping block heights to heights of their parents.
         fn build(
             heights: Vec<BlockHeight>,
             get_parent: fn(BlockHeight) -> Option<BlockHeight>,


### PR DESCRIPTION
Here we cover testing FlatStorageState on more mock chains:

* Chain with forks - we test that if we move flat head to incorrect block, then FS returns proper error. Blocks on top of which flat storage is stored should move only forward.
* Chain with skipped heights - we test that FS handles them normally. The previous mock impl had an error, and real chain impl deserves integration test for that as well.

## Testing

* New `flat_state` tests.