### PR TITLE
Reduce size of the Action enum using Box

### DIFF
--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -2207,7 +2207,7 @@ impl TestEnv {
             relayer,
             sender,
             &relayer_signer,
-            vec![Action::Delegate(signed_delegate_action)],
+            vec![Action::Delegate(Box::new(signed_delegate_action))],
             tip.last_block_hash,
         )
     }
@@ -2246,12 +2246,12 @@ impl TestEnv {
     /// deployed already.
     pub fn call_main(&mut self, account: &AccountId) -> FinalExecutionOutcomeView {
         let signer = InMemorySigner::from_seed(account.clone(), KeyType::ED25519, account.as_str());
-        let actions = vec![Action::FunctionCall(FunctionCallAction {
+        let actions = vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "main".to_string(),
             args: vec![],
             gas: 3 * 10u64.pow(14),
             deposit: 0,
-        })];
+        }))];
         let tx = self.tx_from_actions(actions, &signer, signer.account_id.clone());
         self.execute_tx(tx).unwrap()
     }

--- a/chain/rosetta-rpc/src/adapters/mod.rs
+++ b/chain/rosetta-rpc/src/adapters/mod.rs
@@ -1096,7 +1096,7 @@ mod tests {
         let original_near_actions = NearActions {
             sender_account_id: "proxy.near".parse().unwrap(),
             receiver_account_id: "account.near".parse().unwrap(),
-            actions: vec![Action::Delegate(SignedDelegateAction {
+            actions: vec![Action::Delegate(Box::new(SignedDelegateAction {
                 delegate_action: DelegateAction {
                     sender_id: "account.near".parse().unwrap(),
                     receiver_id: "receiver.near".parse().unwrap(),
@@ -1108,7 +1108,7 @@ mod tests {
                     public_key: sk.public_key(),
                 },
                 signature: sk.sign(&[0]),
-            })],
+            }))],
         };
 
         let operations: Vec<crate::models::Operation> =

--- a/core/primitives/src/action/delegate.rs
+++ b/core/primitives/src/action/delegate.rs
@@ -56,7 +56,7 @@ impl SignedDelegateAction {
 
 impl From<SignedDelegateAction> for Action {
     fn from(delegate_action: SignedDelegateAction) -> Self {
-        Self::Delegate(delegate_action)
+        Self::Delegate(Box::new(delegate_action))
     }
 }
 
@@ -150,7 +150,7 @@ mod tests {
     );
 
     fn create_delegate_action(actions: Vec<Action>) -> Action {
-        Action::Delegate(SignedDelegateAction {
+        Action::Delegate(Box::new(SignedDelegateAction {
             delegate_action: DelegateAction {
                 sender_id: "aaa".parse().unwrap(),
                 receiver_id: "bbb".parse().unwrap(),
@@ -163,7 +163,7 @@ mod tests {
                 public_key: PublicKey::empty(KeyType::ED25519),
             },
             signature: Signature::empty(KeyType::ED25519),
-        })
+        }))
     }
 
     #[test]

--- a/core/primitives/src/action/mod.rs
+++ b/core/primitives/src/action/mod.rs
@@ -178,6 +178,10 @@ pub enum Action {
     DeleteAccount(DeleteAccountAction),
     Delegate(Box<delegate::SignedDelegateAction>),
 }
+const _: () = assert!(
+    cfg!(not(target_pointer_width = "64")) || std::mem::size_of::<Action>() == 32,
+    "Action is less than 32 bytes for performance reasons, see #9451"
+);
 
 impl Action {
     pub fn get_prepaid_gas(&self) -> Gas {

--- a/core/primitives/src/action/mod.rs
+++ b/core/primitives/src/action/mod.rs
@@ -170,13 +170,13 @@ pub enum Action {
     CreateAccount(CreateAccountAction),
     /// Sets a Wasm code to a receiver_id
     DeployContract(DeployContractAction),
-    FunctionCall(FunctionCallAction),
+    FunctionCall(Box<FunctionCallAction>),
     Transfer(TransferAction),
-    Stake(StakeAction),
-    AddKey(AddKeyAction),
-    DeleteKey(DeleteKeyAction),
+    Stake(Box<StakeAction>),
+    AddKey(Box<AddKeyAction>),
+    DeleteKey(Box<DeleteKeyAction>),
     DeleteAccount(DeleteAccountAction),
-    Delegate(delegate::SignedDelegateAction),
+    Delegate(Box<delegate::SignedDelegateAction>),
 }
 
 impl Action {
@@ -209,7 +209,7 @@ impl From<DeployContractAction> for Action {
 
 impl From<FunctionCallAction> for Action {
     fn from(function_call_action: FunctionCallAction) -> Self {
-        Self::FunctionCall(function_call_action)
+        Self::FunctionCall(Box::new(function_call_action))
     }
 }
 
@@ -221,19 +221,19 @@ impl From<TransferAction> for Action {
 
 impl From<StakeAction> for Action {
     fn from(stake_action: StakeAction) -> Self {
-        Self::Stake(stake_action)
+        Self::Stake(Box::new(stake_action))
     }
 }
 
 impl From<AddKeyAction> for Action {
     fn from(add_key_action: AddKeyAction) -> Self {
-        Self::AddKey(add_key_action)
+        Self::AddKey(Box::new(add_key_action))
     }
 }
 
 impl From<DeleteKeyAction> for Action {
     fn from(delete_key_action: DeleteKeyAction) -> Self {
-        Self::DeleteKey(delete_key_action)
+        Self::DeleteKey(Box::new(delete_key_action))
     }
 }
 

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -60,12 +60,12 @@ impl Transaction {
         gas: Gas,
         deposit: Balance,
     ) -> Self {
-        self.actions.push(Action::FunctionCall(FunctionCallAction {
+        self.actions.push(Action::FunctionCall(Box::new(FunctionCallAction {
             method_name,
             args,
             gas,
             deposit,
-        }));
+        })));
         self
     }
 
@@ -75,16 +75,16 @@ impl Transaction {
     }
 
     pub fn stake(mut self, stake: Balance, public_key: PublicKey) -> Self {
-        self.actions.push(Action::Stake(StakeAction { stake, public_key }));
+        self.actions.push(Action::Stake(Box::new(StakeAction { stake, public_key })));
         self
     }
     pub fn add_key(mut self, public_key: PublicKey, access_key: AccessKey) -> Self {
-        self.actions.push(Action::AddKey(AddKeyAction { public_key, access_key }));
+        self.actions.push(Action::AddKey(Box::new(AddKeyAction { public_key, access_key })));
         self
     }
 
     pub fn delete_key(mut self, public_key: PublicKey) -> Self {
-        self.actions.push(Action::DeleteKey(DeleteKeyAction { public_key }));
+        self.actions.push(Action::DeleteKey(Box::new(DeleteKeyAction { public_key })));
         self
     }
 
@@ -145,7 +145,7 @@ impl SignedTransaction {
             signer_id.clone(),
             signer_id,
             signer,
-            vec![Action::Stake(StakeAction { stake, public_key })],
+            vec![Action::Stake(Box::new(StakeAction { stake, public_key }))],
             block_hash,
         )
     }
@@ -166,10 +166,10 @@ impl SignedTransaction {
             signer,
             vec![
                 Action::CreateAccount(CreateAccountAction {}),
-                Action::AddKey(AddKeyAction {
+                Action::AddKey(Box::new(AddKeyAction {
                     public_key,
                     access_key: AccessKey { nonce: 0, permission: AccessKeyPermission::FullAccess },
-                }),
+                })),
                 Action::Transfer(TransferAction { deposit: amount }),
             ],
             block_hash,
@@ -193,10 +193,10 @@ impl SignedTransaction {
             signer,
             vec![
                 Action::CreateAccount(CreateAccountAction {}),
-                Action::AddKey(AddKeyAction {
+                Action::AddKey(Box::new(AddKeyAction {
                     public_key,
                     access_key: AccessKey { nonce: 0, permission: AccessKeyPermission::FullAccess },
-                }),
+                })),
                 Action::Transfer(TransferAction { deposit: amount }),
                 Action::DeployContract(DeployContractAction { code }),
             ],
@@ -220,7 +220,12 @@ impl SignedTransaction {
             signer_id,
             receiver_id,
             signer,
-            vec![Action::FunctionCall(FunctionCallAction { args, method_name, gas, deposit })],
+            vec![Action::FunctionCall(Box::new(FunctionCallAction {
+                args,
+                method_name,
+                gas,
+                deposit,
+            }))],
             block_hash,
         )
     }

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -332,15 +332,18 @@ mod tests {
             actions: vec![
                 Action::CreateAccount(CreateAccountAction {}),
                 Action::DeployContract(DeployContractAction { code: vec![1, 2, 3] }),
-                Action::FunctionCall(FunctionCallAction {
+                Action::FunctionCall(Box::new(FunctionCallAction {
                     method_name: "qqq".to_string(),
                     args: vec![1, 2, 3],
                     gas: 1_000,
                     deposit: 1_000_000,
-                }),
+                })),
                 Action::Transfer(TransferAction { deposit: 123 }),
-                Action::Stake(StakeAction { public_key: public_key.clone(), stake: 1_000_000 }),
-                Action::AddKey(AddKeyAction {
+                Action::Stake(Box::new(StakeAction {
+                    public_key: public_key.clone(),
+                    stake: 1_000_000,
+                })),
+                Action::AddKey(Box::new(AddKeyAction {
                     public_key: public_key.clone(),
                     access_key: AccessKey {
                         nonce: 0,
@@ -350,8 +353,8 @@ mod tests {
                             method_names: vec!["www".to_string()],
                         }),
                     },
-                }),
-                Action::DeleteKey(DeleteKeyAction { public_key }),
+                })),
+                Action::DeleteKey(Box::new(DeleteKeyAction { public_key })),
                 Action::DeleteAccount(DeleteAccountAction {
                     beneficiary_id: "123".parse().unwrap(),
                 }),

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -1231,31 +1231,31 @@ impl TryFrom<ActionView> for Action {
                 Action::DeployContract(DeployContractAction { code })
             }
             ActionView::FunctionCall { method_name, args, gas, deposit } => {
-                Action::FunctionCall(FunctionCallAction {
+                Action::FunctionCall(Box::new(FunctionCallAction {
                     method_name,
                     args: args.into(),
                     gas,
                     deposit,
-                })
+                }))
             }
             ActionView::Transfer { deposit } => Action::Transfer(TransferAction { deposit }),
             ActionView::Stake { stake, public_key } => {
-                Action::Stake(StakeAction { stake, public_key })
+                Action::Stake(Box::new(StakeAction { stake, public_key }))
             }
             ActionView::AddKey { public_key, access_key } => {
-                Action::AddKey(AddKeyAction { public_key, access_key: access_key.into() })
+                Action::AddKey(Box::new(AddKeyAction { public_key, access_key: access_key.into() }))
             }
             ActionView::DeleteKey { public_key } => {
-                Action::DeleteKey(DeleteKeyAction { public_key })
+                Action::DeleteKey(Box::new(DeleteKeyAction { public_key }))
             }
             ActionView::DeleteAccount { beneficiary_id } => {
                 Action::DeleteAccount(DeleteAccountAction { beneficiary_id })
             }
             ActionView::Delegate { delegate_action, signature } => {
-                Action::Delegate(SignedDelegateAction {
+                Action::Delegate(Box::new(SignedDelegateAction {
                     delegate_action: delegate_action,
                     signature,
-                })
+                }))
             }
         })
     }

--- a/genesis-tools/genesis-csv-to-json/src/csv_parser.rs
+++ b/genesis-tools/genesis-csv-to-json/src/csv_parser.rs
@@ -258,12 +258,12 @@ fn account_records(row: &Row, gas_price: Balance) -> Vec<StateRecord> {
                 gas_price,
                 output_data_receivers: vec![],
                 input_data_ids: vec![],
-                actions: vec![Action::FunctionCall(FunctionCallAction {
+                actions: vec![Action::FunctionCall(Box::new(FunctionCallAction {
                     method_name: "init".to_string(),
                     args,
                     gas: INIT_GAS,
                     deposit: 0,
-                })],
+                }))],
             }),
         };
         res.push(StateRecord::PostponedReceipt(Box::new(receipt)));

--- a/integration-tests/src/tests/client/cold_storage.rs
+++ b/integration-tests/src/tests/client/cold_storage.rs
@@ -122,12 +122,12 @@ fn test_storage_after_commit_of_cold_update() {
                     "test0".parse().unwrap(),
                     "test0".parse().unwrap(),
                     &signer,
-                    vec![Action::FunctionCall(FunctionCallAction {
+                    vec![Action::FunctionCall(Box::new(FunctionCallAction {
                         method_name: "write_random_value".to_string(),
                         args: vec![],
                         gas: 100_000_000_000_000,
                         deposit: 0,
-                    })],
+                    }))],
                     last_hash,
                 );
                 assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);

--- a/integration-tests/src/tests/client/epoch_sync.rs
+++ b/integration-tests/src/tests/client/epoch_sync.rs
@@ -34,12 +34,12 @@ fn generate_transactions(last_hash: &CryptoHash, h: BlockHeight) -> Vec<SignedTr
             "test0".parse().unwrap(),
             "test0".parse().unwrap(),
             &signer,
-            vec![Action::FunctionCall(FunctionCallAction {
+            vec![Action::FunctionCall(Box::new(FunctionCallAction {
                 method_name: "write_random_value".to_string(),
                 args: vec![],
                 gas: 100_000_000_000_000,
                 deposit: 0,
-            })],
+            }))],
             last_hash.clone(),
         ));
     }

--- a/integration-tests/src/tests/client/features/account_id_in_function_call_permission.rs
+++ b/integration-tests/src/tests/client/features/account_id_in_function_call_permission.rs
@@ -46,7 +46,7 @@ fn test_account_id_in_function_call_permission_upgrade() {
         signer_id: "test0".parse().unwrap(),
         receiver_id: "test0".parse().unwrap(),
         public_key: signer.public_key(),
-        actions: vec![Action::AddKey(AddKeyAction {
+        actions: vec![Action::AddKey(Box::new(AddKeyAction {
             public_key: signer.public_key(),
             access_key: AccessKey {
                 nonce: 1,
@@ -56,7 +56,7 @@ fn test_account_id_in_function_call_permission_upgrade() {
                     method_names: vec![],
                 }),
             },
-        })],
+        }))],
         nonce: 0,
         block_hash: CryptoHash::default(),
     };
