### PR TITLE
moved rate limit to a separate module

### DIFF
--- a/chain/network/src/concurrency/demux.rs
+++ b/chain/network/src/concurrency/demux.rs
@@ -5,7 +5,7 @@
 //!
 //! Example usage:
 //! `
-//! let d = Demux::new(RateLimit(10.,1));
+//! let d = Demux::new(rate::Limit(10.,1));
 //! ...
 //! let res = d.call(arg,|inout| async {
 //!   // Process all inout[i].arg together.
@@ -17,6 +17,7 @@
 //! of the provided handlers will be executed asynchronously
 //! (other handlers will be dropped).
 //!
+use crate::concurrency::rate;
 use crate::time;
 use futures::future::BoxFuture;
 use futures::FutureExt;
@@ -46,33 +47,6 @@ where
 {
     fn wrap(self) -> BoxAsyncFn<Arg, Res> {
         Box::new(move |a: Arg| self(a).boxed())
-    }
-}
-/// Config of a rate limiter algorithm, which behaves like a semaphore
-/// - with maximal capacity `burst`
-/// - with a new ticket added automatically every 1/qps seconds (qps stands for "queries per
-///   second")
-/// In case of large load, semaphore will be empty most of the time,
-/// letting through requests at frequency `qps`.
-/// In case a number of requests come after a period of inactivity, semaphore will immediately
-/// let through up to `burst` requests, before going into the previous mode.
-#[derive(Copy, Clone)]
-pub struct RateLimit {
-    pub burst: u64,
-    pub qps: f64,
-}
-
-impl RateLimit {
-    // TODO(gprusak): consider having a constructor for RateLimit which enforces validation
-    // and getters for fields, so that they cannot be modified after construction.
-    pub fn validate(&self) -> anyhow::Result<()> {
-        if self.qps <= 0. {
-            anyhow::bail!("qps has to be >0");
-        }
-        if self.burst <= 0 {
-            anyhow::bail!("burst has to be >0");
-        }
-        Ok(())
     }
 }
 
