### PR TITLE
feat: use split store in the view client

### DIFF
--- a/core/store/benches/store_bench.rs
+++ b/core/store/benches/store_bench.rs
@@ -22,7 +22,7 @@ fn benchmark_write_then_read_successful(
     let store = NodeStorage::opener(tmp_dir.path(), false, &Default::default(), None)
         .open()
         .unwrap()
-        .get_store(Temperature::Hot);
+        .get_hot_store();
     let keys = generate_keys(num_keys, key_size);
     write_to_db(&store, &keys, max_value_size, col);
 

--- a/core/store/benches/store_bench.rs
+++ b/core/store/benches/store_bench.rs
@@ -3,7 +3,7 @@ extern crate bencher;
 
 use bencher::{black_box, Bencher};
 use near_primitives::errors::StorageError;
-use near_store::{DBCol, NodeStorage, Store, Temperature};
+use near_store::{DBCol, NodeStorage, Store};
 use std::time::{Duration, Instant};
 
 /// Run a benchmark to generate `num_keys` keys, each of size `key_size`, then write then

--- a/core/store/src/cold_storage.rs
+++ b/core/store/src/cold_storage.rs
@@ -174,7 +174,7 @@ pub fn copy_all_data_to_cold(
     cold_db: std::sync::Arc<ColdDB>,
     hot_store: &Store,
     batch_size: usize,
-    keep_going: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    keep_going: &std::sync::Arc<std::sync::atomic::AtomicBool>,
 ) -> io::Result<CopyAllDataToColdStatus> {
     for col in DBCol::iter() {
         if col.is_cold() {

--- a/core/store/src/cold_storage.rs
+++ b/core/store/src/cold_storage.rs
@@ -144,6 +144,13 @@ pub fn update_cold_head(
         cold_db.write(transaction)?;
     }
 
+    // Write COLD_HEAD_KEY to the cold db.
+    {
+        let mut transaction = DBTransaction::new();
+        transaction.set(DBCol::BlockMisc, COLD_HEAD_KEY.to_vec(), tip.try_to_vec()?);
+        cold_db.write(transaction)?;
+    }
+
     // Write COLD_HEAD to the hot db.
     {
         let mut transaction = DBTransaction::new();

--- a/core/store/src/db/database_tests.rs
+++ b/core/store/src/db/database_tests.rs
@@ -13,7 +13,7 @@ mod tests {
     // Returns test & rocksDB databases.
     fn test_and_rocksdb() -> Vec<Arc<dyn Database>> {
         let (_tmp_dir, opener) = NodeStorage::test_opener();
-        let store = opener.open().unwrap().get_store(crate::Temperature::Hot);
+        let store = opener.open().unwrap().get_hot_store();
         vec![TestDB::new(), store.storage.clone()]
     }
 

--- a/core/store/src/db/rocksdb.rs
+++ b/core/store/src/db/rocksdb.rs
@@ -678,7 +678,7 @@ mod tests {
     #[test]
     fn rocksdb_merge_sanity() {
         let (_tmp_dir, opener) = NodeStorage::test_opener();
-        let store = opener.open().unwrap().get_store(crate::Temperature::Hot);
+        let store = opener.open().unwrap().get_hot_store();
         let ptr = (&*store.storage) as *const (dyn Database + 'static);
         let rocksdb = unsafe { &*(ptr as *const RocksDB) };
         assert_eq!(store.get(DBCol::State, &[1]).unwrap(), None);
@@ -770,7 +770,7 @@ mod tests {
 
     #[test]
     fn test_delete_range() {
-        let store = NodeStorage::test_opener().1.open().unwrap().get_store(crate::Temperature::Hot);
+        let store = NodeStorage::test_opener().1.open().unwrap().get_hot_store();
         let keys = [vec![0], vec![1], vec![2], vec![3]];
         let column = DBCol::Block;
 

--- a/core/store/src/db/rocksdb/snapshot.rs
+++ b/core/store/src/db/rocksdb/snapshot.rs
@@ -173,7 +173,7 @@ fn test_snapshot_recovery() {
 
     // Populate some data
     {
-        let store = opener.open().unwrap().get_store(crate::Temperature::Hot);
+        let store = opener.open().unwrap().get_hot_store();
         let mut update = store.store_update();
         update.set_raw_bytes(COL, KEY, b"value");
         update.commit().unwrap();
@@ -185,7 +185,7 @@ fn test_snapshot_recovery() {
 
     // Delete the data from the database.
     {
-        let store = opener.open().unwrap().get_store(crate::Temperature::Hot);
+        let store = opener.open().unwrap().get_hot_store();
         let mut update = store.store_update();
         update.delete(COL, KEY);
         update.commit().unwrap();
@@ -198,7 +198,7 @@ fn test_snapshot_recovery() {
         let mut config = opener.config().clone();
         config.path = Some(path);
         let opener = crate::NodeStorage::opener(tmpdir.path(), false, &config, None);
-        let store = opener.open().unwrap().get_store(crate::Temperature::Hot);
+        let store = opener.open().unwrap().get_hot_store();
         assert_eq!(Some(&b"value"[..]), store.get(COL, KEY).unwrap().as_deref());
     }
 

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -954,7 +954,7 @@ impl CompiledContractCache for StoreCompiledContractCache {
 mod tests {
     use near_primitives::hash::CryptoHash;
 
-    use super::{DBCol, NodeStorage, Store, Temperature};
+    use super::{DBCol, NodeStorage, Store};
 
     #[test]
     fn test_no_cache_disabled() {

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -182,12 +182,12 @@ impl NodeStorage {
     ///
     /// This method panics if trying to access cold store but it wasn't configured.
     /// Please consider using the get_hot_store and get_cold_store methods to avoid panics.
-    pub fn get_store(&self, temp: Temperature) -> Store {
-        match temp {
-            Temperature::Hot => self.get_hot_store(),
-            Temperature::Cold => self.get_cold_store().unwrap(),
-        }
-    }
+    // pub fn get_store(&self, temp: Temperature) -> Store {
+    //     match temp {
+    //         Temperature::Hot => self.get_hot_store(),
+    //         Temperature::Cold => self.get_cold_store().unwrap(),
+    //     }
+    // }
 
     pub fn get_hot_store(&self) -> Store {
         Store { storage: self.hot_storage.clone() }
@@ -983,7 +983,7 @@ mod tests {
     #[test]
     fn clear_column_rocksdb() {
         let (_tmp_dir, opener) = NodeStorage::test_opener();
-        test_clear_column(opener.open().unwrap().get_store(Temperature::Hot));
+        test_clear_column(opener.open().unwrap().get_hot_store());
     }
 
     #[test]
@@ -1055,7 +1055,7 @@ mod tests {
     #[test]
     fn rocksdb_iter_order() {
         let (_tempdir, opener) = NodeStorage::test_opener();
-        test_iter_order_impl(opener.open().unwrap().get_store(Temperature::Hot));
+        test_iter_order_impl(opener.open().unwrap().get_hot_store());
     }
 
     #[test]

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -167,32 +167,30 @@ impl NodeStorage {
 }
 
 impl NodeStorage {
-    /// Returns storage for given temperature.
+    /// Returns the hot store. The hot store is always available and it provides
+    /// direct access to the hot database.
     ///
-    /// Some data live only in hot and some only in cold storage (which is at
-    /// the moment not implemented but is planned soon).  Hot data is anything
-    /// at the head of the chain.  Cold data, if node is configured with split
-    /// storage, is anything archival.
+    /// For RPC nodes this is the only store available and it should be used for
+    /// all the use cases.
     ///
-    /// Based on block in whose context database access are going to be made,
-    /// you will either need to access hot or cold storage.  Temperature of the
-    /// data is, simplifying slightly, determined based on height of the block.
-    /// Anything above the tail of hot storage is hot and everything else is
-    /// cold.
+    /// For archival nodes that do not have split storage configured this is the
+    /// only store available and it should be used for all the use cases.
     ///
-    /// This method panics if trying to access cold store but it wasn't configured.
-    /// Please consider using the get_hot_store and get_cold_store methods to avoid panics.
-    // pub fn get_store(&self, temp: Temperature) -> Store {
-    //     match temp {
-    //         Temperature::Hot => self.get_hot_store(),
-    //         Temperature::Cold => self.get_cold_store().unwrap(),
-    //     }
-    // }
-
+    /// For archival nodes that do have split storage configured there are three
+    /// stores available: hot, cold and split. The client should use the hot
+    /// store, the view client should use the split store and the cold store
+    /// loop should use cold store.
     pub fn get_hot_store(&self) -> Store {
         Store { storage: self.hot_storage.clone() }
     }
 
+    /// Returns the cold store. The cold store is only available in archival
+    /// nodes with split storage configured.
+    ///
+    /// For archival nodes that do have split storage configured there are three
+    /// stores available: hot, cold and split. The client should use the hot
+    /// store, the view client should use the split store and the cold store
+    /// loop should use cold store.
     pub fn get_cold_store(&self) -> Option<Store> {
         match &self.cold_storage {
             Some(cold_storage) => Some(Store { storage: cold_storage.clone() }),
@@ -200,6 +198,13 @@ impl NodeStorage {
         }
     }
 
+    /// Returns the split store. The split store is only available in archival
+    /// nodes with split storage configured.
+    ///
+    /// For archival nodes that do have split storage configured there are three
+    /// stores available: hot, cold and split. The client should use the hot
+    /// store, the view client should use the split store and the cold store
+    /// loop should use cold store.
     pub fn get_split_store(&self) -> Option<Store> {
         match &self.cold_storage {
             Some(cold_storage) => Some(Store {

--- a/core/store/src/test_utils.rs
+++ b/core/store/src/test_utils.rs
@@ -5,7 +5,7 @@ use rand::Rng;
 
 use crate::db::TestDB;
 use crate::metadata::{DbKind, DbVersion, DB_VERSION};
-use crate::{DBCol, NodeStorage, ShardTries, Store, Temperature};
+use crate::{DBCol, NodeStorage, ShardTries, Store};
 use near_primitives::account::id::AccountId;
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::{DataReceipt, Receipt, ReceiptEnum};
@@ -19,8 +19,8 @@ use std::str::from_utf8;
 pub fn create_test_node_storage(version: DbVersion, hot_kind: DbKind) -> NodeStorage {
     let storage = NodeStorage::new(TestDB::new());
 
-    storage.get_store(Temperature::Hot).set_db_version(version).unwrap();
-    storage.get_store(Temperature::Hot).set_db_kind(hot_kind).unwrap();
+    storage.get_hot_store().set_db_version(version).unwrap();
+    storage.get_hot_store().set_db_kind(hot_kind).unwrap();
 
     storage
 }
@@ -38,17 +38,17 @@ pub fn create_test_node_storage_default() -> NodeStorage {
 pub fn create_test_node_storage_with_cold(version: DbVersion, hot_kind: DbKind) -> NodeStorage {
     let storage = NodeStorage::new_with_cold(TestDB::new(), TestDB::new());
 
-    storage.get_store(Temperature::Hot).set_db_version(version).unwrap();
-    storage.get_store(Temperature::Hot).set_db_kind(hot_kind).unwrap();
-    storage.get_store(Temperature::Cold).set_db_version(version).unwrap();
-    storage.get_store(Temperature::Cold).set_db_kind(DbKind::Cold).unwrap();
+    storage.get_hot_store().set_db_version(version).unwrap();
+    storage.get_hot_store().set_db_kind(hot_kind).unwrap();
+    storage.get_cold_store().unwrap().set_db_version(version).unwrap();
+    storage.get_cold_store().unwrap().set_db_kind(DbKind::Cold).unwrap();
 
     storage
 }
 
 /// Creates an in-memory database.
 pub fn create_test_store() -> Store {
-    create_test_node_storage(DB_VERSION, DbKind::RPC).get_store(crate::Temperature::Hot)
+    create_test_node_storage(DB_VERSION, DbKind::RPC).get_hot_store()
 }
 
 /// Creates a Trie using an in-memory database.

--- a/genesis-tools/genesis-populate/src/main.rs
+++ b/genesis-tools/genesis-populate/src/main.rs
@@ -33,7 +33,7 @@ fn main() {
     )
     .open()
     .unwrap()
-    .get_store(near_store::Temperature::Hot);
+    .get_hot_store();
     GenesisBuilder::from_config_and_store(home_dir, near_config, store)
         .add_additional_accounts(additional_accounts_num)
         .add_additional_accounts_contract(near_test_contracts::trivial_contract().to_vec())

--- a/genesis-tools/genesis-populate/src/state_dump.rs
+++ b/genesis-tools/genesis-populate/src/state_dump.rs
@@ -1,7 +1,7 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_primitives::types::StateRoot;
 use near_store::db::TestDB;
-use near_store::{Store, Temperature};
+use near_store::Store;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
@@ -24,7 +24,7 @@ impl StateDump {
                 .open()
                 .unwrap()
         };
-        let store = node_storage.get_store(Temperature::Hot);
+        let store = node_storage.get_hot_store();
         let state_file = dir.join(STATE_DUMP_FILE);
         store.load_state_from_file(state_file.as_path()).expect("Failed to read state dump");
         let roots_files = dir.join(GENESIS_ROOTS_FILE);

--- a/integration-tests/src/tests/client/cold_storage.rs
+++ b/integration-tests/src/tests/client/cold_storage.rs
@@ -392,7 +392,7 @@ fn test_initial_copy_to_cold(batch_size: usize) {
         (*store.cold_db().unwrap()).clone(),
         &env.clients[0].runtime_adapter.store(),
         batch_size,
-        keep_going,
+        &keep_going,
     )
     .unwrap();
 

--- a/integration-tests/src/tests/client/cold_storage.rs
+++ b/integration-tests/src/tests/client/cold_storage.rs
@@ -18,7 +18,7 @@ use near_store::cold_storage::{
 use near_store::metadata::DbKind;
 use near_store::metadata::DB_VERSION;
 use near_store::test_utils::create_test_node_storage_with_cold;
-use near_store::{DBCol, Store, Temperature, COLD_HEAD_KEY, HEAD_KEY};
+use near_store::{DBCol, Store, COLD_HEAD_KEY, HEAD_KEY};
 use nearcore::config::GenesisExt;
 use std::collections::HashSet;
 use strum::IntoEnumIterator;
@@ -177,7 +177,7 @@ fn test_storage_after_commit_of_cold_update() {
         if col.is_cold() {
             let num_checks = check_iter(
                 &env.clients[0].runtime_adapter.store(),
-                &store.get_store(Temperature::Cold),
+                &store.get_cold_store().unwrap(),
                 col,
                 &no_check_rules,
             );
@@ -207,8 +207,8 @@ fn test_cold_db_head_update() {
     let mut chain_genesis = ChainGenesis::test();
     chain_genesis.epoch_length = epoch_length;
     let store = create_test_node_storage_with_cold(DB_VERSION, DbKind::Hot);
-    let hot_store = &store.get_store(Temperature::Hot);
-    let cold_store = &store.get_store(Temperature::Cold);
+    let hot_store = &store.get_hot_store();
+    let cold_store = &store.get_cold_store().unwrap();
     let runtime_adapter = create_nightshade_runtime_with_store(&genesis, &hot_store);
     let mut env = TestEnv::builder(chain_genesis).runtime_adapters(vec![runtime_adapter]).build();
 
@@ -327,7 +327,7 @@ fn test_cold_db_copy_with_height_skips() {
         if col.is_cold() {
             let num_checks = check_iter(
                 &env.clients[0].runtime_adapter.store(),
-                &store.get_store(Temperature::Cold),
+                &store.get_cold_store().unwrap(),
                 col,
                 &no_check_rules,
             );
@@ -402,7 +402,7 @@ fn test_initial_copy_to_cold(batch_size: usize) {
         }
         let num_checks = check_iter(
             &env.clients[0].runtime_adapter.store(),
-            &store.get_store(Temperature::Cold),
+            &store.get_cold_store().unwrap(),
             col,
             &vec![],
         );

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -79,8 +79,8 @@ use near_store::metadata::DbKind;
 use near_store::metadata::DB_VERSION;
 use near_store::test_utils::create_test_node_storage_with_cold;
 use near_store::test_utils::create_test_store;
+use near_store::NodeStorage;
 use near_store::{get, DBCol, Store, TrieChanges};
-use near_store::{NodeStorage, Temperature};
 use nearcore::config::{GenesisExt, TESTING_INIT_BALANCE, TESTING_INIT_STAKE};
 use nearcore::NEAR_BASE;
 use rand::prelude::StdRng;
@@ -1589,7 +1589,7 @@ fn test_archival_gc_common(
     let mut chain_genesis = ChainGenesis::test();
     chain_genesis.epoch_length = epoch_length;
 
-    let hot_store = &storage.get_store(Temperature::Hot);
+    let hot_store = &storage.get_hot_store();
 
     let runtime_adapter = create_nightshade_runtime_with_store(&genesis, &hot_store);
     let mut env = TestEnv::builder(chain_genesis)

--- a/integration-tests/src/tests/network/runner.rs
+++ b/integration-tests/src/tests/network/runner.rs
@@ -51,11 +51,7 @@ fn setup_network_node(
     let num_validators = validators.len() as ValidatorId;
 
     let vs = ValidatorSchedule::new().block_producers_per_epoch(vec![validators]);
-    let runtime = Arc::new(KeyValueRuntime::new_with_validators(
-        store.get_store(near_store::Temperature::Hot),
-        vs,
-        5,
-    ));
+    let runtime = Arc::new(KeyValueRuntime::new_with_validators(store.get_hot_store(), vs, 5));
     let signer = Arc::new(create_test_signer(account_id.as_str()));
     let telemetry_actor = TelemetryActor::new(TelemetryConfig::default()).start();
 

--- a/nearcore/benches/store.rs
+++ b/nearcore/benches/store.rs
@@ -36,7 +36,7 @@ fn read_trie_items(bench: &mut Bencher, shard_id: usize, mode: Mode) {
         )
         .open_in_mode(mode)
         .unwrap()
-        .get_store(Temperature::Hot);
+        .get_hot_store();
 
         let chain_store =
             ChainStore::new(store.clone(), near_config.genesis.config.genesis_height, true);

--- a/nearcore/benches/store.rs
+++ b/nearcore/benches/store.rs
@@ -6,7 +6,7 @@ use near_chain::{types::RuntimeAdapter, ChainStore, ChainStoreAccess};
 use near_chain_configs::GenesisValidationMode;
 use near_o11y::testonly::init_integration_logger;
 use near_primitives::types::StateRoot;
-use near_store::{Mode, Temperature};
+use near_store::Mode;
 use nearcore::{get_default_home, load_config, NightshadeRuntime};
 use std::time::{Duration, Instant};
 

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -337,7 +337,9 @@ pub struct Config {
     /// This feature is under development, do not use in production.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cold_store: Option<near_store::StoreConfig>,
-
+    /// Configuration for the
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub split_storage: Option<SplitStorageConfig>,
     // TODO(mina86): Remove those two altogether at some point.  We need to be
     // somewhat careful though and make sure that we don’t start silently
     // ignoring this option without users setting corresponding store option.
@@ -385,7 +387,51 @@ impl Default for Config {
             use_db_migration_snapshot: None,
             store: near_store::StoreConfig::default(),
             cold_store: None,
+            split_storage: None,
             expected_shutdown: None,
+        }
+    }
+}
+
+fn default_enable_split_storage_view_client() -> bool {
+    false
+}
+
+fn default_cold_store_initial_migration_batch_size() -> usize {
+    500_000_000
+}
+
+fn default_cold_store_initial_migration_loop_sleep_duration() -> Duration {
+    Duration::from_secs(30)
+}
+
+fn default_cold_store_loop_sleep_duration() -> Duration {
+    Duration::from_secs(1)
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+pub struct SplitStorageConfig {
+    #[serde(default = "default_enable_split_storage_view_client")]
+    pub enable_split_storage_view_client: bool,
+
+    #[serde(default = "default_cold_store_initial_migration_batch_size")]
+    pub cold_store_initial_migration_batch_size: usize,
+    #[serde(default = "default_cold_store_initial_migration_loop_sleep_duration")]
+    pub cold_store_initial_migration_loop_sleep_duration: Duration,
+
+    #[serde(default = "default_cold_store_loop_sleep_duration")]
+    pub cold_store_loop_sleep_duration: Duration,
+}
+
+impl Default for SplitStorageConfig {
+    fn default() -> Self {
+        SplitStorageConfig {
+            enable_split_storage_view_client: default_enable_split_storage_view_client(),
+            cold_store_initial_migration_batch_size:
+                default_cold_store_initial_migration_batch_size(),
+            cold_store_initial_migration_loop_sleep_duration:
+                default_cold_store_initial_migration_loop_sleep_duration(),
+            cold_store_loop_sleep_duration: default_cold_store_loop_sleep_duration(),
         }
     }
 }

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -165,6 +165,11 @@ fn get_split_store(config: &NearConfig, storage: &NodeStorage) -> anyhow::Result
         return Ok(None);
     }
 
+    // SplitStore should only be used in the view client if it is enabled.
+    if !config.config.split_storage.as_ref().map_or(false, |c| c.enable_split_storage_view_client) {
+        return Ok(None);
+    }
+
     // SplitStore should only be used if the migration is finished. The
     // migration to cold store is finished when the db kind of the hot store is
     // changed from Archive to Hot.

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -16,7 +16,8 @@ use near_primitives::time;
 
 use near_network::PeerManagerActor;
 use near_primitives::block::GenesisId;
-use near_store::{DBCol, Mode, NodeStorage, StoreOpenerError};
+use near_store::metadata::DbKind;
+use near_store::{DBCol, Mode, NodeStorage, Store, StoreOpenerError};
 use near_telemetry::TelemetryActor;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -152,6 +153,28 @@ fn open_storage(home_dir: &Path, near_config: &mut NearConfig) -> anyhow::Result
     Ok(storage)
 }
 
+// Safely get the split store while checking that all conditions to use it are met.
+fn get_split_store(config: &NearConfig, storage: &NodeStorage) -> anyhow::Result<Option<Store>> {
+    // SplitStore should only be used on archival nodes.
+    if !config.config.archive {
+        return Ok(None);
+    }
+
+    // SplitStore should only be used if cold store is configured.
+    if config.config.cold_store.is_none() {
+        return Ok(None);
+    }
+
+    // SplitStore should only be used if the migration is finished. The
+    // migration to cold store is finished when the db kind of the hot store is
+    // changed from Archive to Hot.
+    if storage.get_hot_store().get_db_kind()? != Some(DbKind::Hot) {
+        return Ok(None);
+    }
+
+    Ok(storage.get_split_store())
+}
+
 pub struct NearNode {
     pub client: Addr<ClientActor>,
     pub view_client: Addr<ViewClientActor>,
@@ -179,6 +202,15 @@ pub fn start_with_config_and_synchronization(
     let runtime =
         Arc::new(NightshadeRuntime::from_config(home_dir, store.get_hot_store(), &config));
 
+    // Get the split store. If split store is some then create a new runtime for
+    // the view client. Otherwise just re-use the existing runtime.
+    let split_store = get_split_store(&config, &store)?;
+    let view_runtime = if let Some(split_store) = split_store {
+        Arc::new(NightshadeRuntime::from_config(home_dir, split_store, &config))
+    } else {
+        runtime.clone()
+    };
+
     let cold_store_loop_handle = spawn_cold_store_loop(&config, &store, runtime.clone())?;
 
     let telemetry = TelemetryActor::new(config.telemetry_config.clone()).start();
@@ -198,7 +230,7 @@ pub fn start_with_config_and_synchronization(
     let view_client = start_view_client(
         config.validator_signer.as_ref().map(|signer| signer.validator_id().clone()),
         chain_genesis.clone(),
-        runtime.clone(),
+        view_runtime,
         network_adapter.clone().into(),
         config.client_config.clone(),
         adv.clone(),

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -1770,7 +1770,7 @@ mod test {
             minimum_stake_divisor: Option<u64>,
         ) -> Self {
             let (dir, opener) = NodeStorage::test_opener();
-            let store = opener.open().unwrap().get_store(Temperature::Hot);
+            let store = opener.open().unwrap().get_hot_store();
             let all_validators = validators.iter().fold(BTreeSet::new(), |acc, x| {
                 acc.union(&x.iter().cloned().collect()).cloned().collect()
             });

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -1581,7 +1581,7 @@ mod test {
         AccountView, CurrentEpochValidatorInfo, EpochValidatorInfo, NextEpochValidatorInfo,
         ValidatorKickoutView,
     };
-    use near_store::{flat_state, FlatStateDelta, NodeStorage, Temperature};
+    use near_store::{flat_state, FlatStateDelta, NodeStorage};
 
     use super::*;
 

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -793,7 +793,12 @@ def apply_config_changes(node_dir, client_config_change):
     # ClientConfig keys which are valid but may be missing from the config.json
     # file.  Those are often Option<T> types which are not stored in JSON file
     # when None.
-    allowed_missing_configs = ('archive', 'max_gas_burnt_view', 'rosetta_rpc')
+    allowed_missing_configs = (
+        'archive',
+        'save_trie_changes',
+        'max_gas_burnt_view',
+        'rosetta_rpc',
+    )
 
     for k, v in client_config_change.items():
         if not (k in allowed_missing_configs or k in config_json):

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -185,7 +185,7 @@ fn run_estimation(cli_args: CliArgs) -> anyhow::Result<Option<CostTable>> {
         )
         .open()
         .unwrap()
-        .get_store(near_store::Temperature::Hot);
+        .get_hot_store();
         GenesisBuilder::from_config_and_store(&state_dump_path, near_config, store)
             .add_additional_accounts(cli_args.additional_accounts_num)
             .add_additional_accounts_contract(contract_code.to_vec())

--- a/test-utils/runtime-tester/src/run_test.rs
+++ b/test-utils/runtime-tester/src/run_test.rs
@@ -46,7 +46,7 @@ impl Scenario {
         } else {
             let (tempdir, opener) = near_store::NodeStorage::test_opener();
             let store = opener.open().unwrap();
-            (Some(tempdir), store.get_store(near_store::Temperature::Hot))
+            (Some(tempdir), store.get_hot_store())
         };
 
         let mut env = TestEnv::builder(ChainGenesis::new(&genesis))

--- a/test-utils/store-validator/src/main.rs
+++ b/test-utils/store-validator/src/main.rs
@@ -38,7 +38,7 @@ fn main() {
     )
     .open()
     .unwrap()
-    .get_store(near_store::Temperature::Hot);
+    .get_hot_store();
     let runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter> =
         Arc::new(nearcore::NightshadeRuntime::from_config(home_dir, store.clone(), &near_config));
 

--- a/tools/cold-store/src/cli.rs
+++ b/tools/cold-store/src/cli.rs
@@ -194,7 +194,7 @@ fn copy_all_blocks(storage: &NodeStorage, batch_size: usize, check: bool) {
         (*storage.cold_db().unwrap()).clone(),
         &storage.get_hot_store(),
         batch_size,
-        keep_going,
+        &keep_going,
     )
     .expect("Failed to do migration to cold db");
 

--- a/tools/cold-store/src/cli.rs
+++ b/tools/cold-store/src/cli.rs
@@ -5,7 +5,7 @@ use near_primitives::block::Tip;
 use near_primitives::hash::CryptoHash;
 use near_store::cold_storage::{copy_all_data_to_cold, update_cold_db, update_cold_head};
 use near_store::metadata::DbKind;
-use near_store::{DBCol, NodeStorage, Store, Temperature};
+use near_store::{DBCol, NodeStorage, Store};
 use near_store::{COLD_HEAD_KEY, FINAL_HEAD_KEY, HEAD_KEY, TAIL_KEY};
 use nearcore::{NearConfig, NightshadeRuntime};
 use std::io::Result;
@@ -132,7 +132,8 @@ fn copy_next_block(store: &NodeStorage, config: &NearConfig, hot_runtime: &Arc<N
     // It should be set before the copying of a block in prod,
     // but we should default it to genesis height here.
     let cold_head_height = store
-        .get_store(Temperature::Cold)
+        .get_cold_store()
+        .unwrap()
         .get_ser::<Tip>(DBCol::BlockMisc, HEAD_KEY)
         .unwrap_or_else(|e| panic!("Error reading cold HEAD: {:#}", e))
         .map_or(config.genesis.config.genesis_height, |t| t.height);
@@ -140,7 +141,7 @@ fn copy_next_block(store: &NodeStorage, config: &NearConfig, hot_runtime: &Arc<N
     // If FINAL_HEAD is not set for hot storage though, we default it to 0.
     // And subsequently fail in assert!(next_height <= hot_final_height).
     let hot_final_head = store
-        .get_store(Temperature::Hot)
+        .get_hot_store()
         .get_ser::<Tip>(DBCol::BlockMisc, FINAL_HEAD_KEY)
         .unwrap_or_else(|e| panic!("Error reading hot FINAL_HEAD: {:#}", e))
         .map(|t| t.height)
@@ -153,8 +154,7 @@ fn copy_next_block(store: &NodeStorage, config: &NearConfig, hot_runtime: &Arc<N
     // Here it should be sufficient to just read from hot storage.
     // Because BlockHeight is never garbage collectable and is not even copied to cold.
     let cold_head_hash = get_ser_from_store::<CryptoHash>(
-        store,
-        Temperature::Hot,
+        &store.get_hot_store(),
         DBCol::BlockHeight,
         &cold_head_height.to_le_bytes(),
     )
@@ -166,7 +166,7 @@ fn copy_next_block(store: &NodeStorage, config: &NearConfig, hot_runtime: &Arc<N
     // we use cold_head_hash.
     update_cold_db(
         &*store.cold_db().unwrap(),
-        &store.get_store(Temperature::Hot),
+        &store.get_hot_store(),
         &hot_runtime
             .get_shard_layout(&hot_runtime.get_epoch_id_from_prev_block(&cold_head_hash).unwrap())
             .unwrap(),
@@ -174,15 +174,15 @@ fn copy_next_block(store: &NodeStorage, config: &NearConfig, hot_runtime: &Arc<N
     )
     .expect(&std::format!("Failed to copy block at height {} to cold db", next_height));
 
-    update_cold_head(&*store.cold_db().unwrap(), &store.get_store(Temperature::Hot), &next_height)
+    update_cold_head(&*store.cold_db().unwrap(), &store.get_hot_store(), &next_height)
         .expect(&std::format!("Failed to update cold HEAD to {}", next_height));
 }
 
-fn copy_all_blocks(store: &NodeStorage, batch_size: usize, check: bool) {
+fn copy_all_blocks(storage: &NodeStorage, batch_size: usize, check: bool) {
     // If FINAL_HEAD is not set for hot storage we default it to 0
     // not genesis_height, because hot db needs to contain genesis block for that
-    let hot_final_head = store
-        .get_store(Temperature::Hot)
+    let hot_final_head = storage
+        .get_hot_store()
         .get_ser::<Tip>(DBCol::BlockMisc, FINAL_HEAD_KEY)
         .unwrap_or_else(|e| panic!("Error reading hot FINAL_HEAD: {:#}", e))
         .map(|t| t.height)
@@ -191,8 +191,8 @@ fn copy_all_blocks(store: &NodeStorage, batch_size: usize, check: bool) {
     let keep_going = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
 
     copy_all_data_to_cold(
-        (*store.cold_db().unwrap()).clone(),
-        &store.get_store(Temperature::Hot),
+        (*storage.cold_db().unwrap()).clone(),
+        &storage.get_hot_store(),
         batch_size,
         keep_going,
     )
@@ -200,23 +200,15 @@ fn copy_all_blocks(store: &NodeStorage, batch_size: usize, check: bool) {
 
     // Setting cold head to hot_final_head captured BEFORE the start of initial migration.
     // Doesn't really matter here, but very important in case of migration during `neard run`.
-    update_cold_head(
-        &*store.cold_db().unwrap(),
-        &store.get_store(Temperature::Hot),
-        &hot_final_head,
-    )
-    .expect(&std::format!("Failed to update cold HEAD to {}", hot_final_head));
+    update_cold_head(&*storage.cold_db().unwrap(), &storage.get_hot_store(), &hot_final_head)
+        .expect(&std::format!("Failed to update cold HEAD to {}", hot_final_head));
 
     if check {
         for col in DBCol::iter() {
             if col.is_cold() {
                 println!(
                     "Performed {} {:?} checks",
-                    check_iter(
-                        &store.get_store(Temperature::Hot),
-                        &store.get_store(Temperature::Cold),
-                        col,
-                    ),
+                    check_iter(&storage.get_hot_store(), &storage.get_cold_store().unwrap(), col),
                     col
                 );
             }
@@ -255,41 +247,11 @@ fn check_iter(
 /// Calls get_ser on Store with provided temperature from provided NodeStorage.
 /// Expects read to not result in errors.
 fn get_ser_from_store<T: near_primitives::borsh::BorshDeserialize>(
-    store: &NodeStorage,
-    temperature: Temperature,
+    store: &Store,
     col: DBCol,
     key: &[u8],
 ) -> Option<T> {
-    store.get_store(temperature).get_ser(col, key).expect(&std::format!(
-        "Error reading {} {:?} from {:?} store",
-        col,
-        key,
-        temperature
-    ))
-}
-
-/// First try to read col, key from hot storage.
-/// If resulted Option is None, try to read col, key from cold storage.
-/// Returns serialized inner value (not wrapped in option),
-/// or panics, if value isn't found even in cold.
-///
-/// Reads from database are expected to not result in errors.
-///
-/// This function is currently unused, but will be important in the future,
-/// when we start garbage collecting data from hot.
-/// For some columns you can understand the temperature by key.
-/// For others, though, read with fallback is the only working solution right now.
-fn _get_with_fallback<T: near_primitives::borsh::BorshDeserialize>(
-    store: &NodeStorage,
-    col: DBCol,
-    key: &[u8],
-) -> T {
-    let hot_option = get_ser_from_store(store, Temperature::Hot, col, key);
-    match hot_option {
-        Some(value) => value,
-        None => get_ser_from_store(store, Temperature::Cold, col, key)
-            .unwrap_or_else(|| panic!("No value for {} {:?} in any storage", col, key)),
-    }
+    store.get_ser(col, key).expect(&std::format!("Error reading {} {:?} from store", col, key,))
 }
 
 #[derive(clap::Parser)]

--- a/tools/mirror/src/offline.rs
+++ b/tools/mirror/src/offline.rs
@@ -46,7 +46,7 @@ impl ChainAccess {
         let store = store_opener
             .open()
             .with_context(|| format!("Error opening store in {:?}", home.as_ref()))?
-            .get_store(near_store::Temperature::Hot);
+            .get_hot_store();
         let chain = ChainStore::new(
             store.clone(),
             config.genesis.config.genesis_height,

--- a/tools/mock-node/src/setup.rs
+++ b/tools/mock-node/src/setup.rs
@@ -38,7 +38,7 @@ fn setup_runtime(
         near_store::NodeStorage::opener(home_dir, config.config.archive, &config.config.store, None)
             .open()
             .unwrap()
-            .get_store(near_store::Temperature::Hot)
+            .get_hot_store()
     };
 
     Arc::new(NightshadeRuntime::from_config(home_dir, store, config))

--- a/tools/speedy_sync/src/main.rs
+++ b/tools/speedy_sync/src/main.rs
@@ -127,7 +127,7 @@ fn create_snapshot(create_cmd: CreateCmd) {
     let store = NodeStorage::opener(path, false, &Default::default(), None)
         .open_in_mode(Mode::ReadOnly)
         .unwrap()
-        .get_store(near_store::Temperature::Hot);
+        .get_hot_store();
 
     // Get epoch information:
     let mut epochs = store
@@ -225,7 +225,7 @@ fn load_snapshot(load_cmd: LoadCmd) {
     let store = NodeStorage::opener(home_dir, config.config.archive, &Default::default(), None)
         .open()
         .unwrap()
-        .get_store(near_store::Temperature::Hot);
+        .get_hot_store();
     let chain_genesis = ChainGenesis::new(&config.genesis);
     let runtime = Arc::new(NightshadeRuntime::from_config(home_dir, store.clone(), &config));
     // This will initialize the database (add genesis block etc)

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -104,7 +104,11 @@ impl StateViewerSubCommand {
         );
 
         let storage = store_opener.open_in_mode(mode).unwrap();
-        let store = storage.get_store(temperature);
+        let store = match temperature {
+            Temperature::Hot => storage.get_hot_store(),
+            Temperature::Cold => storage.get_cold_store().unwrap(),
+        };
+
         match self {
             StateViewerSubCommand::Apply(cmd) => cmd.run(home_dir, near_config, store),
             StateViewerSubCommand::ApplyChunk(cmd) => cmd.run(home_dir, near_config, store),


### PR DESCRIPTION
- use split store in the view client - when configured
- removed the get_store(Temperature) method and replaced usages with safer get_cold_store and get_hot_store
- added SplitStorageConfig and used it to configure a few things