### PR TITLE
feature: Add shard_id to SECONDS_PER_PETAGAS metric

### DIFF
--- a/nearcore/src/metrics.rs
+++ b/nearcore/src/metrics.rs
@@ -18,7 +18,7 @@ pub static SECONDS_PER_PETAGAS: Lazy<HistogramVec> = Lazy::new(|| {
     try_create_histogram_vec(
         "near_execution_seconds_per_petagas_ratio",
         "Execution time per unit of gas, measured in seconds per petagas. Ignore label 'label'.",
-        &[],
+        &["shard_id"],
         // Non-linear buckets with higher resolution around 1.0.
         Some(vec![
             0.0, 0.1, 0.2, 0.5, 0.7, 0.8, 0.9, 0.95, 0.97, 0.99, 1.0, 1.01, 1.03, 1.05, 1.1, 1.2,

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -536,7 +536,7 @@ impl NightshadeRuntime {
             .observe(elapsed.as_secs_f64());
         if total_gas_burnt > 0 {
             metrics::SECONDS_PER_PETAGAS
-                .with_label_values(&[])
+                .with_label_values(&[&shard_id.to_string()])
                 .observe(elapsed.as_secs_f64() * 1e15 / total_gas_burnt as f64);
         }
         let total_balance_burnt = apply_result


### PR DESCRIPTION
Adding `shard_id` to allow understanding on which shard the undercharging is happening.

Given that this is changing the existing metric, is there any migration process that I need to follow?