### PR TITLE
fix: Change `post_json` type annotation

### DIFF
--- a/pytest/tests/loadtest/locust/common/base.py
+++ b/pytest/tests/loadtest/locust/common/base.py
@@ -192,7 +192,7 @@ class NearNodeProxy:
         self.request_event.fire(**meta)
         return meta["response"]
 
-    def post_json(self, method: str, params: list(str)):
+    def post_json(self, method: str, params: list[str]):
         j = {
             "method": method,
             "params": params,


### PR DESCRIPTION
As the previous fails with:
```
  File "/home/ubuntu/repos/nearcore/pytest/tests/loadtest/locust/common/base.py", line 195, in NearNodeProxy
    def post_json(self, method: str, params: list(str)):
                                             ^^^^^^^^^
TypeError: 'type' object is not iterable
```