### PR TITLE
feat(indexer): Respect `nightly` feature of `nearcore` lib (for betanet)

### DIFF
--- a/chain/indexer/CHANGELOG.md
+++ b/chain/indexer/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 1.26.x (UNRELEASED)
+## 1.32.x
+
+* Add `nightly` feature to NEAR Indexer Framework to respect this feature for `nearcore` lib (requried for `betanet`)
+
+## 1.26.0
 
 * `state_changes` field is moved from the top-level `StreamerMessage` to `IndexerShard` struct to align better with the sharded nature of NEAR protocol. In the future, when nearcore will be able to track only a subset of shards, this API will work naturally, so we take pro-active measures to solidify the APIs
 * All the NEAR Indexer Framework types were extracted to a separate crate `near-indexer-primitives`

--- a/chain/indexer/Cargo.toml
+++ b/chain/indexer/Cargo.toml
@@ -30,3 +30,4 @@ node-runtime = { path = "../../runtime/runtime" }
 
 [features]
 calimero_zero_storage = ["near-primitives/calimero_zero_storage"]
+nightly = ["nearcore/nightly"]


### PR DESCRIPTION
This PR adds a small change that makes NEAR Indexer Framework to respect the `nightly` feature of `nearcore` lib.

This is needed for Indexer Framework to support `betanet` (regarding international testing environmental)

cc @pkudinov @nikurt 