### PR TITLE
toolchain: update to 1.72.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 version = "0.0.0" # managed by cargo-workspaces, see below
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
-rust-version = "1.71.0"
+rust-version = "1.72.0"
 repository = "https://github.com/near/nearcore"
 license = "MIT OR Apache-2.0"
 
@@ -12,6 +12,7 @@ version = "0.17.0"
 exclude = ["neard"]
 
 [workspace]
+resolver = "2"
 members = [
     "chain/chain",
     "chain/chunks",

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -1,3 +1,7 @@
+// FIXME(nagisa): Is there a good reason we're triggering this? Luckily though this is just test
+// code so we're in the clear.
+#![allow(clippy::arc_with_non_send_sync)]
+
 use std::cmp::max;
 use std::collections::{HashMap, HashSet};
 use std::mem::swap;

--- a/integration-tests/src/tests/client/features/delegate_action.rs
+++ b/integration-tests/src/tests/client/features/delegate_action.rs
@@ -314,7 +314,7 @@ fn meta_tx_fn_call_access_key() {
     // Check previous allowance is set as expected
     let key =
         node.user().get_access_key(&sender, &public_key).expect("failed looking up fn access key");
-    let AccessKeyPermissionView::FunctionCall { allowance, ..} = key.permission else {
+    let AccessKeyPermissionView::FunctionCall { allowance, .. } = key.permission else {
         panic!("should be function access key")
     };
     assert_eq!(allowance.unwrap(), INITIAL_ALLOWANCE);
@@ -339,7 +339,7 @@ fn meta_tx_fn_call_access_key() {
         .user()
         .get_access_key(&sender, &signer.public_key())
         .expect("failed looking up fn access key");
-    let AccessKeyPermissionView::FunctionCall { allowance, ..} = key.permission else {
+    let AccessKeyPermissionView::FunctionCall { allowance, .. } = key.permission else {
         panic!("should be function access key")
     };
     assert_eq!(

--- a/runtime/near-vm/test-api/src/sys/externals/function.rs
+++ b/runtime/near-vm/test-api/src/sys/externals/function.rs
@@ -126,7 +126,7 @@ where
         Box::into_raw(Box::new(env_ref.clone())) as _
     };
     let host_env_drop_fn = |ptr: *mut c_void| {
-        unsafe { Box::from_raw(ptr.cast::<Env>()) };
+        drop(unsafe { Box::from_raw(ptr.cast::<Env>()) });
     };
     let env = Box::into_raw(Box::new(env)) as _;
 

--- a/runtime/near-vm/test-api/src/sys/module.rs
+++ b/runtime/near-vm/test-api/src/sys/module.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::arc_with_non_send_sync)]
+
 use super::instance::InstantiationError;
 use super::store::Store;
 use near_vm_compiler::CompileError;

--- a/runtime/near-vm/test-api/src/sys/ptr.rs
+++ b/runtime/near-vm/test-api/src/sys/ptr.rs
@@ -37,7 +37,7 @@ unsafe impl<T: Copy, Ty> ValueType for WasmPtr<T, Ty> {}
 
 impl<T: Copy, Ty> Clone for WasmPtr<T, Ty> {
     fn clone(&self) -> Self {
-        Self { offset: self.offset, _phantom: PhantomData }
+        *self
     }
 }
 

--- a/runtime/runtime-params-estimator/emu-cost/Dockerfile
+++ b/runtime/runtime-params-estimator/emu-cost/Dockerfile
@@ -1,5 +1,5 @@
 # our local base image
-FROM rust:1.71.0
+FROM rust:1.72.0
 
 LABEL description="Container for builds"
 

--- a/runtime/runtime-params-estimator/src/gas_cost.rs
+++ b/runtime/runtime-params-estimator/src/gas_cost.rs
@@ -78,7 +78,9 @@ impl GasCost {
 
     /// Like [`std::cmp::Ord::min`] but operates on heterogenous types ([`GasCost`] + [`Gas`]).
     pub(crate) fn min_gas(mut self, gas: Gas) -> Self {
-        let Some(to_add) = gas.checked_sub(self.to_gas()) else { return self; };
+        let Some(to_add) = gas.checked_sub(self.to_gas()) else {
+            return self;
+        };
         if let Some(qemu) = &mut self.qemu {
             // QEMU gas is split across multiple components (instructions
             // and IO). When rounding up to an amount of gas, the assumption

--- a/runtime/runtime/src/receipt_manager.rs
+++ b/runtime/runtime/src/receipt_manager.rs
@@ -365,15 +365,14 @@ impl ReceiptManager {
         loop {
             let Some((index, weight)) = gas_weight_iterator.next() else { break };
             let FunctionCallActionIndex { receipt_index, action_index } = *index;
-            let Some(Action::FunctionCall(action)) =
-                action_receipts
-                    .get_mut(receipt_index)
-                    .and_then(|(_, receipt)| receipt.actions.get_mut(action_index))
-                else {
-                    panic!(
+            let Some(Action::FunctionCall(action)) = action_receipts
+                .get_mut(receipt_index)
+                .and_then(|(_, receipt)| receipt.actions.get_mut(action_index))
+            else {
+                panic!(
                         "Invalid function call index (promise_index={receipt_index}, action_index={action_index})",
                     );
-                };
+            };
             let to_assign = (unused_gas as u128 * weight.0 as u128 / gas_weight_sum) as u64;
             action.gas = safe_add_gas(action.gas, to_assign)?;
             distributed = distributed

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,6 +2,6 @@
 # This specifies the version of Rust we use to build.
 # Individual crates in the workspace may support a lower version, as indicated by `rust-version` field in each crate's `Cargo.toml`.
 # The version specified below, should be at least as high as the maximum `rust-version` within the workspace.
-channel = "1.71.0"
+channel = "1.72.0"
 components = [ "rustfmt" ]
 targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
The code changes largely just address warnings from the compiler. The `drop` one is fairly straightforward in that `Box::from_raw` got a `#[must_use]` annotation, and the `resolver = "2"` one was a solution to a complaint from cargo about the fact that the default resolver in `edition = "2021"` crates is version 2, but this is only applicable for individual crates and workspaces must opt-in manually.