### PR TITLE
fix: Verbose handler spans

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -5729,10 +5729,13 @@ pub struct ApplyStatePartsRequest {
     pub sync_hash: CryptoHash,
 }
 
-// Partial implementation that skips `runtime_adapter`.
+// Partial implementation that skips `runtime_adapter`, because
+// `runtime_adapter` is a complex object that has complex logic and many
+// fields.
 impl Debug for ApplyStatePartsRequest {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ApplyStatePartsRequest")
+            .field("runtime_adapter", &"<not shown>")
             .field("shard_uid", &self.shard_uid)
             .field("state_root", &self.state_root)
             .field("num_parts", &self.num_parts)
@@ -5759,7 +5762,7 @@ pub struct BlockCatchUpRequest {
     pub work: Vec<Box<dyn FnOnce(&Span) -> Result<ApplyChunkResult, Error> + Send>>,
 }
 
-// Partial implementation that skips `work` because formatting closures is not
+// Partial implementation that skips `work`, because displaying functions is not
 // possible.
 impl Debug for BlockCatchUpRequest {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -5767,7 +5770,7 @@ impl Debug for BlockCatchUpRequest {
             .field("sync_hash", &self.sync_hash)
             .field("block_hash", &self.block_hash)
             .field("block_height", &self.block_height)
-            .field("work_len", &self.work.len())
+            .field("work", &format!("<vector of length {}>", self.work.len()))
             .finish()
     }
 }

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -83,6 +83,7 @@ use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use std::collections::{HashMap, HashSet};
+use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 use std::time::{Duration as TimeDuration, Instant};
 use tracing::{debug, error, info, warn, Span};
@@ -4819,6 +4820,7 @@ pub struct ChainUpdate<'a> {
     transaction_validity_period: BlockHeightDelta,
 }
 
