### PR TITLE
perf: optimize `insert` and `insert_ser`

### DIFF
--- a/core/store/benches/finalize_bench.rs
+++ b/core/store/benches/finalize_bench.rs
@@ -36,7 +36,7 @@ use rand::prelude::SliceRandom;
 
 /// `ShardChunk` -> `StoreUpdate::insert_ser`.
 ///
-/// ~10ms or faster for ~24MB receipts
+/// ~6ms or faster for ~24MB receipts
 fn benchmark_write_shard_chunk(bench: &mut Bencher) {
     let transactions = vec![];
     let receipts = create_benchmark_receipts();
@@ -57,7 +57,7 @@ fn benchmark_write_shard_chunk(bench: &mut Bencher) {
 
 /// `PartialEncodedChunk` -> `StoreUpdate::insert_ser`.
 ///
-/// ~130ms for ~24MB receipts
+/// ~70ms for ~24MB receipts
 fn benchmark_write_partial_encoded_chunk(bench: &mut Bencher) {
     let transactions = vec![];
     let receipts = create_benchmark_receipts();

--- a/core/store/src/db/rocksdb.rs
+++ b/core/store/src/db/rocksdb.rs
@@ -812,7 +812,7 @@ mod tests {
 
         let mut store_update = store.store_update();
         for key in &keys {
-            store_update.insert(column, key, &vec![42]);
+            store_update.insert(column, key.clone(), vec![42]);
         }
         store_update.commit().unwrap();
 

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -432,11 +432,21 @@ impl StoreUpdate {
     ///
     /// It is a programming error if `insert` overwrites an existing, different
     /// value. Use it for insert-only columns.
-    pub fn insert(&mut self, column: DBCol, key: &[u8], value: &[u8]) {
+    pub fn insert(&mut self, column: DBCol, key: Vec<u8>, value: Vec<u8>) {
         assert!(column.is_insert_only(), "can't insert: {column}");
-        self.transaction.insert(column, key.to_vec(), value.to_vec())
+        self.transaction.insert(column, key, value)
     }
 
+    /// Borsh-serializes a value and inserts it into the database.
+    ///
+    /// It is a programming error if `insert` overwrites an existing, different
+    /// value. Use it for insert-only columns.
+    ///
+    /// Note on performance: The key is always copied into a new allocation,
+    /// which is generally bad. However, the insert-only columns use
+    /// `CryptoHash` as key, which has the data in a small fixed-sized array.
+    /// Copying and allocating that is not prohibitively expensive and we have
+    /// to do it either way. Thus, we take a slice for the key for the nice API.
     pub fn insert_ser<T: BorshSerialize>(
         &mut self,
         column: DBCol,
@@ -445,7 +455,7 @@ impl StoreUpdate {
     ) -> io::Result<()> {
         assert!(column.is_insert_only(), "can't insert_ser: {column}");
         let data = value.try_to_vec()?;
-        self.insert(column, key, &data);
+        self.insert(column, key.to_vec(), data);
         Ok(())
     }
 

--- a/core/store/src/migrations.rs
+++ b/core/store/src/migrations.rs
@@ -51,7 +51,7 @@ impl<'a> BatchedStoreUpdate<'a> {
         self.total_size_written += entry_size as u64;
         let update = self.store_update.as_mut().unwrap();
         if insert {
-            update.insert(col, key.as_ref(), &value_bytes);
+            update.insert(col, key.to_vec(), value_bytes);
         } else {
             update.set(col, key.as_ref(), &value_bytes);
         }

--- a/core/store/src/opener.rs
+++ b/core/store/src/opener.rs
@@ -654,7 +654,7 @@ mod tests {
         let mut store_update = node_storage.get_hot_store().store_update();
         for column in columns {
             for key in &keys {
-                store_update.insert(column, key, &vec![42]);
+                store_update.insert(column, key.clone(), vec![42]);
             }
         }
         store_update.commit().unwrap();

--- a/core/store/src/test_utils.rs
+++ b/core/store/src/test_utils.rs
@@ -148,10 +148,10 @@ pub fn test_populate_flat_storage(
 }
 
 /// Insert values to non-reference-counted columns in the store.
-pub fn test_populate_store(store: &Store, data: &[(DBCol, Vec<u8>, Vec<u8>)]) {
+pub fn test_populate_store(store: &Store, data: impl Iterator<Item = (DBCol, Vec<u8>, Vec<u8>)>) {
     let mut update = store.store_update();
     for (column, key, value) in data {
-        update.insert(*column, key, value);
+        update.insert(column, key, value);
     }
     update.commit().expect("db commit failed");
 }

--- a/tools/database/src/make_snapshot.rs
+++ b/tools/database/src/make_snapshot.rs
@@ -46,7 +46,7 @@ mod tests {
             let node_storage = opener.open().unwrap();
             let mut store_update = node_storage.get_hot_store().store_update();
             for key in &keys {
-                store_update.insert(DBCol::Block, key, &vec![42]);
+                store_update.insert(DBCol::Block, key.clone(), vec![42]);
             }
             store_update.commit().unwrap();
             println!("Populated");

--- a/tools/state-viewer/src/contract_accounts.rs
+++ b/tools/state-viewer/src/contract_accounts.rs
@@ -531,7 +531,7 @@ mod tests {
     #[test]
     fn test_simple_summary() {
         let trie_data = vec![contract_tuple("alice.near", 100), contract_tuple("bob.near", 200)];
-        let (store, trie) = create_store_and_trie(&[], &[], trie_data);
+        let (store, trie) = create_store_and_trie([].into_iter(), &[], trie_data);
 
         let filter = full_filter();
         let summary = ContractAccount::in_tries(vec![trie], &filter)
@@ -600,7 +600,8 @@ mod tests {
         ];
 
         let trie_data = vec![contract_tuple("alice.near", 100), contract_tuple("bob.near", 200)];
-        let (store, trie) = create_store_and_trie(&store_data, &store_data_rc, trie_data);
+        let (store, trie) =
+            create_store_and_trie(store_data.into_iter(), &store_data_rc, trie_data);
 
         let filter = full_filter();
         let summary = ContractAccount::in_tries(vec![trie], &filter)
@@ -622,12 +623,12 @@ mod tests {
 
     /// Create an in-memory trie with the key-value pairs.
     fn create_trie(initial: Vec<(Vec<u8>, Option<Vec<u8>>)>) -> Trie {
-        create_store_and_trie(&[], &[], initial).1
+        create_store_and_trie([].into_iter(), &[], initial).1
     }
 
     /// Create an in-memory store + trie with key-value pairs for each.
     fn create_store_and_trie(
-        store_data: &[(DBCol, Vec<u8>, Vec<u8>)],
+        store_data: impl Iterator<Item = (DBCol, Vec<u8>, Vec<u8>)>,
         store_data_rc: &[(DBCol, Vec<u8>, Vec<u8>)],
         trie_data: Vec<(Vec<u8>, Option<Vec<u8>>)>,
     ) -> (Store, Trie) {


### PR DESCRIPTION
Avoid an unnecessary copy of the inserted value.

This improves the `finalize_bench.rs` by 40% - 50%, reducing the time to finalize a single `PartialEncodedChunk` from 130ms to 70ms and for `ShardChunk` it goes from 10ms to 6ms.
(Number before & after are on AMD Ryzen 9 5950X and 3200 MT/s DDR4)