### PR TITLE
Switch to using serde_with

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,16 +60,16 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.2.2"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c83abf9903e1f0ad9973cc4f7b9767fd5a03a583f51a5b7a339e07987cd2724"
+checksum = "c2079246596c18b4a33e274ae10c0e50613f4d32a4198e09c7b93771013fed74"
 dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
  "actix-utils",
- "ahash",
- "base64",
+ "ahash 0.8.3",
+ "base64 0.21.0",
  "bitflags",
  "brotli",
  "bytes",
@@ -91,6 +91,8 @@ dependencies = [
  "rand 0.8.5",
  "sha1",
  "smallvec",
+ "tokio",
+ "tokio-util 0.7.2",
  "tracing",
  "zstd",
 ]
@@ -190,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.0.1"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e5ebffd51d50df56a3ae0de0e59487340ca456f05dd0b90c0a7a6dd6a74d31"
+checksum = "a27e8fe9ba4ae613c21f677c2cfaf0696c3744030c6f485b34634e502d6bb379"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -203,7 +205,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "actix-web-codegen",
- "ahash",
+ "ahash 0.7.6",
  "bytes",
  "bytestring",
  "cfg-if 1.0.0",
@@ -224,7 +226,7 @@ dependencies = [
  "serde_urlencoded",
  "smallvec",
  "socket2",
- "time 0.3.9",
+ "time 0.3.21",
  "url",
 ]
 
@@ -272,7 +274,19 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.6",
+ "getrandom 0.2.9",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "getrandom 0.2.9",
  "once_cell",
  "version_check",
 ]
@@ -299,6 +313,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "697ed7edc0f1711de49ce108c541623a0af97c6c60b2f6e2b65229847ac843c2"
 dependencies = [
  "alloc-no-stdlib",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -483,9 +506,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "awc"
-version = "3.0.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65c60c44fbf3c8cee365e86b97d706e513b733c4eeb16437b45b88d2fffe889a"
+checksum = "87ef547a81796eb2dfe9b345aba34c2e08391a0502493711395b36dd64052b69"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -493,8 +516,8 @@ dependencies = [
  "actix-service",
  "actix-tls",
  "actix-utils",
- "ahash",
- "base64",
+ "ahash 0.7.6",
+ "base64 0.21.0",
  "bytes",
  "cfg-if 1.0.0",
  "cookie",
@@ -528,7 +551,7 @@ dependencies = [
  "serde",
  "serde-xml-rs",
  "thiserror",
- "time 0.3.9",
+ "time 0.3.21",
  "url",
 ]
 
@@ -561,6 +584,12 @@ name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "basic-toml"
@@ -1068,15 +1097,17 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
- "libc",
+ "iana-time-zone",
+ "js-sys",
  "num-integer",
  "num-traits",
  "serde",
  "time 0.1.44",
+ "wasm-bindgen",
  "winapi",
 ]
 
@@ -1163,6 +1194,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
 name = "cold-store-tool"
 version = "0.0.0"
 dependencies = [
@@ -1227,7 +1268,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94d4706de1b0fa5b132270cddffa8585166037822e260a944fe161acd137ca05"
 dependencies = [
  "percent-encoding",
- "time 0.3.9",
+ "time 0.3.21",
  "version_check",
 ]
 
@@ -1613,10 +1654,54 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.13.4"
+name = "cxx"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0558d22a7b463ed0241e993f76f09f30b126687447751a8638587b864e4b3944"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -1624,26 +1709,27 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.13.4"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+checksum = "ab8bfa2e259f8ee1ce5e97824a3c55ec4404a0d772ca7fa96bf19f0752a046eb"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "strsim",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.13.4"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
  "darling_core",
  "quote",
- "syn 1.0.103",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1863,23 +1949,23 @@ dependencies = [
 
 [[package]]
 name = "enumset"
-version = "1.0.11"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4799cdb24d48f1f8a7a98d06b7fde65a85a2d1e42b25a889f5406aa1fbefe074"
+checksum = "e875f1719c16de097dee81ed675e2d9bb63096823ed3f0ca827b7dea3028bbbb"
 dependencies = [
  "enumset_derive",
 ]
 
 [[package]]
 name = "enumset_derive"
-version = "0.6.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea83a3fbdc1d999ccfbcbee717eab36f8edf2d71693a23ce0d7cca19e085304c"
+checksum = "e08b6c6ab82d70f08844964ba10c7babb716de2ecaeab9be5717918a5177d3af"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -2234,13 +2320,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.6"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -2291,7 +2377,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
 ]
 
 [[package]]
@@ -2300,7 +2386,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
 ]
 
 [[package]]
@@ -2478,6 +2564,30 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
 ]
 
 [[package]]
