### PR TITLE
RoutingTableView: fix handling of 0 distances

### DIFF
--- a/tools/debug-ui/src/RoutingTableView.tsx
+++ b/tools/debug-ui/src/RoutingTableView.tsx
@@ -66,7 +66,7 @@ export const RoutingTableView = ({ addr }: RoutingTableViewProps) => {
 
                         const peer_distances = routingInfo.peer_distances[peer_id];
                         const formatted_distances = peer_distances == null ? "null" :
-                            peer_distances.distance.map((x) => x || '_').join(', ');
+                            peer_distances.distance.map((x) => x ?? '_').join(', ');
 
                         return (
                             <tr key={peer_label}>


### PR DESCRIPTION
In RoutingTableView we display a table of routing distances in the network.

Currently, distances of `0` (indicating a trivial path from a node to itself) and distances of `null` (indicating no advertised path between two nodes) are both displayed as `_` due to use of the `||` operator (OR).

What we actually want is for `null` to be rendered as `_` while all defined values are displayed as they are (including 0, a valid distance). Using the `??` operator (nullish coalescing) achieves what we want.