### PR TITLE
fix: temporary disable state sync nightly nayduck tests

### DIFF
--- a/nightly/pytest-sanity.txt
+++ b/nightly/pytest-sanity.txt
@@ -42,8 +42,9 @@ pytest --timeout=600 sanity/state_sync_routed.py manytx 115 --features nightly
 
 pytest --timeout=3600 sanity/state_sync_massive.py
 pytest --timeout=3600 sanity/state_sync_massive_validator.py
-pytest --timeout=3600 sanity/state_sync_massive.py --features nightly
-pytest --timeout=3600 sanity/state_sync_massive_validator.py --features nightly
+# TODO(pugachag) - re-enable these tests when near/nayduck#38 is merged
+# pytest --timeout=3600 sanity/state_sync_massive.py --features nightly
+# pytest --timeout=3600 sanity/state_sync_massive_validator.py --features nightly
 
 # TODO(#8211) - tests broken due to bad behavior in chunk fetching - re-enable when that PR is submitted.
 # pytest sanity/sync_chunks_from_archival.py


### PR DESCRIPTION
#8417 fixes these tests, but nayduck doesn't build `genesis-populate` with nightly features, so disabling again until  https://github.com/near/nayduck/pull/38 is merged.