### PR TITLE
test: first rust meta tx integration tests

### DIFF
--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use near_crypto::{EmptySigner, KeyType, PublicKey, Signature, Signer};
+use near_crypto::{EmptySigner, InMemorySigner, KeyType, PublicKey, Signature, Signer};
 use near_primitives_core::types::ProtocolVersion;
 
 use crate::account::{AccessKey, AccessKeyPermission, Account};
@@ -487,6 +487,13 @@ pub fn create_test_signer(account_name: &str) -> InMemoryValidatorSigner {
         KeyType::ED25519,
         account_name,
     )
+}
+
+/// Helper function that creates a new signer for a given account, that uses the account name as seed.
+///
+/// Should be used only in tests.
+pub fn create_user_test_signer(account_name: &str) -> InMemorySigner {
+    InMemorySigner::from_seed(account_name.parse().unwrap(), KeyType::ED25519, account_name)
 }
 
 impl FinalExecutionOutcomeView {

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -76,7 +76,10 @@ protocol_feature_reject_blocks_with_outdated_protocol_version = [
 ]
 protocol_feature_flat_state = ["nearcore/protocol_feature_flat_state"]
 protocol_feature_zero_balance_account = ["node-runtime/protocol_feature_zero_balance_account"]
-protocol_feature_nep366_delegate_action = ["nearcore/protocol_feature_nep366_delegate_action"]
+protocol_feature_nep366_delegate_action = [
+  "nearcore/protocol_feature_nep366_delegate_action",
+  "testlib/protocol_feature_nep366_delegate_action",
+]
 
 
 nightly = [

--- a/integration-tests/src/node/runtime_node.rs
+++ b/integration-tests/src/node/runtime_node.rs
@@ -5,7 +5,7 @@ use near_crypto::{InMemorySigner, KeyType, Signer};
 use near_primitives::types::AccountId;
 use nearcore::config::GenesisExt;
 use node_runtime::config::RuntimeConfig;
-use testlib::runtime_utils::{add_test_contract, alice_account, bob_account};
+use testlib::runtime_utils::{add_test_contract, alice_account, bob_account, carol_account};
 
 use crate::node::Node;
 use crate::runtime_utils::get_runtime_and_trie_from_genesis;
@@ -20,10 +20,10 @@ pub struct RuntimeNode {
 
 impl RuntimeNode {
     pub fn new(account_id: &AccountId) -> Self {
-        let mut genesis =
-            Genesis::test(vec![alice_account(), bob_account(), "carol.near".parse().unwrap()], 3);
+        let mut genesis = Genesis::test(vec![alice_account(), bob_account(), carol_account()], 3);
         add_test_contract(&mut genesis, &alice_account());
         add_test_contract(&mut genesis, &bob_account());
+        add_test_contract(&mut genesis, &carol_account());
         Self::new_from_genesis(account_id, genesis)
     }
 

--- a/integration-tests/src/tests/client/features/delegate_action.rs
+++ b/integration-tests/src/tests/client/features/delegate_action.rs
@@ -3,16 +3,24 @@
 //! NEP: https://github.com/near/NEPs/pull/366
 //! This is the module for its integration tests.
 
+use crate::node::Node;
+use crate::node::RuntimeNode;
 use crate::tests::client::process_blocks::create_nightshade_runtimes;
+use crate::tests::standard_cases::fee_helper;
 use near_chain::ChainGenesis;
 use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
+use near_crypto::KeyType;
+use near_crypto::PublicKey;
 use near_primitives::errors::{ActionsValidationError, InvalidTxError, TxExecutionError};
-use near_primitives::transaction::Action;
+use near_primitives::transaction::{Action, FunctionCallAction, TransferAction};
 use near_primitives::types::AccountId;
+use near_primitives::types::Balance;
 use near_primitives::version::{ProtocolFeature, ProtocolVersion};
+use near_primitives::views::FinalExecutionOutcomeView;
 use near_primitives::views::FinalExecutionStatus;
 use nearcore::config::GenesisExt;
+use testlib::runtime_utils::{alice_account, bob_account, carol_account};
 
 fn exec_meta_transaction(
     actions: Vec<Action>,
@@ -77,4 +85,150 @@ fn reject_valid_meta_tx_in_older_versions() {
         ),
         "{status:?}",
     );
+}
+
+/// Take a list of actions and execute them as a meta transaction, check
+/// everything executes successfully, return balance differences for the sender,
+/// relayer, and receiver.
+///
+/// This is a common checker function used by the tests below.
+fn check_meta_tx_execution(
+    node: impl Node,
+    actions: Vec<Action>,
+) -> (FinalExecutionOutcomeView, i128, i128, i128) {
+    let account_id = &node.account_id().unwrap();
+    let node_user = node.user();
+
+    let relayer = account_id.clone();
+    let sender = bob_account();
+    let receiver = carol_account();
+
+    let sender_before = node_user.view_balance(&sender).unwrap();
+    let relayer_before = node_user.view_balance(&relayer).unwrap();
+    let receiver_before = node_user.view_balance(&receiver).unwrap();
+
+    let tx_result = node_user
+        .meta_tx(sender.clone(), receiver.clone(), relayer.clone(), actions.clone())
+        .unwrap();
+
+    // Execution of the transaction and all receipts should succeed
+    tx_result.assert_success();
+
+    // both nonces started at 0 and should be updated to 1 now
+    let relayer_nonce = node_user
+        .get_access_key(&account_id, &PublicKey::from_seed(KeyType::ED25519, &account_id))
+        .unwrap()
+        .nonce;
+    let user_nonce = node_user
+        .get_access_key(&sender, &PublicKey::from_seed(KeyType::ED25519, &sender))
+        .unwrap()
+        .nonce;
+    assert_eq!(relayer_nonce, 1);
+    assert_eq!(user_nonce, 1);
+
+    let sender_after = node_user.view_balance(&sender).unwrap();
+    let relayer_after = node_user.view_balance(&relayer).unwrap();
+    let receiver_after = node_user.view_balance(&receiver).unwrap();
+
+    let sender_diff = sender_after as i128 - sender_before as i128;
+    let relayer_diff = relayer_after as i128 - relayer_before as i128;
+    let receiver_diff = receiver_after as i128 - receiver_before as i128;
+    (tx_result, sender_diff, relayer_diff, receiver_diff)
+}
+
+/// Call `check_meta_tx_execution` and perform gas checks for non function call actions.
+///
+/// This is a common checker function used by the tests below.
+fn check_meta_tx_no_fn_call(
+    node: impl Node,
+    actions: Vec<Action>,
+    normal_tx_cost: Balance,
+    tokens_transferred: Balance,
+) -> FinalExecutionOutcomeView {
+    let fee_helper = fee_helper(&node);
+    let gas_cost = normal_tx_cost + fee_helper.meta_tx_overhead_cost(&actions);
+
+    let (tx_result, sender_diff, relayer_diff, receiver_diff) =
+        check_meta_tx_execution(node, actions);
+
+    assert_eq!(sender_diff, 0, "sender should not pay for anything");
+    assert_eq!(receiver_diff, tokens_transferred as i128, "unexpected receiver balance");
+    assert_eq!(
+        relayer_diff,
+        -((gas_cost + tokens_transferred) as i128),
+        "unexpected relayer balance"
+    );
+
+    tx_result
+}
+
+/// Call `check_meta_tx_execution` and perform gas checks specific to function calls.
+///
+/// This is a common checker function used by the tests below.
+fn check_meta_tx_fn_call(
+    node: impl Node,
+    actions: Vec<Action>,
+    msg_len: u64,
+    tokens_transferred: Balance,
+) -> FinalExecutionOutcomeView {
+    let fee_helper = fee_helper(&node);
+    let gas_cost =
+        fee_helper.function_call_cost(msg_len, 0) + fee_helper.meta_tx_overhead_cost(&actions);
+
+    let (tx_result, sender_diff, relayer_diff, receiver_diff) =
+        check_meta_tx_execution(node, actions);
+
+    assert_eq!(sender_diff, 0, "sender should not pay for anything");
+
+    // Assertions on receiver and relayer are tricky because of dynamic gas
+    // costs and contract reward. We need to check in the function call receipt
+    // how much gas was spent and subtract the base cost that is not part of the
+    // dynamic cost. The contract reward can be inferred from that.
+    let gas_burnt_for_function_call = tx_result.receipts_outcome[1].outcome.gas_burnt
+        - fee_helper.function_call_exec_gas(msg_len);
+    let dyn_cost = fee_helper.gas_to_balance(gas_burnt_for_function_call);
+    let contract_reward = fee_helper.gas_burnt_to_reward(gas_burnt_for_function_call);
+
+    let expected_relayer_cost = (gas_cost + tokens_transferred + dyn_cost) as i128;
+    assert_eq!(relayer_diff, -expected_relayer_cost, "unexpected relayer balance");
+
+    let expected_receiver_gain = (tokens_transferred + contract_reward) as i128;
+    assert_eq!(receiver_diff, expected_receiver_gain, "unexpected receiver balance");
+
+    tx_result
+}
+
+/// The simplest non-empty meta transaction: Transferring some NEAR tokens.
+///
+/// Note: The expectation is that the relayer pays for the tokens sent, as
+/// specified in NEP-366.
+#[test]
+fn meta_tx_near_transfer() {
+    let node = RuntimeNode::new(&alice_account());
+    let fee_helper = fee_helper(&node);
+
+    let amount = nearcore::NEAR_BASE;
+    let actions = vec![Action::Transfer(TransferAction { deposit: amount })];
+    let tx_cost = fee_helper.transfer_cost();
+    check_meta_tx_no_fn_call(node, actions, tx_cost, amount);
+}
+
+/// Call a function on the test contract provided by default in the test environment.
+#[test]
+fn meta_tx_fn_call() {
+    let node = RuntimeNode::new(&alice_account());
+    let method_name = "log_something".to_owned();
+    let method_name_len = method_name.len() as u64;
+    let actions = vec![Action::FunctionCall(FunctionCallAction {
+        method_name,
+        args: vec![],
+        gas: 30_000_000_000_000,
+        deposit: 0,
+    })];
+
+    let outcome = check_meta_tx_fn_call(node, actions, method_name_len, 0);
+
+    // Check that the function call was executed as expected
+    let fn_call_logs = &outcome.receipts_outcome[1].outcome.logs;
+    assert_eq!(fn_call_logs, &vec!["hello".to_owned()]);
 }

--- a/integration-tests/src/tests/standard_cases/mod.rs
+++ b/integration-tests/src/tests/standard_cases/mod.rs
@@ -34,7 +34,7 @@ use testlib::runtime_utils::{
 /// The amount to send with function call.
 const FUNCTION_CALL_AMOUNT: Balance = TESTING_INIT_BALANCE / 10;
 
-fn fee_helper(node: &impl Node) -> FeeHelper {
+pub(crate) fn fee_helper(node: &impl Node) -> FeeHelper {
     FeeHelper::new(RuntimeConfig::test().fees, node.genesis().config.min_gas_price)
 }
 

--- a/integration-tests/src/user/mod.rs
+++ b/integration-tests/src/user/mod.rs
@@ -2,9 +2,13 @@ use std::sync::Arc;
 
 use futures::{future::LocalBoxFuture, FutureExt};
 
+#[cfg(feature = "protocol_feature_nep366_delegate_action")]
+use near_crypto::{InMemorySigner, KeyType};
 use near_crypto::{PublicKey, Signer};
 use near_jsonrpc_primitives::errors::ServerError;
 use near_primitives::account::AccessKey;
+#[cfg(feature = "protocol_feature_nep366_delegate_action")]
+use near_primitives::delegate_action::{DelegateAction, NonDelegateAction, SignedDelegateAction};
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::Receipt;
 use near_primitives::transaction::{
@@ -238,6 +242,41 @@ pub trait User {
             signer_id.clone(),
             signer_id,
             vec![Action::Stake(StakeAction { stake, public_key })],
+        )
+    }
+
+    #[cfg(feature = "protocol_feature_nep366_delegate_action")]
+    fn meta_tx(
+        &self,
+        signer_id: AccountId,
+        receiver_id: AccountId,
+        relayer_id: AccountId,
+        actions: Vec<Action>,
+    ) -> Result<FinalExecutionOutcomeView, ServerError> {
+        let inner_signer =
+            InMemorySigner::from_seed(signer_id.clone(), KeyType::ED25519, &signer_id);
+        let user_nonce = self
+            .get_access_key(&signer_id, &inner_signer.public_key)
+            .expect("failed reading user's nonce for access key")
+            .nonce;
+        let delegate_action = DelegateAction {
+            sender_id: signer_id.clone(),
+            receiver_id,
+            actions: actions
+                .into_iter()
+                .map(|action| NonDelegateAction::try_from(action).unwrap())
+                .collect(),
+            nonce: user_nonce + 1,
+            max_block_height: 100,
+            public_key: inner_signer.public_key(),
+        };
+        let signature = inner_signer.sign(delegate_action.get_hash().as_bytes());
+        let signed_delegate_action = SignedDelegateAction { delegate_action, signature };
+
+        self.sign_and_commit_actions(
+            relayer_id,
+            signer_id,
+            vec![Action::Delegate(signed_delegate_action)],
         )
     }
 }

--- a/test-utils/testlib/Cargo.toml
+++ b/test-utils/testlib/Cargo.toml
@@ -16,3 +16,4 @@ near-test-contracts = { path = "../../runtime/near-test-contracts" }
 
 [features]
 default = []
+protocol_feature_nep366_delegate_action = []

--- a/test-utils/testlib/src/fees_utils.rs
+++ b/test-utils/testlib/src/fees_utils.rs
@@ -1,7 +1,15 @@
 //! Helper functions to compute the costs of certain actions assuming they succeed and the only
 //! actions in the transaction batch.
+#[cfg(feature = "protocol_feature_nep366_delegate_action")]
+use near_primitives::account::AccessKeyPermission;
+#[cfg(feature = "protocol_feature_nep366_delegate_action")]
+use near_primitives::account::{AccessKey, FunctionCallPermission};
 use near_primitives::config::ActionCosts;
 use near_primitives::runtime::fees::RuntimeFeesConfig;
+#[cfg(feature = "protocol_feature_nep366_delegate_action")]
+use near_primitives::transaction::{
+    Action, AddKeyAction, DeployContractAction, FunctionCallAction,
+};
 use near_primitives::types::{Balance, Gas};
 
 pub struct FeeHelper {
@@ -159,5 +167,58 @@ impl FeeHelper {
         let total_fee = exec_gas + send_gas;
 
         self.gas_to_balance(total_fee)
+    }
+
+    /// The additional cost to execute a list of actions in a meta transaction,
+    /// compared to executing them directly.
+    ///
+    /// The overhead consists of:
+    /// - The base cost of the delegate action (send and exec).
+    /// - The additional send cost for all inner actions.
+    #[cfg(feature = "protocol_feature_nep366_delegate_action")]
+    pub fn meta_tx_overhead_cost(&self, actions: &[Action]) -> Balance {
+        // for tests, we assume sender != receiver
+        let sir = false;
+        let base = self.cfg.fee(ActionCosts::delegate);
+        let receipt = self.cfg.fee(ActionCosts::new_action_receipt);
+        let mut total_gas = base.exec_fee() + base.send_fee(false) + receipt.send_fee(sir);
+        for action in actions {
+            let send_gas = match action {
+                Action::CreateAccount(_) => self.cfg.fee(ActionCosts::create_account).send_fee(sir),
+                Action::DeployContract(DeployContractAction { code }) => {
+                    self.cfg.fee(ActionCosts::deploy_contract_base).send_fee(sir)
+                        + self.cfg.fee(ActionCosts::deploy_contract_byte).send_fee(sir)
+                            * code.len() as u64
+                }
+                Action::FunctionCall(FunctionCallAction { method_name, args, .. }) => {
+                    let num_bytes = method_name.len() + args.len();
+                    self.cfg.fee(ActionCosts::function_call_base).send_fee(sir)
+                        + self.cfg.fee(ActionCosts::function_call_byte).send_fee(sir)
+                            * num_bytes as u64
+                }
+                Action::Transfer(_) => self.cfg.fee(ActionCosts::transfer).send_fee(sir),
+                Action::Stake(_) => self.cfg.fee(ActionCosts::stake).send_fee(sir),
+                Action::AddKey(AddKeyAction {
+                    access_key: AccessKey { permission, .. }, ..
+                }) => match permission {
+                    AccessKeyPermission::FunctionCall(FunctionCallPermission {
+                        method_names,
+                        ..
+                    }) => {
+                        self.cfg.fee(ActionCosts::add_function_call_key_base).send_fee(sir)
+                            + self.cfg.fee(ActionCosts::add_function_call_key_byte).send_fee(sir)
+                                * method_names.len() as u64
+                    }
+                    AccessKeyPermission::FullAccess => {
+                        self.cfg.fee(ActionCosts::add_full_access_key).send_fee(sir)
+                    }
+                },
+                Action::DeleteKey(_) => self.cfg.fee(ActionCosts::delete_key).send_fee(sir),
+                Action::DeleteAccount(_) => self.cfg.fee(ActionCosts::delete_account).send_fee(sir),
+                Action::Delegate(_) => self.cfg.fee(ActionCosts::delegate).send_fee(sir),
+            };
+            total_gas += send_gas;
+        }
+        self.gas_to_balance(total_gas)
     }
 }

--- a/test-utils/testlib/src/runtime_utils.rs
+++ b/test-utils/testlib/src/runtime_utils.rs
@@ -12,6 +12,9 @@ pub fn alice_account() -> AccountId {
 pub fn bob_account() -> AccountId {
     "bob.near".parse().unwrap()
 }
+pub fn carol_account() -> AccountId {
+    "carol.near".parse().unwrap()
+}
 pub fn eve_dot_alice_account() -> AccountId {
     "eve.alice.near".parse().unwrap()
 }


### PR DESCRIPTION
1. Extend the test utilities to make meta transaction tests easy to add.
2. Add two tests as an example. a) NEAR token transfer b) simple function call

I will cover more cases in future PRs. This is to establish the framework:
- `fn meta_tx` in `trait User`
- Checker function specific to meta transactions
- Provide helpers to do tricky gas checks

The 2 test cases show that it works as intended.