### PR TITLE
feature: Structured parameters config

### DIFF
--- a/core/primitives-core/src/parameter.rs
+++ b/core/primitives-core/src/parameter.rs
@@ -18,10 +18,8 @@ use crate::config::ActionCosts;
 #[strum(serialize_all = "snake_case")]
 pub enum Parameter {
     // Gas economics config
-    BurntGasRewardNumerator,
-    BurntGasRewardDenominator,
-    PessimisticGasPriceInflationNumerator,
-    PessimisticGasPriceInflationDenominator,
+    BurntGasReward,
+    PessimisticGasPriceInflation,
 
     // Account creation config
     MinAllowedTopLevelAccountLength,

--- a/core/primitives/res/runtime_configs/parameters.yaml
+++ b/core/primitives/res/runtime_configs/parameters.yaml
@@ -3,10 +3,14 @@
 # The diffs are stored in files named `NN.txt`, where `NN` is the version.
 
 # Gas economics config
-burnt_gas_reward_numerator: 3
-burnt_gas_reward_denominator: 10
-pessimistic_gas_price_inflation_numerator: 103
-pessimistic_gas_price_inflation_denominator: 100
+burnt_gas_reward: {
+  numerator: 3,
+  denominator: 10,
+}
+pessimistic_gas_price_inflation: {
+  numerator: 103,
+  denominator: 100,
+}
 
 # Account creation config
 min_allowed_top_level_account_length: 32

--- a/core/primitives/res/runtime_configs/parameters_testnet.yaml
+++ b/core/primitives/res/runtime_configs/parameters_testnet.yaml
@@ -1,8 +1,12 @@
 # Gas economics config
-burnt_gas_reward_numerator: 3
-burnt_gas_reward_denominator: 10
-pessimistic_gas_price_inflation_numerator: 103
-pessimistic_gas_price_inflation_denominator: 100
+burnt_gas_reward: {
+  numerator: 3,
+  denominator: 10,
+}
+pessimistic_gas_price_inflation: {
+  numerator: 103,
+  denominator: 100,
+}
 
 # Account creation config
 min_allowed_top_level_account_length: 0

--- a/core/primitives/src/runtime/parameter_table.rs
+++ b/core/primitives/src/runtime/parameter_table.rs
@@ -431,6 +431,10 @@ min_allowed_top_level_account_length: 32
 storage_amount_per_byte: 100_000_000_000_000_000_000
 storage_num_bytes_account: 100
 storage_num_extra_bytes_record: 40
+burnt_gas_reward: {
+  numerator: 1_000_000,
+  denominator: 300,
+}
 "#;
 
     static BASE_1: &str = r#"
@@ -453,6 +457,10 @@ storage_num_extra_bytes_record   :   40
 registrar_account_id: { old: "registrar", new: "near" }
 min_allowed_top_level_account_length: { old: 32, new: 32_000 }
 wasm_regular_op_cost: { new: 3_856_371 }
+burnt_gas_reward: {
+    old: { numerator: 1_000_000, denominator: 300 },
+    new: { numerator: 2_000_000, denominator: 500 },
+}
 "#;
 
     static DIFF_1: &str = r#"
@@ -461,6 +469,10 @@ registrar_account_id: { old: "near", new: "registrar" }
 storage_num_extra_bytes_record: { old: 40, new: 77 }
 wasm_regular_op_cost: { old: 3_856_371, new: 0 }
 max_memory_pages: { new: 512 }
+burnt_gas_reward: {
+    old: { numerator: 2_000_000, denominator: 500 },
+    new: { numerator: 3_000_000, denominator: 800 },
+}
 "#;
 
     // Tests synthetic small example configurations. For tests with "real"
@@ -485,6 +497,7 @@ max_memory_pages: { new: 512 }
                 (Parameter::StorageAmountPerByte, "\"100000000000000000000\""),
                 (Parameter::StorageNumBytesAccount, "100"),
                 (Parameter::StorageNumExtraBytesRecord, "40"),
+                (Parameter::BurntGasReward, "{ numerator: 1_000_000, denominator: 300 }"),
             ],
         );
     }
