### PR TITLE
fix: fix block_refcount_final validation

### DIFF
--- a/chain/chain/src/store_validator/validate.rs
+++ b/chain/chain/src/store_validator/validate.rs
@@ -908,15 +908,21 @@ pub(crate) fn receipt_refcount_final(sv: &mut StoreValidator) -> Result<(), Stor
 }
 
 pub(crate) fn block_refcount_final(sv: &mut StoreValidator) -> Result<(), StoreValidatorError> {
-    if let Some(block_refcount) = sv.inner.block_refcount.iter().next() {
+    let block_refcount_len = sv.inner.block_refcount.len();
+    if block_refcount_len >= 2 {
         err!(
             "Found {:?} Blocks that are not counted, e.g. {:?}",
-            sv.inner.block_refcount.len(),
-            block_refcount
+            block_refcount_len,
+            sv.inner.block_refcount.iter().next()
         );
     }
-    if let Some(tail_block) = sv.inner.genesis_blocks.first() {
-        err!("Found {:?} Genesis Blocks, e.g. {:?}", sv.inner.genesis_blocks.len(), tail_block);
+    let genesis_blocks_len = sv.inner.genesis_blocks.len();
+    if genesis_blocks_len >= 2 {
+        err!(
+            "Found {:?} Genesis Blocks, e.g. {:?}",
+            genesis_blocks_len,
+            sv.inner.genesis_blocks.first()
+        );
     }
     Ok(())
 }


### PR DESCRIPTION
`block_refcount_final` was incorrectly refactored in #8299 to check for `sv.inner.genesis_blocks` and `sv.inner.block_refcount` being non-empty. It should check for more than 1 element instead.

This was caught by [the nayduck test](https://nayduck.near.org/#/test/410756):
```
2023-01-15T12:31:09.117757Z ERROR handle{handler="NetworkAdversarialMessage" actor="ClientActor" msg_type="NetworkAdversarialMessage"}: client: Storage Validation failed, [ErrorMessage { col: "BlockRefCount", key: "\"BLOCK_REFCOUNT\"", err: ValidationFailed { func_name: "f", error: "Found 1 Blocks that are not counted, e.g. (B7Sbqj2uD5M3yACTDgSDG9haw2L5vEdLsJiosuPZCDn1, 1)" } }]
```

See [zulip thread](https://near.zulipchat.com/#narrow/stream/295302-general/topic/failing.20nayduck.20tests) for more context.