### PR TITLE
near-vm-runner: move protocol-sensitive error schemas to near-primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4363,7 +4363,6 @@ dependencies = [
  "near-crypto",
  "near-primitives",
  "near-primitives-core",
- "near-rpc-error-macro",
  "near-stdx",
  "near-test-contracts",
  "near-vm-compiler",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4360,7 +4360,6 @@ dependencies = [
  "hex",
  "loupe",
  "memoffset 0.8.0",
- "near-account-id",
  "near-crypto",
  "near-primitives",
  "near-primitives-core",

--- a/chain/jsonrpc/res/rpc_errors_schema.json
+++ b/chain/jsonrpc/res/rpc_errors_schema.json
@@ -1,425 +1,5 @@
 {
   "schema": {
-    "AltBn128InvalidInput": {
-      "name": "AltBn128InvalidInput",
-      "subtypes": [],
-      "props": {
-        "msg": ""
-      }
-    },
-    "BadUTF16": {
-      "name": "BadUTF16",
-      "subtypes": [],
-      "props": {}
-    },
-    "BadUTF8": {
-      "name": "BadUTF8",
-      "subtypes": [],
-      "props": {}
-    },
-    "BalanceExceeded": {
-      "name": "BalanceExceeded",
-      "subtypes": [],
-      "props": {}
-    },
-    "CallIndirectOOB": {
-      "name": "CallIndirectOOB",
-      "subtypes": [],
-      "props": {}
-    },
-    "CannotAppendActionToJointPromise": {
-      "name": "CannotAppendActionToJointPromise",
-      "subtypes": [],
-      "props": {}
-    },
-    "CannotReturnJointPromise": {
-      "name": "CannotReturnJointPromise",
-      "subtypes": [],
-      "props": {}
-    },
-    "CodeDoesNotExist": {
-      "name": "CodeDoesNotExist",
-      "subtypes": [],
-      "props": {
-        "account_id": ""
-      }
-    },
-    "CompilationError": {
-      "name": "CompilationError",
-      "subtypes": [
-        "CodeDoesNotExist",
-        "PrepareError",
-        "WasmerCompileError"
-      ],
-      "props": {}
-    },
-    "ContractSizeExceeded": {
-      "name": "ContractSizeExceeded",
-      "subtypes": [],
-      "props": {
-        "limit": "",
-        "size": ""
-      }
-    },
-    "Deprecated": {
-      "name": "Deprecated",
-      "subtypes": [],
-      "props": {
-        "method_name": ""
-      }
-    },
-    "Deserialization": {
-      "name": "Deserialization",
-      "subtypes": [],
-      "props": {}
-    },
-    "ECRecoverError": {
-      "name": "ECRecoverError",
-      "subtypes": [],
-      "props": {
-        "msg": ""
-      }
-    },
-    "Ed25519VerifyInvalidInput": {
-      "name": "Ed25519VerifyInvalidInput",
-      "subtypes": [],
-      "props": {
-        "msg": ""
-      }
-    },
-    "EmptyMethodName": {
-      "name": "EmptyMethodName",
-      "subtypes": [],
-      "props": {}
-    },
-    "GasExceeded": {
-      "name": "GasExceeded",
-      "subtypes": [],
-      "props": {}
-    },
-    "GasInstrumentation": {
-      "name": "GasInstrumentation",
-      "subtypes": [],
-      "props": {}
-    },
-    "GasLimitExceeded": {
-      "name": "GasLimitExceeded",
-      "subtypes": [],
-      "props": {}
-    },
-    "GenericTrap": {
-      "name": "GenericTrap",
-      "subtypes": [],
-      "props": {}
-    },
-    "GuestPanic": {
-      "name": "GuestPanic",
-      "subtypes": [],
-      "props": {
-        "panic_msg": ""
-      }
-    },
-    "HostError": {
-      "name": "HostError",
-      "subtypes": [
-        "BadUTF16",
-        "BadUTF8",
-        "GasExceeded",
-        "GasLimitExceeded",
-        "BalanceExceeded",
-        "EmptyMethodName",
-        "GuestPanic",
-        "IntegerOverflow",
-        "InvalidPromiseIndex",
-        "CannotAppendActionToJointPromise",
-        "CannotReturnJointPromise",
-        "InvalidPromiseResultIndex",
-        "InvalidRegisterId",
-        "IteratorWasInvalidated",
-        "MemoryAccessViolation",
-        "InvalidReceiptIndex",
-        "InvalidIteratorIndex",
-        "InvalidAccountId",
-        "InvalidMethodName",
-        "InvalidPublicKey",
-        "ProhibitedInView",
-        "NumberOfLogsExceeded",
-        "KeyLengthExceeded",
-        "ValueLengthExceeded",
-        "TotalLogLengthExceeded",
-        "NumberPromisesExceeded",
-        "NumberInputDataDependenciesExceeded",
-        "ReturnedValueLengthExceeded",
-        "ContractSizeExceeded",
-        "Deprecated",
-        "ECRecoverError",
-        "AltBn128InvalidInput",
-        "Ed25519VerifyInvalidInput"
-      ],
-      "props": {}
-    },
-    "IllegalArithmetic": {
-      "name": "IllegalArithmetic",
-      "subtypes": [],
-      "props": {}
-    },
-    "IncorrectCallIndirectSignature": {
-      "name": "IncorrectCallIndirectSignature",
-      "subtypes": [],
-      "props": {}
-    },
-    "IndirectCallToNull": {
-      "name": "IndirectCallToNull",
-      "subtypes": [],
-      "props": {}
-    },
-    "Instantiate": {
-      "name": "Instantiate",
-      "subtypes": [],
-      "props": {}
-    },
-    "IntegerOverflow": {
-      "name": "IntegerOverflow",
-      "subtypes": [],
-      "props": {}
-    },
-    "InternalMemoryDeclared": {
-      "name": "InternalMemoryDeclared",
-      "subtypes": [],
-      "props": {}
-    },
-    "InvalidAccountId": {
-      "name": "InvalidAccountId",
-      "subtypes": [],
-      "props": {
-        "account_id": ""
-      }
-    },
-    "InvalidIteratorIndex": {
-      "name": "InvalidIteratorIndex",
-      "subtypes": [],
-      "props": {
-        "iterator_index": ""
-      }
-    },
-    "InvalidMethodName": {
-      "name": "InvalidMethodName",
-      "subtypes": [],
-      "props": {}
-    },
-    "InvalidPromiseIndex": {
-      "name": "InvalidPromiseIndex",
-      "subtypes": [],
-      "props": {
-        "promise_idx": ""
-      }
-    },
-    "InvalidPromiseResultIndex": {
-      "name": "InvalidPromiseResultIndex",
-      "subtypes": [],
-      "props": {
-        "result_idx": ""
-      }
-    },
-    "InvalidPublicKey": {
-      "name": "InvalidPublicKey",
-      "subtypes": [],
-      "props": {}
-    },
-    "InvalidReceiptIndex": {
-      "name": "InvalidReceiptIndex",
-      "subtypes": [],
-      "props": {
-        "receipt_index": ""
-      }
-    },
-    "InvalidRegisterId": {
-      "name": "InvalidRegisterId",
-      "subtypes": [],
-      "props": {
-        "register_id": ""
-      }
-    },
-    "IteratorWasInvalidated": {
-      "name": "IteratorWasInvalidated",
-      "subtypes": [],
-      "props": {
-        "iterator_index": ""
-      }
-    },
-    "KeyLengthExceeded": {
-      "name": "KeyLengthExceeded",
-      "subtypes": [],
-      "props": {
-        "length": "",
-        "limit": ""
-      }
-    },
-    "Memory": {
-      "name": "Memory",
-      "subtypes": [],
-      "props": {}
-    },
-    "MemoryAccessViolation": {
-      "name": "MemoryAccessViolation",
-      "subtypes": [],
-      "props": {}
-    },
-    "MemoryOutOfBounds": {
-      "name": "MemoryOutOfBounds",
-      "subtypes": [],
-      "props": {}
-    },
-    "MethodEmptyName": {
-      "name": "MethodEmptyName",
-      "subtypes": [],
-      "props": {}
-    },
-    "MethodInvalidSignature": {
-      "name": "MethodInvalidSignature",
-      "subtypes": [],
-      "props": {}
-    },
-    "MethodNotFound": {
-      "name": "MethodNotFound",
-      "subtypes": [],
-      "props": {}
-    },
-    "MethodResolveError": {
-      "name": "MethodResolveError",
-      "subtypes": [
-        "MethodEmptyName",
-        "MethodNotFound",
-        "MethodInvalidSignature"
-      ],
-      "props": {}
-    },
-    "MisalignedAtomicAccess": {
-      "name": "MisalignedAtomicAccess",
-      "subtypes": [],
-      "props": {}
-    },
-    "NumberInputDataDependenciesExceeded": {
-      "name": "NumberInputDataDependenciesExceeded",
-      "subtypes": [],
-      "props": {
-        "limit": "",
-        "number_of_input_data_dependencies": ""
-      }
-    },
-    "NumberOfLogsExceeded": {
-      "name": "NumberOfLogsExceeded",
-      "subtypes": [],
-      "props": {
-        "limit": ""
-      }
-    },
-    "NumberPromisesExceeded": {
-      "name": "NumberPromisesExceeded",
-      "subtypes": [],
-      "props": {
-        "limit": "",
-        "number_of_promises": ""
-      }
-    },
-    "PrepareError": {
-      "name": "PrepareError",
-      "subtypes": [
-        "Serialization",
-        "Deserialization",
-        "InternalMemoryDeclared",
-        "GasInstrumentation",
-        "StackHeightInstrumentation",
-        "Instantiate",
-        "Memory",
-        "TooManyFunctions",
-        "TooManyLocals"
-      ],
-      "props": {}
-    },
-    "ProhibitedInView": {
-      "name": "ProhibitedInView",
-      "subtypes": [],
-      "props": {
-        "method_name": ""
-      }
-    },
-    "ReturnedValueLengthExceeded": {
-      "name": "ReturnedValueLengthExceeded",
-      "subtypes": [],
-      "props": {
-        "length": "",
-        "limit": ""
-      }
-    },
-    "Serialization": {
-      "name": "Serialization",
-      "subtypes": [],
-      "props": {}
-    },
-    "StackHeightInstrumentation": {
-      "name": "StackHeightInstrumentation",
-      "subtypes": [],
-      "props": {}
-    },
-    "StackOverflow": {
-      "name": "StackOverflow",
-      "subtypes": [],
-      "props": {}
-    },
-    "TooManyFunctions": {
-      "name": "TooManyFunctions",
-      "subtypes": [],
-      "props": {}
-    },
-    "TooManyLocals": {
-      "name": "TooManyLocals",
-      "subtypes": [],
-      "props": {}
-    },
-    "TotalLogLengthExceeded": {
-      "name": "TotalLogLengthExceeded",
-      "subtypes": [],
-      "props": {
-        "length": "",
-        "limit": ""
-      }
-    },
-    "Unreachable": {
-      "name": "Unreachable",
-      "subtypes": [],
-      "props": {}
-    },
-    "ValueLengthExceeded": {
-      "name": "ValueLengthExceeded",
-      "subtypes": [],
-      "props": {
-        "length": "",
-        "limit": ""
-      }
-    },
-    "WasmTrap": {
-      "name": "WasmTrap",
-      "subtypes": [
-        "Unreachable",
-        "IncorrectCallIndirectSignature",
-        "MemoryOutOfBounds",
-        "CallIndirectOOB",
-        "IllegalArithmetic",
-        "MisalignedAtomicAccess",
-        "IndirectCallToNull",
-        "StackOverflow",
-        "GenericTrap"
-      ],
-      "props": {}
-    },
-    "WasmerCompileError": {
-      "name": "WasmerCompileError",
-      "subtypes": [],
-      "props": {
-        "msg": ""
-      }
-    },
     "AccessKeyNotFound": {
       "name": "AccessKeyNotFound",
       "subtypes": [],
@@ -524,6 +104,28 @@
         "total_number_of_bytes": ""
       }
     },
+    "AltBn128InvalidInput": {
+      "name": "AltBn128InvalidInput",
+      "subtypes": [],
+      "props": {
+        "msg": ""
+      }
+    },
+    "BadUTF16": {
+      "name": "BadUTF16",
+      "subtypes": [],
+      "props": {}
+    },
+    "BadUTF8": {
+      "name": "BadUTF8",
+      "subtypes": [],
+      "props": {}
+    },
+    "BalanceExceeded": {
+      "name": "BalanceExceeded",
+      "subtypes": [],
+      "props": {}
+    },
     "BalanceMismatchError": {
       "name": "BalanceMismatchError",
       "subtypes": [],
@@ -540,6 +142,45 @@
         "processed_delayed_receipts_balance": "",
         "slashed_burnt_amount": "",
         "tx_burnt_amount": ""
+      }
+    },
+    "CallIndirectOOB": {
+      "name": "CallIndirectOOB",
+      "subtypes": [],
+      "props": {}
+    },
+    "CannotAppendActionToJointPromise": {
+      "name": "CannotAppendActionToJointPromise",
+      "subtypes": [],
+      "props": {}
+    },
+    "CannotReturnJointPromise": {
+      "name": "CannotReturnJointPromise",
+      "subtypes": [],
+      "props": {}
+    },
+    "CodeDoesNotExist": {
+      "name": "CodeDoesNotExist",
+      "subtypes": [],
+      "props": {
+        "account_id": ""
+      }
+    },
+    "CompilationError": {
+      "name": "CompilationError",
+      "subtypes": [
+        "CodeDoesNotExist",
+        "PrepareError",
+        "WasmerCompileError"
+      ],
+      "props": {}
+    },
+    "ContractSizeExceeded": {
+      "name": "ContractSizeExceeded",
+      "subtypes": [],
+      "props": {
+        "limit": "",
+        "size": ""
       }
     },
     "CostOverflow": {
@@ -635,6 +276,37 @@
       "subtypes": [],
       "props": {}
     },
+    "Deprecated": {
+      "name": "Deprecated",
+      "subtypes": [],
+      "props": {
+        "method_name": ""
+      }
+    },
+    "Deserialization": {
+      "name": "Deserialization",
+      "subtypes": [],
+      "props": {}
+    },
+    "ECRecoverError": {
+      "name": "ECRecoverError",
+      "subtypes": [],
+      "props": {
+        "msg": ""
+      }
+    },
+    "Ed25519VerifyInvalidInput": {
+      "name": "Ed25519VerifyInvalidInput",
+      "subtypes": [],
+      "props": {
+        "msg": ""
+      }
+    },
+    "EmptyMethodName": {
+      "name": "EmptyMethodName",
+      "subtypes": [],
+      "props": {}
+    },
     "Expired": {
       "name": "Expired",
       "subtypes": [],
@@ -661,6 +333,92 @@
       "subtypes": [],
       "props": {}
     },
+    "GasExceeded": {
+      "name": "GasExceeded",
+      "subtypes": [],
+      "props": {}
+    },
+    "GasInstrumentation": {
+      "name": "GasInstrumentation",
+      "subtypes": [],
+      "props": {}
+    },
+    "GasLimitExceeded": {
+      "name": "GasLimitExceeded",
+      "subtypes": [],
+      "props": {}
+    },
+    "GenericTrap": {
+      "name": "GenericTrap",
+      "subtypes": [],
+      "props": {}
+    },
+    "GuestPanic": {
+      "name": "GuestPanic",
+      "subtypes": [],
+      "props": {
+        "panic_msg": ""
+      }
+    },
+    "HostError": {
+      "name": "HostError",
+      "subtypes": [
+        "BadUTF16",
+        "BadUTF8",
+        "GasExceeded",
+        "GasLimitExceeded",
+        "BalanceExceeded",
+        "EmptyMethodName",
+        "GuestPanic",
+        "IntegerOverflow",
+        "InvalidPromiseIndex",
+        "CannotAppendActionToJointPromise",
+        "CannotReturnJointPromise",
+        "InvalidPromiseResultIndex",
+        "InvalidRegisterId",
+        "IteratorWasInvalidated",
+        "MemoryAccessViolation",
+        "InvalidReceiptIndex",
+        "InvalidIteratorIndex",
+        "InvalidAccountId",
+        "InvalidMethodName",
+        "InvalidPublicKey",
+        "ProhibitedInView",
+        "NumberOfLogsExceeded",
+        "KeyLengthExceeded",
+        "ValueLengthExceeded",
+        "TotalLogLengthExceeded",
+        "NumberPromisesExceeded",
+        "NumberInputDataDependenciesExceeded",
+        "ReturnedValueLengthExceeded",
+        "ContractSizeExceeded",
+        "Deprecated",
+        "ECRecoverError",
+        "AltBn128InvalidInput",
+        "Ed25519VerifyInvalidInput"
+      ],
+      "props": {}
+    },
+    "IllegalArithmetic": {
+      "name": "IllegalArithmetic",
+      "subtypes": [],
+      "props": {}
+    },
+    "IncorrectCallIndirectSignature": {
+      "name": "IncorrectCallIndirectSignature",
+      "subtypes": [],
+      "props": {}
+    },
+    "IndirectCallToNull": {
+      "name": "IndirectCallToNull",
+      "subtypes": [],
+      "props": {}
+    },
+    "Instantiate": {
+      "name": "Instantiate",
+      "subtypes": [],
+      "props": {}
+    },
     "InsufficientStake": {
       "name": "InsufficientStake",
       "subtypes": [],
@@ -669,6 +427,16 @@
         "minimum_stake": "",
         "stake": ""
       }
+    },
+    "IntegerOverflow": {
+      "name": "IntegerOverflow",
+      "subtypes": [],
+      "props": {}
+    },
+    "InternalMemoryDeclared": {
+      "name": "InternalMemoryDeclared",
+      "subtypes": [],
+      "props": {}
     },
     "InvalidAccessKeyError": {
       "name": "InvalidAccessKeyError",
@@ -682,6 +450,11 @@
       ],
       "props": {}
     },
