### PR TITLE
feat(mocknet): move initialization logic to neard_runner.py

### DIFF
--- a/pytest/tests/mocknet/README.md
+++ b/pytest/tests/mocknet/README.md
@@ -2,13 +2,10 @@ Mirror transactions from a given network into a custom mocktest network and add 
 
 1. Setup a custom mocknet network following the README in the `provisioning/terraform/network/mocknet/mirror/` directory of the [near-ops](https://github.com/near/near-ops) repo.
 - you'll need the `unique_id`, `chain_id`, and `start_height` from this setup when running the mirror.py test script in 2.
-2. Run `python3 tests/mocknet/mirror.py --chain-id {chain_id} --start-height {start_height} --unique-id {unique_id} setup` replacing the `{}`s with appropriate values from the `nearcore/pytest` directory.
-- This may take a bit to setup, so if you get a Broken pipe make sure to complete the following steps:
-- Get the instances associated with your project: `gcloud --project near-mocknet compute instances list | grep {unique_id}`
-- ssh into the instances and check `/home/ubuntu/.near/logs/amend-genesis.txt` on the nodes to make sure there's nothing bad in there
-- then also run `du -sh /home/ubuntu/.near/records.json` on the validators and  `du -sh /home/ubuntu/.near/target/records.json` on the traffic generator. If it's 27 GB (and there's no neard process when you run `ps -C neard`) it should be done.
-- Run `python3 tests/mocknet/mirror.py --chain-id {chain_id} --start-height {start_height} --unique-id {unique_id} make-backups` replacing the `{}`s with appropriate values. This step will take >12 hours to run (shouldn't be >24 hours).
-- If you get an ssh connection reset or other disconnection error while running the previous command, re-run the command or ssh into the instances and run `top` command to see if the neard is using a lot of CPU to make backups. 
-3. Run `python3 tests/mocknet/mirror.py --chain-id {chain_id} --start-height {start_height} --unique-id {unique_id} --start-traffic` replacing the `{}`s with appropriate values
+2. Run `python3 tests/mocknet/mirror.py --chain-id {chain_id} --start-height {start_height} --unique-id {unique_id} init-neard-runner`, replacing the `{}`s with appropriate values from the `nearcore/pytest` directory. This starts a helper program on each node that will be in charge of the test state and neard process.
+3. Run `python3 tests/mocknet/mirror.py --chain-id {chain_id} --start-height {start_height} --unique-id {unique_id} new-test`. This will take a few hours.
+4. Run `python3 tests/mocknet/mirror.py --chain-id {chain_id} --start-height {start_height} --unique-id {unique_id} start-traffic` replacing the `{}`s with appropriate values
 4. Monitoring
 - See metrics on grafana mocknet https://grafana.near.org/d/jHbiNgSnz/mocknet?orgId=1&refresh=30s&var-chain_id=All&var-node_id=.*unique_id.*&var-account_id=All replacing the "unique_id" with the value from earlier
+
+If there's ever a problem with the neard runners on each node, for example if you get a connection error running the `status` command, run the `restart-neard-runner` command to restart them, which should be safe to do.

--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -1,4 +1,5 @@
 import argparse
+from enum import Enum
 import fcntl
 import json
 import jsonrpc
@@ -6,7 +7,9 @@ import logging
 import os
 import psutil
 import requests
+import shutil
 import signal
+import socket
 import subprocess
 import sys
 import threading
@@ -43,8 +46,14 @@ class JSONHandler(http.server.BaseHTTPRequestHandler):
 
     def __init__(self, request, client_address, server):
         self.dispatcher = jsonrpc.Dispatcher()
+        self.dispatcher.add_method(server.neard_runner.do_new_test,
+                                   name="new_test")
+        self.dispatcher.add_method(server.neard_runner.do_network_init,
+                                   name="network_init")
+        self.dispatcher.add_method(server.neard_runner.do_ready, name="ready")
         self.dispatcher.add_method(server.neard_runner.do_start, name="start")
         self.dispatcher.add_method(server.neard_runner.do_stop, name="stop")
+        self.dispatcher.add_method(server.neard_runner.do_reset, name="reset")
         super().__init__(request, client_address, server)
 
     def do_GET(self):
@@ -83,13 +92,27 @@ class RpcServer(http.server.HTTPServer):
         super().__init__(addr, JSONHandler)
 
 
+class TestState(Enum):
+    NONE = 1
+    AWAITING_NETWORK_INIT = 2
+    AMEND_GENESIS = 3
+    STATE_ROOTS = 4
+    RUNNING = 5
+    STOPPED = 6
+    RESETTING = 7
+
+
 class NeardRunner:
 
     def __init__(self, args):
         self.home = args.home
         self.neard_home = args.neard_home
         self.neard_logs_dir = args.neard_logs_dir
-        with open(os.path.join(self.home, 'config.json'), 'r') as f:
+        try:
+            os.mkdir(self.neard_logs_dir)
+        except FileExistsError:
+            pass
+        with open(self.home_path('config.json'), 'r') as f:
             self.config = json.load(f)
         self.neard = None
         # self.data will contain data that we want to persist so we can
@@ -98,36 +121,25 @@ class NeardRunner:
         # heights where we want to run them), a bool that tells whether neard
         # should be running, and info on the currently running neard process
         try:
-            with open(os.path.join(self.home, 'data.json'), 'r') as f:
+            with open(self.home_path('data.json'), 'r') as f:
                 self.data = json.load(f)
                 self.data['binaries'].sort(key=lambda x: x['epoch_height'])
         except FileNotFoundError:
             self.data = {
                 'binaries': [],
-                'run': False,
-                'neard_process': {
-                    'pid': None,
-                    # we save the create_time so we can tell if the process with pid equal
-                    # to the one we saved is the same process. It's not that likely, but
-                    # if we don't do this (or maybe something else like it), then it's possble
-                    # that if this process is killed and restarted and we see a process with that PID,
-                    # it could actually be a different process that was started later after neard exited
-                    'create_time': 0,
-                    'path': None,
-                }
+                'neard_process': None,
+                'current_neard_path': None,
+                'state': TestState.NONE.value,
             }
-        # here we assume the home dir has already been inited. In the future we will want to
-        # initialize it in this program
-        with open(os.path.join(self.neard_home, 'config.json'), 'r') as f:
-            config = json.load(f)
-            self.neard_addr = config['rpc']['addr']
-        # protects self.data, and its representation on disk, because both the rpc server
-        # and the loop that checks if we should upgrade the binary after a new epoch touch
-        # it concurrently
+        # protects self.data, and its representation on disk,
+        # because both the rpc server and the main loop touch them concurrently
         self.lock = threading.Lock()
 
+    def is_traffic_generator(self):
+        return self.config.get('is_traffic_generator', False)
+
     def save_data(self):
-        with open(os.path.join(self.home, 'data.json'), 'w') as f:
+        with open(self.home_path('data.json'), 'w') as f:
             json.dump(self.data, f)
 
     def parse_binaries_config(self):
@@ -161,25 +173,25 @@ class NeardRunner:
             binaries.append({
                 'url': b['url'],
                 'epoch_height': b['epoch_height'],
-                'system_path': os.path.join(self.home, 'binaries', f'neard{i}')
+                'system_path': self.home_path('binaries', f'neard{i}')
             })
         return binaries
+
+    def reset_current_neard_path(self):
+        self.data['current_neard_path'] = self.data['binaries'][0][
+            'system_path']
 
     # tries to download the binaries specified in config.json, saving them in $home/binaries/
     def download_binaries(self):
         binaries = self.parse_binaries_config()
 
         try:
-            os.mkdir(os.path.join(self.home, 'binaries'))
+            os.mkdir(self.home_path('binaries'))
         except FileExistsError:
             pass
 
         with self.lock:
             num_binaries_saved = len(self.data['binaries'])
-            neard_process = self.data['neard_process']
-            if neard_process['path'] is None:
-                neard_process['path'] = binaries[0]['system_path']
-                self.save_data()
 
         # for now we assume that the binaries recorded in data.json as having been
         # dowloaded are still valid and were not touched. Also this assumes that their
@@ -197,29 +209,216 @@ class NeardRunner:
 
             with self.lock:
                 self.data['binaries'].append(b)
+                if self.data['current_neard_path'] is None:
+                    self.reset_current_neard_path()
                 self.save_data()
+
+    def target_near_home_path(self, *args):
+        if self.is_traffic_generator():
+            args = ('target',) + args
+        return os.path.join(self.neard_home, *args)
+
+    def home_path(self, *args):
+        return os.path.join(self.home, *args)
+
+    def tmp_near_home_path(self, *args):
+        args = ('tmp-near-home',) + args
+        return os.path.join(self.home, *args)
+
+    def neard_init(self):
+        # We make neard init save files to self.tmp_near_home_path() just to make it
+        # a bit cleaner, so we can init to a non-existent directory and then move
+        # the files we want to the real near home without having to remove it first
+        cmd = [
+            self.data['binaries'][0]['system_path'], '--home',
+            self.tmp_near_home_path(), 'init'
+        ]
+        if not self.is_traffic_generator():
+            cmd += ['--account-id', f'{socket.gethostname()}.near']
+        subprocess.check_call(cmd)
+
+        with open(self.tmp_near_home_path('config.json'), 'r') as f:
+            config = json.load(f)
+        self.data['neard_addr'] = config['rpc']['addr']
+        config['tracked_shards'] = [0, 1, 2, 3]
+        config['log_summary_style'] = 'plain'
+        config['network']['skip_sync_wait'] = False
+        config['genesis_records_file'] = 'records.json'
+        config['rpc']['enable_debug_rpc'] = True
+        if self.is_traffic_generator():
+            config['archive'] = True
+        with open(self.tmp_near_home_path('config.json'), 'w') as f:
+            json.dump(config, f, indent=2)
+
+    def move_init_files(self):
+        try:
+            os.mkdir(self.target_near_home_path())
+        except FileExistsError:
+            pass
+        for p in os.listdir(self.target_near_home_path()):
+            filename = self.target_near_home_path(p)
+            if os.path.isfile(filename):
+                os.remove(filename)
+        try:
+            shutil.rmtree(self.target_near_home_path('data'))
+        except FileNotFoundError:
+            pass
+        paths = ['config.json', 'node_key.json']
+        if not self.is_traffic_generator():
+            paths.append('validator_key.json')
+        for path in paths:
+            shutil.move(self.tmp_near_home_path(path),
+                        self.target_near_home_path(path))
+
+    # This RPC method tells to stop neard and re-initialize its home dir. This returns the
+    # validator and node key that resulted from the initialization. We can't yet call amend-genesis
+    # and compute state roots, because the caller of this method needs to hear back from
+    # each node before it can build the list of initial validators. So after this RPC method returns,
+    # we'll be waiting for the network_init RPC.
+    # TODO: add a binaries argument that tells what binaries we want to use in the test. Before we do
+    # this, it is pretty mandatory to implement some sort of client authentication, because without it,
+    # anyone would be able to get us to download and run arbitrary code
+    def do_new_test(self):
+        with self.lock:
+            self.kill_neard()
+            try:
+                shutil.rmtree(self.tmp_near_home_path())
+            except FileNotFoundError:
+                pass
+            try:
+                os.remove(self.home_path('validators.json'))
+            except FileNotFoundError:
+                pass
+            try:
+                os.remove(self.home_path('network_init.json'))
+            except FileNotFoundError:
+                pass
+
+            self.neard_init()
+            self.move_init_files()
+
+            with open(self.target_near_home_path('config.json'), 'r') as f:
+                config = json.load(f)
+            with open(self.target_near_home_path('node_key.json'), 'r') as f:
+                node_key = json.load(f)
+            if not self.is_traffic_generator():
+                with open(self.target_near_home_path('validator_key.json'),
+                          'r') as f:
+                    validator_key = json.load(f)
+                    validator_account_id = validator_key['account_id']
+                    validator_public_key = validator_key['public_key']
+            else:
+                validator_account_id = None
+                validator_public_key = None
+
+            self.set_state(TestState.AWAITING_NETWORK_INIT)
+            self.save_data()
+
+            return {
+                'validator_account_id': validator_account_id,
+                'validator_public_key': validator_public_key,
+                'node_key': node_key['public_key'],
+                'listen_port': config['network']['addr'].split(':')[1],
+            }
+
+    # After the new_test RPC, we wait to get this RPC that gives us the list of validators
+    # and boot nodes for the test network. After this RPC call, we run amend-genesis and
+    # start neard to compute genesis state roots.
+    def do_network_init(self,
+                        validators,
+                        boot_nodes,
+                        epoch_length=1000,
+                        num_seats=100):
+        if not isinstance(validators, list):
+            raise jsonrpc.exceptions.JSONRPCDispatchException(
+                code=-32600, message='validators argument not a list')
+        if not isinstance(boot_nodes, list):
+            raise jsonrpc.exceptions.JSONRPCDispatchException(
+                code=-32600, message='boot_nodes argument not a list')
+
+        # TODO: maybe also check validity of these arguments?
+        if len(validators) == 0:
+            raise jsonrpc.exceptions.JSONRPCDispatchException(
+                code=-32600, message='validators argument must not be empty')
+        if len(boot_nodes) == 0:
+            raise jsonrpc.exceptions.JSONRPCDispatchException(
+                code=-32600, message='boot_nodes argument must not be empty')
+
+        with self.lock:
+            state = self.get_state()
+            if state != TestState.AWAITING_NETWORK_INIT:
+                raise jsonrpc.exceptions.JSONRPCDispatchException(
+                    code=-32600,
+                    message='Can only call network_init after a call to init')
+
+            if len(validators) < 3:
+                with open(self.target_near_home_path('config.json'), 'r') as f:
+                    config = json.load(f)
+                config['consensus']['min_num_peers'] = len(validators) - 1
+                with open(self.target_near_home_path('config.json'), 'w') as f:
+                    json.dump(config, f)
+            with open(self.home_path('validators.json'), 'w') as f:
+                json.dump(validators, f)
+            with open(self.home_path('network_init.json'), 'w') as f:
+                json.dump(
+                    {
+                        'boot_nodes': boot_nodes,
+                        'epoch_length': epoch_length,
+                        'num_seats': num_seats
+                    }, f)
 
     def do_start(self):
         with self.lock:
-            # we should already have tried running it if this is true
-            if self.data['run']:
-                return
+            state = self.get_state()
+            if state == TestState.STOPPED:
+                self.start_neard()
+                self.set_state(TestState.RUNNING)
+                self.save_data()
+            elif state != TestState.RUNNING:
+                raise jsonrpc.exceptions.JSONRPCDispatchException(
+                    code=-32600,
+                    message=
+                    'Cannot start node as test state has not been initialized yet'
+                )
 
-            # for now just set this and wait for the next iteration of the update loop to start it
-            self.data['run'] = True
-            self.save_data()
-
+    # right now only has an effect if the test setup has been initialized. Should it also mean stop setting up
+    # the test if we're in the middle of initializing it?
     def do_stop(self):
         with self.lock:
-            if not self.data['run']:
-                return
+            state = self.get_state()
+            if state == TestState.RUNNING:
+                self.kill_neard()
+                self.set_state(TestState.STOPPED)
+                self.save_data()
 
-            # for now just set this and wait for the next iteration of the update loop to stop it
-            self.data['run'] = False
-            self.save_data()
+    def do_reset(self):
+        with self.lock:
+            state = self.get_state()
+            if state == TestState.RUNNING:
+                self.kill_neard()
+                self.set_state(TestState.RESETTING)
+                self.reset_current_neard_path()
+                self.save_data()
+            elif state == TestState.STOPPED:
+                self.set_state(TestState.RESETTING)
+                self.reset_current_neard_path()
+                self.save_data()
+            else:
+                raise jsonrpc.exceptions.JSONRPCDispatchException(
+                    code=-32600,
+                    message=
+                    'Cannot reset node as test state has not been initialized yet'
+                )
+
+    def do_ready(self):
+        with self.lock:
+            state = self.get_state()
+            return state == TestState.RUNNING or state == TestState.STOPPED
 
     # check the current epoch height, and return the binary path that we should
     # be running given the epoch heights specified in config.json
+    # TODO: should we update it at a random time in the middle of the
+    # epoch instead of the beginning?
     def wanted_neard_path(self):
         j = {
             'method': 'validators',
@@ -228,7 +427,9 @@ class NeardRunner:
             'jsonrpc': '2.0'
         }
         try:
-            r = requests.post(f'http://{self.neard_addr}', json=j, timeout=5)
+            r = requests.post(f'http://{self.data["neard_addr"]}',
+                              json=j,
+                              timeout=5)
             r.raise_for_status()
             response = json.loads(r.content)
             epoch_height = response['result']['epoch_height']
@@ -241,128 +442,305 @@ class NeardRunner:
                     break
             return path
         except (requests.exceptions.ConnectionError, KeyError):
-            return self.data['neard_process']['path']
+            return self.data['current_neard_path']
 
-    def check_run_neard(self):
-        neard_path = self.wanted_neard_path()
-        start_neard = False
+    def run_neard(self, cmd, out_file=None):
+        assert (self.neard is None)
+        assert (self.data['neard_process'] is None)
+        env = os.environ.copy()
+        if 'RUST_LOG' not in env:
+            env['RUST_LOG'] = 'actix_web=warn,mio=warn,tokio_util=warn,actix_server=warn,actix_http=warn,indexer=info,debug'
+        logging.info(f'running {" ".join(cmd)}')
+        self.neard = subprocess.Popen(
+            cmd,
+            stdin=subprocess.DEVNULL,
+            stdout=out_file,
+            stderr=out_file,
+            env=env,
+        )
+        # we save the create_time so we can tell if the process with pid equal
+        # to the one we saved is the same process. It's not that likely, but
+        # if we don't do this (or maybe something else like it), then it's possble
+        # that if this process is killed and restarted and we see a process with that PID,
+        # it could actually be a different process that was started later after neard exited
+        try:
+            create_time = int(psutil.Process(self.neard.pid).create_time())
+        except psutil.NoSuchProcess:
+            # not that likely, but if it already exited, catch the exception so
+            # at least this process doesn't die
+            create_time = 0
 
+        self.data['neard_process'] = {
+            'pid': self.neard.pid,
+            'create_time': create_time,
+            'path': cmd[0],
+        }
+        self.save_data()
+
+    def poll_neard(self):
         if self.neard is not None:
             code = self.neard.poll()
-            if code is not None:
-                logging.info(f'neard exited with code {code}. restarting')
-                start_neard = True
-            else:
-                if self.data['neard_process']['path'] != neard_path:
-                    logging.info('upgrading neard upon new epoch')
-                    self.neard.send_signal(signal.SIGINT)
-                    self.neard.wait()
-                    start_neard = True
-        elif self.data['neard_process']['pid'] is not None:
+            path = self.data['neard_process']['path']
+            running = code is None
+            if not running:
+                self.neard = None
+                self.data['neard_process'] = None
+                self.save_data()
+            return path, running, code
+        elif self.data['neard_process'] is not None:
+            path = self.data['neard_process']['path']
             # we land here if this process previously died and is now restarted,
             # and the old neard process is still running
             try:
                 p = psutil.Process(self.data['neard_process']['pid'])
                 if int(p.create_time()
                       ) == self.data['neard_process']['create_time']:
-                    if self.data['neard_process']['path'] != neard_path:
-                        logging.info('upgrading neard upon new epoch')
-                        p.send_signal(signal.SIGINT)
-                        p.wait()
-                        start_neard = True
-                else:
-                    start_neard = True
+                    return path, True, None
             except psutil.NoSuchProcess:
-                start_neard = True
+                self.neard = None
+                self.data['neard_process'] = None
+                self.save_data()
+                return path, False, None
         else:
-            start_neard = True
+            return None, False, None
 
-        if start_neard:
-            try:
-                os.mkdir(self.neard_logs_dir)
-            except FileExistsError:
-                pass
-            for i in range(20, -1, -1):
-                old_log = os.path.join(self.neard_logs_dir, f'log-{i}.txt')
-                new_log = os.path.join(self.neard_logs_dir, f'log-{i+1}.txt')
-                try:
-                    os.rename(old_log, new_log)
-                except FileNotFoundError:
-                    pass
-
-            with open(os.path.join(self.neard_logs_dir, 'log-0.txt'),
-                      'ab') as out:
-                cmd = [
-                    neard_path, '--home', self.neard_home,
-                    '--unsafe-fast-startup', 'run'
-                ]
-                env = os.environ.copy()
-                if 'RUST_LOG' not in env:
-                    env['RUST_LOG'] = 'actix_web=warn,mio=warn,tokio_util=warn,actix_server=warn,actix_http=warn,debug'
-                logging.info(f'running {" ".join(cmd)}')
-                self.neard = subprocess.Popen(
-                    cmd,
-                    stdin=subprocess.DEVNULL,
-                    stdout=out,
-                    stderr=out,
-                    env=env,
-                )
-
-            try:
-                create_time = int(psutil.Process(self.neard.pid).create_time())
-            except psutil.NoSuchProcess:
-                # not that likely, but if neard already exited, catch the exception so
-                # at least this process doesn't die
-                create_time = 0
-
-            self.data['neard_process'] = {
-                'pid': self.neard.pid,
-                'create_time': create_time,
-                'path': neard_path,
-            }
-            self.save_data()
-
-    def check_stop_neard(self):
+    def kill_neard(self):
         if self.neard is not None:
             logging.info('stopping neard')
             self.neard.send_signal(signal.SIGINT)
             self.neard.wait()
             self.neard = None
-            self.data['neard_process']['pid'] = None
-            self.data['neard_process']['create_time'] = 0
+            self.data['neard_process'] = None
             self.save_data()
-        elif self.data['neard_process']['pid'] is not None:
+            return
+
+        if self.data['neard_process'] is None:
+            return
+
+        try:
+            p = psutil.Process(self.data['neard_process']['pid'])
+            if int(p.create_time()
+                  ) == self.data['neard_process']['create_time']:
+                logging.info('stopping neard')
+                p.send_signal(signal.SIGINT)
+                p.wait()
+        except psutil.NoSuchProcess:
+            pass
+        self.neard = None
+        self.data['neard_process'] = None
+        self.save_data()
+
+    # If this is a regular node, starts neard run. If it's a traffic generator, starts neard mirror run
+    def start_neard(self):
+        for i in range(20, -1, -1):
+            old_log = os.path.join(self.neard_logs_dir, f'log-{i}.txt')
+            new_log = os.path.join(self.neard_logs_dir, f'log-{i+1}.txt')
             try:
-                p = psutil.Process(self.data['neard_process']['pid'])
-                if int(p.create_time()
-                      ) == self.data['neard_process']['create_time']:
-                    logging.info('stopping neard')
-                    p.send_signal(signal.SIGINT)
-                    p.wait()
-            except psutil.NoSuchProcess:
+                os.rename(old_log, new_log)
+            except FileNotFoundError:
                 pass
-            self.data['neard_process']['pid'] = None
-            self.data['neard_process']['create_time'] = 0
+
+        with open(os.path.join(self.neard_logs_dir, 'log-0.txt'), 'ab') as out:
+            if self.is_traffic_generator():
+                cmd = [
+                    self.data['current_neard_path'],
+                    'mirror',
+                    'run',
+                    '--source-home',
+                    self.neard_home,
+                    '--target-home',
+                    self.target_near_home_path(),
+                    '--no-secret',
+                ]
+            else:
+                cmd = [
+                    self.data['current_neard_path'], '--home', self.neard_home,
+                    '--unsafe-fast-startup', 'run'
+                ]
+            self.run_neard(
+                cmd,
+                out_file=out,
+            )
+
+    def check_upgrade_neard(self):
+        neard_path = self.wanted_neard_path()
+
+        path, running, exit_code = self.poll_neard()
+        if path is None:
+            # TODO: This (and below under elif not running) is just a lazy way to deal with the fact
+            # that the mirror command is expected to exit after it finishes sending all the traffic.
+            # For now just don't restart neard on the traffic generator. Here we should be smart
+            # about restarting only if it makes sense, and we also shouldn't restart over and over.
+            # Right now we can't just check the exit_code because there's a bug that makes the
+            # neard mirror run command not exit cleanly when it's finished
+            start_neard = not self.is_traffic_generator()
+        elif not running:
+            if exit_code is not None:
+                logging.info(f'neard exited with code {exit_code}.')
+            start_neard = not self.is_traffic_generator()
+        else:
+            if path == neard_path:
+                start_neard = False
+            else:
+                logging.info('upgrading neard upon new epoch')
+                self.kill_neard()
+                start_neard = True
+
+        if start_neard:
+            self.data['current_neard_path'] = neard_path
+            self.start_neard()
+
+    def get_state(self):
+        return TestState(self.data['state'])
+
+    def set_state(self, state):
+        self.data['state'] = state.value
+
+    def network_init(self):
+        # wait til we get a network_init RPC
+        if not os.path.exists(self.home_path('validators.json')):
+            return
+
+        with open(self.home_path('network_init.json'), 'r') as f:
+            n = json.load(f)
+        with open(self.target_near_home_path('node_key.json'), 'r') as f:
+            node_key = json.load(f)
+        with open(self.target_near_home_path('config.json'), 'r') as f:
+            config = json.load(f)
+        boot_nodes = []
+        for b in n['boot_nodes']:
+            if node_key['public_key'] != b.split('@')[0]:
+                boot_nodes.append(b)
+
+        config['network']['boot_nodes'] = ','.join(boot_nodes)
+        with open(self.target_near_home_path('config.json'), 'w') as f:
+            config = json.dump(config, f, indent=2)
+
+        cmd = [
+            self.data['binaries'][0]['system_path'],
+            'amend-genesis',
+            '--genesis-file-in',
+            os.path.join(self.neard_home, 'setup', 'genesis.json'),
+            '--records-file-in',
+            os.path.join(self.neard_home, 'setup', 'records.json'),
+            '--genesis-file-out',
+            self.target_near_home_path('genesis.json'),
+            '--records-file-out',
+            self.target_near_home_path('records.json'),
+            '--validators',
+            self.home_path('validators.json'),
+            '--chain-id',
+            'mocknet',
+            '--transaction-validity-period',
+            '10000',
+            '--epoch-length',
+            str(n['epoch_length']),
+            '--num-seats',
+            str(n['num_seats']),
+        ]
+        self.run_neard(cmd)
+        self.set_state(TestState.AMEND_GENESIS)
+        self.save_data()
+
+    def check_amend_genesis(self):
+        path, running, exit_code = self.poll_neard()
+        if path is None:
+            logging.error(
+                'state is AMEND_GENESIS, but no amend-genesis process is known')
+            self.set_state(TestState.AWAITING_NETWORK_INIT)
             self.save_data()
+        elif not running:
+            if exit_code is not None and exit_code != 0:
+                logging.error(
+                    f'neard amend-genesis exited with code {exit_code}')
+                # for now just set the state to None, and if this ever happens, the
+                # test operator will have to intervene manually. Probably shouldn't
+                # really happen in practice
+                self.set_state(TestState.NONE)
+                self.save_data()
+            else:
+                # TODO: if exit_code is None then we were interrupted and restarted after starting
+                # the amend-genesis command. We assume here that the command was successful. Ok for now since
+                # the command probably won't fail. But should somehow check that it was OK
+                with open(os.path.join(self.neard_logs_dir, 'initlog.txt'),
+                          'ab') as out:
+                    cmd = [
+                        self.data['binaries'][0]['system_path'], '--home',
+                        self.target_near_home_path(), '--unsafe-fast-startup',
+                        'run'
+                    ]
+                    self.run_neard(
+                        cmd,
+                        out_file=out,
+                    )
+                self.set_state(TestState.STATE_ROOTS)
+                self.save_data()
+
+    def check_genesis_state(self):
+        path, running, exit_code = self.poll_neard()
+        if not running:
+            logging.error(
+                f'neard exited with code {exit_code} on the first run')
+            # For now just exit, because if this happens, there is something pretty wrong with
+            # the setup, so a human needs to investigate and fix the bug
+            sys.exit(1)
+        try:
+            r = requests.get(f'http://{self.data["neard_addr"]}/status',
+                             timeout=5)
+            if r.status_code == 200:
+                logging.info('neard finished computing state roots')
+                self.kill_neard()
+
+                try:
+                    shutil.rmtree(self.home_path('backups'))
+                except FileNotFoundError:
+                    pass
+                os.mkdir(self.home_path('backups'))
+                # Right now we save the backup to backups/start and in the future
+                # it would be nice to support a feature that lets you stop all the nodes and
+                # make another backup to restore to
+                backup_dir = self.home_path('backups', 'start')
+                logging.info(f'copying data dir to {backup_dir}')
+                shutil.copytree(self.target_near_home_path('data'), backup_dir)
+                self.set_state(TestState.STOPPED)
+                self.save_data()
+        except requests.exceptions.ConnectionError:
+            pass
+
+    def reset_near_home(self):
+        try:
+            shutil.rmtree(self.target_near_home_path('data'))
+        except FileNotFoundError:
+            pass
+        logging.info('restoring data dir from backup')
+        shutil.copytree(self.home_path('backups', 'start'),
+                        self.target_near_home_path('data'))
+        logging.info('data dir restored')
+        self.set_state(TestState.STOPPED)
+        self.save_data()
 
     # periodically check if we should update neard after a new epoch
-    # TODO: should we update it at a random time in the middle of the
-    # epoch instead of the beginning?
-    def upgrade_neard(self):
+    def main_loop(self):
         while True:
             with self.lock:
-                if self.data['run']:
-                    self.check_run_neard()
-                else:
-                    self.check_stop_neard()
-
+                state = self.get_state()
+                if state == TestState.AWAITING_NETWORK_INIT:
+                    self.network_init()
+                elif state == TestState.AMEND_GENESIS:
+                    self.check_amend_genesis()
+                elif state == TestState.STATE_ROOTS:
+                    self.check_genesis_state()
+                elif state == TestState.RUNNING:
+                    self.check_upgrade_neard()
+                elif state == TestState.RESETTING:
+                    self.reset_near_home()
             time.sleep(10)
 
     def serve(self, port):
         # TODO: maybe use asyncio? kind of silly to use multiple threads for
         # something so lightweight
-        upgrade_loop = threading.Thread(target=self.upgrade_neard)
-        upgrade_loop.start()
+        main_loop = threading.Thread(target=self.main_loop)
+        main_loop.start()
         s = RpcServer(('0.0.0.0', port), self)
         s.serve_forever()
 

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -221,10 +221,10 @@ def restart_cmd(args, traffic_generator, nodes):
 
 
 # returns boot nodes and validators we want for the new test network
-def get_network_nodes(init_rpc_responses, num_validators):
+def get_network_nodes(new_test_rpc_responses, num_validators):
     validators = []
     boot_nodes = []
-    for ip_addr, response in init_rpc_responses:
+    for ip_addr, response in new_test_rpc_responses:
         if len(validators) < num_validators:
             if response['validator_account_id'] is not None:
                 # we assume here that validator_account_id is not null, validator_public_key
@@ -363,7 +363,7 @@ def neard_runner_reset(node):
 
 
 def start_nodes_cmd(args, traffic_generator, nodes):
-    if not all(pmap(neard_runner_ready, nodes + [traffic_generator])):
+    if not all(pmap(neard_runner_ready, nodes)):
         logger.warn(
             'not all nodes are ready to start yet. Run the `status` command to check their statuses'
         )

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -41,40 +41,6 @@ def get_nodes(args):
     return traffic_generator, nodes
 
 
-def get_node_peer_info(node):
-    config = mocknet.download_and_read_json(node,
-                                            '/home/ubuntu/.near/config.json')
-    node_key = mocknet.download_and_read_json(
-        node, '/home/ubuntu/.near/node_key.json')
-
-    key = node_key['public_key']
-    port = config['network']['addr'].split(':')[1]
-    return f'{key}@{node.machine.ip}:{port}'
-
-
-def get_boot_nodes(nodes):
-    boot_nodes = pmap(get_node_peer_info, nodes[:20])
-    return ','.join(boot_nodes)
-
-
-def get_validator_list(nodes):
-    validators = []
-
-    validator_keys = pmap(
-        lambda node: mocknet.download_and_read_json(
-            node, '/home/ubuntu/.near/validator_key.json'), nodes)
-
-    for i, validator_key in enumerate(validator_keys):
-        validators.append({
-            'account_id': validator_key['account_id'],
-            'public_key': validator_key['public_key'],
-            # TODO: give a way to specify the stakes
-            'amount': str(10**33),
-        })
-
-    return validators
-
-
 def run_cmd(node, cmd):
     r = node.machine.run(cmd)
     if r.exitcode != 0:
@@ -84,8 +50,8 @@ def run_cmd(node, cmd):
     return r
 
 
-LOG_DIR = '/home/ubuntu/.near/logs'
-STATUS_DIR = '/home/ubuntu/.near/logs/status'
+LOG_DIR = '/home/ubuntu/logs'
+STATUS_DIR = '/home/ubuntu/logs/status'
 
 
 def run_in_background(node, cmd, log_filename, env=''):
@@ -97,157 +63,7 @@ def run_in_background(node, cmd, log_filename, env=''):
     )
 
 
