### PR TITLE
feat: adding metrics for the cold store loop

### DIFF
--- a/core/store/src/cold_storage.rs
+++ b/core/store/src/cold_storage.rs
@@ -8,7 +8,6 @@ use near_primitives::block::{Block, BlockHeader, Tip};
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::sharding::ShardChunk;
-use near_primitives::time::Clock;
 use near_primitives::types::BlockHeight;
 use std::collections::HashMap;
 use std::io;
@@ -50,7 +49,7 @@ pub fn update_cold_db<D: Database>(
     height: &BlockHeight,
 ) -> io::Result<bool> {
     let _span = tracing::debug_span!(target: "store", "update cold db", height = height);
-    let start_time = Clock::instant();
+    let _timer = metrics::COLD_COPY_DURATION.start_timer();
 
     let mut store_with_cache = StoreWithCache { store: hot_store, cache: StoreCache::new() };
 
@@ -69,10 +68,6 @@ pub fn update_cold_db<D: Database>(
             )?;
         }
     }
-
-    let end_time = Clock::instant();
-    let duration = end_time.saturating_duration_since(start_time);
-    metrics::COLD_COPY_DURATION.observe(duration.as_secs_f64());
 
     Ok(true)
 }

--- a/core/store/src/metrics.rs
+++ b/core/store/src/metrics.rs
@@ -1,6 +1,7 @@
 use near_o11y::metrics::{
-    try_create_histogram_vec, try_create_int_counter_vec, try_create_int_gauge,
-    try_create_int_gauge_vec, HistogramVec, IntCounterVec, IntGauge, IntGaugeVec,
+    try_create_histogram, try_create_histogram_vec, try_create_int_counter_vec,
+    try_create_int_gauge, try_create_int_gauge_vec, Histogram, HistogramVec, IntCounterVec,
+    IntGauge, IntGaugeVec,
 };
 use once_cell::sync::Lazy;
 
@@ -223,6 +224,13 @@ pub static COLD_MIGRATION_READS: Lazy<IntCounterVec> = Lazy::new(|| {
 });
 pub static COLD_HEAD_HEIGHT: Lazy<IntGauge> = Lazy::new(|| {
     try_create_int_gauge("near_cold_head_height", "Height of the head of cold storage").unwrap()
+});
+pub static COLD_COPY_DURATION: Lazy<Histogram> = Lazy::new(|| {
+    try_create_histogram(
+        "near_cold_copy_duration",
+        "Time it takes to copy one height to cold storage",
+    )
+    .unwrap()
 });
 
 pub static FLAT_STORAGE_HEAD_HEIGHT: Lazy<IntGaugeVec> = Lazy::new(|| {

--- a/nearcore/src/metrics.rs
+++ b/nearcore/src/metrics.rs
@@ -1,5 +1,6 @@
 use near_o11y::metrics::{
-    linear_buckets, try_create_histogram_vec, try_create_int_gauge, HistogramVec, IntGauge,
+    linear_buckets, try_create_histogram_vec, try_create_int_counter_vec, try_create_int_gauge,
+    HistogramVec, IntCounterVec, IntGauge,
 };
 use once_cell::sync::Lazy;
 
@@ -31,6 +32,15 @@ pub(crate) static CONFIG_CORRECT: Lazy<IntGauge> = Lazy::new(|| {
     try_create_int_gauge(
         "near_config_correct",
         "Are the current dynamically loadable configs correct",
+    )
+    .unwrap()
+});
+
+pub(crate) static COLD_STORE_COPY_RESULT: Lazy<IntCounterVec> = Lazy::new(|| {
+    try_create_int_counter_vec(
+        "near_cold_store_copy_result",
+        "The result of a cold store copy iteration in the cold store loop.",
+        &["copy_result"],
     )
     .unwrap()
 });


### PR DESCRIPTION
added two new metrics for the cold store:
- COLD_COPY_DURATION that is a histogram that tracks the time to copy one height from hot to cold
- COLD_STORE_COPY_RESULT that is a counter vector that tracks counters for each possible result of cold store copy (error, no blocks copied, latest block copied, other block copied) 

From the metrics page:
```
# HELP near_cold_store_copy_result The result of a cold store copy iteration in the cold store loop.
# TYPE near_cold_store_copy_result counter
near_cold_store_copy_result{copy_result="latest_block_copied"} 246
near_cold_store_copy_result{copy_result="no_block_copied"} 1
near_cold_store_copy_result{copy_result="other_block_copied"} 175

# HELP near_cold_copy_duration Time it takes to copy one height to cold storage
# TYPE near_cold_copy_duration histogram
near_cold_copy_duration_bucket{le="0.005"} 358
near_cold_copy_duration_bucket{le="0.01"} 413
near_cold_copy_duration_bucket{le="0.025"} 421
near_cold_copy_duration_bucket{le="0.05"} 421
near_cold_copy_duration_bucket{le="0.1"} 421
near_cold_copy_duration_bucket{le="0.25"} 421
near_cold_copy_duration_bucket{le="0.5"} 421
near_cold_copy_duration_bucket{le="1"} 421
near_cold_copy_duration_bucket{le="2.5"} 421
near_cold_copy_duration_bucket{le="5"} 421
near_cold_copy_duration_bucket{le="10"} 421
near_cold_copy_duration_bucket{le="+Inf"} 421
near_cold_copy_duration_sum 1.6452199530000005
near_cold_copy_duration_count 421

```

A few other useful metrics such as cold head height has already been added previously. 