### PR TITLE
store: don’t configure hot columns in cold database

### DIFF
--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -396,7 +396,6 @@ impl DBCol {
     }
 
     /// Whether this column exists in cold storage.
-    #[cfg(feature = "cold_store")]
     pub(crate) const fn is_in_colddb(&self) -> bool {
         matches!(*self, DBCol::DbVersion | DBCol::BlockMisc) || self.is_cold()
     }

--- a/core/store/src/db/rocksdb.rs
+++ b/core/store/src/db/rocksdb.rs
@@ -56,16 +56,20 @@ impl RocksDB {
     /// doesn’t exist nor any migrations will be performed if the database has
     /// database version different than expected.
     ///
-    /// `temp` specifies whether the database is cold or hot which affects
-    /// whether refcount merge operator is configured on reference counted
-    /// column.
+    /// `temp` specifies whether the database is cold or hot which affects which
+    /// column families are configured in the database and whether refcount
+    /// merge operator is set up on reference counted column.
     pub fn open(
         path: &Path,
         store_config: &StoreConfig,
         mode: Mode,
         temp: Temperature,
     ) -> io::Result<Self> {
-        let columns: Vec<DBCol> = DBCol::iter().collect();
+        let columns: Vec<DBCol> = if temp == Temperature::Hot {
+            DBCol::iter().collect()
+        } else {
+            DBCol::iter().filter(DBCol::is_in_colddb).collect()
+        };
         Self::open_with_columns(path, store_config, mode, temp, &columns)
     }
 

--- a/core/store/src/opener.rs
+++ b/core/store/src/opener.rs
@@ -155,9 +155,10 @@ struct DBOpener<'a> {
 
     /// Temperature of the database.
     ///
-    /// This affects whether refcount merge operator is configured on reference
-    /// counted column.  It’s important that the value is correct.  RPC and
-    /// Archive databases are considered hot.
+    /// This affects which column families are configured in the database and
+    /// whether refcount merge operator is set up on reference counted column.
+    /// It’s important that the value is correct.  RPC and Archive databases are
+    /// considered hot.
     temp: Temperature,
 }
 


### PR DESCRIPTION
Cold database stores only some of the columns so when creating it
there’s no reason to configure and create all columns present in hot
database.

With this change, trying to read non-cold columns from cold database
results in panic with ‘Missing cf handle for {col}’ message.  This
happens in RocksDB::get_cf_handles.

This commit will break any existing cold databases (in the sense that
node won’t be able to open them) but since that’s an experimental
feature it should not be an issue.
