### PR TITLE
near-vm: remove dynamically typed APIs from near_vm

### DIFF
--- a/runtime/near-vm/api/src/sys/externals/function.rs
+++ b/runtime/near-vm/api/src/sys/externals/function.rs
@@ -268,7 +268,7 @@ impl Function {
         let address = std::ptr::null() as *const VMFunctionBody;
         let vmctx = VMFunctionEnvironment { host_env };
         let signature = store
-            .engine()
+            .dyn_engine()
             // TODO(0-copy):
             .register_signature(ty);
 
@@ -319,7 +319,7 @@ impl Function {
         let address = function.address() as *const VMFunctionBody;
         let vmctx = VMFunctionEnvironment { host_env: std::ptr::null_mut() as *mut _ };
         let signature = store
-            .engine()
+            .dyn_engine()
             // TODO(0-copy):
             .register_signature(function.ty());
 
@@ -382,7 +382,7 @@ impl Function {
             build_export_function_metadata::<Env>(env, Env::init_with_instance);
 
         let vmctx = VMFunctionEnvironment { host_env };
-        let signature = store.engine().register_signature(function.ty());
+        let signature = store.dyn_engine().register_signature(function.ty());
         Self {
             store: store.clone(),
             exported: ExportFunction {
@@ -418,7 +418,7 @@ impl Function {
     /// ```
     pub fn ty(&self) -> FunctionType {
         self.store
-            .engine()
+            .dyn_engine()
             .lookup_signature(self.exported.vm_function.signature)
             .expect("Could not resolve VMSharedFunctionIndex! Mixing engines?")
     }
@@ -590,7 +590,7 @@ impl Function {
     }
 
     pub(crate) fn vm_funcref(&self) -> VMFuncRef {
-        let engine = self.store.engine();
+        let engine = self.store.dyn_engine();
         engine.register_function_metadata(VMCallerCheckedAnyfunc {
             func_ptr: self.exported.vm_function.address,
             type_index: self.exported.vm_function.signature,
@@ -678,7 +678,7 @@ impl Function {
         Args: WasmTypeList,
         Rets: WasmTypeList,
     {
-        let engine = self.store().engine();
+        let engine = self.store().dyn_engine();
         let signature = engine
             .lookup_signature(self.exported.vm_function.signature)
             .expect("Could not resolve VMSharedSignatureIndex! Wrong engine?");

--- a/runtime/near-vm/api/src/sys/store.rs
+++ b/runtime/near-vm/api/src/sys/store.rs
@@ -45,8 +45,13 @@ impl Store {
     }
 
     /// Returns the [`Engine`].
-    pub fn engine(&self) -> &Arc<dyn Engine + Send + Sync> {
-        &self.engine
+    pub fn engine<E: Engine + 'static>(&self) -> Result<Arc<E>, Arc<dyn Engine + Send + Sync>> {
+        Arc::clone(&self.engine).downcast_arc()
+    }
+
+    /// Returns the [`Engine`].
+    pub fn dyn_engine(&self) -> &(dyn Engine + Send + Sync) {
+        &*self.engine
     }
 
     /// Checks whether two stores are identical. A store is considered

--- a/runtime/near-vm/engine-universal/src/engine.rs
+++ b/runtime/near-vm/engine-universal/src/engine.rs
@@ -481,37 +481,6 @@ impl Engine for UniversalEngine {
         self.inner().validate(binary)
     }
 
-    #[cfg(not(feature = "compiler"))]
-    fn compile(
-        &self,
-        binary: &[u8],
-        tunables: &dyn Tunables,
-    ) -> Result<Box<dyn near_vm_engine::Executable>, CompileError> {
-        return Err(CompileError::Codegen(
-            "The UniversalEngine is operating in headless mode, so it can not compile Modules."
-                .to_string(),
-        ));
-    }
-
-    /// Compile a WebAssembly binary
-    #[cfg(feature = "compiler")]
-    #[tracing::instrument(skip_all)]
-    fn compile(
-        &self,
-        binary: &[u8],
-        tunables: &dyn Tunables,
-    ) -> Result<Box<dyn near_vm_engine::Executable>, CompileError> {
-        self.compile_universal(binary, tunables).map(|ex| Box::new(ex) as _)
-    }
-
-    #[tracing::instrument(skip_all)]
-    fn load(
-        &self,
-        executable: &(dyn near_vm_engine::Executable),
-    ) -> Result<Arc<dyn near_vm_vm::Artifact>, CompileError> {
-        executable.load(self)
-    }
-
     fn id(&self) -> &EngineId {
         &self.engine_id
     }

--- a/runtime/near-vm/engine-universal/src/executable.rs
+++ b/runtime/near-vm/engine-universal/src/executable.rs
@@ -1,17 +1,14 @@
-use std::sync::Arc;
-
 use enumset::EnumSet;
 use near_vm_compiler::{
-    CompileError, CompileModuleInfo, CompiledFunctionFrameInfo, CpuFeature, CustomSection, Dwarf,
+    CompileModuleInfo, CompiledFunctionFrameInfo, CpuFeature, CustomSection, Dwarf,
     Features, FunctionBody, JumpTableOffsets, Relocation, SectionIndex, TrampolinesSection,
 };
-use near_vm_engine::{DeserializeError, Engine};
+use near_vm_engine::DeserializeError;
 use near_vm_types::entity::PrimaryMap;
 use near_vm_types::{
     ExportIndex, FunctionIndex, ImportIndex, LocalFunctionIndex, OwnedDataInitializer,
     SignatureIndex,
 };
-use near_vm_vm::Artifact;
 use rkyv::de::deserializers::SharedDeserializeMap;
 use rkyv::ser::serializers::{
     AllocScratchError, AllocSerializer, CompositeSerializerError, SharedSerializeMapError,
@@ -127,17 +124,6 @@ pub enum ExecutableSerializeError {
 }
 
 impl near_vm_engine::Executable for UniversalExecutable {
-    fn load(
-        &self,
-        engine: &(dyn Engine + 'static),
-    ) -> Result<std::sync::Arc<dyn Artifact>, CompileError> {
-        engine
-            .downcast_ref::<crate::UniversalEngine>()
-            .ok_or(CompileError::EngineDowncast)?
-            .load_universal_executable(self)
-            .map(|a| Arc::new(a) as _)
-    }
-
     fn features(&self) -> Features {
         self.compile_info.features.clone()
     }
@@ -189,17 +175,6 @@ impl near_vm_engine::Executable for UniversalExecutable {
 }
 
 impl<'a> near_vm_engine::Executable for UniversalExecutableRef<'a> {
-    fn load(
-        &self,
-        engine: &(dyn Engine + 'static),
-    ) -> Result<std::sync::Arc<dyn Artifact>, CompileError> {
-        engine
-            .downcast_ref::<crate::UniversalEngine>()
-            .ok_or_else(|| CompileError::Codegen("can't downcast TODO FIXME".into()))?
-            .load_universal_executable_ref(self)
-            .map(|a| Arc::new(a) as _)
-    }
-
     fn features(&self) -> Features {
         unrkyv(&self.archive.compile_info.features)
     }

--- a/runtime/near-vm/engine/src/executable.rs
+++ b/runtime/near-vm/engine/src/executable.rs
@@ -1,8 +1,6 @@
-use crate::Engine;
 use enumset::EnumSet;
-use near_vm_compiler::{CompileError, CpuFeature, Features};
+use near_vm_compiler::{CpuFeature, Features};
 use near_vm_types::FunctionIndex;
-use near_vm_vm::Artifact;
 
 mod private {
     pub struct Internal(pub(super) ());
@@ -13,14 +11,6 @@ mod private {
 /// Types implementing this trait are ready to be saved (to e.g. disk) for later use or loaded with
 /// the `Engine` to in order to produce an [`Artifact`](crate::Artifact).
 pub trait Executable {
-    /// Load this executable with the specified engine.
-    ///
-    /// TODO(0-copy): change error type here.
-    fn load(
-        &self,
-        engine: &(dyn Engine + 'static),
-    ) -> Result<std::sync::Arc<dyn Artifact>, CompileError>;
-
     /// The features with which this `Executable` was built.
     fn features(&self) -> Features;
 

--- a/runtime/near-vm/tests/compilers/compilation.rs
+++ b/runtime/near-vm/tests/compilers/compilation.rs
@@ -11,16 +11,16 @@ fn slow_to_compile_contract(n_fns: usize, n_locals: usize) -> Vec<u8> {
 
 fn compile_uncached<'a>(
     store: &'a Store,
-    engine: &'a dyn Engine,
+    engine: &'a UniversalEngine,
     code: &'a [u8],
     time: bool,
-) -> Result<Box<dyn near_vm_engine::Executable>, CompileError> {
+) -> Result<near_vm_engine_universal::UniversalExecutable, CompileError> {
     use std::time::Instant;
     let now = Instant::now();
     engine.validate(code)?;
     let validate = now.elapsed().as_millis();
     let now = Instant::now();
-    let res = engine.compile(code, store.tunables());
+    let res = engine.compile_universal(code, store.tunables());
     let compile = now.elapsed().as_millis();
     if time {
         println!("validate {}ms compile {}ms", validate, compile);

--- a/runtime/near-vm/tests/compilers/deterministic.rs
+++ b/runtime/near-vm/tests/compilers/deterministic.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use near_vm::{wat2wasm, BaseTunables, Engine};
 use near_vm_compiler_singlepass::Singlepass;
+use near_vm_engine::Executable;
 use near_vm_engine_universal::Universal;
 
 fn compile_and_compare(wasm: &[u8]) -> Result<()> {
@@ -9,11 +10,11 @@ fn compile_and_compare(wasm: &[u8]) -> Result<()> {
     let tunables = BaseTunables::for_target(engine.target());
 
     // compile for first time
-    let executable = engine.compile(wasm, &tunables).unwrap();
+    let executable = engine.compile_universal(wasm, &tunables).unwrap();
     let serialized1 = executable.serialize().unwrap();
 
     // compile for second time
-    let executable = engine.compile(wasm, &tunables).unwrap();
+    let executable = engine.compile_universal(wasm, &tunables).unwrap();
     let serialized2 = executable.serialize().unwrap();
 
     assert_eq!(serialized1, serialized2);

--- a/runtime/near-vm/tests/compilers/serialize.rs
+++ b/runtime/near-vm/tests/compilers/serialize.rs
@@ -14,11 +14,12 @@ fn test_serialize(config: crate::Config) -> Result<()> {
         .as_bytes(),
     )
     .unwrap();
-    let engine = store.engine();
-    let tunables = BaseTunables::for_target(engine.target());
-    let executable = engine.compile(&wasm, &tunables).unwrap();
-    let serialized = executable.serialize().unwrap();
-    assert!(!serialized.is_empty());
+    if let Ok(engine) = store.engine::<UniversalEngine>() {
+        let tunables = BaseTunables::for_target(engine.target());
+        let executable = engine.compile_universal(&wasm, &tunables).unwrap();
+        let serialized = near_vm_engine::Executable::serialize(&executable).unwrap();
+        assert!(!serialized.is_empty());
+    }
     Ok(())
 }
 

--- a/runtime/near-vm/vm/src/artifact.rs
+++ b/runtime/near-vm/vm/src/artifact.rs
@@ -86,7 +86,8 @@ impl dyn Artifact {
     /// Downcast a dynamic Executable object to a concrete implementation of the trait.
     pub fn downcast_arc<T: Artifact + 'static>(self: Arc<Self>) -> Result<Arc<T>, Arc<Self>> {
         if std::any::TypeId::of::<T>() == Artifact::type_id(&*self, private::Internal(())) {
-            // SAFETY: err, its probably sound, we effectively construct a transmute here.
+            // SAFETY: The data pointer is the same between the dynamically and statically typed
+            // `Arc`s.
             unsafe {
                 let ptr = Arc::into_raw(self).cast::<T>();
                 Ok(Arc::from_raw(ptr))


### PR DESCRIPTION
Oringally these have existed to enable switching out the backends in wasmer, however we kept only just the Universal* backend for near-vm, so this dynamicism is unnecessary and overcomplicates the code for no reason (as evidenced by the fact that most of the relevant changes are in the tests!)