### PR TITLE
fix: Update integration and pytests to enable state sync

### DIFF
--- a/integration-tests/src/tests/nearcore/sync_nodes.rs
+++ b/integration-tests/src/tests/nearcore/sync_nodes.rs
@@ -114,10 +114,12 @@ fn setup_configs() -> (Genesis, Block, NearConfig, NearConfig) {
     near1.network_config.peer_store.boot_nodes = convert_boot_nodes(vec![("test2", *port2)]);
     near1.client_config.min_num_peers = 1;
     near1.client_config.epoch_sync_enabled = false;
+    near1.client_config.state_sync_enabled = true;
     let mut near2 = load_test_config("test2", port2, genesis.clone());
     near2.network_config.peer_store.boot_nodes = convert_boot_nodes(vec![("test1", *port1)]);
     near2.client_config.min_num_peers = 1;
     near2.client_config.epoch_sync_enabled = false;
+    near2.client_config.state_sync_enabled = true;
     (genesis, genesis_block, near1, near2)
 }
 

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -795,9 +795,10 @@ def apply_config_changes(node_dir, client_config_change):
     # when None.
     allowed_missing_configs = (
         'archive',
-        'save_trie_changes',
         'max_gas_burnt_view',
         'rosetta_rpc',
+        'save_trie_changes',
+        'state_sync_enabled',
     )
 
     for k, v in client_config_change.items():

--- a/pytest/tests/sanity/state_sync.py
+++ b/pytest/tests/sanity/state_sync.py
@@ -30,19 +30,18 @@ START_AT_BLOCK = int(sys.argv[2])
 TIMEOUT = 150 + START_AT_BLOCK * 10
 
 config = load_config()
+node_config = {
+    "tracked_shards": [0],
+    "state_sync_enabled": True,
+}
+
 near_root, node_dirs = init_cluster(
     2, 1, 1, config,
     [["min_gas_price", 0], ["max_inflation_rate", [0, 1]], ["epoch_length", 10],
      ["block_producer_kickout_threshold", 80]], {
-         0: {
-             "tracked_shards": [0]
-         },
-         1: {
-             "tracked_shards": [0]
-         },
-         2: {
-             "tracked_shards": [0]
-         }
+         0: node_config,
+         1: node_config,
+         2: node_config,
      })
 
 started = time.time()

--- a/pytest/tests/sanity/state_sync1.py
+++ b/pytest/tests/sanity/state_sync1.py
@@ -19,14 +19,21 @@ consensus_config = {
     "consensus": {
         "block_fetch_horizon": 10,
         "block_header_fetch_horizon": 10
-    }
+    },
+    "state_sync_enabled": True,
 }
+node_config = {
+    "state_sync_enabled": True,
+}
+
 nodes = start_cluster(
     4, 0, 1, None,
     [["epoch_length", EPOCH_LENGTH], ["block_producer_kickout_threshold", 10],
      ["chunk_producer_kickout_threshold", 10]], {
          0: consensus_config,
-         1: consensus_config
+         1: consensus_config,
+         2: node_config,
+         3: node_config
      })
 time.sleep(2)
 nodes[1].kill()

--- a/pytest/tests/sanity/state_sync2.py
+++ b/pytest/tests/sanity/state_sync2.py
@@ -20,16 +20,34 @@ BLOCKS = 105  # should be enough to trigger state sync for node 1 later, see com
 
 nightly = len(sys.argv) > 1
 
