### PR TITLE
nearcore: remove old deprecation notice about network.external_address

### DIFF
--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -465,20 +465,7 @@ impl Config {
             })?;
         let config: Config = serde_ignored::deserialize(
             &mut serde_json::Deserializer::from_str(&json_str_without_comments),
-            |field| {
-                let field = field.to_string();
-                // TODO(mina86): Remove this deprecation notice some time by the
-                // end of 2022.
-                if field == "network.external_address" {
-                    warn!(
-                        target: "neard",
-                        "{}: {field} is deprecated; please remove it from the config file",
-                        path.display(),
-                    );
-                } else {
-                    unrecognised_fields.push(field);
-                }
-            },
+            |field| unrecognised_fields.push(field.to_string()),
         )
         .map_err(|_| ValidationError::ConfigFileError {
             error_message: format!("Failed to deserialize config from {}", path.display()),


### PR DESCRIPTION
Users have had enough time to update their config files to no longer
specify network.external_address.  The comment dictates the warning
should be removed by the end of 2022 which was half a year ago.
