### PR TITLE
fix: fuzz target builder CI

### DIFF
--- a/nightly/fuzz.toml
+++ b/nightly/fuzz.toml
@@ -50,21 +50,3 @@ flags = ["-len_control=0", "-prefer_small=0", "-max_len=4000000"]
 # runner = "fuzz_target_1"
 # weight = 0
 # flags = ["-len_control=0", "-prefer_small=0", "-max_len=4000000"]
-
-[[target]]
-crate = "runtime/near-vm/fuzz"
-runner = "equivalence_universal"
-weight = 0
-flags = []
-
-[[target]]
-crate = "runtime/near-vm/fuzz"
-runner = "metering"
-weight = 0
-flags = []
-
-[[target]]
-crate = "runtime/near-vm/fuzz"
-runner = "universal_singlepass"
-weight = 0
-flags = []


### PR DESCRIPTION
GA workflow is failing past few days with:
`FileNotFoundError: [Errno 2] No such file or directory: 'runtime/near-vm/fuzz'`

This will fix it.

No-op for anything else