### PR TITLE
feat: introduce flat storage status

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -633,6 +633,7 @@ impl Chain {
                 if cfg!(feature = "protocol_feature_flat_state") {
                     let tmp_store_update = runtime_adapter.set_flat_storage_for_genesis(
                         genesis.hash(),
+                        genesis.header().height(),
                         genesis.header().epoch_id(),
                     )?;
                     store_update.merge(tmp_store_update);
@@ -3185,7 +3186,10 @@ impl Chain {
                 let block_header = self.get_block_header(block_hash)?;
                 let epoch_id = block_header.epoch_id();
                 let shard_uid = self.runtime_adapter.shard_id_to_uid(shard_id, epoch_id)?;
-                if !matches!(self.runtime_adapter.get_flat_storage_status(shard_uid), FlatStorageStatus::Disabled) {
+                if !matches!(
+                    self.runtime_adapter.get_flat_storage_status(shard_uid),
+                    FlatStorageStatus::Disabled
+                ) {
                     let mut store_update = self.runtime_adapter.store().store_update();
                     store_helper::set_flat_storage_status(
                         &mut store_update,

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3185,20 +3185,22 @@ impl Chain {
                 let block_header = self.get_block_header(block_hash)?;
                 let epoch_id = block_header.epoch_id();
                 let shard_uid = self.runtime_adapter.shard_id_to_uid(shard_id, epoch_id)?;
-                let mut store_update = self.runtime_adapter.store().store_update();
-                store_helper::set_flat_storage_status(
-                    &mut store_update,
-                    shard_uid,
-                    FlatStorageStatus::Ready(FlatStorageReadyStatus {
-                        flat_head: near_store::flat::BlockInfo {
-                            hash: *block_hash,
-                            prev_hash: *block_header.prev_hash(),
-                            height: block_header.height(),
-                        },
-                    }),
-                );
-                store_update.commit()?;
-                self.runtime_adapter.create_flat_storage_for_shard(shard_uid);
+                if !matches!(self.runtime_adapter.get_flat_storage_status(shard_uid), FlatStorageStatus::Disabled) {
+                    let mut store_update = self.runtime_adapter.store().store_update();
+                    store_helper::set_flat_storage_status(
+                        &mut store_update,
+                        shard_uid,
+                        FlatStorageStatus::Ready(FlatStorageReadyStatus {
+                            flat_head: near_store::flat::BlockInfo {
+                                hash: *block_hash,
+                                prev_hash: *block_header.prev_hash(),
+                                height: block_header.height(),
+                            },
+                        }),
+                    );
+                    store_update.commit()?;
+                    self.runtime_adapter.create_flat_storage_for_shard(shard_uid);
+                }
             }
         }
 

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -70,8 +70,8 @@ use near_primitives::views::{
     LightClientBlockView, SignedTransactionView,
 };
 use near_store::flat::{
-    store_helper, FlatStateChanges, FlatStateDelta, FlatStateDeltaMetadata,
-    FlatStorageCreationStatus, FlatStorageError,
+    store_helper, FlatStateChanges, FlatStateDelta, FlatStateDeltaMetadata, FlatStorageError,
+    FlatStorageReadyStatus, FlatStorageStatus,
 };
 use near_store::StorageError;
 use near_store::{DBCol, ShardTries, StoreUpdate, WrappedTrieChanges};
@@ -3178,14 +3178,6 @@ impl Chain {
         // flat storage. Now we can set flat head to hash of this block and create flat storage.
         // TODO (#7327): ensure that no flat storage work is done for `KeyValueRuntime`.
         if cfg!(feature = "protocol_feature_flat_state") {
-            let mut store_update = self.runtime_adapter.store().store_update();
-            store_helper::set_flat_head(&mut store_update, shard_id, block_hash);
-            store_update.commit()?;
-        }
-
-        if self.runtime_adapter.get_flat_storage_creation_status(shard_id)
-            == FlatStorageCreationStatus::Ready
-        {
             // If block_hash is equal to default - this means that we're all the way back at genesis.
             // So we don't have to add the storage state for shard in such case.
             // TODO(8438) - add additional test scenarios for this case.
@@ -3193,7 +3185,19 @@ impl Chain {
                 let block_header = self.get_block_header(block_hash)?;
                 let epoch_id = block_header.epoch_id();
                 let shard_uid = self.runtime_adapter.shard_id_to_uid(shard_id, epoch_id)?;
-
+                let mut store_update = self.runtime_adapter.store().store_update();
+                store_helper::set_flat_storage_status(
+                    &mut store_update,
+                    shard_uid,
+                    FlatStorageStatus::Ready(FlatStorageReadyStatus {
+                        flat_head: near_store::flat::BlockInfo {
+                            hash: *block_hash,
+                            prev_hash: *block_header.prev_hash(),
+                            height: block_header.height(),
+                        },
+                    }),
+                );
+                store_update.commit()?;
                 self.runtime_adapter.create_flat_storage_for_shard(shard_uid);
             }
         }

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -2438,7 +2438,7 @@ impl<'a> ChainStoreUpdate<'a> {
             DBCol::FlatState
             | DBCol::FlatStateChanges
             | DBCol::FlatStateDeltaMetadata
-            | DBCol::FlatStateMisc => {
+            | DBCol::FlatStorageStatus => {
                 unreachable!();
             }
         }

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -852,6 +852,7 @@ impl RuntimeAdapter for KeyValueRuntime {
     fn set_flat_storage_for_genesis(
         &self,
         _genesis_block: &CryptoHash,
+        _genesis_block_height: BlockHeight,
         _genesis_epoch_id: &EpochId,
     ) -> Result<StoreUpdate, Error> {
         Ok(self.store.store_update())

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -52,7 +52,7 @@ use crate::{BlockHeader, RuntimeWithEpochManagerAdapter};
 
 use near_primitives::epoch_manager::ShardConfig;
 
-use near_store::flat::{FlatStorage, FlatStorageCreationStatus};
+use near_store::flat::{FlatStorage, FlatStorageStatus};
 
 use super::ValidatorSchedule;
 
@@ -833,8 +833,8 @@ impl RuntimeAdapter for KeyValueRuntime {
         None
     }
 
-    fn get_flat_storage_creation_status(&self, _shard_id: ShardId) -> FlatStorageCreationStatus {
-        FlatStorageCreationStatus::DontCreate
+    fn get_flat_storage_status(&self, _shard_uid: ShardUId) -> FlatStorageStatus {
+        FlatStorageStatus::Disabled
     }
 
     fn create_flat_storage_for_shard(&self, shard_uid: ShardUId) {

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -317,6 +317,7 @@ pub trait RuntimeAdapter: Send + Sync {
     fn set_flat_storage_for_genesis(
         &self,
         genesis_block: &CryptoHash,
+        genesis_block_height: BlockHeight,
         genesis_epoch_id: &EpochId,
     ) -> Result<StoreUpdate, Error>;
 

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -31,7 +31,7 @@ use near_primitives::version::{
     MIN_PROTOCOL_VERSION_NEP_92_FIX,
 };
 use near_primitives::views::{QueryRequest, QueryResponse};
-use near_store::flat::{FlatStorage, FlatStorageCreationStatus};
+use near_store::flat::{FlatStorage, FlatStorageStatus};
 use near_store::{PartialStorage, ShardTries, Store, StoreUpdate, Trie, WrappedTrieChanges};
 
 pub use near_epoch_manager::EpochManagerAdapter;
@@ -299,8 +299,7 @@ pub trait RuntimeAdapter: Send + Sync {
 
     fn get_flat_storage_for_shard(&self, shard_id: ShardId) -> Option<FlatStorage>;
 
-    /// Gets status of flat storage state background creation.
-    fn get_flat_storage_creation_status(&self, shard_id: ShardId) -> FlatStorageCreationStatus;
+    fn get_flat_storage_status(&self, shard_uid: ShardUId) -> FlatStorageStatus;
 
     /// Creates flat storage state for given shard, assuming that all flat storage data
     /// is already stored in DB.

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -272,13 +272,11 @@ pub enum DBCol {
     /// - *Column type*: `FlatStateDeltaMetadata`
     #[cfg(feature = "protocol_feature_flat_state")]
     FlatStateDeltaMetadata,
-    /// Miscellaneous data for flat state. Stores intermediate flat storage creation statuses and flat
-    /// state heads for each shard.
-    /// - *Rows*: Unique key prefix (e.g. `FLAT_STATE_HEAD_KEY_PREFIX`) + ShardId
-    /// - *Column type*: FetchingStateStatus || flat storage catchup status (bool) || flat storage head (CryptoHash)
-    // TODO (#7327): use only during testing, come up with proper format.
     #[cfg(feature = "protocol_feature_flat_state")]
-    FlatStateMisc,
+    /// Flat storage status for the corresponding shard.
+    /// - *Rows*: `shard_id`
+    /// - *Column type*: `FlatStorageStatus`
+    FlatStorageStatus,
 }
 
 /// Defines different logical parts of a db key.
@@ -483,7 +481,7 @@ impl DBCol {
             #[cfg(feature = "protocol_feature_flat_state")]
             DBCol::FlatStateDeltaMetadata => &[DBKeyType::ShardId, DBKeyType::BlockHash],
             #[cfg(feature = "protocol_feature_flat_state")]
-            DBCol::FlatStateMisc => &[DBKeyType::ShardId],
+            DBCol::FlatStorageStatus => &[DBKeyType::ShardUId],
         }
     }
 }

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -258,24 +258,24 @@ pub enum DBCol {
     /// *Column type*: ExecutionOutcomeWithProof
     TransactionResultForBlock,
     /// Flat state contents. Used to get `ValueRef` by trie key faster than doing a trie lookup.
-    /// - *Rows*: trie key (Vec<u8>)
+    /// - *Rows*: `shard_uid` + trie key (Vec<u8>)
     /// - *Column type*: ValueRef
     #[cfg(feature = "protocol_feature_flat_state")]
     FlatState,
     /// Changes for flat state delta. Stores how flat state should be updated for the given shard and block.
-    /// - *Rows*: `KeyForFlatStateDelta { shard_id, block_hash }`
+    /// - *Rows*: `KeyForFlatStateDelta { shard_uid, block_hash }`
     /// - *Column type*: `FlatStateChanges`
     #[cfg(feature = "protocol_feature_flat_state")]
     FlatStateChanges,
     /// Metadata for flat state delta.
-    /// - *Rows*: `KeyForFlatStateDelta { shard_id, block_hash }`
+    /// - *Rows*: `KeyForFlatStateDelta { shard_uid, block_hash }`
     /// - *Column type*: `FlatStateDeltaMetadata`
     #[cfg(feature = "protocol_feature_flat_state")]
     FlatStateDeltaMetadata,
-    #[cfg(feature = "protocol_feature_flat_state")]
     /// Flat storage status for the corresponding shard.
-    /// - *Rows*: `shard_id`
+    /// - *Rows*: `shard_uid`
     /// - *Column type*: `FlatStorageStatus`
+    #[cfg(feature = "protocol_feature_flat_state")]
     FlatStorageStatus,
 }
 

--- a/core/store/src/flat/manager.rs
+++ b/core/store/src/flat/manager.rs
@@ -4,7 +4,7 @@ use crate::flat::{
 use near_primitives::errors::StorageError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::{ShardLayout, ShardUId};
-use near_primitives::types::ShardId;
+use near_primitives::types::{BlockHeight, ShardId};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use tracing::debug;
@@ -48,6 +48,7 @@ impl FlatStorageManager {
         store_update: &mut StoreUpdate,
         shard_uid: ShardUId,
         genesis_block: &CryptoHash,
+        genesis_height: BlockHeight,
     ) {
         let shard_id = shard_uid.shard_id();
         let flat_storages = self.0.flat_storages.lock().expect(POISONED_LOCK_ERR);
@@ -56,7 +57,7 @@ impl FlatStorageManager {
             store_update,
             shard_uid,
             FlatStorageStatus::Ready(FlatStorageReadyStatus {
-                flat_head: BlockInfo::genesis(*genesis_block),
+                flat_head: BlockInfo::genesis(*genesis_block, genesis_height),
             }),
         );
     }

--- a/core/store/src/flat/manager.rs
+++ b/core/store/src/flat/manager.rs
@@ -1,7 +1,9 @@
-use crate::flat::{store_helper, POISONED_LOCK_ERR};
+use crate::flat::{
+    store_helper, BlockInfo, FlatStorageReadyStatus, FlatStorageStatus, POISONED_LOCK_ERR,
+};
 use near_primitives::errors::StorageError;
 use near_primitives::hash::CryptoHash;
-use near_primitives::shard_layout::ShardLayout;
+use near_primitives::shard_layout::{ShardLayout, ShardUId};
 use near_primitives::types::ShardId;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -44,12 +46,19 @@ impl FlatStorageManager {
     pub fn set_flat_storage_for_genesis(
         &self,
         store_update: &mut StoreUpdate,
-        shard_id: ShardId,
+        shard_uid: ShardUId,
         genesis_block: &CryptoHash,
     ) {
+        let shard_id = shard_uid.shard_id();
         let flat_storages = self.0.flat_storages.lock().expect(POISONED_LOCK_ERR);
         assert!(!flat_storages.contains_key(&shard_id));
-        store_helper::set_flat_head(store_update, shard_id, genesis_block);
+        store_helper::set_flat_storage_status(
+            store_update,
+            shard_uid,
+            FlatStorageStatus::Ready(FlatStorageReadyStatus {
+                flat_head: BlockInfo::genesis(*genesis_block),
+            }),
+        );
     }
 
     /// Add a flat storage state for shard `shard_id`. The function also checks that

--- a/core/store/src/flat/mod.rs
+++ b/core/store/src/flat/mod.rs
@@ -36,7 +36,10 @@ pub use chunk_view::FlatStorageChunkView;
 pub use delta::{FlatStateChanges, FlatStateDelta, FlatStateDeltaMetadata};
 pub use manager::FlatStorageManager;
 pub use storage::FlatStorage;
-pub use types::{BlockInfo, FetchingStateStatus, FlatStorageCreationStatus, FlatStorageError};
+pub use types::{
+    BlockInfo, FetchingStateStatus, FlatStorageCreationStatus, FlatStorageError,
+    FlatStorageReadyStatus, FlatStorageStatus,
+};
 
 pub(crate) const POISONED_LOCK_ERR: &str = "The lock was poisoned.";
 

--- a/core/store/src/flat/store_helper.rs
+++ b/core/store/src/flat/store_helper.rs
@@ -2,23 +2,15 @@
 //! TODO(#8577): remove this file and move functions to the corresponding structs
 
 use crate::flat::delta::{FlatStateChanges, KeyForFlatStateDelta};
-use crate::flat::types::{FetchingStateStatus, FlatStorageCreationStatus, FlatStorageError};
+use crate::flat::types::FlatStorageError;
 use crate::{Store, StoreUpdate};
-use borsh::{BorshDeserialize, BorshSerialize};
-use byteorder::ReadBytesExt;
 use near_primitives::errors::StorageError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::{ShardLayout, ShardUId};
 use near_primitives::state::ValueRef;
-use near_primitives::types::ShardId;
 
-use super::delta::FlatStateDelta;
-use super::FlatStateDeltaMetadata;
-
-/// Prefixes determining type of flat storage creation status stored in DB.
-/// Note that non-existent status is treated as SavingDeltas if flat storage /// does not exist and Ready if it does.
-const FETCHING_STATE: u8 = 0;
-const CATCHING_UP: u8 = 1;
+use super::delta::{FlatStateDelta, FlatStateDeltaMetadata};
+use super::types::FlatStorageStatus;
 
 /// Prefixes for keys in `FlatStateMisc` DB column.
 pub const FLAT_STATE_HEAD_KEY_PREFIX: &[u8; 4] = b"HEAD";
@@ -31,7 +23,7 @@ pub enum FlatStateColumn {
     State,
     Changes,
     DeltaMetadata,
-    Misc,
+    Status,
 }
 
 impl FlatStateColumn {
@@ -41,7 +33,7 @@ impl FlatStateColumn {
             FlatStateColumn::State => crate::DBCol::FlatState,
             FlatStateColumn::Changes => crate::DBCol::FlatStateChanges,
             FlatStateColumn::DeltaMetadata => crate::DBCol::FlatStateDeltaMetadata,
-            FlatStateColumn::Misc => crate::DBCol::FlatStateMisc,
+            FlatStateColumn::Status => crate::DBCol::FlatStorageStatus,
         }
         #[cfg(not(feature = "protocol_feature_flat_state"))]
         panic!("protocol_feature_flat_state feature is not enabled")
@@ -88,31 +80,6 @@ pub fn remove_delta(store_update: &mut StoreUpdate, shard_uid: ShardUId, block_h
     let key = KeyForFlatStateDelta { shard_uid, block_hash }.to_bytes();
     store_update.delete(FlatStateColumn::Changes.to_db_col(), &key);
     store_update.delete(FlatStateColumn::DeltaMetadata.to_db_col(), &key);
-}
-
-fn flat_head_key(shard_id: ShardId) -> Vec<u8> {
-    let mut fetching_state_step_key = FLAT_STATE_HEAD_KEY_PREFIX.to_vec();
-    fetching_state_step_key.extend_from_slice(&shard_id.try_to_vec().unwrap());
-    fetching_state_step_key
-}
-
-pub fn get_flat_head(store: &Store, shard_id: ShardId) -> Option<CryptoHash> {
-    if !cfg!(feature = "protocol_feature_flat_state") {
-        return None;
-    }
-    store
-        .get_ser(FlatStateColumn::Misc.to_db_col(), &flat_head_key(shard_id))
-        .expect("Error reading flat head from storage")
-}
-
-pub fn set_flat_head(store_update: &mut StoreUpdate, shard_id: ShardId, val: &CryptoHash) {
-    store_update
-        .set_ser(FlatStateColumn::Misc.to_db_col(), &flat_head_key(shard_id), val)
-        .expect("Error writing flat head from storage")
-}
-
-pub fn remove_flat_head(store_update: &mut StoreUpdate, shard_id: ShardId) {
-    store_update.delete(FlatStateColumn::Misc.to_db_col(), &flat_head_key(shard_id));
 }
 
 fn encode_flat_state_db_key(shard_uid: ShardUId, key: &[u8]) -> Vec<u8> {
@@ -171,77 +138,24 @@ pub fn set_ref(
     }
 }
 
-fn creation_status_key(shard_id: ShardId) -> Vec<u8> {
-    let mut key = FLAT_STATE_CREATION_STATUS_KEY_PREFIX.to_vec();
-    key.extend_from_slice(&shard_id.try_to_vec().unwrap());
-    key
-}
-
-pub fn set_flat_storage_creation_status(
-    store_update: &mut StoreUpdate,
-    shard_id: ShardId,
-    status: FlatStorageCreationStatus,
-) {
-    let value = match status {
-        FlatStorageCreationStatus::FetchingState(status) => {
-            let mut value = vec![FETCHING_STATE];
-            value.extend_from_slice(&status.try_to_vec().unwrap());
-            value
-        }
-        FlatStorageCreationStatus::CatchingUp(block_hash) => {
-            let mut value = vec![CATCHING_UP];
-            value.extend_from_slice(block_hash.as_bytes());
-            value
-        }
-        status @ _ => {
-            panic!("Attempted to write incorrect flat storage creation status {status:?} for shard {shard_id}");
-        }
-    };
-    store_update.set(FlatStateColumn::Misc.to_db_col(), &creation_status_key(shard_id), &value);
-}
-
-pub fn get_flat_storage_creation_status(
-    store: &Store,
-    shard_id: ShardId,
-) -> FlatStorageCreationStatus {
+pub fn get_flat_storage_status(store: &Store, shard_uid: ShardUId) -> FlatStorageStatus {
     if !cfg!(feature = "protocol_feature_flat_state") {
-        return FlatStorageCreationStatus::DontCreate;
+        return FlatStorageStatus::Disabled;
     }
-
-    match get_flat_head(store, shard_id) {
-        Some(_) => {
-            return FlatStorageCreationStatus::Ready;
-        }
-        None => {}
-    }
-
-    let value = store
-        .get(FlatStateColumn::Misc.to_db_col(), &creation_status_key(shard_id))
-        .expect("Error reading status from storage");
-    match value {
-        None => FlatStorageCreationStatus::SavingDeltas,
-        Some(bytes) => {
-            let mut bytes = bytes.as_slice();
-            let status_type = bytes.read_u8().unwrap();
-            match status_type {
-                FETCHING_STATE => FlatStorageCreationStatus::FetchingState(
-                    FetchingStateStatus::try_from_slice(bytes).unwrap(),
-                ),
-                CATCHING_UP => FlatStorageCreationStatus::CatchingUp(
-                    CryptoHash::try_from_slice(bytes).unwrap(),
-                ),
-                value @ _ => {
-                    panic!(
-                            "Unexpected value type during getting flat storage creation status: {value}"
-                        );
-                }
-            }
-        }
-    }
+    store
+        .get_ser(FlatStateColumn::Status.to_db_col(), &shard_uid.to_bytes())
+        .expect("Error reading flat head from storage")
+        .unwrap_or(FlatStorageStatus::Empty)
 }
 
-pub fn remove_flat_storage_creation_status(store_update: &mut StoreUpdate, shard_id: ShardId) {
-    store_update.delete(FlatStateColumn::Misc.to_db_col(), &creation_status_key(shard_id));
+pub fn set_flat_storage_status(
+    store_update: &mut StoreUpdate,
+    shard_uid: ShardUId,
+    status: FlatStorageStatus,
+) {
+    store_update
+        .set_ser(FlatStateColumn::Status.to_db_col(), &shard_uid.to_bytes(), &status)
+        .expect("Borsh should not fail")
 }
 
 /// Iterate over flat storage entries for a given shard.

--- a/core/store/src/flat/types.rs
+++ b/core/store/src/flat/types.rs
@@ -94,18 +94,6 @@ pub enum FlatStorageCreationStatus {
     CatchingUp(CryptoHash),
 }
 
-impl Into<i64> for &FlatStorageCreationStatus {
-    /// Converts status to integer to export to prometheus later.
-    /// Cast inside enum does not work because it is not fieldless.
-    fn into(self) -> i64 {
-        match self {
-            FlatStorageCreationStatus::SavingDeltas => 0,
-            FlatStorageCreationStatus::FetchingState(_) => 1,
-            FlatStorageCreationStatus::CatchingUp(_) => 2,
-        }
-    }
-}
-
 /// Current step of fetching state to fill flat storage.
 #[derive(BorshSerialize, BorshDeserialize, Copy, Clone, Debug, PartialEq, Eq)]
 pub struct FetchingStateStatus {

--- a/core/store/src/flat/types.rs
+++ b/core/store/src/flat/types.rs
@@ -11,8 +11,8 @@ pub struct BlockInfo {
 }
 
 impl BlockInfo {
-    pub fn genesis(hash: CryptoHash) -> BlockInfo {
-        BlockInfo { hash, height: 0, prev_hash: CryptoHash::default() }
+    pub fn genesis(hash: CryptoHash, height: BlockHeight) -> BlockInfo {
+        BlockInfo { hash, height, prev_hash: CryptoHash::default() }
     }
 }
 

--- a/core/store/src/flat/types.rs
+++ b/core/store/src/flat/types.rs
@@ -38,7 +38,7 @@ impl From<FlatStorageError> for StorageError {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Debug, PartialEq, Eq)]
 pub enum FlatStorageStatus {
     /// 'protocol_feature_flat_state' is disabled
     Disabled,
@@ -65,7 +65,7 @@ impl Into<i64> for &FlatStorageStatus {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Debug, PartialEq, Eq)]
 pub struct FlatStorageReadyStatus {
     pub flat_head: BlockInfo,
 }

--- a/core/store/src/flat/types.rs
+++ b/core/store/src/flat/types.rs
@@ -40,10 +40,13 @@ impl From<FlatStorageError> for StorageError {
 
 #[derive(BorshSerialize, BorshDeserialize, Debug, PartialEq, Eq)]
 pub enum FlatStorageStatus {
-    /// 'protocol_feature_flat_state' is disabled
+    /// Flat Storage is not supported.
     Disabled,
+    /// Flat Storage is empty: either wasn't created yet or was deleted.
     Empty,
+    /// Flat Storage is in the process of being created.
     Creation(FlatStorageCreationStatus),
+    /// Flat Storage is ready to be used.
     Ready(FlatStorageReadyStatus),
 }
 

--- a/integration-tests/src/tests/client/flat_storage.rs
+++ b/integration-tests/src/tests/client/flat_storage.rs
@@ -6,10 +6,10 @@ use near_client::test_utils::TestEnv;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::shard_layout::{ShardLayout, ShardUId};
 use near_primitives::types::AccountId;
-use near_primitives_core::types::{BlockHeight, NumShards};
+use near_primitives_core::types::BlockHeight;
 use near_store::flat::{
-    store_helper, FetchingStateStatus, FlatStorageCreationStatus, FlatStorageStatus,
-    NUM_PARTS_IN_ONE_STEP,
+    store_helper, FetchingStateStatus, FlatStorageCreationStatus, FlatStorageReadyStatus,
+    FlatStorageStatus, NUM_PARTS_IN_ONE_STEP,
 };
 use near_store::test_utils::create_test_store;
 use near_store::{Store, TrieTraversalItem};
@@ -41,18 +41,19 @@ fn setup_env(genesis: &Genesis, store: Store) -> TestEnv {
 fn wait_for_flat_storage_creation(
     env: &mut TestEnv,
     start_height: BlockHeight,
+    shard_uid: ShardUId,
     produce_blocks: bool,
 ) -> BlockHeight {
     let store = env.clients[0].runtime_adapter.store().clone();
     let mut next_height = start_height;
-    let mut prev_status = store_helper::get_flat_storage_status(&store, 0);
+    let mut prev_status = store_helper::get_flat_storage_status(&store, shard_uid);
     while next_height < start_height + CREATION_TIMEOUT {
         if produce_blocks {
             env.produce_block(0, next_height);
         }
         env.clients[0].run_flat_storage_creation_step().unwrap();
 
-        let status = store_helper::get_flat_storage_status(&store, 0);
+        let status = store_helper::get_flat_storage_status(&store, shard_uid);
         // Check validity of state transition for flat storage creation.
         match &prev_status {
             FlatStorageStatus::Empty => assert_matches!(
@@ -94,7 +95,7 @@ fn wait_for_flat_storage_creation(
 
         thread::sleep(Duration::from_secs(1));
     }
-    let status = store_helper::get_flat_storage_status(&store, 0);
+    let status = store_helper::get_flat_storage_status(&store, shard_uid);
     assert_matches!(
         status,
         FlatStorageStatus::Ready(_),
@@ -122,13 +123,16 @@ fn test_flat_storage_creation() {
         if cfg!(feature = "protocol_feature_flat_state") {
             // If chain was initialized from scratch, flat storage state should be created. During block processing, flat
             // storage head should be moved to block `START_HEIGHT - 3`.
-            assert_eq!(
-                store_helper::get_flat_storage_creation_status(&store, 0),
-                FlatStorageCreationStatus::Ready
-            );
+            let flat_head_height = START_HEIGHT - 3;
             let expected_flat_storage_head =
-                env.clients[0].chain.get_block_hash_by_height(START_HEIGHT - 3).unwrap();
-            assert_eq!(store_helper::get_flat_head(&store, 0), Some(expected_flat_storage_head));
+                env.clients[0].chain.get_block_hash_by_height(flat_head_height).unwrap();
+            let status = store_helper::get_flat_storage_status(&store, shard_uid);
+            if let FlatStorageStatus::Ready(FlatStorageReadyStatus { flat_head }) = status {
+                assert_eq!(flat_head.hash, expected_flat_storage_head);
+                assert_eq!(flat_head.height, flat_head_height);
+            } else {
+                panic!("expected FlatStorageStatus::Ready status, got {status:?}");
+            }
 
             // Deltas for blocks until `START_HEIGHT - 2` should not exist.
             for height in 0..START_HEIGHT - 2 {
@@ -148,11 +152,10 @@ fn test_flat_storage_creation() {
                 );
             }
         } else {
-            assert_eq!(
-                store_helper::get_flat_storage_creation_status(&store, 0),
-                FlatStorageCreationStatus::DontCreate
+            assert_matches!(
+                store_helper::get_flat_storage_status(&store, shard_uid),
+                FlatStorageStatus::Disabled
             );
-            assert_eq!(store_helper::get_flat_head(&store, 0), None);
         }
 
         let block_hash = env.clients[0].chain.get_block_hash_by_height(START_HEIGHT - 1).unwrap();
@@ -169,20 +172,21 @@ fn test_flat_storage_creation() {
     assert!(env.clients[0].runtime_adapter.get_flat_storage_for_shard(0).is_none());
 
     if !cfg!(feature = "protocol_feature_flat_state") {
-        assert_eq!(
-            store_helper::get_flat_storage_creation_status(&store, 0),
-            FlatStorageCreationStatus::DontCreate
+        assert_matches!(
+            store_helper::get_flat_storage_status(&store, shard_uid),
+            FlatStorageStatus::Disabled
         );
-        assert_eq!(store_helper::get_flat_head(&store, 0), None);
         // Stop the test here.
         return;
     }
 
+    assert_eq!(store_helper::get_flat_storage_status(&store, shard_uid), FlatStorageStatus::Empty);
+    assert!(!env.clients[0].run_flat_storage_creation_step().unwrap());
     // At first, flat storage state should start saving deltas. Deltas for all newly processed blocks should be saved to
     // disk.
     assert_eq!(
-        store_helper::get_flat_storage_creation_status(&store, 0),
-        FlatStorageCreationStatus::SavingDeltas
+        store_helper::get_flat_storage_status(&store, shard_uid),
+        FlatStorageStatus::Creation(FlatStorageCreationStatus::SavingDeltas)
     );
     for height in START_HEIGHT..START_HEIGHT + 2 {
         let block_hash = env.clients[0].chain.get_block_hash_by_height(height).unwrap();
@@ -199,30 +203,29 @@ fn test_flat_storage_creation() {
     env.produce_block(0, START_HEIGHT + 2);
     assert!(!env.clients[0].run_flat_storage_creation_step().unwrap());
     let final_block_hash = env.clients[0].chain.get_block_hash_by_height(START_HEIGHT).unwrap();
-    assert_eq!(store_helper::get_flat_head(&store, 0), None);
     assert_eq!(
-        store_helper::get_flat_storage_creation_status(&store, 0),
-        FlatStorageCreationStatus::FetchingState(FetchingStateStatus {
-            block_hash: final_block_hash,
-            part_id: 0,
-            num_parts_in_step: NUM_PARTS_IN_ONE_STEP,
-            num_parts: 1,
-        })
+        store_helper::get_flat_storage_status(&store, shard_uid),
+        FlatStorageStatus::Creation(FlatStorageCreationStatus::FetchingState(
+            FetchingStateStatus {
+                block_hash: final_block_hash,
+                part_id: 0,
+                num_parts_in_step: NUM_PARTS_IN_ONE_STEP,
+                num_parts: 1,
+            }
+        ))
     );
 
-    wait_for_flat_storage_creation(&mut env, START_HEIGHT + 3, true);
+    wait_for_flat_storage_creation(&mut env, START_HEIGHT + 3, shard_uid, true);
 }
 
 /// Check that client can create flat storage on some shard while it already exists on another shard.
 #[test]
 fn test_flat_storage_creation_two_shards() {
     init_test_logger();
-    let num_shards: NumShards = 2;
-    let genesis = Genesis::test_sharded_new_version(
-        vec!["test0".parse().unwrap()],
-        1,
-        vec![1; num_shards as usize],
-    );
+    let num_shards = 2;
+    let genesis =
+        Genesis::test_sharded_new_version(vec!["test0".parse().unwrap()], 1, vec![1; num_shards]);
+    let shard_uids = genesis.config.shard_layout.get_shard_uids();
     let store = create_test_store();
 
     // Process some blocks with flat storages for two shards. Then remove flat storage data from disk for shard 0.
@@ -232,16 +235,16 @@ fn test_flat_storage_creation_two_shards() {
             env.produce_block(0, height);
         }
 
-        for shard_id in 0..num_shards {
+        for &shard_uid in &shard_uids {
             if cfg!(feature = "protocol_feature_flat_state") {
-                assert_eq!(
-                    store_helper::get_flat_storage_creation_status(&store, shard_id),
-                    FlatStorageCreationStatus::Ready
+                assert_matches!(
+                    store_helper::get_flat_storage_status(&store, shard_uid),
+                    FlatStorageStatus::Ready(_)
                 );
             } else {
-                assert_eq!(
-                    store_helper::get_flat_storage_creation_status(&store, shard_id),
-                    FlatStorageCreationStatus::DontCreate
+                assert_matches!(
+                    store_helper::get_flat_storage_status(&store, shard_uid),
+                    FlatStorageStatus::Disabled
                 );
             }
         }
@@ -258,17 +261,17 @@ fn test_flat_storage_creation_two_shards() {
     // Check that flat storage is not ready for shard 0 but ready for shard 1.
     let mut env = setup_env(&genesis, store.clone());
     assert!(env.clients[0].runtime_adapter.get_flat_storage_for_shard(0).is_none());
-    assert_eq!(
-        store_helper::get_flat_storage_creation_status(&store, 0),
-        FlatStorageCreationStatus::SavingDeltas
+    assert_matches!(
+        store_helper::get_flat_storage_status(&store, shard_uids[0]),
+        FlatStorageStatus::Empty
     );
     assert!(env.clients[0].runtime_adapter.get_flat_storage_for_shard(1).is_some());
-    assert_eq!(
-        store_helper::get_flat_storage_creation_status(&store, 1),
-        FlatStorageCreationStatus::Ready
+    assert_matches!(
+        store_helper::get_flat_storage_status(&store, shard_uids[1]),
+        FlatStorageStatus::Ready(_)
     );
 
-    wait_for_flat_storage_creation(&mut env, START_HEIGHT, true);
+    wait_for_flat_storage_creation(&mut env, START_HEIGHT, shard_uids[0], true);
 }
 
 /// Check that flat storage creation can be started from intermediate state where one
@@ -294,14 +297,14 @@ fn test_flat_storage_creation_start_from_state_part() {
         }
 
         if cfg!(feature = "protocol_feature_flat_state") {
-            assert_eq!(
-                store_helper::get_flat_storage_creation_status(&store, 0),
-                FlatStorageCreationStatus::Ready
+            assert_matches!(
+                store_helper::get_flat_storage_status(&store, shard_uid),
+                FlatStorageStatus::Ready(_)
             );
         } else {
-            assert_eq!(
-                store_helper::get_flat_storage_creation_status(&store, 0),
-                FlatStorageCreationStatus::DontCreate
+            assert_matches!(
+                store_helper::get_flat_storage_status(&store, shard_uid),
+                FlatStorageStatus::Disabled
             );
             return;
         }
@@ -338,21 +341,27 @@ fn test_flat_storage_creation_start_from_state_part() {
     if cfg!(feature = "protocol_feature_flat_state") {
         // Remove keys of part 1 from the flat state.
         // Manually set flat storage creation status to the step when it should start from fetching part 1.
-        let flat_head = store_helper::get_flat_head(&store, 0).unwrap();
+        let status = store_helper::get_flat_storage_status(&store, shard_uid);
+        let flat_head = if let FlatStorageStatus::Ready(ready_status) = status {
+            ready_status.flat_head.hash
+        } else {
+            panic!("expected FlatStorageStatus::Ready, got: {status:?}");
+        };
         let mut store_update = store.store_update();
         for key in trie_keys[1].iter() {
             store_helper::set_ref(&mut store_update, shard_uid, key.clone(), None).unwrap();
         }
-        store_helper::remove_flat_head(&mut store_update, 0);
-        store_helper::set_flat_storage_creation_status(
+        store_helper::set_flat_storage_status(
             &mut store_update,
-            0,
-            FlatStorageCreationStatus::FetchingState(FetchingStateStatus {
-                block_hash: flat_head,
-                part_id: 1,
-                num_parts_in_step: 1,
-                num_parts: NUM_PARTS,
-            }),
+            shard_uid,
+            FlatStorageStatus::Creation(FlatStorageCreationStatus::FetchingState(
+                FetchingStateStatus {
+                    block_hash: flat_head,
+                    part_id: 1,
+                    num_parts_in_step: 1,
+                    num_parts: NUM_PARTS,
+                },
+            )),
         );
         store_update.commit().unwrap();
 
@@ -361,7 +370,7 @@ fn test_flat_storage_creation_start_from_state_part() {
         assert!(env.clients[0].runtime_adapter.get_flat_storage_for_shard(0).is_none());
 
         // Run chain for a couple of blocks and check that flat storage for shard 0 is eventually created.
-        let next_height = wait_for_flat_storage_creation(&mut env, START_HEIGHT, true);
+        let next_height = wait_for_flat_storage_creation(&mut env, START_HEIGHT, shard_uid, true);
 
         // Check that all the keys are present in flat storage.
         let block_hash = env.clients[0].chain.get_block_hash_by_height(next_height - 1).unwrap();
@@ -392,6 +401,7 @@ fn test_cachup_succeeds_even_if_no_new_blocks() {
     init_test_logger();
     let genesis = Genesis::test(vec!["test0".parse().unwrap()], 1);
     let store = create_test_store();
+    let shard_uid = ShardLayout::v0_single_shard().get_shard_uids()[0];
 
     // Process some blocks with flat storage. Then remove flat storage data from disk.
     {
@@ -406,10 +416,7 @@ fn test_cachup_succeeds_even_if_no_new_blocks() {
     }
     let mut env = setup_env(&genesis, store.clone());
     assert!(env.clients[0].runtime_adapter.get_flat_storage_for_shard(0).is_none());
-    assert_eq!(
-        store_helper::get_flat_storage_creation_status(&store, 0),
-        FlatStorageCreationStatus::SavingDeltas
-    );
+    assert_eq!(store_helper::get_flat_storage_status(&store, shard_uid), FlatStorageStatus::Empty);
     // Create 3 more blocks (so that the deltas are generated) - and assume that no new blocks are received.
     // In the future, we should also support the scenario where no new blocks are created.
 
@@ -418,7 +425,7 @@ fn test_cachup_succeeds_even_if_no_new_blocks() {
     }
 
     assert!(!env.clients[0].run_flat_storage_creation_step().unwrap());
-    wait_for_flat_storage_creation(&mut env, START_HEIGHT + 3, false);
+    wait_for_flat_storage_creation(&mut env, START_HEIGHT + 3, shard_uid, false);
 }
 
 /// Tests the flat storage iterator. Running on a chain with 3 shards, and couple blocks produced.
@@ -426,15 +433,14 @@ fn test_cachup_succeeds_even_if_no_new_blocks() {
 #[test]
 fn test_flat_storage_iter() {
     init_test_logger();
-    let num_shards: NumShards = 3;
-
+    let num_shards = 3;
     let shard_layout =
         ShardLayout::v1(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], vec![], None, 0);
 
     let genesis = Genesis::test_with_seeds(
         vec!["test0".parse().unwrap()],
         1,
-        vec![1; num_shards as usize],
+        vec![1; num_shards],
         shard_layout.clone(),
     );
 

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -1768,7 +1768,7 @@ mod test {
             // and use a mock chain, so we need to initialize flat storage manually.
             if cfg!(feature = "protocol_feature_flat_state") {
                 let store_update = runtime
-                    .set_flat_storage_for_genesis(&genesis_hash, &EpochId::default())
+                    .set_flat_storage_for_genesis(&genesis_hash, 0, &EpochId::default())
                     .unwrap();
                 store_update.commit().unwrap();
                 for shard_id in 0..runtime.num_shards(&EpochId::default()).unwrap() {

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -759,6 +759,7 @@ impl RuntimeAdapter for NightshadeRuntime {
     fn set_flat_storage_for_genesis(
         &self,
         genesis_block: &CryptoHash,
+        genesis_block_height: BlockHeight,
         genesis_epoch_id: &EpochId,
     ) -> Result<StoreUpdate, Error> {
         let mut store_update = self.store.store_update();
@@ -768,6 +769,7 @@ impl RuntimeAdapter for NightshadeRuntime {
                 &mut store_update,
                 shard_uid,
                 genesis_block,
+                genesis_block_height,
             );
         }
         Ok(store_update)

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -157,7 +157,7 @@ impl<'c> EstimatorContext<'c> {
             &mut store_update,
             shard_uid,
             FlatStorageStatus::Ready(FlatStorageReadyStatus {
-                flat_head: BlockInfo::genesis(FLAT_STATE_HEAD),
+                flat_head: BlockInfo::genesis(FLAT_STATE_HEAD, 0),
             }),
         );
         store_update.commit().expect("failed to set flat storage status");

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -11,7 +11,10 @@ use near_primitives::test_utils::MockEpochInfoProvider;
 use near_primitives::transaction::{ExecutionStatus, SignedTransaction};
 use near_primitives::types::{Gas, MerkleHash};
 use near_primitives::version::PROTOCOL_VERSION;
-use near_store::flat::{store_helper, FlatStorage, FlatStorageManager};
+use near_store::flat::{
+    store_helper, BlockInfo, FlatStorage, FlatStorageManager, FlatStorageReadyStatus,
+    FlatStorageStatus,
+};
 use near_store::{ShardTries, ShardUId, Store, StoreCompiledContractCache, TrieUpdate};
 use near_store::{TrieCache, TrieCachingStorage, TrieConfig};
 use near_vm_logic::{ExtCosts, VMLimitConfig};
@@ -150,8 +153,14 @@ impl<'c> EstimatorContext<'c> {
         let shard_uid = ShardUId::single_shard();
         // Set up flat head to be equal to the latest block height
         let mut store_update = store.store_update();
-        store_helper::set_flat_head(&mut store_update, shard_uid.shard_id(), &FLAT_STATE_HEAD);
-        store_update.commit().expect("failed to set flat head");
+        store_helper::set_flat_storage_status(
+            &mut store_update,
+            shard_uid,
+            FlatStorageStatus::Ready(FlatStorageReadyStatus {
+                flat_head: BlockInfo::genesis(FLAT_STATE_HEAD),
+            }),
+        );
+        store_update.commit().expect("failed to set flat storage status");
         let flat_storage = FlatStorage::new(store, shard_uid, cache_capacity as usize);
         flat_storage_manager.add_flat_storage_for_shard(shard_uid.shard_id(), flat_storage);
         flat_storage_manager


### PR DESCRIPTION
Part of #8577

This PR introduces `FlatStorageStatus`:
* it generalises `FlatStorageCreationStatus`
* `FlatStorageCreationStatus::DontCreate` is moved to `::Disabled` status
* flat head is now stored as a part of `::Ready` status.
* `::Empty` status is added to explicitly express that flat storage does not exist
* we no longer need `FlatStateMisc` column, so it is removed 

nayduck run: https://nayduck.near.org/#/run/2905