@@ -111,7 +111,7 @@ fn test_very_long_account_id() {
         signer_id: "test0".parse().unwrap(),
         receiver_id: "test0".parse().unwrap(),
         public_key: signer.public_key(),
-        actions: vec![Action::AddKey(AddKeyAction {
+        actions: vec![Action::AddKey(Box::new(AddKeyAction {
             public_key: signer.public_key(),
             access_key: AccessKey {
                 nonce: 1,
@@ -121,7 +121,7 @@ fn test_very_long_account_id() {
                     method_names: vec![],
                 }),
             },
-        })],
+        }))],
         nonce: 0,
         block_hash: tip.last_block_hash,
     }

--- a/integration-tests/src/tests/client/features/chunk_nodes_cache.rs
+++ b/integration-tests/src/tests/client/features/chunk_nodes_cache.rs
@@ -38,18 +38,18 @@ fn process_transaction(
         "test0".parse().unwrap(),
         signer,
         vec![
-            Action::FunctionCall(FunctionCallAction {
+            Action::FunctionCall(Box::new(FunctionCallAction {
                 args: encode(&[0u64, 10u64]),
                 method_name: "write_key_value".to_string(),
                 gas,
                 deposit: 0,
-            }),
-            Action::FunctionCall(FunctionCallAction {
+            })),
+            Action::FunctionCall(Box::new(FunctionCallAction {
                 args: encode(&[1u64, 20u64]),
                 method_name: "write_key_value".to_string(),
                 gas,
                 deposit: 0,
-            }),
+            })),
         ],
         last_block_hash,
     );

--- a/integration-tests/src/tests/client/features/delegate_action.rs
+++ b/integration-tests/src/tests/client/features/delegate_action.rs
@@ -448,7 +448,7 @@ fn meta_tx_stake() {
 
     let tx_cost = fee_helper.stake_cost();
     let public_key = create_user_test_signer(&sender).public_key;
-    let actions = vec![Action::Stake(StakeAction { public_key, stake: 0 })];
+    let actions = vec![Action::Stake(Box::new(StakeAction { public_key, stake: 0 }))];
     check_meta_tx_no_fn_call(&node, actions, tx_cost, 0, sender, relayer, receiver);
 }
 
