### PR TITLE
Fix proxy-based nayduck tests so that they can run on non-unix systems.

### DIFF
--- a/nightly/pytest-sanity.txt
+++ b/nightly/pytest-sanity.txt
@@ -45,9 +45,8 @@ pytest --timeout=3600 sanity/state_sync_massive_validator.py
 pytest --timeout=3600 sanity/state_sync_massive.py --features nightly
 pytest --timeout=3600 sanity/state_sync_massive_validator.py --features nightly
 
-# TODO(#8211) - tests broken due to bad behavior in chunk fetching - re-enable when that PR is submitted.
-# pytest sanity/sync_chunks_from_archival.py
-# pytest sanity/sync_chunks_from_archival.py --features nightly
+pytest sanity/sync_chunks_from_archival.py
+pytest sanity/sync_chunks_from_archival.py --features nightly
 pytest sanity/rpc_tx_forwarding.py
 pytest sanity/rpc_tx_forwarding.py --features nightly
 pytest --timeout=240 sanity/skip_epoch.py
@@ -98,11 +97,10 @@ pytest sanity/proxy_restart.py
 pytest sanity/proxy_restart.py --features nightly
 pytest sanity/network_drop_package.py
 pytest sanity/network_drop_package.py --features nightly
-# TODO: enable them when we fix the issue with proxy shutdown (#2942)
-# pytest --timeout=900 sanity/sync_ban.py true
-# pytest --timeout=900 sanity/sync_ban.py true --features nightly
-# pytest --timeout=900 sanity/sync_ban.py false
-# pytest --timeout=900 sanity/sync_ban.py false --features nightly
+pytest --timeout=900 sanity/sync_ban.py true
+pytest --timeout=900 sanity/sync_ban.py true --features nightly
+pytest --timeout=900 sanity/sync_ban.py false
+pytest --timeout=900 sanity/sync_ban.py false --features nightly
 pytest sanity/block_chunk_signature.py
 pytest sanity/block_chunk_signature.py --features nightly
 pytest sanity/concurrent_function_calls.py

--- a/pytest/tests/sanity/block_chunk_signature.py
+++ b/pytest/tests/sanity/block_chunk_signature.py
@@ -28,10 +28,10 @@ class Handler(ProxyHandler):
             return msg
         return True
 
+if __name__ == '__main__':
+    nodes = start_cluster(2, 0, 1, None, [], {}, Handler)
 
-nodes = start_cluster(2, 0, 1, None, [], {}, Handler)
-
-time.sleep(5)
-h0 = nodes[0].get_latest_block(verbose=True).height
-h1 = nodes[1].get_latest_block(verbose=True).height
-assert h0 <= 3 and h1 <= 3
+    time.sleep(5)
+    h0 = nodes[0].get_latest_block(verbose=True).height
+    h1 = nodes[1].get_latest_block(verbose=True).height
+    assert h0 <= 3 and h1 <= 3

--- a/pytest/tests/sanity/block_chunk_signature.py
+++ b/pytest/tests/sanity/block_chunk_signature.py
@@ -28,6 +28,7 @@ class Handler(ProxyHandler):
             return msg
         return True
 
+
 if __name__ == '__main__':
     nodes = start_cluster(2, 0, 1, None, [], {}, Handler)
 

--- a/pytest/tests/sanity/network_drop_package.py
+++ b/pytest/tests/sanity/network_drop_package.py
@@ -3,6 +3,7 @@ import sys, time, random
 import multiprocessing
 import logging
 import pathlib
+from functools import partial
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
 
@@ -13,8 +14,6 @@ from proxy import ProxyHandler
 from multiprocessing import Value
 
 TIMEOUT = 90
-success = Value('i', 0)
-height = Value('i', 0)
 
 # Ratio of message that are dropped to simulate bad network performance
 DROP_RATIO = 0.05
@@ -22,7 +21,9 @@ DROP_RATIO = 0.05
 
 class Handler(ProxyHandler):
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, success=None, **kwargs):
+        assert success is not None
+        self.success = success
         super().__init__(*args, **kwargs)
         self.dropped = 0
         self.total = 0
