### PR TITLE
runtime: introduce PublicKeyBuffer to avoid memory allocation

### DIFF
--- a/runtime/near-vm-logic/src/receipt_manager.rs
+++ b/runtime/near-vm-logic/src/receipt_manager.rs
@@ -1,7 +1,6 @@
 use crate::logic;
 use crate::types::ReceiptIndex;
 use crate::External;
-use borsh::BorshDeserialize;
 use near_crypto::PublicKey;
 use near_primitives::receipt::DataReceiver;
 use near_primitives::transaction::{
@@ -243,17 +242,9 @@ impl ReceiptManager {
         &mut self,
         receipt_index: ReceiptIndex,
         stake: Balance,
-        public_key: Vec<u8>,
-    ) -> logic::Result<()> {
-        self.append_action(
-            receipt_index,
-            Action::Stake(StakeAction {
-                stake,
-                public_key: PublicKey::try_from_slice(&public_key)
-                    .map_err(|_| HostError::InvalidPublicKey)?,
-            }),
-        );
-        Ok(())
+        public_key: PublicKey,
+    ) {
+        self.append_action(receipt_index, Action::Stake(StakeAction { stake, public_key }));
     }
 
     /// Attach the [`AddKeyAction`] action to an existing receipt.
@@ -270,18 +261,16 @@ impl ReceiptManager {
     pub(crate) fn append_action_add_key_with_full_access(
         &mut self,
         receipt_index: ReceiptIndex,
-        public_key: Vec<u8>,
+        public_key: PublicKey,
         nonce: Nonce,
-    ) -> logic::Result<()> {
+    ) {
         self.append_action(
             receipt_index,
             Action::AddKey(AddKeyAction {
-                public_key: PublicKey::try_from_slice(&public_key)
-                    .map_err(|_| HostError::InvalidPublicKey)?,
+                public_key,
                 access_key: AccessKey { nonce, permission: AccessKeyPermission::FullAccess },
             }),
         );
-        Ok(())
     }
 
     /// Attach the [`AddKeyAction`] action an existing receipt.
@@ -304,7 +293,7 @@ impl ReceiptManager {
     pub(crate) fn append_action_add_key_with_function_call(
         &mut self,
         receipt_index: ReceiptIndex,
-        public_key: Vec<u8>,
+        public_key: PublicKey,
         nonce: Nonce,
         allowance: Option<Balance>,
         receiver_id: AccountId,
@@ -313,8 +302,7 @@ impl ReceiptManager {
         self.append_action(
             receipt_index,
             Action::AddKey(AddKeyAction {
-                public_key: PublicKey::try_from_slice(&public_key)
-                    .map_err(|_| HostError::InvalidPublicKey)?,
+                public_key,
                 access_key: AccessKey {
                     nonce,
                     permission: AccessKeyPermission::FunctionCall(FunctionCallPermission {
@@ -347,16 +335,9 @@ impl ReceiptManager {
     pub(crate) fn append_action_delete_key(
         &mut self,
         receipt_index: ReceiptIndex,
-        public_key: Vec<u8>,
-    ) -> logic::Result<()> {
-        self.append_action(
-            receipt_index,
-            Action::DeleteKey(DeleteKeyAction {
-                public_key: PublicKey::try_from_slice(&public_key)
-                    .map_err(|_| HostError::InvalidPublicKey)?,
-            }),
-        );
-        Ok(())
+        public_key: PublicKey,
+    ) {
+        self.append_action(receipt_index, Action::DeleteKey(DeleteKeyAction { public_key }));
     }
 
     /// Attach the [`DeleteAccountAction`] action to an existing receipt


### PR DESCRIPTION
Currently when public key is read it’s unnecessarily copied into
a temporary vector.  The copy is necessary because otherwise public
key data would hold a shared reference on self.registers which
prevents any methods which take exclusive reference to self to be
called.

However, if we decode the public key immediately after reading it, we
can deal with sized objects which can be stored on stack.  This is
perfect except because we cannot change when errors are reported we
have to postpone returning of the deserialisation errors.

Introduce PublicKeyBuffer which facilitates that.  It hides from the
users the fact that deserialisation happens immediately as soon as the
data is read providing an interface which looks as if deserialisation
was happening separately from reading.

An alternative would be to use a fixed-size 65-byte array and separate
reading the data from deserialisation just like it’s happening
now. A minor downside of that is hard-coding the 65-byte size.  We’d
probably want PublicKey::MAX_LEN but even then having such a constant
doesn’t seem too clean of a solution to me.
