### PR TITLE
feat(state-sync) config to override state sync peers

### DIFF
--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -642,7 +642,7 @@ pub fn display_sync_status(
                 write!(res, "[{}: {}]", shard_id, shard_status.status.to_string(),).unwrap();
             }
             match state_sync_config {
-                SyncConfig::Peers => {
+                SyncConfig::Peers(_) => {
                     tracing::warn!(
                         target: "stats",
                         "The node is trying to sync its State from its peers. The current implementation of this mechanism is known to be unreliable. It may never complete, or fail randomly and corrupt the DB.\n\

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -83,6 +83,13 @@ fn default_num_concurrent_requests_during_catchup() -> u32 {
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+pub struct PeersConfig {
+    /// Only download state from these peers.
+    #[serde(default)]
+    pub allowed_peers: Vec<String>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct ExternalStorageConfig {
     /// Location of state parts.
     pub location: ExternalStorageLocation,
@@ -131,14 +138,14 @@ pub struct DumpConfig {
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub enum SyncConfig {
     /// Syncs state from the peers without reading anything from external storage.
-    Peers,
+    Peers(PeersConfig),
     /// Expects parts to be available in external storage.
     ExternalStorage(ExternalStorageConfig),
 }
 
 impl Default for SyncConfig {
     fn default() -> Self {
-        Self::Peers
+        Self::Peers(PeersConfig { allowed_peers: vec![] })
     }
 }
 
@@ -155,7 +162,10 @@ pub struct StateSyncConfig {
 impl SyncConfig {
     /// Checks whether the object equals its default value.
     fn is_default(&self) -> bool {
-        matches!(self, Self::Peers)
+        match self {
+            SyncConfig::Peers(PeersConfig { allowed_peers }) => allowed_peers.is_empty(),
+            SyncConfig::ExternalStorage(_) => false,
+        }
     }
 }
 

--- a/core/chain-configs/src/lib.rs
+++ b/core/chain-configs/src/lib.rs
@@ -7,7 +7,7 @@ mod updateable_config;
 
 pub use client_config::{
     ClientConfig, DumpConfig, ExternalStorageConfig, ExternalStorageLocation, GCConfig,
-    LogSummaryStyle, StateSyncConfig, SyncConfig, DEFAULT_GC_NUM_EPOCHS_TO_KEEP,
+    LogSummaryStyle, PeersConfig, StateSyncConfig, SyncConfig, DEFAULT_GC_NUM_EPOCHS_TO_KEEP,
     MIN_GC_NUM_EPOCHS_TO_KEEP, TEST_STATE_SYNC_TIMEOUT,
 };
 pub use genesis_config::{

--- a/nearcore/src/config_validate.rs
+++ b/nearcore/src/config_validate.rs
@@ -111,7 +111,7 @@ impl<'a> ConfigValidator<'a> {
                 }
             }
             match &state_sync.sync {
-                SyncConfig::Peers => {}
+                SyncConfig::Peers(_) => {}
                 SyncConfig::ExternalStorage(config) => {
                     match &config.location {
                         ExternalStorageLocation::S3 { bucket, region } => {


### PR DESCRIPTION
Specify the nodes that we can download state from. This will help us defining test scenarios. Nodes need to be connected so we need to add them to the `boot_nodes` in config.

```
"state_sync_enabled": true,
  "state_sync": {
    "sync": {
       "Peers": {
        "allowed_peers": [
           "<peer addr>"
         ]
       }
    }
  },
...
"network": {
    "boot_nodes": "<peer addr>"
    ...
}
```

Node was able to sync form a peer. https://nearinc.grafana.net/goto/33br-FkSg?orgId=1
