### PR TITLE
refactor: small refactorings and improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3976,6 +3976,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "prometheus",
  "serde",
+ "serde_json",
  "smartstring 1.0.1",
  "strum",
  "thiserror",

--- a/chain/chain/src/block_processing_utils.rs
+++ b/chain/chain/src/block_processing_utils.rs
@@ -18,7 +18,7 @@ pub(crate) const MAX_PROCESSING_BLOCKS: usize = 5;
 /// Contains information from preprocessing a block
 pub(crate) struct BlockPreprocessInfo {
     pub(crate) is_caught_up: bool,
-    pub(crate) state_dl_info: Option<StateSyncInfo>,
+    pub(crate) state_sync_info: Option<StateSyncInfo>,
     pub(crate) incoming_receipts: HashMap<ShardId, Vec<ReceiptProof>>,
     pub(crate) challenges_result: ChallengesResult,
     pub(crate) challenged_blocks: Vec<CryptoHash>,

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -1249,8 +1249,8 @@ pub struct ChainStoreUpdate<'a> {
     remove_blocks_to_catchup: Vec<(CryptoHash, CryptoHash)>,
     // A prev_hash to be removed with all the hashes associated with it
     remove_prev_blocks_to_catchup: Vec<CryptoHash>,
-    add_state_dl_infos: Vec<StateSyncInfo>,
-    remove_state_dl_infos: Vec<CryptoHash>,
+    add_state_sync_infos: Vec<StateSyncInfo>,
+    remove_state_sync_infos: Vec<CryptoHash>,
     challenged_blocks: HashSet<CryptoHash>,
 }
 
@@ -1273,8 +1273,8 @@ impl<'a> ChainStoreUpdate<'a> {
             add_blocks_to_catchup: vec![],
             remove_blocks_to_catchup: vec![],
             remove_prev_blocks_to_catchup: vec![],
-            add_state_dl_infos: vec![],
-            remove_state_dl_infos: vec![],
+            add_state_sync_infos: vec![],
+            remove_state_sync_infos: vec![],
             challenged_blocks: HashSet::default(),
         }
     }
@@ -1917,12 +1917,12 @@ impl<'a> ChainStoreUpdate<'a> {
         self.remove_prev_blocks_to_catchup.push(hash);
     }
 
