### PR TITLE
chore: bump crates version to 0.16.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ members = [
 ]
 
 [workspace.metadata.workspaces]
-version = "0.15.0"
+version = "0.16.0"
 exclude = [ "neard" ]
 
 [workspace.dependencies]


### PR DESCRIPTION
Update the cargo workspace version to trigger a new tag and
release for all crates. More info on this process here: 
https://github.com/near/nearcore/blob/f7a6bd472ceaff270ed913a30dc39cd714195553/docs/misc/README.md

The main motivation for the release it to make meta transaction related
structs (`DelegateAction`, `SignedDelegateAction` and a few others) 
accessible to downstream projects, such as near-cli or near-lake.

## Breaking changes
The changes also includes a new variant to `Action`, which is not marked
as `non_exhaustive`, therefore this alone is a breaking change for code
that exhaustively matched an action.

I don't know of any other breaking changes but most likely we have
some in the last ~5 months of changes across all the published crates.