### PR TITLE
feature: Add metric measuring size of transaction pool

### DIFF
--- a/chain/pool/src/metrics.rs
+++ b/chain/pool/src/metrics.rs
@@ -1,10 +1,18 @@
 use near_o11y::metrics::IntGauge;
 use once_cell::sync::Lazy;
 
-pub static TRANSACTION_POOL_TOTAL: Lazy<IntGauge> = Lazy::new(|| {
+pub static TRANSACTION_POOL_COUNT: Lazy<IntGauge> = Lazy::new(|| {
     near_o11y::metrics::try_create_int_gauge(
         "near_transaction_pool_entries",
         "Total number of transactions currently in the pools tracked by the node",
+    )
+    .unwrap()
+});
+
+pub static TRANSACTION_POOL_SIZE: Lazy<IntGauge> = Lazy::new(|| {
+    near_o11y::metrics::try_create_int_gauge(
+        "near_transaction_pool_size",
+        "Total size in bytes of transactions currently in the pools tracked by the node",
     )
     .unwrap()
 });


### PR DESCRIPTION
This will allow us to understand how big the transaction pools get in practice and what is the realistic limit to set for them.

The logic within pool iterator is a bit complex due to the need to return transactions back to the pool and I'm working on a way to simplify it in a separate PR, but for now this accounting should do the job.

This is one of the steps for https://github.com/near/nearcore/issues/3284