-def wait_process(node, log_filename):
-    r = run_cmd(
-        node,
-        f'stat {STATUS_DIR}/{log_filename} >/dev/null && tail --retry -f {STATUS_DIR}/{log_filename} | head -n 1'
-    )
-    if r.stdout.strip() != '0':
-        sys.exit(
-            f'bad status in {STATUS_DIR}/{log_filename} on {node.instance_name}: {r.stdout}\ncheck {LOG_DIR}/{log_filename} for details'
-        )
-
-
-def check_process(node, log_filename):
-    r = run_cmd(node, f'head -n 1 {STATUS_DIR}/{log_filename}')
-    out = r.stdout.strip()
-    if len(out) > 0 and out != '0':
-        sys.exit(
-            f'bad status in {STATUS_DIR}/{log_filename} on {node.instance_name}: {r.stdout}\ncheck {LOG_DIR}/{log_filename} for details'
-        )
-
-
-def set_boot_nodes(node, boot_nodes):
-    if not node.instance_name.endswith('traffic'):
-        home_dir = '/home/ubuntu/.near'
-    else:
-        home_dir = '/home/ubuntu/.near/target'
-
-    run_cmd(
-        node,
-        f't=$(mktemp) && jq \'.network.boot_nodes = "{boot_nodes}"\' {home_dir}/config.json > $t && mv $t {home_dir}/config.json'
-    )
-
-
-# returns the peer ID of the resulting initialized NEAR dir
-def init_home_dir(node, num_validators):
-    run_cmd(node, f'mkdir -p /home/ubuntu/.near/setup/')
-    run_cmd(node, f'mkdir -p {LOG_DIR}')
-    run_cmd(node, f'mkdir -p {STATUS_DIR}')
-
-    if not node.instance_name.endswith('traffic'):
-        cmd = 'find /home/ubuntu/.near -type f -maxdepth 1 -delete && '
-        cmd += 'rm -rf /home/ubuntu/.near/data && '
-        cmd += '/home/ubuntu/neard init --account-id "$(hostname).near" && '
-        cmd += 'rm -f /home/ubuntu/.near/genesis.json && '
-        home_dir = '/home/ubuntu/.near'
-    else:
-        cmd = 'rm -rf /home/ubuntu/.near/target/ && '
-        cmd += 'mkdir -p /home/ubuntu/.near/target/ && '
-        cmd += '/home/ubuntu/neard --home /home/ubuntu/.near/target/ init && '
-        cmd += 'rm -f /home/ubuntu/.near/target/validator_key.json && '
-        cmd += 'rm -f /home/ubuntu/.near/target/genesis.json && '
-        home_dir = '/home/ubuntu/.near/target'
-
-    # TODO: don't hardcode tracked_shards. mirror run only sends txs for the shards in tracked shards. maybe should change that...
-    config_changes = '.tracked_shards = [0, 1, 2, 3] | .archive = true | .log_summary_style="plain" | .rpc.addr = "0.0.0.0:3030" '
-    config_changes += '| .network.skip_sync_wait=false | .genesis_records_file = "records.json" | .rpc.enable_debug_rpc = true '
-    if num_validators < 3:
-        config_changes += f'| .consensus.min_num_peers = {num_validators}'
-
-    cmd += '''t=$(mktemp) && jq '{config_changes}' {home_dir}/config.json > $t && mv $t {home_dir}/config.json'''.format(
-        config_changes=config_changes, home_dir=home_dir)
-    run_cmd(node, cmd)
-
-    config = mocknet.download_and_read_json(node, f'{home_dir}/config.json')
-    node_key = mocknet.download_and_read_json(node, f'{home_dir}/node_key.json')
-    key = node_key['public_key']
-    port = config['network']['addr'].split(':')[1]
-    return f'{key}@{node.machine.ip}:{port}'
-
-
-BACKUP_DIR = '/home/ubuntu/.near/backup'
-
-
-def make_backup(node, log_filename):
-    if node.instance_name.endswith('traffic'):
-        home = '/home/ubuntu/.near/target'
-    else:
-        home = '/home/ubuntu/.near'
-    run_in_background(
-        node,
-        f'rm -rf {BACKUP_DIR} && mkdir {BACKUP_DIR} && cp -r {home}/data {BACKUP_DIR}/data && cp {home}/genesis.json {BACKUP_DIR}',
-        log_filename)
-
-
-def check_backup(node):
-    if node.instance_name.endswith('traffic'):
-        genesis = '/home/ubuntu/.near/target/genesis.json'
-    else:
-        genesis = '/home/ubuntu/.near/genesis.json'
-
-    cmd = f'current=$(md5sum {genesis} | cut -d " " -f1) '
-    cmd += f'&& saved=$(md5sum {BACKUP_DIR}/genesis.json | cut -d " " -f1)'
-    cmd += f' && if [ $current == $saved ]; then exit 0; else echo "md5sum mismatch between {genesis} and {BACKUP_DIR}/genesis.json"; exit 1; fi'
-    r = node.machine.run(cmd)
-    if r.exitcode != 0:
-        logger.warning(
-            f'on {node.instance_name} could not check that saved state in {BACKUP_DIR} matches with ~/.near:\n{r.stdout}\n{r.stderr}'
-        )
-        return False
-    return True
-
-
-def reset_data_dir(node, log_filename):
-    if node.instance_name.endswith('traffic'):
-        data = '/home/ubuntu/.near/target/data'
-    else:
-        data = '/home/ubuntu/.near/data'
-    run_in_background(node, f'rm -rf {data} && cp -r {BACKUP_DIR}/data {data}',
-                      log_filename)
-
-
-def amend_genesis_file(node, validators, epoch_length, num_seats, log_filename):
-    mocknet.upload_json(node, '/home/ubuntu/.near/setup/validators.json',
-                        validators)
-
-    if not node.instance_name.endswith('traffic'):
-        neard = '/home/ubuntu/neard-setup'
-        genesis_file_out = '/home/ubuntu/.near/genesis.json'
-        records_file_out = '/home/ubuntu/.near/records.json'
-        config_file_path = '/home/ubuntu/.near/config.json'
-    else:
-        neard = '/home/ubuntu/neard'
-        genesis_file_out = '/home/ubuntu/.near/target/genesis.json'
-        records_file_out = '/home/ubuntu/.near/target/records.json'
-    amend_genesis_cmd = [
-        neard,
-        'amend-genesis',
-        '--genesis-file-in',
-        '/home/ubuntu/.near/setup/genesis.json',
-        '--records-file-in',
-        '/home/ubuntu/.near/setup/records.json',
-        '--genesis-file-out',
-        genesis_file_out,
-        '--records-file-out',
-        records_file_out,
-        '--validators',
-        '/home/ubuntu/.near/setup/validators.json',
-        '--chain-id',
-        'mocknet',
-        '--transaction-validity-period',
-        '10000',
-        '--epoch-length',
-        str(epoch_length),
-        '--num-seats',
-        str(args.num_seats),
-    ]
-    amend_genesis_cmd = ' '.join(amend_genesis_cmd)
-    run_in_background(node, amend_genesis_cmd, log_filename)
-
-
-# like mocknet.wait_node_up() but we also check the status file
-def wait_node_up(node, log_filename):
+def wait_node_up(node):
     while True:
         try:
             res = node.get_validators()
