### PR TITLE
fix(state-viewer): fix balance overflow in state-dump command

### DIFF
--- a/tools/state-viewer/src/state_dump.rs
+++ b/tools/state-viewer/src/state_dump.rs
@@ -244,12 +244,14 @@ fn iterate_over_records(
                     continue;
                 }
                 if let StateRecord::Account { account_id, account } = &mut sr {
-                    total_supply += account.amount() + account.locked();
                     if account.locked() > 0 {
                         let stake = *validators.get(account_id).map(|(_, s)| s).unwrap_or(&0);
-                        account.set_amount(account.amount() + account.locked() - stake);
+                        if account.locked() > stake {
+                            account.set_amount(account.amount() + account.locked() - stake);
+                        }
                         account.set_locked(stake);
                     }
+                    total_supply += account.amount() + account.locked();
                 }
                 change_state_record(&mut sr, change_config);
                 callback(sr);


### PR DESCRIPTION
The state-dump command changes the amounts of validator accounts to match the epoch we're dumping state in, in case a validator stakes during that epoch, and the locked amount is different than the stake. The new locked amount computation is correct if a validator staked more, but overflows if the locked amount is smaller than the stake plus amount, which actually does occur on mainnet