### PR TITLE
feat: Export number of expected chunks/blocks in epoch to prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * The contract runtime switched to using our fork of wasmer, with various improvements.
 * undo-block tool to reset the chain head from current head to its prev block. Use the tool by running: `./target/release/neard --home {path_to_config_directory} undo-block`. [#8681](https://github.com/near/nearcore/pull/8681)
 * Add per shard granularity for chunks in validator info metric. [#8934](https://github.com/near/nearcore/pull/8934)
+* Add prometheus metrics for expected number of blocks/chunks at the end of the epoch. [#8759](https://github.com/near/nearcore/pull/8759)
 
 ## 1.33.0
 

--- a/chain/client/src/metrics.rs
+++ b/chain/client/src/metrics.rs
@@ -123,6 +123,15 @@ pub(crate) static VALIDATORS_CHUNKS_EXPECTED_BY_SHARD: Lazy<IntGaugeVec> = Lazy:
     .unwrap()
 });
 
+pub(crate) static VALIDATORS_CHUNKS_EXPECTED_IN_EPOCH: Lazy<IntGaugeVec> = Lazy::new(|| {
+    try_create_int_gauge_vec(
+        "near_validators_chunks_expected_in_epoch",
+        "Number of chunks expected to be produced by a validator within current epoch",
+        &["account_id", "shard_id"],
+    )
+    .unwrap()
+});
+
 pub(crate) static VALIDATORS_BLOCKS_PRODUCED: Lazy<IntGaugeVec> = Lazy::new(|| {
     try_create_int_gauge_vec(
         "near_validators_blocks_produced",
@@ -136,6 +145,15 @@ pub(crate) static VALIDATORS_BLOCKS_EXPECTED: Lazy<IntGaugeVec> = Lazy::new(|| {
     try_create_int_gauge_vec(
         "near_validators_blocks_expected",
         "Number of blocks expected to be produced by a validator",
+        &["account_id"],
+    )
+    .unwrap()
+});
+
+pub(crate) static VALIDATORS_BLOCKS_EXPECTED_IN_EPOCH: Lazy<IntGaugeVec> = Lazy::new(|| {
+    try_create_int_gauge_vec(
+        "near_validators_blocks_expected_in_epoch",
+        "Number of blocks expected to be produced by a validator within current epoch",
         &["account_id"],
     )
     .unwrap()


### PR DESCRIPTION
The producer to block/chunk assignment is known ahead of time so we can
estimate what we expect to see at the end of the epoch.

We are computing these numbers only once per epoch.

Tested on mainnet and localnet. 
On localnet:
- started 4 nodes
- stopped one of them for a delta of 200 blocks
- started it again