### PR TITLE
refactor: put `sync_prev_prev_hash` to `obtain_state_part`

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2968,6 +2968,7 @@ impl Chain {
         }
         let state_root = sync_prev_block.chunks()[shard_id as usize].prev_state_root();
         let sync_prev_hash = *sync_prev_block.hash();
+        let sync_prev_prev_hash = *sync_prev_block.header().prev_hash();
         let state_root_node = self
             .runtime_adapter
             .get_state_root_node(shard_id, &sync_prev_hash, &state_root)
@@ -2982,7 +2983,7 @@ impl Chain {
             .runtime_adapter
             .obtain_state_part(
                 shard_id,
-                &sync_prev_hash,
+                &sync_prev_prev_hash,
                 &state_root,
                 PartId::new(part_id, num_parts),
             )

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -278,9 +278,9 @@ pub trait RuntimeAdapter: Send + Sync {
 
     fn store(&self) -> &Store;
 
-    /// Returns trie with non-view cache for given `state_root`. `prev_hash` is used to access flat storage and to
-    /// identify the epoch the given `shard_id` is at.
-    /// Note that `prev_hash` and `state_root` must correspond to the same block.
+    /// Returns trie with non-view cache for given `state_root`.
+    /// `prev_hash` is a block whose post state root is `state_root`, used to
+    /// access flat storage and to identify the epoch the given `shard_id` is at.
     fn get_trie_for_shard(
         &self,
         shard_id: ShardId,
@@ -477,12 +477,13 @@ pub trait RuntimeAdapter: Send + Sync {
         request: &QueryRequest,
     ) -> Result<QueryResponse, near_chain_primitives::error::QueryError>;
 
-    /// Get the part of the state from given state root.
-    /// `block_hash` is a block whose `prev_state_root` is `state_root`
+    /// Get part of the state corresponding to the given state root.
+    /// `prev_hash` is a block whose post state root is `state_root`.
+    /// Returns error when storage is inconsistent.
     fn obtain_state_part(
         &self,
         shard_id: ShardId,
-        block_hash: &CryptoHash,
+        prev_hash: &CryptoHash,
         state_root: &StateRoot,
         part_id: PartId,
     ) -> Result<Vec<u8>, Error>;

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -270,6 +270,8 @@ impl ChainGenesis {
 /// Bridge between the chain and the runtime.
 /// Main function is to update state given transactions.
 /// Additionally handles validators.
+/// Naming note: `state_root` is a pre state root for block `block_hash` and a
+/// post state root for block `prev_hash`.
 pub trait RuntimeAdapter: Send + Sync {
     /// Get store and genesis state roots
     fn genesis_state(&self) -> (Store, Vec<StateRoot>);

--- a/tools/mock-node/src/setup.rs
+++ b/tools/mock-node/src/setup.rs
@@ -206,7 +206,7 @@ pub fn setup_mock_node(
                     let state_part = mock_network_runtime
                         .obtain_state_part(
                             shard_id,
-                            &next_hash,
+                            &hash,
                             &state_root,
                             PartId::new(part_id, num_parts),
                         )

--- a/tools/state-viewer/src/state_parts.rs
+++ b/tools/state-viewer/src/state_parts.rs
@@ -352,7 +352,7 @@ fn dump_state_parts(
     let sync_hash = get_any_block_hash_of_epoch(&epoch, chain);
     let sync_hash = StateSync::get_epoch_start_sync_hash(chain, &sync_hash).unwrap();
     let sync_block_header = chain.get_block_header(&sync_hash).unwrap();
-    let sync_prev_header = chain.get_previous_header(&sync_block_header)?;
+    let sync_prev_header = chain.get_previous_header(&sync_block_header).unwrap();
     let sync_prev_prev_hash = sync_prev_header.prev_hash();
 
     let state_header = chain.compute_state_response_header(shard_id, sync_hash).unwrap();

--- a/tools/state-viewer/src/state_parts.rs
+++ b/tools/state-viewer/src/state_parts.rs
@@ -351,8 +351,9 @@ fn dump_state_parts(
     let epoch = chain.epoch_manager.get_epoch_info(&epoch_id).unwrap();
     let sync_hash = get_any_block_hash_of_epoch(&epoch, chain);
     let sync_hash = StateSync::get_epoch_start_sync_hash(chain, &sync_hash).unwrap();
-    let sync_block = chain.get_block_header(&sync_hash).unwrap();
-    let sync_prev_hash = sync_block.prev_hash();
+    let sync_block_header = chain.get_block_header(&sync_hash).unwrap();
+    let sync_prev_header = chain.get_previous_header(&sync_block_header)?;
+    let sync_prev_prev_hash = sync_prev_header.prev_hash();
 
     let state_header = chain.compute_state_response_header(shard_id, sync_hash).unwrap();
     let state_root = state_header.chunk_prev_state_root();
@@ -381,7 +382,7 @@ fn dump_state_parts(
             .runtime_adapter
             .obtain_state_part(
                 shard_id,
-                &sync_prev_hash,
+                sync_prev_prev_hash,
                 &state_root,
                 PartId::new(part_id, num_parts),
             )


### PR DESCRIPTION
Replace `block_hash` in `RuntimeAdapter::obtain_state_part` with `prev_hash`.

This doesn't impact functionality but is quite convenient for flat storage integration here: #8927. Existing obstacle is that flat storage includes aggregated updates until flat storage block hash, **included**. So if we want block hash to correspond to state root, state root must be **post state root** for a block.

Existing tests must not fail. Notably, contract precompilation tests passed incorrect hash, but we didn't notice that because block hash was used only for getting shard uids.