### PR TITLE
refactor: Migrate to Rational32 in parameter config

### DIFF
--- a/core/primitives-core/src/runtime/fees.rs
+++ b/core/primitives-core/src/runtime/fees.rs
@@ -7,7 +7,7 @@ use enum_map::EnumMap;
 use serde::{Deserialize, Serialize};
 
 use crate::config::ActionCosts;
-use crate::num_rational::Rational;
+use crate::num_rational::Rational32;
 use crate::types::{Balance, Gas};
 
 /// Costs associated with an object that can only be sent over the network (and executed
@@ -54,10 +54,10 @@ pub struct RuntimeFeesConfig {
     pub storage_usage_config: StorageUsageConfig,
 
     /// Fraction of the burnt gas to reward to the contract account for execution.
-    pub burnt_gas_reward: Rational,
+    pub burnt_gas_reward: Rational32,
 
     /// Pessimistic gas price inflation ratio.
-    pub pessimistic_gas_price_inflation_ratio: Rational,
+    pub pessimistic_gas_price_inflation_ratio: Rational32,
 }
 
 /// Describes the cost of creating a data receipt, `DataReceipt`.
@@ -145,8 +145,8 @@ impl RuntimeFeesConfig {
     pub fn test() -> Self {
         Self {
             storage_usage_config: StorageUsageConfig::test(),
-            burnt_gas_reward: Rational::new(3, 10),
-            pessimistic_gas_price_inflation_ratio: Rational::new(103, 100),
+            burnt_gas_reward: Rational32::new(3, 10),
+            pessimistic_gas_price_inflation_ratio: Rational32::new(103, 100),
             action_fees: enum_map::enum_map! {
                 ActionCosts::create_account => Fee {
                     send_sir: 99607375000,
@@ -239,8 +239,8 @@ impl RuntimeFeesConfig {
                 _ => Fee { send_sir: 0, send_not_sir: 0, execution: 0 }
             },
             storage_usage_config: StorageUsageConfig::free(),
-            burnt_gas_reward: Rational::from_integer(0),
-            pessimistic_gas_price_inflation_ratio: Rational::from_integer(0),
+            burnt_gas_reward: Rational32::from_integer(0),
+            pessimistic_gas_price_inflation_ratio: Rational32::from_integer(0),
         }
     }
 

--- a/core/primitives/src/runtime/parameter_table.rs
+++ b/core/primitives/src/runtime/parameter_table.rs
@@ -4,7 +4,7 @@ use near_primitives_core::config::{ExtCostsConfig, VMConfig};
 use near_primitives_core::parameter::{FeeParameter, Parameter};
 use near_primitives_core::runtime::fees::{RuntimeFeesConfig, StorageUsageConfig};
 use near_primitives_core::types::AccountId;
-use num_rational::Rational;
+use num_rational::Rational32;
 use std::collections::BTreeMap;
 
 /// Represents values supported by parameter config.
@@ -12,7 +12,7 @@ use std::collections::BTreeMap;
 #[serde(untagged)]
 pub(crate) enum ParameterValue {
     U64(u64),
-    Rational { numerator: isize, denominator: isize },
+    Rational { numerator: i32, denominator: i32 },
     String(String),
 }
 
@@ -24,10 +24,10 @@ impl ParameterValue {
         }
     }
 
-    fn as_rational(&self) -> Option<Rational> {
+    fn as_rational(&self) -> Option<Rational32> {
         match self {
             ParameterValue::Rational { numerator, denominator } => {
-                Some(Rational::new(*numerator, *denominator))
+                Some(Rational32::new(*numerator, *denominator))
             }
             _ => None,
         }
@@ -263,11 +263,11 @@ impl ParameterTable {
     }
 
     /// Read and parse a rational parameter from the `ParameterTable`.
-    fn get_rational(&self, key: Parameter) -> Result<Rational, InvalidConfigError> {
+    fn get_rational(&self, key: Parameter) -> Result<Rational32, InvalidConfigError> {
         let value = self.parameters.get(&key).ok_or(InvalidConfigError::MissingParameter(key))?;
         value.as_rational().ok_or(InvalidConfigError::WrongValueType(
             key,
-            std::any::type_name::<Rational>(),
+            std::any::type_name::<Rational32>(),
             value.clone(),
         ))
     }

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -12,7 +12,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use chrono::DateTime;
 use near_primitives_core::config::{ActionCosts, ExtCosts, VMConfig};
 use near_primitives_core::runtime::fees::Fee;
-use num_rational::Rational;
+use num_rational::Rational32;
 use serde::{Deserialize, Serialize};
 
 use near_crypto::{PublicKey, Signature};
@@ -2066,10 +2066,10 @@ pub struct RuntimeFeesConfigView {
     pub storage_usage_config: StorageUsageConfigView,
 
     /// Fraction of the burnt gas to reward to the contract account for execution.
-    pub burnt_gas_reward: Rational,
+    pub burnt_gas_reward: Rational32,
 
     /// Pessimistic gas price inflation ratio.
-    pub pessimistic_gas_price_inflation_ratio: Rational,
+    pub pessimistic_gas_price_inflation_ratio: Rational32,
 }
 
 /// The structure describes configuration for creation of new accounts.

--- a/runtime/runtime/src/config.rs
+++ b/runtime/runtime/src/config.rs
@@ -8,7 +8,7 @@ use num_traits::pow::Pow;
 use near_primitives::account::AccessKeyPermission;
 use near_primitives::errors::IntegerOverflowError;
 // Just re-exporting RuntimeConfig for backwards compatibility.
-pub use near_primitives::num_rational::Rational;
+pub use near_primitives::num_rational::Rational32;
 pub use near_primitives::runtime::config::RuntimeConfig;
 use near_primitives::runtime::fees::{transfer_exec_fee, transfer_send_fee, RuntimeFeesConfig};
 use near_primitives::transaction::{
@@ -37,7 +37,7 @@ pub struct TransactionCost {
 /// Multiplies `gas_price` by the power of `inflation_base` with exponent `inflation_exponent`.
 pub fn safe_gas_price_inflated(
     gas_price: Balance,
-    inflation_base: Rational,
+    inflation_base: Rational32,
     inflation_exponent: u8,
 ) -> Result<Balance, IntegerOverflowError> {
     let numer = BigUint::from(*inflation_base.numer() as usize).pow(inflation_exponent as u32);
@@ -400,10 +400,10 @@ mod tests {
 
     #[test]
     fn test_safe_gas_price_inflated() {
-        assert_eq!(safe_gas_price_inflated(10000, Rational::new(101, 100), 1).unwrap(), 10100);
-        assert_eq!(safe_gas_price_inflated(10000, Rational::new(101, 100), 2).unwrap(), 10201);
+        assert_eq!(safe_gas_price_inflated(10000, Rational32::new(101, 100), 1).unwrap(), 10100);
+        assert_eq!(safe_gas_price_inflated(10000, Rational32::new(101, 100), 2).unwrap(), 10201);
         // Rounded up
-        assert_eq!(safe_gas_price_inflated(10000, Rational::new(101, 100), 3).unwrap(), 10304);
-        assert_eq!(safe_gas_price_inflated(10000, Rational::new(101, 100), 32).unwrap(), 13750);
+        assert_eq!(safe_gas_price_inflated(10000, Rational32::new(101, 100), 3).unwrap(), 10304);
+        assert_eq!(safe_gas_price_inflated(10000, Rational32::new(101, 100), 32).unwrap(), 13750);
     }
 }

--- a/runtime/runtime/tests/runtime_group_tools/random_config.rs
+++ b/runtime/runtime/tests/runtime_group_tools/random_config.rs
@@ -1,4 +1,4 @@
-use near_primitives::num_rational::Rational;
+use near_primitives::num_rational::Rational32;
 use near_primitives::runtime::config::RuntimeConfig;
 use near_primitives::runtime::fees::{Fee, RuntimeFeesConfig, StorageUsageConfig};
 use rand::{thread_rng, RngCore};
@@ -20,8 +20,8 @@ pub fn random_config() -> RuntimeConfig {
                 num_extra_bytes_record: rng.next_u64() % 10000,
                 storage_amount_per_byte: rng.next_u64() as u128,
             },
-            burnt_gas_reward: Rational::new((rng.next_u32() % 100).try_into().unwrap(), 100),
-            pessimistic_gas_price_inflation_ratio: Rational::new(
+            burnt_gas_reward: Rational32::new((rng.next_u32() % 100).try_into().unwrap(), 100),
+            pessimistic_gas_price_inflation_ratio: Rational32::new(
                 (101 + rng.next_u32() % 10).try_into().unwrap(),
                 100,
             ),


### PR DESCRIPTION
As `Rational` uses `isize` that is platform specific which might lead to different behavior on different machines.