### PR TITLE
refactor(loadtest): remove dead code

### DIFF
--- a/pytest/tests/loadtest/locust/common/congestion.py
+++ b/pytest/tests/loadtest/locust/common/congestion.py
@@ -7,7 +7,6 @@ from locust import events, runners
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[4] / "lib"))
 
 import account
-import cluster
 import common.base as base
 import key
 import transaction

--- a/pytest/tests/loadtest/locust/common/ft.py
+++ b/pytest/tests/loadtest/locust/common/ft.py
@@ -6,7 +6,6 @@ from locust import events
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[4] / 'lib'))
 
-import cluster
 import key
 import transaction
 
@@ -136,18 +135,11 @@ class InitFTAccount(Transaction):
 
 @events.init.add_listener
 def on_locust_init(environment, **kwargs):
-    if environment.parsed_options.fungible_token_wasm is None:
-        raise SystemExit(
-            f"Running FT workload requires `--fungible_token_wasm $FT_CONTRACT`. "
-            "Provide the WASM (e.g. nearcore/runtime/near-test-contracts/res/fungible_token.wasm)."
-        )
-
     node = NearNodeProxy(environment)
     ft_contract_code = environment.parsed_options.fungible_token_wasm
     num_ft_contracts = environment.parsed_options.num_ft_contracts
     funding_account = NearUser.funding_account
     parent_id = funding_account.key.account_id
-    worker_id = getattr(environment.runner, "worker_id", "local_id")
 
     funding_account.refresh_nonce(node.node)
 

--- a/pytest/tests/loadtest/locust/common/social.py
+++ b/pytest/tests/loadtest/locust/common/social.py
@@ -10,7 +10,6 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 import transaction
 
 from account import TGAS, NEAR_BASE
-import cluster
 import key
 from common.base import Account, CreateSubAccount, Deploy, NearNodeProxy, Transaction
 from locust import events, runners
@@ -284,12 +283,6 @@ def on_locust_init(environment, **kwargs):
 
     # Create SocialDB account, unless we are a worker, in which case the master already did it
     if not isinstance(environment.runner, runners.WorkerRunner):
-        if environment.parsed_options.social_db_wasm is None:
-            raise SystemExit(
-                f"Running SocialDB workload requires `--social_db_wasm $SOCIAL_CONTRACT`. "
-                "Provide the WASM (can be downloaded from https://github.com/NearSocial/social-db/tree/aa7fafaac92a7dd267993d6c210246420a561370/res)."
-            )
-
         social_contract_code = environment.parsed_options.social_db_wasm
         contract_key = key.Key.from_seed_testonly(environment.social_account_id)
         social_account = Account(contract_key)


### PR DESCRIPTION
- CLI arg checks are no longer necessary, we have default args
- cluster import is not used
- worker id is no longer part of account id seed