### PR TITLE
[neard] Add `view-state clear-cache` command to neard

### DIFF
--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -81,6 +81,9 @@ pub enum StateViewerSubCommand {
     /// View trie structure.
     #[clap(alias = "view_trie")]
     ViewTrie(ViewTrieCmd),
+    /// Clear recoverable data in CachedContractCode column.
+    #[clap(alias = "clear_cache")]
+    ClearCache,
 }
 
 impl StateViewerSubCommand {
@@ -118,6 +121,7 @@ impl StateViewerSubCommand {
             StateViewerSubCommand::Chain(cmd) => cmd.run(near_config, store),
             StateViewerSubCommand::CheckBlock => check_block_chunk_existence(near_config, store),
             StateViewerSubCommand::Chunks(cmd) => cmd.run(near_config, store),
+            StateViewerSubCommand::ClearCache => clear_cache(store),
             StateViewerSubCommand::ContractAccounts(cmd) => cmd.run(home_dir, near_config, store),
             StateViewerSubCommand::DumpAccountStorage(cmd) => cmd.run(home_dir, near_config, store),
             StateViewerSubCommand::DumpCode(cmd) => cmd.run(home_dir, near_config, store),

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -26,8 +26,7 @@ use near_primitives::trie_key::TrieKey;
 use near_primitives::types::{chunk_extra::ChunkExtra, BlockHeight, ShardId, StateRoot};
 use near_primitives_core::types::Gas;
 use near_store::test_utils::create_test_store;
-use near_store::TrieDBStorage;
-use near_store::{Store, Trie, TrieCache, TrieCachingStorage, TrieConfig};
+use near_store::{DBCol, Store, Trie, TrieCache, TrieCachingStorage, TrieConfig, TrieDBStorage};
 use nearcore::{NearConfig, NightshadeRuntime};
 use node_runtime::adapter::ViewRuntimeAdapter;
 use serde_json::json;
@@ -976,4 +975,9 @@ pub(crate) fn contract_accounts(
     }
 
     Ok(())
+}
+
+pub(crate) fn clear_cache(store: Store) {
+    let mut store_update = store.store_update();
+    store_update.delete_all(DBCol::CachedContractCode);
 }

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -980,4 +980,5 @@ pub(crate) fn contract_accounts(
 pub(crate) fn clear_cache(store: Store) {
     let mut store_update = store.store_update();
     store_update.delete_all(DBCol::CachedContractCode);
+    store_update.commit().unwrap();
 }


### PR DESCRIPTION
This PR is related to issue https://github.com/near/nearcore/issues/8650

In this PR we are adding a new `clear-cache` subcommand under neard command `view-state`.

The idea is to create a command to reset state/delete all recoverable data from the DB. `clear-cache` command, for now, deletes all data in the column `DBCol::CachedContractCode`.