### PR TITLE
[WIP] Reduce size of the Action enum using Box

### DIFF
--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -1044,12 +1044,12 @@ impl RuntimeAdapter for KeyValueRuntime {
                 assert_eq!(account_id_to_shard_id(&receipt.receiver_id, self.num_shards), shard_id);
                 if !state.receipt_nonces.contains(&receipt.receipt_id) {
                     state.receipt_nonces.insert(receipt.receipt_id);
-                    if let Action::Transfer(TransferAction { deposit }) = action.actions[0] {
+                    if let Action::Transfer(transfer_action) = &action.actions[0] {
                         balance_transfers.push((
                             receipt.get_hash(),
                             receipt.predecessor_id.clone(),
                             receipt.receiver_id.clone(),
-                            deposit,
+                            transfer_action.deposit,
                             0,
                         ));
                     }
@@ -1069,8 +1069,7 @@ impl RuntimeAdapter for KeyValueRuntime {
             if transaction.transaction.actions.is_empty() {
                 continue;
             }
-            if let Action::Transfer(TransferAction { deposit }) = transaction.transaction.actions[0]
-            {
+            if let Action::Transfer(transfer_action) = &transaction.transaction.actions[0] {
                 if !state.tx_nonces.contains(&AccountNonce(
                     transaction.transaction.receiver_id.clone(),
                     transaction.transaction.nonce,
@@ -1083,7 +1082,7 @@ impl RuntimeAdapter for KeyValueRuntime {
                         transaction.get_hash(),
                         transaction.transaction.signer_id.clone(),
                         transaction.transaction.receiver_id.clone(),
-                        deposit,
+                        transfer_action.deposit,
                         transaction.transaction.nonce,
                     ));
                 } else {
@@ -1133,7 +1132,9 @@ impl RuntimeAdapter for KeyValueRuntime {
                             gas_price,
                             output_data_receivers: vec![],
                             input_data_ids: vec![],
-                            actions: vec![Action::Transfer(TransferAction { deposit: amount })],
+                            actions: vec![Action::Transfer(Box::new(TransferAction {
+                                deposit: amount,
+                            }))],
                         }),
                     };
                     let receipt_hash = receipt.get_hash();

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -2177,7 +2177,7 @@ impl TestEnv {
             relayer,
             sender,
             &relayer_signer,
-            vec![Action::Delegate(signed_delegate_action)],
+            vec![Action::Delegate(Box::new(signed_delegate_action))],
             tip.last_block_hash,
         )
     }
@@ -2216,12 +2216,12 @@ impl TestEnv {
     /// deployed already.
     pub fn call_main(&mut self, account: &AccountId) -> FinalExecutionOutcomeView {
         let signer = InMemorySigner::from_seed(account.clone(), KeyType::ED25519, account.as_str());
-        let actions = vec![Action::FunctionCall(FunctionCallAction {
+        let actions = vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "main".to_string(),
             args: vec![],
             gas: 3 * 10u64.pow(14),
             deposit: 0,
-        })];
+        }))];
         let tx = self.tx_from_actions(actions, &signer, signer.account_id.clone());
         self.execute_tx(tx).unwrap()
     }

--- a/chain/network/src/peer_manager/tests/routing.rs
+++ b/chain/network/src/peer_manager/tests/routing.rs
@@ -27,6 +27,8 @@ use std::collections::HashSet;
 use std::net::Ipv6Addr;
 use std::sync::Arc;
 
+use near_primitives::transaction::Action;
+
 // test routing in a two-node network before and after connecting the nodes
 #[tokio::test]
 async fn simple() {
@@ -1383,4 +1385,9 @@ async fn connect_to_unbanned_peer() {
 
     drop(pm0);
     drop(pm1);
+}
+
+#[test]
+fn saketh() {
+    println!("action size: {}", std::mem::size_of::<Action>());
 }

--- a/chain/rosetta-rpc/src/adapters/mod.rs
+++ b/chain/rosetta-rpc/src/adapters/mod.rs
@@ -1096,7 +1096,7 @@ mod tests {
         let original_near_actions = NearActions {
             sender_account_id: "proxy.near".parse().unwrap(),
             receiver_account_id: "account.near".parse().unwrap(),
-            actions: vec![Action::Delegate(SignedDelegateAction {
+            actions: vec![Action::Delegate(Box::new(SignedDelegateAction {
                 delegate_action: DelegateAction {
                     sender_id: "account.near".parse().unwrap(),
                     receiver_id: "receiver.near".parse().unwrap(),
@@ -1108,7 +1108,7 @@ mod tests {
                     public_key: sk.public_key(),
                 },
                 signature: sk.sign(&[0]),
-            })],
+            }))],
         };
 
         let operations: Vec<crate::models::Operation> =

--- a/chain/rosetta-rpc/src/adapters/mod.rs
+++ b/chain/rosetta-rpc/src/adapters/mod.rs
@@ -1100,7 +1100,7 @@ mod tests {
                 delegate_action: DelegateAction {
                     sender_id: "account.near".parse().unwrap(),
                     receiver_id: "receiver.near".parse().unwrap(),
-                    actions: vec![Action::Transfer(TransferAction { deposit: 1 })
+                    actions: vec![Action::Transfer(Box::new(TransferAction { deposit: 1 }))
                         .try_into()
                         .unwrap()],
                     nonce: 0,

--- a/core/primitives/benches/serialization.rs
+++ b/core/primitives/benches/serialization.rs
@@ -21,7 +21,7 @@ use num_rational::Rational32;
 fn create_transaction() -> SignedTransaction {
     let mut actions = vec![];
     for _ in 0..10 {
-        actions.push(Action::Transfer(TransferAction { deposit: 1_000_000_000 }));
+        actions.push(Action::Transfer(Box::new(TransferAction { deposit: 1_000_000_000 })));
     }
     SignedTransaction::new(
         Signature::empty(KeyType::ED25519),

--- a/core/primitives/src/action/delegate.rs
+++ b/core/primitives/src/action/delegate.rs
@@ -56,7 +56,7 @@ impl SignedDelegateAction {
 
 impl From<SignedDelegateAction> for Action {
     fn from(delegate_action: SignedDelegateAction) -> Self {
-        Self::Delegate(delegate_action)
+        Self::Delegate(Box::new(delegate_action))
     }
 }
 
@@ -150,7 +150,7 @@ mod tests {
     );
 
     fn create_delegate_action(actions: Vec<Action>) -> Action {
-        Action::Delegate(SignedDelegateAction {
+        Action::Delegate(Box::new(SignedDelegateAction {
             delegate_action: DelegateAction {
                 sender_id: "aaa".parse().unwrap(),
                 receiver_id: "bbb".parse().unwrap(),
@@ -163,7 +163,7 @@ mod tests {
                 public_key: PublicKey::empty(KeyType::ED25519),
             },
             signature: Signature::empty(KeyType::ED25519),
-        })
+        }))
     }
 
     #[test]

--- a/core/primitives/src/action/mod.rs
+++ b/core/primitives/src/action/mod.rs
@@ -170,13 +170,13 @@ pub enum Action {
     CreateAccount(CreateAccountAction),
     /// Sets a Wasm code to a receiver_id
     DeployContract(DeployContractAction),
-    FunctionCall(FunctionCallAction),
+    FunctionCall(Box<FunctionCallAction>),
     Transfer(TransferAction),
-    Stake(StakeAction),
-    AddKey(AddKeyAction),
-    DeleteKey(DeleteKeyAction),
+    Stake(Box<StakeAction>),
+    AddKey(Box<AddKeyAction>),
+    DeleteKey(Box<DeleteKeyAction>),
     DeleteAccount(DeleteAccountAction),
-    Delegate(delegate::SignedDelegateAction),
+    Delegate(Box<delegate::SignedDelegateAction>),
 }
 
 impl Action {
@@ -209,7 +209,7 @@ impl From<DeployContractAction> for Action {
 
 impl From<FunctionCallAction> for Action {
     fn from(function_call_action: FunctionCallAction) -> Self {
-        Self::FunctionCall(function_call_action)
+        Self::FunctionCall(Box::new(function_call_action))
     }
 }
 
@@ -221,19 +221,19 @@ impl From<TransferAction> for Action {
 
 impl From<StakeAction> for Action {
     fn from(stake_action: StakeAction) -> Self {
-        Self::Stake(stake_action)
+        Self::Stake(Box::new(stake_action))
     }
 }
 
 impl From<AddKeyAction> for Action {
     fn from(add_key_action: AddKeyAction) -> Self {
-        Self::AddKey(add_key_action)
+        Self::AddKey(Box::new(add_key_action))
     }
 }
 
 impl From<DeleteKeyAction> for Action {
     fn from(delete_key_action: DeleteKeyAction) -> Self {
-        Self::DeleteKey(delete_key_action)
+        Self::DeleteKey(Box::new(delete_key_action))
     }
 }
 

--- a/core/primitives/src/action/mod.rs
+++ b/core/primitives/src/action/mod.rs
@@ -169,13 +169,13 @@ pub enum Action {
     /// <http://nomicon.io/Primitives/Account.html>.
     CreateAccount(CreateAccountAction),
     /// Sets a Wasm code to a receiver_id
-    DeployContract(DeployContractAction),
+    DeployContract(Box<DeployContractAction>),
     FunctionCall(Box<FunctionCallAction>),
-    Transfer(TransferAction),
+    Transfer(Box<TransferAction>),
     Stake(Box<StakeAction>),
     AddKey(Box<AddKeyAction>),
     DeleteKey(Box<DeleteKeyAction>),
-    DeleteAccount(DeleteAccountAction),
+    DeleteAccount(Box<DeleteAccountAction>),
     Delegate(Box<delegate::SignedDelegateAction>),
 }
 
@@ -203,7 +203,7 @@ impl From<CreateAccountAction> for Action {
 
 impl From<DeployContractAction> for Action {
     fn from(deploy_contract_action: DeployContractAction) -> Self {
-        Self::DeployContract(deploy_contract_action)
+        Self::DeployContract(Box::new(deploy_contract_action))
     }
 }
 
@@ -215,7 +215,7 @@ impl From<FunctionCallAction> for Action {
 
 impl From<TransferAction> for Action {
     fn from(transfer_action: TransferAction) -> Self {
-        Self::Transfer(transfer_action)
+        Self::Transfer(Box::new(transfer_action))
     }
 }
 
@@ -239,6 +239,6 @@ impl From<DeleteKeyAction> for Action {
 
 impl From<DeleteAccountAction> for Action {
     fn from(delete_account_action: DeleteAccountAction) -> Self {
-        Self::DeleteAccount(delete_account_action)
+        Self::DeleteAccount(Box::new(delete_account_action))
     }
 }

--- a/core/primitives/src/receipt.rs
+++ b/core/primitives/src/receipt.rs
@@ -64,7 +64,7 @@ impl Receipt {
                 gas_price: 0,
                 output_data_receivers: vec![],
                 input_data_ids: vec![],
-                actions: vec![Action::Transfer(TransferAction { deposit: refund })],
+                actions: vec![Action::Transfer(Box::new(TransferAction { deposit: refund }))],
             }),
         }
     }
@@ -91,7 +91,7 @@ impl Receipt {
                 gas_price: 0,
                 output_data_receivers: vec![],
                 input_data_ids: vec![],
-                actions: vec![Action::Transfer(TransferAction { deposit: refund })],
+                actions: vec![Action::Transfer(Box::new(TransferAction { deposit: refund }))],
             }),
         }
     }

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -60,12 +60,12 @@ impl Transaction {
         gas: Gas,
         deposit: Balance,
     ) -> Self {
-        self.actions.push(Action::FunctionCall(FunctionCallAction {
+        self.actions.push(Action::FunctionCall(Box::new(FunctionCallAction {
             method_name,
             args,
             gas,
             deposit,
-        }));
+        })));
         self
     }
 
@@ -75,16 +75,16 @@ impl Transaction {
     }
 
     pub fn stake(mut self, stake: Balance, public_key: PublicKey) -> Self {
-        self.actions.push(Action::Stake(StakeAction { stake, public_key }));
+        self.actions.push(Action::Stake(Box::new(StakeAction { stake, public_key })));
         self
     }
     pub fn add_key(mut self, public_key: PublicKey, access_key: AccessKey) -> Self {
-        self.actions.push(Action::AddKey(AddKeyAction { public_key, access_key }));
+        self.actions.push(Action::AddKey(Box::new(AddKeyAction { public_key, access_key })));
         self
     }
 
     pub fn delete_key(mut self, public_key: PublicKey) -> Self {
-        self.actions.push(Action::DeleteKey(DeleteKeyAction { public_key }));
+        self.actions.push(Action::DeleteKey(Box::new(DeleteKeyAction { public_key })));
         self
     }
 
@@ -145,7 +145,7 @@ impl SignedTransaction {
             signer_id.clone(),
             signer_id,
             signer,
-            vec![Action::Stake(StakeAction { stake, public_key })],
+            vec![Action::Stake(Box::new(StakeAction { stake, public_key }))],
             block_hash,
         )
     }
@@ -166,10 +166,10 @@ impl SignedTransaction {
             signer,
             vec![
                 Action::CreateAccount(CreateAccountAction {}),
-                Action::AddKey(AddKeyAction {
+                Action::AddKey(Box::new(AddKeyAction {
                     public_key,
                     access_key: AccessKey { nonce: 0, permission: AccessKeyPermission::FullAccess },
-                }),
+                })),
                 Action::Transfer(TransferAction { deposit: amount }),
             ],
             block_hash,
@@ -193,10 +193,10 @@ impl SignedTransaction {
             signer,
             vec![
                 Action::CreateAccount(CreateAccountAction {}),
-                Action::AddKey(AddKeyAction {
+                Action::AddKey(Box::new(AddKeyAction {
                     public_key,
                     access_key: AccessKey { nonce: 0, permission: AccessKeyPermission::FullAccess },
-                }),
+                })),
                 Action::Transfer(TransferAction { deposit: amount }),
                 Action::DeployContract(DeployContractAction { code }),
             ],
@@ -220,7 +220,7 @@ impl SignedTransaction {
             signer_id,
             receiver_id,
             signer,
-            vec![Action::FunctionCall(FunctionCallAction { args, method_name, gas, deposit })],
+            vec![Action::FunctionCall(Box::new(FunctionCallAction { args, method_name, gas, deposit }))],
             block_hash,
         )
     }

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -220,7 +220,12 @@ impl SignedTransaction {
             signer_id,
             receiver_id,
             signer,
-            vec![Action::FunctionCall(Box::new(FunctionCallAction { args, method_name, gas, deposit }))],
+            vec![Action::FunctionCall(Box::new(FunctionCallAction {
+                args,
+                method_name,
+                gas,
+                deposit,
+            }))],
             block_hash,
         )
     }

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -49,7 +49,7 @@ impl Transaction {
     }
 
     pub fn deploy_contract(mut self, code: Vec<u8>) -> Self {
-        self.actions.push(Action::DeployContract(DeployContractAction { code }));
+        self.actions.push(Action::DeployContract(Box::new(DeployContractAction { code })));
         self
     }
 
@@ -70,7 +70,7 @@ impl Transaction {
     }
 
     pub fn transfer(mut self, deposit: Balance) -> Self {
-        self.actions.push(Action::Transfer(TransferAction { deposit }));
+        self.actions.push(Action::Transfer(Box::new(TransferAction { deposit })));
         self
     }
 
@@ -89,7 +89,7 @@ impl Transaction {
     }
 
     pub fn delete_account(mut self, beneficiary_id: AccountId) -> Self {
-        self.actions.push(Action::DeleteAccount(DeleteAccountAction { beneficiary_id }));
+        self.actions.push(Action::DeleteAccount(Box::new(DeleteAccountAction { beneficiary_id })));
         self
     }
 }
@@ -127,7 +127,7 @@ impl SignedTransaction {
             signer_id,
             receiver_id,
             signer,
-            vec![Action::Transfer(TransferAction { deposit })],
+            vec![Action::Transfer(Box::new(TransferAction { deposit }))],
             block_hash,
         )
     }
@@ -170,7 +170,7 @@ impl SignedTransaction {
                     public_key,
                     access_key: AccessKey { nonce: 0, permission: AccessKeyPermission::FullAccess },
                 })),
-                Action::Transfer(TransferAction { deposit: amount }),
+                Action::Transfer(Box::new(TransferAction { deposit: amount })),
             ],
             block_hash,
         )
@@ -197,8 +197,8 @@ impl SignedTransaction {
                     public_key,
                     access_key: AccessKey { nonce: 0, permission: AccessKeyPermission::FullAccess },
                 })),
-                Action::Transfer(TransferAction { deposit: amount }),
-                Action::DeployContract(DeployContractAction { code }),
+                Action::Transfer(Box::new(TransferAction { deposit: amount })),
+                Action::DeployContract(Box::new(DeployContractAction { code })),
             ],
             block_hash,
         )
