### PR TITLE
feat: view client reads data from cold storage

### DIFF
--- a/core/store/src/cold_storage.rs
+++ b/core/store/src/cold_storage.rs
@@ -1,5 +1,5 @@
 use crate::columns::DBKeyType;
-use crate::db::{ColdDB, COLD_HEAD_KEY, HEAD_KEY};
+use crate::db::{ColdDB, COLD_HEAD_KEY};
 use crate::trie::TrieRefcountChange;
 use crate::{metrics, DBCol, DBTransaction, Database, Store, TrieChanges};
 
@@ -136,10 +136,18 @@ pub fn update_cold_head<D: Database>(
     let tip_header = &store.get_ser_or_err::<BlockHeader>(DBCol::BlockHeader, &block_hash_key)?;
     let tip = Tip::from_header(tip_header);
 
-    // Write HEAD to the cold db.
+    // TODO think if safe to remove and about any other usage of this
+    // // Write HEAD to the cold db.
+    // {
+    //     let mut transaction = DBTransaction::new();
+    //     transaction.set(DBCol::BlockMisc, HEAD_KEY.to_vec(), tip.try_to_vec()?);
+    //     cold_db.write(transaction)?;
+    // }
+
+    // Write COLD_HEAD to the cold db.
     {
         let mut transaction = DBTransaction::new();
-        transaction.set(DBCol::BlockMisc, HEAD_KEY.to_vec(), tip.try_to_vec()?);
+        transaction.set(DBCol::BlockMisc, COLD_HEAD_KEY.to_vec(), tip.try_to_vec()?);
         cold_db.write(transaction)?;
     }
 

--- a/pytest/tests/sanity/split_storage.py
+++ b/pytest/tests/sanity/split_storage.py
@@ -249,13 +249,15 @@ class TestSplitStorage(unittest.TestCase):
         logger.info("Phase 3 - Preparing hot storage from rpc backup.")
         logger.info("")
 
+        # TODO Ideally we won't need to stop the node while running prepare-hot.
+        archival.kill(gentle=True)
+        # Need to kill the rpc node in order to force the db to be flushed to disk.
+        rpc.kill(gentle=True)
+
         rpc_src = path.join(rpc.node_dir, "data")
         rpc_dst = path.join(archival.node_dir, "hot_data")
         logger.info(f"Copying rpc backup from {rpc_src} to {rpc_dst}")
         shutil.copytree(rpc_src, rpc_dst)
-
-        # TODO Ideally we won't need to stop the node while running prepare-hot.
-        archival.kill(gentle=True)
 
         archival_dir = pathlib.Path(archival.node_dir)
         with open(archival_dir / 'prepare-hot-stdout', 'w') as stdout, \
@@ -286,6 +288,7 @@ class TestSplitStorage(unittest.TestCase):
         logger.info("Phase 4 - After migration.")
         logger.info("")
 
+        rpc.start()
         archival.start()
 
         # Wait for a few seconds to:

--- a/tools/cold-store/src/cli.rs
+++ b/tools/cold-store/src/cli.rs
@@ -340,7 +340,7 @@ impl PrepareHotCmd {
     /// Check that the DbKind of each of the stores is as expected.
     fn check_db_kind(
         hot_store: &Store,
-        cold_store: &Store,
+        _cold_store: &Store,
         rpc_store: &Store,
     ) -> anyhow::Result<()> {
         let hot_db_kind = hot_store.get_db_kind()?;
@@ -352,14 +352,17 @@ impl PrepareHotCmd {
             ));
         }
 
-        let cold_db_kind = cold_store.get_db_kind()?;
-        if cold_db_kind != Some(DbKind::Cold) {
-            return Err(anyhow::anyhow!(
-                "Unexpected cold_store DbKind, expected: {:?}, got: {:?}",
-                DbKind::Cold,
-                cold_db_kind,
-            ));
-        }
+        // TODO(wacban) the cold store is a ColdDB and it first reads from the hot store
+        // and returns the hot's db kind. Expose the underlying pure cold
+        // storage and uncomment that check.
+        // let cold_db_kind = cold_store.get_db_kind()?;
+        // if cold_db_kind != Some(DbKind::Cold) {
+        //     return Err(anyhow::anyhow!(
+        //         "Unexpected cold_store DbKind, expected: {:?}, got: {:?}",
+        //         DbKind::Cold,
+        //         cold_db_kind,
+        //     ));
+        // }
 
         let rpc_db_kind = rpc_store.get_db_kind()?;
         if rpc_db_kind != Some(DbKind::RPC) {


### PR DESCRIPTION
Looking for some early feedback and ideas for how to best test this. 

- Changed the cold db to always first read from the hot storage and then from cold storage. Previously it was only reading from cold. 
- Changed the neard startup to create two runtimes. One as before and a new one called view_runtime that has the cold_db as it's store. Pass the view_runtime to the view client. 
- Made some small changes to fix the split_storage.py tests. Most notably reading head from cold_db in order to get the cold head doesn't make sense because now it reads from hot first and returns the hot head. 