### PR TITLE
themis: fix ENOENT when rust-toolchain.toml doesn't exist

### DIFF
--- a/tools/themis/src/rules.rs
+++ b/tools/themis/src/rules.rs
@@ -57,7 +57,10 @@ pub fn rust_version_matches_toolchain(workspace: &Workspace) -> anyhow::Result<(
         Ok(val)
     }
 
-    let toolchain_file = read_toml(&workspace.root.join("rust-toolchain.toml"))?;
+    let toolchain_file = match read_toml(&workspace.root.join("rust-toolchain.toml"))? {
+        Some(toolchain_file) => toolchain_file,
+        _ => return Ok(()),
+    };
     let toolchain_version = get(&toolchain_file, &["toolchain", "channel"])?;
     let workspace_version = get(&workspace.raw, &["workspace", "package", "rust-version"])?;
 

--- a/tools/themis/src/rules.rs
+++ b/tools/themis/src/rules.rs
@@ -59,7 +59,7 @@ pub fn rust_version_matches_toolchain(workspace: &Workspace) -> anyhow::Result<(
 
     let toolchain_file = match read_toml(&workspace.root.join("rust-toolchain.toml"))? {
         Some(toolchain_file) => toolchain_file,
-        _ => return Ok(()),
+        None => return Ok(()),
     };
     let toolchain_version = get(&toolchain_file, &["toolchain", "channel"])?;
     let workspace_version = get(&workspace.raw, &["workspace", "package", "rust-version"])?;

--- a/tools/themis/src/utils.rs
+++ b/tools/themis/src/utils.rs
@@ -28,16 +28,14 @@ pub fn parse_workspace() -> anyhow::Result<Workspace> {
         .map(|package| {
             let raw = match read_toml(&package.manifest_path)? {
                 Some(raw) => raw,
-                None => {
-                    return Err(anyhow::anyhow!("package manifest `{}` not found", package.name))
-                }
+                None => anyhow::bail!("package manifest `{}` not found", package.name),
             };
             Ok(Package { parsed: package, raw })
         })
         .collect::<anyhow::Result<_>>()?;
     let raw = match read_toml(&metadata.workspace_root.join("Cargo.toml"))? {
         Some(raw) => raw,
-        None => return Err(anyhow::anyhow!("workspace manifest not found")),
+        None => anyhow::bail!("workspace manifest not found"),
     };
     Ok(Workspace { root: metadata.workspace_root, members, raw })
 }


### PR DESCRIPTION
In the absence of the `rust-toolchain.toml` file, themis exits with "No such file or directory".

Since there's no rule enforcing the presence of a toolchain file, we can ignore its absence.