### PR TITLE
Update .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,3 +20,6 @@ sandbox/
 .dockerignore
 Dockerfile
 Dockerfile.nightly
+
+# Ignore git internal structure
+.git/


### PR DESCRIPTION
This change prevents internal contents of a this git repository from being copied into the context of a docker image.