@@ -243,7 +243,7 @@ impl SignedTransaction {
             signer_id,
             receiver_id,
             signer,
-            vec![Action::DeleteAccount(DeleteAccountAction { beneficiary_id })],
+            vec![Action::DeleteAccount(Box::new(DeleteAccountAction { beneficiary_id }))],
             block_hash,
         )
     }

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -332,15 +332,18 @@ mod tests {
             actions: vec![
                 Action::CreateAccount(CreateAccountAction {}),
                 Action::DeployContract(DeployContractAction { code: vec![1, 2, 3] }),
-                Action::FunctionCall(FunctionCallAction {
+                Action::FunctionCall(Box::new(FunctionCallAction {
                     method_name: "qqq".to_string(),
                     args: vec![1, 2, 3],
                     gas: 1_000,
                     deposit: 1_000_000,
-                }),
+                })),
                 Action::Transfer(TransferAction { deposit: 123 }),
-                Action::Stake(StakeAction { public_key: public_key.clone(), stake: 1_000_000 }),
-                Action::AddKey(AddKeyAction {
+                Action::Stake(Box::new(StakeAction {
+                    public_key: public_key.clone(),
+                    stake: 1_000_000,
+                })),
+                Action::AddKey(Box::new(AddKeyAction {
                     public_key: public_key.clone(),
                     access_key: AccessKey {
                         nonce: 0,
@@ -350,8 +353,8 @@ mod tests {
                             method_names: vec!["www".to_string()],
                         }),
                     },
-                }),
-                Action::DeleteKey(DeleteKeyAction { public_key }),
+                })),
+                Action::DeleteKey(Box::new(DeleteKeyAction { public_key })),
                 Action::DeleteAccount(DeleteAccountAction {
                     beneficiary_id: "123".parse().unwrap(),
                 }),

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -331,14 +331,14 @@ mod tests {
             block_hash: Default::default(),
             actions: vec![
                 Action::CreateAccount(CreateAccountAction {}),
-                Action::DeployContract(DeployContractAction { code: vec![1, 2, 3] }),
+                Action::DeployContract(Box::new(DeployContractAction { code: vec![1, 2, 3] })),
                 Action::FunctionCall(Box::new(FunctionCallAction {
                     method_name: "qqq".to_string(),
                     args: vec![1, 2, 3],
                     gas: 1_000,
                     deposit: 1_000_000,
                 })),
-                Action::Transfer(TransferAction { deposit: 123 }),
+                Action::Transfer(Box::new(TransferAction { deposit: 123 })),
                 Action::Stake(Box::new(StakeAction {
                     public_key: public_key.clone(),
                     stake: 1_000_000,
@@ -355,9 +355,9 @@ mod tests {
                     },
                 })),
                 Action::DeleteKey(Box::new(DeleteKeyAction { public_key })),
-                Action::DeleteAccount(DeleteAccountAction {
+                Action::DeleteAccount(Box::new(DeleteAccountAction {
                     beneficiary_id: "123".parse().unwrap(),
-                }),
+                })),
             ],
         };
         let signed_tx = SignedTransaction::new(Signature::empty(KeyType::ED25519), transaction);

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -1238,7 +1238,9 @@ impl TryFrom<ActionView> for Action {
                     deposit,
                 }))
             }
-            ActionView::Transfer { deposit } => Action::Transfer(Box::new(TransferAction { deposit })),
+            ActionView::Transfer { deposit } => {
+                Action::Transfer(Box::new(TransferAction { deposit }))
+            }
             ActionView::Stake { stake, public_key } => {
                 Action::Stake(Box::new(StakeAction { stake, public_key }))
             }

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -1231,31 +1231,31 @@ impl TryFrom<ActionView> for Action {
                 Action::DeployContract(DeployContractAction { code })
             }
             ActionView::FunctionCall { method_name, args, gas, deposit } => {
-                Action::FunctionCall(FunctionCallAction {
+                Action::FunctionCall(Box::new(FunctionCallAction {
                     method_name,
                     args: args.into(),
                     gas,
                     deposit,
-                })
+                }))
             }
             ActionView::Transfer { deposit } => Action::Transfer(TransferAction { deposit }),
             ActionView::Stake { stake, public_key } => {
-                Action::Stake(StakeAction { stake, public_key })
+                Action::Stake(Box::new(StakeAction { stake, public_key }))
             }
             ActionView::AddKey { public_key, access_key } => {
-                Action::AddKey(AddKeyAction { public_key, access_key: access_key.into() })
+                Action::AddKey(Box::new(AddKeyAction { public_key, access_key: access_key.into() }))
             }
             ActionView::DeleteKey { public_key } => {
-                Action::DeleteKey(DeleteKeyAction { public_key })
+                Action::DeleteKey(Box::new(DeleteKeyAction { public_key }))
             }
             ActionView::DeleteAccount { beneficiary_id } => {
                 Action::DeleteAccount(DeleteAccountAction { beneficiary_id })
             }
             ActionView::Delegate { delegate_action, signature } => {
-                Action::Delegate(SignedDelegateAction {
+                Action::Delegate(Box::new(SignedDelegateAction {
                     delegate_action: delegate_action,
                     signature,
-                })
+                }))
             }
         })
     }

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -1228,7 +1228,7 @@ impl TryFrom<ActionView> for Action {
         Ok(match action_view {
             ActionView::CreateAccount => Action::CreateAccount(CreateAccountAction {}),
             ActionView::DeployContract { code } => {
-                Action::DeployContract(DeployContractAction { code })
+                Action::DeployContract(Box::new(DeployContractAction { code }))
             }
             ActionView::FunctionCall { method_name, args, gas, deposit } => {
                 Action::FunctionCall(Box::new(FunctionCallAction {
@@ -1238,7 +1238,7 @@ impl TryFrom<ActionView> for Action {
                     deposit,
                 }))
             }
-            ActionView::Transfer { deposit } => Action::Transfer(TransferAction { deposit }),
+            ActionView::Transfer { deposit } => Action::Transfer(Box::new(TransferAction { deposit })),
             ActionView::Stake { stake, public_key } => {
                 Action::Stake(Box::new(StakeAction { stake, public_key }))
             }
@@ -1249,7 +1249,7 @@ impl TryFrom<ActionView> for Action {
                 Action::DeleteKey(Box::new(DeleteKeyAction { public_key }))
             }
             ActionView::DeleteAccount { beneficiary_id } => {
-                Action::DeleteAccount(DeleteAccountAction { beneficiary_id })
+                Action::DeleteAccount(Box::new(DeleteAccountAction { beneficiary_id }))
             }
             ActionView::Delegate { delegate_action, signature } => {
                 Action::Delegate(Box::new(SignedDelegateAction {

--- a/genesis-tools/genesis-csv-to-json/src/csv_parser.rs
+++ b/genesis-tools/genesis-csv-to-json/src/csv_parser.rs
@@ -258,12 +258,12 @@ fn account_records(row: &Row, gas_price: Balance) -> Vec<StateRecord> {
                 gas_price,
                 output_data_receivers: vec![],
                 input_data_ids: vec![],
-                actions: vec![Action::FunctionCall(FunctionCallAction {
+                actions: vec![Action::FunctionCall(Box::new(FunctionCallAction {
                     method_name: "init".to_string(),
                     args,
                     gas: INIT_GAS,
                     deposit: 0,
-                })],
+                }))],
             }),
         };
         res.push(StateRecord::PostponedReceipt(Box::new(receipt)));

--- a/integration-tests/src/tests/client/benchmarks.rs
+++ b/integration-tests/src/tests/client/benchmarks.rs
@@ -46,7 +46,7 @@ fn benchmark_large_chunk_production_time() {
             account_id.clone(),
             account_id.clone(),
             &signer,
-            vec![Action::DeployContract(DeployContractAction { code: vec![92; tx_size] })],
+            vec![Action::DeployContract(Box::new(DeployContractAction { code: vec![92; tx_size] }))],
             last_block_hash,
         );
         assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);

--- a/integration-tests/src/tests/client/benchmarks.rs
+++ b/integration-tests/src/tests/client/benchmarks.rs
@@ -46,7 +46,9 @@ fn benchmark_large_chunk_production_time() {
             account_id.clone(),
             account_id.clone(),
             &signer,
-            vec![Action::DeployContract(Box::new(DeployContractAction { code: vec![92; tx_size] }))],
+            vec![Action::DeployContract(Box::new(DeployContractAction {
+                code: vec![92; tx_size],
+            }))],
             last_block_hash,
         );
         assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);

--- a/integration-tests/src/tests/client/cold_storage.rs
+++ b/integration-tests/src/tests/client/cold_storage.rs
@@ -122,12 +122,12 @@ fn test_storage_after_commit_of_cold_update() {
                     "test0".parse().unwrap(),
                     "test0".parse().unwrap(),
                     &signer,
-                    vec![Action::FunctionCall(FunctionCallAction {
+                    vec![Action::FunctionCall(Box::new(FunctionCallAction {
                         method_name: "write_random_value".to_string(),
                         args: vec![],
                         gas: 100_000_000_000_000,
                         deposit: 0,
-                    })],
+                    }))],
                     last_hash,
                 );
                 assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);

--- a/integration-tests/src/tests/client/cold_storage.rs
+++ b/integration-tests/src/tests/client/cold_storage.rs
@@ -105,9 +105,9 @@ fn test_storage_after_commit_of_cold_update() {
                 "test0".parse().unwrap(),
                 "test0".parse().unwrap(),
                 &signer,
-                vec![Action::DeployContract(DeployContractAction {
+                vec![Action::DeployContract(Box::new(DeployContractAction {
                     code: near_test_contracts::rs_contract().to_vec(),
-                })],
+                }))],
                 last_hash,
             );
             assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);

--- a/integration-tests/src/tests/client/features/account_id_in_function_call_permission.rs
+++ b/integration-tests/src/tests/client/features/account_id_in_function_call_permission.rs
@@ -46,7 +46,7 @@ fn test_account_id_in_function_call_permission_upgrade() {
         signer_id: "test0".parse().unwrap(),
         receiver_id: "test0".parse().unwrap(),
         public_key: signer.public_key(),
-        actions: vec![Action::AddKey(AddKeyAction {
+        actions: vec![Action::AddKey(Box::new(AddKeyAction {
             public_key: signer.public_key(),
             access_key: AccessKey {
                 nonce: 1,
@@ -56,7 +56,7 @@ fn test_account_id_in_function_call_permission_upgrade() {
                     method_names: vec![],
                 }),
             },
-        })],
+        }))],
         nonce: 0,
         block_hash: CryptoHash::default(),
     };
@@ -111,7 +111,7 @@ fn test_very_long_account_id() {
         signer_id: "test0".parse().unwrap(),
         receiver_id: "test0".parse().unwrap(),
         public_key: signer.public_key(),
-        actions: vec![Action::AddKey(AddKeyAction {
+        actions: vec![Action::AddKey(Box::new(AddKeyAction {
             public_key: signer.public_key(),
             access_key: AccessKey {
                 nonce: 1,
@@ -121,7 +121,7 @@ fn test_very_long_account_id() {
                     method_names: vec![],
                 }),
             },
-        })],
+        }))],
         nonce: 0,
         block_hash: tip.last_block_hash,
     }

--- a/integration-tests/src/tests/client/features/chunk_nodes_cache.rs
+++ b/integration-tests/src/tests/client/features/chunk_nodes_cache.rs
@@ -38,18 +38,18 @@ fn process_transaction(
         "test0".parse().unwrap(),
         signer,
         vec![
-            Action::FunctionCall(FunctionCallAction {
+            Action::FunctionCall(Box::new(FunctionCallAction {
                 args: encode(&[0u64, 10u64]),
                 method_name: "write_key_value".to_string(),
                 gas,
                 deposit: 0,
-            }),
-            Action::FunctionCall(FunctionCallAction {
+            })),
+            Action::FunctionCall(Box::new(FunctionCallAction {
                 args: encode(&[1u64, 20u64]),
                 method_name: "write_key_value".to_string(),
                 gas,
                 deposit: 0,
-            }),
+            })),
         ],
         last_block_hash,
     );

