### PR TITLE
fix: protocol_feature_nep366_delegate_action feature for runtime-params-estimator

### DIFF
--- a/runtime/runtime-params-estimator/Cargo.toml
+++ b/runtime/runtime-params-estimator/Cargo.toml
@@ -70,6 +70,8 @@ nightly_protocol = [
   "near-test-contracts/nightly",
   "protocol_feature_nep366_delegate_action",
 ]
-protocol_feature_nep366_delegate_action = []
+protocol_feature_nep366_delegate_action = [
+  "nearcore/protocol_feature_nep366_delegate_action",
+]
 sandbox = ["node-runtime/sandbox"]
 io_trace = ["near-store/io_trace", "near-o11y/io_trace", "near-vm-logic/io_trace"]


### PR DESCRIPTION
Currently `runtime-params-estimator` build with `nightly` feature enabled:
```
> cargo build --package runtime-params-estimator --features "nightly"
...
error[E0599]: no variant or associated item named `delegate` found for enum `ActionCosts` in the current scope
  --> runtime/runtime-params-estimator/src/costs_to_runtime_config.rs:58:26
   |
58 |             ActionCosts::delegate => fee(Cost::ActionDelegate)?,
   |                          ^^^^^^^^ variant or associated item not found in `ActionCosts`
```

This PR fixes the issue.