### PR TITLE
[TestLoop] Add AdhocEvent to allow executing arbitrary logic as part of a TestLoop event.

### DIFF
--- a/core/async/src/examples/sum_numbers_test.rs
+++ b/core/async/src/examples/sum_numbers_test.rs
@@ -4,6 +4,7 @@ use near_primitives::time;
 use crate::{
     messaging::{CanSend, IntoSender},
     test_loop::{
+        adhoc::{handle_adhoc_events, AdhocEvent, AdhocRunner},
         event_handler::{capture_events, LoopEventHandler},
         TestLoopBuilder,
     },
@@ -38,19 +39,71 @@ fn test_simple() {
     // Build the SumNumberComponents so that it sends messages back to the test loop.
     let data =
         TestData { summer: SumNumbersComponent::new(builder.sender().into_sender()), sums: vec![] };
-    let sender = builder.sender();
     let mut test = builder.build(data);
     test.register_handler(forward_sum_request().widen());
     test.register_handler(capture_events::<ReportSumMsg>().widen());
 
-    sender.send(TestEvent::Request(SumRequest::Number(1)));
-    sender.send(TestEvent::Request(SumRequest::Number(2)));
-    sender.send(TestEvent::Request(SumRequest::GetSum));
-    sender.send(TestEvent::Request(SumRequest::Number(3)));
-    sender.send(TestEvent::Request(SumRequest::Number(4)));
-    sender.send(TestEvent::Request(SumRequest::Number(5)));
-    sender.send(TestEvent::Request(SumRequest::GetSum));
+    test.sender().send(SumRequest::Number(1));
+    test.sender().send(SumRequest::Number(2));
+    test.sender().send(SumRequest::GetSum);
+    test.sender().send(SumRequest::Number(3));
+    test.sender().send(SumRequest::Number(4));
+    test.sender().send(SumRequest::Number(5));
+    test.sender().send(SumRequest::GetSum);
 
     test.run(time::Duration::milliseconds(1));
     assert_eq!(test.data.sums, vec![ReportSumMsg(3), ReportSumMsg(12)]);
+}
+
+#[derive(Debug, EnumTryInto, EnumFrom)]
+enum TestEventWithAdhoc {
+    Request(SumRequest),
+    Sum(ReportSumMsg),
+    Adhoc(AdhocEvent<TestData>),
+}
+
+#[test]
+fn test_simple_with_adhoc() {
+    let builder = TestLoopBuilder::<TestEventWithAdhoc>::new();
+    // Build the SumNumberComponents so that it sends messages back to the test loop.
+    let data =
+        TestData { summer: SumNumbersComponent::new(builder.sender().into_sender()), sums: vec![] };
+    let mut test = builder.build(data);
+    test.register_handler(forward_sum_request().widen());
+    test.register_handler(capture_events::<ReportSumMsg>().widen());
+    test.register_handler(handle_adhoc_events());
+
+    // It is preferrable to put as much setup logic as possible into an adhoc
+    // event (queued by .run below), so that as much logic as possible is
+    // executed in the TestLoop context. This allows the setup logic to show
+    // up in the visualizer too, with any of its logging shown under the
+    // adhoc event.
+    let sender = test.sender().clone();
+    test.sender().run("initial events", move |_| {
+        sender.send(SumRequest::Number(1));
+        sender.send(SumRequest::Number(2));
+        sender.send(SumRequest::GetSum);
+        sender.send(SumRequest::Number(3));
+        sender.send(SumRequest::Number(4));
+        sender.send(SumRequest::Number(5));
+        sender.send(SumRequest::GetSum);
+    });
+
+    test.run(time::Duration::milliseconds(1));
+
+    // We can put assertions inside an adhoc event as well. This is
+    // especially useful if we had a multi-instance test, so that in the
+    // visualizer we can easily see which assertion was problematic.
+    //
+    // Here, we queue these events after the first test.run call, so we
+    // need to remember to call test.run again to actually execute them.
+    // Alternatively we can use test.sender().run_with_delay to queue
+    // the assertion events after the logic we expect to execute has been
+    // executed; that way we only need to call test.run once. Either way,
+    // don't worry if you forget to call test.run again; the test will
+    // panic at the end if there are unhandled events.
+    test.sender().run("assertions", |data| {
+        assert_eq!(data.sums, vec![ReportSumMsg(3), ReportSumMsg(12)]);
+    });
+    test.run(time::Duration::milliseconds(1));
 }

--- a/core/async/src/test_loop/adhoc.rs
+++ b/core/async/src/test_loop/adhoc.rs
@@ -1,13 +1,10 @@
-use std::fmt::Debug;
-
-use near_primitives::time;
-
-use crate::messaging::CanSend;
-
 use super::{
     delay_sender::DelaySender,
     event_handler::{LoopEventHandler, TryIntoOrSelf},
 };
+use crate::messaging::CanSend;
+use near_primitives::time;
+use std::fmt::Debug;
 
 /// Any arbitrary logic that runs as part of the test loop.
 ///

--- a/core/async/src/test_loop/adhoc.rs
+++ b/core/async/src/test_loop/adhoc.rs
@@ -1,0 +1,67 @@
+use std::fmt::Debug;
+
+use near_primitives::time;
+
+use crate::messaging::CanSend;
+
+use super::{
+    delay_sender::DelaySender,
+    event_handler::{LoopEventHandler, TryIntoOrSelf},
+};
+
+/// Any arbitrary logic that runs as part of the test loop.
+///
+/// This is not necessary (since one can just take the data and perform
+/// arbitrary logic on it), but this is good for documentation and allows
+/// the logs emitted as part of this function's execution to be segmented
+/// in the TestLoop visualizer.
+pub struct AdhocEvent<Data: 'static> {
+    pub description: String,
+    pub handler: Box<dyn FnOnce(&mut Data) + Send + 'static>,
+}
+
+impl<Data> Debug for AdhocEvent<Data> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.description)
+    }
+}
+
+/// Allows DelaySender to be used to run adhoc events.
+pub trait AdhocRunner<Data: 'static> {
+    fn run(&self, description: &str, f: impl FnOnce(&mut Data) + Send + 'static);
+    fn run_with_delay(
+        &self,
+        description: &str,
+        f: impl FnOnce(&mut Data) + Send + 'static,
+        delay: time::Duration,
+    );
+}
+
+impl<Data: 'static, Event: From<AdhocEvent<Data>> + 'static> AdhocRunner<Data>
+    for DelaySender<Event>
+{
+    fn run(&self, description: &str, f: impl FnOnce(&mut Data) + Send + 'static) {
+        self.send(AdhocEvent { description: description.to_string(), handler: Box::new(f) })
+    }
+    fn run_with_delay(
+        &self,
+        description: &str,
+        f: impl FnOnce(&mut Data) + Send + 'static,
+        delay: time::Duration,
+    ) {
+        self.send_with_delay(
+            AdhocEvent { description: description.to_string(), handler: Box::new(f) }.into(),
+            delay,
+        )
+    }
+}
+
+/// Handler to handle adhoc events.
+pub fn handle_adhoc_events<Data: 'static, Event: TryIntoOrSelf<AdhocEvent<Data>>>(
+) -> LoopEventHandler<Data, Event> {
+    LoopEventHandler::new(|event: Event, data, _ctx| {
+        let event = event.try_into_or_self()?;
+        (event.handler)(data);
+        Ok(())
+    })
+}

