### PR TITLE
refactor: use shard_uid as a key in FlatStorageManager

### DIFF
--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -829,7 +829,7 @@ impl RuntimeAdapter for KeyValueRuntime {
         ))
     }
 
-    fn get_flat_storage_for_shard(&self, _shard_id: ShardId) -> Option<FlatStorage> {
+    fn get_flat_storage_for_shard(&self, _shard_uid: ShardUId) -> Option<FlatStorage> {
         None
     }
 
@@ -843,7 +843,7 @@ impl RuntimeAdapter for KeyValueRuntime {
 
     fn remove_flat_storage_for_shard(
         &self,
-        _shard_id: ShardId,
+        _shard_uid: ShardUId,
         _epoch_id: &EpochId,
     ) -> Result<(), Error> {
         Ok(())

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -297,7 +297,7 @@ pub trait RuntimeAdapter: Send + Sync {
         state_root: StateRoot,
     ) -> Result<Trie, Error>;
 
-    fn get_flat_storage_for_shard(&self, shard_id: ShardId) -> Option<FlatStorage>;
+    fn get_flat_storage_for_shard(&self, shard_uid: ShardUId) -> Option<FlatStorage>;
 
     fn get_flat_storage_status(&self, shard_uid: ShardUId) -> FlatStorageStatus;
 
@@ -310,7 +310,7 @@ pub trait RuntimeAdapter: Send + Sync {
     /// Used to clear old flat storage data from disk and memory before syncing to newer state.
     fn remove_flat_storage_for_shard(
         &self,
-        shard_id: ShardId,
+        shard_uid: ShardUId,
         epoch_id: &EpochId,
     ) -> Result<(), Error>;
 

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -143,7 +143,7 @@ impl ShardTries {
             prefetch_api,
         ));
         let flat_storage_chunk_view =
-            self.0.flat_storage_manager.chunk_view(shard_uid.shard_id(), block_hash, is_view);
+            self.0.flat_storage_manager.chunk_view(shard_uid, block_hash, is_view);
 
         Trie::new(storage, state_root, flat_storage_chunk_view)
     }

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -161,7 +161,7 @@ impl<'c> EstimatorContext<'c> {
         );
         store_update.commit().expect("failed to set flat storage status");
         let flat_storage = FlatStorage::new(store, shard_uid);
-        flat_storage_manager.add_flat_storage_for_shard(shard_uid.shard_id(), flat_storage);
+        flat_storage_manager.add_flat_storage_for_shard(shard_uid, flat_storage);
         flat_storage_manager
     }
 }

--- a/tools/flat-storage/src/commands.rs
+++ b/tools/flat-storage/src/commands.rs
@@ -129,7 +129,7 @@ impl FlatStorageCommand {
                     rw_hot_runtime.shard_id_to_uid(reset_cmd.shard_id, &tip.epoch_id)?;
                 rw_hot_runtime.create_flat_storage_for_shard(shard_uid);
 
-                rw_hot_runtime.remove_flat_storage_for_shard(reset_cmd.shard_id, &tip.epoch_id)?;
+                rw_hot_runtime.remove_flat_storage_for_shard(shard_uid, &tip.epoch_id)?;
             }
             SubCommand::Init(init_cmd) => {
                 let (_, rw_hot_runtime, rw_chain_store, rw_hot_store) = Self::get_db(


### PR DESCRIPTION
Part of #8577.

This finishes flat storage transition from `shard_id` to `shard_uid`. 