### PR TITLE
neard: reload key for clients when recv SIGHUP

### DIFF
--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -72,7 +72,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
-use tokio::sync::oneshot;
+use tokio::sync::mpsc;
 use tracing::{debug, error, info, trace, warn};
 
 /// Multiplier on `max_block_time` to wait until deciding that chain stalled.
@@ -119,7 +119,7 @@ pub struct ClientActor {
 
     /// Synchronization measure to allow graceful shutdown.
     /// Informs the system when a ClientActor gets dropped.
-    shutdown_signal: Option<oneshot::Sender<()>>,
+    shutdown_signal: Option<mpsc::Sender<()>>,
 }
 
 /// Blocks the program until given genesis time arrives.
@@ -155,7 +155,7 @@ impl ClientActor {
         enable_doomslug: bool,
         rng_seed: RngSeed,
         ctx: &Context<ClientActor>,
-        shutdown_signal: Option<oneshot::Sender<()>>,
+        shutdown_signal: Option<mpsc::Sender<()>>,
         adv: crate::adversarial::Controls,
     ) -> Result<Self, Error> {
         let state_parts_arbiter = Arbiter::new();
@@ -2077,7 +2077,7 @@ pub fn start_client(
     network_adapter: Arc<dyn PeerManagerAdapter>,
     validator_signer: Option<Arc<dyn ValidatorSigner>>,
     telemetry_actor: Addr<TelemetryActor>,
-    sender: Option<oneshot::Sender<()>>,
+    sender: Option<mpsc::Sender<()>>,
     adv: crate::adversarial::Controls,
 ) -> (Addr<ClientActor>, ArbiterHandle) {
     let client_arbiter = Arbiter::new();

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -93,7 +93,7 @@ pub struct NodeStorage<D = crate::db::RocksDB> {
 /// data.
 #[derive(Clone)]
 pub struct Store {
-    storage: Arc<dyn Database>,
+    pub storage: Arc<dyn Database>,
 }
 
 // Those are temporary.  While cold_store feature is stabilised, remove those

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -11,13 +11,14 @@ use near_network::time;
 use near_network::types::NetworkRecipient;
 use near_network::PeerManagerActor;
 use near_primitives::block::GenesisId;
+use near_primitives::validator_signer::ValidatorSigner;
 #[cfg(feature = "performance_stats")]
 use near_rust_allocator_proxy::reset_memory_usage_max;
 use near_store::{DBCol, Mode, NodeStorage, StoreOpenerError, Temperature};
 use near_telemetry::TelemetryActor;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use tokio::sync::oneshot;
+use tokio::sync::mpsc;
 use tracing::{info, trace};
 
 pub mod append_only_map;
@@ -147,11 +148,69 @@ fn open_storage(home_dir: &Path, near_config: &mut NearConfig) -> anyhow::Result
     Ok(storage)
 }
 
-pub struct NearNode {
+pub struct NearNode<'a> {
+    pub home_dir: &'a Path,
+    pub config_snapshot: NearConfig,
+    pub storage: Arc<dyn near_store::db::Database>,
+    pub runtime: Arc<runtime::NightshadeRuntime>,
     pub client: Addr<ClientActor>,
     pub view_client: Addr<ViewClientActor>,
     pub arbiters: Vec<ArbiterHandle>,
-    pub rpc_servers: Vec<(&'static str, actix_web::dev::ServerHandle)>,
+    pub rpc_servers: Option<Vec<(&'static str, actix_web::dev::ServerHandle)>>,
+    pub shutdown_signal: Option<mpsc::Sender<()>>,
+}
+
+impl<'a> NearNode<'a> {
+    pub fn update_signer(
+        &mut self,
+        new_signer: Option<Arc<dyn ValidatorSigner>>,
+    ) -> anyhow::Result<()> {
+        self.config_snapshot.validator_signer = new_signer;
+        let runtime = Arc::new(NightshadeRuntime::from_config(
+            self.home_dir,
+            near_store::Store { storage: self.storage.clone() },
+            &self.config_snapshot,
+        ));
+        let chain_genesis = ChainGenesis::new(&self.config_snapshot.genesis);
+        let node_id = self.config_snapshot.network_config.node_id();
+        let network_adapter: Arc<NetworkRecipient<Addr<PeerManagerActor>>> =
+            Arc::new(NetworkRecipient::default());
+        let adv =
+            near_client::adversarial::Controls::new(self.config_snapshot.client_config.archive);
+
+        let view_client = start_view_client(
+            self.config_snapshot
+                .validator_signer
+                .as_ref()
+                .map(|signer| signer.validator_id().clone()),
+            chain_genesis.clone(),
+            runtime.clone(),
+            network_adapter.clone(),
+            self.config_snapshot.client_config.clone(),
+            adv.clone(),
+        );
+        let (client_actor, client_arbiter_handle) = start_client(
+            self.config_snapshot.client_config.clone(),
+            chain_genesis,
+            runtime.clone(),
+            node_id,
+            network_adapter.clone(),
+            self.config_snapshot.validator_signer.clone(),
+            TelemetryActor::new(self.config_snapshot.telemetry_config.clone()).start(),
+            self.shutdown_signal.clone(),
+            adv,
+        );
+
+        self.view_client = view_client;
+        self.client = client_actor;
+        self.arbiters = vec![client_arbiter_handle];
+
+        // TODO: update clients for rpc_servers will implement later on
+
+        trace!(target: "diagnostic", key="log", "Reload NEAR validator signer");
+
+        Ok(())
+    }
 }
 
 pub fn start_with_config(home_dir: &Path, config: NearConfig) -> anyhow::Result<NearNode> {
@@ -163,13 +222,14 @@ pub fn start_with_config_and_synchronization(
     mut config: NearConfig,
     // 'shutdown_signal' will notify the corresponding `oneshot::Receiver` when an instance of
     // `ClientActor` gets dropped.
-    shutdown_signal: Option<oneshot::Sender<()>>,
+    shutdown_signal: Option<mpsc::Sender<()>>,
 ) -> anyhow::Result<NearNode> {
-    let store = open_storage(home_dir, &mut config)?;
+    let config_snapshot = config.clone();
+    let storage = open_storage(home_dir, &mut config)?;
 
     let runtime = Arc::new(NightshadeRuntime::from_config(
         home_dir,
-        store.get_store(Temperature::Hot),
+        storage.get_store(Temperature::Hot),
         &config,
     ));
 
@@ -196,20 +256,21 @@ pub fn start_with_config_and_synchronization(
     let (client_actor, client_arbiter_handle) = start_client(
         config.client_config,
         chain_genesis,
-        runtime,
+        runtime.clone(),
         node_id,
         network_adapter.clone(),
         config.validator_signer,
         telemetry,
-        shutdown_signal,
+        shutdown_signal.clone(),
         adv,
     );
+    let storage = storage.into_inner(near_store::Temperature::Hot);
 
     #[allow(unused_mut)]
     let mut rpc_servers = Vec::new();
     let network_actor = PeerManagerActor::spawn(
         time::Clock::real(),
-        store.into_inner(near_store::Temperature::Hot),
+        storage.clone(),
         config.network_config,
         Arc::new(near_client::adapter::Adapter::new(client_actor.clone(), view_client.clone())),
         genesis_id,
@@ -251,10 +312,15 @@ pub fn start_with_config_and_synchronization(
     reset_memory_usage_max();
 
     Ok(NearNode {
+        home_dir,
+        storage,
+        runtime,
+        config_snapshot,
         client: client_actor,
         view_client,
-        rpc_servers,
+        rpc_servers: Some(rpc_servers),
         arbiters: vec![client_arbiter_handle],
+        shutdown_signal,
     })
 }
 

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -28,8 +28,7 @@ use std::fs::File;
 use std::io::BufReader;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
-use tokio::sync::oneshot;
-use tokio::sync::oneshot::Receiver;
+use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
 
 /// NEAR Protocol Node
@@ -448,7 +447,6 @@ impl RunCmd {
             }
         }
 
-        let (tx, rx) = oneshot::channel::<()>();
         let sys = actix::System::new();
 
         sys.block_on(async move {
@@ -467,17 +465,9 @@ impl RunCmd {
             .await
             .global();
 
-            let nearcore::NearNode { rpc_servers, .. } =
-                nearcore::start_with_config_and_synchronization(home_dir, near_config, Some(tx))
-                    .expect("start_with_config");
-
-            let sig = wait_for_interrupt_signal(home_dir, rx).await;
+            let sig = wait_for_interrupt_signal(home_dir, near_config).await;
             warn!(target: "neard", "{}, stopping... this may take a few minutes.", sig);
-            futures::future::join_all(rpc_servers.iter().map(|(name, server)| async move {
-                server.stop(true).await;
-                debug!(target: "neard", "{} server stopped", name);
-            }))
-            .await;
+
             actix::System::current().stop();
 
             // Disable the subscriber to properly shutdown the tracer.
@@ -490,9 +480,19 @@ impl RunCmd {
 }
 
 #[cfg(not(unix))]
-async fn wait_for_interrupt_signal(_home_dir: &Path, mut _rx_crash: Receiver<()>) -> &str {
+async fn wait_for_interrupt_signal(_home_dir: &Path, near_config: nearcore::NearConfig) -> &str {
+    let nearcore::NearNode { rpc_servers, .. } =
+        nearcore::start_with_config_and_synchronization(home_dir, near_config, Some(tx))
+            .expect("start_with_config");
+
     // TODO(#6372): Support graceful shutdown on windows.
     tokio::signal::ctrl_c().await.unwrap();
+
+    futures::future::join_all(rpc_servers.iter().map(|(name, server)| async move {
+        server.stop(true).await;
+        debug!(target: "neard", "{} server stopped", name);
+    }))
+    .await;
     "Ctrl+C"
 }
 
@@ -503,7 +503,14 @@ fn update_watchers(home_dir: &Path, behavior: UpdateBehavior) {
 }
 
 #[cfg(unix)]
-async fn wait_for_interrupt_signal(home_dir: &Path, mut rx_crash: Receiver<()>) -> &str {
+async fn wait_for_interrupt_signal(home_dir: &Path, near_config: nearcore::NearConfig) -> &str {
+    let (tx, mut rx_crash) = mpsc::channel::<()>(1);
+
+    let mut near_node =
+        nearcore::start_with_config_and_synchronization(home_dir, near_config, Some(tx.clone()))
+            .expect("start_with_config");
+    let rpc_servers = near_node.rpc_servers.take();
+
     // Apply all watcher config file if it exists.
     update_watchers(&home_dir, UpdateBehavior::UpdateOnlyIfExists);
 
@@ -512,17 +519,35 @@ async fn wait_for_interrupt_signal(home_dir: &Path, mut rx_crash: Receiver<()>) 
     let mut sigterm = signal(SignalKind::terminate()).unwrap();
     let mut sighup = signal(SignalKind::hangup()).unwrap();
 
-    loop {
+    let output = loop {
         break tokio::select! {
              _ = sigint.recv()  => "SIGINT",
              _ = sigterm.recv() => "SIGTERM",
              _ = sighup.recv() => {
                 update_watchers(&home_dir, UpdateBehavior::UpdateOrReset);
+
+                // Key reload may be triggered by modifing config.json, or other possibles
+                // current impl is POC and rely on SIGHUP
+                if let Ok(new_config) = nearcore::config::load_config(&home_dir, GenesisValidationMode::Full) {
+                    let new_signer = new_config.validator_signer;
+                    near_node.update_signer(new_signer).unwrap_or_else(|e| panic!("Reload new signer fail: {:#}", e));
+                } else {
+                    error!("config is incorrect, could not reload the new config");
+                }
+
                 continue;
              },
-             _ = &mut rx_crash => "ClientActor died",
+             _ = rx_crash.recv() => "ClientActor died",
         };
+    };
+    if let Some(rpc_servers) = rpc_servers {
+        futures::future::join_all(rpc_servers.iter().map(|(name, server)| async move {
+            server.stop(true).await;
+            debug!(target: "neard", "{} server stopped", name);
+        }))
+        .await;
     }
+    output
 }
 
 #[derive(Parser)]


### PR DESCRIPTION
Hi there,

We try to change the validator's key without restarting the node.  This PR is working in progress and want to collect suggestions about this feature.  If there is any obstacle or concern for this PR, please kindly let us know.:pray: 

The way to trigger reload key is still undefined, and this PR will follow the best practice, and currently, the SIGHUP is used for the POC for easier testing from my end. 

Thank you :smile: 
