### PR TITLE
core: avoid memory allocations when dealing with Serde data

### DIFF
--- a/chain/jsonrpc/client/src/lib.rs
+++ b/chain/jsonrpc/client/src/lib.rs
@@ -85,10 +85,8 @@ where
         .map_err(|err| err.to_string())
         .and_then(|mut response| {
             response.body().map(|body| match body {
-                Ok(bytes) => String::from_utf8(bytes.to_vec())
-                    .map_err(|err| format!("Error {:?} in {:?}", err, bytes))
-                    .and_then(|s| serde_json::from_str(&s).map_err(|err| err.to_string())),
-                Err(_) => Err("Payload error: {:?}".to_string()),
+                Ok(bytes) => serde_json::from_slice(&bytes).map_err(|err| err.to_string()),
+                Err(err) => Err(format!("Payload error: {err}")),
             })
         })
         .boxed_local()
@@ -131,7 +129,7 @@ macro_rules! http_client {
                 pub fn $method(&$selff $(, $arg_name: $arg_ty)*)
                     -> HttpRequest<$return_ty>
                 {
-                    let method = String::from(stringify!($method));
+                    let method = stringify!($method);
                     let params = expand_params!($($arg_name,)*);
                     call_http_get(&$selff.client, &$selff.server_addr, &method, params)
                 }
@@ -168,7 +166,7 @@ macro_rules! jsonrpc_client {
                 pub fn $method(&$selff $(, $arg_name: $arg_ty)*)
                     -> RpcRequest<$return_ty>
                 {
-                    let method = String::from(stringify!($method));
+                    let method = stringify!($method);
                     let params = expand_params!($($arg_name,)*);
                     call_method(&$selff.client, &$selff.server_addr, &method, params)
                 }

--- a/utils/fmt/src/lib.rs
+++ b/utils/fmt/src/lib.rs
@@ -62,7 +62,7 @@ impl<'a> Bytes<'a> {
             Ok(s[1..s.len().checked_sub(1).expect("s.len() >= 2 ")].as_bytes().to_vec())
         } else {
             // encoded with base64
-            from_base64(s)
+            from_base64(s).map_err(|err| err.into())
         }
     }
 }


### PR DESCRIPTION
1. Use serde::from_slice instead of String::from_utf8+serde::from_str
   to avoid separate UTF-8 validation and vector allocation.
2. Use serde:\:de::Visitor to avoid String allocation when
   deserialising base64 data.
3. Switch serialising from using serialize_str to calling collect_str
   on base64_display which again avoids temporary String.
4. Postpone when base64 decode error is converted to avoid boxing it.