### PR TITLE
Update to latest rustc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 version = "0.0.0" # managed by cargo-workspaces, see below
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
-rust-version = "1.69.0"
+rust-version = "1.70.0"
 repository = "https://github.com/near/nearcore"
 license = "MIT OR Apache-2.0"
 

--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -177,18 +177,12 @@ impl From<ShardSyncDownload> for ShardSyncDownloadView {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct StateSplitApplyingStatus {
     /// total number of parts to be applied
     pub total_parts: OnceCell<u64>,
     /// number of parts that are done
     pub done_parts: AtomicU64,
-}
-
-impl StateSplitApplyingStatus {
-    pub fn new() -> Self {
-        StateSplitApplyingStatus { total_parts: OnceCell::new(), done_parts: AtomicU64::new(0) }
-    }
 }
 
 /// Stores status of shard sync and statuses of downloading shards.

--- a/chain/client/src/sync/state.rs
+++ b/chain/client/src/sync/state.rs
@@ -1151,7 +1151,7 @@ impl StateSync {
         state_split_scheduler: &dyn Fn(StateSplitRequest),
         me: &Option<AccountId>,
     ) -> Result<(), near_chain::Error> {
-        let status = Arc::new(StateSplitApplyingStatus::new());
+        let status = Arc::new(StateSplitApplyingStatus::default());
         chain.build_state_for_split_shards_preprocessing(
             &sync_hash,
             shard_id,

--- a/runtime/runtime-params-estimator/emu-cost/Dockerfile
+++ b/runtime/runtime-params-estimator/emu-cost/Dockerfile
@@ -1,5 +1,5 @@
 # our local base image
-FROM rust:1.69.0
+FROM rust:1.70.0
 
 LABEL description="Container for builds"
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,6 +2,6 @@
 # This specifies the version of Rust we use to build.
 # Individual crates in the workspace may support a lower version, as indicated by `rust-version` field in each crate's `Cargo.toml`.
 # The version specified below, should be at least as high as the maximum `rust-version` within the workspace.
-channel = "1.69.0"
+channel = "1.70.0"
 components = [ "rustfmt" ]
 targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
I looked into replacing usage of once_cell crate but sadly
std::sync::OnceLock doesn’t implement wait method.
