### PR TITLE
refactor: convenient iteration over flat state entries

### DIFF
--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -187,8 +187,8 @@ pub trait Database: Sync + Send {
     fn iter_range<'a>(
         &'a self,
         col: DBCol,
-        lower_bound: Option<&'a [u8]>,
-        upper_bound: Option<&'a [u8]>,
+        lower_bound: Option<&[u8]>,
+        upper_bound: Option<&[u8]>,
     ) -> DBIterator<'a>;
 
     /// Iterate over items in given column bypassing reference count decoding if

--- a/core/store/src/db/colddb.rs
+++ b/core/store/src/db/colddb.rs
@@ -75,8 +75,8 @@ impl Database for ColdDB {
     fn iter_range<'a>(
         &'a self,
         col: DBCol,
-        lower_bound: Option<&'a [u8]>,
-        upper_bound: Option<&'a [u8]>,
+        lower_bound: Option<&[u8]>,
+        upper_bound: Option<&[u8]>,
     ) -> DBIterator<'a> {
         Self::log_assert_is_in_colddb(col);
         self.cold.iter_range(col, lower_bound, upper_bound)

--- a/core/store/src/db/rocksdb.rs
+++ b/core/store/src/db/rocksdb.rs
@@ -212,9 +212,9 @@ impl RocksDB {
     fn iter_raw_bytes_internal<'a>(
         &'a self,
         col: DBCol,
-        prefix: Option<&'a [u8]>,
-        lower_bound: Option<&'a [u8]>,
-        upper_bound: Option<&'a [u8]>,
+        prefix: Option<&[u8]>,
+        lower_bound: Option<&[u8]>,
+        upper_bound: Option<&[u8]>,
     ) -> RocksDBIterator<'a> {
         let cf_handle = self.cf_handle(col).unwrap();
         let mut read_options = rocksdb_read_options();
@@ -290,15 +290,15 @@ impl Database for RocksDB {
         Ok(result)
     }
 
-    fn iter_raw_bytes<'a>(&'a self, col: DBCol) -> DBIterator<'a> {
+    fn iter_raw_bytes(&self, col: DBCol) -> DBIterator {
         Box::new(self.iter_raw_bytes_internal(col, None, None, None))
     }
 
-    fn iter<'a>(&'a self, col: DBCol) -> DBIterator<'a> {
+    fn iter(&self, col: DBCol) -> DBIterator {
         refcount::iter_with_rc_logic(col, self.iter_raw_bytes_internal(col, None, None, None))
     }
 
