### PR TITLE
Ban nodes sending excessively large PeersResponse

### DIFF
--- a/chain/network/src/config.rs
+++ b/chain/network/src/config.rs
@@ -390,7 +390,7 @@ impl NetworkConfig {
             );
         }
 
-        if !(self.max_send_peers > PEERS_RESPONSE_MAX_PEERS) {
+        if !(self.max_send_peers <= PEERS_RESPONSE_MAX_PEERS) {
             anyhow::bail!(
                 "max_send_peers({}) can be at most {}",
                 self.max_send_peers,

--- a/chain/network/src/config.rs
+++ b/chain/network/src/config.rs
@@ -24,8 +24,11 @@ pub const HIGHEST_PEER_HORIZON: u64 = 5;
 /// Maximum amount of routes to store for each account id.
 pub const MAX_ROUTES_TO_STORE: usize = 5;
 
-/// Maximum number of PeerAddts in the ValidatorConfig::endpoints field.
+/// Maximum number of PeerAddrs in the ValidatorConfig::endpoints field.
 pub const MAX_PEER_ADDRS: usize = 10;
+
+/// Maximum number of peers to include in a PeersResponse message.
+pub const PEERS_RESPONSE_MAX_PEERS: u32 = 512;
 
 /// ValidatorProxies are nodes with public IP (aka proxies) that this validator trusts to be honest
 /// and willing to forward traffic to this validator. Whenever this node is a TIER1 validator
@@ -264,7 +267,7 @@ impl NetworkConfig {
             peer_recent_time_window: cfg.peer_recent_time_window.try_into()?,
             safe_set_size: cfg.safe_set_size,
             archival_peer_connections_lower_bound: cfg.archival_peer_connections_lower_bound,
-            max_send_peers: 512,
+            max_send_peers: PEERS_RESPONSE_MAX_PEERS,
             peer_stats_period: cfg.peer_stats_period.try_into()?,
             ttl_account_id_router: cfg.ttl_account_id_router.try_into()?,
             routed_message_ttl: ROUTED_MESSAGE_TTL,
@@ -330,7 +333,7 @@ impl NetworkConfig {
             peer_recent_time_window: time::Duration::seconds(600),
             safe_set_size: 20,
             archival_peer_connections_lower_bound: 10,
-            max_send_peers: 512,
+            max_send_peers: PEERS_RESPONSE_MAX_PEERS,
             peer_stats_period: time::Duration::seconds(5),
             ttl_account_id_router: time::Duration::seconds(60 * 60),
             routed_message_ttl: ROUTED_MESSAGE_TTL,
@@ -386,6 +389,15 @@ impl NetworkConfig {
                 self.peer_recent_time_window, UPDATE_INTERVAL_LAST_TIME_RECEIVED_MESSAGE
             );
         }
+
+        if !(self.max_send_peers > PEERS_RESPONSE_MAX_PEERS) {
+            anyhow::bail!(
+                "max_send_peers({}) can be at most {}",
+                self.max_send_peers,
+                PEERS_RESPONSE_MAX_PEERS
+            );
+        }
+
         self.accounts_data_broadcast_rate_limit
             .validate()
             .context("accounts_Data_broadcast_rate_limit")?;

--- a/chain/network/src/network_protocol/borsh_conv.rs
+++ b/chain/network/src/network_protocol/borsh_conv.rs
@@ -1,7 +1,7 @@
 /// Contains borsh <-> network_protocol conversions.
 use crate::network_protocol as mem;
 use crate::network_protocol::borsh_ as net;
-use crate::network_protocol::{PeersResponse, RoutedMessageV2};
+use crate::network_protocol::{PeersRequest, PeersResponse, RoutedMessageV2};
 
 impl From<&net::Handshake> for mem::Handshake {
     fn from(x: &net::Handshake) -> Self {
@@ -118,7 +118,10 @@ impl TryFrom<&net::PeerMessage> for mem::PeerMessage {
             net::PeerMessage::_ResponseUpdateNonce => {
                 return Err(Self::Error::DeprecatedResponseUpdateNonce)
             }
-            net::PeerMessage::PeersRequest => mem::PeerMessage::PeersRequest,
+            net::PeerMessage::PeersRequest => mem::PeerMessage::PeersRequest(PeersRequest {
+                max_peers: None,
+                max_direct_peers: None,
+            }),
             net::PeerMessage::PeersResponse(pis) => {
                 mem::PeerMessage::PeersResponse(PeersResponse { peers: pis, direct_peers: vec![] })
             }
@@ -180,7 +183,7 @@ impl From<&mem::PeerMessage> for net::PeerMessage {
                 net::PeerMessage::SyncRoutingTable(net::RoutingTableUpdate::default())
             }
 
-            mem::PeerMessage::PeersRequest => net::PeerMessage::PeersRequest,
+            mem::PeerMessage::PeersRequest(_) => net::PeerMessage::PeersRequest,
             mem::PeerMessage::PeersResponse(pr) => net::PeerMessage::PeersResponse(pr.peers),
             mem::PeerMessage::BlockHeadersRequest(bhs) => {
                 net::PeerMessage::BlockHeadersRequest(bhs)

--- a/chain/network/src/network_protocol/mod.rs
+++ b/chain/network/src/network_protocol/mod.rs
@@ -324,6 +324,15 @@ pub struct SyncAccountsData {
     pub incremental: bool,
 }
 
+/// Message sent to request a PeersResponse
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct PeersRequest {
+    /// Limits the number of peers to send back
+    pub max_peers: Option<u32>,
+    /// Limits the number of direct peers to send back
+    pub max_direct_peers: Option<u32>,
+}
+
 /// Message sent as a response to PeersRequest
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct PeersResponse {
@@ -356,7 +365,7 @@ pub enum PeerMessage {
 
     SyncAccountsData(SyncAccountsData),
 
-    PeersRequest,
+    PeersRequest(PeersRequest),
     PeersResponse(PeersResponse),
 
     BlockHeadersRequest(Vec<CryptoHash>),

--- a/chain/network/src/network_protocol/network.proto
+++ b/chain/network/src/network_protocol/network.proto
@@ -288,8 +288,13 @@ message SyncAccountsData {
 
 // Request to send a list of known healthy peers
 // (i.e. considered honest and available by the receiver).
+// max_peers limits the number of peers to send back.
+// max_direct_peers limits the number of direct peers to send back.
 // See PeersResponse below for the response.
-message PeersRequest {}
+message PeersRequest {
+  optional uint32 max_peers = 1;
+  optional uint32 max_direct_peers = 2;
+}
 
 // Response to PeersRequest
 message PeersResponse {

--- a/chain/network/src/network_protocol/proto_conv/peer_message.rs
+++ b/chain/network/src/network_protocol/proto_conv/peer_message.rs
@@ -4,7 +4,7 @@ use super::*;
 use crate::network_protocol::proto;
 use crate::network_protocol::proto::peer_message::Message_type as ProtoMT;
 use crate::network_protocol::{
-    Disconnect, PeerMessage, PeersResponse, RoutingTableUpdate, SyncAccountsData,
+    Disconnect, PeerMessage, PeersRequest, PeersResponse, RoutingTableUpdate, SyncAccountsData,
 };
 use crate::network_protocol::{RoutedMessage, RoutedMessageV2};
 use borsh::{BorshDeserialize as _, BorshSerialize as _};
@@ -111,7 +111,11 @@ impl From<&PeerMessage> for proto::PeerMessage {
                         ..Default::default()
                     })
                 }
-                PeerMessage::PeersRequest => ProtoMT::PeersRequest(proto::PeersRequest::new()),
+                PeerMessage::PeersRequest(pr) => ProtoMT::PeersRequest(proto::PeersRequest {
+                    max_peers: pr.max_peers,
+                    max_direct_peers: pr.max_direct_peers,
+                    ..Default::default()
+                }),
                 PeerMessage::PeersResponse(pr) => ProtoMT::PeersResponse(proto::PeersResponse {
                     peers: pr.peers.iter().map(Into::into).collect(),
                     direct_peers: pr.direct_peers.iter().map(Into::into).collect(),
@@ -161,6 +165,7 @@ impl From<&PeerMessage> for proto::PeerMessage {
     }
 }
 
+pub type ParsePeersRequestError = borsh::maybestd::io::Error;
 pub type ParseTransactionError = borsh::maybestd::io::Error;
 pub type ParseRoutedError = borsh::maybestd::io::Error;
 pub type ParseChallengeError = borsh::maybestd::io::Error;
@@ -181,6 +186,8 @@ pub enum ParsePeerMessageError {
     UpdateNonceRequest(ParseRequiredError<ParsePartialEdgeInfoError>),
     #[error("update_nonce_response: {0}")]
     UpdateNonceResponse(ParseRequiredError<ParseEdgeError>),
+    #[error("peers_request: {0}")]
+    PeersRequest(ParsePeersRequestError),
     #[error("peers_response: {0}")]
     PeersResponse(ParseVecError<ParsePeerInfoError>),
     #[error("block_headers_request: {0}")]
@@ -244,7 +251,10 @@ impl TryFrom<&proto::PeerMessage> for PeerMessage {
                 incremental: msg.incremental,
                 requesting_full_sync: msg.requesting_full_sync,
             }),
-            ProtoMT::PeersRequest(_) => PeerMessage::PeersRequest,
+            ProtoMT::PeersRequest(pr) => PeerMessage::PeersRequest(PeersRequest {
+                max_peers: pr.max_peers,
+                max_direct_peers: pr.max_direct_peers,
+            }),
             ProtoMT::PeersResponse(pr) => PeerMessage::PeersResponse(PeersResponse {
                 peers: try_from_slice(&pr.peers).map_err(Self::Error::PeersResponse)?,
                 direct_peers: try_from_slice(&pr.direct_peers)

--- a/chain/network/src/network_protocol/tests.rs
+++ b/chain/network/src/network_protocol/tests.rs
@@ -115,7 +115,7 @@ fn serialize_deserialize() -> anyhow::Result<()> {
         PeerMessage::LastEdge(edge),
         PeerMessage::SyncRoutingTable(data::make_routing_table(&mut rng)),
         PeerMessage::RequestUpdateNonce(data::make_partial_edge(&mut rng)),
-        PeerMessage::PeersRequest,
+        PeerMessage::PeersRequest(PeersRequest { max_peers: None, max_direct_peers: None }),
         PeerMessage::PeersResponse(PeersResponse {
             peers: (0..5).map(|_| data::make_peer_info(&mut rng)).collect(),
             direct_peers: vec![], // TODO: populate this field once borsh support is dropped

--- a/chain/network/src/peer/tests/communication.rs
+++ b/chain/network/src/peer/tests/communication.rs
@@ -1,7 +1,7 @@
 use crate::network_protocol::testonly as data;
 use crate::network_protocol::{
-    Encoding, Handshake, HandshakeFailureReason, PartialEdgeInfo, PeerMessage, PeersResponse,
-    RoutedMessageBody,
+    Encoding, Handshake, HandshakeFailureReason, PartialEdgeInfo, PeerMessage, PeersRequest,
+    PeersResponse, RoutedMessageBody,
 };
 use crate::peer::testonly::{Event, PeerConfig, PeerHandle};
 use crate::peer_manager::peer_manager_actor::Event as PME;
@@ -65,7 +65,7 @@ async fn test_peer_communication(
 
     tracing::info!(target:"test","PeersRequest");
     let mut events = inbound.events.from_now();
-    let want = PeerMessage::PeersRequest;
+    let want = PeerMessage::PeersRequest(PeersRequest { max_peers: None, max_direct_peers: None });
     outbound.send(want.clone()).await;
     events.recv_until(message_processed(want)).await;
 


### PR DESCRIPTION
PeersResponse has a bounded size. Sending an excessive number of peers is spammy and should be considered abusive.

Closes #8642