@@ -31,16 +32,11 @@ class Handler(ProxyHandler):
         if msg.enum == 'Block':
             h = msg.Block.BlockV2.header.inner_lite().height
 
-            with height.get_lock():
-                if h > height.value:
-                    height.value = h
-                    logging.info(f"Height: {h}")
-
-            with success.get_lock():
-                if h >= 10 and success.value == 0:
+            with self.success.get_lock():
+                if h >= 10 and self.success.value == 0:
                     logging.info(
                         f'SUCCESS DROP={self.dropped} TOTAL={self.total}')
-                    success.value = 1
+                    self.success.value = 1
 
         drop = random.random() < DROP_RATIO and 'Handshake' not in msg.enum
 
@@ -51,16 +47,19 @@ class Handler(ProxyHandler):
         return not drop
 
 
-start_cluster(3, 0, 1, None, [["epoch_length", 500]], {}, Handler)
+if __name__ == '__main__':
+    success = Value('i', 0)
 
-started = time.time()
+    start_cluster(3, 0, 1, None, [["epoch_length", 500]], {}, partial(Handler, success=success))
 
-while True:
-    logging.info(f"Time: {time.time() - started:0.2}, Fin: {success.value}")
-    assert time.time() - started < TIMEOUT
-    time.sleep(1)
+    started = time.time()
 
-    if success.value == 1:
-        break
+    while True:
+        logging.info(f"Time: {time.time() - started:0.2}, Fin: {success.value}")
+        assert time.time() - started < TIMEOUT
+        time.sleep(1)
 
-logging.info("Success")
+        if success.value == 1:
+            break
+
+    logging.info("Success")

--- a/pytest/tests/sanity/network_drop_package.py
+++ b/pytest/tests/sanity/network_drop_package.py
@@ -50,7 +50,8 @@ class Handler(ProxyHandler):
 if __name__ == '__main__':
     success = Value('i', 0)
 
-    start_cluster(3, 0, 1, None, [["epoch_length", 500]], {}, partial(Handler, success=success))
+    start_cluster(3, 0, 1, None, [["epoch_length", 500]], {},
+                  partial(Handler, success=success))
 
     started = time.time()
 

--- a/pytest/tests/sanity/proxy_example.py
+++ b/pytest/tests/sanity/proxy_example.py
@@ -48,9 +48,11 @@ class Handler(ProxyHandler):
 
         return True
 
+
 if __name__ == '__main__':
     success = Value('i', 0)
-    start_cluster(2, 0, 1, None, [], {}, functools.partial(Handler, success=success))
+    start_cluster(2, 0, 1, None, [], {},
+                  functools.partial(Handler, success=success))
 
     started = time.time()
 

--- a/pytest/tests/sanity/proxy_example.py
+++ b/pytest/tests/sanity/proxy_example.py
@@ -20,12 +20,13 @@ from proxy import ProxyHandler
 from multiprocessing import Value
 
 TIMEOUT = 30
-success = Value('i', 0)
 
 
 class Handler(ProxyHandler):
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, success=None, **kwargs):
+        assert success is not None
+        self.success = success
         super().__init__(*args, **kwargs)
         self.peers_response = 0
 
@@ -43,18 +44,19 @@ class Handler(ProxyHandler):
             self.peers_response += 1
             logger.info(f"Total PeersResponses = {self.peers_response}")
             if self.peers_response == 2:
-                success.value = 1
+                self.success.value = 1
 
         return True
 
+if __name__ == '__main__':
+    success = Value('i', 0)
+    start_cluster(2, 0, 1, None, [], {}, functools.partial(Handler, success=success))
 
-start_cluster(2, 0, 1, None, [], {}, Handler)
+    started = time.time()
 
-started = time.time()
+    while True:
+        assert time.time() - started < TIMEOUT
+        time.sleep(1)
 
