### PR TITLE
fix(state-parts): Adjust state part size

### DIFF
--- a/core/primitives/src/syncing.rs
+++ b/core/primitives/src/syncing.rs
@@ -218,14 +218,10 @@ pub enum EpochSyncResponse {
     Advance { light_client_block_view: LightClientBlockView },
 }
 
-pub const STATE_PART_MEMORY_LIMIT: bytesize::ByteSize = bytesize::ByteSize(bytesize::MIB);
+pub const STATE_PART_MEMORY_LIMIT: bytesize::ByteSize = bytesize::ByteSize(30 * bytesize::MIB);
 
 pub fn get_num_state_parts(memory_usage: u64) -> u64 {
-    // We assume that 1 Mb is a good limit for state part size.
-    // On the other side, it's important to divide any state into
-    // several parts to make sure that partitioning always works.
-    // TODO #1708
-    memory_usage / STATE_PART_MEMORY_LIMIT.as_u64() + 3
+    (memory_usage + STATE_PART_MEMORY_LIMIT.as_u64() - 1) / STATE_PART_MEMORY_LIMIT.as_u64()
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone)]

--- a/core/primitives/src/syncing.rs
+++ b/core/primitives/src/syncing.rs
@@ -245,3 +245,18 @@ pub enum StateSyncDumpProgress {
         sync_hash: CryptoHash,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::syncing::{get_num_state_parts, STATE_PART_MEMORY_LIMIT};
+
+    #[test]
+    fn test_get_num_state_parts() {
+        assert_eq!(get_num_state_parts(0), 0);
+        assert_eq!(get_num_state_parts(1), 1);
+        assert_eq!(get_num_state_parts(STATE_PART_MEMORY_LIMIT.as_u64()), 1);
+        assert_eq!(get_num_state_parts(STATE_PART_MEMORY_LIMIT.as_u64() + 1), 2);
+        assert_eq!(get_num_state_parts(STATE_PART_MEMORY_LIMIT.as_u64() * 100), 100);
+        assert_eq!(get_num_state_parts(STATE_PART_MEMORY_LIMIT.as_u64() * 100 + 1), 101);
+    }
+}

--- a/integration-tests/src/tests/client/state_dump.rs
+++ b/integration-tests/src/tests/client/state_dump.rs
@@ -82,7 +82,7 @@ fn test_state_dump() {
             assert_ne!(num_shards, 0);
 
             for shard_id in 0..num_shards {
-                let num_parts = 3;
+                let num_parts = 1;
                 for part_id in 0..num_parts {
                     let path = root_dir.path().join(external_storage_location(
                         "unittest",


### PR DESCRIPTION
1MB state parts are too inefficient.
The issue is deduplication of contract codes. State part stores values by references. Small state parts only get to store a few contract codes and they are likely to be all unique. Increasing the state part size, a lot more contracts fit into a single state part, and get "compressed" much better.

30MB state part:
* saves 15% of total state dump size for mainnet
* saves 60% of total state dump size for testnet
* 30x-60x reduces the number of state parts. Managing a few thousand files is much easier than 100k files per epoch.

Also this PR removes unconditional addition of 2 state parts. History lost the reasoning for doing it, and not doing it seems to be working fine.