+node_config = {
+    "state_sync_enabled": True,
+}
+client_config_overrides = {
+    0: node_config,
+    1: node_config,
+}
+
 nodes = start_cluster(
-    2, 0, 2, None, [["minimum_validators_per_shard", 2], ["epoch_length", 10],
-                    ["block_producer_kickout_threshold", 10],
-                    ["chunk_producer_kickout_threshold", 10]],
-    {}) if nightly else start_cluster(
-        2, 0, 2, None,
-        [["num_block_producer_seats", 199],
-         ["num_block_producer_seats_per_shard", [99, 100]],
-         ["epoch_length", 10], ["block_producer_kickout_threshold", 10],
-         ["chunk_producer_kickout_threshold", 10]], {})
+    2,
+    0,
+    2,
+    None,
+    [["minimum_validators_per_shard", 2], ["epoch_length", 10],
+     ["block_producer_kickout_threshold", 10],
+     ["chunk_producer_kickout_threshold", 10]],
+    client_config_overrides,
+) if nightly else start_cluster(
+    2,
+    0,
+    2,
+    None,
+    [["num_block_producer_seats", 199],
+     ["num_block_producer_seats_per_shard", [99, 100]], ["epoch_length", 10],
+     ["block_producer_kickout_threshold", 10],
+     ["chunk_producer_kickout_threshold", 10]],
+    client_config_overrides,
+)
 logger.info('cluster started')
 
 started = time.time()

--- a/pytest/tests/sanity/state_sync3.py
+++ b/pytest/tests/sanity/state_sync3.py
@@ -20,7 +20,8 @@ consensus_config0 = {
             "secs": 0,
             "nanos": 100000000
         }
-    }
+    },
+    "state_sync_enabled": True,
 }
 consensus_config1 = {
     "consensus": {
@@ -29,7 +30,8 @@ consensus_config1 = {
             "nanos": 1000
         }
     },
-    "tracked_shards": [0]
+    "tracked_shards": [0],
+    "state_sync_enabled": True,
 }
 nodes = start_cluster(
     1, 1, 1, None,

--- a/pytest/tests/sanity/state_sync4.py
+++ b/pytest/tests/sanity/state_sync4.py
@@ -18,6 +18,9 @@ import utils
 MAX_SYNC_WAIT = 30
 EPOCH_LENGTH = 10
 
+node0_config = {
+    "state_sync_enabled": True,
+}
 node1_config = {
     "consensus": {
         "sync_step_period": {
@@ -25,12 +28,16 @@ node1_config = {
             "nanos": 100
         }
     },
-    "tracked_shards": [0]
+    "tracked_shards": [0],
+    "state_sync_enabled": True,
 }
 nodes = start_cluster(
     1, 1, 1, None,
     [["epoch_length", EPOCH_LENGTH], ["block_producer_kickout_threshold", 10],
-     ["chunk_producer_kickout_threshold", 10]], {1: node1_config})
+     ["chunk_producer_kickout_threshold", 10]], {
+         0: node0_config,
+         1: node1_config,
+     })
 time.sleep(2)
 nodes[1].kill()
 logger.info('node1 is killed')

--- a/pytest/tests/sanity/state_sync5.py
+++ b/pytest/tests/sanity/state_sync5.py
@@ -16,6 +16,9 @@ import utils
 MAX_SYNC_WAIT = 30
 EPOCH_LENGTH = 20
 
+node0_config = {
+    "state_sync_enabled": True,
+}
 node1_config = {
     "consensus": {
         "sync_step_period": {
@@ -23,12 +26,16 @@ node1_config = {
             "nanos": 200000000
         }
     },
-    "tracked_shards": [0]
+    "tracked_shards": [0],
+    "state_sync_enabled": True,
 }
 nodes = start_cluster(
     1, 1, 1, None,
     [["epoch_length", EPOCH_LENGTH], ["block_producer_kickout_threshold", 10],
-     ["chunk_producer_kickout_threshold", 10]], {1: node1_config})
+     ["chunk_producer_kickout_threshold", 10]], {
+         0: node0_config,
+         1: node1_config,
+     })
 time.sleep(2)
 nodes[1].kill()
 logger.info('node1 is killed')

--- a/pytest/tests/sanity/state_sync_fail.py
+++ b/pytest/tests/sanity/state_sync_fail.py
@@ -23,16 +23,19 @@ near_root, node_dirs = init_cluster(
      ["protocol_version", 47], ["use_production_config", True],
      ["block_producer_kickout_threshold", 80]], {
          0: {
-             "tracked_shards": [0]
+             "tracked_shards": [0],
+             "state_sync_enabled": True,
          },
          1: {
-             "tracked_shards": [0]
+             "tracked_shards": [0],
+             "state_sync_enabled": True,
          },
          2: {
              "tracked_shards": [0],
              "consensus": {
                  "block_fetch_horizon": 20,
              },
+             "state_sync_enabled": True,
          }
      })
 

