### PR TITLE
Feat: Adding release fuzz builder workflow

### DIFF
--- a/.github/workflows/master_fuzzer_binaries.yml
+++ b/.github/workflows/master_fuzzer_binaries.yml
@@ -1,0 +1,47 @@
+name: Build @master fuzzers
+on:
+  schedule:
+    # Run once a day, at midnight
+    - cron: "0 0 * * *"
+  # TODO - remove. Used for testing WF
+  push:
+
+jobs:
+  build_fuzzers:
+    runs-on: "ubuntu-20.04"
+
+    permissions:
+      contents: "read"
+      id-token: "write"
+
+    steps:
+      - id: "auth"
+        uses: "google-github-actions/auth@v1"
+        with:
+          workload_identity_provider: "projects/968400232856/locations/global/workloadIdentityPools/project-identity-pool/providers/github-provider"
+          service_account: "near-fuzzer-service-account@near-fuzzer.iam.gserviceaccount.com"
+
+      - uses: hecrj/setup-rust-action@v1
+        with:
+          rust-version: nightly
+
+      - name: Set swap space to 10G
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 10
+
+      - name: Install cargo fuzz subcommand crate
+        run: cargo install cargo-fuzz
+
+      - run: rustup target add --toolchain nightly wasm32-unknown-unknown
+
+      - name: "Set up GCP SDK"
+        uses: "google-github-actions/setup-gcloud@v1"
+        with:
+          version: ">= 416.0.0"
+
+      - uses: actions/checkout@master
+
+      - run: pip install -r scripts/build_fuzzers_requirements.txt
+
+      - run: python3 scripts/build_fuzzers.py master

--- a/.github/workflows/master_fuzzer_binaries.yml
+++ b/.github/workflows/master_fuzzer_binaries.yml
@@ -3,8 +3,6 @@ on:
   schedule:
     # Run once a day, at midnight
     - cron: "0 0 * * *"
-  # TODO - remove. Used for testing WF
-  push:
 
 jobs:
   build_fuzzers:

--- a/.github/workflows/release_fuzzer_binaries
+++ b/.github/workflows/release_fuzzer_binaries
@@ -1,8 +1,8 @@
-name: Build @master fuzzers
+name: Build Release fuzzers
 on:
-  schedule:
-    # Run once a day, at midnight
-    - cron: "0 0 * * *"
+  # Run when a new release is published
+  release:
+    types: [published]
 
 jobs:
   build_fuzzers:
@@ -42,4 +42,4 @@ jobs:
 
       - run: pip install -r scripts/build_fuzzers_requirements.txt
 
-      - run: python3 scripts/build_fuzzers.py
+      - run: python3 scripts/build_fuzzers.py release

--- a/scripts/build_fuzzers.py
+++ b/scripts/build_fuzzers.py
@@ -2,36 +2,35 @@ import logging
 import os
 import re
 import subprocess
+import sys
 import tarfile
 import time
 
 import toml
 
 REPO_DIR = '/home/runner/work/nearcore/nearcore/'
-G_BUCKET = 'gs://fuzzer_targets/master/'
+G_BUCKET = 'gs://fuzzer_targets/{}/'
 ARCH_CONFIG_NAME = 'x86_64-unknown-linux-gnu'
 BUILDER_START_TIME = time.strftime('%Y%m%d%H%M%S', time.gmtime())
-TAR_NAME = f'nearcore-master-{BUILDER_START_TIME}.tar.gz'
+TAR_NAME = 'nearcore-{}-{}.tar.gz'
 ENV = os.environ
 # Default lto="fat" will cause rustc builder to use ~35GB of memory
 # This reduces memory usage to <10GB
 ENV.update({'RUSTFLAGS': "-C lto=thin"})
 
 
-def push_to_google_bucket(archive_name: str) -> None:
+def push_to_google_bucket(archive_name: str, branch: str) -> None:
     try:
-        subprocess.run([
-            'gsutil',
-            'cp',
-            archive_name,
-            G_BUCKET,
-        ], check=True)
+        subprocess.run(['gsutil', 'cp', archive_name,
+                        G_BUCKET.format(branch)],
+                       check=True)
 
     except subprocess.CalledProcessError as e:
         logger.info(f"Failed to upload archive to Google Storage!")
 
 
-def main() -> None:
+def main(branch: str) -> None:
+    arch_name = TAR_NAME.format(branch, BUILDER_START_TIME)
     fuzz_bin_list = []
 
     crates = [i for i in toml.load('nightly/fuzz.toml')['target']]
@@ -61,14 +60,15 @@ def main() -> None:
 
     # adding to archive in 1 operation as tarfile doesn't
     # support appending to existing compressed file
-    with tarfile.open(name=TAR_NAME, mode="w:gz") as archive:
+    with tarfile.open(name=arch_name, mode="w:gz") as archive:
         for file_name in fuzz_bin_list:
             archive.add(file_name, os.path.basename(file_name))
 
-    push_to_google_bucket(TAR_NAME)
+    push_to_google_bucket(arch_name, branch)
 
 
 if __name__ == '__main__':
+    branch = sys.argv[1]
     logger = logging.getLogger()
     logging.basicConfig()
-    main()
+    main(branch)


### PR DESCRIPTION
In this PR I'm adjusting build_fuzzers script to allow specification of the conventional "branch" name.
Workflows will be calling it with either "release" or "master" arg and the resulting archive will be pushed to corresponding bucket: gs://fuzzer_targets/release/ or gs://fuzzer_targets/master/

Release fuzz building workflow will be triggered on release publish even.

Test ran successfully in https://github.com/near/nearcore/actions/runs/4292093900/jobs/7478099145