### PR TITLE
refactor: remove redundant flat storage methods from RuntimeAdapter

### DIFF
--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -52,8 +52,6 @@ use crate::BlockHeader;
 
 use near_primitives::epoch_manager::ShardConfig;
 
-use near_store::flat::{FlatStorage, FlatStorageStatus};
-
 use super::ValidatorSchedule;
 
 /// Simple key value runtime for tests.
@@ -974,31 +972,6 @@ impl RuntimeAdapter for KeyValueRuntime {
             ShardUId { version: 0, shard_id: shard_id as u32 },
             state_root,
         ))
-    }
-
-    fn get_flat_storage_for_shard(&self, _shard_uid: ShardUId) -> Option<FlatStorage> {
-        None
-    }
-
-    fn get_flat_storage_status(&self, _shard_uid: ShardUId) -> FlatStorageStatus {
-        FlatStorageStatus::Disabled
-    }
-
-    fn create_flat_storage_for_shard(&self, shard_uid: ShardUId) {
-        panic!("Flat storage state can't be created for shard {shard_uid} because KeyValueRuntime doesn't support this");
-    }
-
-    fn remove_flat_storage_for_shard(&self, _shard_uid: ShardUId) -> Result<(), Error> {
-        Ok(())
-    }
-
-    fn set_flat_storage_for_genesis(
-        &self,
-        _genesis_block: &CryptoHash,
-        _genesis_block_height: BlockHeight,
-        _genesis_epoch_id: &EpochId,
-    ) -> Result<StoreUpdate, Error> {
-        Ok(self.store.store_update())
     }
 
     fn validate_tx(

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -32,7 +32,6 @@ use near_primitives::version::{
     MIN_PROTOCOL_VERSION_NEP_92_FIX,
 };
 use near_primitives::views::{QueryRequest, QueryResponse};
-use near_store::flat::{FlatStorage, FlatStorageStatus};
 use near_store::{PartialStorage, ShardTries, Store, StoreUpdate, Trie, WrappedTrieChanges};
 
 pub use near_epoch_manager::EpochManagerAdapter;
@@ -301,26 +300,6 @@ pub trait RuntimeAdapter: Send + Sync {
     ) -> Result<Trie, Error>;
 
     fn get_flat_storage_manager(&self) -> Option<FlatStorageManager>;
-
-    fn get_flat_storage_for_shard(&self, shard_uid: ShardUId) -> Option<FlatStorage>;
-
-    fn get_flat_storage_status(&self, shard_uid: ShardUId) -> FlatStorageStatus;
-
-    /// Creates flat storage state for given shard, assuming that all flat storage data
-    /// is already stored in DB.
-    /// TODO (#7327): consider returning flat storage creation errors here
-    fn create_flat_storage_for_shard(&self, shard_uid: ShardUId);
-
-    /// Removes flat storage state for shard, if it exists.
-    /// Used to clear old flat storage data from disk and memory before syncing to newer state.
-    fn remove_flat_storage_for_shard(&self, shard_uid: ShardUId) -> Result<(), Error>;
-
-    fn set_flat_storage_for_genesis(
-        &self,
-        genesis_block: &CryptoHash,
-        genesis_block_height: BlockHeight,
-        genesis_epoch_id: &EpochId,
-    ) -> Result<StoreUpdate, Error>;
 
     /// Validates a given signed transaction.
     /// If the state root is given, then the verification will use the account. Otherwise it will

--- a/core/store/src/flat/manager.rs
+++ b/core/store/src/flat/manager.rs
@@ -57,8 +57,8 @@ impl FlatStorageManager {
 
     /// When a node starts from an empty database, this function must be called to ensure
     /// information such as flat head is set up correctly in the database.
-    /// Note that this function is different from `add_flat_storage_for_shard`,
-    /// it must be called before `add_flat_storage_for_shard` if the node starts from
+    /// Note that this function is different from `create_flat_storage_for_shard`,
+    /// it must be called before `create_flat_storage_for_shard` if the node starts from
     /// an empty database.
     pub fn set_flat_storage_for_genesis(
         &self,
@@ -78,17 +78,22 @@ impl FlatStorageManager {
         );
     }
 
-    /// Add a flat storage state for shard `shard_id`. The function also checks that
+    /// Creates flat storage instance for shard `shard_id`. The function also checks that
     /// the shard's flat storage state hasn't been set before, otherwise it panics.
     /// TODO (#7327): this behavior may change when we implement support for state sync
     /// and resharding.
-    pub fn add_flat_storage_for_shard(&self, shard_uid: ShardUId, flat_storage: FlatStorage) {
+    pub fn create_flat_storage_for_shard(&self, shard_uid: ShardUId) {
         let mut flat_storages = self.0.flat_storages.lock().expect(POISONED_LOCK_ERR);
-        let original_value = flat_storages.insert(shard_uid, flat_storage);
+        let original_value =
+            flat_storages.insert(shard_uid, FlatStorage::new(self.0.store.clone(), shard_uid));
         // TODO (#7327): maybe we should propagate the error instead of assert here
         // assert is fine now because this function is only called at construction time, but we
         // will need to be more careful when we want to implement flat storage for resharding
         assert!(original_value.is_none());
+    }
+
+    pub fn get_flat_storage_status(&self, shard_uid: ShardUId) -> FlatStorageStatus {
+        store_helper::get_flat_storage_status(&self.0.store, shard_uid)
     }
 
     /// Creates `FlatStorageChunkView` to access state for `shard_uid` and block `block_hash`.

--- a/core/store/src/flat/storage.rs
+++ b/core/store/src/flat/storage.rs
@@ -337,7 +337,6 @@ impl FlatStorage {
 mod tests {
     use crate::flat::delta::{FlatStateChanges, FlatStateDelta, FlatStateDeltaMetadata};
     use crate::flat::manager::FlatStorageManager;
-    use crate::flat::storage::FlatStorage;
     use crate::flat::types::{BlockInfo, FlatStorageError};
     use crate::flat::{store_helper, FlatStorageReadyStatus, FlatStorageStatus};
     use crate::test_utils::create_test_store;
@@ -471,9 +470,8 @@ mod tests {
         }
         store_update.commit().unwrap();
 
-        let flat_storage = FlatStorage::new(store.clone(), shard_uid);
         let flat_storage_manager = FlatStorageManager::new(store.clone());
-        flat_storage_manager.add_flat_storage_for_shard(shard_uid, flat_storage);
+        flat_storage_manager.create_flat_storage_for_shard(shard_uid);
         let flat_storage = flat_storage_manager.get_flat_storage_for_shard(shard_uid).unwrap();
 
         // Check `BlockNotSupported` errors which are fine to occur during regular block processing.
@@ -531,9 +529,8 @@ mod tests {
         store_update.commit().unwrap();
 
         // Check that flat storage state is created correctly for chain which has skipped heights.
-        let flat_storage = FlatStorage::new(store.clone(), shard_uid);
         let flat_storage_manager = FlatStorageManager::new(store);
-        flat_storage_manager.add_flat_storage_for_shard(shard_uid, flat_storage);
+        flat_storage_manager.create_flat_storage_for_shard(shard_uid);
         let flat_storage = flat_storage_manager.get_flat_storage_for_shard(shard_uid).unwrap();
 
         // Check that flat head can be moved to block 8.
@@ -578,8 +575,7 @@ mod tests {
         store_update.commit().unwrap();
 
         let flat_storage_manager = FlatStorageManager::new(store.clone());
-        flat_storage_manager
-            .add_flat_storage_for_shard(shard_uid, FlatStorage::new(store.clone(), shard_uid));
+        flat_storage_manager.create_flat_storage_for_shard(shard_uid);
         let flat_storage = flat_storage_manager.get_flat_storage_for_shard(shard_uid).unwrap();
 
         // 2. Check that the chunk_view at block i reads the value of key &[1] as &[i]

--- a/docs/architecture/storage/flat_storage.md
+++ b/docs/architecture/storage/flat_storage.md
@@ -189,7 +189,7 @@ It holds all FlatStorages which NightshadeRuntime knows about and:
 
 * provides views for flat storage for some fixed block - supported by new_flat_state_for_shard
 * sets initial flat storage state for genesis block - set_flat_storage_for_genesis
-* adds/removes/gets flat storage if we started/stopped tracking a shard or need to create a view - add_flat_storage_for_shard, etc.
+* adds/removes/gets flat storage if we started/stopped tracking a shard or need to create a view - create_flat_storage_for_shard, etc.
 
 ## FlatStorageChunkView
 

--- a/tools/flat-storage/src/commands.rs
+++ b/tools/flat-storage/src/commands.rs
@@ -173,9 +173,9 @@ impl FlatStorageCommand {
 
                 // TODO: there should be a method that 'loads' the current flat storage state based on Storage.
                 let shard_uid = epoch_manager.shard_id_to_uid(reset_cmd.shard_id, &tip.epoch_id)?;
-                rw_hot_runtime.create_flat_storage_for_shard(shard_uid);
-
-                rw_hot_runtime.remove_flat_storage_for_shard(shard_uid)?;
+                let flat_storage_manager = rw_hot_runtime.get_flat_storage_manager().unwrap();
+                flat_storage_manager.create_flat_storage_for_shard(shard_uid);
+                flat_storage_manager.remove_flat_storage_for_shard(shard_uid)?;
             }
             SubCommand::Init(init_cmd) => {
                 let (_, epoch_manager, rw_hot_runtime, rw_chain_store, rw_hot_store) = Self::get_db(
@@ -252,7 +252,10 @@ impl FlatStorageCommand {
 
                 let shard_uid =
                     epoch_manager.shard_id_to_uid(verify_cmd.shard_id, &tip.epoch_id)?;
-                hot_runtime.create_flat_storage_for_shard(shard_uid);
+                hot_runtime
+                    .get_flat_storage_manager()
+                    .unwrap()
+                    .create_flat_storage_for_shard(shard_uid);
 
                 let trie = hot_runtime
                     .get_view_trie_for_shard(verify_cmd.shard_id, &head_hash, *state_root)


### PR DESCRIPTION
With #9093 `RuntimeAdapter` has access to `FlatStorageManager` which makes all other flat storage related methods redundant. This PR removes those methods to keep `RuntimeAdapter` trait leaner.