### PR TITLE
fix: add debug page css routing

### DIFF
--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -1504,15 +1504,20 @@ async fn display_debug_html(
 
     let content = match page_name.as_str() {
         "last_blocks" => Some(debug_page_string!("last_blocks.html", handler)),
+        "last_blocks.css" => Some(debug_page_string!("last_blocks.css", handler)),
         "last_blocks.js" => Some(debug_page_string!("last_blocks.js", handler)),
         "network_info" => Some(debug_page_string!("network_info.html", handler)),
         "network_info.css" => Some(debug_page_string!("network_info.css", handler)),
         "network_info.js" => Some(debug_page_string!("network_info.js", handler)),
         "tier1_network_info" => Some(debug_page_string!("tier1_network_info.html", handler)),
         "epoch_info" => Some(debug_page_string!("epoch_info.html", handler)),
+        "epoch_info.css" => Some(debug_page_string!("epoch_info.css", handler)),
         "chain_n_chunk_info" => Some(debug_page_string!("chain_n_chunk_info.html", handler)),
+        "chain_n_chunk_info.css" => Some(debug_page_string!("chain_n_chunk_info.css", handler)),
         "sync" => Some(debug_page_string!("sync.html", handler)),
+        "sync.css" => Some(debug_page_string!("sync.css", handler)),
         "validator" => Some(debug_page_string!("validator.html", handler)),
+        "validator.css" => Some(debug_page_string!("validator.css", handler)),
         _ => None,
     };
 


### PR DESCRIPTION
css was moved to separate files in https://github.com/near/nearcore/pull/9472 but it isn't properly routed, so [the debug page is broken](https://github.com/near/nearcore/pull/9472#issuecomment-1708795219). 