### PR TITLE
refactor: improvements to logging

### DIFF
--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -335,11 +335,6 @@ pub trait RuntimeAdapter: Send + Sync {
         state_patch: SandboxStatePatch,
         use_flat_storage: bool,
     ) -> Result<ApplyTransactionResult, Error> {
-        let _span = tracing::debug_span!(
-            target: "runtime",
-            "apply_transactions",
-            shard_id)
-        .entered();
         let _timer =
             metrics::APPLYING_CHUNKS_TIME.with_label_values(&[&shard_id.to_string()]).start_timer();
         self.apply_transactions_with_optional_storage_proof(

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -851,8 +851,6 @@ impl Client {
 
         debug!(
             target: "client",
-            height=next_height,
-            shard_id,
             me=%validator_signer.validator_id(),
             chunk_hash=%encoded_chunk.chunk_hash().0,
             %prev_block_hash,
@@ -1571,7 +1569,7 @@ impl Client {
                     if &chunk_proposer == &validator_id {
                         let _span = tracing::debug_span!(
                             target: "client",
-                            "on_block_accepted_produce_chunk",
+                            "on_block_accepted",
                             prev_block_hash = ?*block.hash(),
                             ?shard_id)
                         .entered();

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -324,8 +324,7 @@ impl NightshadeRuntime {
             let epoch_manager = self.epoch_manager.read();
             let shard_layout = epoch_manager.get_shard_layout(&epoch_id)?;
             debug!(target: "runtime",
-                   "block height: {}, is next_block_epoch_start {}",
-                   block_height,
+                   "is next_block_epoch_start {}",
                    epoch_manager.is_next_block_epoch_start(prev_block_hash).unwrap()
             );
 

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1313,12 +1313,12 @@ impl Runtime {
                 target: "runtime",
                 "process_receipt",
                 receipt_id = %receipt.receipt_id,
-                node_counter = ?state_update.trie().get_trie_nodes_count(),
                 predecessor = %receipt.predecessor_id,
                 receiver = %receipt.receiver_id,
                 id = %receipt.receipt_id,
             )
             .entered();
+            tracing::trace!(target: "runtime", node_counter = ?state_update.trie().get_trie_nodes_count(), "process_receipt start");
             let result = self.process_receipt(
                 state_update,
                 apply_state,
@@ -1328,7 +1328,7 @@ impl Runtime {
                 &mut stats,
                 epoch_info_provider,
             );
-            tracing::debug!(target: "runtime", node_counter = ?state_update.trie().get_trie_nodes_count());
+            tracing::trace!(target: "runtime", node_counter = ?state_update.trie().get_trie_nodes_count(), "process_receipt done");
             if let Some(outcome_with_id) = result? {
                 *total_gas_burnt =
                     safe_add_gas(*total_gas_burnt, outcome_with_id.outcome.gas_burnt)?;

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1318,7 +1318,7 @@ impl Runtime {
                 id = %receipt.receipt_id,
             )
             .entered();
-            tracing::trace!(target: "runtime", node_counter = ?state_update.trie().get_trie_nodes_count(), "process_receipt start");
+            let node_counter_before = state_update.trie().get_trie_nodes_count();
             let result = self.process_receipt(
                 state_update,
                 apply_state,
@@ -1328,7 +1328,9 @@ impl Runtime {
                 &mut stats,
                 epoch_info_provider,
             );
-            tracing::trace!(target: "runtime", node_counter = ?state_update.trie().get_trie_nodes_count(), "process_receipt done");
+            let node_counter_after = state_update.trie().get_trie_nodes_count();
+            tracing::trace!(target: "runtime", ?node_counter_before, ?node_counter_after);
+
             if let Some(outcome_with_id) = result? {
                 *total_gas_burnt =
                     safe_add_gas(*total_gas_burnt, outcome_with_id.outcome.gas_burnt)?;


### PR DESCRIPTION
There are plenty of log lines that don't fit in a single line, even on a quite wide monitor. This is an attempt to improve that. 
- Removed a few variables in tracing spans that were redundant - already included in parent span.
- Removed `apply_transactions_with_optional_storage_proof` span that immediately enters `process_state_update` and doesn't provide much value.
- Set the test formatter to use a new custom time formatter that only prints seconds and milliseconds since the test started. The default one prints full date, time, and nanoseconds. 
- Mini refactor of the sharding_upgrade.rs that I'm just trying to sneak through. These tests are the inspiration for improving the spam log since I can't parse it. 
- **RFC: changed the log level of the `process_receipt` log to `trace!`. This is very subjective but my reasoning is that if a log line appears more that a few times per block, then if should have the trace level.** Since it's runtime related, cc @jakmeier @nagisa, are you fine with that change? 

For any of those I can be convinced otherwise, please shout.

new log lines look like this:

```
 1.075s DEBUG do_apply_chunks{block_height=23 block_hash=9yH4}:new_chunk{shard_id=1}:process_state_update: runtime: epoch_height=4 epoch_id=EpochId(4kD9) current_protocol_version=48 is_first_block_of_version=false
 1.075s DEBUG do_apply_chunks{block_height=23 block_hash=9yH4}:new_chunk{shard_id=2}:process_state_update: runtime: epoch_height=4 epoch_id=EpochId(4kD9) current_protocol_version=48 is_first_block_of_version=false
 1.075s DEBUG do_apply_chunks{block_height=23 block_hash=9yH4}:new_chunk{shard_id=3}:process_state_update: runtime: is next_block_epoch_start false
 1.075s DEBUG do_apply_chunks{block_height=23 block_hash=9yH4}:new_chunk{shard_id=2}:process_state_update:apply{num_transactions=0}: runtime: close time.busy=39.2µs time.idle=3.04µs
 1.075s DEBUG do_apply_chunks{block_height=23 block_hash=9yH4}:new_chunk{shard_id=3}:process_state_update: runtime: epoch_height=4 epoch_id=EpochId(4kD9) current_protocol_version=48 is_first_block_of_version=false
 1.075s DEBUG do_apply_chunks{block_height=23 block_hash=9yH4}:new_chunk{shard_id=1}:process_state_update:apply{num_transactions=0}: runtime: close time.busy=71.0µs time.idle=2.67µs
 1.075s DEBUG do_apply_chunks{block_height=23 block_hash=9yH4}:new_chunk{shard_id=3}:process_state_update:apply{num_transactions=0}: runtime: close time.busy=62.2µs time.idle=3.58µs
```

(with the exception of hashes, I have them shortened locally, but I'm not including that in this PR) 

On a sidenote, I quite like tracing spans but we may be overdoing it a bit.