### PR TITLE
Rollforward "deprecating AnnounceAccount (#8182)"

### DIFF
--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -474,11 +474,11 @@ impl NetworkState {
         msg: RoutedMessageBody,
     ) -> bool {
         let mut success = false;
+        let accounts_data = self.accounts_data.load();
         // All TIER1 messages are being sent over both TIER1 and TIER2 connections for now,
         // so that we can actually observe the latency/reliability improvements in practice:
         // for each message we track over which network tier it arrived faster?
         if tcp::Tier::T1.is_allowed_routed(&msg) {
-            let accounts_data = self.accounts_data.load();
             for key in accounts_data.keys_by_id.get(account_id).iter().flat_map(|keys| keys.iter())
             {
                 let data = match accounts_data.data.get(key) {
@@ -503,19 +503,34 @@ impl NetworkState {
             }
         }
 
-        let target = match self.graph.routing_table.account_owner(account_id) {
-            Some(peer_id) => peer_id,
-            None => {
-                // TODO(MarX, #1369): Message is dropped here. Define policy for this case.
-                metrics::MessageDropped::UnknownAccount.inc(&msg);
-                tracing::debug!(target: "network",
-                       account_id = ?self.config.validator.as_ref().map(|v|v.account_id()),
-                       to = ?account_id,
-                       ?msg,"Drop message: unknown account",
-                );
-                tracing::trace!(target: "network", known_peers = ?self.graph.routing_table.get_accounts_keys(), "Known peers");
-                return false;
-            }
+        let peer_id_from_account_data = accounts_data
+            .keys_by_id
+            .get(account_id)
+            .iter()
+            .flat_map(|keys| keys.iter())
+            .flat_map(|key| accounts_data.data.get(key))
+            .next()
+            .map(|data| data.peer_id.clone());
+        // Find the target peer_id:
+        // - first look it up in self.accounts_data
+        // - if missing, fall back to lookup in self.graph.routing_table
+        // We want to deprecate self.graph.routing_table.account_owner in the next release.
+        let target = if let Some(peer_id) = peer_id_from_account_data {
+            metrics::ACCOUNT_TO_PEER_LOOKUPS.with_label_values(&["AccountData"]).inc();
+            peer_id
+        } else if let Some(peer_id) = self.graph.routing_table.account_owner(account_id) {
+            metrics::ACCOUNT_TO_PEER_LOOKUPS.with_label_values(&["AnnounceAccount"]).inc();
+            peer_id
+        } else {
+            // TODO(MarX, #1369): Message is dropped here. Define policy for this case.
+            metrics::MessageDropped::UnknownAccount.inc(&msg);
+            tracing::debug!(target: "network",
+                   account_id = ?self.config.validator.as_ref().map(|v|v.account_id()),
+                   to = ?account_id,
+                   ?msg,"Drop message: unknown account",
+            );
+            tracing::trace!(target: "network", known_peers = ?self.graph.routing_table.get_accounts_keys(), "Known peers");
+            return false;
         };
 
         let msg = RawRoutedMessage { target: PeerIdOrHash::PeerId(target), body: msg };

--- a/chain/network/src/peer_manager/tests/routing.rs
+++ b/chain/network/src/peer_manager/tests/routing.rs
@@ -874,7 +874,7 @@ async fn max_num_peers_limit() {
     drop(pm3);
 }
 
-// test that TTL is handled property.
+/// Test that TTL is handled properly.
 #[tokio::test]
 async fn ttl() {
     init_test_logger();
@@ -928,8 +928,8 @@ async fn ttl() {
     }
 }
 
-// After the initial exchange, all subsequent SyncRoutingTable messages are
-// expected to contain only the diff of the known data.
+/// After the initial exchange, all subsequent SyncRoutingTable messages are
+/// expected to contain only the diff of the known data.
 #[tokio::test]
 async fn repeated_data_in_sync_routing_table() {
     init_test_logger();

--- a/chain/network/src/stats/metrics.rs
+++ b/chain/network/src/stats/metrics.rs
@@ -358,6 +358,19 @@ pub(crate) static ALREADY_CONNECTED_ACCOUNT: Lazy<IntCounter> = Lazy::new(|| {
     .unwrap()
 });
 
+pub(crate) static ACCOUNT_TO_PEER_LOOKUPS: Lazy<IntCounterVec> = Lazy::new(|| {
+    try_create_int_counter_vec(
+        "near_account_to_peer_lookups",
+        "number of lookups of peer_id by account_id (for routed messages)",
+        // Source is either "AnnounceAccount" or "AccountData".
+        // We want to deprecate AnnounceAccount, so eventually we want all
+        // lookups to be done via AccountData. For now AnnounceAccount is
+        // used as a fallback.
+        &["source"],
+    )
+    .unwrap()
+});
+
 /// Updated the prometheus metrics about the received routed message `msg`.
 /// `tier` indicates the network over which the message was transmitted.
 /// `fastest` indicates whether this message is the first copy of `msg` received -


### PR DESCRIPTION
This is a roll forward of near/nearcore#8182 ,
which was reverted by near/nearcore#8314 .

The issue that #8182 caused has been fixed in https://github.com/near/nearcore/pull/8407 .
nayduck run: https://nayduck.near.org/#/run/2834
before the fix tests/sanity/switch_node_key.py was failing, now it succeeds.
No nayduck tests are newly failing with this PR, compared to master.