+    "InvalidAccountId": {
+      "name": "InvalidAccountId",
+      "subtypes": [],
+      "props": {}
+    },
     "InvalidChain": {
       "name": "InvalidChain",
       "subtypes": [],
@@ -693,6 +466,18 @@
       "props": {
         "account_id": ""
       }
+    },
+    "InvalidIteratorIndex": {
+      "name": "InvalidIteratorIndex",
+      "subtypes": [],
+      "props": {
+        "iterator_index": ""
+      }
+    },
+    "InvalidMethodName": {
+      "name": "InvalidMethodName",
+      "subtypes": [],
+      "props": {}
     },
     "InvalidNonce": {
       "name": "InvalidNonce",
@@ -709,11 +494,44 @@
         "account_id": ""
       }
     },
+    "InvalidPromiseIndex": {
+      "name": "InvalidPromiseIndex",
+      "subtypes": [],
+      "props": {
+        "promise_idx": ""
+      }
+    },
+    "InvalidPromiseResultIndex": {
+      "name": "InvalidPromiseResultIndex",
+      "subtypes": [],
+      "props": {
+        "result_idx": ""
+      }
+    },
+    "InvalidPublicKey": {
+      "name": "InvalidPublicKey",
+      "subtypes": [],
+      "props": {}
+    },
+    "InvalidReceiptIndex": {
+      "name": "InvalidReceiptIndex",
+      "subtypes": [],
+      "props": {
+        "receipt_index": ""
+      }
+    },
     "InvalidReceiverId": {
       "name": "InvalidReceiverId",
       "subtypes": [],
       "props": {
         "account_id": ""
+      }
+    },
+    "InvalidRegisterId": {
+      "name": "InvalidRegisterId",
+      "subtypes": [],
+      "props": {
+        "register_id": ""
       }
     },
     "InvalidSignature": {
@@ -748,6 +566,21 @@
       ],
       "props": {}
     },
