### PR TITLE
refactor: Separate locust workloads into different files

### DIFF
--- a/pytest/tests/loadtest/locust/README.md
+++ b/pytest/tests/loadtest/locust/README.md
@@ -31,10 +31,9 @@ Then to actually run it, this is the command. (Update ports and IP according to 
 ```sh
 cd pytest/tests/loadtest/locust/
 locust -H 127.0.0.1:3030 \
-  FTTransferUser \
+  -f locustfiles/ft.py \
   --fungible-token-wasm=$CONTRACT \
-  --funding-key=$KEY \
-  --tags ft
+  --funding-key=$KEY
 ```
 
 This will print a link to a web UI where the loadtest can be started and statistics & graphs can be observed.
@@ -56,10 +55,9 @@ will work automagically.)
 Start the master
 ```sh
 locust -H 127.0.0.1:3030 \
-  FTTransferUser \
+  -f locustfiles/ft.py \
   --fungible-token-wasm=$CONTRACT \
   --funding-key=$KEY \
-  --tags ft \
   --master
 ```
 
@@ -70,10 +68,9 @@ On the worker
 ulimit -S -n 100000
 # Run the worker, key must include the same account id as used on master
 locust -H 127.0.0.1:3030 \
-  FTTransferUser \
+  -f locustfiles/ft.py \
   --fungible-token-wasm=$CONTRACT \
   --funding-key=$KEY \
-  --tags ft \
   --worker
 ```
 
@@ -82,10 +79,9 @@ Spawning N workers in a single shell:
 for i in {1..16}
 do
    locust -H 127.0.0.1:3030 \
-    FTTransferUser \
+    -f locustfiles/ft.py \
     --fungible-token-wasm=$CONTRACT \
     --funding-key=$KEY \
-    --tags ft \
     --worker &
 done
 ```
@@ -95,22 +91,16 @@ Stopping the master will also terminate all workers.
 
 # Available load types
 
-User classes can be used as subcommand of `locust` to run a specific load test.
-By default, all user classes are combined. But the example above selects
-specifically `FTTransferUser`.
-
-
-When selecting user classes, it is also necessary to select the right tags that
-control initialization code. For example, running with `locustFTTransferUser`
-requires `--tags ft`.
+Different locust files can be passed as an argument to `locust` to run a specific load test.
+All available workloads can be found in `locustfiles` folder.
 
 Currently supported load types:
 
-| load type | user classes | tag | args | description |
+| load type | file | args | description |
 |---|---|---|---|---|
-| Fungible Token | `FTTransferUser` | `ft` | `--fungible-token-wasm $WASM_PATH` <br> (`--num-ft-contracts $N`) |  Creates `$N` FT contracts per worker, registers each user in one of them. Users transfer FTs between each other. |
-| Social DB  | `SocialDbUser` | `social` | `--social-db-wasm $WASM_PATH` | Creates a single instance of SocialDB and registers users to it. Users post messages and follow other users. (More workload TBD) |
-| Congestion | `CongestionUser` | `congestion` | `--congestion-wasm $WASM_PATH` | Creates a single instance of Congestion contract. Users run large and long transactions. |
+| Fungible Token | ft.py | `--fungible-token-wasm $WASM_PATH` <br> (`--num-ft-contracts $N`) |  Creates `$N` FT contracts per worker, registers each user in one of them. Users transfer FTs between each other. |
+| Social DB  | social.py | `--social-db-wasm $WASM_PATH` | Creates a single instance of SocialDB and registers users to it. Users post messages and follow other users. (More workload TBD) |
+| Congestion | congestion.py | `--congestion-wasm $WASM_PATH` | Creates a single instance of Congestion contract. Users run large and long transactions. |
 
 For the congestion workload you will need to use the following contract:
 

--- a/pytest/tests/loadtest/locust/README.md
+++ b/pytest/tests/loadtest/locust/README.md
@@ -97,7 +97,7 @@ All available workloads can be found in `locustfiles` folder.
 Currently supported load types:
 
 | load type | file | args | description |
-|---|---|---|---|---|
+|---|---|---|---|
 | Fungible Token | ft.py | `--fungible-token-wasm $WASM_PATH` <br> (`--num-ft-contracts $N`) |  Creates `$N` FT contracts per worker, registers each user in one of them. Users transfer FTs between each other. |
 | Social DB  | social.py | `--social-db-wasm $WASM_PATH` | Creates a single instance of SocialDB and registers users to it. Users post messages and follow other users. (More workload TBD) |
 | Congestion | congestion.py | `--congestion-wasm $WASM_PATH` | Creates a single instance of Congestion contract. Users run large and long transactions. |

