### PR TITLE
feat: get blocks until flat storage head instead of deltas

### DIFF
--- a/core/store/src/flat_state.rs
+++ b/core/store/src/flat_state.rs
@@ -93,7 +93,7 @@ mod imp {
     }
 
     #[derive(Clone)]
-    struct FlatStateCache {
+    pub struct FlatStateCache {
         // TODO: add implementation
     }
 
@@ -963,7 +963,11 @@ impl FlatStorageState {
             // interrupted in the middle.
             // TODO (#7327): in case of long forks it can take a while and delay processing of some chunk.
             // Consider avoid iterating over all blocks and make removals lazy.
-            let gc_height = guard.blocks.get(&block).unwrap().height;
+            let gc_height = guard
+                .blocks
+                .get(&block)
+                .ok_or(self.create_block_not_supported_error(&block))?
+                .height;
             let hashes_to_remove: Vec<_> = guard
                 .blocks
                 .iter()
@@ -1000,7 +1004,11 @@ impl FlatStorageState {
 
         let shard_id = guard.shard_id;
         guard.flat_head = *new_head;
-        let flat_head_height = guard.blocks.get(&new_head).unwrap().height;
+        let flat_head_height = guard
+            .blocks
+            .get(&new_head)
+            .ok_or(self.create_block_not_supported_error(&new_head))?
+            .height;
         guard.metrics.flat_head_height.set(flat_head_height as i64);
         info!(target: "chain", %shard_id, %new_head, %flat_head_height, "Moved flat storage head");
 


### PR DESCRIPTION
First step towards limiting flat storage memory usage.

Current implementation requests set of deltas from block from which we apply the chunk to storage head in `get_deltas_between_blocks`. Because we are likely to limit flat storage RAM usage by ~1 GB, if there is no finality for 20 blocks and deltas for them are full, it would exceed such requirement.

The way to limit RAM is to store sequence of blocks in `FlatState` instead. Then, when `get_ref(key)` is called, we look at these blocks one by one. If delta for a block is cached, we get value reference from it, otherwise we read value reference specifically for (key, block_hash) from disk. This will be implemented in next PRs, currently we just get rid of `get_deltas_between_blocks`.

## Testing

Existing tests should not fail.