### PR TITLE
test-utils: remove kind of pointless encode_int function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5628,7 +5628,6 @@ dependencies = [
 name = "testlib"
 version = "0.0.0"
 dependencies = [
- "byteorder",
  "near-chain",
  "near-chain-configs",
  "near-crypto",

--- a/integration-tests/src/tests/runtime/state_viewer.rs
+++ b/integration-tests/src/tests/runtime/state_viewer.rs
@@ -19,7 +19,7 @@ use near_primitives::{
 use near_store::{set_account, NibbleSlice, RawTrieNode, RawTrieNodeWithSize};
 use node_runtime::state_viewer::errors;
 use node_runtime::state_viewer::*;
-use testlib::runtime_utils::{alice_account, encode_int};
+use testlib::runtime_utils::alice_account;
 
 struct ProofVerifier {
     nodes: HashMap<CryptoHash, RawTrieNodeWithSize>,
@@ -122,7 +122,7 @@ fn test_view_call() {
         &MockEpochInfoProvider::default(),
     );
 
-    assert_eq!(result.unwrap(), encode_int(10));
+    assert_eq!(result.unwrap(), (10i32).to_le_bytes());
 }
 
 #[test]

--- a/test-utils/testlib/Cargo.toml
+++ b/test-utils/testlib/Cargo.toml
@@ -6,7 +6,6 @@ publish = false
 edition.workspace = true
 
 [dependencies]
-byteorder.workspace = true
 once_cell.workspace = true
 
 near-chain-configs = { path = "../../core/chain-configs" }

--- a/test-utils/testlib/src/runtime_utils.rs
+++ b/test-utils/testlib/src/runtime_utils.rs
@@ -1,4 +1,3 @@
-use byteorder::{ByteOrder, LittleEndian};
 use once_cell::sync::Lazy;
 
 use near_chain_configs::Genesis;
@@ -45,10 +44,4 @@ pub fn add_test_contract(genesis: &mut Genesis, account_id: &AccountId) {
         account_id: account_id.clone(),
         code: near_test_contracts::rs_contract().to_vec(),
     });
-}
-
-pub fn encode_int(val: i32) -> [u8; 4] {
-    let mut tmp = [0u8; 4];
-    LittleEndian::write_i32(&mut tmp, val);
-    tmp
 }


### PR DESCRIPTION
The function is used in only one place and really it’s more readable
to just use i32::to_le_bytes.