@@ -258,43 +74,7 @@ def wait_node_up(node, log_filename):
         except (ConnectionRefusedError,
                 requests.exceptions.ConnectionError) as e:
             pass
-        check_process(node, log_filename)
         time.sleep(10)
-
-
-def neard_running(node):
-    return len(node.machine.run('ps cax | grep neard').stdout) > 0
-
-
-def start_neard(node, log_filename):
-    if node.instance_name.endswith('traffic'):
-        home = '/home/ubuntu/.near/target'
-    else:
-        home = '/home/ubuntu/.near/'
-
-    if not neard_running(node):
-        run_in_background(
-            node,
-            f'/home/ubuntu/neard --unsafe-fast-startup --home {home} run',
-            log_filename,
-            env='RUST_LOG=debug')
-        logger.info(f'started neard on {node.instance_name}')
-    else:
-        logger.info(f'neard already running on {node.instance_name}')
-
-
-def start_mirror(node, log_filename):
-    assert node.instance_name.endswith('traffic')
-
-    if not neard_running(node):
-        run_in_background(
-            node,
-            f'/home/ubuntu/neard mirror run --source-home /home/ubuntu/.near --target-home /home/ubuntu/.near/target --no-secret',
-            log_filename,
-            env='RUST_LOG=info,mirror=debug')
-        logger.info(f'started neard mirror run on {node.instance_name}')
-    else:
-        logger.info(f'neard already running on {node.instance_name}')
 
 
 def prompt_setup_flags(args):
