### PR TITLE
toolchain: update to Rust 1.68.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -257,4 +257,4 @@ opt-level = 3
 [workspace.package]
 edition = "2021"
 authors = ["Near Inc <hello@nearprotocol.com>"]
-rust-version = "1.67.1"
+rust-version = "1.68.0"

--- a/core/crypto/src/signature.rs
+++ b/core/crypto/src/signature.rs
@@ -160,7 +160,7 @@ impl PublicKey {
 
 // This `Hash` implementation is safe since it retains the property
 // `k1 == k2 ⇒ hash(k1) == hash(k2)`.
-#[allow(clippy::derive_hash_xor_eq)]
+#[allow(clippy::derived_hash_with_manual_eq)]
 impl Hash for PublicKey {
     fn hash<H: Hasher>(&self, state: &mut H) {
         match self {
@@ -493,7 +493,7 @@ pub enum Signature {
 
 // This `Hash` implementation is safe since it retains the property
 // `k1 == k2 ⇒ hash(k1) == hash(k2)`.
-#[allow(clippy::derive_hash_xor_eq)]
+#[allow(clippy::derived_hash_with_manual_eq)]
 impl Hash for Signature {
     fn hash<H: Hasher>(&self, state: &mut H) {
         match self {

--- a/core/crypto/src/signature.rs
+++ b/core/crypto/src/signature.rs
@@ -160,7 +160,6 @@ impl PublicKey {
 
 // This `Hash` implementation is safe since it retains the property
 // `k1 == k2 ⇒ hash(k1) == hash(k2)`.
-#[allow(clippy::derived_hash_with_manual_eq)]
 impl Hash for PublicKey {
     fn hash<H: Hasher>(&self, state: &mut H) {
         match self {
@@ -493,7 +492,6 @@ pub enum Signature {
 
 // This `Hash` implementation is safe since it retains the property
 // `k1 == k2 ⇒ hash(k1) == hash(k2)`.
-#[allow(clippy::derived_hash_with_manual_eq)]
 impl Hash for Signature {
     fn hash<H: Hasher>(&self, state: &mut H) {
         match self {

--- a/core/primitives-core/src/hash.rs
+++ b/core/primitives-core/src/hash.rs
@@ -211,7 +211,7 @@ impl fmt::Display for CryptoHash {
 
 // This implementation is compatible with derived PartialEq.
 // Custom PartialEq implementation was explicitly removed in #4220.
-#[allow(clippy::derive_hash_xor_eq)]
+#[allow(clippy::derived_hash_with_manual_eq)]
 impl Hash for CryptoHash {
     fn hash<H: Hasher>(&self, state: &mut H) {
         state.write(self.as_ref());

--- a/core/primitives-core/src/hash.rs
+++ b/core/primitives-core/src/hash.rs
@@ -211,7 +211,6 @@ impl fmt::Display for CryptoHash {
 
 // This implementation is compatible with derived PartialEq.
 // Custom PartialEq implementation was explicitly removed in #4220.
-#[allow(clippy::derived_hash_with_manual_eq)]
 impl Hash for CryptoHash {
     fn hash<H: Hasher>(&self, state: &mut H) {
         state.write(self.as_ref());

--- a/runtime/runtime-params-estimator/emu-cost/Dockerfile
+++ b/runtime/runtime-params-estimator/emu-cost/Dockerfile
@@ -1,5 +1,5 @@
 # our local base image
-FROM rust:1.67.1
+FROM rust:1.68.0
 
 LABEL description="Container for builds"
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,6 +2,6 @@
 # This specifies the version of Rust we use to build.
 # Individual crates in the workspace may support a lower version, as indicated by `rust-version` field in each crate's `Cargo.toml`.
 # The version specified below, should be at least as high as the maximum `rust-version` within the workspace.
-channel = "1.67.1"
+channel = "1.68.0"
 components = [ "rustfmt" ]
 targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
Routine update to the latest version of Rust.
Release post: https://blog.rust-lang.org/2023/03/09/Rust-1.68.0.html

I don't see anything exciting for nearcore in the release.
Maybe `pin!` for custom futures could be useful.

The commit also includes clippy changes, they renamed 
`derive_hash_xor_eq` to `derived_hash_with_manual_eq`
and changed the check. Now, we no longer need an `allow()`.

There is also a new [future incompatibility warning](https://github.com/rust-lang/rust/pull/103418)
which we hit in `fs_extra v1.2.0` and `wasmparser v0.78.2`.
I don't think we can get rid of the second anytime soon, assuming we
hang on to replayability.