### PR TITLE
docs: Add guidance to install deps for loadtest

### DIFF
--- a/pytest/tests/loadtest/locust/README.md
+++ b/pytest/tests/loadtest/locust/README.md
@@ -7,6 +7,8 @@ TLDR: Use [locust](https://locust.io/) to generate transactions against a Near c
 ## Install
 ```sh
 pip3 install locust
+# Run in nearcore directory.
+pip3 install -r pytest/requirements.txt
 ```
 
 ## Run a first load test


### PR DESCRIPTION
As the test requires some dependencies like `base58` and `retrying` which are not available by default.