@@ -316,6 +96,43 @@ def prompt_setup_flags(args):
         print('number of block producer seats?: ')
         args.num_seats = int(sys.stdin.readline().strip())
 
+
+def start_neard_runner(node):
+    run_in_background(node, f'/home/ubuntu/neard-runner/venv/bin/python /home/ubuntu/neard-runner/neard_runner.py ' \
+        '--home /home/ubuntu/neard-runner --neard-home /home/ubuntu/.near ' \
+        '--neard-logs /home/ubuntu/neard-logs --port 3000', 'neard-runner.txt')
+
+
+def upload_neard_runner(node):
+    node.machine.upload('tests/mocknet/helpers/neard_runner.py',
+                        '/home/ubuntu/neard-runner',
+                        switch_user='ubuntu')
+    node.machine.upload('tests/mocknet/helpers/requirements.txt',
+                        '/home/ubuntu/neard-runner',
+                        switch_user='ubuntu')
+
+
+def init_neard_runner(node, config, remove_home_dir=False):
+    rm_cmd = 'rm -rf /home/ubuntu/neard-runner && ' if remove_home_dir else ''
+    run_cmd(
+        node,
+        f'{rm_cmd}mkdir -p {LOG_DIR} && mkdir -p {STATUS_DIR} && mkdir -p /home/ubuntu/neard-runner'
+    )
+    upload_neard_runner(node)
+    mocknet.upload_json(node, '/home/ubuntu/neard-runner/config.json', config)
+    cmd = 'cd /home/ubuntu/neard-runner && python3 -m virtualenv venv -p $(which python3)' \
+    ' && ./venv/bin/pip install -r requirements.txt'
+    run_cmd(node, cmd)
+    stop_neard_runner(node)
+    start_neard_runner(node)
+
+
+def stop_neard_runner(node):
+    # it's probably fine for now, but this is very heavy handed/not precise
+    node.machine.run('kill $(ps -C python -o pid=)')
+
+
+def prompt_init_flags(args):
     if args.neard_binary_url is None:
         print('neard binary URL?: ')
         args.neard_binary_url = sys.stdin.readline().strip()
