### PR TITLE
State sync mocktest

### DIFF
--- a/pytest/lib/mocknet/helper.py
+++ b/pytest/lib/mocknet/helper.py
@@ -164,7 +164,9 @@ def set_state_parts_sync_mode_for_nodes(nodes,
 
 
 def set_tracked_shard_for_node(node, tracked_shards):
-    modify_config(node, {"tracked_shards": tracked_shards,})
+    modify_config(node, {
+        "tracked_shards": tracked_shards,
+    })
 
 
 def set_tracked_shard_for_nodes(nodes, tracked_shards):

--- a/pytest/lib/mocknet/helper.py
+++ b/pytest/lib/mocknet/helper.py
@@ -121,7 +121,7 @@ def set_s3_state_parts_sync_mode_for_node(node, bucket, region):
     modify_config(
         node, {
             "state_sync": {
-                "dump": {
+                "sync": {
                     "location": {
                         "S3": {
                             "bucket": bucket,
@@ -137,7 +137,7 @@ def set_local_state_parts_sync_mode_for_node(node, root_dir):
     modify_config(
         node, {
             "state_sync": {
-                "dump": {
+                "sync": {
                     "location": {
                         "Filesystem": {
                             "root_dir": root_dir,
@@ -164,7 +164,7 @@ def set_state_parts_sync_mode_for_nodes(nodes,
 
 
 def set_tracked_shard_for_node(node, tracked_shards):
-    modify_config(node, {"consensus": {"tracked_shards": tracked_shards,}})
+    modify_config(node, {"tracked_shards": tracked_shards,})
 
 
 def set_tracked_shard_for_nodes(nodes, tracked_shards):

--- a/pytest/lib/mocknet/helper.py
+++ b/pytest/lib/mocknet/helper.py
@@ -122,10 +122,12 @@ def set_s3_state_parts_sync_mode_for_node(node, bucket, region):
         node, {
             "state_sync": {
                 "sync": {
-                    "location": {
-                        "S3": {
-                            "bucket": bucket,
-                            "region": region,
+                    "ExternalStorage": {
+                        "location": {
+                            "S3": {
+                                "bucket": bucket,
+                                "region": region,
+                            }
                         }
                     }
                 }
@@ -138,9 +140,11 @@ def set_local_state_parts_sync_mode_for_node(node, root_dir):
         node, {
             "state_sync": {
                 "sync": {
-                    "location": {
-                        "Filesystem": {
-                            "root_dir": root_dir,
+                    "ExternalStorage": {
+                        "location": {
+                            "Filesystem": {
+                                "root_dir": root_dir,
+                            }
                         }
                     }
                 }

--- a/pytest/lib/mocknet/helper.py
+++ b/pytest/lib/mocknet/helper.py
@@ -1,0 +1,187 @@
+import json
+import requests
+import time
+import collections
+from prometheus_client.parser import text_string_to_metric_families
+from configured_logger import logger
+
+MAX_RETRIES = 10
+
+
+# TODO(posvyatokum) reuse retry_and_ignore_errors method from mocknet_helpers
+def request_from_helper(address, method, params=[]):
+    for attempt in range(MAX_RETRIES):
+        try:
+            logger.info(
+                f'Requesting {method} method from {address} helper. Attempt #{attempt}'
+            )
+            j = {
+                'method': method,
+                'params': params,
+                'id': 'dontcare',
+                'jsonrpc': '2.0'
+            }
+            r = requests.post(f'http://{address}', json=j, timeout=5)
+            r.raise_for_status()
+            response = json.loads(r.content)
+            return response['result']
+        except Exception as e:
+            logger.error(e)
+            time.sleep(0.1 * 2**attempt)
+    return ""
+
+
+def modify_config(node, modification):
+    request_from_helper(node['address'], 'modify_config', [modification])
+
+
+def stop_node(node):
+    request_from_helper(node['address'], 'stop')
+
+
+def stop_nodes(nodes):
+    for node in nodes:
+        stop_node(node)
+
+
+def restart_node(node, binary, unsafe):
+    request_from_helper(node['address'], 'restart', {
+        'unsafe': unsafe,
+        'binary_name': binary
+    })
+
+
+def restart_nodes(nodes, binary='neard', unsafe=False):
+    for node in nodes:
+        restart_node(node, binary, unsafe)
+
+
+def send_json_rpc_request(node, method, params):
+    return request_from_helper(node['address'], 'json_rpc', {
+        'method': method,
+        'params': params,
+    })
+
+
+def check_node_is_live(node):
+    result = send_json_rpc_request(node, 'validators', [None])
+    if len(result) == 0:
+        return False
+    response = json.loads(result)
+    return 'error' not in response and 'result' in response
+
+
+def set_s3_state_parts_dump_mode_for_node(node, bucket, region):
+    modify_config(
+        node, {
+            "state_sync": {
+                "dump": {
+                    "location": {
+                        "S3": {
+                            "bucket": bucket,
+                            "region": region,
+                        }
+                    }
+                }
+            }
+        })
+
+
+def set_local_state_parts_dump_mode_for_node(node, root_dir):
+    modify_config(
+        node, {
+            "state_sync": {
+                "dump": {
+                    "location": {
+                        "Filesystem": {
+                            "root_dir": root_dir,
+                        }
+                    }
+                }
+            }
+        })
+
+
+def set_state_parts_dump_mode_for_nodes(nodes,
+                                        bucket=None,
+                                        region=None,
+                                        root_dir=None):
+    for node in nodes:
+        if root_dir is not None:
+            set_local_state_parts_dump_mode_for_node(node, root_dir)
+        elif bucket is not None and region is not None:
+            set_s3_state_parts_dump_mode_for_node(node, bucket, region)
+        else:
+            raise Exception(
+                "Must provide either (root_dir) or (bucket, region) to enable StatePart dump"
+            )
+
+
+def set_s3_state_parts_sync_mode_for_node(node, bucket, region):
+    modify_config(
+        node, {
+            "state_sync": {
+                "dump": {
+                    "location": {
+                        "S3": {
+                            "bucket": bucket,
+                            "region": region,
+                        }
+                    }
+                }
+            }
+        })
+
+
+def set_local_state_parts_sync_mode_for_node(node, root_dir):
+    modify_config(
+        node, {
+            "state_sync": {
+                "dump": {
+                    "location": {
+                        "Filesystem": {
+                            "root_dir": root_dir,
+                        }
+                    }
+                }
+            }
+        })
+
+
+def set_state_parts_sync_mode_for_nodes(nodes,
+                                        bucket=None,
+                                        region=None,
+                                        root_dir=None):
+    for node in nodes:
+        if root_dir is not None:
+            set_local_state_parts_sync_mode_for_node(node, root_dir)
+        elif bucket is not None and region is not None:
+            set_s3_state_parts_sync_mode_for_node(node, bucket, region)
+        else:
+            raise Exception(
+                "Must provide either (root_dir) or (bucket, region) to enable StatePart sync"
+            )
+
+
+def set_tracked_shard_for_node(node, tracked_shards):
+    modify_config(node, {"consensus": {"tracked_shards": tracked_shards,}})
+
+
+def set_tracked_shard_for_nodes(nodes, tracked_shards):
+    for node in nodes:
+        set_tracked_shard_for_node(node, tracked_shards)
+
+
+def enable_state_sync(nodes):
+    for node in nodes:
+        modify_config(node, {"state_sync_enabled": True})
+
+
+def get_metrics(node):
+    response_result = request_from_helper(node["address"], "metrics", {})
+    final_result = collections.defaultdict(dict)
+    for metric_family in text_string_to_metric_families(response_result):
+        for sample in metric_family.samples:
+            final_result[sample.name][str(set(
+                (sample.labels.values())))] = sample.value
+    return final_result

--- a/pytest/lib/mocknet/nodes.py
+++ b/pytest/lib/mocknet/nodes.py
@@ -1,0 +1,85 @@
+import subprocess
+import json
+
+
+# Get list of all nodes in `project`.
+# Select the ones that have `chain_id` in the name.
+# Return their name, address (external ip), and labels.
+# TODO(posvyatokum) this should be in some lib.
+def get_gcloud_nodes(project, chain_id):
+    nodes_call = subprocess.run(
+        [
+            f"gcloud compute instances list --project={project}\
+             --format='json(name, labels, networkInterfaces[].accessConfigs[0].natIP)'"
+        ],
+        stdout=subprocess.PIPE,
+        check=True,
+        text=True,
+        shell=True,
+    )
+    all_nodes = json.loads(nodes_call.stdout)
+    all_nodes = list(filter(lambda x: chain_id in x['name'], all_nodes))
+    traffic_nodes = list(filter(lambda x: 'traffic' in x['name'], all_nodes))
+    regular_nodes = list(filter(lambda x: 'traffic' not in x['name'],
+                                all_nodes))
+
+    def create_node(x):
+        return {
+            'name': x['name'],
+            'address': x['networkInterfaces'][0]['accessConfigs'][0]['natIP'],
+            'labels': x['labels']
+        }
+
+    return list(map(create_node,
+                    regular_nodes)), list(map(create_node, traffic_nodes))
+
+
+def get_nodes_by_label(nodes, labels):
+    result = []
+    for node in nodes:
+        for label_key, label_value in labels.items():
+            if node['labels'].get(label_key) != label_value:
+                break
+        else:
+            result.append(node.copy())
+    return result
+
+
+def get_localnet_nodes(test, num_validators=0, num_rpc=0, default_port=3000):
+    if test == 'state_sync':
+        regular_nodes = [{
+            'name': f's3ss{i}',
+            'address': f'0.0.0.0:{default_port + i}',
+            'labels': {
+                'role': 'validator',
+            },
+        } for i in range(num_validators)] + [{
+            'name': f's3ss{num_validators + i}',
+            'address': f'0.0.0.0:{default_port + num_validators + i}',
+            'labels': {
+                'role': 'rpc',
+            },
+        } for i in range(num_rpc)]
+        regular_nodes[num_validators - 1]['labels']['late'] = 'yes'
+        regular_nodes[-1]['labels']['late'] = 'yes'
+        regular_nodes[num_validators]['labels']['state-parts-producer'] = 'yes'
+        regular_nodes[num_validators +
+                      1]['labels']['state-parts-producer'] = 'yes'
+        return regular_nodes, []
+
+    return [{
+        'name': 'localhost',
+        'address': f'0.0.0.0:{default_port}',
+        'labels': {},
+    }]
+
+
+def exclude_nodes(all_nodes, nodes_to_exclude):
+    node_names_to_exclude = set(map(lambda x: x['name'], nodes_to_exclude))
+    return list(
+        filter(lambda x: x['name'] not in node_names_to_exclude, all_nodes))
+
+
+def intersect_nodes(all_nodes, nodes_to_exclude):
+    node_names_to_exclude = set(map(lambda x: x['name'], nodes_to_exclude))
+    return list(filter(lambda x: x['name'] in node_names_to_exclude, all_nodes))

--- a/pytest/lib/mocknet/stats.py
+++ b/pytest/lib/mocknet/stats.py
@@ -1,0 +1,130 @@
+import collections
+from mocknet.helper import get_metrics
+from configured_logger import logger
+
+METRICS_MAPPING = {
+    "height": "near_block_height_head",
+    "epoch_height": "near_epoch_height",
+    "expected_chunks": 'near_validators_chunks_expected',
+    "produced_chunks": 'near_validators_chunks_produced',
+    "sync_status": "near_sync_status",
+}
+RED_COLOR = '\033[31m'
+GREEN_COLOR = '\033[32m'
+YELLOW_COLOR = '\033[33m'
+BOLD = '\033[1m'
+END_FORMAT = '\033[0m'
+
+
+class NodeMetrics:
+
+    def __init__(self, nodes):
+        self.metrics = {node["name"]: get_metrics(node) for node in nodes}
+        # for every node calculating missed chunks of connected account (if any exists)
+        for node, metrics in self.metrics.items():
+            for full_label_str in metrics["expected_chunks"].keys():
+                account_id = full_label_str.strip()
+                if account_id in node:
+                    expected_chunks = self.get_metric(node, "expected_chunks",
+                                                      full_label_str)
+                    produced_chunks = self.get_metric(node, "produced_chunks",
+                                                      full_label_str)
+                    metrics['missed_chunks'][str(
+                        set())] = expected_chunks - produced_chunks
+
+    def get_metric(self, node_name, metric_name, labels=set()):
+        if metric_name in METRICS_MAPPING:
+            return self.metrics[node_name][METRICS_MAPPING[metric_name]].get(
+                str(labels))
+        else:
+            return self.metrics[node_name][metric_name].get(str(labels))
+
+
+# Get the color code for this value based on provided bounds dict.
+# If value is None, yellow color is returned.
+# If value is out of provided bounds, red color is returned.
+# If value is in the bounds (for example, if no bounds are provided), green color is returned.
+def stat_color(value, bounds):
+    min_value = bounds.get('min')
+    max_value = bounds.get('max')
+    if value is None:
+        return YELLOW_COLOR
+    elif min_value is not None and value < min_value:
+        return RED_COLOR
+    elif max_value is not None and value > max_value:
+        return RED_COLOR
+    else:
+        return GREEN_COLOR
+
+
+class NodeStats:
+
+    def __init__(self, first_metrics, second_metrics, time_elapsed):
+        self.stats = collections.defaultdict(dict)
+        for node, _ in second_metrics.metrics.items():
+            if node not in first_metrics.metrics:
+                continue
+
+            def set_diff(metric_name, stat_name):
+                metric2 = second_metrics.get_metric(node, metric_name)
+                metric1 = first_metrics.get_metric(node, metric_name)
+                if metric2 is not None and metric1 is not None:
+                    self.stats[node][stat_name] = (metric2 -
+                                                   metric1) / time_elapsed
+                else:
+                    self.stats[node][stat_name] = None
+
+            set_diff("height", "bps")
+            set_diff("missed_chunks", "missed_chunks")
+
+            self.stats[node]["sync_status"] = second_metrics.get_metric(
+                node, "sync_status")
+            self.stats[node]["epoch_height"] = second_metrics.get_metric(
+                node, "epoch_height")
+
+    # stats_to_output -- what stats to output, what value is considered max/min ok for this stat.
+    # This is needed to decide the color of the stats. If no bounds are provided, green color will be chosen.
+    # For more details look at stat_color function.
+    def print_stat_report(self, stats_to_output):
+        logger.info("\n".join(["NodeStats:"] + list(
+            map(
+                lambda it: '\t'.join([f"{it[0]}"] + [
+                    f"{stat_color(it[1].get(stat_name), bounds)}{stat_name}:{it[1].get(stat_name)}{END_FORMAT}"
+                    for (stat_name, bounds) in stats_to_output.items()
+                ]), self.stats.items()))))
+
+
+class NodeAccumulationStats:
+
+    def __init__(self, all_stats):
+        self.raw_stats = collections.defaultdict(
+            lambda: collections.defaultdict(list))
+        for stats in all_stats:
+            for node_name, node_stats in stats.stats.items():
+                for stat_name, stat_value in node_stats.items():
+                    self.raw_stats[node_name][stat_name].append(stat_value)
+        self.stats = collections.defaultdict(
+            lambda: collections.defaultdict(dict))
+        for node_name, raw_stats in self.raw_stats.items():
+            for stat_name, data in raw_stats.items():
+                filtered = list(filter(lambda x: x is not None, data))
+                self.stats[node_name][stat_name]['min'] = None if len(
+                    filtered) == 0 else min(filtered)
+                self.stats[node_name][stat_name]['max'] = None if len(
+                    filtered) == 0 else max(filtered)
+                self.stats[node_name][stat_name]['avg'] = None if len(
+                    filtered) == 0 else sum(filtered) / len(filtered)
+
+    def print_report(self, stats_to_output):
+        logger.info("NodeAccumulationStats:")
+        for stat_name, stat_bounds in stats_to_output.items():
+            logger.info(f"{BOLD}{stat_name}{END_FORMAT}")
+            for node_name, node_stats in self.stats.items():
+                line = [node_name]
+                if stat_name in node_stats:
+                    for acc in ['min', 'max', 'avg']:
+                        value = node_stats[stat_name][acc]
+                        line.append(
+                            f"{stat_color(value, stat_bounds)}{value}{END_FORMAT}"
+                        )
+                logger.info('\t'.join(line))

--- a/pytest/lib/mocknet/stats.py
+++ b/pytest/lib/mocknet/stats.py
@@ -22,8 +22,9 @@ class NodeMetrics:
         self.metrics = {node["name"]: get_metrics(node) for node in nodes}
         # for every node calculating missed chunks of connected account (if any exists)
         for node, metrics in self.metrics.items():
-            for full_label_str in metrics["expected_chunks"].keys():
-                account_id = full_label_str.strip()
+            for full_label_str in metrics[
+                    METRICS_MAPPING["expected_chunks"]].keys():
+                account_id = full_label_str.strip("{'\"}")
                 if account_id in node:
                     expected_chunks = self.get_metric(node, "expected_chunks",
                                                       full_label_str)

--- a/pytest/lib/mocknet/test_flow.py
+++ b/pytest/lib/mocknet/test_flow.py
@@ -1,0 +1,95 @@
+import time
+from configured_logger import logger
+from mocknet.stats import NodeMetrics, NodeStats
+from mocknet.helper import check_node_is_live
+
+
+def loop_for(nodes, duration, all_stats, stats_bounds, break_condition=None):
+    start_time = time.time()
+    last_time = start_time
+    last_metrics = NodeMetrics(nodes)
+    while time.time() - start_time < duration:
+        time.sleep(10)
+        current_time = time.time()
+
+        current_metrics = NodeMetrics(nodes)
+        current_stats = NodeStats(last_metrics, current_metrics,
+                                  current_time - last_time)
+        current_stats.print_stat_report(stats_bounds)
+        all_stats.append(current_stats)
+
+        last_time = current_time
+        last_metrics = current_metrics
+
+        if break_condition is not None and break_condition(current_metrics):
+            break
+
+    return last_metrics
+
+
+def wait_for_metric(node, metric_name):
+    metrics = NodeMetrics([node])
+    while metrics.get_metric(node['name'], metric_name) is None:
+        time.sleep(30)
+        metrics = NodeMetrics([node])
+    return metrics, metrics.get_metric(node['name'], metric_name)
+
+
+def wait_for_nodes_to_be_up(nodes):
+    logger.info(
+        f'Waiting for nodes {list(map(lambda x: x["name"], nodes))} to be up')
+    for node in nodes:
+        while not check_node_is_live(node):
+            logger.info(f'Waiting for node {node["name"]} to be up')
+            time.sleep(60)
+
+
+def n_epochs_passed(current_metrics, node_name, n, start_epoch):
+    current_epoch = current_metrics.get_metric(node_name, 'epoch_height')
+    logger.info(f'Current epoch height for node {node_name} is {current_epoch}.'
+                f'Waiting for {start_epoch + n}')
+    return current_epoch is not None and current_epoch - start_epoch > n - 1
+
+
+def wait_n_epochs(n, nodes, all_stats, stats_bounds, duration=float('inf')):
+    # Wait for the first node to start and report epoch_height
+    node_name = nodes[0]["name"]
+    logger.info(f'Waiting for epoch height to apper in {node_name} metrics')
+    _, start_epoch_height = wait_for_metric(nodes[0], 'epoch_height')
+
+    logger.info(f'Waiting {n} epochs based on {node_name} metrics')
+    return loop_for(nodes=nodes,
+                    duration=duration,
+                    all_stats=all_stats,
+                    stats_bounds=stats_bounds,
+                    break_condition=lambda x: n_epochs_passed(
+                        x, node_name, n, start_epoch_height))
+
+
+def nodes_are_in_sync(current_metrics, nodes):
+    sync_statuses = [(node['name'],
+                      current_metrics.get_metric(node['name'], 'sync_status'))
+                     for node in nodes]
+    sync_statuses = list(filter(lambda x: 0 < x[1], sync_statuses))
+    logger.info(f'Waiting for nodes {sync_statuses} to sync')
+    return len(sync_statuses) == 0
+
+
+def wait_for_nodes_to_sync(sync_nodes,
+                           all_nodes,
+                           all_stats,
+                           stats_bounds,
+                           duration=float('inf')):
+    logger.info(f'Waiting for nodes {sync_nodes} to sync')
+    return loop_for(nodes=all_nodes,
+                    duration=duration,
+                    all_stats=all_stats,
+                    stats_bounds=stats_bounds,
+                    break_condition=lambda x: nodes_are_in_sync(x, sync_nodes))
+
+
+# Clears data directories.
+# Amends genesis.
+def init_nodes(regular_nodes, traffic_nodes):
+    # TODO(posvyatokum): implement
+    pass

--- a/pytest/tests/mocknet/helpers/neard_helper.py
+++ b/pytest/tests/mocknet/helpers/neard_helper.py
@@ -1,0 +1,309 @@
+import argparse
+import fcntl
+import json
+import jsonrpc
+import logging
+import os
+import psutil
+import requests
+import signal
+import subprocess
+import sys
+import threading
+import http
+import http.server
+
+
+def get_lock(home):
+    lock_file = os.path.join(home, 'LOCK')
+
+    fd = os.open(lock_file, os.O_CREAT | os.O_RDWR)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        raise Exception(f'{lock_file} is currently locked by another process')
+    return fd
+
+
+def http_code(jsonrpc_error):
+    if jsonrpc_error is None:
+        return http.HTTPStatus.OK
+
+    if jsonrpc_error['code'] == -32700 or jsonrpc_error[
+            'code'] == -32600 or jsonrpc_error['code'] == -32602:
+        return http.HTTPStatus.BAD_REQUEST
+    elif jsonrpc_error['code'] == -32601:
+        return http.HTTPStatus.NOT_FOUND
+    else:
+        return http.HTTPStatus.INTERNAL_SERVER_ERROR
+
+
+class JSONHandler(http.server.BaseHTTPRequestHandler):
+
+    def __init__(self, request, client_address, server):
+        self.dispatcher = jsonrpc.Dispatcher()
+        self.dispatcher.add_method(server.neard_runner.get_metrics,
+                                   name="metrics")
+        self.dispatcher.add_method(server.neard_runner.do_modify_config,
+                                   name="modify_config")
+        self.dispatcher.add_method(server.neard_runner.do_stop, name="stop")
+        self.dispatcher.add_method(server.neard_runner.do_restart,
+                                   name="restart")
+        self.dispatcher.add_method(server.neard_runner.do_restart_mirror,
+                                   name="restart_mirror")
+        self.dispatcher.add_method(server.neard_runner.do_json_rpc,
+                                   name="json_rpc")
+        super().__init__(request, client_address, server)
+
+    def do_GET(self):
+        if self.path == '/status':
+            body = 'OK\n'.encode('UTF-8')
+            self.send_response(http.HTTPStatus.OK)
+            self.send_header("Content-Type", 'application/json')
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_error(http.HTTPStatus.NOT_FOUND)
+
+    def do_POST(self):
+        l = self.headers.get('content-length')
+        if l is None:
+            self.send_error(http.HTTPStatus.BAD_REQUEST,
+                            "Content-Length missing")
+            return
+
+        body = self.rfile.read(int(l))
+        response = jsonrpc.JSONRPCResponseManager.handle(body, self.dispatcher)
+        response_body = response.json.encode('UTF-8')
+
+        self.send_response(http_code(response.error))
+        self.send_header("Content-Type", 'application/json')
+        self.send_header("Content-Length", str(len(response_body)))
+        self.end_headers()
+        self.wfile.write(response_body)
+
+
+class RpcServer(http.server.HTTPServer):
+
+    def __init__(self, addr, neard_runner):
+        self.neard_runner = neard_runner
+        super().__init__(addr, JSONHandler)
+
+
+def nested_modification(config, modification):
+    for mkey, mvalue in modification.items():
+        if mkey in config:
+            value = config[mkey]
+            if isinstance(value, dict) and isinstance(mvalue, dict):
+                nested_modification(value, mvalue)
+            else:
+                config[mkey] = mvalue
+        else:
+            config[mkey] = mvalue
+
+
+class NeardRunner:
+
+    def __init__(self, args):
+        self.home = args.home
+        self.neard_home = args.neard_home
+        self.neard_logs_dir = args.neard_logs_dir
+        self.binary_dir = args.binary_dir
+        self.neard = None
+        # self.data will contain data that we want to persist so we can
+        # start where we left off if this process is killed and restarted
+        # for now we save info on the neard binaries (their paths and epoch
+        # heights where we want to run them), a bool that tells whether neard
+        # should be running, and info on the currently running neard process
+        try:
+            with open(os.path.join(self.home, 'data.json'), 'r') as f:
+                self.data = json.load(f)
+                self.data['binaries'].sort(key=lambda x: x['epoch_height'])
+        except FileNotFoundError:
+            self.data = {
+                'binaries': [],
+                'run': False,
+                'neard_process': {
+                    'pid': None,
+                    # we save the create_time so we can tell if the process with pid equal
+                    # to the one we saved is the same process. It's not that likely, but
+                    # if we don't do this (or maybe something else like it), then it's possble
+                    # that if this process is killed and restarted and we see a process with that PID,
+                    # it could actually be a different process that was started later after neard exited
+                    'create_time': 0,
+                    'path': None,
+                }
+            }
+        # here we assume the home dir has already been inited. In the future we will want to
+        # initialize it in this program
+        self.neard_addr = self.get_addr()
+        # protects self.data, and its representation on disk, because both the rpc server
+        # and the loop that checks if we should upgrade the binary after a new epoch touch
+        # it concurrently
+        self.lock = threading.Lock()
+
+    def get_addr(self):
+        with open(os.path.join(self.neard_home, 'config.json'), 'r') as f:
+            config = json.load(f)
+            return config['rpc']['addr']
+
+    def save_data(self):
+        with open(os.path.join(self.home, 'data.json'), 'w') as f:
+            json.dump(self.data, f)
+
+    def shift_logs(self):
+        try:
+            os.mkdir(self.neard_logs_dir)
+        except FileExistsError:
+            pass
+        for i in range(20, -1, -1):
+            old_log = os.path.join(self.neard_logs_dir, f'log-{i}.txt')
+            new_log = os.path.join(self.neard_logs_dir, f'log-{i+1}.txt')
+            try:
+                os.rename(old_log, new_log)
+            except FileNotFoundError:
+                pass
+
+    def do_restart_generic(self, binary_name, add_cmd):
+        self.do_stop()
+
+        self.shift_logs()
+
+        neard_path = os.path.join(self.binary_dir, binary_name)
+
+        with open(os.path.join(self.neard_logs_dir, 'log-0.txt'), 'ab') as out:
+            cmd = [
+                neard_path,
+                '--home',
+                self.neard_home,
+            ] + add_cmd
+            env = os.environ.copy()
+            if 'RUST_LOG' not in env:
+                env['RUST_LOG'] = 'actix_web=warn,mio=warn,tokio_util=warn,actix_server=warn,actix_http=warn,debug'
+            logging.info(f'running {" ".join(cmd)}')
+            self.neard = subprocess.Popen(
+                cmd,
+                stdin=subprocess.DEVNULL,
+                stdout=out,
+                stderr=out,
+                env=env,
+            )
+
+        try:
+            create_time = int(psutil.Process(self.neard.pid).create_time())
+        except psutil.NoSuchProcess:
+            # not that likely, but if neard already exited, catch the exception so
+            # at least this process doesn't die
+            create_time = 0
+
+        self.neard_addr = self.get_addr()
+
+        self.data['neard_process'] = {
+            'pid': self.neard.pid,
+            'create_time': create_time,
+            'path': neard_path,
+        }
+        self.save_data()
+
+    def do_restart(self, binary_name='neard', unsafe=True):
+        add_cmd = []
+        if unsafe:
+            add_cmd.append('--unsafe-fast-startup')
+        add_cmd.append('run')
+        self.do_restart_generic(binary_name, add_cmd)
+
+    def do_restart_mirror(self, binary_name='neard'):
+        add_cmd = [
+            'mirror', 'run', '--source-home', self.neard_home, '--target-home',
+            f'{self.neard_home}/target', '--no-secret'
+        ]
+        self.do_restart_generic(binary_name, add_cmd)
+
+    def do_stop(self):
+        if self.neard is not None:
+            logging.info('stopping neard')
+            self.neard.send_signal(signal.SIGINT)
+            self.neard.wait()
+            self.neard = None
+            self.data['neard_process']['pid'] = None
+            self.data['neard_process']['create_time'] = 0
+            self.save_data()
+            return "stopped neard"
+        elif self.data['neard_process']['pid'] is not None:
+            result = "stopped neard"
+            try:
+                p = psutil.Process(self.data['neard_process']['pid'])
+                if int(p.create_time()
+                      ) == self.data['neard_process']['create_time']:
+                    logging.info('stopping neard')
+                    p.send_signal(signal.SIGINT)
+                    p.wait()
+            except psutil.NoSuchProcess:
+                result = "no running neard found"
+            self.data['neard_process']['pid'] = None
+            self.data['neard_process']['create_time'] = 0
+            self.save_data()
+            return result
+        return "no running neard found"
+
+    def do_json_rpc(self, method, params):
+        try:
+            j = {
+                'method': method,
+                'params': params,
+                'id': 'dontcare',
+                'jsonrpc': '2.0'
+            }
+            r = requests.post(f'http://{self.neard_addr}', json=j, timeout=5)
+            r.raise_for_status()
+            return r.text
+        except requests.exceptions.ConnectionError:
+            return "{}"
+
+    def get_metrics(self):
+        try:
+            r = requests.get(f'http://{self.neard_addr}/metrics', timeout=5)
+            r.raise_for_status()
+            return r.text
+        except requests.exceptions.ConnectionError:
+            return ""
+
+    def do_modify_config(self, modifications):
+        with open(os.path.join(self.neard_home, 'config.json'), 'r') as f:
+            config = json.load(f)
+        nested_modification(config, modifications)
+        with open(os.path.join(self.neard_home, 'config.json'), 'w') as f:
+            json.dump(config, f, indent=1)
+
+    def serve(self, port):
+        s = RpcServer(('0.0.0.0', port), self)
+        s.serve_forever()
+
+
+def main():
+    parser = argparse.ArgumentParser(description='run neard')
+    parser.add_argument('--home', type=str, required=True)
+    parser.add_argument('--neard-home', type=str, required=True)
+    parser.add_argument('--binary-dir', type=str, required=True)
+    parser.add_argument('--neard-logs-dir', type=str, required=True)
+    parser.add_argument('--port', type=int, required=True)
+    args = parser.parse_args()
+
+    logging.basicConfig(format='[%(asctime)s] %(levelname)s: %(message)s',
+                        level=logging.INFO)
+
+    config_path = os.path.join(args.home, 'config.json')
+    if not os.path.isdir(args.home):
+        sys.exit(f'please create the directory at {args.home}')
+
+    # only let one instance of this code run at a time
+    _fd = get_lock(args.home)
+
+    runner = NeardRunner(args)
+
+    runner.serve(args.port)
+
+
+if __name__ == '__main__':
+    main()

--- a/pytest/tests/mocknet/s3_state_sync.py
+++ b/pytest/tests/mocknet/s3_state_sync.py
@@ -7,7 +7,7 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
 from mocknet.nodes import get_gcloud_nodes, get_nodes_by_label, get_localnet_nodes, exclude_nodes, intersect_nodes
 from mocknet.stats import NodeAccumulationStats, NodeMetrics
 from mocknet.helper import stop_nodes, restart_nodes, set_state_parts_dump_mode_for_nodes, set_tracked_shard_for_node, \
-    set_tracked_shard_for_nodes, set_state_parts_sync_mode_for_nodes
+    set_tracked_shard_for_nodes, set_state_parts_sync_mode_for_nodes, enable_state_sync
 from mocknet.test_flow import loop_for, wait_for_metric, wait_n_epochs, wait_for_nodes_to_sync, nodes_are_in_sync, \
     init_nodes, wait_for_nodes_to_be_up
 from configured_logger import logger
@@ -86,6 +86,7 @@ class TestStateSync:
             set_state_parts_sync_mode_for_nodes(nodes,
                                                 bucket=self.s3_bucket,
                                                 region=self.s3_region)
+        enable_state_sync(nodes)
 
     # Starts the traffic node in mirroring mode
     def start_traffic(self):

--- a/pytest/tests/mocknet/s3_state_sync.py
+++ b/pytest/tests/mocknet/s3_state_sync.py
@@ -1,0 +1,159 @@
+import argparse
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
+
+from mocknet.nodes import get_gcloud_nodes, get_nodes_by_label, get_localnet_nodes, exclude_nodes, intersect_nodes
+from mocknet.stats import NodeAccumulationStats, NodeMetrics
+from mocknet.helper import stop_nodes, restart_nodes, set_state_parts_dump_mode_for_nodes, set_tracked_shard_for_node, \
+    set_tracked_shard_for_nodes, set_state_parts_sync_mode_for_nodes
+from mocknet.test_flow import loop_for, wait_for_metric, wait_n_epochs, wait_for_nodes_to_sync, nodes_are_in_sync, \
+    init_nodes, wait_for_nodes_to_be_up
+from configured_logger import logger
+
+
+class TestStateSync:
+
+    def __init__(self, args):
+        self.s3_bucket = args.s3_bucket
+        self.s3_region = args.s3_region
+        self.parts_local_dir = args.parts_local_dir
+
+        self.sync_duration = args.sync_time_limit
+
+        self.localnet = args.localnet
+        if self.localnet:
+            self.nodes, self.traffic_nodes = get_localnet_nodes(
+                'state_sync',
+                num_validators=5,
+                num_rpc=3,
+                default_port=args.port)
+        else:
+            self.nodes, self.traffic_nodes = get_gcloud_nodes(
+                args.project, args.chain_id)
+            for node in self.nodes:
+                node['address'] = node['address'] + ':' + str(args.port)
+
+        self.stats_bounds = {
+            'bps': {
+                'min': args.min_bps,
+            },
+            'missed_chunks': {
+                'max': args.max_missed_chunks
+            },
+            'epoch_height': {},
+            'sync_status': {
+                'max': 0
+            },
+        }
+
+    # if late is True, returns late validators
+    # if late is False, returns not late validators
+    # if late is None, returns all validators
+    def get_validators(self, late=None):
+        # TODO(posvyatokum) this will depend on terraform script implementation
+        labels = {'role': 'validator'}
+        if late is not None:
+            labels['late'] = 'yes' if late else 'no'
+        return get_nodes_by_label(self.nodes, {'role': 'validator'})
+
+    def get_dumping_nodes(self):
+        # TODO(posvyatokum) this will depend on terraform script implementation
+        return get_nodes_by_label(self.nodes, {'state-parts-producer': 'yes'})
+
+    def get_late_nodes(self):
+        # TODO(posvyatokum) this will depend on terraform script implementation
+        return get_nodes_by_label(self.nodes, {'late': 'yes'})
+
+    def setup_dump_nodes(self):
+        if self.localnet:
+            set_state_parts_dump_mode_for_nodes(self.get_dumping_nodes(),
+                                                root_dir=self.parts_local_dir)
+        else:
+            set_state_parts_dump_mode_for_nodes(self.get_dumping_nodes(),
+                                                bucket=self.s3_bucket,
+                                                region=self.s3_region)
+
+        for i, node in enumerate(self.get_dumping_nodes()[:2]):
+            set_tracked_shard_for_node(node, [i * 2, i * 2 + 1])
+
+    # Starts the traffic node in mirroring mode
+    def start_traffic(self):
+        # TODO(posvyatokum): implement
+        pass
+
+    def run(self):
+        all_stats = []
+
+        logger.info("Step 0: setup nodes")
+        stop_nodes(self.nodes)
+        init_nodes(self.nodes, self.traffic_nodes)
+        self.setup_dump_nodes()
+
+        logger.info("Step 1: run early nodes for 5 epochs")
+        early_nodes = exclude_nodes(self.nodes, self.get_late_nodes())
+        restart_nodes(early_nodes)
+        wait_for_nodes_to_be_up(early_nodes)
+        self.start_traffic()
+        wait_n_epochs(5,
+                      early_nodes,
+                      all_stats=all_stats,
+                      stats_bounds=self.stats_bounds)
+
+        all_late_nodes = self.get_late_nodes()
+
+        logger.info("Step 2: setup and run late validator for 2 epochs")
+        late_validators = self.get_validators(late=True)
+        set_tracked_shard_for_nodes(late_validators, [])
+        restart_nodes(late_validators)
+        wait_for_nodes_to_be_up(late_validators)
+        wait_n_epochs(2,
+                      early_nodes + late_validators,
+                      all_stats=all_stats,
+                      stats_bounds=self.stats_bounds)
+
+        logger.info(
+            "Step 3: setup and run late rpc; wait until late nodes sync")
+        late_rpc = exclude_nodes(self.get_late_nodes(), late_validators)
+        set_tracked_shard_for_nodes(late_validators, [1, 2, 3, 4])
+        restart_nodes(late_rpc)
+        wait_for_nodes_to_be_up(late_rpc)
+        final_metrics = wait_for_nodes_to_sync(sync_nodes=all_late_nodes,
+                                               all_nodes=self.nodes,
+                                               duration=self.sync_duration,
+                                               all_stats=all_stats,
+                                               stats_bounds=self.stats_bounds)
+
+        NodeAccumulationStats(all_stats).print_report(self.stats_bounds)
+        if nodes_are_in_sync(final_metrics, all_late_nodes):
+            logger.info('Nodes synced successfully')
+        else:
+            logger.error('Nodes failed to sync')
+            sys.exit('FAIL')
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Run S3 State Sync Test')
+    parser.add_argument('--port',
+                        type=int,
+                        required=True,
+                        help='helper scripts port')
+    parser.add_argument('--sync-time-limit',
+                        type=int,
+                        required=True,
+                        help='Time given to nodes to do a full sync in seconds')
+    parser.add_argument('--s3-bucket', type=str, required=True)
+    parser.add_argument('--s3-region', type=str, required=True)
+    parser.add_argument('--parts-local-dir', type=str)
+    parser.add_argument('--min-bps', type=float, default=1.0)
+    parser.add_argument('--max-missed-chunks', type=float, default=0.1)
+    parser.add_argument('--localnet', type=bool, default=False)
+    args = parser.parse_args()
+
+    test = TestStateSync(args)
+    test.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/pytest/tests/mocknet/s3_state_sync.py
+++ b/pytest/tests/mocknet/s3_state_sync.py
@@ -56,7 +56,7 @@ class TestStateSync:
         labels = {'role': 'validator'}
         if late is not None:
             labels['late'] = 'yes' if late else 'no'
-        return get_nodes_by_label(self.nodes, {'role': 'validator'})
+        return get_nodes_by_label(self.nodes, labels)
 
     def get_dumping_nodes(self):
         # TODO(posvyatokum) this will depend on terraform script implementation


### PR DESCRIPTION
Trigger warning: GIANT PR.
Another warning: Work so very much in progress.

Adding scripts needed to run state sync mocktest.
`neard_helper.py` is a script that should be operating on every machine. It provides json rpc to start/stop nodes, modify config, query metrics (and in future it also should do some basic manipulations with near directory to allow for test initialisation and traffic mirroring). This is a generic file that should be sorta universal and shared between tests.
`s3_state_sync.py` is the test itself. Test flow is designed to follow this document https://docs.google.com/document/d/1B3v6Z2d7Pcls1slqdNTcD3OrsbKdJYTGEBvOEHVXrIU/edit?usp=sharing. 
Everything in `lib/mocknet/` are utils for the test. Generic, universal, shared between tests, etc.. you get it, it's a lib. 

Right now test works with localnet. Not works as in passes, but works as in completes the run. 
Steps to reproduce, and play, and have oh so much fun while doing so:
```
neard localnet --validators 5 --non-validators 3 --shards 1 --tracked-shards none --prefix s3ss

# from near home:
mkdir ./s3ss0/runner ./s3ss1/runner ./s3ss2/runner ./s3ss3/runner ./s3ss4/runner ./s3ss5/runner ./s3ss6/runner  ./s3ss7/runner 

# start helpers for all the nodes
# probably sufficient to only perform this once
# the helper should work fine even if you recreate the localnet
$NEAR_HOME=#something/.near
$BIN_DIR=#something/nearcore/target/release
$i=#0-7]
python3 neard_helper.py --home $NEAR_HOME/s3ss$i/runner --neard-home $NEAR_HOME/s3ss$i --binary-dir $BIN_DIR --neard-logs-dir $NEAR_HOME/s3ss$i --port 222$i

# and finally the test
# s3 params are required but not used with localnet setup
# parts-local-dir is not required but used with localnet setup
# yes, it IS a shitshow right now
python3 s3_state_sync.py --port 2220 --s3-bucket a --s3-region a --localnet=True --parts-local-dir $NEAR_HOME/state-parts --sync-time-limit=600 
```

Choose your own adventure, of course, but still here is a suggested reading order:
- `mocknet/__init__.py` 🙃
- `s3_state_sync.py` starting with `run(self)`
- `mocknet/test_flow.py` starting with `loop_for(...)`
- `mocknet/stats.py`
- `mocknet/nodes.py`
- `helpers/neard_helper.py` (which is a modification of the `neard_runner.py` used in pre-release mocknet test)
- `mocknet/helper.py`

And a final note, I DO NOT intend to merge THIS PR. I mean, nothing bad will happen, it is just not reviewable in this form. 
I am creating this PR to share code, collaborate, and when I'm done testing this particular mocktest, create several smaller PRs out of this thing. 
