### PR TITLE
feat: add database tool subcommand for State read perf testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3619,10 +3619,14 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap 4.2.4",
+ "indicatif",
  "near-chain-configs",
+ "near-primitives",
  "near-store",
  "nearcore",
+ "rand 0.8.5",
  "rayon",
+ "rocksdb",
  "strum",
  "tempfile",
 ]

--- a/tools/database/Cargo.toml
+++ b/tools/database/Cargo.toml
@@ -11,24 +11,29 @@ publish = false
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
+indicatif.workspace = true
+rand.workspace = true
 rayon.workspace = true
+rocksdb.workspace = true
 strum.workspace = true
 tempfile.workspace = true
 
 nearcore.workspace = true
-near-store.workspace = true
 near-chain-configs.workspace = true
-
+near-store.workspace = true
+near-primitives.workspace = true
 
 [features]
 nightly = [
   "nightly_protocol",
   "near-chain-configs/nightly",
+  "near-primitives/nightly",
   "near-store/nightly",
   "nearcore/nightly",
 ]
 nightly_protocol = [
   "near-chain-configs/nightly_protocol",
+  "near-primitives/nightly_protocol",
   "near-store/nightly_protocol",
   "nearcore/nightly_protocol",
 ]

--- a/tools/database/README.md
+++ b/tools/database/README.md
@@ -2,7 +2,7 @@
 
 A set of tools useful when working with the underlying database.
 
-## Analyse Database
+## Analyse data size distribution
 
 The analyse database script provides an efficient way to assess the size distribution
 of keys and values within RocksDB.
@@ -78,3 +78,7 @@ available in `/home/ubuntu/.near/data/snapshot`
 
 This command can be helpful before attempting activities that can potentially
 corrupt the database.
+
+## State read perf
+A tool for performance testing hot storage RocksDB State column reads.
+Use help to get more details: `neard database state-perf --help`

--- a/tools/database/src/adjust_database.rs
+++ b/tools/database/src/adjust_database.rs
@@ -1,6 +1,5 @@
 use near_store::metadata::DbKind;
 use near_store::NodeStorage;
-use nearcore::NearConfig;
 use std::path::Path;
 
 /// This can potentially support db specified not in config, but in command line.
