### PR TITLE
[TestLoop] (9.1/n) Forgot to include the tests into the source tree.

### DIFF
--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -2004,6 +2004,9 @@ impl PartialEncodedChunkResponseSource {
 
 #[cfg(test)]
 mod test {
+    mod basic;
+    mod multi;
+
     use assert_matches::assert_matches;
     use near_async::messaging::IntoSender;
     use near_chain::types::EpochManagerAdapter;


### PR DESCRIPTION
Oops.