### PR TITLE
feat: type guarantees for NonDelegateAction

### DIFF
--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -55,6 +55,8 @@ use near_network::types::{
 use near_o11y::testonly::TracingCapture;
 use near_o11y::{WithSpanContext, WithSpanContextExt};
 use near_primitives::block::{ApprovalInner, Block, GenesisId};
+#[cfg(feature = "protocol_feature_nep366_delegate_action")]
+use near_primitives::delegate_action::{DelegateAction, NonDelegateAction, SignedDelegateAction};
 use near_primitives::epoch_manager::RngSeed;
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::merkle::{merklize, MerklePath, PartialMerkleTree};
@@ -66,8 +68,6 @@ use near_primitives::sharding::{EncodedShardChunk, PartialEncodedChunk, ReedSolo
 use near_primitives::time::Utc;
 use near_primitives::time::{Clock, Instant};
 use near_primitives::transaction::{Action, FunctionCallAction, SignedTransaction};
-#[cfg(feature = "protocol_feature_nep366_delegate_action")]
-use near_primitives::transaction::{DelegateAction, NonDelegateAction, SignedDelegateAction};
 
 use near_primitives::types::{
     AccountId, Balance, BlockHeight, BlockHeightDelta, EpochId, NumBlocks, NumSeats, ShardId,
@@ -1855,7 +1855,10 @@ impl TestEnv {
         let delegate_action = DelegateAction {
             sender_id: inner_signer.account_id.clone(),
             receiver_id,
-            actions: actions.into_iter().map(NonDelegateAction).collect(),
+            actions: actions
+                .into_iter()
+                .map(|action| NonDelegateAction::try_from(action).unwrap())
+                .collect(),
             nonce: user_nonce,
             max_block_height: tip.height + 100,
             public_key: inner_signer.public_key(),

--- a/chain/jsonrpc/res/rpc_errors_schema.json
+++ b/chain/jsonrpc/res/rpc_errors_schema.json
@@ -487,7 +487,6 @@
         "FunctionCallArgumentsLengthExceeded",
         "UnsuitableStakingKey",
         "FunctionCallZeroAttachedGas",
-        "DelegateActionCantContainNestedOne",
         "DelegateActionMustBeOnlyOne",
         "UnsupportedProtocolFeature"
       ],
@@ -564,11 +563,6 @@
         "predecessor_id": "",
         "registrar_account_id": ""
       }
-    },
-    "DelegateActionCantContainNestedOne": {
-      "name": "DelegateActionCantContainNestedOne",
-      "subtypes": [],
-      "props": {}
     },
     "DelegateActionExpired": {
       "name": "DelegateActionExpired",

--- a/core/primitives/src/delegate_action.rs
+++ b/core/primitives/src/delegate_action.rs
@@ -23,13 +23,17 @@ pub struct DelegateAction {
     /// Receiver of the delegated actions.
     pub receiver_id: AccountId,
     /// List of actions to be executed.
+    ///
+    /// With the meta transactions MVP defined in NEP-366, nested
+    /// DelegateActions are not allowed. A separate type is used to enforce it.
     pub actions: Vec<NonDelegateAction>,
-    /// Nonce to ensure that the same delegate action is not sent twice by a relayer and should match for given account's `public_key`.
+    /// Nonce to ensure that the same delegate action is not sent twice by a
+    /// relayer and should match for given account's `public_key`.
     /// After this action is processed it will increment.
     pub nonce: Nonce,
     /// The maximal height of the block in the blockchain below which the given DelegateAction is valid.
     pub max_block_height: BlockHeight,
-    /// Public key that is used to sign this delegated action.
+    /// Public key used to sign this delegated action.
     pub public_key: PublicKey,
 }
 

--- a/core/primitives/src/delegate_action.rs
+++ b/core/primitives/src/delegate_action.rs
@@ -10,7 +10,6 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use near_crypto::{PublicKey, Signature};
 use near_primitives_core::types::BlockHeight;
 use serde::{Deserialize, Serialize};
-use std::hash::Hasher;
 use std::io::{Error, ErrorKind};
 
 // This is an index number of Action::Delegate in Action enumeration

--- a/core/primitives/src/delegate_action.rs
+++ b/core/primitives/src/delegate_action.rs
@@ -103,6 +103,7 @@ mod private_non_delegate_action {
     #[error("attempted to construct NonDelegateAction from Action::Delegate")]
     pub struct IsDelegateAction;
 
+    #[cfg(feature = "protocol_feature_nep366_delegate_action")]
     impl TryFrom<Action> for NonDelegateAction {
         type Error = IsDelegateAction;
 

--- a/core/primitives/src/delegate_action.rs
+++ b/core/primitives/src/delegate_action.rs
@@ -1,0 +1,199 @@
+//! DelegateAction is a type of action to support meta transactions.
+//!
+//! NEP: https://github.com/near/NEPs/pull/366
+//! This is the module containing the types introduced for delegate actions.
+
+use crate::hash::{hash, CryptoHash};
+use crate::transaction::Action;
+use crate::types::{AccountId, Nonce};
+use borsh::{BorshDeserialize, BorshSerialize};
+use near_crypto::{PublicKey, Signature};
+use near_primitives_core::types::BlockHeight;
+use serde::{Deserialize, Serialize};
+use std::hash::Hasher;
+use std::io::{Error, ErrorKind};
+
+// This is an index number of Action::Delegate in Action enumeration
+const ACTION_DELEGATE_NUMBER: u8 = 8;
+
+/// This is Action which mustn't contain DelegateAction.
+// This struct is needed to avoid the recursion when Action/DelegateAction is deserialized.
+#[derive(Serialize, BorshSerialize, Deserialize, PartialEq, Eq, Clone, Debug)]
+pub struct NonDelegateAction(pub Action);
+
+impl From<NonDelegateAction> for Action {
+    fn from(action: NonDelegateAction) -> Self {
+        action.0
+    }
+}
+
+impl borsh::de::BorshDeserialize for NonDelegateAction {
+    fn deserialize(buf: &mut &[u8]) -> ::core::result::Result<Self, borsh::maybestd::io::Error> {
+        if buf.is_empty() {
+            return Err(Error::new(
+                ErrorKind::InvalidInput,
+                "Failed to deserialize DelegateAction",
+            ));
+        }
+        match buf[0] {
+            ACTION_DELEGATE_NUMBER => Err(Error::new(
+                ErrorKind::InvalidInput,
+                "DelegateAction mustn't contain a nested one",
+            )),
+            _ => Ok(Self(borsh::BorshDeserialize::deserialize(buf)?)),
+        }
+    }
+}
+
+/// This action allows to execute the inner actions behalf of the defined sender.
+#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
+pub struct DelegateAction {
+    /// Signer of the delegated actions
+    pub sender_id: AccountId,
+    /// Receiver of the delegated actions.
+    pub receiver_id: AccountId,
+    /// List of actions to be executed.
+    pub actions: Vec<NonDelegateAction>,
+    /// Nonce to ensure that the same delegate action is not sent twice by a relayer and should match for given account's `public_key`.
+    /// After this action is processed it will increment.
+    pub nonce: Nonce,
+    /// The maximal height of the block in the blockchain below which the given DelegateAction is valid.
+    pub max_block_height: BlockHeight,
+    /// Public key that is used to sign this delegated action.
+    pub public_key: PublicKey,
+}
+
+#[cfg_attr(feature = "protocol_feature_nep366_delegate_action", derive(BorshDeserialize))]
+#[derive(BorshSerialize, Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
+pub struct SignedDelegateAction {
+    pub delegate_action: DelegateAction,
+    pub signature: Signature,
+}
+
+#[cfg(not(feature = "protocol_feature_nep366_delegate_action"))]
+impl borsh::de::BorshDeserialize for SignedDelegateAction {
+    fn deserialize(_buf: &mut &[u8]) -> ::core::result::Result<Self, borsh::maybestd::io::Error> {
+        return Err(Error::new(ErrorKind::InvalidInput, "Delegate action isn't supported"));
+    }
+}
+
+impl SignedDelegateAction {
+    pub fn verify(&self) -> bool {
+        let delegate_action = &self.delegate_action;
+        let hash = delegate_action.get_hash();
+        let public_key = &delegate_action.public_key;
+
+        self.signature.verify(hash.as_ref(), public_key)
+    }
+}
+
+#[cfg(feature = "protocol_feature_nep366_delegate_action")]
+impl From<SignedDelegateAction> for Action {
+    fn from(delegate_action: SignedDelegateAction) -> Self {
+        Self::Delegate(delegate_action)
+    }
+}
+
+impl DelegateAction {
+    pub fn get_actions(&self) -> Vec<Action> {
+        self.actions.iter().map(|a| a.clone().into()).collect()
+    }
+
+    pub fn get_hash(&self) -> CryptoHash {
+        let bytes = self.try_to_vec().expect("Failed to deserialize");
+        hash(&bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "protocol_feature_nep366_delegate_action")]
+    fn create_delegate_action(actions: Vec<Action>) -> Action {
+        Action::Delegate(SignedDelegateAction {
+            delegate_action: DelegateAction {
+                sender_id: "aaa".parse().unwrap(),
+                receiver_id: "bbb".parse().unwrap(),
+                actions: actions.iter().map(|a| NonDelegateAction(a.clone())).collect(),
+                nonce: 1,
+                max_block_height: 2,
+                public_key: PublicKey::empty(KeyType::ED25519),
+            },
+            signature: Signature::empty(KeyType::ED25519),
+        })
+    }
+
+    #[test]
+    #[cfg(feature = "protocol_feature_nep366_delegate_action")]
+    fn test_delegate_action_deserialization() {
+        // Expected an error. Buffer is empty
+        assert_eq!(
+            NonDelegateAction::try_from_slice(Vec::new().as_ref()).map_err(|e| e.kind()),
+            Err(ErrorKind::InvalidInput)
+        );
+
+        let delegate_action = create_delegate_action(Vec::<Action>::new());
+        let serialized_non_delegate_action =
+            create_delegate_action(vec![delegate_action]).try_to_vec().expect("Expect ok");
+
+        // Expected Action::Delegate has not been moved in enum Action
+        assert_eq!(serialized_non_delegate_action[0], ACTION_DELEGATE_NUMBER);
+
+        // Expected a nested DelegateAction error
+        assert_eq!(
+            NonDelegateAction::try_from_slice(&serialized_non_delegate_action)
+                .map_err(|e| e.kind()),
+            Err(ErrorKind::InvalidInput)
+        );
+
+        let delegate_action =
+            create_delegate_action(vec![Action::CreateAccount(CreateAccountAction {})]);
+        let serialized_delegate_action = delegate_action.try_to_vec().expect("Expect ok");
+
+        // Valid action
+        assert_eq!(
+            Action::try_from_slice(&serialized_delegate_action).expect("Expect ok"),
+            delegate_action
+        );
+    }
+
+    /// Check that we will not accept delegate actions with the feature
+    /// disabled.
+    ///
+    /// This test is to ensure that while working on meta transactions, we don't
+    /// accientally start accepting delegate actions in receipts. Otherwise, a
+    /// malicious validator could create receipts that include delegate actions
+    /// and other nodes will accept such a receipt.
+    ///
+    /// TODO: Before stabilizing "protocol_feature_nep366_delegate_action" we
+    /// have to replace this rest with a test that checks that we discard
+    /// delegate actions for earlier versions somewhere in validation.
+    #[test]
+    #[cfg(not(feature = "protocol_feature_nep366_delegate_action"))]
+    fn test_delegate_action_deserialization() {
+        let serialized_delegate_action = hex::decode(DELEGATE_ACTION_HEX).expect("invalid hex");
+
+        // DelegateAction isn't supported
+        assert_eq!(
+            Action::try_from_slice(&serialized_delegate_action).map_err(|e| e.kind()),
+            Err(ErrorKind::InvalidInput)
+        );
+    }
+
+    /// Check that the hard-coded delegate action is valid.
+    #[test]
+    #[cfg(feature = "protocol_feature_nep366_delegate_action")]
+    fn test_delegate_action_deserialization_hard_coded() {
+        let serialized_delegate_action = hex::decode(DELEGATE_ACTION_HEX).expect("invalid hex");
+        // The hex data is the same as the one we create below.
+        let delegate_action =
+            create_delegate_action(vec![Action::CreateAccount(CreateAccountAction {})]);
+
+        // Valid action
+        assert_eq!(
+            Action::try_from_slice(&serialized_delegate_action).expect("Expect ok"),
+            delegate_action
+        );
+    }
+}

--- a/core/primitives/src/errors.rs
+++ b/core/primitives/src/errors.rs
@@ -199,8 +199,6 @@ pub enum ActionsValidationError {
     UnsuitableStakingKey { public_key: PublicKey },
     /// The attached amount of gas in a FunctionCall action has to be a positive number.
     FunctionCallZeroAttachedGas,
-    /// DelegateAction actions contain another DelegateAction. This is not allowed.
-    DelegateActionCantContainNestedOne,
     /// There should be the only one DelegateAction
     DelegateActionMustBeOnlyOne,
     /// The transaction includes a feature that the current protocol version
@@ -325,10 +323,6 @@ impl Display for ActionsValidationError {
             ActionsValidationError::FunctionCallZeroAttachedGas => write!(
                 f,
                 "The attached amount of gas in a FunctionCall action has to be a positive number",
-            ),
-            ActionsValidationError::DelegateActionCantContainNestedOne => write!(
-                f,
-                "DelegateAction must not contain another DelegateAction"
             ),
             ActionsValidationError::DelegateActionMustBeOnlyOne => write!(
                 f,

--- a/core/primitives/src/lib.rs
+++ b/core/primitives/src/lib.rs
@@ -10,6 +10,7 @@ pub use near_primitives_core::serialize;
 pub mod block;
 pub mod block_header;
 pub mod challenge;
+pub mod delegate_action;
 pub mod epoch_manager;
 pub mod errors;
 pub mod merkle;

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -456,19 +456,6 @@ mod tests {
     use borsh::BorshDeserialize;
     use near_crypto::{InMemorySigner, KeyType, Signature, Signer};
 
-    /// A serialized `Action::Delegate(SignedDelegateAction)` for testing.
-    ///
-    /// We want this to be parseable and accepted by protocol versions with meta
-    /// transactions enabled. But it should fail either in parsing or in
-    /// validation when this is included in a receipt for a block of an earlier
-    /// version. For now, it just fails to parse, as a test below checks.
-    const DELEGATE_ACTION_HEX: &str = concat!(
-        "0803000000616161030000006262620100000000010000000000000002000000000000",
-        "0000000000000000000000000000000000000000000000000000000000000000000000",
-        "0000000000000000000000000000000000000000000000000000000000000000000000",
-        "0000000000000000000000000000000000000000000000000000000000"
-    );
-
     #[test]
     fn test_verify_transaction() {
         let signer = InMemorySigner::from_random("test".parse().unwrap(), KeyType::ED25519);

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -1,10 +1,8 @@
 use std::borrow::Borrow;
 use std::fmt;
 use std::hash::{Hash, Hasher};
-use std::io::{Error, ErrorKind};
 
 use borsh::{BorshDeserialize, BorshSerialize};
-use near_primitives_core::types::BlockHeight;
 use serde::{Deserialize, Serialize};
 
 use near_crypto::{PublicKey, Signature};
@@ -19,9 +17,6 @@ use crate::serialize::{base64_format, dec_format};
 use crate::types::{AccountId, Balance, Gas, Nonce};
 
 pub type LogEntry = String;
-
-// This is an index number of Action::Delegate in Action enumeration
-const ACTION_DELEGATE_NUMBER: u8 = 8;
 
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 pub struct Transaction {
@@ -214,95 +209,6 @@ pub struct DeleteAccountAction {
 impl From<DeleteAccountAction> for Action {
     fn from(delete_account_action: DeleteAccountAction) -> Self {
         Self::DeleteAccount(delete_account_action)
-    }
-}
-
-/// This is Action which mustn't contain DelegateAction.
-// This struct is needed to avoid the recursion when Action/DelegateAction is deserialized.
-#[derive(Serialize, BorshSerialize, Deserialize, PartialEq, Eq, Clone, Debug)]
-pub struct NonDelegateAction(pub Action);
-
-impl From<NonDelegateAction> for Action {
-    fn from(action: NonDelegateAction) -> Self {
-        action.0
-    }
-}
-
-impl borsh::de::BorshDeserialize for NonDelegateAction {
-    fn deserialize(buf: &mut &[u8]) -> ::core::result::Result<Self, borsh::maybestd::io::Error> {
-        if buf.is_empty() {
-            return Err(Error::new(
-                ErrorKind::InvalidInput,
-                "Failed to deserialize DelegateAction",
-            ));
-        }
-        match buf[0] {
-            ACTION_DELEGATE_NUMBER => Err(Error::new(
-                ErrorKind::InvalidInput,
-                "DelegateAction mustn't contain a nested one",
-            )),
-            _ => Ok(Self(borsh::BorshDeserialize::deserialize(buf)?)),
-        }
-    }
-}
-
-/// This action allows to execute the inner actions behalf of the defined sender.
-#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
-pub struct DelegateAction {
-    /// Signer of the delegated actions
-    pub sender_id: AccountId,
-    /// Receiver of the delegated actions.
-    pub receiver_id: AccountId,
-    /// List of actions to be executed.
-    pub actions: Vec<NonDelegateAction>,
-    /// Nonce to ensure that the same delegate action is not sent twice by a relayer and should match for given account's `public_key`.
-    /// After this action is processed it will increment.
-    pub nonce: Nonce,
-    /// The maximal height of the block in the blockchain below which the given DelegateAction is valid.
-    pub max_block_height: BlockHeight,
-    /// Public key that is used to sign this delegated action.
-    pub public_key: PublicKey,
-}
-
-#[cfg_attr(feature = "protocol_feature_nep366_delegate_action", derive(BorshDeserialize))]
-#[derive(BorshSerialize, Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
-pub struct SignedDelegateAction {
-    pub delegate_action: DelegateAction,
-    pub signature: Signature,
-}
-
-#[cfg(not(feature = "protocol_feature_nep366_delegate_action"))]
-impl borsh::de::BorshDeserialize for SignedDelegateAction {
-    fn deserialize(_buf: &mut &[u8]) -> ::core::result::Result<Self, borsh::maybestd::io::Error> {
-        return Err(Error::new(ErrorKind::InvalidInput, "Delegate action isn't supported"));
-    }
-}
-
-impl SignedDelegateAction {
-    pub fn verify(&self) -> bool {
-        let delegate_action = &self.delegate_action;
-        let hash = delegate_action.get_hash();
-        let public_key = &delegate_action.public_key;
-
-        self.signature.verify(hash.as_ref(), public_key)
-    }
-}
-
-#[cfg(feature = "protocol_feature_nep366_delegate_action")]
-impl From<SignedDelegateAction> for Action {
-    fn from(delegate_action: SignedDelegateAction) -> Self {
-        Self::Delegate(delegate_action)
-    }
-}
-
-impl DelegateAction {
-    pub fn get_actions(&self) -> Vec<Action> {
-        self.actions.iter().map(|a| a.clone().into()).collect()
-    }
-
-    pub fn get_hash(&self) -> CryptoHash {
-        let bytes = self.try_to_vec().expect("Failed to deserialize");
-        hash(&bytes)
     }
 }
 
@@ -654,94 +560,6 @@ mod tests {
                 hash("321".as_bytes()),
             ],
             outcome.to_hashes()
-        );
-    }
-
-    #[cfg(feature = "protocol_feature_nep366_delegate_action")]
-    fn create_delegate_action(actions: Vec<Action>) -> Action {
-        Action::Delegate(SignedDelegateAction {
-            delegate_action: DelegateAction {
-                sender_id: "aaa".parse().unwrap(),
-                receiver_id: "bbb".parse().unwrap(),
-                actions: actions.iter().map(|a| NonDelegateAction(a.clone())).collect(),
-                nonce: 1,
-                max_block_height: 2,
-                public_key: PublicKey::empty(KeyType::ED25519),
-            },
-            signature: Signature::empty(KeyType::ED25519),
-        })
-    }
-
-    #[test]
-    #[cfg(feature = "protocol_feature_nep366_delegate_action")]
-    fn test_delegate_action_deserialization() {
-        // Expected an error. Buffer is empty
-        assert_eq!(
-            NonDelegateAction::try_from_slice(Vec::new().as_ref()).map_err(|e| e.kind()),
-            Err(ErrorKind::InvalidInput)
-        );
-
-        let delegate_action = create_delegate_action(Vec::<Action>::new());
-        let serialized_non_delegate_action =
-            create_delegate_action(vec![delegate_action]).try_to_vec().expect("Expect ok");
-
-        // Expected Action::Delegate has not been moved in enum Action
-        assert_eq!(serialized_non_delegate_action[0], ACTION_DELEGATE_NUMBER);
-
-        // Expected a nested DelegateAction error
-        assert_eq!(
-            NonDelegateAction::try_from_slice(&serialized_non_delegate_action)
-                .map_err(|e| e.kind()),
-            Err(ErrorKind::InvalidInput)
-        );
-
-        let delegate_action =
-            create_delegate_action(vec![Action::CreateAccount(CreateAccountAction {})]);
-        let serialized_delegate_action = delegate_action.try_to_vec().expect("Expect ok");
-
-        // Valid action
-        assert_eq!(
-            Action::try_from_slice(&serialized_delegate_action).expect("Expect ok"),
-            delegate_action
-        );
-    }
-
-    /// Check that we will not accept delegate actions with the feature
-    /// disabled.
-    ///
-    /// This test is to ensure that while working on meta transactions, we don't
-    /// accientally start accepting delegate actions in receipts. Otherwise, a
-    /// malicious validator could create receipts that include delegate actions
-    /// and other nodes will accept such a receipt.
-    ///
-    /// TODO: Before stabilizing "protocol_feature_nep366_delegate_action" we
-    /// have to replace this rest with a test that checks that we discard
-    /// delegate actions for earlier versions somewhere in validation.
-    #[test]
-    #[cfg(not(feature = "protocol_feature_nep366_delegate_action"))]
-    fn test_delegate_action_deserialization() {
-        let serialized_delegate_action = hex::decode(DELEGATE_ACTION_HEX).expect("invalid hex");
-
-        // DelegateAction isn't supported
-        assert_eq!(
-            Action::try_from_slice(&serialized_delegate_action).map_err(|e| e.kind()),
-            Err(ErrorKind::InvalidInput)
-        );
-    }
-
-    /// Check that the hard-coded delegate action is valid.
-    #[test]
-    #[cfg(feature = "protocol_feature_nep366_delegate_action")]
-    fn test_delegate_action_deserialization_hard_coded() {
-        let serialized_delegate_action = hex::decode(DELEGATE_ACTION_HEX).expect("invalid hex");
-        // The hex data is the same as the one we create below.
-        let delegate_action =
-            create_delegate_action(vec![Action::CreateAccount(CreateAccountAction {})]);
-
-        // Valid action
-        assert_eq!(
-            Action::try_from_slice(&serialized_delegate_action).expect("Expect ok"),
-            delegate_action
         );
     }
 }

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -16,6 +16,9 @@ use crate::merkle::MerklePath;
 use crate::serialize::{base64_format, dec_format};
 use crate::types::{AccountId, Balance, Gas, Nonce};
 
+#[cfg(feature = "protocol_feature_nep366_delegate_action")]
+use crate::delegate_action::SignedDelegateAction;
+
 pub type LogEntry = String;
 
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -54,7 +54,7 @@ use crate::version::{ProtocolVersion, Version};
 use validator_stake_view::ValidatorStakeView;
 
 #[cfg(feature = "protocol_feature_nep366_delegate_action")]
-use crate::transaction::{DelegateAction, SignedDelegateAction};
+use crate::delegate_action::{DelegateAction, SignedDelegateAction};
 
 /// A view of the account
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]

--- a/integration-tests/src/tests/client/features/delegate_action.rs
+++ b/integration-tests/src/tests/client/features/delegate_action.rs
@@ -1,6 +1,7 @@
 //! DelegateAction is a type of action to support meta transactions.
 //!
 //! NEP: https://github.com/near/NEPs/pull/366
+//! This is the module for its integration tests.
 
 use crate::tests::client::process_blocks::create_nightshade_runtimes;
 use near_chain::ChainGenesis;
@@ -49,7 +50,7 @@ fn accept_valid_meta_tx() {
 /// During the protocol upgrade phase, before the voting completes, we must not
 /// include meta transaction on the chain.
 ///
-/// Imagine a validator with an update binary. A malicious node sends it a meta
+/// Imagine a validator with an updated binary. A malicious node sends it a meta
 /// transaction to execute before the upgrade has finished. We must ensure the
 /// validator will not attempt adding it to the change unless the protocol
 /// upgrade has completed.

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -985,11 +985,13 @@ mod tests {
     #[cfg(feature = "protocol_feature_nep366_delegate_action")]
     use near_primitives::account::FunctionCallPermission;
     #[cfg(feature = "protocol_feature_nep366_delegate_action")]
+    use near_primitives::delegate_action::NonDelegateAction;
+    #[cfg(feature = "protocol_feature_nep366_delegate_action")]
     use near_primitives::errors::InvalidAccessKeyError;
     #[cfg(feature = "protocol_feature_nep366_delegate_action")]
     use near_primitives::runtime::migration_data::MigrationFlags;
     #[cfg(feature = "protocol_feature_nep366_delegate_action")]
-    use near_primitives::transaction::{CreateAccountAction, NonDelegateAction};
+    use near_primitives::transaction::CreateAccountAction;
     #[cfg(feature = "protocol_feature_nep366_delegate_action")]
     use near_primitives::types::{EpochId, StateChangeCause};
     #[cfg(feature = "protocol_feature_nep366_delegate_action")]
@@ -1182,7 +1184,7 @@ mod tests {
                 sender_id: "bob.test.near".parse().unwrap(),
                 receiver_id: "token.test.near".parse().unwrap(),
                 actions: vec![
-                    NonDelegateAction(
+                    non_delegate_action(
                         Action::FunctionCall(
                             FunctionCallAction {
                                  method_name: "ft_transfer".parse().unwrap(),
@@ -1253,6 +1255,11 @@ mod tests {
         store_update.commit().unwrap();
 
         tries.new_trie_update(ShardUId::single_shard(), root)
+    }
+    #[cfg(feature = "protocol_feature_nep366_delegate_action")]
+    fn non_delegate_action(action: Action) -> NonDelegateAction {
+        NonDelegateAction::try_from(action)
+            .expect("cannot violate type invariants, not even in test")
     }
 
     #[test]
@@ -1591,7 +1598,7 @@ mod tests {
 
         let mut delegate_action = signed_delegate_action.delegate_action.clone();
         delegate_action.actions =
-            vec![NonDelegateAction(Action::FunctionCall(FunctionCallAction {
+            vec![non_delegate_action(Action::FunctionCall(FunctionCallAction {
                 args: Vec::new(),
                 deposit: 0,
                 gas: 300,
@@ -1616,7 +1623,7 @@ mod tests {
 
         let mut delegate_action = signed_delegate_action.delegate_action.clone();
         delegate_action.actions =
-            vec![NonDelegateAction(Action::CreateAccount(CreateAccountAction {}))];
+            vec![non_delegate_action(Action::CreateAccount(CreateAccountAction {}))];
 
         let result = test_delegate_action_key_permissions(&access_key, &delegate_action);
 
@@ -1644,13 +1651,13 @@ mod tests {
 
         let mut delegate_action = signed_delegate_action.delegate_action.clone();
         delegate_action.actions = vec![
-            NonDelegateAction(Action::FunctionCall(FunctionCallAction {
+            non_delegate_action(Action::FunctionCall(FunctionCallAction {
                 args: Vec::new(),
                 deposit: 0,
                 gas: 300,
                 method_name: "test_method".parse().unwrap(),
             })),
-            NonDelegateAction(Action::FunctionCall(FunctionCallAction {
+            non_delegate_action(Action::FunctionCall(FunctionCallAction {
                 args: Vec::new(),
                 deposit: 0,
                 gas: 300,
@@ -1684,7 +1691,7 @@ mod tests {
 
         let mut delegate_action = signed_delegate_action.delegate_action.clone();
         delegate_action.actions =
-            vec![NonDelegateAction(Action::FunctionCall(FunctionCallAction {
+            vec![non_delegate_action(Action::FunctionCall(FunctionCallAction {
                 args: Vec::new(),
                 deposit: 1,
                 gas: 300,
@@ -1717,7 +1724,7 @@ mod tests {
 
         let mut delegate_action = signed_delegate_action.delegate_action.clone();
         delegate_action.actions =
-            vec![NonDelegateAction(Action::FunctionCall(FunctionCallAction {
+            vec![non_delegate_action(Action::FunctionCall(FunctionCallAction {
                 args: Vec::new(),
                 deposit: 0,
                 gas: 300,
@@ -1753,7 +1760,7 @@ mod tests {
 
         let mut delegate_action = signed_delegate_action.delegate_action.clone();
         delegate_action.actions =
-            vec![NonDelegateAction(Action::FunctionCall(FunctionCallAction {
+            vec![non_delegate_action(Action::FunctionCall(FunctionCallAction {
                 args: Vec::new(),
                 deposit: 0,
                 gas: 300,

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -38,9 +38,9 @@ use near_vm_runner::precompile_contract;
 #[cfg(feature = "protocol_feature_nep366_delegate_action")]
 use crate::config::{total_prepaid_exec_fees, total_prepaid_gas, total_prepaid_send_fees};
 #[cfg(feature = "protocol_feature_nep366_delegate_action")]
-use near_primitives::errors::InvalidAccessKeyError;
+use near_primitives::delegate_action::{DelegateAction, SignedDelegateAction};
 #[cfg(feature = "protocol_feature_nep366_delegate_action")]
-use near_primitives::transaction::{DelegateAction, SignedDelegateAction};
+use near_primitives::errors::InvalidAccessKeyError;
 #[cfg(feature = "protocol_feature_nep366_delegate_action")]
 use near_primitives::types::Gas;
 #[cfg(feature = "protocol_feature_nep366_delegate_action")]

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -629,7 +629,7 @@ mod tests {
     #[cfg(feature = "protocol_feature_nep366_delegate_action")]
     use near_crypto::Signature;
     #[cfg(feature = "protocol_feature_nep366_delegate_action")]
-    use near_primitives::transaction::{DelegateAction, NonDelegateAction};
+    use near_primitives::delegate_action::{DelegateAction, NonDelegateAction};
 
     /// Initial balance used in tests.
     const TESTING_INIT_BALANCE: Balance = 1_000_000_000 * NEAR_BASE;
@@ -1905,7 +1905,10 @@ mod tests {
             delegate_action: DelegateAction {
                 sender_id: "bob.test.near".parse().unwrap(),
                 receiver_id: "token.test.near".parse().unwrap(),
-                actions: vec![NonDelegateAction(Action::CreateAccount(CreateAccountAction {}))],
+                actions: vec![NonDelegateAction::try_from(Action::CreateAccount(
+                    CreateAccountAction {},
+                ))
+                .unwrap()],
                 nonce: 19000001,
                 max_block_height: 57,
                 public_key: PublicKey::empty(KeyType::ED25519),

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -134,7 +134,7 @@ fn is_zero_balance_account(
 }
 
 #[cfg(feature = "protocol_feature_nep366_delegate_action")]
-use near_primitives::transaction::SignedDelegateAction;
+use near_primitives::delegate_action::SignedDelegateAction;
 
 /// Validates the transaction without using the state. It allows any node to validate a
 /// transaction before forwarding it to the node that tracks the `signer_id` account.


### PR DESCRIPTION
Reviewer note: You may want to review this commit by commit,
as I also moved code between modules.

Background: I first added an integration test for
`DelegateActionCantContainNestedOne`.
It had the node panic with an "InvalidChunk" message.

So I started thinking. Since we define recursive delegate actions
to be syntactically wrong (parser error) it really is an invalid chunk
when it includes such a transaction. I could only construct it for the
test while bypassing borsh deserialization. Such a test doesn't really
make sense, because then I violate type invariants and in such a case
it's entirely possible that the node crashes.

My conclusion is, we must forbid the creation of an invalid
`NonDelegateAction`. I changed the code to make it obvious that
there is no violating code, using private fields and only checked
constructors.

At last, I can remove `DelegateActionCantContainNestedOne` as a
specific error and instead treat this as a proper borsh deserialization
error. 