### PR TITLE
fix: generate state part for the correct epoch and make total_num_parts stable for dump parts 

### DIFF
--- a/integration-tests/src/tests/client/state_dump.rs
+++ b/integration-tests/src/tests/client/state_dump.rs
@@ -1,8 +1,8 @@
 use assert_matches::assert_matches;
-use near_chain::chain::ApplyStatePartsRequest;
+use borsh::BorshSerialize;
+use near_chain::near_chain_primitives::error::QueryError;
 use near_chain::types::RuntimeAdapter;
 use near_chain::{ChainGenesis, Provenance};
-use near_chain::near_chain_primitives::error::QueryError;
 use near_chain_configs::ExternalStorageLocation::Filesystem;
 use near_chain_configs::{DumpConfig, Genesis};
 use near_client::sync::state::external_storage_location;
@@ -12,6 +12,7 @@ use near_crypto::{InMemorySigner, KeyType, Signer};
 use near_epoch_manager::{EpochManager, EpochManagerAdapter, EpochManagerHandle};
 use near_network::test_utils::wait_or_timeout;
 use near_o11y::testonly::init_test_logger;
+use near_primitives::block::Tip;
 use near_primitives::shard_layout::ShardUId;
 use near_primitives::state_part::PartId;
 use near_primitives::syncing::get_num_state_parts;
@@ -27,7 +28,6 @@ use nearcore::{NightshadeRuntime, NEAR_BASE};
 use std::ops::ControlFlow;
 use std::sync::Arc;
 use std::time::Duration;
-
 
 #[test]
 /// Produce several blocks, wait for the state dump thread to notice and
@@ -134,15 +134,20 @@ fn test_state_dump() {
     });
 }
 
