### PR TITLE
Finish registering a new connection before sending routing update

### DIFF
--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -333,11 +333,11 @@ impl NetworkState {
                     this.add_edges(&clock, vec![edge.clone()])
                         .await
                         .map_err(|_: ReasonForBan| RegisterPeerError::InvalidEdge)?;
+                    // Insert to the local connection pool
+                    this.tier2.insert_ready(conn.clone()).map_err(RegisterPeerError::PoolError)?;
                     // Update the V2 routing table
                     this.update_routes(&clock, NetworkTopologyChange::PeerConnected(peer_info.id.clone(), edge.clone()))
                         .await.map_err(|_: ReasonForBan| RegisterPeerError::InvalidEdge)?;
-                    // Insert to the local connection pool
-                    this.tier2.insert_ready(conn.clone()).map_err(RegisterPeerError::PoolError)?;
                     // Write to the peer store
                     this.peer_store.peer_connected(&clock, peer_info);
                 }


### PR DESCRIPTION
Updates to the routing table trigger a broadcast advising all peers of the latest information:

https://github.com/near/nearcore/blob/9ddfd49fb33288a43dc0ed8f4a37d66a11e69531/chain/network/src/peer_manager/network_state/routing.rs#L36-L41

Connection of a new peer is one type of event which results in a routing table update. The update should be broadcast after registering the new connection, so that the new peer is included in the broadcast.