### PR TITLE
fix: re-enable nayduck nightly state_sync_massive tests

### DIFF
--- a/nightly/pytest-sanity.txt
+++ b/nightly/pytest-sanity.txt
@@ -42,9 +42,8 @@ pytest --timeout=600 sanity/state_sync_routed.py manytx 115 --features nightly
 
 pytest --timeout=3600 sanity/state_sync_massive.py
 pytest --timeout=3600 sanity/state_sync_massive_validator.py
-# TODO(pugachag) - re-enable these tests when near/nayduck#38 is merged
-# pytest --timeout=3600 sanity/state_sync_massive.py --features nightly
-# pytest --timeout=3600 sanity/state_sync_massive_validator.py --features nightly
+pytest --timeout=3600 sanity/state_sync_massive.py --features nightly
+pytest --timeout=3600 sanity/state_sync_massive_validator.py --features nightly
 
 # TODO(#8211) - tests broken due to bad behavior in chunk fetching - re-enable when that PR is submitted.
 # pytest sanity/sync_chunks_from_archival.py


### PR DESCRIPTION
Was disabled in https://github.com/near/nearcore/pull/8463. https://github.com/near/nayduck/pull/38 and https://github.com/near/nayduck/pull/41 are deployed now, so we can enable those tests again.