### PR TITLE
[chunks] Fix subtle chunk distribution behavior around epoch boundaries

### DIFF
--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -11,7 +11,7 @@ use futures::{future, FutureExt};
 use num_rational::Ratio;
 use once_cell::sync::OnceCell;
 use rand::{thread_rng, Rng};
-use tracing::{info, warn};
+use tracing::info;
 
 use crate::{start_view_client, Client, ClientActor, SyncStatus, ViewClientActor};
 use near_chain::chain::{do_apply_chunks, BlockCatchUpRequest, StateSplitRequest};
@@ -1475,9 +1475,10 @@ impl TestEnv {
                 );
             }
         } else {
-            // TODO: Somehow this may fail at epoch boundaries. Figure out why.
-            warn!("Failed to process PartialEncodedChunkRequest from client {}: {:?}", id, request);
-            None
+            panic!(
+                "Failed to process PartialEncodedChunkRequest from client {}: {:?}",
+                id, request
+            );
         }
     }
 

--- a/integration-tests/src/tests/client/features/adversarial_behaviors.rs
+++ b/integration-tests/src/tests/client/features/adversarial_behaviors.rs
@@ -156,14 +156,7 @@ fn test_non_adversarial_case() {
             let prev_block =
                 test.env.clients[0].chain.get_block(&block.header().prev_hash()).unwrap();
             for i in 0..4 {
-                // TODO: mysteriously we might miss a chunk around epoch boundaries.
-                // Figure out why...
-                assert!(
-                    block.chunks()[i].height_created() == prev_block.header().height() + 1
-                        || (height % EPOCH_LENGTH == 1
-                            && block.chunks()[i].chunk_hash()
-                                == prev_block.chunks()[i].chunk_hash())
-                );
+                assert!(block.chunks()[i].height_created() == prev_block.header().height() + 1);
             }
         }
 
@@ -269,14 +262,7 @@ fn test_banning_chunk_producer_when_seeing_invalid_chunk_base(
                 {
                     assert_eq!(block.chunks()[i].chunk_hash(), prev_block.chunks()[i].chunk_hash());
                 } else {
-                    // TODO: mysteriously we might miss a chunk around epoch boundaries.
-                    // Figure out why...
-                    assert!(
-                        block.chunks()[i].height_created() == prev_block.header().height() + 1
-                            || (height % EPOCH_LENGTH == 1
-                                && block.chunks()[i].chunk_hash()
-                                    == prev_block.chunks()[i].chunk_hash())
-                    );
+                    assert!(block.chunks()[i].height_created() == prev_block.header().height() + 1);
                 }
             }
         }


### PR DESCRIPTION
When a node receives a PartialEncodedChunk from a chunk producer, it uses the previous block hash to look up the epoch ID the chunk is intended for. That previous block may not yet have been processed locally, in which case the chunk is an orphan. We do handle orphan chunks, but if the orphan chunk's signature could not be immediately validated using a guessed epoch ID, it is dropped.

This PR removes the logic to drop such orphan chunks. The problem with dropping it is the following: suppose block B has parent A, and chunk C has parent B. (so A -> B -> C). If B is the last block of the epoch (i.e. A and B belong to epoch X, and C belongs to epoch Y), then C belongs to the next epoch. Because of that, the chunk C is signed by the chunk producer assigned to that chunk in epoch Y, not X, and so when we validate C's signature against the guess (epoch X, based on A), it fails, and we drop the chunk. However, this PartialEncodedChunk contains the chunk's header and is the *only* chance we can receive the chunk header from the chunk producer (before the block is produced and broadcast). This isn't a big problem in the current network because when the block producer produces the block and broadcasts it to everyone, those who missed the initial PartialEncodedChunk now has the header and can then request all the parts (since everyone tracks all shards), and as long as the node is able to get 1/3 of the parts, the whole chunk is reconstructed and everything can proceed. In the 100 shards setup however, the node-shard tracking relationship is sparse, and each node that does not track a shard will not attempt to request the whole shard - it would only request the part it is supposed to own (but missed due to dropping orphan chunks). This should've still worked because it would just fetch the parts it is supposed to own from the chunk's producer, but somehow, this isn't working (not sure why, but it may also have something to do with having an epoch transition). So it leads to some nodes not being able to progress through the chain, whereas other nodes continue as long as they have a 2/3 majority - but this still eventually leads to the chain halting somehow.

(The above reasoning is... weak. I'm not confident about it, but more work would be required to fully understand what is going on.)

A risk of accepting orphan chunks is the potential for a DoS attack where someone forges an invalid partial chunk. That however doesn't seem so bad because we only accept one of these chunks, but we always accept chunks we request for ourselves. So the result of accepting a rogue partial chunk into the cache would not be so different from just dropping the correct orphan chunk altogether.

This PR also more carefully forwards the parts around epoch boundaries. If a part owner first receives an owned chunk part as an orphan, it would not have the right set of chunk producers to forward the part to. This does not affect correctness, but it makes testing unreliable - during epoch transitions the code would take a different path because some nodes would expect to have forwarded parts but do not, and if we don't run actors in the test, the node would not have the chunk. Ultimately this is a testing framework issue, but it seems nice to do it correctly across epoch boundaries anyway. The way this works is to forward chunk parts again if we see a different epoch ID (in practice we would only trigger this resend once - switching from a wrong epoch ID to a correct epoch ID).

These two changes get rid of the weird results we were seeing in the adversarial_behavior tests; and those weird asserts are now removed.