### PR TITLE
feat(params-estimator): flat state deltas overhead

### DIFF
--- a/core/store/src/flat/delta.rs
+++ b/core/store/src/flat/delta.rs
@@ -40,7 +40,7 @@ pub struct FlatStateChanges(pub(crate) HashMap<Vec<u8>, Option<ValueRef>>);
 
 impl<T> From<T> for FlatStateChanges
 where
-    T: Iterator<Item = (Vec<u8>, Option<ValueRef>)>,
+    T: IntoIterator<Item = (Vec<u8>, Option<ValueRef>)>,
 {
     fn from(iter: T) -> Self {
         Self(HashMap::from_iter(iter))

--- a/core/store/src/flat/delta.rs
+++ b/core/store/src/flat/delta.rs
@@ -38,9 +38,12 @@ impl KeyForFlatStateDelta {
 #[derive(BorshSerialize, BorshDeserialize, Clone, Default, Debug, PartialEq, Eq)]
 pub struct FlatStateChanges(pub(crate) HashMap<Vec<u8>, Option<ValueRef>>);
 
-impl<const N: usize> From<[(Vec<u8>, Option<ValueRef>); N]> for FlatStateChanges {
-    fn from(arr: [(Vec<u8>, Option<ValueRef>); N]) -> Self {
-        Self(HashMap::from(arr))
+impl<T> From<T> for FlatStateChanges
+where
+    T: Iterator<Item = (Vec<u8>, Option<ValueRef>)>,
+{
+    fn from(iter: T) -> Self {
+        Self(HashMap::from_iter(iter))
     }
 }
 

--- a/runtime/runtime-params-estimator/src/config.rs
+++ b/runtime/runtime-params-estimator/src/config.rs
@@ -22,6 +22,10 @@ pub struct Config {
     pub active_accounts: usize,
     /// Number of the transactions in the block.
     pub block_sizes: Vec<usize>,
+    /// How many blocks behind the final head is assumed to be compared to the tip.
+    pub finality_lag: usize,
+    /// How many key-value pairs change per flat state delta.
+    pub fs_keys_per_delta: usize,
     /// Where state dump is located in case we need to create a testbed.
     pub state_dump_path: PathBuf,
     /// Metric used for counting.

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -7,23 +7,23 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::Receipt;
 use near_primitives::runtime::config_store::RuntimeConfigStore;
 use near_primitives::runtime::migration_data::{MigrationData, MigrationFlags};
+use near_primitives::state::ValueRef;
 use near_primitives::test_utils::MockEpochInfoProvider;
 use near_primitives::transaction::{ExecutionStatus, SignedTransaction};
 use near_primitives::types::{Gas, MerkleHash};
 use near_primitives::version::PROTOCOL_VERSION;
 use near_store::flat::{
-    store_helper, BlockInfo, FlatStorage, FlatStorageManager, FlatStorageReadyStatus,
-    FlatStorageStatus,
+    store_helper, BlockInfo, FlatStateChanges, FlatStateDelta, FlatStateDeltaMetadata, FlatStorage,
+    FlatStorageManager, FlatStorageReadyStatus, FlatStorageStatus,
 };
 use near_store::{ShardTries, ShardUId, Store, StoreCompiledContractCache, TrieUpdate};
 use near_store::{TrieCache, TrieCachingStorage, TrieConfig};
 use near_vm_logic::{ExtCosts, VMLimitConfig};
 use node_runtime::{ApplyState, Runtime};
 use std::collections::HashMap;
+use std::iter;
 use std::rc::Rc;
 use std::sync::Arc;
-
-const FLAT_STATE_HEAD: CryptoHash = CryptoHash::new();
 
 /// Global context shared by all cost calculating functions.
 pub(crate) struct EstimatorContext<'c> {
@@ -80,7 +80,7 @@ impl<'c> EstimatorContext<'c> {
             store.clone(),
             trie_config,
             &shard_uids,
-            Self::create_flat_storage_manager(store.clone()),
+            self.create_flat_storage_manager(store.clone()),
         );
 
         Testbed {
@@ -143,7 +143,7 @@ impl<'c> EstimatorContext<'c> {
         }
     }
 
-    fn create_flat_storage_manager(store: Store) -> FlatStorageManager {
+    fn create_flat_storage_manager(&self, store: Store) -> FlatStorageManager {
         let flat_storage_manager = FlatStorageManager::new(store.clone());
         if !cfg!(feature = "protocol_feature_flat_state") {
             return flat_storage_manager;
@@ -156,13 +156,57 @@ impl<'c> EstimatorContext<'c> {
             &mut store_update,
             shard_uid,
             FlatStorageStatus::Ready(FlatStorageReadyStatus {
-                flat_head: BlockInfo::genesis(FLAT_STATE_HEAD, 0),
+                flat_head: BlockInfo::genesis(CryptoHash::hash_borsh(0usize), 0),
             }),
         );
         store_update.commit().expect("failed to set flat storage status");
         let flat_storage = FlatStorage::new(store, shard_uid);
+        self.generate_deltas(&flat_storage);
         flat_storage_manager.add_flat_storage_for_shard(shard_uid.shard_id(), flat_storage);
         flat_storage_manager
+    }
+
+    /// Construct a chain of fake blocks with fake deltas for flat storage.
+    ///
+    /// Use `hash(height)` as the supposed block hash.
+    /// Keys are randomly generated, values are a constant that's not even stored.
+    /// 
+    /// The blocks aren't valid, nor are the values stored anywhere. They only
+    /// exist within `FlatStorage` and simulate the performance decrease
+    /// observed when the flat head lags behind.
+    fn generate_deltas(&self, flat_storage: &FlatStorage) {
+        // Assumption: One delta per non-final block, which is configurable.
+        // There could be forks but that's considered to e outside the normal
+        // operating conditions for this estimation.
+        let num_deltas = self.config.finality_lag;
+        // Number of keys changed is the same for all deltas and configurable.
+        let num_changes_per_delta = self.config.fs_keys_per_delta;
+        // This is the longest key we allow in storage.
+        let delta_key_len = 2000;
+        for idx in 0..num_deltas {
+            // We want different keys and to avoid all optimization potential.
+            // But the values are never read, so let's just use a dummy constant.
+            let random_data = iter::repeat_with(|| {
+                (
+                    crate::utils::random_vec(delta_key_len),
+                    Some(ValueRef::new(b"this is never stored or accessed, we only need it to blow up in-memory deltas")),
+                )
+            })
+            .take(num_changes_per_delta);
+            let height = 1 + idx as u64;
+            let block = BlockInfo {
+                hash: CryptoHash::hash_borsh(height),
+                height,
+                prev_hash: CryptoHash::hash_borsh(height - 1),
+            };
+
+            flat_storage
+                .add_delta(FlatStateDelta {
+                    changes: FlatStateChanges::from(random_data),
+                    metadata: FlatStateDeltaMetadata { block },
+                })
+                .unwrap();
+        }
     }
 }
 
@@ -383,10 +427,8 @@ impl Testbed<'_> {
 
     /// Instantiate a new trie for the estimator.
     fn trie(&mut self) -> near_store::Trie {
-        self.tries.get_trie_with_block_hash_for_shard(
-            ShardUId::single_shard(),
-            self.root,
-            &FLAT_STATE_HEAD,
-        )
+        let num_deltas = self.config.finality_lag;
+        let tip = CryptoHash::hash_borsh(num_deltas);
+        self.tries.get_trie_with_block_hash_for_shard(ShardUId::single_shard(), self.root, &tip)
     }
 }

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -170,7 +170,7 @@ impl<'c> EstimatorContext<'c> {
     ///
     /// Use `hash(height)` as the supposed block hash.
     /// Keys are randomly generated, values are a constant that's not even stored.
-    /// 
+    ///
     /// The blocks aren't valid, nor are the values stored anywhere. They only
     /// exist within `FlatStorage` and simulate the performance decrease
     /// observed when the flat head lags behind.
@@ -195,9 +195,9 @@ impl<'c> EstimatorContext<'c> {
             .take(num_changes_per_delta);
             let height = 1 + idx as u64;
             let block = BlockInfo {
-                hash: CryptoHash::hash_borsh(height),
+                hash: fs_fake_block_height_to_hash(height),
                 height,
-                prev_hash: CryptoHash::hash_borsh(height - 1),
+                prev_hash: fs_fake_block_height_to_hash(height - 1),
             };
 
             flat_storage
@@ -427,8 +427,17 @@ impl Testbed<'_> {
 
     /// Instantiate a new trie for the estimator.
     fn trie(&mut self) -> near_store::Trie {
-        let num_deltas = self.config.finality_lag;
-        let tip = CryptoHash::hash_borsh(num_deltas);
+        // We generated `finality_lag` fake blocks earlier, so the fake height
+        // will be at the same number.
+        let tip_height = self.config.finality_lag;
+        let tip = fs_fake_block_height_to_hash(tip_height as u64);
         self.tries.get_trie_with_block_hash_for_shard(ShardUId::single_shard(), self.root, &tip)
     }
+}
+
+/// Maps fake block heights to block hashes.
+///
+/// This is ued to generate and access fake deltas for flat storage.
+fn fs_fake_block_height_to_hash(height: u64) -> CryptoHash {
+    CryptoHash::hash_borsh(height)
 }

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -751,7 +751,7 @@ fn action_function_call_per_byte(ctx: &mut EstimatorContext) -> GasCost {
 fn inner_action_function_call_per_byte(ctx: &mut EstimatorContext, arg_len: usize) -> GasCost {
     let mut make_transaction = |tb: &mut TransactionBuilder| -> SignedTransaction {
         let sender = tb.random_unused_account();
-        let args = tb.random_vec(arg_len);
+        let args = utils::random_vec(arg_len);
         tb.transaction_from_function_call(sender, "noop", args)
     };
     let block_size = 5;

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -40,6 +40,14 @@ struct CliArgs {
     /// Number of additional accounts to add to the state, among which active accounts are selected.
     #[clap(long, default_value = "200000")]
     additional_accounts_num: u64,
+    /// How many blocks behind the final head is assumed to be compared to the tip.
+    ///
+    /// This is used to simulate flat state deltas, which depend on finality.
+    #[clap(long, default_value = "50")]
+    pub finality_lag: usize,
+    /// How many key-value pairs change per flat state delta.
+    #[clap(long, default_value = "100")]
+    pub fs_keys_per_delta: usize,
     /// Skip building test contract which is used in metrics computation.
     #[clap(long)]
     skip_build_test_contract: bool,
@@ -289,6 +297,8 @@ fn run_estimation(cli_args: CliArgs) -> anyhow::Result<Option<CostTable>> {
         iter_per_block,
         active_accounts,
         block_sizes: vec![],
+        finality_lag: cli_args.finality_lag,
+        fs_keys_per_delta: cli_args.fs_keys_per_delta,
         state_dump_path: state_dump_path,
         metric,
         vm_kind,

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -515,6 +515,8 @@ mod tests {
             iters: 1,
             accounts_num: 100,
             additional_accounts_num: 100,
+            finality_lag: 3,
+            fs_keys_per_delta: 1,
             skip_build_test_contract: false,
             metric: "time".to_owned(),
             vm_kind: None,

--- a/runtime/runtime-params-estimator/src/transaction_builder.rs
+++ b/runtime/runtime-params-estimator/src/transaction_builder.rs
@@ -146,10 +146,6 @@ impl TransactionBuilder {
         }
     }
 
-    pub(crate) fn random_vec(&mut self, len: usize) -> Vec<u8> {
-        (0..len).map(|_| self.rng().gen()).collect()
-    }
-
     fn nonce(&mut self, account_id: &AccountId) -> u64 {
         let nonce = self.nonces.entry(account_id.clone()).or_default();
         *nonce += 1;

--- a/runtime/runtime-params-estimator/src/trie.rs
+++ b/runtime/runtime-params-estimator/src/trie.rs
@@ -264,7 +264,7 @@ fn read_node_from_chunk_cache_ext(
 
     // Prepare a data buffer that we can read again later to overwrite CPU caches
     let assumed_max_l3_size = 128 * 1024 * 1024;
-    let dummy_data = testbed.transaction_builder().random_vec(assumed_max_l3_size);
+    let dummy_data = crate::utils::random_vec(assumed_max_l3_size);
 
     (0..iters)
         .map(|i| {
@@ -282,7 +282,7 @@ fn read_node_from_chunk_cache_ext(
             let values_inserted = num_values * data_spread_factor;
             let values: Vec<_> = (0..values_inserted)
                 .map(|_| {
-                    let extention_key = tb.random_vec(value_len);
+                    let extention_key = crate::utils::random_vec(value_len);
                     near_store::estimator::encode_extension_node(extention_key)
                 })
                 .collect();

--- a/runtime/runtime-params-estimator/src/utils.rs
+++ b/runtime/runtime-params-estimator/src/utils.rs
@@ -434,6 +434,11 @@ pub(crate) fn generate_data_only_contract(data_size: usize, config: &VMConfig) -
     wasm
 }
 
+pub(crate) fn random_vec(len: usize) -> Vec<u8> {
+    let mut rng = rand::thread_rng();
+    (0..len).map(|_| rng.gen()).collect()
+}
+
 #[cfg(test)]
 mod test {
     use super::percentiles;


### PR DESCRIPTION
Force FlatState used by the estimator to resolve deltas.
The number of deltas and the number of keys per delta is configurable.

Example usage:
```
cargo run -r -p runtime-params-estimator --features=protocol_feature_flat_state -- \
--accounts-num 10000 --additional-accounts-num 10000 \
--finality-lag 50 --fs-keys-per-delta 100 \
--metric time --debug --costs StorageReadBase
```