-    pub fn add_state_dl_info(&mut self, info: StateSyncInfo) {
-        self.add_state_dl_infos.push(info);
+    pub fn add_state_sync_info(&mut self, info: StateSyncInfo) {
+        self.add_state_sync_infos.push(info);
     }
 
-    pub fn remove_state_dl_info(&mut self, hash: CryptoHash) {
-        self.remove_state_dl_infos.push(hash);
+    pub fn remove_state_sync_info(&mut self, hash: CryptoHash) {
+        self.remove_state_sync_infos.push(hash);
     }
 
     pub fn save_challenged_block(&mut self, hash: CryptoHash) {
@@ -3019,14 +3019,14 @@ impl<'a> ChainStoreUpdate<'a> {
             prev_table.push(new_hash);
             store_update.set_ser(DBCol::BlocksToCatchup, prev_hash.as_ref(), &prev_table)?;
         }
-        for state_dl_info in self.add_state_dl_infos.drain(..) {
+        for state_sync_info in self.add_state_sync_infos.drain(..) {
             store_update.set_ser(
                 DBCol::StateDlInfos,
-                state_dl_info.epoch_tail_hash.as_ref(),
-                &state_dl_info,
+                state_sync_info.epoch_tail_hash.as_ref(),
+                &state_sync_info,
             )?;
         }
-        for hash in self.remove_state_dl_infos.drain(..) {
+        for hash in self.remove_state_sync_infos.drain(..) {
             store_update.delete(DBCol::StateDlInfos, hash.as_ref());
         }
         for hash in self.challenged_blocks.drain() {

--- a/core/o11y/Cargo.toml
+++ b/core/o11y/Cargo.toml
@@ -24,6 +24,7 @@ opentelemetry-otlp.workspace = true
 opentelemetry-semantic-conventions.workspace = true
 prometheus.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 strum.workspace = true
 thiserror.workspace = true
 tokio.workspace = true

--- a/core/o11y/src/log_config.rs
+++ b/core/o11y/src/log_config.rs
@@ -1,3 +1,6 @@
+use std::path::Path;
+use std::{fs::File, io::Write};
+
 use serde::{Deserialize, Serialize};
 
 /// Configures logging.
@@ -10,4 +13,12 @@ pub struct LogConfig {
     pub verbose_module: Option<String>,
     /// Verbosity level of collected traces.
     pub opentelemetry_level: Option<crate::OpenTelemetryLevel>,
+}
+
+impl LogConfig {
+    pub fn write_to_file(&self, path: &Path) -> std::io::Result<()> {
+        let mut file = File::create(path)?;
+        let str = serde_json::to_string_pretty(self)?;
+        file.write_all(str.as_bytes())
+    }
 }

--- a/core/o11y/src/log_config.rs
+++ b/core/o11y/src/log_config.rs
@@ -1,7 +1,6 @@
+use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::{fs::File, io::Write};
-
-use serde::{Deserialize, Serialize};
 
 /// Configures logging.
 #[derive(Default, Serialize, Deserialize, Clone, Debug)]

--- a/docs/architecture/how/resharding.md
+++ b/docs/architecture/how/resharding.md
@@ -43,7 +43,7 @@ be needed in next epoch (X+2).
 
 This is the moment, when node can request new shards that it didn't track before (using StateSync) - and if it detects that the shard layout would change in the next epoch, it also involves the StateSync - but skips the download part (as it already has the data) - and starts from state splitting.
 
-StateSync in this phase would send the ``StateSplitRequest`` to the ``SyncJobsActor`` (you can think about the SyncJobsActor as a background thread).
+StateSync in this phase would send the ``StateSplitRequest`` to the ``SyncJobsActor`` (you can think about the ``SyncJobsActor`` as a background thread).
 
 We'd use the background thread to do the state splitting: the goal is to change the one trie (that represents the state of the current shard) - to multiple tries (one for each of the new shards).
 

--- a/docs/architecture/how/resharding.md
+++ b/docs/architecture/how/resharding.md
@@ -38,12 +38,12 @@ do it more often than on new releases?
 
 It all starts in ``preprocess_block`` - if the node sees, that the block it is
 about to preprocess is the first block of the epoch (X+1)  - it calls
-``get_state_dl_info``, which is responsible for figuring out which shards will 
+``get_state_sync_info``, which is responsible for figuring out which shards will 
 be needed in next epoch (X+2).
 
 This is the moment, when node can request new shards that it didn't track before (using StateSync) - and if it detects that the shard layout would change in the next epoch, it also involves the StateSync - but skips the download part (as it already has the data) - and starts from state splitting.
 
-StateSync in this phase would send the ``StateSplitRequest`` to the ``SyncJobActor`` (you can think about the SyncJobActor as a background thread).
+StateSync in this phase would send the ``StateSplitRequest`` to the ``SyncJobsActor`` (you can think about the SyncJobsActor as a background thread).
 
 We'd use the background thread to do the state splitting: the goal is to change the one trie (that represents the state of the current shard) - to multiple tries (one for each of the new shards).
 

--- a/docs/architecture/how/sync.md
+++ b/docs/architecture/how/sync.md
@@ -238,14 +238,14 @@ initiates the syncing process for these shards. After the state is downloaded,
 
 One thing to note is that `run_catchup` is located at `ClientActor`, but
 intensive work such as applying state parts and applying blocks is actually
-offloaded to `SyncJobActor` in another thread, because we don’t want
+offloaded to `SyncJobsActor` in another thread, because we don’t want
 `ClientActor` to be blocked by this. `run_catchup` is simply responsible for
-scheduling `SyncJobActor` to do the intensive job. Note that `SyncJobActor` is
+scheduling `SyncJobsActor` to do the intensive job. Note that `SyncJobsActor` is
 state-less, it doesn’t have write access to the chain. It will return the changes
 that need to be made as part of the response to `ClientActor`, and `ClientActor`
 is responsible for applying these changes. This is to ensure only one thread
 (`ClientActor`) has write access to the chain state. However, this also adds a
-lot of limits, for example, `SyncJobActor` can only be scheduled to apply one
+lot of limits, for example, `SyncJobsActor` can only be scheduled to apply one
 block at a time. Because `run_catchup` is only scheduled to run every 100ms, the
 speed of catching up blocks is limited to 100ms per block, even when blocks
 applying can be faster. Similar constraints happen to apply state parts.
@@ -262,7 +262,7 @@ Second, even though `run_catchup` is scheduled to run every 100ms, the call can
 be delayed if ClientActor has messages in its actix queue. A better way to do
 this is to move the scheduling of `run_catchup` to `check_triggers`.
 
-Third, because of how `run_catchup` interacts with `SyncJobActor`, `run_catchup`
+Third, because of how `run_catchup` interacts with `SyncJobsActor`, `run_catchup`
 can catch up at most one block every 100 ms. This is because we don’t want to
 write to `ChainStore` in multiple threads. However, the changes that catching up
 blocks make do not interfere with regular block processing and they can be

--- a/nearcore/src/dyn_config.rs
+++ b/nearcore/src/dyn_config.rs
@@ -5,7 +5,7 @@ use near_o11y::log_config::LogConfig;
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
 
-const LOG_CONFIG_FILENAME: &str = "log_config.json";
+pub const LOG_CONFIG_FILENAME: &str = "log_config.json";
 
 /// This function gets called at the startup and each time a config needs to be reloaded.
 pub fn read_updateable_configs(

--- a/runtime/near-vm-runner/src/utils.rs
+++ b/runtime/near-vm-runner/src/utils.rs
@@ -1,5 +1,7 @@
 use std::hash::{Hash, Hasher};
 
+// This method is not used on macOS so it's fine to allow it to be unused.
+#[allow(dead_code)]
 pub(crate) fn stable_hash<T: Hash>(value: T) -> u64 {
     // This is ported over from the previous uses, that relied on near-stable-hasher.
     // The need for stability here can certainly be discussed, and it could probably be replaced with DefaultHasher.


### PR DESCRIPTION
- Renamed a lot of "dl_info" and 'to_dl" to "state_sync_info". I'm too afraid to ask what "dl" stands for but either way it's very confusing. (it could be download). I'm not sure I fully appreciate the difference between state sync, catchup and download and I'm open for a better suggestion how to rename those. 
- In the LocalnetCmd I added logic to generate default LogConfig - to get rid of a pesky log message about this config missing when starting neard. 
- In docs, renamed `SyncJobActor` to `SyncJobsActor` which is the correct name. 
- Allowing the `stable_hash` to be unused. It's only unused on macOS so we need to keep it but let's not generate a warning. All of the failed builds (red cross) below are due to this. cc @andrei-near shall we add some automation to notify us when builds are failing? Should this build be also part of PR-buildkite? 
![Screenshot 2023-07-13 at 15 03 36](https://github.com/near/nearcore/assets/1555986/3adf18bf-6adc-4bf3-9996-55dc2ac8ad68)

