### PR TITLE
feat: allow creating cold store when hot store exists

### DIFF
--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -21,10 +21,11 @@ use near_primitives::views::{
     BlockView, ChunkView, DownloadStatusView, EpochValidatorInfo, ExecutionOutcomeWithIdView,
     FinalExecutionOutcomeViewEnum, GasPriceView, LightClientBlockLiteView, LightClientBlockView,
     MaintenanceWindowsView, QueryRequest, QueryResponse, ReceiptView, ShardSyncDownloadView,
-    StateChangesKindsView, StateChangesRequestView, StateChangesView, SyncStatusView,
+    SplitStorageInfoView, StateChangesKindsView, StateChangesRequestView, StateChangesView,
+    SyncStatusView,
 };
 pub use near_primitives::views::{StatusResponse, StatusSyncInfo};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 /// Combines errors coming from chain, tx pool and block producer.
 #[derive(Debug, thiserror::Error)]
@@ -969,15 +970,8 @@ impl From<near_chain_primitives::Error> for GetClientConfigError {
 
 pub struct GetSplitStorageInfo {}
 
-#[derive(Serialize, Deserialize, Debug)]
-pub struct GetSplitStorageInfoResult {
-    pub head_height: Option<BlockHeight>,
-    pub final_head_height: Option<BlockHeight>,
-    pub cold_head_height: Option<BlockHeight>,
-}
-
 impl Message for GetSplitStorageInfo {
-    type Result = Result<GetSplitStorageInfoResult, GetSplitStorageInfoError>;
+    type Result = Result<SplitStorageInfoView, GetSplitStorageInfoError>;
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -25,9 +25,9 @@ use near_client_primitives::types::{
     GetExecutionOutcomesForBlock, GetGasPrice, GetGasPriceError, GetMaintenanceWindows,
     GetMaintenanceWindowsError, GetNextLightClientBlockError, GetProtocolConfig,
     GetProtocolConfigError, GetReceipt, GetReceiptError, GetSplitStorageInfo,
-    GetSplitStorageInfoError, GetSplitStorageInfoResult, GetStateChangesError,
-    GetStateChangesWithCauseInBlock, GetStateChangesWithCauseInBlockForTrackedShards,
-    GetValidatorInfoError, Query, QueryError, TxStatus, TxStatusError,
+    GetSplitStorageInfoError, GetStateChangesError, GetStateChangesWithCauseInBlock,
+    GetStateChangesWithCauseInBlockForTrackedShards, GetValidatorInfoError, Query, QueryError,
+    TxStatus, TxStatusError,
 };
 #[cfg(feature = "test_features")]
 use near_network::types::NetworkAdversarialMessage;
@@ -55,8 +55,8 @@ use near_primitives::views::validator_stake_view::ValidatorStakeView;
 use near_primitives::views::{
     BlockView, ChunkView, EpochValidatorInfo, ExecutionOutcomeWithIdView,
     FinalExecutionOutcomeView, FinalExecutionOutcomeViewEnum, GasPriceView, LightClientBlockView,
-    MaintenanceWindowsView, QueryRequest, QueryResponse, ReceiptView, StateChangesKindsView,
-    StateChangesView,
+    MaintenanceWindowsView, QueryRequest, QueryResponse, ReceiptView, SplitStorageInfoView,
+    StateChangesKindsView, StateChangesView,
 };
 
 use crate::adapter::{
@@ -1424,7 +1424,7 @@ impl Handler<WithSpanContext<GetMaintenanceWindows>> for ViewClientActor {
 }
 
 impl Handler<WithSpanContext<GetSplitStorageInfo>> for ViewClientActor {
-    type Result = Result<GetSplitStorageInfoResult, GetSplitStorageInfoError>;
+    type Result = Result<SplitStorageInfoView, GetSplitStorageInfoError>;
 
     fn handle(
         &mut self,
@@ -1439,10 +1439,13 @@ impl Handler<WithSpanContext<GetSplitStorageInfo>> for ViewClientActor {
         let final_head = store.get_ser::<Tip>(DBCol::BlockMisc, FINAL_HEAD_KEY)?;
         let cold_head = store.get_ser::<Tip>(DBCol::BlockMisc, COLD_HEAD_KEY)?;
 
-        Ok(GetSplitStorageInfoResult {
+        let hot_db_kind = store.get_db_kind()?.map(|kind| kind.to_string());
+
+        Ok(SplitStorageInfoView {
             head_height: head.map(|tip| tip.height),
             final_head_height: final_head.map(|tip| tip.height),
             cold_head_height: cold_head.map(|tip| tip.height),
+            hot_db_kind: hot_db_kind,
         })
     }
 }

--- a/chain/jsonrpc-primitives/src/types/split_storage.rs
+++ b/chain/jsonrpc-primitives/src/types/split_storage.rs
@@ -1,4 +1,4 @@
-use near_client_primitives::types::GetSplitStorageInfoResult;
+use near_primitives::views::SplitStorageInfoView;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -8,7 +8,7 @@ pub struct RpcSplitStorageInfoRequest {}
 #[derive(Serialize, Deserialize, Debug)]
 pub struct RpcSplitStorageInfoResponse {
     #[serde(flatten)]
-    pub result: GetSplitStorageInfoResult,
+    pub result: SplitStorageInfoView,
 }
 
 #[derive(thiserror::Error, Debug, Serialize, Deserialize)]

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -2169,6 +2169,16 @@ pub struct StorageUsageConfigView {
     pub num_extra_bytes_record: u64,
 }
 
+/// Contains the split storage information.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct SplitStorageInfoView {
+    pub head_height: Option<BlockHeight>,
+    pub final_head_height: Option<BlockHeight>,
+    pub cold_head_height: Option<BlockHeight>,
+
+    pub hot_db_kind: Option<String>,
+}
+
 impl From<RuntimeConfig> for RuntimeConfigView {
     fn from(config: RuntimeConfig) -> Self {
         Self {

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -394,9 +394,8 @@ impl Store {
 }
 
 impl Store {
-    pub fn get_db_version(&self) -> io::Result<DbVersion> {
-        let metadata = metadata::DbMetadata::read(self.storage.as_ref())?;
-        Ok(metadata.version)
+    pub fn get_db_version(&self) -> io::Result<Option<DbVersion>> {
+        metadata::DbMetadata::maybe_read_version(self.storage.as_ref())
     }
 
     pub fn set_db_version(&self, version: DbVersion) -> io::Result<()> {
@@ -406,8 +405,7 @@ impl Store {
     }
 
     pub fn get_db_kind(&self) -> io::Result<Option<DbKind>> {
-        let metadata = metadata::DbMetadata::read(self.storage.as_ref())?;
-        Ok(metadata.kind)
+        metadata::DbMetadata::maybe_read_kind(self.storage.as_ref())
     }
 
     pub fn set_db_kind(&self, kind: DbKind) -> io::Result<()> {

--- a/core/store/src/metadata.rs
+++ b/core/store/src/metadata.rs
@@ -1,5 +1,3 @@
-use crate::{DBCol, NodeStorage, Temperature};
-
 /// Database version type.
 pub type DbVersion = u32;
 
@@ -44,40 +42,6 @@ pub enum DbKind {
     Cold,
 }
 
-pub(super) fn set_store_version(storage: &NodeStorage, version: DbVersion) -> std::io::Result<()> {
-    set_store_metadata(storage, DbMetadata { version, kind: None })
-}
-
-fn set_db_metadata(
-    storage: &NodeStorage,
-    temp: Temperature,
-    metadata: DbMetadata,
-) -> std::io::Result<()> {
-    let mut store_update = storage.get_store(temp).store_update();
-    store_update.set(DBCol::DbVersion, VERSION_KEY, metadata.version.to_string().as_bytes());
-    if metadata.version >= DB_VERSION_WITH_KIND {
-        let mut kind = metadata.kind;
-        if temp == Temperature::Cold {
-            kind = Some(DbKind::Cold);
-        }
-        if let Some(kind) = kind {
-            store_update.set(DBCol::DbVersion, KIND_KEY, <&str>::from(kind).as_bytes());
-        }
-    }
-    store_update.commit()
-}
-
-pub(super) fn set_store_metadata(
-    storage: &NodeStorage,
-    metadata: DbMetadata,
-) -> std::io::Result<()> {
-    set_db_metadata(storage, Temperature::Hot, metadata)?;
-    if storage.has_cold() {
-        set_db_metadata(storage, Temperature::Cold, metadata)?;
-    }
-    Ok(())
-}
-
 /// Metadata about a database.
 #[derive(Clone, Copy)]
 pub(super) struct DbMetadata {
@@ -92,7 +56,8 @@ pub(super) struct DbMetadata {
 }
 
 impl DbMetadata {
-    /// Reads metadata from the database.
+    /// Reads metadata from the database. This method enforces the invariant
+    /// that version and kind must alwasy be set.
     ///
     /// If the database version is not present, returns an error.  Similarly, if
     /// database version is ≥ [`DB_VERSION_WITH_KIND`] but the kind is not
@@ -108,6 +73,22 @@ impl DbMetadata {
         };
         Ok(Self { version, kind })
     }
+
+    /// Reads the version from the db. If version is not set returns None. This
+    /// method doesn't enforce the invariant that version must alays be set so
+    /// it can be used when setting the kind for the version first time.
+    pub(super) fn maybe_read_version(
+        db: &dyn crate::Database,
+    ) -> std::io::Result<Option<DbVersion>> {
+        maybe_read("DbVersion", db, VERSION_KEY)
+    }
+
+    /// Reads the kind from the db. If kind is not set returns None. This method
+    /// doesn't enforce the invariant of kind always being set so it can be used
+    /// when setting the kind for the first time.
+    pub(super) fn maybe_read_kind(db: &dyn crate::Database) -> std::io::Result<Option<DbKind>> {
+        maybe_read("DbKind", db, KIND_KEY)
+    }
 }
 
 /// Reads value from DbVersion column and parses it using `FromStr`.
@@ -121,6 +102,25 @@ fn read<T: std::str::FromStr>(
     key: &[u8],
 ) -> std::io::Result<T> {
     let msg = "it’s not a neard database or database is corrupted";
+    let result = maybe_read::<T>(what, db, key)?;
+
+    match result {
+        Some(value) => Ok(value),
+        None => Err(other_error(format!("missing {what}; {msg}"))),
+    }
+}
+
+/// Reads value from DbVersion column and parses it using `FromStr`.
+///
+/// Reads raw bytes for given `key` from [`DBCol::DbVersion`], verifies that
+/// they’re valid UTF-8 and then converts into `T` using `from_str`.  If the
+/// value is missing or parsing fails returns None.
+fn maybe_read<T: std::str::FromStr>(
+    what: &str,
+    db: &dyn crate::Database,
+    key: &[u8],
+) -> std::io::Result<Option<T>> {
+    let msg = "it’s not a neard database or database is corrupted";
     if let Some(bytes) = db.get_raw_bytes(crate::DBCol::DbVersion, key)? {
         let value = std::str::from_utf8(&bytes)
             .map_err(|_err| format!("invalid {what}: {bytes:?}; {msg}"))
@@ -128,9 +128,9 @@ fn read<T: std::str::FromStr>(
         let value = T::from_str(value)
             .map_err(|_err| format!("invalid {what}: ‘{value}’; {msg}"))
             .map_err(other_error)?;
-        Ok(value)
+        Ok(Some(value))
     } else {
-        Err(other_error(format!("missing {what}; {msg}")))
+        Ok(None)
     }
 }
 

--- a/core/store/src/metadata.rs
+++ b/core/store/src/metadata.rs
@@ -75,8 +75,8 @@ impl DbMetadata {
     }
 
     /// Reads the version from the db. If version is not set returns None. This
-    /// method doesn't enforce the invariant that version must alays be set so
-    /// it can be used when setting the kind for the version first time.
+    /// method doesn't enforce the invariant that version must always be set so
+    /// it should only be used when setting the version for the first time.
     pub(super) fn maybe_read_version(
         db: &dyn crate::Database,
     ) -> std::io::Result<Option<DbVersion>> {
@@ -84,8 +84,8 @@ impl DbMetadata {
     }
 
     /// Reads the kind from the db. If kind is not set returns None. This method
-    /// doesn't enforce the invariant of kind always being set so it can be used
-    /// when setting the kind for the first time.
+    /// doesn't enforce the invariant that kind must always be set so it should
+    /// only be used when setting the kind for the first time.
     pub(super) fn maybe_read_kind(db: &dyn crate::Database) -> std::io::Result<Option<DbKind>> {
         maybe_read("DbKind", db, KIND_KEY)
     }
@@ -93,9 +93,7 @@ impl DbMetadata {
 
 /// Reads value from DbVersion column and parses it using `FromStr`.
 ///
-/// Reads raw bytes for given `key` from [`DBCol::DbVersion`], verifies that
-/// they’re valid UTF-8 and then converts into `T` using `from_str`.  If the
-/// value is missing or parsing fails returns an error.
+/// Same as maybe_read but this method returns an error if the value is not set.
 fn read<T: std::str::FromStr>(
     what: &str,
     db: &dyn crate::Database,

--- a/core/store/src/migrations.rs
+++ b/core/store/src/migrations.rs
@@ -123,8 +123,8 @@ where
 ///
 /// Deletes all data from _NextBlockWithNewChunk and _LastBlockWithNewChunk
 /// columns.
-pub fn migrate_28_to_29(storage: &crate::NodeStorage) -> anyhow::Result<()> {
-    let mut update = storage.get_store(crate::Temperature::Hot).store_update();
+pub fn migrate_28_to_29(store: &Store) -> anyhow::Result<()> {
+    let mut update = store.store_update();
     update.delete_all(DBCol::_NextBlockWithNewChunk);
     update.delete_all(DBCol::_LastBlockWithNewChunk);
     update.commit()?;
@@ -134,7 +134,7 @@ pub fn migrate_28_to_29(storage: &crate::NodeStorage) -> anyhow::Result<()> {
 /// Migrates database from version 29 to 30.
 ///
 /// Migrates all structures that use ValidatorStake to versionized version.
-pub fn migrate_29_to_30(storage: &crate::NodeStorage) -> anyhow::Result<()> {
+pub fn migrate_29_to_30(store: &Store) -> anyhow::Result<()> {
     use near_primitives::epoch_manager::block_info::BlockInfo;
     use near_primitives::epoch_manager::epoch_info::EpochSummary;
     use near_primitives::epoch_manager::AGGREGATOR_KEY;
@@ -145,8 +145,6 @@ pub fn migrate_29_to_30(storage: &crate::NodeStorage) -> anyhow::Result<()> {
         ValidatorKickoutReason, ValidatorStats,
     };
     use std::collections::BTreeMap;
-
-    let store = storage.get_store(crate::Temperature::Hot);
 
     #[derive(BorshDeserialize)]
     pub struct OldEpochSummary {
@@ -228,8 +226,8 @@ pub fn migrate_29_to_30(storage: &crate::NodeStorage) -> anyhow::Result<()> {
 ///
 /// This involves deleting contents of ChunkPerHeightShard column which is now
 /// deprecated and no longer used.
-pub fn migrate_31_to_32(storage: &crate::NodeStorage) -> anyhow::Result<()> {
-    let mut update = storage.get_store(crate::Temperature::Hot).store_update();
+pub fn migrate_31_to_32(store: &Store) -> anyhow::Result<()> {
+    let mut update = store.store_update();
     update.delete_all(DBCol::_ChunkPerHeightShard);
     update.commit()?;
     Ok(())
@@ -240,8 +238,7 @@ pub fn migrate_31_to_32(storage: &crate::NodeStorage) -> anyhow::Result<()> {
 /// This removes the TransactionResult column and moves it to TransactionResultForBlock.
 /// The new column removes the need for high-latency read-modify-write operations when committing
 /// new blocks.
-pub fn migrate_32_to_33(storage: &crate::NodeStorage) -> anyhow::Result<()> {
-    let store = storage.get_store(crate::Temperature::Hot);
+pub fn migrate_32_to_33(store: &Store) -> anyhow::Result<()> {
     let mut update = BatchedStoreUpdate::new(&store, 10_000_000);
     for row in
         store.iter_prefix_ser::<Vec<ExecutionOutcomeWithIdAndProof>>(DBCol::_TransactionResult, &[])
@@ -279,13 +276,10 @@ pub fn migrate_32_to_33(storage: &crate::NodeStorage) -> anyhow::Result<()> {
 /// If the database has IS_ARCHIVAL key in BlockMisc column set to true, this
 /// overrides value of is_node_archival argument.  Otherwise, the kind of the
 /// resulting database is determined based on that argument.
-pub fn migrate_33_to_34(
-    storage: &crate::NodeStorage,
-    mut is_node_archival: bool,
-) -> anyhow::Result<()> {
+pub fn migrate_33_to_34(store: &Store, mut is_node_archival: bool) -> anyhow::Result<()> {
     const IS_ARCHIVE_KEY: &[u8; 10] = b"IS_ARCHIVE";
 
-    let hot = storage.get_store(crate::Temperature::Hot);
+    let hot = store;
 
     let is_store_archival =
         hot.get_ser::<bool>(DBCol::BlockMisc, IS_ARCHIVE_KEY)?.unwrap_or_default();

--- a/core/store/src/migrations.rs
+++ b/core/store/src/migrations.rs
@@ -279,10 +279,8 @@ pub fn migrate_32_to_33(store: &Store) -> anyhow::Result<()> {
 pub fn migrate_33_to_34(store: &Store, mut is_node_archival: bool) -> anyhow::Result<()> {
     const IS_ARCHIVE_KEY: &[u8; 10] = b"IS_ARCHIVE";
 
-    let hot = store;
-
     let is_store_archival =
-        hot.get_ser::<bool>(DBCol::BlockMisc, IS_ARCHIVE_KEY)?.unwrap_or_default();
+        store.get_ser::<bool>(DBCol::BlockMisc, IS_ARCHIVE_KEY)?.unwrap_or_default();
 
     if is_store_archival != is_node_archival {
         if is_store_archival {
@@ -296,7 +294,7 @@ pub fn migrate_33_to_34(store: &Store, mut is_node_archival: bool) -> anyhow::Re
         is_node_archival = true;
     }
 
-    let mut update = hot.store_update();
+    let mut update = store.store_update();
     if is_store_archival {
         update.delete(DBCol::BlockMisc, IS_ARCHIVE_KEY);
     }

--- a/core/store/src/opener.rs
+++ b/core/store/src/opener.rs
@@ -220,7 +220,7 @@ impl<'a> StoreOpener<'a> {
         self.open_in_mode(Mode::ReadWrite)
     }
 
-    /// Opens the RocksDB database(s) for hot and, potentially, cold storages.
+    /// Opens the RocksDB database(s) for hot and cold (if configured) storages.
     ///
     /// When opening in read-only mode, verifies that the database version is
     /// what the node expects and fails if it isn’t.  If database doesn’t exist,

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -124,6 +124,9 @@ fn open_storage(home_dir: &Path, near_config: &mut NearConfig) -> anyhow::Result
         Err(StoreOpenerError::DbVersionMismatchOnRead { .. }) => unreachable!(),
         // Cannot happen when migrator is specified.
         Err(StoreOpenerError::DbVersionMismatch { .. }) => unreachable!(),
+        Err(StoreOpenerError::DbVersionMissing { .. }) => {
+            Err(anyhow::anyhow!("Database version is missing!"))
+        },
         Err(StoreOpenerError::DbVersionTooOld { got, latest_release, .. }) => {
             Err(anyhow::anyhow!(
                 "Database version {got} is created by an old version \

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -5,7 +5,7 @@ use near_primitives::types::Gas;
 use near_primitives::utils::index_to_bytes;
 use near_store::metadata::{DbVersion, DB_VERSION};
 use near_store::migrations::BatchedStoreUpdate;
-use near_store::{DBCol, NodeStorage, Temperature};
+use near_store::{DBCol, NodeStorage, Store, Temperature};
 
 /// Fix an issue with block ordinal (#5761)
 // This migration takes at least 3 hours to complete on mainnet
@@ -136,35 +136,36 @@ impl<'a> near_store::StoreMigrator for Migrator<'a> {
         }
     }
 
-    fn migrate(&self, storage: &NodeStorage, version: DbVersion) -> anyhow::Result<()> {
-        match version {
-            0..=26 => unreachable!(),
-            27 => {
-                // version 27 => 28: add DBCol::StateChangesForSplitStates
-                //
-                // Does not need to do anything since open db with option
-                // `create_missing_column_families`.  Nevertheless need to bump
-                // db version, because db_version 27 binary can't open
-                // db_version 28 db.  Combine it with migration from 28 to 29;
-                // don’t do anything here.
-                Ok(())
-            }
-            28 => near_store::migrations::migrate_28_to_29(storage),
-            29 => near_store::migrations::migrate_29_to_30(storage),
-            30 => migrate_30_to_31(storage, &self.config),
-            31 => near_store::migrations::migrate_31_to_32(storage),
-            32 => near_store::migrations::migrate_32_to_33(storage),
-            33 => {
-                near_store::migrations::migrate_33_to_34(storage, self.config.client_config.archive)
-            }
-            #[cfg(feature = "protocol_feature_flat_state")]
-            34 => {
-                tracing::info!(target: "migrations", "Migrating DB version from 34 to 35. Flat storage data will be created on disk.");
-                tracing::info!(target: "migrations", "It will happen in parallel with regular block processing. ETA is 5h for RPC node and 10h for archival node.");
-                Ok(())
-            }
-            DB_VERSION.. => unreachable!(),
-        }
+    fn migrate(&self, _store: &Store, _version: DbVersion) -> anyhow::Result<()> {
+        todo!();
+        // match version {
+        //     0..=26 => unreachable!(),
+        //     27 => {
+        //         // version 27 => 28: add DBCol::StateChangesForSplitStates
+        //         //
+        //         // Does not need to do anything since open db with option
+        //         // `create_missing_column_families`.  Nevertheless need to bump
+        //         // db version, because db_version 27 binary can't open
+        //         // db_version 28 db.  Combine it with migration from 28 to 29;
+        //         // don’t do anything here.
+        //         Ok(())
+        //     }
+        //     28 => near_store::migrations::migrate_28_to_29(storage),
+        //     29 => near_store::migrations::migrate_29_to_30(storage),
+        //     30 => migrate_30_to_31(storage, &self.config),
+        //     31 => near_store::migrations::migrate_31_to_32(storage),
+        //     32 => near_store::migrations::migrate_32_to_33(storage),
+        //     33 => {
+        //         near_store::migrations::migrate_33_to_34(storage, self.config.client_config.archive)
+        //     }
+        //     #[cfg(feature = "protocol_feature_flat_state")]
+        //     34 => {
+        //         tracing::info!(target: "migrations", "Migrating DB version from 34 to 35. Flat storage data will be created on disk.");
+        //         tracing::info!(target: "migrations", "It will happen in parallel with regular block processing. ETA is 5h for RPC node and 10h for archival node.");
+        //         Ok(())
+        //     }
+        //     DB_VERSION.. => unreachable!(),
+        // }
     }
 }
 

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -5,15 +5,11 @@ use near_primitives::types::Gas;
 use near_primitives::utils::index_to_bytes;
 use near_store::metadata::{DbVersion, DB_VERSION};
 use near_store::migrations::BatchedStoreUpdate;
-use near_store::{DBCol, NodeStorage, Store, Temperature};
+use near_store::{DBCol, Store};
 
 /// Fix an issue with block ordinal (#5761)
 // This migration takes at least 3 hours to complete on mainnet
-pub fn migrate_30_to_31(
-    storage: &NodeStorage,
-    near_config: &crate::NearConfig,
-) -> anyhow::Result<()> {
-    let store = storage.get_store(Temperature::Hot);
+pub fn migrate_30_to_31(store: &Store, near_config: &crate::NearConfig) -> anyhow::Result<()> {
     if near_config.client_config.archive && &near_config.genesis.config.chain_id == "mainnet" {
         do_migrate_30_to_31(&store, &near_config.genesis.config)?;
     }
@@ -24,7 +20,7 @@ pub fn migrate_30_to_31(
 ///
 /// Recomputes block ordinal due to a bug fixed in #5761.
 pub fn do_migrate_30_to_31(
-    store: &near_store::Store,
+    store: &Store,
     genesis_config: &near_chain_configs::GenesisConfig,
 ) -> anyhow::Result<()> {
     let genesis_height = genesis_config.genesis_height;
@@ -136,36 +132,35 @@ impl<'a> near_store::StoreMigrator for Migrator<'a> {
         }
     }
 
-    fn migrate(&self, _store: &Store, _version: DbVersion) -> anyhow::Result<()> {
-        todo!();
-        // match version {
-        //     0..=26 => unreachable!(),
-        //     27 => {
-        //         // version 27 => 28: add DBCol::StateChangesForSplitStates
-        //         //
-        //         // Does not need to do anything since open db with option
-        //         // `create_missing_column_families`.  Nevertheless need to bump
-        //         // db version, because db_version 27 binary can't open
-        //         // db_version 28 db.  Combine it with migration from 28 to 29;
-        //         // don’t do anything here.
-        //         Ok(())
-        //     }
-        //     28 => near_store::migrations::migrate_28_to_29(storage),
-        //     29 => near_store::migrations::migrate_29_to_30(storage),
-        //     30 => migrate_30_to_31(storage, &self.config),
-        //     31 => near_store::migrations::migrate_31_to_32(storage),
-        //     32 => near_store::migrations::migrate_32_to_33(storage),
-        //     33 => {
-        //         near_store::migrations::migrate_33_to_34(storage, self.config.client_config.archive)
-        //     }
-        //     #[cfg(feature = "protocol_feature_flat_state")]
-        //     34 => {
-        //         tracing::info!(target: "migrations", "Migrating DB version from 34 to 35. Flat storage data will be created on disk.");
-        //         tracing::info!(target: "migrations", "It will happen in parallel with regular block processing. ETA is 5h for RPC node and 10h for archival node.");
-        //         Ok(())
-        //     }
-        //     DB_VERSION.. => unreachable!(),
-        // }
+    fn migrate(&self, store: &Store, version: DbVersion) -> anyhow::Result<()> {
+        match version {
+            0..=26 => unreachable!(),
+            27 => {
+                // version 27 => 28: add DBCol::StateChangesForSplitStates
+                //
+                // Does not need to do anything since open db with option
+                // `create_missing_column_families`.  Nevertheless need to bump
+                // db version, because db_version 27 binary can't open
+                // db_version 28 db.  Combine it with migration from 28 to 29;
+                // don’t do anything here.
+                Ok(())
+            }
+            28 => near_store::migrations::migrate_28_to_29(store),
+            29 => near_store::migrations::migrate_29_to_30(store),
+            30 => migrate_30_to_31(store, &self.config),
+            31 => near_store::migrations::migrate_31_to_32(store),
+            32 => near_store::migrations::migrate_32_to_33(store),
+            33 => {
+                near_store::migrations::migrate_33_to_34(store, self.config.client_config.archive)
+            }
+            #[cfg(feature = "protocol_feature_flat_state")]
+            34 => {
+                tracing::info!(target: "migrations", "Migrating DB version from 34 to 35. Flat storage data will be created on disk.");
+                tracing::info!(target: "migrations", "It will happen in parallel with regular block processing. ETA is 5h for RPC node and 10h for archival node.");
+                Ok(())
+            }
+            DB_VERSION.. => unreachable!(),
+        }
     }
 }
 

--- a/pytest/lib/branches.py
+++ b/pytest/lib/branches.py
@@ -78,6 +78,8 @@ def _compile_binary(branch: str) -> Executables:
     try:
         subprocess.check_output([
             'git',
+            # When checking out old releases we end up in a detached head state
+            # and git prints a scary warning about that. This config silences it.
             '-c',
             'advice.detachedHead=false',
             'checkout',

--- a/pytest/lib/branches.py
+++ b/pytest/lib/branches.py
@@ -76,7 +76,13 @@ def _compile_binary(branch: str) -> Executables:
     prev_branch = current_branch()
     stash_output = subprocess.check_output(['git', 'stash'])
     try:
-        subprocess.check_output(['git', 'checkout', str(branch)])
+        subprocess.check_output([
+            'git',
+            '-c',
+            'advice.detachedHead=false',
+            'checkout',
+            str(branch),
+        ])
         try:
             subprocess.check_output(['git', 'pull', 'origin', str(branch)])
             result = _compile_current(branch)

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -700,14 +700,23 @@ def spin_up_node(config,
     return node
 
 
-def init_cluster(num_nodes, num_observers, num_shards, config,
-                 genesis_config_changes, client_config_changes):
+def init_cluster(num_nodes,
+                 num_observers,
+                 num_shards,
+                 config,
+                 genesis_config_changes,
+                 client_config_changes,
+                 prefix="test"):
     """
     Create cluster configuration
     """
     if 'local' not in config and 'nodes' in config:
         logger.critical(
             "Attempt to launch a regular test with a mocknet config")
+        sys.exit(1)
+
+    if not prefix.startswith("test"):
+        logger.critical(f"The prefix must begin with 'test'. prefix = {prefix}")
         sys.exit(1)
 
     is_local = config['local']
@@ -730,7 +739,7 @@ def init_cluster(num_nodes, num_observers, num_shards, config,
         "--tracked-shards",
         "none",
         "--prefix",
-        "test",
+        prefix,
     ],
                                stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE)

--- a/pytest/tests/sanity/split_storage.py
+++ b/pytest/tests/sanity/split_storage.py
@@ -18,15 +18,22 @@ from cluster import init_cluster, spin_up_node, load_config, get_config_json, se
 from configured_logger import logger
 
 
-class TestRpcFinality(unittest.TestCase):
+class TestSplitStorage(unittest.TestCase):
 
-    def test_base_case(self):
-        config = load_config()
-        near_root, [node_dir] = init_cluster(1, 0, 1, config, [], {})
+    def _pretty_json(self, value):
+        return json.dumps(value, indent=2)
 
+    def _get_split_storage_info(self, node):
+        return node.json_rpc("EXPERIMENTAL_split_storage_info", {})
+
+    def _configure_archive(self, node_dir):
+        node_config = get_config_json(node_dir)
+        node_config["archive"] = True
+        set_config_json(node_dir, node_config)
+
+    def _configure_cold_storage(self, node_dir):
         node_config = get_config_json(node_dir)
 
-        node_config["archive"] = True
         # Need to create a deepcopy of the store config, otherwise
         # store and cold store will point to the same instance and
         # both will end up with the same path.
@@ -36,6 +43,20 @@ class TestRpcFinality(unittest.TestCase):
 
         set_config_json(node_dir, node_config)
 
+    # Configure cold storage and start neard. Wait for a few blocks
+    # and verify that cold head is moving and that it's close behind
+    # final head.
+    def test_base_case(self):
+        print()
+        logger.info(f"starting test_base_case")
+
+        config = load_config()
+        near_root, [node_dir] = init_cluster(1, 0, 1, config, [], {},
+                                             "test_base_case_")
+
+        self._configure_archive(node_dir)
+        self._configure_cold_storage(node_dir)
+
         node = spin_up_node(config, near_root, node_dir, 0, single_node=True)
 
         # Wait until 20 blocks are produced so that we're guaranteed that
@@ -43,11 +64,9 @@ class TestRpcFinality(unittest.TestCase):
         n = 20
         wait_for_blocks(node, target=n)
 
-        split_storage_info = node.json_rpc("EXPERIMENTAL_split_storage_info",
-                                           {})
-
-        logger.info(
-            f"split storage info \n{json.dumps(split_storage_info, indent=2)}")
+        split_storage_info = self._get_split_storage_info(node)
+        pretty_split_storage_info = self._pretty_json(split_storage_info)
+        logger.info(f"split storage info \n{pretty_split_storage_info}")
 
         self.assertNotIn("error", split_storage_info)
         self.assertIn("result", split_storage_info)
@@ -59,6 +78,77 @@ class TestRpcFinality(unittest.TestCase):
         self.assertGreaterEqual(head_height, n)
         self.assertGreaterEqual(final_head_height, n - 3)
         self.assertGreaterEqual(cold_head_height, final_head_height - 3)
+
+        node.kill(gentle=True)
+
+    # Do not configure cold storage and start neard. Wait for a few blocks,
+    # stop neard and only then configure cold store. Wait for a short while
+    # again and check that the cold head has caught up.
+    def test_migration(self):
+        print()
+        logger.info(f"starting test_migration")
+
+        config = load_config()
+        near_root, [node_dir] = init_cluster(1, 0, 1, config, [], {},
+                                             "test_migration_")
+
+        self._configure_archive(node_dir)
+
+        node = spin_up_node(config, near_root, node_dir, 0, single_node=True)
+
+        # Wait until 10 blocks are produced so that we're sure that the db is
+        # properly created and populated with some data.
+        n = 10
+        n = wait_for_blocks(node, target=n).height
+
+        split_storage_info = self._get_split_storage_info(node)
+        pretty_split_storage_info = self._pretty_json(split_storage_info)
+        logger.info(f"split storage info before \n{pretty_split_storage_info}")
+
+        node.kill(gentle=True)
+
+        self.assertNotIn("error", split_storage_info)
+        self.assertIn("result", split_storage_info)
+        result = split_storage_info["result"]
+        head_height = result["head_height"]
+        final_head_height = result["final_head_height"]
+        cold_head_height = result["cold_head_height"]
+        hot_db_kind = result["hot_db_kind"]
+
+        self.assertGreaterEqual(head_height, n)
+        self.assertGreaterEqual(final_head_height, n - 3)
+        # The cold storage is not configured so cold head should be none.
+        self.assertIsNone(cold_head_height)
+        # The hot db kind should remain archive until fully migrated.
+        self.assertEqual(hot_db_kind, "Archive")
+
+        self._configure_cold_storage(node_dir)
+
+        node.start()
+
+        # Wait until 20 blocks are produced so that cold store loop has enough
+        # time to catch up.
+        n += 20
+        wait_for_blocks(node, target=n)
+
+        split_storage_info = self._get_split_storage_info(node)
+        pretty_split_storage_info = self._pretty_json(split_storage_info)
+        logger.info(f"split storage info after \n{pretty_split_storage_info}")
+
+        self.assertNotIn("error", split_storage_info)
+        self.assertIn("result", split_storage_info)
+        result = split_storage_info["result"]
+        head_height = result["head_height"]
+        final_head_height = result["final_head_height"]
+        cold_head_height = result["cold_head_height"]
+        hot_db_kind = result["hot_db_kind"]
+
+        self.assertGreaterEqual(head_height, n)
+        self.assertGreaterEqual(final_head_height, n - 3)
+        # The cold storage head should be fully caught up by now.
+        self.assertGreaterEqual(cold_head_height, final_head_height - 3)
+        # The hot db kind should remain archive until fully migrated.
+        self.assertEqual(hot_db_kind, "Archive")
 
         node.kill(gentle=True)
 


### PR DESCRIPTION
Currently the opener expects both stores to exist or not exist. The case when hot store exists and should be openened and cold store doesn't exist and should be created is not supported. 

This PR addresses this issue - allowing opening hot and creating cold - as well as refactors some of the opener code. 

The overaching principle here is that we can treat hot and cold storages separately and just open/create each and only combine them into NodeStorage as the last step. 

Some side effects of this refactoring are:
- That the opener will apply migrations to both store independently. Previously only the hot storage had migrations applied to it. It's not what we initially discussed but I think it doesn't hurt. 
- We don't need to do as many check on the kind and version - instead we just independently make sure that both hot and cold have correct versions and kinds. 
- The error messages are a bit more precise - previously we were always logging path() which only uses the hot storage, now we use path from the correct temperature storage. This unfortunately is only in the opener itself but could be extended beyond. 