@@ -518,6 +531,7 @@ max_memory_pages: { new: 512 }
                 (Parameter::StorageNumBytesAccount, "100"),
                 (Parameter::StorageNumExtraBytesRecord, "40"),
                 (Parameter::WasmRegularOpCost, "3856371"),
+                (Parameter::BurntGasReward, "{ numerator: 2_000_000, denominator: 500 }"),
             ],
         );
     }
@@ -536,6 +550,7 @@ max_memory_pages: { new: 512 }
                 (Parameter::StorageNumExtraBytesRecord, "77"),
                 (Parameter::WasmRegularOpCost, "0"),
                 (Parameter::MaxMemoryPages, "512"),
+                (Parameter::BurntGasReward, "{ numerator: 3_000_000, denominator: 800 }"),
             ],
         );
     }
@@ -552,6 +567,7 @@ max_memory_pages: { new: 512 }
                 (Parameter::StorageAmountPerByte, "\"100000000000000000000\""),
                 (Parameter::StorageNumBytesAccount, "100"),
                 (Parameter::StorageNumExtraBytesRecord, "40"),
+                (Parameter::BurntGasReward, "{ numerator: 1_000_000, denominator: 300 }"),
             ],
         );
     }

--- a/core/primitives/src/runtime/parameter_table.rs
+++ b/core/primitives/src/runtime/parameter_table.rs
@@ -191,6 +191,8 @@ impl ParameterTable {
             if let Some(value) = self.get(*param) {
                 yaml.insert(
                     key.into(),
+                    // All parameter values can be serialized as YAML, so we don't ever expect this
+                    // to fail.
                     serde_yaml::to_value(value.clone())
                         .expect("failed to convert parameter value to YAML"),
                 );
@@ -673,6 +675,34 @@ burnt_gas_reward: {
             InvalidConfigError::NoOldValueExists(Parameter::WasmRegularOpCost, found) => {
                 assert_eq!(found, ParameterValue::U64(3200000));
             }
+        );
+    }
+
+    #[test]
+    fn test_parameter_table_yaml_map() {
+        let params: ParameterTable = BASE_0.parse().unwrap();
+        let yaml = params.yaml_map(
+            [
+                Parameter::RegistrarAccountId,
+                Parameter::MinAllowedTopLevelAccountLength,
+                Parameter::StorageAmountPerByte,
+                Parameter::StorageNumBytesAccount,
+                Parameter::StorageNumExtraBytesRecord,
+                Parameter::BurntGasReward,
+            ]
+            .iter(),
+            "",
+        );
+        assert_eq!(
+            yaml,
+            serde_yaml::to_value(
+                params
+                    .parameters
+                    .iter()
+                    .map(|(key, value)| (key.to_string(), value))
+                    .collect::<Vec<_>>()
+            )
+            .unwrap()
         );
     }
 }

--- a/core/primitives/src/runtime/parameter_table.rs
+++ b/core/primitives/src/runtime/parameter_table.rs
@@ -225,7 +225,7 @@ impl ParameterTable {
         let value = self.parameters.get(&key).ok_or(InvalidConfigError::MissingParameter(key))?;
         let value_u64 = value.get_u64().ok_or(InvalidConfigError::WrongValueType(
             key,
-            std::any::type_name::<u64>(),
+            std::any::type_name::<T>(),
             value.clone(),
         ))?;
         T::try_from(value_u64).map_err(|err| {


### PR DESCRIPTION
This is a part of https://github.com/near/nearcore/issues/8264.

This PR introduces structured values for Rationals in the parameter config in the form
```yaml
burnt_gas_reward: {
  numerator: 3,
  denominator: 10,
}
```

To support this in the code, we now interpret parameter values as one of
```rust
enum ParameterValue {
    Null,
    U64(u64),
    Rational { numerator: isize, denominator: isize },
    String(String),
}
```

In the future the plan is to extend this to support Fee structure and Weighted parameters.

One open Rust-related question here:
- [ ] What is a good way to deduplicate code between `get_number`, `get_string`, `get_rational` methods?

Things to finish:
- [x] Tests for the Rational type