### PR TITLE
test_builder: more flexibility and control

### DIFF
--- a/runtime/near-vm-runner/src/tests/compile_errors.rs
+++ b/runtime/near-vm-runner/src/tests/compile_errors.rs
@@ -434,12 +434,12 @@ fn test_sandbox_only_function() {
         .opaque_error();
 
     #[cfg(feature = "sandbox")]
-    tb.expect(expect![[r#"
+    tb.expect(&expect![[r#"
         VMOutcome: balance 4 storage_usage 12 return data None burnt gas 59805981 used gas 59805981
     "#]]);
 
     #[cfg(not(feature = "sandbox"))]
-    tb.expect(expect![[r#"
+    tb.expect(&expect![[r#"
         VMOutcome: balance 4 storage_usage 12 return data None burnt gas 57337713 used gas 57337713
         Err: ...
     "#]]);
@@ -456,12 +456,12 @@ fn extension_saturating_float_to_int() {
     );
 
     #[cfg(feature = "nightly")]
-    tb.expect(expect![[r#"
+    tb.expect(&expect![[r#"
         VMOutcome: balance 4 storage_usage 12 return data None burnt gas 48450963 used gas 48450963
         Err: PrepareError: Error happened while deserializing the module.
     "#]]);
     #[cfg(not(feature = "nightly"))]
-    tb.expect(expect![[r#"
+    tb.expect(&expect![[r#"
         VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
         Err: PrepareError: Error happened while deserializing the module.
     "#]]);

--- a/runtime/near-vm-runner/src/tests/runtime_errors.rs
+++ b/runtime/near-vm-runner/src/tests/runtime_errors.rs
@@ -15,7 +15,7 @@ fn test_infinite_initializer() {
     test_builder()
         .wat(INFINITE_INITIALIZER_CONTRACT)
         .gas(10u64.pow(10))
-        .expect(expect![[r#"
+        .expect(&expect![[r#"
             VMOutcome: balance 4 storage_usage 12 return data None burnt gas 10000000000 used gas 10000000000
             Err: Exceeded the prepaid gas.
         "#]]);
@@ -131,7 +131,7 @@ fn test_export_not_found() {
 
 #[test]
 fn test_empty_method() {
-    test_builder().wat(SIMPLE_CONTRACT).method("").expect(expect![[r#"
+    test_builder().wat(SIMPLE_CONTRACT).method("").expect(&expect![[r#"
         VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
         Err: MethodEmptyName
     "#]]);
@@ -394,7 +394,7 @@ fn test_panic_re_export() {
   (export "main" (func $panic))
 )"#,
         )
-        .expect(expect![[r#"
+        .expect(&expect![[r#"
             VMOutcome: balance 4 storage_usage 12 return data None burnt gas 312352074 used gas 312352074
             Err: Smart contract panicked: explicit guest panic
         "#]]);
@@ -445,7 +445,7 @@ fn test_stack_instrumentation_protocol_upgrade() {
         .opaque_error()
         .expects(&[
             expect![[r#"
-                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 6789985365 used gas 6789985365
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 18136872021 used gas 18136872021
                 Err: ...
             "#]],
             expect![[r#"
@@ -480,7 +480,7 @@ fn test_stack_instrumentation_protocol_upgrade() {
         .skip_wasmtime()
         .expects(&[
             expect![[r#"
-                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 6789985365 used gas 6789985365
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 18136872021 used gas 18136872021
                 Err: ...
             "#]],
             expect![[r#"
@@ -511,7 +511,7 @@ fn test_memory_grow() {
 )"#,
         )
         .gas(10u64.pow(10))
-        .expect(expect![[r#"
+        .expect(&expect![[r#"
             VMOutcome: balance 4 storage_usage 12 return data None burnt gas 10000000000 used gas 10000000000
             Err: Exceeded the prepaid gas.
         "#]]);
@@ -613,7 +613,7 @@ fn test_bad_import_3() {
 
 #[test]
 fn test_bad_import_4() {
-    test_builder().wasm(&bad_import_func("env")).opaque_error().expect(expect![[r#"
+    test_builder().wasm(&bad_import_func("env")).opaque_error().expect(&expect![[r#"
         VMOutcome: balance 4 storage_usage 12 return data None burnt gas 47800713 used gas 47800713
         Err: ...
     "#]]);
@@ -630,7 +630,7 @@ fn test_initializer_no_gas() {
 )"#,
         )
         .gas(0)
-        .expect(expect![[r#"
+        .expect(&expect![[r#"
             VMOutcome: balance 4 storage_usage 12 return data None burnt gas 0 used gas 0
             Err: Exceeded the prepaid gas.
         "#]]);
@@ -652,7 +652,7 @@ fn test_bad_many_imports() {
                 )"#,
         ))
         .opaque_error()
-        .expect(expect![[r#"
+        .expect(&expect![[r#"
             VMOutcome: balance 4 storage_usage 12 return data None burnt gas 299447463 used gas 299447463
             Err: ...
         "#]])
@@ -684,7 +684,7 @@ fn test_external_call_ok() {
 
 #[test]
 fn test_external_call_error() {
-    test_builder().wat(EXTERNAL_CALL_CONTRACT).gas(100).expect(expect![[r#"
+    test_builder().wat(EXTERNAL_CALL_CONTRACT).gas(100).expect(&expect![[r#"
         VMOutcome: balance 4 storage_usage 12 return data None burnt gas 100 used gas 100
         Err: Exceeded the prepaid gas.
     "#]]);
@@ -833,7 +833,7 @@ fn test_nan_sign() {
 // even load a contract.
 #[test]
 fn test_gas_exceed_loading() {
-    test_builder().wat(SIMPLE_CONTRACT).method("non_empty_non_existing").gas(1).expect(expect![[
+    test_builder().wat(SIMPLE_CONTRACT).method("non_empty_non_existing").gas(1).expect(&expect![[
         r#"
             VMOutcome: balance 4 storage_usage 12 return data None burnt gas 1 used gas 1
             Err: Exceeded the prepaid gas.
@@ -854,7 +854,7 @@ fn gas_overflow_direct_call() {
     (call $gas (i32.const 0xffff_ffff)))
 )"#,
         )
-        .expect(expect![[r#"
+        .expect(&expect![[r#"
             VMOutcome: balance 4 storage_usage 12 return data None burnt gas 100000000000000 used gas 100000000000000
             Err: Exceeded the maximum amount of gas allowed to burn per contract.
         "#]]);
@@ -881,7 +881,7 @@ fn gas_overflow_indirect_call() {
       (i32.const 0)))
 )"#,
         )
-        .expect(expect![[r#"
+        .expect(&expect![[r#"
             VMOutcome: balance 4 storage_usage 12 return data None burnt gas 100000000000000 used gas 100000000000000
             Err: Exceeded the maximum amount of gas allowed to burn per contract.
         "#]]);
@@ -908,15 +908,15 @@ mod fix_contract_loading_cost_protocol_upgrade {
         test_builder()
             .wat(ALMOST_TRIVIAL_CONTRACT)
             .protocol_features(&[
+                ProtocolFeature::PreparationV2,
                 ProtocolFeature::FixContractLoadingCost,
-                ProtocolFeature::PreparationV2
             ])
             .expects(&[
                 expect![[r#"
-                    VMOutcome: balance 4 storage_usage 12 return data None burnt gas 53989035 used gas 53989035
+                    VMOutcome: balance 4 storage_usage 12 return data None burnt gas 47406987 used gas 47406987
                 "#]],
                 expect![[r#"
-                    VMOutcome: balance 4 storage_usage 12 return data None burnt gas 47406987 used gas 47406987
+                    VMOutcome: balance 4 storage_usage 12 return data None burnt gas 53989035 used gas 53989035
                 "#]],
                 expect![[r#"
                     VMOutcome: balance 4 storage_usage 12 return data None burnt gas 53989035 used gas 53989035
@@ -1062,8 +1062,8 @@ mod fix_contract_loading_cost_protocol_upgrade {
 
 #[test]
 fn test_regression_9393() {
-    let before_builder = test_builder().protocol_versions(vec![62]);
-    let after_builder = test_builder().protocol_versions(vec![63]);
+    let before_builder = test_builder().only_protocol_versions(vec![62]);
+    let after_builder = test_builder().only_protocol_versions(vec![63]);
     let before_cost = before_builder.configs().next().unwrap().wasm_config.regular_op_cost;
     let after_cost = after_builder.configs().next().unwrap().wasm_config.regular_op_cost;
     assert_eq!(

--- a/runtime/near-vm-runner/src/tests/test_builder.rs
+++ b/runtime/near-vm-runner/src/tests/test_builder.rs
@@ -3,13 +3,8 @@ use crate::logic::{mocks::mock_external::MockedExternal, ProtocolVersion, VMCont
 use near_primitives::runtime::{
     config::RuntimeConfig, config_store::RuntimeConfigStore, fees::RuntimeFeesConfig,
 };
-use near_primitives_core::{
-    contract::ContractCode,
-    types::Gas,
-    version::{ProtocolFeature, PROTOCOL_VERSION},
-};
-use std::sync::Arc;
-use std::{collections::HashSet, fmt::Write};
+use near_primitives_core::{contract::ContractCode, types::Gas, version::ProtocolFeature};
+use std::{collections::HashSet, fmt::Write, sync::Arc};
 
 pub(crate) fn test_builder() -> TestBuilder {
     let context = VMContext {
@@ -34,7 +29,7 @@ pub(crate) fn test_builder() -> TestBuilder {
         code: ContractCode::new(Vec::new(), None),
         context,
         method: "main".to_string(),
-        protocol_versions: vec![PROTOCOL_VERSION],
+        protocol_versions: vec![u32::MAX],
         skip: HashSet::new(),
         opaque_error: false,
         opaque_outcome: false,
@@ -135,8 +130,7 @@ impl TestBuilder {
         self.skip_wasmer0().skip_wasmer2().skip_wasmtime()
     }
 
-    /// Run  the necessary tests to check protocol upgrades for the given
-    /// features.
+    /// Add additional protocol features to this test.
     ///
     /// Tricky. Given `[feat1, feat2, feat3]`, this will run *four* tests for
     /// protocol versions `[feat1 - 1, feat2 - 1, feat3 - 1, PROTOCOL_VERSION]`.
@@ -144,27 +138,33 @@ impl TestBuilder {
     /// When using this method with `n` features, be sure to pass `n + 1`
     /// expectations to the `expects` method. For nightly features, you can
     /// `cfg` the relevant features and expect.
-    pub(crate) fn protocol_features(self, protocol_features: &'static [ProtocolFeature]) -> Self {
-        let mut protocol_versions = Vec::new();
+    pub(crate) fn protocol_features(
+        mut self,
+        protocol_features: &'static [ProtocolFeature],
+    ) -> Self {
         for feat in protocol_features {
-            protocol_versions.push(feat.protocol_version() - 1)
+            self = self.protocol_version(feat.protocol_version() - 1);
         }
-        protocol_versions.push(PROTOCOL_VERSION);
-
-        self.protocol_versions(protocol_versions)
+        self
     }
 
-    /// Run the tests for each protocol version.
-    ///
-    /// Generally you should call `protocol_features` instead.
-    pub(crate) fn protocol_versions(mut self, protocol_versions: Vec<ProtocolVersion>) -> Self {
+    /// Add a protocol version to test.
+    pub(crate) fn protocol_version(mut self, protocol_version: ProtocolVersion) -> Self {
+        self.protocol_versions.push(protocol_version - 1);
+        self
+    }
+
+    pub(crate) fn only_protocol_versions(
+        mut self,
+        protocol_versions: Vec<ProtocolVersion>,
+    ) -> Self {
         self.protocol_versions = protocol_versions;
         self
     }
 
     #[track_caller]
-    pub(crate) fn expect(self, want: expect_test::Expect) {
-        self.expects(&[want])
+    pub(crate) fn expect(self, want: &expect_test::Expect) {
+        self.expects(std::iter::once(want))
     }
 
     pub(crate) fn configs(&self) -> impl Iterator<Item = Arc<RuntimeConfig>> {
@@ -176,9 +176,14 @@ impl TestBuilder {
     }
 
     #[track_caller]
-    pub(crate) fn expects(self, wants: &[expect_test::Expect]) {
+    pub(crate) fn expects<'a, I>(mut self, wants: I)
+    where
+        I: IntoIterator<Item = &'a expect_test::Expect>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        self.protocol_versions.sort();
         let runtime_config_store = RuntimeConfigStore::new(None);
-
+        let wants = wants.into_iter();
         assert_eq!(
             wants.len(),
             self.protocol_versions.len(),
@@ -187,7 +192,7 @@ impl TestBuilder {
             wants.len(),
         );
 
-        for (want, &protocol_version) in wants.iter().zip(&self.protocol_versions) {
+        for (want, &protocol_version) in wants.zip(&self.protocol_versions) {
             let mut results = vec![];
             for vm_kind in [VMKind::NearVm, VMKind::Wasmer2, VMKind::Wasmer0, VMKind::Wasmtime] {
                 if self.skip.contains(&vm_kind) {
@@ -212,6 +217,7 @@ impl TestBuilder {
                 let promise_results = vec![];
 
                 let runtime = vm_kind.runtime(config).expect("runtime has not been compiled");
+                println!("Running {:?} for protocol version {}", vm_kind, protocol_version);
                 let outcome = runtime
                     .run(
                         &self.code,

--- a/runtime/near-vm-runner/src/tests/wasm_validation.rs
+++ b/runtime/near-vm-runner/src/tests/wasm_validation.rs
@@ -115,7 +115,7 @@ fn ensure_fails_verification() {
 #[test]
 fn ensure_fails_execution() {
     for (_feature_name, wat) in EXPECTED_UNSUPPORTED {
-        test_builder().wat(wat).opaque_error().opaque_outcome().expect(expect![[r#"
+        test_builder().wat(wat).opaque_error().opaque_outcome().expect(&expect![[r#"
             Err: ...
         "#]]);
     }


### PR DESCRIPTION
This change allows more control over which versions of the protocols tests will be run. Sorting the tested versions also helps with maintaining the consistent order of expects, and finally expects can be passed across multiple different test builders now, thus ensuring that tests which verify result stays the same don't become wrong after a stray `UPDATE_EXPECT=1` run.