### PR TITLE
fix(state-sync): Disable state snapshots by default

### DIFF
--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -236,7 +236,7 @@ impl Default for StoreConfig {
             // flat storage head quickly. State read work is much more expensive.
             flat_storage_creation_period: Duration::from_secs(1),
 
-            state_snapshot_enabled: true,
+            state_snapshot_enabled: false,
         }
     }
 }


### PR DESCRIPTION
In 1.36 state snapshots will be needed on a small number of nodes producing epoch dumps. Easier to enable it on those nodes.