### PR TITLE
feat: prober checks contract function call on split store node

### DIFF
--- a/pytest/tools/prober/prober.py
+++ b/pytest/tools/prober/prober.py
@@ -22,6 +22,8 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
 
 
 def main():
+    # log an empty line for cloudprober nice formatting
+    logger.info('')
     logger.info('Running Prober')
     parser = argparse.ArgumentParser(description='Run a prober')
     parser.add_argument('--url', required=True)

--- a/pytest/tools/prober/prober_split.py
+++ b/pytest/tools/prober/prober_split.py
@@ -158,6 +158,8 @@ def main():
     args = parser.parse_args()
 
     logger.setLevel(args.log_level)
+    # log an empty line for cloudprober nice formatting
+    logger.info('')
     logger.info('Running Prober Split')
 
     legacy_url = get_random_legacy_url(args.chain_id)

--- a/pytest/tools/prober/prober_split.py
+++ b/pytest/tools/prober/prober_split.py
@@ -100,7 +100,7 @@ def check_chunks(legacy_url: str, split_url: str, block):
 
         if legacy_chunk != split_chunk:
             logger.error(
-                f"Check failed, the legacy chunk and the split chunk are different",
+                f"Check failed, the legacy chunk and the split chunk are different"
                 f"\nlegacy block\n{pretty_print(legacy_chunk)}"
                 f"\nsplit block\n{pretty_print(split_chunk)}")
             sys.exit(1)
@@ -126,6 +126,27 @@ def get_random_legacy_url(chain_id):
 
     logger.info(f'Selected random legacy node - {external_ip}')
     return f'http://{external_ip}:3030'
+
+
+def check_view_call(legacy_url, split_url):
+    # This is the example contract function call from
+    # https://docs.near.org/api/rpc/contracts#call-a-contract-function
+    params = {
+        "request_type": "call_function",
+        "finality": "final",
+        "account_id": "dev-1588039999690",
+        "method_name": "get_num",
+        "args_base64": "e30="
+    }
+    legacy_response = json_rpc('query', params, legacy_url)
+    split_response = json_rpc('query', params, split_url)
+
+    if legacy_response != split_response:
+        logger.error(
+            f'Check failed, the legacy response and the split response are different'
+            f'\nlegacy response\n{legacy_response}'
+            f'\nsplit response\n{split_response}')
+        sys.exit(1)
 
 
 def main():
@@ -160,6 +181,7 @@ def main():
         height = random.randint(genesis_height, head)
         block = check_blocks(legacy_url, split_url, height)
         check_chunks(legacy_url, split_url, block)
+        check_view_call(legacy_url, split_url)
 
         count += 1
         none_count += block is None

--- a/pytest/tools/prober/prober_split.py
+++ b/pytest/tools/prober/prober_split.py
@@ -116,7 +116,7 @@ def check_view_call(legacy_url, split_url):
     legacy_response = json_rpc('query', params, legacy_url)
     split_response = json_rpc('query', params, split_url)
 
