### PR TITLE
feat(state-viewer): exit w nonzero code on bad apply result

### DIFF
--- a/tools/state-viewer/src/apply_chunk.rs
+++ b/tools/state-viewer/src/apply_chunk.rs
@@ -188,7 +188,7 @@ fn apply_tx_in_block(
                     println!("Found tx in block {} shard {}. equivalent command:\nview_state apply --height {} --shard-id {}\n",
                              &block_hash, shard_id, chain_store.get_block_header(&block_hash)?.height(), shard_id);
                     let (block, apply_result) = crate::commands::apply_block(block_hash, shard_id, runtime, chain_store);
-                    crate::commands::print_apply_block_result(&block, &apply_result, runtime, chain_store, shard_id);
+                    crate::commands::check_apply_block_result(&block, &apply_result, runtime, chain_store, shard_id)?;
                     Ok(apply_result)
                 },
                 HashType::Receipt => {
@@ -292,7 +292,7 @@ fn apply_receipt_in_block(
                     println!("Found receipt in block {}. Receiver is in shard {}. equivalent command:\nview_state apply --height {} --shard-id {}\n",
                              &block_hash, shard_id, chain_store.get_block_header(&block_hash)?.height(), shard_id);
                     let (block, apply_result) = crate::commands::apply_block(block_hash, shard_id, runtime, chain_store);
-                    crate::commands::print_apply_block_result(&block, &apply_result, runtime, chain_store, shard_id);
+                    crate::commands::check_apply_block_result(&block, &apply_result, runtime, chain_store, shard_id)?;
                     Ok(apply_result)
                 },
             }

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -148,7 +148,7 @@ pub struct ApplyCmd {
 
 impl ApplyCmd {
     pub fn run(self, home_dir: &Path, near_config: NearConfig, store: Store) {
-        apply_block_at_height(self.height, self.shard_id, home_dir, near_config, store);
+        apply_block_at_height(self.height, self.shard_id, home_dir, near_config, store).unwrap();
     }
 }
 


### PR DESCRIPTION
right now the apply command only prints out the old and new chunk extra that results. We'd like to automatically detect when the results don't match, so change it to compare the two chunk extras and return with an error when they don't match.