--- a/integration-tests/src/tests/client/features/delegate_action.rs
+++ b/integration-tests/src/tests/client/features/delegate_action.rs
@@ -525,8 +525,9 @@ fn meta_tx_delete_account() {
 
     let fee_helper = fee_helper(&node);
 
-    let actions =
-        vec![Action::DeleteAccount(Box::new(DeleteAccountAction { beneficiary_id: relayer.clone() }))];
+    let actions = vec![Action::DeleteAccount(Box::new(DeleteAccountAction {
+        beneficiary_id: relayer.clone(),
+    }))];
 
     // special case balance check for deleting account
     let gas_cost = fee_helper.prepaid_delete_account_cost()

--- a/integration-tests/src/tests/client/features/delegate_action.rs
+++ b/integration-tests/src/tests/client/features/delegate_action.rs
@@ -493,7 +493,8 @@ fn meta_tx_delete_key() {
 
     let tx_cost = fee_helper.delete_key_cost();
     let public_key = PublicKey::from_seed(KeyType::ED25519, &receiver);
-    let actions = vec![Action::DeleteKey(Box::new(DeleteKeyAction { public_key: public_key.clone() }))];
+    let actions =
+        vec![Action::DeleteKey(Box::new(DeleteKeyAction { public_key: public_key.clone() }))];
     check_meta_tx_no_fn_call(&node, actions, tx_cost, 0, sender, relayer, receiver.clone());
 
     let err = node

--- a/integration-tests/src/tests/client/features/delegate_action.rs
+++ b/integration-tests/src/tests/client/features/delegate_action.rs
@@ -269,7 +269,7 @@ fn meta_tx_near_transfer() {
     let fee_helper = fee_helper(&node);
 
     let amount = nearcore::NEAR_BASE;
-    let actions = vec![Action::Transfer(TransferAction { deposit: amount })];
+    let actions = vec![Action::Transfer(Box::new(TransferAction { deposit: amount }))];
     let tx_cost = fee_helper.transfer_cost();
     check_meta_tx_no_fn_call(&node, actions, tx_cost, amount, sender, relayer, receiver);
 }
@@ -433,7 +433,7 @@ fn meta_tx_deploy() {
 
     let code = smallest_rs_contract().to_vec();
     let tx_cost = fee_helper.deploy_contract_cost(code.len() as u64);
-    let actions = vec![Action::DeployContract(DeployContractAction { code })];
+    let actions = vec![Action::DeployContract(Box::new(DeployContractAction { code }))];
     check_meta_tx_no_fn_call(&node, actions, tx_cost, 0, sender, relayer, receiver);
 }
 
@@ -526,7 +526,7 @@ fn meta_tx_delete_account() {
     let fee_helper = fee_helper(&node);
 
     let actions =
-        vec![Action::DeleteAccount(DeleteAccountAction { beneficiary_id: relayer.clone() })];
+        vec![Action::DeleteAccount(Box::new(DeleteAccountAction { beneficiary_id: relayer.clone() }))];
 
     // special case balance check for deleting account
     let gas_cost = fee_helper.prepaid_delete_account_cost()
@@ -762,7 +762,7 @@ fn meta_tx_create_named_account() {
     // That's the minimum to create a (useful) account.
     let actions = vec![
         Action::CreateAccount(CreateAccountAction {}),
-        Action::Transfer(TransferAction { deposit: amount }),
+        Action::Transfer(Box::new(TransferAction { deposit: amount })),
         Action::AddKey(Box::new(AddKeyAction { public_key, access_key: AccessKey::full_access() })),
     ];
 
@@ -815,8 +815,8 @@ fn meta_tx_create_and_use_implicit_account() {
 
     let initial_amount = nearcore::NEAR_BASE;
     let actions = vec![
-        Action::Transfer(TransferAction { deposit: initial_amount }),
-        Action::DeployContract(DeployContractAction { code: ft_contract().to_vec() }),
+        Action::Transfer(Box::new(TransferAction { deposit: initial_amount })),
+        Action::DeployContract(Box::new(DeployContractAction { code: ft_contract().to_vec() })),
     ];
 
     // Execute and expect `AccountDoesNotExist`, as we try to call a meta
@@ -849,7 +849,7 @@ fn meta_tx_create_implicit_account() {
 
     let fee_helper = fee_helper(&node);
     let initial_amount = nearcore::NEAR_BASE;
-    let actions = vec![Action::Transfer(TransferAction { deposit: initial_amount })];
+    let actions = vec![Action::Transfer(Box::new(TransferAction { deposit: initial_amount }))];
     let tx_cost = fee_helper.create_account_transfer_full_key_cost();
     check_meta_tx_no_fn_call(
         &node,
@@ -868,7 +868,7 @@ fn meta_tx_create_implicit_account() {
 
     // Now test we can use this account in a meta transaction that sends back half the tokens to alice.
     let transfer_amount = initial_amount / 2;
-    let actions = vec![Action::Transfer(TransferAction { deposit: transfer_amount })];
+    let actions = vec![Action::Transfer(Box::new(TransferAction { deposit: transfer_amount }))];
     let tx_cost = fee_helper.transfer_cost();
     check_meta_tx_no_fn_call(
         &node,

--- a/integration-tests/src/tests/client/features/delegate_action.rs
+++ b/integration-tests/src/tests/client/features/delegate_action.rs
@@ -448,7 +448,7 @@ fn meta_tx_stake() {
 
     let tx_cost = fee_helper.stake_cost();
     let public_key = create_user_test_signer(&sender).public_key;
-    let actions = vec![Action::Stake(StakeAction { public_key, stake: 0 })];
+    let actions = vec![Action::Stake(Box::new(StakeAction { public_key, stake: 0 }))];
     check_meta_tx_no_fn_call(&node, actions, tx_cost, 0, sender, relayer, receiver);
 }
 
@@ -465,10 +465,10 @@ fn meta_tx_add_key() {
     // any public key works as long as it doesn't exists on the receiver, the
     // relayer public key is just handy
     let public_key = node.signer().public_key();
-    let actions = vec![Action::AddKey(AddKeyAction {
+    let actions = vec![Action::AddKey(Box::new(AddKeyAction {
         public_key: public_key.clone(),
         access_key: AccessKey::full_access(),
-    })];
+    }))];
     check_meta_tx_no_fn_call(&node, actions, tx_cost, 0, sender, relayer, receiver.clone());
 
     let key_view = node
@@ -493,7 +493,7 @@ fn meta_tx_delete_key() {
 
     let tx_cost = fee_helper.delete_key_cost();
     let public_key = PublicKey::from_seed(KeyType::ED25519, &receiver);
-    let actions = vec![Action::DeleteKey(DeleteKeyAction { public_key: public_key.clone() })];
+    let actions = vec![Action::DeleteKey(Box::new(DeleteKeyAction { public_key: public_key.clone() }))];
     check_meta_tx_no_fn_call(&node, actions, tx_cost, 0, sender, relayer, receiver.clone());
 
     let err = node
@@ -627,12 +627,12 @@ fn meta_tx_ft_transfer() {
 
 /// Call the function "log_something" in the test contract.
 fn log_something_fn_call() -> Action {
-    Action::FunctionCall(FunctionCallAction {
+    Action::FunctionCall(Box::new(FunctionCallAction {
         method_name: TEST_METHOD.to_owned(),
         args: vec![],
         gas: 30_000_000_000_000,
         deposit: 0,
-    })
+    }))
 }
 
 /// Construct an function call action with a FT transfer.
@@ -649,12 +649,12 @@ fn ft_transfer_action(receiver: &str, amount: u128) -> (Action, u64) {
     .collect();
     let method_name = "ft_transfer".to_owned();
     let num_bytes = method_name.len() + args.len();
-    let action = Action::FunctionCall(FunctionCallAction {
+    let action = Action::FunctionCall(Box::new(FunctionCallAction {
         method_name,
         args,
         gas: 20_000_000_000_000,
         deposit: 1,
-    });
+    }));
 
     (action, num_bytes as u64)
 }
@@ -669,12 +669,12 @@ fn ft_register_action(receiver: &str) -> Action {
     )
     .bytes()
     .collect();
-    Action::FunctionCall(FunctionCallAction {
+    Action::FunctionCall(Box::new(FunctionCallAction {
         method_name: "storage_deposit".to_owned(),
         args,
         gas: 20_000_000_000_000,
         deposit: NEAR_BASE,
-    })
+    }))
 }
 
 /// Format a NEP-141 event for an ft transfer
@@ -762,7 +762,7 @@ fn meta_tx_create_named_account() {
     let actions = vec![
         Action::CreateAccount(CreateAccountAction {}),
         Action::Transfer(TransferAction { deposit: amount }),
-        Action::AddKey(AddKeyAction { public_key, access_key: AccessKey::full_access() }),
+        Action::AddKey(Box::new(AddKeyAction { public_key, access_key: AccessKey::full_access() })),
     ];
 
     // Check the account doesn't exist, yet. We want to create it.

--- a/integration-tests/src/tests/client/features/flat_storage.rs
+++ b/integration-tests/src/tests/client/features/flat_storage.rs
@@ -65,12 +65,12 @@ fn test_flat_storage_upgrade() {
 
     // Write key-value pair to state.
     {
-        let write_value_action = vec![Action::FunctionCall(FunctionCallAction {
+        let write_value_action = vec![Action::FunctionCall(Box::new(FunctionCallAction {
             args: encode(&[1u64, 10u64]),
             method_name: "write_key_value".to_string(),
             gas,
             deposit: 0,
-        })];
+        }))];
         let tip = env.clients[0].chain.head().unwrap();
         let signed_transaction = Transaction {
             nonce: 10,
@@ -93,12 +93,12 @@ fn test_flat_storage_upgrade() {
 
     let touching_trie_node_costs: Vec<_> = (0..2)
         .map(|i| {
-            let read_value_action = vec![Action::FunctionCall(FunctionCallAction {
+            let read_value_action = vec![Action::FunctionCall(Box::new(FunctionCallAction {
                 args: encode(&[1u64]),
                 method_name: "read_value".to_string(),
                 gas,
                 deposit: 0,
-            })];
+            }))];
             let tip = env.clients[0].chain.head().unwrap();
             let signed_transaction = Transaction {
                 nonce: 20 + i,

--- a/integration-tests/src/tests/client/features/increase_deployment_cost.rs
+++ b/integration-tests/src/tests/client/features/increase_deployment_cost.rs
@@ -46,7 +46,8 @@ fn test_deploy_cost_increased() {
     };
 
     let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
-    let actions = vec![Action::DeployContract(Box::new(DeployContractAction { code: test_contract }))];
+    let actions =
+        vec![Action::DeployContract(Box::new(DeployContractAction { code: test_contract }))];
 
     let tx = env.tx_from_actions(actions.clone(), &signer, signer.account_id.clone());
     let old_outcome = env.execute_tx(tx).unwrap();

--- a/integration-tests/src/tests/client/features/increase_deployment_cost.rs
+++ b/integration-tests/src/tests/client/features/increase_deployment_cost.rs
@@ -46,7 +46,7 @@ fn test_deploy_cost_increased() {
     };
 
     let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
-    let actions = vec![Action::DeployContract(DeployContractAction { code: test_contract })];
+    let actions = vec![Action::DeployContract(Box::new(DeployContractAction { code: test_contract }))];
 
     let tx = env.tx_from_actions(actions.clone(), &signer, signer.account_id.clone());
     let old_outcome = env.execute_tx(tx).unwrap();

--- a/integration-tests/src/tests/client/features/increase_storage_compute_cost.rs
+++ b/integration-tests/src/tests/client/features/increase_storage_compute_cost.rs
@@ -208,7 +208,7 @@ fn assert_compute_limit_reached(
     {
         // This contract has a bunch of methods to invoke storage operations.
         let code = near_test_contracts::backwards_compatible_rs_contract().to_vec();
-        let actions = vec![Action::DeployContract(DeployContractAction { code })];
+        let actions = vec![Action::DeployContract(Box::new(DeployContractAction { code }))];
 
         let signer = InMemorySigner::from_seed(
             contract_account.clone(),

--- a/integration-tests/src/tests/client/features/increase_storage_compute_cost.rs
+++ b/integration-tests/src/tests/client/features/increase_storage_compute_cost.rs
@@ -295,8 +295,12 @@ fn produce_saturated_chunk(
 ) -> std::sync::Arc<ShardChunk> {
     let msg_len = (method_name.len() + args.len()) as u64; // needed for gas computation later
     let gas = 300_000_000_000_000;
-    let actions =
-        vec![Action::FunctionCall(Box::new(FunctionCallAction { method_name, args, gas, deposit: 0 }))];
+    let actions = vec![Action::FunctionCall(Box::new(FunctionCallAction {
+        method_name,
+        args,
+        gas,
+        deposit: 0,
+    }))];
     let signer = InMemorySigner::from_seed(user_account.clone(), KeyType::ED25519, user_account);
 
     let tip = env.clients[0].chain.head().unwrap();

--- a/integration-tests/src/tests/client/features/increase_storage_compute_cost.rs
+++ b/integration-tests/src/tests/client/features/increase_storage_compute_cost.rs
@@ -296,7 +296,7 @@ fn produce_saturated_chunk(
     let msg_len = (method_name.len() + args.len()) as u64; // needed for gas computation later
     let gas = 300_000_000_000_000;
     let actions =
-        vec![Action::FunctionCall(FunctionCallAction { method_name, args, gas, deposit: 0 })];
+        vec![Action::FunctionCall(Box::new(FunctionCallAction { method_name, args, gas, deposit: 0 }))];
     let signer = InMemorySigner::from_seed(user_account.clone(), KeyType::ED25519, user_account);
 
     let tip = env.clients[0].chain.head().unwrap();

--- a/integration-tests/src/tests/client/features/lower_storage_key_limit.rs
+++ b/integration-tests/src/tests/client/features/lower_storage_key_limit.rs
@@ -69,12 +69,12 @@ fn protocol_upgrade() {
         signer_id: "test0".parse().unwrap(),
         receiver_id: "test0".parse().unwrap(),
         public_key: signer.public_key(),
-        actions: vec![Action::FunctionCall(FunctionCallAction {
+        actions: vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "write_key_value".to_string(),
             args,
             gas: 10u64.pow(14),
             deposit: 0,
-        })],
+        }))],
 
         nonce: 0,
         block_hash: CryptoHash::default(),
@@ -129,12 +129,12 @@ fn protocol_upgrade() {
             signer_id: "test0".parse().unwrap(),
             receiver_id: "test0".parse().unwrap(),
             public_key: signer.public_key(),
-            actions: vec![Action::FunctionCall(FunctionCallAction {
+            actions: vec![Action::FunctionCall(Box::new(FunctionCallAction {
                 method_name: "write_key_value".to_string(),
                 args,
                 gas: 10u64.pow(14),
                 deposit: 0,
-            })],
+            }))],
 
             nonce: 0,
             block_hash: CryptoHash::default(),

--- a/integration-tests/src/tests/client/features/nearvm.rs
+++ b/integration-tests/src/tests/client/features/nearvm.rs
@@ -48,12 +48,12 @@ fn test_nearvm_upgrade() {
         signer_id: "test0".parse().unwrap(),
         receiver_id: "test0".parse().unwrap(),
         public_key: signer.public_key(),
-        actions: vec![Action::FunctionCall(FunctionCallAction {
+        actions: vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "log_something".to_string(),
             args: Vec::new(),
             gas: 100_000_000_000_000,
             deposit: 0,
-        })],
+        }))],
 
         nonce: 0,
         block_hash: CryptoHash::default(),

--- a/integration-tests/src/tests/client/features/zero_balance_account.rs
+++ b/integration-tests/src/tests/client/features/zero_balance_account.rs
@@ -230,7 +230,9 @@ fn test_zero_balance_account_add_key() {
         new_account_id.clone(),
         new_account_id.clone(),
         &new_signer,
-        vec![Action::DeleteKey(Box::new(DeleteKeyAction { public_key: keys.last().unwrap().clone() }))],
+        vec![Action::DeleteKey(Box::new(DeleteKeyAction {
+            public_key: keys.last().unwrap().clone(),
+        }))],
         *genesis_block.hash(),
     );
     assert_eq!(env.clients[0].process_tx(delete_key_tx, false, false), ProcessTxResponse::ValidTx);

--- a/integration-tests/src/tests/client/features/zero_balance_account.rs
+++ b/integration-tests/src/tests/client/features/zero_balance_account.rs
@@ -175,14 +175,14 @@ fn test_zero_balance_account_add_key() {
     for i in 1..5 {
         let new_key = PublicKey::from_seed(KeyType::ED25519, format!("{}", i).as_str());
         keys.push(new_key.clone());
-        actions.push(AddKey(AddKeyAction {
+        actions.push(AddKey(Box::new(AddKeyAction {
             public_key: new_key,
             access_key: AccessKey::full_access(),
-        }));
+        })));
     }
     for i in 0..2 {
         let new_key = PublicKey::from_seed(KeyType::ED25519, format!("{}", i + 5).as_str());
-        actions.push(AddKey(AddKeyAction {
+        actions.push(AddKey(Box::new(AddKeyAction {
             public_key: new_key,
             access_key: AccessKey {
                 nonce: 0,
@@ -192,7 +192,7 @@ fn test_zero_balance_account_add_key() {
                     method_names: vec![],
                 }),
             },
-        }));
+        })));
     }
 
     let head = env.clients[0].chain.head().unwrap();
@@ -230,7 +230,7 @@ fn test_zero_balance_account_add_key() {
         new_account_id.clone(),
         new_account_id.clone(),
         &new_signer,
-        vec![Action::DeleteKey(DeleteKeyAction { public_key: keys.last().unwrap().clone() })],
+        vec![Action::DeleteKey(Box::new(DeleteKeyAction { public_key: keys.last().unwrap().clone() }))],
         *genesis_block.hash(),
     );
     assert_eq!(env.clients[0].process_tx(delete_key_tx, false, false), ProcessTxResponse::ValidTx);

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -231,12 +231,12 @@ pub(crate) fn prepare_env_with_congestion(
             "test0".parse().unwrap(),
             "test0".parse().unwrap(),
             &signer,
-            vec![Action::FunctionCall(FunctionCallAction {
+            vec![Action::FunctionCall(Box::new(FunctionCallAction {
                 method_name: "call_promise".to_string(),
                 args: serde_json::to_vec(&data).unwrap(),
                 gas: gas_1,
                 deposit: 0,
-            })],
+            }))],
             *genesis_block.hash(),
         );
         tx_hashes.push(signed_transaction.get_hash());
@@ -2431,12 +2431,12 @@ fn test_validate_chunk_extra() {
         "test0".parse().unwrap(),
         "test0".parse().unwrap(),
         &signer,
-        vec![Action::FunctionCall(FunctionCallAction {
+        vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "write_block_height".to_string(),
             args: vec![],
             gas: 100000000000000,
             deposit: 0,
-        })],
+        }))],
         *last_block.hash(),
     );
     assert_eq!(
@@ -3556,12 +3556,12 @@ fn test_validator_stake_host_function() {
         "test0".parse().unwrap(),
         "test0".parse().unwrap(),
         &signer,
-        vec![Action::FunctionCall(FunctionCallAction {
+        vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "ext_validator_stake".to_string(),
             args: b"test0".to_vec(),
             gas: 100_000_000_000_000,
             deposit: 0,
-        })],
+        }))],
         *genesis_block.hash(),
     );
     assert_eq!(

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -147,7 +147,7 @@ pub(crate) fn deploy_test_contract_with_protocol_version(
         account_id.clone(),
         account_id,
         &signer,
-        vec![Action::DeployContract(DeployContractAction { code: wasm_code.to_vec() })],
+        vec![Action::DeployContract(Box::new(DeployContractAction { code: wasm_code.to_vec() }))],
         *block.hash(),
     );
     assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
@@ -200,9 +200,9 @@ pub(crate) fn prepare_env_with_congestion(
         "test0".parse().unwrap(),
         "test0".parse().unwrap(),
         &signer,
-        vec![Action::DeployContract(DeployContractAction {
+        vec![Action::DeployContract(Box::new(DeployContractAction {
             code: near_test_contracts::backwards_compatible_rs_contract().to_vec(),
-        })],
+        }))],
         *genesis_block.hash(),
     );
     assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
@@ -2412,9 +2412,9 @@ fn test_validate_chunk_extra() {
         "test0".parse().unwrap(),
         "test0".parse().unwrap(),
         &signer,
-        vec![Action::DeployContract(DeployContractAction {
+        vec![Action::DeployContract(Box::new(DeployContractAction {
             code: near_test_contracts::rs_contract().to_vec(),
-        })],
+        }))],
         *genesis_block.hash(),
     );
     assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
@@ -2878,7 +2878,7 @@ fn test_delayed_receipt_count_limit() {
             "test0".parse().unwrap(),
             "test0".parse().unwrap(),
             &signer,
-            vec![Action::DeployContract(DeployContractAction { code: vec![92; 10000] })],
+            vec![Action::DeployContract(Box::new(DeployContractAction { code: vec![92; 10000] }))],
             *genesis_block.hash(),
         );
         assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);

--- a/integration-tests/src/tests/client/sandbox.rs
+++ b/integration-tests/src/tests/client/sandbox.rs
@@ -44,12 +44,12 @@ fn test_setup() -> (TestEnv, InMemorySigner) {
             "test0".parse().unwrap(),
             "test0".parse().unwrap(),
             &signer,
-            vec![Action::FunctionCall(FunctionCallAction {
+            vec![Action::FunctionCall(Box::new(FunctionCallAction {
                 method_name: "write_random_value".to_string(),
                 args: vec![],
                 gas: 100000000000000,
                 deposit: 0,
-            })],
+            }))],
         ),
         ProcessTxResponse::ValidTx
     );

--- a/integration-tests/src/tests/client/sandbox.rs
+++ b/integration-tests/src/tests/client/sandbox.rs
@@ -29,9 +29,9 @@ fn test_setup() -> (TestEnv, InMemorySigner) {
             "test0".parse().unwrap(),
             "test0".parse().unwrap(),
             &signer,
-            vec![Action::DeployContract(DeployContractAction {
+            vec![Action::DeployContract(Box::new(DeployContractAction {
                 code: near_test_contracts::rs_contract().to_vec(),
-            })],
+            }))],
         ),
         ProcessTxResponse::ValidTx
     );

--- a/integration-tests/src/tests/client/sharding_upgrade.rs
+++ b/integration-tests/src/tests/client/sharding_upgrade.rs
@@ -896,9 +896,9 @@ fn setup_test_env_with_cross_contract_txs(
                     account_id.clone(),
                     account_id.clone(),
                     &signer,
-                    vec![Action::DeployContract(DeployContractAction {
+                    vec![Action::DeployContract(Box::new(DeployContractAction {
                         code: near_test_contracts::backwards_compatible_rs_contract().to_vec(),
-                    })],
+                    }))],
                     genesis_hash,
                 )
             })

--- a/integration-tests/src/tests/client/sharding_upgrade.rs
+++ b/integration-tests/src/tests/client/sharding_upgrade.rs
@@ -855,12 +855,12 @@ fn gen_cross_contract_transaction(
         account0.clone(),
         account1.clone(),
         &signer0,
-        vec![Action::FunctionCall(FunctionCallAction {
+        vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "call_promise".to_string(),
             args: serde_json::to_vec(&data).unwrap(),
             gas: GAS_1,
             deposit: 0,
-        })],
+        }))],
         *block_hash,
     )
 }

--- a/integration-tests/src/tests/runtime/deployment.rs
+++ b/integration-tests/src/tests/runtime/deployment.rs
@@ -30,7 +30,7 @@ fn test_deploy_max_size_contract() {
         test_contract_id.clone(),
         test_contract_id.clone(),
         &*node_user.signer(),
-        vec![Action::DeployContract(DeployContractAction { code: vec![0u8] })],
+        vec![Action::DeployContract(Box::new(DeployContractAction { code: vec![0u8] }))],
         block_hash,
     );
     let tx_overhead = signed_transaction.get_size();

--- a/integration-tests/src/tests/test_errors.rs
+++ b/integration-tests/src/tests/test_errors.rs
@@ -43,10 +43,10 @@ fn test_check_tx_error_log() {
         vec![
             Action::CreateAccount(CreateAccountAction {}),
             Action::Transfer(TransferAction { deposit: 1_000 }),
-            Action::AddKey(AddKeyAction {
+            Action::AddKey(Box::new(AddKeyAction {
                 public_key: signer.public_key.clone(),
                 access_key: AccessKey::full_access(),
-            }),
+            })),
         ],
         block_hash,
     );
@@ -83,10 +83,10 @@ fn test_deliver_tx_error_log() {
         vec![
             Action::CreateAccount(CreateAccountAction {}),
             Action::Transfer(TransferAction { deposit: TESTING_INIT_BALANCE + 1 }),
-            Action::AddKey(AddKeyAction {
+            Action::AddKey(Box::new(AddKeyAction {
                 public_key: signer.public_key.clone(),
                 access_key: AccessKey::full_access(),
-            }),
+            })),
         ],
         block_hash,
     );

--- a/integration-tests/src/tests/test_errors.rs
+++ b/integration-tests/src/tests/test_errors.rs
@@ -42,7 +42,7 @@ fn test_check_tx_error_log() {
         &*signer,
         vec![
             Action::CreateAccount(CreateAccountAction {}),
-            Action::Transfer(TransferAction { deposit: 1_000 }),
+            Action::Transfer(Box::new(TransferAction { deposit: 1_000 })),
             Action::AddKey(Box::new(AddKeyAction {
                 public_key: signer.public_key.clone(),
                 access_key: AccessKey::full_access(),
@@ -82,7 +82,7 @@ fn test_deliver_tx_error_log() {
         &*signer,
         vec![
             Action::CreateAccount(CreateAccountAction {}),
-            Action::Transfer(TransferAction { deposit: TESTING_INIT_BALANCE + 1 }),
+            Action::Transfer(Box::new(TransferAction { deposit: TESTING_INIT_BALANCE + 1 })),
             Action::AddKey(Box::new(AddKeyAction {
                 public_key: signer.public_key.clone(),
                 access_key: AccessKey::full_access(),

--- a/integration-tests/src/user/mod.rs
+++ b/integration-tests/src/user/mod.rs
@@ -144,12 +144,12 @@ pub trait User {
         self.sign_and_commit_actions(
             signer_id,
             contract_id,
-            vec![Action::FunctionCall(FunctionCallAction {
+            vec![Action::FunctionCall(Box::new(FunctionCallAction {
                 method_name: method_name.to_string(),
                 args,
                 gas,
                 deposit,
-            })],
+            }))],
         )
     }
 
@@ -166,7 +166,7 @@ pub trait User {
             vec![
                 Action::CreateAccount(CreateAccountAction {}),
                 Action::Transfer(TransferAction { deposit: amount }),
-                Action::AddKey(AddKeyAction { public_key, access_key: AccessKey::full_access() }),
+                Action::AddKey(Box::new(AddKeyAction { public_key, access_key: AccessKey::full_access() })),
             ],
         )
     }
@@ -180,7 +180,7 @@ pub trait User {
         self.sign_and_commit_actions(
             signer_id.clone(),
             signer_id,
-            vec![Action::AddKey(AddKeyAction { public_key, access_key })],
+            vec![Action::AddKey(Box::new(AddKeyAction { public_key, access_key }))],
         )
     }
 
@@ -192,7 +192,7 @@ pub trait User {
         self.sign_and_commit_actions(
             signer_id.clone(),
             signer_id,
-            vec![Action::DeleteKey(DeleteKeyAction { public_key })],
+            vec![Action::DeleteKey(Box::new(DeleteKeyAction { public_key }))],
         )
     }
 
@@ -207,8 +207,8 @@ pub trait User {
             signer_id.clone(),
             signer_id,
             vec![
-                Action::DeleteKey(DeleteKeyAction { public_key: old_public_key }),
-                Action::AddKey(AddKeyAction { public_key: new_public_key, access_key }),
+                Action::DeleteKey(Box::new(DeleteKeyAction { public_key: old_public_key })),
+                Action::AddKey(Box::new(AddKeyAction { public_key: new_public_key, access_key })),
             ],
         )
     }
@@ -243,7 +243,7 @@ pub trait User {
         self.sign_and_commit_actions(
             signer_id.clone(),
             signer_id,
-            vec![Action::Stake(StakeAction { stake, public_key })],
+            vec![Action::Stake(Box::new(StakeAction { stake, public_key }))],
         )
     }
 
@@ -280,7 +280,7 @@ pub trait User {
         self.sign_and_commit_actions(
             relayer_id,
             signer_id,
-            vec![Action::Delegate(signed_delegate_action)],
+            vec![Action::Delegate(Box::new(signed_delegate_action))],
         )
     }
 }

--- a/integration-tests/src/user/mod.rs
+++ b/integration-tests/src/user/mod.rs
@@ -166,7 +166,10 @@ pub trait User {
             vec![
                 Action::CreateAccount(CreateAccountAction {}),
                 Action::Transfer(TransferAction { deposit: amount }),
-                Action::AddKey(Box::new(AddKeyAction { public_key, access_key: AccessKey::full_access() })),
+                Action::AddKey(Box::new(AddKeyAction {
+                    public_key,
+                    access_key: AccessKey::full_access(),
+                })),
             ],
         )
     }

--- a/integration-tests/src/user/mod.rs
+++ b/integration-tests/src/user/mod.rs
@@ -116,7 +116,7 @@ pub trait User {
         self.sign_and_commit_actions(
             signer_id,
             receiver_id,
-            vec![Action::Transfer(TransferAction { deposit: amount })],
+            vec![Action::Transfer(Box::new(TransferAction { deposit: amount }))],
         )
     }
 
@@ -128,7 +128,7 @@ pub trait User {
         self.sign_and_commit_actions(
             signer_id.clone(),
             signer_id,
-            vec![Action::DeployContract(DeployContractAction { code })],
+            vec![Action::DeployContract(Box::new(DeployContractAction { code }))],
         )
     }
 
@@ -165,7 +165,7 @@ pub trait User {
             new_account_id,
             vec![
                 Action::CreateAccount(CreateAccountAction {}),
-                Action::Transfer(TransferAction { deposit: amount }),
+                Action::Transfer(Box::new(TransferAction { deposit: amount })),
                 Action::AddKey(Box::new(AddKeyAction {
                     public_key,
                     access_key: AccessKey::full_access(),
@@ -225,7 +225,7 @@ pub trait User {
         self.sign_and_commit_actions(
             signer_id,
             receiver_id,
-            vec![Action::DeleteAccount(DeleteAccountAction { beneficiary_id })],
+            vec![Action::DeleteAccount(Box::new(DeleteAccountAction { beneficiary_id }))],
         )
     }
 

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -1338,7 +1338,7 @@ mod test {
             sender.validator_id().clone(),
             sender.validator_id().clone(),
             &*signer,
-            vec![Action::Stake(StakeAction { stake, public_key: sender.public_key() })],
+            vec![Action::Stake(Box::new(StakeAction { stake, public_key: sender.public_key() }))],
             // runtime does not validate block history
             CryptoHash::default(),
         )

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -2639,9 +2639,9 @@ mod test {
             signers[1].account_id.clone(),
             signers[1].account_id.clone(),
             &signers[1] as &dyn Signer,
-            vec![Action::DeleteAccount(DeleteAccountAction {
+            vec![Action::DeleteAccount(Box::new(DeleteAccountAction {
                 beneficiary_id: signers[0].account_id.clone(),
-            })],
+            }))],
             // runtime does not validate block history
             CryptoHash::default(),
         );
@@ -2735,7 +2735,7 @@ mod test {
             signers[0].account_id.clone(),
             validators[1].clone(),
             &signers[0] as &dyn Signer,
-            vec![Action::Transfer(TransferAction { deposit: 10 })],
+            vec![Action::Transfer(Box::new(TransferAction { deposit: 10 }))],
             // runtime does not validate block history
             CryptoHash::default(),
         );

--- a/runtime/runtime-params-estimator/src/action_costs.rs
+++ b/runtime/runtime-params-estimator/src/action_costs.rs
@@ -686,10 +686,10 @@ fn create_transfer_action() -> Action {
 }
 
 fn stake_action() -> Action {
-    Action::Stake(near_primitives::transaction::StakeAction {
+    Action::Stake(Box::new(near_primitives::transaction::StakeAction {
         stake: 5u128.pow(28), // some arbitrary positive number
         public_key: PublicKey::from_seed(KeyType::ED25519, "seed"),
-    })
+    }))
 }
 
 fn delete_account_action() -> Action {
@@ -705,10 +705,10 @@ fn deploy_action(size: ActionSize) -> Action {
 }
 
 fn add_full_access_key_action() -> Action {
-    Action::AddKey(near_primitives::transaction::AddKeyAction {
+    Action::AddKey(Box::new(near_primitives::transaction::AddKeyAction {
         public_key: PublicKey::from_seed(KeyType::ED25519, "full-access-key-seed"),
         access_key: AccessKey { nonce: 0, permission: AccessKeyPermission::FullAccess },
-    })
+    }))
 }
 
 fn add_fn_access_key_action(size: ActionSize) -> Action {
@@ -716,7 +716,7 @@ fn add_fn_access_key_action(size: ActionSize) -> Action {
     let method_names = vec!["foo".to_owned(); size.key_methods_list() as usize / 4];
     // This is charged flat, therefore it should always be max len.
     let receiver_id = "a".repeat(AccountId::MAX_LEN).parse().unwrap();
-    Action::AddKey(near_primitives::transaction::AddKeyAction {
+    Action::AddKey(Box::new(near_primitives::transaction::AddKeyAction {
         public_key: PublicKey::from_seed(KeyType::ED25519, "seed"),
         access_key: AccessKey {
             nonce: 0,
@@ -726,13 +726,13 @@ fn add_fn_access_key_action(size: ActionSize) -> Action {
                 method_names,
             }),
         },
-    })
+    }))
 }
 
 fn delete_key_action() -> Action {
-    Action::DeleteKey(near_primitives::transaction::DeleteKeyAction {
+    Action::DeleteKey(Box::new(near_primitives::transaction::DeleteKeyAction {
         public_key: PublicKey::from_seed(KeyType::ED25519, "seed"),
-    })
+    }))
 }
 
 fn transfer_action() -> Action {
@@ -744,12 +744,12 @@ fn function_call_action(size: ActionSize) -> Action {
     let method_len = 4.min(total_size) as usize;
     let method_name: String = "noop".chars().take(method_len).collect();
     let arg_len = total_size as usize - method_len;
-    Action::FunctionCall(near_primitives::transaction::FunctionCallAction {
+    Action::FunctionCall(Box::new(near_primitives::transaction::FunctionCallAction {
         method_name,
         args: vec![1u8; arg_len],
         gas: 3 * 10u64.pow(12), // 3 Tgas, to allow 100 copies in the same receipt
         deposit: 10u128.pow(24),
-    })
+    }))
 }
 
 pub(crate) fn empty_delegate_action(
@@ -772,10 +772,10 @@ pub(crate) fn empty_delegate_action(
     };
     let signature =
         SignableMessage::new(&delegate_action, SignableMessageType::DelegateAction).sign(&signer);
-    Action::Delegate(near_primitives::action::delegate::SignedDelegateAction {
+    Action::Delegate(Box::new(near_primitives::action::delegate::SignedDelegateAction {
         delegate_action,
         signature,
-    })
+    }))
 }
 
 /// Helper enum to select how large an action should be generated.

--- a/runtime/runtime-params-estimator/src/action_costs.rs
+++ b/runtime/runtime-params-estimator/src/action_costs.rs
@@ -682,7 +682,9 @@ fn create_account_action() -> Action {
 }
 
 fn create_transfer_action() -> Action {
-    Action::Transfer(Box::new(near_primitives::transaction::TransferAction { deposit: 10u128.pow(24) }))
+    Action::Transfer(Box::new(near_primitives::transaction::TransferAction {
+        deposit: 10u128.pow(24),
+    }))
 }
 
 fn stake_action() -> Action {

--- a/runtime/runtime-params-estimator/src/action_costs.rs
+++ b/runtime/runtime-params-estimator/src/action_costs.rs
@@ -682,7 +682,7 @@ fn create_account_action() -> Action {
 }
 
 fn create_transfer_action() -> Action {
-    Action::Transfer(near_primitives::transaction::TransferAction { deposit: 10u128.pow(24) })
+    Action::Transfer(Box::new(near_primitives::transaction::TransferAction { deposit: 10u128.pow(24) }))
 }
 
 fn stake_action() -> Action {
@@ -693,15 +693,15 @@ fn stake_action() -> Action {
 }
 
 fn delete_account_action() -> Action {
-    Action::DeleteAccount(near_primitives::transaction::DeleteAccountAction {
+    Action::DeleteAccount(Box::new(near_primitives::transaction::DeleteAccountAction {
         beneficiary_id: "bob.near".parse().unwrap(),
-    })
+    }))
 }
 
 fn deploy_action(size: ActionSize) -> Action {
-    Action::DeployContract(near_primitives::transaction::DeployContractAction {
+    Action::DeployContract(Box::new(near_primitives::transaction::DeployContractAction {
         code: near_test_contracts::sized_contract(size.deploy_contract() as usize),
-    })
+    }))
 }
 
 fn add_full_access_key_action() -> Action {
@@ -736,7 +736,7 @@ fn delete_key_action() -> Action {
 }
 
 fn transfer_action() -> Action {
-    Action::Transfer(near_primitives::transaction::TransferAction { deposit: 77 })
+    Action::Transfer(Box::new(near_primitives::transaction::TransferAction { deposit: 77 }))
 }
 
 fn function_call_action(size: ActionSize) -> Action {

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -522,7 +522,7 @@ fn add_key_transaction(
     tb.transaction_from_actions(
         sender,
         receiver,
-        vec![Action::AddKey(AddKeyAction { public_key, access_key })],
+        vec![Action::AddKey(Box::new(AddKeyAction { public_key, access_key }))],
     )
 }
 
@@ -532,9 +532,9 @@ fn action_delete_key(ctx: &mut EstimatorContext) -> GasCost {
             let sender = tb.random_unused_account();
             let receiver = sender.clone();
 
-            let actions = vec![Action::DeleteKey(DeleteKeyAction {
+            let actions = vec![Action::DeleteKey(Box::new(DeleteKeyAction {
                 public_key: SecretKey::from_seed(KeyType::ED25519, sender.as_ref()).public_key(),
-            })];
+            }))];
             tb.transaction_from_actions(sender, receiver, actions)
         };
         transaction_cost(ctx, &mut make_transaction)
@@ -551,10 +551,10 @@ fn action_stake(ctx: &mut EstimatorContext) -> GasCost {
             let sender = tb.random_unused_account();
             let receiver = sender.clone();
 
-            let actions = vec![Action::Stake(StakeAction {
+            let actions = vec![Action::Stake(Box::new(StakeAction {
                 stake: 1,
                 public_key: "22skMptHjFWNyuEWY22ftn2AbLPSYpmYwGJRGwpNHbTV".parse().unwrap(),
-            })];
+            }))];
             tb.transaction_from_actions(sender, receiver, actions)
         };
         transaction_cost(ctx, &mut make_transaction)

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -403,7 +403,8 @@ fn action_delete_account(ctx: &mut EstimatorContext) -> GasCost {
             let receiver = sender.clone();
             let beneficiary_id = tb.random_unused_account();
 
-            let actions = vec![Action::DeleteAccount(Box::new(DeleteAccountAction { beneficiary_id }))];
+            let actions =
+                vec![Action::DeleteAccount(Box::new(DeleteAccountAction { beneficiary_id }))];
             tb.transaction_from_actions(sender, receiver, actions)
         };
         let block_size = 100;
@@ -648,7 +649,8 @@ fn deploy_contract_cost(
         let sender = tb.random_unused_account();
         let receiver = sender.clone();
 
-        let actions = vec![Action::DeployContract(Box::new(DeployContractAction { code: code_factory() }))];
+        let actions =
+            vec![Action::DeployContract(Box::new(DeployContractAction { code: code_factory() }))];
         tb.transaction_from_actions(sender, receiver, actions)
     };
     // Use a small block size since deployments are gas heavy.

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -358,7 +358,7 @@ fn action_transfer(ctx: &mut EstimatorContext) -> GasCost {
         let mut make_transaction = |tb: &mut TransactionBuilder| -> SignedTransaction {
             let (sender, receiver) = tb.random_account_pair();
 
-            let actions = vec![Action::Transfer(TransferAction { deposit: 1 })];
+            let actions = vec![Action::Transfer(Box::new(TransferAction { deposit: 1 }))];
             tb.transaction_from_actions(sender, receiver, actions)
         };
         let block_size = 100;
@@ -381,7 +381,7 @@ fn action_create_account(ctx: &mut EstimatorContext) -> GasCost {
 
             let actions = vec![
                 Action::CreateAccount(CreateAccountAction {}),
-                Action::Transfer(TransferAction { deposit: 10u128.pow(26) }),
+                Action::Transfer(Box::new(TransferAction { deposit: 10u128.pow(26) })),
             ];
             tb.transaction_from_actions(sender, new_account, actions)
         };
@@ -403,7 +403,7 @@ fn action_delete_account(ctx: &mut EstimatorContext) -> GasCost {
             let receiver = sender.clone();
             let beneficiary_id = tb.random_unused_account();
 
-            let actions = vec![Action::DeleteAccount(DeleteAccountAction { beneficiary_id })];
+            let actions = vec![Action::DeleteAccount(Box::new(DeleteAccountAction { beneficiary_id }))];
             tb.transaction_from_actions(sender, receiver, actions)
         };
         let block_size = 100;
@@ -648,7 +648,7 @@ fn deploy_contract_cost(
         let sender = tb.random_unused_account();
         let receiver = sender.clone();
 
-        let actions = vec![Action::DeployContract(DeployContractAction { code: code_factory() })];
+        let actions = vec![Action::DeployContract(Box::new(DeployContractAction { code: code_factory() }))];
         tb.transaction_from_actions(sender, receiver, actions)
     };
     // Use a small block size since deployments are gas heavy.

--- a/runtime/runtime-params-estimator/src/transaction_builder.rs
+++ b/runtime/runtime-params-estimator/src/transaction_builder.rs
@@ -72,12 +72,12 @@ impl TransactionBuilder {
         args: Vec<u8>,
     ) -> SignedTransaction {
         let receiver = sender.clone();
-        let actions = vec![Action::FunctionCall(FunctionCallAction {
+        let actions = vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: method.to_string(),
             args,
             gas: 10u64.pow(18),
             deposit: 0,
-        })];
+        }))];
         self.transaction_from_actions(sender, receiver, actions)
     }
 

--- a/runtime/runtime-params-estimator/src/utils.rs
+++ b/runtime/runtime-params-estimator/src/utils.rs
@@ -295,12 +295,12 @@ pub(crate) fn fn_cost_in_contract(
 }
 
 fn function_call_action(method_name: String) -> Action {
-    Action::FunctionCall(FunctionCallAction {
+    Action::FunctionCall(Box::new(FunctionCallAction {
         method_name,
         args: Vec::new(),
         gas: 10u64.pow(15),
         deposit: 0,
-    })
+    }))
 }
 
 /// Takes a list of measurements of input blocks and returns the cost for a

--- a/runtime/runtime-params-estimator/src/utils.rs
+++ b/runtime/runtime-params-estimator/src/utils.rs
@@ -254,7 +254,8 @@ pub(crate) fn fn_cost_in_contract(
 
     for account in &chosen_accounts {
         let tb = testbed.transaction_builder();
-        let setup = vec![Action::DeployContract(Box::new(DeployContractAction { code: code.to_vec() }))];
+        let setup =
+            vec![Action::DeployContract(Box::new(DeployContractAction { code: code.to_vec() }))];
         let setup_tx = tb.transaction_from_actions(account.clone(), account.clone(), setup);
 
         testbed.process_block(vec![setup_tx], 0);

--- a/runtime/runtime-params-estimator/src/utils.rs
+++ b/runtime/runtime-params-estimator/src/utils.rs
@@ -254,7 +254,7 @@ pub(crate) fn fn_cost_in_contract(
 
     for account in &chosen_accounts {
         let tb = testbed.transaction_builder();
-        let setup = vec![Action::DeployContract(DeployContractAction { code: code.to_vec() })];
+        let setup = vec![Action::DeployContract(Box::new(DeployContractAction { code: code.to_vec() }))];
         let setup_tx = tb.transaction_from_actions(account.clone(), account.clone(), setup);
 
         testbed.process_block(vec![setup_tx], 0);

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -1168,12 +1168,12 @@ mod tests {
                 actions: vec![
                     non_delegate_action(
                         Action::FunctionCall(
-                            FunctionCallAction {
+                            Box::new(FunctionCallAction {
                                  method_name: "ft_transfer".parse().unwrap(),
                                  args: vec![123, 34, 114, 101, 99, 101, 105, 118, 101, 114, 95, 105, 100, 34, 58, 34, 106, 97, 110, 101, 46, 116, 101, 115, 116, 46, 110, 101, 97, 114, 34, 44, 34, 97, 109, 111, 117, 110, 116, 34, 58, 34, 52, 34, 125],
                                  gas: 30000000000000,
                                  deposit: 1,
-                            }
+                            })
                         )
                     )
                 ],
@@ -1190,7 +1190,7 @@ mod tests {
             gas_price: 1,
             output_data_receivers: Vec::new(),
             input_data_ids: Vec::new(),
-            actions: vec![Action::Delegate(signed_delegate_action.clone())],
+            actions: vec![Action::Delegate(Box::new(signed_delegate_action.clone()))],
         };
 
         (action_receipt, signed_delegate_action)
@@ -1371,7 +1371,7 @@ mod tests {
         // Sender account doesn't exist. Must fail.
         assert_eq!(
             check_account_existence(
-                &Action::Delegate(signed_delegate_action),
+                &Action::Delegate(Box::new(signed_delegate_action)),
                 &mut None,
                 &sender_id,
                 1,
@@ -1567,12 +1567,12 @@ mod tests {
 
         let mut delegate_action = signed_delegate_action.delegate_action;
         delegate_action.actions =
-            vec![non_delegate_action(Action::FunctionCall(FunctionCallAction {
+            vec![non_delegate_action(Action::FunctionCall(Box::new(FunctionCallAction {
                 args: Vec::new(),
                 deposit: 0,
                 gas: 300,
                 method_name: "test_method".parse().unwrap(),
-            }))];
+            })))];
         let result = test_delegate_action_key_permissions(&access_key, &delegate_action);
         assert!(result.result.is_ok(), "Result error {:?}", result.result);
     }
@@ -1618,18 +1618,18 @@ mod tests {
 
         let mut delegate_action = signed_delegate_action.delegate_action;
         delegate_action.actions = vec![
-            non_delegate_action(Action::FunctionCall(FunctionCallAction {
+            non_delegate_action(Action::FunctionCall(Box::new(FunctionCallAction {
                 args: Vec::new(),
                 deposit: 0,
                 gas: 300,
                 method_name: "test_method".parse().unwrap(),
-            })),
-            non_delegate_action(Action::FunctionCall(FunctionCallAction {
+            }))),
+            non_delegate_action(Action::FunctionCall(Box::new(FunctionCallAction {
                 args: Vec::new(),
                 deposit: 0,
                 gas: 300,
                 method_name: "test_method".parse().unwrap(),
-            })),
+            }))),
         ];
 
         let result = test_delegate_action_key_permissions(&access_key, &delegate_action);
@@ -1657,12 +1657,12 @@ mod tests {
 
         let mut delegate_action = signed_delegate_action.delegate_action;
         delegate_action.actions =
-            vec![non_delegate_action(Action::FunctionCall(FunctionCallAction {
+            vec![non_delegate_action(Action::FunctionCall(Box::new(FunctionCallAction {
                 args: Vec::new(),
                 deposit: 1,
                 gas: 300,
                 method_name: "test_method".parse().unwrap(),
-            }))];
+            })))];
 
         let result = test_delegate_action_key_permissions(&access_key, &delegate_action);
 
@@ -1689,12 +1689,12 @@ mod tests {
 
         let mut delegate_action = signed_delegate_action.delegate_action;
         delegate_action.actions =
-            vec![non_delegate_action(Action::FunctionCall(FunctionCallAction {
+            vec![non_delegate_action(Action::FunctionCall(Box::new(FunctionCallAction {
                 args: Vec::new(),
                 deposit: 0,
                 gas: 300,
                 method_name: "test_method".parse().unwrap(),
-            }))];
+            })))];
 
         let result = test_delegate_action_key_permissions(&access_key, &delegate_action);
 
@@ -1724,12 +1724,12 @@ mod tests {
 
         let mut delegate_action = signed_delegate_action.delegate_action;
         delegate_action.actions =
-            vec![non_delegate_action(Action::FunctionCall(FunctionCallAction {
+            vec![non_delegate_action(Action::FunctionCall(Box::new(FunctionCallAction {
                 args: Vec::new(),
                 deposit: 0,
                 gas: 300,
                 method_name: "test_method".parse().unwrap(),
-            }))];
+            })))];
 
         let result = test_delegate_action_key_permissions(&access_key, &delegate_action);
 

--- a/runtime/runtime/src/balance_checker.rs
+++ b/runtime/runtime/src/balance_checker.rs
@@ -436,7 +436,7 @@ mod tests {
                 gas_price,
                 output_data_receivers: vec![],
                 input_data_ids: vec![],
-                actions: vec![Action::Transfer(TransferAction { deposit })],
+                actions: vec![Action::Transfer(Box::new(TransferAction { deposit }))],
             }),
         };
 
@@ -491,7 +491,7 @@ mod tests {
                 gas_price,
                 output_data_receivers: vec![],
                 input_data_ids: vec![],
-                actions: vec![Action::Transfer(TransferAction { deposit })],
+                actions: vec![Action::Transfer(Box::new(TransferAction { deposit }))],
             }),
         };
 

--- a/runtime/runtime/src/config.rs
+++ b/runtime/runtime/src/config.rs
@@ -11,7 +11,7 @@ use near_primitives::errors::IntegerOverflowError;
 pub use near_primitives::num_rational::Rational32;
 pub use near_primitives::runtime::config::RuntimeConfig;
 use near_primitives::runtime::fees::{transfer_exec_fee, transfer_send_fee, RuntimeFeesConfig};
-use near_primitives::transaction::{Action, DeployContractAction, Transaction};
+use near_primitives::transaction::{Action, Transaction};
 use near_primitives::types::{AccountId, Balance, Compute, Gas};
 use near_primitives::version::{checked_feature, ProtocolVersion};
 
@@ -85,8 +85,8 @@ pub fn total_send_fees(
             CreateAccount(_) => {
                 config.fee(ActionCosts::create_account).send_fee(sender_is_receiver)
             }
-            DeployContract(DeployContractAction { code }) => {
-                let num_bytes = code.len() as u64;
+            DeployContract(deploy_contract_action) => {
+                let num_bytes = deploy_contract_action.code.len() as u64;
                 config.fee(ActionCosts::deploy_contract_base).send_fee(sender_is_receiver)
                     + config.fee(ActionCosts::deploy_contract_byte).send_fee(sender_is_receiver)
                         * num_bytes
@@ -191,8 +191,8 @@ pub fn exec_fee(
 
     match action {
         CreateAccount(_) => config.fee(ActionCosts::create_account).exec_fee(),
-        DeployContract(DeployContractAction { code }) => {
-            let num_bytes = code.len() as u64;
+        DeployContract(deploy_contract_action) => {
+            let num_bytes = deploy_contract_action.code.len() as u64;
             config.fee(ActionCosts::deploy_contract_base).exec_fee()
                 + config.fee(ActionCosts::deploy_contract_byte).exec_fee() * num_bytes
         }

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1942,9 +1942,9 @@ mod tests {
                         gas_price: GAS_PRICE,
                         output_data_receivers: vec![],
                         input_data_ids: vec![],
-                        actions: vec![Action::Transfer(TransferAction {
+                        actions: vec![Action::Transfer(Box::new(TransferAction {
                             deposit: small_transfer + Balance::from(i),
-                        })],
+                        }))],
                     }),
                 }
             })
@@ -2297,7 +2297,7 @@ mod tests {
         match &result.outgoing_receipts[0].receipt {
             ReceiptEnum::Action(ActionReceipt { actions, .. }) => {
                 assert!(
-                    matches!(actions[0], Action::Transfer(TransferAction { deposit }) if deposit == expected_refund)
+                    matches!(&actions[0], Action::Transfer(transfer_action) if transfer_action.deposit == expected_refund)
                 );
             }
             _ => unreachable!(),
@@ -2523,9 +2523,9 @@ mod tests {
         let deploy_contract_receipt = create_receipt_with_actions(
             alice_account(),
             signer.clone(),
-            vec![Action::DeployContract(DeployContractAction {
+            vec![Action::DeployContract(Box::new(DeployContractAction {
                 code: near_test_contracts::rs_contract().to_vec(),
-            })],
+            }))],
         );
 
         let first_call_receipt = create_receipt_with_actions(
@@ -2610,9 +2610,9 @@ mod tests {
         let deploy_contract_receipt = create_receipt_with_actions(
             alice_account(),
             signer.clone(),
-            vec![Action::DeployContract(DeployContractAction {
+            vec![Action::DeployContract(Box::new(DeployContractAction {
                 code: near_test_contracts::rs_contract().to_vec(),
-            })],
+            }))],
         );
 
         let first_call_receipt = create_receipt_with_actions(

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -2245,12 +2245,12 @@ mod tests {
 
         let gas = 2 * 10u64.pow(14);
         let gas_price = GAS_PRICE / 10;
-        let actions = vec![Action::FunctionCall(FunctionCallAction {
+        let actions = vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "hello".to_string(),
             args: b"world".to_vec(),
             gas,
             deposit: 0,
-        })];
+        }))];
 
         let expected_gas_burnt = safe_add_gas(
             apply_state.config.fees.fee(ActionCosts::new_action_receipt).exec_fee(),
@@ -2314,12 +2314,12 @@ mod tests {
 
         let gas = 1_000_000;
         let gas_price = GAS_PRICE / 10;
-        let actions = vec![Action::FunctionCall(FunctionCallAction {
+        let actions = vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "hello".to_string(),
             args: b"world".to_vec(),
             gas,
             deposit: 0,
-        })];
+        }))];
 
         let expected_gas_burnt = safe_add_gas(
             apply_state.config.fees.fee(ActionCosts::new_action_receipt).exec_fee(),
@@ -2376,11 +2376,11 @@ mod tests {
         let initial_account_state = get_account(&state_update, &alice_account()).unwrap().unwrap();
 
         let actions = vec![
-            Action::DeleteKey(DeleteKeyAction { public_key: signer.public_key() }),
-            Action::AddKey(AddKeyAction {
+            Action::DeleteKey(Box::new(DeleteKeyAction { public_key: signer.public_key() })),
+            Action::AddKey(Box::new(AddKeyAction {
                 public_key: signer.public_key(),
                 access_key: AccessKey::full_access(),
-            }),
+            })),
         ];
 
         let receipts = vec![create_receipt_with_actions(alice_account(), signer, actions)];
@@ -2427,7 +2427,8 @@ mod tests {
         let root = tries.apply_all(&trie_changes, ShardUId::single_shard(), &mut store_update);
         store_update.commit().unwrap();
 
-        let actions = vec![Action::DeleteKey(DeleteKeyAction { public_key: signer.public_key() })];
+        let actions =
+            vec![Action::DeleteKey(Box::new(DeleteKeyAction { public_key: signer.public_key() }))];
 
         let receipts = vec![create_receipt_with_actions(alice_account(), signer, actions)];
 
@@ -2530,23 +2531,23 @@ mod tests {
         let first_call_receipt = create_receipt_with_actions(
             alice_account(),
             signer.clone(),
-            vec![Action::FunctionCall(FunctionCallAction {
+            vec![Action::FunctionCall(Box::new(FunctionCallAction {
                 method_name: "ext_sha256".to_string(),
                 args: b"first".to_vec(),
                 gas: sha256_cost.gas,
                 deposit: 0,
-            })],
+            }))],
         );
 
         let second_call_receipt = create_receipt_with_actions(
             alice_account(),
             signer,
-            vec![Action::FunctionCall(FunctionCallAction {
+            vec![Action::FunctionCall(Box::new(FunctionCallAction {
                 method_name: "ext_sha256".to_string(),
                 args: b"second".to_vec(),
                 gas: sha256_cost.gas,
                 deposit: 0,
-            })],
+            }))],
         );
 
         let apply_result = runtime
@@ -2617,12 +2618,12 @@ mod tests {
         let first_call_receipt = create_receipt_with_actions(
             alice_account(),
             signer,
-            vec![Action::FunctionCall(FunctionCallAction {
+            vec![Action::FunctionCall(Box::new(FunctionCallAction {
                 method_name: "ext_sha256".to_string(),
                 args: b"first".to_vec(),
                 gas: 1,
                 deposit: 0,
-            })],
+            }))],
         );
 
         let apply_result = runtime

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -2468,8 +2468,9 @@ mod tests {
             setup_runtime(initial_balance, initial_locked, gas_limit);
 
         let wasm_code = near_test_contracts::rs_contract().to_vec();
-        let actions =
-            vec![Action::DeployContract(DeployContractAction { code: wasm_code.clone() })];
+        let actions = vec![Action::DeployContract(Box::new(DeployContractAction {
+            code: wasm_code.clone(),
+        }))];
 
         let receipts = vec![create_receipt_with_actions(alice_account(), signer, actions)];
 

--- a/runtime/runtime/src/receipt_manager.rs
+++ b/runtime/runtime/src/receipt_manager.rs
@@ -136,7 +136,7 @@ impl ReceiptManager {
         receipt_index: ReceiptIndex,
         code: Vec<u8>,
     ) -> Result<(), VMLogicError> {
-        self.append_action(receipt_index, Action::DeployContract(DeployContractAction { code }));
+        self.append_action(receipt_index, Action::DeployContract(Box::new(DeployContractAction { code })));
         Ok(())
     }
 
@@ -205,7 +205,7 @@ impl ReceiptManager {
         receipt_index: ReceiptIndex,
         deposit: Balance,
     ) -> Result<(), VMLogicError> {
-        self.append_action(receipt_index, Action::Transfer(TransferAction { deposit }));
+        self.append_action(receipt_index, Action::Transfer(Box::new(TransferAction { deposit })));
         Ok(())
     }
 
@@ -345,7 +345,7 @@ impl ReceiptManager {
     ) -> Result<(), VMLogicError> {
         self.append_action(
             receipt_index,
-            Action::DeleteAccount(DeleteAccountAction { beneficiary_id }),
+            Action::DeleteAccount(Box::new(DeleteAccountAction { beneficiary_id })),
         );
         Ok(())
     }

--- a/runtime/runtime/src/receipt_manager.rs
+++ b/runtime/runtime/src/receipt_manager.rs
@@ -394,7 +394,7 @@ impl ReceiptManager {
 
 #[cfg(test)]
 mod tests {
-    use near_primitives::transaction::{Action};
+    use near_primitives::transaction::Action;
     use near_primitives_core::types::{Gas, GasWeight};
 
     #[track_caller]

--- a/runtime/runtime/src/receipt_manager.rs
+++ b/runtime/runtime/src/receipt_manager.rs
@@ -171,13 +171,13 @@ impl ReceiptManager {
     ) -> Result<(), VMLogicError> {
         let action_index = self.append_action(
             receipt_index,
-            Action::FunctionCall(FunctionCallAction {
+            Action::FunctionCall(Box::new(FunctionCallAction {
                 method_name: String::from_utf8(method_name)
                     .map_err(|_| HostError::InvalidMethodName)?,
                 args,
                 gas: prepaid_gas,
                 deposit: attached_deposit,
-            }),
+            })),
         );
 
         if gas_weight.0 > 0 {
@@ -226,7 +226,10 @@ impl ReceiptManager {
         stake: Balance,
         public_key: PublicKey,
     ) {
-        self.append_action(receipt_index, Action::Stake(StakeAction { stake, public_key }));
+        self.append_action(
+            receipt_index,
+            Action::Stake(Box::new(StakeAction { stake, public_key })),
+        );
     }
 
     /// Attach the [`AddKeyAction`] action to an existing receipt.
@@ -248,10 +251,10 @@ impl ReceiptManager {
     ) {
         self.append_action(
             receipt_index,
-            Action::AddKey(AddKeyAction {
+            Action::AddKey(Box::new(AddKeyAction {
                 public_key,
                 access_key: AccessKey { nonce, permission: AccessKeyPermission::FullAccess },
-            }),
+            })),
         );
     }
 
@@ -283,7 +286,7 @@ impl ReceiptManager {
     ) -> Result<(), VMLogicError> {
         self.append_action(
             receipt_index,
-            Action::AddKey(AddKeyAction {
+            Action::AddKey(Box::new(AddKeyAction {
                 public_key,
                 access_key: AccessKey {
                     nonce,
@@ -299,7 +302,7 @@ impl ReceiptManager {
                             .collect::<std::result::Result<Vec<_>, _>>()?,
                     }),
                 },
-            }),
+            })),
         );
         Ok(())
     }
@@ -319,7 +322,10 @@ impl ReceiptManager {
         receipt_index: ReceiptIndex,
         public_key: PublicKey,
     ) {
-        self.append_action(receipt_index, Action::DeleteKey(DeleteKeyAction { public_key }));
+        self.append_action(
+            receipt_index,
+            Action::DeleteKey(Box::new(DeleteKeyAction { public_key })),
+        );
     }
 
     /// Attach the [`DeleteAccountAction`] action to an existing receipt
@@ -388,7 +394,7 @@ impl ReceiptManager {
 
 #[cfg(test)]
 mod tests {
-    use near_primitives::transaction::{Action, FunctionCallAction};
+    use near_primitives::transaction::{Action};
     use near_primitives_core::types::{Gas, GasWeight};
 
     #[track_caller]
@@ -425,10 +431,10 @@ mod tests {
         let mut function_calls_iter = function_calls.iter();
         for (_, receipt) in receipt_manager.action_receipts {
             for action in receipt.actions {
-                if let Action::FunctionCall(FunctionCallAction { gas, .. }) = action {
+                if let Action::FunctionCall(function_call_action) = action {
                     let reference = function_calls_iter.next().unwrap();
-                    assert_eq!(gas, accessor(reference));
-                    function_call_gas += gas;
+                    assert_eq!(function_call_action.gas, accessor(reference));
+                    function_call_gas += function_call_action.gas;
                 }
             }
         }

--- a/runtime/runtime/src/receipt_manager.rs
+++ b/runtime/runtime/src/receipt_manager.rs
@@ -136,7 +136,10 @@ impl ReceiptManager {
         receipt_index: ReceiptIndex,
         code: Vec<u8>,
     ) -> Result<(), VMLogicError> {
-        self.append_action(receipt_index, Action::DeployContract(Box::new(DeployContractAction { code })));
+        self.append_action(
+            receipt_index,
+            Action::DeployContract(Box::new(DeployContractAction { code })),
+        );
         Ok(())
     }
 

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -939,12 +939,12 @@ mod tests {
                 alice_account(),
                 bob_account(),
                 &*signer,
-                vec![Action::FunctionCall(FunctionCallAction {
+                vec![Action::FunctionCall(Box::new(FunctionCallAction {
                     method_name: "hello".to_string(),
                     args: b"abc".to_vec(),
                     gas: 200,
                     deposit: 0,
-                })],
+                }))],
                 CryptoHash::default(),
             ),
             RuntimeError::InvalidTxError(InvalidTxError::ActionsValidation(
@@ -1101,12 +1101,12 @@ mod tests {
                 alice_account(),
                 bob_account(),
                 &*signer,
-                vec![Action::FunctionCall(FunctionCallAction {
+                vec![Action::FunctionCall(Box::new(FunctionCallAction {
                     method_name: "hello".to_string(),
                     args: b"abc".to_vec(),
                     gas: 300,
                     deposit: 0,
-                })],
+                }))],
                 CryptoHash::default(),
             ),
             true,
@@ -1234,12 +1234,12 @@ mod tests {
                     bob_account(),
                     &*signer,
                     vec![
-                        Action::FunctionCall(FunctionCallAction {
+                        Action::FunctionCall(Box::new(FunctionCallAction {
                             method_name: "hello".to_string(),
                             args: b"abc".to_vec(),
                             gas: 100,
                             deposit: 0,
-                        }),
+                        })),
                         Action::CreateAccount(CreateAccountAction {})
                     ],
                     CryptoHash::default(),
@@ -1327,12 +1327,12 @@ mod tests {
                     alice_account(),
                     eve_dot_alice_account(),
                     &*signer,
-                    vec![Action::FunctionCall(FunctionCallAction {
+                    vec![Action::FunctionCall(Box::new(FunctionCallAction {
                         method_name: "hello".to_string(),
                         args: b"abc".to_vec(),
                         gas: 100,
                         deposit: 0,
-                    }),],
+                    })),],
                     CryptoHash::default(),
                 ),
                 true,
@@ -1375,12 +1375,12 @@ mod tests {
                     alice_account(),
                     bob_account(),
                     &*signer,
-                    vec![Action::FunctionCall(FunctionCallAction {
+                    vec![Action::FunctionCall(Box::new(FunctionCallAction {
                         method_name: "hello".to_string(),
                         args: b"abc".to_vec(),
                         gas: 100,
                         deposit: 0,
-                    }),],
+                    })),],
                     CryptoHash::default(),
                 ),
                 true,
@@ -1420,12 +1420,12 @@ mod tests {
                     alice_account(),
                     bob_account(),
                     &*signer,
-                    vec![Action::FunctionCall(FunctionCallAction {
+                    vec![Action::FunctionCall(Box::new(FunctionCallAction {
                         method_name: "hello".to_string(),
                         args: b"abc".to_vec(),
                         gas: 100,
                         deposit: 100,
-                    }),],
+                    })),],
                     CryptoHash::default(),
                 ),
                 true,
@@ -1575,12 +1575,12 @@ mod tests {
         let limit_config = VMLimitConfig::test();
         validate_actions(
             &limit_config,
-            &[Action::FunctionCall(FunctionCallAction {
+            &[Action::FunctionCall(Box::new(FunctionCallAction {
                 method_name: "hello".to_string(),
                 args: b"abc".to_vec(),
                 gas: 100,
                 deposit: 0,
-            })],
+            }))],
             PROTOCOL_VERSION,
         )
         .expect("valid function call action");
@@ -1594,18 +1594,18 @@ mod tests {
             validate_actions(
                 &limit_config,
                 &[
-                    Action::FunctionCall(FunctionCallAction {
+                    Action::FunctionCall(Box::new(FunctionCallAction {
                         method_name: "hello".to_string(),
                         args: b"abc".to_vec(),
                         gas: 100,
                         deposit: 0,
-                    }),
-                    Action::FunctionCall(FunctionCallAction {
+                    })),
+                    Action::FunctionCall(Box::new(FunctionCallAction {
                         method_name: "hello".to_string(),
                         args: b"abc".to_vec(),
                         gas: 150,
                         deposit: 0,
-                    })
+                    }))
                 ],
                 PROTOCOL_VERSION,
             )
@@ -1622,18 +1622,18 @@ mod tests {
             validate_actions(
                 &limit_config,
                 &[
-                    Action::FunctionCall(FunctionCallAction {
+                    Action::FunctionCall(Box::new(FunctionCallAction {
                         method_name: "hello".to_string(),
                         args: b"abc".to_vec(),
                         gas: u64::max_value() / 2 + 1,
                         deposit: 0,
-                    }),
-                    Action::FunctionCall(FunctionCallAction {
+                    })),
+                    Action::FunctionCall(Box::new(FunctionCallAction {
                         method_name: "hello".to_string(),
                         args: b"abc".to_vec(),
                         gas: u64::max_value() / 2 + 1,
                         deposit: 0,
-                    })
+                    }))
                 ],
                 PROTOCOL_VERSION,
             )
@@ -1718,12 +1718,12 @@ mod tests {
     fn test_validate_action_valid_function_call() {
         validate_action(
             &VMLimitConfig::test(),
-            &Action::FunctionCall(FunctionCallAction {
+            &Action::FunctionCall(Box::new(FunctionCallAction {
                 method_name: "hello".to_string(),
                 args: b"abc".to_vec(),
                 gas: 100,
                 deposit: 0,
-            }),
+            })),
             PROTOCOL_VERSION,
         )
         .expect("valid action");
@@ -1734,12 +1734,12 @@ mod tests {
         assert_eq!(
             validate_action(
                 &VMLimitConfig::test(),
-                &Action::FunctionCall(FunctionCallAction {
+                &Action::FunctionCall(Box::new(FunctionCallAction {
                     method_name: "new".to_string(),
                     args: vec![],
                     gas: 0,
                     deposit: 0,
-                }),
+                })),
                 PROTOCOL_VERSION,
             )
             .expect_err("expected an error"),
@@ -1761,10 +1761,10 @@ mod tests {
     fn test_validate_action_valid_stake() {
         validate_action(
             &VMLimitConfig::test(),
-            &Action::Stake(StakeAction {
+            &Action::Stake(Box::new(StakeAction {
                 stake: 100,
                 public_key: "ed25519:KuTCtARNzxZQ3YvXDeLjx83FDqxv2SdQTSbiq876zR7".parse().unwrap(),
-            }),
+            })),
             PROTOCOL_VERSION,
         )
         .expect("valid action");
@@ -1775,10 +1775,10 @@ mod tests {
         assert_eq!(
             validate_action(
                 &VMLimitConfig::test(),
-                &Action::Stake(StakeAction {
+                &Action::Stake(Box::new(StakeAction {
                     stake: 100,
                     public_key: PublicKey::empty(KeyType::ED25519),
-                }),
+                })),
                 PROTOCOL_VERSION,
             )
             .expect_err("Expected an error"),
@@ -1792,10 +1792,10 @@ mod tests {
     fn test_validate_action_valid_add_key_full_permission() {
         validate_action(
             &VMLimitConfig::test(),
-            &Action::AddKey(AddKeyAction {
+            &Action::AddKey(Box::new(AddKeyAction {
                 public_key: PublicKey::empty(KeyType::ED25519),
                 access_key: AccessKey::full_access(),
-            }),
+            })),
             PROTOCOL_VERSION,
         )
         .expect("valid action");
@@ -1805,7 +1805,7 @@ mod tests {
     fn test_validate_action_valid_add_key_function_call() {
         validate_action(
             &VMLimitConfig::test(),
-            &Action::AddKey(AddKeyAction {
+            &Action::AddKey(Box::new(AddKeyAction {
                 public_key: PublicKey::empty(KeyType::ED25519),
                 access_key: AccessKey {
                     nonce: 0,
@@ -1815,7 +1815,7 @@ mod tests {
                         method_names: vec!["hello".to_string(), "world".to_string()],
                     }),
                 },
-            }),
+            })),
             PROTOCOL_VERSION,
         )
         .expect("valid action");
@@ -1825,7 +1825,9 @@ mod tests {
     fn test_validate_action_valid_delete_key() {
         validate_action(
             &VMLimitConfig::test(),
-            &Action::DeleteKey(DeleteKeyAction { public_key: PublicKey::empty(KeyType::ED25519) }),
+            &Action::DeleteKey(Box::new(DeleteKeyAction {
+                public_key: PublicKey::empty(KeyType::ED25519),
+            })),
             PROTOCOL_VERSION,
         )
         .expect("valid action");
@@ -1861,8 +1863,8 @@ mod tests {
             validate_actions(
                 &VMLimitConfig::test(),
                 &[
-                    Action::Delegate(signed_delegate_action.clone()),
-                    Action::Delegate(signed_delegate_action.clone()),
+                    Action::Delegate(Box::new(signed_delegate_action.clone())),
+                    Action::Delegate(Box::new(signed_delegate_action.clone())),
                 ],
                 PROTOCOL_VERSION,
             ),
@@ -1871,7 +1873,7 @@ mod tests {
         assert_eq!(
             validate_actions(
                 &&VMLimitConfig::test(),
-                &[Action::Delegate(signed_delegate_action.clone()),],
+                &[Action::Delegate(Box::new(signed_delegate_action.clone())),],
                 PROTOCOL_VERSION,
             ),
             Ok(()),
@@ -1881,7 +1883,7 @@ mod tests {
                 &VMLimitConfig::test(),
                 &[
                     Action::CreateAccount(CreateAccountAction {}),
-                    Action::Delegate(signed_delegate_action),
+                    Action::Delegate(Box::new(signed_delegate_action)),
                 ],
                 PROTOCOL_VERSION,
             ),

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -1837,7 +1837,9 @@ mod tests {
     fn test_validate_action_valid_delete_account() {
         validate_action(
             &VMLimitConfig::test(),
-            &Action::DeleteAccount(Box::new(DeleteAccountAction { beneficiary_id: alice_account() })),
+            &Action::DeleteAccount(Box::new(DeleteAccountAction {
+                beneficiary_id: alice_account(),
+            })),
             PROTOCOL_VERSION,
         )
         .expect("valid action");

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -1449,7 +1449,7 @@ mod tests {
             alice_account(),
             bob_account(),
             &*signer,
-            vec![Action::DeployContract(DeployContractAction { code: vec![1; 5] })],
+            vec![Action::DeployContract(Box::new(DeployContractAction { code: vec![1; 5] }))],
             CryptoHash::default(),
         );
         let transaction_size = transaction.get_size();
@@ -1671,9 +1671,9 @@ mod tests {
             validate_actions(
                 &limit_config,
                 &[
-                    Action::DeleteAccount(DeleteAccountAction {
+                    Action::DeleteAccount(Box::new(DeleteAccountAction {
                         beneficiary_id: "bob".parse().unwrap()
-                    }),
+                    })),
                     Action::CreateAccount(CreateAccountAction {}),
                 ],
                 PROTOCOL_VERSION,
@@ -1692,9 +1692,9 @@ mod tests {
                 &limit_config,
                 &[
                     Action::CreateAccount(CreateAccountAction {}),
-                    Action::DeleteAccount(DeleteAccountAction {
+                    Action::DeleteAccount(Box::new(DeleteAccountAction {
                         beneficiary_id: "bob".parse().unwrap()
-                    }),
+                    })),
                 ],
                 PROTOCOL_VERSION,
             ),
@@ -1751,7 +1751,7 @@ mod tests {
     fn test_validate_action_valid_transfer() {
         validate_action(
             &VMLimitConfig::test(),
-            &Action::Transfer(TransferAction { deposit: 10 }),
+            &Action::Transfer(Box::new(TransferAction { deposit: 10 })),
             PROTOCOL_VERSION,
         )
         .expect("valid action");
@@ -1837,7 +1837,7 @@ mod tests {
     fn test_validate_action_valid_delete_account() {
         validate_action(
             &VMLimitConfig::test(),
-            &Action::DeleteAccount(DeleteAccountAction { beneficiary_id: alice_account() }),
+            &Action::DeleteAccount(Box::new(DeleteAccountAction { beneficiary_id: alice_account() })),
             PROTOCOL_VERSION,
         )
         .expect("valid action");

--- a/runtime/runtime/tests/runtime_group_tools/mod.rs
+++ b/runtime/runtime/tests/runtime_group_tools/mod.rs
@@ -392,7 +392,7 @@ macro_rules! assert_receipts {
     ($group:ident, $from:expr => $receipt:ident @ $to:expr,
     $receipt_pat:pat,
     $receipt_assert:block,
-    $actions_name:ident,
+    $actions_name:expr,
     $($action_name:ident, $action_pat:pat, $action_assert:block ),+
      => [ $($produced_receipt:ident),*] ) => {
         let r = $group.get_receipt($to, $receipt);
@@ -434,9 +434,9 @@ macro_rules! assert_receipts {
 macro_rules! assert_refund {
  ($group:ident, $receipt:ident @ $to:expr) => {
         assert_receipts!($group, "system" => $receipt @ $to,
-                         ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
-                         actions,
-                         a0, Action::Transfer(TransferAction{..}), {}
+                         ReceiptEnum::Action(action_receipt), {},
+                         action_receipt.actions,
+                         a0, Action::Transfer(_), {}
                          => []);
  }
 }

--- a/runtime/runtime/tests/test_async_calls.rs
+++ b/runtime/runtime/tests/test_async_calls.rs
@@ -30,12 +30,12 @@ fn test_simple_func_call() {
         signer_sender.account_id.clone(),
         signer_receiver.account_id,
         &signer_sender,
-        vec![Action::FunctionCall(FunctionCallAction {
+        vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "sum_n".to_string(),
             args: 10u64.to_le_bytes().to_vec(),
             gas: GAS_1,
             deposit: 0,
-        })],
+        }))],
         CryptoHash::default(),
     );
 
@@ -49,7 +49,7 @@ fn test_simple_func_call() {
     assert_receipts!(group, "near_0" => r0 @ "near_1",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{..}), {}
+                     a0, Action::FunctionCall(_function_call_action), {}
                      => [ref1] );
     assert_refund!(group, ref1 @ "near_0");
 }
@@ -76,12 +76,12 @@ fn test_single_promise_no_callback() {
         signer_sender.account_id.clone(),
         signer_receiver.account_id,
         &signer_sender,
-        vec![Action::FunctionCall(FunctionCallAction {
+        vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "call_promise".to_string(),
             args: serde_json::to_vec(&data).unwrap(),
             gas: GAS_1,
             deposit: 0,
-        })],
+        }))],
         CryptoHash::default(),
     );
 
@@ -95,17 +95,17 @@ fn test_single_promise_no_callback() {
     assert_receipts!(group, "near_0" => r0 @ "near_1",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_1);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_1);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [r1, ref0] );
     assert_receipts!(group, "near_1" => r1 @ "near_2",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_2);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_2);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [ref1]);
     assert_refund!(group, ref0 @ "near_0");
@@ -142,12 +142,12 @@ fn test_single_promise_with_callback() {
         signer_sender.account_id.clone(),
         signer_receiver.account_id,
         &signer_sender,
-        vec![Action::FunctionCall(FunctionCallAction {
+        vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "call_promise".to_string(),
             args: serde_json::to_vec(&data).unwrap(),
             gas: GAS_1,
             deposit: 0,
-        })],
+        }))],
         CryptoHash::default(),
     );
 
@@ -161,9 +161,9 @@ fn test_single_promise_with_callback() {
     assert_receipts!(group, "near_0" => r0 @ "near_1",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_1);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_1);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [r1, r2, ref0] );
     let data_id;
@@ -173,9 +173,9 @@ fn test_single_promise_with_callback() {
                         data_id = output_data_receivers[0].data_id;
                      },
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_2);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_2);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [ref1]);
     assert_receipts!(group, "near_1" => r2 @ "near_3",
@@ -184,9 +184,9 @@ fn test_single_promise_with_callback() {
                         assert_eq!(data_id, input_data_ids[0].clone());
                      },
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_2);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_2);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [ref2]);
 
@@ -226,12 +226,12 @@ fn test_two_promises_no_callbacks() {
         signer_sender.account_id.clone(),
         signer_receiver.account_id,
         &signer_sender,
-        vec![Action::FunctionCall(FunctionCallAction {
+        vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "call_promise".to_string(),
             args: serde_json::to_vec(&data).unwrap(),
             gas: GAS_1,
             deposit: 0,
-        })],
+        }))],
         CryptoHash::default(),
     );
 
@@ -245,25 +245,25 @@ fn test_two_promises_no_callbacks() {
     assert_receipts!(group, "near_0" => r0 @ "near_1",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_1);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_1);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [r1, ref0] );
     assert_receipts!(group, "near_1" => r1 @ "near_2",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), { },
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_2);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_2);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [r2, ref1]);
     assert_receipts!(group, "near_2" => r2 @ "near_3",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_3);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_3);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [ref2]);
 
@@ -320,12 +320,12 @@ fn test_two_promises_with_two_callbacks() {
         signer_sender.account_id.clone(),
         signer_receiver.account_id,
         &signer_sender,
-        vec![Action::FunctionCall(FunctionCallAction {
+        vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "call_promise".to_string(),
             args: serde_json::to_vec(&data).unwrap(),
             gas: GAS_1,
             deposit: 0,
-        })],
+        }))],
         CryptoHash::default(),
     );
 
@@ -339,41 +339,41 @@ fn test_two_promises_with_two_callbacks() {
     assert_receipts!(group, "near_0" => r0 @ "near_1",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_1);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_1);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [r1, cb1, ref0] );
     assert_receipts!(group, "near_1" => r1 @ "near_2",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), { },
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_2);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_2);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [r2, cb2, ref1]);
     assert_receipts!(group, "near_2" => r2 @ "near_3",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_3);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_3);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [ref2]);
     assert_receipts!(group, "near_2" => cb2 @ "near_4",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), { },
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_3);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_3);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [ref3]);
     assert_receipts!(group, "near_1" => cb1 @ "near_5",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), { },
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_2);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_2);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [ref4]);
 
@@ -411,12 +411,12 @@ fn test_single_promise_no_callback_batch() {
         signer_sender.account_id.clone(),
         signer_receiver.account_id,
         &signer_sender,
-        vec![Action::FunctionCall(FunctionCallAction {
+        vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "call_promise".to_string(),
             args: serde_json::to_vec(&data).unwrap(),
             gas: GAS_1,
             deposit: 0,
-        })],
+        }))],
         CryptoHash::default(),
     );
 
@@ -430,17 +430,17 @@ fn test_single_promise_no_callback_batch() {
     assert_receipts!(group, "near_0" => r0 @ "near_1",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_1);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_1);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [r1, ref0] );
     assert_receipts!(group, "near_1" => r1 @ "near_2",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_2);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_2);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [ref1]);
     assert_refund!(group, ref0 @ "near_0");
@@ -483,12 +483,12 @@ fn test_single_promise_with_callback_batch() {
         signer_sender.account_id.clone(),
         signer_receiver.account_id,
         &signer_sender,
-        vec![Action::FunctionCall(FunctionCallAction {
+        vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "call_promise".to_string(),
             args: serde_json::to_vec(&data).unwrap(),
             gas: GAS_1,
             deposit: 0,
-        })],
+        }))],
         CryptoHash::default(),
     );
 
@@ -502,9 +502,9 @@ fn test_single_promise_with_callback_batch() {
     assert_receipts!(group, "near_0" => r0 @ "near_1",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_1);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_1);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [r1, r2, ref0] );
     let data_id;
@@ -514,9 +514,9 @@ fn test_single_promise_with_callback_batch() {
                         data_id = output_data_receivers[0].data_id;
                      },
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_2);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_2);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [ref1]);
     assert_receipts!(group, "near_1" => r2 @ "near_3",
@@ -525,9 +525,9 @@ fn test_single_promise_with_callback_batch() {
                         assert_eq!(data_id, input_data_ids[0].clone());
                      },
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_2);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_2);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [ref2]);
 
@@ -557,12 +557,12 @@ fn test_simple_transfer() {
         signer_sender.account_id.clone(),
         signer_receiver.account_id,
         &signer_sender,
-        vec![Action::FunctionCall(FunctionCallAction {
+        vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "call_promise".to_string(),
             args: serde_json::to_vec(&data).unwrap(),
             gas: GAS_1,
             deposit: 0,
-        })],
+        }))],
         CryptoHash::default(),
     );
 
@@ -576,9 +576,9 @@ fn test_simple_transfer() {
     assert_receipts!(group, "near_0" => r0 @ "near_1",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_1);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_1);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [r1, ref0] );
     assert_receipts!(group, "near_1" => r1 @ "near_2",
@@ -624,12 +624,12 @@ fn test_create_account_with_transfer_and_full_key() {
         signer_sender.account_id.clone(),
         signer_receiver.account_id,
         &signer_sender,
-        vec![Action::FunctionCall(FunctionCallAction {
+        vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "call_promise".to_string(),
             args: serde_json::to_vec(&data).unwrap(),
             gas: GAS_1,
             deposit: 0,
-        })],
+        }))],
         CryptoHash::default(),
     );
 
@@ -643,9 +643,9 @@ fn test_create_account_with_transfer_and_full_key() {
     assert_receipts!(group, "near_0" => r0 @ "near_1",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_1);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_1);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [r1, ref0] );
     assert_receipts!(group, "near_1" => r1 @ "near_2",
@@ -655,10 +655,10 @@ fn test_create_account_with_transfer_and_full_key() {
                      a1, Action::Transfer(TransferAction{deposit}), {
                         assert_eq!(*deposit, 10000000000000000000000000);
                      },
-                     a2, Action::AddKey(AddKeyAction{public_key, access_key}), {
-                        assert_eq!(public_key, &signer_new_account.public_key);
-                        assert_eq!(access_key.nonce, 0);
-                        assert_eq!(access_key.permission, AccessKeyPermission::FullAccess);
+                     a2, Action::AddKey(add_key_action), {
+                        assert_eq!(add_key_action.public_key, signer_new_account.public_key);
+                        assert_eq!(add_key_action.access_key.nonce, 0);
+                        assert_eq!(add_key_action.access_key.permission, AccessKeyPermission::FullAccess);
                      }
                      => [ref1] );
 
@@ -736,12 +736,12 @@ fn test_account_factory() {
         signer_sender.account_id.clone(),
         signer_receiver.account_id,
         &signer_sender,
-        vec![Action::FunctionCall(FunctionCallAction {
+        vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "call_promise".to_string(),
             args: serde_json::to_vec(&data).unwrap(),
             gas: GAS_1,
             deposit: 0,
-        })],
+        }))],
         CryptoHash::default(),
     );
 
