### PR TITLE
fix: make save_trie_changes an option and default it correctly

### DIFF
--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -361,9 +361,10 @@ pub struct ChainStore {
     block_ordinal_to_hash: CellLruCache<Vec<u8>, CryptoHash>,
     /// Processed block heights.
     processed_block_heights: CellLruCache<Vec<u8>, ()>,
-    /// Should this node store trie changes? Must be set to true if either of the following is true
-    /// - archive is false - non archival nodes need trie changes for garbage collection
-    /// - the node will be migrated to split storage in the near future - split storage nodes need trie changes for hot storage garbage collection
+    /// save_trie_changes should be set to true iff
+    /// - archive if false - non-archival nodes need trie changes to perform garbage collection
+    /// - archive is true, cold_store is configured and migration to split_storage is finished - node
+    /// working in split storage mode needs trie changes in order to do garbage collection on hot.
     save_trie_changes: bool,
 }
 

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -198,7 +198,7 @@ impl Client {
             DoomslugThresholdMode::NoApprovals
         };
         let chain_config = ChainConfig {
-            save_trie_changes: !config.archive,
+            save_trie_changes: config.save_trie_changes,
             background_migration_threads: config.client_background_migration_threads,
         };
         let chain = Chain::new(

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -148,9 +148,10 @@ pub struct ClientConfig {
     pub tracked_shards: Vec<ShardId>,
     /// Not clear old data, set `true` for archive nodes.
     pub archive: bool,
-    /// Save trie changes. Must be set to true if either of the following is true
-    /// - archive is false - non archival nodes need trie changes for garbage collection
-    /// - the node will be migrated to split storage in the near future - split storage nodes need trie changes for hot storage garbage collection
+    /// save_trie_changes should be set to true iff
+    /// - archive if false - non-archivale nodes need trie changes to perform garbage collection
+    /// - archive is true, cold_store is configured and migration to split_storage is finished - node
+    /// working in split storage mode needs trie changes in order to do garbage collection on hot.
     pub save_trie_changes: bool,
     /// Number of threads for ViewClientActor pool.
     pub view_client_threads: usize,

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -311,6 +311,12 @@ pub struct Config {
     pub tracked_shards: Vec<ShardId>,
     #[serde(skip_serializing_if = "is_false")]
     pub archive: bool,
+    /// If save_trie_changes is not set it will get inferred from the `archive` field as follows:
+    /// save_trie_changes = !archive
+    /// save_trie_changes should be set to true iff
+    /// - archive if false - non-archival nodes need trie changes to perform garbage collection
+    /// - archive is true, cold_store is configured and migration to split_storage is finished - node
+    /// working in split storage mode needs trie changes in order to do garbage collection on hot.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub save_trie_changes: Option<bool>,
     pub log_summary_style: LogSummaryStyle,

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -311,7 +311,8 @@ pub struct Config {
     pub tracked_shards: Vec<ShardId>,
     #[serde(skip_serializing_if = "is_false")]
     pub archive: bool,
-    pub save_trie_changes: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub save_trie_changes: Option<bool>,
     pub log_summary_style: LogSummaryStyle,
     /// Garbage collection configuration.
     #[serde(default, flatten)]
@@ -369,7 +370,7 @@ impl Default for Config {
             tracked_accounts: vec![],
             tracked_shards: vec![],
             archive: false,
-            save_trie_changes: true,
+            save_trie_changes: None,
             log_summary_style: LogSummaryStyle::Colored,
             gc: GCConfig::default(),
             epoch_sync_enabled: true,
@@ -427,7 +428,7 @@ impl Config {
     /// This is the place to check that all config values make sense and fit well together.
     /// `validate()` is called every time `config.json` is read.
     fn validate(&self) -> Result<(), ConfigValidationError> {
-        if !self.archive && !self.save_trie_changes {
+        if self.archive == false && self.save_trie_changes == Some(false) {
             Err(ConfigValidationError::TrieChanges)
         } else {
             Ok(())
@@ -624,7 +625,7 @@ impl NearConfig {
                 tracked_accounts: config.tracked_accounts,
                 tracked_shards: config.tracked_shards,
                 archive: config.archive,
-                save_trie_changes: config.save_trie_changes,
+                save_trie_changes: config.save_trie_changes.unwrap_or(!config.archive),
                 log_summary_style: config.log_summary_style,
                 gc: config.gc,
                 view_client_threads: config.view_client_threads,


### PR DESCRIPTION
full context in https://pagodaplatform.atlassian.net/browse/ND-284 

Making the save_trie_changes a Option<bool> and if not set defaulting it to !archive. 

- for the time being there is no need to save trie changes
- in split storage migration we'll get the RPC backup with trie changes already in place - and then we will need to ensure that save_trie_changes is set to true or codify it
- saving trie changes without need is wasteful and will increase archival node storage needs so let's not do that

Tested the following scenarios:
- archive = true, save_trie_changes = false -> verified that trie changes are not saved - this is how archival nodes should operate and this is the same as the default save_trie_changes not set. 
- archive = true, save_trie_changes = true -> verified that trie changes are saved - this shouldn't be used in prod today but will be used for the split storage
- archive = false, save_trie_changes = true -> verified that trie changes are saved - this is how rpc nodes should operate and this is the same as default save_trie_changes not set
