### PR TITLE
[memtrie] (1/n) Add MemTrieNode, an efficient in-memory trie node structure.

### DIFF
--- a/core/store/src/trie/mem/flexible_data/children.rs
+++ b/core/store/src/trie/mem/flexible_data/children.rs
@@ -1,0 +1,103 @@
+use super::FlexibleDataHeader;
+use crate::trie::mem::node::MemTrieNode;
+use crate::trie::Children;
+use std::mem::MaybeUninit;
+
+/// Flexibly-sized data header for a variable-sized list of children trie nodes.
+/// The header contains a 16-bit mask of which children are present, and the
+/// flexible part is one pointer for each present child.
+#[repr(C, packed(1))]
+#[derive(Clone, Copy)]
+pub struct EncodedChildrenHeader {
+    mask: u16,
+}
+
+impl FlexibleDataHeader for EncodedChildrenHeader {
+    type InputData = Vec<Option<MemTrieNode>>;
+    type View<'a> = ChildrenView<'a>;
+
+    fn from_input(children: &Vec<Option<MemTrieNode>>) -> EncodedChildrenHeader {
+        let mut mask = 0u16;
+        for i in 0..16 {
+            if children[i].is_some() {
+                mask |= 1 << i;
+            }
+        }
+        EncodedChildrenHeader { mask }
+    }
+
+    fn flexible_data_length(&self) -> usize {
+        self.mask.count_ones() as usize * std::mem::size_of::<MemTrieNode>()
+    }
+
+    unsafe fn encode_flexible_data(&self, children: Vec<Option<MemTrieNode>>, mut ptr: *mut u8) {
+        assert_eq!(children.len(), 16);
+        for (i, child) in children.into_iter().enumerate() {
+            if self.mask & (1 << i) != 0 {
+                // Note: we need to use MaybeUninit here, because the memory
+                // we're writing into is uninitialized. If we do not use
+                // MaybeUninit, the compiler would insert a drop call on the
+                // uninitialized memory as a MemTrieNode, which would segfault.
+                (*(ptr as *mut MaybeUninit<MemTrieNode>)).write(child.unwrap());
+                ptr = ptr.offset(std::mem::size_of::<MemTrieNode>() as isize);
+            }
+        }
+    }
+
+    unsafe fn decode_flexible_data<'a>(&'a self, ptr: *const u8) -> ChildrenView<'a> {
+        ChildrenView {
+            children: std::slice::from_raw_parts(
+                ptr as *const MemTrieNode,
+                self.mask.count_ones() as usize,
+            ),
+            mask: self.mask,
+        }
+    }
+
+    unsafe fn drop_flexible_data(&self, ptr: *mut u8) {
+        let num_children = self.mask.count_ones() as usize;
+        for i in 0..num_children {
+            let child_ptr = ptr.offset((i * std::mem::size_of::<MemTrieNode>()) as isize);
+            (*(child_ptr as *mut MaybeUninit<MemTrieNode>)).assume_init_drop();
+        }
+    }
+}
+
+/// Efficient view of the encoded children data.
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub struct ChildrenView<'a> {
+    mask: u16,
+    children: &'a [MemTrieNode],
+}
+
+impl<'a> ChildrenView<'a> {
+    /// Gets the child at a specific index (0 to 15).
+    pub fn get(&self, i: usize) -> Option<&'a MemTrieNode> {
+        assert!(i < 16);
+        let bit = 1u16 << (i as u16);
+        if self.mask & bit == 0 {
+            None
+        } else {
+            let lower_mask = self.mask & (bit - 1);
+            let index = lower_mask.count_ones() as usize;
+            Some(&self.children[index])
+        }
+    }
+
+    /// Converts to a Children struct used in RawTrieNode.
+    pub fn to_children(&self) -> Children {
+        let mut children = Children::default();
+        let mut j = 0;
+        for i in 0..16 {
+            if self.mask & (1 << i) != 0 {
+                children.0[i] = Some(self.children[j].hash());
+                j += 1;
+            }
+        }
+        children
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &'a MemTrieNode> {
+        self.children.iter()
+    }
+}

