### PR TITLE
doc: move estimator guide to workflows

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -28,6 +28,7 @@
 - [Workflows](./practices/workflows/README.md)
   - [Run a Node](./practices/workflows/run_a_node.md)
   - [Deploy a Contract](./practices/workflows/deploy_a_contract.md)
+  - [Run Gas Estimations](./practices/workflows/gas_estimations.md)
 - [Code Style](./practices/style.md)
 - [Documentation](./practices/docs.md)
 - [Tracking Issues](./practices/tracking_issues.md)

--- a/docs/architecture/gas/estimator.md
+++ b/docs/architecture/gas/estimator.md
@@ -20,100 +20,9 @@ clients.
 The estimator code is part of the nearcore repository in the directory
 [runtime/runtime-params-estimator](https://github.com/near/nearcore/tree/master/runtime/runtime-params-estimator).
 
-## Running the Estimator
-
-Type this in your console to quickly run estimations on a couple of action costs.
-
-```bash
-cargo run -p runtime-params-estimator --features required -- \
-    --accounts-num 20000 --additional-accounts-num 20000 \
-    --iters 3 --warmup-iters 1 --metric time \
-    --costs=ActionReceiptCreation,ActionTransfer,ActionCreateAccount,ActionFunctionCallBase
-```
-
-You should get an output like this.
-
-```
-[elapsed 00:00:17 remaining 00:00:00] Writing into storage ████████████████████   20000/20000  
-ActionReceiptCreation         4_499_673_502_000 gas [  4.499674ms]    (computed in 7.22s) 
-ActionTransfer                  410_122_090_000 gas [   410.122µs]    (computed in 4.71s) 
-ActionCreateAccount             237_495_890_000 gas [   237.496µs]    (computed in 4.64s) 
-ActionFunctionCallBase          770_989_128_914 gas [   770.989µs]    (computed in 4.65s) 
-
-
-Finished in 40.11s, output saved to:
-
-    /home/you/near/nearcore/costs-2022-11-11T11:11:11Z-e40863c9b.txt
-```
-
-This shows how much gas a parameter should cost to satisfy the 1ms = 1Tgas rule.
-It also shows how much time that corresponds to and how long it took to compute
-each of the estimations.
-
-Note that the above does not produce very accurate results and it can have high
-variance as well. It runs an unoptimized binary, the state is small, and the
-metric used is wall-clock time which is always prone to variance in hardware and
-can be affected by other processes currently running on your system.
-
-Once your estimation code is ready, it is better to run it with a larger state
-and an optimized binary.
-
-```bash
-cargo run --release -p runtime-params-estimator --features required -- \
-    --accounts-num 20000 --additional-accounts-num 2000000 \
-    --iters 3 --warmup-iters 1 --metric time \
-    --costs=ActionReceiptCreation,ActionTransfer,ActionCreateAccount,ActionFunctionCallBase
-```
-
-You might also want to run a hardware-agnostic estimation using the following
-command. It uses `docker` and `qemu` under the hood, so it will be quite a bit
-slower. You will need to install `docker` to run this command.
-
-
-```bash
-cargo run --release -p runtime-params-estimator --features required -- \
-    --accounts-num 20000 --additional-accounts-num 2000000 \
-    --iters 3 --warmup-iters 1 --metric icount --docker --full \
-    --costs=ActionReceiptCreation,ActionTransfer,ActionCreateAccount,ActionFunctionCallBase
-```
-
-Note how the output looks a bit different now. The `i`, `r` and `w` values show
-instruction count, read IO bytes, and write IO bytes respectively. The IO byte
-count is known to be inaccurate.
-
-```
-+ /host/nearcore/runtime/runtime-params-estimator/emu-cost/counter_plugin/qemu-x86_64 -plugin file=/host/nearcore/runtime/runtime-params-estimator/emu-cost/counter_plugin/libcounter.so -cpu Westmere-v1 /host/nearcore/target/release/runtime-params-estimator --home /.near --accounts-num 20000 --iters 3 --warmup-iters 1 --metric icount --costs=ActionReceiptCreation,ActionTransfer,ActionCreateAccount,ActionFunctionCallBase --skip-build-test-contract --additional-accounts-num 0 --in-memory-db
-ActionReceiptCreation         214_581_685_500 gas [  1716653.48i 0.00r 0.00w]     (computed in 6.11s) 
-ActionTransfer                 21_528_212_916 gas [   172225.70i 0.00r 0.00w]     (computed in 4.71s) 
-ActionCreateAccount            26_608_336_250 gas [   212866.69i 0.00r 0.00w]     (computed in 4.67s) 
-ActionFunctionCallBase         12_193_364_898 gas [    97546.92i 0.00r 0.00w]     (computed in 2.39s) 
-
-
-Finished in 17.92s, output saved to:
-
-    /host/nearcore/costs-2022-11-01T16:27:36Z-e40863c9b.txt
-```
-
-The difference between the metrics will be discussed in the
-section on [Estimation Metrics](#estimation-metrics).
-
-You should now be all setup for running estimations on your local machine. Also
-check `cargo run -p runtime-params-estimator --features required -- --help` for
-the list of available options.
-
-## From Estimations to Parameter Values
-
-To calculate the final gas parameter values, there is more to be done than just
-running a single command. After all, these parameters are part of the protocol
-specification. They cannot be changed easily. And setting them to a wrong value
-can cause severe system instability.
-
-Our current strategy is to run estimations
-with two different metrics and do so on standardized cloud hardware. The output
-is then sanity checked manually by several people. Based on that, the final gas
-parameter value is determined. Usually it will be the higher output of the two
-metrics rounded up. More details on the process will be added to this document
-in due time.
+For a practical guide on how to run the estimator, please take a look at
+[Running the Estimator](/practices/workflows/gas_estimations.html) in the
+workflows chapter.
 
 ## Code Structure
 The estimator contains a binary and a library module. The
@@ -192,6 +101,26 @@ bytes in system calls depends less on the sum of all bytes and more on data
 locality and how it can be cached in the OS page cache. But regardless of all
 these inaccuracies, it can still be useful to compare different implementations
 both measured using `icount`.
+
+## From Estimations to Parameter Values
+
+To calculate the final gas parameter values, there is more to be done than just
+running a single command. After all, these parameters are part of the protocol
+specification. They cannot be changed easily. And setting them to a wrong value
+can cause severe system instability.
+
+Our current strategy is to run estimations
+with two different metrics and do so on standardized cloud hardware. The output
+is then sanity checked manually by several people. Based on that, the final gas
+parameter value is determined. Usually it will be the higher output of the two
+metrics rounded up.
+
+The PR [#8031](https://github.com/near/nearcore/pull/8031) to set the ed25519
+verification gas parameters is a good example for how such an analysis and
+report could look.
+
+More details on the process will be added to this document
+in due time.
 
 <!-- TODO: how to add a new host function estimation -->
 <!-- TODO: state of IO estimations -->

--- a/docs/architecture/gas/estimator.md
+++ b/docs/architecture/gas/estimator.md
@@ -21,7 +21,7 @@ The estimator code is part of the nearcore repository in the directory
 [runtime/runtime-params-estimator](https://github.com/near/nearcore/tree/master/runtime/runtime-params-estimator).
 
 For a practical guide on how to run the estimator, please take a look at
-[Running the Estimator](../../practices/workflows/gas_estimations.html) in the
+[Running the Estimator](../../practices/workflows/gas_estimations.md) in the
 workflows chapter.
 
 ## Code Structure

--- a/docs/architecture/gas/estimator.md
+++ b/docs/architecture/gas/estimator.md
@@ -21,7 +21,7 @@ The estimator code is part of the nearcore repository in the directory
 [runtime/runtime-params-estimator](https://github.com/near/nearcore/tree/master/runtime/runtime-params-estimator).
 
 For a practical guide on how to run the estimator, please take a look at
-[Running the Estimator](/practices/workflows/gas_estimations.html) in the
+[Running the Estimator](../../practices/workflows/gas_estimations.html) in the
 workflows chapter.
 
 ## Code Structure

--- a/docs/practices/workflows/gas_estimations.md
+++ b/docs/practices/workflows/gas_estimations.md
@@ -3,7 +3,7 @@
 
 This workflow describes how to run the gas estimator byzantine-benchmark suite.
 To learn about its background and purpose, refer to [Runtime Parameter
-Estimator](/architecture/gas/estimator.html) in the architecture chapter.
+Estimator](../../architecture/gas/estimator.html) in the architecture chapter.
 
 Type this in your console to quickly run estimations on a couple of action costs.
 
@@ -78,7 +78,7 @@ Finished in 17.92s, output saved to:
 ```
 
 The difference between the metrics is discussed in the [Estimation
-Metrics](/architecture/gas/estimator.html#estimation-metrics).
+Metrics](../../architecture/gas/estimator.html#estimation-metrics).
 
 You should now be all setup for running estimations on your local machine. Also
 check `cargo run -p runtime-params-estimator --features required -- --help` for

--- a/docs/practices/workflows/gas_estimations.md
+++ b/docs/practices/workflows/gas_estimations.md
@@ -3,7 +3,7 @@
 
 This workflow describes how to run the gas estimator byzantine-benchmark suite.
 To learn about its background and purpose, refer to [Runtime Parameter
-Estimator](../../architecture/gas/estimator.html) in the architecture chapter.
+Estimator](../../architecture/gas/estimator.md) in the architecture chapter.
 
 Type this in your console to quickly run estimations on a couple of action costs.
 
@@ -78,7 +78,7 @@ Finished in 17.92s, output saved to:
 ```
 
 The difference between the metrics is discussed in the [Estimation
-Metrics](../../architecture/gas/estimator.html#estimation-metrics).
+Metrics](../../architecture/gas/estimator.md#estimation-metrics).
 
 You should now be all setup for running estimations on your local machine. Also
 check `cargo run -p runtime-params-estimator --features required -- --help` for

--- a/docs/practices/workflows/gas_estimations.md
+++ b/docs/practices/workflows/gas_estimations.md
@@ -1,0 +1,85 @@
+
+# Running the Estimator
+
+This workflow describes how to run the gas estimator byzantine-benchmark suite.
+To learn about its background and purpose, refer to [Runtime Parameter
+Estimator](/architecture/gas/estimator.html) in the architecture chapter.
+
+Type this in your console to quickly run estimations on a couple of action costs.
+
+```bash
+cargo run -p runtime-params-estimator --features required -- \
+    --accounts-num 20000 --additional-accounts-num 20000 \
+    --iters 3 --warmup-iters 1 --metric time \
+    --costs=ActionReceiptCreation,ActionTransfer,ActionCreateAccount,ActionFunctionCallBase
+```
+
+You should get an output like this.
+
+```
+[elapsed 00:00:17 remaining 00:00:00] Writing into storage ████████████████████   20000/20000  
+ActionReceiptCreation         4_499_673_502_000 gas [  4.499674ms]    (computed in 7.22s) 
+ActionTransfer                  410_122_090_000 gas [   410.122µs]    (computed in 4.71s) 
+ActionCreateAccount             237_495_890_000 gas [   237.496µs]    (computed in 4.64s) 
+ActionFunctionCallBase          770_989_128_914 gas [   770.989µs]    (computed in 4.65s) 
+
+
+Finished in 40.11s, output saved to:
+
+    /home/you/near/nearcore/costs-2022-11-11T11:11:11Z-e40863c9b.txt
+```
+
+This shows how much gas a parameter should cost to satisfy the 1ms = 1Tgas rule.
+It also shows how much time that corresponds to and how long it took to compute
+each of the estimations.
+
+Note that the above does not produce very accurate results and it can have high
+variance as well. It runs an unoptimized binary, the state is small, and the
+metric used is wall-clock time which is always prone to variance in hardware and
+can be affected by other processes currently running on your system.
+
+Once your estimation code is ready, it is better to run it with a larger state
+and an optimized binary.
+
+```bash
+cargo run --release -p runtime-params-estimator --features required -- \
+    --accounts-num 20000 --additional-accounts-num 2000000 \
+    --iters 3 --warmup-iters 1 --metric time \
+    --costs=ActionReceiptCreation,ActionTransfer,ActionCreateAccount,ActionFunctionCallBase
+```
+
+You might also want to run a hardware-agnostic estimation using the following
+command. It uses `docker` and `qemu` under the hood, so it will be quite a bit
+slower. You will need to install `docker` to run this command.
+
+
+```bash
+cargo run --release -p runtime-params-estimator --features required -- \
+    --accounts-num 20000 --additional-accounts-num 2000000 \
+    --iters 3 --warmup-iters 1 --metric icount --docker --full \
+    --costs=ActionReceiptCreation,ActionTransfer,ActionCreateAccount,ActionFunctionCallBase
+```
+
+Note how the output looks a bit different now. The `i`, `r` and `w` values show
+instruction count, read IO bytes, and write IO bytes respectively. The IO byte
+count is known to be inaccurate.
+
+```
++ /host/nearcore/runtime/runtime-params-estimator/emu-cost/counter_plugin/qemu-x86_64 -plugin file=/host/nearcore/runtime/runtime-params-estimator/emu-cost/counter_plugin/libcounter.so -cpu Westmere-v1 /host/nearcore/target/release/runtime-params-estimator --home /.near --accounts-num 20000 --iters 3 --warmup-iters 1 --metric icount --costs=ActionReceiptCreation,ActionTransfer,ActionCreateAccount,ActionFunctionCallBase --skip-build-test-contract --additional-accounts-num 0 --in-memory-db
+ActionReceiptCreation         214_581_685_500 gas [  1716653.48i 0.00r 0.00w]     (computed in 6.11s) 
+ActionTransfer                 21_528_212_916 gas [   172225.70i 0.00r 0.00w]     (computed in 4.71s) 
+ActionCreateAccount            26_608_336_250 gas [   212866.69i 0.00r 0.00w]     (computed in 4.67s) 
+ActionFunctionCallBase         12_193_364_898 gas [    97546.92i 0.00r 0.00w]     (computed in 2.39s) 
+
+
+Finished in 17.92s, output saved to:
+
+    /host/nearcore/costs-2022-11-01T16:27:36Z-e40863c9b.txt
+```
+
+The difference between the metrics is discussed in the [Estimation
+Metrics](/architecture/gas/estimator.html#estimation-metrics).
+
+You should now be all setup for running estimations on your local machine. Also
+check `cargo run -p runtime-params-estimator --features required -- --help` for
+the list of available options.


### PR DESCRIPTION
Since we now have a workflow chapter, the section on how to run the
estimator belong there.

Also added a pointer to #8031 as an example for gas parameter analysis.