### PR TITLE
fix(integration-tests): fix tests after tx status RPC changes

### DIFF
--- a/integration-tests/src/tests/runtime/deployment.rs
+++ b/integration-tests/src/tests/runtime/deployment.rs
@@ -51,7 +51,7 @@ fn test_deploy_max_size_contract() {
         )
         .unwrap();
     assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
-    assert_eq!(transaction_result.receipts_outcome.len(), 2);
+    assert_eq!(transaction_result.receipts_outcome.len(), 1);
 
     // Deploy contract
     let wasm_binary = near_test_contracts::sized_contract(contract_size as usize);

--- a/integration-tests/src/tests/runtime/sanity_checks.rs
+++ b/integration-tests/src/tests/runtime/sanity_checks.rs
@@ -63,7 +63,7 @@ fn setup_runtime_node_with_contract(wasm_binary: &[u8]) -> RuntimeNode {
         )
         .unwrap();
     assert_eq!(tx_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
-    assert_eq!(tx_result.receipts_outcome.len(), 2);
+    assert_eq!(tx_result.receipts_outcome.len(), 1);
 
     let tx_result =
         node_user.deploy_contract(test_contract_account(), wasm_binary.to_vec()).unwrap();

--- a/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_gas_profile.snap
+++ b/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_gas_profile.snap
@@ -307,7 +307,6 @@ expression: receipts_gas_profile
             gas_used: 0,
         },
     ],
-    [],
     [
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
@@ -350,7 +349,6 @@ expression: receipts_gas_profile
             gas_used: 0,
         },
     ],
-    [],
     [
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
@@ -363,7 +361,6 @@ expression: receipts_gas_profile
             gas_used: 0,
         },
     ],
-    [],
     [
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
@@ -376,7 +373,6 @@ expression: receipts_gas_profile
             gas_used: 0,
         },
     ],
-    [],
     [
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
@@ -389,9 +385,6 @@ expression: receipts_gas_profile
             gas_used: 0,
         },
     ],
-    [],
-    [],
-    [],
     [],
     [],
     [
@@ -407,9 +400,6 @@ expression: receipts_gas_profile
         },
     ],
     [],
-    [],
-    [],
-    [],
     [
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
@@ -422,7 +412,6 @@ expression: receipts_gas_profile
             gas_used: 0,
         },
     ],
-    [],
     [
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
@@ -450,6 +439,4 @@ expression: receipts_gas_profile
             gas_used: 2865522486,
         },
     ],
-    [],
-    [],
 ]

--- a/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_gas_profile_nightly.snap
+++ b/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_gas_profile_nightly.snap
@@ -307,7 +307,6 @@ expression: receipts_gas_profile
             gas_used: 0,
         },
     ],
-    [],
     [
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
@@ -350,7 +349,6 @@ expression: receipts_gas_profile
             gas_used: 0,
         },
     ],
-    [],
     [
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
@@ -363,7 +361,6 @@ expression: receipts_gas_profile
             gas_used: 0,
         },
     ],
-    [],
     [
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
@@ -376,7 +373,6 @@ expression: receipts_gas_profile
             gas_used: 0,
         },
     ],
-    [],
     [
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
@@ -389,9 +385,6 @@ expression: receipts_gas_profile
             gas_used: 0,
         },
     ],
-    [],
-    [],
-    [],
     [],
     [],
     [
@@ -407,9 +400,6 @@ expression: receipts_gas_profile
         },
     ],
     [],
-    [],
-    [],
-    [],
     [
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
@@ -422,7 +412,6 @@ expression: receipts_gas_profile
             gas_used: 0,
         },
     ],
-    [],
     [
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
@@ -450,6 +439,4 @@ expression: receipts_gas_profile
             gas_used: 2865522486,
         },
     ],
-    [],
-    [],
 ]

--- a/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_gas_profile_nondeterministic.snap
+++ b/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_gas_profile_nondeterministic.snap
@@ -20,5 +20,4 @@ expression: receipts_gas_profile
             gas_used: 1645512,
         },
     ],
-    [],
 ]

--- a/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_status.snap
+++ b/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_status.snap
@@ -1,7 +1,6 @@
 ---
 source: integration-tests/src/tests/runtime/sanity_checks.rs
 expression: receipts_status
-
 ---
 - SuccessReceiptId: "11111111111111111111111111111111"
 - Failure:
@@ -10,7 +9,6 @@ expression: receipts_status
       kind:
         FunctionCallError:
           ExecutionError: "Smart contract panicked: explicit guest panic"
