### PR TITLE
refactor: use proper type for FlatState iterator values

### DIFF
--- a/core/store/src/flat/chunk_view.rs
+++ b/core/store/src/flat/chunk_view.rs
@@ -1,4 +1,5 @@
 use crate::flat::store_helper;
+use near_primitives::errors::StorageError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::state::FlatStateValue;
 
@@ -48,7 +49,7 @@ impl FlatStorageChunkView {
         &'a self,
         from: Option<&[u8]>,
         to: Option<&[u8]>,
-    ) -> impl Iterator<Item = (Vec<u8>, Box<[u8]>)> + 'a {
+    ) -> impl Iterator<Item = Result<(Vec<u8>, FlatStateValue), StorageError>> + 'a {
         store_helper::iter_flat_state_entries(self.flat_storage.shard_uid(), &self.store, from, to)
     }
 

--- a/integration-tests/src/tests/client/flat_storage.rs
+++ b/integration-tests/src/tests/client/flat_storage.rs
@@ -434,7 +434,7 @@ fn test_flat_storage_iter() {
                         account_id: "test0".parse().unwrap()
                     }
                     .to_vec(),
-                    items.get(0).unwrap().0
+                    items[0].as_ref().unwrap().0.to_vec()
                 );
             }
             1 => {
@@ -449,7 +449,7 @@ fn test_flat_storage_iter() {
                         account_id: "near".parse().unwrap()
                     }
                     .to_vec(),
-                    items.get(0).unwrap().0
+                    items[0].as_ref().unwrap().0.to_vec()
                 );
             }
             _ => {

--- a/tools/flat-storage/src/commands.rs
+++ b/tools/flat-storage/src/commands.rs
@@ -5,7 +5,6 @@ use near_chain::flat_storage_creator::FlatStorageShardCreator;
 use near_chain::types::RuntimeAdapter;
 use near_chain::{ChainStore, ChainStoreAccess};
 use near_epoch_manager::{EpochManager, EpochManagerAdapter, EpochManagerHandle};
-use near_primitives::state::FlatStateValue;
 use near_store::flat::{
     inline_flat_state_values, store_helper, FlatStateDelta, FlatStateDeltaMetadata,
     FlatStorageManager, FlatStorageStatus,
@@ -270,8 +269,8 @@ impl FlatStorageCommand {
                 for (item_trie, item_flat) in
                     tqdm(std::iter::zip(trie_iter, flat_state_entries_iter))
                 {
-                    let value_ref =
-                        FlatStateValue::try_from_slice(&item_flat.1).unwrap().to_value_ref();
+                    let item_flat = item_flat.unwrap();
+                    let value_ref = item_flat.1.to_value_ref();
                     verified += 1;
 
                     let item_trie = item_trie.unwrap();


### PR DESCRIPTION
use `FlatStateValue` instead of ra aw `Box<[u8]>`.