@@ -2811,6 +2921,15 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -3198,7 +3317,7 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
- "time 0.3.9",
+ "time 0.3.21",
  "tokio",
 ]
 
@@ -3305,7 +3424,7 @@ dependencies = [
  "once_cell",
  "rand 0.8.5",
  "reed-solomon-erasure",
- "time 0.3.9",
+ "time 0.3.21",
  "tracing",
 ]
 
@@ -3542,6 +3661,7 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
+ "serde_with",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3725,7 +3845,7 @@ dependencies = [
  "stun",
  "tempfile",
  "thiserror",
- "time 0.3.9",
+ "time 0.3.21",
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.2",
@@ -3846,11 +3966,12 @@ dependencies = [
  "reed-solomon-erasure",
  "serde",
  "serde_json",
+ "serde_with",
  "serde_yaml",
  "smart-default",
  "strum",
  "thiserror",
- "time 0.3.9",
+ "time 0.3.21",
  "tracing",
 ]
 
@@ -3859,7 +3980,7 @@ name = "near-primitives-core"
 version = "0.0.0"
 dependencies = [
  "arbitrary",
- "base64",
+ "base64 0.21.0",
  "borsh 0.10.2",
  "bs58",
  "derive_more",
@@ -3870,6 +3991,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
+ "serde_with",
  "sha2 0.10.6",
  "strum",
  "thiserror",
@@ -4552,15 +4674,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi 0.1.19",
- "libc",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
  "libc",
 ]
 
@@ -5285,7 +5398,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.6",
+ "getrandom 0.2.9",
 ]
 
 [[package]]
@@ -5383,7 +5496,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.6",
+ "getrandom 0.2.9",
  "redox_syscall 0.2.13",
  "thiserror",
 ]
