### PR TITLE
feat: introduce post-state-root protocol feature

### DIFF
--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -120,6 +120,9 @@ pub enum ProtocolFeature {
     RejectBlocksWithOutdatedProtocolVersions,
     #[cfg(feature = "protocol_feature_simple_nightshade_v2")]
     SimpleNightshadeV2,
+    /// Enables block production with post-state-root.
+    /// NEP: https://github.com/near/NEPs/pull/507
+    PostStateRoot,
 }
 
 impl ProtocolFeature {
@@ -173,6 +176,7 @@ impl ProtocolFeature {
             ProtocolFeature::RejectBlocksWithOutdatedProtocolVersions => 132,
             #[cfg(feature = "protocol_feature_simple_nightshade_v2")]
             ProtocolFeature::SimpleNightshadeV2 => 135,
+            ProtocolFeature::PostStateRoot => 136,
         }
     }
 }


### PR DESCRIPTION
This PR introduces `ProtocolFeature::PostStateRoot` which is included in nightly.
After a discussion with @nikurt and @jakmeier it was decided not to introduce a cargo feature for conditional compilation until it is actually needed. As far as I see all post-state-root code can be added without need for conditional compilation. The only switch we need is to enable post-state-root chunk and block production based on protocol version check.

This PR is a groundwork for https://github.com/near/nearcore/issues/9450.