--- a/core/store/src/trie/mem/flexible_data/encoding.rs
+++ b/core/store/src/trie/mem/flexible_data/encoding.rs
@@ -1,0 +1,132 @@
+use std::mem::MaybeUninit;
+
+use super::FlexibleDataHeader;
+
+/// Facilitates allocation and encoding of flexibly-sized data.
+pub struct RawEncoder {
+    data: Box<[u8]>,
+    pos: usize,
+}
+
+impl RawEncoder {
+    /// Creates a new memory allocation of the given size, returning an encoder
+    /// that can be used to initialize the allocated memory.
+    pub fn new(n: usize) -> RawEncoder {
+        let mut data = Vec::<u8>::new();
+        data.reserve_exact(n);
+        unsafe {
+            data.set_len(n);
+        }
+        RawEncoder { data: data.into_boxed_slice(), pos: 0 }
+    }
+
+    unsafe fn ptr(&mut self) -> *mut u8 {
+        self.data.as_mut_ptr().offset(self.pos as isize)
+    }
+
+    /// Encodes the given fixed-size field to the current encoder position,
+    /// and then advance the position by the size of the field.
+    pub unsafe fn encode<T>(&mut self, data: T) {
+        assert!(self.pos + std::mem::size_of::<T>() <= self.data.len());
+        (*(self.ptr() as *mut MaybeUninit<T>)).write(data);
+        self.pos += std::mem::size_of::<T>();
+    }
+
+    /// Encodes the given flexibly-sized part of the data to the current
+    /// encoder position, and then advance the position by the size of the
+    /// flexibly-sized part, as returned by `header.flexible_data_length()`.
+    pub unsafe fn encode_flexible<T: FlexibleDataHeader>(
+        &mut self,
+        header: &T,
+        data: T::InputData,
+    ) {
+        let length = header.flexible_data_length();
+        assert!(self.pos + length <= self.data.len());
+        header.encode_flexible_data(data, self.ptr());
+        self.pos += length;
+    }
+
+    /// Finishes the encoding process and returns a pointer to the allocated
+    /// memory. The caller is responsible for freeing the pointer later.
+    pub unsafe fn finish(self) -> *const u8 {
+        assert_eq!(self.pos, self.data.len());
+        Box::into_raw(self.data) as *const u8
+    }
+}
+
+/// Facilitates the decoding of flexibly-sized data.
+/// The lifetime 'a should be a lifetime that guarantees the availability of
+/// the memory being decoded from.
+pub struct RawDecoder<'a> {
+    data: *const u8,
+    pos: usize,
+    _marker: std::marker::PhantomData<&'a ()>,
+}
+
+impl<'a> RawDecoder<'a> {
+    /// Starts decoding from the given memory location. The location should be
+    /// a pointer returned by RawEncoder::finish.
+    pub fn new(data: *const u8) -> RawDecoder<'a> {
+        RawDecoder { data, _marker: std::marker::PhantomData, pos: 0 }
+    }
+
+    unsafe fn ptr(&mut self) -> *const u8 {
+        self.data.offset(self.pos as isize)
+    }
+
+    /// Decodes a fixed-size field at the current decoder position, and then
+    /// advances the position by the size of the field.
+    pub unsafe fn decode<T>(&mut self) -> &'a T {
+        let result = &*(self.ptr() as *const T);
+        self.pos += std::mem::size_of::<T>();
+        result
+    }
+
+    /// Like decode, but returns the reference as mutable.
+    pub unsafe fn decode_as_mut<T>(&mut self) -> &'a mut T {
+        let result = &mut *(self.ptr() as *mut T);
+        self.pos += std::mem::size_of::<T>();
+        result
+    }
+
+    /// Decodes a fixed-sized field at the current position, but does not
+    /// advance the position.
+    pub unsafe fn peek<T>(&mut self) -> &'a T {
+        &*(self.ptr() as *const T)
+    }
+
+    /// Decodes a flexibly-sized part of the data at the current position,
+    /// and then advances the position by the size of the flexibly-sized part,
+    /// as returned by `header.flexible_data_length()`.
+    pub unsafe fn decode_flexible<T: FlexibleDataHeader>(&mut self, header: &'a T) -> T::View<'a> {
+        let length = header.flexible_data_length();
+        let view = header.decode_flexible_data(self.ptr());
+        self.pos += length;
+        view
+    }
+
+    /// Takes a fixed field from the current position, and then advances the
+    /// position by the size of the field. This is useful for dropping the fixed
+    /// field when the overall structure is being dropped.
+    pub unsafe fn take_fixed<T>(&mut self) -> T {
+        let field = &mut *(self.ptr() as *mut MaybeUninit<T>);
+        let result = std::mem::replace(field, MaybeUninit::uninit()).assume_init();
+        self.pos += std::mem::size_of::<T>();
+        result
+    }
+
+    /// Drops a flexibly-sized part of the data at the current position, and
+    /// then advances the position by the size of the flexibly-sized part.
+    pub unsafe fn drop_flexible<T: FlexibleDataHeader>(&mut self, header: &T) {
+        let length = header.flexible_data_length();
+        header.drop_flexible_data(self.ptr() as *mut u8);
+        self.pos += length;
+    }
+
+    /// At the end of decoding, converts the memory buffer to a Box so that the
+    /// memory itself can be deallocated. Requires that the decoding be complete
+    /// (so that we have the right size for the memory allocation).
+    pub unsafe fn take_encoded_data(&self) -> Box<[u8]> {
+        Box::from_raw(std::ptr::slice_from_raw_parts_mut(self.data as *mut u8, self.pos))
+    }
+}

--- a/core/store/src/trie/mem/flexible_data/extension.rs
+++ b/core/store/src/trie/mem/flexible_data/extension.rs
@@ -1,0 +1,31 @@
+use super::FlexibleDataHeader;
+
+/// Flexibly-sized data header for a trie extension path (which is simply
+/// a byte array).
+#[repr(C, packed(1))]
+#[derive(Clone, Copy)]
+pub struct EncodedExtensionHeader {
+    length: u16,
+}
+
+impl FlexibleDataHeader for EncodedExtensionHeader {
+    type InputData = Box<[u8]>;
+    type View<'a> = &'a [u8];
+    fn from_input(extension: &Box<[u8]>) -> EncodedExtensionHeader {
+        EncodedExtensionHeader { length: extension.len() as u16 }
+    }
+
+    fn flexible_data_length(&self) -> usize {
+        self.length as usize
+    }
+
+    unsafe fn encode_flexible_data(&self, extension: Box<[u8]>, ptr: *mut u8) {
+        std::ptr::copy_nonoverlapping(extension.as_ptr(), ptr, self.length as usize);
+    }
+
+    unsafe fn decode_flexible_data<'a>(&'a self, ptr: *const u8) -> &'a [u8] {
+        std::slice::from_raw_parts(ptr, self.length as usize)
+    }
+
+    unsafe fn drop_flexible_data(&self, _ptr: *mut u8) {}
+}

