### PR TITLE
[fix] Fix localnet config - local ports should be set to true

### DIFF
--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -1163,6 +1163,7 @@ pub fn init_testnet_configs(
     num_validator_seats: NumSeats,
     num_non_validator_seats: NumSeats,
     prefix: &str,
+    local_ports: bool,
     archive: bool,
     fixed_shards: bool,
 ) {
@@ -1171,7 +1172,7 @@ pub fn init_testnet_configs(
         num_validator_seats,
         num_non_validator_seats,
         prefix,
-        false,
+        local_ports,
         archive,
         fixed_shards,
     );

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -564,6 +564,7 @@ impl LocalnetCmd {
             self.validators,
             self.non_validators,
             &self.prefix,
+            true,
             self.archival_nodes,
             self.fixed_shards,
         );


### PR DESCRIPTION
When creating configs for multiple nodes with the `neard localnet` we should set the local_ports argument to true so that each node has different ports. Otherwise they will conflict and crash immediately. 