### PR TITLE
feat: don't exclude delayed receipts from flat storage

### DIFF
--- a/core/primitives/src/state_record.rs
+++ b/core/primitives/src/state_record.rs
@@ -161,8 +161,3 @@ pub fn is_contract_code_key(key: &[u8]) -> bool {
     debug_assert!(!key.is_empty());
     key[0] == col::CONTRACT_CODE
 }
-
-pub fn is_delayed_receipt_key(key: &[u8]) -> bool {
-    debug_assert!(!key.is_empty());
-    key[0] == col::DELAYED_RECEIPT || key[0] == col::DELAYED_RECEIPT_INDICES
-}

--- a/core/store/src/flat/delta.rs
+++ b/core/store/src/flat/delta.rs
@@ -69,10 +69,6 @@ impl FlatStateChanges {
         let mut delta = HashMap::new();
         for change in changes.iter() {
             let key = change.trie_key.to_vec();
-            if near_primitives::state_record::is_delayed_receipt_key(&key) {
-                continue;
-            }
-
             // `RawStateChangesWithTrieKey` stores all sequential changes for a key within a chunk, so it is sufficient
             // to take only the last change.
             let last_change = &change
@@ -147,8 +143,24 @@ mod tests {
         let alice_trie_key = TrieKey::ContractCode { account_id: "alice".parse().unwrap() };
         let bob_trie_key = TrieKey::ContractCode { account_id: "bob".parse().unwrap() };
         let carol_trie_key = TrieKey::ContractCode { account_id: "carol".parse().unwrap() };
+        let delayed_trie_key = TrieKey::DelayedReceiptIndices;
+        let delayed_receipt_trie_key = TrieKey::DelayedReceipt { index: 1 };
 
         let state_changes = vec![
+            RawStateChangesWithTrieKey {
+                trie_key: delayed_trie_key.clone(),
+                changes: vec![RawStateChange {
+                    cause: StateChangeCause::InitialState,
+                    data: Some(vec![1]),
+                }],
+            },
+            RawStateChangesWithTrieKey {
+                trie_key: delayed_receipt_trie_key.clone(),
+                changes: vec![RawStateChange {
+                    cause: StateChangeCause::InitialState,
+                    data: Some(vec![2]),
+                }],
+            },
             RawStateChangesWithTrieKey {
                 trie_key: alice_trie_key.clone(),
                 changes: vec![
@@ -188,34 +200,14 @@ mod tests {
         );
         assert_eq!(flat_state_changes.get(&bob_trie_key.to_vec()), Some(None));
         assert_eq!(flat_state_changes.get(&carol_trie_key.to_vec()), None);
-    }
-
-    /// Check that keys related to delayed receipts are not included to `FlatStateChanges`.
-    #[test]
-    fn flat_state_changes_delayed_keys() {
-        let delayed_trie_key = TrieKey::DelayedReceiptIndices;
-        let delayed_receipt_trie_key = TrieKey::DelayedReceipt { index: 1 };
-
-        let state_changes = vec![
-            RawStateChangesWithTrieKey {
-                trie_key: delayed_trie_key.clone(),
-                changes: vec![RawStateChange {
-                    cause: StateChangeCause::InitialState,
-                    data: Some(vec![1]),
-                }],
-            },
-            RawStateChangesWithTrieKey {
-                trie_key: delayed_receipt_trie_key.clone(),
-                changes: vec![RawStateChange {
-                    cause: StateChangeCause::InitialState,
-                    data: Some(vec![2]),
-                }],
-            },
-        ];
-
-        let flat_state_changes = FlatStateChanges::from_state_changes(&state_changes);
-        assert!(flat_state_changes.get(&delayed_trie_key.to_vec()).is_none());
-        assert!(flat_state_changes.get(&delayed_receipt_trie_key.to_vec()).is_none());
+        assert_eq!(
+            flat_state_changes.get(&delayed_trie_key.to_vec()),
+            Some(Some(ValueRef::new(&[1])))
+        );
+        assert_eq!(
+            flat_state_changes.get(&delayed_receipt_trie_key.to_vec()),
+            Some(Some(ValueRef::new(&[2])))
+        );
     }
 
     /// Check that merge of `FlatStateChanges`s overrides the old changes for the same keys and doesn't conflict with

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -12,7 +12,7 @@ use near_primitives::contract::ContractCode;
 use near_primitives::hash::{hash, CryptoHash};
 pub use near_primitives::shard_layout::ShardUId;
 use near_primitives::state::ValueRef;
-use near_primitives::state_record::{is_delayed_receipt_key, StateRecord};
+use near_primitives::state_record::StateRecord;
 use near_primitives::trie_key::TrieKey;
 use near_primitives::types::{StateRoot, StateRootNode};
 
@@ -973,7 +973,7 @@ impl Trie {
         // For now, to test correctness, flat storage does double the work and
         // compares the results. This needs to be changed when the features is
         // stabilized.
-        if matches!(mode, KeyLookupMode::FlatStorage) && !is_delayed_receipt_key(key) {
+        if matches!(mode, KeyLookupMode::FlatStorage) {
             if let Some(flat_storage_chunk_view) = &self.flat_storage_chunk_view {
                 let flat_result = flat_storage_chunk_view.get_ref(&key);
                 if matches!(flat_result, Err(StorageError::FlatStorageBlockNotSupported(_))) {


### PR DESCRIPTION
Previously we didn't have `shard_uid` prefix for `FlatState` keys on disk which meant that we couldn't easily store delayed receipts for different shards there. This is no longer the case and we can store delayed receipts in flat storage now.
This makes `FlatState` store exactly the same data as `State` which makes overall setup more consistent and enables easier flat storage use for state sync without any special cases.


### Testing

Existing tests should not fail.