### PR TITLE
feature: Introduce a limit to transaction pool size

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -2030,9 +2030,9 @@ impl Client {
                         }
                         InsertTransactionResult::NoSpaceLeft => {
                             if is_forwarded {
-                                trace!(target: "client", shard_id, "No space left for transaction, dropping it.");
+                                trace!(target: "client", shard_id, "Transaction pool is full, dropping the transaction.");
                             } else {
-                                trace!(target: "client", shard_id, "No space left for transaction, trying to forward it.");
+                                trace!(target: "client", shard_id, "Transaction pool is full, trying to forward the transaction.");
                             }
                         }
                     }

--- a/chain/pool/src/lib.rs
+++ b/chain/pool/src/lib.rs
@@ -149,13 +149,6 @@ impl TransactionPool {
         }
     }
 
-    /// Reintroduces transactions back during the chain reorg.
-    pub fn reintroduce_transactions(&mut self, transactions: Vec<SignedTransaction>) {
-        for tx in transactions {
-            self.insert_transaction(tx);
-        }
-    }
-
     /// Returns the number of unique transactions in the pool.
     pub fn len(&self) -> usize {
         self.unique_transactions.len()

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -251,6 +251,9 @@ pub struct ClientConfig {
     pub state_sync_enabled: bool,
     /// Options for syncing state.
     pub state_sync: StateSyncConfig,
+    /// Limit of the size of per-shard transaction pool measured in bytes. If not set, the size
+    /// will be unbounded.
+    pub transaction_pool_size_limit: Option<u64>,
 }
 
 impl ClientConfig {
@@ -323,6 +326,7 @@ impl ClientConfig {
             flat_storage_creation_period: Duration::from_secs(1),
             state_sync_enabled: false,
             state_sync: StateSyncConfig::default(),
+            transaction_pool_size_limit: None,
         }
     }
 }

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -680,6 +680,7 @@ impl NearConfig {
                 flat_storage_creation_period: config.store.flat_storage_creation_period,
                 state_sync_enabled: config.state_sync_enabled.unwrap_or(false),
                 state_sync: config.state_sync.unwrap_or_default(),
+                transaction_pool_size_limit: None,
             },
             network_config: NetworkConfig::new(
                 config.network,


### PR DESCRIPTION
The PR introduces a limit to the size of the transaction pool for each shard and a logic that rejects transactions that go over this limit. The reasoning for this work is described in https://github.com/near/nearcore/issues/3284.

To start, the limit will be disabled (effectively set to infinity) and this PR shouldn't have any effect. The node operators can override it with a config option. In the future, we will come up with a safe value to set by default (probably between 10 MiB - 1 GiB).

We also start with a simple option where the RPC client will not know if their transaction runs into this limit. We will need to rework this part in the future, but it will have to touch the transaction forwarding code in a non-trivial way, and I would prefer to work on this when we have a congestion test ready https://github.com/near/nearcore/issues/8920.

Lastly, this PR adds some nuance to handling reintroducing transactions back to the pool after reorg or producing a chunk (`reintroduce_transactions` method), by acknowledging that not all transactions might have been included and logging the number of dropped transactions.