### PR TITLE
feature: Get compute usage from profile

### DIFF
--- a/core/primitives-core/src/config.rs
+++ b/core/primitives-core/src/config.rs
@@ -286,7 +286,7 @@ impl ExtCostsConfig {
 
     /// Convenience constructor to use in tests where the exact gas cost does
     /// not need to correspond to a specific protocol version.
-    pub fn test() -> ExtCostsConfig {
+    pub fn test_with_undercharging_factor(factor: u64) -> ExtCostsConfig {
         let costs = enum_map! {
             ExtCosts::base => SAFETY_MULTIPLIER * 88256037,
             ExtCosts::contract_loading_base => SAFETY_MULTIPLIER * 11815321,
@@ -352,8 +352,13 @@ impl ExtCostsConfig {
             ExtCosts::alt_bn128_g1_sum_base => 3_000_000_000,
             ExtCosts::alt_bn128_g1_sum_element => 5_000_000_000,
         }
-        .map(|_, value| ParameterCost { gas: value, compute: value });
+        .map(|_, value| ParameterCost { gas: value, compute: value * factor });
         ExtCostsConfig { costs }
+    }
+
+    /// `test_with_undercharging_factor` with a factor of 1.
+    pub fn test() -> ExtCostsConfig {
+        Self::test_with_undercharging_factor(1)
     }
 
     fn free() -> ExtCostsConfig {
@@ -482,8 +487,12 @@ pub enum ActionCosts {
 }
 
 impl ExtCosts {
-    pub fn value(self, config: &ExtCostsConfig) -> Gas {
+    pub fn gas(self, config: &ExtCostsConfig) -> Gas {
         config.gas_cost(self)
+    }
+
+    pub fn compute(self, config: &ExtCostsConfig) -> Compute {
+        config.compute_cost(self)
     }
 
     pub fn param(&self) -> Parameter {

--- a/runtime/near-vm-logic/src/gas_counter.rs
+++ b/runtime/near-vm-logic/src/gas_counter.rs
@@ -79,7 +79,7 @@ impl GasCounter {
                 gas_limit: min(max_gas_burnt, prepaid_gas),
                 opcode_cost: Gas::from(opcode_cost),
             },
-            max_gas_burnt: max_gas_burnt,
+            max_gas_burnt,
             promises_gas: 0,
             prepaid_gas,
             is_view,
@@ -218,9 +218,8 @@ impl GasCounter {
 
     /// A helper function to pay a multiple of a cost.
     pub fn pay_per(&mut self, cost: ExtCosts, num: u64) -> Result<()> {
-        let use_gas = num
-            .checked_mul(cost.value(&self.ext_costs_config))
-            .ok_or(HostError::IntegerOverflow)?;
+        let use_gas =
+            num.checked_mul(cost.gas(&self.ext_costs_config)).ok_or(HostError::IntegerOverflow)?;
 
         self.inc_ext_costs_counter(cost, num);
         self.update_profile_host(cost, use_gas);
@@ -229,7 +228,7 @@ impl GasCounter {
 
     /// A helper function to pay base cost gas.
     pub fn pay_base(&mut self, cost: ExtCosts) -> Result<()> {
-        let base_fee = cost.value(&self.ext_costs_config);
+        let base_fee = cost.gas(&self.ext_costs_config);
         self.inc_ext_costs_counter(cost, 1);
         self.update_profile_host(cost, base_fee);
         self.burn_gas(base_fee)
@@ -283,6 +282,9 @@ impl GasCounter {
 mod tests {
     use crate::{ExtCostsConfig, HostError};
     use near_primitives_core::types::Gas;
+
+    /// Max prepaid amount of gas.
+    const MAX_GAS: u64 = 300_000_000_000_000;
 
     fn make_test_counter(max_burnt: Gas, prepaid: Gas, is_view: bool) -> super::GasCounter {
         super::GasCounter::new(ExtCostsConfig::test(), max_burnt, 1, prepaid, is_view)
@@ -343,5 +345,25 @@ mod tests {
         test(5, 8, true, Err(HostError::GasLimitExceeded));
         test(8, 5, false, Err(HostError::GasExceeded));
         test(8, 5, true, Ok(()));
+    }
+
+    #[test]
+    fn test_profile_compute_cost_is_accurate() {
+        let mut counter = make_test_counter(MAX_GAS, MAX_GAS, false);
+        counter.pay_base(near_primitives::config::ExtCosts::storage_write_base).unwrap();
+        counter.pay_per(near_primitives::config::ExtCosts::storage_write_value_byte, 10).unwrap();
+        counter.pay_wasm_gas(20).unwrap();
+        counter
+            .pay_action_accumulated(
+                100,
+                100,
+                near_primitives::config::ActionCosts::new_data_receipt_byte,
+            )
+            .unwrap();
+
+        let mut profile = counter.profile_data().clone();
+        profile.compute_wasm_instruction_cost(counter.burnt_gas());
+
+        assert_eq!(profile.total_compute_usage(&ExtCostsConfig::test()), counter.burnt_gas());
     }
 }


### PR DESCRIPTION
This seemed like the simplest approach that introduced minimal runtime overhead and code changes (as opposed to introducing a dedicated field in the GasCounter). Happy to consider the alternatives though.

Part of https://github.com/near/nearcore/issues/8032

Some follow-up work is planned in https://github.com/near/nearcore/issues/8795