@@ -755,9 +755,9 @@ fn test_account_factory() {
     assert_receipts!(group, "near_0" => r0 @ "near_1",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_1);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_1);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [r1, r2, ref0] );
 
@@ -773,10 +773,10 @@ fn test_account_factory() {
                      a1, Action::Transfer(TransferAction{deposit}), {
                         assert_eq!(*deposit, TESTING_INIT_BALANCE / 2);
                      },
-                     a2, Action::AddKey(AddKeyAction{public_key, access_key}), {
-                        assert_eq!(public_key, &signer_new_account.public_key);
-                        assert_eq!(access_key.nonce, 0);
-                        assert_eq!(access_key.permission, AccessKeyPermission::FunctionCall(FunctionCallPermission {
+                     a2, Action::AddKey(add_key_action), {
+                        assert_eq!(add_key_action.public_key, signer_new_account.public_key);
+                        assert_eq!(add_key_action.access_key.nonce, 0);
+                        assert_eq!(add_key_action.access_key.permission, AccessKeyPermission::FunctionCall(FunctionCallPermission {
                             allowance: Some(TESTING_INIT_BALANCE / 2),
                             receiver_id: "near_1".parse().unwrap(),
                             method_names: vec!["call_promise".to_string(), "hello".to_string()],
@@ -785,9 +785,9 @@ fn test_account_factory() {
                      a3, Action::DeployContract(DeployContractAction{code}), {
                         assert_eq!(code, near_test_contracts::rs_contract());
                      },
-                     a4, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_2);
-                        assert_eq!(*deposit, 0);
+                     a4, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_2);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [r3, ref1] );
     assert_receipts!(group, "near_1" => r2 @ "near_2",
@@ -795,25 +795,25 @@ fn test_account_factory() {
                         assert_eq!(input_data_ids, &[data_id]);
                      },
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_2);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_2);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [r4, ref2] );
     assert_receipts!(group, "near_2" => r3 @ "near_0",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_3);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_3);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [ref3] );
     assert_receipts!(group, "near_2" => r4 @ "near_1",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_3);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_3);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [ref4] );
 
@@ -882,12 +882,12 @@ fn test_create_account_add_key_call_delete_key_delete_account() {
         signer_sender.account_id.clone(),
         signer_receiver.account_id,
         &signer_sender,
-        vec![Action::FunctionCall(FunctionCallAction {
+        vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "call_promise".to_string(),
             args: serde_json::to_vec(&data).unwrap(),
             gas: GAS_1,
             deposit: 0,
-        })],
+        }))],
         CryptoHash::default(),
     );
 
