### PR TITLE
feat: make the resharding tests more deterministic

### DIFF
--- a/core/store/src/test_utils.rs
+++ b/core/store/src/test_utils.rs
@@ -135,7 +135,7 @@ pub fn test_populate_store_rc(store: &Store, data: &[(DBCol, Vec<u8>, Vec<u8>)])
     update.commit().expect("db commit failed");
 }
 
-fn gen_accounts_from_alphabet(
+pub fn gen_accounts_from_alphabet(
     rng: &mut impl Rng,
     min_size: usize,
     max_size: usize,

--- a/core/store/src/test_utils.rs
+++ b/core/store/src/test_utils.rs
@@ -135,7 +135,7 @@ pub fn test_populate_store_rc(store: &Store, data: &[(DBCol, Vec<u8>, Vec<u8>)])
     update.commit().expect("db commit failed");
 }
 
-pub fn gen_accounts_from_alphabet(
+fn gen_accounts_from_alphabet(
     rng: &mut impl Rng,
     min_size: usize,
     max_size: usize,

--- a/core/store/src/test_utils.rs
+++ b/core/store/src/test_utils.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use near_primitives::state::{FlatStateValue, ValueRef};
@@ -153,8 +153,11 @@ pub fn gen_account(rng: &mut impl Rng, alphabet: &[u8]) -> AccountId {
 
 pub fn gen_unique_accounts(rng: &mut impl Rng, min_size: usize, max_size: usize) -> Vec<AccountId> {
     let alphabet = b"abcdefghijklmn";
-    let accounts = gen_accounts_from_alphabet(rng, min_size, max_size, alphabet);
-    accounts.into_iter().collect::<HashSet<_>>().into_iter().collect()
+    let mut accounts = gen_accounts_from_alphabet(rng, min_size, max_size, alphabet);
+    accounts.sort();
+    accounts.dedup();
+    accounts.shuffle(rng);
+    accounts
 }
 
 pub fn gen_receipts(rng: &mut impl Rng, max_size: usize) -> Vec<Receipt> {

--- a/integration-tests/src/tests/client/sharding_upgrade.rs
+++ b/integration-tests/src/tests/client/sharding_upgrade.rs
@@ -2,6 +2,7 @@ use borsh::BorshSerialize;
 use near_client::{Client, ProcessTxResponse};
 use near_primitives::epoch_manager::{AllEpochConfig, EpochConfig};
 use near_primitives_core::num_rational::Rational32;
+use rand::rngs::StdRng;
 
 use crate::tests::client::process_blocks::set_block_protocol_version;
 use assert_matches::assert_matches;
@@ -30,7 +31,7 @@ use near_store::test_utils::{gen_account, gen_unique_accounts};
 use nearcore::config::GenesisExt;
 use nearcore::NEAR_BASE;
 use rand::seq::{IteratorRandom, SliceRandom};
-use rand::{thread_rng, Rng};
+use rand::{thread_rng, Rng, SeedableRng};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 use tracing::debug;
@@ -95,23 +96,6 @@ fn get_expected_shards_num(
     };
 }
 
-/// Test environment prepared for testing the sharding upgrade.
-/// Epoch 0, blocks 1-5  : genesis shard layout
-/// Epoch 1, blocks 6-10 : genesis shard layout, state split happens
-/// Epoch 2: blocks 10-15: target shard layout, shard layout is upgraded
-/// Epoch 3: blocks 16-20: target shard layout,
-///
-/// Note: if the test is extended to more epochs, garbage collection will
-/// kick in and delete data that is checked at the end of the test.
-struct TestShardUpgradeEnv {
-    env: TestEnv,
-    initial_accounts: Vec<AccountId>,
-    init_txs: Vec<SignedTransaction>,
-    txs_by_height: BTreeMap<u64, Vec<SignedTransaction>>,
-    epoch_length: u64,
-    num_clients: usize,
-}
-
 /// The condition that determines if a chunk should be produced of dropped.
 /// Can be probabilistic, predefined based on height and shard id or both.
 struct DropChunkCondition {
@@ -168,6 +152,24 @@ impl DropChunkCondition {
     }
 }
 
+/// Test environment prepared for testing the sharding upgrade.
+/// Epoch 0, blocks 1-5  : genesis shard layout
+/// Epoch 1, blocks 6-10 : genesis shard layout, state split happens
+/// Epoch 2: blocks 10-15: target shard layout, shard layout is upgraded
+/// Epoch 3: blocks 16-20: target shard layout,
+///
+/// Note: if the test is extended to more epochs, garbage collection will
+/// kick in and delete data that is checked at the end of the test.
+struct TestShardUpgradeEnv {
+    env: TestEnv,
+    initial_accounts: Vec<AccountId>,
+    init_txs: Vec<SignedTransaction>,
+    txs_by_height: BTreeMap<u64, Vec<SignedTransaction>>,
+    epoch_length: u64,
+    num_clients: usize,
+    rng: StdRng,
+}
+
 impl TestShardUpgradeEnv {
     fn new(
         epoch_length: u64,
@@ -176,8 +178,9 @@ impl TestShardUpgradeEnv {
         num_init_accounts: usize,
         gas_limit: Option<u64>,
         genesis_protocol_version: ProtocolVersion,
+        rng_seed: u64,
     ) -> Self {
-        let mut rng = thread_rng();
+        let mut rng = SeedableRng::seed_from_u64(rng_seed);
         let validators: Vec<AccountId> =
             (0..num_validators).map(|i| format!("test{}", i).parse().unwrap()).collect();
         let other_accounts = gen_unique_accounts(&mut rng, num_init_accounts, num_init_accounts);
@@ -205,6 +208,7 @@ impl TestShardUpgradeEnv {
             num_clients,
             init_txs: vec![],
             txs_by_height: BTreeMap::new(),
+            rng,
         }
     }
 
@@ -754,7 +758,7 @@ fn setup_genesis(
 }
 
 fn generate_create_accounts_txs(
-    mut rng: &mut rand::rngs::ThreadRng,
+    mut rng: &mut StdRng,
     genesis_hash: CryptoHash,
     initial_accounts: &Vec<AccountId>,
     accounts_to_check: &mut Vec<AccountId>,
@@ -799,19 +803,17 @@ fn generate_create_accounts_txs(
     .collect()
 }
 
-fn test_shard_layout_upgrade_simple_impl(resharding_type: ReshardingType) {
+fn test_shard_layout_upgrade_simple_impl(resharding_type: ReshardingType, rng_seed: u64) {
     init_test_logger();
     tracing::info!(target: "test", "test_shard_layout_upgrade_simple_impl starting");
 
     let genesis_protocol_version = get_genesis_protocol_version(&resharding_type);
     let target_protocol_version = get_target_protocol_version(&resharding_type);
 
-    let mut rng = thread_rng();
-
     // setup
     let epoch_length = 5;
     let mut test_env =
-        TestShardUpgradeEnv::new(epoch_length, 2, 2, 100, None, genesis_protocol_version);
+        TestShardUpgradeEnv::new(epoch_length, 2, 2, 100, None, genesis_protocol_version, rng_seed);
     test_env.set_init_tx(vec![]);
 
     let mut nonce = 100;
@@ -819,23 +821,33 @@ fn test_shard_layout_upgrade_simple_impl(resharding_type: ReshardingType) {
     let mut all_accounts: HashSet<_> = test_env.initial_accounts.clone().into_iter().collect();
     let mut accounts_to_check: Vec<_> = vec![];
     let initial_accounts = test_env.initial_accounts.clone();
-    let generate_create_accounts_txs: &mut dyn FnMut(usize, bool) -> Vec<SignedTransaction> =
-        &mut |max_size: usize, check_accounts: bool| -> Vec<SignedTransaction> {
-            generate_create_accounts_txs(
-                &mut rng,
-                genesis_hash,
-                &initial_accounts,
-                &mut accounts_to_check,
-                &mut all_accounts,
-                &mut nonce,
-                max_size,
-                check_accounts,
-            )
-        };
+    // let generate_create_accounts_txs: &mut dyn FnMut(usize, bool) -> Vec<SignedTransaction> =
+    //     &mut |max_size: usize, check_accounts: bool| -> Vec<SignedTransaction> {
+    //         generate_create_accounts_txs(
+    //             &mut test_env.rng,
+    //             genesis_hash,
+    //             &initial_accounts,
+    //             &mut accounts_to_check,
+    //             &mut all_accounts,
+    //             &mut nonce,
+    //             max_size,
+    //             check_accounts,
+    //         )
+    //     };
 
     // add transactions until after sharding upgrade finishes
     for height in 2..3 * epoch_length {
-        let txs = generate_create_accounts_txs(10, true);
+        let txs = generate_create_accounts_txs(
+            &mut test_env.rng,
+            genesis_hash,
+            &initial_accounts,
+            &mut accounts_to_check,
+            &mut all_accounts,
+            &mut nonce,
+            10,
+            true,
+        );
+
         test_env.set_tx_at_height(height, txs);
     }
 
@@ -854,13 +866,13 @@ fn test_shard_layout_upgrade_simple_impl(resharding_type: ReshardingType) {
 
 #[test]
 fn test_shard_layout_upgrade_simple_v1() {
-    test_shard_layout_upgrade_simple_impl(ReshardingType::V1);
+    test_shard_layout_upgrade_simple_impl(ReshardingType::V1, 42);
 }
 
 #[cfg(feature = "protocol_feature_simple_nightshade_v2")]
 #[test]
 fn test_shard_layout_upgrade_simple_v2() {
-    test_shard_layout_upgrade_simple_impl(ReshardingType::V2);
+    test_shard_layout_upgrade_simple_impl(ReshardingType::V2, 42);
 }
 
 const GAS_1: u64 = 300_000_000_000_000;
@@ -931,23 +943,13 @@ fn gen_cross_contract_transaction(
 
 /// Return test_env and a map from tx hash to the new account that will be added by this transaction
 fn setup_test_env_with_cross_contract_txs(
+    test_env: &mut TestShardUpgradeEnv,
     epoch_length: u64,
-    genesis_protocol_version: ProtocolVersion,
-) -> (TestShardUpgradeEnv, HashMap<CryptoHash, AccountId>) {
-    let mut test_env = TestShardUpgradeEnv::new(
-        epoch_length,
-        4,
-        4,
-        100,
-        Some(100_000_000_000_000),
-        genesis_protocol_version,
-    );
-    let mut rng = thread_rng();
-
+) -> HashMap<CryptoHash, AccountId> {
     let genesis_hash = *test_env.env.clients[0].chain.genesis_block().hash();
     // Use test0, test1 and two random accounts to deploy contracts because we want accounts on
     // different shards.
-    let indices = (4..test_env.initial_accounts.len()).choose_multiple(&mut rng, 2);
+    let indices = (4..test_env.initial_accounts.len()).choose_multiple(&mut test_env.rng, 2);
     let contract_accounts = vec![
         test_env.initial_accounts[0].clone(),
         test_env.initial_accounts[1].clone(),
@@ -1026,17 +1028,20 @@ fn setup_test_env_with_cross_contract_txs(
     // but do not add too many because I want all transactions to
     // finish processing before epoch 5
     for height in 2 * epoch_length + 1..3 * epoch_length {
-        if rng.gen_bool(0.3) {
+        if test_env.rng.gen_bool(0.3) {
             test_env.set_tx_at_height(height, generate_txs(5, 8));
         }
     }
 
-    (test_env, new_accounts)
+    new_accounts
 }
 
 // Test cross contract calls
 // This test case tests postponed receipts and delayed receipts
-fn test_shard_layout_upgrade_cross_contract_calls_impl(resharding_type: ReshardingType) {
+fn test_shard_layout_upgrade_cross_contract_calls_impl(
+    resharding_type: ReshardingType,
+    rng_seed: u64,
+) {
     init_test_logger();
 
     // setup
@@ -1044,8 +1049,17 @@ fn test_shard_layout_upgrade_cross_contract_calls_impl(resharding_type: Reshardi
     let genesis_protocol_version = get_genesis_protocol_version(&resharding_type);
     let target_protocol_version = get_target_protocol_version(&resharding_type);
 
-    let (mut test_env, new_accounts) =
-        setup_test_env_with_cross_contract_txs(epoch_length, genesis_protocol_version);
+    let mut test_env = TestShardUpgradeEnv::new(
+        epoch_length,
+        4,
+        4,
+        100,
+        Some(100_000_000_000_000),
+        genesis_protocol_version,
+        rng_seed,
+    );
+
+    let new_accounts = setup_test_env_with_cross_contract_txs(&mut test_env, epoch_length);
 
     let drop_chunk_condition = DropChunkCondition::new();
     for _ in 1..5 * epoch_length {
@@ -1066,7 +1080,7 @@ fn test_shard_layout_upgrade_cross_contract_calls_impl(resharding_type: Reshardi
 // This test case tests postponed receipts and delayed receipts
 #[test]
 fn test_shard_layout_upgrade_cross_contract_calls_v1() {
-    test_shard_layout_upgrade_cross_contract_calls_impl(ReshardingType::V1);
+    test_shard_layout_upgrade_cross_contract_calls_impl(ReshardingType::V1, 42);
 }
 
 // Test cross contract calls
@@ -1074,10 +1088,13 @@ fn test_shard_layout_upgrade_cross_contract_calls_v1() {
 #[cfg(feature = "protocol_feature_simple_nightshade_v2")]
 #[test]
 fn test_shard_layout_upgrade_cross_contract_calls_v2() {
-    test_shard_layout_upgrade_cross_contract_calls_impl(ReshardingType::V2);
+    test_shard_layout_upgrade_cross_contract_calls_impl(ReshardingType::V2, 42);
 }
 
-fn test_shard_layout_upgrade_incoming_receipts_impl(resharding_type: ReshardingType) {
+fn test_shard_layout_upgrade_incoming_receipts_impl(
+    resharding_type: ReshardingType,
+    rng_seed: u64,
+) {
     init_test_logger();
 
     // setup
@@ -1085,8 +1102,17 @@ fn test_shard_layout_upgrade_incoming_receipts_impl(resharding_type: ReshardingT
     let genesis_protocol_version = get_genesis_protocol_version(&resharding_type);
     let target_protocol_version = get_target_protocol_version(&resharding_type);
 
-    let (mut test_env, new_accounts) =
-        setup_test_env_with_cross_contract_txs(epoch_length, genesis_protocol_version);
+    let mut test_env = TestShardUpgradeEnv::new(
+        epoch_length,
+        4,
+        4,
+        100,
+        Some(100_000_000_000_000),
+        genesis_protocol_version,
+        rng_seed,
+    );
+
+    let new_accounts = setup_test_env_with_cross_contract_txs(&mut test_env, epoch_length);
 
     // Drop one of the chunks in the last block before switching to the new
     // shard layout.
@@ -1120,7 +1146,7 @@ fn test_shard_layout_upgrade_incoming_receipts_impl(resharding_type: ReshardingT
 // receipts at all.
 #[test]
 fn test_shard_layout_upgrade_incoming_receipts_impl_v1() {
-    test_shard_layout_upgrade_incoming_receipts_impl(ReshardingType::V1);
+    test_shard_layout_upgrade_incoming_receipts_impl(ReshardingType::V1, 42);
 }
 
 // TODO(resharding) Add another test like this but drop more chunks and at
@@ -1129,22 +1155,31 @@ fn test_shard_layout_upgrade_incoming_receipts_impl_v1() {
 #[cfg(feature = "protocol_feature_simple_nightshade_v2")]
 #[test]
 fn test_shard_layout_upgrade_incoming_receipts_impl_v2() {
-    test_shard_layout_upgrade_incoming_receipts_impl(ReshardingType::V2);
+    test_shard_layout_upgrade_incoming_receipts_impl(ReshardingType::V2, 42);
 }
 
 // Test cross contract calls
 // This test case tests when there are missing chunks in the produced blocks
 // This is to test that all the chunk management logic in sharding split is correct
-fn test_shard_layout_upgrade_missing_chunks(p_missing: f64) {
+fn test_shard_layout_upgrade_missing_chunks(p_missing: f64, rng_seed: u64) {
     init_test_logger();
 
     let resharding_type = ReshardingType::V1;
     let genesis_protocol_version = get_genesis_protocol_version(&resharding_type);
+    let epoch_length = 10;
+
+    let mut test_env = TestShardUpgradeEnv::new(
+        epoch_length,
+        4,
+        4,
+        100,
+        Some(100_000_000_000_000),
+        genesis_protocol_version,
+        rng_seed,
+    );
 
     // setup
-    let epoch_length = 10;
-    let (mut test_env, new_accounts) =
-        setup_test_env_with_cross_contract_txs(epoch_length, genesis_protocol_version);
+    let new_accounts = setup_test_env_with_cross_contract_txs(&mut test_env, epoch_length);
 
     // randomly dropping chunks at the first few epochs when sharding splits happens
     // make sure initial txs (deploy smart contracts) are processed succesfully
@@ -1184,17 +1219,17 @@ fn test_shard_layout_upgrade_missing_chunks(p_missing: f64) {
 
 #[test]
 fn test_shard_layout_upgrade_missing_chunks_low_missing_prob() {
-    test_shard_layout_upgrade_missing_chunks(0.1);
+    test_shard_layout_upgrade_missing_chunks(0.1, 42);
 }
 
 #[test]
 fn test_shard_layout_upgrade_missing_chunks_mid_missing_prob() {
-    test_shard_layout_upgrade_missing_chunks(0.5);
+    test_shard_layout_upgrade_missing_chunks(0.5, 42);
 }
 
 #[test]
 fn test_shard_layout_upgrade_missing_chunks_high_missing_prob() {
-    test_shard_layout_upgrade_missing_chunks(0.9);
+    test_shard_layout_upgrade_missing_chunks(0.9, 42);
 }
 
 // TODO(resharding) add a test with missing blocks

--- a/integration-tests/src/tests/client/sharding_upgrade.rs
+++ b/integration-tests/src/tests/client/sharding_upgrade.rs
@@ -863,6 +863,22 @@ fn test_shard_layout_upgrade_simple_v2() {
 const GAS_1: u64 = 300_000_000_000_000;
 const GAS_2: u64 = GAS_1 / 3;
 
+fn create_test_env_for_cross_contract_test(
+    genesis_protocol_version: ProtocolVersion,
+    epoch_length: u64,
+    rng_seed: u64,
+) -> TestShardUpgradeEnv {
+    TestShardUpgradeEnv::new(
+        epoch_length,
+        4,
+        4,
+        100,
+        Some(100_000_000_000_000),
+        genesis_protocol_version,
+        rng_seed,
+    )
+}
+
 /// Return test_env and a map from tx hash to the new account that will be added by this transaction
 fn setup_test_env_with_cross_contract_txs(
     test_env: &mut TestShardUpgradeEnv,
@@ -1083,15 +1099,8 @@ fn test_shard_layout_upgrade_cross_contract_calls_impl(
     let genesis_protocol_version = get_genesis_protocol_version(&resharding_type);
     let target_protocol_version = get_target_protocol_version(&resharding_type);
 
-    let mut test_env = TestShardUpgradeEnv::new(
-        epoch_length,
-        4,
-        4,
-        100,
-        Some(100_000_000_000_000),
-        genesis_protocol_version,
-        rng_seed,
-    );
+    let mut test_env =
+        create_test_env_for_cross_contract_test(genesis_protocol_version, epoch_length, rng_seed);
 
     let new_accounts = setup_test_env_with_cross_contract_txs(&mut test_env, epoch_length);
 
@@ -1136,15 +1145,8 @@ fn test_shard_layout_upgrade_incoming_receipts_impl(
     let genesis_protocol_version = get_genesis_protocol_version(&resharding_type);
     let target_protocol_version = get_target_protocol_version(&resharding_type);
 
-    let mut test_env = TestShardUpgradeEnv::new(
-        epoch_length,
-        4,
-        4,
-        100,
-        Some(100_000_000_000_000),
-        genesis_protocol_version,
-        rng_seed,
-    );
+    let mut test_env =
+        create_test_env_for_cross_contract_test(genesis_protocol_version, epoch_length, rng_seed);
 
     let new_accounts = setup_test_env_with_cross_contract_txs(&mut test_env, epoch_length);
 
@@ -1202,15 +1204,8 @@ fn test_shard_layout_upgrade_missing_chunks(p_missing: f64, rng_seed: u64) {
     let genesis_protocol_version = get_genesis_protocol_version(&resharding_type);
     let epoch_length = 10;
 
-    let mut test_env = TestShardUpgradeEnv::new(
-        epoch_length,
-        4,
-        4,
-        100,
-        Some(100_000_000_000_000),
-        genesis_protocol_version,
-        rng_seed,
-    );
+    let mut test_env =
+        create_test_env_for_cross_contract_test(genesis_protocol_version, epoch_length, rng_seed);
 
     // setup
     let new_accounts = setup_test_env_with_cross_contract_txs(&mut test_env, epoch_length);

--- a/integration-tests/src/tests/client/sharding_upgrade.rs
+++ b/integration-tests/src/tests/client/sharding_upgrade.rs
@@ -185,7 +185,6 @@ impl TestShardUpgradeEnv {
             (0..num_validators).map(|i| format!("test{}", i).parse().unwrap()).collect();
         let other_accounts = gen_unique_accounts(&mut rng, num_init_accounts, num_init_accounts);
         let initial_accounts = [validators, other_accounts].concat();
-        tracing::info!(?initial_accounts, "boom initial accounts");
         let genesis = setup_genesis(
             epoch_length,
             num_validators as u64,
@@ -857,8 +856,20 @@ fn test_shard_layout_upgrade_simple_v1() {
 
 #[cfg(feature = "protocol_feature_simple_nightshade_v2")]
 #[test]
-fn test_shard_layout_upgrade_simple_v2() {
+fn test_shard_layout_upgrade_simple_v2_seed_42() {
     test_shard_layout_upgrade_simple_impl(ReshardingType::V2, 42);
+}
+
+#[cfg(feature = "protocol_feature_simple_nightshade_v2")]
+#[test]
+fn test_shard_layout_upgrade_simple_v2_seed_43() {
+    test_shard_layout_upgrade_simple_impl(ReshardingType::V2, 43);
+}
+
+#[cfg(feature = "protocol_feature_simple_nightshade_v2")]
+#[test]
+fn test_shard_layout_upgrade_simple_v2_seed_44() {
+    test_shard_layout_upgrade_simple_impl(ReshardingType::V2, 44);
 }
 
 const GAS_1: u64 = 300_000_000_000_000;
@@ -1020,7 +1031,7 @@ fn generate_cross_contract_tx(
         &genesis_hash,
     );
     new_accounts.insert(tx.get_hash(), account_id);
-    tracing::trace!(target: "test", tx=?tx.get_hash(), contract_accounts=?contract_accounts[..4], "generated tx");
+    tracing::trace!(target: "test", tx=?tx.get_hash(), "generated tx");
     Some(tx)
 }
 
@@ -1131,8 +1142,24 @@ fn test_shard_layout_upgrade_cross_contract_calls_v1() {
 // This test case tests postponed receipts and delayed receipts
 #[cfg(feature = "protocol_feature_simple_nightshade_v2")]
 #[test]
-fn test_shard_layout_upgrade_cross_contract_calls_v2() {
+fn test_shard_layout_upgrade_cross_contract_calls_v2_seed_42() {
     test_shard_layout_upgrade_cross_contract_calls_impl(ReshardingType::V2, 42);
+}
+
+// Test cross contract calls
+// This test case tests postponed receipts and delayed receipts
+#[cfg(feature = "protocol_feature_simple_nightshade_v2")]
+#[test]
+fn test_shard_layout_upgrade_cross_contract_calls_v2_seed_43() {
+    test_shard_layout_upgrade_cross_contract_calls_impl(ReshardingType::V2, 43);
+}
+
+// Test cross contract calls
+// This test case tests postponed receipts and delayed receipts
+#[cfg(feature = "protocol_feature_simple_nightshade_v2")]
+#[test]
+fn test_shard_layout_upgrade_cross_contract_calls_v2_seed_44() {
+    test_shard_layout_upgrade_cross_contract_calls_impl(ReshardingType::V2, 44);
 }
 
 fn test_shard_layout_upgrade_incoming_receipts_impl(
@@ -1191,8 +1218,20 @@ fn test_shard_layout_upgrade_incoming_receipts_impl_v1() {
 // are missing in block but can likely be adjusted for this case.
 #[cfg(feature = "protocol_feature_simple_nightshade_v2")]
 #[test]
-fn test_shard_layout_upgrade_incoming_receipts_impl_v2() {
+fn test_shard_layout_upgrade_incoming_receipts_impl_v2_seed_42() {
     test_shard_layout_upgrade_incoming_receipts_impl(ReshardingType::V2, 42);
+}
+
+#[cfg(feature = "protocol_feature_simple_nightshade_v2")]
+#[test]
+fn test_shard_layout_upgrade_incoming_receipts_impl_v2_seed_43() {
+    test_shard_layout_upgrade_incoming_receipts_impl(ReshardingType::V2, 43);
+}
+
+#[cfg(feature = "protocol_feature_simple_nightshade_v2")]
+#[test]
+fn test_shard_layout_upgrade_incoming_receipts_impl_v2_seed_44() {
+    test_shard_layout_upgrade_incoming_receipts_impl(ReshardingType::V2, 44);
 }
 
 // Test cross contract calls

--- a/integration-tests/src/tests/client/sharding_upgrade.rs
+++ b/integration-tests/src/tests/client/sharding_upgrade.rs
@@ -31,7 +31,7 @@ use near_store::test_utils::{gen_account, gen_unique_accounts};
 use nearcore::config::GenesisExt;
 use nearcore::NEAR_BASE;
 use rand::seq::{IteratorRandom, SliceRandom};
-use rand::{Rng, RngCore, SeedableRng};
+use rand::{Rng, SeedableRng};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 use tracing::debug;
@@ -1263,31 +1263,3 @@ fn test_shard_layout_upgrade_missing_chunks_high_missing_prob() {
 }
 
 // TODO(resharding) add a test with missing blocks
-
-#[test]
-
-fn am_i_crazy() {
-    let rng_seed = 42;
-    let mut rng1: StdRng = SeedableRng::seed_from_u64(rng_seed);
-    let mut rng2: StdRng = SeedableRng::seed_from_u64(rng_seed);
-
-    assert_eq!(rng1.next_u64(), rng2.next_u64());
-
-    let alphabet = b"abc";
-
-    assert_eq!(gen_account(&mut rng1, alphabet), gen_account(&mut rng2, alphabet));
-
-    let accounts1 = near_store::test_utils::gen_accounts_from_alphabet(&mut rng1, 3, 5, alphabet);
-    let accounts2 = near_store::test_utils::gen_accounts_from_alphabet(&mut rng2, 3, 5, alphabet);
-    assert_eq!(accounts1, accounts2);
-
-    let accounts1 = accounts1.into_iter().collect::<HashSet<_>>();
-    let accounts2 = accounts2.into_iter().collect::<HashSet<_>>();
-    assert_eq!(accounts1, accounts2);
-
-    let accounts1: Vec<_> = accounts1.into_iter().collect();
-    let accounts2: Vec<_> = accounts2.into_iter().collect();
-    assert_eq!(accounts1, accounts2);
-
-    // assert_eq!(gen_unique_accounts(&mut rng1, 5, 10), gen_unique_accounts(&mut rng2, 5, 10));
-}


### PR DESCRIPTION
- use seeded rng everywhere
- reuse the same rng everywhere
- refactoring because the rng needs to be mutable and rust doesn't allow having it mutable in a closure and elsewhere at the same time
- minor other change - ensure catchup happens before the last block, otherwise some annoying errors are printed