### PR TITLE
cleanup: Fix clippy::derivable_impls

### DIFF
--- a/chain/network/src/store/testonly.rs
+++ b/chain/network/src/store/testonly.rs
@@ -1,16 +1,10 @@
 use super::*;
 use std::collections::HashMap;
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, Hash, PartialEq, Eq)]
 pub struct Component {
     pub peers: Vec<PeerId>,
     pub edges: Vec<Edge>,
-}
-
-impl Default for Component {
-    fn default() -> Self {
-        Self { peers: vec![], edges: vec![] }
-    }
 }
 
 impl Component {

--- a/core/primitives-core/src/account.rs
+++ b/core/primitives-core/src/account.rs
@@ -10,20 +10,16 @@ use std::io;
     BorshDeserialize,
     PartialEq,
     Eq,
-    Debug,
     Clone,
     Copy,
+    Debug,
+    Default,
     serde::Serialize,
     serde::Deserialize,
 )]
 pub enum AccountVersion {
+    #[default]
     V1,
-}
-
-impl Default for AccountVersion {
-    fn default() -> Self {
-        AccountVersion::V1
-    }
 }
 
 /// Per account information stored in the state.

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -331,9 +331,10 @@ impl Borrow<CryptoHash> for SignedTransaction {
 }
 
 /// The status of execution for a transaction or a receipt.
-#[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Clone)]
+#[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Clone, Default)]
 pub enum ExecutionStatus {
     /// The execution is pending or unknown.
+    #[default]
     Unknown,
     /// The execution has failed with the given execution error.
     Failure(TxExecutionError),
@@ -356,12 +357,6 @@ impl fmt::Debug for ExecutionStatus {
                 f.write_fmt(format_args!("SuccessReceiptId({})", receipt_id))
             }
         }
-    }
-}
-
-impl Default for ExecutionStatus {
-    fn default() -> Self {
-        ExecutionStatus::Unknown
     }
 }
 
@@ -439,20 +434,15 @@ pub struct ExecutionOutcome {
     pub metadata: ExecutionMetadata,
 }
 
-#[derive(BorshSerialize, BorshDeserialize, PartialEq, Clone, Eq, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, PartialEq, Clone, Eq, Debug, Default)]
 pub enum ExecutionMetadata {
     /// V1: Empty Metadata
+    #[default]
     V1,
     /// V2: With ProfileData by legacy `Cost` enum
     V2(ProfileDataV2),
     /// V3: With ProfileData by gas parameters
     V3(ProfileDataV3),
-}
-
-impl Default for ExecutionMetadata {
-    fn default() -> Self {
-        ExecutionMetadata::V1
-    }
 }
 
 impl fmt::Debug for ExecutionOutcome {

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -18,7 +18,7 @@ pub type StateRoot = CryptoHash;
 
 /// Different types of finality.
 #[derive(
-    serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq, arbitrary::Arbitrary,
+    serde::Serialize, serde::Deserialize, Default, Clone, Debug, PartialEq, Eq, arbitrary::Arbitrary,
 )]
 pub enum Finality {
     #[serde(rename = "optimistic")]
@@ -26,13 +26,8 @@ pub enum Finality {
     #[serde(rename = "near-final")]
     DoomSlug,
     #[serde(rename = "final")]
+    #[default]
     Final,
-}
-
-impl Default for Finality {
-    fn default() -> Self {
-        Finality::Final
-    }
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -1252,10 +1252,18 @@ impl From<SignedTransaction> for SignedTransactionView {
 }
 
 #[derive(
-    BorshSerialize, BorshDeserialize, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone,
+    BorshSerialize,
+    BorshDeserialize,
+    serde::Serialize,
+    serde::Deserialize,
+    PartialEq,
+    Eq,
+    Clone,
+    Default,
 )]
 pub enum FinalExecutionStatus {
     /// The execution has not yet started.
+    #[default]
     NotStarted,
     /// The execution has started and still going.
     Started,
@@ -1275,12 +1283,6 @@ impl fmt::Debug for FinalExecutionStatus {
                 f.write_fmt(format_args!("SuccessValue({})", AbbrBytes(v)))
             }
         }
-    }
-}
-
-impl Default for FinalExecutionStatus {
-    fn default() -> Self {
-        FinalExecutionStatus::NotStarted
     }
 }
 

--- a/runtime/near-vm-runner/src/instrument/gas/validation.rs
+++ b/runtime/near-vm-runner/src/instrument/gas/validation.rs
@@ -19,7 +19,7 @@ type NodeId = usize;
 
 /// A node in a control flow graph is commonly known as a basic block. This is a sequence of
 /// operations that are always executed sequentially.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct ControlFlowNode {
     /// The index of the first instruction in the basic block. This is only used for debugging.
     first_instr_pos: Option<usize>,
@@ -40,19 +40,6 @@ struct ControlFlowNode {
 
     /// Edges in the "backwards" direction. These edges form cycles in the graph.
     loopback_edges: Vec<NodeId>,
-}
-
-impl Default for ControlFlowNode {
-    fn default() -> Self {
-        ControlFlowNode {
-            first_instr_pos: None,
-            actual_cost: 0,
-            charged_cost: 0,
-            is_loop_target: false,
-            forward_edges: Vec::new(),
-            loopback_edges: Vec::new(),
-        }
-    }
 }
 
 /// A control flow graph where nodes are basic blocks and edges represent possible transitions

--- a/runtime/runtime-params-estimator/src/qemu.rs
+++ b/runtime/runtime-params-estimator/src/qemu.rs
@@ -48,6 +48,7 @@ fn hypercall(index: u32) -> u64 {
 }
 
 /// Create a command to be executed inside QEMU with the custom counter plugin.
+#[derive(Default)]
 pub struct QemuCommandBuilder {
     started: bool,
     on_every_close: bool,
@@ -107,12 +108,6 @@ impl QemuCommandBuilder {
         cmd.arg(inner_cmd);
 
         Ok(cmd)
-    }
-}
-
-impl Default for QemuCommandBuilder {
-    fn default() -> Self {
-        Self { started: false, on_every_close: false, count_per_thread: false, plugin_log: false }
     }
 }
 

--- a/scripts/run_clippy.sh
+++ b/scripts/run_clippy.sh
@@ -5,6 +5,7 @@ LINTS=(
   -A clippy::all
   -D clippy::clone_on_copy
   -D clippy::correctness
+  -D clippy::derivable_impls
   -D clippy::redundant_clone
   -D clippy::suspicious
 )


### PR DESCRIPTION
We have two types of errors in the codebase resulting in `clippy::derivable_impls` warning:
1. Enums implement `default()` explicitly when it can be derived. This seems to be an unambiguous readability improvement. Removing an explicit function definition is good. `#[default]` is clear enough.
2. Structs implement `default()` to initialize all fields to default values of corresponding types. This seems an improvement too. @jakmeier please check whether it's a readability for `QemuCommandBuilder`.

The PR was generated by running this and adjusting the result manually
```sh
cargo clippy --fix -- -A clippy::all -W clippy::derivable_impls
```

This is part of #8145