### PR TITLE
fix(loadtest2): gas amount

### DIFF
--- a/pytest/tests/loadtest/loadtest2.py
+++ b/pytest/tests/loadtest/loadtest2.py
@@ -165,8 +165,8 @@ class TransferFT(Transaction):
             "ft_transfer",
             json.dumps(args).encode('utf-8'),
             # About enough gas per call to fit N such transactions into an average block.
-            self.tgas**account.TGAS,
-            # Gotta deposit some NEAR for storage?
+            self.tgas * account.TGAS,
+            # Gotta attach exactly 1 yoctoNEAR according to NEP-141 to avoid calls from restricted access keys
             1,
             sender.use_nonce(),
             block_hash)


### PR DESCRIPTION
This should be multiplication, not exponential.

At least in local testing, this caused problems and txs
were never submitted.

(Flyby updating a comment at the same place as well)