### PR TITLE
Fix: adding public queue to buildkite pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,6 +13,7 @@ steps:
 
     agents:
       - "distro=amazonlinux"
+      - "queue=default-public"
 
   - label: "cargo test integration-tests*"
     command: |
@@ -22,6 +23,7 @@ steps:
 
     agents:
       - "distro=amazonlinux"
+      - "queue=default-public"
     branches: "!master"
 
   - label: "cargo test not integration-tests*"
@@ -32,6 +34,7 @@ steps:
 
     agents:
       - "distro=amazonlinux"
+      - "queue=default-public"
     branches: "!master"
 
   - label: "cargo test nightly integration-tests*"
@@ -42,6 +45,7 @@ steps:
 
     agents:
       - "distro=amazonlinux"
+      - "queue=default-public"
     branches: "!master"
 
   - label: "cargo test nightly not integration-tests*"
@@ -53,6 +57,7 @@ steps:
 
     agents:
       - "distro=amazonlinux"
+      - "queue=default-public"
     branches: "!master"
 
   - label: "sanity checks"
@@ -100,6 +105,7 @@ steps:
       fi >&2
     agents:
       - "distro=amazonlinux"
+      - "queue=default-public"
     branches: "!master"
 
   - label: "backward compatible"
@@ -114,6 +120,7 @@ steps:
     branches: "!master !beta !stable"
     agents:
       - "distro=amazonlinux"
+      - "queue=default-public"
 
   - label: "upgradable"
     command: |
@@ -124,6 +131,7 @@ steps:
     branches: "!master"
     agents:
       - "distro=amazonlinux"
+      - "queue=default-public"
 
   - label: "db migration"
     command: |
@@ -134,3 +142,4 @@ steps:
     branches: "!master !beta !stable"
     agents:
       - "distro=amazonlinux"
+      - "queue=default-public"


### PR DESCRIPTION
This change will specify buildkite pipeline to use default-public agents.