### PR TITLE
fix: don't panic on SIGTERM during flat storage creation

### DIFF
--- a/chain/chain/src/flat_storage_creator.rs
+++ b/chain/chain/src/flat_storage_creator.rs
@@ -133,10 +133,12 @@ impl FlatStorageShardCreator {
         match result_sender.send(num_items) {
             Ok(_) => {}
             Err(e) => {
-                error!(target: "client", "During flat storage creation, state \
-                part sender channel was disconnected: {e}. Results of fetching \
-                state part {part_id:?} for shard {shard_uid} will not be recorded \
-                and flat storage creation will stall. Please restart the node.");
+                eprintln!(
+                    "During flat storage creation, state part sender channel \
+                    was disconnected: {e}. Results of fetching state part \
+                    {part_id:?} for shard {shard_uid} will not be recorded \
+                    and flat storage creation will stall. Please restart the node."
+                );
             }
         }
     }

--- a/chain/chain/src/flat_storage_creator.rs
+++ b/chain/chain/src/flat_storage_creator.rs
@@ -30,7 +30,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
-use tracing::{debug, error, info};
+use tracing::{debug, info};
 
 /// If we launched a node with enabled flat storage but it doesn't have flat storage data on disk, we have to create it.
 /// This struct is responsible for this process for the given shard.

--- a/chain/chain/src/flat_storage_creator.rs
+++ b/chain/chain/src/flat_storage_creator.rs
@@ -130,16 +130,15 @@ impl FlatStorageShardCreator {
             proccessed parts: {processed_parts}"
         );
 
-        match result_sender.send(num_items) {
-            Ok(_) => {}
-            Err(e) => {
-                eprintln!(
-                    "During flat storage creation, state part sender channel \
-                    was disconnected: {e}. Results of fetching state part \
-                    {part_id:?} for shard {shard_uid} will not be recorded \
-                    and flat storage creation will stall. Please restart the node."
-                );
-            }
+        if let Err(e) = result_sender.send(num_items) {
+            // Log error with `eprintln` because `tracing` stops working after
+            // SIGTERM.
+            eprintln!(
+                "During flat storage creation, state part sender channel \
+                was disconnected: {e}. Results of fetching state part \
+                {part_id:?} for shard {shard_uid} will not be recorded \
+                and flat storage creation will stall. Please restart the node."
+            );
         }
     }
 


### PR DESCRIPTION
Fixes panicking of threads fetching state on flat storage creation.

If binary is stopped by SIGTERM, channel for receiving messages with state part stats can be disconnected. We shouldn't panic in such case, it's enough to log an error. Still, the node will stall for ~5 minutes because existing rayon threads need to finish heavy IO work. 

Original thread https://near.zulipchat.com/#narrow/stream/308695-pagoda.2Fprivate/topic/Flat.20storage.20crash.20on.20SIGTERM.201.2E34-RC1/near/358803319