### PR TITLE
chore: remove duplicate dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,14 +82,14 @@ dependencies = [
  "http",
  "httparse",
  "httpdate",
- "itoa 1.0.2",
+ "itoa",
  "language-tags",
  "local-channel",
  "mime",
  "percent-encoding",
  "pin-project-lite",
  "rand 0.8.5",
- "sha1 0.10.5",
+ "sha1",
  "smallvec",
  "tracing",
  "zstd",
@@ -212,7 +212,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "itoa 1.0.2",
+ "itoa",
  "language-tags",
  "log",
  "mime",
@@ -453,7 +453,7 @@ dependencies = [
  "futures-util",
  "h2",
  "http",
- "itoa 1.0.2",
+ "itoa",
  "log",
  "mime",
  "openssl",
@@ -842,18 +842,6 @@ name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
-
-[[package]]
-name = "bstr"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
-dependencies = [
- "lazy_static",
- "memchr",
- "regex-automata",
- "serde",
-]
 
 [[package]]
 name = "bumpalo"
@@ -1522,13 +1510,12 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.1.6"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+checksum = "0b015497079b9a9d69c02ad25de6c0a6edef051ea6360a327d0bd05802ef64ad"
 dependencies = [
- "bstr",
  "csv-core",
- "itoa 0.4.8",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -1708,12 +1695,6 @@ name = "dlv-list"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
-
-[[package]]
-name = "dtoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
 name = "dynasm"
@@ -2346,7 +2327,7 @@ checksum = "ff8670570af52249509a86f5e3e18a08c60b177071826898fde8997cf5f6bfbb"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.2",
+ "itoa",
 ]
 
 [[package]]
@@ -2387,7 +2368,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.2",
+ "itoa",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2602,12 +2583,6 @@ checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
-
-[[package]]
-name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
@@ -3149,7 +3124,7 @@ dependencies = [
  "enum-map",
  "insta",
  "itertools",
- "itoa 1.0.2",
+ "itoa",
  "lru",
  "near-cache",
  "near-chain-configs",
@@ -3653,7 +3628,7 @@ dependencies = [
  "atty",
  "bencher",
  "clap 3.1.18",
- "itoa 1.0.2",
+ "itoa",
  "near-crypto",
  "near-primitives-core",
  "once_cell",
@@ -3889,7 +3864,7 @@ dependencies = [
  "fs2",
  "insta",
  "itertools",
- "itoa 1.0.2",
+ "itoa",
  "lru",
  "near-crypto",
  "near-o11y",
@@ -5234,16 +5209,15 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.21.5"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a80b5f38d7f5a020856a0e16e40a9cfabf88ae8f0e4c2dcd8a3114c1e470852"
+checksum = "3ea8c51b5dc1d8e5fd3350ec8167f464ec0995e79f2e90a075b63371500d557f"
 dependencies = [
- "async-trait",
  "combine",
- "dtoa",
- "itoa 0.4.8",
+ "itoa",
  "percent-encoding",
- "sha1 0.6.1",
+ "ryu",
+ "sha1_smol",
  "url",
 ]
 
@@ -5714,9 +5688,9 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "secp256k1"
-version = "0.24.3"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1629c9c557ef9b293568b338dddfc8208c98a18c59d722a9d53f859d9c9b62"
+checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
  "rand 0.8.5",
  "secp256k1-sys",
@@ -5724,9 +5698,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.6.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7058dc8eaf3f2810d7828680320acda0b25a288f6d288e19278e249bbf74226b"
+checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
 dependencies = [
  "cc",
 ]
@@ -5855,7 +5829,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
  "indexmap",
- "itoa 1.0.2",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -5878,7 +5852,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.2",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -5890,19 +5864,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92b5b431e8907b50339b51223b97d102db8d987ced36f6e4d03621db9316c834"
 dependencies = [
  "indexmap",
- "itoa 1.0.2",
+ "itoa",
  "ryu",
  "serde",
  "unsafe-libyaml",
-]
-
-[[package]]
-name = "sha1"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
-dependencies = [
- "sha1_smol",
 ]
 
 [[package]]
@@ -6428,7 +6393,7 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
 dependencies = [
- "itoa 1.0.2",
+ "itoa",
  "libc",
  "num_threads",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ cpu-time = "1.0"
 criterion = { version = "0.3.5", default_features = false, features = ["html_reports", "cargo_bench_support"] }
 crossbeam = "0.8"
 crossbeam-channel = "0.5"
-csv = "1.1.1"
+csv = "1.2.1"
 curve25519-dalek = "3"
 delay-detector = { path = "tools/delay-detector" }
 derive-enum-from-into = "0.1.1"
@@ -245,7 +245,7 @@ rand_core = "0.5"
 rand_hc = "0.3.1"
 rand_xorshift = "0.3"
 rayon = "1.5"
-redis = "0.21.5"
+redis = "0.23.0"
 reed-solomon-erasure = "4"
 regex = "1.7.1"
 region = "3.0"
@@ -258,7 +258,7 @@ runtime-tester = { path = "test-utils/runtime-tester" }
 rust-s3 = { version = "0.32.3", features = ["blocking"] }
 rustc-demangle = "0.1"
 rusqlite = {version = "0.27.0", features = ["bundled", "chrono", "functions"] }
-secp256k1 = { version = "0.24", features = ["recovery", "rand-std"] }
+secp256k1 = { version = "0.27.0", features = ["recovery", "rand-std"] }
 semver = "1.0.4"
 serde = { version = "1.0.136", features = ["alloc", "derive", "rc"] }
 serde_ignored = "0.1"

--- a/deny.toml
+++ b/deny.toml
@@ -71,9 +71,6 @@ skip = [
     # finite-wasm
     { name = "wasmparser", version = "=0.99.0" },
 
-    # chain and param estimator
-    { name = "num-rational", version = "=0.3.2" },
-
     # wasmer 0.17.x
     { name = "parking_lot", version = "=0.10.2" },
     { name = "parking_lot_core", version = "=0.7.2" },
@@ -113,9 +110,6 @@ skip = [
     # paperclip-macros, strum_macros, walrus-macro depend on this while clap3.1.6 uses heck=0.4.0
     { name = "heck", version = "=0.3.3" },
 
-    # actix-http depends on an old version
-    { name = "itoa", version = "=0.4.8" },
-
     # Wasmer requires a newer version and the rest of the ecosystem hasn't caught up yet.
     { name = "hashbrown", version = "0.11.0" },
 
@@ -124,9 +118,6 @@ skip = [
 
     # opentelemetry-otlp depends on an old version of tonic which depends on an old version of tokio-util
     { name = "tokio-util", version = "=0.6.10" },
-
-    # redis we’re using uses ancient sha
-    { name = "sha1", version = "=0.6.1" },
 
     # rust-s3 is using an old version of smartstring
     { name = "smartstring", version = "=0.2.10" },


### PR DESCRIPTION
Updating a couple of dependencies allows to remove old duplicates.
None of the "breaking" API changes affect us.

redis 0.21.5 -> 0.23 gets rid of an old "sha1"
csv 1.1.1 -> 1.2.1 gets rid of an old "itoa"

Also, remove unnecessary exception for "num-rational".
And while I was already going through dependencies and changelogs,
also update "secp256k1" to the latest version.