### PR TITLE
ci: retry flaky test_mock_node_basic

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -4,3 +4,7 @@ slow-timeout = { period = "60s", terminate-after = 2, grace-period = "0s" }
 [[profile.default.overrides]]
 filter = 'test(test_full_estimator)'
 slow-timeout = { period = "10m", terminate-after = 3 }
+
+[[profile.ci.overrides]]
+filter = 'test(test_mock_node_basic)'
+retries = 5


### PR DESCRIPTION
This test is currently very flaky and fails more often than not in CI.

I cannot reproduce it locally even once. Just running all tests together, like in CI, does not work for me locally. Probably it would require some CPU torture running at the same time to make my machine slow enough.

Giving 5 retries makes the chance of passing CI higher. (With merge queues enabled, we must get lucky twice in a row to get passed a flaky test.)