### PR TITLE
[Runtime Epoch Split] (6/n) Refactor state-viewer away from RuntimeWithEpochManagerAdapter.

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3886,7 +3886,7 @@ impl Chain {
                     let is_first_block_with_chunk_of_version =
                         check_if_block_is_first_with_chunk_of_version(
                             self.store(),
-                            self.runtime_adapter.as_ref(),
+                            self.runtime_adapter.epoch_manager_adapter(),
                             prev_block.hash(),
                             shard_id,
                         )?;
@@ -5380,7 +5380,7 @@ impl<'a> ChainUpdate<'a> {
         let gas_limit = chunk_header.gas_limit();
         let is_first_block_with_chunk_of_version = check_if_block_is_first_with_chunk_of_version(
             &mut self.chain_store_update,
-            self.runtime_adapter.as_ref(),
+            self.runtime_adapter.epoch_manager_adapter(),
             &chunk_header.prev_block_hash(),
             shard_id,
         )?;

--- a/chain/chain/src/migrations.rs
+++ b/chain/chain/src/migrations.rs
@@ -1,18 +1,18 @@
 use crate::store::ChainStoreAccess;
-use crate::types::RuntimeWithEpochManagerAdapter;
 use near_chain_primitives::error::Error;
+use near_epoch_manager::EpochManagerAdapter;
 use near_primitives::hash::CryptoHash;
 use near_primitives::types::ShardId;
 
 /// Check that epoch of block with given prev_block_hash is the first one with current protocol version.
 fn is_first_epoch_with_protocol_version(
-    runtime_adapter: &dyn RuntimeWithEpochManagerAdapter,
+    epoch_manager: &dyn EpochManagerAdapter,
     prev_block_hash: &CryptoHash,
 ) -> Result<bool, Error> {
-    let prev_epoch_id = runtime_adapter.get_prev_epoch_id_from_prev_block(prev_block_hash)?;
-    let epoch_id = runtime_adapter.get_epoch_id_from_prev_block(prev_block_hash)?;
-    let protocol_version = runtime_adapter.get_epoch_protocol_version(&epoch_id)?;
-    let prev_epoch_protocol_version = runtime_adapter.get_epoch_protocol_version(&prev_epoch_id)?;
+    let prev_epoch_id = epoch_manager.get_prev_epoch_id_from_prev_block(prev_block_hash)?;
+    let epoch_id = epoch_manager.get_epoch_id_from_prev_block(prev_block_hash)?;
+    let protocol_version = epoch_manager.get_epoch_protocol_version(&epoch_id)?;
+    let prev_epoch_protocol_version = epoch_manager.get_epoch_protocol_version(&prev_epoch_id)?;
     Ok(protocol_version != prev_epoch_protocol_version)
 }
 
@@ -20,22 +20,22 @@ fn is_first_epoch_with_protocol_version(
 /// We assume that current block contain the chunk for shard with the given id.
 pub fn check_if_block_is_first_with_chunk_of_version(
     chain_store: &dyn ChainStoreAccess,
-    runtime_adapter: &dyn RuntimeWithEpochManagerAdapter,
+    epoch_manager: &dyn EpochManagerAdapter,
     prev_block_hash: &CryptoHash,
     shard_id: ShardId,
 ) -> Result<bool, Error> {
     // Check that block belongs to the first epoch with current protocol version
     // to avoid get_epoch_id_of_last_block_with_chunk call in the opposite case
-    if is_first_epoch_with_protocol_version(runtime_adapter, prev_block_hash)? {
+    if is_first_epoch_with_protocol_version(epoch_manager, prev_block_hash)? {
         // Compare only epochs because we already know that current epoch is the first one with current protocol version
         // convert shard id to shard id of previous epoch because number of shards may change
-        let shard_id = runtime_adapter.get_prev_shard_ids(prev_block_hash, vec![shard_id])?[0];
+        let shard_id = epoch_manager.get_prev_shard_ids(prev_block_hash, vec![shard_id])?[0];
         let prev_epoch_id = chain_store.get_epoch_id_of_last_block_with_chunk(
-            runtime_adapter,
+            epoch_manager,
             prev_block_hash,
             shard_id,
         )?;
-        let epoch_id = runtime_adapter.get_epoch_id_from_prev_block(prev_block_hash)?;
+        let epoch_id = epoch_manager.get_epoch_id_from_prev_block(prev_block_hash)?;
         Ok(prev_epoch_id != epoch_id)
     } else {
         Ok(false)

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -7,6 +7,7 @@ use chrono::Utc;
 use near_cache::CellLruCache;
 
 use near_chain_primitives::error::Error;
+use near_epoch_manager::EpochManagerAdapter;
 use near_primitives::block::Tip;
 use near_primitives::errors::InvalidTxError;
 use near_primitives::hash::CryptoHash;
@@ -292,7 +293,7 @@ pub trait ChainStoreAccess {
     /// Get epoch id of the last block with existing chunk for the given shard id.
     fn get_epoch_id_of_last_block_with_chunk(
         &self,
-        runtime_adapter: &dyn RuntimeWithEpochManagerAdapter,
+        epoch_manager: &dyn EpochManagerAdapter,
         hash: &CryptoHash,
         shard_id: ShardId,
     ) -> Result<EpochId, Error> {
@@ -304,7 +305,7 @@ pub trait ChainStoreAccess {
                 break Ok(block_header.epoch_id().clone());
             }
             candidate_hash = *block_header.prev_hash();
-            shard_id = runtime_adapter.get_prev_shard_ids(&candidate_hash, vec![shard_id])?[0];
+            shard_id = epoch_manager.get_prev_shard_ids(&candidate_hash, vec![shard_id])?[0];
         }
     }
 }

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -124,7 +124,7 @@ impl StateViewerSubCommand {
             StateViewerSubCommand::DumpState(cmd) => cmd.run(home_dir, near_config, store),
             StateViewerSubCommand::DumpStateRedis(cmd) => cmd.run(home_dir, near_config, store),
             StateViewerSubCommand::DumpTx(cmd) => cmd.run(home_dir, near_config, store),
-            StateViewerSubCommand::EpochInfo(cmd) => cmd.run(home_dir, near_config, store),
+            StateViewerSubCommand::EpochInfo(cmd) => cmd.run(near_config, store),
             StateViewerSubCommand::PartialChunks(cmd) => cmd.run(near_config, store),
             StateViewerSubCommand::Receipts(cmd) => cmd.run(near_config, store),
             StateViewerSubCommand::Replay(cmd) => cmd.run(home_dir, near_config, store),
@@ -417,11 +417,10 @@ pub struct EpochInfoCmd {
 }
 
 impl EpochInfoCmd {
-    pub fn run(self, home_dir: &Path, near_config: NearConfig, store: Store) {
+    pub fn run(self, near_config: NearConfig, store: Store) {
         print_epoch_info(
             self.epoch_selection,
             self.validator_account_id.map(|s| AccountId::from_str(&s).unwrap()),
-            home_dir,
             near_config,
             store,
         );

--- a/tools/state-viewer/src/epoch_info.rs
+++ b/tools/state-viewer/src/epoch_info.rs
@@ -1,7 +1,7 @@
 use borsh::BorshDeserialize;
 use core::ops::Range;
-use near_chain::{ChainStore, ChainStoreAccess, RuntimeWithEpochManagerAdapter};
-use near_epoch_manager::EpochManager;
+use near_chain::{ChainStore, ChainStoreAccess};
+use near_epoch_manager::{EpochManagerAdapter, EpochManagerHandle};
 use near_primitives::account::id::AccountId;
 use near_primitives::epoch_manager::epoch_info::EpochInfo;
 use near_primitives::epoch_manager::AGGREGATOR_KEY;
@@ -34,8 +34,7 @@ pub(crate) fn print_epoch_info(
     validator_account_id: Option<AccountId>,
     store: Store,
     chain_store: &mut ChainStore,
-    epoch_manager: &mut EpochManager,
-    runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
+    epoch_manager: &EpochManagerHandle,
 ) {
     let epoch_ids = get_epoch_ids(epoch_selection, store, chain_store, epoch_manager);
 
@@ -59,18 +58,11 @@ pub(crate) fn print_epoch_info(
             &head_epoch_height,
             chain_store,
             epoch_manager,
-            runtime_adapter.clone(),
         );
 
         println!("---");
 
-        display_block_and_chunk_producers(
-            epoch_id,
-            epoch_info,
-            chain_store,
-            epoch_manager,
-            runtime_adapter.clone(),
-        );
+        display_block_and_chunk_producers(epoch_id, epoch_info, chain_store, epoch_manager);
     }
     println!("=========================");
     println!("Found {} epochs", epoch_ids.len());
@@ -80,12 +72,11 @@ fn display_block_and_chunk_producers(
     epoch_id: &EpochId,
     epoch_info: &EpochInfo,
     chain_store: &mut ChainStore,
-    epoch_manager: &mut EpochManager,
-    runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
+    epoch_manager: &EpochManagerHandle,
 ) {
     let block_height_range: Range<BlockHeight> =
         get_block_height_range(epoch_info, chain_store, epoch_manager);
-    let num_shards = runtime_adapter.num_shards(epoch_id).unwrap();
+    let num_shards = epoch_manager.num_shards(epoch_id).unwrap();
     for block_height in block_height_range {
         let bp = epoch_info.sample_block_producer(block_height);
         let bp = epoch_info.get_validator(bp).account_id().clone();
@@ -108,7 +99,7 @@ fn display_block_and_chunk_producers(
 fn get_block_height_range(
     epoch_info: &EpochInfo,
     chain_store: &ChainStore,
-    epoch_manager: &mut EpochManager,
+    epoch_manager: &EpochManagerHandle,
 ) -> Range<BlockHeight> {
     let head = chain_store.head().unwrap();
     let mut cur_block_info = epoch_manager.get_block_info(&head.last_block_hash).unwrap();
@@ -142,7 +133,7 @@ fn get_epoch_ids(
     epoch_selection: EpochSelection,
     store: Store,
     chain_store: &mut ChainStore,
-    epoch_manager: &mut EpochManager,
+    epoch_manager: &EpochManagerHandle,
 ) -> Vec<EpochId> {
     match epoch_selection {
         EpochSelection::All => iterate_and_filter(store, |_| true),
@@ -209,8 +200,7 @@ fn display_epoch_info(
     validator_account_id: &Option<AccountId>,
     head_epoch_height: &EpochHeight,
     chain_store: &mut ChainStore,
-    epoch_manager: &mut EpochManager,
-    runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
+    epoch_manager: &EpochManagerHandle,
 ) {
     println!("{:?}: {:#?}", epoch_id, epoch_info);
     if epoch_info.epoch_height() >= *head_epoch_height {
@@ -218,14 +208,7 @@ fn display_epoch_info(
         return;
     }
     if let Some(account_id) = validator_account_id.clone() {
-        display_validator_info(
-            epoch_id,
-            epoch_info,
-            account_id,
-            chain_store,
-            epoch_manager,
-            runtime_adapter,
-        );
+        display_validator_info(epoch_id, epoch_info, account_id, chain_store, epoch_manager);
     }
 }
 
@@ -234,8 +217,7 @@ fn display_validator_info(
     epoch_info: &EpochInfo,
     account_id: AccountId,
     chain_store: &mut ChainStore,
-    epoch_manager: &mut EpochManager,
-    runtime_adapter: Arc<dyn RuntimeWithEpochManagerAdapter>,
+    epoch_manager: &EpochManagerHandle,
 ) {
     if let Some(kickout) = epoch_info.validator_kickout().get(&account_id) {
         println!("Validator {} kickout: {:#?}", account_id, kickout);
@@ -249,7 +231,7 @@ fn display_validator_info(
             .collect();
         println!("Block producer for {} blocks: {:?}", bp_for_blocks.len(), bp_for_blocks);
 
-        let shard_ids = 0..runtime_adapter.num_shards(epoch_id).unwrap();
+        let shard_ids = 0..epoch_manager.num_shards(epoch_id).unwrap();
         let cp_for_chunks: Vec<(BlockHeight, ShardId)> = block_height_range
             .flat_map(|block_height| {
                 shard_ids


### PR DESCRIPTION
As a reminder of the overall goal, we want to split RuntimeWithEpochManagerAdapter, so that any code that needs the runtime will use an Arc<RuntimeAdapter>, and any code that uses the epoch manager will use the EpochManagerHandle.

This PR splits usages in state-viewer, so that it no longer uses RuntimeWithEpochManagerAdapter. It will use EpochManagerHandle wherever possible, but when needed, we fall back to EpochManagerAdapter for code that still needs to convert from RuntimeWithEpochManagerAdapter (since that cannot in general provide an EpochManagerHandle). When EpochManagerAdapter is no longer created from RuntimeWithEpochManagerAdapter, we can remove EpochManagerAdapter and always use EpochManagerHandle, a concrete type.