@@ -901,9 +901,9 @@ fn test_create_account_add_key_call_delete_key_delete_account() {
     assert_receipts!(group, "near_0" => r0 @ "near_1",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_1);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_1);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [r1, ref0] );
     assert_receipts!(group, "near_1" => r1 @ "near_3",
@@ -913,20 +913,20 @@ fn test_create_account_add_key_call_delete_key_delete_account() {
                      a1, Action::Transfer(TransferAction{deposit}), {
                         assert_eq!(*deposit, TESTING_INIT_BALANCE / 2);
                      },
-                     a2, Action::AddKey(AddKeyAction{public_key, access_key}), {
-                        assert_eq!(public_key, &signer_new_account.public_key);
-                        assert_eq!(access_key.nonce, 1);
-                        assert_eq!(access_key.permission, AccessKeyPermission::FullAccess);
+                     a2, Action::AddKey(add_key_action), {
+                        assert_eq!(add_key_action.public_key, signer_new_account.public_key);
+                        assert_eq!(add_key_action.access_key.nonce, 1);
+                        assert_eq!(add_key_action.access_key.permission, AccessKeyPermission::FullAccess);
                      },
                      a3, Action::DeployContract(DeployContractAction{code}), {
                         assert_eq!(code, near_test_contracts::rs_contract());
                      },
-                     a4, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_2);
-                        assert_eq!(*deposit, 0);
+                     a4, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_2);
+                        assert_eq!(function_call_action.deposit, 0);
                      },
