### PR TITLE
fix(pytest): fix assert in switch_node_key.py

### DIFF
--- a/pytest/tests/sanity/switch_node_key.py
+++ b/pytest/tests/sanity/switch_node_key.py
@@ -53,4 +53,4 @@ utils.wait_for_blocks(nodes[1], target=EPOCH_LENGTH * 2 + 5)
 validators = nodes[1].get_validators()
 assert len(
     validators['result']['next_validators']
-) == 2, f'unexpected number of validators, current validators: {status1["validators"]}'
+) == 2, f'unexpected number of validators, next validators: {validators["result"]["next_validators"]}'


### PR DESCRIPTION
status1 isn't defined, so use the validator RPC response to print out the info