### PR TITLE
cleanup: Removing RuntimeConfigView -> RuntimeConfig

### DIFF
--- a/chain/indexer/src/streamer/utils.rs
+++ b/chain/indexer/src/streamer/utils.rs
@@ -1,15 +1,17 @@
 use actix::Addr;
 
+use near_indexer_primitives::types::ProtocolVersion;
 use near_indexer_primitives::IndexerTransactionWithOutcome;
 use near_primitives::views;
-use node_runtime::config::tx_cost;
+use node_runtime::config::{tx_cost, RuntimeConfig};
 
 use super::errors::FailedToFetchData;
 use super::fetchers::fetch_block;
 
 pub(crate) async fn convert_transactions_sir_into_local_receipts(
     client: &Addr<near_client::ViewClientActor>,
-    protocol_config: &near_chain_configs::ProtocolConfigView,
+    runtime_config: &RuntimeConfig,
+    protocol_version: ProtocolVersion,
     txs: Vec<&IndexerTransactionWithOutcome>,
     block: &views::BlockView,
 ) -> Result<Vec<views::ReceiptView>, FailedToFetchData> {
@@ -19,9 +21,6 @@ pub(crate) async fn convert_transactions_sir_into_local_receipts(
     let prev_block = fetch_block(&client, block.header.prev_hash).await?;
     let prev_block_gas_price = prev_block.header.gas_price;
 
-    let runtime_config_store =
-        near_primitives::runtime::config_store::RuntimeConfigStore::new(None);
-    let runtime_config = runtime_config_store.get_config(block.header.latest_protocol_version);
     let local_receipts: Vec<views::ReceiptView> =
         txs.into_iter()
             .map(|tx| {
@@ -45,7 +44,7 @@ pub(crate) async fn convert_transactions_sir_into_local_receipts(
                     },
                     prev_block_gas_price,
                     true,
-                    protocol_config.protocol_version,
+                    protocol_version,
                 );
                 views::ReceiptView {
                     predecessor_id: tx.transaction.signer_id.clone(),

--- a/chain/indexer/src/streamer/utils.rs
+++ b/chain/indexer/src/streamer/utils.rs
@@ -19,8 +19,9 @@ pub(crate) async fn convert_transactions_sir_into_local_receipts(
     let prev_block = fetch_block(&client, block.header.prev_hash).await?;
     let prev_block_gas_price = prev_block.header.gas_price;
 
-    let runtime_config =
-        node_runtime::config::RuntimeConfig::from(protocol_config.runtime_config.clone());
+    let runtime_config_store =
+        near_primitives::runtime::config_store::RuntimeConfigStore::new(None);
+    let runtime_config = runtime_config_store.get_config(block.header.latest_protocol_version);
     let local_receipts: Vec<views::ReceiptView> =
         txs.into_iter()
             .map(|tx| {

--- a/integration-tests/src/tests/nearcore/rpc_nodes.rs
+++ b/integration-tests/src/tests/nearcore/rpc_nodes.rs
@@ -23,7 +23,6 @@ use near_primitives::types::{
 };
 use near_primitives::version::ProtocolVersion;
 use near_primitives::views::{ExecutionOutcomeView, ExecutionStatusView, RuntimeConfigView};
-use node_runtime::config::RuntimeConfig;
 use std::time::Duration;
 
 #[test]
@@ -257,11 +256,6 @@ fn test_protocol_config_rpc() {
         assert_eq!(
             serde_json::json!(config_response.config_view.runtime_config),
             serde_json::json!(RuntimeConfigView::from(latest_runtime_config.as_ref().clone()))
-        );
-        // compare struct used by runtime
-        assert_eq!(
-            RuntimeConfig::from(config_response.config_view.runtime_config),
-            latest_runtime_config.as_ref().clone()
         );
         System::current().stop();
     });


### PR DESCRIPTION
In https://github.com/near/nearcore/pull/8426 this conversion became lossy due to the introduction of Compute Costs. This raised the question of whether this conversion is needed at all. I've found one place in the Indexer code that uses it and replaced it with a direct lookup for config from `RuntimeConfigStore`. As a part of this I've also simplified some code in the indexer.

This should fix the failing nayduck test https://github.com/near/nearcore/issues/8967