### PR TITLE
revived UpdateNonceResponse message.

### DIFF
--- a/chain/network/src/network_protocol/network.proto
+++ b/chain/network/src/network_protocol/network.proto
@@ -264,6 +264,11 @@ message UpdateNonceRequest {
   PartialEdgeInfo partial_edge_info = 1;
 }
 
+// Deprecated. Use SyncRoutingTable instead.
+message UpdateNonceResponse {
+  Edge edge = 1;
+}
+
 // SyncAccountData message can represent:
 // - incremental sync (incremental = true, requesting_full_sync = false)
 // - full sync request (incremental = false, requesting_full_sync = true)
@@ -381,7 +386,7 @@ message PeerMessage {
   // https://docs.google.com/document/d/1gCWmt9O-h_-5JDXIqbKxAaSS3Q9pryB1f9DDY1mMav4/edit
   reserved 1,2,3;
   // Deprecated fields.
-  reserved 9,20,21,22,23,24;
+  reserved 20,21,22,23,24;
 
   // Inter-process tracing information.
   TraceContext trace_context = 26;
@@ -404,6 +409,7 @@ message PeerMessage {
     RoutingTableUpdate sync_routing_table = 7;
     
     UpdateNonceRequest update_nonce_request = 8;
+    UpdateNonceResponse update_nonce_response = 9;
 
     SyncAccountsData sync_accounts_data = 25;
 

--- a/chain/network/src/network_protocol/proto_conv/peer_message.rs
+++ b/chain/network/src/network_protocol/proto_conv/peer_message.rs
@@ -221,6 +221,14 @@ impl TryFrom<&proto::PeerMessage> for PeerMessage {
                 try_from_required(&unr.partial_edge_info)
                     .map_err(Self::Error::UpdateNonceRequest)?,
             ),
+            ProtoMT::UpdateNonceResponse(unr) => {
+                PeerMessage::SyncRoutingTable(RoutingTableUpdate {
+                    edges: vec![
+                        try_from_required(&unr.edge).map_err(Self::Error::UpdateNonceResponse)?
+                    ],
+                    accounts: vec![],
+                })
+            }
             ProtoMT::SyncAccountsData(msg) => PeerMessage::SyncAccountsData(SyncAccountsData {
                 accounts_data: try_from_slice(&msg.accounts_data)
                     .map_err(Self::Error::SyncAccountsData)?


### PR DESCRIPTION
It has been originally removed in favor of SyncRoutingTable, however removing it for both sending and receiving was backward incompatible: if a new binary sends RequestUpdateNonce, it expects SyncRoutingTable, however the old binary will respond with ResponseUpdateNonce which used to be unparseable by the new binary.