### PR TITLE
fix(state-viewer): Use flat storage for block/chunk/transaction/chunk processing

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -25,7 +25,7 @@ use near_chain::{
     BlockProcessingArtifact, BlockStatus, Chain, ChainGenesis, ChainStoreAccess,
     DoneApplyChunkCallback, Doomslug, DoomslugThresholdMode, Provenance,
 };
-use near_chain_configs::{ClientConfig, LogSummaryStyle, UpdateableClientConfig};
+use near_chain_configs::{ClientConfig, UpdateableClientConfig};
 use near_chunks::adapter::ShardsManagerRequestFromClient;
 use near_chunks::client::ShardedTransactionPool;
 use near_chunks::logic::{
@@ -2125,7 +2125,6 @@ impl Client {
             assert_eq!(sync_hash, state_sync_info.epoch_tail_hash);
             let network_adapter1 = self.network_adapter.clone();
 
-            let use_colour = matches!(self.config.log_summary_style, LogSummaryStyle::Colored);
             let new_shard_sync = {
                 let prev_hash = *self.chain.get_block(&sync_hash)?.header().prev_hash();
                 let need_to_split_states =
@@ -2155,6 +2154,8 @@ impl Client {
                             }
                         })
                         .collect();
+                    // For colour decorators to work, they need to printed directly. Otherwise the decorators get escaped, garble output and don't add colours.
+                    let use_colour = false;
                     debug!(target: "catchup", progress_per_shard = ?format_shard_sync_phase_per_shard(&new_shard_sync, use_colour), "Need to split states for shards");
                     new_shard_sync
                 } else {
@@ -2178,6 +2179,8 @@ impl Client {
                     )
                 });
 
