### PR TITLE
refactor: Util function to derive an implicit PK

### DIFF
--- a/core/crypto/src/errors.rs
+++ b/core/crypto/src/errors.rs
@@ -1,3 +1,5 @@
+use near_account_id::AccountId;
+
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum ParseKeyTypeError {
     #[error("unknown key type '{unknown_key_type}'")]
@@ -42,4 +44,10 @@ impl From<ParseKeyTypeError> for ParseSignatureError {
             }
         }
     }
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum ImplicitPublicKeyError {
+    #[error("'{account_id}' is not an implicit account")]
+    AccountIsNotImplicit { account_id: AccountId },
 }

--- a/core/crypto/src/test_utils.rs
+++ b/core/crypto/src/test_utils.rs
@@ -34,19 +34,6 @@ impl PublicKey {
             _ => unimplemented!(),
         }
     }
-
-    pub fn from_implicit_account(account_id: &AccountId) -> Self {
-        assert!(account_id.is_implicit());
-        let mut public_key_data = Vec::with_capacity(33);
-        public_key_data.push(KeyType::ED25519 as u8);
-        public_key_data.extend(
-            hex::decode(account_id.as_ref().as_bytes())
-                .expect("account id was a valid hex of length 64 resulting in 32 bytes"),
-        );
-        assert_eq!(public_key_data.len(), 33);
-        PublicKey::try_from_slice(&public_key_data)
-            .expect("we should be able to deserialize ED25519 public key")
-    }
 }
 
 impl SecretKey {

--- a/core/crypto/src/test_utils.rs
+++ b/core/crypto/src/test_utils.rs
@@ -1,4 +1,3 @@
-use borsh::BorshDeserialize;
 use secp256k1::rand::SeedableRng;
 
 use crate::signature::{ED25519PublicKey, ED25519SecretKey, KeyType, PublicKey, SecretKey};

--- a/core/crypto/src/util.rs
+++ b/core/crypto/src/util.rs
@@ -1,3 +1,5 @@
+use crate::{KeyType, PublicKey};
+use borsh::BorshDeserialize;
 use curve25519_dalek::ristretto::CompressedRistretto;
 use curve25519_dalek::traits::VartimeMultiscalarMul;
 
@@ -89,6 +91,25 @@ impl<
         *d2 = self.1.pack();
         *d3 = self.2.pack();
         res
+    }
+}
+
+impl PublicKey {
+    /// Create the implicit public key from an implicit account ID.
+    ///
+    /// Panics if the given account id is not a valid implicit account ID.
+    /// See [`near_account_id::AccountId#is_implicit`] for the definition.
+    pub fn from_implicit_account(account_id: &near_account_id::AccountId) -> Self {
+        debug_assert!(account_id.is_implicit());
+        let mut public_key_data = Vec::with_capacity(33);
+        public_key_data.push(KeyType::ED25519 as u8);
+        public_key_data.extend(
+            hex::decode(account_id.as_ref().as_bytes())
+                .expect("account id was a valid hex of length 64 resulting in 32 bytes"),
+        );
+        debug_assert_eq!(public_key_data.len(), 33);
+        PublicKey::try_from_slice(&public_key_data)
+            .expect("we should be able to deserialize ED25519 public key")
     }
 }
 

--- a/core/crypto/src/util.rs
+++ b/core/crypto/src/util.rs
@@ -1,3 +1,4 @@
+use crate::errors::ImplicitPublicKeyError;
 use crate::{KeyType, PublicKey};
 use borsh::BorshDeserialize;
 use curve25519_dalek::ristretto::CompressedRistretto;
