### PR TITLE
cold-store:  prepare-hot: error -> warn

### DIFF
--- a/tools/cold-store/src/cli.rs
+++ b/tools/cold-store/src/cli.rs
@@ -429,7 +429,7 @@ impl PrepareHotCmd {
         // COLD  . . . . . . . . . H
 
         if cold_head.height > rpc_head.height {
-            tracing::error!(target : "prepare-hot",
+            tracing::warn!(target : "prepare-hot",
                 "The cold head is ahead of the rpc head. cold head height: {} rpc head height: {}",
                 cold_head.height,
                 rpc_head.height

--- a/tools/cold-store/src/cli.rs
+++ b/tools/cold-store/src/cli.rs
@@ -429,10 +429,10 @@ impl PrepareHotCmd {
         // COLD  . . . . . . . . . H
 
         if cold_head.height > rpc_head.height {
-            tracing::warn!(target : "prepare-hot",
-                "The cold head is ahead of the rpc head. cold head height: {} rpc head height: {}",
-                cold_head.height,
-                rpc_head.height
+            tracing::warn!(target: "prepare-hot",
+                cold_head_height = cold_head.height,
+                rpc_head_height = rpc_head.height,
+                "The cold head is ahead of the RPC head. This should fix itself when the node catches up and becomes in sync"
             );
         }
 


### PR DESCRIPTION
Don't scare users, because rpc head being behind cold head is normal. Rpc DB comes from backups, we only publish those once every 12 hours, it is very likely that cold db is lagging behind by less than 12 hours. 
Error message in this case is confusing, warning is more appropriate.