### PR TITLE
fix(state-viewer): use hashes to determine scanning range

### DIFF
--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -15,6 +15,7 @@ use nearcore::{load_config, NearConfig};
 
 use std::path::{Path, PathBuf};
 
+use borsh::BorshSerialize;
 use std::str::FromStr;
 
 #[derive(clap::Subcommand)]
@@ -525,12 +526,16 @@ pub struct ScanDbColumnCmd {
     #[clap(long)]
     from_bytes: Option<String>,
     #[clap(long)]
+    from_hash: Option<CryptoHash>,
+    #[clap(long)]
     to: Option<String>,
     // List of comma-separated u8-values.
     // For example, if a column key starts wth ShardUId and you want to scan starting from s2.v1 use `--from-bytes 1,0,0,0,2,0,0,0`.
     // Note that the numbers are generally saved as low-endian.
     #[clap(long)]
     to_bytes: Option<String>,
+    #[clap(long)]
+    to_hash: Option<CryptoHash>,
     #[clap(long)]
     max_keys: Option<usize>,
     #[clap(long, default_value = "false")]
@@ -539,8 +544,8 @@ pub struct ScanDbColumnCmd {
 
 impl ScanDbColumnCmd {
     pub fn run(self, store: Store) {
-        let lower_bound = Self::prefix(self.from, self.from_bytes);
-        let upper_bound = Self::prefix(self.to, self.to_bytes);
+        let lower_bound = Self::prefix(self.from, self.from_bytes, self.from_hash);
+        let upper_bound = Self::prefix(self.to, self.to_bytes, self.to_hash);
         crate::scan_db::scan_db_column(
             &self.column,
             lower_bound.as_deref().map(|v| v.as_ref()),
@@ -551,14 +556,19 @@ impl ScanDbColumnCmd {
         )
     }
 
-    fn prefix(s: Option<String>, bytes: Option<String>) -> Option<Vec<u8>> {
-        match (s, bytes) {
-            (None, None) => None,
-            (Some(s), None) => Some(s.into_bytes()),
-            (None, Some(bytes)) => {
+    fn prefix(
+        s: Option<String>,
+        bytes: Option<String>,
+        hash: Option<CryptoHash>,
+    ) -> Option<Vec<u8>> {
+        match (s, bytes, hash) {
+            (None, None, None) => None,
+            (Some(s), None, None) => Some(s.into_bytes()),
+            (None, Some(bytes), None) => {
                 Some(bytes.split(",").map(|s| s.parse::<u8>().unwrap()).collect::<Vec<u8>>())
             }
-            (Some(_), Some(_)) => {
+            (None, None, Some(hash)) => Some(hash.try_to_vec().unwrap()),
+            _ => {
                 panic!("Provided both a Vec and a String as a prefix")
             }
         }

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -2,20 +2,15 @@ use crate::commands::*;
 use crate::contract_accounts::ContractAccountFilter;
 use crate::rocksdb_stats::get_rocksdb_stats;
 use crate::trie_iteration_benchmark::TrieIterationBenchmarkCmd;
-
+use borsh::BorshSerialize;
 use near_chain_configs::{GenesisChangeConfig, GenesisValidationMode};
-
 use near_primitives::account::id::AccountId;
 use near_primitives::hash::CryptoHash;
 use near_primitives::sharding::ChunkHash;
-
 use near_primitives::types::{BlockHeight, ShardId};
 use near_store::{Mode, NodeStorage, Store, Temperature};
 use nearcore::{load_config, NearConfig};
-
 use std::path::{Path, PathBuf};
-
-use borsh::BorshSerialize;
 use std::str::FromStr;
 
 #[derive(clap::Subcommand)]

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -563,9 +563,7 @@ impl ScanDbColumnCmd {
                 Some(bytes.split(",").map(|s| s.parse::<u8>().unwrap()).collect::<Vec<u8>>())
             }
             (None, None, Some(hash)) => Some(hash.try_to_vec().unwrap()),
-            _ => {
-                panic!("Provided both a Vec and a String as a prefix")
-            }
+            _ => panic!("Need to provide exactly one of bytes, str, or hash"),
         }
     }
 }


### PR DESCRIPTION
For example, the ChunkExtra column key is block_hash + shard_uid.
It's much more convenient to use the tool as `neard view-state scan-db-column --column ChunkExtra --from-hash 11153w1N1bFv8fun2FdHfTMj97mF3gaUoV6fdrAQU9 --max-keys 4` to get ChunkExtra of that block.
