### PR TITLE
[TestLoop] (2/n) Introduce Sender<T> and AsyncSender<T>.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3012,6 +3012,7 @@ dependencies = [
  "actix",
  "derive-enum-from-into",
  "derive_more",
+ "futures",
  "near-o11y",
  "once_cell",
  "serde",

--- a/core/async/Cargo.toml
+++ b/core/async/Cargo.toml
@@ -13,6 +13,7 @@ description = "This crate contains the async helpers specific for nearcore"
 actix.workspace = true
 derive-enum-from-into.workspace = true
 derive_more.workspace = true
+futures.workspace = true
 once_cell.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/core/async/README.md
+++ b/core/async/README.md
@@ -6,3 +6,50 @@ used in nearcore:
 * messaging: common interfaces for sending messages between components.
 * test_loop: a event-loop-based test framework that can test multiple components
   together in a synchronous way.
+
+
+## Messaging
+
+`Sender<T>` and `AsyncSender<T>` are abstractions of our Actix interfaces. When
+a component needs to send a message to another component, the component should
+keep a `Sender<T>` as a field and require it during construction, like:
+
+```rust
+struct MyComponent {
+  downstream_component: Sender<DownstreamMessage>,
+}
+
+impl MyComponent {
+  pub fn new(downstream_component: Sender<DownstreamMessage>) -> Self { ... }
+}
+```
+
+The sender can then be used to send messages:
+```rust
+impl MyComponent {
+  fn do_something(&mut self, args: ...) {
+    self.downstream_component.send(DownstreamMessage::DataReady(...));
+  }
+}
+```
+
+To create a `Sender<T>`, we need any implementation of `CanSend<T>`. One way is
+to use an Actix address:
+```rust
+impl Handler<DownstreamMessage> for DownstreamActor {...}
+
+impl DownstreamActor {
+  pub fn spawn(...) -> Addr<DownstreamActor> {...}
+}
+
+fn setup_system() {
+  let addr = DownstreamActor::spawn(...);
+  let my_component = MyComponent::new(addr.into_sender());
+}
+```
+
+In tests, the `TestLoopBuilder` provides the `sender()` function which also
+implements `CanSend`, see the examples directory under this crate.
+
+`AsyncSender<T>` is similar, except that calling `send_async` returns a future
+that carries the response to the message.

--- a/core/async/src/actix.rs
+++ b/core/async/src/actix.rs
@@ -1,0 +1,86 @@
+use futures::{future::BoxFuture, FutureExt, TryFutureExt};
+use near_o11y::{WithSpanContext, WithSpanContextExt};
+
+use crate::messaging::{CanSend, CanSendAsync};
+
+/// An actix Addr implements CanSend for any message type that the actor handles.
+impl<M, A> CanSend<M> for actix::Addr<A>
+where
+    M: actix::Message + Send + 'static,
+    M::Result: Send,
+    A: actix::Actor + actix::Handler<M>,
+    A::Context: actix::dev::ToEnvelope<A, M>,
+{
+    fn send(&self, message: M) {
+        actix::Addr::do_send(self, message)
+    }
+}
+
+/// An actix Addr implements CanSendAsync for any message type that the actor handles.
+/// Here, the future output of send_async is a Result, because Actix may return an
+/// error. The error is converted to (), so that the caller does not need to be aware of
+/// Actix-specific error messages.
+impl<M, A> CanSendAsync<M, Result<M::Result, ()>> for actix::Addr<A>
+where
+    M: actix::Message + Send + 'static,
+    M::Result: Send,
+    A: actix::Actor + actix::Handler<M>,
+    A::Context: actix::dev::ToEnvelope<A, M>,
+{
+    fn send_async(&self, message: M) -> BoxFuture<'static, Result<M::Result, ()>> {
+        self.send(message).map_err(|_| ()).boxed()
+    }
+}
+
+/// Allows an actix Addr<WithSpanContext<T>> to act as if it were an Addr<T>,
+/// by automatically wrapping any message sent with .with_span_context().
+///
+/// This way, the sender side does not need to be concerned about attaching span contexts, e.g.
+///
+///   impl SomeOtherComponent {
+///     pub fn new(sender: Sender<Message>) -> Self {...}
+///   }
+///
+///   impl actix::Handler<WithSpanContext<Message>> for SomeActor {...}
+///
+///   let addr = SomeActor::spawn(...);
+///   let other = SomeOtherComponent::new(
+///       addr.with_auto_span_context().into_sender()  // or .clone() on the addr if needed
+///   );
+pub struct AddrWithAutoSpanContext<T: actix::Actor> {
+    inner: actix::Addr<T>,
+}
+
+/// Extension function to convert an Addr<WithSpanContext<T>> to an AddrWithAutoSpanContext<T>.
+pub trait AddrWithAutoSpanContextExt<T: actix::Actor> {
+    fn with_auto_span_context(self) -> AddrWithAutoSpanContext<T>;
+}
+
+impl<T: actix::Actor> AddrWithAutoSpanContextExt<T> for actix::Addr<T> {
+    fn with_auto_span_context(self) -> AddrWithAutoSpanContext<T> {
+        AddrWithAutoSpanContext { inner: self }
+    }
+}
+
+impl<M, S> CanSend<M> for AddrWithAutoSpanContext<S>
+where
+    M: actix::Message + 'static,
+    S: actix::Actor,
+    actix::Addr<S>: CanSend<WithSpanContext<M>>,
+{
+    fn send(&self, message: M) {
+        CanSend::send(&self.inner, message.with_span_context());
+    }
+}
+
+impl<M, S> CanSendAsync<M, Result<M::Result, ()>> for AddrWithAutoSpanContext<S>
+where
+    M: actix::Message + 'static,
+    M::Result: Send,
+    S: actix::Actor,
+    actix::Addr<S>: CanSendAsync<WithSpanContext<M>, Result<M::Result, ()>>,
+{
+    fn send_async(&self, message: M) -> BoxFuture<'static, Result<M::Result, ()>> {
+        self.inner.send_async(message.with_span_context())
+    }
+}

