### PR TITLE
fix for the flaky no_edge_broadcast_after_restart

### DIFF
--- a/chain/network/src/network_protocol/edge.rs
+++ b/chain/network/src/network_protocol/edge.rs
@@ -147,7 +147,7 @@ impl Edge {
         Edge(Arc::new(edge))
     }
 
-    fn hash(&self) -> CryptoHash {
+    pub(crate) fn hash(&self) -> CryptoHash {
         Edge::build_hash(&self.key().0, &self.key().1, self.nonce())
     }
 

--- a/chain/network/src/peer_manager/tests/routing.rs
+++ b/chain/network/src/peer_manager/tests/routing.rs
@@ -210,6 +210,8 @@ async fn no_edge_broadcast_after_restart() {
         let stream = tcp::Stream::connect(&pm.peer_info()).await.unwrap();
         let mut peer = peer::testonly::PeerHandle::start_endpoint(clock.clock(), cfg, stream).await;
         peer.complete_handshake().await;
+        // Wait for the initial sync, which will contain just 1 edge.
+        // Only incremental sync are guaranteed to not contain already known edges.
         wait_for_edges(peer.events.clone(), &[peer.edge.clone().unwrap()].into()).await;
 
         // Create a bunch of fresh unreachable edges, then send all the edges created so far.
@@ -227,7 +229,7 @@ async fn no_edge_broadcast_after_restart() {
         }))
         .await;
 
-        // Wait for the fresh edges and the connection edge to be broadcasted back.
+        // Wait for the fresh edges to be broadcasted back.
         tracing::info!(target: "test", "wait_for_edges(<fresh edges>)");
         wait_for_edges(peer_events, &fresh_edges).await;
 

--- a/chain/network/src/peer_manager/tests/routing.rs
+++ b/chain/network/src/peer_manager/tests/routing.rs
@@ -158,11 +158,13 @@ async fn wait_for_edges(
     want: &HashSet<Edge>,
 ) {
     let mut got = HashSet::new();
+    tracing::info!(target: "test", "want edges: {:?}",want.iter().map(|e|e.hash()).collect::<Vec<_>>());
     while &got != want {
         match events.recv().await {
             peer::testonly::Event::Network(PME::MessageProcessed(
                 PeerMessage::SyncRoutingTable(msg),
             )) => {
+                tracing::info!(target: "test", "got edges: {:?}",msg.edges.iter().map(|e|e.hash()).collect::<Vec<_>>());
                 got.extend(msg.edges);
                 assert!(want.is_superset(&got), "want: {:#?}, got: {:#?}", want, got);
             }

--- a/chain/network/src/peer_manager/tests/routing.rs
+++ b/chain/network/src/peer_manager/tests/routing.rs
@@ -208,7 +208,7 @@ async fn no_edge_broadcast_after_restart() {
         let stream = tcp::Stream::connect(&pm.peer_info()).await.unwrap();
         let mut peer = peer::testonly::PeerHandle::start_endpoint(clock.clock(), cfg, stream).await;
         peer.complete_handshake().await;
-        pm.wait_for_routing_table(&mut clock, &[(peer.cfg.id(), vec![peer.cfg.id()])]).await;
+        wait_for_edges(peer.events.clone(), &[peer.edge.clone().unwrap()].into()).await;
 
         // Create a bunch of fresh unreachable edges, then send all the edges created so far.
         let fresh_edges: HashSet<_> = [

--- a/chain/network/src/peer_manager/tests/routing.rs
+++ b/chain/network/src/peer_manager/tests/routing.rs
@@ -235,12 +235,14 @@ async fn no_edge_broadcast_after_restart() {
 
         // Trigger update_routing_table, which is expected to prune all edges from total_edges.
         // (Since they are unreachable).
-        let mut events = pm.events.from_now(); 
+        let mut events = pm.events.from_now();
         clock.advance(peer_manager_actor::UPDATE_ROUTING_TABLE_INTERVAL);
-        events.recv_until(|ev|match ev {
-            Event::PeerManager(PME::RoutingTableUpdate{..}) => Some(()),
-            _ => None,
-        }).await;
+        events
+            .recv_until(|ev| match ev {
+                Event::PeerManager(PME::RoutingTableUpdate { .. }) => Some(()),
+                _ => None,
+            })
+            .await;
     }
 }
 


### PR DESCRIPTION
The test is quite fragile unfortunately. To fix that we will need to refactor the routing::Actor.