### PR TITLE
feat: allow updating config.json in mirror script

### DIFF
--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -376,16 +376,16 @@ class NeardRunner:
                         'protocol_version': protocol_version,
                     }, f)
 
-    def do_update_config(self, shard_cache_size_mb):
+    def do_update_config(self, state_cache_size_mb):
         with self.lock:
-            logging.info(f'updating config with {shard_cache_size_mb}')
+            logging.info(f'updating config with {state_cache_size_mb}')
             with open(self.target_near_home_path('config.json'), 'r') as f:
                 config = json.load(f)
 
             config['store']['trie_cache']['per_shard_max_bytes'] = {}
-            if shard_cache_size_mb is not None:
+            if state_cache_size_mb is not None:
                 for i in range(4):
-                    config['store']['trie_cache']['per_shard_max_bytes'][f's{i}.v1'] = shard_cache_size_mb * 10**6
+                    config['store']['trie_cache']['per_shard_max_bytes'][f's{i}.v1'] = state_cache_size_mb * 10**6
 
             with open(self.target_near_home_path('config.json'), 'w') as f:
                 json.dump(config, f, indent=2)

--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -53,6 +53,8 @@ class JSONHandler(http.server.BaseHTTPRequestHandler):
                                    name="new_test")
         self.dispatcher.add_method(server.neard_runner.do_network_init,
                                    name="network_init")
+        self.dispatcher.add_method(server.neard_runner.do_update_config,
+                                   name="update_config")
         self.dispatcher.add_method(server.neard_runner.do_ready, name="ready")
         self.dispatcher.add_method(server.neard_runner.do_start, name="start")
         self.dispatcher.add_method(server.neard_runner.do_stop, name="stop")
@@ -373,6 +375,22 @@ class NeardRunner:
                         'num_seats': num_seats,
                         'protocol_version': protocol_version,
                     }, f)
+
+    def do_update_config(self, shard_cache_size_mb):
+        with self.lock:
+            logging.info(f'updating config with {shard_cache_size_mb}')
+            with open(self.target_near_home_path('config.json'), 'r') as f:
+                config = json.load(f)
+
+            config['store']['trie_cache']['per_shard_max_bytes'] = {}
+            if shard_cache_size_mb is not None:
+                for i in range(4):
+                    config['store']['trie_cache']['per_shard_max_bytes'][f's{i}.v1'] = shard_cache_size_mb * 10**6
+
+            with open(self.target_near_home_path('config.json'), 'w') as f:
+                json.dump(config, f, indent=2)
+
+        return True
 
     def do_start(self):
         with self.lock:

--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -385,7 +385,8 @@ class NeardRunner:
             config['store']['trie_cache']['per_shard_max_bytes'] = {}
             if state_cache_size_mb is not None:
                 for i in range(4):
-                    config['store']['trie_cache']['per_shard_max_bytes'][f's{i}.v1'] = state_cache_size_mb * 10**6
+                    config['store']['trie_cache']['per_shard_max_bytes'][
+                        f's{i}.v1'] = state_cache_size_mb * 10**6
 
             with open(self.target_near_home_path('config.json'), 'w') as f:
                 json.dump(config, f, indent=2)

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -361,6 +361,22 @@ def neard_runner_network_init(node, validators, boot_nodes, epoch_length,
                                     'protocol_version': protocol_version,
                                 })
 
+def neard_update_config(node, shard_cache_size_mb):
+    return neard_runner_jsonrpc(node,
+                                'update_config',
+                                params={
+                                    'shard_cache_size_mb': shard_cache_size_mb,
+                                })
+
+def update_config_cmd(args, traffic_generator, nodes):
+    nodes = nodes + [traffic_generator]
+    results = pmap(lambda node: neard_update_config(node,
+                                                    args.shard_cache_size_mb), nodes)
+    if not all(results):
+        logger.warn(
+            'failed to update configs for some nodes'
+        )
+        return
 
 def neard_runner_ready(node):
     return neard_runner_jsonrpc(node, 'ready')
@@ -416,6 +432,13 @@ if __name__ == '__main__':
     init_parser.add_argument('--neard-binary-url', type=str)
     init_parser.add_argument('--neard-upgrade-binary-url', type=str)
     init_parser.set_defaults(func=init_cmd)
+
+    update_config_parser = subparsers.add_parser('update-config',
+                                                 help='''
+        Update config.json with given flags for all nodes.
+        ''')
+    update_config_parser.add_argument('--shard-cache-size-mb', type=int)
+    update_config_parser.set_defaults(func=update_config_cmd)
 
     restart_parser = subparsers.add_parser('restart-neard-runner',
                                            help='''

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -361,17 +361,17 @@ def neard_runner_network_init(node, validators, boot_nodes, epoch_length,
                                     'protocol_version': protocol_version,
                                 })
 
-def neard_update_config(node, shard_cache_size_mb):
+def neard_update_config(node, state_cache_size_mb):
     return neard_runner_jsonrpc(node,
                                 'update_config',
                                 params={
-                                    'shard_cache_size_mb': shard_cache_size_mb,
+                                    'state_cache_size_mb': state_cache_size_mb,
                                 })
 
 def update_config_cmd(args, traffic_generator, nodes):
     nodes = nodes + [traffic_generator]
     results = pmap(lambda node: neard_update_config(node,
-                                                    args.shard_cache_size_mb), nodes)
+                                                    args.state_cache_size_mb), nodes)
     if not all(results):
         logger.warn(
             'failed to update configs for some nodes'
@@ -437,7 +437,7 @@ if __name__ == '__main__':
                                                  help='''
         Update config.json with given flags for all nodes.
         ''')
-    update_config_parser.add_argument('--shard-cache-size-mb', type=int)
+    update_config_parser.add_argument('--state-cache-size-mb', type=int)
     update_config_parser.set_defaults(func=update_config_cmd)
 
     restart_parser = subparsers.add_parser('restart-neard-runner',

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -361,6 +361,7 @@ def neard_runner_network_init(node, validators, boot_nodes, epoch_length,
                                     'protocol_version': protocol_version,
                                 })
 
+
 def neard_update_config(node, state_cache_size_mb):
     return neard_runner_jsonrpc(node,
                                 'update_config',
@@ -368,15 +369,15 @@ def neard_update_config(node, state_cache_size_mb):
                                     'state_cache_size_mb': state_cache_size_mb,
                                 })
 
+
 def update_config_cmd(args, traffic_generator, nodes):
     nodes = nodes + [traffic_generator]
-    results = pmap(lambda node: neard_update_config(node,
-                                                    args.state_cache_size_mb), nodes)
+    results = pmap(
+        lambda node: neard_update_config(node, args.state_cache_size_mb), nodes)
     if not all(results):
-        logger.warn(
-            'failed to update configs for some nodes'
-        )
+        logger.warn('failed to update configs for some nodes')
         return
+
 
 def neard_runner_ready(node):
     return neard_runner_jsonrpc(node, 'ready')


### PR DESCRIPTION
I find it useful to modify config.json-s for mirrored traffic tests. This doesn't require separate binaries which are built in >10 minutes and allows to skip setup restarts and manual ssh-ing to each node.

Here I allow to modify only state cache size because this is required for testing #9375 - we want to reduce size of 3GB cache at least. But it is easily extendable for other config parameters, I just didn't find generic way to do it.