### PR TITLE
fix: implement valid AccountId generation from arbitrary data

### DIFF
--- a/core/account-id/src/lib.rs
+++ b/core/account-id/src/lib.rs
@@ -399,7 +399,7 @@ impl<'a> arbitrary::Arbitrary<'a> for AccountId {
                 return Ok(a);
             }
         }
-        return Err(arbitrary::Error::IncorrectFormat);
+        Err(arbitrary::Error::IncorrectFormat)
     }
 }
 

--- a/core/account-id/src/lib.rs
+++ b/core/account-id/src/lib.rs
@@ -377,7 +377,7 @@ impl<'a> arbitrary::Arbitrary<'a> for AccountId {
     }
 
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        let s = u.arbitrary::<String>()?;
+        let s = u.arbitrary::<&str>()?;
         match s.parse::<AccountId>() {
             Ok(account_id) => return Ok(account_id),
             Err(e) => {

--- a/core/account-id/src/lib.rs
+++ b/core/account-id/src/lib.rs
@@ -393,13 +393,9 @@ impl<'a> arbitrary::Arbitrary<'a> for AccountId {
     }
 
     fn arbitrary_take_rest(u: arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        let bytes = u.take_rest();
-        if let Ok(s) = std::str::from_utf8(bytes) {
-            if let Ok(a) = s.parse::<AccountId>() {
-                return Ok(a);
-            }
-        }
-        Err(arbitrary::Error::IncorrectFormat)
+        <&str as arbitrary::Arbitrary>::arbitrary_take_rest(u)?
+            .parse()
+            .map_err(|_| arbitrary::Error::IncorrectFormat)
     }
 }
 

--- a/core/account-id/src/lib.rs
+++ b/core/account-id/src/lib.rs
@@ -379,17 +379,18 @@ impl<'a> arbitrary::Arbitrary<'a> for AccountId {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let s = u.arbitrary::<&str>()?;
         match s.parse::<AccountId>() {
-            Ok(account_id) => return Ok(account_id),
+            Ok(account_id) => Ok(account_id),
             Err(e) => {
                 if let Some((valid_up_to, _)) = e.char {
                     let valid = &s[..valid_up_to];
                     debug_assert!(AccountId::validate(valid).is_ok());
                     #[allow(deprecated)]
-                    return Ok(AccountId::new_unvalidated(valid.to_string()));
+                    Ok(AccountId::new_unvalidated(valid.to_string()))
+                } else {
+                    Err(arbitrary::Error::IncorrectFormat)
                 }
             }
         }
-        Err(arbitrary::Error::IncorrectFormat)
     }
 
     fn arbitrary_take_rest(u: arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {

--- a/core/account-id/src/lib.rs
+++ b/core/account-id/src/lib.rs
@@ -381,7 +381,7 @@ impl<'a> arbitrary::Arbitrary<'a> for AccountId {
         match s.parse::<AccountId>() {
             Ok(account_id) => return Ok(account_id),
             Err(e) => {
-                if let Some(valid_up_to) = e.char.map(|(i, _)| i) {
+                if let Some((valid_up_to, _)) = e.char {
                     let valid = &s[..valid_up_to];
                     debug_assert!(AccountId::validate(valid).is_ok());
                     #[allow(deprecated)]


### PR DESCRIPTION
Looks like the former implementation of `Arbitrary` for `AccountId` would assume all strings were well-formed `AccountId`'s. Skipping the validation logic. Which is untrue.

This patch swaps out the derive for a custom implementation that ensures all arbitrary byte slices are validated before an `AccountId` is constructed.