### PR TITLE
feat: simple nightshade v2 - shard layout with 5 shards

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2436,6 +2436,7 @@ impl Chain {
 
         let (is_caught_up, state_dl_info, need_state_snapshot) =
             if self.epoch_manager.is_next_block_epoch_start(&prev_hash)? {
+                debug!(target: "chain", "block {} is the first block of an epoch", block.hash());
                 if !self.prev_block_is_caught_up(&prev_prev_hash, &prev_hash)? {
                     // The previous block is not caught up for the next epoch relative to the previous
                     // block, which is the current epoch for this block, so this block cannot be applied
@@ -2668,9 +2669,12 @@ impl Chain {
         // if shard layout will change the next epoch, we should catch up the shard regardless
         // whether we already have the shard's state this epoch, because we need to generate
         // new states for shards split from the current shard for the next epoch
-        shard_tracker.will_care_about_shard(me.as_ref(), parent_hash, shard_id, true)
-            && (will_shard_layout_change
-                || !shard_tracker.care_about_shard(me.as_ref(), parent_hash, shard_id, true))
+        let will_care_about_shard =
+            shard_tracker.will_care_about_shard(me.as_ref(), parent_hash, shard_id, true);
+        let does_care_about_shard =
+            shard_tracker.care_about_shard(me.as_ref(), parent_hash, shard_id, true);
+
+        will_care_about_shard && (will_shard_layout_change || !does_care_about_shard)
     }
 
     /// Check if any block with missing chunk is ready to be processed and start processing these blocks

--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -48,7 +48,7 @@ fn build_chain() {
     //     cargo insta test --accept -p near-chain --features nightly -- tests::simple_chain::build_chain
     let hash = chain.head().unwrap().last_block_hash;
     if cfg!(feature = "nightly") {
-        insta::assert_display_snapshot!(hash, @"4Lvk4yRcGz5ts7dW14ZQLFkrbUuotmTFvLMnYSheNe7r");
+        insta::assert_display_snapshot!(hash, @"86ZZBdNhwHbXDXdTjFZxGbddSy4qLpoxpWtqJtYwYXX");
     } else {
         insta::assert_display_snapshot!(hash, @"8GP6PcFavb4pqeofMFjDyKUQnfVZtwPWsVA4V47WNbRn");
     }
@@ -78,7 +78,7 @@ fn build_chain() {
 
     let hash = chain.head().unwrap().last_block_hash;
     if cfg!(feature = "nightly") {
-        insta::assert_display_snapshot!(hash, @"DFtmJJtdXKRDYmJLVY8VL85W66FxMBNu2ouMfP6LEWb6");
+        insta::assert_display_snapshot!(hash, @"8XW5k1JDHWPXkRcGwb6PTEgwggnppAW1qwWgwiqPY286");
     } else {
         insta::assert_display_snapshot!(hash, @"319JoVaUej5iXmrZMeaZBPMeBLePQzJofA5Y1ztdyPw9");
     }

--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -48,7 +48,7 @@ fn build_chain() {
     //     cargo insta test --accept -p near-chain --features nightly -- tests::simple_chain::build_chain
     let hash = chain.head().unwrap().last_block_hash;
     if cfg!(feature = "nightly") {
-        insta::assert_display_snapshot!(hash, @"3Dkg6hjpnYvMuoyEdSLnEXza6Ct2ZV9xoridA37AJzSz");
+        insta::assert_display_snapshot!(hash, @"4Lvk4yRcGz5ts7dW14ZQLFkrbUuotmTFvLMnYSheNe7r");
     } else {
         insta::assert_display_snapshot!(hash, @"8GP6PcFavb4pqeofMFjDyKUQnfVZtwPWsVA4V47WNbRn");
     }
@@ -78,7 +78,7 @@ fn build_chain() {
 
     let hash = chain.head().unwrap().last_block_hash;
     if cfg!(feature = "nightly") {
-        insta::assert_display_snapshot!(hash, @"6uCZwfkpE8qV54n5MvZXqTt8RMHYDduX4eE7quNzgLNk");
+        insta::assert_display_snapshot!(hash, @"DFtmJJtdXKRDYmJLVY8VL85W66FxMBNu2ouMfP6LEWb6");
     } else {
         insta::assert_display_snapshot!(hash, @"319JoVaUej5iXmrZMeaZBPMeBLePQzJofA5Y1ztdyPw9");
     }

--- a/core/primitives-core/Cargo.toml
+++ b/core/primitives-core/Cargo.toml
@@ -45,4 +45,5 @@ nightly = [
   "protocol_feature_simple_nightshade_v2",
 ]
 
-nightly_protocol = []
+nightly_protocol = [
+]

--- a/core/primitives-core/Cargo.toml
+++ b/core/primitives-core/Cargo.toml
@@ -35,12 +35,14 @@ default = []
 protocol_feature_fix_staking_threshold = []
 protocol_feature_fix_contract_loading_cost = []
 protocol_feature_reject_blocks_with_outdated_protocol_version = []
+protocol_feature_simple_nightshade_v2 = []
+
 nightly = [
   "nightly_protocol",
   "protocol_feature_fix_contract_loading_cost",
   "protocol_feature_fix_staking_threshold",
   "protocol_feature_reject_blocks_with_outdated_protocol_version",
+  "protocol_feature_simple_nightshade_v2",
 ]
 
-nightly_protocol = [
-]
+nightly_protocol = []

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -120,6 +120,8 @@ pub enum ProtocolFeature {
     FixContractLoadingCost,
     #[cfg(feature = "protocol_feature_reject_blocks_with_outdated_protocol_version")]
     RejectBlocksWithOutdatedProtocolVersions,
+    #[cfg(feature = "protocol_feature_simple_nightshade_v2")]
+    SimpleNightshadeV2,
 }
 
 impl ProtocolFeature {
@@ -170,6 +172,8 @@ impl ProtocolFeature {
             ProtocolFeature::FixContractLoadingCost => 129,
             #[cfg(feature = "protocol_feature_reject_blocks_with_outdated_protocol_version")]
             ProtocolFeature::RejectBlocksWithOutdatedProtocolVersions => 132,
+            #[cfg(feature = "protocol_feature_simple_nightshade_v2")]
+            ProtocolFeature::SimpleNightshadeV2 => 135,
         }
     }
 }
@@ -182,7 +186,7 @@ const STABLE_PROTOCOL_VERSION: ProtocolVersion = 62;
 /// Largest protocol version supported by the current binary.
 pub const PROTOCOL_VERSION: ProtocolVersion = if cfg!(feature = "nightly_protocol") {
     // On nightly, pick big enough version to support all features.
-    136
+    150
 } else {
     // Enable all stable features.
     STABLE_PROTOCOL_VERSION

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -186,7 +186,7 @@ const STABLE_PROTOCOL_VERSION: ProtocolVersion = 62;
 /// Largest protocol version supported by the current binary.
 pub const PROTOCOL_VERSION: ProtocolVersion = if cfg!(feature = "nightly_protocol") {
     // On nightly, pick big enough version to support all features.
-    150
+    137
 } else {
     // Enable all stable features.
     STABLE_PROTOCOL_VERSION

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -47,11 +47,13 @@ dump_errors_schema = ["near-rpc-error-macro/dump_errors_schema"]
 protocol_feature_fix_staking_threshold = ["near-primitives-core/protocol_feature_fix_staking_threshold"]
 protocol_feature_fix_contract_loading_cost = ["near-primitives-core/protocol_feature_fix_contract_loading_cost"]
 protocol_feature_reject_blocks_with_outdated_protocol_version = ["near-primitives-core/protocol_feature_reject_blocks_with_outdated_protocol_version"]
+protocol_feature_simple_nightshade_v2 = ["near-primitives-core/protocol_feature_simple_nightshade_v2"]
 nightly = [
   "nightly_protocol",
   "protocol_feature_fix_contract_loading_cost",
   "protocol_feature_fix_staking_threshold",
   "protocol_feature_reject_blocks_with_outdated_protocol_version",
+  "protocol_feature_simple_nightshade_v2",
   "near-fmt/nightly",
   "near-primitives-core/nightly",
   "near-vm-runner/nightly",

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -91,38 +91,51 @@ impl AllEpochConfig {
     }
 
     pub fn for_protocol_version(&self, protocol_version: ProtocolVersion) -> EpochConfig {
-        // if SimpleNightshade is enabled, we override genesis shard config with
-        // the simple nightshade shard config
         let mut config = self.genesis_epoch_config.clone();
-        if self.use_production_config {
-            if checked_feature!("stable", SimpleNightshade, protocol_version) {
-                config.shard_layout = ShardLayout::get_simple_nightshade_layout();
-                config.num_block_producer_seats_per_shard = vec![
-                    config.num_block_producer_seats;
-                    config.shard_layout.num_shards()
-                        as usize
-                ];
-                config.avg_hidden_validator_seats_per_shard =
-                    vec![0; config.shard_layout.num_shards() as usize];
-            }
-            if checked_feature!("stable", ChunkOnlyProducers, protocol_version) {
-                // On testnet, genesis config set num_block_producer_seats to 200
-                // This is to bring it back to 100 to be the same as on mainnet
-                config.num_block_producer_seats = 100;
-                // Technically, after ChunkOnlyProducers is enabled, this field is no longer used
-                // We still set it here just in case
-                config.num_block_producer_seats_per_shard =
-                    vec![100; config.shard_layout.num_shards() as usize];
-                config.block_producer_kickout_threshold = 80;
-                config.chunk_producer_kickout_threshold = 80;
-                config.validator_selection_config.num_chunk_only_producer_seats = 200;
-            }
+        if !self.use_production_config {
+            return config;
+        }
 
-            if checked_feature!("stable", MaxKickoutStake, protocol_version) {
-                config.validator_max_kickout_stake_perc = 30;
-            }
+        Self::config_nightshade(&mut config, protocol_version);
+
+        if checked_feature!("stable", ChunkOnlyProducers, protocol_version) {
+            // On testnet, genesis config set num_block_producer_seats to 200
+            // This is to bring it back to 100 to be the same as on mainnet
+            config.num_block_producer_seats = 100;
+            // Technically, after ChunkOnlyProducers is enabled, this field is no longer used
+            // We still set it here just in case
+            config.num_block_producer_seats_per_shard =
+                vec![100; config.shard_layout.num_shards() as usize];
+            config.block_producer_kickout_threshold = 80;
+            config.chunk_producer_kickout_threshold = 80;
+            config.validator_selection_config.num_chunk_only_producer_seats = 200;
+        }
+
+        if checked_feature!("stable", MaxKickoutStake, protocol_version) {
+            config.validator_max_kickout_stake_perc = 30;
         }
         config
+    }
+
+    fn config_nightshade(config: &mut EpochConfig, protocol_version: ProtocolVersion) {
+        #[cfg(feature = "protocol_feature_simple_nightshade_v2")]
+        if checked_feature!("stable", SimpleNightshadeV2, protocol_version) {
+            Self::config_nightshade_impl(config, ShardLayout::get_simple_nightshade_layout_v2());
+            return;
+        }
+
+        if checked_feature!("stable", SimpleNightshade, protocol_version) {
+            Self::config_nightshade_impl(config, ShardLayout::get_simple_nightshade_layout());
+            return;
+        }
+    }
+
+    fn config_nightshade_impl(config: &mut EpochConfig, shard_layout: ShardLayout) {
+        let num_shards = shard_layout.num_shards() as usize;
+        config.shard_layout = shard_layout;
+        config.num_block_producer_seats_per_shard =
+            vec![config.num_block_producer_seats; num_shards];
+        config.avg_hidden_validator_seats_per_shard = vec![0; num_shards];
     }
 }
 

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -98,22 +98,10 @@ impl AllEpochConfig {
 
         Self::config_nightshade(&mut config, protocol_version);
 
-        if checked_feature!("stable", ChunkOnlyProducers, protocol_version) {
-            // On testnet, genesis config set num_block_producer_seats to 200
-            // This is to bring it back to 100 to be the same as on mainnet
-            config.num_block_producer_seats = 100;
-            // Technically, after ChunkOnlyProducers is enabled, this field is no longer used
-            // We still set it here just in case
-            config.num_block_producer_seats_per_shard =
-                vec![100; config.shard_layout.num_shards() as usize];
-            config.block_producer_kickout_threshold = 80;
-            config.chunk_producer_kickout_threshold = 80;
-            config.validator_selection_config.num_chunk_only_producer_seats = 200;
-        }
+        Self::config_chunk_only_producers(&mut config, protocol_version);
 
-        if checked_feature!("stable", MaxKickoutStake, protocol_version) {
-            config.validator_max_kickout_stake_perc = 30;
-        }
+        Self::config_max_kickout_stake(&mut config, protocol_version);
+
         config
     }
 
@@ -136,6 +124,27 @@ impl AllEpochConfig {
         config.num_block_producer_seats_per_shard =
             vec![config.num_block_producer_seats; num_shards];
         config.avg_hidden_validator_seats_per_shard = vec![0; num_shards];
+    }
+
+    fn config_chunk_only_producers(config: &mut EpochConfig, protocol_version: u32) {
+        if checked_feature!("stable", ChunkOnlyProducers, protocol_version) {
+            // On testnet, genesis config set num_block_producer_seats to 200
+            // This is to bring it back to 100 to be the same as on mainnet
+            config.num_block_producer_seats = 100;
+            // Technically, after ChunkOnlyProducers is enabled, this field is no longer used
+            // We still set it here just in case
+            config.num_block_producer_seats_per_shard =
+                vec![100; config.shard_layout.num_shards() as usize];
+            config.block_producer_kickout_threshold = 80;
+            config.chunk_producer_kickout_threshold = 80;
+            config.validator_selection_config.num_chunk_only_producer_seats = 200;
+        }
+    }
+
+    fn config_max_kickout_stake(config: &mut EpochConfig, protocol_version: u32) {
+        if checked_feature!("stable", MaxKickoutStake, protocol_version) {
+            config.validator_max_kickout_stake_perc = 30;
+        }
     }
 }
 

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -120,21 +120,21 @@ impl AllEpochConfig {
 
     fn config_nightshade_impl(config: &mut EpochConfig, shard_layout: ShardLayout) {
         let num_shards = shard_layout.num_shards() as usize;
+        let num_block_producer_seats = config.num_block_producer_seats;
         config.shard_layout = shard_layout;
-        config.num_block_producer_seats_per_shard =
-            vec![config.num_block_producer_seats; num_shards];
+        config.num_block_producer_seats_per_shard = vec![num_block_producer_seats; num_shards];
         config.avg_hidden_validator_seats_per_shard = vec![0; num_shards];
     }
 
     fn config_chunk_only_producers(config: &mut EpochConfig, protocol_version: u32) {
         if checked_feature!("stable", ChunkOnlyProducers, protocol_version) {
+            let num_shards = config.shard_layout.num_shards() as usize;
             // On testnet, genesis config set num_block_producer_seats to 200
             // This is to bring it back to 100 to be the same as on mainnet
             config.num_block_producer_seats = 100;
             // Technically, after ChunkOnlyProducers is enabled, this field is no longer used
             // We still set it here just in case
-            config.num_block_producer_seats_per_shard =
-                vec![100; config.shard_layout.num_shards() as usize];
+            config.num_block_producer_seats_per_shard = vec![100; num_shards];
             config.block_producer_kickout_threshold = 80;
             config.chunk_producer_kickout_threshold = 80;
             config.validator_selection_config.num_chunk_only_producer_seats = 200;

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -564,19 +564,14 @@ mod tests {
         ids.into_iter().map(|a| a.parse().unwrap()).collect()
     }
 
-    fn print_shard_layout(name: &str, shard_layout: &ShardLayout) {
-        println!("{name}");
-        println!("{}", serde_json::to_string(shard_layout).unwrap());
-    }
-
     #[test]
-    fn print_shard_layout_all() {
+    fn test_shard_layout_all() {
         let v0 = ShardLayout::v0(1, 0);
         let v1 = ShardLayout::get_simple_nightshade_layout();
         let v2 = ShardLayout::get_simple_nightshade_layout_v2();
 
-        print_shard_layout("v0", &v0);
-        print_shard_layout("v1", &v1);
-        print_shard_layout("v2", &v2);
+        insta::assert_snapshot!(serde_json::to_string(&v0).unwrap(), @r###"{"V0":{"num_shards":1,"version":0}}"###);
+        insta::assert_snapshot!(serde_json::to_string(&v1).unwrap(), @r###"{"V1":{"boundary_accounts":["aurora","aurora-0","kkuuue2akv_1630967379.near"],"shards_split_map":[[0,1,2,3]],"to_parent_shard_map":[0,0,0,0],"version":1}}"###);
+        insta::assert_snapshot!(serde_json::to_string(&v2).unwrap(), @r###"{"V1":{"boundary_accounts":["aurora","aurora-0","kkuuue2akv_1630967379.near","sweat"],"shards_split_map":[[0],[1],[2],[3,4]],"to_parent_shard_map":[0,1,2,3,3],"version":2}}"###);
     }
 }

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -167,8 +167,8 @@ impl ShardLayout {
                 .into_iter()
                 .map(|s| s.parse().unwrap())
                 .collect(),
-            Some(vec![vec![0, 1, 2, 3]]),
-            1,
+            Some(vec![vec![0], vec![1], vec![2], vec![3, 4]]),
+            2,
         )
     }
 
@@ -562,5 +562,21 @@ mod tests {
 
     fn parse_account_ids(ids: &[&str]) -> Vec<AccountId> {
         ids.into_iter().map(|a| a.parse().unwrap()).collect()
+    }
+
+    fn print_shard_layout(name: &str, shard_layout: &ShardLayout) {
+        println!("{name}");
+        println!("{}", serde_json::to_string(shard_layout).unwrap());
+    }
+
+    #[test]
+    fn print_shard_layout_all() {
+        let v0 = ShardLayout::v0(1, 0);
+        let v1 = ShardLayout::get_simple_nightshade_layout();
+        let v2 = ShardLayout::get_simple_nightshade_layout_v2();
+
+        print_shard_layout("v0", &v0);
+        print_shard_layout("v1", &v1);
+        print_shard_layout("v2", &v2);
     }
 }

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -156,6 +156,23 @@ impl ShardLayout {
         )
     }
 
+    /// Returns the simple nightshade layout, version 2, that will be used in production.
+    /// This is work in progress and the exact way of splitting is yet to be determined.
+    pub fn get_simple_nightshade_layout_v2() -> ShardLayout {
+        ShardLayout::v1(
+            vec![],
+            // TODO(resharding) - find the right boundary to split shards in
+            // place of just "sweat". Likely somewhere in between near.social
+            // and sweatcoin.
+            vec!["aurora", "aurora-0", "kkuuue2akv_1630967379.near", "sweat"]
+                .into_iter()
+                .map(|s| s.parse().unwrap())
+                .collect(),
+            Some(vec![vec![0, 1, 2, 3]]),
+            1,
+        )
+    }
+
     /// Given a parent shard id, return the shard uids for the shards in the current shard layout that
     /// are split from this parent shard. If this shard layout has no parent shard layout, return None
     pub fn get_split_shard_uids(&self, parent_shard_id: ShardId) -> Option<Vec<ShardUId>> {

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -160,7 +160,6 @@ impl ShardLayout {
     /// This is work in progress and the exact way of splitting is yet to be determined.
     pub fn get_simple_nightshade_layout_v2() -> ShardLayout {
         ShardLayout::v1(
-            vec![],
             // TODO(resharding) - find the right boundary to split shards in
             // place of just "sweat". Likely somewhere in between near.social
             // and sweatcoin.

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -570,8 +570,74 @@ mod tests {
         let v1 = ShardLayout::get_simple_nightshade_layout();
         let v2 = ShardLayout::get_simple_nightshade_layout_v2();
 
-        insta::assert_snapshot!(serde_json::to_string(&v0).unwrap(), @r###"{"V0":{"num_shards":1,"version":0}}"###);
-        insta::assert_snapshot!(serde_json::to_string(&v1).unwrap(), @r###"{"V1":{"boundary_accounts":["aurora","aurora-0","kkuuue2akv_1630967379.near"],"shards_split_map":[[0,1,2,3]],"to_parent_shard_map":[0,0,0,0],"version":1}}"###);
-        insta::assert_snapshot!(serde_json::to_string(&v2).unwrap(), @r###"{"V1":{"boundary_accounts":["aurora","aurora-0","kkuuue2akv_1630967379.near","sweat"],"shards_split_map":[[0],[1],[2],[3,4]],"to_parent_shard_map":[0,1,2,3,3],"version":2}}"###);
+        insta::assert_snapshot!(serde_json::to_string_pretty(&v0).unwrap(), @r###"
+        {
+          "V0": {
+            "num_shards": 1,
+            "version": 0
+          }
+        }
+        "###);
+        insta::assert_snapshot!(serde_json::to_string_pretty(&v1).unwrap(), @r###"
+        {
+          "V1": {
+            "boundary_accounts": [
+              "aurora",
+              "aurora-0",
+              "kkuuue2akv_1630967379.near"
+            ],
+            "shards_split_map": [
+              [
+                0,
+                1,
+                2,
+                3
+              ]
+            ],
+            "to_parent_shard_map": [
+              0,
+              0,
+              0,
+              0
+            ],
+            "version": 1
+          }
+        }
+        "###);
+        insta::assert_snapshot!(serde_json::to_string_pretty(&v2).unwrap(), @r###"
+        {
+          "V1": {
+            "boundary_accounts": [
+              "aurora",
+              "aurora-0",
+              "kkuuue2akv_1630967379.near",
+              "sweat"
+            ],
+            "shards_split_map": [
+              [
+                0
+              ],
+              [
+                1
+              ],
+              [
+                2
+              ],
+              [
+                3,
+                4
+              ]
+            ],
+            "to_parent_shard_map": [
+              0,
+              1,
+              2,
+              3,
+              3
+            ],
+            "version": 2
+          }
+        }
+        "###);
     }
 }

--- a/nearcore/Cargo.toml
+++ b/nearcore/Cargo.toml
@@ -111,12 +111,16 @@ protocol_feature_fix_staking_threshold = [
 protocol_feature_fix_contract_loading_cost = [
   "near-vm-runner/protocol_feature_fix_contract_loading_cost",
 ]
-serialize_all_state_changes = ["near-store/serialize_all_state_changes"]
+protocol_feature_simple_nightshade_v2 = [
+    "near-primitives/protocol_feature_simple_nightshade_v2",
+]
 
+serialize_all_state_changes = ["near-store/serialize_all_state_changes"]
 nightly = [
   "nightly_protocol",
   "protocol_feature_fix_contract_loading_cost",
   "protocol_feature_fix_staking_threshold",
+  "protocol_feature_simple_nightshade_v2",
   "serialize_all_state_changes",
   "near-async/nightly",
   "near-chain-configs/nightly",

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -70,11 +70,13 @@ delay_detector = ["nearcore/delay_detector"]
 rosetta_rpc = ["nearcore/rosetta_rpc"]
 json_rpc = ["nearcore/json_rpc"]
 protocol_feature_fix_staking_threshold = ["nearcore/protocol_feature_fix_staking_threshold"]
+protocol_feature_simple_nightshade_v2 = ["nearcore/protocol_feature_simple_nightshade_v2"]
 serialize_all_state_changes = ["nearcore/serialize_all_state_changes"]
 
 nightly = [
   "nightly_protocol",
   "protocol_feature_fix_staking_threshold",
+  "protocol_feature_simple_nightshade_v2",
   "serialize_all_state_changes",
   "near-chain-configs/nightly",
   "near-client/nightly",

--- a/pytest/tests/sanity/upgradable.py
+++ b/pytest/tests/sanity/upgradable.py
@@ -109,11 +109,13 @@ def test_upgrade() -> None:
     ]
     for i in range(1, 3):
         nodes.append(
-            cluster.spin_up_node(config,
-                                 executables.stable.root,
-                                 node_dirs[i],
-                                 i,
-                                 boot_node=nodes[0]))
+            cluster.spin_up_node(
+                config,
+                executables.stable.root,
+                node_dirs[i],
+                i,
+                boot_node=nodes[0],
+            ))
     config = executables.current.node_config()
     nodes.append(
         cluster.spin_up_node(config,

--- a/pytest/tests/sanity/upgradable.py
+++ b/pytest/tests/sanity/upgradable.py
@@ -109,13 +109,11 @@ def test_upgrade() -> None:
     ]
     for i in range(1, 3):
         nodes.append(
-            cluster.spin_up_node(
-                config,
-                executables.stable.root,
-                node_dirs[i],
-                i,
-                boot_node=nodes[0],
-            ))
+            cluster.spin_up_node(config,
+                                 executables.stable.root,
+                                 node_dirs[i],
+                                 i,
+                                 boot_node=nodes[0]))
     config = executables.current.node_config()
     nodes.append(
         cluster.spin_up_node(config,


### PR DESCRIPTION
Introduced new protocol version called SimpleNightshadeV2, guarded it behind the rust feature `protocol_feature_simple_nightshade_v2` and added it to nightly. 

Refactored the AllEpochConfig::for_protocol_version a bit and added the SimpleNightshadeV2 shard layout to it. 

Note that I'm only hiding the SimpleNightshadeV2 behind the rust feature, I'm not planning on adding it everywhere. I'm reusing the same ShardLayout::V1 structure, just with bumped version and an extra boundary account. This should allow for smooth development since we won't need to guard all of the new code behind the new rust feature. 

I tested it manually and some sort of resharding did happen. I'm yet to fully appreciate what exactly happened and if it's any good, as well as add some proper tests. I'll do that in separate PRs. 

test repro instructions:
```
- get the current layout in json by running the print_shard_layout_all test and put it in $SHARD_LAYOUT
- generate localnet setup with 4 shards and 1 validator
- in the genesis file overwrite:
  - .epoch_length=10
  - .use_production_config=true
  - .shard_layout=$SHARD_LAYOUT
- build neard with nightly not enabled
- run neard for at least one epoch
- build neard with nightly enabled
- run neard
- watch resharding happening (only enabled debug logs for "catchup" target)
- see new shard layout in the debug page 
```
![Screenshot 2023-07-11 at 15 34 36](https://github.com/near/nearcore/assets/1555986/5b83d645-4fdf-4994-a215-a500c0c0092f)

resharding logs: https://gist.github.com/wacban/7b3a8c74c80f99003c71b92bea44539f 
