### PR TITLE
[Runtime Epoch Split] (3/n) Add ability to get Arc<EpochManagerAdapter> out of an &RuntimeWithEpochManagerAdapter.

### DIFF
--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -3026,8 +3026,7 @@ mod tests {
         let chain_genesis = ChainGenesis::test();
         let vs = ValidatorSchedule::new()
             .block_producers_per_epoch(vec![vec!["test1".parse().unwrap()]]);
-        let runtime_adapter =
-            Arc::new(KeyValueRuntime::new_with_validators(store, vs, epoch_length));
+        let runtime_adapter = KeyValueRuntime::new_with_validators(store, vs, epoch_length);
         Chain::new(
             runtime_adapter,
             &chain_genesis,

--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -388,8 +388,7 @@ mod tests {
     fn init() -> (Chain, StoreValidator) {
         let store = create_test_store();
         let chain_genesis = ChainGenesis::test();
-        let runtime_adapter =
-            Arc::new(KeyValueRuntime::new(store.clone(), chain_genesis.epoch_length));
+        let runtime_adapter = KeyValueRuntime::new(store.clone(), chain_genesis.epoch_length);
         let mut genesis = GenesisConfig::default();
         genesis.genesis_height = 0;
         let chain = Chain::new(

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -88,7 +88,7 @@ pub fn setup_with_tx_validity_period(
 ) -> (Chain, Arc<KeyValueRuntime>, Arc<InMemoryValidatorSigner>) {
     let store = create_test_store();
     let epoch_length = 1000;
-    let runtime = Arc::new(KeyValueRuntime::new(store, epoch_length));
+    let runtime = KeyValueRuntime::new(store, epoch_length);
     let chain = Chain::new(
         runtime.clone(),
         &ChainGenesis {
@@ -120,7 +120,7 @@ pub fn setup_with_validators(
     let store = create_test_store();
     let signers =
         vs.all_block_producers().map(|x| Arc::new(create_test_signer(x.as_str()))).collect();
-    let runtime = Arc::new(KeyValueRuntime::new_with_validators(store, vs, epoch_length));
+    let runtime = KeyValueRuntime::new_with_validators(store, vs, epoch_length);
     let chain = Chain::new(
         runtime.clone(),
         &ChainGenesis {
@@ -151,7 +151,7 @@ pub fn setup_with_validators_and_start_time(
     let store = create_test_store();
     let signers =
         vs.all_block_producers().map(|x| Arc::new(create_test_signer(x.as_str()))).collect();
-    let runtime = Arc::new(KeyValueRuntime::new_with_validators(store, vs, epoch_length));
+    let runtime = KeyValueRuntime::new_with_validators(store, vs, epoch_length);
     let chain = Chain::new(
         runtime.clone(),
         &ChainGenesis {

--- a/chain/chain/src/tests/gc.rs
+++ b/chain/chain/src/tests/gc.rs
@@ -28,7 +28,7 @@ fn get_chain_with_epoch_length_and_num_shards(
     let vs = ValidatorSchedule::new()
         .block_producers_per_epoch(vec![vec!["test1".parse().unwrap()]])
         .num_shards(num_shards);
-    let runtime_adapter = Arc::new(KeyValueRuntime::new_with_validators(store, vs, epoch_length));
+    let runtime_adapter = KeyValueRuntime::new_with_validators(store, vs, epoch_length);
     Chain::new(
         runtime_adapter,
         &chain_genesis,

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -575,7 +575,11 @@ pub trait RuntimeAdapter: Send + Sync {
     fn get_protocol_config(&self, epoch_id: &EpochId) -> Result<ProtocolConfig, Error>;
 }
 
-pub trait RuntimeWithEpochManagerAdapter: RuntimeAdapter + EpochManagerAdapter {}
+/// LEGACY trait. Will be removed. Use RuntimeAdapter or EpochManagerHandler instead.
+pub trait RuntimeWithEpochManagerAdapter: RuntimeAdapter + EpochManagerAdapter {
+    fn epoch_manager_adapter(&self) -> &dyn EpochManagerAdapter;
+    fn epoch_manager_adapter_arc(&self) -> Arc<dyn EpochManagerAdapter>;
+}
 
 /// The last known / checked height and time when we have processed it.
 /// Required to keep track of skipped blocks and not fallback to produce blocks at lower height.

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -2038,7 +2038,7 @@ mod test {
             epoch_id: EpochId::default(),
             next_epoch_id: EpochId::default(),
         };
-        let runtime_adapter = Arc::new(KeyValueRuntime::new(store.clone(), 5));
+        let runtime_adapter = KeyValueRuntime::new(store.clone(), 5);
         let network_adapter = Arc::new(MockPeerManagerAdapter::default());
         let client_adapter = Arc::new(MockClientAdapterForShardsManager::default());
         let clock = FakeClock::default();

--- a/chain/chunks/src/test_utils.rs
+++ b/chain/chunks/src/test_utils.rs
@@ -50,13 +50,16 @@ impl Default for ChunkTestFixture {
 impl ChunkTestFixture {
     pub fn new(orphan_chunk: bool) -> Self {
         // 12 validators, 3 shards, 4 validators per shard
-        Self::new_with_runtime(orphan_chunk, Arc::new(default_runtime()))
+        Self::new_with_runtime(orphan_chunk, default_runtime())
     }
 
     pub fn new_with_all_shards_tracking() -> Self {
-        let mut runtime = default_runtime();
-        runtime.set_tracks_all_shards(true);
-        Self::new_with_runtime(false, Arc::new(runtime))
+        let store = near_store::test_utils::create_test_store();
+        // 12 validators, 3 shards, 4 validators per shard
+        let vs = make_validators(12, 0, 3);
+        let runtime =
+            KeyValueRuntime::new_with_validators_and_no_gc_and_tracking(store, vs, 5, false, true);
+        Self::new_with_runtime(false, runtime)
     }
 
     // Create a ChunkTestFixture to test chunk only producers
@@ -65,8 +68,7 @@ impl ChunkTestFixture {
         // 3 block producer. 1 block producer + 2 chunk only producer per shard
         // This setup ensures that the chunk producer
         let vs = make_validators(6, 2, 3);
-        let mock_runtime =
-            Arc::new(KeyValueRuntime::new_with_validators_and_no_gc(store, vs, 5, false));
+        let mock_runtime = KeyValueRuntime::new_with_validators_and_no_gc(store, vs, 5, false);
         Self::new_with_runtime(false, mock_runtime)
     }
 
@@ -245,7 +247,7 @@ fn make_validators(
 }
 
 // 12 validators, 3 shards, 4 validators per shard
-fn default_runtime() -> KeyValueRuntime {
+fn default_runtime() -> Arc<KeyValueRuntime> {
     let store = near_store::test_utils::create_test_store();
     // 12 validators, 3 shards, 4 validators per shard
     let vs = make_validators(12, 0, 3);

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -744,8 +744,7 @@ mod tests {
         let store = near_store::test_utils::create_test_store();
         let vs =
             ValidatorSchedule::new().block_producers_per_epoch(vec![vec!["test".parse().unwrap()]]);
-        let runtime =
-            Arc::new(KeyValueRuntime::new_with_validators_and_no_gc(store, vs, 123, false));
+        let runtime = KeyValueRuntime::new_with_validators_and_no_gc(store, vs, 123, false);
         let chain_genesis = ChainGenesis {
             time: StaticClock::utc(),
             height: 0,

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -205,12 +205,8 @@ pub fn setup(
 ) -> (Block, ClientActor, Addr<ViewClientActor>, ShardsManagerAdapterForTest) {
     let store = create_test_store();
     let num_validator_seats = vs.all_block_producers().count() as NumSeats;
-    let runtime = Arc::new(KeyValueRuntime::new_with_validators_and_no_gc(
-        store.clone(),
-        vs,
-        epoch_length,
-        archive,
-    ));
+    let runtime =
+        KeyValueRuntime::new_with_validators_and_no_gc(store.clone(), vs, epoch_length, archive);
     let chain_genesis = ChainGenesis {
         time: genesis_time,
         height: 0,
@@ -314,8 +310,7 @@ pub fn setup_only_view(
 ) -> Addr<ViewClientActor> {
     let store = create_test_store();
     let num_validator_seats = vs.all_block_producers().count() as NumSeats;
-    let runtime =
-        Arc::new(KeyValueRuntime::new_with_validators_and_no_gc(store, vs, epoch_length, archive));
+    let runtime = KeyValueRuntime::new_with_validators_and_no_gc(store, vs, epoch_length, archive);
     let chain_genesis = ChainGenesis {
         time: genesis_time,
         height: 0,
@@ -1165,7 +1160,7 @@ pub fn setup_client(
 ) -> Client {
     let num_validator_seats = vs.all_block_producers().count() as NumSeats;
     let runtime_adapter =
-        Arc::new(KeyValueRuntime::new_with_validators(store, vs, chain_genesis.epoch_length));
+        KeyValueRuntime::new_with_validators(store, vs, chain_genesis.epoch_length);
     setup_client_with_runtime(
         num_validator_seats,
         account_id,
@@ -1228,7 +1223,7 @@ pub fn setup_client_with_synchronous_shards_manager(
 ) -> Client {
     let num_validator_seats = vs.all_block_producers().count() as NumSeats;
     let runtime_adapter =
-        Arc::new(KeyValueRuntime::new_with_validators(store, vs, chain_genesis.epoch_length));
+        KeyValueRuntime::new_with_validators(store, vs, chain_genesis.epoch_length);
     let shards_manager_adapter = setup_synchronous_shards_manager(
         account_id.clone(),
         client_adapter,
@@ -1413,11 +1408,11 @@ impl TestEnvBuilder {
                 .map(|_| {
                     let vs = ValidatorSchedule::new()
                         .block_producers_per_epoch(vec![validators.clone()]);
-                    Arc::new(KeyValueRuntime::new_with_validators(
+                    KeyValueRuntime::new_with_validators(
                         create_test_store(),
                         vs,
                         chain_genesis.epoch_length,
-                    )) as Arc<dyn RuntimeWithEpochManagerAdapter>
+                    ) as Arc<dyn RuntimeWithEpochManagerAdapter>
                 })
                 .collect(),
         };

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -57,7 +57,7 @@ pub struct GenesisBuilder {
     tmpdir: tempfile::TempDir,
     genesis: Arc<Genesis>,
     store: Store,
-    runtime: NightshadeRuntime,
+    runtime: Arc<NightshadeRuntime>,
     unflushed_records: BTreeMap<ShardId, Vec<StateRecord>>,
     roots: BTreeMap<ShardId, StateRoot>,
     state_updates: BTreeMap<ShardId, TrieUpdate>,
@@ -208,7 +208,7 @@ impl GenesisBuilder {
             self.genesis.config.min_gas_price,
             self.genesis.config.total_supply,
             Chain::compute_bp_hash(
-                &self.runtime,
+                &*self.runtime,
                 EpochId::default(),
                 EpochId::default(),
                 &CryptoHash::default(),

--- a/integration-tests/src/genesis_helpers.rs
+++ b/integration-tests/src/genesis_helpers.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use tempfile::tempdir;
 
 use near_chain::types::ChainConfig;
@@ -20,7 +18,7 @@ pub fn genesis_header(genesis: &Genesis) -> BlockHeader {
     let dir = tempdir().unwrap();
     let store = create_test_store();
     let chain_genesis = ChainGenesis::new(genesis);
-    let runtime = Arc::new(NightshadeRuntime::test(dir.path(), store, genesis));
+    let runtime = NightshadeRuntime::test(dir.path(), store, genesis);
     let chain =
         Chain::new(runtime, &chain_genesis, DoomslugThresholdMode::TwoThirds, ChainConfig::test())
             .unwrap();
@@ -32,7 +30,7 @@ pub fn genesis_block(genesis: &Genesis) -> Block {
     let dir = tempdir().unwrap();
     let store = create_test_store();
     let chain_genesis = ChainGenesis::new(genesis);
-    let runtime = Arc::new(NightshadeRuntime::test(dir.path(), store, genesis));
+    let runtime = NightshadeRuntime::test(dir.path(), store, genesis);
     let chain =
         Chain::new(runtime, &chain_genesis, DoomslugThresholdMode::TwoThirds, ChainConfig::test())
             .unwrap();

--- a/integration-tests/src/tests/client/challenges.rs
+++ b/integration-tests/src/tests/client/challenges.rs
@@ -328,11 +328,11 @@ fn test_verify_chunk_invalid_state_challenge() {
     let store1 = create_test_store();
     let genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     let mut env = TestEnv::builder(ChainGenesis::test())
-        .runtime_adapters(vec![Arc::new(nearcore::NightshadeRuntime::test(
+        .runtime_adapters(vec![nearcore::NightshadeRuntime::test(
             Path::new("../../../.."),
             store1,
             &genesis,
-        ))])
+        )])
         .build();
     let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
     let validator_signer = create_test_signer("test0");
@@ -600,11 +600,11 @@ fn test_fishermen_challenge() {
     );
     genesis.config.epoch_length = 5;
     let create_runtime = || -> Arc<NightshadeRuntime> {
-        Arc::new(nearcore::NightshadeRuntime::test(
+        nearcore::NightshadeRuntime::test(
             Path::new("../../../.."),
             create_test_store(),
             &genesis.clone(),
-        ))
+        )
     };
     let runtime1 = create_runtime();
     let runtime2 = create_runtime();
@@ -665,16 +665,10 @@ fn test_challenge_in_different_epoch() {
     genesis.config.epoch_length = 3;
     //    genesis.config.validator_kickout_threshold = 10;
     let network_adapter = Arc::new(MockPeerManagerAdapter::default());
-    let runtime1 = Arc::new(nearcore::NightshadeRuntime::test(
-        Path::new("../../../.."),
-        create_test_store(),
-        &genesis,
-    ));
-    let runtime2 = Arc::new(nearcore::NightshadeRuntime::test(
-        Path::new("../../../.."),
-        create_test_store(),
-        &genesis,
-    ));
+    let runtime1 =
+        nearcore::NightshadeRuntime::test(Path::new("../../../.."), create_test_store(), &genesis);
+    let runtime2 =
+        nearcore::NightshadeRuntime::test(Path::new("../../../.."), create_test_store(), &genesis);
     let mut chain_genesis = ChainGenesis::test();
     chain_genesis.epoch_length = 3;
 

--- a/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
+++ b/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
@@ -322,13 +322,13 @@ fn test_request_chunks_for_orphan() {
     let chain_genesis = ChainGenesis::new(&genesis);
     let runtimes: Vec<Arc<dyn RuntimeWithEpochManagerAdapter>> = (0..2)
         .map(|_| {
-            Arc::new(nearcore::NightshadeRuntime::test_with_runtime_config_store(
+            nearcore::NightshadeRuntime::test_with_runtime_config_store(
                 Path::new("."),
                 create_test_store(),
                 &genesis,
                 TrackedConfig::AllShards,
                 RuntimeConfigStore::test(),
-            )) as Arc<dyn RuntimeWithEpochManagerAdapter>
+            ) as Arc<dyn RuntimeWithEpochManagerAdapter>
         })
         .collect();
     let mut env = TestEnv::builder(chain_genesis)
@@ -469,13 +469,13 @@ fn test_processing_chunks_sanity() {
     let chain_genesis = ChainGenesis::new(&genesis);
     let runtimes: Vec<Arc<dyn RuntimeWithEpochManagerAdapter>> = (0..2)
         .map(|_| {
-            Arc::new(nearcore::NightshadeRuntime::test_with_runtime_config_store(
+            nearcore::NightshadeRuntime::test_with_runtime_config_store(
                 Path::new("."),
                 create_test_store(),
                 &genesis,
                 TrackedConfig::AllShards,
                 RuntimeConfigStore::test(),
-            )) as Arc<dyn RuntimeWithEpochManagerAdapter>
+            ) as Arc<dyn RuntimeWithEpochManagerAdapter>
         })
         .collect();
     let mut env = TestEnv::builder(chain_genesis)
@@ -578,13 +578,13 @@ impl ChunkForwardingOptimizationTestData {
         let chain_genesis = ChainGenesis::new(&genesis);
         let runtimes: Vec<Arc<dyn RuntimeWithEpochManagerAdapter>> = (0..num_clients)
             .map(|_| {
-                Arc::new(nearcore::NightshadeRuntime::test_with_runtime_config_store(
+                nearcore::NightshadeRuntime::test_with_runtime_config_store(
                     Path::new("."),
                     create_test_store(),
                     &genesis,
                     TrackedConfig::AllShards,
                     RuntimeConfigStore::test(),
-                )) as Arc<dyn RuntimeWithEpochManagerAdapter>
+                ) as Arc<dyn RuntimeWithEpochManagerAdapter>
             })
             .collect();
         let env = TestEnv::builder(chain_genesis)
@@ -804,13 +804,13 @@ fn test_processing_blocks_async() {
     let chain_genesis = ChainGenesis::new(&genesis);
     let runtimes: Vec<Arc<dyn RuntimeWithEpochManagerAdapter>> = (0..2)
         .map(|_| {
-            Arc::new(nearcore::NightshadeRuntime::test_with_runtime_config_store(
+            nearcore::NightshadeRuntime::test_with_runtime_config_store(
                 Path::new("."),
                 create_test_store(),
                 &genesis,
                 TrackedConfig::AllShards,
                 RuntimeConfigStore::test(),
-            )) as Arc<dyn RuntimeWithEpochManagerAdapter>
+            ) as Arc<dyn RuntimeWithEpochManagerAdapter>
         })
         .collect();
     let mut env = TestEnv::builder(chain_genesis)

--- a/integration-tests/src/tests/client/features/account_id_in_function_call_permission.rs
+++ b/integration-tests/src/tests/client/features/account_id_in_function_call_permission.rs
@@ -31,14 +31,12 @@ fn test_account_id_in_function_call_permission_upgrade() {
         genesis.config.protocol_version = old_protocol_version;
         let chain_genesis = ChainGenesis::new(&genesis);
         TestEnv::builder(chain_genesis)
-            .runtime_adapters(vec![Arc::new(
-                nearcore::NightshadeRuntime::test_with_runtime_config_store(
-                    Path::new("../../../.."),
-                    create_test_store(),
-                    &genesis,
-                    TrackedConfig::new_empty(),
-                    RuntimeConfigStore::new(None),
-                ),
+            .runtime_adapters(vec![nearcore::NightshadeRuntime::test_with_runtime_config_store(
+                Path::new("../../../.."),
+                create_test_store(),
+                &genesis,
+                TrackedConfig::new_empty(),
+                RuntimeConfigStore::new(None),
             ) as Arc<dyn RuntimeWithEpochManagerAdapter>])
             .build()
     };
@@ -98,14 +96,12 @@ fn test_very_long_account_id() {
         let genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
         let chain_genesis = ChainGenesis::new(&genesis);
         TestEnv::builder(chain_genesis)
-            .runtime_adapters(vec![Arc::new(
-                nearcore::NightshadeRuntime::test_with_runtime_config_store(
-                    Path::new("../../../.."),
-                    create_test_store(),
-                    &genesis,
-                    TrackedConfig::new_empty(),
-                    RuntimeConfigStore::new(None),
-                ),
+            .runtime_adapters(vec![nearcore::NightshadeRuntime::test_with_runtime_config_store(
+                Path::new("../../../.."),
+                create_test_store(),
+                &genesis,
+                TrackedConfig::new_empty(),
+                RuntimeConfigStore::new(None),
             ) as Arc<dyn RuntimeWithEpochManagerAdapter>])
             .build()
     };

--- a/integration-tests/src/tests/client/features/adversarial_behaviors.rs
+++ b/integration-tests/src/tests/client/features/adversarial_behaviors.rs
@@ -53,13 +53,13 @@ impl AdversarialBehaviorTestData {
         let chain_genesis = ChainGenesis::new(&genesis);
         let runtimes: Vec<Arc<dyn RuntimeWithEpochManagerAdapter>> = (0..num_clients)
             .map(|_| {
-                Arc::new(nearcore::NightshadeRuntime::test_with_runtime_config_store(
+                nearcore::NightshadeRuntime::test_with_runtime_config_store(
                     Path::new("."),
                     create_test_store(),
                     &genesis,
                     TrackedConfig::AllShards,
                     RuntimeConfigStore::test(),
-                )) as Arc<dyn RuntimeWithEpochManagerAdapter>
+                ) as Arc<dyn RuntimeWithEpochManagerAdapter>
             })
             .collect();
         let env = TestEnv::builder(chain_genesis)

--- a/integration-tests/src/tests/client/features/chunk_nodes_cache.rs
+++ b/integration-tests/src/tests/client/features/chunk_nodes_cache.rs
@@ -93,13 +93,13 @@ fn compare_node_counts() {
     genesis.config.protocol_version = old_protocol_version;
     let chain_genesis = ChainGenesis::new(&genesis);
     let runtimes: Vec<Arc<dyn RuntimeWithEpochManagerAdapter>> =
-        vec![Arc::new(nearcore::NightshadeRuntime::test_with_runtime_config_store(
+        vec![nearcore::NightshadeRuntime::test_with_runtime_config_store(
             Path::new("../../../.."),
             create_test_store(),
             &genesis,
             TrackedConfig::new_empty(),
             RuntimeConfigStore::new(None),
-        ))];
+        )];
     let mut env = TestEnv::builder(chain_genesis).runtime_adapters(runtimes).build();
 
     deploy_test_contract(

--- a/integration-tests/src/tests/client/features/increase_deployment_cost.rs
+++ b/integration-tests/src/tests/client/features/increase_deployment_cost.rs
@@ -33,13 +33,13 @@ fn test_deploy_cost_increased() {
         genesis.config.protocol_version = old_protocol_version;
         let chain_genesis = ChainGenesis::new(&genesis);
         let runtimes: Vec<Arc<dyn RuntimeWithEpochManagerAdapter>> =
-            vec![Arc::new(nearcore::NightshadeRuntime::test_with_runtime_config_store(
+            vec![nearcore::NightshadeRuntime::test_with_runtime_config_store(
                 Path::new("../../../.."),
                 create_test_store(),
                 &genesis,
                 TrackedConfig::new_empty(),
                 RuntimeConfigStore::new(None),
-            ))];
+            )];
         TestEnv::builder(chain_genesis).runtime_adapters(runtimes).build()
     };
 

--- a/integration-tests/src/tests/client/features/limit_contract_functions_number.rs
+++ b/integration-tests/src/tests/client/features/limit_contract_functions_number.rs
@@ -32,13 +32,13 @@ fn verify_contract_limits_upgrade(
         genesis.config.protocol_version = old_protocol_version;
         let chain_genesis = ChainGenesis::new(&genesis);
         let runtimes: Vec<Arc<dyn RuntimeWithEpochManagerAdapter>> =
-            vec![Arc::new(nearcore::NightshadeRuntime::test_with_runtime_config_store(
+            vec![nearcore::NightshadeRuntime::test_with_runtime_config_store(
                 Path::new("../../../.."),
                 create_test_store(),
                 &genesis,
                 TrackedConfig::new_empty(),
                 RuntimeConfigStore::new(None),
-            ))];
+            )];
         let mut env = TestEnv::builder(chain_genesis).runtime_adapters(runtimes).build();
 
         deploy_test_contract(

--- a/integration-tests/src/tests/client/features/lower_storage_key_limit.rs
+++ b/integration-tests/src/tests/client/features/lower_storage_key_limit.rs
@@ -43,13 +43,13 @@ fn protocol_upgrade() {
         genesis.config.protocol_version = old_protocol_version;
         let chain_genesis = ChainGenesis::new(&genesis);
         let runtimes: Vec<Arc<dyn RuntimeWithEpochManagerAdapter>> =
-            vec![Arc::new(nearcore::NightshadeRuntime::test_with_runtime_config_store(
+            vec![nearcore::NightshadeRuntime::test_with_runtime_config_store(
                 Path::new("."),
                 create_test_store(),
                 &genesis,
                 TrackedConfig::AllShards,
                 RuntimeConfigStore::new(None),
-            )) as Arc<dyn RuntimeWithEpochManagerAdapter>];
+            ) as Arc<dyn RuntimeWithEpochManagerAdapter>];
         let mut env = TestEnv::builder(chain_genesis).runtime_adapters(runtimes).build();
 
         deploy_test_contract_with_protocol_version(

--- a/integration-tests/src/tests/client/features/restore_receipts_after_fix_apply_chunks.rs
+++ b/integration-tests/src/tests/client/features/restore_receipts_after_fix_apply_chunks.rs
@@ -38,7 +38,7 @@ fn run_test(
     let migration_data = load_migration_data(&genesis.config.chain_id);
 
     let mut env = TestEnv::builder(chain_genesis)
-        .runtime_adapters(vec![Arc::new(runtime) as Arc<dyn RuntimeWithEpochManagerAdapter>])
+        .runtime_adapters(vec![runtime as Arc<dyn RuntimeWithEpochManagerAdapter>])
         .build();
 
     let get_restored_receipt_hashes = |migration_data: &MigrationData| -> HashSet<CryptoHash> {

--- a/integration-tests/src/tests/client/features/zero_balance_account.rs
+++ b/integration-tests/src/tests/client/features/zero_balance_account.rs
@@ -1,5 +1,4 @@
 use std::path::Path;
-use std::sync::Arc;
 
 use assert_matches::assert_matches;
 
@@ -138,13 +137,13 @@ fn test_zero_balance_account_add_key() {
     };
     runtime_config.wasm_config.ext_costs = ExtCostsConfig::test();
     let runtime_config_store = RuntimeConfigStore::with_one_config(runtime_config);
-    let nightshade_runtime = Arc::new(NightshadeRuntime::test_with_runtime_config_store(
+    let nightshade_runtime = NightshadeRuntime::test_with_runtime_config_store(
         Path::new("."),
         create_test_store(),
         &genesis,
         TrackedConfig::new_empty(),
         runtime_config_store,
-    ));
+    );
     let mut env =
         TestEnv::builder(ChainGenesis::test()).runtime_adapters(vec![nightshade_runtime]).build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();

--- a/integration-tests/src/tests/client/flat_storage.rs
+++ b/integration-tests/src/tests/client/flat_storage.rs
@@ -31,7 +31,7 @@ const CREATION_TIMEOUT: BlockHeight = 30;
 fn setup_env(genesis: &Genesis, store: Store) -> TestEnv {
     let chain_genesis = ChainGenesis::new(genesis);
     let runtimes: Vec<Arc<dyn RuntimeWithEpochManagerAdapter>> =
-        vec![Arc::new(nearcore::NightshadeRuntime::test(Path::new("../../../.."), store, genesis))];
+        vec![nearcore::NightshadeRuntime::test(Path::new("../../../.."), store, genesis)];
     TestEnv::builder(chain_genesis).runtime_adapters(runtimes).build()
 }
 

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -108,8 +108,7 @@ pub fn create_nightshade_runtime_with_store(
     genesis: &Genesis,
     store: &Store,
 ) -> Arc<dyn RuntimeWithEpochManagerAdapter> {
-    Arc::new(nearcore::NightshadeRuntime::test(Path::new("../../../.."), store.clone(), genesis))
-        as Arc<dyn RuntimeWithEpochManagerAdapter>
+    nearcore::NightshadeRuntime::test(Path::new("../../../.."), store.clone(), genesis)
 }
 
 /// Produce `blocks_number` block in the given environment, starting from the given height.
@@ -2142,9 +2141,8 @@ fn test_invalid_block_root() {
 fn test_incorrect_validator_key_produce_block() {
     let genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 2);
     let chain_genesis = ChainGenesis::new(&genesis);
-    let runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter> = Arc::new(
-        nearcore::NightshadeRuntime::test(Path::new("../../../.."), create_test_store(), &genesis),
-    );
+    let runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter> =
+        nearcore::NightshadeRuntime::test(Path::new("../../../.."), create_test_store(), &genesis);
     let signer = Arc::new(InMemoryValidatorSigner::from_seed(
         "test0".parse().unwrap(),
         KeyType::ED25519,
@@ -3532,11 +3530,8 @@ mod contract_precompilation_tests {
         let runtime_adapters = stores
             .iter()
             .map(|store| {
-                Arc::new(nearcore::NightshadeRuntime::test(
-                    Path::new("../../../.."),
-                    store.clone(),
-                    &genesis,
-                )) as Arc<dyn RuntimeWithEpochManagerAdapter>
+                nearcore::NightshadeRuntime::test(Path::new("../../../.."), store.clone(), &genesis)
+                    as Arc<dyn RuntimeWithEpochManagerAdapter>
             })
             .collect();
 
@@ -3633,11 +3628,8 @@ mod contract_precompilation_tests {
         let runtime_adapters = stores
             .iter()
             .map(|store| {
-                Arc::new(nearcore::NightshadeRuntime::test(
-                    Path::new("../../../.."),
-                    store.clone(),
-                    &genesis,
-                )) as Arc<dyn RuntimeWithEpochManagerAdapter>
+                nearcore::NightshadeRuntime::test(Path::new("../../../.."), store.clone(), &genesis)
+                    as Arc<dyn RuntimeWithEpochManagerAdapter>
             })
             .collect();
 
@@ -3717,11 +3709,8 @@ mod contract_precompilation_tests {
         let runtime_adapters = stores
             .iter()
             .map(|store| {
-                Arc::new(nearcore::NightshadeRuntime::test(
-                    Path::new("../../../.."),
-                    store.clone(),
-                    &genesis,
-                )) as Arc<dyn RuntimeWithEpochManagerAdapter>
+                nearcore::NightshadeRuntime::test(Path::new("../../../.."), store.clone(), &genesis)
+                    as Arc<dyn RuntimeWithEpochManagerAdapter>
             })
             .collect();
 

--- a/integration-tests/src/tests/client/runtimes.rs
+++ b/integration-tests/src/tests/client/runtimes.rs
@@ -24,11 +24,11 @@ pub fn create_nightshade_runtimes(
 ) -> Vec<Arc<dyn RuntimeWithEpochManagerAdapter>> {
     (0..n)
         .map(|_| {
-            Arc::new(nearcore::NightshadeRuntime::test(
+            nearcore::NightshadeRuntime::test(
                 Path::new("../../../.."),
                 create_test_store(),
                 genesis,
-            )) as Arc<dyn RuntimeWithEpochManagerAdapter>
+            ) as Arc<dyn RuntimeWithEpochManagerAdapter>
         })
         .collect()
 }

--- a/integration-tests/src/tests/client/sandbox.rs
+++ b/integration-tests/src/tests/client/sandbox.rs
@@ -20,11 +20,11 @@ fn test_setup() -> (TestEnv, InMemorySigner) {
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
     let mut env = TestEnv::builder(ChainGenesis::test())
-        .runtime_adapters(vec![Arc::new(nearcore::NightshadeRuntime::test(
+        .runtime_adapters(vec![nearcore::NightshadeRuntime::test(
             Path::new("../../../.."),
             create_test_store(),
             &genesis,
-        )) as Arc<dyn RuntimeWithEpochManagerAdapter>])
+        ) as Arc<dyn RuntimeWithEpochManagerAdapter>])
         .build();
     let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
     send_tx(

--- a/integration-tests/src/tests/network/runner.rs
+++ b/integration-tests/src/tests/network/runner.rs
@@ -51,7 +51,7 @@ fn setup_network_node(
     let num_validators = validators.len() as ValidatorId;
 
     let vs = ValidatorSchedule::new().block_producers_per_epoch(vec![validators]);
-    let runtime = Arc::new(KeyValueRuntime::new_with_validators(store.get_hot_store(), vs, 5));
+    let runtime = KeyValueRuntime::new_with_validators(store.get_hot_store(), vs, 5);
     let signer = Arc::new(create_test_signer(account_id.as_str()));
     let telemetry_actor = TelemetryActor::new(TelemetryConfig::default()).start();
 

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -208,14 +208,13 @@ pub fn start_with_config_and_synchronization(
 ) -> anyhow::Result<NearNode> {
     let store = open_storage(home_dir, &mut config)?;
 
-    let runtime =
-        Arc::new(NightshadeRuntime::from_config(home_dir, store.get_hot_store(), &config));
+    let runtime = NightshadeRuntime::from_config(home_dir, store.get_hot_store(), &config);
 
     // Get the split store. If split store is some then create a new runtime for
     // the view client. Otherwise just re-use the existing runtime.
     let split_store = get_split_store(&config, &store)?;
     let view_runtime = if let Some(split_store) = split_store {
-        Arc::new(NightshadeRuntime::from_config(home_dir, split_store, &config))
+        NightshadeRuntime::from_config(home_dir, split_store, &config)
     } else {
         runtime.clone()
     };

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -68,7 +68,7 @@ use rayon::prelude::*;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::Path;
-use std::sync::{Arc, RwLockReadGuard, RwLockWriteGuard};
+use std::sync::{Arc, RwLockReadGuard, RwLockWriteGuard, Weak};
 use std::time::Instant;
 use tracing::{debug, error, info, warn};
 
@@ -93,10 +93,14 @@ pub struct NightshadeRuntime {
     genesis_state_roots: Vec<StateRoot>,
     migration_data: Arc<MigrationData>,
     gc_num_epochs_to_keep: u64,
+
+    // For RuntimeAdapter migration only, allows ability to reference an Arc of
+    // itself.
+    myself: Weak<NightshadeRuntime>,
 }
 
 impl NightshadeRuntime {
-    pub fn from_config(home_dir: &Path, store: Store, config: &NearConfig) -> Self {
+    pub fn from_config(home_dir: &Path, store: Store, config: &NearConfig) -> Arc<Self> {
         Self::new(
             home_dir,
             store,
@@ -120,7 +124,7 @@ impl NightshadeRuntime {
         runtime_config_store: Option<RuntimeConfigStore>,
         gc_num_epochs_to_keep: u64,
         trie_config: TrieConfig,
-    ) -> Self {
+    ) -> Arc<Self> {
         let runtime_config_store = match runtime_config_store {
             Some(store) => store,
             None => NightshadeRuntime::create_runtime_config_store(&genesis.config.chain_id),
@@ -145,11 +149,12 @@ impl NightshadeRuntime {
             &genesis_config.shard_layout.get_shard_uids(),
             flat_storage_manager.clone(),
         );
-        let epoch_manager = EpochManager::new_from_genesis_config(store.clone(), &genesis_config)
-            .expect("Failed to start Epoch Manager")
-            .into_handle();
+        let epoch_manager =
+            EpochManager::new_from_genesis_config(store.clone().into(), &genesis_config)
+                .expect("Failed to start Epoch Manager")
+                .into_handle();
         let shard_tracker = ShardTracker::new(tracked_config, epoch_manager.clone());
-        NightshadeRuntime {
+        Arc::new_cyclic(|myself| NightshadeRuntime {
             genesis_config,
             runtime_config_store,
             store,
@@ -162,7 +167,8 @@ impl NightshadeRuntime {
             genesis_state_roots: state_roots,
             migration_data: Arc::new(load_migration_data(&genesis.config.chain_id)),
             gc_num_epochs_to_keep: gc_num_epochs_to_keep.max(MIN_GC_NUM_EPOCHS_TO_KEEP),
-        }
+            myself: myself.clone(),
+        })
     }
 
     pub fn test_with_runtime_config_store(
@@ -171,7 +177,7 @@ impl NightshadeRuntime {
         genesis: &Genesis,
         tracked_config: TrackedConfig,
         runtime_config_store: RuntimeConfigStore,
-    ) -> Self {
+    ) -> Arc<Self> {
         Self::new(
             home_dir,
             store,
@@ -185,7 +191,7 @@ impl NightshadeRuntime {
         )
     }
 
-    pub fn test(home_dir: &Path, store: Store, genesis: &Genesis) -> Self {
+    pub fn test(home_dir: &Path, store: Store, genesis: &Genesis) -> Arc<Self> {
         Self::test_with_runtime_config_store(
             home_dir,
             store,
@@ -1460,7 +1466,15 @@ impl RuntimeAdapter for NightshadeRuntime {
     }
 }
 
-impl RuntimeWithEpochManagerAdapter for NightshadeRuntime {}
+impl RuntimeWithEpochManagerAdapter for NightshadeRuntime {
+    fn epoch_manager_adapter(&self) -> &dyn EpochManagerAdapter {
+        self
+    }
+
+    fn epoch_manager_adapter_arc(&self) -> Arc<dyn EpochManagerAdapter> {
+        self.myself.upgrade().unwrap()
+    }
+}
 
 impl node_runtime::adapter::ViewRuntimeAdapter for NightshadeRuntime {
     fn view_account(
@@ -1678,7 +1692,7 @@ mod test {
     /// Runtime operates in a mock chain where i-th block is attached to (i-1)-th one, has height `i` and hash
     /// `hash([i])`.
     struct TestEnv {
-        pub runtime: NightshadeRuntime,
+        pub runtime: Arc<NightshadeRuntime>,
         pub head: Tip,
         state_roots: Vec<StateRoot>,
         pub last_receipts: HashMap<ShardId, Vec<Receipt>>,
@@ -3123,15 +3137,15 @@ mod test {
         let store = near_store::test_utils::create_test_store();
 
         let tempdir = tempfile::tempdir().unwrap();
-        let runtime = Arc::new(NightshadeRuntime::test_with_runtime_config_store(
+        let runtime = NightshadeRuntime::test_with_runtime_config_store(
             tempdir.path(),
             store.clone(),
             &genesis,
             TrackedConfig::new_empty(),
             RuntimeConfigStore::new(None),
-        ));
+        );
 
-        let block = Chain::make_genesis_block(&*runtime, &chain_genesis).unwrap();
+        let block = Chain::make_genesis_block(runtime.as_ref(), &chain_genesis).unwrap();
         assert_eq!(
             block.header().hash().to_string(),
             "EPnLgE7iEq9s7yTkos96M3cWymH5avBAPm3qx3NXqR8H"

--- a/nearcore/tests/economics.rs
+++ b/nearcore/tests/economics.rs
@@ -33,11 +33,8 @@ fn setup_env(genesis: &Genesis) -> TestEnv {
     init_integration_logger();
     let store1 = create_test_store();
     TestEnv::builder(ChainGenesis::new(&genesis))
-        .runtime_adapters(vec![Arc::new(nearcore::NightshadeRuntime::test(
-            Path::new("."),
-            store1,
-            genesis,
-        )) as Arc<dyn RuntimeWithEpochManagerAdapter>])
+        .runtime_adapters(vec![nearcore::NightshadeRuntime::test(Path::new("."), store1, genesis)
+            as Arc<dyn RuntimeWithEpochManagerAdapter>])
         .build()
 }
 

--- a/test-utils/runtime-tester/src/run_test.rs
+++ b/test-utils/runtime-tester/src/run_test.rs
@@ -12,7 +12,6 @@ use nearcore::TrackedConfig;
 use nearcore::{config::GenesisExt, NightshadeRuntime};
 use std::io;
 use std::path::Path;
-use std::sync::Arc;
 use std::time::Duration;
 
 pub struct ScenarioResult<T, E> {
@@ -52,13 +51,13 @@ impl Scenario {
         let mut env = TestEnv::builder(ChainGenesis::new(&genesis))
             .clients(clients.clone())
             .validators(clients)
-            .runtime_adapters(vec![Arc::new(NightshadeRuntime::test_with_runtime_config_store(
+            .runtime_adapters(vec![NightshadeRuntime::test_with_runtime_config_store(
                 if let Some(tempdir) = &tempdir { tempdir.path() } else { Path::new(".") },
                 store,
                 &genesis,
                 TrackedConfig::new_empty(),
                 runtime_config_store,
-            ))])
+            )])
             .build();
 
         let result = self.process_blocks(&mut env);

--- a/test-utils/store-validator/src/main.rs
+++ b/test-utils/store-validator/src/main.rs
@@ -40,7 +40,7 @@ fn main() {
     .unwrap()
     .get_hot_store();
     let runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter> =
-        Arc::new(nearcore::NightshadeRuntime::from_config(home_dir, store.clone(), &near_config));
+        nearcore::NightshadeRuntime::from_config(home_dir, store.clone(), &near_config);
 
     let mut store_validator = StoreValidator::new(
         near_config.validator_signer.as_ref().map(|x| x.validator_id().clone()),

--- a/tools/cold-store/src/cli.rs
+++ b/tools/cold-store/src/cli.rs
@@ -69,11 +69,8 @@ impl ColdStoreCommand {
         let storage =
             opener.open_in_mode(mode).unwrap_or_else(|e| panic!("Error opening storage: {:#}", e));
 
-        let hot_runtime = Arc::new(NightshadeRuntime::from_config(
-            home_dir,
-            storage.get_hot_store(),
-            &near_config,
-        ));
+        let hot_runtime =
+            NightshadeRuntime::from_config(home_dir, storage.get_hot_store(), &near_config);
         match self.subcmd {
             SubCommand::Open => check_open(&storage),
             SubCommand::Head => print_heads(&storage),

--- a/tools/flat-storage/src/commands.rs
+++ b/tools/flat-storage/src/commands.rs
@@ -70,11 +70,8 @@ impl FlatStorageCommand {
         mode: Mode,
     ) -> (NodeStorage, Arc<NightshadeRuntime>, ChainStore, Store) {
         let node_storage = opener.open_in_mode(mode).unwrap();
-        let hot_runtime = Arc::new(NightshadeRuntime::from_config(
-            home_dir,
-            node_storage.get_hot_store(),
-            &near_config,
-        ));
+        let hot_runtime =
+            NightshadeRuntime::from_config(home_dir, node_storage.get_hot_store(), &near_config);
         let chain_store = ChainStore::new(node_storage.get_hot_store(), 0, false);
         let hot_store = node_storage.get_hot_store();
         (node_storage, hot_runtime, chain_store, hot_store)

--- a/tools/mirror/src/offline.rs
+++ b/tools/mirror/src/offline.rs
@@ -29,7 +29,7 @@ fn is_on_current_chain(
 
 pub(crate) struct ChainAccess {
     chain: ChainStore,
-    runtime: NightshadeRuntime,
+    runtime: Arc<NightshadeRuntime>,
 }
 
 impl ChainAccess {

--- a/tools/mock-node/src/lib.rs
+++ b/tools/mock-node/src/lib.rs
@@ -527,11 +527,11 @@ mod test {
     fn setup_mock() -> (ChainHistoryAccess, TestEnv) {
         let genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
         let chain_genesis = ChainGenesis::new(&genesis);
-        let runtimes = vec![Arc::new(nearcore::NightshadeRuntime::test(
+        let runtimes = vec![nearcore::NightshadeRuntime::test(
             Path::new("../../../.."),
             create_test_store(),
             &genesis,
-        )) as Arc<dyn RuntimeWithEpochManagerAdapter>];
+        ) as Arc<dyn RuntimeWithEpochManagerAdapter>];
         let mut env = TestEnv::builder(chain_genesis.clone())
             .validator_seats(1)
             .runtime_adapters(runtimes.clone())

--- a/tools/mock-node/src/setup.rs
+++ b/tools/mock-node/src/setup.rs
@@ -41,7 +41,7 @@ fn setup_runtime(
             .get_hot_store()
     };
 
-    Arc::new(NightshadeRuntime::from_config(home_dir, store, config))
+    NightshadeRuntime::from_config(home_dir, store, config)
 }
 
 fn setup_mock_peer_manager_actor(

--- a/tools/speedy_sync/src/main.rs
+++ b/tools/speedy_sync/src/main.rs
@@ -17,7 +17,6 @@ use near_store::{DBCol, Mode, NodeStorage, Store, StoreUpdate};
 use nearcore::NightshadeRuntime;
 use std::fs;
 use std::path::Path;
-use std::sync::Arc;
 
 #[derive(serde::Serialize, BorshSerialize, BorshDeserialize)]
 pub struct BlockCheckpoint {
@@ -227,7 +226,7 @@ fn load_snapshot(load_cmd: LoadCmd) {
         .unwrap()
         .get_hot_store();
     let chain_genesis = ChainGenesis::new(&config.genesis);
-    let runtime = Arc::new(NightshadeRuntime::from_config(home_dir, store.clone(), &config));
+    let runtime = NightshadeRuntime::from_config(home_dir, store.clone(), &config);
     // This will initialize the database (add genesis block etc)
     let _chain = Chain::new(
         runtime,

--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -334,7 +334,7 @@ pub fn apply_chain_range(
     start_height: Option<BlockHeight>,
     end_height: Option<BlockHeight>,
     shard_id: ShardId,
-    runtime: NightshadeRuntime,
+    runtime_adapter: Arc<NightshadeRuntime>,
     verbose_output: bool,
     csv_file: Option<&mut File>,
     only_contracts: bool,
@@ -349,7 +349,6 @@ pub fn apply_chain_range(
         only_contracts,
         sequential)
     .entered();
-    let runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter> = Arc::new(runtime);
     let chain_store = ChainStore::new(store.clone(), genesis.config.genesis_height, false);
     let end_height = end_height.unwrap_or_else(|| chain_store.head().unwrap().height);
     let start_height = start_height.unwrap_or_else(|| chain_store.tail().unwrap());
@@ -449,7 +448,6 @@ fn smart_equals(extra1: &ChunkExtra, extra2: &ChunkExtra) -> bool {
 mod test {
     use std::io::{Read, Seek, SeekFrom};
     use std::path::Path;
-    use std::sync::Arc;
 
     use near_chain::{ChainGenesis, Provenance};
     use near_chain_configs::Genesis;
@@ -478,7 +476,7 @@ mod test {
         chain_genesis.gas_limit = genesis.config.gas_limit;
         let env = TestEnv::builder(chain_genesis)
             .validator_seats(2)
-            .runtime_adapters(vec![Arc::new(nightshade_runtime)])
+            .runtime_adapters(vec![nightshade_runtime])
             .build();
         (store, genesis, env)
     }

--- a/tools/state-viewer/src/apply_chunk.rs
+++ b/tools/state-viewer/src/apply_chunk.rs
@@ -423,7 +423,6 @@ mod test {
     use rand::rngs::StdRng;
     use rand::SeedableRng;
     use std::path::Path;
-    use std::sync::Arc;
 
     fn send_txs(env: &mut TestEnv, signers: &[InMemorySigner], height: u64, hash: CryptoHash) {
         for (i, signer) in signers.iter().enumerate() {
@@ -457,13 +456,13 @@ mod test {
 
         let store = create_test_store();
         let mut chain_store = ChainStore::new(store.clone(), genesis.config.genesis_height, false);
-        let runtime = Arc::new(NightshadeRuntime::test_with_runtime_config_store(
+        let runtime = NightshadeRuntime::test_with_runtime_config_store(
             Path::new("."),
             store,
             &genesis,
             TrackedConfig::AllShards,
             RuntimeConfigStore::test(),
-        ));
+        );
         let chain_genesis = ChainGenesis::test();
 
         let signers = (0..4)
@@ -534,13 +533,13 @@ mod test {
 
         let store = create_test_store();
         let chain_store = ChainStore::new(store.clone(), genesis.config.genesis_height, false);
-        let runtime = Arc::new(NightshadeRuntime::test_with_runtime_config_store(
+        let runtime = NightshadeRuntime::test_with_runtime_config_store(
             Path::new("."),
             store.clone(),
             &genesis,
             TrackedConfig::AllShards,
             RuntimeConfigStore::test(),
-        ));
+        );
         let mut chain_genesis = ChainGenesis::test();
         // receipts get delayed with the small ChainGenesis::test() limit
         chain_genesis.gas_limit = genesis.config.gas_limit;

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -132,7 +132,7 @@ pub(crate) fn apply_block_at_height(
         near_config.client_config.save_trie_changes,
     );
     let runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter> =
-        Arc::new(NightshadeRuntime::from_config(home_dir, store, &near_config));
+        NightshadeRuntime::from_config(home_dir, store, &near_config);
     let block_hash = chain_store.get_block_hash_by_height(height).unwrap();
     let (block, apply_result) =
         apply_block(block_hash, shard_id, runtime_adapter.as_ref(), &mut chain_store);
@@ -159,7 +159,7 @@ pub(crate) fn apply_chunk(
         near_config.client_config.save_trie_changes,
     );
     let (apply_result, gas_limit) =
-        apply_chunk::apply_chunk(&runtime, &mut chain_store, chunk_hash, target_height, None)?;
+        apply_chunk::apply_chunk(&*runtime, &mut chain_store, chunk_hash, target_height, None)?;
     println!("resulting chunk extra:\n{:?}", resulting_chunk_extra(&apply_result, gas_limit));
     Ok(())
 }
@@ -200,7 +200,7 @@ pub(crate) fn apply_receipt(
     hash: CryptoHash,
 ) -> anyhow::Result<()> {
     let runtime = NightshadeRuntime::from_config(home_dir, store.clone(), &near_config);
-    apply_chunk::apply_receipt(near_config.genesis.config.genesis_height, &runtime, store, hash)
+    apply_chunk::apply_receipt(near_config.genesis.config.genesis_height, &*runtime, store, hash)
         .map(|_| ())
 }
 
@@ -211,7 +211,7 @@ pub(crate) fn apply_tx(
     hash: CryptoHash,
 ) -> anyhow::Result<()> {
     let runtime = NightshadeRuntime::from_config(home_dir, store.clone(), &near_config);
-    apply_chunk::apply_tx(near_config.genesis.config.genesis_height, &runtime, store, hash)
+    apply_chunk::apply_tx(near_config.genesis.config.genesis_height, &*runtime, store, hash)
         .map(|_| ())
 }
 
@@ -754,7 +754,7 @@ pub(crate) fn print_epoch_info(
         EpochManager::new_from_genesis_config(store.clone(), &near_config.genesis.config)
             .expect("Failed to start Epoch Manager");
     let runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter> =
-        Arc::new(NightshadeRuntime::from_config(&home_dir, store.clone(), &near_config));
+        NightshadeRuntime::from_config(&home_dir, store.clone(), &near_config);
 
     epoch_info::print_epoch_info(
         epoch_selection,
@@ -812,7 +812,7 @@ fn load_trie(
     store: Store,
     home_dir: &Path,
     near_config: &NearConfig,
-) -> (NightshadeRuntime, Vec<StateRoot>, BlockHeader) {
+) -> (Arc<NightshadeRuntime>, Vec<StateRoot>, BlockHeader) {
     load_trie_stop_at_height(store, home_dir, near_config, LoadTrieMode::Latest)
 }
 
@@ -821,7 +821,7 @@ fn load_trie_stop_at_height(
     home_dir: &Path,
     near_config: &NearConfig,
     mode: LoadTrieMode,
-) -> (NightshadeRuntime, Vec<StateRoot>, BlockHeader) {
+) -> (Arc<NightshadeRuntime>, Vec<StateRoot>, BlockHeader) {
     let chain_store = ChainStore::new(
         store.clone(),
         near_config.genesis.config.genesis_height,

--- a/tools/state-viewer/src/state_changes.rs
+++ b/tools/state-viewer/src/state_changes.rs
@@ -72,8 +72,7 @@ fn dump_state_changes(
 ) {
     assert!(height_from <= height_to, "--height-from must be less than or equal to --height-to");
 
-    let runtime: NightshadeRuntime =
-        NightshadeRuntime::from_config(home_dir, store.clone(), &near_config);
+    let runtime = NightshadeRuntime::from_config(home_dir, store.clone(), &near_config);
     let chain_store = ChainStore::new(
         store.clone(),
         near_config.genesis.config.genesis_height,
@@ -89,7 +88,7 @@ fn dump_state_changes(
 
         for row in key.find_rows_iter(&store) {
             let (key, value) = row.unwrap();
-            let shard_id = get_state_change_shard_id(key.as_ref(), &value.trie_key, block_hash, epoch_id, &runtime).unwrap();
+            let shard_id = get_state_change_shard_id(key.as_ref(), &value.trie_key, block_hash, epoch_id, runtime.as_ref()).unwrap();
             state_changes_per_shard[shard_id as usize].push(value);
         }
 
@@ -135,8 +134,7 @@ fn apply_state_changes(
     near_config: NearConfig,
     store: Store,
 ) {
-    let runtime: NightshadeRuntime =
-        NightshadeRuntime::from_config(home_dir, store.clone(), &near_config);
+    let runtime = NightshadeRuntime::from_config(home_dir, store.clone(), &near_config);
     let mut chain_store = ChainStore::new(
         store,
         near_config.genesis.config.genesis_height,

--- a/tools/state-viewer/src/state_parts.rs
+++ b/tools/state-viewer/src/state_parts.rs
@@ -219,7 +219,7 @@ fn apply_state_parts(
     location: Location,
 ) {
     let runtime_adapter: Arc<dyn RuntimeAdapter> =
-        Arc::new(NightshadeRuntime::from_config(home_dir, store.clone(), &near_config));
+        NightshadeRuntime::from_config(home_dir, store.clone(), &near_config);
     let epoch_manager =
         EpochManager::new_from_genesis_config(store.clone(), &near_config.genesis.config)
             .expect("Failed to start Epoch Manager");
@@ -310,7 +310,7 @@ fn dump_state_parts(
     location: Location,
 ) {
     let runtime_adapter: Arc<dyn RuntimeAdapter> =
-        Arc::new(NightshadeRuntime::from_config(home_dir, store.clone(), &near_config));
+        NightshadeRuntime::from_config(home_dir, store.clone(), &near_config);
     let epoch_manager =
         EpochManager::new_from_genesis_config(store.clone(), &near_config.genesis.config)
             .expect("Failed to start Epoch Manager");


### PR DESCRIPTION
As a reminder of the overall goal, we want to split `RuntimeWithEpochManagerAdapter`, so that any code that needs the runtime will use an `Arc<RuntimeAdapter>`, and any code that uses the epoch manager will use the `EpochManagerHandle`.

We're doing this refactoring bottom-up, i.e. propagating `RuntimeWithEpochManagerAdapter` around at the top-level, but making some lower-level components use `Arc<RuntimeAdapter>` and/or `EpochManagerHandle`.

That means we need to be able to obtain an `Arc<RuntimeAdapter>` and an `EpochManagerHandle` from a `RuntimeWithEpochManagerAdapter`. However, this is not trivial at all:
 1. `KeyValueRuntime`, the implementation of `RuntimeWithEpochManagerAdapter` for testing, does not contain an `EpochManager` at all, so it's not possible to extract an `EpochManagerHandle` from it (which is essentially an arc mutex of `EpochManager`). That means instead of using `EpochManagerHandle`, we need to use `Arc<EpochManagerAdapter>` in the meantime.
 2. Extracting an `Arc<EpochManagerAdapter>` from a `Arc<RuntimeWithEpochManagerAdapter>` is not trivial. Even though `RuntimeWithEpochManagerAdapter` is a trait that extends `EpochManagerAdapter`, trait upcast is not allowed by Rust in general. So we need to resort to a workaround.

This PR implements the workaround for (2):

```
pub trait RuntimeWithEpochManagerAdapter: RuntimeAdapter + EpochManagerAdapter {
    fn epoch_manager_adapter(&self) -> &dyn EpochManagerAdapter;
    fn epoch_manager_adapter_arc(&self) -> Arc<dyn EpochManagerAdapter>;
}
```

How to implement `epoch_manager_adapter_arc` from a `&self`? We'll use a self-referencing `Weak<Self>` that implementations must keep as a field. This can be done using `Arc::new_cyclic` in the constructor. As a result, we also enforce that all runtime implementations be used always with an `Arc` (or else the `Weak` would go out of scope). This isn't a problem, because we already require the use of `Arc<RuntimeWithEpochManagerAdapter>` everywhere. To implement `epoch_manager_adpater_arc`, we upgrade the `Weak<Self>` into an `Arc<Self>` which always succeeds because we always use `Arc` (there's no way to construct without returning an `Arc`), and then we return the `Arc<Self>` which succeeds because `Self` implements `EpochManagerAdapter`. `Self` here refers to `KeyValueRuntime` and `NightshadeRuntime`.

This is an interim strategy; when all the refactoring and test migrations are complete, `KeyValueRuntime` would be deleted and we would not have `EpochManagerAdapter` or `RuntimeWithEpochManagerAdapter`.