### PR TITLE
fix: JSON RPC Primitives with default features

### DIFF
--- a/chain/jsonrpc-primitives/src/types/status.rs
+++ b/chain/jsonrpc-primitives/src/types/status.rs
@@ -1,6 +1,8 @@
+#[cfg(feature = "debug_types")]
 use near_client_primitives::debug::{
     DebugBlockStatusData, EpochInfoView, TrackedShardsView, ValidatorStatus,
 };
+#[cfg(feature = "debug_types")]
 use near_primitives::views::{
     CatchupStatusView, ChainProcessingInfo, NetworkGraphView, PeerStoreView,
     RecentOutboundConnectionsView, RequestedStatePartsView, SyncStatusView,
@@ -12,6 +14,7 @@ pub struct RpcStatusResponse {
     pub status_response: near_primitives::views::StatusResponse,
 }
 
+#[cfg(feature = "debug_types")]
 #[derive(serde::Serialize, Debug)]
 pub enum DebugStatusResponse {
     SyncStatus(SyncStatusView),


### PR DESCRIPTION
Building this was just broken, I don't know for how long.
It was now caught when publishing crates, because you can't publish
with compilation errors.


error:
```
error[E0433]: failed to resolve: use of undeclared crate or module `near_client_primitives`
 --> chain/jsonrpc-primitives/src/types/status.rs:1:5
  |
1 | use near_client_primitives::debug::{
  |     ^^^^^^^^^^^^^^^^^^^^^^ use of undeclared crate or module `near_client_primitives`
```