@@ -465,10 +465,10 @@ fn meta_tx_add_key() {
     // any public key works as long as it doesn't exists on the receiver, the
     // relayer public key is just handy
     let public_key = node.signer().public_key();
-    let actions = vec![Action::AddKey(AddKeyAction {
+    let actions = vec![Action::AddKey(Box::new(AddKeyAction {
         public_key: public_key.clone(),
         access_key: AccessKey::full_access(),
-    })];
+    }))];
     check_meta_tx_no_fn_call(&node, actions, tx_cost, 0, sender, relayer, receiver.clone());
 
     let key_view = node
@@ -493,7 +493,8 @@ fn meta_tx_delete_key() {
 
     let tx_cost = fee_helper.delete_key_cost();
     let public_key = PublicKey::from_seed(KeyType::ED25519, &receiver);
-    let actions = vec![Action::DeleteKey(DeleteKeyAction { public_key: public_key.clone() })];
+    let actions =
+        vec![Action::DeleteKey(Box::new(DeleteKeyAction { public_key: public_key.clone() }))];
     check_meta_tx_no_fn_call(&node, actions, tx_cost, 0, sender, relayer, receiver.clone());
 
     let err = node
@@ -627,12 +628,12 @@ fn meta_tx_ft_transfer() {
 
 /// Call the function "log_something" in the test contract.
 fn log_something_fn_call() -> Action {
-    Action::FunctionCall(FunctionCallAction {
+    Action::FunctionCall(Box::new(FunctionCallAction {
         method_name: TEST_METHOD.to_owned(),
         args: vec![],
         gas: 30_000_000_000_000,
         deposit: 0,
-    })
+    }))
 }
 
 /// Construct an function call action with a FT transfer.
@@ -649,12 +650,12 @@ fn ft_transfer_action(receiver: &str, amount: u128) -> (Action, u64) {
     .collect();
     let method_name = "ft_transfer".to_owned();
     let num_bytes = method_name.len() + args.len();
-    let action = Action::FunctionCall(FunctionCallAction {
+    let action = Action::FunctionCall(Box::new(FunctionCallAction {
         method_name,
         args,
         gas: 20_000_000_000_000,
         deposit: 1,
-    });
+    }));
 
     (action, num_bytes as u64)
 }
@@ -669,12 +670,12 @@ fn ft_register_action(receiver: &str) -> Action {
     )
     .bytes()
     .collect();
-    Action::FunctionCall(FunctionCallAction {
+    Action::FunctionCall(Box::new(FunctionCallAction {
         method_name: "storage_deposit".to_owned(),
         args,
         gas: 20_000_000_000_000,
         deposit: NEAR_BASE,
-    })
+    }))
 }
 
 /// Format a NEP-141 event for an ft transfer
@@ -762,7 +763,7 @@ fn meta_tx_create_named_account() {
     let actions = vec![
         Action::CreateAccount(CreateAccountAction {}),
         Action::Transfer(TransferAction { deposit: amount }),
-        Action::AddKey(AddKeyAction { public_key, access_key: AccessKey::full_access() }),
+        Action::AddKey(Box::new(AddKeyAction { public_key, access_key: AccessKey::full_access() })),
     ];
 
     // Check the account doesn't exist, yet. We want to create it.

--- a/integration-tests/src/tests/client/features/flat_storage.rs
+++ b/integration-tests/src/tests/client/features/flat_storage.rs
@@ -65,12 +65,12 @@ fn test_flat_storage_upgrade() {
 
     // Write key-value pair to state.
     {
-        let write_value_action = vec![Action::FunctionCall(FunctionCallAction {
+        let write_value_action = vec![Action::FunctionCall(Box::new(FunctionCallAction {
             args: encode(&[1u64, 10u64]),
             method_name: "write_key_value".to_string(),
             gas,
             deposit: 0,
-        })];
+        }))];
         let tip = env.clients[0].chain.head().unwrap();
         let signed_transaction = Transaction {
             nonce: 10,
@@ -93,12 +93,12 @@ fn test_flat_storage_upgrade() {
 
     let touching_trie_node_costs: Vec<_> = (0..2)
         .map(|i| {
-            let read_value_action = vec![Action::FunctionCall(FunctionCallAction {
+            let read_value_action = vec![Action::FunctionCall(Box::new(FunctionCallAction {
                 args: encode(&[1u64]),
                 method_name: "read_value".to_string(),
                 gas,
                 deposit: 0,
-            })];
+            }))];
             let tip = env.clients[0].chain.head().unwrap();
             let signed_transaction = Transaction {
                 nonce: 20 + i,

--- a/integration-tests/src/tests/client/features/increase_storage_compute_cost.rs
+++ b/integration-tests/src/tests/client/features/increase_storage_compute_cost.rs
@@ -295,8 +295,12 @@ fn produce_saturated_chunk(
 ) -> std::sync::Arc<ShardChunk> {
     let msg_len = (method_name.len() + args.len()) as u64; // needed for gas computation later
     let gas = 300_000_000_000_000;
-    let actions =
-        vec![Action::FunctionCall(FunctionCallAction { method_name, args, gas, deposit: 0 })];
+    let actions = vec![Action::FunctionCall(Box::new(FunctionCallAction {
+        method_name,
+        args,
+        gas,
+        deposit: 0,
+    }))];
     let signer = InMemorySigner::from_seed(user_account.clone(), KeyType::ED25519, user_account);
 
     let tip = env.clients[0].chain.head().unwrap();

--- a/integration-tests/src/tests/client/features/lower_storage_key_limit.rs
+++ b/integration-tests/src/tests/client/features/lower_storage_key_limit.rs
@@ -69,12 +69,12 @@ fn protocol_upgrade() {
         signer_id: "test0".parse().unwrap(),
         receiver_id: "test0".parse().unwrap(),
         public_key: signer.public_key(),
-        actions: vec![Action::FunctionCall(FunctionCallAction {
+        actions: vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "write_key_value".to_string(),
             args,
             gas: 10u64.pow(14),
             deposit: 0,
-        })],
+        }))],
 
         nonce: 0,
         block_hash: CryptoHash::default(),
@@ -129,12 +129,12 @@ fn protocol_upgrade() {
             signer_id: "test0".parse().unwrap(),
             receiver_id: "test0".parse().unwrap(),
             public_key: signer.public_key(),
-            actions: vec![Action::FunctionCall(FunctionCallAction {
+            actions: vec![Action::FunctionCall(Box::new(FunctionCallAction {
                 method_name: "write_key_value".to_string(),
                 args,
                 gas: 10u64.pow(14),
                 deposit: 0,
-            })],
+            }))],
 
             nonce: 0,
             block_hash: CryptoHash::default(),

--- a/integration-tests/src/tests/client/features/nearvm.rs
+++ b/integration-tests/src/tests/client/features/nearvm.rs
@@ -48,12 +48,12 @@ fn test_nearvm_upgrade() {
         signer_id: "test0".parse().unwrap(),
         receiver_id: "test0".parse().unwrap(),
         public_key: signer.public_key(),
-        actions: vec![Action::FunctionCall(FunctionCallAction {
+        actions: vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "log_something".to_string(),
             args: Vec::new(),
             gas: 100_000_000_000_000,
             deposit: 0,
-        })],
+        }))],
 
         nonce: 0,
         block_hash: CryptoHash::default(),

--- a/integration-tests/src/tests/client/features/zero_balance_account.rs
+++ b/integration-tests/src/tests/client/features/zero_balance_account.rs
@@ -175,14 +175,14 @@ fn test_zero_balance_account_add_key() {
     for i in 1..5 {
         let new_key = PublicKey::from_seed(KeyType::ED25519, format!("{}", i).as_str());
         keys.push(new_key.clone());
-        actions.push(AddKey(AddKeyAction {
+        actions.push(AddKey(Box::new(AddKeyAction {
             public_key: new_key,
             access_key: AccessKey::full_access(),
-        }));
+        })));
     }
     for i in 0..2 {
         let new_key = PublicKey::from_seed(KeyType::ED25519, format!("{}", i + 5).as_str());
-        actions.push(AddKey(AddKeyAction {
+        actions.push(AddKey(Box::new(AddKeyAction {
             public_key: new_key,
             access_key: AccessKey {
                 nonce: 0,
@@ -192,7 +192,7 @@ fn test_zero_balance_account_add_key() {
                     method_names: vec![],
                 }),
             },
-        }));
+        })));
     }
 
     let head = env.clients[0].chain.head().unwrap();
@@ -230,7 +230,9 @@ fn test_zero_balance_account_add_key() {
         new_account_id.clone(),
         new_account_id.clone(),
         &new_signer,
-        vec![Action::DeleteKey(DeleteKeyAction { public_key: keys.last().unwrap().clone() })],
+        vec![Action::DeleteKey(Box::new(DeleteKeyAction {
+            public_key: keys.last().unwrap().clone(),
+        }))],
         *genesis_block.hash(),
     );
     assert_eq!(env.clients[0].process_tx(delete_key_tx, false, false), ProcessTxResponse::ValidTx);

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -231,12 +231,12 @@ pub(crate) fn prepare_env_with_congestion(
             "test0".parse().unwrap(),
             "test0".parse().unwrap(),
             &signer,
-            vec![Action::FunctionCall(FunctionCallAction {
+            vec![Action::FunctionCall(Box::new(FunctionCallAction {
                 method_name: "call_promise".to_string(),
                 args: serde_json::to_vec(&data).unwrap(),
                 gas: gas_1,
                 deposit: 0,
-            })],
+            }))],
             *genesis_block.hash(),
         );
         tx_hashes.push(signed_transaction.get_hash());
@@ -2431,12 +2431,12 @@ fn test_validate_chunk_extra() {
         "test0".parse().unwrap(),
         "test0".parse().unwrap(),
         &signer,
-        vec![Action::FunctionCall(FunctionCallAction {
+        vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "write_block_height".to_string(),
             args: vec![],
             gas: 100000000000000,
             deposit: 0,
-        })],
+        }))],
         *last_block.hash(),
     );
     assert_eq!(
@@ -3556,12 +3556,12 @@ fn test_validator_stake_host_function() {
         "test0".parse().unwrap(),
         "test0".parse().unwrap(),
         &signer,
-        vec![Action::FunctionCall(FunctionCallAction {
+        vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "ext_validator_stake".to_string(),
             args: b"test0".to_vec(),
             gas: 100_000_000_000_000,
             deposit: 0,
-        })],
+        }))],
         *genesis_block.hash(),
     );
     assert_eq!(

--- a/integration-tests/src/tests/client/sandbox.rs
+++ b/integration-tests/src/tests/client/sandbox.rs
@@ -44,12 +44,12 @@ fn test_setup() -> (TestEnv, InMemorySigner) {
             "test0".parse().unwrap(),
             "test0".parse().unwrap(),
             &signer,
-            vec![Action::FunctionCall(FunctionCallAction {
+            vec![Action::FunctionCall(Box::new(FunctionCallAction {
                 method_name: "write_random_value".to_string(),
                 args: vec![],
                 gas: 100000000000000,
                 deposit: 0,
-            })],
+            }))],
         ),
         ProcessTxResponse::ValidTx
     );

--- a/integration-tests/src/tests/client/sharding_upgrade.rs
+++ b/integration-tests/src/tests/client/sharding_upgrade.rs
@@ -841,12 +841,12 @@ fn gen_cross_contract_transaction(
         account0.clone(),
         account1.clone(),
         &signer0,
-        vec![Action::FunctionCall(FunctionCallAction {
+        vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "call_promise".to_string(),
             args: serde_json::to_vec(&data).unwrap(),
             gas: GAS_1,
             deposit: 0,
-        })],
+        }))],
         *block_hash,
     )
 }

--- a/integration-tests/src/tests/test_errors.rs
+++ b/integration-tests/src/tests/test_errors.rs
@@ -43,10 +43,10 @@ fn test_check_tx_error_log() {
         vec![
             Action::CreateAccount(CreateAccountAction {}),
             Action::Transfer(TransferAction { deposit: 1_000 }),
-            Action::AddKey(AddKeyAction {
+            Action::AddKey(Box::new(AddKeyAction {
                 public_key: signer.public_key.clone(),
                 access_key: AccessKey::full_access(),
-            }),
+            })),
         ],
         block_hash,
     );
@@ -83,10 +83,10 @@ fn test_deliver_tx_error_log() {
         vec![
             Action::CreateAccount(CreateAccountAction {}),
             Action::Transfer(TransferAction { deposit: TESTING_INIT_BALANCE + 1 }),
-            Action::AddKey(AddKeyAction {
+            Action::AddKey(Box::new(AddKeyAction {
                 public_key: signer.public_key.clone(),
                 access_key: AccessKey::full_access(),
-            }),
+            })),
         ],
         block_hash,
     );

--- a/integration-tests/src/user/mod.rs
+++ b/integration-tests/src/user/mod.rs
@@ -144,12 +144,12 @@ pub trait User {
         self.sign_and_commit_actions(
             signer_id,
             contract_id,
-            vec![Action::FunctionCall(FunctionCallAction {
+            vec![Action::FunctionCall(Box::new(FunctionCallAction {
                 method_name: method_name.to_string(),
                 args,
                 gas,
                 deposit,
-            })],
+            }))],
         )
     }
 
@@ -166,7 +166,10 @@ pub trait User {
             vec![
                 Action::CreateAccount(CreateAccountAction {}),
                 Action::Transfer(TransferAction { deposit: amount }),
-                Action::AddKey(AddKeyAction { public_key, access_key: AccessKey::full_access() }),
+                Action::AddKey(Box::new(AddKeyAction {
+                    public_key,
+                    access_key: AccessKey::full_access(),
+                })),
             ],
         )
     }
@@ -180,7 +183,7 @@ pub trait User {
         self.sign_and_commit_actions(
             signer_id.clone(),
             signer_id,
-            vec![Action::AddKey(AddKeyAction { public_key, access_key })],
+            vec![Action::AddKey(Box::new(AddKeyAction { public_key, access_key }))],
         )
     }
 
@@ -192,7 +195,7 @@ pub trait User {
         self.sign_and_commit_actions(
             signer_id.clone(),
             signer_id,
-            vec![Action::DeleteKey(DeleteKeyAction { public_key })],
+            vec![Action::DeleteKey(Box::new(DeleteKeyAction { public_key }))],
         )
     }
 
