### PR TITLE
[TestLoop] (5/n) Add futures support to TestLoop.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3090,6 +3090,7 @@ dependencies = [
  "derive_more",
  "futures",
  "near-o11y",
+ "near-performance-metrics",
  "once_cell",
  "serde",
  "serde_json",

--- a/core/async/Cargo.toml
+++ b/core/async/Cargo.toml
@@ -18,4 +18,5 @@ once_cell.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 
-near-o11y = { path = "../o11y" }      
+near-o11y = { path = "../o11y" }
+near-performance-metrics = { path = "../../utils/near-performance-metrics" }       

--- a/core/async/src/examples/async_component.rs
+++ b/core/async/src/examples/async_component.rs
@@ -1,0 +1,58 @@
+use crate::{
+    futures::FutureSpawner,
+    messaging::{AsyncSender, Sender},
+};
+
+// For this test, we have an InnerComponent which handles an InnerRequest and
+// responds with InnerResponse, and an OuterComponent which handles an
+// OuterRequest, spawns a future to send a request to the InnerComponent, and
+// then responds back with an OuterResponse (but not as an Actix response; just
+// another message). This mimics how we use Actix in nearcore.
+
+#[derive(Debug)]
+pub(crate) struct InnerRequest(pub String);
+
+#[derive(Debug)]
+pub(crate) struct InnerResponse(pub String);
+
+#[derive(Debug)]
+pub(crate) struct OuterRequest(pub String);
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct OuterResponse(pub String);
+
+pub(crate) struct InnerComponent;
+
+impl InnerComponent {
+    pub fn process_request(&mut self, request: InnerRequest) -> InnerResponse {
+        InnerResponse(request.0 + "!")
+    }
+}
+
+pub(crate) struct OuterComponent {
+    inner_sender: AsyncSender<InnerRequest, InnerResponse>,
+    outer_response_sender: Sender<OuterResponse>,
+}
+
+impl OuterComponent {
+    pub fn new(
+        inner_sender: AsyncSender<InnerRequest, InnerResponse>,
+        outer_response_sender: Sender<OuterResponse>,
+    ) -> Self {
+        Self { inner_sender, outer_response_sender }
+    }
+
+    pub fn process_request(&mut self, request: OuterRequest, future_spawner: &dyn FutureSpawner) {
+        let inner_request = InnerRequest(request.0.clone());
+        let sender = self.inner_sender.clone();
+        let response_sender = self.outer_response_sender.clone();
+
+        // We're mimicing how we use Actix, and in an Actix handler context we don't have access
+        // to async/await. So we use a FutureSpawner to do that.
+        future_spawner.spawn("inner request", async move {
+            let inner_response = sender.send_async(inner_request).await;
+            let response = OuterResponse(inner_response.0.repeat(2));
+            response_sender.send(response);
+        });
+    }
+}

--- a/core/async/src/examples/async_component_test.rs
+++ b/core/async/src/examples/async_component_test.rs
@@ -1,0 +1,88 @@
+use std::{sync::Arc, time::Duration};
+
+use derive_enum_from_into::{EnumFrom, EnumTryInto};
+
+use crate::{
+    messaging::{CanSend, IntoAsyncSender, IntoSender},
+    test_loop::{
+        delay_sender::DelaySender,
+        event_handler::{capture_events, LoopEventHandler},
+        futures::{DriveFutures, MessageExpectingResponse, TestLoopTask},
+        TestLoopBuilder,
+    },
+};
+
+use super::async_component::{
+    InnerComponent, InnerRequest, InnerResponse, OuterComponent, OuterRequest, OuterResponse,
+};
+
+#[derive(derive_more::AsMut, derive_more::AsRef)]
+struct TestData {
+    dummy: (),                  // needed for any handlers that don't require data
+    output: Vec<OuterResponse>, // needed for capture_events handler
+    inner_component: InnerComponent,
+    outer_component: OuterComponent,
+}
+
+#[derive(Debug, EnumTryInto, EnumFrom)]
+enum TestEvent {
+    OuterResponse(OuterResponse),
+    OuterRequest(OuterRequest),
+    // Requests that need responses need to use MessageExpectingResponse.
+    InnerRequest(MessageExpectingResponse<InnerRequest, InnerResponse>),
+    // Arc<TestLoopTask> is needed to support futures.
+    Task(Arc<TestLoopTask>),
+}
+
+struct OuterRequestHandler {
+    future_spawner: DelaySender<Arc<TestLoopTask>>,
+}
+
+impl LoopEventHandler<OuterComponent, OuterRequest> for OuterRequestHandler {
+    fn handle(
+        &mut self,
+        event: OuterRequest,
+        data: &mut OuterComponent,
+    ) -> Result<(), OuterRequest> {
+        data.process_request(event, &self.future_spawner);
+        Ok(())
+    }
+}
+
+struct InnerRequestHandler;
+
+impl LoopEventHandler<InnerComponent, MessageExpectingResponse<InnerRequest, InnerResponse>>
+    for InnerRequestHandler
+{
+    fn handle(
+        &mut self,
+        event: MessageExpectingResponse<InnerRequest, InnerResponse>,
+        data: &mut InnerComponent,
+    ) -> Result<(), MessageExpectingResponse<InnerRequest, InnerResponse>> {
+        (event.responder)(data.process_request(event.message));
+        Ok(())
+    }
+}
+
+#[test]
+fn test_async_component() {
+    let builder = TestLoopBuilder::<TestEvent>::new();
+    let sender = builder.sender();
+    let mut test = builder.build(TestData {
+        dummy: (),
+        output: vec![],
+        inner_component: InnerComponent,
+        outer_component: OuterComponent::new(
+            sender.clone().into_async_sender(),
+            sender.clone().into_sender(),
+        ),
+    });
+    test.register_handler(DriveFutures.widen());
+    test.register_handler(capture_events::<OuterResponse>().widen());
+    test.register_handler(OuterRequestHandler { future_spawner: sender.clone().narrow() }.widen());
+    test.register_handler(InnerRequestHandler.widen());
+
+    sender.send(OuterRequest("hello".to_string()));
+    test.run(Duration::from_secs(1));
+    assert_eq!(test.data.output, vec![OuterResponse("hello!hello!".to_string())]);
+}

--- a/core/async/src/examples/mod.rs
+++ b/core/async/src/examples/mod.rs
@@ -1,3 +1,5 @@
+mod async_component;
+mod async_component_test;
 mod multi_instance_test;
 mod sum_numbers;
 mod sum_numbers_test;

--- a/core/async/src/futures.rs
+++ b/core/async/src/futures.rs
@@ -1,0 +1,33 @@
+use futures::{future::BoxFuture, FutureExt};
+
+/// Abstraction for something that can drive futures.
+///
+/// Rust futures don't run by itself. It needs a driver to execute it. This can
+/// for example be a thread, a thread pool, or Actix. This trait abstracts over
+/// the execution mechanism.
+///
+/// The reason why we need an abstraction is (1) we can intercept the future
+/// spawning to add additional instrumentation (2) we can support driving the
+/// future with TestLoop for testing.
+pub trait FutureSpawner {
+    fn spawn_boxed(&self, description: &'static str, f: BoxFuture<'static, ()>);
+}
+
+impl<'a> dyn FutureSpawner + 'a {
+    /// Spawns a future by automatically boxing it.
+    pub fn spawn<F>(&self, description: &'static str, f: F)
+    where
+        F: futures::Future<Output = ()> + Send + 'static,
+    {
+        self.spawn_boxed(description, f.boxed())
+    }
+}
+
+/// A FutureSpawner that hands over the future to Actix.
+pub struct ActixFutureSpawner;
+
+impl FutureSpawner for ActixFutureSpawner {
+    fn spawn_boxed(&self, description: &'static str, f: BoxFuture<'static, ()>) {
+        near_performance_metrics::actix::spawn(description, f);
+    }
+}

--- a/core/async/src/lib.rs
+++ b/core/async/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod actix;
 #[cfg(test)]
 mod examples;
+pub mod futures;
 pub mod messaging;
 pub mod test_loop;

--- a/core/async/src/test_loop.rs
+++ b/core/async/src/test_loop.rs
@@ -61,6 +61,7 @@
 //! then the actual order of execution is B, D, A, E, C.
 pub mod delay_sender;
 pub mod event_handler;
+pub mod futures;
 pub mod multi_instance;
 
 use std::{collections::BinaryHeap, fmt::Debug, sync, time::Duration};

--- a/core/async/src/test_loop/futures.rs
+++ b/core/async/src/test_loop/futures.rs
@@ -1,0 +1,146 @@
+use std::{
+    fmt::Debug,
+    future::Future,
+    sync::{Arc, Mutex},
+    task::Context,
+    time::Duration,
+};
+
+use futures::{
+    channel::oneshot,
+    future::BoxFuture,
+    task::{waker_ref, ArcWake},
+    FutureExt,
+};
+
+use crate::{
+    futures::FutureSpawner,
+    messaging::{self, CanSend},
+};
+
+use super::{delay_sender::DelaySender, event_handler::LoopEventHandler};
+
+// Support for futures in TestLoop.
+//
+// There are two key features this file provides for TestLoop:
+//
+//   1. A general way to spawn futures and have the TestLoop drive the futures.
+//      To support this, add () to the Data, add Arc<TestLoopTask> as an Event,
+//      and add DriveFutures as a handler. Finally, pass
+//      DelaySender<Arc<TestLoopTask>> as the &dyn FutureSpawner to any
+//      component that needs to spawn futures.
+//
+//      This causes any futures spawned during the test to end up as an event
+//      (an Arc<TestLoopTask>) in the test loop. The event will eventually be
+//      executed by the DriveFutures handler, which will drive the future
+//      until it is either suspended or completed. If suspended, then the waker
+//      of the future (called when the future is ready to resume) will place
+//      the Arc<TestLoopTask> event back into the test loop to be executed
+//      again.
+//
+//   2. A way to send a message to the TestLoop and expect a response as a
+//      future, which will resolve whenever the TestLoop handles the message.
+//      To support this, use MessageExpectingResponse<Request, Response> as the
+//      event type, and in the handler, call (event.responder)(result)
+//      (possibly asynchronously) to complete the future.
+//
+//      This is needed to support the AsyncSender interface, which is required
+//      by some components as they expect a response to each message. The way
+//      this is implemented is by implementing a conversion from
+//      DelaySender<MessageExpectingResponse<Request, Response>> to
+//      AsyncSender<Request, Response>.
+
+/// A message, plus a response callback. This should be used as the event type
+/// when testing an Actix component that's expected to return a result.
+///
+/// The response is used to complete the future that is returned by
+/// our `AsyncSender::send_async` implementation.
+pub struct MessageExpectingResponse<T, R> {
+    pub message: T,
+    pub responder: Box<dyn FnOnce(R) + Send>,
+}
+
+impl<T: Debug, R> Debug for MessageExpectingResponse<T, R> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("MessageWithResponder").field(&self.message).finish()
+    }
+}
+
+/// Function to create a pair of Future and MessageExpectingResponse, so that
+/// the future is resolved when the responder is called.
+fn create_future_for_message_response<T, R: Send + 'static>(
+    message: T,
+) -> (impl Future<Output = R>, MessageExpectingResponse<T, R>) {
+    let (sender, receiver) = oneshot::channel::<R>();
+    let future = async move { receiver.await.expect("Future was cancelled") };
+    let responder = Box::new(move |r| sender.send(r).ok().unwrap());
+    (future, MessageExpectingResponse { message, responder })
+}
+
+impl<
+        Message: 'static,
+        Response: Send + 'static,
+        Event: From<MessageExpectingResponse<Message, Response>> + 'static,
+    > messaging::CanSendAsync<Message, Response> for DelaySender<Event>
+{
+    fn send_async(&self, message: Message) -> BoxFuture<'static, Response> {
+        let (future, responder) = create_future_for_message_response(message);
+        self.send_with_delay(responder.into(), Duration::ZERO);
+        future.boxed()
+    }
+}
+
+pub struct TestLoopTask {
+    future: Mutex<Option<BoxFuture<'static, ()>>>,
+    sender: DelaySender<Arc<TestLoopTask>>,
+    description: String,
+}
+
+impl ArcWake for TestLoopTask {
+    fn wake_by_ref(arc_self: &Arc<Self>) {
+        let clone = arc_self.clone();
+        arc_self.sender.send(clone);
+    }
+}
+
+impl Debug for TestLoopTask {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Task").field(&self.description).finish()
+    }
+}
+
+/// Drives any Arc<TestLoopTask> events (futures spawned by our implementation
+/// of FutureSpawner) that are remaining in the loop.
+pub struct DriveFutures;
+
+impl LoopEventHandler<(), Arc<TestLoopTask>> for DriveFutures {
+    fn handle(&mut self, task: Arc<TestLoopTask>, _: &mut ()) -> Result<(), Arc<TestLoopTask>> {
+        // The following is copied from the Rust async book.
+        // Take the future, and if it has not yet completed (is still Some),
+        // poll it in an attempt to complete it.
+        let mut future_slot = task.future.lock().unwrap();
+        if let Some(mut future) = future_slot.take() {
+            let waker = waker_ref(&task);
+            let context = &mut Context::from_waker(&*waker);
+            if future.as_mut().poll(context).is_pending() {
+                // We're still not done processing the future, so put it
+                // back in its task to be run again in the future.
+                *future_slot = Some(future);
+            }
+        }
+        Ok(())
+    }
+}
+
+/// A DelaySender<Arc<TestLoopTask>> is a FutureSpawner that can be used to
+/// spawn futures into the test loop.
+impl FutureSpawner for DelaySender<Arc<TestLoopTask>> {
+    fn spawn_boxed(&self, description: &str, f: BoxFuture<'static, ()>) {
+        let task = Arc::new(TestLoopTask {
+            future: Mutex::new(Some(f)),
+            sender: self.clone(),
+            description: description.to_string(),
+        });
+        self.send(task);
+    }
+}


### PR DESCRIPTION
See the comment on top of test_loop/futures.rs for what this does.

We need this because we have code like https://github.com/near/nearcore/blob/1.32.0/chain/client/src/sync/state.rs#L607 that spawns a future from an Actix handler, in order to send a message to another Actor and awaiting on the response.

So for testing, this code would be refactored so that instead of `near_performance_metrics::actix::spawn`, we would use `future_spawner.spawn`, where the `future_spawner: &dyn FutureSpawner` is passed in. It's passed in either as `ActixFutureSpawner` (from the ClientActor), or as a `DelaySender<Arc<TestLoopTask>>` from a test loop handler.

Inside, when it says `.send_async(...).then(...)`, the TestLoop will provide that send_async implementation with a `DelaySender<MessageExpectingResponse<PeerManagerMessageRequest, PeerManagerMessageResponse>>`.

Both of these will go into the test loop, where the `DriveFutures` handler will drive the future that was spawned, and the handler for `MessageExpectingResponse<PeerManagerMessageRequest, PeerManagerMessageResponse>` will execute the network adapter part of the logic. In other words, with this PR we can now, in theory, directly support the testing of all actix-based code in nearcore, as long as they use Sender and AsyncSender (whose migration was already partially done).