### PR TITLE
feat: undo-block tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Node can sync State from S3. [#8789](https://github.com/near/nearcore/pull/8789)
 * The contract runtime switched to using our fork of wasmer, with various improvements.
+* undo-block tool to reset the chain head from current head to its prev block. Use the tool by running: `./target/release/neard --home {path_to_config_directory} undo-block`. [#8681](https://github.com/near/nearcore/pull/8681)
 
 ## 1.33.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2542,6 +2542,7 @@ dependencies = [
  "near-store",
  "near-telemetry",
  "near-test-contracts",
+ "near-undo-block",
  "near-vm-errors",
  "near-vm-runner",
  "nearcore",
@@ -3930,6 +3931,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "near-undo-block"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap 3.1.18",
+ "near-chain",
+ "near-chain-configs",
+ "near-primitives",
+ "near-store",
+ "nearcore",
+ "tracing",
+]
+
+[[package]]
 name = "near-vm"
 version = "0.0.0"
 dependencies = [
@@ -4276,6 +4292,7 @@ dependencies = [
  "near-primitives",
  "near-state-parts",
  "near-store",
+ "near-undo-block",
  "nearcore",
  "once_cell",
  "openssl-probe",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ members = [
     "tools/state-viewer",
     "tools/storage-usage-delta-calculator",
     "tools/themis",
+    "tools/undo-block",
     "utils/config",
     "utils/fmt",
     "utils/mainnet-res",
@@ -204,6 +205,7 @@ near-state-viewer = { path = "tools/state-viewer", package = "state-viewer" }
 near-store = { path = "core/store" }
 near-telemetry = { path = "chain/telemetry" }
 near-test-contracts = { path = "runtime/near-test-contracts" }
+near-undo-block = { path = "tools/undo-block" }
 near-vm-compiler = { path = "runtime/near-vm/lib/compiler"}
 near-vm-compiler-singlepass = { path = "runtime/near-vm/lib/compiler-singlepass" }
 near-vm-engine = { path = "runtime/near-vm/lib/engine" }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -49,6 +49,7 @@ near-o11y.workspace = true
 near-telemetry.workspace = true
 near-test-contracts.workspace = true
 near-performance-metrics.workspace = true
+near-undo-block.workspace = true
 near-vm-errors.workspace = true
 near-vm-runner.workspace = true
 nearcore.workspace = true

--- a/integration-tests/src/tests/client/mod.rs
+++ b/integration-tests/src/tests/client/mod.rs
@@ -9,3 +9,4 @@ mod runtimes;
 #[cfg(feature = "sandbox")]
 mod sandbox;
 mod sharding_upgrade;
+mod undo_block;

--- a/integration-tests/src/tests/client/undo_block.rs
+++ b/integration-tests/src/tests/client/undo_block.rs
@@ -1,0 +1,77 @@
+use near_chain::{
+    ChainGenesis, ChainStore, ChainStoreAccess, Provenance, RuntimeWithEpochManagerAdapter,
+};
+use near_chain_configs::Genesis;
+use near_client::test_utils::TestEnv;
+use near_o11y::testonly::init_test_logger;
+use near_store::test_utils::create_test_store;
+use near_store::Store;
+use near_undo_block::undo_block;
+use nearcore::config::GenesisExt;
+use std::path::Path;
+use std::sync::Arc;
+
+/// Setup environment with one Near client for testing.
+fn setup_env(
+    genesis: &Genesis,
+    store: Store,
+) -> (TestEnv, Arc<dyn RuntimeWithEpochManagerAdapter>) {
+    let chain_genesis = ChainGenesis::new(genesis);
+    let runtime: Arc<dyn RuntimeWithEpochManagerAdapter> =
+        nearcore::NightshadeRuntime::test(Path::new("../../../.."), store, genesis);
+    (TestEnv::builder(chain_genesis).runtime_adapters(vec![runtime.clone()]).build(), runtime)
+}
+
+// Checks that Near client can successfully undo block on given height and then produce and process block normally after restart
+fn test_undo_block(epoch_length: u64, stop_height: u64) {
+    init_test_logger();
+
+    let save_trie_changes = true;
+
+    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    genesis.config.epoch_length = epoch_length;
+
+    let store = create_test_store();
+    let (mut env, runtime) = setup_env(&genesis, store.clone());
+
+    for i in 1..=stop_height {
+        let block = env.clients[0].produce_block(i).unwrap().unwrap();
+        env.process_block(0, block, Provenance::PRODUCED);
+    }
+
+    let mut chain_store =
+        ChainStore::new(store.clone(), genesis.config.genesis_height, save_trie_changes);
+
+    let current_head = chain_store.head().unwrap();
+    let prev_block_hash = current_head.prev_block_hash;
+
+    undo_block(&mut chain_store, &*runtime).unwrap();
+
+    // after undo, the current head should be the prev_block_hash
+    assert_eq!(chain_store.head().unwrap().last_block_hash.as_bytes(), prev_block_hash.as_bytes());
+    assert_eq!(chain_store.head().unwrap().height, stop_height - 1);
+
+    // set up an environment again with the same store
+    let (mut env, _) = setup_env(&genesis, store.clone());
+    // the new env should be able to produce block normally
+    let block = env.clients[0].produce_block(stop_height).unwrap().unwrap();
+    env.process_block(0, block, Provenance::PRODUCED);
+
+    // after processing the new block, the head should now be at stop_height
+    assert_eq!(chain_store.head().unwrap().height, stop_height);
+}
+
+#[test]
+fn test_undo_block_middle_of_epoch() {
+    test_undo_block(5, 3)
+}
+
+#[test]
+fn test_undo_block_end_of_epoch() {
+    test_undo_block(5, 5)
+}
+
+#[test]
+fn test_undo_block_start_of_epoch() {
+    test_undo_block(5, 6)
+}

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -48,6 +48,7 @@ near-primitives.workspace = true
 near-state-parts.workspace = true
 near-state-viewer.workspace = true
 near-store.workspace = true
+near-undo-block.workspace = true
 
 [build-dependencies]
 anyhow.workspace = true

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -22,6 +22,7 @@ use near_state_parts::cli::StatePartsCommand;
 use near_state_viewer::StateViewerSubCommand;
 use near_store::db::RocksDB;
 use near_store::Mode;
+use near_undo_block::cli::UndoBlockCommand;
 use serde_json::Value;
 use std::fs::File;
 use std::io::BufReader;
@@ -122,6 +123,9 @@ impl NeardCmd {
             }
             NeardSubCommand::ValidateConfig(cmd) => {
                 cmd.run(&home_dir)?;
+            }
+            NeardSubCommand::UndoBlock(cmd) => {
+                cmd.run(&home_dir, genesis_validation)?;
             }
         };
         Ok(())
@@ -239,6 +243,9 @@ pub(super) enum NeardSubCommand {
 
     /// validate config files including genesis.json and config.json
     ValidateConfig(ValidateConfigCommand),
+
+    // reset the head of the chain locally to the prev block of current head
+    UndoBlock(UndoBlockCommand),
 }
 
 #[derive(clap::Parser)]

--- a/tools/undo-block/Cargo.toml
+++ b/tools/undo-block/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "near-undo-block"
+version = "0.0.0"
+authors.workspace = true
+publish = false
+edition.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+clap.workspace = true
+tracing.workspace = true
+chrono.workspace = true
+
+near-chain.workspace = true
+near-chain-configs.workspace = true
+near-store.workspace = true
+nearcore.workspace = true
+near-primitives.workspace = true

--- a/tools/undo-block/src/cli.rs
+++ b/tools/undo-block/src/cli.rs
@@ -1,0 +1,40 @@
+use near_chain::ChainStore;
+use near_chain_configs::GenesisValidationMode;
+use near_store::{Mode, NodeStorage};
+use nearcore::load_config;
+use nearcore::NightshadeRuntime;
+use std::path::Path;
+
+#[derive(clap::Parser)]
+pub struct UndoBlockCommand {}
+
+impl UndoBlockCommand {
+    pub fn run(
+        self,
+        home_dir: &Path,
+        genesis_validation: GenesisValidationMode,
+    ) -> anyhow::Result<()> {
+        let near_config = load_config(home_dir, genesis_validation)
+            .unwrap_or_else(|e| panic!("Error loading config: {:#}", e));
+
+        let store_opener = NodeStorage::opener(
+            home_dir,
+            near_config.config.archive,
+            &near_config.config.store,
+            None,
+        );
+
+        let storage = store_opener.open_in_mode(Mode::ReadWrite).unwrap();
+        let store = storage.get_hot_store();
+
+        let runtime = NightshadeRuntime::from_config(home_dir, store.clone(), &near_config);
+
+        let mut chain_store = ChainStore::new(
+            store,
+            near_config.genesis.config.genesis_height,
+            near_config.client_config.save_trie_changes,
+        );
+
+        crate::undo_block(&mut chain_store, &*runtime)
+    }
+}

--- a/tools/undo-block/src/lib.rs
+++ b/tools/undo-block/src/lib.rs
@@ -1,0 +1,49 @@
+use chrono::Utc;
+use near_chain::types::LatestKnown;
+use near_chain::RuntimeWithEpochManagerAdapter;
+use near_chain::{ChainStore, ChainStoreAccess, ChainStoreUpdate};
+use near_primitives::block::Tip;
+use near_primitives::utils::to_timestamp;
+
+pub mod cli;
+
+pub fn undo_block(
+    chain_store: &mut ChainStore,
+    runtime: &dyn RuntimeWithEpochManagerAdapter,
+) -> anyhow::Result<()> {
+    let current_head = chain_store.head()?;
+    let current_head_hash = current_head.last_block_hash;
+    let prev_block_hash = current_head.prev_block_hash;
+    let prev_header = chain_store.get_block_header(&prev_block_hash)?;
+    let prev_tip = Tip::from_header(&prev_header);
+    let current_head_height = current_head.height;
+    let prev_block_height = prev_tip.height;
+
+    tracing::info!(target: "neard", ?prev_block_hash, ?current_head_hash, ?prev_block_height, ?current_head_height, "Trying to update head");
+
+    // stop if it's already the final block
+    if chain_store.final_head()?.height >= current_head.height {
+        return Err(anyhow::anyhow!("Cannot revert past final block"));
+    }
+
+    let mut chain_store_update = ChainStoreUpdate::new(chain_store);
+
+    chain_store_update.clear_head_block_data(runtime)?;
+
+    chain_store_update.save_head(&prev_tip)?;
+
+    chain_store_update.commit()?;
+
+    chain_store.save_latest_known(LatestKnown {
+        height: prev_tip.height,
+        seen: to_timestamp(Utc::now()),
+    })?;
+
+    let new_chain_store_head = chain_store.head()?;
+    let new_chain_store_header_head = chain_store.header_head()?;
+    let new_head_height = new_chain_store_head.height;
+    let new_header_height = new_chain_store_header_head.height;
+
+    tracing::info!(target: "neard", ?new_head_height, ?new_header_height, "The current chain store shows");
+    Ok(())
+}


### PR DESCRIPTION
undo-block tool to revert the current head of the chain to its previous block. Typically used when the state of current chain head is messed up, e.g. running a wrong binary like in the case of protocol upgrade or gas price param changes.

To use the tool:
1. stop the node
2. run command `./target/release/neard --home {path_to_config_directory} undo-block`
3. restart node

Assuming only the head of the chain was messed up, not a long fork, then after using the tool, the node should be able to catch up and produce block (if they are block producers).

We intentionally forbid users from reverting beyond final block so that nothing is messed up for flat storage and finality is not broken.

[Design doc for the tool](https://docs.google.com/document/d/1bqdGtMCNwyHDNGWmcsVCR23q1BdcK2tu6ab87Kd43r0/edit#heading=h.dzkwz45fxs82)
