### PR TITLE
fix(pytest): don't rely on log line format in malicious_chain.py

### DIFF
--- a/pytest/tests/adversarial/malicious_chain.py
+++ b/pytest/tests/adversarial/malicious_chain.py
@@ -28,6 +28,13 @@ logger.info(f'Waiting for {BLOCKS} blocks...')
 height, _ = utils.wait_for_blocks(nodes[1], target=BLOCKS)
 logger.info(f'Got to {height} blocks, getting to fun stuff')
 
+# first check that nodes 0 and 2 have two peers each, before we check later that
+# they've dropped to just one peer
+network_info0 = nodes[0].json_rpc('network_info', {})['result']
+network_info2 = nodes[2].json_rpc('network_info', {})['result']
+assert network_info0['num_active_peers'] == 2, network_info0['num_active_peers']
+assert network_info2['num_active_peers'] == 2, network_info2['num_active_peers']
+
 nodes[1].get_status(verbose=True)
 
 res = nodes[1].json_rpc('adv_produce_blocks',

--- a/pytest/tests/adversarial/malicious_chain.py
+++ b/pytest/tests/adversarial/malicious_chain.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# starts two validators and one extra RPC node, and directs one of the validators
+# to produce invalid blocks. Then we check that the other two nodes have banned this peer.
+
 import sys, time
 import pathlib
 
@@ -27,7 +30,6 @@ logger.info(f'Got to {height} blocks, getting to fun stuff')
 
 nodes[1].get_status(verbose=True)
 
-tracker0 = utils.LogTracker(nodes[0])
 res = nodes[1].json_rpc('adv_produce_blocks',
                         [MALICIOUS_BLOCKS, valid_blocks_only])
 assert 'result' in res, res
@@ -39,6 +41,14 @@ height = nodes[0].get_latest_block(verbose=True).height
 
 assert height < 40
 
-assert tracker0.check("Banned(BadBlockHeader)")
+network_info0 = nodes[0].json_rpc('network_info', {})['result']
+network_info2 = nodes[2].json_rpc('network_info', {})['result']
+
+# Since we have 3 nodes, they should all have started with 2 peers. After the above
+# invalid blocks sent by node1, the other two should have banned it, leaving them
+# with one active peer
+
+assert network_info0['num_active_peers'] == 1, network_info0['num_active_peers']
+assert network_info2['num_active_peers'] == 1, network_info2['num_active_peers']
 
 logger.info("Epic")


### PR DESCRIPTION
after having one of the nodes produce invalid blocks, this test checks that the specific string "Banned(BadBlockHeader)" appears in the logs. The format of this log line has changed slightly, so this test fails now. Fix it by checking that the network_info RPC reports only one active peer, instead of grepping the logs