### PR TITLE
refactor(loadtest): remove `send_transaction`

### DIFF
--- a/pytest/tests/loadtest/locust/common/base.py
+++ b/pytest/tests/loadtest/locust/common/base.py
@@ -145,11 +145,34 @@ class NearNodeProxy:
     Wrapper around a RPC node connection that tracks requests on locust.
     """
 
-    def __init__(self, host, request_event):
-        self.request_event = request_event
-        url, port = host.split(":")
+    def __init__(self, environment):
+        self.request_event = environment.events.request
+        url, port = environment.host.split(":")
         self.node = cluster.RpcNode(url, port)
         self.session = requests.Session()
+
+    def send_tx_retry(self, tx: Transaction, locust_name):
+        """
+        Send a transaction and retry until it succeeds
+        
+        This method retries no matter the kind of error, but it tries to be
+        smart about what to do depending on the error.
+        
+        Expected error: UnknownTransactionError means TX has not been executed yet.
+        Expected error: InvalidNonceError means we are using an outdated nonce.
+        Other errors: Probably bugs in the test setup (e.g. invalid signer).
+        """
+        while True:
+            try:
+                result = self.send_tx(tx, locust_name)
+                return result
+            except InvalidNonceError as error:
+                tx.sender_account().fast_forward_nonce(error.ak_nonce)
+            except NearError as error:
+                logger.warn(
+                    f"transaction {tx.transaction_id} failed: {error}, retrying in 0.25s"
+                )
+                time.sleep(0.25)
 
     def send_tx(self, tx: Transaction, locust_name):
         """
@@ -247,7 +270,7 @@ class NearUser(User):
     def __init__(self, environment):
         super().__init__(environment)
         assert self.host is not None, "Near user requires the RPC node address"
-        self.node = NearNodeProxy(self.host, environment.events.request)
+        self.node = NearNodeProxy(environment)
         self.id = NearUser.get_next_id()
         self.account_id = NearUser.generate_account_id(self.id)
 
@@ -275,48 +298,7 @@ class NearUser(User):
         """
         Send a transaction and retry until it succeeds
         """
-        # expected error: UnknownTransactionError means TX has not been executed yet
-        # expected error: InvalidNonceError means we are using an outdated nonce
-        # other errors: probably bugs in the test setup (e.g. invalid signer)
-        # this method is very simple and just retries no matter the kind of
-        # error, as long as it is one defined by us (inherits from NearError)
-        while True:
-            try:
-                result = self.node.send_tx(tx, locust_name=locust_name)
-                return result
-            except InvalidNonceError as error:
-                tx.sender_account().fast_forward_nonce(error.ak_nonce)
-            except NearError as error:
-                logger.warn(
-                    f"transaction {tx.transaction_id} failed: {error}, retrying in 0.25s"
-                )
-                time.sleep(0.25)
-
-
-def send_transaction(node, tx):
-    """
-    Send a transaction without a user.
-    Retry until it is successful.
-    Used for setting up accounts before actual users start their load.
-    """
-    while True:
-        block_hash = base58.b58decode(node.get_latest_block().hash)
-        signed_tx = tx.sign_and_serialize(block_hash)
-        tx_result = node.send_tx_and_wait(signed_tx, timeout=20)
-        success = "error" not in tx_result
-        if success:
-            logger.debug(
-                f"transaction {tx.transaction_id} (for no account) is successful: {tx_result}"
-            )
-            return True, tx_result
-        elif "UNKNOWN_TRANSACTION" in tx_result:
-            logger.debug(
-                f"transaction {tx.transaction_id} (for no account) timed out")
-        else:
-            logger.warn(
-                f"transaction {tx.transaction_id} (for no account) is not successful: {tx_result}"
-            )
-        logger.info(f"re-submitting transaction {tx.transaction_id}")
+        return self.node.send_tx_retry(tx, locust_name=locust_name)
 
 
 class NearError(Exception):
@@ -420,9 +402,7 @@ def evaluate_rpc_result(rpc_result):
 # called once per process before user initialization
 @events.init.add_listener
 def on_locust_init(environment, **kwargs):
-    # Note: These setup requests are not tracked by locust because we use our own http session
-    host, port = environment.host.split(":")
-    node = cluster.RpcNode(host, port)
+    node = NearNodeProxy(environment)
 
     master_funding_key = key.Key.from_json_file(
         environment.parsed_options.funding_key)
@@ -438,11 +418,11 @@ def on_locust_init(environment, **kwargs):
             account_id = f"funds_worker_{id}.{master_funding_account.key.account_id}"
             worker_key = key.Key.from_seed_testonly(account_id, account_id)
             logger.info(f"Creating {account_id}")
