### PR TITLE
feat: better `Serializer` for `MutableConfigValue`

### DIFF
--- a/chain/jsonrpc-primitives/src/types/client_config.rs
+++ b/chain/jsonrpc-primitives/src/types/client_config.rs
@@ -1,10 +1,7 @@
 use serde::Serialize;
 use serde_json::Value;
 
-#[derive(Serialize, Debug)]
-pub struct RpcClientConfigRequest {}
-
-#[derive(Serialize, Debug)]
+#[derive(Serialize)]
 pub struct RpcClientConfigResponse {
     #[serde(flatten)]
     pub client_config: near_chain_configs::ClientConfig,

--- a/chain/jsonrpc-primitives/src/types/client_config.rs
+++ b/chain/jsonrpc-primitives/src/types/client_config.rs
@@ -1,16 +1,16 @@
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use serde_json::Value;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Debug)]
 pub struct RpcClientConfigRequest {}
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Debug)]
 pub struct RpcClientConfigResponse {
     #[serde(flatten)]
     pub client_config: near_chain_configs::ClientConfig,
 }
 
-#[derive(thiserror::Error, Debug, Serialize, Deserialize)]
+#[derive(thiserror::Error, Debug, Serialize)]
 #[serde(tag = "name", content = "info", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum RpcClientConfigError {
     #[error("The node reached its limits. Try again later. More details: {error_message}")]

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -74,7 +74,7 @@ impl GCConfig {
 }
 
 /// ClientConfig where some fields can be updated at runtime.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct ClientConfig {
     /// Version of the binary.
     pub version: Version,

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -74,7 +74,7 @@ impl GCConfig {
 }
 
 /// ClientConfig where some fields can be updated at runtime.
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Serialize)]
 pub struct ClientConfig {
     /// Version of the binary.
     pub version: Version,

--- a/core/chain-configs/src/updateable_config.rs
+++ b/core/chain-configs/src/updateable_config.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex};
 /// When initializing sub-objects (e.g. `ShardsManager`), please make sure to
 /// pass this wrapper instead of passing a value from a single moment in time.
 /// See `expected_shutdown` for an example how to use it.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct MutableConfigValue<T> {
     value: Arc<Mutex<T>>,
     // For metrics.

--- a/core/chain-configs/src/updateable_config.rs
+++ b/core/chain-configs/src/updateable_config.rs
@@ -2,7 +2,7 @@ use crate::metrics;
 use chrono::{DateTime, Utc};
 use near_primitives::time::Clock;
 use near_primitives::types::BlockHeight;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 use std::fmt::Debug;
 use std::sync::{Arc, Mutex};
 
@@ -10,8 +10,7 @@ use std::sync::{Arc, Mutex};
 /// When initializing sub-objects (e.g. `ShardsManager`), please make sure to
 /// pass this wrapper instead of passing a value from a single moment in time.
 /// See `expected_shutdown` for an example how to use it.
-/// TODO: custom implementation for Serialize and Deserialize s.t. only value is necessary(JIRA:ND-283)
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct MutableConfigValue<T> {
     value: Arc<Mutex<T>>,
     // For metrics.
@@ -20,6 +19,19 @@ pub struct MutableConfigValue<T> {
     // For metrics.
     // Mutable config values are exported to prometheus with labels [field_name][last_update][value].
     last_update: DateTime<Utc>,
+}
+
+impl<T: Serialize> Serialize for MutableConfigValue<T> {
+    /// Only include the value field of MutableConfigValue in serialized result
+    /// since field_name and last_update are only relevant for internal monitoring
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let to_string_result = serde_json::to_string(&self.value);
+        let value_str = to_string_result.unwrap_or("unable to serialize the value".to_string());
+        serializer.serialize_str(&value_str)
+    }
 }
 
 impl<T: Copy + PartialEq + Debug> MutableConfigValue<T> {

--- a/core/chain-configs/src/updateable_config.rs
+++ b/core/chain-configs/src/updateable_config.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex};
 /// When initializing sub-objects (e.g. `ShardsManager`), please make sure to
 /// pass this wrapper instead of passing a value from a single moment in time.
 /// See `expected_shutdown` for an example how to use it.
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug)]
 pub struct MutableConfigValue<T> {
     value: Arc<Mutex<T>>,
     // For metrics.


### PR DESCRIPTION
When we enable dynamically config, we use a MutableConfigValue type to represent the mutable fields. 
Only value field is valuable to end users. This PR aims to only show MutableConfigValue.value to users and hide the other 2 fields.
For example, if you navigate to /debug/client_config, and look at the field `expected_shutdown`, this PR should show 
`"expected_shutdown": "null"`
instead of 
`"expected_shutdown: "expected_shutdown":{"value":null,"field_name":"expected_shutdown","last_update":"2023-01-23T19:26:43.817152Z"}`


