### PR TITLE
feature: Stabilize Compute Costs

### DIFF
--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -51,14 +51,12 @@ protocol_feature_fix_staking_threshold = []
 protocol_feature_fix_contract_loading_cost = []
 protocol_feature_reject_blocks_with_outdated_protocol_version = []
 protocol_feature_flat_state = []
-protocol_feature_compute_costs = []
 nightly = [
   "nightly_protocol",
   "protocol_feature_fix_staking_threshold",
   "protocol_feature_fix_contract_loading_cost",
   "protocol_feature_reject_blocks_with_outdated_protocol_version",
   "protocol_feature_flat_state",
-  "protocol_feature_compute_costs",
 ]
 
 nightly_protocol = []

--- a/core/primitives/src/runtime/parameter_table.rs
+++ b/core/primitives/src/runtime/parameter_table.rs
@@ -96,10 +96,6 @@ impl TryFrom<&ParameterValue> for ParameterCost {
     fn try_from(value: &ParameterValue) -> Result<Self, Self::Error> {
         match value {
             ParameterValue::ParameterCost { gas, compute } => {
-                if !cfg!(feature = "protocol_feature_compute_costs") {
-                    assert_eq!(compute, gas, "Compute cost must match gas cost");
-                }
-
                 Ok(ParameterCost { gas: *gas, compute: *compute })
             }
             // If not specified, compute costs default to gas costs.

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -139,6 +139,12 @@ pub enum ProtocolFeature {
     /// Meta Transaction NEP-366: https://github.com/near/NEPs/blob/master/neps/nep-0366.md
     DelegateAction,
 
+    /// Decouple compute and gas costs of operations to safely limit the compute time it takes to
+    /// process the chunk.
+    ///
+    /// Compute Costs NET-455: https://github.com/near/NEPs/blob/master/neps/nep-0455.md
+    ComputeCosts,
+
     /// In case not all validator seats are occupied our algorithm provide incorrect minimal seat
     /// price - it reports as alpha * sum_stake instead of alpha * sum_stake / (1 - alpha), where
     /// alpha is min stake ratio
@@ -152,8 +158,6 @@ pub enum ProtocolFeature {
     RejectBlocksWithOutdatedProtocolVersions,
     #[cfg(feature = "protocol_feature_flat_state")]
     FlatStorageReads,
-    #[cfg(feature = "protocol_feature_compute_costs")]
-    ComputeCosts,
 }
 
 /// Both, outgoing and incoming tcp connections to peers, will be rejected if `peer's`
@@ -238,6 +242,7 @@ impl ProtocolFeature {
             ProtocolFeature::Ed25519Verify
             | ProtocolFeature::ZeroBalanceAccount
             | ProtocolFeature::DelegateAction => 59,
+            ProtocolFeature::ComputeCosts => 61,
 
             // Nightly features
             #[cfg(feature = "protocol_feature_fix_staking_threshold")]
@@ -248,8 +253,6 @@ impl ProtocolFeature {
             ProtocolFeature::RejectBlocksWithOutdatedProtocolVersions => 132,
             #[cfg(feature = "protocol_feature_flat_state")]
             ProtocolFeature::FlatStorageReads => 135,
-            #[cfg(feature = "protocol_feature_compute_costs")]
-            ProtocolFeature::ComputeCosts => 136,
         }
     }
 }

--- a/runtime/runtime/Cargo.toml
+++ b/runtime/runtime/Cargo.toml
@@ -34,7 +34,6 @@ near-vm-runner.workspace = true
 default = []
 dump_errors_schema = ["near-vm-errors/dump_errors_schema"]
 protocol_feature_flat_state = ["near-store/protocol_feature_flat_state", "near-vm-logic/protocol_feature_flat_state"]
-protocol_feature_compute_costs = ["near-primitives/protocol_feature_compute_costs"]
 nightly_protocol = ["near-primitives/nightly_protocol"]
 no_cpu_compatibility_checks = ["near-vm-runner/no_cpu_compatibility_checks"]
 


### PR DESCRIPTION
Remove the compile time feature "protocol_feature_compute_costs" and replace all checks in the code to look at the current protocol version instead.