### PR TITLE
feat(state-sync): Add config for number of downloads during catchup

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -271,6 +271,7 @@ impl Client {
             config.state_sync_timeout,
             &config.chain_id,
             &config.state_sync.sync,
+            false,
         );
         let num_block_producer_seats = config.num_block_producer_seats as usize;
         let data_parts = epoch_manager.num_data_parts();
@@ -2140,6 +2141,7 @@ impl Client {
                             state_sync_timeout,
                             &self.config.chain_id,
                             &self.config.state_sync.sync,
+                            true,
                         ),
                         shards_to_split,
                         BlocksCatchUpState::new(sync_hash, epoch_id),

--- a/chain/client/src/sync/state.rs
+++ b/chain/client/src/sync/state.rs
@@ -166,6 +166,7 @@ impl StateSync {
         timeout: TimeDuration,
         chain_id: &str,
         sync_config: &SyncConfig,
+        catchup: bool,
     ) -> Self {
         let inner = match sync_config {
             SyncConfig::Peers => StateSyncInner::Peers {
@@ -175,6 +176,7 @@ impl StateSync {
             SyncConfig::ExternalStorage(ExternalStorageConfig {
                 location,
                 num_concurrent_requests,
+                num_concurrent_requests_during_catchup,
             }) => {
                 let external = match location {
                     ExternalStorageLocation::S3 { bucket, region } => {
@@ -188,11 +190,14 @@ impl StateSync {
                         ExternalConnection::Filesystem { root_dir: root_dir.clone() }
                     }
                 };
+                let num_permits = if catchup {
+                    *num_concurrent_requests_during_catchup
+                } else {
+                    *num_concurrent_requests
+                } as usize;
                 StateSyncInner::PartsFromExternal {
                     chain_id: chain_id.to_string(),
-                    semaphore: Arc::new(tokio::sync::Semaphore::new(
-                        *num_concurrent_requests as usize,
-                    )),
+                    semaphore: Arc::new(tokio::sync::Semaphore::new(num_permits)),
                     external,
                 }
             }
@@ -1414,6 +1419,7 @@ mod test {
             TimeDuration::from_secs(1),
             "chain_id",
             &SyncConfig::Peers,
+            false,
         );
         let mut new_shard_sync = HashMap::new();
 

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -26,6 +26,7 @@ pub const DEFAULT_GC_NUM_EPOCHS_TO_KEEP: u64 = 5;
 
 /// Default number of concurrent requests to external storage to fetch state parts.
 pub const DEFAULT_STATE_SYNC_NUM_CONCURRENT_REQUESTS_EXTERNAL: u32 = 25;
+pub const DEFAULT_STATE_SYNC_NUM_CONCURRENT_REQUESTS_ON_CATCHUP_EXTERNAL: u32 = 5;
 
 /// Configuration for garbage collection.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq)]
@@ -77,14 +78,22 @@ fn default_num_concurrent_requests() -> u32 {
     DEFAULT_STATE_SYNC_NUM_CONCURRENT_REQUESTS_EXTERNAL
 }
 
+fn default_num_concurrent_requests_during_catchup() -> u32 {
+    DEFAULT_STATE_SYNC_NUM_CONCURRENT_REQUESTS_ON_CATCHUP_EXTERNAL
+}
+
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct ExternalStorageConfig {
     /// Location of state parts.
     pub location: ExternalStorageLocation,
     /// When fetching state parts from external storage, throttle fetch requests
-    /// to this many concurrent requests per shard.
+    /// to this many concurrent requests.
     #[serde(default = "default_num_concurrent_requests")]
     pub num_concurrent_requests: u32,
+    /// During catchup, the node will use a different number of concurrent requests
+    /// to reduce the performance impact of state sync.
+    #[serde(default = "default_num_concurrent_requests_during_catchup")]
+    pub num_concurrent_requests_during_catchup: u32,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]

--- a/integration-tests/src/tests/nearcore/sync_state_nodes.rs
+++ b/integration-tests/src/tests/nearcore/sync_state_nodes.rs
@@ -492,6 +492,7 @@ fn sync_state_dump() {
                                             root_dir: dump_dir.path().to_path_buf(),
                                         },
                                         num_concurrent_requests: 10,
+                                        num_concurrent_requests_during_catchup: 1,
                                     });
 
                                 let nearcore::NearNode {


### PR DESCRIPTION
We can limit the impact of state sync during catchup by turning this number down. This way validation of blocks will not be hindered while the node downloads the state.