### PR TITLE
[Runtime Epoch Split] (1/n) Split RuntimeAdapter to separate trait, and rename combined trait to RuntimeAndEpochManagerAdapter

### DIFF
--- a/chain/chain/src/blocks_delay_tracker.rs
+++ b/chain/chain/src/blocks_delay_tracker.rs
@@ -14,7 +14,7 @@ use std::mem;
 use std::time::Instant;
 use tracing::error;
 
-use crate::{metrics, Chain, ChainStoreAccess, RuntimeAdapter};
+use crate::{metrics, Chain, ChainStoreAccess, RuntimeWithEpochManagerAdapter};
 
 const BLOCK_DELAY_TRACKING_COUNT: u64 = 50;
 
@@ -92,7 +92,7 @@ impl ChunkTrackingStats {
     fn to_chunk_processing_info(
         &self,
         chunk_hash: ChunkHash,
-        runtime_adapter: &dyn RuntimeAdapter,
+        runtime_adapter: &dyn RuntimeWithEpochManagerAdapter,
     ) -> ChunkProcessingInfo {
         let status = if self.completed_timestamp.is_some() {
             ChunkProcessingStatus::Completed
@@ -353,7 +353,7 @@ impl BlocksDelayTracker {
         block_height: BlockHeight,
         block_hash: &CryptoHash,
         chain: &Chain,
-        runtime_adapter: &dyn RuntimeAdapter,
+        runtime_adapter: &dyn RuntimeWithEpochManagerAdapter,
     ) -> Option<BlockProcessingInfo> {
         self.blocks.get(block_hash).map(|block_stats| {
             let chunks_info: Vec<_> = block_stats

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -67,7 +67,7 @@ use crate::store::{ChainStore, ChainStoreAccess, ChainStoreUpdate, GCMode};
 use crate::types::{
     AcceptedBlock, ApplySplitStateResult, ApplySplitStateResultOrStateChanges,
     ApplyTransactionResult, Block, BlockEconomicsConfig, BlockHeader, BlockHeaderInfo, BlockStatus,
-    ChainConfig, ChainGenesis, Provenance, RuntimeAdapter,
+    ChainConfig, ChainGenesis, Provenance, RuntimeWithEpochManagerAdapter,
 };
 use crate::validate::{
     validate_challenge, validate_chunk_proofs, validate_chunk_with_chunk_extra,
@@ -429,7 +429,7 @@ type BlockApplyChunksResult = (CryptoHash, Vec<Result<ApplyChunkResult, Error>>)
 /// Provides current view on the state according to the chain state.
 pub struct Chain {
     store: ChainStore,
-    pub runtime_adapter: Arc<dyn RuntimeAdapter>,
+    pub runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
     orphans: OrphanBlockPool,
     pub blocks_with_missing_chunks: MissingChunksPool<Orphan>,
     genesis: Block,
@@ -479,7 +479,7 @@ impl Drop for Chain {
 }
 impl Chain {
     pub fn make_genesis_block(
-        runtime_adapter: &dyn RuntimeAdapter,
+        runtime_adapter: &dyn RuntimeWithEpochManagerAdapter,
         chain_genesis: &ChainGenesis,
     ) -> Result<Block, Error> {
         let (_, state_roots) = runtime_adapter.genesis_state();
@@ -507,7 +507,7 @@ impl Chain {
     }
 
     pub fn new_for_view_client(
-        runtime_adapter: Arc<dyn RuntimeAdapter>,
+        runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
         chain_genesis: &ChainGenesis,
         doomslug_threshold_mode: DoomslugThresholdMode,
         save_trie_changes: bool,
@@ -538,7 +538,7 @@ impl Chain {
     }
 
     pub fn new(
-        runtime_adapter: Arc<dyn RuntimeAdapter>,
+        runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
         chain_genesis: &ChainGenesis,
         doomslug_threshold_mode: DoomslugThresholdMode,
         chain_config: ChainConfig,
@@ -692,7 +692,7 @@ impl Chain {
     }
 
     pub fn compute_bp_hash(
-        runtime_adapter: &dyn RuntimeAdapter,
+        runtime_adapter: &dyn RuntimeWithEpochManagerAdapter,
         epoch_id: EpochId,
         prev_epoch_id: EpochId,
         last_known_hash: &CryptoHash,
@@ -719,7 +719,7 @@ impl Chain {
     ///               compute the light client block
     pub fn create_light_client_block(
         header: &BlockHeader,
-        runtime_adapter: &dyn RuntimeAdapter,
+        runtime_adapter: &dyn RuntimeWithEpochManagerAdapter,
         chain_store: &dyn ChainStoreAccess,
     ) -> Result<LightClientBlockView, Error> {
         let final_block_header = {
@@ -1086,7 +1086,7 @@ impl Chain {
     }
 
     fn validate_block_impl(
-        runtime_adapter: &dyn RuntimeAdapter,
+        runtime_adapter: &dyn RuntimeWithEpochManagerAdapter,
         genesis_block: &Block,
         block: &Block,
     ) -> Result<(), Error> {
@@ -2560,7 +2560,7 @@ impl Chain {
     /// 2) Shard layout will be the same. In this case, the method returns all shards that `me` will
     ///    track in the next epoch but not this epoch
     fn get_shards_to_dl_state(
-        runtime_adapter: Arc<dyn RuntimeAdapter>,
+        runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
         me: &Option<AccountId>,
         parent_hash: &CryptoHash,
     ) -> Result<Vec<ShardId>, Error> {
@@ -2573,7 +2573,7 @@ impl Chain {
     }
 
     fn should_catch_up_shard(
-        runtime_adapter: Arc<dyn RuntimeAdapter>,
+        runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
         me: &Option<AccountId>,
         parent_hash: &CryptoHash,
         shard_id: ShardId,
@@ -4404,9 +4404,9 @@ impl Chain {
         &mut self.store
     }
 
-    /// Returns underlying RuntimeAdapter.
+    /// Returns underlying RuntimeWithEpochManagerAdapter.
     #[inline]
-    pub fn runtime_adapter(&self) -> Arc<dyn RuntimeAdapter> {
+    pub fn runtime_adapter(&self) -> Arc<dyn RuntimeWithEpochManagerAdapter> {
         self.runtime_adapter.clone()
     }
 
@@ -4549,7 +4549,7 @@ impl Chain {
     /// `get_prev_chunks(runtime_adapter, prev_block)` will return
     /// `[prev_block.chunks()[0], prev_block.chunks()[0], prev_block.chunks()[1], prev_block.chunks()[1]]`
     pub fn get_prev_chunk_headers(
-        runtime_adapter: &dyn RuntimeAdapter,
+        runtime_adapter: &dyn RuntimeWithEpochManagerAdapter,
         prev_block: &Block,
     ) -> Result<Vec<ShardChunkHeader>, Error> {
         let epoch_id = runtime_adapter.get_epoch_id_from_prev_block(prev_block.hash())?;
@@ -4564,7 +4564,7 @@ impl Chain {
     }
 
     pub fn get_prev_chunk_header(
-        runtime_adapter: &dyn RuntimeAdapter,
+        runtime_adapter: &dyn RuntimeWithEpochManagerAdapter,
         prev_block: &Block,
         shard_id: ShardId,
     ) -> Result<ShardChunkHeader, Error> {
@@ -4635,7 +4635,7 @@ impl Chain {
 /// If rejected nothing will be updated in underlying storage.
 /// Safe to stop process mid way (Ctrl+C or crash).
 pub struct ChainUpdate<'a> {
-    runtime_adapter: Arc<dyn RuntimeAdapter>,
+    runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
     chain_store_update: ChainStoreUpdate<'a>,
     doomslug_threshold_mode: DoomslugThresholdMode,
     #[allow(unused)]
@@ -4670,7 +4670,7 @@ pub enum ApplyChunkResult {
 impl<'a> ChainUpdate<'a> {
     pub fn new(
         store: &'a mut ChainStore,
-        runtime_adapter: Arc<dyn RuntimeAdapter>,
+        runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
         doomslug_threshold_mode: DoomslugThresholdMode,
         transaction_validity_period: BlockHeightDelta,
     ) -> Self {
@@ -4684,7 +4684,7 @@ impl<'a> ChainUpdate<'a> {
     }
 
     fn new_impl(
-        runtime_adapter: Arc<dyn RuntimeAdapter>,
+        runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
         doomslug_threshold_mode: DoomslugThresholdMode,
         transaction_validity_period: BlockHeightDelta,
         chain_store_update: ChainStoreUpdate<'a>,
@@ -4777,7 +4777,7 @@ impl<'a> ChainUpdate<'a> {
     ///    otherwise, this function returns state changes needed to be applied to split
     ///    states. These state changes will be stored in the database by `process_split_state`
     fn apply_split_state_changes(
-        runtime_adapter: &dyn RuntimeAdapter,
+        runtime_adapter: &dyn RuntimeWithEpochManagerAdapter,
         block_hash: &CryptoHash,
         prev_block_hash: &CryptoHash,
         apply_result: &ApplyTransactionResult,
@@ -5512,7 +5512,7 @@ pub fn collect_receipts_from_response(
 #[derive(Message)]
 #[rtype(result = "()")]
 pub struct ApplyStatePartsRequest {
-    pub runtime: Arc<dyn RuntimeAdapter>,
+    pub runtime: Arc<dyn RuntimeWithEpochManagerAdapter>,
     pub shard_id: ShardId,
     pub state_root: StateRoot,
     pub num_parts: u64,
@@ -5548,7 +5548,7 @@ pub struct BlockCatchUpResponse {
 #[derive(Message)]
 #[rtype(result = "()")]
 pub struct StateSplitRequest {
-    pub runtime: Arc<dyn RuntimeAdapter>,
+    pub runtime: Arc<dyn RuntimeWithEpochManagerAdapter>,
     pub sync_hash: CryptoHash,
     pub shard_id: ShardId,
     pub shard_uid: ShardUId,

--- a/chain/chain/src/flat_storage_creator.rs
+++ b/chain/chain/src/flat_storage_creator.rs
@@ -9,7 +9,7 @@
 //! `CatchingUp`: moves flat storage head forward, so it may reach chain final head.
 //! `Ready`: flat storage is created and it is up-to-date.
 
-use crate::{ChainStore, ChainStoreAccess, RuntimeAdapter};
+use crate::{ChainStore, ChainStoreAccess, RuntimeWithEpochManagerAdapter};
 #[cfg(feature = "protocol_feature_flat_state")]
 use assert_matches::assert_matches;
 use crossbeam_channel::{unbounded, Receiver, Sender};
@@ -64,7 +64,7 @@ pub struct FlatStorageShardCreator {
     #[allow(unused)]
     start_height: BlockHeight,
     #[allow(unused)]
-    runtime_adapter: Arc<dyn RuntimeAdapter>,
+    runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
     /// Tracks number of state parts which are not fetched yet during a single step.
     /// Stores Some(parts) if threads for fetching state were spawned and None otherwise.
     #[allow(unused)]
@@ -87,7 +87,7 @@ impl FlatStorageShardCreator {
     pub fn new(
         shard_id: ShardId,
         start_height: BlockHeight,
-        runtime_adapter: Arc<dyn RuntimeAdapter>,
+        runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
     ) -> Self {
         let (fetched_parts_sender, fetched_parts_receiver) = unbounded();
         // `itoa` is much faster for printing shard_id to a string than trivial alternatives.
@@ -411,7 +411,7 @@ impl FlatStorageCreator {
     /// or starts migration to flat storage which updates DB in background and creates flat storage afterwards.
     pub fn new(
         me: Option<&AccountId>,
-        runtime_adapter: Arc<dyn RuntimeAdapter>,
+        runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
         chain_store: &ChainStore,
         num_threads: usize,
     ) -> Result<Option<Self>, Error> {

--- a/chain/chain/src/lib.rs
+++ b/chain/chain/src/lib.rs
@@ -6,7 +6,9 @@ pub use near_chain_primitives::{self, Error};
 pub use near_primitives::receipt::ReceiptResult;
 pub use store::{ChainStore, ChainStoreAccess, ChainStoreUpdate};
 pub use store_validator::{ErrorMessage, StoreValidator};
-pub use types::{Block, BlockHeader, BlockStatus, ChainGenesis, Provenance, RuntimeAdapter};
+pub use types::{
+    Block, BlockHeader, BlockStatus, ChainGenesis, Provenance, RuntimeWithEpochManagerAdapter,
+};
 
 mod block_processing_utils;
 pub mod blocks_delay_tracker;

--- a/chain/chain/src/lightclient.rs
+++ b/chain/chain/src/lightclient.rs
@@ -5,12 +5,12 @@ use near_primitives::types::EpochId;
 use near_primitives::views::validator_stake_view::ValidatorStakeView;
 use near_primitives::views::{BlockHeaderInnerLiteView, LightClientBlockView};
 
-use crate::{ChainStoreAccess, RuntimeAdapter};
+use crate::{ChainStoreAccess, RuntimeWithEpochManagerAdapter};
 
 pub fn get_epoch_block_producers_view(
     epoch_id: &EpochId,
     prev_hash: &CryptoHash,
-    runtime_adapter: &dyn RuntimeAdapter,
+    runtime_adapter: &dyn RuntimeWithEpochManagerAdapter,
 ) -> Result<Vec<ValidatorStakeView>, Error> {
     Ok(runtime_adapter
         .get_epoch_block_producers_ordered(epoch_id, prev_hash)?

--- a/chain/chain/src/migrations.rs
+++ b/chain/chain/src/migrations.rs
@@ -1,12 +1,12 @@
 use crate::store::ChainStoreAccess;
-use crate::types::RuntimeAdapter;
+use crate::types::RuntimeWithEpochManagerAdapter;
 use near_chain_primitives::error::Error;
 use near_primitives::hash::CryptoHash;
 use near_primitives::types::ShardId;
 
 /// Check that epoch of block with given prev_block_hash is the first one with current protocol version.
 fn is_first_epoch_with_protocol_version(
-    runtime_adapter: &dyn RuntimeAdapter,
+    runtime_adapter: &dyn RuntimeWithEpochManagerAdapter,
     prev_block_hash: &CryptoHash,
 ) -> Result<bool, Error> {
     let prev_epoch_id = runtime_adapter.get_prev_epoch_id_from_prev_block(prev_block_hash)?;
@@ -20,7 +20,7 @@ fn is_first_epoch_with_protocol_version(
 /// We assume that current block contain the chunk for shard with the given id.
 pub fn check_if_block_is_first_with_chunk_of_version(
     chain_store: &dyn ChainStoreAccess,
-    runtime_adapter: &dyn RuntimeAdapter,
+    runtime_adapter: &dyn RuntimeWithEpochManagerAdapter,
     prev_block_hash: &CryptoHash,
     shard_id: ShardId,
 ) -> Result<bool, Error> {

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -45,7 +45,7 @@ use near_store::{
 
 use crate::chunks_store::ReadOnlyChunksStore;
 use crate::types::{Block, BlockHeader, LatestKnown};
-use crate::{byzantine_assert, RuntimeAdapter};
+use crate::{byzantine_assert, RuntimeWithEpochManagerAdapter};
 use near_store::db::StoreStatistics;
 use near_store::flat_state::{BlockInfo, ChainAccessForFlatStorage};
 use std::sync::Arc;
@@ -293,7 +293,7 @@ pub trait ChainStoreAccess {
     /// Get epoch id of the last block with existing chunk for the given shard id.
     fn get_epoch_id_of_last_block_with_chunk(
         &self,
-        runtime_adapter: &dyn RuntimeAdapter,
+        runtime_adapter: &dyn RuntimeWithEpochManagerAdapter,
         hash: &CryptoHash,
         shard_id: ShardId,
     ) -> Result<EpochId, Error> {
@@ -468,7 +468,7 @@ impl ChainStore {
     /// <https://github.com/near/nearcore/issues/4877>
     pub fn get_outgoing_receipts_for_shard(
         &self,
-        runtime_adapter: &dyn RuntimeAdapter,
+        runtime_adapter: &dyn RuntimeWithEpochManagerAdapter,
         prev_block_hash: CryptoHash,
         shard_id: ShardId,
         last_included_height: BlockHeight,
@@ -2021,7 +2021,7 @@ impl<'a> ChainStoreUpdate<'a> {
 
     fn get_shard_uids_to_gc(
         &mut self,
-        runtime_adapter: &dyn RuntimeAdapter,
+        runtime_adapter: &dyn RuntimeWithEpochManagerAdapter,
         block_hash: &CryptoHash,
     ) -> Vec<ShardUId> {
         let block_header = self.get_block_header(block_hash).expect("block header must exist");
@@ -2048,7 +2048,7 @@ impl<'a> ChainStoreUpdate<'a> {
     // Clearing block data of `block_hash.prev`, if on the Canonical Chain.
     pub fn clear_block_data(
         &mut self,
-        runtime_adapter: &dyn RuntimeAdapter,
+        runtime_adapter: &dyn RuntimeWithEpochManagerAdapter,
         mut block_hash: CryptoHash,
         gc_mode: GCMode,
     ) -> Result<(), Error> {
@@ -2444,7 +2444,7 @@ impl<'a> ChainStoreUpdate<'a> {
     pub fn copy_chain_state_as_of_block(
         chain_store: &'a mut ChainStore,
         block_hash: &CryptoHash,
-        source_runtime: Arc<dyn RuntimeAdapter>,
+        source_runtime: Arc<dyn RuntimeWithEpochManagerAdapter>,
         source_store: &ChainStore,
     ) -> Result<ChainStoreUpdate<'a>, Error> {
         let mut chain_store_update = ChainStoreUpdate::new(chain_store);
@@ -2992,7 +2992,7 @@ mod tests {
     use crate::store_validator::StoreValidator;
     use crate::test_utils::{KeyValueRuntime, ValidatorSchedule};
     use crate::types::ChainConfig;
-    use crate::{Chain, ChainGenesis, DoomslugThresholdMode, RuntimeAdapter};
+    use crate::{Chain, ChainGenesis, DoomslugThresholdMode, RuntimeWithEpochManagerAdapter};
 
     fn get_chain() -> Chain {
         get_chain_with_epoch_length(10)
@@ -3245,7 +3245,7 @@ mod tests {
     // Adds block to the chain at given height after prev_block.
     fn add_block(
         chain: &mut Chain,
-        runtime_adapter: Arc<dyn RuntimeAdapter>,
+        runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
         prev_block: &mut Block,
         blocks: &mut Vec<Block>,
         signer: Arc<InMemoryValidatorSigner>,

--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -24,7 +24,7 @@ use near_store::db::refcount;
 use near_store::{DBCol, Store, TrieChanges};
 use validate::StoreValidatorError;
 
-use crate::RuntimeAdapter;
+use crate::RuntimeWithEpochManagerAdapter;
 use near_primitives::shard_layout::get_block_shard_uid_rev;
 use near_primitives::time::Clock;
 
@@ -69,7 +69,7 @@ pub struct ErrorMessage {
 pub struct StoreValidator {
     me: Option<AccountId>,
     config: GenesisConfig,
-    runtime_adapter: Arc<dyn RuntimeAdapter>,
+    runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
     store: Store,
     inner: StoreValidatorCache,
     timeout: Option<u64>,
@@ -84,7 +84,7 @@ impl StoreValidator {
     pub fn new(
         me: Option<AccountId>,
         config: GenesisConfig,
-        runtime_adapter: Arc<dyn RuntimeAdapter>,
+        runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
         store: Store,
         is_archival: bool,
     ) -> Self {

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -45,8 +45,10 @@ use near_store::{
     DBCol, PartialStorage, ShardTries, Store, StoreUpdate, Trie, TrieChanges, WrappedTrieChanges,
 };
 
-use crate::types::{ApplySplitStateResult, ApplyTransactionResult, BlockHeaderInfo};
-use crate::{BlockHeader, RuntimeAdapter};
+use crate::types::{
+    ApplySplitStateResult, ApplyTransactionResult, BlockHeaderInfo, RuntimeAdapter,
+};
+use crate::{BlockHeader, RuntimeWithEpochManagerAdapter};
 
 use near_primitives::epoch_manager::ShardConfig;
 
@@ -1360,3 +1362,5 @@ impl RuntimeAdapter for KeyValueRuntime {
         Ok(HashMap::new())
     }
 }
+
+impl RuntimeWithEpochManagerAdapter for KeyValueRuntime {}

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -271,7 +271,7 @@ impl ChainGenesis {
 /// Bridge between the chain and the runtime.
 /// Main function is to update state given transactions.
 /// Additionally handles validators.
-pub trait RuntimeAdapter: EpochManagerAdapter + Send + Sync {
+pub trait RuntimeAdapter: Send + Sync {
     /// Get store and genesis state roots
     fn genesis_state(&self) -> (Store, Vec<StateRoot>);
 
@@ -580,6 +580,8 @@ pub trait RuntimeAdapter: EpochManagerAdapter + Send + Sync {
 
     fn get_protocol_config(&self, epoch_id: &EpochId) -> Result<ProtocolConfig, Error>;
 }
+
+pub trait RuntimeWithEpochManagerAdapter: RuntimeAdapter + EpochManagerAdapter {}
 
 /// The last known / checked height and time when we have processed it.
 /// Required to keep track of skipped blocks and not fallback to produce blocks at lower height.

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -95,7 +95,7 @@ use near_primitives::time::Utc;
 use rand::seq::{IteratorRandom, SliceRandom};
 use tracing::{debug, error, warn};
 
-use near_chain::{byzantine_assert, RuntimeAdapter};
+use near_chain::{byzantine_assert, RuntimeWithEpochManagerAdapter};
 use near_network::types::{NetworkRequests, PeerManagerAdapter, PeerManagerMessageRequest};
 use near_primitives::block::Tip;
 use near_primitives::hash::CryptoHash;
@@ -288,7 +288,7 @@ impl Seal<'_> {
 
 pub struct SealsManager {
     me: Option<AccountId>,
-    runtime_adapter: Arc<dyn RuntimeAdapter>,
+    runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
 
     active_demurs: HashMap<ChunkHash, ActiveSealDemur>,
     past_seals: BTreeMap<BlockHeight, HashSet<ChunkHash>>,
@@ -296,7 +296,10 @@ pub struct SealsManager {
 }
 
 impl SealsManager {
-    fn new(me: Option<AccountId>, runtime_adapter: Arc<dyn RuntimeAdapter>) -> Self {
+    fn new(
+        me: Option<AccountId>,
+        runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
+    ) -> Self {
         Self {
             me,
             runtime_adapter,
@@ -474,7 +477,7 @@ pub struct ShardsManager {
     me: Option<AccountId>,
     store: ReadOnlyChunksStore,
 
-    runtime_adapter: Arc<dyn RuntimeAdapter>,
+    runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
     peer_manager_adapter: Arc<dyn PeerManagerAdapter>,
     client_adapter: Arc<dyn ClientAdapterForShardsManager>,
     rs: ReedSolomonWrapper,
@@ -493,7 +496,7 @@ pub struct ShardsManager {
 impl ShardsManager {
     pub fn new(
         me: Option<AccountId>,
-        runtime_adapter: Arc<dyn RuntimeAdapter>,
+        runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
         network_adapter: Arc<dyn PeerManagerAdapter>,
         client_adapter: Arc<dyn ClientAdapterForShardsManager>,
         store: ReadOnlyChunksStore,

--- a/chain/chunks/src/logic.rs
+++ b/chain/chunks/src/logic.rs
@@ -1,4 +1,6 @@
-use near_chain::{validate::validate_chunk_proofs, Chain, ChainStore, RuntimeAdapter};
+use near_chain::{
+    validate::validate_chunk_proofs, Chain, ChainStore, RuntimeWithEpochManagerAdapter,
+};
 use near_chunks_primitives::Error;
 use near_primitives::{
     hash::CryptoHash,
@@ -16,7 +18,7 @@ pub fn need_receipt(
     prev_block_hash: &CryptoHash,
     shard_id: ShardId,
     me: Option<&AccountId>,
-    runtime_adapter: &dyn RuntimeAdapter,
+    runtime_adapter: &dyn RuntimeWithEpochManagerAdapter,
 ) -> bool {
     cares_about_shard_this_or_next_epoch(me, prev_block_hash, shard_id, true, runtime_adapter)
 }
@@ -26,7 +28,7 @@ pub fn need_part(
     prev_block_hash: &CryptoHash,
     part_ord: u64,
     me: Option<&AccountId>,
-    runtime_adapter: &dyn RuntimeAdapter,
+    runtime_adapter: &dyn RuntimeWithEpochManagerAdapter,
 ) -> Result<bool, Error> {
     let epoch_id = runtime_adapter.get_epoch_id_from_prev_block(prev_block_hash)?;
     Ok(Some(&runtime_adapter.get_part_owner(&epoch_id, part_ord)?) == me)
@@ -37,7 +39,7 @@ pub fn cares_about_shard_this_or_next_epoch(
     parent_hash: &CryptoHash,
     shard_id: ShardId,
     is_me: bool,
-    runtime_adapter: &dyn RuntimeAdapter,
+    runtime_adapter: &dyn RuntimeWithEpochManagerAdapter,
 ) -> bool {
     runtime_adapter.cares_about_shard(account_id, parent_hash, shard_id, is_me)
         || runtime_adapter.will_care_about_shard(account_id, parent_hash, shard_id, is_me)
@@ -48,7 +50,7 @@ pub fn cares_about_shard_this_or_next_epoch(
 pub fn make_outgoing_receipts_proofs(
     chunk_header: &ShardChunkHeader,
     outgoing_receipts: &[Receipt],
-    runtime_adapter: &dyn RuntimeAdapter,
+    runtime_adapter: &dyn RuntimeWithEpochManagerAdapter,
 ) -> Result<impl Iterator<Item = ReceiptProof>, near_chunks_primitives::Error> {
     let shard_id = chunk_header.shard_id();
     let shard_layout =
@@ -75,7 +77,7 @@ pub fn make_partial_encoded_chunk_from_owned_parts_and_needed_receipts<'a>(
     parts: impl Iterator<Item = &'a PartialEncodedChunkPart>,
     receipts: impl Iterator<Item = &'a ReceiptProof>,
     me: Option<&AccountId>,
-    runtime_adapter: &dyn RuntimeAdapter,
+    runtime_adapter: &dyn RuntimeWithEpochManagerAdapter,
 ) -> PartialEncodedChunk {
     let prev_block_hash = header.prev_block_hash();
     let cares_about_shard = cares_about_shard_this_or_next_epoch(
@@ -111,7 +113,7 @@ pub fn decode_encoded_chunk(
     encoded_chunk: &EncodedShardChunk,
     merkle_paths: Vec<MerklePath>,
     me: Option<&AccountId>,
-    runtime_adapter: &dyn RuntimeAdapter,
+    runtime_adapter: &dyn RuntimeWithEpochManagerAdapter,
 ) -> Result<(ShardChunk, PartialEncodedChunk), Error> {
     let chunk_hash = encoded_chunk.chunk_hash();
 
@@ -148,7 +150,7 @@ fn create_partial_chunk(
     merkle_paths: Vec<MerklePath>,
     outgoing_receipts: Vec<Receipt>,
     me: Option<&AccountId>,
-    runtime_adapter: &dyn RuntimeAdapter,
+    runtime_adapter: &dyn RuntimeWithEpochManagerAdapter,
 ) -> Result<PartialEncodedChunk, Error> {
     let header = encoded_chunk.cloned_header();
     let receipts =

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -25,7 +25,8 @@ use near_chain::test_utils::format_hash;
 use near_chain::types::{ChainConfig, LatestKnown};
 use near_chain::{
     BlockProcessingArtifact, BlockStatus, Chain, ChainGenesis, ChainStoreAccess,
-    DoneApplyChunkCallback, Doomslug, DoomslugThresholdMode, Provenance, RuntimeAdapter,
+    DoneApplyChunkCallback, Doomslug, DoomslugThresholdMode, Provenance,
+    RuntimeWithEpochManagerAdapter,
 };
 use near_chain_configs::{ClientConfig, UpdateableClientConfig};
 use near_chunks::ShardsManager;
@@ -100,7 +101,7 @@ pub struct Client {
     pub sync_status: SyncStatus,
     pub chain: Chain,
     pub doomslug: Doomslug,
-    pub runtime_adapter: Arc<dyn RuntimeAdapter>,
+    pub runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
     pub shards_mgr: ShardsManager,
     pub sharded_tx_pool: ShardedTransactionPool,
     prev_block_to_chunk_headers_ready_for_inclusion: LruCache<
@@ -184,7 +185,7 @@ impl Client {
     pub fn new(
         config: ClientConfig,
         chain_genesis: ChainGenesis,
-        runtime_adapter: Arc<dyn RuntimeAdapter>,
+        runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
         network_adapter: Arc<dyn PeerManagerAdapter>,
         client_adapter: Arc<dyn ClientAdapterForShardsManager>,
         validator_signer: Option<Arc<dyn ValidatorSigner>>,
@@ -1689,7 +1690,10 @@ impl Client {
         error: near_chain::Error,
     ) {
         let is_validator =
-            |epoch_id, block_hash, account_id, runtime_adapter: &Arc<dyn RuntimeAdapter>| {
+            |epoch_id,
+             block_hash,
+             account_id,
+             runtime_adapter: &Arc<dyn RuntimeWithEpochManagerAdapter>| {
                 match runtime_adapter.get_validator_by_account_id(epoch_id, block_hash, account_id)
                 {
                     Ok((_, is_slashed)) => !is_slashed,
@@ -2327,7 +2331,7 @@ impl Client {
             // are cheaper than block processing (and that they will work with both this and
             // the next epoch). The caching on top of that (in tier1_accounts_cache field) is just
             // a defence in depth, based on the previous experience with expensive
-            // RuntimeAdapter::get_validators_info call.
+            // RuntimeWithEpochManagerAdapter::get_validators_info call.
             for cp in self.runtime_adapter.get_epoch_chunk_producers(epoch_id)? {
                 account_keys
                     .entry(cp.account_id().clone())

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -31,7 +31,7 @@ use near_chain::test_utils::format_hash;
 use near_chain::ChainStoreAccess;
 use near_chain::{
     byzantine_assert, near_chain_primitives, Block, BlockHeader, BlockProcessingArtifact,
-    ChainGenesis, DoneApplyChunkCallback, Provenance, RuntimeAdapter,
+    ChainGenesis, DoneApplyChunkCallback, Provenance, RuntimeWithEpochManagerAdapter,
 };
 use near_chain_configs::ClientConfig;
 use near_chunks::client::ShardsManagerResponse;
@@ -148,7 +148,7 @@ impl ClientActor {
         address: Addr<ClientActor>,
         config: ClientConfig,
         chain_genesis: ChainGenesis,
-        runtime_adapter: Arc<dyn RuntimeAdapter>,
+        runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
         node_id: PeerId,
         network_adapter: Arc<dyn PeerManagerAdapter>,
         validator_signer: Option<Arc<dyn ValidatorSigner>>,
@@ -1997,7 +1997,7 @@ pub fn random_seed_from_thread() -> RngSeed {
 pub fn start_client(
     client_config: ClientConfig,
     chain_genesis: ChainGenesis,
-    runtime_adapter: Arc<dyn RuntimeAdapter>,
+    runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
     node_id: PeerId,
     network_adapter: Arc<dyn PeerManagerAdapter>,
     validator_signer: Option<Arc<dyn ValidatorSigner>>,

--- a/chain/client/src/debug.rs
+++ b/chain/client/src/debug.rs
@@ -5,7 +5,7 @@ use actix::{Context, Handler};
 use borsh::BorshSerialize;
 use itertools::Itertools;
 use near_chain::crypto_hash_timer::CryptoHashTimer;
-use near_chain::{near_chain_primitives, Chain, ChainStoreAccess, RuntimeAdapter};
+use near_chain::{near_chain_primitives, Chain, ChainStoreAccess, RuntimeWithEpochManagerAdapter};
 use near_client_primitives::debug::{
     ApprovalAtHeightStatus, BlockProduction, ChunkCollection, DebugBlockStatusData, DebugStatus,
     DebugStatusResponse, MissedHeightInfo, ProductionAtHeight, ValidatorStatus,
@@ -119,7 +119,7 @@ impl BlockProductionTracker {
         epoch_id: &EpochId,
         num_shards: ShardId,
         new_chunks: &HashMap<ShardId, (ShardChunkHeader, chrono::DateTime<chrono::Utc>, AccountId)>,
-        runtime_adapter: &dyn RuntimeAdapter,
+        runtime_adapter: &dyn RuntimeWithEpochManagerAdapter,
     ) -> Result<Vec<ChunkCollection>, Error> {
         let mut chunk_collection_info = vec![];
         for shard_id in 0..num_shards {

--- a/chain/client/src/sync/state.rs
+++ b/chain/client/src/sync/state.rs
@@ -35,7 +35,7 @@ use rand::seq::SliceRandom;
 use rand::{thread_rng, Rng};
 use tracing::{debug, error, info, warn};
 
-use near_chain::{Chain, RuntimeAdapter};
+use near_chain::{Chain, RuntimeWithEpochManagerAdapter};
 use near_network::types::{
     HighestHeightPeerInfo, NetworkRequests, NetworkResponses, PeerManagerAdapter,
 };
@@ -170,7 +170,7 @@ impl StateSync {
         sync_hash: CryptoHash,
         new_shard_sync: &mut HashMap<u64, ShardSyncDownload>,
         chain: &mut Chain,
-        runtime_adapter: &Arc<dyn RuntimeAdapter>,
+        runtime_adapter: &Arc<dyn RuntimeWithEpochManagerAdapter>,
         highest_height_peers: &[HighestHeightPeerInfo],
         tracking_shards: Vec<ShardId>,
         now: DateTime<Utc>,
@@ -517,7 +517,7 @@ impl StateSync {
         me: &Option<AccountId>,
         shard_id: ShardId,
         chain: &Chain,
-        runtime_adapter: &Arc<dyn RuntimeAdapter>,
+        runtime_adapter: &Arc<dyn RuntimeWithEpochManagerAdapter>,
         sync_hash: CryptoHash,
         highest_height_peers: &[HighestHeightPeerInfo],
     ) -> Result<Vec<AccountOrPeerIdOrHash>, Error> {
@@ -572,7 +572,7 @@ impl StateSync {
         me: &Option<AccountId>,
         shard_id: ShardId,
         chain: &Chain,
-        runtime_adapter: &Arc<dyn RuntimeAdapter>,
+        runtime_adapter: &Arc<dyn RuntimeWithEpochManagerAdapter>,
         sync_hash: CryptoHash,
         shard_sync_download: ShardSyncDownload,
         highest_height_peers: &[HighestHeightPeerInfo],
@@ -693,7 +693,7 @@ impl StateSync {
         sync_hash: CryptoHash,
         new_shard_sync: &mut HashMap<u64, ShardSyncDownload>,
         chain: &mut Chain,
-        runtime_adapter: &Arc<dyn RuntimeAdapter>,
+        runtime_adapter: &Arc<dyn RuntimeWithEpochManagerAdapter>,
         highest_height_peers: &[HighestHeightPeerInfo],
         // Shards to sync.
         tracking_shards: Vec<ShardId>,
@@ -941,7 +941,7 @@ mod test {
                     *request_hash,
                     &mut new_shard_sync,
                     &mut chain,
-                    &(kv as Arc<dyn RuntimeAdapter>),
+                    &(kv as Arc<dyn RuntimeWithEpochManagerAdapter>),
                     &[],
                     vec![0],
                     &apply_parts_fn,

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -22,7 +22,8 @@ use near_chain::test_utils::{
 };
 use near_chain::types::ChainConfig;
 use near_chain::{
-    Chain, ChainGenesis, ChainStoreAccess, DoomslugThresholdMode, Provenance, RuntimeAdapter,
+    Chain, ChainGenesis, ChainStoreAccess, DoomslugThresholdMode, Provenance,
+    RuntimeWithEpochManagerAdapter,
 };
 use near_chain_configs::ClientConfig;
 use near_chunks::client::{ClientAdapterForShardsManager, ShardsManagerResponse};
@@ -1091,7 +1092,7 @@ pub fn setup_client_with_runtime(
     network_adapter: Arc<dyn PeerManagerAdapter>,
     client_adapter: Arc<dyn ClientAdapterForShardsManager>,
     chain_genesis: ChainGenesis,
-    runtime_adapter: Arc<dyn RuntimeAdapter>,
+    runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
     rng_seed: RngSeed,
     archive: bool,
     save_trie_changes: bool,
@@ -1167,7 +1168,7 @@ pub struct TestEnvBuilder {
     chain_genesis: ChainGenesis,
     clients: Vec<AccountId>,
     validators: Vec<AccountId>,
-    runtime_adapters: Option<Vec<Arc<dyn RuntimeAdapter>>>,
+    runtime_adapters: Option<Vec<Arc<dyn RuntimeWithEpochManagerAdapter>>>,
     network_adapters: Option<Vec<Arc<MockPeerManagerAdapter>>>,
     // random seed to be inject in each client according to AccountId
     // if not set, a default constant TEST_SEED will be injected
@@ -1239,7 +1240,10 @@ impl TestEnvBuilder {
     /// The vector must have the same number of elements as they are clients
     /// (one by default).  If that does not hold, [`Self::build`] method will
     /// panic.
-    pub fn runtime_adapters(mut self, adapters: Vec<Arc<dyn RuntimeAdapter>>) -> Self {
+    pub fn runtime_adapters(
+        mut self,
+        adapters: Vec<Arc<dyn RuntimeWithEpochManagerAdapter>>,
+    ) -> Self {
         self.runtime_adapters = Some(adapters);
         self
     }

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -14,7 +14,7 @@ use tracing::{debug, error, info, trace, warn};
 
 use near_chain::{
     get_epoch_block_producers_view, Chain, ChainGenesis, ChainStoreAccess, DoomslugThresholdMode,
-    RuntimeAdapter,
+    RuntimeWithEpochManagerAdapter,
 };
 use near_chain_configs::{ClientConfig, ProtocolConfigView};
 use near_client_primitives::types::{
@@ -93,7 +93,7 @@ pub struct ViewClientActor {
     /// Validator account (if present).
     validator_account_id: Option<AccountId>,
     chain: Chain,
-    runtime_adapter: Arc<dyn RuntimeAdapter>,
+    runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
     network_adapter: Arc<dyn PeerManagerAdapter>,
     pub config: ClientConfig,
     request_manager: Arc<RwLock<ViewClientRequestManager>>,
@@ -119,7 +119,7 @@ impl ViewClientActor {
     pub fn new(
         validator_account_id: Option<AccountId>,
         chain_genesis: &ChainGenesis,
-        runtime_adapter: Arc<dyn RuntimeAdapter>,
+        runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
         network_adapter: Arc<dyn PeerManagerAdapter>,
         config: ClientConfig,
         request_manager: Arc<RwLock<ViewClientRequestManager>>,
@@ -1426,7 +1426,7 @@ impl Handler<WithSpanContext<GetMaintenanceWindows>> for ViewClientActor {
 pub fn start_view_client(
     validator_account_id: Option<AccountId>,
     chain_genesis: ChainGenesis,
-    runtime_adapter: Arc<dyn RuntimeAdapter>,
+    runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
     network_adapter: Arc<dyn PeerManagerAdapter>,
     config: ClientConfig,
     adv: crate::adversarial::Controls,

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -24,7 +24,7 @@ use std::sync::{Arc, RwLockReadGuard, RwLockWriteGuard};
 /// A trait that abstracts the interface of the EpochManager.
 ///
 /// It is intended to be an intermediate state in a refactor: we want to remove
-/// epoch manager stuff from RuntimeAdapter's interface, and, as a first step,
+/// epoch manager stuff from RuntimeWithEpochManagerAdapter's interface, and, as a first step,
 /// we move it to a new trait. The end goal is for the code to use the concrete
 /// epoch manager type directly. Though, we might want to still keep this trait
 /// in, to allow for easy overriding of epoch manager in tests.
@@ -348,7 +348,7 @@ pub trait EpochManagerAdapter: Send + Sync {
 /// A technical plumbing trait to conveniently implement [`EpochManagerAdapter`]
 /// for `NightshadeRuntime` without too much copy-paste.
 ///
-/// Once we remove `RuntimeAdapter: EpochManagerAdapter` bound, we could get rid
+/// Once we remove `RuntimeWithEpochManagerAdapter: EpochManagerAdapter` bound, we could get rid
 /// of this trait and instead add inherent methods directly to
 /// `EpochManagerHandle`.
 pub trait HasEpochMangerHandle {

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -141,7 +141,7 @@ This crate contains most of the chain logic (consensus, block processing, etc).
 happens.
 
 **Architecture Invariant**: interface between chain and runtime is defined by
-`RuntimeAdapter`. All invocations of runtime go through `RuntimeAdapter`
+`RuntimeWithEpochManagerAdapter`. All invocations of runtime go through `RuntimeWithEpochManagerAdapter`
 
 **State update**
 
@@ -244,8 +244,8 @@ contracts on NEAR.
 
 As mentioned before, `neard` is the crate that contains that main entry points.
 All the actors are spawned in `start_with_config`. It is also worth noting that
-`NightshadeRuntime` is the struct that implements `RuntimeAdapter`.
-<!-- TODO: Maybe add RuntimeAdapter mention or explanation in runtime/runtime chapter? -->
+`NightshadeRuntime` is the struct that implements `RuntimeWithEpochManagerAdapter`.
+<!-- TODO: Maybe add RuntimeWithEpochManagerAdapter mention or explanation in runtime/runtime chapter? -->
 
 ### `core/store/src/db.rs`
 

--- a/docs/practices/testing/README.md
+++ b/docs/practices/testing/README.md
@@ -59,7 +59,7 @@ available to test them.
 
 ## Client
 
-Client is separated from the runtime via a `RuntimeAdapter` trait. In production
+Client is separated from the runtime via a `RuntimeWithEpochManagerAdapter` trait. In production
 it uses `NightshadeRuntime` that uses real runtime and epoch managers. To test
 client without instantiating runtime and epoch manager, we have a mock runtime
 `KeyValueRuntime`.

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -4,8 +4,8 @@ pub mod state_dump;
 
 use crate::state_dump::StateDump;
 use indicatif::{ProgressBar, ProgressStyle};
-use near_chain::types::BlockHeaderInfo;
-use near_chain::{Block, Chain, ChainStore, RuntimeAdapter};
+use near_chain::types::{BlockHeaderInfo, RuntimeAdapter};
+use near_chain::{Block, Chain, ChainStore};
 use near_chain_configs::Genesis;
 use near_crypto::{InMemorySigner, KeyType};
 use near_primitives::account::{AccessKey, Account};

--- a/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
+++ b/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
@@ -3,7 +3,7 @@ use crate::tests::client::process_blocks::{
 };
 use assert_matches::assert_matches;
 use near_chain::chain::NUM_ORPHAN_ANCESTORS_CHECK;
-use near_chain::{ChainGenesis, Error, Provenance, RuntimeAdapter};
+use near_chain::{ChainGenesis, Error, Provenance, RuntimeWithEpochManagerAdapter};
 use near_chain_configs::Genesis;
 use near_client::test_utils::{create_chunk_with_transactions, TestEnv};
 use near_client::ProcessTxResponse;
@@ -317,7 +317,7 @@ fn test_request_chunks_for_orphan() {
     genesis.config.num_block_producer_seats_per_shard =
         vec![num_validators, num_validators, num_validators, num_validators];
     let chain_genesis = ChainGenesis::new(&genesis);
-    let runtimes: Vec<Arc<dyn RuntimeAdapter>> = (0..2)
+    let runtimes: Vec<Arc<dyn RuntimeWithEpochManagerAdapter>> = (0..2)
         .map(|_| {
             Arc::new(nearcore::NightshadeRuntime::test_with_runtime_config_store(
                 Path::new("."),
@@ -325,7 +325,7 @@ fn test_request_chunks_for_orphan() {
                 &genesis,
                 TrackedConfig::AllShards,
                 RuntimeConfigStore::test(),
-            )) as Arc<dyn RuntimeAdapter>
+            )) as Arc<dyn RuntimeWithEpochManagerAdapter>
         })
         .collect();
     let mut env = TestEnv::builder(chain_genesis)
@@ -464,7 +464,7 @@ fn test_processing_chunks_sanity() {
     genesis.config.num_block_producer_seats_per_shard =
         vec![num_validators, num_validators, num_validators, num_validators];
     let chain_genesis = ChainGenesis::new(&genesis);
-    let runtimes: Vec<Arc<dyn RuntimeAdapter>> = (0..2)
+    let runtimes: Vec<Arc<dyn RuntimeWithEpochManagerAdapter>> = (0..2)
         .map(|_| {
             Arc::new(nearcore::NightshadeRuntime::test_with_runtime_config_store(
                 Path::new("."),
@@ -472,7 +472,7 @@ fn test_processing_chunks_sanity() {
                 &genesis,
                 TrackedConfig::AllShards,
                 RuntimeConfigStore::test(),
-            )) as Arc<dyn RuntimeAdapter>
+            )) as Arc<dyn RuntimeWithEpochManagerAdapter>
         })
         .collect();
     let mut env = TestEnv::builder(chain_genesis)
@@ -574,7 +574,7 @@ impl ChunkForwardingOptimizationTestData {
             config.num_block_producer_seats = num_block_producers as u64;
         }
         let chain_genesis = ChainGenesis::new(&genesis);
-        let runtimes: Vec<Arc<dyn RuntimeAdapter>> = (0..num_clients)
+        let runtimes: Vec<Arc<dyn RuntimeWithEpochManagerAdapter>> = (0..num_clients)
             .map(|_| {
                 Arc::new(nearcore::NightshadeRuntime::test_with_runtime_config_store(
                     Path::new("."),
@@ -582,7 +582,7 @@ impl ChunkForwardingOptimizationTestData {
                     &genesis,
                     TrackedConfig::AllShards,
                     RuntimeConfigStore::test(),
-                )) as Arc<dyn RuntimeAdapter>
+                )) as Arc<dyn RuntimeWithEpochManagerAdapter>
             })
             .collect();
         let env = TestEnv::builder(chain_genesis)
@@ -813,7 +813,7 @@ fn test_processing_blocks_async() {
     genesis.config.num_block_producer_seats_per_shard =
         vec![num_validators, num_validators, num_validators, num_validators];
     let chain_genesis = ChainGenesis::new(&genesis);
-    let runtimes: Vec<Arc<dyn RuntimeAdapter>> = (0..2)
+    let runtimes: Vec<Arc<dyn RuntimeWithEpochManagerAdapter>> = (0..2)
         .map(|_| {
             Arc::new(nearcore::NightshadeRuntime::test_with_runtime_config_store(
                 Path::new("."),
@@ -821,7 +821,7 @@ fn test_processing_blocks_async() {
                 &genesis,
                 TrackedConfig::AllShards,
                 RuntimeConfigStore::test(),
-            )) as Arc<dyn RuntimeAdapter>
+            )) as Arc<dyn RuntimeWithEpochManagerAdapter>
         })
         .collect();
     let mut env = TestEnv::builder(chain_genesis)

--- a/integration-tests/src/tests/client/features/account_id_in_function_call_permission.rs
+++ b/integration-tests/src/tests/client/features/account_id_in_function_call_permission.rs
@@ -1,4 +1,4 @@
-use near_chain::{ChainGenesis, RuntimeAdapter};
+use near_chain::{ChainGenesis, RuntimeWithEpochManagerAdapter};
 use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
 use near_client::ProcessTxResponse;
@@ -39,7 +39,7 @@ fn test_account_id_in_function_call_permission_upgrade() {
                     TrackedConfig::new_empty(),
                     RuntimeConfigStore::new(None),
                 ),
-            ) as Arc<dyn RuntimeAdapter>])
+            ) as Arc<dyn RuntimeWithEpochManagerAdapter>])
             .build()
     };
 
@@ -106,7 +106,7 @@ fn test_very_long_account_id() {
                     TrackedConfig::new_empty(),
                     RuntimeConfigStore::new(None),
                 ),
-            ) as Arc<dyn RuntimeAdapter>])
+            ) as Arc<dyn RuntimeWithEpochManagerAdapter>])
             .build()
     };
 

--- a/integration-tests/src/tests/client/features/adversarial_behaviors.rs
+++ b/integration-tests/src/tests/client/features/adversarial_behaviors.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, path::Path, sync::Arc};
 
-use near_chain::{ChainGenesis, Provenance, RuntimeAdapter};
+use near_chain::{ChainGenesis, Provenance, RuntimeWithEpochManagerAdapter};
 use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
 use near_network::types::{NetworkRequests, PeerManagerMessageRequest};
@@ -48,7 +48,7 @@ impl AdversarialBehaviorTestData {
             config.chunk_producer_kickout_threshold = 50;
         }
         let chain_genesis = ChainGenesis::new(&genesis);
-        let runtimes: Vec<Arc<dyn RuntimeAdapter>> = (0..num_clients)
+        let runtimes: Vec<Arc<dyn RuntimeWithEpochManagerAdapter>> = (0..num_clients)
             .map(|_| {
                 Arc::new(nearcore::NightshadeRuntime::test_with_runtime_config_store(
                     Path::new("."),
@@ -56,7 +56,7 @@ impl AdversarialBehaviorTestData {
                     &genesis,
                     TrackedConfig::AllShards,
                     RuntimeConfigStore::test(),
-                )) as Arc<dyn RuntimeAdapter>
+                )) as Arc<dyn RuntimeWithEpochManagerAdapter>
             })
             .collect();
         let env = TestEnv::builder(chain_genesis)

--- a/integration-tests/src/tests/client/features/chunk_nodes_cache.rs
+++ b/integration-tests/src/tests/client/features/chunk_nodes_cache.rs
@@ -1,6 +1,6 @@
 use crate::tests::client::process_blocks::{deploy_test_contract, set_block_protocol_version};
 use assert_matches::assert_matches;
-use near_chain::{ChainGenesis, Provenance, RuntimeAdapter};
+use near_chain::{ChainGenesis, Provenance, RuntimeWithEpochManagerAdapter};
 use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
 use near_crypto::{InMemorySigner, KeyType, Signer};
@@ -93,7 +93,7 @@ fn compare_node_counts() {
     genesis.config.epoch_length = epoch_length;
     genesis.config.protocol_version = old_protocol_version;
     let chain_genesis = ChainGenesis::new(&genesis);
-    let runtimes: Vec<Arc<dyn RuntimeAdapter>> =
+    let runtimes: Vec<Arc<dyn RuntimeWithEpochManagerAdapter>> =
         vec![Arc::new(nearcore::NightshadeRuntime::test_with_runtime_config_store(
             Path::new("../../../.."),
             create_test_store(),

--- a/integration-tests/src/tests/client/features/increase_deployment_cost.rs
+++ b/integration-tests/src/tests/client/features/increase_deployment_cost.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use near_chain::{ChainGenesis, RuntimeAdapter};
+use near_chain::{ChainGenesis, RuntimeWithEpochManagerAdapter};
 use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
 use near_crypto::{InMemorySigner, KeyType};
@@ -32,7 +32,7 @@ fn test_deploy_cost_increased() {
         genesis.config.epoch_length = epoch_length;
         genesis.config.protocol_version = old_protocol_version;
         let chain_genesis = ChainGenesis::new(&genesis);
-        let runtimes: Vec<Arc<dyn RuntimeAdapter>> =
+        let runtimes: Vec<Arc<dyn RuntimeWithEpochManagerAdapter>> =
             vec![Arc::new(nearcore::NightshadeRuntime::test_with_runtime_config_store(
                 Path::new("../../../.."),
                 create_test_store(),

--- a/integration-tests/src/tests/client/features/limit_contract_functions_number.rs
+++ b/integration-tests/src/tests/client/features/limit_contract_functions_number.rs
@@ -1,6 +1,6 @@
 use crate::tests::client::process_blocks::deploy_test_contract;
 use assert_matches::assert_matches;
-use near_chain::{ChainGenesis, RuntimeAdapter};
+use near_chain::{ChainGenesis, RuntimeWithEpochManagerAdapter};
 use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
 use near_primitives::errors::{ActionErrorKind, TxExecutionError};
@@ -31,7 +31,7 @@ fn verify_contract_limits_upgrade(
         genesis.config.epoch_length = epoch_length;
         genesis.config.protocol_version = old_protocol_version;
         let chain_genesis = ChainGenesis::new(&genesis);
-        let runtimes: Vec<Arc<dyn RuntimeAdapter>> =
+        let runtimes: Vec<Arc<dyn RuntimeWithEpochManagerAdapter>> =
             vec![Arc::new(nearcore::NightshadeRuntime::test_with_runtime_config_store(
                 Path::new("../../../.."),
                 create_test_store(),

--- a/integration-tests/src/tests/client/features/lower_storage_key_limit.rs
+++ b/integration-tests/src/tests/client/features/lower_storage_key_limit.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use near_chain::{ChainGenesis, Provenance, RuntimeAdapter};
+use near_chain::{ChainGenesis, Provenance, RuntimeWithEpochManagerAdapter};
 use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
 use near_crypto::{InMemorySigner, KeyType, Signer};
@@ -42,14 +42,14 @@ fn protocol_upgrade() {
         genesis.config.epoch_length = epoch_length;
         genesis.config.protocol_version = old_protocol_version;
         let chain_genesis = ChainGenesis::new(&genesis);
-        let runtimes: Vec<Arc<dyn RuntimeAdapter>> =
+        let runtimes: Vec<Arc<dyn RuntimeWithEpochManagerAdapter>> =
             vec![Arc::new(nearcore::NightshadeRuntime::test_with_runtime_config_store(
                 Path::new("."),
                 create_test_store(),
                 &genesis,
                 TrackedConfig::AllShards,
                 RuntimeConfigStore::new(None),
-            )) as Arc<dyn RuntimeAdapter>];
+            )) as Arc<dyn RuntimeWithEpochManagerAdapter>];
         let mut env = TestEnv::builder(chain_genesis).runtime_adapters(runtimes).build();
 
         deploy_test_contract_with_protocol_version(

--- a/integration-tests/src/tests/client/features/restore_receipts_after_fix_apply_chunks.rs
+++ b/integration-tests/src/tests/client/features/restore_receipts_after_fix_apply_chunks.rs
@@ -1,5 +1,5 @@
 use crate::tests::client::process_blocks::set_block_protocol_version;
-use near_chain::{ChainGenesis, Provenance, RuntimeAdapter};
+use near_chain::{ChainGenesis, Provenance, RuntimeWithEpochManagerAdapter};
 use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
 use near_o11y::testonly::init_test_logger;
@@ -38,7 +38,7 @@ fn run_test(
     let migration_data = load_migration_data(&genesis.config.chain_id);
 
     let mut env = TestEnv::builder(chain_genesis)
-        .runtime_adapters(vec![Arc::new(runtime) as Arc<dyn RuntimeAdapter>])
+        .runtime_adapters(vec![Arc::new(runtime) as Arc<dyn RuntimeWithEpochManagerAdapter>])
         .build();
 
     let get_restored_receipt_hashes = |migration_data: &MigrationData| -> HashSet<CryptoHash> {

--- a/integration-tests/src/tests/client/flat_storage.rs
+++ b/integration-tests/src/tests/client/flat_storage.rs
@@ -1,6 +1,6 @@
 /// Tests which check correctness of background flat storage creation.
 use assert_matches::assert_matches;
-use near_chain::{ChainGenesis, RuntimeAdapter};
+use near_chain::{ChainGenesis, RuntimeWithEpochManagerAdapter};
 use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
 use near_o11y::testonly::init_test_logger;
@@ -30,7 +30,7 @@ const CREATION_TIMEOUT: BlockHeight = 30;
 /// Setup environment with one Near client for testing.
 fn setup_env(genesis: &Genesis, store: Store) -> TestEnv {
     let chain_genesis = ChainGenesis::new(genesis);
-    let runtimes: Vec<Arc<dyn RuntimeAdapter>> =
+    let runtimes: Vec<Arc<dyn RuntimeWithEpochManagerAdapter>> =
         vec![Arc::new(nearcore::NightshadeRuntime::test(Path::new("../../../.."), store, genesis))];
     TestEnv::builder(chain_genesis.clone()).runtime_adapters(runtimes).build()
 }

--- a/integration-tests/src/tests/client/runtimes.rs
+++ b/integration-tests/src/tests/client/runtimes.rs
@@ -2,7 +2,7 @@
 //! This client works completely synchronously and must be operated by some async actor outside.
 
 use assert_matches::assert_matches;
-use near_chain::{ChainGenesis, RuntimeAdapter};
+use near_chain::{ChainGenesis, RuntimeWithEpochManagerAdapter};
 use near_chain_configs::Genesis;
 use near_chunks::test_utils::ChunkTestFixture;
 use near_chunks::ProcessPartialEncodedChunkResult;
@@ -25,19 +25,22 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
-pub fn create_nightshade_runtimes(genesis: &Genesis, n: usize) -> Vec<Arc<dyn RuntimeAdapter>> {
+pub fn create_nightshade_runtimes(
+    genesis: &Genesis,
+    n: usize,
+) -> Vec<Arc<dyn RuntimeWithEpochManagerAdapter>> {
     (0..n)
         .map(|_| {
             Arc::new(nearcore::NightshadeRuntime::test(
                 Path::new("../../../.."),
                 create_test_store(),
                 genesis,
-            )) as Arc<dyn RuntimeAdapter>
+            )) as Arc<dyn RuntimeWithEpochManagerAdapter>
         })
         .collect()
 }
 
-fn create_runtimes(n: usize) -> Vec<Arc<dyn RuntimeAdapter>> {
+fn create_runtimes(n: usize) -> Vec<Arc<dyn RuntimeWithEpochManagerAdapter>> {
     let genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     create_nightshade_runtimes(&genesis, n)
 }

--- a/integration-tests/src/tests/client/sandbox.rs
+++ b/integration-tests/src/tests/client/sandbox.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use near_chain::{ChainGenesis, Provenance, RuntimeAdapter};
+use near_chain::{ChainGenesis, Provenance, RuntimeWithEpochManagerAdapter};
 use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
 use near_crypto::{InMemorySigner, KeyType};
@@ -24,7 +24,7 @@ fn test_setup() -> (TestEnv, InMemorySigner) {
             Path::new("../../../.."),
             create_test_store(),
             &genesis,
-        )) as Arc<dyn RuntimeAdapter>])
+        )) as Arc<dyn RuntimeWithEpochManagerAdapter>])
         .build();
     let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
     send_tx(

--- a/nearcore/benches/store.rs
+++ b/nearcore/benches/store.rs
@@ -2,7 +2,7 @@
 extern crate bencher;
 
 use bencher::Bencher;
-use near_chain::{ChainStore, ChainStoreAccess, RuntimeAdapter};
+use near_chain::{types::RuntimeAdapter, ChainStore, ChainStoreAccess};
 use near_chain_configs::GenesisValidationMode;
 use near_o11y::testonly::init_integration_logger;
 use near_primitives::types::StateRoot;

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -5,8 +5,10 @@ use crate::NearConfig;
 use borsh::ser::BorshSerialize;
 use borsh::BorshDeserialize;
 use errors::FromStateViewerErrors;
-use near_chain::types::{ApplySplitStateResult, ApplyTransactionResult, BlockHeaderInfo, Tip};
-use near_chain::{Error, RuntimeAdapter};
+use near_chain::types::{
+    ApplySplitStateResult, ApplyTransactionResult, BlockHeaderInfo, RuntimeAdapter, Tip,
+};
+use near_chain::{Error, RuntimeWithEpochManagerAdapter};
 use near_chain_configs::{
     Genesis, GenesisConfig, ProtocolConfig, DEFAULT_GC_NUM_EPOCHS_TO_KEEP,
     MIN_GC_NUM_EPOCHS_TO_KEEP,
@@ -1456,6 +1458,8 @@ impl RuntimeAdapter for NightshadeRuntime {
         Ok(epoch_manager.will_shard_layout_change(parent_hash)?)
     }
 }
+
+impl RuntimeWithEpochManagerAdapter for NightshadeRuntime {}
 
 impl node_runtime::adapter::ViewRuntimeAdapter for NightshadeRuntime {
     fn view_account(

--- a/nearcore/tests/economics.rs
+++ b/nearcore/tests/economics.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use num_rational::Ratio;
 
-use near_chain::{ChainGenesis, RuntimeAdapter};
+use near_chain::{ChainGenesis, RuntimeWithEpochManagerAdapter};
 use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
 use near_crypto::{InMemorySigner, KeyType};
@@ -37,7 +37,7 @@ fn setup_env(genesis: &Genesis) -> TestEnv {
             Path::new("."),
             store1,
             genesis,
-        )) as Arc<dyn RuntimeAdapter>])
+        )) as Arc<dyn RuntimeWithEpochManagerAdapter>])
         .build()
 }
 

--- a/test-utils/store-validator/src/main.rs
+++ b/test-utils/store-validator/src/main.rs
@@ -6,7 +6,7 @@ use ansi_term::Color::{Green, Red, White, Yellow};
 use clap::{Arg, Command};
 
 use near_chain::store_validator::StoreValidator;
-use near_chain::RuntimeAdapter;
+use near_chain::RuntimeWithEpochManagerAdapter;
 use near_chain_configs::GenesisValidationMode;
 use near_o11y::testonly::init_integration_logger;
 use nearcore::{get_default_home, load_config};
@@ -34,7 +34,7 @@ fn main() {
         .open()
         .unwrap()
         .get_store(near_store::Temperature::Hot);
-    let runtime_adapter: Arc<dyn RuntimeAdapter> =
+    let runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter> =
         Arc::new(nearcore::NightshadeRuntime::from_config(home_dir, store.clone(), &near_config));
 
     let mut store_validator = StoreValidator::new(

--- a/tools/mirror/src/offline.rs
+++ b/tools/mirror/src/offline.rs
@@ -1,7 +1,8 @@
 use crate::{ChainError, SourceBlock};
 use anyhow::Context;
 use async_trait::async_trait;
-use near_chain::{ChainStore, ChainStoreAccess, RuntimeAdapter};
+use near_chain::types::RuntimeAdapter;
+use near_chain::{ChainStore, ChainStoreAccess};
 use near_chain_configs::GenesisValidationMode;
 use near_crypto::PublicKey;
 use near_epoch_manager::EpochManagerAdapter;

--- a/tools/mock-node/src/lib.rs
+++ b/tools/mock-node/src/lib.rs
@@ -525,7 +525,7 @@ impl ChainHistoryAccess {
 mod test {
     use crate::ChainHistoryAccess;
     use near_chain::ChainGenesis;
-    use near_chain::{Chain, RuntimeAdapter};
+    use near_chain::{Chain, RuntimeWithEpochManagerAdapter};
     use near_chain_configs::Genesis;
     use near_client::test_utils::TestEnv;
     use near_network::types::PartialEncodedChunkRequestMsg;
@@ -544,7 +544,7 @@ mod test {
             Path::new("../../../.."),
             create_test_store(),
             &genesis,
-        )) as Arc<dyn RuntimeAdapter>];
+        )) as Arc<dyn RuntimeWithEpochManagerAdapter>];
         let mut env = TestEnv::builder(chain_genesis.clone())
             .validator_seats(1)
             .runtime_adapters(runtimes.clone())

--- a/tools/mock-node/src/setup.rs
+++ b/tools/mock-node/src/setup.rs
@@ -3,10 +3,9 @@
 use crate::{MockNetworkConfig, MockPeerManagerActor};
 use actix::{Actor, Addr, Arbiter};
 use anyhow::Context;
+use near_chain::types::RuntimeAdapter;
 use near_chain::ChainStoreUpdate;
-use near_chain::{
-    Chain, ChainGenesis, ChainStore, ChainStoreAccess, DoomslugThresholdMode, RuntimeAdapter,
-};
+use near_chain::{Chain, ChainGenesis, ChainStore, ChainStoreAccess, DoomslugThresholdMode};
 use near_chain_configs::GenesisConfig;
 use near_client::{start_client, start_view_client, ClientActor, ViewClientActor};
 use near_epoch_manager::{EpochManager, EpochManagerAdapter};

--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -8,7 +8,7 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use near_chain::chain::collect_receipts_from_response;
 use near_chain::migrations::check_if_block_is_first_with_chunk_of_version;
 use near_chain::types::ApplyTransactionResult;
-use near_chain::{ChainStore, ChainStoreAccess, ChainStoreUpdate, RuntimeAdapter};
+use near_chain::{ChainStore, ChainStoreAccess, ChainStoreUpdate, RuntimeWithEpochManagerAdapter};
 use near_chain_configs::Genesis;
 use near_primitives::borsh::maybestd::sync::Arc;
 use near_primitives::hash::CryptoHash;
@@ -115,7 +115,7 @@ fn apply_block_from_range(
     shard_id: ShardId,
     store: Store,
     genesis: &Genesis,
-    runtime_adapter: Arc<dyn RuntimeAdapter>,
+    runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
     progress_reporter: &ProgressReporter,
     verbose_output: bool,
     csv_file_mutex: &Mutex<Option<&mut File>>,
@@ -351,7 +351,7 @@ pub fn apply_chain_range(
         only_contracts,
         sequential)
     .entered();
-    let runtime_adapter: Arc<dyn RuntimeAdapter> = Arc::new(runtime);
+    let runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter> = Arc::new(runtime);
     let chain_store = ChainStore::new(store.clone(), genesis.config.genesis_height, false);
     let end_height = end_height.unwrap_or_else(|| chain_store.head().unwrap().height);
     let start_height = start_height.unwrap_or_else(|| chain_store.tail().unwrap());

--- a/tools/state-viewer/src/apply_chunk.rs
+++ b/tools/state-viewer/src/apply_chunk.rs
@@ -3,7 +3,7 @@ use borsh::BorshDeserialize;
 use near_chain::chain::collect_receipts_from_response;
 use near_chain::migrations::check_if_block_is_first_with_chunk_of_version;
 use near_chain::types::ApplyTransactionResult;
-use near_chain::{ChainStore, ChainStoreAccess, RuntimeAdapter};
+use near_chain::{ChainStore, ChainStoreAccess, RuntimeWithEpochManagerAdapter};
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::combine_hash;
 use near_primitives::receipt::Receipt;
@@ -72,7 +72,7 @@ fn get_incoming_receipts(
 
 // returns (apply_result, gas limit)
 pub(crate) fn apply_chunk(
-    runtime: &dyn RuntimeAdapter,
+    runtime: &dyn RuntimeWithEpochManagerAdapter,
     chain_store: &mut ChainStore,
     chunk_hash: ChunkHash,
     target_height: Option<u64>,
@@ -149,7 +149,7 @@ enum HashType {
 fn find_tx_or_receipt(
     hash: &CryptoHash,
     block_hash: &CryptoHash,
-    runtime: &dyn RuntimeAdapter,
+    runtime: &dyn RuntimeWithEpochManagerAdapter,
     chain_store: &mut ChainStore,
 ) -> anyhow::Result<Option<(HashType, ShardId)>> {
     let block = chain_store.get_block(&block_hash)?;
@@ -176,7 +176,7 @@ fn find_tx_or_receipt(
 }
 
 fn apply_tx_in_block(
-    runtime: &dyn RuntimeAdapter,
+    runtime: &dyn RuntimeWithEpochManagerAdapter,
     chain_store: &mut ChainStore,
     tx_hash: &CryptoHash,
     block_hash: CryptoHash,
@@ -203,7 +203,7 @@ fn apply_tx_in_block(
 }
 
 fn apply_tx_in_chunk(
-    runtime: &dyn RuntimeAdapter,
+    runtime: &dyn RuntimeWithEpochManagerAdapter,
     store: Store,
     chain_store: &mut ChainStore,
     tx_hash: &CryptoHash,
@@ -262,7 +262,7 @@ fn apply_tx_in_chunk(
 
 pub(crate) fn apply_tx(
     genesis_height: BlockHeight,
-    runtime: &dyn RuntimeAdapter,
+    runtime: &dyn RuntimeWithEpochManagerAdapter,
     store: Store,
     tx_hash: CryptoHash,
 ) -> anyhow::Result<Vec<ApplyTransactionResult>> {
@@ -277,7 +277,7 @@ pub(crate) fn apply_tx(
 }
 
 fn apply_receipt_in_block(
-    runtime: &dyn RuntimeAdapter,
+    runtime: &dyn RuntimeWithEpochManagerAdapter,
     chain_store: &mut ChainStore,
     id: &CryptoHash,
     block_hash: CryptoHash,
@@ -305,7 +305,7 @@ fn apply_receipt_in_block(
 }
 
 fn apply_receipt_in_chunk(
-    runtime: &dyn RuntimeAdapter,
+    runtime: &dyn RuntimeWithEpochManagerAdapter,
     store: Store,
     chain_store: &mut ChainStore,
     id: &CryptoHash,
@@ -390,7 +390,7 @@ fn apply_receipt_in_chunk(
 
 pub(crate) fn apply_receipt(
     genesis_height: BlockHeight,
-    runtime: &dyn RuntimeAdapter,
+    runtime: &dyn RuntimeWithEpochManagerAdapter,
     store: Store,
     id: CryptoHash,
 ) -> anyhow::Result<Vec<ApplyTransactionResult>> {

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -7,8 +7,11 @@ use crate::{apply_chunk, epoch_info};
 use ansi_term::Color::Red;
 use near_chain::chain::collect_receipts_from_response;
 use near_chain::migrations::check_if_block_is_first_with_chunk_of_version;
+use near_chain::types::RuntimeAdapter;
 use near_chain::types::{ApplyTransactionResult, BlockHeaderInfo};
-use near_chain::{ChainStore, ChainStoreAccess, ChainStoreUpdate, Error, RuntimeAdapter};
+use near_chain::{
+    ChainStore, ChainStoreAccess, ChainStoreUpdate, Error, RuntimeWithEpochManagerAdapter,
+};
 use near_chain_configs::GenesisChangeConfig;
 use near_epoch_manager::{EpochManager, EpochManagerAdapter};
 use near_network::iter_peers_from_store;
@@ -38,7 +41,7 @@ use std::sync::Arc;
 pub(crate) fn apply_block(
     block_hash: CryptoHash,
     shard_id: ShardId,
-    runtime_adapter: &dyn RuntimeAdapter,
+    runtime_adapter: &dyn RuntimeWithEpochManagerAdapter,
     chain_store: &mut ChainStore,
 ) -> (Block, ApplyTransactionResult) {
     let block = chain_store.get_block(&block_hash).unwrap();
@@ -128,7 +131,7 @@ pub(crate) fn apply_block_at_height(
         near_config.genesis.config.genesis_height,
         near_config.client_config.save_trie_changes,
     );
-    let runtime_adapter: Arc<dyn RuntimeAdapter> =
+    let runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter> =
         Arc::new(NightshadeRuntime::from_config(home_dir, store, &near_config));
     let block_hash = chain_store.get_block_hash_by_height(height).unwrap();
     let (block, apply_result) =
@@ -421,7 +424,7 @@ pub(crate) fn peers(db: Arc<dyn Database>) {
 pub(crate) fn print_apply_block_result(
     block: &Block,
     apply_result: &ApplyTransactionResult,
-    runtime_adapter: &dyn RuntimeAdapter,
+    runtime_adapter: &dyn RuntimeWithEpochManagerAdapter,
     chain_store: &mut ChainStore,
     shard_id: ShardId,
 ) {
@@ -720,7 +723,7 @@ pub(crate) fn print_epoch_info(
     let mut epoch_manager =
         EpochManager::new_from_genesis_config(store.clone(), &near_config.genesis.config)
             .expect("Failed to start Epoch Manager");
-    let runtime_adapter: Arc<dyn RuntimeAdapter> =
+    let runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter> =
         Arc::new(NightshadeRuntime::from_config(&home_dir, store.clone(), &near_config));
 
     epoch_info::print_epoch_info(

--- a/tools/state-viewer/src/dump_state_parts.rs
+++ b/tools/state-viewer/src/dump_state_parts.rs
@@ -1,6 +1,6 @@
 use crate::epoch_info::iterate_and_filter;
 use clap::Subcommand;
-use near_chain::{ChainStore, ChainStoreAccess, RuntimeAdapter};
+use near_chain::{ChainStore, ChainStoreAccess, RuntimeWithEpochManagerAdapter};
 use near_epoch_manager::EpochManager;
 use near_primitives::epoch_manager::epoch_info::EpochInfo;
 use near_primitives::state_part::PartId;
@@ -111,7 +111,7 @@ pub(crate) fn dump_state_parts(
     output_dir: Option<PathBuf>,
     s3_bucket_and_region: Option<(String, String)>,
 ) {
-    let runtime_adapter: Arc<dyn RuntimeAdapter> =
+    let runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter> =
         Arc::new(NightshadeRuntime::from_config(home_dir, store.clone(), &near_config));
     let mut epoch_manager =
         EpochManager::new_from_genesis_config(store.clone(), &near_config.genesis.config)

--- a/tools/state-viewer/src/epoch_info.rs
+++ b/tools/state-viewer/src/epoch_info.rs
@@ -1,7 +1,7 @@
 use borsh::BorshDeserialize;
 use clap::Subcommand;
 use core::ops::Range;
-use near_chain::{ChainStore, ChainStoreAccess, RuntimeAdapter};
+use near_chain::{ChainStore, ChainStoreAccess, RuntimeWithEpochManagerAdapter};
 use near_epoch_manager::EpochManager;
 use near_primitives::account::id::AccountId;
 use near_primitives::epoch_manager::epoch_info::EpochInfo;
@@ -36,7 +36,7 @@ pub(crate) fn print_epoch_info(
     store: Store,
     chain_store: &mut ChainStore,
     epoch_manager: &mut EpochManager,
-    runtime_adapter: Arc<dyn RuntimeAdapter>,
+    runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
 ) {
     let epoch_ids = get_epoch_ids(epoch_selection, store, chain_store, epoch_manager);
 
@@ -82,7 +82,7 @@ fn display_block_and_chunk_producers(
     epoch_info: &EpochInfo,
     chain_store: &mut ChainStore,
     epoch_manager: &mut EpochManager,
-    runtime_adapter: Arc<dyn RuntimeAdapter>,
+    runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
 ) {
     let block_height_range: Range<BlockHeight> =
         get_block_height_range(&epoch_info, &chain_store, epoch_manager);
@@ -212,7 +212,7 @@ fn display_epoch_info(
     head_epoch_height: &EpochHeight,
     chain_store: &mut ChainStore,
     epoch_manager: &mut EpochManager,
-    runtime_adapter: Arc<dyn RuntimeAdapter>,
+    runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
 ) {
     println!("{:?}: {:#?}", epoch_id, epoch_info);
     if epoch_info.epoch_height() >= *head_epoch_height {
@@ -237,7 +237,7 @@ fn display_validator_info(
     account_id: AccountId,
     chain_store: &mut ChainStore,
     epoch_manager: &mut EpochManager,
-    runtime_adapter: Arc<dyn RuntimeAdapter>,
+    runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
 ) {
     if let Some(kickout) = epoch_info.validator_kickout().get(&account_id) {
         println!("Validator {} kickout: {:#?}", account_id, kickout);

--- a/tools/state-viewer/src/state_dump.rs
+++ b/tools/state-viewer/src/state_dump.rs
@@ -1,5 +1,5 @@
 use borsh::BorshSerialize;
-use near_chain::RuntimeAdapter;
+use near_chain::types::RuntimeAdapter;
 use near_chain_configs::{Genesis, GenesisChangeConfig, GenesisConfig};
 use near_crypto::PublicKey;
 use near_epoch_manager::EpochManagerAdapter;


### PR DESCRIPTION
This looks like a sensible first step towards splitting the epoch manager from the runtime. The rough outline of the overall plan is:
 - Split the two traits (this PR), but still leave everyone using the combined trait
 - Incrementally, piece by piece, make each user of the combined trait take two separate traits instead (or only one of them if the other isn't actually needed)
 - Split EpochManager out of NightshadeRuntime and KeyValueRuntime so that the runtime classes only implement RuntimeAdapter and not EpochManagerAdapter.

This first step enables the second step to be done incrementally.