### PR TITLE
Add a flag to neard configuring reconnection to reliable peers on startup

### DIFF
--- a/chain/network/src/config.rs
+++ b/chain/network/src/config.rs
@@ -96,7 +96,8 @@ pub struct NetworkConfig {
     pub whitelist_nodes: Vec<PeerInfo>,
     pub handshake_timeout: time::Duration,
 
-    /// Whether to re-establish connections from the ConnectionStore on startup.
+    /// Whether to re-establish connection to known reliable peers from previous neard run(s).
+    /// See near_network::peer_manager::connection_store for details.
     pub connect_to_reliable_peers_on_startup: bool,
     /// Maximum time between refreshing the peer list.
     pub monitor_peers_max_period: time::Duration,

--- a/chain/network/src/config.rs
+++ b/chain/network/src/config.rs
@@ -96,6 +96,8 @@ pub struct NetworkConfig {
     pub whitelist_nodes: Vec<PeerInfo>,
     pub handshake_timeout: time::Duration,
 
+    /// Whether to re-establish connections from the ConnectionStore on startup.
+    pub connect_to_reliable_peers_on_startup: bool,
     /// Maximum time between refreshing the peer list.
     pub monitor_peers_max_period: time::Duration,
     /// Maximum number of active peers. Hard limit.
@@ -250,6 +252,7 @@ impl NetworkConfig {
                     .collect::<anyhow::Result<_>>()
                     .context("whitelist_nodes")?
             },
+            connect_to_reliable_peers_on_startup: true,
             handshake_timeout: cfg.handshake_timeout.try_into()?,
             monitor_peers_max_period: cfg.monitor_peers_max_period.try_into()?,
             max_num_peers: cfg.max_num_peers,
@@ -315,6 +318,7 @@ impl NetworkConfig {
             },
             whitelist_nodes: vec![],
             handshake_timeout: time::Duration::seconds(5),
+            connect_to_reliable_peers_on_startup: true,
             monitor_peers_max_period: time::Duration::seconds(100),
             max_num_peers: 40,
             minimum_outbound_peers: 5,

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -134,7 +134,12 @@ impl actix::Actor for PeerManagerActor {
         self.push_network_info_trigger(ctx, self.state.config.push_info_period);
 
         // Attempt to reconnect to recent outbound connections from storage
-        self.bootstrap_outbound_from_recent_connections(ctx);
+        if self.state.config.connect_to_reliable_peers_on_startup {
+            tracing::debug!(target: "network", "Reconnecting to reliable peers from storage");
+            self.bootstrap_outbound_from_recent_connections(ctx);
+        } else {
+            tracing::debug!(target: "network", "Skipping reconnection to reliable peers");
+        }
 
         // Periodically starts peer monitoring.
         tracing::debug!(target: "network",

--- a/chain/network/src/peer_manager/tests/tier2.rs
+++ b/chain/network/src/peer_manager/tests/tier2.rs
@@ -134,6 +134,43 @@ async fn test_reconnect_after_restart_outbound_side() {
 }
 
 #[tokio::test]
+async fn test_skip_reconnect_after_restart_outbound_side() {
+    init_test_logger();
+    let mut rng = make_rng(921853233);
+    let rng = &mut rng;
+    let mut clock = time::FakeClock::default();
+    let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
+
+    let pm0_db = TestDB::new();
+    let mut pm0_cfg = chain.make_config(rng);
+    pm0_cfg.connect_to_reliable_peers_on_startup = false;
+
+    let pm0 = start_pm(clock.clock(), pm0_db.clone(), pm0_cfg.clone(), chain.clone()).await;
+    let pm1 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
+
+    let id1 = pm1.cfg.node_id();
+
+    tracing::info!(target:"test", "connect pm0 to pm1");
+    pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
+    clock.advance(STORED_CONNECTIONS_MIN_DURATION);
+
+    tracing::info!(target:"test", "check that pm0 stores the outbound connection to pm1");
+    pm0.update_connection_store(&clock.clock()).await;
+    check_recent_outbound_connections(&pm0, vec![id1.clone()]).await;
+
+    tracing::info!(target:"test", "drop pm0 and start it again with the same db");
+    drop(pm0);
+    let pm0 = start_pm(clock.clock(), pm0_db.clone(), pm0_cfg.clone(), chain.clone()).await;
+
+    tracing::info!(target:"test", "check that pm0 has pm1 as a recent connection");
+    check_recent_outbound_connections(&pm0, vec![id1.clone()]).await;
+
+    // this will error if there's already a connection
+    tracing::info!(target:"test", "try connecting pm0 to pm1");
+    pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
+}
+
+#[tokio::test]
 async fn test_reconnect_after_restart_inbound_side() {
     init_test_logger();
     let mut rng = make_rng(921853233);

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -347,6 +347,9 @@ pub(super) struct RunCmd {
     /// Set the boot nodes to bootstrap network from.
     #[clap(long)]
     boot_nodes: Option<String>,
+    /// Whether to re-establish connections from the ConnectionStore on startup
+    #[clap(long)]
+    connect_to_reliable_peers_on_startup: Option<bool>,
     /// Minimum number of peers to start syncing/producing blocks
     #[clap(long)]
     min_peers: Option<usize>,
@@ -401,6 +404,12 @@ impl RunCmd {
         // Override some parameters from command line.
         if let Some(produce_empty_blocks) = self.produce_empty_blocks {
             near_config.client_config.produce_empty_blocks = produce_empty_blocks;
+        }
+        if let Some(connect_to_reliable_peers_on_startup) =
+            self.connect_to_reliable_peers_on_startup
+        {
+            near_config.network_config.connect_to_reliable_peers_on_startup =
+                connect_to_reliable_peers_on_startup;
         }
         if let Some(boot_nodes) = self.boot_nodes {
             if !boot_nodes.is_empty() {


### PR DESCRIPTION
This is a follow-up to https://github.com/near/nearcore/pull/8318, in which reliable peers are persisted to storage in the ConnectionStore.

A new boolean flag `--connect-to-reliable-peers-on-startup` is added to neard. If set to `true`, the node will attempt to reconnect to known reliable peers from storage upon starting up. The default value is `true`.

Note that setting the flag to `false` skips reconnection, but does not purge the reliable peers in storage.

Closes https://github.com/near/nearcore/issues/8580