### PR TITLE
Set default transaction pool size limit to 100MB.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Non-protocol Changes
 * Dump state by multiple nodes, each node will refer to s3 for which parts need to be dumped. [#9049](https://github.com/near/nearcore/pull/9049)
+* New option `transaction_pool_size_limit` in `config.json` allows to limit the size of the node's transaction pool.
+  By default the limit is set to 100 MB. [#3284](https://github.com/near/nearcore/issues/3284)
 
 ## 1.34.0
 

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -191,6 +191,10 @@ fn default_trie_viewer_state_size_limit() -> Option<u64> {
     Some(50_000)
 }
 
+fn default_transaction_pool_size_limit() -> Option<u64> {
+    Some(100_000_000)  // 100 MB.
+}
+
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct Consensus {
     /// Minimum number of peers to start syncing.
@@ -336,7 +340,7 @@ pub struct Config {
     pub state_sync: Option<StateSyncConfig>,
     /// Limit of the size of per-shard transaction pool measured in bytes. If not set, the size
     /// will be unbounded.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default = "default_transaction_pool_size_limit")]
     pub transaction_pool_size_limit: Option<u64>,
 }
 
@@ -375,7 +379,7 @@ impl Default for Config {
             expected_shutdown: None,
             state_sync: None,
             state_sync_enabled: None,
-            transaction_pool_size_limit: None,
+            transaction_pool_size_limit: default_transaction_pool_size_limit(),
         }
     }
 }

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -192,7 +192,7 @@ fn default_trie_viewer_state_size_limit() -> Option<u64> {
 }
 
 fn default_transaction_pool_size_limit() -> Option<u64> {
-    Some(100_000_000)  // 100 MB.
+    Some(100_000_000) // 100 MB.
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -340,6 +340,10 @@ pub struct Config {
     pub state_sync: Option<StateSyncConfig>,
     /// Limit of the size of per-shard transaction pool measured in bytes. If not set, the size
     /// will be unbounded.
+    /// New transactions that bring the size of the pool over this limit will be rejected. This
+    /// guarantees that the node will use bounded resources to store incoming transactinos.
+    /// Setting this value too low (<1MB) on the validator might lead to production of smaller
+    /// chunks and underutilizing the capacity of the network.
     #[serde(default = "default_transaction_pool_size_limit")]
     pub transaction_pool_size_limit: Option<u64>,
 }


### PR DESCRIPTION
This PR enables the limit discussed in https://github.com/near/nearcore/issues/3284.

I've [considered](https://near.zulipchat.com/#narrow/stream/297873-pagoda.2Fnode/topic/Adding.20a.20new.20field.20to.20config.2Ejson/near/358955785) another approach to rolling this out by changing the value in `config.json` distributed through S3, but that would require more work both on our side and on validators without adding much benefit. 
Specifically, I've checked that we have a good safety margin here, as over the last month on the testnet, the max size of the transaction pool on the validators was < 40 KB: https://nearinc.grafana.net/goto/AhZFN__4R?orgId=1.

@nikurt What would be a good place to document this field for validators? I saw https://near-nodes.io/, but couldn't find the appropriate section there.