### PR TITLE
tests: Verify that transaction is valid and accepted

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1893,6 +1893,11 @@ impl Client {
         Ok(())
     }
 
+    /// Submits the transaction for future inclusion into the chain.
+    ///
+    /// If accepted, it will be added to the transaction pool and possibly forwarded to another
+    /// validator.
+    #[must_use]
     pub fn process_tx(
         &mut self,
         tx: SignedTransaction,

--- a/integration-tests/src/tests/client/benchmarks.rs
+++ b/integration-tests/src/tests/client/benchmarks.rs
@@ -9,6 +9,7 @@ use borsh::BorshSerialize;
 use near_chain::ChainGenesis;
 use near_chain_configs::Genesis;
 use near_client::test_utils::{create_chunk_on_height, TestEnv};
+use near_client::ProcessTxResponse;
 use near_crypto::{InMemorySigner, KeyType};
 use near_primitives::transaction::{Action, DeployContractAction, SignedTransaction};
 use nearcore::config::GenesisExt;
@@ -40,14 +41,14 @@ fn benchmark_large_chunk_production_time() {
     let last_block_hash = env.clients[0].chain.head().unwrap().last_block_hash;
     for i in 0..n_txes {
         let tx = SignedTransaction::from_actions(
-            i,
+            i + 1,
             account_id.clone(),
             account_id.clone(),
             &signer,
             vec![Action::DeployContract(DeployContractAction { code: vec![92; tx_size] })],
             last_block_hash,
         );
-        env.clients[0].process_tx(tx, false, false);
+        assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
     }
 
     let t = std::time::Instant::now();

--- a/integration-tests/src/tests/client/challenges.rs
+++ b/integration-tests/src/tests/client/challenges.rs
@@ -10,7 +10,7 @@ use near_chain::{Block, Chain, ChainGenesis, ChainStoreAccess, Error, Provenance
 use near_chain_configs::Genesis;
 use near_chunks::ShardsManager;
 use near_client::test_utils::{create_chunk, create_chunk_with_transactions, TestEnv};
-use near_client::Client;
+use near_client::{Client, ProcessTxResponse};
 use near_crypto::{InMemorySigner, KeyType, Signer};
 use near_network::test_utils::MockPeerManagerAdapter;
 use near_network::types::NetworkRequests;
@@ -338,17 +338,20 @@ fn test_verify_chunk_invalid_state_challenge() {
     let validator_signer = create_test_signer("test0");
     let genesis_hash = *env.clients[0].chain.genesis().hash();
     env.produce_block(0, 1);
-    env.clients[0].process_tx(
-        SignedTransaction::send_money(
-            0,
-            "test0".parse().unwrap(),
-            "test1".parse().unwrap(),
-            &signer,
-            1000,
-            genesis_hash,
+    assert_eq!(
+        env.clients[0].process_tx(
+            SignedTransaction::send_money(
+                1,
+                "test0".parse().unwrap(),
+                "test1".parse().unwrap(),
+                &signer,
+                1000,
+                genesis_hash,
+            ),
+            false,
+            false,
         ),
-        false,
-        false,
+        ProcessTxResponse::ValidTx
     );
     env.produce_block(0, 2);
 
@@ -623,7 +626,10 @@ fn test_fishermen_challenge() {
         signer.public_key(),
         genesis_hash,
     );
-    env.clients[0].process_tx(stake_transaction, false, false);
+    assert_eq!(
+        env.clients[0].process_tx(stake_transaction, false, false),
+        ProcessTxResponse::ValidTx
+    );
     for i in 1..=11 {
         env.produce_block(0, i);
     }

--- a/integration-tests/src/tests/client/cold_storage.rs
+++ b/integration-tests/src/tests/client/cold_storage.rs
@@ -4,6 +4,7 @@ use borsh::BorshDeserialize;
 use near_chain::{ChainGenesis, Provenance};
 use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
+use near_client::ProcessTxResponse;
 use near_crypto::{InMemorySigner, KeyType};
 use near_o11y::testonly::init_test_logger;
 use near_primitives::block::Tip;
@@ -104,7 +105,7 @@ fn test_storage_after_commit_of_cold_update() {
                 })],
                 last_hash,
             );
-            env.clients[0].process_tx(tx, false, false);
+            assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
         }
         // Don't send transactions in last two blocks. Because on last block production a chunk from
         // the next block will be produced and information about these transactions will be written
@@ -124,7 +125,7 @@ fn test_storage_after_commit_of_cold_update() {
                     })],
                     last_hash,
                 );
