### PR TITLE
debug: abbreviate `PartialEncodedChunkPart`.`part`

### DIFF
--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -8,6 +8,7 @@ use crate::validator_signer::ValidatorSigner;
 use crate::version::{ProtocolFeature, ProtocolVersion, SHARD_CHUNK_HEADER_UPGRADE_VERSION};
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_crypto::Signature;
+use near_fmt::AbbrBytes;
 use reed_solomon_erasure::galois_8::{Field, ReedSolomon};
 use reed_solomon_erasure::ReconstructShard;
 use std::cmp::Ordering;
@@ -617,11 +618,21 @@ impl Ord for ReceiptProof {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug, Clone, Eq, PartialEq)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Eq, PartialEq)]
 pub struct PartialEncodedChunkPart {
     pub part_ord: u64,
     pub part: Box<[u8]>,
     pub merkle_proof: MerklePath,
+}
+
+impl std::fmt::Debug for PartialEncodedChunkPart {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PartialEncodedChunkPart")
+            .field("part_ord", &self.part_ord)
+            .field("part", &format_args!("{}", AbbrBytes(self.part.as_ref())))
+            .field("merkle_proof", &self.merkle_proof)
+            .finish()
+    }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone, Eq, PartialEq)]


### PR DESCRIPTION
The encoded part bytes can be quite large. Printing the list of bytes as

```
part: [0, 0, 0, 0, 12, 0, 0, 0, 6, 0, 0, 0, 115, 121, 115, 116, 101,
109, 22, 0, 0, 0, 117, 117, 57, 120, 115, 56, 95, 117, 115, 101,
114, 53, 95, 114, 117, 110, 46, 110, 111, 100, 101, 48,
(this continues wih 3M entries and no cut-off)
```

in full is not very useful and usually blows
up debug output to an unreadable amount.

With this change, it will show like this:
```
part: (25555924)AAAAAAwAAAAGAAAAc3lzdGVtFgAAAHV1OXhzOF91c2VyNV9ydW4ubm9kZTCnKiyPMf578ZGhbYrbTF8CUXboIjS24ycaZcV0gp8IOgAWAAAAdXU5eHM4X3Vz…
```

It starts with the length and shows the first 128 bytes base64 encoded.