--- a/core/store/src/trie/mem/flexible_data/mod.rs
+++ b/core/store/src/trie/mem/flexible_data/mod.rs
@@ -1,0 +1,72 @@
+#![allow(dead_code)] // still being implemented
+
+pub mod children;
+pub mod encoding;
+pub mod extension;
+pub mod value;
+
+/// This trait simplifies our programming against flexibly-sized structures.
+/// A flexibly-sized structure is one whose memory layout depends on runtime
+/// values. For example, we may use a flexibly-sized structure to encode two
+/// variable-sized strings, like this:
+///
+///   0                4                 8         8+str1len    8+str1len+str2len
+///   |  str1 length   |   str2 length   |    str1    |     str2    |
+///
+/// Why do we do this? Because this is a lot more memory-efficient than the
+/// alternative of storing two heap-allocated Strings; it is a single memory
+/// allocation rather than three, and it saves the need to encode two pointers.
+///
+/// There's no Rust-safe way to do this, however, and it would be too error-
+/// prone to encode and decode these structures manually. This is where
+/// FlexibleDataHeader comes in.
+///
+/// In this string example, these two strings would each define a header struct,
+/// say EncodedStringHeader, that implements FlexibleDataHeader. The struct
+/// itself only contains the fixed-size part, i.e. the length of the string.
+/// Then, we implement encode_flexible_data and decode_flexible_data to specify
+/// how the flexibly-sized part of the data is encoded and decoded. These, of
+/// course need to be consistent with each other.
+///
+/// This trait allows us to then encode and decode a flexibly-sized structure
+/// with multiple flexibly-sized parts with relative ease.
+///
+/// It is possible to envision a more general way to do this that is also safer,
+/// but for now, we'll keep it simple.
+pub trait FlexibleDataHeader {
+    /// The type of the original form of data to be used for encoding.
+    type InputData;
+    /// The type of a view of the decoded data; this should be more efficient
+    /// than InputData so that decoding does not require copying; therefore,
+    /// it carries a lifetime. We assume the lifetime of the view is the same
+    /// as the lifetime of the header.
+    type View<'a>
+    where
+        Self: 'a;
+
+    /// Derives the header (fixed-size part) from the original data.
+    fn from_input(data: &Self::InputData) -> Self;
+
+    /// Calculates the length of the flexibly-sized part of the data.
+    /// This is used to allocate the right amount of memory for the containing
+    /// flexibly-sized structure.
+    fn flexible_data_length(&self) -> usize;
+
+    /// Encodes the flexibly-sized part of the data into the given memory
+    /// location. This function must be implemented in a way that writes
+    /// exactly `self.flexible_data_length()` bytes to the given memory
+    /// location. The caller must ensure that the memory location points into
+    /// an allocation that is large enough to hold these bytes.
+    unsafe fn encode_flexible_data(&self, data: Self::InputData, ptr: *mut u8);
+
+    /// Decodes the flexibly-sized part of the data from the given memory
+    /// location. This function must be implemented in a consistent manner
+    /// with `encode_flexible_data`. It, of course, must only read
+    /// `self.flexible_data_length()` bytes from the given memory location,
+    /// and the caller must ensure that the memory pointer is the same one
+    /// that was used to encode the data.
+    unsafe fn decode_flexible_data<'a>(&'a self, ptr: *const u8) -> Self::View<'a>;
+
+    /// Drops any objects encoded in the flexible data.
+    unsafe fn drop_flexible_data(&self, ptr: *mut u8);
+}

