### PR TITLE
fix: flaky prefetcher tests

### DIFF
--- a/runtime/runtime/src/prefetch.rs
+++ b/runtime/runtime/src/prefetch.rs
@@ -351,10 +351,11 @@ mod tests {
         // here because threads can be in `Trie::lookup` between nodes, at which
         // point no slot is reserved for them but they are still doing work.
         //
-        // Solution: drop `tries`, which also drops prefetchers. In particular,
-        // we want to drop the `PrefetchingThreadsHandle` stored in tries. This
-        // causes all background threads to stop after they finish the current
-        // work. It will even join them and wait until all threads are done.
+        // Solution: `drop(tries)`, which also drops prefetchers. In particular,
+        // we want to drop the `PrefetchingThreadsHandle` stored in tries.
+        // `drop(tries)` causes all background threads to stop after they finish
+        // the current work. It will even join them and wait until all threads
+        // are done.
         //
         // Because threads are joined, there is also a possibility this will
         // hang forever. To avoid that, we drop in a separate thread.

--- a/runtime/runtime/src/prefetch.rs
+++ b/runtime/runtime/src/prefetch.rs
@@ -346,8 +346,35 @@ mod tests {
             );
         }
 
-        // Request can still be pending. Stop threads and wait for them to finish.
-        std::thread::sleep(Duration::from_micros(1000));
+        // The queue is empty now but there can still be requests in progress.
+        // Looking at `Pending` slots in the prefetching area is not sufficient
+        // here because threads can be in `Trie::lookup` between nodes, at which
+        // point no slot is reserved for them but they are still doing work.
+        //
+        // Solution: drop `tries`, which also drops prefetchers. In particular,
+        // we want to drop the `PrefetchingThreadsHandle` stored in tries. This
+        // causes all background threads to stop after they finish the current
+        // work. It will even join them and wait until all threads are done.
+        //
+        // Because threads are joined, there is also a possibility this will
+        // hang forever. To avoid that, we drop in a separate thread.
+        let dropped = std::sync::atomic::AtomicBool::new(false);
+        std::thread::scope(|s| {
+            s.spawn(|| {
+                drop(tries);
+                dropped.store(true, std::sync::atomic::Ordering::Release);
+            });
+            let spawned = Instant::now();
+            while !dropped.load(std::sync::atomic::Ordering::Acquire) {
+                std::thread::yield_now();
+                // 100ms should be enough to finish pending requests. If not,
+                // we should check how the prefetcher affects performance.
+                assert!(
+                    spawned.elapsed() < Duration::from_millis(100),
+                    "timeout while waiting for background threads to terminate"
+                );
+            }
+        });
 
         assert_eq!(
             prefetch_api.num_prefetched_and_staged(),


### PR DESCRIPTION
Prefetcher tests have become flaky in CI lately, failing with
`"unexpected number of prefetched values"`.

I was not able to reproduce it locally. But there is a timeout that
is at least one source for flakyness. This commit removes this
source by properly waiting on the background threads to finish
instead of relying on a timeout.

Hopefully resolves  #8252. (Will have to reopen if not.)