### PR TITLE
refactor: move flat storage metrics to a separate module

### DIFF
--- a/chain/chain/src/flat_storage_creator.rs
+++ b/chain/chain/src/flat_storage_creator.rs
@@ -13,32 +13,22 @@ use crate::{ChainStore, ChainStoreAccess, RuntimeWithEpochManagerAdapter};
 use assert_matches::assert_matches;
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use near_chain_primitives::Error;
-use near_o11y::metrics::{IntCounter, IntGauge};
 use near_primitives::shard_layout::ShardUId;
 use near_primitives::state::ValueRef;
 use near_primitives::state_part::PartId;
 use near_primitives::state_record::is_delayed_receipt_key;
 use near_primitives::types::{AccountId, BlockHeight, StateRoot};
 use near_store::flat::{
-    store_helper, BlockInfo, FetchingStateStatus, FlatStateChanges, FlatStorageCreationStatus,
-    FlatStorageReadyStatus, FlatStorageStatus, NUM_PARTS_IN_ONE_STEP, STATE_PART_MEMORY_LIMIT,
+    store_helper, BlockInfo, FetchingStateStatus, FlatStateChanges, FlatStorageCreationMetrics,
+    FlatStorageCreationStatus, FlatStorageReadyStatus, FlatStorageStatus, NUM_PARTS_IN_ONE_STEP,
+    STATE_PART_MEMORY_LIMIT,
 };
-use near_store::{Store, FLAT_STORAGE_HEAD_HEIGHT};
+use near_store::Store;
 use near_store::{Trie, TrieDBStorage, TrieTraversalItem};
 use std::collections::HashMap;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use tracing::{debug, info};
-
-/// Metrics reporting about flat storage creation progress on each status update.
-struct FlatStorageCreationMetrics {
-    status: IntGauge,
-    flat_head_height: IntGauge,
-    remaining_state_parts: IntGauge,
-    fetched_state_parts: IntCounter,
-    fetched_state_items: IntCounter,
-    threads_used: IntGauge,
-}
 
 /// If we launched a node with enabled flat storage but it doesn't have flat storage data on disk, we have to create it.
 /// This struct is responsible for this process for the given shard.