-#[test]
-fn test_data_after_state_sync_non_final() {
-    //init_test_logger();
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap()], 1);
-    let epoch_length = 5;
-    genesis.config.epoch_length = epoch_length;
-    let chain_genesis = ChainGenesis::new(&genesis);
-
+fn run_state_sync_with_dumped_parts(
+    is_final_block_in_new_epoch: bool,
+    account_creation_at_epoch_height: u64,
+    epoch_length: u64,
+) {
+    if is_final_block_in_new_epoch {
+        println!("Testing for case when both head and final block of the dumping node are in new epoch...");
+    } else {
+        println!("Testing for case when head is in new epoch, but final block isn't for the dumping node...");
+    }
     near_actix_test_utils::run_actix(async {
+        let mut genesis = Genesis::test(vec!["test0".parse().unwrap()], 1);
+        genesis.config.epoch_length = epoch_length;
+        let chain_genesis = ChainGenesis::new(&genesis);
         let num_clients = 2;
         let env_objects = (0..num_clients).map(|_|{
             let tmp_dir = tempfile::tempdir().unwrap();
@@ -195,43 +200,33 @@ fn test_data_after_state_sync_non_final() {
         )
         .unwrap();
 
-        for i in 1..=5 {
-            let block = env.clients[0].produce_block(i).unwrap().unwrap();
-            blocks.push(block.clone());
-            env.process_block(0, block.clone(), Provenance::PRODUCED);
-            env.process_block(1, block, Provenance::NONE);
-        }
-        assert!(env.clients[1]
-            .chain
-            .get_chunk_extra(blocks[4].hash(), &ShardUId::single_shard())
-            .is_err());
+        let account_creation_at_height = (account_creation_at_epoch_height - 1) * epoch_length + 2;
 
-        let tx = SignedTransaction::create_account(
-            1,
-            "test0".parse().unwrap(),
-            "test_account".parse().unwrap(),
-            NEAR_BASE,
-            signer.public_key(),
-            &signer,
-            genesis_hash,
-        );
-        assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+        let dump_node_head_height = if is_final_block_in_new_epoch {
+            (1 + account_creation_at_epoch_height) * epoch_length
+        } else {
+            account_creation_at_epoch_height * epoch_length + 1
+        };
 
-        for i in 6..=10 {
-            let block = env.clients[0].produce_block(i).unwrap().unwrap();
-            blocks.push(block.clone());
-            env.process_block(0, block.clone(), Provenance::PRODUCED);
-            tracing::error!("process_block:{i}:0");
-            if i == 6 {
-                env.process_block(1, block, Provenance::NONE);
-                tracing::error!("process_block:{i}:1");
+        for i in 1..=dump_node_head_height {
+            if i == account_creation_at_height {
+                let tx = SignedTransaction::create_account(
+                    1,
+                    "test0".parse().unwrap(),
+                    "test_account".parse().unwrap(),
+                    NEAR_BASE,
+                    signer.public_key(),
+                    &signer,
+                    genesis_hash,
+                );
+                assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
             }
+            let block = env.clients[0].produce_block(i).unwrap().unwrap();
+            blocks.push(block.clone());
+            env.process_block(0, block.clone(), Provenance::PRODUCED);
+            env.process_block(1, block.clone(), Provenance::NONE);
         }
 
-        assert!(env.clients[1]
-            .chain
-            .get_chunk_extra(blocks[9].hash(), &ShardUId::single_shard())
-            .is_err());
         // check that the new account exists
         let head = env.clients[0].chain.head().unwrap();
         let head_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap();
@@ -250,34 +245,35 @@ fn test_data_after_state_sync_non_final() {
             .unwrap();
         assert_matches!(response.kind, QueryResponseKind::ViewAccount(_));
 
-        for i in 11..12 {
-            let block = env.clients[0].produce_block(i).unwrap().unwrap();
-            blocks.push(block.clone());
-            env.process_block(0, block.clone(), Provenance::PRODUCED);
-            tracing::error!("process_block:{i}:0");
-            // env.process_block(1, block, Provenance::NONE);
-            // tracing::error!("process_block:{i}:1");
-        }
-
-        assert!(env.clients[1]
-            .chain
-            .get_chunk_extra(blocks[10].hash(), &ShardUId::single_shard())
-            .is_err());
-
-        let head = env.clients[0].chain.head().unwrap();
-        println!("client[0]'s head height {:?}", head.height);
         let header = env.clients[0].chain.get_block_header(&head.last_block_hash).unwrap();
         let final_block_hash = header.last_final_block();
         let final_block_header = env.clients[0].chain.get_block_header(final_block_hash).unwrap();
-        let final_block_height = final_block_header.height();
-        println!("client[0]'s final block height {:?}", final_block_height);
+
+        println!(
+            "dumping node: dump_node_head_height is {}, final_block_height is {}",
+            dump_node_head_height,
+            final_block_header.height()
+        );
+
+        // check if final block is in the same epoch as head for dumping node
+        if is_final_block_in_new_epoch {
+            assert_eq!(header.epoch_id().clone(), final_block_header.epoch_id().clone())
+        } else {
+            assert_ne!(header.epoch_id().clone(), final_block_header.epoch_id().clone())
+        }
 
         let epoch_id = final_block_header.epoch_id().clone();
         let epoch_info = epoch_managers[0].get_epoch_info(&epoch_id).unwrap();
         let epoch_height = epoch_info.epoch_height();
 
-        let sync_hash = *blocks[5].hash();
-        assert_ne!(blocks[5].header().epoch_id(), blocks[4].header().epoch_id());
+        let sync_block_height = (epoch_length * epoch_height + 1) as usize;
+        let sync_hash = *blocks[sync_block_height - 1].hash();
+        
+        // the block at sync_block_height should be the start of an epoch
+        assert_ne!(
+            blocks[sync_block_height - 1].header().epoch_id(),
+            blocks[sync_block_height - 2].header().epoch_id()
+        );
         assert!(env.clients[0].chain.check_sync_hash_validity(&sync_hash).unwrap());
         let state_sync_header =
             env.clients[0].chain.get_state_response_header(0, sync_hash).unwrap();
@@ -285,7 +281,7 @@ fn test_data_after_state_sync_non_final() {
         let state_root_node =
             env.clients[0].runtime_adapter.get_state_root_node(0, &sync_hash, &state_root).unwrap();
         let num_parts = get_num_state_parts(state_root_node.memory_usage);
-        
+
         wait_or_timeout(100, 10000, || async {
             let mut all_parts_present = true;
 
@@ -303,10 +299,10 @@ fn test_data_after_state_sync_non_final() {
                         num_parts,
                     ));
                     if std::fs::read(&path).is_err() {
-                        println!("Missing {:?}", path);
+                        println!("dumping node: Missing {:?}", path);
                         all_parts_present = false;
                     } else {
-                        println!("Populated {:?}", path);
+                        println!("dumping node: Populated {:?}", path);
                     }
                 }
             }
@@ -320,293 +316,64 @@ fn test_data_after_state_sync_non_final() {
         .unwrap();
 
         // Simulate state sync
-
-        let head = env.clients[1].chain.head().unwrap();
-        println!("client[1]'s initial head height {:?}", head.height);
-
+        println!("syncing node: simulating state sync..");
         env.clients[1].chain.set_state_header(0, sync_hash, state_sync_header).unwrap();
         let runtime_client_1 = Arc::clone(&env.clients[1].runtime_adapter);
         let runtime_client_0 = Arc::clone(&env.clients[0].runtime_adapter);
-        let f = move |msg: ApplyStatePartsRequest| {
-            use borsh::BorshSerialize;
-            let client_0_store = runtime_client_0.store();
+        let client_0_store = runtime_client_0.store();
 
-            for part_id in 0..msg.num_parts {
-                let key = StatePartKey(msg.sync_hash, msg.shard_id, part_id).try_to_vec().unwrap();
-                let part = client_0_store.get(DBCol::StateParts, &key).unwrap().unwrap();
+        for part_id in 0..num_parts {
+            let key = StatePartKey(sync_hash, 0, part_id).try_to_vec().unwrap();
+            let part = client_0_store.get(DBCol::StateParts, &key).unwrap().unwrap();
 
-                runtime_client_1
-                    .apply_state_part(
-                        msg.shard_id,
-                        &msg.state_root,
-                        PartId::new(part_id, msg.num_parts),
-                        &part,
-                        &msg.epoch_id,
-                    )
-                    .unwrap();
-            }
-        };
-        env.clients[1].chain.schedule_apply_state_parts(0, sync_hash, num_parts, &f).unwrap();
+            runtime_client_1
+                .apply_state_part(0, &state_root, PartId::new(part_id, num_parts), &part, &epoch_id)
+                .unwrap();
+        }
         env.clients[1].chain.set_state_finalize(0, sync_hash, Ok(())).unwrap();
-        let chunk_extra_after_sync = env.clients[1]
-            .chain
-            .get_chunk_extra(blocks[4].hash(), &ShardUId::single_shard())
-            .unwrap();
-        let expected_chunk_extra = env.clients[0]
-            .chain
-            .get_chunk_extra(blocks[4].hash(), &ShardUId::single_shard())
-            .unwrap();
-        // The chunk extra of the prev block of sync block should be the same as the node that it is syncing from
-        assert_eq!(chunk_extra_after_sync, expected_chunk_extra);
+        println!("syncing node: state sync finished.");
 
-        // check that the new account does not exist
-        let head = env.clients[1].chain.head().unwrap();
-        println!("client[1]'s head height {:?}", head.height);
-        let head_block = env.clients[1].chain.get_block(&head.last_block_hash).unwrap();
-        let response = env.clients[1]
-            .runtime_adapter
-            .query(
-                ShardUId::single_shard(),
-                &head_block.chunks()[0].prev_state_root(),
-                head.height,
-                0,
-                &head.prev_block_hash,
-                &head.last_block_hash,
-                head_block.header().epoch_id(),
-                &QueryRequest::ViewAccount { account_id: "test_account".parse().unwrap() },
+        let synced_block = env.clients[1].chain.get_block(&sync_hash).unwrap();
+        let synced_block_header = env.clients[1].chain.get_block_header(&sync_hash).unwrap();
+        let synced_block_tip = Tip::from_header(&synced_block_header);
+        let response = env.clients[1].runtime_adapter.query(
+            ShardUId::single_shard(),
+            &synced_block.chunks()[0].prev_state_root(),
+            synced_block_tip.height,
+            0,
+            &synced_block_tip.prev_block_hash,
+            &synced_block_tip.last_block_hash,
+            synced_block_header.epoch_id(),
+            &QueryRequest::ViewAccount { account_id: "test_account".parse().unwrap() },
+        );
+
+        if is_final_block_in_new_epoch {
+            assert_matches!(
+                response.unwrap().kind,
+                QueryResponseKind::ViewAccount(_),
+                "the synced node should have information about the created account"
             );
-        assert!(response.is_err());
-        assert_matches!(response.unwrap_err(), QueryError::UnknownAccount{ .. });
-
+        } else {
+            assert!(response.is_err());
+            assert_matches!(
+                response.unwrap_err(),
+                QueryError::UnknownAccount { .. },
+                "the synced node should not have information about the created account"
+            );
+        }
         actix_rt::System::current().stop();
     });
 }
 
 #[test]
-fn test_data_after_state_sync() {
-    //init_test_logger();
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap()], 1);
+/// test state sync with state parts that were dumped when the dumping node's head is in new epoch but final block is not
+fn test_state_sync_w_dumped_parts() {
     let epoch_length = 5;
-    genesis.config.epoch_length = epoch_length;
-    let chain_genesis = ChainGenesis::new(&genesis);
-
-    near_actix_test_utils::run_actix(async {
-        let num_clients = 2;
-        let env_objects = (0..num_clients).map(|_|{
-            let tmp_dir = tempfile::tempdir().unwrap();
-            // Use default StoreConfig rather than NodeStorage::test_opener so we’re using the
-            // same configuration as in production.
-            let store = NodeStorage::opener(&tmp_dir.path(), false, &Default::default(), None)
-                .open()
-                .unwrap()
-                .get_hot_store();
-            let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config);
-            let runtime =
-                NightshadeRuntime::test(tmp_dir.path(), store.clone(), &genesis, epoch_manager.clone())
-                    as Arc<dyn RuntimeAdapter>;
-            (tmp_dir, store, epoch_manager, runtime)
-        }).collect::<Vec<(tempfile::TempDir, Store, Arc<EpochManagerHandle>, Arc<dyn RuntimeAdapter>)>>();
-
-        let stores = env_objects.iter().map(|x| x.1.clone()).collect::<Vec<_>>();
-        let epoch_managers = env_objects.iter().map(|x| x.2.clone()).collect::<Vec<_>>();
-        let runtimes = env_objects.iter().map(|x| x.3.clone()).collect::<Vec<_>>();
-
-        let mut env = TestEnv::builder(ChainGenesis::test())
-            .clients_count(env_objects.len())
-            .stores(stores.clone())
-            .epoch_managers(epoch_managers.clone())
-            .runtimes(runtimes.clone())
-            .use_state_snapshots()
-            .build();
-
-        let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
-        let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
-        let genesis_hash = *genesis_block.hash();
-
-        let mut blocks = vec![];
-
-        for i in 1..=5 {
-            let block = env.clients[0].produce_block(i).unwrap().unwrap();
-            blocks.push(block.clone());
-            env.process_block(0, block.clone(), Provenance::PRODUCED);
-            env.process_block(1, block, Provenance::NONE);
-        }
-
-        let tx = SignedTransaction::create_account(
-            1,
-            "test0".parse().unwrap(),
-            "test_account".parse().unwrap(),
-            NEAR_BASE,
-            signer.public_key(),
-            &signer,
-            genesis_hash,
-        );
-        assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
-
-        for i in 6..=10 {
-            let block = env.clients[0].produce_block(i).unwrap().unwrap();
-            blocks.push(block.clone());
-            env.process_block(0, block.clone(), Provenance::PRODUCED);
-            tracing::error!("process_block:{i}:0");
-            env.process_block(1, block, Provenance::NONE);
-            tracing::error!("process_block:{i}:1");
-        }
-        // check that the new account exists
-        let head = env.clients[0].chain.head().unwrap();
-        let head_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap();
-        let response = env.clients[0]
-            .runtime_adapter
-            .query(
-                ShardUId::single_shard(),
-                &head_block.chunks()[0].prev_state_root(),
-                head.height,
-                0,
-                &head.prev_block_hash,
-                &head.last_block_hash,
-                head_block.header().epoch_id(),
-                &QueryRequest::ViewAccount { account_id: "test_account".parse().unwrap() },
-            )
-            .unwrap();
-        assert_matches!(response.kind, QueryResponseKind::ViewAccount(_));
-
-        for i in 11..=15 {
-            let block = env.clients[0].produce_block(i).unwrap().unwrap();
-            blocks.push(block.clone());
-            env.process_block(0, block.clone(), Provenance::PRODUCED);
-            tracing::error!("process_block:{i}:0");
-            env.process_block(1, block, Provenance::NONE);
-            tracing::error!("process_block:{i}:1");
-        }
-
-        let chain = &env.clients[0].chain;
-        let shard_tracker = chain.shard_tracker.clone();
-        let mut config = env.clients[0].config.clone();
-        let root_dir = tempfile::Builder::new().prefix("state_dump").tempdir().unwrap();
-        config.state_sync.dump = Some(DumpConfig {
-            location: Filesystem { root_dir: root_dir.path().to_path_buf() },
-            restart_dump_for_shards: None,
-            iteration_delay: Some(Duration::ZERO),
-        });
-
-        let head = env.clients[0].chain.head().unwrap();
-        println!("client[0]'s head height {:?}", head.height);
-        let header = env.clients[0].chain.get_block_header(&head.last_block_hash).unwrap();
-        let final_block_hash = header.last_final_block();
-        let final_block_header = env.clients[0].chain.get_block_header(final_block_hash).unwrap();
-        let final_block_height = final_block_header.height();
-        println!("client[0]'s final block height {:?}", final_block_height);
-
-        let epoch_id = final_block_header.epoch_id().clone();
-        let epoch_info = epoch_managers[0].get_epoch_info(&epoch_id).unwrap();
-        let epoch_height = epoch_info.epoch_height();
-
-        let _state_sync_dump_handle = spawn_state_sync_dump(
-            &config,
-            chain_genesis,
-            epoch_managers[0].clone(),
-            shard_tracker.clone(),
-            runtimes[0].clone(),
-            Some("test0".parse().unwrap()),
-        )
-        .unwrap();
-
-        let sync_hash = *blocks[10].hash();
-        assert_ne!(blocks[9].header().epoch_id(), blocks[10].header().epoch_id());
-        assert!(env.clients[0].chain.check_sync_hash_validity(&sync_hash).unwrap());
-        let state_sync_header =
-            env.clients[0].chain.get_state_response_header(0, sync_hash).unwrap();
-        let state_root = state_sync_header.chunk_prev_state_root();
-        let state_root_node =
-            env.clients[0].runtime_adapter.get_state_root_node(0, &sync_hash, &state_root).unwrap();
-        let num_parts = get_num_state_parts(state_root_node.memory_usage);
-        
-        wait_or_timeout(100, 10000, || async {
-            let mut all_parts_present = true;
-
-            let num_shards = epoch_managers[0].num_shards(&epoch_id).unwrap();
-            assert_ne!(num_shards, 0);
-
-            for shard_id in 0..num_shards {
-                for part_id in 0..num_parts {
-                    let path = root_dir.path().join(external_storage_location(
-                        &config.chain_id,
-                        &epoch_id,
-                        epoch_height,
-                        shard_id,
-                        part_id,
-                        num_parts,
-                    ));
-                    if std::fs::read(&path).is_err() {
-                        println!("Missing {:?}", path);
-                        all_parts_present = false;
-                    } else {
-                        println!("Found {:?}", path);
-                    }
-                }
-            }
-            if all_parts_present {
-                ControlFlow::Break(())
-            } else {
-                ControlFlow::Continue(())
-            }
-        })
-        .await
-        .unwrap();
-
-        // Simulate state sync
-        env.clients[1].chain.set_state_header(0, sync_hash, state_sync_header).unwrap();
-        let runtime_client_1 = Arc::clone(&env.clients[1].runtime_adapter);
-        let runtime_client_0 = Arc::clone(&env.clients[0].runtime_adapter);
-        let f = move |msg: ApplyStatePartsRequest| {
-            use borsh::BorshSerialize;
-            let client_0_store = runtime_client_0.store();
-
-            for part_id in 0..msg.num_parts {
-                let key = StatePartKey(msg.sync_hash, msg.shard_id, part_id).try_to_vec().unwrap();
-                let part = client_0_store.get(DBCol::StateParts, &key).unwrap().unwrap();
-
-                runtime_client_1
-                    .apply_state_part(
-                        msg.shard_id,
-                        &msg.state_root,
-                        PartId::new(part_id, msg.num_parts),
-                        &part,
-                        &msg.epoch_id,
-                    )
-                    .unwrap();
-            }
-        };
-        env.clients[1].chain.schedule_apply_state_parts(0, sync_hash, num_parts, &f).unwrap();
-        env.clients[1].chain.set_state_finalize(0, sync_hash, Ok(())).unwrap();
-        let chunk_extra_after_sync = env.clients[1]
-            .chain
-            .get_chunk_extra(blocks[9].hash(), &ShardUId::single_shard())
-            .unwrap();
-        let expected_chunk_extra = env.clients[0]
-            .chain
-            .get_chunk_extra(blocks[9].hash(), &ShardUId::single_shard())
-            .unwrap();
-        // The chunk extra of the prev block of sync block should be the same as the node that it is syncing from
-        assert_eq!(chunk_extra_after_sync, expected_chunk_extra);
-
-        // check that the new account exists
-        let head = env.clients[1].chain.head().unwrap();
-        let head_block = env.clients[1].chain.get_block(&head.last_block_hash).unwrap();
-        let response = env.clients[1]
-            .runtime_adapter
-            .query(
-                ShardUId::single_shard(),
-                &head_block.chunks()[0].prev_state_root(),
-                head.height,
-                0,
-                &head.prev_block_hash,
-                &head.last_block_hash,
-                head_block.header().epoch_id(),
-                &QueryRequest::ViewAccount { account_id: "test_account".parse().unwrap() },
-            )
-            .unwrap();
-        assert_matches!(response.kind, QueryResponseKind::ViewAccount(_));
-
-        actix_rt::System::current().stop();
-    });
+    // excluding account_creation_at_epoch_height=1 because first epoch's epoch_id not being block hash of its first block cause issues
+    for account_creation_at_epoch_height in 2..=4 as u64 {
+        println!("account_creation_at_epoch_height = {}", account_creation_at_epoch_height);
+        run_state_sync_with_dumped_parts(false, account_creation_at_epoch_height, epoch_length);
+        run_state_sync_with_dumped_parts(true, account_creation_at_epoch_height, epoch_length);
+    }
+    
 }

--- a/integration-tests/src/tests/client/state_dump.rs
+++ b/integration-tests/src/tests/client/state_dump.rs
@@ -1,20 +1,33 @@
+use assert_matches::assert_matches;
+use near_chain::chain::ApplyStatePartsRequest;
 use near_chain::types::RuntimeAdapter;
 use near_chain::{ChainGenesis, Provenance};
+use near_chain::near_chain_primitives::error::QueryError;
 use near_chain_configs::ExternalStorageLocation::Filesystem;
 use near_chain_configs::{DumpConfig, Genesis};
 use near_client::sync::state::external_storage_location;
 use near_client::test_utils::TestEnv;
+use near_client::ProcessTxResponse;
+use near_crypto::{InMemorySigner, KeyType, Signer};
 use near_epoch_manager::{EpochManager, EpochManagerAdapter, EpochManagerHandle};
 use near_network::test_utils::wait_or_timeout;
 use near_o11y::testonly::init_test_logger;
+use near_primitives::shard_layout::ShardUId;
+use near_primitives::state_part::PartId;
+use near_primitives::syncing::get_num_state_parts;
+use near_primitives::syncing::StatePartKey;
+use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::BlockHeight;
+use near_primitives::views::{QueryRequest, QueryResponseKind};
+use near_store::DBCol;
 use near_store::{NodeStorage, Store};
 use nearcore::config::GenesisExt;
 use nearcore::state_sync::spawn_state_sync_dump;
-use nearcore::NightshadeRuntime;
+use nearcore::{NightshadeRuntime, NEAR_BASE};
 use std::ops::ControlFlow;
 use std::sync::Arc;
 use std::time::Duration;
+
 
 #[test]
 /// Produce several blocks, wait for the state dump thread to notice and
@@ -117,6 +130,483 @@ fn test_state_dump() {
         })
         .await
         .unwrap();
+        actix_rt::System::current().stop();
+    });
+}
+
+#[test]
+fn test_data_after_state_sync_non_final() {
+    //init_test_logger();
+    let mut genesis = Genesis::test(vec!["test0".parse().unwrap()], 1);
+    let epoch_length = 5;
+    genesis.config.epoch_length = epoch_length;
+    let chain_genesis = ChainGenesis::new(&genesis);
+
+    near_actix_test_utils::run_actix(async {
+        let num_clients = 2;
+        let env_objects = (0..num_clients).map(|_|{
+            let tmp_dir = tempfile::tempdir().unwrap();
+            // Use default StoreConfig rather than NodeStorage::test_opener so we’re using the
+            // same configuration as in production.
+            let store = NodeStorage::opener(&tmp_dir.path(), false, &Default::default(), None)
+                .open()
+                .unwrap()
+                .get_hot_store();
+            let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config);
+            let runtime =
+                NightshadeRuntime::test(tmp_dir.path(), store.clone(), &genesis, epoch_manager.clone())
+                    as Arc<dyn RuntimeAdapter>;
+            (tmp_dir, store, epoch_manager, runtime)
+        }).collect::<Vec<(tempfile::TempDir, Store, Arc<EpochManagerHandle>, Arc<dyn RuntimeAdapter>)>>();
+
+        let stores = env_objects.iter().map(|x| x.1.clone()).collect::<Vec<_>>();
+        let epoch_managers = env_objects.iter().map(|x| x.2.clone()).collect::<Vec<_>>();
+        let runtimes = env_objects.iter().map(|x| x.3.clone()).collect::<Vec<_>>();
+
+        let mut env = TestEnv::builder(ChainGenesis::test())
+            .clients_count(env_objects.len())
+            .stores(stores.clone())
+            .epoch_managers(epoch_managers.clone())
+            .runtimes(runtimes.clone())
+            .use_state_snapshots()
+            .build();
+
+        let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+        let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
+        let genesis_hash = *genesis_block.hash();
+
+        let mut blocks = vec![];
+        let chain = &env.clients[0].chain;
+        let shard_tracker = chain.shard_tracker.clone();
+        let mut config = env.clients[0].config.clone();
+        let root_dir = tempfile::Builder::new().prefix("state_dump").tempdir().unwrap();
+        config.state_sync.dump = Some(DumpConfig {
+            location: Filesystem { root_dir: root_dir.path().to_path_buf() },
+            restart_dump_for_shards: None,
+            iteration_delay: Some(Duration::ZERO),
+        });
+        let _state_sync_dump_handle = spawn_state_sync_dump(
+            &config,
+            chain_genesis,
+            epoch_managers[0].clone(),
+            shard_tracker.clone(),
+            runtimes[0].clone(),
+            Some("test0".parse().unwrap()),
+        )
+        .unwrap();
+
+        for i in 1..=5 {
+            let block = env.clients[0].produce_block(i).unwrap().unwrap();
+            blocks.push(block.clone());
+            env.process_block(0, block.clone(), Provenance::PRODUCED);
+            env.process_block(1, block, Provenance::NONE);
+        }
+        assert!(env.clients[1]
+            .chain
+            .get_chunk_extra(blocks[4].hash(), &ShardUId::single_shard())
+            .is_err());
+
+        let tx = SignedTransaction::create_account(
+            1,
+            "test0".parse().unwrap(),
+            "test_account".parse().unwrap(),
+            NEAR_BASE,
+            signer.public_key(),
+            &signer,
+            genesis_hash,
+        );
+        assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+
+        for i in 6..=10 {
+            let block = env.clients[0].produce_block(i).unwrap().unwrap();
+            blocks.push(block.clone());
+            env.process_block(0, block.clone(), Provenance::PRODUCED);
+            tracing::error!("process_block:{i}:0");
+            if i == 6 {
+                env.process_block(1, block, Provenance::NONE);
+                tracing::error!("process_block:{i}:1");
+            }
+        }
+
+        assert!(env.clients[1]
+            .chain
+            .get_chunk_extra(blocks[9].hash(), &ShardUId::single_shard())
+            .is_err());
+        // check that the new account exists
+        let head = env.clients[0].chain.head().unwrap();
+        let head_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap();
+        let response = env.clients[0]
+            .runtime_adapter
+            .query(
+                ShardUId::single_shard(),
+                &head_block.chunks()[0].prev_state_root(),
+                head.height,
+                0,
+                &head.prev_block_hash,
+                &head.last_block_hash,
+                head_block.header().epoch_id(),
+                &QueryRequest::ViewAccount { account_id: "test_account".parse().unwrap() },
+            )
+            .unwrap();
+        assert_matches!(response.kind, QueryResponseKind::ViewAccount(_));
+
+        for i in 11..12 {
+            let block = env.clients[0].produce_block(i).unwrap().unwrap();
+            blocks.push(block.clone());
+            env.process_block(0, block.clone(), Provenance::PRODUCED);
+            tracing::error!("process_block:{i}:0");
+            // env.process_block(1, block, Provenance::NONE);
+            // tracing::error!("process_block:{i}:1");
+        }
+
+        assert!(env.clients[1]
+            .chain
+            .get_chunk_extra(blocks[10].hash(), &ShardUId::single_shard())
+            .is_err());
+
+        let head = env.clients[0].chain.head().unwrap();
+        println!("client[0]'s head height {:?}", head.height);
+        let header = env.clients[0].chain.get_block_header(&head.last_block_hash).unwrap();
+        let final_block_hash = header.last_final_block();
+        let final_block_header = env.clients[0].chain.get_block_header(final_block_hash).unwrap();
+        let final_block_height = final_block_header.height();
+        println!("client[0]'s final block height {:?}", final_block_height);
+
+        let epoch_id = final_block_header.epoch_id().clone();
+        let epoch_info = epoch_managers[0].get_epoch_info(&epoch_id).unwrap();
+        let epoch_height = epoch_info.epoch_height();
+
+        let sync_hash = *blocks[5].hash();
+        assert_ne!(blocks[5].header().epoch_id(), blocks[4].header().epoch_id());
+        assert!(env.clients[0].chain.check_sync_hash_validity(&sync_hash).unwrap());
+        let state_sync_header =
+            env.clients[0].chain.get_state_response_header(0, sync_hash).unwrap();
+        let state_root = state_sync_header.chunk_prev_state_root();
+        let state_root_node =
+            env.clients[0].runtime_adapter.get_state_root_node(0, &sync_hash, &state_root).unwrap();
+        let num_parts = get_num_state_parts(state_root_node.memory_usage);
+        
+        wait_or_timeout(100, 10000, || async {
+            let mut all_parts_present = true;
+
+            let num_shards = epoch_managers[0].num_shards(&epoch_id).unwrap();
+            assert_ne!(num_shards, 0);
+
+            for shard_id in 0..num_shards {
+                for part_id in 0..num_parts {
+                    let path = root_dir.path().join(external_storage_location(
+                        &config.chain_id,
+                        &epoch_id,
+                        epoch_height,
+                        shard_id,
+                        part_id,
+                        num_parts,
+                    ));
+                    if std::fs::read(&path).is_err() {
+                        println!("Missing {:?}", path);
+                        all_parts_present = false;
+                    } else {
+                        println!("Populated {:?}", path);
+                    }
+                }
+            }
+            if all_parts_present {
+                ControlFlow::Break(())
+            } else {
+                ControlFlow::Continue(())
+            }
+        })
+        .await
+        .unwrap();
+
+        // Simulate state sync
+
+        let head = env.clients[1].chain.head().unwrap();
+        println!("client[1]'s initial head height {:?}", head.height);
+
+        env.clients[1].chain.set_state_header(0, sync_hash, state_sync_header).unwrap();
+        let runtime_client_1 = Arc::clone(&env.clients[1].runtime_adapter);
+        let runtime_client_0 = Arc::clone(&env.clients[0].runtime_adapter);
+        let f = move |msg: ApplyStatePartsRequest| {
+            use borsh::BorshSerialize;
+            let client_0_store = runtime_client_0.store();
+
+            for part_id in 0..msg.num_parts {
+                let key = StatePartKey(msg.sync_hash, msg.shard_id, part_id).try_to_vec().unwrap();
+                let part = client_0_store.get(DBCol::StateParts, &key).unwrap().unwrap();
+
+                runtime_client_1
+                    .apply_state_part(
+                        msg.shard_id,
+                        &msg.state_root,
+                        PartId::new(part_id, msg.num_parts),
+                        &part,
+                        &msg.epoch_id,
+                    )
+                    .unwrap();
+            }
+        };
+        env.clients[1].chain.schedule_apply_state_parts(0, sync_hash, num_parts, &f).unwrap();
+        env.clients[1].chain.set_state_finalize(0, sync_hash, Ok(())).unwrap();
+        let chunk_extra_after_sync = env.clients[1]
+            .chain
+            .get_chunk_extra(blocks[4].hash(), &ShardUId::single_shard())
+            .unwrap();
+        let expected_chunk_extra = env.clients[0]
+            .chain
+            .get_chunk_extra(blocks[4].hash(), &ShardUId::single_shard())
+            .unwrap();
+        // The chunk extra of the prev block of sync block should be the same as the node that it is syncing from
+        assert_eq!(chunk_extra_after_sync, expected_chunk_extra);
+
+        // check that the new account does not exist
+        let head = env.clients[1].chain.head().unwrap();
+        println!("client[1]'s head height {:?}", head.height);
+        let head_block = env.clients[1].chain.get_block(&head.last_block_hash).unwrap();
+        let response = env.clients[1]
+            .runtime_adapter
+            .query(
+                ShardUId::single_shard(),
+                &head_block.chunks()[0].prev_state_root(),
+                head.height,
+                0,
+                &head.prev_block_hash,
+                &head.last_block_hash,
+                head_block.header().epoch_id(),
+                &QueryRequest::ViewAccount { account_id: "test_account".parse().unwrap() },
+            );
+        assert!(response.is_err());
+        assert_matches!(response.unwrap_err(), QueryError::UnknownAccount{ .. });
+
+        actix_rt::System::current().stop();
+    });
+}
+
+#[test]
+fn test_data_after_state_sync() {
+    //init_test_logger();
+    let mut genesis = Genesis::test(vec!["test0".parse().unwrap()], 1);
+    let epoch_length = 5;
+    genesis.config.epoch_length = epoch_length;
+    let chain_genesis = ChainGenesis::new(&genesis);
+
+    near_actix_test_utils::run_actix(async {
+        let num_clients = 2;
+        let env_objects = (0..num_clients).map(|_|{
+            let tmp_dir = tempfile::tempdir().unwrap();
+            // Use default StoreConfig rather than NodeStorage::test_opener so we’re using the
+            // same configuration as in production.
+            let store = NodeStorage::opener(&tmp_dir.path(), false, &Default::default(), None)
+                .open()
+                .unwrap()
+                .get_hot_store();
+            let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config);
+            let runtime =
+                NightshadeRuntime::test(tmp_dir.path(), store.clone(), &genesis, epoch_manager.clone())
+                    as Arc<dyn RuntimeAdapter>;
+            (tmp_dir, store, epoch_manager, runtime)
+        }).collect::<Vec<(tempfile::TempDir, Store, Arc<EpochManagerHandle>, Arc<dyn RuntimeAdapter>)>>();
+
+        let stores = env_objects.iter().map(|x| x.1.clone()).collect::<Vec<_>>();
+        let epoch_managers = env_objects.iter().map(|x| x.2.clone()).collect::<Vec<_>>();
+        let runtimes = env_objects.iter().map(|x| x.3.clone()).collect::<Vec<_>>();
+
+        let mut env = TestEnv::builder(ChainGenesis::test())
+            .clients_count(env_objects.len())
+            .stores(stores.clone())
+            .epoch_managers(epoch_managers.clone())
+            .runtimes(runtimes.clone())
+            .use_state_snapshots()
+            .build();
+
+        let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+        let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
+        let genesis_hash = *genesis_block.hash();
+
+        let mut blocks = vec![];
+
+        for i in 1..=5 {
+            let block = env.clients[0].produce_block(i).unwrap().unwrap();
+            blocks.push(block.clone());
+            env.process_block(0, block.clone(), Provenance::PRODUCED);
+            env.process_block(1, block, Provenance::NONE);
+        }
+
+        let tx = SignedTransaction::create_account(
+            1,
+            "test0".parse().unwrap(),
+            "test_account".parse().unwrap(),
+            NEAR_BASE,
+            signer.public_key(),
+            &signer,
+            genesis_hash,
+        );
+        assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+
+        for i in 6..=10 {
+            let block = env.clients[0].produce_block(i).unwrap().unwrap();
+            blocks.push(block.clone());
+            env.process_block(0, block.clone(), Provenance::PRODUCED);
+            tracing::error!("process_block:{i}:0");
+            env.process_block(1, block, Provenance::NONE);
+            tracing::error!("process_block:{i}:1");
+        }
+        // check that the new account exists
+        let head = env.clients[0].chain.head().unwrap();
+        let head_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap();
+        let response = env.clients[0]
+            .runtime_adapter
+            .query(
+                ShardUId::single_shard(),
+                &head_block.chunks()[0].prev_state_root(),
+                head.height,
+                0,
+                &head.prev_block_hash,
+                &head.last_block_hash,
+                head_block.header().epoch_id(),
+                &QueryRequest::ViewAccount { account_id: "test_account".parse().unwrap() },
+            )
+            .unwrap();
+        assert_matches!(response.kind, QueryResponseKind::ViewAccount(_));
+
+        for i in 11..=15 {
+            let block = env.clients[0].produce_block(i).unwrap().unwrap();
+            blocks.push(block.clone());
+            env.process_block(0, block.clone(), Provenance::PRODUCED);
+            tracing::error!("process_block:{i}:0");
+            env.process_block(1, block, Provenance::NONE);
+            tracing::error!("process_block:{i}:1");
+        }
+
+        let chain = &env.clients[0].chain;
+        let shard_tracker = chain.shard_tracker.clone();
+        let mut config = env.clients[0].config.clone();
+        let root_dir = tempfile::Builder::new().prefix("state_dump").tempdir().unwrap();
+        config.state_sync.dump = Some(DumpConfig {
+            location: Filesystem { root_dir: root_dir.path().to_path_buf() },
+            restart_dump_for_shards: None,
+            iteration_delay: Some(Duration::ZERO),
+        });
+
+        let head = env.clients[0].chain.head().unwrap();
+        println!("client[0]'s head height {:?}", head.height);
+        let header = env.clients[0].chain.get_block_header(&head.last_block_hash).unwrap();
+        let final_block_hash = header.last_final_block();
+        let final_block_header = env.clients[0].chain.get_block_header(final_block_hash).unwrap();
+        let final_block_height = final_block_header.height();
+        println!("client[0]'s final block height {:?}", final_block_height);
+
+        let epoch_id = final_block_header.epoch_id().clone();
+        let epoch_info = epoch_managers[0].get_epoch_info(&epoch_id).unwrap();
+        let epoch_height = epoch_info.epoch_height();
+
+        let _state_sync_dump_handle = spawn_state_sync_dump(
+            &config,
+            chain_genesis,
+            epoch_managers[0].clone(),
+            shard_tracker.clone(),
+            runtimes[0].clone(),
+            Some("test0".parse().unwrap()),
+        )
+        .unwrap();
+
+        let sync_hash = *blocks[10].hash();
+        assert_ne!(blocks[9].header().epoch_id(), blocks[10].header().epoch_id());
+        assert!(env.clients[0].chain.check_sync_hash_validity(&sync_hash).unwrap());
+        let state_sync_header =
+            env.clients[0].chain.get_state_response_header(0, sync_hash).unwrap();
+        let state_root = state_sync_header.chunk_prev_state_root();
+        let state_root_node =
+            env.clients[0].runtime_adapter.get_state_root_node(0, &sync_hash, &state_root).unwrap();
+        let num_parts = get_num_state_parts(state_root_node.memory_usage);
+        
+        wait_or_timeout(100, 10000, || async {
+            let mut all_parts_present = true;
+
+            let num_shards = epoch_managers[0].num_shards(&epoch_id).unwrap();
+            assert_ne!(num_shards, 0);
+
+            for shard_id in 0..num_shards {
+                for part_id in 0..num_parts {
+                    let path = root_dir.path().join(external_storage_location(
+                        &config.chain_id,
+                        &epoch_id,
+                        epoch_height,
+                        shard_id,
+                        part_id,
+                        num_parts,
+                    ));
+                    if std::fs::read(&path).is_err() {
+                        println!("Missing {:?}", path);
+                        all_parts_present = false;
+                    } else {
+                        println!("Found {:?}", path);
+                    }
+                }
+            }
+            if all_parts_present {
+                ControlFlow::Break(())
+            } else {
+                ControlFlow::Continue(())
+            }
+        })
+        .await
+        .unwrap();
+
+        // Simulate state sync
+        env.clients[1].chain.set_state_header(0, sync_hash, state_sync_header).unwrap();
+        let runtime_client_1 = Arc::clone(&env.clients[1].runtime_adapter);
+        let runtime_client_0 = Arc::clone(&env.clients[0].runtime_adapter);
+        let f = move |msg: ApplyStatePartsRequest| {
+            use borsh::BorshSerialize;
+            let client_0_store = runtime_client_0.store();
+
+            for part_id in 0..msg.num_parts {
+                let key = StatePartKey(msg.sync_hash, msg.shard_id, part_id).try_to_vec().unwrap();
+                let part = client_0_store.get(DBCol::StateParts, &key).unwrap().unwrap();
+
+                runtime_client_1
+                    .apply_state_part(
+                        msg.shard_id,
+                        &msg.state_root,
+                        PartId::new(part_id, msg.num_parts),
+                        &part,
+                        &msg.epoch_id,
+                    )
+                    .unwrap();
+            }
+        };
+        env.clients[1].chain.schedule_apply_state_parts(0, sync_hash, num_parts, &f).unwrap();
+        env.clients[1].chain.set_state_finalize(0, sync_hash, Ok(())).unwrap();
+        let chunk_extra_after_sync = env.clients[1]
+            .chain
+            .get_chunk_extra(blocks[9].hash(), &ShardUId::single_shard())
+            .unwrap();
+        let expected_chunk_extra = env.clients[0]
+            .chain
+            .get_chunk_extra(blocks[9].hash(), &ShardUId::single_shard())
+            .unwrap();
+        // The chunk extra of the prev block of sync block should be the same as the node that it is syncing from
+        assert_eq!(chunk_extra_after_sync, expected_chunk_extra);
+
+        // check that the new account exists
+        let head = env.clients[1].chain.head().unwrap();
+        let head_block = env.clients[1].chain.get_block(&head.last_block_hash).unwrap();
+        let response = env.clients[1]
+            .runtime_adapter
+            .query(
+                ShardUId::single_shard(),
+                &head_block.chunks()[0].prev_state_root(),
+                head.height,
+                0,
+                &head.prev_block_hash,
+                &head.last_block_hash,
+                head_block.header().epoch_id(),
+                &QueryRequest::ViewAccount { account_id: "test_account".parse().unwrap() },
+            )
+            .unwrap();
+        assert_matches!(response.kind, QueryResponseKind::ViewAccount(_));
+
         actix_rt::System::current().stop();
     });
 }

