### PR TITLE
drop EXPERIMENTAL_validators_ordered RPC endpoint

### DIFF
--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -12,7 +12,6 @@ use near_primitives::types::{
     AccountId, BlockHeight, BlockReference, EpochId, EpochReference, MaybeBlockId, ShardId,
     TransactionOrReceiptId,
 };
-use near_primitives::views::validator_stake_view::ValidatorStakeView;
 use near_primitives::views::{
     BlockView, ChunkView, DownloadStatusView, EpochValidatorInfo, ExecutionOutcomeWithIdView,
     FinalExecutionOutcomeViewEnum, GasPriceView, LightClientBlockLiteView, LightClientBlockView,
@@ -765,15 +764,6 @@ impl From<near_chain_primitives::Error> for GetValidatorInfoError {
             _ => Self::Unreachable(error.to_string()),
         }
     }
-}
-
-#[derive(Debug)]
-pub struct GetValidatorOrdered {
-    pub block_id: MaybeBlockId,
-}
-
-impl Message for GetValidatorOrdered {
-    type Result = Result<Vec<ValidatorStakeView>, GetValidatorInfoError>;
 }
 
 #[derive(Debug)]

--- a/chain/client/src/lib.rs
+++ b/chain/client/src/lib.rs
@@ -4,8 +4,8 @@ pub use near_client_primitives::types::{
     GetExecutionOutcomesForBlock, GetGasPrice, GetMaintenanceWindows, GetNetworkInfo,
     GetNextLightClientBlock, GetProtocolConfig, GetReceipt, GetSplitStorageInfo, GetStateChanges,
     GetStateChangesInBlock, GetStateChangesWithCauseInBlock,
-    GetStateChangesWithCauseInBlockForTrackedShards, GetValidatorInfo, GetValidatorOrdered, Query,
-    QueryError, Status, StatusResponse, SyncStatus, TxStatus, TxStatusError,
+    GetStateChangesWithCauseInBlockForTrackedShards, GetValidatorInfo, Query, QueryError, Status,
+    StatusResponse, SyncStatus, TxStatus, TxStatusError,
 };
 
 pub use near_client_primitives::debug::DebugStatus;

--- a/chain/jsonrpc-primitives/src/types/validator.rs
+++ b/chain/jsonrpc-primitives/src/types/validator.rs
@@ -1,8 +1,5 @@
 use serde_json::Value;
 
-pub type RpcValidatorsOrderedResponse =
-    Vec<near_primitives::views::validator_stake_view::ValidatorStakeView>;
-
 #[derive(thiserror::Error, Debug, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "name", content = "info", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum RpcValidatorError {