@@ -207,8 +210,8 @@ pub trait User {
             signer_id.clone(),
             signer_id,
             vec![
-                Action::DeleteKey(DeleteKeyAction { public_key: old_public_key }),
-                Action::AddKey(AddKeyAction { public_key: new_public_key, access_key }),
+                Action::DeleteKey(Box::new(DeleteKeyAction { public_key: old_public_key })),
+                Action::AddKey(Box::new(AddKeyAction { public_key: new_public_key, access_key })),
             ],
         )
     }
@@ -243,7 +246,7 @@ pub trait User {
         self.sign_and_commit_actions(
             signer_id.clone(),
             signer_id,
-            vec![Action::Stake(StakeAction { stake, public_key })],
+            vec![Action::Stake(Box::new(StakeAction { stake, public_key }))],
         )
     }
 
@@ -280,7 +283,7 @@ pub trait User {
         self.sign_and_commit_actions(
             relayer_id,
             signer_id,
-            vec![Action::Delegate(signed_delegate_action)],
+            vec![Action::Delegate(Box::new(signed_delegate_action))],
         )
     }
 }

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -1338,7 +1338,7 @@ mod test {
             sender.validator_id().clone(),
             sender.validator_id().clone(),
             &*signer,
-            vec![Action::Stake(StakeAction { stake, public_key: sender.public_key() })],
+            vec![Action::Stake(Box::new(StakeAction { stake, public_key: sender.public_key() }))],
             // runtime does not validate block history
             CryptoHash::default(),
         )

--- a/runtime/runtime-params-estimator/src/action_costs.rs
+++ b/runtime/runtime-params-estimator/src/action_costs.rs
@@ -686,10 +686,10 @@ fn create_transfer_action() -> Action {
 }
 
 fn stake_action() -> Action {
-    Action::Stake(near_primitives::transaction::StakeAction {
+    Action::Stake(Box::new(near_primitives::transaction::StakeAction {
         stake: 5u128.pow(28), // some arbitrary positive number
         public_key: PublicKey::from_seed(KeyType::ED25519, "seed"),
-    })
+    }))
 }
 
 fn delete_account_action() -> Action {
@@ -705,10 +705,10 @@ fn deploy_action(size: ActionSize) -> Action {
 }
 
 fn add_full_access_key_action() -> Action {
-    Action::AddKey(near_primitives::transaction::AddKeyAction {
+    Action::AddKey(Box::new(near_primitives::transaction::AddKeyAction {
         public_key: PublicKey::from_seed(KeyType::ED25519, "full-access-key-seed"),
         access_key: AccessKey { nonce: 0, permission: AccessKeyPermission::FullAccess },
-    })
+    }))
 }
 
 fn add_fn_access_key_action(size: ActionSize) -> Action {
@@ -716,7 +716,7 @@ fn add_fn_access_key_action(size: ActionSize) -> Action {
     let method_names = vec!["foo".to_owned(); size.key_methods_list() as usize / 4];
     // This is charged flat, therefore it should always be max len.
     let receiver_id = "a".repeat(AccountId::MAX_LEN).parse().unwrap();
-    Action::AddKey(near_primitives::transaction::AddKeyAction {
+    Action::AddKey(Box::new(near_primitives::transaction::AddKeyAction {
         public_key: PublicKey::from_seed(KeyType::ED25519, "seed"),
         access_key: AccessKey {
             nonce: 0,
@@ -726,13 +726,13 @@ fn add_fn_access_key_action(size: ActionSize) -> Action {
                 method_names,
             }),
         },
-    })
+    }))
 }
 
 fn delete_key_action() -> Action {
-    Action::DeleteKey(near_primitives::transaction::DeleteKeyAction {
+    Action::DeleteKey(Box::new(near_primitives::transaction::DeleteKeyAction {
         public_key: PublicKey::from_seed(KeyType::ED25519, "seed"),
-    })
+    }))
 }
 
 fn transfer_action() -> Action {
@@ -744,12 +744,12 @@ fn function_call_action(size: ActionSize) -> Action {
     let method_len = 4.min(total_size) as usize;
     let method_name: String = "noop".chars().take(method_len).collect();
     let arg_len = total_size as usize - method_len;
-    Action::FunctionCall(near_primitives::transaction::FunctionCallAction {
+    Action::FunctionCall(Box::new(near_primitives::transaction::FunctionCallAction {
         method_name,
         args: vec![1u8; arg_len],
         gas: 3 * 10u64.pow(12), // 3 Tgas, to allow 100 copies in the same receipt
         deposit: 10u128.pow(24),
-    })
+    }))
 }
 
 pub(crate) fn empty_delegate_action(
@@ -772,10 +772,10 @@ pub(crate) fn empty_delegate_action(
     };
     let signature =
         SignableMessage::new(&delegate_action, SignableMessageType::DelegateAction).sign(&signer);
-    Action::Delegate(near_primitives::action::delegate::SignedDelegateAction {
+    Action::Delegate(Box::new(near_primitives::action::delegate::SignedDelegateAction {
         delegate_action,
         signature,
-    })
+    }))
 }
 
 /// Helper enum to select how large an action should be generated.

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -522,7 +522,7 @@ fn add_key_transaction(
     tb.transaction_from_actions(
         sender,
         receiver,
-        vec![Action::AddKey(AddKeyAction { public_key, access_key })],
+        vec![Action::AddKey(Box::new(AddKeyAction { public_key, access_key }))],
     )
 }
 
@@ -532,9 +532,9 @@ fn action_delete_key(ctx: &mut EstimatorContext) -> GasCost {
             let sender = tb.random_unused_account();
             let receiver = sender.clone();
 
-            let actions = vec![Action::DeleteKey(DeleteKeyAction {
+            let actions = vec![Action::DeleteKey(Box::new(DeleteKeyAction {
                 public_key: SecretKey::from_seed(KeyType::ED25519, sender.as_ref()).public_key(),
-            })];
+            }))];
             tb.transaction_from_actions(sender, receiver, actions)
         };
         transaction_cost(ctx, &mut make_transaction)
@@ -551,10 +551,10 @@ fn action_stake(ctx: &mut EstimatorContext) -> GasCost {
             let sender = tb.random_unused_account();
             let receiver = sender.clone();
 
-            let actions = vec![Action::Stake(StakeAction {
+            let actions = vec![Action::Stake(Box::new(StakeAction {
                 stake: 1,
                 public_key: "22skMptHjFWNyuEWY22ftn2AbLPSYpmYwGJRGwpNHbTV".parse().unwrap(),
-            })];
+            }))];
             tb.transaction_from_actions(sender, receiver, actions)
         };
         transaction_cost(ctx, &mut make_transaction)

--- a/runtime/runtime-params-estimator/src/transaction_builder.rs
+++ b/runtime/runtime-params-estimator/src/transaction_builder.rs
@@ -72,12 +72,12 @@ impl TransactionBuilder {
         args: Vec<u8>,
     ) -> SignedTransaction {
         let receiver = sender.clone();
-        let actions = vec![Action::FunctionCall(FunctionCallAction {
+        let actions = vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: method.to_string(),
             args,
             gas: 10u64.pow(18),
             deposit: 0,
-        })];
+        }))];
         self.transaction_from_actions(sender, receiver, actions)
     }
 

