### PR TITLE
chore: fix publish pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2615,7 +2615,7 @@ dependencies = [
  "near-performance-metrics",
  "near-primitives",
  "near-primitives-core",
- "near-stdx 0.16.0",
+ "near-stdx",
  "near-store",
  "near-telemetry",
  "near-test-contracts",
@@ -3409,7 +3409,7 @@ dependencies = [
  "hex-literal",
  "near-account-id",
  "near-config-utils",
- "near-stdx 0.16.0",
+ "near-stdx",
  "once_cell",
  "primitive-types",
  "rand 0.7.3",
@@ -3837,7 +3837,7 @@ dependencies = [
  "near-fmt",
  "near-primitives-core",
  "near-rpc-error-macro",
- "near-stdx 0.16.0",
+ "near-stdx",
  "near-vm-errors",
  "num-rational",
  "once_cell",
@@ -3955,12 +3955,6 @@ name = "near-stdx"
 version = "0.0.0"
 
 [[package]]
-name = "near-stdx"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c05ded9a90c087aaebfafdf01f2801f5d31817f9a3514ce09aed270001d650e"
-
-[[package]]
 name = "near-store"
 version = "0.0.0"
 dependencies = [
@@ -3984,7 +3978,7 @@ dependencies = [
  "near-fmt",
  "near-o11y",
  "near-primitives",
- "near-stdx 0.16.0",
+ "near-stdx",
  "num_cpus",
  "once_cell",
  "rand 0.8.5",
@@ -4190,7 +4184,7 @@ dependencies = [
  "near-o11y",
  "near-primitives",
  "near-primitives-core",
- "near-stdx 0.16.0",
+ "near-stdx",
  "near-vm-errors",
  "ripemd",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,16 @@
+[workspace.package]
+version = "0.0.0" # managed by cargo-workspaces, see below
+authors = ["Near Inc <hello@nearprotocol.com>"]
+edition = "2021"
+rust-version = "1.69.0"
+repository = "https://github.com/near/nearcore"
+license = "MIT OR Apache-2.0"
+
+[workspace.metadata.workspaces]
+# shared version of all public crates in the workspace
+version = "0.16.1"
+exclude = ["neard"]
+
 [workspace]
 members = [
     "chain/chain",
@@ -75,10 +88,6 @@ members = [
     "utils/stdx",
 ]
 
-[workspace.metadata.workspaces]
-version = "0.16.1"
-exclude = [ "neard" ]
-
 [workspace.dependencies]
 actix = "0.13.0"
 actix-cors = "0.6.1"
@@ -135,7 +144,7 @@ flate2 = "1.0.22"
 fs2 = "0.4"
 futures = "0.3.5"
 futures-util = "0.3"
-genesis-populate = { path = "genesis-tools/genesis-populate"}
+genesis-populate = { path = "genesis-tools/genesis-populate" }
 hashbrown = "0.11"
 hex = { version = "0.4.2", features = ["serde"] }
 hex-literal = "0.2"
@@ -160,7 +169,7 @@ lru = "0.7.2"
 memmap2 = "0.5"
 memoffset = "0.6"
 more-asserts = "0.2"
-near-account-id = { path = "core/account-id", features = [ "internal_unstable" ] }
+near-account-id = { path = "core/account-id", features = ["internal_unstable"] }
 near-actix-test-utils = { path = "test-utils/actix-test-utils" }
 near-amend-genesis = { path = "tools/amend-genesis" }
 near-async = { path = "core/async" }
@@ -171,7 +180,7 @@ near-chain-primitives = { path = "chain/chain-primitives" }
 near-chunks = { path = "chain/chunks" }
 near-chunks-primitives = { path = "chain/chunks-primitives" }
 near-client = { path = "chain/client" }
-near-client-primitives = {path = "chain/client-primitives"}
+near-client-primitives = { path = "chain/client-primitives" }
 near-cold-store-tool = { path = "tools/cold-store", package = "cold-store-tool" }
 near-config-utils = { path = "utils/config" }
 nearcore = { path = "nearcore" }
@@ -208,14 +217,14 @@ near-telemetry = { path = "chain/telemetry" }
 near-test-contracts = { path = "runtime/near-test-contracts" }
 near-undo-block = { path = "tools/undo-block" }
 near-vm = { path = "runtime/near-vm/api" }
-near-vm-compiler = { path = "runtime/near-vm/compiler"}
+near-vm-compiler = { path = "runtime/near-vm/compiler" }
 near-vm-compiler-singlepass = { path = "runtime/near-vm/compiler-singlepass" }
 near-vm-compiler-test-derive = { path = "runtime/near-vm/compiler-test-derive" }
 near-vm-engine = { path = "runtime/near-vm/engine" }
 near-vm-engine-universal = { path = "runtime/near-vm/engine-universal" }
 near-vm-errors = { path = "runtime/near-vm-errors" }
 near-vm-logic = { path = "runtime/near-vm-logic" }
-near-vm-runner = { path = "runtime/near-vm-runner"}
+near-vm-runner = { path = "runtime/near-vm-runner" }
 near-vm-test-generator = { path = "runtime/near-vm/test-generator" }
 near-vm-types = { path = "runtime/near-vm/types" }
 near-vm-vm = { path = "runtime/near-vm/vm" }
@@ -262,7 +271,7 @@ rkyv = "0.7.31"
 rlimit = "0.7"
 rocksdb = { version = "0.19.0", default-features = false, features = ["snappy", "lz4", "zstd", "zlib", "jemalloc"] }
 runtime-tester = { path = "test-utils/runtime-tester" }
-rusqlite = {version = "0.27.0", features = ["bundled", "chrono", "functions"] }
+rusqlite = { version = "0.27.0", features = ["bundled", "chrono", "functions"] }
 rustc-demangle = "0.1"
 rust-s3 = { version = "0.32.3", features = ["blocking"] }
 secp256k1 = { version = "0.27.0", features = ["recovery", "rand-std"] }
@@ -325,12 +334,7 @@ winapi = { version = "0.3", features = ["winbase", "memoryapi", "errhandlingapi"
 xshell = "0.2.1"
 xz2 = "0.1.6"
 
-# Polyfill crate introduced in https://github.com/near/nearcore/pull/8087
-# Because public crates depend on it, we have to also publish this.
-# When changing the workspace version, set this back to a local dependency and
-# then update again to the higher published version once we release crates again.
-# TODO(#8604): Fix this process.
-stdx = { package = "near-stdx", version = "0.16.0" }
+stdx = { package = "near-stdx", path = "utils/stdx" }
 
 [patch.crates-io]
 
@@ -363,8 +367,3 @@ opt-level = 3
 opt-level = 3
 [profile.dev.package.sha2]
 opt-level = 3
-
-[workspace.package]
-edition = "2021"
-authors = ["Near Inc <hello@nearprotocol.com>"]
-rust-version = "1.69.0"

--- a/chain/chain-primitives/Cargo.toml
+++ b/chain/chain-primitives/Cargo.toml
@@ -1,14 +1,13 @@
 [package]
 name = "near-chain-primitives"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = true
-# Please update rust-toolchain.toml as well when changing version here:
-rust-version.workspace = true
 edition.workspace = true
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/near/nearcore"
+rust-version.workspace = true
 description = "This crate hosts NEAR chain-related error types"
+repository.workspace = true
+license.workspace = true
+publish = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/chain/chain/Cargo.toml
+++ b/chain/chain/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "near-chain"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+publish = false
 
 [dependencies]
 actix.workspace = true

--- a/chain/chunks-primitives/Cargo.toml
+++ b/chain/chunks-primitives/Cargo.toml
@@ -1,14 +1,13 @@
 [package]
 name = "near-chunks-primitives"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = true
-# Please update rust-toolchain.toml as well when changing version here:
-rust-version.workspace = true
 edition.workspace = true
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/near/nearcore"
+rust-version.workspace = true
 description = "This crate hosts NEAR chunks-related error types"
+repository.workspace = true
+license.workspace = true
+publish = true
 
 [dependencies]
 near-chain-primitives.workspace = true

--- a/chain/chunks/Cargo.toml
+++ b/chain/chunks/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "near-chunks"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 actix.workspace = true

--- a/chain/client-primitives/Cargo.toml
+++ b/chain/client-primitives/Cargo.toml
@@ -1,16 +1,13 @@
 [package]
 name = "near-client-primitives"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = true
-# Please update rust-toolchain.toml as well when changing version here:
-rust-version.workspace = true
 edition.workspace = true
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/near/nearcore"
+rust-version.workspace = true
 description = "This crate hosts NEAR client-related error types"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+repository.workspace = true
+license.workspace = true
+publish = true
 
 [dependencies]
 actix.workspace = true

--- a/chain/client/Cargo.toml
+++ b/chain/client/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "near-client"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 actix-rt.workspace = true

--- a/chain/epoch-manager/Cargo.toml
+++ b/chain/epoch-manager/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "near-epoch-manager"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
-
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 borsh.workspace = true

--- a/chain/indexer-primitives/Cargo.toml
+++ b/chain/indexer-primitives/Cargo.toml
@@ -1,14 +1,13 @@
 [package]
 name = "near-indexer-primitives"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = true
-# Please update rust-toolchain.toml as well when changing version here:
-rust-version.workspace = true
 edition.workspace = true
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/near/nearcore"
+rust-version.workspace = true
 description = "This crate hosts structures for the NEAR Indexer Framework types"
+repository.workspace = true
+license.workspace = true
+publish = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/chain/indexer/Cargo.toml
+++ b/chain/indexer/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "near-indexer"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 actix.workspace = true

--- a/chain/jsonrpc-adversarial-primitives/Cargo.toml
+++ b/chain/jsonrpc-adversarial-primitives/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "near-jsonrpc-adversarial-primitives"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 serde.workspace = true

--- a/chain/jsonrpc-primitives/Cargo.toml
+++ b/chain/jsonrpc-primitives/Cargo.toml
@@ -1,16 +1,13 @@
 [package]
 name = "near-jsonrpc-primitives"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = true
-# Please update rust-toolchain.toml as well when changing version here:
-rust-version.workspace = true
 edition.workspace = true
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/near/nearcore"
+rust-version.workspace = true
 description = "This crate hosts structures for the NEAR JSON RPC Requests, Responses and Error types"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+repository.workspace = true
+license.workspace = true
+publish = true
 
 [dependencies]
 arbitrary.workspace = true

--- a/chain/jsonrpc/Cargo.toml
+++ b/chain/jsonrpc/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "near-jsonrpc"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 actix-cors.workspace = true

--- a/chain/jsonrpc/client/Cargo.toml
+++ b/chain/jsonrpc/client/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "near-jsonrpc-client"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 actix-http.workspace = true

--- a/chain/jsonrpc/fuzz/Cargo.toml
+++ b/chain/jsonrpc/fuzz/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "near-jsonrpc-fuzz"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [package.metadata]
 cargo-fuzz = true

--- a/chain/jsonrpc/jsonrpc-tests/Cargo.toml
+++ b/chain/jsonrpc/jsonrpc-tests/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "near-jsonrpc-tests"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 actix.workspace = true

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "near-network"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
 publish = false
 
 [build-dependencies]

--- a/chain/pool/Cargo.toml
+++ b/chain/pool/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "near-pool"
-version = "0.0.0"
-license = "MIT OR Apache-2.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 borsh.workspace = true

--- a/chain/rosetta-rpc/Cargo.toml
+++ b/chain/rosetta-rpc/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
+name = "near-rosetta-rpc"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
-name = "near-rosetta-rpc"
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
 publish = false
-version = "0.0.0"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 actix-cors.workspace = true

--- a/chain/telemetry/Cargo.toml
+++ b/chain/telemetry/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "near-telemetry"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 actix.workspace = true

--- a/core/account-id/Cargo.toml
+++ b/core/account-id/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "near-account-id"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = true
-# This crate is published to crates.io with a semver API.  Care must be taken
+edition.workspace = true
+# This crate is published to crates.io with a semver API. Care must be taken
 # when updaing its rust-version.
-rust-version = "1.60.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/near/nearcore"
+rust-version = "1.64.0"
 description = "This crate contains the Account ID primitive and its validation facilities"
+repository.workspace = true
+license.workspace = true
+publish = true
 
 [features]
 default = ["borsh", "serde"]

--- a/core/account-id/fuzz/Cargo.toml
+++ b/core/account-id/fuzz/Cargo.toml
@@ -15,9 +15,7 @@ cargo-fuzz = true
 libfuzzer-sys.workspace = true
 borsh.workspace = true
 serde_json.workspace = true
-
-[dependencies.near-account-id]
-path = ".."
+near-account-id.workspace = true
 
 [[bin]]
 name = "serde"

--- a/core/account-id/fuzz/Cargo.toml
+++ b/core/account-id/fuzz/Cargo.toml
@@ -1,10 +1,12 @@
-
 [package]
 name = "near-account-id-fuzz"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [package.metadata]
 cargo-fuzz = true

--- a/core/async/Cargo.toml
+++ b/core/async/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "near-async"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
-rust-version.workspace = true
 edition.workspace = true
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/near/nearcore"
+rust-version.workspace = true
 description = "This crate contains the async helpers specific for nearcore"
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 actix.workspace = true

--- a/core/chain-configs/Cargo.toml
+++ b/core/chain-configs/Cargo.toml
@@ -1,14 +1,13 @@
 [package]
 name = "near-chain-configs"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = true
-# Please update rust-toolchain.toml as well when changing version here:
-rust-version.workspace = true
 edition.workspace = true
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/near/nearcore"
+rust-version.workspace = true
 description = "This crate provides typed interfaces to the NEAR Genesis and Chain Configs"
+repository.workspace = true
+license.workspace = true
+publish = true
 
 [dependencies]
 anyhow.workspace = true

--- a/core/crypto/Cargo.toml
+++ b/core/crypto/Cargo.toml
@@ -1,14 +1,13 @@
 [package]
 name = "near-crypto"
-version = "0.0.0"
-license = "MIT OR Apache-2.0"
+version.workspace = true
 authors.workspace = true
-publish = true
-# Please update rust-toolchain.toml as well when changing version here:
-rust-version.workspace = true
 edition.workspace = true
-repository = "https://github.com/near/nearcore"
+rust-version.workspace = true
 description = "This is an internal crate for common cryptographic types"
+repository.workspace = true
+license.workspace = true
+publish = true
 
 [dependencies]
 blake2.workspace = true

--- a/core/dyn-configs/Cargo.toml
+++ b/core/dyn-configs/Cargo.toml
@@ -1,14 +1,13 @@
 [package]
 name = "near-dyn-configs"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = true
-rust-version.workspace = true
 edition.workspace = true
-readme = "README.md"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/near/nearcore"
+rust-version.workspace = true
 description = "Dynamic configure helpers for the near codebase"
+repository.workspace = true
+license.workspace = true
+publish = true
 
 [dependencies]
 anyhow.workspace = true

--- a/core/o11y/Cargo.toml
+++ b/core/o11y/Cargo.toml
@@ -1,14 +1,13 @@
 [package]
 name = "near-o11y"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = true
-rust-version.workspace = true
 edition.workspace = true
-readme = "README.md"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/near/nearcore"
+rust-version.workspace = true
 description = "Observability helpers for the near codebase"
+repository.workspace = true
+license.workspace = true
+publish = true
 
 [dependencies]
 near-crypto.workspace = true

--- a/core/primitives-core/Cargo.toml
+++ b/core/primitives-core/Cargo.toml
@@ -1,16 +1,13 @@
 [package]
 name = "near-primitives-core"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = true
-# Please update rust-toolchain.toml as well when changing version here:
-rust-version.workspace = true
 edition.workspace = true
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/near/nearcore"
-description = """
-This crate provides the core set of primitives used by other nearcore crates including near-primitives
-"""
+rust-version.workspace = true
+description = "This crate provides the core set of primitives used by other nearcore crates including near-primitives"
+repository.workspace = true
+license.workspace = true
+publish = true
 
 [dependencies]
 arbitrary.workspace = true

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -1,16 +1,13 @@
 [package]
 name = "near-primitives"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = true
-# Please update rust-toolchain.toml as well when changing version here:
-rust-version.workspace = true
 edition.workspace = true
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/near/nearcore"
-description = """
-This crate provides the base set of primitives used by other nearcore crates
-"""
+rust-version.workspace = true
+description = "This crate provides the base set of primitives used by other nearcore crates"
+repository.workspace = true
+license.workspace = true
+publish = true
 
 [dependencies]
 arbitrary.workspace = true

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "near-store"
-version = "0.0.0"
-license = "MIT OR Apache-2.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 actix-rt.workspace = true

--- a/deny.toml
+++ b/deny.toml
@@ -7,7 +7,7 @@ targets = [
 [licenses]
 unlicensed = "deny"
 allow = ["MIT", "Apache-2.0", "Apache-2.0 WITH LLVM-exception"]
-deny = ["AGPL-1.0", "AGPL-3.0",]
+deny = ["AGPL-1.0", "AGPL-3.0"]
 copyleft = "warn"
 allow-osi-fsf-free = "either"
 default = "deny"
@@ -135,11 +135,6 @@ skip = [
 
     # validator 0.12 ~ 0.16 is still using an old version of idna
     { name = "idna", version = "=0.2.3" },
-
-    # v0.0.0 is the local code, whereas the published crate must depend on a
-    # published crate when they are published.
-    # TODO(#8604) Remove this skip entry.
-    { name = "near-stdx", version = "0.0.0" },
 
     # zeropool-bn uses borsh 0.9
     { name = "borsh", version = "=0.9.3" },

--- a/genesis-tools/genesis-csv-to-json/Cargo.toml
+++ b/genesis-tools/genesis-csv-to-json/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "genesis-csv-to-json"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 chrono.workspace = true

--- a/genesis-tools/genesis-populate/Cargo.toml
+++ b/genesis-tools/genesis-populate/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "genesis-populate"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 borsh.workspace = true

--- a/genesis-tools/keypair-generator/Cargo.toml
+++ b/genesis-tools/keypair-generator/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "keypair-generator"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 clap.workspace = true

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "integration-tests"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 actix-rt.workspace = true

--- a/nearcore/Cargo.toml
+++ b/nearcore/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "nearcore"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 actix-rt.workspace = true

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "neard"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
-default-run = "neard"
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [[bin]]
 path = "src/main.rs"

--- a/runtime/near-test-contracts/Cargo.toml
+++ b/runtime/near-test-contracts/Cargo.toml
@@ -1,17 +1,13 @@
 [package]
 name = "near-test-contracts"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
-# Please update rust-toolchain.toml as well when changing version here:
-rust-version.workspace = true
 edition.workspace = true
-license = "MIT OR Apache-2.0"
-readme = "README.md"
-repository = "https://github.com/near/nearcore"
-description ="""
-A collection of smart-contract used in nearcore tests.
-"""
+rust-version.workspace = true
+description = "A collection of smart-contract used in nearcore tests."
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 once_cell.workspace = true

--- a/runtime/near-vm-errors/Cargo.toml
+++ b/runtime/near-vm-errors/Cargo.toml
@@ -1,18 +1,14 @@
 [package]
 name = "near-vm-errors"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = true
-# Please update rust-toolchain.toml as well when changing version here:
-rust-version.workspace = true
 edition.workspace = true
-license = "MIT OR Apache-2.0"
-readme = "README.md"
+rust-version.workspace = true
+description = "Error that can occur inside Near Runtime encapsulated in a separate crate. Might merge it later."
+repository.workspace = true
+license.workspace = true
 categories = ["wasm"]
-repository = "https://github.com/near/nearcore"
-description = """
-Error that can occur inside Near Runtime encapsulated in a separate crate. Might merge it later.
-"""
+publish = true
 
 [dependencies]
 borsh.workspace = true

--- a/runtime/near-vm-logic/Cargo.toml
+++ b/runtime/near-vm-logic/Cargo.toml
@@ -1,18 +1,14 @@
 [package]
 name = "near-vm-logic"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = true
-# Please update rust-toolchain.toml as well when changing version here:
-rust-version.workspace = true
 edition.workspace = true
-license = "MIT OR Apache-2.0"
-readme = "README.md"
+rust-version.workspace = true
+description = "This crate implements the specification of the interface that Near blockchain exposes to the smart contracts."
+repository.workspace = true
+license.workspace = true
 categories = ["wasm"]
-repository = "https://github.com/near/nearcore"
-description = """
-This crate implements the specification of the interface that Near blockchain exposes to the smart contracts.
-"""
+publish = true
 
 [dependencies]
 bn.workspace = true

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -1,18 +1,14 @@
 [package]
 name = "near-vm-runner"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = true
-# Please update rust-toolchain.toml as well when changing version here:
-rust-version.workspace = true
 edition.workspace = true
-license = "MIT OR Apache-2.0"
-readme = "README.md"
+rust-version.workspace = true
+description = "This crate implements the specification of the interface that Near blockchain exposes to the smart contracts."
+repository.workspace = true
+license.workspace = true
 categories = ["wasm"]
-repository = "https://github.com/near/nearcore"
-description = """
-This crate implements the specification of the interface that Near blockchain exposes to the smart contracts.
-"""
+publish = true
 
 [dependencies]
 anyhow = { workspace = true, optional = true }
@@ -41,7 +37,7 @@ parity-wasm_41.workspace = true
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 wasmer-runtime = { workspace = true, optional = true }
-wasmer-runtime-core = { workspace = true, optional = true}
+wasmer-runtime-core = { workspace = true, optional = true }
 wasmer-compiler = { workspace = true, optional = true }
 wasmer-compiler-singlepass = { workspace = true, optional = true }
 wasmer-engine = { workspace = true, optional = true }

--- a/runtime/near-vm-runner/fuzz/Cargo.toml
+++ b/runtime/near-vm-runner/fuzz/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "near-vm-runner-fuzz"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [package.metadata]
 cargo-fuzz = true

--- a/runtime/near-vm/api/Cargo.toml
+++ b/runtime/near-vm/api/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "near-vm"
-version = "0.0.0"
+version.workspace = true
 description = "High-performance WebAssembly runtime"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly", "runtime", "vm"]
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>", "Near Inc <hello@nearprotocol.com>"]
-repository = "https://github.com/near/nearcore"
+repository.workspace = true
 license = "MIT"
 readme = "README.md"
 edition = "2021"

--- a/runtime/near-vm/compiler-singlepass/Cargo.toml
+++ b/runtime/near-vm/compiler-singlepass/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "near-vm-compiler-singlepass"
-version = "0.0.0"
+version.workspace = true
 description = "Singlepass compiler for Wasmer WebAssembly runtime"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly", "compiler", "singlepass"]
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>", "Near Inc <hello@nearprotocol.com>"]
-repository = "https://github.com/near/nearcore"
+repository.workspace = true
 license = "MIT"
 readme = "README.md"
 edition = "2021"

--- a/runtime/near-vm/compiler-test-derive/Cargo.toml
+++ b/runtime/near-vm/compiler-test-derive/Cargo.toml
@@ -3,7 +3,7 @@ proc-macro = true
 
 [package]
 name = "near-vm-compiler-test-derive"
-version = "0.0.0"
+version.workspace = true
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>", "Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 license = "MIT"

--- a/runtime/near-vm/compiler/Cargo.toml
+++ b/runtime/near-vm/compiler/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "near-vm-compiler"
-version = "0.0.0"
+version.workspace = true
 description = "Base compiler abstraction for Wasmer WebAssembly runtime"
 categories = ["wasm", "no-std"]
 keywords = ["wasm", "webassembly", "compiler"]
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>", "Near Inc <hello@nearprotocol.com>"]
-repository = "https://github.com/near/nearcore"
+repository.workspace = true
 license = "MIT OR Apache-2.0 WITH LLVM-exception"
 readme = "README.md"
 edition = "2021"

--- a/runtime/near-vm/engine-universal/Cargo.toml
+++ b/runtime/near-vm/engine-universal/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "near-vm-engine-universal"
-version = "0.0.0"
+version.workspace = true
 description = "Wasmer Universal Engine"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly", "engine", "universal"]
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>", "Near Inc <hello@nearprotocol.com>"]
-repository = "https://github.com/near/nearcore"
+repository.workspace = true
 license = "MIT OR Apache-2.0 WITH LLVM-exception "
 readme = "README.md"
 edition = "2021"

--- a/runtime/near-vm/engine/Cargo.toml
+++ b/runtime/near-vm/engine/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "near-vm-engine"
-version = "0.0.0"
+version.workspace = true
 description = "Wasmer Engine abstraction"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly", "engine"]
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>", "Near Inc <hello@nearprotocol.com>"]
-repository = "https://github.com/near/nearcore"
+repository.workspace = true
 license = "MIT OR Apache-2.0 WITH LLVM-exception "
 readme = "README.md"
 edition = "2021"

--- a/runtime/near-vm/test-generator/Cargo.toml
+++ b/runtime/near-vm/test-generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-vm-test-generator"
-version = "0.0.0"
+version.workspace = true
 edition = "2021"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>", "Near Inc <hello@nearprotocol.com>"]
 publish = false

--- a/runtime/near-vm/types/Cargo.toml
+++ b/runtime/near-vm/types/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "near-vm-types"
-version = "0.0.0"
+version.workspace = true
 description = "Near VM Common Types"
 categories = ["wasm", "data-structures"]
 keywords = ["wasm", "webassembly", "types"]
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>", "Near Inc <hello@nearprotocol.com>"]
-repository = "https://github.com/near/nearcore"
+repository.workspace = true
 license = "MIT OR Apache-2.0 WITH LLVM-exception"
 readme = "README.md"
 edition = "2021"

--- a/runtime/near-vm/vm/Cargo.toml
+++ b/runtime/near-vm/vm/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "near-vm-vm"
-version = "0.0.0"
+version.workspace = true
 description = "Runtime library support for Wasmer"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly"]
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>", "Near Inc <hello@nearprotocol.com>"]
-repository = "https://github.com/near/nearcore"
+repository.workspace = true
 license = "MIT OR Apache-2.0 WITH LLVM-exception"
 readme = "README.md"
 edition = "2021"

--- a/runtime/near-vm/wast/Cargo.toml
+++ b/runtime/near-vm/wast/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "near-vm-wast"
-version = "0.0.0"
+version.workspace = true
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>", "Near Inc <hello@nearprotocol.com>"]
 description = "wast testing support for wasmer"
 license = "MIT OR Apache-2.0 WITH LLVM-exception"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly"]
-repository = "https://github.com/wasmerio/wasmer"
+repository.workspace = true
 readme = "README.md"
 edition = "2021"
 publish = false

--- a/runtime/runtime-params-estimator/Cargo.toml
+++ b/runtime/runtime-params-estimator/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "runtime-params-estimator"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [[bin]]
 name = "runtime-params-estimator"

--- a/runtime/runtime-params-estimator/estimator-warehouse/Cargo.toml
+++ b/runtime/runtime-params-estimator/estimator-warehouse/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
-authors.workspace = true
 name = "estimator-warehouse"
-version = "0.0.0"
-publish = false
+version.workspace = true
+authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 anyhow.workspace = true

--- a/runtime/runtime/Cargo.toml
+++ b/runtime/runtime/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "node-runtime"
-version = "0.0.0"
-license = "MIT OR Apache-2.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 borsh.workspace = true

--- a/test-utils/actix-test-utils/Cargo.toml
+++ b/test-utils/actix-test-utils/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "near-actix-test-utils"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 actix-rt.workspace = true

--- a/test-utils/logger/Cargo.toml
+++ b/test-utils/logger/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "near-logger-utils"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 tracing.workspace = true

--- a/test-utils/runtime-tester/Cargo.toml
+++ b/test-utils/runtime-tester/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "runtime-tester"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 cpu-time.workspace = true

--- a/test-utils/runtime-tester/fuzz/Cargo.toml
+++ b/test-utils/runtime-tester/fuzz/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "runtime-tester-fuzz"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [package.metadata]
 cargo-fuzz = true

--- a/test-utils/store-validator/Cargo.toml
+++ b/test-utils/store-validator/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "store-validator"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 ansi_term.workspace = true

--- a/test-utils/testlib/Cargo.toml
+++ b/test-utils/testlib/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "testlib"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 once_cell.workspace = true

--- a/tools/amend-genesis/Cargo.toml
+++ b/tools/amend-genesis/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "near-amend-genesis"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 anyhow.workspace = true

--- a/tools/chainsync-loadtest/Cargo.toml
+++ b/tools/chainsync-loadtest/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "chainsync-loadtest"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
-default-run = "chainsync-loadtest"
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [[bin]]
 path = "src/main.rs"

--- a/tools/cold-store/Cargo.toml
+++ b/tools/cold-store/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "cold-store-tool"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 anyhow.workspace = true

--- a/tools/delay-detector/Cargo.toml
+++ b/tools/delay-detector/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "delay-detector"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 tracing.workspace = true

--- a/tools/flat-storage/Cargo.toml
+++ b/tools/flat-storage/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "near-flat-storage"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 anyhow.workspace = true

--- a/tools/indexer/example/Cargo.toml
+++ b/tools/indexer/example/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "indexer-example"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 actix.workspace = true

--- a/tools/mirror/Cargo.toml
+++ b/tools/mirror/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "near-mirror"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 actix.workspace = true

--- a/tools/mock-node/Cargo.toml
+++ b/tools/mock-node/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "mock-node"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 actix-rt.workspace = true

--- a/tools/ping/Cargo.toml
+++ b/tools/ping/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "near-ping"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
 publish = false
-edition = "2021"
 
 [dependencies]
 actix-web.workspace = true

--- a/tools/restaked/Cargo.toml
+++ b/tools/restaked/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "restaked"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 clap.workspace = true

--- a/tools/rpctypegen/core/Cargo.toml
+++ b/tools/rpctypegen/core/Cargo.toml
@@ -1,16 +1,13 @@
 [package]
 name = "near-rpc-error-core"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = true
-# Please update rust-toolchain.toml as well when changing version here:
-rust-version.workspace = true
 edition.workspace = true
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/near/nearcore"
-description = """
-This crate generates schema for Rust structs which can be used by TypeScript.
-"""
+rust-version.workspace = true
+description = "This crate generates schema for Rust structs which can be used by TypeScript."
+repository.workspace = true
+license.workspace = true
+publish = true
 
 [dependencies]
 quote.workspace = true

--- a/tools/rpctypegen/macro/Cargo.toml
+++ b/tools/rpctypegen/macro/Cargo.toml
@@ -1,16 +1,13 @@
 [package]
 name = "near-rpc-error-macro"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = true
-# Please update rust-toolchain.toml as well when changing version here:
-rust-version.workspace = true
 edition.workspace = true
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/near/nearcore"
-description = """
-This crate generates schema for Rust structs which can be used by TypeScript.
-"""
+rust-version.workspace = true
+description = "This crate generates schema for Rust structs which can be used by TypeScript."
+repository.workspace = true
+license.workspace = true
+publish = true
 
 [lib]
 proc-macro = true

--- a/tools/speedy_sync/Cargo.toml
+++ b/tools/speedy_sync/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "speedy_sync"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
-rust-version.workspace = true
 edition.workspace = true
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 near-store.workspace = true

--- a/tools/state-parts/Cargo.toml
+++ b/tools/state-parts/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "near-state-parts"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 anyhow.workspace = true

--- a/tools/state-viewer/Cargo.toml
+++ b/tools/state-viewer/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "state-viewer"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 ansi_term.workspace = true

--- a/tools/storage-usage-delta-calculator/Cargo.toml
+++ b/tools/storage-usage-delta-calculator/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "storage-usage-delta-calculator"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 anyhow.workspace = true

--- a/tools/themis/Cargo.toml
+++ b/tools/themis/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 name = "themis"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
-publish = false
-license = "MIT OR Apache-2.0"
+rust-version.workspace = true
 description = "https://en.wikipedia.org/wiki/Themis"
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 toml.workspace = true

--- a/tools/undo-block/Cargo.toml
+++ b/tools/undo-block/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "near-undo-block"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = false
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 anyhow.workspace = true

--- a/utils/config/Cargo.toml
+++ b/utils/config/Cargo.toml
@@ -1,14 +1,13 @@
 [package]
 name = "near-config-utils"
-version = "0.0.0"
-license = "MIT OR Apache-2.0"
+version.workspace = true
 authors.workspace = true
-publish = true
-# Please update rust-toolchain.toml as well when changing version here:
-rust-version.workspace = true
 edition.workspace = true
-repository = "https://github.com/near/nearcore"
+rust-version.workspace = true
 description = "This is an internal crate to provide utils for reading config files"
+repository.workspace = true
+license.workspace = true
+publish = true
 
 [dependencies]
 anyhow.workspace = true

--- a/utils/fmt/Cargo.toml
+++ b/utils/fmt/Cargo.toml
@@ -1,14 +1,13 @@
 [package]
 name = "near-fmt"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
-publish = true
-rust-version.workspace = true
 edition.workspace = true
-readme = "README.md"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/near/nearcore"
+rust-version.workspace = true
 description = "Helpers for pretty formatting."
+repository.workspace = true
+license.workspace = true
+publish = true
 
 [dependencies]
 near-primitives-core.workspace = true

--- a/utils/mainnet-res/Cargo.toml
+++ b/utils/mainnet-res/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "near-mainnet-res"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
 publish = false
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 serde_json.workspace = true

--- a/utils/near-cache/Cargo.toml
+++ b/utils/near-cache/Cargo.toml
@@ -1,15 +1,13 @@
 [package]
 name = "near-cache"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
-publish = true
-# Please update rust-toolchain.toml as well when changing version here:
 rust-version.workspace = true
-license = "MIT OR Apache-2.0"
-readme = "README.md"
-repository = "https://github.com/near/nearcore"
 description = "do not use this, new versions can stop being published at literally any time"
+repository.workspace = true
+license.workspace = true
+publish = true
 
 [dependencies]
 lru.workspace = true

--- a/utils/near-performance-metrics-macros/Cargo.toml
+++ b/utils/near-performance-metrics-macros/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "near-performance-metrics-macros"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
 publish = false
 
 [dependencies]

--- a/utils/near-performance-metrics/Cargo.toml
+++ b/utils/near-performance-metrics/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "near-performance-metrics"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
 publish = false
 
 [dependencies]

--- a/utils/near-stable-hasher/Cargo.toml
+++ b/utils/near-stable-hasher/Cargo.toml
@@ -1,14 +1,10 @@
 [package]
 name = "near-stable-hasher"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
-publish = true
-# Please update rust-toolchain.toml as well when changing version here:
 rust-version.workspace = true
-license = "MIT OR Apache-2.0"
-readme = "README.md"
-repository = "https://github.com/near/nearcore"
-description = """
-`near-stable-hasher` is a library that is essentially a wrapper around, now deprecated, `std::hash::SipHasher`.
-"""
+description = "`near-stable-hasher` is a library that is essentially a wrapper around, now deprecated, `std::hash::SipHasher`."
+repository.workspace = true
+license.workspace = true
+publish = true

--- a/utils/stdx/Cargo.toml
+++ b/utils/stdx/Cargo.toml
@@ -1,15 +1,13 @@
 [package]
 name = "near-stdx"
-version = "0.0.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
-publish = true
 rust-version.workspace = true
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/near/nearcore"
-description = """
-This crate contains polyfills which should really be in std, but currently aren't for one reason or another.
-"""
+description = "This crate contains polyfills which should really be in std, but currently aren't for one reason or another."
+repository.workspace = true
+license.workspace = true
+publish = true
 
 [dependencies]
 # Absolutely must not depend on any crates from nearcore workspace,


### PR DESCRIPTION
The publishing pipeline has been borked for quite a while for a variety of reasons, between workspace inheritance, crate aliases, etc..

This patch is only one part of the solution. The rest of it is patched in a fork of cargo-workspaces: https://github.com/miraclx/cargo-workspaces/pull/1.

That patch also now includes pre-emptive error reports, which would help move any potential errors thrown at CI runtime on master to CI runtime at the PR level. ~I'll extend the buildkite pipeline in a bit.~ (this will come in a follow-up PR)

Fixes #8604.
Further context: https://github.com/near/nearcore/pull/8605