-while True:
-    assert time.time() - started < TIMEOUT
-    time.sleep(1)
-
-    if success.value == 1:
-        break
+        if success.value == 1:
+            break

--- a/pytest/tests/sanity/proxy_restart.py
+++ b/pytest/tests/sanity/proxy_restart.py
@@ -14,9 +14,10 @@ import utils
 
 TARGET_HEIGHT = 20
 
-nodes = start_cluster(2, 0, 1, None, [], {}, ProxyHandler)
+if __name__ == '__main__':
+    nodes = start_cluster(2, 0, 1, None, [], {}, ProxyHandler)
 
-nodes[1].kill()
-nodes[1].start(boot_node=nodes[0])
+    nodes[1].kill()
+    nodes[1].start(boot_node=nodes[0])
 
-utils.wait_for_blocks(nodes[1], target=TARGET_HEIGHT)
+    utils.wait_for_blocks(nodes[1], target=TARGET_HEIGHT)

--- a/pytest/tests/sanity/proxy_simple.py
+++ b/pytest/tests/sanity/proxy_simple.py
@@ -20,6 +20,7 @@ TIMEOUT = 30
 
 
 class Handler(ProxyHandler):
+
     def __init__(self, *args, success=None, **kwargs):
         assert success is not None
         self.success = success

--- a/pytest/tests/sanity/proxy_simple.py
+++ b/pytest/tests/sanity/proxy_simple.py
@@ -9,6 +9,7 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
 
 from cluster import start_cluster
 from configured_logger import logger
+from functools import partial
 from peer import *
 from proxy import ProxyHandler
 
@@ -16,10 +17,13 @@ from multiprocessing import Value
 from utils import obj_to_string
 
 TIMEOUT = 30
-success = Value('i', 0)
 
 
 class Handler(ProxyHandler):
+    def __init__(self, *args, success=None, **kwargs):
+        assert success is not None
+        self.success = success
+        super().__init__(*args, **kwargs)
 
     async def handle(self, msg, fr, to):
         if msg.enum == 'Block':
@@ -27,17 +31,20 @@ class Handler(ProxyHandler):
             logger.info(f"Height: {h}")
             if h >= 10:
                 logger.info('SUCCESS')
-                success.value = 1
+                self.success.value = 1
         return True
 
 
-start_cluster(2, 0, 1, None, [], {}, Handler)
+if __name__ == '__main__':
+    success = Value('i', 0)
 
-started = time.time()
+    start_cluster(2, 0, 1, None, [], {}, partial(Handler, success=success))
 
-while True:
-    assert time.time() - started < TIMEOUT
-    time.sleep(1)
+    started = time.time()
 
-    if success.value == 1:
-        break
+    while True:
+        assert time.time() - started < TIMEOUT
+        time.sleep(1)
+
+        if success.value == 1:
+            break

--- a/pytest/tests/sanity/recompress_storage.py
+++ b/pytest/tests/sanity/recompress_storage.py
@@ -93,8 +93,8 @@ class RecompressStorageTestCase(unittest.TestCase):
         time.sleep(5)
         sanity.rpc_tx_status.test_tx_status(self.nodes, nonce_offset=3)
 
