### PR TITLE
fix wasmer2 output hashes for rust 1.68.2

### DIFF
--- a/runtime/near-vm-runner/src/tests/cache.rs
+++ b/runtime/near-vm-runner/src/tests/cache.rs
@@ -122,13 +122,13 @@ fn test_wasmer2_artifact_output_stability() {
     ];
     let mut got_prepared_hashes = Vec::with_capacity(seeds.len());
     let compiled_hashes = [
-        3818562753706235018,
-        11870140033216711259,
-        5923781907461180018,
-        13755860129954519309,
-        4832119422677650601,
-        14075229507958855911,
-        8220837142162862198,
+        9393269650223240896,
+        6124152160101285799,
+        8789306975506976814,
+        11819823914734034238,
+        5479892730668892774,
+        8176904529073798417,
+        345836015667433529,
     ];
     let mut got_compiled_hashes = Vec::with_capacity(seeds.len());
     for seed in seeds {

--- a/runtime/near-vm-runner/src/wasmer2_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer2_runner.rs
@@ -233,7 +233,7 @@ impl Wasmer2Config {
 //  major version << 6
 //  minor version
 const WASMER2_CONFIG: Wasmer2Config = Wasmer2Config {
-    seed: (1 << 10) | (9 << 6) | 0,
+    seed: (1 << 10) | (9 << 6) | 1,
     engine: WasmerEngine::Universal,
     compiler: WasmerCompiler::Singlepass,
 };


### PR DESCRIPTION
The hashes were for rust 1.69, which is what master uses.

Before this  change:
```
cargo +1.69.0 test -p near-vm-runner // succeeds
cargo test -p near-vm-runner // fails because it uses 1.68.2 specified in rust-toolchain.toml
```

After this  change:
```
cargo +1.69.0 test -p near-vm-runner // fails
cargo test -p near-vm-runner // succeeds
```

1.34 MUST be compiled with rust 1.68.2 or else the smart contract binaries will be incompatible!