### PR TITLE
runtime: introduce MemoryLike::view_memory to avoid memcpy

### DIFF
--- a/runtime/near-vm-logic/src/lib.rs
+++ b/runtime/near-vm-logic/src/lib.rs
@@ -14,7 +14,7 @@ mod utils;
 mod vmstate;
 
 pub use context::VMContext;
-pub use dependencies::{External, MemoryLike, StorageGetMode, ValuePtr};
+pub use dependencies::{External, MemSlice, MemoryLike, StorageGetMode, ValuePtr};
 pub use logic::{VMLogic, VMOutcome};
 pub use near_primitives_core::config::*;
 pub use near_primitives_core::profile;

--- a/runtime/near-vm-logic/src/logic.rs
+++ b/runtime/near-vm-logic/src/logic.rs
@@ -1,5 +1,5 @@
 use crate::context::VMContext;
-use crate::dependencies::{External, MemoryLike};
+use crate::dependencies::{External, MemSlice, MemoryLike};
 use crate::gas_counter::{FastGasCounter, GasCounter};
 use crate::receipt_manager::ReceiptManager;
 use crate::types::{PromiseIndex, PromiseResult, ReceiptIndex, ReturnData};
@@ -238,7 +238,8 @@ impl<'a> VMLogic<'a> {
     /// `base + read_memory_base + read_memory_bytes * num_bytes + write_register_base + write_register_bytes * num_bytes`
     pub fn write_register(&mut self, register_id: u64, data_len: u64, data_ptr: u64) -> Result<()> {
         self.gas_counter.pay_base(base)?;
-        let data = self.memory.get_vec(&mut self.gas_counter, data_ptr, data_len)?;
+        let data =
+            self.memory.view(&mut self.gas_counter, MemSlice { ptr: data_ptr, len: data_len })?;
         self.registers.set(&mut self.gas_counter, &self.config.limit_config, register_id, data)
     }
 
@@ -276,7 +277,7 @@ impl<'a> VMLogic<'a> {
                 }
                 .into());
             }
