### PR TITLE
fix: Up the payload limit on sandbox

### DIFF
--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -63,7 +63,13 @@ pub struct RpcLimitsConfig {
 
 impl Default for RpcLimitsConfig {
     fn default() -> Self {
-        Self { json_payload_max_size: 10 * 1024 * 1024 }
+        if cfg!(feature = "sandbox") {
+            // Sandbox can take large state patches for patching arbitrary data so this value
+            // is a lot larger than the default case. 1 GB should suffice on most contracts.
+            Self { json_payload_max_size: 1024 * 1024 * 1024 }
+        } else {
+            Self { json_payload_max_size: 10 * 1024 * 1024 }
+        }
     }
 }
 


### PR DESCRIPTION
Sandbox requires sending larger than the default limit for requests when it comes to patching state. This ups the limit to 1gb for sandbox only, but while testing it, it seems like the highest it was able to patch was up to ~350mb due to some other constraint that I wasn't able to pinpoint down. Let me know if anyone knows what other configs might be needed, but otherwise, just opening up this PR for feedback and if it's acceptable to be merged in

addresses https://github.com/near/workspaces-rs/issues/223