### PR TITLE
fix: fix recompress storage test and probably a few other things

### DIFF
--- a/core/store/src/opener.rs
+++ b/core/store/src/opener.rs
@@ -39,7 +39,7 @@ pub enum StoreOpenerError {
     /// Specifically, this happens if node is running with a single database and
     /// its kind is not RPC or Archive; or it’s running with two databases and
     /// their types aren’t Hot and Cold respectively.
-    #[error("{which} database kind should be {want} but got {got:?}")]
+    #[error("{which} database kind should be {want} but got {got:?}. Did you forget to set expect_archive on your store opener?")]
     DbKindMismatch { which: &'static str, got: Option<DbKind>, want: DbKind },
 
     /// Unable to create a migration snapshot because one already exists.

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -98,11 +98,9 @@ impl StateViewerSubCommand {
         let near_config = load_config(home_dir, genesis_validation)
             .unwrap_or_else(|e| panic!("Error loading config: {:#}", e));
 
-        let cold_store_config: Option<&near_store::StoreConfig> =
-            near_config.config.cold_store.as_ref();
-
-        let store_opener =
-            NodeStorage::opener(home_dir, &near_config.config.store, cold_store_config);
+        let cold_config: Option<&near_store::StoreConfig> = near_config.config.cold_store.as_ref();
+        let store_opener = NodeStorage::opener(home_dir, &near_config.config.store, cold_config);
+        let store_opener = store_opener.expect_archive(near_config.config.archive);
 
         let storage = store_opener.open_in_mode(mode).unwrap();
         let store = storage.get_store(temperature);


### PR DESCRIPTION
The issue was that the `archive` property was not set in the recompress-storage command and in the neard view-state subcommand. 
- setting archive correctly in both places
- making the test more debuggable by having separate output files for neard run command, view-state command and the recompress-storage command (previously all stderr from those three was dumped into a single stderr file)