### PR TITLE
Revert "feat: implement inlining for small values in flat storage"

### DIFF
--- a/chain/chain/src/flat_storage_creator.rs
+++ b/chain/chain/src/flat_storage_creator.rs
@@ -14,12 +14,13 @@ use assert_matches::assert_matches;
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use near_chain_primitives::Error;
 use near_primitives::shard_layout::ShardUId;
+use near_primitives::state::ValueRef;
 use near_primitives::state_part::PartId;
 use near_primitives::types::{AccountId, BlockHeight, StateRoot};
 use near_store::flat::{
-    store_helper, BlockInfo, FetchingStateStatus, FlatStateChanges, FlatStateValue,
-    FlatStorageCreationMetrics, FlatStorageCreationStatus, FlatStorageReadyStatus,
-    FlatStorageStatus, NUM_PARTS_IN_ONE_STEP, STATE_PART_MEMORY_LIMIT,
+    store_helper, BlockInfo, FetchingStateStatus, FlatStateChanges, FlatStorageCreationMetrics,
+    FlatStorageCreationStatus, FlatStorageReadyStatus, FlatStorageStatus, NUM_PARTS_IN_ONE_STEP,
+    STATE_PART_MEMORY_LIMIT,
 };
 use near_store::Store;
 use near_store::{Trie, TrieDBStorage, TrieTraversalItem};
