### PR TITLE
fix(tests): Fix sync_nodes and sync_after_sync_nodes

### DIFF
--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -167,7 +167,7 @@ pub enum Error {
     /// Invalid Gas Limit
     #[error("Invalid Gas Limit")]
     InvalidGasLimit,
-    /// Invalid Gas Limit
+    /// Invalid Gas Price
     #[error("Invalid Gas Price")]
     InvalidGasPrice,
     /// Invalid Gas Used

--- a/integration-tests/src/tests/nearcore/sync_nodes.rs
+++ b/integration-tests/src/tests/nearcore/sync_nodes.rs
@@ -1,11 +1,9 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
-
 use actix::{Actor, Addr, System};
 use futures::{future, FutureExt};
 use near_primitives::test_utils::create_test_signer;
-
 use crate::genesis_helpers::genesis_block;
 use crate::test_helpers::heavy_test;
 use near_actix_test_utils::run_actix;
@@ -21,7 +19,7 @@ use near_o11y::WithSpanContextExt;
 use near_primitives::block::Approval;
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::PartialMerkleTree;
-use near_primitives::num_rational::Ratio;
+use near_primitives::num_rational::{Ratio, Rational32};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{BlockHeightDelta, EpochId};
@@ -106,6 +104,7 @@ fn add_blocks(
 fn setup_configs() -> (Genesis, Block, NearConfig, NearConfig) {
     let mut genesis = Genesis::test(vec!["other".parse().unwrap()], 1);
     genesis.config.epoch_length = 5;
+    genesis.config.max_inflation_rate = Rational32::from_integer(0);
     let genesis_block = genesis_block(&genesis);
 
     let (port1, port2) =
@@ -115,11 +114,13 @@ fn setup_configs() -> (Genesis, Block, NearConfig, NearConfig) {
     near1.client_config.min_num_peers = 1;
     near1.client_config.epoch_sync_enabled = false;
     near1.client_config.state_sync_enabled = true;
+
     let mut near2 = load_test_config("test2", port2, genesis.clone());
     near2.network_config.peer_store.boot_nodes = convert_boot_nodes(vec![("test1", *port1)]);
     near2.client_config.min_num_peers = 1;
     near2.client_config.epoch_sync_enabled = false;
     near2.client_config.state_sync_enabled = true;
+
     (genesis, genesis_block, near1, near2)
 }
 


### PR DESCRIPTION
The tests were failing because one of the blocks couldn't be added. That block was rejected because it provided wrong total_supply, it didn't take validator rewards into account. Fixed by disabling validator rewards in these tests.