### PR TITLE
reimplemented peer::stream in Scope framework.

### DIFF
--- a/chain/network/src/concurrency/ctx/mod.rs
+++ b/chain/network/src/concurrency/ctx/mod.rs
@@ -54,7 +54,7 @@ impl Drop for Inner {
 }
 
 /// See `Ctx::wait`.
-#[derive(thiserror::Error, Debug, Clone, Copy)]
+#[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq)]
 #[error("task has been canceled")]
 pub struct ErrCanceled;
 

--- a/chain/network/src/concurrency/ctx/mod.rs
+++ b/chain/network/src/concurrency/ctx/mod.rs
@@ -54,7 +54,7 @@ impl Drop for Inner {
 }
 
 /// See `Ctx::wait`.
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, Clone, Copy)]
 #[error("task has been canceled")]
 pub struct ErrCanceled;
 

--- a/chain/network/src/concurrency/ctx/tests.rs
+++ b/chain/network/src/concurrency/ctx/tests.rs
@@ -34,11 +34,14 @@ async fn test_run_with_timeout() {
     let clock = time::FakeClock::default();
     let res = ctx::run_test(clock.clock(), async {
         scope::run!(|s| async {
+            tracing::info!(target:"test", "scope starting");
             s.spawn(ctx::run_with_timeout(1000 * sec, async {
                 ctx::canceled().await;
+                tracing::info!(target:"test", "subtask terminating");
                 R::Err(9)
             }));
             clock.advance(1001 * sec);
+            tracing::info!(target:"test", "root task terminating");
             Ok(())
         })
     })

--- a/chain/network/src/concurrency/scope/mod.rs
+++ b/chain/network/src/concurrency/scope/mod.rs
@@ -261,8 +261,7 @@ impl<E: 'static + Send> Service<E> {
         self.spawn(async {
             run!(|s| async {
                 send.send(s.1.clone()).ok().unwrap();
-                let res = Ok(ctx::canceled().await);
-                res
+                Ok(ctx::canceled().await)
             }).map_err(conv)
         })?;
         Ok(Service(recv.await.unwrap()))

--- a/chain/network/src/concurrency/scope/mod.rs
+++ b/chain/network/src/concurrency/scope/mod.rs
@@ -150,9 +150,10 @@ impl<E: 'static + Send> TerminateGuard<E> {
     }
 
     /// Spawns a new service in the scope.
-    pub fn new_service<S:ServiceTrait>(self: Arc<Self>, s:S) -> Service<S> {
+    pub fn new_service<S: ServiceTrait>(self: Arc<Self>, s: S) -> Service<S> {
         let sub = Arc::new(TerminateGuard::new(&self.0.ctx));
-        let service = Service(Arc::new(s), Arc::downgrade(&sub), sub.0.clone());
+        let service = ServiceScope(Arc::new(s), sub.clone());
+        S::start(&service);
         // Spawn a guard task in `self` scope, so that it is not terminated
         // before `sub` scope is.
         TerminateGuard::spawn(self, async move {
@@ -164,7 +165,7 @@ impl<E: 'static + Send> TerminateGuard<E> {
             sub_inner.terminated.recv().await;
             Ok(())
         });
-        service
+        Service(service.0, Arc::downgrade(&service.1), service.1 .0.clone())
     }
 }
 
@@ -176,8 +177,9 @@ impl<E: 'static + Send> TerminateGuard<E> {
 #[error("service has been terminated")]
 pub struct ErrTerminated;
 
-pub trait ServiceTrait {
-    type E : 'static + Send + Clone;
+pub trait ServiceTrait: Sized {
+    type E: 'static + Send + Clone;
+    fn start(this: &ServiceScope<Self>);
 }
 
 /// A service is a subscope which doesn't keep the scope
@@ -191,41 +193,47 @@ pub trait ServiceTrait {
 /// Service is NOT cancelled just when all tasks within the service complete - in particular
 /// a newly started service has no tasks.
 /// Service is terminated when it is cancelled AND all tasks within the service complete.
-pub struct Service<S:ServiceTrait>(Arc<S>,Weak<TerminateGuard<S::E>>, Arc<Inner<S::E>>);
+pub struct Service<S: ServiceTrait>(Arc<S>, Weak<TerminateGuard<S::E>>, Arc<Inner<S::E>>);
 
-impl<S:ServiceTrait> Clone for Service<S> {
-    fn clone(&self) -> Self { Self(self.0.clone(),self.1.clone(),self.2.clone()) }
+impl<S: ServiceTrait> Clone for Service<S> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), self.1.clone(), self.2.clone())
+    }
 }
 
-impl<S:ServiceTrait> std::ops::Deref for Service<S> {
+impl<S: ServiceTrait> std::ops::Deref for Service<S> {
     type Target = S;
-    fn deref(&self) -> &Self::Target { self.0.as_ref() }
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
 }
 
-pub struct ServiceScope<S:ServiceTrait>(Arc<S>,Arc<TerminateGuard<S::E>>);
+pub struct ServiceScope<S: ServiceTrait>(Arc<S>, Arc<TerminateGuard<S::E>>);
 
-impl<S:ServiceTrait> std::ops::Deref for ServiceScope<S> {
+impl<S: ServiceTrait> std::ops::Deref for ServiceScope<S> {
     type Target = S;
-    fn deref(&self) -> &Self::Target { self.0.as_ref() }
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
 }
 
 #[doc(hidden)]
 pub mod service_internal {
     use super::*;
 
-    pub fn try_spawn<S:ServiceTrait, T:'static + Send>(
-        s:&Service<S>,
-        f: impl FnOnce(ServiceScope<S>) -> BoxFuture<'static,Result<T,S::E>>,
-    ) -> Result<JoinHandle<'static,T,S::E>,ErrTerminated> {
-        s.1.upgrade().map(|g|spawn(&ServiceScope(s.0.clone(),g),f)).ok_or(ErrTerminated)
+    pub fn try_spawn<S: ServiceTrait, T: 'static + Send>(
+        s: &Service<S>,
+        f: impl FnOnce(ServiceScope<S>) -> BoxFuture<'static, Result<T, S::E>>,
+    ) -> Result<JoinHandle<'static, T, S::E>, ErrTerminated> {
+        s.1.upgrade().map(|g| spawn(&ServiceScope(s.0.clone(), g), f)).ok_or(ErrTerminated)
     }
 
-    pub fn spawn<S:ServiceTrait, T:'static + Send>(
+    pub fn spawn<S: ServiceTrait, T: 'static + Send>(
         s: &ServiceScope<S>,
-        f:impl FnOnce(ServiceScope<S>) -> BoxFuture<'static,Result<T,S::E>>
-    ) -> JoinHandle<'static,T,S::E> {
+        f: impl FnOnce(ServiceScope<S>) -> BoxFuture<'static, Result<T, S::E>>,
+    ) -> JoinHandle<'static, T, S::E> {
         JoinHandle(
-            TerminateGuard::spawn(s.1.clone(), f(ServiceScope(s.0.clone(),s.1.clone()))),
+            TerminateGuard::spawn(s.1.clone(), f(ServiceScope(s.0.clone(), s.1.clone()))),
             std::marker::PhantomData,
         )
     }
@@ -234,16 +242,30 @@ pub mod service_internal {
 #[macro_export]
 macro_rules! try_spawn {
     ($x:expr, $f:expr) => {{
-        fn apply<A,R>(a:A, f:impl FnOnce(A) -> R) -> R { f(a) }
-        $crate::concurrency::scope::service_internal::try_spawn($x, |x| Box::pin(async { let x = x; apply(&x, $f).await }))
+        fn apply<A, R>(a: A, f: impl FnOnce(A) -> R) -> R {
+            f(a)
+        }
+        $crate::concurrency::scope::service_internal::try_spawn($x, |x| {
+            Box::pin(async {
+                let x = x;
+                apply(&x, $f).await
+            })
+        })
     }};
 }
 
 #[macro_export]
 macro_rules! spawn {
     ($x:expr, $f:expr) => {{
-        fn apply<A,R>(a:A, f:impl FnOnce(A) -> R) -> R { f(a) }
-        $crate::concurrency::scope::service_internal::spawn($x, |x| Box::pin(async { let x = x; apply(&x, $f).await }))
+        fn apply<A, R>(a: A, f: impl FnOnce(A) -> R) -> R {
+            f(a)
+        }
+        $crate::concurrency::scope::service_internal::spawn($x, |x| {
+            Box::pin(async {
+                let x = x;
+                apply(&x, $f).await
+            })
+        })
     }};
 }
 
@@ -257,7 +279,9 @@ impl<S: ServiceTrait> Service<S> {
     }
 
     /// Cancels the service, then awaits its termination.
-    pub fn terminate(&self) { self.2.ctx.cancel(); }
+    pub fn terminate(&self) {
+        self.2.ctx.cancel();
+    }
 
     /// Awaits termination of the service and returns the service error (if any).
     pub async fn terminated(&self) -> ctx::OrCanceled<Result<(), S::E>> {
@@ -276,7 +300,7 @@ impl<S: ServiceTrait> ServiceScope<S> {
     /// Spawns a subservice.
     ///
     /// Returns ErrTerminated if the service has already terminated.
-    pub fn new_service<S2:ServiceTrait>(&self, s2:S2) -> Service<S2> {
+    pub fn new_service<S2: ServiceTrait>(&self, s2: S2) -> Service<S2> {
         self.1.clone().new_service(s2)
     }
 }
@@ -395,7 +419,7 @@ impl<'env, E: 'static + Send> Scope<'env, E> {
     /// Spawns a service.
     ///
     /// Returns a handle to the service, which allows spawning new tasks within the service.
-    pub fn new_service<S:ServiceTrait>(&self, s:S) -> Service<S> {
+    pub fn new_service<S: ServiceTrait>(&self, s: S) -> Service<S> {
         self.1.upgrade().unwrap().new_service(s)
     }
 }

--- a/chain/network/src/concurrency/scope/mod.rs
+++ b/chain/network/src/concurrency/scope/mod.rs
@@ -179,7 +179,7 @@ pub struct ErrTerminated;
 
 pub trait ServiceTrait: Sized {
     type E: 'static + Send + Clone;
-    fn start(this: &ServiceScope<Self>);
+    fn start(_this: &ServiceScope<Self>) {}
 }
 
 /// A service is a subscope which doesn't keep the scope

--- a/chain/network/src/concurrency/scope/mod.rs
+++ b/chain/network/src/concurrency/scope/mod.rs
@@ -141,7 +141,6 @@ impl<E: 'static + Send> TerminateGuard<E> {
                     let guard = m.as_ref().borrow();
                     guard.register(err);
                     let inner = guard.0.clone();
-                    drop(guard);
                     drop(m);
                     inner.terminated.recv().await;
                     Err(inner)

--- a/chain/network/src/concurrency/scope/mod.rs
+++ b/chain/network/src/concurrency/scope/mod.rs
@@ -57,7 +57,7 @@ use crate::concurrency::signal;
 use futures::future::{BoxFuture, Future, FutureExt};
 use near_primitives::time;
 use std::borrow::Borrow;
-use std::sync::{Arc, Weak, Mutex};
+use std::sync::{Arc, Mutex, Weak};
 
 #[cfg(test)]
 mod tests;
@@ -65,7 +65,8 @@ mod tests;
 /// Passive representation of the scope.
 /// This object may outlive the lifetime of the scope.
 /// New tasks can be spawned in the scope, until the scope is terminated:
-/// To spawn a task on a scope, you need a
+/// To spawn a task on a scope, you need to hold a reference to TerminateGuard,
+/// which statically ensures that the scope is not terminated yet.
 struct Inner<E> {
     /// Context of this scope.
     /// All tasks spawned in this scope are provided with this context.
@@ -76,14 +77,20 @@ struct Inner<E> {
     terminated: signal::Once,
 }
 
-impl<E> Inner<E> { 
+impl<E> Inner<E> {
+    /// Takes out the error from the scope after scope termination.
+    /// For internal use only, because it effectively invalidates the Inner
+    /// object.
     fn err_take(&self) -> Option<E> {
+        debug_assert!(self.terminated.try_recv());
         std::mem::take(&mut *self.err.lock().unwrap())
     }
 }
 
-impl<E:Clone> Inner<E> {
+impl<E: Clone> Inner<E> {
+    /// Clones the error after scope termination.
     fn err_clone(&self) -> Option<E> {
+        debug_assert!(self.terminated.try_recv());
         self.err.lock().unwrap().clone()
     }
 }
@@ -93,7 +100,6 @@ struct TerminateGuard<E: 'static>(Arc<Inner<E>>);
 
 impl<E: 'static> Drop for TerminateGuard<E> {
     fn drop(&mut self) {
-        tracing::debug!("TerminateGuard::drop()");
         self.0.terminated.send();
     }
 }
@@ -101,7 +107,7 @@ impl<E: 'static> Drop for TerminateGuard<E> {
 impl<E: 'static + Send> TerminateGuard<E> {
     pub fn new(ctx: &ctx::Ctx) -> Self {
         Self(Arc::new(Inner {
-            ctx: ctx.sub(time::Deadline::Infinite), 
+            ctx: ctx.sub(time::Deadline::Infinite),
             err: Mutex::new(None),
             terminated: signal::Once::new(),
         }))
@@ -109,7 +115,9 @@ impl<E: 'static + Send> TerminateGuard<E> {
 
     fn register(&self, err: E) {
         let mut m = self.0.err.lock().unwrap();
-        if m.is_some() { return; }
+        if m.is_some() {
+            return;
+        }
         *m = Some(err);
         self.0.ctx.cancel();
     }
@@ -143,12 +151,7 @@ impl<E: 'static + Send> TerminateGuard<E> {
     }
 
     /// Spawns a new service in the scope.
-    ///
-    /// A service is a scope, which gets canceled when
-    /// its handler (`Service`) is dropped. Service belongs to a scope, in a sense that
-    /// a dedicated task is spawned on the scope which awaits for service to terminate and
-    /// returns the service's result.
-    pub fn new_service<E2:'static+Send>(self: Arc<Self>) -> Service<E2> {
+    pub fn new_service<E2: 'static + Send>(self: Arc<Self>) -> Service<E2> {
         let sub = Arc::new(TerminateGuard::new(&self.0.ctx));
         let service = Service(Arc::downgrade(&sub), sub.0.clone());
         // Spawn a guard task in `self` scope, so that it is not terminated
@@ -170,7 +173,7 @@ impl<E: 'static + Send> TerminateGuard<E> {
 /// when spawning new things on the service scope is not allowed, because the
 /// service has been already terminated. Returned by `JoinHandle::join` when
 /// the task has returned an error and therefore the service has been terminated.
-#[derive(thiserror::Error, Debug, Clone, Copy)]
+#[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq)]
 #[error("service has been terminated")]
 pub struct ErrTerminated;
 
@@ -179,16 +182,18 @@ pub struct ErrTerminated;
 /// be cancelled (even though tasks in a service may be still running).
 ///
 /// Note however that the scope won't be terminated until the tasks of the service complete.
-/// Service is cancelled when the handle is dropped, so make sure to store it somewhere.
-/// Service is cancelled when ANY of the tasks/services in the service returns an error.
-/// Service is cancelled when the parent scope/service is cancelled.
+/// Service is cancelled when ANY of the task in the service returns an error.
+/// Service is cancelled when the parent context is cancelled.
+/// Service is cancelled when `Service::terminate()` is called.
 /// Service is NOT cancelled just when all tasks within the service complete - in particular
 /// a newly started service has no tasks.
 /// Service is terminated when it is cancelled AND all tasks within the service complete.
-pub struct Service<E: 'static>(Weak<TerminateGuard<E>>,Arc<Inner<E>>);
+pub struct Service<E: 'static>(Weak<TerminateGuard<E>>, Arc<Inner<E>>);
 
-impl<E: 'static> Drop for Service<E> {
-    fn drop(&mut self) { self.1.ctx.cancel(); }
+impl<E> Clone for Service<E> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), self.1.clone())
+    }
 }
 
 impl<E: 'static + Send + Clone> Service<E> {
@@ -197,24 +202,27 @@ impl<E: 'static + Send + Clone> Service<E> {
         self.1.terminated.try_recv()
     }
 
