### PR TITLE
near-vm-runner: remove reliance on protocol version for import gating

### DIFF
--- a/chain/client/src/adapter.rs
+++ b/chain/client/src/adapter.rs
@@ -160,10 +160,7 @@ impl near_network::client::Client for Adapter {
     ) -> Option<Box<FinalExecutionOutcomeView>> {
         match self
             .view_client_addr
-            .send(
-                TxStatusRequest { tx_hash: tx_hash, signer_account_id: account_id }
-                    .with_span_context(),
-            )
+            .send(TxStatusRequest { tx_hash, signer_account_id: account_id }.with_span_context())
             .await
         {
             Ok(res) => res,
@@ -194,9 +191,7 @@ impl near_network::client::Client for Adapter {
     ) -> Result<Option<StateResponseInfo>, ReasonForBan> {
         match self
             .view_client_addr
-            .send(
-                StateRequestHeader { shard_id: shard_id, sync_hash: sync_hash }.with_span_context(),
-            )
+            .send(StateRequestHeader { shard_id, sync_hash }.with_span_context())
             .await
         {
             Ok(Some(StateResponse(resp))) => Ok(Some(*resp)),
@@ -216,10 +211,7 @@ impl near_network::client::Client for Adapter {
     ) -> Result<Option<StateResponseInfo>, ReasonForBan> {
         match self
             .view_client_addr
-            .send(
-                StateRequestPart { shard_id: shard_id, sync_hash: sync_hash, part_id: part_id }
-                    .with_span_context(),
-            )
+            .send(StateRequestPart { shard_id, sync_hash, part_id }.with_span_context())
             .await
         {
             Ok(Some(StateResponse(resp))) => Ok(Some(*resp)),

--- a/core/primitives-core/src/parameter.rs
+++ b/core/primitives-core/src/parameter.rs
@@ -152,6 +152,10 @@ pub enum Parameter {
     FlatStorageReads,
     ImplicitAccountCreation,
     FixContractLoadingCost,
+    MathExtension,
+    Ed25519Verify,
+    AltBn128,
+    FunctionCallWeight,
 }
 
 #[derive(

--- a/core/primitives/res/runtime_configs/46.yaml
+++ b/core/primitives/res/runtime_configs/46.yaml
@@ -1,0 +1,1 @@
+math_extension: { old: false, new: true }

--- a/core/primitives/res/runtime_configs/53.yaml
+++ b/core/primitives/res/runtime_configs/53.yaml
@@ -13,3 +13,4 @@ action_deploy_contract_per_byte: {
 wasmer2_stack_limit: { new: 204_800 }
 max_length_storage_key: { old: 4_194_304, new: 2_048 }
 max_locals_per_contract: { new: 1_000_000 }
+function_call_weight: { old: false, new: true }

--- a/core/primitives/res/runtime_configs/55.yaml
+++ b/core/primitives/res/runtime_configs/55.yaml
@@ -1,0 +1,1 @@
+alt_bn128: { old: false, new: true }

--- a/core/primitives/res/runtime_configs/59.yaml
+++ b/core/primitives/res/runtime_configs/59.yaml
@@ -1,3 +1,4 @@
+ed25519_verify: { old: false, new: true }
 action_create_account: {
   old: {
     send_sir: 99_607_375_000,

--- a/core/primitives/res/runtime_configs/parameters.snap
+++ b/core/primitives/res/runtime_configs/parameters.snap
@@ -167,4 +167,8 @@ disable_9393_fix                        false
 flat_storage_reads                      true
 implicit_account_creation               true
 fix_contract_loading_cost               true
+math_extension                          true
+ed25519_verify                          true
+alt_bn128                               true
+function_call_weight                    true
 

--- a/core/primitives/res/runtime_configs/parameters.yaml
+++ b/core/primitives/res/runtime_configs/parameters.yaml
@@ -202,3 +202,7 @@ disable_9393_fix: false
 flat_storage_reads: false
 implicit_account_creation: false
 fix_contract_loading_cost: false
+math_extension: false
+ed25519_verify: false
+alt_bn128: false
+function_call_weight: false

--- a/core/primitives/res/runtime_configs/parameters_testnet.yaml
+++ b/core/primitives/res/runtime_configs/parameters_testnet.yaml
@@ -197,3 +197,7 @@ disable_9393_fix: false
 flat_storage_reads: false
 implicit_account_creation: false
 fix_contract_loading_cost: false
+math_extension: false
+ed25519_verify: false
+alt_bn128: false
+function_call_weight: false

--- a/core/primitives/src/runtime/config_store.rs
+++ b/core/primitives/src/runtime/config_store.rs
@@ -20,6 +20,7 @@ static BASE_CONFIG: &str = include_config!("parameters.yaml");
 static CONFIG_DIFFS: &[(ProtocolVersion, &str)] = &[
     (35, include_config!("35.yaml")),
     (42, include_config!("42.yaml")),
+    (46, include_config!("46.yaml")),
     (48, include_config!("48.yaml")),
     (49, include_config!("49.yaml")),
     (50, include_config!("50.yaml")),
@@ -28,6 +29,7 @@ static CONFIG_DIFFS: &[(ProtocolVersion, &str)] = &[
     // Increased deployment costs, increased wasmer2 stack_limit, added limiting of contract locals,
     // set read_cached_trie_node cost, decrease storage key limit
     (53, include_config!("53.yaml")),
+    (55, include_config!("55.yaml")),
     (57, include_config!("57.yaml")),
     // Introduce Zero Balance Account and increase account creation cost to 7.7Tgas
     (59, include_config!("59.yaml")),
@@ -262,19 +264,24 @@ mod tests {
             store.get_config(LowerStorageCost.protocol_version() - 1).as_ref()
         );
 
-        let expected_config = {
-            base_params.apply_diff(CONFIG_DIFFS[0].1.parse().unwrap()).unwrap();
-            base_params.apply_diff(CONFIG_DIFFS[1].1.parse().unwrap()).unwrap();
-            RuntimeConfig::new(&base_params).unwrap()
-        };
+        for (ver, diff) in &CONFIG_DIFFS[..] {
+            if *ver <= LowerStorageCost.protocol_version() {
+                base_params.apply_diff(diff.parse().unwrap()).unwrap();
+            }
+        }
+        let expected_config = RuntimeConfig::new(&base_params).unwrap();
         assert_eq!(**config, expected_config);
 
         let config = store.get_config(LowerDataReceiptAndEcrecoverBaseCost.protocol_version());
         assert_eq!(config.fees.fee(ActionCosts::new_data_receipt_base).send_sir, 36_486_732_312);
-        let expected_config = {
-            base_params.apply_diff(CONFIG_DIFFS[2].1.parse().unwrap()).unwrap();
-            RuntimeConfig::new(&base_params).unwrap()
-        };
+        for (ver, diff) in &CONFIG_DIFFS[..] {
+            if *ver <= LowerStorageCost.protocol_version() {
+                continue;
+            } else if *ver <= LowerDataReceiptAndEcrecoverBaseCost.protocol_version() {
+                base_params.apply_diff(diff.parse().unwrap()).unwrap();
+            }
+        }
+        let expected_config = RuntimeConfig::new(&base_params).unwrap();
         assert_eq!(config.as_ref(), &expected_config);
     }
 

--- a/core/primitives/src/runtime/parameter_table.rs
+++ b/core/primitives/src/runtime/parameter_table.rs
@@ -298,6 +298,10 @@ impl TryFrom<&ParameterTable> for RuntimeConfig {
                     false => StorageGetMode::Trie,
                 },
                 implicit_account_creation: params.get(Parameter::ImplicitAccountCreation)?,
+                math_extension: params.get(Parameter::MathExtension)?,
+                ed25519_verify: params.get(Parameter::Ed25519Verify)?,
+                alt_bn128: params.get(Parameter::AltBn128)?,
+                function_call_weight: params.get(Parameter::FunctionCallWeight)?,
             },
             account_creation_config: AccountCreationConfig {
                 min_allowed_top_level_account_length: params

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__0.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__0.json.snap
@@ -176,6 +176,10 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": false,
+    "math_extension": false,
+    "ed25519_verify": false,
+    "alt_bn128": false,
+    "function_call_weight": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__129.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__129.json.snap
@@ -176,6 +176,10 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": true,
     "implicit_account_creation": true,
+    "math_extension": true,
+    "ed25519_verify": true,
+    "alt_bn128": true,
+    "function_call_weight": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__35.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__35.json.snap
@@ -176,6 +176,10 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
+    "math_extension": false,
+    "ed25519_verify": false,
+    "alt_bn128": false,
+    "function_call_weight": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__42.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__42.json.snap
@@ -176,6 +176,10 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
+    "math_extension": false,
+    "ed25519_verify": false,
+    "alt_bn128": false,
+    "function_call_weight": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__46.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__46.json.snap
@@ -12,14 +12,14 @@ expression: config_view
     },
     "data_receipt_creation_config": {
       "base_cost": {
-        "send_sir": 36486732312,
-        "send_not_sir": 36486732312,
-        "execution": 36486732312
+        "send_sir": 4697339419375,
+        "send_not_sir": 4697339419375,
+        "execution": 4697339419375
       },
       "cost_per_byte": {
-        "send_sir": 17212011,
-        "send_not_sir": 17212011,
-        "execution": 17212011
+        "send_sir": 59357464,
+        "send_not_sir": 59357464,
+        "execution": 59357464
       }
     },
     "action_creation_config": {
@@ -131,7 +131,7 @@ expression: config_view
       "ripemd160_block": 680107584,
       "ed25519_verify_base": 210000000000,
       "ed25519_verify_byte": 9000000,
-      "ecrecover_base": 278821988457,
+      "ecrecover_base": 3365369625000,
       "log_base": 3543313050,
       "log_byte": 13198791,
       "storage_write_base": 64196736000,
@@ -171,7 +171,7 @@ expression: config_view
       "alt_bn128_pairing_check_element": 5102000000000
     },
     "grow_mem_cost": 1,
-    "regular_op_cost": 822756,
+    "regular_op_cost": 3856371,
     "disable_9393_fix": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
@@ -181,9 +181,9 @@ expression: config_view
     "alt_bn128": false,
     "function_call_weight": false,
     "limit_config": {
-      "max_gas_burnt": 300000000000000,
+      "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,
-      "contract_prepare_version": 1,
+      "contract_prepare_version": 0,
       "initial_memory_pages": 1024,
       "max_memory_pages": 2048,
       "registers_memory_limit": 1073741824,
@@ -203,7 +203,6 @@ expression: config_view
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
       "max_number_input_data_dependencies": 128,
-      "max_functions_number_per_contract": 10000,
       "wasmer2_stack_limit": 102400,
       "account_id_validity_rules_version": 0
     }

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__48.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__48.json.snap
@@ -176,6 +176,10 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
+    "math_extension": true,
+    "ed25519_verify": false,
+    "alt_bn128": false,
+    "function_call_weight": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__49.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__49.json.snap
@@ -176,6 +176,10 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
+    "math_extension": true,
+    "ed25519_verify": false,
+    "alt_bn128": false,
+    "function_call_weight": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__50.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__50.json.snap
@@ -176,6 +176,10 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
+    "math_extension": true,
+    "ed25519_verify": false,
+    "alt_bn128": false,
+    "function_call_weight": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__53.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__53.json.snap
@@ -176,6 +176,10 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
+    "math_extension": true,
+    "ed25519_verify": false,
+    "alt_bn128": false,
+    "function_call_weight": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__55.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__55.json.snap
@@ -36,7 +36,7 @@ expression: config_view
       "deploy_contract_cost_per_byte": {
         "send_sir": 6812999,
         "send_not_sir": 6812999,
-        "execution": 6812999
+        "execution": 64572944
       },
       "function_call_cost": {
         "send_sir": 2319861500000,
@@ -178,8 +178,8 @@ expression: config_view
     "implicit_account_creation": true,
     "math_extension": true,
     "ed25519_verify": false,
-    "alt_bn128": false,
-    "function_call_weight": false,
+    "alt_bn128": true,
+    "function_call_weight": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,
@@ -199,12 +199,13 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_length_storage_key": 4194304,
+      "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
       "max_number_input_data_dependencies": 128,
       "max_functions_number_per_contract": 10000,
-      "wasmer2_stack_limit": 102400,
+      "wasmer2_stack_limit": 204800,
+      "max_locals_per_contract": 1000000,
       "account_id_validity_rules_version": 0
     }
   },

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__57.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__57.json.snap
@@ -176,6 +176,10 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
+    "math_extension": true,
+    "ed25519_verify": false,
+    "alt_bn128": true,
+    "function_call_weight": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__59.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__59.json.snap
@@ -176,6 +176,10 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
+    "math_extension": true,
+    "ed25519_verify": true,
+    "alt_bn128": true,
+    "function_call_weight": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__61.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__61.json.snap
@@ -176,6 +176,10 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
+    "math_extension": true,
+    "ed25519_verify": true,
+    "alt_bn128": true,
+    "function_call_weight": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__62.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__62.json.snap
@@ -176,6 +176,10 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
+    "math_extension": true,
+    "ed25519_verify": true,
+    "alt_bn128": true,
+    "function_call_weight": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__63.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__63.json.snap
@@ -176,6 +176,10 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
+    "math_extension": true,
+    "ed25519_verify": true,
+    "alt_bn128": true,
+    "function_call_weight": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_0.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_0.json.snap
@@ -176,6 +176,10 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": false,
+    "math_extension": false,
+    "ed25519_verify": false,
+    "alt_bn128": false,
+    "function_call_weight": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_129.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_129.json.snap
@@ -176,6 +176,10 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": true,
     "implicit_account_creation": true,
+    "math_extension": true,
+    "ed25519_verify": true,
+    "alt_bn128": true,
+    "function_call_weight": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_35.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_35.json.snap
@@ -176,6 +176,10 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
+    "math_extension": false,
+    "ed25519_verify": false,
+    "alt_bn128": false,
+    "function_call_weight": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_42.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_42.json.snap
@@ -176,6 +176,10 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
+    "math_extension": false,
+    "ed25519_verify": false,
+    "alt_bn128": false,
+    "function_call_weight": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_46.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_46.json.snap
@@ -12,14 +12,14 @@ expression: config_view
     },
     "data_receipt_creation_config": {
       "base_cost": {
-        "send_sir": 36486732312,
-        "send_not_sir": 36486732312,
-        "execution": 36486732312
+        "send_sir": 4697339419375,
+        "send_not_sir": 4697339419375,
+        "execution": 4697339419375
       },
       "cost_per_byte": {
-        "send_sir": 17212011,
-        "send_not_sir": 17212011,
-        "execution": 17212011
+        "send_sir": 59357464,
+        "send_not_sir": 59357464,
+        "execution": 59357464
       }
     },
     "action_creation_config": {
@@ -131,7 +131,7 @@ expression: config_view
       "ripemd160_block": 680107584,
       "ed25519_verify_base": 210000000000,
       "ed25519_verify_byte": 9000000,
-      "ecrecover_base": 278821988457,
+      "ecrecover_base": 3365369625000,
       "log_base": 3543313050,
       "log_byte": 13198791,
       "storage_write_base": 64196736000,
@@ -171,7 +171,7 @@ expression: config_view
       "alt_bn128_pairing_check_element": 5102000000000
     },
     "grow_mem_cost": 1,
-    "regular_op_cost": 822756,
+    "regular_op_cost": 3856371,
     "disable_9393_fix": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
@@ -181,9 +181,9 @@ expression: config_view
     "alt_bn128": false,
     "function_call_weight": false,
     "limit_config": {
-      "max_gas_burnt": 300000000000000,
+      "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,
-      "contract_prepare_version": 1,
+      "contract_prepare_version": 0,
       "initial_memory_pages": 1024,
       "max_memory_pages": 2048,
       "registers_memory_limit": 1073741824,
@@ -203,7 +203,6 @@ expression: config_view
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
       "max_number_input_data_dependencies": 128,
-      "max_functions_number_per_contract": 10000,
       "wasmer2_stack_limit": 102400,
       "account_id_validity_rules_version": 0
     }

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_48.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_48.json.snap
@@ -176,6 +176,10 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
+    "math_extension": true,
+    "ed25519_verify": false,
+    "alt_bn128": false,
+    "function_call_weight": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_49.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_49.json.snap
@@ -176,6 +176,10 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
+    "math_extension": true,
+    "ed25519_verify": false,
+    "alt_bn128": false,
+    "function_call_weight": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_50.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_50.json.snap
@@ -176,6 +176,10 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
+    "math_extension": true,
+    "ed25519_verify": false,
+    "alt_bn128": false,
+    "function_call_weight": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_52.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_52.json.snap
@@ -176,6 +176,10 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
+    "math_extension": true,
+    "ed25519_verify": false,
+    "alt_bn128": false,
+    "function_call_weight": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_53.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_53.json.snap
@@ -176,6 +176,10 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
+    "math_extension": true,
+    "ed25519_verify": false,
+    "alt_bn128": false,
+    "function_call_weight": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_55.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_55.json.snap
@@ -36,7 +36,7 @@ expression: config_view
       "deploy_contract_cost_per_byte": {
         "send_sir": 6812999,
         "send_not_sir": 6812999,
-        "execution": 6812999
+        "execution": 64572944
       },
       "function_call_cost": {
         "send_sir": 2319861500000,
@@ -178,8 +178,8 @@ expression: config_view
     "implicit_account_creation": true,
     "math_extension": true,
     "ed25519_verify": false,
-    "alt_bn128": false,
-    "function_call_weight": false,
+    "alt_bn128": true,
+    "function_call_weight": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,
@@ -199,12 +199,13 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_length_storage_key": 4194304,
+      "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
       "max_number_input_data_dependencies": 128,
       "max_functions_number_per_contract": 10000,
-      "wasmer2_stack_limit": 102400,
+      "wasmer2_stack_limit": 204800,
+      "max_locals_per_contract": 1000000,
       "account_id_validity_rules_version": 0
     }
   },

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_57.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_57.json.snap
@@ -176,6 +176,10 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
+    "math_extension": true,
+    "ed25519_verify": false,
+    "alt_bn128": true,
+    "function_call_weight": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_59.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_59.json.snap
@@ -176,6 +176,10 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
+    "math_extension": true,
+    "ed25519_verify": true,
+    "alt_bn128": true,
+    "function_call_weight": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_61.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_61.json.snap
@@ -176,6 +176,10 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
+    "math_extension": true,
+    "ed25519_verify": true,
+    "alt_bn128": true,
+    "function_call_weight": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_62.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_62.json.snap
@@ -176,6 +176,10 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
+    "math_extension": true,
+    "ed25519_verify": true,
+    "alt_bn128": true,
+    "function_call_weight": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_63.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_63.json.snap
@@ -176,6 +176,10 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
+    "math_extension": true,
+    "ed25519_verify": true,
+    "alt_bn128": true,
+    "function_call_weight": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/primitives/src/snapshots/near_primitives__views__tests__runtime_config_view.snap
+++ b/core/primitives/src/snapshots/near_primitives__views__tests__runtime_config_view.snap
@@ -176,6 +176,10 @@ expression: "&view"
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
+    "math_extension": true,
+    "ed25519_verify": true,
+    "alt_bn128": true,
+    "function_call_weight": true,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 262144,

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -2485,6 +2485,14 @@ pub struct VMConfigView {
     pub fix_contract_loading_cost: bool,
     /// See [`VMConfig::implicit_account_creation`].
     pub implicit_account_creation: bool,
+    /// See [`VMConfig::math_extension`].
+    pub math_extension: bool,
+    /// See [`VMConfig::ed25519_verify`].
+    pub ed25519_verify: bool,
+    /// See [`VMConfig::alt_bn128`].
+    pub alt_bn128: bool,
+    /// See [`VMConfig::function_call_weight`].
+    pub function_call_weight: bool,
 
     /// Describes limits for VM and Runtime.
     ///
@@ -2504,6 +2512,10 @@ impl From<near_vm_runner::logic::Config> for VMConfigView {
             storage_get_mode: config.storage_get_mode,
             fix_contract_loading_cost: config.fix_contract_loading_cost,
             implicit_account_creation: config.implicit_account_creation,
+            math_extension: config.math_extension,
+            ed25519_verify: config.ed25519_verify,
+            alt_bn128: config.alt_bn128,
+            function_call_weight: config.function_call_weight,
         }
     }
 }
@@ -2519,6 +2531,10 @@ impl From<VMConfigView> for near_vm_runner::logic::Config {
             storage_get_mode: view.storage_get_mode,
             fix_contract_loading_cost: view.fix_contract_loading_cost,
             implicit_account_creation: view.implicit_account_creation,
+            math_extension: view.math_extension,
+            ed25519_verify: view.ed25519_verify,
+            alt_bn128: view.alt_bn128,
+            function_call_weight: view.function_call_weight,
         }
     }
 }

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -133,7 +133,7 @@ impl NodeStorage {
             None
         };
 
-        Self { hot_storage: hot_storage, cold_storage: cold_db }
+        Self { hot_storage, cold_storage: cold_db }
     }
 
     /// Initialises an opener for a new temporary test store.

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -472,7 +472,7 @@ impl Trie {
             storage,
             root,
             flat_storage_chunk_view,
-            accounting_cache: accounting_cache,
+            accounting_cache,
             recorder: None,
             skip_accounting_cache_for_trie_nodes: false,
         }

--- a/runtime/near-vm-runner/fuzz/fuzz_targets/diffrunner.rs
+++ b/runtime/near-vm-runner/fuzz/fuzz_targets/diffrunner.rs
@@ -35,7 +35,6 @@ fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMOutcome {
         context,
         &fees,
         &promise_results,
-        PROTOCOL_VERSION,
         None,
     );
 

--- a/runtime/near-vm-runner/fuzz/fuzz_targets/diffrunner.rs
+++ b/runtime/near-vm-runner/fuzz/fuzz_targets/diffrunner.rs
@@ -1,7 +1,6 @@
 #![no_main]
 
 use near_primitives::runtime::fees::RuntimeFeesConfig;
-use near_primitives::version::PROTOCOL_VERSION;
 use near_vm_runner::internal::VMKind;
 use near_vm_runner::logic::errors::FunctionCallError;
 use near_vm_runner::logic::mocks::mock_external::MockedExternal;

--- a/runtime/near-vm-runner/fuzz/fuzz_targets/runner.rs
+++ b/runtime/near-vm-runner/fuzz/fuzz_targets/runner.rs
@@ -34,7 +34,6 @@ fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMOutcome {
             context,
             &fees,
             &promise_results,
-            PROTOCOL_VERSION,
             None,
         )
         .unwrap_or_else(|err| panic!("fatal error: {err:?}"))

--- a/runtime/near-vm-runner/fuzz/fuzz_targets/runner.rs
+++ b/runtime/near-vm-runner/fuzz/fuzz_targets/runner.rs
@@ -27,14 +27,6 @@ fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMOutcome {
     vm_kind
         .runtime(config)
         .unwrap()
-        .run(
-            code,
-            &method_name,
-            &mut fake_external,
-            context,
-            &fees,
-            &promise_results,
-            None,
-        )
+        .run(code, &method_name, &mut fake_external, context, &fees, &promise_results, None)
         .unwrap_or_else(|err| panic!("fatal error: {err:?}"))
 }

--- a/runtime/near-vm-runner/src/config.rs
+++ b/runtime/near-vm-runner/src/config.rs
@@ -34,6 +34,18 @@ pub struct Config {
     /// Enable the `ImplicitAccountCreation` protocol feature.
     pub implicit_account_creation: bool,
 
+    /// Enable the host functions added by the `MathExtension` protocol feature.
+    pub math_extension: bool,
+
+    /// Enable the host functions added by the `Ed25519Verify` protocol feature.
+    pub ed25519_verify: bool,
+
+    /// Enable the host functions added by the `AltBn128` protocol feature.
+    pub alt_bn128: bool,
+
+    /// Enable the `FunctionCallWeight` protocol feature.
+    pub function_call_weight: bool,
+
     /// Describes limits for VM and Runtime.
     pub limit_config: LimitConfig,
 }
@@ -173,6 +185,10 @@ impl Config {
             fix_contract_loading_cost: cfg!(feature = "protocol_feature_fix_contract_loading_cost"),
             storage_get_mode: StorageGetMode::FlatStorage,
             implicit_account_creation: true,
+            math_extension: true,
+            ed25519_verify: true,
+            alt_bn128: true,
+            function_call_weight: true,
         }
     }
 
@@ -199,6 +215,10 @@ impl Config {
             fix_contract_loading_cost: cfg!(feature = "protocol_feature_fix_contract_loading_cost"),
             storage_get_mode: StorageGetMode::FlatStorage,
             implicit_account_creation: true,
+            math_extension: true,
+            ed25519_verify: true,
+            alt_bn128: true,
+            function_call_weight: true,
         }
     }
 }

