### PR TITLE
rename exported symbols

### DIFF
--- a/runtime/near-vm/lib/vm/src/libcalls.rs
+++ b/runtime/near-vm/lib/vm/src/libcalls.rs
@@ -51,26 +51,26 @@ use wasmer_types::{
 
 /// Implementation of f32.ceil
 #[no_mangle]
-pub extern "C" fn wasmer_vm_f32_ceil(x: f32) -> f32 {
+pub extern "C" fn near_vm_f32_ceil(x: f32) -> f32 {
     x.ceil()
 }
 
 /// Implementation of f32.floor
 #[no_mangle]
-pub extern "C" fn wasmer_vm_f32_floor(x: f32) -> f32 {
+pub extern "C" fn near_vm_f32_floor(x: f32) -> f32 {
     x.floor()
 }
 
 /// Implementation of f32.trunc
 #[no_mangle]
-pub extern "C" fn wasmer_vm_f32_trunc(x: f32) -> f32 {
+pub extern "C" fn near_vm_f32_trunc(x: f32) -> f32 {
     x.trunc()
 }
 
 /// Implementation of f32.nearest
 #[allow(clippy::float_arithmetic, clippy::float_cmp)]
 #[no_mangle]
-pub extern "C" fn wasmer_vm_f32_nearest(x: f32) -> f32 {
+pub extern "C" fn near_vm_f32_nearest(x: f32) -> f32 {
     // Rust doesn't have a nearest function, so do it manually.
     if x == 0.0 {
         // Preserve the sign of zero.
@@ -96,26 +96,26 @@ pub extern "C" fn wasmer_vm_f32_nearest(x: f32) -> f32 {
 
 /// Implementation of f64.ceil
 #[no_mangle]
-pub extern "C" fn wasmer_vm_f64_ceil(x: f64) -> f64 {
+pub extern "C" fn near_vm_f64_ceil(x: f64) -> f64 {
     x.ceil()
 }
 
 /// Implementation of f64.floor
 #[no_mangle]
-pub extern "C" fn wasmer_vm_f64_floor(x: f64) -> f64 {
+pub extern "C" fn near_vm_f64_floor(x: f64) -> f64 {
     x.floor()
 }
 
 /// Implementation of f64.trunc
 #[no_mangle]
-pub extern "C" fn wasmer_vm_f64_trunc(x: f64) -> f64 {
+pub extern "C" fn near_vm_f64_trunc(x: f64) -> f64 {
     x.trunc()
 }
 
 /// Implementation of f64.nearest
 #[allow(clippy::float_arithmetic, clippy::float_cmp)]
 #[no_mangle]
-pub extern "C" fn wasmer_vm_f64_nearest(x: f64) -> f64 {
+pub extern "C" fn near_vm_f64_nearest(x: f64) -> f64 {
     // Rust doesn't have a nearest function, so do it manually.
     if x == 0.0 {
         // Preserve the sign of zero.
@@ -145,7 +145,7 @@ pub extern "C" fn wasmer_vm_f64_nearest(x: f64) -> f64 {
 ///
 /// `vmctx` must be dereferenceable.
 #[no_mangle]
-pub unsafe extern "C" fn wasmer_vm_memory32_grow(
+pub unsafe extern "C" fn near_vm_memory32_grow(
     vmctx: *mut VMContext,
     delta: u32,
     memory_index: u32,
@@ -162,7 +162,7 @@ pub unsafe extern "C" fn wasmer_vm_memory32_grow(
 ///
 /// `vmctx` must be dereferenceable.
 #[no_mangle]
-pub unsafe extern "C" fn wasmer_vm_imported_memory32_grow(
+pub unsafe extern "C" fn near_vm_imported_memory32_grow(
     vmctx: *mut VMContext,
     delta: u32,
     memory_index: u32,
@@ -182,7 +182,7 @@ pub unsafe extern "C" fn wasmer_vm_imported_memory32_grow(
 ///
 /// `vmctx` must be dereferenceable.
 #[no_mangle]
-pub unsafe extern "C" fn wasmer_vm_memory32_size(vmctx: *mut VMContext, memory_index: u32) -> u32 {
+pub unsafe extern "C" fn near_vm_memory32_size(vmctx: *mut VMContext, memory_index: u32) -> u32 {
     let instance = (&*vmctx).instance();
     let memory_index = LocalMemoryIndex::from_u32(memory_index);
 
@@ -195,7 +195,7 @@ pub unsafe extern "C" fn wasmer_vm_memory32_size(vmctx: *mut VMContext, memory_i
 ///
 /// `vmctx` must be dereferenceable.
 #[no_mangle]
-pub unsafe extern "C" fn wasmer_vm_imported_memory32_size(
+pub unsafe extern "C" fn near_vm_imported_memory32_size(
     vmctx: *mut VMContext,
     memory_index: u32,
 ) -> u32 {
@@ -211,7 +211,7 @@ pub unsafe extern "C" fn wasmer_vm_imported_memory32_size(
 ///
 /// `vmctx` must be dereferenceable.
 #[no_mangle]
-pub unsafe extern "C" fn wasmer_vm_table_copy(
+pub unsafe extern "C" fn near_vm_table_copy(
     vmctx: *mut VMContext,
     dst_table_index: u32,
     src_table_index: u32,
@@ -238,7 +238,7 @@ pub unsafe extern "C" fn wasmer_vm_table_copy(
 ///
 /// `vmctx` must be dereferenceable.
 #[no_mangle]
-pub unsafe extern "C" fn wasmer_vm_table_init(
+pub unsafe extern "C" fn near_vm_table_init(
     vmctx: *mut VMContext,
     table_index: u32,
     elem_index: u32,
@@ -263,7 +263,7 @@ pub unsafe extern "C" fn wasmer_vm_table_init(
 ///
 /// `vmctx` must be dereferenceable.
 #[no_mangle]
-pub unsafe extern "C" fn wasmer_vm_table_fill(
+pub unsafe extern "C" fn near_vm_table_fill(
     vmctx: *mut VMContext,
     table_index: u32,
     start_idx: u32,
@@ -292,7 +292,7 @@ pub unsafe extern "C" fn wasmer_vm_table_fill(
 ///
 /// `vmctx` must be dereferenceable.
 #[no_mangle]
-pub unsafe extern "C" fn wasmer_vm_table_size(vmctx: *mut VMContext, table_index: u32) -> u32 {
+pub unsafe extern "C" fn near_vm_table_size(vmctx: *mut VMContext, table_index: u32) -> u32 {
     let instance = (&*vmctx).instance();
     let table_index = LocalTableIndex::from_u32(table_index);
 
@@ -305,7 +305,7 @@ pub unsafe extern "C" fn wasmer_vm_table_size(vmctx: *mut VMContext, table_index
 ///
 /// `vmctx` must be dereferenceable.
 #[no_mangle]
-pub unsafe extern "C" fn wasmer_vm_imported_table_size(
+pub unsafe extern "C" fn near_vm_imported_table_size(
     vmctx: *mut VMContext,
     table_index: u32,
 ) -> u32 {
@@ -321,7 +321,7 @@ pub unsafe extern "C" fn wasmer_vm_imported_table_size(
 ///
 /// `vmctx` must be dereferenceable.
 #[no_mangle]
-pub unsafe extern "C" fn wasmer_vm_table_get(
+pub unsafe extern "C" fn near_vm_table_get(
     vmctx: *mut VMContext,
     table_index: u32,
     elem_index: u32,
@@ -342,7 +342,7 @@ pub unsafe extern "C" fn wasmer_vm_table_get(
 ///
 /// `vmctx` must be dereferenceable.
 #[no_mangle]
-pub unsafe extern "C" fn wasmer_vm_imported_table_get(
+pub unsafe extern "C" fn near_vm_imported_table_get(
     vmctx: *mut VMContext,
     table_index: u32,
     elem_index: u32,
@@ -366,7 +366,7 @@ pub unsafe extern "C" fn wasmer_vm_imported_table_get(
 /// It is the caller's responsibility to increment the ref count of any ref counted
 /// type before passing it to this function.
 #[no_mangle]
-pub unsafe extern "C" fn wasmer_vm_table_set(
+pub unsafe extern "C" fn near_vm_table_set(
     vmctx: *mut VMContext,
     table_index: u32,
     elem_index: u32,
@@ -386,7 +386,7 @@ pub unsafe extern "C" fn wasmer_vm_table_set(
             raise_lib_trap(trap);
         }
     } else {
-        panic!("wasmer_vm_imported_table_set should have been called");
+        panic!("near_vm_imported_table_set should have been called");
     }
 }
 
@@ -396,7 +396,7 @@ pub unsafe extern "C" fn wasmer_vm_table_set(
 ///
 /// `vmctx` must be dereferenceable.
 #[no_mangle]
-pub unsafe extern "C" fn wasmer_vm_imported_table_set(
+pub unsafe extern "C" fn near_vm_imported_table_set(
     vmctx: *mut VMContext,
     table_index: u32,
     elem_index: u32,
@@ -421,7 +421,7 @@ pub unsafe extern "C" fn wasmer_vm_imported_table_set(
 ///
 /// `vmctx` must be dereferenceable.
 #[no_mangle]
-pub unsafe extern "C" fn wasmer_vm_table_grow(
+pub unsafe extern "C" fn near_vm_table_grow(
     vmctx: *mut VMContext,
     init_value: RawTableElement,
     delta: u32,
@@ -443,7 +443,7 @@ pub unsafe extern "C" fn wasmer_vm_table_grow(
 ///
 /// `vmctx` must be dereferenceable.
 #[no_mangle]
-pub unsafe extern "C" fn wasmer_vm_imported_table_grow(
+pub unsafe extern "C" fn near_vm_imported_table_grow(
     vmctx: *mut VMContext,
     init_value: RawTableElement,
     delta: u32,
@@ -466,10 +466,7 @@ pub unsafe extern "C" fn wasmer_vm_imported_table_grow(
 ///
 /// `vmctx` must be dereferenceable.
 #[no_mangle]
-pub unsafe extern "C" fn wasmer_vm_func_ref(
-    vmctx: *mut VMContext,
-    function_index: u32,
-) -> VMFuncRef {
+pub unsafe extern "C" fn near_vm_func_ref(vmctx: *mut VMContext, function_index: u32) -> VMFuncRef {
     let instance = (&*vmctx).instance();
     let function_index = FunctionIndex::from_u32(function_index);
 
@@ -484,7 +481,7 @@ pub unsafe extern "C" fn wasmer_vm_func_ref(
 ///
 /// This function must only be called at precise locations to prevent memory leaks.
 #[no_mangle]
-pub unsafe extern "C" fn wasmer_vm_externref_inc(externref: VMExternRef) {
+pub unsafe extern "C" fn near_vm_externref_inc(externref: VMExternRef) {
     externref.ref_clone();
 }
 
@@ -497,7 +494,7 @@ pub unsafe extern "C" fn wasmer_vm_externref_inc(externref: VMExternRef) {
 /// This function must only be called at precise locations, otherwise use-after-free
 /// and other serious memory bugs may occur.
 #[no_mangle]
-pub unsafe extern "C" fn wasmer_vm_externref_dec(mut externref: VMExternRef) {
+pub unsafe extern "C" fn near_vm_externref_dec(mut externref: VMExternRef) {
     externref.ref_drop()
 }
 
@@ -507,7 +504,7 @@ pub unsafe extern "C" fn wasmer_vm_externref_dec(mut externref: VMExternRef) {
 ///
 /// `vmctx` must be dereferenceable.
 #[no_mangle]
-pub unsafe extern "C" fn wasmer_vm_elem_drop(vmctx: *mut VMContext, elem_index: u32) {
+pub unsafe extern "C" fn near_vm_elem_drop(vmctx: *mut VMContext, elem_index: u32) {
     let elem_index = ElemIndex::from_u32(elem_index);
     let instance = (&*vmctx).instance();
     instance.elem_drop(elem_index);
@@ -519,7 +516,7 @@ pub unsafe extern "C" fn wasmer_vm_elem_drop(vmctx: *mut VMContext, elem_index: 
 ///
 /// `vmctx` must be dereferenceable.
 #[no_mangle]
-pub unsafe extern "C" fn wasmer_vm_memory32_copy(
+pub unsafe extern "C" fn near_vm_memory32_copy(
     vmctx: *mut VMContext,
     memory_index: u32,
     dst: u32,
@@ -542,7 +539,7 @@ pub unsafe extern "C" fn wasmer_vm_memory32_copy(
 ///
 /// `vmctx` must be dereferenceable.
 #[no_mangle]
-pub unsafe extern "C" fn wasmer_vm_imported_memory32_copy(
+pub unsafe extern "C" fn near_vm_imported_memory32_copy(
     vmctx: *mut VMContext,
     memory_index: u32,
     dst: u32,
@@ -565,7 +562,7 @@ pub unsafe extern "C" fn wasmer_vm_imported_memory32_copy(
 ///
 /// `vmctx` must be dereferenceable.
 #[no_mangle]
-pub unsafe extern "C" fn wasmer_vm_memory32_fill(
+pub unsafe extern "C" fn near_vm_memory32_fill(
     vmctx: *mut VMContext,
     memory_index: u32,
     dst: u32,
@@ -588,7 +585,7 @@ pub unsafe extern "C" fn wasmer_vm_memory32_fill(
 ///
 /// `vmctx` must be dereferenceable.
 #[no_mangle]
-pub unsafe extern "C" fn wasmer_vm_imported_memory32_fill(
+pub unsafe extern "C" fn near_vm_imported_memory32_fill(
     vmctx: *mut VMContext,
     memory_index: u32,
     dst: u32,
@@ -611,7 +608,7 @@ pub unsafe extern "C" fn wasmer_vm_imported_memory32_fill(
 ///
 /// `vmctx` must be dereferenceable.
 #[no_mangle]
-pub unsafe extern "C" fn wasmer_vm_memory32_init(
+pub unsafe extern "C" fn near_vm_memory32_init(
     vmctx: *mut VMContext,
     memory_index: u32,
     data_index: u32,
@@ -636,7 +633,7 @@ pub unsafe extern "C" fn wasmer_vm_memory32_init(
 ///
 /// `vmctx` must be dereferenceable.
 #[no_mangle]
-pub unsafe extern "C" fn wasmer_vm_data_drop(vmctx: *mut VMContext, data_index: u32) {
+pub unsafe extern "C" fn near_vm_data_drop(vmctx: *mut VMContext, data_index: u32) {
     let data_index = DataIndex::from_u32(data_index);
     let instance = (&*vmctx).instance();
     instance.data_drop(data_index)
@@ -649,7 +646,7 @@ pub unsafe extern "C" fn wasmer_vm_data_drop(vmctx: *mut VMContext, data_index: 
 /// Only safe to call when wasm code is on the stack, aka `wasmer_call` or
 /// `wasmer_call_trampoline` must have been previously called.
 #[no_mangle]
-pub unsafe extern "C" fn wasmer_vm_raise_trap(trap_code: TrapCode) -> ! {
+pub unsafe extern "C" fn near_vm_raise_trap(trap_code: TrapCode) -> ! {
     let trap = Trap::lib(trap_code);
     raise_lib_trap(trap)
 }
@@ -661,7 +658,7 @@ pub unsafe extern "C" fn wasmer_vm_raise_trap(trap_code: TrapCode) -> ! {
 /// This function does not follow the standard function ABI, and is called as
 /// part of the function prologue.
 #[no_mangle]
-pub static wasmer_vm_probestack: unsafe extern "C" fn() = PROBESTACK;
+pub static near_vm_probestack: unsafe extern "C" fn() = PROBESTACK;
 
 /// The name of a runtime library routine.
 ///
@@ -769,79 +766,79 @@ impl LibCall {
     /// The function pointer to a libcall
     pub fn function_pointer(self) -> usize {
         match self {
-            Self::CeilF32 => wasmer_vm_f32_ceil as usize,
-            Self::CeilF64 => wasmer_vm_f64_ceil as usize,
-            Self::FloorF32 => wasmer_vm_f32_floor as usize,
-            Self::FloorF64 => wasmer_vm_f64_floor as usize,
-            Self::NearestF32 => wasmer_vm_f32_nearest as usize,
-            Self::NearestF64 => wasmer_vm_f64_nearest as usize,
-            Self::TruncF32 => wasmer_vm_f32_trunc as usize,
-            Self::TruncF64 => wasmer_vm_f64_trunc as usize,
-            Self::Memory32Size => wasmer_vm_memory32_size as usize,
-            Self::ImportedMemory32Size => wasmer_vm_imported_memory32_size as usize,
-            Self::TableCopy => wasmer_vm_table_copy as usize,
-            Self::TableInit => wasmer_vm_table_init as usize,
-            Self::TableFill => wasmer_vm_table_fill as usize,
-            Self::TableSize => wasmer_vm_table_size as usize,
-            Self::ImportedTableSize => wasmer_vm_imported_table_size as usize,
-            Self::TableGet => wasmer_vm_table_get as usize,
-            Self::ImportedTableGet => wasmer_vm_imported_table_get as usize,
-            Self::TableSet => wasmer_vm_table_set as usize,
-            Self::ImportedTableSet => wasmer_vm_imported_table_set as usize,
-            Self::TableGrow => wasmer_vm_table_grow as usize,
-            Self::ImportedTableGrow => wasmer_vm_imported_table_grow as usize,
-            Self::FuncRef => wasmer_vm_func_ref as usize,
-            Self::ElemDrop => wasmer_vm_elem_drop as usize,
-            Self::Memory32Copy => wasmer_vm_memory32_copy as usize,
-            Self::ImportedMemory32Copy => wasmer_vm_imported_memory32_copy as usize,
-            Self::Memory32Fill => wasmer_vm_memory32_fill as usize,
-            Self::ImportedMemory32Fill => wasmer_vm_memory32_fill as usize,
-            Self::Memory32Init => wasmer_vm_memory32_init as usize,
-            Self::DataDrop => wasmer_vm_data_drop as usize,
-            Self::Probestack => wasmer_vm_probestack as usize,
-            Self::RaiseTrap => wasmer_vm_raise_trap as usize,
+            Self::CeilF32 => near_vm_f32_ceil as usize,
+            Self::CeilF64 => near_vm_f64_ceil as usize,
+            Self::FloorF32 => near_vm_f32_floor as usize,
+            Self::FloorF64 => near_vm_f64_floor as usize,
+            Self::NearestF32 => near_vm_f32_nearest as usize,
+            Self::NearestF64 => near_vm_f64_nearest as usize,
+            Self::TruncF32 => near_vm_f32_trunc as usize,
+            Self::TruncF64 => near_vm_f64_trunc as usize,
+            Self::Memory32Size => near_vm_memory32_size as usize,
+            Self::ImportedMemory32Size => near_vm_imported_memory32_size as usize,
+            Self::TableCopy => near_vm_table_copy as usize,
+            Self::TableInit => near_vm_table_init as usize,
+            Self::TableFill => near_vm_table_fill as usize,
+            Self::TableSize => near_vm_table_size as usize,
+            Self::ImportedTableSize => near_vm_imported_table_size as usize,
+            Self::TableGet => near_vm_table_get as usize,
+            Self::ImportedTableGet => near_vm_imported_table_get as usize,
+            Self::TableSet => near_vm_table_set as usize,
+            Self::ImportedTableSet => near_vm_imported_table_set as usize,
+            Self::TableGrow => near_vm_table_grow as usize,
+            Self::ImportedTableGrow => near_vm_imported_table_grow as usize,
+            Self::FuncRef => near_vm_func_ref as usize,
+            Self::ElemDrop => near_vm_elem_drop as usize,
+            Self::Memory32Copy => near_vm_memory32_copy as usize,
+            Self::ImportedMemory32Copy => near_vm_imported_memory32_copy as usize,
+            Self::Memory32Fill => near_vm_memory32_fill as usize,
+            Self::ImportedMemory32Fill => near_vm_memory32_fill as usize,
+            Self::Memory32Init => near_vm_memory32_init as usize,
+            Self::DataDrop => near_vm_data_drop as usize,
+            Self::Probestack => near_vm_probestack as usize,
+            Self::RaiseTrap => near_vm_raise_trap as usize,
         }
     }
 
     /// Return the function name associated to the libcall.
     pub fn to_function_name(&self) -> &str {
         match self {
-            Self::CeilF32 => "wasmer_vm_f32_ceil",
-            Self::CeilF64 => "wasmer_vm_f64_ceil",
-            Self::FloorF32 => "wasmer_vm_f32_floor",
-            Self::FloorF64 => "wasmer_vm_f64_floor",
-            Self::NearestF32 => "wasmer_vm_f32_nearest",
-            Self::NearestF64 => "wasmer_vm_f64_nearest",
-            Self::TruncF32 => "wasmer_vm_f32_trunc",
-            Self::TruncF64 => "wasmer_vm_f64_trunc",
-            Self::Memory32Size => "wasmer_vm_memory32_size",
-            Self::ImportedMemory32Size => "wasmer_vm_imported_memory32_size",
-            Self::TableCopy => "wasmer_vm_table_copy",
-            Self::TableInit => "wasmer_vm_table_init",
-            Self::TableFill => "wasmer_vm_table_fill",
-            Self::TableSize => "wasmer_vm_table_size",
-            Self::ImportedTableSize => "wasmer_vm_imported_table_size",
-            Self::TableGet => "wasmer_vm_table_get",
-            Self::ImportedTableGet => "wasmer_vm_imported_table_get",
-            Self::TableSet => "wasmer_vm_table_set",
-            Self::ImportedTableSet => "wasmer_vm_imported_table_set",
-            Self::TableGrow => "wasmer_vm_table_grow",
-            Self::ImportedTableGrow => "wasmer_vm_imported_table_grow",
-            Self::FuncRef => "wasmer_vm_func_ref",
-            Self::ElemDrop => "wasmer_vm_elem_drop",
-            Self::Memory32Copy => "wasmer_vm_memory32_copy",
-            Self::ImportedMemory32Copy => "wasmer_vm_imported_memory32_copy",
-            Self::Memory32Fill => "wasmer_vm_memory32_fill",
-            Self::ImportedMemory32Fill => "wasmer_vm_imported_memory32_fill",
-            Self::Memory32Init => "wasmer_vm_memory32_init",
-            Self::DataDrop => "wasmer_vm_data_drop",
-            Self::RaiseTrap => "wasmer_vm_raise_trap",
+            Self::CeilF32 => "near_vm_f32_ceil",
+            Self::CeilF64 => "near_vm_f64_ceil",
+            Self::FloorF32 => "near_vm_f32_floor",
+            Self::FloorF64 => "near_vm_f64_floor",
+            Self::NearestF32 => "near_vm_f32_nearest",
+            Self::NearestF64 => "near_vm_f64_nearest",
+            Self::TruncF32 => "near_vm_f32_trunc",
+            Self::TruncF64 => "near_vm_f64_trunc",
+            Self::Memory32Size => "near_vm_memory32_size",
+            Self::ImportedMemory32Size => "near_vm_imported_memory32_size",
+            Self::TableCopy => "near_vm_table_copy",
+            Self::TableInit => "near_vm_table_init",
+            Self::TableFill => "near_vm_table_fill",
+            Self::TableSize => "near_vm_table_size",
+            Self::ImportedTableSize => "near_vm_imported_table_size",
+            Self::TableGet => "near_vm_table_get",
+            Self::ImportedTableGet => "near_vm_imported_table_get",
+            Self::TableSet => "near_vm_table_set",
+            Self::ImportedTableSet => "near_vm_imported_table_set",
+            Self::TableGrow => "near_vm_table_grow",
+            Self::ImportedTableGrow => "near_vm_imported_table_grow",
+            Self::FuncRef => "near_vm_func_ref",
+            Self::ElemDrop => "near_vm_elem_drop",
+            Self::Memory32Copy => "near_vm_memory32_copy",
+            Self::ImportedMemory32Copy => "near_vm_imported_memory32_copy",
+            Self::Memory32Fill => "near_vm_memory32_fill",
+            Self::ImportedMemory32Fill => "near_vm_imported_memory32_fill",
+            Self::Memory32Init => "near_vm_memory32_init",
+            Self::DataDrop => "near_vm_data_drop",
+            Self::RaiseTrap => "near_vm_raise_trap",
             // We have to do this because macOS requires a leading `_` and it's not
             // a normal function, it's a static variable, so we have to do it manually.
             #[cfg(target_vendor = "apple")]
-            Self::Probestack => "_wasmer_vm_probestack",
+            Self::Probestack => "_near_vm_probestack",
             #[cfg(not(target_vendor = "apple"))]
-            Self::Probestack => "wasmer_vm_probestack",
+            Self::Probestack => "near_vm_probestack",
         }
     }
 }

--- a/runtime/near-vm/lib/vm/src/vmcontext.rs
+++ b/runtime/near-vm/lib/vm/src/vmcontext.rs
@@ -989,61 +989,61 @@ impl VMBuiltinFunctionsArray {
         let mut ptrs = [0; Self::len()];
 
         ptrs[VMBuiltinFunctionIndex::get_memory32_grow_index().index() as usize] =
-            wasmer_vm_memory32_grow as usize;
+            near_vm_memory32_grow as usize;
         ptrs[VMBuiltinFunctionIndex::get_imported_memory32_grow_index().index() as usize] =
-            wasmer_vm_imported_memory32_grow as usize;
+            near_vm_imported_memory32_grow as usize;
 
         ptrs[VMBuiltinFunctionIndex::get_memory32_size_index().index() as usize] =
-            wasmer_vm_memory32_size as usize;
+            near_vm_memory32_size as usize;
         ptrs[VMBuiltinFunctionIndex::get_imported_memory32_size_index().index() as usize] =
-            wasmer_vm_imported_memory32_size as usize;
+            near_vm_imported_memory32_size as usize;
 
         ptrs[VMBuiltinFunctionIndex::get_table_copy_index().index() as usize] =
-            wasmer_vm_table_copy as usize;
+            near_vm_table_copy as usize;
 
         ptrs[VMBuiltinFunctionIndex::get_table_init_index().index() as usize] =
-            wasmer_vm_table_init as usize;
+            near_vm_table_init as usize;
         ptrs[VMBuiltinFunctionIndex::get_elem_drop_index().index() as usize] =
-            wasmer_vm_elem_drop as usize;
+            near_vm_elem_drop as usize;
 
         ptrs[VMBuiltinFunctionIndex::get_memory_copy_index().index() as usize] =
-            wasmer_vm_memory32_copy as usize;
+            near_vm_memory32_copy as usize;
         ptrs[VMBuiltinFunctionIndex::get_imported_memory_copy_index().index() as usize] =
-            wasmer_vm_imported_memory32_copy as usize;
+            near_vm_imported_memory32_copy as usize;
         ptrs[VMBuiltinFunctionIndex::get_memory_fill_index().index() as usize] =
-            wasmer_vm_memory32_fill as usize;
+            near_vm_memory32_fill as usize;
         ptrs[VMBuiltinFunctionIndex::get_imported_memory_fill_index().index() as usize] =
-            wasmer_vm_imported_memory32_fill as usize;
+            near_vm_imported_memory32_fill as usize;
         ptrs[VMBuiltinFunctionIndex::get_memory_init_index().index() as usize] =
-            wasmer_vm_memory32_init as usize;
+            near_vm_memory32_init as usize;
         ptrs[VMBuiltinFunctionIndex::get_data_drop_index().index() as usize] =
-            wasmer_vm_data_drop as usize;
+            near_vm_data_drop as usize;
         ptrs[VMBuiltinFunctionIndex::get_raise_trap_index().index() as usize] =
-            wasmer_vm_raise_trap as usize;
+            near_vm_raise_trap as usize;
         ptrs[VMBuiltinFunctionIndex::get_table_size_index().index() as usize] =
-            wasmer_vm_table_size as usize;
+            near_vm_table_size as usize;
         ptrs[VMBuiltinFunctionIndex::get_imported_table_size_index().index() as usize] =
-            wasmer_vm_imported_table_size as usize;
+            near_vm_imported_table_size as usize;
         ptrs[VMBuiltinFunctionIndex::get_table_grow_index().index() as usize] =
-            wasmer_vm_table_grow as usize;
+            near_vm_table_grow as usize;
         ptrs[VMBuiltinFunctionIndex::get_imported_table_grow_index().index() as usize] =
-            wasmer_vm_imported_table_grow as usize;
+            near_vm_imported_table_grow as usize;
         ptrs[VMBuiltinFunctionIndex::get_table_get_index().index() as usize] =
-            wasmer_vm_table_get as usize;
+            near_vm_table_get as usize;
         ptrs[VMBuiltinFunctionIndex::get_imported_table_get_index().index() as usize] =
-            wasmer_vm_imported_table_get as usize;
+            near_vm_imported_table_get as usize;
         ptrs[VMBuiltinFunctionIndex::get_table_set_index().index() as usize] =
-            wasmer_vm_table_set as usize;
+            near_vm_table_set as usize;
         ptrs[VMBuiltinFunctionIndex::get_imported_table_set_index().index() as usize] =
-            wasmer_vm_imported_table_set as usize;
+            near_vm_imported_table_set as usize;
         ptrs[VMBuiltinFunctionIndex::get_func_ref_index().index() as usize] =
-            wasmer_vm_func_ref as usize;
+            near_vm_func_ref as usize;
         ptrs[VMBuiltinFunctionIndex::get_table_fill_index().index() as usize] =
-            wasmer_vm_table_fill as usize;
+            near_vm_table_fill as usize;
         ptrs[VMBuiltinFunctionIndex::get_externref_inc_index().index() as usize] =
-            wasmer_vm_externref_inc as usize;
+            near_vm_externref_inc as usize;
         ptrs[VMBuiltinFunctionIndex::get_externref_dec_index().index() as usize] =
-            wasmer_vm_externref_dec as usize;
+            near_vm_externref_dec as usize;
 
         debug_assert!(ptrs.iter().cloned().all(|p| p != 0));
 


### PR DESCRIPTION
This should avoid conflicts between near-vm and wasmer2

Another carry-over from #8323 