### PR TITLE
deflaked fix_local_edges test

### DIFF
--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -1153,22 +1153,31 @@ impl actix::Actor for PeerActor {
         // It happens a lot in tests.
         metrics::PEER_CONNECTIONS_TOTAL.dec();
         debug!(target: "network", "{:?}: [status = {:?}] Peer {} disconnected.", self.my_node_info.id, self.peer_status, self.peer_info);
+        if self.closing_reason.is_none() {
+            // Due to Actix semantics, sometimes closing reason may be not set.
+            // But it is only expected to happen in tests.
+            tracing::error!(target:"network", "closing reason not set. This should happen only in tests.");
+        }
         match &self.peer_status {
             // If PeerActor is in Connecting state, then
             // it was not registered in the NewtorkState,
             // so there is nothing to be done.
-            PeerStatus::Connecting(..) => {}
+            PeerStatus::Connecting(..) => {
+                // TODO(gprusak): reporting ConnectionClosed event is quite scattered right now and
+                // it is very ugly: it may happen here, in spawn_inner, or in NetworkState::unregister().
+                // Centralize it, once we get rid of actix.
+                self.network_state.config.event_sink.push(Event::ConnectionClosed(
+                    ConnectionClosedEvent {
+                        stream_id: self.stream_id,
+                        reason: self.closing_reason.clone().unwrap_or(ClosingReason::Unknown),
+                    },
+                ));
+            }
             // Clean up the Connection from the NetworkState.
             PeerStatus::Ready(conn) => {
                 let network_state = self.network_state.clone();
                 let clock = self.clock.clone();
                 let conn = conn.clone();
-                if self.closing_reason == None {
-                    // Due to Actix semantics, sometimes closing reason may be not set.
-                    // But it is only expected to happen in tests.
-                    tracing::error!(target:"network", "closing reason not set. This should happen only in tests.");
-                }
-
                 network_state.unregister(
                     &clock,
                     &conn,

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -6,6 +6,7 @@ use crate::network_protocol::{
     Edge, EdgeState, PartialEdgeInfo, PeerIdOrHash, PeerInfo, PeerMessage, Ping, Pong,
     RawRoutedMessage, RoutedMessageBody, RoutedMessageV2, RoutingTableUpdate, SignedAccountData,
 };
+use crate::peer::peer_actor::{ClosingReason, ConnectionClosedEvent};
 use crate::peer_manager::connection;
 use crate::peer_manager::peer_manager_actor::Event;
 use crate::peer_manager::peer_store;
@@ -14,6 +15,7 @@ use crate::routing;
 use crate::routing::routing_table_view::RoutingTableView;
 use crate::stats::metrics;
 use crate::store;
+use crate::tcp;
 use crate::time;
 use crate::types::{ChainInfo, PeerType, ReasonForBan};
 use arc_swap::ArcSwap;
@@ -306,7 +308,8 @@ impl NetworkState {
         self: &Arc<Self>,
         clock: &time::Clock,
         conn: &Arc<connection::Connection>,
-        ban_reason: Option<ReasonForBan>,
+        stream_id: tcp::StreamId,
+        reason: ClosingReason,
     ) {
         let this = self.clone();
         let clock = clock.clone();
@@ -326,15 +329,18 @@ impl NetworkState {
             }
 
             // Save the fact that we are disconnecting to the PeerStore.
-            let res = match ban_reason {
-                Some(ban_reason) => {
+            let res = match reason {
+                ClosingReason::Ban(ban_reason) => {
                     this.peer_store.peer_ban(&clock, &conn.peer_info.id, ban_reason)
                 }
-                None => this.peer_store.peer_disconnected(&clock, &conn.peer_info.id),
+                _ => this.peer_store.peer_disconnected(&clock, &conn.peer_info.id),
             };
             if let Err(err) = res {
                 tracing::error!(target: "network", ?err, "Failed to save peer data");
             }
+            this.config
+                .event_sink
+                .push(Event::ConnectionClosed(ConnectionClosedEvent { stream_id, reason }));
         });
     }
 

--- a/chain/network/src/peer_manager/tests/nonce.rs
+++ b/chain/network/src/peer_manager/tests/nonce.rs
@@ -57,7 +57,7 @@ async fn test_nonces() {
     ];
 
     for test in test_cases {
-        println!("Running test {:?}", test.2);
+        tracing::info!(target: "test", "Running test {:?}", test.2);
         let cfg = peer::testonly::PeerConfig {
             network: chain.make_config(rng),
             chain: chain.clone(),


### PR DESCRIPTION
Removed a flake of fix_local_edges test that I managed to reproduce locally.
The event ConnectionClosed was being emitted too early: it should be sent only once the asynchronous call to unregister completes.