### PR TITLE
Logging: Deprecate `--verbose`

### DIFF
--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -175,6 +175,7 @@ struct NeardOpts {
 }
 
 impl NeardOpts {
+    // TODO(nikurt): Delete in 1.38 or later.
     pub fn verbose_target(&self) -> Option<&str> {
         match self.verbose {
             None => None,

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -177,17 +177,10 @@ struct NeardOpts {
 impl NeardOpts {
     // TODO(nikurt): Delete in 1.38 or later.
     pub fn verbose_target(&self) -> Option<&str> {
-        match self.verbose {
-            None => None,
-            Some(None) => {
-                tracing::error!(target: "neard", "--verbose flag is deprecated, please use RUST_LOG or log_config.json instead.");
-                Some("")
-            }
-            Some(Some(ref target)) => {
-                tracing::error!(target: "neard", "--verbose flag is deprecated, please use RUST_LOG or log_config.json instead.");
-                Some(target.as_str())
-            }
-        }
+        self.verbose.as_ref().map(|inner| {
+            tracing::error!(target: "neard", "--verbose flag is deprecated, please use RUST_LOG or log_config.json instead.");
+            inner.as_ref().map_or("", String::as_str)
+        })
     }
 }
 

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -178,8 +178,14 @@ impl NeardOpts {
     pub fn verbose_target(&self) -> Option<&str> {
         match self.verbose {
             None => None,
-            Some(None) => Some(""),
-            Some(Some(ref target)) => Some(target.as_str()),
+            Some(None) => {
+                tracing::error!(target: "neard", "--verbose flag is deprecated, please use RUST_LOG or log_config.json instead.");
+                Some("")
+            }
+            Some(Some(ref target)) => {
+                tracing::error!(target: "neard", "--verbose flag is deprecated, please use RUST_LOG or log_config.json instead.");
+                Some(target.as_str())
+            }
         }
     }
 }


### PR DESCRIPTION
`--verbose` is not a `bool`, but a `String` argument, which is confusing.