### PR TITLE
jsonrpc: optimise parsing of legacy params format

### DIFF
--- a/chain/jsonrpc/src/api/blocks.rs
+++ b/chain/jsonrpc/src/api/blocks.rs
@@ -3,17 +3,15 @@ use serde_json::Value;
 use near_client_primitives::types::GetBlockError;
 use near_jsonrpc_primitives::errors::RpcParseError;
 use near_jsonrpc_primitives::types::blocks::{RpcBlockError, RpcBlockRequest};
-use near_primitives::types::{BlockId, BlockReference};
+use near_primitives::types::BlockReference;
 
-use super::{parse_params, RpcFrom, RpcRequest};
+use super::{Params, RpcFrom, RpcRequest};
 
 impl RpcRequest for RpcBlockRequest {
     fn parse(value: Value) -> Result<Self, RpcParseError> {
-        let block_reference = if let Ok((block_id,)) = parse_params::<(BlockId,)>(value.clone()) {
-            BlockReference::BlockId(block_id)
-        } else {
-            parse_params::<BlockReference>(value)?
-        };
+        let block_reference = Params::new(value)
+            .try_singleton(|block_id| Ok(BlockReference::BlockId(block_id)))
+            .unwrap_or_parse()?;
         Ok(Self { block_reference })
     }
 }

--- a/chain/jsonrpc/src/api/changes.rs
+++ b/chain/jsonrpc/src/api/changes.rs
@@ -6,17 +6,17 @@ use near_jsonrpc_primitives::types::changes::{
     RpcStateChangesError, RpcStateChangesInBlockByTypeRequest, RpcStateChangesInBlockRequest,
 };
 
-use super::{parse_params, RpcFrom, RpcRequest};
+use super::{Params, RpcFrom, RpcRequest};
 
 impl RpcRequest for RpcStateChangesInBlockRequest {
     fn parse(value: Value) -> Result<Self, RpcParseError> {
-        parse_params::<Self>(value)
+        Params::parse(value)
     }
 }
 
 impl RpcRequest for RpcStateChangesInBlockByTypeRequest {
     fn parse(value: Value) -> Result<Self, RpcParseError> {
-        parse_params::<Self>(value)
+        Params::parse(value)
     }
 }
 

--- a/chain/jsonrpc/src/api/config.rs
+++ b/chain/jsonrpc/src/api/config.rs
@@ -3,13 +3,12 @@ use serde_json::Value;
 use near_client_primitives::types::GetProtocolConfigError;
 use near_jsonrpc_primitives::errors::RpcParseError;
 use near_jsonrpc_primitives::types::config::{RpcProtocolConfigError, RpcProtocolConfigRequest};
-use near_primitives::types::BlockReference;
 
-use super::{parse_params, RpcFrom, RpcRequest};
+use super::{Params, RpcFrom, RpcRequest};
 
 impl RpcRequest for RpcProtocolConfigRequest {
     fn parse(value: Value) -> Result<Self, RpcParseError> {
-        parse_params::<BlockReference>(value).map(|block_reference| Self { block_reference })
+        Params::parse(value).map(|block_reference| Self { block_reference })
     }
 }
 

--- a/chain/jsonrpc/src/api/gas_price.rs
+++ b/chain/jsonrpc/src/api/gas_price.rs
@@ -3,13 +3,12 @@ use serde_json::Value;
 use near_client_primitives::types::GetGasPriceError;
 use near_jsonrpc_primitives::errors::RpcParseError;
 use near_jsonrpc_primitives::types::gas_price::{RpcGasPriceError, RpcGasPriceRequest};
-use near_primitives::types::MaybeBlockId;
 
-use super::{parse_params, RpcFrom, RpcRequest};
+use super::{Params, RpcFrom, RpcRequest};
 
 impl RpcRequest for RpcGasPriceRequest {
     fn parse(value: Value) -> Result<Self, RpcParseError> {
-        parse_params::<(MaybeBlockId,)>(value).map(|(block_id,)| Self { block_id })
+        Params::parse(value).map(|(block_id,)| Self { block_id })
     }
 }
 

--- a/chain/jsonrpc/src/api/light_client.rs
+++ b/chain/jsonrpc/src/api/light_client.rs
@@ -10,24 +10,21 @@ use near_jsonrpc_primitives::types::light_client::{
     RpcLightClientExecutionProofRequest, RpcLightClientNextBlockError,
     RpcLightClientNextBlockRequest, RpcLightClientNextBlockResponse, RpcLightClientProofError,
 };
-use near_primitives::hash::CryptoHash;
 use near_primitives::views::LightClientBlockView;
 
-use super::{parse_params, RpcFrom, RpcRequest};
+use super::{Params, RpcFrom, RpcRequest};
 
 impl RpcRequest for RpcLightClientExecutionProofRequest {
     fn parse(value: Value) -> Result<Self, RpcParseError> {
-        Ok(parse_params::<Self>(value)?)
+        Params::parse(value)
     }
 }
 
 impl RpcRequest for RpcLightClientNextBlockRequest {
     fn parse(value: Value) -> Result<Self, RpcParseError> {
-        if let Ok((last_block_hash,)) = parse_params::<(CryptoHash,)>(value.clone()) {
-            Ok(Self { last_block_hash })
-        } else {
-            Ok(parse_params::<Self>(value)?)
-        }
+        Params::new(value)
+            .try_singleton(|last_block_hash| Ok(Self { last_block_hash }))
+            .unwrap_or_parse()
     }
 }
 