@@ -104,13 +105,9 @@ impl FlatStorageShardCreator {
         {
             if let Some(key) = key {
                 let value = trie.storage.retrieve_raw_bytes(&hash).unwrap();
-                store_helper::set_flat_state_value(
-                    &mut store_update,
-                    shard_uid,
-                    key,
-                    Some(FlatStateValue::value_ref(&value)),
-                )
-                .expect("Failed to put value in FlatState");
+                let value_ref = ValueRef::new(&value);
+                store_helper::set_ref(&mut store_update, shard_uid, key, Some(value_ref))
+                    .expect("Failed to put value in FlatState");
                 num_items += 1;
             }
         }

--- a/core/store/src/flat/chunk_view.rs
+++ b/core/store/src/flat/chunk_view.rs
@@ -1,8 +1,9 @@
 use near_primitives::hash::CryptoHash;
+use near_primitives::state::ValueRef;
 
 use crate::Store;
 
-use super::{FlatStateValue, FlatStorage};
+use super::FlatStorage;
 
 /// Struct for getting value references from the flat storage, corresponding
 /// to some block defined in `blocks_to_head`.
@@ -38,7 +39,7 @@ impl FlatStorageChunkView {
     /// they are stored in `DBCol::State`. Also the separation is done so we
     /// could charge users for the value length before loading the value.
     // TODO (#7327): consider inlining small values, so we could use only one db access.
-    pub fn get_value(&self, key: &[u8]) -> Result<Option<FlatStateValue>, crate::StorageError> {
-        self.flat_storage.get_value(&self.block_hash, key)
+    pub fn get_ref(&self, key: &[u8]) -> Result<Option<ValueRef>, crate::StorageError> {
+        self.flat_storage.get_ref(&self.block_hash, key)
     }
 }

--- a/core/store/src/flat/mod.rs
+++ b/core/store/src/flat/mod.rs
@@ -39,7 +39,7 @@ pub use manager::FlatStorageManager;
 pub use metrics::FlatStorageCreationMetrics;
 pub use storage::FlatStorage;
 pub use types::{
-    BlockInfo, FetchingStateStatus, FlatStateValue, FlatStorageCreationStatus, FlatStorageError,
+    BlockInfo, FetchingStateStatus, FlatStorageCreationStatus, FlatStorageError,
     FlatStorageReadyStatus, FlatStorageStatus,
 };
 

--- a/core/store/src/flat/types.rs
+++ b/core/store/src/flat/types.rs
@@ -4,35 +4,10 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::state::ValueRef;
 use near_primitives::types::BlockHeight;
 
-/// Defines value size threshold for flat state inlining.
-/// It means that values having size greater than the threshold will be stored
-/// in FlatState as `FlatStateValue::Ref`, otherwise the whole value will be
-/// stored as `FlatStateValue::Inlined`.
-/// See the following comment for reasoning behind the threshold value:
-/// https://github.com/near/nearcore/issues/8243#issuecomment-1523049994
-pub const INLINE_DISK_VALUE_THRESHOLD: usize = 4000;
-
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]
 pub enum FlatStateValue {
     Ref(ValueRef),
-    Inlined(Vec<u8>),
-}
-
-impl FlatStateValue {
-    pub fn value_ref(value: &[u8]) -> Self {
-        Self::Ref(ValueRef::new(value))
-    }
-
-    pub fn inlined(value: &[u8]) -> Self {
-        Self::Inlined(value.to_vec())
-    }
-
-    pub fn to_value_ref(&self) -> ValueRef {
-        match self {
-            Self::Ref(value_ref) => value_ref.clone(),
-            Self::Inlined(value) => ValueRef::new(value),
-        }
-    }
+    // TODO(8243): add variant here for the inlined value
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug, Copy, Clone, PartialEq, Eq)]

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -793,9 +793,7 @@ impl Trie {
             matches!(mode, KeyLookupMode::FlatStorage) && self.flat_storage_chunk_view.is_some();
 
         if use_flat_storage {
-            let flat_state_value =
-                self.flat_storage_chunk_view.as_ref().unwrap().get_value(&key)?;
-            Ok(flat_state_value.map(|value| value.to_value_ref()))
+            self.flat_storage_chunk_view.as_ref().unwrap().get_ref(&key)
         } else {
             let key_nibbles = NibbleSlice::new(key);
             self.lookup(key_nibbles)

--- a/core/store/src/trie/state_parts.rs
+++ b/core/store/src/trie/state_parts.rs
@@ -7,7 +7,7 @@ use near_primitives::state_part::PartId;
 use near_primitives::types::StateRoot;
 use tracing::error;
 
-use crate::flat::{FlatStateChanges, FlatStateValue};
+use crate::flat::FlatStateChanges;
 use crate::trie::iterator::TrieTraversalItem;
 use crate::trie::nibble_slice::NibbleSlice;
 use crate::trie::{
@@ -216,7 +216,7 @@ impl Trie {
             map.entry(hash).or_insert_with(|| (value.to_vec(), 0)).1 += 1;
             if let Some(trie_key) = key {
                 let value_ref = ValueRef::new(&value);
-                flat_state_delta.insert(trie_key.clone(), Some(FlatStateValue::Ref(value_ref)));
+                flat_state_delta.insert(trie_key.clone(), Some(value_ref));
                 if is_contract_code_key(&trie_key) {
                     contract_codes.push(ContractCode::new(value.to_vec(), None));
                 }

--- a/integration-tests/src/tests/client/flat_storage.rs
+++ b/integration-tests/src/tests/client/flat_storage.rs
@@ -333,8 +333,7 @@ fn test_flat_storage_creation_start_from_state_part() {
         };
         let mut store_update = store.store_update();
         for key in trie_keys[1].iter() {
-            store_helper::set_flat_state_value(&mut store_update, shard_uid, key.clone(), None)
-                .unwrap();
+            store_helper::set_ref(&mut store_update, shard_uid, key.clone(), None).unwrap();
         }
         store_helper::set_flat_storage_status(
             &mut store_update,
@@ -369,7 +368,7 @@ fn test_flat_storage_creation_start_from_state_part() {
         let chunk_view = trie.flat_storage_chunk_view.unwrap();
         for part_trie_keys in trie_keys.iter() {
             for trie_key in part_trie_keys.iter() {
-                assert_matches!(chunk_view.get_value(trie_key), Ok(Some(_)));
+                assert_matches!(chunk_view.get_ref(trie_key), Ok(Some(_)));
             }
         }
     }

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -7,13 +7,14 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::Receipt;
 use near_primitives::runtime::config_store::RuntimeConfigStore;
 use near_primitives::runtime::migration_data::{MigrationData, MigrationFlags};
+use near_primitives::state::ValueRef;
 use near_primitives::test_utils::MockEpochInfoProvider;
 use near_primitives::transaction::{ExecutionStatus, SignedTransaction};
 use near_primitives::types::{Gas, MerkleHash};
 use near_primitives::version::PROTOCOL_VERSION;
 use near_store::flat::{
-    BlockInfo, FlatStateChanges, FlatStateDelta, FlatStateDeltaMetadata, FlatStateValue,
-    FlatStorage, FlatStorageManager,
+    BlockInfo, FlatStateChanges, FlatStateDelta, FlatStateDeltaMetadata, FlatStorage,
+    FlatStorageManager,
 };
 use near_store::{ShardTries, ShardUId, Store, StoreCompiledContractCache, TrieUpdate};
 use near_store::{TrieCache, TrieCachingStorage, TrieConfig};
@@ -164,7 +165,7 @@ impl<'c> EstimatorContext<'c> {
             let random_data = iter::repeat_with(|| {
                 (
                     crate::utils::random_vec(delta_key_len),
-                    Some(FlatStateValue::value_ref(b"this is never stored or accessed, we only need it to blow up in-memory deltas")),
+                    Some(ValueRef::new(b"this is never stored or accessed, we only need it to blow up in-memory deltas")),
                 )
             })
             .take(num_changes_per_delta);


### PR DESCRIPTION
This reverts #8988 as it results in node crashing: [zulip](https://near.zulipchat.com/#narrow/stream/345766-pagoda.2Fstorage.2Fflat-storage/topic/Canary.20crashes/near/355722627).

The original PR changes data format for delta changes on disk, so binary with the new code failed to deserialise deltas written by the old code.

I suggest we revert the change for now and then re-publish it along with the db migration.