-                     a5, Action::DeleteKey(DeleteKeyAction{public_key}), {
-                        assert_eq!(public_key, &signer_new_account.public_key);
+                     a5, Action::DeleteKey(delete_key_action), {
+                        assert_eq!(delete_key_action.public_key, signer_new_account.public_key);
                      },
                      a6, Action::DeleteAccount(DeleteAccountAction{beneficiary_id}), {
                         assert_eq!(beneficiary_id.as_ref(), "near_2");
@@ -936,9 +936,9 @@ fn test_create_account_add_key_call_delete_key_delete_account() {
     assert_receipts!(group, "near_3" => r2 @ "near_0",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_3);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_3);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [ref2] );
     assert_refund!(group, r3 @ "near_2");
@@ -976,12 +976,12 @@ fn test_transfer_64len_hex() {
         signer_sender.account_id.clone(),
         signer_receiver.account_id,
         &signer_sender,
-        vec![Action::FunctionCall(FunctionCallAction {
+        vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "call_promise".to_string(),
             args: serde_json::to_vec(&data).unwrap(),
             gas: GAS_1,
             deposit: 0,
-        })],
+        }))],
         CryptoHash::default(),
     );
 
@@ -995,9 +995,9 @@ fn test_transfer_64len_hex() {
     assert_receipts!(group, "near_0" => r0 @ "near_1",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_1);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_1);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [r1, ref0] );
     assert_receipts!(group, "near_1" => r1 @ account_id.as_ref(),
@@ -1042,12 +1042,12 @@ fn test_create_transfer_64len_hex_fail() {
         signer_sender.account_id.clone(),
         signer_receiver.account_id,
         &signer_sender,
-        vec![Action::FunctionCall(FunctionCallAction {
+        vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "call_promise".to_string(),
             args: serde_json::to_vec(&data).unwrap(),
             gas: GAS_1,
             deposit: 0,
-        })],
+        }))],
         CryptoHash::default(),
     );
 
