### PR TITLE
feat: support hot/cold store in state viewer and add view-trie2 command 

### DIFF
--- a/chain/network/src/peer_manager/peer_store/mod.rs
+++ b/chain/network/src/peer_manager/peer_store/mod.rs
@@ -7,11 +7,13 @@ use anyhow::bail;
 use im::hashmap::Entry;
 use im::{HashMap, HashSet};
 use near_primitives::network::PeerId;
+use near_store::db::Database;
 use parking_lot::Mutex;
 use rand::seq::IteratorRandom;
 use rand::thread_rng;
 use std::net::SocketAddr;
 use std::ops::Not;
+use std::sync::Arc;
 
 #[cfg(test)]
 mod testonly;
@@ -592,12 +594,12 @@ impl PeerStore {
 }
 
 /// Public method used to iterate through all peers stored in the database.
-pub fn iter_peers_from_store<F>(store: near_store::NodeStorage, f: F)
+pub fn iter_peers_from_store<F>(db: Arc<dyn Database>, f: F)
 where
     F: Fn((PeerId, KnownPeerState)),
 {
-    let db = store.into_inner(near_store::Temperature::Hot);
-    for x in crate::store::Store::from(db).list_peer_states().unwrap() {
+    let store = crate::store::Store::from(db);
+    for x in store.list_peer_states().unwrap() {
         f(x)
     }
 }

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -2,6 +2,7 @@ use std::fs::File;
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::marker::PhantomData;
 use std::path::Path;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::{fmt, io};
 
@@ -67,6 +68,20 @@ pub enum Temperature {
     Hot,
     #[cfg(feature = "cold_store")]
     Cold,
+}
+
+impl FromStr for Temperature {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, String> {
+        let s = s.to_lowercase();
+        match s.as_str() {
+            "hot" => Ok(Temperature::Hot),
+            #[cfg(feature = "cold_store")]
+            "cold" => Ok(Temperature::Cold),
+            _ => Err(String::from(format!("invalid temperature string {s}"))),
+        }
+    }
 }
 
 /// Node’s storage holding chain and all other necessary data.

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -835,6 +835,8 @@ impl Trie {
     }
 
     // Similar to retrieve_raw_node but handles the case where there is a Value (and not a Node) in the database.
+    // This method is not safe to be used in any real scenario as it can incorrectly interpret a value as a trie node.
+    // It's only provided as a convenience for debugging tools.
     fn retrieve_raw_node_or_value(&self, hash: &CryptoHash) -> Result<NodeOrValue, StorageError> {
         let bytes = self.storage.retrieve_raw_bytes(hash)?;
         match RawTrieNodeWithSize::decode(&bytes) {

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -1,6 +1,8 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::fmt::Write;
 use std::io::Read;
+use std::str;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use byteorder::{LittleEndian, ReadBytesExt};
@@ -12,6 +14,7 @@ pub use near_primitives::shard_layout::ShardUId;
 use near_primitives::state::ValueRef;
 #[cfg(feature = "protocol_feature_flat_state")]
 use near_primitives::state_record::is_delayed_receipt_key;
+use near_primitives::state_record::StateRecord;
 use near_primitives::trie_key::TrieKey;
 use near_primitives::types::{StateRoot, StateRootNode};
 
@@ -27,7 +30,6 @@ pub use crate::trie::trie_storage::{TrieCache, TrieCachingStorage, TrieDBStorage
 use crate::trie::trie_storage::{TrieMemoryPartialStorage, TrieRecordingStorage};
 use crate::{FlatStateDelta, StorageError};
 pub use near_primitives::types::TrieNodesCount;
-use std::fmt::Write;
 
 mod config;
 mod insert_delete;
@@ -556,6 +558,11 @@ pub struct ApplyStatePartResult {
     pub contract_codes: Vec<ContractCode>,
 }
 
+enum NodeOrValue {
+    Node(RawTrieNodeWithSize),
+    Value(std::sync::Arc<[u8]>),
+}
+
 impl Trie {
     pub const EMPTY_ROOT: StateRoot = StateRoot::new();
 
@@ -661,14 +668,15 @@ impl Trie {
     }
 
     // Prints the trie nodes starting from hash, up to max_depth depth.
+    // The node hash can be any node in the trie.
     pub fn print_recursive(&self, f: &mut dyn std::io::Write, hash: &CryptoHash, max_depth: u32) {
         match self.retrieve_raw_node_or_value(hash) {
-            Ok(Ok(_)) => {
+            Ok(NodeOrValue::Node(_)) => {
                 let mut prefix: Vec<u8> = Vec::new();
                 self.print_recursive_internal(f, hash, max_depth, &mut "".to_string(), &mut prefix)
                     .expect("write failed");
             }
-            Ok(Err(value_bytes)) => {
+            Ok(NodeOrValue::Value(value_bytes)) => {
                 writeln!(
                     f,
                     "Given node is a value. Len: {}, Data: {:?} ",
@@ -681,6 +689,38 @@ impl Trie {
                 writeln!(f, "Error when reading: {}", err).expect("write failed");
             }
         };
+    }
+
+    // Prints the trie leaves starting from the state root node, up to max_depth depth.
+    // This method can only iterate starting from the root node and it only prints the
+    // leaf nodes but it shows output in more human friendly way.
+    pub fn print_recursive_leaves(&self, f: &mut dyn std::io::Write, max_depth: u32) {
+        let iter = match self.iter_with_max_depth(max_depth as usize) {
+            Ok(iter) => iter,
+            Err(err) => {
+                writeln!(f, "Error when getting the trie iterator: {}", err).expect("write failed");
+                return;
+            }
+        };
+        for node in iter {
+            let (key, value) = match node {
+                Ok((key, value)) => (key, value),
+                Err(err) => {
+                    writeln!(f, "Failed to iterate node with error: {err}").expect("write failed");
+                    continue;
+                }
+            };
+
+            // Try to parse the key in UTF8 which works only for the simplest keys (e.g. account),
+            // or get whitespace padding instead.
+            let key_string = match str::from_utf8(&key) {
+                Ok(value) => String::from(value),
+                Err(_) => " ".repeat(key.len()),
+            };
+            let state_record = StateRecord::from_raw_key_value(key.clone(), value);
+
+            writeln!(f, "{} {state_record:?}", key_string).expect("write failed");
+        }
     }
 
     // Converts the list of Nibbles to a readable string.
@@ -795,12 +835,12 @@ impl Trie {
     }
 
     // Similar to retrieve_raw_node but handles the case where there is a Value (and not a Node) in the database.
-    fn retrieve_raw_node_or_value(
-        &self,
-        hash: &CryptoHash,
-    ) -> Result<Result<RawTrieNodeWithSize, std::sync::Arc<[u8]>>, StorageError> {
+    fn retrieve_raw_node_or_value(&self, hash: &CryptoHash) -> Result<NodeOrValue, StorageError> {
         let bytes = self.storage.retrieve_raw_bytes(hash)?;
-        Ok(RawTrieNodeWithSize::decode(&bytes).map_err(|_| bytes))
+        match RawTrieNodeWithSize::decode(&bytes) {
+            Ok(node) => Ok(NodeOrValue::Node(node)),
+            Err(_) => Ok(NodeOrValue::Value(bytes)),
+        }
     }
 
     fn move_node_to_mutable(
@@ -984,7 +1024,14 @@ impl Trie {
     }
 
     pub fn iter<'a>(&'a self) -> Result<TrieIterator<'a>, StorageError> {
-        TrieIterator::new(self)
+        TrieIterator::new(self, None)
+    }
+
+    pub fn iter_with_max_depth<'a>(
+        &'a self,
+        max_depth: usize,
+    ) -> Result<TrieIterator<'a>, StorageError> {
+        TrieIterator::new(self, Some(max_depth))
     }
 
     pub fn get_trie_nodes_count(&self) -> TrieNodesCount {

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -94,7 +94,7 @@ impl NeardCmd {
 
             NeardSubCommand::StateViewer(cmd) => {
                 let mode = if cmd.readwrite { Mode::ReadWrite } else { Mode::ReadOnly };
-                cmd.subcmd.run(&home_dir, genesis_validation, mode);
+                cmd.subcmd.run(&home_dir, genesis_validation, mode, cmd.store_temperature);
             }
 
             NeardSubCommand::RecompressStorage(cmd) => {
@@ -131,6 +131,10 @@ pub(super) struct StateViewerCommand {
     /// In case an operation needs to write to caches, a read-write mode may be needed.
     #[clap(long, short = 'w')]
     readwrite: bool,
+    /// What store temperature should the state viewer open. Allowed values are hot and cold but
+    /// cold is only available when cold_store feature is enabled.
+    #[clap(long, short = 't', default_value = "hot")]
+    store_temperature: near_store::Temperature,
     #[clap(subcommand)]
     subcmd: StateViewerSubCommand,
 }

--- a/tools/cold-store/src/cli.rs
+++ b/tools/cold-store/src/cli.rs
@@ -45,15 +45,15 @@ fn check_open(store: &NodeStorage) {
 
 fn print_heads(store: &NodeStorage) {
     println!(
-        "HOT HEAD is at {:?}",
+        "HOT HEAD is at {:#?}",
         store.get_store(Temperature::Hot).get_ser::<Tip>(DBCol::BlockMisc, HEAD_KEY)
     );
     println!(
-        "HOT FINAL HEAD is at {:?}",
+        "HOT FINAL HEAD is at {:#?}",
         store.get_store(Temperature::Hot).get_ser::<Tip>(DBCol::BlockMisc, FINAL_HEAD_KEY)
     );
     println!(
-        "COLD HEAD is at {:?}",
+        "COLD HEAD is at {:#?}",
         store.get_store(Temperature::Cold).get_ser::<Tip>(DBCol::BlockMisc, HEAD_KEY)
     );
 }

--- a/tools/state-viewer/Cargo.toml
+++ b/tools/state-viewer/Cargo.toml
@@ -47,3 +47,4 @@ nightly = [
 ]
 nightly_protocol = ["nearcore/nightly_protocol"]
 protocol_feature_flat_state = ["nearcore/protocol_feature_flat_state"]
+cold_store = ["near-store/cold_store"]

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -509,9 +509,6 @@ impl ViewChainCmd {
     }
 }
 
-#[derive(Subcommand)]
-#[clap(subcommand_required = true, arg_required_else_help = true)]
-
 pub enum ViewTrieFormat {
     Full,
     Pretty,

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -8,7 +8,7 @@ use near_primitives::account::id::AccountId;
 use near_primitives::hash::CryptoHash;
 use near_primitives::sharding::ChunkHash;
 use near_primitives::types::{BlockHeight, ShardId};
-use near_store::{Mode, Store};
+use near_store::{Mode, NodeStorage, Store, Temperature};
 use nearcore::{load_config, NearConfig};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -82,37 +82,52 @@ pub enum StateViewerSubCommand {
 }
 
 impl StateViewerSubCommand {
-    pub fn run(self, home_dir: &Path, genesis_validation: GenesisValidationMode, mode: Mode) {
+    pub fn run(
+        self,
+        home_dir: &Path,
+        genesis_validation: GenesisValidationMode,
+        mode: Mode,
+        temperature: Temperature,
+    ) {
         let near_config = load_config(home_dir, genesis_validation)
             .unwrap_or_else(|e| panic!("Error loading config: {:#}", e));
+
+        #[cfg(feature = "cold_store")]
+        let cold_store_config: Option<&near_store::StoreConfig> =
+            near_config.config.cold_store.as_ref();
+        #[cfg(not(feature = "cold_store"))]
+        let cold_store_config: Option<std::convert::Infallible> = None;
+
         let store_opener =
-            near_store::NodeStorage::opener(home_dir, &near_config.config.store, None);
-        let store = store_opener.open_in_mode(mode).unwrap();
-        let hot = store.get_store(near_store::Temperature::Hot);
+            NodeStorage::opener(home_dir, &near_config.config.store, cold_store_config);
+
+        let storage = store_opener.open_in_mode(mode).unwrap();
+        let store = storage.get_store(temperature);
+        let db = storage.into_inner(temperature);
         match self {
-            StateViewerSubCommand::Apply(cmd) => cmd.run(home_dir, near_config, hot),
-            StateViewerSubCommand::ApplyChunk(cmd) => cmd.run(home_dir, near_config, hot),
-            StateViewerSubCommand::ApplyRange(cmd) => cmd.run(home_dir, near_config, hot),
-            StateViewerSubCommand::ApplyReceipt(cmd) => cmd.run(home_dir, near_config, hot),
-            StateViewerSubCommand::ApplyTx(cmd) => cmd.run(home_dir, near_config, hot),
-            StateViewerSubCommand::Chain(cmd) => cmd.run(home_dir, near_config, hot),
-            StateViewerSubCommand::CheckBlock => check_block_chunk_existence(near_config, hot),
-            StateViewerSubCommand::Chunks(cmd) => cmd.run(near_config, hot),
-            StateViewerSubCommand::DumpAccountStorage(cmd) => cmd.run(home_dir, near_config, hot),
-            StateViewerSubCommand::DumpCode(cmd) => cmd.run(home_dir, near_config, hot),
-            StateViewerSubCommand::DumpState(cmd) => cmd.run(home_dir, near_config, hot),
-            StateViewerSubCommand::DumpStateParts(cmd) => cmd.run(home_dir, near_config, hot),
-            StateViewerSubCommand::DumpStateRedis(cmd) => cmd.run(home_dir, near_config, hot),
-            StateViewerSubCommand::DumpTx(cmd) => cmd.run(home_dir, near_config, hot),
-            StateViewerSubCommand::EpochInfo(cmd) => cmd.run(home_dir, near_config, hot),
-            StateViewerSubCommand::PartialChunks(cmd) => cmd.run(near_config, hot),
-            StateViewerSubCommand::Peers => peers(store),
-            StateViewerSubCommand::Receipts(cmd) => cmd.run(near_config, hot),
-            StateViewerSubCommand::Replay(cmd) => cmd.run(home_dir, near_config, hot),
+            StateViewerSubCommand::Apply(cmd) => cmd.run(home_dir, near_config, store),
+            StateViewerSubCommand::ApplyChunk(cmd) => cmd.run(home_dir, near_config, store),
+            StateViewerSubCommand::ApplyRange(cmd) => cmd.run(home_dir, near_config, store),
+            StateViewerSubCommand::ApplyReceipt(cmd) => cmd.run(home_dir, near_config, store),
+            StateViewerSubCommand::ApplyTx(cmd) => cmd.run(home_dir, near_config, store),
+            StateViewerSubCommand::Chain(cmd) => cmd.run(home_dir, near_config, store),
+            StateViewerSubCommand::CheckBlock => check_block_chunk_existence(near_config, store),
+            StateViewerSubCommand::Chunks(cmd) => cmd.run(near_config, store),
+            StateViewerSubCommand::DumpAccountStorage(cmd) => cmd.run(home_dir, near_config, store),
+            StateViewerSubCommand::DumpCode(cmd) => cmd.run(home_dir, near_config, store),
+            StateViewerSubCommand::DumpState(cmd) => cmd.run(home_dir, near_config, store),
+            StateViewerSubCommand::DumpStateParts(cmd) => cmd.run(home_dir, near_config, store),
+            StateViewerSubCommand::DumpStateRedis(cmd) => cmd.run(home_dir, near_config, store),
+            StateViewerSubCommand::DumpTx(cmd) => cmd.run(home_dir, near_config, store),
+            StateViewerSubCommand::EpochInfo(cmd) => cmd.run(home_dir, near_config, store),
+            StateViewerSubCommand::PartialChunks(cmd) => cmd.run(near_config, store),
+            StateViewerSubCommand::Peers => peers(db),
+            StateViewerSubCommand::Receipts(cmd) => cmd.run(near_config, store),
+            StateViewerSubCommand::Replay(cmd) => cmd.run(home_dir, near_config, store),
             StateViewerSubCommand::RocksDBStats(cmd) => cmd.run(store_opener.path()),
-            StateViewerSubCommand::State => state(home_dir, near_config, hot),
-            StateViewerSubCommand::ViewChain(cmd) => cmd.run(near_config, hot),
-            StateViewerSubCommand::ViewTrie(cmd) => cmd.run(hot),
+            StateViewerSubCommand::State => state(home_dir, near_config, store),
+            StateViewerSubCommand::ViewChain(cmd) => cmd.run(near_config, store),
+            StateViewerSubCommand::ViewTrie(cmd) => cmd.run(store),
         }
     }
 }
@@ -494,14 +509,53 @@ impl ViewChainCmd {
     }
 }
 
+#[derive(Subcommand)]
+#[clap(subcommand_required = true, arg_required_else_help = true)]
+
+pub enum ViewTrieFormat {
+    Full,
+    Pretty,
+}
+
+impl std::str::FromStr for ViewTrieFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, String> {
+        let s = s.to_lowercase();
+        match s.as_str() {
+            "full" => Ok(ViewTrieFormat::Full),
+            "pretty" => Ok(ViewTrieFormat::Pretty),
+            _ => Err(String::from(format!("invalid view trie format string {s}"))),
+        }
+    }
+}
+
 #[derive(Parser)]
 pub struct ViewTrieCmd {
+    /// The format of the output. This can be either `full` or `pretty`.
+    /// The full format will print all the trie nodes and can be rooted anywhere in the trie.
+    /// The pretty format will only print leaf nodes and must be rooted in the state root but is more human friendly.
+    #[clap(long, default_value = "pretty")]
+    format: ViewTrieFormat,
+    /// The hash of the trie node.
+    /// For format=full this can be any node in the trie.
+    /// For format=pretty this must the state root node.
+    /// You can find the state root hash using the `view-state view-chain` command.
     #[clap(long)]
     hash: String,
+    /// The id of the shard, a number between [0-NUM_SHARDS). When looking for particular
+    /// account you will need to know on which shard it's located.
     #[clap(long)]
     shard_id: u32,
+    /// The current shard version based on the shard layout.
+    /// You can find the shard version by using the `view-state view-chain` command.
+    /// It's typically equal to 0 for single shard localnet or the most recent near_primitives::shard_layout::ShardLayout for prod.
     #[clap(long)]
     shard_version: u32,
+    /// The max depth of trie iteration. It's recommended to keep that value small,
+    /// otherwise the output may be really large.
+    /// For format=full this measures depth in terms of number of trie nodes.
+    /// For format=pretty this measures depth in terms of key nibbles.
     #[clap(long)]
     max_depth: u32,
 }
@@ -509,6 +563,15 @@ pub struct ViewTrieCmd {
 impl ViewTrieCmd {
     pub fn run(self, store: Store) {
         let hash = CryptoHash::from_str(&self.hash).unwrap();
-        view_trie(store, hash, self.shard_id, self.shard_version, self.max_depth).unwrap();
+
+        match self.format {
+            ViewTrieFormat::Full => {
+                view_trie(store, hash, self.shard_id, self.shard_version, self.max_depth).unwrap();
+            }
+            ViewTrieFormat::Pretty => {
+                view_trie_leaves(store, hash, self.shard_id, self.shard_version, self.max_depth)
+                    .unwrap();
+            }
+        }
     }
 }


### PR DESCRIPTION
- added store_temperature cmdline argument to neard view-state 
- added neard view-state view-trie2 command that is similary to view-trie but
  - can only iterate from the state root node
  - prints leaves only
  - prints data in more human friendly way
- added max_depth to the trie iterator (needed for the view-trie2)
- refactored the retrieve_raw_node_or_value to return NodeOrValue instead of Result