### PR TITLE
fix: only add '-Ctarget-feature=+sse4.1,+sse4.2' flags for x86_64

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,7 @@
 [build]
 # We compile with `panic=abort`, so we need `-Cforce-unwind-tables=y`
 # to get a useful backtrace on panic.
+rustflags = ["-Cforce-unwind-tables=y"]
+
+[target.'cfg(target_arch = "x86_64")']
 rustflags = ["-Ctarget-feature=+sse4.1,+sse4.2", "-Cforce-unwind-tables=y"]


### PR DESCRIPTION
With #8284 we upgraded cargo version to `1.66`, so https://github.com/rust-lang/cargo/pull/11114 is available. This PR is the same as #7130, but we can safely merge it now.

See #7650 for more context.

In order to test it I've used the code from [`librocksdb-sys/build.rs`](https://github.com/rust-rocksdb/rust-rocksdb/blob/master/librocksdb-sys/build.rs#L111) as part of `neard/build.rs`:
```
 fn main() {
-    if let Err(err) = try_main() {
-        eprintln!("{}", err);
-        std::process::exit(1);
+    let target_feature = std::env::var("CARGO_CFG_TARGET_FEATURE").unwrap();
+    let target_features: Vec<_> = target_feature.split(',').collect();
+    if target_features.contains(&"neon") {
+        panic!("FAIL: {target_feature}");
+    } else {
+        panic!("OK: {target_feature}");
     }
 }
```

It was was tested on M1 macbook, so I've changed the feature to `neon` (which is enabled by default), my `.cargo/config.toml` is as follows:
```
-[target.'cfg(target_arch = "x86_64")']
-rustflags = ["-Ctarget-feature=+sse4.1,+sse4.2", "-Cforce-unwind-tables=y"]
+[target.'cfg(target_arch = "aarch64")']
+rustflags = ["-Ctarget-feature=-neon", "-Cforce-unwind-tables=y"]
```

`neon` was successfully removed when using `1.66` toolchain:
```
OK: crc,...,vh
```

while it was still present with `1.65`:
```
FAIL: aes,..,neon,...,vh
```

This proves that rustflags are passed as env variable to `build.rs` in `1.66`, which was not the case in `1.65`
