### PR TITLE
BlockHeaders: move approval Signatures into Box

### DIFF
--- a/chain/chain/src/doomslug.rs
+++ b/chain/chain/src/doomslug.rs
@@ -511,7 +511,7 @@ impl Doomslug {
     /// * `stakes`    - the vector of validator stakes in the current epoch
     pub fn can_approved_block_be_produced(
         mode: DoomslugThresholdMode,
-        approvals: &[Option<Signature>],
+        approvals: &[Option<Box<Signature>>],
         stakes: &[(Balance, Balance, bool)],
     ) -> bool {
         if mode == DoomslugThresholdMode::NoApprovals {

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -853,7 +853,7 @@ impl EpochManagerAdapter for MockEpochManager {
         _prev_block_hash: &CryptoHash,
         _prev_block_height: BlockHeight,
         _block_height: BlockHeight,
-        _approvals: &[Option<Signature>],
+        _approvals: &[Option<Box<Signature>>],
     ) -> Result<bool, Error> {
         Ok(true)
     }
@@ -862,13 +862,13 @@ impl EpochManagerAdapter for MockEpochManager {
         &self,
         epoch_id: &EpochId,
         can_approved_block_be_produced: &dyn Fn(
-            &[Option<Signature>],
+            &[Option<Box<Signature>>],
             &[(Balance, Balance, bool)],
         ) -> bool,
         prev_block_hash: &CryptoHash,
         prev_block_height: BlockHeight,
         block_height: BlockHeight,
-        approvals: &[Option<Signature>],
+        approvals: &[Option<Box<Signature>>],
     ) -> Result<(), Error> {
         let validators = self.get_block_producers(self.get_valset_for_epoch(epoch_id)?);
         let message_to_sign = Approval::get_data_for_sig(

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -508,7 +508,8 @@ mod tests {
         let b1 = TestBlockBuilder::new(&genesis, signer.clone()).build();
         assert!(b1.header().verify_block_producer(&signer.public_key()));
         let other_signer = create_test_signer("other2");
-        let approvals = vec![Some(Approval::new(*b1.hash(), 1, 2, &other_signer).signature)];
+        let approvals =
+            vec![Some(Box::new(Approval::new(*b1.hash(), 1, 2, &other_signer).signature))];
         let b2 = TestBlockBuilder::new(&b1, signer.clone()).approvals(approvals).build();
         b2.header().verify_block_producer(&signer.public_key());
     }

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -615,7 +615,7 @@ impl Client {
                 if is_slashed {
                     None
                 } else {
-                    approvals_map.remove(&account_id).map(|x| x.0.signature)
+                    approvals_map.remove(&account_id).map(|x| x.0.signature.into())
                 }
             })
             .collect();

--- a/chain/client/src/sync/header.rs
+++ b/chain/client/src/sync/header.rs
@@ -676,7 +676,7 @@ mod test {
                 signers2
                     .iter()
                     .map(|signer| {
-                        Some(
+                        Some(Box::new(
                             Approval::new(
                                 *last_block.hash(),
                                 last_block.header().height(),
@@ -684,7 +684,7 @@ mod test {
                                 signer.as_ref(),
                             )
                             .signature,
-                        )
+                        ))
                     })
                     .collect(),
                 Ratio::new(0, 1),

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -343,7 +343,7 @@ pub trait EpochManagerAdapter: Send + Sync {
         prev_block_hash: &CryptoHash,
         prev_block_height: BlockHeight,
         block_height: BlockHeight,
-        approvals: &[Option<Signature>],
+        approvals: &[Option<Box<Signature>>],
     ) -> Result<bool, Error>;
 
     /// Verify approvals and check threshold, but ignore next epoch approvals and slashing
@@ -351,14 +351,14 @@ pub trait EpochManagerAdapter: Send + Sync {
         &self,
         epoch_id: &EpochId,
         can_approved_block_be_produced: &dyn Fn(
-            &[Option<Signature>],
+            &[Option<Box<Signature>>],
             // (stake this in epoch, stake in next epoch, is_slashed)
             &[(Balance, Balance, bool)],
         ) -> bool,
         prev_block_hash: &CryptoHash,
         prev_block_height: BlockHeight,
         block_height: BlockHeight,
-        approvals: &[Option<Signature>],
+        approvals: &[Option<Box<Signature>>],
     ) -> Result<(), Error>;
 
     fn cares_about_shard_from_prev_block(
@@ -838,7 +838,7 @@ impl EpochManagerAdapter for EpochManagerHandle {
         prev_block_hash: &CryptoHash,
         prev_block_height: BlockHeight,
         block_height: BlockHeight,
-        approvals: &[Option<Signature>],
+        approvals: &[Option<Box<Signature>>],
     ) -> Result<bool, Error> {
         let info = {
             let epoch_manager = self.read();
@@ -874,13 +874,13 @@ impl EpochManagerAdapter for EpochManagerHandle {
         &self,
         epoch_id: &EpochId,
         can_approved_block_be_produced: &dyn Fn(
-            &[Option<Signature>],
+            &[Option<Box<Signature>>],
             &[(Balance, Balance, bool)],
         ) -> bool,
         prev_block_hash: &CryptoHash,
         prev_block_height: BlockHeight,
         block_height: BlockHeight,
-        approvals: &[Option<Signature>],
+        approvals: &[Option<Box<Signature>>],
     ) -> Result<(), Error> {
         let info = {
             let epoch_manager = self.read();

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -224,7 +224,7 @@ impl Block {
         epoch_id: EpochId,
         next_epoch_id: EpochId,
         epoch_sync_data_hash: Option<CryptoHash>,
-        approvals: Vec<Option<Signature>>,
+        approvals: Vec<Option<Box<Signature>>>,
         gas_price_adjustment_rate: Rational32,
         min_gas_price: Balance,
         max_gas_price: Balance,

--- a/core/primitives/src/block_header.rs
+++ b/core/primitives/src/block_header.rs
@@ -63,7 +63,7 @@ pub struct BlockHeaderInnerRest {
     pub last_ds_final_block: CryptoHash,
 
     /// All the approvals included in this block
-    pub approvals: Vec<Option<Signature>>,
+    pub approvals: Vec<Option<Box<Signature>>>,
 
     /// Latest protocol version that this block producer has.
     pub latest_protocol_version: ProtocolVersion,
@@ -99,7 +99,7 @@ pub struct BlockHeaderInnerRestV2 {
     pub last_ds_final_block: CryptoHash,
 
     /// All the approvals included in this block
-    pub approvals: Vec<Option<Signature>>,
+    pub approvals: Vec<Option<Box<Signature>>>,
 
     /// Latest protocol version that this block producer has.
     pub latest_protocol_version: ProtocolVersion,
@@ -145,7 +145,7 @@ pub struct BlockHeaderInnerRestV3 {
     pub epoch_sync_data_hash: Option<CryptoHash>,
 
     /// All the approvals included in this block
-    pub approvals: Vec<Option<Signature>>,
+    pub approvals: Vec<Option<Box<Signature>>>,
 
     /// Latest protocol version that this block producer has.
     pub latest_protocol_version: ProtocolVersion,
@@ -190,7 +190,7 @@ pub struct BlockHeaderInnerRestV4 {
     pub epoch_sync_data_hash: Option<CryptoHash>,
 
     /// All the approvals included in this block
-    pub approvals: Vec<Option<Signature>>,
+    pub approvals: Vec<Option<Box<Signature>>>,
 
     /// Latest protocol version that this block producer has.
     pub latest_protocol_version: ProtocolVersion,
@@ -428,7 +428,7 @@ impl BlockHeader {
         last_final_block: CryptoHash,
         last_ds_final_block: CryptoHash,
         epoch_sync_data_hash: Option<CryptoHash>,
-        approvals: Vec<Option<Signature>>,
+        approvals: Vec<Option<Box<Signature>>>,
         next_bp_hash: CryptoHash,
         block_merkle_root: CryptoHash,
         prev_height: BlockHeight,
@@ -1027,7 +1027,7 @@ impl BlockHeader {
     }
 
     #[inline]
-    pub fn approvals(&self) -> &[Option<Signature>] {
+    pub fn approvals(&self) -> &[Option<Box<Signature>>] {
         match self {
             BlockHeader::BlockHeaderV1(header) => &header.inner_rest.approvals,
             BlockHeader::BlockHeaderV2(header) => &header.inner_rest.approvals,

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -355,7 +355,7 @@ pub struct TestBlockBuilder {
     epoch_id: EpochId,
     next_epoch_id: EpochId,
     next_bp_hash: CryptoHash,
-    approvals: Vec<Option<Signature>>,
+    approvals: Vec<Option<Box<Signature>>>,
     block_merkle_root: CryptoHash,
 }
 
@@ -395,7 +395,7 @@ impl TestBlockBuilder {
         self.next_bp_hash = next_bp_hash;
         self
     }
-    pub fn approvals(mut self, approvals: Vec<Option<Signature>>) -> Self {
+    pub fn approvals(mut self, approvals: Vec<Option<Box<Signature>>>) -> Self {
         self.approvals = approvals;
         self
     }

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -757,7 +757,7 @@ pub struct BlockHeaderView {
     pub next_bp_hash: CryptoHash,
     pub block_merkle_root: CryptoHash,
     pub epoch_sync_data_hash: Option<CryptoHash>,
-    pub approvals: Vec<Option<Signature>>,
+    pub approvals: Vec<Option<Box<Signature>>>,
     pub signature: Signature,
     pub latest_protocol_version: ProtocolVersion,
 }
@@ -2014,7 +2014,7 @@ pub struct LightClientBlockView {
     pub inner_lite: BlockHeaderInnerLiteView,
     pub inner_rest_hash: CryptoHash,
     pub next_bps: Option<Vec<ValidatorStakeView>>,
-    pub approvals_after_next: Vec<Option<Signature>>,
+    pub approvals_after_next: Vec<Option<Box<Signature>>>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, BorshDeserialize, BorshSerialize)]

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -1174,10 +1174,10 @@ fn test_invalid_approvals() {
     b1.mut_header().get_mut().inner_rest.approvals = (0..100)
         .map(|i| {
             let account_id = AccountId::try_from(format!("test{}", i)).unwrap();
-            Some(
+            Some(Box::new(
                 create_test_signer(account_id.as_str())
                     .sign_approval(&ApprovalInner::Endorsement(*genesis.hash()), 1),
-            )
+            ))
         })
         .collect();
     b1.mut_header().resign(&*signer);
@@ -1307,7 +1307,7 @@ fn test_bad_orphan() {
         // Orphan block with invalid approvals. Allowed for now.
         let mut block = env.clients[0].produce_block(9).unwrap().unwrap();
         let some_signature = Signature::from_parts(KeyType::ED25519, &[1; 64]).unwrap();
-        block.mut_header().get_mut().inner_rest.approvals = vec![Some(some_signature)];
+        block.mut_header().get_mut().inner_rest.approvals = vec![Some(Box::new(some_signature))];
         block.mut_header().get_mut().prev_hash = CryptoHash([3; 32]);
         block.mut_header().resign(&*signer);
         let res = env.clients[0].process_block_test(block.into(), Provenance::NONE);

--- a/integration-tests/src/tests/nearcore/sync_nodes.rs
+++ b/integration-tests/src/tests/nearcore/sync_nodes.rs
@@ -66,7 +66,7 @@ fn add_blocks(
             epoch_id,
             next_epoch_id,
             None,
-            vec![Some(
+            vec![Some(Box::new(
                 Approval::new(
                     *prev.hash(),
                     prev.header().height(),
@@ -74,7 +74,7 @@ fn add_blocks(
                     signer,
                 )
                 .signature,
-            )],
+            ))],
             Ratio::from_integer(0),
             0,
             1000,


### PR DESCRIPTION
BlockHeaders contains a Vec "approvals" which contains entries of type `Option<Signature>`. 

This PR optimizes BlockHeaders' in-memory size for cases with many None approvals by changing the approval type to `Option<Box<Signature>>`.

Before this change:
- 66 bytes to store Some(approval)
- 66 bytes to store None

After this change:
- 74 bytes to store Some(approval)
- 8 bytes to store None

