### PR TITLE
use split store in state-viewer

### DIFF
--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -136,7 +136,8 @@ pub(super) struct StateViewerCommand {
     #[clap(long, short = 'w')]
     readwrite: bool,
     /// What store temperature should the state viewer open. Allowed values are hot and cold but
-    /// cold is only available when cold_store feature is enabled.
+    /// cold is only available when cold_store is configured.
+    /// Cold temperature actually means the split store will be used.
     #[clap(long, short = 't', default_value = "hot")]
     store_temperature: near_store::Temperature,
     #[clap(subcommand)]

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -106,6 +106,7 @@ impl StateViewerSubCommand {
         let storage = store_opener.open_in_mode(mode).unwrap();
         let store = match temperature {
             Temperature::Hot => storage.get_hot_store(),
+            // Cold store on it's own is useless in majority of subcommandsst
             Temperature::Cold => storage.get_split_store().unwrap(),
         };
 

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -106,7 +106,7 @@ impl StateViewerSubCommand {
         let storage = store_opener.open_in_mode(mode).unwrap();
         let store = match temperature {
             Temperature::Hot => storage.get_hot_store(),
-            // Cold store on it's own is useless in majority of subcommandsst
+            // Cold store on it's own is useless in majority of subcommands
             Temperature::Cold => storage.get_split_store().unwrap(),
         };
 

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -106,7 +106,7 @@ impl StateViewerSubCommand {
         let storage = store_opener.open_in_mode(mode).unwrap();
         let store = match temperature {
             Temperature::Hot => storage.get_hot_store(),
-            Temperature::Cold => storage.get_cold_store().unwrap(),
+            Temperature::Cold => storage.get_split_store().unwrap(),
         };
 
         match self {


### PR DESCRIPTION
State viewer is pretty much useless with cold db only.
Replacing cold store with split store in case Temperature::Cold was provided. 
If you feel bad about this decision, choose one of these alternative options:
- introduce some config flag that essentially means "use_split_store_in_state_viewer_instead_of_cold"
- introduce third Temperature -- Split
- introduce StoreType enum in neard with hot, cold, and split and use it in args instead of Temperature