### PR TITLE
chore: upgrade rust-version to 1.66.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -240,4 +240,4 @@ opt-level = 3
 [workspace.package]
 edition = "2021"
 authors = ["Near Inc <hello@nearprotocol.com>"]
-rust-version = "1.65.0"
+rust-version = "1.66.0"

--- a/chain/chain/src/missing_chunks.rs
+++ b/chain/chain/src/missing_chunks.rs
@@ -149,7 +149,7 @@ impl<Block: BlockLike> MissingChunksPool<Block> {
     }
 
     fn mark_block_as_ready(&mut self, block_hash: &BlockHash) {
-        for block in self.blocks_waiting_for_chunks.remove(block_hash) {
+        if let Some(block) = self.blocks_waiting_for_chunks.remove(block_hash) {
             let height = block.height();
             if let btree_map::Entry::Occupied(mut entry) = self.height_idx.entry(height) {
                 let blocks_at_height = entry.get_mut();

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -1907,7 +1907,7 @@ impl ShardsManager {
     /// complete when a new block is accepted.
     pub fn check_incomplete_chunks(&mut self, prev_block_hash: &CryptoHash) {
         let mut chunks_to_process = vec![];
-        for chunk_hashes in self.encoded_chunks.get_incomplete_chunks(prev_block_hash) {
+        if let Some(chunk_hashes) = self.encoded_chunks.get_incomplete_chunks(prev_block_hash) {
             for chunk_hash in chunk_hashes {
                 if let Some(entry) = self.encoded_chunks.get(chunk_hash) {
                     chunks_to_process.push(entry.header.clone());

--- a/chain/jsonrpc/jsonrpc-tests/tests/rpc_transactions.rs
+++ b/chain/jsonrpc/jsonrpc-tests/tests/rpc_transactions.rs
@@ -128,7 +128,7 @@ fn test_refunds_not_in_receipts() {
                 }
             }
         }
-        for receipt in tx_status.get("receipts") {
+        if let Some(receipt) = tx_status.get("receipts") {
             if !receipt.as_array().unwrap().is_empty() {
                 let receipt_predecessor_id = receipt.get("predecessor_id");
                 if receipt_predecessor_id.is_some() {

--- a/runtime/runtime-params-estimator/emu-cost/Dockerfile
+++ b/runtime/runtime-params-estimator/emu-cost/Dockerfile
@@ -1,5 +1,5 @@
 # our local base image
-FROM rust:1.65.0
+FROM rust:1.66.0
 
 LABEL description="Container for builds"
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,6 +2,6 @@
 # This specifies the version of Rust we use to build.
 # Individual crates in the workspace may support a lower version, as indicated by `rust-version` field in each crate's `Cargo.toml`.
 # The version specified below, should be at least as high as the maximum `rust-version` within the workspace.
-channel = "1.65.0"
+channel = "1.66.0"
 components = [ "rustfmt" ]
 targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
https://blog.rust-lang.org/2022/12/15/Rust-1.66.0.html

Updated the same files as in the previous version bump: https://github.com/near/nearcore/pull/7993

This enables https://github.com/near/nearcore/issues/7650 (see [this comment](https://github.com/near/nearcore/issues/7650#issuecomment-1337180030)).

Also includes fixes for the following warning:
```
warning: for loop over an `Option`. This is more readably written as an `if let` statement
     ...
     = note: `#[warn(for_loops_over_fallibles)]` on by default
```