### PR TITLE
Include signed ip address in TIER2 handshake. #8902 

### DIFF
--- a/chain/network/src/config.rs
+++ b/chain/network/src/config.rs
@@ -446,8 +446,7 @@ impl NetworkConfig {
         self.routing_table_update_rate_limit
             .validate()
             .context("routing_table_update_rate_limit")?;
-        let my_node_id = self.node_id();
-        Ok(VerifiedConfig { node_id: my_node_id, inner: self })
+        Ok(VerifiedConfig { node_id: self.node_id(), inner: self })
     }
 }
 

--- a/chain/network/src/config.rs
+++ b/chain/network/src/config.rs
@@ -452,18 +452,17 @@ impl NetworkConfig {
         if !(self.node_addr.is_some()) {
             anyhow::bail!("no node address given that is necessary for near network handshake");
         }
-        let owned_ip_address = OwnedIpAddress {
-            ip_address: self.node_addr.unwrap().ip(),
-        };
+        let owned_ip_address = OwnedIpAddress { ip_address: self.node_addr.unwrap().ip() };
         let my_node_id = self.node_id();
-        let my_signed_owned_ip_address: SignedOwnedIpAddress = owned_ip_address.sign(&self.node_key);
+        let my_signed_owned_ip_address: SignedOwnedIpAddress =
+            owned_ip_address.sign(&self.node_key);
         if !(my_signed_owned_ip_address.verify(my_node_id.public_key())) {
             anyhow::bail!("Unable to sign and verify ip address with given node_key");
         }
         Ok(VerifiedConfig {
             node_id: my_node_id,
             inner: self,
-            signed_owned_ip_address: my_signed_owned_ip_address
+            signed_owned_ip_address: my_signed_owned_ip_address,
         })
     }
 }

--- a/chain/network/src/config.rs
+++ b/chain/network/src/config.rs
@@ -2,7 +2,6 @@ use crate::blacklist;
 use crate::concurrency::rate;
 use crate::network_protocol::PeerAddr;
 use crate::network_protocol::PeerInfo;
-use crate::network_protocol::{OwnedIpAddress, SignedOwnedIpAddress};
 use crate::peer_manager::peer_manager_actor::Event;
 use crate::peer_manager::peer_store;
 use crate::sink::Sink;
@@ -447,23 +446,8 @@ impl NetworkConfig {
         self.routing_table_update_rate_limit
             .validate()
             .context("routing_table_update_rate_limit")?;
-
-        // Verify ip address can be signed and verified
-        if !(self.node_addr.is_some()) {
-            anyhow::bail!("no node address given that is necessary for near network handshake");
-        }
-        let owned_ip_address = OwnedIpAddress { ip_address: self.node_addr.unwrap().ip() };
         let my_node_id = self.node_id();
-        let my_signed_owned_ip_address: SignedOwnedIpAddress =
-            owned_ip_address.sign(&self.node_key);
-        if !(my_signed_owned_ip_address.verify(my_node_id.public_key())) {
-            anyhow::bail!("Unable to sign and verify ip address with given node_key");
-        }
-        Ok(VerifiedConfig {
-            node_id: my_node_id,
-            inner: self,
-            signed_owned_ip_address: my_signed_owned_ip_address,
-        })
+        Ok(VerifiedConfig { node_id: my_node_id, inner: self })
     }
 }
 
@@ -478,17 +462,11 @@ pub struct VerifiedConfig {
     /// Cached inner.node_id().
     /// It allows to avoid recomputing the public key every time.
     node_id: PeerId,
-    // Cache of SignedOwnedIpAddress as can be re-used for each new handshake connection.
-    signed_owned_ip_address: SignedOwnedIpAddress,
 }
 
 impl VerifiedConfig {
     pub fn node_id(&self) -> PeerId {
         self.node_id.clone()
-    }
-
-    pub fn signed_owned_ip_address(&self) -> SignedOwnedIpAddress {
-        self.signed_owned_ip_address.clone() // Clone as it's sent over the network
     }
 }
 
@@ -617,15 +595,6 @@ mod test {
         nc_after.override_config(overrides.clone());
         check_fields(&nc_before, &nc_after, &overrides);
         assert!(nc_after.verify().is_ok());
-    }
-
-    #[test]
-    fn test_verified_network_config() {
-        let nc = config::NetworkConfig::from_seed("123", tcp::ListenerAddr::reserve_for_test());
-        let verified_config = nc.verify().unwrap();
-        // Assert that the verified config's signed_owned_ip_address can be verified with its owned node_id
-        let signed_owned_ip_address = verified_config.signed_owned_ip_address();
-        assert!(signed_owned_ip_address.verify(verified_config.node_id().public_key()));
     }
 
     // Check that MAX_PEER_ADDRS limit is consistent with the

--- a/chain/network/src/network_protocol/borsh_conv.rs
+++ b/chain/network/src/network_protocol/borsh_conv.rs
@@ -14,7 +14,7 @@ impl From<&net::Handshake> for mem::Handshake {
             sender_chain_info: x.sender_chain_info.clone(),
             partial_edge_info: x.partial_edge_info.clone(),
             owned_account: None,
-            signed_owned_ip_address: None, // borsh isn't backwards compatible. Hence, no support for signing ip address
+            signed_ip_address: None, // borsh isn't backwards compatible. Hence, no support for signing ip address
         }
     }
 }

--- a/chain/network/src/network_protocol/borsh_conv.rs
+++ b/chain/network/src/network_protocol/borsh_conv.rs
@@ -14,7 +14,7 @@ impl From<&net::Handshake> for mem::Handshake {
             sender_chain_info: x.sender_chain_info.clone(),
             partial_edge_info: x.partial_edge_info.clone(),
             owned_account: None,
-            owned_ip_address: None, // borsh isn't backwards compatible. Hence, no support for signing ip address
+            signed_owned_ip_address: None, // borsh isn't backwards compatible. Hence, no support for signing ip address
         }
     }
 }

--- a/chain/network/src/network_protocol/borsh_conv.rs
+++ b/chain/network/src/network_protocol/borsh_conv.rs
@@ -14,6 +14,7 @@ impl From<&net::Handshake> for mem::Handshake {
             sender_chain_info: x.sender_chain_info.clone(),
             partial_edge_info: x.partial_edge_info.clone(),
             owned_account: None,
+            owned_ip_address: None, // borsh isn't backwards compatible. Hence, no support for signing ip address
         }
     }
 }

--- a/chain/network/src/network_protocol/mod.rs
+++ b/chain/network/src/network_protocol/mod.rs
@@ -100,8 +100,8 @@ impl OwnedIpAddress {
     // Serialization of ip address for signing and verification
     fn ip_bytes(&self) -> Vec<u8> {
         let ip_bytes: Vec<u8> = match self.ip_address {
-            std::net::IpAddr::V4(ip) => ip.octets().to_vec().clone(),
-            std::net::IpAddr::V6(ip) => ip.octets().to_vec().clone(),
+            std::net::IpAddr::V4(ip) => ip.octets().to_vec(),
+            std::net::IpAddr::V6(ip) => ip.octets().to_vec(),
         };
         return ip_bytes;
     }

--- a/chain/network/src/network_protocol/mod.rs
+++ b/chain/network/src/network_protocol/mod.rs
@@ -346,8 +346,8 @@ pub struct Handshake {
     pub(crate) partial_edge_info: PartialEdgeInfo,
     /// Account owned by the sender.
     pub(crate) owned_account: Option<SignedOwnedAccount>,
-    /// Ip Address of the sender
-    pub(crate) owned_ip_address: Option<std::net::IpAddr>,
+    /// Signed Ip Address of the sender
+    pub(crate) signed_owned_ip_address: Option<SignedOwnedIpAddress>,
 }
 
 #[derive(PartialEq, Eq, Clone, Debug, strum::IntoStaticStr)]

--- a/chain/network/src/network_protocol/mod.rs
+++ b/chain/network/src/network_protocol/mod.rs
@@ -90,7 +90,7 @@ impl std::str::FromStr for PeerAddr {
     }
 }
 
