### PR TITLE
Locust Congestion Workload

### DIFF
--- a/pytest/tests/loadtest/locust/README.md
+++ b/pytest/tests/loadtest/locust/README.md
@@ -115,7 +115,7 @@ Currently supported load types:
 For the congestion workload you will need to use the following contract:
 
 ```sh
-# This assumes your shell is are in nearcore directory
+# This assumes your shell is in nearcore directory
 CONTRACT="${PWD}/runtime/near-test-contracts/res/test_contract_rs.wasm"
 ```
 

--- a/pytest/tests/loadtest/locust/README.md
+++ b/pytest/tests/loadtest/locust/README.md
@@ -110,6 +110,14 @@ Currently supported load types:
 |---|---|---|---|---|
 | Fungible Token | `FTTransferUser` | `ft` | `--fungible-token-wasm $WASM_PATH` <br> (`--num-ft-contracts $N`) |  Creates `$N` FT contracts per worker, registers each user in one of them. Users transfer FTs between each other. |
 | Social DB  | `SocialDbUser` | `social` | `--social-db-wasm $WASM_PATH` | Creates a single instance of SocialDB and registers users to it. Users post messages and follow other users. (More workload TBD) |
+| Congestion | `CongestionUser` | `congestion` | `--congestion-wasm $WASM_PATH` | Creates a single instance of Congestion contract. Users run large and long transactions. |
+
+For congestion workload you will need to use the following contract
+
+```sh
+# This assumes your shell is are in nearcore directory
+CONTRACT="${PWD}/runtime/near-test-contracts/res/test_contract_rs.wasm"
+```
 
 In the future, we might have multiple users per load type but for now there is a
 one-to-one mapping from users to load type (and tag).

--- a/pytest/tests/loadtest/locust/README.md
+++ b/pytest/tests/loadtest/locust/README.md
@@ -112,7 +112,7 @@ Currently supported load types:
 | Social DB  | `SocialDbUser` | `social` | `--social-db-wasm $WASM_PATH` | Creates a single instance of SocialDB and registers users to it. Users post messages and follow other users. (More workload TBD) |
 | Congestion | `CongestionUser` | `congestion` | `--congestion-wasm $WASM_PATH` | Creates a single instance of Congestion contract. Users run large and long transactions. |
 
