### PR TITLE
feat: add /client_config endpoint to view runtime client config

### DIFF
--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -7,7 +7,7 @@ use actix::Message;
 use chrono::DateTime;
 use near_primitives::time::Utc;
 
-use near_chain_configs::ProtocolConfigView;
+use near_chain_configs::{ProtocolConfigView, ClientConfig};
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{MerklePath, PartialMerkleTree};
 use near_primitives::network::PeerId;
@@ -932,6 +932,33 @@ pub enum GetMaintenanceWindowsError {
 }
 
 impl From<near_chain_primitives::Error> for GetMaintenanceWindowsError {
+    fn from(error: near_chain_primitives::Error) -> Self {
+        match error {
+            near_chain_primitives::Error::IOErr(error) => Self::IOError(error.to_string()),
+            _ => Self::Unreachable(error.to_string()),
+        }
+    }
+}
+
+pub struct GetClientConfig {}
+
+impl Message for GetClientConfig {
+    type Result = Result<ClientConfig, GetClientConfigError>;
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum GetClientConfigError {
+    #[error("IO Error: {0}")]
+    IOError(String),
+    // NOTE: Currently, the underlying errors are too broad, and while we tried to handle
+    // expected cases, we cannot statically guarantee that no other errors will be returned
+    // in the future.
+    // TODO #3851: Remove this variant once we can exhaustively match all the underlying errors
+    #[error("It is a bug if you receive this error type, please, report this incident: https://github.com/near/nearcore/issues/new/choose. Details: {0}")]
+    Unreachable(String),
+}
+
+impl From<near_chain_primitives::Error> for GetClientConfigError {
     fn from(error: near_chain_primitives::Error) -> Self {
         match error {
             near_chain_primitives::Error::IOErr(error) => Self::IOError(error.to_string()),

--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -7,7 +7,7 @@ use actix::Message;
 use chrono::DateTime;
 use near_primitives::time::Utc;
 
-use near_chain_configs::{ProtocolConfigView, ClientConfig};
+use near_chain_configs::{ClientConfig, ProtocolConfigView};
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{MerklePath, PartialMerkleTree};
 use near_primitives::network::PeerId;

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -36,7 +36,7 @@ use near_chain_configs::ClientConfig;
 use near_chunks::client::ShardsManagerResponse;
 use near_chunks::logic::cares_about_shard_this_or_next_epoch;
 use near_client_primitives::types::{
-    Error, GetNetworkInfo, NetworkInfoResponse, Status, StatusError, StatusSyncInfo, SyncStatus,
+    Error, GetNetworkInfo, NetworkInfoResponse, Status, StatusError, StatusSyncInfo, SyncStatus, GetClientConfig, GetClientConfigError
 };
 use near_dyn_configs::EXPECTED_SHUTDOWN_AT;
 #[cfg(feature = "test_features")]
@@ -1951,6 +1951,21 @@ impl Handler<WithSpanContext<ShardsManagerResponse>> for ClientActor {
                 self.client.on_chunk_header_ready_for_inclusion(chunk_header, chunk_producer);
             }
         }
+    }
+}
+
+impl Handler<WithSpanContext<GetClientConfig>> for ClientActor {
+    type Result = Result<ClientConfig, GetClientConfigError>;
+
+    fn handle(
+        &mut self,
+        msg: WithSpanContext<GetClientConfig>,
+        _: &mut Context<Self>,
+    ) -> Self::Result {
+        let (_span, _msg) = handler_debug_span!(target: "client", msg);
+        let _d = delay_detector::DelayDetector::new(|| "client get client config".into());
+
+        Ok(self.client.config.clone())
     }
 }
 

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -36,7 +36,8 @@ use near_chain_configs::ClientConfig;
 use near_chunks::client::ShardsManagerResponse;
 use near_chunks::logic::cares_about_shard_this_or_next_epoch;
 use near_client_primitives::types::{
-    Error, GetNetworkInfo, NetworkInfoResponse, Status, StatusError, StatusSyncInfo, SyncStatus, GetClientConfig, GetClientConfigError
+    Error, GetClientConfig, GetClientConfigError, GetNetworkInfo, NetworkInfoResponse, Status,
+    StatusError, StatusSyncInfo, SyncStatus,
 };
 use near_dyn_configs::EXPECTED_SHUTDOWN_AT;
 #[cfg(feature = "test_features")]

--- a/chain/client/src/lib.rs
+++ b/chain/client/src/lib.rs
@@ -4,7 +4,7 @@ pub use near_client_primitives::types::{
     GetMaintenanceWindows, GetNetworkInfo, GetNextLightClientBlock, GetProtocolConfig, GetReceipt,
     GetStateChanges, GetStateChangesInBlock, GetStateChangesWithCauseInBlock,
     GetStateChangesWithCauseInBlockForTrackedShards, GetValidatorInfo, GetValidatorOrdered, Query,
-    QueryError, Status, StatusResponse, SyncStatus, TxStatus, TxStatusError,
+    QueryError, Status, StatusResponse, SyncStatus, TxStatus, TxStatusError, GetClientConfig
 };
 
 pub use near_client_primitives::debug::DebugStatus;

--- a/chain/client/src/lib.rs
+++ b/chain/client/src/lib.rs
@@ -1,10 +1,11 @@
 pub use near_client_primitives::types::{
     Error, GetBlock, GetBlockProof, GetBlockProofResponse, GetBlockWithMerkleTree, GetChunk,
-    GetExecutionOutcome, GetExecutionOutcomeResponse, GetExecutionOutcomesForBlock, GetGasPrice,
-    GetMaintenanceWindows, GetNetworkInfo, GetNextLightClientBlock, GetProtocolConfig, GetReceipt,
-    GetStateChanges, GetStateChangesInBlock, GetStateChangesWithCauseInBlock,
+    GetClientConfig, GetExecutionOutcome, GetExecutionOutcomeResponse,
+    GetExecutionOutcomesForBlock, GetGasPrice, GetMaintenanceWindows, GetNetworkInfo,
+    GetNextLightClientBlock, GetProtocolConfig, GetReceipt, GetStateChanges,
+    GetStateChangesInBlock, GetStateChangesWithCauseInBlock,
     GetStateChangesWithCauseInBlockForTrackedShards, GetValidatorInfo, GetValidatorOrdered, Query,
-    QueryError, Status, StatusResponse, SyncStatus, TxStatus, TxStatusError, GetClientConfig
+    QueryError, Status, StatusResponse, SyncStatus, TxStatus, TxStatusError,
 };
 
 pub use near_client_primitives::debug::DebugStatus;

--- a/chain/jsonrpc-primitives/src/types/client_config.rs
+++ b/chain/jsonrpc-primitives/src/types/client_config.rs
@@ -1,0 +1,38 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct RpcClientConfigRequest {}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct RpcClientConfigResponse {
+    #[serde(flatten)]
+    pub client_config: near_chain_configs::ClientConfig,
+}
+
+#[derive(thiserror::Error, Debug, Serialize, Deserialize)]
+#[serde(tag = "name", content = "info", rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum RpcClientConfigError {
+    #[error("The node reached its limits. Try again later. More details: {error_message}")]
+    InternalError { error_message: String },
+}
+
+impl From<RpcClientConfigError> for crate::errors::RpcError {
+    fn from(error: RpcClientConfigError) -> Self {
+        let error_data = match &error {
+            RpcClientConfigError::InternalError { .. } => Some(Value::String(error.to_string())),
+        };
+
+        let error_data_value = match serde_json::to_value(error) {
+            Ok(value) => value,
+            Err(err) => {
+                return Self::new_internal_error(
+                    None,
+                    format!("Failed to serialize RpcClientConfigError: {:?}", err),
+                )
+            }
+        };
+
+        Self::new_internal_or_handler_error(error_data, error_data_value)
+    }
+}