+    "IteratorWasInvalidated": {
+      "name": "IteratorWasInvalidated",
+      "subtypes": [],
+      "props": {
+        "iterator_index": ""
+      }
+    },
+    "KeyLengthExceeded": {
+      "name": "KeyLengthExceeded",
+      "subtypes": [],
+      "props": {
+        "length": "",
+        "limit": ""
+      }
+    },
     "LackBalanceForState": {
       "name": "LackBalanceForState",
       "subtypes": [],
@@ -756,12 +589,56 @@
         "amount": ""
       }
     },
+    "Memory": {
+      "name": "Memory",
+      "subtypes": [],
+      "props": {}
+    },
+    "MemoryAccessViolation": {
+      "name": "MemoryAccessViolation",
+      "subtypes": [],
+      "props": {}
+    },
+    "MemoryOutOfBounds": {
+      "name": "MemoryOutOfBounds",
+      "subtypes": [],
+      "props": {}
+    },
+    "MethodEmptyName": {
+      "name": "MethodEmptyName",
+      "subtypes": [],
+      "props": {}
+    },
+    "MethodInvalidSignature": {
+      "name": "MethodInvalidSignature",
+      "subtypes": [],
+      "props": {}
+    },
     "MethodNameMismatch": {
       "name": "MethodNameMismatch",
       "subtypes": [],
       "props": {
         "method_name": ""
       }
+    },
+    "MethodNotFound": {
+      "name": "MethodNotFound",
+      "subtypes": [],
+      "props": {}
+    },
+    "MethodResolveError": {
+      "name": "MethodResolveError",
+      "subtypes": [
+        "MethodEmptyName",
+        "MethodNotFound",
+        "MethodInvalidSignature"
+      ],
+      "props": {}
+    },
+    "MisalignedAtomicAccess": {
+      "name": "MisalignedAtomicAccess",
+      "subtypes": [],
+      "props": {}
     },
     "NonceTooLarge": {
       "name": "NonceTooLarge",
@@ -790,11 +667,56 @@
         "signer_id": ""
       }
     },