@@ -330,38 +147,23 @@ def prompt_setup_flags(args):
             args.neard_upgrade_binary_url = url
 
 
-def upload_neard_runner(node, config):
-    node.machine.run(
-        'rm -rf /home/ubuntu/neard-runner && mkdir /home/ubuntu/neard-runner && mkdir -p /home/ubuntu/neard-logs'
-    )
-    node.machine.upload('tests/mocknet/helpers/neard_runner.py',
-                        '/home/ubuntu/neard-runner',
-                        switch_user='ubuntu')
-    node.machine.upload('tests/mocknet/helpers/requirements.txt',
-                        '/home/ubuntu/neard-runner',
-                        switch_user='ubuntu')
-    mocknet.upload_json(node, '/home/ubuntu/neard-runner/config.json', config)
-    cmd = 'cd /home/ubuntu/neard-runner && python3 -m virtualenv venv -p $(which python3)' \
-    ' && ./venv/bin/pip install -r requirements.txt'
-    run_cmd(node, cmd)
-    run_in_background(node, f'/home/ubuntu/neard-runner/venv/bin/python /home/ubuntu/neard-runner/neard_runner.py ' \
-        '--home /home/ubuntu/neard-runner --neard-home /home/ubuntu/.near ' \
-        '--neard-logs /home/ubuntu/neard-logs --port 3000', 'neard-runner.txt')
-
-
-def stop_neard_runner(node):
-    # it's probably fine for now, but this is very heavy handed/not precise
-    node.machine.run('kill $(ps -C python -o pid=)')
-
-
-def init_neard_runner(nodes, binary_url, upgrade_binary_url):
-    if upgrade_binary_url is None:
+def init_neard_runners(args, traffic_generator, nodes, remove_home_dir=False):
+    prompt_init_flags(args)
+    if args.neard_upgrade_binary_url is None:
         configs = [{
+            "is_traffic_generator": False,
             "binaries": [{
-                "url": binary_url,
+                "url": args.neard_binary_url,
                 "epoch_height": 0
             }]
         }] * len(nodes)
