### PR TITLE
feature: Account for gas running over the limit

### DIFF
--- a/core/primitives-core/src/profile.rs
+++ b/core/primitives-core/src/profile.rs
@@ -123,9 +123,9 @@ impl ProfileDataV3 {
                 }
                 // If the `value` is non-zero, the gas cost also must be non-zero.
                 debug_assert!(key.gas(ext_costs_config) != 0);
-                debug_assert!(*value % key.gas(ext_costs_config) == 0);
                 // TODO(#8795): Consider storing the count of calls and avoid division here.
-                (*value / key.gas(ext_costs_config)).saturating_mul(key.compute(ext_costs_config))
+                ((*value as u128).saturating_mul(key.compute(ext_costs_config) as u128)
+                    / (key.gas(ext_costs_config) as u128)) as u64
             })
             .fold(0, Compute::saturating_add);
 

--- a/core/primitives-core/src/profile.rs
+++ b/core/primitives-core/src/profile.rs
@@ -123,7 +123,6 @@ impl ProfileDataV3 {
                 }
                 // If the `value` is non-zero, the gas cost also must be non-zero.
                 debug_assert!(key.gas(ext_costs_config) != 0);
-                // TODO(#8795): Consider storing the count of calls and avoid division here.
                 ((*value as u128).saturating_mul(key.compute(ext_costs_config) as u128)
                     / (key.gas(ext_costs_config) as u128)) as u64
             })


### PR DESCRIPTION
This is a solution to https://github.com/near/nearcore/issues/8908.

Now when we try to prepay the gas for some operation and run into the gas limit, both the gas and compute usage for that operation will be paid partially, where compute cost is calculated as `gas_burnt / gas_cost * compute_cost`.