### PR TITLE
A tool to dump a single or all state parts of the state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3419,6 +3419,7 @@ dependencies = [
  "smart-default",
  "strum",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2824,6 +2824,13 @@ impl Chain {
         part_id: u64,
         sync_hash: CryptoHash,
     ) -> Result<Vec<u8>, Error> {
+        let _span = tracing::debug_span!(
+            target: "sync",
+            "get_state_response_part",
+            shard_id,
+            part_id,
+            %sync_hash)
+        .entered();
         // Check cache
         let key = StatePartKey(sync_hash, shard_id, part_id).try_to_vec()?;
         if let Ok(Some(state_part)) = self.store.store().get(DBCol::StateParts, &key) {

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -32,6 +32,7 @@ serde_json.workspace = true
 smart-default.workspace = true
 strum.workspace = true
 thiserror.workspace = true
+tracing.workspace = true
 
 near-crypto = { path = "../crypto" }
 near-o11y = { path = "../o11y" }

--- a/core/primitives/src/state_part.rs
+++ b/core/primitives/src/state_part.rs
@@ -1,5 +1,5 @@
 // to specify a part we always specify both part_id and num_parts together
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct PartId {
     pub idx: u64,
     pub total: u64,

--- a/core/primitives/src/syncing.rs
+++ b/core/primitives/src/syncing.rs
@@ -224,5 +224,7 @@ pub fn get_num_state_parts(memory_usage: u64) -> u64 {
     // On the other side, it's important to divide any state into
     // several parts to make sure that partitioning always works.
     // TODO #1708
-    memory_usage / STATE_PART_MEMORY_LIMIT.as_u64() + 3
+    let num_parts = memory_usage / STATE_PART_MEMORY_LIMIT.as_u64() + 3;
+    tracing::debug!(target: "sync", memory_usage, num_parts, "get_num_state_parts");
+    num_parts
 }

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -1203,6 +1203,13 @@ impl RuntimeAdapter for NightshadeRuntime {
         state_root: &StateRoot,
         part_id: PartId,
     ) -> Result<Vec<u8>, Error> {
+        let _span = tracing::debug_span!(
+            target: "runtime",
+            "obtain_state_part",
+            shard_id,
+            %block_hash,
+            ?part_id)
+        .entered();
         let epoch_id = self.get_epoch_id(block_hash)?;
         let shard_uid = self.get_shard_uid_from_epoch_id(shard_id, &epoch_id)?;
         let trie = self.tries.get_view_trie_for_shard(shard_uid, state_root.clone());

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -1,4 +1,5 @@
 use crate::commands::*;
+use crate::dump_state_parts::dump_state_parts;
 use crate::epoch_info;
 use crate::rocksdb_stats::get_rocksdb_stats;
 use clap::{Args, Parser, Subcommand};
@@ -70,6 +71,7 @@ pub enum StateViewerSubCommand {
     /// View trie structure.
     #[clap(alias = "view_trie")]
     ViewTrie(ViewTrieCmd),
+    DumpStateParts(DumpStatePartsCmd),
 }
 
 impl StateViewerSubCommand {
@@ -84,6 +86,7 @@ impl StateViewerSubCommand {
             StateViewerSubCommand::Peers => peers(store),
             StateViewerSubCommand::State => state(home_dir, near_config, hot),
             StateViewerSubCommand::DumpState(cmd) => cmd.run(home_dir, near_config, hot),
+            StateViewerSubCommand::DumpStateParts(cmd) => cmd.run(home_dir, near_config, hot),
             StateViewerSubCommand::DumpStateRedis(cmd) => cmd.run(home_dir, near_config, hot),
             StateViewerSubCommand::DumpTx(cmd) => cmd.run(home_dir, near_config, hot),
             StateViewerSubCommand::Chain(cmd) => cmd.run(home_dir, near_config, hot),
@@ -468,5 +471,28 @@ impl ViewTrieCmd {
     pub fn run(self, store: Store) {
         let hash = CryptoHash::from_str(&self.hash).unwrap();
         view_trie(store, hash, self.shard_id, self.shard_version, self.max_depth).unwrap();
+    }
+}
+
+#[derive(Parser)]
+pub struct DumpStatePartsCmd {
+    #[clap(long)]
+    block_hash: CryptoHash,
+    #[clap(long)]
+    shard_id: ShardId,
+    #[clap(long)]
+    part_id: Option<u64>,
+}
+
+impl DumpStatePartsCmd {
+    pub fn run(self, home_dir: &Path, near_config: NearConfig, store: Store) {
+        dump_state_parts(
+            self.block_hash,
+            self.shard_id,
+            self.part_id,
+            home_dir,
+            near_config,
+            store,
+        );
     }
 }

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -71,6 +71,7 @@ pub enum StateViewerSubCommand {
     /// View trie structure.
     #[clap(alias = "view_trie")]
     ViewTrie(ViewTrieCmd),
+    /// Dump all or a single state part of a shard.
     DumpStateParts(DumpStatePartsCmd),
 }
 

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -476,12 +476,18 @@ impl ViewTrieCmd {
 
 #[derive(Parser)]
 pub struct DumpStatePartsCmd {
+    /// Last block of a previous epoch.
     #[clap(long)]
     block_hash: CryptoHash,
+    /// Shard id.
     #[clap(long)]
     shard_id: ShardId,
+    /// State part id. Leave empty to go through every part in the shard.
     #[clap(long)]
     part_id: Option<u64>,
+    /// Where to write the state parts to.
+    #[clap(long)]
+    output_dir: PathBuf,
 }
 
 impl DumpStatePartsCmd {
@@ -493,6 +499,7 @@ impl DumpStatePartsCmd {
             home_dir,
             near_config,
             store,
+            &self.output_dir,
         );
     }
 }

--- a/tools/state-viewer/src/dump_state_parts.rs
+++ b/tools/state-viewer/src/dump_state_parts.rs
@@ -53,7 +53,7 @@ pub(crate) fn dump_state_parts(
                 PartId::new(part_id, num_parts),
             )
             .unwrap();
-        let filename = output_dir.join(format!("state_part_{}", part_id));
+        let filename = output_dir.join(format!("state_part_{:06}", part_id));
         let len = state_part.len();
         std::fs::write(filename.clone(), state_part).unwrap();
         tracing::debug!(

--- a/tools/state-viewer/src/dump_state_parts.rs
+++ b/tools/state-viewer/src/dump_state_parts.rs
@@ -1,0 +1,56 @@
+use near_chain::{ChainStore, ChainStoreAccess, RuntimeAdapter};
+use near_primitives::state_part::PartId;
+use near_primitives::syncing::get_num_state_parts;
+use near_primitives_core::hash::CryptoHash;
+use near_primitives_core::types::ShardId;
+use near_store::Store;
+use nearcore::{NearConfig, NightshadeRuntime};
+use std::path::Path;
+use std::sync::Arc;
+
+pub(crate) fn dump_state_parts(
+    sync_prev_hash: CryptoHash,
+    shard_id: ShardId,
+    part_id: Option<u64>,
+    home_dir: &Path,
+    near_config: NearConfig,
+    store: Store,
+) {
+    let runtime_adapter: Arc<dyn RuntimeAdapter> =
+        Arc::new(NightshadeRuntime::from_config(home_dir, store.clone(), &near_config));
+
+    let chain_store = ChainStore::new(
+        store.clone(),
+        near_config.genesis.config.genesis_height,
+        !near_config.client_config.archive,
+    );
+
+    let sync_prev_block = chain_store.get_block(&sync_prev_hash).unwrap();
+
+    assert!(runtime_adapter.is_next_block_epoch_start(&sync_prev_hash).unwrap());
+
+    assert!(
+        shard_id < sync_prev_block.chunks().len() as u64,
+        "shard_id: {}, #shards: {}",
+        shard_id,
+        sync_prev_block.chunks().len()
+    );
+    let state_root = sync_prev_block.chunks()[shard_id as usize].prev_state_root();
+    let state_root_node =
+        runtime_adapter.get_state_root_node(shard_id, &sync_prev_hash, &state_root).unwrap();
+
+    let num_parts = get_num_state_parts(state_root_node.memory_usage);
+
+    for part_id in if let Some(part_id) = part_id { part_id..part_id + 1 } else { 0..num_parts } {
+        assert!(part_id < num_parts, "part_id: {}, num_parts: {}", part_id, num_parts);
+        let state_part = runtime_adapter
+            .obtain_state_part(
+                shard_id,
+                &sync_prev_hash,
+                &state_root,
+                PartId::new(part_id, num_parts),
+            )
+            .unwrap();
+        println!("part_id: {}, result length: {}", part_id, state_part.len());
+    }
+}

--- a/tools/state-viewer/src/lib.rs
+++ b/tools/state-viewer/src/lib.rs
@@ -4,6 +4,7 @@ mod apply_chain_range;
 mod apply_chunk;
 pub mod cli;
 mod commands;
+mod dump_state_parts;
 mod epoch_info;
 mod rocksdb_stats;
 mod state_dump;


### PR DESCRIPTION
Tested by running on a testnet node.
`--block-hash` can be obtained by running `neard view-state epoch-info current`.