### PR TITLE
fix(flat-storage): Handle chain forks gracefully

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2287,7 +2287,13 @@ impl Chain {
                         // where during postprocessing (5) we call `update_flat_head(3)` and then for (6) we can
                         // call `update_flat_head(2)` because (2) will be last visible final block from it.
                         // In such case, just log an error.
-                        debug!(target: "chain", ?new_flat_head, ?err, ?shard_uid, block_hash = ?block.header().hash(), "Cannot update flat head");
+                        debug!(
+                            target: "chain",
+                            ?new_flat_head,
+                            ?err,
+                            ?shard_uid,
+                            block_hash = ?block.header().hash(),
+                            "Cannot update flat head");
                     }
                     _ => {
                         // All other errors are unexpected, so we panic.

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2287,11 +2287,11 @@ impl Chain {
                         // where during postprocessing (5) we call `update_flat_head(3)` and then for (6) we can
                         // call `update_flat_head(2)` because (2) will be last visible final block from it.
                         // In such case, just log an error.
-                        debug!(target: "chain", "Cannot update flat head to {:?}: {:?}", new_flat_head, err);
+                        debug!(target: "chain", ?new_flat_head, ?err, ?shard_uid, block_hash = ?block.header().hash(), "Cannot update flat head");
                     }
                     _ => {
                         // All other errors are unexpected, so we panic.
-                        panic!("Cannot update flat head to {:?}: {:?}", new_flat_head, err);
+                        panic!("Cannot update flat head of shard {shard_uid:?} to {new_flat_head:?}: {err:?}");
                     }
                 }
             });


### PR DESCRIPTION
Also avoid printing WARNings when too many cached deltas are in memory.
Currently the number of cached deltas doesn't matter, only the number of blocks needed to get from a block to flat head is important.