-- SuccessValue: ""
 - Failure:
     ActionError:
       index: 0
@@ -26,15 +24,4 @@ expression: receipts_status
 - SuccessValue: ""
 - SuccessValue: ""
 - SuccessValue: ""
-- SuccessValue: ""
-- SuccessValue: ""
-- SuccessValue: ""
-- SuccessValue: ""
-- SuccessValue: ""
-- SuccessValue: ""
-- SuccessValue: ""
-- SuccessValue: ""
-- SuccessValue: ""
-- SuccessValue: ""
-- SuccessValue: ""
-- SuccessValue: ""
+

--- a/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_status_nondeterministic.snap
+++ b/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_status_nondeterministic.snap
@@ -1,8 +1,6 @@
 ---
 source: integration-tests/src/tests/runtime/sanity_checks.rs
 expression: receipts_status
-
 ---
-- SuccessValue: ""
 - SuccessValue: ""
 

--- a/integration-tests/src/tests/runtime/test_evil_contracts.rs
+++ b/integration-tests/src/tests/runtime/test_evil_contracts.rs
@@ -28,7 +28,7 @@ fn setup_test_contract(wasm_binary: &[u8]) -> RuntimeNode {
         )
         .unwrap();
     assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
-    assert_eq!(transaction_result.receipts_outcome.len(), 2);
+    assert_eq!(transaction_result.receipts_outcome.len(), 1);
 
     let transaction_result =
         node_user.deploy_contract("test_contract".parse().unwrap(), wasm_binary.to_vec()).unwrap();

--- a/integration-tests/src/tests/standard_cases/mod.rs
+++ b/integration-tests/src/tests/standard_cases/mod.rs
@@ -96,7 +96,7 @@ pub fn test_smart_contract_panic(node: impl Node) {
             .into()
         )
     );
