### PR TITLE
feat: make FlatState value future proof for value inlining support

### DIFF
--- a/core/store/src/flat/types.rs
+++ b/core/store/src/flat/types.rs
@@ -1,7 +1,14 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_primitives::errors::StorageError;
 use near_primitives::hash::CryptoHash;
+use near_primitives::state::ValueRef;
 use near_primitives::types::BlockHeight;
+
+#[derive(BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
+pub enum FlatStateValue {
+    Ref(ValueRef),
+    // TODO(8243): add variant here for the inlined value
+}
 
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
 pub struct BlockInfo {


### PR DESCRIPTION
We plan introducing small value inlining as a next step in Flat Storage, see #8243 for more details. This is not a part of MVP which means it will not be included in the first Flat Storage release.
This PR wraps `ValueRef` in `FlatStateValue` enum, so later we can simply add another variant for inlined value there without changing the format on disk. This significantly simplifies migration in the future.