--- a/pytest/tests/sanity/state_sync_late.py
+++ b/pytest/tests/sanity/state_sync_late.py
@@ -33,9 +33,18 @@ config = load_config()
 near_root, node_dirs = init_cluster(
     2, 1, 1, config,
     [["min_gas_price", 0], ["max_inflation_rate", [0, 1]], ["epoch_length", 10],
-     ["block_producer_kickout_threshold", 80]], {2: {
-         "tracked_shards": [0]
-     }})
+     ["block_producer_kickout_threshold", 80]], {
+         0: {
+             "state_sync_enabled": True,
+         },
+         1: {
+             "state_sync_enabled": True,
+         },
+         2: {
+             "tracked_shards": [0],
+             "state_sync_enabled": True,
+         },
+     })
 
 started = time.time()
 

--- a/pytest/tests/sanity/state_sync_massive.py
+++ b/pytest/tests/sanity/state_sync_massive.py
@@ -64,11 +64,16 @@ near_root, node_dirs = init_cluster(
     1, 2, 1,
     config, [["min_gas_price", 0], ["max_inflation_rate", [0, 1]],
              ["epoch_length", 300], ["block_producer_kickout_threshold", 80]], {
+                 0: {
+                     "state_sync_enabled": True,
+                 },
                  1: {
-                     "tracked_shards": [0]
+                     "tracked_shards": [0],
+                     "state_sync_enabled": True,
                  },
                  2: {
-                     "tracked_shards": [0]
+                     "tracked_shards": [0],
+                     "state_sync_enabled": True,
                  }
              })
 

--- a/pytest/tests/sanity/state_sync_massive_validator.py
+++ b/pytest/tests/sanity/state_sync_massive_validator.py
@@ -64,18 +64,21 @@ near_root, node_dirs = init_cluster(
     config, [["min_gas_price", 0], ["max_inflation_rate", [0, 1]],
              ["epoch_length", 300], ["block_producer_kickout_threshold", 0],
              ["chunk_producer_kickout_threshold", 0]], {
+                 0: {
+                     "state_sync_enabled": True,
+                 },
                  1: {
-                     "tracked_shards": [0]
+                     "tracked_shards": [0],
+                     "state_sync_enabled": True,
                  },
                  2: {
-                     "tracked_shards": [0]
+                     "tracked_shards": [0],
+                     "state_sync_enabled": True,
                  },
                  3: {
-                     "tracked_shards": [0]
+                     "tracked_shards": [0],
+                     "state_sync_enabled": True,
                  },
-                 4: {
-                     "tracked_shards": [0]
-                 }
              })
 
 logging.info("Populating genesis")

--- a/pytest/tests/sanity/state_sync_routed.py
+++ b/pytest/tests/sanity/state_sync_routed.py
@@ -32,26 +32,20 @@ START_AT_BLOCK = int(sys.argv[2])
 TIMEOUT = 150 + START_AT_BLOCK * 10
 
 config = load_config()
+node_config = {
+    "tracked_shards": [0],
+    "state_sync_enabled": True,
+}
 
 near_root, node_dirs = init_cluster(
     2, 3, 1, config,
     [["min_gas_price", 0], ["max_inflation_rate", [0, 1]], ["epoch_length", 10],
      ["block_producer_kickout_threshold", 80]], {
-         0: {
-             "tracked_shards": [0]
-         },
-         1: {
-             "tracked_shards": [0]
-         },
-         2: {
-             "tracked_shards": [0]
-         },
-         3: {
-             "tracked_shards": [0]
-         },
-         4: {
-             "tracked_shards": [0]
-         },
+         0: node_config,
+         1: node_config,
+         2: node_config,
+         3: node_config,
+         4: node_config,
      })
 
 started = time.time()


### PR DESCRIPTION
State Sync remains important functionality that needs to be tested, and which is expected to work on networks that are smaller than testnet/mainnet

TODO: Run Nayduck before merging