### PR TITLE
Fuzz on master, do not use RUSTC_BOOTSTRAP as we are already using nightly

### DIFF
--- a/.github/workflows/fuzzer_binaries.yml
+++ b/.github/workflows/fuzzer_binaries.yml
@@ -1,8 +1,9 @@
 name: Fuzzer Binaries
 on:
   push:
-    paths:
-      - "scripts/build_fuzzers.py"
+    branches:
+      - master
+      # TODO: see with node team how the info that this is a push to a testnet/mainnet branch should be recorded
 
 jobs:
   build_fuzzers:
@@ -41,5 +42,3 @@ jobs:
       - run: pip install -r scripts/build_fuzzers_requirements.txt
 
       - run: python scripts/build_fuzzers.py
-        env:
-          RUSTC_BOOTSTRAP: "1"


### PR DESCRIPTION
Also, I noticed that in `scripts/build_fuzzers.py` you ended up going with incremental revisions number.

Any reason not to go with just naming each file `-YYYYMMDDhhmmss.zip`? That should be just as monotonically increasing as manually dealing with the files; and should avoid issues like race conditions if two builds run concurrently for two commits that made it to master close to each other. (The date should be acquired at the beginning of the execution of the github action for that)