### PR TITLE
test: parallel account creation in loadtest

### DIFF
--- a/pytest/tests/loadtest/locust/common/base.py
+++ b/pytest/tests/loadtest/locust/common/base.py
@@ -392,12 +392,16 @@ class NearNodeProxy:
         #
         # FSM outline:
         #
-        # [INIT] -> [TO_CREATE] --(post tx)--> [INFLIGHT] --(poll result)--> [TO_REFRESH] --(refresh)--> [DONE]
-        #   |        ^                    |        ^                    |         ^
-        #   |        |                    |        |                    |         |
-        #   |        |--(fail to submit)<--        |-----(not ready)<----         |
-        #   |                                                                     |
-        #   ----------------(account exists already)------------------------------|
+        #    [INIT] -----------------(account exists already)-------------
+        #       |                                                        |
+        #       V                                                        V
+        #  [TO_CREATE] --(post tx)--> [INFLIGHT] --(poll result)--> [TO_REFRESH]
+        #   ^                    |                                       |
+        #   |                    |                                       |
+        #   |--(fail to submit)<--                                   (refresh)
+        #                                                                |
+        #                                                                V
+        #                                                              [DONE]
         #
         to_create: typing.List[Account] = []
         inflight: typing.List[Transaction, dict, Account] = []

--- a/pytest/tests/loadtest/locust/common/base.py
+++ b/pytest/tests/loadtest/locust/common/base.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 from locust import User, events, runners
 from retrying import retry
 import abc
@@ -263,24 +263,14 @@ class NearNodeProxy:
                 )
                 time.sleep(0.25)
 
-    def send_tx(self, tx: Transaction, locust_name) -> dict:
+    def send_tx(self, tx: Transaction, locust_name: str) -> dict:
         """
         Send a transaction and return the result, no retry attempted.
         """
-        block_hash = base58.b58decode(
-            self.node.get_final_block()['result']['header']['hash'])
+        block_hash = self.final_block_hash()
         signed_tx = tx.sign_and_serialize(block_hash)
 
-        meta = {
-            "request_type": "near-rpc",
-            "name": locust_name,
-            "start_time": time.time(),
-            "response_time": 0,  # overwritten later  with end-to-end time
-            "response_length": 0,  # overwritten later
-            "response": None,  # overwritten later
-            "context": {},  # not used  right now
-            "exception": None,  # maybe overwritten later
-        }
+        meta = self.new_locust_metadata(locust_name)
         start_perf_counter = time.perf_counter()
 
         try:
@@ -318,6 +308,22 @@ class NearNodeProxy:
         # Track request + response in Locust
         self.request_event.fire(**meta)
         return meta
+
+    def final_block_hash(self):
+        return base58.b58decode(
+            self.node.get_final_block()['result']['header']['hash'])
+
+    def new_locust_metadata(self, locust_name: str):
+        return {
+            "request_type": "near-rpc",
+            "name": locust_name,
+            "start_time": time.time(),
+            "response_time": 0,  # overwritten later  with end-to-end time
+            "response_length": 0,  # overwritten later
+            "response": None,  # overwritten later
+            "context": {},  # not used  right now
+            "exception": None,  # maybe overwritten later
+        }
 
     def post_json(self, method: str, params: typing.List[str]):
         j = {
@@ -363,6 +369,94 @@ class NearNodeProxy:
                 CreateSubAccount(parent, account.key, balance=balance), msg)
         account.refresh_nonce(self.node)
         return exists
+
+    def prepare_accounts(self,
+                         accounts: typing.List[Account],
+                         parent: Account,
+                         balance: int,
+                         msg: str,
+                         timeout: timedelta = timedelta(minutes=3)):
+        """
+        Creates accounts if they don't exist and refreshes their nonce.
+        Accounts must share the parent account.
+        
+        This implementation attempts on-chain parallelization, hence it should
+        be faster than calling `prepare_account` in a loop.
+        
+        Note that error-handling in this variant isn't quite as smooth. Errors
+        that are only reported by the sync API of RPC nodes will not be caught
+        here. Instead, we do a best-effort retry and stop after a fixed timeout.
+        """
+
+        # To avoid blocking, each account goes though a FSM independently.
+        #
+        # FSM outline:
+        #
+        # [INIT] -> [TO_CREATE] --(post tx)--> [INFLIGHT] --(poll result)--> [TO_REFRESH] --(refresh)--> [DONE]
+        #   |        ^                    |        ^                    |         ^
+        #   |        |                    |        |                    |         |
+        #   |        |--(fail to submit)<--        |-----(not ready)<----         |
+        #   |                                                                     |
+        #   ----------------(account exists already)------------------------------|
+        #
+        to_create: typing.List[Account] = []
+        inflight: typing.List[Transaction, dict, Account] = []
+        to_refresh: typing.List[Account] = []
+
+        for account in accounts:
+            if self.account_exists(account.key.account_id):
+                to_refresh.append(account)
+            else:
+                to_create.append(account)
+
+        block_hash = self.final_block_hash()
+        start = datetime.now()
+        while len(to_create) + len(to_refresh) + len(inflight) > 0:
+            logger.info(
+                f"preparing {len(accounts)} accounts, {len(to_create)} to create, {len(to_refresh)} to refresh, {len(inflight)} inflight"
+            )
+            if start + timeout < datetime.now():
+                raise SystemExit("Account preparation timed out")
+            try_again = []
+            for account in to_create:
+                meta = self.new_locust_metadata(msg)
+                tx = CreateSubAccount(parent, account.key, balance=balance)
+                signed_tx = tx.sign_and_serialize(block_hash)
+                submit_raw_response = self.post_json(
+                    "broadcast_tx_async",
+                    [base64.b64encode(signed_tx).decode('utf8')])
+                meta["response_length"] = len(submit_raw_response.text)
+                submit_response = submit_raw_response.json()
+                if not "result" in submit_response:
+                    # something failed, let's not block, just try again later
+                    logger.debug(
+                        f"couldn't submit account creation TX, got {submit_raw_response.text}"
+                    )
+                    try_again.append(account)
+                else:
+                    tx.transaction_id = submit_response["result"]
+                    inflight.append((tx, meta, account))
+            to_create = try_again
+
+            # while requests are processed on-chain, refresh nonces for existing accounts
+            for account in to_refresh:
+                account.refresh_nonce(self.node)
+            to_refresh.clear()
+
+            # poll all pending requests
+            for tx, meta, account in inflight:
+                # Using retrying lib here to poll until a response is ready.
+                # This is blocking on a single request, but we expect requests
+                # to be processed in order so it shouldn't matter.
+                self.poll_tx_result(meta, tx)
+                meta["response_time"] = (time.time() -
+                                         meta["start_time"]) * 1000
+                to_refresh.append(account)
+                # Locust tracking
+                self.request_event.fire(**meta)
+            inflight.clear()
+
+        logger.info(f"done preparing {len(accounts)} accounts")
 
 
 class NearUser(User):
