### PR TITLE
fix: Safely accumulate burnt gas for transaction to receipt conversion

### DIFF
--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1267,8 +1267,7 @@ impl Runtime {
                 outgoing_receipts.push(receipt);
             }
 
-            total_gas_burnt += outcome_with_id.outcome.gas_burnt;
-
+            total_gas_burnt = safe_add_gas(total_gas_burnt, outcome_with_id.outcome.gas_burnt)?;
             outcomes.push(outcome_with_id);
         }
 


### PR DESCRIPTION
First off, we should always use `safe_add_gas` when adding gas to avoid bugs and for code consistency, even in cases when we know there won't be an overflow.

Moreover, in this particular case, I actually wasn't able to strictly prove that the value never overflows as it depends on the send fees set in the config.

This is technically a protocol change. In practice, we don't expect this addition to ever overflow and if this actually happens in practice, I argue that it's better to loudly fail rather than corrupt the state of the network by acting on the overflowed value of the `total_gas_burnt`.