--- a/pytest/tests/loadtest/locust/common/base.py
+++ b/pytest/tests/loadtest/locust/common/base.py
@@ -302,17 +302,6 @@ def evaluate_rpc_result(rpc_result):
     return result
 
 
-def is_tag_active(environment, tag):
-    run_all = environment.parsed_options.tags is None and \
-        environment.parsed_options.exclude_tags is None
-    opt_in = environment.parsed_options.tags is not None \
-        and tag in environment.parsed_options.tags
-    not_excluded = environment.parsed_options.tags is None \
-        and not environment.parsed_options.exclude_tags is None \
-        and not tag in environment.parsed_options.exclude_tags
-    return run_all or opt_in or not_excluded
-
-
 # called once per process before user initialization
 @events.init.add_listener
 def on_locust_init(environment, **kwargs):

--- a/pytest/tests/loadtest/locust/common/congestion.py
+++ b/pytest/tests/loadtest/locust/common/congestion.py
@@ -70,9 +70,6 @@ class ComputeSum(base.Transaction):
 
 @events.init.add_listener
 def on_locust_init(environment, **kwargs):
-    if not base.is_tag_active(environment, "congestion"):
-        return
-
     # `master_funding_account` is the same on all runners, allowing to share a
     # single instance of congestion contract.
     funding_account = environment.master_funding_account

--- a/pytest/tests/loadtest/locust/common/ft.py
+++ b/pytest/tests/loadtest/locust/common/ft.py
@@ -130,7 +130,8 @@ def on_locust_init(environment, **kwargs):
     if environment.parsed_options.fungible_token_wasm is None:
         raise SystemExit(
             f"Running FT workload requires `--fungible_token_wasm $FT_CONTRACT`. "
-            "Provide the WASM (e.g. nearcore/runtime/near-test-contracts/res/fungible_token.wasm).")
+            "Provide the WASM (e.g. nearcore/runtime/near-test-contracts/res/fungible_token.wasm)."
+        )
 
     # Note: These setup requests are not tracked by locust because we use our own http session
     host, port = environment.host.split(":")

--- a/pytest/tests/loadtest/locust/common/ft.py
+++ b/pytest/tests/loadtest/locust/common/ft.py
@@ -11,7 +11,7 @@ import key
 import transaction
 
 from account import TGAS
-from common.base import Account, CreateSubAccount, Deploy, NearUser, is_tag_active, send_transaction, Transaction
+from common.base import Account, CreateSubAccount, Deploy, NearUser, send_transaction, Transaction
 
 
 class FTContract:
@@ -127,14 +127,10 @@ class InitFTAccount(Transaction):
 
 @events.init.add_listener
 def on_locust_init(environment, **kwargs):
-    if not is_tag_active(environment, "ft"):
-        return
-
     if environment.parsed_options.fungible_token_wasm is None:
         raise SystemExit(
             f"Running FT workload requires `--fungible_token_wasm $FT_CONTRACT`. "
-            "Either provide the WASM (e.g. nearcore/runtime/near-test-contracts/res/fungible_token.wasm) "
-            "or run with `--exclude-tag ft`")
+            "Provide the WASM (e.g. nearcore/runtime/near-test-contracts/res/fungible_token.wasm).")
 
     # Note: These setup requests are not tracked by locust because we use our own http session
     host, port = environment.host.split(":")

--- a/pytest/tests/loadtest/locust/common/social.py
+++ b/pytest/tests/loadtest/locust/common/social.py
@@ -12,7 +12,7 @@ import transaction
 from account import TGAS, NEAR_BASE
 import cluster
 import key
-from common.base import Account, CreateSubAccount, Deploy, NearUser, Transaction, is_tag_active, send_transaction
+from common.base import Account, CreateSubAccount, Deploy, NearUser, Transaction, send_transaction
 from locust import events, runners
 from transaction import create_function_call_action
 
@@ -268,9 +268,6 @@ class TestSocialDbSetMsg(unittest.TestCase):
 
 @events.init.add_listener
 def on_locust_init(environment, **kwargs):
-    if not is_tag_active(environment, "social"):
-        return
-
     # `master_funding_account` is the same on all runners, allowing to share a
     # single instance of SocialDB in its `social` sub account
     funding_account = environment.master_funding_account