-// Wrapper around std::net::IpAddr, which constructs a SignedOwnedIpAddress
+// Wrapper around std::net::IpAddr, which constructs a SignedIpAddress
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub struct OwnedIpAddress {
     pub(crate) ip_address: std::net::IpAddr,
@@ -107,22 +107,22 @@ impl OwnedIpAddress {
     }
 
     /// Sign with a given SecretKey, but must not store it.
-    pub fn sign(self, secret_key: &near_crypto::SecretKey) -> SignedOwnedIpAddress {
+    pub fn sign(self, secret_key: &near_crypto::SecretKey) -> SignedIpAddress {
         let signature = secret_key.sign(&self.ip_bytes());
-        SignedOwnedIpAddress { owned_ip_address: self, signature_ip_address: signature }
+        SignedIpAddress { owned_ip_address: self, signature: signature }
     }
 }
 
 /// Proof that a given peer_id owns an ip address, included in Handshake message
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
-pub struct SignedOwnedIpAddress {
+pub struct SignedIpAddress {
     pub(crate) owned_ip_address: OwnedIpAddress,
-    pub(crate) signature_ip_address: near_crypto::Signature, // signature for signed ip_address
+    pub(crate) signature: near_crypto::Signature, // signature for signed ip_address
 }
 
-impl SignedOwnedIpAddress {
+impl SignedIpAddress {
     pub fn verify(&self, public_key: &PublicKey) -> bool {
-        self.signature_ip_address.verify(&self.owned_ip_address.ip_bytes(), &public_key)
+        self.signature.verify(&self.owned_ip_address.ip_bytes(), &public_key)
     }
 }
 
@@ -344,7 +344,7 @@ pub struct Handshake {
     /// Account owned by the sender.
     pub(crate) owned_account: Option<SignedOwnedAccount>,
     /// Signed Ip Address of the sender
-    pub(crate) signed_owned_ip_address: Option<SignedOwnedIpAddress>,
+    pub(crate) signed_ip_address: Option<SignedIpAddress>,
 }
 
 #[derive(PartialEq, Eq, Clone, Debug, strum::IntoStaticStr)]

--- a/chain/network/src/network_protocol/mod.rs
+++ b/chain/network/src/network_protocol/mod.rs
@@ -307,6 +307,8 @@ pub struct Handshake {
     pub(crate) partial_edge_info: PartialEdgeInfo,
     /// Account owned by the sender.
     pub(crate) owned_account: Option<SignedOwnedAccount>,
+    /// Ip Address of the sender
+    pub(crate) owned_ip_address: Option<std::net::IpAddr>,
 }
 
 #[derive(PartialEq, Eq, Clone, Debug, strum::IntoStaticStr)]

--- a/chain/network/src/network_protocol/mod.rs
+++ b/chain/network/src/network_protocol/mod.rs
@@ -109,10 +109,7 @@ impl OwnedIpAddress {
     /// Sign with a given SecretKey, but must not store it.
     pub fn sign(self, secret_key: &near_crypto::SecretKey) -> SignedOwnedIpAddress {
         let signature = secret_key.sign(&self.ip_bytes());
-        SignedOwnedIpAddress {
-            owned_ip_address: self,
-            signature_ip_address: signature,
-        }
+        SignedOwnedIpAddress { owned_ip_address: self, signature_ip_address: signature }
     }
 }
 

--- a/chain/network/src/network_protocol/network.proto
+++ b/chain/network/src/network_protocol/network.proto
@@ -168,6 +168,8 @@ message Handshake {
   PartialEdgeInfo partial_edge_info = 7;
   // See description of OwnedAccount.
   AccountKeySignedPayload owned_account = 8; // optional
+  // Sender's signature to verify ip address of the sender
+  IpAddr owned_ip_address = 9; // required, but marked as optional for protocol buffer backward compatibility
 }
 
 // Response to Handshake, in case the Handshake was rejected.

--- a/chain/network/src/network_protocol/network.proto
+++ b/chain/network/src/network_protocol/network.proto
@@ -199,6 +199,11 @@ message LastEdge {
   Edge edge = 1;
 }
 
+message IpAddr {
+  // IPv4 (4 bytes) or IPv6 (16 bytes) in network byte order.
+  bytes ip = 1;
+}
+
 message SocketAddr {
   // IPv4 (4 bytes) or IPv6 (16 bytes) in network byte order.
   bytes ip = 1;

--- a/chain/network/src/network_protocol/network.proto
+++ b/chain/network/src/network_protocol/network.proto
@@ -169,7 +169,7 @@ message Handshake {
   // See description of OwnedAccount.
   AccountKeySignedPayload owned_account = 8; // optional
   // Sender's signature to verify ip address of the sender
-  SignedOwnedIpAddr signed_owned_ip_addr = 9; // required, but marked as optional for protocol buffer backward compatibility
+  SignedIpAddr signed_ip_addr = 9; // required, but marked as optional for protocol buffer backward compatibility
 }
 
 // Response to Handshake, in case the Handshake was rejected.
@@ -210,9 +210,9 @@ message OwnedIpAddr {
   IpAddr ip_addr = 1;
 }
 
-message SignedOwnedIpAddr {
+message SignedIpAddr {
   OwnedIpAddr owned_ip_addr = 1;
-  Signature signature_ip_addr = 2;
+  Signature signature = 2;
 }
 
 message SocketAddr {

--- a/chain/network/src/network_protocol/network.proto
+++ b/chain/network/src/network_protocol/network.proto
@@ -206,12 +206,8 @@ message IpAddr {
   bytes ip = 1;
 }
 
-message OwnedIpAddr {
-  IpAddr ip_addr = 1;
-}
-
 message SignedIpAddr {
-  OwnedIpAddr owned_ip_addr = 1;
+  IpAddr ip_addr = 1;
   Signature signature = 2;
 }
 

--- a/chain/network/src/network_protocol/network.proto
+++ b/chain/network/src/network_protocol/network.proto
@@ -169,7 +169,7 @@ message Handshake {
   // See description of OwnedAccount.
   AccountKeySignedPayload owned_account = 8; // optional
   // Sender's signature to verify ip address of the sender
-  IpAddr owned_ip_address = 9; // required, but marked as optional for protocol buffer backward compatibility
+  SignedOwnedIpAddr signed_owned_ip_addr = 9; // required, but marked as optional for protocol buffer backward compatibility
 }
 
 // Response to Handshake, in case the Handshake was rejected.

--- a/chain/network/src/network_protocol/network.proto
+++ b/chain/network/src/network_protocol/network.proto
@@ -206,6 +206,15 @@ message IpAddr {
   bytes ip = 1;
 }
 
+message OwnedIpAddr {
+  IpAddr ip_addr = 1;
+}
+
+message SignedOwnedIpAddr {
+  OwnedIpAddr owned_ip_addr = 1;
+  Signature signature_ip_addr = 2;
+}
+
 message SocketAddr {
   // IPv4 (4 bytes) or IPv6 (16 bytes) in network byte order.
   bytes ip = 1;

--- a/chain/network/src/network_protocol/proto_conv/handshake.rs
+++ b/chain/network/src/network_protocol/proto_conv/handshake.rs
@@ -77,8 +77,8 @@ pub enum ParseHandshakeError {
     PartialEdgeInfo(ParseRequiredError<ParsePartialEdgeInfoError>),
     #[error("owned_account {0}")]
     OwnedAccount(ParseSignedOwnedAccountError),
-    #[error("signed_owned_ip_address {0}")]
-    SignedOwnedIpAddress(ParseSignedOwnedIpAddrError),
+    #[error("signed_ip_address {0}")]
+    SignedIpAddress(ParseSignedIpAddrError),
 }
 
 impl From<&Handshake> for proto::Handshake {
@@ -92,7 +92,7 @@ impl From<&Handshake> for proto::Handshake {
             sender_chain_info: MF::some((&x.sender_chain_info).into()),
             partial_edge_info: MF::some((&x.partial_edge_info).into()),
             owned_account: x.owned_account.as_ref().map(Into::into).into(),
-            signed_owned_ip_addr: x.signed_owned_ip_address.as_ref().map(Into::into).into(),
+            signed_ip_addr: x.signed_ip_address.as_ref().map(Into::into).into(),
             ..Self::default()
         }
     }
@@ -123,8 +123,8 @@ impl TryFrom<&proto::Handshake> for Handshake {
                 .map_err(Self::Error::PartialEdgeInfo)?,
             owned_account: try_from_optional(&p.owned_account)
                 .map_err(Self::Error::OwnedAccount)?,
-            signed_owned_ip_address: try_from_optional(&p.signed_owned_ip_addr)
-                .map_err(Self::Error::SignedOwnedIpAddress)?,
+            signed_ip_address: try_from_optional(&p.signed_ip_addr)
+                .map_err(Self::Error::SignedIpAddress)?,
         })
     }
 }

--- a/chain/network/src/network_protocol/proto_conv/handshake.rs
+++ b/chain/network/src/network_protocol/proto_conv/handshake.rs
@@ -77,6 +77,8 @@ pub enum ParseHandshakeError {
     PartialEdgeInfo(ParseRequiredError<ParsePartialEdgeInfoError>),
     #[error("owned_account {0}")]
     OwnedAccount(ParseSignedOwnedAccountError),
+    #[error("owned_ip_address {0}")]
+    OwnedIpAddress(ParseIpAddrError),
 }
 
 impl From<&Handshake> for proto::Handshake {
@@ -90,6 +92,7 @@ impl From<&Handshake> for proto::Handshake {
             sender_chain_info: MF::some((&x.sender_chain_info).into()),
             partial_edge_info: MF::some((&x.partial_edge_info).into()),
             owned_account: x.owned_account.as_ref().map(Into::into).into(),
+            owned_ip_address: x.owned_ip_address.as_ref().map(Into::into).into(),
             ..Self::default()
         }
     }
@@ -120,6 +123,8 @@ impl TryFrom<&proto::Handshake> for Handshake {
                 .map_err(Self::Error::PartialEdgeInfo)?,
             owned_account: try_from_optional(&p.owned_account)
                 .map_err(Self::Error::OwnedAccount)?,
+            owned_ip_address: try_from_optional(&p.owned_ip_address)
+                .map_err(Self::Error::OwnedIpAddress)?,
         })
     }
 }

--- a/chain/network/src/network_protocol/proto_conv/handshake.rs
+++ b/chain/network/src/network_protocol/proto_conv/handshake.rs
@@ -77,8 +77,8 @@ pub enum ParseHandshakeError {
     PartialEdgeInfo(ParseRequiredError<ParsePartialEdgeInfoError>),
     #[error("owned_account {0}")]
     OwnedAccount(ParseSignedOwnedAccountError),
-    #[error("owned_ip_address {0}")]
-    OwnedIpAddress(ParseIpAddrError),
+    #[error("signed_owned_ip_address {0}")]
+    SignedOwnedIpAddress(ParseSignedOwnedIpAddrError),
 }
 
 impl From<&Handshake> for proto::Handshake {
@@ -92,7 +92,7 @@ impl From<&Handshake> for proto::Handshake {
             sender_chain_info: MF::some((&x.sender_chain_info).into()),
             partial_edge_info: MF::some((&x.partial_edge_info).into()),
             owned_account: x.owned_account.as_ref().map(Into::into).into(),
-            owned_ip_address: x.owned_ip_address.as_ref().map(Into::into).into(),
+            signed_owned_ip_addr: x.signed_owned_ip_address.as_ref().map(Into::into).into(),
             ..Self::default()
         }
     }
@@ -123,8 +123,8 @@ impl TryFrom<&proto::Handshake> for Handshake {
                 .map_err(Self::Error::PartialEdgeInfo)?,
             owned_account: try_from_optional(&p.owned_account)
                 .map_err(Self::Error::OwnedAccount)?,
-            owned_ip_address: try_from_optional(&p.owned_ip_address)
-                .map_err(Self::Error::OwnedIpAddress)?,
+            signed_owned_ip_address: try_from_optional(&p.signed_owned_ip_addr)
+                .map_err(Self::Error::SignedOwnedIpAddress)?,
         })
     }
 }

--- a/chain/network/src/network_protocol/proto_conv/net.rs
+++ b/chain/network/src/network_protocol/proto_conv/net.rs
@@ -3,7 +3,9 @@ use super::*;
 
 use crate::network_protocol::proto;
 use crate::network_protocol::PeerAddr;
-use crate::network_protocol::{Edge, PartialEdgeInfo, PeerInfo, OwnedIpAddress, SignedOwnedIpAddress};
+use crate::network_protocol::{
+    Edge, OwnedIpAddress, PartialEdgeInfo, PeerInfo, SignedOwnedIpAddress,
+};
 use borsh::{BorshDeserialize as _, BorshSerialize as _};
 use near_primitives::network::AnnounceAccount;
 use protobuf::MessageField as MF;
