### PR TITLE
fix(loadtest): submit tx on top of final chain

### DIFF
--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -321,6 +321,9 @@ class BaseNode(object):
     def get_block_by_height(self, block_height, **kwargs):
         return self.json_rpc('block', {'block_id': block_height}, **kwargs)
 
+    def get_final_block(self, **kwargs):
+        return self.json_rpc('block', {'finality': 'final'}, **kwargs)
+
     def get_chunk(self, chunk_id):
         return self.json_rpc('chunk', [chunk_id])
 

--- a/pytest/tests/loadtest/locust/common/base.py
+++ b/pytest/tests/loadtest/locust/common/base.py
@@ -219,7 +219,7 @@ class NearNodeProxy:
         """
         Send a transaction and return the result, no retry attempted.
         """
-        block_hash = base58.b58decode(self.node.get_latest_block().hash)
+        block_hash = base58.b58decode(self.node.get_final_block()['result']['header']['hash'])
         signed_tx = tx.sign_and_serialize(block_hash)
 
         meta = {

--- a/pytest/tests/loadtest/locust/common/base.py
+++ b/pytest/tests/loadtest/locust/common/base.py
@@ -219,7 +219,8 @@ class NearNodeProxy:
         """
         Send a transaction and return the result, no retry attempted.
         """
-        block_hash = base58.b58decode(self.node.get_final_block()['result']['header']['hash'])
+        block_hash = base58.b58decode(
+            self.node.get_final_block()['result']['header']['hash'])
         signed_tx = tx.sign_and_serialize(block_hash)
 
         meta = {


### PR DESCRIPTION
Instead of submitting a transaction that builds on top of the very
latest block the queried node knows, we should build on top of the final
head. This avoid race conditions where transactions could reach a chunk
producer before the block the transaction builds upon is processed.

This was the main problem that caused the issue described in #9326