@@ -1061,9 +1061,9 @@ fn test_create_transfer_64len_hex_fail() {
     assert_receipts!(group, "near_0" => r0 @ "near_1",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_1);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_1);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [r1, ref0] );
     assert_receipts!(group, "near_1" => r1 @ account_id.as_ref(),

--- a/runtime/runtime/tests/test_async_calls.rs
+++ b/runtime/runtime/tests/test_async_calls.rs
@@ -584,8 +584,8 @@ fn test_simple_transfer() {
     assert_receipts!(group, "near_1" => r1 @ "near_2",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::Transfer(TransferAction{deposit}), {
-                        assert_eq!(*deposit, 1000000000);
+                     a0, Action::Transfer(transfer_action), {
+                        assert_eq!(transfer_action.deposit, 1000000000);
                      }
                      => [ref1] );
 
@@ -652,8 +652,8 @@ fn test_create_account_with_transfer_and_full_key() {
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
                      a0, Action::CreateAccount(CreateAccountAction{}), {},
-                     a1, Action::Transfer(TransferAction{deposit}), {
-                        assert_eq!(*deposit, 10000000000000000000000000);
+                     a1, Action::Transfer(transfer_action), {
+                        assert_eq!(transfer_action.deposit, 10000000000000000000000000);
                      },
                      a2, Action::AddKey(add_key_action), {
                         assert_eq!(add_key_action.public_key, signer_new_account.public_key);
@@ -770,8 +770,8 @@ fn test_account_factory() {
                      },
                      actions,
                      a0, Action::CreateAccount(CreateAccountAction{}), {},
-                     a1, Action::Transfer(TransferAction{deposit}), {
-                        assert_eq!(*deposit, TESTING_INIT_BALANCE / 2);
+                     a1, Action::Transfer(transfer_action), {
+                        assert_eq!(transfer_action.deposit, TESTING_INIT_BALANCE / 2);
                      },
                      a2, Action::AddKey(add_key_action), {
                         assert_eq!(add_key_action.public_key, signer_new_account.public_key);
@@ -782,8 +782,8 @@ fn test_account_factory() {
                             method_names: vec!["call_promise".to_string(), "hello".to_string()],
                         }));
                      },
-                     a3, Action::DeployContract(DeployContractAction{code}), {
-                        assert_eq!(code, near_test_contracts::rs_contract());
+                     a3, Action::DeployContract(deploy_contract_action), {
+                        assert_eq!(deploy_contract_action.code, near_test_contracts::rs_contract());
                      },
                      a4, Action::FunctionCall(function_call_action), {
                         assert_eq!(function_call_action.gas, GAS_2);
@@ -910,16 +910,16 @@ fn test_create_account_add_key_call_delete_key_delete_account() {
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
                      a0, Action::CreateAccount(CreateAccountAction{}), {},
-                     a1, Action::Transfer(TransferAction{deposit}), {
-                        assert_eq!(*deposit, TESTING_INIT_BALANCE / 2);
+                     a1, Action::Transfer(transfer_action), {
+                        assert_eq!(transfer_action.deposit, TESTING_INIT_BALANCE / 2);
                      },
                      a2, Action::AddKey(add_key_action), {
                         assert_eq!(add_key_action.public_key, signer_new_account.public_key);
                         assert_eq!(add_key_action.access_key.nonce, 1);
                         assert_eq!(add_key_action.access_key.permission, AccessKeyPermission::FullAccess);
                      },
-                     a3, Action::DeployContract(DeployContractAction{code}), {
-                        assert_eq!(code, near_test_contracts::rs_contract());
+                     a3, Action::DeployContract(deploy_contract_action), {
+                        assert_eq!(deploy_contract_action.code, near_test_contracts::rs_contract());
                      },
                      a4, Action::FunctionCall(function_call_action), {
                         assert_eq!(function_call_action.gas, GAS_2);
@@ -928,8 +928,8 @@ fn test_create_account_add_key_call_delete_key_delete_account() {
                      a5, Action::DeleteKey(delete_key_action), {
                         assert_eq!(delete_key_action.public_key, signer_new_account.public_key);
                      },
-                     a6, Action::DeleteAccount(DeleteAccountAction{beneficiary_id}), {
-                        assert_eq!(beneficiary_id.as_ref(), "near_2");
+                     a6, Action::DeleteAccount(delete_account_action), {
+                        assert_eq!(delete_account_action.beneficiary_id.as_ref(), "near_2");
                      }
                      => [r2, r3, ref1] );
 
@@ -1003,8 +1003,8 @@ fn test_transfer_64len_hex() {
     assert_receipts!(group, "near_1" => r1 @ account_id.as_ref(),
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::Transfer(TransferAction{deposit}), {
-                        assert_eq!(*deposit, TESTING_INIT_BALANCE / 2);
+                     a0, Action::Transfer(transfer_action), {
+                        assert_eq!(transfer_action.deposit, TESTING_INIT_BALANCE / 2);
                      }
                      => [ref1] );
     assert_refund!(group, ref0 @ "near_0");
@@ -1070,8 +1070,8 @@ fn test_create_transfer_64len_hex_fail() {
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
                      a0, Action::CreateAccount(CreateAccountAction{}), {},
-                     a1, Action::Transfer(TransferAction{deposit}), {
-                        assert_eq!(*deposit, TESTING_INIT_BALANCE / 2);
+                     a1, Action::Transfer(transfer_action), {
+                        assert_eq!(transfer_action.deposit, TESTING_INIT_BALANCE / 2);
                      }
                      => [ref1, ref2] );
     assert_refund!(group, ref0 @ "near_0");

--- a/test-utils/runtime-tester/src/fuzzing.rs
+++ b/test-utils/runtime-tester/src/fuzzing.rs
@@ -155,13 +155,13 @@ impl TransactionConfig {
                 signer,
                 actions: vec![
                     Action::CreateAccount(CreateAccountAction {}),
-                    Action::AddKey(AddKeyAction {
+                    Action::AddKey(Box::new(AddKeyAction {
                         public_key: new_public_key,
                         access_key: AccessKey {
                             nonce: 0,
                             permission: AccessKeyPermission::FullAccess,
                         },
-                    }),
+                    })),
                     Action::Transfer(TransferAction { deposit: NEAR_BASE }),
                 ],
             })
@@ -266,7 +266,7 @@ impl TransactionConfig {
 
             while actions.len() < actions_num && u.len() > Function::size_hint(0).1.unwrap() {
                 let function = u.choose(&receiver_functions)?;
-                actions.push(Action::FunctionCall(function.arbitrary(u)?));
+                actions.push(Action::FunctionCall(Box::new(function.arbitrary(u)?)));
             }
 
             Ok(TransactionConfig {
@@ -291,11 +291,11 @@ impl TransactionConfig {
                 signer_id: signer_account.id.clone(),
                 receiver_id: signer_account.id.clone(),
                 signer,
-                actions: vec![Action::AddKey(scope.add_new_key(
+                actions: vec![Action::AddKey(Box::new(scope.add_new_key(
                     u,
                     scope.usize_id(&signer_account),
                     nonce,
-                )?)],
+                )?))],
             })
         });
 
@@ -323,7 +323,7 @@ impl TransactionConfig {
                 signer_id: signer_account.id.clone(),
                 receiver_id: signer_account.id.clone(),
                 signer,
-                actions: vec![Action::DeleteKey(DeleteKeyAction { public_key })],
+                actions: vec![Action::DeleteKey(Box::new(DeleteKeyAction { public_key }))],
             })
         });
 

--- a/test-utils/runtime-tester/src/fuzzing.rs
+++ b/test-utils/runtime-tester/src/fuzzing.rs
@@ -110,7 +110,7 @@ impl TransactionConfig {
                 signer_id: signer_account.id.clone(),
                 receiver_id: receiver_account.id,
                 signer: scope.full_access_signer(u, &signer_account)?,
-                actions: vec![Action::Transfer(TransferAction { deposit: amount })],
+                actions: vec![Action::Transfer(Box::new(TransferAction { deposit: amount }))],
             })
         });
 
@@ -162,7 +162,7 @@ impl TransactionConfig {
                             permission: AccessKeyPermission::FullAccess,
                         },
                     })),
-                    Action::Transfer(TransferAction { deposit: NEAR_BASE }),
+                    Action::Transfer(Box::new(TransferAction { deposit: NEAR_BASE })),
                 ],
             })
         });