--- a/core/async/src/examples/sum_numbers.rs
+++ b/core/async/src/examples/sum_numbers.rs
@@ -1,4 +1,4 @@
-use crate::messaging::ArcSender;
+use crate::messaging::Sender;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ReportSumMsg(pub i64);
@@ -11,15 +11,15 @@ pub enum SumRequest {
 
 // Mimics a typical backing component of some actor in nearcore. Handles request
 // messages, and sends some other messages to another actor. The other actor is
-// abstracted with an ArcSender here. We'll show how to test this in
+// abstracted with an Sender here. We'll show how to test this in
 // sum_numbers_test.rs.
 pub struct SumNumbersComponent {
-    result_sender: ArcSender<ReportSumMsg>,
+    result_sender: Sender<ReportSumMsg>,
     numbers: Vec<i64>,
 }
 
 impl SumNumbersComponent {
-    pub fn new(result_sender: ArcSender<ReportSumMsg>) -> Self {
+    pub fn new(result_sender: Sender<ReportSumMsg>) -> Self {
         Self { result_sender, numbers: vec![] }
     }
 

--- a/core/async/src/examples/sum_numbers_test.rs
+++ b/core/async/src/examples/sum_numbers_test.rs
@@ -1,9 +1,9 @@
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 
 use derive_enum_from_into::{EnumFrom, EnumTryInto};
 
 use crate::{
-    messaging::Sender,
+    messaging::{CanSend, IntoSender},
     test_loop::{CaptureEvents, LoopEventHandler, TestLoopBuilder, TryIntoOrSelf},
 };
 
@@ -45,7 +45,7 @@ fn test_simple() {
     let builder = TestLoopBuilder::<TestEvent>::new();
     // Build the SumNumberComponents so that it sends messages back to the test loop.
     let data =
-        TestData { summer: SumNumbersComponent::new(Arc::new(builder.sender())), sums: vec![] };
+        TestData { summer: SumNumbersComponent::new(builder.sender().into_sender()), sums: vec![] };
     let sender = builder.sender();
     let mut test = builder.build(data);
     test.register_handler(ForwardSumRequest);

--- a/core/async/src/lib.rs
+++ b/core/async/src/lib.rs
@@ -1,5 +1,5 @@
-pub mod messaging;
-pub mod test_loop;
-
+pub mod actix;
 #[cfg(test)]
 mod examples;
+pub mod messaging;
+pub mod test_loop;

--- a/core/async/src/messaging.rs
+++ b/core/async/src/messaging.rs
@@ -1,10 +1,180 @@
+use futures::future::BoxFuture;
+use once_cell::sync::OnceCell;
 use std::sync::Arc;
 
-/// Anything that allows sending a message of type M.
-pub trait Sender<M>: Send + Sync + 'static {
+/// Trait for sending a typed message.
+pub trait CanSend<M>: Send + Sync + 'static {
     fn send(&self, message: M);
 }
 
-pub type ArcSender<M> = Arc<dyn Sender<M>>;
+/// Wraps a CanSend. This should be used to pass around an Arc<dyn CanSend<M>>, instead
+/// of spelling out that type. Using a wrapper struct allows us to define more flexible
+/// APIs.
+pub struct Sender<M: 'static> {
+    sender: Arc<dyn CanSend<M>>,
+}
 
-// TODO: Sender implementation for actix::Addr and other utils.
+impl<M> Clone for Sender<M> {
+    fn clone(&self) -> Self {
+        Self { sender: self.sender.clone() }
+    }
+}
+
+/// Extension functions to wrap a CanSend as a Sender.
+pub trait IntoSender<M> {
+    /// This allows conversion of an owned CanSend into a Sender.
+    fn into_sender(self) -> Sender<M>;
+    /// This allows conversion of a reference-counted CanSend into a Sender.
+    fn as_sender(self: &Arc<Self>) -> Sender<M>;
+}
+
+impl<M, T: CanSend<M>> IntoSender<M> for T {
+    fn into_sender(self) -> Sender<M> {
+        Sender::from_impl(self)
+    }
+    fn as_sender(self: &Arc<Self>) -> Sender<M> {
+        Sender::from_arc(self.clone())
+    }
+}
+
+impl<M> Sender<M> {
+    pub fn send(&self, message: M) {
+        self.sender.send(message)
+    }
+
+    fn from_impl(sender: impl CanSend<M> + 'static) -> Self {
+        Self { sender: Arc::new(sender) }
+    }
+
+    fn from_arc<T: CanSend<M> + 'static>(arc: Arc<T>) -> Self {
+        Self { sender: arc }
+    }
+
+    /// Creates a no-op sender that does nothing with the message.
+    pub fn noop() -> Self {
+        Self::from_impl(Noop)
+    }
+}
+
+/// Allows the sending of a message while expecting a response.
+pub trait CanSendAsync<M, R>: Send + Sync + 'static {
+    fn send_async(&self, message: M) -> BoxFuture<'static, R>;
+}
+
+pub struct AsyncSender<M: 'static, R: 'static> {
+    sender: Arc<dyn CanSendAsync<M, R>>,
+}
+
+impl<M, R> Clone for AsyncSender<M, R> {
+    fn clone(&self) -> Self {
+        Self { sender: self.sender.clone() }
+    }
+}
+
+/// Extension functions to wrap a CanSendAsync as an AsyncSender.
+pub trait IntoAsyncSender<M, R> {
+    /// This allows conversion of an owned CanSendAsync into an AsyncSender.
+    fn into_async_sender(self) -> AsyncSender<M, R>;
+    /// This allows conversion of a reference-counted CanSendAsync into an AsyncSender.
+    fn as_async_sender(self: &Arc<Self>) -> AsyncSender<M, R>;
+}
+
+impl<M, R, T: CanSendAsync<M, R>> IntoAsyncSender<M, R> for T {
+    fn into_async_sender(self) -> AsyncSender<M, R> {
+        AsyncSender::from_impl(self)
+    }
+    fn as_async_sender(self: &Arc<Self>) -> AsyncSender<M, R> {
+        AsyncSender::from_arc(self.clone())
+    }
+}
+
+impl<M, R> AsyncSender<M, R> {
+    pub fn send_async(&self, message: M) -> BoxFuture<'static, R> {
+        self.sender.send_async(message)
+    }
+
+    fn from_impl(sender: impl CanSendAsync<M, R> + 'static) -> Self {
+        Self { sender: Arc::new(sender) }
+    }
+
+    fn from_arc<T: CanSendAsync<M, R> + 'static>(arc: Arc<T>) -> Self {
+        Self { sender: arc }
+    }
+}
+
+/// Sometimes we want to be able to pass in a sender that has not yet been fully constructed.
+/// LateBoundSender can act as a placeholder to pass CanSend and CanSendAsync capabilities
+/// through to the inner object. bind() should be called when the inner object is ready.
+/// All calls to send() and send_async() through this wrapper will block until bind() is called.
+///
+/// This struct is intended to be wrapped with an Arc, e.g.
+///   let late_bound = Arc::new(LateBoundSender::default());
+///   let something_else = SomethingElse::new(late_bound.as_sender());
+///   let implementation = Implementation::new(something_else);
+///   late_bound.bind(implementation);
+pub struct LateBoundSender<S> {
+    sender: OnceCell<S>,
+}
+
+impl<S> Default for LateBoundSender<S> {
+    fn default() -> Self {
+        Self { sender: OnceCell::default() }
+    }
+}
+
+impl<S> LateBoundSender<S> {
+    pub fn bind(&self, sender: S) {
+        self.sender.set(sender).map_err(|_| ()).expect("cannot set sender twice");
+    }
+}
+
+/// Allows LateBoundSender to be convertible to a Sender as long as the inner object could be.
+impl<M, S: CanSend<M>> CanSend<M> for LateBoundSender<S> {
+    fn send(&self, message: M) {
+        self.sender.wait().send(message);
+    }
+}
+
+/// Allows LateBoundSender to be convertible to an AsyncSender as long as the inner object could
+/// be.
+impl<M, R, S: CanSendAsync<M, R>> CanSendAsync<M, R> for LateBoundSender<S> {
+    fn send_async(&self, message: M) -> BoxFuture<'static, R> {
+        self.sender.wait().send_async(message)
+    }
+}
+
+struct Noop;
+
+impl<M> CanSend<M> for Noop {
+    fn send(&self, _message: M) {}
+}
+
+/// Anything that contains a Sender also implements CanSend. This is useful for implementing
+/// APIs that require multiple sender interfaces, so that the multi-sender API can be used
+/// to send individual message types directly.
+///
+/// For example:
+///
+///   #[derive(Clone, derive_more::AsRef)]
+///   pub struct MyAPI {
+///     client: Sender<ClientMessage>,
+///     network: AsyncSender<NetworkMessage, NetworkResponse>,
+///   }
+///
+///   fn something(api: &MyAPI) {
+///     // There's no need to do api.client.send() or api.network.send_async() here.
+///     api.send(ClientMessage::Something);
+///     api.send_async(NetworkMessage::Something).then(...);
+///   }
+impl<A: AsRef<Sender<M>> + Send + Sync + 'static, M: 'static> CanSend<M> for A {
+    fn send(&self, message: M) {
+        self.as_ref().send(message)
+    }
+}
+impl<A: AsRef<AsyncSender<M, R>> + Send + Sync + 'static, M: 'static, R: 'static> CanSendAsync<M, R>
+    for A
+{
+    fn send_async(&self, message: M) -> BoxFuture<'static, R> {
+        self.as_ref().send_async(message)
+    }
+}