--- a/chain/jsonrpc/src/api/maintenance.rs
+++ b/chain/jsonrpc/src/api/maintenance.rs
@@ -6,11 +6,11 @@ use near_jsonrpc_primitives::types::maintenance::{
     RpcMaintenanceWindowsError, RpcMaintenanceWindowsRequest,
 };
 
-use super::{parse_params, RpcFrom, RpcRequest};
+use super::{Params, RpcFrom, RpcRequest};
 
 impl RpcRequest for RpcMaintenanceWindowsRequest {
     fn parse(value: Value) -> Result<Self, RpcParseError> {
-        parse_params::<Self>(value)
+        Params::parse(value)
     }
 }
 

--- a/chain/jsonrpc/src/api/receipts.rs
+++ b/chain/jsonrpc/src/api/receipts.rs
@@ -1,4 +1,4 @@
-use super::{parse_params, RpcFrom, RpcRequest};
+use super::{Params, RpcFrom, RpcRequest};
 use near_client_primitives::types::{GetReceipt, GetReceiptError};
 use near_jsonrpc_primitives::errors::RpcParseError;
 use near_jsonrpc_primitives::types::receipts::{
@@ -8,8 +8,7 @@ use serde_json::Value;
 
 impl RpcRequest for RpcReceiptRequest {
     fn parse(value: Value) -> Result<Self, RpcParseError> {
-        let receipt_reference = parse_params::<ReceiptReference>(value)?;
-        Ok(Self { receipt_reference })
+        Ok(Self { receipt_reference: Params::parse(value)? })
     }
 }
 

--- a/chain/jsonrpc/src/api/sandbox.rs
+++ b/chain/jsonrpc/src/api/sandbox.rs
@@ -6,17 +6,17 @@ use near_jsonrpc_primitives::types::sandbox::{
     RpcSandboxPatchStateRequest,
 };
 
-use super::{parse_params, RpcFrom, RpcRequest};
+use super::{Params, RpcFrom, RpcRequest};
 
 impl RpcRequest for RpcSandboxPatchStateRequest {
     fn parse(value: Value) -> Result<Self, RpcParseError> {
-        parse_params::<Self>(value)
+        Params::parse(value)
     }
 }
 
 impl RpcRequest for RpcSandboxFastForwardRequest {
     fn parse(value: Value) -> Result<Self, RpcParseError> {
-        parse_params::<Self>(value)
+        Params::parse(value)
     }
 }
 

--- a/chain/jsonrpc/src/api/split_storage.rs
+++ b/chain/jsonrpc/src/api/split_storage.rs
@@ -5,11 +5,11 @@ use near_jsonrpc_primitives::{
 };
 use serde_json::Value;
 
-use super::{parse_params, RpcFrom, RpcRequest};
+use super::{Params, RpcFrom, RpcRequest};
 
 impl RpcRequest for RpcSplitStorageInfoRequest {
     fn parse(value: Value) -> Result<Self, RpcParseError> {
-        parse_params::<Self>(value)
+        Params::parse(value)
     }
 }
 

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -1268,7 +1268,7 @@ impl JsonRpcHandler {
     }
 
     async fn adv_produce_blocks(&self, params: Value) -> Result<Value, RpcError> {
-        let (num_blocks, only_valid) = crate::api::parse_params::<(u64, bool)>(params)?;
+        let (num_blocks, only_valid) = crate::api::Params::parse(params)?;
         actix::spawn(
             self.client_addr
                 .send(
@@ -1283,7 +1283,7 @@ impl JsonRpcHandler {
     }
 
     async fn adv_switch_to_height(&self, params: Value) -> Result<Value, RpcError> {
-        let (height,) = crate::api::parse_params::<(u64,)>(params)?;
+        let (height,) = crate::api::Params::parse(params)?;
         actix::spawn(
             self.client_addr
                 .send(

--- a/core/primitives-core/src/serialize.rs
+++ b/core/primitives-core/src/serialize.rs
@@ -34,16 +34,14 @@ pub mod base64_format {
     }
 }
 
+#[derive(PartialEq, Eq, Debug, serde::Deserialize, serde::Serialize)]
+#[serde(transparent)]
+pub struct Base64Bytes(#[serde(with = "base64_format")] pub Vec<u8>);
+
 #[test]
 fn test_base64_format() {
-    #[derive(PartialEq, Debug, serde::Deserialize, serde::Serialize)]
-    struct Test {
-        #[serde(with = "base64_format")]
-        field: Vec<u8>,
-    }
-
-    assert_round_trip("{\"field\":\"Zm9v\"}", Test { field: b"foo".to_vec() });
-    assert_de_error::<Test>("{\"field\":null}");
+    assert_round_trip("\"Zm9v\"", Base64Bytes(b"foo".to_vec()));
+    assert_de_error::<Base64Bytes>("null");
 }
 
 pub mod option_base64_format {


### PR DESCRIPTION
Some JSON RPC requests support a legacy parameters format where
instead of a structured object the `params` field is an array.
Currently this is handled by first trying to parse parameters value
into a tuple and only if that fails it’s then parsed as a request
type.  Unfortunately, this introduces a clone of the value.

With this commit, parameters parsing now checks whether value is an
array of appropriate length.  Depending if it is or not, the value
will be parsed accordingly.  It’s parsed only once and thus no clone
is necessary.