-                env.clients[0].process_tx(tx, false, false);
+                assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
             }
             for i in 0..5 {
                 let tx = SignedTransaction::send_money(
@@ -135,7 +136,7 @@ fn test_storage_after_commit_of_cold_update() {
                     1,
                     last_hash,
                 );
-                env.clients[0].process_tx(tx, false, false);
+                assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
             }
         }
 
@@ -299,7 +300,7 @@ fn test_cold_db_copy_with_height_skips() {
                     1,
                     last_hash,
                 );
-                env.clients[0].process_tx(tx, false, false);
+                assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
             }
         }
 
@@ -410,7 +411,7 @@ fn test_initial_copy_to_cold(batch_size: usize) {
                 1,
                 last_hash,
             );
-            env.clients[0].process_tx(tx, false, false);
+            assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
         }
 
         let block = env.clients[0].produce_block(h).unwrap().unwrap();

--- a/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
+++ b/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
@@ -43,7 +43,7 @@ fn check_tx_processing(
     blocks_number: u64,
 ) -> BlockHeight {
     let tx_hash = tx.get_hash();
-    env.clients[0].process_tx(tx, false, false);
+    assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
     let next_height = produce_blocks_from_height(env, blocks_number, height);
     let final_outcome = env.clients[0].chain.get_final_transaction_result(&tx_hash).unwrap();
     assert_matches!(final_outcome.status, FinalExecutionStatus::SuccessValue(_));
@@ -80,8 +80,14 @@ fn test_transaction_hash_collision() {
         *genesis_block.hash(),
     );
 
-    env.clients[0].process_tx(send_money_tx.clone(), false, false);
-    env.clients[0].process_tx(delete_account_tx, false, false);
+    assert_eq!(
+        env.clients[0].process_tx(send_money_tx.clone(), false, false),
+        ProcessTxResponse::ValidTx
+    );
+    assert_eq!(
+        env.clients[0].process_tx(delete_account_tx, false, false),
+        ProcessTxResponse::ValidTx
+    );
 
     for i in 1..4 {
         env.produce_block(0, i);
@@ -96,14 +102,18 @@ fn test_transaction_hash_collision() {
         &signer0,
         *genesis_block.hash(),
     );
-    let res = env.clients[0].process_tx(create_account_tx, false, false);
-    assert_matches!(res, ProcessTxResponse::ValidTx);
+    assert_eq!(
+        env.clients[0].process_tx(create_account_tx, false, false),
+        ProcessTxResponse::ValidTx
+    );
     for i in 4..8 {
         env.produce_block(0, i);
     }
 
-    let res = env.clients[0].process_tx(send_money_tx, false, false);
-    assert_matches!(res, ProcessTxResponse::InvalidTx(_));
+    assert_matches!(
+        env.clients[0].process_tx(send_money_tx, false, false),
+        ProcessTxResponse::InvalidTx(_)
+    );
 }
 
 /// Helper for checking that duplicate transactions from implicit accounts are properly rejected.
@@ -179,7 +189,7 @@ fn get_status_of_tx_hash_collision_for_implicit_account(
         100,
         *block.hash(),
     );
-    let status = env.clients[0].process_tx(send_money_from_implicit_account_tx, false, false);
+    let response = env.clients[0].process_tx(send_money_from_implicit_account_tx, false, false);
 
     // Check that sending money from implicit account with correct nonce is still valid.
     let send_money_from_implicit_account_tx = SignedTransaction::send_money(
@@ -192,7 +202,7 @@ fn get_status_of_tx_hash_collision_for_implicit_account(
     );
     check_tx_processing(&mut env, send_money_from_implicit_account_tx, height, blocks_number);
 
-    status
+    response
 }
 
 /// Test that duplicate transactions from implicit accounts are properly rejected.
@@ -272,8 +282,10 @@ fn test_transaction_nonce_too_large() {
         100,
         *genesis_block.hash(),
     );
-    let res = env.clients[0].process_tx(tx, false, false);
-    assert_matches!(res, ProcessTxResponse::InvalidTx(InvalidTxError::InvalidAccessKeyError(_)));
+    assert_matches!(
+        env.clients[0].process_tx(tx, false, false),
+        ProcessTxResponse::InvalidTx(InvalidTxError::InvalidAccessKeyError(_))
+    );
 }
 
 /// This test tests the logic regarding requesting chunks for orphan.