--- a/runtime/runtime-params-estimator/src/utils.rs
+++ b/runtime/runtime-params-estimator/src/utils.rs
@@ -295,12 +295,12 @@ pub(crate) fn fn_cost_in_contract(
 }
 
 fn function_call_action(method_name: String) -> Action {
-    Action::FunctionCall(FunctionCallAction {
+    Action::FunctionCall(Box::new(FunctionCallAction {
         method_name,
         args: Vec::new(),
         gas: 10u64.pow(15),
         deposit: 0,
-    })
+    }))
 }
 
 /// Takes a list of measurements of input blocks and returns the cost for a

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -1168,12 +1168,12 @@ mod tests {
                 actions: vec![
                     non_delegate_action(
                         Action::FunctionCall(
-                            FunctionCallAction {
+                            Box::new(FunctionCallAction {
                                  method_name: "ft_transfer".parse().unwrap(),
                                  args: vec![123, 34, 114, 101, 99, 101, 105, 118, 101, 114, 95, 105, 100, 34, 58, 34, 106, 97, 110, 101, 46, 116, 101, 115, 116, 46, 110, 101, 97, 114, 34, 44, 34, 97, 109, 111, 117, 110, 116, 34, 58, 34, 52, 34, 125],
                                  gas: 30000000000000,
                                  deposit: 1,
-                            }
+                            })
                         )
                     )
                 ],
@@ -1190,7 +1190,7 @@ mod tests {
             gas_price: 1,
             output_data_receivers: Vec::new(),
             input_data_ids: Vec::new(),
-            actions: vec![Action::Delegate(signed_delegate_action.clone())],
+            actions: vec![Action::Delegate(Box::new(signed_delegate_action.clone()))],
         };
 
         (action_receipt, signed_delegate_action)
@@ -1371,7 +1371,7 @@ mod tests {
         // Sender account doesn't exist. Must fail.
         assert_eq!(
             check_account_existence(
-                &Action::Delegate(signed_delegate_action),
+                &Action::Delegate(Box::new(signed_delegate_action)),
                 &mut None,
                 &sender_id,
                 1,
@@ -1567,12 +1567,12 @@ mod tests {
 
         let mut delegate_action = signed_delegate_action.delegate_action;
         delegate_action.actions =
-            vec![non_delegate_action(Action::FunctionCall(FunctionCallAction {
+            vec![non_delegate_action(Action::FunctionCall(Box::new(FunctionCallAction {
                 args: Vec::new(),
                 deposit: 0,
                 gas: 300,
                 method_name: "test_method".parse().unwrap(),
-            }))];
+            })))];
         let result = test_delegate_action_key_permissions(&access_key, &delegate_action);
         assert!(result.result.is_ok(), "Result error {:?}", result.result);
     }
@@ -1618,18 +1618,18 @@ mod tests {
 
         let mut delegate_action = signed_delegate_action.delegate_action;
         delegate_action.actions = vec![
-            non_delegate_action(Action::FunctionCall(FunctionCallAction {
+            non_delegate_action(Action::FunctionCall(Box::new(FunctionCallAction {
                 args: Vec::new(),
                 deposit: 0,
                 gas: 300,
                 method_name: "test_method".parse().unwrap(),
-            })),
-            non_delegate_action(Action::FunctionCall(FunctionCallAction {
+            }))),
+            non_delegate_action(Action::FunctionCall(Box::new(FunctionCallAction {
                 args: Vec::new(),
                 deposit: 0,
                 gas: 300,
                 method_name: "test_method".parse().unwrap(),
-            })),
+            }))),
         ];
 
         let result = test_delegate_action_key_permissions(&access_key, &delegate_action);
@@ -1657,12 +1657,12 @@ mod tests {
 
         let mut delegate_action = signed_delegate_action.delegate_action;
         delegate_action.actions =
-            vec![non_delegate_action(Action::FunctionCall(FunctionCallAction {
+            vec![non_delegate_action(Action::FunctionCall(Box::new(FunctionCallAction {
                 args: Vec::new(),
                 deposit: 1,
                 gas: 300,
                 method_name: "test_method".parse().unwrap(),
-            }))];
+            })))];
 
         let result = test_delegate_action_key_permissions(&access_key, &delegate_action);
 
@@ -1689,12 +1689,12 @@ mod tests {
 
         let mut delegate_action = signed_delegate_action.delegate_action;
         delegate_action.actions =
-            vec![non_delegate_action(Action::FunctionCall(FunctionCallAction {
+            vec![non_delegate_action(Action::FunctionCall(Box::new(FunctionCallAction {
                 args: Vec::new(),
                 deposit: 0,
                 gas: 300,
                 method_name: "test_method".parse().unwrap(),
-            }))];
+            })))];
 
         let result = test_delegate_action_key_permissions(&access_key, &delegate_action);
 
@@ -1724,12 +1724,12 @@ mod tests {
 
         let mut delegate_action = signed_delegate_action.delegate_action;
         delegate_action.actions =
-            vec![non_delegate_action(Action::FunctionCall(FunctionCallAction {
+            vec![non_delegate_action(Action::FunctionCall(Box::new(FunctionCallAction {
                 args: Vec::new(),
                 deposit: 0,
                 gas: 300,
                 method_name: "test_method".parse().unwrap(),
-            }))];
+            })))];
 
         let result = test_delegate_action_key_permissions(&access_key, &delegate_action);
 

--- a/runtime/runtime/src/config.rs
+++ b/runtime/runtime/src/config.rs
@@ -102,7 +102,7 @@ pub fn total_send_fees(
                 transfer_send_fee(fees, sender_is_receiver, is_receiver_implicit)
             }
             Stake(_) => fees.fee(ActionCosts::stake).send_fee(sender_is_receiver),
-            AddKey(add_key_action) => match add_key_action.access_key.permission.clone() {
+            AddKey(add_key_action) => match &add_key_action.access_key.permission {
                 AccessKeyPermission::FunctionCall(call_perm) => {
                     let num_bytes = call_perm
                         .method_names
@@ -194,7 +194,7 @@ pub fn exec_fee(config: &RuntimeConfig, action: &Action, receiver_id: &AccountId
             transfer_exec_fee(fees, is_receiver_implicit)
         }
         Stake(_) => fees.fee(ActionCosts::stake).exec_fee(),
-        AddKey(add_key_action) => match add_key_action.access_key.permission.clone() {
+        AddKey(add_key_action) => match &add_key_action.access_key.permission {
             AccessKeyPermission::FunctionCall(call_perm) => {
                 let num_bytes = call_perm
                     .method_names

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -2245,12 +2245,12 @@ mod tests {
 
         let gas = 2 * 10u64.pow(14);
         let gas_price = GAS_PRICE / 10;
-        let actions = vec![Action::FunctionCall(FunctionCallAction {
+        let actions = vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "hello".to_string(),
             args: b"world".to_vec(),
             gas,
             deposit: 0,
-        })];
+        }))];
 
         let expected_gas_burnt = safe_add_gas(
             apply_state.config.fees.fee(ActionCosts::new_action_receipt).exec_fee(),
@@ -2314,12 +2314,12 @@ mod tests {
 
         let gas = 1_000_000;
         let gas_price = GAS_PRICE / 10;
-        let actions = vec![Action::FunctionCall(FunctionCallAction {
+        let actions = vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "hello".to_string(),
             args: b"world".to_vec(),
             gas,
             deposit: 0,
-        })];
+        }))];
 
         let expected_gas_burnt = safe_add_gas(
             apply_state.config.fees.fee(ActionCosts::new_action_receipt).exec_fee(),
@@ -2376,11 +2376,11 @@ mod tests {
         let initial_account_state = get_account(&state_update, &alice_account()).unwrap().unwrap();
 
         let actions = vec![
-            Action::DeleteKey(DeleteKeyAction { public_key: signer.public_key() }),
-            Action::AddKey(AddKeyAction {
+            Action::DeleteKey(Box::new(DeleteKeyAction { public_key: signer.public_key() })),
+            Action::AddKey(Box::new(AddKeyAction {
                 public_key: signer.public_key(),
                 access_key: AccessKey::full_access(),
-            }),
+            })),
         ];
 
         let receipts = vec![create_receipt_with_actions(alice_account(), signer, actions)];
@@ -2427,7 +2427,8 @@ mod tests {
         let root = tries.apply_all(&trie_changes, ShardUId::single_shard(), &mut store_update);
         store_update.commit().unwrap();
 
-        let actions = vec![Action::DeleteKey(DeleteKeyAction { public_key: signer.public_key() })];
+        let actions =
+            vec![Action::DeleteKey(Box::new(DeleteKeyAction { public_key: signer.public_key() }))];
 
         let receipts = vec![create_receipt_with_actions(alice_account(), signer, actions)];
 
@@ -2530,23 +2531,23 @@ mod tests {
         let first_call_receipt = create_receipt_with_actions(
             alice_account(),
             signer.clone(),
-            vec![Action::FunctionCall(FunctionCallAction {
+            vec![Action::FunctionCall(Box::new(FunctionCallAction {
                 method_name: "ext_sha256".to_string(),
                 args: b"first".to_vec(),
                 gas: sha256_cost.gas,
                 deposit: 0,
-            })],
+            }))],
         );
 
         let second_call_receipt = create_receipt_with_actions(
             alice_account(),
             signer,
-            vec![Action::FunctionCall(FunctionCallAction {
+            vec![Action::FunctionCall(Box::new(FunctionCallAction {
                 method_name: "ext_sha256".to_string(),
                 args: b"second".to_vec(),
                 gas: sha256_cost.gas,
                 deposit: 0,
-            })],
+            }))],
         );
 
         let apply_result = runtime
@@ -2617,12 +2618,12 @@ mod tests {
         let first_call_receipt = create_receipt_with_actions(
             alice_account(),
             signer,
-            vec![Action::FunctionCall(FunctionCallAction {
+            vec![Action::FunctionCall(Box::new(FunctionCallAction {
                 method_name: "ext_sha256".to_string(),
                 args: b"first".to_vec(),
                 gas: 1,
                 deposit: 0,
-            })],
+            }))],
         );
 
         let apply_result = runtime

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -939,12 +939,12 @@ mod tests {
                 alice_account(),
                 bob_account(),
                 &*signer,
-                vec![Action::FunctionCall(FunctionCallAction {
+                vec![Action::FunctionCall(Box::new(FunctionCallAction {
                     method_name: "hello".to_string(),
                     args: b"abc".to_vec(),
                     gas: 200,
                     deposit: 0,
-                })],
+                }))],
                 CryptoHash::default(),
             ),
             RuntimeError::InvalidTxError(InvalidTxError::ActionsValidation(
@@ -1101,12 +1101,12 @@ mod tests {
                 alice_account(),
                 bob_account(),
                 &*signer,
-                vec![Action::FunctionCall(FunctionCallAction {
+                vec![Action::FunctionCall(Box::new(FunctionCallAction {
                     method_name: "hello".to_string(),
                     args: b"abc".to_vec(),
                     gas: 300,
                     deposit: 0,
-                })],
+                }))],
                 CryptoHash::default(),
             ),
             true,
@@ -1234,12 +1234,12 @@ mod tests {
                     bob_account(),
                     &*signer,
                     vec![
-                        Action::FunctionCall(FunctionCallAction {
+                        Action::FunctionCall(Box::new(FunctionCallAction {
                             method_name: "hello".to_string(),
                             args: b"abc".to_vec(),
                             gas: 100,
                             deposit: 0,
-                        }),
+                        })),
                         Action::CreateAccount(CreateAccountAction {})
                     ],
                     CryptoHash::default(),
@@ -1327,12 +1327,12 @@ mod tests {
                     alice_account(),
                     eve_dot_alice_account(),
                     &*signer,
-                    vec![Action::FunctionCall(FunctionCallAction {
+                    vec![Action::FunctionCall(Box::new(FunctionCallAction {
                         method_name: "hello".to_string(),
                         args: b"abc".to_vec(),
                         gas: 100,
                         deposit: 0,
-                    }),],
+                    })),],
                     CryptoHash::default(),
                 ),
                 true,
@@ -1375,12 +1375,12 @@ mod tests {
                     alice_account(),
                     bob_account(),
                     &*signer,
-                    vec![Action::FunctionCall(FunctionCallAction {
+                    vec![Action::FunctionCall(Box::new(FunctionCallAction {
                         method_name: "hello".to_string(),
                         args: b"abc".to_vec(),
                         gas: 100,
                         deposit: 0,
-                    }),],
+                    })),],
                     CryptoHash::default(),
                 ),
                 true,
@@ -1420,12 +1420,12 @@ mod tests {
                     alice_account(),
                     bob_account(),
                     &*signer,
-                    vec![Action::FunctionCall(FunctionCallAction {
+                    vec![Action::FunctionCall(Box::new(FunctionCallAction {
                         method_name: "hello".to_string(),
                         args: b"abc".to_vec(),
                         gas: 100,
                         deposit: 100,
-                    }),],
+                    })),],
                     CryptoHash::default(),
                 ),
                 true,
@@ -1575,12 +1575,12 @@ mod tests {
         let limit_config = VMLimitConfig::test();
         validate_actions(
             &limit_config,
-            &[Action::FunctionCall(FunctionCallAction {
+            &[Action::FunctionCall(Box::new(FunctionCallAction {
                 method_name: "hello".to_string(),
                 args: b"abc".to_vec(),
                 gas: 100,
                 deposit: 0,
-            })],
+            }))],
             PROTOCOL_VERSION,
         )
         .expect("valid function call action");
@@ -1594,18 +1594,18 @@ mod tests {
             validate_actions(
                 &limit_config,
                 &[
-                    Action::FunctionCall(FunctionCallAction {
+                    Action::FunctionCall(Box::new(FunctionCallAction {
                         method_name: "hello".to_string(),
                         args: b"abc".to_vec(),
                         gas: 100,
                         deposit: 0,
-                    }),
-                    Action::FunctionCall(FunctionCallAction {
+                    })),
+                    Action::FunctionCall(Box::new(FunctionCallAction {
                         method_name: "hello".to_string(),
                         args: b"abc".to_vec(),
                         gas: 150,
                         deposit: 0,
-                    })
+                    }))
                 ],
                 PROTOCOL_VERSION,
             )
@@ -1622,18 +1622,18 @@ mod tests {
             validate_actions(
                 &limit_config,
                 &[
-                    Action::FunctionCall(FunctionCallAction {
+                    Action::FunctionCall(Box::new(FunctionCallAction {
                         method_name: "hello".to_string(),
                         args: b"abc".to_vec(),
                         gas: u64::max_value() / 2 + 1,
                         deposit: 0,
-                    }),
-                    Action::FunctionCall(FunctionCallAction {
+                    })),
+                    Action::FunctionCall(Box::new(FunctionCallAction {
                         method_name: "hello".to_string(),
                         args: b"abc".to_vec(),
                         gas: u64::max_value() / 2 + 1,
                         deposit: 0,
-                    })
+                    }))
                 ],
                 PROTOCOL_VERSION,
             )
@@ -1718,12 +1718,12 @@ mod tests {
     fn test_validate_action_valid_function_call() {
         validate_action(
             &VMLimitConfig::test(),
-            &Action::FunctionCall(FunctionCallAction {
+            &Action::FunctionCall(Box::new(FunctionCallAction {
                 method_name: "hello".to_string(),
                 args: b"abc".to_vec(),
                 gas: 100,
                 deposit: 0,
-            }),
+            })),
             PROTOCOL_VERSION,
         )
         .expect("valid action");
@@ -1734,12 +1734,12 @@ mod tests {
         assert_eq!(
             validate_action(
                 &VMLimitConfig::test(),
-                &Action::FunctionCall(FunctionCallAction {
+                &Action::FunctionCall(Box::new(FunctionCallAction {
                     method_name: "new".to_string(),
                     args: vec![],
                     gas: 0,
                     deposit: 0,
-                }),
+                })),
                 PROTOCOL_VERSION,
             )
             .expect_err("expected an error"),
@@ -1761,10 +1761,10 @@ mod tests {
     fn test_validate_action_valid_stake() {
         validate_action(
             &VMLimitConfig::test(),
-            &Action::Stake(StakeAction {
+            &Action::Stake(Box::new(StakeAction {
                 stake: 100,
                 public_key: "ed25519:KuTCtARNzxZQ3YvXDeLjx83FDqxv2SdQTSbiq876zR7".parse().unwrap(),
-            }),
+            })),
             PROTOCOL_VERSION,
         )
         .expect("valid action");
@@ -1775,10 +1775,10 @@ mod tests {
         assert_eq!(
             validate_action(
                 &VMLimitConfig::test(),
-                &Action::Stake(StakeAction {
+                &Action::Stake(Box::new(StakeAction {
                     stake: 100,
                     public_key: PublicKey::empty(KeyType::ED25519),
-                }),
+                })),
                 PROTOCOL_VERSION,
             )
             .expect_err("Expected an error"),
@@ -1792,10 +1792,10 @@ mod tests {
     fn test_validate_action_valid_add_key_full_permission() {
         validate_action(
             &VMLimitConfig::test(),
-            &Action::AddKey(AddKeyAction {
+            &Action::AddKey(Box::new(AddKeyAction {
                 public_key: PublicKey::empty(KeyType::ED25519),
                 access_key: AccessKey::full_access(),
-            }),
+            })),
             PROTOCOL_VERSION,
         )
         .expect("valid action");
@@ -1805,7 +1805,7 @@ mod tests {
     fn test_validate_action_valid_add_key_function_call() {
         validate_action(
             &VMLimitConfig::test(),
-            &Action::AddKey(AddKeyAction {
+            &Action::AddKey(Box::new(AddKeyAction {
                 public_key: PublicKey::empty(KeyType::ED25519),
                 access_key: AccessKey {
                     nonce: 0,
@@ -1815,7 +1815,7 @@ mod tests {
                         method_names: vec!["hello".to_string(), "world".to_string()],
                     }),
                 },
-            }),
+            })),
             PROTOCOL_VERSION,
         )
         .expect("valid action");
@@ -1825,7 +1825,9 @@ mod tests {
     fn test_validate_action_valid_delete_key() {
         validate_action(
             &VMLimitConfig::test(),
-            &Action::DeleteKey(DeleteKeyAction { public_key: PublicKey::empty(KeyType::ED25519) }),
+            &Action::DeleteKey(Box::new(DeleteKeyAction {
+                public_key: PublicKey::empty(KeyType::ED25519),
+            })),
             PROTOCOL_VERSION,
         )
         .expect("valid action");
@@ -1861,8 +1863,8 @@ mod tests {
             validate_actions(
                 &VMLimitConfig::test(),
                 &[
-                    Action::Delegate(signed_delegate_action.clone()),
-                    Action::Delegate(signed_delegate_action.clone()),
+                    Action::Delegate(Box::new(signed_delegate_action.clone())),
+                    Action::Delegate(Box::new(signed_delegate_action.clone())),
                 ],
                 PROTOCOL_VERSION,
             ),
@@ -1871,7 +1873,7 @@ mod tests {
         assert_eq!(
             validate_actions(
                 &&VMLimitConfig::test(),
-                &[Action::Delegate(signed_delegate_action.clone()),],
+                &[Action::Delegate(Box::new(signed_delegate_action.clone())),],
                 PROTOCOL_VERSION,
             ),
             Ok(()),
@@ -1881,7 +1883,7 @@ mod tests {
                 &VMLimitConfig::test(),
                 &[
                     Action::CreateAccount(CreateAccountAction {}),
-                    Action::Delegate(signed_delegate_action),
+                    Action::Delegate(Box::new(signed_delegate_action)),
                 ],
                 PROTOCOL_VERSION,
             ),

--- a/runtime/runtime/tests/test_async_calls.rs
+++ b/runtime/runtime/tests/test_async_calls.rs
@@ -30,12 +30,12 @@ fn test_simple_func_call() {
         signer_sender.account_id.clone(),
         signer_receiver.account_id,
         &signer_sender,
-        vec![Action::FunctionCall(FunctionCallAction {
+        vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "sum_n".to_string(),
             args: 10u64.to_le_bytes().to_vec(),
             gas: GAS_1,
             deposit: 0,
-        })],
+        }))],
         CryptoHash::default(),
     );
 
@@ -49,7 +49,7 @@ fn test_simple_func_call() {
     assert_receipts!(group, "near_0" => r0 @ "near_1",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{..}), {}
+                     a0, Action::FunctionCall(_function_call_action), {}
                      => [ref1] );
     assert_refund!(group, ref1 @ "near_0");
 }
@@ -76,12 +76,12 @@ fn test_single_promise_no_callback() {
         signer_sender.account_id.clone(),
         signer_receiver.account_id,
         &signer_sender,
-        vec![Action::FunctionCall(FunctionCallAction {
+        vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "call_promise".to_string(),
             args: serde_json::to_vec(&data).unwrap(),
             gas: GAS_1,
             deposit: 0,
-        })],
+        }))],
         CryptoHash::default(),
     );
 
@@ -95,17 +95,17 @@ fn test_single_promise_no_callback() {
     assert_receipts!(group, "near_0" => r0 @ "near_1",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_1);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_1);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [r1, ref0] );
     assert_receipts!(group, "near_1" => r1 @ "near_2",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_2);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_2);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [ref1]);
     assert_refund!(group, ref0 @ "near_0");
@@ -142,12 +142,12 @@ fn test_single_promise_with_callback() {
         signer_sender.account_id.clone(),
         signer_receiver.account_id,
         &signer_sender,
-        vec![Action::FunctionCall(FunctionCallAction {
+        vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "call_promise".to_string(),
             args: serde_json::to_vec(&data).unwrap(),
             gas: GAS_1,
             deposit: 0,
-        })],
+        }))],
         CryptoHash::default(),
     );
 
@@ -161,9 +161,9 @@ fn test_single_promise_with_callback() {
     assert_receipts!(group, "near_0" => r0 @ "near_1",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_1);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_1);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [r1, r2, ref0] );
     let data_id;
@@ -173,9 +173,9 @@ fn test_single_promise_with_callback() {
                         data_id = output_data_receivers[0].data_id;
                      },
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_2);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_2);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [ref1]);
     assert_receipts!(group, "near_1" => r2 @ "near_3",
@@ -184,9 +184,9 @@ fn test_single_promise_with_callback() {
                         assert_eq!(data_id, input_data_ids[0].clone());
                      },
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_2);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_2);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [ref2]);
 
@@ -226,12 +226,12 @@ fn test_two_promises_no_callbacks() {
         signer_sender.account_id.clone(),
         signer_receiver.account_id,
         &signer_sender,
-        vec![Action::FunctionCall(FunctionCallAction {
+        vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "call_promise".to_string(),
             args: serde_json::to_vec(&data).unwrap(),
             gas: GAS_1,
             deposit: 0,
-        })],
+        }))],
         CryptoHash::default(),
     );
 
@@ -245,25 +245,25 @@ fn test_two_promises_no_callbacks() {
     assert_receipts!(group, "near_0" => r0 @ "near_1",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_1);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_1);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [r1, ref0] );
     assert_receipts!(group, "near_1" => r1 @ "near_2",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), { },
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_2);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_2);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [r2, ref1]);
     assert_receipts!(group, "near_2" => r2 @ "near_3",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_3);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_3);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [ref2]);
 
@@ -320,12 +320,12 @@ fn test_two_promises_with_two_callbacks() {
         signer_sender.account_id.clone(),
         signer_receiver.account_id,
         &signer_sender,
-        vec![Action::FunctionCall(FunctionCallAction {
+        vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "call_promise".to_string(),
             args: serde_json::to_vec(&data).unwrap(),
             gas: GAS_1,
             deposit: 0,
-        })],
+        }))],
         CryptoHash::default(),
     );
 
