### PR TITLE
fix: [resharding] fix gas and balance redistribution during resharding

### DIFF
--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -89,7 +89,11 @@ pub struct ApplySplitStateResult {
 // otherwise, it simply returns the state changes needed to be applied to split states
 #[derive(Debug)]
 pub enum ApplySplitStateResultOrStateChanges {
+    /// Immediately apply the split state result.
+    /// Happens during IsCaughtUp and CatchingUp
     ApplySplitStateResults(Vec<ApplySplitStateResult>),
+    /// Store the split state results so that they can be applied later.
+    /// Happens during NotCaughtUp.
     StateChangesForSplitStates(StateChangesForSplitStates),
 }
 


### PR DESCRIPTION
During resharding we need to redistribute the gas and balance to the children shards. 

The old implementation relied on the fact that the split shards and indexed from 0. In the future reshardings this may not be the case, for example when splitting shard 3, the split shard ids will be 3 & 4. 

The principle idea of the distribution remains the same. Both quantities are distributed evenly across the children shards. If there is any remainder := quantity % num_split_shards, then we assign 1 extra unit to each of the first `remainder` children shards. 

e.g. splitting shard 3 -> 3' & 4'
there is 5 gas to redistribute to children
shard 3' will get 3 units of gas
shard 4' will get 2 units of gas

the old implementation relied on a math trick to do that, the new one takes a more engineering leaning approach 