### PR TITLE
jsonrpc: encode state proofs using base64 and remove deprecated field

### DIFF
--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -228,7 +228,7 @@ pub struct StateItem {
 pub struct ViewStateResult {
     pub values: Vec<StateItem>,
     #[serde_as(as = "Vec<Base64>")]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub proof: Vec<Arc<[u8]>>,
 }
 

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -221,19 +221,14 @@ impl From<AccessKeyView> for AccessKey {
 pub struct StateItem {
     pub key: StoreKey,
     pub value: StoreValue,
-    /// Deprecated, always empty, eventually will be deleted.
-    // TODO(mina86): This was deprecated in 1.30.  Get rid of the field
-    // altogether at 1.33 or something.
-    #[serde(default)]
-    pub proof: Vec<()>,
 }
 
+#[serde_as]
 #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct ViewStateResult {
     pub values: Vec<StateItem>,
-    // TODO(mina86): Empty proof (i.e. sending proof when include_proof is not
-    // set in the request) was deprecated in 1.30.  Add
-    // `#[serde(skip(Vec::if_empty))` at 1.33 or something.
+    #[serde_as(as = "Vec<Base64>")]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub proof: Vec<Arc<[u8]>>,
 }
 

--- a/integration-tests/src/tests/runtime/state_viewer.rs
+++ b/integration-tests/src/tests/runtime/state_viewer.rs
@@ -200,11 +200,7 @@ fn assert_view_state(
 
     let values = want_values
         .iter()
-        .map(|(key, value)| StateItem {
-            key: key.to_vec().into(),
-            value: value.to_vec().into(),
-            proof: vec![],
-        })
+        .map(|(key, value)| StateItem { key: key.to_vec().into(), value: value.to_vec().into() })
         .collect::<Vec<_>>();
 
     let view_state =

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -148,11 +148,7 @@ impl TrieViewer {
         iter.seek_prefix(&query)?;
         for item in &mut iter {
             let (key, value) = item?;
-            values.push(StateItem {
-                key: key[acc_sep_len..].to_vec().into(),
-                value: value.into(),
-                proof: vec![],
-            });
+            values.push(StateItem { key: key[acc_sep_len..].to_vec().into(), value: value.into() });
         }
         let proof = iter.into_visited_nodes();
         Ok(ViewStateResult { values, proof })


### PR DESCRIPTION
Change ViewStateResult::proof serialisation to base64.  This has been
the plan all along but back when proof was added¹ I forgot to follow
up with encoding change.  At the moment the proof is sent as an array
of integers which is inefficient and inconsistent with how binary data
is other JSON messages is encoded.

Furthermore, follow up with the deprecation notices: don’t include
proof field in StateItem and don’t include proof field in the response
if it hasn’t been requested.

¹ See commit faa1811d1625: ‘add proof to ViewState response’.
