### PR TITLE
chore: tokio patch version update to 1.18.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5769,16 +5769,15 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.18.2"
+version = "1.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4903bf0427cf68dddd5aa6a93220756f8be0c34fcfa9f5e6191e103e15a31395"
+checksum = "8bfb875c82dc0a4f1f37a30e720dee181a2b3a06a428b0fc6873ea38d6407850"
 dependencies = [
  "bytes",
  "libc",
  "memchr",
  "mio",
  "num_cpus",
- "once_cell",
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,7 +184,7 @@ tempfile = "3.3"
 thiserror = "1.0.30"
 tikv-jemallocator = "0.5.0"
 time = "0.3.9"
-tokio = { version = "1.16.1", features = ["fs", "macros", "net", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "~1.18", features = ["fs", "macros", "net", "rt-multi-thread", "sync", "time"] }
 tokio-stream = { version = "0.1.2", features = ["net"] }
 tokio-util = { version = "0.7.1", features = ["codec", "io"] }
 toml = "0.5.8"


### PR DESCRIPTION
replaces #8304

dependabot made us aware of bugfixes and wanted to update to 1.20.3

Instead I propose we update only the patch version and keep major/minor.
1.18.x is a LTS version and it is what we are currently using.
1.18.4 contains the same fixes the bot wants.
Updating further should be done as a conscious decision.

`version = "~1.18"` means we want a fixed 1.18 minor version with
the newest patch version.

The old `"1.16.1"` is equivalent to `^1.16.1"` but in the lock file it
was fixed to `"1.18.2"`. Since we check in the lock file and only update
versions occasionally and consciously, I suggest we use `~` which is
less confusing.