### PR TITLE
refactor: improve flat storage error handling

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -5019,8 +5019,7 @@ impl<'a> ChainUpdate<'a> {
             // Otherwise, save delta to disk so it will be used for flat storage creation later.
             debug!(target: "chain", %shard_id, "Add delta for flat storage creation");
             let mut store_update = self.chain_store_update.store().store_update();
-            store_helper::set_delta(&mut store_update, shard_uid, &delta)
-                .map_err(|e| StorageError::from(e))?;
+            store_helper::set_delta(&mut store_update, shard_uid, &delta);
             self.chain_store_update.merge(store_update);
         }
 

--- a/chain/chain/src/flat_storage_creator.rs
+++ b/chain/chain/src/flat_storage_creator.rs
@@ -116,8 +116,7 @@ impl FlatStorageShardCreator {
                     shard_uid,
                     key,
                     Some(FlatStateValue::value_ref(&value)),
-                )
-                .expect("Failed to put value in FlatState");
+                );
                 num_items += 1;
             }
         }
@@ -153,7 +152,8 @@ impl FlatStorageShardCreator {
     ) -> Result<bool, Error> {
         let shard_id = self.shard_uid.shard_id();
         let current_status =
-            store_helper::get_flat_storage_status(chain_store.store(), self.shard_uid);
+            store_helper::get_flat_storage_status(chain_store.store(), self.shard_uid)
+                .expect("failed to read flat storage status");
         self.metrics.set_status(&current_status);
         match &current_status {
             FlatStorageStatus::Empty => {

--- a/core/store/src/flat/chunk_view.rs
+++ b/core/store/src/flat/chunk_view.rs
@@ -1,10 +1,10 @@
 use crate::flat::store_helper;
-use near_primitives::errors::StorageError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::state::FlatStateValue;
 
 use crate::Store;
 
+use super::types::FlatStateIterator;
 use super::FlatStorage;
 
 /// Struct for getting value references from the flat storage, corresponding
@@ -49,7 +49,7 @@ impl FlatStorageChunkView {
         &'a self,
         from: Option<&[u8]>,
         to: Option<&[u8]>,
-    ) -> impl Iterator<Item = Result<(Vec<u8>, FlatStateValue), StorageError>> + 'a {
+    ) -> FlatStateIterator<'a> {
         store_helper::iter_flat_state_entries(self.flat_storage.shard_uid(), &self.store, from, to)
     }
 

--- a/core/store/src/flat/delta.rs
+++ b/core/store/src/flat/delta.rs
@@ -22,6 +22,7 @@ pub struct FlatStateDeltaMetadata {
     pub block: BlockInfo,
 }
 
+#[derive(Debug)]
 pub struct KeyForFlatStateDelta {
     pub shard_uid: ShardUId,
     pub block_hash: CryptoHash,
@@ -108,8 +109,7 @@ impl FlatStateChanges {
     /// Applies delta to the flat state.
     pub fn apply_to_flat_state(self, store_update: &mut StoreUpdate, shard_uid: ShardUId) {
         for (key, value) in self.0.into_iter() {
-            store_helper::set_flat_state_value(store_update, shard_uid, key, value)
-                .expect("Borsh cannot fail");
+            store_helper::set_flat_state_value(store_update, shard_uid, key, value);
         }
     }
 }

--- a/core/store/src/flat/manager.rs
+++ b/core/store/src/flat/manager.rs
@@ -94,6 +94,7 @@ impl FlatStorageManager {
 
     pub fn get_flat_storage_status(&self, shard_uid: ShardUId) -> FlatStorageStatus {
         store_helper::get_flat_storage_status(&self.0.store, shard_uid)
+            .expect("failed to read flat storage status")
     }
 
     /// Creates `FlatStorageChunkView` to access state for `shard_uid` and block `block_hash`.

--- a/core/store/src/flat/mod.rs
+++ b/core/store/src/flat/mod.rs
@@ -41,7 +41,7 @@ pub use manager::FlatStorageManager;
 pub use metrics::FlatStorageCreationMetrics;
 pub use storage::FlatStorage;
 pub use types::{
-    BlockInfo, FetchingStateStatus, FlatStorageCreationStatus, FlatStorageError,
+    BlockInfo, FetchingStateStatus, FlatStateIterator, FlatStorageCreationStatus, FlatStorageError,
     FlatStorageReadyStatus, FlatStorageStatus,
 };
 

--- a/core/store/src/flat/storage.rs
+++ b/core/store/src/flat/storage.rs
@@ -72,7 +72,7 @@ impl FlatStorageInner {
         // and read single `ValueRef` from delta if it is not cached.
         self.deltas
             .get(block_hash)
-            .ok_or(FlatStorageError::StorageInternalError)
+            .ok_or_else(|| missing_delta_error(block_hash))
             .map(|delta| delta.changes.clone())
     }
 
@@ -134,7 +134,7 @@ impl FlatStorage {
     pub fn new(store: Store, shard_uid: ShardUId) -> Self {
         let shard_id = shard_uid.shard_id();
         let flat_head = match store_helper::get_flat_storage_status(&store, shard_uid) {
-            FlatStorageStatus::Ready(ready_status) => ready_status.flat_head,
+            Ok(FlatStorageStatus::Ready(ready_status)) => ready_status.flat_head,
             status => {
                 panic!("cannot create flat storage for shard {shard_id} with status {status:?}")
             }
@@ -151,9 +151,9 @@ impl FlatStorage {
             let block_hash = delta_metadata.block.hash;
             let changes: CachedFlatStateChanges =
                 store_helper::get_delta_changes(&store, shard_uid, block_hash)
-                    .expect("Borsh cannot fail")
+                    .expect("failed to read flat state delta changes")
                     .unwrap_or_else(|| {
-                        panic!("Cannot find block delta for block {block_hash:?} shard {shard_id}")
+                        panic!("cannot find block delta for block {block_hash:?} shard {shard_id}")
                     })
                     .into();
             deltas.insert(
@@ -225,7 +225,7 @@ impl FlatStorage {
             // Delta must exist because flat storage is locked and we could retrieve
             // path from old to new head. Otherwise we return internal error.
             let changes = store_helper::get_delta_changes(&guard.store, shard_uid, block_hash)?
-                .ok_or(FlatStorageError::StorageInternalError)?;
+                .ok_or_else(|| missing_delta_error(&block_hash))?;
             changes.apply_to_flat_state(&mut store_update, guard.shard_uid);
             let block = &guard.deltas[&block_hash].metadata.block;
             let block_height = block.height;
@@ -246,7 +246,7 @@ impl FlatStorage {
             let gc_height = guard
                 .deltas
                 .get(&block_hash)
-                .ok_or(FlatStorageError::StorageInternalError)?
+                .ok_or_else(|| missing_delta_error(&block_hash))?
                 .metadata
                 .block
                 .height;
@@ -287,7 +287,7 @@ impl FlatStorage {
             return Err(guard.create_block_not_supported_error(&block_hash));
         }
         let mut store_update = StoreUpdate::new(guard.store.storage.clone());
-        store_helper::set_delta(&mut store_update, shard_uid, &delta)?;
+        store_helper::set_delta(&mut store_update, shard_uid, &delta);
         let cached_changes: CachedFlatStateChanges = delta.changes.into();
         guard.deltas.insert(
             block_hash,
@@ -331,6 +331,10 @@ impl FlatStorage {
         let mut guard = self.0.write().expect(crate::flat::POISONED_LOCK_ERR);
         guard.move_head_enabled = enabled;
     }
+}
+
+fn missing_delta_error(block_hash: &CryptoHash) -> FlatStorageError {
+    FlatStorageError::StorageInternalError(format!("delta does not exist for block {block_hash}"))
 }
 
 #[cfg(test)]
@@ -466,7 +470,7 @@ mod tests {
                 changes: FlatStateChanges::default(),
                 metadata: FlatStateDeltaMetadata { block: chain.get_block(i) },
             };
-            store_helper::set_delta(&mut store_update, shard_uid, &delta).unwrap();
+            store_helper::set_delta(&mut store_update, shard_uid, &delta);
         }
         store_update.commit().unwrap();
 
@@ -501,9 +505,9 @@ mod tests {
         let mut store_update = store.store_update();
         store_helper::remove_delta(&mut store_update, shard_uid, chain.get_block_hash(3));
         store_update.commit().unwrap();
-        assert_eq!(
+        assert_matches!(
             flat_storage.update_flat_head(&chain.get_block_hash(3)),
-            Err(FlatStorageError::StorageInternalError)
+            Err(FlatStorageError::StorageInternalError(_))
         );
     }
 
@@ -524,7 +528,7 @@ mod tests {
                 changes: FlatStateChanges::default(),
                 metadata: FlatStateDeltaMetadata { block: chain.get_block(i * 2) },
             };
-            store_helper::set_delta(&mut store_update, shard_uid, &delta).unwrap();
+            store_helper::set_delta(&mut store_update, shard_uid, &delta);
         }
         store_update.commit().unwrap();
 
@@ -560,8 +564,7 @@ mod tests {
             shard_uid,
             vec![1],
             Some(FlatStateValue::value_ref(&[0])),
-        )
-        .unwrap();
+        );
         for i in 1..10 {
             let delta = FlatStateDelta {
                 changes: FlatStateChanges::from([(
@@ -570,7 +573,7 @@ mod tests {
                 )]),
                 metadata: FlatStateDeltaMetadata { block: chain.get_block(i) },
             };
-            store_helper::set_delta(&mut store_update, shard_uid, &delta).unwrap();
+            store_helper::set_delta(&mut store_update, shard_uid, &delta);
         }
         store_update.commit().unwrap();
 

--- a/core/store/src/flat/types.rs
+++ b/core/store/src/flat/types.rs
@@ -1,6 +1,7 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_primitives::errors::StorageError;
 use near_primitives::hash::CryptoHash;
+use near_primitives::state::FlatStateValue;
 use near_primitives::types::BlockHeight;
 
 /// Defines value size threshold for flat state inlining.
@@ -33,7 +34,7 @@ pub enum FlatStorageError {
     BlockNotSupported((CryptoHash, CryptoHash)),
     /// Internal error, caused by DB or in-memory data corruption. Should result
     /// in panic, because correctness of flat storage is not guaranteed afterwards.
-    StorageInternalError,
+    StorageInternalError(String),
 }
 
 impl From<FlatStorageError> for StorageError {
@@ -45,10 +46,12 @@ impl From<FlatStorageError> for StorageError {
                     head_hash, block_hash
                 ))
             }
-            FlatStorageError::StorageInternalError => StorageError::StorageInternalError,
+            FlatStorageError::StorageInternalError(_) => StorageError::StorageInternalError,
         }
     }
 }
+
+pub type FlatStorageResult<T> = Result<T, FlatStorageError>;
 
 #[derive(BorshSerialize, BorshDeserialize, Debug, PartialEq, Eq)]
 pub enum FlatStateValuesInliningMigrationStatus {
@@ -128,3 +131,6 @@ pub struct FetchingStateStatus {
     /// Total number of state parts.
     pub num_parts: u64,
 }
+
+pub type FlatStateIterator<'a> =
+    Box<dyn Iterator<Item = FlatStorageResult<(Vec<u8>, FlatStateValue)>> + 'a>;

--- a/tools/flat-storage/src/commands.rs
+++ b/tools/flat-storage/src/commands.rs
@@ -218,7 +218,9 @@ impl FlatStorageCommand {
                 let shard_uid =
                     epoch_manager.shard_id_to_uid(verify_cmd.shard_id, &tip.epoch_id)?;
 
-                let head_hash = match store_helper::get_flat_storage_status(&hot_store, shard_uid) {
+                let head_hash = match store_helper::get_flat_storage_status(&hot_store, shard_uid)
+                    .expect("falied to read flat storage status")
+                {
                     FlatStorageStatus::Ready(ready_status) => ready_status.flat_head.hash,
                     status => {
                         panic!(


### PR DESCRIPTION
* Replace `StorageError` with `FlatStorageError` in `store_helper`.
* Add message to `FlatStorageError::StorageInternalError` to avoid losing information about the underlying error
* Introduce `FlatStateIterator` and get rid of the hack around empty iterator (not exactly related to error handling, just a general improvement)