### PR TITLE
Use relative paths in debug pages

### DIFF
--- a/chain/jsonrpc/res/chain_n_chunk_info.html
+++ b/chain/jsonrpc/res/chain_n_chunk_info.html
@@ -151,7 +151,7 @@
         function fetchChainInfo(status_data) {
             $.ajax({
                 type: "GET",
-                url: "debug/api/chain_processing_status",
+                url: "../api/chain_processing_status",
                 success: data => {
                     onChainInfoFetched(status_data, data);
                 },
@@ -167,7 +167,7 @@
         function fetchStatus() {
             $.ajax({
                 type: "GET",
-                url: "debug/api/status",
+                url: "../api/status",
                 success: data => {
                     fetchChainInfo(data);
                 },

--- a/chain/jsonrpc/res/chain_n_chunk_info.html
+++ b/chain/jsonrpc/res/chain_n_chunk_info.html
@@ -151,7 +151,7 @@
         function fetchChainInfo(status_data) {
             $.ajax({
                 type: "GET",
-                url: "/debug/api/chain_processing_status",
+                url: "debug/api/chain_processing_status",
                 success: data => {
                     onChainInfoFetched(status_data, data);
                 },
@@ -167,7 +167,7 @@
         function fetchStatus() {
             $.ajax({
                 type: "GET",
-                url: "/debug/api/status",
+                url: "debug/api/status",
                 success: data => {
                     fetchChainInfo(data);
                 },

--- a/chain/jsonrpc/res/debug.html
+++ b/chain/jsonrpc/res/debug.html
@@ -59,12 +59,12 @@
 
     </h3>
 
-    <h1><a href="/debug/pages/last_blocks">Last blocks</a></h1>
-    <h1><a href="/debug/pages/network_info">Network info</a></h1>
-    <h1><a href="/debug/pages/epoch_info">Epoch info</a></h1>
-    <h1><a href="/debug/pages/chain_n_chunk_info">Chain & Chunk info</a></h1>
-    <h1><a href="/debug/pages/sync">Sync info</a></h1>
-    <h1><a href="/debug/pages/validator">Validator info</a></h1>
+    <h1><a href="debug/pages/last_blocks">Last blocks</a></h1>
+    <h1><a href="debug/pages/network_info">Network info</a></h1>
+    <h1><a href="debug/pages/epoch_info">Epoch info</a></h1>
+    <h1><a href="debug/pages/chain_n_chunk_info">Chain & Chunk info</a></h1>
+    <h1><a href="debug/pages/sync">Sync info</a></h1>
+    <h1><a href="debug/pages/validator">Validator info</a></h1>
 </body>
 
 </html>

--- a/chain/jsonrpc/res/debug.html
+++ b/chain/jsonrpc/res/debug.html
@@ -22,7 +22,7 @@
         $(document).ready(() => {
             $.ajax({
                 type: "GET",
-                url: "/status",
+                url: "status",
                 success: data => {
                     let binaryText = $('<span>');
                     let version = data.version;

--- a/chain/jsonrpc/res/epoch_info.html
+++ b/chain/jsonrpc/res/epoch_info.html
@@ -242,7 +242,7 @@
         function request_epoch_info(status_data) {
             $.ajax({
                 type: "GET",
-                url: "debug/api/epoch_info",
+                url: "../api/epoch_info",
                 success: epoch_data => {
                     process_responses(status_data, epoch_data);
                 },
@@ -258,7 +258,7 @@
         $(document).ready(() => {
             $.ajax({
                 type: "GET",
-                url: "debug/api/status",
+                url: "../api/status",
                 success: data => {
                     request_epoch_info(data);
                 },

--- a/chain/jsonrpc/res/epoch_info.html
+++ b/chain/jsonrpc/res/epoch_info.html
@@ -242,7 +242,7 @@
         function request_epoch_info(status_data) {
             $.ajax({
                 type: "GET",
-                url: "/debug/api/epoch_info",
+                url: "debug/api/epoch_info",
                 success: epoch_data => {
                     process_responses(status_data, epoch_data);
                 },
@@ -258,7 +258,7 @@
         $(document).ready(() => {
             $.ajax({
                 type: "GET",
-                url: "/debug/api/status",
+                url: "debug/api/status",
                 success: data => {
                     request_epoch_info(data);
                 },

--- a/chain/jsonrpc/res/last_blocks.js
+++ b/chain/jsonrpc/res/last_blocks.js
@@ -235,7 +235,7 @@ function Page() {
     React.useEffect(() => {
         (async () => {
             try {
-                let resp = await fetch('debug/api/status');
+                let resp = await fetch('../api/status');
                 if (resp.status == 405) {
                     throw new Error('Debug not allowed - did you set enable_debug_rpc: true in your config?');
                 } else if (!resp.ok) {

--- a/chain/jsonrpc/res/last_blocks.js
+++ b/chain/jsonrpc/res/last_blocks.js
@@ -224,7 +224,7 @@ function Page() {
     const [expandAll, setExpandAll] = React.useState(false);
     const [hideMissingHeights, setHideMissingHeights] = React.useState(false);
     const updateXarrow = reactXarrow.useXarrow();
-    let blockStatusApiPath = '/debug/api/block_status';
+    let blockStatusApiPath = 'debug/api/block_status';
     const url = new URL(window.location.toString());
     let title = 'Most Recent Blocks';
     if (url.searchParams.has('height')) {
@@ -235,7 +235,7 @@ function Page() {
     React.useEffect(() => {
         (async () => {
             try {
-                let resp = await fetch('/debug/api/status');
+                let resp = await fetch('debug/api/status');
                 if (resp.status == 405) {
                     throw new Error('Debug not allowed - did you set enable_debug_rpc: true in your config?');
                 } else if (!resp.ok) {

--- a/chain/jsonrpc/res/last_blocks.js
+++ b/chain/jsonrpc/res/last_blocks.js
@@ -224,7 +224,7 @@ function Page() {
     const [expandAll, setExpandAll] = React.useState(false);
     const [hideMissingHeights, setHideMissingHeights] = React.useState(false);
     const updateXarrow = reactXarrow.useXarrow();
-    let blockStatusApiPath = 'debug/api/block_status';
+    let blockStatusApiPath = '../api/block_status';
     const url = new URL(window.location.toString());
     let title = 'Most Recent Blocks';
     if (url.searchParams.has('height')) {

--- a/chain/jsonrpc/res/network_info.html
+++ b/chain/jsonrpc/res/network_info.html
@@ -126,7 +126,7 @@
         function fetchProducers(epoch_id, producers_callback) {
             $.ajax({
                 type: "GET",
-                url: "/debug/api/epoch_info",
+                url: "debug/api/epoch_info",
                 success: data => {
                     let epoch_found = false;
                     data.status_response.EpochInfo.forEach(element => {
@@ -166,7 +166,7 @@
             $('span').text("Loading...");
             $.ajax({
                 type: "GET",
-                url: "/debug/api/status",
+                url: "debug/api/status",
                 success: data => {
 
                     fetchProducers(data.sync_info.epoch_id, (block_producers, chunk_producers) => {
@@ -309,7 +309,7 @@
             $(".tbody-detailed-peer-storage").html("");
             $.ajax({
                 type: "GET",
-                url: "/debug/api/peer_store",
+                url: "debug/api/peer_store",
                 success: data => {
                     $(".detailed-peer-storage-size").text(data.status_response.PeerStore.peer_states.length);
                     data.status_response.PeerStore.peer_states.forEach(element => {

--- a/chain/jsonrpc/res/network_info.html
+++ b/chain/jsonrpc/res/network_info.html
@@ -126,7 +126,7 @@
         function fetchProducers(epoch_id, producers_callback) {
             $.ajax({
                 type: "GET",
-                url: "debug/api/epoch_info",
+                url: "../api/epoch_info",
                 success: data => {
                     let epoch_found = false;
                     data.status_response.EpochInfo.forEach(element => {
@@ -166,7 +166,7 @@
             $('span').text("Loading...");
             $.ajax({
                 type: "GET",
-                url: "debug/api/status",
+                url: "../api/status",
                 success: data => {
 
                     fetchProducers(data.sync_info.epoch_id, (block_producers, chunk_producers) => {
@@ -309,7 +309,7 @@
             $(".tbody-detailed-peer-storage").html("");
             $.ajax({
                 type: "GET",
-                url: "debug/api/peer_store",
+                url: "../api/peer_store",
                 success: data => {
                     $(".detailed-peer-storage-size").text(data.status_response.PeerStore.peer_states.length);
                     data.status_response.PeerStore.peer_states.forEach(element => {

--- a/chain/jsonrpc/res/sync.html
+++ b/chain/jsonrpc/res/sync.html
@@ -172,7 +172,7 @@
             $('span').text("Loading...");
             $.ajax({
                 type: "GET",
-                url: "debug/api/sync_status",
+                url: "../api/sync_status",
                 success: data => {
                     process_sync_status(data);
                 },
@@ -184,7 +184,7 @@
             });
             $.ajax({
                 type: "GET",
-                url: "debug/api/tracked_shards",
+                url: "../api/tracked_shards",
                 success: data => {
                     process_tracked_shards(data);
                 },
@@ -196,7 +196,7 @@
             });
             $.ajax({
                 type: "GET",
-                url: "debug/api/catchup_status",
+                url: "../api/catchup_status",
                 success: data => {
                     process_catchup_status(data);
                 },

--- a/chain/jsonrpc/res/sync.html
+++ b/chain/jsonrpc/res/sync.html
@@ -172,7 +172,7 @@
             $('span').text("Loading...");
             $.ajax({
                 type: "GET",
-                url: "/debug/api/sync_status",
+                url: "debug/api/sync_status",
                 success: data => {
                     process_sync_status(data);
                 },
@@ -184,7 +184,7 @@
             });
             $.ajax({
                 type: "GET",
-                url: "/debug/api/tracked_shards",
+                url: "debug/api/tracked_shards",
                 success: data => {
                     process_tracked_shards(data);
                 },
@@ -196,7 +196,7 @@
             });
             $.ajax({
                 type: "GET",
-                url: "/debug/api/catchup_status",
+                url: "debug/api/catchup_status",
                 success: data => {
                     process_catchup_status(data);
                 },

--- a/chain/jsonrpc/res/validator.html
+++ b/chain/jsonrpc/res/validator.html
@@ -396,7 +396,7 @@
             $('span').text("Loading...");
             $.ajax({
                 type: "GET",
-                url: "/debug/api/validator_status",
+                url: "debug/api/validator_status",
                 success: data => {
                     process_validator_status(data);
                 },

--- a/chain/jsonrpc/res/validator.html
+++ b/chain/jsonrpc/res/validator.html
@@ -396,7 +396,7 @@
             $('span').text("Loading...");
             $.ajax({
                 type: "GET",
-                url: "debug/api/validator_status",
+                url: "../api/validator_status",
                 success: data => {
                     process_validator_status(data);
                 },


### PR DESCRIPTION
This PR updates the request to debug pages and debug links to work in a reverse proxy setup.
Say, we have a reverse proxy that exposes a debug page at the following URL: `http://myproxy/node1/debug`.
Today that would not be possible, because the node would make requests to `http://myproxy/debug/api/status` which doesn't exist.
With this PR, the node would make a request to `http://myproxy/node1/debug/api/status` which can be reverse-proxied to the node correctly.

Demo: http://35.204.154.4:3131/level/debug