### PR TITLE
[Debug UI] Migrate Epoch Info page to new UI

### DIFF
--- a/tools/debug-ui/package-lock.json
+++ b/tools/debug-ui/package-lock.json
@@ -17,6 +17,7 @@
         "react-router": "^6.4.4",
         "react-router-dom": "^6.4.4",
         "react-scripts": "^5.0.1",
+        "react-tooltip": "^5.4.0",
         "react-xarrows": "^2.0.2",
         "typescript": "^4.9.3"
       },
@@ -2351,6 +2352,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.1.0.tgz",
+      "integrity": "sha512-zbsLwtnHo84w1Kc8rScAo5GMk1GdecSlrflIbfnEBJwvTSj1SL6kkOYV+nHraMCPEy+RNZZUaZyL8JosDGCtGQ=="
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.1.0.tgz",
+      "integrity": "sha512-TSogMPVxbRe77QCj1dt8NmRiJasPvuc+eT5jnJ6YpLqgOD2zXc5UA3S1qwybN+GVCDNdKfpKy1oj8RpzLJvh6A==",
+      "dependencies": {
+        "@floating-ui/core": "^1.0.5"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -5668,6 +5682,11 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA=="
+    },
+    "node_modules/classnames": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "node_modules/clean-css": {
       "version": "5.3.1",
@@ -14778,6 +14797,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/react-tooltip": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.4.0.tgz",
+      "integrity": "sha512-bfUZUQ1im0TrO49yhG4qtYsx4WTPzF4TSELAgQfcOYuUfO7Ho09SdIU9LxzbBwhH55ZWgYhOpeCp9VKH6Cokdw==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.4",
+        "classnames": "^2.3.2"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
     "node_modules/react-xarrows": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/react-xarrows/-/react-xarrows-2.0.2.tgz",
@@ -19228,6 +19260,19 @@
         }
       }
     },
+    "@floating-ui/core": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.1.0.tgz",
+      "integrity": "sha512-zbsLwtnHo84w1Kc8rScAo5GMk1GdecSlrflIbfnEBJwvTSj1SL6kkOYV+nHraMCPEy+RNZZUaZyL8JosDGCtGQ=="
+    },
+    "@floating-ui/dom": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.1.0.tgz",
+      "integrity": "sha512-TSogMPVxbRe77QCj1dt8NmRiJasPvuc+eT5jnJ6YpLqgOD2zXc5UA3S1qwybN+GVCDNdKfpKy1oj8RpzLJvh6A==",
+      "requires": {
+        "@floating-ui/core": "^1.0.5"
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.11.7",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
@@ -21658,6 +21703,11 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA=="
+    },
+    "classnames": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "clean-css": {
       "version": "5.3.1",
@@ -28194,6 +28244,15 @@
             "lru-cache": "^6.0.0"
           }
         }
+      }
+    },
+    "react-tooltip": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.4.0.tgz",
+      "integrity": "sha512-bfUZUQ1im0TrO49yhG4qtYsx4WTPzF4TSELAgQfcOYuUfO7Ho09SdIU9LxzbBwhH55ZWgYhOpeCp9VKH6Cokdw==",
+      "requires": {
+        "@floating-ui/dom": "^1.0.4",
+        "classnames": "^2.3.2"
       }
     },
     "react-xarrows": {

--- a/tools/debug-ui/package.json
+++ b/tools/debug-ui/package.json
@@ -12,6 +12,7 @@
     "react-router": "^6.4.4",
     "react-router-dom": "^6.4.4",
     "react-scripts": "^5.0.1",
+    "react-tooltip": "^5.4.0",
     "react-xarrows": "^2.0.2",
     "typescript": "^4.9.3"
   },

--- a/tools/debug-ui/src/App.tsx
+++ b/tools/debug-ui/src/App.tsx
@@ -2,6 +2,7 @@ import { Navigate, Route, Routes, useParams } from 'react-router';
 import { NavLink } from 'react-router-dom';
 import './App.scss';
 import { ClusterView } from './ClusterView';
+import { EpochInfoView } from './EpochInfoView';
 import { HeaderBar } from './HeaderBar';
 import { LatestBlocksView } from './LatestBlocksView';
 import { NetworkInfoView } from './NetworkInfoView';
