### PR TITLE
fix(near-cache): Failed to puslibh the crate

### DIFF
--- a/utils/near-cache/Cargo.toml
+++ b/utils/near-cache/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/near/nearcore"
-description = ""
+description = "do not use this, new versions can stop being published at literally any time"
 
 [dependencies]
 lru.workspace = true

--- a/utils/near-cache/README.md
+++ b/utils/near-cache/README.md
@@ -1,1 +1,3 @@
 # near-cache
+
+Do not use this, new versions can stop being published on crates.io at literally any time


### PR DESCRIPTION
The publishing of the  crate `near-cache` failing with an error

```
Uploading near-cache v0.16.1 (/var/lib/buildkite-agent/builds/buildkite-i-04b8708aca8b70702-1/nearprotocol/nearcore-release/utils/near-cache)
error: failed to publish to registry at https://crates.io/
 
Caused by:
  the remote server responded with an error: missing or empty metadata fields: description. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for how to upload metadata
error: unable to publish package near-cache
🚨 Error: The command exited with status 1
```

I hope this PR is fixing it.