-    assert_eq!(transaction_result.receipts_outcome.len(), 2);
+    assert_eq!(transaction_result.receipts_outcome.len(), 1);
 }
 
 pub fn test_smart_contract_self_call(node: impl Node) {
@@ -218,7 +218,7 @@ pub fn test_async_call_with_logs(node: impl Node) {
         .function_call(account_id.clone(), bob_account(), "log_something", vec![], 10u64.pow(14), 0)
         .unwrap();
     assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
-    assert_eq!(transaction_result.receipts_outcome.len(), 2);
+    assert_eq!(transaction_result.receipts_outcome.len(), 1);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
     assert_eq!(transaction_result.receipts_outcome[0].outcome.logs[0], "hello".to_string());
@@ -340,7 +340,7 @@ pub fn transfer_tokens_implicit_account(node: impl Node) {
     let transaction_result =
         node_user.send_money(account_id.clone(), receiver_id.clone(), tokens_used).unwrap();
     assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
-    assert_eq!(transaction_result.receipts_outcome.len(), 2);
+    assert_eq!(transaction_result.receipts_outcome.len(), 1);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
     assert_eq!(node_user.get_access_key_nonce_for_signer(account_id).unwrap(), 1);
@@ -364,7 +364,7 @@ pub fn transfer_tokens_implicit_account(node: impl Node) {
         node_user.send_money(account_id.clone(), receiver_id.clone(), tokens_used).unwrap();
 
     assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
-    assert_eq!(transaction_result.receipts_outcome.len(), 2);
+    assert_eq!(transaction_result.receipts_outcome.len(), 1);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
     assert_eq!(node_user.get_access_key_nonce_for_signer(account_id).unwrap(), 2);
@@ -423,7 +423,7 @@ pub fn trying_to_create_implicit_account(node: impl Node) {
             .into()
         )
     );
-    assert_eq!(transaction_result.receipts_outcome.len(), 3);
+    assert_eq!(transaction_result.receipts_outcome.len(), 1);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
     assert_eq!(node_user.get_access_key_nonce_for_signer(account_id).unwrap(), 1);
@@ -450,7 +450,7 @@ pub fn test_smart_contract_reward(node: impl Node) {
         transaction_result.status,
         FinalExecutionStatus::SuccessValue(10i32.to_le_bytes().to_vec())
     );
-    assert_eq!(transaction_result.receipts_outcome.len(), 2);
+    assert_eq!(transaction_result.receipts_outcome.len(), 1);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
 
@@ -600,7 +600,7 @@ pub fn test_create_account_again(node: impl Node) {
             .into()
         )
     );
-    assert_eq!(transaction_result.receipts_outcome.len(), 3);
+    assert_eq!(transaction_result.receipts_outcome.len(), 1);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
     assert_eq!(node_user.get_access_key_nonce_for_signer(account_id).unwrap(), 2);
@@ -1158,7 +1158,7 @@ pub fn test_unstake_while_not_staked(node: impl Node) {
         )
         .unwrap();
     assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
-    assert_eq!(transaction_result.receipts_outcome.len(), 2);
+    assert_eq!(transaction_result.receipts_outcome.len(), 1);
     let transaction_result =
         node_user.stake(eve_dot_alice_account(), node.block_signer().public_key(), 0).unwrap();
     assert_eq!(
@@ -1256,7 +1256,7 @@ pub fn test_delete_account_fail(node: impl Node) {
             .into()
         )
     );
-    assert_eq!(transaction_result.receipts_outcome.len(), 2);
+    assert_eq!(transaction_result.receipts_outcome.len(), 1);
     assert!(node.user().view_account(&bob_account()).is_ok());
     assert_eq!(
         node.user().view_account(&node.account_id().unwrap()).unwrap().amount,
@@ -1278,7 +1278,7 @@ pub fn test_delete_account_no_account(node: impl Node) {
             .into()
         )
     );
-    assert_eq!(transaction_result.receipts_outcome.len(), 2);
+    assert_eq!(transaction_result.receipts_outcome.len(), 1);
 }
 
 pub fn test_delete_account_while_staking(node: impl Node) {
@@ -1381,7 +1381,7 @@ pub fn test_contract_write_key_value_cost(node: impl Node) {
             )
             .unwrap();
         assert_matches!(transaction_result.status, FinalExecutionStatus::SuccessValue(_));
-        assert_eq!(transaction_result.receipts_outcome.len(), 2);
+        assert_eq!(transaction_result.receipts_outcome.len(), 1);
 
         let trie_nodes_count = get_trie_nodes_count(
             &transaction_result.receipts_outcome[0].outcome.metadata,

--- a/integration-tests/src/tests/standard_cases/mod.rs
+++ b/integration-tests/src/tests/standard_cases/mod.rs
@@ -67,7 +67,7 @@ pub fn test_smart_contract_simple(node: impl Node) {
         transaction_result.status,
         FinalExecutionStatus::SuccessValue(10i32.to_le_bytes().to_vec())
     );
-    assert_eq!(transaction_result.receipts_outcome.len(), 2);
+    assert_eq!(transaction_result.receipts_outcome.len(), 1);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
 }
@@ -110,7 +110,7 @@ pub fn test_smart_contract_self_call(node: impl Node) {
         transaction_result.status,
         FinalExecutionStatus::SuccessValue(10i32.to_le_bytes().to_vec())
     );
-    assert_eq!(transaction_result.receipts_outcome.len(), 2);
+    assert_eq!(transaction_result.receipts_outcome.len(), 1);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
 }
@@ -134,7 +134,7 @@ pub fn test_smart_contract_bad_method_name(node: impl Node) {
             .into()
         )
     );
-    assert_eq!(transaction_result.receipts_outcome.len(), 2);
+    assert_eq!(transaction_result.receipts_outcome.len(), 1);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
 }
@@ -158,7 +158,7 @@ pub fn test_smart_contract_empty_method_name_with_no_tokens(node: impl Node) {
             .into()
         )
     );
-    assert_eq!(transaction_result.receipts_outcome.len(), 2);
+    assert_eq!(transaction_result.receipts_outcome.len(), 1);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
 }
@@ -182,7 +182,7 @@ pub fn test_smart_contract_empty_method_name_with_tokens(node: impl Node) {
             .into()
         )
     );
-    assert_eq!(transaction_result.receipts_outcome.len(), 3);
+    assert_eq!(transaction_result.receipts_outcome.len(), 1);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
 }
@@ -205,7 +205,7 @@ pub fn test_smart_contract_with_args(node: impl Node) {
         transaction_result.status,
         FinalExecutionStatus::SuccessValue(5u64.to_le_bytes().to_vec())
     );
-    assert_eq!(transaction_result.receipts_outcome.len(), 2);
+    assert_eq!(transaction_result.receipts_outcome.len(), 1);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
 }
@@ -261,7 +261,7 @@ pub fn test_upload_contract(node: impl Node) {
         )
         .unwrap();
     assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
