### PR TITLE
Stop accepting transactions when number of delayed receipts is large

### DIFF
--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -60,8 +60,8 @@ use near_primitives::sharding::{
 };
 use near_primitives::state_part::PartId;
 use near_primitives::syncing::{get_num_state_parts, StatePartKey};
-use near_primitives::test_utils::TestBlockBuilder;
 use near_primitives::test_utils::create_test_signer;
+use near_primitives::test_utils::TestBlockBuilder;
 use near_primitives::transaction::{
     Action, DeployContractAction, ExecutionStatus, FunctionCallAction, SignedTransaction,
     Transaction,
@@ -2862,11 +2862,7 @@ fn test_delayed_receipt_count_limit() {
 
     let epoch_length = 5;
     let min_gas_price = 10000;
-    let mut genesis = Genesis::test_sharded_new_version(
-        vec!["test0".parse().unwrap()],
-        1,
-        vec![1],
-    );
+    let mut genesis = Genesis::test_sharded_new_version(vec!["test0".parse().unwrap()], 1, vec![1]);
     genesis.config.epoch_length = epoch_length;
     genesis.config.min_gas_price = min_gas_price;
     // Set gas limit to be small enough to produce some delayed receipts, but large enough for

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -2861,7 +2861,7 @@ fn test_refund_receipts_processing() {
             assert_matches!(
                 receipt_outcome.outcome_with_id.outcome.status,
                 ExecutionStatus::Failure(TxExecutionError::ActionError(_))
-                );
+            );
             refund_receipt_ids.extend(receipt_outcome.outcome_with_id.outcome.receipt_ids);
         } else {
             unreachable!("Transaction must succeed");

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -2871,8 +2871,8 @@ fn test_delayed_receipt_count_limit() {
     genesis.config.min_gas_price = min_gas_price;
     // Set gas limit to be small enough to produce some delayed receipts, but large enough for
     // transactions to get through.
-    let transaction_costs = RuntimeConfig::test().fees;
     // This will result in delayed receipt count limit of 20.
+    let transaction_costs = RuntimeConfig::test().fees;
     let chunk_gas_limit = 10 * transaction_costs.fee(ActionCosts::new_action_receipt).exec_fee();
     genesis.config.gas_limit = chunk_gas_limit;
     let chain_genesis = ChainGenesis::new(&genesis);

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -46,8 +46,8 @@ use near_o11y::WithSpanContextExt;
 use near_primitives::block::{Approval, ApprovalInner};
 use near_primitives::block_header::BlockHeader;
 use near_primitives::epoch_manager::RngSeed;
-use near_primitives::errors::InvalidTxError;
 use near_primitives::errors::TxExecutionError;
+use near_primitives::errors::{ActionError, ActionErrorKind, InvalidTxError};
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::merkle::{verify_hash, PartialMerkleTree};
 use near_primitives::receipt::DelayedReceiptIndices;
@@ -60,8 +60,8 @@ use near_primitives::sharding::{
 };
 use near_primitives::state_part::PartId;
 use near_primitives::syncing::{get_num_state_parts, StatePartKey};
-use near_primitives::test_utils::create_test_signer;
 use near_primitives::test_utils::TestBlockBuilder;
+use near_primitives::test_utils::{create_test_signer, encode};
 use near_primitives::transaction::{
     Action, DeployContractAction, ExecutionStatus, FunctionCallAction, SignedTransaction,
     Transaction,
@@ -2829,7 +2829,10 @@ fn test_refund_receipts_processing() {
             let receipt_outcome = env.clients[0].chain.get_execution_outcome(&id).unwrap();
             assert_matches!(
                 receipt_outcome.outcome_with_id.outcome.status,
-                ExecutionStatus::Failure(TxExecutionError::ActionError(_))
+                ExecutionStatus::Failure(TxExecutionError::ActionError(ActionError {
+                    kind: ActionErrorKind::AccountDoesNotExist { .. },
+                    ..
+                }))
             );
             let execution_outcomes_from_block = env.clients[0]
                 .chain
@@ -2839,6 +2842,120 @@ fn test_refund_receipts_processing() {
                 .remove(&0)
                 .unwrap();
             assert_eq!(execution_outcomes_from_block.len(), 1);
+            let chunk_extra = env.clients[0]
+                .chain
+                .get_chunk_extra(&receipt_outcome.block_hash, &test_shard_uid)
+                .unwrap()
+                .clone();
+            assert!(chunk_extra.gas_used() >= chunk_extra.gas_limit());
+        } else {
+            unreachable!("Transaction must succeed");
+        }
+    }
+}
+
+// Tests that the number of delayed receipts in each shard is bounded based on the gas limit of
+// the chunk and any new receipts are not included if there are too many delayed receipts.
+#[test]
+fn test_delayed_receipt_count_limit() {
+    init_test_logger();
+
+    let epoch_length = 5;
+    let min_gas_price = 10000;
+    let mut genesis = Genesis::test_sharded_new_version(
+        vec!["test0".parse().unwrap(), "test1".parse().unwrap()],
+        1,
+        vec![1],
+    );
+    genesis.config.epoch_length = epoch_length;
+    genesis.config.min_gas_price = min_gas_price;
+    // Set gas limit to be small enough to produce some delayed receipts, but large enough for
+    // transactions to get through.
+    let transaction_costs = RuntimeConfig::test().fees;
+    // This will result in delayed receipt count limit of 8 and up to 2 transactions included in
+    // each chunk.
+    let chunk_gas_limit = 4 * transaction_costs.fee(ActionCosts::new_action_receipt).exec_fee();
+    genesis.config.gas_limit = chunk_gas_limit;
+    let chain_genesis = ChainGenesis::new(&genesis);
+    let mut env = TestEnv::builder(chain_genesis)
+        .real_epoch_managers(&genesis.config)
+        .nightshade_runtimes(&genesis)
+        .build();
+    let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
+    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+
+    let deploy_tx = SignedTransaction::from_actions(
+        1,
+        "test0".parse().unwrap(),
+        "test0".parse().unwrap(),
+        &signer,
+        vec![Action::DeployContract(DeployContractAction {
+            code: near_test_contracts::rs_contract().to_vec(),
+        })],
+        *genesis_block.hash(),
+    );
+    let deploy_tx_hash = deploy_tx.get_hash();
+    assert_eq!(env.clients[0].process_tx(deploy_tx, false, false), ProcessTxResponse::ValidTx);
+    for i in 1..3 {
+        env.produce_block(0, i);
+    }
+    assert_matches!(
+        env.clients[0]
+            .chain
+            .get_execution_outcome(&deploy_tx_hash)
+            .unwrap()
+            .outcome_with_id
+            .outcome
+            .status,
+        ExecutionStatus::SuccessReceiptId(_)
+    );
+
+    let mut tx_hashes = vec![];
+    for i in 1..3 {
+        // This transaction will run out of gas (and consume all attached gas).
+        let tx = SignedTransaction::from_actions(
+            i + 1,
+            "test0".parse().unwrap(),
+            "test0".parse().unwrap(),
+            &signer,
+            vec![Action::FunctionCall(FunctionCallAction {
+                method_name: "sum_n".to_string(),
+                args: encode(&[10000u64]),
+                gas: chunk_gas_limit,
+                deposit: 0,
+            })],
+            *genesis_block.hash(),
+        );
+        tx_hashes.push(tx.get_hash());
+        assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+    }
+
+    // Make sure all transactions are processed.
+    for i in 4..16 {
+        env.produce_block(0, i);
+    }
+
+    let test_shard_uid = ShardUId { version: 1, shard_id: 0 };
+    for tx_hash in tx_hashes {
+        let tx_outcome = env.clients[0].chain.get_execution_outcome(&tx_hash).unwrap();
+        assert_eq!(tx_outcome.outcome_with_id.outcome.receipt_ids.len(), 1);
+        if let ExecutionStatus::SuccessReceiptId(id) = tx_outcome.outcome_with_id.outcome.status {
+            let receipt_outcome = env.clients[0].chain.get_execution_outcome(&id).unwrap();
+            assert_matches!(
+                receipt_outcome.outcome_with_id.outcome.status,
+                ExecutionStatus::Failure(TxExecutionError::ActionError(ActionError {
+                    kind: ActionErrorKind::FunctionCallError { .. },
+                    ..
+                }))
+            );
+            let execution_outcomes_from_block = env.clients[0]
+                .chain
+                .store()
+                .get_block_execution_outcomes(&receipt_outcome.block_hash)
+                .unwrap()
+                .remove(&0)
+                .unwrap();
+            assert!(execution_outcomes_from_block.len() <= 8);
             let chunk_extra = env.clients[0]
                 .chain
                 .get_chunk_extra(&receipt_outcome.block_hash, &test_shard_uid)

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -698,7 +698,8 @@ impl RuntimeAdapter for NightshadeRuntime {
         // a bound of at most 10000 receipts processed in a chunk.
         let delayed_receipts_indices: DelayedReceiptIndices =
             near_store::get(&state_update, &TrieKey::DelayedReceiptIndices)?.unwrap_or_default();
-        let new_receipt_count_limit = if let min_fee = runtime_config.fees.fee(ActionCosts::new_action_receipt).exec_fee() > 0 {
+        let min_fee = runtime_config.fees.fee(ActionCosts::new_action_receipt).exec_fee();
+        let new_receipt_count_limit = if min_fee > 0 {
             let max_processed_receipts_in_chunk = gas_limit / min_fee;
             max_processed_receipts_in_chunk.saturating_sub(delayed_receipts_indices.len()) as usize
         } else {

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -698,10 +698,12 @@ impl RuntimeAdapter for NightshadeRuntime {
         // a bound of at most 10000 receipts processed in a chunk.
         let delayed_receipts_indices: DelayedReceiptIndices =
             near_store::get(&state_update, &TrieKey::DelayedReceiptIndices)?.unwrap_or_default();
-        let max_processed_receipts_in_chunk =
-            gas_limit / runtime_config.fees.fee(ActionCosts::new_action_receipt).exec_fee();
-        let new_receipt_count_limit =
-            max_processed_receipts_in_chunk.saturating_sub(delayed_receipts_indices.len()) as usize;
+        let new_receipt_count_limit = if let min_fee = runtime_config.fees.fee(ActionCosts::new_action_receipt).exec_fee() > 0 {
+            let max_processed_receipts_in_chunk = gas_limit / min_fee;
+            max_processed_receipts_in_chunk.saturating_sub(delayed_receipts_indices.len()) as usize
+        } else {
+            usize::MAX
+        };
 
         // In general, we limit the number of transactions via send_fees.
         // However, as a second line of defense, we want to limit the byte size

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -700,7 +700,8 @@ impl RuntimeAdapter for NightshadeRuntime {
             near_store::get(&state_update, &TrieKey::DelayedReceiptIndices)?.unwrap_or_default();
         let min_fee = runtime_config.fees.fee(ActionCosts::new_action_receipt).exec_fee();
         let new_receipt_count_limit = if min_fee > 0 {
-            let max_processed_receipts_in_chunk = gas_limit / min_fee;
+            // Round up to include at least one receipt.
+            let max_processed_receipts_in_chunk = (gas_limit + min_fee - 1) / min_fee;
             max_processed_receipts_in_chunk.saturating_sub(delayed_receipts_indices.len()) as usize
         } else {
             usize::MAX

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -18,7 +18,7 @@ use near_primitives::config::ExtCosts;
 use near_primitives::contract::ContractCode;
 use near_primitives::errors::{InvalidTxError, RuntimeError, StorageError};
 use near_primitives::hash::{hash, CryptoHash};
-use near_primitives::receipt::{Receipt, DelayedReceiptIndices};
+use near_primitives::receipt::{DelayedReceiptIndices, Receipt};
 use near_primitives::runtime::config_store::RuntimeConfigStore;
 use near_primitives::runtime::migration_data::{MigrationData, MigrationFlags};
 use near_primitives::sandbox::state_patch::SandboxStatePatch;


### PR DESCRIPTION
This PR introduces a soft limit on the number of delayed receipts in each shard. The limit is around 10000 delayed receipts to make sure this is enough to saturate the chunk capacity even if receipts are very small. The largest number of delayed receipts that we've seen in the last 3 months is around 400 and it stays at 0 most of the time.

In the future, we would be also using other signals like the size of delayed receipts, but this information will have to be first computed and stored in the chunk headers/trie store and will be done in https://github.com/near/nearcore/issues/9228.

Addresses: https://github.com/near/nearcore/issues/8877