@@ -339,41 +339,41 @@ fn test_two_promises_with_two_callbacks() {
     assert_receipts!(group, "near_0" => r0 @ "near_1",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_1);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_1);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [r1, cb1, ref0] );
     assert_receipts!(group, "near_1" => r1 @ "near_2",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), { },
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_2);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_2);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [r2, cb2, ref1]);
     assert_receipts!(group, "near_2" => r2 @ "near_3",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_3);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_3);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [ref2]);
     assert_receipts!(group, "near_2" => cb2 @ "near_4",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), { },
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_3);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_3);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [ref3]);
     assert_receipts!(group, "near_1" => cb1 @ "near_5",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), { },
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_2);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_2);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [ref4]);
 
@@ -411,12 +411,12 @@ fn test_single_promise_no_callback_batch() {
         signer_sender.account_id.clone(),
         signer_receiver.account_id,
         &signer_sender,
-        vec![Action::FunctionCall(FunctionCallAction {
+        vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "call_promise".to_string(),
             args: serde_json::to_vec(&data).unwrap(),
             gas: GAS_1,
             deposit: 0,
-        })],
+        }))],
         CryptoHash::default(),
     );
 
@@ -430,17 +430,17 @@ fn test_single_promise_no_callback_batch() {
     assert_receipts!(group, "near_0" => r0 @ "near_1",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_1);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_1);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [r1, ref0] );
     assert_receipts!(group, "near_1" => r1 @ "near_2",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_2);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_2);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [ref1]);
     assert_refund!(group, ref0 @ "near_0");
