### PR TITLE
Improve consensus performance when there are invalid chunks.

### DIFF
--- a/chain/chain/src/block_processing_utils.rs
+++ b/chain/chain/src/block_processing_utils.rs
@@ -4,7 +4,7 @@ use crate::Provenance;
 use near_primitives::block::Block;
 use near_primitives::challenge::{ChallengeBody, ChallengesResult};
 use near_primitives::hash::CryptoHash;
-use near_primitives::sharding::{ReceiptProof, StateSyncInfo};
+use near_primitives::sharding::{ReceiptProof, ShardChunkHeader, StateSyncInfo};
 use near_primitives::types::ShardId;
 use once_cell::sync::OnceCell;
 use std::collections::HashMap;
@@ -64,6 +64,7 @@ pub struct BlockProcessingArtifact {
     pub orphans_missing_chunks: Vec<OrphanMissingChunks>,
     pub blocks_missing_chunks: Vec<BlockMissingChunks>,
     pub challenges: Vec<ChallengeBody>,
+    pub invalid_chunks: Vec<ShardChunkHeader>,
 }
 
 /// This struct defines the callback function that will be called after apply chunks are finished

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -130,7 +130,7 @@ const NEAR_BASE: Balance = 1_000_000_000_000_000_000_000_000;
 /// has not been caught up yet, thus the two modes IsCaughtUp and NotCaughtUp.
 /// CatchingUp is for when apply_chunks is called through catchup_blocks, this is to catch up the
 /// shard states for the next epoch