-            send_transaction(
-                node,
+            node.send_tx_retry(
                 CreateSubAccount(master_funding_account,
                                  worker_key,
-                                 balance=funding_balance))
+                                 balance=funding_balance),
+                "create funding account")
         funding_account = master_funding_account
     elif isinstance(environment.runner, runners.WorkerRunner):
         worker_id = environment.runner.worker_index

--- a/pytest/tests/loadtest/locust/common/base.py
+++ b/pytest/tests/loadtest/locust/common/base.py
@@ -167,6 +167,9 @@ class NearNodeProxy:
                 result = self.send_tx(tx, locust_name)
                 return result
             except InvalidNonceError as error:
+                logger.debug(
+                    f"{error} for {tx.sender_account().key.account_id}, updating nonce and retrying"
+                )
                 tx.sender_account().fast_forward_nonce(error.ak_nonce)
             except NearError as error:
                 logger.warn(
@@ -417,7 +420,6 @@ def on_locust_init(environment, **kwargs):
         for id in range(num_funding_accounts):
             account_id = f"funds_worker_{id}.{master_funding_account.key.account_id}"
             worker_key = key.Key.from_seed_testonly(account_id, account_id)
-            logger.info(f"Creating {account_id}")
             node.send_tx_retry(
                 CreateSubAccount(master_funding_account,
                                  worker_key,

--- a/pytest/tests/loadtest/locust/common/base.py
+++ b/pytest/tests/loadtest/locust/common/base.py
@@ -164,8 +164,7 @@ class NearNodeProxy:
         """
         while True:
             try:
-                result = self.send_tx(tx, locust_name)
-                return result
+                return self.send_tx(tx, locust_name)
             except InvalidNonceError as error:
                 logger.debug(
                     f"{error} for {tx.sender_account().key.account_id}, updating nonce and retrying"

--- a/pytest/tests/loadtest/locust/common/congestion.py
+++ b/pytest/tests/loadtest/locust/common/congestion.py
@@ -85,29 +85,23 @@ def on_locust_init(environment, **kwargs):
     if isinstance(environment.runner, runners.WorkerRunner):
         return
 
-    # Note: These setup requests are not tracked by locust because we use our own http session.
-    host, port = environment.host.split(":")
-    node = cluster.RpcNode(host, port)
-
+    node = base.NearNodeProxy(environment)
     funding_account = base.NearUser.funding_account
     funding_account.refresh_nonce(node)
 
     account = base.Account(
         key.Key.from_seed_testonly(environment.congestion_account_id,
                                    environment.congestion_account_id))
-    base.send_transaction(
-        node,
+    node.send_tx_retry(
         base.CreateSubAccount(funding_account, account.key, balance=50000.0),
-    )
-    account.refresh_nonce(node)
-    base.send_transaction(
-        node,
+        "create congestion funding account")
+    account.refresh_nonce(node.node)
+    node.send_tx_retry(
         base.Deploy(
             account,
             environment.parsed_options.congestion_wasm,
             "Congestion",
-        ),
-    )
+        ), "deploy congestion contract")
 
 
 # Congestion specific CLI args

--- a/pytest/tests/loadtest/locust/common/congestion.py
+++ b/pytest/tests/loadtest/locust/common/congestion.py
@@ -87,7 +87,7 @@ def on_locust_init(environment, **kwargs):
 
     node = base.NearNodeProxy(environment)
     funding_account = base.NearUser.funding_account
-    funding_account.refresh_nonce(node)
+    funding_account.refresh_nonce(node.node)
 
     account = base.Account(
         key.Key.from_seed_testonly(environment.congestion_account_id,

--- a/pytest/tests/loadtest/locust/common/ft.py
+++ b/pytest/tests/loadtest/locust/common/ft.py
@@ -11,7 +11,7 @@ import key
 import transaction
 
 from account import TGAS
-from common.base import Account, CreateSubAccount, Deploy, NearUser, send_transaction, Transaction
+from common.base import Account, CreateSubAccount, Deploy, NearNodeProxy, NearUser, Transaction
 
 
 class FTContract:
@@ -24,14 +24,14 @@ class FTContract:
         self.registered_users = []
         self.code = code
 
-    def install(self, node):
+    def install(self, node: NearNodeProxy):
         """
         Deploy and initialize the contract on chain.
         The account should already exist at this point.
         """
-        self.account.refresh_nonce(node)
-        send_transaction(node, Deploy(self.account, self.code, "FT"))
-        send_transaction(node, InitFT(self.account))
+        self.account.refresh_nonce(node.node)
+        node.send_tx_retry(Deploy(self.account, self.code, "FT"), "deploy ft")
+        node.send_tx_retry(InitFT(self.account), "init ft")
 
     def register_user(self, user: NearUser):
         user.send_tx(InitFTAccount(self.account, user.account),
@@ -142,17 +142,14 @@ def on_locust_init(environment, **kwargs):
             "Provide the WASM (e.g. nearcore/runtime/near-test-contracts/res/fungible_token.wasm)."
         )
 
-    # Note: These setup requests are not tracked by locust because we use our own http session
-    host, port = environment.host.split(":")
-    node = cluster.RpcNode(host, port)
-
+    node = NearNodeProxy(environment)
     ft_contract_code = environment.parsed_options.fungible_token_wasm
     num_ft_contracts = environment.parsed_options.num_ft_contracts
     funding_account = NearUser.funding_account
     parent_id = funding_account.key.account_id
     worker_id = getattr(environment.runner, "worker_id", "local_id")
 
-    funding_account.refresh_nonce(node)
+    funding_account.refresh_nonce(node.node)
 
     environment.ft_contracts = []
     # TODO: Create accounts in parallel
@@ -163,12 +160,11 @@ def on_locust_init(environment, **kwargs):
         prefix = str(hash(str(worker_id) + str(i)))[-6:]
         contract_key = key.Key.from_random(f"{prefix}_ft.{parent_id}")
         ft_account = Account(contract_key)
-        send_transaction(
-            node,
+        node.send_tx_retry(
             CreateSubAccount(funding_account,
                              ft_account.key,
-                             balance=FTContract.INIT_BALANCE))
-
+                             balance=FTContract.INIT_BALANCE),
+            "create ft funding account")
         ft_contract = FTContract(ft_account, ft_contract_code)
         ft_contract.install(node)
         environment.ft_contracts.append(ft_contract)

--- a/pytest/tests/loadtest/locust/common/social.py
+++ b/pytest/tests/loadtest/locust/common/social.py
@@ -12,7 +12,7 @@ import transaction
 from account import TGAS, NEAR_BASE
 import cluster
 import key
-from common.base import Account, CreateSubAccount, Deploy, NearUser, Transaction, send_transaction
+from common.base import Account, CreateSubAccount, Deploy, NearNodeProxy, Transaction
 from locust import events, runners
 from transaction import create_function_call_action
 
@@ -294,19 +294,18 @@ def on_locust_init(environment, **kwargs):
         contract_key = key.Key.from_random(environment.social_account_id)
         social_account = Account(contract_key)
 
-        # Note: These setup requests are not tracked by locust because we use our own http session
-        host, port = environment.host.split(":")
-        node = cluster.RpcNode(host, port)
-
-        send_transaction(
-            node,
+        node = NearNodeProxy(environment)
+        node.send_tx_retry(
             CreateSubAccount(funding_account,
                              social_account.key,
-                             balance=50000.0))
+                             balance=50000.0),
+            "create socialDB funding account")
         social_account.refresh_nonce(node)
-        send_transaction(
-            node, Deploy(social_account, social_contract_code, "Social DB"))
-        send_transaction(node, InitSocialDB(social_account))
+        node.send_tx_retry(
+            Deploy(social_account, social_contract_code, "Social DB"),
+            "deploy socialDB contract")
+        node.send_tx_retry(node, InitSocialDB(social_account),
+                           "init socialDB contract")
 
 
 # Social specific CLI args

--- a/pytest/tests/loadtest/locust/common/social.py
+++ b/pytest/tests/loadtest/locust/common/social.py
@@ -300,7 +300,7 @@ def on_locust_init(environment, **kwargs):
                              social_account.key,
                              balance=50000.0),
             "create socialDB funding account")
-        social_account.refresh_nonce(node)
+        social_account.refresh_nonce(node.node)
         node.send_tx_retry(
             Deploy(social_account, social_contract_code, "Social DB"),
             "deploy socialDB contract")

--- a/pytest/tests/loadtest/locust/common/social.py
+++ b/pytest/tests/loadtest/locust/common/social.py
@@ -304,7 +304,7 @@ def on_locust_init(environment, **kwargs):
         node.send_tx_retry(
             Deploy(social_account, social_contract_code, "Social DB"),
             "deploy socialDB contract")
-        node.send_tx_retry(node, InitSocialDB(social_account),
+        node.send_tx_retry(InitSocialDB(social_account),
                            "init socialDB contract")
 
 


### PR DESCRIPTION
Just a DRY refactor. At least in spirit.
There are some consequences, such as more calls being tracked
by locust and different paths for error handling.

This method was used to avoid restrictions in the sync RPC api.
Now that we have properly retrying async api access, we might as well
use that in all places.