-For congestion workload you will need to use the following contract
+For the congestion workload you will need to use the following contract:
 
 ```sh
 # This assumes your shell is are in nearcore directory

--- a/pytest/tests/loadtest/locust/common/congestion.py
+++ b/pytest/tests/loadtest/locust/common/congestion.py
@@ -78,13 +78,13 @@ def on_locust_init(environment, **kwargs):
         return
 
     # `master_funding_account` is the same on all runners, allowing to share a
-    # single instance of Congestion contract.
+    # single instance of congestion contract.
     funding_account = environment.master_funding_account
     environment.congestion_account_id = (
         f"congestion.{funding_account.key.account_id}"
     )
 
-    # Create SocialDB account, unless we are a worker, in which case the master already did it
+    # Only create congestion contract on master.
     if isinstance(environment.runner, runners.WorkerRunner):
         return
 

--- a/pytest/tests/loadtest/locust/common/congestion.py
+++ b/pytest/tests/loadtest/locust/common/congestion.py
@@ -1,0 +1,119 @@
+import json
+import pathlib
+import sys
+
+from locust import events, runners
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[4] / "lib"))
+
+import account
+import cluster
+import common.base as base
+import key
+import transaction
+
+
+class LargeTransaction(base.Transaction):
+    """Transaction with a large size in bytes."""
+
+    def __init__(
+        self,
+        contract_account_id: str,
+        sender: base.Account,
+        size_bytes: int,
+    ):
+        super().__init__()
+        self.contract_account_id = contract_account_id
+        self.sender = sender
+        self.size_bytes = size_bytes
+
+    def sign_and_serialize(self, block_hash) -> bytes:
+        args = {
+            "key": "a" * self.size_bytes,
+        }
+        return transaction.sign_function_call_tx(
+            self.sender.key,
+            self.contract_account_id,
+            "ext_sha256",
+            json.dumps(args).encode("utf-8"),
+            300 * account.TGAS,
+            # Attach exactly 1 yoctoNEAR according to NEP-141 to avoid
+            # calls from restricted access keys.
+            1,
+            self.sender.use_nonce(),
+            block_hash,
+        )
+
+
+class LongTransaction(base.Transaction):
+    """Transaction with a large size in bytes."""
+
+    def __init__(
+        self,
+        contract_account_id: str,
+        sender: base.Account,
+    ):
+        super().__init__()
+        self.contract_account_id = contract_account_id
+        self.sender = sender
+
+    def sign_and_serialize(self, block_hash) -> bytes:
+        return transaction.sign_function_call_tx(
+            self.sender.key,
+            self.contract_account_id,
+            "fibonacci",
+            [33],
+            300 * account.TGAS,
+            # Attach exactly 1 yoctoNEAR according to NEP-141 to avoid
+            # calls from restricted access keys.
+            1,
+            self.sender.use_nonce(),
+            block_hash,
+        )
+
+
+@events.init.add_listener
+def on_locust_init(environment, **kwargs):
+    if not base.is_tag_active(environment, "congestion"):
+        return
+
+    # `master_funding_account` is the same on all runners, allowing to share a
+    # single instance of Congestion contract.
+    funding_account = environment.master_funding_account
+    environment.congestion_account_id = (
+        f"congestion.{funding_account.key.account_id}"
+    )
+
+    # Create SocialDB account, unless we are a worker, in which case the master already did it
+    if isinstance(environment.runner, runners.WorkerRunner):
+        return
+
+    contract_key = key.Key.from_random(environment.congestion_account_id)
+    account = base.Account(contract_key)
+
+    # Note: These setup requests are not tracked by locust because we use our own http session
+    host, port = environment.host.split(":")
+    node = cluster.RpcNode(host, port)
+
+    funding_account = base.NearUser.funding_account
+    funding_account.refresh_nonce(node)
+    base.send_transaction(
+        node,
+        base.CreateSubAccount(funding_account, account.key, balance=50000.0),
+    )
+    account.refresh_nonce(node)
+    contract_code = environment.parsed_options.congestion_wasm
+    base.send_transaction(
+        node, base.Deploy(account, contract_code, "Congestion Contract")
+    )
+
+
+# Congestion specific CLI args
+@events.init_command_line_parser.add_listener
+def _(parser):
+    parser.add_argument(
+        "--congestion-wasm",
+        type=str,
+        required=False,
+        help="Path to the compiled congestion contract",
+    )

--- a/pytest/tests/loadtest/locust/common/congestion.py
+++ b/pytest/tests/loadtest/locust/common/congestion.py
@@ -81,8 +81,7 @@ def on_locust_init(environment, **kwargs):
     # single instance of congestion contract.
     funding_account = environment.master_funding_account
     environment.congestion_account_id = (
-        f"congestion.{funding_account.key.account_id}"
-    )
+        f"congestion.{funding_account.key.account_id}")
 
     # Only create congestion contract on master.
     if isinstance(environment.runner, runners.WorkerRunner):
@@ -96,8 +95,7 @@ def on_locust_init(environment, **kwargs):
     funding_account.refresh_nonce(node)
 
     account = base.Account(
-        key.Key.from_random(environment.congestion_account_id)
-    )
+        key.Key.from_random(environment.congestion_account_id))
     base.send_transaction(
         node,
         base.CreateSubAccount(funding_account, account.key, balance=50000.0),

--- a/pytest/tests/loadtest/locust/common/congestion.py
+++ b/pytest/tests/loadtest/locust/common/congestion.py
@@ -90,10 +90,8 @@ def on_locust_init(environment, **kwargs):
     funding_account.refresh_nonce(node)
 
     account = base.Account(
-        key.Key.from_seed_testonly(
-            environment.congestion_account_id, environment.congestion_account_id
-        )
-    )
+        key.Key.from_seed_testonly(environment.congestion_account_id,
+                                   environment.congestion_account_id))
     base.send_transaction(
         node,
         base.CreateSubAccount(funding_account, account.key, balance=50000.0),

--- a/pytest/tests/loadtest/locust/common/congestion.py
+++ b/pytest/tests/loadtest/locust/common/congestion.py
@@ -108,7 +108,7 @@ def on_locust_init(environment, **kwargs):
         base.Deploy(
             account,
             environment.parsed_options.congestion_wasm,
-            "Congestion Contract",
+            "Congestion",
         ),
     )
 

--- a/pytest/tests/loadtest/locust/common/congestion.py
+++ b/pytest/tests/loadtest/locust/common/congestion.py
@@ -34,9 +34,7 @@ class ComputeSha256(base.Transaction):
             "ext_sha256",
             json.dumps(["a" * self.size_bytes]).encode("utf-8"),
             300 * account.TGAS,
-            # Attach exactly 1 yoctoNEAR according to NEP-141 to avoid
-            # calls from restricted access keys.
-            1,
+            0,
             self.sender.use_nonce(),
             block_hash,
         )
@@ -64,9 +62,7 @@ class ComputeSum(base.Transaction):
             # 1000000 is around 12 TGas.
             ((1000000 * self.usage_tgas) // 12).to_bytes(8, byteorder="little"),
             300 * account.TGAS,
-            # Attach exactly 1 yoctoNEAR according to NEP-141 to avoid
-            # calls from restricted access keys.
-            1,
+            0,
             self.sender.use_nonce(),
             block_hash,
         )

--- a/pytest/tests/loadtest/locust/common/congestion.py
+++ b/pytest/tests/loadtest/locust/common/congestion.py
@@ -76,8 +76,7 @@ def on_locust_init(environment, **kwargs):
     # `master_funding_account` is the same on all runners, allowing to share a
     # single instance of congestion contract.
     funding_account = environment.master_funding_account
-    environment.congestion_account_id = (
-        f"congestion.{funding_account.key.account_id}")
+    environment.congestion_account_id = f"congestion.{funding_account.key.account_id}"
 
     # Only create congestion contract on master.
     if isinstance(environment.runner, runners.WorkerRunner):
@@ -91,7 +90,10 @@ def on_locust_init(environment, **kwargs):
     funding_account.refresh_nonce(node)
 
     account = base.Account(
-        key.Key.from_random(environment.congestion_account_id))
+        key.Key.from_seed_testonly(
+            environment.congestion_account_id, environment.congestion_account_id
+        )
+    )
     base.send_transaction(
         node,
         base.CreateSubAccount(funding_account, account.key, balance=50000.0),

--- a/pytest/tests/loadtest/locust/locustfile.py
+++ b/pytest/tests/loadtest/locust/locustfile.py
@@ -109,7 +109,8 @@ class CongestionUser(NearUser):
     @tag("congestion")
     @task
     def compute_sha256(self):
-        self.send_tx(ComputeSha256(self.contract_account_id, self.account, 100000),
+        self.send_tx(ComputeSha256(self.contract_account_id, self.account,
+                                   100000),
                      locust_name="SHA256, 100 KiB")
 
     @tag("congestion")

--- a/pytest/tests/loadtest/locust/locustfile.py
+++ b/pytest/tests/loadtest/locust/locustfile.py
@@ -102,8 +102,7 @@ class SocialDbUser(NearUser):
 
 class CongestionUser(NearUser):
     """
-    Registers itself on near.social in the setup phase, then starts posting,
-    following, and liking posts.
+    Runs transactions that cause congestion.
     """
     wait_time = between(1, 3)  # random pause between transactions
 
@@ -123,15 +122,6 @@ class CongestionUser(NearUser):
     def on_start(self):
         super().on_start()
         if not is_tag_active(self.environment, "congestion"):
-            raise SystemExit("SocialDbUser requires --tag social")
+            raise SystemExit("Congestion requires --tag social")
 
         self.contract_account_id = self.environment.congestion_account_id
-
-        # self.send_tx(InitSocialDbAccount(self.contract_account_id,
-        #                                  self.account),
-        #              locust_name="Init Social Account")
-        logger.debug(
-            f"user {self.account_id} ready to use SocialDB on {self.contract_account_id}"
-        )
-
-        # SocialDbUser.registered_users.append(self.account_id)

--- a/pytest/tools/prober/prober_split.py
+++ b/pytest/tools/prober/prober_split.py
@@ -116,7 +116,8 @@ def check_view_call(legacy_url, split_url):
     legacy_response = json_rpc('query', params, legacy_url)
     split_response = json_rpc('query', params, split_url)
 
-    if legacy_response['result']['result'] != split_response['result']['result']:
+    if legacy_response['result']['result'] != split_response['result'][
+            'result']:
         logger.error(
             f'View call check failed, the legacy response and the split response are different'
             f'\nlegacy response\n{legacy_response}'

--- a/pytest/tools/prober/prober_split.py
+++ b/pytest/tools/prober/prober_split.py
@@ -116,8 +116,7 @@ def check_view_call(legacy_url, split_url):
     legacy_response = json_rpc('query', params, legacy_url)
     split_response = json_rpc('query', params, split_url)
 
-    if legacy_response['result']['result'] != split_response['result'][
-            'result']:
+    if legacy_response['result']['result'] != split_response['result']['result']:
         logger.error(
             f'View call check failed, the legacy response and the split response are different'
             f'\nlegacy response\n{legacy_response}'


### PR DESCRIPTION
This PR introduces a Locust Workload for the Congestion Test: https://github.com/near/nearcore/issues/8920.

A typical run would be:
```sh
CONTRACT="path/to/nearcore/runtime/near-test-contracts/res/test_contract_rs.wasm"
locust -H 127.0.0.1:3030 \
  CongestionUser \
  --congestion-wasm=$CONTRACT \
  --funding-key=$KEY \
  --tags congestion
```

Then cranking up the number of users to 50-200 should be enough to cause congestion.

Wishlist of things I want to improve:
- Remove the need to specify `CONTRACT` variable every time as we know which contract we want to use for each workload type, we just don't know where it is stored
  - We can use the same approach as "runtime/runtime-params-estimator/res/" - submitting WASM contracts that this test depends on alongside the code and update them once in a while.
- Make it possible to specify which exact method of Congestion workload to run as a parameter