-#[derive(Eq, PartialEq)]
+#[derive(Eq, PartialEq, Copy, Clone, Debug)]
 enum ApplyChunksMode {
     IsCaughtUp,
     CatchingUp,
@@ -1937,6 +1937,7 @@ impl Chain {
             &block,
             &provenance,
             &mut block_processing_artifact.challenges,
+            &mut block_processing_artifact.invalid_chunks,
             block_received_time,
             state_patch,
         );
@@ -2113,6 +2114,14 @@ impl Chain {
         let prev_head = self.store.head()?;
         let provenance = block_preprocess_info.provenance.clone();
         let block_start_processing_time = block_preprocess_info.block_start_processing_time.clone();
+        // TODO(#8055): this zip relies on the ordering of the apply_results.
+        for (apply_result, chunk) in apply_results.iter().zip(block.chunks().iter()) {
+            if let Err(err) = apply_result {
+                if err.is_bad_data() {
+                    block_processing_artifacts.invalid_chunks.push(chunk.clone());
+                }
+            }
+        }
         let new_head =
             match self.postprocess_block_only(me, &block, block_preprocess_info, apply_results) {
                 Err(err) => {
@@ -2235,6 +2244,7 @@ impl Chain {
         block: &MaybeValidated<Block>,
         provenance: &Provenance,
         challenges: &mut Vec<ChallengeBody>,
+        invalid_chunks: &mut Vec<ShardChunkHeader>,
         block_received_time: Instant,
         state_patch: SandboxStatePatch,
     ) -> Result<
@@ -2399,6 +2409,7 @@ impl Chain {
             // otherwise put the block into the permanent storage, waiting for be caught up
             if is_caught_up { ApplyChunksMode::IsCaughtUp } else { ApplyChunksMode::NotCaughtUp },
             state_patch,
+            invalid_chunks,
         )?;
 
         Ok((
@@ -3241,6 +3252,7 @@ impl Chain {
                 &receipts_by_shard,
                 ApplyChunksMode::CatchingUp,
                 Default::default(),
+                &mut Vec::new(),
             )?;
             blocks_catch_up_state.scheduled_blocks.insert(pending_block);
             block_catch_up_scheduler(BlockCatchUpRequest {
@@ -3571,14 +3583,12 @@ impl Chain {
         incoming_receipts: &HashMap<ShardId, Vec<ReceiptProof>>,
         mode: ApplyChunksMode,
         mut state_patch: SandboxStatePatch,
+        invalid_chunks: &mut Vec<ShardChunkHeader>,
     ) -> Result<
         Vec<Box<dyn FnOnce(&Span) -> Result<ApplyChunkResult, Error> + Send + 'static>>,
         Error,
     > {
         let _span = tracing::debug_span!(target: "chain", "apply_chunks_preprocessing").entered();
-        let mut result: Vec<
-            Box<dyn FnOnce(&Span) -> Result<ApplyChunkResult, Error> + Send + 'static>,
-        > = Vec::new();
         #[cfg(not(feature = "mock_node"))]
         let protocol_version =
             self.runtime_adapter.get_epoch_protocol_version(block.header().epoch_id())?;
@@ -3587,9 +3597,13 @@ impl Chain {
         let will_shard_layout_change =
             self.runtime_adapter.will_shard_layout_change_next_epoch(prev_hash)?;
         let prev_chunk_headers = Chain::get_prev_chunk_headers(&*self.runtime_adapter, prev_block)?;
-        for (shard_id, (chunk_header, prev_chunk_header)) in
-            (block.chunks().iter().zip(prev_chunk_headers.iter())).enumerate()
-        {
+        let mut process_one_chunk = |shard_id: usize,
+                                     chunk_header: &ShardChunkHeader,
+                                     prev_chunk_header: &ShardChunkHeader|
+         -> Result<
+            Option<Box<dyn FnOnce(&Span) -> Result<ApplyChunkResult, Error> + Send + 'static>>,
+            Error,
+        > {
             // XXX: This is a bit questionable -- sandbox state patching works
             // only for a single shard. This so far has been enough.
             let state_patch = state_patch.take();
@@ -3747,7 +3761,7 @@ impl Chain {
                     let height = chunk_header.height_included();
                     let prev_block_hash = chunk_header.prev_block_hash().clone();
 
-                    result.push(Box::new(move |parent_span| -> Result<ApplyChunkResult, Error> {
+                    Ok(Some(Box::new(move |parent_span| -> Result<ApplyChunkResult, Error> {
                         let _span = tracing::debug_span!(
                             target: "chain",
                             parent: parent_span,
@@ -3796,7 +3810,7 @@ impl Chain {
                             }
                             Err(err) => Err(err),
                         }
-                    }));
+                    })))
                 } else {
                     let new_extra = self.get_chunk_extra(prev_block.hash(), &shard_uid)?.clone();
 
@@ -3809,7 +3823,7 @@ impl Chain {
                     let height = block.header().height();
                     let prev_block_hash = *prev_block.hash();
 
-                    result.push(Box::new(move |parent_span| -> Result<ApplyChunkResult, Error> {
+                    Ok(Some(Box::new(move |parent_span| -> Result<ApplyChunkResult, Error> {
                         let _span = tracing::debug_span!(
                             target: "chain",
                             parent: parent_span,
@@ -3856,7 +3870,7 @@ impl Chain {
                             }
                             Err(err) => Err(err),
                         }
-                    }));
+                    })))
                 }
             } else if let Some(split_state_roots) = split_state_roots {
                 // case 3)
@@ -3869,7 +3883,7 @@ impl Chain {
                     self.store().get_state_changes_for_split_states(block.hash(), shard_id)?;
                 let runtime_adapter = self.runtime_adapter.clone();
                 let block_hash = *block.hash();
-                result.push(Box::new(move |parent_span| -> Result<ApplyChunkResult, Error> {
+                Ok(Some(Box::new(move |parent_span| -> Result<ApplyChunkResult, Error> {
                     let _span = tracing::debug_span!(
                         target: "chain",
                         parent: parent_span,
@@ -3886,11 +3900,29 @@ impl Chain {
                             state_changes,
                         )?,
                     }))
-                }));
+                })))
+            } else {
+                Ok(None)
             }
-        }
-
-        Ok(result)
+        };
+        block
+            .chunks()
+            .iter()
+            .zip(prev_chunk_headers.iter())
+            .enumerate()
+            .filter_map(|(shard_id, (chunk_header, prev_chunk_header))| {
+                match process_one_chunk(shard_id, chunk_header, prev_chunk_header) {
+                    Ok(Some(processor)) => Some(Ok(processor)),
+                    Ok(None) => None,
+                    Err(err) => {
+                        if err.is_bad_data() {
+                            invalid_chunks.push(chunk_header.clone());
+                        }
+                        Some(Err(err))
+                    }
+                }
+            })
+            .collect()
     }
 }
 

--- a/chain/chain/src/tests/challenges.rs
+++ b/chain/chain/src/tests/challenges.rs
@@ -52,6 +52,7 @@ fn challenges_new_head_prev() {
         &MaybeValidated::from(last_block),
         &Provenance::NONE,
         &mut vec![],
+        &mut vec![],
         Clock::instant(),
         Default::default(),
     ) {

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -975,11 +975,12 @@ impl ShardsManager {
             .collect()
     }
 
+    /// Returns true if we were able to answer the request. This is for testing.
     pub fn process_partial_encoded_chunk_request(
         &mut self,
         request: PartialEncodedChunkRequestMsg,
         route_back: CryptoHash,
-    ) {
+    ) -> bool {
         let _span = tracing::debug_span!(
             target: "chunks",
             "process_partial_encoded_chunk_request",
@@ -1005,8 +1006,10 @@ impl ShardsManager {
                     NetworkRequests::PartialEncodedChunkResponse { route_back, response },
                 )
                 .with_span_context(),
-            )
+            );
+            return true;
         }
+        false
     }
 
     fn prepare_partial_encoded_chunk_response(
@@ -1799,7 +1802,8 @@ impl ShardsManager {
 
         if have_all_parts && self.seals_mgr.should_trust_chunk_producer(&chunk_producer) {
             if self.encoded_chunks.mark_chunk_for_inclusion(&chunk_hash) {
-                self.client_adapter.chunk_header_ready_for_inclusion(header.clone());
+                self.client_adapter
+                    .chunk_header_ready_for_inclusion(header.clone(), chunk_producer);
             }
         }
         // we can safely unwrap here because we already checked that chunk_hash exist in encoded_chunks

--- a/chain/chunks/src/test_utils.rs
+++ b/chain/chunks/src/test_utils.rs
@@ -332,7 +332,7 @@ impl ChunkTestFixture {
     pub fn count_chunk_ready_for_inclusion_messages(&self) -> usize {
         let mut chunks_ready = 0;
         while let Some(message) = self.mock_client_adapter.pop() {
-            if let ShardsManagerResponse::ChunkHeaderReadyForInclusion(_) = message {
+            if let ShardsManagerResponse::ChunkHeaderReadyForInclusion { .. } = message {
                 chunks_ready += 1;
             }
         }

--- a/chain/client-primitives/src/debug.rs
+++ b/chain/client-primitives/src/debug.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 use crate::types::StatusError;
 use actix::Message;
 use chrono::DateTime;
+use near_primitives::types::EpochId;
 use near_primitives::views::{
     CatchupStatusView, ChainProcessingInfo, EpochValidatorInfo, RequestedStatePartsView,
     SyncStatusView,
@@ -165,6 +166,8 @@ pub struct ValidatorStatus {
     // Sorted by block height inversely (high to low)
     // The range of heights are controlled by constants in client_actor.rs
     pub production: Vec<(BlockHeight, ProductionAtHeight)>,
+    // Chunk producers that this node has banned.
+    pub banned_chunk_producers: Vec<(EpochId, Vec<AccountId>)>,
 }
 
 // Different debug requests that can be sent by HTML pages, via GET.

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -62,6 +62,7 @@ use near_primitives::views::{CatchupStatusView, DroppedReason};
 
 const NUM_REBROADCAST_BLOCKS: usize = 30;
 const CHUNK_HEADERS_FOR_INCLUSION_CACHE_SIZE: usize = 2048;
+const NUM_EPOCH_CHUNK_PRODUCERS_TO_KEEP_IN_BLOCKLIST: usize = 1000;
 
 /// The time we wait for the response to a Epoch Sync request before retrying
 // TODO #3488 set 30_000
@@ -81,6 +82,10 @@ pub struct Client {
     pub adv_produce_blocks: bool,
     #[cfg(feature = "test_features")]
     pub adv_produce_blocks_only_valid: bool,
+    #[cfg(feature = "test_features")]
+    pub produce_invalid_chunks: bool,
+    #[cfg(feature = "test_features")]
+    pub produce_invalid_tx_in_chunks: bool,
 
     /// Fast Forward accrued delta height used to calculate fast forwarded timestamps for each block.
     #[cfg(feature = "sandbox")]
@@ -94,8 +99,11 @@ pub struct Client {
     pub shards_mgr: ShardsManager,
     me: Option<AccountId>,
     pub sharded_tx_pool: ShardedTransactionPool,
-    prev_block_to_chunk_headers_ready_for_inclusion:
-        LruCache<CryptoHash, HashMap<ShardId, (ShardChunkHeader, chrono::DateTime<chrono::Utc>)>>,
+    prev_block_to_chunk_headers_ready_for_inclusion: LruCache<
+        CryptoHash,
+        HashMap<ShardId, (ShardChunkHeader, chrono::DateTime<chrono::Utc>, AccountId)>,
+    >,
+    pub do_not_include_chunks_from: LruCache<(EpochId, AccountId), ()>,
     /// Network adapter.
     network_adapter: Arc<dyn PeerManagerAdapter>,
     /// Signer for block producer (if present).
@@ -237,6 +245,10 @@ impl Client {
             adv_produce_blocks: false,
             #[cfg(feature = "test_features")]
             adv_produce_blocks_only_valid: false,
+            #[cfg(feature = "test_features")]
+            produce_invalid_chunks: false,
+            #[cfg(feature = "test_features")]
+            produce_invalid_tx_in_chunks: false,
             #[cfg(feature = "sandbox")]
             accrued_fastforward_delta: 0,
             config,
@@ -249,6 +261,9 @@ impl Client {
             sharded_tx_pool,
             prev_block_to_chunk_headers_ready_for_inclusion: LruCache::new(
                 CHUNK_HEADERS_FOR_INCLUSION_CACHE_SIZE,
+            ),
+            do_not_include_chunks_from: LruCache::new(
+                NUM_EPOCH_CHUNK_PRODUCERS_TO_KEEP_IN_BLOCKLIST,
             ),
             network_adapter,
             validator_signer,
@@ -408,19 +423,49 @@ impl Client {
 
     pub fn get_chunk_headers_ready_for_inclusion(
         &self,
+        epoch_id: &EpochId,
         prev_block_hash: &CryptoHash,
-    ) -> HashMap<ShardId, (ShardChunkHeader, chrono::DateTime<chrono::Utc>)> {
+    ) -> HashMap<ShardId, (ShardChunkHeader, chrono::DateTime<chrono::Utc>, AccountId)> {
         self.prev_block_to_chunk_headers_ready_for_inclusion
             .peek(prev_block_hash)
             .cloned()
             .unwrap_or_default()
+            .into_iter()
+            .filter(|(_, (chunk_header, _, chunk_producer))| {
+                let banned = self
+                    .do_not_include_chunks_from
+                    .contains(&(epoch_id.clone(), chunk_producer.clone()));
+                if banned {
+                    warn!(
+                        target: "client",
+                        "Not including chunk {:?} from banned validator {}",
+                        chunk_header.chunk_hash(),
+                        chunk_producer);
+                    metrics::CHUNK_DROPPED_BECAUSE_OF_BANNED_CHUNK_PRODUCER.inc();
+                }
+                !banned
+            })
+            .collect()
     }
 
-    pub fn get_num_chunks_ready_for_inclusion(&self, prev_block_hash: &CryptoHash) -> usize {
-        self.prev_block_to_chunk_headers_ready_for_inclusion
-            .peek(prev_block_hash)
-            .map(|x| x.len())
-            .unwrap_or(0)
+    pub fn num_chunk_headers_ready_for_inclusion(
+        &self,
+        epoch_id: &EpochId,
+        prev_block_hash: &CryptoHash,
+    ) -> usize {
+        let entries =
+            match self.prev_block_to_chunk_headers_ready_for_inclusion.peek(prev_block_hash) {
+                Some(entries) => entries,
+                None => return 0,
+            };
+        entries
+            .values()
+            .filter(|(_, _, chunk_producer)| {
+                !self
+                    .do_not_include_chunks_from
+                    .contains(&(epoch_id.clone(), chunk_producer.clone()))
+            })
+            .count()
     }
 
     /// Produce block if we are block producer for given `next_height` block height.
@@ -485,7 +530,7 @@ impl Client {
             }
         }
 
-        let new_chunks = self.get_chunk_headers_ready_for_inclusion(&prev_hash);
+        let new_chunks = self.get_chunk_headers_ready_for_inclusion(&epoch_id, &prev_hash);
         debug!(target: "client", "{:?} Producing block at height {}, parent {} @ {}, {} new chunks", validator_signer.validator_id(),
                next_height, prev.height(), format_hash(head.last_block_hash), new_chunks.len());
 
@@ -577,7 +622,7 @@ impl Client {
         );
 
         // Collect new chunks.
-        for (shard_id, (mut chunk_header, _)) in new_chunks {
+        for (shard_id, (mut chunk_header, _, _)) in new_chunks {
             *chunk_header.height_included_mut() = next_height;
             chunks[shard_id as usize] = chunk_header;
         }
@@ -700,6 +745,13 @@ impl Client {
 
         let prev_block_header = self.chain.get_block_header(&prev_block_hash)?;
         let transactions = self.prepare_transactions(shard_id, &chunk_extra, &prev_block_header)?;
+        let transactions = transactions;
+        #[cfg(feature = "test_features")]
+        let transactions = Self::maybe_insert_invalid_transaction(
+            transactions,
+            prev_block_hash,
+            self.produce_invalid_tx_in_chunks,
+        );
         let num_filtered_transactions = transactions.len();
         let (tx_root, _) = merklize(&transactions);
         let outgoing_receipts = self.chain.get_outgoing_receipts_for_shard(
@@ -726,13 +778,16 @@ impl Client {
         let (outgoing_receipts_root, _) = merklize(&outgoing_receipts_hashes);
 
         let protocol_version = self.runtime_adapter.get_epoch_protocol_version(epoch_id)?;
+        let gas_used = chunk_extra.gas_used();
+        #[cfg(feature = "test_features")]
+        let gas_used = if self.produce_invalid_chunks { gas_used + 1 } else { gas_used };
         let (encoded_chunk, merkle_paths) = ShardsManager::create_encoded_shard_chunk(
             prev_block_hash,
             *chunk_extra.state_root(),
             *chunk_extra.outcome_root(),
             next_height,
             shard_id,
-            chunk_extra.gas_used(),
+            gas_used,
             chunk_extra.gas_limit(),
             chunk_extra.balance_burnt(),
             chunk_extra.validator_proposals().collect(),
@@ -766,6 +821,27 @@ impl Client {
             },
         );
         Ok(Some((encoded_chunk, merkle_paths, outgoing_receipts)))
+    }
+
+    #[cfg(feature = "test_features")]
+    fn maybe_insert_invalid_transaction(
+        mut txs: Vec<SignedTransaction>,
+        prev_block_hash: CryptoHash,
+        insert: bool,
+    ) -> Vec<SignedTransaction> {
+        if insert {
+            txs.push(SignedTransaction::new(
+                near_crypto::Signature::empty(near_crypto::KeyType::ED25519),
+                near_primitives::transaction::Transaction::new(
+                    "test".parse().unwrap(),
+                    near_crypto::PublicKey::empty(near_crypto::KeyType::SECP256K1),
+                    "other".parse().unwrap(),
+                    3,
+                    prev_block_hash,
+                ),
+            ));
+        }
+        txs
     }
 
     /// Prepares an ordered list of valid transactions from the pool up the limits.
@@ -1097,8 +1173,12 @@ impl Client {
         &mut self,
         block_processing_artifacts: BlockProcessingArtifact,
     ) {
-        let BlockProcessingArtifact { orphans_missing_chunks, blocks_missing_chunks, challenges } =
-            block_processing_artifacts;
+        let BlockProcessingArtifact {
+            orphans_missing_chunks,
+            blocks_missing_chunks,
+            challenges,
+            invalid_chunks,
+        } = block_processing_artifacts;
         // Send out challenges that accumulated via on_challenge.
         self.send_challenges(challenges);
         // For any missing chunk, call the ShardsManager with it so that it may apply forwarded parts.
@@ -1117,6 +1197,34 @@ impl Client {
         }
         // Request any (still) missing chunks.
         self.request_missing_chunks(blocks_missing_chunks, orphans_missing_chunks);
+
+        for chunk_header in invalid_chunks {
+            if let Err(err) = self.ban_chunk_producer_for_producing_invalid_chunk(chunk_header) {
+                error!(target: "client", "Failed to ban chunk producer for producing invalid chunk: {:?}", err);
+            }
+        }
+    }
+
+    fn ban_chunk_producer_for_producing_invalid_chunk(
+        &mut self,
+        chunk_header: ShardChunkHeader,
+    ) -> Result<(), Error> {
+        let epoch_id =
+            self.runtime_adapter.get_epoch_id_from_prev_block(chunk_header.prev_block_hash())?;
+        let chunk_producer = self.runtime_adapter.get_chunk_producer(
+            &epoch_id,
+            chunk_header.height_created(),
+            chunk_header.shard_id(),
+        )?;
+        error!(
+            target: "client",
+            "Banning chunk producer {} for epoch {:?} for producing invalid chunk {:?}",
+            chunk_producer,
+            epoch_id,
+            chunk_header.chunk_hash());
+        metrics::CHUNK_PRODUCER_BANNED_FOR_EPOCH.inc();
+        self.do_not_include_chunks_from.put((epoch_id, chunk_producer), ());
+        Ok(())
     }
 
     fn rebroadcast_block(&mut self, block: &Block) {
@@ -1158,14 +1266,18 @@ impl Client {
         }
     }
 
-    pub fn on_chunk_header_ready_for_inclusion(&mut self, chunk_header: ShardChunkHeader) {
+    pub fn on_chunk_header_ready_for_inclusion(
+        &mut self,
+        chunk_header: ShardChunkHeader,
+        chunk_producer: AccountId,
+    ) {
         let prev_block_hash = chunk_header.prev_block_hash();
         self.prev_block_to_chunk_headers_ready_for_inclusion
             .get_or_insert(prev_block_hash.clone(), || HashMap::new());
         self.prev_block_to_chunk_headers_ready_for_inclusion
             .get_mut(prev_block_hash)
             .unwrap()
-            .insert(chunk_header.shard_id(), (chunk_header, chrono::Utc::now()));
+            .insert(chunk_header.shard_id(), (chunk_header, chrono::Utc::now(), chunk_producer));
     }
 
     pub fn sync_block_headers(
@@ -1468,7 +1580,10 @@ impl Client {
             self.runtime_adapter.as_ref(),
         )?;
         persist_chunk(partial_chunk.clone(), Some(shard_chunk), self.chain.mut_store())?;
-        self.on_chunk_header_ready_for_inclusion(encoded_chunk.cloned_header());
+        self.on_chunk_header_ready_for_inclusion(
+            encoded_chunk.cloned_header(),
+            self.me.clone().unwrap(),
+        );
         self.shards_mgr.distribute_encoded_chunk(
             partial_chunk,
             encoded_chunk,

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1152,8 +1152,9 @@ impl ClientActor {
                 self.client.runtime_adapter.get_block_producer(&epoch_id, height)?;
 
             if me == next_block_producer_account {
-                let num_chunks =
-                    self.client.get_num_chunks_ready_for_inclusion(&head.last_block_hash);
+                let num_chunks = self
+                    .client
+                    .num_chunk_headers_ready_for_inclusion(&epoch_id, &head.last_block_hash);
                 let have_all_chunks = head.height == 0
                     || num_chunks as u64
                         == self.client.runtime_adapter.num_shards(&epoch_id).unwrap();
@@ -2042,8 +2043,11 @@ impl Handler<WithSpanContext<ShardsManagerResponse>> for ClientActor {
             ShardsManagerResponse::InvalidChunk(encoded_chunk) => {
                 self.client.on_invalid_chunk(encoded_chunk);
             }
-            ShardsManagerResponse::ChunkHeaderReadyForInclusion(chunk_header) => {
-                self.client.on_chunk_header_ready_for_inclusion(chunk_header);
+            ShardsManagerResponse::ChunkHeaderReadyForInclusion {
+                chunk_header,
+                chunk_producer,
+            } => {
+                self.client.on_chunk_header_ready_for_inclusion(chunk_header, chunk_producer);
             }
         }
     }

--- a/chain/client/src/metrics.rs
+++ b/chain/client/src/metrics.rs
@@ -151,6 +151,24 @@ pub(crate) static CHUNK_SKIPPED_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
+pub(crate) static CHUNK_PRODUCER_BANNED_FOR_EPOCH: Lazy<IntCounter> = Lazy::new(|| {
+    try_create_int_counter(
+        "near_chunk_producer_banned_for_epoch",
+        "Number of times we have banned a chunk producer for an epoch",
+    )
+    .unwrap()
+});
+
+pub(crate) static CHUNK_DROPPED_BECAUSE_OF_BANNED_CHUNK_PRODUCER: Lazy<IntCounter> =
+    Lazy::new(|| {
+        try_create_int_counter(
+            "near_chunk_dropped_because_of_banned_chunk_producer",
+            "Number of chunks we, as a block producer, 
+                dropped, because the chunk is produced by a banned chunk producer",
+        )
+        .unwrap()
+    });
+
 pub(crate) static PARTIAL_ENCODED_CHUNK_RESPONSE_DELAY: Lazy<Histogram> = Lazy::new(|| {
     try_create_histogram(
         "near_partial_encoded_chunk_response_delay",

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -11,7 +11,7 @@ use futures::{future, FutureExt};
 use num_rational::Ratio;
 use once_cell::sync::OnceCell;
 use rand::{thread_rng, Rng};
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::{start_view_client, Client, ClientActor, SyncStatus, ViewClientActor};
 use near_chain::chain::{do_apply_chunks, BlockCatchUpRequest, StateSplitRequest};
@@ -173,8 +173,7 @@ impl Client {
     /// has started.
     pub fn finish_block_in_processing(&mut self, hash: &CryptoHash) -> Vec<CryptoHash> {
         if let Ok(()) = wait_for_block_in_processing(&mut self.chain, hash) {
-            let (accepted_blocks, errors) = self.postprocess_ready_blocks(Arc::new(|_| {}), true);
-            assert!(errors.is_empty());
+            let (accepted_blocks, _) = self.postprocess_ready_blocks(Arc::new(|_| {}), true);
             return accepted_blocks;
         }
         vec![]
@@ -1429,7 +1428,12 @@ impl TestEnv {
         {
             let target_id = self.account_to_client_index[&target.account_id.unwrap()];
             let response = self.get_partial_encoded_chunk_response(target_id, request);
-            self.clients[id].shards_mgr.process_partial_encoded_chunk_response(response).unwrap();
+            if let Some(response) = response {
+                self.clients[id]
+                    .shards_mgr
+                    .process_partial_encoded_chunk_response(response)
+                    .unwrap();
+            }
         } else {
             panic!("The request is not a PartialEncodedChunk request {:?}", request);
         }
@@ -1439,24 +1443,33 @@ impl TestEnv {
         &mut self,
         id: usize,
         request: PartialEncodedChunkRequestMsg,
-    ) -> PartialEncodedChunkResponseMsg {
+    ) -> Option<PartialEncodedChunkResponseMsg> {
         let client = &mut self.clients[id];
-        client.shards_mgr.process_partial_encoded_chunk_request(request, CryptoHash::default());
-        let response = self.network_adapters[id].pop_most_recent().unwrap();
-        if let PeerManagerMessageRequest::NetworkRequests(
-            NetworkRequests::PartialEncodedChunkResponse { route_back: _, response },
-        ) = response
+        if client
+            .shards_mgr
+            .process_partial_encoded_chunk_request(request.clone(), CryptoHash::default())
         {
-            return response;
+            let response = self.network_adapters[id].pop_most_recent().unwrap();
+            if let PeerManagerMessageRequest::NetworkRequests(
+                NetworkRequests::PartialEncodedChunkResponse { route_back: _, response },
+            ) = response
+            {
+                Some(response)
+            } else {
+                panic!(
+                    "did not find PartialEncodedChunkResponse from the network queue {:?}",
+                    response
+                );
+            }
         } else {
-            panic!(
-                "did not find PartialEncodedChunkResponse from the network queue {:?}",
-                response
-            );
+            // TODO: Somehow this may fail at epoch boundaries. Figure out why.
+            warn!("Failed to process PartialEncodedChunkRequest from client {}: {:?}", id, request);
+            None
         }
     }
 
-    pub fn process_shards_manager_responses(&mut self, id: usize) {
+    pub fn process_shards_manager_responses(&mut self, id: usize) -> bool {
+        let mut any_processed = false;
         while let Some(msg) = self.client_adapters[id].pop() {
             match msg {
                 ShardsManagerResponse::ChunkCompleted { partial_chunk, shard_chunk } => {
@@ -1469,11 +1482,17 @@ impl TestEnv {
                 ShardsManagerResponse::InvalidChunk(encoded_chunk) => {
                     self.clients[id].on_invalid_chunk(encoded_chunk);
                 }
-                ShardsManagerResponse::ChunkHeaderReadyForInclusion(header) => {
-                    self.clients[id].on_chunk_header_ready_for_inclusion(header);
+                ShardsManagerResponse::ChunkHeaderReadyForInclusion {
+                    chunk_header,
+                    chunk_producer,
+                } => {
+                    self.clients[id]
+                        .on_chunk_header_ready_for_inclusion(chunk_header, chunk_producer);
                 }
             }
+            any_processed = true;
         }
+        any_processed
     }
 
     pub fn process_shards_manager_responses_and_finish_processing_blocks(&mut self, idx: usize) {

--- a/chain/jsonrpc/res/validator.html
+++ b/chain/jsonrpc/res/validator.html
@@ -346,7 +346,7 @@
                                 chunk_cell.append("<b>F + " + time_delta + "ms</b><br>")
                                 if (thresholdApprovalTime != null) {
                                     let time_since_threshold = Date.parse(chunk_collection_time) - thresholdApprovalTime;
-                                    let text = $("<span><b>T + " + time_since_threshold+ "ms</b><br></span>");
+                                    let text = $("<span><b>T + " + time_since_threshold + "ms</b><br></span>");
                                     if (time_since_threshold > 300) {
                                         text.addClass('chunk-delay-red')
                                     } else if (time_since_threshold > 150) {
@@ -389,6 +389,12 @@
                 $('.js-tbody-production').append($("<tr><td colspan=10><b>HEAD</b></td></tr>"));
             }
 
+            for (let [epoch_id, chunk_producers] of data.status_response.ValidatorStatus.banned_chunk_producers) {
+                $('#banned-chunk-producers').append(
+                    $('<p>')
+                        .text('Banned chunk producers for epoch ' + epoch_id + ': ' + chunk_producers.join(', '))
+                );
+            }
         };
 
         $(document).ready(() => {
@@ -426,7 +432,8 @@
             Shards can either be produced by this validator (marked as 'ME') or received from other
             validators.<br>
             Shards have missing chunks are marked as grey. <br>
-            We also mark shards arrival time in color. Shards that are delayed by more than 150ms after T are marked as orange,
+            We also mark shards arrival time in color. Shards that are delayed by more than 150ms after T are marked as
+            orange,
             and ones delayed more than 300 marked as red.<br>
             <b>Approvals</b><br>
             Green field means that validators endorses the PREVIOUS block.<br>
@@ -434,6 +441,7 @@
             Other colors means different amount of skips.
 
         </p>
+        <div id="banned-chunk-producers"></div>
         <table>
             <thead>
                 <tr class="js-thead-production">

--- a/integration-tests/src/tests/client/features.rs
+++ b/integration-tests/src/tests/client/features.rs
@@ -2,6 +2,7 @@
 
 mod access_key_nonce_for_implicit_accounts;
 mod account_id_in_function_call_permission;
+mod adversarial_behaviors;
 mod cap_max_gas_price;
 mod chunk_nodes_cache;
 #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]

--- a/integration-tests/src/tests/client/features/adversarial_behaviors.rs
+++ b/integration-tests/src/tests/client/features/adversarial_behaviors.rs
@@ -1,0 +1,353 @@
+use std::{collections::HashSet, path::Path, sync::Arc};
+
+use near_chain::{ChainGenesis, Provenance, RuntimeAdapter};
+use near_chain_configs::Genesis;
+use near_client::test_utils::TestEnv;
+use near_network::types::{NetworkRequests, PeerManagerMessageRequest};
+use near_o11y::testonly::init_test_logger;
+use near_primitives::{
+    runtime::config_store::RuntimeConfigStore,
+    shard_layout::ShardLayout,
+    sharding::PartialEncodedChunk,
+    types::{AccountId, EpochId, ShardId},
+};
+use near_store::test_utils::create_test_store;
+use nearcore::{config::GenesisExt, TrackedConfig};
+use tracing::log::debug;
+
+struct AdversarialBehaviorTestData {
+    num_validators: usize,
+    env: TestEnv,
+}
+
+const EPOCH_LENGTH: u64 = 20;
+
+impl AdversarialBehaviorTestData {
+    fn new() -> AdversarialBehaviorTestData {
+        let num_clients = 8;
+        let num_validators = 8 as usize;
+        let num_block_producers = 4;
+        let epoch_length = EPOCH_LENGTH;
+
+        let accounts: Vec<AccountId> =
+            (0..num_clients).map(|i| format!("test{}", i).parse().unwrap()).collect();
+        let mut genesis = Genesis::test(accounts, num_validators as u64);
+        {
+            let config = &mut genesis.config;
+            config.epoch_length = epoch_length;
+            config.shard_layout = ShardLayout::v1_test();
+            config.num_block_producer_seats_per_shard = vec![
+                num_block_producers as u64,
+                num_block_producers as u64,
+                num_block_producers as u64,
+                num_block_producers as u64,
+            ];
+            config.num_block_producer_seats = num_block_producers as u64;
+            // Configure kickout threshold at 50%.
+            config.block_producer_kickout_threshold = 50;
+            config.chunk_producer_kickout_threshold = 50;
+        }
+        let chain_genesis = ChainGenesis::new(&genesis);
+        let runtimes: Vec<Arc<dyn RuntimeAdapter>> = (0..num_clients)
+            .map(|_| {
+                Arc::new(nearcore::NightshadeRuntime::test_with_runtime_config_store(
+                    Path::new("."),
+                    create_test_store(),
+                    &genesis,
+                    TrackedConfig::AllShards,
+                    RuntimeConfigStore::test(),
+                )) as Arc<dyn RuntimeAdapter>
+            })
+            .collect();
+        let env = TestEnv::builder(chain_genesis)
+            .clients_count(num_clients)
+            .validator_seats(num_validators as usize)
+            .runtime_adapters(runtimes)
+            .build();
+
+        AdversarialBehaviorTestData { num_validators, env }
+    }
+
+    fn process_one_peer_message(&mut self, client_id: usize, requests: NetworkRequests) {
+        match requests {
+            NetworkRequests::PartialEncodedChunkRequest { .. } => {
+                self.env.process_partial_encoded_chunk_request(
+                    client_id,
+                    PeerManagerMessageRequest::NetworkRequests(requests),
+                );
+            }
+            NetworkRequests::PartialEncodedChunkMessage { account_id, partial_encoded_chunk } => {
+                self.env
+                    .client(&account_id)
+                    .shards_mgr
+                    .process_partial_encoded_chunk(
+                        PartialEncodedChunk::from(partial_encoded_chunk).into(),
+                    )
+                    .unwrap();
+            }
+            NetworkRequests::PartialEncodedChunkForward { account_id, forward } => {
+                match self
+                    .env
+                    .client(&account_id)
+                    .shards_mgr
+                    .process_partial_encoded_chunk_forward(forward)
+                {
+                    Ok(_) | Err(near_chunks::Error::UnknownChunk) => {}
+                    Err(e) => {
+                        panic!("Unexpected error from chunk forward: {:?}", e)
+                    }
+                }
+            }
+            NetworkRequests::Challenge(_) => {
+                // challenges not enabled.
+            }
+            _ => {
+                panic!("Unexpected network request: {:?}", requests);
+            }
+        }
+    }
+
+    fn process_all_actor_messages(&mut self) {
+        loop {
+            let mut any_message_processed = false;
+            for i in 0..self.num_validators {
+                if let Some(msg) = self.env.network_adapters[i].pop() {
+                    any_message_processed = true;
+                    match msg {
+                        PeerManagerMessageRequest::NetworkRequests(requests) => {
+                            self.process_one_peer_message(i, requests);
+                        }
+                        _ => {
+                            panic!("Unexpected message: {:?}", msg);
+                        }
+                    }
+                }
+            }
+            for i in 0..self.env.clients.len() {
+                any_message_processed |= self.env.process_shards_manager_responses(i);
+            }
+            if !any_message_processed {
+                break;
+            }
+        }
+    }
+}
+
+#[test]
+fn test_non_adversarial_case() {
+    init_test_logger();
+    let mut test = AdversarialBehaviorTestData::new();
+    let runtime_adapter = test.env.clients[0].runtime_adapter.clone();
+    for height in 1..=EPOCH_LENGTH * 4 + 5 {
+        debug!(target: "test", "======= Height {} ======", height);
+        test.process_all_actor_messages();
+        let epoch_id = runtime_adapter
+            .get_epoch_id_from_prev_block(
+                &test.env.clients[0].chain.head().unwrap().last_block_hash,
+            )
+            .unwrap();
+        let block_producer = runtime_adapter.get_block_producer(&epoch_id, height).unwrap();
+
+        let block = test.env.client(&block_producer).produce_block(height).unwrap().unwrap();
+        assert_eq!(block.header().height(), height);
+
+        if height > 1 {
+            assert_eq!(block.header().prev_height().unwrap(), height - 1);
+            let prev_block =
+                test.env.clients[0].chain.get_block(&block.header().prev_hash()).unwrap();
+            for i in 0..4 {
+                // TODO: mysteriously we might miss a chunk around epoch boundaries.
+                // Figure out why...
+                assert!(
+                    block.chunks()[i].height_created() == prev_block.header().height() + 1
+                        || (height % EPOCH_LENGTH == 1
+                            && block.chunks()[i].chunk_hash()
+                                == prev_block.chunks()[i].chunk_hash())
+                );
+            }
+        }
+
+        for i in 0..test.num_validators {
+            debug!(target: "test", "Processing block {} as validator #{}", height, i);
+            let _ = test.env.clients[i].start_process_block(
+                block.clone().into(),
+                if i == 0 { Provenance::PRODUCED } else { Provenance::NONE },
+                Arc::new(|_| {}),
+            );
+            let mut accepted_blocks =
+                test.env.clients[i].finish_block_in_processing(block.header().hash());
+            // Process any chunk part requests that this client sent. Note that this would also
+            // process other network messages (such as production of the next chunk) which is OK.
+            test.process_all_actor_messages();
+            accepted_blocks.extend(test.env.clients[i].finish_blocks_in_processing());
+
+            assert_eq!(
+                accepted_blocks.len(),
+                1,
+                "Processing of block {} failed at validator #{}",
+                height,
+                i
+            );
+            assert_eq!(&accepted_blocks[0], block.header().hash());
+            assert_eq!(test.env.clients[i].chain.head().unwrap().height, height);
+        }
+    }
+
+    // Sanity check that the final chain head is what we expect
+    assert_eq!(test.env.clients[0].chain.head().unwrap().height, EPOCH_LENGTH * 4 + 5);
+    let final_prev_block_hash = test.env.clients[0].chain.head().unwrap().prev_block_hash;
+    let final_epoch_id =
+        runtime_adapter.get_epoch_id_from_prev_block(&final_prev_block_hash).unwrap();
+    let final_block_producers = runtime_adapter
+        .get_epoch_block_producers_ordered(&final_epoch_id, &final_prev_block_hash)
+        .unwrap();
+    // No producers should be kicked out.
+    assert_eq!(final_block_producers.len(), 4);
+    let final_chunk_producers = runtime_adapter.get_epoch_chunk_producers(&final_epoch_id).unwrap();
+    assert_eq!(final_chunk_producers.len(), 8);
+}
+
+// Not marking this with test_features, because it's good to ensure this compiles, and also
+// if we mark this with features we'd also have to mark a bunch of imports as features.
+#[allow(dead_code)]
+fn test_banning_chunk_producer_when_seeing_invalid_chunk_base(
+    mut test: AdversarialBehaviorTestData,
+) {
+    let runtime_adapter = test.env.clients[0].runtime_adapter.clone();
+    let bad_chunk_producer =
+        test.env.clients[7].validator_signer.as_ref().unwrap().validator_id().clone();
+    let mut epochs_seen_invalid_chunk: HashSet<EpochId> = HashSet::new();
+    let mut last_block_skipped = false;
+    for height in 1..=EPOCH_LENGTH * 4 + 5 {
+        debug!(target: "test", "======= Height {} ======", height);
+        test.process_all_actor_messages();
+        let epoch_id = runtime_adapter
+            .get_epoch_id_from_prev_block(
+                &test.env.clients[0].chain.head().unwrap().last_block_hash,
+            )
+            .unwrap();
+        let block_producer = runtime_adapter.get_block_producer(&epoch_id, height).unwrap();
+
+        let block = test.env.client(&block_producer).produce_block(height).unwrap().unwrap();
+        assert_eq!(block.header().height(), height);
+
+        let mut invalid_chunks_in_this_block: HashSet<ShardId> = HashSet::new();
+        let mut this_block_should_be_skipped = false;
+        if height > 1 {
+            if last_block_skipped {
+                assert_eq!(block.header().prev_height().unwrap(), height - 2);
+            } else {
+                assert_eq!(block.header().prev_height().unwrap(), height - 1);
+            }
+            for shard_id in 0..4 {
+                let chunk_producer = runtime_adapter
+                    .get_chunk_producer(
+                        &epoch_id,
+                        block.header().prev_height().unwrap() + 1,
+                        shard_id,
+                    )
+                    .unwrap();
+                if &chunk_producer == &bad_chunk_producer {
+                    invalid_chunks_in_this_block.insert(shard_id);
+                    if !epochs_seen_invalid_chunk.contains(&epoch_id) {
+                        this_block_should_be_skipped = true;
+                        epochs_seen_invalid_chunk.insert(epoch_id.clone());
+                    }
+                }
+            }
+        }
+        debug!(target: "test", "Epoch id of new block: {:?}", epoch_id);
+        debug!(target: "test", "Block should be skipped: {}; previous block skipped: {}",
+            this_block_should_be_skipped, last_block_skipped);
+
+        if height > 1 {
+            let prev_block =
+                test.env.clients[0].chain.get_block(&block.header().prev_hash()).unwrap();
+            for i in 0..4 {
+                if invalid_chunks_in_this_block.contains(&(i as ShardId))
+                    && !this_block_should_be_skipped
+                {
+                    assert_eq!(block.chunks()[i].chunk_hash(), prev_block.chunks()[i].chunk_hash());
+                } else {
+                    // TODO: mysteriously we might miss a chunk around epoch boundaries.
+                    // Figure out why...
+                    assert!(
+                        block.chunks()[i].height_created() == prev_block.header().height() + 1
+                            || (height % EPOCH_LENGTH == 1
+                                && block.chunks()[i].chunk_hash()
+                                    == prev_block.chunks()[i].chunk_hash())
+                    );
+                }
+            }
+        }
+
+        // The block producer of course has the complete block so we can process that.
+        for i in 0..test.num_validators {
+            debug!(target: "test", "Processing block {} as validator #{}", height, i);
+            let _ = test.env.clients[i].start_process_block(
+                block.clone().into(),
+                if i == 0 { Provenance::PRODUCED } else { Provenance::NONE },
+                Arc::new(|_| {}),
+            );
+            let mut accepted_blocks =
+                test.env.clients[i].finish_block_in_processing(block.header().hash());
+            // Process any chunk part requests that this client sent. Note that this would also
+            // process other network messages (such as production of the next chunk) which is OK.
+            test.process_all_actor_messages();
+            accepted_blocks.extend(test.env.clients[i].finish_blocks_in_processing());
+
+            if this_block_should_be_skipped {
+                assert_eq!(
+                    accepted_blocks.len(),
+                    0,
+                    "Processing of block {} should have failed due to invalid chunk",
+                    height
+                );
+            } else {
+                assert_eq!(
+                    accepted_blocks.len(),
+                    1,
+                    "Processing of block {} failed at validator #{}",
+                    height,
+                    i
+                );
+                assert_eq!(&accepted_blocks[0], block.header().hash());
+                assert_eq!(test.env.clients[i].chain.head().unwrap().height, height);
+            }
+        }
+        last_block_skipped = this_block_should_be_skipped;
+    }
+
+    // Sanity check that the final chain head is what we expect
+    assert_eq!(test.env.clients[0].chain.head().unwrap().height, EPOCH_LENGTH * 4 + 5);
+    // Bad validator should've been kicked out in the third epoch, so it only had two chances
+    // to produce bad chunks. Other validators should not be kicked out.
+    assert_eq!(epochs_seen_invalid_chunk.len(), 2);
+    let final_prev_block_hash = test.env.clients[0].chain.head().unwrap().prev_block_hash;
+    let final_epoch_id =
+        runtime_adapter.get_epoch_id_from_prev_block(&final_prev_block_hash).unwrap();
+    let final_block_producers = runtime_adapter
+        .get_epoch_block_producers_ordered(&final_epoch_id, &final_prev_block_hash)
+        .unwrap();
+    assert!(final_block_producers.len() >= 3); // 3 validators if the bad validator was a block producer
+    let final_chunk_producers = runtime_adapter.get_epoch_chunk_producers(&final_epoch_id).unwrap();
+    assert_eq!(final_chunk_producers.len(), 7);
+}
+
+#[test]
+#[cfg(feature = "test_features")]
+fn test_banning_chunk_producer_when_seeing_invalid_chunk() {
+    init_test_logger();
+    let mut test = AdversarialBehaviorTestData::new();
+    test.env.clients[7].produce_invalid_chunks = true;
+    test_banning_chunk_producer_when_seeing_invalid_chunk_base(test);
+}
+
+#[test]
+#[cfg(feature = "test_features")]
+fn test_banning_chunk_producer_when_seeing_invalid_tx_in_chunk() {
+    init_test_logger();
+    let mut test = AdversarialBehaviorTestData::new();
+    test.env.clients[7].produce_invalid_tx_in_chunks = true;
+    test_banning_chunk_producer_when_seeing_invalid_chunk_base(test);
+}

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -2265,7 +2265,8 @@ fn test_validate_chunk_extra() {
     assert_eq!(accepted_blocks.len(), 1);
 
     // About to produce a block on top of block1. Validate that this chunk is legit.
-    let chunks = env.clients[0].get_chunk_headers_ready_for_inclusion(&block1.hash());
+    let chunks = env.clients[0]
+        .get_chunk_headers_ready_for_inclusion(block1.header().epoch_id(), &block1.hash());
     let chunk_extra =
         env.clients[0].chain.get_chunk_extra(block1.hash(), &ShardUId::single_shard()).unwrap();
     assert!(validate_chunk_with_chunk_extra(

--- a/integration-tests/src/tests/client/shards_manager.rs
+++ b/integration-tests/src/tests/client/shards_manager.rs
@@ -38,7 +38,7 @@ fn test_prepare_partial_encoded_chunk_response() {
         part_ords: (0..env.clients[0].runtime_adapter.num_total_parts() as u64).collect(),
         tracking_shards: Some(0u64).into_iter().collect(),
     };
-    let res = Some(env.get_partial_encoded_chunk_response(0, request.clone()));
+    let res = env.get_partial_encoded_chunk_response(0, request.clone());
 
     // Make the same request but this time call directly to ShardsManager and
     // get the request from a PartialEncodedChunk object.


### PR DESCRIPTION
Previously this would lead to skips as validators filter out the invalid chunks. Now, any invalid chunk producer is immediately banned after the first invalid chunk, so the consensus performance is almost not affected at all.