-    def _call(self, node: cluster.LocalNode, prefix: str,
-              *args: typing.Union[str, pathlib.Path]) -> None:
+    def _call(self, node: cluster.LocalNode, prefix: str, *args:
+              typing.Union[str, pathlib.Path]) -> None:
         """Calls node’s neard with given arguments."""
         node_dir = pathlib.Path(node.node_dir)
         cmd = [

--- a/pytest/tests/sanity/recompress_storage.py
+++ b/pytest/tests/sanity/recompress_storage.py
@@ -93,8 +93,8 @@ class RecompressStorageTestCase(unittest.TestCase):
         time.sleep(5)
         sanity.rpc_tx_status.test_tx_status(self.nodes, nonce_offset=3)
 
-    def _call(self, node: cluster.LocalNode, prefix: str, *args:
-              typing.Union[str, pathlib.Path]) -> None:
+    def _call(self, node: cluster.LocalNode, prefix: str,
+              *args: typing.Union[str, pathlib.Path]) -> None:
         """Calls node’s neard with given arguments."""
         node_dir = pathlib.Path(node.node_dir)
         cmd = [

--- a/pytest/tests/sanity/sync_ban.py
+++ b/pytest/tests/sanity/sync_ban.py
@@ -26,6 +26,7 @@ BAN_STRING = 'ban a fraudulent peer'
 
 
 class Handler(ProxyHandler):
+
     def __init__(self, *args, should_sync=None, should_ban=None, **kwargs):
         assert should_sync is not None
         self.should_sync = should_sync
@@ -83,10 +84,14 @@ if __name__ == '__main__':
     }
 
     should_sync = Value('i', False)
-    nodes = start_cluster(1, 1, 1, None, [["epoch_length", EPOCH_LENGTH]], {
-        0: node0_config,
-        1: node1_config
-    }, functools.partial(Handler, should_sync=should_sync, should_ban=should_ban))
+    nodes = start_cluster(
+        1, 1, 1, None, [["epoch_length", EPOCH_LENGTH]], {
+            0: node0_config,
+            1: node1_config
+        },
+        functools.partial(Handler,
+                          should_sync=should_sync,
+                          should_ban=should_ban))
 
     utils.wait_for_blocks(nodes[0], target=30, poll_interval=2)
 
@@ -109,14 +114,16 @@ if __name__ == '__main__':
             cur_height = nodes[0].get_latest_block().height
             node1_height = nodes[1].get_latest_block().height
             status1 = nodes[1].get_status()
-            print(f"Sync: node 1 at block {node1_height}, node 0 at block {cur_height}; waiting for node 1 to catch up")
+            print(
+                f"Sync: node 1 at block {node1_height}, node 0 at block {cur_height}; waiting for node 1 to catch up"
+            )
             if (abs(node1_height - cur_height) < 5 and
                     status1['sync_info']['syncing'] is False):
                 break
         time.sleep(2)
 
     if not should_ban and (tracker0.check(BAN_STRING) or
-                        tracker1.check(BAN_STRING)):
+                           tracker1.check(BAN_STRING)):
         assert False, "unexpected ban of peers"
 
     # logger.info('shutting down')

--- a/pytest/tests/sanity/sync_ban.py
+++ b/pytest/tests/sanity/sync_ban.py
@@ -19,97 +19,105 @@ from peer import *
 from proxy import ProxyHandler
 import utils
 
-should_ban = sys.argv[1] == 'true'
-
 TIMEOUT = 300
 EPOCH_LENGTH = 50
 
 BAN_STRING = 'ban a fraudulent peer'
 
-should_sync = Value('i', False)
-
 
 class Handler(ProxyHandler):
+    def __init__(self, *args, should_sync=None, should_ban=None, **kwargs):
+        assert should_sync is not None
+        self.should_sync = should_sync
+        assert should_ban is not None
+        self.should_ban = should_ban
+        super().__init__(*args, **kwargs)
 
     async def handle(self, msg, fr, to):
         if msg is not None:
             if msg.enum == 'Block':
                 loop = asyncio.get_running_loop()
                 send = functools.partial(self.do_send_message, msg, 1)
-                if should_sync.value:
+                if self.should_sync.value:
                     loop.call_later(1, send)
                 return False
             elif msg.enum == 'BlockRequest':
                 loop = asyncio.get_running_loop()
                 send = functools.partial(self.do_send_message, msg, 0)
-                if should_sync.value:
+                if self.should_sync.value:
                     loop.call_later(6, send)
                 return False
             elif msg.enum == 'BlockHeaders':
-                if should_ban:
+                if self.should_ban:
                     return False
                 loop = asyncio.get_running_loop()
                 send = functools.partial(self.do_send_message, msg, 1)
-                if should_sync.value:
+                if self.should_sync.value:
                     loop.call_later(2, send)
                 return False
         return True
 
 
