### PR TITLE
fix: estimator generates too long account names

### DIFF
--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -376,9 +376,9 @@ fn action_transfer(ctx: &mut EstimatorContext) -> GasCost {
 fn action_create_account(ctx: &mut EstimatorContext) -> GasCost {
     let total_cost = {
         let mut make_transaction = |tb: &mut TransactionBuilder| -> SignedTransaction {
-            let sender = tb.random_account();
-            let new_account =
-                AccountId::try_from(format!("{}_{}", sender, tb.rng().gen::<u64>())).unwrap();
+            let sender = tb.random_unused_account();
+            // derive a non-existing account id
+            let new_account = AccountId::try_from(format!("{sender}_x")).unwrap();
 
             let actions = vec![
                 Action::CreateAccount(CreateAccountAction {}),

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -103,7 +103,6 @@ use near_primitives::version::PROTOCOL_VERSION;
 use near_vm_logic::mocks::mock_external::MockedExternal;
 use near_vm_logic::{ExtCosts, VMConfig};
 use near_vm_runner::MockCompiledContractCache;
-use rand::Rng;
 use serde_json::json;
 use utils::{
     average_cost, fn_cost, fn_cost_count, fn_cost_in_contract, fn_cost_with_setup,


### PR DESCRIPTION
In the estimation for CreateAccountAction, we appended a long hash to a
random account to generate a new and unique account ID. This could
trigger ParseAccountError { kind: TooLong, char: None }'.

New approach: Append a constant suffix to a random unused account.

This also guarantees the sender account is only used once.
This reduces randomness on whether the sender account is already
cached due to previous iterations, which was another source of
measurement noise.