+        traffic_generator_config = {
+            "is_traffic_generator": True,
+            "binaries": [{
+                "url": args.neard_binary_url,
+                "epoch_height": 0
+            }]
+        }
     else:
         # for now this test starts all validators with the same stake, so just make the upgrade
         # epoch random. If we change the stakes, we should change this to choose how much stake
@@ -369,19 +171,87 @@ def init_neard_runner(nodes, binary_url, upgrade_binary_url):
         configs = []
         for i in range(len(nodes)):
             configs.append({
+                "is_traffic_generator":
+                    False,
                 "binaries": [{
-                    "url": binary_url,
+                    "url": args.neard_binary_url,
                     "epoch_height": 0
                 }, {
-                    "url": upgrade_binary_url,
+                    "url": args.neard_upgrade_binary_url,
                     "epoch_height": random.randint(1, 4)
                 }]
             })
+        traffic_generator_config = {
+            "is_traffic_generator":
+                True,
+            "binaries": [{
+                "url": args.neard_upgrade_binary_url,
+                "epoch_height": 0
+            }]
+        }
 
-    pmap(lambda x: upload_neard_runner(x[0], x[1]), zip(nodes, configs))
+    init_neard_runner(traffic_generator, traffic_generator_config,
+                      remove_home_dir)
+    pmap(lambda x: init_neard_runner(x[0], x[1], remove_home_dir),
+         zip(nodes, configs))
 
 
-def setup(args, traffic_generator, nodes):
+def init_cmd(args, traffic_generator, nodes):
+    init_neard_runners(args, traffic_generator, nodes, remove_home_dir=False)
+
+
+def hard_reset_cmd(args, traffic_generator, nodes):
+    print(
+        """This will stop neard on all nodes and remove the neard runner\'s state on each node \
+        , which will undo any current test progress. Continue? [yes/no]""")
+    if sys.stdin.readline().strip() != 'yes':
+        return
+    all_nodes = nodes + [traffic_generator]
+    pmap(stop_neard_runner, all_nodes)
+    mocknet.stop_nodes(all_nodes)
+    init_neard_runners(args, traffic_generator, nodes, remove_home_dir=True)
+
+
+def restart_cmd(args, traffic_generator, nodes):
+    all_nodes = nodes + [traffic_generator]
+    pmap(stop_neard_runner, all_nodes)
+    if args.upload_program:
+        pmap(upload_neard_runner, all_nodes)
+    pmap(start_neard_runner, all_nodes)
+
+
+# returns boot nodes and validators we want for the new test network
+def get_network_nodes(init_rpc_responses, num_validators):
+    validators = []
+    boot_nodes = []
+    for ip_addr, response in init_rpc_responses:
+        if len(validators) < num_validators:
+            if response['validator_account_id'] is not None:
+                # we assume here that validator_account_id is not null, validator_public_key
+                # better not be null either
+                validators.append({
+                    'account_id': response['validator_account_id'],
+                    'public_key': response['validator_public_key'],
+                    'amount': str(10**33),
+                })
+        if len(boot_nodes) < 20:
+            boot_nodes.append(
+                f'{response["node_key"]}@{ip_addr}:{response["listen_port"]}')
+
+        if len(validators) >= num_validators and len(boot_nodes) >= 20:
+            break
+    # neither of these should happen, since we check the number of available nodes in new_test(), and
+    # only the traffic generator will respond with null validator_account_id and validator_public_key
+    if len(validators) == 0:
+        sys.exit('no validators available after new_test RPCs')
+    if len(validators) < num_validators:
+        logger.warning(
+            f'wanted {num_validators} validators, but only {len(validators)} available'
+        )
+    return validators, boot_nodes
+
+
+def new_test(args, traffic_generator, nodes):
     prompt_setup_flags(args)
 
     if args.epoch_length <= 0:
