### PR TITLE
chain: remove deprecated near_peer_message_received_total metric

### DIFF
--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -1526,7 +1526,6 @@ impl actix::Handler<stream::Frame> for PeerActor {
         // Message type agnostic stats.
         {
             metrics::PEER_DATA_RECEIVED_BYTES.inc_by(msg.len() as u64);
-            metrics::PEER_MESSAGE_RECEIVED_TOTAL.inc();
             tracing::trace!(target: "network", msg_len=msg.len());
             self.tracker.lock().increment_received(&self.clock, msg.len() as u64);
         }

--- a/chain/network/src/stats/metrics.rs
+++ b/chain/network/src/stats/metrics.rs
@@ -168,14 +168,6 @@ pub(crate) static PEER_MESSAGE_RECEIVED_BY_TYPE_BYTES: Lazy<IntCounterVec> = Laz
     )
     .unwrap()
 });
-// TODO(mina86): This has been deprecated in 1.30.  Remove at 1.32 or so.
-pub(crate) static PEER_MESSAGE_RECEIVED_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
-    try_create_int_counter(
-        "near_peer_message_received_total",
-        "Deprecated; aggregate near_peer_message_received_by_type_total instead",
-    )
-    .unwrap()
-});
 pub(crate) static PEER_MESSAGE_RECEIVED_BY_TYPE_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
     try_create_int_counter_vec(
         "near_peer_message_received_by_type_total",


### PR DESCRIPTION
The metric has been deprecated since 1.30.  Users should use
near_peer_message_received_by_type_total instead.
