### PR TITLE
feat: Adding metric for the delayed receipts queue length

### DIFF
--- a/core/primitives/src/receipt.rs
+++ b/core/primitives/src/receipt.rs
@@ -214,5 +214,11 @@ pub struct DelayedReceiptIndices {
     pub next_available_index: u64,
 }
 
+impl DelayedReceiptIndices {
+    pub fn len(&self) -> u64 {
+        self.next_available_index - self.first_index
+    }
+}
+
 /// Map of shard to list of receipts to send to it.
 pub type ReceiptResult = HashMap<ShardId, Vec<Receipt>>;

--- a/nearcore/src/metrics.rs
+++ b/nearcore/src/metrics.rs
@@ -15,9 +15,9 @@ pub(crate) static APPLY_CHUNK_DELAY: Lazy<HistogramVec> = Lazy::new(|| {
         .unwrap()
 });
 
-pub(crate) static DELAYED_RECEIPTS_QUEUE_LENGTH: Lazy<IntGaugeVec> = Lazy::new(|| {
+pub(crate) static DELAYED_RECEIPTS_COUNT: Lazy<IntGaugeVec> = Lazy::new(|| {
     try_create_int_gauge_vec(
-        "near_delayed_receipts_queue_length",
+        "near_delayed_receipts_count",
         "The length of the delayed receipts queue. Indicator of congestion.",
         &["shard_id"],
     )

--- a/nearcore/src/metrics.rs
+++ b/nearcore/src/metrics.rs
@@ -15,6 +15,15 @@ pub(crate) static APPLY_CHUNK_DELAY: Lazy<HistogramVec> = Lazy::new(|| {
         .unwrap()
 });
 
+pub(crate) static DELAYED_RECEIPTS_QUEUE_LENGTH: Lazy<IntGaugeVec> = Lazy::new(|| {
+    try_create_int_gauge_vec(
+        "near_delayed_receipts_queue_length",
+        "The length of the delayed receipts queue. Indicator of congestion.",
+        &["shard_id"],
+    )
+    .unwrap()
+});
+
 pub(crate) static CONFIG_CORRECT: Lazy<IntGauge> = Lazy::new(|| {
     try_create_int_gauge(
         "near_config_correct",

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -550,6 +550,10 @@ impl NightshadeRuntime {
         metrics::APPLY_CHUNK_DELAY
             .with_label_values(&[&format_total_gas_burnt(total_gas_burnt)])
             .observe(elapsed.as_secs_f64());
+        metrics::DELAYED_RECEIPTS_QUEUE_LENGTH
+            .with_label_values(&[&shard_id.to_string()])
+            .set(apply_result.delayed_receiptes_queue_length as i64);
+
         let total_balance_burnt = apply_result
             .stats
             .tx_burnt_amount

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -550,9 +550,9 @@ impl NightshadeRuntime {
         metrics::APPLY_CHUNK_DELAY
             .with_label_values(&[&format_total_gas_burnt(total_gas_burnt)])
             .observe(elapsed.as_secs_f64());
-        metrics::DELAYED_RECEIPTS_QUEUE_LENGTH
+        metrics::DELAYED_RECEIPTS_COUNT
             .with_label_values(&[&shard_id.to_string()])
-            .set(apply_result.delayed_receiptes_queue_length as i64);
+            .set(apply_result.delayed_receipts_count as i64);
 
         let total_balance_burnt = apply_result
             .stats

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -108,6 +108,7 @@ pub struct ApplyStats {
     pub gas_deficit_amount: Balance,
 }
 
+#[derive(Debug)]
 pub struct ApplyResult {
     pub state_root: StateRoot,
     pub trie_changes: TrieChanges,
@@ -118,6 +119,7 @@ pub struct ApplyResult {
     pub stats: ApplyStats,
     pub processed_delayed_receipts: Vec<Receipt>,
     pub proof: Option<PartialStorage>,
+    pub delayed_receiptes_queue_length: u64,
 }
 
 #[derive(Debug)]
@@ -1235,6 +1237,10 @@ impl Runtime {
             receipts_to_restore.as_slice()
         };
 
+        let mut delayed_receipts_indices: DelayedReceiptIndices =
+            get(&state_update, &TrieKey::DelayedReceiptIndices)?.unwrap_or_default();
+        let initial_delayed_receipt_indices = delayed_receipts_indices.clone();
+
         if !apply_state.is_new_chunk
             && apply_state.current_protocol_version
                 >= ProtocolFeature::FixApplyChunks.protocol_version()
@@ -1251,6 +1257,7 @@ impl Runtime {
                 stats,
                 processed_delayed_receipts: vec![],
                 proof,
+                delayed_receiptes_queue_length: delayed_receipts_indices.len(),
             });
         }
 
@@ -1296,10 +1303,6 @@ impl Runtime {
 
             outcomes.push(outcome_with_id);
         }
-
-        let mut delayed_receipts_indices: DelayedReceiptIndices =
-            get(&state_update, &TrieKey::DelayedReceiptIndices)?.unwrap_or_default();
-        let initial_delayed_receipt_indices = delayed_receipts_indices.clone();
 
         let mut process_receipt = |receipt: &Receipt,
                                    state_update: &mut TrieUpdate,
@@ -1492,6 +1495,7 @@ impl Runtime {
             stats,
             processed_delayed_receipts,
             proof,
+            delayed_receiptes_queue_length: delayed_receipts_indices.len(),
         })
     }
 
@@ -1969,10 +1973,16 @@ mod tests {
                     + small_transfer * Balance::from(num_receipts_processed)
                     + Balance::from(num_receipts_processed * (num_receipts_processed - 1) / 2)
             );
+            let expected_queue_length = num_receipts_given - num_receipts_processed;
             println!(
-                "{} processed out of {} given. With limit {} receipts per block",
-                num_receipts_processed, num_receipts_given, num_receipts_per_block
+                "{} processed out of {} given. With limit {} receipts per block. The expected delayed_receiptes_queue_length is {}. The delayed_receiptes_queue_length is {}.",
+                num_receipts_processed,
+                num_receipts_given,
+                num_receipts_per_block,
+                expected_queue_length,
+                apply_result.delayed_receiptes_queue_length,
             );
+            assert_eq!(apply_result.delayed_receiptes_queue_length, expected_queue_length);
         }
     }
 

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -119,7 +119,7 @@ pub struct ApplyResult {
     pub stats: ApplyStats,
     pub processed_delayed_receipts: Vec<Receipt>,
     pub proof: Option<PartialStorage>,
-    pub delayed_receiptes_queue_length: u64,
+    pub delayed_receipts_count: u64,
 }
 
 #[derive(Debug)]
@@ -1257,7 +1257,7 @@ impl Runtime {
                 stats,
                 processed_delayed_receipts: vec![],
                 proof,
-                delayed_receiptes_queue_length: delayed_receipts_indices.len(),
+                delayed_receipts_count: delayed_receipts_indices.len(),
             });
         }
 
@@ -1495,7 +1495,7 @@ impl Runtime {
             stats,
             processed_delayed_receipts,
             proof,
-            delayed_receiptes_queue_length: delayed_receipts_indices.len(),
+            delayed_receipts_count: delayed_receipts_indices.len(),
         })
     }
 
