### PR TITLE
Update borsh dependency; again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,8 +711,18 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15bf3650200d8bffa99015595e10f1fbd17de07abbc25bb067da79e769939bfa"
 dependencies = [
- "borsh-derive",
+ "borsh-derive 0.9.3",
  "hashbrown 0.11.2",
+]
+
+[[package]]
+name = "borsh"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40f9ca3698b2e4cb7c15571db0abc5551dca417a21ae8140460b50309bb2cc62"
+dependencies = [
+ "borsh-derive 0.10.2",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -721,8 +731,21 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6441c552f230375d18e3cc377677914d2ca2b0d36e52129fe15450a2dce46775"
 dependencies = [
- "borsh-derive-internal",
- "borsh-schema-derive-internal",
+ "borsh-derive-internal 0.9.3",
+ "borsh-schema-derive-internal 0.9.3",
+ "proc-macro-crate",
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598b3eacc6db9c3ee57b22707ad8f6a8d2f6d442bfe24ffeb8cbb70ca59e6a35"
+dependencies = [
+ "borsh-derive-internal 0.10.2",
+ "borsh-schema-derive-internal 0.10.2",
  "proc-macro-crate",
  "proc-macro2",
  "syn",
@@ -740,10 +763,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh-derive-internal"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186b734fa1c9f6743e90c95d7233c9faab6360d1a96d4ffa19d9cfd1e9350f8a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "borsh-schema-derive-internal"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "borsh-schema-derive-internal"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b7ff1008316626f485991b960ade129253d4034014616b94f309a15366cc49"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2053,7 +2098,7 @@ dependencies = [
 name = "genesis-populate"
 version = "0.0.0"
 dependencies = [
- "borsh",
+ "borsh 0.10.2",
  "clap 3.1.18",
  "indicatif",
  "near-chain",
@@ -2430,7 +2475,7 @@ dependencies = [
  "actix-rt",
  "anyhow",
  "assert_matches",
- "borsh",
+ "borsh 0.10.2",
  "chrono",
  "clap 3.1.18",
  "futures",
@@ -2961,7 +3006,7 @@ version = "0.0.0"
 dependencies = [
  "arbitrary",
  "bolero",
- "borsh",
+ "borsh 0.10.2",
  "serde",
  "serde_json",
 ]
@@ -2970,7 +3015,7 @@ dependencies = [
 name = "near-account-id-fuzz"
 version = "0.0.0"
 dependencies = [
- "borsh",
+ "borsh 0.10.2",
  "libfuzzer-sys",
  "near-account-id",
  "serde_json",
@@ -2991,7 +3036,7 @@ name = "near-amend-genesis"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.10.2",
  "clap 3.1.18",
  "near-chain",
  "near-chain-configs",
@@ -3041,7 +3086,7 @@ dependencies = [
  "actix",
  "ansi_term",
  "assert_matches",
- "borsh",
+ "borsh 0.10.2",
  "chrono",
  "crossbeam-channel",
  "delay-detector",
@@ -3107,7 +3152,7 @@ version = "0.0.0"
 dependencies = [
  "actix",
  "assert_matches",
- "borsh",
+ "borsh 0.10.2",
  "chrono",
  "futures",
  "lru",
@@ -3144,7 +3189,7 @@ dependencies = [
  "ansi_term",
  "assert_matches",
  "async-trait",
- "borsh",
+ "borsh 0.10.2",
  "chrono",
  "delay-detector",
  "derive_more",
@@ -3211,7 +3256,7 @@ name = "near-crypto"
 version = "0.0.0"
 dependencies = [
  "blake2",
- "borsh",
+ "borsh 0.10.2",
  "bs58",
  "c2-chacha",
  "curve25519-dalek",
@@ -3255,7 +3300,7 @@ dependencies = [
 name = "near-epoch-manager"
 version = "0.0.0"
 dependencies = [
- "borsh",
+ "borsh 0.10.2",
  "chrono",
  "near-cache",
  "near-chain-configs",
@@ -3396,7 +3441,7 @@ version = "0.0.0"
 dependencies = [
  "actix",
  "awc",
- "borsh",
+ "borsh 0.10.2",
  "futures",
  "near-actix-test-utils",
  "near-chain-configs",
@@ -3430,7 +3475,7 @@ dependencies = [
  "actix",
  "anyhow",
  "async-trait",
- "borsh",
+ "borsh 0.10.2",
  "bs58",
  "clap 3.1.18",
  "ed25519-dalek",
@@ -3474,7 +3519,7 @@ dependencies = [
  "arc-swap",
  "assert_matches",
  "async-trait",
- "borsh",
+ "borsh 0.10.2",
  "bytes",
  "bytesize",
  "chrono",
@@ -3594,7 +3639,7 @@ dependencies = [
 name = "near-pool"
 version = "0.0.0"
 dependencies = [
- "borsh",
+ "borsh 0.10.2",
  "near-crypto",
  "near-o11y",
  "near-primitives",
@@ -3609,7 +3654,7 @@ dependencies = [
  "arbitrary",
  "assert_matches",
  "bencher",
- "borsh",
+ "borsh 0.10.2",
  "bytesize",
  "cfg-if 1.0.0",
  "chrono",
@@ -3644,7 +3689,7 @@ version = "0.0.0"
 dependencies = [
  "arbitrary",
  "base64",
- "borsh",
+ "borsh 0.10.2",
  "bs58",
  "derive_more",
  "enum-map",
@@ -3748,7 +3793,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "bencher",
- "borsh",
+ "borsh 0.10.2",
  "byteorder",
  "bytesize",
  "crossbeam",
@@ -3810,7 +3855,7 @@ dependencies = [
 name = "near-vm-errors"
 version = "0.0.0"
 dependencies = [
- "borsh",
+ "borsh 0.10.2",
  "near-account-id",
  "near-rpc-error-macro",
  "serde",
@@ -3822,7 +3867,7 @@ dependencies = [
 name = "near-vm-logic"
 version = "0.0.0"
 dependencies = [
- "borsh",
+ "borsh 0.10.2",
  "ed25519-dalek",
  "expect-test",
  "hex",
@@ -3850,7 +3895,7 @@ dependencies = [
  "arbitrary",
  "assert_matches",
  "bolero",
- "borsh",
+ "borsh 0.10.2",
  "expect-test",
  "hex",
  "loupe",
@@ -3908,7 +3953,7 @@ dependencies = [
  "anyhow",
  "awc",
  "bencher",
- "borsh",
+ "borsh 0.10.2",
  "byteorder",
  "chrono",
  "delay-detector",
@@ -4031,7 +4076,7 @@ name = "node-runtime"
 version = "0.0.0"
 dependencies = [
  "assert_matches",
- "borsh",
+ "borsh 0.10.2",
  "enum-map",
  "hex",
  "indicatif",
@@ -5160,7 +5205,7 @@ name = "runtime-params-estimator"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.10.2",
  "bs58",
  "bytesize",
  "cfg-if 1.0.0",
@@ -5756,7 +5801,7 @@ dependencies = [
 name = "speedy_sync"
 version = "0.0.0"
 dependencies = [
- "borsh",
+ "borsh 0.10.2",
  "clap 3.1.18",
  "near-chain",
  "near-chain-configs",
@@ -5787,7 +5832,7 @@ version = "0.0.0"
 dependencies = [
  "ansi_term",
  "anyhow",
- "borsh",
+ "borsh 0.10.2",
  "clap 3.1.18",
  "insta",
  "near-chain",
@@ -6796,7 +6841,7 @@ checksum = "5a3fac37da3c625e98708c5dd92d3f642aaf700fd077168d3d0fff277ec6a165"
 dependencies = [
  "bincode",
  "blake3",
- "borsh",
+ "borsh 0.9.3",
  "cc",
  "digest 0.8.1",
  "errno",
@@ -6839,7 +6884,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6edd0ba6c0bcf9b279186d4dbe81649dda3e5ef38f586865943de4dcd653f8"
 dependencies = [
  "bincode",
- "borsh",
+ "borsh 0.9.3",
  "byteorder",
  "dynasm",
  "dynasmrt",
@@ -7361,7 +7406,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e61de68ede9ffdd69c01664f65a178c5188b73f78faa21f0936016a888ff7c"
 dependencies = [
- "borsh",
+ "borsh 0.9.3",
  "byteorder",
  "crunchy",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ bitflags = "1.2"
 blake2 = "0.9.1"
 bn = { package = "zeropool-bn", version = "0.5.11" }
 bolero = "0.8.0"
-borsh = { version = "0.9", features = ["rc"] }
+borsh = { version = "0.10.2", features = ["rc"] }
 bs58 = "0.4"
 byteorder = "1.3"
 bytes = "1"

--- a/chain/network/src/network_protocol/borsh.rs
+++ b/chain/network/src/network_protocol/borsh.rs
@@ -57,8 +57,8 @@ struct HandshakeAutoDes {
 // Use custom deserializer for HandshakeV2. Try to read version of the other peer from the header.
 // If the version is supported then fallback to standard deserializer.
 impl BorshDeserialize for Handshake {
-    fn deserialize(buf: &mut &[u8]) -> std::io::Result<Self> {
-        <HandshakeAutoDes as BorshDeserialize>::deserialize(buf).map(Into::into)
+    fn deserialize_reader<R: std::io::Read>(rd: &mut R) -> std::io::Result<Self> {
+        HandshakeAutoDes::deserialize_reader(rd).map(Into::into)
     }
 }
 

--- a/core/account-id/src/borsh.rs
+++ b/core/account-id/src/borsh.rs
@@ -1,18 +1,18 @@
 use super::AccountId;
 
-use std::io::{Error, Write};
+use std::io::{Read, Write};
 
 use borsh::{BorshDeserialize, BorshSerialize};
 
 impl BorshSerialize for AccountId {
-    fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
+    fn serialize<W: Write>(&self, writer: &mut W) -> std::io::Result<()> {
         self.0.serialize(writer)
     }
 }
 
 impl BorshDeserialize for AccountId {
-    fn deserialize(buf: &mut &[u8]) -> Result<Self, std::io::Error> {
-        let account_id = Box::<str>::deserialize(buf)?;
+    fn deserialize_reader<R: Read>(rd: &mut R) -> std::io::Result<Self> {
+        let account_id = Box::<str>::deserialize_reader(rd)?;
         Self::validate(&account_id).map_err(|err| {
             std::io::Error::new(
                 std::io::ErrorKind::InvalidData,

--- a/core/crypto/src/traits.rs
+++ b/core/crypto/src/traits.rs
@@ -116,7 +116,7 @@ macro_rules! eq {
 
 macro_rules! value_type {
     ($vis:vis, $ty:ident, $l:literal, $what:literal) => {
-        #[derive(Copy, Clone, Eq, PartialEq)]
+        #[derive(Copy, Clone, Eq, PartialEq, borsh::BorshDeserialize, borsh::BorshSerialize)]
         $vis struct $ty(pub [u8; $l]);
 
         impl AsMut<[u8; $l]> for $ty {
@@ -134,30 +134,6 @@ macro_rules! value_type {
         impl From<&[u8; $l]> for $ty {
             fn from(value: &[u8; $l]) -> Self {
                 Self(*value)
-            }
-        }
-
-        impl borsh::BorshSerialize for $ty {
-            #[inline]
-            fn serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
-                writer.write_all(&self.0)
-            }
-        }
-
-        impl borsh::BorshDeserialize for $ty {
-            #[inline]
-            fn deserialize(buf: &mut &[u8]) -> Result<Self, std::io::Error> {
-                if buf.len() < $l {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::InvalidInput,
-                        "Unexpected length of input",
-                    ));
-                }
-
-                let mut data = [0u8; $l];
-                data.copy_from_slice(&buf[..$l]);
-                *buf = &buf[$l..];
-                Ok($ty(data))
             }
         }
 

--- a/core/primitives-core/src/account.rs
+++ b/core/primitives-core/src/account.rs
@@ -117,10 +117,10 @@ struct LegacyAccount {
 }
 
 impl BorshDeserialize for Account {
-    fn deserialize(buf: &mut &[u8]) -> Result<Self, io::Error> {
+    fn deserialize_reader<R: io::Read>(rd: &mut R) -> io::Result<Self> {
         // This should only ever happen if we have pre-transition account serialized in state
         // See test_account_size
-        let deserialized_account = LegacyAccount::deserialize(buf)?;
+        let deserialized_account = LegacyAccount::deserialize_reader(rd)?;
         Ok(Account {
             amount: deserialized_account.amount,
             locked: deserialized_account.locked,

--- a/core/primitives-core/src/hash.rs
+++ b/core/primitives-core/src/hash.rs
@@ -15,6 +15,8 @@ use std::io::Write;
     derive_more::AsRef,
     derive_more::AsMut,
     arbitrary::Arbitrary,
+    borsh::BorshDeserialize,
+    borsh::BorshSerialize,
 )]
 #[as_ref(forward)]
 #[as_mut(forward)]
@@ -113,19 +115,6 @@ enum Decode58Result {
 impl Default for CryptoHash {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-impl borsh::BorshSerialize for CryptoHash {
-    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
-        writer.write_all(&self.0)?;
-        Ok(())
-    }
-}
-
-impl borsh::BorshDeserialize for CryptoHash {
-    fn deserialize(buf: &mut &[u8]) -> Result<Self, std::io::Error> {
-        Ok(CryptoHash(borsh::BorshDeserialize::deserialize(buf)?))
     }
 }
 

--- a/core/primitives-core/src/profile.rs
+++ b/core/primitives-core/src/profile.rs
@@ -108,10 +108,10 @@ impl ProfileDataV3 {
 }
 
 impl BorshDeserialize for ProfileDataV3 {
-    fn deserialize(buf: &mut &[u8]) -> Result<Self, std::io::Error> {
-        let actions_array: Vec<u64> = BorshDeserialize::deserialize(buf)?;
-        let ext_array: Vec<u64> = BorshDeserialize::deserialize(buf)?;
-        let wasm_gas: u64 = BorshDeserialize::deserialize(buf)?;
+    fn deserialize_reader<R: std::io::Read>(rd: &mut R) -> std::io::Result<Self> {
+        let actions_array: Vec<u64> = BorshDeserialize::deserialize_reader(rd)?;
+        let ext_array: Vec<u64> = BorshDeserialize::deserialize_reader(rd)?;
+        let wasm_gas: u64 = BorshDeserialize::deserialize_reader(rd)?;
 
         // Mapping raw arrays to enum maps.
         // The enum map could be smaller or larger than the raw array.

--- a/core/primitives-core/src/profile/profile_v2.rs
+++ b/core/primitives-core/src/profile/profile_v2.rs
@@ -219,8 +219,8 @@ impl Index<ExtCosts> for ProfileDataV2 {
 }
 
 impl BorshDeserialize for DataArray {
-    fn deserialize(buf: &mut &[u8]) -> Result<Self, std::io::Error> {
-        let data_vec: Vec<u64> = BorshDeserialize::deserialize(buf)?;
+    fn deserialize_reader<R: std::io::Read>(rd: &mut R) -> std::io::Result<Self> {
+        let data_vec: Vec<u64> = BorshDeserialize::deserialize_reader(rd)?;
         let mut data_array = [0; Self::LEN];
         let len = Self::LEN.min(data_vec.len());
         data_array[0..len].copy_from_slice(&data_vec[0..len]);
@@ -230,8 +230,7 @@ impl BorshDeserialize for DataArray {
 
 impl BorshSerialize for DataArray {
     fn serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
-        let v: Vec<_> = self.0.as_ref().to_vec();
-        BorshSerialize::serialize(&v, writer)
+        (&self.0[..]).serialize(writer)
     }
 }
 

--- a/core/primitives/src/delegate_action.rs
+++ b/core/primitives/src/delegate_action.rs
@@ -116,21 +116,15 @@ mod private_non_delegate_action {
     }
 
     impl borsh::de::BorshDeserialize for NonDelegateAction {
-        fn deserialize(
-            buf: &mut &[u8],
+        fn deserialize_reader<R: borsh::maybestd::io::Read>(
+            rd: &mut R,
         ) -> ::core::result::Result<Self, borsh::maybestd::io::Error> {
-            if buf.is_empty() {
-                return Err(Error::new(
-                    ErrorKind::InvalidInput,
-                    "Failed to deserialize DelegateAction",
-                ));
-            }
-            match buf[0] {
+            match u8::deserialize_reader(rd)? {
                 ACTION_DELEGATE_NUMBER => Err(Error::new(
                     ErrorKind::InvalidInput,
                     "DelegateAction mustn't contain a nested one",
                 )),
-                _ => Ok(Self(borsh::BorshDeserialize::deserialize(buf)?)),
+                n => borsh::de::EnumExt::deserialize_variant(rd, n).map(Self),
             }
         }
     }

--- a/core/primitives/src/time.rs
+++ b/core/primitives/src/time.rs
@@ -304,16 +304,13 @@ mod time {
 
     impl BorshSerialize for Time {
         fn serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
-            let nanos = self.to_unix_timestamp_nanos().as_nanos() as u64;
-            BorshSerialize::serialize(&nanos, writer).unwrap();
-            Ok(())
+            (self.to_unix_timestamp_nanos().as_nanos() as u64).serialize(writer)
         }
     }
 
     impl BorshDeserialize for Time {
-        fn deserialize(buf: &mut &[u8]) -> Result<Self, std::io::Error> {
-            let nanos: u64 = borsh::BorshDeserialize::deserialize(buf)?;
-
+        fn deserialize_reader<R: std::io::Read>(rd: &mut R) -> std::io::Result<Self> {
+            let nanos = u64::deserialize_reader(rd)?;
             Ok(Time::from_unix_timestamp(Duration::from_nanos(nanos)))
         }
     }

--- a/deny.toml
+++ b/deny.toml
@@ -14,6 +14,9 @@ deny = [
     { name = "keccak-hash", version = "<0.4.1" },
     { name = "primitive-types", version = "<0.10.1" },
     { name = "uint", version = "<0.8.2" },
+
+    # https://github.com/near/nearcore/pull/8562
+    { name = "borsh", version = "0.10, <0.10.2" },
 ]
 
 skip = [
@@ -112,4 +115,10 @@ skip = [
     # published crate when they are published.
     # TODO(#8604) Remove this skip entry.
     { name = "near-stdx", version = "0.0.0" },
+
+    # zeropool-bn uses borsh 0.9
+    { name = "borsh", version = "=0.9.3" },
+    { name = "borsh-derive", version = "=0.9.3" },
+    { name = "borsh-derive-internal", version = "=0.9.3" },
+    { name = "borsh-schema-derive-internal", version = "=0.9.3" },
 ]

--- a/tools/speedy_sync/Cargo.toml
+++ b/tools/speedy_sync/Cargo.toml
@@ -17,8 +17,7 @@ near-chain-configs = { path = "../../core/chain-configs" }
 near-chain = { path = "../../chain/chain"}
 near-epoch-manager = {path = "../../chain/epoch-manager" }
 
-borsh = "0.9"
+borsh = "0.10.2"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 clap = { version = "3.1.6", features = ["derive"] }
-


### PR DESCRIPTION
This is re-application of commit b8196b1aa with the same subject alas
this time borsh is updated to 0.10.2.  Previous attempt to update the
dependency was reverted becauses of potential DOS which was addressed
in borsh 0.10.2 (see <https://github.com/near/borsh-rs/pull/129>).

Like before, the update is mostly a matter of replacing deserialize
function in BorshDeserialize implementations by deserialize_reader.
In a few of existing custom implementations for (de)serialization
could be removed altogether.
