### PR TITLE
Revert nearvm 1.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
 * undo-block tool to reset the chain head from current head to its prev block. Use the tool by running: `./target/release/neard undo-block`. [#8681](https://github.com/near/nearcore/pull/8681)
 * Add prometheus metrics for expected number of blocks/chunks at the end of the epoch. [#8759](https://github.com/near/nearcore/pull/8759)
 * Node can sync State from S3. [#8789](https://github.com/near/nearcore/pull/8789)
-* The contract runtime switched to using our fork of wasmer, with various improvements. [#8912](https://github.com/near/nearcore/pull/8912)
 * Node can sync State from local filesystem. [#8913](https://github.com/near/nearcore/pull/8913)
 * Add per shard granularity for chunks in validator info metric. [#8934](https://github.com/near/nearcore/pull/8934)
 
@@ -61,14 +60,14 @@ to pay for the storage of their accounts.
 [Stabilization #8601](https://github.com/near/nearcore/pull/8601)
 
 ### Non-protocol Changes
-* Config validation can be done by following command: 
-  `./target/debug/neard --home {path_to_config_files} validate-config`. 
-  This will show error if there are file issues or semantic issues in `config.json`, `genesis.json`, `records.json`, `node_key.json` and `validator_key.json`. 
+* Config validation can be done by following command:
+  `./target/debug/neard --home {path_to_config_files} validate-config`.
+  This will show error if there are file issues or semantic issues in `config.json`, `genesis.json`, `records.json`, `node_key.json` and `validator_key.json`.
   [#8485](https://github.com/near/nearcore/pull/8485)
 * Comments are allowed in configs. This includes
   `config.json`, `genesis.json`, `node_key.json` and `validator_key.json`. You can use `//`, `#` and `/*...*/` for comments.
   [#8423](https://github.com/near/nearcore/pull/8423)
-* `/debug` page now has client_config linked. 
+* `/debug` page now has client_config linked.
   You can also check your client_config directly at /debug/client_config
   [#8400](https://github.com/near/nearcore/pull/8400)
 * Added cold store loop - a background thread that copies data from hot to cold storage and a new json rpc endpoing - split_storage_info - that

--- a/core/primitives-core/src/config.rs
+++ b/core/primitives-core/src/config.rs
@@ -210,8 +210,8 @@ impl VMLimitConfig {
 
             // NOTE: Stack height has to be 16K, otherwise Wasmer produces non-deterministic results.
             // For experimentation try `test_stack_overflow`.
-            max_stack_height: 256 * 1024, // 256kiB of stack.
-            contract_prepare_version: ContractPrepareVersion::V2,
+            max_stack_height: 16 * 1024, // 16Kib of stack.
+            contract_prepare_version: ContractPrepareVersion::V1,
             initial_memory_pages: 2u32.pow(10), // 64Mib of memory.
             max_memory_pages: 2u32.pow(11),     // 128Mib of memory.
 

--- a/core/primitives/res/runtime_configs/61.yaml
+++ b/core/primitives/res/runtime_configs/61.yaml
@@ -1,6 +1,3 @@
-max_stack_height: { old: 16384, new: 262144 }
-contract_prepare_version: { old: 1, new: 2 }
-
 # Compute costs to allow for flat storage read-only MVP.
 # See https://github.com/near/nearcore/issues/8006
 wasm_touching_trie_node:    { old: 16_101_955_926, new: { gas: 16_101_955_926, compute: 110_000_000_000 } }

--- a/core/primitives/res/runtime_configs/parameters.snap
+++ b/core/primitives/res/runtime_configs/parameters.snap
@@ -138,8 +138,8 @@ wasm_alt_bn128_g1_sum_base                     3_000_000_000
 wasm_alt_bn128_g1_sum_element                  5_000_000_000
 max_gas_burnt                            300_000_000_000_000
 max_gas_burnt_view                       300_000_000_000_000
-max_stack_height                                     262_144
-contract_prepare_version                                   2
+max_stack_height                                      16_384
+contract_prepare_version                                   1
 initial_memory_pages                                   1_024
 max_memory_pages                                       2_048
 registers_memory_limit                         1_073_741_824

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__61.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__61.json.snap
@@ -174,8 +174,8 @@ expression: config_view
     "regular_op_cost": 822756,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
-      "max_stack_height": 262144,
-      "contract_prepare_version": 2,
+      "max_stack_height": 16384,
+      "contract_prepare_version": 1,
       "initial_memory_pages": 1024,
       "max_memory_pages": 2048,
       "registers_memory_limit": 1073741824,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_61.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_61.json.snap
@@ -174,8 +174,8 @@ expression: config_view
     "regular_op_cost": 822756,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
-      "max_stack_height": 262144,
-      "contract_prepare_version": 2,
+      "max_stack_height": 16384,
+      "contract_prepare_version": 1,
       "initial_memory_pages": 1024,
       "max_memory_pages": 2048,
       "registers_memory_limit": 1073741824,

--- a/core/primitives/src/snapshots/near_primitives__views__tests__runtime_config_view.snap
+++ b/core/primitives/src/snapshots/near_primitives__views__tests__runtime_config_view.snap
@@ -174,8 +174,8 @@ expression: "&view"
     "regular_op_cost": 3856371,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
-      "max_stack_height": 262144,
-      "contract_prepare_version": 2,
+      "max_stack_height": 16384,
+      "contract_prepare_version": 1,
       "initial_memory_pages": 1024,
       "max_memory_pages": 2048,
       "registers_memory_limit": 1073741824,

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -89,12 +89,6 @@ pub enum ProtocolFeature {
     /// Although wasmer2 is faster, we don't change fees with this protocol
     /// version -- we can safely do that in a separate step.
     Wasmer2,
-    /// This feature switch our WASM engine implementation from wasmer 2.* to
-    /// near-vm, bringing better performance and reliability.
-    ///
-    /// Although near-vm is faster, we don't change fees with this protocol
-    /// version -- we can safely do that in a separate step.
-    NearVm,
     SimpleNightshade,
     LowerDataReceiptAndEcrecoverBaseCost,
     /// Lowers the cost of wasm instruction due to switch to wasmer2.
@@ -250,9 +244,7 @@ impl ProtocolFeature {
             ProtocolFeature::Ed25519Verify
             | ProtocolFeature::ZeroBalanceAccount
             | ProtocolFeature::DelegateAction => 59,
-            ProtocolFeature::ComputeCosts
-            | ProtocolFeature::NearVm
-            | ProtocolFeature::FlatStorageReads => 61,
+            ProtocolFeature::ComputeCosts | ProtocolFeature::FlatStorageReads => 61,
 
             // Nightly features
             #[cfg(feature = "protocol_feature_fix_staking_threshold")]

--- a/integration-tests/src/tests/client/features/wasmer2.rs
+++ b/integration-tests/src/tests/client/features/wasmer2.rs
@@ -10,13 +10,12 @@ use nearcore::config::GenesisExt;
 // This test fails on aarch because wasmer0 and wasmer2 are not available.
 #[cfg_attr(all(target_arch = "aarch64", target_vendor = "apple"), ignore)]
 #[test]
-fn test_near_vm_upgrade() {
+fn test_wasmer2_upgrade() {
     let mut capture = near_o11y::testonly::TracingCapture::enable();
 
     let old_protocol_version =
-        near_primitives::version::ProtocolFeature::NearVm.protocol_version() - 1;
+        near_primitives::version::ProtocolFeature::Wasmer2.protocol_version() - 1;
     let new_protocol_version = old_protocol_version + 1;
-    eprintln!("Testing protocol upgrade between {old_protocol_version} and {new_protocol_version}");
 
     // Prepare TestEnv with a contract at the old protocol version.
     let mut env = {
@@ -82,10 +81,6 @@ fn test_near_vm_upgrade() {
         capture.drain()
     };
 
-    assert!(logs_at_old_version.iter().any(|l| l.contains(&"vm_kind=Wasmer2")));
-    assert!(
-        logs_at_new_version.iter().any(|l| l.contains(&"vm_kind=NearVm")),
-        "Expected to find 'vm_kind=NearVm' in logs, occurences of vm_kind are {:?}",
-        logs_at_new_version.iter().filter(|l| l.contains("vm_kind")).collect::<Vec<_>>(),
-    );
+    assert!(logs_at_old_version.iter().any(|l| l.contains(&"vm_kind=Wasmer0")));
+    assert!(logs_at_new_version.iter().any(|l| l.contains(&"vm_kind=Wasmer2")));
 }

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -2858,11 +2858,11 @@ fn test_execution_metadata() {
         "cost": "CONTRACT_LOADING_BYTES",
         "gas_used": "18423750"
       },
-      // We spend two wasm instructions (call & drop), plus 8 ops for initializing the stack.
+      // We spend two wasm instructions (call & drop).
       {
         "cost_category": "WASM_HOST_COST",
         "cost": "WASM_INSTRUCTION",
-        "gas_used": (config.wasm_config.regular_op_cost as u64 * 10).to_string()
+        "gas_used": (config.wasm_config.regular_op_cost as u64 * 2).to_string()
       }
     ]);
     let outcome = &execution_outcome.receipts_outcome[0].outcome;

--- a/integration-tests/src/tests/runtime/sanity_checks.rs
+++ b/integration-tests/src/tests/runtime/sanity_checks.rs
@@ -232,19 +232,22 @@ fn test_sanity_used_gas() {
         .collect::<Vec<_>>();
 
     // Executing `used_gas` costs `base_cost`. When executing `used_gas` twice
-    // within a metered block, the returned values should differ by that amount
-    // plus 2 regular_op_cost, one for the local.set and one for the call.
+    // within a metered block, the returned values should differ by that amount.
     let base_cost =
         node.client.read().unwrap().runtime_config.wasm_config.ext_costs.gas_cost(ExtCosts::base);
-    let regular_op_cost =
-        u64::from(node.client.read().unwrap().runtime_config.wasm_config.regular_op_cost);
-    assert_eq!(used_gas[1] - used_gas[0], base_cost + 2 * regular_op_cost);
+    assert_eq!(used_gas[1] - used_gas[0], base_cost);
 
-    // Similarly, we have 7 instructions between the two used_gas calls.
-    assert_eq!(used_gas[2] - used_gas[1], base_cost + 7 * regular_op_cost);
+    // The fees for executing a metered block's WASM code should be paid before
+    // any of the call instructions within that block are executed. Hence, even
+    // after arithmetics, the next call of `used_gas` should still return a
+    // value that differs only by `base_cost`.
+    assert_eq!(used_gas[2] - used_gas[1], base_cost);
 
-    // And still the same if there are br_if calls (6 regular ops, as block doesn’t count)
-    assert_eq!(used_gas[3] - used_gas[2], base_cost + 6 * regular_op_cost);
+    // Entering a new metered block, all of its instructions are paid upfront.
+    // Therefore, the difference across blocks must be larger than `base_cost`,
+    // given that the block contains other instructions besides the call of
+    // `used_gas`.
+    assert!(used_gas[3] - used_gas[2] > base_cost);
 }
 
 /// Returns a contract which calls host function `used_gas` multiple times, both

--- a/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_gas_profile.snap
+++ b/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_gas_profile.snap
@@ -382,11 +382,6 @@ expression: receipts_gas_profile
             cost: "CONTRACT_LOADING_BYTES",
             gas_used: 0,
         },
-        CostGasUsed {
-            cost_category: "WASM_HOST_COST",
-            cost: "WASM_INSTRUCTION",
-            gas_used: 0,
-        },
     ],
     [],
     [
@@ -400,11 +395,6 @@ expression: receipts_gas_profile
             cost: "CONTRACT_LOADING_BYTES",
             gas_used: 0,
         },
-        CostGasUsed {
-            cost_category: "WASM_HOST_COST",
-            cost: "WASM_INSTRUCTION",
-            gas_used: 0,
-        },
     ],
     [],
     [
@@ -416,11 +406,6 @@ expression: receipts_gas_profile
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
             cost: "CONTRACT_LOADING_BYTES",
-            gas_used: 0,
-        },
-        CostGasUsed {
-            cost_category: "WASM_HOST_COST",
-            cost: "WASM_INSTRUCTION",
             gas_used: 0,
         },
     ],
@@ -440,11 +425,6 @@ expression: receipts_gas_profile
             cost: "CONTRACT_LOADING_BYTES",
             gas_used: 0,
         },
-        CostGasUsed {
-            cost_category: "WASM_HOST_COST",
-            cost: "WASM_INSTRUCTION",
-            gas_used: 0,
-        },
     ],
     [],
     [],
@@ -459,11 +439,6 @@ expression: receipts_gas_profile
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
             cost: "CONTRACT_LOADING_BYTES",
-            gas_used: 0,
-        },
-        CostGasUsed {
-            cost_category: "WASM_HOST_COST",
-            cost: "WASM_INSTRUCTION",
             gas_used: 0,
         },
     ],

--- a/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_gas_profile_nightly.snap
+++ b/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_gas_profile_nightly.snap
@@ -382,11 +382,6 @@ expression: receipts_gas_profile
             cost: "CONTRACT_LOADING_BYTES",
             gas_used: 0,
         },
-        CostGasUsed {
-            cost_category: "WASM_HOST_COST",
-            cost: "WASM_INSTRUCTION",
-            gas_used: 0,
-        },
     ],
     [],
     [
@@ -400,11 +395,6 @@ expression: receipts_gas_profile
             cost: "CONTRACT_LOADING_BYTES",
             gas_used: 0,
         },
-        CostGasUsed {
-            cost_category: "WASM_HOST_COST",
-            cost: "WASM_INSTRUCTION",
-            gas_used: 0,
-        },
     ],
     [],
     [
@@ -416,11 +406,6 @@ expression: receipts_gas_profile
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
             cost: "CONTRACT_LOADING_BYTES",
-            gas_used: 0,
-        },
-        CostGasUsed {
-            cost_category: "WASM_HOST_COST",
-            cost: "WASM_INSTRUCTION",
             gas_used: 0,
         },
     ],
@@ -440,11 +425,6 @@ expression: receipts_gas_profile
             cost: "CONTRACT_LOADING_BYTES",
             gas_used: 0,
         },
