### PR TITLE
feat(estimator): --check-only option for estimator

### DIFF
--- a/runtime/runtime-params-estimator/src/config.rs
+++ b/runtime/runtime-params-estimator/src/config.rs
@@ -44,4 +44,6 @@ pub struct Config {
     pub drop_os_cache: bool,
     /// Use in-memory test DB, useful to avoid variance caused by DB.
     pub in_memory_db: bool,
+    /// Only run a minimal check that's faster than trying to get accurate results.
+    pub check_only: bool,
 }

--- a/runtime/runtime-params-estimator/src/config.rs
+++ b/runtime/runtime-params-estimator/src/config.rs
@@ -44,6 +44,6 @@ pub struct Config {
     pub drop_os_cache: bool,
     /// Use in-memory test DB, useful to avoid variance caused by DB.
     pub in_memory_db: bool,
-    /// Only run a minimal check that's faster than trying to get accurate results.
-    pub check_only: bool,
+    /// If false, only runs a minimal check that's faster than trying to get accurate results.
+    pub accurate: bool,
 }

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -531,6 +531,7 @@ mod tests {
             in_memory_db: false,
             db_test_config: clap::Parser::parse_from(std::iter::empty::<std::ffi::OsString>()),
             sub_cmd: None,
+            check_only: false, // we run a small number of estimations, no need to take more shortcuts
         };
         run_estimation(args).unwrap();
     }

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -102,6 +102,9 @@ struct CliArgs {
     /// Use in-memory test DB, useful to avoid variance caused by DB.
     #[clap(long)]
     pub in_memory_db: bool,
+    /// Only run a minimal check that's faster than trying to get accurate results.
+    #[clap(long)]
+    pub check_only: bool,
     /// Extra configuration parameters for RocksDB specific estimations
     #[clap(flatten)]
     db_test_config: RocksDBTestConfig,
@@ -301,6 +304,7 @@ fn run_estimation(cli_args: CliArgs) -> anyhow::Result<Option<CostTable>> {
         json_output: cli_args.json_output,
         drop_os_cache: cli_args.drop_os_cache,
         in_memory_db: cli_args.in_memory_db,
+        check_only: cli_args.check_only,
     };
     let cost_table = runtime_params_estimator::run(config);
     Ok(Some(cost_table))

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -102,9 +102,9 @@ struct CliArgs {
     /// Use in-memory test DB, useful to avoid variance caused by DB.
     #[clap(long)]
     pub in_memory_db: bool,
-    /// Only run a minimal check that's faster than trying to get accurate results.
-    #[clap(long)]
-    pub check_only: bool,
+    /// If false, only runs a minimal check that's faster than trying to get accurate results.
+    #[clap(long, default_value_t = false)]
+    pub accurate: bool,
     /// Extra configuration parameters for RocksDB specific estimations
     #[clap(flatten)]
     db_test_config: RocksDBTestConfig,
@@ -304,7 +304,7 @@ fn run_estimation(cli_args: CliArgs) -> anyhow::Result<Option<CostTable>> {
         json_output: cli_args.json_output,
         drop_os_cache: cli_args.drop_os_cache,
         in_memory_db: cli_args.in_memory_db,
-        check_only: cli_args.check_only,
+        accurate: cli_args.accurate,
     };
     let cost_table = runtime_params_estimator::run(config);
     Ok(Some(cost_table))
@@ -531,7 +531,7 @@ mod tests {
             in_memory_db: false,
             db_test_config: clap::Parser::parse_from(std::iter::empty::<std::ffi::OsString>()),
             sub_cmd: None,
-            check_only: false, // we run a small number of estimations, no need to take more shortcuts
+            accurate: true, // we run a small number of estimations, no need to take more shortcuts
         };
         run_estimation(args).unwrap();
     }

--- a/runtime/runtime-params-estimator/src/rocksdb.rs
+++ b/runtime/runtime-params-estimator/src/rocksdb.rs
@@ -71,7 +71,7 @@ pub(crate) fn rocks_db_inserts_cost(config: &Config) -> GasCost {
     let db_config = &config.rocksdb_test_config;
     let data = input_data(db_config, INPUT_DATA_BUFFER_SIZE);
     let tmp_dir = tempfile::TempDir::new().expect("Failed to create directory for temp DB");
-    let db = new_test_db(&tmp_dir, &data, &db_config);
+    let db = new_test_db(&tmp_dir, &data, &db_config, config.check_only);
 
     if db_config.debug_rocksdb {
         eprintln!("# {:?}", db_config);
@@ -79,21 +79,24 @@ pub(crate) fn rocks_db_inserts_cost(config: &Config) -> GasCost {
         print_levels_info(&db);
     }
 
+    let setup_insertions = if config.check_only { 1 } else { db_config.setup_insertions };
+    let op_count = if config.check_only { 1 } else { db_config.op_count };
+
     let gas_counter = GasCost::measure(config.metric);
 
     if db_config.sequential_keys {
         sequential_inserts(
-            db_config.op_count,
+            op_count,
             db_config.value_size,
             &data,
-            db_config.setup_insertions,
+            setup_insertions,
             &db,
             db_config.force_compaction,
             db_config.force_flush,
         );
     } else {
         prandom_inserts(
-            db_config.op_count,
+            op_count,
             db_config.value_size,
             &data,
             ANOTHER_PRANDOM_SEED,
@@ -124,7 +127,7 @@ pub(crate) fn rocks_db_read_cost(config: &Config) -> GasCost {
     let db_config = &config.rocksdb_test_config;
     let tmp_dir = tempfile::TempDir::new().expect("Failed to create directory for temp DB");
     let data = input_data(db_config, INPUT_DATA_BUFFER_SIZE);
-    let db = new_test_db(&tmp_dir, &data, &db_config);
+    let db = new_test_db(&tmp_dir, &data, &db_config, config.check_only);
 
     if db_config.debug_rocksdb {
         eprintln!("# {:?}", db_config);
@@ -132,9 +135,11 @@ pub(crate) fn rocks_db_read_cost(config: &Config) -> GasCost {
         print_levels_info(&db);
     }
 
+    let setup_insertions = if config.check_only { 1 } else { db_config.setup_insertions };
+    let op_count = if config.check_only { 1 } else { db_config.op_count };
+
     let mut prng: XorShiftRng = rand::SeedableRng::seed_from_u64(SETUP_PRANDOM_SEED);
-    let mut keys: Vec<usize> =
-        iter::repeat_with(|| prng.gen()).take(db_config.setup_insertions).collect();
+    let mut keys: Vec<usize> = iter::repeat_with(|| prng.gen()).take(setup_insertions).collect();
     if db_config.sequential_keys {
         keys.sort();
     } else {
@@ -144,7 +149,7 @@ pub(crate) fn rocks_db_read_cost(config: &Config) -> GasCost {
 
     let gas_counter = GasCost::measure(config.metric);
 
-    for i in 0..db_config.op_count {
+    for i in 0..op_count {
         let key = keys[i as usize % keys.len()];
         db.get(&key.to_string()).unwrap();
     }
@@ -254,6 +259,7 @@ fn new_test_db(
     db_dir: impl AsRef<std::path::Path>,
     data: &[u8],
     db_config: &RocksDBTestConfig,
+    check_only: bool,
 ) -> DB {
     let mut opts = rocksdb::Options::default();
 
@@ -277,9 +283,10 @@ fn new_test_db(
     }
 
     let db = rocksdb::DB::open(&opts, db_dir).expect("Failed to create RocksDB");
+    let setup_insertions = if check_only { 1 } else { db_config.setup_insertions };
 
     prandom_inserts(
-        db_config.setup_insertions,
+        setup_insertions,
         db_config.value_size,
         &data,
         SETUP_PRANDOM_SEED,

--- a/runtime/runtime-params-estimator/src/trie.rs
+++ b/runtime/runtime-params-estimator/src/trie.rs
@@ -75,7 +75,7 @@ pub(crate) fn read_node_from_accounting_cache(testbed: &mut Testbed) -> GasCost 
 
     // Worst-case
     // - L3 CPU cache is filled with dummy data before measuring
-    let spoil_l3 = true;
+    let spoil_l3 = !testbed.config.check_only;
     // - Completely cold cache
     let warmups = 0;
     // - Single node read, no amortization possible

--- a/runtime/runtime-params-estimator/src/trie.rs
+++ b/runtime/runtime-params-estimator/src/trie.rs
@@ -75,7 +75,7 @@ pub(crate) fn read_node_from_accounting_cache(testbed: &mut Testbed) -> GasCost 
 
     // Worst-case
     // - L3 CPU cache is filled with dummy data before measuring
-    let spoil_l3 = !testbed.config.check_only;
+    let spoil_l3 = testbed.config.accurate;
     // - Completely cold cache
     let warmups = 0;
     // - Single node read, no amortization possible

--- a/runtime/runtime-params-estimator/src/utils.rs
+++ b/runtime/runtime-params-estimator/src/utils.rs
@@ -122,7 +122,12 @@ pub(crate) fn fn_cost_count(
     ext_cost: ExtCosts,
     block_latency: usize,
 ) -> (GasCost, u64) {
-    let block_size = 20;
+    // Block size: 20 is a good number if you want to reduce the effect of
+    // constant-per-block overhead and the tx takes less than 50 Tgas to
+    // execute. It's hard-coded because the range of values supported depends on
+    // each estimation. For a check-only run, a single tx per block is faster
+    // and good enough.
+    let block_size = if ctx.config.check_only { 1 } else { 20 };
     let mut make_transaction = |tb: &mut TransactionBuilder| -> SignedTransaction {
         let sender = tb.random_unused_account();
         tb.transaction_from_function_call(sender, method, Vec::new())

--- a/runtime/runtime-params-estimator/src/utils.rs
+++ b/runtime/runtime-params-estimator/src/utils.rs
@@ -127,7 +127,7 @@ pub(crate) fn fn_cost_count(
     // execute. It's hard-coded because the range of values supported depends on
     // each estimation. For a check-only run, a single tx per block is faster
     // and good enough.
-    let block_size = if ctx.config.check_only { 1 } else { 20 };
+    let block_size = if ctx.config.accurate { 20 } else { 1 };
     let mut make_transaction = |tb: &mut TransactionBuilder| -> SignedTransaction {
         let sender = tb.random_unused_account();
         tb.transaction_from_function_call(sender, method, Vec::new())


### PR DESCRIPTION
There are several expensive things we do in the estimator that are only
necessary to make results more accurate. If we want to have CI checks,
we want to avoid them. `--check-only` allows to opt out.

Specifically, `--check-only` does:
- Disable CPU cache spoiling.
- Use a single tx per block instead of multiple.
- Reduce RocksDB benchmarks to a single operation.