-            buf = self.memory.get_vec(&mut self.gas_counter, ptr, len)?;
+            buf = self.memory.view(&mut self.gas_counter, MemSlice { ptr, len })?.into_owned();
         } else {
             buf = vec![];
             for i in 0..=max_len {
@@ -305,7 +306,7 @@ impl<'a> VMLogic<'a> {
     /// * It's up to the caller to set correct len
     #[cfg(feature = "sandbox")]
     fn sandbox_get_utf8_string(&mut self, len: u64, ptr: u64) -> Result<String> {
-        let buf = self.memory.get_vec_for_free(ptr, len)?;
+        let buf = self.memory.view_for_free(MemSlice { ptr, len })?.into_owned();
         String::from_utf8(buf).map_err(|_| HostError::BadUTF8.into())
     }
 
@@ -330,7 +331,7 @@ impl<'a> VMLogic<'a> {
         let max_len =
             self.config.limit_config.max_total_log_length.saturating_sub(self.total_log_length);
         if len != u64::MAX {
-            let input = self.memory.get_vec(&mut self.gas_counter, ptr, len)?;
+            let input = self.memory.view(&mut self.gas_counter, MemSlice { ptr, len })?;
             if len % 2 != 0 {
                 return Err(HostError::BadUTF16.into());
             }
@@ -1337,8 +1338,9 @@ impl<'a> VMLogic<'a> {
         self.gas_counter.pay_per(promise_and_per_promise, memory_len)?;
 
         // Read indices as little endian u64.
-        let promise_indices =
-            self.memory.get_vec(&mut self.gas_counter, promise_idx_ptr, memory_len)?;
+        let promise_indices = self
+            .memory
+            .view(&mut self.gas_counter, MemSlice { ptr: promise_idx_ptr, len: memory_len })?;
         let promise_indices = stdx::as_chunks_exact::<{ size_of::<u64>() }, u8>(&promise_indices)
             .unwrap()
             .into_iter()

--- a/runtime/near-vm-logic/src/mocks/mock_memory.rs
+++ b/runtime/near-vm-logic/src/mocks/mock_memory.rs
@@ -1,11 +1,18 @@
-use crate::MemoryLike;
+use crate::{MemSlice, MemoryLike};
+
+use std::borrow::Cow;
 
 #[derive(Default)]
 pub struct MockedMemory {}
 
 impl MemoryLike for MockedMemory {
-    fn fits_memory(&self, _offset: u64, _len: u64) -> Result<(), ()> {
+    fn fits_memory(&self, _slice: MemSlice) -> Result<(), ()> {
         Ok(())
+    }
+
+    fn view_memory(&self, slice: MemSlice) -> Result<Cow<[u8]>, ()> {
+        let view = unsafe { std::slice::from_raw_parts(slice.ptr as *const u8, slice.len()?) };
+        Ok(Cow::Borrowed(view))
     }
 
     fn read_memory(&self, offset: u64, buffer: &mut [u8]) -> Result<(), ()> {

--- a/runtime/near-vm-logic/src/vmstate.rs
+++ b/runtime/near-vm-logic/src/vmstate.rs
@@ -1,4 +1,4 @@
-use crate::dependencies::MemoryLike;
+use crate::dependencies::{MemSlice, MemoryLike};
 use crate::gas_counter::GasCounter;
 
 use near_primitives_core::config::ExtCosts::*;
@@ -55,35 +55,32 @@ impl<'a> Memory<'a> {
         Self(mem)
     }
 
+    /// Returns view of the guest memory.
+    ///
+    /// Not all runtimes support returning a view to the guest memory so this
+    /// may return an owned vector.
+    pub(super) fn view<'s>(
+        &'s self,
+        gas_counter: &mut GasCounter,
+        slice: MemSlice,
+    ) -> Result<Cow<'s, [u8]>> {
+        gas_counter.pay_base(read_memory_base)?;
+        gas_counter.pay_per(read_memory_byte, slice.len)?;
+        self.0.view_memory(slice).map_err(|_| HostError::MemoryAccessViolation.into())
+    }
+
+    #[cfg(feature = "sandbox")]
+    /// Like [`Self::view`] but does not pay gas fees.
+    pub(super) fn view_for_free(&self, slice: MemSlice) -> Result<Cow<[u8]>> {
+        self.0.view_memory(slice).map_err(|_| HostError::MemoryAccessViolation.into())
+    }
+
     /// Copies data from guest memory into provided buffer accounting for gas.
     fn get_into(&self, gas_counter: &mut GasCounter, offset: u64, buf: &mut [u8]) -> Result<()> {
         gas_counter.pay_base(read_memory_base)?;
         let len = u64::try_from(buf.len()).map_err(|_| HostError::MemoryAccessViolation)?;
         gas_counter.pay_per(read_memory_byte, len)?;
         self.0.read_memory(offset, buf).map_err(|_| HostError::MemoryAccessViolation.into())
-    }
-
-    /// Copies data from guest memory into a newly allocated vector accounting for gas.
-    pub(super) fn get_vec(
-        &self,
-        gas_counter: &mut GasCounter,
-        offset: u64,
-        len: u64,
-    ) -> Result<Vec<u8>> {
-        gas_counter.pay_base(read_memory_base)?;
-        gas_counter.pay_per(read_memory_byte, len)?;
-        self.get_vec_for_free(offset, len)
-    }
-
-    /// Like [`Self::get_vec`] but does not pay gas fees.
-    pub(super) fn get_vec_for_free(&self, offset: u64, len: u64) -> Result<Vec<u8>> {
-        // This check is redundant in the sense that read_memory will perform it
-        // as well however it’s here to validate that `len` is a valid value.
-        // See documentation of MemoryLike::read_memory for more information.
-        self.0.fits_memory(offset, len).map_err(|_| HostError::MemoryAccessViolation)?;
-        let mut buf = vec![0; len as usize];
-        self.0.read_memory(offset, &mut buf).map_err(|_| HostError::MemoryAccessViolation)?;
-        Ok(buf)
     }
 
     /// Copies data from provided buffer into guest memory accounting for gas.
@@ -224,7 +221,7 @@ impl Registers {
 
 /// Reads data from guest memory or register.
 ///
-/// If `len` is `u64::MAX` read register with index `offset`.  Otherwise, reads
+/// If `len` is `u64::MAX` read register with index `ptr`.  Otherwise, reads
 /// `len` bytes of guest memory starting at given offset.  Returns error if
 /// there’s insufficient gas, memory interval is out of bounds or given register
 /// isn’t set.
@@ -235,15 +232,15 @@ impl Registers {
 /// references to other fields in the structure..
 pub(super) fn get_memory_or_register<'a, 'b>(
     gas_counter: &mut GasCounter,
-    memory: &Memory<'a>,
+    memory: &'b Memory<'a>,
     registers: &'b Registers,
-    offset: u64,
+    ptr: u64,
     len: u64,
 ) -> Result<Cow<'b, [u8]>> {
     if len == u64::MAX {
-        registers.get(gas_counter, offset).map(Cow::Borrowed)
+        registers.get(gas_counter, ptr).map(Cow::Borrowed)
     } else {
-        memory.get_vec(gas_counter, offset, len).map(Cow::Owned)
+        memory.view(gas_counter, MemSlice { ptr, len })
     }
 }
 

--- a/runtime/near-vm-runner/src/wasmer2_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer2_runner.rs
@@ -60,26 +60,47 @@ impl Wasmer2Memory {
         )?)))
     }
 
-    // Returns the pointer to memory at the specified offset and the size of the buffer starting at
-    // the returned pointer.
-    fn data_offset(&self, offset: u64) -> Option<(*mut u8, usize)> {
-        let size = self.0.size().bytes().0;
-        let offset = usize::try_from(offset).ok()?;
-        // `checked_sub` here verifies that offsetting the buffer by offset still lands us
-        // in-bounds of the allocated object.
-        let remaining = size.checked_sub(offset)?;
-        Some(unsafe {
-            // SAFETY: we verified that offsetting the base pointer by `offset` still lands us
-            // in-bounds of the original object.
-            (self.0.vmmemory().as_ref().base.add(offset), remaining)
-        })
+    /// Returns pointer to memory at the specified offset provided that there’s
+    /// enough space in the buffer starting at the returned pointer.
+    ///
+    /// Safety: Caller must guarantee that the returned pointer is not used
+    /// after guest memory mapping is changed (e.g. grown).
+    unsafe fn get_ptr(&self, offset: u64, len: usize) -> Result<*mut u8, ()> {
+        let offset = usize::try_from(offset).map_err(|_| ())?;
+        // SAFETY: Caller promisses memory mapping won’t change.
+        let vmmem = unsafe { self.0.vmmemory().as_ref() };
+        // `checked_sub` here verifies that offsetting the buffer by offset
+        // still lands us in-bounds of the allocated object.
+        let remaining = vmmem.current_length.checked_sub(offset).ok_or(())?;
+        if len <= remaining {
+            Ok(vmmem.base.add(offset))
+        } else {
+            Err(())
+        }
     }
 
-    fn get_memory_buffer(&self, offset: u64, len: usize) -> Result<*mut u8, ()> {
-        match self.data_offset(offset) {
-            Some((ptr, remaining)) if len <= remaining => Ok(ptr),
-            _ => Err(()),
-        }
+    /// Returns shared reference to slice in guest memory at given offset.
+    ///
+    /// Safety: Caller must guarantee that guest memory mapping is not changed
+    /// (e.g. grown) while the slice is held.
+    unsafe fn get(&self, offset: u64, len: usize) -> Result<&[u8], ()> {
+        // SAFETY: Caller promisses memory mapping won’t change.
+        let ptr = unsafe { self.get_ptr(offset, len)? };
+        // SAFETY: get_ptr verifies that [ptr, ptr+len) is valid slice.
+        Ok(unsafe { core::slice::from_raw_parts(ptr, len) })
+    }
+
+    /// Returns shared reference to slice in guest memory at given offset.
+    ///
+    /// Safety: Caller must guarantee that guest memory mapping is not changed
+    /// (e.g. grown) while the slice is held.
+    unsafe fn get_mut(&mut self, offset: u64, len: usize) -> Result<&mut [u8], ()> {
+        // SAFETY: Caller promisses memory mapping won’t change.
+        let ptr = unsafe { self.get_ptr(offset, len)? };
+        // SAFETY: get_ptr verifies that [ptr, ptr+len) is valid slice and since
+        // we’re holding exclusive self reference another mut reference won’t be
+        // created
+        Ok(unsafe { core::slice::from_raw_parts_mut(ptr, len) })
     }
 
     pub(crate) fn vm(&self) -> VMMemory {
@@ -89,37 +110,29 @@ impl Wasmer2Memory {
 
 impl MemoryLike for Wasmer2Memory {
     fn fits_memory(&self, slice: MemSlice) -> Result<(), ()> {
-        self.get_memory_buffer(slice.ptr, slice.len()?).map(|_| ())
+        // SAFETY: Contracts are executed on a single thread thus we know no one
+        // will change guest memory mapping under us.
+        unsafe { self.get_ptr(slice.ptr, slice.len()?) }.map(|_| ())
     }
 
     fn view_memory(&self, slice: MemSlice) -> Result<Cow<[u8]>, ()> {
-        let len = slice.len()?;
-        let memory = self.get_memory_buffer(slice.ptr, len)?;
-        // SAFETY: we verified indices into are valid and the pointer will
-        // always be valid as well. Our runtime is currently only executing Wasm
-        // code on a single thread, so data races aren't a concern here.
-        let memory = unsafe { core::slice::from_raw_parts(memory, len) };
-        Ok(Cow::Borrowed(memory))
+        // SAFETY: Firstly, contracts are executed on a single thread thus we
+        // know no one will change guest memory mapping under us.  Secondly, the
+        // way MemoryLike interface is used we know the memory mapping won’t be
+        // changed by the caller while it holds the slice reference.
+        unsafe { self.get(slice.ptr, slice.len()?) }.map(Cow::Borrowed)
     }
 
     fn read_memory(&self, offset: u64, buffer: &mut [u8]) -> Result<(), ()> {
-        let len = buffer.len();
-        let memory = self.get_memory_buffer(offset, len)?;
-        // SAFETY: we verified indices into are valid and the pointer will
-        // always be valid as well. Our runtime is currently only executing Wasm
-        // code on a single thread, so data races aren't a concern here.
-        let memory = unsafe { core::slice::from_raw_parts(memory, len) };
-        Ok(buffer.copy_from_slice(memory))
+        // SAFETY: Contracts are executed on a single thread thus we know no one
+        // will change guest memory mapping under us.
+        Ok(buffer.copy_from_slice(unsafe { self.get(offset, buffer.len())? }))
     }
 
     fn write_memory(&mut self, offset: u64, buffer: &[u8]) -> Result<(), ()> {
-        let len = buffer.len();
-        let memory = self.get_memory_buffer(offset, len)?;
-        // SAFETY: we verified indices into are valid and the pointer will
-        // always be valid as well. Our runtime is currently only executing Wasm
-        // code on a single thread, so data races aren't a concern here.
-        let memory = unsafe { core::slice::from_raw_parts_mut(memory, len) };
-        Ok(memory.copy_from_slice(buffer))
+        // SAFETY: Contracts are executed on a single thread thus we know no one
+        // will change guest memory mapping under us.
+        Ok(unsafe { self.get_mut(offset, buffer.len())? }.copy_from_slice(buffer))
     }
 }
 
@@ -659,33 +672,7 @@ impl crate::runner::VM for Wasmer2VM {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use assert_matches::assert_matches;
-    use wasmer_types::WASM_PAGE_SIZE;
-
-    #[test]
-    fn get_memory_buffer() {
-        let memory = super::Wasmer2Memory::new(1, 1).unwrap();
-        // these should not panic with memory out of bounds
-        memory.get_memory_buffer(0, WASM_PAGE_SIZE).unwrap();
-        memory.get_memory_buffer(WASM_PAGE_SIZE as u64 - 1, 1).unwrap();
-        memory.get_memory_buffer(WASM_PAGE_SIZE as u64, 0).unwrap();
-    }
-
-    #[test]
-    fn memory_data_offset() {
-        let memory = super::Wasmer2Memory::new(1, 1).unwrap();
-        assert_matches!(memory.data_offset(0), Some((_, size)) => assert_eq!(size, WASM_PAGE_SIZE));
-        assert_matches!(memory.data_offset(WASM_PAGE_SIZE as u64), Some((_, size)) => {
-            assert_eq!(size, 0)
-        });
-        assert_matches!(memory.data_offset(WASM_PAGE_SIZE as u64 + 1), None);
-        assert_matches!(memory.data_offset(0xFFFF_FFFF_FFFF_FFFF), None);
-    }
-
-    #[test]
-    fn test_memory_like() {
-        crate::tests::test_memory_like(|| Box::new(super::Wasmer2Memory::new(1, 1).unwrap()));
-    }
+#[test]
+fn test_memory_like() {
+    crate::tests::test_memory_like(|| Box::new(Wasmer2Memory::new(1, 1).unwrap()));
 }


### PR DESCRIPTION
Add a view_memory method to MemoryLike trait which returns a view of
the guest memory.  This allows caller to read data directly from guest
memory instead of using read_memory to first copy it into a vector.

To accommodate implementations which cannot support borrowing the
memory, the method returns a Cow which allows such implementations to
return a copy of the memory.  WasmerMemory doesn’t support it because
its memory is made of `Cell`s and transmuting `&[Cell<u8>]` to `&[u8]`
is maybe not sound.  Importantly though, Wasmer2Memory supports
returning the view.

Also introduce a simple MemSlice structure which combines guest memory
pointer and slice length in a single object.  This avoids confusing
when function accepts two u64 arguments and caller just needs to know
which is the pointer and which is the length.
