### PR TITLE
fix: more precise flat storage errors

### DIFF
--- a/core/primitives/src/errors.rs
+++ b/core/primitives/src/errors.rs
@@ -93,7 +93,7 @@ pub enum StorageError {
     /// Flat storage error, meaning that it doesn't support some block anymore.
     /// We guarantee that such block cannot become final, thus block processing
     /// must resume normally.
-    FlatStorageError(String),
+    FlatStorageBlockNotSupported(String),
 }
 
 impl std::fmt::Display for StorageError {

--- a/core/primitives/src/errors.rs
+++ b/core/primitives/src/errors.rs
@@ -90,7 +90,9 @@ pub enum StorageError {
     /// panic in every place that produces this error.
     /// We can check if db is corrupted by verifying everything in the state trie.
     StorageInconsistentState(String),
-    /// Error from flat storage
+    /// Flat storage error, meaning that it doesn't support some block anymore.
+    /// We guarantee that such block cannot become final, thus block processing
+    /// must resume normally.
     FlatStorageError(String),
 }
 

--- a/core/store/src/flat/storage.rs
+++ b/core/store/src/flat/storage.rs
@@ -68,7 +68,7 @@ impl FlatStorageInner {
         // and read single `ValueRef` from delta if it is not cached.
         self.deltas
             .get(block_hash)
-            .ok_or_else(|| self.create_block_not_supported_error(block_hash))
+            .ok_or(FlatStorageError::StorageInternalError)
             .map(|delta| delta.changes.clone())
     }
 
@@ -201,24 +201,21 @@ impl FlatStorage {
         let shard_uid = guard.shard_uid;
         let shard_id = shard_uid.shard_id();
         let blocks = guard.get_blocks_to_head(new_head)?;
-        if blocks.is_empty() {
-            // This effectively means that new flat head is the same as the current one,
-            // so we are not updating it
-            return Err(guard.create_block_not_supported_error(new_head));
-        }
         for block_hash in blocks.into_iter().rev() {
             let mut store_update = StoreUpdate::new(guard.store.storage.clone());
-            // We unwrap here because flat storage is locked and we could retrieve path from old to new head,
-            // so delta must exist.
-            let changes =
-                store_helper::get_delta_changes(&guard.store, shard_uid, block_hash)?.unwrap();
+            // Delta must exist because flat storage is locked and we could retrieve
+            // path from old to new head. Otherwise we return internal error.
+            let changes = store_helper::get_delta_changes(&guard.store, shard_uid, block_hash)?
+                .ok_or(FlatStorageError::StorageInternalError)?;
             changes.apply_to_flat_state(&mut store_update, guard.shard_uid);
             let block = &guard.deltas[&block_hash].metadata.block;
+            let block_height = block.height;
             store_helper::set_flat_storage_status(
                 &mut store_update,
                 shard_uid,
                 FlatStorageStatus::Ready(FlatStorageReadyStatus { flat_head: block.clone() }),
             );
+
             guard.metrics.flat_head_height.set(block.height as i64);
             guard.flat_head = block.clone();
 
@@ -230,7 +227,7 @@ impl FlatStorage {
             let gc_height = guard
                 .deltas
                 .get(&block_hash)
-                .ok_or(guard.create_block_not_supported_error(&block_hash))?
+                .ok_or(FlatStorageError::StorageInternalError)?
                 .metadata
                 .block
                 .height;
@@ -254,10 +251,8 @@ impl FlatStorage {
             }
 
             store_update.commit().unwrap();
+            info!(target: "chain", %shard_id, %block_hash, %block_height, "Moved flat storage head");
         }
-
-        let new_head_height = guard.flat_head.height;
-        info!(target: "chain", %shard_id, %new_head, %new_head_height, "Moved flat storage head");
 
         Ok(())
     }
@@ -447,7 +442,7 @@ mod tests {
     }
 
     #[test]
-    fn block_not_supported_errors() {
+    fn flat_storage_errors() {
         // Create a chain with two forks. Set flat head to be at block 0.
         let chain = MockChain::chain_with_two_forks(5);
         let shard_uid = ShardUId::single_shard();
@@ -473,7 +468,8 @@ mod tests {
         flat_storage_manager.add_flat_storage_for_shard(shard_id, flat_storage);
         let flat_storage = flat_storage_manager.get_flat_storage_for_shard(shard_id).unwrap();
 
-        // Check that flat head can be moved to block 1.
+        // Check `BlockNotSupported` errors which are fine to occur during regular block processing.
+        // First, check that flat head can be moved to block 1.
         let flat_head_hash = chain.get_block_hash(1);
         assert_eq!(flat_storage.update_flat_head(&flat_head_hash), Ok(()));
         // Check that attempt to move flat head to block 2 results in error because it lays in unreachable fork.
@@ -493,6 +489,15 @@ mod tests {
         assert_eq!(
             flat_storage.update_flat_head(&not_existing_hash),
             Err(FlatStorageError::BlockNotSupported((flat_head_hash, not_existing_hash)))
+        );
+        // Corrupt DB state for block 3 and try moving flat head to it.
+        // Should result in `StorageInternalError` indicating that flat storage is broken.
+        let mut store_update = store.store_update();
+        store_helper::remove_delta(&mut store_update, shard_uid, chain.get_block_hash(3));
+        store_update.commit().unwrap();
+        assert_eq!(
+            flat_storage.update_flat_head(&chain.get_block_hash(3)),
+            Err(FlatStorageError::StorageInternalError)
         );
     }
 

--- a/core/store/src/flat/storage.rs
+++ b/core/store/src/flat/storage.rs
@@ -59,7 +59,7 @@ impl FlatStorageInner {
         FlatStorageError::BlockNotSupported((self.flat_head.hash, *block_hash))
     }
 
-    /// Gets changes for the given block and shard `self.shard_id`, expects that they must exist.
+    /// Gets changes for the given block and shard `self.shard_id`, assuming that they must exist.
     fn get_block_changes(
         &self,
         block_hash: &CryptoHash,

--- a/core/store/src/flat/storage.rs
+++ b/core/store/src/flat/storage.rs
@@ -59,7 +59,7 @@ impl FlatStorageInner {
         FlatStorageError::BlockNotSupported((self.flat_head.hash, *block_hash))
     }
 
-    /// Gets changes for the given block and shard `self.shard_id`.
+    /// Gets changes for the given block and shard `self.shard_id`, expects that they must exist.
     fn get_block_changes(
         &self,
         block_hash: &CryptoHash,
@@ -626,7 +626,10 @@ mod tests {
         assert_eq!(blocks.len(), 5);
         assert_eq!(chunk_view0.get_ref(&[1]).unwrap(), None);
         assert_eq!(chunk_view0.get_ref(&[2]).unwrap(), Some(ValueRef::new(&[1])));
-        assert_matches!(chunk_view1.get_ref(&[1]), Err(StorageError::FlatStorageError(_)));
+        assert_matches!(
+            chunk_view1.get_ref(&[1]),
+            Err(StorageError::FlatStorageBlockNotSupported(_))
+        );
         assert_matches!(
             store_helper::get_delta_changes(&store, shard_uid, chain.get_block_hash(5)).unwrap(),
             None

--- a/core/store/src/flat/types.rs
+++ b/core/store/src/flat/types.rs
@@ -39,7 +39,7 @@ impl From<FlatStorageError> for StorageError {
     fn from(err: FlatStorageError) -> Self {
         match err {
             FlatStorageError::BlockNotSupported((head_hash, block_hash)) => {
-                StorageError::FlatStorageError(format!(
+                StorageError::FlatStorageBlockNotSupported(format!(
                     "FlatStorage with head {:?} does not support this block {:?}",
                     head_hash, block_hash
                 ))

--- a/core/store/src/flat/types.rs
+++ b/core/store/src/flat/types.rs
@@ -18,9 +18,13 @@ impl BlockInfo {
 
 #[derive(strum::AsRefStr, Debug, PartialEq, Eq)]
 pub enum FlatStorageError {
-    /// This means we can't find a path from `flat_head` to the block. Includes `flat_head` hash and block hash,
-    /// respectively.
+    /// This means we can't find a path from `flat_head` to the block. Includes
+    /// `flat_head` hash and block hash, respectively.
+    /// Should not result in node panic, because flat head can move during processing
+    /// of some chunk.
     BlockNotSupported((CryptoHash, CryptoHash)),
+    /// Internal error, caused by DB or in-memory data corruption. Should result
+    /// in panic, because correctness of flat storage is not guaranteed afterwards.
     StorageInternalError,
 }
 

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -976,7 +976,7 @@ impl Trie {
         if matches!(mode, KeyLookupMode::FlatStorage) && !is_delayed_receipt_key(key) {
             if let Some(flat_storage_chunk_view) = &self.flat_storage_chunk_view {
                 let flat_result = flat_storage_chunk_view.get_ref(&key);
-                if matches!(flat_result, Err(StorageError::FlatStorageError(_))) {
+                if matches!(flat_result, Err(StorageError::FlatStorageBlockNotSupported(_))) {
                     return flat_result;
                 } else {
                     assert_eq!(result, flat_result);

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -976,13 +976,10 @@ impl Trie {
         if matches!(mode, KeyLookupMode::FlatStorage) && !is_delayed_receipt_key(key) {
             if let Some(flat_storage_chunk_view) = &self.flat_storage_chunk_view {
                 let flat_result = flat_storage_chunk_view.get_ref(&key);
-                match flat_result {
-                    err @ Err(StorageError::FlatStorageError(_)) => {
-                        return err;
-                    }
-                    flat_result @ _ => {
-                        assert_eq!(result, flat_result);
-                    }
+                if matches!(flat_result, Err(StorageError::FlatStorageError(_))) {
+                    return flat_result;
+                } else {
+                    assert_eq!(result, flat_result);
                 }
             }
         }

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -976,7 +976,14 @@ impl Trie {
         if matches!(mode, KeyLookupMode::FlatStorage) && !is_delayed_receipt_key(key) {
             if let Some(flat_storage_chunk_view) = &self.flat_storage_chunk_view {
                 let flat_result = flat_storage_chunk_view.get_ref(&key);
-                assert_eq!(result, flat_result);
+                match flat_result {
+                    err @ Err(StorageError::FlatStorageError(_)) => {
+                        return err;
+                    }
+                    flat_result @ _ => {
+                        assert_eq!(result, flat_result);
+                    }
+                }
             }
         }
         result

--- a/integration-tests/src/tests/client/flat_storage.rs
+++ b/integration-tests/src/tests/client/flat_storage.rs
@@ -4,6 +4,7 @@ use near_chain::{ChainGenesis, RuntimeWithEpochManagerAdapter};
 use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
 use near_o11y::testonly::init_test_logger;
+use near_primitives::errors::StorageError;
 use near_primitives::shard_layout::{ShardLayout, ShardUId};
 use near_primitives::types::AccountId;
 use near_primitives_core::types::BlockHeight;
@@ -12,7 +13,7 @@ use near_store::flat::{
     FlatStorageStatus, NUM_PARTS_IN_ONE_STEP,
 };
 use near_store::test_utils::create_test_store;
-use near_store::{Store, TrieTraversalItem};
+use near_store::{KeyLookupMode, Store, TrieTraversalItem};
 use nearcore::config::GenesisExt;
 use std::path::Path;
 use std::str::FromStr;
@@ -493,4 +494,59 @@ fn test_flat_storage_iter() {
             }
         }
     }
+}
+
+#[test]
+fn test_not_supported_block() {
+    init_test_logger();
+    let genesis = Genesis::test(vec!["test0".parse().unwrap()], 1);
+    let shard_layout = ShardLayout::v0_single_shard();
+    let shard_uid = shard_layout.get_shard_uids()[0];
+    let store = create_test_store();
+
+    let mut env = setup_env(&genesis, store.clone());
+    // Produce blocks up to `START_HEIGHT`.
+    for height in 1..START_HEIGHT {
+        env.produce_block(0, height);
+    }
+
+    // Trie key which must exist in the storage.
+    let trie_key_bytes =
+        near_primitives::trie_key::TrieKey::Account { account_id: "test0".parse().unwrap() }
+            .to_vec();
+    // Create trie, which includes creating chunk view, and get `ValueRef`s
+    // for post state roots for blocks `START_HEIGHT - 3` and `START_HEIGHT - 2`.
+    // After creating the first trie, produce block `START_HEIGHT` which moves flat storage
+    // head 1 block further and invalidates it.
+    let get_ref_results: Vec<_> = (START_HEIGHT - 3..START_HEIGHT - 1)
+        .map(|height| {
+            let block_hash = env.clients[0].chain.get_block_hash_by_height(height).unwrap();
+            let state_root = *env.clients[0]
+                .chain
+                .get_chunk_extra(&block_hash, &ShardUId::from_shard_id_and_layout(0, &shard_layout))
+                .unwrap()
+                .state_root();
+
+            let trie = env.clients[0]
+                .runtime_adapter
+                .get_trie_for_shard(shard_uid.shard_id(), &block_hash, state_root, true)
+                .unwrap();
+            if height == START_HEIGHT - 3 {
+                env.produce_block(0, START_HEIGHT);
+            }
+            trie.get_ref(&trie_key_bytes, KeyLookupMode::FlatStorage)
+        })
+        .collect();
+
+    // The first result should be FlatStorageError, because we can't read from first chunk view anymore.
+    // But the node must not panic as this is normal behaviour.
+    // Ideally it should be tested on chain level, but there is no easy way to
+    // postpone applying chunks reliably.
+    if cfg!(feature = "protocol_feature_flat_state") {
+        assert_matches!(get_ref_results[0], Err(StorageError::FlatStorageError(_)));
+    } else {
+        assert_matches!(get_ref_results[0], Ok(Some(_)));
+    }
+    // For the second result chunk view is valid, so result is Ok.
+    assert_matches!(get_ref_results[1], Ok(Some(_)));
 }

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -1015,7 +1015,7 @@ impl RuntimeAdapter for NightshadeRuntime {
             Ok(result) => Ok(result),
             Err(e) => match e {
                 Error::StorageError(err) => match &err {
-                    StorageError::FlatStorageError(_) => Err(err.into()),
+                    StorageError::FlatStorageBlockNotSupported(_) => Err(err.into()),
                     _ => panic!("{err}"),
                 },
                 _ => Err(e),


### PR DESCRIPTION
Making flat storage errors more clear and fix error types in several places. Fixes [flat storage failure on March 14](https://near.zulipchat.com/#narrow/stream/345766-pagoda.2Fstorage.2Fflat-storage/topic/FS.20failure.20March.2014th/near/341648913).
This PR needs a review with **extra caution**, because `StorageInternalError` in incorrect place may lead to node panic and `BlockNotSupported` when DB is corrupted may lead to weird behaviour of node.

Here I claim that there are two types of `FlatStorageError`:
* `BlockNotSupported` - can occur in normal circumstances, when flat storage head was moved forward during processing some chunk.
* `StorageInternalError` - means that flat storage is corrupted, we have to panic.

I looked at every single place where we return these errors, and replaced some of them:
* `get_block_changes` - once it is called, we already know that delta exists in cache, otherwise it is state inconsistency.
* `update_flat_head`, `store_helper::get_delta_changes` - it is more sane to return error, after which we panic later, on `apply_transactions_with_optional_storage_proof`.
* `update_flat_head`, `gc_height` - delta exists in cache, otherwise we have inconsistency.

`Trie::get_ref` is fixed to properly propagate flat storage error [here](https://github.com/near/nearcore/blob/d230eaf07da01df4b47f77f2a240d2cfefbc0592/nearcore/src/runtime/mod.rs#L1018-L1021).

## Testing
* `flat_storage_errors` - check for `StorageInternalError` as well.
* `test_not_supported_block` - check that instead of panic, `Trie::get_ref` returns correct error now.