@@ -1975,14 +1975,14 @@ mod tests {
             );
             let expected_queue_length = num_receipts_given - num_receipts_processed;
             println!(
-                "{} processed out of {} given. With limit {} receipts per block. The expected delayed_receiptes_queue_length is {}. The delayed_receiptes_queue_length is {}.",
+                "{} processed out of {} given. With limit {} receipts per block. The expected delayed_receipts_count is {}. The delayed_receipts_count is {}.",
                 num_receipts_processed,
                 num_receipts_given,
                 num_receipts_per_block,
                 expected_queue_length,
-                apply_result.delayed_receiptes_queue_length,
+                apply_result.delayed_receipts_count,
             );
-            assert_eq!(apply_result.delayed_receiptes_queue_length, expected_queue_length);
+            assert_eq!(apply_result.delayed_receipts_count, expected_queue_length);
         }
     }
 


### PR DESCRIPTION
Adding a new metric for the delayed receipts queue length as part of #8880. 

The delayed receipts are updated in the apply method on runtime. I considered three ways to implement logging the length of that queue:
- Log from the apply method itself. It's nice becase it's right next to where the queue is updated. It's not nice because it would require passing the shard id as an argument to the apply method. In principle I would rather keep runtime agnostic of the shard id as far as possible. 
- Log from the process_state_update method on NightshadeRuntime. 
  - Read the value directly from the trie - seems cumbersome and requires touching the trie. 
  - Get the value passed from the apply method in the ApplyResult - this seems passable as the delayed receipts queue can easily be considered to be a part of the result of apply(). This is the solution that I opted to implement here. 
  
Note - this will likely break in case of a fork in the chain. My guess would be that only one of the forks will be logged and the other will be discarded, based on race conditions. It's not a priority so I am not going to address this issue here. 