### PR TITLE
Don't prune peers on each update run

### DIFF
--- a/chain/network/src/routing/graph/mod.rs
+++ b/chain/network/src/routing/graph/mod.rs
@@ -225,11 +225,12 @@ impl Inner {
             self.peer_reachable_at.insert(peer.clone(), now);
         }
         // Prune unreachable peers from time to time.
+        // Peers are removed if they are not reacheable for prune_unreachable_peers_after - so we run the pruning every
+        // prune_unreachable_peers_after / 2 seconds (so peer can be in the memory for max 1.5 * prune_unreachable_peers_after).
         if self
             .last_time_peers_pruned
             .map_or(true, |t| t < now - self.config.prune_unreachable_peers_after / 2)
         {
-            tracing::error!("Pruning now..");
             self.prune_unreachable_peers(now - self.config.prune_unreachable_peers_after);
             self.last_time_peers_pruned = Some(now);
         }

--- a/chain/network/src/routing/graph/tests.rs
+++ b/chain/network/src/routing/graph/tests.rs
@@ -194,6 +194,7 @@ async fn components_nonces_are_tracked_in_storage() {
     let p2 = data::make_peer_id(rng);
     let p3 = data::make_peer_id(rng);
     let e23 = edge(&p2, &p3, 2);
+    clock.advance(time::Duration::seconds(2));
     g.update(&clock.clock(), vec![e23.clone()]).await;
     g.check(
         &[],
@@ -225,6 +226,7 @@ async fn components_nonces_are_tracked_in_storage() {
 
     // Add an active edge between unreachable nodes, which will merge 2 components in DB.
     let e34 = edge(&p3, &p4, 1);
+    clock.advance(time::Duration::seconds(2));
     g.update(&clock.clock(), vec![e34.clone()]).await;
     g.check(
         &[],


### PR DESCRIPTION
Currently we're pruning the list of peers on each update run - which can happen every second or so.

This operation can sometimes be expensive (at it touches database) - so in this PR I'm changing it to happen less often.