-    pub async fn terminate(&self) -> ctx::OrCanceled<Result<(),E>> {
+    /// Cancels the service, then awaits its termination.
+    pub async fn terminate(&self) -> ctx::OrCanceled<Result<(), E>> {
         self.1.ctx.cancel();
         self.terminated().await
     }
 
-    pub async fn terminated(&self) -> ctx::OrCanceled<Result<(),E>> {
+    /// Awaits termination of the service and returns the service error (if any).
+    pub async fn terminated(&self) -> ctx::OrCanceled<Result<(), E>> {
         ctx::wait(async {
             self.1.terminated.recv().await;
             match self.1.err_clone() {
                 None => Ok(()),
                 Some(err) => Err(err),
             }
-        }).await
+        })
+        .await
     }
 
     /// Spawns a task in this scope.
     ///
-    /// Returns ErrTerminated if the scope has already terminated.
+    /// Returns ErrTerminated if service has already terminated.
     pub fn spawn<T: 'static + Send>(
         &self,
         f: impl 'static + Send + Future<Output = Result<T, E>>,
@@ -225,17 +233,15 @@ impl<E: 'static + Send + Clone> Service<E> {
         }
     }
 
-    /// Spawns a service in this scope.
+    /// Spawns a subservice.
     ///
-    /// Returns ErrTerminated if the scope has already terminated.
-    pub fn new_service<E2:'static+Send>(&self) -> Result<Service<E2>,ErrTerminated> {
+    /// Returns ErrTerminated if the service has already terminated.
+    pub fn new_service<E2: 'static + Send>(&self) -> Result<Service<E2>, ErrTerminated> {
         self.0.upgrade().map(|m| m.new_service()).ok_or(ErrTerminated)
     }
 }
 
-impl<E:'static+Send+Clone> Service<E> {
-    
-}
+impl<E: 'static + Send + Clone> Service<E> {}
 
 /// Wrapper of a scope reference which cancels the scope when dropped.
 ///
@@ -244,13 +250,14 @@ impl<E:'static+Send+Clone> Service<E> {
 struct CancelGuard<E: 'static>(Arc<TerminateGuard<E>>);
 
 impl<E: 'static> Borrow<TerminateGuard<E>> for CancelGuard<E> {
-    fn borrow(&self) -> &TerminateGuard<E> { &*self.0 }
+    fn borrow(&self) -> &TerminateGuard<E> {
+        &*self.0
+    }
 }
 
 impl<E: 'static> Drop for CancelGuard<E> {
-    fn drop(&mut self) { 
-        tracing::debug!("CancelGuard::drop()");
-        self.0.0.ctx.cancel();
+    fn drop(&mut self) {
+        self.0 .0.ctx.cancel();
     }
 }
 
@@ -267,23 +274,27 @@ pub struct JoinHandle<'env, T, E>(
 impl<'env, T, E> JoinHandle<'env, T, E> {
     /// Cancel-safe.
     async fn join_raw(self) -> Result<T, ErrTerminated> {
-        self.0.await.unwrap().map_err(|_|ErrTerminated)
+        self.0.await.unwrap().map_err(|_| ErrTerminated)
     }
 
-    /// Awaits for a task to be completed and returns the result.
-    /// Returns Err(ErrCanceled) if the awaiting (current task) has been canceled.
-    /// Returns Ok(Err(ErrTerminated)) if the awaited (joined task) has been canceled.
+    /// Awaits the sucessful task termination (returning `Ok(Ok(result))`)
+    /// or termination of the scope/service (returnign `Ok(Err(ErrTerminated))`).
+    /// Returns `Err(ErrCanceled)` if the context is canceled earlier.
+    /// Note that it doesn't require `E` to be cloneable, while `join_err` does.
     pub async fn join(self) -> ctx::OrCanceled<Result<T, ErrTerminated>> {
         ctx::wait(self.join_raw()).await
     }
 }
 
-impl<'env, T, E:Clone> JoinHandle<'env, T, E> {
+impl<'env, T, E: Clone> JoinHandle<'env, T, E> {
     /// Cancel-safe.
     async fn join_err_raw(self) -> Result<T, E> {
-        self.0.await.unwrap().map_err(|inner|inner.err_clone().unwrap())
+        self.0.await.unwrap().map_err(|inner| inner.err_clone().unwrap())
     }
 
+    /// Awaits the sucessful task termination (returning `Ok(Ok(result))`)
+    /// or termination of the scope/service (returnign `Ok(Err(scope_error))`).
+    /// Returns `Err(ErrCanceled)` if the context is canceled earlier.
     pub async fn join_err(self) -> ctx::OrCanceled<Result<T, E>> {
         ctx::wait(self.join_err_raw()).await
     }
@@ -346,7 +357,7 @@ impl<'env, E: 'static + Send> Scope<'env, E> {
     /// Spawns a service.
     ///
     /// Returns a handle to the service, which allows spawning new tasks within the service.
-    pub fn new_service<E2:'static+Send>(&self) -> Service<E2> {
+    pub fn new_service<E2: 'static + Send>(&self) -> Service<E2> {
         self.1.upgrade().unwrap().new_service()
     }
 }
@@ -387,7 +398,10 @@ pub mod internal {
         Scope(Weak::new(), Weak::new(), std::marker::PhantomData)
     }
 
-    pub async fn run<'env, E, T, F, Fut>(scope: &'env mut Scope<'env, E>, root_task: F) -> Result<T, E>
+    pub async fn run<'env, E, T, F, Fut>(
+        scope: &'env mut Scope<'env, E>,
+        root_task: F,
+    ) -> Result<T, E>
     where
         E: 'static + Send,
         T: 'static + Send,
@@ -399,12 +413,13 @@ pub mod internal {
             scope.0 = Arc::downgrade(&guard);
             scope.1 = Arc::downgrade(&guard.0);
             let root_task = scope.spawn(root_task(scope));
-            let inner = guard.0.0.clone();
-            // each task spawned on `scope` keeps its own reference to `guard` or `guard.0`.
+            let inner = guard.0 .0.clone();
+            // Each task spawned on `scope` keeps its own reference to `guard` or `guard.0`.
             // As soon as all references to `guard` are dropped, scope will be cancelled.
             drop(guard);
+            // Wait for the scope termination.
             inner.terminated.recv().await;
-            tracing::debug!("scope terminated");
+            // Return the error, or the result of the root_task.
             match inner.err_take() {
                 Some(err) => Err(err),
                 None => Ok(root_task.join_raw().await.unwrap()),

--- a/chain/network/src/concurrency/scope/mod.rs
+++ b/chain/network/src/concurrency/scope/mod.rs
@@ -150,9 +150,9 @@ impl<E: 'static + Send> TerminateGuard<E> {
     }
 
     /// Spawns a new service in the scope.
-    pub fn new_service<E2: 'static + Send>(self: Arc<Self>) -> Service<E2> {
+    pub fn new_service<S:ServiceTrait>(self: Arc<Self>, s:S) -> Service<S> {
         let sub = Arc::new(TerminateGuard::new(&self.0.ctx));
-        let service = Service(Arc::downgrade(&sub), sub.0.clone());
+        let service = Service(Arc::new(s), Arc::downgrade(&sub), sub.0.clone());
         // Spawn a guard task in `self` scope, so that it is not terminated
         // before `sub` scope is.
         TerminateGuard::spawn(self, async move {
@@ -168,13 +168,17 @@ impl<E: 'static + Send> TerminateGuard<E> {
     }
 }
 
-/// Error returned `Service::spawn()` and `Service::new_service()`
+/// Error returned `Service::try_spawn()`
 /// when spawning new things on the service scope is not allowed, because the
 /// service has been already terminated. Returned by `JoinHandle::join` when
 /// the task has returned an error and therefore the service has been terminated.
 #[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq)]
 #[error("service has been terminated")]
 pub struct ErrTerminated;
+
+pub trait ServiceTrait {
+    type E : 'static + Send + Clone;
+}
 
 /// A service is a subscope which doesn't keep the scope
 /// alive, i.e. if all tasks spawned via `Scope::spawn` complete, the scope will
@@ -187,60 +191,95 @@ pub struct ErrTerminated;
 /// Service is NOT cancelled just when all tasks within the service complete - in particular
 /// a newly started service has no tasks.
 /// Service is terminated when it is cancelled AND all tasks within the service complete.
-pub struct Service<E: 'static>(Weak<TerminateGuard<E>>, Arc<Inner<E>>);
+pub struct Service<S:ServiceTrait>(Arc<S>,Weak<TerminateGuard<S::E>>, Arc<Inner<S::E>>);
 
-impl<E> Clone for Service<E> {
-    fn clone(&self) -> Self {
-        Self(self.0.clone(), self.1.clone())
+impl<S:ServiceTrait> Clone for Service<S> {
+    fn clone(&self) -> Self { Self(self.0.clone(),self.1.clone(),self.2.clone()) }
+}
+
+impl<S:ServiceTrait> std::ops::Deref for Service<S> {
+    type Target = S;
+    fn deref(&self) -> &Self::Target { self.0.as_ref() }
+}
+
+pub struct ServiceScope<S:ServiceTrait>(Arc<S>,Arc<TerminateGuard<S::E>>);
+
+impl<S:ServiceTrait> std::ops::Deref for ServiceScope<S> {
+    type Target = S;
+    fn deref(&self) -> &Self::Target { self.0.as_ref() }
+}
+
+#[doc(hidden)]
+pub mod service_internal {
+    use super::*;
+
+    pub fn try_spawn<S:ServiceTrait, T:'static + Send>(
+        s:&Service<S>,
+        f: impl FnOnce(ServiceScope<S>) -> BoxFuture<'static,Result<T,S::E>>,
+    ) -> Result<JoinHandle<'static,T,S::E>,ErrTerminated> {
+        s.1.upgrade().map(|g|spawn(&ServiceScope(s.0.clone(),g),f)).ok_or(ErrTerminated)
+    }
+
+    pub fn spawn<S:ServiceTrait, T:'static + Send>(
+        s: &ServiceScope<S>,
+        f:impl FnOnce(ServiceScope<S>) -> BoxFuture<'static,Result<T,S::E>>
+    ) -> JoinHandle<'static,T,S::E> {
+        JoinHandle(
+            TerminateGuard::spawn(s.1.clone(), f(ServiceScope(s.0.clone(),s.1.clone()))),
+            std::marker::PhantomData,
+        )
     }
 }
 
