### PR TITLE
Introduce ‘stdx’ crate with split array polyfills

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3033,6 +3033,7 @@ dependencies = [
  "ed25519-dalek",
  "hex-literal",
  "near-account-id",
+ "near-stdx",
  "once_cell",
  "primitive-types",
  "rand 0.7.3",
@@ -3040,7 +3041,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.2",
- "stdx",
  "subtle",
  "tempfile",
  "thiserror",
@@ -3518,6 +3518,10 @@ name = "near-stable-hasher"
 version = "0.0.0"
 
 [[package]]
+name = "near-stdx"
+version = "0.0.0"
+
+[[package]]
 name = "near-store"
 version = "0.0.0"
 dependencies = [
@@ -3538,6 +3542,7 @@ dependencies = [
  "near-crypto",
  "near-o11y",
  "near-primitives",
+ "near-stdx",
  "num_cpus",
  "once_cell",
  "rand 0.8.5",
@@ -3545,7 +3550,6 @@ dependencies = [
  "rocksdb",
  "serde",
  "serde_json",
- "stdx",
  "strum",
  "tempfile",
  "thiserror",
@@ -3607,13 +3611,13 @@ dependencies = [
  "near-o11y",
  "near-primitives",
  "near-primitives-core",
+ "near-stdx",
  "near-vm-errors",
  "ripemd",
  "serde",
  "serde_json",
  "sha2 0.10.2",
  "sha3",
- "stdx",
  "tracing",
  "zeropool-bn",
 ]
@@ -5483,10 +5487,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "stdx"
-version = "0.0.0"
 
 [[package]]
 name = "storage-usage-delta-calculator"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3040,6 +3040,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.2",
+ "stdx",
  "subtle",
  "tempfile",
  "thiserror",
@@ -3544,6 +3545,7 @@ dependencies = [
  "rocksdb",
  "serde",
  "serde_json",
+ "stdx",
  "strum",
  "tempfile",
  "thiserror",
@@ -3611,6 +3613,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.2",
  "sha3",
+ "stdx",
  "tracing",
  "zeropool-bn",
 ]
@@ -5480,6 +5483,10 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stdx"
+version = "0.0.0"
 
 [[package]]
 name = "storage-usage-delta-calculator"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ members = [
     "tools/themis",
     "utils/mainnet-res",
     "utils/near-cache",
+    "utils/stdx",
 ]
 
 [workspace.metadata.workspaces]
@@ -201,6 +202,8 @@ wasmtime = { version = "0.37.0", default-features = false, features = ["cranelif
 wat = "1.0.40"
 xshell = "0.2.1"
 xz2 = "0.1.6"
+
+stdx = { path = "utils/stdx" }
 
 [patch.crates-io]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,7 +203,7 @@ wat = "1.0.40"
 xshell = "0.2.1"
 xz2 = "0.1.6"
 
-stdx = { path = "utils/stdx" }
+stdx = { package = "near-stdx", path = "utils/stdx" }
 
 [patch.crates-io]
 

--- a/core/crypto/Cargo.toml
+++ b/core/crypto/Cargo.toml
@@ -25,6 +25,7 @@ rand = "0.7"
 secp256k1.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+stdx.workspace = true
 subtle.workspace = true
 thiserror.workspace = true
 

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -25,6 +25,7 @@ rlimit.workspace = true
 rocksdb.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+stdx.workspace = true
 strum.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true

--- a/core/store/src/db/refcount.rs
+++ b/core/store/src/db/refcount.rs
@@ -39,11 +39,8 @@ pub fn decode_value_with_rc(bytes: &[u8]) -> (Option<&[u8]>, i64) {
         debug_assert!(bytes.is_empty());
         return (None, 0);
     }
-    // TODO(mina86): Use rsplit_array_ref once split_array feature is stabilised
-    //    let (head, tail) = bytes.rsplit_array_ref<8>();
-    //    let rc = i64::from_le_bytes(tail);
-    let (head, tail) = bytes.split_at(bytes.len() - 8);
-    let rc = i64::from_le_bytes(tail.try_into().unwrap());
+    let (head, tail) = stdx::rsplit_slice::<8>(bytes);
+    let rc = i64::from_le_bytes(*tail);
     if rc <= 0 {
         (None, rc)
     } else {

--- a/runtime/near-vm-logic/Cargo.toml
+++ b/runtime/near-vm-logic/Cargo.toml
@@ -23,6 +23,7 @@ ripemd.workspace = true
 serde.workspace = true
 sha2.workspace = true
 sha3.workspace = true
+stdx.workspace = true
 tracing = { workspace = true, optional = true }
 
 near-crypto = { path = "../../core/crypto" }

--- a/runtime/near-vm-logic/src/alt_bn128.rs
+++ b/runtime/near-vm-logic/src/alt_bn128.rs
@@ -1,4 +1,4 @@
-use crate::array_utils::{join_array, split_array, ArrayChunks};
+use crate::array_utils::ArrayChunks;
 use bn::Group;
 use near_vm_errors::{HostError, VMLogicError};
 
@@ -40,7 +40,7 @@ pub(crate) fn g1_multiexp(
 ) -> Result<[u8; POINT_SIZE], InvalidInput> {
     let elements: Vec<(bn::G1, bn::Fr)> = elements
         .map(|chunk| {
-            let (g1, fr) = split_array(chunk);
+            let (g1, fr) = stdx::split_array(chunk);
             let g1 = decode_g1(g1)?;
             let fr = decode_fr(fr)?;
             Ok((g1, fr))
@@ -60,7 +60,7 @@ pub(crate) fn g1_sum(
     let elements: Vec<(bool, bn::G1)> = {
         elements
             .map(|chunk| {
-                let (sign, g1) = split_array(chunk);
+                let (sign, g1) = stdx::split_array(chunk);
                 let sign = decode_bool(sign)?;
                 let g1 = decode_g1(g1)?;
                 Ok((sign, g1))
@@ -82,7 +82,7 @@ pub(crate) fn pairing_check(
 ) -> Result<bool, InvalidInput> {
     let elements: Vec<(bn::G1, bn::G2)> = elements
         .map(|chunk| {
-            let (g1, g2) = split_array(chunk);
+            let (g1, g2) = stdx::split_array(chunk);
             let g1 = decode_g1(g1)?;
             let g2 = decode_g2(g2)?;
             Ok((g1, g2))
@@ -100,7 +100,7 @@ fn encode_g1(val: bn::G1) -> [u8; POINT_SIZE] {
         .unwrap_or_else(|| (bn::Fq::zero(), bn::Fq::zero()));
     let x = encode_fq(x);
     let y = encode_fq(y);
-    join_array(x, y)
+    stdx::join_array(x, y)
 }
 
 fn encode_fq(val: bn::Fq) -> [u8; SCALAR_SIZE] {
@@ -109,11 +109,11 @@ fn encode_fq(val: bn::Fq) -> [u8; SCALAR_SIZE] {
 
 fn encode_u256(val: bn::arith::U256) -> [u8; SCALAR_SIZE] {
     let [lo, hi] = val.0;
-    join_array(lo.to_le_bytes(), hi.to_le_bytes())
+    stdx::join_array(lo.to_le_bytes(), hi.to_le_bytes())
 }
 
 fn decode_g1(raw: &[u8; POINT_SIZE]) -> Result<bn::G1, InvalidInput> {
-    let (x, y) = split_array(raw);
+    let (x, y) = stdx::split_array(raw);
     let x = decode_fq(x)?;
     let y = decode_fq(y)?;
     if x.is_zero() && y.is_zero() {
@@ -131,7 +131,7 @@ fn decode_fq(raw: &[u8; SCALAR_SIZE]) -> Result<bn::Fq, InvalidInput> {
 }
 
 fn decode_g2(raw: &[u8; 2 * POINT_SIZE]) -> Result<bn::G2, InvalidInput> {
-    let (x, y) = split_array(raw);
+    let (x, y) = stdx::split_array(raw);
     let x = decode_fq2(x)?;
     let y = decode_fq2(y)?;
     if x.is_zero() && y.is_zero() {
@@ -144,7 +144,7 @@ fn decode_g2(raw: &[u8; 2 * POINT_SIZE]) -> Result<bn::G2, InvalidInput> {
 }
 
 fn decode_fq2(raw: &[u8; 2 * SCALAR_SIZE]) -> Result<bn::Fq2, InvalidInput> {
-    let (real, imaginary) = split_array(raw);
+    let (real, imaginary) = stdx::split_array(raw);
     let real = decode_fq(real)?;
     let imaginary = decode_fq(imaginary)?;
     Ok(bn::Fq2::new(real, imaginary))
@@ -156,7 +156,7 @@ fn decode_fr(raw: &[u8; SCALAR_SIZE]) -> Result<bn::Fr, InvalidInput> {
 }
 
 fn decode_u256(raw: &[u8; SCALAR_SIZE]) -> bn::arith::U256 {
-    let (lo, hi) = split_array(raw);
+    let (lo, hi) = stdx::split_array(raw);
     let lo = u128::from_le_bytes(*lo);
     let hi = u128::from_le_bytes(*hi);
     bn::arith::U256([lo, hi])

--- a/runtime/near-vm-logic/src/array_utils.rs
+++ b/runtime/near-vm-logic/src/array_utils.rs
@@ -2,30 +2,6 @@
 
 use std::slice::ChunksExact;
 
-/// Splits `&[u8; A + B]` into `(&[u8; A], &[u8; B])`.
-pub(crate) fn split_array<const N: usize, const L: usize, const R: usize>(
-    xs: &[u8; N],
-) -> (&[u8; L], &[u8; R]) {
-    let () = AssertEqSum::<N, L, R>::OK;
-
-    let (left, right) = xs.split_at(L);
-    (left.try_into().unwrap(), right.try_into().unwrap())
-}
-
-/// Joins `[u8; A]` and `[u8; B]` into `[u8; A + B]`.
-pub(crate) fn join_array<const N: usize, const L: usize, const R: usize>(
-    left: [u8; L],
-    right: [u8; R],
-) -> [u8; N] {
-    let () = AssertEqSum::<N, L, R>::OK;
-
-    let mut res = [0; N];
-    let (l, r) = res.split_at_mut(L);
-    l.copy_from_slice(&left);
-    r.copy_from_slice(&right);
-    res
-}
-
 /// Converts an `&[u8]` slice of length `N * k` into iterator of `k` `[u8; N]`
 /// chunks.
 pub(crate) struct ArrayChunks<'a, const N: usize> {
@@ -55,9 +31,3 @@ impl<'a, const N: usize> Iterator for ArrayChunks<'a, N> {
 }
 
 impl<'a, const N: usize> ExactSizeIterator for ArrayChunks<'a, N> {}
-
-/// Asserts, at compile time, that `S == A + B`.
-struct AssertEqSum<const S: usize, const A: usize, const B: usize>;
-impl<const S: usize, const A: usize, const B: usize> AssertEqSum<S, A, B> {
-    const OK: () = [()][A + B - S];
-}

--- a/utils/stdx/Cargo.toml
+++ b/utils/stdx/Cargo.toml
@@ -6,4 +6,5 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-# Must not depend on any crates from nearcore workspace.
+# Absolutely must not depend on any crates from nearcore workspace,
+# and should have as few dependencies as possible otherwise. 

--- a/utils/stdx/Cargo.toml
+++ b/utils/stdx/Cargo.toml
@@ -4,6 +4,12 @@ version = "0.0.0"
 authors.workspace = true
 edition.workspace = true
 publish = true
+rust-version.workspace = true
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/near/nearcore"
+description = """
+This crate contains polyfills which should really be in std, but currently aren't for one reason or another.
+"""
 
 [dependencies]
 # Absolutely must not depend on any crates from nearcore workspace,

--- a/utils/stdx/Cargo.toml
+++ b/utils/stdx/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "stdx"
+version = "0.0.0"
+authors.workspace = true
+edition.workspace = true
+publish = false
+
+[dependencies]
+# Must not depend on any crates from nearcore workspace.

--- a/utils/stdx/Cargo.toml
+++ b/utils/stdx/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "stdx"
+name = "near-stdx"
 version = "0.0.0"
 authors.workspace = true
 edition.workspace = true
-publish = false
+publish = true
 
 [dependencies]
 # Absolutely must not depend on any crates from nearcore workspace,
-# and should have as few dependencies as possible otherwise. 
+# and should have as few dependencies as possible otherwise.

--- a/utils/stdx/LICENSE-APACHE
+++ b/utils/stdx/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/utils/stdx/LICENSE-MIT
+++ b/utils/stdx/LICENSE-MIT
@@ -1,0 +1,19 @@
+The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/utils/stdx/src/lib.rs
+++ b/utils/stdx/src/lib.rs
@@ -1,3 +1,6 @@
+//! `stdx` crate contains polyfills which should really be in std,
+//! but currently aren't for one reason or another. 
+
 // TODO(mina86): Replace usage of the split functions by split_array_ref et al
 // methods of array and slice types once those are stabilised.
 

--- a/utils/stdx/src/lib.rs
+++ b/utils/stdx/src/lib.rs
@@ -1,5 +1,5 @@
 //! `stdx` crate contains polyfills which should really be in std,
-//! but currently aren't for one reason or another. 
+//! but currently aren't for one reason or another.
 
 // TODO(mina86): Replace usage of the split functions by split_array_ref et al
 // methods of array and slice types once those are stabilised.

--- a/utils/stdx/src/lib.rs
+++ b/utils/stdx/src/lib.rs
@@ -1,0 +1,88 @@
+// TODO(mina86): Replace usage of the split functions by split_array_ref et al
+// methods of array and slice types once those are stabilised.
+
+/// Splits `&[u8; L + R]` into `(&[u8; L], &[u8; R])`.
+pub fn split_array<const N: usize, const L: usize, const R: usize>(
+    xs: &[u8; N],
+) -> (&[u8; L], &[u8; R]) {
+    let () = AssertEqSum::<N, L, R>::OK;
+
+    let (left, right) = xs.split_at(L);
+    (left.try_into().unwrap(), right.try_into().unwrap())
+}
+
+/// Splits `&mut [u8; L + R]` into `(&mut [u8; L], &mut [u8; R])`.
+pub fn split_array_mut<const N: usize, const L: usize, const R: usize>(
+    xs: &mut [u8; N],
+) -> (&mut [u8; L], &mut [u8; R]) {
+    let () = AssertEqSum::<N, L, R>::OK;
+
+    let (left, right) = xs.split_at_mut(L);
+    (left.try_into().unwrap(), right.try_into().unwrap())
+}
+
+/// Splits `&[u8]` into `(&[u8; N], &[u8])`.  **Panics** if slice is shorter
+/// than `N`.
+pub fn split_slice<const N: usize>(slice: &[u8]) -> (&[u8; N], &[u8]) {
+    let (head, tail) = slice.split_at(N);
+    (head.try_into().unwrap(), tail)
+}
+
+/// Splits `&[u8]` into `(&[u8], &[u8; N])`.  **Panics** if slice is shorter
+/// than `N`.
+pub fn rsplit_slice<const N: usize>(slice: &[u8]) -> (&[u8], &[u8; N]) {
+    let index = slice.len().checked_sub(N).expect("len to be ≥ N");
+    let (head, tail) = slice.split_at(index);
+    (head, tail.try_into().unwrap())
+}
+
+/// Splits `&[u8]` into `(&[u8; N], &[u8])`.  **Panics** if slice is shorter
+/// than `N`.
+pub fn split_slice_mut<const N: usize>(slice: &mut [u8]) -> (&mut [u8; N], &mut [u8]) {
+    let (head, tail) = slice.split_at_mut(N);
+    (head.try_into().unwrap(), tail)
+}
+
+/// Splits `&[u8]` into `(&[u8], &[u8; N])`.  **Panics** if slice is shorter
+/// than `N`.
+pub fn rsplit_slice_mut<const N: usize>(slice: &mut [u8]) -> (&mut [u8], &mut [u8; N]) {
+    let index = slice.len().checked_sub(N).expect("len to be ≥ N");
+    let (head, tail) = slice.split_at_mut(index);
+    (head, tail.try_into().unwrap())
+}
+
+#[test]
+fn test_split() {
+    assert_eq!((&[0, 1], &[2, 3, 4]), split_array(&[0, 1, 2, 3, 4]));
+    assert_eq!((&mut [0, 1], &mut [2, 3, 4]), split_array_mut(&mut [0, 1, 2, 3, 4]));
+
+    assert_eq!((&[0, 1], &[2, 3, 4][..]), split_slice(&[0, 1, 2, 3, 4]));
+    assert_eq!((&[0, 1][..], &[2, 3, 4]), rsplit_slice(&[0, 1, 2, 3, 4]));
+    assert_eq!((&mut [0, 1], &mut [2, 3, 4][..]), split_slice_mut(&mut [0, 1, 2, 3, 4]));
+    assert_eq!((&mut [0, 1][..], &mut [2, 3, 4]), rsplit_slice_mut(&mut [0, 1, 2, 3, 4]));
+}
+
+/// Joins `[u8; L]` and `[u8; R]` into `[u8; L + R]`.
+pub fn join_array<const N: usize, const L: usize, const R: usize>(
+    left: [u8; L],
+    right: [u8; R],
+) -> [u8; N] {
+    let () = AssertEqSum::<N, L, R>::OK;
+
+    let mut res = [0; N];
+    let (l, r) = res.split_at_mut(L);
+    l.copy_from_slice(&left);
+    r.copy_from_slice(&right);
+    res
+}
+
+#[test]
+fn test_join() {
+    assert_eq!([0, 1, 2, 3], join_array([0, 1], [2, 3]));
+}
+
+/// Asserts, at compile time, that `S == A + B`.
+struct AssertEqSum<const S: usize, const A: usize, const B: usize>;
+impl<const S: usize, const A: usize, const B: usize> AssertEqSum<S, A, B> {
+    const OK: () = [()][A + B - S];
+}


### PR DESCRIPTION
This consolidates all the places where array splitting happens into
a single module.  In the future, once split_array_ref feature gets
stabilised, we’ll be able to get rid of those polyfills but for now
it’s nice to have them all in one place.

The new `stdx` crate also provides a place where other common utility
features can be put so that the same function doesn’t need to be
implemented in multiple crates or put in a crate it doesn’t fit in and
made public just because some other crate depends on it.

Crucially, the crate must not depend on any crates from the workspace.
