### PR TITLE
near-vm: enable sign-extension instructions

### DIFF
--- a/runtime/near-vm-runner/src/features.rs
+++ b/runtime/near-vm-runner/src/features.rs
@@ -1,0 +1,141 @@
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) struct WasmFeatures {
+    sign_extension: bool,
+}
+
+impl From<near_vm_logic::ContractPrepareVersion> for WasmFeatures {
+    fn from(version: near_vm_logic::ContractPrepareVersion) -> Self {
+        let sign_extension = match version {
+            near_vm_logic::ContractPrepareVersion::V0 => false,
+            near_vm_logic::ContractPrepareVersion::V1 => false,
+            near_vm_logic::ContractPrepareVersion::V2 => true,
+        };
+        WasmFeatures { sign_extension }
+    }
+}
+
+impl From<WasmFeatures> for finite_wasm::wasmparser::WasmFeatures {
+    fn from(f: WasmFeatures) -> Self {
+        finite_wasm::wasmparser::WasmFeatures {
+            floats: true,
+            mutable_global: true,
+            sign_extension: f.sign_extension,
+
+            reference_types: false,
+            // wasmer singlepass compiler requires multi_value return values to be disabled.
+            multi_value: false,
+            bulk_memory: false,
+            simd: false,
+            threads: false,
+            tail_call: false,
+            multi_memory: false,
+            exceptions: false,
+            memory64: false,
+            saturating_float_to_int: false,
+            relaxed_simd: false,
+            extended_const: false,
+            component_model: false,
+            function_references: false,
+            memory_control: false,
+            gc: false,
+        }
+    }
+}
+
+impl From<WasmFeatures> for wasmparser::WasmFeatures {
+    fn from(f: WasmFeatures) -> Self {
+        // /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\
+        //
+        // There are features that this version of wasmparser enables by default, but pwasm
+        // currently does not and the compilers' support for these features is therefore largely
+        // untested if it exists at all. Non exhaustive list of examples:
+        //
+        // * saturating_float_to_int
+        // * sign_extension
+        //
+        // This is instead ensured by the fact that the V0 and V1 use pwasm utils in preparation
+        // and it does not support these extensions.
+        //
+        // /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\
+        wasmparser::WasmFeatures {
+            reference_types: false,
+            multi_value: false,
+            bulk_memory: false,
+            module_linking: false,
+            simd: false,
+            threads: false,
+            tail_call: false,
+            deterministic_only: false,
+            multi_memory: false,
+            exceptions: false,
+            memory64: false,
+        }
+    }
+}
+
+#[cfg(all(feature = "near_vm", target_arch = "x86_64"))]
+impl From<WasmFeatures> for near_vm_types::Features {
+    fn from(f: crate::features::WasmFeatures) -> Self {
+        Self {
+            mutable_global: true,
+            sign_extension: f.sign_extension,
+
+            threads: false,
+            reference_types: false,
+            simd: false,
+            bulk_memory: false,
+            multi_value: false,
+            tail_call: false,
+            multi_memory: false,
+            memory64: false,
+            exceptions: false,
+            saturating_float_to_int: false,
+        }
+    }
+}
+
+#[cfg(all(feature = "wasmer2_vm", target_arch = "x86_64"))]
+impl From<WasmFeatures> for wasmer_types::Features {
+    fn from(f: crate::features::WasmFeatures) -> Self {
+        // /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\
+        //
+        // There are features that this version of wasmparser enables by default, but pwasm
+        // currently does not and the compilers' support for these features is therefore largely
+        // untested if it exists at all. Non exhaustive list of examples:
+        //
+        // * saturating_float_to_int
+        // * sign_extension
+        //
+        // This is instead ensured by the fact that the V0 and V1 use pwasm utils in preparation
+        // and it does not support these extensions.
+        //
+        // /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\
+        Self {
+            threads: false,
+            reference_types: false,
+            simd: false,
+            bulk_memory: false,
+            multi_value: false,
+            tail_call: false,
+            multi_memory: false,
+            memory64: false,
+            exceptions: false,
+            module_linking: false,
+        }
+    }
+}
+
+#[cfg(feature = "wasmtime_vm")]
+impl From<WasmFeatures> for wasmtime::Config {
+    fn from(value: WasmFeatures) -> Self {
+        let mut config = wasmtime::Config::default();
+        config.wasm_threads(false);
+        config.wasm_reference_types(false);
+        config.wasm_simd(false);
+        config.wasm_bulk_memory(false);
+        config.wasm_multi_value(false);
+        config.wasm_multi_memory(false);
+        config.wasm_memory64(false);
+        config
+    }
+}