--- a/core/store/src/trie/mem/flexible_data/value.rs
+++ b/core/store/src/trie/mem/flexible_data/value.rs
@@ -1,0 +1,102 @@
+use near_primitives::hash::CryptoHash;
+use near_primitives::state::{FlatStateValue, ValueRef};
+
+use super::FlexibleDataHeader;
+
+/// Flexibly-sized data header for a trie value, representing either an inline
+/// value, or a reference to a value stored in the State column.
+///
+/// The flexible part of the data is either the inlined value as a byte array,
+/// or a CryptoHash representing the reference hash.
+#[repr(C, packed(1))]
+#[derive(Clone, Copy)]
+pub struct EncodedValueHeader {
+    // The high bit is 1 if the value is inlined, 0 if it is a reference.
+    // The lower bits are the length of the value.
+    length_and_inlined: u32,
+}
+
+impl EncodedValueHeader {
+    const INLINED_MASK: u32 = 0x80000000;
+
+    fn decode(&self) -> (u32, bool) {
+        (
+            self.length_and_inlined & !Self::INLINED_MASK,
+            self.length_and_inlined & Self::INLINED_MASK != 0,
+        )
+    }
+}
+
+impl FlexibleDataHeader for EncodedValueHeader {
+    type InputData = FlatStateValue;
+    type View<'a> = ValueView<'a>;
+
+    fn from_input(value: &FlatStateValue) -> Self {
+        match value {
+            FlatStateValue::Ref(value_ref) => {
+                EncodedValueHeader { length_and_inlined: value_ref.length }
+            }
+            FlatStateValue::Inlined(v) => {
+                assert!(v.len() as u32 & Self::INLINED_MASK == 0);
+                EncodedValueHeader { length_and_inlined: Self::INLINED_MASK | v.len() as u32 }
+            }
+        }
+    }
+
+    fn flexible_data_length(&self) -> usize {
+        let (length, inlined) = self.decode();
+        if inlined {
+            length as usize
+        } else {
+            std::mem::size_of::<CryptoHash>()
+        }
+    }
+
+    unsafe fn encode_flexible_data(&self, value: FlatStateValue, ptr: *mut u8) {
+        let (length, inlined) = self.decode();
+        match value {
+            FlatStateValue::Ref(value_ref) => {
+                assert!(!inlined);
+                *(ptr as *mut CryptoHash) = value_ref.hash;
+            }
+            FlatStateValue::Inlined(v) => {
+                assert!(inlined);
+                std::ptr::copy_nonoverlapping(v.as_ptr(), ptr, length as usize);
+            }
+        }
+    }
+
+    unsafe fn decode_flexible_data<'a>(&'a self, ptr: *const u8) -> ValueView<'a> {
+        let (length, inlined) = self.decode();
+        if inlined {
+            ValueView::Inlined(std::slice::from_raw_parts(ptr, length as usize))
+        } else {
+            ValueView::Ref { length, hash: &*(ptr as *const CryptoHash) }
+        }
+    }
+
+    unsafe fn drop_flexible_data(&self, _ptr: *mut u8) {}
+}
+
+// Efficient view of the encoded value.
+#[derive(Debug, Clone)]
+pub enum ValueView<'a> {
+    Ref { length: u32, hash: &'a CryptoHash },
+    Inlined(&'a [u8]),
+}
+
+impl<'a> ValueView<'a> {
+    pub fn to_flat_value(self) -> FlatStateValue {
+        match self {
+            Self::Ref { length, hash } => FlatStateValue::Ref(ValueRef { length, hash: *hash }),
+            Self::Inlined(data) => FlatStateValue::Inlined(data.to_vec()),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Ref { length, .. } => *length as usize,
+            Self::Inlined(data) => data.len(),
+        }
+    }
+}

--- a/core/store/src/trie/mem/mod.rs
+++ b/core/store/src/trie/mem/mod.rs
@@ -1,0 +1,2 @@
+mod flexible_data;
+mod node;

--- a/core/store/src/trie/mem/node/encoding.rs
+++ b/core/store/src/trie/mem/node/encoding.rs
@@ -1,0 +1,223 @@
+use near_primitives::hash::CryptoHash;
+
+use crate::trie::mem::flexible_data::children::EncodedChildrenHeader;
+use crate::trie::mem::flexible_data::encoding::{RawDecoder, RawEncoder};
+use crate::trie::mem::flexible_data::extension::EncodedExtensionHeader;
+use crate::trie::mem::flexible_data::value::EncodedValueHeader;
+use crate::trie::mem::flexible_data::FlexibleDataHeader;
+
+use super::{InputMemTrieNode, MemTrieNode, MemTrieNodeView};
+
+#[repr(u8)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+pub(crate) enum NodeKind {
+    Leaf,
+    Extension,
+    Branch,
+    BranchWithValue,
+}
+
+#[repr(C, packed(1))]
+pub(crate) struct CommonHeader {
+    refcount: u32,
+    pub(crate) kind: NodeKind,
+}
+
+#[repr(C, packed(1))]
+#[derive(Default)]
+pub(crate) struct NonLeafHeader {
+    pub(crate) hash: CryptoHash,
+    pub(crate) memory_usage: u64,
+}
+
+#[repr(C, packed(1))]
+pub(crate) struct LeafHeader {
+    common: CommonHeader,
+    value: EncodedValueHeader,
+    extension: EncodedExtensionHeader,
+}
+
+#[repr(C, packed(1))]
+pub(crate) struct ExtensionHeader {
+    common: CommonHeader,
+    nonleaf: NonLeafHeader,
+    child: MemTrieNode,
+    extension: EncodedExtensionHeader,
+}
+
+#[repr(C, packed(1))]
+pub(crate) struct BranchHeader {
+    common: CommonHeader,
+    nonleaf: NonLeafHeader,
+    children: EncodedChildrenHeader,
+}
+
+#[repr(C, packed(1))]
+pub(crate) struct BranchWithValueHeader {
+    common: CommonHeader,
+    nonleaf: NonLeafHeader,
+    value: EncodedValueHeader,
+    children: EncodedChildrenHeader,
+}
+
+impl MemTrieNode {
+    /// Encodes the data.
+    pub(crate) unsafe fn new_impl(node: InputMemTrieNode) -> Self {
+        let data = match node {
+            InputMemTrieNode::Leaf { value, extension } => {
+                let extension_header = EncodedExtensionHeader::from_input(&extension);
+                let value_header = EncodedValueHeader::from_input(&value);
+                let mut data = RawEncoder::new(
+                    std::mem::size_of::<LeafHeader>()
+                        + extension_header.flexible_data_length()
+                        + value_header.flexible_data_length(),
+                );
+                data.encode(LeafHeader {
+                    common: CommonHeader { refcount: 1, kind: NodeKind::Leaf },
+                    extension: extension_header,
+                    value: value_header,
+                });
+                data.encode_flexible(&extension_header, extension);
+                data.encode_flexible(&value_header, value);
+                data.finish()
+            }
+            InputMemTrieNode::Extension { extension, child } => {
+                let extension_header = EncodedExtensionHeader::from_input(&extension);
+                let mut data = RawEncoder::new(
+                    std::mem::size_of::<ExtensionHeader>()
+                        + extension_header.flexible_data_length(),
+                );
+                data.encode(ExtensionHeader {
+                    common: CommonHeader { refcount: 1, kind: NodeKind::Extension },
+                    nonleaf: NonLeafHeader::default(),
+                    child,
+                    extension: extension_header,
+                });
+                data.encode_flexible(&extension_header, extension);
+                data.finish()
+            }
+            InputMemTrieNode::Branch { children } => {
+                let children_header = EncodedChildrenHeader::from_input(&children);
+                let mut data = RawEncoder::new(
+                    std::mem::size_of::<BranchHeader>() + children_header.flexible_data_length(),
+                );
+                data.encode(BranchHeader {
+                    common: CommonHeader { refcount: 1, kind: NodeKind::Branch },
+                    nonleaf: NonLeafHeader::default(),
+                    children: children_header,
+                });
+                data.encode_flexible(&children_header, children);
+                data.finish()
+            }
+            InputMemTrieNode::BranchWithValue { children, value } => {
+                let children_header = EncodedChildrenHeader::from_input(&children);
+                let value_header = EncodedValueHeader::from_input(&value);
+                let mut data = RawEncoder::new(
+                    std::mem::size_of::<BranchWithValueHeader>()
+                        + children_header.flexible_data_length()
+                        + value_header.flexible_data_length(),
+                );
+                data.encode(BranchWithValueHeader {
+                    common: CommonHeader { refcount: 1, kind: NodeKind::BranchWithValue },
+                    nonleaf: NonLeafHeader::default(),
+                    children: children_header,
+                    value: value_header,
+                });
+                data.encode_flexible(&children_header, children);
+                data.encode_flexible(&value_header, value);
+                data.finish()
+            }
+        };
+        Self { data }
+    }
+
+    pub(crate) fn decoder<'a>(&'a self) -> RawDecoder<'a> {
+        RawDecoder::new(self.data)
+    }
+
+    /// Decodes the data.
+    pub(crate) unsafe fn view_impl<'a>(&'a self) -> MemTrieNodeView<'a> {
+        let mut decoder = self.decoder();
+        let kind = decoder.peek::<CommonHeader>().kind;
+        match kind {
+            NodeKind::Leaf => {
+                let header = decoder.decode::<LeafHeader>();
+                let extension = decoder.decode_flexible(&header.extension);
+                let value = decoder.decode_flexible(&header.value);
+                MemTrieNodeView::Leaf { extension, value }
+            }
+            NodeKind::Extension => {
+                let header = decoder.decode::<ExtensionHeader>();
+                let extension = decoder.decode_flexible(&header.extension);
+                MemTrieNodeView::Extension {
+                    hash: &header.nonleaf.hash,
+                    memory_usage: header.nonleaf.memory_usage,
+                    extension,
+                    child: &header.child,
+                }
+            }
+            NodeKind::Branch => {
+                let header = decoder.decode::<BranchHeader>();
+                let children = decoder.decode_flexible(&header.children);
+                MemTrieNodeView::Branch {
+                    hash: &header.nonleaf.hash,
+                    memory_usage: header.nonleaf.memory_usage,
+                    children,
+                }
+            }
+            NodeKind::BranchWithValue => {
+                let header = decoder.decode::<BranchWithValueHeader>();
+                let children = decoder.decode_flexible(&header.children);
+                let value = decoder.decode_flexible(&header.value);
+                MemTrieNodeView::BranchWithValue {
+                    hash: &header.nonleaf.hash,
+                    memory_usage: header.nonleaf.memory_usage,
+                    children,
+                    value,
+                }
+            }
+        }
+    }
+
+    /// Deallocates memory and drops references to children.
+    pub(crate) unsafe fn delete(&self) {
+        let mut decoder = self.decoder();
+        match decoder.peek::<CommonHeader>().kind {
+            NodeKind::Leaf => {
+                let header = decoder.take_fixed::<LeafHeader>();
+                decoder.drop_flexible(&header.extension);
+                decoder.drop_flexible(&header.value);
+            }
+            NodeKind::Extension => {
+                let header = decoder.take_fixed::<ExtensionHeader>();
+                decoder.drop_flexible(&header.extension);
+            }
+            NodeKind::Branch => {
+                let header = decoder.take_fixed::<BranchHeader>();
+                decoder.drop_flexible(&header.children);
+            }
+            NodeKind::BranchWithValue => {
+                let header = decoder.take_fixed::<BranchWithValueHeader>();
+                decoder.drop_flexible(&header.children);
+                decoder.drop_flexible(&header.value);
+            }
+        }
+        decoder.take_encoded_data(); // drops the memory allocation
+    }
+
+    pub(crate) unsafe fn clone_impl(&self) -> Self {
+        let mut decoder = self.decoder();
+        let header = decoder.decode_as_mut::<CommonHeader>();
+        header.refcount += 1;
+        Self { data: self.data }
+    }
+
+    pub(crate) unsafe fn drop_impl(&mut self) {
+        let mut decoder = self.decoder();
+        let header = decoder.decode_as_mut::<CommonHeader>();
+        header.refcount -= 1;
+        if header.refcount == 0 {
+            self.delete();
+        }
+    }
+}

