### PR TITLE
pytest: require urllib3 version <2

### DIFF
--- a/pytest/requirements.txt
+++ b/pytest/requirements.txt
@@ -15,3 +15,4 @@ scipy
 semver
 toml
 tqdm
+urllib3<2


### PR DESCRIPTION
buildkite suddenly started failing

```
python3 tests/sanity/backward_compatible.py
...
    "urllib3 v2.0 only supports OpenSSL 1.1.1+, currently "
ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with OpenSSL 1.0.2k-fips  26 Jan 2017. See: https://github.com/urllib3/urllib3/issues/2168
```

Trying with a strict lower version requirement to see if that works.