### PR TITLE
feat(state-viewer): Display kickouts information

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6264,6 +6264,7 @@ dependencies = [
  "chrono",
  "clap 4.2.4",
  "insta",
+ "itertools",
  "near-chain",
  "near-chain-configs",
  "near-client",

--- a/tools/state-viewer/Cargo.toml
+++ b/tools/state-viewer/Cargo.toml
@@ -14,6 +14,7 @@ anyhow.workspace = true
 borsh.workspace = true
 chrono.workspace = true
 clap.workspace = true
+itertools.workspace = true
 once_cell.workspace = true
 rand.workspace = true
 rayon.workspace = true

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -402,11 +402,15 @@ impl DumpTxCmd {
 
 #[derive(clap::Args)]
 pub struct EpochInfoCmd {
+    /// Which EpochInfos to process.
     #[clap(subcommand)]
     epoch_selection: crate::epoch_info::EpochSelection,
     /// Displays kickouts of the given validator and expected and missed blocks and chunks produced.
     #[clap(long)]
     validator_account_id: Option<String>,
+    /// Show only information about kickouts.
+    #[clap(long)]
+    kickouts_summary: bool,
 }
 
 impl EpochInfoCmd {
@@ -414,6 +418,7 @@ impl EpochInfoCmd {
         print_epoch_info(
             self.epoch_selection,
             self.validator_account_id.map(|s| AccountId::from_str(&s).unwrap()),
+            self.kickouts_summary,
             near_config,
             store,
         );

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -796,6 +796,7 @@ pub(crate) fn check_block_chunk_existence(near_config: NearConfig, store: Store)
 pub(crate) fn print_epoch_info(
     epoch_selection: epoch_info::EpochSelection,
     validator_account_id: Option<AccountId>,
+    kickouts_summary: bool,
     near_config: NearConfig,
     store: Store,
 ) {
@@ -810,6 +811,7 @@ pub(crate) fn print_epoch_info(
     epoch_info::print_epoch_info(
         epoch_selection,
         validator_account_id,
+        kickouts_summary,
         store,
         &mut chain_store,
         &epoch_manager,

--- a/tools/state-viewer/src/epoch_info.rs
+++ b/tools/state-viewer/src/epoch_info.rs
@@ -208,10 +208,10 @@ pub(crate) fn iterate_and_filter(
 }
 
 fn display_kickouts(epoch_info: &EpochInfo) {
-    for (key, value) in
-        epoch_info.validator_kickout().iter().sorted_by_key(|(&ref account_id, _)| account_id)
+    for (account_id, kickout_reason) in
+        epoch_info.validator_kickout().iter().sorted_by_key(|&(account_id, _)| account_id)
     {
-        println!("{:?}: {:?}", key, value);
+        println!("{:?}: {:?}", account_id, kickout_reason);
     }
 }
 

--- a/tools/state-viewer/src/epoch_info.rs
+++ b/tools/state-viewer/src/epoch_info.rs
@@ -1,5 +1,6 @@
 use borsh::BorshDeserialize;
 use core::ops::Range;
+use itertools::Itertools;
 use near_chain::{ChainStore, ChainStoreAccess};
 use near_epoch_manager::{EpochManagerAdapter, EpochManagerHandle};
 use near_primitives::account::id::AccountId;
@@ -207,7 +208,9 @@ pub(crate) fn iterate_and_filter(
 }
 
 fn display_kickouts(epoch_info: &EpochInfo) {
-    for (key, value) in epoch_info.validator_kickout() {
+    for (key, value) in
+        epoch_info.validator_kickout().iter().sorted_by_key(|(&ref account_id, _)| account_id)
+    {
         println!("{:?}: {:?}", key, value);
     }
 }


### PR DESCRIPTION
Extends the `neard view-state epoch-info` command to show only the kickouts.
Fixes that tool not to panic while displaying EpochInfo which doesn't have the corresponding blocks.