### PR TITLE
feat: enable FlatState values inlining migration in the background

### DIFF
--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -2568,7 +2568,8 @@ impl<'a> ChainStoreUpdate<'a> {
             | DBCol::FlatState
             | DBCol::FlatStateChanges
             | DBCol::FlatStateDeltaMetadata
-            | DBCol::FlatStorageStatus => {
+            | DBCol::FlatStorageStatus
+            | DBCol::Misc => {
                 unreachable!();
             }
         }

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -960,6 +960,10 @@ impl RuntimeAdapter for KeyValueRuntime {
             .get_trie_for_shard(ShardUId { version: 0, shard_id: shard_id as u32 }, state_root))
     }
 
+    fn get_flat_storage_manager(&self) -> Option<near_store::flat::FlatStorageManager> {
+        None
+    }
+
     fn get_view_trie_for_shard(
         &self,
         shard_id: ShardId,

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -5,6 +5,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use chrono::DateTime;
 use chrono::Utc;
 use near_primitives::sandbox::state_patch::SandboxStatePatch;
+use near_store::flat::FlatStorageManager;
 use num_rational::Rational32;
 
 use crate::metrics;
@@ -298,6 +299,8 @@ pub trait RuntimeAdapter: Send + Sync {
         prev_hash: &CryptoHash,
         state_root: StateRoot,
     ) -> Result<Trie, Error>;
+
+    fn get_flat_storage_manager(&self) -> Option<FlatStorageManager>;
 
     fn get_flat_storage_for_shard(&self, shard_uid: ShardUId) -> Option<FlatStorage>;
 

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -23,7 +23,7 @@ pub enum DBCol {
     /// - *Rows*: single row `"VERSION"`
     /// - *Content type*: The version of the database (u32), serialized as JSON.
     DbVersion,
-    /// Column that store Misc cells.
+    /// Column that stores miscellaneous block-related cells.
     /// - *Rows*: multiple, for example `"GENESIS_JSON_HASH"`, `"HEAD_KEY"`, `"LATEST_KNOWN_KEY"` etc.
     /// - *Content type*: cell specific.
     BlockMisc,
@@ -273,6 +273,11 @@ pub enum DBCol {
     /// - *Rows*: `shard_uid`
     /// - *Column type*: `FlatStorageStatus`
     FlatStorageStatus,
+    /// Column to persist pieces of miscellaneous small data. Should only be used to store
+    /// constant or small (for example per-shard) amount of data.
+    /// - *Rows*: arbitrary string, see `crate::db::FLAT_STATE_VALUES_INLINING_MIGRATION_STATUS_KEY` for example
+    /// - *Column type*: arbitrary bytes
+    Misc,
 }
 
 /// Defines different logical parts of a db key.
@@ -422,6 +427,7 @@ impl DBCol {
 
             // TODO
             DBCol::ChallengedBlocks => false,
+            DBCol::Misc => false,
             // BlockToCatchup is only needed while syncing and it is not immutable.
             DBCol::BlocksToCatchup => false,
             // BlockRefCount is only needed when handling forks and it is not immutable.
@@ -479,6 +485,7 @@ impl DBCol {
         match self {
             DBCol::DbVersion => &[DBKeyType::StringLiteral],
             DBCol::BlockMisc => &[DBKeyType::StringLiteral],
+            DBCol::Misc => &[DBKeyType::StringLiteral],
             DBCol::Block => &[DBKeyType::BlockHash],
             DBCol::BlockHeader => &[DBKeyType::BlockHash],
             DBCol::BlockHeight => &[DBKeyType::BlockHeight],

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -20,6 +20,7 @@ pub use self::splitdb::SplitDB;
 pub use self::slice::DBSlice;
 pub use self::testdb::TestDB;
 
+// `DBCol::BlockMisc` keys
 pub const HEAD_KEY: &[u8; 4] = b"HEAD";
 pub const TAIL_KEY: &[u8; 4] = b"TAIL";
 pub const CHUNK_TAIL_KEY: &[u8; 10] = b"CHUNK_TAIL";
@@ -31,6 +32,10 @@ pub const LARGEST_TARGET_HEIGHT_KEY: &[u8; 21] = b"LARGEST_TARGET_HEIGHT";
 pub const GENESIS_JSON_HASH_KEY: &[u8; 17] = b"GENESIS_JSON_HASH";
 pub const GENESIS_STATE_ROOTS_KEY: &[u8; 19] = b"GENESIS_STATE_ROOTS";
 pub const COLD_HEAD_KEY: &[u8; 9] = b"COLD_HEAD";
+
+// `DBCol::Misc` keys
+pub const FLAT_STATE_VALUES_INLINING_MIGRATION_STATUS_KEY: &[u8] =
+    b"FLAT_STATE_VALUES_INLINING_MIGRATION_STATUS";
 
 #[derive(Default, Debug)]
 pub struct DBTransaction {

--- a/core/store/src/flat/mod.rs
+++ b/core/store/src/flat/mod.rs
@@ -36,7 +36,7 @@ mod types;
 
 pub use chunk_view::FlatStorageChunkView;
 pub use delta::{FlatStateChanges, FlatStateDelta, FlatStateDeltaMetadata};
-pub use inlining_migration::inline_flat_state_values;
+pub use inlining_migration::{inline_flat_state_values, FlatStateValuesInliningMigrationHandle};
 pub use manager::FlatStorageManager;
 pub use metrics::FlatStorageCreationMetrics;
 pub use storage::FlatStorage;

--- a/core/store/src/flat/types.rs
+++ b/core/store/src/flat/types.rs
@@ -75,6 +75,13 @@ impl From<FlatStorageError> for StorageError {
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug, PartialEq, Eq)]
+pub enum FlatStateValuesInliningMigrationStatus {
+    Empty,
+    InProgress,
+    Finished,
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Debug, PartialEq, Eq)]
 pub enum FlatStorageStatus {
     /// Flat Storage is not supported.
     Disabled,

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -10,6 +10,7 @@ use cold_storage::ColdStoreLoopHandle;
 use near_async::actix::AddrWithAutoSpanContextExt;
 use near_async::messaging::{IntoSender, LateBoundSender};
 use near_async::time;
+use near_chain::types::RuntimeAdapter;
 use near_chain::{Chain, ChainGenesis};
 use near_chunks::shards_manager_actor::start_shards_manager;
 use near_client::{start_client, start_view_client, ClientActor, ConfigUpdater, ViewClientActor};
@@ -17,6 +18,7 @@ use near_epoch_manager::shard_tracker::{ShardTracker, TrackedConfig};
 use near_epoch_manager::EpochManager;
 use near_network::PeerManagerActor;
 use near_primitives::block::GenesisId;
+use near_store::flat::FlatStateValuesInliningMigrationHandle;
 use near_store::metadata::DbKind;
 use near_store::metrics::spawn_db_metrics_loop;
 use near_store::{DBCol, Mode, NodeStorage, Store, StoreOpenerError};
@@ -193,6 +195,9 @@ pub struct NearNode {
     pub cold_store_loop_handle: Option<ColdStoreLoopHandle>,
     /// Contains handles to background threads that may be dumping state to S3.
     pub state_sync_dump_handle: Option<StateSyncDumpHandle>,
+    /// A handle to control background flat state values inlining migration.
+    /// Needed temporarily, will be removed after the migration is completed.
+    pub flat_state_migration_handle: Option<FlatStateValuesInliningMigrationHandle>,
 }
 
 pub fn start_with_config(home_dir: &Path, config: NearConfig) -> anyhow::Result<NearNode> {
@@ -303,6 +308,18 @@ pub fn start_with_config_and_synchronization(
     );
     shards_manager_adapter.bind(shards_manager_actor);
 
+    let flat_state_migration_handle =
+        if let Some(flat_storage_manager) = runtime.get_flat_storage_manager() {
+            let handle = FlatStateValuesInliningMigrationHandle::start_background_migration(
+                storage.get_hot_store(),
+                flat_storage_manager,
+                config.client_config.client_background_migration_threads,
+            );
+            Some(handle)
+        } else {
+            None
+        };
+
     let state_sync_dump_handle = spawn_state_sync_dump(
         &config.client_config,
         chain_genesis,
@@ -366,6 +383,7 @@ pub fn start_with_config_and_synchronization(
         arbiters,
         cold_store_loop_handle,
         state_sync_dump_handle,
+        flat_state_migration_handle,
     })
 }
 

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -733,6 +733,10 @@ impl RuntimeAdapter for NightshadeRuntime {
         Ok(self.tries.get_view_trie_for_shard(shard_uid, state_root))
     }
 
+    fn get_flat_storage_manager(&self) -> Option<FlatStorageManager> {
+        Some(self.flat_storage_manager.clone())
+    }
+
     fn get_flat_storage_for_shard(&self, shard_uid: ShardUId) -> Option<FlatStorage> {
         self.flat_storage_manager.get_flat_storage_for_shard(shard_uid)
     }

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -518,6 +518,7 @@ impl RunCmd {
                 rpc_servers,
                 cold_store_loop_handle,
                 state_sync_dump_handle,
+                flat_state_migration_handle,
                 ..
             } = nearcore::start_with_config_and_synchronization(
                 home_dir,
@@ -543,6 +544,9 @@ impl RunCmd {
             }
             if let Some(handle) = state_sync_dump_handle {
                 handle.stop()
+            }
+            if let Some(handle) = flat_state_migration_handle {
+                handle.stop();
             }
             futures::future::join_all(rpc_servers.iter().map(|(name, server)| async move {
                 server.stop(true).await;

--- a/tools/flat-storage/src/commands.rs
+++ b/tools/flat-storage/src/commands.rs
@@ -11,6 +11,7 @@ use near_store::flat::{
 };
 use near_store::{DBCol, Mode, NodeStorage, ShardUId, Store, StoreOpener};
 use nearcore::{load_config, NearConfig, NightshadeRuntime};
+use std::sync::atomic::AtomicBool;
 use std::{path::PathBuf, sync::Arc, time::Duration};
 use tqdm::tqdm;
 
@@ -318,6 +319,7 @@ impl FlatStorageCommand {
                 inline_flat_state_values(
                     store,
                     &flat_storage_manager,
+                    &AtomicBool::new(true),
                     cmd.num_threads,
                     cmd.batch_size,
                 );


### PR DESCRIPTION
Part of #8243.

This PR enables the migration added in #9037 to be executed in the background on the running node.
It supports graceful stop when the node is shut down. The implementation is heavily inspired by state sync background dumping to S3.

This PR also introduces a new column `DBCol::Misc`. For now it only stores the status of the migration, but it can hold any small pieces of data, similar to `DBCol::BlockMisc`.

`FlatStorageManager` is exposed as part of `RuntimeAdapter` in this PR. This is the first step in cleaning `RuntimeAdapter` from all other flat storage related methods, as the manager can be directly used instead.

Tested by manually running a node and checking metrics and log messages. After that flat storage was checked with `flat-storage verify` cmd.