### PR TITLE
chore: add support for workspace inheritance to themis

### DIFF
--- a/tools/themis/src/types.rs
+++ b/tools/themis/src/types.rs
@@ -170,21 +170,23 @@ mod tests {
             read_toml_with_potential_inheritance(&pkg, Some(&workspace), &["dependencies", "syn"])
         );
 
-        assert_ne!(
-            Some(&toml::Value::String("..".to_owned())),
-            read_toml_with_potential_inheritance(
-                &pkg,
-                Some(&workspace),
-                &["dependencies", "serde", "path"]
-            )
-        );
-
         assert_eq!(
             Some(&toml::Value::Boolean(true)),
             read_toml_with_potential_inheritance(
                 &pkg,
                 Some(&workspace),
                 &["dependencies", "quote", "optional"]
+            )
+        );
+
+        assert_eq!(
+            Some(&toml! {
+                "path" = "../serde"
+            }),
+            read_toml_with_potential_inheritance(
+                &pkg,
+                Some(&workspace),
+                &["dependencies", "serde"]
             )
         );
     }
@@ -201,6 +203,7 @@ mod tests {
             [dependencies]
             syn.workspace = true
             quote.workspace = true
+            serde = { workspace = true }
         };
 
         let workspace = toml! {
@@ -227,21 +230,23 @@ mod tests {
             read_toml_with_potential_inheritance(&pkg, Some(&workspace), &["dependencies", "syn"])
         );
 
-        assert_ne!(
-            Some(&toml::Value::String("..".to_owned())),
-            read_toml_with_potential_inheritance(
-                &pkg,
-                Some(&workspace),
-                &["dependencies", "serde", "path"]
-            )
-        );
-
         assert_eq!(
             Some(&toml::Value::Boolean(true)),
             read_toml_with_potential_inheritance(
                 &pkg,
                 Some(&workspace),
                 &["dependencies", "quote", "optional"]
+            )
+        );
+
+        assert_eq!(
+            Some(&toml! {
+                "path" = "../serde"
+            }),
+            read_toml_with_potential_inheritance(
+                &pkg,
+                Some(&workspace),
+                &["dependencies", "serde"]
             )
         );
     }

--- a/tools/themis/src/types.rs
+++ b/tools/themis/src/types.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::rc::Rc;
 
 use cargo_metadata::camino::Utf8PathBuf;
 
@@ -7,14 +8,30 @@ use super::style;
 #[derive(Debug)]
 pub struct Package {
     pub parsed: cargo_metadata::Package,
-    pub raw: toml::Value,
+    pub manifest: Manifest,
 }
 
 #[derive(Debug)]
 pub struct Workspace {
     pub root: Utf8PathBuf,
     pub members: Vec<Package>,
-    pub raw: toml::Value,
+    pub manifest: Rc<Manifest>,
+}
+
+#[derive(Debug)]
+pub struct Manifest {
+    raw: toml::Value,
+    parent: Option<Rc<Manifest>>,
+}
+
+impl Manifest {
+    pub fn new(this: toml::Value, parent: Option<Rc<Manifest>>) -> Self {
+        Self { raw: this, parent }
+    }
+
+    pub fn read(&self, path: &[&str]) -> Option<&toml::Value> {
+        read_toml_with_potential_inheritance(&self.raw, self.parent.as_ref().map(|p| &p.raw), path)
+    }
 }
 
 #[derive(Debug)]
@@ -90,5 +107,142 @@ impl ComplianceError {
             ));
         }
         eprintln!("{}", report);
+    }
+}
+
+fn read_toml_with_potential_inheritance<'a>(
+    this: &'a toml::Value,
+    parent: Option<&'a toml::Value>,
+    path: &[&str],
+) -> Option<&'a toml::Value> {
+    let mut raw = this;
+    let mut cursor = 0;
+
+    for (i, key) in path.iter().enumerate() {
+        if let Some(_raw) = raw.get(key) {
+            (raw, cursor) = (_raw, i);
+        }
+    }
+
+    if let (toml::Value::Table(contents), Some(parent)) = (raw, parent) {
+        if let Some(toml::Value::Boolean(true)) = contents.get("workspace") {
+            return read_toml_with_potential_inheritance(&parent["workspace"], None, path);
+        }
+    }
+
+    (cursor == path.len() - 1).then_some(raw)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use toml::toml;
+
+    #[test]
+    fn test_read_pkg() {
+        let pkg = toml! {
+            [package]
+            name = "pkg"
+            version = "0.1.0"
+            edition = "2021"
+            authors = ["Alice <alice@p2p.io>"]
+
+            [dependencies]
+            syn = "2"
+            quote = { version = "0.6", optional = true }
+
+            [dependencies.serde]
+            path = "../serde"
+        };
+
+        let workspace = toml! {
+            [workspace]
+            members = ["pkg"]
+        };
+
+        assert_eq!(
+            Some(&toml::Value::String("2021".to_owned())),
+            read_toml_with_potential_inheritance(&pkg, Some(&workspace), &["package", "edition"])
+        );
+
+        assert_eq!(
+            Some(&toml::Value::String("2".to_owned())),
+            read_toml_with_potential_inheritance(&pkg, Some(&workspace), &["dependencies", "syn"])
+        );
+
+        assert_ne!(
+            Some(&toml::Value::String("..".to_owned())),
+            read_toml_with_potential_inheritance(
+                &pkg,
+                Some(&workspace),
+                &["dependencies", "serde", "path"]
+            )
+        );
+
+        assert_eq!(
+            Some(&toml::Value::Boolean(true)),
+            read_toml_with_potential_inheritance(
+                &pkg,
+                Some(&workspace),
+                &["dependencies", "quote", "optional"]
+            )
+        );
+    }
+
+    #[test]
+    fn test_workspace_inheritance() {
+        let pkg = toml! {
+            [package]
+            name = "pkg"
+            version.workspace = true
+            edition.workspace = true
+            authors.workspace = true
+
+            [dependencies]
+            syn.workspace = true
+            quote.workspace = true
+        };
+
+        let workspace = toml! {
+            [workspace.package]
+            version = "0.1.0"
+            edition = "2021"
+            authors = ["Alice <alice@p2p.io>"]
+
+            [workspace.dependencies]
+            syn = "2"
+            quote = { version = "0.6", optional = true }
+
+            [workspace.dependencies.serde]
+            path = "../serde"
+        };
+
+        assert_eq!(
+            Some(&toml::Value::String("2021".to_owned())),
+            read_toml_with_potential_inheritance(&pkg, Some(&workspace), &["package", "edition"])
+        );
+
+        assert_eq!(
+            Some(&toml::Value::String("2".to_owned())),
+            read_toml_with_potential_inheritance(&pkg, Some(&workspace), &["dependencies", "syn"])
+        );
+
+        assert_ne!(
+            Some(&toml::Value::String("..".to_owned())),
+            read_toml_with_potential_inheritance(
+                &pkg,
+                Some(&workspace),
+                &["dependencies", "serde", "path"]
+            )
+        );
+
+        assert_eq!(
+            Some(&toml::Value::Boolean(true)),
+            read_toml_with_potential_inheritance(
+                &pkg,
+                Some(&workspace),
+                &["dependencies", "quote", "optional"]
+            )
+        );
     }
 }


### PR DESCRIPTION
`themis` needs to read directly from package manifests in some cases. Since we updated to workspace inheritance, this format has changed.

To avoid the flow potentially breaking in the future, this patch allows the interpretation of `.workspace = true` entries.