### PR TITLE
panic if cold_store is configured without saving trie changes

### DIFF
--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -313,8 +313,8 @@ pub struct Config {
     /// save_trie_changes = !archive
     /// save_trie_changes should be set to true iff
     /// - archive if false - non-archival nodes need trie changes to perform garbage collection
-    /// - archive is true, cold_store is configured and migration to split_storage is finished - node
-    /// working in split storage mode needs trie changes in order to do garbage collection on hot.
+    /// - archive is true and cold_store is configured - node working in split storage mode
+    /// needs trie changes in order to do garbage collection on hot and populate cold State column.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub save_trie_changes: Option<bool>,
     pub log_summary_style: LogSummaryStyle,


### PR DESCRIPTION
Adding extra validation step to prevent node running in split storage mode without saving trie changes.
Right now we have some check around not starting cold loop if trie changes are not saved, which does not protect us at all, because TrieChanges are created and saved in completely different place that is in no way shape or form blocked by cold loop. 
I want the node to crash and burn if someone even thinks about running cold storage without saving TrieChanges. Or do our best approximation of that.

This commit isn't completely preventing people from corrupting State column, but it is making it a lot harder.
To shoot themselves in the foot with this setup, node maintainers will have to:
1. set up cold storage
2. run the node for 3 days to finish initial migration
3. delete save_trie_changes and cold_store sections from config and run the node some more
4. return those sections and run the node again
and then, I think, they can achieve a corrupt cold storage