+            // For colour decorators to work, they need to printed directly. Otherwise the decorators get escaped, garble output and don't add colours.
+            let use_colour = false;
             debug!(target: "catchup", ?me, ?sync_hash, progress_per_shard = ?format_shard_sync_phase_per_shard(&new_shard_sync, use_colour), "Catchup");
 
             match state_sync.run(

--- a/core/store/src/flat/mod.rs
+++ b/core/store/src/flat/mod.rs
@@ -42,7 +42,7 @@ pub use metrics::FlatStorageCreationMetrics;
 pub use storage::FlatStorage;
 pub use types::{
     BlockInfo, FetchingStateStatus, FlatStateIterator, FlatStorageCreationStatus, FlatStorageError,
-    FlatStorageReadyStatus, FlatStorageStatus,
+    FlatStorageReadyStatus, FlatStorageStatus, INLINE_DISK_VALUE_THRESHOLD,
 };
 
 pub(crate) const POISONED_LOCK_ERR: &str = "The lock was poisoned.";

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -1249,6 +1249,8 @@ impl RuntimeAdapter for NightshadeRuntime {
         let mut store_update = tries.store_update();
         tries.apply_all(&trie_changes, shard_uid, &mut store_update);
         debug!(target: "chain", %shard_id, "Inserting {} values to flat storage", flat_state_delta.len());
+        // TODO: `apply_to_flat_state` inserts values with random writes, which can be time consuming.
+        //       Optimize taking into account that flat state values always correspond to a consecutive range of keys.
         flat_state_delta.apply_to_flat_state(&mut store_update, shard_uid);
         self.precompile_contracts(epoch_id, contract_codes)?;
         Ok(store_update.commit()?)

--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -120,6 +120,7 @@ fn apply_block_from_range(
     verbose_output: bool,
     csv_file_mutex: &Mutex<Option<&mut File>>,
     only_contracts: bool,
+    use_flat_storage: bool,
 ) {
     // normally save_trie_changes depends on whether the node is
     // archival, but here we don't care, and can just set it to false
@@ -243,7 +244,7 @@ fn apply_block_from_range(
                 true,
                 is_first_block_with_chunk_of_version,
                 Default::default(),
-                false,
+                use_flat_storage,
             )
             .unwrap()
     } else {
@@ -270,7 +271,7 @@ fn apply_block_from_range(
                 false,
                 false,
                 Default::default(),
-                false,
+                use_flat_storage,
             )
             .unwrap()
     };
@@ -339,6 +340,7 @@ pub fn apply_chain_range(
     csv_file: Option<&mut File>,
     only_contracts: bool,
     sequential: bool,
+    use_flat_storage: bool,
 ) {
     let parent_span = tracing::debug_span!(
         target: "state_viewer",
@@ -384,6 +386,7 @@ pub fn apply_chain_range(
             verbose_output,
             &csv_file_mutex,
             only_contracts,
+            use_flat_storage,
         );
     };
 

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -160,11 +160,21 @@ pub struct ApplyCmd {
     height: BlockHeight,
     #[clap(long)]
     shard_id: ShardId,
+    #[clap(long)]
+    use_flat_storage: bool,
 }
 
 impl ApplyCmd {
     pub fn run(self, home_dir: &Path, near_config: NearConfig, store: Store) {
-        apply_block_at_height(self.height, self.shard_id, home_dir, near_config, store).unwrap();
+        apply_block_at_height(
+            self.height,
+            self.shard_id,
+            self.use_flat_storage,
+            home_dir,
+            near_config,
+            store,
+        )
+        .unwrap();
     }
 }
 
@@ -174,12 +184,15 @@ pub struct ApplyChunkCmd {
     chunk_hash: String,
     #[clap(long)]
     target_height: Option<u64>,
+    #[clap(long)]
+    use_flat_storage: bool,
 }
 
 impl ApplyChunkCmd {
     pub fn run(self, home_dir: &Path, near_config: NearConfig, store: Store) {
         let hash = ChunkHash::from(CryptoHash::from_str(&self.chunk_hash).unwrap());
-        apply_chunk(home_dir, near_config, store, hash, self.target_height).unwrap()
+        apply_chunk(home_dir, near_config, store, hash, self.target_height, self.use_flat_storage)
+            .unwrap()
     }
 }
 
@@ -199,6 +212,8 @@ pub struct ApplyRangeCmd {
     only_contracts: bool,
     #[clap(long)]
     sequential: bool,
+    #[clap(long)]
+    use_flat_storage: bool,
 }
 
 impl ApplyRangeCmd {
@@ -214,6 +229,7 @@ impl ApplyRangeCmd {
             store,
             self.only_contracts,
             self.sequential,
+            self.use_flat_storage,
         );
     }
 }
@@ -222,12 +238,14 @@ impl ApplyRangeCmd {
 pub struct ApplyReceiptCmd {
     #[clap(long)]
     hash: String,
+    #[clap(long)]
+    use_flat_storage: bool,
 }
 
 impl ApplyReceiptCmd {
     pub fn run(self, home_dir: &Path, near_config: NearConfig, store: Store) {
         let hash = CryptoHash::from_str(&self.hash).unwrap();
-        apply_receipt(home_dir, near_config, store, hash).unwrap();
+        apply_receipt(home_dir, near_config, store, hash, self.use_flat_storage).unwrap();
     }
 }
 
@@ -235,12 +253,14 @@ impl ApplyReceiptCmd {
 pub struct ApplyTxCmd {
     #[clap(long)]
     hash: String,
+    #[clap(long)]
+    use_flat_storage: bool,
 }
 
 impl ApplyTxCmd {
     pub fn run(self, home_dir: &Path, near_config: NearConfig, store: Store) {
         let hash = CryptoHash::from_str(&self.hash).unwrap();
-        apply_tx(home_dir, near_config, store, hash).unwrap();
+        apply_tx(home_dir, near_config, store, hash, self.use_flat_storage).unwrap();
     }
 }
 

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -586,7 +586,7 @@ pub(crate) fn print_chain(
                     let block_producer = epoch_manager
                         .get_block_producer(&epoch_id, header.height())
                         .map(|account_id| account_id.to_string())
-                        .unwrap_or("error".to_owned());
+                        .ok().unwrap_or("error".to_owned());
                     account_id_to_blocks
                         .entry(block_producer.clone())
                         .and_modify(|e| *e += 1)


### PR DESCRIPTION
Also handle a few corner cases in subcommands `chain` and `view-chain` to make state viewer work when not all shards are tracked.