### PR TITLE
PeersResponse: always include connected peers

### DIFF
--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -1117,10 +1117,9 @@ impl PeerActor {
                 tracing::debug!(target: "network", "Duplicate handshake from {}", self.peer_info);
             }
             PeerMessage::PeersRequest => {
-                let peers = self
-                    .network_state
-                    .peer_store
-                    .healthy_peers(self.network_state.config.max_send_peers as usize);
+                let peers = self.network_state.get_healthy_peers_preferring_connected(
+                    self.network_state.config.max_send_peers as usize,
+                );
                 if !peers.is_empty() {
                     tracing::debug!(target: "network", "Peers request from {}: sending {} peers.", self.peer_info, peers.len());
                     self.send_message_or_log(&PeerMessage::PeersResponse(peers));

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -29,6 +29,8 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
 use near_primitives::types::AccountId;
 use parking_lot::Mutex;
+use rand::seq::IteratorRandom;
+use rand::thread_rng;
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -716,6 +718,32 @@ impl NetworkState {
         let polled = pending_reconnect.clone();
         pending_reconnect.clear();
         return polled;
+    }
+
+    /// Returns healthy known peers up to given amount.
+    /// First collects directly known peers from the tier2 connection pool.
+    /// Adds remaining peers from the peer store.
+    pub fn get_healthy_peers_preferring_connected(
+        self: &Arc<Self>,
+        max_count: usize,
+    ) -> Vec<PeerInfo> {
+        // Collect the PeerInfos for active TIER2 connections
+        let mut peer_infos: Vec<PeerInfo> =
+            self.tier2.load().ready.values().map(|c| c.peer_info.clone()).collect();
+
+        // If there are enough already, return a randomly selected subset
+        if peer_infos.len() >= max_count {
+            return peer_infos.into_iter().choose_multiple(&mut thread_rng(), max_count);
+        }
+
+        // Add healthy peers chosen at random from the PeerStore
+        peer_infos.append(&mut self.peer_store.healthy_peers(
+            max_count - peer_infos.len(),
+            // Ask the PeerStore to exclude the peers already included from TIER2 connections
+            peer_infos.iter().map(|p| p.id.clone()).collect(),
+        ));
+
+        return peer_infos;
     }
 
     /// Sets the chain info, and updates the set of TIER1 keys.

--- a/chain/network/src/peer_manager/peer_store/mod.rs
+++ b/chain/network/src/peer_manager/peer_store/mod.rs
@@ -538,11 +538,19 @@ impl PeerStore {
         .cloned()
     }
 
-    /// Return healthy known peers up to given amount.
-    pub fn healthy_peers(&self, max_count: usize) -> Vec<PeerInfo> {
-        self.0
-            .lock()
-            .find_peers(|p| matches!(p.status, KnownPeerStatus::Banned(_, _)).not(), max_count)
+    /// Return healthy known peers up to given amount, excluding the specified PeerIds.
+    pub fn healthy_peers(
+        &self,
+        max_count: usize,
+        excluded_peer_ids: HashSet<PeerId>,
+    ) -> Vec<PeerInfo> {
+        self.0.lock().find_peers(
+            |p| {
+                matches!(p.status, KnownPeerStatus::Banned(_, _)).not()
+                    && !excluded_peer_ids.contains(&p.peer_info.id)
+            },
+            max_count,
+        )
     }
 
     /// Adds peers we’ve learned about from other peers.

--- a/chain/network/src/peer_manager/testonly.rs
+++ b/chain/network/src/peer_manager/testonly.rs
@@ -365,6 +365,19 @@ impl ActorHandler {
         self.with_state(move |s| async move { s.peer_store.update(&clock) }).await;
     }
 
+    pub async fn peer_store_add_indirect_peers(&self, clock: &time::Clock, peers: Vec<PeerInfo>) {
+        let clock = clock.clone();
+        self.with_state(move |s| async move {
+            s.peer_store.add_indirect_peers(&clock, peers.into_iter())
+        })
+        .await;
+    }
+
+    pub async fn get_healthy_peers_preferring_connected(&self, max_count: usize) -> Vec<PeerInfo> {
+        self.with_state(move |s| async move { s.get_healthy_peers_preferring_connected(max_count) })
+            .await
+    }
+
     pub async fn send_ping(&self, nonce: u64, target: PeerId) {
         self.actix
             .addr

--- a/chain/network/src/peer_manager/tests/tier2.rs
+++ b/chain/network/src/peer_manager/tests/tier2.rs
@@ -1,5 +1,6 @@
 use crate::broadcast;
 use crate::network_protocol::testonly as data;
+use crate::network_protocol::testonly::make_peer_info;
 use crate::peer_manager::connection_store::STORED_CONNECTIONS_MIN_DURATION;
 use crate::peer_manager::network_state::RECONNECT_ATTEMPT_INTERVAL;
 use crate::peer_manager::peer_manager_actor::Event as PME;
@@ -14,6 +15,7 @@ use crate::time;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::network::PeerId;
 use near_store::db::TestDB;
+use std::collections::HashSet;
 use std::sync::Arc;
 
 async fn check_recent_outbound_connections(pm: &ActorHandler, want: Vec<PeerId>) {
@@ -294,4 +296,50 @@ async fn test_reconnect_after_restart_outbound_side_multi() {
     pm0.wait_for_direct_connection(id2.clone()).await;
     pm0.wait_for_direct_connection(id3.clone()).await;
     pm0.wait_for_direct_connection(id4.clone()).await;
+}
+
+#[tokio::test]
+async fn test_get_healthy_peers_preferring_connected() {
+    init_test_logger();
+    let mut rng = make_rng(921853233);
+    let rng = &mut rng;
+    let mut clock = time::FakeClock::default();
+    let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
+
+    let pm0 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
+    let pm1 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
+    let pm2 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
+    let pm3 = start_pm(clock.clock(), TestDB::new(), chain.make_config(rng), chain.clone()).await;
+
+    let id1 = pm1.cfg.node_id();
+    let id2 = pm2.cfg.node_id();
+    let id3 = pm3.cfg.node_id();
+
+    tracing::info!(target:"test", "connect pm0 to other peer managers");
+    pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
+    pm0.connect_to(&pm2.peer_info(), tcp::Tier::T2).await;
+    pm0.connect_to(&pm3.peer_info(), tcp::Tier::T2).await;
+    pm0.wait_for_direct_connection(id1.clone()).await;
+    pm0.wait_for_direct_connection(id2.clone()).await;
+    pm0.wait_for_direct_connection(id3.clone()).await;
+
+    tracing::info!(target:"test", "add 100 more peers to pm0's peer store");
+    pm0.peer_store_add_indirect_peers(
+        &clock.clock(),
+        (0..100).map(|_| make_peer_info(rng)).collect(),
+    )
+    .await;
+
+    tracing::info!(target:"test", "request 5 healthy peers from pm0");
+    let selected = pm0
+        .get_healthy_peers_preferring_connected(5)
+        .await
+        .iter()
+        .map(|p| p.id.clone())
+        .collect::<HashSet<PeerId>>();
+
+    tracing::info!(target:"test", "check that all connected peers are included");
+    assert!(selected.contains(&id1));
+    assert!(selected.contains(&id2));
+    assert!(selected.contains(&id3));
 }


### PR DESCRIPTION
PeersRequest/PeersResponse are used to share information about peers in the network to which a node may connect.

Currently, PeersResponse contains a randomly selected subset of the responding node's PeerStore. However, the PeerStore includes unverified data reported by other nodes, potentially including fake information from malicious nodes.

This PR changes PeerResponse to always include the peers directly connected to the responding node. It ensures that some useful information is passed even when the responding node is under attack and flooded with fake peers.