### PR TITLE
feat: try reading shard_cache if prefetcher blocking_get returns None

### DIFF
--- a/core/store/src/metrics.rs
+++ b/core/store/src/metrics.rs
@@ -181,6 +181,14 @@ pub static PREFETCH_MEMORY_LIMIT_REACHED: Lazy<IntCounterVec> = Lazy::new(|| {
     )
     .unwrap()
 });
+pub static PREFETCH_CONFLICT: Lazy<IntCounterVec> = Lazy::new(|| {
+    try_create_int_counter_vec(
+        "near_prefetch_conflict",
+        "Main thread retrieved value from shard_cache after a conflict with another main thread from a fork.",
+        &["shard_id"],
+    )
+    .unwrap()
+});
 pub static PREFETCH_RETRY: Lazy<IntCounterVec> = Lazy::new(|| {
     try_create_int_counter_vec(
         "near_prefetch_retries",

--- a/core/store/src/trie/prefetching_trie_storage.rs
+++ b/core/store/src/trie/prefetching_trie_storage.rs
@@ -269,8 +269,7 @@ impl TrieStorage for TriePrefetchingStorage {
                     .or_else(|| {
                         // `blocking_get` will return None if the prefetch slot has been removed
                         // by the main thread and the value inserted into the shard cache.
-                        let mut guard = self.shard_cache.lock();
-                        guard.get(hash)
+                        self.shard_cache.get(hash)
                     })
                     .ok_or_else(|| {
                         // This could only happen if this thread started prefetching a value

--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -414,6 +414,7 @@ struct TrieCacheInnerMetrics {
     prefetch_not_requested: GenericCounter<prometheus::core::AtomicU64>,
     prefetch_memory_limit_reached: GenericCounter<prometheus::core::AtomicU64>,
     prefetch_retry: GenericCounter<prometheus::core::AtomicU64>,
+    prefetch_conflict: GenericCounter<prometheus::core::AtomicU64>,
 }
 
 impl TrieCachingStorage {
@@ -447,6 +448,7 @@ impl TrieCachingStorage {
             prefetch_memory_limit_reached: metrics::PREFETCH_MEMORY_LIMIT_REACHED
                 .with_label_values(&metrics_labels[..1]),
             prefetch_retry: metrics::PREFETCH_RETRY.with_label_values(&metrics_labels[..1]),
+            prefetch_conflict: metrics::PREFETCH_CONFLICT.with_label_values(&metrics_labels[..1]),
         };
         TrieCachingStorage {
             store,
@@ -565,6 +567,7 @@ impl TrieStorage for TrieCachingStorage {
                                 // fetch the data from the DB.
                                 None => {
                                     if let Some(value) = self.shard_cache.get(hash) {
+                                        self.metrics.prefetch_conflict.inc();
                                         value
                                     } else {
                                         self.metrics.prefetch_retry.inc();


### PR DESCRIPTION
This is the second part of https://github.com/near/nearcore/issues/7723: avoid an unnecessary storage lookup from the main thread in the scenario of forks.