### PR TITLE
Add flat_storage_creation_enabled config flag

### DIFF
--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1430,6 +1430,9 @@ impl ClientActor {
     }
 
     fn start_flat_storage_creation(&mut self, ctx: &mut Context<ClientActor>) {
+        if !self.client.config.flat_storage_creation_enabled {
+            return;
+        }
         match self.client.run_flat_storage_creation_step() {
             Ok(false) => {}
             Ok(true) => {

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -164,6 +164,8 @@ pub struct ClientConfig {
     pub enable_statistics_export: bool,
     /// Number of threads to execute background migration work in client.
     pub client_background_migration_threads: usize,
+    /// Enables background flat storage creation.
+    pub flat_storage_creation_enabled: bool,
     /// Duration to perform background flat storage creation step.
     pub flat_storage_creation_period: Duration,
     /// If enabled, will dump state of every epoch to external storage.
@@ -251,6 +253,7 @@ impl ClientConfig {
             max_gas_burnt_view: None,
             enable_statistics_export: true,
             client_background_migration_threads: 1,
+            flat_storage_creation_enabled: true,
             flat_storage_creation_period: Duration::from_secs(1),
             state_sync_dump_enabled: false,
             state_sync_s3_bucket: String::new(),

--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -85,6 +85,10 @@ pub struct StoreConfig {
     /// with block processing.
     pub background_migration_threads: usize,
 
+
+    /// Enables background flat storage creation.
+    pub flat_storage_creation_enabled: bool,
+
     /// Duration to perform background flat storage creation step. Defines how
     /// frequently we check creation status and execute work related to it in
     /// main thread (scheduling and collecting state parts, catching up blocks, etc.).
@@ -219,6 +223,8 @@ impl Default for StoreConfig {
             // We checked that this number of threads doesn't impact
             // regular block processing significantly.
             background_migration_threads: 8,
+
+            flat_storage_creation_enabled: true,
 
             // It shouldn't be very low, because on single flat storage creation step
             // we do several disk reads from `FlatStateMisc` and `FlatStateDeltas`.

--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -85,7 +85,6 @@ pub struct StoreConfig {
     /// with block processing.
     pub background_migration_threads: usize,
 
-
     /// Enables background flat storage creation.
     pub flat_storage_creation_enabled: bool,
 

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -676,6 +676,7 @@ impl NearConfig {
                 max_gas_burnt_view: config.max_gas_burnt_view,
                 enable_statistics_export: config.store.enable_statistics_export,
                 client_background_migration_threads: config.store.background_migration_threads,
+                flat_storage_creation_enabled: config.store.flat_storage_creation_enabled,
                 flat_storage_creation_period: config.store.flat_storage_creation_period,
                 state_sync_dump_enabled: config
                     .state_sync


### PR DESCRIPTION
Part of #8827.

Adds `flat_storage_creation_enabled` config flag to enable/disable flat storage creation. The default value is `true`.

This is needed for SREs to be able to manually enable/disable flat storage creation when taking state backup.

