### PR TITLE
fix: Make sure we generate enough accounts for sharding test

### DIFF
--- a/core/store/src/test_utils.rs
+++ b/core/store/src/test_utils.rs
@@ -107,10 +107,11 @@ pub fn test_populate_store_rc(store: &Store, data: &[(DBCol, Vec<u8>, Vec<u8>)])
 
 fn gen_accounts_from_alphabet(
     rng: &mut impl Rng,
+    min_size: usize,
     max_size: usize,
     alphabet: &[u8],
 ) -> Vec<AccountId> {
-    let size = rng.gen_range(0..max_size) + 1;
+    let size = rng.gen_range(min_size..=max_size);
     std::iter::repeat_with(|| gen_account(rng, alphabet)).take(size).collect()
 }
 
@@ -120,15 +121,15 @@ pub fn gen_account(rng: &mut impl Rng, alphabet: &[u8]) -> AccountId {
     from_utf8(&s).unwrap().parse().unwrap()
 }
 
-pub fn gen_unique_accounts(rng: &mut impl Rng, max_size: usize) -> Vec<AccountId> {
+pub fn gen_unique_accounts(rng: &mut impl Rng, min_size: usize, max_size: usize) -> Vec<AccountId> {
     let alphabet = b"abcdefghijklmn";
-    let accounts = gen_accounts_from_alphabet(rng, max_size, alphabet);
+    let accounts = gen_accounts_from_alphabet(rng, min_size, max_size, alphabet);
     accounts.into_iter().collect::<HashSet<_>>().into_iter().collect()
 }
 
 pub fn gen_receipts(rng: &mut impl Rng, max_size: usize) -> Vec<Receipt> {
     let alphabet = &b"abcdefgh"[0..rng.gen_range(4..8)];
-    let accounts = gen_accounts_from_alphabet(rng, max_size, alphabet);
+    let accounts = gen_accounts_from_alphabet(rng, 1, max_size, alphabet);
     accounts
         .iter()
         .map(|account_id| Receipt {

--- a/core/store/src/trie/split_state.rs
+++ b/core/store/src/trie/split_state.rs
@@ -635,7 +635,7 @@ mod tests {
     fn test_split_and_update_state_impl(rng: &mut impl Rng) {
         let tries = create_tries();
         // add accounts and receipts to state
-        let mut account_ids = gen_unique_accounts(rng, 100);
+        let mut account_ids = gen_unique_accounts(rng, 1, 100);
         let mut trie_update = tries.new_trie_update(ShardUId::single_shard(), Trie::EMPTY_ROOT);
         for account_id in account_ids.iter() {
             set_account(
@@ -712,7 +712,7 @@ mod tests {
         // update the original shard
         for _ in 0..10 {
             // add accounts
-            let new_accounts = gen_unique_accounts(rng, 10);
+            let new_accounts = gen_unique_accounts(rng, 1, 10);
             let mut trie_update = tries.new_trie_update(ShardUId::single_shard(), state_root);
             for account_id in new_accounts.iter() {
                 set_account(

--- a/integration-tests/src/tests/client/sharding_upgrade.rs
+++ b/integration-tests/src/tests/client/sharding_upgrade.rs
@@ -67,7 +67,8 @@ impl TestShardUpgradeEnv {
         let validators: Vec<AccountId> =
             (0..num_validators).map(|i| format!("test{}", i).parse().unwrap()).collect();
         let initial_accounts =
-            [validators, gen_unique_accounts(&mut rng, num_init_accounts)].concat();
+            [validators, gen_unique_accounts(&mut rng, num_init_accounts, num_init_accounts)]
+                .concat();
         let genesis =
             setup_genesis(epoch_length, num_validators as u64, initial_accounts.clone(), gas_limit);
         let chain_genesis = ChainGenesis::new(&genesis);


### PR DESCRIPTION
As before, even though the setup specified `num_init_accounts` in reality this was an upper bound on the number of accounts to generate, which ended up breaking an assumption in one of the tests:

```
thread 'tests::client::sharding_upgrade::test_shard_layout_upgrade_missing_chunks_mid_missing_prob' panicked at 'index out of bounds: the len is 1 but the index is 1', integration-tests/src/tests/client/sharding_upgrade.rs:623:35
```