### PR TITLE
feat: flat storage cache

### DIFF
--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -93,6 +93,8 @@ pub struct StoreConfig {
     /// frequently we check creation status and execute work related to it in
     /// main thread (scheduling and collecting state parts, catching up blocks, etc.).
     pub flat_storage_creation_period: Duration,
+    /// Capacity of `ValueRef`s cache for flat storage head for each shard.
+    pub flat_state_cache_capacity: u64,
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -231,6 +233,12 @@ impl Default for StoreConfig {
             // One second should be enough to save deltas on start and catch up
             // flat storage head quickly. State read work is much more expensive.
             flat_storage_creation_period: Duration::from_secs(1),
+
+            // Chosen based on our estimations on Dec 2022, so that performances of
+            // flat storage and trie with caches are comparable.
+            // Total size of all flat state caches can't exceed 100_000 * 2 KB (max
+            // storage key length) * 4 (number of tracked shards) = 800 MB.
+            flat_state_cache_capacity: 100_000,
         }
     }
 }

--- a/core/store/src/trie/config.rs
+++ b/core/store/src/trie/config.rs
@@ -31,6 +31,8 @@ pub struct TrieConfig {
     pub sweat_prefetch_receivers: Vec<AccountId>,
     /// List of allowed predecessor accounts for SWEAT prefetching.
     pub sweat_prefetch_senders: Vec<AccountId>,
+    /// Capacity of `ValueRef`s cache for flat storage head for each shard.
+    pub flat_state_cache_capacity: u64,
 }
 
 impl TrieConfig {
@@ -62,6 +64,8 @@ impl TrieConfig {
                 Err(e) => error!(target: "config", "invalid account id {account}: {e}"),
             }
         }
+
+        this.flat_state_cache_capacity = config.flat_state_cache_capacity.clone();
 
         this
     }

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -331,6 +331,10 @@ impl ShardTries {
     ) -> StateRoot {
         self.apply_all_inner(trie_changes, shard_uid, true, store_update)
     }
+
+    pub fn flat_state_cache_capacity(&self) -> u64 {
+        self.0.trie_config.flat_state_cache_capacity
+    }
 }
 
 pub struct WrappedTrieChanges {

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -747,8 +747,14 @@ impl RuntimeAdapter for NightshadeRuntime {
         latest_block_height: BlockHeight,
         chain_access: &dyn ChainAccessForFlatStorage,
     ) {
-        let flat_storage_state =
-            FlatStorageState::new(self.store.clone(), shard_id, latest_block_height, chain_access);
+        let cache_capacity = self.tries.flat_state_cache_capacity() as usize;
+        let flat_storage_state = FlatStorageState::new(
+            self.store.clone(),
+            shard_id,
+            latest_block_height,
+            chain_access,
+            cache_capacity,
+        );
         self.flat_state_factory.add_flat_storage_state_for_shard(shard_id, flat_storage_state);
     }
 


### PR DESCRIPTION
Based on @jakmeier' estimations, we need to cache `ValueRef`s for flat storage head (see https://github.com/near/nearcore/issues/8006). RocksDB internal impl and block cache doesn't help, and we need to make flat storage performance to be at least comparable to trie performance in MVP, in order not to make undercharging issue worse.

This cache lives inside `FlatStorageState`, can be accessed in `get_ref` before attempt to read value ref from flat storage head, and must be updated when we apply delta.

I think it makes sense to make cache capacity configurable, and this config fits into `StoreConfig`. I don't like that is propagated to `FlatStorageState` from `ShardTries`, it makes trie storage and flat storage mixed even more. Perhaps it needs to be fully moved inside `FlatStateFactory`, but I am not sure.

## Testing

Extend `flat_storage_state_sanity` to check both cached and non-cached versions.