--- a/chain/jsonrpc-primitives/src/types/mod.rs
+++ b/chain/jsonrpc-primitives/src/types/mod.rs
@@ -1,6 +1,7 @@
 pub mod blocks;
 pub mod changes;
 pub mod chunks;
+pub mod client_config;
 pub mod config;
 pub mod gas_price;
 pub mod light_client;
@@ -12,4 +13,3 @@ pub mod sandbox;
 pub mod status;
 pub mod transactions;
 pub mod validator;
-pub mod client_config;

--- a/chain/jsonrpc-primitives/src/types/mod.rs
+++ b/chain/jsonrpc-primitives/src/types/mod.rs
@@ -12,3 +12,4 @@ pub mod sandbox;
 pub mod status;
 pub mod transactions;
 pub mod validator;
+pub mod client_config;

--- a/chain/jsonrpc/src/api/client_config.rs
+++ b/chain/jsonrpc/src/api/client_config.rs
@@ -1,0 +1,25 @@
+use near_client_primitives::types::GetClientConfigError;
+use near_jsonrpc_primitives::types::client_config::RpcClientConfigError;
+
+use super::RpcFrom;
+
+impl RpcFrom<actix::MailboxError> for RpcClientConfigError {
+    fn rpc_from(error: actix::MailboxError) -> Self {
+        Self::InternalError { error_message: error.to_string() }
+    }
+}
+
+impl RpcFrom<GetClientConfigError> for RpcClientConfigError {
+    fn rpc_from(error: GetClientConfigError) -> Self {
+        match error {
+            GetClientConfigError::IOError(error_message) => Self::InternalError { error_message },
+            GetClientConfigError::Unreachable(ref error_message) => {
+                tracing::warn!(target: "jsonrpc", "Unreachable error occurred: {}", error_message);
+                crate::metrics::RPC_UNREACHABLE_ERROR_COUNT
+                    .with_label_values(&["RpcClientConfigError"])
+                    .inc();
+                Self::InternalError { error_message: error.to_string() }
+            }
+        }
+    }
+}

--- a/chain/jsonrpc/src/api/mod.rs
+++ b/chain/jsonrpc/src/api/mod.rs
@@ -8,6 +8,7 @@ use near_primitives::borsh::BorshDeserialize;
 mod blocks;
 mod changes;
 mod chunks;