@@ -483,12 +483,12 @@ fn test_single_promise_with_callback_batch() {
         signer_sender.account_id.clone(),
         signer_receiver.account_id,
         &signer_sender,
-        vec![Action::FunctionCall(FunctionCallAction {
+        vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "call_promise".to_string(),
             args: serde_json::to_vec(&data).unwrap(),
             gas: GAS_1,
             deposit: 0,
-        })],
+        }))],
         CryptoHash::default(),
     );
 
@@ -502,9 +502,9 @@ fn test_single_promise_with_callback_batch() {
     assert_receipts!(group, "near_0" => r0 @ "near_1",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_1);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_1);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [r1, r2, ref0] );
     let data_id;
@@ -514,9 +514,9 @@ fn test_single_promise_with_callback_batch() {
                         data_id = output_data_receivers[0].data_id;
                      },
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_2);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_2);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [ref1]);
     assert_receipts!(group, "near_1" => r2 @ "near_3",
@@ -525,9 +525,9 @@ fn test_single_promise_with_callback_batch() {
                         assert_eq!(data_id, input_data_ids[0].clone());
                      },
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_2);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_2);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [ref2]);
 
@@ -557,12 +557,12 @@ fn test_simple_transfer() {
         signer_sender.account_id.clone(),
         signer_receiver.account_id,
         &signer_sender,
-        vec![Action::FunctionCall(FunctionCallAction {
+        vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "call_promise".to_string(),
             args: serde_json::to_vec(&data).unwrap(),
             gas: GAS_1,
             deposit: 0,
-        })],
+        }))],
         CryptoHash::default(),
     );
 
@@ -576,9 +576,9 @@ fn test_simple_transfer() {
     assert_receipts!(group, "near_0" => r0 @ "near_1",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_1);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_1);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [r1, ref0] );
     assert_receipts!(group, "near_1" => r1 @ "near_2",
@@ -624,12 +624,12 @@ fn test_create_account_with_transfer_and_full_key() {
         signer_sender.account_id.clone(),
         signer_receiver.account_id,
         &signer_sender,
-        vec![Action::FunctionCall(FunctionCallAction {
+        vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "call_promise".to_string(),
             args: serde_json::to_vec(&data).unwrap(),
             gas: GAS_1,
             deposit: 0,
-        })],
+        }))],
         CryptoHash::default(),
     );
 
@@ -643,9 +643,9 @@ fn test_create_account_with_transfer_and_full_key() {
     assert_receipts!(group, "near_0" => r0 @ "near_1",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_1);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_1);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [r1, ref0] );
     assert_receipts!(group, "near_1" => r1 @ "near_2",
@@ -655,10 +655,10 @@ fn test_create_account_with_transfer_and_full_key() {
                      a1, Action::Transfer(TransferAction{deposit}), {
                         assert_eq!(*deposit, 10000000000000000000000000);
                      },
-                     a2, Action::AddKey(AddKeyAction{public_key, access_key}), {
-                        assert_eq!(public_key, &signer_new_account.public_key);
-                        assert_eq!(access_key.nonce, 0);
-                        assert_eq!(access_key.permission, AccessKeyPermission::FullAccess);
+                     a2, Action::AddKey(add_key_action), {
+                        assert_eq!(add_key_action.public_key, signer_new_account.public_key);
+                        assert_eq!(add_key_action.access_key.nonce, 0);
+                        assert_eq!(add_key_action.access_key.permission, AccessKeyPermission::FullAccess);
                      }
                      => [ref1] );
 
@@ -736,12 +736,12 @@ fn test_account_factory() {
         signer_sender.account_id.clone(),
         signer_receiver.account_id,
         &signer_sender,
-        vec![Action::FunctionCall(FunctionCallAction {
+        vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "call_promise".to_string(),
             args: serde_json::to_vec(&data).unwrap(),
             gas: GAS_1,
             deposit: 0,
-        })],
+        }))],
         CryptoHash::default(),
     );
 
@@ -755,9 +755,9 @@ fn test_account_factory() {
     assert_receipts!(group, "near_0" => r0 @ "near_1",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_1);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_1);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [r1, r2, ref0] );
 
@@ -773,10 +773,10 @@ fn test_account_factory() {
                      a1, Action::Transfer(TransferAction{deposit}), {
                         assert_eq!(*deposit, TESTING_INIT_BALANCE / 2);
                      },
-                     a2, Action::AddKey(AddKeyAction{public_key, access_key}), {
-                        assert_eq!(public_key, &signer_new_account.public_key);
-                        assert_eq!(access_key.nonce, 0);
-                        assert_eq!(access_key.permission, AccessKeyPermission::FunctionCall(FunctionCallPermission {
+                     a2, Action::AddKey(add_key_action), {
+                        assert_eq!(add_key_action.public_key, signer_new_account.public_key);
+                        assert_eq!(add_key_action.access_key.nonce, 0);
+                        assert_eq!(add_key_action.access_key.permission, AccessKeyPermission::FunctionCall(FunctionCallPermission {
                             allowance: Some(TESTING_INIT_BALANCE / 2),
                             receiver_id: "near_1".parse().unwrap(),
                             method_names: vec!["call_promise".to_string(), "hello".to_string()],
@@ -785,9 +785,9 @@ fn test_account_factory() {
                      a3, Action::DeployContract(DeployContractAction{code}), {
                         assert_eq!(code, near_test_contracts::rs_contract());
                      },
-                     a4, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_2);
-                        assert_eq!(*deposit, 0);
+                     a4, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_2);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [r3, ref1] );
     assert_receipts!(group, "near_1" => r2 @ "near_2",
@@ -795,25 +795,25 @@ fn test_account_factory() {
                         assert_eq!(input_data_ids, &[data_id]);
                      },
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_2);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_2);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [r4, ref2] );
     assert_receipts!(group, "near_2" => r3 @ "near_0",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_3);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_3);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [ref3] );
     assert_receipts!(group, "near_2" => r4 @ "near_1",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_3);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_3);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [ref4] );
 
@@ -882,12 +882,12 @@ fn test_create_account_add_key_call_delete_key_delete_account() {
         signer_sender.account_id.clone(),
         signer_receiver.account_id,
         &signer_sender,
-        vec![Action::FunctionCall(FunctionCallAction {
+        vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "call_promise".to_string(),
             args: serde_json::to_vec(&data).unwrap(),
             gas: GAS_1,
             deposit: 0,
-        })],
+        }))],
         CryptoHash::default(),
     );
 
@@ -901,9 +901,9 @@ fn test_create_account_add_key_call_delete_key_delete_account() {
     assert_receipts!(group, "near_0" => r0 @ "near_1",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_1);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_1);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [r1, ref0] );
     assert_receipts!(group, "near_1" => r1 @ "near_3",
@@ -913,20 +913,20 @@ fn test_create_account_add_key_call_delete_key_delete_account() {
                      a1, Action::Transfer(TransferAction{deposit}), {
                         assert_eq!(*deposit, TESTING_INIT_BALANCE / 2);
                      },
-                     a2, Action::AddKey(AddKeyAction{public_key, access_key}), {
-                        assert_eq!(public_key, &signer_new_account.public_key);
-                        assert_eq!(access_key.nonce, 1);
-                        assert_eq!(access_key.permission, AccessKeyPermission::FullAccess);
+                     a2, Action::AddKey(add_key_action), {
+                        assert_eq!(add_key_action.public_key, signer_new_account.public_key);
+                        assert_eq!(add_key_action.access_key.nonce, 1);
+                        assert_eq!(add_key_action.access_key.permission, AccessKeyPermission::FullAccess);
                      },
                      a3, Action::DeployContract(DeployContractAction{code}), {
                         assert_eq!(code, near_test_contracts::rs_contract());
                      },
-                     a4, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_2);
-                        assert_eq!(*deposit, 0);
+                     a4, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_2);
+                        assert_eq!(function_call_action.deposit, 0);
                      },
-                     a5, Action::DeleteKey(DeleteKeyAction{public_key}), {
-                        assert_eq!(public_key, &signer_new_account.public_key);
+                     a5, Action::DeleteKey(delete_key_action), {
+                        assert_eq!(delete_key_action.public_key, signer_new_account.public_key);
                      },
                      a6, Action::DeleteAccount(DeleteAccountAction{beneficiary_id}), {
                         assert_eq!(beneficiary_id.as_ref(), "near_2");
@@ -936,9 +936,9 @@ fn test_create_account_add_key_call_delete_key_delete_account() {
     assert_receipts!(group, "near_3" => r2 @ "near_0",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_3);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_3);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [ref2] );
     assert_refund!(group, r3 @ "near_2");
@@ -976,12 +976,12 @@ fn test_transfer_64len_hex() {
         signer_sender.account_id.clone(),
         signer_receiver.account_id,
         &signer_sender,
-        vec![Action::FunctionCall(FunctionCallAction {
+        vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "call_promise".to_string(),
             args: serde_json::to_vec(&data).unwrap(),
             gas: GAS_1,
             deposit: 0,
-        })],
+        }))],
         CryptoHash::default(),
     );
 