@@ -27,13 +28,12 @@ export const App = () => {
         <NavLink to="sync_info" className={navLinkClassName}>Sync Info</NavLink>
         <NavLink to="validator_info" className={navLinkClassName}>Validator Info</NavLink>
         <NavLink to="cluster" className={navLinkClassName}>Cluster View</NavLink>
-
       </div>
       <Routes>
         <Route path="" element={<Navigate to="cluster" />} />
         <Route path="last_blocks" element={<LatestBlocksView addr={addr} />} />
         <Route path="network_info/*" element={<NetworkInfoView addr={addr} />} />
-        <Route path="epoch_info" element={<div>TODO</div>} />
+        <Route path="epoch_info/*" element={<EpochInfoView addr={addr} />} />
         <Route path="chain_and_chunk_info" element={<div>TODO</div>} />
         <Route path="sync_info" element={<div>TODO</div>} />
         <Route path="validator_info" element={<div>TODO</div>} />

--- a/tools/debug-ui/src/EpochInfoView.scss
+++ b/tools/debug-ui/src/EpochInfoView.scss
@@ -1,0 +1,32 @@
+.epoch-info-view {
+    .error {
+        color: red;
+    }
+
+    table {
+        width: 100%;
+        border-collapse: collapse;
+    }
+
+    th,
+    td {
+        border: 1px solid #444;
+    }
+
+    td {
+        text-align: left;
+        vertical-align: top;
+        padding: 8px;
+    }
+
+    th {
+        text-align: center;
+        vertical-align: center;
+        padding: 8px;
+        background-color: lightgrey;
+    }
+
+    .content {
+        padding: 10px;
+    }
+}

--- a/tools/debug-ui/src/EpochInfoView.tsx
+++ b/tools/debug-ui/src/EpochInfoView.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { Navigate, Route, Routes } from "react-router";
+import { NavLink } from "react-router-dom";
+import './EpochInfoView.scss';
+import { EpochShardsView } from "./EpochShardsView";
+import { EpochValidatorsView } from "./EpochValidatorsView";
+import { RecentEpochsView } from "./RecentEpochsView";
+
+type EpochInfoViewProps = {
+    addr: string,
+};
+
+export const EpochInfoView = ({ addr }: EpochInfoViewProps) => {
+    return <div className="epoch-info-view">
+        <div className="navbar">
+            <NavLink to="recent" className={navLinkClassName}>Recent Epochs</NavLink>
+            <NavLink to="validators" className={navLinkClassName}>Validators</NavLink>
+            <NavLink to="shards" className={navLinkClassName}>Shard Sizes</NavLink>
+        </div>
+        <div className="content">
+            <Routes>
+                <Route path="" element={<Navigate to="recent" />} />
+                <Route path="recent" element={<RecentEpochsView addr={addr} />} />
+                <Route path="validators" element={<EpochValidatorsView addr={addr} />} />
+                <Route path="shards" element={<EpochShardsView addr={addr} />} />
+            </Routes>
+        </div>
+    </div >;
+};
+
+function navLinkClassName({ isActive }: { isActive: boolean }) {
+    return isActive ? 'nav-link active' : 'nav-link';
+}

--- a/tools/debug-ui/src/EpochShardsView.scss
+++ b/tools/debug-ui/src/EpochShardsView.scss
@@ -1,0 +1,70 @@
+.epoch-shards-table {
+    .shard-cell {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+
+        .shard-size-bar {
+            flex: 1;
+            display: flex;
+            align-items: center;
+            margin-right: 8px;
+
+            .bar {
+                background-color: rgb(14, 14, 188);
+                height: 8px;
+                margin-right: 6px;
+            }
+
+            .text {
+                font-size: 14px;
+                white-space: nowrap;
+            }
+        }
+
+        .shard-parts {
+            font-size: 14px;
+        }
+    }
+
+    th:first-child {
+        border: none;
+        background: none;
+    }
+
+    thead tr:first-child th {
+        background: none;
+    }
+
+    thead tr:first-child th:nth-child(3) {
+        border: none;
+    }
+
+    $current-border: 4px solid #3bda26;
+
+    thead tr:first-child th:nth-child(2) {
+        border-top: $current-border;
+        border-left: $current-border;
+        border-right: $current-border;
+    }
+
+    thead tr:nth-child(2) th,
+    tbody td {
+        &:nth-child(2) {
+            border-left: $current-border;
+            border-right: $current-border;
+        }
+    }
+
+    tbody td:first-child {
+        background-color: lightgray;
+    }
+
+    tbody tr:last-child td:nth-child(2) {
+        border-bottom: $current-border;
+    }
+
+    thead tr:nth-child(2) th:nth-child(2) {
+        background-color: #d6ffd0;
+    }
+}

--- a/tools/debug-ui/src/EpochShardsView.tsx
+++ b/tools/debug-ui/src/EpochShardsView.tsx
@@ -1,0 +1,95 @@
+import { useQuery } from "react-query";
+import { fetchEpochInfo } from "./api";
+import "./EpochShardsView.scss";
+
+function humanFileSize(bytes: number, si: boolean = false, dp: number = 1): string {
+    const thresh = si ? 1000 : 1024;
+
+    if (Math.abs(bytes) < thresh) {
+        return bytes + ' B';
+    }
+
+    const units = si
+        ? ['kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+        : ['KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'];
+    let u = -1;
+    const r = 10 ** dp;
+
+    do {
+        bytes /= thresh;
+        ++u;
+    } while (Math.round(Math.abs(bytes) * r) / r >= thresh && u < units.length - 1);
+
+    return bytes.toFixed(dp) + ' ' + units[u];
+}
+
+type EpochShardsViewProps = {
+    addr: string,
+};
+
+export const EpochShardsView = ({ addr }: EpochShardsViewProps) => {
+    const { data: epochData, error: epochError, isLoading: epochIsLoading } =
+        useQuery(['epochInfo', addr], () => fetchEpochInfo(addr));
+
+    if (epochIsLoading) {
+        return <div>Loading...</div>;
+    }
+    if (epochError) {
+        return <div className="error">
+            {(epochError as Error).stack}
+        </div>;
+    }
+    const epochs = epochData!.status_response.EpochInfo;
+
+    let numShards = 0;
+    let maxShardSize = 0;
+    for (const epoch of epochs.slice(1)) {
+        numShards = Math.max(epoch.shards_size_and_parts.length, numShards);
+        for (const [size] of epoch.shards_size_and_parts) {
+            maxShardSize = Math.max(maxShardSize, size);
+        }
+    }
+    return <table className="epoch-shards-table">
+        <thead>
+            <tr>
+                <th></th>
+                <th>Current Epoch</th>
+                <th colSpan={epochs.length - 2}>Past Epochs</th>
+            </tr>
+            <tr>
+                <th></th>
+                {epochs.slice(1).map(epoch => {
+                    return <th key={epoch.epoch_id}>{epoch.epoch_id.substring(0, 6)}...</th>
+                })}
+            </tr>
+        </thead>
+        <tbody>
+            {[...Array(numShards).keys()].map(i => {
+                return <tr key={i}>
+                    <td>Shard {i}</td>
+                    {epochs.slice(1).map(epoch => {
+                        if (epoch.shards_size_and_parts.length <= i) {
+                            return <></>;
+                        }
+                        const [size, parts, requested] = epoch.shards_size_and_parts[i];
+                        return <td key={epoch.epoch_id}>
+                            <div className={`shard-cell ${requested ? 'requested' : ''}`}>
+                                {drawShardSizeBar(size, maxShardSize)}
+                                <div className="shard-parts">{parts} parts</div>
+                            </div>
+                        </td>;
+                    })}
+                </tr>;
+            })}
+        </tbody>
+    </table>;
+};
+
+function drawShardSizeBar(size: number, maxSize: number): JSX.Element {
+    const width = size / maxSize * 100 + 5;
+    const text = humanFileSize(size);
+    return <div className="shard-size-bar">
+        <div className="bar" style={{ width }}></div>
+        <div className="text">{text}</div>
+    </div>;
+}

--- a/tools/debug-ui/src/EpochValidatorsView.scss
+++ b/tools/debug-ui/src/EpochValidatorsView.scss
@@ -1,0 +1,121 @@
+.epoch-validators-table {
+    td {
+        vertical-align: middle;
+    }
+
+    .produced-and-expected-bar {
+        display: flex;
+        align-items: center;
+
+        .produced {
+            background-color: green;
+            height: 6px;
+        }
+
+        .missed {
+            background-color: red;
+            height: 6px;
+        }
+
+        .produced-count {
+            color: green;
+            font-size: 12px;
+            margin-right: 4px;
+        }
+
+        .missed-count {
+            color: red;
+            font-size: 12px;
+            margin-left: 4px;
+        }
+    }
+
+    .stake-bar {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+
+        .bar {
+            background-color: rgb(14, 14, 188);
+            height: 6px;
+            margin-right: 4px;
+        }
+
+        .text {
+            font-size: 12px;
+        }
+    }
+
+    .kickout-reason {
+        color: red;
+    }
+
+    $current-border: 4px solid #3bda26;
+    $next-border: 3px solid gray;
+
+    th.small-text {
+        font-size: 12px;
+    }
+
+    thead tr:first-child {
+        th {
+            background: none;
+            border: none;
+        }
+
+        th:nth-child(3) {
+            border-left: $current-border;
+            border-top: $current-border;
+            border-right: $current-border;
+        }
+
+        th:nth-child(2) {
+            border-left: $next-border;
+        }
+    }
+
+    thead tr:nth-child(2) th,
+    tbody td {
+        &:nth-child(2) {
+            border-left: $next-border;
+        }
+
+        &:nth-child(2),
+        &:nth-child(3),
+        &:nth-child(4),
+        &:nth-child(5) {
+            opacity: 0.5;
+        }
+
+        &:nth-child(6) {
+            border-left: $current-border;
+        }
+
+        &:nth-child(10) {
+            border-right: $current-border;
+        }
+    }
+
+
+    thead tr:nth-child(2) th {
+
+        &:nth-child(6),
+        &:nth-child(7),
+        &:nth-child(8),
+        &:nth-child(9),
+        &:nth-child(10) {
+            background-color: #d6ffd0;
+        }
+    }
+
+    tbody tr:last-child td {
+
+        &:nth-child(6),
+        &:nth-child(7),
+        &:nth-child(8),
+        &:nth-child(9),
+        &:nth-child(10) {
+            border-bottom: $current-border;
+        }
+    }
+}

--- a/tools/debug-ui/src/EpochValidatorsView.tsx
+++ b/tools/debug-ui/src/EpochValidatorsView.tsx
@@ -1,0 +1,293 @@
+import { useId } from "react";
+import { useQuery } from "react-query";
+import { Tooltip } from "react-tooltip";
+import { fetchEpochInfo, ValidatorKickoutReason } from "./api";
+import "./EpochValidatorsView.scss";
+
+interface ProducedAndExpected {
+    produced: number,
+    expected: number,
+}
+
+type ValidatorRole = 'BlockProducer' | 'ChunkOnlyProducer' | 'None';
+
+interface CurrentValidatorInfo {
+    stake: number,
+    shards: number[],
+    blocks: ProducedAndExpected,
+    chunks: ProducedAndExpected,
+}
+
+interface NextValidatorInfo {
+    stake: number,
+    shards: number[],
+}
+
+interface ValidatorInfo {
+    accountId: string,
+    current: CurrentValidatorInfo | null,
+    next: NextValidatorInfo | null,
+    proposalStake: number | null,
+    kickoutReason: ValidatorKickoutReason | null,
+    roles: ValidatorRole[],
+}
+
+class Validators {
+    validators: Map<string, ValidatorInfo> = new Map();
+
+    constructor(private numEpochs: number) { }
+
+    validator(accountId: string): ValidatorInfo {
+        if (this.validators.has(accountId)) {
+            return this.validators.get(accountId)!;
+        }
+        const roles = [] as ValidatorRole[];
+        for (let i = 0; i < this.numEpochs; i++) {
+            roles.push('None');
+        }
+        this.validators.set(accountId, {
+            accountId,
+            current: null,
+            next: null,
+            proposalStake: null,
+            kickoutReason: null,
+            roles,
+        });
+        return this.validators.get(accountId)!;
+    }
+
+    setValidatorRole(accountId: string, epochIndex: number, role: ValidatorRole) {
+        const validator = this.validator(accountId);
+        validator.roles[epochIndex] = role;
+    }
+
+    sorted(): ValidatorInfo[] {
+        const validators = [...this.validators.values()];
+        function sortingKey(info: ValidatorInfo) {
+            if (info.current !== null) {
+                return [0, -info.current.stake];
+            }
+            if (info.next !== null) {
+                return [1, -info.next.stake];
+            }
+            if (info.proposalStake !== null) {
+                return [2, -info.proposalStake];
+            }
+            return [3, 0];
+        }
+        validators.sort((a, b) => {
+            const [ax, ay] = sortingKey(a);
+            const [bx, by] = sortingKey(b);
+            if (ax == bx) {
+                return ay - by;
+            }
+            return ax - bx;
+        });
+        return validators;
+    }
+}
+
+type EpochValidatorViewProps = {
+    addr: string,
+};
+
+export const EpochValidatorsView = ({ addr }: EpochValidatorViewProps) => {
+    const { data: epochData, error: epochError, isLoading: epochIsLoading } =
+        useQuery(['epochInfo', addr], () => fetchEpochInfo(addr));
+
+    if (epochIsLoading) {
+        return <div>Loading...</div>;
+    }
+    if (epochError) {
+        return <div className="error">
+            {(epochError as Error).stack}
+        </div>;
+    }
+    let maxStake = 0, totalStake = 0, maxExpectedBlocks = 0, maxExpectedChunks = 0;
+    const epochs = epochData!.status_response.EpochInfo;
+    const validators = new Validators(epochs.length);
+    const currentValidatorInfo = epochData!.status_response.EpochInfo[1].validator_info;
+    for (const validatorInfo of currentValidatorInfo.current_validators) {
+        const validator = validators.validator(validatorInfo.account_id);
+        const stake = parseFloat(validatorInfo.stake);
+        validator.current = {
+            stake,
+            shards: validatorInfo.shards,
+            blocks: {
+                produced: validatorInfo.num_produced_blocks,
+                expected: validatorInfo.num_expected_blocks,
+            },
+            chunks: {
+                produced: validatorInfo.num_produced_chunks,
+                expected: validatorInfo.num_expected_chunks,
+            },
+        };
+        maxStake = Math.max(maxStake, stake);
+        totalStake += stake;
+        maxExpectedBlocks = Math.max(maxExpectedBlocks, validatorInfo.num_expected_blocks);
+        maxExpectedChunks = Math.max(maxExpectedChunks, validatorInfo.num_expected_chunks);
+    }
+    for (const validatorInfo of currentValidatorInfo.next_validators) {
+        const validator = validators.validator(validatorInfo.account_id);
+        validator.next = {
+            stake: parseFloat(validatorInfo.stake),
+            shards: validatorInfo.shards,
+        };
+    }
+    for (const proposal of currentValidatorInfo.current_proposals) {
+        const validator = validators.validator(proposal.account_id);
+        validator.proposalStake = parseFloat(proposal.stake);
+    }
+    for (const kickout of currentValidatorInfo.prev_epoch_kickout) {
+        const validator = validators.validator(kickout.account_id);
+        validator.kickoutReason = kickout.reason;
+    }
+    epochs.forEach((epochInfo, index) => {
+        for (const chunkOnlyProducer of epochInfo.chunk_only_producers) {
+            validators.setValidatorRole(chunkOnlyProducer, index, 'ChunkOnlyProducer');
+        }
+        for (const blockProducer of epochInfo.block_producers) {
+            validators.setValidatorRole(blockProducer.account_id, index, 'BlockProducer');
+        }
+    });
+
+    return <table className="epoch-validators-table">
+        <thead>
+            <tr>
+                <th></th>
+                <th colSpan={4}>Next Epoch</th>
+                <th colSpan={5}>Current Epoch</th>
+                <th colSpan={1 + epochs.length - 2}>Past Epochs</th>
+            </tr>
+            <tr>
+                <th>Validator</th>
+
+                <th className="small-text">Role</th>
+                <th className="small-text">Shards</th>
+                <th>Stake</th>
+                <th>Proposal</th>
+
+                <th className="small-text">Role</th>
+                <th className="small-text">Shards</th>
+                <th>Stake</th>
+                <th>Blocks</th>
+                <th>Chunks</th>
+
+                <th>Kickout</th>
+                {epochs.slice(2).map(epoch => {
+                    return <th key={epoch.epoch_id} className="small-text">{epoch.epoch_id.substring(0, 4)}...</th>;
+                })}
+            </tr>
+        </thead>
+        <tbody>
+            {validators.sorted().map(validator => {
+                return <tr key={validator.accountId}>
+                    <td>{validator.accountId}</td>
+                    <td>{renderRole(validator.roles[0])}</td>
+                    <td>{validator.next?.shards?.join(',') ?? ''}</td>
+                    <td>{drawStakeBar(validator.next?.stake ?? null, maxStake, totalStake)}</td>
+                    <td>{drawStakeBar(validator.proposalStake, maxStake, totalStake)}</td>
+
+                    <td>{renderRole(validator.roles[1])}</td>
+                    <td>{validator.current?.shards?.join(',') ?? ''}</td>
+                    <td>{drawStakeBar(validator.current?.stake ?? null, maxStake, totalStake)}</td>
+                    <td>{drawProducedAndExpectedBar(validator.current?.blocks ?? null, maxExpectedBlocks)}</td>
+                    <td>{drawProducedAndExpectedBar(validator.current?.chunks ?? null, maxExpectedChunks)}</td>
+
+                    <td><KickoutReason reason={validator.kickoutReason} /></td>
+                    {validator.roles.slice(2).map((role, i) => {
+                        return <td key={i}>{renderRole(role)}</td>
+                    })}
+                </tr>;
+            })}
+        </tbody>
+    </table>
+
+};
+
+function drawProducedAndExpectedBar(producedAndExpected: ProducedAndExpected | null, maxExpected: number): JSX.Element {
+    if (producedAndExpected === null) {
+        return <></>;
+    }
+    const { produced, expected } = producedAndExpected;
+    if (expected == 0) {
+        return <div className="expects-zero">0</div>;
+    }
+    const expectedWidth = expected / maxExpected * 100 + 10;
+    let producedWidth = expectedWidth * produced / expected;
+    let missedWidth = expectedWidth * (expected - produced) / expected;
+    if (produced !== expected) {
+        if (producedWidth < 5) {
+            producedWidth = 5;
+            missedWidth = expectedWidth - producedWidth;
+        }
+        if (missedWidth < 5) {
+            missedWidth = 5;
+            producedWidth = expectedWidth - missedWidth;
+        }
+    }
+    return <div className="produced-and-expected-bar">
+        <div className="produced-count">{produced}</div>
+        <div className="produced" style={{ width: producedWidth }}></div>
+        {produced !== expected && <>
+            <div className="missed" style={{ width: missedWidth }}></div>
+            <div className="missed-count">{expected - produced}</div>
+        </>}
+    </div>
+}
+
+function drawStakeBar(stake: number | null, maxStake: number, totalStake: number): JSX.Element {
+    if (stake === null) {
+        return <></>;
+    }
+    const width = stake / maxStake * 100 + 5;
+    const stakeText = Math.floor(stake / 1e24).toLocaleString('en-US');
+    const stakePercentage = (100 * stake / totalStake).toFixed(2) + '%';
+    return <div className="stake-bar">
+        <div className="bar" style={{ width }}></div>
+        <div className="text">{stakeText} ({stakePercentage})</div>
+    </div>;
+}
+
+function renderRole(role: ValidatorRole): JSX.Element {
+    switch (role) {
+        case 'BlockProducer': return <span className="role-block-producer">BP</span>;
+        case 'ChunkOnlyProducer': return <span className="role-chunk-only-producer">CP</span>;
+        default: return <></>;
+    }
+}
+
+const KickoutReason = ({ reason }: { reason: ValidatorKickoutReason | null }) => {
+    const id = useId();
+    if (reason === null) {
+        return <></>;
+    }
+    let kickoutSummary = '';
+    let kickoutReason = '';
+    if (reason == 'Slashed') {
+        kickoutSummary = 'Slashed';
+        kickoutReason = 'Validator was slashed';
+    } else if (reason == 'Unstaked') {
+        kickoutSummary = 'Unstaked';
+        kickoutReason = 'Validator unstaked';
+    } else if (reason == 'DidNotGetASeat') {
+        kickoutSummary = 'Seat';
+        kickoutReason = 'Validator did not get a seat';
+    } else if ('NotEnoughBlocks' in reason) {
+        kickoutSummary = '#Blocks';
+        kickoutReason = `Validator did not produce enough blocks: expected ${reason.NotEnoughBlocks.expected}, actually produced ${reason.NotEnoughBlocks.produced}`;
+    } else if ('NotEnoughChunks' in reason) {
+        kickoutSummary = '#Chunks';
+        kickoutReason = `Validator did not produce enough chunks: expected ${reason.NotEnoughChunks.expected}, actually produced ${reason.NotEnoughChunks.produced}`;
+    } else if ('NotEnoughStake' in reason) {
+        kickoutSummary = 'LowStake';
+        kickoutReason = `Validator did not have enough stake: minimum stake required was ${reason.NotEnoughStake.threshold}, but validator only had ${reason.NotEnoughStake.stake}`;
+    } else {
+        kickoutSummary = 'Other';
+        kickoutReason = JSON.stringify(reason);
+    }
+    return <>
+        <span className="kickout-reason" id={id}>{kickoutSummary}</span>
+        <Tooltip anchorId={id} content={kickoutReason} />
+    </>
+};

--- a/tools/debug-ui/src/RecentEpochsView.scss
+++ b/tools/debug-ui/src/RecentEpochsView.scss
@@ -1,0 +1,27 @@
+.recent-epochs-table {
+    th:first-child {
+        border: none;
+        background-color: transparent;
+    }
+
+    td:first-child {
+        border: none;
+        background-color: none;
+        text-align: right;
+        white-space: nowrap;
+    }
+
+    tr.current-epoch {
+        td:not(:first-child) {
+            background-color: #c6f8bf;
+        }
+
+        td:first-child {
+            color: #3bda26;
+        }
+    }
+
+    tr.next-epoch {
+        color: gray;
+    }
+}

--- a/tools/debug-ui/src/RecentEpochsView.tsx
+++ b/tools/debug-ui/src/RecentEpochsView.tsx
@@ -1,0 +1,78 @@
+import { useQuery } from "react-query";
+import { fetchEpochInfo, fetchFullStatus } from "./api";
+import { formatDurationInMillis } from "./utils";
+import "./RecentEpochsView.scss";
+
+type RecentEpochsViewProps = {
+    addr: string,
+};
+
+export const RecentEpochsView = ({ addr }: RecentEpochsViewProps) => {
+    const { data: epochData, error: epochError, isLoading: epochIsLoading } =
+        useQuery(['epochInfo', addr], () => fetchEpochInfo(addr));
+    const { data: statusData, error: statusError, isLoading: statusIsLoading } =
+        useQuery(['fullStatus', addr], () => fetchFullStatus(addr));
+
+    if (epochIsLoading || statusIsLoading) {
+        return <div>Loading...</div>;
+    }
+    if (epochError || statusError) {
+        return <div className="error">
+            {((epochError || statusError) as Error).stack}
+        </div>;
+    }
+    const epochInfos = epochData!.status_response.EpochInfo;
+    const status = statusData!;
+
+    return <table className="recent-epochs-table">
+        <thead>
+            <tr>
+                <th></th>
+                <th>Epoch ID</th>
+                <th>Start Height</th>
+                <th>Protocol Version</th>
+                <th>First Block</th>
+                <th>Epoch Start</th>
+                <th>Block Producers</th>
+                <th>Chunk-only Producers</th>
+            </tr>
+        </thead>
+        <tbody>
+            {epochInfos.map((epochInfo, index) => {
+                let firstBlockColumn = "";
+                let epochStartColumn = "";
+                if (epochInfo.first_block === null) {
+                    if (index == 0) {
+                        const blocksRemaining = (epochInfo.height - status.sync_info.latest_block_height);
+                        const millisecondsRemaining = blocksRemaining * status.detailed_debug_status!.block_production_delay_millis;
+                        firstBlockColumn = `Next epoch - in ${blocksRemaining} blocks`;
+                        epochStartColumn = `in ${formatDurationInMillis(millisecondsRemaining)}`;
+                    }
+                } else {
+                    firstBlockColumn = epochInfo.first_block[0];
+                    epochStartColumn = `${formatDurationInMillis(Date.now() - Date.parse(epochInfo.first_block[1]))} ago`;
+                }
+                let rowClassName = "";
+                let firstColumnText = "";
+                if (index == 0) {
+                    rowClassName = "next-epoch";
+                    firstColumnText = "Next ⮕";
+                } else if (index == 1) {
+                    rowClassName = "current-epoch";
+                    firstColumnText = "Current ⮕";
+                }
+
+                return <tr className={rowClassName} key={epochInfo.epoch_id}>
+                    <td>{firstColumnText}</td>
+                    <td>{epochInfo.epoch_id}</td>
+                    <td>{epochInfo.height}</td>
+                    <td>{epochInfo.protocol_version}</td>
+                    <td>{firstBlockColumn}</td>
+                    <td>{epochStartColumn}</td>
+                    <td>{epochInfo.block_producers.length}</td>
+                    <td>{epochInfo.chunk_only_producers.length}</td>
+                </tr>;
+            })}
+        </tbody>
+    </table>;
+};

--- a/tools/debug-ui/src/api.tsx
+++ b/tools/debug-ui/src/api.tsx
@@ -41,7 +41,7 @@ export interface BuildInfo {
 
 export interface DetailedDebugStatus {
     network_info: NetworkInfoView,
-    sync_status: String,
+    sync_status: string,
     catchup_status: CatchupStatusView[],
     current_head_status: BlockStatusView,
     current_header_head_status: BlockStatusView,
@@ -175,9 +175,9 @@ export interface EpochInfoView {
     first_block: null | [string, string],
     block_producers: ValidatorInfo[],
     chunk_only_producers: string[],
-    validator_info: EpochValidatorInfo[],
+    validator_info: EpochValidatorInfo,
     protocol_version: number,
-    shard_size_and_parts: [number, number, boolean][],
+    shards_size_and_parts: [number, number, boolean][],
 }
 
 export interface EpochValidatorInfo {
@@ -211,11 +211,10 @@ export interface NextEpochValidatorInfo {
 }
 
 export interface ValidatorStakeView {
-    V1: {
-        account_id: string,
-        public_key: string,
-        stake: string,
-    }
+    account_id: string,
+    public_key: string,
+    stake: string,
+    validator_stake_struct_version: 'V1',
 }
 
 export interface ValidatorKickoutView {

--- a/tools/debug-ui/src/index.tsx
+++ b/tools/debug-ui/src/index.tsx
@@ -4,6 +4,7 @@ import './index.css';
 import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { App } from './App';
+import 'react-tooltip/dist/react-tooltip.css';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement

--- a/tools/debug-ui/src/utils.tsx
+++ b/tools/debug-ui/src/utils.tsx
@@ -1,3 +1,5 @@
+import { ReactElement } from "react";
+
 export function formatDurationInMillis(millis: number): string {
     if (millis == null) {
         return '(null)';


### PR DESCRIPTION
I've turned the many tables on that page to three tabs: recent epochs, validators, and shard sizes:

**Recent Epochs**
<img width="1728" alt="Screen Shot 2023-01-12 at 9 45 09 AM" src="https://user-images.githubusercontent.com/111538878/212141921-b23bb0f9-9b63-4406-ba33-8f4e37b9fcdb.png">

**Validators** (this is all combined into one table)
<img width="1728" alt="Screen Shot 2023-01-12 at 9 45 02 AM" src="https://user-images.githubusercontent.com/111538878/212141982-2ef8204f-c750-40c5-abb3-be217a4ed970.png">
Kickout reason:
<img width="1721" alt="Screen Shot 2023-01-11 at 10 16 47 PM" src="https://user-images.githubusercontent.com/111538878/212142015-448da5f0-a406-4e93-920d-fcc0c0bbe949.png">

**Shard Sizes** (this table is transposed from the original, so that the bars can more easily be compared visually, and also this will look much better with 100 shards)
<img width="1728" alt="Screen Shot 2023-01-12 at 9 41 03 AM" src="https://user-images.githubusercontent.com/111538878/212142149-2dd851e0-e2b9-4d7e-9d04-a3fedb58850c.png">

(includes changes from the base PR for now, will be moved out when that's merged)