### PR TITLE
Fix debug rpc ports localnet near/nearcore#8583

### DIFF
--- a/chain/jsonrpc/res/network_info.js
+++ b/chain/jsonrpc/res/network_info.js
@@ -38,10 +38,23 @@ function computeTraffic(bytes_received, bytes_sent) {
     return "⬇ " + convertBps(bytes_received) + "<br>⬆ " + convertBps(bytes_sent);
 }
 
-function add_debug_port_link(peer_addr) {
+function add_debug_port_link(peer_network_addr) {
+    // Assume rpc port is always 3030 and network port is always 24567 for the first neard process on a machine
+    // Then, each subsequence neard process on the same machine will are strict increments of a fix constant from both ports
+    // peer_num should only be > 0 for nearup's localnet and 0 otherwise
+    // Reference to nearup's localnet port assumptions
+    // https://github.com/near/nearup/blob/0b9a7b60236f3164dd32677b6fa58c531a586200/nearuplib/localnet.py#L93-L94
+    // Reference to mainnet's assumption of network port
+    // https://github.com/near/nearcore/blob/e61da3d26e3614d3f6c1b669d31fca7a12d55296/chain/network/src/raw/connection.rs#L153
+    rpc_port_assumption = 3030
+    network_port_assumption = 24567
+    peer_network_port = peer_network_addr.split(":").pop()
+    peer_num = peer_network_port - network_port_assumption
+    peer_rpc_port = rpc_port_assumption + peer_num;
+    peer_rpc_address = "http://" + peer_network_addr.replace(/:.*/, ":") + peer_rpc_port + "/debug"
     return $('<a>', {
-        href: "http://" + peer_addr.replace(/:.*/, ":3030/debug"),
-        text: peer_addr
+        href: peer_rpc_address,
+        text: peer_network_addr
     });
 }
 

--- a/tools/debug-ui/src/utils.tsx
+++ b/tools/debug-ui/src/utils.tsx
@@ -45,8 +45,22 @@ export function formatTraffic(bytes_received: number, bytes_sent: number): React
     );
 }
 
-export function addDebugPortLink(peer_addr: string): ReactElement {
-    return <a href={'http://localhost:3000/' + peer_addr.replace(/:.*/, '/')}>{peer_addr}</a>;
+export function addDebugPortLink(peer_network_addr: string): ReactElement {
+    // Assume rpc port is always 3030 and network port is always 24567 for the first neard process on a machine
+    // Then, each subsequence neard process on the same machine will are strict increments of a fix constant from both ports
+    // peer_num should only be > 0 for nearup's localnet and 0 otherwise
+    // Reference to nearup's localnet port assumptions
+    // https://github.com/near/nearup/blob/0b9a7b60236f3164dd32677b6fa58c531a586200/nearuplib/localnet.py#L93-L94
+    // Reference to mainnet's assumption of network port
+    // https://github.com/near/nearcore/blob/e61da3d26e3614d3f6c1b669d31fca7a12d55296/chain/network/src/raw/connection.rs#L153
+    const rpc_port_assumption = 3030;
+    const network_port_assumption = 24567;
+    const peer_network_port = parseInt(peer_network_addr.split(':').pop() || '24567');
+    const peer_num = peer_network_port - network_port_assumption;
+    const peer_rpc_port = rpc_port_assumption + peer_num;
+    const peer_rpc_address =
+        peer_network_addr.replace(/:.*/, ':') + peer_rpc_port.toString() + '/debug';
+    return <a href={'http://localhost:3000/' + peer_rpc_address}>{peer_network_addr}</a>;
 }
 
 export function toHumanTime(seconds: number): string {


### PR DESCRIPTION
<h1> Problem </h1>
This is only an issue on localnet and not production (mainnet, testnet) Hence, prefer having this fix within the frontend webserver itself. Alternatively, could have an optional approach for nodes to fetch rpc address from each peer. However, this introduces both complexity and additional bandwidth that will only be useful for localnet testing.

<h1> Solution </h1>
The code currently uses the assumption on the ports that the nodes will be started in the ranges:
- Network address : 24567 + [0, numNodes - 1]
- RPC address: 3030 + [0, numNodes - 1]
- Reference: https://github.com/near/nearup/blob/0b9a7b60236f3164dd32677b6fa58c531a586200/nearuplib/localnet.py#L93-L94 If this assumption is ever violated in future,
only the debug pages would break and can easily be fixed without affecting the actual core network itself.

<h1> Testing </h1>

```
cd nearcore
make debug
nearup run localnet --binary-path ~/Github/near/nearcore/target/debug/
open http://localhost:3030/debug

cd nearcore/tools/debug-ui
npm install
npm start
open http://localhost:3000/localhost:3030/cluster
```