--- a/core/async/src/test_loop/multi_instance.rs
+++ b/core/async/src/test_loop/multi_instance.rs
@@ -31,4 +31,12 @@ impl<Data, Event> LoopEventHandlerImpl<Vec<Data>, (usize, Event)>
             Err(event)
         }
     }
+
+    fn try_drop(&self, event: (usize, Event)) -> Result<(), (usize, Event)> {
+        if event.0 == self.index {
+            self.inner.try_drop(event.1).map_err(|event| (self.index, event))
+        } else {
+            Err(event)
+        }
+    }
 }


### PR DESCRIPTION
Adhoc events allow executing arbitrary logic as part of a TestLoop event, so that it shows up on the visualizer. This helps with understanding the test setup, and also when assertions fail, we know which assertion failed - e.g. in the following screenshot, if that assertion failed, the logs for that event should show the panic, and the assertions to the right would be missing (since the test crashed).

<img width="805" alt="image" src="https://user-images.githubusercontent.com/111538878/227016958-bc1e6edf-42d6-47b7-a38b-220353d3f00d.png">

Also two minor improvements:
 - Make test loop panic if non-timer events remain in the queue when the test ends. This is useful if the test has forgotten to run() everything, and if not done can lead to tests not actually running what it's supposed to run or what it's supposed to assert (if assertion is done in an adhoc event). This is implemented by having each handler specify whether an event can be dropped - only timer handlers allow dropping.
 - Bump the time at the end of run() even if the events it ran did not reach the target deadline.

