### PR TITLE
demo: reproduce clippy::integer_arithmetic issue with arbitrary::Arbitrary

### DIFF
--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -1,3 +1,4 @@
+#![deny(clippy::integer_arithmetic)]
 use borsh::{BorshDeserialize, BorshSerialize};
 use derive_more::{AsRef as DeriveAsRef, From as DeriveFrom};
 use once_cell::sync::Lazy;


### PR DESCRIPTION
Unfixable issue from `#[derive(arbitrary::Arbitrary)]`

`./scripts/run_clippy.sh `
```
error: integer arithmetic detected
   --> core/primitives/src/types.rs:795:63
    |
795 | #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, arbitrary::Arbitrary)]
    |                                                               ^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#integer_arithmetic
    = note: this error originates in the derive macro `arbitrary::Arbitrary` (in Nightly builds, run with -Z macro-backtrace for more info)
```