### PR TITLE
do not enter sync mode if peer is at an invalid hash

### DIFF
--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -348,4 +348,6 @@ pub enum BlockKnownError {
     KnownInStore,
     #[error("already known in blocks in processing")]
     KnownInProcessing,
+    #[error("already known in invalid blocks")]
+    KnownAsInvalid,
 }

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -79,6 +79,7 @@ use crate::{metrics, DoomslugThresholdMode};
 use actix::Message;
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use delay_detector::DelayDetector;
+use lru::LruCache;
 use near_client_primitives::types::StateSplitApplyingStatus;
 use near_primitives::shard_layout::{
     account_id_to_shard_id, account_id_to_shard_uid, ShardLayout, ShardUId,
@@ -100,6 +101,9 @@ const MAX_ORPHAN_AGE_SECS: u64 = 300;
 // Orphans for which we will request for missing chunks must satisfy,
 // its NUM_ORPHAN_ANCESTORS_CHECK'th ancestor has been accepted
 pub const NUM_ORPHAN_ANCESTORS_CHECK: u64 = 3;
+
+/// The size of the invalid_blocks in-memory pool
+pub const INVALID_CHUNKS_POOL_SIZE: usize = 5000;
 
 // Maximum number of orphans that we can request missing chunks
 // Note that if there are no forks, the maximum number of orphans we would
@@ -414,6 +418,9 @@ pub fn check_known(
     if chain.blocks_with_missing_chunks.contains(block_hash) {
         return Ok(Err(BlockKnownError::KnownInMissingChunks));
     }
+    if chain.is_block_invalid(block_hash) {
+        return Ok(Err(BlockKnownError::KnownAsInvalid));
+    }
     check_known_store(chain, block_hash)
 }
 
@@ -446,6 +453,8 @@ pub struct Chain {
     last_time_head_updated: Instant,
     /// Used when it is needed to create flat storage in background for some shards.
     flat_storage_creator: Option<FlatStorageCreator>,
+
+    invalid_blocks: LruCache<CryptoHash, ()>,
 
     /// Support for sandbox's patch_state requests.
     ///
@@ -526,6 +535,7 @@ impl Chain {
             apply_chunks_receiver: rc,
             last_time_head_updated: Clock::instant(),
             flat_storage_creator: None,
+            invalid_blocks: LruCache::new(INVALID_CHUNKS_POOL_SIZE),
             pending_state_patch: Default::default(),
             requested_state_parts: StateRequestTracker::new(),
         })
@@ -667,6 +677,7 @@ impl Chain {
             orphans: OrphanBlockPool::new(),
             blocks_with_missing_chunks: MissingChunksPool::new(),
             blocks_in_processing: BlocksInProcessing::new(),
+            invalid_blocks: LruCache::new(INVALID_CHUNKS_POOL_SIZE),
             genesis: genesis.clone(),
             transaction_validity_period: chain_genesis.transaction_validity_period,
             epoch_length: chain_genesis.epoch_length,
@@ -2116,6 +2127,10 @@ impl Chain {
         let new_head =
             match self.postprocess_block_only(me, &block, block_preprocess_info, apply_results) {
                 Err(err) => {
+                    if err.is_bad_data() {
+                        self.invalid_blocks.put(*block.hash(), ());
+                        metrics::NUM_INVALID_BLOCKS.inc();
+                    }
                     self.blocks_delay_tracker.mark_block_errored(&block_hash, err.to_string());
                     return Err(err);
                 }
@@ -4333,6 +4348,11 @@ impl Chain {
     #[inline]
     pub fn is_height_processed(&self, height: BlockHeight) -> Result<bool, Error> {
         self.store.is_height_processed(height)
+    }
+
+    #[inline]
+    pub fn is_block_invalid(&self, hash: &CryptoHash) -> bool {
+        self.invalid_blocks.contains(hash)
     }
 
     /// Check if can sync with sync_hash

--- a/chain/chain/src/metrics.rs
+++ b/chain/chain/src/metrics.rs
@@ -105,7 +105,7 @@ pub static STATE_PART_ELAPSED: Lazy<HistogramVec> = Lazy::new(|| {
         &["shard_id"],
         Some(exponential_buckets(0.001, 1.6, 20).unwrap()),
     )
-    .unwrap();
+    .unwrap()
 });
 pub static NUM_INVALID_BLOCKS: Lazy<IntGauge> = Lazy::new(|| {
     try_create_int_gauge("near_num_invalid_blocks", "Number of invalid blocks").unwrap()

--- a/chain/chain/src/metrics.rs
+++ b/chain/chain/src/metrics.rs
@@ -105,7 +105,8 @@ pub static STATE_PART_ELAPSED: Lazy<HistogramVec> = Lazy::new(|| {
         &["shard_id"],
         Some(exponential_buckets(0.001, 1.6, 20).unwrap()),
     )
-    .unwrap()
+    .unwrap();
+});
 pub static NUM_INVALID_BLOCKS: Lazy<IntGauge> = Lazy::new(|| {
     try_create_int_gauge("near_num_invalid_blocks", "Number of invalid blocks").unwrap()
 });

--- a/chain/chain/src/metrics.rs
+++ b/chain/chain/src/metrics.rs
@@ -106,4 +106,6 @@ pub static STATE_PART_ELAPSED: Lazy<HistogramVec> = Lazy::new(|| {
         Some(exponential_buckets(0.001, 1.6, 20).unwrap()),
     )
     .unwrap()
+pub static NUM_INVALID_BLOCKS: Lazy<IntGauge> = Lazy::new(|| {
+    try_create_int_gauge("near_num_invalid_blocks", "Number of invalid blocks").unwrap()
 });

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1486,7 +1486,7 @@ impl ClientActor {
             .network_info
             .highest_height_peers
             .iter()
-            .filter(|p| !self.client.chain.is_block_invalid(&p.hash));
+            .filter(|p| !self.client.chain.is_block_invalid(&p.highest_block_hash));
         let peer_info = if let Some(peer_info) = eligible_peers.choose(&mut thread_rng()) {
             peer_info
         } else {

--- a/chain/client/src/metrics.rs
+++ b/chain/client/src/metrics.rs
@@ -142,6 +142,11 @@ pub(crate) static PROTOCOL_UPGRADE_BLOCK_HEIGHT: Lazy<IntGauge> = Lazy::new(|| {
     .unwrap()
 });
 
+pub(crate) static PEERS_WITH_INVALID_HASH: Lazy<IntGauge> = Lazy::new(|| {
+    try_create_int_gauge("near_peers_with_invalid_hash", "Number of peers that are on invalid hash")
+        .unwrap()
+});
+
 pub(crate) static CHUNK_SKIPPED_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
     try_create_int_counter_vec(
         "near_chunk_skipped_total",


### PR DESCRIPTION
Unfortunately, it is very hard to add test for this because the syncing logic is in ClientActor. I already tested this in localnet and Robin tested it on mocknet and we verified that it behaves as expected.

My plan is to merge this PR as it is, but I'll have a follow up PR where I refactor the ClientActor code to move the logic into client and also add tests. 