--- a/nearcore/src/state_sync.rs
+++ b/nearcore/src/state_sync.rs
@@ -496,7 +496,8 @@ fn get_latest_epoch(
     let header = chain.get_block_header(&hash)?;
     let final_hash = header.last_final_block();
     let sync_hash = StateSync::get_epoch_start_sync_hash(chain, final_hash)?;
-    let epoch_id = head.epoch_id;
+    let final_block_header = chain.get_block_header(&final_hash)?;
+    let epoch_id = final_block_header.epoch_id().clone();
     let epoch_info = epoch_manager.get_epoch_info(&epoch_id)?;
     let epoch_height = epoch_info.epoch_height();
     tracing::debug!(target: "state_sync_dump", ?final_hash, ?sync_hash, ?epoch_id, epoch_height, "get_latest_epoch");


### PR DESCRIPTION
caveat is in get_latest_epoch(): turns out in the case that head is in epoch x+1, final block is in epoch x, the get_latest_epoch() function will return epoch_id of x+1 but sync_hash (first block hash) of epoch x and our code logic will recognize this as a new complete epoch available. The sync_hash returned by get_latest_epoch() and its sync_prev_prev_hash will be used to get the state part in obtain_and_store_state_part(), which means the state part obtained are actually not for the latest complete epoch, but for the one before that.