### PR TITLE
[fix] Set tracked shards to none in pytest localnet command usage

### DIFF
--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -717,11 +717,20 @@ def init_cluster(num_nodes, num_observers, num_shards, config,
     logger.info("Creating %s cluster configuration with %s nodes" %
                 ("LOCAL" if is_local else "REMOTE", num_nodes + num_observers))
 
+    binary_path = os.path.join(near_root, binary_name)
     process = subprocess.Popen([
-        os.path.join(near_root, binary_name), "localnet", "--v",
-        str(num_nodes), "--shards",
-        str(num_shards), "--n",
-        str(num_observers), "--prefix", "test"
+        binary_path,
+        "localnet",
+        "--validators",
+        str(num_nodes),
+        "--non-validators",
+        str(num_observers),
+        "--shards",
+        str(num_shards),
+        "--tracked-shards",
+        "none",
+        "--prefix",
+        "test",
     ],
                                stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE)

--- a/pytest/tests/sanity/repro_2916.py
+++ b/pytest/tests/sanity/repro_2916.py
@@ -12,8 +12,8 @@
 # incorrect reconstruction of the receipts.
 
 import asyncio, sys, time
-import socket, base58
-import nacl.signing, hashlib
+import base58
+import nacl.signing
 import pathlib
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))

--- a/scripts/nayduck.py
+++ b/scripts/nayduck.py
@@ -254,7 +254,7 @@ def run_locally(args, tests):
                 shlex.quote(str(cwd)),
                 ' '.join(shlex.quote(str(arg)) for arg in cmd)))
             continue
-        print("RUNNING COMMAND cwd=%s cmd = %s", (cwd, cmd))
+        print(f"RUNNING COMMAND cwd = {cwd} cmd = {cmd}")
         subprocess.check_call(cmd, cwd=cwd, timeout=_parse_timeout(timeout))
 
 


### PR DESCRIPTION
Fix https://github.com/near/nearcore/issues/8272. 

The recently added --tracked-shards command line argument for the localnet command changed the default of tracked-shards and it broke some of the tests. In this PR I'm setting the --tracked-shards to none which is what the tests expect. 

I was able to confirm that this fixed the repro_2916.py test using the following command:
python3 tests/sanity/repro_2916.py

I was not able to check all the tests using nayduck because they are broken for unrelated reasons. 

Also added some small styling and logging improvements. 