--- a/core/store/src/trie/mem/node/loading.rs
+++ b/core/store/src/trie/mem/node/loading.rs
@@ -1,0 +1,42 @@
+use super::encoding::{CommonHeader, NodeKind, NonLeafHeader};
+use super::MemTrieNode;
+use borsh::BorshSerialize;
+use near_primitives::hash::hash;
+
+impl MemTrieNode {
+    unsafe fn compute_hash_and_memory_usage(&self) {
+        let raw_trie_node_with_size = self.view().to_raw_trie_node_with_size();
+        let mut decoder = self.decoder();
+        match decoder.decode::<CommonHeader>().kind {
+            NodeKind::Leaf => {}
+            _ => {
+                let nonleaf = decoder.decode_as_mut::<NonLeafHeader>();
+                nonleaf.memory_usage = raw_trie_node_with_size.memory_usage;
+                nonleaf.hash = hash(&raw_trie_node_with_size.try_to_vec().unwrap());
+            }
+        }
+    }
+
+    unsafe fn is_hash_and_memory_usage_computed(&self) -> bool {
+        let mut decoder = self.decoder();
+        match decoder.decode::<CommonHeader>().kind {
+            NodeKind::Leaf => true,
+            _ => decoder.decode::<NonLeafHeader>().memory_usage != 0,
+        }
+    }
+
+    /// This is used after initially constructing the in-memory trie strcuture,
+    /// to compute the hash and memory usage recursively. The computation is
+    /// expensive, so we defer it in order to make it parallelizable.
+    pub(crate) fn compute_hash_and_memory_usage_recursively(&self) {
+        unsafe {
+            if self.is_hash_and_memory_usage_computed() {
+                return;
+            }
+            for child in self.view().iter_children() {
+                child.compute_hash_and_memory_usage_recursively();
+            }
+            self.compute_hash_and_memory_usage();
+        }
+    }
+}