+    "NumberInputDataDependenciesExceeded": {
+      "name": "NumberInputDataDependenciesExceeded",
+      "subtypes": [],
+      "props": {
+        "limit": "",
+        "number_of_input_data_dependencies": ""
+      }
+    },
+    "NumberOfLogsExceeded": {
+      "name": "NumberOfLogsExceeded",
+      "subtypes": [],
+      "props": {
+        "limit": ""
+      }
+    },
+    "NumberPromisesExceeded": {
+      "name": "NumberPromisesExceeded",
+      "subtypes": [],
+      "props": {
+        "limit": "",
+        "number_of_promises": ""
+      }
+    },
     "OnlyImplicitAccountCreationAllowed": {
       "name": "OnlyImplicitAccountCreationAllowed",
       "subtypes": [],
       "props": {
         "account_id": ""
+      }
+    },
+    "PrepareError": {
+      "name": "PrepareError",
+      "subtypes": [
+        "Serialization",
+        "Deserialization",
+        "InternalMemoryDeclared",
+        "GasInstrumentation",
+        "StackHeightInstrumentation",
+        "Instantiate",
+        "Memory",
+        "TooManyFunctions",
+        "TooManyLocals"
+      ],
+      "props": {}
+    },
+    "ProhibitedInView": {
+      "name": "ProhibitedInView",
+      "subtypes": [],
+      "props": {
+        "method_name": ""
       }
     },
     "ReceiptValidationError": {
@@ -823,11 +745,52 @@
       "subtypes": [],
       "props": {}
     },
+    "ReturnedValueLengthExceeded": {
+      "name": "ReturnedValueLengthExceeded",
+      "subtypes": [],
+      "props": {
+        "length": "",
+        "limit": ""
+      }
+    },
+    "Serialization": {
+      "name": "Serialization",
+      "subtypes": [],
+      "props": {}
+    },
     "SignerDoesNotExist": {
       "name": "SignerDoesNotExist",
       "subtypes": [],
       "props": {
         "signer_id": ""
+      }
+    },
+    "StackHeightInstrumentation": {
+      "name": "StackHeightInstrumentation",
+      "subtypes": [],
+      "props": {}
+    },
+    "StackOverflow": {
+      "name": "StackOverflow",
+      "subtypes": [],
+      "props": {}
+    },
+    "TooManyFunctions": {
+      "name": "TooManyFunctions",
+      "subtypes": [],
+      "props": {}
+    },
+    "TooManyLocals": {
+      "name": "TooManyLocals",
+      "subtypes": [],
+      "props": {}
+    },
+    "TotalLogLengthExceeded": {
+      "name": "TotalLogLengthExceeded",
+      "subtypes": [],
+      "props": {
+        "length": "",
+        "limit": ""
       }
     },
     "TotalNumberOfActionsExceeded": {
@@ -879,6 +842,11 @@
       ],
       "props": {}
     },
