### PR TITLE
fix: clear previous epoch block/chunk production metrics

### DIFF
--- a/chain/client/src/metrics.rs
+++ b/chain/client/src/metrics.rs
@@ -127,7 +127,7 @@ pub(crate) static VALIDATORS_CHUNKS_EXPECTED_IN_EPOCH: Lazy<IntGaugeVec> = Lazy:
     try_create_int_gauge_vec(
         "near_validators_chunks_expected_in_epoch",
         "Number of chunks expected to be produced by a validator within current epoch",
-        &["account_id", "shard_id"],
+        &["account_id", "shard_id", "epoch_height"],
     )
     .unwrap()
 });
@@ -154,7 +154,7 @@ pub(crate) static VALIDATORS_BLOCKS_EXPECTED_IN_EPOCH: Lazy<IntGaugeVec> = Lazy:
     try_create_int_gauge_vec(
         "near_validators_blocks_expected_in_epoch",
         "Number of blocks expected to be produced by a validator within current epoch",
-        &["account_id"],
+        &["account_id", "epoch_height"],
     )
     .unwrap()
 });


### PR DESCRIPTION
Information about the block/chunk production was not cleared between epochs.

Clear the metrics before adding new data.
Add `epoch_height` as a field.