### PR TITLE
chore: remove outdated constant ATTO_NEAR

### DIFF
--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -55,9 +55,6 @@ pub const NEAR_BASE: Balance = 1_000_000_000_000_000_000_000_000;
 /// Millinear, 1/1000 of NEAR.
 pub const MILLI_NEAR: Balance = NEAR_BASE / 1000;
 
-/// Attonear, 1/10^18 of NEAR.
-pub const ATTO_NEAR: Balance = 1;
-
 /// Block production tracking delay.
 pub const BLOCK_PRODUCTION_TRACKING_DELAY: u64 = 100;
 


### PR DESCRIPTION
This constant is:
- wrong: it should be yocto near (10^-24) and not atto (10^-18)
- outdated: we haven't used atto near since 2019 (#1827)
- unused: there are no code references to it

Better we get rid of it.