### PR TITLE
Fix boot nodes in fork_sync

### DIFF
--- a/pytest/tests/adversarial/fork_sync.py
+++ b/pytest/tests/adversarial/fork_sync.py
@@ -46,7 +46,7 @@ for i in range(2, 4):
 logger.info("killing node 2 and 3")
 
 for i in range(2):
-    nodes[i].start(boot_node=nodes[i])
+    nodes[i].start(boot_node=nodes[0])
     res = nodes[i].json_rpc('adv_disable_doomslug', [])
     assert 'result' in res, res
 
@@ -55,7 +55,7 @@ time.sleep(1)
 utils.wait_for_blocks(nodes[0], target=FIRST_STEP_WAIT + SECOND_STEP_WAIT)
 
 for i in range(2, 4):
-    nodes[i].start(boot_node=nodes[i])
+    nodes[i].start(boot_node=nodes[0])
     res = nodes[i].json_rpc('adv_disable_doomslug', [])
     assert 'result' in res, res
 


### PR DESCRIPTION
This test spins up some nodes using `start_cluster`, then brings them down and back up again. They are brought back up with incorrectly configured `boot_nodes`, preventing them from reconnecting and causing the test to fail.

Before #8617 information about peers learned in the first run was persisted to disk, so the boot nodes configured when restarting the nodes didn't matter.