### PR TITLE
do not spend time tracing finite_wasm_gas

### DIFF
--- a/runtime/near-vm-runner/src/imports.rs
+++ b/runtime/near-vm-runner/src/imports.rs
@@ -294,7 +294,7 @@ pub(crate) mod wasmer {
             ) => {
                 #[allow(unused_parens)]
                 fn $name( ctx: &mut wasmer_runtime::Ctx, $( $arg_name: $arg_type ),* ) -> Result<($( $returns ),*), VMLogicError> {
-                    const IS_GAS: bool = str_eq(stringify!($name), "gas");
+                    const IS_GAS: bool = str_eq(stringify!($name), "gas") || str_eq(stringify!($name), "finite_wasm_gas");
                     let _span = if IS_GAS {
                         None
                     } else {
@@ -393,7 +393,7 @@ pub(crate) mod wasmer2 {
                     extern "C" fn $name(env: *mut VMLogic<'_>, $( $arg_name: $arg_type ),* )
                     -> Ret {
                         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                            const IS_GAS: bool = str_eq(stringify!($name), "gas");
+                            const IS_GAS: bool = str_eq(stringify!($name), "gas") || str_eq(stringify!($name), "finite_wasm_gas");
                             let _span = if IS_GAS {
                                 None
                             } else {
@@ -555,7 +555,7 @@ pub(crate) mod near_vm {
                     extern "C" fn $name(env: *mut VMLogic<'_>, $( $arg_name: $arg_type ),* )
                     -> Ret {
                         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                            const IS_GAS: bool = str_eq(stringify!($name), "gas");
+                            const IS_GAS: bool = str_eq(stringify!($name), "gas") || str_eq(stringify!($name), "finite_wasm_gas");
                             let _span = if IS_GAS {
                                 None
                             } else {
@@ -687,7 +687,7 @@ pub(crate) mod wasmtime {
             ) => {
                 #[allow(unused_parens)]
                 fn $name(caller: wasmtime::Caller<'_, ()>, $( $arg_name: $arg_type ),* ) -> anyhow::Result<($( $returns ),*)> {
-                    const IS_GAS: bool = str_eq(stringify!($name), "gas");
+                    const IS_GAS: bool = str_eq(stringify!($name), "gas") || str_eq(stringify!($name), "finite_wasm_gas");
                     let _span = if IS_GAS {
                         None
                     } else {

--- a/runtime/near-vm-runner/src/tests/regression_tests.rs
+++ b/runtime/near-vm-runner/src/tests/regression_tests.rs
@@ -32,3 +32,29 @@ fn memory_size_alignment_issue() {
             "#]],
         ]);
 }
+
+#[test]
+fn finite_wasm_gas_was_being_traced_and_thus_slow() {
+    test_builder()
+        .wat(
+            r#"(module
+              (type (func))
+              (func (type 0)
+                loop (result i64)
+                  loop
+                    br 0
+                  end
+                  i64.const 0
+                end
+                drop)
+              (export "foo" (func 0)))
+            "#,
+        )
+        .method("foo")
+        .expects(&[
+            expect![[r#"
+              VMOutcome: balance 4 storage_usage 12 return data None burnt gas 100000000000000 used gas 100000000000000
+              Err: Exceeded the prepaid gas.
+            "#]],
+        ]);
+}


### PR DESCRIPTION
This should fix the issue we hit in https://github.com/near/nearcore/pull/9066 with one test being too slow.

Intrinsic-ifying could help even more, but this should already bring a significant multiplier to the performance, which hopefully should be enough to handle all practical concerns.