### PR TITLE
adding cold_head_height metric

### DIFF
--- a/core/store/src/cold_storage.rs
+++ b/core/store/src/cold_storage.rs
@@ -131,6 +131,8 @@ pub fn update_cold_head<D: Database>(
         let mut transaction = DBTransaction::new();
         transaction.set(DBCol::BlockMisc, COLD_HEAD_KEY.to_vec(), tip.try_to_vec()?);
         hot_store.storage.write(transaction)?;
+
+        crate::metrics::COLD_HEAD_HEIGHT.set(*height as i64);
     }
 
     return Ok(());
@@ -156,6 +158,10 @@ pub fn test_cold_genesis_update<D: Database>(
 
 pub fn test_get_store_reads(column: DBCol) -> u64 {
     crate::metrics::COLD_MIGRATION_READS.with_label_values(&[<&str>::from(column)]).get()
+}
+
+pub fn test_get_cold_head_height() -> i64 {
+    crate::metrics::COLD_HEAD_HEIGHT.get()
 }
 
 /// Returns HashMap from DBKeyType to possible keys of that type for provided height.

--- a/core/store/src/cold_storage.rs
+++ b/core/store/src/cold_storage.rs
@@ -160,10 +160,6 @@ pub fn test_get_store_reads(column: DBCol) -> u64 {
     crate::metrics::COLD_MIGRATION_READS.with_label_values(&[<&str>::from(column)]).get()
 }
 
-pub fn test_get_cold_head_height() -> i64 {
-    crate::metrics::COLD_HEAD_HEIGHT.get()
-}
-
 /// Returns HashMap from DBKeyType to possible keys of that type for provided height.
 /// Only constructs keys for key types that are used in cold columns.
 /// The goal is to capture all changes to db made during production of the block at provided height.

--- a/core/store/src/metrics.rs
+++ b/core/store/src/metrics.rs
@@ -1,6 +1,6 @@
 use near_o11y::metrics::{
-    try_create_histogram_vec, try_create_int_counter_vec, try_create_int_gauge_vec, HistogramVec,
-    IntCounterVec, IntGaugeVec,
+    try_create_histogram_vec, try_create_int_counter_vec, try_create_int_gauge,
+    try_create_int_gauge_vec, HistogramVec, IntCounterVec, IntGauge, IntGaugeVec,
 };
 use once_cell::sync::Lazy;
 
@@ -220,6 +220,9 @@ pub static COLD_MIGRATION_READS: Lazy<IntCounterVec> = Lazy::new(|| {
         &["col"],
     )
     .unwrap()
+});
+pub static COLD_HEAD_HEIGHT: Lazy<IntGauge> = Lazy::new(|| {
+    try_create_int_gauge("near_cold_head_height", "Height of the head of cold storage").unwrap()
 });
 
 pub static FLAT_STORAGE_HEAD_HEIGHT: Lazy<IntGaugeVec> = Lazy::new(|| {

--- a/integration-tests/src/tests/client/cold_storage.rs
+++ b/integration-tests/src/tests/client/cold_storage.rs
@@ -225,6 +225,5 @@ fn test_cold_db_head_update() {
 
         assert_eq!(head, &cold_head_in_cold);
         assert_eq!(head, &cold_head_in_hot);
-        assert_eq!(h, test_get_cold_head_height() as u64);
     }
 }

--- a/integration-tests/src/tests/client/cold_storage.rs
+++ b/integration-tests/src/tests/client/cold_storage.rs
@@ -12,7 +12,8 @@ use near_primitives::transaction::{
     Action, DeployContractAction, FunctionCallAction, SignedTransaction,
 };
 use near_store::cold_storage::{
-    test_cold_genesis_update, test_get_store_reads, update_cold_db, update_cold_head,
+    test_cold_genesis_update, test_get_cold_head_height, test_get_store_reads, update_cold_db,
+    update_cold_head,
 };
 use near_store::metadata::DbKind;
 use near_store::metadata::DB_VERSION;
@@ -224,5 +225,6 @@ fn test_cold_db_head_update() {
 
         assert_eq!(head, &cold_head_in_cold);
         assert_eq!(head, &cold_head_in_hot);
+        assert_eq!(h, test_get_cold_head_height() as u64);
     }
 }

--- a/integration-tests/src/tests/client/cold_storage.rs
+++ b/integration-tests/src/tests/client/cold_storage.rs
@@ -12,8 +12,7 @@ use near_primitives::transaction::{
     Action, DeployContractAction, FunctionCallAction, SignedTransaction,
 };
 use near_store::cold_storage::{
-    test_cold_genesis_update, test_get_cold_head_height, test_get_store_reads, update_cold_db,
-    update_cold_head,
+    test_cold_genesis_update, test_get_store_reads, update_cold_db, update_cold_head,
 };
 use near_store::metadata::DbKind;
 use near_store::metadata::DB_VERSION;


### PR DESCRIPTION
Adding height of the head of the cold storage to the metrics page.
It is updated when we call for update_cold_head.

Technically, it can be absent from metrics with this implementation in these cases:
1. During initial migration, but it is useless during that time and is not set in the storage at all.
2. If copying loop is broken during normal run of the node. I'm okay with that kind of additional signal that something is wrong.
3. If node does not have a cold storage. We don't need it in that case anyway. 

@nikurt, making you a reviewer as an expert on metrics (at least from my point of view). 