### PR TITLE
chore: Disable publishing `near-test-contracts` (redundant)

### DIFF
--- a/runtime/near-test-contracts/Cargo.toml
+++ b/runtime/near-test-contracts/Cargo.toml
@@ -2,7 +2,7 @@
 name = "near-test-contracts"
 version = "0.0.0"
 authors.workspace = true
-publish = true
+publish = false
 # Please update rust-toolchain.toml as well when changing version here:
 rust-version.workspace = true
 edition.workspace = true


### PR DESCRIPTION
Following the PR #8762

Figured out we don't need to publish the `neat-test-contract`, by crates.io `dev-dependencies` are not required to be published.

This PR just sets `publish = false` for that crate (**note** the publishing of the crate anyway has failed)