@@ -394,96 +264,70 @@ def setup(args, traffic_generator, nodes):
         )
 
     all_nodes = nodes + [traffic_generator]
-    pmap(stop_neard_runner, nodes)
-    mocknet.stop_nodes(all_nodes)
 
-    # TODO: move all the setup logic to neard_runner.py and just call it here, so
-    # that each node does its own setup and we don't rely on the computer running this script
     logger.info(f'resetting/initializing home dirs')
-    boot_nodes = pmap(lambda node: init_home_dir(node, args.num_validators),
-                      all_nodes)
-    pmap(lambda node: set_boot_nodes(node, ','.join(boot_nodes[:20])),
-         all_nodes)
-    logger.info(f'home dir initialization finished')
+    test_keys = pmap(neard_runner_new_test, all_nodes)
 
-    random.shuffle(nodes)
-    validators = get_validator_list(nodes[:args.num_validators])
+    validators, boot_nodes = get_network_nodes(
+        zip([n.machine.ip for n in all_nodes], test_keys), args.num_validators)
 
-    init_neard_runner(nodes, args.neard_binary_url,
-                      args.neard_upgrade_binary_url)
-
-    logger.info(
-        f'setting validators and running neard amend-genesis on all nodes. validators: {validators}'
-    )
-    logger.info(f'this step will take a while (> 10 minutes)')
+    logger.info("""setting validators: {0}
+Then running neard amend-genesis on all nodes, and starting neard to compute genesis \
+state roots. This will take a few hours. Run `status` to check if the nodes are \
+ready. After they're ready, you can run `start-traffic`""".format(validators))
     pmap(
-        lambda node: amend_genesis_file(node, validators, args.epoch_length,
-                                        args.num_seats, 'amend-genesis.txt'),
+        lambda node: neard_runner_network_init(
+            node, validators, boot_nodes, args.epoch_length, args.num_seats),
         all_nodes)
-    pmap(lambda node: wait_process(node, 'amend-genesis.txt'), all_nodes)
-    logger.info(f'finished neard amend-genesis step')
-
-    logger.info(
-        f'starting neard nodes then waiting for them to be ready. This may take a long time (a couple hours)'
-    )
-    logger.info(
-        'If your connection is broken in the meantime, run "make-backups" to resume'
-    )
-
-    make_backups(args, traffic_generator, nodes)
-
-    logger.info('test setup complete')
-
-    if args.start_traffic:
-        start_traffic(args, traffic_generator, nodes)
 
 
-def make_backups(args, traffic_generator, nodes):
+def status_cmd(args, traffic_generator, nodes):
     all_nodes = nodes + [traffic_generator]
-    pmap(lambda node: start_neard(node, 'neard.txt'), all_nodes)
-    pmap(lambda node: wait_node_up(node, 'neard.txt'), all_nodes)
-    mocknet.stop_nodes(all_nodes)
+    statuses = pmap(neard_runner_ready, all_nodes)
+    num_ready = 0
+    not_ready = []
+    for ready, node in zip(statuses, all_nodes):
+        if not ready:
+            not_ready.append(node.instance_name)
 
-    logger.info(f'copying data dirs to {BACKUP_DIR}')
-    pmap(lambda node: make_backup(node, 'make-backup.txt'), all_nodes)
-    pmap(lambda node: wait_process(node, 'make-backup.txt'), all_nodes)
+    if len(not_ready) == 0:
+        print(f'all {len(all_nodes)} nodes ready')
+    else:
+        print(
+            f'{len(all_nodes)-len(not_ready)}/{len(all_nodes)} ready. Nodes not ready: {not_ready[:3]}'
+        )
 
 
-def reset_data_dirs(args, traffic_generator, nodes):
+def reset_cmd(args, traffic_generator, nodes):
+    print(
+        'this will reset all nodes\' home dirs to their initial states right after test initialization finished. continue? [yes/no]'
+    )
+    if sys.stdin.readline().strip() != 'yes':
+        sys.exit()
     all_nodes = nodes + [traffic_generator]
-    stop_nodes(args, traffic_generator, nodes)
-    # TODO: maybe have the neard runner not return from the JSON rpc until it's stopped?
-    while True:
-        if not any(mocknet.is_binary_running_all_nodes(
-                'neard',
-                all_nodes,
-        )):
-            break
-    if not all(pmap(check_backup, all_nodes)):
-        logger.warning('Not continuing with backup restoration')
-        return
-
-    logger.info('restoring data dirs from /home/ubuntu/.near/data-backup')
-    pmap(lambda node: reset_data_dir(node, 'reset-data.txt'), all_nodes)
-    pmap(lambda node: wait_process(node, 'reset-data.txt'), all_nodes)
-
-    if args.start_traffic:
-        start_traffic(args, traffic_generator, nodes)
+    pmap(neard_runner_reset, all_nodes)
+    logger.info(
+        'Data dir reset in progress. Run the `status` command to see when this is finished. Until it is finished, neard runners may not respond to HTTP requests.'
+    )
 
 
-def stop_nodes(args, traffic_generator, nodes):
-    mocknet.stop_nodes([traffic_generator])
-    pmap(neard_runner_stop, nodes)
+def stop_nodes_cmd(args, traffic_generator, nodes):
+    pmap(neard_runner_stop, nodes + [traffic_generator])
 
 
-def neard_runner_jsonrpc(node, method):
-    j = {'method': method, 'params': [], 'id': 'dontcare', 'jsonrpc': '2.0'}
+def stop_traffic_cmd(args, traffic_generator, nodes):
+    neard_runner_stop(traffic_generator)
+
+
+def neard_runner_jsonrpc(node, method, params=[]):
+    j = {'method': method, 'params': params, 'id': 'dontcare', 'jsonrpc': '2.0'}
     r = requests.post(f'http://{node.machine.ip}:3000', json=j, timeout=5)
     if r.status_code != 200:
         logger.warning(
             f'bad response {r.status_code} trying to send {method} JSON RPC to neard runner on {node.instance_name}:\n{r.content}'
         )
     r.raise_for_status()
