### PR TITLE
Revert borsh update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,18 +711,8 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15bf3650200d8bffa99015595e10f1fbd17de07abbc25bb067da79e769939bfa"
 dependencies = [
- "borsh-derive 0.9.3",
+ "borsh-derive",
  "hashbrown 0.11.2",
-]
-
-[[package]]
-name = "borsh"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ef05d137e34b7ac51dbec170ee523a9b728cff71385796771d259771d592f8"
-dependencies = [
- "borsh-derive 0.10.1",
- "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -731,21 +721,8 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6441c552f230375d18e3cc377677914d2ca2b0d36e52129fe15450a2dce46775"
 dependencies = [
- "borsh-derive-internal 0.9.3",
- "borsh-schema-derive-internal 0.9.3",
- "proc-macro-crate",
- "proc-macro2",
- "syn",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190b1188f062217531748807129459c8c14641b648e887e39681a433db7fc939"
-dependencies = [
- "borsh-derive-internal 0.10.1",
- "borsh-schema-derive-internal 0.10.1",
+ "borsh-derive-internal",
+ "borsh-schema-derive-internal",
  "proc-macro-crate",
  "proc-macro2",
  "syn",
@@ -763,32 +740,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "borsh-derive-internal"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fcf747a3e4eb47869441664df09d0eb88dcc9a85d499860efb82c2cfe6affc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "borsh-schema-derive-internal"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "borsh-schema-derive-internal"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f671d085f791c5fd3331c843ded45454b034b6188bf0f78ed28e7fd66a8b3f69"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2095,7 +2050,7 @@ dependencies = [
 name = "genesis-populate"
 version = "0.0.0"
 dependencies = [
- "borsh 0.10.1",
+ "borsh",
  "clap 3.1.18",
  "indicatif",
  "near-chain",
@@ -2472,7 +2427,7 @@ dependencies = [
  "actix-rt",
  "anyhow",
  "assert_matches",
- "borsh 0.10.1",
+ "borsh",
  "chrono",
  "clap 3.1.18",
  "futures",
@@ -3001,7 +2956,7 @@ version = "0.0.0"
 dependencies = [
  "arbitrary",
  "bolero",
- "borsh 0.10.1",
+ "borsh",
  "serde",
  "serde_json",
 ]
@@ -3010,7 +2965,7 @@ dependencies = [
 name = "near-account-id-fuzz"
 version = "0.0.0"
 dependencies = [
- "borsh 0.10.1",
+ "borsh",
  "libfuzzer-sys",
  "near-account-id",
  "serde_json",
@@ -3031,7 +2986,7 @@ name = "near-amend-genesis"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "borsh 0.10.1",
+ "borsh",
  "clap 3.1.18",
  "near-chain",
  "near-chain-configs",
@@ -3081,7 +3036,7 @@ dependencies = [
  "actix",
  "ansi_term",
  "assert_matches",
- "borsh 0.10.1",
+ "borsh",
  "chrono",
  "crossbeam-channel",
  "delay-detector",
@@ -3147,7 +3102,7 @@ version = "0.0.0"
 dependencies = [
  "actix",
  "assert_matches",
- "borsh 0.10.1",
+ "borsh",
  "chrono",
  "futures",
  "lru",
@@ -3183,7 +3138,7 @@ dependencies = [
  "ansi_term",
  "assert_matches",
  "async-trait",
- "borsh 0.10.1",
+ "borsh",
  "chrono",
  "delay-detector",
  "futures",
@@ -3248,7 +3203,7 @@ name = "near-crypto"
 version = "0.0.0"
 dependencies = [
  "blake2",
- "borsh 0.10.1",
+ "borsh",
  "bs58",
  "c2-chacha",
  "curve25519-dalek",
@@ -3291,7 +3246,7 @@ dependencies = [
 name = "near-epoch-manager"
 version = "0.0.0"
 dependencies = [
- "borsh 0.10.1",
+ "borsh",
  "chrono",
  "near-cache",
  "near-chain-configs",
@@ -3432,7 +3387,7 @@ version = "0.0.0"
 dependencies = [
  "actix",
  "awc",
- "borsh 0.10.1",
+ "borsh",
  "futures",
  "near-actix-test-utils",
  "near-chain-configs",
@@ -3466,7 +3421,7 @@ dependencies = [
  "actix",
  "anyhow",
  "async-trait",
- "borsh 0.10.1",
+ "borsh",
  "bs58",
  "clap 3.1.18",
  "ed25519-dalek",
@@ -3510,7 +3465,7 @@ dependencies = [
  "arc-swap",
  "assert_matches",
  "async-trait",
- "borsh 0.10.1",
+ "borsh",
  "bytes",
  "bytesize",
  "chrono",
@@ -3628,7 +3583,7 @@ dependencies = [
 name = "near-pool"
 version = "0.0.0"
 dependencies = [
- "borsh 0.10.1",
+ "borsh",
  "near-crypto",
  "near-o11y",
  "near-primitives",
@@ -3643,7 +3598,7 @@ dependencies = [
  "arbitrary",
  "assert_matches",
  "bencher",
- "borsh 0.10.1",
+ "borsh",
  "bytesize",
  "cfg-if 1.0.0",
  "chrono",
@@ -3678,7 +3633,7 @@ version = "0.0.0"
 dependencies = [
  "arbitrary",
  "base64",
- "borsh 0.10.1",
+ "borsh",
  "bs58",
  "derive_more",
  "enum-map",
@@ -3776,7 +3731,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "bencher",
- "borsh 0.10.1",
+ "borsh",
  "byteorder",
  "bytesize",
  "crossbeam",
@@ -3838,7 +3793,7 @@ dependencies = [
 name = "near-vm-errors"
 version = "0.0.0"
 dependencies = [
- "borsh 0.10.1",
+ "borsh",
  "near-account-id",
  "near-rpc-error-macro",
  "serde",
@@ -3850,7 +3805,7 @@ dependencies = [
 name = "near-vm-logic"
 version = "0.0.0"
 dependencies = [
- "borsh 0.10.1",
+ "borsh",
  "ed25519-dalek",
  "expect-test",
  "hex",
@@ -3878,7 +3833,7 @@ dependencies = [
  "arbitrary",
  "assert_matches",
  "bolero",
- "borsh 0.10.1",
+ "borsh",
  "expect-test",
  "hex",
  "loupe",
@@ -3936,7 +3891,7 @@ dependencies = [
  "anyhow",
  "awc",
  "bencher",
- "borsh 0.10.1",
+ "borsh",
  "byteorder",
  "chrono",
  "delay-detector",
@@ -4058,7 +4013,7 @@ name = "node-runtime"
 version = "0.0.0"
 dependencies = [
  "assert_matches",
- "borsh 0.10.1",
+ "borsh",
  "enum-map",
  "hex",
  "indicatif",
@@ -5187,7 +5142,7 @@ name = "runtime-params-estimator"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "borsh 0.10.1",
+ "borsh",
  "bs58",
  "bytesize",
  "cfg-if 1.0.0",
@@ -5783,7 +5738,7 @@ dependencies = [
 name = "speedy_sync"
 version = "0.0.0"
 dependencies = [
- "borsh 0.10.1",
+ "borsh",
  "clap 3.1.18",
  "near-chain",
  "near-chain-configs",
@@ -5814,7 +5769,7 @@ version = "0.0.0"
 dependencies = [
  "ansi_term",
  "anyhow",
- "borsh 0.10.1",
+ "borsh",
  "clap 3.1.18",
  "insta",
  "near-chain",
@@ -6822,7 +6777,7 @@ checksum = "5a3fac37da3c625e98708c5dd92d3f642aaf700fd077168d3d0fff277ec6a165"
 dependencies = [
  "bincode",
  "blake3",
- "borsh 0.9.3",
+ "borsh",
  "cc",
  "digest 0.8.1",
  "errno",
@@ -6865,7 +6820,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6edd0ba6c0bcf9b279186d4dbe81649dda3e5ef38f586865943de4dcd653f8"
 dependencies = [
  "bincode",
- "borsh 0.9.3",
+ "borsh",
  "byteorder",
  "dynasm",
  "dynasmrt",
@@ -7387,7 +7342,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e61de68ede9ffdd69c01664f65a178c5188b73f78faa21f0936016a888ff7c"
 dependencies = [
- "borsh 0.9.3",
+ "borsh",
  "byteorder",
  "crunchy",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ bitflags = "1.2"
 blake2 = "0.9.1"
 bn = { package = "zeropool-bn", version = "0.5.11" }
 bolero = "0.8.0"
-borsh = { version = "0.10.1", features = ["rc"] }
+borsh = { version = "0.9", features = ["rc"] }
 bs58 = "0.4"
 byteorder = "1.3"
 bytes = "1"

--- a/chain/network/src/network_protocol/borsh.rs
+++ b/chain/network/src/network_protocol/borsh.rs
@@ -57,8 +57,8 @@ struct HandshakeAutoDes {
 // Use custom deserializer for HandshakeV2. Try to read version of the other peer from the header.
 // If the version is supported then fallback to standard deserializer.
 impl BorshDeserialize for Handshake {
-    fn deserialize_reader<R: std::io::Read>(rd: &mut R) -> std::io::Result<Self> {
-        HandshakeAutoDes::deserialize_reader(rd).map(Into::into)
+    fn deserialize(buf: &mut &[u8]) -> std::io::Result<Self> {
+        <HandshakeAutoDes as BorshDeserialize>::deserialize(buf).map(Into::into)
     }
 }
 

--- a/core/account-id/src/borsh.rs
+++ b/core/account-id/src/borsh.rs
@@ -1,18 +1,18 @@
 use super::AccountId;
 
-use std::io::{Read, Write};
+use std::io::{Error, Write};
 
 use borsh::{BorshDeserialize, BorshSerialize};
 
 impl BorshSerialize for AccountId {
-    fn serialize<W: Write>(&self, writer: &mut W) -> std::io::Result<()> {
+    fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
         self.0.serialize(writer)
     }
 }
 
 impl BorshDeserialize for AccountId {
-    fn deserialize_reader<R: Read>(rd: &mut R) -> std::io::Result<Self> {
-        let account_id = Box::<str>::deserialize_reader(rd)?;
+    fn deserialize(buf: &mut &[u8]) -> Result<Self, std::io::Error> {
+        let account_id = Box::<str>::deserialize(buf)?;
         Self::validate(&account_id).map_err(|err| {
             std::io::Error::new(
                 std::io::ErrorKind::InvalidData,

--- a/core/crypto/src/signature.rs
+++ b/core/crypto/src/signature.rs
@@ -209,16 +209,16 @@ impl BorshSerialize for PublicKey {
 }
 
 impl BorshDeserialize for PublicKey {
-    fn deserialize_reader<R: Read>(rd: &mut R) -> std::io::Result<Self> {
-        let key_type = KeyType::try_from(u8::deserialize_reader(rd)?)
+    fn deserialize(buf: &mut &[u8]) -> Result<Self, Error> {
+        let key_type = KeyType::try_from(<u8 as BorshDeserialize>::deserialize(buf)?)
             .map_err(|err| Error::new(ErrorKind::InvalidData, err.to_string()))?;
         match key_type {
             KeyType::ED25519 => {
-                Ok(PublicKey::ED25519(ED25519PublicKey(BorshDeserialize::deserialize_reader(rd)?)))
+                Ok(PublicKey::ED25519(ED25519PublicKey(BorshDeserialize::deserialize(buf)?)))
             }
-            KeyType::SECP256K1 => Ok(PublicKey::SECP256K1(Secp256K1PublicKey(
-                BorshDeserialize::deserialize_reader(rd)?,
-            ))),
+            KeyType::SECP256K1 => {
+                Ok(PublicKey::SECP256K1(Secp256K1PublicKey(BorshDeserialize::deserialize(buf)?)))
+            }
         }
     }
 }
@@ -593,20 +593,20 @@ impl BorshSerialize for Signature {
 }
 
 impl BorshDeserialize for Signature {
-    fn deserialize_reader<R: Read>(rd: &mut R) -> std::io::Result<Self> {
-        let key_type = KeyType::try_from(u8::deserialize_reader(rd)?)
+    fn deserialize(buf: &mut &[u8]) -> Result<Self, Error> {
+        let key_type = KeyType::try_from(<u8 as BorshDeserialize>::deserialize(buf)?)
             .map_err(|err| Error::new(ErrorKind::InvalidData, err.to_string()))?;
         match key_type {
             KeyType::ED25519 => {
                 let array: [u8; ed25519_dalek::SIGNATURE_LENGTH] =
-                    BorshDeserialize::deserialize_reader(rd)?;
+                    BorshDeserialize::deserialize(buf)?;
                 Ok(Signature::ED25519(
                     ed25519_dalek::Signature::from_bytes(&array)
                         .map_err(|e| Error::new(ErrorKind::InvalidData, e.to_string()))?,
                 ))
             }
             KeyType::SECP256K1 => {
-                let array: [u8; 65] = BorshDeserialize::deserialize_reader(rd)?;
+                let array: [u8; 65] = BorshDeserialize::deserialize(buf)?;
                 Ok(Signature::SECP256K1(Secp256K1Signature(array)))
             }
         }

--- a/core/crypto/src/signature.rs
+++ b/core/crypto/src/signature.rs
@@ -7,7 +7,7 @@ use secp256k1::Message;
 use std::convert::AsRef;
 use std::fmt::{Debug, Display, Formatter};
 use std::hash::{Hash, Hasher};
-use std::io::{Error, ErrorKind, Read, Write};
+use std::io::{Error, ErrorKind, Write};
 use std::str::FromStr;
 
 pub static SECP256K1: Lazy<secp256k1::Secp256k1<secp256k1::All>> =

--- a/core/primitives-core/src/account.rs
+++ b/core/primitives-core/src/account.rs
@@ -117,10 +117,10 @@ struct LegacyAccount {
 }
 
 impl BorshDeserialize for Account {
-    fn deserialize_reader<R: io::Read>(rd: &mut R) -> io::Result<Self> {
+    fn deserialize(buf: &mut &[u8]) -> Result<Self, io::Error> {
         // This should only ever happen if we have pre-transition account serialized in state
         // See test_account_size
-        let deserialized_account = LegacyAccount::deserialize_reader(rd)?;
+        let deserialized_account = LegacyAccount::deserialize(buf)?;
         Ok(Account {
             amount: deserialized_account.amount,
             locked: deserialized_account.locked,

--- a/core/primitives-core/src/hash.rs
+++ b/core/primitives-core/src/hash.rs
@@ -15,8 +15,6 @@ use std::io::Write;
     derive_more::AsRef,
     derive_more::AsMut,
     arbitrary::Arbitrary,
-    borsh::BorshDeserialize,
-    borsh::BorshSerialize,
 )]
 #[as_ref(forward)]
 #[as_mut(forward)]
@@ -115,6 +113,19 @@ enum Decode58Result {
 impl Default for CryptoHash {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl borsh::BorshSerialize for CryptoHash {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
+        writer.write_all(&self.0)?;
+        Ok(())
+    }
+}
+
+impl borsh::BorshDeserialize for CryptoHash {
+    fn deserialize(buf: &mut &[u8]) -> Result<Self, std::io::Error> {
+        Ok(CryptoHash(borsh::BorshDeserialize::deserialize(buf)?))
     }
 }
 

--- a/core/primitives-core/src/profile.rs
+++ b/core/primitives-core/src/profile.rs
@@ -108,10 +108,10 @@ impl ProfileDataV3 {
 }
 
 impl BorshDeserialize for ProfileDataV3 {
-    fn deserialize_reader<R: std::io::Read>(rd: &mut R) -> std::io::Result<Self> {
-        let actions_array: Vec<u64> = BorshDeserialize::deserialize_reader(rd)?;
-        let ext_array: Vec<u64> = BorshDeserialize::deserialize_reader(rd)?;
-        let wasm_gas: u64 = BorshDeserialize::deserialize_reader(rd)?;
+    fn deserialize(buf: &mut &[u8]) -> Result<Self, std::io::Error> {
+        let actions_array: Vec<u64> = BorshDeserialize::deserialize(buf)?;
+        let ext_array: Vec<u64> = BorshDeserialize::deserialize(buf)?;
+        let wasm_gas: u64 = BorshDeserialize::deserialize(buf)?;
 
         // Mapping raw arrays to enum maps.
         // The enum map could be smaller or larger than the raw array.

--- a/core/primitives-core/src/profile/profile_v2.rs
+++ b/core/primitives-core/src/profile/profile_v2.rs
@@ -219,8 +219,8 @@ impl Index<ExtCosts> for ProfileDataV2 {
 }
 
 impl BorshDeserialize for DataArray {
-    fn deserialize_reader<R: std::io::Read>(rd: &mut R) -> std::io::Result<Self> {
-        let data_vec: Vec<u64> = BorshDeserialize::deserialize_reader(rd)?;
+    fn deserialize(buf: &mut &[u8]) -> Result<Self, std::io::Error> {
+        let data_vec: Vec<u64> = BorshDeserialize::deserialize(buf)?;
         let mut data_array = [0; Self::LEN];
         let len = Self::LEN.min(data_vec.len());
         data_array[0..len].copy_from_slice(&data_vec[0..len]);
@@ -230,7 +230,8 @@ impl BorshDeserialize for DataArray {
 
 impl BorshSerialize for DataArray {
     fn serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
-        (&self.0[..]).serialize(writer)
+        let v: Vec<_> = self.0.as_ref().to_vec();
+        BorshSerialize::serialize(&v, writer)
     }
 }
 

--- a/core/primitives/src/delegate_action.rs
+++ b/core/primitives/src/delegate_action.rs
@@ -46,9 +46,7 @@ pub struct SignedDelegateAction {
 
 #[cfg(not(feature = "protocol_feature_nep366_delegate_action"))]
 impl borsh::de::BorshDeserialize for SignedDelegateAction {
-    fn deserialize_reader<R: borsh::maybestd::io::Read>(
-        _rd: &mut R,
-    ) -> ::core::result::Result<Self, borsh::maybestd::io::Error> {
+    fn deserialize(_buf: &mut &[u8]) -> ::core::result::Result<Self, borsh::maybestd::io::Error> {
         return Err(Error::new(ErrorKind::InvalidInput, "Delegate action isn't supported"));
     }
 }
@@ -122,15 +120,21 @@ mod private_non_delegate_action {
     }
 
     impl borsh::de::BorshDeserialize for NonDelegateAction {
-        fn deserialize_reader<R: borsh::maybestd::io::Read>(
-            rd: &mut R,
+        fn deserialize(
+            buf: &mut &[u8],
         ) -> ::core::result::Result<Self, borsh::maybestd::io::Error> {
-            match u8::deserialize_reader(rd)? {
+            if buf.is_empty() {
+                return Err(Error::new(
+                    ErrorKind::InvalidInput,
+                    "Failed to deserialize DelegateAction",
+                ));
+            }
+            match buf[0] {
                 ACTION_DELEGATE_NUMBER => Err(Error::new(
                     ErrorKind::InvalidInput,
                     "DelegateAction mustn't contain a nested one",
                 )),
-                n => borsh::de::EnumExt::deserialize_variant(rd, n).map(Self),
+                _ => Ok(Self(borsh::BorshDeserialize::deserialize(buf)?)),
             }
         }
     }

--- a/core/primitives/src/time.rs
+++ b/core/primitives/src/time.rs
@@ -304,13 +304,16 @@ mod time {
 
     impl BorshSerialize for Time {
         fn serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
-            (self.to_unix_timestamp_nanos().as_nanos() as u64).serialize(writer)
+            let nanos = self.to_unix_timestamp_nanos().as_nanos() as u64;
+            BorshSerialize::serialize(&nanos, writer).unwrap();
+            Ok(())
         }
     }
 
     impl BorshDeserialize for Time {
-        fn deserialize_reader<R: std::io::Read>(rd: &mut R) -> std::io::Result<Self> {
-            let nanos = u64::deserialize_reader(rd)?;
+        fn deserialize(buf: &mut &[u8]) -> Result<Self, std::io::Error> {
+            let nanos: u64 = borsh::BorshDeserialize::deserialize(buf)?;
+
             Ok(Time::from_unix_timestamp(Duration::from_nanos(nanos)))
         }
     }

--- a/deny.toml
+++ b/deny.toml
@@ -107,10 +107,4 @@ skip = [
 
     # validator 0.12 ~ 0.16 is still using an old version of idna
     { name = "idna", version = "=0.2.3" },
-
-    # zeropool-bn uses borsh 0.9
-    { name = "borsh", version = "=0.9.3" },
-    { name = "borsh-derive", version = "=0.9.3" },
-    { name = "borsh-derive-internal", version = "=0.9.3" },
-    { name = "borsh-schema-derive-internal", version = "=0.9.3" },
 ]

--- a/tools/speedy_sync/Cargo.toml
+++ b/tools/speedy_sync/Cargo.toml
@@ -17,7 +17,8 @@ near-chain-configs = { path = "../../core/chain-configs" }
 near-chain = { path = "../../chain/chain"}
 near-epoch-manager = {path = "../../chain/epoch-manager" }
 
-borsh = "0.10.1"
+borsh = "0.9"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 clap = { version = "3.1.6", features = ["derive"] }
+


### PR DESCRIPTION
Reverts b8196b1aa735b5f9ea1c53c1a248fdd4a4bf54bd due to fuzzer-found OOM issue in our code with a more recent borsh.

With a more recent borsh the fuzzer finds OOM issues in our account-id deserialization code. To repro, run with a file like this: (unfortunately github doesn’t allow random file uploads)
```
$ cd core/account-id/fuzz
$ hexdump artifacts/borsh/clusterfuzz-testcase-minimized-borsh-5679095853613056 
0000000 fe00 ffff                              
0000004
$ cargo +nightly fuzz run borsh artifacts/borsh/clusterfuzz-testcase-minimized-borsh-5679095853613056  -- -rss_limit_mb=2560 -timeout=60 -runs=100
```

This attempts a ~4G RAM allocation for a 4B input. Unfortunately I don’t think we can easily add a unit test for this, as it’d rely on limiting the RAM available to the test. Good news is, the fuzzer will probably find this issue easily enough should it resurface — you can try locally with `cargo +nightly fuzz run borsh` in the same directory for a few minutes to see if it can find anything obvious.

I think this is a bug we’ll need to fix in borsh before being able to attempt the version bump in nearcore again.

cc @mina86 @nikurt 