### PR TITLE
refactor: no logic duplication in `TrieRecordingStorage`

### DIFF
--- a/chain/chain/src/flat_storage_creator.rs
+++ b/chain/chain/src/flat_storage_creator.rs
@@ -24,6 +24,7 @@ use near_store::flat::{
 use near_store::Store;
 use near_store::{Trie, TrieDBStorage, TrieTraversalItem};
 use std::collections::HashMap;
+use std::rc::Rc;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use tracing::{debug, info};
@@ -89,7 +90,7 @@ impl FlatStorageShardCreator {
         result_sender: Sender<u64>,
     ) {
         let trie_storage = TrieDBStorage::new(store.clone(), shard_uid);
-        let trie = Trie::new(Box::new(trie_storage), state_root, None);
+        let trie = Trie::new(Rc::new(trie_storage), state_root, None);
         let path_begin = trie.find_path_for_part_boundary(part_id.idx, part_id.total).unwrap();
         let path_end = trie.find_path_for_part_boundary(part_id.idx + 1, part_id.total).unwrap();
         let hex_path_begin = Self::nibbles_to_hex(&path_begin);
@@ -186,7 +187,7 @@ impl FlatStorageShardCreator {
                     let trie_storage = TrieDBStorage::new(store, shard_uid);
                     let state_root =
                         *chain_store.get_chunk_extra(&block_hash, &shard_uid)?.state_root();
-                    let trie = Trie::new(Box::new(trie_storage), state_root, None);
+                    let trie = Trie::new(Rc::new(trie_storage), state_root, None);
                     let root_node = trie.retrieve_root_node().unwrap();
                     let num_state_parts =
                         root_node.memory_usage / STATE_PART_MEMORY_LIMIT.as_u64() + 1;

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -305,7 +305,7 @@ impl std::fmt::Debug for TrieNode {
 }
 
 pub struct Trie {
-    pub storage: Box<dyn TrieStorage + Send>,
+    pub storage: Box<dyn TrieStorage>,
     root: StateRoot,
     pub flat_storage_chunk_view: Option<FlatStorageChunkView>,
 }
@@ -405,7 +405,7 @@ impl Trie {
     pub const EMPTY_ROOT: StateRoot = StateRoot::new();
 
     pub fn new(
-        storage: Box<dyn TrieStorage + Send>,
+        storage: Box<dyn TrieStorage>,
         root: StateRoot,
         flat_storage_chunk_view: Option<FlatStorageChunkView>,
     ) -> Self {

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -432,7 +432,7 @@ impl Trie {
     pub fn from_recorded_storage(partial_storage: PartialStorage, root: StateRoot) -> Self {
         let recorded_storage =
             partial_storage.nodes.0.into_iter().map(|value| (hash(&value), value)).collect();
-        let storage = Box::new(TrieMemoryPartialStorage {
+        let storage = Rc::new(TrieMemoryPartialStorage {
             recorded_storage,
             visited_nodes: Default::default(),
         });

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -23,6 +23,7 @@ pub use raw_node::{Children, RawTrieNode, RawTrieNodeWithSize};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt::Write;
+use std::rc::Rc;
 use std::str;
 
 mod config;
@@ -305,7 +306,7 @@ impl std::fmt::Debug for TrieNode {
 }
 
 pub struct Trie {
-    pub storage: Box<dyn TrieStorage>,
+    pub storage: Rc<dyn TrieStorage>,
     root: StateRoot,
     pub flat_storage_chunk_view: Option<FlatStorageChunkView>,
 }
@@ -405,7 +406,7 @@ impl Trie {
     pub const EMPTY_ROOT: StateRoot = StateRoot::new();
 
     pub fn new(
-        storage: Box<dyn TrieStorage>,
+        storage: Rc<dyn TrieStorage>,
         root: StateRoot,
         flat_storage_chunk_view: Option<FlatStorageChunkView>,
     ) -> Self {
@@ -413,14 +414,11 @@ impl Trie {
     }
 
     pub fn recording_reads(&self) -> Self {
-        let storage =
-            self.storage.as_caching_storage().expect("Storage should be TrieCachingStorage");
         let storage = TrieRecordingStorage {
-            store: storage.store.clone(),
-            shard_uid: storage.shard_uid,
+            storage: Rc::clone(&self.storage),
             recorded: RefCell::new(Default::default()),
         };
-        Trie { storage: Box::new(storage), root: self.root, flat_storage_chunk_view: None }
+        Trie { storage: Rc::new(storage), root: self.root, flat_storage_chunk_view: None }
     }
 
     pub fn recorded_storage(&self) -> Option<PartialStorage> {

--- a/core/store/src/trie/prefetching_trie_storage.rs
+++ b/core/store/src/trie/prefetching_trie_storage.rs
@@ -12,6 +12,7 @@ use near_primitives::shard_layout::ShardUId;
 use near_primitives::trie_key::TrieKey;
 use near_primitives::types::{AccountId, ShardId, StateRoot, TrieNodesCount};
 use std::collections::HashMap;
+use std::rc::Rc;
 use std::sync::Arc;
 use std::thread;
 
@@ -473,7 +474,7 @@ impl PrefetchApi {
                         // the clone only clones a few `Arc`s, so the performance
                         // hit is small.
                         let prefetcher_trie =
-                            Trie::new(Box::new(prefetcher_storage.clone()), trie_root, None);
+                            Trie::new(Rc::new(prefetcher_storage.clone()), trie_root, None);
                         let storage_key = trie_key.to_vec();
                         metric_prefetch_sent.inc();
                         if let Ok(_maybe_value) = prefetcher_trie.get(&storage_key) {

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -13,6 +13,7 @@ use near_primitives::trie_key::TrieKey;
 use near_primitives::types::{
     NumShards, RawStateChange, RawStateChangesWithTrieKey, StateChangeCause, StateRoot,
 };
+use std::rc::Rc;
 use std::sync::{Arc, RwLock};
 
 struct ShardTriesInner {
@@ -138,7 +139,7 @@ impl ShardTries {
                 .clone()
         });
 
-        let storage = Box::new(TrieCachingStorage::new(
+        let storage = Rc::new(TrieCachingStorage::new(
             self.0.store.clone(),
             cache,
             shard_uid,

--- a/core/store/src/trie/trie_tests.rs
+++ b/core/store/src/trie/trie_tests.rs
@@ -78,7 +78,7 @@ where
     for i in 0..(size + 1) {
         let storage = IncompletePartialStorage::new(storage.clone(), i);
         let new_trie = Trie {
-            storage: Box::new(storage),
+            storage: Rc::new(storage),
             root: *trie.get_root(),
             flat_storage_chunk_view: None,
         };

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -914,7 +914,7 @@ pub(crate) fn contract_accounts(
         let storage = TrieDBStorage::new(store.clone(), shard_uid);
         // We don't need flat state to traverse all accounts.
         let flat_storage_chunk_view = None;
-        Trie::new(Box::new(storage), state_root, flat_storage_chunk_view)
+        Trie::new(Rc::new(storage), state_root, flat_storage_chunk_view)
     });
 
     filter.write_header(&mut std::io::stdout().lock())?;

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -35,6 +35,7 @@ use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::rc::Rc;
 use std::sync::Arc;
 
 pub(crate) fn apply_block(
@@ -788,7 +789,7 @@ fn get_trie(store: Store, hash: CryptoHash, shard_id: u32, shard_version: u32) -
     let trie_config: TrieConfig = Default::default();
     let shard_cache = TrieCache::new(&trie_config, shard_uid, true);
     let trie_storage = TrieCachingStorage::new(store, shard_cache, shard_uid, true, None);
-    Trie::new(Box::new(trie_storage), hash, None)
+    Trie::new(Rc::new(trie_storage), hash, None)
 }
 
 pub(crate) fn view_trie(


### PR DESCRIPTION
There is no need to duplicate logic of reading from DB in `TrieRecordingStorage`. It makes more sense to create it over existing `TrieStorage` and reuse `retrieve_raw_bytes` impl from it. Also this allows us to get rid of annoying `as_caching_storage` cast. It is not actually necessary for underlying storage to be `TrieCachingStorage`.

Some consequences:
* `Rc` replaces `Box` in Trie, because we need to be able to copy pointer to trie storage. Looks like a reasonable requirement.
* `TrieStorage` is not `Send` anymore, but this is not needed in the code anyway. Otherwise we can consider `Arc`.

cc @jbajic as an example of existing issues with trie logic