### PR TITLE
fix: fixed nayduck test state_sync_fail.py for nightly build

### DIFF
--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -946,3 +946,23 @@ def load_config():
     else:
         logger.info(f"Use default config {config}")
     return config
+
+
+# Returns the protocol version of the binary.
+def get_binary_protocol_version(config) -> typing.Optional[int]:
+    binary_name = config.get('binary_name', 'neard')
+    near_root = config.get('near_root')
+    binary_path = os.path.join(near_root, binary_name)
+
+    # Get the protocol version of the binary
+    # The --version output looks like this:
+    # neard (release trunk) (build 1.1.0-3884-ge93793a61-modified) (rustc 1.71.0) (protocol 137) (db 37)
+    out = subprocess.check_output([binary_path, "--version"], text=True)
+    out = out.replace('(', '')
+    out = out.replace(')', '')
+    tokens = out.split()
+    n = len(tokens)
+    for i in range(n):
+        if tokens[i] == "protocol" and i + 1 < n:
+            return int(tokens[i + 1])
+    return None

--- a/pytest/tests/sanity/state_sync_fail.py
+++ b/pytest/tests/sanity/state_sync_fail.py
@@ -21,8 +21,11 @@ import utils
 EPOCH_LENGTH = 10
 START_AT_BLOCK = int(EPOCH_LENGTH * 2.5)
 
-V0 = {"V0": {"num_shards": 1, "version": 0}}
-V1 = {
+V1_PROTOCOL_VERSION = 48
+V2_PROTOCOL_VERSION = 135
+
+V0_SHARD_LAYOUT = {"V0": {"num_shards": 1, "version": 0}}
+V1_SHARD_LAYOUT = {
     "V1": {
         "boundary_accounts": [
             "aurora", "aurora-0", "kkuuue2akv_1630967379.near"
@@ -33,58 +36,88 @@ V1 = {
     }
 }
 
+
+def append_shard_layout_config_changes(
+    binary_protocol_version,
+    genesis_config_changes,
+):
+    if binary_protocol_version >= V2_PROTOCOL_VERSION:
+        logger.info("Testing migration from V1 to V2.")
+        # Set the initial protocol version to a version just before V2.
+        genesis_config_changes.append([
+            "protocol_version",
+            V2_PROTOCOL_VERSION - 1,
+        ])
+        genesis_config_changes.append([
+            "shard_layout",
+            V1_SHARD_LAYOUT,
+        ])
+        genesis_config_changes.append([
+            "num_block_producer_seats_per_shard",
+            [1, 1, 1, 1],
+        ])
+        genesis_config_changes.append([
+            "avg_hidden_validator_seats_per_shard",
+            [0, 0, 0, 0],
+        ])
+        print(genesis_config_changes)
+        return
+
+    if binary_protocol_version >= V1_PROTOCOL_VERSION:
+        logger.info("Testing migration from V0 to V1.")
+        # Set the initial protocol version to a version just before V1.
+        genesis_config_changes.append([
+            "protocol_version",
+            V1_PROTOCOL_VERSION - 1,
+        ])
+        genesis_config_changes.append([
+            "shard_layout",
+            V0_SHARD_LAYOUT,
+        ])
+        genesis_config_changes.append([
+            "num_block_producer_seats_per_shard",
+            [100],
+        ])
+        genesis_config_changes.append([
+            "avg_hidden_validator_seats_per_shard",
+            [0],
+        ])
+        print(genesis_config_changes)
+        return
+
+    assert False
+
+
+def get_genesis_config_changes(binary_protocol_version):
+    genesis_config_changes = [
+        ["min_gas_price", 0],
+        ["max_inflation_rate", [0, 1]],
+        ["epoch_length", EPOCH_LENGTH],
+        ["use_production_config", True],
+        ["block_producer_kickout_threshold", 80],
+    ]
+
+    append_shard_layout_config_changes(
+        binary_protocol_version,
+        genesis_config_changes,
+    )
+
+    print(genesis_config_changes)
+
+    return genesis_config_changes
+
+
 config = load_config()
 
 binary_protocol_version = get_binary_protocol_version(config)
 assert binary_protocol_version is not None
-
-V1_PROTOCOL_VERSION = 48
-V2_PROTOCOL_VERSION = 135
-
-
-def get_initial_protocol_version(binary_protocol_version):
-    if binary_protocol_version >= V2_PROTOCOL_VERSION:
-        # We'll be testing V1 -> V2 resharding.
-        # Set the initial protocol version to a version before V2.
-        return V2_PROTOCOL_VERSION - 1
-
-    if binary_protocol_version >= V1_PROTOCOL_VERSION:
-        # We'll be testing V0 -> V1 resharding.
-        # Set the initial protocol version to a version before V1.
-        return V1_PROTOCOL_VERSION - 1
-
-    assert False
-
-
-def get_initial_shard_layout(binary_protocol_version):
-    if binary_protocol_version >= V2_PROTOCOL_VERSION:
-        # We'll be testing V1 -> V2 resharding.
-        return V1
-
-    if binary_protocol_version >= V1_PROTOCOL_VERSION:
-        # We'll be testing V0 -> V1 resharding.
-        return V0
-
-    assert False
-
-
-protocol_version = get_initial_protocol_version(binary_protocol_version)
-shard_layout = get_initial_shard_layout(binary_protocol_version)
 
 near_root, node_dirs = init_cluster(
     num_nodes=2,
     num_observers=1,
     num_shards=4,
     config=config,
-    genesis_config_changes=[
-        ["min_gas_price", 0],
-        ["max_inflation_rate", [0, 1]],
-        ["epoch_length", EPOCH_LENGTH],
-        ["protocol_version", protocol_version],
-        ["use_production_config", True],
-        ["block_producer_kickout_threshold", 80],
-        ["shard_layout", shard_layout],
-    ],
+    genesis_config_changes=get_genesis_config_changes(binary_protocol_version),
     client_config_changes={
         0: {
             "tracked_shards": [0],


### PR DESCRIPTION
In #9274 I introduced simple nightshade V2 layout and added it to the nightly build. This broke the nayduck test state_sync_fail.py. Here is the fix for it. 

The test performs resharding and then checks some postconditions. It broke because it attempted to reshard from V0 shard layout to V2 shard layout. This doesn't work because ShardLayout contains shard split map that only makes sense when resharding from a shard layout version to the immediate next. 

The fix is to check what is the protocol version supported in the binary and depending on it reshard from V0 to V1 or from V1 to V2. 