### PR TITLE
feat(loadtest): handle invalid nonce

### DIFF
--- a/pytest/tests/loadtest/locust/common/base.py
+++ b/pytest/tests/loadtest/locust/common/base.py
@@ -62,6 +62,11 @@ class Account:
             self.current_nonce.value = new_nonce
             return new_nonce
 
+    def fast_forward_nonce(self, ak_nonce):
+        with self.current_nonce.get_lock():
+            self.current_nonce.value = max(self.current_nonce.value,
+                                           ak_nonce + 1)
+
 
 class Transaction:
     """
@@ -88,9 +93,9 @@ class Transaction:
         """
 
     @abc.abstractmethod
-    def sender_id(self) -> str:
+    def sender_account(self) -> Account:
         """
-        Account id of the sender that signs the tx, which must be known to map
+        Account of the sender that signs the tx, which must be known to map
         the tx-result request to the right shard.
         """
 
@@ -111,8 +116,8 @@ class Deploy(Transaction):
                                                    account.use_nonce(),
                                                    block_hash)
 
-    def sender_id(self) -> str:
-        return self.account.key.account_id
+    def sender_account(self) -> Account:
+        return self.account
 
 
 class CreateSubAccount(Transaction):
@@ -131,8 +136,8 @@ class CreateSubAccount(Transaction):
             sender.key, sub.account_id, sub, int(self.balance * 1E24),
             sender.use_nonce(), block_hash)
 
-    def sender_id(self) -> str:
-        return self.sender.key.account_id
+    def sender_account(self) -> Account:
+        return self.sender
 
 
 class NearNodeProxy:
@@ -180,7 +185,10 @@ class NearNodeProxy:
             tx.transaction_id = submit_response["result"]
             try:
                 # using retrying lib here to poll until a response is ready
-                self.poll_tx_result(meta, [tx.transaction_id, tx.sender_id()])
+                self.poll_tx_result(
+                    meta,
+                    [tx.transaction_id,
+                     tx.sender_account().key.account_id])
             except NearError as err:
                 logging.warn(f"marking an error {err.message}, {err.details}")
                 meta["exception"] = err
@@ -267,7 +275,8 @@ class NearUser(User):
         """
         Send a transaction and retry until it succeeds
         """
-        # expected error: UNKNOWN_TRANSACTION means TX has not been executed yet
+        # expected error: UnknownTransactionError means TX has not been executed yet
+        # expected error: InvalidNonceError means we are using an outdated nonce
         # other errors: probably bugs in the test setup (e.g. invalid signer)
         # this method is very simple and just retries no matter the kind of
         # error, as long as it is one defined by us (inherits from NearError)
@@ -275,6 +284,8 @@ class NearUser(User):
             try:
                 result = self.node.send_tx(tx, locust_name=locust_name)
                 return result