+    "Unreachable": {
+      "name": "Unreachable",
+      "subtypes": [],
+      "props": {}
+    },
     "UnsuitableStakingKey": {
       "name": "UnsuitableStakingKey",
       "subtypes": [],
@@ -892,6 +860,36 @@
       "props": {
         "protocol_feature": "",
         "version": ""
+      }
+    },
+    "ValueLengthExceeded": {
+      "name": "ValueLengthExceeded",
+      "subtypes": [],
+      "props": {
+        "length": "",
+        "limit": ""
+      }
+    },
+    "WasmTrap": {
+      "name": "WasmTrap",
+      "subtypes": [
+        "Unreachable",
+        "IncorrectCallIndirectSignature",
+        "MemoryOutOfBounds",
+        "CallIndirectOOB",
+        "IllegalArithmetic",
+        "MisalignedAtomicAccess",
+        "IndirectCallToNull",
+        "StackOverflow",
+        "GenericTrap"
+      ],
+      "props": {}
+    },
+    "WasmerCompileError": {
+      "name": "WasmerCompileError",
+      "subtypes": [],
+      "props": {
+        "msg": ""
       }
     },
     "Closed": {

--- a/integration-tests/src/tests/client/features/limit_contract_functions_number.rs
+++ b/integration-tests/src/tests/client/features/limit_contract_functions_number.rs
@@ -4,11 +4,12 @@ use assert_matches::assert_matches;
 use near_chain::ChainGenesis;
 use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
-use near_primitives::errors::{ActionErrorKind, TxExecutionError};
+use near_primitives::errors::{
+    ActionErrorKind, CompilationError, FunctionCallError, PrepareError, TxExecutionError,
+};
 use near_primitives::runtime::config_store::RuntimeConfigStore;
 use near_primitives::version::ProtocolFeature;
 use near_primitives::views::FinalExecutionStatus;
-use near_vm_runner::logic::errors::{CompilationError, FunctionCallErrorSer, PrepareError};
 use nearcore::config::GenesisExt;
 
 fn verify_contract_limits_upgrade(
@@ -64,7 +65,7 @@ fn verify_contract_limits_upgrade(
         status => panic!("expected transaction to fail, got {:?}", status),
     };
     match e.kind {
-        ActionErrorKind::FunctionCallError(FunctionCallErrorSer::CompilationError(
+        ActionErrorKind::FunctionCallError(FunctionCallError::CompilationError(
             CompilationError::PrepareError(e),
         )) if e == expected_prepare_err => (),
         kind => panic!("got unexpected action error kind: {:?}", kind),

--- a/integration-tests/src/tests/runtime/test_evil_contracts.rs
+++ b/integration-tests/src/tests/runtime/test_evil_contracts.rs
@@ -1,7 +1,6 @@
 use crate::node::{Node, RuntimeNode};
-use near_primitives::errors::{ActionError, ActionErrorKind};
+use near_primitives::errors::{ActionError, ActionErrorKind, FunctionCallError};
 use near_primitives::views::FinalExecutionStatus;
-use near_vm_runner::logic::errors::FunctionCallErrorSer;
 use std::mem::size_of;
 
 use assert_matches::assert_matches;
@@ -129,7 +128,7 @@ fn test_evil_abort() {
         FinalExecutionStatus::Failure(
             ActionError {
                 index: Some(0),
-                kind: ActionErrorKind::FunctionCallError(FunctionCallErrorSer::ExecutionError(
+                kind: ActionErrorKind::FunctionCallError(FunctionCallError::ExecutionError(
                     "String encoding is bad UTF-16 sequence.".to_string()
                 ))
             }

--- a/integration-tests/src/tests/standard_cases/mod.rs
+++ b/integration-tests/src/tests/standard_cases/mod.rs
@@ -9,7 +9,8 @@ use near_jsonrpc_primitives::errors::ServerError;
 use near_primitives::account::{AccessKey, AccessKeyPermission, FunctionCallPermission};
 use near_primitives::config::{ActionCosts, ExtCosts};
 use near_primitives::errors::{
-    ActionError, ActionErrorKind, InvalidAccessKeyError, InvalidTxError, TxExecutionError,
+    ActionError, ActionErrorKind, FunctionCallError, InvalidAccessKeyError, InvalidTxError,
+    MethodResolveError, TxExecutionError,
 };
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::types::{AccountId, Balance, TrieNodesCount};
@@ -17,7 +18,6 @@ use near_primitives::views::{
     AccessKeyView, AccountView, ExecutionMetadataView, FinalExecutionOutcomeView,
     FinalExecutionStatus,
 };
-use near_vm_runner::logic::errors::{FunctionCallErrorSer, MethodResolveError};
 use nearcore::config::{NEAR_BASE, TESTING_INIT_BALANCE, TESTING_INIT_STAKE};
 
 use crate::node::Node;
@@ -89,7 +89,7 @@ pub fn test_smart_contract_panic(node: impl Node) {
         FinalExecutionStatus::Failure(
             ActionError {
                 index: Some(0),
-                kind: ActionErrorKind::FunctionCallError(FunctionCallErrorSer::ExecutionError(
+                kind: ActionErrorKind::FunctionCallError(FunctionCallError::ExecutionError(
                     "Smart contract panicked: WAT?".to_string()
                 ))
             }
@@ -127,7 +127,7 @@ pub fn test_smart_contract_bad_method_name(node: impl Node) {
         FinalExecutionStatus::Failure(
             ActionError {
                 index: Some(0),
-                kind: ActionErrorKind::FunctionCallError(FunctionCallErrorSer::MethodResolveError(
+                kind: ActionErrorKind::FunctionCallError(FunctionCallError::MethodResolveError(
                     MethodResolveError::MethodNotFound
                 ))
             }
@@ -151,7 +151,7 @@ pub fn test_smart_contract_empty_method_name_with_no_tokens(node: impl Node) {
         FinalExecutionStatus::Failure(
             ActionError {
                 index: Some(0),
-                kind: ActionErrorKind::FunctionCallError(FunctionCallErrorSer::MethodResolveError(
+                kind: ActionErrorKind::FunctionCallError(FunctionCallError::MethodResolveError(
                     MethodResolveError::MethodEmptyName
                 ))
             }
@@ -175,7 +175,7 @@ pub fn test_smart_contract_empty_method_name_with_tokens(node: impl Node) {
         FinalExecutionStatus::Failure(
             ActionError {
                 index: Some(0),
-                kind: ActionErrorKind::FunctionCallError(FunctionCallErrorSer::MethodResolveError(
+                kind: ActionErrorKind::FunctionCallError(FunctionCallError::MethodResolveError(
                     MethodResolveError::MethodEmptyName
                 ))
             }

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -39,9 +39,6 @@ wasmtime = { workspace = true, optional = true }
 near-crypto.workspace = true
 near-primitives-core.workspace = true
 
-# Does not affect protocol stability (is only used to generate information about code structure.)
-near-rpc-error-macro.workspace = true
-
 # Old versions of pwasm-utils we need to preserve backwards compatibility under
 # old protocol versions.
 pwasm-utils_12.workspace = true
@@ -126,8 +123,6 @@ nightly = [
 ]
 sandbox = []
 io_trace = []
-
-dump_errors_schema = ["near-rpc-error-macro/dump_errors_schema"]
 
 # Use this feature to enable counting of fees and costs applied.
 costs_counting = []

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -36,9 +36,10 @@ tracing.workspace = true
 wasmparser.workspace = true
 wasmtime = { workspace = true, optional = true }
 
-near-account-id.workspace = true
 near-crypto.workspace = true
 near-primitives-core.workspace = true
+
+# Does not affect protocol stability (is only used to generate information about code structure.)
 near-rpc-error-macro.workspace = true
 
 # Old versions of pwasm-utils we need to preserve backwards compatibility under

--- a/runtime/near-vm-runner/src/logic/errors.rs
+++ b/runtime/near-vm-runner/src/logic/errors.rs
@@ -1,5 +1,4 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use near_rpc_error_macro::RpcError;
 use std::any::Any;
 use std::fmt::{self, Error, Formatter};
 use std::io;
@@ -54,44 +53,7 @@ pub enum FunctionCallError {
     HostError(HostError),
 }
 
-/// Serializable version of `FunctionCallError`. Must never reorder/remove elements, can only
-/// add new variants at the end (but do that very carefully).
-/// It describes stable serialization format, and only used by serialization logic.
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    BorshDeserialize,
-    BorshSerialize,
-    serde::Serialize,
-    serde::Deserialize,
-)]
-pub enum FunctionCallErrorSer {
-    /// Wasm compilation error
-    CompilationError(CompilationError),
-    /// Wasm binary env link error
-    ///
-    /// Note: this is only to deserialize old data, use execution error for new data
-    LinkError {
-        msg: String,
-    },
-    /// Import/export resolve error
-    MethodResolveError(MethodResolveError),
-    /// A trap happened during execution of a binary
-    ///
-    /// Note: this is only to deserialize old data, use execution error for new data
-    WasmTrap(WasmTrap),
-    WasmUnknownError,
-    /// Note: this is only to deserialize old data, use execution error for new data
-    HostError(HostError),
-    // Unused, can be reused by a future error but must be exactly one error to keep ExecutionError
-    // error borsh serialized at correct index
-    _EVMError,
-    ExecutionError(String),
-}
-
-#[derive(Debug, strum::IntoStaticStr, thiserror::Error)]
+#[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
 pub enum CacheError {
     #[error("cache read error")]
     ReadError(#[source] io::Error),
@@ -103,18 +65,7 @@ pub enum CacheError {
     SerializationError { hash: [u8; 32] },
 }
 /// A kind of a trap happened during execution of a binary
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    BorshDeserialize,
-    BorshSerialize,
-    RpcError,
-    serde::Deserialize,
-    serde::Serialize,
-    strum::IntoStaticStr,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, strum::IntoStaticStr)]
 pub enum WasmTrap {
     /// An `unreachable` opcode was executed.
     Unreachable,
@@ -136,36 +87,14 @@ pub enum WasmTrap {
     GenericTrap,
 }
 
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    BorshDeserialize,
-    BorshSerialize,
-    RpcError,
-    serde::Deserialize,
-    serde::Serialize,
-    strum::IntoStaticStr,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, strum::IntoStaticStr)]
 pub enum MethodResolveError {
     MethodEmptyName,
     MethodNotFound,
     MethodInvalidSignature,
 }
 
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    BorshDeserialize,
-    BorshSerialize,
-    RpcError,
-    serde::Deserialize,
-    serde::Serialize,
-    strum::IntoStaticStr,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshDeserialize, BorshSerialize, strum::IntoStaticStr)]
 pub enum CompilationError {
     CodeDoesNotExist {
         account_id: Box<str>,
@@ -179,17 +108,7 @@ pub enum CompilationError {
     },
 }
 
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    BorshDeserialize,
-    BorshSerialize,
-    RpcError,
-    serde::Deserialize,
-    serde::Serialize,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshDeserialize, BorshSerialize)]
 /// Error that can occur while preparing or executing Wasm smart-contract.
 pub enum PrepareError {
     /// Error happened while serializing the module.
@@ -219,18 +138,7 @@ pub enum PrepareError {
     TooManyLocals,
 }
 
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    BorshDeserialize,
-    BorshSerialize,
-    RpcError,
-    serde::Deserialize,
-    serde::Serialize,
-    strum::IntoStaticStr,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, strum::IntoStaticStr)]
 pub enum HostError {
     /// String encoding is bad UTF-16 sequence
     BadUTF16,
@@ -258,8 +166,6 @@ pub enum HostError {
     InvalidPromiseResultIndex { result_idx: u64 },
     /// Accessed invalid register id
     InvalidRegisterId { register_id: u64 },
-    /// Iterator `iterator_index` was invalidated after its creation by performing a mutable operation on trie
-    IteratorWasInvalidated { iterator_index: u64 },
     /// Accessed memory outside the bounds
     MemoryAccessViolation,
     /// VM Logic returned an invalid receipt index
@@ -320,27 +226,6 @@ impl std::error::Error for VMLogicError {}
 pub enum InconsistentStateError {
     /// Math operation with a value from the state resulted in a integer overflow.
     IntegerOverflow,
-}
-
-impl From<FunctionCallError> for FunctionCallErrorSer {
-    fn from(outer_err: FunctionCallError) -> Self {
-        match outer_err {
-            FunctionCallError::CompilationError(e) => FunctionCallErrorSer::CompilationError(e),
-            FunctionCallError::MethodResolveError(e) => FunctionCallErrorSer::MethodResolveError(e),
-            // Note: We deliberately collapse all execution errors for
-            // serialization to make the DB representation less dependent
-            // on specific types in Rust code.
-            FunctionCallError::HostError(ref _e) => {
-                FunctionCallErrorSer::ExecutionError(outer_err.to_string())
-            }
-            FunctionCallError::LinkError { msg } => {
-                FunctionCallErrorSer::ExecutionError(format!("Link Error: {}", msg))
-            }
-            FunctionCallError::WasmTrap(ref _e) => {
-                FunctionCallErrorSer::ExecutionError(outer_err.to_string())
-            }
-        }
-    }
 }
 
 impl From<HostError> for VMLogicError {
@@ -475,36 +360,81 @@ impl std::fmt::Display for HostError {
             BadUTF8 => write!(f, "String encoding is bad UTF-8 sequence."),
             BadUTF16 => write!(f, "String encoding is bad UTF-16 sequence."),
             GasExceeded => write!(f, "Exceeded the prepaid gas."),
-            GasLimitExceeded => write!(f, "Exceeded the maximum amount of gas allowed to burn per contract."),
+            GasLimitExceeded => {
+                write!(f, "Exceeded the maximum amount of gas allowed to burn per contract.")
+            }
             BalanceExceeded => write!(f, "Exceeded the account balance."),
             EmptyMethodName => write!(f, "Tried to call an empty method name."),
             GuestPanic { panic_msg } => write!(f, "Smart contract panicked: {}", panic_msg),
             IntegerOverflow => write!(f, "Integer overflow."),
-            InvalidIteratorIndex { iterator_index } => write!(f, "Iterator index {:?} does not exist", iterator_index),
-            InvalidPromiseIndex { promise_idx } => write!(f, "{:?} does not correspond to existing promises", promise_idx),
-            CannotAppendActionToJointPromise => write!(f, "Actions can only be appended to non-joint promise."),
-            CannotReturnJointPromise => write!(f, "Returning joint promise is currently prohibited."),
-            InvalidPromiseResultIndex { result_idx } => write!(f, "Accessed invalid promise result index: {:?}", result_idx),
-            InvalidRegisterId { register_id } => write!(f, "Accessed invalid register id: {:?}", register_id),
-            IteratorWasInvalidated { iterator_index } => write!(f, "Iterator {:?} was invalidated after its creation by performing a mutable operation on trie", iterator_index),
+            InvalidIteratorIndex { iterator_index } => {
+                write!(f, "Iterator index {:?} does not exist", iterator_index)
+            }
+            InvalidPromiseIndex { promise_idx } => {
+                write!(f, "{:?} does not correspond to existing promises", promise_idx)
+            }
+            CannotAppendActionToJointPromise => {
+                write!(f, "Actions can only be appended to non-joint promise.")
+            }
+            CannotReturnJointPromise => {
+                write!(f, "Returning joint promise is currently prohibited.")
+            }
+            InvalidPromiseResultIndex { result_idx } => {
+                write!(f, "Accessed invalid promise result index: {:?}", result_idx)
+            }
+            InvalidRegisterId { register_id } => {
+                write!(f, "Accessed invalid register id: {:?}", register_id)
+            }
             MemoryAccessViolation => write!(f, "Accessed memory outside the bounds."),
-            InvalidReceiptIndex { receipt_index } => write!(f, "VM Logic returned an invalid receipt index: {:?}", receipt_index),
+            InvalidReceiptIndex { receipt_index } => {
+                write!(f, "VM Logic returned an invalid receipt index: {:?}", receipt_index)
+            }
             InvalidAccountId => write!(f, "VM Logic returned an invalid account id"),
             InvalidMethodName => write!(f, "VM Logic returned an invalid method name"),
             InvalidPublicKey => write!(f, "VM Logic provided an invalid public key"),
-            ProhibitedInView { method_name } => write!(f, "{} is not allowed in view calls", method_name),
-            NumberOfLogsExceeded { limit } => write!(f, "The number of logs will exceed the limit {}", limit),
-            KeyLengthExceeded { length, limit } => write!(f, "The length of a storage key {} exceeds the limit {}", length, limit),
-            ValueLengthExceeded { length, limit } => write!(f, "The length of a storage value {} exceeds the limit {}", length, limit),
-            TotalLogLengthExceeded{ length, limit } => write!(f, "The length of a log message {} exceeds the limit {}", length, limit),
-            NumberPromisesExceeded { number_of_promises, limit } => write!(f, "The number of promises within a FunctionCall {} exceeds the limit {}", number_of_promises, limit),
-            NumberInputDataDependenciesExceeded { number_of_input_data_dependencies, limit } => write!(f, "The number of input data dependencies {} exceeds the limit {}", number_of_input_data_dependencies, limit),
-            ReturnedValueLengthExceeded { length, limit } => write!(f, "The length of a returned value {} exceeds the limit {}", length, limit),
-            ContractSizeExceeded { size, limit } => write!(f, "The size of a contract code in DeployContract action {} exceeds the limit {}", size, limit),
-            Deprecated {method_name}=> write!(f, "Attempted to call deprecated host function {}", method_name),
+            ProhibitedInView { method_name } => {
+                write!(f, "{} is not allowed in view calls", method_name)
+            }
+            NumberOfLogsExceeded { limit } => {
+                write!(f, "The number of logs will exceed the limit {}", limit)
+            }
+            KeyLengthExceeded { length, limit } => {
+                write!(f, "The length of a storage key {} exceeds the limit {}", length, limit)
+            }
+            ValueLengthExceeded { length, limit } => {
+                write!(f, "The length of a storage value {} exceeds the limit {}", length, limit)
+            }
+            TotalLogLengthExceeded { length, limit } => {
+                write!(f, "The length of a log message {} exceeds the limit {}", length, limit)
+            }
+            NumberPromisesExceeded { number_of_promises, limit } => write!(
+                f,
+                "The number of promises within a FunctionCall {} exceeds the limit {}",
+                number_of_promises, limit
+            ),
+            NumberInputDataDependenciesExceeded { number_of_input_data_dependencies, limit } => {
+                write!(
+                    f,
+                    "The number of input data dependencies {} exceeds the limit {}",
+                    number_of_input_data_dependencies, limit
+                )
+            }
+            ReturnedValueLengthExceeded { length, limit } => {
+                write!(f, "The length of a returned value {} exceeds the limit {}", length, limit)
+            }
+            ContractSizeExceeded { size, limit } => write!(
+                f,
+                "The size of a contract code in DeployContract action {} exceeds the limit {}",
+                size, limit
+            ),
+            Deprecated { method_name } => {
+                write!(f, "Attempted to call deprecated host function {}", method_name)
+            }
             AltBn128InvalidInput { msg } => write!(f, "AltBn128 invalid input: {}", msg),
             ECRecoverError { msg } => write!(f, "ECDSA recover error: {}", msg),
-            Ed25519VerifyInvalidInput { msg } => write!(f, "ED25519 signature verification error: {}", msg),
+            Ed25519VerifyInvalidInput { msg } => {
+                write!(f, "ED25519 signature verification error: {}", msg)
+            }
         }
     }
 }

--- a/runtime/near-vm-runner/src/logic/errors.rs
+++ b/runtime/near-vm-runner/src/logic/errors.rs
@@ -1,5 +1,4 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use near_account_id::AccountId;
 use near_rpc_error_macro::RpcError;
 use std::any::Any;
 use std::fmt::{self, Error, Formatter};
@@ -169,7 +168,7 @@ pub enum MethodResolveError {
 )]
 pub enum CompilationError {
     CodeDoesNotExist {
-        account_id: AccountId,
+        account_id: Box<str>,
     },
     PrepareError(PrepareError),
     /// This is for defense in depth.

--- a/runtime/near-vm-runner/src/logic/tests/promises.rs
+++ b/runtime/near-vm-runner/src/logic/tests/promises.rs
@@ -4,17 +4,16 @@ use crate::logic::tests::vm_logic_builder::VMLogicBuilder;
 use crate::logic::types::PromiseResult;
 use crate::logic::VMLogic;
 use borsh::BorshSerialize;
-use near_account_id::AccountId;
 use near_crypto::PublicKey;
 use serde_json;
 
-#[derive(serde::Serialize)]
-struct ReceiptView<'a> {
-    receiver_id: &'a AccountId,
-    actions: &'a [Action],
-}
+fn vm_receipts<'a>(logic: &'a VMLogic) -> Vec<impl serde::Serialize + 'a> {
+    #[derive(serde::Serialize)]
+    struct ReceiptView<'a, T> {
+        receiver_id: T,
+        actions: &'a [Action],
+    }
 
-fn vm_receipts<'a>(logic: &'a VMLogic) -> Vec<ReceiptView<'a>> {
     logic
         .receipt_manager()
         .action_receipts

--- a/runtime/runtime/Cargo.toml
+++ b/runtime/runtime/Cargo.toml
@@ -40,7 +40,6 @@ nightly = [
   "near-vm-runner/nightly",
 ]
 default = []
-dump_errors_schema = ["near-vm-runner/dump_errors_schema"]
 nightly_protocol = [
   "near-chain-configs/nightly_protocol",
   "near-o11y/nightly_protocol",

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -58,7 +58,7 @@ pub(crate) fn execute_function_call(
         Ok(Some(code)) => code,
         Ok(None) => {
             let error = FunctionCallError::CompilationError(CompilationError::CodeDoesNotExist {
-                account_id: account_id.clone(),
+                account_id: account_id.as_str().into(),
             });
             return Ok(VMOutcome::nop_outcome(error));
         }

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -31,8 +31,7 @@ use near_store::{
     StorageError, TrieUpdate,
 };
 use near_vm_runner::logic::errors::{
-    CompilationError, FunctionCallError, FunctionCallErrorSer, InconsistentStateError,
-    VMRunnerError,
+    CompilationError, FunctionCallError, InconsistentStateError, VMRunnerError,
 };
 use near_vm_runner::logic::types::PromiseResult;
 use near_vm_runner::logic::{ActionCosts, VMContext, VMOutcome};
@@ -241,8 +240,7 @@ pub(crate) fn action_function_call(
         }
         // Update action result with the abort error converted to the
         // transaction runtime's format of errors.
-        let ser: FunctionCallErrorSer = err.into();
-        let action_err: ActionError = ActionErrorKind::FunctionCallError(ser).into();
+        let action_err: ActionError = ActionErrorKind::FunctionCallError(err.into()).into();
         result.result = Err(action_err);
     }
     result.gas_burnt = safe_add_gas(result.gas_burnt, outcome.burnt_gas)?;


### PR DESCRIPTION
This allows to drop a dependency on `near-account-id` and `near-rpc-error-macro` crates and brings us ever-so-slightly closer to having a contract runtime suitable for limited replayability.

But more importantly this also solves a long-term pain point in the contract runtime where we never really felt too confident modifying errors that are output from the contract runtime due to our fears about it possibly affecting the protocol output. Now that the schemas are outside of `nearcore/runtime` there's also a neat rule of thumb: anything goes inside `nearcore/runtime` (as far as errors are concerned.)