### PR TITLE
refactor: removing cold store rust feature and conditional compilation

### DIFF
--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -56,7 +56,6 @@ no_cache = []
 single_thread_rocksdb = [] # Deactivate RocksDB IO background threads
 test_features = []
 protocol_feature_flat_state = []
-cold_store = []
 
 nightly_protocol = []
 nightly = [

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -397,7 +397,6 @@ impl DBCol {
     }
 
     /// Whether this column exists in cold storage.
-    #[cfg(feature = "cold_store")]
     pub(crate) const fn is_in_colddb(&self) -> bool {
         matches!(*self, DBCol::DbVersion | DBCol::BlockMisc) || self.is_cold()
     }

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -2,14 +2,12 @@ use std::io;
 
 use crate::DBCol;
 
-#[cfg(feature = "cold_store")]
 mod colddb;
 pub mod refcount;
 pub(crate) mod rocksdb;
 mod slice;
 mod testdb;
 
-#[cfg(feature = "cold_store")]
 pub use self::colddb::ColdDB;
 pub use self::rocksdb::RocksDB;
 pub use self::slice::DBSlice;

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -41,7 +41,6 @@ pub use crate::trie::{
 };
 pub use flat_state::FlatStateDelta;
 
-#[cfg(feature = "cold_store")]
 pub mod cold_storage;
 mod columns;
 pub mod config;
@@ -68,7 +67,6 @@ pub use crate::opener::{StoreMigrator, StoreOpener, StoreOpenerError};
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Temperature {
     Hot,
-    #[cfg(feature = "cold_store")]
     Cold,
 }
 
@@ -79,7 +77,6 @@ impl FromStr for Temperature {
         let s = s.to_lowercase();
         match s.as_str() {
             "hot" => Ok(Temperature::Hot),
-            #[cfg(feature = "cold_store")]
             "cold" => Ok(Temperature::Cold),
             _ => Err(String::from(format!("invalid temperature string {s}"))),
         }
@@ -94,10 +91,7 @@ impl FromStr for Temperature {
 /// the storage.
 pub struct NodeStorage<D = crate::db::RocksDB> {
     hot_storage: Arc<dyn Database>,
-    #[cfg(feature = "cold_store")]
     cold_storage: Option<Arc<crate::db::ColdDB<D>>>,
-    #[cfg(not(feature = "cold_store"))]
-    cold_storage: Option<std::convert::Infallible>,
     _phantom: PhantomData<D>,
 }
 
@@ -116,10 +110,8 @@ pub struct Store {
 
 // Those are temporary.  While cold_store feature is stabilised, remove those
 // type aliases and just use the type directly.
-#[cfg(feature = "cold_store")]
+// TODO
 pub type ColdConfig<'a> = Option<&'a StoreConfig>;
-#[cfg(not(feature = "cold_store"))]
-pub type ColdConfig<'a> = Option<std::convert::Infallible>;
 
 impl NodeStorage {
     /// Initialises a new opener with given home directory and hot and cold
@@ -127,28 +119,19 @@ impl NodeStorage {
     pub fn opener<'a>(
         home_dir: &std::path::Path,
         config: &'a StoreConfig,
-        #[allow(unused_variables)] cold_config: ColdConfig<'a>,
+        cold_config: ColdConfig<'a>,
     ) -> StoreOpener<'a> {
-        StoreOpener::new(
-            home_dir,
-            config,
-            #[cfg(feature = "cold_store")]
-            cold_config,
-        )
+        StoreOpener::new(home_dir, config, cold_config)
     }
 
     /// Constructs new object backed by given database.
     fn from_rocksdb(
         hot_storage: crate::db::RocksDB,
-        #[cfg(feature = "cold_store")] cold_storage: Option<crate::db::RocksDB>,
-        #[cfg(not(feature = "cold_store"))] cold_storage: Option<std::convert::Infallible>,
+        cold_storage: Option<crate::db::RocksDB>,
     ) -> Self {
         let hot_storage = Arc::new(hot_storage);
-        #[cfg(feature = "cold_store")]
         let cold_storage = cold_storage
             .map(|cold_db| Arc::new(crate::db::ColdDB::new(hot_storage.clone(), cold_db)));
-        #[cfg(not(feature = "cold_store"))]
-        let cold_storage = cold_storage.map(|_| unreachable!());
         Self { hot_storage, cold_storage, _phantom: PhantomData {} }
     }
 
@@ -163,12 +146,7 @@ impl NodeStorage {
     pub fn test_opener() -> (tempfile::TempDir, StoreOpener<'static>) {
         static CONFIG: Lazy<StoreConfig> = Lazy::new(StoreConfig::test_config);
         let dir = tempfile::tempdir().unwrap();
-        let opener = StoreOpener::new(
-            dir.path(),
-            &CONFIG,
-            #[cfg(feature = "cold_store")]
-            None,
-        );
+        let opener = StoreOpener::new(dir.path(), &CONFIG, None);
         (dir, opener)
     }
 
@@ -199,10 +177,12 @@ impl<D: Database + 'static> NodeStorage<D> {
     /// data is, simplifying slightly, determined based on height of the block.
     /// Anything above the tail of hot storage is hot and everything else is
     /// cold.
+    ///
+    /// This method panics if trying to access cold store but it wasn't configured.
+    /// Please consider using the get_hot_store and get_cold_store methods to avoid panics.
     pub fn get_store(&self, temp: Temperature) -> Store {
         match temp {
             Temperature::Hot => Store { storage: self.hot_storage.clone() },
-            #[cfg(feature = "cold_store")]
             Temperature::Cold => Store { storage: self.cold_storage.as_ref().unwrap().clone() },
         }
     }
@@ -225,7 +205,6 @@ impl<D: Database + 'static> NodeStorage<D> {
     pub fn _get_inner(&self, temp: Temperature) -> &Arc<dyn Database> {
         match temp {
             Temperature::Hot => &self.hot_storage,
-            #[cfg(feature = "cold_store")]
             Temperature::Cold => todo!(),
         }
     }
@@ -237,14 +216,12 @@ impl<D: Database + 'static> NodeStorage<D> {
     pub fn into_inner(self, temp: Temperature) -> Arc<dyn Database> {
         match temp {
             Temperature::Hot => self.hot_storage,
-            #[cfg(feature = "cold_store")]
             Temperature::Cold => self.cold_storage.unwrap(),
         }
     }
 
     pub fn set_version(&self, version: DbVersion) -> std::io::Result<()> {
         self.get_store(Temperature::Hot).set_db_version(version)?;
-        #[cfg(feature = "cold_store")]
         self.get_store(Temperature::Cold).set_db_version(version)?;
         Ok(())
     }
@@ -268,7 +245,6 @@ impl<D> NodeStorage<D> {
         })
     }
 
-    #[cfg(feature = "cold_store")]
     pub fn new_with_cold(hot: Arc<dyn Database>, cold: D) -> Self {
         Self {
             hot_storage: hot.clone(),
@@ -277,7 +253,6 @@ impl<D> NodeStorage<D> {
         }
     }
 
-    #[cfg(feature = "cold_store")]
     pub fn cold_db(&self) -> io::Result<&Arc<crate::db::ColdDB<D>>> {
         self.cold_storage
             .as_ref()

--- a/core/store/src/metadata.rs
+++ b/core/store/src/metadata.rs
@@ -58,12 +58,11 @@ fn set_db_metadata(
     if metadata.version >= DB_VERSION_WITH_KIND {
         #[allow(unused_mut)]
         let mut kind = metadata.kind;
-        #[cfg(feature = "cold_store")]
-        if matches!(temp, Temperature::Cold) || storage.has_cold() {
-            kind = Some(if matches!(temp, Temperature::Hot) { DbKind::Hot } else { DbKind::Cold });
+        if temp == Temperature::Cold {
+            kind = Some(DbKind::Cold);
         }
-        if let Some(kind) = kind.map(|kind| <&str>::from(kind).as_bytes()) {
-            store_update.set(DBCol::DbVersion, KIND_KEY, kind);
+        if let Some(kind) = kind {
+            store_update.set(DBCol::DbVersion, KIND_KEY, <&str>::from(kind).as_bytes());
         }
     }
     store_update.commit()
@@ -74,7 +73,6 @@ pub(super) fn set_store_metadata(
     metadata: DbMetadata,
 ) -> std::io::Result<()> {
     set_db_metadata(storage, Temperature::Hot, metadata)?;
-    #[cfg(feature = "cold_store")]
     if storage.has_cold() {
         set_db_metadata(storage, Temperature::Cold, metadata)?;
     }

--- a/core/store/src/metadata.rs
+++ b/core/store/src/metadata.rs
@@ -56,7 +56,6 @@ fn set_db_metadata(
     let mut store_update = storage.get_store(temp).store_update();
     store_update.set(DBCol::DbVersion, VERSION_KEY, metadata.version.to_string().as_bytes());
     if metadata.version >= DB_VERSION_WITH_KIND {
-        #[allow(unused_mut)]
         let mut kind = metadata.kind;
         if temp == Temperature::Cold {
             kind = Some(DbKind::Cold);

--- a/core/store/src/metrics.rs
+++ b/core/store/src/metrics.rs
@@ -213,7 +213,6 @@ pub static PREFETCH_STAGED_SLOTS: Lazy<IntGaugeVec> = Lazy::new(|| {
     )
     .unwrap()
 });
-#[cfg(feature = "cold_store")]
 pub static COLD_MIGRATION_READS: Lazy<IntCounterVec> = Lazy::new(|| {
     try_create_int_counter_vec(
         "near_cold_migration_reads",

--- a/core/store/src/opener.rs
+++ b/core/store/src/opener.rs
@@ -166,14 +166,11 @@ impl<'a> StoreOpener<'a> {
     pub(crate) fn new(
         home_dir: &std::path::Path,
         config: &'a StoreConfig,
-        #[cfg(feature = "cold_store")] cold_config: super::ColdConfig<'a>,
+        cold_config: super::ColdConfig<'a>,
     ) -> Self {
         Self {
             hot: DBOpener::new(home_dir, config, Temperature::Hot),
-            #[cfg(feature = "cold_store")]
             cold: cold_config.map(|config| ColdDBOpener::new(home_dir, config, Temperature::Cold)),
-            #[cfg(not(feature = "cold_store"))]
-            cold: None,
             expected_kind: None,
             migrator: None,
         }
@@ -232,25 +229,22 @@ impl<'a> StoreOpener<'a> {
 
         if let Some(hot_meta) = hot_meta {
             if let Some(Some(cold_meta)) = cold_meta {
-                assert!(cfg!(feature = "cold_store"));
                 // If cold database exists, hot and cold databases must have the
-                // same version and to be Hot and Cold kinds respectively.
+                // same version and to be Hot and Cold or Archive and Cold kinds respectively.
                 if hot_meta.version != cold_meta.version {
                     return Err(StoreOpenerError::HotColdVersionMismatch {
                         hot_version: hot_meta.version,
                         cold_version: cold_meta.version,
                     });
                 }
-                #[cfg(feature = "cold_store")]
-                if hot_meta.kind != Some(DbKind::Hot) {
+                if !matches!(hot_meta.kind, Some(DbKind::Hot) | Some(DbKind::Archive)) {
                     return Err(StoreOpenerError::DbKindMismatch {
                         which: "Hot",
                         got: hot_meta.kind,
                         want: DbKind::Hot,
                     });
                 }
-                #[cfg(feature = "cold_store")]
-                if cold_meta.kind != Some(DbKind::Cold) {
+                if !matches!(cold_meta.kind, Some(DbKind::Cold)) {
                     return Err(StoreOpenerError::DbKindMismatch {
                         which: "Cold",
                         got: cold_meta.kind,
@@ -260,7 +254,6 @@ impl<'a> StoreOpener<'a> {
             } else if cold_meta.is_some() {
                 // If cold database is configured and hot database exists,
                 // cold database must exist as well.
-                assert!(cfg!(feature = "cold_store"));
                 return Err(StoreOpenerError::HotColdExistenceMismatch);
             } else if !matches!(hot_meta.kind, None | Some(DbKind::RPC | DbKind::Archive)) {
                 // If cold database is not configured, hot database must be
@@ -291,13 +284,9 @@ impl<'a> StoreOpener<'a> {
         tracing::info!(target: "near", path=%self.path().display(),
                        "Opening an existing RocksDB database");
         let (storage, hot_meta, cold_meta) = self.open_storage(mode, DB_VERSION)?;
-        if let Some(_cold_meta) = cold_meta {
-            assert!(cfg!(feature = "cold_store"));
-            // open_storage has verified this.
-            #[cfg(feature = "cold_store")]
-            assert_eq!(Some(DbKind::Hot), hot_meta.kind);
-            #[cfg(feature = "cold_store")]
-            assert_eq!(Some(DbKind::Cold), _cold_meta.kind);
+        if let Some(cold_meta) = cold_meta {
+            assert!(matches!(hot_meta.kind, Some(DbKind::Hot) | Some(DbKind::Archive)));
+            assert!(matches!(cold_meta.kind, Some(DbKind::Cold)));
         } else {
             self.ensure_kind(&storage, hot_meta)?;
         }
@@ -427,17 +416,14 @@ impl<'a> StoreOpener<'a> {
         // Those are mostly sanity checks.  If any of those conditions fails
         // than either there’s bug in code or someone does something weird on
         // the file system and tries to switch databases under us.
-        if let Some(_cold_meta) = cold_meta {
-            #[cfg(feature = "cold_store")]
-            if hot_meta.kind != Some(DbKind::Hot) {
+        if let Some(cold_meta) = cold_meta {
+            if !matches!(hot_meta.kind, Some(DbKind::Hot) | Some(DbKind::Archive)) {
                 Err((hot_meta.kind, "Hot"))
-            } else if _cold_meta.kind != Some(DbKind::Cold) {
-                Err((_cold_meta.kind, "Cold"))
+            } else if !matches!(cold_meta.kind, Some(DbKind::Cold)) {
+                Err((cold_meta.kind, "Cold"))
             } else {
                 Ok(())
             }
-            #[cfg(not(feature = "cold_store"))]
-            Ok(())
         } else if matches!(hot_meta.kind, None | Some(DbKind::RPC | DbKind::Archive)) {
             Ok(())
         } else {
@@ -542,40 +528,9 @@ pub trait StoreMigrator {
 
 // This is only here to make conditional compilation simpler.  Once cold_store
 // feature is stabilised, get rid of it and use DBOpener directly.
+// TODO
 use cold_db_opener::ColdDBOpener;
 
-#[cfg(feature = "cold_store")]
 mod cold_db_opener {
     pub(super) type ColdDBOpener<'a> = super::DBOpener<'a>;
-}
-
-#[cfg(not(feature = "cold_store"))]
-mod cold_db_opener {
-    use super::*;
-
-    pub(super) enum OpenerImpl {}
-
-    impl OpenerImpl {
-        pub(super) fn get_metadata(&self) -> std::io::Result<Option<DbMetadata>> {
-            unreachable!()
-        }
-
-        pub(super) fn open(
-            &self,
-            _mode: Mode,
-            _want_version: DbVersion,
-        ) -> std::io::Result<(std::convert::Infallible, DbMetadata)> {
-            unreachable!()
-        }
-
-        pub(super) fn create(&self) -> std::io::Result<std::convert::Infallible> {
-            unreachable!()
-        }
-
-        pub(super) fn snapshot(&self) -> Result<Snapshot, SnapshotError> {
-            Ok(Snapshot::none())
-        }
-    }
-
-    pub(super) type ColdDBOpener<'a> = OpenerImpl;
 }

--- a/core/store/src/opener.rs
+++ b/core/store/src/opener.rs
@@ -131,7 +131,7 @@ pub struct StoreOpener<'a> {
     hot: DBOpener<'a>,
 
     /// Opener for an instance of Cold RocksDB store if one was configured.
-    cold: Option<ColdDBOpener<'a>>,
+    cold: Option<DBOpener<'a>>,
 
     /// What kind of database we should expect; if `None`, the kind of the
     /// database is not checked.
@@ -166,11 +166,11 @@ impl<'a> StoreOpener<'a> {
     pub(crate) fn new(
         home_dir: &std::path::Path,
         config: &'a StoreConfig,
-        cold_config: super::ColdConfig<'a>,
+        cold_config: Option<&'a StoreConfig>,
     ) -> Self {
         Self {
             hot: DBOpener::new(home_dir, config, Temperature::Hot),
-            cold: cold_config.map(|config| ColdDBOpener::new(home_dir, config, Temperature::Cold)),
+            cold: cold_config.map(|config| DBOpener::new(home_dir, config, Temperature::Cold)),
             expected_kind: None,
             migrator: None,
         }
@@ -524,13 +524,4 @@ pub trait StoreMigrator {
     /// check support via [`Self::check_support`] method) or if it’s greater or
     /// equal to [`DB_VERSION`].
     fn migrate(&self, storage: &NodeStorage, version: DbVersion) -> anyhow::Result<()>;
-}
-
-// This is only here to make conditional compilation simpler.  Once cold_store
-// feature is stabilised, get rid of it and use DBOpener directly.
-// TODO
-use cold_db_opener::ColdDBOpener;
-
-mod cold_db_opener {
-    pub(super) type ColdDBOpener<'a> = super::DBOpener<'a>;
 }

--- a/core/store/src/test_utils.rs
+++ b/core/store/src/test_utils.rs
@@ -35,7 +35,6 @@ pub fn create_test_node_storage_default() -> NodeStorage {
 }
 
 /// Creates an in-memory node storage with ColdDB<TestDB>
-#[cfg(feature = "cold_store")]
 pub fn create_test_node_storage_with_cold(
     version: DbVersion,
     hot_kind: DbKind,

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -89,6 +89,3 @@ sandbox = [
   "near-client/sandbox",
 ]
 no_cache = ["nearcore/no_cache"]
-cold_store = [
-  "near-store/cold_store"
-]

--- a/integration-tests/src/tests/client/mod.rs
+++ b/integration-tests/src/tests/client/mod.rs
@@ -1,7 +1,6 @@
 mod benchmarks;
 mod challenges;
 mod chunks_management;
-#[cfg(feature = "cold_store")]
 mod cold_storage;
 mod features;
 mod flat_storage;

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -71,18 +71,13 @@ use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives::views::{
     BlockHeaderView, FinalExecutionStatus, QueryRequest, QueryResponseKind,
 };
-#[cfg(feature = "cold_store")]
 use near_store::cold_storage::{update_cold_db, update_cold_head};
-#[cfg(feature = "cold_store")]
 use near_store::db::TestDB;
 use near_store::metadata::DbKind;
-#[cfg(feature = "cold_store")]
 use near_store::metadata::DB_VERSION;
-#[cfg(feature = "cold_store")]
 use near_store::test_utils::create_test_node_storage_with_cold;
 use near_store::test_utils::create_test_store;
 use near_store::{get, DBCol, Store, TrieChanges};
-#[cfg(feature = "cold_store")]
 use near_store::{NodeStorage, Temperature};
 use nearcore::config::{GenesisExt, TESTING_INIT_BALANCE, TESTING_INIT_STAKE};
 use nearcore::NEAR_BASE;
@@ -1569,7 +1564,6 @@ fn test_archival_save_trie_changes() {
     }
 }
 
-#[cfg(feature = "cold_store")]
 fn test_archival_gc_common(
     storage: NodeStorage<TestDB>,
     epoch_length: u64,
@@ -1644,7 +1638,6 @@ fn test_archival_gc_common(
 /// date on the hot -> cold block copying is correctly garbage collecting
 /// blocks older than 5 epochs.
 #[test]
-#[cfg(feature = "cold_store")]
 fn test_archival_gc_migration() {
     // Split storage in the middle of migration has hot store kind set to archive.
     let storage = create_test_node_storage_with_cold(DB_VERSION, DbKind::Archive);
@@ -1660,7 +1653,6 @@ fn test_archival_gc_migration() {
 /// date on the hot -> cold block copying is correctly garbage collecting
 /// blocks older than 5 epochs.
 #[test]
-#[cfg(feature = "cold_store")]
 fn test_archival_gc_split_storage_current() {
     // Fully migrated split storage has each store configured with kind = temperature.
     let storage = create_test_node_storage_with_cold(DB_VERSION, DbKind::Hot);
@@ -1676,7 +1668,6 @@ fn test_archival_gc_split_storage_current() {
 /// on the hot -> cold block copying is correctly garbage collecting blocks
 /// older than the cold head.
 #[test]
-#[cfg(feature = "cold_store")]
 fn test_archival_gc_split_storage_behind() {
     // Fully migrated split storage has each store configured with kind = temperature.
     let storage = create_test_node_storage_with_cold(DB_VERSION, DbKind::Hot);

--- a/nearcore/Cargo.toml
+++ b/nearcore/Cargo.toml
@@ -140,5 +140,3 @@ sandbox = [
   "near-jsonrpc/sandbox",
 ]
 io_trace = ["near-vm-runner/io_trace"]
-
-cold_store = ["near-store/cold_store"]

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -329,7 +329,7 @@ pub struct Config {
     /// Different parameters to configure underlying storage.
     pub store: near_store::StoreConfig,
     /// Different parameters to configure underlying cold storage.
-    #[cfg(feature = "cold_store")]
+    /// This feature is under development, do not use in production.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cold_store: Option<near_store::StoreConfig>,
 
@@ -380,7 +380,6 @@ impl Default for Config {
             db_migration_snapshot_path: None,
             use_db_migration_snapshot: None,
             store: near_store::StoreConfig::default(),
-            #[cfg(feature = "cold_store")]
             cold_store: None,
             expected_shutdown: None,
         }

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -56,10 +56,7 @@ fn open_storage(home_dir: &Path, near_config: &mut NearConfig) -> anyhow::Result
     let opener = NodeStorage::opener(
         home_dir,
         &near_config.config.store,
-        #[cfg(feature = "cold_store")]
         near_config.config.cold_store.as_ref(),
-        #[cfg(not(feature = "cold_store"))]
-        None,
     )
     .with_migrator(&migrator)
     .expect_archive(near_config.client_config.archive);

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -64,7 +64,6 @@ json_rpc = ["nearcore/json_rpc"]
 protocol_feature_fix_staking_threshold = ["nearcore/protocol_feature_fix_staking_threshold"]
 protocol_feature_flat_state = ["nearcore/protocol_feature_flat_state"]
 protocol_feature_nep366_delegate_action = ["nearcore/protocol_feature_nep366_delegate_action"]
-cold_store = ["nearcore/cold_store", "near-store/cold_store", "near-state-viewer/cold_store", "near-cold-store-tool/cold_store"]
 
 nightly = [
   "nightly_protocol",

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -4,7 +4,6 @@ use clap::{Args, Parser};
 use near_amend_genesis::AmendGenesisCommand;
 use near_chain_configs::GenesisValidationMode;
 use near_client::ConfigUpdater;
-#[cfg(feature = "cold_store")]
 use near_cold_store_tool::ColdStoreCommand;
 use near_dyn_configs::{UpdateableConfigLoader, UpdateableConfigLoaderError, UpdateableConfigs};
 use near_jsonrpc_primitives::types::light_client::RpcLightClientExecutionProofResponse;
@@ -111,7 +110,6 @@ impl NeardCmd {
             NeardSubCommand::AmendGenesis(cmd) => {
                 cmd.run()?;
             }
-            #[cfg(feature = "cold_store")]
             NeardSubCommand::ColdStore(cmd) => {
                 cmd.run(&home_dir);
             }
@@ -222,7 +220,6 @@ pub(super) enum NeardSubCommand {
     /// Amend a genesis/records file created by `dump-state`.
     AmendGenesis(AmendGenesisCommand),
 
-    #[cfg(feature = "cold_store")]
     /// Testing tool for cold storage
     ColdStore(ColdStoreCommand),
 

--- a/tools/cold-store/Cargo.toml
+++ b/tools/cold-store/Cargo.toml
@@ -13,9 +13,3 @@ near-chain-configs = { path = "../../core/chain-configs"}
 near-epoch-manager = { path = "../../chain/epoch-manager" }
 near-primitives = { path = "../../core/primitives" }
 near-store = { path = "../../core/store"}
-
-[features]
-cold_store = [
-    "near-store/cold_store",
-    "nearcore/cold_store",
-]

--- a/tools/cold-store/src/cli.rs
+++ b/tools/cold-store/src/cli.rs
@@ -41,11 +41,8 @@ impl ColdStoreCommand {
         );
         let store = opener.open().unwrap_or_else(|e| panic!("Error opening storage: {:#}", e));
 
-        let hot_runtime = Arc::new(NightshadeRuntime::from_config(
-            home_dir,
-            store.get_store(Temperature::Hot),
-            &near_config,
-        ));
+        let hot_runtime =
+            Arc::new(NightshadeRuntime::from_config(home_dir, store.get_hot_store(), &near_config));
         match self.subcmd {
             SubCommand::Open => check_open(&store),
             SubCommand::Head => print_heads(&store),
@@ -87,6 +84,15 @@ fn print_heads(store: &NodeStorage) {
     println!("COLD STORE HEAD is at {:#?}", head_in_cold);
 
     assert_eq!(cold_head_in_hot.unwrap_or_default(), head_in_cold.unwrap_or_default());
+
+    // cold store
+    if let Some(cold_store) = cold_store {
+        let kind = cold_store.get_db_kind()?;
+        let head_in_cold = cold_store.get_ser::<Tip>(DBCol::BlockMisc, HEAD_KEY)?;
+        println!("COLD STORE KIND is {:#?}", kind);
+        println!("COLD STORE HEAD is at {:#?}", head_in_cold);
+    }
+    Ok(())
 }
 
 fn copy_next_block(store: &NodeStorage, config: &NearConfig, hot_runtime: &Arc<NightshadeRuntime>) {

--- a/tools/cold-store/src/cli.rs
+++ b/tools/cold-store/src/cli.rs
@@ -6,6 +6,7 @@ use near_store::{DBCol, NodeStorage, Temperature, COLD_HEAD_KEY, FINAL_HEAD_KEY,
 use nearcore::{NearConfig, NightshadeRuntime};
 
 use clap::Parser;
+use std::io::Result;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -45,7 +46,7 @@ impl ColdStoreCommand {
             Arc::new(NightshadeRuntime::from_config(home_dir, store.get_hot_store(), &near_config));
         match self.subcmd {
             SubCommand::Open => check_open(&store),
-            SubCommand::Head => print_heads(&store),
+            SubCommand::Head => print_heads(&store).unwrap(),
             SubCommand::CopyNextBlocks(cmd) => {
                 for _ in 0..cmd.number_of_blocks {
                     copy_next_block(&store, &near_config, &hot_runtime);
@@ -65,25 +66,21 @@ fn check_open(store: &NodeStorage) {
     assert!(store.has_cold());
 }
 
-fn print_heads(store: &NodeStorage) {
-    println!(
-        "HOT STORE HEAD is at {:#?}",
-        store.get_store(Temperature::Hot).get_ser::<Tip>(DBCol::BlockMisc, HEAD_KEY)
-    );
-    println!(
-        "HOT STORE FINAL_HEAD is at {:#?}",
-        store.get_store(Temperature::Hot).get_ser::<Tip>(DBCol::BlockMisc, FINAL_HEAD_KEY)
-    );
+fn print_heads(store: &NodeStorage) -> Result<()> {
+    let hot_store = store.get_hot_store();
+    let cold_store = store.get_cold_store();
 
-    let cold_head_in_hot =
-        store.get_store(Temperature::Hot).get_ser::<Tip>(DBCol::BlockMisc, COLD_HEAD_KEY);
-    println!("HOT STORE COLD_HEAD is at {:#?}", cold_head_in_hot);
-
-    let head_in_cold =
-        store.get_store(Temperature::Cold).get_ser::<Tip>(DBCol::BlockMisc, HEAD_KEY);
-    println!("COLD STORE HEAD is at {:#?}", head_in_cold);
-
-    assert_eq!(cold_head_in_hot.unwrap_or_default(), head_in_cold.unwrap_or_default());
+    // hot store
+    {
+        let kind = hot_store.get_db_kind()?;
+        let head = hot_store.get_ser::<Tip>(DBCol::BlockMisc, HEAD_KEY)?;
+        let final_head = hot_store.get_ser::<Tip>(DBCol::BlockMisc, FINAL_HEAD_KEY)?;
+        let cold_head = hot_store.get_ser::<Tip>(DBCol::BlockMisc, COLD_HEAD_KEY)?;
+        println!("HOT STORE KIND is {:#?}", kind);
+        println!("HOT STORE HEAD is at {:#?}", head);
+        println!("HOT STORE FINAL_HEAD is at {:#?}", final_head);
+        println!("HOT STORE COLD_HEAD is at {:#?}", cold_head);
+    }
 
     // cold store
     if let Some(cold_store) = cold_store {

--- a/tools/cold-store/src/lib.rs
+++ b/tools/cold-store/src/lib.rs
@@ -1,4 +1,2 @@
-#[cfg(feature = "cold_store")]
 pub mod cli;
-#[cfg(feature = "cold_store")]
 pub use cli::ColdStoreCommand;

--- a/tools/state-viewer/Cargo.toml
+++ b/tools/state-viewer/Cargo.toml
@@ -49,4 +49,3 @@ nightly = [
 ]
 nightly_protocol = ["nearcore/nightly_protocol"]
 protocol_feature_flat_state = ["nearcore/protocol_feature_flat_state"]
-cold_store = ["near-store/cold_store"]

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -95,11 +95,8 @@ impl StateViewerSubCommand {
         let near_config = load_config(home_dir, genesis_validation)
             .unwrap_or_else(|e| panic!("Error loading config: {:#}", e));
 
-        #[cfg(feature = "cold_store")]
         let cold_store_config: Option<&near_store::StoreConfig> =
             near_config.config.cold_store.as_ref();
-        #[cfg(not(feature = "cold_store"))]
-        let cold_store_config: Option<std::convert::Infallible> = None;
 
         let store_opener =
             NodeStorage::opener(home_dir, &near_config.config.store, cold_store_config);


### PR DESCRIPTION
- removing the cold store rust feature because:
  - it's really annoying to add new cold store code 
  - the conditional code is ugly
  - the cold store tests were not running in buildkite
  - development is slow because of need to build and run tests twice, once with and once without cold_store
- changed how opener sets the db kind - it used to be that once cold store is configured the hot store kind would be set to hot. I changed it in line with the migration plan to preserve the hot store kind as archive until migration is over. Sorry for sneaking that change in here but it kind of happened. 
- small changes to the cold store cli
- some cleanup