### PR TITLE
feat: add Prometheus metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 * Experimental option to dump state of every epoch to external storage. [#8661](https://github.com/near/nearcore/pull/8661)
 * State-viewer tool to dump and apply state changes from/to a range of blocks [#8628](https://github.com/near/nearcore/pull/8628)
 * Node can restart if State Sync gets interrupted [#8732](https://github.com/near/nearcore/pull/8732)
+* Add prometheus metrics for tracked shards, block height within epoch, if is block/chunk producer
+>>>>>>> f4538a8ce (feat: changelog for PR#8728)
 
 ## 1.32.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 * State-viewer tool to dump and apply state changes from/to a range of blocks [#8628](https://github.com/near/nearcore/pull/8628)
 * Node can restart if State Sync gets interrupted [#8732](https://github.com/near/nearcore/pull/8732)
 * Add prometheus metrics for tracked shards, block height within epoch, if is block/chunk producer
->>>>>>> f4538a8ce (feat: changelog for PR#8728)
 
 ## 1.32.0
 

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1239,6 +1239,59 @@ impl ClientActor {
         Ok(())
     }
 
+    fn send_chunks_metrics(&mut self, block: &Block) {
+        let chunks = block.chunks();
+        for (chunk, &included) in chunks.iter().zip(block.header().chunk_mask().iter()) {
+            if included {
+                self.info_helper.chunk_processed(
+                    chunk.shard_id(),
+                    chunk.gas_used(),
+                    chunk.balance_burnt(),
+                );
+            } else {
+                self.info_helper.chunk_skipped(chunk.shard_id());
+            }
+        }
+    }
+
+    fn send_block_metrics(&mut self, block: &Block) {
+        let chunks_in_block = block.header().chunk_mask().iter().filter(|&&m| m).count();
+        let gas_used = Block::compute_gas_used(block.chunks().iter(), block.header().height());
+
+        let last_final_hash = block.header().last_final_block();
+        let last_final_ds_hash = block.header().last_ds_final_block();
+        let last_final_block_height = self
+            .client
+            .chain
+            .get_block(&last_final_hash)
+            .map_or(0, |block| block.header().height());
+        let last_final_ds_block_height = self
+            .client
+            .chain
+            .get_block(&last_final_ds_hash)
+            .map_or(0, |block| block.header().height());
+
+        let epoch_height =
+            self.client.runtime_adapter.get_epoch_height_from_prev_block(block.hash()).unwrap_or(0);
+        let epoch_start_height = self
+            .client
+            .runtime_adapter
+            .get_epoch_start_height(&last_final_hash)
+            .unwrap_or(last_final_block_height);
+        let last_final_block_height_in_epoch = last_final_block_height - epoch_start_height;
+
+        self.info_helper.block_processed(
+            gas_used,
+            chunks_in_block as u64,
+            block.header().gas_price(),
+            block.header().total_supply(),
+            last_final_block_height,
+            last_final_ds_block_height,
+            epoch_height,
+            last_final_block_height_in_epoch,
+        );
+    }
+
     /// Process all blocks that were accepted by calling other relevant services.
     fn process_accepted_blocks(&mut self, accepted_blocks: Vec<CryptoHash>) {
         let _span = tracing::debug_span!(
@@ -1248,58 +1301,9 @@ impl ClientActor {
         .entered();
         for accepted_block in accepted_blocks {
             let block = self.client.chain.get_block(&accepted_block).unwrap().clone();
-            let chunks_in_block = block.header().chunk_mask().iter().filter(|&&m| m).count();
-            let gas_used = Block::compute_gas_used(block.chunks().iter(), block.header().height());
-
-            let last_final_hash = block.header().last_final_block();
-            let last_final_ds_hash = block.header().last_ds_final_block();
-            let last_final_block_height = self
-                .client
-                .chain
-                .get_block(&last_final_hash)
-                .map_or(0, |block| block.header().height());
-            let last_final_ds_block_height = self
-                .client
-                .chain
-                .get_block(&last_final_ds_hash)
-                .map_or(0, |block| block.header().height());
-
-            let chunks = block.chunks();
-            for (chunk, &included) in chunks.iter().zip(block.header().chunk_mask().iter()) {
-                if included {
-                    self.info_helper.chunk_processed(
-                        chunk.shard_id(),
-                        chunk.gas_used(),
-                        chunk.balance_burnt(),
-                    );
-                } else {
-                    self.info_helper.chunk_skipped(chunk.shard_id());
-                }
-            }
-
-            let epoch_height = self
-                .client
-                .runtime_adapter
-                .get_epoch_height_from_prev_block(block.hash())
-                .unwrap_or(0);
-            let epoch_start_height = self
-                .client
-                .runtime_adapter
-                .get_epoch_start_height(last_final_hash)
-                .unwrap_or(last_final_block_height);
-            let block_height_within_epoch = last_final_block_height - epoch_start_height;
-
-            self.info_helper.block_processed(
-                gas_used,
-                chunks_in_block as u64,
-                block.header().gas_price(),
-                block.header().total_supply(),
-                last_final_block_height,
-                last_final_ds_block_height,
-                epoch_height,
-                block_height_within_epoch,
-            );
-            self.check_send_announce_account(*last_final_hash);
+            self.send_chunks_metrics(&block);
+            self.send_block_metrics(&block);
+            self.check_send_announce_account(*block.header().last_final_block());
         }
     }
 

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1282,6 +1282,12 @@ impl ClientActor {
                 .runtime_adapter
                 .get_epoch_height_from_prev_block(block.hash())
                 .unwrap_or(0);
+            let epoch_start_height = self
+                .client
+                .runtime_adapter
+                .get_epoch_start_height(last_final_hash)
+                .unwrap_or(last_final_block_height);
+            let block_height_within_epoch = last_final_block_height - epoch_start_height;
 
             self.info_helper.block_processed(
                 gas_used,
@@ -1291,6 +1297,7 @@ impl ClientActor {
                 last_final_block_height,
                 last_final_ds_block_height,
                 epoch_height,
+                block_height_within_epoch,
             );
             self.check_send_announce_account(*last_final_hash);
         }

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -107,6 +107,7 @@ impl InfoHelper {
         last_final_block_height: BlockHeight,
         last_final_ds_block_height: BlockHeight,
         epoch_height: EpochHeight,
+        block_height_within_epoch: BlockHeight,
     ) {
         self.num_blocks_processed += 1;
         self.num_chunks_in_blocks_processed += num_chunks;
@@ -119,6 +120,7 @@ impl InfoHelper {
         metrics::FINAL_BLOCK_HEIGHT.set(last_final_block_height as i64);
         metrics::FINAL_DOOMSLUG_BLOCK_HEIGHT.set(last_final_ds_block_height as i64);
         metrics::EPOCH_HEIGHT.set(epoch_height as i64);
+        metrics::BLOCK_HEIGHT_WITHIN_EPOCH.set(block_height_within_epoch as i64);
     }
 
     /// Print current summary.

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -107,7 +107,7 @@ impl InfoHelper {
         last_final_block_height: BlockHeight,
         last_final_ds_block_height: BlockHeight,
         epoch_height: EpochHeight,
-        block_height_within_epoch: BlockHeight,
+        last_final_block_height_in_epoch: BlockHeight,
     ) {
         self.num_blocks_processed += 1;
         self.num_chunks_in_blocks_processed += num_chunks;
@@ -120,7 +120,7 @@ impl InfoHelper {
         metrics::FINAL_BLOCK_HEIGHT.set(last_final_block_height as i64);
         metrics::FINAL_DOOMSLUG_BLOCK_HEIGHT.set(last_final_ds_block_height as i64);
         metrics::EPOCH_HEIGHT.set(epoch_height as i64);
-        metrics::BLOCK_HEIGHT_WITHIN_EPOCH.set(block_height_within_epoch as i64);
+        metrics::FINAL_BLOCK_HEIGHT_IN_EPOCH.set(last_final_block_height_in_epoch as i64);
     }
 
     /// Count which shards are tracked by the node in the epoch indicated by head parameter.

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -140,6 +140,43 @@ impl InfoHelper {
         }
     }
 
+    fn record_block_producers(head: &Tip, client: &crate::client::Client) {
+        let me = client.validator_signer.as_ref().map(|x| x.validator_id().clone());
+        let is_bp = me.map_or(false, |account_id| {
+            client
+                .runtime_adapter
+                .get_epoch_block_producers_ordered(&head.epoch_id, &head.last_block_hash)
+                .unwrap()
+                .iter()
+                .any(|bp| bp.0.account_id() == &account_id)
+        });
+        metrics::IS_BLOCK_PRODUCER.set(if is_bp { 1 } else { 0 });
+    }
+
+    fn record_chunk_producers(head: &Tip, client: &crate::client::Client) {
+        if let (Some(account_id), Ok(epoch_info)) = (
+            client.validator_signer.as_ref().map(|x| x.validator_id().clone()),
+            client.runtime_adapter.get_epoch_info(&head.epoch_id),
+        ) {
+            for (shard_id, validators) in
+                epoch_info.chunk_producers_settlement().into_iter().enumerate()
+            {
+                let is_chunk_producer_for_shard = validators.iter().any(|&validator_id| {
+                    *epoch_info.validator_account_id(validator_id) == account_id
+                });
+                metrics::IS_CHUNK_PRODUCER_FOR_SHARD
+                    .with_label_values(&[&shard_id.to_string()])
+                    .set(if is_chunk_producer_for_shard { 1 } else { 0 });
+            }
+        } else if let Ok(num_shards) = client.runtime_adapter.num_shards(&head.epoch_id) {
+            for shard_id in 0..num_shards {
+                metrics::IS_CHUNK_PRODUCER_FOR_SHARD
+                    .with_label_values(&[&shard_id.to_string()])
+                    .set(0);
+            }
+        }
+    }
+
     /// Print current summary.
     pub fn log_summary(
         &mut self,
@@ -199,6 +236,8 @@ impl InfoHelper {
         };
 
         InfoHelper::record_tracked_shards(&head, &client);
+        InfoHelper::record_block_producers(&head, &client);
+        InfoHelper::record_chunk_producers(&head, &client);
 
         self.info(
             &head,

--- a/chain/client/src/metrics.rs
+++ b/chain/client/src/metrics.rs
@@ -135,9 +135,12 @@ pub(crate) static EPOCH_HEIGHT: Lazy<IntGauge> = Lazy::new(|| {
         .unwrap()
 });
 
-pub(crate) static BLOCK_HEIGHT_WITHIN_EPOCH: Lazy<IntGauge> = Lazy::new(|| {
-    try_create_int_gauge("near_block_height_within_epoch", "Height of the block within the epoch.")
-        .unwrap()
+pub(crate) static FINAL_BLOCK_HEIGHT_IN_EPOCH: Lazy<IntGauge> = Lazy::new(|| {
+    try_create_int_gauge(
+        "near_final_block_height_in_epoch",
+        "Height of the last block within the epoch.",
+    )
+    .unwrap()
 });
 
 pub(crate) static PROTOCOL_UPGRADE_BLOCK_HEIGHT: Lazy<IntGauge> = Lazy::new(|| {

--- a/chain/client/src/metrics.rs
+++ b/chain/client/src/metrics.rs
@@ -23,8 +23,28 @@ pub(crate) static CHUNK_PRODUCED_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
 });
 
 pub(crate) static IS_VALIDATOR: Lazy<IntGauge> = Lazy::new(|| {
-    try_create_int_gauge("near_is_validator", "Bool to denote if it is currently validating")
-        .unwrap()
+    try_create_int_gauge(
+        "near_is_validator",
+        "Bool to denote if it is validating in the current epoch",
+    )
+    .unwrap()
+});
+
+pub(crate) static IS_BLOCK_PRODUCER: Lazy<IntGauge> = Lazy::new(|| {
+    try_create_int_gauge(
+        "near_is_block_producer",
+        "Bool to denote if the node is a block producer in the current epoch",
+    )
+    .unwrap()
+});
+
+pub(crate) static IS_CHUNK_PRODUCER_FOR_SHARD: Lazy<IntGaugeVec> = Lazy::new(|| {
+    try_create_int_gauge_vec(
+        "near_is_chunk_producer_for_shard",
+        "Bool to denote if the node is a chunk producer for a shard in the current epoch",
+        &["shard_id"],
+    )
+    .unwrap()
 });
 
 pub(crate) static RECEIVED_BYTES_PER_SECOND: Lazy<IntGauge> = Lazy::new(|| {
@@ -104,12 +124,7 @@ pub(crate) static VALIDATORS_BLOCKS_EXPECTED: Lazy<IntGaugeVec> = Lazy::new(|| {
 });
 
 pub(crate) static TRACKED_SHARDS: Lazy<IntGaugeVec> = Lazy::new(|| {
-    try_create_int_gauge_vec(
-        "near_client_tracked_shards",
-        "Tracked shards",
-        &["shard_id"],
-    )
-    .unwrap()
+    try_create_int_gauge_vec("near_client_tracked_shards", "Tracked shards", &["shard_id"]).unwrap()
 });
 
 pub(crate) static SYNC_STATUS: Lazy<IntGauge> =

--- a/chain/client/src/metrics.rs
+++ b/chain/client/src/metrics.rs
@@ -103,6 +103,15 @@ pub(crate) static VALIDATORS_BLOCKS_EXPECTED: Lazy<IntGaugeVec> = Lazy::new(|| {
     .unwrap()
 });
 
+pub(crate) static TRACKED_SHARDS: Lazy<IntGaugeVec> = Lazy::new(|| {
+    try_create_int_gauge_vec(
+        "near_client_tracked_shards",
+        "Tracked shards",
+        &["shard_id"],
+    )
+    .unwrap()
+});
+
 pub(crate) static SYNC_STATUS: Lazy<IntGauge> =
     Lazy::new(|| try_create_int_gauge("near_sync_status", "Node sync status").unwrap());
 

--- a/chain/client/src/metrics.rs
+++ b/chain/client/src/metrics.rs
@@ -111,6 +111,11 @@ pub(crate) static EPOCH_HEIGHT: Lazy<IntGauge> = Lazy::new(|| {
         .unwrap()
 });
 
+pub(crate) static BLOCK_HEIGHT_WITHIN_EPOCH: Lazy<IntGauge> = Lazy::new(|| {
+    try_create_int_gauge("near_block_height_within_epoch", "Height of the block within the epoch.")
+        .unwrap()
+});
+
 pub(crate) static PROTOCOL_UPGRADE_BLOCK_HEIGHT: Lazy<IntGauge> = Lazy::new(|| {
     try_create_int_gauge(
         "near_protocol_upgrade_block_height",


### PR DESCRIPTION
* Current block height since the start of the current epoch
* shards tracked by the current node. (currently all shards but in the feature it might change)
* whether the node is a block producer
* whether the node is a chunk producer and for which shard

Tested on localnet and mainnet on a canary rpc node.
The gist of metrics from the node in prod. [link](https://gist.github.com/VanBarbascu/ccb1d60dbcc66a0444eb7092e4970fc9)
For additional test results check each commit message