### PR TITLE
feat: Reset block head to tail

### DIFF
--- a/tools/undo-block/src/cli.rs
+++ b/tools/undo-block/src/cli.rs
@@ -6,7 +6,11 @@ use nearcore::load_config;
 use std::path::Path;
 
 #[derive(clap::Parser)]
-pub struct UndoBlockCommand {}
+pub struct UndoBlockCommand {
+    /// Only reset the block head to the tail block. Does not reset the header head.
+    #[arg(short, long)]
+    reset_only_body: bool,
+}
 
 impl UndoBlockCommand {
     pub fn run(
@@ -36,6 +40,10 @@ impl UndoBlockCommand {
             near_config.client_config.save_trie_changes,
         );
 
-        crate::undo_block(&mut chain_store, &*epoch_manager)
+        if self.reset_only_body {
+            crate::undo_only_block_head(&mut chain_store, &*epoch_manager)
+        } else {
+            crate::undo_block(&mut chain_store, &*epoch_manager)
+        }
     }
 }


### PR DESCRIPTION
Reset the block head to the tail block to trigger the state sync.

Does not apply the db migration. You need to run `neard run` for that. 

Example of the first run:
```
./neard undo-block -r
2023-06-14T12:31:13.537336Z  INFO neard: version="trunk" build="10778b837" latest_protocol=62
2023-06-14T12:31:13.554894Z  INFO config: Validating Config, extracted from config.json...
2023-06-14T12:31:13.601524Z  WARN genesis: Skipped genesis validation
2023-06-14T12:31:13.601651Z  INFO config: Validating Genesis config and records. This could take a few minutes...
2023-06-14T12:31:13.603661Z  INFO config: All validations have passed!
2023-06-14T12:31:13.604209Z  INFO db_opener: Opening NodeStorage path="/home/ubuntu/.near/data" cold_path="none"
2023-06-14T12:31:13.604279Z  INFO db: Opened a new RocksDB instance. num_instances=1
2023-06-14T12:31:23.052937Z  INFO db: Closed a RocksDB instance. num_instances=0
2023-06-14T12:31:23.053016Z  INFO db_opener: The database exists. path=/home/ubuntu/.near/data
2023-06-14T12:31:23.053052Z  INFO db: Opened a new RocksDB instance. num_instances=1
2023-06-14T12:31:41.361874Z  INFO db: Closed a RocksDB instance. num_instances=0
2023-06-14T12:31:41.362009Z  INFO db: Opened a new RocksDB instance. num_instances=1
2023-06-14T12:31:41.421380Z  INFO db: Closed a RocksDB instance. num_instances=0
2023-06-14T12:31:41.421471Z  INFO db: Opened a new RocksDB instance. num_instances=1
2023-06-14T12:31:41.896566Z  INFO neard: Trying to update head tail_height=93973895 current_head_height=94176168 current_header_height=94176686
2023-06-14T12:31:41.957383Z  INFO neard: The current chain store shows new_head_height=93973895 new_header_height=94176686
2023-06-14T12:31:42.017884Z  INFO db: Closed a RocksDB instance. num_instances=0
```

Example of the second run:
```
./neard undo-block -r
2023-06-14T12:32:39.801573Z  INFO neard: version="trunk" build="10778b837" latest_protocol=62
2023-06-14T12:32:39.802762Z  INFO config: Validating Config, extracted from config.json...
2023-06-14T12:32:39.812411Z  WARN genesis: Skipped genesis validation
2023-06-14T12:32:39.812505Z  INFO config: Validating Genesis config and records. This could take a few minutes...
2023-06-14T12:32:39.814436Z  INFO config: All validations have passed!
2023-06-14T12:32:39.814900Z  INFO db_opener: Opening NodeStorage path="/home/ubuntu/.near/data" cold_path="none"
2023-06-14T12:32:39.814965Z  INFO db: Opened a new RocksDB instance. num_instances=1
2023-06-14T12:32:39.870937Z  INFO db: Closed a RocksDB instance. num_instances=0
2023-06-14T12:32:39.871009Z  INFO db_opener: The database exists. path=/home/ubuntu/.near/data
2023-06-14T12:32:39.871040Z  INFO db: Opened a new RocksDB instance. num_instances=1
2023-06-14T12:32:40.481939Z  INFO db: Closed a RocksDB instance. num_instances=0
2023-06-14T12:32:40.482063Z  INFO db: Opened a new RocksDB instance. num_instances=1
2023-06-14T12:32:40.540065Z  INFO db: Closed a RocksDB instance. num_instances=0
2023-06-14T12:32:40.540150Z  INFO db: Opened a new RocksDB instance. num_instances=1
2023-06-14T12:32:41.007628Z  INFO neard: Trying to update head tail_height=93973895 current_head_height=93973895 current_header_height=94176686
2023-06-14T12:32:41.007697Z  INFO neard: Body head is alreay at the oldest block.
2023-06-14T12:32:41.068641Z  INFO db: Closed a RocksDB instance. num_instances=0
```