### PR TITLE
Improve naming of public definitions in crate accounts_data

### DIFF
--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -1,4 +1,4 @@
-use crate::accounts_data;
+use crate::accounts_data::AccountDataError;
 use crate::concurrency::atomic_cell::AtomicCell;
 use crate::concurrency::demux;
 use crate::config::PEERS_RESPONSE_MAX_PEERS;
@@ -1284,13 +1284,9 @@ impl PeerActor {
                         network_state.add_accounts_data(&clock, msg.accounts_data).await
                     {
                         conn.stop(Some(match err {
-                            accounts_data::Error::InvalidSignature => {
-                                ReasonForBan::InvalidSignature
-                            }
-                            accounts_data::Error::DataTooLarge => ReasonForBan::Abusive,
-                            accounts_data::Error::SingleAccountMultipleData => {
-                                ReasonForBan::Abusive
-                            }
+                            AccountDataError::InvalidSignature => ReasonForBan::InvalidSignature,
+                            AccountDataError::DataTooLarge => ReasonForBan::Abusive,
+                            AccountDataError::SingleAccountMultipleData => ReasonForBan::Abusive,
                         }));
                     }
                     network_state

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -1,4 +1,4 @@
-use crate::accounts_data;
+use crate::accounts_data::{AccountDataCache, AccountDataError};
 use crate::client;
 use crate::concurrency::demux;
 use crate::concurrency::runtime::Runtime;
@@ -101,7 +101,7 @@ pub(crate) struct NetworkState {
     /// Network-related info about the chain.
     pub chain_info: ArcSwap<Option<ChainInfo>>,
     /// AccountsData for TIER1 accounts.
-    pub accounts_data: Arc<accounts_data::Cache>,
+    pub accounts_data: Arc<AccountDataCache>,
     /// Connected peers (inbound and outbound) with their full peer information.
     pub tier2: connection::Pool,
     pub tier1: connection::Pool,
@@ -178,7 +178,7 @@ impl NetworkState {
             peer_store,
             connection_store: connection_store::ConnectionStore::new(store).unwrap(),
             pending_reconnect: Mutex::new(Vec::<PeerInfo>::new()),
-            accounts_data: Arc::new(accounts_data::Cache::new()),
+            accounts_data: Arc::new(AccountDataCache::new()),
             tier1_route_back: Mutex::new(RouteBackCache::default()),
             recent_routed_messages: Mutex::new(lru::LruCache::new(
                 RECENT_ROUTED_MESSAGES_CACHE_SIZE,
@@ -604,7 +604,7 @@ impl NetworkState {
         self: &Arc<Self>,
         clock: &time::Clock,
         accounts_data: Vec<Arc<SignedAccountData>>,
-    ) -> Option<accounts_data::Error> {
+    ) -> Option<AccountDataError> {
         let this = self.clone();
         let clock = clock.clone();
         self.spawn(async move {

--- a/chain/network/src/peer_manager/network_state/tier1.rs
+++ b/chain/network/src/peer_manager/network_state/tier1.rs
@@ -1,4 +1,4 @@
-use crate::accounts_data;
+use crate::accounts_data::{AccountDataCacheSnapshot, LocalAccountData};
 use crate::config;
 use crate::network_protocol::{
     AccountData, PeerAddr, PeerInfo, PeerMessage, SignedAccountData, SyncAccountsData,
@@ -21,7 +21,7 @@ impl super::NetworkState {
     // Returns ValidatorConfig of this node iff it belongs to TIER1 according to `accounts_data`.
     pub fn tier1_validator_config(
         &self,
-        accounts_data: &accounts_data::CacheSnapshot,
+        accounts_data: &AccountDataCacheSnapshot,
     ) -> Option<&config::ValidatorConfig> {
         if self.config.tier1.is_none() {
             return None;
@@ -187,7 +187,7 @@ impl super::NetworkState {
         tracing::info!(target:"network","connected to proxies {my_proxies:?}");
         let new_data = self.accounts_data.set_local(
             clock,
-            accounts_data::LocalData {
+            LocalAccountData {
                 signer: vc.signer.clone(),
                 data: Arc::new(AccountData { peer_id: self.config.node_id(), proxies: my_proxies }),
             },

--- a/chain/network/src/peer_manager/testonly.rs
+++ b/chain/network/src/peer_manager/testonly.rs
@@ -1,4 +1,4 @@
-use crate::accounts_data;
+use crate::accounts_data::AccountDataCacheSnapshot;
 use crate::broadcast;
 use crate::config;
 use crate::network_protocol::testonly as data;
@@ -387,7 +387,7 @@ impl ActorHandler {
     // Awaits until the accounts_data state satisfies predicate `pred`.
     pub async fn wait_for_accounts_data_pred(
         &self,
-        pred: impl Fn(Arc<accounts_data::CacheSnapshot>) -> bool,
+        pred: impl Fn(Arc<AccountDataCacheSnapshot>) -> bool,
     ) {
         let mut events = self.events.from_now();
         loop {


### PR DESCRIPTION
This crate exposes some very generic names such as `Error`, `Cache`, and `CacheSnapshot` which we end up referring to elsewhere by the full path (for example, writing `accounts_data::Error` everywhere).

This PR makes the names less generic so that we can directly import them.