--- a/core/store/src/trie/mem/node/mod.rs
+++ b/core/store/src/trie/mem/node/mod.rs
@@ -1,0 +1,93 @@
+#![allow(dead_code)] // still being implemented
+
+mod encoding;
+mod loading;
+#[cfg(test)]
+mod tests;
+mod view;
+
+use near_primitives::hash::CryptoHash;
+use near_primitives::state::FlatStateValue;
+
+use super::flexible_data::children::ChildrenView;
+use super::flexible_data::value::ValueView;
+
+/// An efficiently encoded in-memory trie node.
+///
+/// This struct is internally refcounted, similar to an Rc<T>. When all clones
+/// of the same `MemTrieNode` are dropped, the associated memory allocation is
+/// freed.
+///
+/// To construct a `MemTrieNode`, call `MemTrieNode::new`. To read its contents,
+/// call `MemTrieNode::view()`, which returns a `MemTrieNodeView`.
+#[derive(Debug, Hash, PartialEq, Eq)]
+#[repr(C, packed(1))]
+pub struct MemTrieNode {
+    data: *const u8,
+}
+
+impl MemTrieNode {
+    pub fn new(input: InputMemTrieNode) -> Self {
+        unsafe { Self::new_impl(input) }
+    }
+
+    pub fn view(&self) -> MemTrieNodeView<'_> {
+        unsafe { self.view_impl() }
+    }
+
+    pub fn hash(&self) -> CryptoHash {
+        self.view().node_hash()
+    }
+
+    pub fn memory_usage(&self) -> u64 {
+        self.view().memory_usage()
+    }
+}
+
+impl Clone for MemTrieNode {
+    fn clone(&self) -> Self {
+        unsafe { self.clone_impl() }
+    }
+}
+
+impl Drop for MemTrieNode {
+    fn drop(&mut self) {
+        unsafe { self.drop_impl() }
+    }
+}
+
+/// Used to construct a new `MemTrieNode`.
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub enum InputMemTrieNode {
+    Leaf { value: FlatStateValue, extension: Box<[u8]> },
+    Extension { extension: Box<[u8]>, child: MemTrieNode },
+    Branch { children: Vec<Option<MemTrieNode>> },
+    BranchWithValue { children: Vec<Option<MemTrieNode>>, value: FlatStateValue },
+}
+
+/// A view of the encoded data of `MemTrieNode`, obtainable via
+/// `MemTrieNode::view()`.
+#[derive(Debug, Clone)]
+pub enum MemTrieNodeView<'a> {
+    Leaf {
+        extension: &'a [u8],
+        value: ValueView<'a>,
+    },
+    Extension {
+        hash: &'a CryptoHash,
+        memory_usage: u64,
+        extension: &'a [u8],
+        child: &'a MemTrieNode,
+    },
+    Branch {
+        hash: &'a CryptoHash,
+        memory_usage: u64,
+        children: ChildrenView<'a>,
+    },
+    BranchWithValue {
+        hash: &'a CryptoHash,
+        memory_usage: u64,
+        children: ChildrenView<'a>,
+        value: ValueView<'a>,
+    },
+}

