### PR TITLE
cleanup: Remove `SECONDS_PER_PETAGAS` metric

### DIFF
--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -245,11 +245,6 @@ impl InfoHelper {
         let avg_bls = (self.num_blocks_processed as f64)
             / (self.started.elapsed().as_millis() as f64)
             * 1000.0;
-        let chunks_per_block = if self.num_blocks_processed > 0 {
-            (self.num_chunks_in_blocks_processed as f64) / (self.num_blocks_processed as f64)
-        } else {
-            0.
-        };
         let avg_gas_used =
             ((self.gas_used as f64) / (self.started.elapsed().as_millis() as f64) * 1000.0) as u64;
         let blocks_info_log =
@@ -289,13 +284,6 @@ impl InfoHelper {
         (metrics::CPU_USAGE.set(cpu_usage as i64));
         (metrics::MEMORY_USAGE.set((memory_usage * 1024) as i64));
         (metrics::PROTOCOL_UPGRADE_BLOCK_HEIGHT.set(protocol_upgrade_block_height as i64));
-
-        // TODO: Deprecated.
-        (metrics::BLOCKS_PER_MINUTE.set((avg_bls * (60 as f64)) as i64));
-        // TODO: Deprecated.
-        (metrics::CHUNKS_PER_BLOCK_MILLIS.set((1000. * chunks_per_block) as i64));
-        // TODO: Deprecated.
-        (metrics::AVG_TGAS_USAGE.set((avg_gas_used as f64 / TERAGAS).round() as i64));
 
         // In case we can't get the list of validators for the current and the previous epoch,
         // skip updating the per-validator metrics.

--- a/chain/client/src/metrics.rs
+++ b/chain/client/src/metrics.rs
@@ -43,20 +43,6 @@ pub(crate) static SENT_BYTES_PER_SECOND: Lazy<IntGauge> = Lazy::new(|| {
     .unwrap()
 });
 
-// Deprecated.
-pub(crate) static BLOCKS_PER_MINUTE: Lazy<IntGauge> = Lazy::new(|| {
-    try_create_int_gauge("near_blocks_per_minute", "Blocks produced per minute").unwrap()
-});
-
-// Deprecated.
-pub(crate) static CHUNKS_PER_BLOCK_MILLIS: Lazy<IntGauge> = Lazy::new(|| {
-    try_create_int_gauge(
-        "near_chunks_per_block_millis",
-        "Average number of chunks included in blocks",
-    )
-    .unwrap()
-});
-
 pub(crate) static CPU_USAGE: Lazy<IntGauge> =
     Lazy::new(|| try_create_int_gauge("near_cpu_usage_ratio", "Percent of CPU usage").unwrap());
 
@@ -66,15 +52,6 @@ pub(crate) static MEMORY_USAGE: Lazy<IntGauge> = Lazy::new(|| {
 
 pub(crate) static GC_TIME: Lazy<Histogram> = Lazy::new(|| {
     try_create_histogram("near_gc_time", "Time taken to do garbage collection").unwrap()
-});
-
-// Deprecated.
-pub(crate) static AVG_TGAS_USAGE: Lazy<IntGauge> = Lazy::new(|| {
-    try_create_int_gauge(
-        "near_chunk_tgas_used",
-        "Number of Tgas (10^12 of gas) used by the last processed chunks",
-    )
-    .unwrap()
 });
 
 pub(crate) static TGAS_USAGE_HIST: Lazy<HistogramVec> = Lazy::new(|| {

--- a/nearcore/src/metrics.rs
+++ b/nearcore/src/metrics.rs
@@ -15,20 +15,6 @@ pub static APPLY_CHUNK_DELAY: Lazy<HistogramVec> = Lazy::new(|| {
         .unwrap()
 });
 
-pub static SECONDS_PER_PETAGAS: Lazy<HistogramVec> = Lazy::new(|| {
-    try_create_histogram_vec(
-        "near_execution_seconds_per_petagas_ratio",
-        "Execution time per unit of gas, measured in seconds per petagas. Ignore label 'label'.",
-        &["shard_id"],
-        // Non-linear buckets with higher resolution around 1.0.
-        Some(vec![
-            0.0, 0.1, 0.2, 0.5, 0.7, 0.8, 0.9, 0.95, 0.97, 0.99, 1.0, 1.01, 1.03, 1.05, 1.1, 1.2,
-            1.3, 1.5, 2.0, 5.0, 10.0,
-        ]),
-    )
-    .unwrap()
-});
-
 pub(crate) static CONFIG_CORRECT: Lazy<IntGauge> = Lazy::new(|| {
     try_create_int_gauge(
         "near_config_correct",

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -531,11 +531,6 @@ impl NightshadeRuntime {
         metrics::APPLY_CHUNK_DELAY
             .with_label_values(&[&format_total_gas_burnt(total_gas_burnt)])
             .observe(elapsed.as_secs_f64());
-        if total_gas_burnt > 0 {
-            metrics::SECONDS_PER_PETAGAS
-                .with_label_values(&[&shard_id.to_string()])
-                .observe(elapsed.as_secs_f64() * 1e15 / total_gas_burnt as f64);
-        }
         let total_balance_burnt = apply_result
             .stats
             .tx_burnt_amount


### PR DESCRIPTION
As is turned out to be too noisy, hard to aggregate and not allowing to filter out chunks with small gas usage. We have better metrics based on average gas usage and apply delays.

I've added an alternative metric at panel "Processing time per gas burnt" at https://nearinc.grafana.net/goto/UvpFf7-4z?orgId=1 which ended up less noisy and easier to work with.