### PR TITLE
[feat] Add --track-all-shards cmd line arg to the LocalnetCmd

### DIFF
--- a/integration-tests/src/node/mod.rs
+++ b/integration-tests/src/node/mod.rs
@@ -145,14 +145,14 @@ fn near_configs_to_node_configs(
 
 pub fn create_nodes(num_nodes: usize, prefix: &str) -> Vec<NodeConfig> {
     let (configs, validator_signers, network_signers, genesis, _) =
-        create_testnet_configs(1, num_nodes as NumSeats, 0, prefix, true, false, false);
+        create_testnet_configs(1, num_nodes as NumSeats, 0, prefix, true, false, false, vec![]);
     near_configs_to_node_configs(configs, validator_signers, network_signers, genesis)
 }
 
 pub fn create_nodes_from_seeds(seeds: Vec<String>) -> Vec<NodeConfig> {
     let code = near_test_contracts::rs_contract();
     let (configs, validator_signers, network_signers, mut genesis) =
-        create_testnet_configs_from_seeds(seeds.clone(), 1, 0, true, false, None);
+        create_testnet_configs_from_seeds(seeds.clone(), 1, 0, true, false, None, vec![]);
     genesis.config.gas_price_adjustment_rate = Ratio::from_integer(0);
     for seed in seeds {
         let mut is_account_record_found = false;

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -1055,6 +1055,7 @@ pub fn create_testnet_configs_from_seeds(
     local_ports: bool,
     archive: bool,
     fixed_shards: Option<Vec<String>>,
+    tracked_shards: Vec<u64>,
 ) -> (Vec<Config>, Vec<InMemoryValidatorSigner>, Vec<InMemorySigner>, Genesis) {
     let num_validator_seats = (seeds.len() - num_non_validator_seats as usize) as NumSeats;
     let validator_signers =
@@ -1110,6 +1111,7 @@ pub fn create_testnet_configs_from_seeds(
             config.network.skip_sync_wait = num_validator_seats == 1;
         }
         config.archive = archive;
+        config.tracked_shards = tracked_shards.clone();
         config.consensus.min_num_peers =
             std::cmp::min(num_validator_seats as usize - 1, config.consensus.min_num_peers);
         configs.push(config);
@@ -1127,6 +1129,7 @@ pub fn create_testnet_configs(
     local_ports: bool,
     archive: bool,
     fixed_shards: bool,
+    tracked_shards: Vec<u64>,
 ) -> (Vec<Config>, Vec<InMemoryValidatorSigner>, Vec<InMemorySigner>, Genesis, Vec<InMemorySigner>)
 {
     let fixed_shards = if fixed_shards {
@@ -1152,6 +1155,7 @@ pub fn create_testnet_configs(
         local_ports,
         archive,
         fixed_shards,
+        tracked_shards,
     );
 
     (configs, validator_signers, network_signers, genesis, shard_keys)
@@ -1166,6 +1170,7 @@ pub fn init_testnet_configs(
     local_ports: bool,
     archive: bool,
     fixed_shards: bool,
+    tracked_shards: Vec<u64>,
 ) {
     let (configs, validator_signers, network_signers, genesis, shard_keys) = create_testnet_configs(
         num_shards,
@@ -1175,6 +1180,7 @@ pub fn init_testnet_configs(
         local_ports,
         archive,
         fixed_shards,
+        tracked_shards,
     );
     for i in 0..(num_validator_seats + num_non_validator_seats) as usize {
         let node_dir = dir.join(format!("{}{}", prefix, i));
@@ -1414,4 +1420,68 @@ fn test_config_from_file() {
             config.telemetry.endpoints
         );
     }
+}
+
+#[test]
+fn test_create_testnet_configs() {
+    let num_shards = 4;
+    let num_validator_seats = 4;
+    let num_non_validator_seats = 8;
+    let prefix = "node";
+    let local_ports = true;
+
+    // Set all supported options to true and verify config and genesis.
+
+    let archive = true;
+    let fixed_shards = true;
+    let tracked_shards: Vec<u64> = vec![0, 1, 3];
+
+    let (configs, _validator_signers, _network_signers, genesis, _shard_keys) =
+        create_testnet_configs(
+            num_shards,
+            num_validator_seats,
+            num_non_validator_seats,
+            prefix,
+            local_ports,
+            archive,
+            fixed_shards,
+            tracked_shards.clone(),
+        );
+
+    assert_eq!(configs.len() as u64, num_validator_seats + num_non_validator_seats);
+
+    for config in configs {
+        assert_eq!(config.archive, true);
+        assert_eq!(config.tracked_shards, tracked_shards);
+    }
+
+    assert_eq!(genesis.config.validators.len(), num_shards as usize);
+    assert_eq!(genesis.config.shard_layout.num_shards(), num_shards);
+
+    // Set all supported options to false and verify config and genesis.
+
+    let archive = false;
+    let fixed_shards = false;
+    let tracked_shards: Vec<u64> = vec![];
+
+    let (configs, _validator_signers, _network_signers, genesis, _shard_keys) =
+        create_testnet_configs(
+            num_shards,
+            num_validator_seats,
+            num_non_validator_seats,
+            prefix,
+            local_ports,
+            archive,
+            fixed_shards,
+            tracked_shards.clone(),
+        );
+    assert_eq!(configs.len() as u64, num_validator_seats + num_non_validator_seats);
+
+    for config in configs {
+        assert_eq!(config.archive, false);
+        assert_eq!(config.tracked_shards, tracked_shards);
+    }
+
+    assert_eq!(genesis.config.validators.len() as u64, num_shards);
+    assert_eq!(genesis.config.shard_layout.num_shards(), num_shards);
 }

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -554,10 +554,28 @@ pub(super) struct LocalnetCmd {
     /// Whether to configure nodes as archival.
     #[clap(long)]
     archival_nodes: bool,
+    /// Comma separated list of shards to track, the word 'all' to track all shards or the word 'none' to track no shards.
+    #[clap(long, default_value = "all")]
+    tracked_shards: String,
 }
 
 impl LocalnetCmd {
+    fn parse_tracked_shards(tracked_shards: &String, num_shards: NumShards) -> Vec<u64> {
+        if tracked_shards.to_lowercase() == "all" {
+            return (0..num_shards).collect();
+        }
+        if tracked_shards.to_lowercase() == "none" {
+            return vec![];
+        }
+        tracked_shards
+            .split(',')
+            .map(|shard_id| shard_id.parse::<u64>().expect("Shard id must be an integer"))
+            .collect()
+    }
+
     pub(super) fn run(self, home_dir: &Path) {
+        let tracked_shards = Self::parse_tracked_shards(&self.tracked_shards, self.shards);
+
         nearcore::config::init_testnet_configs(
             home_dir,
             self.shards,
@@ -567,6 +585,7 @@ impl LocalnetCmd {
             true,
             self.archival_nodes,
             self.fixed_shards,
+            tracked_shards,
         );
     }
 }


### PR DESCRIPTION
Changing tracked_shards is tricky so adding a cmd line option to set it initially in the localnet command. 
Added a small unit test for the config generation. 