### PR TITLE
debug/api/network_graph: include next hops

### DIFF
--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -1090,6 +1090,7 @@ impl actix::Handler<GetDebugStatus> for PeerManagerActor {
                         EdgeView { peer0: key.0.clone(), peer1: key.1.clone(), nonce: edge.nonce() }
                     })
                     .collect(),
+                next_hops: (*self.state.graph.routing_table.info().next_hops).clone(),
             }),
             GetDebugStatus::RecentOutboundConnections => {
                 DebugStatus::RecentOutboundConnections(RecentOutboundConnectionsView {

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -454,6 +454,7 @@ pub struct EdgeView {
 #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq)]
 pub struct NetworkGraphView {
     pub edges: Vec<EdgeView>,
+    pub next_hops: HashMap<PeerId, Vec<PeerId>>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq)]


### PR DESCRIPTION
It is currently possible to fetch the list of known edges in the network via the debug api.

This PR adds the node's computed "next hops" as well to the result. It will be useful in understanding and comparing the state of the old routing protocol as we roll out and test the V2 protocol.

The amount of data returned now is roughly double; both the number of edges and the size of the next hop table scale with `num_nodes * max_node_degree`.

The result is potentially large (with 700 nodes each with degree 35, around 3 MB for edges plus next hops), but this API endpoint is used only for manual debugging and is not programmatically queried. In testnet/mainnet nodes, the debug port is typically either blocked entirely or gated behind a password.

Example result via `:3030/debug/api/network_graph`:
<img width="694" alt="image" src="https://github.com/near/nearcore/assets/3241341/312e0607-d0e0-4964-93a2-044ba6162616">
