### PR TITLE
fix: remove unused validator stake view type

### DIFF
--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -1663,16 +1663,11 @@ pub struct FinalExecutionOutcomeWithReceiptView {
 }
 
 pub mod validator_stake_view {
+    pub use super::ValidatorStakeViewV1;
     use crate::types::validator_stake::ValidatorStake;
     use borsh::{BorshDeserialize, BorshSerialize};
     use near_primitives_core::types::AccountId;
-    use serde::{Deserialize, Serialize};
-
-    use crate::serialize::dec_format;
-    use near_crypto::PublicKey;
-    use near_primitives_core::types::Balance;
-
-    pub use super::ValidatorStakeViewV1;
+    use serde::Deserialize;
 
     #[derive(
         BorshSerialize, BorshDeserialize, serde::Serialize, Deserialize, Debug, Clone, Eq, PartialEq,
@@ -1700,17 +1695,6 @@ pub mod validator_stake_view {
                 Self::V1(v1) => &v1.account_id,
             }
         }
-    }
-
-    #[derive(
-        BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, Clone, Eq, PartialEq,
-    )]
-    pub struct ValidatorStakeViewV2 {
-        pub account_id: AccountId,
-        pub public_key: PublicKey,
-        #[serde(with = "dec_format")]
-        pub stake: Balance,
-        pub is_chunk_only: bool,
     }
 
     impl From<ValidatorStake> for ValidatorStakeView {

--- a/pytest/lib/lightclient.py
+++ b/pytest/lib/lightclient.py
@@ -143,8 +143,6 @@ def validate_light_client_block(last_known_block,
             for i in range(16):
                 serialized_next_bp.append(stake & 255)
                 stake >>= 8
-            if version > 0:
-                serialized_next_bp.append(1 if bp['is_chunk_only'] else 0)
 
         serialized_next_bp = bytes(serialized_next_bp)
 

--- a/pytest/lib/messages/block.py
+++ b/pytest/lib/messages/block.py
@@ -605,14 +605,6 @@ block_schema = [
         }
     ],
     [
-        ValidatorStakeV2, {
-            'kind':
-                'struct',
-            'fields': [['account_id', 'string'], ['public_key', PublicKey],
-                       ['stake', 'u128'], ['is_chunk_only', 'u8']]
-        }
-    ],
-    [
         Approval, {
             'kind':
                 'struct',


### PR DESCRIPTION
Unclear why this is here, opening it just to see if anything breaks, and see what does. Curious if it's a refactor that's broken this support, as I've gotten some server-side RPC errors relating to this type.