### PR TITLE
feat: params estimator for delegate action

### DIFF
--- a/runtime/runtime-params-estimator/src/cost.rs
+++ b/runtime/runtime-params-estimator/src/cost.rs
@@ -202,6 +202,9 @@ pub enum Cost {
     /// Estimates `action_creation_config.delegate_cost` which is charged
     /// for `DelegateAction` actions.
     ActionDelegate,
+    ActionDelegateSendNotSir,
+    ActionDelegateSendSir,
+    ActionDelegateExec,
     /// Estimates `wasm_config.ext_costs.base` which is intended to be charged
     /// once on every host function call. However, this is currently
     /// inconsistent. First, we do not charge on Math API methods (`sha256`,

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -191,6 +191,14 @@ static ALL_COSTS: &[(Cost, fn(&mut EstimatorContext) -> GasCost)] = &[
     (Cost::ActionFunctionCallPerByteSendNotSir, action_costs::function_call_byte_send_not_sir),
     (Cost::ActionFunctionCallPerByteSendSir, action_costs::function_call_byte_send_sir),
     (Cost::ActionFunctionCallPerByteExec, action_costs::function_call_byte_exec),
+    #[cfg(feature = "protocol_feature_nep366_delegate_action")]
+    (Cost::ActionDelegate, action_delegate_base),
+    #[cfg(feature = "protocol_feature_nep366_delegate_action")]
+    (Cost::ActionDelegateSendNotSir, action_costs::delegate_send_not_sir),
+    #[cfg(feature = "protocol_feature_nep366_delegate_action")]
+    (Cost::ActionDelegateSendSir, action_costs::delegate_send_sir),
+    #[cfg(feature = "protocol_feature_nep366_delegate_action")]
+    (Cost::ActionDelegateExec, action_costs::delegate_exec),
     (Cost::HostFunctionCall, host_function_call),
     (Cost::WasmInstruction, wasm_instruction),
     (Cost::DataReceiptCreationBase, data_receipt_creation_base),
@@ -817,6 +825,34 @@ fn data_receipt_creation_per_byte(ctx: &mut EstimatorContext) -> GasCost {
     let bytes_per_transaction = 1000 * 100 * 1024;
 
     total_cost.saturating_sub(&base_cost, &NonNegativeTolerance::PER_MILLE) / bytes_per_transaction
+}
+
+#[cfg(feature = "protocol_feature_nep366_delegate_action")]
+fn action_delegate_base(ctx: &mut EstimatorContext) -> GasCost {
+    let total_cost = {
+        let mut nonce = 1;
+        let mut make_transaction = |tb: &mut TransactionBuilder| -> SignedTransaction {
+            let sender = tb.random_unused_account();
+            let receiver = tb.random_unused_account();
+
+            let action =
+                action_costs::empty_delegate_action(nonce, sender.clone(), receiver.clone());
+            nonce += 1;
+
+            let actions = vec![action];
+            tb.transaction_from_actions(sender, receiver, actions)
+        };
+        // meta tx is delayed by 2 block compared to local receipt
+        let block_latency = 2;
+        let block_size = 100;
+        let (gas_cost, _ext_costs) =
+            transaction_cost_ext(ctx, block_size, &mut make_transaction, block_latency);
+        gas_cost
+    };
+
+    let base_cost = action_receipt_creation(ctx);
+
+    total_cost.saturating_sub(&base_cost, &NonNegativeTolerance::PER_MILLE)
 }
 
 fn host_function_call(ctx: &mut EstimatorContext) -> GasCost {

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -850,7 +850,9 @@ fn action_delegate_base(ctx: &mut EstimatorContext) -> GasCost {
         gas_cost
     };
 
-    let base_cost = action_receipt_creation(ctx);
+    // action receipt creation send cost is paid twice for meta transactions,
+    // exec only once, thus we want to subtract this cost 1.5 times
+    let base_cost = action_receipt_creation(ctx) * 3 / 2;
 
     total_cost.saturating_sub(&base_cost, &NonNegativeTolerance::PER_MILLE)
 }

--- a/runtime/runtime-params-estimator/src/transaction_builder.rs
+++ b/runtime/runtime-params-estimator/src/transaction_builder.rs
@@ -28,6 +28,11 @@ pub(crate) enum AccountRequirement {
     SameAsSigner,
     /// Use sub account of the signer. Useful for `CreateAction` estimations.
     SubOfSigner,
+    /// Account must be `generated_account_id(seed = 0)`.
+    ///
+    /// Usage: Delegate actions are signed by the sender, so it can't be
+    /// replaced with a random account.
+    ConstantAccount0,
 }
 
 impl TransactionBuilder {
@@ -143,6 +148,7 @@ impl TransactionBuilder {
             AccountRequirement::SubOfSigner => {
                 format!("sub.{}", signer_id.expect("no signer_id")).parse().unwrap()
             }
+            AccountRequirement::ConstantAccount0 => self.account(0),
         }
     }
 


### PR DESCRIPTION
The main cost of a meta transaction is for all the inner action costs.
The send costs for them are paid twice, which covers all the extra checks.

However, there is also a bit of constant overhead for each delegate action.
One very small bit when sending it, a slightly larger bit when executing it.

This adds the estimation code for this to the parameter estimator.

Note: All estimations were run on top of the changes from #8578
because that actually changes the signature verification, which happens
to be 99% of the cost we measure here.