### PR TITLE
chore: update changelog with 1.32.1 and 1.32.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@
 * Node can restart if State Sync gets interrupted. [#8732](https://github.com/near/nearcore/pull/8732)
 * Merged two `neard view-state` commands: `apply-state-parts` and `dump-state-parts` into a single `state-parts` command. [#8739](https://github.com/near/nearcore/pull/8739)
 
+## 1.32.2
+
+### Fixes
+* Fix: rosetta zero balance accounts [#8833](https://github.com/near/nearcore/pull/8833)
+
+## 1.32.1
+
+### Fixes
+* Fix vulnerabilities in block outcome root validation and total supply validation [#8790](https://github.com/near/nearcore/pull/8790)
+
 ## 1.32.0
 
 ### Protocol Changes


### PR DESCRIPTION
Not entirely clear if we want minor releases tracked in changelog, do we? If so here is the PR for 1.32.1 and 1.32.2. 