@@ -281,8 +278,7 @@ def on_locust_init(environment, **kwargs):
         if environment.parsed_options.social_db_wasm is None:
             raise SystemExit(
                 f"Running SocialDB workload requires `--social_db_wasm $SOCIAL_CONTRACT`. "
-                "Either provide the WASM (can be downloaded from https://github.com/NearSocial/social-db/tree/aa7fafaac92a7dd267993d6c210246420a561370/res) "
-                "or run with `--exclude-tag social`")
+                "Provide the WASM (can be downloaded from https://github.com/NearSocial/social-db/tree/aa7fafaac92a7dd267993d6c210246420a561370/res).")
 
         social_contract_code = environment.parsed_options.social_db_wasm
         contract_key = key.Key.from_random(environment.social_account_id)

--- a/pytest/tests/loadtest/locust/common/social.py
+++ b/pytest/tests/loadtest/locust/common/social.py
@@ -278,7 +278,8 @@ def on_locust_init(environment, **kwargs):
         if environment.parsed_options.social_db_wasm is None:
             raise SystemExit(
                 f"Running SocialDB workload requires `--social_db_wasm $SOCIAL_CONTRACT`. "
-                "Provide the WASM (can be downloaded from https://github.com/NearSocial/social-db/tree/aa7fafaac92a7dd267993d6c210246420a561370/res).")
+                "Provide the WASM (can be downloaded from https://github.com/NearSocial/social-db/tree/aa7fafaac92a7dd267993d6c210246420a561370/res)."
+            )
 
         social_contract_code = environment.parsed_options.social_db_wasm
         contract_key = key.Key.from_random(environment.social_account_id)

--- a/pytest/tests/loadtest/locust/locustfiles/congestion.py
+++ b/pytest/tests/loadtest/locust/locustfiles/congestion.py
@@ -1,0 +1,38 @@
+"""
+A workload that generates congestion.
+"""
+
+import logging
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[4] / 'lib'))
+
+from configured_logger import new_logger
+from locust import between, task
+from common.base import NearUser
+from common.congestion import ComputeSha256, ComputeSum
+
+logger = new_logger(level=logging.WARN)
+
+
+class CongestionUser(NearUser):
+    """
+    Runs a resource-heavy workload that is likely to cause congestion.
+    """
+    wait_time = between(1, 3)  # random pause between transactions
+
+    @task
+    def compute_sha256(self):
+        self.send_tx(ComputeSha256(self.contract_account_id, self.account,
+                                   100000),
+                     locust_name="SHA256, 100 KiB")
+
+    @task
+    def compute_sum(self):
+        self.send_tx(ComputeSum(self.contract_account_id, self.account, 250),
+                     locust_name="Sum, 250 TGas")
+
+    def on_start(self):
+        super().on_start()
+        self.contract_account_id = self.environment.congestion_account_id

--- a/pytest/tests/loadtest/locust/locustfiles/ft.py
+++ b/pytest/tests/loadtest/locust/locustfiles/ft.py
@@ -1,0 +1,39 @@
+"""
+A workload with Fungible Token operations.
+"""
+
+import logging
+import pathlib
+import random
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[4] / 'lib'))
+
+from configured_logger import new_logger
+from locust import between, task
+from common.base import NearUser
+from common.ft import TransferFT
+
+logger = new_logger(level=logging.WARN)
+
+
+class FTTransferUser(NearUser):
+    """
+    Registers itself on an FT contract in the setup phase, then just sends FTs to
+    random users.
+    """
+    wait_time = between(1, 3)  # random pause between transactions
+
+    @task
+    def ft_transfer(self):
+        receiver = self.ft.random_receiver(self.account_id)
+        tx = TransferFT(self.ft.account, self.account, receiver, how_much=1)
+        self.send_tx(tx, locust_name="FT transfer")
+
+    def on_start(self):
+        super().on_start()
+        self.ft = random.choice(self.environment.ft_contracts)
+        self.ft.register_user(self)
+        logger.debug(
+            f"{self.account_id} ready to use FT contract {self.ft.account.key.account_id}"
+        )


### PR DESCRIPTION
This removes the need for tags and makes the start command simpler. We still can combine the workloads by passing multiple locustfiles during launch as in:
```sh
locust -H 127.0.0.1:3030 \
     -f locustfiles/ft.py,locustfiles/social.py \
     --fungible-token-wasm=$FT_CONTRACT \
     --social-db-wasm=$SOCIAL_DB_CONTRACT \
     --funding-key=$KEY \
     --headless
```

Because we don't import all workloads in a single file, there is no need to conditionally check for tags in the library modules, so I got rid of `is_tag_active` altogether.