@@ -189,9 +189,9 @@ impl TransactionConfig {
                     signer_id: signer_account.id.clone(),
                     receiver_id: receiver_account.id,
                     signer,
-                    actions: vec![Action::DeleteAccount(DeleteAccountAction {
+                    actions: vec![Action::DeleteAccount(Box::new(DeleteAccountAction {
                         beneficiary_id: beneficiary_id.id,
-                    })],
+                    }))],
                 })
             });
         }
@@ -214,9 +214,9 @@ impl TransactionConfig {
                 signer_id: signer_account.id.clone(),
                 receiver_id: signer_account.id.clone(),
                 signer,
-                actions: vec![Action::DeployContract(DeployContractAction {
+                actions: vec![Action::DeployContract(Box::new(DeployContractAction {
                     code: scope.available_contracts[contract_id].code.clone(),
-                })],
+                }))],
             })
         });
 

--- a/test-utils/runtime-tester/src/lib.rs
+++ b/test-utils/runtime-tester/src/lib.rs
@@ -43,7 +43,7 @@ fn scenario_smoke_test() {
                 signer_id,
                 receiver_id,
                 signer,
-                actions: vec![Action::Transfer(TransferAction { deposit: 10 })],
+                actions: vec![Action::Transfer(Box::new(TransferAction { deposit: 10 }))],
             }
         };
         block.transactions.push(transaction);

--- a/test-utils/runtime-tester/src/scenario_builder.rs
+++ b/test-utils/runtime-tester/src/scenario_builder.rs
@@ -27,9 +27,9 @@ pub struct ScenarioBuilder {
 ///
 ///     builder.add_block();
 ///     builder.add_transaction(0, 9,
-///                             vec![Action::DeployContract(DeployContractAction {
+///                             vec![Action::DeployContract(Box::new(DeployContractAction {
 ///                                 code: near_test_contracts::rs_contract().to_vec(),
-///                             })]);
+///                             }))]);
 ///
 ///     builder.add_block();
 ///     builder.add_block();

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -969,17 +969,17 @@ impl<T: ChainAccess> TxMirror<T> {
                         crate::key_mapping::map_account(tx.receiver_id(), self.secret.as_ref());
 
                     nonce_updates.insert((receiver_id, public_key.clone()));
-                    actions.push(Action::AddKey(AddKeyAction {
+                    actions.push(Action::AddKey(Box::new(AddKeyAction {
                         public_key,
                         access_key: add_key.access_key.clone(),
-                    }));
+                    })));
                 }
                 Action::DeleteKey(delete_key) => {
                     let replacement =
                         crate::key_mapping::map_key(&delete_key.public_key, self.secret.as_ref());
                     let public_key = replacement.public_key();
 
-                    actions.push(Action::DeleteKey(DeleteKeyAction { public_key }));
+                    actions.push(Action::DeleteKey(Box::new(DeleteKeyAction { public_key })));
                 }
                 Action::Transfer(_) => {
                     if tx.receiver_id().is_implicit() && source_actions.len() == 1 {
@@ -1018,10 +1018,10 @@ impl<T: ChainAccess> TxMirror<T> {
             };
         }
         if account_created && !full_key_added {
-            actions.push(Action::AddKey(AddKeyAction {
+            actions.push(Action::AddKey(Box::new(AddKeyAction {
                 public_key: crate::key_mapping::EXTRA_KEY.public_key(),
                 access_key: AccessKey::full_access(),
-            }));
+            })));
         }
         Ok((actions, nonce_updates))
     }
@@ -1185,10 +1185,10 @@ impl<T: ChainAccess> TxMirror<T> {
                             .public_key();
 
                     nonce_updates.insert((target_receiver_id.clone(), target_public_key.clone()));
-                    target_actions.push(Action::AddKey(AddKeyAction {
+                    target_actions.push(Action::AddKey(Box::new(AddKeyAction {
                         public_key: target_public_key,
                         access_key: a.access_key.clone(),
-                    }));
+                    })));
                 }
                 Action::CreateAccount(_) => {
                     target_actions.push(Action::CreateAccount(CreateAccountAction {}))
@@ -1618,7 +1618,7 @@ impl<T: ChainAccess> TxMirror<T> {
                 &mut txs,
                 predecessor_id,
                 receiver_id.clone(),
-                &[Action::Stake(StakeAction { public_key, stake: 0 })],
+                &[Action::Stake(Box::new(StakeAction { public_key, stake: 0 }))],
                 target_hash,
                 MappedTxProvenance::Unstake(*target_hash),
                 None,

--- a/tools/state-viewer/src/contract_accounts.rs
+++ b/tools/state-viewer/src/contract_accounts.rs
@@ -563,12 +563,12 @@ mod tests {
         let fn_call_receipt = create_receipt_with_actions(
             "alice.near",
             "bob.near",
-            vec![Action::FunctionCall(FunctionCallAction {
+            vec![Action::FunctionCall(Box::new(FunctionCallAction {
                 method_name: "foo".to_owned(),
                 args: vec![],
                 gas: 1000,
                 deposit: 0,
-            })],
+            }))],
         );
 
         // This is the receipt spawned, with the actions triggered by the

--- a/tools/state-viewer/src/contract_accounts.rs
+++ b/tools/state-viewer/src/contract_accounts.rs
@@ -579,9 +579,9 @@ mod tests {
             "bob.near",
             "alice.near",
             vec![
-                Action::Transfer(TransferAction { deposit: 20 }),
+                Action::Transfer(Box::new(TransferAction { deposit: 20 })),
                 Action::CreateAccount(CreateAccountAction {}),
-                Action::DeployContract(DeployContractAction { code: vec![] }),
+                Action::DeployContract(Box::new(DeployContractAction { code: vec![] })),
             ],
         );
 

--- a/tools/state-viewer/src/state_dump.rs
+++ b/tools/state-viewer/src/state_dump.rs
@@ -455,9 +455,9 @@ mod test {
             "test0".parse().unwrap(),
             "test0".parse().unwrap(),
             &signer0,
-            vec![Action::DeployContract(DeployContractAction {
+            vec![Action::DeployContract(Box::new(DeployContractAction {
                 code: near_test_contracts::backwards_compatible_rs_contract().to_vec(),
-            })],
+            }))],
             genesis_hash,
         );
         let tx01 = SignedTransaction::stake(


### PR DESCRIPTION
The Action enum has several variants of differing sizes:

| Variant | Size (Bytes) | Boxed in this PR |
| ------- | ------------ | ---------------- |
CreateAccountAction | 0 |
DeployContractAction | 24 |
FunctionCallAction | 80 | Yes
TransferAction | 16 |
StakeAction | 96 | Yes
AddKeyAction | 176 | Yes
DeleteKeyAction | 65 | Yes
DeleteAccountAction | 16
SignedDelegateAction | 216 | Yes

The size of every Action instance was 224 Bytes before this PR, which is wasteful when storing variants such as CreateAccountAction (0 bytes).

By Box-wrapping the larger variants, this PR reduces the size of Action to 32 Bytes.