--- a/core/store/src/trie/mem/node/tests.rs
+++ b/core/store/src/trie/mem/node/tests.rs
@@ -1,0 +1,247 @@
+use borsh::BorshSerialize;
+use near_primitives::hash::hash;
+use near_primitives::state::{FlatStateValue, ValueRef};
+
+use crate::trie::mem::node::MemTrieNodeView;
+use crate::trie::Children;
+use crate::{RawTrieNode, RawTrieNodeWithSize};
+
+use super::{InputMemTrieNode, MemTrieNode};
+
+#[test]
+fn test_basic_leaf_node_inlined() {
+    let node = MemTrieNode::new(InputMemTrieNode::Leaf {
+        extension: vec![0, 1, 2, 3, 4].into_boxed_slice(),
+        value: FlatStateValue::Inlined(vec![5, 6, 7, 8, 9]),
+    });
+    let view = node.view();
+    assert_eq!(
+        node.view().to_raw_trie_node_with_size(),
+        RawTrieNodeWithSize {
+            memory_usage: 115,
+            node: RawTrieNode::Leaf(
+                vec![0, 1, 2, 3, 4],
+                FlatStateValue::Inlined(vec![5, 6, 7, 8, 9]).to_value_ref()
+            ),
+        }
+    );
+    assert_eq!(node.memory_usage(), 115);
+    assert_eq!(node.hash(), hash(&view.to_raw_trie_node_with_size().try_to_vec().unwrap()));
+    match node.view() {
+        MemTrieNodeView::Leaf { extension, value } => {
+            assert_eq!(extension, &[0, 1, 2, 3, 4]);
+            assert_eq!(value.to_flat_value(), FlatStateValue::Inlined(vec![5, 6, 7, 8, 9]));
+        }
+        _ => panic!(),
+    }
+}
+
+#[test]
+fn test_basic_leaf_node_ref() {
+    let test_hash = hash(&[5, 6, 7, 8, 9]);
+    let node = MemTrieNode::new(InputMemTrieNode::Leaf {
+        extension: vec![0, 1, 2, 3, 4].into_boxed_slice(),
+        value: FlatStateValue::Ref(ValueRef { hash: test_hash, length: 5 }),
+    });
+    let view = node.view();
+    assert_eq!(
+        node.view().to_raw_trie_node_with_size(),
+        RawTrieNodeWithSize {
+            memory_usage: 115,
+            node: RawTrieNode::Leaf(vec![0, 1, 2, 3, 4], ValueRef { hash: test_hash, length: 5 }),
+        }
+    );
+    assert_eq!(node.memory_usage(), 115);
+    assert_eq!(node.hash(), hash(&view.to_raw_trie_node_with_size().try_to_vec().unwrap()));
+    match node.view() {
+        MemTrieNodeView::Leaf { extension, value } => {
+            assert_eq!(extension, &[0, 1, 2, 3, 4]);
+            assert_eq!(
+                value.to_flat_value(),
+                FlatStateValue::Ref(ValueRef { hash: test_hash, length: 5 })
+            );
+        }
+        _ => panic!(),
+    }
+}
+
+#[test]
+fn test_basic_leaf_node_empty_extension_empty_value() {
+    let node = MemTrieNode::new(InputMemTrieNode::Leaf {
+        extension: vec![].into_boxed_slice(),
+        value: FlatStateValue::Inlined(vec![]),
+    });
+    let view = node.view();
+    assert_eq!(
+        node.view().to_raw_trie_node_with_size(),
+        RawTrieNodeWithSize {
+            memory_usage: 100,
+            node: RawTrieNode::Leaf(vec![], FlatStateValue::Inlined(vec![]).to_value_ref()),
+        }
+    );
+    assert_eq!(node.memory_usage(), 100);
+    assert_eq!(node.hash(), hash(&view.to_raw_trie_node_with_size().try_to_vec().unwrap()));
+    match node.view() {
+        MemTrieNodeView::Leaf { extension, value } => {
+            assert!(extension.is_empty());
+            assert_eq!(value.to_flat_value(), FlatStateValue::Inlined(vec![]));
+        }
+        _ => panic!(),
+    }
+}
+
+#[test]
+fn test_basic_extension_node() {
+    let child = MemTrieNode::new(InputMemTrieNode::Leaf {
+        extension: vec![0, 1, 2, 3, 4].into_boxed_slice(),
+        value: FlatStateValue::Inlined(vec![5, 6, 7, 8, 9]),
+    });
+    let node = MemTrieNode::new(InputMemTrieNode::Extension {
+        extension: vec![5, 6, 7, 8, 9].into_boxed_slice(),
+        child: child.clone(),
+    });
+    assert_eq!(
+        node.view().to_raw_trie_node_with_size(),
+        RawTrieNodeWithSize {
+            memory_usage: child.memory_usage() + 60,
+            node: RawTrieNode::Extension(vec![5, 6, 7, 8, 9], child.hash()),
+        }
+    );
+    node.compute_hash_and_memory_usage_recursively();
+    assert_eq!(node.memory_usage(), child.memory_usage() + 60);
+    assert_eq!(node.hash(), hash(&node.view().to_raw_trie_node_with_size().try_to_vec().unwrap()));
+    match node.view() {
+        MemTrieNodeView::Extension { hash, memory_usage, extension, child: actual_child } => {
+            assert_eq!(*hash, node.hash());
+            assert_eq!(memory_usage, node.memory_usage());
+            assert_eq!(extension, &[5, 6, 7, 8, 9]);
+            assert_eq!(actual_child, &child);
+        }
+        _ => panic!(),
+    }
+}
+
+fn branch_vec(children: Vec<(usize, MemTrieNode)>) -> Vec<Option<MemTrieNode>> {
+    let mut result: Vec<Option<MemTrieNode>> = std::iter::repeat_with(|| None).take(16).collect();
+    for (idx, child) in children {
+        result[idx] = Some(child);
+    }
+    result
+}
+
+#[test]
+fn test_basic_branch_node() {
+    let child1 = MemTrieNode::new(InputMemTrieNode::Leaf {
+        extension: vec![].into_boxed_slice(),
+        value: FlatStateValue::Inlined(vec![1]),
+    });
+    let child2 = MemTrieNode::new(InputMemTrieNode::Leaf {
+        extension: vec![1].into_boxed_slice(),
+        value: FlatStateValue::Inlined(vec![2]),
+    });
+    let node = MemTrieNode::new(InputMemTrieNode::Branch {
+        children: branch_vec(vec![(3, child1.clone()), (5, child2.clone())]),
+    });
+    assert_eq!(
+        node.view().to_raw_trie_node_with_size(),
+        RawTrieNodeWithSize {
+            memory_usage: child1.memory_usage() + child2.memory_usage() + 50,
+            node: RawTrieNode::BranchNoValue(Children([
+                None,
+                None,
+                None,
+                Some(child1.hash()),
+                None,
+                Some(child2.hash()),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None
+            ])),
+        }
+    );
+    node.compute_hash_and_memory_usage_recursively();
+    assert_eq!(node.memory_usage(), child1.memory_usage() + child2.memory_usage() + 50);
+    assert_eq!(node.hash(), hash(&node.view().to_raw_trie_node_with_size().try_to_vec().unwrap()));
+    match node.view() {
+        MemTrieNodeView::Branch { hash, memory_usage, children } => {
+            assert_eq!(*hash, node.hash());
+            assert_eq!(memory_usage, node.memory_usage());
+            assert_eq!(
+                children.iter().cloned().collect::<Vec<_>>(),
+                vec![child1.clone(), child2.clone()]
+            );
+            assert_eq!(children.get(3).cloned(), Some(child1));
+            assert_eq!(children.get(1), None);
+            assert_eq!(children.get(5).cloned(), Some(child2));
+        }
+        _ => panic!(),
+    }
+}
+
+#[test]
+fn test_basic_branch_with_value_node() {
+    let child1 = MemTrieNode::new(InputMemTrieNode::Leaf {
+        extension: vec![].into_boxed_slice(),
+        value: FlatStateValue::Inlined(vec![1]),
+    });
+    let child2 = MemTrieNode::new(InputMemTrieNode::Leaf {
+        extension: vec![1].into_boxed_slice(),
+        value: FlatStateValue::Inlined(vec![2]),
+    });
+    let node = MemTrieNode::new(InputMemTrieNode::BranchWithValue {
+        children: branch_vec(vec![(0, child1.clone()), (15, child2.clone())]),
+        value: FlatStateValue::Inlined(vec![3, 4, 5]),
+    });
+    assert_eq!(
+        node.view().to_raw_trie_node_with_size(),
+        RawTrieNodeWithSize {
+            memory_usage: child1.memory_usage() + child2.memory_usage() + 103,
+            node: RawTrieNode::BranchWithValue(
+                FlatStateValue::Inlined(vec![3, 4, 5]).to_value_ref(),
+                Children([
+                    Some(child1.hash()),
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    Some(child2.hash()),
+                ])
+            ),
+        }
+    );
+    node.compute_hash_and_memory_usage_recursively();
+    assert_eq!(node.memory_usage(), child1.memory_usage() + child2.memory_usage() + 103);
+    assert_eq!(node.hash(), hash(&node.view().to_raw_trie_node_with_size().try_to_vec().unwrap()));
+    match node.view() {
+        MemTrieNodeView::BranchWithValue { hash, memory_usage, children, value } => {
+            assert_eq!(*hash, node.hash());
+            assert_eq!(memory_usage, node.memory_usage());
+            assert_eq!(
+                children.iter().cloned().collect::<Vec<_>>(),
+                vec![child1.clone(), child2.clone()]
+            );
+            assert_eq!(children.get(0).cloned(), Some(child1));
+            assert_eq!(children.get(1), None);
+            assert_eq!(children.get(15).cloned(), Some(child2));
+            assert_eq!(value.to_flat_value(), FlatStateValue::Inlined(vec![3, 4, 5]));
+        }
+        _ => panic!(),
+    }
+}

