### PR TITLE
fix(state-sync): Simplify storage format of state sync dump progress

### DIFF
--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -886,7 +886,7 @@ impl ChainStore {
     pub fn get_state_sync_dump_progress(
         &self,
         shard_id: ShardId,
-    ) -> Result<Option<StateSyncDumpProgress>, Error> {
+    ) -> Result<StateSyncDumpProgress, Error> {
         option_to_not_found(
             self.store
                 .get_ser(DBCol::BlockMisc, &ChainStore::state_sync_dump_progress_key(shard_id)),
@@ -902,7 +902,10 @@ impl ChainStore {
     ) -> Result<(), Error> {
         let mut store_update = self.store.store_update();
         let key = ChainStore::state_sync_dump_progress_key(shard_id);
-        store_update.set_ser(DBCol::BlockMisc, &key, &value)?;
+        match value {
+            None => store_update.delete(DBCol::BlockMisc, &key),
+            Some(value) => store_update.set_ser(DBCol::BlockMisc, &key, &value)?,
+        }
         store_update.commit().map_err(|err| err.into())
     }
 }

--- a/nearcore/src/state_sync.rs
+++ b/nearcore/src/state_sync.rs
@@ -338,11 +338,7 @@ async fn state_sync_dump(
                                         &shard_id,
                                         epoch_height,
                                         Some(state_part.len()),
-                                        num_parts
-                                            .checked_sub(
-                                                parts_to_dump.len().checked_add(1).unwrap() as u64,
-                                            )
-                                            .unwrap(),
+                                        num_parts.checked_sub(parts_to_dump.len() as u64).unwrap(),
                                         num_parts,
                                     );
                                     dumped_any_state_part = true;

--- a/nearcore/src/state_sync.rs
+++ b/nearcore/src/state_sync.rs
@@ -174,7 +174,7 @@ fn get_current_state(
     epoch_manager: Arc<dyn EpochManagerAdapter>,
 ) -> Result<Option<(EpochId, EpochHeight, CryptoHash)>, Error> {
     let was_last_epoch_dumped = match chain.store().get_state_sync_dump_progress(*shard_id) {
-        Ok(Some(StateSyncDumpProgress::AllDumped { epoch_id, .. })) => Some(epoch_id),
+        Ok(StateSyncDumpProgress::AllDumped { epoch_id, .. }) => Some(epoch_id),
         _ => None,
     };
 

--- a/tools/state-viewer/src/scan_db.rs
+++ b/tools/state-viewer/src/scan_db.rs
@@ -231,7 +231,7 @@ fn format_block_misc_value<'a>(key: &'a [u8], value: &'a [u8]) -> Box<dyn Debug 
     } else if key == near_store::GENESIS_STATE_ROOTS_KEY {
         Box::new(Vec::<StateRoot>::try_from_slice(value).unwrap())
     } else if key.starts_with(near_store::STATE_SYNC_DUMP_KEY) {
-        Box::new(Option::<StateSyncDumpProgress>::try_from_slice(value).unwrap())
+        Box::new(StateSyncDumpProgress::try_from_slice(value).unwrap())
     } else {
         Box::new(value)
     }


### PR DESCRIPTION
No reason why `StateSyncDumpProgress` had to be stored as `Some(x)` instead of simply `x`