-impl<E: 'static + Send + Clone> Service<E> {
+#[macro_export]
+macro_rules! try_spawn {
+    ($x:expr, $f:expr) => {{
+        fn apply<A,R>(a:A, f:impl FnOnce(A) -> R) -> R { f(a) }
+        $crate::concurrency::scope::service_internal::try_spawn($x, |x| Box::pin(async { let x = x; apply(&x, $f).await }))
+    }};
+}
+
+#[macro_export]
+macro_rules! spawn {
+    ($x:expr, $f:expr) => {{
+        fn apply<A,R>(a:A, f:impl FnOnce(A) -> R) -> R { f(a) }
+        $crate::concurrency::scope::service_internal::spawn($x, |x| Box::pin(async { let x = x; apply(&x, $f).await }))
+    }};
+}
+
+pub use spawn;
+pub use try_spawn;
+
+impl<S: ServiceTrait> Service<S> {
     /// Checks if the referred scope has been terminated.
     pub fn is_terminated(&self) -> bool {
-        self.1.terminated.try_recv()
+        self.2.terminated.try_recv()
     }
 
     /// Cancels the service, then awaits its termination.
-    pub async fn terminate(&self) -> ctx::OrCanceled<Result<(), E>> {
-        self.1.ctx.cancel();
-        self.terminated().await
-    }
+    pub fn terminate(&self) { self.2.ctx.cancel(); }
 
     /// Awaits termination of the service and returns the service error (if any).
-    pub async fn terminated(&self) -> ctx::OrCanceled<Result<(), E>> {
+    pub async fn terminated(&self) -> ctx::OrCanceled<Result<(), S::E>> {
         ctx::wait(async {
-            self.1.terminated.recv().await;
-            match self.1.err_clone() {
+            self.2.terminated.recv().await;
+            match self.2.err_clone() {
                 None => Ok(()),
                 Some(err) => Err(err),
             }
         })
         .await
     }
+}
 
-    /// Spawns a task in this scope.
-    ///
-    /// Returns ErrTerminated if service has already terminated.
-    pub fn spawn<T: 'static + Send>(
-        &self,
-        f: impl 'static + Send + Future<Output = Result<T, E>>,
-    ) -> Result<JoinHandle<'static, T, E>, ErrTerminated> {
-        match self.0.upgrade().map(|m| TerminateGuard::spawn(m, f)) {
-            Some(h) => Ok(JoinHandle(h, std::marker::PhantomData)),
-            None => Err(ErrTerminated),
-        }
-    }
-
+impl<S: ServiceTrait> ServiceScope<S> {
     /// Spawns a subservice.
     ///
     /// Returns ErrTerminated if the service has already terminated.
-    pub fn new_service<E2: 'static + Send>(&self) -> Result<Service<E2>, ErrTerminated> {
-        self.0.upgrade().map(|m| m.new_service()).ok_or(ErrTerminated)
+    pub fn new_service<S2:ServiceTrait>(&self, s2:S2) -> Service<S2> {
+        self.1.clone().new_service(s2)
     }
 }
-
-impl<E: 'static + Send + Clone> Service<E> {}
 
 /// Wrapper of a scope reference which cancels the scope when dropped.
 ///
@@ -356,8 +395,8 @@ impl<'env, E: 'static + Send> Scope<'env, E> {
     /// Spawns a service.
     ///
     /// Returns a handle to the service, which allows spawning new tasks within the service.
-    pub fn new_service<E2: 'static + Send>(&self) -> Service<E2> {
-        self.1.upgrade().unwrap().new_service()
+    pub fn new_service<S:ServiceTrait>(&self, s:S) -> Service<S> {
+        self.1.upgrade().unwrap().new_service(s)
     }
 }
 

