### PR TITLE
refactor(loadtest): backwards compatible type hints

### DIFF
--- a/pytest/tests/loadtest/locust/common/base.py
+++ b/pytest/tests/loadtest/locust/common/base.py
@@ -270,7 +270,7 @@ class NearNodeProxy:
         self.request_event.fire(**meta)
         return meta
 
-    def post_json(self, method: str, params: list[str]):
+    def post_json(self, method: str, params: typing.List[str]):
         j = {
             "method": method,
             "params": params,

--- a/pytest/tests/loadtest/locust/common/ft.py
+++ b/pytest/tests/loadtest/locust/common/ft.py
@@ -1,6 +1,7 @@
 import random
 import sys
 import pathlib
+import typing
 from locust import events
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[4] / 'lib'))
@@ -46,7 +47,7 @@ class FTContract:
     def random_receiver(self, sender: str) -> str:
         return self.random_receivers(sender, 1)[0]
 
-    def random_receivers(self, sender: str, num) -> list[str]:
+    def random_receivers(self, sender: str, num) -> typing.List[str]:
         rng = random.Random()
         receivers = rng.sample(self.registered_users, num)
         # Sender must be != receiver but maybe there is no other registered user

--- a/pytest/tests/loadtest/locust/common/social.py
+++ b/pytest/tests/loadtest/locust/common/social.py
@@ -2,6 +2,7 @@ from abc import abstractmethod
 import json
 import sys
 import pathlib
+import typing
 import unittest
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[4] / 'lib'))
@@ -40,7 +41,7 @@ class SubmitPost(SocialDbSet):
 class Follow(SocialDbSet):
 
     def __init__(self, contract_id: str, sender: Account,
-                 follow_list: list[str]):
+                 follow_list: typing.List[str]):
         super().__init__(contract_id, sender)
         self.follow_list = follow_list
 
@@ -118,7 +119,7 @@ def social_db_build_index_obj(key_list_pairs: dict) -> dict:
     A dict instead of a list of tuples doesn't work because keys can be duplicated.
     """
 
-    def serialize_values(values: list[tuple[str, dict]]):
+    def serialize_values(values: typing.List[typing.Tuple[str, dict]]):
         return json.dumps([{"key": k, "value": v} for k, v in values])
 
     return {
@@ -151,7 +152,7 @@ def social_db_set_msg(sender: str, values: dict, index: dict) -> dict:
     return msg
 
 
-def social_follow_args(sender: str, follow_list: list[str]) -> dict:
+def social_follow_args(sender: str, follow_list: typing.List[str]) -> dict:
     follow_map = {}
     graph = []
     notify = []

--- a/pytest/tests/loadtest/locust/common/sweat.py
+++ b/pytest/tests/loadtest/locust/common/sweat.py
@@ -120,7 +120,7 @@ class SweatMintBatch(FunctionCall):
     """
 
     def __init__(self, sweat_id: str, oracle: Account,
-                 recipient_step_pairs: list[RecipientSteps]):
+                 recipient_step_pairs: typing.List[RecipientSteps]):
         super().__init__(oracle, sweat_id, "record_batch")
         self.recipient_step_pairs = recipient_step_pairs
 


### PR DESCRIPTION
`list[...]` in type hints only works for python 3.9 and up.
For older python versions, we should use `typing.List[...]`.

I first thought we should require newer python for locust tests, also using `match` (see #9125) but it seems we are somewhat dependent on older Ubuntu versions for now. At least I've been checking out code on gcp machines created by terraform templates and needed to patch the type hints to get the code running without installing a new python version.

This PR makes the code fully backward compatible again by simply using the `typing` module which is available since python 3.5.