@@ -129,7 +103,7 @@ impl<Arg: 'static + Send, Res: 'static + Send> Demux<Arg, Res> {
 
     // Spawns a subroutine performing the demultiplexing.
     // Panics if rl is not valid.
-    pub fn new(rl: RateLimit) -> Demux<Arg, Res> {
+    pub fn new(rl: rate::Limit) -> Demux<Arg, Res> {
         rl.validate().unwrap();
         let (send, mut recv): (Stream<Arg, Res>, _) = mpsc::unbounded_channel();
         // TODO(gprusak): this task should be running as long as Demux object exists.

--- a/chain/network/src/concurrency/mod.rs
+++ b/chain/network/src/concurrency/mod.rs
@@ -1,6 +1,7 @@
 pub mod arc_mutex;
 pub mod atomic_cell;
 pub mod demux;
+pub mod rate;
 pub mod rayon;
 
 #[cfg(test)]

--- a/chain/network/src/concurrency/rate.rs
+++ b/chain/network/src/concurrency/rate.rs
@@ -1,0 +1,27 @@
+/// Config of a rate limiter algorithm, which behaves like a semaphore
+/// - with maximal capacity `burst`
+/// - with a new ticket added automatically every 1/qps seconds (qps stands for "queries per
+///   second")
+/// In case of large load, semaphore will be empty most of the time,
+/// letting through requests at frequency `qps`.
+/// In case a number of requests come after a period of inactivity, semaphore will immediately
+/// let through up to `burst` requests, before going into the previous mode.
+#[derive(Copy, Clone)]
+pub struct Limit {
+    pub burst: u64,
+    pub qps: f64,
+}
+
+impl Limit {
+    // TODO(gprusak): consider having a constructor for RateLimit which enforces validation
+    // and getters for fields, so that they cannot be modified after construction.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if self.qps <= 0. {
+            anyhow::bail!("qps has to be >0");
+        }
+        if self.burst <= 0 {
+            anyhow::bail!("burst has to be >0");
+        }
+        Ok(())
+    }
+}

--- a/chain/network/src/concurrency/tests.rs
+++ b/chain/network/src/concurrency/tests.rs
@@ -1,5 +1,6 @@
 use crate::concurrency::arc_mutex::ArcMutex;
 use crate::concurrency::demux;
+use crate::concurrency::rate;
 use crate::concurrency::rayon;
 
 // drop a trivial future without completion => panic (in debug mode at least).
@@ -17,7 +18,7 @@ async fn must_complete_ok() {
 
 #[tokio::test]
 async fn test_demux() {
-    let demux = demux::Demux::new(demux::RateLimit { qps: 50., burst: 1 });
+    let demux = demux::Demux::new(rate::Limit { qps: 50., burst: 1 });
     for _ in 0..5 {
         let mut handles = vec![];
         for i in 0..1000 {
@@ -40,7 +41,7 @@ async fn test_demux() {
 fn demux_runtime_dropped_before_call() {
     let r1 = tokio::runtime::Runtime::new().unwrap();
     let r2 = tokio::runtime::Runtime::new().unwrap();
-    let demux = r1.block_on(async { demux::Demux::new(demux::RateLimit { qps: 1., burst: 1000 }) });
+    let demux = r1.block_on(async { demux::Demux::new(rate::Limit { qps: 1., burst: 1000 }) });
     drop(r1);
     let call = demux.call(0, |is: Vec<u64>| async { is });
     assert_eq!(Err(demux::ServiceStoppedError), r2.block_on(call));
@@ -50,7 +51,7 @@ fn demux_runtime_dropped_before_call() {
 fn demux_runtime_dropped_during_call() {
     let r1 = tokio::runtime::Runtime::new().unwrap();
     let r2 = tokio::runtime::Runtime::new().unwrap();
-    let demux = r1.block_on(async { demux::Demux::new(demux::RateLimit { qps: 1., burst: 1000 }) });
+    let demux = r1.block_on(async { demux::Demux::new(rate::Limit { qps: 1., burst: 1000 }) });
 
     // Start the call and pause.
     let (send, recv) = tokio::sync::oneshot::channel();

--- a/chain/network/src/config.rs
+++ b/chain/network/src/config.rs
@@ -1,5 +1,5 @@
 use crate::blacklist;
-use crate::concurrency::demux;
+use crate::concurrency::rate;
 use crate::network_protocol::PeerAddr;
 use crate::network_protocol::PeerInfo;
 use crate::peer_manager::peer_manager_actor::Event;
@@ -66,9 +66,6 @@ impl ValidatorConfig {
 }
 
 #[derive(Clone)]
-pub struct Features {}
-
-#[derive(Clone)]
 pub struct Tier1 {
     /// Interval between broacasts of the list of validator's proxies.
     /// Before the broadcast, validator tries to establish all the missing connections to proxies.
@@ -132,9 +129,9 @@ pub struct NetworkConfig {
     /// Whether this is an archival node.
     pub archive: bool,
     /// Maximal rate at which SyncAccountsData can be broadcasted.
-    pub accounts_data_broadcast_rate_limit: demux::RateLimit,
+    pub accounts_data_broadcast_rate_limit: rate::Limit,
     /// Maximal rate at which RoutingTableUpdate can be sent out.
-    pub routing_table_update_rate_limit: demux::RateLimit,
+    pub routing_table_update_rate_limit: rate::Limit,
     /// Config of the TIER1 network.
     pub tier1: Option<Tier1>,
 
@@ -254,8 +251,8 @@ impl NetworkConfig {
             push_info_period: time::Duration::milliseconds(100),
             outbound_disabled: false,
             archive,
-            accounts_data_broadcast_rate_limit: demux::RateLimit { qps: 0.1, burst: 1 },
-            routing_table_update_rate_limit: demux::RateLimit { qps: 0.5, burst: 1 },
+            accounts_data_broadcast_rate_limit: rate::Limit { qps: 0.1, burst: 1 },
+            routing_table_update_rate_limit: rate::Limit { qps: 0.5, burst: 1 },
             tier1: Some(Tier1 { advertise_proxies_interval: time::Duration::minutes(15) }),
             inbound_disabled: cfg.experimental.inbound_disabled,
             skip_tombstones: if cfg.experimental.skip_sending_tombstones_seconds > 0 {
@@ -319,8 +316,8 @@ impl NetworkConfig {
             outbound_disabled: false,
             inbound_disabled: false,
             archive: false,
-            accounts_data_broadcast_rate_limit: demux::RateLimit { qps: 100., burst: 1000000 },
-            routing_table_update_rate_limit: demux::RateLimit { qps: 100., burst: 1000000 },
+            accounts_data_broadcast_rate_limit: rate::Limit { qps: 100., burst: 1000000 },
+            routing_table_update_rate_limit: rate::Limit { qps: 100., burst: 1000000 },
             tier1: Some(Tier1 {
                 // Interval is very large, so that it doesn't happen spontaneously in tests.
                 // It should rather be triggered manually in tests.
@@ -364,6 +361,9 @@ impl NetworkConfig {
         self.accounts_data_broadcast_rate_limit
             .validate()
             .context("accounts_Data_broadcast_rate_limit")?;
+        self.routing_table_update_rate_limit
+            .validate()
+            .context("routing_table_update_rate_limit")?;
         Ok(VerifiedConfig { node_id: self.node_id(), inner: self })
     }
 }

--- a/chain/network/src/peer_manager/tests/accounts_data.rs
+++ b/chain/network/src/peer_manager/tests/accounts_data.rs
@@ -1,4 +1,4 @@
-use crate::concurrency::demux;
+use crate::concurrency::rate;
 use crate::network_protocol::testonly as data;
 use crate::network_protocol::SyncAccountsData;
 use crate::peer;
@@ -182,7 +182,7 @@ async fn rate_limiting() {
     let mut pms = vec![];
     for _ in 0..n * m {
         let mut cfg = chain.make_config(rng);
-        cfg.accounts_data_broadcast_rate_limit = demux::RateLimit { qps: 0.5, burst: 1 };
+        cfg.accounts_data_broadcast_rate_limit = rate::Limit { qps: 0.5, burst: 1 };
         pms.push(
             peer_manager::testonly::start(
                 clock.clock(),


### PR DESCRIPTION
In a sense a demultiplexer is a specific implementation of the rate limiter, so I've moved the rate limit specification itself to a separate module, so that demux module doesn't appear in places like config module. I'm also planning on adding additional primitives for rate limiting in the near future.