--- a/core/async/src/test_loop.rs
+++ b/core/async/src/test_loop.rs
@@ -359,7 +359,7 @@ impl<Event> Clone for DelaySender<Event> {
 
 /// Allows DelaySender to be used in contexts where we don't need a delay,
 /// such as being given to something that expects an actix recipient.
-impl<Message, Event: From<Message> + 'static> messaging::Sender<Message> for DelaySender<Event> {
+impl<Message, Event: From<Message> + 'static> messaging::CanSend<Message> for DelaySender<Event> {
     fn send(&self, message: Message) {
         self.send_with_delay(message.into(), Duration::ZERO);
     }


### PR DESCRIPTION
See README.md changes for details.

This is intended to replace:
 - `MsgRecipient` (which was similar to a combination of Sender and AsyncSender, but is Actix-specific)
 - `NetworkRecipient` (which is basically LateBoundSender)
 - adapters that are trait combinations (e.g. PeerManagerAdapter used to be defined as a trait that requires two MsgRecipient supertraits, but now would be a struct of Senders - making it much more flexible, e.g. we can extract one sender out of the combination)
 - Calling `.with_span_context` everywhere (now we just need to call it once during construction of the Senders)
 - MockXXXAdapters (with a generic Sender implementation)
 - NoOpXXXAdapters (with Sender::noop())

Note that Sender<T> and AsyncSender<T> are structs, so no more having to spell out Arc<dyn PeerManagerAdapter> anymore, it's just PeerManagerAdapter (a struct of senders), and instead of Arc<dyn ClientAdapterForShardsManager> it is now Sender<ShardsManagerResponse>.

In further PRs I will migrate existing code to use these two interfaces.

#8513 