### PR TITLE
fix(state-sync): Print context when a node panics with `MissingTrieValue`

### DIFF
--- a/core/primitives/src/sandbox.rs
+++ b/core/primitives/src/sandbox.rs
@@ -9,7 +9,7 @@ pub mod state_patch {
     /// object can be non-empty only if `sandbox` feature is enabled.  On
     /// non-sandbox build, this struct is ZST and its methods are essentially
     /// short-circuited by treating the type as always empty.
-    #[derive(Default)]
+    #[derive(Default, Debug, Clone)]
     pub struct SandboxStatePatch {
         records: Vec<StateRecord>,
     }
@@ -50,7 +50,7 @@ pub mod state_patch {
 pub mod state_patch {
     use crate::state_record::StateRecord;
 
-    #[derive(Default)]
+    #[derive(Default, Debug, Clone)]
     pub struct SandboxStatePatch;
 
     impl SandboxStatePatch {

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -318,7 +318,6 @@ impl NightshadeRuntime {
         is_first_block_with_chunk_of_version: bool,
         state_patch: SandboxStatePatch,
     ) -> Result<ApplyTransactionResult, Error> {
-        return Err(Error::StorageError(near_primitives::errors::StorageError::MissingTrieValue));
         let _span = tracing::debug_span!(target: "runtime", "process_state_update").entered();
         let epoch_id = self.epoch_manager.get_epoch_id_from_prev_block(prev_block_hash)?;
         let validator_accounts_update = {


### PR DESCRIPTION
Debugging an issue where a node panics after state sync.
I would like to have as much context as possible. What was shard_id, what was state_root, etc. But logging from multiple threads is interleaved and it seems that the information is not available at all.

Having verbose panic messages doesn't have any downsides, as far as I can tell