### PR TITLE
fix(locust): wait for base on_locust_init() to finish before other in…

### DIFF
--- a/pytest/tests/loadtest/locust/common/base.py
+++ b/pytest/tests/loadtest/locust/common/base.py
@@ -11,6 +11,7 @@ import multiprocessing
 import pathlib
 import requests
 import sys
+import threading
 import time
 import typing
 import unittest
@@ -550,8 +551,7 @@ def init_account_generator(parsed_options):
 
 
 # called once per process before user initialization
-@events.init.add_listener
-def on_locust_init(environment, **kwargs):
+def do_on_locust_init(environment):
     node = NearNodeProxy(environment)
 
     master_funding_key = key.Key.from_json_file(
@@ -592,6 +592,15 @@ def on_locust_init(environment, **kwargs):
 
     NearUser.funding_account = funding_account
     environment.master_funding_account = master_funding_account
+
+
+INIT_DONE = threading.Event()
+
+
+@events.init.add_listener
+def on_locust_init(environment, **kwargs):
+    do_on_locust_init(environment)
+    INIT_DONE.set()
 
 
 # Add custom CLI args here, will be available in `environment.parsed_options`

--- a/pytest/tests/loadtest/locust/common/congestion.py
+++ b/pytest/tests/loadtest/locust/common/congestion.py
@@ -66,6 +66,7 @@ class ComputeSum(base.Transaction):
 
 @events.init.add_listener
 def on_locust_init(environment, **kwargs):
+    base.INIT_DONE.wait()
     # `master_funding_account` is the same on all runners, allowing to share a
     # single instance of congestion contract.
     funding_account = environment.master_funding_account

--- a/pytest/tests/loadtest/locust/common/ft.py
+++ b/pytest/tests/loadtest/locust/common/ft.py
@@ -6,7 +6,7 @@ from locust import events
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[4] / 'lib'))
 
 import key
-from common.base import Account, Deploy, NearNodeProxy, NearUser, FunctionCall
+from common.base import Account, Deploy, NearNodeProxy, NearUser, FunctionCall, INIT_DONE
 
 
 class FTContract:
@@ -116,6 +116,7 @@ class InitFTAccount(FunctionCall):
 
 @events.init.add_listener
 def on_locust_init(environment, **kwargs):
+    INIT_DONE.wait()
     node = NearNodeProxy(environment)
     ft_contract_code = environment.parsed_options.fungible_token_wasm
     num_ft_contracts = environment.parsed_options.num_ft_contracts

--- a/pytest/tests/loadtest/locust/common/social.py
+++ b/pytest/tests/loadtest/locust/common/social.py
@@ -11,7 +11,7 @@ import transaction
 
 from account import TGAS, NEAR_BASE
 import key
-from common.base import Account, Deploy, NearNodeProxy, Transaction, FunctionCall
+from common.base import Account, Deploy, NearNodeProxy, Transaction, FunctionCall, INIT_DONE
 from locust import events, runners
 from transaction import create_function_call_action
 
@@ -256,6 +256,7 @@ class TestSocialDbSetMsg(unittest.TestCase):
 
 @events.init.add_listener
 def on_locust_init(environment, **kwargs):
+    INIT_DONE.wait()
     # `master_funding_account` is the same on all runners, allowing to share a
     # single instance of SocialDB in its `social` sub account
     funding_account = environment.master_funding_account

--- a/pytest/tests/loadtest/locust/common/sweat.py
+++ b/pytest/tests/loadtest/locust/common/sweat.py
@@ -1,6 +1,6 @@
 import typing
 from common.ft import FTContract, InitFTAccount
-from common.base import Account, NearNodeProxy, NearUser, FunctionCall, MultiFunctionCall
+from common.base import Account, NearNodeProxy, NearUser, FunctionCall, MultiFunctionCall, INIT_DONE
 import locust
 import sys
 import pathlib
@@ -130,6 +130,7 @@ class SweatMintBatch(FunctionCall):
 
 @events.init.add_listener
 def on_locust_init(environment, **kwargs):
+    INIT_DONE.wait()
     node = NearNodeProxy(environment)
     worker_id = getattr(environment.runner, "worker_index", "_master")
     run_id = environment.parsed_options.run_id


### PR DESCRIPTION
…it fns

the base on_locust_init() function sets
`environment.master_funding_account`, and other init functions expect it to be set when they're run. When that isn't the case, you can get this sort of error:

```
Traceback (most recent call last):
  File "/home/ubuntu/.local/lib/python3.8/site-packages/locust/event.py", line 40, in fire
    handler(**kwargs)
  File "/home/ubuntu/nearcore/pytest/tests/loadtest/locust/common/social.py", line 261, in on_locust_init
    funding_account = environment.master_funding_account
AttributeError: 'Environment' object has no attribute 'master_funding_account
```

This error can even happen in the master, before the workers have been started, and it might be related to this issue (which has been closed due to inactivity):
https://github.com/locustio/locust/issues/1730. That bug mentions that `User`s get started before on_locust_init() runs, but maybe for similar reasons, we can't guarantee the order in which each on_locust_init() function will run.  This doesn't seem to happen every time, and it hasn't really been triggered on MacOS, only on Linux. But this makes it kind of a blocker for setting this test up on cloud VMs (where this bug has been observed)