-    assert_eq!(transaction_result.receipts_outcome.len(), 2);
+    assert_eq!(transaction_result.receipts_outcome.len(), 1);
 
     node_user.view_contract_code(&eve_dot_alice_account()).expect_err(
         "RpcError { code: -32000, message: \"Server error\", data: Some(String(\"contract code of account eve.alice.near does not exist while viewing\")) }");
@@ -307,7 +307,7 @@ pub fn test_send_money(node: impl Node) {
     let transaction_result =
         node_user.send_money(account_id.clone(), bob_account(), money_used).unwrap();
     assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
-    assert_eq!(transaction_result.receipts_outcome.len(), 2);
+    assert_eq!(transaction_result.receipts_outcome.len(), 1);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
     assert_eq!(node_user.get_access_key_nonce_for_signer(account_id).unwrap(), 1);
@@ -504,7 +504,7 @@ pub fn test_refund_on_send_money_to_non_existent_account(node: impl Node) {
             .into()
         )
     );
-    assert_eq!(transaction_result.receipts_outcome.len(), 3);
+    assert_eq!(transaction_result.receipts_outcome.len(), 1);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
     let result1 = node_user.view_account(account_id).unwrap();
@@ -535,7 +535,7 @@ pub fn test_create_account(node: impl Node) {
     let create_account_cost = fee_helper.create_account_transfer_full_key_cost();
 
     assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
-    assert_eq!(transaction_result.receipts_outcome.len(), 2);
+    assert_eq!(transaction_result.receipts_outcome.len(), 1);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
     assert_eq!(node_user.get_access_key_nonce_for_signer(account_id).unwrap(), 1);
@@ -568,7 +568,7 @@ pub fn test_create_account_again(node: impl Node) {
         .unwrap();
 
     assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
-    assert_eq!(transaction_result.receipts_outcome.len(), 2);
+    assert_eq!(transaction_result.receipts_outcome.len(), 1);
     let fee_helper = fee_helper(&node);
     let create_account_cost = fee_helper.create_account_transfer_full_key_cost();
 
@@ -655,7 +655,7 @@ pub fn test_create_account_failure_already_exists(node: impl Node) {
             .into()
         )
     );
-    assert_eq!(transaction_result.receipts_outcome.len(), 3);
+    assert_eq!(transaction_result.receipts_outcome.len(), 1);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
     assert_eq!(node_user.get_access_key_nonce_for_signer(account_id).unwrap(), 1);
@@ -998,7 +998,7 @@ pub fn test_access_key_smart_contract(node: impl Node) {
         prepaid_gas + exec_gas - transaction_result.receipts_outcome[0].outcome.gas_burnt,
     );
 
-    assert_eq!(transaction_result.receipts_outcome.len(), 2);
+    assert_eq!(transaction_result.receipts_outcome.len(), 1);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
 

--- a/integration-tests/src/user/runtime_user.rs
+++ b/integration-tests/src/user/runtime_user.rs
@@ -170,6 +170,12 @@ impl RuntimeUser {
             block_hash: Default::default(),
         }];
         for hash in &receipt_ids {
+            if let Some(receipt) = self.receipts.borrow().get(hash) {
+                let is_refund = receipt.predecessor_id.is_system();
+                if is_refund {
+                    continue;
+                }
+            }
             transactions.extend(self.get_recursive_transaction_results(hash).into_iter());
         }
         transactions


### PR DESCRIPTION
https://github.com/near/nearcore/pull/7928 changed `Chain::get_recursive_transaction_results()` to skip refund receipts, so the several checks for receipts outcome length in `standard_cases::rpc` are now wrong, because they expect to find the refunds. Fix it by changing all these asserts, and by changing
`RuntimeUser::get_recursive_transaction_results` to match `Chain::get_recursive_transaction_results`

failed tests (the ones that start with `standard_cases::rpc::`): https://nayduck.near.org/#/run/2802

to be safe, can check that these are indeed refunds by printing rceipts out like:

```
for r in transaction_result.receipts_outcome.iter() {
    let b = node_user.get_block(r.block_hash).unwrap();
    let mut found = false;
    'outer: for c in b.chunks {
        let ch = node_user.get_chunk_by_height(b.header.height, c.shard_id).unwrap();
        for receipt in ch.receipts {
            if receipt.receipt_id == r.id {
                dbg!(receipt);
                found = true;
                break 'outer;
            }
        }
    }
    if !found {
        eprintln!("cant find {}", r.id);
    }
}

```