### PR TITLE
core: add Children type representing trie branch’s childrenas 

### DIFF
--- a/integration-tests/src/tests/runtime/state_viewer.rs
+++ b/integration-tests/src/tests/runtime/state_viewer.rs
@@ -78,9 +78,8 @@ impl ProofVerifier {
                             _ => false,
                         };
                     }
-                    let index = key.at(0);
-                    match &children[index as usize] {
-                        Some(child_hash) => {
+                    match children[key.at(0)] {
+                        Some(ref child_hash) => {
                             key = key.mid(1);
                             expected_hash = child_hash;
                         }

--- a/tools/cold-store/src/cli.rs
+++ b/tools/cold-store/src/cli.rs
@@ -603,16 +603,14 @@ impl CheckStateRootCmd {
                 return Ok(());
             }
             near_store::RawTrieNode::Branch(mut children, _) => {
-                children.shuffle(&mut rand::thread_rng());
-                for child in children.iter() {
-                    if let Some(child) = child {
-                        // Record in prune state that we are visiting a child node
-                        prune_state.down();
-                        // Visit a child node
-                        Self::check_trie(store, child, prune_state, prune_condition)?;
-                        // Record in prune state that we are returning from a child node
-                        prune_state.up();
-                    }
+                children.0.shuffle(&mut rand::thread_rng());
+                for (_, child) in children.iter() {
+                    // Record in prune state that we are visiting a child node
+                    prune_state.down();
+                    // Visit a child node
+                    Self::check_trie(store, child, prune_state, prune_condition)?;
+                    // Record in prune state that we are returning from a child node
+                    prune_state.up();
                 }
             }
             near_store::RawTrieNode::Extension(_, child) => {


### PR DESCRIPTION
Add a generic Children type which holds references to the children
of a trie branch node.  This is a minor refactoring which does three
things.

* It provides iterator which filters missing children.  This
  simplifies usage as explicit `filter` call is no longer necessary.

* It eliminates ‘as usize’ casts from the code. NibbleSlice returns
  nibbles as `u8`, to use the value as an index in an array a cast is
  necessary.  Now that Children uses `u8` indexes this is no longer
  needed leading to slightly cleaner code.

* It provides a common generic type for children in RawTrieNode and
  TrieNode types providing common interface for those two cases.