-node0_config = {
-    "consensus": {
-        "min_block_production_delay": {
-            "secs": 0,
-            "nanos": 400000000
+if __name__ == '__main__':
+    should_ban = sys.argv[1] == 'true'
+    node0_config = {
+        "consensus": {
+            "min_block_production_delay": {
+                "secs": 0,
+                "nanos": 1000000000
+            },
         },
     }
-}
-node1_config = {
-    "consensus": {
-        "header_sync_initial_timeout": {
-            "secs": 3,
-            "nanos": 0
+    node1_config = {
+        "consensus": {
+            "header_sync_initial_timeout": {
+                "secs": 3,
+                "nanos": 0
+            },
+            "header_sync_stall_ban_timeout": {
+                "secs": 5,
+                "nanos": 0
+            }
         },
-        "header_sync_stall_ban_timeout": {
-            "secs": 5,
-            "nanos": 0
-        }
-    },
-    "tracked_shards": [0]
-}
-nodes = start_cluster(1, 1, 1, None, [["epoch_length", EPOCH_LENGTH]], {
-    0: node0_config,
-    1: node1_config
-}, Handler)
+        "tracked_shards": [0]
+    }
 
-utils.wait_for_blocks(nodes[0], target=110, poll_interval=2)
+    should_sync = Value('i', False)
+    nodes = start_cluster(1, 1, 1, None, [["epoch_length", EPOCH_LENGTH]], {
+        0: node0_config,
+        1: node1_config
+    }, functools.partial(Handler, should_sync=should_sync, should_ban=should_ban))
 
-should_sync.value = True
+    utils.wait_for_blocks(nodes[0], target=30, poll_interval=2)
 
-logger.info("sync node 1")
+    should_sync.value = True
 
-start = time.time()
+    logger.info("sync node 1")
 
-tracker0 = utils.LogTracker(nodes[0])
-tracker1 = utils.LogTracker(nodes[1])
+    start = time.time()
 
-while True:
-    assert time.time() - start < TIMEOUT
+    tracker0 = utils.LogTracker(nodes[0])
+    tracker1 = utils.LogTracker(nodes[1])
 
-    if should_ban:
-        if tracker1.check(BAN_STRING):
-            break
-    else:
-        cur_height = nodes[0].get_latest_block().height
-        node1_height = nodes[1].get_latest_block().height
-        if (abs(node1_height - cur_height) < 5 and
-                status1['sync_info']['syncing'] is False):
-            break
-    time.sleep(2)
+    while True:
+        assert time.time() - start < TIMEOUT
 
-if not should_ban and (tracker0.check(BAN_STRING) or
-                       tracker1.check(BAN_STRING)):
-    assert False, "unexpected ban of peers"
+        if should_ban:
+            if tracker1.check(BAN_STRING):
+                break
+        else:
+            cur_height = nodes[0].get_latest_block().height
+            node1_height = nodes[1].get_latest_block().height
+            status1 = nodes[1].get_status()
+            print(f"Sync: node 1 at block {node1_height}, node 0 at block {cur_height}; waiting for node 1 to catch up")
+            if (abs(node1_height - cur_height) < 5 and
+                    status1['sync_info']['syncing'] is False):
+                break
+        time.sleep(2)
 
-logger.info('shutting down')
-time.sleep(10)
+    if not should_ban and (tracker0.check(BAN_STRING) or
+                        tracker1.check(BAN_STRING)):
+        assert False, "unexpected ban of peers"
+
+    # logger.info('shutting down')
+    # time.sleep(10)


### PR DESCRIPTION
Before this, running proxy-based nayduck tests (such as proxy_simple.py) fails on Mac because on Mac, multiprocessing.Process uses spawn, not fork, and our tests were written in a way that was unfriendly to spawn:

1. the entry point was not protected by `if __name__ == '__main__':`, causing spawned processes to re-execute the main module's code;
2. shared memory was not properly passed to the child process - we relied on referencing the same global variable which only worked with the fork implementation.

This PR fixes these. Also, re-enable two tests which are now fixed.