### PR TITLE
jsonrpc: simplify params representation

### DIFF
--- a/chain/jsonrpc/client/src/lib.rs
+++ b/chain/jsonrpc/client/src/lib.rs
@@ -42,8 +42,7 @@ where
     P: Serialize,
     R: serde::de::DeserializeOwned + 'static,
 {
-    let request =
-        Message::request(method.to_string(), Some(serde_json::to_value(&params).unwrap()));
+    let request = Message::request(method.to_string(), serde_json::to_value(&params).unwrap());
     // TODO: simplify this.
     client
         .post(server_addr)

--- a/chain/jsonrpc/src/api/blocks.rs
+++ b/chain/jsonrpc/src/api/blocks.rs
@@ -8,7 +8,7 @@ use near_primitives::types::{BlockId, BlockReference};
 use super::{parse_params, RpcFrom, RpcRequest};
 
 impl RpcRequest for RpcBlockRequest {
-    fn parse(value: Option<Value>) -> Result<Self, RpcParseError> {
+    fn parse(value: Value) -> Result<Self, RpcParseError> {
         let block_reference = if let Ok((block_id,)) = parse_params::<(BlockId,)>(value.clone()) {
             BlockReference::BlockId(block_id)
         } else {

--- a/chain/jsonrpc/src/api/changes.rs
+++ b/chain/jsonrpc/src/api/changes.rs
@@ -9,13 +9,13 @@ use near_jsonrpc_primitives::types::changes::{
 use super::{parse_params, RpcFrom, RpcRequest};
 
 impl RpcRequest for RpcStateChangesInBlockRequest {
-    fn parse(value: Option<Value>) -> Result<Self, RpcParseError> {
+    fn parse(value: Value) -> Result<Self, RpcParseError> {
         parse_params::<Self>(value)
     }
 }
 
 impl RpcRequest for RpcStateChangesInBlockByTypeRequest {
-    fn parse(value: Option<Value>) -> Result<Self, RpcParseError> {
+    fn parse(value: Value) -> Result<Self, RpcParseError> {
         parse_params::<Self>(value)
     }
 }

--- a/chain/jsonrpc/src/api/chunks.rs
+++ b/chain/jsonrpc/src/api/chunks.rs
@@ -9,7 +9,7 @@ use near_primitives::types::{BlockId, ShardId};
 use super::{parse_params, RpcFrom, RpcRequest};
 
 impl RpcRequest for RpcChunkRequest {
-    fn parse(value: Option<Value>) -> Result<Self, RpcParseError> {
+    fn parse(value: Value) -> Result<Self, RpcParseError> {
         // Try to parse legacy positioned args and if it fails parse newer named args
         let chunk_reference = if let Ok((chunk_id,)) = parse_params::<(CryptoHash,)>(value.clone())
         {

--- a/chain/jsonrpc/src/api/config.rs
+++ b/chain/jsonrpc/src/api/config.rs
@@ -8,7 +8,7 @@ use near_primitives::types::BlockReference;
 use super::{parse_params, RpcFrom, RpcRequest};
 
 impl RpcRequest for RpcProtocolConfigRequest {
-    fn parse(value: Option<Value>) -> Result<Self, RpcParseError> {
+    fn parse(value: Value) -> Result<Self, RpcParseError> {
         parse_params::<BlockReference>(value).map(|block_reference| Self { block_reference })
     }
 }

--- a/chain/jsonrpc/src/api/gas_price.rs
+++ b/chain/jsonrpc/src/api/gas_price.rs
@@ -8,7 +8,7 @@ use near_primitives::types::MaybeBlockId;
 use super::{parse_params, RpcFrom, RpcRequest};
 
 impl RpcRequest for RpcGasPriceRequest {
-    fn parse(value: Option<Value>) -> Result<Self, RpcParseError> {
+    fn parse(value: Value) -> Result<Self, RpcParseError> {
         parse_params::<(MaybeBlockId,)>(value).map(|(block_id,)| Self { block_id })
     }
 }

--- a/chain/jsonrpc/src/api/light_client.rs
+++ b/chain/jsonrpc/src/api/light_client.rs
@@ -16,13 +16,13 @@ use near_primitives::views::LightClientBlockView;
 use super::{parse_params, RpcFrom, RpcRequest};
 
 impl RpcRequest for RpcLightClientExecutionProofRequest {
-    fn parse(value: Option<Value>) -> Result<Self, RpcParseError> {
+    fn parse(value: Value) -> Result<Self, RpcParseError> {
         Ok(parse_params::<Self>(value)?)
     }
 }
 
 impl RpcRequest for RpcLightClientNextBlockRequest {
-    fn parse(value: Option<Value>) -> Result<Self, RpcParseError> {
+    fn parse(value: Value) -> Result<Self, RpcParseError> {
         if let Ok((last_block_hash,)) = parse_params::<(CryptoHash,)>(value.clone()) {
             Ok(Self { last_block_hash })
         } else {

--- a/chain/jsonrpc/src/api/maintenance.rs
+++ b/chain/jsonrpc/src/api/maintenance.rs
@@ -9,7 +9,7 @@ use near_jsonrpc_primitives::types::maintenance::{
 use super::{parse_params, RpcFrom, RpcRequest};
 
 impl RpcRequest for RpcMaintenanceWindowsRequest {
-    fn parse(value: Option<Value>) -> Result<Self, RpcParseError> {
+    fn parse(value: Value) -> Result<Self, RpcParseError> {
         parse_params::<Self>(value)
     }
 }

--- a/chain/jsonrpc/src/api/mod.rs
+++ b/chain/jsonrpc/src/api/mod.rs
@@ -23,11 +23,11 @@ mod transactions;
 mod validator;
 
 pub(crate) trait RpcRequest: Sized {
-    fn parse(value: Option<Value>) -> Result<Self, RpcParseError>;
+    fn parse(value: Value) -> Result<Self, RpcParseError>;
 }
 
 impl RpcRequest for () {
-    fn parse(_: Option<Value>) -> Result<Self, RpcParseError> {
+    fn parse(_: Value) -> Result<Self, RpcParseError> {
         Ok(())
     }
 }
@@ -80,17 +80,13 @@ impl RpcFrom<near_primitives::errors::InvalidTxError> for ServerError {
     }
 }
 
-pub(crate) fn parse_params<T: DeserializeOwned>(value: Option<Value>) -> Result<T, RpcParseError> {
-    if let Some(value) = value {
-        serde_json::from_value(value)
-            .map_err(|err| RpcParseError(format!("Failed parsing args: {}", err)))
-    } else {
-        Err(RpcParseError("Require at least one parameter".to_owned()))
-    }
+pub(crate) fn parse_params<T: DeserializeOwned>(value: Value) -> Result<T, RpcParseError> {
+    serde_json::from_value(value)
+        .map_err(|err| RpcParseError(format!("Failed parsing args: {}", err)))
 }
 
 fn parse_signed_transaction(
-    value: Option<Value>,
+    value: Value,
 ) -> Result<near_primitives::transaction::SignedTransaction, RpcParseError> {
     let (encoded,) = parse_params::<(String,)>(value)?;
     let bytes = near_primitives::serialize::from_base64(&encoded)

--- a/chain/jsonrpc/src/api/query.rs
+++ b/chain/jsonrpc/src/api/query.rs
@@ -29,7 +29,7 @@ fn parse_bs58_data(max_len: usize, encoded: String) -> Result<Vec<u8>, RpcParseE
 }
 
 impl RpcRequest for RpcQueryRequest {
-    fn parse(value: Option<Value>) -> Result<Self, RpcParseError> {
+    fn parse(value: Value) -> Result<Self, RpcParseError> {
         let params = parse_params::<(String, String)>(value.clone());
         let query_request = if let Ok((path, data)) = params {
             // Handle a soft-deprecated version of the query API, which is based on

--- a/chain/jsonrpc/src/api/receipts.rs
+++ b/chain/jsonrpc/src/api/receipts.rs
@@ -9,7 +9,7 @@ use near_jsonrpc_primitives::types::receipts::{
 use super::{parse_params, RpcFrom, RpcRequest};
 
 impl RpcRequest for RpcReceiptRequest {
-    fn parse(value: Option<Value>) -> Result<Self, RpcParseError> {
+    fn parse(value: Value) -> Result<Self, RpcParseError> {
         let receipt_reference = parse_params::<ReceiptReference>(value)?;
         Ok(Self { receipt_reference })
     }

--- a/chain/jsonrpc/src/api/sandbox.rs
+++ b/chain/jsonrpc/src/api/sandbox.rs
@@ -9,13 +9,13 @@ use near_jsonrpc_primitives::types::sandbox::{
 use super::{parse_params, RpcFrom, RpcRequest};
 
 impl RpcRequest for RpcSandboxPatchStateRequest {
-    fn parse(value: Option<Value>) -> Result<Self, RpcParseError> {
+    fn parse(value: Value) -> Result<Self, RpcParseError> {
         parse_params::<Self>(value)
     }
 }
 
 impl RpcRequest for RpcSandboxFastForwardRequest {
-    fn parse(value: Option<Value>) -> Result<Self, RpcParseError> {
+    fn parse(value: Value) -> Result<Self, RpcParseError> {
         parse_params::<Self>(value)
     }
 }

--- a/chain/jsonrpc/src/api/split_storage.rs
+++ b/chain/jsonrpc/src/api/split_storage.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use super::{parse_params, RpcFrom, RpcRequest};
 
 impl RpcRequest for RpcSplitStorageInfoRequest {
-    fn parse(value: Option<Value>) -> Result<Self, RpcParseError> {
+    fn parse(value: Value) -> Result<Self, RpcParseError> {
         parse_params::<Self>(value)
     }
 }

--- a/chain/jsonrpc/src/api/transactions.rs
+++ b/chain/jsonrpc/src/api/transactions.rs
@@ -13,14 +13,14 @@ use near_primitives::views::FinalExecutionOutcomeViewEnum;
 use super::{parse_params, parse_signed_transaction, RpcFrom, RpcRequest};
 
 impl RpcRequest for RpcBroadcastTransactionRequest {
-    fn parse(value: Option<Value>) -> Result<Self, RpcParseError> {
+    fn parse(value: Value) -> Result<Self, RpcParseError> {
         let signed_transaction = parse_signed_transaction(value)?;
         Ok(Self { signed_transaction })
     }
 }
 
 impl RpcRequest for RpcTransactionStatusCommonRequest {
-    fn parse(value: Option<Value>) -> Result<Self, RpcParseError> {
+    fn parse(value: Value) -> Result<Self, RpcParseError> {
         if let Ok((hash, account_id)) = parse_params::<(CryptoHash, AccountId)>(value.clone()) {
             let transaction_info = TransactionInfo::TransactionId { hash, account_id };
             Ok(Self { transaction_info })

--- a/chain/jsonrpc/src/api/validator.rs
+++ b/chain/jsonrpc/src/api/validator.rs
@@ -10,7 +10,7 @@ use near_primitives::types::{EpochReference, MaybeBlockId};
 use super::{parse_params, RpcFrom, RpcRequest};
 
 impl RpcRequest for RpcValidatorRequest {
-    fn parse(value: Option<Value>) -> Result<Self, RpcParseError> {
+    fn parse(value: Value) -> Result<Self, RpcParseError> {
         let epoch_reference =
             if let Ok((block_id,)) = parse_params::<(MaybeBlockId,)>(value.clone()) {
                 match block_id {
@@ -25,7 +25,7 @@ impl RpcRequest for RpcValidatorRequest {
 }
 
 impl RpcRequest for RpcValidatorsOrderedRequest {
-    fn parse(value: Option<Value>) -> Result<Self, RpcParseError> {
+    fn parse(value: Value) -> Result<Self, RpcParseError> {
         parse_params::<Self>(value)
     }
 }

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -1226,7 +1226,7 @@ impl JsonRpcHandler {
 
 #[cfg(feature = "test_features")]
 impl JsonRpcHandler {
-    async fn adv_disable_header_sync(&self, _params: Option<Value>) -> Result<Value, RpcError> {
+    async fn adv_disable_header_sync(&self, _params: Value) -> Result<Value, RpcError> {
         actix::spawn(
             self.client_addr
                 .send(
@@ -1243,10 +1243,10 @@ impl JsonRpcHandler {
                 )
                 .map(|_| ()),
         );
-        Ok(Value::String("".to_string()))
+        Ok(Value::String(String::new()))
     }
 
-    async fn adv_disable_doomslug(&self, _params: Option<Value>) -> Result<Value, RpcError> {
+    async fn adv_disable_doomslug(&self, _params: Value) -> Result<Value, RpcError> {
         actix::spawn(
             self.client_addr
                 .send(
@@ -1263,10 +1263,10 @@ impl JsonRpcHandler {
                 )
                 .map(|_| ()),
         );
-        Ok(Value::String("".to_string()))
+        Ok(Value::String(String::new()))
     }
 
-    async fn adv_produce_blocks(&self, params: Option<Value>) -> Result<Value, RpcError> {
+    async fn adv_produce_blocks(&self, params: Value) -> Result<Value, RpcError> {
         let (num_blocks, only_valid) = crate::api::parse_params::<(u64, bool)>(params)?;
         actix::spawn(
             self.client_addr
@@ -1278,10 +1278,10 @@ impl JsonRpcHandler {
                 )
                 .map(|_| ()),
         );
-        Ok(Value::String("".to_string()))
+        Ok(Value::String(String::new()))
     }
 
-    async fn adv_switch_to_height(&self, params: Option<Value>) -> Result<Value, RpcError> {
+    async fn adv_switch_to_height(&self, params: Value) -> Result<Value, RpcError> {
         let (height,) = crate::api::parse_params::<(u64,)>(params)?;
         actix::spawn(
             self.client_addr
@@ -1299,10 +1299,10 @@ impl JsonRpcHandler {
                 )
                 .map(|_| ()),
         );
-        Ok(Value::String("".to_string()))
+        Ok(Value::String(String::new()))
     }
 
-    async fn adv_get_saved_blocks(&self, _params: Option<Value>) -> Result<Value, RpcError> {
+    async fn adv_get_saved_blocks(&self, _params: Value) -> Result<Value, RpcError> {
         match self
             .client_addr
             .send(
@@ -1319,7 +1319,7 @@ impl JsonRpcHandler {
         }
     }
 
-    async fn adv_check_store(&self, _params: Option<Value>) -> Result<Value, RpcError> {
+    async fn adv_check_store(&self, _params: Value) -> Result<Value, RpcError> {
         match self
             .client_addr
             .send(


### PR DESCRIPTION
There’s really no need to distinguish lack of params from a null
params.  In all existing cases both of those situations are treated
the same way and it’s unlikely that in the future there would be
a need to treat those two differently.  Meanwhile, assuming missing
params is equivalent to null value simplifies the code slightly.
