### PR TITLE
fix: less spammy flat storage logs

### DIFF
--- a/core/store/src/flat/storage.rs
+++ b/core/store/src/flat/storage.rs
@@ -5,7 +5,7 @@ use near_primitives::errors::StorageError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::{ShardLayout, ShardUId};
 use near_primitives::state::ValueRef;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::flat::delta::CachedFlatStateChanges;
 use crate::flat::store_helper::FlatStateColumn;
@@ -251,7 +251,7 @@ impl FlatStorage {
             }
 
             store_update.commit().unwrap();
-            info!(target: "chain", %shard_id, %block_hash, %block_height, "Moved flat storage head");
+            debug!(target: "chain", %shard_id, %block_hash, %block_height, "Moved flat storage head");
         }
         guard.update_delta_metrics();
 
@@ -270,7 +270,7 @@ impl FlatStorage {
         let block = &delta.metadata.block;
         let block_hash = block.hash;
         let block_height = block.height;
-        info!(target: "chain", %shard_id, %block_hash, %block_height, "Adding block to flat storage");
+        debug!(target: "chain", %shard_id, %block_hash, %block_height, "Adding block to flat storage");
         if block.prev_hash != guard.flat_head.hash && !guard.deltas.contains_key(&block.prev_hash) {
             return Err(guard.create_block_not_supported_error(&block_hash));
         }


### PR DESCRIPTION
Change info to debug because it is +8 messages per block and postprocess/preprocess block messages are already at debug level.