### PR TITLE
Ondemand fuzz target build

### DIFF
--- a/.github/workflows/master_fuzzer_binaries.yml
+++ b/.github/workflows/master_fuzzer_binaries.yml
@@ -19,14 +19,21 @@ jobs:
           workload_identity_provider: "projects/968400232856/locations/global/workloadIdentityPools/project-identity-pool/providers/github-provider"
           service_account: "near-fuzzer-service-account@near-fuzzer.iam.gserviceaccount.com"
 
-      - uses: hecrj/setup-rust-action@v1
-        with:
-          rust-version: nightly
+      - name: Installing nightly rust
+        run: |
+          rustup install nightly
+          rustup default nightly
 
-      - name: Set swap space to 10G
-        uses: pierotofy/set-swap-space@master
-        with:
-          swap-size-gb: 10
+      - name: Set swap to 10G
+        shell: bash
+        run: |
+          export SWAP_FILE=$(swapon --show=NAME | tail -n 1)
+          sudo swapoff $SWAP_FILE
+          sudo rm $SWAP_FILE
+          sudo fallocate -l 10G $SWAP_FILE
+          sudo chmod 600 $SWAP_FILE
+          sudo mkswap $SWAP_FILE
+          sudo swapon $SWAP_FILE
 
       - name: Install cargo fuzz subcommand crate
         run: cargo install cargo-fuzz

--- a/.github/workflows/master_fuzzer_binaries.yml
+++ b/.github/workflows/master_fuzzer_binaries.yml
@@ -1,4 +1,4 @@
-name: Build @master fuzzers
+name: Build fuzz targets from master
 on:
   schedule:
     # Run once a day, at midnight

--- a/.github/workflows/ondemand_fuzzer_binaries.yml
+++ b/.github/workflows/ondemand_fuzzer_binaries.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Build Release branch fuzz targets
         if: ${{ github.event.action == 'released'}}
-        run: python3 scripts/build_fuzzers.py rc
+        run: python3 scripts/build_fuzzers.py release
 
       - name: Build RC branch fuzz targets
         if: ${{ github.event.action == 'prereleased'}}

--- a/.github/workflows/ondemand_fuzzer_binaries.yml
+++ b/.github/workflows/ondemand_fuzzer_binaries.yml
@@ -1,14 +1,20 @@
 name: Build on-demand fuzz targets
 on:
+  # Run when a new release or rc is created
+  release:
+    types: [released, prereleased]
+
+  # Run on-demand
   workflow_dispatch:
     inputs:
       branch_type:
         type: choice
         required: true
         options:
+          - master
           - release
           - rc
-        description: Type of branch to build binaries for - release or rc
+        description: Type of branch to build fuzz targets
       branch_ref:
         type: string
         required: true
@@ -45,14 +51,27 @@ jobs:
 
       - name: "Set up GCP SDK"
         uses: "google-github-actions/setup-gcloud@v1"
-        with:
-          version: ">= 416.0.0"
+
+      - name: Checkout Release/RC branch
+        if: contains(fromJSON('["released", "prereleased"]'), github.event.action)
+        uses: actions/checkout@master
 
       - name: Checkout ${{ github.event.inputs.branch_ref }} branch
+        if: ${{ github.event_name == 'workflow_dispatch'}}
         uses: actions/checkout@master
         with:
           ref: ${{ github.event.inputs.branch_ref }}
 
       - run: pip install -r scripts/build_fuzzers_requirements.txt
 
-      - run: python3 scripts/build_fuzzers.py ${{ github.event.inputs.branch_type }}
+      - name: Build Release branch fuzz targets
+        if: ${{ github.event.action == 'released'}}
+        run: python3 scripts/build_fuzzers.py rc
+
+      - name: Build RC branch fuzz targets
+        if: ${{ github.event.action == 'prereleased'}}
+        run: python3 scripts/build_fuzzers.py rc
+
+      - name: Build fuzz targets from ${{ github.event.inputs.branch_ref }}" branch
+        if: ${{ github.event_name == 'workflow_dispatch'}}
+        run: python3 scripts/build_fuzzers.py ${{ github.event.inputs.branch_type }}

--- a/.github/workflows/ondemand_fuzzer_binaries.yml
+++ b/.github/workflows/ondemand_fuzzer_binaries.yml
@@ -35,14 +35,21 @@ jobs:
           workload_identity_provider: "projects/968400232856/locations/global/workloadIdentityPools/project-identity-pool/providers/github-provider"
           service_account: "near-fuzzer-service-account@near-fuzzer.iam.gserviceaccount.com"
 
-      - uses: hecrj/setup-rust-action@v1
-        with:
-          rust-version: nightly
+      - name: Installing nightly rust
+        run: |
+          rustup install nightly
+          rustup default nightly
 
-      - name: Set swap space to 10G
-        uses: pierotofy/set-swap-space@master
-        with:
-          swap-size-gb: 10
+      - name: Set swap to 10G
+        shell: bash
+        run: |
+          export SWAP_FILE=$(swapon --show=NAME | tail -n 1)
+          sudo swapoff $SWAP_FILE
+          sudo rm $SWAP_FILE
+          sudo fallocate -l 10G $SWAP_FILE
+          sudo chmod 600 $SWAP_FILE
+          sudo mkswap $SWAP_FILE
+          sudo swapon $SWAP_FILE
 
       - name: Install cargo fuzz subcommand crate
         run: cargo install cargo-fuzz

--- a/.github/workflows/ondemand_fuzzer_binaries.yml
+++ b/.github/workflows/ondemand_fuzzer_binaries.yml
@@ -1,8 +1,18 @@
-name: Build Release fuzzers
+name: Build on-demand fuzz targets
 on:
-  # Run when a new release is published
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      branch_type:
+        type: choice
+        required: true
+        options:
+          - release
+          - rc
+        description: Type of branch to build binaries for - release or rc
+      branch_ref:
+        type: string
+        required: true
+        description: Branch name or tag to build from
 
 jobs:
   build_fuzzers:
@@ -38,8 +48,11 @@ jobs:
         with:
           version: ">= 416.0.0"
 
-      - uses: actions/checkout@master
+      - name: Checkout ${{ github.event.inputs.branch_ref }} branch
+        uses: actions/checkout@master
+        with:
+          ref: ${{ github.event.inputs.branch_ref }}
 
       - run: pip install -r scripts/build_fuzzers_requirements.txt
 
-      - run: python3 scripts/build_fuzzers.py release
+      - run: python3 scripts/build_fuzzers.py ${{ github.event.inputs.branch_type }}


### PR DESCRIPTION
With this workflow we will be able to build fuzz targets based on:
- release events: new release or new prerelease (release candidate)
- manual builds - required to retroactively build missing binaries or for development purposes (fixing bugs)