@@ -25,7 +24,11 @@ pub(crate) struct ChangeDbKindCommand {
 }
 
 impl ChangeDbKindCommand {
-    pub(crate) fn run(&self, home_dir: &Path, near_config: &NearConfig) -> anyhow::Result<()> {
+    pub(crate) fn run(&self, home_dir: &Path) -> anyhow::Result<()> {
+        let near_config = nearcore::config::load_config(
+            &home_dir,
+            near_chain_configs::GenesisValidationMode::UnsafeFast,
+        )?;
         let opener = NodeStorage::opener(
             home_dir,
             near_config.config.archive,

--- a/tools/database/src/commands.rs
+++ b/tools/database/src/commands.rs
@@ -1,6 +1,7 @@
 use crate::adjust_database::ChangeDbKindCommand;
 use crate::analyse_data_size_distribution::AnalyseDataSizeDistributionCommand;
 use crate::make_snapshot::MakeSnapshotCommand;
+use crate::state_perf::StatePerfCommand;
 use clap::Parser;
 use std::path::PathBuf;
 
@@ -21,20 +22,17 @@ enum SubCommand {
 
     /// Make snapshot of the database
     MakeSnapshot(MakeSnapshotCommand),
+
+    /// Run performance test for State column reads.
+    /// Uses RocksDB data specified via --home argument.
+    StatePerf(StatePerfCommand),
 }
 
 impl DatabaseCommand {
     pub fn run(&self, home: &PathBuf) -> anyhow::Result<()> {
         match &self.subcmd {
             SubCommand::AnalyseDataSizeDistribution(cmd) => cmd.run(home),
-            SubCommand::ChangeDbKind(cmd) => {
-                let near_config = nearcore::config::load_config(
-                    &home,
-                    near_chain_configs::GenesisValidationMode::UnsafeFast,
-                )
-                .unwrap_or_else(|e| panic!("Error loading config: {:#}", e));
-                cmd.run(home, &near_config)
-            }
+            SubCommand::ChangeDbKind(cmd) => cmd.run(home),
             SubCommand::MakeSnapshot(cmd) => {
                 let near_config = nearcore::config::load_config(
                     &home,
@@ -43,6 +41,7 @@ impl DatabaseCommand {
                 .unwrap_or_else(|e| panic!("Error loading config: {:#}", e));
                 cmd.run(home, near_config.config.archive, &near_config.config.store)
             }
+            SubCommand::StatePerf(cmd) => cmd.run(home),
         }
     }
 }

--- a/tools/database/src/lib.rs
+++ b/tools/database/src/lib.rs
@@ -2,3 +2,5 @@ mod adjust_database;
 mod analyse_data_size_distribution;
 pub mod commands;
 mod make_snapshot;
+mod state_perf;
+mod utils;

--- a/tools/database/src/state_perf.rs
+++ b/tools/database/src/state_perf.rs
@@ -1,0 +1,195 @@
+use clap::Parser;
+use indicatif::{ProgressBar, ProgressIterator};
+use std::collections::BTreeMap;
+use std::fmt::{Display, Write};
+use std::path::Path;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use near_primitives::shard_layout::{ShardLayout, ShardUId};
+use near_primitives::state::ValueRef;
+use rand::rngs::StdRng;
+use rand::seq::SliceRandom;
+use rand::SeedableRng;
+
+use near_store::flat::store_helper::iter_flat_state_entries;
+use near_store::{Store, TrieStorage};
+
+use crate::utils::open_rocksdb;
+
+#[derive(Parser)]
+pub(crate) struct StatePerfCommand {
+    /// Number of requests to use for the performance evaluation.
+    /// Increasing this value results in more precise measurements, but longer test execution.
+    #[arg(short, long, default_value_t = 10000)]
+    samples: usize,
+
+    /// Number of requests to use for the database warmup.
+    /// Those requests will be excluded from the measurements.
+    #[arg(short, long, default_value_t = 1000)]
+    warmup_samples: usize,
+}
+
+impl StatePerfCommand {
+    pub(crate) fn run(&self, home: &Path) -> anyhow::Result<()> {
+        let rocksdb = Arc::new(open_rocksdb(home)?);
+        let store = near_store::NodeStorage::new(rocksdb).get_hot_store();
+        eprintln!("Start State perf test");
+        let mut perf_context = PerfContext::new();
+        let total_samples = self.warmup_samples + self.samples;
+        for (sample_i, (shard_uid, value_ref)) in
+            generate_state_requests(store.clone(), total_samples).into_iter().enumerate().progress()
+        {
+            let trie_storage = near_store::TrieDBStorage::new(store.clone(), shard_uid);
+            let include_sample = sample_i >= self.warmup_samples;
+            if include_sample {
+                perf_context.reset();
+            }
+            trie_storage.retrieve_raw_bytes(&value_ref.hash).unwrap();
+            if include_sample {
+                perf_context.record();
+            }
+        }
+        eprintln!("Finished State perf test");
+        println!("{}", perf_context.format());
+        Ok(())
+    }
+}
+
+struct PerfContext {
+    rocksdb_context: rocksdb::perf::PerfContext,
+    start: Instant,
+    measurements_per_block_reads: BTreeMap<usize, Measurements>,
+    measurements_overall: Measurements,
+}
+
+#[derive(Default)]
+struct Measurements {
+    samples: usize,
+    total_observed_latency: Duration,
+    total_read_block_latency: Duration,
+    samples_with_merge: usize,
+}
+
+impl Measurements {
+    fn record(
+        &mut self,
+        observed_latency: Duration,
+        read_block_latency: Duration,
+        has_merge: bool,
+    ) {
+        self.samples += 1;
+        self.total_observed_latency += observed_latency;
+        self.total_read_block_latency += read_block_latency;
+        if has_merge {
+            self.samples_with_merge += 1;
+        }
+    }
+
+    fn avg_observed_latency(&self) -> Duration {
+        self.total_observed_latency / (self.samples as u32)
+    }
+
+    fn avg_read_block_latency(&self) -> Duration {
+        self.total_read_block_latency / (self.samples as u32)
+    }
+}
+
+impl Display for Measurements {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "avg observed_latency: {:?}, block_read_time: {:?}, samples with merge: {}",
+            self.avg_observed_latency(),
+            self.avg_read_block_latency(),
+            format_samples(self.samples_with_merge, self.samples)
+        )
+    }
+}
+
+impl PerfContext {
+    fn new() -> Self {
+        rocksdb::perf::set_perf_stats(rocksdb::perf::PerfStatsLevel::EnableTime);
+        Self {
+            rocksdb_context: rocksdb::perf::PerfContext::default(),
+            start: Instant::now(),
+            measurements_per_block_reads: BTreeMap::new(),
+            measurements_overall: Measurements::default(),
+        }
+    }
+
+    fn reset(&mut self) {
+        self.rocksdb_context.reset();
+        self.start = Instant::now();
+    }
+
+    fn record(&mut self) {
+        let observed_latency = self.start.elapsed();
+        let block_read_cnt =
+            self.rocksdb_context.metric(rocksdb::PerfMetric::BlockReadCount) as usize;
+        let read_block_latency =
+            Duration::from_nanos(self.rocksdb_context.metric(rocksdb::PerfMetric::BlockReadTime));
+        assert!(observed_latency > read_block_latency);
+        // This is a hack to check if at least one merge operator was executed during this request,
+        // will be replaced by a proper metric after `internal_merge_point_lookup_count` is added to
+        // rust-rocksdb
+        let has_merge =
+            self.rocksdb_context.metric(rocksdb::PerfMetric::MergeOperatorTimeNanos) > 0;
+        self.measurements_per_block_reads.entry(block_read_cnt).or_default().record(
+            observed_latency,
+            read_block_latency,
+            has_merge,
+        );
+        self.measurements_overall.record(observed_latency, read_block_latency, has_merge);
+    }
+
+    fn format(&self) -> String {
+        let mut ret = String::new();
+        writeln!(&mut ret, "overall | {}", self.measurements_overall).unwrap();
+        for (&block_read_cnt, measurements) in &self.measurements_per_block_reads {
+            writeln!(
+                &mut ret,
+                "block_read_count: {block_read_cnt}, samples: {}: | {}",
+                format_samples(measurements.samples, self.measurements_overall.samples),
+                measurements
+            )
+            .unwrap();
+        }
+        ret
+    }
+}
+
+fn generate_state_requests(store: Store, samples: usize) -> Vec<(ShardUId, ValueRef)> {
+    eprintln!("Generate {samples} requests to State");
+    let shard_uids = ShardLayout::get_simple_nightshade_layout().get_shard_uids();
+    let mut ret = Vec::new();
+    let progress = ProgressBar::new(samples as u64);
+    for &shard_uid in &shard_uids {
+        let shard_samples = samples / shard_uids.len();
+        let mut keys_read = std::collections::HashSet::new();
+        for value_ref in iter_flat_state_entries(shard_uid, &store, None, None)
+            .flat_map(|res| res.map(|(_, value)| value.to_value_ref()))
+        {
+            if value_ref.length > 4096 || !keys_read.insert(value_ref.hash) {
+                continue;
+            }
+            ret.push((shard_uid, value_ref));
+            progress.inc(1);
+            if keys_read.len() == shard_samples {
+                break;
+            }
+        }
+    }
+    progress.finish();
+    // Shuffle to avoid clustering requests to the same shard
+    ret.shuffle(&mut StdRng::seed_from_u64(42));
+    eprintln!("Finished requests generation");
+    ret
+}
+
+fn format_samples(positive: usize, total: usize) -> String {
+    format!(
+        "{positive} ({:.2}%)",
+        if total == 0 { 0.0 } else { 100.0 * positive as f64 / total as f64 }
+    )
+}

--- a/tools/database/src/utils.rs
+++ b/tools/database/src/utils.rs
@@ -1,0 +1,16 @@
+use std::path::Path;
+
+pub(crate) fn open_rocksdb(home: &Path) -> anyhow::Result<near_store::db::RocksDB> {
+    let config = nearcore::config::Config::from_file_skip_validation(
+        &home.join(nearcore::config::CONFIG_FILENAME),
+    )?;
+    let store_config = &config.store;
+    let db_path = store_config.path.as_ref().cloned().unwrap_or_else(|| home.join("data"));
+    let rocksdb = near_store::db::RocksDB::open(
+        &db_path,
+        store_config,
+        near_store::Mode::ReadOnly,
+        near_store::Temperature::Hot,
+    )?;
+    Ok(rocksdb)
+}


### PR DESCRIPTION
This PR adds a tool used to evaluate State read performance as part of `neard database` CLI. For more details on the approach see [the Methodology section](https://github.com/near/nearcore/discussions/9235).
Also includes some minor refactoring around database tool.

<details>
  <summary>Example executions</summary>
  
```
ubuntu@pugachag-mainnet:~/nearcore$ ./target/quick-release/neard database state-perf --help
Run performance test for State column reads

Usage: neard database state-perf [OPTIONS]

Options:
  -s, --samples <SAMPLES>
          Number of requsts to use for the performance evaluation. Increasing this value results in more precise measurements, but longer test execution [default: 10000]
  -w, --warmup-samples <WARMUP_SAMPLES>
          Number of requests to use for database warmup. Those requests will be excluded from the measurements [default: 1000]
  -h, --help
          Print help
ubuntu@pugachag-mainnet:~/nearcore$ ./target/quick-release/neard database state-perf 
2023-07-12T10:21:15.258765Z  INFO neard: version="trunk" build="44a09bf39" latest_protocol=62
2023-07-12T10:21:15.292835Z  INFO db: Opened a new RocksDB instance. num_instances=1
Start State perf test
Generate 11000 requests to State
█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 11000/11000
Finished requests generation
█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 11000/11000
Finished State perf test
overall | avg observed_latency: 1.45039ms, block_read_time: 1.196571ms, samples with merge: 1596 (15.96%)
block_read_count: 0, samples: 7 (0.07%): | avg observed_latency: 36.126µs, block_read_time: 0ns, samples with merge: 4 (57.14%)
block_read_count: 1, samples: 4613 (46.13%): | avg observed_latency: 886.908µs, block_read_time: 790.738µs, samples with merge: 36 (0.78%)
block_read_count: 2, samples: 1962 (19.62%): | avg observed_latency: 1.383988ms, block_read_time: 1.221933ms, samples with merge: 904 (46.08%)
block_read_count: 3, samples: 1375 (13.75%): | avg observed_latency: 1.526996ms, block_read_time: 1.271185ms, samples with merge: 363 (26.40%)
block_read_count: 4, samples: 1361 (13.61%): | avg observed_latency: 1.575212ms, block_read_time: 1.207766ms, samples with merge: 148 (10.87%)
block_read_count: 5, samples: 221 (2.21%): | avg observed_latency: 2.080291ms, block_read_time: 1.660845ms, samples with merge: 89 (40.27%)
block_read_count: 6, samples: 382 (3.82%): | avg observed_latency: 6.281688ms, block_read_time: 4.545931ms, samples with merge: 28 (7.33%)
block_read_count: 7, samples: 41 (0.41%): | avg observed_latency: 6.709164ms, block_read_time: 4.897512ms, samples with merge: 14 (34.15%)
block_read_count: 8, samples: 13 (0.13%): | avg observed_latency: 6.569955ms, block_read_time: 4.73201ms, samples with merge: 7 (53.85%)
block_read_count: 9, samples: 3 (0.03%): | avg observed_latency: 7.457121ms, block_read_time: 5.517267ms, samples with merge: 2 (66.67%)
block_read_count: 10, samples: 22 (0.22%): | avg observed_latency: 9.602637ms, block_read_time: 6.658604ms, samples with merge: 1 (4.55%)

2023-07-12T10:21:46.995873Z  INFO db: Closed a RocksDB instance. num_instances=0
```
</details>