### PR TITLE
Fix: garbage collection test

### DIFF
--- a/pytest/tests/sanity/garbage_collection1.py
+++ b/pytest/tests/sanity/garbage_collection1.py
@@ -17,7 +17,7 @@ import utils
 TARGET_HEIGHT = 60
 TIMEOUT = 30
 
-consensus_config = {
+nodes_config = {
     "consensus": {
         "min_block_production_delay": {
             "secs": 0,
@@ -31,7 +31,8 @@ consensus_config = {
             "secs": 0,
             "nanos": 400000000
         }
-    }
+    },
+    "state_sync_enabled": True
 }
 
 nodes = start_cluster(
@@ -44,9 +45,9 @@ nodes = start_cluster(
          "records", 0, "Account", "account", "locked",
          "260000000000000000000000000000000"
      ]], {
-         0: consensus_config,
-         1: consensus_config,
-         2: consensus_config
+         0: nodes_config,
+         1: nodes_config,
+         2: nodes_config
      })
 
 logger.info('kill node1 and node2')

--- a/pytest/tests/sanity/gc_sync_after_sync.py
+++ b/pytest/tests/sanity/gc_sync_after_sync.py
@@ -16,20 +16,20 @@ from cluster import start_cluster
 from configured_logger import logger
 import utils
 
-TARGET_HEIGHT1 = 60
-TARGET_HEIGHT2 = 170
-TARGET_HEIGHT3 = 250
+TARGET_HEIGHT1 = 125
+TARGET_HEIGHT2 = 275
+TARGET_HEIGHT3 = 370
 
 consensus_config = {
     "consensus": {
-        "block_fetch_horizon": 20,
-        "block_header_fetch_horizon": 20
+        "block_fetch_horizon": 40,
+        "block_header_fetch_horizon": 40
     }
 }
 
 nodes = start_cluster(
     4, 0, 1, None,
-    [["epoch_length", 10],
+    [["epoch_length", 30],
      ["validators", 0, "amount", "12500000000000000000000000000000"],
      [
          "records", 0, "Account", "account", "locked",
@@ -46,17 +46,13 @@ nodes = start_cluster(
 logger.info('Kill node 1')
 nodes[1].kill()
 
-node0_height, _ = utils.wait_for_blocks(nodes[0],
-                                        target=TARGET_HEIGHT1,
-                                        verbose=True)
+node0_height, _ = utils.wait_for_blocks(nodes[0], target=TARGET_HEIGHT1)
 
 logger.info('Restart node 1')
 nodes[1].start(boot_node=nodes[1])
 time.sleep(3)
 
-node1_height, _ = utils.wait_for_blocks(nodes[1],
-                                        target=node0_height,
-                                        verbose=True)
+node1_height, _ = utils.wait_for_blocks(nodes[1], target=node0_height)
 
 if swap_nodes:
     logger.info('Swap nodes 0 and 1')
@@ -65,17 +61,13 @@ if swap_nodes:
 logger.info('Kill node 1')
 nodes[1].kill()
 
-node0_height, _ = utils.wait_for_blocks(nodes[0],
-                                        target=TARGET_HEIGHT2,
-                                        verbose=True)
+node0_height, _ = utils.wait_for_blocks(nodes[0], target=TARGET_HEIGHT2)
 
 logger.info('Restart node 1')
 nodes[1].start(boot_node=nodes[1])
 time.sleep(3)
 
-node1_height, _ = utils.wait_for_blocks(nodes[1],
-                                        target=node0_height,
-                                        verbose=True)
+node1_height, _ = utils.wait_for_blocks(nodes[1], target=node0_height)
 
 # all fresh data should be synced
 blocks_count = 0

--- a/pytest/tests/sanity/gc_sync_after_sync.py
+++ b/pytest/tests/sanity/gc_sync_after_sync.py
@@ -16,20 +16,21 @@ from cluster import start_cluster
 from configured_logger import logger
 import utils
 
-TARGET_HEIGHT1 = 125
-TARGET_HEIGHT2 = 245
-TARGET_HEIGHT3 = 370
+TARGET_HEIGHT1 = 60
+TARGET_HEIGHT2 = 170
+TARGET_HEIGHT3 = 250
 
-consensus_config = {
+node1_config = {
     "consensus": {
         "block_fetch_horizon": 20,
         "block_header_fetch_horizon": 20
-    }
+    },
+    "state_sync_enabled": True
 }
 
 nodes = start_cluster(
     4, 0, 1, None,
-    [["epoch_length", 30],
+    [["epoch_length", 10],
      ["validators", 0, "amount", "12500000000000000000000000000000"],
      [
          "records", 0, "Account", "account", "locked",
@@ -41,7 +42,7 @@ nodes = start_cluster(
      ], ['total_supply', "4925000000000000000000000000000000"],
      ["block_producer_kickout_threshold", 40],
      ["chunk_producer_kickout_threshold", 40], ["num_block_producer_seats", 10],
-     ["num_block_producer_seats_per_shard", [10]]], {1: consensus_config})
+     ["num_block_producer_seats_per_shard", [10]]], {1: node1_config})
 
 logger.info('Kill node 1')
 nodes[1].kill()
@@ -102,7 +103,7 @@ assert blocks_count == 0
 
 # all data before second sync should be GCed
 blocks_count = 0
-for height in range(100, 120):
+for height in range(130, 150):
     block1 = nodes[1].json_rpc('block', [height], timeout=15)
     if 'result' in block1:
         blocks_count += 1

--- a/pytest/tests/sanity/gc_sync_after_sync.py
+++ b/pytest/tests/sanity/gc_sync_after_sync.py
@@ -17,7 +17,7 @@ from configured_logger import logger
 import utils
 
 TARGET_HEIGHT1 = 125
-TARGET_HEIGHT2 = 275
+TARGET_HEIGHT2 = 245
 TARGET_HEIGHT3 = 370
 
 consensus_config = {
@@ -48,7 +48,7 @@ nodes[1].kill()
 
 node0_height, _ = utils.wait_for_blocks(nodes[0], target=TARGET_HEIGHT1)
 
-logger.info('Restart node 1')
+logger.info('Starting back node 1')
 nodes[1].start(boot_node=nodes[1])
 time.sleep(3)
 
@@ -102,7 +102,7 @@ assert blocks_count == 0
 
 # all data before second sync should be GCed
 blocks_count = 0
-for height in range(130, 150):
+for height in range(100, 120):
     block1 = nodes[1].json_rpc('block', [height], timeout=15)
     if 'result' in block1:
         blocks_count += 1

--- a/pytest/tests/sanity/gc_sync_after_sync.py
+++ b/pytest/tests/sanity/gc_sync_after_sync.py
@@ -22,8 +22,8 @@ TARGET_HEIGHT3 = 370
 
 consensus_config = {
     "consensus": {
-        "block_fetch_horizon": 40,
-        "block_header_fetch_horizon": 40
+        "block_fetch_horizon": 20,
+        "block_header_fetch_horizon": 20
     }
 }
 


### PR DESCRIPTION
This PR is to fix long running issue with garbage collection test.

Test was failing because node 1 could not sync from remaining 3 peers, which did not have the required by node 1 blocks, for example target heigh 1:
epoch_length = 10
target_heigh1 = 60 
gc_num_epochs_to_keep = 5

This means that by the time network reached target heigh 60, nodes 0, 2 and 3 garbage collection mechanism will clear blocks from 1 to 10:  
60 (heigh) - 10 (epoch length) * 5 (epochs to keep).

Fix is to enable STATE SYNC