@@ -5467,11 +5580,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.10"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a1f7aa4f35e5e8b4160449f51afc758f0ce6454315a9fa7d0d113e958c41eb"
+checksum = "13293b639a097af28fc8a90f22add145a9c954e49d77da06263d58cf44d5fb91"
 dependencies = [
- "base64",
+ "base64 0.21.0",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -5483,10 +5596,10 @@ dependencies = [
  "hyper-tls",
  "ipnet",
  "js-sys",
- "lazy_static",
  "log",
  "mime",
  "native-tls",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "serde",
@@ -5494,10 +5607,12 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-util 0.6.10",
+ "tokio-util 0.7.2",
+ "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "winreg",
 ]
@@ -5693,7 +5808,7 @@ dependencies = [
  "async-trait",
  "aws-creds",
  "aws-region",
- "base64",
+ "base64 0.13.0",
  "block_on_proc",
  "cfg-if 1.0.0",
  "hex",
@@ -5710,7 +5825,7 @@ dependencies = [
  "serde_derive",
  "sha2 0.10.6",
  "thiserror",
- "time 0.3.9",
+ "time 0.3.21",
  "tokio",
  "tokio-stream",
  "url",
@@ -5835,6 +5950,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "scratch"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
 
 [[package]]
 name = "seahash"
@@ -6011,6 +6132,34 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f02d8aa6e3c385bf084924f660ce2a3a6bd333ba55b35e8590b321f35d88513"
+dependencies = [
+ "base64 0.21.0",
+ "chrono",
+ "hex",
+ "indexmap",
+ "serde",
+ "serde_json",
+ "serde_with_macros",
+ "time 0.3.21",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc7d5d3932fb12ce722ee5e64dd38c504efba37567f0c402f6ca728c3b8b070"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -6368,7 +6517,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7e94b1ec00bad60e6410e058b52f1c66de3dc5fe4d62d09b3e52bb7d3b73e25"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "crc",
  "lazy_static",
  "md-5",
@@ -6584,22 +6733,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.9"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
 dependencies = [
  "itoa",
- "libc",
- "num_threads",
  "serde",
+ "time-core",
  "time-macros",
 ]
 
 [[package]]
-name = "time-macros"
-version = "0.2.4"
+name = "time-core"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+
+[[package]]
+name = "time-macros"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
+dependencies = [
+ "time-core",
+]
 
 [[package]]
 name = "tinytemplate"
@@ -6744,7 +6901,7 @@ checksum = "ff08f4649d10a70ffa3522ca559031285d8e421d727ac85c60825761818f5d0a"
 dependencies = [
  "async-stream",
  "async-trait",
- "base64",
+ "base64 0.13.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -6840,7 +6997,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
 dependencies = [
  "crossbeam-channel",
- "time 0.3.9",
+ "time 0.3.21",
  "tracing-subscriber",
 ]
 
@@ -6956,7 +7113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4712ee30d123ec7ae26d1e1b218395a16c87cdbaf4b3925d170d684af62ea5e8"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.13.0",
  "futures",
  "log",
  "md-5",
@@ -7244,6 +7401,19 @@ dependencies = [
  "leb128",
  "wasm-encoder 0.11.0",
  "wasmparser 0.84.0",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bbae3363c08332cadccd13b67db371814cd214c2524020932f0804b8cf7c078"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -7729,6 +7899,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.0",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8012,18 +8191,18 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.11.2+zstd.1.5.2"
+version = "0.12.3+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+checksum = "76eea132fb024e0e13fd9c2f5d5d595d8a967aa72382ac2f9d39fcc95afd0806"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
+version = "6.0.3+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+checksum = "68e4a3f57d13d0ab7e478665c60f35e2a613dcd527851c2c7287ce5c787e134a"
 dependencies = [
  "libc",
  "zstd-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,9 +82,9 @@ exclude = [ "neard" ]
 [workspace.dependencies]
 actix = "0.13.0"
 actix-cors = "0.6.1"
-actix-http = "3.0.4"
+actix-http = "3.3"
 actix-rt = "2"
-actix-web = "4.0.1"
+actix-web = "4.1"
 ansi_term = "0.12"
 anyhow = "1.0.62"
 arbitrary = { version = "1.2.3", features = ["derive"] }
@@ -95,7 +95,7 @@ async-trait = "0.1.58"
 atty = "0.2"
 awc = { version = "3", features = ["openssl"] }
 backtrace = "0.3"
-base64 = "0.13"
+base64 = "0.21"
 bencher = "0.1.5"
 bitflags = "1.2"
 blake2 = "0.9.1"
@@ -256,7 +256,7 @@ redis = "0.23.0"
 reed-solomon-erasure = "4"
 regex = "1.7.1"
 region = "3.0"
-reqwest = { version = "0.11.0", features = ["blocking"] }
+reqwest = { version = "0.11.14", features = ["blocking"] }
 ripemd = "0.1.1"
 rkyv = "0.7.31"
 rlimit = "0.7"
@@ -271,6 +271,7 @@ serde = { version = "1.0.136", features = ["alloc", "derive", "rc"] }
 serde_ignored = "0.1"
 serde_json = "1.0.68"
 serde_repr = "0.1.8"
+serde_with = { version = "3.0", features = ["base64"] }
 serde_yaml = "0.9"
 serial_test = "0.5"
 sha2 = "0.10"

--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -13,13 +13,18 @@ use num_rational::Ratio;
 use std::sync::Arc;
 use std::time::Instant;
 
+fn timestamp(hour: u32, min: u32, sec: u32, millis: u32) -> chrono::DateTime<chrono::Utc> {
+    chrono::Utc.with_ymd_and_hms(2020, 10, 1, hour, min, sec).single().unwrap()
+        + chrono::Duration::milliseconds(i64::from(millis))
+}
+
 #[test]
 fn build_chain() {
     init_test_logger();
     let mock_clock_guard = MockClockGuard::default();
 
-    mock_clock_guard.add_utc(chrono::Utc.ymd(2020, 10, 1).and_hms_milli(0, 0, 3, 444));
-    mock_clock_guard.add_utc(chrono::Utc.ymd(2020, 10, 1).and_hms_milli(0, 0, 0, 0)); // Client startup timestamp.
+    mock_clock_guard.add_utc(timestamp(0, 0, 3, 444));
+    mock_clock_guard.add_utc(timestamp(0, 0, 0, 0)); // Client startup timestamp.
     mock_clock_guard.add_instant(Instant::now());
 
     let (mut chain, _, _, signer) = setup();
@@ -52,8 +57,8 @@ fn build_chain() {
         // two entries, because the clock is called 2 times per block
         // - one time for creation of the block
         // - one time for validating block header
-        mock_clock_guard.add_utc(chrono::Utc.ymd(2020, 10, 1).and_hms_milli(0, 0, 3, 444 + i));
-        mock_clock_guard.add_utc(chrono::Utc.ymd(2020, 10, 1).and_hms_milli(0, 0, 3, 444 + i));
+        mock_clock_guard.add_utc(timestamp(0, 0, 3, 444 + i));
+        mock_clock_guard.add_utc(timestamp(0, 0, 3, 444 + i));
         // Instant calls for CryptoHashTimer.
         mock_clock_guard.add_instant(Instant::now());
         mock_clock_guard.add_instant(Instant::now());

--- a/chain/client/src/debug.rs
+++ b/chain/client/src/debug.rs
@@ -709,7 +709,8 @@ pub(crate) fn new_network_info_view(chain: &Chain, network_info: &NetworkInfo) -
                     .collect(),
                 account_key: d.account_key.clone(),
                 timestamp: chrono::DateTime::from_utc(
-                    chrono::NaiveDateTime::from_timestamp(d.timestamp.unix_timestamp(), 0),
+                    chrono::NaiveDateTime::from_timestamp_opt(d.timestamp.unix_timestamp(), 0)
+                        .unwrap(),
                     chrono::Utc,
                 ),
             })

--- a/chain/jsonrpc/Cargo.toml
+++ b/chain/jsonrpc/Cargo.toml
@@ -15,6 +15,7 @@ futures.workspace = true
 once_cell.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+serde_with.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/chain/jsonrpc/fuzz/fuzz_targets_disabled/fuzz_target_1.rs
+++ b/chain/jsonrpc/fuzz/fuzz_targets_disabled/fuzz_target_1.rs
@@ -86,7 +86,8 @@ impl JsonRpcRequest {
 
 impl Serialize for Base64String {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        near_primitives::serialize::base64_format::serialize(&self.0, serializer)
+        let encoded = near_primitives::serialize::to_base64(&self.0);
+        serializer.serialize_str(&encoded)
     }
 }
 

--- a/core/primitives-core/Cargo.toml
+++ b/core/primitives-core/Cargo.toml
@@ -22,6 +22,7 @@ enum-map.workspace = true
 num-rational.workspace = true
 serde.workspace = true
 serde_repr.workspace = true
+serde_with.workspace = true
 sha2.workspace = true
 strum.workspace = true
 thiserror.workspace = true

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -29,6 +29,7 @@ rand.workspace = true
 reed-solomon-erasure.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+serde_with.workspace = true
 serde_yaml.workspace = true
 smart-default.workspace = true
 stdx.workspace = true

--- a/core/primitives/src/receipt.rs
+++ b/core/primitives/src/receipt.rs
@@ -1,11 +1,13 @@
 use crate::borsh::maybestd::collections::HashMap;
 use crate::hash::CryptoHash;
-use crate::serialize::{dec_format, option_base64_format};
+use crate::serialize::dec_format;
 use crate::transaction::{Action, TransferAction};
 use crate::types::{AccountId, Balance, ShardId};
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_crypto::{KeyType, PublicKey};
 use near_fmt::AbbrBytes;
+use serde_with::base64::Base64;
+use serde_with::serde_as;
 use std::borrow::Borrow;
 use std::fmt;
 
@@ -142,6 +144,7 @@ pub struct ActionReceipt {
 
 /// An incoming (ingress) `DataReceipt` which is going to a Receipt's `receiver` input_data_ids
 /// Which will be converted to `PromiseResult::Successful(value)` or `PromiseResult::Failed`
+#[serde_as]
 #[derive(
     BorshSerialize,
     BorshDeserialize,
@@ -154,7 +157,7 @@ pub struct ActionReceipt {
 )]
 pub struct DataReceipt {
     pub data_id: CryptoHash,
-    #[serde(with = "option_base64_format")]
+    #[serde_as(as = "Option<Base64>")]
     pub data: Option<Vec<u8>>,
 }
 

--- a/core/primitives/src/state_record.rs
+++ b/core/primitives/src/state_record.rs
@@ -1,7 +1,6 @@
 use crate::account::{AccessKey, Account};
 use crate::hash::{hash, CryptoHash};
 use crate::receipt::{Receipt, ReceivedData};
-use crate::serialize::{base64_format, option_base64_format};
 use crate::trie_key::col;
 use crate::trie_key::trie_key_parsers::{
     parse_account_id_from_access_key_key, parse_account_id_from_account_key,
@@ -12,9 +11,12 @@ use crate::trie_key::trie_key_parsers::{
 use crate::types::{AccountId, StoreKey, StoreValue};
 use borsh::BorshDeserialize;
 use near_crypto::PublicKey;
+use serde_with::base64::Base64;
+use serde_with::serde_as;
 use std::fmt::{Display, Formatter};
 
 /// Record in the state storage.
+#[serde_as]
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub enum StateRecord {
     /// Account information.
@@ -24,7 +26,7 @@ pub enum StateRecord {
     /// Contract code encoded in base64.
     Contract {
         account_id: AccountId,
-        #[serde(with = "base64_format")]
+        #[serde_as(as = "Base64")]
         code: Vec<u8>,
     },
     /// Access key associated with some account.
@@ -35,7 +37,7 @@ pub enum StateRecord {
     ReceivedData {
         account_id: AccountId,
         data_id: CryptoHash,
-        #[serde(with = "option_base64_format")]
+        #[serde_as(as = "Option<Base64>")]
         data: Option<Vec<u8>>,
     },
     /// Delayed Receipt.

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -3,13 +3,15 @@ use crate::delegate_action::SignedDelegateAction;
 use crate::errors::TxExecutionError;
 use crate::hash::{hash, CryptoHash};
 use crate::merkle::MerklePath;
-use crate::serialize::{base64_format, dec_format};
+use crate::serialize::dec_format;
 use crate::types::{AccountId, Balance, Gas, Nonce};
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_crypto::{PublicKey, Signature};
 use near_fmt::{AbbrBytes, Slice};
 use near_primitives_core::profile::{ProfileDataV2, ProfileDataV3};
 use near_primitives_core::types::Compute;
+use serde_with::base64::Base64;
+use serde_with::serde_as;
 use std::borrow::Borrow;
 use std::fmt;
 use std::hash::{Hash, Hasher};
@@ -114,12 +116,13 @@ impl From<CreateAccountAction> for Action {
 }
 
 /// Deploy contract action
+#[serde_as]
 #[derive(
     BorshSerialize, BorshDeserialize, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone,
 )]
 pub struct DeployContractAction {
     /// WebAssembly binary
-    #[serde(with = "base64_format")]
+    #[serde_as(as = "Base64")]
     pub code: Vec<u8>,
 }
 
@@ -137,12 +140,13 @@ impl fmt::Debug for DeployContractAction {
     }
 }
 
+#[serde_as]
 #[derive(
     BorshSerialize, BorshDeserialize, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone,
 )]
 pub struct FunctionCallAction {
     pub method_name: String,
-    #[serde(with = "base64_format")]
+    #[serde_as(as = "Base64")]
     pub args: Vec<u8>,
     pub gas: Gas,
     #[serde(with = "dec_format")]

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -3,7 +3,6 @@ use crate::challenge::ChallengesResult;
 use crate::errors::EpochError;
 use crate::hash::CryptoHash;
 use crate::receipt::Receipt;
-use crate::serialize::base64_format;
 use crate::serialize::dec_format;
 use crate::trie_key::TrieKey;
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -11,6 +10,8 @@ use near_crypto::PublicKey;
 /// Reexport primitive types
 pub use near_primitives_core::types::*;
 use once_cell::sync::Lazy;
+use serde_with::base64::Base64;
+use serde_with::serde_as;
 use std::sync::Arc;
 
 /// Hash used by to store state root.
@@ -49,6 +50,7 @@ pub struct AccountInfo {
 ///
 /// NOTE: Currently, this type is only used in the view_client and RPC to be able to transparently
 /// pretty-serialize the bytes arrays as base64-encoded strings (see `serialize.rs`).
+#[serde_as]
 #[derive(
     serde::Serialize,
     serde::Deserialize,
@@ -63,12 +65,13 @@ pub struct AccountInfo {
     BorshDeserialize,
 )]
 #[serde(transparent)]
-pub struct StoreKey(#[serde(with = "base64_format")] Vec<u8>);
+pub struct StoreKey(#[serde_as(as = "Base64")] Vec<u8>);
 
 /// This type is used to mark values returned from store (arrays of bytes).
 ///
 /// NOTE: Currently, this type is only used in the view_client and RPC to be able to transparently
 /// pretty-serialize the bytes arrays as base64-encoded strings (see `serialize.rs`).
+#[serde_as]
 #[derive(
     serde::Serialize,
     serde::Deserialize,
@@ -83,13 +86,14 @@ pub struct StoreKey(#[serde(with = "base64_format")] Vec<u8>);
     BorshDeserialize,
 )]
 #[serde(transparent)]
-pub struct StoreValue(#[serde(with = "base64_format")] Vec<u8>);
+pub struct StoreValue(#[serde_as(as = "Base64")] Vec<u8>);
 
 /// This type is used to mark function arguments.
 ///
 /// NOTE: The main reason for this to exist (except the type-safety) is that the value is
 /// transparently serialized and deserialized as a base64-encoded string when serde is used
 /// (serde_json).
+#[serde_as]
 #[derive(
     serde::Serialize,
     serde::Deserialize,
@@ -104,7 +108,7 @@ pub struct StoreValue(#[serde(with = "base64_format")] Vec<u8>);
     BorshDeserialize,
 )]
 #[serde(transparent)]
-pub struct FunctionArgs(#[serde(with = "base64_format")] Vec<u8>);
+pub struct FunctionArgs(#[serde_as(as = "Base64")] Vec<u8>);
 
 /// A structure used to indicate the kind of state changes due to transaction/receipt processing, etc.
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]

--- a/core/primitives/src/upgrade_schedule.rs
+++ b/core/primitives/src/upgrade_schedule.rs
@@ -11,8 +11,7 @@ pub struct ProtocolUpgradeVotingSchedule {
 
 impl Default for ProtocolUpgradeVotingSchedule {
     fn default() -> Self {
-        let epoch = NaiveDateTime::from_timestamp(0, 0);
-        Self { timestamp: DateTime::<Utc>::from_utc(epoch, Utc) }
+        Self { timestamp: DateTime::<Utc>::from_utc(Default::default(), Utc) }
     }
 }
 

--- a/core/primitives/src/utils.rs
+++ b/core/primitives/src/utils.rs
@@ -408,10 +408,10 @@ macro_rules! unwrap_or_return {
 
 /// Converts timestamp in ns into DateTime UTC time.
 pub fn from_timestamp(timestamp: u64) -> DateTime<chrono::Utc> {
-    let secs =
-        timestamp.checked_div(NS_IN_SECOND).expect("dividing by non-zero const is safe") as i64;
-    let nsecs = timestamp.checked_rem(NS_IN_SECOND).expect("modulo non-zero const is safe") as u32;
-    DateTime::from_utc(NaiveDateTime::from_timestamp(secs, nsecs), chrono::Utc)
+    let secs = (timestamp / NS_IN_SECOND) as i64;
+    let nsecs = (timestamp % NS_IN_SECOND) as u32;
+    let naive = NaiveDateTime::from_timestamp_opt(secs, nsecs).unwrap();
+    DateTime::from_utc(naive, chrono::Utc)
 }
 
 /// Converts DateTime UTC time into timestamp in ns.

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -18,7 +18,7 @@ use crate::merkle::{combine_hash, MerklePath};
 use crate::network::PeerId;
 use crate::receipt::{ActionReceipt, DataReceipt, DataReceiver, Receipt, ReceiptEnum};
 use crate::runtime::config::RuntimeConfig;
-use crate::serialize::{base64_format, dec_format, option_base64_format};
+use crate::serialize::dec_format;
 use crate::sharding::{
     ChunkHash, ShardChunk, ShardChunkHeader, ShardChunkHeaderInner, ShardChunkHeaderInnerV2,
     ShardChunkHeaderV3,
@@ -43,6 +43,8 @@ use near_fmt::{AbbrBytes, Slice};
 use near_primitives_core::config::{ActionCosts, ExtCosts, ParameterCost, VMConfig};
 use near_primitives_core::runtime::fees::Fee;
 use num_rational::Rational32;
+use serde_with::base64::Base64;
+use serde_with::serde_as;
 use std::collections::HashMap;
 use std::fmt;
 use std::ops::Range;
@@ -65,9 +67,11 @@ pub struct AccountView {
 }
 
 /// A view of the contract code.
+#[serde_as]
 #[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq, Debug, Clone)]
 pub struct ContractCodeView {
-    #[serde(rename = "code_base64", with = "base64_format")]
+    #[serde(rename = "code_base64")]
+    #[serde_as(as = "Base64")]
     pub code: Vec<u8>,
     pub hash: CryptoHash,
 }
@@ -1091,6 +1095,7 @@ impl ChunkView {
     }
 }
 
+#[serde_as]
 #[derive(
     BorshSerialize,
     BorshDeserialize,
@@ -1104,7 +1109,7 @@ impl ChunkView {
 pub enum ActionView {
     CreateAccount,
     DeployContract {
-        #[serde(with = "base64_format")]
+        #[serde_as(as = "Base64")]
         code: Vec<u8>,
     },
     FunctionCall {
@@ -1253,6 +1258,7 @@ impl From<SignedTransaction> for SignedTransactionView {
     }
 }
 
+#[serde_as]
 #[derive(
     BorshSerialize,
     BorshDeserialize,
@@ -1272,7 +1278,7 @@ pub enum FinalExecutionStatus {
     /// The execution has failed with the given error.
     Failure(TxExecutionError),
     /// The execution has succeeded and returned some value or an empty vec encoded in base64.
-    SuccessValue(#[serde(with = "base64_format")] Vec<u8>),
+    SuccessValue(#[serde_as(as = "Base64")] Vec<u8>),
 }
 
 impl fmt::Debug for FinalExecutionStatus {
@@ -1304,6 +1310,7 @@ pub enum ServerError {
     Closed,
 }
 
+#[serde_as]
 #[derive(
     BorshSerialize, BorshDeserialize, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone,
 )]
@@ -1313,7 +1320,7 @@ pub enum ExecutionStatusView {
     /// The execution has failed.
     Failure(TxExecutionError),
     /// The final action succeeded and returned some value or an empty vec encoded in base64.
-    SuccessValue(#[serde(with = "base64_format")] Vec<u8>),
+    SuccessValue(#[serde_as(as = "Base64")] Vec<u8>),
     /// The final action of the receipt returned a promise or the signed transaction was converted
     /// to a receipt. Contains the receipt_id of the generated receipt.
     SuccessReceiptId(CryptoHash),
@@ -1770,6 +1777,7 @@ pub struct DataReceiverView {
     pub receiver_id: AccountId,
 }
 
+#[serde_as]
 #[derive(
     BorshSerialize,
     BorshDeserialize,
@@ -1792,7 +1800,7 @@ pub enum ReceiptEnumView {
     },
     Data {
         data_id: CryptoHash,
-        #[serde(with = "option_base64_format")]
+        #[serde_as(as = "Option<Base64>")]
         data: Option<Vec<u8>>,
     },
 }
@@ -2124,6 +2132,7 @@ impl From<StateChangeCause> for StateChangeCauseView {
     }
 }
 
+#[serde_as]
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case", tag = "type", content = "change")]
 pub enum StateChangeValueView {
@@ -2158,7 +2167,8 @@ pub enum StateChangeValueView {
     },
     ContractCodeUpdate {
         account_id: AccountId,
-        #[serde(rename = "code_base64", with = "base64_format")]
+        #[serde(rename = "code_base64")]
+        #[serde_as(as = "Base64")]
         code: Vec<u8>,
     },
     ContractCodeDeletion {

--- a/deny.toml
+++ b/deny.toml
@@ -117,6 +117,7 @@ skip = [
     # criterion and wasmer-runtime-core-near depend on this older
     # version of the crate.
     { name = "rustc_version", version = "=0.2.3" },
+    { name = "errno", version = "=0.2.8" },
 
     # paperclip-macros, strum_macros, walrus-macro depend on this while clap3.1.6 uses heck=0.4.0
     { name = "heck", version = "=0.3.3" },
@@ -149,4 +150,8 @@ skip = [
 
     # near-test-contracts
     { name = "wasm-encoder", version = "=0.11.0" },
+
+    # Various packages haven’t upgraded to 0.base64 21 yet.
+    { name = "base64", version = "=0.13.0" },
+    { name = "ahash", version = "=0.7.6" },
 ]

--- a/genesis-tools/genesis-csv-to-json/src/csv_parser.rs
+++ b/genesis-tools/genesis-csv-to-json/src/csv_parser.rs
@@ -286,6 +286,10 @@ mod tests {
 
     #[test]
     fn test_with_file() {
+        fn timestamp(hour: u32, min: u32, sec: u32) -> Option<DateTime<Utc>> {
+            Some(Utc.with_ymd_and_hms(2019, 12, 21, hour, min, sec).single().unwrap())
+        }
+
         let file = NamedTempFile::new().unwrap();
         let mut writer = WriterBuilder::new().has_headers(true).from_writer(file.reopen().unwrap());
         writer
@@ -300,10 +304,10 @@ mod tests {
                 foundation_pks: vec![PublicKey::empty(KeyType::ED25519)],
                 full_pks: vec![],
                 amount: 1000,
-                lockup: Some(Utc.ymd(2019, 12, 21).and_hms(23, 0, 0)),
-                vesting_start: Some(Utc.ymd(2019, 12, 21).and_hms(22, 0, 0)),
-                vesting_end: Some(Utc.ymd(2019, 12, 21).and_hms(23, 30, 0)),
-                vesting_cliff: Some(Utc.ymd(2019, 12, 21).and_hms(22, 30, 20)),
+                lockup: timestamp(23, 0, 0),
+                vesting_start: timestamp(22, 0, 0),
+                vesting_end: timestamp(23, 30, 0),
+                vesting_cliff: timestamp(22, 30, 20),
                 validator_stake: 100,
                 validator_key: Some(PublicKey::empty(KeyType::ED25519)),
                 peer_info: Some(PeerInfo {
@@ -324,7 +328,7 @@ mod tests {
                 foundation_pks: vec![PublicKey::empty(KeyType::ED25519)],
                 full_pks: vec![],
                 amount: 2000,
-                lockup: Some(Utc.ymd(2019, 12, 21).and_hms(23, 0, 0)),
+                lockup: timestamp(23, 0, 0),
                 vesting_start: None,
                 vesting_end: None,
                 vesting_cliff: None,

--- a/runtime/near-test-contracts/test-contract-rs/Cargo.lock
+++ b/runtime/near-test-contracts/test-contract-rs/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "itoa"

--- a/runtime/near-test-contracts/test-contract-rs/Cargo.toml
+++ b/runtime/near-test-contracts/test-contract-rs/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-base64 = "0.13"
+base64 = "0.21"
 serde_json = "1"
 
 [profile.release]

--- a/runtime/near-test-contracts/test-contract-rs/src/lib.rs
+++ b/runtime/near-test-contracts/test-contract-rs/src/lib.rs
@@ -608,7 +608,8 @@ fn log_u64(msg: u64) {
 }
 
 pub fn from_base64(s: &str) -> Vec<u8> {
-    base64::decode(s).unwrap()
+    let engine = &base64::engine::general_purpose::STANDARD;
+    base64::Engine::decode(engine, s).unwrap()
 }
 
 #[no_mangle]

--- a/runtime/runtime-params-estimator/estimator-warehouse/src/db.rs
+++ b/runtime/runtime-params-estimator/estimator-warehouse/src/db.rs
@@ -206,7 +206,9 @@ mod tests {
             let init_sql = include_str!("init.sql");
             conn.execute_batch(init_sql).unwrap();
             let db = Self::new(conn);
-            db.mock_time(NaiveDate::from_ymd(2015, 5, 15).and_hms(11, 22, 33));
+            db.mock_time(
+                NaiveDate::from_ymd_opt(2015, 5, 15).unwrap().and_hms_opt(11, 22, 33).unwrap(),
+            );
             db
         }
 


### PR DESCRIPTION
Using serde_with to customise serde serialisation removes some of the
code while at the same time enables more powerful customisation
annotations.

Bringing the dependency forces update of base64 and chrono
dependencies.