-        CostGasUsed {
-            cost_category: "WASM_HOST_COST",
-            cost: "WASM_INSTRUCTION",
-            gas_used: 0,
-        },
     ],
     [],
     [],
@@ -459,11 +439,6 @@ expression: receipts_gas_profile
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
             cost: "CONTRACT_LOADING_BYTES",
-            gas_used: 0,
-        },
-        CostGasUsed {
-            cost_category: "WASM_HOST_COST",
-            cost: "WASM_INSTRUCTION",
             gas_used: 0,
         },
     ],

--- a/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_gas_profile_nondeterministic.snap
+++ b/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_gas_profile_nondeterministic.snap
@@ -17,7 +17,7 @@ expression: receipts_gas_profile
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
             cost: "WASM_INSTRUCTION",
-            gas_used: 8227560,
+            gas_used: 1645512,
         },
     ],
     [],

--- a/runtime/near-test-contracts/src/lib.rs
+++ b/runtime/near-test-contracts/src/lib.rs
@@ -30,7 +30,7 @@ pub fn sized_contract(size: usize) -> Vec<u8> {
     let adjusted_size = size as i64 - (base_size as i64 - size as i64);
     let payload = "x".repeat(adjusted_size as usize);
     let code = format!(
-        r#"(module
+        r#"(module 
             (memory 1)
             (func (export "main"))
             (data (i32.const 0) "{payload}")

--- a/runtime/near-test-contracts/test-contract-rs/src/lib.rs
+++ b/runtime/near-test-contracts/test-contract-rs/src/lib.rs
@@ -578,7 +578,6 @@ pub unsafe fn recurse() {
 /// Rust compiler is getting smarter and starts to optimize my deep recursion.
 /// We're going to fight it with a more obscure implementations.
 #[no_mangle]
-#[inline(never)]
 fn internal_recurse(n: u64) -> u64 {
     if n <= 1 {
         n

--- a/runtime/near-vm-runner/src/tests/cache.rs
+++ b/runtime/near-vm-runner/src/tests/cache.rs
@@ -18,7 +18,6 @@ use near_vm_logic::VMConfig;
 use std::hash::{Hash, Hasher};
 use std::io;
 use std::sync::atomic::{AtomicBool, Ordering};
-use wasmer_compiler::{CpuFeature, Target};
 use wasmer_engine::Executable;
 
 #[test]
@@ -122,13 +121,13 @@ fn test_wasmer2_artifact_output_stability() {
     ];
     let mut got_prepared_hashes = Vec::with_capacity(seeds.len());
     let compiled_hashes = [
-        3818562753706235018,
-        11870140033216711259,
-        5923781907461180018,
-        13755860129954519309,
-        4832119422677650601,
-        14075229507958855911,
-        8220837142162862198,
+        9393269650223240896,
+        6124152160101285799,
+        8789306975506976814,
+        11819823914734034238,
+        5479892730668892774,
+        8176904529073798417,
+        345836015667433529,
     ];
     let mut got_compiled_hashes = Vec::with_capacity(seeds.len());
     for seed in seeds {

--- a/runtime/near-vm-runner/src/tests/cache.rs
+++ b/runtime/near-vm-runner/src/tests/cache.rs
@@ -3,7 +3,6 @@
 
 use super::{create_context, with_vm_variants, LATEST_PROTOCOL_VERSION};
 use crate::internal::VMKind;
-use crate::near_vm_runner::NearVM;
 use crate::runner::VMResult;
 use crate::wasmer2_runner::Wasmer2VM;
 use crate::{prepare, MockCompiledContractCache};
@@ -13,14 +12,14 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::runtime::fees::RuntimeFeesConfig;
 use near_primitives::types::{CompiledContract, CompiledContractCache};
 use near_stable_hasher::StableHasher;
-use near_vm_compiler::{CpuFeature, Target};
-use near_vm_engine::Executable;
 use near_vm_errors::VMRunnerError;
 use near_vm_logic::mocks::mock_external::MockedExternal;
 use near_vm_logic::VMConfig;
 use std::hash::{Hash, Hasher};
 use std::io;
 use std::sync::atomic::{AtomicBool, Ordering};
+use wasmer_compiler::{CpuFeature, Target};
+use wasmer_engine::Executable;
 
 #[test]
 fn test_caches_compilation_error() {
@@ -106,7 +105,6 @@ fn make_cached_contract_call_vm(
 
 #[test]
 fn test_wasmer2_artifact_output_stability() {
-    use wasmer_engine::Executable;
     // If this test has failed, you want to adjust the necessary constants so that `cache::vm_hash`
     // changes (and only then the hashes here).
     //
@@ -114,23 +112,23 @@ fn test_wasmer2_artifact_output_stability() {
     // fall through the cracks here, but hopefully it should catch most of the fish just fine.
     let seeds = [2, 3, 5, 7, 11, 13, 17];
     let prepared_hashes = [
-        11313378614122864359,
-        5865541421624917606,
-        11731917380556063495,
-        8000182875575317016,
-        3130574445877428311,
-        11574598916196339098,
-        10719493536745069553,
+        12248437801724644735,
+        2647244875869025389,
+        892153519407678490,
+        8592050243596620350,
+        2309330154575012917,
+        9323529151210819831,
+        11488755771702465226,
     ];
     let mut got_prepared_hashes = Vec::with_capacity(seeds.len());
     let compiled_hashes = [
-        5254981150840481178,
-        15529260255496677612,
-        407257192602619216,
-        10913823971520273759,
-        17423008210698923502,
-        7011050181604188333,
-        15514788595649734538,
+        3818562753706235018,
+        11870140033216711259,
+        5923781907461180018,
+        13755860129954519309,
+        4832119422677650601,
+        14075229507958855911,
+        8220837142162862198,
     ];
     let mut got_compiled_hashes = Vec::with_capacity(seeds.len());
     for seed in seeds {
@@ -148,79 +146,6 @@ fn test_wasmer2_artifact_output_stability() {
         let triple = "x86_64-unknown-linux-gnu".parse().unwrap();
         let target = wasmer_compiler::Target::new(triple, features);
         let vm = Wasmer2VM::new_for_target(config, target);
-        let artifact = vm.compile_uncached(&contract).unwrap();
-        let serialized = artifact.serialize().unwrap();
-        let mut hasher = StableHasher::new();
-        serialized.hash(&mut hasher);
-        let this_hash = hasher.finish();
-        got_compiled_hashes.push(this_hash);
-
-        std::fs::write(format!("/tmp/artifact{}", this_hash), serialized).unwrap();
-    }
-    // These asserts have failed as a result of some change and the following text describes what
-    // the implications of the change.
-    //
-    // May need a protocol version change, and definitely wants a `WASMER2_CONFIG version update
-    // too, as below. Maybe something else too.
-    assert!(
-        got_prepared_hashes == prepared_hashes,
-        "contract preparation hashes have changed to {:#?}",
-        got_prepared_hashes
-    );
-    // In this case you will need to adjust the WASMER2_CONFIG version so that the cached contracts
-    // are evicted from the contract cache.
-    assert!(
-        got_compiled_hashes == compiled_hashes,
-        "VM output hashes have changed to {:#?}",
-        got_compiled_hashes
-    );
-    // Once it has been confirmed that these steps have been done, the expected hashes in this test
-    // can be adjusted.
-}
-
-#[test]
-fn test_near_vm_artifact_output_stability() {
-    // If this test has failed, you want to adjust the necessary constants so that `cache::vm_hash`
-    // changes (and only then the hashes here).
-    //
-    // Note that this test is a best-effort fish net. Some changes that should modify the hash will
-    // fall through the cracks here, but hopefully it should catch most of the fish just fine.
-    let seeds = [2, 3, 5, 7, 11, 13, 17];
-    let prepared_hashes = [
-        15237011375120738807,
-        3750594434467176559,
-        2196541628148102482,
-        1576495094908614397,
-        6394387219699970793,
-        18132026143745992229,
-        4095228008100475322,
-    ];
-    let mut got_prepared_hashes = Vec::with_capacity(seeds.len());
-    let compiled_hashes = [
-        10351663297260604629,
-        13937571770370186345,
-        9438649787181538636,
-        17513376043726020657,
-        8030854424152836681,
-        8449792361847063954,
-        2655860096455618118,
-    ];
-    let mut got_compiled_hashes = Vec::with_capacity(seeds.len());
-    for seed in seeds {
-        let contract = ContractCode::new(near_test_contracts::arbitrary_contract(seed), None);
-
-        let config = VMConfig::test();
-        let prepared_code =
-            prepare::prepare_contract(contract.code(), &config, VMKind::NearVm).unwrap();
-        let mut hasher = StableHasher::new();
-        (&contract.code(), &prepared_code).hash(&mut hasher);
-        got_prepared_hashes.push(hasher.finish());
-
-        let mut features = CpuFeature::set();
-        features.insert(CpuFeature::AVX);
-        let triple = "x86_64-unknown-linux-gnu".parse().unwrap();
-        let target = Target::new(triple, features);
-        let vm = NearVM::new_for_target(config, target);
         let artifact = vm.compile_uncached(&contract).unwrap();
         let serialized = artifact.serialize().unwrap();
         let mut hasher = StableHasher::new();

--- a/runtime/near-vm-runner/src/tests/compile_errors.rs
+++ b/runtime/near-vm-runner/src/tests/compile_errors.rs
@@ -171,11 +171,11 @@ fn test_limit_contract_functions_number() {
             VMOutcome: balance 4 storage_usage 12 return data None burnt gas 13048032213 used gas 13048032213
         "#]],
         expect![[r#"
-            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 13054614261 used gas 13054614261
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 13048032213 used gas 13048032213
         "#]],
         #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
         expect![[r#"
-            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 13054614261 used gas 13054614261
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 13048032213 used gas 13048032213
         "#]],
     ]);
 
@@ -258,7 +258,7 @@ fn test_limit_contract_functions_number() {
 }
 
 #[test]
-fn test_limit_locals_bigfunc() {
+fn test_limit_locals() {
     test_builder()
         .wasm(
             &near_test_contracts::LargeContract {
@@ -293,10 +293,10 @@ fn test_limit_locals_bigfunc() {
             }
             .make(),
         )
-        .opaque_error() // near-vm returns a proper stack overflow, others return memory access violation
+        .skip_wasmtime()
         .expect(expect![[r#"
             VMOutcome: balance 4 storage_usage 12 return data None burnt gas 43682463 used gas 43682463
-            Err: ...
+            Err: WebAssembly trap: An `unreachable` opcode was executed.
         "#]]);
 }
 
@@ -338,7 +338,7 @@ fn test_limit_locals_global() {
             .make(),
         )
         .expect(expect![[r#"
-            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 13001413761 used gas 13001413761
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 139269213 used gas 139269213
         "#]]);
 }
 
@@ -361,7 +361,7 @@ pub fn test_stablized_host_function() {
                 Err: ...
             "#]],
             expect![[r#"
-                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 7149592671 used gas 7149592671
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 7143010623 used gas 7143010623
             "#]],
         ]);
 }

--- a/runtime/near-vm-runner/src/tests/fuzzers.rs
+++ b/runtime/near-vm-runner/src/tests/fuzzers.rs
@@ -170,21 +170,7 @@ fn wasmer2_and_wasmtime_agree() {
         let wasmer2 = run_fuzz(&code, VMKind::Wasmer2).expect("fatal failure");
         let wasmtime = run_fuzz(&code, VMKind::Wasmtime).expect("fatal failure");
         assert_eq!(wasmer2, wasmtime);
-    });
-}
-
-#[test]
-fn near_vm_and_wasmtime_agree() {
-    check!().for_each(|data: &[u8]| {
-        let module = ArbitraryModule::arbitrary(&mut arbitrary::Unstructured::new(data));
-        let module = match module {
-            Ok(m) => m,
-            Err(_) => return,
-        };
-        let code = ContractCode::new(module.0.module.to_bytes(), None);
-        let near_vm = run_fuzz(&code, VMKind::NearVm).expect("fatal failure");
-        let wasmtime = run_fuzz(&code, VMKind::Wasmtime).expect("fatal failure");
-        assert_eq!(near_vm, wasmtime);
+        assert_eq!(wasmer2, wasmtime);
     });
 }
 
@@ -202,35 +188,6 @@ fn wasmer2_is_reproducible() {
             let mut first_hash = None;
             for _ in 0..3 {
                 let vm = Wasmer2VM::new(config.clone());
-                let exec = match vm.compile_uncached(&code) {
-                    Ok(e) => e,
-                    Err(_) => return,
-                };
-                let code = exec.serialize().unwrap();
-                let hash = CryptoHash::hash_bytes(&code);
-                match first_hash {
-                    None => first_hash = Some(hash),
-                    Some(h) => assert_eq!(h, hash),
-                }
-            }
-        }
-    })
-}
-
-#[cfg(all(feature = "near_vm", target_arch = "x86_64"))]
-#[test]
-fn near_vm_is_reproducible() {
-    use crate::near_vm_runner::NearVM;
-    use near_primitives::hash::CryptoHash;
-    use near_vm_engine::Executable;
-
-    bolero::check!().for_each(|data: &[u8]| {
-        if let Ok(module) = ArbitraryModule::arbitrary(&mut arbitrary::Unstructured::new(data)) {
-            let code = ContractCode::new(module.0.module.to_bytes(), None);
-            let config = VMConfig::test();
-            let mut first_hash = None;
-            for _ in 0..3 {
-                let vm = NearVM::new(config.clone());
                 let exec = match vm.compile_uncached(&code) {
                     Ok(e) => e,
                     Err(_) => return,

--- a/runtime/near-vm-runner/src/tests/rs_contract.rs
+++ b/runtime/near-vm-runner/src/tests/rs_contract.rs
@@ -151,7 +151,7 @@ def_test_ext!(ext_block_timestamp, "ext_block_timestamp", &42u64.to_le_bytes());
 def_test_ext!(ext_storage_usage, "ext_storage_usage", &12u64.to_le_bytes());
 // Note, the used_gas is not a global used_gas at the beginning of method, but instead a diff
 // in used_gas for computing fib(30) in a loop
-def_test_ext!(ext_used_gas, "ext_used_gas", &[72, 146, 120, 16, 0, 0, 0, 0]);
+def_test_ext!(ext_used_gas, "ext_used_gas", &[111, 10, 200, 15, 0, 0, 0, 0]);
 def_test_ext!(
     ext_sha256,
     "ext_sha256",

--- a/runtime/near-vm-runner/src/tests/runtime_errors.rs
+++ b/runtime/near-vm-runner/src/tests/runtime_errors.rs
@@ -1,6 +1,5 @@
 use super::test_builder::test_builder;
 use expect_test::expect;
-#[allow(unused_imports)] // used only when specific features are enabled
 use near_primitives::version::ProtocolFeature;
 use std::fmt::Write;
 
@@ -12,7 +11,7 @@ static INFINITE_INITIALIZER_CONTRACT: &str = r#"
 )"#;
 
 #[test]
-fn test_infinite_initializer_basic() {
+fn test_infinite_initializer() {
     test_builder()
         .wat(INFINITE_INITIALIZER_CONTRACT)
         .gas(10u64.pow(10))
@@ -48,7 +47,7 @@ static SIMPLE_CONTRACT: &str = r#"(module (func (export "main")))"#;
 #[test]
 fn test_simple_contract() {
     test_builder().wat(SIMPLE_CONTRACT).expect(expect![[r#"
-        VMOutcome: balance 4 storage_usage 12 return data None burnt gas 49397511 used gas 49397511
+        VMOutcome: balance 4 storage_usage 12 return data None burnt gas 42815463 used gas 42815463
     "#]]);
 }
 
@@ -134,7 +133,7 @@ fn test_trap_contract() {
         .wat(r#"(module (func (export "main") (unreachable)) )"#)
         .skip_wasmtime()
         .expect(expect![[r#"
-            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 50437017 used gas 50437017
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 43854969 used gas 43854969
             Err: WebAssembly trap: An `unreachable` opcode was executed.
         "#]]);
 }
@@ -151,7 +150,7 @@ fn test_trap_initializer() {
         )
         .skip_wasmtime()
         .expect(expect![[r#"
-            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 53905017 used gas 53905017
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 47322969 used gas 47322969
             Err: WebAssembly trap: An `unreachable` opcode was executed.
         "#]]);
 }
@@ -172,7 +171,7 @@ fn test_div_by_zero_contract() {
         )
         .skip_wasmtime()
         .expect(expect![[r#"
-            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 53166279 used gas 53166279
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 47406987 used gas 47406987
             Err: WebAssembly trap: An arithmetic exception, e.g. divided by zero.
         "#]]);
 }
@@ -193,7 +192,7 @@ fn test_float_to_int_contract() {
             ))
             .skip_wasmtime()
             .expect(expect![[r#"
-                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 53427273 used gas 53427273
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 47667981 used gas 47667981
                 Err: WebAssembly trap: An arithmetic exception, e.g. divided by zero.
             "#]]);
     }
@@ -217,7 +216,7 @@ fn test_indirect_call_to_null_contract() {
         .opaque_error()
         .skip_wasmtime()
         .expect(expect![[r#"
-            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 56678523 used gas 56678523
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 50919231 used gas 50919231
             Err: ...
         "#]])
 }
@@ -243,7 +242,7 @@ fn test_indirect_call_to_wrong_signature_contract() {
         )
         .skip_wasmtime()
         .expect(expect![[r#"
-            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 61663773 used gas 61663773
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 55904481 used gas 55904481
             Err: WebAssembly trap: Call indirect incorrect signature trap.
         "#]])
 }
@@ -301,7 +300,7 @@ fn test_guest_panic() {
 )"#,
         )
         .expect(expect![[r#"
-            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 322357878 used gas 322357878
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 315775830 used gas 315775830
             Err: Smart contract panicked: explicit guest panic
         "#]]);
 }
@@ -327,10 +326,9 @@ fn test_stack_overflow() {
     test_builder()
         .wat(r#"(module (func $f (export "main") (call $f)))"#)
         .skip_wasmtime()
-        .opaque_error() // near-vm returns stack overflow, others return invalid memory access
         .expect(expect![[r#"
-            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 30376143897 used gas 30376143897
-            Err: ...
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 13526101017 used gas 13526101017
+            Err: WebAssembly trap: An `unreachable` opcode was executed.
         "#]]);
 }
 
@@ -351,15 +349,14 @@ fn test_stack_instrumentation_protocol_upgrade() {
         .method("f1")
         .protocol_features(&[ProtocolFeature::CorrectStackLimit])
         .skip_wasmtime()
-        .opaque_error() // near-vm returns stack overflow, others return invalid memory access
         .expects(&[
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 6789985365 used gas 6789985365
-                Err: ...
+                Err: WebAssembly trap: An `unreachable` opcode was executed.
             "#]],
             expect![[r#"
-                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 31767212013 used gas 31767212013
-                Err: ...
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 6789985365 used gas 6789985365
+                Err: WebAssembly trap: An `unreachable` opcode was executed.
             "#]],
         ]);
 
@@ -378,15 +375,14 @@ fn test_stack_instrumentation_protocol_upgrade() {
         .method("f2")
         .protocol_features(&[ProtocolFeature::CorrectStackLimit])
         .skip_wasmtime()
-        .opaque_error() // near-vm returns stack overflow, others return invalid memory access
         .expects(&[
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 6789985365 used gas 6789985365
-                Err: ...
+                Err: WebAssembly trap: An `unreachable` opcode was executed.
             "#]],
             expect![[r#"
-                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 29698803429 used gas 29698803429
-                Err: ...
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 2745316869 used gas 2745316869
+                Err: WebAssembly trap: An `unreachable` opcode was executed.
             "#]],
         ]);
 }
@@ -546,7 +542,7 @@ static EXTERNAL_CALL_CONTRACT: &str = r#"
 #[test]
 fn test_external_call_ok() {
     test_builder().wat(EXTERNAL_CALL_CONTRACT).expect(expect![[r#"
-        VMOutcome: balance 4 storage_usage 12 return data None burnt gas 326865384 used gas 326865384
+        VMOutcome: balance 4 storage_usage 12 return data None burnt gas 320283336 used gas 320283336
     "#]]);
 }
 
@@ -575,7 +571,7 @@ fn test_external_call_indirect() {
   )
 )"#
         ).expect(expect![[r#"
-            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 335491140 used gas 335491140
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 328909092 used gas 328909092
         "#]]);
 }
 
@@ -593,31 +589,13 @@ fn test_address_overflow() {
 )"#;
 
     test_builder().wat(code).skip_wasmtime().skip_wasmer0().expect(expect![[r#"
-        VMOutcome: balance 4 storage_usage 12 return data None burnt gas 54294273 used gas 54294273
+        VMOutcome: balance 4 storage_usage 12 return data None burnt gas 48534981 used gas 48534981
         Err: WebAssembly trap: Memory out of bounds trap.
     "#]]);
 
     // wasmer0 incorrectly doesn't catch overflow during address calculation
-    test_builder().wat(code).only_wasmer0().expect(expect![[r#"
-        VMOutcome: balance 4 storage_usage 12 return data None burnt gas 55117029 used gas 55117029
-    "#]]);
-}
-
-/// Load from address that is within bounds, validating that not all loads do overflow
-#[test]
-fn test_address_valid() {
-    let code = r#"
-(module
-  (memory 1)
-  (func (export "main")
-    i32.const 10
-    i64.load32_u offset=10 align=1
-    drop
-  )
-)"#;
-
-    test_builder().wat(code).expect(expect![[r#"
-        VMOutcome: balance 4 storage_usage 12 return data None burnt gas 54250029 used gas 54250029
+    test_builder().wat(code).skip_wasmtime().skip_wasmer2().expect(expect![[r#"
+        VMOutcome: balance 4 storage_usage 12 return data None burnt gas 48534981 used gas 48534981
     "#]]);
 }
 
@@ -645,12 +623,12 @@ fn test_nan_sign() {
 )"#;
 
     test_builder().wat(code).skip_wasmtime().skip_wasmer0().expect(expect![[r#"
-        VMOutcome: balance 4 storage_usage 12 return data None burnt gas 61570815 used gas 61570815
+        VMOutcome: balance 4 storage_usage 12 return data None burnt gas 54988767 used gas 54988767
     "#]]);
 
     // wasmer0 doesn't canonicalize NaNs
-    test_builder().wat(code).only_wasmer0().expect(expect![[r#"
-        VMOutcome: balance 4 storage_usage 12 return data None burnt gas 60748059 used gas 60748059
+    test_builder().wat(code).skip_wasmtime().skip_wasmer2().expect(expect![[r#"
+        VMOutcome: balance 4 storage_usage 12 return data None burnt gas 54988767 used gas 54988767
         Err: WebAssembly trap: An arithmetic exception, e.g. divided by zero.
     "#]]);
 }
@@ -736,10 +714,10 @@ mod fix_contract_loading_cost_protocol_upgrade {
             .protocol_features(&[ProtocolFeature::FixContractLoadingCost])
             .expects(&[
                 expect![[r#"
-                    VMOutcome: balance 4 storage_usage 12 return data None burnt gas 53989035 used gas 53989035
+                    VMOutcome: balance 4 storage_usage 12 return data None burnt gas 47406987 used gas 47406987
                 "#]],
                 expect![[r#"
-                    VMOutcome: balance 4 storage_usage 12 return data None burnt gas 53989035 used gas 53989035
+                    VMOutcome: balance 4 storage_usage 12 return data None burnt gas 47406987 used gas 47406987
                 "#]],
             ]);
     }

--- a/runtime/near-vm-runner/src/vm_kind.rs
+++ b/runtime/near-vm-runner/src/vm_kind.rs
@@ -25,10 +25,10 @@ impl VMKind {
         // Only wasmtime supports non-x86_64 systems
         #[cfg(all(
             not(target_arch = "x86_64"),
-            any(feature = "force_wasmer0", feature = "force_wasmer2", feature = "force_near_vm")
+            any(feature = "force_wasmer0", feature = "force_wasmer2")
         ))]
         compile_error!(
-            "Wasmer and NearVM only support x86_64, but such a force_* feature was passed to near-vm-runner"
+            "Wasmer only supports x86_64, but a force_wasmer* feature was passed to near-vm-runner"
         );
 
         if cfg!(feature = "force_wasmer0") {
@@ -40,14 +40,9 @@ impl VMKind {
         if cfg!(feature = "force_wasmer2") {
             return VMKind::Wasmer2;
         }
-        if cfg!(feature = "force_near_vm") {
-            return VMKind::NearVm;
-        }
 
         if cfg!(target_arch = "x86_64") {
-            if checked_feature!("stable", NearVm, protocol_version) {
-                VMKind::NearVm
-            } else if checked_feature!("stable", Wasmer2, protocol_version) {
+            if checked_feature!("stable", Wasmer2, protocol_version) {
                 VMKind::Wasmer2
             } else {
                 VMKind::Wasmer0

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -61,7 +61,7 @@ struct CliArgs {
     #[clap(long, default_value = "time", possible_values = &["icount", "time"])]
     metric: String,
     /// Which VM to test.
-    #[clap(long, possible_values = &["wasmer", "wasmer2", "wasmtime", "near-vm"])]
+    #[clap(long, possible_values = &["wasmer", "wasmer2", "wasmtime"])]
     vm_kind: Option<String>,
     /// Render existing `costs.txt` as `RuntimeConfig`.
     #[clap(long)]
@@ -289,7 +289,6 @@ fn run_estimation(cli_args: CliArgs) -> anyhow::Result<Option<CostTable>> {
         Some("wasmer") => VMKind::Wasmer0,
         Some("wasmer2") => VMKind::Wasmer2,
         Some("wasmtime") => VMKind::Wasmtime,
-        Some("near-vm") => VMKind::NearVm,
         None => VMKind::for_protocol_version(PROTOCOL_VERSION),
         Some(other) => unreachable!("Unknown vm_kind {}", other),
     };


### PR DESCRIPTION
The fuzzer found an issue with finite-wasm, and we are currently
investigating unexpected gas changes due to near-vm.

Revert both changes for now so they aren't included in v1.34.