### PR TITLE
remove old function checking for protocol version

### DIFF
--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -10,6 +10,7 @@ use crate::types::ProtocolVersion;
 #[derive(Hash, PartialEq, Eq, Clone, Copy, Debug)]
 pub enum ProtocolFeature {
     // stable features
+    ImplicitAccountCreation,
     RectifyInflation,
     /// Add `AccessKey` nonce range by setting nonce to `(block_height - 1) * 1e6`, see
     /// <https://github.com/near/nearcore/issues/3779>.
@@ -125,6 +126,7 @@ impl ProtocolFeature {
     pub const fn protocol_version(self) -> ProtocolVersion {
         match self {
             // Stable features
+            ProtocolFeature::ImplicitAccountCreation => 35,
             ProtocolFeature::LowerStorageCost => 42,
             ProtocolFeature::DeleteActionRestriction => 43,
             ProtocolFeature::FixApplyChunks => 44,

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -29,9 +29,6 @@ pub const MIN_PROTOCOL_VERSION_NEP_92_FIX: ProtocolVersion = 32;
 
 pub const CORRECT_RANDOM_VALUE_PROTOCOL_VERSION: ProtocolVersion = 33;
 
-/// See [NEP 71](https://github.com/nearprotocol/NEPs/pull/71)
-pub const IMPLICIT_ACCOUNT_CREATION_PROTOCOL_VERSION: ProtocolVersion = 35;
-
 /// The protocol version that enables reward on mainnet.
 pub const ENABLE_INFLATION_PROTOCOL_VERSION: ProtocolVersion = 36;
 
@@ -49,10 +46,6 @@ pub const SHARD_CHUNK_HEADER_UPGRADE_VERSION: ProtocolVersion = 41;
 
 /// Updates the way receipt ID is constructed to use current block hash instead of last block hash
 pub const CREATE_RECEIPT_ID_SWITCH_TO_CURRENT_BLOCK_VERSION: ProtocolVersion = 42;
-
-pub fn is_implicit_account_creation_enabled(protocol_version: ProtocolVersion) -> bool {
-    protocol_version >= IMPLICIT_ACCOUNT_CREATION_PROTOCOL_VERSION
-}
 
 /// The points in time after which the voting for the latest protocol version
 /// should start.

--- a/runtime/near-vm-logic/src/logic.rs
+++ b/runtime/near-vm-logic/src/logic.rs
@@ -10,7 +10,6 @@ use near_primitives::checked_feature;
 use near_primitives::config::ViewConfig;
 use near_primitives::profile::ProfileDataV3;
 use near_primitives::runtime::fees::RuntimeFeesConfig;
-use near_primitives::version::is_implicit_account_creation_enabled;
 use near_primitives_core::config::ExtCosts::*;
 use near_primitives_core::config::{ActionCosts, ExtCosts, VMConfig};
 use near_primitives_core::runtime::fees::{transfer_exec_fee, transfer_send_fee};
@@ -1796,7 +1795,7 @@ impl<'a> VMLogic<'a> {
         let (receipt_idx, sir) = self.promise_idx_to_receipt_idx_with_sir(promise_idx)?;
         let receiver_id = self.get_account_by_receipt(receipt_idx);
         let is_receiver_implicit =
-            is_implicit_account_creation_enabled(self.current_protocol_version)
+            checked_feature!("stable", ImplicitAccountCreation, self.current_protocol_version)
                 && receiver_id.is_implicit();
 
         let send_fee = transfer_send_fee(self.fees_config, sir, is_receiver_implicit);

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -24,8 +24,7 @@ use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{AccountId, BlockHeight, EpochInfoProvider, Gas, TrieCacheMode};
 use near_primitives::utils::create_random_seed;
 use near_primitives::version::{
-    is_implicit_account_creation_enabled, ProtocolFeature, ProtocolVersion,
-    DELETE_KEY_STORAGE_USAGE_PROTOCOL_VERSION,
+    ProtocolFeature, ProtocolVersion, DELETE_KEY_STORAGE_USAGE_PROTOCOL_VERSION,
 };
 use near_store::{
     get_access_key, get_code, remove_access_key, remove_account, set_access_key, set_code,
@@ -888,7 +887,7 @@ pub(crate) fn check_account_existence(
                 }
                 .into());
             } else {
-                if is_implicit_account_creation_enabled(current_protocol_version)
+                if checked_feature!("stable", ImplicitAccountCreation, current_protocol_version)
                     && account_id.is_implicit()
                 {
                     // If the account doesn't exist and it's 64-length hex account ID, then you
@@ -909,8 +908,11 @@ pub(crate) fn check_account_existence(
         }
         Action::Transfer(_) => {
             if account.is_none() {
-                return if is_implicit_account_creation_enabled(current_protocol_version)
-                    && is_the_only_action
+                return if checked_feature!(
+                    "stable",
+                    ImplicitAccountCreation,
+                    current_protocol_version
+                ) && is_the_only_action
                     && account_id.is_implicit()
                     && !is_refund
                 {

--- a/runtime/runtime/src/config.rs
+++ b/runtime/runtime/src/config.rs
@@ -15,7 +15,7 @@ use near_primitives::transaction::{
     Action, AddKeyAction, DeployContractAction, FunctionCallAction, Transaction,
 };
 use near_primitives::types::{AccountId, Balance, Compute, Gas};
-use near_primitives::version::{is_implicit_account_creation_enabled, ProtocolVersion};
+use near_primitives::version::{checked_feature, ProtocolVersion};
 
 /// Describes the cost of converting this transaction into a receipt.
 #[derive(Debug)]
@@ -102,7 +102,7 @@ pub fn total_send_fees(
             Transfer(_) => {
                 // Account for implicit account creation
                 let is_receiver_implicit =
-                    is_implicit_account_creation_enabled(current_protocol_version)
+                    checked_feature!("stable", ImplicitAccountCreation, current_protocol_version)
                         && receiver_id.is_implicit();
                 transfer_send_fee(config, sender_is_receiver, is_receiver_implicit)
             }
@@ -205,7 +205,7 @@ pub fn exec_fee(
         Transfer(_) => {
             // Account for implicit account creation
             let is_receiver_implicit =
-                is_implicit_account_creation_enabled(current_protocol_version)
+                checked_feature!("stable", ImplicitAccountCreation, current_protocol_version)
                     && receiver_id.is_implicit();
             transfer_exec_fee(config, is_receiver_implicit)
         }

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -41,9 +41,7 @@ use near_primitives::types::{
 use near_primitives::utils::{
     create_action_hash, create_receipt_id_from_receipt, create_receipt_id_from_transaction,
 };
-use near_primitives::version::{
-    is_implicit_account_creation_enabled, ProtocolFeature, ProtocolVersion,
-};
+use near_primitives::version::{ProtocolFeature, ProtocolVersion};
 use near_store::{
     get, get_account, get_postponed_receipt, get_received_data, remove_postponed_receipt, set,
     set_account, set_postponed_receipt, set_received_data, PartialStorage, ShardTries,
@@ -387,7 +385,9 @@ impl Runtime {
                     }
                 } else {
                     // Implicit account creation
-                    debug_assert!(is_implicit_account_creation_enabled(
+                    debug_assert!(checked_feature!(
+                        "stable",
+                        ImplicitAccountCreation,
                         apply_state.current_protocol_version
                     ));
                     debug_assert!(!is_refund);


### PR DESCRIPTION
Replace `is_implicit_account_creation_enabled` with an actual `ProtocolFeature::ImplicitAccountCreation` 