@@ -68,10 +58,6 @@ impl FlatStorageShardCreator {
         runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
     ) -> Self {
         let (fetched_parts_sender, fetched_parts_receiver) = unbounded();
-        // `itoa` is much faster for printing shard_id to a string than trivial alternatives.
-        let mut buffer = itoa::Buffer::new();
-        let shard_id_label = buffer.format(shard_uid.shard_id());
-
         Self {
             shard_uid,
             start_height,
@@ -79,22 +65,7 @@ impl FlatStorageShardCreator {
             remaining_state_parts: None,
             fetched_parts_sender,
             fetched_parts_receiver,
-            metrics: FlatStorageCreationMetrics {
-                status: near_store::flat_state_metrics::FLAT_STORAGE_CREATION_STATUS
-                    .with_label_values(&[shard_id_label]),
-                flat_head_height: FLAT_STORAGE_HEAD_HEIGHT.with_label_values(&[shard_id_label]),
-                remaining_state_parts:
-                    near_store::flat_state_metrics::FLAT_STORAGE_CREATION_REMAINING_STATE_PARTS
-                        .with_label_values(&[shard_id_label]),
-                fetched_state_parts:
-                    near_store::flat_state_metrics::FLAT_STORAGE_CREATION_FETCHED_STATE_PARTS
-                        .with_label_values(&[shard_id_label]),
-                fetched_state_items:
-                    near_store::flat_state_metrics::FLAT_STORAGE_CREATION_FETCHED_STATE_ITEMS
-                        .with_label_values(&[shard_id_label]),
-                threads_used: near_store::flat_state_metrics::FLAT_STORAGE_CREATION_THREADS_USED
-                    .with_label_values(&[shard_id_label]),
-            },
+            metrics: FlatStorageCreationMetrics::new(shard_uid.shard_id()),
         }
     }
 
@@ -167,7 +138,7 @@ impl FlatStorageShardCreator {
         let shard_id = self.shard_uid.shard_id();
         let current_status =
             store_helper::get_flat_storage_status(chain_store.store(), self.shard_uid);
-        self.metrics.status.set((&current_status).into());
+        self.metrics.set_status(&current_status);
         match &current_status {
             FlatStorageStatus::Empty => {
                 let mut store_update = chain_store.store().store_update();
@@ -229,7 +200,7 @@ impl FlatStorageShardCreator {
                     info!(target: "store", %shard_id, %final_height, ?status, "Switching status to fetching state");
 
                     let mut store_update = chain_store.store().store_update();
-                    self.metrics.flat_head_height.set(final_head.height as i64);
+                    self.metrics.set_flat_head_height(final_head.height);
                     store_helper::set_flat_storage_status(
                         &mut store_update,
                         self.shard_uid,
@@ -249,7 +220,7 @@ impl FlatStorageShardCreator {
                 let num_parts_in_step = fetching_state_status.num_parts_in_step;
                 let num_parts = fetching_state_status.num_parts;
                 let next_start_part_id = num_parts.min(start_part_id + num_parts_in_step);
-                self.metrics.remaining_state_parts.set((num_parts - start_part_id) as i64);
+                self.metrics.set_remaining_state_parts(num_parts - start_part_id);
 
                 match self.remaining_state_parts {
                     None => {
@@ -269,7 +240,7 @@ impl FlatStorageShardCreator {
                             let inner_store = store.clone();
                             let inner_progress = progress.clone();
                             let inner_sender = self.fetched_parts_sender.clone();
-                            let inner_threads_used = self.metrics.threads_used.clone();
+                            let inner_threads_used = self.metrics.threads_used();
                             thread_pool.spawn(move || {
                                 inner_threads_used.inc();
                                 Self::fetch_state_part(
@@ -291,8 +262,7 @@ impl FlatStorageShardCreator {
                         let mut updated_state_parts = state_parts;
                         while let Ok(num_items) = self.fetched_parts_receiver.try_recv() {
                             updated_state_parts -= 1;
-                            self.metrics.fetched_state_items.inc_by(num_items);
-                            self.metrics.fetched_state_parts.inc();
+                            self.metrics.inc_fetched_state(num_items);
                         }
                         self.remaining_state_parts = Some(updated_state_parts);
                     }
@@ -321,7 +291,7 @@ impl FlatStorageShardCreator {
                         } else {
                             // If all parts were fetched, we can start catchup.
                             info!(target: "chain", %shard_id, %block_hash, "Finished fetching state");
-                            self.metrics.remaining_state_parts.set(0);
+                            self.metrics.set_remaining_state_parts(0);
                             store_helper::remove_delta(
                                 &mut store_update,
                                 self.shard_uid,
@@ -374,7 +344,7 @@ impl FlatStorageShardCreator {
                     let flat_head_block_header = chain_store.get_block_header(&flat_head).unwrap();
                     let height = flat_head_block_header.height();
                     debug!(target: "chain", %shard_id, %old_flat_head, %old_height, %flat_head, %height, "Catching up flat head");
-                    self.metrics.flat_head_height.set(height as i64);
+                    self.metrics.set_flat_head_height(height);
                     merged_changes.apply_to_flat_state(&mut store_update, shard_uid);
                     store_helper::set_flat_storage_status(
                         &mut store_update,

--- a/core/store/src/flat/metrics.rs
+++ b/core/store/src/flat/metrics.rs
@@ -1,0 +1,101 @@
+use crate::metrics::flat_state_metrics;
+use near_o11y::metrics::{IntCounter, IntGauge};
+use near_primitives::types::ShardId;
+
+use super::FlatStorageStatus;
+
+pub(crate) struct FlatStorageMetrics {
+    flat_head_height: IntGauge,
+    distance_to_head: IntGauge,
+    cached_deltas: IntGauge,
+    cached_changes_num_items: IntGauge,
+    cached_changes_size: IntGauge,
+}
+
+impl FlatStorageMetrics {
+    pub(crate) fn new(shard_id: ShardId) -> Self {
+        let shard_id_label = shard_id.to_string();
+        Self {
+            flat_head_height: flat_state_metrics::FLAT_STORAGE_HEAD_HEIGHT
+                .with_label_values(&[&shard_id_label]),
+            distance_to_head: flat_state_metrics::FLAT_STORAGE_DISTANCE_TO_HEAD
+                .with_label_values(&[&shard_id_label]),
+            cached_deltas: flat_state_metrics::FLAT_STORAGE_CACHED_DELTAS
+                .with_label_values(&[&shard_id_label]),
+            cached_changes_num_items: flat_state_metrics::FLAT_STORAGE_CACHED_CHANGES_NUM_ITEMS
+                .with_label_values(&[&shard_id_label]),
+            cached_changes_size: flat_state_metrics::FLAT_STORAGE_CACHED_CHANGES_SIZE
+                .with_label_values(&[&shard_id_label]),
+        }
+    }
+
+    pub(crate) fn set_distance_to_head(&self, distance: usize) {
+        self.distance_to_head.set(distance as i64);
+    }
+
+    pub(crate) fn set_flat_head_height(&self, height: u64) {
+        self.flat_head_height.set(height as i64);
+    }
+
+    pub(crate) fn set_cached_deltas(
+        &self,
+        cached_deltas: usize,
+        cached_changes_num_items: usize,
+        cached_changes_size: u64,
+    ) {
+        self.cached_deltas.set(cached_deltas as i64);
+        self.cached_changes_num_items.set(cached_changes_num_items as i64);
+        self.cached_changes_size.set(cached_changes_size as i64);
+    }
+}
+
+/// Metrics reporting about flat storage creation progress on each status update.
+pub struct FlatStorageCreationMetrics {
+    status: IntGauge,
+    flat_head_height: IntGauge,
+    remaining_state_parts: IntGauge,
+    fetched_state_parts: IntCounter,
+    fetched_state_items: IntCounter,
+    threads_used: IntGauge,
+}
+
+impl FlatStorageCreationMetrics {
+    pub fn new(shard_id: ShardId) -> Self {
+        let shard_id_label = shard_id.to_string();
+        Self {
+            status: flat_state_metrics::FLAT_STORAGE_CREATION_STATUS
+                .with_label_values(&[&shard_id_label]),
+            flat_head_height: flat_state_metrics::FLAT_STORAGE_HEAD_HEIGHT
+                .with_label_values(&[&shard_id_label]),
+            remaining_state_parts: flat_state_metrics::FLAT_STORAGE_CREATION_REMAINING_STATE_PARTS
+                .with_label_values(&[&shard_id_label]),
+            fetched_state_parts: flat_state_metrics::FLAT_STORAGE_CREATION_FETCHED_STATE_PARTS
+                .with_label_values(&[&shard_id_label]),
+            fetched_state_items: flat_state_metrics::FLAT_STORAGE_CREATION_FETCHED_STATE_ITEMS
+                .with_label_values(&[&shard_id_label]),
+            threads_used: flat_state_metrics::FLAT_STORAGE_CREATION_THREADS_USED
+                .with_label_values(&[&shard_id_label]),
+        }
+    }
+
+    pub fn set_status(&self, status: &FlatStorageStatus) {
+        self.status.set(status.into());
+    }
+
+    pub fn set_flat_head_height(&self, height: u64) {
+        self.flat_head_height.set(height as i64);
+    }
+
+    pub fn set_remaining_state_parts(&self, remaining_parts: u64) {
+        self.remaining_state_parts.set(remaining_parts as i64);
+    }
+
+    pub fn threads_used(&self) -> IntGauge {
+        self.threads_used.clone()
+    }
+
+    pub fn inc_fetched_state(&self, num_items: u64) {
+        self.fetched_state_items.inc_by(num_items);
+        self.fetched_state_parts.inc();
+    }
+}

--- a/core/store/src/flat/mod.rs
+++ b/core/store/src/flat/mod.rs
@@ -28,6 +28,7 @@
 mod chunk_view;
 mod delta;
 mod manager;
+mod metrics;
 mod storage;
 pub mod store_helper;
 mod types;
@@ -35,6 +36,7 @@ mod types;
 pub use chunk_view::FlatStorageChunkView;
 pub use delta::{FlatStateChanges, FlatStateDelta, FlatStateDeltaMetadata};
 pub use manager::FlatStorageManager;
+pub use metrics::FlatStorageCreationMetrics;
 pub use storage::FlatStorage;
 pub use types::{
     BlockInfo, FetchingStateStatus, FlatStorageCreationStatus, FlatStorageError,

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -53,7 +53,6 @@ pub mod test_utils;
 mod trie;
 
 pub use crate::config::{Mode, StoreConfig};
-pub use crate::metrics::{flat_state_metrics, FLAT_STORAGE_HEAD_HEIGHT};
 pub use crate::opener::{StoreMigrator, StoreOpener, StoreOpenerError};
 
 /// Specifies temperature of a storage.

--- a/core/store/src/metrics.rs
+++ b/core/store/src/metrics.rs
@@ -233,46 +233,6 @@ pub static COLD_COPY_DURATION: Lazy<Histogram> = Lazy::new(|| {
     .unwrap()
 });
 
-pub static FLAT_STORAGE_HEAD_HEIGHT: Lazy<IntGaugeVec> = Lazy::new(|| {
-    try_create_int_gauge_vec(
-        "flat_storage_head_height",
-        "Height of flat storage head",
-        &["shard_id"],
-    )
-    .unwrap()
-});
-pub static FLAT_STORAGE_CACHED_DELTAS: Lazy<IntGaugeVec> = Lazy::new(|| {
-    try_create_int_gauge_vec(
-        "flat_storage_cached_deltas",
-        "Number of cached deltas in flat storage",
-        &["shard_id"],
-    )
-    .unwrap()
-});
-pub static FLAT_STORAGE_CACHED_CHANGES_NUM_ITEMS: Lazy<IntGaugeVec> = Lazy::new(|| {
-    try_create_int_gauge_vec(
-        "flat_storage_cached_changes_num_items",
-        "Number of items in all cached changes in flat storage",
-        &["shard_id"],
-    )
-    .unwrap()
-});
-pub static FLAT_STORAGE_CACHED_CHANGES_SIZE: Lazy<IntGaugeVec> = Lazy::new(|| {
-    try_create_int_gauge_vec(
-        "flat_storage_cached_changes_size",
-        "Total size of cached changes in flat storage",
-        &["shard_id"],
-    )
-    .unwrap()
-});
-pub static FLAT_STORAGE_DISTANCE_TO_HEAD: Lazy<IntGaugeVec> = Lazy::new(|| {
-    try_create_int_gauge_vec(
-        "flat_storage_distance_to_head",
-        "Distance between processed block and flat storage head",
-        &["shard_id"],
-    )
-    .unwrap()
-});
 pub mod flat_state_metrics {
     use super::*;
 
@@ -312,6 +272,46 @@ pub mod flat_state_metrics {
         try_create_int_gauge_vec(
             "flat_storage_creation_threads_used",
             "Number of currently used threads to fetch state",
+            &["shard_id"],
+        )
+        .unwrap()
+    });
+    pub static FLAT_STORAGE_HEAD_HEIGHT: Lazy<IntGaugeVec> = Lazy::new(|| {
+        try_create_int_gauge_vec(
+            "flat_storage_head_height",
+            "Height of flat storage head",
+            &["shard_id"],
+        )
+        .unwrap()
+    });
+    pub static FLAT_STORAGE_CACHED_DELTAS: Lazy<IntGaugeVec> = Lazy::new(|| {
+        try_create_int_gauge_vec(
+            "flat_storage_cached_deltas",
+            "Number of cached deltas in flat storage",
+            &["shard_id"],
+        )
+        .unwrap()
+    });
+    pub static FLAT_STORAGE_CACHED_CHANGES_NUM_ITEMS: Lazy<IntGaugeVec> = Lazy::new(|| {
+        try_create_int_gauge_vec(
+            "flat_storage_cached_changes_num_items",
+            "Number of items in all cached changes in flat storage",
+            &["shard_id"],
+        )
+        .unwrap()
+    });
+    pub static FLAT_STORAGE_CACHED_CHANGES_SIZE: Lazy<IntGaugeVec> = Lazy::new(|| {
+        try_create_int_gauge_vec(
+            "flat_storage_cached_changes_size",
+            "Total size of cached changes in flat storage",
+            &["shard_id"],
+        )
+        .unwrap()
+    });
+    pub static FLAT_STORAGE_DISTANCE_TO_HEAD: Lazy<IntGaugeVec> = Lazy::new(|| {
+        try_create_int_gauge_vec(
+            "flat_storage_distance_to_head",
+            "Distance between processed block and flat storage head",
             &["shard_id"],
         )
         .unwrap()


### PR DESCRIPTION
Part of https://github.com/near/nearcore/issues/8577.

This PR moves flat storage metrics structs to a separate module under `near_store::flat`.

Benefits of this change:
* separation of concerns
* metrics setup involves quite some boilerplate code which pollutes business logic and increases file size, hence moving that to a separate file