### PR TITLE
[resharding] Initialize and write to flat storage during resharding

### DIFF
--- a/core/store/src/flat/delta.rs
+++ b/core/store/src/flat/delta.rs
@@ -109,6 +109,15 @@ impl FlatStateChanges {
         Self(delta)
     }
 
+    pub fn from_raw_key_value(entries: Vec<(Vec<u8>, Option<Vec<u8>>)>) -> Self {
+        let mut delta = HashMap::new();
+        for (key, raw_value) in entries {
+            let flat_state_value = raw_value.as_ref().map(|value| FlatStateValue::on_disk(value));
+            delta.insert(key, flat_state_value);
+        }
+        Self(delta)
+    }
+
     /// Applies delta to the flat state.
     pub fn apply_to_flat_state(self, store_update: &mut StoreUpdate, shard_uid: ShardUId) {
         for (key, value) in self.0.into_iter() {


### PR DESCRIPTION
It turns out that we were completely ignoring flat storage during resharding and we didn't really have any tests to capture this.

Flat storage was not being written to when we were splitting a shard during resharding. This PR initializes the flat storage in flat storage manager and writes data to the flat storage.

Updated tests to reflect we are writing to flat storage

Future work
- Clean up work to merge the different implementations of flat storage initialization during state sync and resharding
- Update the tests to better reflect catch up with should automatically handle updating the flat storage of the child shards. Current tests don't handle that and so we need to disable checking flat storage.
- Once this is in place, merge PR https://github.com/near/nearcore/pull/9335 