### PR TITLE
feat(loadtest): Sweat record large batches

### DIFF
--- a/pytest/tests/loadtest/locust/README.md
+++ b/pytest/tests/loadtest/locust/README.md
@@ -92,9 +92,11 @@ Currently supported load types:
 
 | load type | file | args | description |
 |---|---|---|---|
-| Fungible Token | ft.py | `--fungible-token-wasm $WASM_PATH` <br> (`--num-ft-contracts $N`) |  Creates `$N` FT contracts per worker, registers each user in one of them. Users transfer FTs between each other. |
-| Social DB  | social.py | `--social-db-wasm $WASM_PATH` | Creates a single instance of SocialDB and registers users to it. Users post messages and follow other users. (More workload TBD) |
-| Congestion | congestion.py | `--congestion-wasm $WASM_PATH` | Creates a single instance of Congestion contract. Users run large and long transactions. |
+| Fungible Token | ft.py | (`--fungible-token-wasm $WASM_PATH`) <br> (`--num-ft-contracts $N`) |  Creates `$N` FT contracts per worker, registers each user in one of them. Users transfer FTs between each other. |
+| Social DB  | social.py | (`--social-db-wasm $WASM_PATH`) | Creates a single instance of SocialDB and registers users to it. Users post messages and follow other users. (More workload TBD) |
+| Congestion | congestion.py | (`--congestion-wasm $WASM_PATH`) | Creates a single instance of Congestion contract. Users run large and long transactions. |
+| Sweat (normal load) | sweat.py | (`--sweat-wasm $WASM_PATH`) | Creates a single instance of the SWEAT contract. A mix of FT transfers and batch minting with batch sizes comparable to mainnet observations in summer 2023. |
+| Sweat (storage stress test) | sweat.py | `--tags=storage-stres-test` <br> (`--sweat-wasm $WASM_PATH`) | Creates a single instance of the SWEAT contract. Sends maximally large batches to mint more tokens, thereby touching many storage nodes per receipt. This load will take a while to initialize enough Sweat users on chain. |
 
 In the future, we might have multiple users per load type but for now there is a
 one-to-one mapping from users to load type (and tag).

--- a/pytest/tests/loadtest/locust/README.md
+++ b/pytest/tests/loadtest/locust/README.md
@@ -96,7 +96,7 @@ Currently supported load types:
 | Social DB  | social.py | (`--social-db-wasm $WASM_PATH`) | Creates a single instance of SocialDB and registers users to it. Users post messages and follow other users. (More workload TBD) |
 | Congestion | congestion.py | (`--congestion-wasm $WASM_PATH`) | Creates a single instance of Congestion contract. Users run large and long transactions. |
 | Sweat (normal load) | sweat.py | (`--sweat-wasm $WASM_PATH`) | Creates a single instance of the SWEAT contract. A mix of FT transfers and batch minting with batch sizes comparable to mainnet observations in summer 2023. |
-| Sweat (storage stress test) | sweat.py | `--tags=storage-stres-test` <br> (`--sweat-wasm $WASM_PATH`) | Creates a single instance of the SWEAT contract. Sends maximally large batches to mint more tokens, thereby touching many storage nodes per receipt. This load will take a while to initialize enough Sweat users on chain. |
+| Sweat (storage stress test) | sweat.py | `--tags=storage-stress-test` <br> (`--sweat-wasm $WASM_PATH`) | Creates a single instance of the SWEAT contract. Sends maximally large batches to mint more tokens, thereby touching many storage nodes per receipt. This load will take a while to initialize enough Sweat users on chain. |
 
 In the future, we might have multiple users per load type but for now there is a
 one-to-one mapping from users to load type (and tag).

--- a/pytest/tests/loadtest/locust/common/base.py
+++ b/pytest/tests/loadtest/locust/common/base.py
@@ -130,8 +130,8 @@ class FunctionCall(Transaction):
     def sign_and_serialize(self, block_hash) -> bytes:
         return transaction.sign_function_call_tx(
             self.sender.key, self.receiver_id, self.method,
-            json.dumps(self.args()).encode('utf-8'), 300 * TGAS, self.balance,
-            self.sender.use_nonce(), block_hash)
+            json.dumps(self.args()).encode('utf-8'), 300 * TGAS,
+            int(self.balance), self.sender.use_nonce(), block_hash)
 
     def sender_account(self) -> Account:
         return self.sender

