### PR TITLE
feat: neard init can initialize only node and validator keys if both Config and Genesis exist

### DIFF
--- a/chain/indexer/src/lib.rs
+++ b/chain/indexer/src/lib.rs
@@ -157,7 +157,7 @@ pub fn indexer_init_configs(
 ) -> Result<(), anyhow::Error> {
     init_configs(
         dir,
-        params.chain_id.as_deref(),
+        params.chain_id,
         params.account_id.and_then(|account_id| account_id.parse().ok()),
         params.test_seed.as_deref(),
         params.num_shards,

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -325,7 +325,7 @@ impl InitCmd {
 
         nearcore::init_configs(
             home_dir,
-            self.chain_id.as_deref(),
+            self.chain_id,
             self.account_id.and_then(|account_id| account_id.parse().ok()),
             self.test_seed.as_deref(),
             self.num_shards,


### PR DESCRIPTION
cc: @anshal-savla @wacban 
```
% ./target/debug/neard --home /tmp/h init
2023-02-22T10:01:50.785498Z  INFO neard: version="trunk" build="1.1.0-3443-g179b3eee4-modified" latest_protocol=59
2023-02-22T10:01:50.786814Z  INFO config: Validating Config, extracted from config.json...
2023-02-22T10:02:05.791962Z  INFO near: Using key ed25519:7ZdLJmUGUBXGmwYuDXNaRsnZphvGLKQadseHKpohchx8 for test.near
2023-02-22T10:02:05.792411Z  INFO near: Using key ed25519:AEHuWUqhFQVi4Sef8GrDSjos55JHhbBjBFocyNzgLp1t for node

% ./target/debug/neard --home /tmp/h init
2023-02-22T10:02:19.591430Z  INFO neard: version="trunk" build="1.1.0-3443-g179b3eee4-modified" latest_protocol=59
2023-02-22T10:02:19.592395Z  INFO config: Validating Config, extracted from config.json...
2023-02-22T10:02:34.521485Z  INFO near: Reusing key ed25519:7ZdLJmUGUBXGmwYuDXNaRsnZphvGLKQadseHKpohchx8 for test.near
2023-02-22T10:02:34.521628Z  INFO near: Reusing key ed25519:AEHuWUqhFQVi4Sef8GrDSjos55JHhbBjBFocyNzgLp1t for node
```