### PR TITLE
fix: remove cfg from undo block tool

### DIFF
--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -2271,11 +2271,9 @@ impl<'a> ChainStoreUpdate<'a> {
             }
 
             // delete flat storage columns: FlatStateChanges and FlatStateDeltaMetadata
-            if cfg!(feature = "protocol_feature_flat_state") {
-                let mut store_update = self.store().store_update();
-                store_helper::remove_delta(&mut store_update, shard_uid, block_hash);
-                self.merge(store_update);
-            }
+            let mut store_update = self.store().store_update();
+            store_helper::remove_delta(&mut store_update, shard_uid, block_hash);
+            self.merge(store_update);
         }
 
         // 2. Delete block_hash-indexed data


### PR DESCRIPTION
There was a minor conflict while merging #8681 and #8761. Removing cfg(feature) because feature is stabilized now.