### PR TITLE
Fix unwanted UnknownChunk warning log messages.

### DIFF
--- a/chain/chunks/src/metrics.rs
+++ b/chain/chunks/src/metrics.rs
@@ -51,3 +51,15 @@ pub static PARTIAL_ENCODED_CHUNK_FORWARD_CACHED_WITHOUT_HEADER: Lazy<Counter> = 
     )
     .unwrap()
 });
+
+pub static PARTIAL_ENCODED_CHUNK_FORWARD_CACHED_WITHOUT_PREV_BLOCK: Lazy<Counter> = Lazy::new(
+    || {
+        near_o11y::metrics::try_create_counter(
+        "near_partial_encoded_chunk_forward_cached_without_prev_block",
+        concat!(
+            "Number of times we received a partial encoded chunk forward without having the previous block to fully validate it, so we cached it"
+        ),
+    )
+    .unwrap()
+    },
+);


### PR DESCRIPTION
See https://near.zulipchat.com/#narrow/stream/295302-general/topic/UnknownChunk.20bug.20report

Problem:
> Getting a lot of "WARN chunks: Error processing partial encoded chunk forward: UnknownChunk" in the testnet after upgrading to 1.32.0-rc.1

Cause:
> This "error" happens in a normal code path (where we cache a forwarded chunk even if header isn't available - what Marcin said), so there's nothing wrong. However, a recent refactoring changed the handler of this error, and instead of ignoring it, it was printed out.

Fix: don't return error anymore. This is no longer necessary after migrating ShardsManager to its own actor. Verified that unit tests still have good coverage even without asserting the error (a test fails if one of the insertion statements is commented out). Also rename one of the prometheus metrics to distinguish the two subtle caching cases.