@@ -97,10 +98,17 @@ impl<
 impl PublicKey {
     /// Create the implicit public key from an implicit account ID.
     ///
-    /// Panics if the given account id is not a valid implicit account ID.
+    /// Returns `ImplicitPublicKeyError::AccountIsNotImplicit` if the given
+    /// account id is not a valid implicit account ID.
     /// See [`near_account_id::AccountId#is_implicit`] for the definition.
-    pub fn from_implicit_account(account_id: &near_account_id::AccountId) -> Self {
-        debug_assert!(account_id.is_implicit());
+    pub fn from_implicit_account(
+        account_id: &near_account_id::AccountId,
+    ) -> Result<Self, ImplicitPublicKeyError> {
+        if !account_id.is_implicit() {
+            return Err(ImplicitPublicKeyError::AccountIsNotImplicit {
+                account_id: account_id.clone(),
+            });
+        }
         let mut public_key_data = Vec::with_capacity(33);
         public_key_data.push(KeyType::ED25519 as u8);
         public_key_data.extend(
@@ -108,8 +116,9 @@ impl PublicKey {
                 .expect("account id was a valid hex of length 64 resulting in 32 bytes"),
         );
         debug_assert_eq!(public_key_data.len(), 33);
-        PublicKey::try_from_slice(&public_key_data)
-            .expect("we should be able to deserialize ED25519 public key")
+        let public_key = PublicKey::try_from_slice(&public_key_data)
+            .expect("we should be able to deserialize ED25519 public key");
+        Ok(public_key)
     }
 }
 

--- a/integration-tests/src/tests/client/features/delegate_action.rs
+++ b/integration-tests/src/tests/client/features/delegate_action.rs
@@ -133,7 +133,7 @@ fn check_meta_tx_execution(
         .unwrap()
         .nonce;
     let user_pubk = if sender.is_implicit() {
-        PublicKey::from_implicit_account(&sender)
+        PublicKey::from_implicit_account(&sender).unwrap()
     } else {
         PublicKey::from_seed(KeyType::ED25519, &sender)
     };

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -4,7 +4,7 @@ use crate::config::{
 };
 use crate::ext::{ExternalError, RuntimeExt};
 use crate::{metrics, ActionResult, ApplyState};
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::BorshSerialize;
 use near_crypto::PublicKey;
 use near_primitives::account::{AccessKey, AccessKeyPermission, Account};
 use near_primitives::checked_feature;
@@ -444,16 +444,7 @@ pub(crate) fn action_implicit_account_creation_transfer(
             * near_primitives::account::AccessKey::ACCESS_KEY_NONCE_RANGE_MULTIPLIER;
     }
 
-    // 0 for ED25519
-    let mut public_key_data = Vec::with_capacity(33);
-    public_key_data.push(0u8);
-    public_key_data.extend(
-        hex::decode(account_id.as_ref().as_bytes())
-            .expect("account id was a valid hex of length 64 resulting in 32 bytes"),
-    );
-    debug_assert_eq!(public_key_data.len(), 33);
-    let public_key = PublicKey::try_from_slice(&public_key_data)
-        .expect("we should be able to deserialize ED25519 public key");
+    let public_key = PublicKey::from_implicit_account(account_id);
 
     *account = Some(Account::new(
         transfer.deposit,

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -441,8 +441,8 @@ pub(crate) fn action_implicit_account_creation_transfer(
             * near_primitives::account::AccessKey::ACCESS_KEY_NONCE_RANGE_MULTIPLIER;
     }
 
-    // NOTE: The account_id is hex like, because we've checked the permissions before.
-    debug_assert!(account_id.is_implicit());
+    // Invariant: The account_id is hex like (implicit account id).
+    // It holds because in the only calling site, we've checked the permissions before.
     // unwrap: Can only fail if `account_id` is not implicit.
     let public_key = PublicKey::from_implicit_account(account_id).unwrap();
 

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -431,9 +431,6 @@ pub(crate) fn action_implicit_account_creation_transfer(
     block_height: BlockHeight,
     current_protocol_version: ProtocolVersion,
 ) {
-    // NOTE: The account_id is hex like, because we've checked the permissions before.
-    debug_assert!(account_id.is_implicit());
-
     *actor_id = account_id.clone();
 
     let mut access_key = AccessKey::full_access();
@@ -444,7 +441,10 @@ pub(crate) fn action_implicit_account_creation_transfer(
             * near_primitives::account::AccessKey::ACCESS_KEY_NONCE_RANGE_MULTIPLIER;
     }
 
-    let public_key = PublicKey::from_implicit_account(account_id);
+    // NOTE: The account_id is hex like, because we've checked the permissions before.
+    debug_assert!(account_id.is_implicit());
+    // unwrap: Can only fail if `account_id` is not implicit.
+    let public_key = PublicKey::from_implicit_account(account_id).unwrap();
 
     *account = Some(Account::new(
         transfer.deposit,

--- a/tools/mirror/src/key_mapping.rs
+++ b/tools/mirror/src/key_mapping.rs
@@ -1,4 +1,3 @@
-use borsh::BorshDeserialize;
 use hkdf::Hkdf;
 use near_crypto::{ED25519PublicKey, ED25519SecretKey, PublicKey, Secp256K1PublicKey, SecretKey};
 use near_primitives::types::AccountId;
@@ -94,17 +93,6 @@ pub(crate) fn map_key(
     }
 }
 
-// returns the public key encoded in this implicit account. panics if it's not
-// actually an implicit account
-// basically copy pasted from runtime/runtime/src/actions.rs
-pub(crate) fn implicit_account_key(account_id: &AccountId) -> PublicKey {
-    let mut public_key_data = Vec::with_capacity(33);
-    public_key_data.push(0u8);
-    public_key_data.extend(hex::decode(account_id.as_ref().as_bytes()).unwrap());
-    assert_eq!(public_key_data.len(), 33);
-    PublicKey::try_from_slice(&public_key_data).unwrap()
-}
-
 // If it's an implicit account, interprets it as an ed25519 public key, maps that and then returns
 // the resulting implicit account. Otherwise does nothing. We do this so that transactions creating
 // an implicit account by sending money will generate an account that we can control
@@ -113,7 +101,7 @@ pub(crate) fn map_account(
     secret: Option<&[u8; crate::secret::SECRET_LEN]>,
 ) -> AccountId {
     if account_id.is_implicit() {
-        let public_key = implicit_account_key(account_id);
+        let public_key = PublicKey::from_implicit_account(account_id);
         let mapped_key = map_key(&public_key, secret);
         hex::encode(mapped_key.public_key().key_data()).parse().unwrap()
     } else {

--- a/tools/mirror/src/key_mapping.rs
+++ b/tools/mirror/src/key_mapping.rs
@@ -101,7 +101,7 @@ pub(crate) fn map_account(
     secret: Option<&[u8; crate::secret::SECRET_LEN]>,
 ) -> AccountId {
     if account_id.is_implicit() {
-        let public_key = PublicKey::from_implicit_account(account_id);
+        let public_key = PublicKey::from_implicit_account(account_id).expect("must be implicit");
         let mapped_key = map_key(&public_key, secret);
         hex::encode(mapped_key.public_key().key_data()).parse().unwrap()
     } else {

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -994,8 +994,7 @@ impl<T: ChainAccess> TxMirror<T> {
                                 )
                             })?
                         {
-                            let public_key =
-                                crate::key_mapping::implicit_account_key(&target_account);
+                            let public_key = PublicKey::from_implicit_account(&target_account);
                             nonce_updates.insert((target_account, public_key));
                         }
                     }

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -994,7 +994,8 @@ impl<T: ChainAccess> TxMirror<T> {
                                 )
                             })?
                         {
-                            let public_key = PublicKey::from_implicit_account(&target_account);
+                            let public_key = PublicKey::from_implicit_account(&target_account)
+                                .expect("must be implicit");
                             nonce_updates.insert((target_account, public_key));
                         }
                     }


### PR DESCRIPTION
`PublicKey::from_implicit_account` derives the implicit PK for
 an account ID, both for tests/tooling as well as for production code.

 Closes #8588