### PR TITLE
feat(flat-state): don't increase column caches

### DIFF
--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -159,10 +159,6 @@ impl StoreConfig {
             crate::DBCol::State => self.col_state_cache_size,
             #[cfg(feature = "protocol_feature_flat_state")]
             crate::DBCol::FlatState => self.col_state_cache_size,
-            #[cfg(feature = "protocol_feature_flat_state")]
-            crate::DBCol::BlockInfo => bytesize::ByteSize::mib(64),
-            #[cfg(feature = "protocol_feature_flat_state")]
-            crate::DBCol::BlockHeight => bytesize::ByteSize::mib(64),
             _ => bytesize::ByteSize::mib(32),
         }
     }


### PR DESCRIPTION
`BlockHeight` and `BlockInfo` had an increased request count in an
earlier implementation snapshot of flat state. At the time, there was a
measurable positive effect for increasing these two caches from 32MB to
64MB. This is no longer the case, so let's not increase them.