### PR TITLE
perf: don't read chunk when checking existence

### DIFF
--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -1201,7 +1201,11 @@ impl ChainStoreAccess for ChainStore {
     }
 
     fn chunk_exists(&self, h: &ChunkHash) -> Result<bool, Error> {
-        self.store.exists(DBCol::Chunks, h.as_ref()).map_err(|e| e.into())
+        if self.chunks.get(h.as_ref()).is_some() {
+            Ok(true)
+        } else {
+            self.store.exists(DBCol::Chunks, h.as_ref()).map_err(|e| e.into())
+        }
     }
 
     /// Get previous header.
@@ -3009,7 +3013,7 @@ impl<'a> ChainStoreUpdate<'a> {
         }
         let mut chunk_hashes_by_height: HashMap<BlockHeight, HashSet<ChunkHash>> = HashMap::new();
         for (chunk_hash, chunk) in self.chain_store_cache_update.chunks.iter() {
-            if self.chain_store.get_chunk(chunk_hash).is_ok() {
+            if self.chain_store.chunk_exists(chunk_hash)? {
                 // No need to add same Chunk once again
                 continue;
             }


### PR DESCRIPTION
Chunks can be MBs in size. We should not force a read from DB when it's not cached already.

Also alters the `chunk_exists` method to check the cache first. An `exists` call on the DB is still more expensive than looking up an `Arc` in the in-memory cache.