### PR TITLE
Move flat-storage-reads/fix-contract-loading-cost/implicit-accounts features to runtime configuration 

### DIFF
--- a/chain/indexer/src/streamer/mod.rs
+++ b/chain/indexer/src/streamer/mod.rs
@@ -2,7 +2,6 @@ use std::time::Duration;
 
 use actix::Addr;
 use async_recursion::async_recursion;
-use near_indexer_primitives::types::ProtocolVersion;
 use node_runtime::config::RuntimeConfig;
 use rocksdb::DB;
 use tokio::sync::mpsc;
@@ -128,7 +127,6 @@ async fn build_streamer_message(
         let chunk_local_receipts = convert_transactions_sir_into_local_receipts(
             &client,
             &runtime_config,
-            protocol_config_view.protocol_version,
             indexer_transactions
                 .iter()
                 .filter(|tx| tx.transaction.signer_id == tx.transaction.receiver_id)
@@ -175,7 +173,6 @@ async fn build_streamer_message(
                     if let Some(receipt) = find_local_receipt_by_id_in_block(
                         &client,
                         &runtime_config,
-                        protocol_config_view.protocol_version,
                         prev_block,
                         execution_outcome.id,
                     )
@@ -188,7 +185,7 @@ async fn build_streamer_message(
                 }
             };
             receipt_execution_outcomes
-                .push(IndexerExecutionOutcomeWithReceipt { execution_outcome, receipt: receipt });
+                .push(IndexerExecutionOutcomeWithReceipt { execution_outcome, receipt });
         }
 
         // Blocks #47317863 and #47317864
@@ -246,7 +243,6 @@ async fn build_streamer_message(
 async fn find_local_receipt_by_id_in_block(
     client: &Addr<near_client::ViewClientActor>,
     runtime_config: &RuntimeConfig,
-    protocol_version: ProtocolVersion,
     block: views::BlockView,
     receipt_id: near_primitives::hash::CryptoHash,
 ) -> Result<Option<views::ReceiptView>, FailedToFetchData> {
@@ -276,7 +272,6 @@ async fn find_local_receipt_by_id_in_block(
             let local_receipts = convert_transactions_sir_into_local_receipts(
                 &client,
                 &runtime_config,
-                protocol_version,
                 vec![&indexer_transaction],
                 &block,
             )

--- a/chain/indexer/src/streamer/utils.rs
+++ b/chain/indexer/src/streamer/utils.rs
@@ -1,6 +1,5 @@
 use actix::Addr;
 
-use near_indexer_primitives::types::ProtocolVersion;
 use near_indexer_primitives::IndexerTransactionWithOutcome;
 use near_primitives::views;
 use node_runtime::config::{tx_cost, RuntimeConfig};
@@ -11,7 +10,6 @@ use super::fetchers::fetch_block;
 pub(crate) async fn convert_transactions_sir_into_local_receipts(
     client: &Addr<near_client::ViewClientActor>,
     runtime_config: &RuntimeConfig,
-    protocol_version: ProtocolVersion,
     txs: Vec<&IndexerTransactionWithOutcome>,
     block: &views::BlockView,
 ) -> Result<Vec<views::ReceiptView>, FailedToFetchData> {
@@ -44,7 +42,6 @@ pub(crate) async fn convert_transactions_sir_into_local_receipts(
                     },
                     prev_block_gas_price,
                     true,
-                    protocol_version,
                 );
                 views::ReceiptView {
                     predecessor_id: tx.transaction.signer_id.clone(),

--- a/core/primitives-core/src/config.rs
+++ b/core/primitives-core/src/config.rs
@@ -25,6 +25,17 @@ pub struct VMConfig {
     /// Disable the fix for the #9393 issue in near-vm-runner.
     pub disable_9393_fix: bool,
 
+    /// Enable the `FlatStorageReads` protocol feature.
+    ///
+    // TODO(nagisa): replace with StorageGetMode when VMConfig is moved to near-vm-runner.
+    pub flat_storage_reads: bool,
+
+    /// Enable the `FixContractLoadingCost` protocol feature.
+    pub fix_contract_loading_cost: bool,
+
+    /// Enable the `ImplicitAccountCreation` protocol feature.
+    pub implicit_account_creation: bool,
+
     /// Describes limits for VM and Runtime.
     pub limit_config: VMLimitConfig,
 }
@@ -184,6 +195,9 @@ impl VMConfig {
             regular_op_cost: (SAFETY_MULTIPLIER as u32) * 1285457,
             disable_9393_fix: false,
             limit_config: VMLimitConfig::test(),
+            fix_contract_loading_cost: cfg!(feature = "protocol_feature_fix_contract_loading_cost"),
+            flat_storage_reads: true,
+            implicit_account_creation: true,
         }
     }
 
@@ -203,6 +217,9 @@ impl VMConfig {
             disable_9393_fix: false,
             // We shouldn't have any costs in the limit config.
             limit_config: VMLimitConfig { max_gas_burnt: u64::MAX, ..VMLimitConfig::test() },
+            fix_contract_loading_cost: cfg!(feature = "protocol_feature_fix_contract_loading_cost"),
+            flat_storage_reads: true,
+            implicit_account_creation: true,
         }
     }
 }

--- a/core/primitives-core/src/parameter.rs
+++ b/core/primitives-core/src/parameter.rs
@@ -146,8 +146,12 @@ pub enum Parameter {
     MaxLocalsPerContract,
     AccountIdValidityRulesVersion,
 
+    // Contract runtime features
     #[strum(serialize = "disable_9393_fix")]
     Disable9393Fix,
+    FlatStorageReads,
+    ImplicitAccountCreation,
+    FixContractLoadingCost,
 }
 
 #[derive(

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -96,23 +96,18 @@ pub enum ProtocolFeature {
     ///
     /// Compute Costs NEP-455: https://github.com/near/NEPs/blob/master/neps/nep-0455.md
     ComputeCosts,
-
     /// Enable flat storage for reads, reducing number of DB accesses from `2 * key.len()` in
     /// the worst case to 2.
     ///
     /// Flat Storage NEP-399: https://github.com/near/NEPs/blob/master/neps/nep-0399.md
     FlatStorageReads,
-
     /// Enables preparation V2. Note that this setting is not supported in production settings
     /// without NearVmRuntime enabled alongside it, as the VM runner would be too slow.
     PreparationV2,
-
     /// Enables Near-Vm. Note that this setting is not at all supported without PreparationV2,
     /// as it hardcodes preparation v2 code into the generated assembly.
     NearVmRuntime,
-
     BlockHeaderV4,
-
     /// In case not all validator seats are occupied our algorithm provide incorrect minimal seat
     /// price - it reports as alpha * sum_stake instead of alpha * sum_stake / (1 - alpha), where
     /// alpha is min stake ratio

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -96,6 +96,7 @@ pub enum ProtocolFeature {
     ///
     /// Compute Costs NEP-455: https://github.com/near/NEPs/blob/master/neps/nep-0455.md
     ComputeCosts,
+
     /// Enable flat storage for reads, reducing number of DB accesses from `2 * key.len()` in
     /// the worst case to 2.
     ///

--- a/core/primitives/res/runtime_configs/129.yaml
+++ b/core/primitives/res/runtime_configs/129.yaml
@@ -1,0 +1,1 @@
+fix_contract_loading_cost: { old: false, new: true }

--- a/core/primitives/res/runtime_configs/35.yaml
+++ b/core/primitives/res/runtime_configs/35.yaml
@@ -1,0 +1,1 @@
+implicit_account_creation: { old: false, new: true }

--- a/core/primitives/res/runtime_configs/61.yaml
+++ b/core/primitives/res/runtime_configs/61.yaml
@@ -5,3 +5,4 @@ wasm_storage_write_base:    { old: 64_196_736_000, new: { gas: 64_196_736_000, c
 wasm_storage_remove_base:   { old: 53_473_030_500, new: { gas: 53_473_030_500, compute: 200_000_000_000 } }
 wasm_storage_read_base:     { old: 56_356_845_750, new: { gas: 56_356_845_750, compute: 200_000_000_000 } }
 wasm_storage_has_key_base:  { old: 54_039_896_625, new: { gas: 54_039_896_625, compute: 200_000_000_000 } }
+flat_storage_reads:         { old: false, new: true }

--- a/core/primitives/res/runtime_configs/parameters.snap
+++ b/core/primitives/res/runtime_configs/parameters.snap
@@ -164,4 +164,7 @@ wasmer2_stack_limit                                  204_800
 max_locals_per_contract                            1_000_000
 account_id_validity_rules_version                          1
 disable_9393_fix                        false
+flat_storage_reads                      true
+implicit_account_creation               true
+fix_contract_loading_cost               true
 

--- a/core/primitives/res/runtime_configs/parameters.yaml
+++ b/core/primitives/res/runtime_configs/parameters.yaml
@@ -197,4 +197,8 @@ max_promises_per_function_call_action: 1_024
 max_number_input_data_dependencies: 128
 account_id_validity_rules_version: 0
 
+# Contract runtime configuration
 disable_9393_fix: false
+flat_storage_reads: false
+implicit_account_creation: false
+fix_contract_loading_cost: false

--- a/core/primitives/res/runtime_configs/parameters_testnet.yaml
+++ b/core/primitives/res/runtime_configs/parameters_testnet.yaml
@@ -194,3 +194,6 @@ max_promises_per_function_call_action: 1_024
 max_number_input_data_dependencies: 128
 
 disable_9393_fix: false
+flat_storage_reads: false
+implicit_account_creation: false
+fix_contract_loading_cost: false

--- a/core/primitives/src/runtime/config_store.rs
+++ b/core/primitives/src/runtime/config_store.rs
@@ -18,6 +18,7 @@ static BASE_CONFIG: &str = include_config!("parameters.yaml");
 /// Stores pairs of protocol versions for which runtime config was updated and
 /// the file containing the diffs in bytes.
 static CONFIG_DIFFS: &[(ProtocolVersion, &str)] = &[
+    (35, include_config!("35.yaml")),
     (42, include_config!("42.yaml")),
     (48, include_config!("48.yaml")),
     (49, include_config!("49.yaml")),
@@ -33,6 +34,7 @@ static CONFIG_DIFFS: &[(ProtocolVersion, &str)] = &[
     (61, include_config!("61.yaml")),
     (62, include_config!("62.yaml")),
     (63, include_config!("63.yaml")),
+    (129, include_config!("129.yaml")),
 ];
 
 /// Testnet parameters for versions <= 29, which (incorrectly) differed from mainnet parameters
@@ -261,8 +263,8 @@ mod tests {
         );
 
         let expected_config = {
-            let first_diff = CONFIG_DIFFS[0].1.parse().unwrap();
-            base_params.apply_diff(first_diff).unwrap();
+            base_params.apply_diff(CONFIG_DIFFS[0].1.parse().unwrap()).unwrap();
+            base_params.apply_diff(CONFIG_DIFFS[1].1.parse().unwrap()).unwrap();
             RuntimeConfig::new(&base_params).unwrap()
         };
         assert_eq!(**config, expected_config);
@@ -270,8 +272,7 @@ mod tests {
         let config = store.get_config(LowerDataReceiptAndEcrecoverBaseCost.protocol_version());
         assert_eq!(config.fees.fee(ActionCosts::new_data_receipt_base).send_sir, 36_486_732_312);
         let expected_config = {
-            let second_diff = CONFIG_DIFFS[1].1.parse().unwrap();
-            base_params.apply_diff(second_diff).unwrap();
+            base_params.apply_diff(CONFIG_DIFFS[2].1.parse().unwrap()).unwrap();
             RuntimeConfig::new(&base_params).unwrap()
         };
         assert_eq!(config.as_ref(), &expected_config);

--- a/core/primitives/src/runtime/parameter_table.rs
+++ b/core/primitives/src/runtime/parameter_table.rs
@@ -291,6 +291,9 @@ impl TryFrom<&ParameterTable> for RuntimeConfig {
                 disable_9393_fix: params.get(Parameter::Disable9393Fix)?,
                 limit_config: serde_yaml::from_value(params.yaml_map(Parameter::vm_limits()))
                     .map_err(InvalidConfigError::InvalidYaml)?,
+                fix_contract_loading_cost: params.get(Parameter::FixContractLoadingCost)?,
+                flat_storage_reads: params.get(Parameter::FlatStorageReads)?,
+                implicit_account_creation: params.get(Parameter::ImplicitAccountCreation)?,
             },
             account_creation_config: AccountCreationConfig {
                 min_allowed_top_level_account_length: params

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__0.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__0.json.snap
@@ -173,6 +173,9 @@ expression: config_view
     "grow_mem_cost": 1,
     "regular_op_cost": 3856371,
     "disable_9393_fix": false,
+    "flat_storage_reads": false,
+    "fix_contract_loading_cost": false,
+    "implicit_account_creation": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__129.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__129.json.snap
@@ -24,9 +24,9 @@ expression: config_view
     },
     "action_creation_config": {
       "create_account_cost": {
-        "send_sir": 99607375000,
-        "send_not_sir": 99607375000,
-        "execution": 99607375000
+        "send_sir": 3850000000000,
+        "send_not_sir": 3850000000000,
+        "execution": 3850000000000
       },
       "deploy_contract_cost": {
         "send_sir": 184765750000,
@@ -173,13 +173,13 @@ expression: config_view
     "grow_mem_cost": 1,
     "regular_op_cost": 822756,
     "disable_9393_fix": false,
-    "flat_storage_reads": false,
-    "fix_contract_loading_cost": false,
+    "flat_storage_reads": true,
+    "fix_contract_loading_cost": true,
     "implicit_account_creation": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
-      "max_stack_height": 16384,
-      "contract_prepare_version": 1,
+      "max_stack_height": 262144,
+      "contract_prepare_version": 2,
       "initial_memory_pages": 1024,
       "max_memory_pages": 2048,
       "registers_memory_limit": 1073741824,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__35.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__35.json.snap
@@ -3,7 +3,7 @@ source: core/primitives/src/runtime/config_store.rs
 expression: config_view
 ---
 {
-  "storage_amount_per_byte": "10000000000000000000",
+  "storage_amount_per_byte": "100000000000000000000",
   "transaction_costs": {
     "action_receipt_creation_config": {
       "send_sir": 108059500000,
@@ -12,14 +12,14 @@ expression: config_view
     },
     "data_receipt_creation_config": {
       "base_cost": {
-        "send_sir": 36486732312,
-        "send_not_sir": 36486732312,
-        "execution": 36486732312
+        "send_sir": 4697339419375,
+        "send_not_sir": 4697339419375,
+        "execution": 4697339419375
       },
       "cost_per_byte": {
-        "send_sir": 17212011,
-        "send_not_sir": 17212011,
-        "execution": 17212011
+        "send_sir": 59357464,
+        "send_not_sir": 59357464,
+        "execution": 59357464
       }
     },
     "action_creation_config": {
@@ -36,7 +36,7 @@ expression: config_view
       "deploy_contract_cost_per_byte": {
         "send_sir": 6812999,
         "send_not_sir": 6812999,
-        "execution": 64572944
+        "execution": 6812999
       },
       "function_call_cost": {
         "send_sir": 2319861500000,
@@ -131,7 +131,7 @@ expression: config_view
       "ripemd160_block": 680107584,
       "ed25519_verify_base": 210000000000,
       "ed25519_verify_byte": 9000000,
-      "ecrecover_base": 278821988457,
+      "ecrecover_base": 3365369625000,
       "log_base": 3543313050,
       "log_byte": 13198791,
       "storage_write_base": 64196736000,
@@ -171,15 +171,15 @@ expression: config_view
       "alt_bn128_pairing_check_element": 5102000000000
     },
     "grow_mem_cost": 1,
-    "regular_op_cost": 822756,
+    "regular_op_cost": 3856371,
     "disable_9393_fix": false,
     "flat_storage_reads": false,
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "limit_config": {
-      "max_gas_burnt": 300000000000000,
+      "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,
-      "contract_prepare_version": 1,
+      "contract_prepare_version": 0,
       "initial_memory_pages": 1024,
       "max_memory_pages": 2048,
       "registers_memory_limit": 1073741824,
@@ -195,14 +195,12 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_length_storage_key": 2048,
+      "max_length_storage_key": 4194304,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
       "max_number_input_data_dependencies": 128,
-      "max_functions_number_per_contract": 10000,
-      "wasmer2_stack_limit": 204800,
-      "max_locals_per_contract": 1000000,
-      "account_id_validity_rules_version": 1
+      "wasmer2_stack_limit": 102400,
+      "account_id_validity_rules_version": 0
     }
   },
   "account_creation_config": {

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__42.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__42.json.snap
@@ -173,6 +173,9 @@ expression: config_view
     "grow_mem_cost": 1,
     "regular_op_cost": 3856371,
     "disable_9393_fix": false,
+    "flat_storage_reads": false,
+    "fix_contract_loading_cost": false,
+    "implicit_account_creation": true,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__48.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__48.json.snap
@@ -173,6 +173,9 @@ expression: config_view
     "grow_mem_cost": 1,
     "regular_op_cost": 2207874,
     "disable_9393_fix": false,
+    "flat_storage_reads": false,
+    "fix_contract_loading_cost": false,
+    "implicit_account_creation": true,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__49.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__49.json.snap
@@ -173,6 +173,9 @@ expression: config_view
     "grow_mem_cost": 1,
     "regular_op_cost": 822756,
     "disable_9393_fix": false,
+    "flat_storage_reads": false,
+    "fix_contract_loading_cost": false,
+    "implicit_account_creation": true,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__50.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__50.json.snap
@@ -173,6 +173,9 @@ expression: config_view
     "grow_mem_cost": 1,
     "regular_op_cost": 822756,
     "disable_9393_fix": false,
+    "flat_storage_reads": false,
+    "fix_contract_loading_cost": false,
+    "implicit_account_creation": true,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__52.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__52.json.snap
@@ -173,6 +173,9 @@ expression: config_view
     "grow_mem_cost": 1,
     "regular_op_cost": 822756,
     "disable_9393_fix": false,
+    "flat_storage_reads": false,
+    "fix_contract_loading_cost": false,
+    "implicit_account_creation": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__53.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__53.json.snap
@@ -173,6 +173,9 @@ expression: config_view
     "grow_mem_cost": 1,
     "regular_op_cost": 822756,
     "disable_9393_fix": false,
+    "flat_storage_reads": false,
+    "fix_contract_loading_cost": false,
+    "implicit_account_creation": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__59.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__59.json.snap
@@ -173,6 +173,9 @@ expression: config_view
     "grow_mem_cost": 1,
     "regular_op_cost": 822756,
     "disable_9393_fix": false,
+    "flat_storage_reads": false,
+    "fix_contract_loading_cost": false,
+    "implicit_account_creation": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__61.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__61.json.snap
@@ -173,6 +173,9 @@ expression: config_view
     "grow_mem_cost": 1,
     "regular_op_cost": 822756,
     "disable_9393_fix": false,
+    "flat_storage_reads": true,
+    "fix_contract_loading_cost": false,
+    "implicit_account_creation": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__62.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__62.json.snap
@@ -173,6 +173,9 @@ expression: config_view
     "grow_mem_cost": 1,
     "regular_op_cost": 822756,
     "disable_9393_fix": true,
+    "flat_storage_reads": true,
+    "fix_contract_loading_cost": false,
+    "implicit_account_creation": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__63.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__63.json.snap
@@ -173,6 +173,9 @@ expression: config_view
     "grow_mem_cost": 1,
     "regular_op_cost": 822756,
     "disable_9393_fix": false,
+    "flat_storage_reads": true,
+    "fix_contract_loading_cost": false,
+    "implicit_account_creation": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_0.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_0.json.snap
@@ -173,6 +173,9 @@ expression: config_view
     "grow_mem_cost": 1,
     "regular_op_cost": 3856371,
     "disable_9393_fix": false,
+    "flat_storage_reads": false,
+    "fix_contract_loading_cost": false,
+    "implicit_account_creation": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_129.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_129.json.snap
@@ -24,9 +24,9 @@ expression: config_view
     },
     "action_creation_config": {
       "create_account_cost": {
-        "send_sir": 99607375000,
-        "send_not_sir": 99607375000,
-        "execution": 99607375000
+        "send_sir": 3850000000000,
+        "send_not_sir": 3850000000000,
+        "execution": 3850000000000
       },
       "deploy_contract_cost": {
         "send_sir": 184765750000,
@@ -173,13 +173,13 @@ expression: config_view
     "grow_mem_cost": 1,
     "regular_op_cost": 822756,
     "disable_9393_fix": false,
-    "flat_storage_reads": false,
-    "fix_contract_loading_cost": false,
+    "flat_storage_reads": true,
+    "fix_contract_loading_cost": true,
     "implicit_account_creation": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
-      "max_stack_height": 16384,
-      "contract_prepare_version": 1,
+      "max_stack_height": 262144,
+      "contract_prepare_version": 2,
       "initial_memory_pages": 1024,
       "max_memory_pages": 2048,
       "registers_memory_limit": 1073741824,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_35.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_35.json.snap
@@ -3,7 +3,7 @@ source: core/primitives/src/runtime/config_store.rs
 expression: config_view
 ---
 {
-  "storage_amount_per_byte": "10000000000000000000",
+  "storage_amount_per_byte": "100000000000000000000",
   "transaction_costs": {
     "action_receipt_creation_config": {
       "send_sir": 108059500000,
@@ -12,14 +12,14 @@ expression: config_view
     },
     "data_receipt_creation_config": {
       "base_cost": {
-        "send_sir": 36486732312,
-        "send_not_sir": 36486732312,
-        "execution": 36486732312
+        "send_sir": 4697339419375,
+        "send_not_sir": 4697339419375,
+        "execution": 4697339419375
       },
       "cost_per_byte": {
-        "send_sir": 17212011,
-        "send_not_sir": 17212011,
-        "execution": 17212011
+        "send_sir": 59357464,
+        "send_not_sir": 59357464,
+        "execution": 59357464
       }
     },
     "action_creation_config": {
@@ -36,7 +36,7 @@ expression: config_view
       "deploy_contract_cost_per_byte": {
         "send_sir": 6812999,
         "send_not_sir": 6812999,
-        "execution": 64572944
+        "execution": 6812999
       },
       "function_call_cost": {
         "send_sir": 2319861500000,
@@ -131,7 +131,7 @@ expression: config_view
       "ripemd160_block": 680107584,
       "ed25519_verify_base": 210000000000,
       "ed25519_verify_byte": 9000000,
-      "ecrecover_base": 278821988457,
+      "ecrecover_base": 3365369625000,
       "log_base": 3543313050,
       "log_byte": 13198791,
       "storage_write_base": 64196736000,
@@ -171,15 +171,15 @@ expression: config_view
       "alt_bn128_pairing_check_element": 5102000000000
     },
     "grow_mem_cost": 1,
-    "regular_op_cost": 822756,
+    "regular_op_cost": 3856371,
     "disable_9393_fix": false,
     "flat_storage_reads": false,
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "limit_config": {
-      "max_gas_burnt": 300000000000000,
+      "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,
-      "contract_prepare_version": 1,
+      "contract_prepare_version": 0,
       "initial_memory_pages": 1024,
       "max_memory_pages": 2048,
       "registers_memory_limit": 1073741824,
@@ -195,14 +195,12 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_length_storage_key": 2048,
+      "max_length_storage_key": 4194304,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
       "max_number_input_data_dependencies": 128,
-      "max_functions_number_per_contract": 10000,
-      "wasmer2_stack_limit": 204800,
-      "max_locals_per_contract": 1000000,
-      "account_id_validity_rules_version": 1
+      "wasmer2_stack_limit": 102400,
+      "account_id_validity_rules_version": 0
     }
   },
   "account_creation_config": {

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_42.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_42.json.snap
@@ -173,6 +173,9 @@ expression: config_view
     "grow_mem_cost": 1,
     "regular_op_cost": 3856371,
     "disable_9393_fix": false,
+    "flat_storage_reads": false,
+    "fix_contract_loading_cost": false,
+    "implicit_account_creation": true,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_48.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_48.json.snap
@@ -173,6 +173,9 @@ expression: config_view
     "grow_mem_cost": 1,
     "regular_op_cost": 2207874,
     "disable_9393_fix": false,
+    "flat_storage_reads": false,
+    "fix_contract_loading_cost": false,
+    "implicit_account_creation": true,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_49.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_49.json.snap
@@ -173,6 +173,9 @@ expression: config_view
     "grow_mem_cost": 1,
     "regular_op_cost": 822756,
     "disable_9393_fix": false,
+    "flat_storage_reads": false,
+    "fix_contract_loading_cost": false,
+    "implicit_account_creation": true,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_50.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_50.json.snap
@@ -173,6 +173,9 @@ expression: config_view
     "grow_mem_cost": 1,
     "regular_op_cost": 822756,
     "disable_9393_fix": false,
+    "flat_storage_reads": false,
+    "fix_contract_loading_cost": false,
+    "implicit_account_creation": true,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_52.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_52.json.snap
@@ -173,6 +173,9 @@ expression: config_view
     "grow_mem_cost": 1,
     "regular_op_cost": 822756,
     "disable_9393_fix": false,
+    "flat_storage_reads": false,
+    "fix_contract_loading_cost": false,
+    "implicit_account_creation": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_53.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_53.json.snap
@@ -173,6 +173,9 @@ expression: config_view
     "grow_mem_cost": 1,
     "regular_op_cost": 822756,
     "disable_9393_fix": false,
+    "flat_storage_reads": false,
+    "fix_contract_loading_cost": false,
+    "implicit_account_creation": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_57.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_57.json.snap
@@ -173,6 +173,9 @@ expression: config_view
     "grow_mem_cost": 1,
     "regular_op_cost": 822756,
     "disable_9393_fix": false,
+    "flat_storage_reads": false,
+    "fix_contract_loading_cost": false,
+    "implicit_account_creation": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_59.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_59.json.snap
@@ -173,6 +173,9 @@ expression: config_view
     "grow_mem_cost": 1,
     "regular_op_cost": 822756,
     "disable_9393_fix": false,
+    "flat_storage_reads": false,
+    "fix_contract_loading_cost": false,
+    "implicit_account_creation": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_61.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_61.json.snap
@@ -173,6 +173,9 @@ expression: config_view
     "grow_mem_cost": 1,
     "regular_op_cost": 822756,
     "disable_9393_fix": false,
+    "flat_storage_reads": true,
+    "fix_contract_loading_cost": false,
+    "implicit_account_creation": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_62.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_62.json.snap
@@ -173,6 +173,9 @@ expression: config_view
     "grow_mem_cost": 1,
     "regular_op_cost": 822756,
     "disable_9393_fix": true,
+    "flat_storage_reads": true,
+    "fix_contract_loading_cost": false,
+    "implicit_account_creation": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_63.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_63.json.snap
@@ -173,6 +173,9 @@ expression: config_view
     "grow_mem_cost": 1,
     "regular_op_cost": 822756,
     "disable_9393_fix": false,
+    "flat_storage_reads": true,
+    "fix_contract_loading_cost": false,
+    "implicit_account_creation": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/primitives/src/snapshots/near_primitives__views__tests__runtime_config_view.snap
+++ b/core/primitives/src/snapshots/near_primitives__views__tests__runtime_config_view.snap
@@ -173,6 +173,9 @@ expression: "&view"
     "grow_mem_cost": 1,
     "regular_op_cost": 3856371,
     "disable_9393_fix": false,
+    "flat_storage_reads": true,
+    "fix_contract_loading_cost": false,
+    "implicit_account_creation": true,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 262144,

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -2473,7 +2473,14 @@ pub struct VMConfigView {
     /// Gas cost of a regular operation.
     pub regular_op_cost: u32,
 
+    /// See [`VMConfig::disable_9393_fix`].
     pub disable_9393_fix: bool,
+    /// See [`VMConfig::flat_storage_reads`].
+    pub flat_storage_reads: bool,
+    /// See [`VMConfig::fix_contract_loading_cost`].
+    pub fix_contract_loading_cost: bool,
+    /// See [`VMConfig::implicit_account_creation`].
+    pub implicit_account_creation: bool,
 
     /// Describes limits for VM and Runtime.
     ///
@@ -2490,6 +2497,9 @@ impl From<VMConfig> for VMConfigView {
             regular_op_cost: config.regular_op_cost,
             disable_9393_fix: config.disable_9393_fix,
             limit_config: config.limit_config,
+            flat_storage_reads: config.flat_storage_reads,
+            fix_contract_loading_cost: config.fix_contract_loading_cost,
+            implicit_account_creation: config.implicit_account_creation,
         }
     }
 }
@@ -2502,6 +2512,9 @@ impl From<VMConfigView> for VMConfig {
             regular_op_cost: view.regular_op_cost,
             disable_9393_fix: view.disable_9393_fix,
             limit_config: view.limit_config,
+            flat_storage_reads: view.flat_storage_reads,
+            fix_contract_loading_cost: view.fix_contract_loading_cost,
+            implicit_account_creation: view.implicit_account_creation,
         }
     }
 }

--- a/integration-tests/src/tests/client/features/fix_contract_loading_cost.rs
+++ b/integration-tests/src/tests/client/features/fix_contract_loading_cost.rs
@@ -18,9 +18,10 @@ fn prepare_env_with_contract(
     let mut genesis = Genesis::test(vec![account.clone()], 1);
     genesis.config.epoch_length = epoch_length;
     genesis.config.protocol_version = protocol_version;
+    let runtime_config = near_primitives::runtime::config_store::RuntimeConfigStore::new(None);
     let mut env = TestEnv::builder(ChainGenesis::new(&genesis))
         .real_epoch_managers(&genesis.config)
-        .nightshade_runtimes(&genesis)
+        .nightshade_runtimes_with_runtime_config_store(&genesis, vec![runtime_config])
         .build();
     deploy_test_contract(&mut env, account, &contract, epoch_length, 1);
     env

--- a/integration-tests/src/tests/client/features/flat_storage.rs
+++ b/integration-tests/src/tests/client/features/flat_storage.rs
@@ -29,9 +29,10 @@ fn test_flat_storage_upgrade() {
     genesis.config.epoch_length = epoch_length;
     genesis.config.protocol_version = old_protocol_version;
     let chain_genesis = ChainGenesis::new(&genesis);
+    let runtime_config = near_primitives::runtime::config_store::RuntimeConfigStore::new(None);
     let mut env = TestEnv::builder(chain_genesis)
         .real_epoch_managers(&genesis.config)
-        .nightshade_runtimes(&genesis)
+        .nightshade_runtimes_with_runtime_config_store(&genesis, vec![runtime_config])
         .build();
 
     // We assume that it is enough to process 4 blocks to get a single txn included and processed.

--- a/runtime/near-vm-runner/src/logic/tests/vm_logic_builder.rs
+++ b/runtime/near-vm-runner/src/logic/tests/vm_logic_builder.rs
@@ -3,9 +3,6 @@ use crate::logic::mocks::mock_memory::MockedMemory;
 use crate::logic::types::PromiseResult;
 use crate::logic::{MemSlice, VMConfig, VMContext, VMLogic};
 use near_primitives_core::runtime::fees::RuntimeFeesConfig;
-use near_primitives_core::types::ProtocolVersion;
-
-pub(super) const LATEST_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::MAX;
 
 pub(super) struct VMLogicBuilder {
     pub ext: MockedExternal,
@@ -13,7 +10,6 @@ pub(super) struct VMLogicBuilder {
     pub fees_config: RuntimeFeesConfig,
     pub promise_results: Vec<PromiseResult>,
     pub memory: MockedMemory,
-    pub current_protocol_version: ProtocolVersion,
     pub context: VMContext,
 }
 
@@ -25,7 +21,6 @@ impl Default for VMLogicBuilder {
             ext: MockedExternal::default(),
             memory: MockedMemory::default(),
             promise_results: vec![],
-            current_protocol_version: LATEST_PROTOCOL_VERSION,
             context: get_context(),
         }
     }
@@ -41,14 +36,13 @@ impl VMLogicBuilder {
 
     pub fn build(&mut self) -> TestVMLogic<'_> {
         let context = self.context.clone();
-        TestVMLogic::from(VMLogic::new_with_protocol_version(
+        TestVMLogic::from(VMLogic::new(
             &mut self.ext,
             context,
             &self.config,
             &self.fees_config,
             &self.promise_results,
             &mut self.memory,
-            self.current_protocol_version,
         ))
     }
 
@@ -59,7 +53,6 @@ impl VMLogicBuilder {
             ext: MockedExternal::default(),
             memory: MockedMemory::default(),
             promise_results: vec![],
-            current_protocol_version: LATEST_PROTOCOL_VERSION,
             context: get_context(),
         }
     }

--- a/runtime/near-vm-runner/src/near_vm_runner.rs
+++ b/runtime/near-vm-runner/src/near_vm_runner.rs
@@ -677,21 +677,10 @@ impl crate::runner::VM for NearVM {
         // FIXME: this mostly duplicates the `run_module` method.
         // Note that we don't clone the actual backing memory, just increase the RC.
         let vmmemory = memory.vm();
-        let mut logic = VMLogic::new_with_protocol_version(
-            ext,
-            context,
-            &self.config,
-            fees_config,
-            promise_results,
-            &mut memory,
-            current_protocol_version,
-        );
+        let mut logic =
+            VMLogic::new(ext, context, &self.config, fees_config, promise_results, &mut memory);
 
-        let result = logic.before_loading_executable(
-            method_name,
-            current_protocol_version,
-            code.code().len(),
-        );
+        let result = logic.before_loading_executable(method_name, code.code().len());
         if let Err(e) = result {
             return Ok(VMOutcome::abort(logic, e));
         }
@@ -704,7 +693,7 @@ impl crate::runner::VM for NearVM {
             }
         };
 
-        let result = logic.after_loading_executable(current_protocol_version, code.code().len());
+        let result = logic.after_loading_executable(code.code().len());
         if let Err(e) = result {
             return Ok(VMOutcome::abort(logic, e));
         }
@@ -715,11 +704,7 @@ impl crate::runner::VM for NearVM {
             artifact.engine(),
         );
         if let Err(e) = get_entrypoint_index(&*artifact, method_name) {
-            return Ok(VMOutcome::abort_but_nop_outcome_in_old_protocol(
-                logic,
-                e,
-                current_protocol_version,
-            ));
+            return Ok(VMOutcome::abort_but_nop_outcome_in_old_protocol(logic, e));
         }
         match self.run_method(&artifact, import, method_name)? {
             Ok(()) => Ok(VMOutcome::ok(logic)),

--- a/runtime/near-vm-runner/src/tests.rs
+++ b/runtime/near-vm-runner/src/tests.rs
@@ -57,17 +57,3 @@ fn create_context(input: Vec<u8>) -> VMContext {
         output_data_receivers: vec![],
     }
 }
-
-/// Small helper to compute expected loading gas cost charged before loading.
-///
-/// Includes hard-coded value for runtime parameter values
-/// `wasm_contract_loading_base` and `wasm_contract_loading_bytes` which would
-/// have to be updated if they change in the future.
-#[allow(unused)]
-fn prepaid_loading_gas(bytes: usize) -> u64 {
-    if cfg!(feature = "protocol_feature_fix_contract_loading_cost") {
-        35_445_963 + bytes as u64 * 21_6750
-    } else {
-        0
-    }
-}

--- a/runtime/near-vm-runner/src/tests/compile_errors.rs
+++ b/runtime/near-vm-runner/src/tests/compile_errors.rs
@@ -2,6 +2,8 @@ use super::test_builder::test_builder;
 use expect_test::expect;
 use near_primitives_core::version::ProtocolFeature;
 
+const FIX_CONTRACT_LOADING_COST: u32 = 129;
+
 #[test]
 fn test_initializer_wrong_signature_contract() {
     test_builder()
@@ -13,16 +15,12 @@ fn test_initializer_wrong_signature_contract() {
   (func (export "main"))
 )"#,
         )
-        .protocol_features(&[
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
-            ProtocolFeature::FixContractLoadingCost,
-        ])
+        .protocol_version(FIX_CONTRACT_LOADING_COST)
         .expects(&[
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
                 Err: PrepareError: Error happened while deserializing the module.
             "#]],
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 48017463 used gas 48017463
                 Err: PrepareError: Error happened while deserializing the module.
@@ -36,16 +34,14 @@ fn test_function_not_defined_contract() {
     test_builder()
         .wat(r#"(module (export "hello" (func 0)))"#)
         .method("hello")
-        .protocol_features(&[
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
-            ProtocolFeature::FixContractLoadingCost,
-        ])
+        .protocol_version(
+            FIX_CONTRACT_LOADING_COST
+        )
         .expects(&[
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
                 Err: PrepareError: Error happened while deserializing the module.
             "#]],
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 39564213 used gas 39564213
                 Err: PrepareError: Error happened while deserializing the module.
@@ -68,16 +64,14 @@ fn function_type_not_defined_contract(bad_type: u64) -> Vec<u8> {
 fn test_function_type_not_defined_contract_1() {
     test_builder()
         .wasm(&function_type_not_defined_contract(1))
-        .protocol_features(&[
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
-            ProtocolFeature::FixContractLoadingCost,
-        ])
+        .protocol_version(
+            FIX_CONTRACT_LOADING_COST
+        )
         .expects(&[
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
                 Err: PrepareError: Error happened while deserializing the module.
             "#]],
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 44982963 used gas 44982963
                 Err: PrepareError: Error happened while deserializing the module.
@@ -90,16 +84,14 @@ fn test_function_type_not_defined_contract_1() {
 fn test_function_type_not_defined_contract_2() {
     test_builder()
         .wasm(&function_type_not_defined_contract(0))
-        .protocol_features(&[
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
-            ProtocolFeature::FixContractLoadingCost,
-        ])
+        .protocol_version(
+            FIX_CONTRACT_LOADING_COST
+        )
         .expects(&[
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
                 Err: PrepareError: Error happened while deserializing the module.
             "#]],
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 44982963 used gas 44982963
                 Err: PrepareError: Error happened while deserializing the module.
@@ -111,16 +103,13 @@ fn test_function_type_not_defined_contract_2() {
 fn test_garbage_contract() {
     test_builder()
         .wasm(&[])
-        .protocol_features(&[
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
-            ProtocolFeature::FixContractLoadingCost,
-        ])
+        .protocol_version(FIX_CONTRACT_LOADING_COST
+        )
         .expects(&[
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
                 Err: PrepareError: Error happened while deserializing the module.
             "#]],
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 35445963 used gas 35445963
                 Err: PrepareError: Error happened while deserializing the module.
@@ -133,16 +122,14 @@ fn test_evil_function_index() {
     test_builder()
         .wat(r#"(module (func (export "main") call 4294967295))"#)
         .method("abort_with_zero")
-        .protocol_features(&[
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
-            ProtocolFeature::FixContractLoadingCost,
-        ])
+        .protocol_version(
+            FIX_CONTRACT_LOADING_COST
+        )
         .expects(&[
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
                 Err: PrepareError: Error happened while deserializing the module.
             "#]],
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 44115963 used gas 44115963
                 Err: PrepareError: Error happened while deserializing the module.
@@ -164,9 +151,8 @@ fn test_limit_contract_functions_number() {
     .protocol_features(&[
         ProtocolFeature::LimitContractFunctionsNumber,
         ProtocolFeature::PreparationV2,
-        #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
-        ProtocolFeature::FixContractLoadingCost,
     ])
+    .protocol_version(FIX_CONTRACT_LOADING_COST)
     .expects(&[
         expect![[r#"
             VMOutcome: balance 4 storage_usage 12 return data None burnt gas 13048032213 used gas 13048032213
@@ -177,7 +163,6 @@ fn test_limit_contract_functions_number() {
         expect![[r#"
             VMOutcome: balance 4 storage_usage 12 return data None burnt gas 13054614261 used gas 13054614261
         "#]],
-        #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
         expect![[r#"
             VMOutcome: balance 4 storage_usage 12 return data None burnt gas 13054614261 used gas 13054614261
         "#]],
@@ -193,9 +178,8 @@ fn test_limit_contract_functions_number() {
     .protocol_features(&[
         ProtocolFeature::LimitContractFunctionsNumber,
         ProtocolFeature::PreparationV2,
-        #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
-        ProtocolFeature::FixContractLoadingCost,
     ])
+    .protocol_version(FIX_CONTRACT_LOADING_COST)
     .expects(&[
         expect![[r#"
             VMOutcome: balance 4 storage_usage 12 return data None burnt gas 13049332713 used gas 13049332713
@@ -208,7 +192,6 @@ fn test_limit_contract_functions_number() {
             VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
             Err: PrepareError: Too many functions in contract.
         "#]],
-        #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
         expect![[r#"
             VMOutcome: balance 4 storage_usage 12 return data None burnt gas 13049332713 used gas 13049332713
             Err: PrepareError: Too many functions in contract.
@@ -226,9 +209,10 @@ fn test_limit_contract_functions_number() {
         )
         .protocol_features(&[
             ProtocolFeature::PreparationV2,
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
-            ProtocolFeature::FixContractLoadingCost,
         ])
+        .protocol_version(
+            FIX_CONTRACT_LOADING_COST
+                )
         .expects(&[
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
@@ -238,7 +222,6 @@ fn test_limit_contract_functions_number() {
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
                 Err: PrepareError: Too many functions in contract.
             "#]],
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 19554433713 used gas 19554433713
                 Err: PrepareError: Too many functions in contract.
@@ -256,9 +239,9 @@ fn test_limit_contract_functions_number() {
         )
         .protocol_features(&[
             ProtocolFeature::PreparationV2,
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
-            ProtocolFeature::FixContractLoadingCost,
+
         ])
+        .protocol_version(FIX_CONTRACT_LOADING_COST)
         .expects(&[
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
@@ -268,7 +251,6 @@ fn test_limit_contract_functions_number() {
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
                 Err: PrepareError: Too many functions in contract.
             "#]],
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 13051283463 used gas 13051283463
                 Err: PrepareError: Too many functions in contract.
@@ -289,9 +271,11 @@ fn test_limit_locals() {
         )
         .protocol_features(&[
             ProtocolFeature::PreparationV2,
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
-            ProtocolFeature::FixContractLoadingCost,
         ])
+
+        .protocol_version(
+            FIX_CONTRACT_LOADING_COST
+        )
         .expects(&[
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
@@ -301,7 +285,6 @@ fn test_limit_locals() {
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
                 Err: PrepareError: Error happened while deserializing the module.
             "#]],
-            #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 43682463 used gas 43682463
                 Err: PrepareError: Error happened while deserializing the module.
@@ -345,9 +328,9 @@ fn test_limit_locals_global() {
     .protocol_features(&[
         ProtocolFeature::LimitContractLocals,
         ProtocolFeature::PreparationV2,
-        #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
-        ProtocolFeature::FixContractLoadingCost,
+
     ])
+    .protocol_version(FIX_CONTRACT_LOADING_COST,)
     .expects(&[
         expect![[r#"
             VMOutcome: balance 4 storage_usage 12 return data None burnt gas 195407463 used gas 195407463
@@ -360,7 +343,6 @@ fn test_limit_locals_global() {
             VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
             Err: PrepareError: Too many locals declared in the contract.
         "#]],
-        #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
         expect![[r#"
             VMOutcome: balance 4 storage_usage 12 return data None burnt gas 195407463 used gas 195407463
             Err: PrepareError: Too many locals declared in the contract.
@@ -447,24 +429,25 @@ fn test_sandbox_only_function() {
 
 #[test]
 fn extension_saturating_float_to_int() {
-    let tb = test_builder().wat(
-        r#"
+    test_builder()
+        .wat(
+            r#"
             (module
                 (func $test_trunc (param $x f64) (result i32) (i32.trunc_sat_f64_s (local.get $x)))
             )
             "#,
-    );
-
-    #[cfg(feature = "nightly")]
-    tb.expect(&expect![[r#"
-        VMOutcome: balance 4 storage_usage 12 return data None burnt gas 48450963 used gas 48450963
-        Err: PrepareError: Error happened while deserializing the module.
-    "#]]);
-    #[cfg(not(feature = "nightly"))]
-    tb.expect(&expect![[r#"
-        VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
-        Err: PrepareError: Error happened while deserializing the module.
-    "#]]);
+        )
+        .protocol_version(FIX_CONTRACT_LOADING_COST)
+        .expects(&[
+            expect![[r#"
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
+                Err: PrepareError: Error happened while deserializing the module.
+            "#]],
+            expect![[r#"
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 48450963 used gas 48450963
+                Err: PrepareError: Error happened while deserializing the module.
+            "#]],
+        ]);
 }
 
 #[test]

--- a/runtime/near-vm-runner/src/wasmer2_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer2_runner.rs
@@ -580,21 +580,10 @@ impl crate::runner::VM for Wasmer2VM {
         // FIXME: this mostly duplicates the `run_module` method.
         // Note that we don't clone the actual backing memory, just increase the RC.
         let vmmemory = memory.vm();
-        let mut logic = VMLogic::new_with_protocol_version(
-            ext,
-            context,
-            &self.config,
-            fees_config,
-            promise_results,
-            &mut memory,
-            current_protocol_version,
-        );
+        let mut logic =
+            VMLogic::new(ext, context, &self.config, fees_config, promise_results, &mut memory);
 
-        let result = logic.before_loading_executable(
-            method_name,
-            current_protocol_version,
-            code.code().len(),
-        );
+        let result = logic.before_loading_executable(method_name, code.code().len());
         if let Err(e) = result {
             return Ok(VMOutcome::abort(logic, e));
         }
@@ -607,7 +596,7 @@ impl crate::runner::VM for Wasmer2VM {
             }
         };
 
-        let result = logic.after_loading_executable(current_protocol_version, code.code().len());
+        let result = logic.after_loading_executable(code.code().len());
         if let Err(e) = result {
             return Ok(VMOutcome::abort(logic, e));
         }
@@ -618,11 +607,7 @@ impl crate::runner::VM for Wasmer2VM {
             artifact.engine(),
         );
         if let Err(e) = get_entrypoint_index(&*artifact, method_name) {
-            return Ok(VMOutcome::abort_but_nop_outcome_in_old_protocol(
-                logic,
-                e,
-                current_protocol_version,
-            ));
+            return Ok(VMOutcome::abort_but_nop_outcome_in_old_protocol(logic, e));
         }
         match self.run_method(&artifact, import, method_name)? {
             Ok(()) => Ok(VMOutcome::ok(logic)),

--- a/runtime/near-vm-runner/src/wasmtime_runner.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner.rs
@@ -175,21 +175,10 @@ impl crate::runner::VM for WasmtimeVM {
         )
         .unwrap();
         let memory_copy = memory.0;
-        let mut logic = VMLogic::new_with_protocol_version(
-            ext,
-            context,
-            &self.config,
-            fees_config,
-            promise_results,
-            &mut memory,
-            current_protocol_version,
-        );
+        let mut logic =
+            VMLogic::new(ext, context, &self.config, fees_config, promise_results, &mut memory);
 
-        let result = logic.before_loading_executable(
-            method_name,
-            current_protocol_version,
-            code.code().len(),
-        );
+        let result = logic.before_loading_executable(method_name, code.code().len());
         if let Err(e) = result {
             return Ok(VMOutcome::abort(logic, e));
         }
@@ -205,7 +194,7 @@ impl crate::runner::VM for WasmtimeVM {
         };
         let mut linker = Linker::new(&engine);
 
-        let result = logic.after_loading_executable(current_protocol_version, code.code().len());
+        let result = logic.after_loading_executable(code.code().len());
         if let Err(e) = result {
             return Ok(VMOutcome::abort(logic, e));
         }
@@ -227,18 +216,13 @@ impl crate::runner::VM for WasmtimeVM {
                         let err = FunctionCallError::MethodResolveError(
                             MethodResolveError::MethodInvalidSignature,
                         );
-                        return Ok(VMOutcome::abort_but_nop_outcome_in_old_protocol(
-                            logic,
-                            err,
-                            current_protocol_version,
-                        ));
+                        return Ok(VMOutcome::abort_but_nop_outcome_in_old_protocol(logic, err));
                     }
                 }
                 _ => {
                     return Ok(VMOutcome::abort_but_nop_outcome_in_old_protocol(
                         logic,
                         FunctionCallError::MethodResolveError(MethodResolveError::MethodNotFound),
-                        current_protocol_version,
                     ));
                 }
             },
@@ -246,7 +230,6 @@ impl crate::runner::VM for WasmtimeVM {
                 return Ok(VMOutcome::abort_but_nop_outcome_in_old_protocol(
                     logic,
                     FunctionCallError::MethodResolveError(MethodResolveError::MethodNotFound),
-                    current_protocol_version,
                 ));
             }
         }
@@ -263,7 +246,6 @@ impl crate::runner::VM for WasmtimeVM {
                     return Ok(VMOutcome::abort_but_nop_outcome_in_old_protocol(
                         logic,
                         FunctionCallError::MethodResolveError(MethodResolveError::MethodNotFound),
-                        current_protocol_version,
                     ));
                 }
             },

--- a/runtime/runtime-params-estimator/src/costs_to_runtime_config.rs
+++ b/runtime/runtime-params-estimator/src/costs_to_runtime_config.rs
@@ -36,6 +36,9 @@ pub fn costs_to_runtime_config(cost_table: &CostTable) -> anyhow::Result<Runtime
             regular_op_cost: u32::try_from(regular_op_cost).unwrap(),
             disable_9393_fix: false,
             limit_config: vm_limit_config,
+            flat_storage_reads: true,
+            fix_contract_loading_cost: false,
+            implicit_account_creation: true,
         },
         account_creation_config: AccountCreationConfig::default(),
     };

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -896,9 +896,8 @@ pub(crate) fn check_account_existence(
                 }
                 .into());
             } else {
-                if checked_feature!("stable", ImplicitAccountCreation, current_protocol_version)
-                    && account_id.is_implicit()
-                {
+                // TODO: this should be `config.implicit_account_creation`.
+                if config.wasm_config.implicit_account_creation && account_id.is_implicit() {
                     // If the account doesn't exist and it's 64-length hex account ID, then you
                     // should only be able to create it using single transfer action.
                     // Because you should not be able to add another access key to the account in
@@ -917,11 +916,8 @@ pub(crate) fn check_account_existence(
         }
         Action::Transfer(_) => {
             if account.is_none() {
-                return if checked_feature!(
-                    "stable",
-                    ImplicitAccountCreation,
-                    current_protocol_version
-                ) && is_the_only_action
+                return if config.wasm_config.implicit_account_creation
+                    && is_the_only_action
                     && account_id.is_implicit()
                     && !is_refund
                 {
@@ -1374,7 +1370,7 @@ mod tests {
                 &Action::Delegate(signed_delegate_action),
                 &mut None,
                 &sender_id,
-                1,
+                &RuntimeConfig::test(),
                 false,
                 false
             ),

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -684,11 +684,7 @@ pub(crate) fn apply_delegate_action(
     // Some contracts refund the deposit. Usually they refund the deposit to the predecessor and this is sender_id/Sender from DelegateAction.
     // Therefore Relayer should verify DelegateAction before submitting it because it spends the attached deposit.
 
-    let prepaid_send_fees = total_prepaid_send_fees(
-        &apply_state.config,
-        &action_receipt.actions,
-        apply_state.current_protocol_version,
-    )?;
+    let prepaid_send_fees = total_prepaid_send_fees(&apply_state.config, &action_receipt.actions)?;
     let required_gas = receipt_required_gas(apply_state, &new_receipt)?;
     // This gas will be burnt by the receiver of the created receipt,
     result.gas_used = safe_add_gas(result.gas_used, required_gas)?;
@@ -712,7 +708,6 @@ fn receipt_required_gas(apply_state: &ApplyState, receipt: &Receipt) -> Result<G
                     &apply_state.config,
                     &action_receipt.actions,
                     &receipt.receiver_id,
-                    apply_state.current_protocol_version,
                 )?,
                 total_prepaid_gas(&action_receipt.actions)?,
             )?;
@@ -884,7 +879,7 @@ pub(crate) fn check_account_existence(
     action: &Action,
     account: &mut Option<Account>,
     account_id: &AccountId,
-    current_protocol_version: ProtocolVersion,
+    config: &RuntimeConfig,
     is_the_only_action: bool,
     is_refund: bool,
 ) -> Result<(), ActionError> {

--- a/runtime/runtime/src/config.rs
+++ b/runtime/runtime/src/config.rs
@@ -15,7 +15,6 @@ use near_primitives::transaction::{
     Action, AddKeyAction, DeployContractAction, FunctionCallAction, Transaction,
 };
 use near_primitives::types::{AccountId, Balance, Compute, Gas};
-use near_primitives::version::ProtocolVersion;
 
 /// Describes the cost of converting this transaction into a receipt.
 #[derive(Debug)]
@@ -77,7 +76,6 @@ pub fn total_send_fees(
     sender_is_receiver: bool,
     actions: &[Action],
     receiver_id: &AccountId,
-    current_protocol_version: ProtocolVersion,
 ) -> Result<Gas, IntegerOverflowError> {
     let mut result = 0;
     let fees = &config.fees;
@@ -101,8 +99,7 @@ pub fn total_send_fees(
             Transfer(_) => {
                 // Account for implicit account creation
                 let is_receiver_implicit =
-                    checked_feature!("stable", ImplicitAccountCreation, current_protocol_version)
-                        && receiver_id.is_implicit();
+                    config.wasm_config.implicit_account_creation && receiver_id.is_implicit();
                 transfer_send_fee(fees, sender_is_receiver, is_receiver_implicit)
             }
             Stake(_) => fees.fee(ActionCosts::stake).send_fee(sender_is_receiver),
@@ -136,7 +133,6 @@ pub fn total_send_fees(
                         sender_is_receiver,
                         &delegate_action.get_actions(),
                         &delegate_action.receiver_id,
-                        current_protocol_version,
                     )?
             }
         };
@@ -153,7 +149,6 @@ pub fn total_send_fees(
 pub fn total_prepaid_send_fees(
     config: &RuntimeConfig,
     actions: &[Action],
-    current_protocol_version: ProtocolVersion,
 ) -> Result<Gas, IntegerOverflowError> {
     let mut result = 0;
     for action in actions {
@@ -168,7 +163,6 @@ pub fn total_prepaid_send_fees(
                     sender_is_receiver,
                     &delegate_action.get_actions(),
                     &delegate_action.receiver_id,
-                    current_protocol_version,
                 )?
             }
             _ => 0,
@@ -178,12 +172,7 @@ pub fn total_prepaid_send_fees(
     Ok(result)
 }
 
-pub fn exec_fee(
-    config: &RuntimeConfig,
-    action: &Action,
-    receiver_id: &AccountId,
-    current_protocol_version: ProtocolVersion,
-) -> Gas {
+pub fn exec_fee(config: &RuntimeConfig, action: &Action, receiver_id: &AccountId) -> Gas {
     use Action::*;
     let fees = &config.fees;
     match action {
@@ -201,8 +190,7 @@ pub fn exec_fee(
         Transfer(_) => {
             // Account for implicit account creation
             let is_receiver_implicit =
-                checked_feature!("stable", ImplicitAccountCreation, current_protocol_version)
-                    && receiver_id.is_implicit();
+                config.wasm_config.implicit_account_creation && receiver_id.is_implicit();
             transfer_exec_fee(fees, is_receiver_implicit)
         }
         Stake(_) => fees.fee(ActionCosts::stake).exec_fee(),
@@ -233,7 +221,6 @@ pub fn tx_cost(
     transaction: &Transaction,
     gas_price: Balance,
     sender_is_receiver: bool,
-    current_protocol_version: ProtocolVersion,
 ) -> Result<TransactionCost, IntegerOverflowError> {
     let fees = &config.fees;
     let mut gas_burnt: Gas = fees.fee(ActionCosts::new_action_receipt).send_fee(sender_is_receiver);
@@ -244,12 +231,11 @@ pub fn tx_cost(
             sender_is_receiver,
             &transaction.actions,
             &transaction.receiver_id,
-            current_protocol_version,
         )?,
     )?;
     let prepaid_gas = safe_add_gas(
         total_prepaid_gas(&transaction.actions)?,
-        total_prepaid_send_fees(config, &transaction.actions, current_protocol_version)?,
+        total_prepaid_send_fees(config, &transaction.actions)?,
     )?;
     // If signer is equals to receiver the receipt will be processed at the same block as this
     // transaction. Otherwise it will processed in the next block and the gas might be inflated.
@@ -274,12 +260,7 @@ pub fn tx_cost(
         safe_add_gas(prepaid_gas, fees.fee(ActionCosts::new_action_receipt).exec_fee())?;
     gas_remaining = safe_add_gas(
         gas_remaining,
-        total_prepaid_exec_fees(
-            config,
-            &transaction.actions,
-            &transaction.receiver_id,
-            current_protocol_version,
-        )?,
+        total_prepaid_exec_fees(config, &transaction.actions, &transaction.receiver_id)?,
     )?;
     let burnt_amount = safe_gas_to_balance(gas_price, gas_burnt)?;
     let remaining_gas_amount = safe_gas_to_balance(receipt_gas_price, gas_remaining)?;
@@ -293,7 +274,6 @@ pub fn total_prepaid_exec_fees(
     config: &RuntimeConfig,
     actions: &[Action],
     receiver_id: &AccountId,
-    current_protocol_version: ProtocolVersion,
 ) -> Result<Gas, IntegerOverflowError> {
     let mut result = 0;
     let fees = &config.fees;
@@ -306,20 +286,14 @@ pub fn total_prepaid_exec_fees(
                 config,
                 &actions,
                 &signed_delegate_action.delegate_action.receiver_id,
-                current_protocol_version,
             )?;
             delta = safe_add_gas(
                 delta,
-                exec_fee(
-                    config,
-                    action,
-                    &signed_delegate_action.delegate_action.receiver_id,
-                    current_protocol_version,
-                ),
+                exec_fee(config, action, &signed_delegate_action.delegate_action.receiver_id),
             )?;
             delta = safe_add_gas(delta, fees.fee(ActionCosts::new_action_receipt).exec_fee())?;
         } else {
-            delta = exec_fee(config, action, receiver_id, current_protocol_version);
+            delta = exec_fee(config, action, receiver_id);
         }
 
         result = safe_add_gas(result, delta)?;

--- a/runtime/runtime/src/config.rs
+++ b/runtime/runtime/src/config.rs
@@ -15,7 +15,7 @@ use near_primitives::transaction::{
     Action, AddKeyAction, DeployContractAction, FunctionCallAction, Transaction,
 };
 use near_primitives::types::{AccountId, Balance, Compute, Gas};
-use near_primitives::version::{checked_feature, ProtocolVersion};
+use near_primitives::version::ProtocolVersion;
 
 /// Describes the cost of converting this transaction into a receipt.
 #[derive(Debug)]

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -383,11 +383,7 @@ impl Runtime {
                     }
                 } else {
                     // Implicit account creation
-                    debug_assert!(checked_feature!(
-                        "stable",
-                        ImplicitAccountCreation,
-                        apply_state.current_protocol_version
-                    ));
+                    debug_assert!(apply_state.config.wasm_config.implicit_account_creation);
                     debug_assert!(!is_refund);
                     action_implicit_account_creation_transfer(
                         state_update,

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -298,12 +298,7 @@ impl Runtime {
         actions: &[Action],
         epoch_info_provider: &dyn EpochInfoProvider,
     ) -> Result<ActionResult, RuntimeError> {
-        let exec_fees = exec_fee(
-            &apply_state.config,
-            action,
-            &receipt.receiver_id,
-            apply_state.current_protocol_version,
-        );
+        let exec_fees = exec_fee(&apply_state.config, action, &receipt.receiver_id);
         let mut result = ActionResult::default();
         result.gas_used = exec_fees;
         result.gas_burnt = exec_fees;
@@ -317,7 +312,7 @@ impl Runtime {
             action,
             account,
             account_id,
-            apply_state.current_protocol_version,
+            &apply_state.config,
             is_the_only_action,
             is_refund,
         ) {
@@ -609,7 +604,6 @@ impl Runtime {
                 receipt,
                 action_receipt,
                 &mut result,
-                apply_state.current_protocol_version,
                 &apply_state.config,
             )?
         };
@@ -768,21 +762,15 @@ impl Runtime {
         receipt: &Receipt,
         action_receipt: &ActionReceipt,
         result: &mut ActionResult,
-        current_protocol_version: ProtocolVersion,
         config: &RuntimeConfig,
     ) -> Result<Balance, RuntimeError> {
         let total_deposit = total_deposit(&action_receipt.actions)?;
         let prepaid_gas = safe_add_gas(
             total_prepaid_gas(&action_receipt.actions)?,
-            total_prepaid_send_fees(config, &action_receipt.actions, current_protocol_version)?,
+            total_prepaid_send_fees(config, &action_receipt.actions)?,
         )?;
         let prepaid_exec_gas = safe_add_gas(
-            total_prepaid_exec_fees(
-                config,
-                &action_receipt.actions,
-                &receipt.receiver_id,
-                current_protocol_version,
-            )?,
+            total_prepaid_exec_fees(config, &action_receipt.actions, &receipt.receiver_id)?,
             config.fees.fee(ActionCosts::new_action_receipt).exec_fee(),
         )?;
         let deposit_refund = if result.result.is_err() { total_deposit } else { 0 };
@@ -1462,7 +1450,6 @@ impl Runtime {
             transactions,
             &outgoing_receipts,
             &stats,
-            apply_state.current_protocol_version,
         )?;
 
         state_update.commit(StateChangeCause::UpdatedDelayedReceipts);
@@ -2246,13 +2233,7 @@ mod tests {
 
         let expected_gas_burnt = safe_add_gas(
             apply_state.config.fees.fee(ActionCosts::new_action_receipt).exec_fee(),
-            total_prepaid_exec_fees(
-                &apply_state.config,
-                &actions,
-                &alice_account(),
-                PROTOCOL_VERSION,
-            )
-            .unwrap(),
+            total_prepaid_exec_fees(&apply_state.config, &actions, &alice_account()).unwrap(),
         )
         .unwrap();
         let receipts = vec![Receipt {
@@ -2315,13 +2296,7 @@ mod tests {
 
         let expected_gas_burnt = safe_add_gas(
             apply_state.config.fees.fee(ActionCosts::new_action_receipt).exec_fee(),
-            total_prepaid_exec_fees(
-                &apply_state.config,
-                &actions,
-                &alice_account(),
-                PROTOCOL_VERSION,
-            )
-            .unwrap(),
+            total_prepaid_exec_fees(&apply_state.config, &actions, &alice_account()).unwrap(),
         )
         .unwrap();
         let receipts = vec![Receipt {

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -123,7 +123,7 @@ pub fn validate_transaction(
 
     let sender_is_receiver = &transaction.receiver_id == signer_id;
 
-    tx_cost(&config, transaction, gas_price, sender_is_receiver, current_protocol_version)
+    tx_cost(&config, transaction, gas_price, sender_is_receiver)
         .map_err(|_| InvalidTxError::CostOverflow.into())
 }
 

--- a/test-utils/testlib/src/fees_utils.rs
+++ b/test-utils/testlib/src/fees_utils.rs
@@ -5,7 +5,6 @@ use near_primitives::runtime::config::RuntimeConfig;
 use near_primitives::runtime::fees::RuntimeFeesConfig;
 use near_primitives::transaction::Action;
 use near_primitives::types::{AccountId, Balance, Gas};
-use near_primitives::version::PROTOCOL_VERSION;
 
 pub struct FeeHelper {
     pub rt_cfg: RuntimeConfig,
@@ -182,14 +181,7 @@ impl FeeHelper {
         let total_gas = base.exec_fee()
             + base.send_fee(sir)
             + receipt.send_fee(sir)
-            + node_runtime::config::total_send_fees(
-                &self.rt_cfg,
-                sir,
-                actions,
-                receiver,
-                PROTOCOL_VERSION,
-            )
-            .unwrap();
+            + node_runtime::config::total_send_fees(&self.rt_cfg, sir, actions, receiver).unwrap();
         self.gas_to_balance(total_gas)
     }
 }


### PR DESCRIPTION
This PR is built on top of a previous PR (see the base branch). Here the noted protocol features have been replaced with runtime configuration via parameters instead.

This would be one solution/option to getting rid of compile-time features in contract runtime which is interfering with limited replayability (compile-time feature control means that all of the crates still need to be built as a single compilation unit with consistent options.)

cc @jakmeier 

cc  #8197