--- a/core/store/src/trie/mem/node/view.rs
+++ b/core/store/src/trie/mem/node/view.rs
@@ -1,0 +1,89 @@
+use super::{MemTrieNode, MemTrieNodeView};
+use crate::trie::TRIE_COSTS;
+use crate::{RawTrieNode, RawTrieNodeWithSize};
+use borsh::BorshSerialize;
+use near_primitives::hash::{hash, CryptoHash};
+
+impl<'a> MemTrieNodeView<'a> {
+    pub fn node_hash(self) -> CryptoHash {
+        match self {
+            Self::Leaf { .. } => {
+                let node = self.to_raw_trie_node_with_size();
+                hash(&node.try_to_vec().unwrap())
+            }
+            Self::Extension { hash, .. }
+            | Self::Branch { hash, .. }
+            | Self::BranchWithValue { hash, .. } => *hash,
+        }
+    }
+
+    pub fn to_raw_trie_node_with_size(self) -> RawTrieNodeWithSize {
+        match self {
+            Self::Leaf { value, extension } => {
+                let node = RawTrieNode::Leaf(
+                    extension.to_vec(),
+                    value.clone().to_flat_value().to_value_ref(),
+                );
+                let memory_usage = Self::Leaf { value, extension }.memory_usage();
+                RawTrieNodeWithSize { node, memory_usage }
+            }
+            Self::Extension { extension, child, .. } => {
+                let node = RawTrieNode::Extension(extension.to_vec(), child.hash());
+                let memory_usage = TRIE_COSTS.node_cost
+                    + child.memory_usage()
+                    + extension.len() as u64 * TRIE_COSTS.byte_of_key;
+                RawTrieNodeWithSize { node, memory_usage }
+            }
+            Self::Branch { children, .. } => {
+                let node = RawTrieNode::BranchNoValue(children.to_children());
+                let mut memory_usage = TRIE_COSTS.node_cost;
+                for child in children.iter() {
+                    memory_usage += child.memory_usage();
+                }
+                RawTrieNodeWithSize { node, memory_usage }
+            }
+            Self::BranchWithValue { children, value, .. } => {
+                let mut memory_usage = TRIE_COSTS.node_cost
+                    + value.len() as u64 * TRIE_COSTS.byte_of_value
+                    + TRIE_COSTS.node_cost;
+                let node = RawTrieNode::BranchWithValue(
+                    value.to_flat_value().to_value_ref(),
+                    children.to_children(),
+                );
+                for child in children.iter() {
+                    memory_usage += child.memory_usage();
+                }
+                RawTrieNodeWithSize { node, memory_usage }
+            }
+        }
+    }
+
+    pub fn memory_usage(&self) -> u64 {
+        match self {
+            Self::Leaf { value, extension } => {
+                TRIE_COSTS.node_cost
+                    + extension.len() as u64 * TRIE_COSTS.byte_of_key
+                    + value.len() as u64 * TRIE_COSTS.byte_of_value
+                    + TRIE_COSTS.node_cost // yes, twice.
+            }
+            Self::Extension { memory_usage, .. }
+            | Self::Branch { memory_usage, .. }
+            | Self::BranchWithValue { memory_usage, .. } => {
+                // Memory usage is computed after loading is complete.
+                // For that, we use the to_raw_trie_node_with_size code path.
+                // So make sure that's the case by checking here.
+                assert!(*memory_usage != 0, "memory_usage is not computed yet");
+                *memory_usage
+            }
+        }
+    }
+
+    pub(crate) fn iter_children(&'a self) -> Box<dyn Iterator<Item = &'a MemTrieNode> + 'a> {
+        match self {
+            MemTrieNodeView::Leaf { .. } => Box::new(std::iter::empty()),
+            MemTrieNodeView::Extension { child, .. } => Box::new(std::iter::once(*child)),
+            MemTrieNodeView::Branch { children, .. }
+            | MemTrieNodeView::BranchWithValue { children, .. } => Box::new(children.iter()),
+        }
+    }
+}

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -36,6 +36,7 @@ mod config;
 mod from_flat;
 mod insert_delete;
 pub mod iterator;
+mod mem;
 mod nibble_slice;
 mod prefetching_trie_storage;
 mod raw_node;


### PR DESCRIPTION
This is the first step towards implementing the efficient in-memory data structure for the in-memory trie prototype mentioned here https://near.zulipchat.com/#narrow/stream/295558-pagoda.2Fcore/topic/Stateless.20validation.20-.20putting.20all.20state.20in.20memory

There is unsafe Rust involved, due to the need to co-allocate variable-size data, in order to save memory. The intent is that all the unsafe code is contained within MemTrieNode.

mem/node/encoding.rs contains the top-level encoding, decoding, and destruction logic for the MemTrieNode. The code in flexible_data is used to help with this encoding/decoding, so that even though the code is unsafe it is still organized. mem/node/mod.rs contains the high level API for MemTrieNode.