--- a/integration-tests/src/tests/client/features/account_id_in_function_call_permission.rs
+++ b/integration-tests/src/tests/client/features/account_id_in_function_call_permission.rs
@@ -70,8 +70,10 @@ fn test_account_id_in_function_call_permission_upgrade() {
         let tip = env.clients[0].chain.head().unwrap();
         let signed_transaction =
             Transaction { nonce: 10, block_hash: tip.last_block_hash, ..tx.clone() }.sign(&signer);
-        let res = env.clients[0].process_tx(signed_transaction, false, false);
-        assert_eq!(res, ProcessTxResponse::ValidTx);
+        assert_eq!(
+            env.clients[0].process_tx(signed_transaction, false, false),
+            ProcessTxResponse::ValidTx
+        );
         for i in 0..3 {
             env.produce_block(0, tip.height + i + 1);
         }
@@ -84,9 +86,8 @@ fn test_account_id_in_function_call_permission_upgrade() {
         let tip = env.clients[0].chain.head().unwrap();
         let signed_transaction =
             Transaction { nonce: 11, block_hash: tip.last_block_hash, ..tx }.sign(&signer);
-        let res = env.clients[0].process_tx(signed_transaction, false, false);
         assert_eq!(
-            res,
+            env.clients[0].process_tx(signed_transaction, false, false),
             ProcessTxResponse::InvalidTx(InvalidTxError::ActionsValidation(
                 ActionsValidationError::InvalidAccountId { account_id: "#".to_string() }
             ))
@@ -132,9 +133,8 @@ fn test_very_long_account_id() {
     }
     .sign(&signer);
 
-    let res = env.clients[0].process_tx(tx, false, false);
     assert_eq!(
-        res,
+        env.clients[0].process_tx(tx, false, false),
         ProcessTxResponse::InvalidTx(InvalidTxError::ActionsValidation(
             ActionsValidationError::InvalidAccountId { account_id: "A".repeat(128) }
         ))

--- a/integration-tests/src/tests/client/features/chunk_nodes_cache.rs
+++ b/integration-tests/src/tests/client/features/chunk_nodes_cache.rs
@@ -3,6 +3,7 @@ use assert_matches::assert_matches;
 use near_chain::{ChainGenesis, Provenance, RuntimeWithEpochManagerAdapter};
 use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
+use near_client::ProcessTxResponse;
 use near_crypto::{InMemorySigner, KeyType, Signer};
 use near_epoch_manager::shard_tracker::TrackedConfig;
 use near_primitives::config::ExtCosts;
@@ -56,7 +57,7 @@ fn process_transaction(
         last_block_hash,
     );
     let tx_hash = tx.get_hash();
-    env.clients[0].process_tx(tx, false, false);
+    assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
 
     for i in next_height..next_height + num_blocks {
         let mut block = env.clients[0].produce_block(i).unwrap().unwrap();

--- a/integration-tests/src/tests/client/features/flat_storage.rs
+++ b/integration-tests/src/tests/client/features/flat_storage.rs
@@ -3,6 +3,7 @@ use crate::tests::client::runtimes::create_nightshade_runtimes;
 use near_chain::ChainGenesis;
 use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
+use near_client::ProcessTxResponse;
 use near_crypto::{InMemorySigner, KeyType, Signer};
 use near_primitives::test_utils::encode;
 use near_primitives::transaction::{Action, ExecutionMetadata, FunctionCallAction, Transaction};
@@ -78,7 +79,10 @@ fn test_flat_storage_upgrade() {
         }
         .sign(&signer);
         let tx_hash = signed_transaction.get_hash();
-        env.clients[0].process_tx(signed_transaction, false, false);
+        assert_eq!(
+            env.clients[0].process_tx(signed_transaction, false, false),
+            ProcessTxResponse::ValidTx
+        );
         for i in 0..blocks_to_process_txn {
             env.produce_block(0, tip.height + i + 1);
         }
@@ -103,7 +107,10 @@ fn test_flat_storage_upgrade() {
             }
             .sign(&signer);
             let tx_hash = signed_transaction.get_hash();
-            env.clients[0].process_tx(signed_transaction, false, false);
+            assert_eq!(
+                env.clients[0].process_tx(signed_transaction, false, false),
+                ProcessTxResponse::ValidTx
+            );
             for i in 0..blocks_to_process_txn {
                 env.produce_block(0, tip.height + i + 1);
             }

--- a/integration-tests/src/tests/client/features/increase_storage_compute_cost.rs
+++ b/integration-tests/src/tests/client/features/increase_storage_compute_cost.rs
@@ -10,7 +10,6 @@
 //! We also test unaffected cases to make sure compute costs only affect
 //! parameters they should.
 
-use assert_matches::assert_matches;
 use near_chain::ChainGenesis;
 use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
@@ -294,8 +293,7 @@ fn produce_saturated_chunk(
         tx_ids.push(tx.get_hash());
 
         // add tx to the mempool but don't execute it yet
-        let res = env.clients[0].process_tx(tx, false, false);
-        assert_matches!(res, ProcessTxResponse::ValidTx);
+        assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
     }
 
     // process the queued transactions

--- a/integration-tests/src/tests/client/features/lower_storage_key_limit.rs
+++ b/integration-tests/src/tests/client/features/lower_storage_key_limit.rs
@@ -2,6 +2,7 @@ use assert_matches::assert_matches;
 use near_chain::{ChainGenesis, Provenance, RuntimeWithEpochManagerAdapter};
 use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
+use near_client::ProcessTxResponse;
 use near_crypto::{InMemorySigner, KeyType, Signer};
 use near_epoch_manager::shard_tracker::TrackedConfig;
 use near_o11y::testonly::init_test_logger;
@@ -90,7 +91,7 @@ fn protocol_upgrade() {
             Transaction { nonce: tip.height + 1, block_hash: tip.last_block_hash, ..tx.clone() }
                 .sign(&signer);
         let tx_hash = signed_tx.get_hash();
-        env.clients[0].process_tx(signed_tx, false, false);
+        assert_eq!(env.clients[0].process_tx(signed_tx, false, false), ProcessTxResponse::ValidTx);
         produce_blocks_from_height_with_protocol_version(
             &mut env,
             epoch_length,
@@ -110,7 +111,7 @@ fn protocol_upgrade() {
             Transaction { nonce: tip.height + 1, block_hash: tip.last_block_hash, ..tx }
                 .sign(&signer);
         let tx_hash = signed_tx.get_hash();
-        env.clients[0].process_tx(signed_tx, false, false);
+        assert_eq!(env.clients[0].process_tx(signed_tx, false, false), ProcessTxResponse::ValidTx);
         for i in 0..epoch_length {
             let block = env.clients[0].produce_block(tip.height + i + 1).unwrap().unwrap();
             env.process_block(0, block.clone(), Provenance::PRODUCED);
@@ -147,7 +148,7 @@ fn protocol_upgrade() {
             Transaction { nonce: tip.height + 1, block_hash: tip.last_block_hash, ..tx }
                 .sign(&signer);
         let tx_hash = signed_tx.get_hash();
-        env.clients[0].process_tx(signed_tx, false, false);
+        assert_eq!(env.clients[0].process_tx(signed_tx, false, false), ProcessTxResponse::ValidTx);
         for i in 0..epoch_length {
             let block = env.clients[0].produce_block(tip.height + i + 1).unwrap().unwrap();
             env.process_block(0, block.clone(), Provenance::PRODUCED);

--- a/integration-tests/src/tests/client/features/wasmer2.rs
+++ b/integration-tests/src/tests/client/features/wasmer2.rs
@@ -2,6 +2,7 @@ use crate::tests::client::process_blocks::{create_nightshade_runtimes, deploy_te
 use near_chain::ChainGenesis;
 use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
+use near_client::ProcessTxResponse;
 use near_crypto::{InMemorySigner, KeyType, Signer};
 use near_primitives::hash::CryptoHash;
 use near_primitives::transaction::{Action, FunctionCallAction, Transaction};
@@ -61,7 +62,10 @@ fn test_near_vm_upgrade() {
         let tip = env.clients[0].chain.head().unwrap();
         let signed_transaction =
             Transaction { nonce: 10, block_hash: tip.last_block_hash, ..tx.clone() }.sign(&signer);
-        env.clients[0].process_tx(signed_transaction, false, false);
+        assert_eq!(
+            env.clients[0].process_tx(signed_transaction, false, false),
+            ProcessTxResponse::ValidTx
+        );
         for i in 0..3 {
             env.produce_block(0, tip.height + i + 1);
         }
@@ -75,7 +79,10 @@ fn test_near_vm_upgrade() {
         let tip = env.clients[0].chain.head().unwrap();
         let signed_transaction =
             Transaction { nonce: 11, block_hash: tip.last_block_hash, ..tx }.sign(&signer);
-        env.clients[0].process_tx(signed_transaction, false, false);
+        assert_eq!(
+            env.clients[0].process_tx(signed_transaction, false, false),
+            ProcessTxResponse::ValidTx
+        );
         for i in 0..3 {
             env.produce_block(0, tip.height + i + 1);
         }

--- a/integration-tests/src/tests/client/features/zero_balance_account.rs
+++ b/integration-tests/src/tests/client/features/zero_balance_account.rs
@@ -82,8 +82,10 @@ fn test_zero_balance_account_creation() {
         &signer0,
         *genesis_block.hash(),
     );
-    let res = env.clients[0].process_tx(create_account_tx, false, false);
-    assert_matches!(res, ProcessTxResponse::ValidTx);
+    assert_eq!(
+        env.clients[0].process_tx(create_account_tx, false, false),
+        ProcessTxResponse::ValidTx
+    );
     for i in 1..5 {
         env.produce_block(0, i);
     }
@@ -104,8 +106,10 @@ fn test_zero_balance_account_creation() {
         *genesis_block.hash(),
     );
     let tx_hash = create_account_tx.get_hash();
-    let res = env.clients[0].process_tx(create_account_tx, false, false);
-    assert_matches!(res, ProcessTxResponse::ValidTx);
+    assert_eq!(
+        env.clients[0].process_tx(create_account_tx, false, false),
+        ProcessTxResponse::ValidTx
+    );
     for i in 5..10 {
         env.produce_block(0, i);
     }
@@ -164,8 +168,10 @@ fn test_zero_balance_account_add_key() {
         &signer0,
         *genesis_block.hash(),
     );
-    let res = env.clients[0].process_tx(create_account_tx, false, false);
-    assert_matches!(res, ProcessTxResponse::ValidTx);
+    assert_eq!(
+        env.clients[0].process_tx(create_account_tx, false, false),
+        ProcessTxResponse::ValidTx
+    );
     for i in 1..5 {
         env.produce_block(0, i);
     }
@@ -207,8 +213,7 @@ fn test_zero_balance_account_add_key() {
         actions,
         *genesis_block.hash(),
     );
-    let res = env.clients[0].process_tx(add_key_tx, false, false);
-    assert_matches!(res, ProcessTxResponse::ValidTx);
+    assert_eq!(env.clients[0].process_tx(add_key_tx, false, false), ProcessTxResponse::ValidTx);
     for i in 5..10 {
         env.produce_block(0, i);
     }
@@ -223,8 +228,10 @@ fn test_zero_balance_account_add_key() {
         amount,
         *genesis_block.hash(),
     );
-    let res = env.clients[0].process_tx(send_money_tx.clone(), false, false);
-    assert_matches!(res, ProcessTxResponse::InvalidTx(InvalidTxError::LackBalanceForState { .. }));
+    assert_matches!(
+        env.clients[0].process_tx(send_money_tx.clone(), false, false),
+        ProcessTxResponse::InvalidTx(InvalidTxError::LackBalanceForState { .. })
+    );
 
     let delete_key_tx = SignedTransaction::from_actions(
         nonce + 1,
@@ -234,12 +241,11 @@ fn test_zero_balance_account_add_key() {
         vec![Action::DeleteKey(DeleteKeyAction { public_key: keys.last().unwrap().clone() })],
         *genesis_block.hash(),
     );
-    env.clients[0].process_tx(delete_key_tx, false, false);
+    assert_eq!(env.clients[0].process_tx(delete_key_tx, false, false), ProcessTxResponse::ValidTx);
     for i in 10..15 {
         env.produce_block(0, i);
     }
-    let res = env.clients[0].process_tx(send_money_tx, false, false);
-    assert_matches!(res, ProcessTxResponse::ValidTx);
+    assert_eq!(env.clients[0].process_tx(send_money_tx, false, false), ProcessTxResponse::ValidTx);
     for i in 15..20 {
         env.produce_block(0, i);
     }
@@ -269,7 +275,7 @@ fn test_zero_balance_account_upgrade() {
         InMemorySigner::from_seed(new_account_id.clone(), KeyType::ED25519, "hello.test0");
 
     // before protocol upgrade, should not be possible to create a zero balance account
-    let create_account_tx = SignedTransaction::create_account(
+    let first_create_account_tx = SignedTransaction::create_account(
         1,
         signer0.account_id.clone(),
         new_account_id.clone(),
@@ -278,13 +284,15 @@ fn test_zero_balance_account_upgrade() {
         &signer0,
         *genesis_block.hash(),
     );
-    let tx_hash = create_account_tx.get_hash();
-    let res = env.clients[0].process_tx(create_account_tx, false, false);
-    assert_matches!(res, ProcessTxResponse::ValidTx);
+    let first_tx_hash = first_create_account_tx.get_hash();
+    assert_eq!(
+        env.clients[0].process_tx(first_create_account_tx, false, false),
+        ProcessTxResponse::ValidTx
+    );
     for i in 1..12 {
         env.produce_block(0, i);
     }
-    let outcome = env.clients[0].chain.get_final_transaction_result(&tx_hash).unwrap();
+    let outcome = env.clients[0].chain.get_final_transaction_result(&first_tx_hash).unwrap();
     assert_matches!(
         outcome.status,
         FinalExecutionStatus::Failure(TxExecutionError::ActionError(ActionError {
@@ -292,7 +300,8 @@ fn test_zero_balance_account_upgrade() {
             ..
         }))
     );
-    let create_account_tx2 = SignedTransaction::create_account(
+
+    let second_create_account_tx = SignedTransaction::create_account(
         2,
         signer0.account_id.clone(),
         new_account_id,
@@ -301,13 +310,15 @@ fn test_zero_balance_account_upgrade() {
         &signer0,
         *genesis_block.hash(),
     );
-    let tx_hash2 = create_account_tx2.get_hash();
-    let res = env.clients[0].process_tx(create_account_tx2, false, false);
-    assert_matches!(res, ProcessTxResponse::ValidTx);
+    let second_tx_hash = second_create_account_tx.get_hash();
+    assert_eq!(
+        env.clients[0].process_tx(second_create_account_tx, false, false),
+        ProcessTxResponse::ValidTx
+    );
     for i in 12..20 {
         env.produce_block(0, i);
     }
-    let outcome = env.clients[0].chain.get_final_transaction_result(&tx_hash2).unwrap();
+    let outcome = env.clients[0].chain.get_final_transaction_result(&second_tx_hash).unwrap();
     assert_matches!(outcome.status, FinalExecutionStatus::SuccessValue(_));
 }
 

--- a/integration-tests/src/tests/client/sharding_upgrade.rs
+++ b/integration-tests/src/tests/client/sharding_upgrade.rs
@@ -1,4 +1,5 @@
 use borsh::BorshSerialize;
+use near_client::ProcessTxResponse;
 
 use crate::tests::client::process_blocks::{
     create_nightshade_runtimes, set_block_protocol_version,
@@ -110,7 +111,10 @@ impl TestShardUpgradeEnv {
         if height == 1 {
             for tx in self.init_txs.iter() {
                 for j in 0..self.num_validators {
-                    env.clients[j].process_tx(tx.clone(), false, false);
+                    assert_eq!(
+                        env.clients[j].process_tx(tx.clone(), false, false),
+                        ProcessTxResponse::ValidTx
+                    );
                 }
             }
         }
@@ -122,7 +126,10 @@ impl TestShardUpgradeEnv {
         if let Some(txs) = self.txs_by_height.get(&(height + 1)) {
             for tx in txs {
                 for j in 0..self.num_validators {
-                    env.clients[j].process_tx(tx.clone(), false, false);
+                    assert_eq!(
+                        env.clients[j].process_tx(tx.clone(), false, false),
+                        ProcessTxResponse::ValidTx
+                    );
                 }
             }
         }

--- a/nearcore/tests/economics.rs
+++ b/nearcore/tests/economics.rs
@@ -2,6 +2,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
+use near_client::ProcessTxResponse;
 use num_rational::Ratio;
 
 use near_chain::{ChainGenesis, RuntimeWithEpochManagerAdapter};
@@ -64,17 +65,20 @@ fn test_burn_mint() {
     let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
     let initial_total_supply = env.chain_genesis.total_supply;
     let genesis_hash = *env.clients[0].chain.genesis().hash();
-    env.clients[0].process_tx(
-        SignedTransaction::send_money(
-            1,
-            "test0".parse().unwrap(),
-            "test1".parse().unwrap(),
-            &signer,
-            1000,
-            genesis_hash,
+    assert_eq!(
+        env.clients[0].process_tx(
+            SignedTransaction::send_money(
+                1,
+                "test0".parse().unwrap(),
+                "test1".parse().unwrap(),
+                &signer,
+                1000,
+                genesis_hash,
+            ),
+            false,
+            false,
         ),
-        false,
-        false,
+        ProcessTxResponse::ValidTx
     );
     let near_balance = env.query_balance("near".parse().unwrap());
     assert_eq!(calc_total_supply(&mut env), initial_total_supply);

--- a/test-utils/runtime-tester/src/run_test.rs
+++ b/test-utils/runtime-tester/src/run_test.rs
@@ -1,6 +1,7 @@
 use near_chain::{Block, ChainGenesis, Provenance};
 use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
+use near_client::ProcessTxResponse;
 use near_client_primitives::types::Error;
 use near_crypto::InMemorySigner;
 use near_epoch_manager::shard_tracker::TrackedConfig;
@@ -75,7 +76,10 @@ impl Scenario {
             for tx in &block.transactions {
                 let signed_tx = tx.to_signed_transaction(&last_block);
                 block_stats.tx_hashes.push(signed_tx.get_hash());
-                env.clients[0].process_tx(signed_tx, false, false);
+                assert_eq!(
+                    env.clients[0].process_tx(signed_tx, false, false),
+                    ProcessTxResponse::ValidTx
+                );
             }
 
             let start_time = cpu_time::ProcessTime::now();

--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -453,6 +453,7 @@ mod test {
     use near_chain::{ChainGenesis, Provenance};
     use near_chain_configs::Genesis;
     use near_client::test_utils::TestEnv;
+    use near_client::ProcessTxResponse;
     use near_crypto::{InMemorySigner, KeyType};
     use near_epoch_manager::EpochManager;
     use near_primitives::transaction::SignedTransaction;
@@ -531,7 +532,7 @@ mod test {
             signer.public_key.clone(),
             genesis_hash,
         );
-        env.clients[0].process_tx(tx, false, false);
+        assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
 
         safe_produce_blocks(&mut env, 1, epoch_length * 2 + 1, None);
 
@@ -568,7 +569,7 @@ mod test {
             signer.public_key.clone(),
             genesis_hash,
         );
-        env.clients[0].process_tx(tx, false, false);
+        assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
 
         safe_produce_blocks(&mut env, 1, epoch_length * 2 + 1, Some(5));
 

--- a/tools/state-viewer/src/apply_chunk.rs
+++ b/tools/state-viewer/src/apply_chunk.rs
@@ -457,8 +457,7 @@ mod test {
                 100,
                 hash,
             );
-            let response = env.clients[0].process_tx(tx, false, false);
-            assert_eq!(response, ProcessTxResponse::ValidTx);
+            assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
         }
     }
 

--- a/tools/state-viewer/src/state_dump.rs
+++ b/tools/state-viewer/src/state_dump.rs
@@ -295,6 +295,7 @@ mod test {
     use near_chain_configs::genesis_validate::validate_genesis;
     use near_chain_configs::{Genesis, GenesisChangeConfig};
     use near_client::test_utils::TestEnv;
+    use near_client::ProcessTxResponse;
     use near_crypto::{InMemorySigner, KeyFile, KeyType, PublicKey, SecretKey};
     use near_primitives::account::id::AccountId;
     use near_primitives::state_record::StateRecord;
@@ -390,7 +391,7 @@ mod test {
             signer.public_key.clone(),
             genesis_hash,
         );
-        env.clients[0].process_tx(tx, false, false);
+        assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
 
         safe_produce_blocks(&mut env, 1, epoch_length * 2 + 1);
 
@@ -450,8 +451,8 @@ mod test {
             signer0.public_key.clone(),
             genesis_hash,
         );
-        env.clients[0].process_tx(tx00, false, false);
-        env.clients[0].process_tx(tx01, false, false);
+        assert_eq!(env.clients[0].process_tx(tx00, false, false), ProcessTxResponse::ValidTx);
+        assert_eq!(env.clients[0].process_tx(tx01, false, false), ProcessTxResponse::ValidTx);
 
         let signer1 =
             InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1");
@@ -463,7 +464,7 @@ mod test {
             signer1.public_key.clone(),
             genesis_hash,
         );
-        env.clients[0].process_tx(tx1, false, false);
+        assert_eq!(env.clients[0].process_tx(tx1, false, false), ProcessTxResponse::ValidTx);
 
         safe_produce_blocks(&mut env, 1, epoch_length * 2 + 1);
 
@@ -522,7 +523,7 @@ mod test {
             signer.public_key.clone(),
             genesis_hash,
         );
-        env.clients[0].process_tx(tx, false, false);
+        assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
 
         safe_produce_blocks(&mut env, 1, epoch_length * 2 + 1);
 
@@ -569,7 +570,7 @@ mod test {
             signer.public_key.clone(),
             genesis_hash,
         );
-        env.clients[0].process_tx(tx, false, false);
+        assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
         for i in 1..=epoch_length + 1 {
             env.produce_block(0, i);
         }
@@ -676,7 +677,7 @@ mod test {
             1,
             genesis_hash,
         );
-        env.clients[0].process_tx(tx, false, false);
+        assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
 
         let mut blocks = vec![];
         for i in 1..epoch_length {
@@ -745,7 +746,7 @@ mod test {
             signer.public_key.clone(),
             genesis_hash,
         );
-        env.clients[0].process_tx(tx, false, false);
+        assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
 
         safe_produce_blocks(&mut env, 1, epoch_length * 2 + 1);
 
@@ -808,7 +809,7 @@ mod test {
             signer.public_key.clone(),
             genesis_hash,
         );
-        env.clients[0].process_tx(tx, false, false);
+        assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
 
         safe_produce_blocks(&mut env, 1, epoch_length * 2 + 1);
 


### PR DESCRIPTION
The result of `process_tx` is important because it tells whether the submitted transaction is valid and has been accepted.

So we add `#[must_use]` annotation to it and fix all the tests that were not checking it.
As a part of this, we fix two tests that were using incorrect nonce (but still somehow functioned...):
- `benchmark_large_chunk_production_time`
- `test_verify_chunk_invalid_state_challenge`

This is a part of the work on introducing the transaction pool limits https://github.com/near/nearcore/issues/8878.