### PR TITLE
chain: allow querying shard by account id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3727,6 +3727,7 @@ name = "near-jsonrpc-tests"
 version = "0.0.0"
 dependencies = [
  "actix",
+ "assert_matches",
  "awc",
  "borsh 0.10.2",
  "futures",
@@ -3953,6 +3954,7 @@ dependencies = [
  "enum-map",
  "hex",
  "insta",
+ "near-account-id",
  "near-crypto",
  "near-fmt",
  "near-primitives-core",

--- a/chain/indexer/src/streamer/fetchers.rs
+++ b/chain/indexer/src/streamer/fetchers.rs
@@ -141,8 +141,9 @@ async fn fetch_single_chunk(
     client: &Addr<near_client::ViewClientActor>,
     chunk_hash: near_primitives::hash::CryptoHash,
 ) -> Result<views::ChunkView, FailedToFetchData> {
+    let chunk_hash = near_primitives::sharding::ChunkHash(chunk_hash);
     client
-        .send(near_client::GetChunk::ChunkHash(chunk_hash.into()).with_span_context())
+        .send(near_client::GetChunk::from(chunk_hash).with_span_context())
         .await?
         .map_err(|err| FailedToFetchData::String(err.to_string()))
 }

--- a/chain/jsonrpc/client/src/lib.rs
+++ b/chain/jsonrpc/client/src/lib.rs
@@ -15,10 +15,15 @@ use near_primitives::views::{
 };
 use std::time::Duration;
 
+/// Unique identifier for a chunk.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(untagged)]
 pub enum ChunkId {
+    /// Identifies chunk by block it belongs to and shard index.
     BlockShardId(BlockId, ShardId),
+    /// Identifies chunk by block it belongs to and account held in that shard.
+    BlockAccountId(BlockId, AccountId),
+    /// Identifies chunk by its hash.
     Hash(CryptoHash),
 }
 
@@ -38,7 +43,11 @@ where
     P: serde::Serialize,
     R: serde::de::DeserializeOwned + 'static,
 {
-    let request = Message::request(method.to_string(), serde_json::to_value(&params).unwrap());
+    let request = serde_json::to_value(&params).unwrap();
+    if method == "chunk" {
+        eprintln!("\n\n{request}\n\n");
+    }
+    let request = Message::request(method.to_string(), request);
     // TODO: simplify this.
     client
         .post(server_addr)

--- a/chain/jsonrpc/jsonrpc-tests/Cargo.toml
+++ b/chain/jsonrpc/jsonrpc-tests/Cargo.toml
@@ -28,6 +28,7 @@ near-jsonrpc.workspace = true
 near-jsonrpc-primitives.workspace = true
 
 [dev-dependencies]
+assert_matches.workspace = true
 near-actix-test-utils.workspace = true
 
 [features]

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -35,6 +35,7 @@ thiserror.workspace = true
 time.workspace = true
 tracing.workspace = true
 
+near-account-id = { workspace = true, features = ["arbitrary"] }
 near-crypto.workspace = true
 near-fmt.workspace = true
 near-primitives-core.workspace = true

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -485,6 +485,13 @@ impl StateRootNode {
 #[as_ref(forward)]
 pub struct EpochId(pub CryptoHash);
 
+impl std::fmt::Display for EpochId {
+    #[inline]
+    fn fmt(&self, fmtr: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(fmtr)
+    }
+}
+
 /// Stores validator and its stake for two consecutive epochs.
 /// It is necessary because the blocks on the epoch boundary need to contain approvals from both
 /// epochs.
@@ -846,6 +853,19 @@ impl From<Finality> for BlockReference {
     fn from(finality: Finality) -> Self {
         Self::Finality(finality)
     }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, arbitrary::Arbitrary)]
+#[serde(untagged)]
+pub enum ChunkReference {
+    /// Identifies chunk by its hash.
+    ChunkHash { chunk_id: CryptoHash },
+    /// Identifies chunk by block it belongs to and shard index the chunk is
+    /// for.
+    BlockShardId { block_id: BlockId, shard_id: ShardId },
+    /// Identifies chunk by block it belongs to and account that belongs to the
+    /// shard.
+    BlockAccountId { block_id: BlockId, account_id: AccountId },
 }
 
 #[derive(Default, BorshSerialize, BorshDeserialize, Clone, Debug, PartialEq, Eq)]

--- a/integration-tests/src/tests/nearcore/track_shards.rs
+++ b/integration-tests/src/tests/nearcore/track_shards.rs
@@ -8,6 +8,7 @@ use near_network::test_utils::wait_or_timeout;
 use near_o11y::testonly::init_integration_logger;
 use near_o11y::WithSpanContextExt;
 use near_primitives::hash::CryptoHash;
+use near_primitives::types::{BlockId, ChunkReference};
 
 use crate::tests::nearcore::node_cluster::NodeCluster;
 
@@ -30,8 +31,9 @@ fn track_shards() {
         wait_or_timeout(100, 30000, || async {
             let bh = *last_block_hash.read().unwrap();
             if let Some(block_hash) = bh {
-                let res =
-                    view_client.send(GetChunk::BlockHash(block_hash, 3).with_span_context()).await;
+                let block_id = BlockId::Hash(block_hash);
+                let chunk_ref = ChunkReference::BlockShardId { block_id, shard_id: 3 };
+                let res = view_client.send(GetChunk(chunk_ref).with_span_context()).await;
                 match &res {
                     Ok(Ok(_)) => {
                         return ControlFlow::Break(());


### PR DESCRIPTION
In addition to querying shard headers by block reference + shard id,
add an option to identity shards by block reference + account name.
In that form, the node first figures out which shard given account
lives in on given block and then proceeds to handle the request as if
shard id was provided.

This offers a way for light clients to query mapping from account name
to shard id.  There is currently no way to do it expect to hard-code
the mapping.