+#[derive(Debug)]
 pub struct SameHeightResult {
     shard_uid: ShardUId,
     gas_limit: Gas,
@@ -4826,18 +4828,21 @@ pub struct SameHeightResult {
     apply_split_result_or_state_changes: Option<ApplySplitStateResultOrStateChanges>,
 }
 
+#[derive(Debug)]
 pub struct DifferentHeightResult {
     shard_uid: ShardUId,
     apply_result: ApplyTransactionResult,
     apply_split_result_or_state_changes: Option<ApplySplitStateResultOrStateChanges>,
 }
 
+#[derive(Debug)]
 pub struct SplitStateResult {
     // parent shard of the split states
     shard_uid: ShardUId,
     results: Vec<ApplySplitStateResult>,
 }
 
+#[derive(Debug)]
 pub enum ApplyChunkResult {
     SameHeight(SameHeightResult),
     DifferentHeight(DifferentHeightResult),
@@ -5724,7 +5729,20 @@ pub struct ApplyStatePartsRequest {
     pub sync_hash: CryptoHash,
 }
 
-#[derive(actix::Message)]
+// Partial implementation that skips `runtime_adapter`.
+impl Debug for ApplyStatePartsRequest {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApplyStatePartsRequest")
+            .field("shard_uid", &self.shard_uid)
+            .field("state_root", &self.state_root)
+            .field("num_parts", &self.num_parts)
+            .field("epoch_id", &self.epoch_id)
+            .field("sync_hash", &self.sync_hash)
+            .finish()
+    }
+}
+
+#[derive(actix::Message, Debug)]
 #[rtype(result = "()")]
 pub struct ApplyStatePartsResponse {
     pub apply_result: Result<(), near_chain_primitives::error::Error>,
@@ -5741,7 +5759,20 @@ pub struct BlockCatchUpRequest {
     pub work: Vec<Box<dyn FnOnce(&Span) -> Result<ApplyChunkResult, Error> + Send>>,
 }
 
-#[derive(actix::Message)]
+// Partial implementation that skips `work` because formatting closures is not
+// possible.
+impl Debug for BlockCatchUpRequest {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BlockCatchUpRequest")
+            .field("sync_hash", &self.sync_hash)
+            .field("block_hash", &self.block_hash)
+            .field("block_height", &self.block_height)
+            .field("work_len", &self.work.len())
+            .finish()
+    }
+}
+
+#[derive(actix::Message, Debug)]
 #[rtype(result = "()")]
 pub struct BlockCatchUpResponse {
     pub sync_hash: CryptoHash,

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -5735,9 +5735,8 @@ pub struct ApplyStatePartsRequest {
     pub sync_hash: CryptoHash,
 }
 
-// Partial implementation that skips `runtime_adapter`, because
-// `runtime_adapter` is a complex object that has complex logic and many
-// fields.
+// Skip `runtime_adapter`, because it's a complex object that has complex logic
+// and many fields.
 impl Debug for ApplyStatePartsRequest {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ApplyStatePartsRequest")
@@ -5768,8 +5767,7 @@ pub struct BlockCatchUpRequest {
     pub work: Vec<Box<dyn FnOnce(&Span) -> Result<ApplyChunkResult, Error> + Send>>,
 }
 
-// Partial implementation that skips `work`, because displaying functions is not
-// possible.
+// Skip `work`, because displaying functions is not possible.
 impl Debug for BlockCatchUpRequest {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("BlockCatchUpRequest")

--- a/chain/chain/src/resharding.rs
+++ b/chain/chain/src/resharding.rs
@@ -32,10 +32,13 @@ pub struct StateSplitRequest {
     pub next_epoch_shard_layout: ShardLayout,
 }
 
-// Partial implementation that skips `runtime_adapter`.
+// Partial implementation that skips `runtime_adapter`, because
+// `runtime_adapter` is a complex object that has complex logic and many
+// fields.
 impl Debug for StateSplitRequest {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("StateSplitRequest")
+            .field("runtime_adapter", &"<not shown>")
             .field("sync_hash", &self.sync_hash)
             .field("shard_uid", &self.shard_uid)
             .field("state_root", &self.state_root)

--- a/chain/chain/src/resharding.rs
+++ b/chain/chain/src/resharding.rs
@@ -32,9 +32,8 @@ pub struct StateSplitRequest {
     pub next_epoch_shard_layout: ShardLayout,
 }
 
-// Partial implementation that skips `runtime_adapter`, because
-// `runtime_adapter` is a complex object that has complex logic and many
-// fields.
+// Skip `runtime_adapter`, because it's a complex object that has complex logic
+// and many fields.
 impl Debug for StateSplitRequest {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("StateSplitRequest")

--- a/chain/chain/src/resharding.rs
+++ b/chain/chain/src/resharding.rs
@@ -4,6 +4,7 @@
 /// by the client_actor while the heavy resharding build_state_for_split_shards is done by SyncJobsActor
 /// so as to not affect client.
 use std::collections::{HashMap, HashSet};
+use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
 use near_chain_primitives::error::Error;
@@ -31,7 +32,19 @@ pub struct StateSplitRequest {
     pub next_epoch_shard_layout: ShardLayout,
 }
 
-#[derive(actix::Message)]
+// Partial implementation that skips `runtime_adapter`.
+impl Debug for StateSplitRequest {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StateSplitRequest")
+            .field("sync_hash", &self.sync_hash)
+            .field("shard_uid", &self.shard_uid)
+            .field("state_root", &self.state_root)
+            .field("next_epoch_shard_layout", &self.next_epoch_shard_layout)
+            .finish()
+    }
+}
+
+#[derive(actix::Message, Debug)]
 #[rtype(result = "()")]
 pub struct StateSplitResponse {
     pub sync_hash: CryptoHash,

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -75,6 +75,7 @@ pub struct AcceptedBlock {
     pub provenance: Provenance,
 }
 
+#[derive(Debug)]
 pub struct ApplySplitStateResult {
     pub shard_uid: ShardUId,
     pub trie_changes: WrappedTrieChanges,
@@ -86,11 +87,13 @@ pub struct ApplySplitStateResult {
 // if it's ready, apply transactions also apply updates to split states and this enum will be
 //    ApplySplitStateResults
 // otherwise, it simply returns the state changes needed to be applied to split states
+#[derive(Debug)]
 pub enum ApplySplitStateResultOrStateChanges {
     ApplySplitStateResults(Vec<ApplySplitStateResult>),
     StateChangesForSplitStates(StateChangesForSplitStates),
 }
 
+#[derive(Debug)]
 pub struct ApplyTransactionResult {
     pub trie_changes: WrappedTrieChanges,
     pub new_root: StateRoot,

--- a/chain/client-primitives/src/debug.rs
+++ b/chain/client-primitives/src/debug.rs
@@ -167,6 +167,7 @@ pub struct ValidatorStatus {
 }
 
 // Different debug requests that can be sent by HTML pages, via GET.
+#[derive(Debug)]
 pub enum DebugStatus {
     // Request for the current sync status
     SyncStatus,

--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -372,6 +372,7 @@ impl From<SyncStatus> for SyncStatusView {
 }
 
 /// Actor message requesting block by id, hash or sync state.
+#[derive(Debug)]
 pub struct GetBlock(pub BlockReference);
 
 #[derive(thiserror::Error, Debug)]
@@ -415,6 +416,7 @@ impl Message for GetBlock {
 }
 
 /// Get block with the block merkle tree. Used for testing
+#[derive(Debug)]
 pub struct GetBlockWithMerkleTree(pub BlockReference);
 
 impl GetBlockWithMerkleTree {
@@ -428,6 +430,7 @@ impl Message for GetBlockWithMerkleTree {
 }
 
 /// Actor message requesting a chunk by chunk hash and block hash + shard id.
+#[derive(Debug)]
 pub enum GetChunk {
     Height(BlockHeight, ShardId),
     BlockHash(CryptoHash, ShardId),
@@ -558,6 +561,7 @@ pub enum QueryError {
     Unreachable { error_message: String },
 }
 
+#[derive(Debug)]
 pub struct Status {
     pub is_health_check: bool,
     // If true - return more detailed information about the current status (recent blocks etc).
@@ -604,6 +608,7 @@ impl Message for Status {
     type Result = Result<StatusResponse, StatusError>;
 }
 
+#[derive(Debug)]
 pub struct GetNextLightClientBlock {
     pub last_block_hash: CryptoHash,
 }
@@ -645,12 +650,14 @@ impl Message for GetNextLightClientBlock {
     type Result = Result<Option<Arc<LightClientBlockView>>, GetNextLightClientBlockError>;
 }
 
+#[derive(Debug)]
 pub struct GetNetworkInfo {}
 
 impl Message for GetNetworkInfo {
     type Result = Result<NetworkInfoResponse, String>;
 }
 
+#[derive(Debug)]
 pub struct GetGasPrice {
     pub block_id: MaybeBlockId,
 }
@@ -739,6 +746,7 @@ impl Message for TxStatus {
     type Result = Result<Option<FinalExecutionOutcomeViewEnum>, TxStatusError>;
 }
 
+#[derive(Debug)]
 pub struct GetValidatorInfo {
     pub epoch_reference: EpochReference,
 }
@@ -774,6 +782,7 @@ impl From<near_chain_primitives::Error> for GetValidatorInfoError {
     }
 }
 
+#[derive(Debug)]
 pub struct GetValidatorOrdered {
     pub block_id: MaybeBlockId,
 }
@@ -782,6 +791,7 @@ impl Message for GetValidatorOrdered {
     type Result = Result<Vec<ValidatorStakeView>, GetValidatorInfoError>;
 }
 
+#[derive(Debug)]
 pub struct GetStateChanges {
     pub block_hash: CryptoHash,
     pub state_changes_request: StateChangesRequestView,
@@ -821,6 +831,7 @@ impl Message for GetStateChanges {
     type Result = Result<StateChangesView, GetStateChangesError>;
 }
 
+#[derive(Debug)]
 pub struct GetStateChangesInBlock {
     pub block_hash: CryptoHash,
 }
@@ -829,6 +840,7 @@ impl Message for GetStateChangesInBlock {
     type Result = Result<StateChangesKindsView, GetStateChangesError>;
 }
 
+#[derive(Debug)]
 pub struct GetStateChangesWithCauseInBlock {
     pub block_hash: CryptoHash,
 }
@@ -837,6 +849,7 @@ impl Message for GetStateChangesWithCauseInBlock {
     type Result = Result<StateChangesView, GetStateChangesError>;
 }
 
+#[derive(Debug)]
 pub struct GetStateChangesWithCauseInBlockForTrackedShards {
     pub block_hash: CryptoHash,
     pub epoch_id: EpochId,
@@ -846,6 +859,7 @@ impl Message for GetStateChangesWithCauseInBlockForTrackedShards {
     type Result = Result<HashMap<ShardId, StateChangesView>, GetStateChangesError>;
 }
 
+#[derive(Debug)]
 pub struct GetExecutionOutcome {
     pub id: TransactionOrReceiptId,
 }
@@ -912,6 +926,7 @@ impl Message for GetExecutionOutcome {
     type Result = Result<GetExecutionOutcomeResponse, GetExecutionOutcomeError>;
 }
 
+#[derive(Debug)]
 pub struct GetExecutionOutcomesForBlock {
     pub block_hash: CryptoHash,
 }
@@ -920,6 +935,7 @@ impl Message for GetExecutionOutcomesForBlock {
     type Result = Result<HashMap<ShardId, Vec<ExecutionOutcomeWithIdView>>, String>;
 }
 
+#[derive(Debug)]
 pub struct GetBlockProof {
     pub block_hash: CryptoHash,
     pub head_block_hash: CryptoHash,
@@ -962,6 +978,7 @@ impl Message for GetBlockProof {
     type Result = Result<GetBlockProofResponse, GetBlockProofError>;
 }
 
+#[derive(Debug)]
 pub struct GetReceipt {
     pub receipt_id: CryptoHash,
 }
@@ -993,6 +1010,7 @@ impl Message for GetReceipt {
     type Result = Result<Option<ReceiptView>, GetReceiptError>;
 }
 
+#[derive(Debug)]
 pub struct GetProtocolConfig(pub BlockReference);
 
 impl Message for GetProtocolConfig {
@@ -1023,6 +1041,7 @@ impl From<near_chain_primitives::Error> for GetProtocolConfigError {
     }
 }
 
+#[derive(Debug)]
 pub struct GetMaintenanceWindows {
     pub account_id: AccountId,
 }
@@ -1048,6 +1067,7 @@ impl From<near_chain_primitives::Error> for GetMaintenanceWindowsError {
     }
 }
 
+#[derive(Debug)]
 pub struct GetClientConfig {}
 
 impl Message for GetClientConfig {
@@ -1075,6 +1095,7 @@ impl From<near_chain_primitives::Error> for GetClientConfigError {
     }
 }
 
+#[derive(Debug)]
 pub struct GetSplitStorageInfo {}
 
 impl Message for GetSplitStorageInfo {

--- a/chain/client/src/adapter.rs
+++ b/chain/client/src/adapter.rs
@@ -16,7 +16,7 @@ use near_primitives::types::{AccountId, EpochId, ShardId};
 use near_primitives::views::FinalExecutionOutcomeView;
 
 /// Transaction status query
-#[derive(actix::Message)]
+#[derive(actix::Message, Debug)]
 #[rtype(result = "Option<Box<FinalExecutionOutcomeView>>")]
 pub(crate) struct TxStatusRequest {
     pub tx_hash: CryptoHash,
@@ -24,12 +24,12 @@ pub(crate) struct TxStatusRequest {
 }
 
 /// Transaction status response
-#[derive(actix::Message)]
+#[derive(actix::Message, Debug)]
 #[rtype(result = "()")]
 pub(crate) struct TxStatusResponse(pub Box<FinalExecutionOutcomeView>);
 
 /// Request a block.
-#[derive(actix::Message)]
+#[derive(actix::Message, Debug)]
 #[rtype(result = "Option<Box<Block>>")]
 pub(crate) struct BlockRequest(pub CryptoHash);
 
@@ -47,7 +47,7 @@ pub struct BlockResponse {
 pub struct BlockApproval(pub Approval, pub PeerId);
 
 /// Request headers.
-#[derive(actix::Message)]
+#[derive(actix::Message, Debug)]
 #[rtype(result = "Option<Vec<BlockHeader>>")]
 pub(crate) struct BlockHeadersRequest(pub Vec<CryptoHash>);
 
@@ -57,7 +57,7 @@ pub(crate) struct BlockHeadersRequest(pub Vec<CryptoHash>);
 pub(crate) struct BlockHeadersResponse(pub Vec<BlockHeader>, pub PeerId);
 
 /// State request header.
-#[derive(actix::Message)]
+#[derive(actix::Message, Debug)]
 #[rtype(result = "Option<StateResponse>")]
 pub(crate) struct StateRequestHeader {
     pub shard_id: ShardId,
@@ -81,7 +81,7 @@ pub(crate) struct StateResponse(pub Box<StateResponseInfo>);
 /// Account announcements that needs to be validated before being processed.
 /// They are paired with last epoch id known to this announcement, in order to accept only
 /// newer announcements.
-#[derive(actix::Message)]
+#[derive(actix::Message, Debug)]
 #[rtype(result = "Result<Vec<AnnounceAccount>,ReasonForBan>")]
 pub(crate) struct AnnounceAccountRequest(pub Vec<(AnnounceAccount, Option<EpochId>)>);
 

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -48,7 +48,7 @@ use near_network::types::ReasonForBan;
 use near_network::types::{
     NetworkInfo, NetworkRequests, PeerManagerAdapter, PeerManagerMessageRequest,
 };
-use near_o11y::{handler_debug_span, OpenTelemetrySpanExt, WithSpanContext, WithSpanContextExt};
+use near_o11y::{handler_debug_span, handler_trace_span, OpenTelemetrySpanExt, WithSpanContext, WithSpanContextExt};
 use near_performance_metrics;
 use near_performance_metrics_macros::perf;
 use near_primitives::block::Tip;
@@ -262,6 +262,25 @@ impl ClientActor {
         f: impl FnOnce(&mut Self, Req) -> Res,
     ) -> Res {
         let (_span, msg) = handler_debug_span!(target: "client", msg, msg_type);
+        self.check_triggers(ctx);
+        let _d =
+            delay_detector::DelayDetector::new(|| format!("NetworkClientMessage {:?}", msg).into());
+        metrics::CLIENT_MESSAGES_COUNT.with_label_values(&[msg_type]).inc();
+        let timer =
+            metrics::CLIENT_MESSAGES_PROCESSING_TIME.with_label_values(&[msg_type]).start_timer();
+        let res = f(self, msg);
+        timer.observe_duration();
+        res
+    }
+
+    fn wrap_trace<Req: std::fmt::Debug + actix::Message, Res>(
+        &mut self,
+        msg: WithSpanContext<Req>,
+        ctx: &mut Context<Self>,
+        msg_type: &str,
+        f: impl FnOnce(&mut Self, Req) -> Res,
+    ) -> Res {
+        let (_span, msg) = handler_trace_span!(target: "client", msg, msg_type);
         self.check_triggers(ctx);
         let _d =
             delay_detector::DelayDetector::new(|| format!("NetworkClientMessage {:?}", msg).into());
@@ -557,7 +576,7 @@ impl Handler<WithSpanContext<SetNetworkInfo>> for ClientActor {
     type Result = ();
 
     fn handle(&mut self, msg: WithSpanContext<SetNetworkInfo>, ctx: &mut Context<Self>) {
-        self.wrap(msg, ctx, "SetNetworkInfo", |this, msg| {
+        self.wrap_trace(msg, ctx, "SetNetworkInfo", |this, msg| {
             let SetNetworkInfo(network_info) = msg;
             this.network_info = network_info;
         })

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -787,7 +787,7 @@ impl Handler<WithSpanContext<GetNetworkInfo>> for ClientActor {
 /// `ApplyChunksDoneMessage` is a message that signals the finishing of applying chunks of a block.
 /// Upon receiving this message, ClientActors knows that it's time to finish processing the blocks that
 /// just finished applying chunks.
-#[derive(actix::Message)]
+#[derive(actix::Message, Debug)]
 #[rtype(result = "()")]
 pub struct ApplyChunksDoneMessage;
 

--- a/chain/network/src/test_utils.rs
+++ b/chain/network/src/test_utils.rs
@@ -182,7 +182,7 @@ pub fn expected_routing_tables(
 }
 
 /// `GetInfo` gets `NetworkInfo` from `PeerManager`.
-#[derive(actix::Message)]
+#[derive(actix::Message, Debug)]
 #[rtype(result = "NetworkInfo")]
 pub struct GetInfo {}
 
@@ -196,7 +196,7 @@ impl Handler<WithSpanContext<GetInfo>> for PeerManagerActor {
 }
 
 // `StopSignal is used to stop PeerManagerActor for unit tests
-#[derive(actix::Message, Default)]
+#[derive(actix::Message, Default, Debug)]
 #[rtype(result = "()")]
 pub struct StopSignal {
     pub should_panic: bool,

--- a/core/o11y/src/macros.rs
+++ b/core/o11y/src/macros.rs
@@ -9,6 +9,7 @@ macro_rules! handler_span {
             "handle",
             handler = near_o11y::macros::type_name_of(&msg),
             actor = near_o11y::macros::last_component_of_name(std::any::type_name::<Self>()),
+            ?msg,
             $($extra_fields)*)
         .entered();
         span.set_parent(context);

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -726,6 +726,17 @@ pub struct WrappedTrieChanges {
     block_hash: CryptoHash,
 }
 
+// Partial implementation. Skips `tries` due to its complexity and
+// `trie_changes` and `state_changes` due to their large volume.
+impl std::fmt::Debug for WrappedTrieChanges {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WrappedTrieChanges")
+            .field("shard_uid", &self.shard_uid)
+            .field("block_hash", &self.block_hash)
+            .finish()
+    }
+}
+
 impl WrappedTrieChanges {
     pub fn new(
         tries: ShardTries,

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -731,7 +731,10 @@ pub struct WrappedTrieChanges {
 impl std::fmt::Debug for WrappedTrieChanges {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("WrappedTrieChanges")
+            .field("tries", &"<not shown>")
             .field("shard_uid", &self.shard_uid)
+            .field("trie_changes", &"<not shown>")
+            .field("state_changes", &"<not shown>")
             .field("block_hash", &self.block_hash)
             .finish()
     }

--- a/integration-tests/src/tests/client/chunks_management.rs
+++ b/integration-tests/src/tests/client/chunks_management.rs
@@ -138,6 +138,9 @@ impl Test {
 
                         if h > 1 {
                             // Make sure doomslug finality is computed correctly.
+                            assert!(
+                                height_to_hash.get(&(h-1)).is_some(),
+                                "h: {h}, last_ds_final_block: {:?}, height_to_hash: {height_to_hash:?}", block.header().last_ds_final_block());
                             assert_eq!(
                                 block.header().last_ds_final_block(),
                                 height_to_hash.get(&(h - 1)).unwrap(),

--- a/integration-tests/src/tests/client/chunks_management.rs
+++ b/integration-tests/src/tests/client/chunks_management.rs
@@ -138,13 +138,10 @@ impl Test {
 
                         if h > 1 {
                             // Make sure doomslug finality is computed correctly.
-                            assert!(
-                                height_to_hash.get(&(h-1)).is_some(),
-                                "h: {h}, last_ds_final_block: {:?}, height_to_hash: {height_to_hash:?}", block.header().last_ds_final_block());
                             assert_eq!(
                                 block.header().last_ds_final_block(),
-                                height_to_hash.get(&(h - 1)).unwrap(),
-                                "h: {h}, last_ds_final_block: {:?}, height_to_hash: {height_to_hash:?}", block.header().last_ds_final_block());
+                                height_to_hash.get(&(h - 1)).unwrap()
+                            );
 
                             // Make sure epoch length actually corresponds to the desired epoch length
                             // The switches are expected at 0->1, 5->6 and 10->11

--- a/integration-tests/src/tests/client/chunks_management.rs
+++ b/integration-tests/src/tests/client/chunks_management.rs
@@ -140,8 +140,8 @@ impl Test {
                             // Make sure doomslug finality is computed correctly.
                             assert_eq!(
                                 block.header().last_ds_final_block(),
-                                height_to_hash.get(&(h - 1)).unwrap()
-                            );
+                                height_to_hash.get(&(h - 1)).unwrap(),
+                                "h: {h}, last_ds_final_block: {:?}, height_to_hash: {height_to_hash:?}", block.header().last_ds_final_block());
 
                             // Make sure epoch length actually corresponds to the desired epoch length
                             // The switches are expected at 0->1, 5->6 and 10->11


### PR DESCRIPTION
Apparently, even the most verbose logging level gives us no information about the actual actix requests processed by actix actors.
Log the request messages at the debug and trace levels.