### PR TITLE
fix: fixed the mac binary release tag pattern

### DIFF
--- a/.github/workflows/mac_binary.yml
+++ b/.github/workflows/mac_binary.yml
@@ -1,11 +1,11 @@
 name: MacOS binary release
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
     tags:
       - '[0-9]+.[0-9]+.[0-9]+*'
-    workflow_dispatch:
 jobs:
   build_binary:
     runs-on: macOS-latest

--- a/.github/workflows/mac_binary.yml
+++ b/.github/workflows/mac_binary.yml
@@ -5,6 +5,7 @@ on:
       - master
     tags:
       - '[0-9]+.[0-9]+.[0-9]+*'
+    workflow_dispatch:
 jobs:
   build_binary:
     runs-on: macOS-latest

--- a/.github/workflows/mac_binary.yml
+++ b/.github/workflows/mac_binary.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - master
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+.*'
+      - '[0-9]+.[0-9]+.[0-9]+*'
 jobs:
   build_binary:
     runs-on: macOS-latest

--- a/.github/workflows/mac_m1_binary.yml
+++ b/.github/workflows/mac_m1_binary.yml
@@ -3,8 +3,9 @@ on:
   push:
     branches:
       - master
-    #tags:
-    #  - '[0-9]+.[0-9]+.[0-9]+.*'
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+*'
+    workflow_dispatch:
 jobs:
   build_binary:
     runs-on: macOS-m1

--- a/.github/workflows/mac_m1_binary.yml
+++ b/.github/workflows/mac_m1_binary.yml
@@ -1,11 +1,11 @@
 name: MacOS-m1 binary release
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
     tags:
       - '[0-9]+.[0-9]+.[0-9]+*'
-    workflow_dispatch:
 jobs:
   build_binary:
     runs-on: macOS-m1


### PR DESCRIPTION
tldr - regexes are hard

The mac_binary.yml configures that macbook binaries should be uploaded to S3 for any commit pushed to master as well as any tag matching the given pattern. Unforunately the pattern is invalid and it doesn't capture our release tags and so we never upload mac binaries. This breaks a few things including `nearup localnet` and `db_migration.py` pytest.

I have no clue how to test this PR so I'm looking for suggestions. It's broken anyway so I don't think I'll make it any worse though so merging without a test would be acceptable too. 

references:
- [6426](https://github.com/near/nearcore/pull/6426/files#r831461185)  the PR that introduced the tag trigger and discussion about whether the right pattern is `.*` or `*` 
- [mac_binary](https://github.com/near/nearcore/actions/workflows/mac_binary.yml) Is the github action that is triggered by the mac_binary.yml. You can see that it only gets triggered for commits pushed to master but there aren't any runs release tags. 
- [workflow-syntax](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet) Shows that indeed the pattern for capturing any string (excl. `/`) is `*`. 

