### PR TITLE
RoutingTableView: gracefully handle missing distance vectors

### DIFF
--- a/tools/debug-ui/src/RoutingTableView.tsx
+++ b/tools/debug-ui/src/RoutingTableView.tsx
@@ -63,11 +63,16 @@ export const RoutingTableView = ({ addr }: RoutingTableViewProps) => {
                 <tbody>
                     {direct_peers.map((peer_id) => {
                         const peer_label = peerLabels[peer_id];
+
+                        const peer_distances = routingInfo.peer_distances[peer_id];
+                        const formatted_distances =
+                            peer_distances == null ? "null" : peer_distances.distance.join(', ');
+
                         return (
                             <tr key={peer_label}>
                                 <td>{peer_id.substring(8, 14)}...</td>
                                 <td>{peer_label}</td>
-                                <td>{routingInfo.peer_distances[peer_id].distance.join(', ')}</td>
+                                <td>{formatted_distances}</td>
                             </tr>
                         );
                     })}


### PR DESCRIPTION
The RoutingTableView in the debug UI includes a table over the direct peers of the node:

<img width="516" alt="image" src="https://github.com/near/nearcore/assets/3241341/c8c1f0b8-1e0a-458e-a2ad-f09f20fcb57c">

Each active connection of the node has one row in the table. The last column is populated using the most recent distance vector shared by the direct peer.

In some cases there may be a direct connection for which we have not received a distance vector yet. This PR allows the debug UI to gracefully handle such cases and display "null" instead of producing an error.