### PR TITLE
fix: disable integration tests that are broken on mac

### DIFF
--- a/integration-tests/src/tests/client/features/wasmer2.rs
+++ b/integration-tests/src/tests/client/features/wasmer2.rs
@@ -1,84 +1,88 @@
-use crate::tests::client::process_blocks::{create_nightshade_runtimes, deploy_test_contract};
-use near_chain::ChainGenesis;
-use near_chain_configs::Genesis;
-use near_client::test_utils::TestEnv;
-use near_crypto::{InMemorySigner, KeyType, Signer};
-use near_primitives::hash::CryptoHash;
-use near_primitives::transaction::{Action, FunctionCallAction, Transaction};
-use nearcore::config::GenesisExt;
+#[cfg(all(feature = "wasmer0_vm", feature = "wasmer2_vm"))]
+mod test_wasmer2_upgrade {
+    use crate::tests::client::process_blocks::{create_nightshade_runtimes, deploy_test_contract};
+    use near_chain::ChainGenesis;
+    use near_chain_configs::Genesis;
+    use near_client::test_utils::TestEnv;
+    use near_crypto::{InMemorySigner, KeyType, Signer};
+    use near_primitives::hash::CryptoHash;
+    use near_primitives::transaction::{Action, FunctionCallAction, Transaction};
+    use nearcore::config::GenesisExt;
 
-#[test]
-fn test_wasmer2_upgrade() {
-    let mut capture = near_o11y::testonly::TracingCapture::enable();
+    #[test]
+    fn test_wasmer2_upgrade() {
+        let mut capture = near_o11y::testonly::TracingCapture::enable();
 
-    let old_protocol_version =
-        near_primitives::version::ProtocolFeature::Wasmer2.protocol_version() - 1;
-    let new_protocol_version = old_protocol_version + 1;
+        let old_protocol_version =
+            near_primitives::version::ProtocolFeature::Wasmer2.protocol_version() - 1;
+        let new_protocol_version = old_protocol_version + 1;
 
-    // Prepare TestEnv with a contract at the old protocol version.
-    let mut env = {
-        let epoch_length = 5;
-        let mut genesis =
-            Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
-        genesis.config.epoch_length = epoch_length;
-        genesis.config.protocol_version = old_protocol_version;
-        let chain_genesis = ChainGenesis::new(&genesis);
-        let mut env = TestEnv::builder(chain_genesis)
-            .runtime_adapters(create_nightshade_runtimes(&genesis, 1))
-            .build();
+        // Prepare TestEnv with a contract at the old protocol version.
+        let mut env = {
+            let epoch_length = 5;
+            let mut genesis =
+                Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+            genesis.config.epoch_length = epoch_length;
+            genesis.config.protocol_version = old_protocol_version;
+            let chain_genesis = ChainGenesis::new(&genesis);
+            let mut env = TestEnv::builder(chain_genesis)
+                .runtime_adapters(create_nightshade_runtimes(&genesis, 1))
+                .build();
 
-        deploy_test_contract(
-            &mut env,
-            "test0".parse().unwrap(),
-            near_test_contracts::rs_contract(),
-            epoch_length,
-            1,
-        );
-        env
-    };
+            deploy_test_contract(
+                &mut env,
+                "test0".parse().unwrap(),
+                near_test_contracts::rs_contract(),
+                epoch_length,
+                1,
+            );
+            env
+        };
 
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
-    let tx = Transaction {
-        signer_id: "test0".parse().unwrap(),
-        receiver_id: "test0".parse().unwrap(),
-        public_key: signer.public_key(),
-        actions: vec![Action::FunctionCall(FunctionCallAction {
-            method_name: "log_something".to_string(),
-            args: Vec::new(),
-            gas: 100_000_000_000_000,
-            deposit: 0,
-        })],
+        let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+        let tx = Transaction {
+            signer_id: "test0".parse().unwrap(),
+            receiver_id: "test0".parse().unwrap(),
+            public_key: signer.public_key(),
+            actions: vec![Action::FunctionCall(FunctionCallAction {
+                method_name: "log_something".to_string(),
+                args: Vec::new(),
+                gas: 100_000_000_000_000,
+                deposit: 0,
+            })],
 
-        nonce: 0,
-        block_hash: CryptoHash::default(),
-    };
+            nonce: 0,
+            block_hash: CryptoHash::default(),
+        };
 
-    // Run the transaction & collect the logs.
-    let logs_at_old_version = {
-        let tip = env.clients[0].chain.head().unwrap();
-        let signed_transaction =
-            Transaction { nonce: 10, block_hash: tip.last_block_hash, ..tx.clone() }.sign(&signer);
-        env.clients[0].process_tx(signed_transaction, false, false);
-        for i in 0..3 {
-            env.produce_block(0, tip.height + i + 1);
-        }
-        capture.drain()
-    };
+        // Run the transaction & collect the logs.
+        let logs_at_old_version = {
+            let tip = env.clients[0].chain.head().unwrap();
+            let signed_transaction =
+                Transaction { nonce: 10, block_hash: tip.last_block_hash, ..tx.clone() }
+                    .sign(&signer);
+            env.clients[0].process_tx(signed_transaction, false, false);
+            for i in 0..3 {
+                env.produce_block(0, tip.height + i + 1);
+            }
+            capture.drain()
+        };
 
-    env.upgrade_protocol(new_protocol_version);
+        env.upgrade_protocol(new_protocol_version);
 
-    // Re-run the transaction.
-    let logs_at_new_version = {
-        let tip = env.clients[0].chain.head().unwrap();
-        let signed_transaction =
-            Transaction { nonce: 11, block_hash: tip.last_block_hash, ..tx }.sign(&signer);
-        env.clients[0].process_tx(signed_transaction, false, false);
-        for i in 0..3 {
-            env.produce_block(0, tip.height + i + 1);
-        }
-        capture.drain()
-    };
+        // Re-run the transaction.
+        let logs_at_new_version = {
+            let tip = env.clients[0].chain.head().unwrap();
+            let signed_transaction =
+                Transaction { nonce: 11, block_hash: tip.last_block_hash, ..tx }.sign(&signer);
+            env.clients[0].process_tx(signed_transaction, false, false);
+            for i in 0..3 {
+                env.produce_block(0, tip.height + i + 1);
+            }
+            capture.drain()
+        };
 
-    assert!(logs_at_old_version.iter().any(|l| l.contains(&"vm_kind=Wasmer0")));
-    assert!(logs_at_new_version.iter().any(|l| l.contains(&"vm_kind=Wasmer2")));
+        assert!(logs_at_old_version.iter().any(|l| l.contains(&"vm_kind=Wasmer0")));
+        assert!(logs_at_new_version.iter().any(|l| l.contains(&"vm_kind=Wasmer2")));
+    }
 }

--- a/integration-tests/src/tests/client/features/wasmer2.rs
+++ b/integration-tests/src/tests/client/features/wasmer2.rs
@@ -1,89 +1,86 @@
+use crate::tests::client::process_blocks::{create_nightshade_runtimes, deploy_test_contract};
+use near_chain::ChainGenesis;
+use near_chain_configs::Genesis;
+use near_client::test_utils::TestEnv;
+use near_crypto::{InMemorySigner, KeyType, Signer};
+use near_primitives::hash::CryptoHash;
+use near_primitives::transaction::{Action, FunctionCallAction, Transaction};
+use nearcore::config::GenesisExt;
+
 // This test fails on aarch because wasmer0 and wasmer2 are not available.
-#[cfg(not(all(target_arch = "aarch64", target_vendor = "apple")))]
-mod test_wasmer2_upgrade {
-    use crate::tests::client::process_blocks::{create_nightshade_runtimes, deploy_test_contract};
-    use near_chain::ChainGenesis;
-    use near_chain_configs::Genesis;
-    use near_client::test_utils::TestEnv;
-    use near_crypto::{InMemorySigner, KeyType, Signer};
-    use near_primitives::hash::CryptoHash;
-    use near_primitives::transaction::{Action, FunctionCallAction, Transaction};
-    use nearcore::config::GenesisExt;
+#[cfg_attr(all(target_arch = "aarch64", target_vendor = "apple"), ignore)]
+#[test]
+fn test_wasmer2_upgrade() {
+    let mut capture = near_o11y::testonly::TracingCapture::enable();
 
-    #[test]
-    fn test_wasmer2_upgrade() {
-        let mut capture = near_o11y::testonly::TracingCapture::enable();
+    let old_protocol_version =
+        near_primitives::version::ProtocolFeature::Wasmer2.protocol_version() - 1;
+    let new_protocol_version = old_protocol_version + 1;
 
-        let old_protocol_version =
-            near_primitives::version::ProtocolFeature::Wasmer2.protocol_version() - 1;
-        let new_protocol_version = old_protocol_version + 1;
+    // Prepare TestEnv with a contract at the old protocol version.
+    let mut env = {
+        let epoch_length = 5;
+        let mut genesis =
+            Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+        genesis.config.epoch_length = epoch_length;
+        genesis.config.protocol_version = old_protocol_version;
+        let chain_genesis = ChainGenesis::new(&genesis);
+        let mut env = TestEnv::builder(chain_genesis)
+            .runtime_adapters(create_nightshade_runtimes(&genesis, 1))
+            .build();
 
-        // Prepare TestEnv with a contract at the old protocol version.
-        let mut env = {
-            let epoch_length = 5;
-            let mut genesis =
-                Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
-            genesis.config.epoch_length = epoch_length;
-            genesis.config.protocol_version = old_protocol_version;
-            let chain_genesis = ChainGenesis::new(&genesis);
-            let mut env = TestEnv::builder(chain_genesis)
-                .runtime_adapters(create_nightshade_runtimes(&genesis, 1))
-                .build();
+        deploy_test_contract(
+            &mut env,
+            "test0".parse().unwrap(),
+            near_test_contracts::rs_contract(),
+            epoch_length,
+            1,
+        );
+        env
+    };
 
-            deploy_test_contract(
-                &mut env,
-                "test0".parse().unwrap(),
-                near_test_contracts::rs_contract(),
-                epoch_length,
-                1,
-            );
-            env
-        };
+    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let tx = Transaction {
+        signer_id: "test0".parse().unwrap(),
+        receiver_id: "test0".parse().unwrap(),
+        public_key: signer.public_key(),
+        actions: vec![Action::FunctionCall(FunctionCallAction {
+            method_name: "log_something".to_string(),
+            args: Vec::new(),
+            gas: 100_000_000_000_000,
+            deposit: 0,
+        })],
 
-        let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
-        let tx = Transaction {
-            signer_id: "test0".parse().unwrap(),
-            receiver_id: "test0".parse().unwrap(),
-            public_key: signer.public_key(),
-            actions: vec![Action::FunctionCall(FunctionCallAction {
-                method_name: "log_something".to_string(),
-                args: Vec::new(),
-                gas: 100_000_000_000_000,
-                deposit: 0,
-            })],
+        nonce: 0,
+        block_hash: CryptoHash::default(),
+    };
 
-            nonce: 0,
-            block_hash: CryptoHash::default(),
-        };
+    // Run the transaction & collect the logs.
+    let logs_at_old_version = {
+        let tip = env.clients[0].chain.head().unwrap();
+        let signed_transaction =
+            Transaction { nonce: 10, block_hash: tip.last_block_hash, ..tx.clone() }.sign(&signer);
+        env.clients[0].process_tx(signed_transaction, false, false);
+        for i in 0..3 {
+            env.produce_block(0, tip.height + i + 1);
+        }
+        capture.drain()
+    };
 
-        // Run the transaction & collect the logs.
-        let logs_at_old_version = {
-            let tip = env.clients[0].chain.head().unwrap();
-            let signed_transaction =
-                Transaction { nonce: 10, block_hash: tip.last_block_hash, ..tx.clone() }
-                    .sign(&signer);
-            env.clients[0].process_tx(signed_transaction, false, false);
-            for i in 0..3 {
-                env.produce_block(0, tip.height + i + 1);
-            }
-            capture.drain()
-        };
+    env.upgrade_protocol(new_protocol_version);
 
-        env.upgrade_protocol(new_protocol_version);
+    // Re-run the transaction.
+    let logs_at_new_version = {
+        let tip = env.clients[0].chain.head().unwrap();
+        let signed_transaction =
+            Transaction { nonce: 11, block_hash: tip.last_block_hash, ..tx }.sign(&signer);
+        env.clients[0].process_tx(signed_transaction, false, false);
+        for i in 0..3 {
+            env.produce_block(0, tip.height + i + 1);
+        }
+        capture.drain()
+    };
 
-        // Re-run the transaction.
-        let logs_at_new_version = {
-            let tip = env.clients[0].chain.head().unwrap();
-            let signed_transaction =
-                Transaction { nonce: 11, block_hash: tip.last_block_hash, ..tx }.sign(&signer);
-            env.clients[0].process_tx(signed_transaction, false, false);
-            for i in 0..3 {
-                env.produce_block(0, tip.height + i + 1);
-            }
-            capture.drain()
-        };
-
-        assert!(logs_at_old_version.iter().any(|l| l.contains(&"vm_kind=Wasmer0")));
-        assert!(logs_at_new_version.iter().any(|l| l.contains(&"vm_kind=Wasmer2")));
-    }
+    assert!(logs_at_old_version.iter().any(|l| l.contains(&"vm_kind=Wasmer0")));
+    assert!(logs_at_new_version.iter().any(|l| l.contains(&"vm_kind=Wasmer2")));
 }

--- a/integration-tests/src/tests/client/features/wasmer2.rs
+++ b/integration-tests/src/tests/client/features/wasmer2.rs
@@ -1,4 +1,5 @@
-#[cfg(all(feature = "wasmer0_vm", feature = "wasmer2_vm"))]
+// This test fails on aarch because wasmer0 and wasmer2 are not available.
+#[cfg(not(all(target_arch = "aarch64", target_vendor = "apple")))]
 mod test_wasmer2_upgrade {
     use crate::tests::client::process_blocks::{create_nightshade_runtimes, deploy_test_contract};
     use near_chain::ChainGenesis;

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -3475,7 +3475,6 @@ fn test_catchup_no_sharding_change() {
 
 /// These tests fail on aarch because the WasmtimeVM::precompile method doesn't populate the cache.
 #[cfg(not(all(target_arch = "aarch64", target_vendor = "apple")))]
-
 mod contract_precompilation_tests {
     use super::*;
     use near_primitives::contract::ContractCode;

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -3474,7 +3474,6 @@ fn test_catchup_no_sharding_change() {
 }
 
 /// These tests fail on aarch because the WasmtimeVM::precompile method doesn't populate the cache.
-#[cfg(not(all(target_arch = "aarch64", target_vendor = "apple")))]
 mod contract_precompilation_tests {
     use super::*;
     use near_primitives::contract::ContractCode;
@@ -3513,6 +3512,7 @@ mod contract_precompilation_tests {
     }
 
     #[test]
+    #[cfg_attr(all(target_arch = "aarch64", target_vendor = "apple"), ignore)]
     fn test_sync_and_call_cached_contract() {
         let num_clients = 2;
         let stores: Vec<Store> = (0..num_clients).map(|_| create_test_store()).collect();
@@ -3615,6 +3615,7 @@ mod contract_precompilation_tests {
     }
 
     #[test]
+    #[cfg_attr(all(target_arch = "aarch64", target_vendor = "apple"), ignore)]
     fn test_two_deployments() {
         let num_clients = 2;
         let stores: Vec<Store> = (0..num_clients).map(|_| create_test_store()).collect();
@@ -3696,6 +3697,7 @@ mod contract_precompilation_tests {
     }
 
     #[test]
+    #[cfg_attr(all(target_arch = "aarch64", target_vendor = "apple"), ignore)]
     fn test_sync_after_delete_account() {
         let num_clients = 3;
         let stores: Vec<Store> = (0..num_clients).map(|_| create_test_store()).collect();

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -3473,6 +3473,9 @@ fn test_catchup_no_sharding_change() {
     }
 }
 
+/// These tests fail on aarch because the WasmtimeVM::precompile method doesn't populate the cache.
+#[cfg(not(all(target_arch = "aarch64", target_vendor = "apple")))]
+
 mod contract_precompilation_tests {
     use super::*;
     use near_primitives::contract::ContractCode;


### PR DESCRIPTION
I made two types of tests conditionally compiled to exclude them from running on macbooks - because they don't work on macs anyway. 

- test_two_deployments 
The test relies on the contract cache to be populated but the precompile method of the wasmtime runner doesn’t populate the cache
- test_wasmer2_upgrade 
The test checks transition from wasmer0 to wasmer2 but wasmer0 and wasmer2 are not available on macs
