### PR TITLE
refactor: replace TrieNodesCount sub with checked_sub

### DIFF
--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -3,7 +3,6 @@ use derive_more::{AsRef as DeriveAsRef, From as DeriveFrom};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 
-use std::ops;
 use std::sync::Arc;
 
 use near_crypto::PublicKey;
@@ -955,14 +954,12 @@ pub struct TrieNodesCount {
     pub mem_reads: u64,
 }
 
-/// Used to determine the number of trie nodes charged during some operation. Panics on underflow.
-impl ops::Sub for TrieNodesCount {
-    type Output = Self;
-
-    fn sub(self, other: Self) -> Self::Output {
-        Self {
-            db_reads: self.db_reads - other.db_reads,
-            mem_reads: self.mem_reads - other.mem_reads,
-        }
+impl TrieNodesCount {
+    /// Used to determine the number of trie nodes charged during some operation.
+    pub fn checked_sub(self, other: &Self) -> Option<Self> {
+        Some(Self {
+            db_reads: self.db_reads.checked_sub(other.db_reads)?,
+            mem_reads: self.mem_reads.checked_sub(other.mem_reads)?,
+        })
     }
 }

--- a/core/store/src/trie/trie_tests.rs
+++ b/core/store/src/trie/trie_tests.rs
@@ -255,7 +255,8 @@ mod trie_storage_tests {
         for _ in 0..2 {
             let count_before = trie_caching_storage.get_trie_nodes_count();
             let result = trie_caching_storage.retrieve_raw_bytes(&key);
-            let count_delta = trie_caching_storage.get_trie_nodes_count() - count_before;
+            let count_delta =
+                trie_caching_storage.get_trie_nodes_count().checked_sub(&count_before).unwrap();
             assert_eq!(result.unwrap().as_ref(), value);
             assert_eq!(count_delta.db_reads, 1);
             assert_eq!(count_delta.mem_reads, 0);
@@ -299,7 +300,8 @@ mod trie_storage_tests {
 
         let count_before = trie_caching_storage.get_trie_nodes_count();
         let result = trie_caching_storage.retrieve_raw_bytes(&key);
-        let count_delta = trie_caching_storage.get_trie_nodes_count() - count_before;
+        let count_delta =
+            trie_caching_storage.get_trie_nodes_count().checked_sub(&count_before).unwrap();
         assert_eq!(trie_cache.get(&key), None);
         assert_eq!(result.unwrap().as_ref(), value);
         assert_eq!(count_delta.db_reads, 0);
@@ -330,7 +332,8 @@ mod trie_storage_tests {
         trie_caching_storage.set_mode(TrieCacheMode::CachingChunk);
         let count_before = trie_caching_storage.get_trie_nodes_count();
         let result = trie_caching_storage.retrieve_raw_bytes(&key);
-        let count_delta = trie_caching_storage.get_trie_nodes_count() - count_before;
+        let count_delta =
+            trie_caching_storage.get_trie_nodes_count().checked_sub(&count_before).unwrap();
         assert_eq!(result.unwrap().as_ref(), value);
         assert_eq!(count_delta.db_reads, 1);
         assert_eq!(count_delta.mem_reads, 0);
@@ -338,7 +341,8 @@ mod trie_storage_tests {
         // After previous retrieval, item must be copied to chunk cache. Retrieval shouldn't increment the counter.
         let count_before = trie_caching_storage.get_trie_nodes_count();
         let result = trie_caching_storage.retrieve_raw_bytes(&key);
-        let count_delta = trie_caching_storage.get_trie_nodes_count() - count_before;
+        let count_delta =
+            trie_caching_storage.get_trie_nodes_count().checked_sub(&count_before).unwrap();
         assert_eq!(result.unwrap().as_ref(), value);
         assert_eq!(count_delta.db_reads, 0);
         assert_eq!(count_delta.mem_reads, 1);
@@ -348,7 +352,8 @@ mod trie_storage_tests {
         trie_caching_storage.set_mode(TrieCacheMode::CachingShard);
         let count_before = trie_caching_storage.get_trie_nodes_count();
         let result = trie_caching_storage.retrieve_raw_bytes(&key);
-        let count_delta = trie_caching_storage.get_trie_nodes_count() - count_before;
+        let count_delta =
+            trie_caching_storage.get_trie_nodes_count().checked_sub(&count_before).unwrap();
         assert_eq!(result.unwrap().as_ref(), value);
         assert_eq!(count_delta.db_reads, 0);
         assert_eq!(count_delta.mem_reads, 1);
@@ -384,7 +389,8 @@ mod trie_storage_tests {
         assert_eq!(trie_cache.get(&key), None);
         let count_before = trie_caching_storage.get_trie_nodes_count();
         let result = trie_caching_storage.retrieve_raw_bytes(&key);
-        let count_delta = trie_caching_storage.get_trie_nodes_count() - count_before;
+        let count_delta =
+            trie_caching_storage.get_trie_nodes_count().checked_sub(&count_before).unwrap();
         assert_eq!(result.unwrap().as_ref(), value);
         assert_eq!(count_delta.db_reads, 0);
         assert_eq!(count_delta.mem_reads, 1);

--- a/runtime/near-vm-logic/src/logic.rs
+++ b/runtime/near-vm-logic/src/logic.rs
@@ -2358,7 +2358,11 @@ impl<'a> VMLogic<'a> {
         let evicted_ptr = self.ext.storage_get(&key, StorageGetMode::Trie)?;
         let evicted =
             Self::deref_value(&mut self.gas_counter, storage_write_evicted_byte, evicted_ptr)?;
-        let nodes_delta = self.ext.get_trie_nodes_count() - nodes_before;
+        let nodes_delta = self
+            .ext
+            .get_trie_nodes_count()
+            .checked_sub(&nodes_before)
+            .ok_or(InconsistentStateError::IntegerOverflow)?;
 
         near_o11y::io_trace!(
             storage_op = "write",
@@ -2455,7 +2459,11 @@ impl<'a> VMLogic<'a> {
         let read = self.ext.storage_get(&key, StorageGetMode::FlatStorage);
         #[cfg(not(feature = "protocol_feature_flat_state"))]
         let read = self.ext.storage_get(&key, StorageGetMode::Trie);
-        let nodes_delta = self.ext.get_trie_nodes_count() - nodes_before;
+        let nodes_delta = self
+            .ext
+            .get_trie_nodes_count()
+            .checked_sub(&nodes_before)
+            .ok_or(InconsistentStateError::IntegerOverflow)?;
         self.gas_counter.add_trie_fees(&nodes_delta)?;
         let read = Self::deref_value(&mut self.gas_counter, storage_read_value_byte, read?)?;
 
@@ -2524,7 +2532,11 @@ impl<'a> VMLogic<'a> {
             Self::deref_value(&mut self.gas_counter, storage_remove_ret_value_byte, removed_ptr)?;
 
         self.ext.storage_remove(&key)?;
-        let nodes_delta = self.ext.get_trie_nodes_count() - nodes_before;
+        let nodes_delta = self
+            .ext
+            .get_trie_nodes_count()
+            .checked_sub(&nodes_before)
+            .ok_or(InconsistentStateError::IntegerOverflow)?;
 
         near_o11y::io_trace!(
             storage_op = "remove",
@@ -2585,7 +2597,11 @@ impl<'a> VMLogic<'a> {
         self.gas_counter.pay_per(storage_has_key_byte, key.len() as u64)?;
         let nodes_before = self.ext.get_trie_nodes_count();
         let res = self.ext.storage_has_key(&key);
-        let nodes_delta = self.ext.get_trie_nodes_count() - nodes_before;
+        let nodes_delta = self
+            .ext
+            .get_trie_nodes_count()
+            .checked_sub(&nodes_before)
+            .ok_or(InconsistentStateError::IntegerOverflow)?;
 
         near_o11y::io_trace!(
             storage_op = "exists",


### PR DESCRIPTION
Part of #8210.

This potentially changes runtime behaviour to return `Err` instead of panicking (see [this comment](https://github.com/near/nearcore/pull/8370#pullrequestreview-1265508077)). I've discussed this with @jakmeier and returning `InconsistentStateError` will effectively result in panic later.

`saturating_sub` was considered as an alternative, but underflow when subtracting trie nodes count means that we have some kind of bug in our logic. Since we use those count diffs when to calculate gas, it is better to panic instead of hiding the issue by saturating the result to 0.
