### PR TITLE
Adding write_raw_to_column to Database trait

### DIFF
--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -138,6 +138,13 @@ pub trait Database: Sync + Send {
     /// Atomically apply all operations in given batch at once.
     fn write(&self, batch: DBTransaction) -> io::Result<()>;
 
+    /// Atomically writes raw Sets for pairs of keys and values to column.
+    fn write_raw_to_column(
+        &self,
+        batch: Vec<(Box<[u8]>, Box<[u8]>)>,
+        column: DBCol,
+    ) -> io::Result<()>;
+
     /// Flush all in-memory data to disk.
     ///
     /// This is a no-op for in-memory databases.

--- a/core/store/src/db/rocksdb.rs
+++ b/core/store/src/db/rocksdb.rs
@@ -323,6 +323,19 @@ impl Database for RocksDB {
         self.db.write(batch).map_err(into_other)
     }
 
+    fn write_raw_to_column(
+        &self,
+        batch: Vec<(Box<[u8]>, Box<[u8]>)>,
+        column: DBCol,
+    ) -> io::Result<()> {
+        let mut rocksdb_batch = WriteBatch::default();
+        let cf_handle = self.cf_handle(column)?;
+        for (key, value) in batch.into_iter() {
+            rocksdb_batch.put_cf(cf_handle, key, value);
+        }
+        self.db.write(rocksdb_batch).map_err(into_other)
+    }
+
     fn compact(&self) -> io::Result<()> {
         let none = Option::<&[u8]>::None;
         for col in DBCol::iter() {

--- a/core/store/src/db/testdb.rs
+++ b/core/store/src/db/testdb.rs
@@ -88,6 +88,18 @@ impl Database for TestDB {
         Ok(())
     }
 
+    fn write_raw_to_column(
+        &self,
+        batch: Vec<(Box<[u8]>, Box<[u8]>)>,
+        column: DBCol,
+    ) -> io::Result<()> {
+        let mut db = self.db.write().unwrap();
+        for (key, value) in batch.into_iter() {
+            db[column].insert(key.to_vec(), value.to_vec());
+        }
+        Ok(())
+    }
+
     fn flush(&self) -> io::Result<()> {
         Ok(())
     }


### PR DESCRIPTION
This is done to write to ColdDB more efficiently during cold storage initial migration.