### PR TITLE
feat: enable clippy suspicious as part of CI

### DIFF
--- a/integration-tests/src/test_helpers.rs
+++ b/integration-tests/src/test_helpers.rs
@@ -21,9 +21,9 @@ pub fn check_result(output: Output) -> Result<String, String> {
         if result.is_empty() {
             result = String::from_utf8_lossy(output.stderr.as_slice());
         }
-        return Err(result.to_owned().to_string());
+        return Err(result.into_owned());
     }
-    Ok(result.to_owned().to_string())
+    Ok(result.into_owned())
 }
 
 pub fn wait<F>(mut f: F, check_interval_ms: u64, max_wait_ms: u64)

--- a/scripts/run_clippy.sh
+++ b/scripts/run_clippy.sh
@@ -2,5 +2,6 @@
 # clippy adoption is in progress, see https://github.com/near/nearcore/issues/8145
 cargo clippy -- \
     -A clippy::all \
-    -D clippy::correctness
+    -D clippy::correctness \
+    -D clippy::suspicious
 


### PR DESCRIPTION
Enable `clippy::suspicious` checks as part of CI.

Part of #8145.