### PR TITLE
refactor: default seed in `key.from_seed_testonly`

### DIFF
--- a/pytest/lib/key.py
+++ b/pytest/lib/key.py
@@ -38,10 +38,12 @@ class Key:
             return cls.from_json(json.load(rd))
 
     @classmethod
-    def from_seed_testonly(cls, account_id: str, seed: str) -> 'Key':
+    def from_seed_testonly(cls, account_id: str, seed: str = None) -> 'Key':
         """
         Deterministically produce an **insecure** signer pair from a seed.
         """
+        if seed is None:
+            seed = account_id
         # use the repeated seed string as secret key by injecting fake entropy
         fake_entropy = lambda length: (seed *
                                        (1 + int(length / 32))).encode()[:length]

--- a/pytest/lib/key.py
+++ b/pytest/lib/key.py
@@ -41,6 +41,8 @@ class Key:
     def from_seed_testonly(cls, account_id: str, seed: str = None) -> 'Key':
         """
         Deterministically produce an **insecure** signer pair from a seed.
+        
+        If no seed is provided, the account id is used as seed.
         """
         if seed is None:
             seed = account_id

--- a/pytest/tests/loadtest/locust/common/base.py
+++ b/pytest/tests/loadtest/locust/common/base.py
@@ -426,7 +426,7 @@ def on_locust_init(environment, **kwargs):
         # TODO: Create accounts in parallel
         for id in range(num_funding_accounts):
             account_id = f"funds_worker_{id}.{master_funding_account.key.account_id}"
-            worker_key = key.Key.from_seed_testonly(account_id, account_id)
+            worker_key = key.Key.from_seed_testonly(account_id)
             if not node.account_exists(account_id):
                 node.send_tx_retry(
                     CreateSubAccount(master_funding_account,
@@ -437,8 +437,7 @@ def on_locust_init(environment, **kwargs):
     elif isinstance(environment.runner, runners.WorkerRunner):
         worker_id = environment.runner.worker_index
         worker_account_id = f"funds_worker_{worker_id}.{master_funding_account.key.account_id}"
-        worker_key = key.Key.from_seed_testonly(worker_account_id,
-                                                worker_account_id)
+        worker_key = key.Key.from_seed_testonly(worker_account_id)
         funding_account = Account(worker_key)
     elif isinstance(environment.runner, runners.LocalRunner):
         funding_account = master_funding_account

--- a/pytest/tests/loadtest/locust/common/congestion.py
+++ b/pytest/tests/loadtest/locust/common/congestion.py
@@ -90,8 +90,7 @@ def on_locust_init(environment, **kwargs):
     funding_account.refresh_nonce(node.node)
 
     account = base.Account(
-        key.Key.from_seed_testonly(environment.congestion_account_id,
-                                   environment.congestion_account_id))
+        key.Key.from_seed_testonly(environment.congestion_account_id))
     if not node.account_exists(account.key.account_id):
         node.send_tx_retry(
             base.CreateSubAccount(funding_account, account.key,

--- a/pytest/tests/loadtest/locust/common/social.py
+++ b/pytest/tests/loadtest/locust/common/social.py
@@ -291,8 +291,7 @@ def on_locust_init(environment, **kwargs):
             )
 
         social_contract_code = environment.parsed_options.social_db_wasm
-        contract_key = key.Key.from_seed_testonly(environment.social_account_id,
-                                                  environment.social_account_id)
+        contract_key = key.Key.from_seed_testonly(environment.social_account_id)
         social_account = Account(contract_key)
 
         node = NearNodeProxy(environment)


### PR DESCRIPTION
Currently all callers use seed=account_id.
Make this the default but still allow to use a different seed.