@@ -18,11 +15,6 @@ pub enum RpcValidatorError {
 pub struct RpcValidatorRequest {
     #[serde(flatten)]
     pub epoch_reference: near_primitives::types::EpochReference,
-}
-
-#[derive(serde::Serialize, serde::Deserialize, Debug)]
-pub struct RpcValidatorsOrderedRequest {
-    pub block_id: near_primitives::types::MaybeBlockId,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]

--- a/chain/jsonrpc/client/src/lib.rs
+++ b/chain/jsonrpc/client/src/lib.rs
@@ -5,10 +5,8 @@ use near_jsonrpc_primitives::message::{from_slice, Message};
 use near_jsonrpc_primitives::types::changes::{
     RpcStateChangesInBlockByTypeRequest, RpcStateChangesInBlockByTypeResponse,
 };
-use near_jsonrpc_primitives::types::validator::RpcValidatorsOrderedRequest;
 use near_primitives::hash::CryptoHash;
 use near_primitives::types::{AccountId, BlockId, BlockReference, MaybeBlockId, ShardId};
-use near_primitives::views::validator_stake_view::ValidatorStakeView;
 use near_primitives::views::{
     BlockView, ChunkView, EpochValidatorInfo, FinalExecutionOutcomeView, GasPriceView,
     StatusResponse,
@@ -226,14 +224,6 @@ impl JsonRpcClient {
         request: RpcStateChangesInBlockByTypeRequest,
     ) -> RpcRequest<RpcStateChangesInBlockByTypeResponse> {
         call_method(&self.client, &self.server_addr, "EXPERIMENTAL_changes", request)
-    }
-
-    #[allow(non_snake_case)]
-    pub fn EXPERIMENTAL_validators_ordered(
-        &self,
-        request: RpcValidatorsOrderedRequest,
-    ) -> RpcRequest<Vec<ValidatorStakeView>> {
-        call_method(&self.client, &self.server_addr, "EXPERIMENTAL_validators_ordered", request)
     }
 
     #[allow(non_snake_case)]

--- a/chain/jsonrpc/jsonrpc-tests/tests/rpc_query.rs
+++ b/chain/jsonrpc/jsonrpc-tests/tests/rpc_query.rs
@@ -9,7 +9,6 @@ use near_actix_test_utils::run_actix;
 use near_crypto::{KeyType, PublicKey, Signature};
 use near_jsonrpc::client::{new_client, ChunkId};
 use near_jsonrpc_primitives::types::query::QueryResponseKind;
-use near_jsonrpc_primitives::types::validator::RpcValidatorsOrderedRequest;
 use near_network::test_utils::wait_or_timeout;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::account::{AccessKey, AccessKeyPermission};
@@ -442,20 +441,6 @@ fn test_health_ok() {
     test_with_client!(test_utils::NodeType::NonValidator, client, async move {
         let health = client.health().await;
         assert_eq!(health, Ok(()));
-    });
-}
-
-#[test]
-fn test_validators_ordered() {
-    test_with_client!(test_utils::NodeType::Validator, client, async move {
-        let validators = client
-            .EXPERIMENTAL_validators_ordered(RpcValidatorsOrderedRequest { block_id: None })
-            .await
-            .unwrap();
-        assert_eq!(
-            validators.into_iter().map(|v| v.take_account_id()).collect::<Vec<_>>(),
-            vec!["test1".parse().unwrap(), "test2".parse().unwrap()]
-        )
     });
 }
 

--- a/chain/jsonrpc/src/api/validator.rs
+++ b/chain/jsonrpc/src/api/validator.rs
@@ -2,9 +2,7 @@ use serde_json::Value;
 
 use near_client_primitives::types::GetValidatorInfoError;
 use near_jsonrpc_primitives::errors::RpcParseError;
-use near_jsonrpc_primitives::types::validator::{
-    RpcValidatorError, RpcValidatorRequest, RpcValidatorsOrderedRequest,
-};
+use near_jsonrpc_primitives::types::validator::{RpcValidatorError, RpcValidatorRequest};
 use near_primitives::types::EpochReference;
 
 use super::{Params, RpcFrom, RpcRequest};
@@ -18,12 +16,6 @@ impl RpcRequest for RpcValidatorRequest {
             })
             .unwrap_or_parse()?;
         Ok(Self { epoch_reference })
-    }
-}
-
-impl RpcRequest for RpcValidatorsOrderedRequest {
-    fn parse(value: Value) -> Result<Self, RpcParseError> {
-        Params::parse(value)
     }
 }
 

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -14,8 +14,8 @@ use near_client::{
     ClientActor, DebugStatus, GetBlock, GetBlockProof, GetChunk, GetClientConfig,
     GetExecutionOutcome, GetGasPrice, GetMaintenanceWindows, GetNetworkInfo,
     GetNextLightClientBlock, GetProtocolConfig, GetReceipt, GetStateChanges,
-    GetStateChangesInBlock, GetValidatorInfo, GetValidatorOrdered, ProcessTxRequest,
-    ProcessTxResponse, Query, Status, TxStatus, ViewClientActor,
+    GetStateChangesInBlock, GetValidatorInfo, ProcessTxRequest, ProcessTxResponse, Query, Status,
+    TxStatus, ViewClientActor,
 };
 use near_client_primitives::types::GetSplitStorageInfo;
 pub use near_jsonrpc_client as client;
@@ -342,9 +342,6 @@ impl JsonRpcHandler {
             }
             "EXPERIMENTAL_tx_status" => {
                 process_method_call(request, |params| self.tx_status_common(params, true)).await
-            }
-            "EXPERIMENTAL_validators_ordered" => {
-                process_method_call(request, |params| self.validators_ordered(params)).await
             }
             "EXPERIMENTAL_maintenance_windows" => {
                 process_method_call(request, |params| self.maintenance_windows(params)).await
@@ -1044,22 +1041,6 @@ impl JsonRpcHandler {
             .view_client_send(GetValidatorInfo { epoch_reference: request_data.epoch_reference })
             .await?;
         Ok(near_jsonrpc_primitives::types::validator::RpcValidatorResponse { validator_info })
-    }
-
-    /// Returns the current epoch validators ordered in the block producer order with repetition.
-    /// This endpoint is solely used for bridge currently and is not intended for other external use
-    /// cases.
-    async fn validators_ordered(
-        &self,
-        request: near_jsonrpc_primitives::types::validator::RpcValidatorsOrderedRequest,
-    ) -> Result<
-        near_jsonrpc_primitives::types::validator::RpcValidatorsOrderedResponse,
-        near_jsonrpc_primitives::types::validator::RpcValidatorError,
-    > {
-        let near_jsonrpc_primitives::types::validator::RpcValidatorsOrderedRequest { block_id } =
-            request;
-        let validators = self.view_client_send(GetValidatorOrdered { block_id }).await?;
-        Ok(validators)
     }
 
     /// If experimental_debug_pages_src_path config is set, reads the html file from that


### PR DESCRIPTION
This method was never used for the last 6 months, according to Prometheus.

@bowenwang1996 left the comment in the code
> /// Returns the current epoch validators ordered in the block producer order with repetition.
    /// This endpoint is solely used for bridge currently and is not intended for other external use
    /// cases.


Do we need to contact bridge and clarify whether they still need this?