--- a/runtime/near-vm-runner/src/lib.rs
+++ b/runtime/near-vm-runner/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod cache;
 mod errors;
+mod features;
 mod imports;
 mod instrument;
 #[cfg(all(feature = "wasmer0_vm", target_arch = "x86_64"))]

--- a/runtime/near-vm-runner/src/tests/compile_errors.rs
+++ b/runtime/near-vm-runner/src/tests/compile_errors.rs
@@ -469,21 +469,23 @@ fn extension_saturating_float_to_int() {
 
 #[test]
 fn extension_signext() {
-    let tb = test_builder().wat(
-        r#"
+    let tb = test_builder()
+        .wat(
+            r#"
             (module
                 (func $extend8_s (param $x i32) (result i32) (i32.extend8_s (local.get $x)))
+                (func (export "main"))
             )
             "#,
-    );
-    #[cfg(feature = "nightly")]
-    tb.expect(expect![[r#"
-        VMOutcome: balance 4 storage_usage 12 return data None burnt gas 48017463 used gas 48017463
-        Err: PrepareError: Error happened while deserializing the module.
-    "#]]);
-    #[cfg(not(feature = "nightly"))]
-    tb.expect(expect![[r#"
-        VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
-        Err: PrepareError: Error happened while deserializing the module.
-    "#]]);
+        )
+        .protocol_features(&[ProtocolFeature::PreparationV2]);
+    tb.expects(&[
+        expect![[r#"
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
+            Err: PrepareError: Error happened while deserializing the module.
+        "#]],
+        expect![[r#"
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 58284261 used gas 58284261
+        "#]],
+    ]);
 }

--- a/runtime/near-vm-runner/src/wasmer2_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer2_runner.rs
@@ -1,7 +1,7 @@
 use crate::errors::ContractPrecompilatonResult;
 use crate::imports::wasmer2::Wasmer2Imports;
 use crate::internal::VMKind;
-use crate::prepare::{self, WASM_FEATURES};
+use crate::prepare;
 use crate::runner::VMResult;
 use crate::{get_contract_cache_key, imports};
 use memoffset::offset_of;
@@ -24,22 +24,9 @@ use wasmer_engine::{Engine, Executable};
 use wasmer_engine_universal::{
     Universal, UniversalEngine, UniversalExecutable, UniversalExecutableRef,
 };
-use wasmer_types::{Features, FunctionIndex, InstanceConfig, MemoryType, Pages, WASM_PAGE_SIZE};
+use wasmer_types::{FunctionIndex, InstanceConfig, MemoryType, Pages, WASM_PAGE_SIZE};
 use wasmer_vm::{
     Artifact, Instantiatable, LinearMemory, LinearTable, Memory, MemoryStyle, TrapCode, VMMemory,
-};
-
-const WASMER_FEATURES: Features = Features {
-    threads: WASM_FEATURES.threads,
-    reference_types: WASM_FEATURES.reference_types,
-    simd: WASM_FEATURES.simd,
-    bulk_memory: WASM_FEATURES.bulk_memory,
-    multi_value: WASM_FEATURES.multi_value,
-    tail_call: WASM_FEATURES.tail_call,
-    module_linking: WASM_FEATURES.module_linking,
-    multi_memory: WASM_FEATURES.multi_memory,
-    memory64: WASM_FEATURES.memory64,
-    exceptions: WASM_FEATURES.exceptions,
 };
 
 #[derive(Clone)]
@@ -256,9 +243,11 @@ impl Wasmer2VM {
         let compiler = Singlepass::new();
         // We only support universal engine at the moment.
         assert_eq!(WASMER2_CONFIG.engine, WasmerEngine::Universal);
+        let features =
+            crate::features::WasmFeatures::from(config.limit_config.contract_prepare_version);
         Self {
             config,
-            engine: Universal::new(compiler).target(target).features(WASMER_FEATURES).engine(),
+            engine: Universal::new(compiler).target(target).features(features.into()).engine(),
         }
     }
 


### PR DESCRIPTION
This allows contracts compiled with Rust 1.70 toolchain to work correctly.

This is tied to the `PreparationV2` protocol feature, since any earlier version of the preparation code is unable to support these new instructions.

I also took an opportunity to refactor the handling of webassembly features so it is all in the same place...