### PR TITLE
feat: remove flat state cache

### DIFF
--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -93,8 +93,6 @@ pub struct StoreConfig {
     /// frequently we check creation status and execute work related to it in
     /// main thread (scheduling and collecting state parts, catching up blocks, etc.).
     pub flat_storage_creation_period: Duration,
-    /// Capacity of `ValueRef`s cache for flat storage head for each shard.
-    pub flat_state_cache_capacity: u64,
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -233,12 +231,6 @@ impl Default for StoreConfig {
             // One second should be enough to save deltas on start and catch up
             // flat storage head quickly. State read work is much more expensive.
             flat_storage_creation_period: Duration::from_secs(1),
-
-            // Chosen based on our estimations on Dec 2022, so that performances of
-            // flat storage and trie with caches are comparable.
-            // Total size of all flat state caches can't exceed 100_000 * 2 KB (max
-            // storage key length) * 4 (number of tracked shards) = 800 MB.
-            flat_state_cache_capacity: 100_000,
         }
     }
 }

--- a/core/store/src/metrics.rs
+++ b/core/store/src/metrics.rs
@@ -273,31 +273,6 @@ pub static FLAT_STORAGE_DISTANCE_TO_HEAD: Lazy<IntGaugeVec> = Lazy::new(|| {
     )
     .unwrap()
 });
-pub static FLAT_STORAGE_VALUE_REF_CACHE_LEN: Lazy<IntGaugeVec> = Lazy::new(|| {
-    try_create_int_gauge_vec(
-        "flat_storage_value_ref_cache_len",
-        "Number of items in flat storage cache for its head",
-        &["shard_id"],
-    )
-    .unwrap()
-});
-pub static FLAT_STORAGE_VALUE_REF_CACHE_TOTAL_KEY_SIZE: Lazy<IntGaugeVec> = Lazy::new(|| {
-    try_create_int_gauge_vec(
-        "flat_storage_value_ref_cache_total_key_size",
-        "Total size of all keys in flat storage cache for its head",
-        &["shard_id"],
-    )
-    .unwrap()
-});
-pub static FLAT_STORAGE_VALUE_REF_CACHE_TOTAL_VALUE_SIZE: Lazy<IntGaugeVec> = Lazy::new(|| {
-    try_create_int_gauge_vec(
-        "flat_storage_value_ref_cache_total_value_size",
-        "Total size of all values in flat storage cache for its head",
-        &["shard_id"],
-    )
-    .unwrap()
-});
-
 pub mod flat_state_metrics {
     use super::*;
 

--- a/core/store/src/trie/config.rs
+++ b/core/store/src/trie/config.rs
@@ -31,8 +31,6 @@ pub struct TrieConfig {
     pub sweat_prefetch_receivers: Vec<AccountId>,
     /// List of allowed predecessor accounts for SWEAT prefetching.
     pub sweat_prefetch_senders: Vec<AccountId>,
-    /// Capacity of `ValueRef`s cache for flat storage head for each shard.
-    pub flat_state_cache_capacity: u64,
 }
 
 impl TrieConfig {
@@ -64,8 +62,6 @@ impl TrieConfig {
                 Err(e) => error!(target: "config", "invalid account id {account}: {e}"),
             }
         }
-
-        this.flat_state_cache_capacity = config.flat_state_cache_capacity;
 
         this
     }

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -322,10 +322,6 @@ impl ShardTries {
     ) -> StateRoot {
         self.apply_all_inner(trie_changes, shard_uid, true, store_update)
     }
-
-    pub fn flat_state_cache_capacity(&self) -> u64 {
-        self.0.trie_config.flat_state_cache_capacity
-    }
 }
 
 pub struct WrappedTrieChanges {

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -734,8 +734,7 @@ impl RuntimeAdapter for NightshadeRuntime {
 
     // TODO (#7327): consider passing flat storage errors here to handle them gracefully
     fn create_flat_storage_for_shard(&self, shard_uid: ShardUId) {
-        let cache_capacity = self.tries.flat_state_cache_capacity() as usize;
-        let flat_storage = FlatStorage::new(self.store.clone(), shard_uid, cache_capacity);
+        let flat_storage = FlatStorage::new(self.store.clone(), shard_uid);
         self.flat_storage_manager.add_flat_storage_for_shard(shard_uid.shard_id(), flat_storage);
     }
 

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -75,13 +75,12 @@ impl<'c> EstimatorContext<'c> {
         let shard_uids = [ShardUId { shard_id: 0, version: 0 }];
         let mut trie_config = near_store::TrieConfig::default();
         trie_config.enable_receipt_prefetching = true;
-        let flat_state_cache_capacity = trie_config.flat_state_cache_capacity;
 
         let tries = ShardTries::new(
             store.clone(),
             trie_config,
             &shard_uids,
-            Self::create_flat_storage_manager(store.clone(), flat_state_cache_capacity),
+            Self::create_flat_storage_manager(store.clone()),
         );
 
         Testbed {
@@ -144,7 +143,7 @@ impl<'c> EstimatorContext<'c> {
         }
     }
 
-    fn create_flat_storage_manager(store: Store, cache_capacity: u64) -> FlatStorageManager {
+    fn create_flat_storage_manager(store: Store) -> FlatStorageManager {
         let flat_storage_manager = FlatStorageManager::new(store.clone());
         if !cfg!(feature = "protocol_feature_flat_state") {
             return flat_storage_manager;
@@ -161,7 +160,7 @@ impl<'c> EstimatorContext<'c> {
             }),
         );
         store_update.commit().expect("failed to set flat storage status");
-        let flat_storage = FlatStorage::new(store, shard_uid, cache_capacity as usize);
+        let flat_storage = FlatStorage::new(store, shard_uid);
         flat_storage_manager.add_flat_storage_for_shard(shard_uid.shard_id(), flat_storage);
         flat_storage_manager
     }


### PR DESCRIPTION
Part of #8577 and #8684, was introduced in #8540.

This PR removes custom `FlatState` cache from `FlatStorage` since experiments show very low hit rate which is not worth used memory.