+    return r.json()['result']
 
 
 def neard_runner_start(node):
@@ -494,20 +338,53 @@ def neard_runner_stop(node):
     neard_runner_jsonrpc(node, 'stop')
 
 
-def start_traffic(args, traffic_generator, nodes):
-    if not all(pmap(check_backup, nodes + [traffic_generator])):
-        logger.warning(
-            f'Not sending traffic, as the backups in {BACKUP_DIR} dont seem to be up to date'
+def neard_runner_new_test(node):
+    return neard_runner_jsonrpc(node, 'new_test')
+
+
+def neard_runner_network_init(node, validators, boot_nodes, epoch_length,
+                              num_seats):
+    return neard_runner_jsonrpc(node,
+                                'network_init',
+                                params={
+                                    'validators': validators,
+                                    'boot_nodes': boot_nodes,
+                                    'epoch_length': epoch_length,
+                                    'num_seats': num_seats,
+                                })
+
+
+def neard_runner_ready(node):
+    return neard_runner_jsonrpc(node, 'ready')
+
+
+def neard_runner_reset(node):
+    return neard_runner_jsonrpc(node, 'reset')
+
+
+def start_nodes_cmd(args, traffic_generator, nodes):
+    if not all(pmap(neard_runner_ready, nodes + [traffic_generator])):
+        logger.warn(
+            'not all nodes are ready to start yet. Run the `status` command to check their statuses'
         )
         return
+    pmap(neard_runner_start, nodes)
+    pmap(wait_node_up, nodes)
 
+
+def start_traffic_cmd(args, traffic_generator, nodes):
+    if not all(pmap(neard_runner_ready, nodes + [traffic_generator])):
+        logger.warn(
+            'not all nodes are ready to start yet. Run the `status` command to check their statuses'
+        )
+        return
     pmap(neard_runner_start, nodes)
     logger.info("waiting for validators to be up")
-    pmap(lambda node: wait_node_up(node, 'neard.txt'), nodes)
+    pmap(wait_node_up, nodes)
     logger.info(
         "waiting a bit after validators started before starting traffic")
     time.sleep(10)
-    start_mirror(traffic_generator, 'mirror.txt')
+    neard_runner_start(traffic_generator)
     logger.info(
         f'test running. to check the traffic sent, try running "curl http://{traffic_generator.machine.ip}:3030/metrics | grep mirror"'
     )
@@ -519,61 +396,80 @@ if __name__ == '__main__':
     parser.add_argument('--start-height', type=int, required=True)
     parser.add_argument('--unique-id', type=str, required=True)
 
-    parser.add_argument('--epoch-length', type=int)
-    parser.add_argument('--num-validators', type=int)
-    parser.add_argument('--num-seats', type=int)
-
-    parser.add_argument('--neard-binary-url', type=str)
-    parser.add_argument('--neard-upgrade-binary-url', type=str)
-
     subparsers = parser.add_subparsers(title='subcommands',
                                        description='valid subcommands',
                                        help='additional help')
 
-    setup_parser = subparsers.add_parser('setup',
-                                         help='''
+    init_parser = subparsers.add_parser('init-neard-runner',
+                                        help='''
+    Sets up the helper servers on each of the nodes. Doesn't start initializing the test
+    state, which is done with the `new-test` command.
+    ''')
+    init_parser.add_argument('--neard-binary-url', type=str)
+    init_parser.add_argument('--neard-upgrade-binary-url', type=str)
+    init_parser.set_defaults(func=init_cmd)
+
+    restart_parser = subparsers.add_parser('restart-neard-runner',
+                                           help='''
+    Restarts the neard runner on all nodes.
+    ''')
+    restart_parser.add_argument('--upload-program', action='store_true')
+    restart_parser.set_defaults(func=restart_cmd, upload_program=False)
+
+    hard_reset_parser = subparsers.add_parser('hard-reset',
+                                              help='''
+    Stops neard and clears all test state on all nodes.
+    ''')
+    hard_reset_parser.add_argument('--neard-binary-url', type=str)
+    hard_reset_parser.add_argument('--neard-upgrade-binary-url', type=str)
+    hard_reset_parser.set_defaults(func=hard_reset_cmd)
+
+    new_test_parser = subparsers.add_parser('new-test',
+                                            help='''
     Sets up new state from the prepared records and genesis files with the number
     of validators specified. This calls neard amend-genesis to create the new genesis
     and records files, and then starts the neard nodes and waits for them to be online
-    after computing the genesis state roots. This step takes a very long time (> 12 hours).
-    Use --start-traffic to start traffic after the setup is complete, which is equivalent to
-    just running the start-traffic subcommand manually after.
+    after computing the genesis state roots. This step takes a long time (a few hours).
     ''')
-    setup_parser.add_argument('--start-traffic',
-                              default=False,
-                              action='store_true')
-    setup_parser.set_defaults(func=setup)
+    new_test_parser.add_argument('--epoch-length', type=int)
+    new_test_parser.add_argument('--num-validators', type=int)
+    new_test_parser.add_argument('--num-seats', type=int)
+    new_test_parser.set_defaults(func=new_test)
 
-    start_parser = subparsers.add_parser(
+    status_parser = subparsers.add_parser('status',
+                                          help='''
+    Checks the status of test initialization on each node
+    ''')
+    status_parser.set_defaults(func=status_cmd)
+
+    start_traffic_parser = subparsers.add_parser(
         'start-traffic',
         help=
-        'starts all nodes and starts neard mirror run on the traffic generator')
-    start_parser.set_defaults(func=start_traffic)
+        'Starts all nodes and starts neard mirror run on the traffic generator.'
+    )
+    start_traffic_parser.set_defaults(func=start_traffic_cmd)
+
+    start_nodes_parser = subparsers.add_parser(
+        'start-nodes',
+        help='Starts all nodes, but does not start the traffic generator.')
+    start_nodes_parser.set_defaults(func=start_nodes_cmd)
 
     stop_parser = subparsers.add_parser('stop-nodes',
                                         help='kill all neard processes')
-    stop_parser.set_defaults(func=stop_nodes)
+    stop_parser.set_defaults(func=stop_nodes_cmd)
 
-    backup_parser = subparsers.add_parser('make-backups',
-                                          help='''
-    This is run automatically by "setup", but if your connection is interrupted during "setup", this will
-    resume waiting for the nodes to compute the state roots, and then will make a backup of all data dirs
-    ''')
-    backup_parser.add_argument('--start-traffic',
-                               default=False,
-                               action='store_true')
-    backup_parser.set_defaults(func=make_backups)
+    stop_parser = subparsers.add_parser(
+        'stop-traffic',
+        help='stop the traffic generator, but leave the other nodes running')
+    stop_parser.set_defaults(func=stop_traffic_cmd)
 
     reset_parser = subparsers.add_parser('reset',
                                          help='''
-    The setup command saves the data directory after the genesis state roots are computed so that
+    The new_test command saves the data directory after the genesis state roots are computed so that
     the test can be reset from the start without having to do that again. This command resets all nodes'
     data dirs to what was saved then, so that start-traffic will start the test all over again.
     ''')
-    reset_parser.add_argument('--start-traffic',
-                              default=False,
-                              action='store_true')
-    reset_parser.set_defaults(func=reset_data_dirs)
+    reset_parser.set_defaults(func=reset_cmd)
 
     args = parser.parse_args()
 


### PR DESCRIPTION
This moves the initialization steps (running neard amend-genesis) and starting neard to compute genesis state roots from the test script to the neard_runner.py helper program on the nodes. After this change, the test setup is done by first running `mirror.py init-neard-runner`, which uploads and starts neard_runner.py on each node, and then running `mirror.py new_test`, which sends a JSON RPC request to each node asking it to setup the test state. Now instead of having the computer running the test script run the commands and wait for them to finish (which would often get interrupted by SSH connections getting dropped), the test script exits quickly and the work is all done by neard_runner.py on each of the nodes, and the test operator can check the status by running `mirror.py status`.