### PR TITLE
make sure diffrunner fuzzer actually runs with contract prepare version v2

### DIFF
--- a/integration-tests/src/tests/runtime/deployment.rs
+++ b/integration-tests/src/tests/runtime/deployment.rs
@@ -56,8 +56,8 @@ fn test_deploy_max_size_contract() {
 
     // Deploy contract
     let wasm_binary = near_test_contracts::sized_contract(contract_size as usize);
-    // Rune code through preparation for validation. (Deploying will succeed either way).
-    near_vm_runner::prepare::prepare_contract(&wasm_binary, &config.wasm_config, VMKind::NearVm)
+    // Run code through preparation for validation. (Deploying will succeed either way).
+    near_vm_runner::prepare::prepare_contract(&wasm_binary, &config.wasm_config, VMKind::Wasmer2)
         .unwrap();
     let transaction_result =
         node_user.deploy_contract(test_contract_id, wasm_binary.to_vec()).unwrap();

--- a/runtime/near-vm-runner/fuzz/fuzz_targets/diffrunner.rs
+++ b/runtime/near-vm-runner/fuzz/fuzz_targets/diffrunner.rs
@@ -21,7 +21,7 @@ fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMOutcome {
     let mut context = create_context(vec![]);
     context.prepaid_gas = 10u64.pow(14);
     let mut config = VMConfig::test();
-    config.limit_config.wasmer2_stack_limit = i32::MAX; // If we can crash wasmer2 even without the secondary stack limit it's still good to know
+    config.limit_config.contract_prepare_version = near_vm_logic::ContractPrepareVersion::V2;
     let fees = RuntimeFeesConfig::test();
 
     let promise_results = vec![];

--- a/runtime/near-vm-runner/src/prepare.rs
+++ b/runtime/near-vm-runner/src/prepare.rs
@@ -54,7 +54,13 @@ pub fn prepare_contract(
     config: &VMConfig,
     kind: VMKind,
 ) -> Result<Vec<u8>, PrepareError> {
-    match config.limit_config.contract_prepare_version {
+    let prepare = config.limit_config.contract_prepare_version;
+    // NearVM => ContractPrepareVersion::V2
+    assert!(
+        (kind != VMKind::NearVm) || (prepare == near_vm_logic::ContractPrepareVersion::V2),
+        "NearVM only works with contract prepare version V2",
+    );
+    match prepare {
         near_vm_logic::ContractPrepareVersion::V0 => {
             // NB: v1 here is not a bug, we are reusing the code.
             prepare_v1::validate_contract(original_code, config)?;


### PR DESCRIPTION
Without that, it tries running with contract prepare version v1 since the near-vm landing revert.
In turn, this means that gas accounting becomes nonsensical, as near-vm has its own gas accounting that is only compatible with contract prepare version v1, and is only expected to be consistent with contract prepare version v1