@@ -17,7 +19,7 @@ pub enum ParseIpAddrError {
     InvalidIP,
 }
 
-impl From<&std::net::IpAddr> for proto::IpAddr{
+impl From<&std::net::IpAddr> for proto::IpAddr {
     fn from(x: &std::net::IpAddr) -> Self {
         Self {
             ip: match x {
@@ -51,19 +53,14 @@ pub enum ParseOwnedIpAddrError {
 
 impl From<&OwnedIpAddress> for proto::OwnedIpAddr {
     fn from(x: &OwnedIpAddress) -> Self {
-        Self {
-            ip_addr: MF::some((&x.ip_address).into()),
-            ..Self::default()
-        }
+        Self { ip_addr: MF::some((&x.ip_address).into()), ..Self::default() }
     }
 }
 
 impl TryFrom<&proto::OwnedIpAddr> for OwnedIpAddress {
     type Error = ParseOwnedIpAddrError;
     fn try_from(p: &proto::OwnedIpAddr) -> Result<Self, Self::Error> {
-        Ok(Self {
-            ip_address: try_from_required(&p.ip_addr).map_err(Self::Error::IpAddr)?,
-        })
+        Ok(Self { ip_address: try_from_required(&p.ip_addr).map_err(Self::Error::IpAddr)? })
     }
 }
 
@@ -91,8 +88,10 @@ impl TryFrom<&proto::SignedOwnedIpAddr> for SignedOwnedIpAddress {
     type Error = ParseSignedOwnedIpAddrError;
     fn try_from(p: &proto::SignedOwnedIpAddr) -> Result<Self, Self::Error> {
         Ok(Self {
-            owned_ip_address: try_from_required(&p.owned_ip_addr).map_err(Self::Error::OwnedIpAddr)?,
-            signature_ip_address: try_from_required(&p.signature_ip_addr).map_err(Self::Error::Signature)?,
+            owned_ip_address: try_from_required(&p.owned_ip_addr)
+                .map_err(Self::Error::OwnedIpAddr)?,
+            signature_ip_address: try_from_required(&p.signature_ip_addr)
+                .map_err(Self::Error::Signature)?,
         })
     }
 }

--- a/chain/network/src/network_protocol/proto_conv/net.rs
+++ b/chain/network/src/network_protocol/proto_conv/net.rs
@@ -3,9 +3,7 @@ use super::*;
 
 use crate::network_protocol::proto;
 use crate::network_protocol::PeerAddr;
-use crate::network_protocol::{
-    Edge, OwnedIpAddress, PartialEdgeInfo, PeerInfo, SignedOwnedIpAddress,
-};
+use crate::network_protocol::{Edge, OwnedIpAddress, PartialEdgeInfo, PeerInfo, SignedIpAddress};
 use borsh::{BorshDeserialize as _, BorshSerialize as _};
 use near_primitives::network::AnnounceAccount;
 use protobuf::MessageField as MF;
@@ -65,33 +63,32 @@ impl TryFrom<&proto::OwnedIpAddr> for OwnedIpAddress {
 }
 
 ////////////////////////////////////////
-// Parse SignedOwnedIpAddr to Protocol Buffer and back
+// Parse SignedIpAddr to Protocol Buffer and back
 #[derive(thiserror::Error, Debug)]
-pub enum ParseSignedOwnedIpAddrError {
+pub enum ParseSignedIpAddrError {
     #[error("owned_ip_addr: {0}")]
     OwnedIpAddr(ParseRequiredError<ParseOwnedIpAddrError>),
     #[error("signed_owned_ip_address: {0}")]
     Signature(ParseRequiredError<ParseSignatureError>),
 }
 
-impl From<&SignedOwnedIpAddress> for proto::SignedOwnedIpAddr {
-    fn from(x: &SignedOwnedIpAddress) -> Self {
+impl From<&SignedIpAddress> for proto::SignedIpAddr {
+    fn from(x: &SignedIpAddress) -> Self {
         Self {
             owned_ip_addr: MF::some((&x.owned_ip_address).into()),
-            signature_ip_addr: MF::some((&x.signature_ip_address).into()),
+            signature: MF::some((&x.signature).into()),
             ..Self::default()
         }
     }
 }
 
-impl TryFrom<&proto::SignedOwnedIpAddr> for SignedOwnedIpAddress {
-    type Error = ParseSignedOwnedIpAddrError;
-    fn try_from(p: &proto::SignedOwnedIpAddr) -> Result<Self, Self::Error> {
+impl TryFrom<&proto::SignedIpAddr> for SignedIpAddress {
+    type Error = ParseSignedIpAddrError;
+    fn try_from(p: &proto::SignedIpAddr) -> Result<Self, Self::Error> {
         Ok(Self {
             owned_ip_address: try_from_required(&p.owned_ip_addr)
                 .map_err(Self::Error::OwnedIpAddr)?,
-            signature_ip_address: try_from_required(&p.signature_ip_addr)
-                .map_err(Self::Error::Signature)?,
+            signature: try_from_required(&p.signature).map_err(Self::Error::Signature)?,
         })
     }
 }

--- a/chain/network/src/network_protocol/proto_conv/net.rs
+++ b/chain/network/src/network_protocol/proto_conv/net.rs
@@ -3,7 +3,7 @@ use super::*;
 
 use crate::network_protocol::proto;
 use crate::network_protocol::PeerAddr;
-use crate::network_protocol::{Edge, OwnedIpAddress, PartialEdgeInfo, PeerInfo, SignedIpAddress};
+use crate::network_protocol::{Edge, PartialEdgeInfo, PeerInfo, SignedIpAddress};
 use borsh::{BorshDeserialize as _, BorshSerialize as _};
 use near_primitives::network::AnnounceAccount;
 use protobuf::MessageField as MF;
@@ -42,32 +42,11 @@ impl TryFrom<&proto::IpAddr> for std::net::IpAddr {
 }
 
 ////////////////////////////////////////
-// Parse OwnedIpAddr to Protocol Buffer and back
-#[derive(thiserror::Error, Debug)]
-pub enum ParseOwnedIpAddrError {
-    #[error("ip_addr: {0}")]
-    IpAddr(ParseRequiredError<ParseIpAddrError>),
-}
-
-impl From<&OwnedIpAddress> for proto::OwnedIpAddr {
-    fn from(x: &OwnedIpAddress) -> Self {
-        Self { ip_addr: MF::some((&x.ip_address).into()), ..Self::default() }
-    }
-}
-
-impl TryFrom<&proto::OwnedIpAddr> for OwnedIpAddress {
-    type Error = ParseOwnedIpAddrError;
-    fn try_from(p: &proto::OwnedIpAddr) -> Result<Self, Self::Error> {
-        Ok(Self { ip_address: try_from_required(&p.ip_addr).map_err(Self::Error::IpAddr)? })
-    }
-}
-
-////////////////////////////////////////
 // Parse SignedIpAddr to Protocol Buffer and back
 #[derive(thiserror::Error, Debug)]
 pub enum ParseSignedIpAddrError {
-    #[error("owned_ip_addr: {0}")]
-    OwnedIpAddr(ParseRequiredError<ParseOwnedIpAddrError>),
+    #[error("ip_addr: {0}")]
+    IpAddr(ParseRequiredError<ParseIpAddrError>),
     #[error("signed_owned_ip_address: {0}")]
     Signature(ParseRequiredError<ParseSignatureError>),
 }
@@ -75,7 +54,7 @@ pub enum ParseSignedIpAddrError {
 impl From<&SignedIpAddress> for proto::SignedIpAddr {
     fn from(x: &SignedIpAddress) -> Self {
         Self {
-            owned_ip_addr: MF::some((&x.owned_ip_address).into()),
+            ip_addr: MF::some((&x.ip_address).into()),
             signature: MF::some((&x.signature).into()),
             ..Self::default()
         }
@@ -86,8 +65,7 @@ impl TryFrom<&proto::SignedIpAddr> for SignedIpAddress {
     type Error = ParseSignedIpAddrError;
     fn try_from(p: &proto::SignedIpAddr) -> Result<Self, Self::Error> {
         Ok(Self {
-            owned_ip_address: try_from_required(&p.owned_ip_addr)
-                .map_err(Self::Error::OwnedIpAddr)?,
+            ip_address: try_from_required(&p.ip_addr).map_err(Self::Error::IpAddr)?,
             signature: try_from_required(&p.signature).map_err(Self::Error::Signature)?,
         })
     }

--- a/chain/network/src/network_protocol/testonly.rs
+++ b/chain/network/src/network_protocol/testonly.rs
@@ -336,8 +336,7 @@ pub fn make_signed_ip_addr(
     ip_addr: &std::net::IpAddr,
     secret_key: &near_crypto::SecretKey,
 ) -> SignedIpAddress {
-    let owned_ip_address = OwnedIpAddress { ip_address: *ip_addr };
-    let signed_ip_address: SignedIpAddress = owned_ip_address.sign(secret_key);
+    let signed_ip_address: SignedIpAddress = SignedIpAddress::new(*ip_addr, secret_key);
     return signed_ip_address;
 }
 

--- a/chain/network/src/network_protocol/testonly.rs
+++ b/chain/network/src/network_protocol/testonly.rs
@@ -332,13 +332,13 @@ impl Chain {
     }
 }
 
-pub fn make_signed_owned_ip_addr(
+pub fn make_signed_ip_addr(
     ip_addr: &std::net::IpAddr,
     secret_key: &near_crypto::SecretKey,
-) -> SignedOwnedIpAddress {
+) -> SignedIpAddress {
     let owned_ip_address = OwnedIpAddress { ip_address: *ip_addr };
-    let signed_owned_ip_address: SignedOwnedIpAddress = owned_ip_address.sign(secret_key);
-    return signed_owned_ip_address;
+    let signed_ip_address: SignedIpAddress = owned_ip_address.sign(secret_key);
+    return signed_ip_address;
 }
 
 pub fn make_handshake_with_ip<R: Rng>(
@@ -350,8 +350,8 @@ pub fn make_handshake_with_ip<R: Rng>(
     let target = make_signer(rng);
     let sender_id = PeerId::new(sender.public_key);
     let target_id = PeerId::new(target.public_key);
-    let signed_owned_ip_address = match ip_addr {
-        Some(ip) => Some(make_signed_owned_ip_addr(&ip, &sender.secret_key)),
+    let signed_ip_address = match ip_addr {
+        Some(ip) => Some(make_signed_ip_addr(&ip, &sender.secret_key)),
         _ => None,
     };
     Handshake {
@@ -363,7 +363,7 @@ pub fn make_handshake_with_ip<R: Rng>(
         sender_chain_info: chain.get_peer_chain_info(),
         partial_edge_info: make_partial_edge(rng),
         owned_account: None,
-        signed_owned_ip_address: signed_owned_ip_address,
+        signed_ip_address: signed_ip_address,
     }
 }
 

--- a/chain/network/src/network_protocol/testonly.rs
+++ b/chain/network/src/network_protocol/testonly.rs
@@ -336,7 +336,7 @@ pub fn make_signed_owned_ip_addr(
     ip_addr: &std::net::IpAddr,
     secret_key: &near_crypto::SecretKey,
 ) -> SignedOwnedIpAddress {
-    let owned_ip_address = OwnedIpAddress { ip_address: ip_addr.clone() };
+    let owned_ip_address = OwnedIpAddress { ip_address: *ip_addr };
     let signed_owned_ip_address: SignedOwnedIpAddress = owned_ip_address.sign(secret_key);
     return signed_owned_ip_address;
 }

--- a/chain/network/src/network_protocol/testonly.rs
+++ b/chain/network/src/network_protocol/testonly.rs
@@ -332,7 +332,7 @@ impl Chain {
     }
 }
 
-pub fn make_handshake<R: Rng>(rng: &mut R, chain: &Chain) -> Handshake {
+pub fn make_handshake_with_ip<R: Rng>(rng: &mut R, chain: &Chain, ip_addr: Option<std::net::IpAddr>) -> Handshake {
     let a = make_signer(rng);
     let b = make_signer(rng);
     let a_id = PeerId::new(a.public_key);
@@ -346,7 +346,12 @@ pub fn make_handshake<R: Rng>(rng: &mut R, chain: &Chain) -> Handshake {
         sender_chain_info: chain.get_peer_chain_info(),
         partial_edge_info: make_partial_edge(rng),
         owned_account: None,
+        owned_ip_address: ip_addr,
     }
+}
+
+pub fn make_handshake<R: Rng>(rng: &mut R, chain: &Chain) -> Handshake {
+    make_handshake_with_ip(rng, chain, None)
 }
 
 pub fn make_routed_message<R: Rng>(rng: &mut R, body: RoutedMessageBody) -> RoutedMessageV2 {

--- a/chain/network/src/network_protocol/testonly.rs
+++ b/chain/network/src/network_protocol/testonly.rs
@@ -332,15 +332,20 @@ impl Chain {
     }
 }
 
-pub fn make_signed_owned_ip_addr(ip_addr: &std::net::IpAddr, secret_key: &near_crypto::SecretKey) -> SignedOwnedIpAddress {
-    let owned_ip_address = OwnedIpAddress {
-        ip_address: ip_addr.clone()
-    };
+pub fn make_signed_owned_ip_addr(
+    ip_addr: &std::net::IpAddr,
+    secret_key: &near_crypto::SecretKey,
+) -> SignedOwnedIpAddress {
+    let owned_ip_address = OwnedIpAddress { ip_address: ip_addr.clone() };
     let signed_owned_ip_address: SignedOwnedIpAddress = owned_ip_address.sign(secret_key);
     return signed_owned_ip_address;
 }
 
-pub fn make_handshake_with_ip<R: Rng>(rng: &mut R, chain: &Chain, ip_addr: Option<std::net::IpAddr>) -> Handshake {
+pub fn make_handshake_with_ip<R: Rng>(
+    rng: &mut R,
+    chain: &Chain,
+    ip_addr: Option<std::net::IpAddr>,
+) -> Handshake {
     let sender = make_signer(rng);
     let target = make_signer(rng);
     let sender_id = PeerId::new(sender.public_key);

--- a/chain/network/src/network_protocol/tests.rs
+++ b/chain/network/src/network_protocol/tests.rs
@@ -219,3 +219,53 @@ fn sign_and_verify_ip_addr_with_peer_id() {
     assert!(signed_owned_ip_address.verify(&node_key.public_key()));
     assert!(signed_owned_ip_address.verify(peer_id.public_key()));
 }
+
+#[test]
+fn serialize_deserialize_owned_ip_address() {
+    let mut rng = make_rng(89028037453);
+    let ip_addr: net::IpAddr = data::make_ipv4(&mut rng);
+    let owned_ip_addr_before_serialize = OwnedIpAddress {
+        ip_address: ip_addr.clone(),
+    };
+
+    // Convert OwnedIpAddress to proto::OwnedIpAddr for protocol buffer serialization
+    let proto_owned_ip_addr_before_serialize: proto::OwnedIpAddr = proto::OwnedIpAddr::from(&owned_ip_addr_before_serialize);
+    // Serialize and deserialize for transporting over the network
+    let owned_ip_addr_bytes: Vec<u8> = proto_owned_ip_addr_before_serialize.write_to_bytes().unwrap();
+    let proto_owned_ip_addr_after_deserialize: proto::OwnedIpAddr = proto::OwnedIpAddr::parse_from_bytes(&owned_ip_addr_bytes).unwrap();
+    assert_eq!(proto_owned_ip_addr_before_serialize,  proto_owned_ip_addr_after_deserialize);
+    // Convert proto::OwnedIpAddr back to OwnedIpAddress to be independent of protocol buffer in near network
+    let result_deserialized_actual_owned_ip_addr = OwnedIpAddress::try_from(&proto_owned_ip_addr_after_deserialize);
+    assert!(result_deserialized_actual_owned_ip_addr.is_ok());
+    let deserialized_actual_owned_ip_addr = result_deserialized_actual_owned_ip_addr.unwrap();
+    assert_eq!(owned_ip_addr_before_serialize, deserialized_actual_owned_ip_addr);
+}
+
+#[test]
+fn serialize_deserialize_signed_owned_ip_address() {
+    let mut rng = make_rng(89028037453);
+    let ip_addr: net::IpAddr = data::make_ipv4(&mut rng);
+    let owned_ip_addr_before_serialize = OwnedIpAddress {
+        ip_address: ip_addr.clone(),
+    };
+    let seed = "123";
+    let node_key = SecretKey::from_seed(KeyType::ED25519, seed);
+    let signed_owned_ip_addr_before_serialize: SignedOwnedIpAddress = owned_ip_addr_before_serialize.sign(&node_key);
+    // Convert SignedOwnedIpAddress to proto::SignedOwnedIpAddr for protocol buffer serialization
+    let proto_signed_owned_ip_addr_before_serialize: proto::SignedOwnedIpAddr = proto::SignedOwnedIpAddr::from(&signed_owned_ip_addr_before_serialize);
+
+    // Serialize and deserialize for transporting over the network
+    let signed_owned_ip_addr_bytes: Vec<u8> = proto_signed_owned_ip_addr_before_serialize.write_to_bytes().unwrap();
+    let proto_signed_owned_ip_addr_after_deserialize: proto::SignedOwnedIpAddr = proto::SignedOwnedIpAddr::parse_from_bytes(&signed_owned_ip_addr_bytes).unwrap();
+    assert_eq!(proto_signed_owned_ip_addr_before_serialize,  proto_signed_owned_ip_addr_after_deserialize);
+    // Convert proto::SignedOwnedIpAddr back to SignedOwnedIpAddress to be independent of protocol buffer in near network
+    let result_deserialized_actual_signed_owned_ip_addr = SignedOwnedIpAddress::try_from(&proto_signed_owned_ip_addr_after_deserialize);
+    assert!(result_deserialized_actual_signed_owned_ip_addr.is_ok());
+    let deserialized_actual_signed_owned_ip_addr = result_deserialized_actual_signed_owned_ip_addr.unwrap();
+    assert_eq!(signed_owned_ip_addr_before_serialize, deserialized_actual_signed_owned_ip_addr);
+
+    // Verify the deserialized works with verification via peer_id
+    let peer_id = PeerId::new(node_key.public_key());
+    assert!(deserialized_actual_signed_owned_ip_addr.verify(&node_key.public_key()));
+    assert!(deserialized_actual_signed_owned_ip_addr.verify(peer_id.public_key()));
+}

--- a/chain/network/src/network_protocol/tests.rs
+++ b/chain/network/src/network_protocol/tests.rs
@@ -183,13 +183,15 @@ fn serialize_deserialize_ip_addr() {
 
     // Convert IpAddr to proto::IpAddr for protocol buffer serialization
     let ip_addr_before_serialize: net::IpAddr = data::make_ipv4(&mut rng);
-    let proto_ip_addr_before_serialize: proto::IpAddr = proto::IpAddr::from(&ip_addr_before_serialize);
+    let proto_ip_addr_before_serialize: proto::IpAddr =
+        proto::IpAddr::from(&ip_addr_before_serialize);
     // Serialize and deserialize for transporting over the network
     let ip_addr_bytes: Vec<u8> = proto_ip_addr_before_serialize.write_to_bytes().unwrap();
     let proto_ip_addr_after_deserialize = proto::IpAddr::parse_from_bytes(&ip_addr_bytes).unwrap();
-    assert_eq!(proto_ip_addr_before_serialize,  proto_ip_addr_after_deserialize);
+    assert_eq!(proto_ip_addr_before_serialize, proto_ip_addr_after_deserialize);
     // Convert proto::IpAddr back to IpAddr to be independent of protocol buffer in near network
-    let result_deserialized_actual_ip_addr = net::IpAddr::try_from(&proto_ip_addr_after_deserialize);
+    let result_deserialized_actual_ip_addr =
+        net::IpAddr::try_from(&proto_ip_addr_after_deserialize);
     assert!(result_deserialized_actual_ip_addr.is_ok());
     let deserialized_actual_ip_addr = result_deserialized_actual_ip_addr.unwrap();
     assert_eq!(ip_addr_before_serialize, deserialized_actual_ip_addr);
@@ -212,9 +214,7 @@ fn sign_and_verify_ip_addr_with_peer_id() {
     assert!(signature.verify(&ip_bytes, peer_id.public_key()));
 
     // Wrap ip address sign and verify algorithm with interfaces: OwnedIpAddress and SignedOwnedIpAddress
-    let owned_ip_address = OwnedIpAddress {
-        ip_address: ip_addr.clone(),
-    };
+    let owned_ip_address = OwnedIpAddress { ip_address: ip_addr.clone() };
     let signed_owned_ip_address: SignedOwnedIpAddress = owned_ip_address.sign(&node_key);
     assert!(signed_owned_ip_address.verify(&node_key.public_key()));
     assert!(signed_owned_ip_address.verify(peer_id.public_key()));
@@ -224,18 +224,20 @@ fn sign_and_verify_ip_addr_with_peer_id() {
 fn serialize_deserialize_owned_ip_address() {
     let mut rng = make_rng(89028037453);
     let ip_addr: net::IpAddr = data::make_ipv4(&mut rng);
-    let owned_ip_addr_before_serialize = OwnedIpAddress {
-        ip_address: ip_addr.clone(),
-    };
+    let owned_ip_addr_before_serialize = OwnedIpAddress { ip_address: ip_addr.clone() };
 
     // Convert OwnedIpAddress to proto::OwnedIpAddr for protocol buffer serialization
-    let proto_owned_ip_addr_before_serialize: proto::OwnedIpAddr = proto::OwnedIpAddr::from(&owned_ip_addr_before_serialize);
+    let proto_owned_ip_addr_before_serialize: proto::OwnedIpAddr =
+        proto::OwnedIpAddr::from(&owned_ip_addr_before_serialize);
     // Serialize and deserialize for transporting over the network
-    let owned_ip_addr_bytes: Vec<u8> = proto_owned_ip_addr_before_serialize.write_to_bytes().unwrap();
-    let proto_owned_ip_addr_after_deserialize: proto::OwnedIpAddr = proto::OwnedIpAddr::parse_from_bytes(&owned_ip_addr_bytes).unwrap();
-    assert_eq!(proto_owned_ip_addr_before_serialize,  proto_owned_ip_addr_after_deserialize);
+    let owned_ip_addr_bytes: Vec<u8> =
+        proto_owned_ip_addr_before_serialize.write_to_bytes().unwrap();
+    let proto_owned_ip_addr_after_deserialize: proto::OwnedIpAddr =
+        proto::OwnedIpAddr::parse_from_bytes(&owned_ip_addr_bytes).unwrap();
+    assert_eq!(proto_owned_ip_addr_before_serialize, proto_owned_ip_addr_after_deserialize);
     // Convert proto::OwnedIpAddr back to OwnedIpAddress to be independent of protocol buffer in near network
-    let result_deserialized_actual_owned_ip_addr = OwnedIpAddress::try_from(&proto_owned_ip_addr_after_deserialize);
+    let result_deserialized_actual_owned_ip_addr =
+        OwnedIpAddress::try_from(&proto_owned_ip_addr_after_deserialize);
     assert!(result_deserialized_actual_owned_ip_addr.is_ok());
     let deserialized_actual_owned_ip_addr = result_deserialized_actual_owned_ip_addr.unwrap();
     assert_eq!(owned_ip_addr_before_serialize, deserialized_actual_owned_ip_addr);
@@ -245,23 +247,30 @@ fn serialize_deserialize_owned_ip_address() {
 fn serialize_deserialize_signed_owned_ip_address() {
     let mut rng = make_rng(89028037453);
     let ip_addr: net::IpAddr = data::make_ipv4(&mut rng);
-    let owned_ip_addr_before_serialize = OwnedIpAddress {
-        ip_address: ip_addr.clone(),
-    };
+    let owned_ip_addr_before_serialize = OwnedIpAddress { ip_address: ip_addr.clone() };
     let seed = "123";
     let node_key = SecretKey::from_seed(KeyType::ED25519, seed);
-    let signed_owned_ip_addr_before_serialize: SignedOwnedIpAddress = owned_ip_addr_before_serialize.sign(&node_key);
+    let signed_owned_ip_addr_before_serialize: SignedOwnedIpAddress =
+        owned_ip_addr_before_serialize.sign(&node_key);
     // Convert SignedOwnedIpAddress to proto::SignedOwnedIpAddr for protocol buffer serialization
-    let proto_signed_owned_ip_addr_before_serialize: proto::SignedOwnedIpAddr = proto::SignedOwnedIpAddr::from(&signed_owned_ip_addr_before_serialize);
+    let proto_signed_owned_ip_addr_before_serialize: proto::SignedOwnedIpAddr =
+        proto::SignedOwnedIpAddr::from(&signed_owned_ip_addr_before_serialize);
 
     // Serialize and deserialize for transporting over the network
-    let signed_owned_ip_addr_bytes: Vec<u8> = proto_signed_owned_ip_addr_before_serialize.write_to_bytes().unwrap();
-    let proto_signed_owned_ip_addr_after_deserialize: proto::SignedOwnedIpAddr = proto::SignedOwnedIpAddr::parse_from_bytes(&signed_owned_ip_addr_bytes).unwrap();
-    assert_eq!(proto_signed_owned_ip_addr_before_serialize,  proto_signed_owned_ip_addr_after_deserialize);
+    let signed_owned_ip_addr_bytes: Vec<u8> =
+        proto_signed_owned_ip_addr_before_serialize.write_to_bytes().unwrap();
+    let proto_signed_owned_ip_addr_after_deserialize: proto::SignedOwnedIpAddr =
+        proto::SignedOwnedIpAddr::parse_from_bytes(&signed_owned_ip_addr_bytes).unwrap();
+    assert_eq!(
+        proto_signed_owned_ip_addr_before_serialize,
+        proto_signed_owned_ip_addr_after_deserialize
+    );
     // Convert proto::SignedOwnedIpAddr back to SignedOwnedIpAddress to be independent of protocol buffer in near network
-    let result_deserialized_actual_signed_owned_ip_addr = SignedOwnedIpAddress::try_from(&proto_signed_owned_ip_addr_after_deserialize);
+    let result_deserialized_actual_signed_owned_ip_addr =
+        SignedOwnedIpAddress::try_from(&proto_signed_owned_ip_addr_after_deserialize);
     assert!(result_deserialized_actual_signed_owned_ip_addr.is_ok());
-    let deserialized_actual_signed_owned_ip_addr = result_deserialized_actual_signed_owned_ip_addr.unwrap();
+    let deserialized_actual_signed_owned_ip_addr =
+        result_deserialized_actual_signed_owned_ip_addr.unwrap();
     assert_eq!(signed_owned_ip_addr_before_serialize, deserialized_actual_signed_owned_ip_addr);
 
     // Verify the deserialized works with verification via peer_id

--- a/chain/network/src/network_protocol/tests.rs
+++ b/chain/network/src/network_protocol/tests.rs
@@ -214,7 +214,7 @@ fn sign_and_verify_ip_addr_with_peer_id() {
     assert!(signature.verify(&ip_bytes, peer_id.public_key()));
 
     // Wrap ip address sign and verify algorithm with interfaces: OwnedIpAddress and SignedOwnedIpAddress
-    let owned_ip_address = OwnedIpAddress { ip_address: ip_addr.clone() };
+    let owned_ip_address = OwnedIpAddress { ip_address: ip_addr };
     let signed_owned_ip_address: SignedOwnedIpAddress = owned_ip_address.sign(&node_key);
     assert!(signed_owned_ip_address.verify(&node_key.public_key()));
     assert!(signed_owned_ip_address.verify(peer_id.public_key()));
@@ -224,7 +224,7 @@ fn sign_and_verify_ip_addr_with_peer_id() {
 fn serialize_deserialize_owned_ip_address() {
     let mut rng = make_rng(89028037453);
     let ip_addr: net::IpAddr = data::make_ipv4(&mut rng);
-    let owned_ip_addr_before_serialize = OwnedIpAddress { ip_address: ip_addr.clone() };
+    let owned_ip_addr_before_serialize = OwnedIpAddress { ip_address: ip_addr };
 
     // Convert OwnedIpAddress to proto::OwnedIpAddr for protocol buffer serialization
     let proto_owned_ip_addr_before_serialize: proto::OwnedIpAddr =
@@ -247,7 +247,7 @@ fn serialize_deserialize_owned_ip_address() {
 fn serialize_deserialize_signed_owned_ip_address() {
     let mut rng = make_rng(89028037453);
     let ip_addr: net::IpAddr = data::make_ipv4(&mut rng);
-    let owned_ip_addr_before_serialize = OwnedIpAddress { ip_address: ip_addr.clone() };
+    let owned_ip_addr_before_serialize = OwnedIpAddress { ip_address: ip_addr };
     let seed = "123";
     let node_key = SecretKey::from_seed(KeyType::ED25519, seed);
     let signed_owned_ip_addr_before_serialize: SignedOwnedIpAddress =

--- a/chain/network/src/network_protocol/tests.rs
+++ b/chain/network/src/network_protocol/tests.rs
@@ -62,8 +62,11 @@ fn serialize_deserialize_protobuf_only() {
     let mut rng = make_rng(39521947542);
     let mut clock = time::FakeClock::default();
     let chain = data::Chain::make(&mut clock, &mut rng, 12);
+    let ip_addr: net::IpAddr = data::make_ipv4(&mut rng);
     let msgs = [
-        PeerMessage::Tier1Handshake(data::make_handshake(&mut rng, &chain)),
+        PeerMessage::Tier1Handshake(data::make_handshake_with_ip(&mut rng, &chain, Some(ip_addr))), // with ip address
+        PeerMessage::Tier1Handshake(data::make_handshake(&mut rng, &chain)), // without ip address, temporarily supported for backwards compatibility migration
+        PeerMessage::Tier2Handshake(data::make_handshake_with_ip(&mut rng, &chain, Some(ip_addr))), // Tier2 Handshake does not maintain ip address with borsh serialization
         PeerMessage::SyncAccountsData(SyncAccountsData {
             accounts_data: (0..4)
                 .map(|_| Arc::new(data::make_signed_account_data(&mut rng, &clock.clock())))
@@ -108,7 +111,7 @@ fn serialize_deserialize() -> anyhow::Result<()> {
         }),
     ));
     let msgs = [
-        PeerMessage::Tier2Handshake(data::make_handshake(&mut rng, &chain)),
+        PeerMessage::Tier2Handshake(data::make_handshake(&mut rng, &chain)), // without ip address, temporarily supported for backwards compatibility migration
         PeerMessage::HandshakeFailure(
             data::make_peer_info(&mut rng),
             HandshakeFailureReason::InvalidTarget,

--- a/chain/network/src/network_protocol/tests.rs
+++ b/chain/network/src/network_protocol/tests.rs
@@ -183,9 +183,8 @@ fn sign_and_verify_with_signed_ip_address_interface() {
     let peer_id = PeerId::new(node_key.public_key());
     let mut rng = make_rng(89028037453);
     let ip_addr: net::IpAddr = data::make_ipv4(&mut rng);
-    // Wrap ip address sign and verify algorithm with interfaces: OwnedIpAddress and SignedIpAddress
-    let owned_ip_address = OwnedIpAddress { ip_address: ip_addr };
-    let signed_ip_address: SignedIpAddress = owned_ip_address.sign(&node_key);
+    // Wrap ip address sign and verify algorithm with interfaces SignedIpAddress
+    let signed_ip_address: SignedIpAddress = SignedIpAddress::new(ip_addr, &node_key);
     assert!(signed_ip_address.verify(&node_key.public_key()));
     assert!(signed_ip_address.verify(peer_id.public_key()));
 }

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -442,6 +442,7 @@ impl PeerActor {
                 }
                 .sign(vc.signer.as_ref())
             }),
+            owned_ip_address: self.my_node_info.addr.map(|addr| addr.ip()),
         };
         let msg = match spec.tier {
             tcp::Tier::T1 => PeerMessage::Tier1Handshake(handshake),

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -424,10 +424,9 @@ impl PeerActor {
             } else {
                 (0, vec![])
             };
-            let owned_ip_address = OwnedIpAddress {
-                ip_address: self.my_node_info.addr.unwrap().ip()
-            };
-            let my_signed_owned_ip_address: SignedOwnedIpAddress = owned_ip_address.sign(&self.network_state.config.node_key);
+        let owned_ip_address = OwnedIpAddress { ip_address: self.my_node_info.addr.unwrap().ip() };
+        let my_signed_owned_ip_address: SignedOwnedIpAddress =
+            owned_ip_address.sign(&self.network_state.config.node_key);
         let handshake = Handshake {
             protocol_version: spec.protocol_version,
             oldest_supported_version: PEER_MIN_ALLOWED_PROTOCOL_VERSION,
@@ -586,7 +585,7 @@ impl PeerActor {
                 return;
             }
         } // else do nothing as temporary leniency for backward compatibility purposes
-        // TODO(soon): Fail the handshake if its doesn't include the required signed_owned_ip_address after all production nodes have upgraded to latest handshake protocol
+          // TODO(soon): Fail the handshake if its doesn't include the required signed_owned_ip_address after all production nodes have upgraded to latest handshake protocol
 
         // Verify that handshake.owned_account is valid.
         if let Some(owned_account) = &handshake.owned_account {

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -442,7 +442,7 @@ impl PeerActor {
                 }
                 .sign(vc.signer.as_ref())
             }),
-            owned_ip_address: self.my_node_info.addr.map(|addr| addr.ip()),
+            signed_owned_ip_address: Some(self.network_state.config.signed_owned_ip_address()),
         };
         let msg = match spec.tier {
             tcp::Tier::T1 => PeerMessage::Tier1Handshake(handshake),

--- a/chain/network/src/peer/tests/communication.rs
+++ b/chain/network/src/peer/tests/communication.rs
@@ -200,7 +200,8 @@ async fn test_handshake(outbound_encoding: Option<Encoding>, inbound_encoding: O
     let outbound_port = outbound_stream.local_addr.port();
     let mut outbound = Stream::new(outbound_encoding, outbound_stream);
     let ip_addr = outbound.stream.local_addr.ip();
-    let signed_owned_ip_address = make_signed_owned_ip_addr(&ip_addr, &outbound_cfg.network.node_key);
+    let signed_owned_ip_address =
+        make_signed_owned_ip_addr(&ip_addr, &outbound_cfg.network.node_key);
 
     // Send too old PROTOCOL_VERSION, expect ProtocolVersionMismatch
     let mut handshake = Handshake {
@@ -251,7 +252,10 @@ async fn test_handshake(outbound_encoding: Option<Encoding>, inbound_encoding: O
     assert_matches!(resp, PeerMessage::Tier2Handshake(_));
 }
 
-async fn test_backward_compatible_handshake_without_signed_ip_address(outbound_encoding: Option<Encoding>, inbound_encoding: Option<Encoding>) {
+async fn test_backward_compatible_handshake_without_signed_ip_address(
+    outbound_encoding: Option<Encoding>,
+    inbound_encoding: Option<Encoding>,
+) {
     let mut rng = make_rng(89028037453);
     let mut clock = time::FakeClock::default();
 

--- a/chain/network/src/peer/tests/communication.rs
+++ b/chain/network/src/peer/tests/communication.rs
@@ -210,6 +210,7 @@ async fn test_handshake(outbound_encoding: Option<Encoding>, inbound_encoding: O
         sender_chain_info: outbound_cfg.chain.get_peer_chain_info(),
         partial_edge_info: outbound_cfg.partial_edge_info(&inbound.cfg.id(), 1),
         owned_account: None,
+        owned_ip_address: Some(outbound.stream.local_addr.ip()),
     };
     // We will also introduce chain_id mismatch, but ProtocolVersionMismatch is expected to take priority.
     handshake.sender_chain_info.genesis_id.chain_id = "unknown_chain".to_string();

--- a/chain/network/src/peer_manager/tests/connection_pool.rs
+++ b/chain/network/src/peer_manager/tests/connection_pool.rs
@@ -11,11 +11,11 @@ use crate::private_actix::RegisterPeerError;
 use crate::tcp;
 use crate::testonly::make_rng;
 use crate::testonly::stream::Stream;
+use crate::types::ReasonForBan;
 use near_async::time;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::version::PROTOCOL_VERSION;
 use std::sync::Arc;
-use crate::types::ReasonForBan;
 
 #[tokio::test]
 async fn connection_spam_security_test() {
@@ -321,7 +321,11 @@ async fn invalid_edge() {
     }
 }
 
-async fn test_signed_owned_ip_address(expected_closing_reason: ClosingReason, wrong_ip_address: &Option<std::net::IpAddr>, wrong_node_key: &Option<near_crypto::SecretKey>) {
+async fn test_signed_owned_ip_address(
+    expected_closing_reason: ClosingReason,
+    wrong_ip_address: &Option<std::net::IpAddr>,
+    wrong_node_key: &Option<near_crypto::SecretKey>,
+) {
     init_test_logger();
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
@@ -386,10 +390,9 @@ async fn test_signed_owned_ip_address(expected_closing_reason: ClosingReason, wr
                 Event::PeerManager(PME::ConnectionClosed(ev)) if ev.stream_id == stream_id => {
                     Some(ev.reason)
                 }
-                Event::PeerManager(PME::HandshakeCompleted(ev))
-                    if ev.stream_id == stream_id => {
-                        panic!("PeerManager accepted the handshake")
-                    }
+                Event::PeerManager(PME::HandshakeCompleted(ev)) if ev.stream_id == stream_id => {
+                    panic!("PeerManager accepted the handshake")
+                }
                 _ => None,
             })
             .await;

--- a/chain/network/src/peer_manager/tests/connection_pool.rs
+++ b/chain/network/src/peer_manager/tests/connection_pool.rs
@@ -1,4 +1,4 @@
-use crate::network_protocol::testonly::{self as data, make_signed_owned_ip_addr};
+use crate::network_protocol::testonly::{self as data, make_signed_ip_addr};
 use crate::network_protocol::PeerMessage;
 use crate::network_protocol::{Encoding, Handshake, OwnedAccount, PartialEdgeInfo};
 use crate::peer::peer_actor::ClosingReason;
@@ -90,7 +90,7 @@ async fn loop_connection() {
     let mut events = pm.events.from_now();
     let mut stream = Stream::new(Some(Encoding::Proto), stream);
     let ip_addr = stream.stream.local_addr.ip();
-    let signed_owned_ip_address = make_signed_owned_ip_addr(&ip_addr, &cfg.node_key);
+    let signed_ip_address = make_signed_ip_addr(&ip_addr, &cfg.node_key);
     stream
         .write(&PeerMessage::Tier2Handshake(Handshake {
             protocol_version: PROTOCOL_VERSION,
@@ -106,7 +106,7 @@ async fn loop_connection() {
                 &pm.cfg.node_key,
             ),
             owned_account: None,
-            signed_owned_ip_address: Some(signed_owned_ip_address),
+            signed_ip_address: Some(signed_ip_address),
         }))
         .await;
     let reason = events
@@ -153,7 +153,7 @@ async fn owned_account_mismatch() {
     let cfg = chain.make_config(rng);
     let vc = cfg.validator.clone().unwrap();
     let ip_addr = stream.stream.local_addr.ip();
-    let signed_owned_ip_address = make_signed_owned_ip_addr(&ip_addr, &cfg.node_key);
+    let signed_ip_address = make_signed_ip_addr(&ip_addr, &cfg.node_key);
     stream
         .write(&PeerMessage::Tier2Handshake(Handshake {
             protocol_version: PROTOCOL_VERSION,
@@ -177,7 +177,7 @@ async fn owned_account_mismatch() {
                 }
                 .sign(vc.signer.as_ref()),
             ),
-            signed_owned_ip_address: Some(signed_owned_ip_address),
+            signed_ip_address: Some(signed_ip_address),
         }))
         .await;
     let reason = events
@@ -275,7 +275,7 @@ async fn invalid_edge() {
             let mut events = pm.events.from_now();
             let mut stream = Stream::new(Some(Encoding::Proto), stream);
             let ip_addr = stream.stream.local_addr.ip();
-            let signed_owned_ip_address = make_signed_owned_ip_addr(&ip_addr, &cfg.node_key);
+            let signed_ip_address = make_signed_ip_addr(&ip_addr, &cfg.node_key);
             let vc = cfg.validator.clone().unwrap();
             let handshake = Handshake {
                 protocol_version: PROTOCOL_VERSION,
@@ -293,7 +293,7 @@ async fn invalid_edge() {
                     }
                     .sign(vc.signer.as_ref()),
                 ),
-                signed_owned_ip_address: Some(signed_owned_ip_address),
+                signed_ip_address: Some(signed_ip_address),
             };
             let handshake = match tier {
                 tcp::Tier::T1 => PeerMessage::Tier1Handshake(handshake),
@@ -321,7 +321,7 @@ async fn invalid_edge() {
     }
 }
 
-async fn test_signed_owned_ip_address(
+async fn test_signed_ip_address(
     expected_closing_reason: ClosingReason,
     wrong_ip_address: &Option<std::net::IpAddr>,
     wrong_node_key: &Option<near_crypto::SecretKey>,
@@ -331,6 +331,7 @@ async fn test_signed_owned_ip_address(
     let rng = &mut rng;
     let mut clock = time::FakeClock::default();
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
+
     let pm = peer_manager::testonly::start(
         clock.clock(),
         near_store::db::TestDB::new(),
@@ -338,25 +339,28 @@ async fn test_signed_owned_ip_address(
         chain.clone(),
     )
     .await;
-
     let cfg = chain.make_config(rng);
+
     for tier in [tcp::Tier::T1, tcp::Tier::T2] {
         let stream = tcp::Stream::connect(&pm.peer_info(), tier).await.unwrap();
         let stream_id = stream.id();
         let port = stream.local_addr.port();
         let mut events = pm.events.from_now();
         let mut stream = Stream::new(Some(Encoding::Proto), stream);
+
         let ip_addr = match *wrong_ip_address {
             Some(wrong_ip_address) => wrong_ip_address,
             None => stream.stream.local_addr.ip(),
         };
+
         let wrong_node_key = wrong_node_key.clone();
         let node_key = match wrong_node_key {
             Some(wrong_node_key) => wrong_node_key,
             None => cfg.node_key.clone(),
         };
-        let signed_owned_ip_address = make_signed_owned_ip_addr(&ip_addr, &node_key);
+        let signed_ip_address = make_signed_ip_addr(&ip_addr, &node_key);
         let vc = cfg.validator.clone().unwrap();
+
         let handshake = Handshake {
             protocol_version: PROTOCOL_VERSION,
             oldest_supported_version: PROTOCOL_VERSION,
@@ -378,13 +382,16 @@ async fn test_signed_owned_ip_address(
                 }
                 .sign(vc.signer.as_ref()),
             ),
-            signed_owned_ip_address: Some(signed_owned_ip_address),
+            signed_ip_address: Some(signed_ip_address),
         };
+
         let handshake = match tier {
             tcp::Tier::T1 => PeerMessage::Tier1Handshake(handshake),
             tcp::Tier::T2 => PeerMessage::Tier2Handshake(handshake),
         };
+
         stream.write(&handshake).await;
+
         let reason: ClosingReason = events
             .recv_until(|ev| match ev {
                 Event::PeerManager(PME::ConnectionClosed(ev)) if ev.stream_id == stream_id => {
@@ -403,13 +410,13 @@ async fn test_signed_owned_ip_address(
 #[tokio::test]
 async fn signed_with_wrong_ip_address() {
     let wrong_ip_address: std::net::IpAddr = data::make_ipv4(&mut make_rng(89028037453));
-    let expected_closing_reason = ClosingReason::SignedOwnedIpAddressIpAddressMismatch;
-    test_signed_owned_ip_address(expected_closing_reason, &Some(wrong_ip_address), &None).await;
+    let expected_closing_reason = ClosingReason::IpAddressMismatch;
+    test_signed_ip_address(expected_closing_reason, &Some(wrong_ip_address), &None).await;
 }
 
 #[tokio::test]
 async fn signed_with_wrong_key() {
     let wrong_node_key = near_crypto::SecretKey::from_seed(near_crypto::KeyType::ED25519, "123");
     let expected_closing_reason = ClosingReason::Ban(ReasonForBan::InvalidSignature);
-    test_signed_owned_ip_address(expected_closing_reason, &None, &Some(wrong_node_key)).await;
+    test_signed_ip_address(expected_closing_reason, &None, &Some(wrong_node_key)).await;
 }

--- a/chain/network/src/peer_manager/tests/connection_pool.rs
+++ b/chain/network/src/peer_manager/tests/connection_pool.rs
@@ -103,6 +103,7 @@ async fn loop_connection() {
                 &pm.cfg.node_key,
             ),
             owned_account: None,
+            owned_ip_address: Some(stream.stream.local_addr.ip()),
         }))
         .await;
     let reason = events
@@ -171,6 +172,7 @@ async fn owned_account_mismatch() {
                 }
                 .sign(vc.signer.as_ref()),
             ),
+            owned_ip_address: Some(stream.stream.local_addr.ip()),
         }))
         .await;
     let reason = events
@@ -284,6 +286,7 @@ async fn invalid_edge() {
                     }
                     .sign(vc.signer.as_ref()),
                 ),
+                owned_ip_address: Some(stream.stream.local_addr.ip()),
             };
             let handshake = match tier {
                 tcp::Tier::T1 => PeerMessage::Tier1Handshake(handshake),

--- a/chain/network/src/peer_manager/tests/nonce.rs
+++ b/chain/network/src/peer_manager/tests/nonce.rs
@@ -1,4 +1,4 @@
-use crate::network_protocol::testonly as data;
+use crate::network_protocol::testonly::{self as data, make_signed_owned_ip_addr};
 use crate::network_protocol::{
     Encoding, Handshake, PartialEdgeInfo, PeerMessage, EDGE_MIN_TIMESTAMP_NONCE,
 };
@@ -64,6 +64,8 @@ async fn test_nonces() {
         let mut stream = stream::Stream::new(Some(Encoding::Proto), stream);
         let peer_key = data::make_secret_key(rng);
         let peer_id = PeerId::new(peer_key.public_key());
+        let ip_addr = stream.stream.local_addr.ip();
+        let signed_owned_ip_address = make_signed_owned_ip_addr(&ip_addr, &peer_key);
         let handshake = PeerMessage::Tier2Handshake(Handshake {
             protocol_version: version::PROTOCOL_VERSION,
             oldest_supported_version: version::PEER_MIN_ALLOWED_PROTOCOL_VERSION,
@@ -75,7 +77,7 @@ async fn test_nonces() {
             sender_chain_info: chain.get_peer_chain_info(),
             partial_edge_info: PartialEdgeInfo::new(&peer_id, &pm.cfg.node_id(), test.0, &peer_key),
             owned_account: None,
-            owned_ip_address: Some(stream.stream.local_addr.ip()),
+            signed_owned_ip_address: Some(signed_owned_ip_address),
         });
         stream.write(&handshake).await;
         if test.1 {

--- a/chain/network/src/peer_manager/tests/nonce.rs
+++ b/chain/network/src/peer_manager/tests/nonce.rs
@@ -75,6 +75,7 @@ async fn test_nonces() {
             sender_chain_info: chain.get_peer_chain_info(),
             partial_edge_info: PartialEdgeInfo::new(&peer_id, &pm.cfg.node_id(), test.0, &peer_key),
             owned_account: None,
+            owned_ip_address: Some(stream.stream.local_addr.ip()),
         });
         stream.write(&handshake).await;
         if test.1 {

--- a/chain/network/src/peer_manager/tests/nonce.rs
+++ b/chain/network/src/peer_manager/tests/nonce.rs
@@ -1,4 +1,4 @@
-use crate::network_protocol::testonly::{self as data, make_signed_owned_ip_addr};
+use crate::network_protocol::testonly::{self as data, make_signed_ip_addr};
 use crate::network_protocol::{
     Encoding, Handshake, PartialEdgeInfo, PeerMessage, EDGE_MIN_TIMESTAMP_NONCE,
 };
@@ -65,7 +65,7 @@ async fn test_nonces() {
         let peer_key = data::make_secret_key(rng);
         let peer_id = PeerId::new(peer_key.public_key());
         let ip_addr = stream.stream.local_addr.ip();
-        let signed_owned_ip_address = make_signed_owned_ip_addr(&ip_addr, &peer_key);
+        let signed_ip_address = make_signed_ip_addr(&ip_addr, &peer_key);
         let handshake = PeerMessage::Tier2Handshake(Handshake {
             protocol_version: version::PROTOCOL_VERSION,
             oldest_supported_version: version::PEER_MIN_ALLOWED_PROTOCOL_VERSION,
@@ -77,7 +77,7 @@ async fn test_nonces() {
             sender_chain_info: chain.get_peer_chain_info(),
             partial_edge_info: PartialEdgeInfo::new(&peer_id, &pm.cfg.node_id(), test.0, &peer_key),
             owned_account: None,
-            signed_owned_ip_address: Some(signed_owned_ip_address),
+            signed_ip_address: Some(signed_ip_address),
         });
         stream.write(&handshake).await;
         if test.1 {

--- a/chain/network/src/raw/connection.rs
+++ b/chain/network/src/raw/connection.rs
@@ -210,6 +210,7 @@ fn new_handshake(
         },
         partial_edge_info: PartialEdgeInfo::new(my_peer_id, target_peer_id, nonce, secret_key),
         owned_account: None,
+        owned_ip_address: None,
     })
 }
 

--- a/chain/network/src/raw/connection.rs
+++ b/chain/network/src/raw/connection.rs
@@ -210,7 +210,7 @@ fn new_handshake(
         },
         partial_edge_info: PartialEdgeInfo::new(my_peer_id, target_peer_id, nonce, secret_key),
         owned_account: None,
-        owned_ip_address: None,
+        signed_owned_ip_address: None,
     })
 }
 

--- a/chain/network/src/raw/connection.rs
+++ b/chain/network/src/raw/connection.rs
@@ -210,7 +210,7 @@ fn new_handshake(
         },
         partial_edge_info: PartialEdgeInfo::new(my_peer_id, target_peer_id, nonce, secret_key),
         owned_account: None,
-        signed_owned_ip_address: None,
+        signed_ip_address: None,
     })
 }
 

--- a/chain/network/src/testonly/stream.rs
+++ b/chain/network/src/testonly/stream.rs
@@ -7,7 +7,7 @@ use crate::network_protocol::{Encoding, PeerMessage};
 use crate::tcp;
 
 pub struct Stream {
-    stream: tcp::Stream,
+    pub stream: tcp::Stream,
     force_encoding: Option<Encoding>,
     protocol_buffers_supported: bool,
 }

--- a/chain/network/src/testonly/stream.rs
+++ b/chain/network/src/testonly/stream.rs
@@ -7,7 +7,7 @@ use crate::network_protocol::{Encoding, PeerMessage};
 use crate::tcp;
 
 pub struct Stream {
-    pub stream: tcp::Stream,
+    pub(crate) stream: tcp::Stream,
     force_encoding: Option<Encoding>,
     protocol_buffers_supported: bool,
 }

--- a/core/chain-configs/src/genesis_config.rs
+++ b/core/chain-configs/src/genesis_config.rs
@@ -476,18 +476,18 @@ impl Genesis {
 
         let mut json_str = String::new();
         file.read_to_string(&mut json_str).map_err(|_| ValidationError::GenesisFileError {
-            error_message: format!("Failed to read genesis config file to string. "),
+            error_message: "Failed to read genesis config file to string. ".to_string(),
         })?;
 
         let json_str_without_comments = near_config_utils::strip_comments_from_json_str(&json_str)
             .map_err(|_| ValidationError::GenesisFileError {
-                error_message: format!("Failed to strip comments from genesis config file"),
+                error_message: "Failed to strip comments from genesis config file".to_string(),
             })?;
 
         let genesis =
             serde_json::from_str::<Genesis>(&json_str_without_comments).map_err(|_| {
                 ValidationError::GenesisFileError {
-                    error_message: format!("Failed to deserialize the genesis records."),
+                    error_message: "Failed to deserialize the genesis records.".to_string(),
                 }
             })?;
 

--- a/core/chain-configs/src/genesis_validate.rs
+++ b/core/chain-configs/src/genesis_validate.rs
@@ -81,7 +81,7 @@ impl<'a> GenesisValidator<'a> {
             .into_iter()
             .map(|account_info| {
                 if !is_valid_staking_key(&account_info.public_key) {
-                    let error_message = format!("validator staking key is not valid");
+                    let error_message = "validator staking key is not valid".to_string();
                     self.validation_errors.push_genesis_semantics_error(error_message);
                 }
                 (account_info.account_id, account_info.amount)
@@ -94,7 +94,7 @@ impl<'a> GenesisValidator<'a> {
         }
 
         if validators.is_empty() {
-            let error_message = format!("No validators in genesis");
+            let error_message = "No validators in genesis".to_string();
             self.validation_errors.push_genesis_semantics_error(error_message)
         }
 
@@ -104,7 +104,7 @@ impl<'a> GenesisValidator<'a> {
         }
 
         if validators != self.staked_accounts {
-            let error_message = format!("Validator accounts do not match staked accounts.");
+            let error_message = "Validator accounts do not match staked accounts.".to_string();
             self.validation_errors.push_genesis_semantics_error(error_message)
         }
 
@@ -140,25 +140,25 @@ impl<'a> GenesisValidator<'a> {
 
         if *self.genesis_config.online_max_threshold.numer() >= 10_000_000 {
             let error_message =
-                format!("online_max_threshold's numerator is too large, may lead to overflow.");
+                "online_max_threshold's numerator is too large, may lead to overflow.".to_string();
             self.validation_errors.push_genesis_semantics_error(error_message)
         }
 
         if *self.genesis_config.online_min_threshold.numer() >= 10_000_000 {
             let error_message =
-                format!("online_min_threshold's numerator is too large, may lead to overflow.");
+                "online_min_threshold's numerator is too large, may lead to overflow.".to_string();
             self.validation_errors.push_genesis_semantics_error(error_message)
         }
 
         if *self.genesis_config.online_max_threshold.denom() >= 10_000_000 {
             let error_message =
-                format!("online_max_threshold's denominator is too large, may lead to overflow.");
+                "online_max_threshold's denominator is too large, may lead to overflow.".to_string();
             self.validation_errors.push_genesis_semantics_error(error_message)
         }
 
         if *self.genesis_config.online_min_threshold.denom() >= 10_000_000 {
             let error_message =
-                format!("online_min_threshold's denominator is too large, may lead to overflow.");
+                "online_min_threshold's denominator is too large, may lead to overflow.".to_string();
             self.validation_errors.push_genesis_semantics_error(error_message)
         }
 
@@ -171,7 +171,7 @@ impl<'a> GenesisValidator<'a> {
         }
 
         if self.genesis_config.epoch_length == 0 {
-            let error_message = format!("Epoch Length must be greater than 0");
+            let error_message = "Epoch Length must be greater than 0".to_string();
             self.validation_errors.push_genesis_semantics_error(error_message)
         }
     }

--- a/core/chain-configs/src/genesis_validate.rs
+++ b/core/chain-configs/src/genesis_validate.rs
@@ -152,13 +152,15 @@ impl<'a> GenesisValidator<'a> {
 
         if *self.genesis_config.online_max_threshold.denom() >= 10_000_000 {
             let error_message =
-                "online_max_threshold's denominator is too large, may lead to overflow.".to_string();
+                "online_max_threshold's denominator is too large, may lead to overflow."
+                    .to_string();
             self.validation_errors.push_genesis_semantics_error(error_message)
         }
 
         if *self.genesis_config.online_min_threshold.denom() >= 10_000_000 {
             let error_message =
-                "online_min_threshold's denominator is too large, may lead to overflow.".to_string();
+                "online_min_threshold's denominator is too large, may lead to overflow."
+                    .to_string();
             self.validation_errors.push_genesis_semantics_error(error_message)
         }
 

--- a/nearcore/src/config_validate.rs
+++ b/nearcore/src/config_validate.rs
@@ -84,7 +84,7 @@ impl<'a> ConfigValidator<'a> {
                 if let Some(restart_dump_for_shards) = &dump_config.restart_dump_for_shards {
                     let unique_values: HashSet<_> = restart_dump_for_shards.iter().collect();
                     if unique_values.len() != restart_dump_for_shards.len() {
-                        let error_message = format!("'config.state_sync.dump.restart_dump_for_shards' contains duplicate values.");
+                        let error_message = "'config.state_sync.dump.restart_dump_for_shards' contains duplicate values.".to_string();
                         self.validation_errors.push_config_semantics_error(error_message);
                     }
                 }
@@ -92,13 +92,13 @@ impl<'a> ConfigValidator<'a> {
                 match &dump_config.location {
                     ExternalStorageLocation::S3 { bucket, region } => {
                         if bucket.is_empty() || region.is_empty() {
-                            let error_message = format!("'config.state_sync.dump.location.S3.bucket' and 'config.state_sync.dump.location.S3.region' need to be specified when 'config.state_sync.dump.location.S3' is present.");
+                            let error_message = "'config.state_sync.dump.location.S3.bucket' and 'config.state_sync.dump.location.S3.region' need to be specified when 'config.state_sync.dump.location.S3' is present.".to_string();
                             self.validation_errors.push_config_semantics_error(error_message);
                         }
                     }
                     ExternalStorageLocation::Filesystem { root_dir } => {
                         if root_dir.as_path() == Path::new("") {
-                            let error_message = format!("'config.state_sync.dump.location.Filesystem.root_dir' needs to be specified when 'config.state_sync.dump.location.Filesystem' is present.");
+                            let error_message = "'config.state_sync.dump.location.Filesystem.root_dir' needs to be specified when 'config.state_sync.dump.location.Filesystem' is present.".to_string();
                             self.validation_errors.push_config_semantics_error(error_message);
                         }
                     }
@@ -110,19 +110,19 @@ impl<'a> ConfigValidator<'a> {
                     match &config.location {
                         ExternalStorageLocation::S3 { bucket, region } => {
                             if bucket.is_empty() || region.is_empty() {
-                                let error_message = format!("'config.state_sync.sync.ExternalStorage.location.S3.bucket' and 'config.state_sync.sync.ExternalStorage.location.S3.region' need to be specified when 'config.state_sync.sync.ExternalStorage.location.S3' is present.");
+                                let error_message = "'config.state_sync.sync.ExternalStorage.location.S3.bucket' and 'config.state_sync.sync.ExternalStorage.location.S3.region' need to be specified when 'config.state_sync.sync.ExternalStorage.location.S3' is present.".to_string();
                                 self.validation_errors.push_config_semantics_error(error_message);
                             }
                         }
                         ExternalStorageLocation::Filesystem { root_dir } => {
                             if root_dir.as_path() == Path::new("") {
-                                let error_message = format!("'config.state_sync.sync.ExternalStorage.location.Filesystem.root_dir' needs to be specified when 'config.state_sync.sync.ExternalStorage.location.Filesystem' is present.");
+                                let error_message = "'config.state_sync.sync.ExternalStorage.location.Filesystem.root_dir' needs to be specified when 'config.state_sync.sync.ExternalStorage.location.Filesystem' is present.".to_string();
                                 self.validation_errors.push_config_semantics_error(error_message);
                             }
                         }
                     }
                     if config.num_concurrent_requests == 0 {
-                        let error_message = format!("'config.state_sync.sync.ExternalStorage.num_concurrent_requests' needs to be greater than 0");
+                        let error_message = "'config.state_sync.sync.ExternalStorage.num_concurrent_requests' needs to be greater than 0".to_string();
                         self.validation_errors.push_config_semantics_error(error_message);
                     }
                 }

--- a/nearcore/src/state_sync.rs
+++ b/nearcore/src/state_sync.rs
@@ -287,7 +287,9 @@ async fn state_sync_dump(
                         match missing_parts {
                             Err(err) => {
                                 tracing::debug!(target: "state_sync_dump", shard_id, ?err, "get_missing_state_parts_for_epoch error");
-                                Err(Error::Other("get_missing_state_parts_for_epoch failed".to_string()))
+                                Err(Error::Other(
+                                    "get_missing_state_parts_for_epoch failed".to_string(),
+                                ))
                             }
                             Ok(parts_not_dumped) if parts_not_dumped.is_empty() => {
                                 Ok(Some(StateSyncDumpProgress::AllDumped {

--- a/nearcore/src/state_sync.rs
+++ b/nearcore/src/state_sync.rs
@@ -287,9 +287,7 @@ async fn state_sync_dump(
                         match missing_parts {
                             Err(err) => {
                                 tracing::debug!(target: "state_sync_dump", shard_id, ?err, "get_missing_state_parts_for_epoch error");
-                                Err(Error::Other(format!(
-                                    "get_missing_state_parts_for_epoch failed"
-                                )))
+                                Err(Error::Other("get_missing_state_parts_for_epoch failed".to_string()))
                             }
                             Ok(parts_not_dumped) if parts_not_dumped.is_empty() => {
                                 Ok(Some(StateSyncDumpProgress::AllDumped {


### PR DESCRIPTION
https://github.com/near/nearcore/issues/8902

The problem being solved
- Prevent man in middle attacks on Tier2 network 

The approach taken
- Pass the signed ip address of the sender 

Remaining steps to fully deploy this solution after this PR is merged
- Fail the handshake only after all nodes on both mainnet and testnet have updated to the latest version of Tier2 handshake that includes signing the ip address. It currently only fails if the signed ip address is present and faulty but doesn't fail if the signed ip address is absent (for backward compatibility temporary migration purposes)


Also needed to run auto-linter to pass buildkite tests
```
cargo fmt -- --emit files 
cargo clippy --fix -- -A clippy::all -W clippy::useless_format -W clippy::clone_on_copy
cargo clippy --fix -- -A clippy::all -W clippy::useless_format -W clippy::redundant_clone
./scripts/formatting --fix
```
