### PR TITLE
fix: State Sync no longer corrupts the DB

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1454,7 +1454,7 @@ impl Client {
             // send_network_chain_info should be called whenever the chain head changes.
             // See send_network_chain_info() for more details.
             if let Err(err) = self.send_network_chain_info() {
-                error!(target:"client","Failed to update network chain info: {err}");
+                error!(target: "client", ?err, "Failed to update network chain info");
             }
         }
 

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -255,7 +255,9 @@ impl Actor for ClientActor {
         // Start catchup job.
         self.catchup(ctx);
 
-        self.client.send_network_chain_info().unwrap();
+        if let Err(err) = self.client.send_network_chain_info() {
+            error!(target: "client", ?err, "Failed to update network chain info");
+        }
     }
 }
 


### PR DESCRIPTION
If a node gets stopped during State Sync then it fails to start due to an `unwrap()` on `send_network_chain_info()`. The state of the DB itself is fine. This PR makes the node gracefully handle that scenario and State Sync can safely resume and complete.