### PR TITLE
core: use ValueRef in trie nodes structs

### DIFF
--- a/core/primitives/src/state.rs
+++ b/core/primitives/src/state.rs
@@ -3,7 +3,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use near_primitives_core::hash::{hash, CryptoHash};
 
 /// State value reference. Used to charge fees for value length before retrieving the value itself.
-#[derive(BorshSerialize, BorshDeserialize, Clone, PartialEq, Eq, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, PartialEq, Eq, Hash)]
 pub struct ValueRef {
     /// Value length in bytes.
     pub length: u32,
@@ -24,6 +24,23 @@ impl ValueRef {
         let (length, hash) = stdx::split_array(bytes);
         let length = u32::from_le_bytes(*length);
         ValueRef { length, hash: CryptoHash(*hash) }
+    }
+
+    /// Returns length of the referenced value.
+    pub fn len(&self) -> usize {
+        usize::try_from(self.length).unwrap()
+    }
+}
+
+impl std::cmp::PartialEq<[u8]> for ValueRef {
+    fn eq(&self, rhs: &[u8]) -> bool {
+        self.len() == rhs.len() && self.hash == CryptoHash::hash_bytes(rhs)
+    }
+}
+
+impl std::fmt::Debug for ValueRef {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(fmt, "({}, {})", self.length, self.hash)
     }
 }
 

--- a/core/store/src/trie/iterator.rs
+++ b/core/store/src/trie/iterator.rs
@@ -239,7 +239,7 @@ impl<'a> TrieIterator<'a> {
             }
             (CrumbStatus::At, TrieNode::Branch(_, Some(value))) => {
                 let hash = match value {
-                    ValueHandle::HashAndSize(_, hash) => *hash,
+                    ValueHandle::HashAndSize(value) => value.hash,
                     ValueHandle::InMemory(_node) => unreachable!(),
                 };
                 Some(IterStep::Value(hash))
@@ -247,7 +247,7 @@ impl<'a> TrieIterator<'a> {
             (CrumbStatus::At, TrieNode::Branch(_, None)) => Some(IterStep::Continue),
             (CrumbStatus::At, TrieNode::Leaf(key, value)) => {
                 let hash = match value {
-                    ValueHandle::HashAndSize(_, hash) => *hash,
+                    ValueHandle::HashAndSize(value) => value.hash,
                     ValueHandle::InMemory(_node) => unreachable!(),
                 };
                 let key = NibbleSlice::from_encoded(key).0;

--- a/integration-tests/src/tests/runtime/state_viewer.rs
+++ b/integration-tests/src/tests/runtime/state_viewer.rs
@@ -51,17 +51,12 @@ impl ProofVerifier {
         let mut expected_hash = state_root;
         while let Some(node) = self.nodes.get(expected_hash) {
             match &node.node {
-                RawTrieNode::Leaf(node_key, value_length, value_hash) => {
+                RawTrieNode::Leaf(node_key, value) => {
                     let nib = &NibbleSlice::from_encoded(&node_key).0;
                     return if &key != nib {
-                        return expected.is_none();
-                    } else if let Some(value) = expected {
-                        if *value_length as usize != value.len() {
-                            return false;
-                        }
-                        CryptoHash::hash_bytes(value) == *value_hash
+                        expected.is_none()
                     } else {
-                        false
+                        expected.map_or(false, |expected| value == expected)
                     };
                 }
 
@@ -77,10 +72,11 @@ impl ProofVerifier {
                 }
                 RawTrieNode::Branch(children, value) => {
                     if key.is_empty() {
-                        return *value
-                            == expected.map(|value| {
-                                (value.len().try_into().unwrap(), CryptoHash::hash_bytes(&value))
-                            });
+                        return match (value, expected) {
+                            (Some(value), Some(expected)) => value == expected,
+                            (None, None) => true,
+                            _ => false,
+                        };
                     }
                     let index = key.at(0);
                     match &children[index as usize] {


### PR DESCRIPTION
Rather than handling value references as a (size, hash) tuples, use
existing ValueRef type in RawTrieNode and ValueHandle.  This better
documents what the u32 and CryptoHash mean and simplifies some code
by having a single object representing what so far was handled with
two variables.