+            except InvalidNonceError as error:
+                tx.sender_account().fast_forward_nonce(error.ak_nonce)
             except NearError as error:
                 logger.warn(
                     f"transaction {tx.transaction_id} failed: {error}, retrying in 0.25s"
@@ -331,6 +342,18 @@ class TxUnknownError(RpcError):
         super().__init__(message)
 
 
+class InvalidNonceError(RpcError):
+
+    def __init__(
+        self,
+        used_nonce,
+        ak_nonce,
+    ):
+        super().__init__(
+            f"Tried to use nonce {used_nonce} but AK nonce is {ak_nonce}")
+        self.ak_nonce = ak_nonce
+
+
 class TxError(NearError):
 
     def __init__(self,
@@ -351,10 +374,19 @@ def evaluate_rpc_result(rpc_result):
     and failure cases. Failures are raised as exceptions.
     """
     if "error" in rpc_result:
-        if rpc_result["error"]["cause"]["name"] == "UNKNOWN_TRANSACTION":
+        err_name = rpc_result["error"]["cause"]["name"]
+        if err_name == "UNKNOWN_TRANSACTION":
             raise TxUnknownError("UNKNOWN_TRANSACTION")
-        else:
-            raise RpcError(rpc_result["error"])
+        # When reusing keys across test runs, the nonce is higher than expected.
+        elif err_name == "INVALID_TRANSACTION":
+            err_description = rpc_result["error"]["data"]["TxExecutionError"][
+                "InvalidTxError"]
+            if "InvalidNonce" in err_description:
+                raise InvalidNonceError(
+                    err_description["InvalidNonce"]["tx_nonce"],
+                    err_description["InvalidNonce"]["ak_nonce"])
+
+        raise RpcError(rpc_result["error"])
 
     result = rpc_result["result"]
     transaction_outcome = result["transaction_outcome"]

--- a/pytest/tests/loadtest/locust/common/congestion.py
+++ b/pytest/tests/loadtest/locust/common/congestion.py
@@ -39,8 +39,8 @@ class ComputeSha256(base.Transaction):
             block_hash,
         )
 
-    def sender_id(self) -> str:
-        return self.sender.key.account_id
+    def sender_account(self) -> base.Account:
+        return self.sender
 
 
 class ComputeSum(base.Transaction):
@@ -70,8 +70,8 @@ class ComputeSum(base.Transaction):
             block_hash,
         )
 
-    def sender_id(self) -> str:
-        return self.sender.key.account_id
+    def sender_account(self) -> base.Account:
+        return self.sender
 
 
 @events.init.add_listener

--- a/pytest/tests/loadtest/locust/common/ft.py
+++ b/pytest/tests/loadtest/locust/common/ft.py
@@ -84,8 +84,8 @@ class TransferFT(Transaction):
             sender.use_nonce(),
             block_hash)
 
-    def sender_id(self) -> str:
-        return self.sender.key.account_id
+    def sender_account(self) -> Account:
+        return self.sender
 
 
 class InitFT(Transaction):
@@ -108,8 +108,8 @@ class InitFT(Transaction):
                                                  contract.use_nonce(),
                                                  block_hash)
 
-    def sender_id(self) -> str:
-        return self.contract.key.account_id
+    def sender_account(self) -> Account:
+        return self.contract
 
 
 class InitFTAccount(Transaction):
@@ -130,8 +130,8 @@ class InitFTAccount(Transaction):
                                                  account.use_nonce(),
                                                  block_hash)
 
-    def sender_id(self) -> str:
-        return self.account.key.account_id
+    def sender_account(self) -> Account:
+        return self.account
 
 
 @events.init.add_listener

--- a/pytest/tests/loadtest/locust/common/social.py
+++ b/pytest/tests/loadtest/locust/common/social.py
@@ -37,8 +37,8 @@ class SocialDbSet(Transaction):
                                                  self.sender.use_nonce(),
                                                  block_hash)
 
-    def sender_id(self) -> str:
-        return self.sender.key.account_id
+    def sender_account(self) -> Account:
+        return self.sender
 
 
 class SubmitPost(SocialDbSet):
@@ -86,8 +86,8 @@ class InitSocialDB(Transaction):
             key.account_id, nonce, [call_new_action, call_set_status_action],
             block_hash, key.account_id, key.decoded_pk(), key.decoded_sk())
 
-    def sender_id(self) -> str:
-        return self.contract.key.account_id
+    def sender_account(self) -> Account:
+        return self.contract
 
 
 class InitSocialDbAccount(Transaction):
@@ -113,8 +113,8 @@ class InitSocialDbAccount(Transaction):
                                                  self.account.use_nonce(),
                                                  block_hash)
 
-    def sender_id(self) -> str:
-        return self.account.key.account_id
+    def sender_account(self) -> Account:
+        return self.account
 
 
 def social_db_build_index_obj(key_list_pairs: dict) -> dict:


### PR DESCRIPTION
This case of an RPC error means the current TX is technically invalid but from a user perspective it can still succeed, as long as the nonce is updated.

Hence, update the nonce, retry immediately, and include the time it took for the first back-and-forth in the end-to-end response time.

To do this, we need access to the Account used to sign a tx. Thus the function `sender_id` changes to `sender_account`.