### PR TITLE
feat(indexer): add a validate_genesis option to the config

### DIFF
--- a/chain/indexer/src/lib.rs
+++ b/chain/indexer/src/lib.rs
@@ -79,6 +79,8 @@ pub struct IndexerConfig {
     pub sync_mode: SyncModeEnum,
     /// Whether await for node to be synced or not
     pub await_for_node_synced: AwaitForNodeSyncedEnum,
+    /// Tells whether to validate the genesis file before starting
+    pub validate_genesis: bool,
 }
 
 /// This is the core component, which handles `nearcore` and internal `streamer`.
@@ -98,8 +100,13 @@ impl Indexer {
             indexer_config.home_dir.display()
         );
 
+        let genesis_validation_mode = if indexer_config.validate_genesis {
+            GenesisValidationMode::Full
+        } else {
+            GenesisValidationMode::UnsafeFast
+        };
         let near_config =
-            nearcore::config::load_config(&indexer_config.home_dir, GenesisValidationMode::Full)
+            nearcore::config::load_config(&indexer_config.home_dir, genesis_validation_mode)
                 .unwrap_or_else(|e| panic!("Error loading config: {:#}", e));
 
         assert!(

--- a/tools/indexer/example/src/main.rs
+++ b/tools/indexer/example/src/main.rs
@@ -275,6 +275,7 @@ fn main() -> Result<()> {
                 home_dir,
                 sync_mode: near_indexer::SyncModeEnum::FromInterruption,
                 await_for_node_synced: near_indexer::AwaitForNodeSyncedEnum::WaitForFullSync,
+                validate_genesis: true,
             };
             let system = actix::System::new();
             system.block_on(async move {

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -807,6 +807,7 @@ impl<T: ChainAccess> TxMirror<T> {
             home_dir: target_home.as_ref().to_path_buf(),
             sync_mode: near_indexer::SyncModeEnum::LatestSynced,
             await_for_node_synced: near_indexer::AwaitForNodeSyncedEnum::WaitForFullSync,
+            validate_genesis: false,
         })
         .context("failed to start target chain indexer")?;
         let (target_view_client, target_client) = target_indexer.client_actors();


### PR DESCRIPTION
in the mirror code, where we're starting an indexer for the target chain, the genesis records file is usually very big since we're forking mainnet or testnet state to run a mocknet test. So starting the indexer with full genesis validation takes quite a long time and we don't really need it.