@@ -626,12 +720,16 @@ def do_on_locust_init(environment):
     if isinstance(environment.runner, runners.MasterRunner):
         num_funding_accounts = environment.parsed_options.max_workers
         funding_balance = 10000 * NearUser.INIT_BALANCE
-        # TODO: Create accounts in parallel
-        for id in range(num_funding_accounts):
+
+        def create_account(id):
             account_id = f"funds_worker_{id}.{master_funding_account.key.account_id}"
-            worker_key = key.Key.from_seed_testonly(account_id)
-            node.prepare_account(Account(worker_key), master_funding_account,
-                                 funding_balance, "create funding account")
+            return Account(key.Key.from_seed_testonly(account_id))
+
+        funding_accounts = [
+            create_account(id) for id in range(num_funding_accounts)
+        ]
+        node.prepare_accounts(funding_accounts, master_funding_account,
+                              funding_balance, "create funding account")
         funding_account = master_funding_account
     elif isinstance(environment.runner, runners.WorkerRunner):
         worker_id = environment.runner.worker_index

--- a/pytest/tests/loadtest/locust/common/sweat.py
+++ b/pytest/tests/loadtest/locust/common/sweat.py
@@ -167,12 +167,15 @@ def on_locust_init(environment, **kwargs):
     if isinstance(environment.runner, locust.runners.MasterRunner):
         num_oracles = int(environment.parsed_options.max_workers)
         oracle_accounts = [
-            Account(key.Key.from_seed_testonly(worker_oracle_id(id, run_id,environment.master_funding_account)))
+            Account(
+                key.Key.from_seed_testonly(
+                    worker_oracle_id(id, run_id,
+                                     environment.master_funding_account)))
             for id in range(num_oracles)
         ]
         node.prepare_accounts(oracle_accounts,
-                                 environment.master_funding_account, 100000,
-                                 "create contract account")
+                              environment.master_funding_account, 100000,
+                              "create contract account")
         for oracle in oracle_accounts:
             id = oracle.key.account_id
             environment.sweat.register_oracle(node, id)

--- a/pytest/tests/loadtest/locust/common/sweat.py
+++ b/pytest/tests/loadtest/locust/common/sweat.py
@@ -166,14 +166,15 @@ def on_locust_init(environment, **kwargs):
     # on master, register oracles for workers
     if isinstance(environment.runner, locust.runners.MasterRunner):
         num_oracles = int(environment.parsed_options.max_workers)
-        # TODO: Add oracles in parallel
-        for worker_id in range(num_oracles):
-            id = worker_oracle_id(worker_id, run_id,
-                                  environment.master_funding_account)
-            worker_oracle = Account(key.Key.from_seed_testonly(id))
-            node.prepare_account(worker_oracle,
+        oracle_accounts = [
+            Account(key.Key.from_seed_testonly(worker_oracle_id(id, run_id,environment.master_funding_account)))
+            for id in range(num_oracles)
+        ]
+        node.prepare_accounts(oracle_accounts,
                                  environment.master_funding_account, 100000,
                                  "create contract account")
+        for oracle in oracle_accounts:
+            id = oracle.key.account_id
             environment.sweat.register_oracle(node, id)
             environment.sweat.top_up(node, id)
 


### PR DESCRIPTION
Create accounts in parallel where easily possible. This shaves off 20-30s in a typical Sweat load scenario.

Sadly, we still block on FT contract creation and deployment. We need some generalization of what I do here, or maybe some `deploy_contracts` helper.
Submitting this PR for now as it is a step in the right direction. Maybe feedback on the PR will change the direction of the next.