### PR TITLE
refactor: use shard uid in flat state keys

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3187,10 +3187,13 @@ impl Chain {
             // So we don't have to add the storage state for shard in such case.
             // TODO(8438) - add additional test scenarios for this case.
             if *block_hash != CryptoHash::default() {
-                let block_height = self.get_block_header(block_hash)?.height();
+                let block_header = self.get_block_header(block_hash)?;
+                let epoch_id = block_header.epoch_id();
+                let shard_uid = self.runtime_adapter.shard_id_to_uid(shard_id, epoch_id)?;
+                let block_height = block_header.height();
 
                 self.runtime_adapter.create_flat_storage_for_shard(
-                    shard_id,
+                    shard_uid,
                     block_height,
                     self.store(),
                 );

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -839,11 +839,11 @@ impl RuntimeAdapter for KeyValueRuntime {
 
     fn create_flat_storage_for_shard(
         &self,
-        shard_id: ShardId,
+        shard_uid: ShardUId,
         _latest_block_height: BlockHeight,
         _chain_access: &dyn ChainAccessForFlatStorage,
     ) {
-        panic!("Flat storage state can't be created for shard {shard_id} because KeyValueRuntime doesn't support this");
+        panic!("Flat storage state can't be created for shard {shard_uid} because KeyValueRuntime doesn't support this");
     }
 
     fn remove_flat_storage_for_shard(

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -307,7 +307,7 @@ pub trait RuntimeAdapter: Send + Sync {
     /// TODO (#7327): consider returning flat storage creation errors here
     fn create_flat_storage_for_shard(
         &self,
-        shard_id: ShardId,
+        shard_uid: ShardUId,
         latest_block_height: BlockHeight,
         chain_access: &dyn ChainAccessForFlatStorage,
     );

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -472,7 +472,7 @@ impl DBCol {
             DBCol::StateChangesForSplitStates => &[DBKeyType::BlockHash, DBKeyType::ShardId],
             DBCol::TransactionResultForBlock => &[DBKeyType::OutcomeId, DBKeyType::BlockHash],
             #[cfg(feature = "protocol_feature_flat_state")]
-            DBCol::FlatState => &[DBKeyType::TrieKey],
+            DBCol::FlatState => &[DBKeyType::ShardUId, DBKeyType::TrieKey],
             #[cfg(feature = "protocol_feature_flat_state")]
             DBCol::FlatStateDeltas => &[DBKeyType::ShardId, DBKeyType::BlockHash],
             #[cfg(feature = "protocol_feature_flat_state")]

--- a/core/store/src/flat/delta.rs
+++ b/core/store/src/flat/delta.rs
@@ -1,6 +1,7 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 
 use near_primitives::hash::hash;
+use near_primitives::shard_layout::ShardUId;
 use near_primitives::state::ValueRef;
 use near_primitives::types::{RawStateChangesWithTrieKey, ShardId};
 use std::collections::HashMap;
@@ -72,9 +73,9 @@ impl FlatStateDelta {
     }
 
     /// Applies delta to the flat state.
-    pub fn apply_to_flat_state(self, store_update: &mut StoreUpdate) {
+    pub fn apply_to_flat_state(self, store_update: &mut StoreUpdate, shard_uid: ShardUId) {
         for (key, value) in self.0.into_iter() {
-            store_helper::set_ref(store_update, key, value).expect("Borsh cannot fail");
+            store_helper::set_ref(store_update, shard_uid, key, value).expect("Borsh cannot fail");
         }
     }
 }

--- a/core/store/src/flat/storage.rs
+++ b/core/store/src/flat/storage.rs
@@ -5,7 +5,7 @@ use lru::LruCache;
 use near_o11y::metrics::IntGauge;
 use near_primitives::errors::StorageError;
 use near_primitives::hash::CryptoHash;
-use near_primitives::shard_layout::ShardLayout;
+use near_primitives::shard_layout::{ShardLayout, ShardUId};
 use near_primitives::state::ValueRef;
 use near_primitives::types::{BlockHeight, ShardId};
 use tracing::info;
@@ -41,7 +41,7 @@ pub struct FlatStorage(pub(crate) Arc<RwLock<FlatStorageInner>>);
 pub(crate) struct FlatStorageInner {
     store: Store,
     /// Id of the shard which state is accessed by this flat storage.
-    shard_id: ShardId,
+    shard_uid: ShardUId,
     /// The block for which we store the key value pairs of the state after it is applied.
     /// For non catchup mode, it should be the last final block.
     flat_head: CryptoHash,
@@ -97,12 +97,12 @@ impl FlatStorageInner {
         &self,
         target_block_hash: &CryptoHash,
     ) -> Result<Vec<CryptoHash>, FlatStorageError> {
-        let shard_id = &self.shard_id;
+        let shard_uid = &self.shard_uid;
         let flat_head = &self.flat_head;
         let flat_head_info = self
             .blocks
             .get(flat_head)
-            .expect(&format!("Inconsistent flat storage state for shard {shard_id}: head {flat_head} not found in cached blocks"));
+            .expect(&format!("Inconsistent flat storage state for shard {shard_uid}: head {flat_head} not found in cached blocks"));
 
         let mut block_hash = *target_block_hash;
         let mut blocks = vec![];
@@ -152,13 +152,14 @@ impl FlatStorage {
     /// including those on forks into the returned FlatStorage.
     pub fn new(
         store: Store,
-        shard_id: ShardId,
+        shard_uid: ShardUId,
         latest_block_height: BlockHeight,
         // Unfortunately we don't have access to ChainStore inside this file because of package
         // dependencies, so we pass these functions in to access chain info
         chain_access: &dyn ChainAccessForFlatStorage,
         cache_capacity: usize,
     ) -> Self {
+        let shard_id = shard_uid.shard_id();
         let flat_head = store_helper::get_flat_head(&store, shard_id)
             .unwrap_or_else(|| panic!("Cannot read flat head for shard {} from storage", shard_id));
         let flat_head_info = chain_access.get_block_info(&flat_head);
@@ -225,7 +226,7 @@ impl FlatStorage {
 
         Self(Arc::new(RwLock::new(FlatStorageInner {
             store,
-            shard_id,
+            shard_uid,
             flat_head,
             blocks,
             deltas,
@@ -279,17 +280,18 @@ impl FlatStorage {
     /// returns an error.
     pub fn update_flat_head(&self, new_head: &CryptoHash) -> Result<(), FlatStorageError> {
         let mut guard = self.0.write().expect(crate::flat::POISONED_LOCK_ERR);
+        let shard_id = guard.shard_uid.shard_id();
         let blocks = guard.get_blocks_to_head(new_head)?;
         for block in blocks.into_iter().rev() {
             let mut store_update = StoreUpdate::new(guard.store.storage.clone());
             // We unwrap here because flat storage is locked and we could retrieve path from old to new head, so delta
             // must exist.
-            let delta = store_helper::get_delta(&guard.store, guard.shard_id, block)?.unwrap();
+            let delta = store_helper::get_delta(&guard.store, shard_id, block)?.unwrap();
             for (key, value) in delta.0.iter() {
                 guard.put_value_ref_to_cache(key.clone(), value.clone());
             }
-            delta.apply_to_flat_state(&mut store_update);
-            store_helper::set_flat_head(&mut store_update, guard.shard_id, &block);
+            delta.apply_to_flat_state(&mut store_update, guard.shard_uid);
+            store_helper::set_flat_head(&mut store_update, shard_id, &block);
 
             // Remove old blocks and deltas from disk and memory.
             // Do it for each head update separately to ensure that old data is removed properly if node was
@@ -311,7 +313,7 @@ impl FlatStorage {
             for hash in hashes_to_remove {
                 // It is fine to remove all deltas in single store update, because memory overhead of `DeleteRange`
                 // operation is low.
-                store_helper::remove_delta(&mut store_update, guard.shard_id, hash);
+                store_helper::remove_delta(&mut store_update, shard_id, hash);
                 match guard.deltas.remove(&hash) {
                     Some(delta) => {
                         guard.metrics.cached_deltas.dec();
@@ -335,7 +337,6 @@ impl FlatStorage {
             store_update.commit().unwrap();
         }
 
-        let shard_id = guard.shard_id;
         guard.flat_head = *new_head;
         let flat_head_height = guard
             .blocks
@@ -360,14 +361,14 @@ impl FlatStorage {
         block: BlockInfo,
     ) -> Result<StoreUpdate, FlatStorageError> {
         let mut guard = self.0.write().expect(super::POISONED_LOCK_ERR);
-        let shard_id = guard.shard_id;
+        let shard_id = guard.shard_uid.shard_id();
         let block_height = block.height;
         info!(target: "chain", %shard_id, %block_hash, %block_height, "Adding block to flat storage");
         if !guard.blocks.contains_key(&block.prev_hash) {
             return Err(guard.create_block_not_supported_error(block_hash));
         }
         let mut store_update = StoreUpdate::new(guard.store.storage.clone());
-        store_helper::set_delta(&mut store_update, guard.shard_id, *block_hash, &delta)?;
+        store_helper::set_delta(&mut store_update, shard_id, *block_hash, &delta)?;
         let cached_delta: CachedFlatStateDelta = delta.into();
         guard.metrics.cached_deltas.inc();
         guard.metrics.cached_deltas_num_items.add(cached_delta.len() as i64);
@@ -381,7 +382,7 @@ impl FlatStorage {
     /// Clears all State key-value pairs from flat storage.
     pub fn clear_state(&self, shard_layout: ShardLayout) -> Result<(), StorageError> {
         let guard = self.0.write().expect(super::POISONED_LOCK_ERR);
-        let shard_id = guard.shard_id;
+        let shard_id = guard.shard_uid.shard_id();
 
         // Removes all items belonging to the shard one by one.
         // Note that it does not work for resharding.

--- a/core/store/src/flat/storage.rs
+++ b/core/store/src/flat/storage.rs
@@ -40,7 +40,7 @@ pub struct FlatStorage(pub(crate) Arc<RwLock<FlatStorageInner>>);
 //   after the `flat_head` block successfully.
 pub(crate) struct FlatStorageInner {
     store: Store,
-    /// Id of the shard which state is accessed by this flat storage.
+    /// UId of the shard which state is accessed by this flat storage.
     shard_uid: ShardUId,
     /// The block for which we store the key value pairs of the state after it is applied.
     /// For non catchup mode, it should be the last final block.

--- a/core/store/src/flat/store_helper.rs
+++ b/core/store/src/flat/store_helper.rs
@@ -97,9 +97,9 @@ pub fn remove_flat_head(store_update: &mut StoreUpdate, shard_id: ShardId) {
 }
 
 fn flat_state_db_key(shard_uid: ShardUId, key: &[u8]) -> Vec<u8> {
-    let mut buffer = Vec::with_capacity(key.len() + 8);
-    buffer[0..8].copy_from_slice(&shard_uid.to_bytes());
-    buffer[8..].copy_from_slice(key);
+    let mut buffer = vec![];
+    buffer.extend_from_slice(&shard_uid.to_bytes());
+    buffer.extend_from_slice(key);
     buffer
 }
 

--- a/core/store/src/flat/store_helper.rs
+++ b/core/store/src/flat/store_helper.rs
@@ -8,9 +8,8 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use byteorder::ReadBytesExt;
 use near_primitives::errors::StorageError;
 use near_primitives::hash::CryptoHash;
-use near_primitives::shard_layout::{account_id_to_shard_id, ShardLayout, ShardUId};
+use near_primitives::shard_layout::{ShardLayout, ShardUId};
 use near_primitives::state::ValueRef;
-use near_primitives::trie_key::trie_key_parsers::parse_account_id_from_raw_key;
 use near_primitives::types::ShardId;
 
 /// Prefixes determining type of flat storage creation status stored in DB.

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -183,7 +183,7 @@ impl GenesisBuilder {
         let root = tries.apply_all(&trie_changes, shard_uid, &mut store_update);
         if cfg!(feature = "protocol_feature_flat_state") {
             near_store::flat::FlatStateDelta::from_state_changes(&state_changes)
-                .apply_to_flat_state(&mut store_update);
+                .apply_to_flat_state(&mut store_update, shard_uid);
         }
         store_update.commit()?;
 

--- a/integration-tests/src/tests/client/flat_storage.rs
+++ b/integration-tests/src/tests/client/flat_storage.rs
@@ -260,6 +260,7 @@ fn test_flat_storage_creation_start_from_state_part() {
     let genesis = Genesis::test(accounts, 1);
     let store = create_test_store();
     let shard_layout = ShardLayout::v0_single_shard();
+    let shard_uid = shard_layout.get_shard_uids()[0];
 
     // Process some blocks with flat storage.
     // Split state into two parts and return trie keys corresponding to each part.
@@ -317,8 +318,8 @@ fn test_flat_storage_creation_start_from_state_part() {
         // Manually set flat storage creation status to the step when it should start from fetching part 1.
         let flat_head = store_helper::get_flat_head(&store, 0).unwrap();
         let mut store_update = store.store_update();
-        for key in trie_keys[1].iter() {
-            store_update.delete(store_helper::FlatStateColumn::State.to_db_col(), key);
+        for key in trie_keys[1].into_iter() {
+            store_helper::set_ref(&mut store_update, shard_uid, key, None).unwrap();
         }
         store_helper::remove_flat_head(&mut store_update, 0);
         store_helper::set_flat_storage_creation_status(

--- a/integration-tests/src/tests/client/flat_storage.rs
+++ b/integration-tests/src/tests/client/flat_storage.rs
@@ -441,9 +441,8 @@ fn test_flat_storage_iter() {
                     near_primitives::trie_key::TrieKey::Account {
                         account_id: "test0".parse().unwrap()
                     }
-                    .to_vec()
-                    .as_slice(),
-                    items.get(0).unwrap().0.as_ref()
+                    .to_vec(),
+                    items.get(0).unwrap().0
                 );
             }
             1 => {
@@ -457,9 +456,8 @@ fn test_flat_storage_iter() {
                     near_primitives::trie_key::TrieKey::Account {
                         account_id: "near".parse().unwrap()
                     }
-                    .to_vec()
-                    .as_slice(),
-                    items.get(0).unwrap().0.as_ref()
+                    .to_vec(),
+                    items.get(0).unwrap().0
                 );
             }
             _ => {

--- a/integration-tests/src/tests/client/flat_storage.rs
+++ b/integration-tests/src/tests/client/flat_storage.rs
@@ -318,8 +318,8 @@ fn test_flat_storage_creation_start_from_state_part() {
         // Manually set flat storage creation status to the step when it should start from fetching part 1.
         let flat_head = store_helper::get_flat_head(&store, 0).unwrap();
         let mut store_update = store.store_update();
-        for key in trie_keys[1].into_iter() {
-            store_helper::set_ref(&mut store_update, shard_uid, key, None).unwrap();
+        for key in trie_keys[1].iter() {
+            store_helper::set_ref(&mut store_update, shard_uid, key.clone(), None).unwrap();
         }
         store_helper::remove_flat_head(&mut store_update, 0);
         store_helper::set_flat_storage_creation_status(

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -743,19 +743,19 @@ impl RuntimeAdapter for NightshadeRuntime {
     // TODO (#7327): consider passing flat storage errors here to handle them gracefully
     fn create_flat_storage_for_shard(
         &self,
-        shard_id: ShardId,
+        shard_uid: ShardUId,
         latest_block_height: BlockHeight,
         chain_access: &dyn ChainAccessForFlatStorage,
     ) {
         let cache_capacity = self.tries.flat_state_cache_capacity() as usize;
         let flat_storage = FlatStorage::new(
             self.store.clone(),
-            shard_id,
+            shard_uid,
             latest_block_height,
             chain_access,
             cache_capacity,
         );
-        self.flat_storage_manager.add_flat_storage_for_shard(shard_id, flat_storage);
+        self.flat_storage_manager.add_flat_storage_for_shard(shard_uid.shard_id(), flat_storage);
     }
 
     fn remove_flat_storage_for_shard(
@@ -1376,7 +1376,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         tries.apply_all(&trie_changes, shard_uid, &mut store_update);
         if cfg!(feature = "protocol_feature_flat_state") {
             debug!(target: "chain", %shard_id, "Inserting {} values to flat storage", flat_state_delta.len());
-            flat_state_delta.apply_to_flat_state(&mut store_update);
+            flat_state_delta.apply_to_flat_state(&mut store_update, shard_uid);
         }
         self.precompile_contracts(epoch_id, contract_codes)?;
         Ok(store_update.commit()?)
@@ -1821,7 +1821,8 @@ mod test {
                         runtime.get_flat_storage_creation_status(shard_id),
                         FlatStorageCreationStatus::Ready
                     );
-                    runtime.create_flat_storage_for_shard(shard_id, 0, &mock_chain);
+                    let shard_uid = runtime.shard_id_to_uid(shard_id, &EpochId::default())?;
+                    runtime.create_flat_storage_for_shard(shard_uid, 0, &mock_chain);
                 }
             }
 

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -1821,7 +1821,7 @@ mod test {
                         runtime.get_flat_storage_creation_status(shard_id),
                         FlatStorageCreationStatus::Ready
                     );
-                    let shard_uid = runtime.shard_id_to_uid(shard_id, &EpochId::default())?;
+                    let shard_uid = runtime.shard_id_to_uid(shard_id, &EpochId::default()).unwrap();
                     runtime.create_flat_storage_for_shard(shard_uid, 0, &mock_chain);
                 }
             }

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -169,14 +169,14 @@ impl<'c> EstimatorContext<'c> {
             }
         }
 
-        let shard_id = ShardUId::single_shard().shard_id();
+        let shard_uid = ShardUId::single_shard();
         // Set up flat head to be equal to the latest block height
         let mut store_update = store.store_update();
-        store_helper::set_flat_head(&mut store_update, shard_id, &FLAT_STATE_HEAD);
+        store_helper::set_flat_head(&mut store_update, shard_uid.shard_id(), &FLAT_STATE_HEAD);
         store_update.commit().expect("failed to set flat head");
         let flat_storage = FlatStorage::new(
             store,
-            shard_id,
+            shard_uid,
             BLOCK_HEIGHT,
             &ChainAccess {},
             cache_capacity as usize,

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -306,14 +306,11 @@ impl Testbed<'_> {
             .unwrap();
 
         let mut store_update = self.tries.store_update();
-        self.root = self.tries.apply_all(
-            &apply_result.trie_changes,
-            ShardUId::single_shard(),
-            &mut store_update,
-        );
+        let shard_uid = ShardUId::single_shard();
+        self.root = self.tries.apply_all(&apply_result.trie_changes, shard_uid, &mut store_update);
         if cfg!(feature = "protocol_feature_flat_state") {
             near_store::flat::FlatStateDelta::from_state_changes(&apply_result.state_changes)
-                .apply_to_flat_state(&mut store_update);
+                .apply_to_flat_state(&mut store_update, shard_uid);
         }
         store_update.commit().unwrap();
         self.apply_state.block_height += 1;

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -181,7 +181,7 @@ impl<'c> EstimatorContext<'c> {
             &ChainAccess {},
             cache_capacity as usize,
         );
-        flat_storage_manager.add_flat_storage_for_shard(shard_id, flat_storage);
+        flat_storage_manager.add_flat_storage_for_shard(shard_uid.shard_id(), flat_storage);
         flat_storage_manager
     }
 }

--- a/runtime/runtime/src/genesis.rs
+++ b/runtime/runtime/src/genesis.rs
@@ -99,7 +99,7 @@ impl GenesisStateApplier {
         *current_state_root = tries.apply_all(&trie_changes, shard_uid, &mut store_update);
         if cfg!(feature = "protocol_feature_flat_state") {
             FlatStateDelta::from_state_changes(&state_changes)
-                .apply_to_flat_state(&mut store_update);
+                .apply_to_flat_state(&mut store_update, shard_uid);
         }
         drop(state_changes); // silence compiler when not protocol_feature_flat_state
         store_update.commit().expect("Store update failed on genesis initialization");

--- a/tools/flat-storage/src/commands.rs
+++ b/tools/flat-storage/src/commands.rs
@@ -197,8 +197,7 @@ impl FlatStorageCommand {
                 println!("Verifying using the {:?} as state_root", state_root);
                 let tip = chain_store.final_head().unwrap();
 
-                let shard_uid =
-                    rw_hot_runtime.shard_id_to_uid(verify_cmd.shard_id, &tip.epoch_id)?;
+                let shard_uid = hot_runtime.shard_id_to_uid(verify_cmd.shard_id, &tip.epoch_id)?;
                 hot_runtime.create_flat_storage_for_shard(shard_uid, tip.height, &chain_store);
 
                 let trie = hot_runtime

--- a/tools/flat-storage/src/commands.rs
+++ b/tools/flat-storage/src/commands.rs
@@ -126,8 +126,10 @@ impl FlatStorageCommand {
                 let tip = rw_chain_store.final_head().unwrap();
 
                 // TODO: there should be a method that 'loads' the current flat storage state based on Storage.
+                let shard_uid =
+                    rw_hot_runtime.shard_id_to_uid(reset_cmd.shard_id, &tip.epoch_id)?;
                 rw_hot_runtime.create_flat_storage_for_shard(
-                    reset_cmd.shard_id,
+                    shard_uid,
                     tip.height,
                     &rw_chain_store,
                 );
@@ -195,11 +197,9 @@ impl FlatStorageCommand {
                 println!("Verifying using the {:?} as state_root", state_root);
                 let tip = chain_store.final_head().unwrap();
 
-                hot_runtime.create_flat_storage_for_shard(
-                    verify_cmd.shard_id,
-                    tip.height,
-                    &chain_store,
-                );
+                let shard_uid =
+                    rw_hot_runtime.shard_id_to_uid(verify_cmd.shard_id, &tip.epoch_id)?;
+                hot_runtime.create_flat_storage_for_shard(shard_uid, tip.height, &chain_store);
 
                 let trie = hot_runtime
                     .get_view_trie_for_shard(verify_cmd.shard_id, &head_hash, *state_root)


### PR DESCRIPTION
Prepend `ShardUId` to flat state keys, as motivated in https://github.com/near/nearcore/issues/8670.

Ideally we need to replace `shard_id` with `shard_uid` everywhere, including other DB keys and `RuntimeAdapter` flat storage methods. But this change would be too involved, so let's do it incrementally.

The biggest structural consequence is that `FlatStorage` now stores `shard_uid`, which makes sense, and later it will be used for writing deltas as well. It's not a big deal, but because of that changes are scattered throughout the code and may look scary.

## Testing

* `test_flat_storage_iter` checks that new `key_belongs_to_shard` impl is aligned with shard layout; also we can see that the change takes place in this failing test: https://buildkite.com/nearprotocol/nearcore/builds/25676#0186bc8f-12a2-410a-b74c-e326f3b963fa
* https://nayduck.near.org/#/run/2898