### PR TITLE
[TestLoop] (3.4/n) Remove MsgRecipient and NetworkRecipient which are no longer used.

### DIFF
--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -5,8 +5,6 @@ pub use crate::network_protocol::{
 };
 use crate::routing::routing_table_view::RoutingTableInfo;
 use crate::time;
-use futures::future::BoxFuture;
-use futures::FutureExt;
 use near_async::messaging::{
     AsyncSender, CanSend, CanSendAsync, IntoAsyncSender, IntoSender, Sender,
 };
@@ -19,7 +17,6 @@ use near_primitives::sharding::PartialEncodedChunkWithArcReceipts;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::BlockHeight;
 use near_primitives::types::{AccountId, ShardId};
-use once_cell::sync::OnceCell;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::net::SocketAddr;
@@ -397,53 +394,6 @@ pub enum NetworkAdversarialMessage {
     AdvDisableDoomslug,
     AdvGetSavedBlocks,
     AdvCheckStorageConsistency,
-}
-
-// TODO: remove trait and all related traits once migration is complete.
-pub trait MsgRecipient<M: actix::Message>: Send + Sync + 'static {
-    fn send(&self, msg: M) -> BoxFuture<'static, Result<M::Result, actix::MailboxError>>;
-    fn do_send(&self, msg: M);
-}
-
-impl<A, M> MsgRecipient<M> for actix::Addr<A>
-where
-    M: actix::Message + Send + 'static,
-    M::Result: Send,
-    A: actix::Actor + actix::Handler<M>,
-    A::Context: actix::dev::ToEnvelope<A, M>,
-{
-    fn send(&self, msg: M) -> BoxFuture<'static, Result<M::Result, actix::MailboxError>> {
-        actix::Addr::send(self, msg).boxed()
-    }
-    fn do_send(&self, msg: M) {
-        actix::Addr::do_send(self, msg)
-    }
-}
-
-// TODO: rename to a more generic name.
-pub struct NetworkRecipient<T> {
-    recipient: OnceCell<Arc<T>>,
-}
-
-impl<T> Default for NetworkRecipient<T> {
-    fn default() -> Self {
-        Self { recipient: OnceCell::default() }
-    }
-}
-
-impl<T> NetworkRecipient<T> {
-    pub fn set_recipient(&self, t: T) {
-        self.recipient.set(Arc::new(t)).ok().expect("cannot set recipient twice");
-    }
-}
-
-impl<M: actix::Message, T: MsgRecipient<M>> MsgRecipient<M> for NetworkRecipient<T> {
-    fn send(&self, msg: M) -> BoxFuture<'static, Result<M::Result, actix::MailboxError>> {
-        self.recipient.wait().send(msg)
-    }
-    fn do_send(&self, msg: M) {
-        self.recipient.wait().do_send(msg);
-    }
 }
 
 #[derive(Clone, derive_more::AsRef)]


### PR DESCRIPTION
They have been superseded by Sender/AsyncSender and LateBoundSender.