### PR TITLE
chore: Bump crates version to 0.16.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ members = [
 ]
 
 [workspace.metadata.workspaces]
-version = "0.16.0"
+version = "0.16.1"
 exclude = [ "neard" ]
 
 [workspace.dependencies]

--- a/utils/near-cache/README.md
+++ b/utils/near-cache/README.md
@@ -1,0 +1,1 @@
+# near-cache


### PR DESCRIPTION
Following up PR #8762 by bumping versions for the `near-*` crates to `0.16.1` in order to release the ones mentioned in the PR and updating the others to have a set of compatible packages released.

cc @jakmeier As you said to bump the version

P.S. adding an empty README to the `near-cache` crate to avoid "publisher" from failing