### PR TITLE
docs: Update command to retrieve transaction gas profile

### DIFF
--- a/docs/architecture/gas/gas_profile.md
+++ b/docs/architecture/gas/gas_profile.md
@@ -16,8 +16,12 @@ You can query the gas profile of a transaction with
 [NEAR CLI](https://docs.near.org/tools/near-cli).
 
 ```bash
-NEAR_ENV=mainnet near tx-status 8vYxsqYp5Kkfe8j9LsTqZRsEupNkAs1WvgcGcUE4MUUw --accountId app.nearcrowd.near
+NEAR_ENV=mainnet near tx-status 8vYxsqYp5Kkfe8j9LsTqZRsEupNkAs1WvgcGcUE4MUUw  \
+  --accountId app.nearcrowd.near  \
+  --nodeUrl https://archival-rpc.mainnet.near.org  # Allows to retrieve older transactions.
+```
 
+```
 Transaction app.nearcrowd.near:8vYxsqYp5Kkfe8j9LsTqZRsEupNkAs1WvgcGcUE4MUUw
 {
   receipts_outcome: [


### PR DESCRIPTION
The old command was returning an error because transaction was no longer cached in the active validating(?) nodes. So adding `nodeUrl` to query the archive node as this is most likely what the user would want to do in this case anyway.

Also separate the code block in two parts to make it easier to copy.