-    if legacy_response['result'] != split_response['result']:
+    if legacy_response['result']['result'] != split_response['result']['result']:
         logger.error(
             f'View call check failed, the legacy response and the split response are different'
             f'\nlegacy response\n{legacy_response}'

--- a/pytest/tools/prober/prober_split.py
+++ b/pytest/tools/prober/prober_split.py
@@ -4,7 +4,8 @@ Prober that is compatible with cloudprober.
 
 The ProberSplit queries two nodes for blocks and chunks at random heights and
 compares the results. The expectation is that the block and chunks at each
-height will be identical even when fetched from two different nodes.
+height will be identical even when fetched from two different nodes. It also
+executes a contract view call on both nodes and compares the results.
 
 The prober runs continuously for the duration specified in the command line
 arguments. It runs at least one block and chunk check at a random height.
@@ -13,7 +14,7 @@ The intended goal of this prober is ensure that a legacy archival node and a
 split storage archival node contain the same data.
 
 Run like this:
-./prober_split.py --legacy-url http://legacy.archival.node:3030 --split-url http://split.archival.node:3030
+./prober_split.py --chain-id testnet --split-url http://split.archival.node:3030 --duration-ms 20000
 
 """
 
@@ -88,7 +89,6 @@ def check_chunks(legacy_url: str, split_url: str, block):
         return
 
     logger.info(f"Checking chunks.")
-
     for chunk in block['chunks']:
         legacy_chunk = get_chunk(chunk, legacy_url)
         split_chunk = get_chunk(chunk, split_url)

--- a/pytest/tools/prober/prober_util.py
+++ b/pytest/tools/prober/prober_util.py
@@ -82,9 +82,7 @@ def get_chunk(chunk, url):
         chunk = json_rpc('chunk', {'chunk_id': chunk_hash}, url)
         chunk = chunk['result']
 
-        logger.debug(
-            f'Got chunk {chunk_hash} for shard {shard_id} chunk: {pretty_print(chunk)}'
-        )
+        logger.debug(f'Got chunk {chunk_hash} for shard {shard_id}')
         return chunk
     except Exception as e:
         logger.error(f'get_chunk({chunk_hash}, {url}) failed: {e}')

--- a/pytest/tools/prober/prober_util.py
+++ b/pytest/tools/prober/prober_util.py
@@ -5,12 +5,17 @@ import json
 import time
 import pathlib
 import requests
+import json
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
 
 import configured_logger
 
 logger = configured_logger.new_logger("stderr", stderr=True)
+
+
+def pretty_print(value) -> str:
+    return json.dumps(value, indent=2)
 
 
 def json_rpc(method, params, url):
@@ -76,7 +81,10 @@ def get_chunk(chunk, url):
         chunk_hash = chunk['chunk_hash']
         chunk = json_rpc('chunk', {'chunk_id': chunk_hash}, url)
         chunk = chunk['result']
-        logger.debug(f'Got chunk {chunk_hash} for shard {shard_id}')
+
+        logger.debug(
+            f'Got chunk {chunk_hash} for shard {shard_id} chunk: {pretty_print(chunk)}'
+        )
         return chunk
     except Exception as e:
         logger.error(f'get_chunk({chunk_hash}, {url}) failed: {e}')


### PR DESCRIPTION
Make a contarct call from the prober on the legacy and the split archival nodes and check that the results are the same. 

They aren't right now and this seems to be a real issue in the split store implementation - I'll be debugging that. If anyone happens to have any idea on where this error is coming from let me know. 

```
[2023-03-15 13:21:08] INFO: Running Prober Split
[2023-03-15 13:21:08] INFO: gcloud compute instances list
[2023-03-15 13:21:09] INFO: Selected random legacy node - 35.194.243.155
[2023-03-15 13:21:10] INFO: The genesis height is 42376888. The head height is 120422174
[2023-03-15 13:21:10] INFO: Checking blocks at height 48488222
[2023-03-15 13:21:11] INFO: Checking chunks
[2023-03-15 13:21:12] ERROR: Check failed, the legacy response and the split response are different
legacy response
{'jsonrpc': '2.0', 'result': {'block_hash': 'Dok8ha8HceGRiv3MEPoxnJL2tJVxpDAo7cAc44WKSw6i', 'block_height': 120422176, 'logs': [], 'result': [48]}, 'id': 'dontcare'}
split response
{'jsonrpc': '2.0', 'error': {'name': 'INTERNAL_ERROR', 'cause': {'info': {'error_message': 'StorageError(StorageInconsistentState("cache write error"))'}, 'name': 'INTERNAL_ERROR'}, 'code': -32000, 'message': 'Server error', 'data': 'The node reached its limits. Try again later. More details: StorageError(StorageInconsistentState("cache write error"))'}, 'id': 'dontcare'}
```

The innermost erorr is `StorageInconsistentState("cache write error")`

Note to self - don't straight up compare the whole results as the block_height may be different. Only compare the 'result' field. 