+mod client_config;
 mod config;
 mod gas_price;
 mod light_client;
@@ -19,7 +20,6 @@ mod sandbox;
 mod status;
 mod transactions;
 mod validator;
-mod client_config;
 
 pub(crate) trait RpcRequest: Sized {
     fn parse(value: Option<Value>) -> Result<Self, RpcParseError>;

--- a/chain/jsonrpc/src/api/mod.rs
+++ b/chain/jsonrpc/src/api/mod.rs
@@ -19,6 +19,7 @@ mod sandbox;
 mod status;
 mod transactions;
 mod validator;
+mod client_config;
 
 pub(crate) trait RpcRequest: Sized {
     fn parse(value: Option<Value>) -> Result<Self, RpcParseError>;

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -21,7 +21,7 @@ use near_client::{
     ClientActor, DebugStatus, GetBlock, GetBlockProof, GetChunk, GetExecutionOutcome, GetGasPrice,
     GetMaintenanceWindows, GetNetworkInfo, GetNextLightClientBlock, GetProtocolConfig, GetReceipt,
     GetStateChanges, GetStateChangesInBlock, GetValidatorInfo, GetValidatorOrdered,
-    ProcessTxRequest, ProcessTxResponse, Query, Status, TxStatus, ViewClientActor,
+    ProcessTxRequest, ProcessTxResponse, Query, Status, TxStatus, ViewClientActor, GetClientConfig
 };
 pub use near_jsonrpc_client as client;
 use near_jsonrpc_primitives::errors::RpcError;
@@ -1089,6 +1089,16 @@ impl JsonRpcHandler {
         let windows = self.view_client_send(GetMaintenanceWindows { account_id }).await?;
         Ok(windows.iter().map(|r| (r.start, r.end)).collect())
     }
+
+    async fn client_config(
+        &self,
+    ) -> Result<
+        near_jsonrpc_primitives::types::client_config::RpcClientConfigResponse,
+        near_jsonrpc_primitives::types::client_config::RpcClientConfigError,
+    > {
+        let client_config = self.client_send(GetClientConfig {}).await?;
+        Ok(near_jsonrpc_primitives::types::client_config::RpcClientConfigResponse { client_config })
+    }
 }
 
 #[cfg(feature = "sandbox")]
@@ -1409,6 +1419,18 @@ pub async fn prometheus_handler() -> Result<HttpResponse, HttpError> {
     }
 }
 
+fn client_config_handler(
+    handler: web::Data<JsonRpcHandler>,
+) -> impl Future<Output = Result<HttpResponse, HttpError>> {
+    let response = async move {
+        match handler.client_config().await {
+            Ok(value) => Ok(HttpResponse::Ok().json(&value)),
+            Err(_) => Ok(HttpResponse::ServiceUnavailable().finish()),
+        }
+    };
+    response.boxed()
+}
+
 fn get_cors(cors_allowed_origins: &[String]) -> Cors {
     let mut cors = Cors::permissive();
     if cors_allowed_origins != ["*".to_string()] {
@@ -1535,6 +1557,7 @@ pub fn start_http(
             )
             .service(debug_html)
             .service(display_debug_html)
+            .service(web::resource("/client_config").route(web::get().to(client_config_handler)))
     })
     .bind(addr)
     .unwrap()

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -18,10 +18,11 @@ use tracing::info;
 
 use near_chain_configs::GenesisConfig;
 use near_client::{
-    ClientActor, DebugStatus, GetBlock, GetBlockProof, GetChunk, GetExecutionOutcome, GetGasPrice,
-    GetMaintenanceWindows, GetNetworkInfo, GetNextLightClientBlock, GetProtocolConfig, GetReceipt,
-    GetStateChanges, GetStateChangesInBlock, GetValidatorInfo, GetValidatorOrdered,
-    ProcessTxRequest, ProcessTxResponse, Query, Status, TxStatus, ViewClientActor, GetClientConfig
+    ClientActor, DebugStatus, GetBlock, GetBlockProof, GetChunk, GetClientConfig,
+    GetExecutionOutcome, GetGasPrice, GetMaintenanceWindows, GetNetworkInfo,
+    GetNextLightClientBlock, GetProtocolConfig, GetReceipt, GetStateChanges,
+    GetStateChangesInBlock, GetValidatorInfo, GetValidatorOrdered, ProcessTxRequest,
+    ProcessTxResponse, Query, Status, TxStatus, ViewClientActor,
 };
 pub use near_jsonrpc_client as client;
 use near_jsonrpc_primitives::errors::RpcError;

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -70,7 +70,7 @@ impl GCConfig {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ClientConfig {
     /// Version of the binary.
     pub version: Version,


### PR DESCRIPTION
add endpoint /client_config to dump runtime client config


# Context
https://pagodaplatform.atlassian.net/browse/ND-273  

# Testing and QA
tested by starting a localnet and tested endpoint on localnet
<img width="1668" alt="local_client_config" src="https://user-images.githubusercontent.com/16693342/213029344-40d90be3-a7d1-434f-bc4f-fd52b00de27b.png">