--- a/chain/network/src/concurrency/scope/tests.rs
+++ b/chain/network/src/concurrency/scope/tests.rs
@@ -17,7 +17,7 @@ type R<E> = Result<(), E>;
 async fn test_drop_service() {
     abort_on_panic();
     let res = scope::run!(|s| async {
-        let service = s.new_service().await;
+        let service = s.new_service();
         service
             .spawn(async {
                 ctx::canceled().await;
@@ -52,7 +52,7 @@ async fn test_spawn_after_cancelling_scope() {
 async fn test_spawn_after_dropping_service() {
     abort_on_panic();
     let res = scope::run!(|s| async {
-        let service = Arc::new(s.new_service().await);
+        let service = Arc::new(s.new_service());
         service
             .spawn({
                 let service = service.clone();
@@ -78,7 +78,7 @@ async fn test_spawn_after_dropping_service() {
 async fn test_service_termination() {
     abort_on_panic();
     let res = scope::run!(|s| async {
-        let service = s.new_service().await;
+        let service = s.new_service();
         service.spawn(async { Ok(ctx::canceled().await) }).unwrap();
         service.spawn(async { Ok(ctx::canceled().await) }).unwrap();
         service.terminate().await.unwrap();
@@ -94,13 +94,13 @@ async fn test_nested_service() {
     abort_on_panic();
     let res = scope::run!(|s| async {
         let has_spawned = signal::Once::new();
-        let outer = Arc::new(s.new_service().await);
+        let outer = Arc::new(s.new_service());
         outer
             .spawn({
                 let has_spawned = has_spawned.clone();
                 let outer = outer.clone();
                 async move {
-                    let inner = outer.new_service().await.unwrap();
+                    let inner = outer.new_service().unwrap();
                     inner
                         .spawn(async move {
                             has_spawned.send();
@@ -158,7 +158,7 @@ async fn test_already_canceled() {
 async fn test_service_cancel() {
     abort_on_panic();
     scope::run!(|s| async {
-        let service = Arc::new(s.new_service().await);
+        let service = Arc::new(s.new_service());
         service
             .spawn({
                 let service = service.clone();
@@ -178,7 +178,7 @@ async fn test_service_cancel() {
 async fn test_service_error_before_cancel() {
     abort_on_panic();
     let res = scope::run!(|s| async {
-        let service = Arc::new(s.new_service().await);
+        let service = Arc::new(s.new_service());
 
         service
             .spawn({
@@ -199,7 +199,7 @@ async fn test_service_error_before_cancel() {
 async fn test_service_error_after_cancel() {
     abort_on_panic();
     let res = scope::run!(|s| async {
-        let service = Arc::new(s.new_service().await);
+        let service = Arc::new(s.new_service());
 
         service
             .spawn({
@@ -220,7 +220,7 @@ async fn test_service_error_after_cancel() {
 async fn test_scope_error() {
     abort_on_panic();
     let res = scope::run!(|s| async {
-        let service = Arc::new(s.new_service().await);
+        let service = Arc::new(s.new_service());
 
         service
             .spawn({
@@ -241,7 +241,7 @@ async fn test_scope_error() {
 async fn test_scope_error_nonoverridable() {
     abort_on_panic();
     let res = scope::run!(|s| async {
-        let service = Arc::new(s.new_service().await);
+        let service = Arc::new(s.new_service());
         service
             .spawn({
                 let service = service.clone();

--- a/chain/network/src/concurrency/scope/tests.rs
+++ b/chain/network/src/concurrency/scope/tests.rs
@@ -278,6 +278,9 @@ async fn test_spawn_from_spawn_bg() {
     assert_eq!(Err(3), res);
 }
 
+// TODO: spawn a service after all main tasks complete successfully.
+// TODO: whole service is terminated after joining a task which returned an error.
+
 #[tokio::test]
 async fn test_access_to_vars_outside_of_scope() {
     abort_on_panic();

--- a/chain/network/src/concurrency/scope/tests.rs
+++ b/chain/network/src/concurrency/scope/tests.rs
@@ -3,12 +3,16 @@ use crate::concurrency::scope;
 use crate::concurrency::signal;
 use crate::testonly::abort_on_panic;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
 
 // run a trivial future until completion => OK
 #[tokio::test]
 async fn must_complete_ok() {
     assert_eq!(5, scope::must_complete(async move { 5 }).await);
+}
+
+struct S;
+impl scope::ServiceTrait for S {
+    type E = usize;
 }
 
 type R = Result<(), usize>;
@@ -29,12 +33,13 @@ async fn test_spawn_after_cancelling_scope() {
 async fn test_service_termination() {
     abort_on_panic();
     let res = scope::run!(|s| async {
-        let service = s.new_service();
-        service.spawn(async { Ok(ctx::canceled().await) }).unwrap();
-        service.spawn(async { Ok(ctx::canceled().await) }).unwrap();
-        service.terminate().await.unwrap().unwrap();
+        let service = s.new_service(S);
+        scope::try_spawn!(&service, |_| async { Ok(ctx::canceled().await) }).unwrap();
+        scope::try_spawn!(&service, |_| async { Ok(ctx::canceled().await) }).unwrap();
+        service.terminate();
+        service.terminated().await.unwrap().unwrap();
         // Spawning after service termination should fail.
-        assert!(service.spawn(async { R::Err(1) }).is_err());
+        assert!(scope::try_spawn!(&service, |_| async { R::Err(1) }).is_err());
         R::Ok(())
     });
     assert_eq!(Ok(()), res);
@@ -45,36 +50,41 @@ async fn test_nested_service() {
     abort_on_panic();
     let inner_spawned = signal::Once::new();
     scope::run!(|s| async {
-        let outer = s.new_service();
-        let inner = outer.new_service().unwrap();
-        outer
-            .spawn({
-                let inner = inner.clone();
-                let inner_spawned = inner_spawned.clone();
-                async move {
-                    let x = inner
-                        .spawn(async move {
-                            inner_spawned.send();
-                            // inner service task waits for cancelation, then returns an error.
-                            ctx::canceled().await;
-                            R::Err(8)
-                        })
-                        .unwrap()
-                        .join_err()
-                        .await
-                        .unwrap()
-                        .err()
-                        .unwrap();
-                    // outer service task waits for inner task to return an error,
-                    // then it returns its own error.
-                    R::Err(x + 1)
-                }
+        let outer = s.new_service(S);
+        let inner = scope::try_spawn!(&outer, |s| async { Ok(s.new_service(S)) })
+            .unwrap()
+            .join()
+            .await
+            .unwrap()
+            .unwrap();
+        {
+            let inner = inner.clone();
+            let inner_spawned = inner_spawned.clone();
+            scope::try_spawn!(&outer, |_| async move {
+                let x = scope::try_spawn!(&inner, |_| async move {
+                    inner_spawned.send();
+                    // inner service task waits for cancelation, then returns an error.
+                    ctx::canceled().await;
+                    R::Err(8)
+                })
+                .unwrap()
+                .join_err()
+                .await
+                .unwrap()
+                .err()
+                .unwrap();
+                // outer service task waits for inner task to return an error,
+                // then it returns its own error.
+                R::Err(x + 1)
             })
             .unwrap();
+        }
         // Wait for the inner task to get spawned.
         inner_spawned.recv().await;
-        // Terminate the inner service and await the service error.
-        assert_eq!(Err(8), inner.terminate().await.unwrap());
+        // Terminate the inner service.
+        inner.terminate();
+        // Await the inner service error.
+        assert_eq!(Err(8), inner.terminated().await.unwrap());
         // Expect the outer service to return an error by itself.
         assert_eq!(Err(9), outer.terminated().await.unwrap());
         R::Ok(())
@@ -119,8 +129,8 @@ async fn test_already_canceled() {
 async fn test_service_error_collected() {
     abort_on_panic();
     let res = scope::run!(|s| async {
-        let service = Arc::new(s.new_service());
-        service.spawn(async { R::Err(1) }).unwrap();
+        let service = s.new_service(S);
+        scope::try_spawn!(&service, |_| async { R::Err(1) }).unwrap();
         service.terminated().await.unwrap()
     });
     assert_eq!(Err(1), res);
@@ -130,26 +140,23 @@ async fn test_service_error_collected() {
 async fn test_service_spawn_while_terminating() {
     abort_on_panic();
     let res = scope::run!(|s| async {
-        let service = s.new_service();
-        service
-            .spawn({
-                let service = service.clone();
-                async move {
-                    ctx::canceled().await;
-                    // Until service is terminated, you are still
-                    // able to spawn new tasks, but you cannot await them,
-                    // because the context is canceled at this point.
-                    //
-                    // `join()` and `join_err()` await the termination of the whole
-                    // service if the task returns an error. The fact that context
-                    // gets cancelled prevents a deadlock.
-                    let res = service.spawn(async { R::Err(7) }).unwrap().join_err().await;
-                    assert_eq!(Err(ctx::ErrCanceled), res);
-                    Ok(())
-                }
-            })
-            .unwrap();
-        assert_eq!(Err(7), service.terminate().await.unwrap());
+        let service = s.new_service(S);
+        scope::try_spawn!(&service, |s| async {
+            ctx::canceled().await;
+            // Until service is terminated, you are still
+            // able to spawn new tasks, but you cannot await them,
+            // because the context is canceled at this point.
+            //
+            // `join()` and `join_err()` await the termination of the whole
+            // service if the task returns an error. The fact that context
+            // gets cancelled prevents a deadlock.
+            let res = scope::spawn!(s, |_| async { R::Err(7) }).join_err().await;
+            assert_eq!(Err(ctx::ErrCanceled), res);
+            Ok(())
+        })
+        .unwrap();
+        service.terminate();
+        assert_eq!(Err(7), service.terminated().await.unwrap());
         // Service error doesn't affect the scope. We can return a different error, or even
         // success.
         R::Err(3)
@@ -161,19 +168,23 @@ async fn test_service_spawn_while_terminating() {
 async fn test_service_join() {
     abort_on_panic();
     scope::run!(|s| async {
-        let service = s.new_service();
+        let service = s.new_service(S);
         // Task which returns a success doesn't terminate the service (using `join_err`).
-        let res = service.spawn(async { Ok(3) }).unwrap().join_err().await.unwrap();
+        let res =
+            scope::try_spawn!(&service, |_| async { Ok(3) }).unwrap().join_err().await.unwrap();
         assert_eq!(Ok(3), res);
         // Task which returns a success doesn't terminate the service (using `join`).
-        let res = service.spawn(async { Ok(2) }).unwrap().join().await.unwrap();
+        let res = scope::try_spawn!(&service, |_| async { Ok(2) }).unwrap().join().await.unwrap();
         assert_eq!(Ok(2), res);
         // Task which returns an error terminates the service.
-        let res = service.spawn(async { R::Err(7) }).unwrap().join_err().await.unwrap();
+        let res =
+            scope::try_spawn!(&service, |_| async { R::Err(7) }).unwrap().join_err().await.unwrap();
         assert_eq!(Err(7), res);
         // After the service is terminated, no new task can be spawned.
-        let res = service.spawn::<()>(async {
+        let res = scope::try_spawn!(&service, |_| async {
             panic!("shouldn't be executed");
+            #[allow(unreachable_code)]
+            Ok(())
         });
         assert_eq!(scope::ErrTerminated, res.err().unwrap());
         R::Ok(())
@@ -187,20 +198,20 @@ async fn test_service_join() {
 async fn test_service_join_error_override() {
     abort_on_panic();
     scope::run!(|s| async {
-        let s = s.new_service();
-        let t1 = s
-            .spawn(async {
-                ctx::canceled().await;
-                R::Err(1)
-            })
-            .unwrap();
-        let t2 = s
-            .spawn(async {
-                ctx::canceled().await;
-                R::Err(2)
-            })
-            .unwrap();
-        let res = s.terminate().await.unwrap();
+        let s = s.new_service(S);
+        let t1 = scope::try_spawn!(&s, |_| async {
+            ctx::canceled().await;
+            R::Err(1)
+        })
+        .unwrap();
+        let t2 = scope::try_spawn!(&s, |_| async {
+            ctx::canceled().await;
+            R::Err(2)
+        })
+        .unwrap();
+        s.terminate();
+        let res = s.terminated().await.unwrap();
+        assert!(res.is_err());
         assert_eq!(res, t1.join_err().await.unwrap());
         assert_eq!(res, t2.join_err().await.unwrap());
         R::Ok(())
@@ -212,13 +223,12 @@ async fn test_service_join_error_override() {
 async fn test_scope_error() {
     abort_on_panic();
     let res = scope::run!(|s| async {
-        let service = s.new_service();
-        service
-            .spawn(async {
-                ctx::canceled().await;
-                R::Ok(())
-            })
-            .unwrap();
+        let service = s.new_service(S);
+        scope::try_spawn!(&service, |_| async {
+            ctx::canceled().await;
+            R::Ok(())
+        })
+        .unwrap();
         R::Err(2)
     });
     assert_eq!(Err(2), res);
@@ -240,7 +250,7 @@ async fn test_spawn_from_spawn_bg() {
             });
             // Service can be spawned, but we cannot do anything about it
             // (within the canceled scope).
-            s.new_service::<()>();
+            s.new_service(S);
             Ok(())
         });
         Ok(())
@@ -250,18 +260,18 @@ async fn test_spawn_from_spawn_bg() {
 
 #[tokio::test]
 async fn test_service_outside_of_the_scope() {
-    let service = scope::run!(|s| async { Result::<_, ()>::Ok(s.new_service::<()>()) }).unwrap();
+    let service = scope::run!(|s| async { Result::<_, ()>::Ok(s.new_service(S)) }).unwrap();
     // If the service object outlives the scope it is nested in, it should be already terminated.
     assert!(service.is_terminated());
     // Therefore spawning should fail.
     assert_eq!(
         scope::ErrTerminated,
-        service
-            .spawn::<()>(async {
-                panic!("unreachable");
-            })
-            .err()
-            .unwrap()
+        scope::try_spawn!(&service, |_| async {
+            #[allow(unreachable_code)]
+            Ok(panic!("unreachable"))
+        })
+        .err()
+        .unwrap()
     );
 }
 

--- a/chain/network/src/concurrency/scope/tests.rs
+++ b/chain/network/src/concurrency/scope/tests.rs
@@ -14,29 +14,6 @@ async fn must_complete_ok() {
 type R = Result<(), usize>;
 
 #[tokio::test]
-async fn test_drop_service() {
-    abort_on_panic();
-    let res = scope::run!(|s| async {
-        let service = s.new_service();
-        service
-            .spawn(async {
-                ctx::canceled().await;
-                R::Err(2)
-            })
-            .unwrap();
-        // Both scope task and service task await context cancellation.
-        // However, scope task drops the only reference to service before
-        // awaiting, which should cause service to cancel.
-        // The canceled service task returns an error which should cancel
-        // the whole scope.
-        drop(service);
-        ctx::canceled().await;
-        Ok(())
-    });
-    assert_eq!(Err(2), res);
-}
-
-#[tokio::test]
 async fn test_spawn_after_cancelling_scope() {
     abort_on_panic();
     let res = scope::run!(|s| async {
@@ -46,32 +23,6 @@ async fn test_spawn_after_cancelling_scope() {
         Ok(())
     });
     assert_eq!(R::Err(7), res);
-}
-
-#[tokio::test]
-async fn test_spawn_after_dropping_service() {
-    abort_on_panic();
-    let res = scope::run!(|s| async {
-        let service = Arc::new(s.new_service());
-        service
-            .spawn({
-                let service = service.clone();
-                async move {
-                    ctx::canceled().await;
-                    // Even though the service has been cancelled, you can spawn more tasks on it
-                    // until it is actually terminated. So it is always OK to spawn new tasks on
-                    // a service from another task running on this service.
-                    service.spawn(async { R::Err(5) }).unwrap();
-                    Ok(())
-                }
-            })
-            .unwrap();
-        // terminate() may get cancelled, because we expect the service to return an error.
-        // Error may or may not get propagated before terminate completes.
-        let _ = service.terminate().await;
-        Ok(())
-    });
-    assert_eq!(Err(5), res);
 }
 
 #[tokio::test]
@@ -92,25 +43,43 @@ async fn test_service_termination() {
 #[tokio::test]
 async fn test_nested_service() {
     abort_on_panic();
-    let has_terminated = scope::run!(|s| async {
-        let outer = s.new_service::<()>();
+    let inner_spawned = signal::Once::new();
+    scope::run!(|s| async {
+        let outer = s.new_service();
         let inner = outer.new_service().unwrap();
-        outer.spawn(async move {
-            let has_terminated = signal::Once::new();
-            inner.spawn({
-                let has_terminated = has_terminated.clone();
+        outer
+            .spawn({
+                let inner = inner.clone();
+                let inner_spawned = inner_spawned.clone();
                 async move {
-                    ctx::canceled().await;
-                    has_terminated.send();
-                    R::Err(9)
+                    let x = inner
+                        .spawn(async move {
+                            inner_spawned.send();
+                            // inner service task waits for cancelation, then returns an error.
+                            ctx::canceled().await;
+                            R::Err(8)
+                        })
+                        .unwrap()
+                        .join_err()
+                        .await
+                        .unwrap()
+                        .err()
+                        .unwrap();
+                    // outer service task waits for inner task to return an error,
+                    // then it returns its own error.
+                    R::Err(x + 1)
                 }
-            }).unwrap();
-            Ok(has_terminated)
-        }).unwrap().join_err().await.unwrap()
-        // Scope (and all the transitive subservices) get cancelled once this task completes.
-        // Scope won't be terminated until all the transitive subservices terminate.
-    }).unwrap();
-    assert!(has_terminated.try_recv());
+            })
+            .unwrap();
+        // Wait for the inner task to get spawned.
+        inner_spawned.recv().await;
+        // Terminate the inner service and await the service error.
+        assert_eq!(Err(8), inner.terminate().await.unwrap());
+        // Expect the outer service to return an error by itself.
+        assert_eq!(Err(9), outer.terminated().await.unwrap());
+        R::Ok(())
+    })
+    .unwrap();
 }
 
 #[tokio::test]
@@ -147,101 +116,107 @@ async fn test_already_canceled() {
 }
 
 #[tokio::test]
-async fn test_service_cancel() {
+async fn test_service_error_collected() {
     abort_on_panic();
-    scope::run!(|s| async {
+    let res = scope::run!(|s| async {
         let service = Arc::new(s.new_service());
+        service.spawn(async { R::Err(1) }).unwrap();
+        service.terminated().await.unwrap()
+    });
+    assert_eq!(Err(1), res);
+}
+
+#[tokio::test]
+async fn test_service_spawn_while_terminating() {
+    abort_on_panic();
+    let res = scope::run!(|s| async {
+        let service = s.new_service();
         service
             .spawn({
                 let service = service.clone();
                 async move {
-                    let _service = service;
                     ctx::canceled().await;
-                    R::Ok(())
+                    // Until service is terminated, you are still
+                    // able to spawn new tasks, but you cannot await them,
+                    // because the context is canceled at this point.
+                    //
+                    // `join()` and `join_err()` await the termination of the whole
+                    // service if the task returns an error. The fact that context
+                    // gets cancelled prevents a deadlock.
+                    let res = service.spawn(async { R::Err(7) }).unwrap().join_err().await;
+                    assert_eq!(Err(ctx::ErrCanceled), res);
+                    Ok(())
                 }
             })
             .unwrap();
+        assert_eq!(Err(7), service.terminate().await.unwrap());
+        // Service error doesn't affect the scope. We can return a different error, or even
+        // success.
+        R::Err(3)
+    });
+    assert_eq!(Err(3), res);
+}
+
+#[tokio::test]
+async fn test_service_join() {
+    abort_on_panic();
+    scope::run!(|s| async {
+        let service = s.new_service();
+        // Task which returns a success doesn't terminate the service (using `join_err`).
+        let res = service.spawn(async { Ok(3) }).unwrap().join_err().await.unwrap();
+        assert_eq!(Ok(3), res);
+        // Task which returns a success doesn't terminate the service (using `join`).
+        let res = service.spawn(async { Ok(2) }).unwrap().join().await.unwrap();
+        assert_eq!(Ok(2), res);
+        // Task which returns an error terminates the service.
+        let res = service.spawn(async { R::Err(7) }).unwrap().join_err().await.unwrap();
+        assert_eq!(Err(7), res);
+        // After the service is terminated, no new task can be spawned.
+        let res = service.spawn::<()>(async {
+            panic!("shouldn't be executed");
+        });
+        assert_eq!(scope::ErrTerminated, res.err().unwrap());
+        R::Ok(())
+    })
+    .unwrap();
+}
+
+// We treat all tasks within a service as a single error domain.
+// If more that one task returns an error, the first error is returned in every join.
+#[tokio::test]
+async fn test_service_join_error_override() {
+    abort_on_panic();
+    scope::run!(|s| async {
+        let s = s.new_service();
+        let t1 = s
+            .spawn(async {
+                ctx::canceled().await;
+                R::Err(1)
+            })
+            .unwrap();
+        let t2 = s
+            .spawn(async {
+                ctx::canceled().await;
+                R::Err(2)
+            })
+            .unwrap();
+        let res = s.terminate().await.unwrap();
+        assert_eq!(res, t1.join_err().await.unwrap());
+        assert_eq!(res, t2.join_err().await.unwrap());
         R::Ok(())
     })
     .unwrap();
 }
 
 #[tokio::test]
-async fn test_service_error_before_cancel() {
-    abort_on_panic();
-    let res = scope::run!(|s| async {
-        let service = Arc::new(s.new_service());
-
-        service
-            .spawn({
-                let service = service.clone();
-                async move {
-                    let _service = service;
-                    R::Err(1)
-                }
-            })
-            .unwrap();
-        ctx::canceled().await;
-        Ok(())
-    });
-    assert_eq!(Err(1), res);
-}
-
-/// Service error is not forwarded automatically
-/// as the scope error.
-#[tokio::test]
-async fn test_service_non_awaited_error() {
-    abort_on_panic();
-    let res = scope::run!(|s| async {
-        let service = Arc::new(s.new_service());
-        service
-            .spawn({
-                let service = service.clone();
-                async move {
-                    let _service = service;
-                    ctx::canceled().await;
-                    R::Err(2)
-                }
-            })
-            .unwrap();
-        R::Ok(())
-    });
-    assert_eq!(Ok(()), res);
-}
-
-#[tokio::test]
 async fn test_scope_error() {
     abort_on_panic();
     let res = scope::run!(|s| async {
-        let service = Arc::new(s.new_service());
+        let service = s.new_service();
         service
-            .spawn({
-                let service = service.clone();
-                async move {
-                    let _service = service;
-                    ctx::canceled().await;
-                    R::Ok(())
-                }
-            })
-            .unwrap();
-        R::Err(2)
-    });
-    assert_eq!(Err(2), res);
-}
-
-#[tokio::test]
-async fn test_scope_error_nonoverridable() {
-    abort_on_panic();
-    let res = scope::run!(|s| async {
-        let service = Arc::new(s.new_service());
-        service
-            .spawn({
-                let service = service.clone();
-                async {
-                    let _service = service;
-                    ctx::canceled().await;
-                    R::Err(3)
-                }
+            .spawn(async {
+                ctx::canceled().await;
+                R::Ok(())
             })
             .unwrap();
         R::Err(2)
@@ -263,6 +238,9 @@ async fn test_spawn_from_spawn_bg() {
                 assert!(ctx::is_canceled());
                 R::Err(3)
             });
+            // Service can be spawned, but we cannot do anything about it
+            // (within the canceled scope).
+            s.new_service::<()>();
             Ok(())
         });
         Ok(())
@@ -270,8 +248,22 @@ async fn test_spawn_from_spawn_bg() {
     assert_eq!(Err(3), res);
 }
 
-// TODO: spawn a service after all main tasks complete successfully.
-// TODO: whole service is terminated after joining a task which returned an error.
+#[tokio::test]
+async fn test_service_outside_of_the_scope() {
+    let service = scope::run!(|s| async { Result::<_, ()>::Ok(s.new_service::<()>()) }).unwrap();
+    // If the service object outlives the scope it is nested in, it should be already terminated.
+    assert!(service.is_terminated());
+    // Therefore spawning should fail.
+    assert_eq!(
+        scope::ErrTerminated,
+        service
+            .spawn::<()>(async {
+                panic!("unreachable");
+            })
+            .err()
+            .unwrap()
+    );
+}
 
 #[tokio::test]
 async fn test_access_to_vars_outside_of_scope() {

--- a/chain/network/src/peer/stream.rs
+++ b/chain/network/src/peer/stream.rs
@@ -78,7 +78,7 @@ where
         let (queue_send, queue_recv) = tokio::sync::mpsc::unbounded_channel();
         let send_buf_size_metric = Arc::new(metrics::MetricGuard::new(
             &*metrics::PEER_DATA_WRITE_BUFFER_SIZE,
-            vec![stream.peer_addr.to_string()],
+            vec![stream.info.peer_addr.to_string()],
         ));
         ctx.spawn(wrap_future({
             let addr = ctx.address();
@@ -95,7 +95,7 @@ where
             let stats = stats.clone();
             async move {
                 if let Err(err) =
-                    Self::run_recv_loop(stream.peer_addr, tcp_recv, addr.clone(), stats).await
+                    Self::run_recv_loop(stream.info.peer_addr, tcp_recv, addr.clone(), stats).await
                 {
                     addr.do_send(Error::Recv(err));
                 }

--- a/chain/network/src/peer_manager/connection/mod.rs
+++ b/chain/network/src/peer_manager/connection/mod.rs
@@ -27,6 +27,8 @@ use std::sync::{Arc, Weak};
 #[cfg(test)]
 mod tests;
 
+mod stream;
+
 impl tcp::Tier {
     /// Checks if the given message type is allowed on a connection of the given Tier.
     /// TIER1 is reserved exclusively for BFT consensus messages.

--- a/chain/network/src/peer_manager/connection/stream/mod.rs
+++ b/chain/network/src/peer_manager/connection/stream/mod.rs
@@ -1,0 +1,116 @@
+#![allow(dead_code)]
+use crate::concurrency::ctx;
+use crate::concurrency::scope;
+use crate::tcp;
+use std::sync::Arc;
+use tokio::io::AsyncReadExt as _;
+use tokio::io::AsyncWriteExt as _;
+
+pub(crate) mod stats;
+type ReadHalf = tokio::io::BufReader<tokio::io::ReadHalf<tokio::net::TcpStream>>;
+type WriteHalf = tokio::io::BufWriter<tokio::io::WriteHalf<tokio::net::TcpStream>>;
+
+#[derive(thiserror::Error, Debug)]
+#[error("ErrStreamClosed")]
+pub(crate) struct ErrStreamClosed;
+
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub(crate) struct Frame(pub Vec<u8>);
+
+pub struct FrameStream {
+    service: scope::Service<anyhow::Error>,
+    stats: Arc<stats::Stats>,
+    flusher: tokio::sync::Notify,
+    send: Arc<tokio::sync::Mutex<Option<WriteHalf>>>,
+    recv: Arc<tokio::sync::Mutex<Option<ReadHalf>>>,
+}
+
+impl FrameStream {
+    fn new(
+        service: scope::Service<anyhow::Error>,
+        stream: tcp::Stream,
+    ) -> anyhow::Result<Arc<FrameStream>> {
+        let (tcp_recv, tcp_send) = tokio::io::split(stream.stream);
+
+        const READ_BUFFER_CAPACITY: usize = 8 * 1024;
+        const WRITE_BUFFER_CAPACITY: usize = 8 * 1024;
+        let s = Arc::new(Self {
+            service,
+            stats: Arc::new(stats::Stats::new(&stream.peer_addr)),
+            flusher: tokio::sync::Notify::new(),
+            send: Arc::new(tokio::sync::Mutex::new(Some(WriteHalf::with_capacity(
+                WRITE_BUFFER_CAPACITY,
+                tcp_send,
+            )))),
+            recv: Arc::new(tokio::sync::Mutex::new(Some(ReadHalf::with_capacity(
+                READ_BUFFER_CAPACITY,
+                tcp_recv,
+            )))),
+        });
+
+        // Subtask flushing the sending buffer.
+        let self_ = s.clone();
+        s.service.spawn::<()>(async move {
+            loop {
+                ctx::wait(self_.flusher.notified()).await?;
+                let mut send = ctx::wait(self_.send.lock()).await?;
+                let mut inner = send.take().ok_or(ErrStreamClosed)?;
+                ctx::wait(inner.flush()).await??;
+                // If loop iteration exits early, the stream becomes broken.
+                *send = Some(inner);
+            }
+        })?;
+        Ok(s)
+    }
+
+    /// Sends a frame over the TCP connection.
+    /// If error is returned, the message may or may not have been sent.
+    async fn send(self: &Arc<Self>, frame: Frame) -> anyhow::Result<()> {
+        let guard = stats::SendGuard::new(self.stats.clone(), frame.0.len())?;
+        let mut send = ctx::wait(self.send.clone().lock_owned()).await?;
+        let mut inner = send.take().ok_or(ErrStreamClosed)?;
+        let self_ = self.clone();
+        Ok(self
+            .service
+            .spawn(ctx::run_with_timeout(time::Duration::minutes(1), async move {
+                let _guard = guard;
+                ctx::wait(inner.write_u32_le(frame.0.len() as u32)).await??;
+                ctx::wait(inner.write_all(&frame.0[..])).await??;
+                self_.flusher.notify_one();
+                // If this task exits early, the stream becomes broken.
+                *send = Some(inner);
+                Ok(())
+            }))?
+            .join()
+            .await??)
+    }
+
+    /// Receives a frame from the TCP connection.
+    /// If error is returned, a message may or may not been received.
+    // TODO(gprusak): partially received message will be still received in the background and
+    // then dropped. If that semantics is not OK, we can use tokio::sync::mpsc channel instead.
+    // reserve_owned() function will allow us to avoid receiving messages that are not awaited yet.
+    async fn recv(self: &Arc<Self>) -> anyhow::Result<Frame> {
+        let mut recv = ctx::wait(self.recv.clone().lock_owned()).await?;
+        let mut inner = recv.take().ok_or(ErrStreamClosed)?;
+        let stats = self.stats.clone();
+        Ok(self
+            .service
+            .spawn(async move {
+                let n = ctx::wait(inner.read_u32_le()).await?? as usize;
+                let _guard = stats::RecvGuard::new(stats, n)?;
+                let mut buf = vec![0; n];
+                // Timeout on message transmission.
+                ctx::run_with_timeout(
+                    time::Duration::minutes(1),
+                    ctx::wait(inner.read_exact(&mut buf[..])),
+                )
+                .await??;
+                // If loop iteration exits early, the stream becomes broken.
+                *recv = Some(inner);
+                Ok(Frame(buf))
+            })?
+            .join()
+            .await??)
+    }
+}

--- a/chain/network/src/peer_manager/connection/stream/mod.rs
+++ b/chain/network/src/peer_manager/connection/stream/mod.rs
@@ -13,16 +13,22 @@ type WriteHalf = tokio::io::BufWriter<tokio::io::WriteHalf<tokio::net::TcpStream
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub(crate) struct Frame(pub Vec<u8>);
 
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Clone, Debug)]
 pub(crate) enum Error {
     #[error(transparent)]
-    IO(#[from] std::io::Error),
+    IO(Arc<std::io::Error>),
     #[error(transparent)]
     Canceled(#[from] ctx::ErrCanceled),
     #[error(transparent)]
     Stats(#[from] stats::Error),
     #[error("Stream has been closed")]
     StreamClosed,
+}
+
+impl From<std::io::Error> for Error {
+    fn from(err: std::io::Error) -> Error{
+        Error::IO(Arc::new(err))
+    }
 }
 
 pub struct FrameStream {

--- a/chain/network/src/peer_manager/connection/stream/mod.rs
+++ b/chain/network/src/peer_manager/connection/stream/mod.rs
@@ -7,6 +7,10 @@ use tokio::io::AsyncReadExt as _;
 use tokio::io::AsyncWriteExt as _;
 
 pub(crate) mod stats;
+
+#[cfg(test)]
+mod tests;
+
 type ReadHalf = tokio::io::BufReader<tokio::io::ReadHalf<tokio::net::TcpStream>>;
 type WriteHalf = tokio::io::BufWriter<tokio::io::WriteHalf<tokio::net::TcpStream>>;
 

--- a/chain/network/src/peer_manager/connection/stream/mod.rs
+++ b/chain/network/src/peer_manager/connection/stream/mod.rs
@@ -11,14 +11,11 @@ pub(crate) mod stats;
 #[cfg(test)]
 mod tests;
 
-/// If sending/receiving a message takes more than `RESPONSIVENESS_TIMEOUT`, we consider the stream broken.
+/// If sending/receiving/flushing takes more than `RESPONSIVENESS_TIMEOUT`, we consider the stream broken.
 const RESPONSIVENESS_TIMEOUT: time::Duration = time::Duration::minutes(1);
 
-type ReadHalf = tokio::io::BufReader<tokio::io::ReadHalf<tokio::net::TcpStream>>;
-type WriteHalf = tokio::io::BufWriter<tokio::io::WriteHalf<tokio::net::TcpStream>>;
-
-#[derive(PartialEq, Eq, Clone, Debug)]
-pub(crate) struct Frame(pub Vec<u8>);
+type SendHalf = tokio::io::BufReader<tokio::io::ReadHalf<tokio::net::TcpStream>>;
+type RecvHalf = tokio::io::BufWriter<tokio::io::WriteHalf<tokio::net::TcpStream>>;
 
 #[derive(thiserror::Error, Clone, Debug)]
 pub(crate) enum Error {
@@ -28,11 +25,86 @@ pub(crate) enum Error {
     Canceled(#[from] ctx::ErrCanceled),
     #[error(transparent)]
     Stats(#[from] stats::Error),
+    #[error("Stream has been closed")]
+    StreamClosed,
 }
 
-#[derive(thiserror::Error, Debug)]
-#[error("Stream has been closed")]
-pub(crate) struct ErrStreamClosed;
+/// or_close executes the future f(stream.unwrap()) iff stream.is_some().
+/// If the future returns an error, stream is dropped (replaced with None).
+///
+/// All the low level stream operations in this module invalidate the stream if they fail.
+/// or_close allows to prevent further use after such a failure.
+/// An example of important cases for preventing further use:
+/// * we read/write a part of a frame, then encounter an error
+/// * reading/writing the next frame may lead to unexpected errors which might be hard to
+///  diagnose.
+async fn or_close<R,Fut:Future<Output=Result<R,Error>>(
+    stream :&mut Option<Stream>,
+    f:impl FnOnce(&mut Stream) -> Fut,
+) -> Result<R,Error> {
+    let res = f(stream.as_mut().ok_or(ErrStreamClosed)?).await;
+    if res.is_err() { stream.take(); }
+    res
+}
+
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub(crate) struct Frame(pub Vec<u8>);
+
+pub(crate) struct FrameSender {
+    inner: Option<SendHalf>,
+    stats: Arc<stats::Stats>,
+}
+
+impl FrameSender {
+    /// Sends the frame synchronously. Closes the stream on failure.
+    pub async fn send(&mut self, frame: &Frame) -> Result<(),Error> {
+        or_close(&mut self.inner, |this| async {
+            let _guard = stats::SendGuard::new(self.stats.clone(), frame.0.len())?;
+            ctx::wait(this.write_u32_le(frame.0.len() as u32)).await??;
+            ctx::wait(this.write_all(&frame.0[..])).await??;
+            ctx::wait(this.flush()).await??;
+            Ok(())
+        }).await
+    }
+}
+
+pub(crate) struct FrameReceiver{
+    inner: Option<RecvHalf>,
+    stats: Arc<stats::Stats>,
+}
+
+impl FrameReceiver {
+    /// Receives a frame from the TCP connection. Closes the stream on error.
+    pub async fn recv(&mut self) -> Result<Frame,Error> {
+        or_close(&mut self.inner, |this| async {
+            // First we wait for the initial size bytes.
+            let n = ctx::wait(this.read_u32_le()).await??;
+            // Then we expect the message to be received in a reasonable time.
+            ctx::run_with_timeout(RESPONSIVENESS_TIMEOUT, async {
+                let _guard = stats::RecvGuard::new(self.stats, n)?;
+                let mut buf = vec![0; n];
+                ctx::wait(this.read_exact(&mut buf[..])).await??;
+                anyhow::Ok(Frame(buf))
+            }).await
+        }).await
+    }
+}
+
+pub fn split(stream: tcp::Stream) -> (FrameSender,FrameReceiver) {
+    let (tcp_recv, tcp_send) = tokio::io::split(stream.stream);
+    const RECV_BUFFER_CAPACITY: usize = 8 * 1024;
+    const SEND_BUFFER_CAPACITY: usize = 8 * 1024;
+    let stats = Arc::new(stats::Stats::new(&stream.info));
+    let sender = FrameSender{
+        inner: Some(SendHalf::with_capacity(SEND_BUFFER_CAPACITY, tcp_send)),
+        stats: stats.clone(),
+    };
+    let receiver = FrameReceiver{
+        inner: Some(RecvHalf::with_capacity(RECV_BUFFER_CAPACITY, tcp_recv)),
+        stats: stats.clone(),
+    };
+    (sender,receiver)
+}
 
 // Manual implementation of the error casting, to wrap io::Error into a
 // cloneable Arc.
@@ -42,178 +114,87 @@ impl From<std::io::Error> for Error {
     }
 }
 
-pub struct FrameStream {
-    /// FrameStream acts as a microservice - it is running some tasks in the background.
-    /// These tasks are executed within the "service" scope (therefore they will be canceled
-    /// and terminated as soon as the outer scope terminates).
-    service: scope::Service<Error>,
-    /// Statistics about the resource usage.
-    stats: Arc<stats::Stats>,
+pub(crate) struct SharedFrameSender {
+    /// To allow independent callers to send messages, we need a mutex.
+    /// This mutex also acts as a FIFO queue for the messages to send.
+    inner: tokio::sync::Mutex<Option<SendHalf>>,
     /// Signal used to trigger background flushing of the send stream,
     /// as soon as the current batch of send calls is completed.
     flusher: tokio::sync::Notify,
-    /// send and recv halfs of the stream can be accessed independently,
-    /// but each half supports only synchronous sending/receiving.
-    /// To allow independent callers to send/recv messages, we need a mutex.
-    /// As soon as the stream becomes broken (i.e. an unrecoverable error occurs)
-    /// we want to prevent further use of the TCP stream halfs - the call which
-    /// encounters the error replaces the respective stream half with None
-    /// (that's why we use Mutex<Option<StreamHalf>>).
-    ///
-    /// An example of important case for preventing further use:
-    /// * we read/write a part of a frame, then encounter an error
-    /// * reading/writing the next frame may lead to unexpected errors which might be hard to
-    ///  diagnose.
-    send: Arc<tokio::sync::Mutex<Option<WriteHalf>>>,
-    recv: Arc<tokio::sync::Mutex<Option<ReadHalf>>>,
+    /// Statistics about the resource usage.
+    stats: Arc<stats::Stats>,
 }
 
-impl FrameStream {
-    fn new(
-        service: scope::Service<Error>,
-        stream: tcp::Stream,
-    ) -> anyhow::Result<Arc<FrameStream>> {
-        let (tcp_recv, tcp_send) = tokio::io::split(stream.stream);
+/// SharedFrameSender
+/// * sends the frame asynchronously (to avoid invalidating the stream),
+///   in case the caller of SharedFrameSender::send cancels in the middle.
+/// * flushes the constant size buffer asynchronously, which allows batching
+///   small messages before the flush.
+impl scope::ServiceTrait for SharedFrameSender {
+    type E = Error;
 
-        const READ_BUFFER_CAPACITY: usize = 8 * 1024;
-        const WRITE_BUFFER_CAPACITY: usize = 8 * 1024;
-        let s = Arc::new(Self {
-            service,
-            stats: Arc::new(stats::Stats::new(&stream.peer_addr)),
-            flusher: tokio::sync::Notify::new(),
-            send: Arc::new(tokio::sync::Mutex::new(Some(WriteHalf::with_capacity(
-                WRITE_BUFFER_CAPACITY,
-                tcp_send,
-            )))),
-            recv: Arc::new(tokio::sync::Mutex::new(Some(ReadHalf::with_capacity(
-                READ_BUFFER_CAPACITY,
-                tcp_recv,
-            )))),
-        });
-
-        // Subtask flushing the sending buffer.
-        let self_ = s.clone();
-        s.service.spawn::<()>(async move {
+    fn start(this: &scope::ServiceScope<Self>) {
+        // Subtask flushing the stream buffer.
+        scope::spawn!(this, |this| async move {
             loop {
                 // Flushing is triggered after each send().
-                ctx::wait(self_.flusher.notified()).await?;
-                // Once triggered, we take a lock on the send half of the TCP stream.
-                // Since tokio::sync::Mutex implements FIFO semantics, all send() calls
-                // already waiting in queue have priority, hence we flush only after a batch
-                // of send() calls.
-                let mut send = ctx::wait(self_.send.lock()).await?;
-                let mut inner = match send.take() {
-                    Some(it) => it,
-                    // If stream has been closed, then task is done.
-                    None => return Ok(()),
-                };
-                ctx::wait(inner.flush()).await??;
-                // If loop iteration exits early, the stream becomes broken.
-                *send = Some(inner);
+                // Since there is only one task doing the flushing,
+                // the flushing requests get deduplicated here
+                // (see `tokio::sync::Notify`).
+                ctx::wait(this.flusher.notified()).await?;
+                // Flusher needs to acquire the stream.
+                // Since tokio mutex acts as a FIFO queue, all the
+                // awaiting messages will be sent before the flushing.
+                let mut inner = ctx::wait(this.inner.lock()).await?;
+                // Failure to flush within timeout invalidates the stream.
+                or_close(&mut *inner, |inner| async {
+                    ctx::run_with_timeout(RESPONSIVENESS_TIMEOUT, async {
+                        ctx::wait(inner.flush()).await?
+                    }).await
+                }).await?;
             }
-        })?;
-        Ok(s)
+        });
+    }
+}
+
+impl SharedFrameSender {
+    fn new(sender: FrameSender) -> Self {
+        Self {
+            inner: tokio::sync::Mutex(sender.inner),
+            stats: sender.stats,
+            flusher: tokio::sync::Notify::new(),
+        }
     }
 
     /// Sends a frame over the TCP connection.
-    /// If error is returned, the message may or may not have been sent.
-    async fn send(self: &Arc<Self>, frame: Frame) -> anyhow::Result<()> {
+    /// If an error is returned, the message may or may not have been sent.
+    async fn send(this: &scope::ServiceScope<Self>, frame: Frame) -> Result<(),Error> {
         // Guard which increments the usage of resources in the stats object.
         // The usage will be decremented back as soon as the guard is dropped.
         // If creating the guard fails, it means that resource quota has been exceeded.
-        let guard = stats::SendGuard::new(self.stats.clone(), frame.0.len())?;
+        let guard = stats::SendGuard::new(this.stats.clone(), frame.0.len())?;
         // Take ownership of the send half of the TCP stream.
         // If the context is canceled before getting the stream, nothing gets send as intended.
-        let mut send = ctx::wait(self.send.clone().lock_owned()).await?;
-        // We extract the stream from the mutex guard to utilize RAII for
-        // handling unrecoverable errors: if an error occurs while sending the frame,
-        // we won't put the stream back into the guard, therefore we prevent further use of the
-        // stream.
-        let mut inner = send.take().ok_or(ErrStreamClosed)?;
-        let self_ = self.clone();
+        let mut inner = ctx::wait(this.inner.lock()).await?;
         // We execute the actual sending of the message in the background.
         // This way, even if the context gets canceled, we send the full message anyway
         // (since this is a TCP stream, sending part of the message and then giving up would
-        // invalidate the stream). Still we put a constant timeout on sending the message,
-        // after which we consider the stream broken.
-        Ok(self
-            .service
-            .spawn(ctx::run_with_timeout(RESPONSIVENESS_TIMEOUT, async move {
-                // Stats guard is moved into the sending task, so that the background resource
-                // usage is tracked appropriately.
-                let _guard = guard;
-                // NOTE: write_* are not cancel-safe technically (they might write
-                // only some of the bytes, if they return an error). Therefore
-                // any error (including ErrCanceled) invalidates the stream at this point.
-                // This WAI, just in this specific case calling `ctx::wait` on the whole task would
-                // be equally good.
-                ctx::wait(inner.write_u32_le(frame.0.len() as u32)).await??;
-                ctx::wait(inner.write_all(&frame.0[..])).await??;
-                // After sending we trigger flushing the stream.
-                // Flushing is implemented in a way that if multiple messages are sent at once
-                // flushing occurs only once. See implementation of `FramedStream::new`.
-                self_.flusher.notify_one();
-                // If sending the frame fails and exits early, the stream becomes broken.
-                *send = Some(inner);
-                Ok(())
-            }))?
-            .join()
-            .await??)
-    }
-
-    /// Receives a frame from the TCP connection.
-    /// If error is returned, a message may or may not been received.
-    async fn recv(self: &Arc<Self>) -> anyhow::Result<Frame> {
-        // Take ownership of the recv half of the TCP stream.
-        // If the context is canceled before getting the stream, nothing gets received, as intended.
-        let mut recv = ctx::wait(self.recv.clone().lock_owned()).await?;
-        // We extract the stream from the mutex guard to utilize RAII for
-        // handling unrecoverable errors: if an error occurs while receiving the frame,
-        // we won't put the stream back into the guard, therefore we prevent further use of the
-        // stream.
-        let mut inner = recv.take().ok_or(ErrStreamClosed)?;
-        let stats = self.stats.clone();
-        // We execute the actual receiving of the message in the background.
-        // This way, even if the context gets canceled, we receive the full message anyway
-        // (since this is a TCP stream, receiving part of the message and then giving up would
         // invalidate the stream).
-        Ok(self
-            .service
-            .spawn(async move {
-                // First we wait for some initial bytes.
-                // Note that we will read and drop the whole frame,
-                // if the caller context cancels even before the first byte arrives.
-                // That's good enough - optimizing the implementation to avoid dropping
-                // before receiving the first byte doesn't give us any useful guarantees.
-                // NOTE: we intentionally do not cache a Frame in FrameStream if noone is
-                // awaiting recv() - this prevents memory leaks caused by caching large unwanted
-                // messages. Still, some improvement could be made, as currently we keep the buffer
-                // until the frame is received (or until RESPONSIVENESS_TIMEOUT).
-                // Alternatively we could drop the large buffer immediately as soon as
-                // the recv() caller cancels the context and just drop the remaining incoming bytes
-                // in the background.
-                // NOTE: read_* are not cancel safe, hence any error (including ErrCanceled)
-                // invalidates the stream (WAI). However, wrapping the whole task in ctx::wait
-                // would be equivalent in this specific case.
-                let n = ctx::wait(inner.read_u32_le()).await?? as usize;
-                // Once we know how large the frame will be, we create a guard which increments
-                // the usage of resources in the stats object.
-                // The usage will be decremented back as soon as the guard is dropped.
-                // If creating the guard fails, it means that resource quota has been exceeded.
-                let _guard = stats::RecvGuard::new(stats, n)?;
-                let mut buf = vec![0; n];
-                // Once we received the first bytes, we apply a constant timeout for
-                // receiving the frame, after which we consider the stream broken.
-                ctx::run_with_timeout(
-                    RESPONSIVENESS_TIMEOUT,
-                    ctx::wait(inner.read_exact(&mut buf[..])),
-                )
-                .await??;
-                // If receiving the frame fails and exits early, the stream becomes broken.
-                *recv = Some(inner);
-                Ok(Frame(buf))
-            })?
-            .join()
-            .await??)
+        scope::spawn!(this, |this| async move {
+            or_close(&mut *inner, |this| async {
+                ctx::run_with_timeout(RESPONSIVENESS_TIMEOUT, async {
+                    // Stats guard is moved into the sending task, so that the background resource
+                    // usage is tracked appropriately.
+                    let _guard = guard;
+                    ctx::wait(inner.write_u32_le(frame.0.len() as u32)).await??;
+                    ctx::wait(inner.write_all(&frame.0[..])).await??;
+                    // After sending we trigger flushing the stream.
+                    // Flushing is implemented in a way that if multiple messages are sent at once
+                    // flushing occurs only once. See `SharedFrameSender::start`.
+                    inner.flusher.notify();
+                    anyhow::Ok(())
+                }).await
+            }).await
+        }).join().await??
     }
 }

--- a/chain/network/src/peer_manager/connection/stream/mod.rs
+++ b/chain/network/src/peer_manager/connection/stream/mod.rs
@@ -11,6 +11,9 @@ pub(crate) mod stats;
 #[cfg(test)]
 mod tests;
 
+/// If sending/receiving a message takes more than `RESPONSIVENESS_TIMEOUT`, we consider the stream broken.
+const RESPONSIVENESS_TIMEOUT: time::Duration = time::Duration::minutes(1);
+
 type ReadHalf = tokio::io::BufReader<tokio::io::ReadHalf<tokio::net::TcpStream>>;
 type WriteHalf = tokio::io::BufWriter<tokio::io::WriteHalf<tokio::net::TcpStream>>;
 
@@ -25,10 +28,14 @@ pub(crate) enum Error {
     Canceled(#[from] ctx::ErrCanceled),
     #[error(transparent)]
     Stats(#[from] stats::Error),
-    #[error("Stream has been closed")]
-    StreamClosed,
 }
 
+#[derive(thiserror::Error, Debug)]
+#[error("Stream has been closed")]
+pub(crate) struct ErrStreamClosed;
+
+// Manual implementation of the error casting, to wrap io::Error into a
+// cloneable Arc.
 impl From<std::io::Error> for Error {
     fn from(err: std::io::Error) -> Error {
         Error::IO(Arc::new(err))
@@ -36,9 +43,27 @@ impl From<std::io::Error> for Error {
 }
 
 pub struct FrameStream {
+    /// FrameStream acts as a microservice - it is running some tasks in the background.
+    /// These tasks are executed within the "service" scope (therefore they will be canceled
+    /// and terminated as soon as the outer scope terminates).
     service: scope::Service<Error>,
+    /// Statistics about the resource usage.
     stats: Arc<stats::Stats>,
+    /// Signal used to trigger background flushing of the send stream,
+    /// as soon as the current batch of send calls is completed.
     flusher: tokio::sync::Notify,
+    /// send and recv halfs of the stream can be accessed independently,
+    /// but each half supports only synchronous sending/receiving.
+    /// To allow independent callers to send/recv messages, we need a mutex.
+    /// As soon as the stream becomes broken (i.e. an unrecoverable error occurs)
+    /// we want to prevent further use of the TCP stream halfs - the call which
+    /// encounters the error replaces the respective stream half with None
+    /// (that's why we use Mutex<Option<StreamHalf>>).
+    ///
+    /// An example of important case for preventing further use:
+    /// * we read/write a part of a frame, then encounter an error
+    /// * reading/writing the next frame may lead to unexpected errors which might be hard to
+    ///  diagnose.
     send: Arc<tokio::sync::Mutex<Option<WriteHalf>>>,
     recv: Arc<tokio::sync::Mutex<Option<ReadHalf>>>,
 }
@@ -70,9 +95,18 @@ impl FrameStream {
         let self_ = s.clone();
         s.service.spawn::<()>(async move {
             loop {
+                // Flushing is triggered after each send().
                 ctx::wait(self_.flusher.notified()).await?;
+                // Once triggered, we take a lock on the send half of the TCP stream.
+                // Since tokio::sync::Mutex implements FIFO semantics, all send() calls
+                // already waiting in queue have priority, hence we flush only after a batch
+                // of send() calls.
                 let mut send = ctx::wait(self_.send.lock()).await?;
-                let mut inner = send.take().ok_or(Error::StreamClosed)?;
+                let mut inner = match send.take() {
+                    Some(it) => it,
+                    // If stream has been closed, then task is done.
+                    None => return Ok(()),
+                };
                 ctx::wait(inner.flush()).await??;
                 // If loop iteration exits early, the stream becomes broken.
                 *send = Some(inner);
@@ -84,16 +118,40 @@ impl FrameStream {
     /// Sends a frame over the TCP connection.
     /// If error is returned, the message may or may not have been sent.
     async fn send(self: &Arc<Self>, frame: Frame) -> anyhow::Result<()> {
+        // Guard which increments the usage of resources in the stats object.
+        // The usage will be decremented back as soon as the guard is dropped.
+        // If creating the guard fails, it means that resource quota has been exceeded.
         let guard = stats::SendGuard::new(self.stats.clone(), frame.0.len())?;
+        // Take ownership of the send half of the TCP stream.
+        // If the context is canceled before getting the stream, nothing gets send as intended.
         let mut send = ctx::wait(self.send.clone().lock_owned()).await?;
-        let mut inner = send.take().ok_or(Error::StreamClosed)?;
+        // We extract the stream from the mutex guard to utilize RAII for
+        // handling unrecoverable errors: if an error occurs while sending the frame,
+        // we won't put the stream back into the guard, therefore we prevent further use of the
+        // stream.
+        let mut inner = send.take().ok_or(ErrStreamClosed)?;
         let self_ = self.clone();
+        // We execute the actual sending of the message in the background.
+        // This way, even if the context gets canceled, we send the full message anyway
+        // (since this is a TCP stream, sending part of the message and then giving up would
+        // invalidate the stream). Still we put a constant timeout on sending the message,
+        // after which we consider the stream broken.
         Ok(self
             .service
-            .spawn(ctx::run_with_timeout(time::Duration::minutes(1), async move {
+            .spawn(ctx::run_with_timeout(RESPONSIVENESS_TIMEOUT, async move {
+                // Stats guard is moved into the sending task, so that the background resource
+                // usage is tracked appropriately.
                 let _guard = guard;
+                // NOTE: write_* are not cancel-safe technically (they might write
+                // only some of the bytes, if they return an error). Therefore
+                // any error (including ErrCanceled) invalidates the stream at this point.
+                // This WAI, just in this specific case calling `ctx::wait` on the whole task would
+                // be equally good.
                 ctx::wait(inner.write_u32_le(frame.0.len() as u32)).await??;
                 ctx::wait(inner.write_all(&frame.0[..])).await??;
+                // After sending we trigger flushing the stream.
+                // Flushing is implemented in a way that if multiple messages are sent at once
+                // flushing occurs only once. See implementation of `FramedStream::new`.
                 self_.flusher.notify_one();
                 // If this task exits early, the stream becomes broken.
                 *send = Some(inner);
@@ -109,18 +167,41 @@ impl FrameStream {
     // then dropped. If that semantics is not OK, we can use tokio::sync::mpsc channel instead.
     // reserve_owned() function will allow us to avoid receiving messages that are not awaited yet.
     async fn recv(self: &Arc<Self>) -> anyhow::Result<Frame> {
+        // Take ownership of the recv half of the TCP stream.
+        // If the context is canceled before getting the stream, nothing gets received, as intended.
         let mut recv = ctx::wait(self.recv.clone().lock_owned()).await?;
-        let mut inner = recv.take().ok_or(Error::StreamClosed)?;
+        // We extract the stream from the mutex guard to utilize RAII for
+        // handling unrecoverable errors: if an error occurs while receiving the frame,
+        // we won't put the stream back into the guard, therefore we prevent further use of the
+        // stream.
+        let mut inner = recv.take().ok_or(ErrStreamClosed)?;
         let stats = self.stats.clone();
+        // We execute the actual receiving of the message in the background.
+        // This way, even if the context gets canceled, we receive the full message anyway
+        // (since this is a TCP stream, receiving part of the message and then giving up would
+        // invalidate the stream).
         Ok(self
             .service
             .spawn(async move {
+                // First we wait for some initial bytes.
+                // Note that we will read and drop the whole frame,
+                // if the caller context cancels even before the first byte arrives.
+                // That's good enough - optimizing the implementation to avoid dropping
+                // before receiving the first byte doesn't give us any useful guarantees.
+                // NOTE: read_* are not cancel safe, hence any error (including ErrCanceled)
+                // invalidates the stream (WAI). However, wrapping the whole task in ctx::wait
+                // would be equivalent in this specific case.
                 let n = ctx::wait(inner.read_u32_le()).await?? as usize;
+                // Once we know how large the frame will be, we create a guard which increments
+                // the usage of resources in the stats object.
+                // The usage will be decremented back as soon as the guard is dropped.
+                // If creating the guard fails, it means that resource quota has been exceeded.
                 let _guard = stats::RecvGuard::new(stats, n)?;
                 let mut buf = vec![0; n];
-                // Timeout on message transmission.
+                // Once we received the first bytes, we apply a constant timeout for
+                // receiving the frame, after which we consider the stream broken.
                 ctx::run_with_timeout(
-                    time::Duration::minutes(1),
+                    RESPONSIVENESS_TIMEOUT,
                     ctx::wait(inner.read_exact(&mut buf[..])),
                 )
                 .await??;

--- a/chain/network/src/peer_manager/connection/stream/mod.rs
+++ b/chain/network/src/peer_manager/connection/stream/mod.rs
@@ -26,7 +26,7 @@ pub(crate) enum Error {
 }
 
 impl From<std::io::Error> for Error {
-    fn from(err: std::io::Error) -> Error{
+    fn from(err: std::io::Error) -> Error {
         Error::IO(Arc::new(err))
     }
 }

--- a/chain/network/src/peer_manager/connection/stream/stats.rs
+++ b/chain/network/src/peer_manager/connection/stream/stats.rs
@@ -119,7 +119,7 @@ impl Stats {
             ),
             recv_msg_size_metric: metrics::MetricGuard::new(
                 &metrics::PEER_MSG_SIZE_BYTES,
-                labels.clone(),
+                labels,
             ),
         }
     }

--- a/chain/network/src/peer_manager/connection/stream/stats.rs
+++ b/chain/network/src/peer_manager/connection/stream/stats.rs
@@ -1,5 +1,6 @@
 use crate::concurrency::ctx;
 use crate::stats::metrics;
+use crate::tcp;
 use bytesize::{GIB, MIB};
 use near_primitives::time;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -77,6 +78,7 @@ impl WindowMetric {
 }
 
 pub(crate) struct Stats {
+    pub info: tcp::StreamInfo,
     /// Number of messages received since the last reset of the counter.
     pub received_messages: Arc<Mutex<WindowMetric>>,
     /// Avg received bytes/s, based on the last few minutes of traffic.
@@ -96,9 +98,10 @@ pub(crate) struct Stats {
 }
 
 impl Stats {
-    pub fn new(peer_addr: &std::net::SocketAddr) -> Self {
-        let labels = vec![peer_addr.to_string()];
+    pub fn new(info: tcp::StreamInfo) -> Self {
+        let labels = vec![info.peer_addr.to_string()];
         Self {
+            info,
             received_messages: Arc::new(Mutex::new(WindowMetric::new(
                 10,
                 time::Duration::minutes(1),
@@ -179,11 +182,13 @@ impl RecvGuard {
 
 impl Drop for RecvGuard {
     fn drop(&mut self) {
-        metrics::PEER_MSG_READ_LATENCY
-            .observe((ctx::time::now() - self.start_time).as_seconds_f64());
         self.stats.recv_buf_size_metric.set(0);
         self.stats.recv_msg_size_metric.observe(self.frame_size as f64);
         self.stats.received_messages.lock().unwrap().observe(1);
         self.stats.received_bytes.lock().unwrap().observe(self.frame_size as u64);
+        metrics::PEER_DATA_RECEIVED_BYTES.inc_by(self.frame_size as u64);
+        metrics::PEER_MESSAGE_RECEIVED_TOTAL.inc();
+        metrics::PEER_MSG_READ_LATENCY
+            .observe((ctx::time::now() - self.start_time).as_seconds_f64());
     }
 }

--- a/chain/network/src/peer_manager/connection/stream/stats.rs
+++ b/chain/network/src/peer_manager/connection/stream/stats.rs
@@ -1,0 +1,192 @@
+use crate::concurrency::ctx;
+use crate::stats::metrics;
+use bytesize::{GIB, MIB};
+use near_primitives::time;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+/// Maximum size of network message in encoded format.
+/// We encode length as `u32`, and therefore maximum size can't be larger than `u32::MAX`.
+const MESSAGE_MAX_BYTES: usize = 512 * MIB as usize;
+/// Maximum capacity of write buffer in bytes.
+const SEND_QUEUE_MAX_BYTES: usize = GIB as usize;
+
+#[derive(thiserror::Error, Debug, Clone)]
+pub(crate) enum Error {
+    #[error("send queue is full")]
+    SendQueueFull,
+    #[error("message too large: got {got_bytes}B, want <={want_max_bytes}B")]
+    MessageTooLarge { got_bytes: usize, want_max_bytes: usize },
+}
+
+pub(crate) struct WindowMetric {
+    buckets: Vec<u64>,
+    current_bucket: usize,
+    current_time: time::Instant,
+    window_size: time::Duration,
+    bucket_size: time::Duration,
+    total: u64,
+    window: u64,
+}
+
+impl WindowMetric {
+    pub fn new(buckets: usize, window_size: time::Duration) -> Self {
+        Self {
+            current_time: ctx::time::now(),
+            current_bucket: 0,
+            buckets: vec![0; buckets + 1],
+            window_size,
+            bucket_size: window_size / (buckets as f64),
+            total: 0,
+            window: 0,
+        }
+    }
+
+    pub fn observe(&mut self, sample: u64) {
+        self.roll();
+        self.total += sample;
+        self.buckets[self.current_bucket] += sample;
+    }
+
+    pub fn rate_per_sec(&mut self) -> f64 {
+        self.roll();
+        (self.total as f64) / self.window_size.as_seconds_f64()
+    }
+
+    pub fn total(&self) -> u64 {
+        self.total
+    }
+
+    fn roll(&mut self) {
+        let now = ctx::time::now();
+        if self.current_time + self.window_size < now {
+            self.current_time = now;
+            for b in &mut self.buckets {
+                *b = 0;
+            }
+            self.window = 0;
+        }
+        while self.current_time + self.bucket_size < now {
+            self.window += self.buckets[self.current_bucket];
+            self.current_bucket = (self.current_bucket + 1) % self.buckets.len();
+            self.window -= self.buckets[self.current_bucket];
+            self.buckets[self.current_bucket] = 0;
+            self.current_time += self.bucket_size;
+        }
+    }
+}
+
+pub(crate) struct Stats {
+    /// Number of messages received since the last reset of the counter.
+    pub received_messages: Arc<Mutex<WindowMetric>>,
+    /// Avg received bytes/s, based on the last few minutes of traffic.
+    pub received_bytes: Arc<Mutex<WindowMetric>>,
+    /// Avg sent bytes/s, based on the last few minutes of traffic.
+    pub sent_bytes: Arc<Mutex<WindowMetric>>,
+
+    /// Number of messages in the buffer to send.
+    pub messages_to_send: AtomicU64,
+    /// Number of bytes (sum of message sizes) in the buffer to send.
+    pub bytes_to_send: AtomicU64,
+
+    /// metrics
+    send_buf_size_metric: metrics::IntGaugeGuard,
+    recv_buf_size_metric: metrics::IntGaugeGuard,
+    recv_msg_size_metric: metrics::HistogramGuard,
+}
+
+impl Stats {
+    pub fn new(peer_addr: &std::net::SocketAddr) -> Self {
+        let labels = vec![peer_addr.to_string()];
+        Self {
+            received_messages: Arc::new(Mutex::new(WindowMetric::new(
+                10,
+                time::Duration::minutes(1),
+            ))),
+            sent_bytes: Arc::new(Mutex::new(WindowMetric::new(10, time::Duration::minutes(1)))),
+            received_bytes: Arc::new(Mutex::new(WindowMetric::new(10, time::Duration::minutes(1)))),
+
+            messages_to_send: AtomicU64::new(0),
+            bytes_to_send: AtomicU64::new(0),
+
+            send_buf_size_metric: metrics::MetricGuard::new(
+                &*metrics::PEER_DATA_WRITE_BUFFER_SIZE,
+                labels.clone(),
+            ),
+            recv_buf_size_metric: metrics::MetricGuard::new(
+                &metrics::PEER_DATA_READ_BUFFER_SIZE,
+                labels.clone(),
+            ),
+            recv_msg_size_metric: metrics::MetricGuard::new(
+                &metrics::PEER_MSG_SIZE_BYTES,
+                labels.clone(),
+            ),
+        }
+    }
+}
+
+pub(crate) struct SendGuard {
+    stats: Arc<Stats>,
+    frame_size: usize,
+}
+
+impl SendGuard {
+    pub fn new(stats: Arc<Stats>, frame_size: usize) -> Result<SendGuard, Error> {
+        if frame_size > MESSAGE_MAX_BYTES {
+            metrics::MessageDropped::InputTooLong.inc_unknown_msg();
+            return Err(Error::MessageTooLarge {
+                got_bytes: frame_size,
+                want_max_bytes: MESSAGE_MAX_BYTES,
+            });
+        }
+        let buf_size = stats.bytes_to_send.fetch_add(frame_size as u64, Ordering::Relaxed) as usize
+            + frame_size;
+        if buf_size > SEND_QUEUE_MAX_BYTES {
+            metrics::MessageDropped::MaxCapacityExceeded.inc_unknown_msg();
+            stats.bytes_to_send.fetch_sub(frame_size as u64, Ordering::Relaxed);
+            return Err(Error::SendQueueFull);
+        }
+        stats.messages_to_send.fetch_add(1, Ordering::Relaxed);
+        stats.send_buf_size_metric.add(frame_size as i64);
+        Ok(Self { stats, frame_size })
+    }
+}
+
+impl Drop for SendGuard {
+    fn drop(&mut self) {
+        self.stats.send_buf_size_metric.sub(self.frame_size as i64);
+        self.stats.messages_to_send.fetch_sub(1, Ordering::Relaxed);
+        self.stats.bytes_to_send.fetch_sub(self.frame_size as u64, Ordering::Relaxed);
+        self.stats.sent_bytes.lock().unwrap().observe(self.frame_size as u64);
+    }
+}
+
+pub(super) struct RecvGuard {
+    stats: Arc<Stats>,
+    start_time: time::Instant,
+    frame_size: usize,
+}
+
+impl RecvGuard {
+    pub fn new(stats: Arc<Stats>, frame_size: usize) -> Result<RecvGuard, Error> {
+        if frame_size > MESSAGE_MAX_BYTES {
+            return Err(Error::MessageTooLarge {
+                got_bytes: frame_size,
+                want_max_bytes: MESSAGE_MAX_BYTES,
+            });
+        }
+        stats.recv_buf_size_metric.set(frame_size as i64);
+        Ok(Self { stats, start_time: ctx::time::now(), frame_size })
+    }
+}
+
+impl Drop for RecvGuard {
+    fn drop(&mut self) {
+        metrics::PEER_MSG_READ_LATENCY
+            .observe((ctx::time::now() - self.start_time).as_seconds_f64());
+        self.stats.recv_buf_size_metric.set(0);
+        self.stats.recv_msg_size_metric.observe(self.frame_size as f64);
+        self.stats.received_messages.lock().unwrap().observe(1);
+        self.stats.received_bytes.lock().unwrap().observe(self.frame_size as u64);
+    }
+}

--- a/chain/network/src/peer_manager/connection/stream/stats.rs
+++ b/chain/network/src/peer_manager/connection/stream/stats.rs
@@ -117,10 +117,7 @@ impl Stats {
                 &metrics::PEER_DATA_READ_BUFFER_SIZE,
                 labels.clone(),
             ),
-            recv_msg_size_metric: metrics::MetricGuard::new(
-                &metrics::PEER_MSG_SIZE_BYTES,
-                labels,
-            ),
+            recv_msg_size_metric: metrics::MetricGuard::new(&metrics::PEER_MSG_SIZE_BYTES, labels),
         }
     }
 }

--- a/chain/network/src/peer_manager/connection/stream/tests.rs
+++ b/chain/network/src/peer_manager/connection/stream/tests.rs
@@ -1,0 +1,92 @@
+use crate::actix::ActixSystem;
+use crate::network_protocol::testonly as data;
+use crate::peer::stream;
+use crate::tcp;
+use crate::testonly::make_rng;
+use actix::Actor as _;
+use actix::ActorContext as _;
+use rand::Rng as _;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+
+struct Actor {
+    stream: stream::FramedStream<Actor>,
+    queue_send: mpsc::UnboundedSender<stream::Frame>,
+}
+
+impl actix::Actor for Actor {
+    type Context = actix::Context<Actor>;
+}
+
+#[derive(actix::Message)]
+#[rtype("()")]
+struct SendFrame(stream::Frame);
+
+impl actix::Handler<SendFrame> for Actor {
+    type Result = ();
+    fn handle(&mut self, SendFrame(frame): SendFrame, _ctx: &mut Self::Context) {
+        self.stream.send(frame);
+    }
+}
+
+impl actix::Handler<stream::Frame> for Actor {
+    type Result = ();
+    fn handle(&mut self, frame: stream::Frame, _ctx: &mut Self::Context) {
+        self.queue_send.send(frame).ok().unwrap();
+    }
+}
+
+impl actix::Handler<stream::Error> for Actor {
+    type Result = ();
+    fn handle(&mut self, _err: stream::Error, ctx: &mut Self::Context) {
+        ctx.stop();
+    }
+}
+
+struct Handler {
+    queue_recv: mpsc::UnboundedReceiver<stream::Frame>,
+    system: ActixSystem<Actor>,
+}
+
+impl Actor {
+    async fn spawn(s: tcp::Stream) -> Handler {
+        let (queue_send, queue_recv) = mpsc::unbounded_channel();
+        Handler {
+            queue_recv,
+            system: ActixSystem::spawn(|| {
+                Actor::create(|ctx| {
+                    let stream = stream::FramedStream::spawn(ctx, s, Arc::default());
+                    Self { stream, queue_send }
+                })
+            })
+            .await,
+        }
+    }
+}
+
+#[tokio::test]
+async fn send_recv() {
+    let mut rng = make_rng(98324532);
+    let (s1, s2) = tcp::Stream::loopback(data::make_peer_id(&mut rng), tcp::Tier::T2).await;
+    let a1 = Actor::spawn(s1).await;
+    let mut a2 = Actor::spawn(s2).await;
+
+    for _ in 0..5 {
+        let n = rng.gen_range(1..10);
+        let msgs: Vec<_> = (0..n)
+            .map(|_| {
+                let size = rng.gen_range(0..10000);
+                let mut msg = vec![0; size];
+                rng.fill(&mut msg[..]);
+                stream::Frame(msg)
+            })
+            .collect();
+        for msg in &msgs {
+            a1.system.addr.send(SendFrame(msg.clone())).await.unwrap();
+        }
+        for want in &msgs {
+            let got = a2.queue_recv.recv().await.unwrap();
+            assert_eq!(&got, want);
+        }
+    }
+}

--- a/chain/network/src/peer_manager/connection/stream/tests.rs
+++ b/chain/network/src/peer_manager/connection/stream/tests.rs
@@ -5,45 +5,40 @@ use crate::tcp;
 use crate::testonly::abort_on_panic;
 use crate::testonly::make_rng;
 use rand::Rng as _;
-use std::sync::Arc;
 
 #[tokio::test]
 async fn send_recv() {
     const OK: Result<(), ()> = Ok(());
     abort_on_panic();
     let mut rng = make_rng(98324532);
-    scope::run!(|s| async {
-        let (s1, s2) = tcp::Stream::loopback(data::make_peer_id(&mut rng), tcp::Tier::T2).await;
-        let s1 = Arc::new(stream::FrameStream::new(s.new_service(), s1).unwrap());
-        let s2 = Arc::new(stream::FrameStream::new(s.new_service(), s2).unwrap());
-        for _ in 0..5 {
-            let n = rng.gen_range(1..10);
-            let msgs: Vec<_> = (0..n)
-                .map(|_| {
-                    let size = rng.gen_range(0..10000);
-                    let mut msg = vec![0; size];
-                    rng.fill(&mut msg[..]);
-                    stream::Frame(msg)
-                })
-                .collect();
-            scope::run!(|s| async {
-                s.spawn(async {
-                    for msg in &msgs {
-                        s1.send(msg.clone()).await.unwrap();
-                    }
-                    OK
-                });
-                s.spawn(async {
-                    for msg in &msgs {
-                        assert_eq!(msg, &s2.recv().await.unwrap());
-                    }
-                    OK
-                });
-                OK
+    let (s1, s2) = tcp::Stream::loopback(data::make_peer_id(&mut rng), tcp::Tier::T2).await;
+    let (mut s1send, _) = stream::split(s1);
+    let (_, mut s2recv) = stream::split(s2);
+    for _ in 0..5 {
+        let n = rng.gen_range(1..10);
+        let msgs: Vec<_> = (0..n)
+            .map(|_| {
+                let size = rng.gen_range(0..10000);
+                let mut msg = vec![0; size];
+                rng.fill(&mut msg[..]);
+                stream::Frame(msg)
             })
-            .unwrap();
-        }
-        OK
-    })
-    .unwrap();
+            .collect();
+        scope::run!(|s| async {
+            s.spawn(async {
+                for msg in &msgs {
+                    s1send.send(&msg).await.unwrap();
+                }
+                OK
+            });
+            s.spawn(async {
+                for msg in &msgs {
+                    assert_eq!(msg, &s2recv.recv().await.unwrap());
+                }
+                OK
+            });
+            OK
+        })
+        .unwrap();
+    }
 }

--- a/chain/network/src/peer_manager/connection/stream/tests.rs
+++ b/chain/network/src/peer_manager/connection/stream/tests.rs
@@ -1,92 +1,49 @@
-use crate::actix::ActixSystem;
+use crate::concurrency::scope;
 use crate::network_protocol::testonly as data;
-use crate::peer::stream;
+use crate::peer_manager::connection::stream;
 use crate::tcp;
+use crate::testonly::abort_on_panic;
 use crate::testonly::make_rng;
-use actix::Actor as _;
-use actix::ActorContext as _;
 use rand::Rng as _;
 use std::sync::Arc;
-use tokio::sync::mpsc;
-
-struct Actor {
-    stream: stream::FramedStream<Actor>,
-    queue_send: mpsc::UnboundedSender<stream::Frame>,
-}
-
-impl actix::Actor for Actor {
-    type Context = actix::Context<Actor>;
-}
-
-#[derive(actix::Message)]
-#[rtype("()")]
-struct SendFrame(stream::Frame);
-
-impl actix::Handler<SendFrame> for Actor {
-    type Result = ();
-    fn handle(&mut self, SendFrame(frame): SendFrame, _ctx: &mut Self::Context) {
-        self.stream.send(frame);
-    }
-}
-
-impl actix::Handler<stream::Frame> for Actor {
-    type Result = ();
-    fn handle(&mut self, frame: stream::Frame, _ctx: &mut Self::Context) {
-        self.queue_send.send(frame).ok().unwrap();
-    }
-}
-
-impl actix::Handler<stream::Error> for Actor {
-    type Result = ();
-    fn handle(&mut self, _err: stream::Error, ctx: &mut Self::Context) {
-        ctx.stop();
-    }
-}
-
-struct Handler {
-    queue_recv: mpsc::UnboundedReceiver<stream::Frame>,
-    system: ActixSystem<Actor>,
-}
-
-impl Actor {
-    async fn spawn(s: tcp::Stream) -> Handler {
-        let (queue_send, queue_recv) = mpsc::unbounded_channel();
-        Handler {
-            queue_recv,
-            system: ActixSystem::spawn(|| {
-                Actor::create(|ctx| {
-                    let stream = stream::FramedStream::spawn(ctx, s, Arc::default());
-                    Self { stream, queue_send }
-                })
-            })
-            .await,
-        }
-    }
-}
 
 #[tokio::test]
 async fn send_recv() {
+    const OK: Result<(), ()> = Ok(());
+    abort_on_panic();
     let mut rng = make_rng(98324532);
-    let (s1, s2) = tcp::Stream::loopback(data::make_peer_id(&mut rng), tcp::Tier::T2).await;
-    let a1 = Actor::spawn(s1).await;
-    let mut a2 = Actor::spawn(s2).await;
-
-    for _ in 0..5 {
-        let n = rng.gen_range(1..10);
-        let msgs: Vec<_> = (0..n)
-            .map(|_| {
-                let size = rng.gen_range(0..10000);
-                let mut msg = vec![0; size];
-                rng.fill(&mut msg[..]);
-                stream::Frame(msg)
+    scope::run!(|s| async {
+        let (s1, s2) = tcp::Stream::loopback(data::make_peer_id(&mut rng), tcp::Tier::T2).await;
+        let s1 = Arc::new(stream::FrameStream::new(s.new_service(), s1).unwrap());
+        let s2 = Arc::new(stream::FrameStream::new(s.new_service(), s2).unwrap());
+        for _ in 0..5 {
+            let n = rng.gen_range(1..10);
+            let msgs: Vec<_> = (0..n)
+                .map(|_| {
+                    let size = rng.gen_range(0..10000);
+                    let mut msg = vec![0; size];
+                    rng.fill(&mut msg[..]);
+                    stream::Frame(msg)
+                })
+                .collect();
+            scope::run!(|s| async {
+                s.spawn(async {
+                    for msg in &msgs {
+                        s1.send(msg.clone()).await.unwrap();
+                    }
+                    OK
+                });
+                s.spawn(async {
+                    for msg in &msgs {
+                        assert_eq!(msg, &s2.recv().await.unwrap());
+                    }
+                    OK
+                });
+                OK
             })
-            .collect();
-        for msg in &msgs {
-            a1.system.addr.send(SendFrame(msg.clone())).await.unwrap();
+            .unwrap();
         }
-        for want in &msgs {
-            let got = a2.queue_recv.recv().await.unwrap();
-            assert_eq!(&got, want);
-        }
-    }
+        OK
+    })
+    .unwrap();
 }

--- a/chain/network/src/stats/metrics.rs
+++ b/chain/network/src/stats/metrics.rs
@@ -106,6 +106,7 @@ impl<M: prometheus::core::Metric> std::ops::Deref for MetricGuard<M> {
 }
 
 pub(crate) type IntGaugeGuard = MetricGuard<prometheus::IntGauge>;
+pub(crate) type HistogramGuard = MetricGuard<prometheus::Histogram>;
 
 pub static PEER_CONNECTIONS: Lazy<Gauge<Connection>> =
     Lazy::new(|| Gauge::new("near_peer_connections", "Number of connected peers").unwrap());


### PR DESCRIPTION
The new implementation is located in peer_manager/connection/stream . It should be functionally equivalent to peer/stream . For now those two coexist - the new implementation is unused, but once the refactor is complete, the old implementation will be removed.

While at it, I realized that I have to revamp scope::Service semantics and implementation, as the original one turned out to be unusable: Service lifetime is bounded by the scope, however service error shouldn't cancel the scope automatically: take a specific example: if a connection to a single peer dies (a service terminates with an error), it doesn't mean that the whole server should shut down. The reason why the connection died should be observed and registered accordingly, but scope should be able to continue operating.

Disclaimer: next steps of the refactor might inspire further changes to the Scope framework.