### PR TITLE
fix: crates.io compatible stdx dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2453,7 +2453,7 @@ dependencies = [
  "near-performance-metrics",
  "near-primitives",
  "near-primitives-core",
- "near-stdx",
+ "near-stdx 0.16.0",
  "near-store",
  "near-telemetry",
  "near-test-contracts",
@@ -3221,7 +3221,7 @@ dependencies = [
  "hex-literal",
  "near-account-id",
  "near-config-utils",
- "near-stdx",
+ "near-stdx 0.16.0",
  "once_cell",
  "primitive-types",
  "rand 0.7.3",
@@ -3622,7 +3622,7 @@ dependencies = [
  "near-o11y",
  "near-primitives-core",
  "near-rpc-error-macro",
- "near-stdx",
+ "near-stdx 0.16.0",
  "near-vm-errors",
  "num-rational",
  "once_cell",
@@ -3736,6 +3736,12 @@ name = "near-stdx"
 version = "0.0.0"
 
 [[package]]
+name = "near-stdx"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c05ded9a90c087aaebfafdf01f2801f5d31817f9a3514ce09aed270001d650e"
+
+[[package]]
 name = "near-store"
 version = "0.0.0"
 dependencies = [
@@ -3756,7 +3762,7 @@ dependencies = [
  "near-crypto",
  "near-o11y",
  "near-primitives",
- "near-stdx",
+ "near-stdx 0.16.0",
  "num_cpus",
  "once_cell",
  "rand 0.8.5",
@@ -3825,7 +3831,7 @@ dependencies = [
  "near-o11y",
  "near-primitives",
  "near-primitives-core",
- "near-stdx",
+ "near-stdx 0.16.0",
  "near-vm-errors",
  "ripemd",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -214,7 +214,12 @@ webrtc-util = "0.7"
 xshell = "0.2.1"
 xz2 = "0.1.6"
 
-stdx = { package = "near-stdx", path = "utils/stdx" }
+# Polyfill crate introduced in https://github.com/near/nearcore/pull/8087
+# Because public crates depend on it, we have to also publish this.
+# When changing the workspace version, set this back to a local dependency and
+# then update again to the higher published version once we release crates again.
+# TODO(#8604): Fix this process.
+stdx = { package = "near-stdx", version = "0.16.0" }
 
 [patch.crates-io]
 

--- a/deny.toml
+++ b/deny.toml
@@ -107,4 +107,9 @@ skip = [
 
     # validator 0.12 ~ 0.16 is still using an old version of idna
     { name = "idna", version = "=0.2.3" },
+
+    # v0.0.0 is the local code, whereas the published crate must depend on a
+    # published crate when they are published.
+    # TODO(#8604) Remove this skip entry.
+    { name = "near-stdx", version = "0.0.0" },
 ]


### PR DESCRIPTION
See https://github.com/near/nearcore/issues/8604