--- a/runtime/near-vm-runner/src/imports.rs
+++ b/runtime/near-vm-runner/src/imports.rs
@@ -42,7 +42,7 @@
 //! `for_each_available_import` with its own import definition logic.
 //!
 //! The real `for_each_available_import` takes one more argument --
-//! `protocol_version`. We can add new imports, but we must make sure that they
+//! `VMConfig`. We can add new imports, but we must make sure that they
 //! are only available to contracts at a specific protocol version -- we can't
 //! make imports retroactively available to old transactions. So
 //! `for_each_available_import` takes care to invoke `M!` only for currently
@@ -62,19 +62,15 @@ macro_rules! call_with_name {
 
 macro_rules! imports {
     (
-      $($(#[$stable_feature:ident])? $(#[$feature_name:literal, $feature:ident])* $(##[$feature_name2:literal])?
+      $($(#[$config_field:ident])? $(##[$feature_name:literal])?
         $( @in $mod:ident : )?
         $( @as $name:ident : )?
         $func:ident < [ $( $arg_name:ident : $arg_type:ident ),* ] -> [ $( $returns:ident ),* ] >,)*
     ) => {
         macro_rules! for_each_available_import {
-            ($protocol_version:expr, $M:ident) => {$(
-                $(#[cfg(feature = $feature_name2)])?
-                $(#[cfg(feature = $feature_name)])*
-                if true
-                    $(&& near_primitives_core::checked_feature!($feature_name, $feature, $protocol_version))*
-                    $(&& near_primitives_core::checked_feature!("stable", $stable_feature, $protocol_version))?
-                {
+            ($config:expr, $M:ident) => {$(
+                $(#[cfg(feature = $feature_name)])?
+                if true $(&& ($config).$config_field)? {
                     call_with_name!($M => $( @in $mod : )? $( @as $name : )? $func < [ $( $arg_name : $arg_type ),* ] -> [ $( $returns ),* ] >);
                 }
             )*}
@@ -122,15 +118,15 @@ imports! {
     sha256<[value_len: u64, value_ptr: u64, register_id: u64] -> []>,
     keccak256<[value_len: u64, value_ptr: u64, register_id: u64] -> []>,
     keccak512<[value_len: u64, value_ptr: u64, register_id: u64] -> []>,
-    #[Ed25519Verify] ed25519_verify<[sig_len: u64,
+    #[ed25519_verify] ed25519_verify<[sig_len: u64,
         sig_ptr: u64,
         msg_len: u64,
         msg_ptr: u64,
         pub_key_len: u64,
         pub_key_ptr: u64
     ] -> [u64]>,
-    #[MathExtension] ripemd160<[value_len: u64, value_ptr: u64, register_id: u64] -> []>,
-    #[MathExtension] ecrecover<[hash_len: u64, hash_ptr: u64, sign_len: u64, sig_ptr: u64, v: u64, malleability_flag: u64, register_id: u64] -> [u64]>,
+    #[math_extension] ripemd160<[value_len: u64, value_ptr: u64, register_id: u64] -> []>,
+    #[math_extension] ecrecover<[hash_len: u64, hash_ptr: u64, sign_len: u64, sig_ptr: u64, v: u64, malleability_flag: u64, register_id: u64] -> [u64]>,
     // #####################
     // # Miscellaneous API #
     // #####################
@@ -181,7 +177,7 @@ imports! {
         amount_ptr: u64,
         gas: u64
     ] -> []>,
-    #[FunctionCallWeight] promise_batch_action_function_call_weight<[
+    #[function_call_weight] promise_batch_action_function_call_weight<[
         promise_index: u64,
         method_name_len: u64,
         method_name_ptr: u64,
@@ -251,9 +247,9 @@ imports! {
     // #############
     // # Alt BN128 #
     // #############
-    #[AltBn128] alt_bn128_g1_multiexp<[value_len: u64, value_ptr: u64, register_id: u64] -> []>,
-    #[AltBn128] alt_bn128_g1_sum<[value_len: u64, value_ptr: u64, register_id: u64] -> []>,
-    #[AltBn128] alt_bn128_pairing_check<[value_len: u64, value_ptr: u64] -> [u64]>,
+    #[alt_bn128] alt_bn128_g1_multiexp<[value_len: u64, value_ptr: u64, register_id: u64] -> []>,
+    #[alt_bn128] alt_bn128_g1_sum<[value_len: u64, value_ptr: u64, register_id: u64] -> []>,
+    #[alt_bn128] alt_bn128_pairing_check<[value_len: u64, value_ptr: u64] -> [u64]>,
     // #############
     // #  Sandbox  #
     // #############
@@ -263,7 +259,7 @@ imports! {
 #[cfg(all(feature = "wasmer0_vm", target_arch = "x86_64"))]
 pub(crate) mod wasmer {
     use super::str_eq;
-    use crate::logic::{ProtocolVersion, VMLogic, VMLogicError};
+    use crate::logic::{VMLogic, VMLogicError};
     use std::ffi::c_void;
 
     #[derive(Clone, Copy)]
@@ -274,7 +270,6 @@ pub(crate) mod wasmer {
     pub(crate) fn build(
         memory: wasmer_runtime::memory::Memory,
         logic: &mut VMLogic<'_>,
-        protocol_version: ProtocolVersion,
     ) -> wasmer_runtime::ImportObject {
         let raw_ptr = logic as *mut _ as *mut c_void;
         let import_reference = ImportReference(raw_ptr);
@@ -311,7 +306,7 @@ pub(crate) mod wasmer {
                 }
             };
         }
-        for_each_available_import!(protocol_version, add_import);
+        for_each_available_import!(logic.config, add_import);
 
         import_object.register("env", ns_env);
         import_object.register("internal", ns_internal);
@@ -324,7 +319,7 @@ pub(crate) mod wasmer2 {
     use std::sync::Arc;
 
     use super::str_eq;
-    use crate::logic::{ProtocolVersion, VMLogic};
+    use crate::logic::{VMLogic};
     use wasmer_engine::Engine;
     use wasmer_engine_universal::UniversalEngine;
     use wasmer_vm::{
@@ -336,7 +331,6 @@ pub(crate) mod wasmer2 {
         // Note: this same object is also referenced by the `metadata` field!
         pub(crate) vmlogic: &'vmlogic mut VMLogic<'vmlogic_refs>,
         pub(crate) metadata: Arc<ExportFunctionMetadata>,
-        pub(crate) protocol_version: ProtocolVersion,
         pub(crate) engine: &'engine UniversalEngine,
     }
 
@@ -454,7 +448,7 @@ pub(crate) mod wasmer2 {
                     }
                 };
             }
-            for_each_available_import!(self.protocol_version, add_import);
+            for_each_available_import!(self.vmlogic.config, add_import);
             return None;
         }
     }
@@ -462,7 +456,6 @@ pub(crate) mod wasmer2 {
     pub(crate) fn build<'e, 'a, 'b>(
         memory: VMMemory,
         logic: &'a mut VMLogic<'b>,
-        protocol_version: ProtocolVersion,
         engine: &'e UniversalEngine,
     ) -> Wasmer2Imports<'e, 'a, 'b> {
         let metadata = unsafe {
@@ -475,7 +468,6 @@ pub(crate) mod wasmer2 {
             memory,
             vmlogic: logic,
             metadata: Arc::new(metadata),
-            protocol_version,
             engine,
         }
     }
@@ -486,7 +478,7 @@ pub(crate) mod near_vm {
     use std::sync::Arc;
 
     use super::str_eq;
-    use crate::logic::{ProtocolVersion, VMLogic};
+    use crate::logic::{VMLogic};
     use near_vm_engine::universal::UniversalEngine;
     use near_vm_vm::{
         ExportFunction, ExportFunctionMetadata, Resolver, VMFunction, VMFunctionKind, VMMemory,
@@ -497,7 +489,6 @@ pub(crate) mod near_vm {
         // Note: this same object is also referenced by the `metadata` field!
         pub(crate) vmlogic: &'vmlogic mut VMLogic<'vmlogic_refs>,
         pub(crate) metadata: Arc<ExportFunctionMetadata>,
-        pub(crate) protocol_version: ProtocolVersion,
         pub(crate) engine: &'engine UniversalEngine,
     }
 
@@ -615,7 +606,7 @@ pub(crate) mod near_vm {
                     }
                 };
             }
-            for_each_available_import!(self.protocol_version, add_import);
+            for_each_available_import!(self.vmlogic.config, add_import);
             return None;
         }
     }
@@ -623,7 +614,6 @@ pub(crate) mod near_vm {
     pub(crate) fn build<'e, 'a, 'b>(
         memory: VMMemory,
         logic: &'a mut VMLogic<'b>,
-        protocol_version: ProtocolVersion,
         engine: &'e UniversalEngine,
     ) -> NearVmImports<'e, 'a, 'b> {
         let metadata = unsafe {
@@ -636,7 +626,6 @@ pub(crate) mod near_vm {
             memory,
             vmlogic: logic,
             metadata: Arc::new(metadata),
-            protocol_version,
             engine,
         }
     }
@@ -645,7 +634,7 @@ pub(crate) mod near_vm {
 #[cfg(feature = "wasmtime_vm")]
 pub(crate) mod wasmtime {
     use super::str_eq;
-    use crate::logic::{ProtocolVersion, VMLogic, VMLogicError};
+    use crate::logic::{VMLogic, VMLogicError};
     use std::cell::UnsafeCell;
     use std::ffi::c_void;
 
@@ -671,13 +660,17 @@ pub(crate) mod wasmtime {
         static CALLER_CONTEXT: UnsafeCell<*mut c_void> = UnsafeCell::new(0 as *mut c_void);
     }
 
-    pub(crate) fn link(
+    pub(crate) fn link<'a, 'b>(
         linker: &mut wasmtime::Linker<()>,
         memory: wasmtime::Memory,
         store: &wasmtime::Store<()>,
-        raw_logic: *mut c_void,
-        protocol_version: ProtocolVersion,
+        logic: &'a mut VMLogic<'b>,
     ) {
+        // Unfortunately, due to the Wasmtime implementation we have to do tricks with the
+        // lifetimes of the logic instance and pass raw pointers here.
+        // FIXME(nagisa): I believe this is no longer required, we just need to look at this code
+        // again.
+        let raw_logic = logic as *mut _ as *mut c_void;
         CALLER_CONTEXT.with(|caller_context| unsafe { *caller_context.get() = raw_logic });
         linker.define(store, "env", "memory", memory).expect("cannot define memory");
 
@@ -717,7 +710,7 @@ pub(crate) mod wasmtime {
                 linker.func_wrap(stringify!($mod), stringify!($name), $name).expect("cannot link external");
             };
         }
-        for_each_available_import!(protocol_version, add_import);
+        for_each_available_import!(logic.config, add_import);
     }
 }
 

--- a/runtime/near-vm-runner/src/imports.rs
+++ b/runtime/near-vm-runner/src/imports.rs
@@ -319,7 +319,7 @@ pub(crate) mod wasmer2 {
     use std::sync::Arc;
 
     use super::str_eq;
-    use crate::logic::{VMLogic};
+    use crate::logic::VMLogic;
     use wasmer_engine::Engine;
     use wasmer_engine_universal::UniversalEngine;
     use wasmer_vm::{
@@ -464,12 +464,7 @@ pub(crate) mod wasmer2 {
             // contains this metadata.
             ExportFunctionMetadata::new(logic as *mut _ as *mut _, None, |ptr| ptr, |_| {})
         };
-        Wasmer2Imports {
-            memory,
-            vmlogic: logic,
-            metadata: Arc::new(metadata),
-            engine,
-        }
+        Wasmer2Imports { memory, vmlogic: logic, metadata: Arc::new(metadata), engine }
     }
 }
 
@@ -478,7 +473,7 @@ pub(crate) mod near_vm {
     use std::sync::Arc;
 
     use super::str_eq;
-    use crate::logic::{VMLogic};
+    use crate::logic::VMLogic;
     use near_vm_engine::universal::UniversalEngine;
     use near_vm_vm::{
         ExportFunction, ExportFunctionMetadata, Resolver, VMFunction, VMFunctionKind, VMMemory,
@@ -622,12 +617,7 @@ pub(crate) mod near_vm {
             // contains this metadata.
             ExportFunctionMetadata::new(logic as *mut _ as *mut _, None, |ptr| ptr, |_| {})
         };
-        NearVmImports {
-            memory,
-            vmlogic: logic,
-            metadata: Arc::new(metadata),
-            engine,
-        }
+        NearVmImports { memory, vmlogic: logic, metadata: Arc::new(metadata), engine }
     }
 }
 

--- a/runtime/near-vm-runner/src/logic/logic.rs
+++ b/runtime/near-vm-runner/src/logic/logic.rs
@@ -34,7 +34,7 @@ pub struct VMLogic<'a> {
     /// Part of Context API and Economics API that was extracted from the receipt.
     context: VMContext,
     /// All gas and economic parameters required during contract execution.
-    config: &'a Config,
+    pub(crate) config: &'a Config,
     /// Fees for creating (async) actions on runtime.
     fees_config: &'a RuntimeFeesConfig,
     /// If this method execution is invoked directly as a callback by one or more contract calls the

--- a/runtime/near-vm-runner/src/near_vm_runner.rs
+++ b/runtime/near-vm-runner/src/near_vm_runner.rs
@@ -5,7 +5,7 @@ use crate::logic::errors::{
     CacheError, CompilationError, FunctionCallError, MethodResolveError, VMRunnerError, WasmTrap,
 };
 use crate::logic::gas_counter::FastGasCounter;
-use crate::logic::types::{PromiseResult, ProtocolVersion};
+use crate::logic::types::PromiseResult;
 use crate::logic::{
     CompiledContract, CompiledContractCache, Config, External, MemSlice, MemoryLike, VMContext,
     VMLogic, VMOutcome,
@@ -664,7 +664,6 @@ impl crate::runner::VM for NearVM {
         context: VMContext,
         fees_config: &RuntimeFeesConfig,
         promise_results: &[PromiseResult],
-        current_protocol_version: ProtocolVersion,
         cache: Option<&dyn CompiledContractCache>,
     ) -> Result<VMOutcome, VMRunnerError> {
         let mut memory = NearVmMemory::new(
@@ -696,12 +695,7 @@ impl crate::runner::VM for NearVM {
         if let Err(e) = result {
             return Ok(VMOutcome::abort(logic, e));
         }
-        let import = imports::near_vm::build(
-            vmmemory,
-            &mut logic,
-            current_protocol_version,
-            artifact.engine(),
-        );
+        let import = imports::near_vm::build(vmmemory, &mut logic, artifact.engine());
         if let Err(e) = get_entrypoint_index(&*artifact, method_name) {
             return Ok(VMOutcome::abort_but_nop_outcome_in_old_protocol(logic, e));
         }

--- a/runtime/near-vm-runner/src/runner.rs
+++ b/runtime/near-vm-runner/src/runner.rs
@@ -75,7 +75,6 @@ pub fn run(
         context,
         fees_config,
         promise_results,
-        current_protocol_version,
         cache,
     )?;
 
@@ -106,7 +105,6 @@ pub trait VM {
         context: VMContext,
         fees_config: &RuntimeFeesConfig,
         promise_results: &[PromiseResult],
-        current_protocol_version: ProtocolVersion,
         cache: Option<&dyn CompiledContractCache>,
     ) -> VMResult;
 

--- a/runtime/near-vm-runner/src/runner.rs
+++ b/runtime/near-vm-runner/src/runner.rs
@@ -68,15 +68,8 @@ pub fn run(
         .runtime(wasm_config.clone())
         .unwrap_or_else(|| panic!("the {vm_kind:?} runtime has not been enabled at compile time"));
 
-    let outcome = runtime.run(
-        code,
-        method_name,
-        ext,
-        context,
-        fees_config,
-        promise_results,
-        cache,
-    )?;
+    let outcome =
+        runtime.run(code, method_name, ext, context, fees_config, promise_results, cache)?;
 
     span.record("burnt_gas", &outcome.burnt_gas);
     Ok(outcome)

--- a/runtime/near-vm-runner/src/tests.rs
+++ b/runtime/near-vm-runner/src/tests.rs
@@ -12,14 +12,11 @@ mod wasm_validation;
 use crate::config::ContractPrepareVersion;
 use crate::logic::{Config, VMContext};
 use crate::vm_kind::VMKind;
-use near_primitives_core::types::ProtocolVersion;
 
 const CURRENT_ACCOUNT_ID: &str = "alice";
 const SIGNER_ACCOUNT_ID: &str = "bob";
 const SIGNER_ACCOUNT_PK: [u8; 3] = [0, 1, 2];
 const PREDECESSOR_ACCOUNT_ID: &str = "carol";
-
-const LATEST_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::MAX;
 
 pub(crate) fn with_vm_variants(#[allow(unused)] cfg: &Config, runner: impl Fn(VMKind) -> ()) {
     #[cfg(all(feature = "wasmer0_vm", target_arch = "x86_64"))]

--- a/runtime/near-vm-runner/src/tests/cache.rs
+++ b/runtime/near-vm-runner/src/tests/cache.rs
@@ -1,7 +1,7 @@
 //! Tests that `CompiledContractCache` is working correctly. Currently testing only wasmer code, so disabled outside of x86_64
 #![cfg(target_arch = "x86_64")]
 
-use super::{create_context, with_vm_variants, LATEST_PROTOCOL_VERSION};
+use super::{create_context, with_vm_variants};
 use crate::internal::VMKind;
 use crate::logic::errors::VMRunnerError;
 use crate::logic::mocks::mock_external::MockedExternal;
@@ -96,7 +96,6 @@ fn make_cached_contract_call_vm(
         context,
         &fees,
         &promise_results,
-        LATEST_PROTOCOL_VERSION,
         Some(cache),
     )
 }

--- a/runtime/near-vm-runner/src/tests/fuzzers.rs
+++ b/runtime/near-vm-runner/src/tests/fuzzers.rs
@@ -126,7 +126,6 @@ fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMResult {
         context,
         &fees,
         &promise_results,
-        PROTOCOL_VERSION,
         None,
     );
 

--- a/runtime/near-vm-runner/src/tests/rs_contract.rs
+++ b/runtime/near-vm-runner/src/tests/rs_contract.rs
@@ -10,8 +10,8 @@ use std::mem::size_of;
 
 use crate::runner::VMResult;
 use crate::tests::{
-    create_context, with_vm_variants, CURRENT_ACCOUNT_ID, LATEST_PROTOCOL_VERSION,
-    PREDECESSOR_ACCOUNT_ID, SIGNER_ACCOUNT_ID, SIGNER_ACCOUNT_PK,
+    create_context, with_vm_variants, CURRENT_ACCOUNT_ID, PREDECESSOR_ACCOUNT_ID,
+    SIGNER_ACCOUNT_ID, SIGNER_ACCOUNT_PK,
 };
 use crate::vm_kind::VMKind;
 
@@ -60,7 +60,6 @@ pub fn test_read_write() {
             context,
             &fees,
             &promise_results,
-            LATEST_PROTOCOL_VERSION,
             None,
         );
         assert_run_result(result, 0);
@@ -73,7 +72,6 @@ pub fn test_read_write() {
             context,
             &fees,
             &promise_results,
-            LATEST_PROTOCOL_VERSION,
             None,
         );
         assert_run_result(result, 20);
@@ -127,7 +125,7 @@ fn run_test_ext(
     let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
 
     let outcome = runtime
-        .run(&code, method, &mut fake_external, context, &fees, &[], LATEST_PROTOCOL_VERSION, None)
+        .run(&code, method, &mut fake_external, context, &fees, &[], None)
         .unwrap_or_else(|err| panic!("Failed execution: {:?}", err));
 
     assert_eq!(outcome.profile.action_gas(), 0);
@@ -233,16 +231,7 @@ pub fn test_out_of_memory() {
 
         let promise_results = vec![];
         let result = runtime
-            .run(
-                &code,
-                "out_of_memory",
-                &mut fake_external,
-                context,
-                &fees,
-                &promise_results,
-                LATEST_PROTOCOL_VERSION,
-                None,
-            )
+            .run(&code, "out_of_memory", &mut fake_external, context, &fees, &promise_results, None)
             .expect("execution failed");
         assert_eq!(
             result.aborted,
@@ -281,7 +270,6 @@ fn attach_unspent_gas_but_use_all_gas() {
                 context.clone(),
                 &fees,
                 &[],
-                LATEST_PROTOCOL_VERSION,
                 None,
             )
             .unwrap_or_else(|err| panic!("Failed execution: {:?}", err));

--- a/runtime/near-vm-runner/src/tests/test_builder.rs
+++ b/runtime/near-vm-runner/src/tests/test_builder.rs
@@ -224,7 +224,6 @@ impl TestBuilder {
                         context,
                         &fees,
                         &promise_results,
-                        protocol_version,
                         None,
                     )
                     .expect("execution failed");

--- a/runtime/near-vm-runner/src/tests/ts_contract.rs
+++ b/runtime/near-vm-runner/src/tests/ts_contract.rs
@@ -5,7 +5,7 @@ use crate::logic::{Config, External, StorageGetMode};
 use crate::ContractCode;
 use near_primitives_core::runtime::fees::RuntimeFeesConfig;
 
-use crate::tests::{create_context, with_vm_variants, LATEST_PROTOCOL_VERSION};
+use crate::tests::{create_context, with_vm_variants};
 use crate::vm_kind::VMKind;
 
 #[test]
@@ -28,7 +28,6 @@ pub fn test_ts_contract() {
             context,
             &fees,
             &promise_results,
-            LATEST_PROTOCOL_VERSION,
             None,
         );
         let outcome = result.expect("execution failed");
@@ -49,7 +48,6 @@ pub fn test_ts_contract() {
                 context,
                 &fees,
                 &promise_results,
-                LATEST_PROTOCOL_VERSION,
                 None,
             )
             .expect("bad failure");
@@ -72,7 +70,6 @@ pub fn test_ts_contract() {
                 context,
                 &fees,
                 &promise_results,
-                LATEST_PROTOCOL_VERSION,
                 None,
             )
             .expect("execution failed");

--- a/runtime/near-vm-runner/src/wasmer2_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer2_runner.rs
@@ -5,7 +5,7 @@ use crate::logic::errors::{
     CacheError, CompilationError, FunctionCallError, MethodResolveError, VMRunnerError, WasmTrap,
 };
 use crate::logic::gas_counter::FastGasCounter;
-use crate::logic::types::{PromiseResult, ProtocolVersion};
+use crate::logic::types::PromiseResult;
 use crate::logic::{
     CompiledContract, CompiledContractCache, Config, External, MemSlice, MemoryLike, VMContext,
     VMLogic, VMOutcome,
@@ -567,7 +567,6 @@ impl crate::runner::VM for Wasmer2VM {
         context: VMContext,
         fees_config: &RuntimeFeesConfig,
         promise_results: &[PromiseResult],
-        current_protocol_version: ProtocolVersion,
         cache: Option<&dyn CompiledContractCache>,
     ) -> Result<VMOutcome, VMRunnerError> {
         let mut memory = Wasmer2Memory::new(
@@ -599,12 +598,7 @@ impl crate::runner::VM for Wasmer2VM {
         if let Err(e) = result {
             return Ok(VMOutcome::abort(logic, e));
         }
-        let import = imports::wasmer2::build(
-            vmmemory,
-            &mut logic,
-            current_protocol_version,
-            artifact.engine(),
-        );
+        let import = imports::wasmer2::build(vmmemory, &mut logic, artifact.engine());
         if let Err(e) = get_entrypoint_index(&*artifact, method_name) {
             return Ok(VMOutcome::abort_but_nop_outcome_in_old_protocol(logic, e));
         }

--- a/runtime/near-vm-runner/src/wasmer_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer_runner.rs
@@ -13,7 +13,6 @@ use crate::prepare;
 use crate::runner::VMResult;
 use crate::{get_contract_cache_key, imports, ContractCode};
 use near_primitives_core::runtime::fees::RuntimeFeesConfig;
-use near_primitives_core::types::ProtocolVersion;
 use wasmer_runtime::{ImportObject, Module};
 
 fn check_method(module: &Module, method_name: &str) -> Result<(), FunctionCallError> {
@@ -351,7 +350,6 @@ impl crate::runner::VM for Wasmer0VM {
         context: VMContext,
         fees_config: &RuntimeFeesConfig,
         promise_results: &[PromiseResult],
-        current_protocol_version: ProtocolVersion,
         cache: Option<&dyn CompiledContractCache>,
     ) -> Result<VMOutcome, VMRunnerError> {
         if !cfg!(target_arch = "x86") && !cfg!(target_arch = "x86_64") {
@@ -403,7 +401,7 @@ impl crate::runner::VM for Wasmer0VM {
         }
 
         let import_object =
-            imports::wasmer::build(memory_copy, &mut logic, current_protocol_version);
+            imports::wasmer::build(memory_copy, &mut logic);
 
         if let Err(e) = check_method(&module, method_name) {
             return Ok(VMOutcome::abort_but_nop_outcome_in_old_protocol(logic, e));

--- a/runtime/near-vm-runner/src/wasmer_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer_runner.rs
@@ -400,8 +400,7 @@ impl crate::runner::VM for Wasmer0VM {
             return Ok(VMOutcome::abort(logic, e));
         }
 
-        let import_object =
-            imports::wasmer::build(memory_copy, &mut logic);
+        let import_object = imports::wasmer::build(memory_copy, &mut logic);
 
         if let Err(e) = check_method(&module, method_name) {
             return Ok(VMOutcome::abort_but_nop_outcome_in_old_protocol(logic, e));

--- a/runtime/near-vm-runner/src/wasmtime_runner.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner.rs
@@ -195,12 +195,7 @@ impl crate::runner::VM for WasmtimeVM {
             return Ok(VMOutcome::abort(logic, e));
         }
 
-        imports::wasmtime::link(
-            &mut linker,
-            memory_copy,
-            &store,
-            &mut logic,
-        );
+        imports::wasmtime::link(&mut linker, memory_copy, &store, &mut logic);
         match module.get_export(method_name) {
             Some(export) => match export {
                 Func(func_type) => {

--- a/runtime/near-vm-runner/src/wasmtime_runner.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner.rs
@@ -11,10 +11,8 @@ use crate::logic::{
 };
 use crate::{imports, prepare, ContractCode};
 use near_primitives_core::runtime::fees::RuntimeFeesConfig;
-use near_primitives_core::types::ProtocolVersion;
 use std::borrow::Cow;
 use std::cell::RefCell;
-use std::ffi::c_void;
 use wasmtime::ExternType::Func;
 use wasmtime::{Engine, Linker, Memory, MemoryType, Module, Store};
 
@@ -161,7 +159,6 @@ impl crate::runner::VM for WasmtimeVM {
         context: VMContext,
         fees_config: &RuntimeFeesConfig,
         promise_results: &[PromiseResult],
-        current_protocol_version: ProtocolVersion,
         _cache: Option<&dyn CompiledContractCache>,
     ) -> Result<VMOutcome, VMRunnerError> {
         let mut config = self.default_wasmtime_config();
@@ -198,15 +195,11 @@ impl crate::runner::VM for WasmtimeVM {
             return Ok(VMOutcome::abort(logic, e));
         }
 
-        // Unfortunately, due to the Wasmtime implementation we have to do tricks with the
-        // lifetimes of the logic instance and pass raw pointers here.
-        let raw_logic = &mut logic as *mut _ as *mut c_void;
         imports::wasmtime::link(
             &mut linker,
             memory_copy,
             &store,
-            raw_logic,
-            current_protocol_version,
+            &mut logic,
         );
         match module.get_export(method_name) {
             Some(export) => match export {

--- a/runtime/runtime-params-estimator/src/costs_to_runtime_config.rs
+++ b/runtime/runtime-params-estimator/src/costs_to_runtime_config.rs
@@ -40,6 +40,10 @@ pub fn costs_to_runtime_config(cost_table: &CostTable) -> anyhow::Result<Runtime
             storage_get_mode: StorageGetMode::FlatStorage,
             fix_contract_loading_cost: false,
             implicit_account_creation: true,
+            math_extension: true,
+            ed25519_verify: true,
+            alt_bn128: true,
+            function_call_weight: true,
         },
         account_creation_config: AccountCreationConfig::default(),
     };

--- a/runtime/runtime-params-estimator/src/function_call.rs
+++ b/runtime/runtime-params-estimator/src/function_call.rs
@@ -86,7 +86,6 @@ fn compute_function_call_cost(
                 fake_context.clone(),
                 &fees,
                 &promise_results,
-                protocol_version,
                 cache,
             )
             .expect("fatal error");
@@ -103,7 +102,6 @@ fn compute_function_call_cost(
                 fake_context.clone(),
                 &fees,
                 &promise_results,
-                protocol_version,
                 cache,
             )
             .expect("fatal_error");

--- a/runtime/runtime-params-estimator/src/gas_metering.rs
+++ b/runtime/runtime-params-estimator/src/gas_metering.rs
@@ -150,7 +150,6 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
                 fake_context.clone(),
                 &fees,
                 &promise_results,
-                PROTOCOL_VERSION,
                 cache,
             )
             .expect("fatal_error");
@@ -171,7 +170,6 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
                 fake_context.clone(),
                 &fees,
                 &promise_results,
-                PROTOCOL_VERSION,
                 cache,
             )
             .expect("fatal_error");
@@ -189,7 +187,6 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
                 fake_context.clone(),
                 &fees,
                 &promise_results,
-                PROTOCOL_VERSION,
                 cache,
             )
             .expect("fatal_error");
@@ -207,7 +204,6 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
                 fake_context.clone(),
                 &fees,
                 &promise_results,
-                PROTOCOL_VERSION,
                 cache,
             )
             .expect("fatal_error");

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -99,7 +99,6 @@ use near_primitives::transaction::{
     DeployContractAction, SignedTransaction, StakeAction, TransferAction,
 };
 use near_primitives::types::AccountId;
-use near_primitives::version::PROTOCOL_VERSION;
 use near_vm_runner::logic::mocks::mock_external::MockedExternal;
 use near_vm_runner::logic::Config as VMConfig;
 use near_vm_runner::ContractCode;
@@ -885,7 +884,6 @@ fn wasm_instruction(ctx: &mut EstimatorContext) -> GasCost {
                 context,
                 &fees,
                 &promise_results,
-                PROTOCOL_VERSION,
                 Some(&cache),
             )
             .expect("fatal_error");


### PR DESCRIPTION
I had entirely forgotten/missed that this was still using protocol versioning rather than configs to control availability of host functions for the contracts. This hopefully should be the last place where we truly depend on them (outside of tests?)