@@ -995,9 +995,9 @@ fn test_transfer_64len_hex() {
     assert_receipts!(group, "near_0" => r0 @ "near_1",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_1);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_1);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [r1, ref0] );
     assert_receipts!(group, "near_1" => r1 @ account_id.as_ref(),
@@ -1042,12 +1042,12 @@ fn test_create_transfer_64len_hex_fail() {
         signer_sender.account_id.clone(),
         signer_receiver.account_id,
         &signer_sender,
-        vec![Action::FunctionCall(FunctionCallAction {
+        vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "call_promise".to_string(),
             args: serde_json::to_vec(&data).unwrap(),
             gas: GAS_1,
             deposit: 0,
-        })],
+        }))],
         CryptoHash::default(),
     );
 
@@ -1061,9 +1061,9 @@ fn test_create_transfer_64len_hex_fail() {
     assert_receipts!(group, "near_0" => r0 @ "near_1",
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
-                     a0, Action::FunctionCall(FunctionCallAction{gas, deposit, ..}), {
-                        assert_eq!(*gas, GAS_1);
-                        assert_eq!(*deposit, 0);
+                     a0, Action::FunctionCall(function_call_action), {
+                        assert_eq!(function_call_action.gas, GAS_1);
+                        assert_eq!(function_call_action.deposit, 0);
                      }
                      => [r1, ref0] );
     assert_receipts!(group, "near_1" => r1 @ account_id.as_ref(),

--- a/test-utils/runtime-tester/src/fuzzing.rs
+++ b/test-utils/runtime-tester/src/fuzzing.rs
@@ -155,13 +155,13 @@ impl TransactionConfig {
                 signer,
                 actions: vec![
                     Action::CreateAccount(CreateAccountAction {}),
-                    Action::AddKey(AddKeyAction {
+                    Action::AddKey(Box::new(AddKeyAction {
                         public_key: new_public_key,
                         access_key: AccessKey {
                             nonce: 0,
                             permission: AccessKeyPermission::FullAccess,
                         },
-                    }),
+                    })),
                     Action::Transfer(TransferAction { deposit: NEAR_BASE }),
                 ],
             })
@@ -266,7 +266,7 @@ impl TransactionConfig {
 
             while actions.len() < actions_num && u.len() > Function::size_hint(0).1.unwrap() {
                 let function = u.choose(&receiver_functions)?;
-                actions.push(Action::FunctionCall(function.arbitrary(u)?));
+                actions.push(Action::FunctionCall(Box::new(function.arbitrary(u)?)));
             }
 
             Ok(TransactionConfig {
@@ -291,11 +291,11 @@ impl TransactionConfig {
                 signer_id: signer_account.id.clone(),
                 receiver_id: signer_account.id.clone(),
                 signer,
-                actions: vec![Action::AddKey(scope.add_new_key(
+                actions: vec![Action::AddKey(Box::new(scope.add_new_key(
                     u,
                     scope.usize_id(&signer_account),
                     nonce,
-                )?)],
+                )?))],
             })
         });
 
@@ -323,7 +323,7 @@ impl TransactionConfig {
                 signer_id: signer_account.id.clone(),
                 receiver_id: signer_account.id.clone(),
                 signer,
-                actions: vec![Action::DeleteKey(DeleteKeyAction { public_key })],
+                actions: vec![Action::DeleteKey(Box::new(DeleteKeyAction { public_key }))],
             })
         });
 

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -969,17 +969,17 @@ impl<T: ChainAccess> TxMirror<T> {
                         crate::key_mapping::map_account(tx.receiver_id(), self.secret.as_ref());
 
                     nonce_updates.insert((receiver_id, public_key.clone()));
-                    actions.push(Action::AddKey(AddKeyAction {
+                    actions.push(Action::AddKey(Box::new(AddKeyAction {
                         public_key,
                         access_key: add_key.access_key.clone(),
-                    }));
+                    })));
                 }
                 Action::DeleteKey(delete_key) => {
                     let replacement =
                         crate::key_mapping::map_key(&delete_key.public_key, self.secret.as_ref());
                     let public_key = replacement.public_key();
 
-                    actions.push(Action::DeleteKey(DeleteKeyAction { public_key }));
+                    actions.push(Action::DeleteKey(Box::new(DeleteKeyAction { public_key })));
                 }
                 Action::Transfer(_) => {
                     if tx.receiver_id().is_implicit() && source_actions.len() == 1 {
@@ -1018,10 +1018,10 @@ impl<T: ChainAccess> TxMirror<T> {
             };
         }
         if account_created && !full_key_added {
-            actions.push(Action::AddKey(AddKeyAction {
+            actions.push(Action::AddKey(Box::new(AddKeyAction {
                 public_key: crate::key_mapping::EXTRA_KEY.public_key(),
                 access_key: AccessKey::full_access(),
-            }));
+            })));
         }
         Ok((actions, nonce_updates))
     }
@@ -1185,10 +1185,10 @@ impl<T: ChainAccess> TxMirror<T> {
                             .public_key();
 
                     nonce_updates.insert((target_receiver_id.clone(), target_public_key.clone()));
-                    target_actions.push(Action::AddKey(AddKeyAction {
+                    target_actions.push(Action::AddKey(Box::new(AddKeyAction {
                         public_key: target_public_key,
                         access_key: a.access_key.clone(),
-                    }));
+                    })));
                 }
                 Action::CreateAccount(_) => {
                     target_actions.push(Action::CreateAccount(CreateAccountAction {}))
@@ -1618,7 +1618,7 @@ impl<T: ChainAccess> TxMirror<T> {
                 &mut txs,
                 predecessor_id,
                 receiver_id.clone(),
-                &[Action::Stake(StakeAction { public_key, stake: 0 })],
+                &[Action::Stake(Box::new(StakeAction { public_key, stake: 0 }))],
                 target_hash,
                 MappedTxProvenance::Unstake(*target_hash),
                 None,

--- a/tools/state-viewer/src/contract_accounts.rs
+++ b/tools/state-viewer/src/contract_accounts.rs
@@ -563,12 +563,12 @@ mod tests {
         let fn_call_receipt = create_receipt_with_actions(
             "alice.near",
             "bob.near",
-            vec![Action::FunctionCall(FunctionCallAction {
+            vec![Action::FunctionCall(Box::new(FunctionCallAction {
                 method_name: "foo".to_owned(),
                 args: vec![],
                 gas: 1000,
                 deposit: 0,
-            })],
+            }))],
         );
 
         // This is the receipt spawned, with the actions triggered by the


### PR DESCRIPTION
**TL;DR**: The `Action` enum has several variants of differing sizes. By Box-ing the larger variants, this PR significantly reduces the memory usage for almost all of `Action`'s variants. Only the largest, `Action::SignedDelegate`, sees a slight increase in total memory usage from 224 Bytes to 248 Bytes.

### Detailed Outcome

| Variant | Size (Bytes) | Boxed in this PR | Memory Usage (Before) | Memory Usage (After) |
| ------- | ------------ | ---------------- | ---------------------------|---------------------------|
CreateAccount | 0 | | 224 | 32 |
DeployContract | 24 | | 224 | 32 |
FunctionCall | 80 | Yes | 224 | 112 |
Transfer | 16 | | 224 | 32 |
Stake | 96 | Yes | 224 | 128 |
AddKey | 176 | Yes | 224 | 208 |
DeleteKey | 65 | Yes | 224 | 97 |
DeleteAccount | 16 | | 224 | 32 |
SignedDelegate | 216 | Yes | 224 | 248 |

One specific benefit of this change is reducing decoding overhead for network messages. For example, an action of type `Action::CreateAccount` occupies a single byte in serialized network format. When a message's single byte can deserialize back to 224 bytes in memory, it places a higher and less easily predictable resource demand on the node. This PR makes progress on that front by reducing the deserialized size for `Action::CreateAccount` to 32 bytes.

### How does it work?

The size of an enum is statically determined by the size of its largest variant plus the size of its discriminant (some bits telling us which variant is stored). In this case, `Action::SignedDelegate` is the largest variant; it  stores a struct `SignedDelegateAction` with size 216 bytes. After adding a discriminant and some padding bits for memory alignment, the `Action` enum reaches its total size of 224 Bytes.

`Box<T>` is a pointer type allocating memory on the heap to store data of type `T`. By having the `Action::SignedDelegate` variant store a `Box<SignedDelegateAction>`, we reduce its direct size from 224 Bytes to 8 Bytes, the size of a Box pointer on a 64-bit machine. Indirectly, it allocates an additional 224 Bytes to store the value of the `SignedDelegateAction` struct.

By Box-ing the large `Action` variants and reducing their direct size to 8 bytes, we leave `Action::DeployContract` as the variant with the largest direct size at 24 Bytes. Adding the discriminant and padding leaves `Action` with a new total size of 32 Bytes.

### Why don't we just Box everything?

#### Performance Considerations
Generally, reducing the size of a datatype will also reduce the processing time associated with writes or reads on it.

However, use of Box comes with some small performance penalties. Box's memory indirection means that reading or writing a Boxed value involves 1 additional memory lookup. It also means that Box-ed variants stored in a Vec<Action> no longer have all their data stored contiguously in the Vec, weakening benefits of memory caching. If a variant is small enough already, a small reduction in size may not bring enough benefit to offset these other penalties.

Without good benchmarks on node performance to guide our decision-making, this PR makes the choice to Box the very large variants (>64 Bytes) and leave smaller ones untouched.

#### Limited Remaining Upside

The size of an enum is determined by the size of its largest variant plus the size of its discriminant (some bits telling us which variant is stored). On a 64-bit machine, Box occupies 8 bytes. After adding a discriminant and padding for memory alignment, the minimum possible size for an Enum with a Box-ed variant is 16 Bytes. We've already reduced Action to 32 Bytes in this PR by addressing the very large variants.