-    fn iter_prefix<'a>(&'a self, col: DBCol, key_prefix: &'a [u8]) -> DBIterator<'a> {
+    fn iter_prefix(&self, col: DBCol, key_prefix: &[u8]) -> DBIterator {
         let iter = self.iter_raw_bytes_internal(col, Some(key_prefix), None, None);
         refcount::iter_with_rc_logic(col, iter)
     }
@@ -306,8 +306,8 @@ impl Database for RocksDB {
     fn iter_range<'a>(
         &'a self,
         col: DBCol,
-        lower_bound: Option<&'a [u8]>,
-        upper_bound: Option<&'a [u8]>,
+        lower_bound: Option<&[u8]>,
+        upper_bound: Option<&[u8]>,
     ) -> DBIterator<'a> {
         let iter = self.iter_raw_bytes_internal(col, None, lower_bound, upper_bound);
         refcount::iter_with_rc_logic(col, iter)

--- a/core/store/src/db/splitdb.rs
+++ b/core/store/src/db/splitdb.rs
@@ -144,8 +144,8 @@ impl Database for SplitDB {
     fn iter_range<'a>(
         &'a self,
         col: DBCol,
-        lower_bound: Option<&'a [u8]>,
-        upper_bound: Option<&'a [u8]>,
+        lower_bound: Option<&[u8]>,
+        upper_bound: Option<&[u8]>,
     ) -> DBIterator<'a> {
         if !col.is_cold() {
             return self.hot.iter_range(col, lower_bound, upper_bound);

--- a/core/store/src/db/testdb.rs
+++ b/core/store/src/db/testdb.rs
@@ -62,8 +62,8 @@ impl Database for TestDB {
     fn iter_range<'a>(
         &'a self,
         col: DBCol,
-        lower_bound: Option<&'a [u8]>,
-        upper_bound: Option<&'a [u8]>,
+        lower_bound: Option<&[u8]>,
+        upper_bound: Option<&[u8]>,
     ) -> DBIterator<'a> {
         let lower = lower_bound.map_or(Bound::Unbounded, |f| Bound::Included(f.to_vec()));
         let upper = upper_bound.map_or(Bound::Unbounded, |f| Bound::Excluded(f.to_vec()));

--- a/core/store/src/flat/store_helper.rs
+++ b/core/store/src/flat/store_helper.rs
@@ -123,39 +123,38 @@ pub fn set_flat_storage_status(
     shard_uid: ShardUId,
     status: FlatStorageStatus,
 ) {
+    ShardUId::next_shard_prefix(&key_from);
     store_update
         .set_ser(DBCol::FlatStorageStatus, &shard_uid.to_bytes(), &status)
         .expect("Borsh should not fail")
 }
 
 /// Iterate over flat storage entries for a given shard.
-/// It reads data only from the 'main' column - which represents the state as of final head.
-///
-/// WARNING: flat storage keeps changing, so the results might be inconsistent, unless you're running
-/// this method on the shapshot of the data.
-// TODO(#8676): Support non-trivial ranges and maybe pass `shard_uid` as key prefix.
+/// It reads data only from `FlatState` column which represents the state at
+/// flat storage head.
 pub fn iter_flat_state_entries<'a>(
-    shard_layout: ShardLayout,
-    shard_id: u64,
+    shard_uid: ShardUId,
     store: &'a Store,
-    from: Option<&'a Vec<u8>>,
-    to: Option<&'a Vec<u8>>,
+    from: Option<&[u8]>,
+    to: Option<&[u8]>,
 ) -> impl Iterator<Item = (Vec<u8>, Box<[u8]>)> + 'a {
-    store
-        .iter_range(DBCol::FlatState, from.map(|x| x.as_slice()), to.map(|x| x.as_slice()))
-        .filter_map(move |result| {
+    let db_key_from = match from {
+        Some(from) => encode_flat_state_db_key(shard_uid, from),
+        None => shard_uid.to_bytes().to_vec(),
+    };
+    let db_key_to = match to {
+        Some(to) => encode_flat_state_db_key(shard_uid, to),
+        None => ShardUId::next_shard_prefix(&shard_uid.to_bytes()).to_vec(),
+    };
+    store.iter_range(DBCol::FlatState, Some(&db_key_from), Some(&db_key_to)).filter_map(
+        move |result| {
             if let Ok((key, value)) = result {
-                // Currently all the data in flat storage is 'together' - so we have to parse the key,
-                // to see if this element belongs to this shard.
-                if let Ok(key_in_shard) = key_belongs_to_shard(&key, &shard_layout, shard_id) {
-                    if key_in_shard {
-                        let (_, trie_key) = decode_flat_state_db_key(&key).unwrap();
-                        return Some((trie_key, value));
-                    }
-                }
+                let (_, trie_key) = decode_flat_state_db_key(&key).unwrap();
+                return Some((trie_key, value));
             }
             return None;
-        })
+        },
+    )
 }
 
 /// Currently all the data in flat storage is 'together' - so we have to parse the key,

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -319,8 +319,8 @@ impl Store {
     pub fn iter_range<'a>(
         &'a self,
         col: DBCol,
-        lower_bound: Option<&'a [u8]>,
-        upper_bound: Option<&'a [u8]>,
+        lower_bound: Option<&[u8]>,
+        upper_bound: Option<&[u8]>,
     ) -> DBIterator<'a> {
         self.storage.iter_range(col, lower_bound, upper_bound)
     }

--- a/integration-tests/src/tests/client/flat_storage.rs
+++ b/integration-tests/src/tests/client/flat_storage.rs
@@ -438,14 +438,9 @@ fn test_flat_storage_iter() {
     }
 
     for shard_id in 0..3 {
-        let items: Vec<_> = store_helper::iter_flat_state_entries(
-            shard_layout.clone(),
-            shard_id,
-            &store,
-            None,
-            None,
-        )
-        .collect();
+        let shard_uid = ShardUId::from_shard_id_and_layout(shard_id, &shard_layout);
+        let items: Vec<_> =
+            store_helper::iter_flat_state_entries(shard_uid, &store, None, None).collect();
 
         match shard_id {
             0 => {

--- a/tools/flat-storage/src/commands.rs
+++ b/tools/flat-storage/src/commands.rs
@@ -243,13 +243,8 @@ impl FlatStorageCommand {
                     .get_view_trie_for_shard(verify_cmd.shard_id, &head_hash, *state_root)
                     .unwrap();
 
-                let flat_state_entries_iter = store_helper::iter_flat_state_entries(
-                    shard_layout,
-                    verify_cmd.shard_id,
-                    &hot_store,
-                    None,
-                    None,
-                );
+                let flat_state_entries_iter =
+                    store_helper::iter_flat_state_entries(shard_uid, &hot_store, None, None);
 
                 // Trie iterator which skips all the 'delayed' keys - that don't contain the account_id as string.
                 let trie_iter = trie.iter().unwrap().filter(|entry| {


### PR DESCRIPTION
Needed for #8927.

1. From what I see in https://doc.rust-lang.org/rust-by-example/scope/lifetime/explicit.html, lifetimes introduce restriction over passed variables - they must outlive function lifetime. But this doesn't make sense for iterator. It doesn't save much memory, because iterator is expected to return lots of vectors anyway. And slices `from` and `to` are converted to vectors inside anyway. This allows us to construct DB keys inside `iter_flat_state_entries`.
2. Construction of DB keys is hidden inside `flat` module now. You give state keys and receive state keys back, without knowing how they are stored on the lower level.

## Testing

@jbajic would you like to cover `iter_flat_state_entries` with some test? 
This function will be covered by integration tests for state parts anyway and it is not used much currently.
But it seems nice to have a test which creates flat storage for, say, 3 shards, writes some KV pairs to it and then checks that flat state iterator gives us correct data.