### PR TITLE
feat: use shard uids in deltas

### DIFF
--- a/chain/chain/src/flat_storage_creator.rs
+++ b/chain/chain/src/flat_storage_creator.rs
@@ -43,7 +43,7 @@ struct FlatStorageCreationMetrics {
 /// This struct is responsible for this process for the given shard.
 /// See doc comment on [`FlatStorageCreationStatus`] for the details of the process.
 pub struct FlatStorageShardCreator {
-    shard_id: ShardId,
+    shard_uid: ShardUId,
     /// Height on top of which this struct was created.
     start_height: BlockHeight,
     runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
@@ -62,17 +62,17 @@ impl FlatStorageShardCreator {
     const CATCH_UP_BLOCKS: usize = 50;
 
     pub fn new(
-        shard_id: ShardId,
+        shard_uid: ShardUId,
         start_height: BlockHeight,
         runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
     ) -> Self {
         let (fetched_parts_sender, fetched_parts_receiver) = unbounded();
         // `itoa` is much faster for printing shard_id to a string than trivial alternatives.
         let mut buffer = itoa::Buffer::new();
-        let shard_id_label = buffer.format(shard_id);
+        let shard_id_label = buffer.format(shard_uid.shard_id());
 
         Self {
-            shard_id,
+            shard_uid,
             start_height,
             runtime_adapter,
             remaining_state_parts: None,
@@ -163,10 +163,10 @@ impl FlatStorageShardCreator {
         chain_store: &ChainStore,
         thread_pool: &rayon::ThreadPool,
     ) -> Result<bool, Error> {
+        let shard_id = self.shard_uid.shard_id();
         let current_status =
-            store_helper::get_flat_storage_creation_status(chain_store.store(), self.shard_id);
+            store_helper::get_flat_storage_creation_status(chain_store.store(), shard_id);
         self.metrics.status.set((&current_status).into());
-        let shard_id = self.shard_id;
         match &current_status {
             FlatStorageCreationStatus::SavingDeltas => {
                 let final_head = chain_store.final_head()?;
@@ -189,7 +189,7 @@ impl FlatStorageShardCreator {
                                 assert_matches!(
                                     store_helper::get_delta_changes(
                                         chain_store.store(),
-                                        shard_id,
+                                        self.shard_uid,
                                         *hash
                                     ),
                                     Ok(Some(_))
@@ -334,7 +334,7 @@ impl FlatStorageShardCreator {
                         break;
                     }
                     flat_head = chain_store.get_next_block_hash(&flat_head).unwrap();
-                    let changes = store_helper::get_delta_changes(store, shard_id, flat_head)
+                    let changes = store_helper::get_delta_changes(store, self.shard_uid, flat_head)
                         .unwrap()
                         .unwrap();
                     merged_changes.merge(changes);
@@ -382,7 +382,7 @@ impl FlatStorageShardCreator {
 
 /// Creates flat storages for all shards.
 pub struct FlatStorageCreator {
-    pub shard_creators: HashMap<ShardId, FlatStorageShardCreator>,
+    pub shard_creators: HashMap<ShardUId, FlatStorageShardCreator>,
     /// Used to spawn threads for traversing state parts.
     pub pool: rayon::ThreadPool,
 }
@@ -398,24 +398,24 @@ impl FlatStorageCreator {
     ) -> Result<Option<Self>, Error> {
         let chain_head = chain_store.head()?;
         let num_shards = runtime_adapter.num_shards(&chain_head.epoch_id)?;
-        let mut shard_creators: HashMap<ShardId, FlatStorageShardCreator> = HashMap::new();
+        let mut shard_creators: HashMap<ShardUId, FlatStorageShardCreator> = HashMap::new();
         let mut creation_needed = false;
         for shard_id in 0..num_shards {
             if runtime_adapter.cares_about_shard(me, &chain_head.prev_block_hash, shard_id, true) {
                 let status = runtime_adapter.get_flat_storage_creation_status(shard_id);
+                let shard_uid = runtime_adapter.shard_id_to_uid(shard_id, &chain_head.epoch_id)?;
+
                 match status {
                     FlatStorageCreationStatus::Ready => {
-                        let shard_uid =
-                            runtime_adapter.shard_id_to_uid(shard_id, &chain_head.epoch_id)?;
                         runtime_adapter.create_flat_storage_for_shard(shard_uid);
                     }
                     FlatStorageCreationStatus::DontCreate => {}
                     _ => {
                         creation_needed = true;
                         shard_creators.insert(
-                            shard_id,
+                            shard_uid,
                             FlatStorageShardCreator::new(
-                                shard_id,
+                                shard_uid,
                                 chain_head.height,
                                 runtime_adapter.clone(),
                             ),

--- a/chain/chain/src/flat_storage_creator.rs
+++ b/chain/chain/src/flat_storage_creator.rs
@@ -17,7 +17,7 @@ use near_o11y::metrics::{IntCounter, IntGauge};
 use near_primitives::shard_layout::ShardUId;
 use near_primitives::state::ValueRef;
 use near_primitives::state_part::PartId;
-use near_primitives::types::{AccountId, BlockHeight, ShardId, StateRoot};
+use near_primitives::types::{AccountId, BlockHeight, StateRoot};
 use near_store::flat::{
     store_helper, FetchingStateStatus, FlatStateChanges, FlatStorageCreationStatus,
     NUM_PARTS_IN_ONE_STEP, STATE_PART_MEMORY_LIMIT,

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -1,3 +1,5 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+
 use crate::hash::CryptoHash;
 use crate::types::{AccountId, NumShards};
 use near_primitives_core::types::ShardId;
@@ -270,7 +272,7 @@ fn is_top_level_account(top_account: &AccountId, account: &AccountId) -> bool {
 }
 
 /// ShardUId is an unique representation for shards from different shard layout
-#[derive(Hash, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(BorshSerialize, BorshDeserialize, Hash, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ShardUId {
     pub version: ShardVersion,
     pub shard_id: u32,

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -1,5 +1,3 @@
-use borsh::{BorshDeserialize, BorshSerialize};
-
 use crate::hash::CryptoHash;
 use crate::types::{AccountId, NumShards};
 use near_primitives_core::types::ShardId;

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -272,7 +272,7 @@ fn is_top_level_account(top_account: &AccountId, account: &AccountId) -> bool {
 }
 
 /// ShardUId is an unique representation for shards from different shard layout
-#[derive(BorshSerialize, BorshDeserialize, Hash, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Hash, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ShardUId {
     pub version: ShardVersion,
     pub shard_id: u32,

--- a/core/store/src/flat/delta.rs
+++ b/core/store/src/flat/delta.rs
@@ -20,12 +20,19 @@ pub struct FlatStateDeltaMetadata {
     pub block: BlockInfo,
 }
 
-#[derive(BorshSerialize, BorshDeserialize)]
 pub struct KeyForFlatStateDelta {
     pub shard_uid: ShardUId,
     pub block_hash: CryptoHash,
 }
 
+impl KeyForFlatStateDelta {
+    pub fn to_bytes(&self) -> [u8; 40] {
+        let mut res = [0; 40];
+        res[..8].copy_from_slice(&self.shard_uid.to_bytes());
+        res[8..].copy_from_slice(self.block_hash.as_bytes());
+        res
+    }
+}
 /// Delta of the state for some shard and block, stores mapping from keys to value refs or None, if key was removed in
 /// this block.
 #[derive(BorshSerialize, BorshDeserialize, Clone, Default, Debug, PartialEq, Eq)]

--- a/core/store/src/flat/delta.rs
+++ b/core/store/src/flat/delta.rs
@@ -3,7 +3,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use near_primitives::hash::hash;
 use near_primitives::shard_layout::ShardUId;
 use near_primitives::state::ValueRef;
-use near_primitives::types::{RawStateChangesWithTrieKey, ShardId};
+use near_primitives::types::RawStateChangesWithTrieKey;
 use std::collections::HashMap;
 use std::sync::Arc;
 

--- a/core/store/src/flat/delta.rs
+++ b/core/store/src/flat/delta.rs
@@ -22,7 +22,7 @@ pub struct FlatStateDeltaMetadata {
 
 #[derive(BorshSerialize, BorshDeserialize)]
 pub struct KeyForFlatStateDelta {
-    pub shard_id: ShardId,
+    pub shard_uid: ShardUId,
     pub block_hash: CryptoHash,
 }
 

--- a/core/store/src/flat/store_helper.rs
+++ b/core/store/src/flat/store_helper.rs
@@ -50,10 +50,10 @@ impl FlatStateColumn {
 
 pub fn get_delta_changes(
     store: &Store,
-    shard_id: ShardId,
+    shard_uid: ShardUId,
     block_hash: CryptoHash,
 ) -> Result<Option<FlatStateChanges>, FlatStorageError> {
-    let key = KeyForFlatStateDelta { shard_id, block_hash };
+    let key = KeyForFlatStateDelta { shard_uid, block_hash };
     Ok(store
         .get_ser::<FlatStateChanges>(
             FlatStateColumn::Changes.to_db_col(),
@@ -64,9 +64,9 @@ pub fn get_delta_changes(
 
 pub fn get_all_deltas_metadata(
     store: &Store,
-    shard_id: ShardId,
+    shard_uid: ShardUId,
 ) -> Result<Vec<FlatStateDeltaMetadata>, FlatStorageError> {
-    let prefix = shard_id.try_to_vec().map_err(|_| FlatStorageError::StorageInternalError)?;
+    let prefix = shard_uid.try_to_vec().map_err(|_| FlatStorageError::StorageInternalError)?;
     store
         .iter_prefix_ser(FlatStateColumn::DeltaMetadata.to_db_col(), &prefix)
         .map(|res| res.map(|(_, value)| value).map_err(|_| FlatStorageError::StorageInternalError))
@@ -75,10 +75,10 @@ pub fn get_all_deltas_metadata(
 
 pub fn set_delta(
     store_update: &mut StoreUpdate,
-    shard_id: ShardId,
+    shard_uid: ShardUId,
     delta: &FlatStateDelta,
 ) -> Result<(), FlatStorageError> {
-    let key = KeyForFlatStateDelta { shard_id, block_hash: delta.metadata.block.hash }
+    let key = KeyForFlatStateDelta { shard_uid, block_hash: delta.metadata.block.hash }
         .try_to_vec()
         .map_err(|_| FlatStorageError::StorageInternalError)?;
     store_update
@@ -90,8 +90,8 @@ pub fn set_delta(
     Ok(())
 }
 
-pub fn remove_delta(store_update: &mut StoreUpdate, shard_id: ShardId, block_hash: CryptoHash) {
-    let key = KeyForFlatStateDelta { shard_id, block_hash }.try_to_vec().unwrap();
+pub fn remove_delta(store_update: &mut StoreUpdate, shard_uid: ShardUId, block_hash: CryptoHash) {
+    let key = KeyForFlatStateDelta { shard_uid, block_hash }.try_to_vec().unwrap();
     store_update.delete(FlatStateColumn::Changes.to_db_col(), &key);
     store_update.delete(FlatStateColumn::DeltaMetadata.to_db_col(), &key);
 }

--- a/tools/flat-storage/src/commands.rs
+++ b/tools/flat-storage/src/commands.rs
@@ -142,8 +142,9 @@ impl FlatStorageCommand {
 
                 let tip = rw_chain_store.final_head().unwrap();
 
+                let shard_uid = rw_hot_runtime.shard_id_to_uid(init_cmd.shard_id, &tip.epoch_id)?;
                 let mut creator =
-                    FlatStorageShardCreator::new(init_cmd.shard_id, tip.height - 1, rw_hot_runtime);
+                    FlatStorageShardCreator::new(shard_uid, tip.height - 1, rw_hot_runtime);
                 let pool = rayon::ThreadPoolBuilder::new()
                     .num_threads(init_cmd.num_threads)
                     .build()


### PR DESCRIPTION
Part of https://github.com/near/nearcore/issues/8577.

Use `ShardUId` instead of `ShardId` in delta key, for consistency with flat state keys. This is not strictly needed today, but may help later if we do resharding - that's how we can support flat storages for old and new shard versions.

## Testing

Existing tests should not fail.