### PR TITLE
docs: mention intrinsification of `gas` host fn

### DIFF
--- a/runtime/near-vm-logic/src/gas_counter.rs
+++ b/runtime/near-vm-logic/src/gas_counter.rs
@@ -25,7 +25,8 @@ pub fn with_ext_cost_counter(f: impl FnOnce(&mut HashMap<ExtCosts, u64>)) {
 
 type Result<T> = ::std::result::Result<T, VMLogicError>;
 
-/// Fast gas counter with very simple structure, could be exposed to compiled code in the VM.
+/// Fast gas counter with very simple structure, could be exposed to compiled code in the VM. For
+/// instance by intrinsifying host functions responsible for gas metering.
 #[repr(C)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FastGasCounter {

--- a/runtime/near-vm-logic/src/logic.rs
+++ b/runtime/near-vm-logic/src/logic.rs
@@ -1221,6 +1221,8 @@ impl<'a> VMLogic<'a> {
     ///
     /// For now it is consuming the gas for `gas` opcodes. When we switch to finite-wasm it’ll
     /// be made to be a no-op.
+    ///
+    /// This function might be intrinsified.
     pub fn gas_seen_from_wasm(&mut self, gas: u32) -> Result<()> {
         self.gas_opcodes(gas)
     }

--- a/runtime/near-vm/lib/types/src/types.rs
+++ b/runtime/near-vm/lib/types/src/types.rs
@@ -537,7 +537,9 @@ impl<T> ExportType<T> {
     }
 }
 
-/// Fast gas counter with very simple structure, could be exposed to compiled code in the VM.
+/// Fast gas counter with very simple structure, could be exposed to compiled code in the VM. For
+/// instance by intrinsifying host functions responsible for gas metering.
+
 #[repr(C)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FastGasCounter {


### PR DESCRIPTION
## Summary
This PR proposes some small additions to documentation that could aid to understand the purpose and usage of `FastGasCounter`.

## Motivation
https://github.com/near/nearcore/blob/24c4f4981c18edc003413dfc2c3fa4a0b98a810f/runtime/near-vm-logic/src/gas_counter.rs#L28

A hint on how this exposure is generated would have been helpful for me. In particular since the comment below may raise the question ‘Why have `FastGasCounter` when gas metering is done on the host?’. I think knowing about the (potential) intrinsification of the `gas` host function helps to clarify this.

https://github.com/near/nearcore/blob/83b1f80313ec982a6e16a1941d07701e46b7fc35/runtime/near-vm-runner/src/instrument/gas/mod.rs#L396-L402