--- a/pytest/tests/loadtest/locust/common/base.py
+++ b/pytest/tests/loadtest/locust/common/base.py
@@ -130,8 +130,8 @@ class FunctionCall(Transaction):
     def sign_and_serialize(self, block_hash) -> bytes:
         return transaction.sign_function_call_tx(
             self.sender.key, self.receiver_id, self.method,
-            json.dumps(self.args()).encode('utf-8'), 300 * TGAS,
-            int(self.balance), self.sender.use_nonce(), block_hash)
+            json.dumps(self.args()).encode('utf-8'), 300 * TGAS, self.balance,
+            self.sender.use_nonce(), block_hash)
 
     def sender_account(self) -> Account:
         return self.sender

--- a/pytest/tests/loadtest/locust/common/base.py
+++ b/pytest/tests/loadtest/locust/common/base.py
@@ -151,14 +151,15 @@ class MultiFunctionCall(FunctionCall):
         super().__init__(sender, receiver_id, method, balance=balance)
 
     def sign_and_serialize(self, block_hash) -> bytes:
-        actions = []
         all_args = self.args()
         gas = 300 * TGAS // len(all_args)
-        for arg in all_args:
-            action = transaction.create_function_call_action(
+
+        def create_action(args):
+            return transaction.create_function_call_action(
                 self.method,
-                json.dumps(arg).encode('utf-8'), gas, int(self.balance))
-            actions.append(action)
+                json.dumps(args).encode('utf-8'), gas, int(self.balance))
+
+        actions = [create_action(args) for args in all_args]
         return transaction.sign_and_serialize_transaction(
             self.receiver_id, self.sender.use_nonce(), actions, block_hash,
             self.sender.key.account_id, self.sender.key.decoded_pk(),

--- a/pytest/tests/loadtest/locust/common/base.py
+++ b/pytest/tests/loadtest/locust/common/base.py
@@ -205,6 +205,25 @@ class CreateSubAccount(Transaction):
         return self.sender
 
 
+class AddFullAccessKey(Transaction):
+
+    def __init__(self, parent: Account, new_key: key.Key):
+        super().__init__()
+        self.sender = parent
+        self.new_key = new_key
+
+    def sign_and_serialize(self, block_hash) -> bytes:
+        action = transaction.create_full_access_key_action(
+            self.new_key.decoded_pk())
+        return transaction.sign_and_serialize_transaction(
+            self.sender.key.account_id, self.sender.use_nonce(),
+            [action], block_hash, self.sender.key.account_id,
+            self.sender.key.decoded_pk(), self.sender.key.decoded_sk())
+
+    def sender_account(self) -> Account:
+        return self.sender
+
+
 class NearNodeProxy:
     """
     Wrapper around a RPC node connection that tracks requests on locust.

--- a/pytest/tests/loadtest/locust/common/ft.py
+++ b/pytest/tests/loadtest/locust/common/ft.py
@@ -26,10 +26,11 @@ class FTContract:
         Deploy and initialize the contract on chain.
         The account is created if it doesn't exist yet.
         """
-        node.prepare_account(self.account, parent, FTContract.INIT_BALANCE,
+        existed = node.prepare_account(self.account, parent, FTContract.INIT_BALANCE,
                              "create contract account")
-        node.send_tx_retry(Deploy(self.account, self.code, "FT"), "deploy ft")
-        self.init_contract(node)
+        if not existed:
+            node.send_tx_retry(Deploy(self.account, self.code, "FT"), "deploy ft")
+            self.init_contract(node)
 
     def init_contract(self, node: NearNodeProxy):
         node.send_tx_retry(InitFT(self.account), "init ft")

--- a/pytest/tests/loadtest/locust/common/ft.py
+++ b/pytest/tests/loadtest/locust/common/ft.py
@@ -26,10 +26,12 @@ class FTContract:
         Deploy and initialize the contract on chain.
         The account is created if it doesn't exist yet.
         """
-        existed = node.prepare_account(self.account, parent, FTContract.INIT_BALANCE,
-                             "create contract account")
+        existed = node.prepare_account(self.account, parent,
+                                       FTContract.INIT_BALANCE,
+                                       "create contract account")
         if not existed:
-            node.send_tx_retry(Deploy(self.account, self.code, "FT"), "deploy ft")
+            node.send_tx_retry(Deploy(self.account, self.code, "FT"),
+                               "deploy ft")
             self.init_contract(node)
 
     def init_contract(self, node: NearNodeProxy):

--- a/pytest/tests/loadtest/locust/common/sweat.py
+++ b/pytest/tests/loadtest/locust/common/sweat.py
@@ -127,7 +127,8 @@ class SweatMintBatch(MultiFunctionCall):
 
     def args(self) -> typing.List[dict]:
         # above a threshold, we hit the log output limit of 16kB
-        max_chunk_len = 180
+        # this depends a bit on the exact account id names
+        max_chunk_len = 160
         remaining = len(self.recipient_step_paris)
         chunks = []
         while remaining > max_chunk_len:

--- a/pytest/tests/loadtest/locust/common/sweat.py
+++ b/pytest/tests/loadtest/locust/common/sweat.py
@@ -129,14 +129,14 @@ class SweatMintBatch(MultiFunctionCall):
         # above a threshold, we hit the log output limit of 16kB
         # this depends a bit on the exact account id names
         max_chunk_len = 160
-        remaining = len(self.recipient_step_paris)
+        remaining = len(self.recipient_step_pairs)
         chunks = []
         while remaining > max_chunk_len:
-            chunks.append(self.recipient_step_paris[remaining -
+            chunks.append(self.recipient_step_pairs[remaining -
                                                     max_chunk_len:remaining])
             remaining -= max_chunk_len
         if remaining > 0:
-            chunks.append(self.recipient_step_paris[0:remaining])
+            chunks.append(self.recipient_step_pairs[0:remaining])
         return [{"steps_batch": chunk} for chunk in chunks]
 
 

--- a/pytest/tests/loadtest/locust/common/sweat.py
+++ b/pytest/tests/loadtest/locust/common/sweat.py
@@ -128,7 +128,7 @@ class SweatMintBatch(MultiFunctionCall):
     def args(self) -> typing.List[dict]:
         # above a threshold, we hit the log output limit of 16kB
         # this depends a bit on the exact account id names
-        max_chunk_len = 160
+        max_chunk_len = 150
         remaining = len(self.recipient_step_pairs)
         chunks = []
         while remaining > max_chunk_len:

--- a/pytest/tests/loadtest/locust/common/sweat.py
+++ b/pytest/tests/loadtest/locust/common/sweat.py
@@ -159,9 +159,11 @@ def on_locust_init(environment, **kwargs):
         num_oracles = int(environment.parsed_options.max_workers)
         # TODO: Add oracles in parallel
         for worker_id in range(num_oracles):
-            id = worker_oracle_id(worker_id, run_id, funding_account)
+            id = worker_oracle_id(worker_id, run_id,
+                                  environment.master_funding_account)
             worker_oracle = Account(key.Key.from_seed_testonly(id))
-            node.prepare_account(worker_oracle, funding_account, 100000,
+            node.prepare_account(worker_oracle,
+                                 environment.master_funding_account, 100000,
                                  "create contract account")
             environment.sweat.register_oracle(node, id)
             environment.sweat.top_up(node, id)

--- a/pytest/tests/loadtest/locust/common/sweat.py
+++ b/pytest/tests/loadtest/locust/common/sweat.py
@@ -128,15 +128,12 @@ class SweatMintBatch(MultiFunctionCall):
     def args(self) -> typing.List[dict]:
         # above a threshold, we hit the log output limit of 16kB
         # this depends a bit on the exact account id names
-        max_chunk_len = 150
-        remaining = len(self.recipient_step_pairs)
-        chunks = []
-        while remaining > max_chunk_len:
-            chunks.append(self.recipient_step_pairs[remaining -
-                                                    max_chunk_len:remaining])
-            remaining -= max_chunk_len
-        if remaining > 0:
-            chunks.append(self.recipient_step_pairs[0:remaining])
+        chunk_len = 150
+        chunks = [
+            self.recipient_step_pairs[s:s + chunk_len]
+            for s in range(0, len(self.recipient_step_pairs), chunk_len)
+        ]
+
         return [{"steps_batch": chunk} for chunk in chunks]
 
 

--- a/pytest/tests/loadtest/locust/locustfiles/sweat.py
+++ b/pytest/tests/loadtest/locust/locustfiles/sweat.py
@@ -47,6 +47,7 @@ class SweatUser(NearUser):
     @task(1)
     def record_single_batch(self):
         rng = random.Random()
+        # just around the log limit
         batch_size = min(rng.randint(100, 150),
                          len(self.sweat.registered_users))
         receivers = self.sweat.random_receivers(self.account_id, batch_size)
@@ -67,13 +68,10 @@ class SweatUser(NearUser):
         rng = random.Random()
         # just around 300Tgas
         batch_size = rng.randint(700, 750)
-        # just around the log limit
-        # batch_size = rng.randint(150, 180)
         receivers = self.sweat.random_receivers(self.account_id, batch_size)
         tx = SweatMintBatch(
             self.sweat.account.key.account_id,
-            self.sweat.
-            oracle,  # TODO: one oracel shared between users of a worker => nonce conflict
+            self.sweat.oracle,
             [[account_id, rng.randint(1000, 3000)] for account_id in receivers])
         self.send_tx(tx, locust_name="Sweat record batch (stress test)")
 

--- a/pytest/tests/loadtest/locust/locustfiles/sweat.py
+++ b/pytest/tests/loadtest/locust/locustfiles/sweat.py
@@ -14,7 +14,7 @@ This workload is similar to the FT workload with 2 major differences:
 from common.sweat import RecipientSteps, SweatMintBatch
 from common.ft import TransferFT
 from common.base import NearUser
-from locust import between, task
+from locust import between, tag, task
 import logging
 import pathlib
 import random
@@ -36,13 +36,13 @@ class SweatUser(NearUser):
     """
     wait_time = between(1, 3)  # random pause between transactions
 
-    @task
+    @task(3)
     def ft_transfer(self):
         receiver = self.sweat.random_receiver(self.account_id)
         tx = TransferFT(self.sweat.account, self.account, receiver)
         self.send_tx(tx, locust_name="Sweat transfer")
 
-    @task
+    @task(1)
     def record_single_batch(self):
         rng = random.Random()
         batch_size = min(rng.randint(100, 150),
@@ -55,6 +55,7 @@ class SweatUser(NearUser):
             ])
         self.send_tx(tx, locust_name="Sweat record batch")
 
+    @tag("storage-stress-test")
     @task
     def record_batch_of_large_batches(self):
         # ensure large enough state by creating more sweat users

--- a/pytest/tests/loadtest/locust/locustfiles/sweat.py
+++ b/pytest/tests/loadtest/locust/locustfiles/sweat.py
@@ -51,11 +51,10 @@ class SweatUser(NearUser):
         batch_size = min(rng.randint(100, 150),
                          len(self.sweat.registered_users))
         receivers = self.sweat.random_receivers(self.account_id, batch_size)
-        tx = SweatMintBatch(
-            self.sweat.account.key.account_id, self.oracle, [
-                RecipientSteps(account_id, steps=rng.randint(1000, 3000))
-                for account_id in receivers
-            ])
+        tx = SweatMintBatch(self.sweat.account.key.account_id, self.oracle, [
+            RecipientSteps(account_id, steps=rng.randint(1000, 3000))
+            for account_id in receivers
+        ])
         self.send_tx(tx, locust_name="Sweat record batch")
 
     @tag("storage-stress-test")

--- a/pytest/tests/loadtest/locust/locustfiles/sweat.py
+++ b/pytest/tests/loadtest/locust/locustfiles/sweat.py
@@ -52,7 +52,7 @@ class SweatUser(NearUser):
                          len(self.sweat.registered_users))
         receivers = self.sweat.random_receivers(self.account_id, batch_size)
         tx = SweatMintBatch(
-            self.sweat.account.key.account_id, self.sweat.oracle, [
+            self.sweat.account.key.account_id, self.oracle, [
                 RecipientSteps(account_id, steps=rng.randint(1000, 3000))
                 for account_id in receivers
             ])
@@ -70,7 +70,7 @@ class SweatUser(NearUser):
         batch_size = rng.randint(700, 750)
         receivers = self.sweat.random_receivers(self.account_id, batch_size)
         tx = SweatMintBatch(
-            self.sweat.account.key.account_id, self.sweat.oracle,
+            self.sweat.account.key.account_id, self.oracle,
             [[account_id, rng.randint(1000, 3000)] for account_id in receivers])
         self.send_tx(tx, locust_name="Sweat record batch (stress test)")
 
@@ -85,11 +85,8 @@ class SweatUser(NearUser):
         self.send_tx_retry(AddFullAccessKey(oracle, user_oracle_key),
                            "add user key to oracle")
 
-        # Shallow copy to share all state of the sweat contract, like registered
-        # users, but then overwrite the oracle to use a different access key.
-        self.sweat = copy.copy(self.environment.sweat)
-        self.sweat.oracle = Account(user_oracle_key)
-        self.sweat.oracle.refresh_nonce(self.node.node)
+        self.oracle = Account(user_oracle_key)
+        self.oracle.refresh_nonce(self.node.node)
 
         self.sweat.register_user(self)
         logger.debug(

--- a/pytest/tests/loadtest/locust/locustfiles/sweat.py
+++ b/pytest/tests/loadtest/locust/locustfiles/sweat.py
@@ -70,8 +70,7 @@ class SweatUser(NearUser):
         batch_size = rng.randint(700, 750)
         receivers = self.sweat.random_receivers(self.account_id, batch_size)
         tx = SweatMintBatch(
-            self.sweat.account.key.account_id,
-            self.sweat.oracle,
+            self.sweat.account.key.account_id, self.sweat.oracle,
             [[account_id, rng.randint(1000, 3000)] for account_id in receivers])
         self.send_tx(tx, locust_name="Sweat record batch (stress test)")
 
@@ -82,12 +81,14 @@ class SweatUser(NearUser):
         # batches. Hence, let's add a new access key to the oracle account for
         # each sweat user.
         oracle = self.environment.sweat.oracle
-        user_orcale_key = key.Key.from_random(oracle.key.account_id)
-        self.send_tx_retry(AddFullAccessKey(oracle, user_orcale_key),
+        user_oracle_key = key.Key.from_random(oracle.key.account_id)
+        self.send_tx_retry(AddFullAccessKey(oracle, user_oracle_key),
                            "add user key to oracle")
 
+        # Shallow copy to share all state of the sweat contract, like registered
+        # users, but then overwrite the oracle to use a different access key.
         self.sweat = copy.copy(self.environment.sweat)
-        self.sweat.oracle = Account(user_orcale_key)
+        self.sweat.oracle = Account(user_oracle_key)
         self.sweat.oracle.refresh_nonce(self.node.node)
 
         self.sweat.register_user(self)


### PR DESCRIPTION
For stress testing the storage performance, we fit as many Sweat
balance updates in a single receipt as possible.

For this, we combine multiple actions in a single receipt
to get around the per-receipt log output limit.
Of course, we are still limited by gas.

To run these large batches, use the `SweatUser` with `--tags=storage-stres-test`.
Otherwise, the `SweatUser` performs "small" batches and FT transfers in a 1:3 rate.
(Small batches are around the size of real SWEAT load.)